### PR TITLE
[codex] add PR integration skill before verification

### DIFF
--- a/.codex/skills/docs-to-issue/SKILL.md
+++ b/.codex/skills/docs-to-issue/SKILL.md
@@ -11,7 +11,7 @@ Your job is to convert active documentation into bounded GitHub Issues without i
 
 ## Canonical workflow
 
-`Docs -> Issue -> Project -> Issue maintenance -> Agent -> PR -> CI -> Verification -> Project/doc closure -> Owner Doc`
+`Docs -> Issue -> Project -> Issue maintenance -> Agent -> PR -> PR integration -> CI -> Verification -> Project/doc closure -> Owner Doc`
 
 Plus: periodic reconciliation.
 

--- a/.codex/skills/issue-to-code/SKILL.md
+++ b/.codex/skills/issue-to-code/SKILL.md
@@ -12,7 +12,7 @@ Only execute bounded implementation work from a GitHub Issue that is the canonic
 
 ## Canonical workflow
 
-`Docs -> Issue -> Project -> Issue maintenance -> Agent -> PR -> CI -> Verification -> Project/doc closure -> Owner Doc`
+`Docs -> Issue -> Project -> Issue maintenance -> Agent -> PR -> PR integration -> CI -> Verification -> Project/doc closure -> Owner Doc`
 
 Treat these Issue sections as binding:
 
@@ -128,7 +128,8 @@ When continuing through anchor drift:
 9. Rewrite roadmap/plan wording if the delivered work was previously listed as pending.
 10. Run `Suggested Validation` plus any obviously necessary focused checks.
 11. Open or update a PR linked to the governing Issue.
-12. Ensure Project Status is `Review` only once the PR is the active review handoff artifact.
+12. Run `.codex/skills/pr-integration/SKILL.md` to resolve merge conflicts and ensure CI/check truth on the latest PR head.
+13. Ensure Project Status is `Review` only once the PR is the active review handoff artifact.
 
 ## PR requirements
 

--- a/.codex/skills/pr-integration/SKILL.md
+++ b/.codex/skills/pr-integration/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: pr-integration
+description: "Prepare an implementation PR for verification by resolving merge conflicts, enforcing PR contract metadata, and ensuring CI is attached to the latest head."
+---
+
+# PR Integration
+
+Use this skill after `issue-to-code` implementation work and before the verification stage.
+
+Goal:
+produce a mergeable, policy-compliant PR with CI attached to the latest head SHA so verification can run on truthful state.
+
+## Canonical workflow position
+
+`Docs -> Issue -> Project -> Issue maintenance -> Agent -> PR -> PR integration -> CI -> Verification -> Project/doc closure -> Owner Doc`
+
+## First context to load
+
+- `AGENTS.md`
+- `docs/development/DEV_WORKFLOW.md`
+- `.github/pull_request_template.md`
+- `.github/workflows/issue-pr-governance.yml`
+- `.github/workflows/project-status-reconcile.yml`
+
+## Entry conditions
+
+- A bounded governing implementation Issue exists.
+- A PR exists (draft or ready) and links the governing branch.
+- Implementation changes are already in place.
+
+## Exit conditions
+
+- PR `mergeable` state is `MERGEABLE`.
+- No unresolved merge conflicts remain.
+- PR body/classification satisfies governance contract.
+- CI/checks are attached to the current head SHA and either:
+  - green and ready for verification handoff, or
+  - explicitly blocked with concrete failing jobs/log pointers.
+
+## Required gates
+
+### 1) Contract and metadata gate
+
+- Confirm PR lane classification is truthful:
+  - implementation lane must include `Fixes #<id>`, `Closes #<id>`, or `Resolves #<id>`
+  - docs/governance lanes must follow allowed-surface constraints from workflow policy
+- Ensure PR template checklists are not left in contradictory states.
+- Ensure linked Issue still matches actual scope; if scope drift occurred, stop and route through Issue maintenance.
+
+Operational checks:
+
+- `gh pr view <pr> --json number,state,isDraft,mergeable,headRefOid,baseRefName,labels,body,statusCheckRollup`
+- `gh pr checks <pr>`
+
+### 2) Mergeability gate
+
+- Query PR mergeability and head SHA first.
+- If merge conflicts exist:
+  - sync with latest base branch (`main`)
+  - rebase or merge base into the PR branch (follow repository norm)
+  - resolve conflicts without expanding scope beyond the governing Issue
+  - rerun focused validation for touched surfaces
+  - push updated branch and re-check mergeability
+- If mergeability remains blocked due ambiguity, mark as blocked and hand off with explicit conflict context.
+
+### 3) CI attachment gate
+
+- Verify checks are attached to the current PR head SHA.
+- If checks are missing on current head after a short wait, retrigger by a minimal deterministic change (for example an empty commit) or another allowed PR event.
+- Do not run verification against stale check results from an older SHA.
+
+### 4) CI result gate
+
+- Wait for required checks to complete.
+- If checks fail:
+  - capture failing jobs and log URLs
+  - fix within bounded scope when safe
+  - push and re-evaluate from mergeability + CI attachment gates
+- If checks pass, hand off to verification.
+
+## Lifecycle truth rules during integration
+
+- Keep Issue/Project state truthful:
+  - active work remains `In Progress`
+  - move to `Review` only when review handoff is explicit (normally after review requested)
+- Do not mark lifecycle `Done` in this stage.
+- Do not close the governing Issue in this stage.
+
+## Output format
+
+1. PR Integration Inputs
+2. Contract Gate Result
+3. Mergeability Actions
+4. CI Attachment and Status
+5. Handoff Decision
+
+Handoff decision must be exactly one of:
+
+- `ready-for-verification`
+- `blocked-merge-conflict`
+- `blocked-ci-failure`
+- `blocked-contract-drift`

