### PR TITLE
docs: refresh temporal control docs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,12 @@
 State: SoT v5.5 Reality-MVP baseline locked (watcher safety, panel action provenance, and concurrency hardening) with the forward line now entering v5.6 LangGraph/Reasoning rollouts.
 Doc role: Core SoT
 Authority: Active runtime architecture source of truth for the current baseline and runtime contracts; wins over roadmap and historical references on current-state questions.
+Owner: Runtime / architecture SoT
+Temporal class: operational
+Review cadence: event-driven
+Source of truth: mixed
+Last reviewed: 2026-04-04
+Last verified against: docs/ENVIRONMENTS.md, docs/STATUS.md, docs/PANEL_AGENT.md, app/cli/__init__.py, current repo state on 2026-04-04
 # Architecture — SoT v5.5 Reality-MVP baseline (forward line v5.6)
 
 This document is the active architecture source of truth for the SoT v5.5 Reality-MVP baseline and the place where current runtime contracts are defined.
@@ -13,7 +19,7 @@ This architecture focuses on the runtime and data model for the Mimer module (th
 Related documents and authority boundaries:
 - `docs/DESIGN_PRINCIPLES.md` defines the stable design rules for modularity, flexibility, authority separation, and documentation layering. Use it before changing architecture wording or roadmap framing.
 - `docs/HUMAN-FLOWS.md` is the user-facing behavior contract. Any architecture change that alters user-visible behavior should be validated against it before shipping.
-- `docs/ENVIRONMENTS.md` defines `dev` and `prod` as first-class environments, including environment invariants, allowed variance, persistence/runtime separation, and production safety expectations.
+- `docs/ENVIRONMENTS.md` defines the active `dev` / `test` / `prod` environment model, including environment invariants, allowed variance, persistence/runtime separation, and production safety expectations.
 - `docs/ONTOLOGY_RUNTIME_BRIDGE.md` is the cross-layer reading guide connecting human functions, semantic classes, persistence surfaces, and runtime contracts. It does not replace the owning SoT docs, but it should be used when architecture wording risks collapsing those layers.
 - `docs/CONCEPTS/COGNITIVE_ONTOLOGY.md` defines the broader human-first second-brain ontology. This document uses narrower runtime and storage language where needed and should not be read as the full domain ontology.
 - `docs/CONCEPTS/ONTOLOGY_VOCABULARY.md` defines the normalized vocabulary and explains where repo terms such as `note`, `object`, `agent`, `source`, and `promotion` drift across layers.
@@ -190,7 +196,7 @@ See also:
 - DB outbox is canonical in runtime; JSONL outbox is audit/diagnostic only.
 
 ### Environment contract (current architecture reading)
-- `dev` and `prod` are first-class environments in the SoT. Their purpose, invariants, and allowed variance are defined in `docs/ENVIRONMENTS.md`.
+- `dev`, `test`, and `prod` are the active environment model in the SoT. Their purpose, invariants, and allowed variance are defined in `docs/ENVIRONMENTS.md`.
 - Environment changes may affect runtime topology, provider choice, diagnostics, fixture data, and tuning, but they MUST NOT change artifact semantics, event contracts, provenance rules, or write-safety boundaries.
 - Vault surface, companion/system surface, runtime stores, and operational artifacts must remain separable by environment even when the underlying architecture is otherwise shared.
 - Production runtime must prefer conservative behavior, explicit gating, and recoverable failure over convenience.

--- a/docs/HUMAN-FLOWS.md
+++ b/docs/HUMAN-FLOWS.md
@@ -1,6 +1,12 @@
 State: SoT v5.5 Reality-MVP baseline locked with v5.6 forward line extending PanelAgent runtime and registry watcher behavior.
 Doc role: Core SoT
 Authority: Canonical user-facing function contract for the system; architecture and implementation changes should remain compatible with this document unless it is updated intentionally.
+Owner: Product / human contract SoT
+Temporal class: strategic
+Review cadence: event-driven
+Source of truth: mixed
+Last reviewed: 2026-04-04
+Last verified against: docs/PROJECT_KERNEL.md, docs/PANEL_AGENT.md, docs/OPERATIONS.md, current repo state on 2026-04-04
 
 # Human Flows — Yggdrasil / agentic-pkm-mvp
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,6 +1,12 @@
 State: SoT v5.5 Reality-MVP baseline locked. This is the top-level operations entrypoint for the current runtime.
 Doc role: Core SoT
 Authority: Top-level operator guidance for the current runtime; delegates specialized operational detail to linked companion docs but remains the main operational entrypoint.
+Owner: Runtime / operator playbook
+Temporal class: operational
+Review cadence: event-driven
+Source of truth: mixed
+Last reviewed: 2026-04-04
+Last verified against: docs/HEALTH.md, docs/INFRASTRUCTURE.md, docs/ENVIRONMENTS.md, app/cli/__init__.py, Makefile, current repo state on 2026-04-04
 # Operations Playbook
 
 Use this document as the operator-facing starting point for runtime operations.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,8 +5,8 @@ Owner: Product / architecture forward line
 Temporal class: strategic
 Review cadence: biweekly
 Source of truth: mixed
-Last reviewed: 2026-04-01
-Last verified against: docs/STATUS.md, docs/ARCHITECTURE.md, docs/DOCS_INDEX.md, current repo state on 2026-04-01
+Last reviewed: 2026-04-04
+Last verified against: docs/STATUS.md, docs/ARCHITECTURE.md, docs/ENVIRONMENTS.md, docs/PANEL_AGENT.md, docs/DOCS_INDEX.md, app/cli/__init__.py, current repo state on 2026-04-04
 # Roadmap — Strategic Control
 
 This roadmap is forward-looking and skimmable. History lives in `docs/history/SOT_4X_HISTORY.md`; deep track details live under `docs/tracks/`. Current truth stays in `docs/ARCHITECTURE.md` and `docs/STATUS.md`.
@@ -24,9 +24,9 @@ This roadmap is forward-looking and skimmable. History lives in `docs/history/SO
 ## Now / Next / Later
 - **Now**
   - **v5.5 baseline lock + safety guard** — runtime/startup defaults `WATCHER_AUTO_EXEC=1`, but operators can force emit-only mode with `WATCHER_AUTO_EXEC=0`; allowlists, dedup/idempotency, optimistic writes, and write-guard/status signals remain the real enablement gates for safe rollout.
-  - PanelAgent LangGraph decider opt-in, watcher policy auto-exec plumbing (v5.5C in progress).
+  - PanelAgent LLM-first decider posture is shipped; watcher policy auto-exec plumbing remains under rollout guardrails while rule-mode stays as the explicit deterministic opt-out for tests and bounded validation lanes.
   - Watcher → panel → planner/orchestrator automation with safety limits now includes dedup reports, promotion consumer visibility, and explicit skipped receipts.
-  - Vault-first config validation (panel wiring, watcher, outbox) with schema enforcement and `python -m app.cli.settings_explain`.
+  - Vault-first config validation (panel wiring, watcher, outbox) with schema enforcement and `python -m app.cli settings-explain`.
 - **Next**
   - **Environment contract follow-through** — implement the remaining docs-first environment contract slices from `docs/ENVIRONMENTS.md` in bounded steps: explicit runtime environment selection and environment-scoped vault/store separation are shipped, and environment-aware operator diagnostics are delivered via Issue #265 / PR #272; remaining follow-through should stay bounded and avoid changing the shared architecture contracts.
   - **Companion note + Note Context rollout hardening** — the core companion-note and Note Context implementation is shipped, and the active doc-sync correction has landed. Delivery receipt: Issue #229, PR #237. Any remaining rollout verification or cleanup should be captured as new bounded follow-up issues rather than treated as missing first implementation.
@@ -37,7 +37,7 @@ This roadmap is forward-looking and skimmable. History lives in `docs/history/SO
     - Back-compat preserved: `ORCHESTRATOR_VERSION=v1` (default) uses existing sequential V1; `v2` selects parallel pilot with compensation.
     - Next slices: checkpoint persistence, retry/timeout policy.
   - PanelAgent 2.0 timeline: <!-- PA2-ROLLUP -->
-    - v5.5C: decider — shipped (rule default + opt-in LLM mode + fallback + telemetry).
+    - v5.5C: decider — shipped (LLM-first runtime posture + explicit rule-mode opt-out + fallback + telemetry).
     - v5.6 shipped/in progress: engine-neutral cognition seam (#244, PR #249), freeform catalog-driven proposal path (#241, PR #248), suggested checkbox writeback for uncertain/freeform panel proposals (#242), multi-step plans (#243, PR #302). Remaining: real-vault acceptance (#240).
     - Broader expansion beyond the current PanelAgent 2.0 slices is deferred until the real-vault acceptance slice is closed and the operator story is stable. Keep new work bounded and break it down from the owner docs / tracks before expanding scope.
     - v5.7: advanced (panel versioning, cross-note coordination) remains future-line work and should stay in roadmap form until a governing slice issue exists.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -5,8 +5,8 @@ Owner: Runtime / current-state SoT
 Temporal class: operational
 Review cadence: weekly
 Source of truth: mixed
-Last reviewed: 2026-04-02
-Last verified against: docs/ARCHITECTURE.md, docs/ROADMAP.md, docs/DOCS_INDEX.md, docs/plans/LOCAL_TEST_ENVIRONMENT_BOOTSTRAP.md, scripts/start_full_system.sh, current repo state on 2026-04-02
+Last reviewed: 2026-04-04
+Last verified against: docs/ARCHITECTURE.md, docs/ROADMAP.md, docs/ENVIRONMENTS.md, docs/DOCS_INDEX.md, docs/plans/LOCAL_TEST_ENVIRONMENT_BOOTSTRAP.md, docs/PANEL_AGENT.md, scripts/start_full_system.sh, app/cli/__init__.py, current repo state on 2026-04-04
 Status snapshot now includes SoT baseline + forward-line fields and intent/event counters (`promote.intent.created`, `panel.intent.executed`, ingest runs by plane). `watcher_runs` refers to legacy snapshot watchers only; registry watcher health is via heartbeat + tick logs.
 
 Concept anchors: layering, portability, archive exposure, trust semantics, event compatibility, and config-as-product are now defined as concept contracts under `docs/CONCEPTS/` and are considered the canonical statements of intent. This status document describes operational snapshots and may lag those contracts.


### PR DESCRIPTION
## Summary
- refresh temporal metadata on the high-risk temporal docs audited in this run
- align architecture wording with the active `dev` / `test` / `prod` environment contract
- correct roadmap drift around the current PanelAgent decider posture and `settings-explain` command spelling

## Classification
- docs authoring / temporal doc governance

## Validation
- `python3 scripts/docs_guard.py`
