### PR TITLE
Add event envelope and outbox consumer contracts

### DIFF
--- a/app/events/schema.py
+++ b/app/events/schema.py
@@ -11,6 +11,10 @@ def _now_iso() -> str:
     return datetime.now(tz=timezone.utc).isoformat().replace("+00:00", "Z")
 
 
+def _default_meta() -> Dict[str, Any]:
+    return {"version": "1.0"}
+
+
 class OutboxEvent(BaseModel):
     """Canonical outbox event envelope."""
 
@@ -22,7 +26,7 @@ class OutboxEvent(BaseModel):
     source: str
     timestamp: str = Field(default_factory=_now_iso)
     payload: Dict[str, Any] = Field(default_factory=dict)
-    meta: Dict[str, Any] = Field(default_factory=dict)
+    meta: Dict[str, Any] = Field(default_factory=_default_meta)
 
     @property
     def event_type(self) -> str:
@@ -45,7 +49,7 @@ def make_outbox_event(
         source=source,
         timestamp=timestamp or _now_iso(),
         payload=payload or {},
-        meta=meta or {},
+        meta=meta or _default_meta(),
     )
 
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,7 +154,10 @@ Connector/Watcher/Inbox decisions (architecture alternatives, watcher matrix, in
 
 ## Component Catalog
 - See `docs/COMPONENTS.md` for the canonical, human- and machine-readable list of active components (stores, agents, embeddings, rerankers, eval stack, observability). Update it when wiring new component entrypoints under `app/components/*`.
-- The outbox/event system uses a common envelope (`event`, `trace_id`, `source`, `timestamp`, `payload`, `meta`) defined in `app/events/schema.py` and enforced by architecture tests; emitters should write via outbox helpers to preserve the contract.
+- The outbox/event system uses a common envelope (`event`, `event_id`, `trace_id`, `source`,
+  `timestamp`, `payload`, `meta`, and version metadata for new/changed families) defined in
+  `app/events/schema.py` and enforced by architecture tests; emitters should write via outbox
+  helpers to preserve the contract.
 
 ## System-of-systems view
 

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -44,6 +44,12 @@ Notes:
 
 - Producers MAY add additional top-level fields for compatibility or convenience; consumers MUST ignore unknown fields (see `docs/CONCEPTS/EVENT_COMPATIBILITY_CONTRACT.md`).
 - Some producers emit a richer `source` object (e.g. `{component, trigger, sot}`) instead of a string, especially for watcher/panel runtime events. Consumers MUST support both shapes and degrade safely by extracting a string attribution (typically `source.component`) when present. New event producers should prefer a string unless the `component/trigger/sot` trio is required for auditability.
+- New or changed event families MUST keep envelope versioning explicit. The active envelope version is
+  carried by `version` when a typed event model exposes it, or by `meta.version` for generic
+  `OutboxEvent` emitters. Compatibility-only legacy events may omit version only when the owning
+  compatibility contract documents the exception.
+- Representative CI coverage must include watcher, panel/promotion, orchestrator, and MCP/tool event
+  families so envelope regressions fail before runtime rollout.
 
 ## Event Idempotency (normative)
 
@@ -53,6 +59,26 @@ Notes:
 - `watcher.run` and watcher auto-exec events MUST be deduplicated to prevent duplicate panel intents or promotions.
 
 See `docs/CONCURRENCY.md` for the broader concurrency and idempotency guardrails.
+
+## Outbox consumer contract
+
+The DB outbox is the canonical worker queue. JSONL event files are audit/diagnostic surfaces unless
+an explicitly configured file-backed worker queue says otherwise.
+
+Current consumer expectations:
+
+- Ordering is FIFO by `created_at` for undelivered DB rows.
+- Delivery completion is recorded by `delivered_at`; rows without `delivered_at` remain pending.
+- Worker handlers propagate `trace_id` from the event envelope or payload into downstream spans and
+  emitted retry events.
+- Consumer idempotency is keyed by `event_id`; duplicate event ids are skipped without replaying
+  mutation work.
+- Transient note-read failures in ingest and panel-scan handlers are requeued with
+  `_worker_retry_count`, `_worker_retry_reason`, and `_worker_retry_enqueued_at` metadata up to the
+  bounded retry limit.
+- There is no dedicated DLQ service in the active runtime. When retry enqueueing fails or retry
+  attempts are exhausted, the worker logs the failure and leaves the condition observable through
+  worker logs, status/heartbeat signals, and the undelivered DB outbox row.
 
 ## Embeddings and Outbox
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -39,6 +39,10 @@ Logs are the primary tracing surface; no external APM is required for the curren
 - Canonical compose stack: `db`, `api`, `watcher`, `worker` (registry watcher).
 - The watcher writes audit JSONL events and enqueues DB outbox events; the worker consumes the DB outbox for ingest and promotion side effects.
 - Treat `events_log` as append-only audit and `worker_queue` as the live queue; do not derive pending across them unless `worker_queue.mode` is `file`/`jsonl` and explicitly wired.
+- Retry/poison-message posture is current-state and bounded: transient missing or unstable note
+  failures are requeued with retry metadata, duplicate `event_id` values are skipped, and exhausted
+  or failed retry enqueue paths are observable through worker logs plus undelivered DB outbox rows.
+  The active runtime does not claim a dedicated DLQ service.
 
 Architectural reading note:
 - these monitoring and queue interpretations are current operational truth,

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -223,6 +223,24 @@ Task-specific operator walkthroughs live in `docs/runbooks/`.
 - Settings gate view: `python -m app.cli settings-explain --json` is the canonical provenance and gate-resolution surface for watcher auto-exec, allowlist validity, and write guard context.
 - Health command semantics and degradation rules live in `docs/HEALTH.md`.
 
+## Event and queue troubleshooting
+- Use the DB `outbox` table as the authoritative queue. Rows with `delivered_at is null` are pending
+  or failed work; order them by `created_at` when reconstructing worker consumption order.
+- Inspect the worker logs for `worker retry queued`, `worker retry exhausted`, `worker retry enqueue
+  failed`, and `worker handler failed` messages. These are the current poison-message and retry
+  observation points; there is no separate DLQ service in the active runtime.
+- Promotion consumer failures should also surface as `promote.error` rows in the DB outbox or
+  JSONL audit stream, with `source_event` and `trace_id` intact so the failed intent can be traced
+  back to the originating input.
+- Retry events carry `_worker_retry_count`, `_worker_retry_reason`, and
+  `_worker_retry_enqueued_at` in the payload so operators can distinguish transient deferrals from
+  fresh work.
+- Use `event_id` to identify duplicate deliveries and `trace_id` to correlate watcher, worker,
+  panel, promotion, and status/audit observations.
+- Treat `INDEX_OUTBOX_PATH` JSONL lines as audit evidence only. A line in JSONL does not prove a DB
+  outbox row is pending, delivered, or failed, and `python -m app.cli status` keeps
+  `events_log` separate from `worker_queue` for that reason.
+
 Operator triage order:
 1. Run `make verify-runtime`.
 2. If you need extra detail, run `docker compose exec -T api python -m app.cli health --json`.

--- a/tests/events/test_event_envelope_versioning.py
+++ b/tests/events/test_event_envelope_versioning.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from app.events.panel import NoteRef, PanelInfo, PanelIntentAction, PanelIntentEvent, PanelIntentPayload
+from app.events.schema import make_outbox_event
+from app.events.types import MCP_TOOL_CALL_STARTED, ORCHESTRATOR_STEP_STARTED, PROMOTE_INTENT_CREATED
+from app.watcher.events import build_watcher_run_event
+
+
+def _parse_ts(ts: str) -> None:
+    try:
+        datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except Exception as exc:  # pragma: no cover - assertion message matters more than branch coverage
+        raise AssertionError(f"timestamp is not ISO-8601: {ts}") from exc
+
+
+def _assert_versioned_envelope(record: dict[str, object]) -> None:
+    assert isinstance(record.get("event"), str) and record["event"], "event must be non-empty string"
+    assert isinstance(record.get("version"), str) and record["version"] == "1.0", "version must be 1.0"
+    assert isinstance(record.get("event_id"), str) and record["event_id"], "event_id must be non-empty string"
+    assert isinstance(record.get("trace_id"), str) and record["trace_id"], "trace_id must be non-empty string"
+    source = record.get("source")
+    assert isinstance(source, dict), "source must be a dict for versioned events"
+    assert isinstance(source.get("component"), str) and source["component"], "source.component must be set"
+    assert isinstance(record.get("payload"), dict), "payload must be a dict"
+    _parse_ts(str(record.get("timestamp") or ""))
+
+
+def _assert_outbox_envelope(record: dict[str, object]) -> None:
+    assert isinstance(record.get("event"), str) and record["event"], "event must be non-empty string"
+    assert isinstance(record.get("event_id"), str) and record["event_id"], "event_id must be non-empty string"
+    assert isinstance(record.get("trace_id"), str) and record["trace_id"], "trace_id must be non-empty string"
+    source = record.get("source")
+    if isinstance(source, dict):
+        assert isinstance(source.get("component"), str) and source["component"], "source.component must be set"
+    else:
+        assert isinstance(source, str) and source, "source must be non-empty string"
+    assert isinstance(record.get("payload"), dict), "payload must be a dict"
+    assert isinstance(record.get("meta"), dict), "meta must be a dict"
+    _parse_ts(str(record.get("timestamp") or ""))
+
+
+def _watcher_record(tmp_path: Path) -> dict[str, object]:
+    return build_watcher_run_event(
+        {
+            "changed": 1,
+            "ingest_attempted": 1,
+            "ingested": 1,
+            "panel_candidates": 1,
+            "panel_runs": 1,
+            "panel_promotions": 1,
+            "panel_skipped_policy": 0,
+            "panel_skipped_limit": 0,
+            "panel_skipped_auto_exec": 0,
+            "panel_skipped_allowed_actions": 0,
+            "skipped_dedup": 0,
+            "skipped_idempotent": 0,
+            "skipped_writes_blocked": 0,
+            "errors": 0,
+            "dry_run": False,
+            "limit_exceeded": False,
+            "snapshot_path": "tmp/snapshot.json",
+        },
+        vault_root=tmp_path,
+        snapshot_path="tmp/snapshot.json",
+        trigger="test",
+        trace_id="trace-watcher",
+    ).model_dump(mode="json")
+
+
+def _panel_record() -> dict[str, object]:
+    panel_note = NoteRef(uuid="note-1", path="vault/Note.md", origin="vault")
+    panel = PanelInfo(panel_id="panel-1", instruction="Do the thing.", raw_block=None)
+    panel_action = PanelIntentAction(id="promote.evergreen", label="Promote", checked=True, mapping=None)
+    return PanelIntentEvent(
+        payload=PanelIntentPayload(note=panel_note, panel=panel, actions=[panel_action]),
+        trace_id="trace-panel",
+    ).model_dump(mode="json")
+
+
+def _outbox_record(event_name: str, *, source: str, trace_id: str, payload: dict[str, object]) -> dict[str, object]:
+    return make_outbox_event(event_name, source=source, trace_id=trace_id, payload=payload).model_dump(mode="json")
+
+
+def test_representative_events_include_version_trace_and_idempotency_fields(tmp_path: Path) -> None:
+    watcher_record = _watcher_record(tmp_path)
+    _assert_versioned_envelope(watcher_record)
+
+    missing_version = dict(watcher_record)
+    missing_version.pop("version", None)
+    with pytest.raises(AssertionError, match="version"):
+        _assert_versioned_envelope(missing_version)
+
+    missing_event_id = dict(watcher_record)
+    missing_event_id.pop("event_id", None)
+    with pytest.raises(AssertionError, match="event_id"):
+        _assert_versioned_envelope(missing_event_id)
+
+    missing_trace_id = dict(watcher_record)
+    missing_trace_id.pop("trace_id", None)
+    with pytest.raises(AssertionError, match="trace_id"):
+        _assert_versioned_envelope(missing_trace_id)
+
+
+def test_existing_event_families_pass_envelope_lint(tmp_path: Path) -> None:
+    records = [
+        _watcher_record(tmp_path),
+        _panel_record(),
+        _outbox_record(
+            PROMOTE_INTENT_CREATED,
+            source="panel_agent.runtime",
+            trace_id="trace-promote",
+            payload={
+                "note": {"uuid": "note-1", "path": "vault/Note.md"},
+                "panel": {"panel_id": "panel-1", "instruction": "Do the thing."},
+                "action": {"id": "promote.evergreen", "label": "Promote"},
+                "instruction": "Do the thing.",
+            },
+        ),
+        _outbox_record(
+            ORCHESTRATOR_STEP_STARTED,
+            source="orchestrator.runtime",
+            trace_id="trace-orchestrator",
+            payload={"plan_id": "plan-1", "step_id": "step-1"},
+        ),
+        _outbox_record(
+            MCP_TOOL_CALL_STARTED,
+            source="orchestrator.runtime",
+            trace_id="trace-mcp-tool",
+            payload={"plan_id": "plan-1", "step_id": "step-1", "tool": "mcp.vault.append_note"},
+        ),
+    ]
+
+    for record in records:
+        if "version" in record:
+            _assert_versioned_envelope(record)
+        else:
+            _assert_outbox_envelope(record)
+

--- a/tests/events/test_event_envelope_versioning.py
+++ b/tests/events/test_event_envelope_versioning.py
@@ -40,7 +40,9 @@ def _assert_outbox_envelope(record: dict[str, object]) -> None:
     else:
         assert isinstance(source, str) and source, "source must be non-empty string"
     assert isinstance(record.get("payload"), dict), "payload must be a dict"
-    assert isinstance(record.get("meta"), dict), "meta must be a dict"
+    meta = record.get("meta")
+    assert isinstance(meta, dict), "meta must be a dict"
+    assert meta.get("version") == "1.0", "meta.version must be 1.0"
     _parse_ts(str(record.get("timestamp") or ""))
 
 
@@ -105,6 +107,19 @@ def test_representative_events_include_version_trace_and_idempotency_fields(tmp_
     with pytest.raises(AssertionError, match="trace_id"):
         _assert_versioned_envelope(missing_trace_id)
 
+    outbox_record = _outbox_record(
+        ORCHESTRATOR_STEP_STARTED,
+        source="orchestrator.runtime",
+        trace_id="trace-orchestrator",
+        payload={"plan_id": "plan-1", "step_id": "step-1"},
+    )
+    _assert_outbox_envelope(outbox_record)
+
+    missing_meta_version = dict(outbox_record)
+    missing_meta_version["meta"] = {}
+    with pytest.raises(AssertionError, match="meta.version"):
+        _assert_outbox_envelope(missing_meta_version)
+
 
 def test_existing_event_families_pass_envelope_lint(tmp_path: Path) -> None:
     records = [
@@ -140,4 +155,3 @@ def test_existing_event_families_pass_envelope_lint(tmp_path: Path) -> None:
             _assert_versioned_envelope(record)
         else:
             _assert_outbox_envelope(record)
-

--- a/tests/events/test_outbox_consumer_contract.py
+++ b/tests/events/test_outbox_consumer_contract.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from app.events.types import PROMOTE_DONE, PROMOTE_ERROR, PROMOTE_INTENT_CREATED
+from app.observability import status_service
+from app.promotion.consumer import consume_promotion_intents, reset_promotion_dedup_store
+from app.store import object_store as object_store_module
+from app.store.object_store import DomainObject, ObjectStore
+
+pytestmark = pytest.mark.not_pg
+
+
+def _write_note(path: Path, uuid: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"---\nuuid: {uuid}\nreview_state: draft\n---\nContent\n",
+        encoding="utf-8",
+    )
+
+
+def _make_promotion_intent(
+    *,
+    event_id: str,
+    trace_id: str,
+    note_uuid: str,
+    note_path: Path,
+) -> dict:
+    return {
+        "event": PROMOTE_INTENT_CREATED,
+        "event_id": event_id,
+        "trace_id": trace_id,
+        "source": "panel_agent",
+        "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "payload": {
+            "note": {"uuid": note_uuid, "path": str(note_path)},
+            "transition": {"family": "promotion", "target_maturity": "evergreen"},
+        },
+    }
+
+
+def _read_records(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+@pytest.fixture(autouse=True)
+def _reset_state() -> None:
+    object_store_module._MEMORY_STORE.clear()
+    reset_promotion_dedup_store()
+    yield
+    object_store_module._MEMORY_STORE.clear()
+    reset_promotion_dedup_store()
+
+
+def test_consumer_failure_paths_are_observable_and_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_DSN", raising=False)
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+
+    vault_root = tmp_path / "vault"
+    applied_uuid = "00000000-0000-0000-0000-000000000001"
+    missing_uuid = "00000000-0000-0000-0000-000000000002"
+    applied_path = vault_root / "Notes" / "applied.md"
+    missing_path = vault_root / "Notes" / "missing.md"
+    _write_note(applied_path, applied_uuid)
+
+    ObjectStore().save_object(
+        DomainObject(
+            uuid=applied_uuid,
+            kind="note",
+            payload={"raw_text": applied_path.read_text(encoding="utf-8"), "origin": "vault"},
+            source_ref=str(applied_path),
+            created_at=datetime.now(timezone.utc),
+        ),
+        emit_outbox=False,
+        trace_id="trace-seed",
+    )
+
+    trace_id = "trace-outbox-consumer"
+    event_1 = _make_promotion_intent(
+        event_id="evt-1",
+        trace_id=trace_id,
+        note_uuid=applied_uuid,
+        note_path=applied_path,
+    )
+    event_2 = _make_promotion_intent(
+        event_id="evt-1",
+        trace_id=trace_id,
+        note_uuid=applied_uuid,
+        note_path=applied_path,
+    )
+    event_3 = _make_promotion_intent(
+        event_id="evt-2",
+        trace_id=trace_id,
+        note_uuid=missing_uuid,
+        note_path=missing_path,
+    )
+
+    outbox_path = tmp_path / "index-outbox.jsonl"
+    outbox_path.write_text(
+        "\n".join(json.dumps(event, ensure_ascii=False) for event in (event_1, event_2, event_3)) + "\n",
+        encoding="utf-8",
+    )
+
+    summary = consume_promotion_intents(outbox_path=outbox_path)
+    assert summary["intents_seen"] == 3
+    assert summary["applied"] == 1
+    assert summary["errors"] == 1
+    assert summary["skipped_duplicates"] == 1
+    assert summary["emitted"] == 2
+
+    summary_again = consume_promotion_intents(outbox_path=outbox_path)
+    assert summary_again == {"intents_seen": 0, "applied": 0, "errors": 0, "emitted": 0, "skipped_duplicates": 0}
+
+    records = _read_records(outbox_path)
+    done_events = [record for record in records if record.get("event") == PROMOTE_DONE]
+    error_events = [record for record in records if record.get("event") == PROMOTE_ERROR]
+
+    assert len(done_events) == 1
+    assert len(error_events) == 1
+
+    done = done_events[0]
+    assert done["trace_id"] == trace_id
+    assert done["payload"]["source_event"] == "evt-1"
+    assert done["payload"]["note_uuid"] == applied_uuid
+
+    error = error_events[0]
+    assert error["trace_id"] == trace_id
+    assert error["payload"]["reason"] == "path_not_found"
+    assert error["payload"]["source_event"] == "evt-2"
+    assert error["payload"]["note_uuid"] == missing_uuid
+
+    updated_note = applied_path.read_text(encoding="utf-8")
+    assert "review_state: reviewed" in updated_note
+    assert "maturity: evergreen" in updated_note
+
+
+def test_jsonl_audit_is_not_treated_as_worker_queue(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    outbox_path = tmp_path / "index-outbox.jsonl"
+    outbox_path.write_text(
+        "\n".join(
+            json.dumps(
+                {
+                    "event": PROMOTE_INTENT_CREATED,
+                    "event_id": "evt-audit-1",
+                    "trace_id": "trace-audit",
+                    "source": "panel_agent",
+                    "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                    "payload": {
+                        "note": {
+                            "uuid": "00000000-0000-0000-0000-000000000003",
+                            "path": str(tmp_path / "vault" / "Notes" / "audit.md"),
+                        },
+                        "transition": {"family": "promotion", "target_maturity": "evergreen"},
+                    },
+                },
+                ensure_ascii=False,
+            )
+            for _ in range(2)
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://app:app@db:5432/app")
+    monkeypatch.setenv("STORE_BACKEND", "pg")
+    monkeypatch.setattr(status_service, "INDEX_OUTBOX_PATH", outbox_path, raising=False)
+    monkeypatch.setattr(status_service, "_count_outbox_pending_db", lambda: 7)
+
+    worker_queue = status_service._get_worker_queue_status()
+    events_log = status_service._events_log_status()
+
+    assert worker_queue.mode == "db"
+    assert worker_queue.source_path == "postgresql://app:app@db:5432/app"
+    assert worker_queue.pending == 7
+    assert events_log.path == str(outbox_path)
+    assert events_log.total_lines == 2

--- a/tests/events/test_outbox_consumer_contract.py
+++ b/tests/events/test_outbox_consumer_contract.py
@@ -174,6 +174,7 @@ def test_jsonl_audit_is_not_treated_as_worker_queue(
 
     monkeypatch.setenv("DATABASE_URL", "postgresql://app:app@db:5432/app")
     monkeypatch.setenv("STORE_BACKEND", "pg")
+    monkeypatch.setenv("WORKER_ENABLE", "1")
     monkeypatch.setattr(status_service, "INDEX_OUTBOX_PATH", outbox_path, raising=False)
     monkeypatch.setattr(status_service, "_count_outbox_pending_db", lambda: 7)
 


### PR DESCRIPTION
Fixes #544
Fixes #545

## Summary
Adds focused event envelope/version/idempotency contract coverage for representative watcher, panel/promotion, orchestrator, and MCP/tool families.

Documents and tests current outbox consumer retry, poison-message observability, idempotency, and JSONL-audit-vs-DB-queue semantics without adding a DLQ or changing event names.

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/events/test_event_envelope_versioning.py tests/architecture/test_events_outbox_contracts.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/events/test_outbox_consumer_contract.py tests/ops/test_no_op_convergence.py
- git diff --check
- rg -n "version|idempotency|event_id|trace_id|DLQ|retry" docs/EVENTS.md docs/ARCHITECTURE.md
- rg -n "outbox|retry|poison|DLQ|JSONL audit|worker queue" docs/EVENTS.md docs/OBSERVABILITY.md docs/OPERATIONS.md

## Notes
Issue #544 suggested `tests/architecture/test_event_contracts.py`, which is not present in this repo. I used the existing architecture event contract suite `tests/architecture/test_events_outbox_contracts.py` for the equivalent focused validation.