### PR TITLE
docs: PKM runtime benchmark protocol (measurement-only, docs-first)

### DIFF
--- a/docs/benchmarks/BENCHMARK_PROTOCOL.md
+++ b/docs/benchmarks/BENCHMARK_PROTOCOL.md
@@ -62,7 +62,7 @@ Every benchmark sample must carry a scenario triple. This enables filtering and 
 |---|---|---|
 | `storage_profile` | `ssd`, `external`, `memory`, `pg` | Storage backend or device class |
 | `runtime_placement` | `local`, `docker`, `colima` | Where the runtime processes execute |
-| `model_profile` | `mock`, `local-ollama`, `cloud-anthropic` | LLM/embedding provider class |
+| `model_profile` | `mock`, `local`, `cloud` | LLM/embedding provider class |
 
 The `memory` and `pg` storage profile values are used in the benchmark runner (in-process). The `ssd` and `external` values are reserved for future runtime instrumentation where the physical storage device matters for latency analysis.
 
@@ -137,7 +137,7 @@ description: <human-readable description>
 seed_dir: <path relative to repo root>
 storage_profile: <memory|pg|ssd|external>
 runtime_placement: <local|docker|colima>
-model_profile: <mock|local-ollama|cloud-anthropic>
+model_profile: <mock|local|cloud>
 notes: <optional free text>
 ```
 
@@ -151,8 +151,8 @@ notes: <optional free text>
 - Seed vault files present at `docs/examples/vault_test_seed/`.
 - For `memory` profile: no external services needed.
 - For `pg` profile: PostgreSQL accessible via `DATABASE_URL`.
-- For `local-ollama` model profile: Ollama running locally.
-- For `cloud-anthropic` model profile: `ANTHROPIC_API_KEY` configured.
+- For `local` model profile: Ollama running locally.
+- For `cloud` model profile: `ANTHROPIC_API_KEY` configured.
 
 ### Running a benchmark scenario
 

--- a/ops/benchmarks/record_sample.py
+++ b/ops/benchmarks/record_sample.py
@@ -1,0 +1,75 @@
+"""Append-to-JSONL benchmark helper.
+
+Runs one benchmark scenario via run_benchmark.run() and appends the result
+as a single JSON line to the specified JSONL output file.
+
+This is the accumulator companion to run_benchmark.py:
+  - run_benchmark.py  → writes one pretty-printed JSON file per invocation
+  - record_sample.py  → appends one compact JSON line per invocation to a JSONL accumulator
+
+Usage:
+    python ops/benchmarks/record_sample.py \\
+      --storage-profile memory \\
+      --runtime-placement local \\
+      --model-profile mock \\
+      --seed-dir docs/examples/vault_test_seed \\
+      --output ops/benchmarks/baselines/samples.jsonl
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from ops.benchmarks.run_benchmark import main as _run_main, run  # noqa: E402
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Append one PKM benchmark run to a JSONL accumulator file. "
+            "Measurement only — no thresholds enforced."
+        ),
+    )
+    parser.add_argument(
+        "--storage-profile",
+        default="memory",
+        choices=["memory", "pg"],
+        help="Store backend profile (default: memory)",
+    )
+    parser.add_argument(
+        "--runtime-placement",
+        default="local",
+        choices=["local", "docker", "colima"],
+        help="Runtime placement (default: local)",
+    )
+    parser.add_argument(
+        "--model-profile",
+        default="mock",
+        choices=["mock", "local", "cloud"],
+        help="LLM/embedding provider profile (default: mock)",
+    )
+    parser.add_argument(
+        "--seed-dir",
+        default="docs/examples/vault_test_seed",
+        help="Path to seed vault directory (default: docs/examples/vault_test_seed)",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="JSONL file to append the run result to (created if absent)",
+    )
+    args = parser.parse_args()
+
+    result = run(args)
+
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(result, separators=(",", ":")) + "\n")
+
+    print(f"Appended run {result['run_id']} to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ops/benchmarks/run_benchmark.py
+++ b/ops/benchmarks/run_benchmark.py
@@ -302,7 +302,9 @@ def main() -> None:
 
     output_str = json.dumps(result, indent=2)
     if args.output:
-        Path(args.output).write_text(output_str, encoding="utf-8")
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(output_str, encoding="utf-8")
     else:
         print(output_str)
 


### PR DESCRIPTION
## Summary
- Add `docs/benchmarks/BENCHMARK_PROTOCOL.md` defining standardised metric names, tag dimensions, scenario format, and repeatable test protocol for runtime drift measurement
- Covers the full pipeline: watcher → outbox → worker → index → ASK/panel/promote
- Tag dimensions: `storage_profile`, `runtime_placement`, `model_profile`
- Phase 1 metrics measurable in-process today; Phase 2 metrics defined for future runtime instrumentation

**Measurement-only:** no latency thresholds enforced, no CI gates added, no storage migration decisions until baseline data exists.

## Test plan
- [ ] Doc renders correctly in GitHub
- [ ] No conflicting metric name definitions with `ops/quality/baselines.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)