### PR TITLE
Harden post-merge-owner-doc enforcement: watchdog, receipt assertion, spec clarifications

### DIFF
--- a/.codex/skills/post-merge-owner-doc/SKILL.md
+++ b/.codex/skills/post-merge-owner-doc/SKILL.md
@@ -22,6 +22,10 @@ For the merged PR, read:
 
 Then answer: does the diff change something those owner docs currently claim?
 
+## Receipt placement
+
+The receipt comment always goes on the **closed issue** that the PR fixes. If the PR closed multiple issues, post the receipt on each one. If the PR closed no issues (docs-only lane, governance lane), post the receipt as a **PR comment** instead — the PR is then the auditable artifact.
+
 ## Three outcomes
 
 **1. Yes, and the wording change is clear.**

--- a/.codex/skills/post-merge-owner-doc/agents/openai.yaml
+++ b/.codex/skills/post-merge-owner-doc/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Post-Merge Owner Doc"
+  short_description: "After a PR merges, check whether any owner doc needs updating and act on it"
+  default_prompt: "Use $post-merge-owner-doc to read the merged PR diff, determine whether any owner doc is now wrong or outdated, and act: open a docs-only PR, file a bounded follow-up issue, or leave a no-change receipt comment on the closed issue."

--- a/.codex/skills/verification-and-closure/SKILL.md
+++ b/.codex/skills/verification-and-closure/SKILL.md
@@ -144,7 +144,13 @@ When all merge prerequisites are met:
    gh pr view #<PR> --json state,projectItems
    ```
 
-9. **Invoke `post-merge-owner-doc`** on the merged PR. It reads the diff and either opens a docs-only PR, files one bounded follow-up issue, or leaves an explicit "no owner-doc change implied" receipt comment on the closed issue. This is the only owner-doc promotion step; do not duplicate its judgment here. If the skill does not leave a receipt comment on the closed issue, verification is not complete.
+9. **Invoke `post-merge-owner-doc`** on the merged PR. It reads the diff and either opens a docs-only PR, files one bounded follow-up issue, or leaves an explicit "no owner-doc change implied" receipt comment on the closed issue. This is the only owner-doc promotion step; do not duplicate its judgment here.
+
+10. **Assert the receipt exists** before emitting `DELIVERY RECEIPT`. For each issue closed by the PR, run:
+    ```bash
+    gh issue view #<N> --json comments --jq '[.comments[].body | select(contains("post-merge owner-doc check"))] | length'
+    ```
+    If the result is `0`, the skill did not complete. Do not emit `DELIVERY RECEIPT` until the receipt comment is present on every closed issue (or on the PR itself if no issues were closed).
 
 ### When NOT to merge
 

--- a/.github/workflows/post-merge-owner-doc-watchdog.yml
+++ b/.github/workflows/post-merge-owner-doc-watchdog.yml
@@ -1,0 +1,83 @@
+name: Post-Merge Owner Doc Watchdog
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  check-receipt:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const prNumber = pr.number;
+            const prBody = pr.body || "";
+            const RECEIPT_MARKER = "post-merge owner-doc check";
+
+            // Resolve closed issues from the PR's closing references
+            const closingIssues = await github.paginate(
+              "GET /repos/{owner}/{repo}/pulls/{pull_number}/commits",
+              { owner: context.repo.owner, repo: context.repo.repo, pull_number: prNumber }
+            ).catch(() => []);
+
+            // GraphQL gives us the closing issues directly
+            const { repository } = await github.graphql(`
+              query($owner: String!, $repo: String!, $pr: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $pr) {
+                    closingIssuesReferences(first: 25) {
+                      nodes { number }
+                    }
+                  }
+                }
+              }
+            `, { owner: context.repo.owner, repo: context.repo.repo, pr: prNumber });
+
+            const linkedIssues = repository.pullRequest.closingIssuesReferences.nodes.map(n => n.number);
+
+            const NUDGE = `post-merge owner-doc check: not yet run.\n\nInvoke \`$post-merge-owner-doc\` on PR #${prNumber} to complete the delivery feedback loop. Outcome will be one of: docs PR opened, follow-up issue filed, or this comment replaced with a no-change receipt.`;
+
+            if (linkedIssues.length === 0) {
+              // No linked issues — check the PR itself for a receipt comment
+              const prComments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+              });
+              const hasReceipt = prComments.some(c => c.body.includes(RECEIPT_MARKER));
+              if (!hasReceipt) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body: NUDGE,
+                });
+              }
+              return;
+            }
+
+            // For each closed issue, check whether a receipt comment exists
+            for (const issueNumber of linkedIssues) {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+              });
+              const hasReceipt = comments.some(c => c.body.includes(RECEIPT_MARKER));
+              if (!hasReceipt) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  body: NUDGE,
+                });
+              }
+            }


### PR DESCRIPTION
Fixes #528

## Summary

Two enforcement layers for post-merge owner-doc receipts where previously only a prose instruction existed. Adds the missing `agents/openai.yaml` for Codex platform invocability and clarifies the receipt-placement spec for PRs with no linked issues.

## Validation

All four acceptance-criteria commands pass on HEAD:

```bash
test -f .codex/skills/post-merge-owner-doc/agents/openai.yaml && grep -q display_name .codex/skills/post-merge-owner-doc/agents/openai.yaml
grep -n "Receipt placement" .codex/skills/post-merge-owner-doc/SKILL.md
grep -n "Assert the receipt exists" .codex/skills/verification-and-closure/SKILL.md
test -f .github/workflows/post-merge-owner-doc-watchdog.yml && grep -q "types: \[closed\]" .github/workflows/post-merge-owner-doc-watchdog.yml
```

---