### PR TITLE
docs(v6): tighten finding and reorienting wording before unblocking #396-399

### DIFF
--- a/docs/FINDING_AND_REORIENTING/DEFINE_ORIENTATION_CAPABILITY_CONTRACT.md
+++ b/docs/FINDING_AND_REORIENTING/DEFINE_ORIENTATION_CAPABILITY_CONTRACT.md
@@ -15,6 +15,8 @@ can_parallelize_with: [DEFINE_RETRIEVAL_CAPABILITY_CONTRACT, DEFINE_RESURFACING_
 
 Let the user come back to work and rediscover what mattered without doing the remembering themselves. When the user is lost — after interruption, a context switch, or time passing — there is not yet a question in their head. There is a missing situational frame. Orientation is the cognitive prosthetic that rebuilds that frame and leads the human back to where they were and what mattered when they left. This task writes the orientation contract.
 
+Orientation is repo working language closest to task resumption, context reconstruction, and situation-awareness recovery; it is not generic Q&A and not merely retrieving artifacts.
+
 ## What This Task Does
 
 This task produces the orientation capability contract as a docs artifact inside `docs/FINDING_AND_REORIENTING/`. It:
@@ -37,7 +39,7 @@ The contract the document establishes:
   - what mattered (the open commitments or active threads at that point),
   - what is still open (unresolved loops that had not closed before the leave),
   - and what has changed (anything relevant that moved while the user was away).
-- **Explanation shape:** orientation explains itself as "you were here, this mattered, and this is different now." Situation-anchored, not request-anchored and not surfacing-decision-anchored.
+- **Explanation shape:** orientation explains itself as "when you left, you were here; these threads were active; these remain open; this changed while you were away." Situation-anchored, not request-anchored and not surfacing-decision-anchored.
 - **Does not do:** orientation does not require or wait for a query, does not reduce its output to a ranked artifact list, does not silently promote items into attention for the user (that is resurfacing), and does not write any durable situational field anywhere.
 
 Boundary with retrieval:
@@ -67,7 +69,7 @@ If orientation is not specified:
 - [ ] The contract lists the signals orientation draws on as situational and derived, not as stored fields.
 - [ ] The contract states that the primary output is a situational frame, not a ranked artifact list.
 - [ ] The situational frame is specified as answering at minimum four things: where the user was, what mattered, what is still open, what has changed.
-- [ ] The contract specifies the orientation explanation shape ("you were here, this mattered, this is different now") and confirms it differs structurally from the retrieval and resurfacing explanation shapes.
+- [ ] The contract specifies the orientation explanation shape ("when you left, you were here; these threads were active; these remain open; this changed while you were away") and confirms it differs structurally from the retrieval and resurfacing explanation shapes.
 - [ ] The contract states that orientation may compose retrieval as a subordinate mechanism without inheriting retrieval's contract.
 - [ ] The contract explicitly states that orientation does not write any durable situational field.
 - [ ] The contract cites Pillar 7, Pillar 7A, and Delta 7 of `docs/plans/V60_ARCHITECTURE_TARGET.md`.

--- a/docs/FINDING_AND_REORIENTING/DEFINE_RESURFACING_CAPABILITY_CONTRACT.md
+++ b/docs/FINDING_AND_REORIENTING/DEFINE_RESURFACING_CAPABILITY_CONTRACT.md
@@ -15,6 +15,8 @@ can_parallelize_with: [DEFINE_RETRIEVAL_CAPABILITY_CONTRACT, DEFINE_ORIENTATION_
 
 Let the user come back to work and rediscover what mattered without doing the remembering themselves. The third prosthetic — the one the user is least likely to ask for, and the one the system must do without being asked — is resurfacing. Resurfacing brings something back into view because open-loop pressure, temporal drift, relational change, or renewed context has made it quietly matter again. This task writes the resurfacing contract and pins down the distinction that keeps being lost: resurfacing is not ranking, and resurfacing is not retrieval-with-a-timer.
 
+Resurfacing is repo working language for unprompted return-to-attention support, adjacent to prospective-memory reminders, opportunistic reminding, and information encountering.
+
 ## What This Task Does
 
 This task produces the resurfacing capability contract as a docs artifact inside `docs/FINDING_AND_REORIENTING/`. It:
@@ -32,14 +34,15 @@ This task produces the resurfacing capability contract as a docs artifact inside
 The contract the document establishes:
 
 - **Trigger:** a change in attentional relevance that the system notices on behalf of the user. The user has not asked, is not resuming work, and has not posed a query. The system notices that something once parked has become relevant again.
-- **Consumes (conceptually):** derived salience signals as specified by `docs/CONCEPTS/SALIENCE_AND_ATTENTIONAL_RELEVANCE_CONTRACT.md` — open-loop pressure, temporal drift or staleness, relational change, renewed context, review cadence, and so on. All of these are situational and computed at decision time. None of them are stored on an artifact.
+- **Consumes (conceptually):** derived salience signals as specified by `docs/CONCEPTS/SALIENCE_AND_ATTENTIONAL_RELEVANCE_CONTRACT.md` — open-loop pressure, temporal drift or staleness, relational change, renewed context, review cadence, and so on. These signals are evaluated at decision time; any durable operational inputs must not be treated as salience stored on an artifact.
 - **Produces:** a surfacing decision — one item (or a small set) accompanied by a "why now" explanation and enough provenance that the user can answer "is this really relevant right now or is the system wrong about me." The output is a surfacing event, not a ranked list of hits.
-- **Explanation shape:** resurfacing explains itself as "this became relevant again because…" — relevance-change-anchored, pointing at the specific signal (a loop that reopened, a commitment whose deadline moved, a context that became active again, a related artifact that changed). The sentence is always anchored in a change, not in a query and not in a situational frame.
+- **Explanation shape:** resurfacing explains itself as "this is back in view now because…" — relevance-change-anchored, pointing at the specific signal (a loop that reopened, a commitment whose deadline moved, a context that became active again, a related artifact that changed). The sentence is always anchored in a change, not in a query and not in a situational frame.
 - **Does not do:** resurfacing does not fire in response to a user query (that is retrieval), does not fire because the user just came back to work (that is orientation), does not store its own decisions as durable fields, and does not collapse into "the top of a ranked list."
 
 Relationship to ranking:
 
 - Ranking is a mechanism. Given a candidate set and some signals, ranking orders them. Resurfacing is the decision that a surfacing event should happen at all. Ranking may be used as a subordinate mechanism inside a resurfacing pipeline, but a resurfacing decision is never reducible to "the top of a ranking."
+- Ranking orders candidates after a candidate set exists; resurfacing governs whether something should be brought into attention at all.
 - A higher-ranked retrieval hit is not a resurfacing event. If the user did not ask, ranking alone did nothing.
 
 Relationship to salience:
@@ -66,7 +69,7 @@ If resurfacing is not specified:
 - [ ] The contract states the trigger: a change in attentional relevance noticed without a user query or a user-initiated return to work.
 - [ ] The contract cites `docs/CONCEPTS/SALIENCE_AND_ATTENTIONAL_RELEVANCE_CONTRACT.md` and affirms that resurfacing consumes derived salience signals, does not own them, and does not store them.
 - [ ] The contract states that the output is a surfacing decision with a "why now" explanation, not a ranked list.
-- [ ] The contract specifies the resurfacing explanation shape as relevance-change-anchored and confirms it differs structurally from the retrieval and orientation explanation shapes.
+- [ ] The contract specifies the resurfacing explanation shape ("this is back in view now because…") as relevance-change-anchored and confirms it differs structurally from the retrieval and orientation explanation shapes.
 - [ ] The contract explicitly rejects two collapses: resurfacing-as-better-ranking and resurfacing-as-retrieval-with-a-timer.
 - [ ] The contract cites Finding 2 in `docs/plans/V60_ARCHITECTURE_TARGET.md` as the cautionary tale for storing attentional overlays, without attempting to fix Finding 2.
 - [ ] The contract does not propose any code change or any durable storage of salience or surfacing decisions.

--- a/docs/FINDING_AND_REORIENTING/DOCUMENT_SALIENCE_AS_DERIVED.md
+++ b/docs/FINDING_AND_REORIENTING/DOCUMENT_SALIENCE_AS_DERIVED.md
@@ -37,6 +37,8 @@ Salience is real in the user's model — they experience what is mentally near, 
 
 This rule exists because salience is situational and relational, not essential. What matters changes when context changes, when time passes, when relations shift, or when the human's open loops resolve. A stored salience field would capture a frozen moment and then slowly become obsolete, creating silent failures where the system appears to work but returns stale answers (see Finding 2, below).
 
+The prohibition is specifically against storing salience as the durable essence of an artifact. Durable operational fields such as review cadence, commitment state, due date, or last-reviewed timestamp may still exist as input signals, provided they are not treated as salience itself.
+
 ### Allowed Signal Families (Concept-Level Only)
 
 The three capabilities may derive salience signals from any of the following signal families. **This list is conceptual only; no weights, thresholds, or fusion rules are specified here.** Those decisions are implementation details downstream of this spec.
@@ -58,6 +60,7 @@ To enforce that salience stays derived, the following moves are forbidden. Any t
 - **No durable `salience` field on any artifact.** The runtime must not add a `salience` property to any artifact payload, frontmatter, or metadata, regardless of whether the field is set during ingest, promotion, or later.
 - **No durable `zone` field on any artifact,** regardless of what the current v5.x runtime does. The v5.x runtime reads `zone` from payloads that never had it written; this is the exact anti-pattern this spec forbids.
 - **No persistent "attentional state" on any artifact.** No capability in this directory may mark an artifact with an attentional overlay, hotness label, temperature, or any equivalent that claims to be a durable property of the artifact itself.
+- **No treating operational fields as salience itself.** Durable fields such as review cadence, commitment state, due date, or last-reviewed timestamp may inform a derived salience calculation, but they must not be renamed, read, or governed as durable attentional truth.
 - **No implication that ingest should set an attentional flag.** Ingest writes artifact identity, domain, and provenance. It must not attempt to set any salience-related property.
 - **No implication that a mirror, receipt, or projection should carry salience as stored truth.** Mirrors and receipts are structural aids for the runtime; they are not the place to store salience. Projections (such as ordered lists or ranked views) are ephemeral; they must not be promoted into artifact-level attentional state.
 
@@ -65,7 +68,7 @@ To enforce that salience stays derived, the following moves are forbidden. Any t
 
 **Retrieval:** Retrieval may consult any of the signal families above to influence ranking within a single query execution. For example, it may weight recent matches higher, or prefer artifacts with unresolved status. It must not read a stored salience field, and it must not write one. It must not assume that a high-ranking result is the same as a resurfacing decision; the two are distinct user needs.
 
-**Orientation:** Orientation builds a situational frame at request time, drawing on the signal families above to help the human regain context after an interruption. It must not persist the frame as a durable field on any artifact. It may cite the signals it used inside its explanation — e.g., "this came back to your attention because it has unresolved status" — so the human can see where the reorientation came from and decide whether the frame is still correct.
+**Orientation:** Orientation builds a situational frame at request time, drawing on the signal families above to help the human regain context after an interruption. It must not persist the frame as a durable field on any artifact. It may cite the signals it used inside its explanation — e.g., "this remains open because it has unresolved status" — so the human can see where the reorientation came from and decide whether the frame is still correct.
 
 **Resurfacing:** Resurfacing decides to bring an artifact back into view based on a change in derived relevance (a signal family above shifted in a way that matters). It must not cache the decision as a durable field on the artifact — no "attention marker," no "resurfaced on [date]" property. It may record that a resurfacing decision happened as a receipt or trace, but receipts and traces are structural records of what the system did, not the same as artifact-level attentional state.
 

--- a/docs/FINDING_AND_REORIENTING/NAME_THE_THREE_CAPABILITIES.md
+++ b/docs/FINDING_AND_REORIENTING/NAME_THE_THREE_CAPABILITIES.md
@@ -31,7 +31,7 @@ This task produces the canonical naming document for the three sub-capabilities 
 The canonical three-way naming the rest of this directory cites:
 
 - **Retrieval** answers the user verb "retrieve the right thing." The user has a concrete question, lookup, or operation in mind. A query or retrieval request exists. The system's job is to return the correct material with legible provenance.
-- **Orientation** answers the user verb "re-orient after interruption." The user has lost the thread. There is not yet a question in their head — there is a missing situational picture. The system's job is to walk the user back to where they were and what mattered when they left.
+- **Orientation** answers the user verb "re-orient after interruption." Orientation is situational reorientation after interruption: the user cannot yet formulate a query and needs the system to reconstruct where they were, what mattered, what remains open, and what changed.
 - **Resurfacing** answers the user verb "notice what is becoming relevant again." The user has no active query and is not asking to be led home. The system's job is to bring something back into view because open-loop pressure, temporal drift, relational change, or renewed context has made it quietly matter again.
 
 What each uniquely does that the other two cannot:

--- a/docs/FINDING_AND_REORIENTING/README.md
+++ b/docs/FINDING_AND_REORIENTING/README.md
@@ -49,7 +49,7 @@ The spec must hold these negatives as firmly as it holds the positives. Task wri
 
 - **Not generic question-answering.** ASK-as-center is explicitly deprecated in `docs/plans/V60_CAPABILITY_AND_AGENT_EVOLUTION.md` Fixed Decisions. This capability is not an ASK replacement; it is the reason ASK no longer needs to be the architectural center.
 - **Not a search box.** Retrieval is one of three functions, and none of them is a free-text search input. A search box is a UI affordance; this capability is a cognitive-prosthetic contract.
-- **Not a ranking algorithm.** Resurfacing is not "better ranking." Ranking is a mechanism detail downstream of a surfacing decision; the decision to surface at all is what resurfacing specifies.
+- **Not a ranking algorithm.** Resurfacing is not "better ranking." Ranking orders candidates after a candidate set exists; resurfacing governs whether something should be brought into attention at all.
 - **Not salience-as-stored-field.** Salience is derived, always, per `docs/CONCEPTS/SALIENCE_AND_ATTENTIONAL_RELEVANCE_CONTRACT.md`. No task in this directory may propose a durable `salience`, `zone`, or equivalent field on an artifact.
 - **Not an agent.** Per Pillar 7A and the Fixed Decisions, retrieval is a reusable capability, not an agent. Orientation and resurfacing follow the same rule: reusable capabilities, not new architectural agents.
 - **Not an interaction-surface authority decision.** Whether Panel, Chat, or another surface consumes these capabilities, and with what mutation rights, is out of scope. That question belongs to a separate `INTERACTION_SURFACES_AND_AUTHORITY` capability.
@@ -79,7 +79,7 @@ The capability FINDING_AND_REORIENTING is accepted when all of the following are
 - [ ] Salience is documented as derived in every place this capability references it, and no spec task proposes a durable salience field.
 - [ ] ASK's de-centering is framed in text, with a clear statement of what ASK stops being as an architectural center and what stays as a runtime/API compatibility concern.
 - [ ] A human returning to work after an interruption could read the three contracts and correctly articulate which of the three capabilities applies to their situation.
-- [ ] The system's future explanation of "why this was surfaced" differs correctly between the retrieval case, the orientation case, and the resurfacing case — i.e. each contract specifies its own explanation shape.
+- [ ] The system's future explanation differs correctly between the retrieval case ("this matched your request because…"), the orientation case ("when you left, you were here; these threads were active; these remain open; this changed while you were away"), and the resurfacing case ("this is back in view now because…").
 - [ ] All tasks in this directory are deliverable by editing `docs/` only; no task requires code, runtime, or schema change to be considered complete.
 - [ ] The boundary is internally consistent: no task contradicts another, and no task takes authority that belongs to `INTERACTION_SURFACES_AND_AUTHORITY`.
 


### PR DESCRIPTION
## Change Lane
- [ ] Implementation lane
- [x] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Fixes #

Required for implementation lane. Leave blank for docs authoring lane.

## Summary
- Tightens Orientation as situational reorientation after interruption, not generic Q&A or artifact retrieval.
- Tightens Resurfacing as unprompted return-to-attention support, distinct from ranking and retrieval.
- Clarifies that durable operational fields may be salience inputs without becoming stored salience.
- Makes retrieval/orientation/resurfacing explanation shapes more parallel.

## Implementation Scope Check
- [ ] Change stays within the linked Issue scope.
- [ ] Constraints from the linked Issue were followed.
- [ ] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [ ] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [x] This PR only changes approved docs-authoring surfaces.
- [x] No code, runtime behavior, contracts, or shipped reality changed.
- [x] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [ ] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [x] No product/runtime implementation or shipped feature behavior changed.

## Validation
Docs authoring lane:
- [x] `git diff --check`
- [x] PR checks inspected; initial `pr-contract` failure was missing lane classification, corrected here.

## Notes
- Docs-only refinement pass for the v6.0 FINDING_AND_REORIENTING specification lane.
- No runtime, code, schema, API, migration, or test changes.
- Intended to unblock #396-399 with small wording refinements rather than reframing the capability boundary.
