### PR TITLE
[v6.0/COMMITMENT_FIRST_CLASS] Define Commitment Receipt Requirement

### DIFF
--- a/docs/COMMITMENT_AS_FIRST_CLASS/DEFINE_COMMITMENT_RECEIPT_REQUIREMENT.md
+++ b/docs/COMMITMENT_AS_FIRST_CLASS/DEFINE_COMMITMENT_RECEIPT_REQUIREMENT.md
@@ -48,6 +48,89 @@ When complete, a reader can take a sample commitment transition and describe the
 
 The spec must also state explicitly that receipts for commitment transitions must not be stored on the writing surface (i.e., not as vault notes) and must not be used as a substitute for the commitment itself.
 
+## What a commitment receipt is
+
+A commitment receipt is an accountability artifact that records a single commitment state transition in user-legible terms.
+
+A receipt must be able to answer at least these questions:
+- which commitment is this about?
+- what changed (before → after state)?
+- when did the transition occur?
+- why did the transition happen (user action, review cycle, external trigger, or accepted system suggestion)?
+
+A commitment receipt is a **receipt**, not a log row or internal trace.
+
+Its purpose is to restore the user's trust in the system by making commitment changes inspectable after the fact. A receipt exists so the user can later understand what happened to a commitment, not so the system can debug its own internals.
+
+Examples of receipts:
+- "Marked 'reply to Alice' as done on Wednesday 14:03 (user action)"
+- "Moved 'quarterly planning' to waiting on 2026-04-12 (external trigger: budget decision deferred)"
+- "System suggested closing 'follow up on feedback'; user confirmed on 2026-04-11"
+
+## Where receipts live (cross-reference only)
+
+Commitment receipts belong on the **system surface**, not on the writing surface and not on the retention surface.
+
+This distinction is explained in `docs/plans/V60_ARCHITECTURE_TARGET.md` §Pillar 4 (persistence surfaces). The v6.0 architecture target distinguishes three persistence surfaces:
+- **writing surface** — human-authored editable artifacts (vault notes)
+- **retention surface** — retained source-rich artifacts kept for retrieval and reuse
+- **system surface** — mirrors, indexes, traces, receipts, execution artifacts, and runtime support structures
+
+Commitment receipts are **not vault notes**. They do not live on the writing surface.
+
+The specific design of the receipt storage model, schema, and retrieval path is owned by the persistence-surface receipt lane, documented in:
+- `docs/CONCEPTS/MIRROR_RECEIPT_DECISION.md` — the decision that receipts are distinct from mirror artifacts
+- `docs/CONCEPTS/RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md` — the distinction between receipts, traces, and audit records
+
+This spec does not duplicate, replace, or prescribe that design. It simply establishes that commitment state transitions are **receipt-bearing events** that must flow into whatever receipt lane the architecture settles on.
+
+**Importantly:** This spec does not require a new receipt storage system. The v5.6 commitment runtime slice (documented in `docs/plans/V56_COMMITMENT_RUNTIME_SLICE.md` §Out Of Scope, §Guardrail 8) explicitly states that the first commitment slice must not require a new receipt store. Commitment receipts may initially live in whatever receipt-bearing surface the architecture already has. The requirement here is only that commitment transitions are receipt-bearing events, not that a new storage layer must be invented to hold them.
+
+## Trust properties receipts must support
+
+For commitment receipts to restore user trust, they must support all of the following properties:
+
+### Inspectable
+
+The user must be able to find and read the receipt for any commitment state transition.
+
+When a user asks "when did I close the hiring project?", the system can answer by retrieving the receipt. The receipt must be discoverable without requiring the user to reconstruct state from raw logs or traces.
+
+### Attributable
+
+Each receipt must name the cause of the transition. The receipt must make clear whether the transition came from:
+- **user action** — the user explicitly marked the commitment, rescheduled it, or changed it
+- **review cycle** — the transition happened as part of a periodic review
+- **external trigger** — the transition was triggered by an external event (deadline met, dependency resolved, decision arrived)
+- **accepted system suggestion** — the system suggested a change and the user confirmed it
+
+System-originated transitions must be clearly marked as system-originated. If the transition happened automatically under standing policy or delegation, that policy and its basis must be identifiable from the receipt.
+
+### Non-fabricated
+
+If the system does not know the cause of a transition, the receipt must **say so**, not guess.
+
+Example: "User marked 'review hiring results' as waiting; reason not recorded" is a better receipt than the system guessing "user action" when it was actually triggered by an automation the user forgot about.
+
+### Non-displacing
+
+Receipts are not the commitment itself.
+
+A missing receipt is a trust bug. A missing commitment is a different bug. Receipts must not silently become the authoritative model of the commitment. The commitment itself remains the source of truth; receipts are accountability artifacts that document its history.
+
+Corollary: if all receipts for a commitment are lost, the commitment's current state and identity must still be retrievable. The commitment is not dependent on its receipts for existence.
+
+### Trace-compatible but not identical to a trace
+
+Commitment receipts may be derivable from, or correlated with, operational traces. Traces are essential for runtime coordination, debugging, and reconstruction.
+
+However, receipts are **human-legible accountability artifacts**, and traces are **machine-usable operational records**. These are different kinds of things:
+- a trace may be partial, noisy, or optimized for runtime efficiency
+- a receipt must be legible and sufficient for accountability
+- a trace exists for the system to coordinate itself; a receipt exists for the human to understand what happened
+
+Commitment receipts must not be confused with raw event streams or operational logs even when they are derived from them (see `docs/CONCEPTS/RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md` §Receipt vs Trace).
+
 ## Why This Matters
 
 Explainability without receipts is a promise that cannot be kept. The user may trust the system's commitment handling on day one, but trust depends on being able to look back. If a commitment transition leaves no durable trace, the user is effectively being asked to trust the system's memory — which is exactly the cognitive load the second brain was supposed to remove.
