### PR TITLE
Validate panel action and watcher settings schemas

### DIFF
--- a/app/settings/validate.py
+++ b/app/settings/validate.py
@@ -54,7 +54,17 @@ def _panel_action_catalog_paths() -> list[Path]:
 def _validate_panel_action_entries() -> list[ValidationIssue]:
     issues: list[ValidationIssue] = []
     for path in _panel_action_catalog_paths():
-        frontmatter, _ = parse_markdown(path)
+        try:
+            frontmatter, _ = parse_markdown(path)
+        except Exception as exc:
+            issues.append(
+                ValidationIssue(
+                    code="panel_actions.invalid",
+                    message=f"{path}: failed to load panel action catalog: {exc}",
+                    ref="panel_actions",
+                )
+            )
+            continue
         mappings = frontmatter.get("mappings")
         if not isinstance(mappings, list):
             continue

--- a/app/settings/validate.py
+++ b/app/settings/validate.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
+import os
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from app.agents.panel_agent.wiring import (
+    DEFAULT_PANEL_ACTION_WIRING_PATH,
+    WiringConfigError,
+    _load_yaml as load_wiring_yaml,
+    _parse_wiring as parse_wiring,
+)
 from app.components.settings.prompts_loader import load_prompts
 from app.components.settings.standards_loader import load_standards_registry
 from app.components.settings.tools_loader import load_tools
@@ -11,8 +19,11 @@ from app.components.settings.agents_loader import load_agents
 from app.components.settings.graphs_loader import load_graphs
 from app.components.settings.models_loader import load_models
 from app.components.settings.events_loader import load_events
+from app.components.settings.panel_actions_loader import DEFAULT_PANEL_ACTIONS_PATH
+from app.index.ingest_md import parse_markdown
+from app.settings.panel_actions import resolve_panel_actions_root
 from app.settings.panel_actions_settings import load_panel_actions_settings, panel_action_ids
-from app.settings.watcher_settings import invalid_allowed_actions, load_watcher_settings
+from app.settings.watcher_settings import _settings_file, _read_frontmatter, invalid_allowed_actions, load_watcher_settings
 
 
 @dataclass(frozen=True)
@@ -20,6 +31,133 @@ class ValidationIssue:
     code: str
     message: str
     ref: Optional[str] = None
