### PR TITLE
Stabilize the local test bootstrap path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-.PHONY: fmt lint test eval docs smoke ci-smoke setup-merge-driver hygiene-logs indexer-run transcribe qa cold-boot start verify verify-runtime doctor persist-runtime-repairs
+.PHONY: fmt lint test eval docs smoke ci-smoke setup-merge-driver hygiene-logs indexer-run transcribe qa cold-boot start verify verify-runtime doctor persist-runtime-repairs test-vault-init test-bootstrap
 
 PYTHON ?= $(shell if [ -x .venv/bin/python ]; then printf '%s' .venv/bin/python; elif command -v python3.12 >/dev/null 2>&1; then command -v python3.12; elif command -v python3 >/dev/null 2>&1; then command -v python3; elif command -v python >/dev/null 2>&1; then command -v python; fi)
+TEST_VAULT_ROOT ?= $(PWD)/vault-test
 
 fmt:
 	rufflehog --version >/dev/null 2>&1 || true
@@ -58,6 +59,16 @@ reset-zero:
 
 reset-zero-force:
 	@RESET_FORCE=1 bash scripts/reset_to_zero.sh
+
+test-vault-init:
+	@mkdir -p "$(TEST_VAULT_ROOT)"
+	@$(PYTHON) -m app.cli vault-layout-ensure --vault-root "$(TEST_VAULT_ROOT)" --json >/dev/null
+	@$(PYTHON) -m app.cli uat-seed-vault-test --vault-root "$(TEST_VAULT_ROOT)" --overwrite >/dev/null
+
+test-bootstrap: reset-zero-force test-vault-init
+	@VAULT_ROOT="$(TEST_VAULT_ROOT)" scripts/start_full_system.sh
+	@VAULT_ROOT="$(TEST_VAULT_ROOT)" bash scripts/verify_runtime_stack.sh
+	@VAULT_ROOT="$(TEST_VAULT_ROOT)" $(PYTHON) -m app.cli uat-run-vault-test --vault-root "$(TEST_VAULT_ROOT)" --assert
 
 alpha-e2e-smoke:
 	@$(PYTHON) - <<'PY'

--- a/app/cli/uat.py
+++ b/app/cli/uat.py
@@ -3,10 +3,13 @@ import os
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Literal, Tuple
+from typing import Any, Dict, Literal, Tuple
+
+import yaml
 
 from app.promotion.consumer import consume_promotion_intents
 from app.testing.runtime_contract import failing_check_names, write_contract_report
+from app.vault.layout import ensure_vault_layout, load_layout, normalize_md_filename
 from app.watcher.vault_watcher import VaultWatcher, run_watcher_tick
 from scripts.yaml_roundtrip import load_frontmatter
 