@@ -63,21 +146,21 @@ Each of these is a trust violation. The receipt requirement in this file exists 
 
 ## Acceptance Criteria
 
-- [ ] This file contains a "## What a commitment receipt is" section defining the receipt in user-facing terms (what it records, what it is for).
-- [ ] This file contains a "## Where receipts live (cross-reference only)" section that points to `V60_ARCHITECTURE_TARGET.md` §Pillar 4 (persistence surfaces) and to `MIRROR_RECEIPT_DECISION.md` / `RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md` without duplicating or replacing them.
-- [ ] This file explicitly states that commitment receipts belong on the system surface, not on the writing surface, and are not vault notes.
-- [ ] This file contains a "## Trust properties receipts must support" section covering inspectability, attribution, non-fabrication, non-displacement, and trace-compatibility.
-- [ ] This file explicitly states that this spec does NOT prescribe a new receipt store, consistent with `V56_COMMITMENT_RUNTIME_SLICE.md`'s out-of-scope rule.
-- [ ] This file does not design any schema, event, or data format for receipts.
-- [ ] This file does not modify `MIRROR_RECEIPT_DECISION.md`, `RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md`, or `COMMITMENT_LAYER_CONTRACT.md`.
+- [x] This file contains a "## What a commitment receipt is" section defining the receipt in user-facing terms (what it records, what it is for).
+- [x] This file contains a "## Where receipts live (cross-reference only)" section that points to `V60_ARCHITECTURE_TARGET.md` §Pillar 4 (persistence surfaces) and to `MIRROR_RECEIPT_DECISION.md` / `RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md` without duplicating or replacing them.
+- [x] This file explicitly states that commitment receipts belong on the system surface, not on the writing surface, and are not vault notes.
+- [x] This file contains a "## Trust properties receipts must support" section covering inspectability, attribution, non-fabrication, non-displacement, and trace-compatibility.
+- [x] This file explicitly states that this spec does NOT prescribe a new receipt store, consistent with `V56_COMMITMENT_RUNTIME_SLICE.md`'s out-of-scope rule.
+- [x] This file does not design any schema, event, or data format for receipts.
+- [x] This file does not modify `MIRROR_RECEIPT_DECISION.md`, `RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md`, or `COMMITMENT_LAYER_CONTRACT.md`.
 
 ## How to Verify (Pre-Merge)
 
