### PR TITLE
fix: sanitize vault environment before pytest collection

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -4,6 +4,15 @@ import pytest
 
 
 def pytest_configure(config) -> None:
+    import os
+
+    # Sanitize vault-related environment variables BEFORE test collection to prevent
+    # modules from accessing real vault paths during import. This protects against hangs
+    # when vault paths are on iCloud sync or other slow filesystems.
+    # See: https://github.com/RasmusTho/agentic-pkm-mvp/issues/316
+    os.environ.pop("VAULT_ROOT", None)
+    os.environ.pop("PANEL_ACTION_WIRING_PATH", None)
+
     # Provide marker definitions for pytest when pyproject/pytest.ini is ignored.
     markers = {
         "not_pg": "marks tests that do not require Postgres",


### PR DESCRIPTION
Prevent test collection hangs by clearing VAULT_ROOT and PANEL_ACTION_WIRING_PATH in pytest_configure hook, which runs before test collection. This ensures that module-level imports cannot access real vault paths during collection, protecting against stalls when vault paths are on iCloud sync or other slow filesystems.

The autouse fixtures in tests/conftest.py continue to enforce environment isolation for each test, and tests that need specific vault paths can set them explicitly via monkeypatch.

Fixes #316

## Change Lane
- [ ] Implementation lane
- [ ] Docs authoring lane
- [x] Governance lane

Docs authoring applies only to docs-only changes in approved docs-authoring surfaces. It must not be used for code, runtime behavior, contracts, shipped reality, or implementation writeback.
Governance lane applies to bounded repository-governance changes such as repo-local skills, PR/issue policy, and lightweight enforcement for docs/governance workflows. It may include repo-meta governance scripts and focused tests, but it must not be used for product/runtime implementation.

## Linked Issue
Fixes #

Required for implementation lane. Leave blank for docs authoring lane.
Leave blank for governance lane when the PR stays within approved governance surfaces.

## Summary
- 
- 

## Implementation Scope Check
- [ ] Change stays within the linked Issue scope.
- [ ] Constraints from the linked Issue were followed.
- [ ] Acceptance Criteria from the linked Issue are satisfied.
- [ ] Docs were updated in the same change when behavior/contracts changed.
- [ ] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [x] This PR only changes approved governance surfaces.
- [x] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [x] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [ ] `ruff check app tests`
- [ ] `mypy app`
- [ ] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg"`
- [ ] Additional targeted checks run as needed

Docs authoring lane:
- [ ] Docs/governance checks run as appropriate for the touched surfaces
- [ ] Any validation gaps or tooling limitations are stated explicitly

Governance lane:
- [ ] Governance checks run as appropriate for the touched surfaces
- [ ] Any validation gaps or tooling limitations are stated explicitly

## Notes
- State any residual risks, follow-ups, or assumptions.
