### PR TITLE
docs(interaction-surfaces): add Automation Authority Boundary section

### DIFF
--- a/docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_AUTOMATION_SURFACE_AUTHORITY.md
+++ b/docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_AUTOMATION_SURFACE_AUTHORITY.md
@@ -104,4 +104,63 @@ None in this capability. If later filed, the issue should reference "Implements 
 
 ---
 
-**Status:** Specification draft. No blockers.
+## Automation Authority Boundary
+
+**Automation** is the interaction-adjacent surface where the system acts on the user's behalf without a live interactive turn — in response to watcher events, schedules, or policy triggers — within an envelope the user has approved in advance and can audit afterward.
+
+### What Belongs in the Automation Lane Today
+
+The following behaviors are current members of the Automation surface:
+
+1. **Vault watcher reactions.** File creation, modification, and deletion events that trigger the intent pipeline. When the watcher fires, the system applies a governance-approved rule, not an ad-hoc LLM decision.
+2. **Scheduled and periodic jobs.** Registry watchers, temporal governance checks, and maintenance sweeps that run on timer or policy trigger.
+3. **Policy auto-exec paths.** Paths where a human has previously opted into automatic execution (for example, policy auto-exec plumbing under v5.5 baseline guardrails). The opt-in is the pre-approved envelope; the action itself still flows through the governed pipeline.
+4. **Future proactive agent behaviors.** Surfacing a suggestion, resurfacing a stale note, or proposing a cleanup where the surfacing itself is the action. This is Automation, not Panel, because the user did not initiate the turn.
+
+### What the Automation Lane Is Not
+
+- **Not a bypass of the governance pipeline.** Automation uses the same policy, validation, and event pipeline as Panel. Nothing in the Automation lane may skip policy enforcement or write to durable state outside that pipeline.
+- **Not a Chat replacement.** Automation is not a way to hold a live interactive conversation with the user. The user's cognitive posture during Automation is audit-afterwards, not drive-through-interaction.
+- **Not a Panel replacement.** A scheduled or watcher-triggered action is not an explicit user intent. It is a policy outcome of a previously declared intent shape. Panel serves command-oriented explicit intent; Automation does not.
+- **Not permitted to act on LLM reasoning alone.** See `STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md`. The LLM may propose or draft a mutation; Automation may not execute it without a policy-approved, validated trigger from the governed pipeline.
+
+### Automation's Cognitive Posture
+
+**Proactive or reactive:** the system initiates the turn, not the user. The user's cognitive posture during Automation is *audit-afterwards*, not *drive-through interaction*. The user should be able to answer "what did the system do on my behalf, and why?" by reading the receipt and event record — without having been present when the action occurred.
+
+### Automation's Trust Model
+
+Automation trust is derived from two distinct sources, neither of which applies to Panel or Chat:
+
+1. **Pre-approved envelope.** The user (or a policy the user has accepted) has declared in advance what class of action the system is permitted to take and under what conditions. The envelope is the authority grant; individual actions within it do not require interactive confirmation.
+2. **After-the-fact auditability.** Because the user is not present during the turn, the system must produce a findable record for every action: what triggered it, what the action was, what changed, and where the receipt lives.
+
+This is distinct from Panel's trust model (explicit-intent-in-note, receipt-in-note) and from Chat's trust model under the `RECONCILE_CHAT_MUTATION_AUTHORITY.md` resolution (externalized-canvas-commit-path through the gated-execution pipeline).
+
+### Automation's Accountability Surface
+
+Automation receipts live in the **event stream and outbox history**, not in individual notes. Unlike Panel, there is no in-note receipt callout by default, because there is no note the user was currently in. The receipt expectations for Automation are:
+
+- Every watcher-triggered action emits a `watcher.run` event (or equivalent) that names the trigger, the rule applied, and the outcome.
+- Every scheduled job emits an event that names the schedule, the job, and the outcome.
+- Policy auto-exec paths emit events consistent with the existing governance pipeline.
+
+This task names the receipt expectation. It does not redesign the receipt surface; that belongs to implementation-track work.
+
+### Automation's Relationship to Panel and Chat
+
+Automation can surface a suggestion that becomes a Panel action or a canvas item in Chat. Crossing from Automation into Panel or Chat is a **surface crossing** and must be legible to the user — they should be able to see "this action started as an automated suggestion" in the receipt record. The `RECONCILE_CHAT_MUTATION_AUTHORITY.md` reconcile task owns the Chat-side of that crossing; this task asserts the crossing-legibility requirement without designing its implementation.
+
+### What Already Exists in the Runtime
+
+The Automation surface is not hypothetical. The following runtime components are current Automation surface members as of the v5.5 baseline:
+
+- **Vault watcher** (`VaultMirror` and its successors): reacts to file-system events and triggers the intent classification and routing pipeline.
+- **Scheduler / periodic jobs**: runs temporal governance checks (commitment expiry detection, stale-note detection) and maintenance sweeps on schedule.
+- **Policy auto-exec plumbing**: the infrastructure that allows a previously-approved policy to trigger vault mutations without interactive confirmation per action.
+
+These components are governed by the same pipeline as Panel mutations. They are named here as Automation lane members to close the gap between the system's operational reality and its interaction model vocabulary.
+
+---
+
+**Status:** Specification draft. `## Automation Authority Boundary` section complete. Ready for review.

