### PR TITLE
Fix orchestrator runtime typing

### DIFF
--- a/app/orchestrator/runtime.py
+++ b/app/orchestrator/runtime.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Dict, List, Mapping, MutableMapping, Set, Union
+from typing import Any, Callable, Dict, List, Mapping, MutableMapping, Set
 
 from app.planner.schema import Plan, PlanStep
 
@@ -64,7 +64,7 @@ class Orchestrator:
     def __init__(self, executor: PlanExecutor | None = None, *, tool_settings: Mapping[str, Any] | None = None) -> None:
         self._executor = executor or MockPlanExecutor()
         self._tool_settings = dict(tool_settings) if tool_settings else None
-        self._run_plan_impl = None  # Can be set by factory to use alternate implementation
+        self._run_plan_impl: Callable[[Plan], List[Dict[str, Any]]] | None = None
 
     def run_plan(self, plan: Plan) -> List[Dict[str, Any]]:
         # If using alternate implementation (e.g., V2), delegate to it

--- a/app/orchestrator/v2_runtime.py
+++ b/app/orchestrator/v2_runtime.py
@@ -14,7 +14,8 @@ Preserves:
 from __future__ import annotations
 
 from collections import defaultdict
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+import time
 from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Set
 
 from app.planner.schema import Plan, PlanMetadata, PlanStep
@@ -187,7 +188,7 @@ class OrchestratorV2:
 
         # Execute with parallel scheduling
         with ThreadPoolExecutor(max_workers=self._max_workers) as executor:
-            pending_futures: Dict[str, Any] = {}
+            pending_futures: Dict[Future[Dict[str, Any]], tuple[PlanStep, str]] = {}
 
             while not graph.all_steps_completed(completed_steps):
                 # Get steps that can run now
@@ -235,7 +236,7 @@ class OrchestratorV2:
                         step, step_id = pending_futures.pop(future)
 
                         try:
-                            output = future.result()
+                            output: Dict[str, Any] = future.result()
                             emit_step_finished(
                                 plan_id=plan.id,
                                 step=step,
@@ -469,7 +470,12 @@ class OrchestratorV2:
                 # Retries exhausted
                 raise
 
-    def _emit_retry_event(self, plan_id: str, step_id: str, attempt: int, trace_id: str) -> None:
+        raise StepExecutionError(
+            last_error or f"step '{step.id}' failed after retry handling",
+            error_type=last_error_type,
+        )
+
+    def _emit_retry_event(self, plan_id: str, step_id: str, attempt: int, trace_id: str | None) -> None:
         """Emit a retry event."""
         if not self._outbox:
             return
@@ -501,7 +507,7 @@ class OrchestratorV2:
         self._checkpoint_store.save_checkpoint(checkpoint_key, checkpoint_data)
         self._emit_checkpoint_event(plan.id, len(completed_steps), plan.meta.trace_id)
 
-    def _emit_checkpoint_event(self, plan_id: str, step_count: int, trace_id: str) -> None:
+    def _emit_checkpoint_event(self, plan_id: str, step_count: int, trace_id: str | None) -> None:
         """Emit a checkpoint creation event."""
         if not self._outbox:
             return


### PR DESCRIPTION
Fixes #299

## Summary
- type the V1 orchestrator delegate hook as an optional callable instead of `None`
- fix V2 future-tracking annotations to match the actual `Future -> (step, step_id)` map
- align V2 retry/checkpoint helpers with optional trace IDs and add the missing `time` import

## Validation
- `/Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/ruff check app/orchestrator/runtime.py app/orchestrator/v2_runtime.py`
- `/Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/python -m mypy app/orchestrator/runtime.py app/orchestrator/v2_runtime.py`
- `/Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/python -m pytest -q tests/orchestration/v2/test_orchestrator_retry.py tests/orchestration/v2/test_orchestrator_checkpoints.py tests/orchestration/v2/test_orchestrator_compensation.py tests/orchestrator/test_orchestrator_runtime_external.py -m "not pg"`
