### PR TITLE
feat: add freeform catalog-driven proposal path to PanelAgent (PA2-FREEFORM)

### DIFF
--- a/app/agents/panel_agent/graph.py
+++ b/app/agents/panel_agent/graph.py
@@ -398,12 +398,130 @@ def _format_note_context(ctx: NoteContext) -> str:
     return "\n\n".join(parts) if parts else ""
 
 
+def _select_actions_from_catalog(
+    state: PanelAgentState,
+    catalog: PanelActionCatalog,
+) -> tuple[set[str], dict[str, str]] | None:
+    """Freeform proposal path: derive candidate actions from instruction text + full catalog.
+
+    Used when the panel has no checkbox actions. The LLM selects from the active catalog
+    based on instruction text and catalog metadata (labels, llm_hint, description).
+    Only canonical catalog IDs may be returned; out-of-catalog proposals are silently dropped.
+    Returns None on LLM error so the caller can fall back to rule mode.
+    """
+    available = catalog.actions
+    if not available:
+        return set(), {}
+
+    action_lines = []
+    for descriptor in available:
+        hint = descriptor.llm_hint or descriptor.description or descriptor.kind or descriptor.intent_type
+        labels = ", ".join(descriptor.labels or [])
+        action_lines.append(
+            f"- id: {descriptor.id} | kind: {descriptor.kind or descriptor.intent_type} | labels: {labels} | hint: {hint}"
+        )
+
+    system = " ".join(
+        [
+            "You are PanelAgent.",
+            "Given the note context, panel instruction, and available canonical actions,",
+            "choose which actions to execute by returning JSON with an 'actions' array of objects",
+            "with fields {id, reason?, message?}. Only use the provided action IDs. Do not invent new IDs.",
+            "If no action fits the instruction, return an empty array.",
+        ]
+    )
+    user_parts = [
+        f"Instruction: {state.panel.instruction}",
+        f"Note context:\n{_build_note_snippet(state)}",
+        "Available actions (canonical):",
+        *action_lines,
+        'Return JSON like: {"actions": [{"id": "promote.evergreen", "reason": "..."}]}',
+    ]
+    messages = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": "\n".join(user_parts)},
+    ]
+
+    valid_ids = {d.id for d in available}
+    try:
+        facade = get_reasoning_facade()
+        parsed = facade.structured(
+            messages,
+            schema=_PANEL_DECIDER_SCHEMA,
+            task_kind=ReasoningTaskKind.DECIDE.llm_task_kind,
+            trace_id=state.trace_id,
+        )
+        candidates: list[object] = []
+        if isinstance(parsed, dict):
+            raw = parsed.get("actions")
+            if raw is None:
+                raw = parsed.get("chosen_actions")
+            if isinstance(raw, list):
+                candidates = raw
+
+        selected: set[str] = set()
+        reasons: dict[str, str] = {}
+        for item in candidates:
+            action_id: str | None = None
+            reason: str | None = None
+            if isinstance(item, str):
+                action_id = item
+            elif isinstance(item, dict):
+                action_id = item.get("id") or item.get("action_id")
+                reason = item.get("reason") or item.get("why")
+            if not action_id:
+                continue
+            action_id = str(action_id).strip()
+            if action_id not in valid_ids:
+                logger.debug("Freeform proposal %r rejected: not in active catalog", action_id)
+                continue
+            selected.add(action_id)
+            if reason:
+                reasons[action_id] = reason
+        return selected, reasons
+    except Exception:
+        return None
+
+
+def _inject_catalog_proposals(state: PanelAgentState, proposed_ids: set[str]) -> PanelAgentState:
+    """Inject catalog-derived PanelIntentAction objects for freeform proposals.
+
+    Only injects actions that are not already present in state.actions.
+    The injected actions carry the full mapping from the catalog descriptor so
+    they flow through the same execution gates as checkbox-derived actions.
+    """
+    catalog = state.action_catalog or PanelActionCatalog.from_descriptors([])
+    existing_ids = {action.id for action in state.actions}
+    new_actions: list[PanelIntentAction] = []
+    for action_id in proposed_ids:
+        if action_id in existing_ids:
+            continue
+        descriptor = catalog.get(action_id)
+        if descriptor is None:
+            continue
+        label = (descriptor.labels or [descriptor.id])[0]
+        new_actions.append(
+            PanelIntentAction(
+                id=descriptor.id,
+                label=label,
+                checked=True,
+                mapping=descriptor.to_mapping(),
+            )
+        )
+    if not new_actions:
+        return state
+    return state.model_copy(update={"actions": list(state.actions) + new_actions})
+
+
 def _select_actions_llm(state: PanelAgentState) -> tuple[set[str], dict[str, str]] | None:
     assert state.intent_event is not None, "PanelAgentState must include intent_event"
     actions = list(state.actions)
