### PR TITLE
docs: align lifecycle governance truth model

### DIFF
--- a/.codex/skills/backlog-reconciliation-drift-audit/SKILL.md
+++ b/.codex/skills/backlog-reconciliation-drift-audit/SKILL.md
@@ -26,7 +26,10 @@ You must detect:
 - duplicate Issues covering the same anchored source item
 - Issues in false Project status
 - issues missing required contract sections
+- open implementation Issues missing a truthful agent-state label
 - stale `agent:ready` labels on work that is blocked or already done
+- draft PR work or open PR work that was moved to `Review` before explicit review handoff
+- active work that still presents as `Ready`
 
 ## Authority order
 
@@ -76,6 +79,8 @@ For each drift case, recommend one concrete corrective action only:
 - Roadmap should remain forward-looking.
 - Status may note delivery, but lasting truth belongs in the owner doc.
 - GitHub remains the canonical backlog-state surface.
+- Treat Project `Status` as the primary lifecycle signal.
+- Treat `agent:ready` as the pickup qualifier for `Status=Ready`, not as a substitute for `In Progress`, `Review`, or `Done`.
 
 ## Output format
 

--- a/.codex/skills/docs-to-issue/SKILL.md
+++ b/.codex/skills/docs-to-issue/SKILL.md
@@ -99,7 +99,10 @@ Issue body must contain exactly these sections:
 - Set Status appropriately:
   - `Ready` only if bounded, testable, unblocked, and safe for agent execution
   - otherwise `Backlog`
-- Match `agent:ready`, `agent:blocked`, or `agent:needs-human` honestly.
+- Every new implementation Issue should leave creation with exactly one truthful agent-state label.
+- Use `agent:ready` only with `Status=Ready`.
+- Use `agent:blocked` or `agent:needs-human` only for non-active work, normally with `Status=Backlog`.
+- Do not leave delivered or closed work with any `agent:*` label.
 
 ## Output format
 

--- a/.codex/skills/issue-maintenance-change-control/SKILL.md
+++ b/.codex/skills/issue-maintenance-change-control/SKILL.md
@@ -35,10 +35,14 @@ You operate between:
 ## Canonical lifecycle expectations
 
 - Open backlog work should be present in the Project.
+- Open implementation Issues should normally carry exactly one truthful agent-state label.
 - Active implementation work should not remain `Ready`.
-- Open PR work should normally be `Review`.
+- Draft PRs and open PRs without explicit review handoff should normally remain `In Progress`.
+- `Review` starts only when the PR is the explicit review handoff artifact, normally after review is requested.
 - Delivered and merged work should normally be `Done`.
-- Closed Issues must not retain `agent:ready`.
+- `agent:ready` should only pair with `Status=Ready`.
+- `agent:blocked` and `agent:needs-human` should pair with non-active work, normally `Backlog`.
+- Closed Issues must not retain `agent:ready`, `agent:blocked`, or `agent:needs-human`.
 - If repo reality satisfies the Issue, the Issue and Project state should reflect that.
 
 ## Checks to perform
@@ -72,7 +76,8 @@ You operate between:
 
 ## Lifecycle correction rules
 
-- If an Issue is closed, remove `agent:ready`.
+- If an Issue is closed, remove any `agent:*` label.
+- If an open implementation Issue is malformed, stale, or no longer safely executable, do not leave it unlabeled or falsely `agent:ready`; normally use `agent:needs-human` with a non-active Project status.
 - If an Issue is delivered, Project Status should be `Done`.
 - If a PR is merged, Project Status should normally be `Done`.
 - If delivered work is still open because traceability is ambiguous, prefer `agent:needs-human` over false `agent:ready`.

--- a/.codex/skills/issue-to-code/SKILL.md
+++ b/.codex/skills/issue-to-code/SKILL.md
@@ -32,7 +32,7 @@ Treat these Issue sections as binding:
 - The agent is responsible for keeping Project status truthful while it works.
 - Do not leave actively worked Issues in `Ready`.
 - Do not leave blocked Issues in `In Progress`.
-- Do not leave PR-backed work outside `Review`.
+- Do not use `Review` only because a PR exists; keep work `In Progress` until review handoff is explicit.
 
 Allowed labels:
 
@@ -56,7 +56,7 @@ Allowed Project statuses:
 
 ## Issue selection rule before implementation
 
