### PR TITLE
Reset to zero removes WATCHER_STOP

### DIFF
--- a/docs/runbooks/RUNBOOK_RESET_TO_ZERO.md
+++ b/docs/runbooks/RUNBOOK_RESET_TO_ZERO.md
@@ -16,6 +16,7 @@ scripts/reset_to_zero.sh
 ```
 The script stops the stack (same as step 1), lists the runtime files it will delete, and removes:
 - `tmp/index-outbox.jsonl` (append-only audit log for ingest/panel events)
+- `tmp/WATCHER_STOP` (watcher pause flag)
 - Heartbeat files: `tmp/worker_heartbeat.json`, `tmp/watcher_heartbeat.json`, plus watcher state files under `tmp/watcher_state*.json` and `tmp/watcher_states`
 - `tmp/health_incidents.jsonl`
 
@@ -68,3 +69,10 @@ If you point at a live Ollama daemon, make sure `OLLAMA_HOST`/`OLLAMA_URL` is se
 5. Optionally query the API with `curl -sS http://127.0.0.1:18000/api/status` or an `/api/ask` prompt to ensure the embeddings/index bank the event.
 
 This runbook alongside `scripts/reset_to_zero.sh` and the `make` helpers (`reset-zero`, `reset-zero-force`, `alpha-e2e-smoke`) provides a repeatable reset workflow without leaking old health/state breadcrumbs.
+
+Validation note for watcher pause reset:
+```
+touch tmp/WATCHER_STOP
+RESET_FORCE=1 bash scripts/reset_to_zero.sh
+test ! -f tmp/WATCHER_STOP
+```

--- a/scripts/reset_to_zero.sh
+++ b/scripts/reset_to_zero.sh
@@ -10,6 +10,7 @@ shopt -s nullglob
 patterns=(
   "tmp/index-outbox.jsonl"
   "tmp/index-outbox.*.jsonl"
+  "tmp/WATCHER_STOP"
   "tmp/worker_heartbeat.json"
   "tmp/watcher_heartbeat.json"
   "tmp/watcher_state.json"
@@ -63,6 +64,6 @@ fi
 cat <<SUMMARY
 SUMMARY:
   docker compose down -v --remove-orphans
-  cleaned tmp/index-outbox* + heartbeat/health state files
+  cleaned tmp/index-outbox* + WATCHER_STOP + heartbeat/health state files
   use scripts/reset_to_zero.sh RESET_FORCE=1 to repeat non-interactively
 SUMMARY


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Fixes #309

## Summary
- remove `tmp/WATCHER_STOP` during reset-to-zero
- document watcher stop cleanup and add a reset verification snippet

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [ ] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [ ] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [ ] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [ ] `ruff check app tests`
- [ ] `mypy app`
- [ ] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg"`
- [ ] Additional targeted checks run as needed

Docs authoring lane:
- [ ] Docs/governance checks run as appropriate for the touched surfaces
- [ ] Any validation gaps or tooling limitations are stated explicitly

Governance lane:
- [ ] Governance checks run as appropriate for the touched surfaces
- [ ] Any validation gaps or tooling limitations are stated explicitly

## Notes
- Validation not run (docs + small shell change).
