### PR TITLE
test: close issue 265 verification gap

### DIFF
--- a/app/cli/__init__.py
+++ b/app/cli/__init__.py
@@ -1024,7 +1024,7 @@ def status() -> None:
     intents = getattr(status, "intents", None)
     events = getattr(status, "events", None)
 
-    click.echo(f"Environment: {active_environment()}")
+    click.echo(f"Environment: {status.environment}")
     click.echo(f"SoT baseline: {baseline} (Reality-MVP, locked)")
     if forward_line:
         click.echo(f"SoT forward line: {forward_line} (PanelAgent + Watchers)")

--- a/tests/cli/test_settings_explain_cli.py
+++ b/tests/cli/test_settings_explain_cli.py
@@ -3,6 +3,34 @@ from __future__ import annotations
 from app.cli.settings_explain import build_settings_explain_payload
 
 
+def test_settings_explain_surfaces_explicit_environment(monkeypatch, tmp_path) -> None:
+    vault = tmp_path / "vault"
+    settings_dir = vault / "@Settings"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    (settings_dir / "watchers.md").write_text("---\n---\n", encoding="utf-8")
+    panel_actions = tmp_path / "panel-actions.md"
+    panel_actions.write_text(
+        "---\n"
+        "mappings:\n"
+        "  - id: promote.evergreen\n"
+        "    label: Promote\n"
+        "    intent_type: promotion\n"
+        "    downstream_event: promote.intent.created\n"
+        "    params:\n"
+        "      maturity: evergreen\n"
+        "---\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("VAULT_ROOT", str(vault))
+    monkeypatch.setenv("PANEL_ACTIONS_PATH", str(panel_actions))
+    monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+
+    payload = build_settings_explain_payload()
+
+    assert payload["environment"] == "dev"
+
+
 def test_settings_explain_includes_watcher_gate_and_allowlist(monkeypatch, tmp_path) -> None:
     vault = tmp_path / "vault"
     settings_dir = vault / "@Settings"


### PR DESCRIPTION
## Summary
- add a focused regression test that verifies `settings-explain` surfaces the resolved environment
- make the human-readable `status` CLI print `status.environment` from the computed snapshot
- re-run the focused issue 265 verification suite

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/python -m pytest -q -c /dev/null tests/cli/test_health_contract_cli.py tests/cli/test_status_cli.py tests/cli/test_settings_explain_cli.py -m 'not pg'`
- `PKM_ENVIRONMENT=dev /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/python -m app.cli settings-explain --compact`
- `PKM_ENVIRONMENT=dev /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/python -m app.cli status`

Fixes #265