### PR TITLE
Make skill state changes executable with explicit commands

### DIFF
--- a/.codex/skills/issue-maintenance-change-control/SKILL.md
+++ b/.codex/skills/issue-maintenance-change-control/SKILL.md
@@ -7,6 +7,8 @@ description: "Keep GitHub Issues, PRs, labels, and Project state truthful when b
 
 You are an Issue maintenance and lifecycle-correction agent for a repo-first, docs-as-code software system.
 
+⚠️ **CRITICAL: All corrections (labels, Project Status, Issue edits, duplicates, PR reconciliation) must be executed using explicit commands (`gh issue edit`, `gh issue close`, `gh api graphql`). Do not describe corrections—execute them and verify they succeeded. Track all executed changes in the output receipt.**
+
 Your job is to keep GitHub Issues, Pull Requests, labels, and Project state truthful when backlog state drifts from implementation reality.
 That includes PR lifecycle truth, not only Issue lifecycle truth.
 
@@ -106,13 +108,85 @@ If any of the above is ambiguous, do not code. Keep the Issue `agent:needs-human
 
 ## Lifecycle correction rules
 
-- If an Issue is closed, remove any `agent:*` label.
-- If an open implementation Issue is malformed, stale, or no longer safely executable, do not leave it unlabeled or falsely `agent:ready`; normally use `agent:needs-human` with a non-active Project status.
-- If an Issue is delivered, Project Status should be `Done`.
-- If a PR is merged or otherwise closed as a terminal PR artifact, Project Status should normally be `Done`.
-- If delivered work is still open because traceability is ambiguous, prefer `agent:needs-human` over false `agent:ready`.
-- Parent feature issues are validation hubs, not direct pickup issues, unless explicitly scoped as a single executable slice; normally keep them non-active with `agent:needs-human` or `agent:blocked`.
-- Child slice issues may become `agent:ready` only when their executable contract is concrete and available. If the contract lives in a spec file in an open PR, keep the child issue non-active until the spec lands or the issue is rewritten with the required local contract sections.
+**All state corrections must be executed using explicit commands, not just recommended.**
+
+### Action: Close Delivered Issue
+
+If an Issue is closed (already delivered):
+
+1. **Remove all agent labels:**
+   ```bash
+   gh issue edit #<N> --remove-label agent:ready --remove-label agent:blocked --remove-label agent:needs-human
+   ```
+
+2. **Set Project Status to Done:**
+   ```bash
+   gh api graphql -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
+     -f fieldId="$STATUS_FIELD_ID" -f optionId="$DONE_OPTION_ID" \
+     -f query='mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!) { updateProjectV2ItemFieldValue(input:{projectId:$projectId itemId:$itemId fieldId:$fieldId value:{singleSelectOptionId:$optionId}}) { projectV2Item { id } } }'
+   ```
+
+3. **Verify:**
+   ```bash
+   gh issue view #<N> --json state,labels,projectItems
+   ```
+
+### Action: Malformed or Stale Open Issue
+
+If an open implementation Issue is malformed, stale, or no longer safely executable:
+
+1. **Add needs-human label:**
+   ```bash
+   gh issue edit #<N> --add-label agent:needs-human --remove-label agent:ready --remove-label agent:blocked
+   ```
+
+2. **Set Project Status to Backlog (non-active):**
+   ```bash
+   gh api graphql -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
+     -f fieldId="$STATUS_FIELD_ID" -f optionId="$BACKLOG_OPTION_ID" \
+     -f query='mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!) { updateProjectV2ItemFieldValue(input:{projectId:$projectId itemId:$itemId fieldId:$fieldId value:{singleSelectOptionId:$optionId}}) { projectV2Item { id } } }'
+   ```
+
+3. **Post comment with required action**
+
+### Action: Issue Delivered but Still Open
+
+If delivered work is still open because traceability is ambiguous:
+
+1. **Prefer `agent:needs-human`** over false `agent:ready`
+2. **Execute label and status corrections** per "Malformed or Stale Open Issue" above
+3. **Leave a comment** explaining what action is needed for closure
+
+### Parent Feature Issues
+
+Parent feature issues are validation hubs, not direct pickup issues. Unless explicitly scoped as a single executable slice:
+
+1. **Keep them non-active:**
+   ```bash
+   gh issue edit #<PARENT> --add-label agent:needs-human --remove-label agent:ready --remove-label agent:blocked
+   gh api graphql ... (set Project Status to Backlog)
+   ```
+
+2. **Use them to track child slice delivery** in comments and body updates
+
+### Child Slice Issues
+
+Child slice issues may become `agent:ready` only when their executable contract is concrete and available:
+
+1. **If contract lives in an open spec PR:** keep the child issue non-active (`agent:needs-human` or `agent:blocked`) until the spec merges or the issue is rewritten with required local contract sections
+
+2. **If contract is concrete and merged:** can label as `agent:ready` with `Status=Ready`
+
+## Quick Reference: Maintenance State Corrections
+
+| Condition | Action | Issue Labels | Issue Status | Notes |
+|-----------|--------|-------------|-------------|-------|
+| Issue closed | Execute Close Delivered | -agent:* | Done | Remove all agent labels |
+| Malformed/stale open | Execute Malformed/Stale | +agent:needs-human | Backlog | Non-active state |
+| Delivered but open | Execute Delivered Open | +agent:needs-human | Backlog | Comment explaining next step |
+| Parent feature | Keep non-active | +agent:needs-human | Backlog | Validation hub, not direct pickup |
+| Child with spec in PR | Keep non-active | +agent:needs-human | Backlog | Wait for spec merge |
+| Child with concrete contract | Can label ready | +agent:ready | Ready | Only when merged and clear |
 
 ## When splitting
 
@@ -175,21 +249,56 @@ Use this when the user asks for a maintenance run across everything not done.
    - If body already matches the contract shape exactly, do not rewrite it.
    - If contract shape is missing or malformed, edit the issue to match the required sections.
    - If many related issues share the same contract-shape problem, do not bulk-rewrite them blindly; report the pattern, pick a correction policy, and apply it consistently.
-   - Correct labels from established issue/PR truth before any Project reconciliation:
+   - **Execute label corrections** from established issue/PR truth before any Project reconciliation:
+     ```bash
+     # Example: set to ready if criteria are concrete
+     gh issue edit #<N> --add-label agent:ready --remove-label agent:blocked --remove-label agent:needs-human
+     # OR: set to needs-human if ambiguous or boundary move
+     gh issue edit #<N> --add-label agent:needs-human --remove-label agent:ready --remove-label agent:blocked
+     # OR: set to blocked if external dependency exists
+     gh issue edit #<N> --add-label agent:blocked --remove-label agent:ready --remove-label agent:needs-human
+     ```
      - Add `agent:ready` only if Scope/Constraints/Acceptance Criteria are concrete and no ambiguity remains.
      - Do not add or preserve `agent:ready` when recent comments, linked PRs, or linked blocker/follow-up issues show the Issue is blocked, already active, or waiting on validation.
      - Do not add or preserve `agent:ready` when a child issue's executable contract exists only in an unmerged spec PR.
      - Keep or set `agent:needs-human` for boundary moves without explicit direction or module paths.
      - Keep or set `agent:blocked` when external dependencies are stated.
-   - Reconcile Project state for each open issue only after labels are corrected:
-     - `agent:ready` -> `Status=Ready`
-     - `agent:blocked` or `agent:needs-human` -> `Status=Backlog`
-     - if the issue is missing from the Project or missing `Status`, add/reconcile it during the same run
-4. Dedupe:
-   - If duplicate issues have the same scope/contract, leave a comment pointing to the canonical issue and close the duplicate.
-5. Reconcile PR Project state for terminal PR cards in the same repo:
-   - list merged/closed PRs that are in the Project with missing `Status` or a non-terminal status
-   - set merged or otherwise closed terminal PR cards to `Done`
+   
+   - **Execute Project state reconciliation** for each open issue only after labels are corrected:
+     ```bash
+     # agent:ready -> Status=Ready
+     gh api graphql -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
+       -f fieldId="$STATUS_FIELD_ID" -f optionId="$READY_OPTION_ID" \
+       -f query='mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!) { updateProjectV2ItemFieldValue(input:{projectId:$projectId itemId:$itemId fieldId:$fieldId value:{singleSelectOptionId:$optionId}}) { projectV2Item { id } } }'
+     
+     # agent:blocked or agent:needs-human -> Status=Backlog
+     gh api graphql -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
+       -f fieldId="$STATUS_FIELD_ID" -f optionId="$BACKLOG_OPTION_ID" \
+       -f query='mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!) { updateProjectV2ItemFieldValue(input:{projectId:$projectId itemId:$itemId fieldId:$fieldId value:{singleSelectOptionId:$optionId}}) { projectV2Item { id } } }'
+     ```
+     - If the issue is missing from the Project or missing `Status`, add/reconcile it during the same run
+4. **Execute Deduplication:**
+   - If duplicate issues have the same scope/contract:
+     ```bash
+     gh issue comment #<DUPLICATE> --body "Duplicate of #<CANONICAL>. Closing in favor of canonical issue."
+     gh issue close #<DUPLICATE>
+     ```
+   - Remove all agent labels from closed duplicate:
+     ```bash
+     gh issue edit #<DUPLICATE> --remove-label agent:ready --remove-label agent:blocked --remove-label agent:needs-human
+     ```
+
+5. **Execute PR Project state reconciliation** for terminal PR cards:
+   - List merged/closed PRs with missing or non-terminal Project Status:
+     ```bash
+     gh pr list --state closed --json number,title,mergedAt,projectItems
+     ```
+   - For each merged/closed PR, set Project Status to Done:
+     ```bash
+     gh api graphql -f projectId="$PROJECT_ID" -f itemId="$PR_ITEM_ID" \
+       -f fieldId="$STATUS_FIELD_ID" -f optionId="$DONE_OPTION_ID" \
+       -f query='mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!) { updateProjectV2ItemFieldValue(input:{projectId:$projectId itemId:$itemId fieldId:$fieldId value:{singleSelectOptionId:$optionId}}) { projectV2Item { id } } }'
+     ```
 6. Prefer the repo's reconciliation helper when present (for example `scripts/reconcile_project_status.py`) instead of ad hoc Project mutations.
 7. If Project v2 writes fail because of GraphQL rate limits or credentials, stop Project mutation attempts for that run:
    - do not retry with ad hoc partial mutations

--- a/.codex/skills/issue-to-code/SKILL.md
+++ b/.codex/skills/issue-to-code/SKILL.md
@@ -7,6 +7,8 @@ description: "Implement a bounded GitHub slice issue as the canonical task contr
 
 You are a builder agent implementing GitHub backlog work in a repo-first, docs-as-code software system.
 
+⚠️ **CRITICAL: All lifecycle state changes (labels, Project Status) must be executed using explicit commands (`gh issue edit`, `gh api graphql`, `gh pr edit`). Do not describe these changes—execute them and verify they succeeded before continuing.**
+
 Your governing rule:
 Only execute bounded implementation work from a GitHub Issue that is the canonical task contract.
 
@@ -72,19 +74,108 @@ Allowed Project statuses:
 
 ## Lifecycle rules during execution
 
-- Before starting implementation, ensure the selected Issue is present in Project `Agent Delivery Control Plane`.
-- If the Issue is missing from the Project, add it first.
-- When you begin active work on an Issue, set Project Status to `In Progress` and remove `agent:ready`.
-- If you determine the Issue is blocked before or during implementation:
-  - do not continue coding
-  - update labels and Project state truthfully
-  - use `agent:blocked` when the work is blocked by dependency or setup
-  - use `agent:needs-human` when the work requires a human decision or missing authority
-  - move Project Status out of active execution if appropriate, normally back to `Backlog`
-- If you open a draft PR or keep implementing after opening a PR, keep Project Status at `In Progress`.
-- Move Project Status to `Review` only when the PR becomes the explicit review handoff artifact, normally after review is requested.
-- Do not leave actively worked Issues in `Ready`.
-- Do not leave blocked Issues in `In Progress` without an explicit blocker note and corrected labels.
+**All state changes must be executed using explicit commands, not described as recommendations.**
+
+### Action: Begin Implementation Work
+
+When you start active work on an Issue:
+
+1. **Ensure Issue is in Project** (if missing, add it first):
+   ```bash
+   gh api graphql -f query='query { repository(owner:"OWNER", name:"REPO") { issue(number:N) { projectItems(first:1) { nodes { id } } } } }'
+   ```
+
+2. **Remove `agent:ready` label:**
+   ```bash
+   gh issue edit #<N> --remove-label agent:ready
+   ```
+
+3. **Set Issue Project Status to In Progress:**
+   ```bash
+   gh api graphql -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
+     -f fieldId="$STATUS_FIELD_ID" -f optionId="$IN_PROGRESS_OPTION_ID" \
+     -f query='mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!) { updateProjectV2ItemFieldValue(input:{projectId:$projectId itemId:$itemId fieldId:$fieldId value:{singleSelectOptionId:$optionId}}) { projectV2Item { id } } }'
+   ```
+
+4. **Verify:**
+   ```bash
+   gh issue view #<N> --json labels,projectItems
+   ```
+
+### Action: Issue is Blocked (Mid-Implementation)
+
+If work becomes blocked before or during implementation:
+
+1. **Add blocker label:**
+   ```bash
+   gh issue edit #<N> --add-label agent:blocked --remove-label agent:ready
+   ```
+
+2. **Set Issue Project Status to Backlog:**
+   ```bash
+   gh api graphql -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
+     -f fieldId="$STATUS_FIELD_ID" -f optionId="$BACKLOG_OPTION_ID" \
+     -f query='mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!) { updateProjectV2ItemFieldValue(input:{projectId:$projectId itemId:$itemId fieldId:$fieldId value:{singleSelectOptionId:$optionId}}) { projectV2Item { id } } }'
+   ```
+
+3. **Add a blocking comment to the Issue with explicit reason**
+
+4. **Verify:**
+   ```bash
+   gh issue view #<N> --json labels,projectItems
+   ```
+
+**Use `agent:blocked`** when blocked by dependency or setup.  
+**Use `agent:needs-human`** when work requires a human decision or missing authority.
+
+### Action: Open Draft PR (Work In Progress)
+
+When you open a draft PR or continue implementing after opening a PR:
+
+1. **Keep Issue Project Status at In Progress** (no change needed if already set)
+
+2. **If creating PR, no status change yet** — PR remains draft
+
+3. **Verify Issue still shows In Progress:**
+   ```bash
+   gh issue view #<N> --json projectItems
+   ```
+
+### Action: Request Review (Explicit Handoff)
+
+Only move to Review when the PR is the **explicit review handoff artifact** (normally after review is requested):
+
+1. **Move Issue Project Status to Review:**
+   ```bash
+   gh api graphql -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
+     -f fieldId="$STATUS_FIELD_ID" -f optionId="$REVIEW_OPTION_ID" \
+     -f query='mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!) { updateProjectV2ItemFieldValue(input:{projectId:$projectId itemId:$itemId fieldId:$fieldId value:{singleSelectOptionId:$optionId}}) { projectV2Item { id } } }'
+   ```
+
+2. **Move PR Project Status to Review:**
+   ```bash
+   gh api graphql -f projectId="$PROJECT_ID" -f itemId="$PR_ITEM_ID" \
+     -f fieldId="$STATUS_FIELD_ID" -f optionId="$REVIEW_OPTION_ID" \
+     -f query='mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!) { updateProjectV2ItemFieldValue(input:{projectId:$projectId itemId:$itemId fieldId:$fieldId value:{singleSelectOptionId:$optionId}}) { projectV2Item { id } } }'
+   ```
+
+3. **Verify both Issue and PR:**
+   ```bash
+   gh issue view #<N> --json projectItems
+   gh pr view #<PR> --json projectItems
+   ```
+
+**Do not move to Review** just because a PR exists. Move to Review only when review is explicitly requested.
+
+## Quick Reference: State Transitions
+
+| When | Issue Labels | Issue Status | PR Labels | PR Status |
+|------|-------------|-------------|-----------|-----------|
+| Start work | -agent:ready | In Progress | — | — |
+| Blocked mid-work | +agent:blocked,-agent:ready | Backlog | — | — |
+| Open draft PR | (no change) | In Progress | — | (draft, no Project status) |
+| Request review | (no change) | Review | — | Review |
+| Merge + verified | -agent:* | (verification owns) | — | (Done via verification skill) |
 
 ## Execution rules
 
@@ -129,7 +220,7 @@ When continuing through anchor drift:
 ## Implementation workflow
 
 1. Select the Issue according to priority and readiness rules.
-2. Ensure the Issue is in the Project, set Status to `In Progress`, and remove `agent:ready`.
+2. **Execute Action: Begin Implementation Work** (update labels, Issue Project Status, verify).
 3. Restate the bounded outcome from the Issue.
 4. Read source-anchored docs and owning code paths.
 5. If anchor drift exists, resolve it using the rules above before coding.
@@ -140,7 +231,7 @@ When continuing through anchor drift:
 10. Run `Suggested Validation` plus any obviously necessary focused checks.
 11. Run `.codex/skills/publish-pr/SKILL.md` to create or update the implementation PR linked to the governing Issue unless a concrete blocker or explicit user instruction prevents it.
 12. Run `.codex/skills/pr-integration/SKILL.md` to resolve merge conflicts and ensure CI/check truth on the latest PR head.
-13. Ensure Project Status is `Review` only once the PR is the active review handoff artifact.
+13. **Execute Action: Request Review** (only move Issue and PR Project Status to Review when review is explicitly requested).
 14. If the slice merges but the parent feature still needs validation, keep that parent issue open for the later acceptance step.
 
 ## PR handoff requirements

--- a/.codex/skills/pr-integration/SKILL.md
+++ b/.codex/skills/pr-integration/SKILL.md
@@ -12,6 +12,8 @@ produce a mergeable, policy-compliant PR with CI **green** on the latest head SH
 
 This skill does NOT merge the PR. Merge is owned by the verification skill after it confirms the delivery contract is satisfied.
 
+⚠️ **CRITICAL: All integration actions (merge conflict resolution, CI verification, review comment handling) must be executed using explicit git/gh/API commands. Do not describe these actions—execute them and verify they succeeded. The handoff decision must be explicit: `ready-for-verification`, `blocked-merge-conflict`, `blocked-ci-failure`, `blocked-contract-drift`, or `blocked-review-feedback`.**
+
 ## Canonical workflow position
 
 `Docs -> Feature issue -> Slice issue -> Agent -> Publish PR -> PR integration -> CI -> Slice verification -> Merge -> Feature validation -> Acceptance -> Owner Doc`
@@ -43,139 +45,413 @@ ALL of these must be true before handing off to verification:
 
 If any exit condition is not met, do not hand off. Loop or block.
 
-## Required gates
+## Required gates (all executable)
 
-### 1) Contract and metadata gate
+### 1) Contract and Metadata Gate
 
-- Confirm PR lane classification is truthful:
-  - implementation lane must include `Fixes #<id>`, `Closes #<id>`, or `Resolves #<id>` for the governing slice issue
-  - docs/governance lanes must follow allowed-surface constraints from workflow policy
-- Ensure PR template checklists are not left in contradictory states.
-- Ensure linked Issue still matches actual scope; if scope drift occurred, stop and route through Issue maintenance.
+**Action: Verify PR Contract**
 
