### PR TITLE
feat: align startup and watcher entrypoints with dev/prod environment model

### DIFF
--- a/app/cli/__init__.py
+++ b/app/cli/__init__.py
@@ -673,8 +673,8 @@ def panel_orchestrate_plan(plan_id: str | None, note_uuid: str | None) -> None:
 @cli.command(
     name="alpha-human-flows",
     help=(
-        "Run alpha human flows end-to-end (sample ingest, test note, panel, promotion, ASK) "
-        "against a vault root."
+        "Dev-only: run alpha human flows end-to-end (sample ingest, test note, panel, promotion, ASK) "
+        "against a vault root for testing."
     ),
 )
 @click.option(
@@ -1331,8 +1331,8 @@ def uat_run_vault_test(
 @cli.command(
     name="runtime-loop",
     help=(
-        "Legacy/dev-only watcher→panel→promotion loop (requires PKM_SETTINGS_PROFILE=lab). "
-        "Use `watcher run` for operator runtime."
+        "Dev-only watcher→panel→promotion loop (requires PKM_ENVIRONMENT=dev or PKM_SETTINGS_PROFILE=lab). "
+        "Use `watcher run` for production operation."
     ),
 )
 @click.option("--vault-root", type=click.Path(path_type=Path), required=True, help="Vault root path.")

--- a/app/cli/watcher.py
+++ b/app/cli/watcher.py
@@ -74,7 +74,7 @@ def watcher_once() -> None:
 
 @watcher_group.command(
     name="run",
-    help="Run the watcher registry loop continuously with operator summaries.",
+    help="Production-facing registry watcher: run the canonical watcher loop continuously with operator summaries (prod/dev environments).",
 )
 @click.option(
     "--config",
@@ -121,8 +121,9 @@ def watcher_run(config: Path, max_ticks: int | None) -> None:
 @click.command(
     name="vault-watcher-run",
     help=(
-        "Legacy/dev-only single-shot snapshot watcher (requires PKM_SETTINGS_PROFILE=lab): "
-        "detects changed notes via snapshot, ingests them, and optionally runs PanelAgent runtime."
+        "Dev-only single-shot snapshot watcher (requires PKM_ENVIRONMENT=dev or PKM_SETTINGS_PROFILE=lab): "
+        "detects changed notes via snapshot, ingests them, and optionally runs PanelAgent runtime. "
+        "Use `watcher run` for production operation."
     ),
 )
 @click.option(
@@ -221,8 +222,9 @@ def vault_watcher_run(
 @click.command(
     name="vault-watcher-daemon",
     help=(
-        "Legacy/dev-only snapshot daemon (requires PKM_SETTINGS_PROFILE=lab): "
-        "polls for changed notes and runs ingest/panel."
+        "Dev-only snapshot daemon (requires PKM_ENVIRONMENT=dev or PKM_SETTINGS_PROFILE=lab): "
+        "polls for changed notes and runs ingest/panel. "
+        "Use `watcher run` for production operation."
     ),
 )
 @click.option(

--- a/app/settings/tiering.py
+++ b/app/settings/tiering.py
@@ -68,11 +68,18 @@ def resolve_dev_lab_env_typed(
 
 
 def require_lab_profile(*, command_name: str) -> None:
+    # Check both legacy profile (lab) and new environment model (dev)
     if is_lab_profile():
         return
+
+    # Also check the explicit environment model
+    from app.config.environment import is_dev_environment
+    if is_dev_environment():
+        return
+
     raise RuntimeError(
-        f"{command_name} is legacy/dev-only and requires {PROFILE_ENV}={LAB_PROFILE}. "
-        "Use `python -m app.cli watcher run` for operator runtime."
+        f"{command_name} is dev-only and requires {PROFILE_ENV}={LAB_PROFILE} or PKM_ENVIRONMENT=dev. "
+        "Use `python -m app.cli watcher run` for production operation."
     )
 
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -59,6 +59,23 @@ When the issue is health semantics or degraded-state rules, switch to `docs/HEAL
 
 Use this section only when the issue is specifically about watcher deployment, config, or execution mode.
 
+### Watcher entrypoint classification
+
+Entrypoints are explicitly classified by environment per `docs/ENVIRONMENTS.md`:
+
+**Production-facing entrypoint:**
+- `python -m app.cli watcher run` — canonical production registry watcher (prod/dev)
+  - Multi-spec watcher registry loop, artifact path and state separation by environment
+  - Supports both `prod` and `dev` environments via `PKM_ENVIRONMENT` or profile-based inference
+  - This is the entrypoint for the current production baseline
+
+**Dev-only legacy entrypoints (require `PKM_ENVIRONMENT=dev` or `PKM_SETTINGS_PROFILE=lab`):**
+- `python -m app.cli vault-watcher-run` — single-shot snapshot watcher (historical implementation)
+- `python -m app.cli vault-watcher-daemon` — snapshot daemon (historical implementation)
+- `python -m app.cli runtime-loop` — watcher → panel → promotion loop (historical test path)
+
+The legacy entrypoints are retained for lab/dev workflows but should not be used for production operation. Use `watcher run` for all production-facing and standard dev runtimes.
+
 Watcher auto-exec enablement rule:
 - Treat `python -m app.cli settings-explain` plus `python -m app.cli status` as the canonical enablement check.
 - `WATCHER_AUTO_EXEC=1` is necessary to arm panel auto-exec, but it is not sufficient on its own to prove rollout safety.

--- a/docs/runbooks/RUNBOOK_STARTUP_FULL_SYSTEM.md
+++ b/docs/runbooks/RUNBOOK_STARTUP_FULL_SYSTEM.md
@@ -27,6 +27,10 @@ make alpha-up
 
 ## Alpha Compose Runtime (canonical)
 - Services: `db`, `api`, `watcher`, `worker`.
+- The watcher runs the production-facing registry loop (`python -m app.cli watcher run`) and is environment-aware:
+  - In `prod` (default), artifact paths and state are scoped to base directories (`tmp/`, `vault/`)
+  - In `dev` (via `PKM_ENVIRONMENT=dev` or `PKM_SETTINGS_PROFILE=lab`), artifact paths are scoped to `-dev` subdirectories (`tmp-dev/`, `vault-dev/`)
+  - For the Compose runtime, watcher is deployed in a container and auto-selects environment based on inherited settings
 - The watcher writes audit JSONL events and enqueues DB outbox events (`ingest.vault.changed`, `panel.scan.requested`).
 - The worker consumes the DB outbox to perform ingest, panel, and promotion side effects, emitting `panel.intent.*`, `promote.intent.created`, and `promote.done` on success.
 - Inbox UUID healing is performed by the worker on `ingest.vault.changed` for notes under the inbox folder (from `vault.layout.md` or `VAULT_INBOX_DIR_REL`) so notes do not linger without `uuid:` after a worker pass.

--- a/tests/cli/test_entrypoint_environment_classification.py
+++ b/tests/cli/test_entrypoint_environment_classification.py
@@ -1,0 +1,183 @@
+"""Tests for environment-aware entrypoint classification and guards.
+
+This test module verifies that CLI entrypoints are explicitly classified as prod,
+dev, or lab-only per the environment model defined in ENVIRONMENTS.md.
+
+Focus areas:
+- Registry watcher (prod/dev) vs legacy watchers (dev-only)
+- Runtime loop (dev-only)
+- Startup/reset commands
+- Help text clarity for environment classification
+"""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+from pathlib import Path
+
+from app.cli import cli
+from app.cli.watcher import watcher_group
+from app.config.environment import (
+    ENV_DEV,
+    ENV_PROD,
+    ENVIRONMENT_ENV,
+    LAB_PROFILE,
+    OPERATOR_PROFILE,
+    PROFILE_ENV,
+)
+from app.settings.tiering import require_lab_profile
+
+pytestmark = pytest.mark.not_pg
+
+
+class TestWatcherEntrypointClassification:
+    """Test that watcher entrypoints are correctly classified by environment."""
+
+    def test_registry_watcher_run_help_documents_prod_facing(self) -> None:
+        """Registry watcher run command help should document it as production-facing."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["watcher", "run", "--help"])
+        assert result.exit_code == 0
+        assert "production-facing" in result.output.lower()
+        assert "registry watcher" in result.output.lower()
+
+    def test_legacy_vault_watcher_run_help_documents_dev_only(self) -> None:
+        """Legacy vault-watcher-run help should clearly mark it as dev-only."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["vault-watcher-run", "--help"])
+        assert result.exit_code == 0
+        assert "dev-only" in result.output.lower()
+        assert "legacy" not in result.output.lower()  # "dev-only" is the modern term
+        assert "watcher run" in result.output.lower()
+
+    def test_legacy_vault_watcher_daemon_help_documents_dev_only(self) -> None:
+        """Legacy vault-watcher-daemon help should clearly mark it as dev-only."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["vault-watcher-daemon", "--help"])
+        assert result.exit_code == 0
+        assert "dev-only" in result.output.lower()
+        assert "legacy" not in result.output.lower()  # "dev-only" is the modern term
+        assert "watcher run" in result.output.lower()
+
+    def test_vault_watcher_run_requires_lab_profile(self) -> None:
+        """vault-watcher-run should enforce lab profile requirement."""
+        # When called without PKM_SETTINGS_PROFILE=lab, it should fail
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["vault-watcher-run", "--vault-root", "/tmp/vault"],
+            env={},
+        )
+        assert result.exit_code != 0
+        assert "dev-only" in result.output.lower() or "legacy" in result.output.lower()
+
+    def test_vault_watcher_daemon_requires_lab_profile(self) -> None:
+        """vault-watcher-daemon should enforce lab profile requirement."""
+        # When called without PKM_SETTINGS_PROFILE=lab, it should fail
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["vault-watcher-daemon", "--vault-root", "/tmp/vault"],
+            env={},
+        )
+        assert result.exit_code != 0
+        assert "dev-only" in result.output.lower() or "legacy" in result.output.lower()
+
+
+class TestRuntimeLoopEntrypointClassification:
+    """Test that runtime-loop is correctly classified as dev-only."""
+
+    def test_runtime_loop_help_documents_dev_only(self) -> None:
+        """runtime-loop help should clearly mark it as dev-only."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["runtime-loop", "--help"])
+        assert result.exit_code == 0
+        assert "dev-only" in result.output.lower()
+        assert "watcher run" in result.output.lower()
+
+    def test_runtime_loop_requires_lab_profile(self) -> None:
+        """runtime-loop should enforce lab profile requirement."""
+        # When called without PKM_SETTINGS_PROFILE=lab, it should fail
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["runtime-loop", "--vault-root", "/tmp/vault"],
+            env={},
+        )
+        assert result.exit_code != 0
+        assert "dev-only" in result.output.lower() or "legacy" in result.output.lower()
+
+
+class TestDevOnlyCommandsClassification:
+    """Test that other dev-only commands are classified appropriately."""
+
+    def test_alpha_human_flows_help_documents_dev_only(self) -> None:
+        """alpha-human-flows help should clearly mark it as dev-only."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["alpha-human-flows", "--help"])
+        assert result.exit_code == 0
+        assert "dev-only" in result.output.lower() or "testing" in result.output.lower()
+
+
+class TestRequireLabProfileFunction:
+    """Test the require_lab_profile enforcement function."""
+
+    def test_require_lab_profile_passes_in_lab(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """require_lab_profile should pass when PKM_SETTINGS_PROFILE=lab."""
+        monkeypatch.setenv(PROFILE_ENV, LAB_PROFILE)
+        try:
+            require_lab_profile(command_name="test")
+        except RuntimeError:
+            pytest.fail("require_lab_profile raised when lab profile was set")
+
+    def test_require_lab_profile_fails_in_operator(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """require_lab_profile should fail when PKM_SETTINGS_PROFILE=operator."""
+        monkeypatch.setenv(PROFILE_ENV, OPERATOR_PROFILE)
+        with pytest.raises(RuntimeError, match="dev-only|legacy"):
+            require_lab_profile(command_name="test")
+
+    def test_require_lab_profile_fails_in_prod_environment(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """require_lab_profile should fail when PKM_ENVIRONMENT=prod."""
+        monkeypatch.delenv(PROFILE_ENV, raising=False)
+        monkeypatch.setenv(ENVIRONMENT_ENV, ENV_PROD)
+        with pytest.raises(RuntimeError, match="dev-only|legacy"):
+            require_lab_profile(command_name="test")
+
+    def test_require_lab_profile_passes_in_dev_environment(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """require_lab_profile should pass when PKM_ENVIRONMENT=dev."""
+        monkeypatch.delenv(PROFILE_ENV, raising=False)
+        monkeypatch.setenv(ENVIRONMENT_ENV, ENV_DEV)
+        try:
+            require_lab_profile(command_name="test")
+        except RuntimeError:
+            pytest.fail("require_lab_profile raised when dev environment was set")
+
+
+class TestEnvironmentConsistency:
+    """Test that environment classification is consistent across the CLI."""
+
+    def test_prod_facing_commands_are_documented(self) -> None:
+        """Production-facing commands should have clear documentation."""
+        runner = CliRunner()
+        # Registry watcher is production-facing
+        result = runner.invoke(cli, ["watcher", "run", "--help"])
+        assert result.exit_code == 0
+        assert "production" in result.output.lower() or "operator" in result.output.lower()
+
+    def test_dev_only_commands_are_marked(self) -> None:
+        """Dev-only commands should explicitly say 'dev-only'."""
+        dev_only_commands = [
+            ["vault-watcher-run", "--help"],
+            ["vault-watcher-daemon", "--help"],
+            ["runtime-loop", "--help"],
+            ["alpha-human-flows", "--help"],
+        ]
+        runner = CliRunner()
+        for cmd_args in dev_only_commands:
+            result = runner.invoke(cli, cmd_args)
+            assert result.exit_code == 0
+            assert (
+                "dev-only" in result.output.lower()
+                or "legacy" in result.output.lower()
+            ), f"Command {cmd_args[0]} should be marked as dev-only in help"


### PR DESCRIPTION
## Summary
- CLI commands are now explicitly classified by environment (prod-facing vs dev-only)
- Registry watcher help text updated to document production-facing intent
- Legacy watcher commands and runtime-loop require dev environment (via explicit PKM_ENVIRONMENT=dev or legacy PKM_SETTINGS_PROFILE=lab)
- require_lab_profile() guard updated to respect both legacy profile mapping and new environment model
- 14 focused tests verify environment-aware entrypoint classification and guards

## Acceptance Criteria
✓ Relevant startup/watcher entrypoints explicitly classified as prod, dev, or lab-only
✓ Production-facing entrypoints (registry watcher) remain distinct from dev/lab-only flows
✓ Focused tests cover environment-aware entrypoint classification/guard behavior
✓ Owner docs/runbooks updated where entrypoint behavior changes

## Test Plan
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/cli/test_entrypoint_environment_classification.py -m "not pg"` — 14 tests verify environment classification
- `python -m app.cli watcher run --help` — help documents production-facing
- `python -m app.cli vault-watcher-run --help` — help documents dev-only
- `PKM_ENVIRONMENT=dev python -m app.cli vault-watcher-run` — env-aware guard accepts dev
- `python -m app.cli vault-watcher-run` — guard rejects prod (default)

📄 Implementation follows environment model from ENVIRONMENTS.md and aligns with issue #264 scope.

Fixes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)