### PR TITLE
docs(FINDING_AND_REORIENTING): satisfy ASK deprecation framing doc ACs (#401)

### DIFF
--- a/docs/FINDING_AND_REORIENTING/DEPRECATE_ASK_AS_ARCHITECTURAL_CENTER.md
+++ b/docs/FINDING_AND_REORIENTING/DEPRECATE_ASK_AS_ARCHITECTURAL_CENTER.md
@@ -28,6 +28,16 @@ This task produces the ASK-deprecation framing document inside `docs/FINDING_AND
 
 ## Concretely
 
+The binding decision this document acts on is the Fixed Decision recorded in `docs/plans/V60_CAPABILITY_AND_AGENT_EVOLUTION.md`:
+
+> **ASK is deprecated as an architectural center**
+>
+> - ASK may remain a valid runtime/API surface in the v5.x line.
+> - ASK should not remain the conceptual center for retrieval, reasoning, or future cognition.
+> - New design work should not extend a special central-agent framing around ASK.
+
+This document states that deprecation in full — conceptual only — and maps what it means in practice.
+
 What ASK stops being (conceptual deprecation):
 
 - ASK stops being the place new retrieval work is attached to.
@@ -40,7 +50,7 @@ What ASK remains (non-deprecation):
 
 - ASK remains a working v5.x runtime and API surface.
 - Existing callers of ASK keep working.
-- `app/agents/ask/*` continues to exist and behave as it does today.
+- `app/agents/ask/*`, `app/api/routes/ask.py`, and all related runtime files are not modified by this spec or by any task in this directory. They continue to exist and behave as they do today.
 - Finding 2 remains ASK's bug and is owned by the v5.x enablement lane, not by this spec.
 
 What replaces ASK at the conceptual center:


### PR DESCRIPTION
Fixes #401

- [x] Docs authoring lane

## Summary

Satisfies all acceptance criteria for the ASK-deprecation framing document (`DEPRECATE_ASK_AS_ARCHITECTURAL_CENTER.md`). The spec file serves as the framing document — two content gaps required patching:

- **AC1**: Added inline blockquote of the Fixed Decision from `docs/plans/V60_CAPABILITY_AND_AGENT_EVOLUTION.md` directly in the "Concretely" section so a skimmer sees the authoritative decision without leaving the document.
- **AC4**: Strengthened the non-modification bullet to name both `app/agents/ask/*` and `app/api/routes/ask.py` explicitly and state they are not modified by this spec or by any task in this directory.

All other ACs (AC2, AC3, AC5, AC6, AC7, AC8, AC9) were already satisfied by existing document content.

## Validation

- Grepped document: no proposed edits to `app/agents/ask/*` or `app/api/routes/ask.py` present.
- Panel/Chat appear only in deferral paragraph pointing at `INTERACTION_SURFACES_AND_AUTHORITY`.
- Three-responsibility mapping (retrieval, orientation, resurfacing) each points to correct sibling contract file.
- Fixed Decision quote is verbatim from source doc.
- No `.py` files modified.

---