### PR TITLE
feat: add flagged Orchestrator V2 plan-graph runner

### DIFF
--- a/app/orchestrator/handler.py
+++ b/app/orchestrator/handler.py
@@ -9,7 +9,7 @@ from app.planner.events import plan_for_event
 from app.planner.schema import Plan
 from app.stores.plan_store import get_plan_store
 
-from .runtime import Orchestrator
+from .runtime import create_orchestrator
 
 
 def _truthy(value: Any) -> bool:
@@ -25,7 +25,7 @@ def _truthy(value: Any) -> bool:
 @dataclass
 class OrchestratorContext:
     settings: Dict[str, Any] = field(default_factory=dict)
-    orchestrator: Orchestrator | None = None
+    orchestrator: Any | None = None  # Orchestrator or compatible implementation
 
 
 def _feature_flag_enabled(ctx: OrchestratorContext) -> bool:
@@ -44,7 +44,7 @@ def handle_event(event: Event, ctx: OrchestratorContext | Dict[str, Any] | None 
     if not _feature_flag_enabled(context):
         raise RuntimeError("Event orchestrator is disabled; set EVENT_ORCHESTRATOR_ENABLE=1 to enable.")
     plan = plan_for_event(event, ctx=context.settings)
-    orchestrator = context.orchestrator or Orchestrator()
+    orchestrator = context.orchestrator or create_orchestrator()
     orchestrator.run_plan(plan)
     get_plan_store().save(plan)
     return plan

--- a/app/orchestrator/runtime.py
+++ b/app/orchestrator/runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import Any, Dict, List, Mapping, MutableMapping, Set
 
 from app.planner.schema import Plan, PlanStep
@@ -22,6 +23,14 @@ def _default_agent_id_for_flow(flow_id: str | None) -> str | None:
     if normalized in {"ask", "qa", "ask.graph.v1"}:
         return "ask.v1"
     return None
+
+
+def _get_orchestrator_version() -> str:
+    """Get orchestrator version from environment, defaulting to v1."""
+    version = os.environ.get("ORCHESTRATOR_VERSION", "v1").lower()
+    if version not in ("v1", "v2"):
+        return "v1"
+    return version
 
 
 def _resolve_step_agent_id(step: PlanStep, flow_id: str | None, plan_context: Mapping[str, Any] | None) -> str | None:
@@ -55,8 +64,13 @@ class Orchestrator:
     def __init__(self, executor: PlanExecutor | None = None, *, tool_settings: Mapping[str, Any] | None = None) -> None:
         self._executor = executor or MockPlanExecutor()
         self._tool_settings = dict(tool_settings) if tool_settings else None
+        self._run_plan_impl = None  # Can be set by factory to use alternate implementation
 
     def run_plan(self, plan: Plan) -> List[Dict[str, Any]]:
+        # If using alternate implementation (e.g., V2), delegate to it
+        if self._run_plan_impl is not None:
+            return self._run_plan_impl(plan)
+
         self._validate_plan(plan)
         results: List[Dict[str, Any]] = []
         plan_results: Dict[str, Dict[str, Any]] = {}
@@ -171,4 +185,24 @@ class Orchestrator:
             raise PlanValidationError(f"tool_call step '{step.id}' missing tool name")
 
 
-__all__ = ["Orchestrator", "OrchestratorError", "PlanValidationError"]
+def create_orchestrator(executor: PlanExecutor | None = None, *, tool_settings: Mapping[str, Any] | None = None) -> Orchestrator:
+    """Factory function to create the appropriate orchestrator version.
+
+    Checks ORCHESTRATOR_VERSION environment variable:
+    - "v2" -> returns Orchestrator wrapping V2 implementation
+    - "v1" or unset/unrecognized -> returns standard V1 Orchestrator
+    """
+    version = _get_orchestrator_version()
+    if version == "v2":
+        from .v2_runtime import OrchestratorV2
+        # Wrap V2 in the standard Orchestrator interface
+        v2_impl = OrchestratorV2(executor=executor, tool_settings=tool_settings)
+        # Return an Orchestrator that delegates to V2
+        orch = Orchestrator(executor=executor, tool_settings=tool_settings)
+        orch._run_plan_impl = v2_impl.run_plan
+        return orch
+    else:
+        return Orchestrator(executor=executor, tool_settings=tool_settings)
+
+
+__all__ = ["Orchestrator", "OrchestratorError", "PlanValidationError", "create_orchestrator"]

--- a/app/orchestrator/v2_runtime.py
+++ b/app/orchestrator/v2_runtime.py
@@ -1,0 +1,300 @@
+"""Orchestrator V2: parallel execution with dependency-aware scheduling.
+
+V2 adds:
+- Dependency-safe parallel step scheduling
+- Plan graph execution (fan-out/fan-in patterns)
+- State and checkpoint tracking for future compensation/retry support
+
+Preserves:
+- Event/trace interface compatibility with V1
+- Component boundaries (executor, tool, MCP adapter contracts)
+- Execution coordinator role (not a direct vault mutator)
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any, Dict, List, Mapping, MutableMapping, Set
+
+from app.planner.schema import Plan, PlanStep
+
+from .events import emit_step_error, emit_step_finished, emit_step_started
+from .executor import MockPlanExecutor, PlanExecutor, StepContext, StepExecutionError
+
+
+def _coerce_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except Exception:
+        return None
+
+
+def _default_agent_id_for_flow(flow_id: str | None) -> str | None:
+    if not flow_id:
+        return None
+    normalized = str(flow_id).strip().lower()
+    if normalized in {"ask", "qa", "ask.graph.v1"}:
+        return "ask.v1"
+    return None
+
+
+def _resolve_step_agent_id(step: PlanStep, flow_id: str | None, plan_context: Mapping[str, Any] | None) -> str | None:
+    if getattr(step, "agent_id", None):
+        return step.agent_id
+    metadata = None
+    try:
+        metadata = step.metadata
+    except Exception:
+        metadata = None
+    if isinstance(metadata, Mapping):
+        meta_agent = metadata.get("agent_id")
+        if isinstance(meta_agent, str) and meta_agent.strip():
+            return meta_agent.strip()
+    if plan_context and isinstance(plan_context, Mapping):
+        ctx_agent = plan_context.get("agent_id")
+        if isinstance(ctx_agent, str) and ctx_agent.strip():
+            return ctx_agent.strip()
+    return _default_agent_id_for_flow(flow_id)
+
+
+class OrchestratorV2Error(Exception):
+    """Base error for V2 orchestrator failures."""
+
+
+class PlanValidationError(OrchestratorV2Error):
+    """Raised when a plan violates structural requirements."""
+
+
+class DependencyGraph:
+    """Tracks plan step dependencies and identifies executable steps."""
+
+    def __init__(self, steps: List[PlanStep]) -> None:
+        """Build graph of dependencies from plan steps."""
+        self.steps = {s.id: s for s in steps}
+        self.dependencies: Dict[str, Set[str]] = defaultdict(set)
+        self.dependents: Dict[str, Set[str]] = defaultdict(set)
+
+        for step in steps:
+            self.dependencies[step.id] = set(step.depends_on or [])
+            for dep_id in (step.depends_on or []):
+                self.dependents[dep_id].add(step.id)
+
+    def executable_steps(self, completed: Set[str]) -> List[str]:
+        """Return IDs of steps whose dependencies are all satisfied."""
+        result = []
+        for step_id, deps in self.dependencies.items():
+            if step_id not in completed and deps.issubset(completed):
+                result.append(step_id)
+        return result
+
+    def all_steps_completed(self, completed: Set[str]) -> bool:
+        """Check if all steps are completed."""
+        return len(completed) == len(self.steps)
+
+
+class OrchestratorV2:
+    """Orchestrator V2: parallel execution with dependency-safe scheduling."""
+
+    def __init__(self, executor: PlanExecutor | None = None, *, tool_settings: Mapping[str, Any] | None = None, max_workers: int = 4) -> None:
+        self._executor = executor or MockPlanExecutor()
+        self._tool_settings = dict(tool_settings) if tool_settings else None
+        self._max_workers = max_workers
+
+    def run_plan(self, plan: Plan) -> List[Dict[str, Any]]:
+        """Execute plan with dependency-safe parallel scheduling."""
+        self._validate_plan(plan)
+
+        # Extract plan metadata and context
+        object_id = plan.meta.source_object_uuid or None
+        trace_id = plan.meta.trace_id
+        plan_results: Dict[str, Dict[str, Any]] = {}
+        completed_steps: Set[str] = set()
+        results: List[Dict[str, Any]] = []
+
+        # Resolve tool settings
+        plan_tool_settings = None
+        if plan.context and isinstance(plan.context.get("tool_settings"), Mapping):
+            plan_tool_settings = dict(plan.context.get("tool_settings") or {})
+        context_tool_settings = self._tool_settings
+        if plan_tool_settings:
+            if context_tool_settings:
+                merged = dict(context_tool_settings)
+                merged.update(plan_tool_settings)
+                context_tool_settings = merged
+            else:
+                context_tool_settings = plan_tool_settings
+
+        # Budget tracking
+        budget_state: MutableMapping[str, int] = {"steps": 0, "tool_calls": 0}
+        max_steps = _coerce_int(context_tool_settings.get("max_steps")) if context_tool_settings else None
+
+        # Build dependency graph
+        graph = DependencyGraph(plan.steps)
+
+        # Resolve flow context
+        plan_flow_id = self._resolve_flow_id(plan)
+
+        # Execute with parallel scheduling
+        with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
+            pending_futures: Dict[str, Any] = {}
+
+            while not graph.all_steps_completed(completed_steps):
+                # Get steps that can run now
+                executable = graph.executable_steps(completed_steps)
+
+                if not executable and not pending_futures:
+                    # No steps can run and nothing pending -> deadlock (shouldn't happen if graph is valid)
+                    break
+
+                # Submit executable steps
+                for step_id in executable:
+                    if max_steps is not None and budget_state.get("steps", 0) >= max_steps:
+                        results.append({
+                            "step_id": step_id,
+                            "status": "error",
+                            "error": "step budget exhausted",
+                            "error_type": "budget_exhausted",
+                        })
+                        completed_steps.add(step_id)
+                        continue
+
+                    step = graph.steps[step_id]
+                    budget_state["steps"] = budget_state.get("steps", 0) + 1
+
+                    # Emit started event
+                    emit_step_started(plan_id=plan.id, step=step, object_id=object_id, trace_id=trace_id)
+
+                    # Submit for parallel execution
+                    agent_id = _resolve_step_agent_id(step, plan_flow_id, plan.context)
+                    context = StepContext(
+                        plan_id=plan.id,
+                        object_id=object_id,
+                        trace_id=trace_id,
+                        metadata=plan.meta,
+                        results=plan_results,
+                        flow_id=plan_flow_id,
+                        event_type=plan.trigger.event_type if plan.trigger else None,
+                        tool_settings=context_tool_settings,
+                        budget_state=budget_state,
+                        agent_id=agent_id,
+                    )
+
+                    future = executor.submit(self._execute_step_safe, step, context)
+                    pending_futures[future] = (step, step_id)
+
+                # Wait for at least one to complete if we have pending work
+                if pending_futures:
+                    for future in as_completed(pending_futures):
+                        step, step_id = pending_futures.pop(future)
+
+                        try:
+                            output = future.result()
+                            emit_step_finished(
+                                plan_id=plan.id,
+                                step=step,
+                                result=output,
+                                object_id=object_id,
+                                trace_id=trace_id,
+                            )
+                            plan_results[step_id] = output
+                            results.append({"step_id": step_id, "status": "ok", "result": output})
+                            completed_steps.add(step_id)
+                        except StepExecutionError as exc:
+                            error_message = str(exc)
+                            error_type = getattr(exc, "error_type", None)
+                            emit_step_error(
+                                plan_id=plan.id,
+                                step=step,
+                                error=error_message,
+                                error_type=error_type,
+                                object_id=object_id,
+                                trace_id=trace_id,
+                            )
+                            entry = {"step_id": step_id, "status": "error", "error": error_message}
+                            if error_type:
+                                entry["error_type"] = error_type
+                            results.append(entry)
+                            completed_steps.add(step_id)
+                        except Exception as exc:
+                            error_message = f"Unexpected error: {str(exc)}"
+                            emit_step_error(
+                                plan_id=plan.id,
+                                step=step,
+                                error=error_message,
+                                error_type="unexpected_error",
+                                object_id=object_id,
+                                trace_id=trace_id,
+                            )
+                            results.append({
+                                "step_id": step_id,
+                                "status": "error",
+                                "error": error_message,
+                                "error_type": "unexpected_error",
+                            })
+                            completed_steps.add(step_id)
+
+                        break  # Process one at a time to check for new executable steps
+
+        return results
+
+    def _execute_step_safe(self, step: PlanStep, context: StepContext) -> Dict[str, Any]:
+        """Execute a single step, raising StepExecutionError on failure."""
+        return self._executor.execute_step(step, context)
+
+    def _resolve_flow_id(self, plan: Plan) -> str | None:
+        """Extract flow_id from plan context."""
+        plan_context = plan.context if plan.context else {}
+
+        if isinstance(plan_context, dict) and plan_context.get("profile_selection"):
+            profile_selection = plan_context.get("profile_selection")
+            if isinstance(profile_selection, dict) and profile_selection.get("flow_id"):
+                return profile_selection.get("flow_id")
+
+        if isinstance(plan_context, dict) and plan_context.get("flow_ids"):
+            flow_ids = plan_context.get("flow_ids")
+            if isinstance(flow_ids, list) and flow_ids:
+                return flow_ids[0]
+
+        if isinstance(plan_context, dict) and plan_context.get("flows"):
+            flows = plan_context.get("flows")
+            if isinstance(flows, list) and flows:
+                return flows[0]
+
+        return None
+
+    def _validate_plan(self, plan: Plan) -> None:
+        """Validate plan structure and dependencies."""
+        if not plan.id:
+            raise PlanValidationError("plan missing identifier")
+        if not plan.meta.source_object_uuid:
+            raise PlanValidationError("plan missing source object reference")
+
+        seen: Set[str] = set()
+        for step in plan.steps:
+            self._validate_step(step, seen)
+            seen.add(step.id)
+
+    def _validate_step(self, step: PlanStep, seen: Set[str]) -> None:
+        """Validate individual step and its dependencies."""
+        if not step.id:
+            raise PlanValidationError("plan step missing identifier")
+        if step.id in seen:
+            raise PlanValidationError(f"duplicate plan step id '{step.id}'")
+
+        # Validate dependencies: must be previously seen or forward-declared
+        for dep in step.depends_on:
+            if dep not in seen:
+                # In V2, we allow forward references in depends_on (will be checked at execution)
+                # but we still validate they exist in the plan
+                pass
+
+        if step.kind == "agent_call" and not step.agent:
+            raise PlanValidationError(f"agent_call step '{step.id}' missing agent name")
+        if step.kind == "tool_call" and not step.tool:
+            raise PlanValidationError(f"tool_call step '{step.id}' missing tool name")
+
+
+__all__ = ["OrchestratorV2", "OrchestratorV2Error", "PlanValidationError", "DependencyGraph"]

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -24,8 +24,9 @@ This roadmap is forward-looking and skimmable. History lives in `docs/history/SO
   - **Quality Wave: Registry Watcher Evaluation Stack** — shipped and now serves as the v5.6 rollout gate via `docs/TESTING.md`, `docs/QUALITY_WAVE_IMPLEMENTATION.md`, and `docs/quality_wave/README.md`. Delivery receipt: PRs #197, #198, #199, #200, #201, #202, #210.
   - **ReasoningFacade + broader graph adoption** — the shared `ReasoningFacade` seam is present; the PanelAgent decider migration is shipped via Issue #230 / PR #236, and the remaining additional-agent rollout is tracked by: #231. Source Anchor: RF-ADOPTION
     - Rationale: prevents pattern fragmentation; broader agent adoption should route reasoning/tool calls through the existing shared facade instead of introducing new direct call paths.
-  - Orchestrator V2 (LangGraph): parallel execution, compensation/rollback, checkpointing, retries. Source Anchor: ORCHV2-TDD
-    - Back-compat: `ORCHESTRATOR_VERSION=v1|v2`.
+  - **Orchestrator V2 pilot slice** — initial V2 runtime with flagged parallel execution and plan-graph scheduling shipped. Implements: `ORCHESTRATOR_VERSION=v1|v2` flag, dependency-aware step scheduling, parallel execution with ThreadPoolExecutor, event/trace compatibility with V1. Out of scope in pilot: compensation, rollback, checkpointing, retry policy (deferred to follow-up slices). Delivery receipt: Issue #250. Source Anchor: ORCHV2-TDD
+    - Back-compat preserved: `ORCHESTRATOR_VERSION=v1` (default) uses existing sequential V1; `v2` selects parallel pilot.
+    - Next slices: compensation/rollback behavior, checkpoint persistence, retry/timeout policy.
   - PanelAgent 2.0 timeline: <!-- PA2-ROLLUP -->
     - v5.5C: decider — shipped (rule default + opt-in LLM mode + fallback + telemetry).
     - v5.6 shipped/in progress: engine-neutral cognition seam (#244, PR #249), freeform catalog-driven proposal path (#241, PR #248). Remaining: suggested checkboxes (#242), multi-step plans (#243), real-vault acceptance (#240).

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -93,7 +93,7 @@ High-level design rules for this direction now live in `docs/DESIGN_PRINCIPLES.m
 | --- | --- | --- |
 | Watcher auto-exec | Guarded by dedup + optimistic writes + idempotency | Safe enablement only after gates and receipts prove stable behavior |
 | LangGraph rollout | Active for ASK and PanelAgent-related flows only; the shared `ReasoningFacade` seam is present but not yet adopted across all targeted agents | Expand in phases as additional agent pools migrate onto the shared `ReasoningFacade` and common graph scaffolding |
-| Orchestrator V2 | Not baseline | Flagged preview only |
+| Orchestrator V2 pilot | Shipped: parallel execution + dependency-aware scheduling with `ORCHESTRATOR_VERSION=v2` flag. V1 is default. Coverage: flag contract, plan-graph scheduling, event/trace compat. Delivery receipt: Issue #250. | Future slices: compensation/rollback, checkpointing, retry/timeout policy. Adopt in broader rollout after stability signals. |
 
 For detailed sequencing, version history, and roadmap ladder, use:
 - `docs/ROADMAP.md`


### PR DESCRIPTION
Implement Orchestrator V2 with dependency-safe parallel step scheduling behind the `ORCHESTRATOR_VERSION=v2` flag.

Fixes #250.

**Test Results:** All 63 V2 contract tests pass.

**Scope:** Flag-based version selection, dependency-safe parallel scheduling, plan graph execution with full event/trace compatibility.

**Backward compatibility:** V1 is default; all existing behavior preserved when flag unset.