### PR TITLE
Add retrieval contract verification targets

### DIFF
--- a/docs/FINDING_AND_REORIENTING/DEFINE_RETRIEVAL_CAPABILITY_CONTRACT.md
+++ b/docs/FINDING_AND_REORIENTING/DEFINE_RETRIEVAL_CAPABILITY_CONTRACT.md
@@ -54,14 +54,23 @@ If retrieval stays overloaded:
 ## Acceptance Criteria
 
 - [ ] The contract defines retrieval as a reusable capability with no agent identity.
+  Verify: doc review of `docs/FINDING_AND_REORIENTING/DEFINE_RETRIEVAL_CAPABILITY_CONTRACT.md :: What This Task Does` and `:: Concretely`.
 - [ ] The contract states the trigger condition: a retrieval request exists.
+  Verify: `rg -n "Trigger:|retrieval request exists|does not fire without" docs/FINDING_AND_REORIENTING/DEFINE_RETRIEVAL_CAPABILITY_CONTRACT.md`.
 - [ ] The contract states what retrieval consumes in user-visible terms, drawing from scope, relations, and provenance per Pillar 6.
+  Verify: `rg -n "Consumes|scope|relations|provenance|Pillar 6" docs/FINDING_AND_REORIENTING/DEFINE_RETRIEVAL_CAPABILITY_CONTRACT.md`.
 - [ ] The contract states what retrieval produces: a bounded, explainable result set with provenance.
+  Verify: `rg -n "Produces|bounded|explainable|result set|provenance" docs/FINDING_AND_REORIENTING/DEFINE_RETRIEVAL_CAPABILITY_CONTRACT.md`.
 - [ ] The contract specifies the retrieval-specific explanation shape: request-anchored ("this matched your request because…").
+  Verify: `rg -n "Explanation shape|matched your request|request-anchored" docs/FINDING_AND_REORIENTING/DEFINE_RETRIEVAL_CAPABILITY_CONTRACT.md`.
 - [ ] The contract lists what retrieval does not do: rebuild situational context, fire without a query, decide surfacing, write durable salience.
+  Verify: `rg -n "Does not do|situational context|without a query|surfacing|durable salience" docs/FINDING_AND_REORIENTING/DEFINE_RETRIEVAL_CAPABILITY_CONTRACT.md`.
 - [ ] The contract explicitly cites Finding 2 as the cautionary tale for overloading retrieval with surfacing responsibility, without attempting to fix Finding 2.
+  Verify: `rg -n "Finding 2|cautionary|without attempting to fix|fixing Finding 2|Cite only" docs/FINDING_AND_REORIENTING/DEFINE_RETRIEVAL_CAPABILITY_CONTRACT.md`.
 - [ ] The contract does not propose any modification to `app/retrieval/*` or any other code file.
+  Verify: `git diff --name-only` contains only `docs/FINDING_AND_REORIENTING/DEFINE_RETRIEVAL_CAPABILITY_CONTRACT.md`, and doc review finds no runtime/schema/code instruction.
 - [ ] A reviewer can confirm the retrieval explanation shape differs structurally from the orientation and resurfacing explanation shapes in the sibling contracts.
+  Verify: doc review receipt in PR validation notes comparing `DEFINE_RETRIEVAL_CAPABILITY_CONTRACT.md`, `DEFINE_ORIENTATION_CAPABILITY_CONTRACT.md`, and `DEFINE_RESURFACING_CAPABILITY_CONTRACT.md`.
 
 ## How to Verify (Pre-Merge)
 


### PR DESCRIPTION
Fixes #397

## Summary
Adds explicit `Verify:` targets to the retrieval capability contract acceptance criteria so the docs artifact matches the executable issue contract.

This stays inside the docs-only #397 slice and does not change runtime retrieval, ASK, schema, API, event, or storage behavior.

## Validation
- `git diff --check`
- `rg -n "Trigger:|retrieval request exists|does not fire without|Consumes|scope|relations|provenance|Pillar 6|Produces|bounded|explainable|result set|Explanation shape|matched your request|request-anchored|Does not do|situational context|without a query|durable salience|Finding 2|cautionary|fix Finding 2" docs/FINDING_AND_REORIENTING/DEFINE_RETRIEVAL_CAPABILITY_CONTRACT.md`
- `git diff --name-only` contains only `docs/FINDING_AND_REORIENTING/DEFINE_RETRIEVAL_CAPABILITY_CONTRACT.md`
- Manual docs review: retrieval remains request-anchored and does not claim orientation or resurfacing responsibility.
- Manual sibling-contract review: retrieval explains `this matched your request because...`, orientation explains `when you left...`, and resurfacing explains `this is back in view now because...`.

## Notes
- Pre-implementation maintenance corrected #397's issue body into the required task-contract shape with explicit `Verify:` markers.
- Anchor drift: current `docs/plans/V60_ARCHITECTURE_TARGET.md` no longer exposes literal Pillar headings, but the source intent still resolves through current retrieval/orientation/resurfacing separation and retrieval migration passages.