### PR TITLE
Remediate pytest tmpdir vulnerability by upgrading to 9.0.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ psycopg[binary]==3.2.10
 pydantic==2.12.0
 pydantic-settings==2.6.1
 pydantic_core==2.41.1
-pytest==8.3.3
+pytest==9.0.3
 pytest-cov==5.0.0
 python-dotenv==1.1.1
 PyYAML==6.0.3


### PR DESCRIPTION
Fixes #487

## Summary
Upgrade `pytest` from `8.3.3` to `9.0.3` in `requirements.txt` to satisfy the patched floor for Dependabot alerts #18 and #19.

## Validation
- `rg -n "^pytest==|^pytest>=|pytest" requirements.txt pyproject.toml`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/architecture/test_docs_index.py tests/ops/test_project_status_reconcile.py -m "not pg"`

## Dependabot Receipt
- Covered alerts: #18 and #19

---