### PR TITLE
Fix Starlette O(n²) DoS via Range Header (Dependabot alert #1)

### DIFF
--- a/docs/SECURITY-ROADMAP-v6.1.md
+++ b/docs/SECURITY-ROADMAP-v6.1.md
@@ -39,11 +39,11 @@ Last verified against: Issue #374 audit on 2026-04-18; GitHub Advisory GHSA-v34v
 - **Context:** All three are decompression-related; bundled fix in single urllib3 upgrade
 - **Action:** Create GitHub issue; upgrade urllib3 to latest patched version
 
-### #1: Starlette O(n²) DoS via Range Header (HIGH)
+### #1: Starlette O(n²) DoS via Range Header (HIGH) — REMEDIATED
 - **Package:** starlette
 - **Risk:** DoS via malicious Range header merging in FileResponse
 - **Single-User Impact:** MEDIUM - affects your FastAPI app if it serves files or uses Range requests
-- **Action:** Create GitHub issue; upgrade starlette to patch version
+- **Resolution:** Upgraded starlette 0.48.0 → 0.49.1 and fastapi 0.119.0 → 0.121.0. Closes Dependabot alert #1.
 
 ### #16: LangChain Path Traversal (HIGH)
 - **Package:** langchain-core

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ click==8.1.7
 coverage==7.11.0
 debugpy==1.8.17
 duckdb==1.4.1
-fastapi==0.119.0
+fastapi==0.121.0
 h11==0.16.0
 httpcore==1.0.9
 httptools==0.7.1
@@ -50,7 +50,7 @@ requests-toolbelt==1.0.0
 sniffio==1.3.1
 SQLAlchemy==2.0.36
 sqlite-vec==0.1.6
-starlette==0.48.0
+starlette==0.49.1
 tenacity==9.1.2
 typing-inspection==0.4.2
 typing_extensions==4.15.0


### PR DESCRIPTION
Fixes #371

## Summary
Upgrades starlette 0.48.0 → 0.49.1 (patched for Range-header O(n²) DoS) and fastapi 0.119.0 → 0.121.0 to satisfy the starlette<0.50.0 constraint. Closes Dependabot alert #1.

## Validation
- `rg -n "starlette|fastapi" requirements.txt` confirms correct pins
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/api -m "not pg"` — 36 passed, 2 deselected
- `git diff --name-only`: only `requirements.txt` and `docs/SECURITY-ROADMAP-v6.1.md`
- No route semantics, runtime defaults, schema, event, or on-disk behavior changes beyond dependency compatibility

## Delivery Receipt
Remediation of Dependabot alert #1 (Starlette O(n^2) DoS via Range Header, vulnerable range >= 0.39.0, <= 0.49.0, patched in 0.49.1).

---