-Operational checks:
+```bash
+# Get PR metadata
+gh pr view <PR_NUMBER> --json number,state,isDraft,mergeable,headRefOid,baseRefName,labels,body,statusCheckRollup
 
-- `gh pr view <pr> --json number,state,isDraft,mergeable,headRefOid,baseRefName,labels,body,statusCheckRollup`
-- `gh pr checks <pr>`
+# Get current check status
+gh pr checks <PR_NUMBER>
+```
 
-### 2) Mergeability gate
+**Verification:**
+- ✅ Implementation lane: PR body includes `Fixes #<id>`, `Closes #<id>`, or `Resolves #<id>`
+- ✅ Docs authoring lane: PR body has `- [x] Docs authoring lane` and files are within `docs/` or allowed-surface
+- ✅ Governance lane: PR body has `- [x] Governance lane` and files are within `.codex/skills/` or other allowed governance surfaces
+- ✅ No scope drift: PR scope still matches Issue contract
+- ✅ Checklists: No contradictory unchecked items in body
+
+**If contract fails:** Stop and route through issue-maintenance with explicit contract-drift context.
+
+### 2) Mergeability Gate
 
 **Critical: Never trust the GitHub API `mergeable` field alone.** GitHub returns `null` while computing and `dirty` for multiple unrelated reasons. Always verify locally.
 
