### PR TITLE
Remediate yt-dlp --netrc-cmd advisory and audit usage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ httpcore==1.0.9
 httptools==0.7.1
 httpx==0.27.2
 faster-whisper==1.0.3
-yt-dlp==2024.8.6
+yt-dlp==2026.3.17
 rank-bm25==0.2.2
 numpy==1.26.4
 tqdm==4.66.4


### PR DESCRIPTION
Fixes #373

## Summary
- upgrade `yt-dlp` from `2024.8.6` to `2026.3.17` in `requirements.txt`
- audit repository usage for `yt-dlp` / `YoutubeDL` and `--netrc-cmd` exposure
- confirm there is direct `YoutubeDL` usage and no `--netrc-cmd` usage in code/tests/docs

## Security Receipt
- Dependabot alert covered: #11 (yt-dlp command injection via `--netrc-cmd`)
- Audit result: repo uses `yt_dlp.YoutubeDL` in `app/media/transcribe.py`; no `--netrc-cmd` or `netrc-cmd` usage found

## Validation
- `rg -n "^yt-dlp==|yt-dlp|YoutubeDL|netrc-cmd|--netrc" requirements.txt app/media/transcribe.py tests docs/SECURITY-ROADMAP-v6.1.md`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_transcribe_smoke.py -m "not pg"`