--- a/.codex/skills/pr-integration/agents/openai.yaml
+++ b/.codex/skills/pr-integration/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PR Integration"
+  short_description: "Prepare PR state before verification"
+  default_prompt: "Use $pr-integration to make this PR mergeable, policy-compliant, and CI-attached before verification."

--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -115,7 +115,7 @@ Execution rule:
 
 Docs-authoring and governance-lane PRs are separate lanes and do not replace this implementation contract.
 
-Optional repo-local Codex skills may assist with either lane from `.codex/skills/`, but they do not replace the governing repo policy. Implementation-facing skills must still route work through the same `Docs -> Issue -> Project -> Agent -> PR -> CI -> Feedback` sequence and keep `AGENTS.md` as the canonical builder-agent policy surface.
+Optional repo-local Codex skills may assist with either lane from `.codex/skills/`, but they do not replace the governing repo policy. Implementation-facing skills must still route work through the same `Docs -> Issue -> Project -> Agent -> PR -> PR integration -> CI -> Feedback` sequence and keep `AGENTS.md` as the canonical builder-agent policy surface.
 
 Lifecycle truth rule:
 


### PR DESCRIPTION
## Change Lane
- [ ] Implementation lane
- [ ] Docs authoring lane
- [x] Governance lane

Docs authoring applies only to docs-only changes in approved docs-authoring surfaces. It must not be used for code, runtime behavior, contracts, shipped reality, or implementation writeback.
Governance lane applies to bounded repository-governance changes such as repo-local skills, PR/issue policy, and lightweight enforcement for docs/governance workflows. It must not be used for product/runtime implementation.

## Linked Issue
Fixes #

Required for implementation lane. Leave blank for docs authoring lane.
Leave blank for governance lane when the PR stays within approved governance surfaces.

## Summary
- Add a new `.codex/skills/pr-integration` skill for the handoff stage between implementation and verification.
- Define contract, mergeability, CI-attachment, and CI-result gates before verification.
- Update existing workflow references to include `PR integration` in the canonical sequence.

## Implementation Scope Check
- [ ] Change stays within the linked Issue scope.
- [ ] Constraints from the linked Issue were followed.
- [ ] Acceptance Criteria from the linked Issue are satisfied.
- [ ] Docs were updated in the same change when behavior/contracts changed.
- [ ] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [x] This PR only changes approved governance surfaces.
- [x] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [x] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [ ] `ruff check app tests`
- [ ] `mypy app`
- [ ] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg"`
- [ ] Additional targeted checks run as needed

Docs authoring lane:
- [ ] Docs/governance checks run as appropriate for the touched surfaces
- [ ] Any validation gaps or tooling limitations are stated explicitly

Governance lane:
- [x] Governance checks run as appropriate for the touched surfaces
- [x] Any validation gaps or tooling limitations are stated explicitly

## Notes
- Validation for this PR was limited to diff/consistency checks because it changes only skill/governance docs and metadata.
