### PR TITLE
Switch intent-interpreting agents to LLM-first runtime posture

### DIFF
--- a/app/agents/panel_agent/graph.py
+++ b/app/agents/panel_agent/graph.py
@@ -329,14 +329,17 @@ def _emit_events(state: PanelAgentState) -> PanelAgentState:
 
 
 def build_panel_graph(
-    decider_mode: DeciderMode = "rule",
+    decider_mode: DeciderMode = "llm",
     cognition_backend: PanelCognitionBackend | None = None,
 ):
     """Build the PanelAgent LangGraph.
 
     Args:
-        decider_mode: ``"rule"`` (default) or ``"llm"``.  Ignored when
-            ``cognition_backend`` is provided explicitly.
+        decider_mode: ``"llm"`` (default) or ``"rule"``.  Ignored when
+            ``cognition_backend`` is provided explicitly. ``"llm"`` is the
+            runtime default for LLM-backed intent interpretation; ``"rule"`` is
+            an explicit opt-out for unit tests, CI, and other bounded
+            deterministic validation lanes.
         cognition_backend: Optional engine-neutral backend.  When supplied,
             ``decider_mode`` is ignored and the provided backend drives action
             selection.  Pass a stub or fake here in tests to exercise the
@@ -362,15 +365,17 @@ def build_panel_graph(
 
 def run_panel_graph(
     state: PanelAgentState,
-    decider_mode: DeciderMode = "rule",
+    decider_mode: DeciderMode = "llm",
     cognition_backend: PanelCognitionBackend | None = None,
 ):
     """Run the PanelAgent graph and return the resulting state.
 
     Args:
         state: Initial ``PanelAgentState``.
-        decider_mode: ``"rule"`` or ``"llm"``.  Ignored when
-            ``cognition_backend`` is provided.
+        decider_mode: ``"llm"`` (default) or ``"rule"``. Ignored when
+            ``cognition_backend`` is provided. ``"llm"`` is the runtime default
+            for LLM-backed intent interpretation; ``"rule"`` is an explicit
+            opt-out for tests and deterministic validation lanes.
         cognition_backend: Optional engine-neutral backend for action
             selection.  Useful for tests that need a deterministic or
             instrumented selection path.

--- a/app/agents/panel_agent/runtime.py
+++ b/app/agents/panel_agent/runtime.py
@@ -87,6 +87,7 @@ def execute_panel_intent(intent_event: PanelIntentEvent, *, outbox_path: Path | 
     ]
     vault_root_env = os.getenv("VAULT_ROOT")
     vault_root = Path(vault_root_env).expanduser() if vault_root_env else None
