### PR TITLE
[A2A Routing] Complete routed receipt set: emit response and error events

### DIFF
--- a/app/orchestrator/executor.py
+++ b/app/orchestrator/executor.py
@@ -152,7 +152,19 @@ class MockPlanExecutor(PlanExecutor):
                 f"{agent_name} has no registered handler",
                 error_type="not_implemented",
             )
-        response = handler(request)
+        try:
+            response = handler(request)
+        except Exception as exc:
+            error = new_error(
+                sender="orchestrator.runtime",
+                recipient=agent_name,
+                error_type="handler_error",
+                error_message=str(exc),
+                correlation_id=str(request.id),
+                trace_id=context.trace_id,
+            )
+            emit_agent_error_event(error, object_id=context.object_id)
+            raise StepExecutionError(str(exc), error_type="handler_error") from exc
         emit_agent_response_event(response, object_id=context.object_id)
         return {
             "agent": agent_name,

--- a/tests/orchestrator/test_orchestrator_a2a_errors.py
+++ b/tests/orchestrator/test_orchestrator_a2a_errors.py
@@ -90,3 +90,27 @@ def test_permission_check_runs_before_handler(monkeypatch: pytest.MonkeyPatch) -
     results = orchestrator.run_plan(plan)
     assert results[0]["status"] == "error"
     assert results[0].get("error_type") == "agent_permission"
+
+
+def test_handler_exception_emits_error_event_and_fails_step() -> None:
+    """Handler raising an exception must emit agent.error.created and surface as a failed step."""
+    def _raising_handler(request: AgentRequest) -> AgentResponse:
+        raise RuntimeError("handler crashed")
+
+    plan = _plan_with_agent("review-agent")
+    executor = MockPlanExecutor(handlers={"review-agent": _raising_handler})
+    orchestrator = Orchestrator(executor=executor)
+    before = _audit_ring_snapshot()
+    results = orchestrator.run_plan(plan)
+    after = _audit_ring_snapshot()
+    new_events = [evt for evt in after if evt not in before]
+
+    assert results[0]["status"] == "error"
+    assert results[0].get("error_type") == "handler_error"
+    assert any(evt["event_type"] == AGENT_REQUEST_CREATED for evt in new_events)
+    assert any(
+        evt["event_type"] == AGENT_ERROR_CREATED
+        and evt["payload"].get("details", {}).get("error_type") == "handler_error"
+        for evt in new_events
+    )
+    assert not any(evt["event_type"] == AGENT_RESPONSE_CREATED for evt in new_events)


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Fixes #361

## Summary
- Adds try/except around registered handler dispatch in `MockPlanExecutor._execute_agent_call` so that handler exceptions emit `agent.error.created` with `error_type=handler_error` before surfacing as `StepExecutionError`.
- The success path (`emit_agent_response_event`) and the no-handler path (`not_implemented`) were already implemented in main; this slice closes the failure receipt for the handler-exception case.
- Test added: `test_handler_exception_emits_error_event_and_fails_step` — verifies error event emitted, response event not emitted, step result carries `error_type=handler_error`.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Validation
Implementation lane:
- [x] `ruff check app tests` — passed
- [ ] `mypy app` — mypy not installed in environment; no new type annotations added
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg"` — 8 tests pass across touched surfaces
- [x] Additional targeted checks run as needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)