### PR TITLE
feat: surface environment in health, status, and settings diagnostics

### DIFF
--- a/app/cli/__init__.py
+++ b/app/cli/__init__.py
@@ -11,6 +11,7 @@ import click
 import httpx
 from watchfiles import watch
 
+from app.config.environment import active_environment
 from app.observability.status_service import get_system_status
 from app.promotion.consumer import consume_promotion_intents
 from app.ingest.config import DEFAULT_VAULT_ROOT
@@ -1023,6 +1024,7 @@ def status() -> None:
     intents = getattr(status, "intents", None)
     events = getattr(status, "events", None)
 
+    click.echo(f"Environment: {active_environment()}")
     click.echo(f"SoT baseline: {baseline} (Reality-MVP, locked)")
     if forward_line:
         click.echo(f"SoT forward line: {forward_line} (PanelAgent + Watchers)")

--- a/app/cli/health.py
+++ b/app/cli/health.py
@@ -12,6 +12,7 @@ from typing import Any, Dict
 import httpx
 
 from app.components.llm.fabric import describe_default_route_policies, describe_default_routes
+from app.config.environment import active_environment
 from app.eval.llm_client import DEFAULT_MODE as DEFAULT_EVAL_MODE
 from app.knowledge.errors import KnowledgeConfigError
 from app.knowledge.health import obsidian_dependency_status
@@ -604,5 +605,5 @@ def run_health(*, trace_id: str | None = None, **kwargs: Any) -> Dict[str, Any]:
     ok = bool(checks_ok and runtime_ok)
     required_ok = bool(_required_checks_ok(checks) and runtime_ok)
     suggested_actions = _suggested_actions(checks, runtime)
-    return {"ok": ok, "required_ok": required_ok, "checks": checks, "runtime": runtime, "trace_id": trace_id, "suggested_actions": suggested_actions}
+    return {"environment": active_environment(), "ok": ok, "required_ok": required_ok, "checks": checks, "runtime": runtime, "trace_id": trace_id, "suggested_actions": suggested_actions}
 __all__ = ["run_health"]

--- a/app/cli/health_contract.py
+++ b/app/cli/health_contract.py
@@ -12,6 +12,7 @@ def emit_health_contract_status(as_json: bool) -> None:
     if as_json:
         click.echo(json.dumps(payload, ensure_ascii=False, indent=2))
         return
+    click.echo(f"environment: {payload['environment']}")
     click.echo(f"state: {payload['state']}")
     click.echo(f"reason: {payload['reason']}")
     click.echo(f"since: {payload['since_ts']}")

--- a/app/cli/settings_explain.py
+++ b/app/cli/settings_explain.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from typing import Any, Sequence
 
+from app.config.environment import active_environment
 from app.health_contract import DEFAULT_CONTRACT
 from app.settings.panel_actions_settings import load_panel_actions_settings, panel_action_ids
 from app.settings.watcher_settings import invalid_allowed_actions, load_watcher_settings, resolve_auto_exec_state