+
+
+_ACTION_ID_PATTERN = re.compile(r"^[a-z0-9]+(?:[._-][a-z0-9]+)*$")
+
+
+def _panel_action_catalog_paths() -> list[Path]:
+    for key in ("PANEL_ACTIONS_PATH", "PANEL_ACTIONS_FILE"):
+        value = os.getenv(key)
+        if value:
+            return [Path(value).expanduser()]
+    resolved = resolve_panel_actions_root()
+    if resolved is None:
+        return [DEFAULT_PANEL_ACTIONS_PATH] if DEFAULT_PANEL_ACTIONS_PATH.exists() else []
+    if resolved.is_file():
+        return [resolved]
+    if resolved.is_dir():
+        return sorted(path for path in resolved.glob("*.md") if path.is_file())
+    return []
+
+
+def _validate_panel_action_entries() -> list[ValidationIssue]:
+    issues: list[ValidationIssue] = []
+    for path in _panel_action_catalog_paths():
+        frontmatter, _ = parse_markdown(path)
+        mappings = frontmatter.get("mappings")
+        if not isinstance(mappings, list):
+            continue
+        for idx, raw in enumerate(mappings, start=1):
+            if not isinstance(raw, dict):
+                issues.append(
+                    ValidationIssue(
+                        code="panel_actions.missing_required_fields",
+                        message=f"{path}: mappings[{idx}] must be a mapping with required fields (id, intent_type, downstream_event)",
+                        ref="panel_actions",
+                    )
+                )
+                continue
+            action_id = str(raw.get("id") or "").strip()
+            intent_type = str(raw.get("intent_type") or raw.get("intent") or "").strip()
+            downstream_event = str(raw.get("downstream_event") or raw.get("event_type") or "").strip()
+            if not action_id or not intent_type or not downstream_event:
+                issues.append(
+                    ValidationIssue(
+                        code="panel_actions.missing_required_fields",
+                        message=f"{path}: mappings[{idx}] is missing required fields (id, intent_type, downstream_event)",
+                        ref="panel_actions",
+                    )
+                )
+                continue
+            if not _ACTION_ID_PATTERN.match(action_id):
+                issues.append(
+                    ValidationIssue(
+                        code="panel_actions.invalid_action_id",
+                        message=f"{path}: action id '{action_id}' at mappings[{idx}] must match {_ACTION_ID_PATTERN.pattern}",
+                        ref="panel_actions",
+                    )
+                )
+    return issues
+
+
+def _validate_watcher_auto_run_shape() -> list[ValidationIssue]:
+    issues: list[ValidationIssue] = []
+    path = _settings_file()
+    try:
+        data = _read_frontmatter(path)
+    except Exception as exc:
+        return [ValidationIssue(code="watcher_settings.invalid", message=str(exc), ref="watcher_settings")]
+    auto_run = data.get("auto_run")
+    if auto_run is None:
+        return issues
+    if not isinstance(auto_run, dict):
+        return [
+            ValidationIssue(
+                code="watcher_settings.malformed_auto_run",
+                message=f"{path}: auto_run must be a mapping",
+                ref="watcher_settings:auto_run",
+            )
+        ]
+    if "auto_exec_default" in auto_run and not isinstance(auto_run.get("auto_exec_default"), bool):
+        issues.append(
+            ValidationIssue(
+                code="watcher_settings.malformed_auto_run",
+                message=f"{path}: auto_run.auto_exec_default must be a boolean",
+                ref="watcher_settings:auto_run",
+            )
+        )
+    if "auto_exec_env" in auto_run:
+        env_key = auto_run.get("auto_exec_env")
+        if not isinstance(env_key, str) or not env_key.strip():
+            issues.append(
+                ValidationIssue(
+                    code="watcher_settings.malformed_auto_run",
+                    message=f"{path}: auto_run.auto_exec_env must be a non-empty string",
+                    ref="watcher_settings:auto_run",
+                )
+            )
+    if "allowed_actions" in auto_run:
+        allowed_actions = auto_run.get("allowed_actions")
+        if not isinstance(allowed_actions, list):
+            issues.append(
+                ValidationIssue(
+                    code="watcher_settings.malformed_auto_run",
+                    message=f"{path}: auto_run.allowed_actions must be a list of action ids",
+                    ref="watcher_settings:auto_run",
+                )
+            )
+        else:
+            for idx, action in enumerate(allowed_actions, start=1):
+                if not isinstance(action, str) or not action.strip():
+                    issues.append(
+                        ValidationIssue(
+                            code="watcher_settings.malformed_auto_run",
+                            message=f"{path}: auto_run.allowed_actions[{idx}] must be a non-empty string",
+                            ref="watcher_settings:auto_run",
+                        )
+                    )
+    return issues
+
+
+def _validate_panel_action_wiring() -> list[ValidationIssue]:
+    candidate = Path(os.getenv("PANEL_ACTION_WIRING_PATH") or DEFAULT_PANEL_ACTION_WIRING_PATH)
+    try:
+        data = load_wiring_yaml(candidate)
+        parse_wiring(data, candidate)
+        return []
+    except WiringConfigError as exc:
+        return [ValidationIssue(code="panel_wiring.invalid", message=str(exc), ref="panel_wiring")]
 
 
 def validate_settings() -> List[ValidationIssue]:
@@ -140,11 +278,16 @@ def validate_settings() -> List[ValidationIssue]:
         panel_actions_settings = load_panel_actions_settings()
     except Exception as exc:
         issues.append(ValidationIssue(code="panel_actions.invalid", message=str(exc), ref="panel_actions"))