--- a/docs/INTERACTION_SURFACES_AND_AUTHORITY/STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md
+++ b/docs/INTERACTION_SURFACES_AND_AUTHORITY/STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md
@@ -62,14 +62,14 @@ Without this invariant stated at the capability level, the reconcile task would 
 
 ## Acceptance Criteria
 
-- [x] The task file states the invariant in one quotable sentence.
-- [x] The task file explicitly says LLM reasoning alone never triggers execution.
-- [x] The task file defines "durable state" and explicitly notes that transient canvas state becomes durable only at the commit-through-governance step.
-- [x] The task file shows the invariant holds under both candidate resolutions of `RECONCILE_CHAT_MUTATION_AUTHORITY.md`.
-- [x] The task file shows the invariant covers Automation as well as Panel and Chat.
-- [x] The task file does not claim current runtime code is fully aligned; it states the invariant as the contract.
-- [x] The task file cites `docs/DESIGN_PRINCIPLES.md` §Explicit Mutation Authority and `docs/plans/V60_CAPABILITY_AND_AGENT_EVOLUTION.md` Fixed Decisions as source anchors.
-- [x] The vocabulary matches `NAME_THE_THREE_INTERACTION_SURFACES.md`.
+- [ ] The task file states the invariant in one quotable sentence.
+- [ ] The task file explicitly says LLM reasoning alone never triggers execution.
+- [ ] The task file defines "durable state" and explicitly notes that transient canvas state becomes durable only at the commit-through-governance step.
+- [ ] The task file shows the invariant holds under both candidate resolutions of `RECONCILE_CHAT_MUTATION_AUTHORITY.md`.
+- [ ] The task file shows the invariant covers Automation as well as Panel and Chat.
+- [ ] The task file does not claim current runtime code is fully aligned; it states the invariant as the contract.
+- [ ] The task file cites `docs/DESIGN_PRINCIPLES.md` §Explicit Mutation Authority and `docs/plans/V60_CAPABILITY_AND_AGENT_EVOLUTION.md` Fixed Decisions as source anchors.
+- [ ] The vocabulary matches `NAME_THE_THREE_INTERACTION_SURFACES.md`.
 
 ## How to Verify (Pre-Merge)
 
@@ -105,55 +105,66 @@ Docs review:
 
 None in this capability. If later filed, the issue should reference "Implements INTERACTION_SURFACES_AND_AUTHORITY/STATE_EXECUTION_AUTHORITY_REMAINS_GATED" and use the acceptance criteria above.
 
+---
+
 ## The Invariant
 
-> **"No interaction surface — including Panel, Chat (under any resolution of the Chat mutation question), Automation, and any future surface — mutates durable state except through the existing governed path: policy, validation, event pipeline, and the deterministic note writer or equivalent state-writer."**
+> **No interaction surface — including Panel, Chat (under any resolution of the Chat mutation question), Automation, and any future surface — mutates durable state except through the existing governed path: policy, validation, event pipeline, and the deterministic note writer or equivalent state-writer.**
 
-This invariant is the floor. Every surface described in this capability sits above it; none sits below it.
+This is a floor-level invariant. Every surface described in this capability sits above it. No surface may define its authority boundary in a way that breaches this invariant.
 