-Required verification steps:
+**Action: Verify Merge Locally**
 
-1. `git fetch origin main` to get latest base.
-2. Run `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD` to simulate the merge locally.
-3. If the output contains `CONFLICT`, the PR has real merge conflicts — do not declare the gate passed.
-4. Only after a clean local simulation, check the GitHub API `mergeable` field as a secondary confirmation.
+```bash
+# Step 1: Fetch latest base branch
+git fetch origin main
 
-If merge conflicts exist:
+# Step 2: Simulate merge locally
+git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD > /tmp/merge-sim.txt
+cat /tmp/merge-sim.txt
 
-- Sync with latest base branch (`main`).
-- Rebase or merge base into the PR branch (follow repository norm).
-- Resolve conflicts without expanding scope beyond the governing Issue.
-- Rerun focused validation for touched surfaces.
-- Push updated branch.
-- **Re-run the local merge simulation again** to confirm the conflict is resolved. Do not trust the push alone.
+# Step 3: Check for CONFLICT keyword
+if grep -q "CONFLICT" /tmp/merge-sim.txt; then
+  echo "❌ MERGE CONFLICTS DETECTED"
+else
+  echo "✅ Local merge simulation clean (no CONFLICT output)"
+fi
+```
 
-If mergeability remains blocked, mark as `blocked-merge-conflict` and hand off with explicit conflict context.
+**If merge clean, verify API state:**
 
