### PR TITLE
Fix urllib3 decompression alert set by upgrading to 2.6.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ starlette==0.48.0
 tenacity==9.1.2
 typing-inspection==0.4.2
 typing_extensions==4.15.0
-urllib3==2.5.0
+urllib3==2.6.3
 uvicorn==0.37.0
 uvloop==0.21.0
 watchfiles==1.1.1


### PR DESCRIPTION
Fixes #370

## Summary
- Upgrade `urllib3` from `2.5.0` to `2.6.3` in `requirements.txt`.
- Keep the remediation bounded to dependency compatibility with no runtime behavior changes.
- Covers Dependabot alerts #8, #4, and #5 (urllib3 decompression issue set).

## Validation
- `rg -n \"^urllib3==|^urllib3>=\" requirements.txt`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/api tests/cli/test_health_contract_cli.py tests/cli/test_status_cli.py -m \"not pg\"`
- Baseline note: the broader suggested suite `pytest -q tests/cli tests/api -m \"not pg\"` has pre-existing unrelated failures in `tests/cli/test_ask_cli.py`.