### PR TITLE
feat: add automated multi-device sync latency harness

### DIFF
--- a/app/cli/__init__.py
+++ b/app/cli/__init__.py
@@ -44,6 +44,7 @@ from app.cli.uat import (
     run_vault_test_flow,
     seed_vault_test_notes,
 )
+from app.cli.latency_harness import run_latency_harness
 from app.stores import get_object_store, get_vector_index, resolve_store_backend
 from app.agents.classifier.agent import run as classify_run
 from app.agents.panel.integration import handle_panel_update
@@ -1328,6 +1329,85 @@ def uat_run_vault_test(
     if summary.watcher.get("errors", 0) or summary.promotion.get("errors", 0):
         raise SystemExit(1)
 
+
+@cli.command(
+    name="sync-latency-harness",
+    help="Run automated multi-device sync latency measurements on seeded test vault.",
+)
+@click.option(
+    "--vault-root",
+    type=click.Path(path_type=Path),
+    required=True,
+    help="Vault root path; watcher scope will be <vault_root>/<target-subdir>.",
+)
+@click.option(
+    "--target-subdir",
+    type=str,
+    default=DEFAULT_TARGET_SUBDIR,
+    show_default=True,
+    help="Subdirectory under vault root to watch (default Test).",
+)
+@click.option(
+    "--folder",
+    type=str,
+    default=DEFAULT_FOLDER_NAME,
+    show_default=True,
+    help="Folder name containing test notes for latency measurement.",
+)
+@click.option(
+    "--scenario",
+    type=str,
+    default="changed-note-default",
+    show_default=True,
+    help="Name of the latency measurement scenario.",
+)
+@click.option(
+    "--report",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Optional path to write machine-readable JSON report.",
+)
+@click.option("--dry-run", is_flag=True, help="Skip watcher/panel execution, report only.")
+def sync_latency_harness(
+    vault_root: Path,
+    target_subdir: str,
+    folder: str,
+    scenario: str,
+    report: Path | None,
+    dry_run: bool,
+) -> None:
+    """Run automated multi-device sync latency measurements.
+
+    The harness seeds or targets a bounded changed-note scenario, waits for
+    the sync/runtime chain to converge, and collects machine-readable timing
+    outputs. Suitable for repeated trials and latency analysis.
+    """
+    resolved = _resolve_vault_root_path(vault_root, allow_env=True, fallback_to_default=False)
+    if resolved is None:
+        raise click.BadParameter("Vault root could not be resolved.")
+
+    try:
+        summary = run_latency_harness(
+            vault_root=resolved,
+            target_subdir=target_subdir,
+            folder=folder,
+            scenario=scenario,
+            report_path=report,
+            dry_run=dry_run,
+        )
+    except FileNotFoundError as exc:
+        raise click.BadParameter(str(exc))
+
+    for line in summary.to_lines():
+        click.echo(line)
+
+    if report:
+        click.echo(f"Report written to: {report}")
+
+    if not summary.latency_results:
+        click.echo("WARNING: No latency measurements captured. Verify notes were changed and events were emitted.")
+        if not dry_run:
+            raise SystemExit(1)
 
 
 @cli.command(

--- a/app/cli/latency_harness.py
+++ b/app/cli/latency_harness.py
@@ -1,0 +1,292 @@
+"""Automated multi-device sync latency harness.
+
+Runs a controlled changed-note scenario on the supported local test bootstrap path
+and emits machine-readable latency results for each sync-chain stage.
+
+The harness:
+1. Seeds or targets a bounded changed-note scenario
+2. Waits for the sync/runtime chain to converge
+3. Collects machine-readable timing outputs from sync.latency.summary events
+4. Emits a per-run latency summary suitable for repeated trials
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
+
+from app.events.outbox import read_outbox
+from app.events.sync import SyncLatencySummaryEvent
+from app.testing.runtime_contract import write_contract_report
+from app.watcher.vault_watcher import VaultWatcher, run_watcher_tick
+from app.promotion.consumer import consume_promotion_intents
+
+
+@dataclass
+class LatencyResult:
+    """A single latency measurement from a changed-note scenario."""
+
+    note_uuid: str
+    note_path: str
+    file_detection_ts: str
+    scan_requested_ts: str
+    runtime_start_ts: str
+    runtime_complete_ts: str
+    watcher_to_scan_ms: int
+    scan_to_runtime_start_ms: int
+    runtime_execution_ms: int
+    end_to_end_ms: int
+    trace_id: str
+
+
+@dataclass
+class LatencySummary:
+    """Summary of all latency measurements from a harness run."""
+
+    run_id: str
+    timestamp: str
+    scenario: str
+    latency_results: list[LatencyResult]
+    transport: str = "test"  # Changed note source transport
+    statistics: Dict[str, Any] | None = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to machine-readable JSON-compatible dict."""
+        stats = self.statistics or {}
+        return {
+            "run_id": self.run_id,
+            "timestamp": self.timestamp,
+            "scenario": self.scenario,
+            "transport": self.transport,
+            "latency_count": len(self.latency_results),
+            "statistics": stats,
+            "measurements": [
+                {
+                    "note_uuid": r.note_uuid,
+                    "note_path": r.note_path,
+                    "trace_id": r.trace_id,
+                    "timestamps": {
+                        "file_detection": r.file_detection_ts,
+                        "scan_requested": r.scan_requested_ts,
+                        "runtime_start": r.runtime_start_ts,
+                        "runtime_complete": r.runtime_complete_ts,
+                    },
+                    "latencies_ms": {
+                        "watcher_to_scan": r.watcher_to_scan_ms,
+                        "scan_to_runtime_start": r.scan_to_runtime_start_ms,
+                        "runtime_execution": r.runtime_execution_ms,
+                        "end_to_end": r.end_to_end_ms,
+                    },
+                }
+                for r in self.latency_results
+            ],
+        }
+
+    def to_lines(self) -> list[str]:
+        """Convert to human-readable output lines."""
+        lines = [
+            f"Latency Harness Run: {self.run_id}",
+            f"Timestamp: {self.timestamp}",
+            f"Scenario: {self.scenario}",
+            f"Transport: {self.transport}",
+            f"Latency measurements captured: {len(self.latency_results)}",
+        ]
+
+        if self.statistics:
+            lines.append("")
+            lines.append("Latency Statistics:")
+            for key, value in self.statistics.items():
+                lines.append(f"  {key}: {value}")
+
+        if self.latency_results:
+            lines.append("")
+            lines.append("Per-note latencies (milliseconds):")
+            for r in self.latency_results:
+                lines.append(f"  {r.note_uuid} ({r.note_path})")
+                lines.append(f"    watcher→scan: {r.watcher_to_scan_ms}ms")
+                lines.append(f"    scan→runtime: {r.scan_to_runtime_start_ms}ms")
+                lines.append(f"    runtime execution: {r.runtime_execution_ms}ms")
+                lines.append(f"    end-to-end: {r.end_to_end_ms}ms")
+
+        return lines
+
+
+def _extract_sync_latency_events(outbox_path: Path) -> list[Dict[str, Any]]:
+    """Extract sync.latency.summary events from the outbox."""
+    events = read_outbox(outbox_path)
+    latency_events = [
+        e for e in events if e.get("event") == "sync.latency.summary"
+    ]
+    return latency_events
+
+
+def _parse_latency_event(event: Dict[str, Any]) -> LatencyResult | None:
+    """Parse a sync.latency.summary event into a LatencyResult."""
+    try:
+        payload = event.get("payload")
+        if not isinstance(payload, dict):
+            return None
+
+        # Ensure we have at least the minimal required fields
+        if not payload.get("note_uuid"):
+            return None
+
+        return LatencyResult(
+            note_uuid=str(payload.get("note_uuid", "")),
+            note_path=str(payload.get("note_path", "")),
+            file_detection_ts=str(payload.get("file_detection_ts", "")),
+            scan_requested_ts=str(payload.get("scan_requested_ts", "")),
+            runtime_start_ts=str(payload.get("runtime_start_ts", "")),
+            runtime_complete_ts=str(payload.get("runtime_complete_ts", "")),
+            watcher_to_scan_ms=int(payload.get("watcher_to_scan_ms", 0)),
+            scan_to_runtime_start_ms=int(payload.get("scan_to_runtime_start_ms", 0)),
+            runtime_execution_ms=int(payload.get("runtime_execution_ms", 0)),
+            end_to_end_ms=int(payload.get("end_to_end_ms", 0)),
+            trace_id=str(event.get("trace_id", "")),
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def _compute_statistics(results: list[LatencyResult]) -> Dict[str, Any]:
+    """Compute aggregate latency statistics from a list of results."""
+    if not results:
+        return {}
+
+    e2e_latencies = [r.end_to_end_ms for r in results]
+    watcher_latencies = [r.watcher_to_scan_ms for r in results]
+    scan_latencies = [r.scan_to_runtime_start_ms for r in results]
+    runtime_latencies = [r.runtime_execution_ms for r in results]
+
+    def _stats(values: list[int]) -> Dict[str, int]:
+        if not values:
+            return {}
+        return {
+            "min": min(values),
+            "max": max(values),
+            "mean": sum(values) // len(values),
+        }
+
+    return {
+        "end_to_end_ms": _stats(e2e_latencies),
+        "watcher_to_scan_ms": _stats(watcher_latencies),
+        "scan_to_runtime_start_ms": _stats(scan_latencies),
+        "runtime_execution_ms": _stats(runtime_latencies),
+    }
+
+
+def run_latency_harness(
+    *,
+    vault_root: Path,
+    target_subdir: str = "Test",
+    folder: str = "AgenticPKM-UAT",
+    scenario: str = "changed-note-default",
+    outbox_path: Path | None = None,
+    report_path: Path | None = None,
+    dry_run: bool = False,
+) -> LatencySummary:
+    """Run an automated latency harness against a changed-note scenario.
+
+    Args:
+        vault_root: Root path of the vault
+        target_subdir: Vault subdirectory to watch
+        folder: Folder name containing test notes
+        scenario: Name of the scenario being measured
+        outbox_path: Path to the event outbox (defaults to INDEX_OUTBOX_PATH)
+        report_path: Optional path to write JSON report
+        dry_run: If True, don't run the watcher/panel flow
+
+    Returns:
+        LatencySummary with all captured latency measurements
+    """
+    resolved_root = vault_root.expanduser().resolve()
+    scenario_path = resolved_root / target_subdir / folder
+
+    if not scenario_path.exists():
+        raise FileNotFoundError(f"Scenario folder not found: {scenario_path}")
+
+    if outbox_path is None:
+        outbox_path = Path(os.getenv("INDEX_OUTBOX_PATH", "index-outbox.jsonl"))
+
+    outbox_path = outbox_path.expanduser().resolve()
+
+    # Record the initial event count to find new latency events
+    initial_events = read_outbox(outbox_path)
+    initial_count = len(initial_events)
+
+    # Run the watcher/panel flow to generate changed-note events
+    snapshot_path = scenario_path / ".agentic-pkm" / "latency_harness_snapshot.json"
+    snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+
+    original_scope = os.environ.get("WATCHER_SCOPE_GLOB")
+    os.environ["WATCHER_SCOPE_GLOB"] = f"{target_subdir}/{folder}/*.md,{target_subdir}/{folder}/**/*.md"
+
+    try:
+        if not dry_run:
+            # Run watcher with panel execution to generate sync.latency.summary events
+            watcher_summary, watcher_messages = run_watcher_tick(
+                vault_root=resolved_root,
+                snapshot_path=snapshot_path,
+                skip_panel=False,  # Enable panel to generate latency events
+                emit_only=False,
+                dry_run=False,
+                max_notes=50,
+                force=True,  # Force re-evaluation to capture latency
+                outbox_path=outbox_path,
+            )
+
+            for msg in watcher_messages:
+                print(msg)
+
+            # Consume promotions to ensure full pipeline execution
+            consume_promotion_intents(outbox_path=outbox_path)
+            VaultWatcher(resolved_root, snapshot_path=snapshot_path).refresh_snapshot()
+    finally:
+        if original_scope is None:
+            os.environ.pop("WATCHER_SCOPE_GLOB", None)
+        else:
+            os.environ["WATCHER_SCOPE_GLOB"] = original_scope
+
+    # Extract latency events from the outbox
+    all_events = read_outbox(outbox_path)
+    new_events = all_events[initial_count:] if initial_count < len(all_events) else all_events
+
+    latency_events = _extract_sync_latency_events(outbox_path)
+    latency_results = [
+        result
+        for event in latency_events
+        if (result := _parse_latency_event(event)) is not None
+    ]
+
+    # Create the summary
+    run_id = datetime.now().strftime("%Y%m%d-%H%M%S")
+    timestamp = datetime.utcnow().isoformat() + "Z"
+    statistics = _compute_statistics(latency_results)
+
+    summary = LatencySummary(
+        run_id=run_id,
+        timestamp=timestamp,
+        scenario=scenario,
+        latency_results=latency_results,
+        statistics=statistics if latency_results else None,
+    )
+
+    # Write JSON report if requested
+    if report_path:
+        report_path = report_path.expanduser().resolve()
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_data = summary.to_dict()
+        write_contract_report(report_path, report_data)
+
+    return summary
+
+
+__all__ = [
+    "run_latency_harness",
+    "LatencySummary",
+    "LatencyResult",
+]

--- a/docs/plans/LOCAL_TEST_ENVIRONMENT_BOOTSTRAP.md
+++ b/docs/plans/LOCAL_TEST_ENVIRONMENT_BOOTSTRAP.md
@@ -1,12 +1,12 @@
-State: Local test bootstrap plan with steps 1-3 and 5 shipped; deterministic runtime verification remains open as the active stabilization slice.
+State: Local test bootstrap plan with steps 1-3 and 5 shipped; deterministic runtime verification remains open as the active stabilization slice. Automated latency harness available for multi-device sync validation.
 Doc role: Plan
 Authority: Canonical plan for the scripted local test bootstrap chain; step specs and current-state SoT docs win on implementation detail and shipped runtime claims.
 Owner: Runtime / local test bootstrap stabilization
 Temporal class: strategic
 Review cadence: event-driven
 Source of truth: mixed
-Last reviewed: 2026-04-07
-Last verified against: docs/TESTING.md, docs/ENVIRONMENTS.md, Makefile, scripts/start_full_system.sh, scripts/verify_runtime_stack.sh, app/cli/uat.py, merged PRs #340/#346/#348/#349, GitHub Issue #334, current repo + GitHub delivery state on 2026-04-07
+Last reviewed: 2026-04-08
+Last verified against: docs/TESTING.md, docs/ENVIRONMENTS.md, Makefile, scripts/start_full_system.sh, scripts/verify_runtime_stack.sh, app/cli/uat.py, app/cli/latency_harness.py, tests/cli/test_latency_harness.py, merged PRs #340/#346/#348/#349/#367, GitHub Issues #334/#357/#358, current repo + GitHub delivery state on 2026-04-08
 
 # Local Test Environment Bootstrap
 

--- a/tests/cli/test_latency_harness.py
+++ b/tests/cli/test_latency_harness.py
@@ -1,0 +1,252 @@
+"""Tests for the automated multi-device sync latency harness.
+
+Tests the latency event extraction, parsing, and summary generation
+for the sync chain latency measurement harness.
+"""
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
+import tempfile
+
+import pytest
+
+from app.cli.latency_harness import (
+    LatencyResult,
+    LatencySummary,
+    _extract_sync_latency_events,
+    _parse_latency_event,
+    _compute_statistics,
+)
+
+
+@pytest.fixture
+def sample_latency_event() -> Dict[str, Any]:
+    """Create a sample sync.latency.summary event."""
+    return {
+        "event": "sync.latency.summary",
+        "version": "1.0",
+        "timestamp": "2026-04-08T10:30:45Z",
+        "trace_id": "trace-001",
+        "event_id": "event-001",
+        "source": "worker",
+        "payload": {
+            "note_uuid": "note-uuid-001",
+            "note_path": "Test/Folder/note.md",
+            "file_detection_ts": "2026-04-08T10:30:00Z",
+            "scan_requested_ts": "2026-04-08T10:30:02Z",
+            "runtime_start_ts": "2026-04-08T10:30:03Z",
+            "runtime_complete_ts": "2026-04-08T10:30:05Z",
+            "watcher_to_scan_ms": 2000,
+            "scan_to_runtime_start_ms": 1000,
+            "runtime_execution_ms": 2000,
+            "end_to_end_ms": 5000,
+            "trace_id": "trace-001",
+            "source_watcher": "registry",
+        },
+    }
+
+
+@pytest.fixture
+def sample_mixed_events(sample_latency_event: Dict[str, Any]) -> list[Dict[str, Any]]:
+    """Create a mixed list of events including latency events."""
+    return [
+        {
+            "event": "ingest.vault.changed",
+            "timestamp": "2026-04-08T10:30:01Z",
+            "trace_id": "trace-001",
+        },
+        sample_latency_event,
+        {
+            "event": "promotion.project.done",
+            "timestamp": "2026-04-08T10:30:06Z",
+            "trace_id": "trace-001",
+        },
+    ]
+
+
+class TestLatencyEventParsing:
+    """Test parsing of latency events."""
+
+    def test_parse_valid_latency_event(self, sample_latency_event: Dict[str, Any]) -> None:
+        """Parse a valid sync.latency.summary event."""
+        result = _parse_latency_event(sample_latency_event)
+        assert result is not None
+        assert result.note_uuid == "note-uuid-001"
+        assert result.note_path == "Test/Folder/note.md"
+        assert result.end_to_end_ms == 5000
+        assert result.trace_id == "trace-001"
+
+    def test_parse_missing_payload(self) -> None:
+        """Handle events with missing payload."""
+        event = {
+            "event": "sync.latency.summary",
+            "trace_id": "trace-001",
+        }
+        result = _parse_latency_event(event)
+        assert result is None
+
+    def test_parse_invalid_payload_type(self) -> None:
+        """Handle events with non-dict payload."""
+        event = {
+            "event": "sync.latency.summary",
+            "trace_id": "trace-001",
+            "payload": "not a dict",
+        }
+        result = _parse_latency_event(event)
+        assert result is None
+
+    def test_parse_missing_required_fields(self) -> None:
+        """Handle events with missing required fields."""
+        event = {
+            "event": "sync.latency.summary",
+            "trace_id": "trace-001",
+            "payload": {
+                "note_uuid": "note-001",
+                # Missing other required fields
+            },
+        }
+        result = _parse_latency_event(event)
+        # Should still create a result with defaults
+        assert result is not None
+        assert result.note_uuid == "note-001"
+
+
+class TestEventExtraction:
+    """Test extraction of latency events from mixed event lists."""
+
+    def test_extract_latency_events_from_mixed(self, sample_mixed_events: list[Dict[str, Any]]) -> None:
+        """Extract only latency events from mixed event stream."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            outbox_path = Path(tmpdir) / "outbox.jsonl"
+            outbox_path.write_text(
+                "\n".join(json.dumps(e) for e in sample_mixed_events),
+                encoding="utf-8",
+            )
+
+            latency_events = _extract_sync_latency_events(outbox_path)
+            assert len(latency_events) == 1
+            assert latency_events[0]["event"] == "sync.latency.summary"
+            assert latency_events[0]["trace_id"] == "trace-001"
+
+    def test_extract_from_empty_outbox(self) -> None:
+        """Handle extraction from empty or missing outbox."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            outbox_path = Path(tmpdir) / "outbox.jsonl"
+            latency_events = _extract_sync_latency_events(outbox_path)
+            assert latency_events == []
+
+
+class TestStatisticsComputation:
+    """Test computation of latency statistics."""
+
+    def test_compute_statistics_single_result(self) -> None:
+        """Compute statistics from a single latency measurement."""
+        result = LatencyResult(
+            note_uuid="note-001",
+            note_path="path",
+            file_detection_ts="2026-04-08T10:30:00Z",
+            scan_requested_ts="2026-04-08T10:30:02Z",
+            runtime_start_ts="2026-04-08T10:30:03Z",
+            runtime_complete_ts="2026-04-08T10:30:05Z",
+            watcher_to_scan_ms=2000,
+            scan_to_runtime_start_ms=1000,
+            runtime_execution_ms=2000,
+            end_to_end_ms=5000,
+            trace_id="trace-001",
+        )
+
+        stats = _compute_statistics([result])
+        assert stats["end_to_end_ms"]["min"] == 5000
+        assert stats["end_to_end_ms"]["max"] == 5000
+        assert stats["end_to_end_ms"]["mean"] == 5000
+
+    def test_compute_statistics_multiple_results(self) -> None:
+        """Compute statistics from multiple latency measurements."""
+        results = [
+            LatencyResult(
+                note_uuid=f"note-{i}",
+                note_path=f"path-{i}",
+                file_detection_ts="2026-04-08T10:30:00Z",
+                scan_requested_ts="2026-04-08T10:30:02Z",
+                runtime_start_ts="2026-04-08T10:30:03Z",
+                runtime_complete_ts="2026-04-08T10:30:05Z",
+                watcher_to_scan_ms=2000,
+                scan_to_runtime_start_ms=1000,
+                runtime_execution_ms=2000,
+                end_to_end_ms=5000 + i * 1000,  # Vary latencies
+                trace_id=f"trace-{i}",
+            )
+            for i in range(3)
+        ]
+
+        stats = _compute_statistics(results)
+        e2e = stats["end_to_end_ms"]
+        assert e2e["min"] == 5000
+        assert e2e["max"] == 7000
+        assert e2e["mean"] == 6000  # (5000 + 6000 + 7000) / 3 = 6000
+
+
+class TestLatencySummary:
+    """Test latency summary generation."""
+
+    def test_summary_to_dict(self) -> None:
+        """Convert summary to machine-readable JSON dict."""
+        result = LatencyResult(
+            note_uuid="note-001",
+            note_path="Test/note.md",
+            file_detection_ts="2026-04-08T10:30:00Z",
+            scan_requested_ts="2026-04-08T10:30:02Z",
+            runtime_start_ts="2026-04-08T10:30:03Z",
+            runtime_complete_ts="2026-04-08T10:30:05Z",
+            watcher_to_scan_ms=2000,
+            scan_to_runtime_start_ms=1000,
+            runtime_execution_ms=2000,
+            end_to_end_ms=5000,
+            trace_id="trace-001",
+        )
+
+        summary = LatencySummary(
+            run_id="run-20260408-103000",
+            timestamp="2026-04-08T10:30:00Z",
+            scenario="test-scenario",
+            latency_results=[result],
+            statistics={"end_to_end_ms": {"min": 5000, "max": 5000, "mean": 5000}},
+        )
+
+        data = summary.to_dict()
+        assert data["run_id"] == "run-20260408-103000"
+        assert data["scenario"] == "test-scenario"
+        assert data["latency_count"] == 1
+        assert len(data["measurements"]) == 1
+        assert data["measurements"][0]["note_uuid"] == "note-001"
+        assert data["measurements"][0]["latencies_ms"]["end_to_end"] == 5000
+
+    def test_summary_to_lines(self) -> None:
+        """Convert summary to human-readable lines."""
+        result = LatencyResult(
+            note_uuid="note-001",
+            note_path="Test/note.md",
+            file_detection_ts="2026-04-08T10:30:00Z",
+            scan_requested_ts="2026-04-08T10:30:02Z",
+            runtime_start_ts="2026-04-08T10:30:03Z",
+            runtime_complete_ts="2026-04-08T10:30:05Z",
+            watcher_to_scan_ms=2000,
+            scan_to_runtime_start_ms=1000,
+            runtime_execution_ms=2000,
+            end_to_end_ms=5000,
+            trace_id="trace-001",
+        )
+
+        summary = LatencySummary(
+            run_id="run-001",
+            timestamp="2026-04-08T10:30:00Z",
+            scenario="test-scenario",
+            latency_results=[result],
+        )
+
+        lines = summary.to_lines()
+        assert any("Latency Harness Run" in line for line in lines)
+        assert any("test-scenario" in line for line in lines)
+        assert any("1" in line for line in lines)  # 1 measurement


### PR DESCRIPTION
## Summary

Add a new `sync-latency-harness` CLI command that runs an automated latency measurement on the supported local test bootstrap path.

The harness seeds or targets a bounded changed-note scenario, captures machine-readable latency events from the sync chain, and outputs per-run latency summaries suitable for repeated trials and automated multi-device sync validation.

## Changes

- **app/cli/latency_harness.py** — New latency harness module with:
  - `LatencySummary` and `LatencyResult` dataclasses for latency measurements
  - `run_latency_harness()` function that orchestrates the measurement flow
  - Event extraction and parsing from `sync.latency.summary` events
  - Statistics computation (min/max/mean) for latency milestones
  - Both human-readable and machine-readable (JSON) output support

- **app/cli/__init__.py** — New CLI command:
  - `sync-latency-harness --vault-root <path> [--scenario <name>] [--report <path>] [--dry-run]`
  - Integrates with existing test bootstrap infrastructure
  - Runs watcher/panel flow to generate latency events
  - Outputs human-readable latency summary to console
  - Optionally writes JSON report for further analysis

- **tests/cli/test_latency_harness.py** — Comprehensive test suite:
  - 10 tests covering event parsing, extraction, statistics, and summary generation
  - Tests for malformed/missing data handling
  - Multi-measurement statistics verification

- **docs/plans/LOCAL_TEST_ENVIRONMENT_BOOTSTRAP.md** — Updated with:
  - Latency harness availability noted in state line
  - Updated verification sources and last-reviewed date

## How It Works

1. The harness accepts a vault root and scenario parameters
2. Runs the watcher tick with panel execution enabled
3. Consumes promotion intents to complete the sync chain
4. Extracts `sync.latency.summary` events from the outbox
5. Parses events into structured `LatencyResult` objects
6. Computes aggregate statistics (min/max/mean) for each latency stage
7. Outputs human-readable latency report and optional JSON report

## Acceptance Criteria

- ✓ Scripted harness exists that can run bounded changed-note scenario
- ✓ Harness uses supported local test/bootstrap path as base flow
- ✓ Output is suitable for repeated runs and parent feature validation
- ✓ Focused tests cover the new flow (10 tests, all passing)
- ✓ Docs updated in same change

## Test Plan

- Run harness against seeded vault-test notes
- Verify latency measurements are captured and output
- Check that rerun produces idempotent results
- Validate JSON report format when `--report` is specified
- Confirm error handling for missing notes/scenarios

Fixes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)