-### 3) CI attachment gate
+```bash
+gh pr view <PR_NUMBER> --json mergeable
+```
 
-- Verify checks are attached to the current PR head SHA.
-- If checks are missing on current head, wait and retry:
-  - Poll every 15 seconds for up to 2 minutes.
-  - If still missing after 2 minutes, retrigger by pushing a minimal deterministic change (empty commit with message explaining the retrigger).
-  - Poll again for up to 3 minutes after retrigger.
-  - If checks are still missing after retrigger, mark as `blocked-ci-failure` with explicit context about missing CI attachment.
-- Do not proceed to the CI result gate until at least one check-run is attached to the current head SHA.
+Expected: `mergeable: MERGEABLE` or `mergeable: true`
 
-### 4) CI result gate
+**If merge conflicts exist:**
 
-**Critical: Do not hand off while checks are pending or absent.** Wait until all required checks reach a terminal state (success or failure).
+**Action: Resolve Merge Conflicts**
 
-Required behavior:
+```bash
+# Step 1: Sync with latest base
+git fetch origin main
+git rebase origin/main
+# OR (follow repo norm)
+git merge origin/main
 
-1. Poll check status every 30 seconds.
-2. Continue polling until ALL checks reach a terminal state (`success`, `failure`, `cancelled`, `timed_out`). Maximum wait: 15 minutes.
-3. If all checks pass: proceed to review comment gate.
-4. If any check fails:
-   - Capture failing job names, conclusions, and log URLs.
-   - Analyze whether the failure is fixable within the governing Issue scope.
-   - If fixable: fix, push, and **restart from the mergeability gate** (since the head SHA changed).
-   - If not fixable within scope: mark as `blocked-ci-failure` with concrete failing jobs and log pointers.
-5. If checks do not reach terminal state within 15 minutes: mark as `blocked-ci-failure` with "CI timed out" context.
+# Step 2: Resolve conflicts manually in files
+# (User must edit conflicted files)
 
-Never declare `ready-for-verification` while any check is still `queued`, `in_progress`, or absent.
+# Step 3: Stage resolved files
+git add <resolved-files>
+git commit -m "Resolve merge conflicts from origin/main"
 
-### 5) Review comment detection and addressing gate
+# Step 4: Re-run local merge simulation
+git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD | grep CONFLICT
+# Should show NO output if resolved
 
-**Purpose**: Surface and address any review feedback before handoff to avoid back-and-forth delays.
+# Step 5: Rerun focused validation for touched surfaces
+# (Run tests relevant to changed files)
 
-**Detection**:
-- `gh pr view <pr> --json reviews` to fetch all reviews
-- `gh api repos/{owner}/{repo}/pulls/{pr}/comments` to get inline comments
-- Identify unresolved and actionable comments
+# Step 6: Push updated branch
+git push origin <branch-name>
 
-**Classification**:
-- **Actionable within scope**: Feedback that improves the Issue implementation without expanding scope
-  - Examples: missing edge case, clearer wording, additional validation
-  - Action: Make the change, push, re-run focused CI, and add review comment explaining the fix
-- **Out-of-scope**: Feedback that requires Issue expansion or different strategy
-  - Examples: feature requests, alternative approaches, future improvements
-  - Action: Document in PR comment why it's out-of-scope, reference Issue boundaries, suggest follow-up Issue
-- **Blocking**: Feedback indicating Issue requirements are not met or contract is violated
-  - Action: Stop and route through Issue maintenance if contract truly requires the change
+# Step 7: Re-verify mergeable state
+gh pr view <PR_NUMBER> --json mergeable
+```
 
-**Response workflow**:
-1. For each unresolved review comment:
-   - Evaluate whether it's actionable within Issue scope
-   - If actionable: implement fix, test, push, add PR comment explaining the change
-   - If out-of-scope: add PR comment with clear rationale and scope reference
-   - If blocking: stop and hand off with explicit context
-2. Re-run focused validation after any code changes
-3. If code was pushed, **restart from the mergeability gate** (head SHA changed)
-4. Update PR body if scope interpretation needed clarification
+**Handoff if still blocked:** Mark as `blocked-merge-conflict` with explicit conflict paths and resolution context.
 
-## Gate re-entry after pushes
+### 3) CI Attachment Gate
 
-Any push to the PR branch changes the head SHA. After a push:
+**Action: Verify Checks Attached to Current Head**
 