-- Work only from GitHub Issues labeled `agent:ready`.
+- Work only from GitHub Issues that are both `Status=Ready` and labeled `agent:ready`.
 - Among ready issues, pick one of the highest available priority:
   - `prio:high` before `prio:med` before `prio:low`
 - If several candidate issues share the same priority, use engineering judgment and prefer:
@@ -72,14 +72,15 @@ Allowed Project statuses:
 
 - Before starting implementation, ensure the selected Issue is present in Project `Agent Delivery Control Plane`.
 - If the Issue is missing from the Project, add it first.
-- When you begin active work on an Issue, set Project Status to `In Progress`.
+- When you begin active work on an Issue, set Project Status to `In Progress` and remove `agent:ready`.
 - If you determine the Issue is blocked before or during implementation:
   - do not continue coding
   - update labels and Project state truthfully
   - use `agent:blocked` when the work is blocked by dependency or setup
   - use `agent:needs-human` when the work requires a human decision or missing authority
   - move Project Status out of active execution if appropriate, normally back to `Backlog`
-- When you open a PR for the Issue, ensure Project Status is `Review`.
+- If you open a draft PR or keep implementing after opening a PR, keep Project Status at `In Progress`.
+- Move Project Status to `Review` only when the PR becomes the explicit review handoff artifact, normally after review is requested.
 - Do not leave actively worked Issues in `Ready`.
 - Do not leave blocked Issues in `In Progress` without an explicit blocker note and corrected labels.
 
@@ -117,7 +118,7 @@ When continuing through anchor drift:
 ## Implementation workflow
 
 1. Select the Issue according to priority and readiness rules.
-2. Ensure the Issue is in the Project and set Status to `In Progress`.
+2. Ensure the Issue is in the Project, set Status to `In Progress`, and remove `agent:ready`.
 3. Restate the bounded outcome from the Issue.
 4. Read source-anchored docs and owning code paths.
 5. If anchor drift exists, resolve it using the rules above before coding.
@@ -127,7 +128,7 @@ When continuing through anchor drift:
 9. Rewrite roadmap/plan wording if the delivered work was previously listed as pending.
 10. Run `Suggested Validation` plus any obviously necessary focused checks.
 11. Open or update a PR linked to the governing Issue.
-12. Ensure Project Status is `Review` once the PR is the active handoff artifact.
+12. Ensure Project Status is `Review` only once the PR is the active review handoff artifact.
 
 ## PR requirements
 

--- a/.codex/skills/verification-validation-feedback/SKILL.md
+++ b/.codex/skills/verification-validation-feedback/SKILL.md
@@ -65,10 +65,11 @@ Prioritize findings first:
 ## Lifecycle rules during verification
 
 - Verification owns terminal delivery-state correction.
+- An open or draft PR without explicit review handoff remains `In Progress`; `Review` is reserved for the review handoff state.
 - If the Issue is fully delivered and acceptance criteria are satisfied:
   - ensure the Issue is closed or recommended for closure
   - ensure Project Status is `Done`
-  - remove stale active-work labels such as `agent:ready`
+  - remove stale active-work labels such as `agent:ready`, `agent:blocked`, and `agent:needs-human`
 - If the PR is merged and the linked Issue is satisfied, the default expected state is:
   - Issue: closed
   - Project Status: `Done`
@@ -87,6 +88,7 @@ Prioritize findings first:
   - roadmap/plan text still reads as pending after delivery
   - owner doc not updated even though behavior shipped
   - issue still marked `agent:ready` or `Backlog` even though a merged PR already satisfies acceptance criteria
+  - issue or PR moved to `Review` even though explicit review handoff has not happened
 - If work is truly delivered:
   - confirm or recommend Issue closure and Project Status=`Done`
   - require owner-doc writeback

--- a/.github/github-governance.yml
+++ b/.github/github-governance.yml
@@ -24,6 +24,10 @@ labels:
     - agent:ready
     - agent:blocked
     - agent:needs-human
+  interpretation:
+    agent:ready: queue-eligible work when Status=Ready
+    agent:blocked: blocked by dependency or setup; normally non-active backlog work
+    agent:needs-human: blocked on human decision or missing authority; normally non-active backlog work
 project:
   name: Agent Delivery Control Plane
   type: github-project-v2
