### PR TITLE
[codex] defer panelagent expansion

### DIFF
--- a/docs/PANEL_AGENT.md
+++ b/docs/PANEL_AGENT.md
@@ -42,6 +42,7 @@ Interpretation note:
 - Remaining backlog: #240 (real-vault acceptance).
 - Emit ordered multi-step panel plans through the planner/orchestration contract rather than investing in richer LangGraph-only node choreography. Delivery receipt: Issue #243 delivered via PR #302. Source Anchor: PA2-MULTISTEP-PLANS.
 - Prove the PanelAgent 2.0 path operationally on a real vault with soak, receipts, and owner-doc writeback before it is treated as operationally accepted. Source Anchor: PA2-REAL-VAULT-ACCEPTANCE. Tracked by: #240
+- Broader PanelAgent expansion is deferred until the real-vault acceptance slice closes. Treat any new behavior beyond the current slices as a separately scoped follow-up and break it into smaller issues before implementation.
 
 Other implementation notes:
 - Introduces an explicit `PanelAgentState` (note reference, panel intent, actions, history, policy) and drives behaviour from a LangGraph graph (e.g., `app/agents/panel_agent/graph.py`).
@@ -50,6 +51,7 @@ Other implementation notes:
 - LangGraph control flow supports a decider mode (`PANEL_AGENT_DECIDER=rule|llm`); `llm` is the default runtime posture for LLM-backed intent interpretation, while `rule` is an explicit opt-out for unit tests, CI, and other bounded deterministic validation lanes. Both modes route through the shared `ReasoningFacade` with the canonical `decide` task kind.
 - The executed `cognition_mode` is included in the `panel.intent.executed` event payload and in `panel.log.created` entries so external consumers can observe which interpretation path was used.
 - LLM-driven contract tests live under `tests/e2e/test_panel_llm_e2e.py` (gated by `@pytest.mark.panel_llm_e2e` and `PANEL_AGENT_LLM_E2E=1`) to validate end-to-end promotion/non-promotion scenarios (including the freeform no-checkbox path) using the real decider. Tests requiring deterministic rule-mode behavior explicitly set `PANEL_AGENT_DECIDER=rule`.
+- Any future PanelAgent expansion beyond the current shipped slices should be decomposed via the issue/track flow first so the remaining work stays bounded and reviewable.
 
 Direction note:
 - the forward direction is richer cognition in support of Panel,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -39,7 +39,8 @@ This roadmap is forward-looking and skimmable. History lives in `docs/history/SO
   - PanelAgent 2.0 timeline: <!-- PA2-ROLLUP -->
     - v5.5C: decider — shipped (rule default + opt-in LLM mode + fallback + telemetry).
     - v5.6 shipped/in progress: engine-neutral cognition seam (#244, PR #249), freeform catalog-driven proposal path (#241, PR #248), suggested checkbox writeback for uncertain/freeform panel proposals (#242), multi-step plans (#243, PR #302). Remaining: real-vault acceptance (#240).
-    - v5.7: advanced (panel versioning, cross-note coordination).
+    - Broader expansion beyond the current PanelAgent 2.0 slices is deferred until the real-vault acceptance slice is closed and the operator story is stable. Keep new work bounded and break it down from the owner docs / tracks before expanding scope.
+    - v5.7: advanced (panel versioning, cross-note coordination) remains future-line work and should stay in roadmap form until a governing slice issue exists.
   - Vault-as-GUI settings compiler (`@Settings` / System/Config) now covers panel-action catalogs, watcher settings, and outbox paths with CI schema checks (v5.6 track).
   - LangGraph rollout to additional agents (Promotion/Reviewer/Hygiene) in phases:
     - Phase 1: single pilot agent behind a flag; AgentState + graph parity tests green.
@@ -48,6 +49,7 @@ This roadmap is forward-looking and skimmable. History lives in `docs/history/SO
   - A2A/MCP orchestration routing with deterministic adapters and audit.
 - **Later**
   - Watcher auto-exec of panel plans with guardrails and rollback; richer panel actions (summary/reply) via tool/MCP boundary.
+  - PanelAgent 2.0 expansion beyond the current slices is deferred until real-vault acceptance is closed; break new behavior into smaller tracked slices first.
   - Reasoning/reflective layers with eval gates; expanded observability counters for orchestration/A2A.
   - Collaboration/multi-user after single-user flows are stable.
   - `v6.0` architecture target: semantics-aligned runtime architecture where context layering,

--- a/docs/tracks/TRACK_PANELAGENT_LANGGRAPH.md
+++ b/docs/tracks/TRACK_PANELAGENT_LANGGRAPH.md
@@ -21,6 +21,7 @@ Scope: PanelAgent evolution toward LangGraph inner loops with catalog-driven dec
 - Watcher auto-exec path for panel plans with safety limits (gated by concurrency/idempotency guards).
 - Richer panel actions (summary/reply) with MCP/tool boundaries; A2A envelopes for planner/orchestrator integration.
 - Multi-step workflows, uncertainty→suggested checkboxes (remaining PA2 items).
+- PanelAgent expansion beyond the current real-vault acceptance / writeback slices is deferred. Treat new work as separate bounded slices derived from this track rather than widening the current scope inline.
 
 ## Notes
 - External contract updated: panel CLI and watcher flows remain policy-gated; decider now defaults to LLM-backed intent interpretation in runtime; rule mode available as explicit opt-out for tests; planner/orchestrator path opt-in.


### PR DESCRIPTION
## Change Lane
- [ ] Implementation lane
- [x] Docs authoring lane
- [ ] Governance lane

Docs authoring applies only to docs-only changes in approved docs-authoring surfaces. It must not be used for code, runtime behavior, contracts, shipped reality, or implementation writeback.

## Linked Issue

## Summary
- Defer broader PanelAgent expansion until the real-vault acceptance slice is closed.
- Keep the current PanelAgent 2.0 slices as the active shipped scope.
- Make future expansion available for later bounded slice breakdown instead of widening inline.

## Docs Authoring Check
- [x] This PR only changes approved docs-authoring surfaces.
- [x] No code, runtime behavior, contracts, or shipped reality changed.
- [x] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Validation
- [x] Reviewed the updated roadmap, PanelAgent owner doc, and track note for consistent deferment language.
- [x] No runtime validation required for a docs-only change.

## Notes
- Residual risk is limited to wording drift if future runtime expansion lands without a follow-up docs update.