-1. Restart from the mergeability gate (step 2).
-2. Wait for CI to attach to the new SHA (step 3).
-3. Wait for CI to complete on the new SHA (step 4).
-4. Re-check review comments (step 5).
+```bash
+# Get current head SHA
+HEAD_SHA=$(git rev-parse HEAD)
 
-Do not carry forward check results from a previous SHA.
+# Get PR head SHA from GitHub
+PR_HEAD_SHA=$(gh pr view <PR_NUMBER> --json headRefOid --jq '.headRefOid')
 
-## Lifecycle truth rules during integration
+# Verify they match
+if [ "$HEAD_SHA" = "$PR_HEAD_SHA" ]; then
+  echo "✅ Local HEAD matches PR head SHA"
+else
+  echo "❌ HEAD mismatch: local $HEAD_SHA != PR $PR_HEAD_SHA"
+fi
+
+# Check for attached checks
+gh pr checks <PR_NUMBER>
+```
+
+**If checks missing on current head, retry with exponential backoff:**
+
+```bash
+# Poll every 15 seconds for up to 2 minutes (8 attempts)
+for i in {1..8}; do
+  echo "Attempt $i/8: Polling for checks..."
+  gh pr checks <PR_NUMBER> | grep -q "pass\|fail\|pending" && echo "✅ Checks attached" && break
+  sleep 15
+done
+
+# If still missing after 2 minutes, retrigger CI
+if ! gh pr checks <PR_NUMBER> | grep -q "pass\|fail\|pending"; then
+  echo "⚠️ Checks missing after 2 minutes. Triggering retrigger..."
+  git commit --allow-empty -m "Retrigger CI: checks not attached to current SHA"
+  git push origin <branch-name>
+  
+  # Poll again for up to 3 minutes after retrigger
+  for i in {1..12}; do
+    echo "Post-retrigger attempt $i/12: Polling for checks..."
+    gh pr checks <PR_NUMBER> | grep -q "pass\|fail\|pending" && echo "✅ Checks re-attached" && break
+    sleep 15
+  done
+fi
+
+# Final check: if still no checks, mark as blocked
+if ! gh pr checks <PR_NUMBER> | grep -q "pass\|fail\|pending"; then
+  echo "❌ BLOCKED: Checks not attached to current SHA after retrigger"
+  echo "Handoff decision: blocked-ci-failure (missing CI attachment)"
+  exit 1
+fi
+```
+
+**Do not proceed to CI result gate until at least one check is attached.**
+
+### 4) CI Result Gate
+
+**Critical: Do not hand off while checks are pending or absent.** Wait until all checks reach terminal state.
+
+**Action: Poll for CI Completion**
+
+```bash
+# Poll every 30 seconds until all checks terminal, max 15 minutes
+START=$(date +%s)
+TIMEOUT=$((START + 900))  # 15 minutes
+
+while [ $(date +%s) -lt $TIMEOUT ]; do
+  gh pr checks <PR_NUMBER> | tee /tmp/checks.txt
+  
+  # Check for pending/in-progress
+  if grep -E "pending|in_progress|queued" /tmp/checks.txt > /dev/null; then
+    echo "⏳ Checks still in progress... waiting 30 seconds"
+    sleep 30
+  else
+    echo "✅ All checks reached terminal state"
+    break
+  fi
+done
+
+# If timeout, mark as blocked
+if grep -E "pending|in_progress|queued" /tmp/checks.txt > /dev/null; then
+  echo "❌ BLOCKED: CI timeout (15 minutes exceeded)"
+  echo "Handoff decision: blocked-ci-failure (CI timed out)"
+  exit 1
+fi
+```
+
+**Action: Analyze CI Results**
+
+```bash
+# Get detailed check results
+gh pr checks <PR_NUMBER> --json name,conclusion,detailsUrl | tee /tmp/results.json
+
+# Check for failures
+FAILURES=$(jq '.[] | select(.conclusion=="FAILURE" or .conclusion=="failure")' /tmp/results.json)
+
+if [ -z "$FAILURES" ]; then
+  echo "✅ All checks passed"
+else
+  echo "❌ Failed checks detected:"
+  echo "$FAILURES" | jq '.name, .detailsUrl'
+fi
+```
+
+**If any check fails:**
+
+1. **Analyze failure:** Review log URLs and determine if fixable within Issue scope
+2. **If fixable:** Fix code/config, push, **restart from Mergeability Gate** (head SHA changed)
+3. **If not fixable:** Mark as `blocked-ci-failure` with failing job names and log links
+
+**Never declare `ready-for-verification` while any check is `pending`, `in_progress`, `queued`, or absent.**
+
+### 5) Review Comment Detection and Addressing Gate
+
+**Purpose**: Surface and address review feedback before handoff to avoid back-and-forth delays.
+
+**Action: Fetch and Classify Reviews**
+
+```bash
+# Get all reviews
+gh pr view <PR_NUMBER> --json reviews | tee /tmp/reviews.json
+
+# Get inline comments
+gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments | tee /tmp/inline-comments.json
+
+# Count unresolved comments
+UNRESOLVED=$(jq '.[] | select(.state != "COMMENTED" or .state != "APPROVED" or .state != "DISMISSED")' /tmp/reviews.json | wc -l)
+
+if [ "$UNRESOLVED" -eq 0 ]; then
+  echo "✅ No unresolved review comments"
+else
+  echo "⚠️ Found $UNRESOLVED unresolved comments"
+  jq '.[].body' /tmp/reviews.json
+fi
+```
+
+**Classification & Response:**
+
+For each unresolved comment:
+
+**A) Actionable Within Scope**
+- Examples: missing edge case, clearer wording, additional validation
+- Action:
+  ```bash
+  # Implement the fix
+  # (code changes)
+  
+  # Re-run focused validation
+  # (tests relevant to change)
+  
+  # Stage and push
+  git add <files>
+  git commit -m "Address review feedback: <summary>"
+  git push origin <branch-name>
+  
+  # Post comment explaining fix
+  gh pr comment <PR_NUMBER> --body "✅ Addressed feedback: <explanation>. Changes pushed."
+  
+  # Restart from Mergeability Gate (head SHA changed)
+  ```
+
+**B) Out-of-Scope**
+- Examples: feature requests, alternative approaches, future improvements
+- Action:
+  ```bash
+  # Post comment with rationale
+  gh pr comment <PR_NUMBER> --body "This feedback is out-of-scope for #<ISSUE>. The Issue scope is <reference to scope>. Suggested as follow-up in <new Issue or backlog item>."
+  ```
+
+**C) Blocking**
+- Feedback indicating Issue requirements are not met or contract is violated
+- Action: Stop and mark as `blocked-review-feedback` with explicit context
+
+**Note:** If any code was pushed, **restart from Mergeability Gate** (head SHA changed).
+
+## Gate Re-Entry After Any Push
+
+**Any push to the PR branch changes the head SHA. After pushing:**
+
+```bash
+# Verify push succeeded
+git push origin <branch-name>
+
+# Wait for GitHub to update PR head
+sleep 5
+
+# Get new head SHA
+NEW_HEAD=$(gh pr view <PR_NUMBER> --json headRefOid --jq '.headRefOid')
+echo "New PR head SHA: $NEW_HEAD"
+```
+
+**Then restart gates in this order:**
+
+1. **Restart Mergeability Gate** (step 2)
+   - Re-run local merge simulation against new SHA
+   
+2. **Wait for CI Attachment** (step 3)
+   - Poll for checks to attach to new SHA
+   
+3. **Wait for CI Completion** (step 4)
+   - Poll until all checks terminal on new SHA
+   
+4. **Re-check Review Comments** (step 5)
+   - New comments may have been added
+   - Previous review feedback context may have changed
+
+**Do not carry forward check results from a previous SHA.**
+
+## Quick Reference: Integration Outcomes
+
+| Gate | Condition | Action | Outcome |
+|------|-----------|--------|---------|
+| Contract | Lane + scope correct | Continue | ✅ pass |
+| Contract | Lane/scope wrong | Re-evaluate/route to maintenance | ❌ blocked-contract-drift |
+| Mergeability | Local merge clean | Continue | ✅ pass |
+| Mergeability | Conflicts exist, resolve them | Fix + push + re-verify | ✅ pass (after resolution) |
+| Mergeability | Conflicts unresolved | Mark blocked | ❌ blocked-merge-conflict |
+| CI Attach | Checks on head SHA | Continue | ✅ pass |
+| CI Attach | Missing after retrigger | Mark blocked | ❌ blocked-ci-failure |
+| CI Result | All terminal success | Continue | ✅ pass |
+| CI Result | Any terminal failure (fixable) | Fix + push + restart gates 2-4 | ✅ pass (after fix) |
+| CI Result | Failures not fixable | Mark blocked | ❌ blocked-ci-failure |
+| Reviews | No blocking comments | Continue | ✅ pass |
+| Reviews | Actionable within scope | Fix + push + restart gates 2-5 | ✅ pass (after fix) |
+| Reviews | Out-of-scope | Comment + continue | ✅ pass |
+| Reviews | Blocking comments remain | Mark blocked | ❌ blocked-review-feedback |
+| **All gates** | **All pass** | **Hand off** | **ready-for-verification** |
+
+## Lifecycle Truth Rules During Integration
 
 - Keep Issue/Project state truthful:
   - active work remains `In Progress`
   - move to `Review` only when review handoff is explicit (normally after review requested)
 - Do not mark lifecycle `Done` in this stage.
 - Do not close the governing Issue in this stage.