@@ -52,6 +56,12 @@ project:
       set_status: Review
     - event: pr_merged
       set_status: Done
+  interpretation:
+    status_is_primary_lifecycle_signal: true
+    ready_requires_agent_ready: true
+    in_progress_covers_open_pr_before_review_handoff: true
+    review_requires_explicit_review_handoff: true
+    done_requires_closed_issue_or_merged_delivery: true
 pull_requests:
   implementation:
     issue_reference_required: true
@@ -71,10 +81,11 @@ rules:
   pr_must_reference_issue_for_implementation: true
   docs_authoring_prs_may_skip_issue_reference: true
   docs_authoring_prs_must_be_docs_only: true
-  agents_only_pick: label:agent:ready
+  agents_only_pick: label:agent:ready + status:Ready
   agents_must_follow_issue_constraints: true
   agents_must_satisfy_acceptance: true
   no_free_form_tasks: true
   backlog_state_lives_in_github: true
   source_anchor_required_for_new_backlog_work: true
   inline_doc_receipts_are_secondary: true
+  closed_issues_must_not_keep_agent_labels: true

--- a/.github/workflows/issue-pr-governance.yml
+++ b/.github/workflows/issue-pr-governance.yml
@@ -2,7 +2,7 @@ name: Issue and PR Governance
 
 on:
   issues:
-    types: [opened, edited, reopened]
+    types: [opened, edited, reopened, labeled, unlabeled, closed]
   pull_request:
     types: [opened, edited, reopened, synchronize, review_requested]
 
@@ -12,6 +12,31 @@ permissions:
   pull-requests: read
 
 jobs:
+  issue-agent-labels:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const labels = (issue.labels || []).map(label => label.name);
+            const agentLabels = labels.filter(name => name.startsWith("agent:"));
+            if (agentLabels.length > 1) {
+              core.setFailed(`Issue must not carry more than one agent label at once: ${agentLabels.join(", ")}`);
+              return;
+            }
+            if (issue.state === "closed" && agentLabels.length) {
+              for (const name of agentLabels) {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  name,
+                });
+              }
+            }
+
   issue-shape:
     if: github.event_name == 'issues'
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ For implementation work, GitHub Issues are the canonical task contract.
 
 Builder-agent rules:
 
-- Only pick work from a GitHub Issue labeled `agent:ready`.
+- Only pick work from a GitHub Issue that is both `Status=Ready` and labeled `agent:ready`.
 - Read the full Issue before editing.
 - Treat `Context`, `Scope`, `Source Anchors`, `Constraints`, `Acceptance Criteria`, `Out of Scope`, `Suggested Validation`, and `Source Docs` as binding.
 - Link the PR back to the governing Issue using `Fixes #<id>`, `Closes #<id>`, or `Resolves #<id>`.
@@ -62,4 +62,5 @@ Builder-agent rules:
 - Do not create new backlog work in GitHub without stable `Source Anchors` that point to the most local governing doc items.
 - Prefer stable anchor IDs over prose fragments when the source doc is likely to produce multiple Issues over time.
 - Treat GitHub Issue + Project state as the canonical backlog receipt; inline doc markers such as `Tracked by: #...` are secondary convenience notes only.
+- Treat Project `Status` as the primary lifecycle signal. `agent:ready` is only the pickup qualifier for `Status=Ready`; blocked labels belong on non-active work, and closed issues must not retain `agent:*` labels.
 - When a PR delivers a tracked backlog item, update the owner doc to describe shipped reality and rewrite roadmap/plan wording so it no longer reads as pending work.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -459,7 +459,7 @@ Required label ontology:
 
 - type: `type:task`, `type:bug`, `type:refactor`
 - priority: `prio:high`, `prio:med`, `prio:low`
-- agent state: `agent:ready`, `agent:blocked`, `agent:needs-human`
+- agent qualifiers: `agent:ready`, `agent:blocked`, `agent:needs-human`
 
 Required Project state machine:
 
@@ -471,7 +471,12 @@ Optional Project field:
 
 Guardrails for builder agents:
 
