### PR TITLE
fix: normalize whitespace-only domain values to 'unscoped' at ingest boundary

### DIFF
--- a/app/ingest/vault_alpha.py
+++ b/app/ingest/vault_alpha.py
@@ -402,7 +402,7 @@ def _ingest_single(path: Path, *, vault_root: Path, trace_id: str, raw_text: str
     title = _frontmatter_title(frontmatter) or _derive_title(body, path)
     review_state = str(frontmatter.get("review_state") or "provisional")
     maturity = str(frontmatter.get("maturity") or "note")
-    domain = str(frontmatter.get("domain") or "unscoped")
+    domain = str(frontmatter.get("domain") or "").strip() or "unscoped"
     stripped_body = strip_ai_panels(body)
     stripped_text = stripped_body.strip()
     ingest_fingerprint = _compute_ingest_fingerprint(stripped_text, path)

--- a/tests/test_domain_write_boundary.py
+++ b/tests/test_domain_write_boundary.py
@@ -36,6 +36,22 @@ def test_ingest_without_domain_marks_unscoped(tmp_path: Path) -> None:
     assert obj.payload["core6"].get("domain") == "unscoped"
 
 
+def test_ingest_with_whitespace_only_domain_normalizes_to_unscoped(tmp_path: Path) -> None:
+    """Whitespace-only domain values must normalize to 'unscoped' at ingest boundary (Issue #466)."""
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir()
+
+    note_path = vault_root / "test_note.md"
+    note_path.write_text("---\ndomain: \"   \"\n---\n# Test Note\n\nWhitespace domain.")
+
+    note_uuid = _ingest_single(note_path, vault_root=vault_root, trace_id="test-trace")
+
+    obj = ObjectStore().get_object(note_uuid)
+    assert obj is not None
+    assert obj.payload.get("domain") == "unscoped"
+    assert obj.payload["core6"].get("domain") == "unscoped"
+
+
 def test_ingest_with_explicit_domain_preserves_domain(tmp_path: Path) -> None:
     """Test that notes with explicit domain preserve that domain."""
     vault_root = tmp_path / "vault"


### PR DESCRIPTION
Fixes #466

## Summary
Whitespace-only `domain` frontmatter values (e.g. `"   "`) were truthy and bypassed the `or "unscoped"` fallback, leaving those documents silently un-queryable. The fix strips the value before falling back so any whitespace-only value is treated as absent.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.12 -m pytest tests/test_domain_write_boundary.py -v -m "not pg"` — 8/8 passed, including new `test_ingest_with_whitespace_only_domain_normalizes_to_unscoped`.

---