### PR TITLE
docs: record partial acceptance of iCloud sync-latency harness

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,7 +5,7 @@ Owner: Product / architecture forward line
 Temporal class: strategic
 Review cadence: biweekly
 Source of truth: mixed
-Last reviewed: 2026-04-12
+Last reviewed: 2026-04-13
 Last verified against: docs/STATUS.md, docs/ARCHITECTURE.md, docs/DOCS_INDEX.md, docs/EVENTS.md, docs/OBSERVABILITY.md, docs/plans/AUTONOMY_AND_SYNC_VALIDATION.md, docs/plans/LOCAL_TEST_ENVIRONMENT_BOOTSTRAP.md, docs/plans/V60_CAPABILITY_AND_AGENT_EVOLUTION.md, docs/INTERACTION_SURFACES_AND_AUTHORITY/README.md, docs/INTERACTION_SURFACES_AND_AUTHORITY/RECONCILE_CHAT_MUTATION_AUTHORITY.md, docs/COMMITMENT_AS_FIRST_CLASS/README.md, merged PRs #365/#376/#382/#383/#386/#389/#391/#423/#424/#425/#426/#427, current repo state at 0d37257 on 2026-04-12
 # Roadmap — Strategic Control
 
@@ -28,7 +28,7 @@ This roadmap is forward-looking and skimmable. History lives in `docs/history/SO
   - Watcher → panel → planner/orchestrator automation with safety limits now includes dedup reports, promotion consumer visibility, and explicit skipped receipts.
   - Vault-first config validation (panel wiring, watcher, outbox) with schema enforcement and `python -m app.cli settings-explain`.
 - **Next**
-  - **Low-risk autonomy + automated sync validation** — define and implement the next bounded forward path for autonomous low-risk proposal surfacing and automated multi-device latency verification, using AI-panel proposal writeback as the first interaction surface and a scripted sync-latency harness as the first acceptance path. Source Anchor: AUTO-LOW-RISK-AUTONOMY
+  - **Low-risk autonomy + automated sync validation** — iCloud transport chain validated end-to-end (MacBook → Mac mini via CloudDocs, 2026-04-12); `.git.nosync` fix shipped (Issue #421); server-side watcher detection confirmed. Partial receipt posted to #355. Remaining: (1) extend allowlist in `vault/@Settings/watchers.md` to permit the harness action type so the harness captures real numeric latency; (2) stabilize Mac mini headless infrastructure (#432); (3) capture clean timing receipt (#433). Proposal writeback path and broader low-risk autonomy expansion remain as follow-on slices after timing receipt is captured. Source Anchor: AUTO-LOW-RISK-AUTONOMY
   - **Environment contract follow-through** — implement the remaining docs-first environment contract slices from `docs/ENVIRONMENTS.md` in bounded steps: explicit runtime environment selection and environment-scoped vault/store separation are shipped, and environment-aware operator diagnostics are delivered via Issue #265 / PR #272; remaining follow-through should stay bounded and avoid changing the shared architecture contracts.
   - **Companion note + Note Context rollout hardening** — the core companion-note and Note Context implementation is shipped, and the active doc-sync correction has landed. Delivery receipt: Issue #229, PR #237. Any remaining rollout verification or cleanup should be captured as new bounded follow-up issues rather than treated as missing first implementation.
   - **Quality Wave: Registry Watcher Evaluation Stack** — shipped and now serves as the v5.6 rollout gate via `docs/TESTING.md`, `docs/QUALITY_WAVE_IMPLEMENTATION.md`, and `docs/quality_wave/README.md`. Delivery receipt: PRs #197, #198, #199, #200, #201, #202, #210.
@@ -221,7 +221,7 @@ Explicit rule: "LLM reasoning must never directly trigger execution."
 | v5.1–v5.4 | Watcher track (ingest/panel CLI, policy, ergonomics) | Operationally accepted |
 | v5.5A/B | Panel planner pipeline + CLI-first orchestration/promotion consumer | Shipped |
 | v5.5C/D | Panel LangGraph decider + watcher auto-exec; watcher→planner/orchestrator automation | Planned/In progress |
-| v5.6 | Engine-neutral cognition seam (PA2-ENGINE-SEAM, shipped), freeform panel catalog-discovery (shipped), suggested checkbox writeback for uncertain/no-checkbox panel proposals (shipped), multi-step plans (shipped, PR #302), real-vault acceptance (accepted on Alpha vault for #240), Companion note/doc-sync cleanup, shared ReasoningFacade + LangGraph rollout, Orchestrator V2 (flagged), Vault-as-GUI settings compiler | Selective forward work (multiple panel/runtime slices shipped; acceptance receipt recorded) |
+| v5.6 | Engine-neutral cognition seam (PA2-ENGINE-SEAM, shipped), freeform panel catalog-discovery (shipped), suggested checkbox writeback for uncertain/no-checkbox panel proposals (shipped), multi-step plans (shipped, PR #302), real-vault acceptance (accepted on Alpha vault for #240), Companion note/doc-sync cleanup, shared ReasoningFacade + LangGraph rollout, Orchestrator V2 (flagged), Vault-as-GUI settings compiler, iCloud transport chain validated + `.git.nosync` fix shipped (#421), sync-latency harness partial receipt posted (#355); clean timing measurement pending (#433) | Selective forward work (multiple panel/runtime slices shipped; acceptance receipt recorded; sync transport validated) |
 | v6.0 | Wanted-state architecture pass to align runtime boundaries with the newer human/context/artifact semantics, ontology/runtime bridge, commitment-first modeling, retrieval vs orientation vs resurfacing separation, and clearer surface/authority contracts; target described in `docs/plans/V60_ARCHITECTURE_TARGET.md` | Proposed target state |
 
 ## Tracks (details moved)

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -5,7 +5,7 @@ Owner: Runtime / current-state SoT
 Temporal class: operational
 Review cadence: weekly
 Source of truth: mixed
-Last reviewed: 2026-04-12
+Last reviewed: 2026-04-13
 Last verified against: docs/ARCHITECTURE.md, docs/ROADMAP.md, docs/DOCS_INDEX.md, docs/ENVIRONMENTS.md, docs/EVENTS.md, docs/OBSERVABILITY.md, docs/runbooks/UAT_PANEL_WATCHER.md, docs/plans/AUTONOMY_AND_SYNC_VALIDATION.md, docs/INTERACTION_SURFACES_AND_AUTHORITY/README.md, docs/INTERACTION_SURFACES_AND_AUTHORITY/RECONCILE_CHAT_MUTATION_AUTHORITY.md, docs/COMMITMENT_AS_FIRST_CLASS/README.md, app/cli/__init__.py, app/cli/latency_harness.py, app/observability/status_service.py, app/watcher/registry.py, app/workers/outbox_worker.py, Makefile, merged PRs #365/#376/#382/#383/#386/#389/#391/#423/#424/#425/#426/#427, current repo state at 0d37257 on 2026-04-12
 Status snapshot now includes SoT baseline + forward-line fields and intent/event counters (`promote.intent.created`, `panel.intent.executed`, `watcher.run`, ingest runs by plane). `watcher_runs` now counts watcher audit events from the registry watcher as well as the legacy snapshot watcher, while runtime health still relies on heartbeat + tick logs.
 
@@ -20,6 +20,7 @@ Concept anchors: layering, portability, archive exposure, trust semantics, event
 - The interim GUI and Status service consume these heartbeats/events so the dashboard shows ingest health, counts, and incidents in one place.
 - The local `test` bootstrap path is now treated as a first-class verification concern: parts of the path work today, but the repo-supported clean-state path is not yet fully self-contained end to end.
 - `python -m app.cli sync-latency-harness` now defaults to provider-free `PANEL_AGENT_DECIDER=rule` for deterministic operator validation, emits progress before long-running watcher work, and fails within a bounded timeout instead of hanging indefinitely when a live LLM provider is unavailable.
+- **Sync-latency harness — partial acceptance (2026-04-12):** iCloud transport chain validated end-to-end (MacBook → Mac mini via CloudDocs); server-side watcher detection confirmed; clean numeric latency measurement not yet captured. Blocking gaps: (1) allowlist gate in `vault/@Settings/watchers.md` only permits `promote.evergreen` — `ingest.summary.create` is known but not allowlisted, so the harness exits with 0 measurements on summary-type test notes; (2) Mac mini headless infrastructure gaps (Screen Sharing, auto-login recovery) tracked in #432. Follow-up timing receipt tracked in #433. Root cause of iCloud upload-queue blockage (`.git` dir inside vault) fixed by `.git.nosync` + symlink (Issue #421 closed).
 
 ## CI & Test Markers
 - CI legs assert `docs/ARCHITECTURE.md` contains fitness guard statements, confirm CLI health smoke commands pass, and verify the worker logs show `worker starting`.
@@ -99,6 +100,7 @@ High-level design rules for this direction now live in `docs/DESIGN_PRINCIPLES.m
 - The local test stack can be started successfully against a separate test vault, and `uat-seed-vault-test` works.
 - The repo-supported local bootstrap/UAT path is still not fully self-contained end to end; several concrete blocker issues already exist for that work.
 - Issue #240 has a real-vault Alpha acceptance receipt recorded in `docs/PANEL_AGENT.md` after the 2026-04-08 server-side soak; that specific PanelAgent 2.0 acceptance gate is no longer pending.