-- Agents only pick Issues labeled `agent:ready`.
+- Project `Status` is the primary lifecycle signal.
+- `agent:ready` qualifies an Issue for pickup only when `Status=Ready`.
+- `In Progress` covers active implementation and open PR work before explicit review handoff.
+- `Review` begins only when review handoff is explicit, normally after review is requested.
+- Closed or delivered work must not retain `agent:*` labels.
+- Agents only pick Issues with `Status=Ready` and label `agent:ready`.
 - Agents must stay within the linked Issue scope.
 - Agents must respect the linked Issue constraints.
 - Agents must satisfy the linked Issue acceptance criteria before claiming completion.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -232,11 +232,12 @@ The repo now adopts a GitHub-based delivery control plane for implementation wor
 
 Delivery lifecycle:
 
-`Backlog -> Ready -> agent:ready -> In Progress -> Review -> Done`
+`Backlog -> Ready -> In Progress -> Review -> Done`
 
 Builder-agent rule:
 
-- agents only pick Issues labeled `agent:ready`
+- agents only pick Issues with `Status=Ready` and label `agent:ready`
+- `agent:ready` is the pickup qualifier for `Ready`, not a separate lifecycle state
 - agents must follow `Constraints`
 - agents must satisfy `Acceptance Criteria`
 - PRs must link the governing Issue

--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -82,7 +82,7 @@ For implementation work, the delivery loop is:
 Execution rule:
 
 - do not start non-trivial implementation without a governing Issue
-- prefer Issues labeled `agent:ready`
+- prefer Issues with `Status=Ready` and label `agent:ready`
 - use the linked Issue as the bounded source of truth for scope and acceptance
 - implementation PRs must link the governing Issue
 
@@ -90,7 +90,13 @@ Docs-authoring PRs are a separate lane and do not replace this implementation co
 
 Optional repo-local Codex skills may assist with either lane from `.codex/skills/`, but they do not replace the governing repo policy. Implementation-facing skills must still route work through the same `Docs -> Issue -> Project -> Agent -> PR -> CI -> Feedback` sequence and keep `AGENTS.md` as the canonical builder-agent policy surface.
 
-Optional repo-local Codex skills may assist with this loop from `.codex/skills/`, but they do not replace the Issue-first contract. Any such skill must route work through the same `Docs -> Issue -> Project -> Agent -> PR -> CI -> Feedback` sequence and keep `AGENTS.md` as the canonical builder-agent policy surface.
+Lifecycle truth rule:
+
+- `Status` is the primary lifecycle state machine.
+- `agent:ready` qualifies an Issue for pickup only when `Status=Ready`.
+- `In Progress` covers active implementation, including draft PRs and open PRs before explicit review handoff.
+- `Review` begins only when the PR becomes the explicit review handoff artifact, normally after review is requested.
+- closed or delivered work must not retain `agent:*` labels.
 
 ## Source-anchor rule for backlog creation
 

--- a/docs/development/GITHUB_GOVERNANCE_SETUP.md
+++ b/docs/development/GITHUB_GOVERNANCE_SETUP.md
@@ -35,6 +35,23 @@ Required fields:
 - `Status`: `Backlog`, `Ready`, `In Progress`, `Review`, `Done`
 - `Agent State`: `Idle`, `Running`, `Waiting`
 
+Status meanings:
+- `Backlog`: tracked work that is not yet ready for agent execution or has been moved out of active execution
+- `Ready`: bounded, testable, unblocked work that is eligible for pickup and labeled `agent:ready`
+- `In Progress`: active implementation, including draft PRs and open PRs before explicit review handoff
+- `Review`: explicit review handoff, normally after review is requested on the active PR
+- `Done`: merged or otherwise fully delivered work; the Issue is closed and no `agent:*` labels remain
+
+Agent-label meanings:
+- `agent:ready`: queue-eligible work; use only with `Status=Ready`
+- `agent:blocked`: blocked by dependency or setup; normally pair with a non-active status such as `Backlog`
+- `agent:needs-human`: blocked on human decision or missing authority; normally pair with a non-active status such as `Backlog`
+- open implementation Issues should normally carry exactly one truthful agent-state label
+
+Interpretation rule:
+- `Status` is the primary lifecycle signal.
+- Agent labels qualify pickup or blocker state; they do not replace `Status`.
+
 Required views:
 - `Kanban` grouped by `Status`
 - `Agent Queue` filtered to `label:agent:ready` and `Status = Ready`
