### PR TITLE
fix: emit watcher.run events from registry watcher; document memory mode limitations

### DIFF
--- a/app/watcher/registry.py
+++ b/app/watcher/registry.py
@@ -26,6 +26,7 @@ from app.settings.panel_actions import PanelActionMapping, load_panel_action_map
 from app.settings.tiering import resolve_dev_lab_env_typed, resolve_dev_lab_env_value
 from app.settings.watcher_settings import load_watcher_settings, resolve_auto_exec_enabled
 from app.vault.layout import load_layout
+from app.watcher.events import emit_watcher_run_event
 from app.watcher.heartbeat import resolve_heartbeat_path, write_registry_heartbeat
 from app.watcher.state import WatcherState
 from app.write_guard import DEFAULT_WRITE_GUARD
@@ -243,9 +244,44 @@ def _finalize_spec_tick(
     summary.setdefault("chosen_sleep_seconds", state.dynamic_sleep_seconds or cfg.tick_sleep_seconds)
     try:
         _log_tick_diagnostics_registry(cfg, summary, scan_root, watcher_name)
+        _emit_registry_watcher_run_event(cfg, summary, watcher_name)
     finally:
         state.save(_state_path(cfg.state_dir, watcher_name))
     return summary
+
+
+def _emit_registry_watcher_run_event(
+    cfg: RegistryConfig,
+    summary: dict[str, object],
+    watcher_name: str,
+) -> None:
+    """Emit a watcher.run event to the outbox so `status` can count registry watcher ticks."""
+    try:
+        run_summary = {
+            "changed": summary.get("changed_in_tick", 0),
+            "ingest_attempted": summary.get("ingest_attempted", 0),
+            "ingested": summary.get("ingested", 0),
+            "panel_candidates": summary.get("panel_candidates", 0),
+            "panel_runs": summary.get("panel_runs_in_tick", 0),
+            "panel_promotions": 0,
+            "panel_skipped_policy": summary.get("panel_skipped_policy", 0),
+            "panel_skipped_limit": 0,
+            "panel_skipped_auto_exec": summary.get("panel_skipped_auto_exec", 0),
+            "errors": summary.get("errors_in_tick", 0),
+            "dry_run": False,
+            "limit_exceeded": bool(summary.get("stop_tripped")),
+            "snapshot_path": "",
+            "vault_root": str(cfg.vault_path),
+        }
+        emit_watcher_run_event(
+            run_summary,
+            vault_root=cfg.vault_path,
+            snapshot_path=None,
+            outbox_path=cfg.outbox_path,
+            trigger=f"registry:{watcher_name}",
+        )
+    except Exception:
+        pass
 
 
 def _write_jsonl_event(event: OutboxEvent, outbox_path: Path) -> None:

--- a/docs/runbooks/UAT_PANEL_WATCHER.md
+++ b/docs/runbooks/UAT_PANEL_WATCHER.md
@@ -53,6 +53,15 @@ VAULT_ROOT="$(pwd)/vault-test" python -m app.cli uat-run-vault-test --vault-root
 - Inbox UUID healing is automatic during watcher/ingest runs; inbox notes should not remain without a `uuid` after a watcher pass.
 
 ## 3) Manual ingest + panel runs (sanity)
+
+**Store backend requirement:** `ingest-vault-paths` and `panel run-many` are separate CLI processes. Each process creates its own in-process store. With `STORE_BACKEND=memory` (the default when no `DATABASE_URL` is set), notes ingested by `ingest-vault-paths` are discarded when that process exits — they are not visible to a subsequent `panel run-many` invocation. The "Note not found in ObjectStore" error is expected in this mode.
+
+To run this manual sanity flow you need either:
+- `DATABASE_URL=<pg_dsn>` — notes are persisted in Postgres across CLI invocations (full stack)
+- or skip this section and use the host-only watcher path in section 4a instead, where ingest and panel run inside the same watcher process
+
+With `DATABASE_URL` set:
+
 1. Ingest the test notes by path:
    ```bash
    python -m app.cli ingest-vault-paths --vault-root <vault_root> path/to/note1.md path/to/note2.md
@@ -66,6 +75,51 @@ VAULT_ROOT="$(pwd)/vault-test" python -m app.cli uat-run-vault-test --vault-root
    - Outbox events (DB): `panel.intent.created`, `panel.intent.executed`, `panel.action.*`, `panel.log.created`, `promote.intent.created` (when mappings include promotion).
    - `panel_logs` field on the note payload (via status/ASK surfaces) contains AI-log entries.
    - No note body rewrites; only frontmatter/mirror metadata changes.
+
+## 4a) Host-only acceptance path (no Docker / no DATABASE_URL)
+
+Use this section when you need to validate watcher + panel behavior on a real vault subset without a running Postgres instance. The registry watcher runs ingest and panel in-process per tick, so the cross-process store limitation in section 3 does not apply.
+
+**Prerequisites:**
+- `STORE_BACKEND` not set (defaults to `memory`) — no Postgres required
+- `INDEX_OUTBOX_PATH` set to a writable JSONL file (e.g. `tmp/index-outbox.jsonl`) so status can read watcher activity
+
+```bash
+export WATCHER_ENABLE=1
+export WATCHER_VAULT_PATH=<vault_root>
+export VAULT_INBOX_DIR_REL=<inbox_dir_rel>       # e.g. Inbox
+export WATCHER_SCOPE_GLOB='_CodexUAT/**/*.md'    # bounded subset
+export INDEX_OUTBOX_PATH=tmp/index-outbox.jsonl
+export WATCHER_AUTO_EXEC=0
+python -m app.cli watcher run --max-ticks 1
+```
+
+Then check status:
+```bash
+python -m app.cli status
+```
+
+Expected after the watcher tick:
+- `watcher runs: total` increments by 1 (or more for multi-spec configs).
+- `Watcher automation` shows `mode=emit-only`, `panel_candidates` > 0, `panel_skipped_auto_exec` = panel_candidates.
+- `tmp/watcher_tick.jsonl` and `tmp/index-outbox.jsonl` contain consistent tick records.
+- `vault: 0 objects` is expected in memory mode after the watcher exits — memory is not persisted across CLI processes. This is correct behavior, not a bug.
+
+To also exercise panel runs inline:
+```bash
+export WATCHER_AUTO_EXEC=1
+python -m app.cli watcher run --max-ticks 1
+```
+
+After a full auto-exec tick:
+- `watcher runs: total` increments again.
+- JSONL outbox contains `panel.scan.requested` entries for candidate notes.
+- Tick log shows non-zero `panel_candidates` and zero (or low) `panel_skipped_auto_exec`.
+
+**What this path does not validate:**
+- Persistent store state across CLI boundaries (requires DATABASE_URL).
+- `panel run-many` on previously ingested notes (requires DATABASE_URL).
+- Worker/outbox delivery (requires DATABASE_URL + worker process).
 
 ## 4) Registry watcher pass — no panel mutations
 1. Run a limited tick with panel auto-exec disabled:
@@ -96,10 +150,12 @@ VAULT_ROOT="$(pwd)/vault-test" python -m app.cli uat-run-vault-test --vault-root
    - `python -m app.cli settings-explain` should show the effective gate as enabled, the allowlist, and watcher settings provenance.
 
 ## 6) What to observe & rollback posture
-- Status: `python -m app.cli status` (or status API) should reflect ingest counts and runs; ASK should surface the UAT notes with source refs.
+- Status: `python -m app.cli status` (or status API) should reflect ingest counts and watcher runs; ASK should surface the UAT notes with source refs (requires DATABASE_URL for cross-process note persistence).
+- Watcher runs counter: after `watcher run --max-ticks 1`, `status` should show `watcher runs: total >= 1`. If still 0, check that `INDEX_OUTBOX_PATH` resolves to a writable path and re-run.
+- Memory mode store: `store-stats` and `status vault: N objects` will report 0 in memory mode after a watcher process exits. This is expected — memory store is per-process. Use `DATABASE_URL` for persistent object counts.
 - Enablement signals: `settings-explain` should agree with `status` on auto-exec mode, allowlist, skip counters, and write-guard/provenance context before an operator treats watcher auto-run as safe.
 - DB outbox: inspect `outbox` table (or `/api/events/tail` if available) for `panel.intent.*` and `promote.intent.created`.
-- JSONL audit: `INDEX_OUTBOX_PATH` lines should mirror watcher emissions but are not consumed by the worker.
+- JSONL audit: `INDEX_OUTBOX_PATH` lines contain `watcher.run` and `panel.scan.requested` entries after a watcher tick; these are the basis for `status watcher runs` counts.
 - CI corroboration: when this UAT flow is part of a release or merge gate, require `CI SUMMARY GATES ok=true` in addition to the local operator signals.
 - Safety: watcher does not rewrite note bodies; downstream agents may update frontmatter/mirrors only. UAT is scoped to the selected notes; the rest of the vault is untouched.
 - Scripted UAT report: `uat-run-vault-test --assert` writes `.agentic-pkm/uat_report.json` inside the seeded folder. Treat that report as the machine-readable release/UAT artifact; it includes first-run results, rerun idempotence, and pass/fail checks.


### PR DESCRIPTION
## Summary

Fixes #378

- **`app/watcher/registry.py`**: `_finalize_spec_tick` now calls `_emit_registry_watcher_run_event` after each tick. This writes a `watcher.run` event to `cfg.outbox_path` so that `python -m app.cli status` can count registry watcher ticks (`watcher runs: total`) instead of always showing 0.
- **`docs/runbooks/UAT_PANEL_WATCHER.md`**: Adds a host-only / memory-mode acceptance path (section 4a), documents that `ingest-vault-paths + panel run-many` requires `DATABASE_URL` in separate CLI invocations (section 3), and clarifies that `vault: 0 objects` after a watcher exit is expected in memory mode (section 6).

### Root causes addressed

| Symptom | Root cause | Fix |
|---|---|---|
| `status` shows `watcher runs: total=0` after `watcher run` | Registry watcher never emitted `watcher.run` events; only `vault-watcher-run` (dev-only) did | Emit `watcher.run` from `_finalize_spec_tick` via new `_emit_registry_watcher_run_event` |
| "Note not found in ObjectStore" when running `panel run-many` after `ingest-vault-paths` in memory mode | Memory store is per-process; notes don't persist across CLI invocations | Document limitation; provide single-process watcher path as host-only alternative |
| `store-stats` shows 0 objects after `ingest-vault-paths` | Same memory-mode per-process limitation | Documented as expected behavior in runbook section 6 |

## Test plan

- [ ] `python -m app.cli watcher run --max-ticks 1` (with `WATCHER_ENABLE=1`, `WATCHER_VAULT_PATH`, `INDEX_OUTBOX_PATH` set) followed by `python -m app.cli status` → `watcher runs: total >= 1`
- [ ] `cat $INDEX_OUTBOX_PATH` → contains `"event":"watcher.run"` record with `"trigger":"registry:panel"` (or `registry:ingest`)
- [ ] Section 4a host-only path in updated runbook is executable end-to-end without Docker
- [ ] Pre-existing test suite collection errors are not introduced by this change (pre-existing Python 3.9 typing issue in `reasoning/facade.py` is unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)