### PR TITLE
Add optional strict Obsidian gate to startup preflight

### DIFF
--- a/docs/runbooks/RUNBOOK_STARTUP_FULL_SYSTEM.md
+++ b/docs/runbooks/RUNBOOK_STARTUP_FULL_SYSTEM.md
@@ -14,6 +14,7 @@ make alpha-up
    - requires `LLM_PROVIDER` + `LLM_MODEL`; mock requires no endpoint, Ollama accepts `OLLAMA_URL` or `OPENAI_BASE_URL`, other providers require `OPENAI_BASE_URL`
    - waits for `/api/status` then `/api/health` to report runtime `db`/`worker`/`watcher` as ok (timeout 60s)
    - optional checks like `ffmpeg` are ignored by default via `STARTUP_IGNORE_CHECKS=ffmpeg` (set to `""` for strict mode)
+   - optional strict Obsidian gate: set `STARTUP_ENFORCE_OBSIDIAN=1` to fail fast unless host Obsidian dependency checks pass (`obsidian` CLI + installer floor)
    - on failure, prints `docker compose ps`, tails api/worker/watcher logs, and dumps `/api/health`
 
 ## Alpha Compose Runtime (canonical)
@@ -54,6 +55,13 @@ Tests: `tests/e2e/test_operator_workflows.py::test_operator_can_diagnose_stale_w
 - Run the gap test after startup:
 ```
 scripts/gap_test_alpha.sh
+```
+- For Obsidian-required server posture, export before startup:
+```
+export STARTUP_ENFORCE_OBSIDIAN=1
+export KNOWLEDGE_PRIMARY_ADAPTER=obsidian_cli
+export KNOWLEDGE_STRICT_STARTUP=1
+export KNOWLEDGE_ALLOW_FALLBACK=0
 ```
 - If `/api/health` fails:
   - check heartbeat files in `/app/tmp`

--- a/scripts/lib/start_full_system_env.sh
+++ b/scripts/lib/start_full_system_env.sh
@@ -5,4 +5,7 @@ apply_start_full_system_defaults() {
   if [ -z "${WATCHER_AUTO_EXEC+x}" ]; then
     export WATCHER_AUTO_EXEC=1
   fi
+  if [ -z "${STARTUP_ENFORCE_OBSIDIAN+x}" ]; then
+    export STARTUP_ENFORCE_OBSIDIAN=0
+  fi
 }

--- a/scripts/start_full_system.sh
+++ b/scripts/start_full_system.sh
@@ -239,6 +239,35 @@ require_db_outbox_env() {
   fi
 }
 
+preflight_obsidian_strict() {
+  if [ "${STARTUP_ENFORCE_OBSIDIAN:-0}" != "1" ]; then
+    return 0
+  fi
+  export KNOWLEDGE_PRIMARY_ADAPTER="${KNOWLEDGE_PRIMARY_ADAPTER:-obsidian_cli}"
+  export KNOWLEDGE_FALLBACK_ADAPTER="${KNOWLEDGE_FALLBACK_ADAPTER:-fs_vault}"
+  export KNOWLEDGE_STRICT_STARTUP="${KNOWLEDGE_STRICT_STARTUP:-1}"
+  export KNOWLEDGE_ALLOW_FALLBACK="${KNOWLEDGE_ALLOW_FALLBACK:-0}"
+
+  obsidian_gate_json=$(python - <<'PY'
+import json
+from app.knowledge.health import obsidian_dependency_status
+
+status = obsidian_dependency_status()
+print(json.dumps({"ok": status.ok, "details": status.details}, ensure_ascii=False))
+PY
+)
+  obsidian_ok=$(OBSIDIAN_GATE_JSON="$obsidian_gate_json" python - <<'PY'
+import json
+import os
+payload = json.loads(os.environ.get("OBSIDIAN_GATE_JSON", "{}"))
+print("1" if payload.get("ok") else "0")
+PY
+)
+  if [ "$obsidian_ok" != "1" ]; then
+    fail_preflight "runtime mode Obsidian strict gate failed: $obsidian_gate_json"
+  fi
+}
+
 preflight_runtime() {
   require_vars LLM_PROVIDER LLM_MODEL
   if [ "${LLM_PROVIDER_ENFORCE:-}" != "1" ]; then
@@ -284,6 +313,7 @@ PYLLM
   if [ "${START_WATCHERS:-0}" -eq 1 ] || [ "${START_WORKER:-0}" -eq 1 ]; then
     require_db_outbox_env
   fi
+  preflight_obsidian_strict
   export LLM_PROVIDER_ENFORCE=1
 }
 


### PR DESCRIPTION
## Summary
- add optional host-side strict Obsidian startup gate to `scripts/start_full_system.sh`
- new gate is controlled by `STARTUP_ENFORCE_OBSIDIAN=1`
- when enabled, startup preflight exports strict knowledge policy env:
  - `KNOWLEDGE_PRIMARY_ADAPTER=obsidian_cli`
  - `KNOWLEDGE_FALLBACK_ADAPTER=fs_vault`
  - `KNOWLEDGE_STRICT_STARTUP=1`
  - `KNOWLEDGE_ALLOW_FALLBACK=0`
- preflight fails fast if Obsidian dependency check does not pass
- add default `STARTUP_ENFORCE_OBSIDIAN=0` in startup env defaults
- document this operator mode in runbook

## Why host-side
- runtime services run in Docker; requiring Obsidian inside containers would create false negatives
- this gate enforces server policy at startup on the host where Obsidian is expected

## Validation
- `bash -n scripts/start_full_system.sh scripts/lib/start_full_system_env.sh`