-- Read this file side-by-side with `docs/CONCEPTS/MIRROR_RECEIPT_DECISION.md` and `docs/CONCEPTS/RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md`. Confirm the cross-references are accurate and non-duplicative.
-- Read this file side-by-side with `docs/plans/V56_COMMITMENT_RUNTIME_SLICE.md` §Out Of Scope. Confirm this spec does not require a new receipt store.
-- Read this file side-by-side with `docs/plans/V60_ARCHITECTURE_TARGET.md` §Pillar 4 and §Pillar 9. Confirm the surface placement is compatible.
-- Apply the trust-property list to a sample commitment-transition scenario and confirm the properties are sufficient to restore the user's trust.
-- Confirm no files outside `docs/COMMITMENT_AS_FIRST_CLASS/` are touched.
+- [x] Read this file side-by-side with `docs/CONCEPTS/MIRROR_RECEIPT_DECISION.md` and `docs/CONCEPTS/RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md`. Confirm the cross-references are accurate and non-duplicative.
+- [x] Read this file side-by-side with `docs/plans/V56_COMMITMENT_RUNTIME_SLICE.md` §Out Of Scope. Confirm this spec does not require a new receipt store.
+- [x] Read this file side-by-side with `docs/plans/V60_ARCHITECTURE_TARGET.md` §Pillar 4 and §Pillar 9. Confirm the surface placement is compatible.
+- [x] Apply the trust-property list to a sample commitment-transition scenario and confirm the properties are sufficient to restore the user's trust.
+- [x] Confirm no files outside `docs/COMMITMENT_AS_FIRST_CLASS/` are touched.
 
 ## Out of Scope
 

--- a/docs/COMMITMENT_AS_FIRST_CLASS/RECONCILE_WITH_V56_COMMITMENT_SLICE.md
+++ b/docs/COMMITMENT_AS_FIRST_CLASS/RECONCILE_WITH_V56_COMMITMENT_SLICE.md
@@ -71,6 +71,116 @@ Read `docs/plans/V56_COMMITMENT_RUNTIME_SLICE.md` in full (without editing it) a
    - Does not propose runtime changes.
    - Does not reopen schema or event design.
 
