### PR TITLE
feat(state): introduce maturity as primary standing axis

### DIFF
--- a/app/agents/planner/agent.py
+++ b/app/agents/planner/agent.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from typing import Optional
 
-from app.domain.state_axes import review_state_for_maturity
+from app.domain.state_axes import normalize_plan_state_action
 from app.domain.plan import Plan, PlanStep
 from app.store.object_store import ObjectStore
 
@@ -38,11 +38,9 @@ class PlannerAgent:
 
     def build_seed_primitive_step(self, goal: str, target: Optional[str], *, step_id: str = "primitive-1") -> PlanStep:
         wants_evergreen = self._goal_wants_evergreen(goal)
-        primitive_action = "promote_to_evergreen" if wants_evergreen else "update_review_state"
-        primitive_args = (
-            {"review_state": review_state_for_maturity("evergreen"), "maturity": "evergreen"}
-            if wants_evergreen
-            else {"review_state": "processed"}
+        primitive_action, primitive_args = normalize_plan_state_action(
+            "request_promotion_transition" if wants_evergreen else "set_review_state",
+            {"maturity": "evergreen"} if wants_evergreen else {"review_state": "processed"},
         )
         return PlanStep(
             id=step_id,

--- a/app/agents/planner/graph.py
+++ b/app/agents/planner/graph.py
@@ -7,7 +7,7 @@ from langgraph.graph import StateGraph, START, END
 
 from app.agents.base.graph import AgentState
 from app.agents.planner.agent import PlannerAgent
-from app.domain.state_axes import review_state_for_maturity
+from app.domain.state_axes import normalize_plan_state_action
 from app.domain.plan import Plan, PlanStep
 from app.store.object_store import ObjectStore
 import app.guardrails as guardrails
@@ -220,24 +220,29 @@ class PlannerGraph:
         if not obj:
             return {"ok": False, "reason": "missing_object", "target": target}
 
-        if action_name in ("update_review_state", "promote_to_evergreen", "set_review_state", "set_maturity"):
-            new_state = args.get("review_state") or "processed"
-            new_maturity = args.get("maturity")
-            if action_name == "promote_to_evergreen":
-                new_maturity = new_maturity or "evergreen"
-                new_state = args.get("review_state") or review_state_for_maturity(str(new_maturity))
+        normalized_action, normalized_args = normalize_plan_state_action(action_name, args)
+
+        if normalized_action in ("set_review_state", "set_maturity", "request_promotion_transition"):
             payload = obj.payload or {}
             frontmatter = payload.get("frontmatter") or {}
-            frontmatter["review_state"] = new_state
-            if new_maturity:
-                frontmatter["maturity"] = str(new_maturity)
+
+            if normalized_action in ("set_review_state", "request_promotion_transition"):
+                frontmatter["review_state"] = normalized_args.get("review_state") or "processed"
+
+            if normalized_action in ("set_maturity", "request_promotion_transition"):
+                new_maturity = normalized_args.get("maturity")
+                if new_maturity:
+                    frontmatter["maturity"] = str(new_maturity)
+
             payload["frontmatter"] = frontmatter
             obj.payload = payload
-            # Save updated object
             self.store.save_object(obj, emit_outbox=False)
-            result = {"ok": True, "action": action_name, "review_state": new_state, "target": target}
-            if new_maturity:
-                result["maturity"] = str(new_maturity)
+
+            result = {"ok": True, "action": normalized_action, "target": target}
+            if "review_state" in frontmatter:
+                result["review_state"] = frontmatter["review_state"]
+            if "maturity" in frontmatter:
+                result["maturity"] = frontmatter["maturity"]
             return result
 
         return {"ok": False, "reason": "unknown_action", "action": action_name, "target": target}

--- a/app/domain/state_axes.py
+++ b/app/domain/state_axes.py
@@ -1,35 +1,38 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any, Mapping
 
 
-def normalize_promotion_target(payload: Mapping[str, Any]) -> str:
-    transition = payload.get("transition")
-    if isinstance(transition, Mapping):
-        target = transition.get("target_maturity")
-        if target:
-            return str(target).strip()
-    maturity = payload.get("maturity")
-    if maturity:
-        return str(maturity).strip()
-    action = payload.get("action")
-    if isinstance(action, Mapping):
-        action_id = action.get("id")
-        if action_id:
-            return str(action_id).strip()
+@dataclass(frozen=True)
+class PromotionAxes:
+    maturity: str | None
+    review_state: str
+
+
+def normalize_review_state(value: Any) -> str:
+    cleaned = str(value or "").strip().lower()
+    if not cleaned:
+        return ""
+    if cleaned == "evergreen":
+        return "reviewed"
+    return cleaned
+
+
+def normalize_maturity(value: Any) -> str:
+    cleaned = str(value or "").strip().lower()
+    return cleaned
+
+
+def legacy_maturity_from_review_state(review_state: Any) -> str:
+    cleaned = str(review_state or "").strip().lower()
+    if cleaned == "evergreen":
+        return "evergreen"
     return ""
 
 
-def build_promotion_transition(*, target_maturity: str) -> dict[str, str]:
-    cleaned = str(target_maturity).strip()
-    return {
-        "family": "promotion",
-        "target_maturity": cleaned,
-    }
-
-
-def review_state_for_maturity(maturity: str) -> str:
-    cleaned = str(maturity).strip().lower()
+def review_state_for_maturity(maturity: Any) -> str:
+    cleaned = normalize_maturity(maturity)
     if cleaned == "evergreen":
         return "reviewed"
     if cleaned:
@@ -37,4 +40,92 @@ def review_state_for_maturity(maturity: str) -> str:
     return "processed"
 
 
-__all__ = ["normalize_promotion_target", "build_promotion_transition", "review_state_for_maturity"]
+def resolve_promotion_axes(*, maturity: Any = None, review_state: Any = None) -> PromotionAxes:
+    normalized_maturity = normalize_maturity(maturity)
+    if not normalized_maturity:
+        normalized_maturity = legacy_maturity_from_review_state(review_state)
+
+    normalized_review_state = normalize_review_state(review_state)
+    if normalized_maturity and not normalized_review_state:
+        normalized_review_state = review_state_for_maturity(normalized_maturity)
+    if not normalized_review_state:
+        normalized_review_state = "processed"
+
+    return PromotionAxes(maturity=normalized_maturity or None, review_state=normalized_review_state)
+
+
+def normalize_promotion_target(payload: Mapping[str, Any]) -> str:
+    transition = payload.get("transition")
+    if isinstance(transition, Mapping):
+        target = transition.get("target_maturity")
+        if target:
+            return normalize_maturity(target)
+
+    maturity = payload.get("maturity")
+    if maturity:
+        return normalize_maturity(maturity)
+
+    review_state = payload.get("review_state")
+    if review_state:
+        legacy = legacy_maturity_from_review_state(review_state)
+        if legacy:
+            return legacy
+
+    action = payload.get("action")
+    if isinstance(action, Mapping):
+        action_id = str(action.get("id") or "").strip().lower()
+        if action_id.startswith("promote."):
+            return normalize_maturity(action_id.split(".", 1)[1])
+
+    return ""
+
+
+def build_promotion_transition(*, target_maturity: str) -> dict[str, str]:
+    cleaned = normalize_maturity(target_maturity)
+    return {
+        "family": "promotion",
+        "target_maturity": cleaned,
+    }
+
+
+def normalize_plan_state_action(action_name: str | None, args: Mapping[str, Any] | None) -> tuple[str, dict[str, Any]]:
+    normalized_action = str(action_name or "noop").strip()
+    normalized_args = dict(args or {})
+
+    if normalized_action == "update_review_state":
+        normalized_action = "set_review_state"
+    elif normalized_action == "promote_to_evergreen":
+        normalized_action = "request_promotion_transition"
+        normalized_args.setdefault("maturity", "evergreen")
+
+    if normalized_action == "request_promotion_transition":
+        axes = resolve_promotion_axes(
+            maturity=normalized_args.get("maturity"),
+            review_state=normalized_args.get("review_state"),
+        )
+        normalized_args["review_state"] = axes.review_state
+        if axes.maturity:
+            normalized_args["maturity"] = axes.maturity
+    elif normalized_action == "set_review_state":
+        normalized_args["review_state"] = normalize_review_state(normalized_args.get("review_state")) or "processed"
+    elif normalized_action == "set_maturity":
+        normalized_maturity = normalize_maturity(normalized_args.get("maturity"))
+        if normalized_maturity:
+            normalized_args["maturity"] = normalized_maturity
+        else:
+            normalized_args.pop("maturity", None)
+
+    return normalized_action, normalized_args
+
+
+__all__ = [
+    "PromotionAxes",
+    "build_promotion_transition",
+    "legacy_maturity_from_review_state",
+    "normalize_maturity",
+    "normalize_plan_state_action",
+    "normalize_promotion_target",
+    "normalize_review_state",
+    "resolve_promotion_axes",
+    "review_state_for_maturity",
+]

--- a/app/orchestrator/executor.py
+++ b/app/orchestrator/executor.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Iterable, Mapping, MutableMapping, Protocol
 from app.a2a.events import emit_agent_error_event, send_agent_request
 from app.a2a.schema import new_error
 from app.agents.base.loop import Agent
-from app.domain.state_axes import build_promotion_transition
+from app.domain.state_axes import build_promotion_transition, normalize_maturity, resolve_promotion_axes
 from app.mcp.vault_tools import VaultToolError, append_note
 from app.orchestrator.agents import AgentPermissionError, resolve_agent_config, validate_agent_permissions
 from app.planner.schema import PlanMetadata, PlanStep, ToolDescriptor
@@ -312,9 +312,9 @@ def _run_promotion_intent(args: Mapping[str, Any], context: StepContext) -> Dict
     instruction = args.get("instruction")
     if instruction:
         payload["instruction"] = str(instruction)
-    maturity = args.get("maturity")
-    if maturity:
-        target_maturity = str(maturity)
+    axes = resolve_promotion_axes(maturity=args.get("target_maturity") or args.get("maturity"), review_state=args.get("review_state"))
+    target_maturity = normalize_maturity(axes.maturity)
+    if target_maturity:
         payload["maturity"] = target_maturity
         payload["transition"] = build_promotion_transition(target_maturity=target_maturity)
 

--- a/app/promotion/consumer.py
+++ b/app/promotion/consumer.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable, Mapping
 
-from app.domain.state_axes import normalize_promotion_target, review_state_for_maturity
+from app.domain.state_axes import normalize_promotion_target, resolve_promotion_axes
 from app.events.schema import OutboxEvent, make_outbox_event
 from app.events.types import PROMOTE_DONE, PROMOTE_ERROR, PROMOTE_INTENT_CREATED
 from app.events.models import new_event
@@ -63,17 +63,23 @@ def _save_cursor(cursor_path: Path | None, outbox_path: Path, line_index: int) -
 _PROMOTION_DEDUP = EventDedupStore()
 
 
-def _apply_promotion_to_store(note_uuid: str, desired_state: str, trace_id: str | None, note_path: Path | None) -> None:
+def _apply_promotion_to_store(
+    note_uuid: str,
+    maturity: str | None,
+    review_state: str,
+    trace_id: str | None,
+    note_path: Path | None,
+) -> None:
     store = ObjectStore()
     existing = store.get_object(note_uuid)
     payload = dict(existing.payload or {}) if existing else {}
-    review_state = review_state_for_maturity(desired_state)
     promotion_meta = {
-        "state": desired_state,
+        "state": maturity or review_state,
         "applied_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
     }
     payload["promotion"] = promotion_meta
-    payload["maturity"] = desired_state
+    if maturity:
+        payload["maturity"] = maturity
     payload["review_state"] = review_state
     if existing is None:
         obj = DomainObject(
@@ -122,9 +128,13 @@ def _handle_promotion_payload(
         title = None
     if not note_path_value:
         note_path_value = payload.get("note_path") if isinstance(payload, dict) else None
-    desired_state = "promoted"
+    target_maturity = ""
     if isinstance(payload, dict):
-        desired_state = normalize_promotion_target(payload) or desired_state
+        target_maturity = normalize_promotion_target(payload)
+    axes = resolve_promotion_axes(
+        maturity=target_maturity or None,
+        review_state=payload.get("review_state") if isinstance(payload, dict) else None,
+    )
 
     if not note_uuid:
         summary["errors"] += 1
@@ -147,13 +157,12 @@ def _handle_promotion_payload(
         return summary
 
     note_path = Path(str(note_path_value))
-    review_state = review_state_for_maturity(desired_state)
     if not apply_promotion_frontmatter(
         note_path,
         note_uuid,
-        review_state,
+        axes.review_state,
         optional_title=title,
-        maturity=desired_state,
+        maturity=axes.maturity,
     ):
         summary["errors"] += 1
         emit(
@@ -169,16 +178,22 @@ def _handle_promotion_payload(
         summary["emitted"] += 1
         return summary
 
-    _apply_promotion_to_store(note_uuid, desired_state, trace_id, note_path)
+    _apply_promotion_to_store(
+        note_uuid,
+        axes.maturity,
+        axes.review_state,
+        trace_id,
+        note_path,
+    )
     summary["applied"] += 1
     emit(
         PROMOTE_DONE,
         {
             "note_uuid": note_uuid,
             "note_path": str(note_path),
-            "state": desired_state,
-            "maturity": desired_state,
-            "review_state": review_state,
+            "state": axes.maturity or axes.review_state,
+            "maturity": axes.maturity,
+            "review_state": axes.review_state,
             "source_event": event_id,
         },
         trace_id,

--- a/app/services/note_update.py
+++ b/app/services/note_update.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 
 from app.agents.panel.integration import handle_panel_update
 from app.components.concurrency import OptimisticWriteGuard
+from app.domain.state_axes import resolve_promotion_axes
 from app.knowledge.write_ops import default_vault_root_for_path, write_note_from_absolute
 from app.orchestrator.handler import OrchestratorContext
 from app.services.note_uuid import ensure_note_uuid
@@ -41,9 +42,9 @@ def apply_promotion_frontmatter(
     *,
     maturity: str | None = None,
 ) -> bool:
-    # `new_review_state` remains the primary compatibility input for current callers.
-    # During the state-axis migration, callers may also pass `maturity` explicitly so
-    # promotion standing can be persisted without overloading review posture.
+    # Current callers still pass `new_review_state`, including legacy `evergreen`.
+    # During the first state-axis separation wave we normalize that input here so
+    # standing is written to `maturity` while `review_state` keeps review posture.
     try:
         markdown = note_path.read_text(encoding="utf-8")
     except Exception:
@@ -72,11 +73,10 @@ def apply_promotion_frontmatter(
     if optional_title and not fm.get("title"):
         fm["title"] = optional_title
 
-    target_maturity = str(maturity or new_review_state).strip()
-    if target_maturity:
-        fm["maturity"] = target_maturity
-
-    fm["review_state"] = new_review_state
+    axes = resolve_promotion_axes(maturity=maturity, review_state=new_review_state)
+    if axes.maturity:
+        fm["maturity"] = axes.maturity
+    fm["review_state"] = axes.review_state
 
     updated = dump_frontmatter(fm, body)
     if updated != markdown:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -193,6 +193,10 @@ Tests: `tests/architecture/test_architecture_tests_validation.py::test_import_bo
 ## Core Contract, State Axes, and Overlays
 - Core contract: Core-6 is the minimal semantic projection (uuid, title, origin, source_ref, trust, review_state). Fields may be explicit or derived; see `docs/CORE_CONTRACT.md`.
 - State axes: orthogonal and policy-driven via vault settings; policies define which axes are enabled, locked, or forced.
+- Current promotion compatibility rule: promotion paths now write `maturity` as the primary standing
+  sink when a standing transition is known (for example `evergreen`), while `review_state` remains
+  the review/mutation posture field. Legacy notes that still express standing through
+  `review_state: evergreen` remain accepted as compatibility input during the migration period.
 - Derived / overlay metadata: system-owned overlays such as `zone`, recency, or salience are computed from signals and remain outside the core contract.
 - Agent reasoning operates on Core-6 + state axes + policy profiles (see `docs/NOTE_KIND_POLICIES.md`) + derived overlays.
 

--- a/tests/agents/planner/test_planner_real_flow.py
+++ b/tests/agents/planner/test_planner_real_flow.py
@@ -39,7 +39,12 @@ def test_planner_runs_real_mutation_on_note() -> None:
     assert plan.goal == goal
     assert plan.executed_steps > 0
     assert plan.status in ("done", "in_progress")
-    assert any(step.kind == "primitive" and step.target == note_uuid for step in plan.steps)
+    assert any(
+        step.kind == "primitive"
+        and step.target == note_uuid
+        and step.action == "request_promotion_transition"
+        for step in plan.steps
+    )
 
     updated = store.get_object(note_uuid)
     assert updated is not None
@@ -56,6 +61,12 @@ def test_planner_subplan_seed_preserves_non_evergreen_goal() -> None:
     plan = run_planner_for_goal(goal=goal, store=store, max_steps=5, max_replans=1)
 
     assert isinstance(plan, Plan)
+    assert any(
+        step.kind == "primitive"
+        and step.target == note_uuid
+        and step.action == "set_review_state"
+        for step in plan.steps
+    )
     updated = store.get_object(note_uuid)
     assert updated is not None
     fm = (updated.payload or {}).get("frontmatter", {})

--- a/tests/planner/test_state_axes.py
+++ b/tests/planner/test_state_axes.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from app.domain.state_axes import (
+    normalize_plan_state_action,
+    normalize_promotion_target,
+    resolve_promotion_axes,
+)
+
+
+def test_normalize_promotion_target_accepts_action_id_fallback() -> None:
+    payload = {"action": {"id": "promote.evergreen"}}
+
+    assert normalize_promotion_target(payload) == "evergreen"
+
+
+def test_normalize_plan_state_action_preserves_legacy_promote_name_as_internal_transition() -> None:
+    action, args = normalize_plan_state_action("promote_to_evergreen", {})
+
+    assert action == "request_promotion_transition"
+    assert args["maturity"] == "evergreen"
+    assert args["review_state"] == "reviewed"
+
+
+def test_resolve_promotion_axes_prefers_explicit_maturity_sink() -> None:
+    axes = resolve_promotion_axes(maturity="evergreen", review_state="evergreen")
+
+    assert axes.maturity == "evergreen"
+    assert axes.review_state == "reviewed"

--- a/tests/services/test_note_update_promotion.py
+++ b/tests/services/test_note_update_promotion.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from app.domain.state_axes import resolve_promotion_axes
 from app.services.note_update import apply_promotion_frontmatter
 from scripts.yaml_roundtrip import load_frontmatter
 
@@ -13,7 +14,7 @@ def test_promotion_frontmatter_created_when_missing(tmp_path: Path) -> None:
 
     frontmatter, body = load_frontmatter(note_path.read_text(encoding="utf-8"))
     assert frontmatter["uuid"] == "UUID-1"
-    assert frontmatter["review_state"] == "evergreen"
+    assert frontmatter["review_state"] == "reviewed"
     assert frontmatter["maturity"] == "evergreen"
     assert "Body content" in body
 
@@ -36,7 +37,7 @@ Keep body.
 
     frontmatter, _ = load_frontmatter(note_path.read_text(encoding="utf-8"))
     assert frontmatter["uuid"] == "UUID-2"
-    assert frontmatter["review_state"] == "evergreen"
+    assert frontmatter["review_state"] == "reviewed"
     assert frontmatter["maturity"] == "evergreen"
     assert frontmatter["title"] == "Sample"
 
@@ -52,3 +53,10 @@ def test_promotion_frontmatter_supports_normalized_review_and_maturity_axes(tmp_
     assert frontmatter["uuid"] == "UUID-3"
     assert frontmatter["review_state"] == "reviewed"
     assert frontmatter["maturity"] == "evergreen"
+
+
+def test_resolve_promotion_axes_accepts_legacy_review_state_evergreen() -> None:
+    axes = resolve_promotion_axes(review_state="evergreen")
+
+    assert axes.review_state == "reviewed"
+    assert axes.maturity == "evergreen"


### PR DESCRIPTION
## Summary
- centralize review-state and maturity normalization in `app/domain/state_axes.py`
- write promotion standing to `maturity` while keeping `review_state` as the compatibility posture sink
- normalize planner/orchestrator promotion actions through the shared state-axis boundary and update tests

## Testing
- `./.venv/bin/python -m pytest -q tests/services/test_note_update_promotion.py tests/services/test_write_guard.py tests/promotion/test_consumer_idempotency.py tests/agents/planner/test_planner_real_flow.py tests/planner/test_state_axes.py`
- `./.venv/bin/python -m pytest -q tests/e2e/test_panel_to_promotion_consume.py tests/agents/panel_agent/test_panel_runtime.py`
- `./.venv/bin/python -m compileall app/domain/state_axes.py app/services/note_update.py app/promotion/consumer.py app/orchestrator/executor.py app/agents/planner/graph.py app/agents/planner/agent.py`