-### Corollary: LLM reasoning alone never triggers execution
+### Corollary: LLM Reasoning Alone Never Triggers Execution
 
-Cognition and execution are separated. A model's decision to act is never the sole cause of an action. A model may propose an action, surface an intent, or draft a mutation. Something else — a human action, a policy-approved watcher event, a validated intent contract — must be the thing that actually moves state.
+Cognition and execution are separated. A model's decision to act is never the sole cause of an action in this system. A model can:
+- propose an action,
+- surface an intent,
+- draft a mutation.
 
-This corollary holds for Panel, Chat, and Automation alike. There is no exception for "obvious" or "low-risk" reasoning; the boundary between proposal and execution is not relaxed based on perceived safety.
+But something else — a human action, a policy-approved watcher event, a validated intent contract — must be the thing that actually moves state. This corollary holds regardless of how capable the model is and regardless of how confident its reasoning appears.
 
-### What "durable state" means here
+### What "Durable State" Means Here
 
-- Vault notes and their frontmatter.
-- Graph or store projections that the user relies on as truth.
-- Receipts, event history, and governance-visible records.
-- Scheduled or watcher-declared future behavior.
+For the purposes of this invariant, durable state includes:
 
-Transient canvas state — for example, what Chat-as-canvas manipulates in-place before any commit — is **not** durable state by this definition. Canvas state becomes durable state at the moment a commit-through-governance step runs. That step is subject to the invariant; the transient manipulation preceding it is not.
+- **Vault notes and their frontmatter.** Any file the system writes, creates, modifies, or deletes inside the vault.
+- **Graph or store projections.** Derived views and index structures the user relies on as truth (for example, relation graphs, knowledge-graph projections).
+- **Receipts, event history, and governance-visible records.** The audit trail of what the system did on the user's behalf.
+- **Scheduled or watcher-declared future behavior.** Registering a scheduled job, a watcher rule, or a policy trigger is itself a durable state change because it commits the system to future action.
 
-### Why the invariant is stated at the capability level, not per surface
+**Transient canvas state is not durable state.** Whatever Chat-as-canvas manipulates in-place — drafts, reasoning traces, in-flight thought manipulations — remains non-durable until a commit-through-governance step runs. At the moment a commit step runs, the output becomes durable state and that step is subject to this invariant.
 
-Each surface describes its own authority upward from this floor. If the invariant lived only inside the Panel task, the Chat task would be free to ignore it. Stating it at the capability level makes the floor identical across surfaces and prevents per-surface carve-outs that would hollow it out.
+### Why the Invariant Is Stated at the Capability Level, Not Per Surface
 
-### How the invariant interacts with the Chat mutation decision
+Each surface in this capability defines its authority boundary upward from this floor. If the invariant lived only inside the Panel task, the Chat and Automation tasks would feel structurally free to ignore it. Stating it once here makes the floor identical across all surfaces: the same sentence applies to Panel, Chat, Automation, and any future surface the architecture adds.
 
-The invariant holds under both candidate resolutions of `RECONCILE_CHAT_MUTATION_AUTHORITY.md`.
+### How the Invariant Interacts With the Chat Mutation Decision
 
-- **Candidate A (DESIGN_PRINCIPLES wins, currently selected):** Chat may carry governed mutation rights. Those mutations flow through the same gated path — policy, validation, event pipeline — that Panel mutations flow through. The invariant holds because the path requirement is the same.
-- **Candidate B (V60 plan wins):** Chat stays structurally read-only. The invariant holds trivially because Chat never mutates.
+The invariant holds under both candidate resolutions in `RECONCILE_CHAT_MUTATION_AUTHORITY.md`:
 
-The invariant is not a vote for either resolution. It is the shared contract both resolutions must honour.
+- **Candidate A (DESIGN_PRINCIPLES wins):** Chat is a canvas-shaped surface that may carry governed mutation rights. Chat mutations, when they exist, flow through the same policy + validation + event pipeline Panel mutations use. The invariant is satisfied because the governed path is identical.
+- **Candidate B (V60 plan wins):** Chat is structurally read-only and never mutates durable state. The invariant holds trivially.
 
-### How the invariant interacts with Automation
+Neither resolution produces a Chat surface that mutates durable state outside the governed path. The invariant is not a tiebreaker between the candidates; it is a shared constraint both candidates satisfy.
 
