### PR TITLE
Expand deterministic verification harness

### DIFF
--- a/app/memory/store.py
+++ b/app/memory/store.py
@@ -69,6 +69,21 @@ def _recall_in_memory(agent: str, kind: str, object_id: Optional[str], limit: in
     return [dict(entry[1]) for entry in entries[:limit]]
 
 
+def _decay_in_memory(agent: str, kind: str, before_ts: datetime) -> int:
+    total_deleted = 0
+    for key, entries in list(_IN_MEMORY_STORE.items()):
+        key_agent, key_kind, _ = key
+        if key_agent != agent or key_kind != kind:
+            continue
+        kept = [entry for entry in entries if entry[0] >= before_ts]
+        total_deleted += len(entries) - len(kept)
+        if kept:
+            _IN_MEMORY_STORE[key] = kept
+        else:
+            _IN_MEMORY_STORE.pop(key, None)
+    return total_deleted
+
+
 def remember(agent: str, kind: str, object_id: Optional[str], trace_id: str, data: dict) -> None:
     if not _enabled():
         return
@@ -154,18 +169,7 @@ def decay(agent: str, kind: str, *, before_ts: Optional[datetime] = None) -> int
 
     conn = _safe_connect(rowed=False)
     if conn is None:
-        total_deleted = 0
-        for key, entries in list(_IN_MEMORY_STORE.items()):
-            key_agent, key_kind, _ = key
-            if key_agent != agent or key_kind != kind:
-                continue
-            kept = [entry for entry in entries if entry[0] >= before_ts]
-            total_deleted += len(entries) - len(kept)
-            if kept:
-                _IN_MEMORY_STORE[key] = kept
-            else:
-                _IN_MEMORY_STORE.pop(key, None)
-        return total_deleted
+        return _decay_in_memory(agent, kind, before_ts)
 
     try:
         with conn:
@@ -182,6 +186,6 @@ def decay(agent: str, kind: str, *, before_ts: Optional[datetime] = None) -> int
                 )
                 return cur.rowcount or 0
     except psycopg.errors.UndefinedTable:
-        return 0
+        return _decay_in_memory(agent, kind, before_ts)
     finally:
         conn.close()

--- a/tests/config/test_environment.py
+++ b/tests/config/test_environment.py
@@ -55,9 +55,10 @@ class TestEnvironmentResolution:
         assert active_environment({ENVIRONMENT_ENV: "  dev  "}) == ENV_DEV
         assert active_environment({ENVIRONMENT_ENV: "  prod  "}) == ENV_PROD
 
-    def test_invalid_explicit_environment_defaults_to_prod(self) -> None:
-        """Invalid PKM_ENVIRONMENT values should default to prod."""
-        assert active_environment({ENVIRONMENT_ENV: "invalid"}) == ENV_PROD
+    def test_invalid_explicit_environment_raises_value_error(self) -> None:
+        """Invalid PKM_ENVIRONMENT values should raise so operators fix their input."""
+        with pytest.raises(ValueError):
+            active_environment({ENVIRONMENT_ENV: "invalid"})
         assert active_environment({ENVIRONMENT_ENV: ""}) == ENV_PROD
         assert active_environment({ENVIRONMENT_ENV: "   "}) == ENV_PROD
 

--- a/tests/ops/test_acceptance_harness_cli.py
+++ b/tests/ops/test_acceptance_harness_cli.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.not_pg
+def test_ops_quality_acceptance_harness_runs(tmp_path: Path) -> None:
+    vault_path = Path("docs/examples/vault_test_seed").resolve()
+    assert vault_path.exists(), "golden vault seed must exist"
+
+    env = {**os.environ, "PYTHONPATH": str(Path.cwd())}
+    result = subprocess.run(
+        [sys.executable, "-m", "ops.quality.acceptance_test", "--vault", str(vault_path)],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(Path.cwd()),
+        check=True,
+    )
+
+    stderr = result.stderr
+    assert "CI SUMMARY GATES ok=True" in stderr, "expect acceptance harness to report success"

--- a/tests/watcher/test_registry_outbox_enqueue_logging.py
+++ b/tests/watcher/test_registry_outbox_enqueue_logging.py
@@ -44,6 +44,7 @@ def test_registry_logs_db_outbox_enqueue_failures_with_context(
         raise RuntimeError("boom")
 
     monkeypatch.setattr("app.services.outbox.insert_object_and_outbox", boom)
+    monkeypatch.setattr(registry.__name__ + ".insert_object_and_outbox", boom)
 
     monkeypatch.setenv("STORE_BACKEND", "memory")
     monkeypatch.setenv("WATCHER_ENABLE", "1")
@@ -55,6 +56,11 @@ def test_registry_logs_db_outbox_enqueue_failures_with_context(
     monkeypatch.setenv("WATCHER_DEBOUNCE_MS", "0")
     monkeypatch.setenv("WATCHER_REQUIRE_DB_OUTBOX", "0")
     monkeypatch.setenv("INDEX_OUTBOX_PATH", str(tmp_path / "outbox.jsonl"))
+
+    stop_file = tmp_path / "stop"
+    monkeypatch.setenv("WATCHER_STOP_FILE", str(stop_file))
+    if stop_file.exists():
+        stop_file.unlink()
 
     monkeypatch.setenv("DB_DSN", "postgresql://example.invalid")
 


### PR DESCRIPTION
## Summary
- keep the in-memory memory store decay path deterministic even when the Postgres schema is missing so the memory suite passes
- adjust the environment test to match the new enforced validation and ensure the watcher enqueue failure test exercises the failure path without hitting the shared `WATCHER_STOP`
- add a deterministic CLI test for `ops.quality.acceptance_test` seeds so the golden vault UAT harness is exercised in the standard `tests/` tree

## Testing
- `PYTHONPATH="$(pwd)" STORE_BACKEND=memory LLM_PROVIDER=mock REASONING_PROVIDER=mock PLANNER_PROVIDER=mock REASONING_ENABLE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 KNOWLEDGE_PRIMARY_ADAPTER=fs_vault KNOWLEDGE_FALLBACK_ADAPTER=obsidian_cli KNOWLEDGE_STRICT_STARTUP=0 KNOWLEDGE_ALLOW_FALLBACK=0 INDEX_PERSIST_PATH=tmp/index.jsonl pytest -c /dev/null -q -m "not pg and not alpha_llm and not eval and not human_uat" --durations=30`
- `PYTHONPATH="$(pwd)" ... pytest -q tests/ops/test_acceptance_harness_cli.py -m "not pg"`
- `PYTHONPATH="$(pwd)" ... pytest -q tests/watcher/test_registry_outbox_enqueue_logging.py::test_registry_logs_db_outbox_enqueue_failures_with_context`