### PR TITLE
docs: specify canvas-Chat co-editing model and build-vs-buy research

### DIFF
--- a/docs/HUMAN-FLOWS.md
+++ b/docs/HUMAN-FLOWS.md
@@ -6,7 +6,7 @@ Temporal class: strategic
 Review cadence: event-driven
 Source of truth: mixed
 Last reviewed: 2026-04-20
-Last verified against: docs/PROJECT_KERNEL.md, docs/ARCHITECTURE.md, docs/STATUS.md, docs/OPERATIONS.md, docs/PANEL_AGENT.md, docs/plans/AUTONOMY_AND_SYNC_VALIDATION.md, docs/plans/V60_COGNITIVE_SUPPORT_PRIORITIES.md, docs/contracts/A2A_CONTRACT_AND_TRACE.md, docs/INTERACTION_SURFACES_AND_AUTHORITY/README.md, docs/INTERACTION_SURFACES_AND_AUTHORITY/RECONCILE_CHAT_MUTATION_AUTHORITY.md, docs/FINDING_AND_REORIENTING/README.md, docs/FINDING_AND_REORIENTING/DOCUMENT_SALIENCE_AS_DERIVED.md, docs/SEPARATING_PERSISTENCE_SURFACES/README.md, docs/COMMITMENT_AS_FIRST_CLASS/README.md, merged PRs #423/#424/#425/#426/#427/#431/#439/#448/#453/#454/#460/#463/#467/#469/#472/#473/#474/#475/#476/#477/#478/#479/#490/#491/#492/#493/#494/#496/#501/#521/#527, current repo state at 17eef96 on 2026-04-20, closed current-state bug issues #435/#436/#437
+Last verified against: docs/PROJECT_KERNEL.md, docs/ARCHITECTURE.md, docs/STATUS.md, docs/OPERATIONS.md, docs/PANEL_AGENT.md, docs/plans/AUTONOMY_AND_SYNC_VALIDATION.md, docs/plans/V60_COGNITIVE_SUPPORT_PRIORITIES.md, docs/contracts/A2A_CONTRACT_AND_TRACE.md, docs/INTERACTION_SURFACES_AND_AUTHORITY/README.md, docs/INTERACTION_SURFACES_AND_AUTHORITY/RECONCILE_CHAT_MUTATION_AUTHORITY.md, docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CANVAS_COEDITING_MODEL.md, docs/FINDING_AND_REORIENTING/README.md, docs/FINDING_AND_REORIENTING/DOCUMENT_SALIENCE_AS_DERIVED.md, docs/SEPARATING_PERSISTENCE_SURFACES/README.md, docs/COMMITMENT_AS_FIRST_CLASS/README.md, docs/research/CHAT_SURFACE_BUILD_VS_BUY.md, merged PRs #423/#424/#425/#426/#427/#431/#439/#448/#453/#454/#460/#463/#467/#469/#472/#473/#474/#475/#476/#477/#478/#479/#490/#491/#492/#493/#494/#496/#501/#521/#527, current repo state at 17eef96 on 2026-04-20, closed current-state bug issues #435/#436/#437
 
 # Human Flows — Yggdrasil / agentic-pkm-mvp
 
@@ -618,6 +618,21 @@ The system should help the user:
 - distinguish commitment from note text,
 - and inspect what the system did, under what authority, and with what result.
 
+### Case: I want to think on a note with a writing partner
+
+User need:
+- "I have a note that is rough, or partial, or messy, and I want to work on it with assistance that edits the note directly, not in a separate chat window."
+
+The system should help the user:
+- open a canvas session on the note where edits apply in place as they are generated, the way a collaborative editor behaves,
+- treat the note itself as the surface they are working on, not a conversation transcript,
+- keep sessions short and purposeful rather than accumulating a long chat log per note,
+- retain the session as a subordinate intent trail so the user can later ask "why did this note become what it is," without that trail growing into a second document that competes with the note,
+- keep content edits in the active session authorized by the user's presence, and keep any governance-bearing change (classification, cross-note moves, lifecycle transitions) on the same gated-execution path the Panel already uses,
+- and undo any edit the way the user would undo their own typing.
+
+This case is what the canvas-Chat surface exists for. The note remains the artifact; the session log remains the provenance of intent behind it.
+
 ## 9. Context-sensitive use
 
 The same human may use the system across multiple life spheres and contexts.
@@ -746,6 +761,14 @@ The human may also occasionally observe system-surface artifacts such as compani
 Those artifacts are not normal authoring surfaces, but their presence should still remain legible
 enough that the human is not surprised by them.
 
+A canvas-Chat surface is specified as a future human-facing surface for thinking on a note with
+assistance — direct in-place editing during an active session, with session logs retained
+alongside the note as subordinate intent trails. This surface is designed but not yet implemented.
+Its authority model and artifact conventions are specified in
+`docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CANVAS_COEDITING_MODEL.md` so that the co-editing
+posture cannot be either over-restricted (reintroducing ASK-shaped turn-taking) or
+over-permissive (collapsing the gated-execution invariant) when it ships.
+
 ### Satellite and tablet flow
 
 The system should support a practical flow where:
@@ -782,6 +805,9 @@ The current baseline realizes only part of the broader function set.
 - stronger learning-oriented flows
 - clearer creative/hobby-specific support patterns
 - fuller receipt artifacts beyond current overlays and operational traces
+- canvas-Chat surface for direct in-place co-authoring of a note with assistance, with
+  session-as-provenance stored alongside the note as a subordinate artifact class (see
+  `docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CANVAS_COEDITING_MODEL.md`)
 
 This is acceptable as long as the system is developed toward the broader human functions rather than
 mistaking current baseline mechanics for the full target.

--- a/docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CANVAS_COEDITING_MODEL.md
+++ b/docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CANVAS_COEDITING_MODEL.md
@@ -82,7 +82,9 @@ The following mutations do **not** fall under co-authoring and must route throug
 - cross-note operations (edits to notes other than the currently-open one, multi-note synthesis that writes to other files),
 - note lifecycle transitions (creation of new notes, renames, moves between folders, deletions, archival),
 - promotions of maturity or commitment state,
