### PR TITLE
Fix Starlette Range-header DoS dependency exposure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ requests-toolbelt==1.0.0
 sniffio==1.3.1
 SQLAlchemy==2.0.36
 sqlite-vec==0.1.6
-starlette==0.48.0
+starlette==0.49.1
 tenacity==9.1.2
 typing-inspection==0.4.2
 typing_extensions==4.15.0


### PR DESCRIPTION
Fixes #371

## Summary
Update `starlette` in `requirements.txt` from `0.48.0` to patched `0.49.1` to remediate Dependabot alert #1 (`>=0.39.0, <=0.49.0` vulnerable range).

## Validation
- `rg -n \"starlette|fastapi\" requirements.txt pyproject.toml`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/api -m \"not pg\"`

## Dependabot Receipt
- Covered alert: #1 (Starlette O(n^2) DoS via Range header merging)

---