### PR TITLE
fix: stabilize ollama endpoint resolution tests

### DIFF
--- a/app/cli/llm_doctor.py
+++ b/app/cli/llm_doctor.py
@@ -8,6 +8,8 @@ from typing import Dict, Optional
 
 import click
 
+from app.llm.endpoints import resolve_ollama_base_url
+
 LLM_CHECK_TIMEOUT = 5
 
 
@@ -31,7 +33,7 @@ def _resolve_endpoint() -> tuple[Optional[str], Optional[str]]:
     if provider == "mock":
         return None, "mock"
     if provider == "ollama":
-        base = os.getenv("OLLAMA_BASE_URL") or os.getenv("OLLAMA_URL") or os.getenv("OLLAMA_HOST")
+        base = resolve_ollama_base_url(strip_v1=False, include_openai_fallback=False)
         if base:
             return base.rstrip("/"), "ollama"
         fallback = os.getenv("OPENAI_BASE_URL")
@@ -43,7 +45,7 @@ def _resolve_endpoint() -> tuple[Optional[str], Optional[str]]:
         if base:
             return base.rstrip("/"), "openai_compat"
         return None, provider
-    base = os.getenv("OLLAMA_BASE_URL") or os.getenv("OLLAMA_URL") or os.getenv("OLLAMA_HOST")
+    base = resolve_ollama_base_url(strip_v1=False, include_openai_fallback=False)
     if base:
         return base.rstrip("/"), "ollama"
     fallback = os.getenv("OPENAI_BASE_URL")

--- a/app/llm/embeddings.py
+++ b/app/llm/embeddings.py
@@ -9,6 +9,7 @@ import httpx
 
 from app.config.llm import get_provider
 from app.embedding_config import assert_embed_dim, get_embed_dim, l2_normalize
+from app.llm.endpoints import require_ollama_base_url
 
 _TRUE_VALUES = {"1", "true", "yes", "on"}
 _MOCK_EMBED_MODEL = "mock-embedding"
@@ -37,24 +38,8 @@ def _extract_error_detail(response: httpx.Response) -> str | None:
         return text
     return None
 
-
-def _normalize_ollama_url(url: str) -> str:
-    clean = (url or "").rstrip("/")
-    if clean.endswith("/v1"):
-        clean = clean[:-3]
-    return clean
-
-
 def _ollama_base_url() -> str:
-    base_url = _normalize_ollama_url(
-        os.getenv("OLLAMA_BASE_URL", "")
-        or os.getenv("OLLAMA_URL", "")
-        or os.getenv("OLLAMA_HOST", "")
-        or os.getenv("OPENAI_BASE_URL", "")
-    )
-    if not base_url:
-        raise RuntimeError("OLLAMA_BASE_URL, OLLAMA_URL, OLLAMA_HOST, or OPENAI_BASE_URL is required for embeddings")
-    return base_url
+    return require_ollama_base_url(strip_v1=True, context="embeddings")
 
 
 def get_embed_model() -> str:

--- a/app/llm/endpoints.py
+++ b/app/llm/endpoints.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import os
+
+
+_OLLAMA_ENV_KEYS = ("OLLAMA_BASE_URL", "OLLAMA_URL", "OLLAMA_HOST")
+_OLLAMA_FALLBACK_ENV_KEYS = _OLLAMA_ENV_KEYS + ("OPENAI_BASE_URL",)
+
+
+def normalize_ollama_url(url: str) -> str:
+    clean = (url or "").rstrip("/")
+    if clean.endswith("/v1"):
+        clean = clean[:-3]
+    return clean
+
+
+def resolve_ollama_base_url(*, strip_v1: bool = False, include_openai_fallback: bool = True) -> str:
+    base_url = ""
+    keys = _OLLAMA_FALLBACK_ENV_KEYS if include_openai_fallback else _OLLAMA_ENV_KEYS
+    for key in keys:
+        value = os.getenv(key, "").strip()
+        if value:
+            base_url = value
+            break
+    if strip_v1:
+        return normalize_ollama_url(base_url)
+    return base_url.rstrip("/")
+
+
+def require_ollama_base_url(
+    *, strip_v1: bool = False, include_openai_fallback: bool = True, context: str = "ollama"
+) -> str:
+    base_url = resolve_ollama_base_url(strip_v1=strip_v1, include_openai_fallback=include_openai_fallback)
+    if base_url:
+        return base_url
+    keys = ", ".join(_OLLAMA_FALLBACK_ENV_KEYS if include_openai_fallback else _OLLAMA_ENV_KEYS)
+    raise RuntimeError(f"{keys} is required for {context}")
+
+
+__all__ = ["normalize_ollama_url", "resolve_ollama_base_url", "require_ollama_base_url"]