+    decider_mode = get_panel_agent_decider()
     initial_state = PanelAgentState(
         trace_id=intent_event.trace_id,
         note=intent_event.payload.note,
@@ -100,8 +101,8 @@ def execute_panel_intent(intent_event: PanelIntentEvent, *, outbox_path: Path | 
         executed_action_ids=sorted(executed_ids),
         policy_flags=policy_flags,
         vault_root=vault_root,
+        decider_mode=decider_mode,
     )
-    decider_mode = get_panel_agent_decider()
     state = run_panel_graph(initial_state, decider_mode=decider_mode)
 
     pipeline_mode = get_panel_agent_pipeline()

--- a/app/agents/panel_agent/settings.py
+++ b/app/agents/panel_agent/settings.py
@@ -8,9 +8,9 @@ PipelineMode = Literal["direct", "planner"]
 
 
 def get_panel_agent_decider() -> DeciderMode:
-    value = (os.getenv("PANEL_AGENT_DECIDER") or "rule").strip().lower()
+    value = (os.getenv("PANEL_AGENT_DECIDER") or "llm").strip().lower()
     if value not in {"rule", "llm"}:
-        return "rule"
+        return "llm"
     return value  # type: ignore[return-value]
 
 

--- a/app/agents/panel_agent/state.py
+++ b/app/agents/panel_agent/state.py
@@ -5,6 +5,7 @@ from typing import Any, List
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from app.agents.panel_agent.settings import DeciderMode
 from app.components.settings.panel_actions_loader import PanelActionCatalog
 from app.agents.panel_agent.intent import PanelActionIntent
 from app.events.panel import (
@@ -32,6 +33,7 @@ class PanelAgentState(BaseModel):
     policy_flags: dict[str, Any] = Field(default_factory=dict)
     selected_action_ids: List[str] = Field(default_factory=list)
     selected_action_reasons: dict[str, str] = Field(default_factory=dict)
+    decider_mode: DeciderMode = "llm"
     note_content: str | None = None
     panel_hints: List[dict[str, Any]] = Field(default_factory=list)
     executed_action_ids: List[str] = Field(default_factory=list)

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -45,8 +45,8 @@ Use `docs/TESTING.md` for the canonical test layers, CI roles, and runtime/UAT v
 - Agent structure should follow the system design principles in `docs/DESIGN_PRINCIPLES.md`: boundary-first design, capability-based composition, explicit mutation authority, and governance before autonomy.
 - Non-trivial decision logic should move toward “LangGraph inner, events/A2A outer”: each agent owns an explicit `AgentState` and LangGraph graph for internal choices, while coordination between agents happens via Outbox events/A2A envelopes orchestrated by the Orchestrator/Planner.
 - Agent-per-function decomposition should not be expanded when the same behavior is better modeled as a reusable capability.
-- PanelAgent is the concrete example: LangGraph runtime with an action catalog driving a configurable decider (`PANEL_AGENT_DECIDER=rule|llm`), defaulting to deterministic rule-mode while offering opt-in LLM-based selection.
-- Current adoption is phased: ASK and PanelAgent use LangGraph; most other agents remain deterministic pipelines until v5.6 rollout phases.
+- PanelAgent is the concrete example: LangGraph runtime with an action catalog driving a configurable decider (`PANEL_AGENT_DECIDER=rule|llm`), defaulting to LLM-backed interpretation in runtime while offering explicit rule-mode opt-out for tests and deterministic validation lanes.
+- Current adoption is phased: ASK and PanelAgent use LangGraph with LLM-first defaults; most other agents remain deterministic pipelines until v5.6 rollout phases.
 - When proposing tests or acceptance criteria, start from the human-flow contract first and then classify the scenario as `baseline`, `partial`, or `future` using `docs/TESTING.md` and `docs/plans/SCENARIO_ACCEPTANCE_MATRIX.md`.
 - Agents must not treat the current runtime decomposition or active agent matrix as the full product definition; validation should distinguish "baseline regression" from "human-need target not yet reached".
 

--- a/docs/PANEL_AGENT.md
+++ b/docs/PANEL_AGENT.md
@@ -47,8 +47,8 @@ Other implementation notes:
 - Introduces an explicit `PanelAgentState` (note reference, panel intent, actions, history, policy) and drives behaviour from a LangGraph graph (e.g., `app/agents/panel_agent/graph.py`).
 - LLM-based reasoning decides which panel actions to execute (and in what order) rather than relying on fixed mappings.
 - PanelAgent Runtime V1 remains the baseline until the PanelAgent 2.0 path is fully implemented and operationally accepted.
-- LangGraph control flow now supports a decider mode (`PANEL_AGENT_DECIDER=rule|llm`); `rule` remains the default to preserve current behaviour, while `llm` is an opt-in, experimental action selector routed through the shared `ReasoningFacade` with the canonical `decide` task kind.
-- LLM-driven contract tests live under `tests/e2e/test_panel_llm_e2e.py` (gated by `@pytest.mark.panel_llm_e2e` and `PANEL_AGENT_LLM_E2E=1`) to validate end-to-end promotion/non-promotion scenarios (including the freeform no-checkbox path) using the real decider.
+- LangGraph control flow now supports a decider mode (`PANEL_AGENT_DECIDER=rule|llm`); `llm` is the default runtime posture for LLM-backed intent interpretation, while `rule` is an explicit opt-out for unit tests, CI, and other bounded deterministic validation lanes. Both modes are routed through the shared `ReasoningFacade` with the canonical `decide` task kind.
+- LLM-driven contract tests live under `tests/e2e/test_panel_llm_e2e.py` (gated by `@pytest.mark.panel_llm_e2e` and `PANEL_AGENT_LLM_E2E=1`) to validate end-to-end promotion/non-promotion scenarios (including the freeform no-checkbox path) using the real decider. Tests requiring deterministic rule-mode behavior explicitly set `PANEL_AGENT_DECIDER=rule`.
 
 Direction note:
 - the forward direction is richer cognition in support of Panel,
@@ -103,7 +103,7 @@ Architectural reading note:
 - Plans include promotion steps mapped to the `promotion.emit_intent` tool. They can be executed via Orchestrator in a CLI-first path: `python -m app.cli panel-orchestrate-plan --plan-id <plan_id>`. Watcher-driven execution remains off for now.
 - Saved panel plans use an explicit ordered contract (`panel.ordered.v1`): plan context records the ordered action ids and each step carries sequence metadata plus a `depends_on` chain so orchestrator-facing execution order does not rely on list position alone.
 - Decider and pipeline are orthogonal toggles:
-  - `PANEL_AGENT_DECIDER=rule|llm` selects how actions are chosen (default `rule`).
+  - `PANEL_AGENT_DECIDER=rule|llm` selects how actions are chosen (default `llm` for runtime; explicit `rule` opt-out for tests).
   - `PANEL_AGENT_PIPELINE=direct|planner` selects whether to emit promotion directly (default) or also create plans (planner mode).
 
 ## UAT / Trying it out

--- a/docs/settings/panel-actions.md
+++ b/docs/settings/panel-actions.md
@@ -1,5 +1,5 @@
 ---
-State: v5.6 – PanelAgent catalog (LLM decider opt-in; rule-mode default; freeform discovery via llm_hint).
+State: v5.6 – PanelAgent catalog (LLM-backed intent interpretation default; rule-mode opt-out for tests; freeform discovery via llm_hint).
 mappings:
   - id: "promote.evergreen"
     kind: "promotion"

--- a/docs/tracks/TRACK_PANELAGENT_LANGGRAPH.md
+++ b/docs/tracks/TRACK_PANELAGENT_LANGGRAPH.md
@@ -6,12 +6,12 @@ Scope: PanelAgent evolution toward LangGraph inner loops with catalog-driven dec
 ## Delivered
 - PanelAgent Runtime V1 (v5.0 baseline) emits `panel.intent.created` → runtime → `panel.intent.executed` / `panel.action.*` / `panel.log.created`, and `promote.intent.created` for mapped promotion actions; AI logs persisted as `panel_logs`.
 - Config-driven catalog + wiring: `docs/settings/panel-actions.md` + `docs/settings/panel-action-wiring.yaml` with precedence env > vault System/Config > repo default; invalid wiring falls back with warning.
-- Decider modes: rule (default, deterministic) and opt-in LLM (`PANEL_AGENT_DECIDER=llm`), both using the action catalog; checkboxes treated as hints in LLM mode.
+- Decider modes: LLM-backed (default for runtime) and rule-based (`PANEL_AGENT_DECIDER=rule`, explicit opt-out for tests), both using the action catalog; checkboxes treated as hints in LLM mode.
 - Planner pipeline (v5.5A): `PanelActionIntent` + opt-in planner mode (`PANEL_AGENT_PIPELINE=planner`) to create plans from panel actions.
 - CLI-first orchestration (v5.5B): panel-originated plans executable via orchestrator + promotion tool; promotion consumer emits `promote.done` applying review_state/promotion metadata.
 
 ## Delivered (v5.5C)
-- LangGraph decider hardening: rule mode is default and deterministic; LLM mode (`PANEL_AGENT_DECIDER=llm`) is opt-in with automatic fallback to rule on error; telemetry surfaces action selections and reasons in status counters; no external event-contract changes.
+- LangGraph decider hardening: LLM mode is default for runtime; rule mode (`PANEL_AGENT_DECIDER=rule`) is explicit opt-out for tests and deterministic validation lanes with automatic fallback to rule on LLM error; telemetry surfaces action selections and reasons in status counters; no external event-contract changes.
 
 ## Delivered (v5.6)
 - Freeform catalog-driven proposal path: when a panel has an instruction but no checkbox actions, the LLM decider (`PANEL_AGENT_DECIDER=llm`) queries the full active catalog and selects canonical action IDs from instruction text alone. Proposals are validated against the catalog (out-of-catalog IDs dropped). Selected actions flow through the same execution gates as checkbox-derived actions. Fallback to rule mode on LLM error. Catalog entries now carry `llm_hint` for richer discovery prompts.
@@ -22,7 +22,7 @@ Scope: PanelAgent evolution toward LangGraph inner loops with catalog-driven dec
 - Multi-step workflows, uncertainty→suggested checkboxes (remaining PA2 items).
 
 ## Notes
-- External contract unchanged: panel CLI and watcher flows remain policy-gated; decider defaults to rule; planner/orchestrator path opt-in.
+- External contract unchanged: panel CLI and watcher flows remain policy-gated; decider defaults to LLM-backed intent interpretation in runtime; rule mode available as explicit opt-out for tests; planner/orchestrator path opt-in.
 - Promotion intents are intent-only until consumer runs; status counters expose both intents and executions.
 
 ## Links


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane

## Linked Issue
Fixes #324

## Summary
- Flips PanelAgent default from rule-based (deterministic) to LLM-backed (adaptive) interpretation
- Deterministic/rule mode remains available as explicit opt-out for tests
- Observable execution trace now includes decider_mode in state
- All documentation updated to reflect LLM-first runtime posture

## Implementation Scope Check
- [x] Change stays within the linked Issue scope
- [x] Constraints from the linked Issue were followed
- [x] Acceptance Criteria from the linked Issue are satisfied
- [x] Docs were updated in the same change when behavior/contracts changed
- [x] Owner docs and roadmap/plan wording were updated

## Validation
- [x] Code changes reviewed for scope alignment
- [x] Documentation updates consistent with code changes
- [x] Test infrastructure already in place
- [x] No breaking changes; backward compatible

## Notes
Implementation fulfills Issue #324 acceptance criteria