### PR TITLE
skill(maintenance): enforce lifecycle truth matrix and pre-flight audit

### DIFF
--- a/.codex/skills/issue-maintenance-change-control/SKILL.md
+++ b/.codex/skills/issue-maintenance-change-control/SKILL.md
@@ -273,7 +273,10 @@ Use this when the user asks for a maintenance run across everything not done.
                content {
                  __typename
                  ... on Issue { number state }
-                 ... on PullRequest { number state isDraft mergedAt }
+                 ... on PullRequest {
+                   number state isDraft mergedAt
+                   reviewRequests { totalCount }
+                 }
                }
                fieldValues(first: 20) {
                  nodes {
@@ -383,6 +386,8 @@ Use this when the user asks for a maintenance run across everything not done.
     - Every closed Issue is in `Status=Done`
     - Every merged / closed PR is in `Status=Done`
     - Every open Draft PR is in `Status=In Progress`
+    - Every open non-Draft PR with review explicitly requested is in `Status=Review`
+    - Every open non-Draft PR without review requested is in `Status=In Progress`
     - Zero Project items are in `NO_STATUS`
     If any drift remains, the run is not complete — fix before writing the receipt.
 

--- a/.codex/skills/issue-maintenance-change-control/SKILL.md
+++ b/.codex/skills/issue-maintenance-change-control/SKILL.md
@@ -51,15 +51,35 @@ You operate between:
 - Open backlog work should be present in the Project.
 - Open implementation Issues should normally carry exactly one truthful agent-state label.
 - Active implementation work should not remain `Ready`.
-- Draft PRs and open PRs without explicit review handoff should normally remain `In Progress`.
-- `Review` starts only when the PR is the explicit review handoff artifact, normally after review is requested.
-- Delivered and merged work should normally be `Done`.
-- Closed terminal PRs should not remain blank in the Project; they should reconcile to `Done`.
 - If Project state disagrees with Issue state, PR state, or merged delivery reality, correct the Project projection to match the harder lifecycle truth.
-- `agent:ready` should only pair with `Status=Ready`.
-- `agent:blocked` and `agent:needs-human` should pair with non-active work, normally `Backlog`.
 - Closed Issues must not retain `agent:ready`, `agent:blocked`, or `agent:needs-human`.
 - If repo reality satisfies the Issue, the Issue and Project state should reflect that.
+
+### Lifecycle truth matrix
+
+Project Status must match content state. Every other cell is drift and must be corrected. This matrix is the source of truth for all Project reconciliation — it covers both Issues and PRs.
+
+| Content | Content state | Required Project Status |
+|---------|---------------|-------------------------|
+| Issue | CLOSED | `Done` |
+| Issue | OPEN + `agent:ready` | `Ready` |
+| Issue | OPEN + `agent:blocked` | `Backlog` |
+| Issue | OPEN + `agent:needs-human` | `Backlog` |
+| PR | MERGED | `Done` |
+| PR | CLOSED (unmerged) | `Done` |
+| PR | OPEN + Draft | `In Progress` |
+| PR | OPEN + review requested | `Review` |
+| PR | OPEN + no review requested | `In Progress` |
+| Any | Present but no Project entry | Add to Project, apply row above |
+
+### Drift patterns that must be flagged explicitly
+
+These are the high-frequency drift patterns that are easy to miss. A maintenance run is not complete until all have been audited:
+
+- **Merged/closed PRs stuck in `Review` or `In Progress`** — stale handoff state on terminal work. "Terminal status on terminal work" is as common as blank PR cards and must be checked alongside them.
+- **Closed Issues stuck in `Review` or `In Progress`** — the Issue is Done; non-terminal status on closed Issues is drift, not a pending handoff.
+- **Open `agent:ready` Issues not in `Ready`** — the queue is lying about what is pickable. The `agent:ready ↔ Status=Ready` binding is a post-condition, not just a declarative rule.
+- **PRs with no Project Status (blank / not in Project)** — the board cannot reflect lifecycle if the PR isn't represented at all. Open and closed PRs both need Project entries.
 
 ## Change-control checklist (Core Runtime <-> Agentic Lab)
 
@@ -76,14 +96,15 @@ If any of the above is ambiguous, do not code. Keep the Issue `agent:needs-human
 
 ## Checks to perform
 
-1. Compare Issue `Scope`, `Source Anchors`, `Acceptance Criteria`, and `Source Docs` to current docs.
-2. Compare the Issue to open, merged, and closed PRs and repo reality.
-3. Check whether the Issue is too large, stale, partially shipped, or blocked.
-4. Check whether labels and Project state still match reality.
-5. Check whether owner-doc writeback and roadmap/plan cleanup exist for delivered work.
-6. For feature-breakdown issue waves, distinguish parent feature issues from child slice issues before changing labels.
-7. If a child issue delegates its contract to a `Source contract` spec file instead of carrying the standard issue sections, verify whether the spec is already merged and reachable; if the spec is not merged/reachable and the issue body lacks the required local contract sections, do not mark it `agent:ready`.
-8. Check acceptance verifiability: every `Acceptance Criterion` must carry a `Verify:` marker naming a test (behavioral) or a concrete doc/receipt target (non-behavioral). ACs without a resolvable `Verify:` target are a malformed contract shape.
+1. **Project-state audit:** bucket every Project item by (`content.state`, `Status`) and list every cell that violates the lifecycle truth matrix. This is the authoritative drift set for the run; nothing below may proceed on the assumption the board is clean until this audit is produced.
+2. Compare Issue `Scope`, `Source Anchors`, `Acceptance Criteria`, and `Source Docs` to current docs.
+3. Compare the Issue to open, merged, and closed PRs and repo reality.
+4. Check whether the Issue is too large, stale, partially shipped, or blocked.
+5. Check whether labels and Project state still match reality (driven by check 1's drift set).
+6. Check whether owner-doc writeback and roadmap/plan cleanup exist for delivered work.
+7. For feature-breakdown issue waves, distinguish parent feature issues from child slice issues before changing labels.
+8. If a child issue delegates its contract to a `Source contract` spec file instead of carrying the standard issue sections, verify whether the spec is already merged and reachable; if the spec is not merged/reachable and the issue body lacks the required local contract sections, do not mark it `agent:ready`.
+9. Check acceptance verifiability: every `Acceptance Criterion` must carry a `Verify:` marker naming a test (behavioral) or a concrete doc/receipt target (non-behavioral). ACs without a resolvable `Verify:` target are a malformed contract shape.
 
 ## Allowed corrective actions
 
@@ -238,10 +259,45 @@ Use this when the user asks for a maintenance run across everything not done.
 1. Resolve repo:
    - If repo not given, ask for `owner/repo`.
    - If user says they are the owner, resolve the username via GitHub app `list_installed_accounts` and use that as owner.
-2. List open issues:
+2. **Pre-flight Project-state audit.** Before any label edits or helper scripts, query every Project item and bucket it by (`content.state`, `Status`). Flag every cell that violates the lifecycle truth matrix. This audit is independent of any reconciliation helper and must be executed directly via GraphQL:
+
+   ```bash
+   gh api graphql -f projectId="$PROJECT_ID" -f query='
+     query($projectId:ID!, $cursor:String) {
+       node(id: $projectId) {
+         ... on ProjectV2 {
+           items(first: 100, after: $cursor) {
+             pageInfo { hasNextPage endCursor }
+             nodes {
+               id
+               content {
+                 __typename
+                 ... on Issue { number state }
+                 ... on PullRequest { number state isDraft mergedAt }
+               }
+               fieldValues(first: 20) {
+                 nodes {
+                   __typename
+                   ... on ProjectV2ItemFieldSingleSelectValue {
+                     field { ... on ProjectV2SingleSelectField { name } }
+                     name
+                   }
+                 }
+               }
+             }
+           }
+         }
+       }
+     }
+   '
+   ```
+
+   Paginate until `hasNextPage` is false. Then bucket items by `(state, status)` and list every cell that is not allowed by the matrix. The resulting list is the authoritative drift set for this run — nothing else may claim the board is clean until every entry in this set has been corrected.
+
+3. List open issues:
    - Prefer GitHub app for structured data when possible.
    - For bulk edits, use `gh issue list --state open --json number,title,labels,body,comments` for full bodies and blocker context.
-3. For each open issue:
+4. For each open issue:
    - Establish issue/PR truth before deciding labels:
      - inspect recent comments for acceptance failures, blocker receipts, and follow-up issue links
      - inspect linked open PRs and closing references
@@ -280,7 +336,7 @@ Use this when the user asks for a maintenance run across everything not done.
        -f query='mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!) { updateProjectV2ItemFieldValue(input:{projectId:$projectId itemId:$itemId fieldId:$fieldId value:{singleSelectOptionId:$optionId}}) { projectV2Item { id } } }'
      ```
      - If the issue is missing from the Project or missing `Status`, add/reconcile it during the same run
-4. **Execute Deduplication:**
+5. **Execute Deduplication:**
    - If duplicate issues have the same scope/contract:
      ```bash
      gh issue comment #<DUPLICATE> --body "Duplicate of #<CANONICAL>. Closing in favor of canonical issue."
@@ -291,21 +347,43 @@ Use this when the user asks for a maintenance run across everything not done.
      gh issue edit #<DUPLICATE> --remove-label agent:ready --remove-label agent:blocked --remove-label agent:needs-human
      ```
 
-5. **Execute PR Project state reconciliation** for terminal PR cards:
-   - List merged/closed PRs with missing or non-terminal Project Status:
+6. **Reconcile terminal work stuck in non-terminal status** (expanded from "blank PR cards"):
+   - The pre-flight audit (step 2) should have surfaced these, but enumerate them explicitly here to prevent silent skips.
+   - Terminal work is: merged PRs, closed PRs (unmerged), closed Issues.
+   - Any of the above sitting in `In Progress`, `Review`, `Backlog`, `Ready`, or with no Status is drift.
+   - Set each to `Done`:
      ```bash
-     gh pr list --state closed --json number,title,mergedAt,projectItems
-     ```
-   - For each merged/closed PR, set Project Status to Done:
-     ```bash
-     gh api graphql -f projectId="$PROJECT_ID" -f itemId="$PR_ITEM_ID" \
+     gh api graphql -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
        -f fieldId="$STATUS_FIELD_ID" -f optionId="$DONE_OPTION_ID" \
        -f query='mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!) { updateProjectV2ItemFieldValue(input:{projectId:$projectId itemId:$itemId fieldId:$fieldId value:{singleSelectOptionId:$optionId}}) { projectV2Item { id } } }'
      ```
-6. Prefer the repo's reconciliation helper when present (for example `scripts/reconcile_project_status.py`) instead of ad hoc Project mutations.
-7. If Project v2 writes fail because of GraphQL rate limits or credentials, stop Project mutation attempts for that run:
+   - Do not limit this step to "blank" cards. Stale `In Progress` / `Review` on merged or closed items is as common as missing status and is equally drift.
+
+7. **Reconcile open PR Project status** against the lifecycle truth matrix:
+   - Open Draft PRs → `In Progress`
+   - Open non-Draft PRs with review explicitly requested → `Review`
+   - Open non-Draft PRs without review requested → `In Progress`
+   - Open PRs missing from the Project entirely → add them, then apply the row above
+
+8. **Reconciliation helper (optional, with known gaps).** If the repo has a reconciliation helper (for example `scripts/reconcile_project_status.py`), run it after steps 2, 6, and 7 as a belt-and-braces pass — not as the primary mechanism. Known gaps in common helpers:
+   - They typically reconcile Issue-label → Status drift only
+   - They may not reconcile PR lifecycle state (merged/closed/draft)
+   - They may not correct non-terminal Status on terminal work (e.g. merged PR in `Review`)
+   - Do not treat a helper's "N change(s)" output as complete. If the pre-flight audit in step 2 counted more drift than the helper reported, the helper did not close the gap and manual mutations are required.
+
+9. If Project v2 writes fail because of GraphQL rate limits or credentials, stop Project mutation attempts for that run:
    - do not retry with ad hoc partial mutations
    - output the exact pending status changes that were not applied
    - output the rate-limit reset time when available
    - state that Issue/PR truth remains authoritative until Project reconciliation can resume
-8. Output a receipt listing edited issues, label changes, issue status changes, and any PR cards moved to `Done`.
+
+10. **Post-condition verification.** After all corrections, re-run the step 2 audit query and verify zero drift cells remain. Specifically check:
+    - Every `agent:ready` open Issue is in `Status=Ready`
+    - Every `agent:blocked` / `agent:needs-human` open Issue is in `Status=Backlog`
+    - Every closed Issue is in `Status=Done`
+    - Every merged / closed PR is in `Status=Done`
+    - Every open Draft PR is in `Status=In Progress`
+    - Zero Project items are in `NO_STATUS`
+    If any drift remains, the run is not complete — fix before writing the receipt.
+
+11. Output a receipt listing edited issues, label changes, issue status changes, PR status changes, and the before/after drift counts from step 2 and step 10.


### PR DESCRIPTION
- [x] Governance lane

## Summary

- Today's maintenance run left 14 items in the wrong Project column because `scripts/reconcile_project_status.py --scan` reports only Issue-label drift — merged PRs sat stale in `Review`/`In Progress` and 7 merged PRs had no Project status at all.
- The existing `issue-maintenance-change-control` skill trusted the helper's "2 change(s)" output as complete, so the Kanban silently drifted.
- This PR updates the skill so a maintenance run (a) audits the whole board up front, (b) enforces an explicit lifecycle truth matrix for Issues **and** PRs, (c) treats the helper as optional with documented gaps, and (d) post-condition-verifies every correction.

## What changed in the skill

- **Lifecycle truth matrix** replaces the scattered lifecycle bullets. Covers every `(content type, state)` → required `Status` pair. Cells outside the matrix are drift.
- **Pre-flight Project-state audit (Fast run step 2)**: GraphQL query that paginates every Project item and buckets by `(state, Status)` before any label edits. Produces the authoritative drift set. Query now includes `reviewRequests { totalCount }` on PRs so open non-draft PRs can be classified correctly.
- **"Terminal work stuck in non-terminal status"** replaces the old "terminal PR cards" check. Now covers closed Issues in `In Progress`/`Review`, not just blank PR cards.
- **Open PR Project status reconciliation** becomes its own explicit step: Draft → `In Progress`, review requested → `Review`.
- **Helper-gap callout**: the skill now names what `reconcile_project_status.py` does *not* cover (PR lifecycle, non-Backlog→Done drift) so the agent won't treat its output as complete.
- **Post-condition verification (step 10)**: re-runs the audit after corrections and fails the receipt if any drift cell survives. Now covers all four open-PR matrix rows including non-draft PRs with/without review requested.

## Board corrections applied today

15 Project items reconciled alongside the skill update:

| Moved to `Done` (13) | Moved to `Ready` (1) | Moved to `In Progress` (1) |
|---|---|---|
| #436, #453, #454, #455, #457, #458, #459, #460, #461, #462, #464, #465, #467 | #466 | #470 |

Before: Backlog 17 / Done 212 / In Progress 3 / NO_STATUS 9 / Ready 7 / Review 3
After:  Backlog 17 / Done 225 / In Progress 1 / NO_STATUS 0 / Ready 8 / Review 0

## Test plan

- [ ] Run the skill's Fast maintenance run on a fresh state; confirm step 2's audit produces a drift set and step 10's verification reports zero drift after corrections
- [ ] Introduce a deliberate drift (e.g. move a merged PR card back to `Review`) and confirm the next run catches it where the previous skill did not
- [ ] Confirm `scripts/reconcile_project_status.py --scan` is treated as optional, not as the run's authority

🤖 Generated with [Claude Code](https://claude.com/claude-code)