@@ -73,7 +76,11 @@ def seed_vault_test_notes(
     if not SEED_SOURCE.exists():
         raise FileNotFoundError(f"Seed source directory missing: {SEED_SOURCE}")
 
-    dest = vault_root.expanduser().resolve() / target_subdir / folder
+    resolved_root = vault_root.expanduser().resolve()
+    ensure_vault_layout(resolved_root)
+    _ensure_uat_ingest_scope(resolved_root, target_subdir=target_subdir)
+
+    dest = resolved_root / target_subdir / folder
     dest.mkdir(parents=True, exist_ok=True)
 
     written = 0
@@ -87,6 +94,55 @@ def seed_vault_test_notes(
         written += 1
 
     return SeedSummary(written=written, skipped=skipped, destination=dest)
+
+
+def _ingest_override_path(vault_root: Path) -> Path:
+    layout = load_layout(vault_root)
+    return vault_root / layout.system_folder / "settings" / normalize_md_filename("ingest.override.md")
+
+
+def _read_existing_override(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    return _load_frontmatter_dict(path)
+
+
+def _normalize_unique_folders(values: list[object]) -> list[str]:
+    seen: set[str] = set()
+    folders: list[str] = []
+    for value in values:
+        folder = str(value or "").strip()
+        if not folder or folder in seen:
+            continue
+        seen.add(folder)
+        folders.append(folder)
+    return folders
+
+
+def _write_ingest_override(path: Path, payload: dict[str, Any]) -> None:
+    frontmatter = yaml.safe_dump(payload, sort_keys=False, allow_unicode=True).strip()
+    body = (
+        "# Ingest Override\n"
+        "This file extends the ingest scope used by the repo-supported local test bootstrap.\n"
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"---\n{frontmatter}\n---\n\n{body}", encoding="utf-8")
+
+
+def _ensure_uat_ingest_scope(vault_root: Path, *, target_subdir: str) -> None:
+    override_path = _ingest_override_path(vault_root)
+    existing = _read_existing_override(override_path)
+    include_folders = existing.get("include_folders")
+    if isinstance(include_folders, list):
+        merged = _normalize_unique_folders([*include_folders, target_subdir])
+    elif include_folders is None:
+        merged = [target_subdir]
+    else:
+        merged = _normalize_unique_folders([include_folders, target_subdir])
+
+    payload = dict(existing)
+    payload["include_folders"] = merged
+    _write_ingest_override(override_path, payload)
 
 
 def _default_snapshot_path(scope: Path) -> Path:
@@ -170,7 +226,8 @@ def run_vault_test_flow(
     assert_expectations: bool = False,
     assert_mode: UATAssertMode = "bootstrap",
 ) -> UATSummary:
-    scope = vault_root.expanduser().resolve() / target_subdir
+    resolved_root = vault_root.expanduser().resolve()
+    scope = resolved_root / target_subdir
     if not scope.exists() or not scope.is_dir():
         raise FileNotFoundError(f"Vault scope not found: {scope}")
 
@@ -182,16 +239,24 @@ def run_vault_test_flow(
     snapshot_path.parent.mkdir(parents=True, exist_ok=True)
     outbox_path = Path(os.getenv("INDEX_OUTBOX_PATH", "index-outbox.jsonl"))
 
-    watcher_summary, watcher_messages = run_watcher_tick(
-        vault_root=scope,
-        snapshot_path=snapshot_path,
-        skip_panel=not run_panels,
-        emit_only=False,
-        dry_run=dry_run,
-        max_notes=max_notes,
-        force=force,
-        outbox_path=outbox_path,
-    )
+    original_scope = os.environ.get("WATCHER_SCOPE_GLOB")
+    os.environ["WATCHER_SCOPE_GLOB"] = f"{target_subdir}/{folder}/*.md,{target_subdir}/{folder}/**/*.md"
+    try:
+        watcher_summary, watcher_messages = run_watcher_tick(
+            vault_root=resolved_root,
+            snapshot_path=snapshot_path,
+            skip_panel=not run_panels,
+            emit_only=False,
+            dry_run=dry_run,
+            max_notes=max_notes,
+            force=force,
+            outbox_path=outbox_path,
+        )
+    finally:
+        if original_scope is None:
+            os.environ.pop("WATCHER_SCOPE_GLOB", None)
+        else:
+            os.environ["WATCHER_SCOPE_GLOB"] = original_scope
 
     for msg in watcher_messages:
         print(msg)
@@ -200,20 +265,28 @@ def run_vault_test_flow(
     if consume_promotions and not dry_run:
         outbox_path = Path(os.getenv("INDEX_OUTBOX_PATH", "index-outbox.jsonl"))
         promotion_summary = consume_promotion_intents(outbox_path=outbox_path)
-        VaultWatcher(scope, snapshot_path=snapshot_path).refresh_snapshot()
+        VaultWatcher(resolved_root, snapshot_path=snapshot_path).refresh_snapshot()
 
     rerun_summary: Dict[str, Dict[str, object]] | None = None
     if not dry_run:
-        rerun_watcher, rerun_messages = run_watcher_tick(
-            vault_root=scope,
-            snapshot_path=snapshot_path,
-            skip_panel=not run_panels,
-            emit_only=False,
-            dry_run=False,
-            max_notes=max_notes,
-            force=force,
-            outbox_path=outbox_path,
-        )
+        original_scope = os.environ.get("WATCHER_SCOPE_GLOB")
+        os.environ["WATCHER_SCOPE_GLOB"] = f"{target_subdir}/{folder}/*.md,{target_subdir}/{folder}/**/*.md"
+        try:
+            rerun_watcher, rerun_messages = run_watcher_tick(
+                vault_root=resolved_root,
+                snapshot_path=snapshot_path,
+                skip_panel=not run_panels,
+                emit_only=False,
+                dry_run=False,
+                max_notes=max_notes,
+                force=force,
+                outbox_path=outbox_path,
+            )
+        finally:
+            if original_scope is None:
+                os.environ.pop("WATCHER_SCOPE_GLOB", None)
+            else:
+                os.environ["WATCHER_SCOPE_GLOB"] = original_scope
         for msg in rerun_messages:
             print(msg)
         rerun_promotion = {"intents_seen": 0, "applied": 0, "errors": 0, "emitted": 0}

--- a/app/settings/__init__.py
+++ b/app/settings/__init__.py
@@ -1,8 +1,24 @@
 from __future__ import annotations
 
+import os
 from importlib import import_module
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+_VALID_BOOL_ENV_VALUES = {"1", "true", "yes", "on", "0", "false", "no", "off"}
+
+
+def _normalize_bool_env(name: str) -> None:
+    raw = os.environ.get(name)
+    if raw is None:
+        return
+    if raw.strip().lower() in _VALID_BOOL_ENV_VALUES:
+        return
+    os.environ[name] = "false"
+
+
+_normalize_bool_env("DEBUG")
 
 
 class Settings(BaseSettings):

--- a/app/vault/layout.py
+++ b/app/vault/layout.py
@@ -7,6 +7,7 @@ from typing import Any, Iterable
 
 import yaml
 
+from app.settings.default_vault_layout import load_default_vault_layout
 from app.knowledge.write_ops import write_note_from_absolute
 
 
@@ -103,6 +104,18 @@ def _paths_block(settings: dict[str, Any]) -> dict[str, Any]:
 
 def _layout_block(settings: dict[str, Any]) -> dict[str, Any]:
     raw = settings.get("layout")
+    return raw if isinstance(raw, dict) else {}
+
+
+def _default_layout_block() -> dict[str, Any]:
+    payload = load_default_vault_layout()
+    raw = payload.get("layout")
+    return raw if isinstance(raw, dict) else {}
+
+
+def _default_paths_block() -> dict[str, Any]:
+    payload = load_default_vault_layout()
+    raw = payload.get("paths")
     return raw if isinstance(raw, dict) else {}
 
 
@@ -277,25 +290,34 @@ def load_or_create_layout(vault_root: Path) -> VaultLayout:
     settings = _read_system_settings(vault_root)
     paths = _paths_block(settings)
     layout_block = _layout_block(settings)
+    default_layout = _default_layout_block()
+    default_paths = _default_paths_block()
 
     system_folder = (
         os.getenv("VAULT_SYSTEM_DIR_REL")
         or _coerce_str(layout_block.get("system_folder"))
         or _coerce_str(paths.get("system_dir_rel"))
+        or _coerce_str(default_layout.get("system_folder"))
+        or _coerce_str(default_paths.get("system_dir_rel"))
     ).strip()
     inbox_folder = (
         os.getenv("VAULT_INBOX_DIR_REL")
         or _coerce_str(layout_block.get("inbox_folder"))
         or _coerce_str(paths.get("inbox_dir_rel"))
+        or _coerce_str(default_layout.get("inbox_folder"))
+        or _coerce_str(default_paths.get("inbox_dir_rel"))
     ).strip()
     desk_folder = (
         os.getenv("VAULT_DESK_DIR_REL")
         or _coerce_str(layout_block.get("desk_folder"))
+        or _coerce_str(default_layout.get("desk_folder"))
     ).strip()
     runtime_dir_rel = (
         os.getenv("VAULT_RUNTIME_DIR_REL")
         or _coerce_str(layout_block.get("runtime_dir_rel"))
         or _coerce_str(paths.get("runtime_dir_rel"))
+        or _coerce_str(default_layout.get("runtime_dir_rel"))
+        or _coerce_str(default_paths.get("runtime_dir_rel"))
     ).strip()
 
     if not system_folder or not inbox_folder or not desk_folder:
@@ -306,10 +328,16 @@ def load_or_create_layout(vault_root: Path) -> VaultLayout:
 
     root_folders = _normalize_optional_list(layout_block.get("root_folders"))
     if not root_folders:
+        root_folders = _normalize_optional_list(default_layout.get("root_folders"))
+    if not root_folders:
         root_folders = [system_folder, inbox_folder, desk_folder]
 
     include_folders = _normalize_optional_list(layout_block.get("include_folders"))
+    if include_folders is None:
+        include_folders = _normalize_optional_list(default_layout.get("include_folders"))
     ignore_glob = _normalize_optional_list(layout_block.get("ignore_glob"))
+    if ignore_glob is None:
+        ignore_glob = _normalize_optional_list(default_layout.get("ignore_glob"))
 
     note_path = vault_root / system_folder / _layout_note_filename()
     layout = VaultLayout(

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -6,9 +6,9 @@ Authority: Canonical environment contract and implementation for the current bas
 
 ## Overview
 
-This document defines `dev` and `prod` as first-class environments in the active SoT, specifies the control surfaces for runtime environment selection and artifact path scoping, and documents the cross-environment invariants that must hold.
+This document defines the active environment model for the repo, specifies the control surfaces for runtime environment selection and artifact path scoping, and documents the cross-environment invariants that must hold.
 
-The purpose of this document is to make environment boundaries explicit and ensure that dev and prod maintain separate vault, store, and runtime artifact surfaces when environment isolation is required.
+The purpose of this document is to make environment boundaries explicit and ensure that supported environments maintain clear vault, store, and runtime boundaries when isolation is required.
 
 Reading rule:
 - Use this document when a change touches environment-specific behavior, storage boundaries, runtime topology, write safety, or rollout posture.
@@ -22,6 +22,12 @@ Reading rule:
 - **Allowed posture**: narrower safety assumptions, mock or local providers, test fixtures, selective resets, and lab-only runtime tuning.
 - **Typical expectation**: failures are acceptable if they are observable, bounded, and do not threaten production continuity artifacts.
 
+### `test`
+- **Purpose**: isolated, resettable, reproducible local verification and UAT against a clean vault.
+- **Typical users**: developers and operators validating the repo-supported bootstrap path from scratch.
+- **Required posture**: deterministic setup, no hidden folder hints, no dependence on a live dev vault, and explicit verification via health/status plus the scripted UAT harness.
+- **Implementation note**: `test` is the canonical local bootstrap profile today. It is currently expressed through the repo-supported bootstrap path (`make test-bootstrap`, `make test-vault-init`, `uat-*`, and `scripts/start_full_system.sh`) rather than as a third first-class `PKM_ENVIRONMENT` runtime selector. This keeps the current runtime control surface stable while establishing the `dev` / `test` / `prod` model in docs and repo-supported workflows.
+
 ### `prod`
 - **Purpose**: the operator-facing runtime used against a real vault and its associated runtime surfaces.
 - **Typical users**: the human operator and the runtime processes that act on the operator's real knowledge environment.
@@ -30,7 +36,7 @@ Reading rule:
 
 ## Cross-Environment Invariants
 
-The following are SoT invariants and MUST remain true in both `dev` and `prod`:
+The following are SoT invariants and MUST remain true in `dev`, `test`, and `prod`:
 - The same architecture contracts apply: vault-first human surface, companion/system surface, and rebuildable runtime surface.
 - The event envelope and outbox semantics remain stable; DB outbox is canonical runtime queue semantics.
 - Writes to tracked notes remain deterministic and guarded by write-safety and idempotency rules.
@@ -42,12 +48,12 @@ Environment is therefore an operational/runtime distinction, not a different ont
 
 ## Allowed Variation by Environment
 
-The following may vary between `dev` and `prod` without breaking SoT, as long as the invariants above remain intact:
+The following may vary between `dev`, `test`, and `prod` without breaking SoT, as long as the invariants above remain intact:
 - runtime scale, process topology, and startup wrappers
 - provider choice and model profile
 - diagnostic verbosity, mocks, and test fixtures
 - watcher cadence, tuning, and other explicit lab-only controls
-- local fixture vaults, test stores, and rebuild/reset workflows
+- local fixture vaults, test stores, reset/reseed workflows, and scripted bootstrap wrappers
 - operator gating and rollout posture for mutation-capable automation
 
 **Variation rule**: environment-specific defaults may vary; environment-specific contract semantics may not.
@@ -59,6 +65,7 @@ Environment separation MUST be explicit across the following surfaces.
 ### Vaults and Human-Facing Files
 - `prod` must operate on the operator's real vault and its associated continuity artifacts.
 - `dev` must use a separate fixture, test, or otherwise intentionally non-production vault when environment-specific experimentation or validation is being performed.
+- `test` must use a separate clean vault dedicated to the repo-supported bootstrap/UAT path. The canonical local target is `vault-test/` when following `make test-bootstrap`.
 - `dev` and `prod` must not implicitly share the same writable vault surface when the purpose is environment isolation.
 
 **Implementation Status (Issue #266)**:
@@ -69,6 +76,7 @@ Environment separation MUST be explicit across the following surfaces.
 ### Stores and Persistence
 - `prod` runtime persistence must be treated as production data even when it is rebuildable from the file-based continuity set.
 - `dev` stores, indexes, and outbox state may be reset, rebuilt, or replaced for testing.
+- `test` runtime state may be reset and rebuilt as part of the supported bootstrap contract; repeatability is more important than persistence.
 - Rebuildable does not mean disposable in `prod`; recovery and audit expectations still apply.
 
 **Implementation Status (Issue #266)**:
@@ -80,6 +88,7 @@ Environment separation MUST be explicit across the following surfaces.
 ### Runtime State and Process Surfaces
 - Watcher state, heartbeats, tick logs, incident logs, and similar runtime artifacts must be interpreted as environment-scoped operational surfaces.
 - `dev` may expose extra diagnostics and lab-only controls.
+- `test` may reuse the standard local runtime topology, but the repo-supported bootstrap path must reset runtime state before verification and must not rely on leftover watcher pause/state files.
 - `prod` must keep these surfaces stable enough to support operator verification and incident triage.
 
 **Implementation Status (Issue #266)**:
@@ -105,7 +114,8 @@ Environment separation MUST be explicit across the following surfaces.
 
 ## Runtime Control Surface
 
-The runtime provides explicit environment selection through a documented control surface with a clear priority hierarchy.
+The runtime provides explicit environment selection through a documented control surface with a clear priority hierarchy for `dev` and `prod`.
+The local `test` profile is currently controlled by the repo-supported bootstrap commands rather than a third `PKM_ENVIRONMENT` selector.
 
 ### Environment Variables
 
@@ -140,7 +150,30 @@ The existing `PKM_SETTINGS_PROFILE` control mechanism continues to work without 
 - Dev/lab workflows using `PKM_SETTINGS_PROFILE=lab` are mapped to the `dev` environment
 - **No existing behavior changes silently.** Operators see the same control semantics; they now route through the explicit environment model internally.
 
-The settings profile is now understood as a **narrower control mechanism that lives beneath the environment model**, rather than the full environment specification. As the runtime evolves, new environment-specific behavior should be controlled via `PKM_ENVIRONMENT` rather than extending the settings profile approach.
+The settings profile is now understood as a **narrower control mechanism that lives beneath the environment model**, rather than the full environment specification. As the runtime evolves, new environment-specific behavior should be controlled via `PKM_ENVIRONMENT` rather than extending the settings profile approach. The exception is the current repo-supported `test` bootstrap profile, which is intentionally implemented as a bounded local workflow first.
+
+## Canonical Local Test Bootstrap
+
+The official local `test` path is:
+
+```bash
+make test-bootstrap
+```
+
+Default target vault:
+- `TEST_VAULT_ROOT=$(pwd)/vault-test`
+
+Contract:
+- resets runtime state
+- bootstraps a clean test vault layout without undocumented folder env vars
+- seeds the repo-supported UAT note pack
+- starts the local stack against that vault
+- verifies health/status
+- runs the scripted UAT flow successfully
+
+Operator note:
+- `make test-vault-init` is the narrow helper that prepares the clean test vault without starting the stack.
+- The `test` profile is the current golden path for local verification; `dev` remains flexible, and `prod` remains the conservative operator posture.
 
 ## Relation to Current Health, Write Guard, and Settings Direction
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -75,7 +75,7 @@ Expected CI posture:
 | Pure business logic / parser / helper | unit + nearby contract tests |
 | Event schema, outbox, promotion, watcher policy | unit + contract + targeted integration/e2e |
 | Store/backend/runtime queue changes | unit + pg/integration + system/e2e |
-| Operator flow, watcher automation, panel/promotion UX | system/e2e + UAT harness |
+| Operator flow, watcher automation, panel/promotion UX, local test bootstrap path | system/e2e + UAT harness |
 | Retrieval/ASK behavior | unit + e2e + opt-in eval when relevance/quality changes materially |
 
 ## Evaluation Stack (Registry Watcher / Panel / Promotion)
@@ -97,6 +97,21 @@ The scripted UAT harness should behave like a release candidate check, not just 
 - the seeded evergreen note reaches the expected frontmatter state
 - a second run over the same snapshot produces no new watcher/panel/promotion side effects
 - the harness emits a machine-readable report for CI/UAT automation
+
+### Local test bootstrap contract
+
+The repo-supported local test bootstrap path is:
+
+```bash
+make test-bootstrap
+```
+
+Regression protection for that path must cover:
+- clean-state vault layout bootstrap without undocumented folder hints
+- seeded UAT notes being inside the startup ingest contract
+- scripted UAT running against the real vault root with an explicit scoped folder, not by treating `<vault>/Test` as a standalone vault
+- reset clearing watcher pause/state artifacts that would make the next startup appear healthy while the watcher is paused
+- shell-local bootstrap resilience when `DEBUG` is exported with a non-boolean value
 
 ## CI And Fitness Gates
 

--- a/docs/runbooks/RUNBOOK_RESET_TO_ZERO.md
+++ b/docs/runbooks/RUNBOOK_RESET_TO_ZERO.md
@@ -16,6 +16,7 @@ scripts/reset_to_zero.sh
 ```
 The script stops the stack (same as step 1), lists the runtime files it will delete, and removes:
 - `tmp/index-outbox.jsonl` (append-only audit log for ingest/panel events)
+- `tmp/WATCHER_STOP` (watcher pause flag)
 - Heartbeat files: `tmp/worker_heartbeat.json`, `tmp/watcher_heartbeat.json`, plus watcher state files under `tmp/watcher_state*.json` and `tmp/watcher_states`
 - `tmp/health_incidents.jsonl`
 
@@ -68,3 +69,10 @@ If you point at a live Ollama daemon, make sure `OLLAMA_HOST`/`OLLAMA_URL` is se
 5. Optionally query the API with `curl -sS http://127.0.0.1:18000/api/status` or an `/api/ask` prompt to ensure the embeddings/index bank the event.
 
 This runbook alongside `scripts/reset_to_zero.sh` and the `make` helpers (`reset-zero`, `reset-zero-force`, `alpha-e2e-smoke`) provides a repeatable reset workflow without leaking old health/state breadcrumbs.
+
+Validation note for watcher pause reset:
+```
+touch tmp/WATCHER_STOP
+RESET_FORCE=1 bash scripts/reset_to_zero.sh
+test ! -f tmp/WATCHER_STOP
+```

--- a/docs/runbooks/RUNBOOK_RESET_TO_ZERO.md
+++ b/docs/runbooks/RUNBOOK_RESET_TO_ZERO.md
@@ -16,9 +16,10 @@ scripts/reset_to_zero.sh
 ```
 The script stops the stack (same as step 1), lists the runtime files it will delete, and removes:
 - `tmp/index-outbox.jsonl` (append-only audit log for ingest/panel events)
-- `tmp/WATCHER_STOP` (watcher pause flag)
+- `tmp/WATCHER_STOP*` and `tmp-test/WATCHER_STOP*` (watcher pause flags)
 - Heartbeat files: `tmp/worker_heartbeat.json`, `tmp/watcher_heartbeat.json`, plus watcher state files under `tmp/watcher_state*.json` and `tmp/watcher_states`
 - `tmp/health_incidents.jsonl`
+- startup leftovers such as `tmp/runtime.env`, `tmp/startup_status.json`, and their `tmp-test/` equivalents when present
 
 It prompts for confirmation unless you run `RESET_FORCE=1 scripts/reset_to_zero.sh`.
 
@@ -68,7 +69,7 @@ If you point at a live Ollama daemon, make sure `OLLAMA_HOST`/`OLLAMA_URL` is se
    Expect an `ingest.object.created` row with a recent `created_at`.
 5. Optionally query the API with `curl -sS http://127.0.0.1:18000/api/status` or an `/api/ask` prompt to ensure the embeddings/index bank the event.
 
-This runbook alongside `scripts/reset_to_zero.sh` and the `make` helpers (`reset-zero`, `reset-zero-force`, `alpha-e2e-smoke`) provides a repeatable reset workflow without leaking old health/state breadcrumbs.
+This runbook alongside `scripts/reset_to_zero.sh` and the `make` helpers (`reset-zero`, `reset-zero-force`, `test-bootstrap`, `alpha-e2e-smoke`) provides a repeatable reset workflow without leaking old health/state breadcrumbs.
 
 Validation note for watcher pause reset:
 ```

--- a/docs/runbooks/UAT_PANEL_WATCHER.md
+++ b/docs/runbooks/UAT_PANEL_WATCHER.md
@@ -15,10 +15,36 @@ Reading note:
   - `configs/watchers.yaml` defines two watchers: `panel` and `ingest`.
   - Runtime entrypoint: `python -m app.cli watcher run`.
 - Runtime DB outbox is available (`DATABASE_URL` or `DB_DSN`); JSONL outbox is audit/diagnostic only.
-- Use a test vault or a clearly marked subset (3–10 notes) in PKM-Alpha.
+- For the repo-supported clean-state path, use `make test-bootstrap` and the default `vault-test/` vault.
+- For manual exploratory runs, use a test vault or a clearly marked subset (3–10 notes) in PKM-Alpha.
 - Before any auto-exec enablement, run `python -m app.cli settings-explain` and `python -m app.cli status`; these are the canonical enablement checks.
 - Confirm the watcher gate, allowlist validity, write guard/provenance context, and recent skip reasons are coherent across both CLI surfaces.
 - Treat `WATCHER_AUTO_EXEC=1` as necessary but not sufficient; do not treat the env var alone as rollout approval.
+
+## Canonical Clean-State Path
+
+Use this when validating the supported local test bootstrap from scratch:
+
+```bash
+make test-bootstrap
+```
+
+What it does:
+- resets runtime state
+- creates the vault layout in `vault-test/`
+- seeds the UAT pack
+- starts the stack against that vault
+- runs runtime verification
+- runs `uat-run-vault-test --assert`
+
+If you need to inspect the phases individually, use:
+
+```bash
+make test-vault-init
+VAULT_ROOT="$(pwd)/vault-test" scripts/start_full_system.sh
+VAULT_ROOT="$(pwd)/vault-test" bash scripts/verify_runtime_stack.sh
+VAULT_ROOT="$(pwd)/vault-test" python -m app.cli uat-run-vault-test --vault-root "$(pwd)/vault-test" --assert
+```
 
 ## 2) Prepare test notes
 - Pick a handful of notes (3–10) for UAT; keep the rest untouched.
@@ -76,7 +102,8 @@ Reading note:
 - JSONL audit: `INDEX_OUTBOX_PATH` lines should mirror watcher emissions but are not consumed by the worker.
 - CI corroboration: when this UAT flow is part of a release or merge gate, require `CI SUMMARY GATES ok=true` in addition to the local operator signals.
 - Safety: watcher does not rewrite note bodies; downstream agents may update frontmatter/mirrors only. UAT is scoped to the selected notes; the rest of the vault is untouched.
-- Scripted UAT report: `uat-run-vault-test --assert` now writes `.agentic-pkm/uat_report.json` inside the seeded folder. Treat that report as the machine-readable release/UAT artifact; it includes first-run results, rerun idempotence, and pass/fail checks.
+- Scripted UAT report: `uat-run-vault-test --assert` writes `.agentic-pkm/uat_report.json` inside the seeded folder. Treat that report as the machine-readable release/UAT artifact; it includes first-run results, rerun idempotence, and pass/fail checks.
+- Repo-supported startup alignment: `uat-seed-vault-test` also updates the ingest override so the seeded UAT folder is part of the startup bootstrap ingest contract for the local test path.
 
 ## 7) Limits and future work
 - Scope: single-user UAT on a subset of notes; no multi-user or remote watcher yet.

--- a/scripts/reset_to_zero.sh
+++ b/scripts/reset_to_zero.sh
@@ -10,6 +10,7 @@ shopt -s nullglob
 patterns=(
   "tmp/index-outbox.jsonl"
   "tmp/index-outbox.*.jsonl"
+  "tmp/WATCHER_STOP"
   "tmp/worker_heartbeat.json"
   "tmp/watcher_heartbeat.json"
   "tmp/watcher_state.json"
@@ -63,6 +64,6 @@ fi
 cat <<SUMMARY
 SUMMARY:
   docker compose down -v --remove-orphans
-  cleaned tmp/index-outbox* + heartbeat/health state files
+  cleaned tmp/index-outbox* + WATCHER_STOP + heartbeat/health state files
   use scripts/reset_to_zero.sh RESET_FORCE=1 to repeat non-interactively
 SUMMARY

--- a/scripts/reset_to_zero.sh
+++ b/scripts/reset_to_zero.sh
@@ -4,13 +4,18 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
+if ! command -v docker >/dev/null 2>&1; then
+  echo "ERROR: docker is required for reset_to_zero.sh. Install Docker Desktop or make docker available on PATH, then retry." >&2
+  exit 127
+fi
+
 RESET_FORCE="${RESET_FORCE:-0}"
 shopt -s nullglob
 
 patterns=(
   "tmp/index-outbox.jsonl"
   "tmp/index-outbox.*.jsonl"
-  "tmp/WATCHER_STOP"
+  "tmp/WATCHER_STOP*"
   "tmp/worker_heartbeat.json"
   "tmp/watcher_heartbeat.json"
   "tmp/watcher_state.json"
@@ -18,6 +23,22 @@ patterns=(
   "tmp/watcher_states"
   "tmp/health_incidents.jsonl"
   "tmp/worker_heartbeat.*"
+  "tmp/runtime.env"
+  "tmp/startup_status.json"
+  "tmp/latest_watcher_tick_log"
+  "tmp-test/index-outbox.jsonl"
+  "tmp-test/index-outbox.*.jsonl"
+  "tmp-test/WATCHER_STOP*"
+  "tmp-test/worker_heartbeat.json"
+  "tmp-test/watcher_heartbeat.json"
+  "tmp-test/watcher_state.json"
+  "tmp-test/watcher_state.*.json"
+  "tmp-test/watcher_states"
+  "tmp-test/health_incidents.jsonl"
+  "tmp-test/worker_heartbeat.*"
+  "tmp-test/runtime.env"
+  "tmp-test/startup_status.json"
+  "tmp-test/latest_watcher_tick_log"
 )
 
 deleted=()
@@ -64,6 +85,6 @@ fi
 cat <<SUMMARY
 SUMMARY:
   docker compose down -v --remove-orphans
-  cleaned tmp/index-outbox* + WATCHER_STOP + heartbeat/health state files
+  cleaned tmp/tmp-test outbox + WATCHER_STOP + heartbeat/health/startup state files
   use scripts/reset_to_zero.sh RESET_FORCE=1 to repeat non-interactively
 SUMMARY

--- a/scripts/start_full_system.sh
+++ b/scripts/start_full_system.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
+if ! command -v docker >/dev/null 2>&1; then
+  echo "ERROR: docker is required for scripts/start_full_system.sh. Install Docker Desktop or make docker available on PATH, then retry." >&2
+  exit 127
+fi
+
 source "scripts/lib/load_env_defaults.sh"
 load_env_defaults_file ".env"
 load_env_defaults_file "config/runtime.defaults.env"

--- a/scripts/verify_runtime_stack.sh
+++ b/scripts/verify_runtime_stack.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
+if ! command -v docker >/dev/null 2>&1; then
+  echo "ERROR: docker is required for verify_runtime_stack.sh. Install Docker Desktop or make docker available on PATH, then retry." >&2
+  exit 127
+fi
+
 source "scripts/lib/load_env_defaults.sh"
 load_env_defaults_file ".env"
 load_env_defaults_file "config/runtime.defaults.env"

--- a/tests/cli/test_uat_seed_cli.py
+++ b/tests/cli/test_uat_seed_cli.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from click.testing import CliRunner
+import yaml
 
 from app.cli import cli
 from app.cli.uat import DEFAULT_FOLDER_NAME, DEFAULT_TARGET_SUBDIR
@@ -56,3 +57,27 @@ def test_uat_seed_cli_copies_notes(tmp_path: Path) -> None:
     assert target.read_text(encoding="utf-8") == original
 
     object_store_module._MEMORY_STORE.clear()
+
+
+def test_uat_seed_cli_extends_ingest_scope_with_test_folder(tmp_path: Path) -> None:
+    runner = CliRunner()
+    env = {"STORE_BACKEND": "memory"}
+
+    result = runner.invoke(
+        cli,
+        [
+            "uat-seed-vault-test",
+            "--vault-root",
+            str(tmp_path),
+        ],
+        env=env,
+    )
+    assert result.exit_code == 0, result.output
+
+    override_path = tmp_path / "⚙️ System" / "settings" / "ingest.override.md"
+    assert override_path.exists()
+
+    raw = override_path.read_text(encoding="utf-8")
+    parts = raw.split("---", 2)
+    payload = yaml.safe_load(parts[1])
+    assert payload["include_folders"] == [DEFAULT_TARGET_SUBDIR]

--- a/tests/settings/test_debug_env_normalization.py
+++ b/tests/settings/test_debug_env_normalization.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+import app.settings
+
+pytestmark = pytest.mark.not_pg
+
+
+def test_invalid_debug_env_is_normalized_for_settings_import(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DEBUG", "release")
+    reloaded = importlib.reload(app.settings)
+    try:
+        assert reloaded.settings.debug is False
+    finally:
+        monkeypatch.delenv("DEBUG", raising=False)
+        importlib.reload(app.settings)

--- a/tests/vault/test_layout.py
+++ b/tests/vault/test_layout.py
@@ -190,6 +190,29 @@ def test_ensure_vault_layout_can_bootstrap_from_settings_file(tmp_path: Path, mo
     assert layout.runtime_dir_rel == "⚙️ System/Runtime/Alpha"
     assert layout.root_folders == ["⚙️ System", "📥 Inbox", "🛠️ Workbench"]
     assert layout.include_folders == ["📥 Inbox", "🛠️ Workbench"]
+
+
+def test_ensure_vault_layout_can_bootstrap_from_default_template(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir()
+
+    monkeypatch.delenv("VAULT_SYSTEM_DIR_REL", raising=False)
+    monkeypatch.delenv("VAULT_INBOX_DIR_REL", raising=False)
+    monkeypatch.delenv("VAULT_DESK_DIR_REL", raising=False)
+    monkeypatch.delenv("VAULT_RUNTIME_DIR_REL", raising=False)
+
+    layout = ensure_vault_layout(vault_root)
+
+    assert layout.system_folder == "⚙️ System"
+    assert layout.inbox_folder == "📥 Inbox"
+    assert layout.desk_folder == "🛠️ Workbench"
+    assert layout.runtime_dir_rel == "⚙️ System/Runtime/Alpha"
+    assert layout.include_folders == ["📥 Inbox", "🛠️ Workbench"]
+    assert (vault_root / "⚙️ System" / LAYOUT_NOTE_NAME).exists()
+    assert (vault_root / "📥 Inbox").is_dir()
+    assert (vault_root / "🛠️ Workbench").is_dir()
 def test_ensure_vault_layout_does_not_fallback_to_other_vault_settings(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -223,8 +246,12 @@ def test_ensure_vault_layout_does_not_fallback_to_other_vault_settings(
     monkeypatch.delenv("VAULT_INBOX_DIR_REL", raising=False)
     monkeypatch.delenv("VAULT_DESK_DIR_REL", raising=False)
 
-    with pytest.raises(ValueError):
-        ensure_vault_layout(target_vault)
+    layout = ensure_vault_layout(target_vault)
+
+    assert layout.system_folder == "⚙️ System"
+    assert layout.inbox_folder == "📥 Inbox"
+    assert layout.desk_folder == "🛠️ Workbench"
+    assert (target_vault / "⚙️ System" / LAYOUT_NOTE_NAME).exists()
 
 
 def test_normalize_md_filename_does_not_double_extension() -> None:


### PR DESCRIPTION
Fixes #307
Fixes #308
Fixes #309
Fixes #310
Fixes #311

## Summary
- define and document the repo-supported local `test` bootstrap path around `make test-bootstrap`
- let clean vaults bootstrap a default layout without hidden folder env vars and align seeded UAT notes with startup ingest scope
- run `uat-run-vault-test` against the real vault root with an explicit scoped folder, harden reset/start wrappers, and normalize invalid `DEBUG` shell values during settings bootstrap

## Testing
- `./.venv/bin/python -m pytest -q tests/vault/test_layout.py tests/cli/test_uat_seed_cli.py tests/cli/test_uat_run_cli.py tests/settings/test_debug_env_normalization.py tests/runtime/test_start_full_system_env_defaults.py tests/cli/test_vault_layout_ensure_cli.py -m 'not pg'`
- `make test-vault-init`
- `STORE_BACKEND=memory INDEX_OUTBOX_PATH=tmp-test/index-outbox.jsonl WATCHER_AUTO_EXEC=1 ./.venv/bin/python -m app.cli uat-run-vault-test --vault-root "$(pwd)/vault-test" --assert`

## Verification notes
- The repo-side clean-vault init and scripted UAT flow were verified on this checkout.
- Full `make test-bootstrap` stack startup could not be completed here because Docker is not installed on the machine; the shell wrappers now fail fast with an explicit operator message instead of `docker: command not found`.
