### PR TITLE
fix: remove path-derived domain fallback from retrieval (#435)

### DIFF
--- a/app/retrieval/hybrid.py
+++ b/app/retrieval/hybrid.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import math
 import os
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any, Iterable, Iterator, List, Optional
 
 import numpy as np
@@ -137,11 +136,6 @@ def _extract_domain(doc: Document) -> str | None:
     raw = payload.get("domain")
     if isinstance(raw, str) and raw.strip():
         return raw.strip()
-    if doc.source_ref:
-        path = Path(str(doc.source_ref))
-        parts = [part for part in path.parts if part not in (path.anchor, "")]
-        if parts:
-            return parts[0]
     return None
 
 

--- a/tests/boundaries/test_domain_separation_defaults.py
+++ b/tests/boundaries/test_domain_separation_defaults.py
@@ -62,6 +62,61 @@ def test_domain_bridge_allows_cross_domain(monkeypatch) -> None:
     assert "rpg-bridge" in ids
 
 
+def test_missing_payload_domain_is_excluded_from_domain_scope(monkeypatch) -> None:
+    """A document with no payload domain must not be included in a domain-scoped search,
+    even if its source_ref path starts with the active domain name."""
+    store = get_store()
+    store.set_documents([])
+
+    store.add_document(
+        doc_id="no-domain-1",
+        text="Shared marker text",
+        source_ref="work/note.md",
+        payload={},
+    )
+    store.add_document(
+        doc_id="work-explicit",
+        text="Shared marker text",
+        source_ref="work/other.md",
+        payload={"domain": "work"},
+    )
+
+    monkeypatch.setenv("ASK_DOMAIN_SCOPE", "work")
+    results = hybrid_search("marker", k=5)
+    ids = {res.get("doc_id") for res in results}
+    assert "work-explicit" in ids
+    assert "no-domain-1" not in ids, (
+        "Document with no payload domain must not be included via path-derived inference"
+    )
+
+
+def test_path_change_does_not_invent_domain(monkeypatch) -> None:
+    """Moving a note to a different folder must not silently assign a domain when
+    the payload carries no domain field."""
+    store = get_store()
+    store.set_documents([])
+
+    # Same document, different source_ref paths — neither should be scope-included
+    store.add_document(
+        doc_id="moved-1",
+        text="Shared marker text",
+        source_ref="work/subfolder/note.md",
+        payload={},
+    )
+    store.add_document(
+        doc_id="moved-2",
+        text="Shared marker text",
+        source_ref="personal/note.md",
+        payload={},
+    )
+
+    monkeypatch.setenv("ASK_DOMAIN_SCOPE", "work")
+    results = hybrid_search("marker", k=5)
+    ids = {res.get("doc_id") for res in results}
+    assert "moved-1" not in ids, "Path-matching source_ref must not grant domain membership"
+    assert "moved-2" not in ids
+
+
 def test_sphere_membership_relation_does_not_change_scope_filter(monkeypatch) -> None:
     store = get_store()
     store.set_documents([])


### PR DESCRIPTION
## Linked Issues
Fixes #435

## Lane
Implementation

## Bounded change
Remove the path-based domain fallback in `_extract_domain()` in `app/retrieval/hybrid.py`.

Previously, when `payload["domain"]` was absent or blank, the function inferred domain from the first path segment of `doc.source_ref`. This violated the layering contract: folder placement must not silently become semantic scope. Moving a note between folders could change retrieval results without any payload change.

Now `_extract_domain()` returns `None` for any document without an explicit `payload["domain"]`. Documents with missing domain are excluded from domain-scoped retrieval via the existing `_doc_in_scope()` logic.

Also removes the now-unused `from pathlib import Path` import.

## Files changed
- `app/retrieval/hybrid.py` — removed path-inference block from `_extract_domain()`
- `tests/boundaries/test_domain_separation_defaults.py` — added 2 regression tests:
  - `test_missing_payload_domain_is_excluded_from_domain_scope`: documents with no payload domain are excluded even when `source_ref` path starts with the active domain name
  - `test_path_change_does_not_invent_domain`: path changes alone cannot grant domain membership

## Source authority
- `docs/plans/V60_ARCHITECTURE_TARGET.md` :: Current-state bugs :: Finding 1
- `docs/CONCEPTS/LAYERING_MODEL.md` :: Missing or unknown domain

## Validation run
```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests -k "domain or retrieval"
→ 38 passed

PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg"
→ 2196 passed, 8 pre-existing Docker-dependency failures in test_bootstrap_reset.py (unrelated)
```

## Out of scope
Domain assignment at the ingest/write boundary (tracked by #437) and ASK zone payload reads (tracked by #436) are not touched here.