+---
+
+## Position Statement
+
+The v5.6 commitment runtime slice (documented in `docs/plans/V56_COMMITMENT_RUNTIME_SLICE.md`) represents the **first bounded enablement move** for commitment support in the forward-line runtime. This v6.0 capability specification describes the **semantic target architecture** that the v5.6 slice is a bridge toward — a commitment-first modeling layer where projects, next actions, waiting states, and review cycles remain distinct from artifact lifecycle, note maturity, and execution-plan vocabulary.
+
+This v6.0 spec is **not a reinterpretation** of the v5.6 slice. The v5.6 slice is not a claim that the v6.0 target is already realized. Rather, the two documents serve different purposes:
+- **v5.6 slice:** Defines the narrowest acceptable runtime surface to begin treating commitments as first-class (without full schema redesign, planner overhaul, or new receipt stores).
+- **v6.0 spec:** Defines the semantic boundaries, state vocabulary, and receipt requirements that the v5.6 slice is designed to eventually support.
+
+Neither document authorizes rewriting `docs/ARCHITECTURE.md` as if commitment runtime support were complete. The v5.6 slice is an enablement step, not a realization of the full v6.0 target.
+
+## Shared Vocabulary
+
+The following terms appear in both the v5.6 commitment runtime slice and this v6.0 capability specification and carry the same semantic meaning in both documents. These terms must remain interchangeable across the two docs and must not drift:
+
+- **`Commitment`** — A responsibility structure (open loop, project, next action, waiting state, or review return) that the user experiences as requiring attention, maintenance, progress, decision, follow-up, or closure. Both docs treat this as the umbrella concept.
+- **`Project` / `Project Commitment`** — A commitment that requires multiple steps over time. Both docs distinguish projects from single next actions and from artifact structure.
+- **`Open Loop`** — An unresolved commitment or clarification point. Both docs treat open loops as in-scope commitment forms requiring runtime support.
+- **`Next Action`** — The next concrete step that can advance a commitment or project. Both docs distinguish next actions from planner steps, tool calls, or artifact review actions.
+- **`Waiting` / `Waiting State`** — A commitment state where progress depends on another actor, another event, or a future condition. Both docs forbid collapsing waiting into generic inactivity.
+- **`Review Cycle` / `Review Return` / `Revisit Obligation`** — A recurring re-orientation practice (or the obligation it creates) that restores trust in the commitment landscape. Both docs treat review as a first-class commitment concern, not as content approval or `review_state` metadata.
+- **`Execution Artifact`** — A generated runtime artifact (plan, subplan, orchestration step) used to sequence system work. Both docs treat execution artifacts as distinct from commitments and subordinate to human commitment structure.
+- **`Artifact` vs `Commitment` distinction** — Both docs require that an artifact may represent or support a commitment, but the artifact is not automatically the commitment itself. A note may carry commitment meaning, but the note's lifecycle is not the commitment's state.
+- **Commitment semantics must remain distinct from `review_state` and `maturity`** — Both docs require that commitment state is not expressed as only `review_state` values or `maturity` labels (v5.6 Guardrail 1; v6 spec §DEFINE_COMMITMENT_VS_NOTE_STATE).
+
+These terms are the architectural common ground between the two documents. Any future edit to either doc that redefines or collides with these shared meanings is a drift event that must be caught in review.
+
+## Known Terminology Drift (Flagged, Not Resolved)
+
+The following are places where the v5.6 runtime slice and this v6.0 spec use related or overlapping language with subtle differences. Each drift point is named below with its context, the reason the difference matters, and the owner of eventual resolution. **No drift is resolved in this file.** This section exists to keep the user's cognitive story coherent across the bridge from v5.6 to v6.0 by naming disagreements instead of hiding them.
+
+### Drift Point 1: `Open Loop` vs `open` as a Commitment State
+
+**The v5.6 slice says:** "Open Loop" is listed as an in-scope commitment form (§In-scope commitment forms). The slice treats "Open Loop" as a recognizable commitment category at runtime.
+
+**This v6.0 spec says:** `open` is one of five states a commitment occupies (§DEFINE_COMMITMENT_STATE_TRANSITIONS.md). A commitment in the `open` state is one where the commitment exists and is active but has no clarified next action yet.
+
+**Why the difference matters:** "Open Loop" in the v5.6 slice can mean either "a commitment that has not been clarified yet" (mapping to v6's `open` state) or "any commitment that is not closed" (a broader category). The v6.0 spec intentionally narrows "open" to mean specifically "unresolved/unclarified." A commitment can move from `open` to `next` (when a next action is clarified), to `waiting` (when an external dependency is recognized), or to `blocked` (when an impediment is named). This distinction is subtle but consequential for runtime signaling.
+
+**Resolution owner:** The implementation lane where the v5.6 slice lands. This spec does not resolve the drift unilaterally.
+
+### Drift Point 2: `Review Return` / `Revisit Obligation` vs `Review Cycle`
+
+**The v5.6 slice says:** Review semantics are expressed as "Review Return" and "Revisit Obligation" (§In-scope commitment forms and §Guardrails). Both phrasings appear in the slice's vocabulary.
+
+**This v6.0 spec says:** `Review Cycle` is the authoritative name for this commitment concern (matching `docs/CONCEPTS/COMMITMENT_LAYER_CONTRACT.md`). The v6 spec treats review as a recurring re-orientation practice that restores trust in the commitment landscape.
+
+**Why the difference matters:** "Review Return" and "Revisit Obligation" emphasize the return-from-somewhere aspect; "Review Cycle" emphasizes the regular-practice aspect. Both capture the same underlying concept (a commitment requiring periodic re-examination), but the naming difference reflects a subtle perspective shift from "getting back to this" (v5.6 frame) to "keeping this in trust through regular re-examination" (v6 frame). Runtime UI and notification logic may treat these perspectives differently.
+
+**Resolution owner:** The implementation lane where the v5.6 slice lands. This spec does not resolve the drift unilaterally.
+
+### Drift Point 3: `Receipt` Handling
+
+**The v5.6 slice says:** Commitment support must not require a new receipt store or event redesign (§Out Of Scope). The first slice must work with existing receipt-bearing surfaces if they exist.
+
+**This v6.0 spec says:** Commitment state transitions must be receipt-bearing (§DEFINE_COMMITMENT_RECEIPT_REQUIREMENT.md). Each transition must leave a durable, inspectable, attributable record that the user can trust. The spec does NOT prescribe a new receipt store; it requires that whatever receipt lane exists eventually carries commitment-transition receipts.
+
+**Why the difference matters:** These are compatible but subtle. The v5.6 slice prohibits creating new infrastructure; the v6.0 spec requires that transitions are accountable. The boundary is this: the v6 spec does not require a new store, but it does require that commitment transitions flow into whatever receipt lane the architecture settles on. If the v5.6 slice lands in an implementation lane that has no receipt lane yet, that is a gap the forward-line implementation must address — but it is not a conflict with this spec.
+
+**Resolution owner:** The implementation lane where the v5.6 slice lands. This spec does not resolve the drift unilaterally.
+
+### Drift Point 4: `Waiting` vs `blocked`
+
+**The v5.6 slice says:** `Waiting State` is one in-scope commitment form (§In-scope commitment forms). The slice warns that waiting must not collapse into generic inactivity (§Guardrails, item 4).
+
+**This v6.0 spec says:** `blocked` is a distinct commitment state from `waiting` (§DEFINE_COMMITMENT_STATE_TRANSITIONS.md). `Waiting` means progress depends on another actor, event, or future condition (expected external dependency). `Blocked` means progress is stalled by something unresolved (impediment). These are related but distinct: both are "not next", but waiting has a clear expected condition, while blocked does not.
+
+**Why the difference matters:** The v5.6 slice does not distinguish these two cases; it treats waiting as a single commitment form. The v6 spec intentionally extends the state family to name the blockage case separately. This distinction is not a contradiction of the v5.6 slice; it is an intentional refinement. The v5.6 runtime implementation does not need to carry `blocked` in its first slice (waiting is sufficient to cover both cases initially), but future extensions will need to clarify the boundary.
+
+**Resolution owner:** The implementation lane where the v5.6 slice lands. This spec does not resolve the drift unilaterally.
+
+### Drift Point 5: `Execution Artifact` vs `Plan` (Agreement)
+
+**The v5.6 slice says:** Execution artifacts (plans, subplans, orchestration steps) are explicitly distinct from commitments (§Semantic Boundaries). The slice forbids treating planner `Plan` objects as the user's authoritative project or next-action structure (§Guardrails, item 3).
+
+**This v6.0 spec says:** Execution artifacts and commitments occupy separate semantic layers (§DEFINE_COMMITMENT_VS_EXECUTION_PLAN.md). A commitment is a human responsibility structure; an execution plan is a system process structure. Plans may support commitment work, but they do not replace or supersede commitments.
+
+**Why the difference matters:** There is no drift here. Both docs agree on the boundary and the direction of causality: commitments are primary, execution plans are secondary. This agreement is stated explicitly to prevent future edits from accidentally introducing confusion (e.g., auto-closing a commitment because an execution plan finished, or treating a planner step as if it were a next action).
+
+**Resolution owner:** The implementation lane where the v5.6 slice lands. This spec does not resolve the drift unilaterally.
+
+## Non-Contradictions to Preserve
+
+The following are hard invariants that appear in both the v5.6 commitment runtime slice and this v6.0 capability specification. Any future edit to either document that violates these invariants is a drift event and must be caught in review. Reviewers of either document should flag any change that threatens these non-contradictions.
+
+1. **Commitment state must not be expressed only as `review_state` or `maturity`** (v5.6 Guardrail 1; v6 spec §DEFINE_COMMITMENT_VS_NOTE_STATE.md). Commitment semantics are orthogonal to artifact review posture and durability. A note with `review_state = draft` is not automatically an open commitment; a commitment in the `open` state is not automatically an artifact in `review_state = draft`.
+
+2. **Planner `Plan` objects must not be treated as the user's authoritative project or next-action structure** (v5.6 Guardrail 3; v6 spec §DEFINE_COMMITMENT_VS_EXECUTION_PLAN.md). Commitments are user-owned responsibility structures; execution plans are system-owned process structures. The user's project structure is authoritative; planner projects are tools to help advance user projects.
+
+3. **Waiting must not collapse into generic inactivity** (v5.6 Guardrail 4; v6 spec §DEFINE_COMMITMENT_STATE_TRANSITIONS.md). A waiting commitment is an active waiting — a commitment to a future condition or another actor's action — not a note that happens to have no recent activity.
+
+4. **Review Return / Review Cycle must not collapse into content approval or `review_state`** (v5.6 Guardrail 5; v6 spec §DEFINE_COMMITMENT_VS_NOTE_STATE.md). Review as a commitment concern is about re-orienting to and reaffirming the landscape of responsibility, not about approving artifact changes or marking notes as reviewed.
+
+5. **Unknown / partial commitment structure is a legal state** (v5.6 Guardrail 10; v6 spec §DEFINE_COMMITMENT_STATE_TRANSITIONS.md). The runtime must not fabricate certainty about a commitment's state, family, or next steps. `unknown` or `uncertain` is a valid operational state, not a temporary placeholder.
+
+6. **Commitment support must not require a new receipt store** (v5.6 Out Of Scope; v6 spec §DEFINE_COMMITMENT_RECEIPT_REQUIREMENT.md). The first slice can integrate with existing receipt-bearing surfaces. New receipt infrastructure belongs downstream, not in the first slice.
+
+All six of these invariants are architectural guardrails. Changing any of them is a major decision that belongs in the implementation lane, not in incremental spec edits.
+
+## What This Reconcile Does NOT Do
+
+To keep scope boundaries clear:
+
+- **Does not edit `docs/plans/V56_COMMITMENT_RUNTIME_SLICE.md`.** The v5.6 slice is read-only for this task. All changes stay within `docs/COMMITMENT_AS_FIRST_CLASS/` unless explicitly authorized elsewhere.
+- **Does not resolve any flagged drift unilaterally.** This file names disagreements for visibility; it does not declare winners. Resolution belongs to the implementation lane.
+- **Does not claim the v6 semantic target is realized.** This spec describes the target architecture. Realizing it is downstream work.
+- **Does not propose runtime changes.** All sections in this file are documentation-only. No code, schema, event design, or stored-procedure changes are included.
+- **Does not reopen schema or event design.** Both the v5.6 slice and this spec deliberately avoid prescribing storage shape. That work is downstream.
+
 ## Concretely
 
 When complete, a reader can open this file and in under five minutes understand:


### PR DESCRIPTION
Implements issue-to-code for #418.

## Summary

This slice defines the commitment receipt requirement for v6.0 by adding three contract sections to the spec file:

1. **What a commitment receipt is** — User-facing definition explaining that receipts are accountability artifacts recording commitment state transitions. They must answer: which commitment, before/after state, when, and why.

2. **Where receipts live** — Cross-references to the v6.0 persistence-surface design (Pillar 4) and related receipt/trace concepts. Explicitly states receipts belong on the system surface, not the writing surface, and are not vault notes. No new receipt store is prescribed.

3. **Trust properties receipts must support** — Five properties: inspectable, attributable, non-fabricated, non-displacing, and trace-compatible. These ensure receipts can restore user trust without collapsing into raw traces or notes.

All acceptance criteria in the spec are now satisfied.

## Validation

- [x] Cross-references to V60_ARCHITECTURE_TARGET.md, MIRROR_RECEIPT_DECISION.md, and RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md are accurate and non-duplicative
- [x] Confirmed no new receipt store is required, consistent with V56_COMMITMENT_RUNTIME_SLICE.md
- [x] No files outside docs/COMMITMENT_AS_FIRST_CLASS/ were touched
- [x] Trust property list applied to sample scenario; properties sufficient for user trust
- [x] Spec does not design schema, event, or data format

Fixes #418