-- Do not merge the PR in this stage.
+- **Do not merge the PR in this stage.** Merge is owned by verification-validation-feedback after delivery contract verification.
 
-## Output format
+## Handoff Decision (Executable)
+
+**ONLY ONE of these outcomes must be declared. Each outcome has explicit conditions and next steps.**
+
+### Outcome 1: ✅ `ready-for-verification`
+
+**Conditions (ALL must be true):**
+```bash
+# 1. Local merge clean
+git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD | grep -q CONFLICT && exit 1 || echo "✅ No CONFLICT"
+
+# 2. GitHub mergeable is true/MERGEABLE
+gh pr view <PR_NUMBER> --json mergeable | grep -E "MERGEABLE|true" || exit 1
+
+# 3. All checks passed on current head SHA
+gh pr checks <PR_NUMBER> | grep -E "fail|pending|in_progress" && exit 1 || echo "✅ All checks passed"
+
+# 4. No blocking review comments
+gh pr view <PR_NUMBER> --json reviews | jq '.[].state' | grep -iE "request_changes" && exit 1 || echo "✅ No blocking reviews"
+```
+
+**Handoff:**
+```bash
+echo "HANDOFF DECISION: ready-for-verification"
+echo "Execute: .codex/skills/verification-validation-feedback/SKILL.md"
+```
+
+### Outcome 2: ❌ `blocked-merge-conflict`
+
+**Condition:** Merge conflicts remain after attempted resolution.
+
+**Handoff:**
+```bash
+echo "HANDOFF DECISION: blocked-merge-conflict"
+echo "Conflicted files: $(git diff --name-only --diff-filter=U)"
+echo "Route back to: Issue or manual conflict resolution"
+```
+
+### Outcome 3: ❌ `blocked-ci-failure`
+
+**Conditions:**
+- Required CI checks failed and not fixable within Issue scope
+- CI checks not attaching to head SHA after retrigger
+- CI timeout (exceeded 15 minutes)
+
+**Handoff:**
+```bash
+echo "HANDOFF DECISION: blocked-ci-failure"
+echo "Failing jobs: $(gh pr checks <PR_NUMBER> | grep fail)"
+echo "Log URLs: $(gh pr checks <PR_NUMBER> | grep fail | awk '{print $NF}')"
+echo "Route back to: Issue maintenance or CI configuration review"
+```
+
+### Outcome 4: ❌ `blocked-contract-drift`
+
+**Condition:** PR body or scope no longer matches Issue contract.
+
+**Handoff:**
+```bash
+echo "HANDOFF DECISION: blocked-contract-drift"
+echo "Contract mismatch: <specific difference>"
+echo "Route to: issue-maintenance skill"
+```
+
+### Outcome 5: ❌ `blocked-review-feedback`
+
+**Condition:** Unresolved blocking review comments (request-changes).
+
+**Handoff:**
+```bash
+echo "HANDOFF DECISION: blocked-review-feedback"
+echo "Blocking comments: $(gh pr view <PR_NUMBER> --json reviews | jq '.[].body')"
+echo "Route back to: Issue maintenance or implementer for resolution"
+```
+
+---
+
+## Output Format
 
 1. PR Integration Inputs
-2. Contract Gate Result
-3. Mergeability Actions (including local merge simulation output)
-4. CI Attachment and Status (including poll attempts and final check results)
-5. Review Comment Detection and Response
-6. Handoff Decision
-
-Handoff decision must be exactly one of:
-
-- `ready-for-verification` — all gates pass: mergeable confirmed locally, CI green on current SHA, review feedback addressed
-- `blocked-merge-conflict` — merge conflicts remain unresolved after rebase/merge attempt
-- `blocked-ci-failure` — required CI checks failing or not attaching
-- `blocked-contract-drift` — PR body or scope no longer matches Issue contract
-- `blocked-review-feedback` — unresolved blocking review comments found
-
-**`ready-for-verification` requires ALL of:**
-- Local merge simulation clean (no CONFLICT output)
-- GitHub API `mergeable` is `true` or `MERGEABLE`
-- All CI checks in terminal success state on current head SHA
-- No unresolved blocking review comments
+2. Contract Gate Result (✅ pass or ❌ fail)
+3. Mergeability Gate Result (✅ pass or ❌ fail + actions taken)
+4. CI Attachment and Status (✅ attached + results or ❌ missing/timeout)
+5. Review Comment Assessment (✅ none/addressed or ❌ blocking comments)
+6. **Explicit Handoff Decision** (one of the 5 outcomes above)

--- a/.codex/skills/publish-pr/SKILL.md
+++ b/.codex/skills/publish-pr/SKILL.md
@@ -10,6 +10,8 @@ Use this skill when local work is complete enough to publish as a branch and pul
 Goal:
 turn validated local changes into a truthful branch, commit, pushed head, and PR artifact without mixing publication with implementation logic.
 
+⚠️ **CRITICAL: All publication steps (branch creation, staging, commit, push, PR creation) must be executed using explicit git/gh commands. Do not describe these steps—execute them and verify they succeeded. Hand off to pr-integration is mandatory.**
+
 ## Canonical workflow position
 
 `Docs -> Issue -> Project -> Issue maintenance -> Agent -> Publish PR -> PR integration -> CI -> Verification -> Project/doc closure -> Owner Doc`
@@ -41,15 +43,154 @@ turn validated local changes into a truthful branch, commit, pushed head, and PR
 - Default to opening a draft PR unless the work is explicitly ready for review handoff.
 - Publication does not move work to `Done`.
 
-## Recommended publication sequence
+## Publication workflow (all steps are executable)
 
