### PR TITLE
Route inbox log writes through KnowledgePort

### DIFF
--- a/app/services/inbox.py
+++ b/app/services/inbox.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from app.knowledge.contracts import NoteLocator
 from app.knowledge.references import build_obsidian_advanced_uri
+from app.knowledge.service import resolve_knowledge_port
 from app.vault.paths import get_vault_inbox_dir_rel
 
 
@@ -67,15 +68,15 @@ def _append_line(
     uri: str | None = None,
 ) -> None:
     root = _resolve_vault_root(vault_root)
-    target = root / Path(note_rel_path)
-    target.parent.mkdir(parents=True, exist_ok=True)
-
     timestamp = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
     action_link = uri or _build_uri(vault_path)
     suffix = f" | {action_link}" if action_link else ""
+    line = f"- [{timestamp}] {message}{suffix}\n"
 
-    with target.open("a", encoding="utf-8") as handle:
-        handle.write(f"- [{timestamp}] {message}{suffix}\n")
+    vault_name = os.getenv("OBSIDIAN_VAULT_NAME", "Vault")
+    locator = NoteLocator(vault=vault_name, path=note_rel_path.replace("\\", "/"))
+    port = resolve_knowledge_port(vault_root=root)
+    port.append_note(locator, line)
 
 
 def _build_uri(vault_path: Path | str | None) -> str | None:

--- a/docs/OBSIDIANSYNC.md
+++ b/docs/OBSIDIANSYNC.md
@@ -41,5 +41,6 @@ Watcher note: Runtime now uses the registry watcher (`configs/watchers.yaml` + `
 - Current adapters:
   - `FsVaultAdapter` for deterministic local/test writes.
   - `ObsidianCliAdapter` for Obsidian CLI-driven operations.
+- Inbox service writes (change/conflict logs) now append via `KnowledgePort` rather than direct file I/O.
 - Policy + startup posture is governed by `KNOWLEDGE_*` settings and health-gated via `python -m app.cli health --json`.
 - See `docs/contracts/OBSIDIAN_KNOWLEDGE_PORT.md`.

--- a/tests/services/test_inbox_service.py
+++ b/tests/services/test_inbox_service.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.services.inbox import append_change
+
+
+def test_append_change_writes_line_via_default_fs_port(tmp_path: Path) -> None:
+    note_rel = "Inbox/_system_changes.md"
+    append_change("hello", note_rel_path=note_rel, vault_root=tmp_path)
+    target = tmp_path / note_rel
+    assert target.exists()
+    content = target.read_text(encoding="utf-8")
+    assert "hello" in content
+
+
+def test_append_change_uses_knowledge_port(monkeypatch, tmp_path: Path) -> None:
+    calls: list[tuple[str, str]] = []
+
+    class FakePort:
+        def append_note(self, locator, content):  # type: ignore[no-untyped-def]
+            calls.append((locator.path, content))
+            return None
+
+    monkeypatch.setattr("app.services.inbox.resolve_knowledge_port", lambda **kwargs: FakePort())
+    append_change("world", note_rel_path="Inbox/_system_changes.md", vault_root=tmp_path)
+    assert calls
+    assert calls[0][0] == "Inbox/_system_changes.md"
+    assert "world" in calls[0][1]


### PR DESCRIPTION
## Summary
- route `app.services.inbox` change/conflict log appends through `KnowledgePort` via `resolve_knowledge_port(...)`
- preserve existing line format and URI suffix behavior, but remove direct file append from inbox service
- add service-level tests for both default append behavior and adapter dispatch
- update Obsidian sync docs to note that inbox writes now go through the abstraction

## Testing
- Added `tests/services/test_inbox_service.py`
- Local runtime here only verified via `python3 -m py_compile` due missing `pytest` module in this shell image
