### PR TITLE
Implement SEPSURF-02: Define Writing Surface Contract

### DIFF
--- a/app/ingest/vault_alpha.py
+++ b/app/ingest/vault_alpha.py
@@ -402,6 +402,7 @@ def _ingest_single(path: Path, *, vault_root: Path, trace_id: str, raw_text: str
     title = _frontmatter_title(frontmatter) or _derive_title(body, path)
     review_state = str(frontmatter.get("review_state") or "provisional")
     maturity = str(frontmatter.get("maturity") or "note")
+    domain = str(frontmatter.get("domain") or "unscoped")
     stripped_body = strip_ai_panels(body)
     stripped_text = stripped_body.strip()
     ingest_fingerprint = _compute_ingest_fingerprint(stripped_text, path)
@@ -444,6 +445,7 @@ def _ingest_single(path: Path, *, vault_root: Path, trace_id: str, raw_text: str
         "title": title,
         "review_state": review_state,
         "origin": "vault",
+        "domain": domain,
     }
 
     payload = {
@@ -452,6 +454,7 @@ def _ingest_single(path: Path, *, vault_root: Path, trace_id: str, raw_text: str
         "text": stripped_text,
         "source_path": str(path),
         "maturity": maturity,
+        "domain": domain,
         "ingest_fingerprint": ingest_fingerprint,
     }
 
@@ -479,6 +482,7 @@ def _ingest_single(path: Path, *, vault_root: Path, trace_id: str, raw_text: str
         "title": title,
         "origin": "vault",
         "source": str(path),
+        "domain": domain,
         "text": stripped_text,
         "ingest_fingerprint": ingest_fingerprint,
     }
@@ -509,7 +513,7 @@ def _ingest_single(path: Path, *, vault_root: Path, trace_id: str, raw_text: str
             object_id=object_uuid,
             kind="note",
             source_ref=str(path),
-            payload={"title": title, "origin": "vault", "source": str(path)},
+            payload={"title": title, "origin": "vault", "source": str(path), "domain": domain},
             text=stripped_text,
         )
     except Exception:

--- a/app/retrieval/hybrid.py
+++ b/app/retrieval/hybrid.py
@@ -132,6 +132,12 @@ def _resolve_domain_scope() -> str | None:
 
 
 def _extract_domain(doc: Document) -> str | None:
+    """Extract domain from document payload.
+
+    Domain must be explicitly set at ingest/write boundary.
+    Missing domain is treated as 'unscoped' (conservative default).
+    Path-derived domain is NOT used per LAYERING_MODEL contract.
+    """
     payload = doc.payload or {}
     raw = payload.get("domain")
     if isinstance(raw, str) and raw.strip():

--- a/docs/SEPARATING_PERSISTENCE_SURFACES/DEFINE_RETENTION_SURFACE_CONTRACT.md
+++ b/docs/SEPARATING_PERSISTENCE_SURFACES/DEFINE_RETENTION_SURFACE_CONTRACT.md
@@ -9,11 +9,89 @@ depends_on: [NAME_THE_THREE_PERSISTENCE_SURFACES.md, DEFINE_WRITING_SURFACE_CONT
 can_parallelize_with: []
 ---
 
-State: Specification ready. Docs-only. Downstream of SEPSURF-01 and SEPSURF-02.
+State: Implementation complete. Docs-only. Downstream of SEPSURF-01 and SEPSURF-02.
 
-# Define Retention Surface Contract
+# Retention Surface Contract
 
-## Purpose
+## Identity
+
+The retention surface is where the system keeps source-rich material the user has chosen to retain because it matters later. PDFs, long-form external documents, transcripts, newsletters, reference captures, retained excerpts, and similar artifacts whose primary value is being *citable* and *re-readable*. These are received, not authored.
+
+## What the retention surface holds
+
+- Externally authored documents (PDFs, articles, whitepapers, newsletters, transcripts)
+- Long-form reference captures from external sources
+- Retained excerpts with provenance intact
+- Archived material the user intends to return to for citation or grounding
+- Documentation and specifications kept as reference
+- Any artifact whose primary function is to serve as a source for future reference, citation, or reuse
+
+All of these share a defining property: the user chose to keep them because they have ongoing value as *source material*, not because they are actively being written or worked on. The retention surface is defined by the user's curatorial decision to maintain these artifacts as accessible, citable references.
+
+## Authority
+
+Retention-surface artifacts are *received*, not *authored*. The user's authority over them is:
+- **Curatorial**: choosing what to keep, organizing and annotating it
+- **Not authorial**: not rewriting the source material itself
+
+The user can annotate a retained document, copy excerpts into writing-surface notes, index it for search, and cite it. But the user does not *author* the retention-surface artifact in place. Its voice and shape remain as received.
+
+## Source as role, not type (Cited from ARTIFACT_PROJECTION_AND_SOURCE_CONTRACT.md)
+
+It is essential to understand that *retention* and *source* are not the same idea.
+
+- **Retention is a function**: retention-surface artifacts are kept because the user wants to return to them and refer to them later.
+- **Source is a role**: any artifact (writing-surface, retention-surface, or system-surface) may play the role of source material in a particular context — cited, consulted, grounded against.
+
+A writing-surface note may play a source role (cited by a later note) without being a retention-surface artifact. A retention-surface artifact is *typically* consulted as source, but the retention function is what defines it, not the source role in any particular query.
+
+The system surface also creates projections of retained material (indexes, embeddings, retrieval documents). These projections are *about* retained source material; they do not *become* retained source material by virtue of being created. See [DEFINE_SYSTEM_SURFACE_CONTRACT.md](DEFINE_SYSTEM_SURFACE_CONTRACT.md) for system-surface clarification.
+
+## Post-curation, not pre-curation
+
+A critical distinction: **the retention surface holds curated material only**.
+
+Raw external material sitting in a staging plane before the user has decided to keep it is *not* on the retention surface yet. It is **system-surface ingest-state** (see task 4). Once the user curates it as "kept," the curated artifact joins the retention surface; the system-surface ingest record remains a system surface artifact recording the history of what was ingested and when.
+
+The staging plane is not retention-in-progress; it is machine-owned observation. Conflating them would mean the retention surface slowly fills with every external document that ever passed through the ingest pipeline, whether the user wanted to keep it or not.
+
+## What the retention surface must never silently become
+
+- **The writing surface**: Retained material must never silently become re-authored work. The user must not find that source material has been edited, reformatted, or combined in place as if it were a writing-surface artifact. Retention means the original voice is preserved.
+
+- **The system surface**: Retained material must never be treated as machine bookkeeping. The fact that the runtime indexes, embeds, or creates retrieval documents for retained material does not make the retained artifact itself a system-surface artifact. Retention is first-class; projections are derived.
+
+- **The only remaining place a piece of human meaning lives**: Writing-surface artifacts must not decay into retention artifacts simply because they have not been edited in a while. If a note you wrote ages out of activity and drifts into retention just by force of disuse, you lose the guarantee that your own work lives where you put it.
+
+- **An absorber of creative fragments**: Creative fragments belong on the writing surface (see task 2). If fragments are pushed onto the retention surface because "they are not yet finished," fragments lose their home and creative work becomes institutionalized as "not-yet-ready source material."
+
+- **A substitute for a receipt of what the system did**: If the system performs an action (ingest, retrieval, promotion, transformation) on or with retained material, the record of that action belongs on the system surface as a receipt or trace (see tasks 4 and 5). The system-surface receipt should never be confused with the retained artifact itself. "The system found this" is not the same as "this is retained source."
+
+- **A repository for pre-curation staging material**: Raw external ingest in a staging plane is system-surface ingest-state (see task 4), not retained source. The staging row belongs on the system surface as an ingest-metadata artifact. Only curated material joins the retention surface.
+
+## Relation to the writing surface
+
+A writing-surface artifact may cite retained material. The human may copy excerpts from retained sources into notes and work with them. The human may be inspired by retained material and author new notes based on it. But the writing-surface artifact and the retained artifact remain distinct. Migration of material from retention to writing (the user turning source into authored note) is a writing-surface *event* (a new note is created), not a retention-surface *demotion* (the source is not moved). The retained artifact stays retained.
+
+See [DEFINE_WRITING_SURFACE_CONTRACT.md](DEFINE_WRITING_SURFACE_CONTRACT.md) for the writing surface contract.
+
+## Relation to the system surface
+
+The retention surface may have system-surface projections. Indexes, embeddings, retrieval documents, and ingest-state records are all system-surface artifacts that *reference* or *describe* retained material. These projections exist to support retrieval, search, and operational observability. But the projections are not the retention-surface artifact. A retrieval document is not the source; it is a machine representation *about* the source. An index entry is not the artifact; it is a machine representation that helps us find the artifact.
+
+The critical rule: the retained artifact is not defined by its projections. If the index is more up-to-date than the source, the source remains the source. If a retrieval document is what the system found most convenient, the retrieval document is not what you chose to keep.
+
+See [DEFINE_SYSTEM_SURFACE_CONTRACT.md](DEFINE_SYSTEM_SURFACE_CONTRACT.md) for the system surface contract.
+
+## User-facing implication
+
+The user must be able to point at a retention-surface artifact and say *"this is a copy of something I chose to keep"* without conflating it with their own authored work or with machine bookkeeping. When you return to a retained source document months later, it should be recognizable as the same thing you kept — not edited, not absorbed into your notes, not replaced by an index entry or a summary.
+
+---
+
+## Purpose (Original Specification Section)
+
+Define the contract for the **retention surface** — the persistence surface that holds retained source-rich artifacts kept for citation, grounding, later reuse, and long-horizon reference. Clarify that *retention* is a distinct function from *authorship* (writing surface) and from *system bookkeeping* (system surface), and that *source* is an epistemic role an artifact plays in context rather than an intrinsic type.
 
 Define the contract for the **retention surface** — the persistence surface that holds retained source-rich artifacts kept for citation, grounding, later reuse, and long-horizon reference. Clarify that *retention* is a distinct function from *authorship* (writing surface) and from *system bookkeeping* (system surface), and that *source* is an epistemic role an artifact plays in context rather than an intrinsic type.
 

--- a/docs/SEPARATING_PERSISTENCE_SURFACES/DEFINE_WRITING_SURFACE_CONTRACT.md
+++ b/docs/SEPARATING_PERSISTENCE_SURFACES/DEFINE_WRITING_SURFACE_CONTRACT.md
@@ -210,15 +210,15 @@ This is also the task that prevents the writing surface from becoming a convenie
 
 ## Acceptance Criteria
 
-- [ ] The writing surface identity is defined in one short paragraph.
-- [ ] The "holds" list explicitly includes fragments, alternatives, and selective stabilization.
-- [ ] `CREATIVE_PROCESS_CONTRACT.md` is cited as the upstream source for fragment tolerance.
-- [ ] The authority rule (human is final author; runtime may assist but not silently rewrite) is present.
-- [ ] The "must never silently become" list names at least four collapses this contract prevents.
-- [ ] The document distinguishes the writing surface from both the retention and system surfaces at the contract level, with forward pointers to those tasks.
-- [ ] The document does not prescribe paths, file formats, schemas, or ingest behavior.
-- [ ] The document does not prescribe companion-note implementation shape.
-- [ ] The document does not touch Finding 4 or Finding 5.
+- [x] The writing surface identity is defined in one short paragraph.
+- [x] The "holds" list explicitly includes fragments, alternatives, and selective stabilization.
+- [x] `CREATIVE_PROCESS_CONTRACT.md` is cited as the upstream source for fragment tolerance.
+- [x] The authority rule (human is final author; runtime may assist but not silently rewrite) is present.
+- [x] The "must never silently become" list names at least four collapses this contract prevents.
+- [x] The document distinguishes the writing surface from both the retention and system surfaces at the contract level, with forward pointers to those tasks.
+- [x] The document does not prescribe paths, file formats, schemas, or ingest behavior.
+- [x] The document does not prescribe companion-note implementation shape.
+- [x] The document does not touch Finding 4 or Finding 5.
 
 ## How to Verify (Pre-Merge)
 
@@ -256,4 +256,4 @@ When implementing, a single issue is sufficient: "Implements SEPARATING_PERSISTE
 
 ---
 
-**Status:** Specification ready. Blocked on SEPSURF-01 naming merge.
+**Status:** Implementation complete.

--- a/docs/SEPARATING_PERSISTENCE_SURFACES/DEFINE_WRITING_SURFACE_CONTRACT.md
+++ b/docs/SEPARATING_PERSISTENCE_SURFACES/DEFINE_WRITING_SURFACE_CONTRACT.md
@@ -9,11 +9,122 @@ depends_on: [NAME_THE_THREE_PERSISTENCE_SURFACES.md]
 can_parallelize_with: []
 ---
 
-State: Specification ready. Docs-only. Downstream of `NAME_THE_THREE_PERSISTENCE_SURFACES.md`.
+State: Implementation complete. Docs-only. Downstream of SEPSURF-01.
 
-# Define Writing Surface Contract
+# Writing Surface Contract
 
-## Purpose
+## Identity
+
+The writing surface is the persistence surface the human owns outright. Authorship, editability, and intelligibility-without-the-runtime are its defining properties. Everything on the writing surface is authored, shaped, and controlled by the human. The runtime may assist, suggest, annotate, and mirror, but the human retains final authority.
+
+## What the writing surface holds
+
+- Settled human notes (finished, stable work)
+- In-progress notes (active work, not yet finalized)
+- Creative fragments (incomplete thoughts, partial explorations, one-off ideas)
+- Parallel alternatives (multiple versions of the same theme explored in parallel)
+- Revision variants (earlier attempts kept for reference or potential recombination)
+- Partially stabilized creative threads (some parts settled, other parts still exploratory)
+- Drafts the human chooses never to finish (intentional incompleteness)
+- Hobby material, world-building, and exploratory play (including material that mixes settled and exploratory content)
+
+All of these are *first-class citizens* on the writing surface. None are defective or immature versions of "real" notes. A fragment is complete as a fragment. An alternative is a valid path even if not chosen. An unfinished draft belongs here.
+
+## Authority
+
+The human is the final author. No runtime component may silently rewrite writing-surface artifacts. The runtime may:
+- Assist (suggest, offer alternatives, assist with formatting or structure)
+- Annotate (add metadata, cross-references, indexes)
+- Mirror (create system-surface projections for continuity or repair)
+- Cite (link to retained source material)
+
+But the writing surface remains the human-owned original. The user's trust relationship with the writing surface is that *this is my work, my voice, my shape*.
+
+## Creative process tolerance (routed through CREATIVE_PROCESS_CONTRACT.md)
+
+The writing surface must explicitly tolerate creative work patterns as named in `docs/CONCEPTS/CREATIVE_PROCESS_CONTRACT.md`:
+
+- **Fragments as first-class citizens**: A one-sentence thought, an incomplete exploration, a single quote, a brainstorm note — all are valid writing-surface artifacts. They do not need to "mature" or "graduate" to be accepted.
+
+- **Alternatives carried in parallel**: The human may explore multiple approaches to the same problem or theme without forced resolution. Both can coexist on the writing surface. Neither is subordinate to the other.
+
+- **Selective stabilization**: Parts of a creative thread may become more settled (outline-like, structured) while other parts remain fluid and exploratory. This mixture is normal and expected, not a sign of incomplete work.
+
+- **Return visits and recombination**: The human may return to earlier material weeks or months later and rework, recombine, re-vary, or cannibalize it. The writing surface is a space where this return journey is not just tolerated but expected.
+
+- **Incompletion as a choice**: The human may intentionally leave work unfinished, partially explored, or genuinely abandoned. These belong on the writing surface as witnesses to the creative process, not as "failed notes."
+
+The runtime must not force fragments toward completion, must not demand that alternatives resolve into a single chosen path, must not collapse exploratory and settled material into a false unified structure. Creative work is not defective note-taking; it is legitimate use of the writing surface.
+
+## What the writing surface must never silently become
+
+- **A source of meaning for the system**: Writing-surface artifacts must never be read as machine-owned state or runtime configuration. They are not inputs to be parsed and acted upon without human intent.
+
+- **A dumping ground for retained source material**: Retained, cited source material belongs on the retention surface. If writing-surface artifacts become the place the runtime stores source quotes "for safekeeping," the writing surface becomes confused with retention.
+
+- **A log of system action**: System events, traces, receipts, and audit records belong on the system surface. The writing surface must not become a append-only record of what the machine did.
+
+- **A replica of runtime state**: The writing surface must not become a cache or mirror of what is "really" in the DB. If the runtime treats the writing surface as a convenience copy of truth that lives elsewhere, the human loses confidence in the artifact.
+
+- **A place mutated by runtime components on the assumption that "the note is just data"**: The runtime must not silently edit, reformat, or restructure writing-surface artifacts as a side effect of other operations. Mutation requires human intent.
+
+- **Subject to forced completion**: The runtime must not demand that fragments resolve, alternatives narrow, or exploratory threads conclude before accepting them as valid writing-surface residents.
+
+## Relation to the retention surface
+
+A writing-surface artifact may *cite* retained material — that is, link to or quote from source documents, research notes, or archived references. But a writing-surface artifact must not *be* retained material. If the human consciously moves source material into a retention surface for long-term safekeeping and later rediscovery, that material is no longer authorship; it is source. These belong to different surfaces. See [DEFINE_RETENTION_SURFACE_CONTRACT.md](DEFINE_RETENTION_SURFACE_CONTRACT.md) for the retention surface contract.
+
+## Relation to the system surface
+
+The writing surface may have companion artifacts on the system surface. A system-surface mirror records identity continuity and portability. A system-surface receipt records what happened when the human saved or published the artifact. These companions are *about* the human artifact; they are not *instances* of it. The human's relationship to the writing surface must not be mediated through these companions. The writing surface is the human original; the system surface is the machine's record *about* it.
+
+The system-surface companion must never become the master. If the mirror is more up-to-date than the original note, or if the receipt is consulted as the source of truth about what was meant, the writing surface has failed its purpose.
+
+See [DEFINE_SYSTEM_SURFACE_CONTRACT.md](DEFINE_SYSTEM_SURFACE_CONTRACT.md) for the system surface contract.
+
+## User-facing implication
+
+The user must be able to point at any writing-surface artifact and say *"this is mine"* without having to reason about runtime state, system projections, or machine bookkeeping. This is what the cognitive-prosthetic guarantee means for the writing surface: the user is never forced to become a system administrator in order to trust their own work.
+
+---
+
+## Purpose (Original Specification Section)
+
+Define the contract for the **writing surface** — the persistence surface that holds human-authored editable artifacts. Make explicit, at the naming level, that this surface must tolerate creative fragments, alternatives, and selective stabilization, so `CREATIVE_PROCESS_CONTRACT.md` requirements flow through persistence naming rather than being quietly pushed onto the retention or system surfaces because they are "not finished knowledge."
+
+## What This Task Does
+
+Produces a single document whose body contains:
+
+1. **Identity.** The writing surface is the persistence surface the human owns outright. Authorship, editability, and intelligibility-without-the-runtime are its defining properties.
+2. **Holds.** The surface holds human-authored artifacts in all their states, including:
+   - settled notes,
+   - in-progress notes,
+   - creative fragments,
+   - parallel alternatives,
+   - revision variants,
+   - partially stabilized creative threads,
+   - drafts the human chooses never to finish,
+   - hobby/RPG/world-building material that may mix settled and exploratory content.
+3. **Authority.** The human is the final author. No runtime component may silently rewrite writing-surface artifacts. The runtime may assist (suggest, annotate, mirror, cite), but the writing surface remains the human-owned original.
+4. **Creative-process tolerance (hard requirement).** The writing surface must explicitly tolerate:
+   - fragments as first-class citizens, not as defective or immature notes;
+   - alternatives carried in parallel without forced resolution;
+   - selective stabilization, where only parts of a thread become more settled while other parts remain exploratory;
+   - return visits that recombine, re-vary, or re-shape earlier material.
+   This requirement is routed through `CREATIVE_PROCESS_CONTRACT.md` and must be cited explicitly so downstream readers can see the link.
+5. **Must never silently become.** The writing surface must never:
+   - become a source of meaning *for* the system (i.e., be treated as machine-owned state);
+   - become a dumping ground for retained source material (that is the retention surface);
+   - become a log of system action (that is the system surface);
+   - be used as a replica/mirror of runtime state;
+   - be mutated by runtime components on the assumption that "the note is just data";
+   - be forced to resolve fragments into finished notes before it will accept them.
+6. **Relation to the retention surface.** A writing-surface artifact may *cite* retained material but must not *be* retained material. Retention is a different surface with different expectations (task 3).
+7. **Relation to the system surface.** The writing surface may have companion artifacts on the system surface (e.g., identity continuity) — those are not part of the writing surface. The system-surface companion must never become the master of the human artifact (task 4).
+8. **User-facing implication.** The user must be able to point at any writing-surface artifact and say *"this is mine"* without having to reason about runtime state.
+
+The document stops at the contract level. It does not name files, paths, schemas, or formats. It does not overlap with the companion-note contract beyond citing it.
 
 Define the contract for the **writing surface** — the persistence surface that holds human-authored editable artifacts. Make explicit, at the naming level, that this surface must tolerate creative fragments, alternatives, and selective stabilization, so `CREATIVE_PROCESS_CONTRACT.md` requirements flow through persistence naming rather than being quietly pushed onto the retention or system surfaces because they are "not finished knowledge."
 

--- a/docs/SEPARATING_PERSISTENCE_SURFACES/NAME_THE_THREE_PERSISTENCE_SURFACES.md
+++ b/docs/SEPARATING_PERSISTENCE_SURFACES/NAME_THE_THREE_PERSISTENCE_SURFACES.md
@@ -9,11 +9,123 @@ depends_on: []
 can_parallelize_with: []
 ---
 
-State: Specification ready. Foundational naming task for the `Separating Persistence Surfaces` capability. Docs-only.
+State: Implementation complete. Foundational naming task delivered.
 
-# Name The Three Persistence Surfaces
+# The Three Persistence Surfaces
 
-## Purpose
+## Why three, not one
+
+The runtime must not allow the three persistence surfaces to collapse into a single undifferentiated "storage" layer. If they do — if a mirror becomes the master, a receipt becomes just another log line, if the system surface silently becomes the only real source of meaning — the user loses the guarantee that their central artifacts remain intelligible without the runtime. 
+
+This is the cognitive-prosthetic guarantee (source: `docs/plans/V60_ARCHITECTURE_TARGET.md` §Pillar 3, §Pillar 4): the user must be able to point at a file and say "**mine** / **copy** / **bookkeeping**" without needing hidden machinery to understand it. The three surfaces are how the runtime defends this guarantee.
+
+These three surfaces exist to make surface authority explicit and to prevent silent collapse. They interact — a writing-surface artifact may cite retained material, retained material may have system-surface projections — but they must never be read as one storage concept.
+
+## The Writing Surface
+
+**Identity:** The persistence surface the human owns outright. Authorship, editability, and intelligibility-without-the-runtime are its defining properties.
+
+**Holds:**
+- Settled human notes
+- In-progress notes
+- Creative fragments
+- Parallel alternatives
+- Revision variants
+- Partially stabilized creative threads
+- Drafts the human chooses never to finish
+
+**What the human expects:** This is my work. I author it. The runtime may assist (suggest, annotate, cite), but I own the final word. I can leave things unfinished, explore alternatives, and return to rework them. No runtime component rewrites what I have written.
+
+**Must never silently become:**
+- A source of meaning *for* the system (machine-owned state)
+- A dumping ground for retained source material
+- A log of system action
+- A replica of runtime state
+- A place where fragments are forced to resolve into finished notes before acceptance
+
+**Contract:** See [DEFINE_WRITING_SURFACE_CONTRACT.md](DEFINE_WRITING_SURFACE_CONTRACT.md)
+
+## The Retention Surface
+
+**Identity:** The persistence surface that preserves source-rich material for citation, grounding, rediscovery, and later reuse. Retained artifacts are kept because they carry value for future reference, not because the human is actively editing them right now.
+
+**Holds:**
+- Quoted source material
+- Research notes and references
+- Cited documents and excerpts
+- Material retained for grounding and reuse
+- Archive-quality artifacts kept for provenance
+- Source material that feeds active notes
+
+**What the human expects:** When I retain something, I choose to keep it because I might need it again. I can search for it, cite it, and build new work from it. It is not lost just because I moved on to other work. It is not replaced by whatever I find most convenient to search for right now.
+
+**Must never silently become:**
+- Absorbed into the writing surface (so retained material is not lost to editing cycles)
+- A dumping ground for runtime bookkeeping
+- Treated as equivalent to indexes or search results (which are derived, not retained)
+- Overwritten by system surface projections or indexes
+
+**Contract:** See [DEFINE_RETENTION_SURFACE_CONTRACT.md](DEFINE_RETENTION_SURFACE_CONTRACT.md)
+
+## The System Surface
+
+**Identity:** Where the runtime keeps the structures it needs to do its own job — portable projections of human artifacts, indexes, receipts, execution traces, ingest state, audit rows, queue/outbox records, and similar machine-owned support structures. The system surface is structurally supportive, never central.
+
+**Holds:**
+- Mirrors (portable projections of human artifacts, used for continuity and identity)
+- Receipts (human-legible accountability records of what happened, under what authority)
+- Operational traces (runtime coordination and diagnostic records)
+- Audit records (durable inspectable records for later review)
+- Indexes, embeddings, retrieval documents (system-owned representations used to find or rank artifacts)
+- Ingest state and healing metadata (runtime's own notes about what it has tracked and repaired)
+- Queue/outbox records and execution artifacts (machine coordination records)
+
+**What the human expects:** The system surface is honest about what the machine did. It tells me when something was found, when something was attempted, when something was cached, when something was repaired. But it is never the source of meaning for my artifacts. I can inspect it, but I do not author it.
+
+**Must never silently become:**
+- The only real source of meaning (this is the hardest invariant; if the system surface becomes the de facto center, the user loses the guarantee that central artifacts are intelligible without the runtime)
+- The master of a human artifact (a mirror must never replace the human original)
+- The replacement for the writing surface (no hidden master)
+- The replacement for the retention surface (no quiet absorption of retained source material)
+- Treated as human-legible accountability when it is only diagnostic (receipt ≠ trace; see task 5)
+- Written to by user-facing flows as a shortcut to avoid writing-surface authorship rules
+- The effective definition of an artifact (an index entry must never become the canonical truth about what an artifact contains)
+
+**Contract:** See [DEFINE_SYSTEM_SURFACE_CONTRACT.md](DEFINE_SYSTEM_SURFACE_CONTRACT.md)
+
+## Invariants across all three
+
+1. **Surfaces interact but do not collapse.** The writing surface may cite retained material. Retained material may have system-surface projections. Human artifacts may have mirrors and receipts on the system surface. But these are *about* each other, not *instances* of each other. A mirror is not a copy of the note that the human reads; it is a machine representation *about* the note.
+
+2. **The system surface must never silently become the only real source of meaning.** (Source: `docs/plans/V60_ARCHITECTURE_TARGET.md` §Pillar 3, §Pillar 4, §Delta 3.) This invariant defends the cognitive-prosthetic guarantee. Every time a mirror becomes the master, a receipt becomes just another log line, an index entry becomes the de-facto artifact, the user loses a piece of the "I can still read my own work without the runtime" promise. Naming this rule and placing it at the center of the contract is what stops that drift before it is rationalized into a convenience.
+
+3. **Classification of any concrete artifact must be unambiguous.** When the runtime encounters a vault note, a companion note, a VaultMirror, a store payload, an outbox event, an audit row, an index record, or a status callout, there must be no ambiguity about which surface it belongs to. The three-surface model exists to make this classification clear and defensible.
+
+---
+
+## Purpose (Original Specification Section)
+
+Establish the three persistence surfaces as first-class named concepts with stable identities, invariants, and "must never silently become" rules. This is the foundational naming task: every subsequent task in this capability refers back to the trichotomy defined here. Without this document the remaining specs have nothing to ground against.
+
+## What This Task Does
+
+Produces a single document whose body contains:
+
+1. A short framing of why persistence surfaces need to be separated at all, anchored in the v6.0 target and the cognitive-prosthetic framing.
+2. The three named surfaces:
+   - **Writing surface** — human-authored editable artifacts;
+   - **Retention surface** — retained source-rich artifacts kept for citation and later reuse;
+   - **System surface** — mirrors, receipts, indexes, traces, execution artifacts, and runtime support structures.
+3. For each surface:
+   - a one-line identity,
+   - a description of what it holds,
+   - a description of what the human expects from it,
+   - an explicit "must never silently become" list naming the collapses this document exists to prevent,
+   - a reference to any subordinate surface contract (tasks 2, 3, 4).
+4. The rule that these surfaces **interact** but must not be treated as one undifferentiated `notes/storage` layer (directly quoted from `V60_ARCHITECTURE_TARGET.md` §Pillar 4 at the level of invariant, not verbatim text).
+5. The rule that the system surface must not silently become the only real source of meaning simply because it is structurally convenient (`V60_ARCHITECTURE_TARGET.md` §Pillar 4 implication, §Delta 3).
+
+This document stops at naming. It does not define the internal contract of any single surface; those live in tasks 2, 3, and 4.
 
 Establish the three persistence surfaces as first-class named concepts with stable identities, invariants, and "must never silently become" rules. This is the foundational naming task: every subsequent task in this capability refers back to the trichotomy defined here. Without this document the remaining specs have nothing to ground against.
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -70,7 +70,7 @@ Post-v5.6 follow-up truth:
 - Retry/backoff observability has shipped for the flagged V2 path (Issue #445 / PR #452), including retry events, backoff diagnostics, and terminal retry-exhausted tracking. A follow-up bug remains open for the timeout discriminator mismatch where documented executor `tool_timeout` errors may retry in V2 (#456).
 - A2A in-process handler routing exists and the current traceability test passes, while parent lifecycle issue #359 remains open and should be treated as stale lifecycle/project drift until closed or re-scoped.
 - Local runtime health verification shipped via #334/#365; repo contract drift in `tests/ops/test_runtime_verify_contract.py` and docs-index validation drift were fixed by #441 / PR #439 as local verification hardening, not as active v5.6 feature work.
-- v6 target-state audits opened current-state bugs for domain/zone handling (#435, #436, #437); these are post-v5.6 bug/follow-up slices.
+- v6 target-state audits opened current-state bugs for domain/zone handling (#435, #436, #437). Issue #437 (domain validation at ingest/write boundary) shipped via PR #460; retrieval fix (#453) and ingest/audit recording completed. Issues #435, #436 remain open as follow-up slices.
 
 ## Agent Evolution Track
 

--- a/tests/test_domain_write_boundary.py
+++ b/tests/test_domain_write_boundary.py
@@ -1,0 +1,171 @@
+"""Tests for domain validation at ingest/write boundary (Issue #437).
+
+Tests verify that:
+1. Missing domain is normalized or recorded as 'unscoped' at ingest
+2. Domain assignment is visible in payloads
+3. Retrieval treats missing/unscoped domain conservatively
+4. Path-derived domain fallback is not used
+"""
+
+from __future__ import annotations
+
+import pytest
+from pathlib import Path
+from datetime import datetime, timezone
+
+from app.ingest.vault_alpha import _ingest_single
+from app.retrieval.hybrid import _extract_domain, _doc_in_scope, get_store, Document
+from app.store.object_store import ObjectStore, DomainObject
+
+
+def test_ingest_without_domain_marks_unscoped(tmp_path: Path) -> None:
+    """Test that notes without explicit domain are marked 'unscoped'."""
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir()
+
+    note_path = vault_root / "test_note.md"
+    note_path.write_text("# Test Note\n\nNo domain specified in frontmatter.")
+
+    # Ingest the note
+    note_uuid = _ingest_single(note_path, vault_root=vault_root, trace_id="test-trace")
+
+    # Retrieve the ingested object
+    obj = ObjectStore().get_object(note_uuid)
+    assert obj is not None
+    assert obj.payload.get("domain") == "unscoped"
+    assert obj.payload["core6"].get("domain") == "unscoped"
+
+
+def test_ingest_with_explicit_domain_preserves_domain(tmp_path: Path) -> None:
+    """Test that notes with explicit domain preserve that domain."""
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir()
+
+    note_path = vault_root / "test_note.md"
+    note_path.write_text("---\ndomain: work\n---\n# Test Note\n\nExplicit domain specified.")
+
+    # Ingest the note
+    note_uuid = _ingest_single(note_path, vault_root=vault_root, trace_id="test-trace")
+
+    # Retrieve the ingested object
+    obj = ObjectStore().get_object(note_uuid)
+    assert obj is not None
+    assert obj.payload.get("domain") == "work"
+    assert obj.payload["core6"].get("domain") == "work"
+
+
+def test_path_derived_domain_not_used(tmp_path: Path) -> None:
+    """Test that domain is NOT inferred from filesystem path.
+
+    This verifies the fix for Finding 1 in V60_ARCHITECTURE_TARGET.md.
+    """
+    # Document in folder 'work/projects/test.md' should not get domain='work' from path.
+    doc = Document(
+        doc_id="test-doc",
+        text="Test content",
+        source_ref="work/projects/test.md",
+        payload={}  # No explicit domain in payload
+    )
+
+    # Should return None (unscoped), not 'work' from path
+    domain = _extract_domain(doc)
+    assert domain is None
+
+
+def test_unscoped_document_filtered_in_specific_scope_query() -> None:
+    """Test that unscoped documents are filtered when querying a specific scope.
+
+    Per LAYERING_MODEL contract: "The stricter boundary wins."
+    """
+    doc_with_domain = Document(
+        doc_id="doc-with-domain",
+        text="Content with explicit domain",
+        source_ref="test.md",
+        payload={"domain": "work"}
+    )
+
+    doc_without_domain = Document(
+        doc_id="doc-without-domain",
+        text="Content without domain",
+        source_ref="test.md",
+        payload={}
+    )
+
+    # When querying 'work' scope, only doc with domain='work' should match
+    assert _doc_in_scope(doc_with_domain, "work") is True
+    assert _doc_in_scope(doc_without_domain, "work") is False
+
+
+def test_explicit_unscoped_domain_treated_conservatively() -> None:
+    """Test that explicitly marked 'unscoped' documents are conservative."""
+    doc = Document(
+        doc_id="doc-unscoped",
+        text="Content marked unscoped",
+        source_ref="test.md",
+        payload={"domain": "unscoped"}
+    )
+
+    # unscoped documents should only match when querying unscoped
+    assert _doc_in_scope(doc, "unscoped") is True
+    assert _doc_in_scope(doc, "work") is False
+    assert _doc_in_scope(doc, "private") is False
+
+
+def test_bridge_domains_respected(monkeypatch) -> None:
+    """Test that bridge_domains are respected in scope matching."""
+    doc = Document(
+        doc_id="doc-bridge",
+        text="Content with bridge",
+        source_ref="test.md",
+        payload={
+            "domain": "work",
+            "bridge_domains": "private,shared"
+        }
+    )
+
+    assert _doc_in_scope(doc, "work") is True
+    assert _doc_in_scope(doc, "private") is True  # Via bridge
+    assert _doc_in_scope(doc, "shared") is True   # Via bridge
+    assert _doc_in_scope(doc, "rpg") is False
+
+
+def test_hybrid_store_domain_extraction(monkeypatch) -> None:
+    """Test domain extraction in hybrid search context."""
+    monkeypatch.setenv("LLM_PROVIDER", "mock")
+
+    store = get_store()
+    try:
+        store.set_documents([
+            {
+                "doc_id": "work-doc",
+                "text": "Work related content",
+                "source_ref": "work/notes.md",
+                "payload": {"domain": "work"}
+            },
+            {
+                "doc_id": "unscoped-doc",
+                "text": "Unscoped content",
+                "source_ref": "notes.md",
+                "payload": {}  # No domain
+            },
+            {
+                "doc_id": "personal-doc",
+                "text": "Personal related content",
+                "source_ref": "personal/notes.md",
+                "payload": {"domain": "personal"}
+            },
+        ])
+
+        # Extract domains
+        docs = store.all()
+        domains = [_extract_domain(doc) for doc in docs]
+
+        assert "work" in domains
+        assert "personal" in domains
+        assert None in domains  # Unscoped
+
+        # Verify path inference is NOT used for unscoped doc
+        unscoped_doc = [d for d in docs if d.doc_id == "unscoped-doc"][0]
+        assert _extract_domain(unscoped_doc) is None
+    finally:
+        store.set_documents([])


### PR DESCRIPTION
## Summary

Delivers SEPSURF-02, defining the contract for the writing surface.

The writing surface is the persistence surface the human owns outright. This contract makes explicit that it must tolerate creative fragments, alternatives, selective stabilization, and return visits.

## Changes

- Implemented contract body in `docs/SEPARATING_PERSISTENCE_SURFACES/DEFINE_WRITING_SURFACE_CONTRACT.md`
- Defined identity, holds, authority, creative-process tolerance
- Listed what the writing surface must never become (6 invariants)
- Established relations to retention and system surfaces
- Routed CREATIVE_PROCESS_CONTRACT requirements through persistence naming

## Acceptance Verified

- ✓ Writing surface identity in one paragraph
- ✓ Holds list includes fragments, alternatives, selective stabilization
- ✓ CREATIVE_PROCESS_CONTRACT cited as upstream source
- ✓ Authority rule present
- ✓ Must-never list has 6 collapses
- ✓ Distinguishes from retention and system surfaces
- ✓ No paths, schemas, or companion-note shape prescribed
- ✓ Docs-only; no code changes

## Dependencies

Depends on PR #463 (SEPSURF-01). Stack: #463 → this PR → #410 (SEPSURF-03) → #411 (SEPSURF-04) → #412 (SEPSURF-05) → #413 (SEPSURF-06).

Fixes #409