### PR TITLE
Emit ordered multi-step panel plans from panel proposals

### DIFF
--- a/app/agents/panel_agent/planning.py
+++ b/app/agents/panel_agent/planning.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List
+from typing import Any, List
 
 from app.agents.panel_agent.intent import PanelActionIntent
 from app.events.panel import PanelIntentAction
@@ -11,6 +11,7 @@ from app.events.models import new_event
 
 
 _PANEL_AGENT_ID = "panel_agent.v5"
+_PANEL_PLAN_CONTRACT_VERSION = "panel.ordered.v1"
 
 
 def _is_promotion(action_id: str, action: PanelIntentAction | None) -> bool:
@@ -36,8 +37,16 @@ def _steps_for_actions(
 ) -> List[PlanStep]:
     steps: List[PlanStep] = []
     resolved = resolved or []
+    total = len(actions)
     for idx, action_id in enumerate(actions, start=1):
         action = next((candidate for candidate in resolved if candidate.id == action_id), None)
+        metadata: dict[str, Any] = {
+            "action_id": action_id,
+            "sequence_index": idx,
+            "sequence_total": total,
+            "ordered_contract": _PANEL_PLAN_CONTRACT_VERSION,
+        }
+        depends_on = [f"step-{idx - 1}"] if idx > 1 else []
         if _is_promotion(action_id, action):
             steps.append(
                 PlanStep(
@@ -47,7 +56,8 @@ def _steps_for_actions(
                     tool="promotion.emit_intent",
                     tool_args=_promotion_tool_args(action_id, note_uuid, action, instruction),
                     reason="Panel requested evergreen promotion",
-                    metadata={"action_id": action_id, "intent_type": "promotion"},
+                    depends_on=depends_on,
+                    metadata={**metadata, "intent_type": "promotion"},
                     agent_id=_PANEL_AGENT_ID,
                 )
             )
@@ -58,7 +68,8 @@ def _steps_for_actions(
                     kind="note",
                     description=f"Unhandled panel action: {action_id}",
                     reason="Panel action not yet mapped to a tool",
-                    metadata={"action_id": action_id},
+                    depends_on=depends_on,
+                    metadata=metadata,
                 )
             )
     return steps
