### PR TITLE
governance: add README.md to approved docs-authoring and governance surfaces

### DIFF
--- a/.codex/skills/docs-authoring/SKILL.md
+++ b/.codex/skills/docs-authoring/SKILL.md
@@ -20,6 +20,7 @@ Use this skill when the task is a docs-only change that evolves or clarifies aut
 - the PR is docs-only
 - changed files stay inside approved docs-authoring surfaces:
   - `docs/**`
+  - `README.md`
   - `AGENTS.md`
   - `CLAUDE.md`
   - `.codex/AGENTS.md`

--- a/.github/workflows/issue-pr-governance.yml
+++ b/.github/workflows/issue-pr-governance.yml
@@ -99,6 +99,7 @@ jobs:
               return;
             }
             const docsAllowedExact = new Set([
+              "README.md",
               "AGENTS.md",
               "CLAUDE.md",
               ".codex/AGENTS.md",
@@ -111,6 +112,7 @@ jobs:
               ".github/ISSUE_TEMPLATE/",
             ];
             const governanceAllowedExact = new Set([
+              "README.md",
               "AGENTS.md",
               "CLAUDE.md",
               ".codex/AGENTS.md",

--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -85,6 +85,7 @@ Use this lane only when:
 
 - changed files stay inside approved docs-authoring surfaces:
   - `docs/**`
+  - `README.md`
   - `AGENTS.md`
   - `CLAUDE.md`
   - `.codex/AGENTS.md`

--- a/docs/development/GITHUB_GOVERNANCE_SETUP.md
+++ b/docs/development/GITHUB_GOVERNANCE_SETUP.md
@@ -100,6 +100,7 @@ Docs authoring is the separate PR lane for docs-only changes that evolve or clar
 Approved docs-authoring surfaces:
 
 - `docs/**`
+- `README.md`
 - `AGENTS.md`
 - `CLAUDE.md`
 - `.codex/AGENTS.md`


### PR DESCRIPTION
- [x] Governance lane

## Summary
Adds `README.md` to the approved docs-authoring and governance surface lists so the repo entry-point doc can be updated without a governing Issue. This is the surface-expansion-only bootstrap step; the README content update follows as a docs-authoring PR.

## Changes
- `.github/workflows/issue-pr-governance.yml` — adds `README.md` to `docsAllowedExact` and `governanceAllowedExact`
- `docs/development/DEV_WORKFLOW.md` — adds `README.md` to approved docs-authoring surfaces
- `docs/development/GITHUB_GOVERNANCE_SETUP.md` — same
- `.codex/skills/docs-authoring/SKILL.md` — same

## Validation
- Governance checks: surface lists consistent across all four policy files and the CI enforcement workflow
- `README.md` is not changed in this PR — this PR can pass CI against the current main enforcement rules
- No code, runtime behavior, contracts, or shipped reality changed

## Notes
- Supersedes PR #498 (which combined this surface expansion with the README content update, causing a bootstrap failure where CI read the old workflow from main and rejected README.md as a disallowed file)
- README version-framing correction (v5.6 delivered, v6 active) will follow as a docs-authoring PR after this merges