### PR TITLE
Add watcher registry contract tests

### DIFF
--- a/tests/quality_wave/test_metamorphic_watcher.py
+++ b/tests/quality_wave/test_metamorphic_watcher.py
@@ -86,6 +86,18 @@ def _summary_key_fields(summary: dict[str, object]) -> dict[str, object]:
     }
 
 
+def _run_tick(
+    monkeypatch: pytest.MonkeyPatch,
+    cfg: registry.RegistryConfig,
+    spec: registry.WatcherSpec,
+    state: WatcherState,
+    *,
+    now: float,
+) -> dict[str, object]:
+    monkeypatch.setattr(registry.time, "time", lambda: now)
+    return registry._run_spec_tick(cfg, spec, state, now=now)
+
+
 @pytest.mark.parametrize("note_count", [1, 3])
 def test_narrower_scope_fewer_or_equal_changes(
     tmp_path: Path,
@@ -106,8 +118,8 @@ def test_narrower_scope_fewer_or_equal_changes(
         _write_note(narrow_cfg.vault_path / rel, source.read_text(encoding="utf-8"), mtime=source.stat().st_mtime)
         _write_note(wide_cfg.vault_path / rel, source.read_text(encoding="utf-8"), mtime=source.stat().st_mtime)
 
-    narrow_summary = registry._run_spec_tick(narrow_cfg, narrow_spec, WatcherState(), now=1_700_000_500.0)
-    wide_summary = registry._run_spec_tick(wide_cfg, wide_spec, WatcherState(), now=1_700_000_500.0)
+    narrow_summary = _run_tick(monkeypatch, narrow_cfg, narrow_spec, WatcherState(), now=1_700_000_500.0)
+    wide_summary = _run_tick(monkeypatch, wide_cfg, wide_spec, WatcherState(), now=1_700_000_500.0)
 
     assert narrow_summary["changed_in_tick"] <= wide_summary["changed_in_tick"]
     assert narrow_summary["scanned_files"] <= wide_summary["scanned_files"]
@@ -125,9 +137,9 @@ def test_more_ticks_unchanged_vault_same_total(
         _write_note(cfg.vault_path / "Inbox" / f"note-{idx}.md", f"payload {idx}", mtime=1_700_000_000 + idx)
 
     state = WatcherState()
-    first = registry._run_spec_tick(cfg, spec, state, now=1_700_000_100.0)
-    second = registry._run_spec_tick(cfg, spec, state, now=1_700_000_101.0)
-    third = registry._run_spec_tick(cfg, spec, state, now=1_700_000_102.0)
+    first = _run_tick(monkeypatch, cfg, spec, state, now=1_700_000_100.0)
+    second = _run_tick(monkeypatch, cfg, spec, state, now=1_700_000_101.0)
+    third = _run_tick(monkeypatch, cfg, spec, state, now=1_700_000_102.0)
 
     assert first["changed_in_tick"] == note_count
     assert second["changed_in_tick"] == 0
@@ -146,7 +158,7 @@ def test_rate_limit_zero_no_emissions(
     for idx in range(note_count):
         _write_note(cfg.vault_path / "Inbox" / f"note-{idx}.md", f"payload {idx}", mtime=1_700_000_000 + idx)
 
-    summary = registry._run_spec_tick(cfg, spec, WatcherState(), now=1_700_000_200.0)
+    summary = _run_tick(monkeypatch, cfg, spec, WatcherState(), now=1_700_000_200.0)
 
     assert summary["changed_in_tick"] == note_count
     assert summary["emitted_in_tick"] == 0
@@ -165,8 +177,8 @@ def test_idempotent_same_params_same_summary(
     _write_note(cfg.vault_path / "Inbox" / "same.md", "stable", mtime=1_700_000_000)
     _write_note(cfg.vault_path / "Archive" / "other.md", "archive", mtime=1_700_000_100)
 
-    summary_one = registry._run_spec_tick(cfg, spec, WatcherState(), now=1_700_000_300.0)
-    summary_two = registry._run_spec_tick(cfg, spec, WatcherState(), now=1_700_000_300.0)
+    summary_one = _run_tick(monkeypatch, cfg, spec, WatcherState(), now=1_700_000_300.0)
+    summary_two = _run_tick(monkeypatch, cfg, spec, WatcherState(), now=1_700_000_300.0)
 
     assert _summary_key_fields(summary_one) == _summary_key_fields(summary_two)
 
@@ -184,12 +196,12 @@ def test_more_notes_more_or_equal_scanned(
         _write_note(cfg.vault_path / "Inbox" / f"note-{idx}.md", f"payload {idx}", mtime=1_700_000_000 + idx)
 
     state = WatcherState()
-    first = registry._run_spec_tick(cfg, spec, state, now=1_700_000_400.0)
+    first = _run_tick(monkeypatch, cfg, spec, state, now=1_700_000_400.0)
 
     for idx in range(initial_count, initial_count + added_count):
         _write_note(cfg.vault_path / "Inbox" / f"note-{idx}.md", f"payload {idx}", mtime=1_700_000_100 + idx)
 
-    second = registry._run_spec_tick(cfg, spec, state, now=1_700_000_401.0)
+    second = _run_tick(monkeypatch, cfg, spec, state, now=1_700_000_401.0)
 
     assert first["scanned_files"] == initial_count
     assert second["scanned_files"] >= first["scanned_files"]
@@ -207,7 +219,7 @@ def test_max_scanned_files_caps_processing(
     for idx in range(10):
         _write_note(cfg.vault_path / "Inbox" / f"note-{idx}.md", f"payload {idx}", mtime=1_700_000_000 + idx)
 
-    summary = registry._run_spec_tick(cfg, spec, WatcherState(), now=1_700_000_500.0)
+    summary = _run_tick(monkeypatch, cfg, spec, WatcherState(), now=1_700_000_500.0)
 
     assert summary["scanned_files"] == 10
     assert summary["bad_tick"] is True
@@ -218,7 +230,7 @@ def test_empty_vault_zero_changes(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
     _install_fake_emit(monkeypatch)
     cfg, spec = _make_cfg(tmp_path)
 
-    summary = registry._run_spec_tick(cfg, spec, WatcherState(), now=1_700_000_600.0)
+    summary = _run_tick(monkeypatch, cfg, spec, WatcherState(), now=1_700_000_600.0)
 
     assert summary["changed_in_tick"] == 0
     assert summary["scanned_files"] == 0
@@ -236,7 +248,7 @@ def test_debounce_zero_processes_immediately(
     for idx in range(note_count):
         _write_note(cfg.vault_path / "Inbox" / f"note-{idx}.md", f"payload {idx}", mtime=1_700_000_000 + idx)
 
-    summary = registry._run_spec_tick(cfg, spec, WatcherState(), now=1_700_000_700.0)
+    summary = _run_tick(monkeypatch, cfg, spec, WatcherState(), now=1_700_000_700.0)
 
     assert summary["changed_in_tick"] == note_count
     assert summary["emitted_in_tick"] == note_count
@@ -254,7 +266,7 @@ def test_scope_excludes_dotfolders(
     _write_note(cfg.vault_path / ".obsidian" / "settings.md", "hidden", mtime=1_700_000_000)
     _write_note(cfg.vault_path / "Inbox" / "visible.md", "visible", mtime=1_700_000_001)
 
-    summary = registry._run_spec_tick(cfg, spec, WatcherState(), now=1_700_000_800.0)
+    summary = _run_tick(monkeypatch, cfg, spec, WatcherState(), now=1_700_000_800.0)
 
     assert summary["scanned_files"] == 1
     assert summary["changed_in_tick"] == 1

--- a/tests/quality_wave/test_watcher_registry_contracts.py
+++ b/tests/quality_wave/test_watcher_registry_contracts.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from app.watcher import registry
+from app.watcher.state import WatcherState
+
+pytestmark = pytest.mark.not_pg
+
+
+def _make_cfg(
+    tmp_path: Path,
+    *,
+    scope_glob: str = "**/*.md",
+    rate_limit: int = 60,
+    max_scanned: int = 100,
+    debounce_ms: int = 0,
+    backoff_seconds: int = 10,
+) -> tuple[registry.RegistryConfig, registry.WatcherSpec]:
+    vault = tmp_path / "vault"
+    vault.mkdir(parents=True, exist_ok=True)
+    spec = registry.WatcherSpec(
+        name="contract",
+        scope_glob=scope_glob,
+        debounce_ms=debounce_ms,
+        rate_limit_per_min=rate_limit,
+        emit_event="ingest.vault.changed",
+        backoff_seconds=backoff_seconds,
+    )
+    cfg = registry.RegistryConfig(
+        enable=True,
+        outbox_path=tmp_path / "outbox.jsonl",
+        vault_path=vault,
+        scope_glob=scope_glob,
+        debounce_ms=debounce_ms,
+        rate_limit_per_min=rate_limit,
+        state_dir=tmp_path / "state",
+        heartbeat_path=tmp_path / "heartbeat.json",
+        config_path=tmp_path / "watchers.yaml",
+        summary_interval=0,
+        stop_file=tmp_path / "WATCHER_STOP",
+        tick_sleep_seconds=0.0,
+        tick_log_path=tmp_path / "tick.jsonl",
+        max_scanned_files_per_tick=max_scanned,
+        max_bytes_read_per_tick=1_000_000,
+        max_elapsed_ms_per_tick=10_000,
+        max_bad_ticks=5,
+        bad_tick_backoff_seconds=1.0,
+        specs=[spec],
+    )
+    cfg.stop_file.parent.mkdir(parents=True, exist_ok=True)
+    return cfg, spec
+
+
+def _write_note(path: Path, content: str, *, mtime: float) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    os.utime(path, (mtime, mtime))
+
+
+def _install_fake_emit(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, object]]:
+    calls: list[dict[str, object]] = []
+
+    def fake_emit_watch_event(**kwargs) -> str:
+        calls.append(kwargs)
+        return uuid4().hex
+
+    monkeypatch.setattr(registry, "_emit_watch_event", fake_emit_watch_event)
+    return calls
+
+
+def _run_tick(
+    monkeypatch: pytest.MonkeyPatch,
+    cfg: registry.RegistryConfig,
+    spec: registry.WatcherSpec,
+    state: WatcherState,
+    *,
+    now: float,
+) -> dict[str, object]:
+    monkeypatch.setattr(registry.time, "time", lambda: now)
+    return registry._run_spec_tick(cfg, spec, state, now=now)
+
+
+def test_tick_summary_tracks_state_accumulation_and_rate_limit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _install_fake_emit(monkeypatch)
+    cfg, spec = _make_cfg(tmp_path, rate_limit=1)
+    note = cfg.vault_path / "Inbox" / "note.md"
+    _write_note(note, "v1", mtime=1_700_001_000)
+
+    state = WatcherState()
+    first = _run_tick(monkeypatch, cfg, spec, state, now=1_700_001_100.0)
+
+    _write_note(note, "v2", mtime=1_700_001_101)
+    second = _run_tick(monkeypatch, cfg, spec, state, now=1_700_001_101.0)
+
+    assert first["changed_in_tick"] == 1
+    assert first["emitted_in_tick"] == 1
+    assert second["changed_in_tick"] == 1
+    assert second["emitted_in_tick"] == 0
+    assert second["rate_limited_in_tick"] == 1
+    assert second["changed_detected"] == state.changed_detected == 2
+    assert second["intents_emitted"] == state.intents_emitted == 1
+    assert state.changed_detected >= state.intents_emitted
+    assert len(calls) == 1
+
+
+def test_backoff_tick_short_circuits_scanning_until_expiry(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg, spec = _make_cfg(tmp_path, backoff_seconds=30)
+    _write_note(cfg.vault_path / "Inbox" / "note.md", "payload", mtime=1_700_002_000)
+
+    def boom(**kwargs) -> str:
+        raise RuntimeError("emit failed")
+
+    monkeypatch.setattr(registry, "_emit_watch_event", boom)
+
+    state = WatcherState()
+    first = _run_tick(monkeypatch, cfg, spec, state, now=1_700_002_100.0)
+    second = _run_tick(monkeypatch, cfg, spec, state, now=1_700_002_110.0)
+
+    assert first["changed_in_tick"] == 1
+    assert first["backoff_active"] is True
+    assert state.backoff_until == 1_700_002_130.0
+    assert second["backoff_active"] is True
+    assert second["scanned_files"] == 0
+    assert second["changed_in_tick"] == 0
+    assert second["emitted_in_tick"] == 0
+    assert state.intents_emitted == 0
+
+
+def test_bad_tick_resets_after_following_healthy_tick(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_fake_emit(monkeypatch)
+    cfg, spec = _make_cfg(tmp_path, max_scanned=1)
+    one = cfg.vault_path / "Inbox" / "one.md"
+    two = cfg.vault_path / "Inbox" / "two.md"
+    _write_note(one, "one", mtime=1_700_003_000)
+    _write_note(two, "two", mtime=1_700_003_001)
+
+    state = WatcherState()
+    bad = _run_tick(monkeypatch, cfg, spec, state, now=1_700_003_100.0)
+    assert bad["bad_tick"] is True
+    assert state.bad_ticks == 1
+
+    two.unlink()
+    cfg.max_scanned_files_per_tick = 2
+    healthy = _run_tick(monkeypatch, cfg, spec, state, now=1_700_003_200.0)
+
+    assert healthy["bad_tick"] is False
+    assert healthy["bad_tick_reason"] is None
+    assert state.bad_ticks == 0
+    assert healthy["chosen_sleep_seconds"] == cfg.tick_sleep_seconds
+    assert state.dynamic_sleep_seconds is None
+
+
+def test_derive_scan_root_rejects_parent_escape(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (tmp_path / "outside").mkdir()
+
+    with pytest.raises(ValueError):
+        registry._derive_scan_root(vault, "../outside/**")
+
+
+def test_derive_scan_root_uses_specific_scope_prefix(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    inbox = vault / "Inbox"
+    inbox.mkdir(parents=True)
+
+    scan_root = registry._derive_scan_root(vault, "Inbox/**")
+
+    assert scan_root == inbox
+
+
+def test_derive_scan_root_stays_at_vault_for_vaultwide_scope(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+
+    scan_root = registry._derive_scan_root(vault, "*.md,**/*.md")
+
+    assert scan_root == vault
+
+
+def test_derive_scan_root_fails_for_missing_prefixed_directory(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+
+    with pytest.raises(FileNotFoundError):
+        registry._derive_scan_root(vault, "Missing/**")


### PR DESCRIPTION
## Summary
- add watcher registry contract tests for tick summary/state invariants and scan-root policy
- harden the existing metamorphic watcher tests by pinning the internal tick clock during assertions
- keep the change isolated to quality wave tests only

## Testing
- /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/python -m pytest tests/quality_wave/test_watcher_registry_contracts.py -v --override-ini="addopts=" --no-header
- /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/python -m pytest tests/quality_wave/ -v --override-ini="addopts=" --no-header