@@ -45,12 +62,18 @@ Required automation:
 - PR review requested -> `Status=Review`
 - PR merged -> `Status=Done`
 
+Lifecycle guardrails:
+- active implementation must not remain `Ready`
+- `Review` must not be used only because a PR exists; use it when review handoff is explicit
+- closed issues must not retain `agent:ready`, `agent:blocked`, or `agent:needs-human`
+
 ## Enforcement intent
 
 - Issues are the canonical delivery task contract for implementation work.
 - Implementation PRs must reference an Issue using `Fixes #<id>`, `Closes #<id>`, or `Resolves #<id>`.
 - Docs-authoring PRs may omit an Issue reference only when they are explicitly classified as docs authoring and remain limited to approved docs-authoring surfaces.
 - Agents only pick Issues labeled `agent:ready`.
+- Agents only pick Issues when `Status=Ready` and the Issue is labeled `agent:ready`.
 - Agents must stay within Issue scope, constraints, and acceptance criteria.
 - Blank/free-form Issues are disabled at repo level.
 


### PR DESCRIPTION
## Linked Issue
Fixes #279

## Summary
- make `Status` the explicit primary lifecycle signal across the governing docs, governance contract, and repo-local execution skills
- narrow `agent:ready` to the `Status=Ready` pickup state and distinguish blocked labels from active execution
- align the lifecycle split so open or draft PR work stays `In Progress` until explicit review handoff, while merged delivery ends at `Done`
- add a narrow workflow guard that removes stale `agent:*` labels from closed issues and rejects multiple agent labels at once
- repair live GitHub drift for the current governance issue plus affected closed issue and merged PR project items

## Canonical Lifecycle Now Enforced
- `Backlog`: tracked work that is not yet ready or has been moved out of active execution
- `Ready`: bounded, unblocked, safe to pick up, no active implementation, labeled `agent:ready`
- `In Progress`: active implementation, including draft PRs and open PRs before explicit review handoff
- `Review`: explicit review handoff, typically after review is requested on the active PR
- `Done`: merged and satisfied, with lifecycle state and labels corrected truthfully

## Canonical Label Meanings Now Enforced
- `agent:ready`: bounded, unblocked, safe to pick up, and not under active implementation
- `agent:blocked`: blocked by dependency, setup, or runtime precondition; not actively executable
- `agent:needs-human`: requires a human decision, missing authority, or task-contract correction
- `agent:ready` is not left on draft PR work, active implementation, blocked work, malformed work, or delivered work

## Draft PR / Review Handoff Interpretation
- draft PRs remain `In Progress`
- open non-draft PRs remain `In Progress` until review handoff is explicit
- `Review` is reserved for the explicit review handoff state, not merely the existence of a PR

## Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when governance/contracts changed.
- [x] Live Issue/Project state corrections were applied where the available tools made that safe.

## Drift Cases Corrected In This Pass
- `#279`: removed stale `agent:ready`, moved to `Status=In Progress`
- `#251`, `#264`, `#265`, `#275`, `#277`: removed stale `agent:ready` from closed issues
- `#265`, `#275`, `#277`: corrected issue Project status to `Done`
- merged PR project items `#249`, `#253`-`#257`, `#259`-`#270`, `#276`, and `#278`: backfilled to `Done`
- `#273`: marked `agent:needs-human` because the open issue is stale/malformed and should not present as ready backlog work

## Intentionally Left As Follow-up
- closed-but-unmerged PR `#258` was left unchanged rather than falsely marked delivered
- `#273` was not silently rewritten or closed in this PR; only the label truth was corrected because the task contract itself needs issue-maintenance follow-up

## Validation
- [x] `python3 scripts/docs_guard.py`
- [x] `python3 scripts/validate_source_anchors.py "$(gh issue view 279 --repo RasmusTho/agentic-pkm-mvp --json body -q .body)"`
- [x] `python3 - <<'PY' ... yaml.safe_load(...) ... PY` for `.github/github-governance.yml` and `.github/workflows/issue-pr-governance.yml`
- [x] `python3 - <<'PY' ... PY` workflow sanity samples for agent-label cleanup and conflict detection
- [x] `python3 - <<'PY' ... PY` skill-file sanity check for touched repo-local skills
- [x] `git diff --check`

## Notes
- This is governance alignment and Project/label correction only; no runtime code paths changed.