--- a/tests/cli/test_llm_doctor.py
+++ b/tests/cli/test_llm_doctor.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 from app.cli import llm_doctor
 
 
+def _clear_llm_endpoint_env(monkeypatch) -> None:
+    for key in ("OLLAMA_BASE_URL", "OLLAMA_URL", "OLLAMA_HOST", "OPENAI_BASE_URL"):
+        monkeypatch.delenv(key, raising=False)
+
+
 def test_llm_doctor_ollama_prefers_ollama_url(monkeypatch) -> None:
+    _clear_llm_endpoint_env(monkeypatch)
     monkeypatch.setenv("LLM_PROVIDER", "ollama")
     monkeypatch.setenv("OLLAMA_URL", "http://ollama:11434/")
     monkeypatch.setenv("OPENAI_BASE_URL", "http://openai.local/v1")
@@ -15,9 +21,8 @@ def test_llm_doctor_ollama_prefers_ollama_url(monkeypatch) -> None:
 
 
 def test_llm_doctor_ollama_accepts_ollama_host(monkeypatch) -> None:
+    _clear_llm_endpoint_env(monkeypatch)
     monkeypatch.setenv("LLM_PROVIDER", "ollama")
-    monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
-    monkeypatch.delenv("OLLAMA_URL", raising=False)
     monkeypatch.setenv("OLLAMA_HOST", "http://ollama-host:11434/")
 
     base, provider = llm_doctor._resolve_endpoint()
@@ -27,6 +32,7 @@ def test_llm_doctor_ollama_accepts_ollama_host(monkeypatch) -> None:
 
 
 def test_llm_doctor_ollama_prefers_ollama_base_url(monkeypatch) -> None:
+    _clear_llm_endpoint_env(monkeypatch)
     monkeypatch.setenv("LLM_PROVIDER", "ollama")
     monkeypatch.setenv("OLLAMA_BASE_URL", "http://ollama-base:11434/v1/")
     monkeypatch.setenv("OLLAMA_URL", "http://ollama:11434/")
@@ -38,8 +44,8 @@ def test_llm_doctor_ollama_prefers_ollama_base_url(monkeypatch) -> None:
 
 
 def test_llm_doctor_ollama_falls_back_to_openai(monkeypatch) -> None:
+    _clear_llm_endpoint_env(monkeypatch)
     monkeypatch.setenv("LLM_PROVIDER", "ollama")
-    monkeypatch.delenv("OLLAMA_URL", raising=False)
     monkeypatch.setenv("OPENAI_BASE_URL", "http://openai.local/v1/")
 
     base, provider = llm_doctor._resolve_endpoint()
@@ -49,6 +55,7 @@ def test_llm_doctor_ollama_falls_back_to_openai(monkeypatch) -> None:
 
 
 def test_llm_doctor_non_ollama_prefers_openai_base(monkeypatch) -> None:
+    _clear_llm_endpoint_env(monkeypatch)
     monkeypatch.setenv("LLM_PROVIDER", "openai")
     monkeypatch.setenv("OLLAMA_URL", "http://ollama:11434/")
     monkeypatch.setenv("OPENAI_BASE_URL", "http://openai.local/v1/")
@@ -60,6 +67,7 @@ def test_llm_doctor_non_ollama_prefers_openai_base(monkeypatch) -> None:
 
 
 def test_llm_doctor_mock_short_circuits(monkeypatch) -> None:
+    _clear_llm_endpoint_env(monkeypatch)
     monkeypatch.setenv("LLM_PROVIDER", "mock")
     monkeypatch.setenv("OLLAMA_URL", "http://ollama:11434/")
     monkeypatch.setenv("OPENAI_BASE_URL", "http://openai.local/v1/")
