### PR TITLE
fix: preserve transient worker retries for iCloud sync notes

### DIFF
--- a/app/workers/outbox_worker.py
+++ b/app/workers/outbox_worker.py
@@ -20,13 +20,15 @@ from app.runtime.worker_heartbeat import resolve_worker_heartbeat_path, write_wo
 from app.services.indexer import handle_ingest_object_created
 from app.services.companion_note import CompanionNote, scan_attachments, write_companion
 from app.services.note_uuid import ensure_note_uuid
-from app.services.outbox import ack_outbox, bootstrap, poll_outbox_one
+from app.services.outbox import ack_outbox, append_jsonl_outbox_event, bootstrap, poll_outbox_one, write_outbox_event
 from app.vault.paths import get_vault_inbox_dir_rel
 from app.write_guard import DEFAULT_WRITE_GUARD
+from app.events.models import new_event
 from scripts.yaml_roundtrip import load_frontmatter
 
 logger = logging.getLogger(__name__)
 _WRITE_GUARD = OptimisticWriteGuard()
+_MAX_TRANSIENT_RETRY_ATTEMPTS = 3
 
 
 @dataclass
@@ -224,6 +226,66 @@ def _stabilized_note_text(note_path: Path, *, attempts: int = 6, base_sleep: flo
     return None
 
 
+def _outbox_audit_path() -> Path:
+    return Path(os.getenv("INDEX_OUTBOX_PATH", "/app/tmp/index-outbox.jsonl")).expanduser()
+
+
+def _payload_retry_count(payload: Mapping[str, Any]) -> int:
+    raw = payload.get("_worker_retry_count")
+    try:
+        return max(int(raw), 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _queue_transient_retry(topic: str, payload: Mapping[str, Any], *, note_path: Path, reason: str) -> bool:
+    retry_count = _payload_retry_count(payload)
+    if retry_count >= _MAX_TRANSIENT_RETRY_ATTEMPTS:
+        logger.warning(
+            "worker retry exhausted topic=%s note_path=%s reason=%s retry_count=%s",
+            topic,
+            note_path,
+            reason,
+            retry_count,
+        )
+        return False
+
+    retry_payload = dict(payload)
+    retry_payload["_worker_retry_count"] = retry_count + 1
+    retry_payload["_worker_retry_reason"] = reason
+    retry_payload["_worker_retry_enqueued_at"] = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    retry_event = new_event(
+        event_type=topic,
+        payload=retry_payload,
+        trace_id=str(payload.get("trace_id") or "") or None,
+        source="worker",
+    )
+
+    try:
+        if _use_db_outbox():
+            write_outbox_event(retry_event)
+        else:
+            append_jsonl_outbox_event(_outbox_audit_path(), retry_event, default_source="worker")
+    except Exception:
+        logger.exception(
+            "worker retry enqueue failed topic=%s note_path=%s reason=%s retry_count=%s",
+            topic,
+            note_path,
+            reason,
+            retry_count + 1,
+        )
+        return False
+
+    logger.info(
+        "worker retry queued topic=%s note_path=%s reason=%s retry_count=%s",
+        topic,
+        note_path,
+        reason,
+        retry_count + 1,
+    )
+    return True
+
+
 
 def handle_panel_scan_requested(
     payload: Mapping[str, Any], *, vault_root: Path | None = None, trace_id: str | None = None, scan_requested_ts: str | None = None
@@ -237,6 +299,7 @@ def handle_panel_scan_requested(
 
     raw_text = _stabilized_note_text(note_path)
     if raw_text is None:
+        _queue_transient_retry(PANEL_SCAN_REQUESTED, payload, note_path=note_path, reason="file_unstable")
         logger.info("panel scan deferred (file unstable) note_path=%s", note_path)
         return WorkerPanelSummary(emitted=0, deferred=True)
 
@@ -250,6 +313,7 @@ def handle_panel_scan_requested(
         note_uuid = _normalize_uuid_value(frontmatter.get("uuid") if isinstance(frontmatter, dict) else None) or healed_uuid
 
     if not note_uuid:
+        _queue_transient_retry(PANEL_SCAN_REQUESTED, payload, note_path=note_path, reason="missing_uuid")
         logger.info("panel scan skipped (missing uuid) note_path=%s", note_path)
         return WorkerPanelSummary(emitted=0, deferred=True)
 
@@ -263,7 +327,7 @@ def handle_panel_scan_requested(
     execution = run_panel_note_execution(
         note_uuid,
         trace_id=trace_id,
-        outbox_path=Path(os.getenv("INDEX_OUTBOX_PATH", "/app/tmp/index-outbox.jsonl")).expanduser(),
+        outbox_path=_outbox_audit_path(),
         persist_created_to_db=_use_db_outbox(),
     )
     emitted = execution.emitted_count
@@ -293,7 +357,7 @@ def handle_panel_scan_requested(
                 trace_id=trace_id,
                 payload=latency_payload,
             )
-            outbox_path_obj = Path(os.getenv("INDEX_OUTBOX_PATH", "/app/tmp/index-outbox.jsonl")).expanduser()
+            outbox_path_obj = _outbox_audit_path()
             outbox_path_obj.parent.mkdir(parents=True, exist_ok=True)
             with outbox_path_obj.open("a", encoding="utf-8") as f:
                 f.write(latency_event.model_dump_json())
@@ -326,21 +390,11 @@ def handle_ingest_vault_changed(
 
     healed_uuid = _maybe_heal_uuid(note_path, resolved_root)
 
-    try:
-        raw_text = note_path.read_text(encoding="utf-8")
-    except OSError as exc:
-        if exc.errno == errno.ENOENT:
-            logger.warning("ingest skipped (missing note) note_path=%s", note_path)
-            return WorkerIngestSummary(ingested=0)
-        if exc.errno in {errno.EPERM, errno.EACCES, errno.EROFS}:
-            _warn_once(
-                f"ingest_read_perm:{note_path}",
-                "ingest skipped (permission) note_path=%s errno=%s",
-                note_path,
-                exc.errno,
-            )
-            return WorkerIngestSummary(ingested=0)
-        raise
+    raw_text = _stabilized_note_text(note_path)
+    if raw_text is None:
+        _queue_transient_retry(INGEST_VAULT_CHANGED, payload, note_path=note_path, reason="missing_or_unstable_note")
+        logger.warning("ingest skipped (missing note) note_path=%s", note_path)
+        return WorkerIngestSummary(ingested=0)
 
     frontmatter, body = load_frontmatter(raw_text)
     content = (body or raw_text).strip()

--- a/app/workers/outbox_worker.py
+++ b/app/workers/outbox_worker.py
@@ -31,6 +31,10 @@ _WRITE_GUARD = OptimisticWriteGuard()
 _MAX_TRANSIENT_RETRY_ATTEMPTS = 3
 
 
+class TransientRetryEnqueueError(RuntimeError):
+    """Raised when a transient retry cannot be persisted safely."""
+
+
 @dataclass
 class WorkerIngestSummary:
     ingested: int
@@ -238,7 +242,14 @@ def _payload_retry_count(payload: Mapping[str, Any]) -> int:
         return 0
 
 
-def _queue_transient_retry(topic: str, payload: Mapping[str, Any], *, note_path: Path, reason: str) -> bool:
+def _queue_transient_retry(
+    topic: str,
+    payload: Mapping[str, Any],
+    *,
+    note_path: Path,
+    reason: str,
+    trace_id: str | None = None,
+) -> bool:
     retry_count = _payload_retry_count(payload)
     if retry_count >= _MAX_TRANSIENT_RETRY_ATTEMPTS:
         logger.warning(
@@ -257,7 +268,7 @@ def _queue_transient_retry(topic: str, payload: Mapping[str, Any], *, note_path:
     retry_event = new_event(
         event_type=topic,
         payload=retry_payload,
-        trace_id=str(payload.get("trace_id") or "") or None,
+        trace_id=trace_id or str(payload.get("trace_id") or "") or None,
         source="worker",
     )
 
@@ -299,7 +310,14 @@ def handle_panel_scan_requested(
 
     raw_text = _stabilized_note_text(note_path)
     if raw_text is None:
-        _queue_transient_retry(PANEL_SCAN_REQUESTED, payload, note_path=note_path, reason="file_unstable")
+        if not _queue_transient_retry(
+            PANEL_SCAN_REQUESTED,
+            payload,
+            note_path=note_path,
+            reason="file_unstable",
+            trace_id=trace_id,
+        ):
+            raise TransientRetryEnqueueError(f"failed to queue retry for unstable panel note: {note_path}")
         logger.info("panel scan deferred (file unstable) note_path=%s", note_path)
         return WorkerPanelSummary(emitted=0, deferred=True)
 
@@ -313,7 +331,14 @@ def handle_panel_scan_requested(
         note_uuid = _normalize_uuid_value(frontmatter.get("uuid") if isinstance(frontmatter, dict) else None) or healed_uuid
 
     if not note_uuid:
-        _queue_transient_retry(PANEL_SCAN_REQUESTED, payload, note_path=note_path, reason="missing_uuid")
+        if not _queue_transient_retry(
+            PANEL_SCAN_REQUESTED,
+            payload,
+            note_path=note_path,
+            reason="missing_uuid",
+            trace_id=trace_id,
+        ):
+            raise TransientRetryEnqueueError(f"failed to queue retry for missing panel note uuid: {note_path}")
         logger.info("panel scan skipped (missing uuid) note_path=%s", note_path)
         return WorkerPanelSummary(emitted=0, deferred=True)
 
@@ -383,7 +408,7 @@ def _use_db_outbox() -> bool:
     return backend == "pg" or bool(os.getenv("DATABASE_URL") or os.getenv("DB_DSN"))
 
 def handle_ingest_vault_changed(
-    payload: Mapping[str, Any], *, vault_root: Path | None = None
+    payload: Mapping[str, Any], *, vault_root: Path | None = None, trace_id: str | None = None
 ) -> WorkerIngestSummary:
     resolved_root = _resolve_vault_root(vault_root)
     note_path = _note_path_from_payload(payload, vault_root=resolved_root)
@@ -392,7 +417,14 @@ def handle_ingest_vault_changed(
 
     raw_text = _stabilized_note_text(note_path)
     if raw_text is None:
-        _queue_transient_retry(INGEST_VAULT_CHANGED, payload, note_path=note_path, reason="missing_or_unstable_note")
+        if not _queue_transient_retry(
+            INGEST_VAULT_CHANGED,
+            payload,
+            note_path=note_path,
+            reason="missing_or_unstable_note",
+            trace_id=trace_id,
+        ):
+            raise TransientRetryEnqueueError(f"failed to queue retry for missing or unstable note: {note_path}")
         logger.warning("ingest skipped (missing note) note_path=%s", note_path)
         return WorkerIngestSummary(ingested=0)
 
@@ -544,7 +576,7 @@ def run(
                         if topic == INGEST_OBJECT_CREATED:
                             handle_ingest_object_created(payload)
                         elif topic == INGEST_VAULT_CHANGED:
-                            handle_ingest_vault_changed(payload)
+                            handle_ingest_vault_changed(payload, trace_id=trace_id)
                         elif topic == INGEST_OBJECT_DELETED:
                             handle_ingest_object_deleted(payload)
                         elif topic == PANEL_SCAN_REQUESTED:

--- a/tests/runtime/test_worker_dispatch_ingest_vault_changed.py
+++ b/tests/runtime/test_worker_dispatch_ingest_vault_changed.py
@@ -15,8 +15,8 @@ def test_worker_run_dispatches_ingest_vault_changed(
 ) -> None:
     called: list[dict] = []
 
-    def fake_handle(payload, *, vault_root=None):
-        called.append(dict(payload))
+    def fake_handle(payload, *, vault_root=None, trace_id=None):
+        called.append({"payload": dict(payload), "trace_id": trace_id})
         return outbox_worker.WorkerIngestSummary(ingested=0)
 
     monkeypatch.setattr(outbox_worker, "handle_ingest_vault_changed", fake_handle)
@@ -52,7 +52,17 @@ def test_worker_run_dispatches_ingest_vault_changed(
 
     outbox_worker.run(interval=0.0, heartbeat_interval=9999, log_heartbeat_interval=None, stop_after_ticks=2)
 
-    assert called
+    assert called == [
+        {
+            "payload": {
+                "vault_path": str(note_path),
+                "relative_path": "Inbox/note.md",
+                "event_id": "evt-1",
+                "trace_id": "trace-1",
+            },
+            "trace_id": "trace-1",
+        }
+    ]
 
 
 def test_worker_run_dispatches_ingest_object_deleted(

--- a/tests/runtime/test_worker_dispatch_ingest_vault_changed.py
+++ b/tests/runtime/test_worker_dispatch_ingest_vault_changed.py
@@ -103,7 +103,7 @@ def test_worker_run_dispatches_panel_scan_requested(
     called: list[dict] = []
     acked: list[str] = []
 
-    def fake_handle(payload, *, vault_root=None):
+    def fake_handle(payload, *, vault_root=None, trace_id=None, scan_requested_ts=None):
         called.append(dict(payload))
         return outbox_worker.WorkerPanelSummary(emitted=0, deferred=False)
 

--- a/tests/runtime/test_worker_ingest_event.py
+++ b/tests/runtime/test_worker_ingest_event.py
@@ -4,9 +4,12 @@ import json
 import uuid
 from pathlib import Path
 
+import pytest
+
 from app.services.companion_note import read_companion
 from app.store.object_store import ObjectStore
 from app.workers import outbox_worker
+from app.events.types import INGEST_VAULT_CHANGED, PANEL_SCAN_REQUESTED
 from scripts.yaml_roundtrip import load_frontmatter
 from tests.helpers.pkm_alpha_helper import reset_memory_stores
 
@@ -318,3 +321,81 @@ def test_handle_panel_scan_requested_defers_unstable_file(tmp_path: Path, monkey
     summary = outbox_worker.handle_panel_scan_requested(payload, vault_root=vault_root)
     assert summary.emitted == 0
     assert summary.deferred is True
+
+
+def test_handle_panel_scan_requested_queues_retry_for_unstable_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    reset_memory_stores()
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_DSN", raising=False)
+
+    vault_root = tmp_path / "vault"
+    inbox = vault_root / "📥 Inbox"
+    inbox.mkdir(parents=True, exist_ok=True)
+
+    note_path = inbox / "panel-note.md"
+    note_path.write_text("stub", encoding="utf-8")
+
+    monkeypatch.setattr(outbox_worker, "_stabilized_note_text", lambda *_args, **_kwargs: None)
+
+    queued: list[tuple[Path, object, str]] = []
+
+    def fake_append(path: Path, event, default_source: str = "worker") -> None:
+        queued.append((path, event, default_source))
+
+    monkeypatch.setattr(outbox_worker, "append_jsonl_outbox_event", fake_append)
+
+    payload = {
+        "vault_path": str(note_path),
+        "relative_path": "📥 Inbox/panel-note.md",
+        "hash": "test-hash",
+        "mtime": 123.0,
+    }
+
+    summary = outbox_worker.handle_panel_scan_requested(payload, vault_root=vault_root)
+    assert summary.emitted == 0
+    assert summary.deferred is True
+    assert len(queued) == 1
+
+    retry_event = queued[0][1]
+    assert retry_event.event_type == PANEL_SCAN_REQUESTED
+    assert retry_event.payload["_worker_retry_count"] == 1
+    assert retry_event.payload["_worker_retry_reason"] == "file_unstable"
+
+
+def test_handle_ingest_vault_changed_queues_retry_for_missing_note(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    reset_memory_stores()
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_DSN", raising=False)
+
+    vault_root = tmp_path / "vault"
+    (vault_root / "📥 Inbox").mkdir(parents=True, exist_ok=True)
+    note_path = vault_root / "📥 Inbox" / "missing.md"
+
+    queued: list[tuple[Path, object, str]] = []
+
+    def fake_append(path: Path, event, default_source: str = "worker") -> None:
+        queued.append((path, event, default_source))
+
+    monkeypatch.setattr(outbox_worker, "append_jsonl_outbox_event", fake_append)
+
+    payload = {
+        "vault_path": str(note_path),
+        "relative_path": "📥 Inbox/missing.md",
+        "hash": "test-hash",
+        "mtime": 123.0,
+    }
+
+    summary = outbox_worker.handle_ingest_vault_changed(payload, vault_root=vault_root)
+    assert summary.ingested == 0
+    assert len(queued) == 1
+
+    retry_event = queued[0][1]
+    assert retry_event.event_type == INGEST_VAULT_CHANGED
+    assert retry_event.payload["_worker_retry_count"] == 1
+    assert retry_event.payload["_worker_retry_reason"] == "missing_or_unstable_note"

--- a/tests/runtime/test_worker_ingest_event.py
+++ b/tests/runtime/test_worker_ingest_event.py
@@ -354,15 +354,49 @@ def test_handle_panel_scan_requested_queues_retry_for_unstable_file(
         "mtime": 123.0,
     }
 
-    summary = outbox_worker.handle_panel_scan_requested(payload, vault_root=vault_root)
+    summary = outbox_worker.handle_panel_scan_requested(payload, vault_root=vault_root, trace_id="trace-panel-envelope")
     assert summary.emitted == 0
     assert summary.deferred is True
     assert len(queued) == 1
 
     retry_event = queued[0][1]
     assert retry_event.event_type == PANEL_SCAN_REQUESTED
+    assert retry_event.trace_id == "trace-panel-envelope"
     assert retry_event.payload["_worker_retry_count"] == 1
     assert retry_event.payload["_worker_retry_reason"] == "file_unstable"
+
+
+def test_handle_panel_scan_requested_aborts_when_retry_enqueue_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    reset_memory_stores()
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_DSN", raising=False)
+
+    vault_root = tmp_path / "vault"
+    inbox = vault_root / "📥 Inbox"
+    inbox.mkdir(parents=True, exist_ok=True)
+
+    note_path = inbox / "panel-note.md"
+    note_path.write_text("stub", encoding="utf-8")
+
+    monkeypatch.setattr(outbox_worker, "_stabilized_note_text", lambda *_args, **_kwargs: None)
+
+    def fail_append(*_args, **_kwargs) -> None:
+        raise OSError("outbox unavailable")
+
+    monkeypatch.setattr(outbox_worker, "append_jsonl_outbox_event", fail_append)
+
+    payload = {
+        "vault_path": str(note_path),
+        "relative_path": "📥 Inbox/panel-note.md",
+        "hash": "test-hash",
+        "mtime": 123.0,
+    }
+
+    with pytest.raises(outbox_worker.TransientRetryEnqueueError):
+        outbox_worker.handle_panel_scan_requested(payload, vault_root=vault_root, trace_id="trace-panel-envelope")
 
 
 def test_handle_ingest_vault_changed_queues_retry_for_missing_note(
@@ -391,11 +425,40 @@ def test_handle_ingest_vault_changed_queues_retry_for_missing_note(
         "mtime": 123.0,
     }
 
-    summary = outbox_worker.handle_ingest_vault_changed(payload, vault_root=vault_root)
+    summary = outbox_worker.handle_ingest_vault_changed(payload, vault_root=vault_root, trace_id="trace-ingest-envelope")
     assert summary.ingested == 0
     assert len(queued) == 1
 
     retry_event = queued[0][1]
     assert retry_event.event_type == INGEST_VAULT_CHANGED
+    assert retry_event.trace_id == "trace-ingest-envelope"
     assert retry_event.payload["_worker_retry_count"] == 1
     assert retry_event.payload["_worker_retry_reason"] == "missing_or_unstable_note"
+
+
+def test_handle_ingest_vault_changed_aborts_when_retry_enqueue_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    reset_memory_stores()
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_DSN", raising=False)
+
+    vault_root = tmp_path / "vault"
+    (vault_root / "📥 Inbox").mkdir(parents=True, exist_ok=True)
+    note_path = vault_root / "📥 Inbox" / "missing.md"
+
+    def fail_append(*_args, **_kwargs) -> None:
+        raise OSError("outbox unavailable")
+
+    monkeypatch.setattr(outbox_worker, "append_jsonl_outbox_event", fail_append)
+
+    payload = {
+        "vault_path": str(note_path),
+        "relative_path": "📥 Inbox/missing.md",
+        "hash": "test-hash",
+        "mtime": 123.0,
+    }
+
+    with pytest.raises(outbox_worker.TransientRetryEnqueueError):
+        outbox_worker.handle_ingest_vault_changed(payload, vault_root=vault_root, trace_id="trace-ingest-envelope")


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Fixes #388

## Summary
- preserve transient worker events by queuing a bounded retry when panel or ingest note reads fail during iCloud convergence
- add focused regression coverage for unstable panel reads, missing ingest notes, and the panel dispatch signature used by the worker loop

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [ ] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [ ] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [ ] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [ ] `ruff check app tests`
- [ ] `mypy app`
- [ ] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg"`
- [x] Additional targeted checks run as needed

Targeted checks run:
- `python3 -m ruff check app/workers/outbox_worker.py tests/runtime/test_worker_ingest_event.py tests/runtime/test_worker_dispatch_ingest_vault_changed.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest -q tests/runtime/test_worker_ingest_event.py tests/runtime/test_worker_uuid_heal_retry.py tests/runtime/test_worker_dispatch_ingest_vault_changed.py tests/workers/test_panel_scan_latency.py`

## Notes
- This PR keeps the existing watcher -> outbox -> worker path intact and bounds the retry path to the worker.
- Full repo-wide validation was not run in this turn.
- Owner-doc promotion is not applicable yet because this slice fixes runtime behavior rather than promoting a completed feature acceptance state.