-- operations against system-owned artifacts (companion notes, receipts, chat-session logs themselves).
+- operations against system-owned artifacts (companion notes, receipts, and explicit user-directed edits to prior session logs).
+
+**Carve-out:** Routine session-log appends during an active session (the system recording the current turn's prompts and change summaries) are co-authoring mechanics, not governance-bearing actions. They are append-only, scoped to the current open session, and authorized by the same user-presence signal as content co-authoring. The governance-bearing rule applies to user-directed or system-autonomous edits to closed session logs — not to the system's own ongoing session transcript.
 
 These are *the same actions Panel would take through its proposal flow*. Candidate A's decision — that Chat-originated governance-bearing mutations land their receipts in Panel's gated-execution pipeline locality — applies to this class.
 

--- a/docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CANVAS_COEDITING_MODEL.md
+++ b/docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CANVAS_COEDITING_MODEL.md
@@ -1,0 +1,273 @@
+---
+name: Define Canvas Co-Editing Model
+description: Specify the direct in-place editing posture for canvas Chat, the co-authoring authority model, the one-to-many note↔session relationship, the session-as-provenance pattern, and the .chats/ + type: frontmatter conventions
+task_id: INTERACTION-07
+source_anchor: docs/INTERACTION_SURFACES_AND_AUTHORITY/RECONCILE_CHAT_MUTATION_AUTHORITY.md :: Decision (Candidate A)
+parent_capability: Interaction surfaces and authority boundaries
+prerequisites: [INTERACTION-01, INTERACTION-03, INTERACTION-05, INTERACTION-06]
+depends_on:
+  - NAME_THE_THREE_INTERACTION_SURFACES.md
+  - DEFINE_CHAT_AUTHORITY_BOUNDARY.md
+  - RECONCILE_CHAT_MUTATION_AUTHORITY.md
+  - STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md
+can_parallelize_with: []
+---
+
+State: Specification draft. Docs-only. Extends the Candidate A decision recorded in `RECONCILE_CHAT_MUTATION_AUTHORITY.md` with the concrete co-editing posture, the authority split between co-authoring and governance-bearing mutation, and the file-system conventions for chat-session artifacts.
+Doc role: Spec
+Authority: SoT for the canvas-Chat co-editing posture and the system-owned chat-session artifact class. Binding on any runtime implementation of a canvas Chat surface.
+Owner: v6.0 architecture owner
+Last reviewed: 2026-04-20
+Last verified against: RECONCILE_CHAT_MUTATION_AUTHORITY.md §Decision, DEFINE_CHAT_AUTHORITY_BOUNDARY.md, STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md, docs/CONCEPTS/COMPANION_NOTE_CONTRACT.md, docs/HUMAN-FLOWS.md, docs/research/CHAT_SURFACE_BUILD_VS_BUY.md
+
+# Define Canvas Co-Editing Model
+
+## Purpose
+
+State how the canvas Chat surface behaves when a user is editing a note with assistance: directly, in place, live, like a collaborative editor. Name the authority model that makes that safe without collapsing the gated-execution invariant. Name the artifact class that captures intent-trail provenance for those sessions, and the file-system conventions that keep chat artifacts subordinate to the vault.
+
+This spec is a downstream extension of `RECONCILE_CHAT_MUTATION_AUTHORITY.md` Candidate A. It does not reopen the mutation-authority decision; it describes how that decision expresses itself in a co-editing workflow.
+
+## What This Task Does
+
+Produces a specification that states:
+
+1. **The co-editing posture.** Canvas Chat applies edits directly to the open note as they are generated, without a pre-commit approval step. The note is the durable surface; the chat is not a proposal queue. The user's experience is of co-authoring a document, not of reviewing diffs.
+2. **The authority split.** Two distinct mutation classes, each with its own governance model:
+   - *Content co-authoring* within the currently-open note during an active session: authorized by user presence, rolled back by undo, audited by the session log.
+   - *Governance-bearing mutations* (frontmatter `type:`/classification fields, cross-note operations, note creation/deletion/rename, promotion of maturity or commitment state): flow through the gated-execution pipeline named in `STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md`.
+3. **The note↔session relationship.** One-to-many: one note, many short purposeful sessions over time. Each session is ephemeral; the note is the persistent memory across sessions. Long-lived chats that accumulate semantic value are explicitly out of scope because they reintroduce the failure mode of the chat log becoming a shadow source of truth.
+4. **The artifact classes.** The note is the *artifact* (primary, curated, canonical). The session log is the *provenance* (retained, subordinate, captures intent). The relationship is the same as code-to-commit-message: both are retained, but they are different classes of thing and only one of them is the load-bearing artifact.
+5. **The file-system conventions.** Session logs live under `vault/.chats/<note-slug>/<timestamp>-<short-label>.md`. Classification is carried in frontmatter as `type: chat-session`. The `.chats/` namespace keeps system-generated artifacts out of the human writing surface; the `type:` field lets Obsidian search, Dataview, graph view, and system retrieval distinguish artifact from exhaust.
+6. **Retention and reversibility.** Session logs are retained by default but bounded: a retention window (to be named) after which sessions are soft-deleted unless explicitly preserved. Retention is per-note: when a note is deleted, its session history becomes eligible for the same disposition as the note.
+
+## The Canvas Co-Editing Posture
+
+### Direct in-place editing, not suggest-then-accept
+
+Canvas Chat edits apply to the open note immediately as they are generated. The user does not review a diff before each change lands. The editor behaves like a live collaborative editor where the assistant is the second author.
+
+This is deliberate. The canvas posture is *externalize and manipulate thought*, not *review and approve suggestions*. A diff-review gate would reimport ASK-shaped turn-taking under a different name and defeat the canvas-vs-ASK distinction this capability protects.
+
+Undo is the per-edit rollback mechanism. Autosave to the vault file is continuous — Obsidian's file watcher picks up saves normally, no plugin required.
+
+### The session, not the turn
+
+A canvas session is the unit of work. Sessions are short and purposeful: "clean this up," "expand the decision section," "restructure into context/decision/implications." A session opens, edits accumulate in place, the session closes, and the note reflects the accumulated work.
+
+The chat transcript inside the session is not the thing the user operates on — the note is. The chat transcript is an intent trail that the system captures for later retrieval, not a document the user will return to as their canonical memory.
+
+## The Authority Split
+
+Candidate A records that Chat may carry governed mutation rights through the same pipeline as Panel. This spec names the split that makes direct in-place editing compatible with that decision.
+
+### Co-authoring: authorized by presence
+
+The following mutations occur within the active co-authoring mode:
+
+- edits to the body of the currently-open note,
+- rearrangement, insertion, or deletion of content within that note,
+- in-note formatting and prose-level revision,
+- any edit the user could equivalently make by typing themselves.
+
+These are authorized by the fact that the user is actively present in the session. The authority class is the same as the user's own keystrokes — the assistant is a second author, and the user's presence is the authorization signal. The session log is the audit record; undo is the rollback mechanism.
+
+This does not bypass the gated-execution invariant. It recognizes that user-present co-authoring is a distinct mutation class from autonomous system action, and that the invariant applies to the latter class.
+
+### Governance-bearing: flows through the gated pipeline
+
+The following mutations do **not** fall under co-authoring and must route through the gated-execution pipeline regardless of user presence:
+
+- changes to frontmatter fields that carry classification or governance meaning (`type:`, `maturity`, `review_state`, `kind`, scope/sphere tags),
+- cross-note operations (edits to notes other than the currently-open one, multi-note synthesis that writes to other files),
+- note lifecycle transitions (creation of new notes, renames, moves between folders, deletions, archival),
+- promotions of maturity or commitment state,
+- operations against system-owned artifacts (companion notes, receipts, chat-session logs themselves).
+
+These are *the same actions Panel would take through its proposal flow*. Candidate A's decision — that Chat-originated governance-bearing mutations land their receipts in Panel's gated-execution pipeline locality — applies to this class.
+
+### The line between them
+
+The distinction is not stylistic or judgement-based. It is defined by scope:
+
+> Co-authoring is "within this note's body, during this session, with the user present." Anything outside that scope is governance-bearing.
+
+When an action is ambiguous, it is treated as governance-bearing. The default failure mode is caution, not fluidity.
+
+## The Note↔Session Relationship
+
+### One-to-many
+
+One note, many sessions over time. Each session is short, focused on a single editing intent. Sessions close and the note persists.
+
+Long-lived chats per note are explicitly out of scope. They look attractive because the chat accumulates context, but they introduce the failure mode the architecture is built to prevent: the chat log becomes the document the user needs to consult to understand the note's history, and the note is silently demoted to a derived artifact.
+
+### The note is the persistent memory
+
+Continuity across sessions is carried by the note itself, not by a long-running chat. A new session opens the note, reads its current state, and has everything it needs. If a decision made in session 1 matters for session 3, it lives in the note.
+
+This makes each session self-contained and makes the note's own evolution the load-bearing history.
+
+### Workspace mode: a bounded exception
+
+There is a legitimate use case for longer-lived sessions that span multiple notes — cross-note synthesis, reconciliation of related material, thematic review. This is workspace mode.
+
+Workspace mode is out of scope for the initial canvas co-editing capability but is named here so it does not silently grow without spec. When it ships, it inherits the same artifact-vs-provenance model: the output lands back in a note (new or existing), the session is provenance, the note is the artifact. Workspace-mode edits to multiple notes are *governance-bearing by definition* (they are cross-note operations) and must flow through the gated pipeline, even if the interaction feels co-authoring-like.
+
+## Artifact Classes
+
+### The note: artifact
+
+- The durable, canonical, curated object.
+- What the system retrieves, surfaces, links, and treats as the primary record.
+- What the user reads, writes, and cites.
+- What must remain understandable without the current system.
+
+### The session log: provenance
+
+- A retained intent trail capturing *why* the note evolved the way it did.
+- Contains the user's prompts (intent), a summary of what changed (diff or description), and a timestamp.
+- Not the full LLM response body — that is noise, not provenance.
+- Readable by humans if consulted, but not part of normal browsing.
+- Subject to retention policy.
+
+The relationship mirrors code-to-commit-message: both are kept, both are useful, but the code is the artifact and the commit messages are the history of intent behind it.
+
+## File-System Conventions
+
+### Location: `.chats/`
+
+Session logs live inside the vault under a system-owned namespace:
+
+```
+vault/
+  notes/
+    v6-architecture.md         ← artifact (primary human surface)
+  .chats/
+    v6-architecture/
+      2026-04-20T14-30-restructure.md    ← provenance
+      2026-04-11T09-15-initial-draft.md
+```
+
+Reasoning:
+
+- **In-vault** so sessions sync, back up, and are locally searchable alongside the notes they describe. The same local-first, device-portable guarantees that apply to notes apply to their provenance.
+- **Dotfile-prefixed (`.chats/`)** so Obsidian, Dataview, and the user's normal browsing ignore the directory by default. The user can opt in to viewing it, but does not encounter it while writing.
+- **Per-note subdirectory** so the one-to-many relationship is visible in the file system and retention operations are straightforward.
+
+### Classification: `type:` frontmatter
+
+Chat-session logs carry a `type:` field in their frontmatter as the classification signal:
+
+```yaml
+---
+type: chat-session
+note: "[[v6-architecture]]"
+date: 2026-04-20T14:30
+session_id: <uuid>
+---
+```
+
+The `type:` field is system-assigned and governance-bearing. It is distinct from user-managed `tags:`, which remain the user's authorship surface.
+
+This spec introduces `type:` as the classification mechanism for the chat-session artifact class. It proposes — but does not unilaterally adopt — `type:` as a shared convention for other system-owned artifact classes. The companion-note contract (`docs/CONCEPTS/COMPANION_NOTE_CONTRACT.md`) does not currently declare a `type:` field; adopting `type: companion` there would require a separate owner-doc promotion of the companion-note contract and is explicitly out of scope for this spec. Until that promotion happens, `type:` is a chat-session field only.
+
+### Obsidian integration
+
+The `type: chat-session` field and the `.chats/` namespace together let chat-session artifacts be handled in the user's normal tools:
+
+- Dataview can filter them out of views with `WHERE type != "chat-session"`.
+- Graph view can hide them by tag/type group.
+- Obsidian search can exclude the `.chats/` folder.
+- System retrieval uses `type: chat-session` to distinguish artifact from exhaust.
+
+If `type:` is later adopted by the companion-note contract, the same filters extend to those artifacts without change.
+
+## Retention and Reversibility
+
+### Default retention
+
+Session logs are retained by default. The canvas surface does not create them for transient display and then discard them — the retention is part of the provenance contract.
+
+### Bounded retention
+
+A retention window (duration to be named during implementation) after which old sessions are eligible for soft deletion unless explicitly preserved. The user can pin a session to keep it indefinitely.
+
+### Deletion of a note
+
+When a note is deleted, its session history becomes eligible for the same disposition. The default is that session logs follow the note's lifecycle; explicit preservation overrides this.
+
+### Reversibility at the docs layer
+
+This spec is reversible at the docs layer until the first canvas-Chat co-editing runtime slice is implemented. After that point, changes to the artifact-vs-provenance split or the `.chats/` convention require migration, not just doc edits.
+
+## What This Spec Does Not Do
+
+- Does not describe a runtime implementation. The editor library, the streaming protocol, the Obsidian-vs-standalone location question, and the backend routing are all deferred to the implementation lane.
+- Does not name the retention window duration. That is a policy decision for the retention-policy lane.
+- Does not define the exact session-log schema beyond the minimum fields above (`type`, `note`, `date`, `session_id`, user prompts, change summary).
+- Does not specify the governance-bearing receipt shape. That inherits from Panel's receipts (per `RECONCILE_CHAT_MUTATION_AUTHORITY.md` Decision) and will be named by the canvas-commit capability lane when a cross-note or frontmatter mutation is first implemented.
+- Does not pick the UI primitive (CodeMirror, ProseMirror, or another editor). That is an implementation choice.
+- Does not authorize workspace mode. Workspace mode is named as a future capability and inherits this spec's artifact-vs-provenance split when it ships.
+
+## Why This Matters
+
+Canvas Chat will feel like a collaborative editor to the user. If the authority model is not named before the runtime ships, one of two failure modes is likely:
+
+1. *Over-restriction.* The implementer treats every edit as governance-bearing and adds a pre-approval gate, which reintroduces ASK-shaped turn-taking and defeats the canvas posture.
+2. *Over-permissiveness.* The implementer treats all Chat-originated actions as co-authoring and lets the assistant rewrite frontmatter, move notes, or mutate other notes without governance, which collapses the gated-execution invariant.
+
+Naming the co-authoring/governance-bearing split in docs, before the first runtime slice, makes both failure modes structurally harder.
+
+The `.chats/` and `type:` conventions serve the same purpose for persistence: they prevent session logs from either being lost (no retention) or from polluting the human writing surface (unnamespaced). Either failure would make the vault less trustworthy as a writing environment.
+
+## Acceptance Criteria
+
+- [ ] The spec names direct in-place editing as the canvas posture and explicitly rejects suggest-then-accept as the default interaction.
+- [ ] The spec names exactly two mutation classes (co-authoring, governance-bearing) and gives a scope-based definition of the boundary.
+- [ ] The spec names the one-to-many note↔session relationship and explicitly rejects long-lived per-note chats.
+- [ ] The spec names the note as artifact and the session log as provenance, with the code/commit-message analogy.
+- [ ] The spec names `.chats/<note-slug>/` as the session log location and `type: chat-session` as the classification mechanism.
+- [ ] The spec cites `RECONCILE_CHAT_MUTATION_AUTHORITY.md` §Decision and does not reopen or contradict Candidate A.
+- [ ] The spec cites `STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md` and does not loosen the gated-execution invariant.
+- [ ] The spec names what it does not do (runtime, retention window, exact schema, receipt shape, UI primitive, workspace mode).
+
+## How to Verify (Pre-Merge)
+
+Docs review:
+
+- A reviewer can quote a sentence that says canvas edits apply directly, not through a diff-review gate.
+- A reviewer can quote the scope-based definition of co-authoring vs governance-bearing.
+- A reviewer can state the artifact-vs-provenance distinction and the note↔session cardinality.
+- A reviewer can point to the `.chats/` convention and the `type:` frontmatter field without finding conflicting guidance elsewhere in this directory.
+- A grep for "suggest-then-accept" or "diff-review" returns only rejection language in this file.
+- No part of this spec picks a runtime, UI library, retention window, or hosting location.
+
+## Out of Scope
+
+- Implementing the canvas Chat surface.
+- Choosing an editor primitive or UI framework.
+- Deciding the hosting location (inside Obsidian, standalone web app, other).
+- Naming the retention window duration.
+- Defining the governance-bearing receipt schema.
+- Implementing workspace mode.
+- Modifying the companion-note contract beyond naming the shared `type:` field convention.
+
+## Related Docs
+
+- `docs/INTERACTION_SURFACES_AND_AUTHORITY/RECONCILE_CHAT_MUTATION_AUTHORITY.md` §Decision
+- `docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CHAT_AUTHORITY_BOUNDARY.md` §Chat Authority Boundary
+- `docs/INTERACTION_SURFACES_AND_AUTHORITY/STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md`
+- `docs/INTERACTION_SURFACES_AND_AUTHORITY/NAME_THE_THREE_INTERACTION_SURFACES.md` §The Three Surfaces :: Chat
+- `docs/CONCEPTS/COMPANION_NOTE_CONTRACT.md`
+- `docs/CONCEPTS/USER_NEEDS_MODEL.md` :: externalize and manipulate thought
+- `docs/HUMAN-FLOWS.md` §8 (scenario), §13 (surfaces)
+- `docs/research/CHAT_SURFACE_BUILD_VS_BUY.md` §F, §G (phased path to custom canvas)
+
+## Related GitHub Issues
+
+If later filed, the issue should reference "Implements INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CANVAS_COEDITING_MODEL" and must preserve the co-authoring/governance-bearing split recorded here.
+
+---
+
+**Status:** Specification draft. Extends Candidate A with the concrete co-editing posture and the system-owned chat-session artifact class. Runtime implementation remains out of scope here.

--- a/docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CHAT_AUTHORITY_BOUNDARY.md
+++ b/docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CHAT_AUTHORITY_BOUNDARY.md
@@ -144,16 +144,27 @@ The read-only language in `docs/plans/V60_CAPABILITY_AND_AGENT_EVOLUTION.md` §F
 5. **Chat-originated mutation receipts live in the existing gated-execution pipeline locality.** The concrete canvas-commit receipt shape is deferred to a later capability lane, but the receipt locality is not deferred: receipts live where Panel mutation receipts already live.
 6. **Chat must not reintroduce ASK semantics.** Any future Chat evolution that converts the canvas into a query-response surface would fail the canvas-vs-ASK criterion recorded in `RECONCILE_CHAT_MUTATION_AUTHORITY.md`.
 
+### Co-Authoring vs Governance-Bearing Mutation
+
+Candidate A makes Chat mutation-capable but does not, on its own, say how that mutation expresses itself in a live editing workflow. `DEFINE_CANVAS_COEDITING_MODEL.md` extends the decision with a two-class split:
+
+- **Co-authoring.** Content edits to the body of the currently-open note during an active session. Authorized by user presence (the same authority class as the user's own keystrokes). Rolled back by undo. Audited by the session log. Applied in place, live — not through a pre-commit approval step.
+- **Governance-bearing.** Frontmatter classification changes, cross-note operations, note lifecycle transitions, promotions, and mutations of system-owned artifacts. Flow through the gated-execution pipeline named in `STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md` regardless of user presence — the same locality Panel mutations use, as recorded in Candidate A.
+
+The split is scope-based: co-authoring is "within this note's body, during this session, with the user present." Anything outside that scope is governance-bearing. Ambiguous cases default to governance-bearing.
+
+This extension does not loosen the gated-execution invariant. It recognizes that user-present co-authoring is a distinct mutation class from autonomous system action, and that the invariant applies to the latter.
+
 ### What This Boundary Does Not Say
 
 - The concrete runtime shape for canvas-Chat commits to the vault.
 - Which runtime hosts Chat or whether Chat lives inside or outside Obsidian.
 - Which Deep Agent implementation is introduced in Chat first.
-- The concrete receipt field shape Chat uses when it mutates.
+- The concrete receipt field shape Chat uses when it mutates governance-bearing state.
 - How canvas-Chat integrates with existing Panel flows.
 
-These questions are deferred to later capability work and are out of scope for this task.
+These questions are deferred to later capability work. The co-editing posture and its artifact/provenance conventions are specified in `DEFINE_CANVAS_COEDITING_MODEL.md`.
 
 ---
 
-**Status:** Specification draft. The Chat mutation decision is resolved by `RECONCILE_CHAT_MUTATION_AUTHORITY.md`; runtime implementation remains out of scope here.
+**Status:** Specification draft. The Chat mutation decision is resolved by `RECONCILE_CHAT_MUTATION_AUTHORITY.md`; the co-editing posture extension is in `DEFINE_CANVAS_COEDITING_MODEL.md`; runtime implementation remains out of scope here.

--- a/docs/INTERACTION_SURFACES_AND_AUTHORITY/README.md
+++ b/docs/INTERACTION_SURFACES_AND_AUTHORITY/README.md
@@ -70,6 +70,7 @@ Crucially, "Chat as canvas" is not a revival of the ASK-style question-answering
 5. [DEFINE_AUTOMATION_SURFACE_AUTHORITY.md](DEFINE_AUTOMATION_SURFACE_AUTHORITY.md) — Automation as a distinct authority lane.
 6. [RECONCILE_CHAT_MUTATION_AUTHORITY.md](RECONCILE_CHAT_MUTATION_AUTHORITY.md) — the keystone decision task.
 7. [STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md](STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md) — the invariant that no surface mutates durable state without governance.
+8. [DEFINE_CANVAS_COEDITING_MODEL.md](DEFINE_CANVAS_COEDITING_MODEL.md) — the co-editing posture, co-authoring vs governance-bearing split, note-as-artifact / session-as-provenance, `.chats/` and `type:` conventions.
 
 Tasks 2, 3, 4, 5, and 7 may proceed in parallel as docs drafts. Task 6 (reconcile) depends on tasks 2–5 naming the surfaces consistently and on task 7 stating the gated-execution invariant, because the reconcile task evaluates options against those contracts.
 

--- a/docs/research/CHAT_SURFACE_BUILD_VS_BUY.md
+++ b/docs/research/CHAT_SURFACE_BUILD_VS_BUY.md
@@ -1,0 +1,377 @@
+State: Research analysis — architectural decision brief. Not a roadmap commitment; does not override `docs/ARCHITECTURE.md` or `docs/STATUS.md`. Authored against repo state 2026-04-20.
+Doc role: Research
+Authority: Framing and recommendation for the Chat-surface build-vs-buy question. Binding only if promoted into an ADR or owner-doc edit via a separate lane.
+Owner: `docs/ROADMAP.md` (Interaction Model Evolution)
+Last reviewed: 2026-04-20
+Last verified against: docs/plans/V60_ARCHITECTURE_TARGET.md, docs/plans/V60_CAPABILITY_AND_AGENT_EVOLUTION.md, docs/plans/V60_COGNITIVE_SUPPORT_PRIORITIES.md, docs/plans/COMPANION_NOTE_AND_NOTE_CONTEXT.md, docs/plans/COMPANION_NOTE_AND_AGENT_CONTEXT_PLAN.md, docs/plans/AUTONOMY_AND_SYNC_VALIDATION.md, docs/research/pattern-harvest-agentic-architecture.md, docs/settings/panel-actions.md, docs/INTERACTION_SURFACES_AND_AUTHORITY/** (README, RECONCILE_CHAT_MUTATION_AUTHORITY, DEFINE_CHAT_AUTHORITY_BOUNDARY, DEFINE_CANVAS_COEDITING_MODEL, STATE_EXECUTION_AUTHORITY_REMAINS_GATED)
+
+Downstream companion spec: the concrete co-editing posture, co-authoring vs governance-bearing split, one-to-many note↔session model, `.chats/` file-system convention, and `type:` frontmatter classification for Phase 2 are specified in `docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CANVAS_COEDITING_MODEL.md`. Read that spec for the shape the Phase 2 surface must implement.
+
+# Chat Surface: Build vs Buy vs External Tool
+
+## A. Executive answer
+
+**Phased hybrid, anchored to external agent tooling for now, with a custom thin Chat surface later.**
+
+Concretely:
+
+1. Phase 1 (now): keep using **Claude Code / Codex CLI** as the *builder-and-operator* surface they already are. Do not elevate them to a user-facing Chat surface.
+2. Phase 1 (now, in parallel): continue the v6.0 priority stack — operationalize salience/staleness, finish receipt + SUGGEST/APPLY gating, extract retrieval as a capability (`docs/plans/V60_COGNITIVE_SUPPORT_PRIORITIES.md` Priorities 1, 3, 4). Chat has no home until those land; putting a UI in front of them earlier would harden the wrong semantics.
+3. Phase 2: stand up a **thin, custom canvas-shaped Chat surface** — a UI over the capability contracts, not a new cognition stack. Explicitly reject adopting Open WebUI or LibreChat as the primary Chat surface.
+4. Phase 3: governed canvas-commit path through the same gated-execution pipeline Panel uses.
+
+The justification is architectural, not taste. "Chat" in this system is a *governed-capability-entry-point on top of a canvas-shaped interaction posture*, not a thin LLM frontend. OSS chat UIs are built around a different primitive — model-invocation-as-the-product — and would push the architecture toward exactly the failure mode `DEPRECATE_ASK_AS_ARCHITECTURAL_CENTER.md` names. The v6.0 invariant from `STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md` (LLM reasoning alone never triggers execution) makes the UI layer's job narrow, which in turn makes "build small" cheaper than "adopt-and-constrain large". Governance readiness — receipts, scope/sphere split, retrieval capability — is the gating variable, not UI polish.
+
+## B. Framing
+
+"Chat surface" is doing too much work in casual conversation. This system has at least seven candidate meanings, and the build-vs-buy answer changes by which one you pick:
+
+| Framing | What it implies | Relevant to us? |
+| --- | --- | --- |
+| **Chat-as-Q&A** | ASK-style receive-query → return-answer | **No.** Explicitly rejected by `docs/FINDING_AND_REORIENTING/DEPRECATE_ASK_AS_ARCHITECTURAL_CENTER.md` and by `DEFINE_CHAT_AUTHORITY_BOUNDARY.md` ("Chat is canvas, not ASK"). Any OSS chat UI whose native metaphor is Q&A is a misleading comparison. |
+| **Chat-as-canvas** | Externalize and manipulate thought across existing vault context; state is transient until commit | **Yes — this is the target.** Recorded as Candidate A in `RECONCILE_CHAT_MUTATION_AUTHORITY.md`. |
+| **Chat-as-agent-console** | Operator-side surface for running/inspecting agent workflows | **Partially.** Claude Code and Codex CLI already do this well for builder/operator tasks. Not the user-facing goal. |
+| **Chat-as-orchestration** | Workflow editor / agent graph canvas | **Not here.** Would collapse interaction and orchestration layers — explicitly against `V60_ARCHITECTURE_TARGET.md` operating layers. |
+| **Chat-as-mutation-capable-interface** | Third governed mutation path alongside Panel and Automation | **Phase 3.** Allowed by Candidate A but gated behind receipts and canvas-commit pipeline. |
+| **Chat-as-dev-tool** | Where engineers write code, change settings, run migrations | **Already covered by Claude Code / Codex CLI.** Not the user-facing Chat question. |
+| **Chat-as-thin-LLM-frontend** | "ChatGPT clone for my stack" | **No.** Adopting this framing is the single largest architectural risk: it re-centers the system on model invocation and silently re-enthrones the ASK loop. |
+| **Chat-as-governed-capability-entry-point** | A surface whose commands/thoughts dispatch *capability contracts* (retrieve, rerank, orient, propose, commit), not raw model calls | **Yes — this is the shape.** The UI is thin; capabilities and governance carry the weight. |
+
+The relevant comparisons are therefore: canvas + governed-capability-entry-point. Everything else is a category error in this decision.
+
+A second disambiguation: "build vs buy" is not binary. The real question is *where the seam is*. Three candidate seams:
+
+- **Seam A — UI only**: we build/buy only rendering + input; capability contracts, retrieval, governance, note-writer remain ours.
+- **Seam B — UI + conversation store + RAG**: we adopt an OSS stack's conversation history, thread model, vector/RAG layer, and tool-calling format.
+- **Seam C — UI + cognition**: we adopt an OSS or external stack's entire agent runtime (e.g., use Claude Code as the user-facing surface).
+
+Adopting Seam B or C binds our architecture to a vendor's model of what a chat is. Seam A is the only honest answer for a vault-first, capability-based, governance-gated system. The rest of this document treats Seam A as the live option when it says "buy".
+
+## C. Option analysis
+
+### Option A — Build custom Chat surface (Seam A, thin UI over our capabilities)
+
+**Strengths.**
+- UI maps directly to our capability contracts (`retrieve`, `rerank`, `orient`, `resurface`, `propose`, `commit`); no translation layer.
+- Canvas semantics (externalize / manipulate / optionally-commit) have no off-the-shelf equivalent — they are not the chat primitive OSS tools optimize for.
+- Receipts, scope/sphere, staleness, salience, admission gate render natively. No fighting a host application's assumptions about what "a message" is.
+- Governance-gated mutation path (per `STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md`) is simpler to enforce when we own the commit button.
+- Multi-user-neutral by construction; instance/device/replica provenance can live in the UI's authority model rather than being bolted on.
+
+**Weaknesses.**
+- Real UI work: editor, diff view, commit affordance, receipt rendering, thread/canvas state. Non-trivial even as "thin".
+- Risk of mission creep: every generic chat feature (search, export, branching) is a temptation that doesn't serve cognitive support.
+- Opportunity cost versus shipping the signals underneath (`V60_COGNITIVE_SUPPORT_PRIORITIES.md` Priorities 1–4).
+
+**Architectural fit.** Highest. Interaction is primary (`V60_CAPABILITY_AND_AGENT_EVOLUTION.md` §Fixed Decisions), and a custom surface keeps interaction separate from cognition/execution/governance/memory.
+
+**Near-term fit.** Low. The priorities that would make a Chat surface non-trivially useful have not landed yet.
+
+**Long-term fit.** Highest. Canvas-commit through gated execution is only reachable from a UI we control.
+
+**Key risks.**
+- Building the UI before the capability contracts exist hardens heuristics into durable affordances (`V60_COGNITIVE_SUPPORT_PRIORITIES.md` §Sequencing Principles: "surfaces built on absent signals become heuristics that silently become truth").
+- Temptation to build "a ChatGPT clone, but ours" instead of a canvas.
+
+### Option B — Adopt OSS chat UI (Open WebUI / LibreChat)
+
+**Strengths.**
+- Authentication, conversation history, multi-provider model routing, streaming, RAG wiring are already solved.
+- Tool-calling / MCP plumbing exists (stronger in LibreChat per its docs; present in Open WebUI via Pipelines).
+- Visibly productive demo in days, not weeks.
+
+**Weaknesses.**
+- Both are built around chat-as-Q&A / chat-as-thin-LLM-frontend primitives. Neither is a canvas. Retrofitting canvas semantics onto a thread-of-messages UI is not a feature add — it's a fight with the framework's world model.
+- The "conversation" is the primary persistent artifact. In our architecture, **the vault is**. Adopting a system whose data model centers the chat log silently demotes the vault to "RAG source" and re-introduces the exact failure mode `V60_ARCHITECTURE_TARGET.md` warns against ("v6.0 does not make ... derived runtime DB/index state semantically primary").
+- Authority boundaries are invisible in these UIs. Neither tool has a concept of receipts, SUGGEST/APPLY verbs, scope/sphere, admission, or instance provenance. We would have to ship all of that as either (a) patches/forks or (b) a sidecar backend the UI can't render.
+- **Open WebUI license (v0.6.6+, April 2025): non-OSI, branding-preservation required above a 50-user / 30-day threshold, CLA required for new contributions.** This is decisive for a project whose design principles include human-first governance and long-term architecture reversibility. Sources: [Open WebUI license docs](https://docs.openwebui.com/license/), [HN discussion](https://news.ycombinator.com/item?id=43901575), [BigGo coverage](https://finance.biggo.com/news/202511041923_open-webui-license-change-backlash). For a single-user system this is legally workable, but depending on a project that has relicensed multiple times (Apache → MIT → CC BY-NC-SA → MIT → BSD-3 → custom) is a structural risk, not a compliance footnote.
+- LibreChat remains MIT and has stronger MCP/Agents shape, but the same vault-demotion issue applies.
+
+**Architectural fit.** Low. Adoption collapses the interaction / cognition separation because the tool owns both.
+
+**Near-term fit.** Superficially high (fast demo), actually low (re-centers the architecture wrong).
+
+**Long-term fit.** Low. Reversibility at the docs layer is lost the moment users accumulate conversation history in the adopted tool's store.
+
+**Key risks.**
+- The chat log becomes the de facto source of truth (Red Flag #1 below).
+- Branding lock-in (Open WebUI) or governance boundary drift.
+- "Just use its RAG / tool layer" silently re-introduces ASK semantics.
+
+### Option C — Use external agent/coding tool as the Chat surface (Claude Code / Codex CLI / ChatGPT-Codex)
+
+**Strengths.**
+- Already in use by the builder agents. MCP, hooks, skills, sub-agents, plugins are all first-class. Headless SDK exists (Claude Code Agent SDK; Codex CLI as MCP server) per [Claude Code overview](https://code.claude.com/docs/en/overview) and [Codex MCP docs](https://developers.openai.com/codex/mcp).
+- Operator-grade: diffs, receipts, permissions, allow-lists, sandboxing. These are well-fit to *governance and execution*.
+- Zero UI build cost for the operator surface.
+
+**Weaknesses.**
+- These are **developer/operator surfaces**, not user-facing cognitive-support surfaces. Their primary metaphor is "agent acts on repo" — the repo is the object, and the user is the operator. For our user (a thinker with a vault), that inversion does not hold: the vault is not a repo being acted on, it is a canvas being thought-with.
+- Conflating dev tooling with user-facing interaction is Red Flag #4 below — the inverse failure of Red Flag #1.
+- Vendor lock-in: Claude Code binds to Anthropic subscription / console; Codex CLI binds to a ChatGPT plan or OpenAI API. Both send user thought to a remote service by default. Our stated posture is local-first; this is structurally contrary.
+- No native canvas metaphor. "Plan mode" is close, but the surface still thinks in terms of tasks and diffs, not thought-manipulation.
+- Receipts are coding-shaped (file diffs, PR descriptions), not cognition-shaped (SUGGEST/APPLY, scope-aware proposals).
+
+**Architectural fit.** Low for the *user-facing Chat surface* question. **High** for the *builder/operator* question — which is already the status quo.
+
+**Near-term fit.** Keep as operator surface. Do not promote.
+
+**Long-term fit.** Stays operator-side.
+
+**Key risks.**
+- Accidental scope creep: "Claude Code is our agent UI" would collapse user and operator authority into the same surface.
+- Vendor / license / pricing coupling to Anthropic or OpenAI.
+
+### Option D — Hybrid / phased
+
+**Strengths.**
+- Lets external tooling carry Phase 1 (builder-agent work, operator tasks) while the v6.0 capability contracts that would underpin a real Chat surface are being built.
+- Defers the custom UI build until there are actual capabilities for it to render — which is when the UI is cheap to scope.
+- Keeps the decision reversible at each phase boundary.
+
+**Weaknesses.**
+- Requires discipline to *not* let Phase 1 tooling drift into Phase 2 territory ("we're already typing into Claude Code, let's just put users in there").
+- Two surfaces coexisting (operator CLI + eventual canvas) means the docs must keep the authority lanes sharp.
+
+**Architectural fit.** Highest of the four, because it matches the separation `V60_ARCHITECTURE_TARGET.md` already describes: observation, contract, admission, execution are distinct stages with distinct tooling appropriate to each stage.
+
+**Near-term fit.** High — it's essentially the status quo plus a commitment not to promote the operator surface.
+
+**Long-term fit.** High — ends in Option A (thin custom canvas) with governance-grade signals underneath.
+
+**Key risks.**
+- Indefinite deferral: "we'll build the custom UI later" becoming "we never build it and just keep widening Claude Code's role".
+- Exit criteria for each phase must be explicit and verifiable (see §G).
+
+## D. Tool-by-tool evaluation
+
+Dimensions for each tool: *what it is → self-hostable → extensibility → local-model support → tool calling → custom API → context injection → identity/session → auditability → role separation → suitable as*.
+
+### Open WebUI
+
+- **What it is.** Self-hostable web UI for LLM chat + RAG, originally a ChatGPT-alternative frontend for Ollama. Pipelines, Tools, Functions extensibility. Latest release noted as v0.8.12 (March 2026). ([GitHub](https://github.com/open-webui/open-webui))
+- **Self-hostable.** Yes — Docker / pip / compose / Kustomize / Helm.
+- **Extensibility.** Pipelines framework (Python), native Python Tools, Functions. Mature plugin surface.
+- **Local-model support.** Strong (Ollama-native; any OpenAI-compatible endpoint).
+- **Tool calling.** Yes, via Pipelines; tool-calling in the OpenAI-compatible idiom.
+- **Custom API.** OpenAI-compatible endpoint configurable.
+- **Context injection.** RAG-shaped (vector DB + document upload + web search). Not vault-native.
+- **Identity/session.** RBAC, LDAP/AD, SCIM, SSO, OAuth. Enterprise-capable.
+- **Auditability.** OpenTelemetry traces/metrics/logs. Audit trail is infrastructure-shaped, not governance-shaped.
+- **Role separation.** Admin/user via RBAC.
+- **Critical fact.** License changed April 2025 (v0.6.6+) to non-OSI custom license with branding-preservation clauses and a CLA. Enterprise license required above 50 users / 30 days for white-labeling. ([license docs](https://docs.openwebui.com/license/))
+- **Suitable as.** Operator/admin LLM gateway for teams. **Not suitable** as our user-facing canvas-Chat surface because (a) conversation-centric data model demotes the vault, (b) license volatility, (c) no canvas primitive.
+
+### LibreChat
+
+- **What it is.** MIT-licensed self-hostable multi-provider chat app with Agents, MCP, Code Interpreter, Artifacts, custom endpoints via `librechat.yaml`. ([GitHub](https://github.com/danny-avila/LibreChat), [MCP docs](https://www.librechat.ai/docs/features/mcp))
+- **Self-hostable.** Yes — Docker / Railway / Zeabur / Sealos.
+- **Extensibility.** Custom endpoints, tool/plugin system, Agents marketplace, MCP servers configured via YAML.
+- **Local-model support.** Yes via Ollama and other OpenAI-compatible endpoints.
+- **Tool calling.** Strong. MCP servers with deferred-tool loading and Tool Search.
+- **Custom API.** First-class custom endpoints.
+- **Context injection.** RAG as separate service with Meilisearch + vector hybrid.
+- **Identity/session.** OAuth2, LDAP, email, Azure AD, AWS Cognito. Enterprise-shaped auth.
+- **Auditability.** Recommends comprehensive logging; no built-in receipt/verb contract.
+- **Role separation.** Multi-user with token-spend tracking.
+- **Suitable as.** Strong team chatops / multi-provider gateway. **Not suitable** as our canvas-Chat surface for the same structural reason as Open WebUI: chat-thread is the durable primary, vault would be relegated to RAG source. But MIT + MCP maturity makes it the *least bad* Seam-B fallback if we are ever forced to adopt.
+
+### Claude Code
+
+- **What it is.** Anthropic's terminal / IDE / desktop / web agentic coding tool with MCP, Skills, Plugins, Hooks, Sub-Agents, Agent SDK, headless CLI. ([overview](https://code.claude.com/docs/en/overview))
+- **Self-hostable.** No — model runs via Anthropic API / Bedrock / Vertex / Foundry. The CLI itself runs locally.
+- **Extensibility.** Skills (filesystem), Plugins (public beta since Oct 2025), Hooks, CLAUDE.md, MCP. High for coding and agent workflows.
+- **Local-model support.** No (binds to Claude).
+- **Tool calling.** First-class MCP.
+- **Custom API.** Not a generic hosted API surface; can act as MCP server via Agent SDK.
+- **Context injection.** CLAUDE.md, Skills, auto-memory, MCP.
+- **Identity/session.** Tied to Anthropic account / third-party provider credentials.
+- **Auditability.** Session transcripts; diffs; hook logs. Operator-grade, not governance-grade.
+- **Role separation.** Assumes a developer operator.
+- **Suitable as.** **Builder-agent surface (current use, keep).** Inference: operator surface for running maintenance, doc-authoring, and repo work. **Not suitable** as user-facing canvas because (a) coding-shaped metaphor, (b) vendor/model lock-in contrary to local-first posture, (c) receipts are file-shaped, not cognition-shaped.
+
+### Codex CLI / ChatGPT-Codex
+
+- **What it is.** OpenAI's agentic coding CLI (Apache-2.0), with ChatGPT-account auth preferred, plus a web surface at chatgpt.com/codex. MCP support in CLI and IDE extension; can act as MCP server. ([Codex changelog](https://developers.openai.com/codex/changelog), [MCP](https://developers.openai.com/codex/mcp))
+- **Self-hostable.** CLI is local; model inference is cloud (OpenAI).
+- **Extensibility.** MCP (STDIO / streamable HTTP), slash commands, config.toml.
+- **Local-model support.** No (cloud OpenAI).
+- **Tool calling.** MCP first-class.
+- **Custom API.** Can expose as MCP server.
+- **Context injection.** Agents-style; repo-focused.
+- **Identity/session.** ChatGPT plan / OpenAI API.
+- **Auditability.** Command approval flows; network domain restriction in cloud mode.
+- **Role separation.** Developer operator.
+- **Suitable as.** Alternative to Claude Code in the builder/operator lane. Same verdict: **not a user-facing Chat surface**. Useful as a parallel agent if workload needs redundancy or if a task benefits from a different model lineage.
+
+### Brief notes on other contenders (one-line each)
+
+- **AnythingLLM** — MIT, workspace-centric ("documents-plus-chat"); closer to "PKM chat" than Open WebUI, but workspace model still centers the conversation, and its agent framework is its own — adopting means adopting their agent metaphor.
+- **Msty** — Offline-first desktop app with knowledge stacks, chat branching; polished but closed-ish; not extensible enough to host our capability contracts.
+- **Jan** — Open-source local-first desktop LLM client; too consumer-shaped, not a platform.
+- **Cherry Studio** — Multi-model desktop client; same category as Msty/Jan.
+- **Continue** — IDE-integrated coding assistant; same category as Claude Code/Codex for our purposes.
+- **Big-AGI** — Open-source chat UI; same conversation-as-primary issue as Open WebUI.
+- **assistant-ui** / **Vercel AI SDK UI kits** — React component libraries (inferred: MIT). If we ever build custom Chat, these are the right-sized building blocks for Seam A, not competitors to it. They are UI primitives, not chat applications.
+
+The practical implication of the brief survey: there is no OSS chat app whose data model puts the vault first. There is a category of UI-kit libraries (assistant-ui, Vercel AI SDK UI) that could accelerate a custom build.
+
+## E. Comparison matrix
+
+Scale: **H** = high / strong fit, **M** = medium / partial fit, **L** = low / weak fit. "Fit" means fit to *our* stated architecture, not general quality.
+
+| Option / tool | Arch. fit | Governance fit | OSS / local-first fit | Extensibility | Integration complexity | Time to value | Long-term maintainability | UX fit (canvas) | Observability / audit | Mutation safety |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **A. Build custom (thin canvas)** | H | H | H | H | M (we own it) | L (months) | H | H | H (we define) | H |
+| **B. Adopt OSS chat UI (generic)** | L | L | M | H | M-H (fork/patch) | H | L | L | M | L |
+| **C. External agent tool as Chat** | L (user-facing) / H (operator) | M (operator only) | L (cloud model) | H | L (status quo) | H | M | L | M (operator-shaped) | M |
+| **D. Hybrid / phased** | H | H | H | H | M | M | H | H (phase 2+) | H | H |
+| Open WebUI | L | L | L (non-OSI since v0.6.6) | H | M | H | L (license volatility) | L | M | L |
+| LibreChat | L | L | M (MIT) | H | M | H | M | L | M | L |
+| Claude Code | L (user) / H (operator) | M (operator) | L (cloud model) | H | L | H | M | L | M | M |
+| Codex CLI | L (user) / H (operator) | M (operator) | L (cloud model) | H | L | H | M | L | M | M |
+| AnythingLLM | L-M | L | M (MIT) | M | M | H | M | L-M | L-M | L |
+| assistant-ui / Vercel AI SDK UI | n/a (building block) | n/a | H (inferred MIT) | H | M | M | H | H (when used in A) | n/a | n/a |
+
+## F. Recommended path
+
+**Do now (Phase 1).**
+
+1. **Keep Claude Code / Codex CLI as builder-agent and operator surfaces.** Do not promote them. They carry the Phase 1 load correctly. (Principle: interaction / cognition / execution / memory / governance are separate subsystems — `V60_ARCHITECTURE_TARGET.md`.)
+2. **Finish the signal layer before any UI move.** Priorities 1 (salience/staleness), 3 (receipts + SUGGEST/APPLY), and 4 (retrieval as capability) from `V60_COGNITIVE_SUPPORT_PRIORITIES.md`. (Principle: signal before surface.)
+3. **Do not adopt Open WebUI.** License trajectory (non-OSI, branding clauses, CLA, enterprise gating) is structurally incompatible with a long-lived, vault-first, single-user-now-but-reversible system.
+4. **Do not adopt LibreChat as the primary Chat surface.** MIT is fine, MCP is good, but its data model centers the conversation — which silently demotes the vault. (Principle: vault is canonical human writing/reading surface — `V60_ARCHITECTURE_TARGET.md` operating layers.)
+5. **Keep the Panel proposal surface as the live mutation-capable interaction baseline.** Do not widen it into Chat work (`docs/plans/AUTONOMY_AND_SYNC_VALIDATION.md`).
+
+**Do not do now.**
+
+- Do not stand up *any* persistent user-facing chat UI. Not a forked OSS app, not a custom prototype, not Obsidian plugin UI. A Chat surface without receipts is architecturally unsafe.
+- Do not let Claude Code / Codex become the end-user's primary surface by default. It is a builder surface for this project and must stay that way.
+- Do not wire vault into an OSS chat app's RAG layer "to evaluate". That evaluation is the thing that silently demotes the vault.
+
+**Revisit later.**
+
+- When Priorities 1, 3, 4 have landed: reopen Phase 2 (build thin custom Chat).
+- When the first canvas-commit receipt shape is specified: reopen Phase 3 (governed Chat mutation).
+- If Anthropic or OpenAI change auth / pricing / data-retention policies unfavorably: reopen Phase 1 (builder surface choice), fall back to the other.
+- If a new OSS project emerges whose primitive is *canvas*, not *chat-thread*, re-evaluate Option B with honest criteria.
+
+Justification references by principle:
+
+| Recommendation | Principle invoked |
+| --- | --- |
+| No chat UI before signals | `V60_COGNITIVE_SUPPORT_PRIORITIES.md` §Sequencing Principles |
+| Thin custom UI in Phase 2 | `DEFINE_CHAT_AUTHORITY_BOUNDARY.md` "Chat is canvas, not ASK" |
+| Keep external tools as operator-only | `V60_CAPABILITY_AND_AGENT_EVOLUTION.md` §System-of-systems framing |
+| Reject Open WebUI | OSS / local-first posture in `V60_ARCHITECTURE_TARGET.md`; reversibility principle in `RECONCILE_CHAT_MUTATION_AUTHORITY.md` |
+| Receipts before Chat mutation | `STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md` |
+
+## G. Suggested phased strategy
+
+### Phase 1 — Months 1–3: keep the status quo, finish the signal layer
+
+**Surfaces used.**
+- **Vault (Obsidian)** — primary human writing/reading surface. Unchanged.
+- **Panel** — primary mutation-capable interaction surface with low-risk autonomy proposals (already delivered per `AUTONOMY_AND_SYNC_VALIDATION.md`).
+- **Claude Code / Codex CLI** — builder/operator surface for engineering work.
+- **No user-facing Chat surface.**
+
+**What's governed.** Panel mutation path (existing). Watcher policy. Companion-note ingest.
+**What's exploratory.** Claude Code / Codex sessions, as operator side-channels.
+**Exit criterion to Phase 2.**
+- `V60_COGNITIVE_SUPPORT_PRIORITIES.md` Priorities 1, 3, and 4 shipped (or at minimum: receipt artifact fields defined + retrieval capability contract defined).
+- A receipt shape exists that Chat-originated mutations *could* pass through without redesigning it.
+- One end-to-end Panel proposal flow produces a receipt that the owner-doc describes as the canonical example.
+
+### Phase 2 — Months 3–6: thin custom canvas Chat (read-only, Deep-Agent-hosting)
+
+**Surfaces used.**
+- Vault, Panel as Phase 1.
+- **New: a custom canvas Chat surface.** Location decision (inside/outside Obsidian) is deferred per `RECONCILE_CHAT_MUTATION_AUTHORITY.md`.
+- Thin UI built on UI primitives (assistant-ui or Vercel AI SDK UI kits; final choice at Phase-2 start).
+- Binds to capability contracts (retrieve, rerank, orient, resurface, propose). Does *not* mutate durable state.
+- Hosts the first Deep Agent rollout in **read-only mode** (`V60_CAPABILITY_AND_AGENT_EVOLUTION.md` §Deep Agents start in Chat before Panel).
+
+**What's governed.** Retrieval capability inputs/outputs; salience/staleness flags are surfaced; conversation transcript is transient, not durable.
+**What's exploratory.** Canvas interaction model (how drafts/arrangements/annotations behave visually); salience-driven resurfacing surface.
+**Exit criterion to Phase 3.**
+- A canvas-commit proposal shape exists on paper, with a receipt target, scoped to the Priority 3 gating verbs.
+- One Deep Agent has completed a read-only slice with acceptance receipts.
+- The canvas-vs-ASK distinction remains verifiable: nothing in the UI rewards turn-based Q&A over thought-manipulation.
+
+### Phase 3 — Months 6–18: governed canvas-commit
+
+**Surfaces used.**
+- Vault, Panel, Chat (now mutation-capable through the gated-execution pipeline).
+
+**What's governed.** Canvas-commit actions flow through the same policy + validation + event pipeline Panel uses. No separate Chat receipt store. ("Receipts live where Panel mutation receipts already live." — `RECONCILE_CHAT_MUTATION_AUTHORITY.md` §Decision.)
+**What's exploratory.** Richer Deep Agent cognition in Chat; selective cognition in Panel planning (`V60_CAPABILITY_AND_AGENT_EVOLUTION.md` Phase 3).
+**Exit criterion.** Reversibility budget: if within one-to-two releases canvas-commit cannot be made to satisfy `STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md` *and* Governance Before Autonomy simultaneously, Phase 3 is rolled back at the docs layer. (Per `RECONCILE_CHAT_MUTATION_AUTHORITY.md` §Re-evaluation trigger.)
+
+## H. Decision criteria
+
+The choice is driven by the following hard criteria, in order. If a criterion fails, the choice must be revisited.
+
+1. **Vault stays canonical.** Any option whose data model centers the conversation (Open WebUI, LibreChat, generic OSS chat UIs) fails. The vault must remain the primary durable artifact. If we can't state "the chat log is not where meaning lives" in one sentence, the option is wrong.
+2. **Governance must be expressible in the surface.** Receipts, SUGGEST/APPLY verbs, scope/sphere, admission must be representable. Surfaces that cannot render these fail. This rules out all OSS chat apps at the user-facing layer.
+3. **LLM reasoning alone never triggers execution.** The surface must not allow a model-decided mutation that bypasses the gated pipeline. External agent tools (Claude Code, Codex) *can* bypass it when given shell access — which is why they are operator surfaces, not user surfaces.
+4. **Local-first and license-stable.** Surfaces whose licenses have shifted multiple times (Open WebUI) or whose inference requires a specific cloud vendor (Claude Code, Codex) fail this criterion for the user-facing role. They are acceptable for the *builder* role because builders can accept vendor coupling that users should not be forced into.
+5. **Reversible at the docs layer until first commit.** If canvas-Chat cannot be rolled back without unwinding shipped code, stop. This is the `RECONCILE_CHAT_MUTATION_AUTHORITY.md` re-evaluation trigger.
+6. **Cognitive-support fit, not chatbot fit.** The surface should help the user externalize and manipulate thought (USER_NEEDS_MODEL Need #3, #4, #5). A surface optimized for "answer my question" fails this criterion, regardless of how nice its UX is.
+7. **Hard fallbacks.**
+   - If Claude Code changes license / pricing / data policy unfavorably → fall back to Codex CLI as operator surface, and vice versa.
+   - If Open WebUI's license drifts further → not a fallback candidate at all (was already rejected).
+   - If LibreChat changes license → drop from the Seam-B fallback list.
+   - If we cannot ship receipts by Phase-2 start → Phase 2 does not start. Build no UI until the gate exists.
+
+## I. Red flags
+
+These are the high-probability failure modes for this decision. Most of them look reasonable in the moment.
+
+1. **The chat tool becomes the semantic center.** The highest-severity failure. An OSS chat UI is adopted "just for the interface"; users start treating the conversation history as memory; the vault becomes RAG source material; the entire cognitive-prosthetic framing inverts. Triggering condition to watch: anyone says "we can use the chat logs as context for the next thing" without flinching.
+2. **Bypassing governance through "temporary" integrations.** An external tool is given direct write access to the vault for a demo; the demo ships; the governance path is quietly skipped. `STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md` exists precisely to forbid this. Triggering condition: any PR that wires an LLM response into a file-write without passing through the admission pipeline.
+3. **Building a large custom UI too early.** The custom surface ships before the signals (salience, staleness, scope, receipt) exist. The UI then hardens the wrong semantics (cf. `V60_COGNITIVE_SUPPORT_PRIORITIES.md` §Sequencing Principles). Triggering condition: a Chat UI PR that predates the receipt-artifact PR.
+4. **Conflating dev tooling with user-facing interaction surface.** Claude Code or Codex silently becomes "the chat" because we're already living in it. The operator metaphor takes over the user metaphor. Triggering condition: the user-facing docs start mentioning CLI commands or shell-like semantics as normal cognitive interaction.
+5. **ASK semantics re-introduced under a new name.** Canvas becomes query-and-response over time because query-and-response is easier to build. Explicitly guarded against in `DEFINE_CHAT_AUTHORITY_BOUNDARY.md`. Triggering condition: the primary verb in the Chat UI is "send" rather than something like "lay down / arrange / commit".
+6. **License ratchet in the UI substrate.** Adopting an OSS UI whose license trajectory has included relicensing moves (Open WebUI: Apache → MIT → CC BY-NC-SA → MIT → BSD-3 → custom-non-OSI). Even if today's license is usable, the ratchet risk alone is architecturally disqualifying for a multi-year project.
+7. **Vault demotion via "RAG plumbing".** Wiring vault notes through a vector-DB-centric RAG layer provided by a chat app makes the app's retrieval path authoritative and hides retrieval-as-capability behind a vendor's framing. This is the same failure as #1, one layer down.
+8. **Instance/replica assumptions baked into a borrowed UI.** OSS chat apps assume a single-server truth. Our v6.0 stance explicitly models multi-device/replica posture as normal (`V60_ARCHITECTURE_TARGET.md` §Multi-device / replica migration). A borrowed UI will silently foreclose this.
+9. **"Let's just prototype it in Open WebUI."** Even a throwaway prototype creates conversation history that users rely on; removing it later is politically expensive. Prototyping on a structurally wrong surface produces structurally wrong feedback.
+10. **Forgetting that Panel is not Chat.** Panel is command-oriented with in-note receipts; Chat is canvas-shaped with pipeline-local receipts. Merging them "to simplify" collapses two different authority lanes.
+
+---
+
+## Sources
+
+Internal (repo):
+- `docs/plans/V60_ARCHITECTURE_TARGET.md`
+- `docs/plans/V60_CAPABILITY_AND_AGENT_EVOLUTION.md`
+- `docs/plans/V60_COGNITIVE_SUPPORT_PRIORITIES.md`
+- `docs/plans/COMPANION_NOTE_AND_NOTE_CONTEXT.md`
+- `docs/plans/COMPANION_NOTE_AND_AGENT_CONTEXT_PLAN.md`
+- `docs/plans/AUTONOMY_AND_SYNC_VALIDATION.md`
+- `docs/research/pattern-harvest-agentic-architecture.md`
+- `docs/settings/panel-actions.md`
+- `docs/INTERACTION_SURFACES_AND_AUTHORITY/README.md`
+- `docs/INTERACTION_SURFACES_AND_AUTHORITY/RECONCILE_CHAT_MUTATION_AUTHORITY.md` (Decision: Candidate A, 2026-04-11)
+- `docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CHAT_AUTHORITY_BOUNDARY.md`
+- `docs/INTERACTION_SURFACES_AND_AUTHORITY/STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md`
+
+External (verified):
+- Open WebUI repository: https://github.com/open-webui/open-webui
+- Open WebUI license (v0.6.6+, non-OSI, branding clause, CLA): https://docs.openwebui.com/license/
+- Open WebUI license-change community discussion: https://news.ycombinator.com/item?id=43901575
+- Open WebUI license-change coverage: https://finance.biggo.com/news/202511041923_open-webui-license-change-backlash
+- LibreChat repository (MIT): https://github.com/danny-avila/LibreChat
+- LibreChat MCP docs: https://www.librechat.ai/docs/features/mcp
+- LibreChat Agents docs: https://www.librechat.ai/docs/features/agents
+- LibreChat custom endpoints: https://www.librechat.ai/docs/configuration/librechat_yaml
+- Claude Code overview: https://code.claude.com/docs/en/overview
+- Claude Code Agent SDK: https://platform.claude.com/docs/en/agent-sdk/overview
+- Claude Code Skills: https://code.claude.com/docs/en/skills
+- OpenAI Codex CLI changelog: https://developers.openai.com/codex/changelog
+- OpenAI Codex MCP: https://developers.openai.com/codex/mcp
+- OpenAI Codex CLI: https://developers.openai.com/codex/cli
+- Comparison surveys consulted (not authoritative): https://portkey.ai/blog/librechat-vs-openwebui/, https://blog.elest.io/the-best-open-source-chatgpt-interfaces-lobechat-vs-open-webui-vs-librechat/, https://www.helicone.ai/blog/open-webui-alternatives
+
+Inferences explicitly marked in the text include: Open WebUI v0.8.12 release date (per README excerpt, March 2026, not independently re-verified); assistant-ui / Vercel AI SDK UI kits license (stated as "inferred MIT"); LibreChat audit-log specifics (search results summarized the feature area but did not produce a fielded spec — treated as "recommended by community, not fielded").


### PR DESCRIPTION
- [x] Docs authoring lane

## Summary

Specifies the canvas-Chat co-editing model (INTERACTION-07) and records the build-vs-buy research that informed it. Captures the user's resolved intent from the 2026-04-20 design conversation so future work has an authoritative reference.

## Changes

**New specs:**
- `docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CANVAS_COEDITING_MODEL.md` — new task spec (INTERACTION-07) covering:
  - Direct in-place editing posture (not suggest-then-accept), grounded in the user's explicit request
  - Authority split: **co-authoring** (content edits under presence-as-authorization) vs **governance-bearing mutation** (frontmatter / cross-note / lifecycle through the gated pipeline, preserving Candidate A)
  - Note↔session relationship: one-to-many; note is the valuable artifact, session is provenance (code-vs-commit-message analogy)
  - File-system convention: `.chats/<note-slug>/<timestamp>-<label>.md` with bounded retention
  - Classification: `type: chat-session` as system-assigned frontmatter, distinct from user `tags:`; companion-note `type:` adoption explicitly out of scope for this spec
- `docs/research/CHAT_SURFACE_BUILD_VS_BUY.md` — build-vs-buy research report (phased hybrid recommendation; OSS surface evaluation incl. Open WebUI relicense risk)

**Updates:**
- `docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CHAT_AUTHORITY_BOUNDARY.md` — new §Co-Authoring vs Governance-Bearing Mutation subsection pointing to INTERACTION-07
- `docs/INTERACTION_SURFACES_AND_AUTHORITY/README.md` — new reading-order entry for INTERACTION-07
- `docs/HUMAN-FLOWS.md` — new §8 flow (\"think on a note with a writing partner\"), extended §13 Panel↔Chat interaction, new §14 emerging-surface entry, refreshed \"Last verified against\" anchor

## Validation

- Subagent review pass flagged `type: companion` overreach; spec reworded to scope `type:` to chat-session only
- Cross-doc references resolve (README reading-order, DEFINE_CHAT_AUTHORITY_BOUNDARY back-link, HUMAN-FLOWS anchors)
- Rebased on latest `origin/main` (17eef96 / #527) cleanly
- No runtime code touched; no owner-doc (DESIGN_PRINCIPLES / V60 plan / ROADMAP / PANEL_AGENT) edits — promotion deferred to post-merge-owner-doc

## Scope boundaries

Does not implement Chat, does not change Panel runtime, does not propose companion-note `type:` adoption (that needs a separate owner-doc promotion), does not create GitHub issues.

---