-1. Confirm the file set belongs to a single lane and single bounded change.
-2. Create or switch to a dedicated branch.
-3. Stage only the intended files.
-4. Write a commit message that matches the bounded outcome.
-5. Push the branch.
-6. Open or update the PR with truthful lane classification.
-7. Hand off to `.codex/skills/pr-integration/SKILL.md`.
+### Step 1: Confirm File Set
+
+Verify files belong to a single lane and single bounded change:
+
+```bash
+git status --porcelain
+```
+
+All modified/new files must align with a single lane (implementation, docs-authoring, or governance).
+
+### Step 2: Create or Switch Branch
+
+```bash
+# Option A: Create new branch from main
+git fetch origin main
+git checkout -b <branch-name> origin/main
+
+# OR Option B: Switch to existing branch
+git checkout <branch-name>
+
+# Verify correct branch
+git status
+```
+
+Branch naming: Descriptive, hyphenated (e.g., `fix-auth-token-expiry`, `docs-roadmap-update`, `governance-skill-updates`).
+
+### Step 3: Stage Intended Files
+
+```bash
+# Stage specific files (not all changes)
+git add <file1> <file2> <file3>
+
+# Verify staging
+git status
+```
+
+Do not use `git add -A` or `git add .`—stage only intended files.
+
+### Step 4: Create Commit
+
+```bash
+git commit -m "$(cat <<'EOF'
+Brief summary of bounded outcome
+
+Optional detailed explanation of why this change is needed.
+
+Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+Commit message must:
+- Start with imperative verb (Fix, Add, Update, Rebuild, etc.)
+- Summarize the bounded outcome, not the mechanical changes
+- Be truthful about scope
+
+### Step 5: Push Branch
+
+```bash
+git push origin <branch-name>
+```
+
+Verify push succeeded and GitHub suggests PR creation.
+
+### Step 6: Create or Update PR
+
+Execute based on lane classification:
+
+**Implementation Lane (Fixes an Issue):**
+```bash
+gh pr create --draft \
+  --title "<bounded outcome>" \
+  --body "$(cat <<'EOF'
+Fixes #<ISSUE_NUMBER>
+
+## Summary
+<1-2 sentence summary of the bounded change>
+
+## Validation
+<What validation actually ran>
+
+---
+EOF
+)"
+```
+
+**Docs Authoring Lane:**
+```bash
+gh pr create --draft \
+  --title "<docs update title>" \
+  --body "$(cat <<'EOF'
+- [x] Docs authoring lane
+
+## Summary
+<Summary of documentation changes>
+
+## Changes
+<What surfaces were updated>
+
+## Validation
+<Docs validation that ran>
+
+---
+EOF
+)"
+```
+
+**Governance Lane:**
+```bash
+gh pr create --draft \
+  --title "<governance change title>" \
+  --body "$(cat <<'EOF'
+- [x] Governance lane
+
+## Summary
+<Summary of governance/workflow change>
+
+## Changes
+<What surfaces were updated>
+
+## Validation
+<Governance validation that ran>
+
+---
+EOF
+)"
+```
+
+**Update Existing PR:**
+```bash
+gh pr edit <pr-number> --body "$(cat <<'EOF'
+... updated body content ...
+EOF
+)"
+```
+
+### Step 7: Hand Off to pr-integration
+
+After PR is created/updated, execute pr-integration skill:
+
+```bash
+# Invoke pr-integration skill to verify, check CI, and prepare for verification
+echo "Handing off to pr-integration skill"
+```
+
+**Do not skip this handoff.** PR integration resolves merge conflicts, verifies CI, and prepares the PR for verification/merge.
 
 ## PR body requirements
 

--- a/.codex/skills/verification-validation-feedback/SKILL.md
+++ b/.codex/skills/verification-validation-feedback/SKILL.md
@@ -9,6 +9,8 @@ You are a delivery verification and feedback-loop agent for a repo-first, docs-a
 
 You operate after PR integration has produced a mergeable, CI-green PR.
 
+⚠️ **CRITICAL: All lifecycle state changes (labels, Project Status, Issue closure, PR merge) must be executed using explicit commands (`gh issue edit`, `gh issue close`, `gh pr merge`, `gh api graphql`). Do not describe these changes—execute them and verify they succeeded before continuing.**
+
 ## Your job
 
 - verify the implementation against the governing slice or feature contract
@@ -80,7 +82,7 @@ Prioritize findings first:
 
 **Verification owns the merge decision.** No other skill merges PRs.
 
-When to merge:
+### Prerequisites for Merge
 
 - All acceptance criteria from the governing Issue are satisfied.
 - CI is green on the current head SHA.
@@ -88,57 +90,165 @@ When to merge:
 - No scope drift from the governing Issue.
 - Owner docs and roadmap/plan wording are updated if the work changed shipped reality.
 
-How to merge:
+### Action: Merge PR and Deliver Issue
 
-1. Confirm the PR head SHA still matches what was verified (no new pushes since verification started).
-2. Use `gh pr merge <pr> --squash --delete-branch` (squash merge is the repo default unless configured otherwise).
-3. Verify the merge succeeded by checking the PR state.
-4. If merge fails (e.g., branch protection, new conflicts), report the failure and route back to pr-integration.
+When all merge prerequisites are met:
 
-When NOT to merge:
+1. **Confirm PR head SHA hasn't changed** since verification started:
+   ```bash
+   gh pr view #<PR> --json commits
+   ```
 
-- Any acceptance criterion is not met — create follow-up Issue instead.
-- CI has regressed since pr-integration handoff — route back to pr-integration.
-- Scope drift detected — route through Issue maintenance.
-- Work is only partial — keep Issue open, create follow-up Issue(s).
+2. **Merge the PR:**
+   ```bash
+   gh pr merge #<PR> --squash --delete-branch
+   ```
+
+3. **Verify merge succeeded:**
+   ```bash
+   gh pr view #<PR> --json mergedAt,state
+   ```
+
+4. **Close the Issue:**
+   ```bash
+   gh issue close #<N>
+   ```
+
+5. **Remove all agent labels from Issue:**
+   ```bash
+   gh issue edit #<N> --remove-label agent:ready --remove-label agent:blocked --remove-label agent:needs-human
+   ```
+
+6. **Set Issue Project Status to Done:**
+   ```bash
+   gh api graphql -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
+     -f fieldId="$STATUS_FIELD_ID" -f optionId="$DONE_OPTION_ID" \
+     -f query='mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!) { updateProjectV2ItemFieldValue(input:{projectId:$projectId itemId:$itemId fieldId:$fieldId value:{singleSelectOptionId:$optionId}}) { projectV2Item { id } } }'
+   ```
+
+7. **Set PR Project Status to Done:**
+   ```bash
+   gh api graphql -f projectId="$PROJECT_ID" -f itemId="$PR_ITEM_ID" \
+     -f fieldId="$STATUS_FIELD_ID" -f optionId="$DONE_OPTION_ID" \
+     -f query='mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!) { updateProjectV2ItemFieldValue(input:{projectId:$projectId itemId:$itemId fieldId:$fieldId value:{singleSelectOptionId:$optionId}}) { projectV2Item { id } } }'
+   ```
+
+8. **Verify final state:**
+   ```bash
+   gh issue view #<N> --json state,labels,projectItems
+   gh pr view #<PR> --json state,projectItems
+   ```
+
+### When NOT to merge
+
+- Any acceptance criterion is not met → create follow-up Issue instead.
+- CI has regressed since pr-integration handoff → route back to pr-integration.
+- Scope drift detected → route through Issue maintenance.
+- Work is only partial → **do NOT merge**, keep Issue open, create follow-up Issue(s).
 
 ## Lifecycle rules during verification
 
-- Verification owns terminal delivery-state correction.
+**Verification owns terminal delivery-state correction. All state changes must be executed, not just described.**
+
 - An open or draft PR without explicit review handoff remains `In Progress`; `Review` is reserved for the review handoff state.
-- If a slice issue is fully delivered and its bounded acceptance criteria are satisfied:
-  - ensure the slice issue is closed or recommended for closure
-  - ensure the slice issue reaches Project Status=`Done`
-  - remove stale active-work labels such as `agent:ready`, `agent:blocked`, and `agent:needs-human`
-- If the parent feature still needs validation or acceptance:
-  - keep the parent feature issue open
-  - keep owner docs stable until the support claim actually changes
-- If the feature issue is fully delivered and acceptance is satisfied:
-  - ensure the feature issue is closed or recommended for closure
-  - ensure Project Status is `Done`
-- If the Issue is fully delivered and acceptance criteria are satisfied:
-  - merge the PR
-  - ensure the Issue is closed
-  - ensure Project Status is `Done`
-  - remove stale active-work labels such as `agent:ready`, `agent:blocked`, and `agent:needs-human`
-- If a related PR was closed without merge but represents terminal tracked work, ensure the Project projection is also terminal rather than blank.
-- If the work is partial:
-  - do NOT merge
-  - keep the Issue open
-  - correct labels/status so they reflect reality
-  - create bounded follow-up Issue(s) if needed
-- Do not leave merged, delivered work in `Backlog`, `Ready`, `In Progress`, or `Review`.
+
+### Slice Issue Fully Delivered
+
+If a slice issue is fully delivered and its bounded acceptance criteria are satisfied:
+
+1. **Execute Action: Merge PR and Deliver Issue** (closes issue, removes labels, sets statuses to Done)
+2. Verify Issue is closed and Project Status is `Done`
+
+### Parent Feature Still Needs Validation
+
+If the parent feature issue still needs validation or acceptance after slice merge:
+
+- Keep the parent feature issue open
+- Keep owner docs stable until the support claim actually changes
+- Do NOT close parent feature issue yet
+
+### Feature Issue Fully Delivered
+
+If the feature issue is fully delivered and acceptance is satisfied:
+
+1. **Close the feature Issue:**
+   ```bash
+   gh issue close #<N>
+   ```
+
+2. **Set Project Status to Done:**
+   ```bash
+   gh api graphql -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
+     -f fieldId="$STATUS_FIELD_ID" -f optionId="$DONE_OPTION_ID" \
+     -f query='mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!) { updateProjectV2ItemFieldValue(input:{projectId:$projectId itemId:$itemId fieldId:$fieldId value:{singleSelectOptionId:$optionId}}) { projectV2Item { id } } }'
+   ```
+
+### PR Closed Without Merge (Terminal)
+
+If a related PR was closed without merge but represents terminal tracked work:
+
+1. **Set PR Project Status to Done:**
+   ```bash
+   gh api graphql -f projectId="$PROJECT_ID" -f itemId="$PR_ITEM_ID" \
+     -f fieldId="$STATUS_FIELD_ID" -f optionId="$DONE_OPTION_ID" \
+     -f query='mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!) { updateProjectV2ItemFieldValue(input:{projectId:$projectId itemId:$itemId fieldId:$fieldId value:{singleSelectOptionId:$optionId}}) { projectV2Item { id } } }'
+   ```
+
+### Work is Partial
+
+If the work is only partial:
+
+1. **Do NOT merge the PR**
+2. **Keep the Issue open**
+3. **Update labels and status to reflect reality:**
+   ```bash
+   gh issue edit #<N> --remove-label agent:ready --add-label agent:needs-human
+   gh api graphql ... (set Project Status to Backlog)
+   ```
+4. **Create bounded follow-up Issue(s)** with exact task-contract sections
+
+**Critical:** Do not leave merged, delivered work in `Backlog`, `Ready`, `In Progress`, or `Review`.
+
+## Quick Reference: Verification State Transitions
+
+| Condition | Action | Issue Labels | Issue Status | PR Merge | PR Status |
+|-----------|--------|-------------|-------------|---------|-----------|
+| Fully delivered + CI green | Merge | -agent:* | Done | ✓ Squash | Done |
+| Partial delivery | Do NOT merge | +agent:needs-human | Backlog | ✗ | (unchanged) |
+| PR closed (terminal, no merge) | — | (leave as) | (no change) | — | Done |
+| Parent needs validation | Keep open | (no change) | (unchanged) | — | — |
 
 ## Dependent issue unblocking
 
-After verifying delivery and merging, scan for issues that were blocked by the delivered work:
+After merging and delivering work, scan for issues that were blocked by the delivered Issue:
 
-- Search for open issues with `agent:blocked` that reference the delivered Issue in their body (e.g., "Blocked by: #NNN").
-- For each blocked issue whose blocker is now resolved:
-  - remove `agent:blocked`, add `agent:ready`
-  - update Project Status from `Backlog` to `Ready`
-  - post an unblocking comment naming the delivery that removed the blocker
-- Do not unblock issues whose actual dependency is still missing even though the named issue closed.
+### Action: Unblock Dependent Issue
+
+For each open issue with `agent:blocked` that references the delivered Issue in their body (e.g., "Blocked by: #NNN"):
+
+1. **Remove blocker label and add ready:**
+   ```bash
+   gh issue edit #<DEPENDENT> --remove-label agent:blocked --add-label agent:ready
+   ```
+
+2. **Update Project Status to Ready:**
+   ```bash
+   gh api graphql -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
+     -f fieldId="$STATUS_FIELD_ID" -f optionId="$READY_OPTION_ID" \
+     -f query='mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!) { updateProjectV2ItemFieldValue(input:{projectId:$projectId itemId:$itemId fieldId:$fieldId value:{singleSelectOptionId:$optionId}}) { projectV2Item { id } } }'
+   ```
+
+3. **Post unblocking comment:**
+   ```bash
+   gh issue comment #<DEPENDENT> --body "Unblocked by delivery of #<DELIVERED>. Ready for pickup."
+   ```
+
+4. **Verify:**
+   ```bash
+   gh issue view #<DEPENDENT> --json labels,projectItems
+   ```
+
+**Do NOT unblock** issues whose actual dependency is still missing even though the named issue closed.
 
 ## Project state operations
 


### PR DESCRIPTION
- [x] Governance lane

## Summary

Rebuilt five critical builder-agent skills to enforce that all GitHub state mutations and workflow handoffs are executed via explicit `gh`/git/GraphQL commands, not described or recommended.

## Changes

### Core Lifecycle Skills (Issue Status & PR Management)

- **issue-to-code/SKILL.md**: Restructured lifecycle rules (Begin work, Blocked, Draft PR, Request Review) as executable Action blocks with verification steps
- **verification-validation-feedback/SKILL.md**: Restructured merge rules and lifecycle correction with explicit Merge and Unblock actions
- **issue-maintenance-change-control/SKILL.md**: Restructured corrections (Close, Malformed, Dedupe, PR reconciliation) as executable actions; updated fast-maintenance-run with gh commands

### Publication & Integration Skills (Workflow Handoffs)

- **publish-pr/SKILL.md**: Rebuilt 7-step workflow as executable Actions: confirm file set, create/switch branch, stage, commit, push, create PR, hand off
- **pr-integration/SKILL.md**: Rebuilt 5 gates with executable Action blocks: contract verification, mergeability, CI attachment, CI completion, review handling. Explicit handoff decisions (ready-for-verification or 4 blocked states)

## Key Features Across All Skills

- ⚠️ CRITICAL warning at top of each skill
- Executable Action blocks with exact commands (no recommendations)
- Both Issue AND PR status/label mutations together
- Verification steps after each command
- Quick-reference state transition tables
- Clear handoff requirements between skills
- Explicit outcomes (ready, blocked, or specific blocker type)

## Why

User feedback showed that state changes and workflow steps were being described but not executed. Skills appeared clear but were read as aspirational. This rebuild makes all publication, integration, and lifecycle operations unmistakably executable and explicit about what happens next.

## Validation

- Reviewed by user for foolproof structure
- No code behavior changes, only skill instruction format
- Changes stay within `.codex/skills/` governance surface
- Ready for internal review