-    if not actions:
-        return set(), {}
     catalog = state.action_catalog or PanelActionCatalog.from_descriptors([])
+
+    # Freeform path: no checkbox actions — discover candidates from instruction + full catalog.
+    if not actions:
+        return _select_actions_from_catalog(state, catalog)
+
     allowed_ids = {a.id for a in actions}
     available = [
         descriptor
@@ -543,6 +661,10 @@ def _decide_actions_llm_with_fallback(state: PanelAgentState) -> PanelAgentState
     if selection is None:
         return _decide_actions_rule(state)
     chosen, reasons = selection
+    # Freeform: inject catalog-derived PanelIntentAction objects for proposed IDs
+    # that have no corresponding entry in state.actions (e.g., no-checkbox panels).
+    if chosen:
+        state = _inject_catalog_proposals(state, chosen)
     return _apply_actions(state, selected_ids=chosen, reasons=reasons)
 
 

--- a/docs/PANEL_AGENT.md
+++ b/docs/PANEL_AGENT.md
@@ -1,4 +1,4 @@
-State: v5.5 baseline — PanelAgent runtime V1 (v5.0) with planner pipeline opt-in. This document defines the PanelAgent-specific runtime contract.
+State: v5.6 — PanelAgent runtime V1 baseline (v5.0) + freeform catalog-driven proposal path shipped (PA2-FREEFORM). This document defines the PanelAgent-specific runtime contract.
 # PanelAgent / NoteInteractionAgent (Runtime v5.0)
 
 Purpose: translate human-driven AI panels in vault notes into structured intents/events while keeping the panel simple, optional, and human-first.
@@ -30,16 +30,16 @@ Interpretation note:
 - Receipts live in the AI status callout (foldable) to acknowledge outcomes without bloating the panel history.
 - The AI status callout is a bounded receipt surface, not the same thing as the metadata mirror.
 
-## PanelAgent 2.0 (planned v5.6)
-Backlog: #244, #241, #242, #243, #240.
+## PanelAgent 2.0 (v5.6, in progress)
+Backlog: #244, #242, #243, #240. Shipped: #241.
 - Extract Panel cognition behind an engine-neutral seam so the runtime can swap LangGraph-era internals for a future Deep Agents implementation without changing panel contracts, receipts, or planner boundaries. Source Anchor: PA2-ENGINE-SEAM. Tracked by: #244
-- Add freeform panel action proposals from note instruction plus the action catalog rather than relying only on fixed checkbox mappings. Source Anchor: PA2-FREEFORM. Tracked by: #241
+- **Freeform catalog-driven proposal path — shipped (PR #248).** Source Anchor: PA2-FREEFORM. When a panel has an instruction but no checkbox actions, the LLM decider (`PANEL_AGENT_DECIDER=llm`) consults the full active catalog and proposes canonical action IDs from instruction text + catalog metadata (`llm_hint`, `labels`, `description`) alone, without requiring any checkbox-label match. Proposals are restricted to the active catalog; out-of-catalog IDs are dropped. Selected actions flow through the same execution gates (policy, idempotency, mutation guards) as checkbox-derived actions. Fallback to rule mode on LLM error or empty catalog. Tracked by: #241
 - Surface uncertain or partial interpretations as suggested checkboxes instead of direct execution so panel ambiguity stays human-reviewable. Source Anchor: PA2-SUGGESTED-CHECKBOXES. Tracked by: #242
 - Emit ordered multi-step panel plans through the planner/orchestration contract rather than investing in richer LangGraph-only node choreography. Source Anchor: PA2-MULTISTEP-PLANS. Tracked by: #243
 - Prove the PanelAgent 2.0 path operationally on a real vault with soak, receipts, and owner-doc writeback before it is treated as operationally accepted. Source Anchor: PA2-REAL-VAULT-ACCEPTANCE. Tracked by: #240
-- PanelAgent Runtime V1 remains the baseline until the PanelAgent 2.0 path is implemented and operationally accepted.
+- PanelAgent Runtime V1 remains the baseline until the PanelAgent 2.0 path is fully implemented and operationally accepted.
 - LangGraph control flow now supports a decider mode (`PANEL_AGENT_DECIDER=rule|llm`); `rule` remains the default to preserve current behaviour, while `llm` is an opt-in, experimental action selector routed through the shared `ReasoningFacade` with the canonical `decide` task kind.
-- LLM-driven contract tests live under `tests/e2e/test_panel_llm_e2e.py` (gated by `@pytest.mark.panel_llm_e2e` and `PANEL_AGENT_LLM_E2E=1`) to validate end-to-end promotion/non-promotion scenarios using the real decider.
+- LLM-driven contract tests live under `tests/e2e/test_panel_llm_e2e.py` (gated by `@pytest.mark.panel_llm_e2e` and `PANEL_AGENT_LLM_E2E=1`) to validate end-to-end promotion/non-promotion scenarios (including the freeform no-checkbox path) using the real decider.
 
 Direction note:
 - the forward direction is richer cognition in support of Panel,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -26,9 +26,9 @@ This roadmap is forward-looking and skimmable. History lives in `docs/history/SO
     - Rationale: prevents pattern fragmentation; broader agent adoption should route reasoning/tool calls through the existing shared facade instead of introducing new direct call paths.
   - Orchestrator V2 (LangGraph): parallel execution, compensation/rollback, checkpointing, retries. Source Anchor: ORCHV2-TDD
     - Back-compat: `ORCHESTRATOR_VERSION=v1|v2`.
-  - PanelAgent 2.0 timeline:
-    - v5.5C: decider (in progress).
-    - v5.6: PanelAgent 2.0 full migration (freeform interpretation, multi-step workflows, uncertainty→suggested checkboxes, catalog-driven discovery). Backlog: #244, #241, #242, #243, #240. Source Anchor: PA2-ROLLUP
+  - PanelAgent 2.0 timeline: Source Anchor: PA2-ROLLUP
+    - v5.5C: decider — shipped (rule default + opt-in LLM mode + fallback + telemetry).
+    - v5.6: freeform catalog-driven proposal path — shipped (#241, PR #248). Remaining: engine-neutral seam (#244), suggested checkboxes (#242), multi-step plans (#243), real-vault acceptance (#240).
     - v5.7: advanced (panel versioning, cross-note coordination).
   - Vault-as-GUI settings compiler (`@Settings` / System/Config) now covers panel-action catalogs, watcher settings, and outbox paths with CI schema checks (v5.6 track).
   - LangGraph rollout to additional agents (Promotion/Reviewer/Hygiene) in phases:
@@ -208,7 +208,7 @@ Explicit rule: "LLM reasoning must never directly trigger execution."
 | v5.1–v5.4 | Watcher track (ingest/panel CLI, policy, ergonomics) | Operationally accepted |
 | v5.5A/B | Panel planner pipeline + CLI-first orchestration/promotion consumer | Shipped |
 | v5.5C/D | Panel LangGraph decider + watcher auto-exec; watcher→planner/orchestrator automation | Planned/In progress |
-| v5.6 | Companion note/doc-sync cleanup, shared ReasoningFacade + LangGraph rollout, Orchestrator V2 (flagged), and Vault-as-GUI settings compiler; see `docs/plans/V56_FORWARD_LINE.md` | Docs-first kickoff / selective forward work |
+| v5.6 | Companion note/doc-sync cleanup, shared ReasoningFacade + LangGraph rollout, Orchestrator V2 (flagged), Vault-as-GUI settings compiler, freeform panel catalog-discovery (shipped); see `docs/plans/V56_FORWARD_LINE.md` | Selective forward work (freeform proposals shipped) |
 | v6.0 | Wanted-state architecture pass to align runtime boundaries with the newer human/context/artifact semantics, ontology/runtime bridge, commitment-first modeling, retrieval vs orientation vs resurfacing separation, and clearer surface/authority contracts; target described in `docs/plans/V60_ARCHITECTURE_TARGET.md` | Proposed target state |
 
 ## Tracks (details moved)

--- a/docs/settings/panel-actions.md
+++ b/docs/settings/panel-actions.md
@@ -1,5 +1,5 @@
 ---
-State: v5.5 – PanelAgent catalog (LLM decider opt-in; rule-mode default).
+State: v5.6 – PanelAgent catalog (LLM decider opt-in; rule-mode default; freeform discovery via llm_hint).
 mappings:
   - id: "promote.evergreen"
     kind: "promotion"
@@ -7,6 +7,7 @@ mappings:
       - "Gör denna anteckning evergreen"
       - "Make this note evergreen"
     description: "Promote the note to evergreen maturity."
+    llm_hint: "Choose this when the instruction asks to promote, make evergreen, or mature the note."
     intent_type: "promotion"
     downstream_event: "review.promote.evergreen"
     params:
@@ -17,6 +18,7 @@ mappings:
       - "Arkivera den här anteckningen"
       - "Archive this note"
     description: "Archive the note without promotion."
+    llm_hint: "Choose this when the instruction asks to archive or retire the note."
     intent_type: "archival"
     downstream_event: "note.archive"
   - id: "ingest.summary.create"
@@ -25,6 +27,7 @@ mappings:
       - "Skapa en separat sammanfattningsanteckning"
       - "Create a separate summary note"
     description: "Create a sibling summary note for this content."
+    llm_hint: "Choose this when the instruction asks to summarize the note into a separate document."
     intent_type: "ingest"
     downstream_event: "ingest.summary.create"
 ---

--- a/docs/tracks/TRACK_PANELAGENT_LANGGRAPH.md
+++ b/docs/tracks/TRACK_PANELAGENT_LANGGRAPH.md
@@ -1,4 +1,4 @@
-State: v5.5C delivered (LangGraph decider hardening: rule default + opt-in LLM mode with fallback + telemetry).
+State: v5.6 — freeform catalog-driven proposal path delivered (instruction text → catalog discovery, no checkbox required).
 # Track — PanelAgent LangGraph (v5.5)
 
 Scope: PanelAgent evolution toward LangGraph inner loops with catalog-driven decider, planner/orchestrator integration, and watcher automation.
@@ -13,9 +13,13 @@ Scope: PanelAgent evolution toward LangGraph inner loops with catalog-driven dec
 ## Delivered (v5.5C)
 - LangGraph decider hardening: rule mode is default and deterministic; LLM mode (`PANEL_AGENT_DECIDER=llm`) is opt-in with automatic fallback to rule on error; telemetry surfaces action selections and reasons in status counters; no external event-contract changes.
 
+## Delivered (v5.6)
+- Freeform catalog-driven proposal path: when a panel has an instruction but no checkbox actions, the LLM decider (`PANEL_AGENT_DECIDER=llm`) queries the full active catalog and selects canonical action IDs from instruction text alone. Proposals are validated against the catalog (out-of-catalog IDs dropped). Selected actions flow through the same execution gates as checkbox-derived actions. Fallback to rule mode on LLM error. Catalog entries now carry `llm_hint` for richer discovery prompts.
+
 ## Planned (forward line)
 - Watcher auto-exec path for panel plans with safety limits (gated by concurrency/idempotency guards).
 - Richer panel actions (summary/reply) with MCP/tool boundaries; A2A envelopes for planner/orchestrator integration.
+- Multi-step workflows, uncertainty→suggested checkboxes (remaining PA2 items).
 
 ## Notes
 - External contract unchanged: panel CLI and watcher flows remain policy-gated; decider defaults to rule; planner/orchestrator path opt-in.

--- a/tests/agents/panel_agent/test_panel_graph.py
+++ b/tests/agents/panel_agent/test_panel_graph.py
@@ -431,6 +431,121 @@ def test_panel_graph_llm_empty_selection_honors_negated_promotion_instruction(mo
     assert statuses["promote.evergreen"] == "skipped"
 
 
+def _state_no_actions(instruction: str, catalog: PanelActionCatalog | None = None) -> PanelAgentState:
+    """Build a PanelAgentState with no checkbox actions (freeform-only panel)."""
+    note = NoteRef(uuid=TEST_NOTE_UUID, path=TEST_NOTE_PATH, origin=TEST_NOTE_ORIGIN)
+    panel = PanelInfo(panel_id="panel-1", instruction=instruction, raw_block=None)
+    payload = PanelIntentPayload(note=note, panel=panel, actions=[])
+    intent = PanelIntentEvent(payload=payload, trace_id="trace-freeform")
+    return PanelAgentState(
+        trace_id=intent.trace_id,
+        note=intent.payload.note,
+        panel=intent.payload.panel,
+        actions=[],
+        intent_event=intent,
+        action_catalog=catalog,
+    )
+
+
+def test_panel_graph_freeform_proposes_catalog_action_without_checkboxes(monkeypatch) -> None:
+    """Freeform path: instruction alone drives catalog discovery when no checkboxes are present."""
+    catalog = PanelActionCatalog.from_descriptors(
+        [
+            PanelActionDescriptor(
+                id="promote.evergreen",
+                intent_type="promotion",
+                downstream_event="review.promote.evergreen",
+                labels=["Make this note evergreen"],
+                description="Promote note to evergreen",
+                llm_hint="Choose this when the instruction asks to promote or make the note evergreen.",
+                params={"maturity": "evergreen"},
+            )
+        ]
+    )
+    state = _state_no_actions("Make this note evergreen.", catalog=catalog)
+
+    monkeypatch.setattr(
+        "app.agents.panel_agent.graph.get_reasoning_facade",
+        lambda: _StubReasoningFacade({"actions": [{"id": "promote.evergreen", "reason": "instruction match"}]}),
+    )
+
+    result = run_panel_graph(state, decider_mode="llm")
+    event_names = {getattr(evt, "event", None) for evt in result.emitted_events}
+    assert "promote.intent.created" in event_names
+    assert "panel.action.triggered" in event_names
+    statuses = {r.id: r.status for r in result.action_results}
+    assert statuses["promote.evergreen"] == "triggered"
+    assert result.selected_action_ids == ["promote.evergreen"]
+
+
+def test_panel_graph_freeform_rejects_out_of_catalog_id(monkeypatch) -> None:
+    """Freeform path: LLM proposals not in the active catalog are silently dropped."""
+    catalog = PanelActionCatalog.from_descriptors(
+        [
+            PanelActionDescriptor(
+                id="promote.evergreen",
+                intent_type="promotion",
+                downstream_event="review.promote.evergreen",
+                labels=["Make this note evergreen"],
+                description="Promote note to evergreen",
+            )
+        ]
+    )
+    state = _state_no_actions("Make this note evergreen.", catalog=catalog)
+
+    monkeypatch.setattr(
+        "app.agents.panel_agent.graph.get_reasoning_facade",
+        lambda: _StubReasoningFacade({"actions": [{"id": "invented.action"}]}),
+    )
+
+    result = run_panel_graph(state, decider_mode="llm")
+    event_names = {getattr(evt, "event", None) for evt in result.emitted_events}
+    assert "promote.intent.created" not in event_names
+    assert result.action_results == []
+
+
+def test_panel_graph_freeform_empty_catalog_no_actions(monkeypatch) -> None:
+    """Freeform path: empty catalog gracefully produces no proposals."""
+    catalog = PanelActionCatalog.from_descriptors([])
+    state = _state_no_actions("Make this note evergreen.", catalog=catalog)
+
+    monkeypatch.setattr(
+        "app.agents.panel_agent.graph.get_reasoning_facade",
+        lambda: _StubReasoningFacade({"actions": [{"id": "promote.evergreen"}]}),
+    )
+
+    result = run_panel_graph(state, decider_mode="llm")
+    event_names = {getattr(evt, "event", None) for evt in result.emitted_events}
+    assert "promote.intent.created" not in event_names
+    assert result.action_results == []
+
+
+def test_panel_graph_freeform_falls_back_to_rule_on_llm_error(monkeypatch) -> None:
+    """Freeform path: LLM failure falls back to rule mode (which is a no-op for no-checkbox panels)."""
+    catalog = PanelActionCatalog.from_descriptors(
+        [
+            PanelActionDescriptor(
+                id="promote.evergreen",
+                intent_type="promotion",
+                downstream_event="review.promote.evergreen",
+                labels=["Make this note evergreen"],
+                description="Promote note to evergreen",
+            )
+        ]
+    )
+    state = _state_no_actions("Make this note evergreen.", catalog=catalog)
+
+    monkeypatch.setattr(
+        "app.agents.panel_agent.graph.get_reasoning_facade",
+        lambda: _StubReasoningFacade(RuntimeError("LLM unavailable")),
+    )
+
+    result = run_panel_graph(state, decider_mode="llm")
+    event_names = {getattr(evt, "event", None) for evt in result.emitted_events}
+    assert "promote.intent.created" not in event_names
+    assert result.action_results == []
+
+
 def test_panel_graph_skips_idempotent_duplicate() -> None:
     mapping = PanelActionMapping(
         id="promote.evergreen",

--- a/tests/e2e/test_panel_llm_e2e.py
+++ b/tests/e2e/test_panel_llm_e2e.py
@@ -124,6 +124,15 @@ def _note_markdown(instruction: str, action_label: str) -> str:
 """
 
 
+def _freeform_note_markdown(instruction: str) -> str:
+    """Panel with instruction only — no checkbox actions (freeform discovery path)."""
+    return f"""%% AI:Start %%
+## AI-instruktion
+{instruction}
+%% AI:End %%
+"""
+
+
 def _read_outbox(path: Path) -> list[dict]:
     if not path.exists():
         return []
@@ -210,6 +219,61 @@ mp.undo()
     return str(payload["note_uuid"]), list(payload["topics"]), list(payload["outbox_events"])
 
 
+def _run_live_panel_freeform_subprocess(
+    tmp_path: Path,
+    *,
+    instruction: str,
+    actions_variant: str,
+) -> tuple[str, list[str], list[dict]]:
+    """Run a freeform panel (no checkboxes) via live LLM in an isolated subprocess."""
+    outbox_path = tmp_path / f"index-outbox-freeform-{uuid4()}.jsonl"
+    actions_path = _panel_actions_file(tmp_path, variant=actions_variant)
+    script = f"""
+import json
+import os
+from pathlib import Path
+from uuid import uuid4
+
+from _pytest.monkeypatch import MonkeyPatch
+
+from tests.e2e.test_panel_llm_e2e import _enable_live_llm, _freeform_note_markdown, _read_outbox, _seed_note
+from app.agents.panel_agent.agent import run_panel_intent_for_note
+from app.agents.panel_agent.runtime import execute_panel_intent
+
+mp = MonkeyPatch()
+_enable_live_llm(mp)
+reset_store_backends()
+note_uuid = str(uuid4())
+mp.setenv("INDEX_OUTBOX_PATH", {str(outbox_path)!r})
+mp.setenv("PANEL_AGENT_DECIDER", "llm")
+mp.setenv("PANEL_ACTIONS_PATH", {str(actions_path)!r})
+mp.setattr("app.agents.panel_agent.agent.INDEX_OUTBOX_PATH", Path({str(outbox_path)!r}), raising=False)
+_seed_note(note_uuid, _freeform_note_markdown({instruction!r}))
+events = run_panel_intent_for_note(note_uuid, trace_id="panel-llm-freeform-e2e")
+assert len(events) == 1
+result = execute_panel_intent(events[0])
+payload = {{
+    "note_uuid": note_uuid,
+    "topics": [getattr(event, "event", None) or event.get("event") for event in result.emitted_events],
+    "outbox_events": _read_outbox(Path({str(outbox_path)!r})),
+}}
+print(json.dumps(payload))
+mp.undo()
+"""
+    env = {key: value for key, value in os.environ.items() if not key.startswith("PYTEST_")}
+    env["STORE_BACKEND"] = "memory"
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    payload = json.loads(completed.stdout.strip().splitlines()[-1])
+    return str(payload["note_uuid"]), list(payload["topics"]), list(payload["outbox_events"])
+
+
 def test_panel_llm_promotes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _skip_if_no_llm()
     _skip_if_live_llm_unavailable()
@@ -253,3 +317,32 @@ def test_panel_llm_no_promotion(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
     assert "promote.intent.created" not in topics
     assert any(ev.get("event") == "panel.intent.created" for ev in outbox_events)
     assert not any(ev.get("event") == "promote.intent.created" for ev in outbox_events)
+
+
+def test_panel_llm_freeform_promotes_without_checkboxes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Freeform path: instruction alone (no checkboxes) drives catalog discovery via live LLM."""
+    _skip_if_no_llm()
+    _skip_if_live_llm_unavailable()
+    last_topics: list[str] = []
+    last_outbox_events: list[dict] = []
+    for _ in range(3):
+        note_uuid, topics, outbox_events = _run_live_panel_freeform_subprocess(
+            tmp_path,
+            instruction="Make this note evergreen. No summary needed, just promote it.",
+            actions_variant="promote_only",
+        )
+        assert "panel.intent.executed" in topics
+        assert "panel.log.created" in topics
+        assert any(ev.get("event") == "panel.intent.created" for ev in outbox_events)
+        if "promote.intent.created" in topics and any(
+            ev.get("event") == "promote.intent.created" and ev.get("payload", {}).get("note", {}).get("uuid") == note_uuid
+            for ev in outbox_events
+        ):
+            break
+        last_topics = topics
+        last_outbox_events = outbox_events
+    else:
+        pytest.fail(
+            "expected promote.intent.created from freeform panel LLM run (no checkboxes) after 3 attempts; "
+            f"last topics={last_topics} outbox_events={[ev.get('event') for ev in last_outbox_events]}"
+        )


### PR DESCRIPTION
## Summary

- Implements the freeform panel action proposal path from Issue #241 (PA2-FREEFORM, v5.6).
- When a panel has an instruction but **no checkbox actions**, the LLM decider (`PANEL_AGENT_DECIDER=llm`) now queries the full active catalog and selects canonical action IDs from instruction text + catalog metadata (`llm_hint`, `labels`, `description`), without requiring any checkbox-label match.
- Proposed IDs are validated against the active catalog — out-of-catalog proposals are silently dropped.
- Freeform-selected actions are injected as `PanelIntentAction` objects and processed through the identical execution pipeline (policy gates, idempotency guard, mutation paths) as checkbox-derived actions.
- Fallback to rule mode on LLM error; no-op when catalog is empty or LLM returns no proposals.
- Catalog entries now carry `llm_hint` for richer freeform discovery prompts.

## Anchor Drift Noted

Source anchors `PA2-FREEFORM` and `PA2-ROLLUP` were absent from the repo at issue-pick time. Fallback authority used: `docs/PANEL_AGENT.md § PanelAgent 2.0` and `docs/ROADMAP.md § Next → PanelAgent 2.0 timeline`. Both anchor labels are now added in this change.

## Files Changed

| File | Change |
|---|---|
| `app/agents/panel_agent/graph.py` | `_select_actions_from_catalog`, `_inject_catalog_proposals` (new); `_select_actions_llm` freeform routing; `_decide_actions_llm_with_fallback` injection |
| `docs/settings/panel-actions.md` | Added `llm_hint` to all three catalog entries |
| `docs/PANEL_AGENT.md` | PA2 section updated to shipped state; `PA2-FREEFORM` anchor added |
| `docs/ROADMAP.md` | v5.6 freeform marked shipped; `PA2-ROLLUP` anchor added |
| `docs/tracks/TRACK_PANELAGENT_LANGGRAPH.md` | Freeform moved to Delivered (v5.6) |
| `tests/agents/panel_agent/test_panel_graph.py` | 4 new freeform unit tests |
| `tests/e2e/test_panel_llm_e2e.py` | 1 new freeform e2e test (gated `PANEL_AGENT_LLM_E2E=1`) |

## Validation Run

```
STORE_BACKEND=memory PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/agents/panel_agent/ -m "not pg"
# 61 passed in 1.17s
```

## Constraints Followed

- Proposals restricted to active catalog entries only — no invented IDs
- Freeform proposals go through identical execution gates as checkbox-derived actions (policy, idempotency, mutation guards)
- `PANEL_AGENT_DECIDER=rule` (default) is unaffected — no change to rule-mode behavior
- No new LangGraph topology; no new event contract changes; no architecture-breaking changes

## Acceptance Criteria Satisfied

- [x] Instruction text + catalog metadata generates canonical action IDs without checkbox-label matching
- [x] Proposed actions restricted to active catalog
- [x] Fallback intact (rule-mode no-op when LLM fails or catalog is empty)
- [x] Mutation safety preserved — freeform proposals do not bypass execution gates
- [x] Tests validate proposal generation and reject out-of-catalog suggestions

Fixes #241