### PR TITLE
docs: normalize version framing to v6 active design direction

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-State: SoT v5.5 Reality-MVP baseline locked (watcher safety, panel action provenance, and concurrency hardening) with the v5.6 delivery line closed and post-v5.6 follow-ups tracked separately for LangGraph/Reasoning expansion, Orchestrator V2 hardening, A2A/MCP lifecycle cleanup, and local verification hardening.
+State: SoT v5.5 Reality-MVP baseline locked (watcher safety, panel action provenance, and concurrency hardening); v5.6 delivery line closed; v6 is the active design and planning direction. Post-v5.6 follow-ups are tracked separately for LangGraph/Reasoning expansion, Orchestrator V2 hardening, A2A/MCP lifecycle cleanup, and local verification hardening.
 Doc role: Core SoT
 Authority: Active runtime architecture source of truth for the current baseline and runtime contracts; wins over roadmap and historical references on current-state questions.
 Owner: Runtime / architecture SoT
@@ -7,7 +7,7 @@ Review cadence: event-driven
 Source of truth: mixed
 Last reviewed: 2026-04-16
 Last verified against: docs/ENVIRONMENTS.md, docs/STATUS.md, docs/PANEL_AGENT.md, docs/EVENTS.md, docs/OBSERVABILITY.md, docs/ROADMAP.md, docs/contracts/A2A_CONTRACT_AND_TRACE.md, docs/contracts/TOOL_POLICY_AND_MCP_ADAPTER_CONTRACT.md, docs/contracts/TIMEOUT_AND_SLA_CONTRACT.md, docs/INTERACTION_SURFACES_AND_AUTHORITY/README.md, docs/INTERACTION_SURFACES_AND_AUTHORITY/RECONCILE_CHAT_MUTATION_AUTHORITY.md, docs/FINDING_AND_REORIENTING/README.md, docs/FINDING_AND_REORIENTING/DOCUMENT_SALIENCE_AS_DERIVED.md, docs/COMMITMENT_AS_FIRST_CLASS/README.md, app/cli/__init__.py, app/orchestrator/runtime.py, app/orchestrator/v2_runtime.py, app/orchestrator/executor.py, app/watcher/registry.py, app/workers/outbox_worker.py, Makefile, merged PRs #272/#302/#346/#349/#365/#376/#377/#382/#383/#386/#389/#391/#423/#424/#425/#426/#427/#431/#439/#448/#450/#452, current repo state at e226878 on 2026-04-16, backlog issues #435/#436/#437/#456, stale lifecycle issue #359, and closed Orchestrator follow-up issues #444/#445/#446
-# Architecture — SoT v5.5 Reality-MVP baseline (v5.6 delivered)
+# Architecture — SoT v5.5 Reality-MVP baseline (v5.6 delivered, v6 active design)
 
 This document is the active architecture source of truth for the SoT v5.5 Reality-MVP baseline and the place where current runtime contracts are defined.
 

--- a/docs/CONCEPTS/COMPANION_NOTE_CONTRACT.md
+++ b/docs/CONCEPTS/COMPANION_NOTE_CONTRACT.md
@@ -1,4 +1,4 @@
-State: SoT v5.x forward line (v5.6 companion note contract)
+State: Delivered (v5.6 companion note contract); stable invariant for v6 design
 Doc role: Core SoT
 Authority: Canonical definition of the companion note as a first-class system artifact for continuity, identity repair, and bounded system-side tracking of vault notes.
 

--- a/docs/DOCS_INDEX.md
+++ b/docs/DOCS_INDEX.md
@@ -1,7 +1,7 @@
-State: SoT v5.5 Reality-MVP baseline locked (watcher safety, panel action provenance, and concurrency guardrails); v5.6 delivery line closed with post-v5.6 follow-ups tracked separately for LangGraph/Reasoning expansion, Orchestrator V2 hardening, A2A/MCP lifecycle cleanup, and local verification hardening while referencing `docs/STATUS.md#baseline-definition`.
+State: SoT v5.5 Reality-MVP baseline locked (watcher safety, panel action provenance, and concurrency guardrails); v5.6 delivery line closed; v6 is the active design and planning direction. Post-v5.6 follow-ups are tracked separately; see `docs/STATUS.md#version-framing-consistency-note` for the authoritative framing map.
 Doc role: Core SoT
 Authority: Canonical map of document roles and review status for the current repo; use it to determine whether a document is Core SoT, Reference, Plan, or Historical.
-# Documentation Review Index — SoT v5.5 baseline + v5.x delivery line
+# Documentation Review Index — SoT v5.5 baseline + v6 active planning
 
 Central map of active and archived documentation artifacts in this repo. Use this index before treating any document as decision input.
 
