### PR TITLE
deps: bump langsmith to 0.7.31 (alerts #9/#20)

### DIFF
--- a/docs/SECURITY-ROADMAP-v6.1.md
+++ b/docs/SECURITY-ROADMAP-v6.1.md
@@ -103,7 +103,7 @@ Last verified against: Dependabot alert snapshot summarized on 2026-04-07
 - **Risk:** SSRF via tracing header injection
 - **Single-User Impact:** LOW-MEDIUM - requires attacker to inject malicious tracing headers
 - **Context:** Client SDK for LangSmith monitoring
-- **Action:** Plan for v6.2; upgrade langsmith with next release cycle
+- **Action:** Remediated via Issue #488 by upgrading `langsmith` to `0.7.31`, which also closes Dependabot alert #20; keep this row as the historical snapshot record.
 
 ### #15: Requests Insecure Temp File Reuse (MEDIUM)
 - **Package:** requests

--- a/docs/adr/ADR-0006-deepagents-harness.md
+++ b/docs/adr/ADR-0006-deepagents-harness.md
@@ -98,7 +98,7 @@ This eliminates most of the need for a custom MCP filesystem layer.
 
 ### 6. LangSmith observability — ALREADY IN REQUIREMENTS
 
-`langsmith==0.4.37` is already locked in `requirements.txt`. DeepAgents is built on LangChain and traces automatically via LangSmith when `LANGCHAIN_API_KEY` is set. This complements (not replaces) the Prometheus/status stack.
+`langsmith==0.7.31` is pinned in `requirements.txt`. DeepAgents is built on LangChain and traces automatically via LangSmith when `LANGCHAIN_API_KEY` is set. This complements (not replaces) the Prometheus/status stack.
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ langgraph-checkpoint==4.0.0
 langgraph-checkpoint-sqlite==3.0.3
 langgraph-prebuilt==1.0.10
 langgraph-sdk==0.3.13
-langsmith==0.4.37
+langsmith==0.7.31
 Mako==1.3.11
 MarkupSafe==3.0.3
 orjson==3.11.8


### PR DESCRIPTION
Fixes #488

## Summary
- upgrade langsmith from 0.4.37 to 0.7.31
- update security roadmap receipt for alert #9 and superseding alert #20
- align ADR-0006 dependency note with the pinned version

## Verification
- rg -n "^langsmith==|^langsmith>=" requirements.txt
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/components/llm -m "not pg"
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/reasoning -m "not pg"

## Delivery receipt
- Covers Dependabot alerts #9 and #20
- Supersedes duplicate issue #483 via this canonical remediation issue