@@ -77,6 +85,7 @@ def test_llm_doctor_mock_short_circuits(monkeypatch) -> None:
 
 
 def test_llm_doctor_alias_llm_uses_ollama_resolution(monkeypatch) -> None:
+    _clear_llm_endpoint_env(monkeypatch)
     monkeypatch.setenv("LLM_PROVIDER", "llm")
     monkeypatch.setenv("OLLAMA_URL", "http://ollama:11434/")
 

--- a/tests/cli/test_llm_doctor_cli.py
+++ b/tests/cli/test_llm_doctor_cli.py
@@ -7,6 +7,8 @@ from app.cli import cli
 
 
 def test_llm_check_reports_unreachable(monkeypatch):
+    for key in ("OLLAMA_BASE_URL", "OLLAMA_URL", "OLLAMA_HOST", "OPENAI_BASE_URL"):
+        monkeypatch.delenv(key, raising=False)
     monkeypatch.setenv("LLM_PROVIDER", "ollama")
     monkeypatch.setenv("OLLAMA_URL", "http://127.0.0.1:9")
     runner = CliRunner()
@@ -19,6 +21,8 @@ def test_llm_check_reports_unreachable(monkeypatch):
 
 
 def test_llm_check_strict_fails(monkeypatch):
+    for key in ("OLLAMA_BASE_URL", "OLLAMA_URL", "OLLAMA_HOST", "OPENAI_BASE_URL"):
+        monkeypatch.delenv(key, raising=False)
     monkeypatch.setenv("LLM_PROVIDER", "ollama")
     monkeypatch.setenv("OLLAMA_URL", "http://127.0.0.1:9")
     runner = CliRunner()

--- a/tests/llm/test_ollama_embedding_request.py
+++ b/tests/llm/test_ollama_embedding_request.py
@@ -4,6 +4,8 @@ from app.llm.embeddings import embed_text
 
 
 def test_ollama_embedding_calls_native_endpoint(monkeypatch) -> None:
+    for key in ("OLLAMA_BASE_URL", "OLLAMA_URL", "OLLAMA_HOST", "OPENAI_BASE_URL"):
+        monkeypatch.delenv(key, raising=False)
     monkeypatch.setenv("LLM_PROVIDER", "ollama")
     monkeypatch.setenv("OLLAMA_HOST", "https://ollama.local:11434/")
     monkeypatch.setenv("EMBED_DIM", "3")

--- a/tests/llm/test_ollama_embeddings_fallback.py
+++ b/tests/llm/test_ollama_embeddings_fallback.py
@@ -10,6 +10,13 @@ def _make_payload_response(url: str, status_code: int, payload: dict) -> httpx.R
     return httpx.Response(status_code, json=payload, request=httpx.Request("POST", url))
 
 
