### PR TITLE
Upgrade langchain-core to 1.2.28 for advisory remediation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ iniconfig==2.1.0
 jsonpatch==1.33
 jsonschema==4.23.0
 jsonpointer==3.0.0
-langchain-core==1.0.0
+langchain-core==1.2.28
 langgraph==0.6.10
 langgraph-checkpoint==2.1.2
 langgraph-checkpoint-sqlite==2.0.11


### PR DESCRIPTION
Fixes #369

## Summary
- upgrade `langchain-core` pin in `requirements.txt` from `1.0.0` to `1.2.28`
- covers the LangChain-core advisory set tracked in #369 (alerts #3, #7, #10, #16, #17)
- this supersedes duplicate/superseded tracking issues #372, #485, and #486 via the canonical issue contract

## Validation
- `source .venv/bin/activate && python -m pip install "langchain-core==1.2.28"`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/components/llm tests/reasoning tests/agents/panel_agent -m "not pg" --deselect tests/agents/panel_agent/test_panel_runtime.py::test_runtime_writeback_proposes_idempotent_on_rerun`
- baseline note: `test_runtime_writeback_proposes_idempotent_on_rerun` fails on both `langchain-core==1.0.0` and `1.2.28` (pre-existing, not introduced by this change)