+    issues.extend(_validate_panel_action_entries())
+
+    issues.extend(_validate_panel_action_wiring())
+
     watcher_settings = None
     try:
         watcher_settings = load_watcher_settings()
     except Exception as exc:
         issues.append(ValidationIssue(code="watcher_settings.invalid", message=str(exc), ref="watcher_settings"))
+    issues.extend(_validate_watcher_auto_run_shape())
     if panel_actions_settings and watcher_settings:
         invalid_actions = invalid_allowed_actions(watcher_settings, panel_action_ids(panel_actions_settings))
         if invalid_actions:
@@ -163,4 +306,3 @@ def issues_to_json(issues: List[ValidationIssue]) -> Dict[str, Any]:
         "ok": len(issues) == 0,
         "issues": [{"code": i.code, "message": i.message, "ref": i.ref} for i in issues],
     }
-

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -125,6 +125,8 @@ Watcher auto-exec enablement rule:
 - `WATCHER_AUTO_EXEC=1` is necessary to arm panel auto-exec, but it is not sufficient on its own to prove rollout safety.
 - Before enabling auto-exec for a wider runtime scope, confirm the effective allowlist, recent skip counters, and write-guard/provenance context are coherent across both CLI surfaces.
 - When the question is release or merge readiness rather than a live local diagnosis, corroborate the operator view with the enforced CI summary line (`CI SUMMARY GATES ok=<bool>`).
+- `python -m app.cli settings-validate` is the schema validation gate for repo-shipped panel action catalog/wiring and watcher settings. It rejects invalid panel action ids, missing required panel fields, malformed watcher `auto_run` values, and unknown watcher allowlist action ids.
+- This validation path does not widen runtime authority: watcher auto-exec remains guarded by `WATCHER_AUTO_EXEC`, allowlist policy, and per-note `ai_panel_auto_run: never` opt-out.
 
 ### Docker-first deployment
 1. Set `VAULT_ROOT` to your local vault path:
@@ -278,6 +280,7 @@ LLM_PROVIDER=mock python -m app.cli health --json
 python -m app.cli watcher run --max-ticks 1
 python -m app.cli pipe notes/meeting.md
 python -m app.cli settings-explain --json