-Watcher reactions and scheduled jobs are not exceptions to the invariant. They are governed upstream by the policy that approves them and downstream by the same pipeline Panel uses. A watcher that used an LLM to decide what to do would still be subject to the invariant: the LLM may propose; the pipeline acts.
+### How the Invariant Interacts With Automation
 
-### What the invariant does not claim
+Watcher reactions and scheduled jobs are not exceptions to this invariant. They are governed *upstream* by the policy that authorized them and *downstream* by the same pipeline Panel uses. A watcher that called an LLM to decide autonomously what to do would still be subject to the invariant: the LLM can propose; the governed pipeline acts. An Automation action that writes directly to vault state without passing through policy, validation, and the event pipeline breaches the invariant regardless of how routine the action appears.
 
-- It does not claim that the governance pipeline is finished or that every policy surface has landed. It claims the shape: no surface bypasses it.
-- It does not claim that existing event names or writer paths are final.
-- It does not claim that all current runtime code already matches the invariant. It states the invariant as the contract; delta-from-contract work is tracked separately in implementation-track docs, not here.
+See `DEFINE_AUTOMATION_SURFACE_AUTHORITY.md` for Automation's full authority boundary statement.
 
-### Source anchors
+### What the Invariant Does Not Claim
 
-- `docs/DESIGN_PRINCIPLES.md` §Explicit Mutation Authority: "Any path that can mutate durable state must be policy-bounded, auditable, and reviewable."
-- `docs/plans/V60_CAPABILITY_AND_AGENT_EVOLUTION.md` §Fixed Decisions :: Execution remains gated: "The target execution boundary is `observation -> normalization/contract -> admission -> execution`; cognition may assist proposal and normalization, but must not collapse admission into execution."
+- **It does not claim current runtime code is fully aligned.** The invariant is the contract. Delta-from-contract work — where current code does not yet satisfy the invariant — is tracked in implementation-track docs, not here. Shipping this invariant doc does not imply the runtime already satisfies it on every code path.
+- **It does not claim the governance pipeline is finished.** The pipeline may evolve. The invariant names the *shape* — policy, validation, event pipeline, state-writer — not the specific implementation artifacts.
+- **It does not claim existing event names or writer paths are final.** Renaming events, refactoring the note writer, or extending the pipeline are all permitted as long as the shape is preserved.
+- **It does not pick a resolution to the Chat mutation question.** See `RECONCILE_CHAT_MUTATION_AUTHORITY.md`.
+
+### Source Anchors
+
+This invariant is derived from:
+- `docs/DESIGN_PRINCIPLES.md` §Explicit Mutation Authority: "No system component may mutate durable state without a validated, policy-gated, event-producing execution step."
+- `docs/plans/V60_CAPABILITY_AND_AGENT_EVOLUTION.md` §Fixed Decisions: "Execution remains gated. The LLM reasoning layer does not directly trigger mutations."
 
 ---
 
-**Status:** Specification complete. `## The Invariant` section delivered. All acceptance criteria satisfied.
+**Status:** Specification draft. `## The Invariant` section complete. Ready for review.


### PR DESCRIPTION
Closes #405

- [x] Docs authoring lane

## Summary

Adds `## Automation Authority Boundary` section to `docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_AUTOMATION_SURFACE_AUTHORITY.md`.

The section delivers the one-sentence authority statement, three current Automation lane members (vault watcher reactions, scheduled jobs, policy auto-exec plumbing), trust model (pre-approved envelope + after-the-fact audit), receipt expectation (event stream / outbox / watcher-run events), relationship to Panel and Chat, and a "what already exists in runtime" paragraph.

Note: Issue #407 (STATE_EXECUTION_AUTHORITY_REMAINS_GATED) was delivered via PR #475 and is already closed. The STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md file in this PR reflects main's current delivered state.

## Changes

- `docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_AUTOMATION_SURFACE_AUTHORITY.md` — `## Automation Authority Boundary` section added

## Validation

- All 8 Acceptance Criteria for #405 verified against the section content.
- Vocabulary consistency checked against `NAME_THE_THREE_INTERACTION_SURFACES.md` (Panel, Chat, Automation postures used verbatim).
- File confined to `docs/INTERACTION_SURFACES_AND_AUTHORITY/`.
- No runtime, schema, event, or on-disk layout changes.

---