### PR TITLE
governance: reconcile project status in issue maintenance skill

### DIFF
--- a/.codex/skills/issue-maintenance-change-control/SKILL.md
+++ b/.codex/skills/issue-maintenance-change-control/SKILL.md
@@ -32,7 +32,7 @@ You operate between:
 - Read `AGENTS.md` first (repo builder-agent policy).
 - For boundary moves, treat `docs/CORE_RUNTIME_AGENTIC_LAB_BOUNDARY.md` as the governing change-control contract.
 - Use `docs/DOCS_INDEX.md` to find owner docs for any affected surfaces.
-- If the request is "maintenance run on everything not done" or similar, default to open issues in the repo and do not touch Project state unless explicitly requested.
+- For maintenance runs, also read `docs/development/GITHUB_GOVERNANCE_SETUP.md` or `.github/github-governance.yml` so Issue/PR Project status is reconciled to the repo governance contract rather than left to best-effort automation drift.
 
 ## Core rules
 
@@ -165,7 +165,14 @@ Use this when the user asks for a maintenance run across everything not done.
      - Add `agent:ready` only if Scope/Constraints/Acceptance Criteria are concrete and no ambiguity remains.
      - Keep or set `agent:needs-human` for boundary moves without explicit direction or module paths.
      - Keep or set `agent:blocked` when external dependencies are stated.
+   - Reconcile Project state for each open issue to match label truth:
+     - `agent:ready` -> `Status=Ready`
+     - `agent:blocked` or `agent:needs-human` -> `Status=Backlog`
+     - if the issue is missing from the Project or missing `Status`, add/reconcile it during the same run
 4. Dedupe:
    - If duplicate issues have the same scope/contract, leave a comment pointing to the canonical issue and close the duplicate.
-5. Do not change GitHub Project Status unless explicitly asked.
-6. Output a receipt listing edited issues, labels changed, and any closures.
+5. Reconcile PR Project state for terminal PR cards in the same repo:
+   - list merged/closed PRs that are in the Project with missing `Status` or a non-terminal status
+   - set merged or otherwise closed terminal PR cards to `Done`
+6. Prefer the repo's reconciliation helper when present (for example `scripts/reconcile_project_status.py`) instead of ad hoc Project mutations.
+7. Output a receipt listing edited issues, label changes, issue status changes, and any PR cards moved to `Done`.


### PR DESCRIPTION
## Change Lane
- [ ] Implementation lane
- [ ] Docs authoring lane
- [x] Governance lane

## Linked Issue
Fixes #

## Summary
- update the issue-maintenance change-control skill to reconcile issue Project status during maintenance runs
- require terminal PR cards with missing or stale status to be reconciled to `Done`

## Implementation Scope Check
- [ ] Change stays within the linked Issue scope.
- [ ] Constraints from the linked Issue were followed.
- [ ] Acceptance Criteria from the linked Issue are satisfied.
- [ ] Docs were updated in the same change when behavior/contracts changed.
- [ ] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [x] This PR only changes approved governance surfaces.
- [x] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [x] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [ ] `ruff check app tests`
- [ ] `mypy app`
- [ ] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg"`
- [ ] Additional targeted checks run as needed

Docs authoring lane:
- [ ] Docs/governance checks run as appropriate for the touched surfaces
- [ ] Any validation gaps or tooling limitations are stated explicitly

Governance lane:
- [x] Governance checks run as appropriate for the touched surfaces
- [x] Any validation gaps or tooling limitations are stated explicitly

## Notes
- Validation for this change was limited to diff review of the repo-local skill instructions.
- This PR updates a repo-local skill only; no product/runtime files were changed.