+python -m app.cli settings-validate
 ```
 
 Startup/runtime verification now treats task routes and embeddings explicitly:

--- a/docs/PANEL_AGENT.md
+++ b/docs/PANEL_AGENT.md
@@ -148,6 +148,8 @@ Architectural reading note:
 - Default wiring: `docs/settings/panel-action-wiring.yaml` (maps canonical action ids to target events).
 - Resolution order: `PANEL_ACTION_WIRING_PATH` env override > `<vault>/System/Config/panel-action-wiring.yaml` (vault override) > repo default.
 - Validation: config must define an `actions` list with `id`, `kind` (event|intent, defaults to event), and `event_type`/`target_event` (or `intent_type`). Unknown/invalid configs emit a warning and fall back to the default wiring; runtime behaviour stays unchanged.
+- CI/operator validation path: run `python -m app.cli settings-validate` to validate panel action catalog entries, panel action wiring schema, and watcher settings schema before rollout.
 - CLI/Watcher use the same wiring; panel decider (rule/LLM) still selects actions, wiring only controls emitted events.
+- Guardrails remain unchanged: watcher auto-exec still requires `WATCHER_AUTO_EXEC=1`, only allows configured `auto_run.allowed_actions`, and preserves per-note opt-out via `ai_panel_auto_run: never`.
 
 Promotion intents (`promote.intent.created`) represent intent-only; apply effects by running the promotion consumer (`python -m app.cli promote-consume`), which emits `promote.done` when successful and updates the vault note frontmatter via the note writer path, writing standing changes to `maturity` and review posture separately (Store updates remain optional).

--- a/tests/settings/test_panel_watcher_config_validation.py
+++ b/tests/settings/test_panel_watcher_config_validation.py
@@ -77,3 +77,16 @@ def test_invalid_panel_and_watcher_settings_fail_with_clear_errors(
     assert "missing target_event/event_type" in by_code["panel_wiring.invalid"].message
     assert "watcher_settings.malformed_auto_run" in by_code
     assert "auto_run.allowed_actions must be a list" in by_code["watcher_settings.malformed_auto_run"].message
+
+
+def test_unreadable_panel_actions_path_reports_validation_issue(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    missing_panel_actions = tmp_path / "missing-panel-actions.md"
+    monkeypatch.setenv("PANEL_ACTIONS_PATH", str(missing_panel_actions))
+
+    issues = validate_settings()
+    panel_issues = [issue for issue in issues if issue.code == "panel_actions.invalid"]
+
+    assert panel_issues
+    assert all(issue.message for issue in panel_issues)

--- a/tests/settings/test_panel_watcher_config_validation.py
+++ b/tests/settings/test_panel_watcher_config_validation.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.settings.validate import validate_settings
+
+
+def _write_watchers_file(vault: Path, content: str) -> None:
+    settings_dir = vault / "@Settings"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    (settings_dir / "watchers.md").write_text(content, encoding="utf-8")
+
+
+pytestmark = pytest.mark.not_pg
+
+
+def test_repo_panel_action_settings_validate(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PANEL_ACTIONS_PATH", raising=False)
+    monkeypatch.delenv("PANEL_ACTIONS_FILE", raising=False)
+    monkeypatch.delenv("PANEL_ACTION_WIRING_PATH", raising=False)
+
+    issues = validate_settings()
+
+    assert not any(
+        issue.code.startswith("panel_actions.")
+        or issue.code.startswith("panel_wiring.")
+        or issue.code.startswith("watcher_settings.")
+        for issue in issues
+    )
+
+
+def test_invalid_panel_and_watcher_settings_fail_with_clear_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    panel_actions = tmp_path / "panel-actions.md"
+    panel_actions.write_text(
+        (
+            "---\n"
+            "mappings:\n"
+            "  - id: \"Bad Id!\"\n"
+            "    intent_type: promotion\n"
+            "    downstream_event: promote.intent.created\n"
+            "  - labels: [\"Missing required fields\"]\n"
+            "---\n"
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PANEL_ACTIONS_PATH", str(panel_actions))
+
+    wiring = tmp_path / "panel-action-wiring.yaml"
+    wiring.write_text("actions:\n  - id: promote.evergreen\n", encoding="utf-8")
+    monkeypatch.setenv("PANEL_ACTION_WIRING_PATH", str(wiring))
+
+    vault = tmp_path / "vault"
+    _write_watchers_file(
+        vault,
+        (
+            "---\n"
+            "auto_run:\n"
+            "  auto_exec_default: \"yes\"\n"
+            "  allowed_actions: promote.evergreen\n"
+            "---\n"
+        ),
+    )
+    monkeypatch.setenv("VAULT_ROOT", str(vault))
+
+    issues = validate_settings()
+    by_code = {issue.code: issue for issue in issues}
+
+    assert "panel_actions.invalid_action_id" in by_code
+    assert "action id" in by_code["panel_actions.invalid_action_id"].message
+    assert "panel_actions.missing_required_fields" in by_code
+    assert "required fields" in by_code["panel_actions.missing_required_fields"].message
+    assert "panel_wiring.invalid" in by_code
+    assert "missing target_event/event_type" in by_code["panel_wiring.invalid"].message
+    assert "watcher_settings.malformed_auto_run" in by_code
+    assert "auto_run.allowed_actions must be a list" in by_code["watcher_settings.malformed_auto_run"].message


### PR DESCRIPTION
Fixes #546

## Summary
- add deterministic validation coverage for panel action catalog entries and panel wiring schema
- validate watcher auto_run shape with actionable error codes
- document settings validation command and reaffirm existing auto-exec guardrails

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/settings/test_panel_watcher_config_validation.py tests/settings/test_validate_settings.py tests/settings/test_compile.py
- .venv/bin/python -m app.cli settings-validate

---