@@ -70,7 +70,8 @@ The 2026 docs cleanup work is archived under `docs/archive/docs-refactor/`. The 
 ## SoT Notes
 - v4.10 — locked Reality-MVP baseline (foundation only).
 - v5.0 — PanelAgent Runtime V1 baseline on top of v4.10.
-- v5.x — **SoT delivery line** (v5.5 locked baseline plus delivered v5.6 enablement) for guarded automation, PanelAgent planner/runtime evolution, A2A/MCP contracts, Orchestrator/Reasoning 2.0 pilots, and local verification; unresolved work is post-v5.6 follow-up unless an owner issue reclassifies it.
+- v5.x — **SoT delivery line** (v5.5 locked baseline plus delivered v5.6 enablement); v5.6 is closed. Unresolved work is post-v5.6 follow-up unless an owner issue reclassifies it.
+- v6 — **active design and planning direction**; target operating model under active design but not yet runtime baseline. Governing docs: `docs/ROADMAP.md`, `docs/plans/V60_ARCHITECTURE_TARGET.md`, `docs/plans/V60_CAPABILITY_AND_AGENT_EVOLUTION.md`. See `docs/STATUS.md#version-framing-consistency-note` for the authoritative framing map.
 
 ## Root and Repo Docs
 - `docs/EMBEDDINGS.md` — Normative embeddings spec (identity, guardrails, rebuild policy).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,4 +1,4 @@
-State: Locked baseline SoT v5.5 (Reality-MVP + watchers/panel policy) with the v5.6 delivery line closed and post-v5.6 follow-ups tracked separately for LangGraph/Reasoning expansion, Orchestrator V2 hardening, A2A/MCP lifecycle cleanup, and local verification hardening.
+State: SoT v5.5 baseline locked (Reality-MVP + watchers/panel policy); v5.6 delivery line closed; v6 is the active design and planning direction. Post-v5.6 follow-ups are tracked separately for LangGraph/Reasoning expansion, Orchestrator V2 hardening, A2A/MCP lifecycle cleanup, and local verification hardening.
 Doc role: Plan
 Authority: Strategic sequencing and forward-looking delivery/follow-up framing; owner/current-state docs win on shipped reality and present-tense behavior.
 Owner: Product / architecture forward line
