### PR TITLE
Fix orjson recursion DoS by upgrading to patched versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "httpx>=0.27",
     "pydantic>=2.7",
     "rapidfuzz>=3.0",
-    "orjson>=3.9",
+    "orjson>=3.11.6",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ langgraph-sdk==0.2.9
 langsmith==0.4.37
 Mako==1.3.10
 MarkupSafe==3.0.3
-orjson==3.11.3
+orjson==3.11.8
 ormsgpack==1.11.0
 packaging==25.0
 pluggy==1.6.0


### PR DESCRIPTION
Fixes #481

## Summary
- upgrade runtime pin to orjson==3.11.8 in requirements.txt
- raise project floor to orjson>=3.11.6 in pyproject.toml so vulnerable ranges are excluded
- remediation receipt: addresses Dependabot alert #14 (GHSA-hx9q-6w63-j58v / CVE-2025-67221)

## Validation
- rg -n "^orjson==|^orjson>=|orjson" requirements.txt pyproject.toml
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/api -m "not pg"
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/architecture/test_events_outbox_contracts.py -m "not pg"
- gh api repos/RasmusTho/agentic-pkm-mvp/dependabot/alerts/14 (vulnerable range < 3.11.6, first patched 3.11.6)