@@ -16,6 +17,7 @@ def build_settings_explain_payload() -> dict[str, Any]:
     invalid_actions = invalid_allowed_actions(watcher_settings, allowed_action_ids)
     write_guard = DEFAULT_CONTRACT.evaluate()
     return {
+        "environment": active_environment(),
         "panel_actions": {
             "action_count": len(panel_settings.catalog.actions),
             "action_ids": sorted(panel_settings.catalog.ids()),

--- a/app/health_contract.py
+++ b/app/health_contract.py
@@ -7,6 +7,7 @@ from datetime import timezone, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+from app.config.environment import active_environment
 from app.config.paths import resolve_vault_root
 from app.events.outbox import event_name, latest_trace_story, normalize_timestamp, read_outbox
 from app.index.doctor import diagnose_index
@@ -168,6 +169,7 @@ class HealthContract:
                     )
 
         result = {
+            "environment": active_environment(),
             "state": state,
             "reason": reason,
             "since_ts": since_ts,
@@ -306,6 +308,7 @@ class HealthContract:
     ) -> dict[str, Any]:
         entry: dict[str, Any] = {
             "ts": now.isoformat(),
+            "environment": active_environment(),
             "state": state,
             "reason": reason,
             "since_ts": since_ts,

--- a/app/observability/status_model.py
+++ b/app/observability/status_model.py
@@ -131,6 +131,7 @@ class WatcherAutomationStatus(BaseModel):
 
 class SystemStatus(BaseModel):
     timestamp: datetime
+    environment: str
     sot_version: str  # legacy alias for baseline SoT
     sot_baseline_version: str
     sot_forward_line_version: str

--- a/app/observability/status_service.py
+++ b/app/observability/status_service.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Iterable
 
+from app.config.environment import active_environment
 from app.events.types import PROMOTE_INTENT_CREATED, PROMOTE_DONE
 from app.observability.ingest_meta import get_ingest_status
 from app.observability.status_model import (
@@ -643,6 +644,7 @@ def get_system_status() -> SystemStatus:
     intent_status = _get_intent_status(counters)
     return SystemStatus(
         timestamp=datetime.now(timezone.utc),
+        environment=active_environment(),
         sot_version=get_sot_version(),
         sot_baseline_version=sot_meta["baseline"],
         sot_forward_line_version=sot_meta["forward_line"],

--- a/docs/HEALTH.md
+++ b/docs/HEALTH.md
@@ -26,7 +26,8 @@ python -m app.cli health --json
 ```bash
 python -m app.cli health status --json
 ```
-- Emits the `HealthContract` snapshot (`state`, `reason`, `outbox_recent_age_s`, `catch_up_progress`, etc.).
+- Emits the `HealthContract` snapshot (`environment`, `state`, `reason`, `outbox_recent_age_s`, `catch_up_progress`, etc.).
+- `environment` reflects the resolved runtime environment (`dev` or `prod`); controlled by `PKM_ENVIRONMENT` env var or implicit from `PKM_SETTINGS_PROFILE` (see `docs/ENVIRONMENTS.md`).
 - `catch_up_progress` reports how the worker interprets its active queue (DB outbox when `STORE_BACKEND=pg`), while the JSONL audit log (`INDEX_OUTBOX_PATH`) is used for lag/idle detection.
 - The worker heartbeat file (`$WORKER_HEARTBEAT_PATH`) is the signal the Docker healthcheck verifies; the contract observes the latest heartbeat timestamp too.
 

--- a/tests/cli/test_health_contract_cli.py
+++ b/tests/cli/test_health_contract_cli.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 
 from click.testing import CliRunner
 
-from app.cli import health
+from app.cli import health, cli
 from app.health_contract import reset_state_machine
 
 
@@ -33,6 +33,7 @@ def test_health_status_cli_json(monkeypatch, tmp_path: Path) -> None:
     result = CliRunner().invoke(health, ["status", "--json"])
     assert result.exit_code == 0
     payload = json.loads(result.output)
+    assert payload["environment"] in {"dev", "prod"}
     assert payload["state"] in {"running", "catch_up", "degraded", "recovery"}
     assert payload["index_doctor_status"] == "pass"
     assert payload["events_doctor_status"] == "pass"
@@ -42,3 +43,61 @@ def test_health_status_cli_json(monkeypatch, tmp_path: Path) -> None:
     assert payload["settings_source"]["path"].endswith("health.md")
     assert payload["writes_allowed"] is True
     assert payload["write_guard_reason"] is None
+
+
+def test_health_status_cli_environment_explicit_dev(monkeypatch, tmp_path: Path) -> None:
+    """Test that health status surfaces explicit dev environment."""
+    reset_state_machine()
+    monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+    outbox = tmp_path / "outbox.jsonl"
+    now = uuid4()
+    records = [
+        {"event": "watcher.run", "timestamp": "2024-01-01T00:00:00Z", "trace_id": str(now)},
+    ]
+    outbox.write_text("\n".join(json.dumps(r) for r in records), encoding="utf-8")
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox))
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path / "vault"))
+    monkeypatch.setattr(
+        "app.health_contract.diagnose_index",
+        lambda: {
+            "backend": "mock",
+            "expected_identity": {"provider": "test"},
+            "stored_identity": {"provider": "test"},
+            "issues": [],
+            "warnings": [],
+        },
+    )
+
+    result = CliRunner().invoke(health, ["status", "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["environment"] == "dev"
+
+
+def test_health_status_cli_environment_explicit_prod(monkeypatch, tmp_path: Path) -> None:
+    """Test that health status surfaces explicit prod environment."""
+    reset_state_machine()
+    monkeypatch.setenv("PKM_ENVIRONMENT", "prod")
+    outbox = tmp_path / "outbox.jsonl"
+    now = uuid4()
+    records = [
+        {"event": "watcher.run", "timestamp": "2024-01-01T00:00:00Z", "trace_id": str(now)},
+    ]
+    outbox.write_text("\n".join(json.dumps(r) for r in records), encoding="utf-8")
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox))
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path / "vault"))
+    monkeypatch.setattr(
+        "app.health_contract.diagnose_index",
+        lambda: {
+            "backend": "mock",
+            "expected_identity": {"provider": "test"},
+            "stored_identity": {"provider": "test"},
+            "issues": [],
+            "warnings": [],
+        },
+    )
+
+    result = CliRunner().invoke(health, ["status", "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["environment"] == "prod"

--- a/tests/cli/test_status_cli.py
+++ b/tests/cli/test_status_cli.py
@@ -18,6 +18,7 @@ from app.observability.status_model import (
 def test_status_cli_prints_snapshot(monkeypatch):
     snapshot = SystemStatus(
         timestamp=datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+        environment="prod",
         sot_version="vX",
         sot_baseline_version="v5.5",
         sot_forward_line_version="v5.6",
@@ -101,6 +102,7 @@ def test_status_cli_prints_snapshot(monkeypatch):
     result = runner.invoke(cli, ["status"])
 
     assert result.exit_code == 0, result.output
+    assert "Environment: prod" in result.output
     assert "SoT baseline: v5.5" in result.output
     assert "SoT forward line: v5.6" in result.output
     assert "Active features:" in result.output


### PR DESCRIPTION
Fixes #265

## Summary

Add environment-aware reporting to operator diagnostics so health, status, settings-explain, and incident-facing surfaces clearly identify the resolved environment (dev or prod) without changing underlying health/write-guard semantics.

## Changes

### Core Implementation
- **HealthContract**: Add `environment` field to `evaluate()` output via `active_environment()` 
- **Health CLI**: Surface environment in both JSON and text output modes
- **Settings Explain**: Add environment to settings explain payload  
- **Status CLI**: Add environment at the top of status output
- **SystemStatus API Model**: Add `environment` field and populate from `active_environment()`
- **Incident Logs**: Include environment in incident entries for full diagnostic traceability

### Documentation
- Update **HEALTH.md** to document environment field in health contract snapshot
- Note that environment is controlled by `PKM_ENVIRONMENT` env var or implicit from `PKM_SETTINGS_PROFILE`

### Tests
- Add assertion for environment field in `test_health_status_cli_json`
- Add `test_health_status_cli_environment_explicit_dev` to verify dev environment
- Add `test_health_status_cli_environment_explicit_prod` to verify prod environment  
- Update `test_status_cli_prints_snapshot` to include environment field and assertion

## Acceptance Criteria

- ✅ Health/status/settings-explain surfaces expose the resolved environment in a stable, operator-visible way
- ✅ Incident or diagnostic records carry environment identity where relevant
- ✅ Production-facing diagnostics remain conservative and compatible with current baseline
- ✅ Focused tests cover environment reporting on touched surfaces
- ✅ Owner docs updated when shipped diagnostics behavior changes

## Test Plan

- Verify `python -m app.cli health status --json` includes `"environment": "dev"` or `"prod"`
- Verify `python -m app.cli status` outputs `Environment: dev` or `Environment: prod`
- Verify `python -m app.cli settings-explain --json` includes `"environment"` field
- Verify `/api/status` endpoint JSON includes `"environment"` field
- Verify environment is correctly resolved from `PKM_ENVIRONMENT` and `PKM_SETTINGS_PROFILE`
- Run focused test suite: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/cli/test_health_contract_cli.py tests/cli/test_status_cli.py -m "not pg" -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)