### PR TITLE
docs(tracks): close A2A routing parent feature #359 — promote #362 to delivered

### DIFF
--- a/docs/tracks/TRACK_AGENTOPS_A2A_MCP.md
+++ b/docs/tracks/TRACK_AGENTOPS_A2A_MCP.md
@@ -1,11 +1,11 @@
-State: A2A handler-registry routing and response/error receipts delivered (issues #360, #361); multi-agent chain traceability (#362) and MCP orchestration still planned.
+State: Orchestrator-managed A2A routing fully delivered — handler-registry routing (#360), response/error receipts (#361), multi-agent chain traceability (#362). Parent feature #359 closed. MCP orchestration still planned.
 # Track — AgentOps, A2A, MCP
 
 Scope: outer agent coordination, event/A2A contracts, tool/MCP boundaries, and observability/ops hardening.
 
 ## Architecture hardening themes
 - Event schema discipline: naming/versioning/idempotency/trace_id; DLQ/retry thinking captured in `docs/research/pattern-harvest-agentic-architecture.md`.
-- A2A contracts: current-state envelope schema and emitted audit actions are documented in `docs/contracts/A2A_CONTRACT_AND_TRACE.md`; handler-registry routing and response/error receipts are delivered in issues #360 and #361. Full capability spec: `docs/ORCHESTRATOR_A2A_ROUTING/README.md`. Parent feature: #359. Tracked by: #233, #360, #361. Source Anchor: A2A-ROUTING
+- A2A contracts: current-state envelope schema and emitted audit actions are documented in `docs/contracts/A2A_CONTRACT_AND_TRACE.md`; handler-registry routing (#360), response/error receipts (#361), and multi-step chain traceability (#362) are all delivered. Full capability spec: `docs/ORCHESTRATOR_A2A_ROUTING/README.md`. Parent feature: #359 (closed). Tracked by: #233, #360, #361, #362. Source Anchor: A2A-ROUTING
 - Tool boundary: MCP descriptor registry with allowed_args + mock_result; deterministic adapters; permission/timeouts documented in `docs/contracts/TOOL_POLICY_AND_MCP_ADAPTER_CONTRACT.md`. Tracked by: #234. Source Anchor: MCP-TOOL-BOUNDARY
 - Observability & agent-ops: audit events/metrics/runbooks for panel/watcher/orchestrator; CLI is tooling (not UI). Current incident workflow now lives in `docs/runbooks/RUNBOOK_AGENTOPS_INCIDENT_TRIAGE.md`. Tracked by: #235. Source Anchor: AGENTOPS-OBSERVABILITY
 - Config validation: vault-first, schema-validated wiring for panel actions/watcher policies.
@@ -15,11 +15,12 @@ Scope: outer agent coordination, event/A2A contracts, tool/MCP boundaries, and o
 - MCP descriptor registry with mocks; Plan/PlanStep schema (v4.9) shared by planner backends.
 - Pattern harvest doc with backlog and Mermaid stack view: `docs/research/pattern-harvest-agentic-architecture.md`.
 
-## Delivered routing
+## Delivered routing (complete)
 - Orchestrator-managed in-process A2A routing via handler registry (`MockPlanExecutor`). Supported recipients route through registered handlers with audit/trace; unsupported recipients fail the step clearly with `not_implemented`. Issue #360. Spec: `docs/ORCHESTRATOR_A2A_ROUTING/ROUTE_AGENT_CALLS_THROUGH_REGISTERED_HANDLERS.md`.
+- Complete routed receipt set: response and error events emitted for all handler dispatch paths. Issue #361, PR #377.
+- Multi-step chain traceability proven across V1 and V2 orchestrator surfaces. Issue #362, PR #383.
 
 ## Planned
-- Orchestrator-managed A2A routing — remaining capability: multi-agent chain traceability (#362). Specification: `docs/ORCHESTRATOR_A2A_ROUTING/README.md`.
 - MCP ToolProvider integration for LangGraph executor; richer tool coverage under strict descriptors.
 
 ## Links


### PR DESCRIPTION
## Summary

- Updates `TRACK_AGENTOPS_A2A_MCP.md` state header and routing section to reflect all three A2A routing slices delivered
- Moves #362 (chain traceability) from Planned → Delivered routing
- Marks parent feature #359 as closed in the source anchor line
- Removes stale Planned entry for multi-agent chain traceability

## Validation

All 33 A2A/orchestrator tests pass locally:
- `tests/orchestrator/test_agent_config_enforcement.py` + `test_orchestrator_a2a_errors.py` + `test_orchestrator_runs_steps.py` — 10 passed
- `tests/a2a/test_events.py` + `test_orchestrator_runs_steps.py` + `test_pipeline_executes_plan.py` + `tests/orchestration/v2/test_orchestrator_integration.py` — 16 passed
- `tests/orchestrator/test_multi_step_chain_traceability.py` — 7 passed

## Closes

Closes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)