+- iCloud sync transport chain is validated end-to-end (MacBook → Mac mini via CloudDocs, 2026-04-12); the `.git.nosync` + symlink fix (Issue #421) removed the root-cause CloudDocs upload-queue blocker. Sync-latency harness partial receipt posted to parent feature #355. Clean timing measurement (numeric MacBook→Mac mini latency) is pending until allowlist is extended and Mac mini headless infrastructure is stable (#432, #433).
 - The current docs-first stabilization wave is making the intended supported path explicit before further implementation continues.
 - Objective: a clean-state, repo-supported local test bootstrap path that is resettable, reproducible, verified, and acceptable as the canonical local verification flow.
 - PanelAgent runtime V1 is part of the active baseline; planner pipeline and LangGraph expansion remain opt-in.


### PR DESCRIPTION
- [x] Docs authoring lane

Updates `docs/STATUS.md` and `docs/ROADMAP.md` to record the outcome of the 2026-04-12 iCloud sync validation session.

### What changed

**STATUS.md**
- Added sync-latency harness partial acceptance note under Runtime verification: iCloud transport chain validated end-to-end, watcher detection confirmed, numeric timing blocked by allowlist gate and Mac mini headless infra gaps (#432, #433)
- Added iCloud chain validation note to Current Snapshot: `.git.nosync` fix shipped (#421), partial receipt posted to #355

**ROADMAP.md**
- Updated "Low-risk autonomy + automated sync validation" Next item: shipped vs pending states made explicit; follow-on issues referenced
- Version ladder v5.6 row updated with sync transport delivery and pending timing receipt

### Validation run
- Doc-only change; no code modified
- Wording cross-checked against Issues #421 (closed), #432, #433, #355

### Pending (not in this PR)
- #433: clean numeric latency receipt (allowlist extension + harness re-run)
- #432: Mac mini headless infrastructure hardening