### PR TITLE
fix: watchdog nudge marker conflicts with receipt marker; paginate closing-issues query

### DIFF
--- a/.github/workflows/post-merge-owner-doc-watchdog.yml
+++ b/.github/workflows/post-merge-owner-doc-watchdog.yml
@@ -19,31 +19,32 @@ jobs:
           script: |
             const pr = context.payload.pull_request;
             const prNumber = pr.number;
-            const prBody = pr.body || "";
             const RECEIPT_MARKER = "post-merge owner-doc check";
+            const NUDGE_PREFIX = "post-merge owner-doc watchdog:";
 
-            // Resolve closed issues from the PR's closing references
-            const closingIssues = await github.paginate(
-              "GET /repos/{owner}/{repo}/pulls/{pull_number}/commits",
-              { owner: context.repo.owner, repo: context.repo.repo, pull_number: prNumber }
-            ).catch(() => []);
-
-            // GraphQL gives us the closing issues directly
-            const { repository } = await github.graphql(`
-              query($owner: String!, $repo: String!, $pr: Int!) {
-                repository(owner: $owner, name: $repo) {
-                  pullRequest(number: $pr) {
-                    closingIssuesReferences(first: 25) {
-                      nodes { number }
+            // Paginate closingIssuesReferences until hasNextPage is false
+            let linkedIssues = [];
+            let cursor = null;
+            do {
+              const cursorArg = cursor ? `, after: "${cursor}"` : "";
+              const result = await github.graphql(`
+                query($owner: String!, $repo: String!, $pr: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $pr) {
+                      closingIssuesReferences(first: 100${cursorArg}) {
+                        nodes { number }
+                        pageInfo { hasNextPage endCursor }
+                      }
                     }
                   }
                 }
-              }
-            `, { owner: context.repo.owner, repo: context.repo.repo, pr: prNumber });
+              `, { owner: context.repo.owner, repo: context.repo.repo, pr: prNumber });
+              const conn = result.repository.pullRequest.closingIssuesReferences;
+              linkedIssues = linkedIssues.concat(conn.nodes.map(n => n.number));
+              cursor = conn.pageInfo.hasNextPage ? conn.pageInfo.endCursor : null;
+            } while (cursor !== null);
 
-            const linkedIssues = repository.pullRequest.closingIssuesReferences.nodes.map(n => n.number);
-
-            const NUDGE = `post-merge owner-doc check: not yet run.\n\nInvoke \`$post-merge-owner-doc\` on PR #${prNumber} to complete the delivery feedback loop. Outcome will be one of: docs PR opened, follow-up issue filed, or this comment replaced with a no-change receipt.`;
+            const NUDGE = `${NUDGE_PREFIX} check not yet run for PR #${prNumber}.\n\nInvoke \`$post-merge-owner-doc\` on PR #${prNumber} to complete the delivery feedback loop. The skill will leave a receipt comment (outcome 1: docs PR, outcome 2: follow-up issue, or outcome 3: no-change note).`;
 
             if (linkedIssues.length === 0) {
               // No linked issues — check the PR itself for a receipt comment


### PR DESCRIPTION
Fixes #530

## Summary

Two bugs in the watchdog workflow shipped in PR #529, caught by the Codex inline review.

**P1 — marker conflict:** nudge comment now starts with `post-merge owner-doc watchdog:` instead of `post-merge owner-doc check:`, so it cannot satisfy the v-v-f step 10 receipt assertion.

**P2 — incomplete pagination:** replaced `first: 25` with a cursor loop (`first: 100`, paginate while `hasNextPage`).

## Validation

```bash
# AC1: receipt marker only in the RECEIPT_MARKER constant, not in nudge text
grep "post-merge owner-doc check" .github/workflows/post-merge-owner-doc-watchdog.yml
# expected: only the RECEIPT_MARKER = "..." line

# AC2: pagination present
grep -n "hasNextPage\|endCursor" .github/workflows/post-merge-owner-doc-watchdog.yml
# expected: lines 25, 36, 44
```

---