### PR TITLE
Systematize panel scan worker flow and refresh model defaults

### DIFF
--- a/app/cli/__init__.py
+++ b/app/cli/__init__.py
@@ -1228,6 +1228,13 @@ def uat_seed_vault_test(vault_root: Path, target_subdir: str, folder: str, overw
 @click.option("--run-panels/--no-run-panels", default=True, show_default=True)
 @click.option("--consume-promotions/--no-consume-promotions", default=True, show_default=True)
 @click.option("--assert", "assert_expectations", is_flag=True, help="Fail if expected intents/effects are missing.")
+@click.option(
+    "--assert-mode",
+    type=click.Choice(["bootstrap", "converged"], case_sensitive=False),
+    default="bootstrap",
+    show_default=True,
+    help="Assertion profile for scripted UAT: first successful run vs stable rerun.",
+)
 def uat_run_vault_test(
     vault_root: Path,
     target_subdir: str,
@@ -1238,6 +1245,7 @@ def uat_run_vault_test(
     run_panels: bool,
     consume_promotions: bool,
     assert_expectations: bool,
+    assert_mode: str,
 ) -> None:
     resolved = _resolve_vault_root_path(vault_root, allow_env=True, fallback_to_default=False)
     if resolved is None:
@@ -1253,6 +1261,7 @@ def uat_run_vault_test(
             run_panels=run_panels,
             consume_promotions=consume_promotions,
             assert_expectations=assert_expectations,
+            assert_mode=assert_mode.lower(),
         )
     except FileNotFoundError as exc:
         raise click.BadParameter(str(exc))

--- a/app/cli/uat.py
+++ b/app/cli/uat.py
@@ -4,7 +4,7 @@ import os
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Tuple
+from typing import Dict, Literal, Tuple
 
 from app.promotion.consumer import consume_promotion_intents
 from app.watcher.vault_watcher import run_watcher_tick
@@ -38,6 +38,9 @@ class UATSummary:
 
 class UATAssertionError(Exception):
     pass
+
+
+UATAssertMode = Literal["bootstrap", "converged"]
 
 
 def seed_vault_test_notes(
@@ -81,6 +84,7 @@ def run_vault_test_flow(
     run_panels: bool = True,
     consume_promotions: bool = True,
     assert_expectations: bool = False,
+    assert_mode: UATAssertMode = "bootstrap",
 ) -> UATSummary:
     scope = vault_root.expanduser().resolve() / target_subdir
     if not scope.exists() or not scope.is_dir():
@@ -116,17 +120,34 @@ def run_vault_test_flow(
     summary = UATSummary(watcher=watcher_summary, promotion=promotion_summary)
 
     if assert_expectations and not dry_run:
-        _assert_uat_expectations(summary)
+        _assert_uat_expectations(summary, mode=assert_mode)
 
     return summary
 
 
-def _assert_uat_expectations(summary: UATSummary) -> None:
+def _assert_uat_expectations(summary: UATSummary, *, mode: UATAssertMode = "bootstrap") -> None:
     failures: list[str] = []
-    if summary.watcher.get("panel_promotions", 0) < 1:
-        failures.append("Expected at least one promote.intent.created")
-    if summary.promotion.get("applied", 0) < 1:
-        failures.append("Expected at least one promotion to be applied by consumer")
+    if mode == "bootstrap":
+        if summary.watcher.get("panel_promotions", 0) < 1:
+            failures.append("Expected at least one promote.intent.created")
+        if summary.promotion.get("applied", 0) < 1:
+            failures.append("Expected at least one promotion to be applied by consumer")
+        return _raise_if_failures(failures)
+
+    if mode == "converged":
+        if summary.watcher.get("panel_promotions", 0) != 0:
+            failures.append("Expected no promote.intent.created during converged rerun")
+        if summary.promotion.get("applied", 0) != 0:
+            failures.append("Expected promotion consumer to be a no-op during converged rerun")
+        if summary.promotion.get("errors", 0) != 0:
+            failures.append("Expected no promotion consumer errors during converged rerun")
+        return _raise_if_failures(failures)
+
+    failures.append(f"Unknown UAT assert mode: {mode}")
+    _raise_if_failures(failures)
+
+
+def _raise_if_failures(failures: list[str]) -> None:
     if failures:
         raise UATAssertionError("; ".join(failures))
 
@@ -140,4 +161,5 @@ __all__ = [
     "SEED_SOURCE",
     "DEFAULT_TARGET_SUBDIR",
     "DEFAULT_FOLDER_NAME",
+    "UATAssertMode",
 ]

--- a/app/events/types.py
+++ b/app/events/types.py
@@ -8,6 +8,7 @@ INGEST_NORMALIZE_DONE = "ingest.normalize.done"
 INGEST_CHUNK_DONE = "ingest.chunk.done"
 INGEST_INDEX_DONE = "ingest.index.done"
 INGEST_VAULT_CHANGED = "ingest.vault.changed"
+PANEL_SCAN_REQUESTED = "panel.scan.requested"
 INDEX_OBJECT_EMBEDDED = "index.object.embedded"
 INDEX_EMBEDDING_FAILED = "index.embedding.failed"
 TEXT_CHUNK_CREATED = "text.chunk.created"
@@ -72,6 +73,7 @@ __all__ = [
     "INGEST_CHUNK_DONE",
     "INGEST_INDEX_DONE",
     "INGEST_VAULT_CHANGED",
+    "PANEL_SCAN_REQUESTED",
     "INDEX_OBJECT_EMBEDDED",
     "INDEX_EMBEDDING_FAILED",
     "TEXT_CHUNK_CREATED",

--- a/app/watcher/registry.py
+++ b/app/watcher/registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 from app.watcher.scope import matches_scope
 import hashlib
 import json
@@ -18,9 +19,9 @@ from app.agents.panel.agent import handle_note_update
 from app.agents.panel_agent.policy import watcher_panel_candidate_for_path
 from app.components.concurrency import OptimisticWriteGuard, VersionMismatch
 from app.events.schema import OutboxEvent
-from app.events.types import INGEST_VAULT_CHANGED
+from app.events.types import INGEST_VAULT_CHANGED, PANEL_SCAN_REQUESTED
 from app.services.note_uuid import ensure_note_uuid
-from app.services.outbox import write_outbox_event
+from app.services.outbox import insert_object_and_outbox, write_outbox_event
 from app.settings.panel_actions import PanelActionMapping, load_panel_action_mappings
 from app.settings.tiering import resolve_dev_lab_env_typed, resolve_dev_lab_env_value
 from app.settings.watcher_settings import load_watcher_settings, resolve_auto_exec_enabled
@@ -257,6 +258,35 @@ def _write_markdown_if_changed(note_path: Path, original: str, updated: str) -> 
         return False
 
 
+def _read_panel_note_with_retry(note_path: Path, *, attempts: int = 5, base_sleep: float = 0.2) -> str:
+    for attempt in range(attempts):
+        try:
+            return note_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            if exc.errno in {errno.ENOENT, errno.EPERM, errno.EACCES, errno.EROFS} and attempt + 1 < attempts:
+                time.sleep(base_sleep * (2**attempt))
+                continue
+            raise
+    raise FileNotFoundError(note_path)
+
+
+def _ensure_panel_note_uuid_with_retry(
+    note_path: Path,
+    *,
+    attempts: int = 5,
+    base_sleep: float = 0.2,
+) -> str:
+    for attempt in range(attempts):
+        try:
+            return ensure_note_uuid(note_path)
+        except OSError as exc:
+            if exc.errno in {errno.ENOENT, errno.EPERM, errno.EACCES, errno.EROFS} and attempt + 1 < attempts:
+                time.sleep(base_sleep * (2**attempt))
+                continue
+            raise
+    raise FileNotFoundError(note_path)
+
+
 def _process_panel_note(
     *,
     vault_root: Path,
@@ -264,21 +294,26 @@ def _process_panel_note(
     outbox_path: Path,
     state: WatcherState,
     action_mappings: Mapping[str, PanelActionMapping],
-) -> None:
+) -> int:
     note_path = vault_root / rel_path
+    logger.info(
+        "panel note start relative_path=%s note_path=%s",
+        str(rel_path),
+        str(note_path),
+    )
     try:
-        markdown = note_path.read_text(encoding="utf-8")
+        markdown = _read_panel_note_with_retry(note_path)
     except Exception as exc:
         state.errors += 1
         print(f"WARN: failed to read panel note {note_path}: {exc}")
-        return
+        return 0
 
     try:
-        note_uuid = ensure_note_uuid(note_path)
+        note_uuid = _ensure_panel_note_uuid_with_retry(note_path)
     except Exception as exc:
         state.errors += 1
         print(f"WARN: failed to ensure uuid for {note_path}: {exc}")
-        return
+        return 0
 
     frontmatter, _ = load_frontmatter(markdown)
     note_title = frontmatter.get("title") if isinstance(frontmatter, dict) else None
@@ -295,7 +330,7 @@ def _process_panel_note(
     except Exception as exc:
         state.errors += 1
         print(f"WARN: panel agent failed for {note_path}: {exc}")
-        return
+        return 0
 
     try:
         _write_markdown_if_changed(note_path, markdown, result.updated_markdown)
@@ -319,6 +354,24 @@ def _process_panel_note(
             _write_jsonl_event(event, outbox_path)
         except Exception as exc:
             print(f"WARN: failed to append JSONL outbox event {event.event}: {exc}")
+    emitted_events = len(result.events)
+    if emitted_events <= 0:
+        logger.info(
+            "panel note no events relative_path=%s note_path=%s note_uuid=%s",
+            str(rel_path),
+            str(note_path),
+            note_uuid,
+        )
+        return 0
+    logger.info(
+        "panel note emitted relative_path=%s note_path=%s note_uuid=%s events=%s wrote_markdown=%s",
+        str(rel_path),
+        str(note_path),
+        note_uuid,
+        ",".join(getattr(event, "event", "") for event in result.events),
+        result.updated_markdown != markdown,
+    )
+    return emitted_events
 
 
 
@@ -677,22 +730,44 @@ def _emit_panel_events(
     last_seen = state.last_seen(str(rel))
     state.update_file_state(str(rel), mtime=mtime, content_hash=digest, seen_at=now)
     if last_seen is not None and (now - last_seen) * 1000 < spec.debounce_ms:
+        logger.info(
+            "panel emit skipped debounce relative_path=%s debounce_ms=%s",
+            str(rel),
+            spec.debounce_ms,
+        )
         return None
     if state.rate_window_count(now) >= spec.rate_limit_per_min:
         state.rate_limited += 1
+        logger.info(
+            "panel emit skipped rate_limit relative_path=%s rate_limit_per_min=%s",
+            str(rel),
+            spec.rate_limit_per_min,
+        )
         return None
-    _process_panel_note(
+    emitted_events = _process_panel_note(
         vault_root=cfg.vault_path,
         rel_path=rel,
         outbox_path=cfg.outbox_path,
         state=state,
         action_mappings=action_mappings,
     )
+    if emitted_events <= 0:
+        logger.info(
+            "panel emit produced no events relative_path=%s",
+            str(rel),
+        )
+        return None
     state.intents_emitted += 1
     state.record_rate_event(now)
     state.update_file_state(str(rel), mtime=mtime, content_hash=digest, emitted_at=now)
     trace_id = uuid4().hex
     state.last_trace_id = trace_id
+    logger.info(
+        "panel emit success relative_path=%s emitted_events=%s trace_id=%s",
+        str(rel),
+        emitted_events,
+        trace_id,
+    )
     return trace_id
 
 
@@ -706,19 +781,44 @@ def _emit_watch_event(
     mtime: float,
     content_hash: str | None,
     state: WatcherState,
-) -> str:
+) -> str | None:
     if spec.emit_event == "panel.scan.requested":
-        action_mappings = load_panel_action_mappings()
-        trace = _emit_panel_events(
-            spec=spec,
-            cfg=cfg,
-            rel=rel_path,
-            mtime=mtime,
-            digest=content_hash or "",
-            state=state,
-            action_mappings=action_mappings,
+        trace_id = uuid4().hex
+        payload = {
+            "vault_path": str(vault_root / rel_path),
+            "relative_path": str(rel_path),
+            "mtime": mtime,
+            "hash": content_hash,
+            "watcher": spec.name,
+        }
+        event = OutboxEvent(
+            event=PANEL_SCAN_REQUESTED,
+            source="watcher.registry",
+            trace_id=trace_id,
+            payload=payload,
         )
-        return trace or uuid4().hex
+        outbox_path.parent.mkdir(parents=True, exist_ok=True)
+        with outbox_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(event.model_dump(mode="json"), ensure_ascii=False))
+            handle.write("\n")
+        require_db = _db_outbox_required()
+        if require_db and not _has_db_outbox_env():
+            raise RuntimeError("DATABASE_URL or DB_DSN required for watcher DB outbox")
+        if require_db or _has_db_outbox_env():
+            try:
+                write_outbox_event(event)
+            except Exception:
+                state.enqueue_failures_total += 1
+                if require_db:
+                    raise
+                logger.exception(
+                    "watcher db outbox enqueue failed topic=%s trace_id=%s note_path=%s relative_path=%s",
+                    PANEL_SCAN_REQUESTED,
+                    trace_id,
+                    str(vault_root / rel_path),
+                    str(rel_path),
+                )
+        return trace_id
 
     trace_id = uuid4().hex
     payload = {
@@ -747,8 +847,6 @@ def _emit_watch_event(
             raise RuntimeError("DATABASE_URL or DB_DSN required for watcher DB outbox")
         if require_db or _has_db_outbox_env():
             try:
-                from app.services.outbox import insert_object_and_outbox
-
                 insert_object_and_outbox(
                     payload,
                     spec.emit_event,
@@ -894,6 +992,8 @@ def _run_spec_tick(
                 content_hash=current_digest,
                 state=state,
             )
+            if not trace_id:
+                continue
             state.last_trace_id = trace_id
             state.intents_emitted += 1
             emitted_in_tick += 1

--- a/app/workers/outbox_worker.py
+++ b/app/workers/outbox_worker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import errno
+import hashlib
 import logging
 import os
 import sys
@@ -9,21 +10,33 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping
 
-from app.events.types import INGEST_OBJECT_CREATED, INGEST_OBJECT_DELETED, INGEST_VAULT_CHANGED, PROMOTE_INTENT_CREATED
+from app.agents.panel.agent import handle_note_update
+from app.components.concurrency import OptimisticWriteGuard, VersionMismatch
+from app.events.schema import OutboxEvent
+from app.events.types import INGEST_OBJECT_CREATED, INGEST_OBJECT_DELETED, INGEST_VAULT_CHANGED, PANEL_SCAN_REQUESTED, PROMOTE_INTENT_CREATED
 from app.observability.tracer import start_span
 from app.runtime.worker_heartbeat import resolve_worker_heartbeat_path, write_worker_heartbeat
 from app.services.indexer import handle_ingest_object_created
 from app.services.note_uuid import ensure_note_uuid
-from app.services.outbox import ack_outbox, bootstrap, poll_outbox_one
+from app.services.outbox import ack_outbox, bootstrap, poll_outbox_one, write_outbox_event
+from app.settings.panel_actions import load_panel_action_mappings
 from app.vault.paths import get_vault_inbox_dir_rel
+from app.write_guard import DEFAULT_WRITE_GUARD
 from scripts.yaml_roundtrip import load_frontmatter
 
 logger = logging.getLogger(__name__)
+_WRITE_GUARD = OptimisticWriteGuard()
 
 
 @dataclass
 class WorkerIngestSummary:
     ingested: int
+
+
+@dataclass
+class WorkerPanelSummary:
+    emitted: int
+    deferred: bool = False
 
 
 def handle_ingest_object_deleted(payload: Mapping[str, Any]) -> None:
@@ -56,9 +69,19 @@ def _ensure_logging_configured() -> None:
 def _resolve_vault_root(vault_root: Path | None = None) -> Path:
     if vault_root is not None:
         return vault_root.expanduser().resolve()
+    watcher_root = os.getenv("WATCHER_VAULT_PATH")
+    if watcher_root:
+        watcher_path = Path(watcher_root).expanduser()
+        if watcher_path.exists():
+            return watcher_path.resolve()
     env_root = os.getenv("VAULT_ROOT")
     if env_root:
-        return Path(env_root).expanduser().resolve()
+        env_path = Path(env_root).expanduser()
+        if env_path.exists():
+            return env_path.resolve()
+    mounted_root = Path("/app/vault")
+    if mounted_root.exists():
+        return mounted_root.resolve()
     return Path("vault").expanduser().resolve()
 
 
@@ -161,6 +184,107 @@ def _maybe_heal_uuid(note_path: Path, vault_root: Path) -> str:
 
     return ""
 
+
+def _append_audit_event(event: OutboxEvent) -> None:
+    outbox_path = Path(os.getenv("INDEX_OUTBOX_PATH", "/app/tmp/index-outbox.jsonl")).expanduser()
+    try:
+        outbox_path.parent.mkdir(parents=True, exist_ok=True)
+        with outbox_path.open("a", encoding="utf-8") as handle:
+            handle.write(event.model_dump_json())
+            handle.write("\n")
+    except Exception:
+        return
+
+
+def _write_markdown_if_changed(note_path: Path, original: str, updated: str) -> bool:
+    if original == updated:
+        return False
+    expected_version = _WRITE_GUARD.compute_version(original.encode("utf-8"))
+    DEFAULT_WRITE_GUARD.assert_writes_allowed("panel worker update")
+    try:
+        _WRITE_GUARD.write_if_unchanged(note_path, expected_version, updated)
+        return True
+    except VersionMismatch:
+        return False
+
+
+def _stabilized_note_text(note_path: Path, *, attempts: int = 6, base_sleep: float = 0.25) -> str | None:
+    previous_signature: tuple[float, int, str] | None = None
+    for attempt in range(attempts):
+        try:
+            before = note_path.stat()
+            raw_text = note_path.read_text(encoding="utf-8")
+            after = note_path.stat()
+        except OSError as exc:
+            if exc.errno in {errno.ENOENT, errno.EPERM, errno.EACCES, errno.EROFS}:
+                if attempt + 1 < attempts:
+                    time.sleep(base_sleep * (2**attempt))
+                    continue
+                return None
+            raise
+        signature = (
+            float(after.st_mtime),
+            int(after.st_size),
+            hashlib.sha256(raw_text.encode("utf-8")).hexdigest(),
+        )
+        if before.st_mtime == after.st_mtime and before.st_size == after.st_size:
+            if signature == previous_signature:
+                return raw_text
+            previous_signature = signature
+        if attempt + 1 < attempts:
+            time.sleep(base_sleep * (2**attempt))
+    return None
+
+
+def handle_panel_scan_requested(
+    payload: Mapping[str, Any], *, vault_root: Path | None = None
+) -> WorkerPanelSummary:
+    resolved_root = _resolve_vault_root(vault_root)
+    note_path = _note_path_from_payload(payload, vault_root=resolved_root)
+
+    raw_text = _stabilized_note_text(note_path)
+    if raw_text is None:
+        logger.info("panel scan deferred (file unstable) note_path=%s", note_path)
+        return WorkerPanelSummary(emitted=0, deferred=True)
+
+    frontmatter, _ = load_frontmatter(raw_text)
+    note_uuid = _normalize_uuid_value(frontmatter.get("uuid") if isinstance(frontmatter, dict) else None)
+    healed_uuid = ""
+    if not note_uuid:
+        healed_uuid = _maybe_heal_uuid(note_path, resolved_root)
+        raw_text = _stabilized_note_text(note_path) or raw_text
+        frontmatter, _ = load_frontmatter(raw_text)
+        note_uuid = _normalize_uuid_value(frontmatter.get("uuid") if isinstance(frontmatter, dict) else None) or healed_uuid
+
+    if not note_uuid:
+        logger.info("panel scan skipped (missing uuid) note_path=%s", note_path)
+        return WorkerPanelSummary(emitted=0, deferred=True)
+
+    result = handle_note_update(
+        note_id=note_uuid,
+        old_markdown=raw_text,
+        new_markdown=raw_text,
+        action_mappings=load_panel_action_mappings(),
+        note_path=str(note_path),
+        proactive_assist=True,
+    )
+
+    try:
+        _write_markdown_if_changed(note_path, raw_text, result.updated_markdown)
+    except Exception as exc:
+        logger.warning("panel worker failed to write %s: %s", note_path, exc)
+
+    emitted = 0
+    for event in result.events:
+        write_outbox_event(event)
+        _append_audit_event(event)
+        emitted += 1
+    if emitted:
+        logger.info("panel scan handled note_path=%s note_uuid=%s emitted=%s", note_path, note_uuid, emitted)
+    else:
+        logger.info("panel scan produced no events note_path=%s note_uuid=%s", note_path, note_uuid)
+    return WorkerPanelSummary(emitted=emitted)
+
 def handle_ingest_vault_changed(
     payload: Mapping[str, Any], *, vault_root: Path | None = None
 ) -> WorkerIngestSummary:
@@ -172,6 +296,9 @@ def handle_ingest_vault_changed(
     try:
         raw_text = note_path.read_text(encoding="utf-8")
     except OSError as exc:
+        if exc.errno == errno.ENOENT:
+            logger.warning("ingest skipped (missing note) note_path=%s", note_path)
+            return WorkerIngestSummary(ingested=0)
         if exc.errno in {errno.EPERM, errno.EACCES, errno.EROFS}:
             _warn_once(
                 f"ingest_read_perm:{note_path}",
@@ -305,6 +432,8 @@ def run(
                             handle_ingest_vault_changed(payload)
                         elif topic == INGEST_OBJECT_DELETED:
                             handle_ingest_object_deleted(payload)
+                        elif topic == PANEL_SCAN_REQUESTED:
+                            handle_panel_scan_requested(payload)
                         elif topic == PROMOTE_INTENT_CREATED:
                             from app.promotion.consumer import consume_promotion_intent_payload
 

--- a/config/agents.yaml
+++ b/config/agents.yaml
@@ -3,7 +3,7 @@ merge:
   epsilon_score_gap: 0.25
   near_duplicate_similarity: 0.88
   overlap_similarity: 0.78
-  model: gpt-5-thinking@2025-09
+  model: gpt-5.4
   temperature: 0
   invariants:
     review_state_order: [draft, reviewed, promoted]
@@ -16,7 +16,7 @@ hygiene:
   empty_tokens: 0
   near_empty_tokens: 80
   salvage_llm: true
-  model: gpt-5-thinking@2025-09
+  model: gpt-5.4
   temperature: 0
   archive_path: Archive/Trash
   allow_hard_delete: false

--- a/docs/LLM.md
+++ b/docs/LLM.md
@@ -70,7 +70,7 @@ Embeddings are handled by `app/llm/embeddings.py`.
 | Mock (CLI/tests default) | `LLM_PROVIDER=mock`, `LLM_MOCK_RESPONSE='{"type":"note", ...}'` | No network calls. Health check skips Ollama reachability. |
 | Local Ollama | `LLM_PROVIDER=ollama`, `OLLAMA_HOST=http://127.0.0.1:11434`, `LLM_MODEL=llama3.1:8b-instruct`, `OLLAMA_EMBED_MODEL=nomic-embed-text:latest` | Pre-pull models (`ollama pull llama3.1:8b`). |
 | DeepSeek via Ollama tag | `LLM_PROVIDER=ollama`, `LLM_MODEL=deepseek-r1:8b` | Same health flow. Pull via `ollama pull deepseek-r1:8b`. |
-| OpenAI API | `LLM_PROVIDER=openai`, `OPENAI_API_KEY=...`, `LLM_MODEL=gpt-4o-mini` | No built-in retry; consider guardrail breaker integration for unstable remote providers. |
+| OpenAI API | `LLM_PROVIDER=openai`, `OPENAI_API_KEY=...`, `LLM_MODEL=gpt-5.4-mini` | Current lower-latency default. Use `gpt-5.4` for heavier reasoning/coding flows. No built-in retry; consider guardrail breaker integration for unstable remote providers. |
 | DeepSeek API | `LLM_PROVIDER=deepseek`, `DEEPSEEK_API_KEY=...`, `LLM_MODEL=deepseek-chat` | Reuses the same timeout model as other chat providers. |
 
 ## Timeouts, retries, breakers

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -34,7 +34,7 @@ CLI note:
 
 Current runtime path:
 1. The registry watcher scans the vault and emits DB outbox events.
-2. The worker consumes DB outbox rows and performs ingest/index work.
+2. The worker consumes DB outbox rows and performs ingest/index, panel scan, and promotion work.
 3. Health, status, and metrics confirm whether that path is healthy.
 
 When the issue is startup topology or Compose wiring, switch to `docs/INFRASTRUCTURE.md`.
@@ -114,7 +114,7 @@ Companion docs:
 - Postgres data lives in the `postgres-data` volume; `docker compose down -v` wipes it.
 - The API container runs `scripts/start_api.sh` (migrations + `uvicorn`).
 - The worker runs `python -m app.workers.outbox_worker` (consumes DB outbox).
-- The watcher runs `python -m app.cli watcher run` (registry loop; emits `ingest.vault.changed` or `panel.scan.requested` to outbox).
+- The watcher runs `python -m app.cli watcher run` (registry loop; emits `ingest.vault.changed` or `panel.scan.requested` to outbox only).
 - Legacy dev stacks may include agent/redis containers; they are not part of the runtime start-system path.
 - `scripts/start_full_system.sh` is the supported startup wrapper. It now auto-probes Ollama reachability from inside the containerized runtime and persists the selected Docker-reachable endpoint into `tmp/runtime.env` before declaring startup healthy.
 - When `LLM_PROVIDER=ollama`, startup tries the configured endpoint first, then Docker-safe candidates such as `host.docker.internal`, before failing the run.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -4,11 +4,21 @@ Authority: Canonical testing and validation strategy for the active baseline, in
 # TESTING
 
 ## Layers
-- Unit: pure functions and single-agent logic
-- Contract: `.done` event payload shape and DB side-effects per agent
-- E2E: normalizer → classifier → chunker → deduper → citation → indexer → reviewer → projector
-- LLM eval (DeepEval/Ragas): opt-in `@pytest.mark.eval` tests for ASK/retrieval quality (see `docs/eval.md`)
+- Unit testing: pure functions and single-agent logic in isolation.
+- Integration testing: component boundaries such as API ↔ stores ↔ services, routing compilation, and outbox/store interactions.
+- System testing: end-to-end runtime flows such as note → ingest → index → ASK or watcher → panel → promotion chains.
+- System integration testing (SIT): opt-in flows that exercise multiple runtime systems or external dependencies together, such as live LLM/provider wiring and full startup/runtime verification.
+- Contract: `.done` event payload shape and DB side-effects per agent.
+- LLM eval (DeepEval/Ragas): opt-in `@pytest.mark.eval` tests for ASK/retrieval quality (see `docs/eval.md`).
 - Property-based ingest invariants: `tests/ingest/test_normalize_properties.py` ensures normalize outputs Core-6 fields robustly.
+
+## Layer mapping
+| Layer | Focus | Representative suites | Command |
+| --- | --- | --- | --- |
+| Unit | Correct logic in one function/class/module | `tests/components/llm/test_router.py`, `tests/settings/test_model_registry.py`, `tests/guards/test_no_hardcoded_inbox_scope.py` | `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/components/llm/test_router.py tests/settings/test_model_registry.py tests/guards/test_no_hardcoded_inbox_scope.py -m "not pg"` |
+| Integration | Boundaries and data integration inside this repo | `tests/settings/test_runtime.py`, `tests/settings/test_auto_heal.py`, `tests/cli/test_health_llm_routing.py`, `tests/runtime/test_startup_env.py` | `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/settings/test_runtime.py tests/settings/test_auto_heal.py tests/cli/test_health_llm_routing.py tests/runtime/test_startup_env.py -m "not pg"` |
+| System | Whole-system end-to-end flows in a production-like local test harness | `tests/e2e/test_reality_mvp_pipeline.py`, `tests/e2e/test_watcher_registry_e2e.py` | `STORE_BACKEND=memory PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/e2e/test_reality_mvp_pipeline.py tests/e2e/test_watcher_registry_e2e.py -m "not pg"` |
+| SIT | Cross-system/runtime/provider integration, often opt-in or environment-dependent | `tests/e2e/test_panel_llm_e2e.py`, `tests/reasoning/test_reasoning_llm_live_alpha.py`, `tests/cli/test_llm_doctor_cli.py` | `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/cli/test_llm_doctor_cli.py -m "not pg"` |
 
 ## Evaluation Stack (Registry Watcher / Panel / Promotion)
 - **A. Contract tests** — assert watcher→panel→promotion event envelopes and payload invariants; run via `pytest -q tests/e2e/test_watcher_registry_e2e.py -m "not pg"` (exact command may move to `tests/fitness`).

--- a/docs/runbooks/RUNBOOK_STARTUP_FULL_SYSTEM.md
+++ b/docs/runbooks/RUNBOOK_STARTUP_FULL_SYSTEM.md
@@ -22,8 +22,8 @@ make alpha-up
 
 ## Alpha Compose Runtime (canonical)
 - Services: `db`, `api`, `watcher`, `worker`.
-- The watcher writes audit JSONL events and enqueues DB outbox events (`ingest.vault.changed`, `promote.intent.created`).
-- The worker consumes the DB outbox to perform ingest and promotion side effects, emitting `promote.done` on success.
+- The watcher writes audit JSONL events and enqueues DB outbox events (`ingest.vault.changed`, `panel.scan.requested`).
+- The worker consumes the DB outbox to perform ingest, panel, and promotion side effects, emitting `panel.intent.*`, `promote.intent.created`, and `promote.done` on success.
 - Inbox UUID healing is performed by the worker on `ingest.vault.changed` for notes under the inbox folder (from `vault.layout.md` or `VAULT_INBOX_DIR_REL`) so notes do not linger without `uuid:` after a worker pass.
 - Status/health surfaces should be used for operator gating (`required_ok` is the primary signal).
 

--- a/docs/settings/models/openai.chat.gpt_5_4.yaml
+++ b/docs/settings/models/openai.chat.gpt_5_4.yaml
@@ -1,0 +1,6 @@
+id: openai.chat.gpt_5_4
+status: active
+kind: chat
+provider: openai
+model: gpt-5.4
+notes: Current flagship OpenAI chat model for complex reasoning, coding, and planning workloads.

--- a/docs/settings/models/openai.chat.gpt_5_4_mini.yaml
+++ b/docs/settings/models/openai.chat.gpt_5_4_mini.yaml
@@ -1,0 +1,6 @@
+id: openai.chat.gpt_5_4_mini
+status: active
+kind: chat
+provider: openai
+model: gpt-5.4-mini
+notes: Current lower-latency OpenAI chat default for everyday ask, QA, and classification flows.

--- a/docs/settings/models/registry.yaml
+++ b/docs/settings/models/registry.yaml
@@ -1,5 +1,11 @@
 version: 1
 models:
+  - id: openai.chat.gpt_5_4_mini
+    path: docs/settings/models/openai.chat.gpt_5_4_mini.yaml
+    status: active
+  - id: openai.chat.gpt_5_4
+    path: docs/settings/models/openai.chat.gpt_5_4.yaml
+    status: active
   - id: openai.chat.gpt_4_1_mini
     path: docs/settings/models/openai.chat.gpt_4_1_mini.yaml
     status: active

--- a/tests/cli/test_alpha_human_flows.py
+++ b/tests/cli/test_alpha_human_flows.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import shutil
 import textwrap
 from pathlib import Path
 
@@ -12,6 +13,7 @@ from app.services.note_log import note_log_path
 from scripts.yaml_roundtrip import load_frontmatter
 
 alpha_human_flows_module = importlib.import_module("app.cli.alpha_human_flows")
+FIXTURE_VAULT = Path(__file__).resolve().parents[1] / "fixtures" / "vault_alpha"
 
 
 def _base_env(tmp_path: Path) -> dict[str, str]:
@@ -42,6 +44,12 @@ def _make_vault(tmp_path: Path) -> Path:
     )
     filler = vault / "Projects" / "other.md"
     filler.write_text("# Other project\nThis note is unrelated.\n", encoding="utf-8")
+    return vault
+
+
+def _copy_fixture_vault(tmp_path: Path) -> Path:
+    vault = tmp_path / "vault"
+    shutil.copytree(FIXTURE_VAULT, vault)
     return vault
 
 
@@ -179,6 +187,25 @@ def test_alpha_human_flows_writes_test_note_via_knowledge_port(tmp_path: Path, m
     result = _run_cli(vault, tmp_path)
     assert result.exit_code == 0, result.output
     assert "Test/Alpha-HumanFlows.md" in writes
+
+
+def test_alpha_human_flows_runs_against_fixture_vault_alpha(tmp_path: Path) -> None:
+    get_store().set_documents([])
+    vault = _copy_fixture_vault(tmp_path)
+
+    result = _run_cli(vault, tmp_path)
+
+    assert result.exit_code == 0, result.output
+    assert 'ASK: "What does the Alpha Human Flows test note say?"' in result.output
+    assert "SOURCES:" in result.output
+    assert "Test/Alpha-HumanFlows.md" in result.output or "Concepts/ExistingUUID.md" in result.output
+
+    test_note = vault / "Test" / "Alpha-HumanFlows.md"
+    frontmatter, body = load_frontmatter(test_note.read_text(encoding="utf-8"))
+    assert frontmatter.get("uuid") == "22222222-2222-2222-2222-222222222222"
+    assert frontmatter.get("review_state") == "promoted"
+    assert frontmatter.get("maturity") == "evergreen"
+    assert "Alpha Human Flows test note for orchestration." in body
 
 
 # Coverage gaps: Flow A sample selection errors not exercised; mirror file creation not asserted (path only);

--- a/tests/cli/test_health_llm_routing.py
+++ b/tests/cli/test_health_llm_routing.py
@@ -29,7 +29,7 @@ def test_health_llm_router_includes_configured_task_routes(monkeypatch) -> None:
         llm_routing=LLMRoutingSettings(
             tasks={
                 "qa": LLMRoutingSettings.TaskPolicy(
-                    primary=LLMRoutingSettings.RouteTarget(provider="openai", model="gpt-4.1-mini")
+                    primary=LLMRoutingSettings.RouteTarget(provider="openai", model="gpt-5.4-mini")
                 )
             }
         )

--- a/tests/cli/test_uat_run_cli.py
+++ b/tests/cli/test_uat_run_cli.py
@@ -6,6 +6,7 @@ from app.cli import cli
 from app.cli.uat import DEFAULT_FOLDER_NAME, DEFAULT_TARGET_SUBDIR
 from app.store.object_store import ObjectStore
 from app.store import object_store as object_store_module
+from scripts.yaml_roundtrip import load_frontmatter
 
 
 PROMOTE_UUID = "11111111-1111-4111-8111-111111111111"
@@ -53,8 +54,96 @@ def test_uat_run_cli_end_to_end(tmp_path: Path) -> None:
     assert promoted is not None
     assert (promoted.payload or {}).get("review_state")
 
-    # manual/never note should remain skipped by policy
     summary_path = tmp_path / DEFAULT_TARGET_SUBDIR / DEFAULT_FOLDER_NAME / ".agentic-pkm" / "vault_watcher_uat_state.json"
     assert summary_path.exists()
+
+    object_store_module._MEMORY_STORE.clear()
+
+
+def test_uat_run_cli_dry_run_is_non_mutating(tmp_path: Path) -> None:
+    object_store_module._MEMORY_STORE.clear()
+    runner = CliRunner()
+    env = _env(tmp_path)
+
+    seed_result = runner.invoke(
+        cli,
+        [
+            "uat-seed-vault-test",
+            "--vault-root",
+            str(tmp_path),
+        ],
+        env=env,
+    )
+    assert seed_result.exit_code == 0, seed_result.output
+
+    note_path = tmp_path / DEFAULT_TARGET_SUBDIR / DEFAULT_FOLDER_NAME / "evergreen-strategy.md"
+    before = note_path.read_text(encoding="utf-8")
+
+    run_result = runner.invoke(
+        cli,
+        [
+            "uat-run-vault-test",
+            "--vault-root",
+            str(tmp_path),
+            "--dry-run",
+        ],
+        env=env,
+    )
+    assert run_result.exit_code == 0, run_result.output
+    assert note_path.read_text(encoding="utf-8") == before
+
+    frontmatter, _ = load_frontmatter(before)
+    assert "review_state" not in (frontmatter or {})
+    store = ObjectStore()
+    assert store.get_object(PROMOTE_UUID) is None
+
+    object_store_module._MEMORY_STORE.clear()
+
+
+def test_uat_run_cli_supports_converged_rerun_assertions(tmp_path: Path) -> None:
+    object_store_module._MEMORY_STORE.clear()
+    runner = CliRunner()
+    env = _env(tmp_path)
+
+    seed_result = runner.invoke(
+        cli,
+        [
+            "uat-seed-vault-test",
+            "--vault-root",
+            str(tmp_path),
+        ],
+        env=env,
+    )
+    assert seed_result.exit_code == 0, seed_result.output
+
+    first_run = runner.invoke(
+        cli,
+        [
+            "uat-run-vault-test",
+            "--vault-root",
+            str(tmp_path),
+            "--assert",
+            "--assert-mode",
+            "bootstrap",
+        ],
+        env=env,
+    )
+    assert first_run.exit_code == 0, first_run.output
+
+    second_run = runner.invoke(
+        cli,
+        [
+            "uat-run-vault-test",
+            "--vault-root",
+            str(tmp_path),
+            "--assert",
+            "--assert-mode",
+            "converged",
+        ],
+        env=env,
+    )
+    assert second_run.exit_code == 0, second_run.output
+    assert "promote_intents=0" in second_run.output
+    assert "applied=0" in second_run.output
 
     object_store_module._MEMORY_STORE.clear()

--- a/tests/components/llm/test_router.py
+++ b/tests/components/llm/test_router.py
@@ -138,7 +138,7 @@ def test_router_uses_settings_task_policy(monkeypatch, clean_llm_env) -> None:
         llm_routing=LLMRoutingSettings(
             default_chat=LLMRoutingSettings.TaskPolicy(
                 primary=LLMRoutingSettings.RouteTarget(
-                    model_id="openai.chat.gpt_4_1_mini", provider="openai", model="gpt-chat"
+                    model_id="openai.chat.gpt_5_4_mini", provider="openai", model="gpt-chat"
                 ),
                 fallback=LLMRoutingSettings.FallbackPolicy(
                     mode="local", model_id="ollama.chat.llama3_1_8b", provider="ollama", model="llama-local"
@@ -147,7 +147,7 @@ def test_router_uses_settings_task_policy(monkeypatch, clean_llm_env) -> None:
             tasks={
                 "plan": LLMRoutingSettings.TaskPolicy(
                     primary=LLMRoutingSettings.RouteTarget(
-                        model_id="openai.chat.gpt_4_1", provider="openai", model="gpt-4.1"
+                        model_id="openai.chat.gpt_5_4", provider="openai", model="gpt-5.4"
                     ),
                     fallback=LLMRoutingSettings.FallbackPolicy(
                         mode="local", model_id="ollama.chat.llama3_1_8b", provider="ollama", model="llama-local"
@@ -162,11 +162,11 @@ def test_router_uses_settings_task_policy(monkeypatch, clean_llm_env) -> None:
     route = router.route(LLMTaskIntent(task_kind="plan"))
 
     assert route.provider == "openai"
-    assert route.model == "gpt-4.1"
+    assert route.model == "gpt-5.4"
     assert route.reason == "settings"
 
     described = router.describe_intent(LLMTaskIntent(task_kind="plan"))
-    assert described["policy"]["primary"]["model_id"] == "openai.chat.gpt_4_1"
+    assert described["policy"]["primary"]["model_id"] == "openai.chat.gpt_5_4"
     assert described["policy"]["fallback"]["model_id"] == "ollama.chat.llama3_1_8b"
 
 
@@ -177,7 +177,7 @@ def test_router_prefers_selected_model_id_over_env_defaults(monkeypatch, clean_l
         llm_routing=LLMRoutingSettings(
             tasks={
                 "plan": LLMRoutingSettings.TaskPolicy(
-                    primary=LLMRoutingSettings.RouteTarget(model_id="openai.chat.gpt_4_1")
+                    primary=LLMRoutingSettings.RouteTarget(model_id="openai.chat.gpt_5_4")
                 )
             }
         )
@@ -188,7 +188,7 @@ def test_router_prefers_selected_model_id_over_env_defaults(monkeypatch, clean_l
     route = router.route(LLMTaskIntent(task_kind="plan"))
 
     assert route.provider == "openai"
-    assert route.model == "gpt-4.1"
+    assert route.model == "gpt-5.4"
 
 
 def test_router_rejects_incompatible_embedding_fallback(monkeypatch, clean_llm_env) -> None:
@@ -218,7 +218,7 @@ def test_router_honors_model_id_only_chat_fallback(monkeypatch, clean_llm_env) -
         llm_routing=LLMRoutingSettings(
             tasks={
                 "plan": LLMRoutingSettings.TaskPolicy(
-                    primary=LLMRoutingSettings.RouteTarget(provider="openai", model="gpt-4.1"),
+                    primary=LLMRoutingSettings.RouteTarget(provider="openai", model="gpt-5.4"),
                     fallback=LLMRoutingSettings.FallbackPolicy(
                         mode="allowed",
                         model_id="mock.chat",
@@ -267,7 +267,7 @@ def test_router_verification_intents_include_configured_tasks(monkeypatch, clean
         llm_routing=LLMRoutingSettings(
             tasks={
                 "qa": LLMRoutingSettings.TaskPolicy(
-                    primary=LLMRoutingSettings.RouteTarget(provider="openai", model="gpt-4.1-mini")
+                    primary=LLMRoutingSettings.RouteTarget(provider="openai", model="gpt-5.4-mini")
                 )
             }
         )

--- a/tests/e2e/test_watcher_registry_e2e.py
+++ b/tests/e2e/test_watcher_registry_e2e.py
@@ -1,4 +1,5 @@
 
+import json
 import uuid
 from pathlib import Path
 from textwrap import dedent
@@ -158,15 +159,24 @@ def test_watcher_registry_uses_env_paths_heals_uuid_and_applies_panel_policy(
     candidate_text = panel_candidate.read_text(encoding="utf-8")
     candidate_frontmatter, _ = load_frontmatter(candidate_text)
     assert watcher_panel_candidate_for_path(panel_candidate, candidate_frontmatter or {}, candidate_text)
-    assert "<!--ai:assist:start-->" in candidate_text
+    assert "<!--ai:assist:start-->" not in candidate_text
 
     never_text = panel_never.read_text(encoding="utf-8")
     never_frontmatter, _ = load_frontmatter(never_text)
     assert not watcher_panel_candidate_for_path(panel_never, never_frontmatter or {}, never_text)
 
     proactive_text = proactive_note.read_text(encoding="utf-8")
-    assert "%% AI %%" in proactive_text
-    assert "<!--ai:assist:start-->" in proactive_text
+    assert "%% AI %%" not in proactive_text
+    assert "<!--ai:assist:start-->" not in proactive_text
 
     ineligible_text = ineligible_note.read_text(encoding="utf-8")
     assert "%% AI %%" not in ineligible_text
+
+    outbox_records = [
+        json.loads(line)
+        for line in Path(env["INDEX_OUTBOX_PATH"]).read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    topics = [rec.get("event") for rec in outbox_records]
+    assert "panel.scan.requested" in topics
+    assert "ingest.vault.changed" in topics

--- a/tests/runtime/test_startup_env.py
+++ b/tests/runtime/test_startup_env.py
@@ -70,7 +70,7 @@ def test_llm_alias_normalizes_to_ollama() -> None:
 
 
 def test_openai_provider_requires_openai_base_url() -> None:
-    env = {"LLM_PROVIDER": "openai", "LLM_MODEL": "gpt-4.1"}
+    env = {"LLM_PROVIDER": "openai", "LLM_MODEL": "gpt-5.4"}
     result = validate_llm_env(env)
     assert result["ok"] is False
     assert result["missing_all_of"] == ["OPENAI_BASE_URL"]

--- a/tests/runtime/test_worker_dispatch_ingest_vault_changed.py
+++ b/tests/runtime/test_worker_dispatch_ingest_vault_changed.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from app.events.types import INGEST_OBJECT_DELETED, INGEST_VAULT_CHANGED
+from app.events.types import INGEST_OBJECT_DELETED, INGEST_VAULT_CHANGED, PANEL_SCAN_REQUESTED
 from app.workers import outbox_worker
 
 pytestmark = pytest.mark.not_pg
@@ -95,3 +95,45 @@ def test_worker_run_dispatches_ingest_object_deleted(
 
     assert called == [{"uuid": "u-del-1", "path": "/tmp/vault/Inbox/deleted.md", "deleted": True, "event_id": "evt-del-1", "trace_id": "trace-del-1"}]
     assert acked == ["del-1"]
+
+
+def test_worker_run_dispatches_panel_scan_requested(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called: list[dict] = []
+    acked: list[str] = []
+
+    def fake_handle(payload, *, vault_root=None):
+        called.append(dict(payload))
+        return outbox_worker.WorkerPanelSummary(emitted=0, deferred=False)
+
+    monkeypatch.setattr(outbox_worker, "handle_panel_scan_requested", fake_handle)
+    monkeypatch.setattr(outbox_worker, "bootstrap", lambda: None)
+    monkeypatch.setattr(outbox_worker, "ack_outbox", lambda msg_id: acked.append(str(msg_id)) or True)
+    monkeypatch.setattr(outbox_worker, "write_worker_heartbeat", lambda **_: None)
+
+    messages = [
+        {
+            "id": "panel-1",
+            "topic": PANEL_SCAN_REQUESTED,
+            "payload": {
+                "vault_path": "/tmp/vault/Inbox/panel.md",
+                "relative_path": "Inbox/panel.md",
+                "event_id": "evt-panel-1",
+                "trace_id": "trace-panel-1",
+            },
+        }
+    ]
+
+    def fake_poll():
+        if messages:
+            return messages.pop(0)
+        return None
+
+    monkeypatch.setattr(outbox_worker, "poll_outbox_one", fake_poll)
+    monkeypatch.setenv("WORKER_HEARTBEAT_INTERVAL", "9999")
+
+    outbox_worker.run(interval=0.0, heartbeat_interval=9999, log_heartbeat_interval=None, stop_after_ticks=2)
+
+    assert called == [{"vault_path": "/tmp/vault/Inbox/panel.md", "relative_path": "Inbox/panel.md", "event_id": "evt-panel-1", "trace_id": "trace-panel-1"}]
+    assert acked == ["panel-1"]

--- a/tests/runtime/test_worker_ingest_event.py
+++ b/tests/runtime/test_worker_ingest_event.py
@@ -98,3 +98,127 @@ def test_handle_ingest_vault_changed_heals_uuid_using_vault_layout_inbox(
 
     obj = ObjectStore().get_object(healed_uuid)
     assert obj is not None
+
+
+def test_handle_ingest_vault_changed_uses_relative_path_when_payload_path_is_host_absolute(
+    tmp_path: Path, monkeypatch
+) -> None:
+    reset_memory_stores()
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+
+    mounted_vault_root = tmp_path / "mounted-vault"
+    inbox = mounted_vault_root / "📥 Inbox"
+    inbox.mkdir(parents=True, exist_ok=True)
+
+    note_uuid = str(uuid.uuid4())
+    note_path = inbox / "host-path-note.md"
+    note_path.write_text(
+        f"---\nuuid: {note_uuid}\n---\n\nRuntime path translation works.\n",
+        encoding="utf-8",
+    )
+
+    host_style_root = Path("/Users/rasmus/Library/Mobile Documents/iCloud~md~obsidian/Documents/PKM - Alpha")
+    payload = {
+        "vault_path": str(host_style_root / "📥 Inbox" / "host-path-note.md"),
+        "relative_path": "📥 Inbox/host-path-note.md",
+        "hash": "test-hash",
+        "mtime": 123.0,
+    }
+
+    summary = outbox_worker.handle_ingest_vault_changed(payload, vault_root=mounted_vault_root)
+    assert summary.ingested == 1
+
+    obj = ObjectStore().get_object(note_uuid)
+    assert obj is not None
+    assert "Runtime path translation works." in str(obj.payload.get("raw_text") or obj.payload.get("text") or "")
+
+
+def test_handle_ingest_vault_changed_skips_missing_note(tmp_path: Path, monkeypatch) -> None:
+    reset_memory_stores()
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+
+    vault_root = tmp_path / "vault"
+    (vault_root / "📥 Inbox").mkdir(parents=True, exist_ok=True)
+
+    payload = {
+        "vault_path": str(vault_root / "📥 Inbox" / "missing.md"),
+        "relative_path": "📥 Inbox/missing.md",
+        "hash": "test-hash",
+        "mtime": 123.0,
+    }
+
+    summary = outbox_worker.handle_ingest_vault_changed(payload, vault_root=vault_root)
+    assert summary.ingested == 0
+
+
+def test_handle_panel_scan_requested_emits_panel_events(tmp_path: Path, monkeypatch) -> None:
+    reset_memory_stores()
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv("PANEL_AGENT_DECIDER", "rule")
+
+    vault_root = tmp_path / "vault"
+    inbox = vault_root / "📥 Inbox"
+    inbox.mkdir(parents=True, exist_ok=True)
+
+    note_uuid = str(uuid.uuid4())
+    note_path = inbox / "panel-note.md"
+    note_path.write_text(
+        "---\n"
+        f"uuid: {note_uuid}\n"
+        "ai_panel_auto_run: watcher\n"
+        "---\n"
+        "%% AI:Start %%\n"
+        "## AI-instruktion\n"
+        "Promote this test note when checked.\n\n"
+        "## AI-åtgärder\n"
+        "- [x] Make this note evergreen <!--ai:id=promote.evergreen-->\n\n"
+        "## AI-logg\n"
+        "%% AI:End %%\n",
+        encoding="utf-8",
+    )
+
+    events: list[str] = []
+
+    def fake_write_outbox(event):
+        events.append(getattr(event, "event", ""))
+        return "ok"
+
+    monkeypatch.setattr(outbox_worker, "write_outbox_event", fake_write_outbox)
+
+    payload = {
+        "vault_path": str(note_path),
+        "relative_path": "📥 Inbox/panel-note.md",
+        "hash": "test-hash",
+        "mtime": 123.0,
+    }
+
+    summary = outbox_worker.handle_panel_scan_requested(payload, vault_root=vault_root)
+    assert summary.emitted >= 3
+    assert "panel.intent.created" in events
+    assert "panel.intent.executed" in events
+    assert "promote.intent.created" in events
+
+
+def test_handle_panel_scan_requested_defers_unstable_file(tmp_path: Path, monkeypatch) -> None:
+    reset_memory_stores()
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+
+    vault_root = tmp_path / "vault"
+    inbox = vault_root / "📥 Inbox"
+    inbox.mkdir(parents=True, exist_ok=True)
+
+    note_path = inbox / "panel-note.md"
+    note_path.write_text("stub", encoding="utf-8")
+
+    monkeypatch.setattr(outbox_worker, "_stabilized_note_text", lambda *_args, **_kwargs: None)
+
+    payload = {
+        "vault_path": str(note_path),
+        "relative_path": "📥 Inbox/panel-note.md",
+        "hash": "test-hash",
+        "mtime": 123.0,
+    }
+
+    summary = outbox_worker.handle_panel_scan_requested(payload, vault_root=vault_root)
+    assert summary.emitted == 0
+    assert summary.deferred is True

--- a/tests/settings/test_auto_heal.py
+++ b/tests/settings/test_auto_heal.py
@@ -54,7 +54,7 @@ def test_auto_heal_rewrites_invalid_values(tmp_path, monkeypatch):
         ```yaml settings
         default_chat:
           primary:
-            model_id: openai.chat.gpt_4_1_mini
+            model_id: openai.chat.gpt_5_4_mini
         ```
         """,
     )
@@ -126,7 +126,7 @@ def test_auto_heal_writes_settings_via_knowledge_port(tmp_path, monkeypatch) -> 
         ```yaml settings
         default_chat:
           primary:
-            model_id: openai.chat.gpt_4_1_mini
+            model_id: openai.chat.gpt_5_4_mini
         ```
         """,
     )
@@ -190,7 +190,7 @@ def test_compile_all_writes_llm_routing_runtime_file(tmp_path, monkeypatch) -> N
         tasks:
           plan:
             primary:
-              model_id: openai.chat.gpt_4_1
+              model_id: openai.chat.gpt_5_4
         ```
         """,
     )
@@ -200,10 +200,10 @@ def test_compile_all_writes_llm_routing_runtime_file(tmp_path, monkeypatch) -> N
 
     bundle = compiler.compile_all(auto_heal=False)
 
-    assert bundle.llm_routing.tasks["plan"].primary.model_id == "openai.chat.gpt_4_1"
+    assert bundle.llm_routing.tasks["plan"].primary.model_id == "openai.chat.gpt_5_4"
     assert bundle.llm_routing.tasks["plan"].primary.provider == "openai"
     compiled = (runtime_dir / "llm_routing.yaml").read_text(encoding="utf-8")
-    assert "gpt-4.1" in compiled
+    assert "gpt-5.4" in compiled
 
 
 def test_compile_all_rejects_incompatible_model_kind_for_embed_task(tmp_path, monkeypatch) -> None:
@@ -245,7 +245,7 @@ def test_compile_all_rejects_incompatible_model_kind_for_embed_task(tmp_path, mo
         tasks:
           embed:
             primary:
-              model_id: openai.chat.gpt_4_1_mini
+              model_id: openai.chat.gpt_5_4_mini
         ```
         """,
     )

--- a/tests/settings/test_model_registry.py
+++ b/tests/settings/test_model_registry.py
@@ -12,6 +12,8 @@ def test_model_registry_loads() -> None:
     reg = load_model_registry()
     assert reg.version >= 1
     ids = {m.id for m in reg.models}
+    assert "openai.chat.gpt_5_4_mini" in ids
+    assert "openai.chat.gpt_5_4" in ids
     assert "openai.chat.gpt_4_1_mini" in ids
     assert "openai.chat.gpt_4_1" in ids
     assert "ollama.chat.llama3_1_8b" in ids
@@ -22,7 +24,7 @@ def test_model_registry_loads() -> None:
 
 def test_models_load_and_match_manifest() -> None:
     models = load_models()
-    assert models["openai.chat.gpt_4_1_mini"].provider == "openai"
+    assert models["openai.chat.gpt_5_4_mini"].provider == "openai"
     assert models["mock.embed"].kind == "embedding"
     assert models["mock.embed"].dims is not None
 

--- a/tests/settings/test_runtime.py
+++ b/tests/settings/test_runtime.py
@@ -49,9 +49,9 @@ def test_runtime_loads_llm_routing_settings(tmp_path, monkeypatch):
         {
             "default_chat": {
                 "primary": {
-                    "model_id": "openai.chat.gpt_4_1_mini",
+                    "model_id": "openai.chat.gpt_5_4_mini",
                     "provider": "openai",
-                    "model": "gpt-4.1-mini",
+                    "model": "gpt-5.4-mini",
                 },
                 "fallback": {
                     "mode": "local",
@@ -80,6 +80,6 @@ def test_runtime_loads_llm_routing_settings(tmp_path, monkeypatch):
     bundle = runtime.reload_settings_bundle(notify=False)
 
     assert bundle.llm_routing.default_chat.primary.provider == "openai"
-    assert bundle.llm_routing.default_chat.primary.model_id == "openai.chat.gpt_4_1_mini"
+    assert bundle.llm_routing.default_chat.primary.model_id == "openai.chat.gpt_5_4_mini"
     assert bundle.llm_routing.default_chat.fallback.mode == "local"
     assert bundle.llm_routing.default_embedding.require_compatible_identity is True

--- a/tests/watcher/test_panel_watcher_outbox_db.py
+++ b/tests/watcher/test_panel_watcher_outbox_db.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 from app.events.schema import OutboxEvent
 from app.settings.panel_actions import PanelActionMapping
 from app.vault.paths import get_vault_inbox_dir_rel
-from app.watcher.registry import _process_panel_note
+from app.watcher.registry import _emit_panel_events, _process_panel_note, RegistryConfig, WatcherSpec, _run_spec_tick
 from app.watcher.state import WatcherState
 
 
@@ -61,3 +62,332 @@ uuid: test-uuid
         if line.strip()
     ]
     assert payloads, "expected payloads in JSONL"
+
+
+def test_process_panel_note_retries_transient_read_failure(tmp_path, monkeypatch):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    note_dir = vault / get_vault_inbox_dir_rel(vault)
+    note_dir.mkdir()
+    note_path = note_dir / "note.md"
+    note_path.write_text(
+        """---
+uuid: test-uuid
+---
+# Panel
+- [x] Make this note evergreen <!--ai:id=promote.evergreen-->
+""",
+        encoding="utf-8",
+    )
+
+    events: list[OutboxEvent] = []
+
+    def fake_write_outbox(ev):
+        events.append(ev)
+        return "ok"
+
+    monkeypatch.setattr("app.watcher.registry.write_outbox_event", fake_write_outbox)
+
+    attempts = {"count": 0}
+    real_read = Path.read_text
+
+    def flaky_read(self: Path, *args, **kwargs):
+        if self == note_path and attempts["count"] == 0:
+            attempts["count"] += 1
+            raise OSError(2, "No such file or directory")
+        return real_read(self, *args, **kwargs)
+
+    monkeypatch.setattr("pathlib.Path.read_text", flaky_read)
+
+    mappings = {
+        "Make this note evergreen": PanelActionMapping(
+            text="Make this note evergreen",
+            event_type="promote.intent.created",
+            payload_template={"maturity": "evergreen"},
+            action_id="promote.evergreen",
+        )
+    }
+    state = WatcherState()
+
+    written = _process_panel_note(
+        vault_root=vault,
+        rel_path=note_path.relative_to(vault),
+        outbox_path=tmp_path / "outbox.jsonl",
+        state=state,
+        action_mappings=mappings,
+    )
+
+    assert written > 0
+    assert events
+
+
+def test_process_panel_note_retries_transient_uuid_failure(tmp_path, monkeypatch):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    note_dir = vault / get_vault_inbox_dir_rel(vault)
+    note_dir.mkdir()
+    note_path = note_dir / "note.md"
+    note_path.write_text(
+        """---
+uuid: test-uuid
+---
+# Panel
+- [x] Make this note evergreen <!--ai:id=promote.evergreen-->
+""",
+        encoding="utf-8",
+    )
+
+    events: list[OutboxEvent] = []
+
+    def fake_write_outbox(ev):
+        events.append(ev)
+        return "ok"
+
+    monkeypatch.setattr("app.watcher.registry.write_outbox_event", fake_write_outbox)
+
+    attempts = {"count": 0}
+
+    def flaky_ensure(path: Path) -> str:
+        if path == note_path and attempts["count"] == 0:
+            attempts["count"] += 1
+            raise OSError(2, "No such file or directory")
+        return "test-uuid"
+
+    monkeypatch.setattr("app.watcher.registry.ensure_note_uuid", flaky_ensure)
+
+    mappings = {
+        "Make this note evergreen": PanelActionMapping(
+            text="Make this note evergreen",
+            event_type="promote.intent.created",
+            payload_template={"maturity": "evergreen"},
+            action_id="promote.evergreen",
+        )
+    }
+    state = WatcherState()
+
+    written = _process_panel_note(
+        vault_root=vault,
+        rel_path=note_path.relative_to(vault),
+        outbox_path=tmp_path / "outbox.jsonl",
+        state=state,
+        action_mappings=mappings,
+    )
+
+    assert written > 0
+    assert events
+
+
+def test_emit_panel_events_counts_only_real_emissions(tmp_path, monkeypatch):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    note_dir = vault / get_vault_inbox_dir_rel(vault)
+    note_dir.mkdir()
+    note_path = note_dir / "note.md"
+    note_path.write_text("stub", encoding="utf-8")
+
+    cfg = RegistryConfig(
+        enable=True,
+        outbox_path=tmp_path / "outbox.jsonl",
+        vault_path=vault,
+        scope_glob="*.md",
+        debounce_ms=0,
+        rate_limit_per_min=30,
+        state_dir=tmp_path / "state",
+        heartbeat_path=tmp_path / "heartbeat.json",
+        config_path=tmp_path / "watchers.yaml",
+        summary_interval=0,
+        stop_file=tmp_path / "WATCHER_STOP",
+        tick_sleep_seconds=0.2,
+        tick_log_path=tmp_path / "watcher_tick.jsonl",
+        max_scanned_files_per_tick=500,
+        max_bytes_read_per_tick=50_000_000,
+        max_elapsed_ms_per_tick=2000,
+        max_bad_ticks=10,
+        bad_tick_backoff_seconds=2.0,
+        specs=[],
+    )
+    spec = WatcherSpec(
+        name="panel",
+        scope_glob="*.md",
+        debounce_ms=0,
+        rate_limit_per_min=30,
+        emit_event="panel.scan.requested",
+    )
+    state = WatcherState()
+
+    monkeypatch.setattr("app.watcher.registry._process_panel_note", lambda **_: 0)
+
+    trace_id = _emit_panel_events(
+        spec=spec,
+        cfg=cfg,
+        rel=note_path.relative_to(vault),
+        mtime=note_path.stat().st_mtime,
+        digest="hash",
+        state=state,
+        action_mappings={},
+    )
+
+    assert trace_id is None
+    assert state.intents_emitted == 0
+    assert state.last_trace_id is None
+
+
+def test_emit_panel_events_updates_state_after_success(tmp_path, monkeypatch):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    note_dir = vault / get_vault_inbox_dir_rel(vault)
+    note_dir.mkdir()
+    note_path = note_dir / "note.md"
+    note_path.write_text("stub", encoding="utf-8")
+
+    cfg = RegistryConfig(
+        enable=True,
+        outbox_path=tmp_path / "outbox.jsonl",
+        vault_path=vault,
+        scope_glob="*.md",
+        debounce_ms=0,
+        rate_limit_per_min=30,
+        state_dir=tmp_path / "state",
+        heartbeat_path=tmp_path / "heartbeat.json",
+        config_path=tmp_path / "watchers.yaml",
+        summary_interval=0,
+        stop_file=tmp_path / "WATCHER_STOP",
+        tick_sleep_seconds=0.2,
+        tick_log_path=tmp_path / "watcher_tick.jsonl",
+        max_scanned_files_per_tick=500,
+        max_bytes_read_per_tick=50_000_000,
+        max_elapsed_ms_per_tick=2000,
+        max_bad_ticks=10,
+        bad_tick_backoff_seconds=2.0,
+        specs=[],
+    )
+    spec = WatcherSpec(
+        name="panel",
+        scope_glob="*.md",
+        debounce_ms=0,
+        rate_limit_per_min=30,
+        emit_event="panel.scan.requested",
+    )
+    state = WatcherState()
+
+    monkeypatch.setattr("app.watcher.registry._process_panel_note", lambda **_: 2)
+
+    trace_id = _emit_panel_events(
+        spec=spec,
+        cfg=cfg,
+        rel=note_path.relative_to(vault),
+        mtime=note_path.stat().st_mtime,
+        digest="hash",
+        state=state,
+        action_mappings={},
+    )
+
+    assert trace_id
+    assert state.intents_emitted == 1
+    assert state.last_trace_id == trace_id
+    file_state = state.files[str(note_path.relative_to(vault))]
+    assert file_state.get("last_emitted") is not None
+
+
+def test_run_spec_tick_does_not_count_panel_when_emit_returns_none(tmp_path, monkeypatch):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    note_dir = vault / get_vault_inbox_dir_rel(vault)
+    note_dir.mkdir()
+    note_path = note_dir / "note.md"
+    note_path.write_text("%% AI %%\n- [x] Make this note evergreen <!--ai:id=promote.evergreen-->\n%% AI %%\n", encoding="utf-8")
+
+    cfg = RegistryConfig(
+        enable=True,
+        outbox_path=tmp_path / "outbox.jsonl",
+        vault_path=vault,
+        scope_glob="📥 Inbox/*.md",
+        debounce_ms=0,
+        rate_limit_per_min=30,
+        state_dir=tmp_path / "state",
+        heartbeat_path=tmp_path / "heartbeat.json",
+        config_path=tmp_path / "watchers.yaml",
+        summary_interval=0,
+        stop_file=tmp_path / "WATCHER_STOP",
+        tick_sleep_seconds=0.2,
+        tick_log_path=tmp_path / "watcher_tick.jsonl",
+        max_scanned_files_per_tick=500,
+        max_bytes_read_per_tick=50_000_000,
+        max_elapsed_ms_per_tick=2000,
+        max_bad_ticks=10,
+        bad_tick_backoff_seconds=2.0,
+        specs=[],
+    )
+    spec = WatcherSpec(
+        name="panel",
+        scope_glob="📥 Inbox/*.md",
+        debounce_ms=0,
+        rate_limit_per_min=30,
+        emit_event="panel.scan.requested",
+    )
+    state = WatcherState()
+
+    monkeypatch.setattr("app.watcher.registry._emit_watch_event", lambda **_: None)
+    monkeypatch.setattr("app.watcher.registry._panel_candidate_for_path", lambda *_: (True, True))
+    monkeypatch.setattr("app.watcher.registry._auto_exec_enabled", lambda *_args, **_kwargs: True)
+
+    summary = _run_spec_tick(cfg, spec, state, now=note_path.stat().st_mtime + 1)
+
+    assert summary["emitted_in_tick"] == 0
+    assert state.intents_emitted == 0
+    assert state.last_trace_id is None
+
+
+def test_emit_panel_events_logs_no_event_outcome(tmp_path, monkeypatch, caplog):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    note_dir = vault / get_vault_inbox_dir_rel(vault)
+    note_dir.mkdir()
+    note_path = note_dir / "note.md"
+    note_path.write_text("stub", encoding="utf-8")
+
+    cfg = RegistryConfig(
+        enable=True,
+        outbox_path=tmp_path / "outbox.jsonl",
+        vault_path=vault,
+        scope_glob="*.md",
+        debounce_ms=0,
+        rate_limit_per_min=30,
+        state_dir=tmp_path / "state",
+        heartbeat_path=tmp_path / "heartbeat.json",
+        config_path=tmp_path / "watchers.yaml",
+        summary_interval=0,
+        stop_file=tmp_path / "WATCHER_STOP",
+        tick_sleep_seconds=0.2,
+        tick_log_path=tmp_path / "watcher_tick.jsonl",
+        max_scanned_files_per_tick=500,
+        max_bytes_read_per_tick=50_000_000,
+        max_elapsed_ms_per_tick=2000,
+        max_bad_ticks=10,
+        bad_tick_backoff_seconds=2.0,
+        specs=[],
+    )
+    spec = WatcherSpec(
+        name="panel",
+        scope_glob="*.md",
+        debounce_ms=0,
+        rate_limit_per_min=30,
+        emit_event="panel.scan.requested",
+    )
+    state = WatcherState()
+
+    monkeypatch.setattr("app.watcher.registry._process_panel_note", lambda **_: 0)
+
+    caplog.set_level(logging.INFO)
+    trace_id = _emit_panel_events(
+        spec=spec,
+        cfg=cfg,
+        rel=note_path.relative_to(vault),
+        mtime=note_path.stat().st_mtime,
+        digest="hash",
+        state=state,
+        action_mappings={},
+    )
+
+    assert trace_id is None
+    assert any("panel emit produced no events" in rec.getMessage() for rec in caplog.records)


### PR DESCRIPTION
## Summary
- move watcher auto-panel execution to a worker-driven  flow with file stabilization
- keep watcher focused on detection/outbox emission and harden worker/registry regressions
- refresh GPT-5.4 model defaults/docs and extend UAT/runtime test coverage

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/runtime/test_worker_ingest_event.py tests/runtime/test_worker_dispatch_ingest_vault_changed.py tests/e2e/test_watcher_registry_e2e.py tests/watcher/test_panel_watcher_outbox_db.py -m 'not pg'
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/watcher/test_panel_watcher_outbox_db.py tests/watcher/test_registry_outbox_enqueue_logging.py -m 'not pg'
- live runtime probe against PKM Alpha vault with watcher -> panel.scan.requested -> worker -> promote.done