### PR TITLE
Add CLI utilities, note logging, and deliberation agent rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Stegvalidering (unik ID, uppfyllda dependencies) sker före körning. Exekvering
 Allt valideras av schema.
 Reasoning-resultat kopplas till relationsgrafen och påverkar promotion gates.
 
-I CI används en 100% deterministisk MockReasoner.
+I CI används en 100% deterministisk MockDeliberationAgent.
 
 ⸻
 

--- a/app/agents/pipeline.py
+++ b/app/agents/pipeline.py
@@ -18,7 +18,7 @@ from app.events.types import (
     TEXT_CHUNK_CREATED,
 )
 from app.orchestrator.runtime import Orchestrator, OrchestratorError, PlanValidationError
-from app.reasoning.provider import get_reasoner
+from app.reasoning.provider import get_deliberation_agent
 from app.reasoning.schema import ReasoningInput, RelationSnapshot, ReasoningValidationError
 from app.reasoning.store import get_reasoning_store
 from app.stores import get_relation_index
@@ -114,9 +114,9 @@ def _run_reasoning_if_enabled(obj: Dict[str, Any], text: str) -> None:
         metadata=obj.get("metadata") or obj.get("frontmatter") or {},
         relations=relations,
     )
-    reasoner = get_reasoner()
+    deliberation_agent = get_deliberation_agent()
     try:
-        output = reasoner.reason(reasoning_input)
+        output = deliberation_agent.reason(reasoning_input)
     except ReasoningValidationError as exc:
         audit_log(
             object_id=object_id,

--- a/app/cli/__init__.py
+++ b/app/cli/__init__.py
@@ -36,6 +36,7 @@ from app.llm.trace_inspect import (
     list_agents_in_sequence,
     load_trace,
 )
+from app.settings.runtime import get_settings_bundle
 
 _AUDIO_EXTS = {".mp3", ".wav", ".m4a", ".aac", ".flac", ".ogg"}
 _DOWNLOAD_DIR = Path("tmp/normalize")
@@ -101,6 +102,20 @@ def _resolve_vault_root_path(
     if fallback_to_default:
         return DEFAULT_VAULT_ROOT
     return None
+
+
+def _resolve_yggdrasil_root(path_override: Path | None) -> Path:
+    if path_override is not None:
+        return path_override
+    try:
+        settings_bundle = get_settings_bundle()
+        settings_root = getattr(settings_bundle, "yggdrasil_paths", None)
+        if settings_root and getattr(settings_root, "yggdrasil_root", None):
+            return Path(settings_root.yggdrasil_root)
+    except Exception:
+        # Settings are optional for scaffolding; fall back to default root.
+        pass
+    return Path.home() / "Yggdrasil"
 
 
 def _truncate_preview(text: str, limit: int) -> str:
@@ -342,6 +357,96 @@ def pkm_alpha_ingest(limit: int | None) -> None:
     )
     count = ingest_vault_root(resolved, limit=limit)
     click.echo(f"Successfully ingested {count} files.")
+
+
+@cli.command(name="yggdrasil-init", help="Initialize a Yggdrasil root with module folders and the Mimer vault layout.")
+@click.option(
+    "--root",
+    "root_dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Optional Yggdrasil root path (defaults to settings.yggdrasil_paths.yggdrasil_root or ~/Yggdrasil).",
+)
+def yggdrasil_init(root_dir: Path | None) -> None:
+    yggdrasil_root = _resolve_yggdrasil_root(root_dir).expanduser()
+    module_paths = {
+        "Mimer": yggdrasil_root / "Mimer",
+        "Hugin": yggdrasil_root / "Hugin",
+        "Munin": yggdrasil_root / "Munin",
+        "Ratatosk": yggdrasil_root / "Ratatosk",
+        "Brokkr": yggdrasil_root / "Brokkr",
+        "Tyr": yggdrasil_root / "Tyr",
+        "Heimdall": yggdrasil_root / "Heimdall",
+    }
+
+    created: list[Path] = []
+    existed: list[Path] = []
+
+    for path in module_paths.values():
+        if path.exists():
+            existed.append(path)
+        else:
+            created.append(path)
+        path.mkdir(parents=True, exist_ok=True)
+
+    mimer_subdirs = [
+        "Index",
+        "Workspace",
+        "Ingress",
+        "Projects",
+        "Domains",
+        "Corpus",
+        "Sources",
+        "Ontology",
+        "Taxonomy",
+        "Canon",
+        "Archive",
+        "Machina",
+        "@Settings",
+    ]
+    mimer_root = module_paths["Mimer"]
+    for subdir in mimer_subdirs:
+        subdir_path = mimer_root / subdir
+        if subdir_path.exists():
+            existed.append(subdir_path)
+        else:
+            created.append(subdir_path)
+        subdir_path.mkdir(parents=True, exist_ok=True)
+
+    settings_dir = mimer_root / "@Settings"
+    placeholder = settings_dir / "global.md"
+    if not any(settings_dir.iterdir()):
+        placeholder.write_text(
+            "\n".join(
+                [
+                    "---",
+                    "kind: settings",
+                    "scope: global",
+                    "module: Mimer",
+                    "system: Yggdrasil",
+                    "---",
+                    "",
+                    "# Global settings for Mimer (Yggdrasil)",
+                    "",
+                    "This is an initial placeholder created by the `yggdrasil-init` command.",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        created.append(placeholder)
+    elif placeholder.exists():
+        existed.append(placeholder)
+
+    click.echo(f"Yggdrasil root: {yggdrasil_root}")
+    if created:
+        click.echo("Created:")
+        for path in sorted(created):
+            click.echo(f"  - {path}")
+    if existed:
+        click.echo("Already existed:")
+        for path in sorted(set(existed)):
+            click.echo(f"  - {path}")
 
 
 @cli.command(help="Ask a question through the planner/orchestrator pipeline.")

--- a/app/fitness/reasoning.py
+++ b/app/fitness/reasoning.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 from typing import List
 
-from app.reasoning.provider import MockReasoner
+from app.reasoning.provider import MockDeliberationAgent
 from app.reasoning.schema import ReasoningInput, RelationSnapshot
 
 DATASET_PATH = Path("data") / "golden" / "reasoning_samples.jsonl"
@@ -29,7 +29,7 @@ def reasoning_metrics(flag_enabled: bool) -> dict[str, float]:
     samples = _load_samples()
     if not samples:
         return {"claims_avg": 0.0, "inferences_avg": 0.0, "conflicts": 0.0}
-    reasoner = MockReasoner()
+    reasoner = MockDeliberationAgent()
     claims_total = 0
     inference_total = 0
     conflicts = 0

--- a/app/ingest/config.py
+++ b/app/ingest/config.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
-# Alpha-only default vault root for the PKM - Alpha Obsidian vault.
+# Alpha-only default vault root for the Mimer Obsidian vault (previously "PKM-Alpha"),
+# which is the knowledge module inside the broader Yggdrasil system.
 # TODO: replace this hard-coded path with settings-driven configuration when we leave alpha.
 DEFAULT_VAULT_ROOT = Path(
     "/Users/rasmus/Library/Mobile Documents/iCloud~md~obsidian/Documents/PKM - Alpha"

--- a/app/reasoning/provider.py
+++ b/app/reasoning/provider.py
@@ -16,12 +16,12 @@ from app.stores import get_object_store
 _FIXTURE_PATH = Path("data") / "golden" / "reasoning_samples.jsonl"
 
 
-class BaseReasoner:
+class BaseDeliberationAgent:
     def reason(self, reasoning_input: ReasoningInput) -> ReasoningOutput:  # pragma: no cover - interface
         raise NotImplementedError
 
 
-class MockReasoner(BaseReasoner):
+class MockDeliberationAgent(BaseDeliberationAgent):
     def __init__(self) -> None:
         self._fixtures = self._load_fixtures()
 
@@ -48,7 +48,7 @@ class MockReasoner(BaseReasoner):
         return self._fixtures.get(reasoning_input.text, ReasoningOutput())
 
 
-class OllamaReasoner(BaseReasoner):
+class OllamaDeliberationAgent(BaseDeliberationAgent):
     def __init__(self, *, model: str | None = None) -> None:
         self.model = model or os.getenv("REASONING_MODEL", "llama3.1:8b")
 
@@ -76,23 +76,34 @@ class OllamaReasoner(BaseReasoner):
         return validate_output(payload)
 
 
-def get_reasoner() -> BaseReasoner:
+# Backward-compatible aliases for legacy Reasoner naming.
+BaseReasoner = BaseDeliberationAgent
+MockReasoner = MockDeliberationAgent
+OllamaReasoner = OllamaDeliberationAgent
+
+
+def get_deliberation_agent() -> BaseDeliberationAgent:
     backend = os.getenv("REASONING_PROVIDER", "").strip().lower()
     llm_provider = os.getenv("LLM_PROVIDER", "").strip().lower()
     ci = os.getenv("CI", "") == "1"
 
     if backend in {"mock", "golden"} or (ci and backend == ""):
-        return MockReasoner()
+        return MockDeliberationAgent()
 
     if backend == "":
         backend = "llm"
 
     if backend in {"llm", "ollama"}:
         if llm_provider == "mock":
-            return MockReasoner()
-        return OllamaReasoner()
+            return MockDeliberationAgent()
+        return OllamaDeliberationAgent()
 
-    return MockReasoner()
+    return MockDeliberationAgent()
+
+
+def get_reasoner() -> BaseDeliberationAgent:
+    # Backward-compatible alias for DeliberationAgent provider.
+    return get_deliberation_agent()
 
 
 def _load_object_text(object_id: str) -> Tuple[str, dict]:
@@ -161,7 +172,7 @@ def run_reasoning(
             relations=[],
         )
         try:
-            output = get_reasoner().reason(reasoning_input)
+            output = get_deliberation_agent().reason(reasoning_input)
         except Exception as exc:  # pragma: no cover - defensive
             return ReasoningRun(
                 mode=mode,
@@ -320,4 +331,17 @@ def run_reasoning_claims_for_object(object_id: str, trace_id: str | None = None)
     return ReasoningOutput()
 
 
-__all__ = ["get_reasoner", "MockReasoner", "OllamaReasoner", "run_reasoning", "ReasoningMode", "ReasoningRun", "run_reasoning_claims_for_object"]
+__all__ = [
+    "get_deliberation_agent",
+    "get_reasoner",
+    "BaseDeliberationAgent",
+    "BaseReasoner",
+    "MockDeliberationAgent",
+    "OllamaDeliberationAgent",
+    "MockReasoner",
+    "OllamaReasoner",
+    "run_reasoning",
+    "ReasoningMode",
+    "ReasoningRun",
+    "run_reasoning_claims_for_object",
+]

--- a/app/services/note_log.py
+++ b/app/services/note_log.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def note_log_path(note_uuid: str, vault_relative_path: Path | str) -> Path:
+    """
+    Return the canonical per-note log path (`uuid.md`) under the VaultMirror metadata tree,
+    preserving the note's vault-relative folder structure for sync/merge.
+    """
+    uuid_str = str(note_uuid).strip()
+    rel_path = Path(str(vault_relative_path).lstrip("/"))
+    # If a file path is provided, mirror only the directory structure and replace the filename with uuid.md
+    if rel_path.suffix:
+        rel_path = rel_path.parent
+    mirror_root = Path("System/Metadata/VaultMirror")
+    return mirror_root / rel_path / f"{uuid_str}.md"
+
+
+__all__ = ["note_log_path"]

--- a/app/settings/compiler.py
+++ b/app/settings/compiler.py
@@ -21,6 +21,7 @@ from .models import (
     QaSettings,
     ReviewerSettings,
     SettingsBundle,
+    YggdrasilPaths,
 )
 from .parsers import parse_section
 from .writeback import writeback_settings_block
@@ -191,6 +192,18 @@ def compile_all(*, auto_heal: bool | None = None) -> SettingsBundle:
     if "providers" in file_paths:
         _update_reference(file_paths["providers"], "Providers", bundle.providers, auto_heal_enabled)
 
+    yggdrasil_payload = _merge_sections(file_sections.get("yggdrasil", {}))
+    if yggdrasil_payload:
+        ygg_model, ygg_canonical, ygg_fixed = _hydrate_model(
+            payload=yggdrasil_payload,
+            model_cls=YggdrasilPaths,
+        )
+        bundle.yggdrasil_paths = ygg_model
+        if auto_heal_enabled and ygg_fixed and "yggdrasil" in file_paths:
+            writeback_settings_block(file_paths["yggdrasil"], ygg_canonical)
+        if "yggdrasil" in file_paths:
+            _update_reference(file_paths["yggdrasil"], "Yggdrasil", ygg_model, auto_heal_enabled)
+
     agents_cfg: Dict[str, Any] = {}
     for agent_name, sections in agent_sections.items():
         merged = _merge_sections(sections)
@@ -213,6 +226,8 @@ def compile_all(*, auto_heal: bool | None = None) -> SettingsBundle:
 
     dump("global.yaml", bundle.global_.model_dump())
     dump("providers.yaml", bundle.providers.model_dump())
+    if bundle.yggdrasil_paths is not None:
+        dump("yggdrasil.yaml", bundle.yggdrasil_paths.model_dump())
 
     agents_output_dir = RUNTIME / "agents"
     existing_agent_files = {

--- a/app/settings/models.py
+++ b/app/settings/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
@@ -107,7 +108,19 @@ class QaSettings(AgentBase):
     llm: QaLLMSettings = Field(default_factory=QaLLMSettings)
 
 
+class YggdrasilPaths(BaseModel):
+    yggdrasil_root: Path
+    mimer_root: Path
+    hugin_root: Optional[Path] = None
+    munin_root: Optional[Path] = None
+    ratatosk_root: Optional[Path] = None
+    brokkr_root: Optional[Path] = None
+    tyr_root: Optional[Path] = None
+    heimdall_root: Optional[Path] = None
+
+
 class SettingsBundle(BaseModel):
     global_: GlobalSettings = Field(default_factory=GlobalSettings)
     providers: Providers = Field(default_factory=Providers)
     agents: Dict[str, Any] = Field(default_factory=dict)
+    yggdrasil_paths: Optional[YggdrasilPaths] = None

--- a/app/settings/runtime.py
+++ b/app/settings/runtime.py
@@ -15,6 +15,7 @@ from .models import (
     QaSettings,
     ReviewerSettings,
     SettingsBundle,
+    YggdrasilPaths,
 )
 from .hotreload import init_hot_reload
 
@@ -42,6 +43,7 @@ def _read_yaml(path: Path) -> Dict[str, Any]:
 def _build_bundle() -> SettingsBundle:
     global_yaml = _read_yaml(RUNTIME / "global.yaml")
     providers_yaml = _read_yaml(RUNTIME / "providers.yaml")
+    yggdrasil_yaml = _read_yaml(RUNTIME / "yggdrasil.yaml")
     agents_dir = RUNTIME / "agents"
     agents: Dict[str, Any] = {}
     if agents_dir.exists():
@@ -52,10 +54,17 @@ def _build_bundle() -> SettingsBundle:
                 agents[file.stem] = model_cls(**agent_data)
             else:
                 agents[file.stem] = agent_data
+    yggdrasil_paths = None
+    if yggdrasil_yaml:
+        try:
+            yggdrasil_paths = YggdrasilPaths(**yggdrasil_yaml)
+        except Exception:
+            yggdrasil_paths = None
     bundle = SettingsBundle(
         global_=GlobalSettings(**global_yaml),
         providers=Providers(**providers_yaml),
         agents=agents,
+        yggdrasil_paths=yggdrasil_paths,
     )
     return bundle
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,6 +4,8 @@ System map: `docs/SYSTEM_YGGDRASIL_Modules_And_Flows.md` covers the high-level Y
 
 `docs/HUMAN-FLOWS.md` captures the intended human experience and interaction flows; any architecture change that alters user-facing behavior should be validated against that contract before shipping.
 
+This architecture focuses on the runtime and data model for the Mimer module (the Obsidian vault + ingestion/indexing/agents) within the broader Yggdrasil system. A high-level overview of Yggdrasil’s modules and flows lives in `docs/SYSTEM_YGGDRASIL_Modules_And_Flows.md`, and human interaction patterns in `docs/HUMAN-FLOWS.md`.
+
 ## Reality-MVP Orientation
 - Primary focus: make ingestion of the real Obsidian vault stable, add a minimal external ingest path, expose a reliable ASK API, and ship observability plus an interim GUI so the system is usable end to end.
 - Zoned cognition overlay (Active/ Warm/ Cold) applied on top of the knowledge base; zones are derived from signals (usage, recency, trust) rather than folder names.
@@ -22,6 +24,11 @@ System map: `docs/SYSTEM_YGGDRASIL_Modules_And_Flows.md` covers the high-level Y
 - Vault plane (Obsidian): the human graph of linkable notes; minimal human frontmatter is allowed/encouraged, but the system does not require heavy YAML. Notes belong here when the user might want to read or link them directly.
 - External corpus plane: imported newsletters/emails/PDFs/raw docs that should be searchable and usable for answers but should not appear as notes. These objects live only in Stores/AMG with origins such as `origin: external_newsletter` and review states like `external_raw`.
 - Human frontmatter vs system metadata: frontmatter is for user-facing fields (uuid, title, type/status/area); system metadata (signals, zone inference inputs, relations, promotions, usage counts) remains in SetDB/AMG and Stores. Core-6 remains a projection ({uuid, title, origin, review_state, trust, source_ref}) and is not the full truth.
+
+### Note Log i metadata-spegeln
+- För varje objekt/uuid i valvet finns en motsvarande `uuid.md` i metadata-spegeln (`System/Metadata/VaultMirror/<vault-relativ path>/`).
+- Samma fil är metadata-spegel och per-note-logg: den samlar körningar från agenter, promotionshändelser, proveniens och ev. satellit-synk-bevis så att maskinhistoriken följer objektet oavsett backend.
+- Note Log är portabel Markdown som kan flyttas via Git mellan instanser även om SetDB/AMG eller andra Stores skiljer sig.
 
 ## Reality-MVP Architecture Components
 1) **Vault ingestion** — CLI/agent path to ingest selected Obsidian folders, normalize into Core-6 envelopes, persist in ObjectStore, emit Outbox events, chunk/index into VectorIndex, and keep provenance intact.
@@ -104,15 +111,15 @@ Every agent follows Plan → Execute → Reflect. Plan inspects the latest event
 When `DIARIZE_ENABLE=1`, the ingestion pipeline now feeds diarization metadata (speaker, start, end) into `speaker_aware_chunks()` so spans are cut on speaker changes or size boundaries (O(n) over segment length). Each emitted chunk carries `{speaker,start,end,speaker_segments}` metadata that flows through `ingest_and_chunk()` to indexing, and the audit stream (`text.chunk.created`) records `speaker_count` so reviewers can trace diarization coverage. With the flag disabled, `build_chunks()` preserves the legacy token/character splitter to keep defaults inert and deterministic.
 Oversized per-speaker segments are deterministically pre-split to respect `max_chars`; proportional start/end timestamps keep timelines monotonic without re-reading audio.
 
-### Reasoning Layer (modes & PER-style runs)
-Reasoning is now a multi-mode layer (`app/reasoning/models.py`) rather than a single JSON extractor. `ReasoningMode` defines the supported modes and `ReasoningRun` captures each run (id, mode, trace_id, object_uuids, steps, result, status/error). The router `run_reasoning(...)` in `app/reasoning/provider.py` orchestrates:
+### Reasoning Layer (cross-agent capability + DeliberationAgent)
+Reasoning är en tvärgående förmåga som alla agenter kan använda för planering, granskning och reflektion. Lagret är multi-mode (`app/reasoning/models.py`) snarare än en enkel JSON-extraktor. `ReasoningMode` definierar stödda lägen och `ReasoningRun` fångar varje körning (id, mode, trace_id, object_uuids, steps, result, status/error). Routern `run_reasoning(...)` i `app/reasoning/provider.py` orkestrerar:
 
 - `claims`: existing claims/evidence/inferences extraction (backed by `ReasoningInput` + `ReasoningOutput`); still fixture-backed for mock runs (`data/golden/reasoning_samples.jsonl`) and Ollama-backed locally.
 - `review`: lightweight review/critique of a note (summary/issues/suggestions), mock-deterministic in CI, LLM-backed locally.
 - `ranking`: candidate ranking with reasons, mock-deterministic in CI, LLM-backed locally (SetEvaluator consumes this).
 - `planning`: reserved/TBD.
 
-Calls include `agent` and `kind` (e.g., `reasoning.claims`, `reasoning.review`, `reasoning.ranking`) for tracing. The pipeline still gates on `REASONING_ENABLE=1` and stores claims outputs in the ReasoningStore; other modes feed agents directly (Reviewer, SetEvaluator) while remaining observable via the JSONL trace.
+Calls include `agent` and `kind` (e.g., `reasoning.claims`, `reasoning.review`, `reasoning.ranking`) for tracing. The pipeline still gates on `REASONING_ENABLE=1` and stores claims outputs in the ReasoningStore; other modes feed agents directly (Reviewer, SetEvaluator) while remaining observable via the JSONL trace. DeliberationAgent är den specialiserade multi-step-ASK-agenten som använder Reasoning Layer för att gå flera hopp, men samma mönster återanvänds av t.ex. Reviewer, SetEvaluator och Planner.
 
 Invariants:
 - `claims` is successful (`status="ok"`) only when at least one claim or evidence exists; fully empty `{claims:[], evidence:[], inferences:[]}` is `status="failed"`.
@@ -203,7 +210,7 @@ Envelopes reuse Core-6 metadata and append an `a2a.intent` field so determinism 
 Agents subscribe to A2A messages through the same PER scheduler: Plan inspects incoming envelopes (if enabled), Execute performs the requested action, and Reflect emits the response event plus standard audit spans. A2A never replaces Store interactions; it simply allows agents to chain themselves without introducing side channels. Hooks remain inert unless the flag is set, ensuring default CI paths stay unchanged.
 
 ### Sample Chain
-Classifier can request deeper reasoning by emitting `agent.request.created(intent="reason")` for the Reasoner; once processed, Reasoner answers via `agent.response.created` and can critique via `agent.critique.created`. PromotionAgent or Projector may then issue a follow-up request to Projector for packaging, giving a deterministic Classifier → Reasoner → Projector chain that is fully audited yet optional.
+Classifier can request deeper deliberation by emitting `agent.request.created(intent="reason")` for DeliberationAgent; once processed, DeliberationAgent answers via `agent.response.created` and can critique via `agent.critique.created`. PromotionAgent or Projector may then issue a follow-up request to Projector for packaging, giving a deterministic Classifier → DeliberationAgent → Projector chain that is fully audited yet optional, even though strukturerat resonemang är en tvärgående förmåga alla agenter använder.
 
 ## A2A Message Flow
 The A2A protocol is intentionally narrow and mediated entirely by the Orchestrator. Envelopes remain internal:

--- a/docs/HUMAN-FLOWS.md
+++ b/docs/HUMAN-FLOWS.md
@@ -3,12 +3,19 @@
 ## 1. Purpose & Scope
 - This document states the intended behavior of the Agentic PKM system from the human (Rasmus) perspective, not the code structure.
 - It complements `docs/ARCHITECTURE.md` and `docs/STATUS.md`: those describe internals and current state; this file is the human-facing contract for how core flows should feel and behave.
-- Applies to the PKM-Alpha vault surface plus the Agentic PKM runtime (ObjectStore, SetDB, Reasoner, Outbox-driven agents, etc.), covering both ingestion and ASK/reasoning loops.
+- Applies to the PKM-Alpha vault surface plus the Agentic PKM runtime (ObjectStore, SetDB, Reasoning Layer, Outbox-driven agents incl. DeliberationAgent, etc.), covering both ingestion and ASK/reasoning loops.
+- I den här dokumentationen avser “PKM-Alpha vault” samma Obsidian-valv som nu kallas Mimer – kunskapsmodulen i det större systemet Yggdrasil.
 
 ## 2. Mental Model: Layers and Roles
 - **Surface layer (Obsidian PKM-Alpha vault)** — Human-authored notes, minimal frontmatter, free linking; this is where the human reads and writes.
 - **System layer** — `ObjectStore` / `SetDB` hold UUID-based knowledge objects; a metadata mirror lives under `System/Metadata/VaultMirror/.../uuid.md`; Outbox emits events that drive agents and downstream stores.
-- **Key agents (as seen by the human)** — Ingest/Normalizer (pulls notes safely), Classifier (proposes types/facets), ASK/QA (answers questions), Reasoner (multi-step thinking), SetEvaluator (ranks/evaluates candidates), Planner/Orchestrator (orders work), PanelAgent (handles AI panels in notes), Promotion/Evergreen logic (moves maturity forward). These collaborate to keep vault writing human-first while the system maintains structure underneath.
+- **Key agents (as seen by the human)** — Ingest/Normalizer (pulls notes safely), Classifier (proposes types/facets), ASK/QA (answers questions), DeliberationAgent (multi-step deliberation for ASK), SetEvaluator (ranks/evaluates candidates), Planner/Orchestrator (orders work), PanelAgent (handles AI panels in notes), Promotion/Evergreen logic (moves maturity forward). These collaborate to keep vault writing human-first while the system maintains structure underneath, and reasoning är en grundförmåga som alla agenter kan använda.
+
+### Per-noteloggen (maskinlogg)
+- För varje note med `uuid` finns en speglad metadatafil `uuid.md` i `System/Metadata/VaultMirror/<vault-relativ path>/`.
+- Samma fil är både metadata-spegel och per-note-logg: här kan systemet samla agentbeslut, promotionshistorik, konfliktlösning och proveniens från satelliter.
+- Den är den kanoniska maskinlogg-/historikfilen för noten och fungerar som synk-/merge-ankare mellan master och satelliter.
+- Den mänskliga noten hålls ren; maskinbrus hör hemma i spegelns `uuid.md`.
 
 ## 3. Core Flows (From the Human’s Perspective)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -96,7 +96,7 @@ SoT v4.6-A expands the corpus to 16 deterministic queries (10 candidates each) a
 
 ## Forward Outlook (v4.7)
 ### Objective A — LLM Reasoning Layer v1 *(active — SoT v4.7-A)*
-- `REASONING_ENABLE=1` routes notes + relation snapshots through `get_reasoner()` (mock in CI, Ollama locally) using strict prompts; outputs must pass schema validation (`claims`, `evidence`, `inferences`) before being stored/audited.
+- `REASONING_ENABLE=1` routes notes + relation snapshots through `get_deliberation_agent()` (mock i CI, Ollama lokalt) using strict prompts; outputs must pass schema validation (`claims`, `evidence`, `inferences`) before being stored/audited.
 - Fitness adds an eighth summary line `CI SUMMARY REASONING claims_avg=<v> inferences_avg=<v> conflicts=<n> flag=on` with baselines defined in `ops/quality/baselines.yaml`; gates require non-zero inferences_avg and conflicts ≤ baseline when the flag is on.
 - Docs + README describe baselines and overrides (`THRESHOLDS_PATH`, `GATE_STRICT=1`), ensuring PRs paste the seven existing lines plus the new REASONING line.
 
@@ -104,13 +104,13 @@ SoT v4.6-A expands the corpus to 16 deterministic queries (10 candidates each) a
 ### Goals
 - Introduce the canonical A2A envelope schema (`agent.request.created`, `agent.response.created`, `agent.error`) and thread it through the Orchestrator so multi-agent work stays audited.
 - Allow agents to request, respond, and critique peer work without bypassing Stores/Outbox, keeping Planner Agent outputs replayable.
-- Enable deterministic multi-agent task sequences (e.g., Classifier → Reasoner → Projector) with Orchestrator-managed routing.
-- Provide orchestration hooks plus a sample chain template (Classifier → Reasoner → Projector) that operators can rehearse locally.
+- Enable deterministic multi-agent task sequences (e.g., Classifier → DeliberationAgent → Projector) with Orchestrator-managed routing.
+- Provide orchestration hooks plus a sample chain template (Classifier → DeliberationAgent → Projector) that operators can rehearse locally.
 
 ### Acceptance Criteria
 - `agent.request.created`, `agent.response.created`, and `agent.error` documented under Event Choreography with Core-6 + trace requirements.
 - Base agent exposes `handle_agent_message()` and routes envelopes via A2A middleware managed by the Orchestrator.
-- ≥1 multi-agent interaction scenario scripted end-to-end (Classifier requests Reasoner, Reasoner responds, Projector critiques) with deterministic fixtures.
+- ≥1 multi-agent interaction scenario scripted end-to-end (Classifier requests DeliberationAgent, DeliberationAgent responds, Projector critiques) with deterministic fixtures.
 - CI ships mock-backed A2A fixtures; default flags keep the feature inert (no new smoke gates) until `A2A_ENABLE=1`.
 
 ### Delivered so far

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -111,7 +111,7 @@ Reasoning Alpha (local LLM)
 - The same env routes calls through the local LLM and writes JSONL traces for inspection.
 
 ## PKM-Alpha Alpha Reasoning Run (local LLM)
-- End-to-end local run against the real PKM-Alpha vault (limited ingest, alpha LLM tests, trace export to Obsidian).
+- End-to-end local run against the real PKM-Alpha vault (Mimer-modulen i Yggdrasil) (limited ingest, alpha LLM tests, trace export to Obsidian).
 
 Environment (local LLM + memory/pg)
 ```bash

--- a/docs/SYSTEM_YGGDRASIL_Modules_And_Flows.md
+++ b/docs/SYSTEM_YGGDRASIL_Modules_And_Flows.md
@@ -2,8 +2,10 @@
 
 High-level map of modules and how material moves between them. This orients intent and responsibilities; detailed technical design, data contracts, and runtime specifics live in `docs/ARCHITECTURE.md`.
 
+In SoT v4.10 this codebase primarily implements the Mimer module (the Obsidian vault + ingestion/indexing/agents). The other Yggdrasil modules (Hugin, Munin, Ratatosk, Brokkr, Tyr, Heimdall) are currently partly conceptual and/or handled by external tools and file-system organization.
+
 ## Modules at a glance
-- **Mimer — Knowledge (Obsidian vault)**: Human-first vault with notes, ontology, and semantic links; minimal frontmatter plus UUID identity. Acts as the cognitive graph that threads together interpretations of media, records, and projects. Provides Core-6 projections and references (e.g., `source_ref`) into other modules without duplicating their artifacts.
+- **Mimer — Knowledge (Obsidian vault)**: Human-first vault with notes, ontology, and semantic links; minimal frontmatter plus UUID identity. Acts as the cognitive graph that threads together interpretations of media, records, and projects. Provides Core-6 projections and references (e.g., `source_ref`) into other modules without duplicating their artifacts. This is the same vault historically referred to as PKM-Alpha.
 - **Hugin — Intelligence & agents**: Hosts agent profiles, policies, reasoning traces, plans, and experiments. Runs ASK/QA, reasoning loops, and evaluator workflows that read from Mimer and stores, then emit structured spans and decisions. Optimized for explainable, replayable agentic behavior rather than storage.
 - **Munin — Media & raw memory**: Holds photos, audio, video, recordings, and ebooks/audiobooks in original or lightly processed form. Serves as the media source of truth; derived transcripts or annotations link back into Mimer via citations and `source_ref`. Supports indexing hooks without altering the originals.
 - **Ratatosk — Ingestion & pipelines**: Inbox and ETL flows that capture material from devices, apps, or external feeds. Normalizes and routes payloads into Munin/Brokkr/Tyr as appropriate while seeding stubs in Mimer for interpretation. Prioritizes idempotent, auditable moves with Outbox events for agents.
@@ -30,6 +32,11 @@ Mimer is the cognitive hub. It hosts human-authored notes and semantic structure
 - Hugin owns agents and reasoning: profiles, policies, reasoning traces, generated plans, experiments, and ASK/QA logic.
 - Heimdall owns runtime and observability: deployment/configuration, system logs, metrics, dashboards, and operational runbooks.
 - "Agents conceptually belong to Hugin (intelligence), while Heimdall is responsible for infrastructure and observability. Hugin holds the 'mind', Heimdall the 'machinery'."
+
+### Git & Obsidian automation
+- Obsidian Git-automation (Obsidian Git-plugin eller motsvarande) är en nyckel i Mimers synkväv: den commitar/pushar/pullar Markdown-noter och per-note-loggar så text och loggar är portabla mellan instanser.
+- Automationen ligger i Machina/Heimdall-lagret: infrastruktur vi lutar oss mot men inte helt styr själva.
+- Eftersom Git kan skriva vid sidan av agenterna måste systemet tåla out-of-band-commits och merges; agenter kan inte anta att de är ensamma skribenter.
 
 ### Flows between Modules
 - Brokkr contains full project folders; `Mimer/Projects` holds each project’s semantic brain (status, decisions, links) and references Brokkr outputs instead of copying them.

--- a/tests/a2a/test_events.py
+++ b/tests/a2a/test_events.py
@@ -28,7 +28,7 @@ def test_emit_agent_request_event(monkeypatch) -> None:
     recorder = AuditRecorder()
     monkeypatch.setattr("app.a2a.events.audit_log", recorder)
 
-    message = new_request(sender="Classifier", recipient="Reasoner", intent="reason")
+    message = new_request(sender="Classifier", recipient="DeliberationAgent", intent="reason")
     emit_agent_request_event(message, object_id="obj-1")
 
     record = recorder.records.pop()
@@ -41,10 +41,10 @@ def test_emit_agent_response_and_error_events(monkeypatch) -> None:
     recorder = AuditRecorder()
     monkeypatch.setattr("app.a2a.events.audit_log", recorder)
 
-    response = new_response(sender="Reasoner", recipient="Classifier", status="ok")
+    response = new_response(sender="DeliberationAgent", recipient="Classifier", status="ok")
     emit_agent_response_event(response)
     error = new_error(
-        sender="Reasoner",
+        sender="DeliberationAgent",
         recipient="Classifier",
         error_type="failed",
         error_message="no context",

--- a/tests/a2a/test_schema.py
+++ b/tests/a2a/test_schema.py
@@ -11,7 +11,7 @@ from app.a2a.schema import AgentError, new_error, new_request, new_response
 def test_agent_request_roundtrip_serializable() -> None:
     request = new_request(
         sender="Classifier",
-        recipient="Reasoner",
+        recipient="DeliberationAgent",
         intent="reason",
         payload={"topic": "delta"},
         metadata={"priority": "low"},
@@ -25,7 +25,7 @@ def test_agent_request_roundtrip_serializable() -> None:
 
 
 def test_agent_response_defaults() -> None:
-    response = new_response(sender="Reasoner", recipient="Classifier")
+    response = new_response(sender="DeliberationAgent", recipient="Classifier")
     assert response.status == "ok"
     assert response.kind == "response"
 

--- a/tests/cli/test_yggdrasil_init.py
+++ b/tests/cli/test_yggdrasil_init.py
@@ -1,0 +1,19 @@
+from click.testing import CliRunner
+
+from app.cli import cli
+
+
+def test_yggdrasil_init_scaffolds_directories(tmp_path):
+    runner = CliRunner()
+    result = runner.invoke(cli, ["yggdrasil-init", "--root", str(tmp_path)])
+
+    assert result.exit_code == 0, result.output
+
+    mimer_root = tmp_path / "Mimer"
+    assert (mimer_root / "Workspace").is_dir()
+    settings_dir = mimer_root / "@Settings"
+    assert settings_dir.is_dir()
+    assert any(settings_dir.iterdir())
+
+    for name in ["Hugin", "Munin", "Ratatosk", "Brokkr", "Tyr", "Heimdall"]:
+        assert (tmp_path / name).is_dir()

--- a/tests/helpers/pkm_alpha_helper.py
+++ b/tests/helpers/pkm_alpha_helper.py
@@ -1,3 +1,4 @@
+"""Helper for the Mimer Obsidian vault (historically called 'PKM-Alpha') in the Yggdrasil system."""
 # Reasoning entrypoint: app/agents/pipeline.py:ingest_and_chunk() → _run_reasoning_if_enabled()
 # Reviewer entrypoint: app/agents/reviewer/agent.py:run(...) (graph wrapper in app/agents/reviewer/graph.py:invoke)
 # pkm-alpha path: app/ingest/config.DEFAULT_VAULT_ROOT (local repo mirror under vault/)

--- a/tests/reasoning/test_provider_mock.py
+++ b/tests/reasoning/test_provider_mock.py
@@ -5,17 +5,22 @@ from pathlib import Path
 
 import pytest
 
-from app.reasoning.provider import MockReasoner, OllamaReasoner, get_reasoner
+from app.reasoning.provider import (
+    MockDeliberationAgent,
+    OllamaDeliberationAgent,
+    get_deliberation_agent,
+    get_reasoner,
+)
 from app.reasoning.schema import ReasoningInput, RelationSnapshot
 
 pytestmark = pytest.mark.not_pg
 
 
-def test_mock_reasoner_returns_fixture() -> None:
+def test_mock_deliberation_agent_returns_fixture() -> None:
     samples = Path("data/golden/reasoning_samples.jsonl").read_text(encoding="utf-8").splitlines()
     fixture = json.loads(samples[0])
-    reasoner = MockReasoner()
-    result = reasoner.reason(
+    agent = MockDeliberationAgent()
+    result = agent.reason(
         ReasoningInput(
             object_uuid=fixture["object_uuid"],
             text=fixture["text"],
@@ -26,15 +31,17 @@ def test_mock_reasoner_returns_fixture() -> None:
     assert result.claims[0].text.startswith("Solar storage")
 
 
-def test_get_reasoner_falls_back_to_mock_when_ollama_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_deliberation_agent_falls_back_to_mock_when_ollama_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("CI", raising=False)
     monkeypatch.setenv("REASONING_PROVIDER", "ollama")
     monkeypatch.setenv("LLM_PROVIDER", "mock")
-    assert isinstance(get_reasoner(), MockReasoner)
+    assert isinstance(get_deliberation_agent(), MockDeliberationAgent)
+    # Alias preserved for compatibility
+    assert isinstance(get_reasoner(), MockDeliberationAgent)
 
 
-def test_get_reasoner_uses_ollama_when_llm_provider_matches(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_deliberation_agent_uses_ollama_when_llm_provider_matches(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("CI", raising=False)
     monkeypatch.setenv("REASONING_PROVIDER", "ollama")
     monkeypatch.setenv("LLM_PROVIDER", "ollama")
-    assert isinstance(get_reasoner(), OllamaReasoner)
+    assert isinstance(get_deliberation_agent(), OllamaDeliberationAgent)

--- a/tests/reasoning/test_reasoning_llm_logging.py
+++ b/tests/reasoning/test_reasoning_llm_logging.py
@@ -8,7 +8,7 @@ import pytest
 
 from app.agents.set_evaluator.agent import run_set_evaluator
 from app.reasoning.multi import run_multi_note_reasoning
-from app.reasoning.provider import get_reasoner
+from app.reasoning.provider import get_deliberation_agent
 from app.reasoning.schema import ReasoningInput
 from app.stores import get_object_store, reset_store_backends
 
@@ -66,11 +66,11 @@ def test_reasoning_single_note_logs_real_json(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setattr("app.services.llm.log_llm_call", fake_log_llm_call)
     monkeypatch.setattr("app.services.llm._deterministic_llm_response", lambda: fake_json)
 
-    reasoner = get_reasoner()
+    deliberation_agent = get_deliberation_agent()
     note_text = "Note about safety and alignment."
     ri = ReasoningInput(object_uuid="OBJ-SINGLE", text=note_text, metadata={"trace_id": "T-single"}, relations=[])
 
-    output = reasoner.reason(ri)
+    output = deliberation_agent.reason(ri)
 
     assert output.claims and output.evidence and output.inferences
     assert captured, "log_llm_call should be invoked"

--- a/tests/reasoning/test_reasoning_modes_contract.py
+++ b/tests/reasoning/test_reasoning_modes_contract.py
@@ -39,7 +39,7 @@ def test_run_reasoning_claims_mode_failed_when_empty(monkeypatch: pytest.MonkeyP
     reset_store_backends()
     store = get_object_store()
     object_id = uuid4()
-    store.put(object_id, kind="note", source_ref="b.md", payload={"text": "Unrecognized text for mock reasoner"})
+    store.put(object_id, kind="note", source_ref="b.md", payload={"text": "Unrecognized text for mock deliberation agent"})
 
     run = run_reasoning(ReasoningMode.CLAIMS, [str(object_id)])
 

--- a/tests/reasoning/test_reasoning_trace_e2e.py
+++ b/tests/reasoning/test_reasoning_trace_e2e.py
@@ -7,7 +7,7 @@ import pytest
 
 from app.agents.set_evaluator.agent import run_set_evaluator
 from app.llm.trace_inspect import load_trace
-from app.reasoning.provider import get_reasoner
+from app.reasoning.provider import get_deliberation_agent
 from app.reasoning.schema import ReasoningInput
 from app.reasoning.multi import run_multi_note_reasoning
 from app.stores import get_object_store, reset_store_backends
@@ -57,9 +57,9 @@ def test_reasoning_single_note_trace_has_non_empty_response_preview(monkeypatch:
     fake_json = _fake_reasoning_json("OBJ-SINGLE")
     monkeypatch.setattr("app.services.llm._deterministic_llm_response", lambda: fake_json)
 
-    reasoner = get_reasoner()
+    deliberation_agent = get_deliberation_agent()
     ri = ReasoningInput(object_uuid="OBJ-SINGLE", text="Note A about testing.", metadata={"trace_id": "T-single"}, relations=[])
-    out = reasoner.reason(ri)
+    out = deliberation_agent.reason(ri)
 
     assert out.claims and out.evidence and out.inferences
     assert trace_path.exists()

--- a/tests/services/test_note_log.py
+++ b/tests/services/test_note_log.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from app.services.note_log import note_log_path
+
+
+def test_note_log_path_preserves_vault_relative_structure() -> None:
+    path = note_log_path("1234-uuid", "Workspace/Area1/note.md")
+    assert path == Path("System/Metadata/VaultMirror/Workspace/Area1/1234-uuid.md")
+
+
+def test_note_log_path_strips_leading_slash() -> None:
+    path = note_log_path("abcd", "/Projects/X.md")
+    assert path == Path("System/Metadata/VaultMirror/Projects/abcd.md")


### PR DESCRIPTION
## Summary
- 

## Acceptance Criteria
- [ ] Objective A (cross-encoder rerank provider)
- [ ] Objective B (RelationIndex gate + override audit)
- [ ] Objective C (diarization hook + chunk integration)
- [ ] Objective D (golden-set evaluation + CI summary)

## Flags Used
- `RERANK_ENABLE=`
- `RERANK_PROVIDER=`
- `DIARIZE_ENABLE=`
- Others:

## CI Metrics
- QAS-003 p95: 
- QAS-010 p95: 
- Golden P@10 / nDCG@10: 
- Relation coverage %:
- Diarization chunk p95 / speaker avg:

## CI Checklist
- [ ] Pasted the six CI summary lines plus the `CI SUMMARY GATES` line in this PR description.
- [ ] Confirmed no TODO/FIXME remain in any touched docs.
- [ ] Listed all flags used (if any) and documented whether positive/zero deltas are expected.

## Risks & Rollback
-

## Docs Updated
- [ ] docs/ARCHITECTURE.md
- [ ] docs/ROADMAP.md
- [ ] docs/STATUS.md
- [ ] CHANGELOG.md
