### PR TITLE
Fix Project reconciliation item discovery

### DIFF
--- a/scripts/reconcile_project_status.py
+++ b/scripts/reconcile_project_status.py
@@ -17,6 +17,7 @@ from typing import Any
 
 GOVERNANCE_PATH = Path(".github/github-governance.yml")
 DEFAULT_PROJECT_NAME = "Agent Delivery Control Plane"
+PROJECT_ITEM_LIST_INITIAL_LIMIT = 200
 
 
 def run_gh(*args: str) -> str:
@@ -71,20 +72,31 @@ def get_status_field(owner: str, project_number: int) -> tuple[str, dict[str, st
 
 
 def list_project_items(owner: str, project_number: int) -> list[dict[str, Any]]:
-    payload = json.loads(
-        run_gh(
-            "project",
-            "item-list",
-            str(project_number),
-            "--owner",
-            owner,
-            "--limit",
-            "200",
-            "--format",
-            "json",
+    limit = PROJECT_ITEM_LIST_INITIAL_LIMIT
+    while True:
+        payload = json.loads(
+            run_gh(
+                "project",
+                "item-list",
+                str(project_number),
+                "--owner",
+                owner,
+                "--limit",
+                str(limit),
+                "--format",
+                "json",
+            )
         )
-    )
-    return payload.get("items", [])
+        items = payload.get("items", [])
+        total_count = payload.get("totalCount")
+        if not isinstance(total_count, int) or len(items) >= total_count:
+            return items
+        if total_count <= limit:
+            raise RuntimeError(
+                "Project item-list returned"
+                f" {len(items)} of {total_count} item(s) with limit {limit}"
+            )
+        limit = total_count
 
 
 def find_item_by_number(items: list[dict[str, Any]], kind: str, number: int) -> dict[str, Any] | None:

--- a/tests/ops/test_project_status_reconcile.py
+++ b/tests/ops/test_project_status_reconcile.py
@@ -1,6 +1,16 @@
 from pathlib import Path
+import subprocess
 
-from scripts.reconcile_project_status import desired_pr_status, load_governance_project_name
+import pytest
+
+from scripts import reconcile_project_status
+from scripts.reconcile_project_status import (
+    desired_pr_status,
+    list_project_items,
+    load_governance_project_name,
+    reconcile_issue,
+    reconcile_pr,
+)
 
 
 def test_desired_pr_status_open_pr_is_in_progress() -> None:
@@ -41,3 +51,209 @@ def test_load_governance_project_name_uses_env_override_when_file_missing(
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("GOVERNANCE_PROJECT_NAME", "Override Project")
     assert load_governance_project_name() == "Override Project"
+
+
+def test_list_project_items_fetches_beyond_initial_limit(monkeypatch) -> None:
+    commands = []
+    first_page_items = [
+        {"id": f"item-{index}", "content": {"type": "Issue", "number": index}}
+        for index in range(200)
+    ]
+    full_items = [
+        *first_page_items,
+        {"id": "item-201", "content": {"type": "Issue", "number": 201}},
+    ]
+
+    def fake_run_gh(*args: str) -> str:
+        commands.append(args)
+        limit = args[args.index("--limit") + 1]
+        if limit == "200":
+            return reconcile_project_status.json.dumps(
+                {"items": first_page_items, "totalCount": 201}
+            )
+        if limit == "201":
+            return reconcile_project_status.json.dumps(
+                {"items": full_items, "totalCount": 201}
+            )
+        raise AssertionError(f"unexpected limit: {limit}")
+
+    monkeypatch.setattr(reconcile_project_status, "run_gh", fake_run_gh)
+
+    assert list_project_items("RasmusTho", 1) == full_items
+    assert [command[command.index("--limit") + 1] for command in commands] == [
+        "200",
+        "201",
+    ]
+
+
+def test_reconcile_issue_does_not_add_item_found_after_initial_limit(
+    monkeypatch, capsys
+) -> None:
+    first_page_items = [
+        {"id": f"item-{index}", "content": {"type": "Issue", "number": index}}
+        for index in range(200)
+    ]
+    full_items = [
+        *first_page_items,
+        {
+            "id": "item-495",
+            "content": {"type": "Issue", "number": 495},
+            "status": "Ready",
+        },
+    ]
+    add_calls = []
+
+    def fake_run_gh(*args: str) -> str:
+        if args[:3] == ("project", "item-list", "1"):
+            limit = args[args.index("--limit") + 1]
+            if limit == "200":
+                return reconcile_project_status.json.dumps(
+                    {"items": first_page_items, "totalCount": 201}
+                )
+            if limit == "201":
+                return reconcile_project_status.json.dumps(
+                    {"items": full_items, "totalCount": 201}
+                )
+        raise AssertionError(f"unexpected gh command: {args}")
+
+    def fail_add_item_to_project(*_args) -> None:
+        add_calls.append(_args)
+        raise AssertionError("should not add an existing project item")
+
+    monkeypatch.setattr(reconcile_project_status, "run_gh", fake_run_gh)
+    monkeypatch.setattr(
+        reconcile_project_status,
+        "get_issue",
+        lambda _repo, _number: {
+            "number": 495,
+            "state": "OPEN",
+            "labels": [{"name": "agent:ready"}],
+            "url": "https://github.com/RasmusTho/agentic-pkm-mvp/issues/495",
+        },
+    )
+    monkeypatch.setattr(
+        reconcile_project_status, "add_item_to_project", fail_add_item_to_project
+    )
+
+    args = reconcile_project_status.argparse.Namespace(
+        repo="RasmusTho/agentic-pkm-mvp",
+        issue=495,
+        dry_run=False,
+        status=None,
+    )
+
+    assert reconcile_issue(args, "RasmusTho", {"number": 1}, "field", {"Ready": "opt"}) == 0
+    assert add_calls == []
+    assert "issue #495: already Ready" in capsys.readouterr().out
+
+
+def test_reconcile_pr_does_not_add_item_found_after_initial_limit(
+    monkeypatch, capsys
+) -> None:
+    first_page_items = [
+        {
+            "id": f"item-{index}",
+            "content": {"type": "PullRequest", "number": index},
+        }
+        for index in range(200)
+    ]
+    full_items = [
+        *first_page_items,
+        {
+            "id": "item-501",
+            "content": {"type": "PullRequest", "number": 501},
+            "status": "In Progress",
+        },
+    ]
+    add_calls = []
+
+    def fake_run_gh(*args: str) -> str:
+        if args[:3] == ("project", "item-list", "1"):
+            limit = args[args.index("--limit") + 1]
+            if limit == "200":
+                return reconcile_project_status.json.dumps(
+                    {"items": first_page_items, "totalCount": 201}
+                )
+            if limit == "201":
+                return reconcile_project_status.json.dumps(
+                    {"items": full_items, "totalCount": 201}
+                )
+        raise AssertionError(f"unexpected gh command: {args}")
+
+    def fail_add_item_to_project(*_args) -> None:
+        add_calls.append(_args)
+        raise AssertionError("should not add an existing project item")
+
+    monkeypatch.setattr(reconcile_project_status, "run_gh", fake_run_gh)
+    monkeypatch.setattr(
+        reconcile_project_status,
+        "get_pr",
+        lambda _repo, _number: {
+            "number": 501,
+            "state": "OPEN",
+            "mergedAt": None,
+            "url": "https://github.com/RasmusTho/agentic-pkm-mvp/pull/501",
+        },
+    )
+    monkeypatch.setattr(
+        reconcile_project_status, "add_item_to_project", fail_add_item_to_project
+    )
+
+    args = reconcile_project_status.argparse.Namespace(
+        repo="RasmusTho/agentic-pkm-mvp",
+        pr=501,
+        dry_run=False,
+        status=None,
+    )
+
+    assert (
+        reconcile_pr(args, "RasmusTho", {"number": 1}, "field", {"In Progress": "opt"})
+        == 0
+    )
+    assert add_calls == []
+    assert "pr #501: already In Progress" in capsys.readouterr().out
+
+
+def test_reconcile_issue_stops_when_project_listing_fails_before_mutation(
+    monkeypatch,
+) -> None:
+    add_calls = []
+
+    def fake_run_gh(*args: str) -> str:
+        if args[:3] == ("project", "item-list", "1"):
+            raise subprocess.CalledProcessError(
+                returncode=1,
+                cmd=["gh", *args],
+                stderr="GraphQL: API rate limit exceeded",
+            )
+        raise AssertionError(f"unexpected gh command: {args}")
+
+    def fail_add_item_to_project(*_args) -> None:
+        add_calls.append(_args)
+        raise AssertionError("should not mutate project after list failure")
+
+    monkeypatch.setattr(reconcile_project_status, "run_gh", fake_run_gh)
+    monkeypatch.setattr(
+        reconcile_project_status,
+        "get_issue",
+        lambda _repo, _number: {
+            "number": 495,
+            "state": "OPEN",
+            "labels": [{"name": "agent:ready"}],
+            "url": "https://github.com/RasmusTho/agentic-pkm-mvp/issues/495",
+        },
+    )
+    monkeypatch.setattr(
+        reconcile_project_status, "add_item_to_project", fail_add_item_to_project
+    )
+
+    args = reconcile_project_status.argparse.Namespace(
+        repo="RasmusTho/agentic-pkm-mvp",
+        issue=495,
+        dry_run=False,
+        status=None,
+    )
+
+    with pytest.raises(subprocess.CalledProcessError):
+        reconcile_issue(args, "RasmusTho", {"number": 1}, "field", {"Ready": "opt"})
+    assert add_calls == []


### PR DESCRIPTION
Fixes #495

## Summary
- fetch Project items up to GitHub's reported `totalCount` before deciding an issue or PR card is missing
- add focused regression coverage for Project item discovery beyond the first 200 entries and failure-before-mutation behavior

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/ops/test_project_status_reconcile.py`
- `git diff --check`
- `git diff --name-only`
- `python3 scripts/reconcile_project_status.py --repo RasmusTho/agentic-pkm-mvp --owner RasmusTho --issue 495 --status 'In Progress' --dry-run`
- `.venv/bin/ruff check scripts/reconcile_project_status.py tests/ops/test_project_status_reconcile.py`

---