@@ -81,6 +92,11 @@ def plan_panel_actions(intent: PanelActionIntent, *, event_id: str | None = None
         context={
             "panel_instruction": intent.instruction,
             "panel_actions": list(intent.actions),
+            "panel_plan": {
+                "contract_version": _PANEL_PLAN_CONTRACT_VERSION,
+                "ordered": True,
+                "action_ids": list(intent.actions),
+            },
             "source": intent.source,
         },
         tags=["panel", "panel_agent", "panel:planner"],

--- a/app/agents/panel_agent/runtime.py
+++ b/app/agents/panel_agent/runtime.py
@@ -106,13 +106,18 @@ def execute_panel_intent(intent_event: PanelIntentEvent, *, outbox_path: Path | 
 
     pipeline_mode = get_panel_agent_pipeline()
     if pipeline_mode == "planner":
-        triggered_ids = [a.id for a in state.action_results if a.checked and a.status == "triggered"]
-        if triggered_ids:
-            resolved_actions = [action for action in state.actions if action.id in triggered_ids]
+        planned_action_ids: list[str] = []
+        for result in state.action_results:
+            if not result.checked or result.status not in {"triggered", "logged"}:
+                continue
+            if result.id not in planned_action_ids:
+                planned_action_ids.append(result.id)
+        if planned_action_ids:
+            resolved_actions = [action for action in state.actions if action.id in planned_action_ids]
             state.panel_action_intent = PanelActionIntent(
                 note=intent_event.payload.note,
                 instruction=intent_event.payload.panel.instruction,
-                actions=triggered_ids,
+                actions=planned_action_ids,
                 resolved_actions=resolved_actions,
                 source="panel_agent",
             )

--- a/docs/PANEL_AGENT.md
+++ b/docs/PANEL_AGENT.md
@@ -99,8 +99,9 @@ Architectural reading note:
 - not as proof that every future cognition or capability boundary should be modeled as a dedicated event-emitting agent.
 
 ### Planner pipeline (opt-in)
-- `PANEL_AGENT_PIPELINE=planner` keeps the external runtime behaviour the same and also builds a `PanelActionIntent` for triggered actions, storing a plan via Planner (`plan_panel_actions`).
+- `PANEL_AGENT_PIPELINE=planner` keeps the external runtime behaviour the same and also builds a `PanelActionIntent` for ordered handled actions (`triggered` and `logged`), storing a plan via Planner (`plan_panel_actions`).
 - Plans include promotion steps mapped to the `promotion.emit_intent` tool. They can be executed via Orchestrator in a CLI-first path: `python -m app.cli panel-orchestrate-plan --plan-id <plan_id>`. Watcher-driven execution remains off for now.
+- Saved panel plans use an explicit ordered contract (`panel.ordered.v1`): plan context records the ordered action ids and each step carries sequence metadata plus a `depends_on` chain so orchestrator-facing execution order does not rely on list position alone.
 - Decider and pipeline are orthogonal toggles:
   - `PANEL_AGENT_DECIDER=rule|llm` selects how actions are chosen (default `rule`).
   - `PANEL_AGENT_PIPELINE=direct|planner` selects whether to emit promotion directly (default) or also create plans (planner mode).

--- a/tests/agents/panel_agent/test_panel_planner_pipeline.py
+++ b/tests/agents/panel_agent/test_panel_planner_pipeline.py
@@ -9,9 +9,10 @@ import pytest
 
 from app.agents.panel_agent.agent import run_panel_intent_for_note
 from app.agents.panel_agent.intent import PanelActionIntent
+from app.agents.panel_agent.planning import plan_panel_actions
 from app.agents.panel_agent.runtime import execute_panel_intent
 from app.agents.panel_agent.settings import get_panel_agent_pipeline
-from app.events.panel import NoteRef
+from app.events.panel import NoteRef, PanelActionMapping, PanelIntentAction
 from app.store import object_store as object_store_module
 from app.store.object_store import DomainObject, ObjectStore
 from app.stores.plan_store import get_plan_store, reset_plan_store
@@ -57,6 +58,21 @@ Please process this panel.
 """
 
 
+def _panel_markdown_multi(actions: list[tuple[str, bool]]) -> str:
+    lines = []
+    for label, checked in actions:
+        mark = "x" if checked else " "
+        lines.append(f"- [{mark}] {label}")
+    body = "\n".join(lines)
+    return f"""%% AI:Start %%
+## AI-instruktion
+Please process this panel.
+## AI-åtgärder
+{body}
+%% AI:End %%
+"""
+
+
 def _read_outbox(outbox_path: Path) -> list[dict]:
     if not outbox_path.exists():
         return []
@@ -78,6 +94,43 @@ def test_panel_action_intent_round_trip() -> None:
     assert restored.instruction == "Do things"
     assert restored.actions == ["promote.evergreen"]
     assert restored.source == "panel_agent"
+
+
+def test_plan_panel_actions_creates_ordered_step_chain() -> None:
+    note = NoteRef(uuid="abc-123", path="vault/Test.md", origin="vault")
+    intent = PanelActionIntent(
+        note=note,
+        instruction="Do things in order",
+        actions=["promote.evergreen", "note.archive"],
+        resolved_actions=[
+            PanelIntentAction(
+                id="promote.evergreen",
+                label="Promote",
+                checked=True,
+                mapping=PanelActionMapping(
+                    id="promote.evergreen",
+                    intent_type="promotion",
+                    downstream_event="review.promote.evergreen",
+                    params={"maturity": "evergreen"},
+                ),
+            )
+        ],
+        source="panel_agent",
+    )
+
+    plan = plan_panel_actions(intent, event_id="evt-123", trace_id="trace-123")
+
+    assert [step.id for step in plan.steps] == ["step-1", "step-2"]
+    assert plan.steps[0].depends_on == []
+    assert plan.steps[1].depends_on == ["step-1"]
+    assert plan.steps[0].metadata["sequence_index"] == 1
+    assert plan.steps[1].metadata["sequence_index"] == 2
+    assert plan.steps[1].metadata["sequence_total"] == 2
+    assert plan.context["panel_plan"] == {
+        "contract_version": "panel.ordered.v1",
+        "ordered": True,
+        "action_ids": ["promote.evergreen", "note.archive"],
+    }
 
 
 def test_pipeline_setting_defaults_and_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -139,4 +192,41 @@ def test_execute_panel_intent_planner_creates_plan(tmp_path: Path, monkeypatch: 
     assert plan.meta.source_object_uuid == note_uuid
     assert "panel" in plan.tags
     assert plan.trigger and plan.trigger.event_id == events[0].event_id
+    assert plan.context["panel_plan"]["ordered"] is True
+    assert plan.steps[0].metadata["ordered_contract"] == "panel.ordered.v1"
 
+
+def test_execute_panel_intent_planner_includes_logged_selected_actions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    note_uuid = str(uuid4())
+    outbox_path = tmp_path / "index-outbox.jsonl"
+    settings_path = _settings_file(tmp_path)
+    markdown = _panel_markdown_multi(
+        [
+            ("Gör denna anteckning evergreen", True),
+            ("Archive this note", True),
+        ]
+    )
+    _seed_note(note_uuid, markdown)
+
+    monkeypatch.setenv("PANEL_AGENT_PIPELINE", "planner")
+    monkeypatch.setenv("PANEL_ACTIONS_PATH", str(settings_path))
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    monkeypatch.setattr("app.agents.panel_agent.agent.INDEX_OUTBOX_PATH", outbox_path, raising=False)
+
+    events = run_panel_intent_for_note(note_uuid, trace_id="trace-panel-planner-multi")
+    assert len(events) == 1
+    execute_panel_intent(events[0], outbox_path=outbox_path)
+
+    store = get_plan_store()
+    plans = store.list_by_event(events[0].event_id)
+    assert len(plans) == 1
+    plan = plans[0]
+    assert [step.id for step in plan.steps] == ["step-1", "step-2"]
+    assert [step.metadata["action_id"] for step in plan.steps] == [
+        "promote.evergreen",
+        "archive this note",
+    ]
+    assert plan.steps[1].kind == "note"
+    assert plan.steps[1].depends_on == ["step-1"]


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Fixes #243

## Summary
- add ordered plan contract metadata (`panel.ordered.v1`) for panel planner steps
- preserve explicit execution order with `depends_on` step chaining and stable sequence metadata
- include handled selected actions (`triggered` + `logged`) in planner-mode `PanelActionIntent` so selected proposals are represented in the emitted plan
- add focused planner pipeline regression tests for ordered chain emission and logged-action inclusion
- update `docs/PANEL_AGENT.md` planner pipeline contract wording

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [ ] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Validation
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/pytest -q tests/agents/panel_agent/test_panel_planner_pipeline.py -m "not pg"`
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/pytest -q tests/agents/test_planner_reasoning_e2e.py tests/agents/panel_agent/test_panel_runtime.py -m "not pg"`
- [x] `rg -n "PlanStep|panel:planner|panel_action_intent|plan_panel_actions" app/agents/panel_agent app/planner`
- [ ] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/pytest -q -m "not pg"` (currently fails on pre-existing docs index entry `docs/tracks/*.md`, unrelated to this issue)

## Notes
- Full `not pg` run currently fails from `tests/architecture/test_docs_index.py::test_index_paths_exist` on `docs/tracks/*.md` reference in `docs/DOCS_INDEX.md`; this failure is pre-existing in `origin/main` and not introduced by this PR.
