### PR TITLE
deps: bump requests to 2.33.0 (alert #15)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ pytest==9.0.3
 pytest-cov==5.0.0
 python-dotenv==1.1.1
 PyYAML==6.0.3
-requests==2.32.5
+requests==2.33.0
 requests-toolbelt==1.0.0
 sniffio==1.3.1
 SQLAlchemy==2.0.36


### PR DESCRIPTION
Fixes #484

## Summary
- upgrade requests from 2.32.5 to 2.33.0 to remediate Dependabot alert #15
- keep scope limited to dependency bump only

## Verification
- rg -n "^requests==|^requests>=" requirements.txt
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/api -m "not pg"
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/cli -m "not pg" (2 pre-existing failures in tests/cli/test_ask_cli.py)

## Delivery receipt
- Covers Dependabot alert #15 (requests insecure temp file reuse)