+def _set_ollama_base(monkeypatch: pytest.MonkeyPatch, url: str = "http://ollama.test:11434") -> None:
+    for key in ("OLLAMA_BASE_URL", "OLLAMA_URL", "OLLAMA_HOST", "OPENAI_BASE_URL"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("OLLAMA_URL", url)
+    embeddings._embed_single.cache_clear()
+
+
 def test_ollama_embed_payload_includes_text_and_dimensions(monkeypatch) -> None:
     called: list[dict] = []
 
@@ -17,6 +24,7 @@ def test_ollama_embed_payload_includes_text_and_dimensions(monkeypatch) -> None:
         called.append({"url": url, "json": kwargs.get("json")})
         return _make_payload_response(url, 200, {"embeddings": [[0.1, -0.1, 0.2, 0.3]]})
 
+    _set_ollama_base(monkeypatch)
     monkeypatch.setattr(httpx, "post", fake_post)
     vector = embeddings.embed_text("payload-test", provider="ollama", model="test", dim=4, normalize=False)
     assert len(called) == 1
@@ -32,6 +40,7 @@ def test_ollama_embed_dimensions_flag(monkeypatch) -> None:
         called.append({"url": url, "json": kwargs.get("json")})
         return _make_payload_response(url, 200, {"embeddings": [[0.1, -0.1, 0.2, 0.3]]})
 
+    _set_ollama_base(monkeypatch)
     monkeypatch.setenv("OLLAMA_EMBED_DIMENSIONS", "0")
     monkeypatch.setattr(httpx, "post", fake_post)
     vector = embeddings.embed_text("payload-dim", provider="ollama", model="test", dim=4, normalize=False)
@@ -46,6 +55,7 @@ def test_ollama_embed_fallback_on_error(monkeypatch) -> None:
             raise httpx.HTTPStatusError("error", request=request, response=httpx.Response(500, request=request))
         return _make_payload_response(url, 200, {"data": [{"embedding": [0.2, 0.4, -0.1, 0.0]}]})
 
+    _set_ollama_base(monkeypatch)
     monkeypatch.setattr(httpx, "post", fake_post)
     vector = embeddings.embed_text("fallback-test", provider="ollama", model="test", dim=4, normalize=False)
     assert vector == [0.2, 0.4, -0.1, 0.0]
@@ -55,6 +65,7 @@ def test_ollama_embed_dim_mismatch_raises(monkeypatch) -> None:
     def fake_post(url: str, **kwargs) -> httpx.Response:
         return _make_payload_response(url, 200, {"embeddings": [[0.1, 0.2]]})
 
+    _set_ollama_base(monkeypatch)
     monkeypatch.setattr(httpx, "post", fake_post)
     with pytest.raises(ValueError) as excinfo:
         embeddings.embed_text("dim-mismatch", provider="ollama", model="test", dim=4, normalize=False)
@@ -67,6 +78,7 @@ def test_ollama_embed_reports_http_errors(monkeypatch) -> None:
         response = httpx.Response(404, request=request)
         raise httpx.HTTPStatusError("not found", request=request, response=response)
 
+    _set_ollama_base(monkeypatch)
     monkeypatch.setattr(httpx, "post", fake_post)
     with pytest.raises(RuntimeError) as excinfo:
         embeddings.embed_text("missing", provider="ollama", model="test", dim=4, normalize=False)

--- a/tests/llm/test_ollama_embeddings_http_server.py
+++ b/tests/llm/test_ollama_embeddings_http_server.py
@@ -54,6 +54,8 @@ def test_ollama_embeddings_hits_native_path(monkeypatch) -> None:
     }
     server, thread = _start_server(responses)
     try:
+        for key in ("OLLAMA_BASE_URL", "OLLAMA_URL", "OLLAMA_HOST", "OPENAI_BASE_URL"):
+            monkeypatch.delenv(key, raising=False)
         base_url = f"http://127.0.0.1:{server.server_address[1]}/v1"
         monkeypatch.setenv("OLLAMA_URL", base_url)
         embeddings._embed_single.cache_clear()
@@ -76,6 +78,8 @@ def test_ollama_embeddings_404_reports_actionable_error(monkeypatch) -> None:
     }
     server, thread = _start_server(responses)
     try:
+        for key in ("OLLAMA_BASE_URL", "OLLAMA_URL", "OLLAMA_HOST", "OPENAI_BASE_URL"):
+            monkeypatch.delenv(key, raising=False)
         base_url = f"http://127.0.0.1:{server.server_address[1]}/v1"
         monkeypatch.setenv("OLLAMA_URL", base_url)
         embeddings._embed_single.cache_clear()


### PR DESCRIPTION
## Summary
- add a shared Ollama endpoint resolver used by embeddings and llm doctor
- keep llm doctor's native-vs-openai-compat distinction while normalizing endpoint lookup
- make the Ollama endpoint tests hermetic by clearing competing env vars before setting the case under test

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/llm/test_ollama_embeddings_fallback.py tests/cli/test_llm_doctor.py tests/cli/test_llm_doctor_cli.py tests/llm/test_ollama_embedding_request.py tests/llm/test_ollama_embeddings_http_server.py -m "not pg"`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/runtime/test_startup_env.py tests/cli/test_health_ollama_env.py -m "not pg"`
- `LLM_PROVIDER=mock PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 STORE_BACKEND=memory LLM_MOCK_RESPONSE='{"type":"note","trust":"own","tags":["topic/test"],"confidence":0.95}' python -m pytest -q -m "not pg" -c /dev/null`

## Result
- smoke gate now passes locally: `924 passed, 21 skipped, 9 deselected`