@@ -57,7 +57,7 @@ This roadmap is forward-looking and skimmable. History lives in `docs/history/SO
   - PanelAgent 2.0 expansion beyond the current slices remains bounded even after real-vault acceptance; break new behavior into smaller tracked slices first.
   - Reasoning/reflective layers with eval gates; expanded observability counters for orchestration/A2A.
   - Collaboration/multi-user after single-user flows are stable.
-  - `v6.0` architecture target: a baseline-aware target operating model that preserves the
+  - `v6.0` architecture target (**active design direction** — see `Capability-Based Architecture & Agent Evolution` above): a baseline-aware target operating model that preserves the
     vault-first / registry-watcher / DB-outbox / companion-note continuity baseline while making
     the next operating boundary explicit: `observation -> normalization/contract -> admission -> execution`.
     - Make the ontology/runtime bridge explicit so human loops, ontology classes, and runtime contracts can be read together without pretending they are the same layer.
@@ -222,9 +222,9 @@ Explicit rule: "LLM reasoning must never directly trigger execution."
 | v5.0 | PanelAgent Runtime V1 | Shipped |
 | v5.1–v5.4 | Watcher track (ingest/panel CLI, policy, ergonomics) | Operationally accepted |
 | v5.5A/B | Panel planner pipeline + CLI-first orchestration/promotion consumer | Shipped |
-| v5.5C/D | Panel LangGraph decider + watcher auto-exec; watcher→planner/orchestrator automation | Planned/In progress |
+| v5.5C/D | Panel LangGraph decider + watcher auto-exec; watcher→planner/orchestrator automation | Shipped |
 | v5.6 | Engine-neutral cognition seam (PA2-ENGINE-SEAM, shipped), freeform catalog-discovery (shipped), suggested checkbox writeback for uncertain/no-checkbox panel proposals (shipped), multi-step plans (shipped, PR #302), real-vault acceptance (accepted on Alpha vault for #240), Companion note/doc-sync cleanup, shared ReasoningFacade + LangGraph rollout, Orchestrator V2 (flagged), Vault-as-GUI settings compiler, A2A in-process routing, iCloud transport chain validated + `.git.nosync` fix shipped (#421), low-risk autonomy + sync validation parent #355 closed | Closed delivery line; remaining statistical sync/infra hardening, A2A lifecycle/project cleanup, and timeout discriminator bug #456 are post-v5.6 follow-ups; local runtime/docs validation drift was fixed by #441 / PR #439 |
-| v6.0 | Baseline-aware target operating model that preserves the current vault-first/runtime-queue/continuity baseline while aligning operating boundaries with human/context/artifact semantics, ontology/runtime bridge, commitment-first modeling, retrieval vs orientation vs resurfacing separation, and clearer surface/authority contracts; target described in `docs/plans/V60_ARCHITECTURE_TARGET.md` | Proposed target state |
+| v6.0 | Baseline-aware target operating model that preserves the current vault-first/runtime-queue/continuity baseline while aligning operating boundaries with human/context/artifact semantics, ontology/runtime bridge, commitment-first modeling, retrieval vs orientation vs resurfacing separation, and clearer surface/authority contracts; target described in `docs/plans/V60_ARCHITECTURE_TARGET.md` | Active design/planning direction |
 
 ## Tracks (details moved)
 - Watcher track details: `docs/tracks/TRACK_WATCHER.md`

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,4 +1,4 @@
-State: SoT v5.5 Reality-MVP baseline locked (watcher auto-run gate, panel action provenance, and concurrency guard) with the v5.6 delivery line closed and post-v5.6 follow-ups tracked separately for LangGraph/Reasoning expansion, Orchestrator V2 hardening, A2A/MCP lifecycle cleanup, and local verification hardening.
+State: SoT v5.5 Reality-MVP baseline locked (watcher auto-run gate, panel action provenance, and concurrency guard); v5.6 delivery line closed; v6 is the active design and planning direction. Post-v5.6 follow-ups are tracked separately for LangGraph/Reasoning expansion, Orchestrator V2 hardening, A2A/MCP lifecycle cleanup, and local verification hardening.
 Doc role: Core SoT
 Authority: Current operational snapshot for the active baseline; subordinate to concept contracts for normative semantics, but authoritative for current runtime status and rollout posture.
 Owner: Runtime / current-state SoT
@@ -30,6 +30,16 @@ Validation posture note:
 - blocking smoke/release gates are anchored to the active baseline in this document
 - broader human-need acceptance scenarios may exist in the repo as non-blocking system-level TDD derived from `docs/HUMAN-FLOWS.md`
 - failures in those broader scenarios indicate target-state gaps unless and until this status document promotes the capability into the claimed baseline
+
+## Version framing consistency note
+
+| Version framing | Role | Authoritative doc |
+| --- | --- | --- |
+| v5.5 (SoT baseline locked) | Current operational runtime; no new feature scope | `docs/ARCHITECTURE.md`, `docs/STATUS.md` |
+| v5.6 (delivered/closed) | Historical delivery line; read as shipped invariants | `docs/ROADMAP.md#closed-v56-delivery-line`, `docs/STATUS.md#v56-closure` |
+| v6 (active design/planning direction) | Target operating model under active design; not yet baseline | `docs/ROADMAP.md`, `docs/plans/V60_ARCHITECTURE_TARGET.md`, `docs/plans/V60_CAPABILITY_AND_AGENT_EVOLUTION.md` |
+
+Use `docs/ARCHITECTURE.md` for current-state runtime questions. Use `docs/ROADMAP.md` and the v6 plans for target-state design direction questions. Do not read v5.5 as an active work queue; new implementation work is sliced against v6 target-state docs.
 
 ## Baseline Definition (SoT v5.5)
 - Environment posture: `dev`, `test`, and `prod` are now the explicit minimal environment model in the SoT. The governing contract lives in `docs/ENVIRONMENTS.md`. `dev` and `prod` are runtime-selected environments today; `test` is the current workflow-driven bootstrap and verification environment.


### PR DESCRIPTION
Fixes #449

## Summary
Normalizes all version references across governing docs so the repo consistently reflects: v5.5 = locked operational baseline, v5.6 = delivered/closed, v6 = active design and planning direction.

## Changes
- `docs/STATUS.md`: Updated State banner; added **Version framing consistency note** table mapping each version to its role and authoritative doc
- `docs/ARCHITECTURE.md`: Updated State banner and doc title
- `docs/ROADMAP.md`: Updated State banner; fixed v5.5C/D row ("Planned/In progress" → "Shipped"); fixed v6.0 row ("Proposed target state" → "Active design/planning direction"); annotated v6.0 in Now/Next/Later as active design direction
- `docs/DOCS_INDEX.md`: Updated State banner, title ("v5.x delivery line" → "v6 active planning"), and SoT Notes to add explicit v6 entry
- `docs/CONCEPTS/COMPANION_NOTE_CONTRACT.md`: Updated State banner to "Delivered (v5.6 companion note contract); stable invariant for v6 design"

## Validation
- All five file State banners verified to consistently carry v6 framing
- Version ladder spot-checked: v5.5C/D = Shipped, v6.0 = Active design/planning direction
- No contradictory version claims remain across STATUS / ARCHITECTURE / ROADMAP

---