### PR TITLE
Define cheaper issue/PR state model and align workflow skills

### DIFF
--- a/.codex/skills/README.md
+++ b/.codex/skills/README.md
@@ -8,7 +8,11 @@ These skills are workflow helpers, not replacements for the canonical builder-ag
 
 ## Workflow map
 
-`Docs -> Issue -> Project -> Issue maintenance -> Agent -> Publish PR -> PR integration -> CI -> Verification -> Merge -> Project/doc closure -> Owner Doc`
+Hot path:
+`Docs -> Issue -> Project -> Issue maintenance -> Agent -> issue-to-code fast claim -> Publish PR -> CI -> Verification -> Merge -> Project/doc closure -> Owner Doc`
+
+Conditional / maintenance path:
+`Issue maintenance -> Agent` for stale or false backlog state, and `Publish PR -> pr-integration` only when readiness/repair work is still needed before verification.
 
 ## Skill routing
 
@@ -17,6 +21,7 @@ These skills are workflow helpers, not replacements for the canonical builder-ag
 - `issue-to-code`
   - implementation entrypoint for bounded GitHub Issue work
   - before coding, update lifecycle state truthfully: move active work to `In Progress` and remove `agent:ready`
+  - use that transition as the minimal shared claim/lease compatibility signal in multi-agent environments
 - `issue-maintenance-change-control`
   - repair stale or false Issue / PR / label / Project state before or during execution
 - `docs-authoring`
@@ -28,9 +33,9 @@ These skills are workflow helpers, not replacements for the canonical builder-ag
 - `publish-pr`
   - publication boundary for branch, commit, push, and PR creation after local work is ready
 - `pr-integration`
-  - run after `publish-pr` and before verification to make the PR mergeable and CI-attached
+  - readiness/repair path after `publish-pr` when the PR still needs mergeability, CI attachment, or review-feedback repair before verification
 - `verification-and-closure`
-  - final verification, merge, and delivery-state closure after implementation / PR work
+  - final verification, merge, and delivery-state closure after implementation / PR work; honors automation-driven `Done` projection and only fallback-writes it when needed
 - `post-merge-owner-doc`
   - invoked by `verification-and-closure` at merge time; reads the diff and decides whether any owner doc needs promotion, then acts on it
 - `backlog-reconciliation-drift-audit`

--- a/.codex/skills/backlog-reconciliation-drift-audit/SKILL.md
+++ b/.codex/skills/backlog-reconciliation-drift-audit/SKILL.md
@@ -12,6 +12,7 @@ Treat closed PR cards as part of lifecycle truth, not as an afterthought.
 
 This is not feature planning.
 This is anti-drift maintenance.
+It is a cold-path audit, not a hot-path intake workflow.
 
 ## Audit model
 
@@ -24,6 +25,7 @@ You must detect:
 - Issues whose `Source Anchors` no longer match current docs
 - roadmap/plan items that still read as pending after merge
 - delivered code with missing owner-doc writeback
+- backlog items that should have been repaired in a batch but were instead handled one-by-one
 - duplicate Issues covering the same anchored source item
 - Issues in false Project status
 - closed PR cards that still have blank or non-terminal Project status
@@ -85,6 +87,7 @@ For each drift case, recommend one concrete corrective action only:
 - GitHub remains the canonical backlog-state surface.
 - Treat Project `Status` as the primary lifecycle signal.
 - Treat `agent:ready` as the pickup qualifier for `Status=Ready`, not as a substitute for `In Progress`, `Review`, or `Done`.
+- Prefer one repair action per drift class when the same correction repeats across multiple items; do not churn the board with separate micro-fixes when a batched audit can close the gap.
 
 
 ## Capturing learning

--- a/.codex/skills/bug-to-issue/SKILL.md
+++ b/.codex/skills/bug-to-issue/SKILL.md
@@ -8,6 +8,7 @@ description: "Create a GitHub Issue whenever a bug is discovered during analysis
 ## Overview
 
 Turn any discovered bug into a compliant GitHub Issue that matches the repo's contract shape and labels. Default to creating issues in the current repo unless the user specifies a different one.
+This is the hot-path defect intake lane, not the cold-path maintenance lane.
 
 ## Workflow
 
@@ -27,6 +28,7 @@ Turn any discovered bug into a compliant GitHub Issue that matches the repo's co
      - `## Suggested Validation`
      - `## Source Docs`
    - Include exact repro steps and observed/expected results when available.
+   - Do not create a micro-issue for routine repair, reconciliation, or bookkeeping churn; route those signals to the maintenance skills instead.
    - Acceptance Criteria must carry `Verify:` markers:
      - The primary behavioral AC ("bug no longer reproduces") points to a regression test the fix will add: `Verify: \`tests/<path>::test_<bug_name>\`` — the test should fail against current code and go green after the fix.
      - Any non-behavioral AC (doc clarifications, roadmap/status wording) points to its observable target.
@@ -46,6 +48,7 @@ Set `agent:ready` when all are true:
 - Every AC carries a resolvable `Verify:` target; the repro is expressible as a named failing test.
 - Source anchors point to specific files or docs.
 - No unresolved decisions or missing contract inputs.
+- The bug is a real defect, not a low-signal maintenance correction that should be batched into audit or retrospective work.
 
 Force `agent:needs-human` when:
 - It is a Core Runtime ↔ Agentic Lab boundary move without explicit direction and module paths.

--- a/.codex/skills/capture-learning/SKILL.md
+++ b/.codex/skills/capture-learning/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: capture-learning
-description: "Append one structured divergence entry to docs/learning-log.md. Invoke when you do something you did not expect to do, or discover an earlier artifact was wrong — not on normal work."
+description: "Append one structured divergence entry to docs/learning-log.md when a concrete divergence is worth immediate upstream repair; defer low-signal cases to retrospective batching."
 ---
 
 # Capture Learning
 
-Single-job micro-skill. Appends one entry to `docs/learning-log.md` when a plan divergence occurs during delivery.
+Maintenance-path repair skill. Appends one entry to `docs/learning-log.md` when a plan divergence is concrete enough to name an upstream artifact now.
 
 ## When to invoke
 
@@ -14,6 +14,8 @@ Invoke only when:
 - you discovered an earlier artifact was wrong
 
 Do NOT invoke when work went exactly as planned.
+
+This is not a hot-path routine for every small divergence. If the signal is minor, repetitive, or not yet actionable, batch it for `learning-retrospective` instead of interrupting the current task.
 
 The "name an artifact" gate: you must name an upstream artifact before logging. If you cannot name one, do not log.
 
@@ -44,7 +46,7 @@ Append after the last existing entry (or after the `---` separator if the log is
 
 ## Timing
 
-Invoke before continuing with remaining task work. Context is freshest at the moment of divergence — do not batch to end of task.
+Invoke before continuing only when the divergence needs immediate upstream repair. Otherwise, collect the signal and let the next retrospective convert batched notes into a concrete edit.
 
 ## Output format
 

--- a/.codex/skills/docs-to-issue/SKILL.md
+++ b/.codex/skills/docs-to-issue/SKILL.md
@@ -8,12 +8,15 @@ description: "Convert active repo documentation into bounded GitHub Issues witho
 You are a repository backlog-orchestration agent for a repo-first, docs-as-code software system.
 
 Your job is to convert active documentation into bounded GitHub Issues without inventing strategy.
+This is the backlog-intake lane, not the maintenance repair lane.
 
 ## Canonical workflow
 
 `Docs -> Feature issue or slice issue -> Project -> Issue maintenance -> Agent -> PR -> PR integration -> CI -> Slice verification -> Merge -> Feature validation -> Acceptance -> Owner Doc`
 
 Plus: periodic reconciliation.
+
+Use maintenance skills instead of this lane when the work is a repair, audit, or periodic drift correction.
 
 ## Authority order
 
@@ -31,6 +34,7 @@ Plus: periodic reconciliation.
 - Inline doc markers such as `Tracked by: #123` and `Backlog: #123` are secondary convenience notes only.
 - New backlog work must use stable `Source Anchors`.
 - Do not create duplicate Issues.
+- Do not create micro-issues or churn Project state for routine maintenance notes that can be batched into one bounded repair item.
 - If a docs item is larger than one bounded implementation issue or clearly needs post-merge validation before owner docs should change, route it through `feature-breakdown` instead of flattening it into one issue.
 - Do not create Issues for vague aspirations, broad cleanup, philosophy, or already delivered work.
 - If an item is too large, split it into multiple bounded Issues with explicit dependency order.
@@ -51,6 +55,7 @@ For every candidate doc item, determine exactly one state:
 3. Inspect recent open and merged PRs.
 4. Check whether the work is already tracked, already delivered, superseded, partially delivered, or blocked.
 5. Decide whether the item should stay as one bounded issue or be turned into one parent feature issue plus child slices via `feature-breakdown`.
+6. If the candidate would only create bookkeeping churn, keep it out of the backlog and route it to the maintenance path instead.
 
 ## When a doc item becomes a new Issue
 

--- a/.codex/skills/issue-maintenance-change-control/SKILL.md
+++ b/.codex/skills/issue-maintenance-change-control/SKILL.md
@@ -11,6 +11,7 @@ You are an Issue maintenance and lifecycle-correction agent for a repo-first, do
 
 Your job is to keep GitHub Issues, Pull Requests, labels, and Project state truthful when backlog state drifts from implementation reality.
 That includes PR lifecycle truth, not only Issue lifecycle truth.
+This is a cold-path maintenance role, not a hot-path implementation routine.
 
 You operate between:
 `Docs -> Issue -> Project -> Issue maintenance -> Agent -> PR -> CI -> Verification -> Project/doc closure -> Owner Doc`
@@ -28,6 +29,7 @@ You operate between:
 - owner-doc writeback or roadmap cleanup is missing after delivery
 - Issue state, PR state, labels, and Project state disagree
 - the request touches Core Runtime <-> Agentic Lab boundary moves or operator-facing defaults
+- the same repair should be batched across several drifted items instead of handled as isolated micro-fixes
 
 ## Authority and entry points
 
@@ -45,6 +47,7 @@ You operate between:
 - Correct Project drift opportunistically, but do not block delivery solely because a personal Project v2 board cannot be updated.
 - Do not invent strategy.
 - Preserve traceability through `Source Anchors`.
+- Prefer batched maintenance actions for repeated drift patterns; reserve single-item churn for cases where the items genuinely differ.
 
 ## Canonical lifecycle expectations
 
@@ -171,6 +174,12 @@ If an open implementation Issue is malformed, stale, or no longer safely executa
    ```
 
 3. **Post comment with required action**
+
+### Maintenance path versus hot path
+
+- Hot path: active implementation work that is ready to be picked up and executed by an agent.
+- Maintenance path: repairs, audits, reconciliation, and cleanup that exist to restore truth in docs, issues, projects, or receipts.
+- If the task is on the maintenance path, do not force it into `agent:ready` just to make it look executable.
 
 ### Action: Issue Delivered but Still Open
 

--- a/.codex/skills/issue-to-code/SKILL.md
+++ b/.codex/skills/issue-to-code/SKILL.md
@@ -14,7 +14,11 @@ Only execute bounded implementation work from a GitHub Issue that is the canonic
 
 ## Canonical workflow
 
-`Docs -> Feature issue -> Slice issue -> Agent -> Publish PR -> PR integration -> CI -> Slice verification -> Merge -> Feature validation -> Acceptance -> Owner Doc`
+Hot path:
+`Docs -> Feature issue -> Slice issue -> Agent -> Fast claim (Ready -> In Progress + remove agent:ready) -> Publish PR -> PR integration (conditional readiness/repair) -> CI -> Slice verification -> Merge -> Feature validation -> Acceptance -> Owner Doc`
+
+Conditional / maintenance path:
+`Issue maintenance -> Agent` and `Publish PR -> PR integration` only when mergeability, CI attachment, or review repair is still needed.
 
 Treat these Issue sections as binding for the governing slice issue:
 
@@ -35,6 +39,8 @@ Treat these Issue sections as binding for the governing slice issue:
 - Do not leave actively worked Issues in `Ready`.
 - Do not leave blocked Issues in `In Progress`.
 - Do not use `Review` only because a PR exists; keep work `In Progress` until review handoff is explicit.
+- Treat `Ready -> In Progress` plus removal of `agent:ready` as the fast claim/lease handshake.
+- Keep that claim minimal and compatible with multi-agent environments: one active lease per Issue, with the label/status transition as the shared signal.
 
 Allowed labels:
 
@@ -85,7 +91,7 @@ When you start active work on an Issue:
    gh api graphql -f query='query { repository(owner:"OWNER", name:"REPO") { issue(number:N) { projectItems(first:1) { nodes { id } } } } }'
    ```
 
-2. **Remove `agent:ready` label:**
+2. **Fast-claim the Issue by removing `agent:ready`:**
    ```bash
    gh issue edit #<N> --remove-label agent:ready
    ```

--- a/.codex/skills/learning-retrospective/SKILL.md
+++ b/.codex/skills/learning-retrospective/SKILL.md
@@ -5,13 +5,15 @@ description: "Read docs/learning-log.md since the last retro marker, cluster sig
 
 # Learning Retrospective
 
-Cadence-triggered (manual, or roughly every 10 deliveries). Reads divergence signals logged since the last retrospective and converts them into concrete, actionable edit proposals for upstream artifacts.
+Periodic maintenance pass. Reads batched divergence signals logged since the last retrospective and converts them into concrete, actionable edit proposals for upstream artifacts.
 
 **Does NOT execute edits.** All proposals go to human review first.
 
 ## Trigger
 
 Run when the human requests a retrospective, or after approximately 10 deliveries have accumulated entries in `docs/learning-log.md`.
+
+This is a cold-path repair step, not a hot-path delivery routine.
 
 ## Workflow
 
@@ -33,6 +35,8 @@ Group entries by their `**Upstream artifact:**` field. Example clusters:
 - `.codex/skills/issue-to-code/SKILL.md` — entries pointing to the issue-to-code skill
 - `task-contract template` — entries pointing to the issue body template
 - `unknown — flag for retro` — entries where the artifact was unresolved at log time
+
+Prefer batching similar low-signal entries into one repair proposal when they point at the same upstream artifact.
 
 ### Step 3: Propose concrete edits
 

--- a/.codex/skills/post-merge-owner-doc/SKILL.md
+++ b/.codex/skills/post-merge-owner-doc/SKILL.md
@@ -8,6 +8,7 @@ description: "After an implementation PR merges, read the diff and decide whethe
 You are invoked at the end of `verification-and-closure`, after a PR has merged. Your job is one question: **did this merge change something an owner doc currently claims?**
 
 You act on the answer. You do not ask the user to classify, attest, or unblock.
+This is a cold-path maintenance check, not a hot-path implementation step.
 
 ## The one question
 
@@ -28,11 +29,13 @@ The receipt comment always goes on the **closed issue** that the PR fixes. If th
 
 ## Three outcomes
 
-**1. Yes, and the wording change is clear.**
+Classify the claim into one of three lanes: immediate action, queued follow-up, or no change.
+
+**1. Yes, and the wording change is clear. Immediate action.**
 
 Open a docs-only PR via `docs-authoring` that updates the owner doc(s). Title: `docs: owner-doc promotion for #<closed-issue>`. Body links back to the closed issue and names the specific claim(s) being corrected. Add a comment on the closed issue: `post-merge owner-doc check: docs PR opened at #<docs-pr>`.
 
-**2. Yes, but the right wording needs human judgment.**
+**2. Yes, but the right wording needs human judgment. Queue a follow-up.**
 
 Open one bounded follow-up issue. Title: `docs: owner-doc promotion needed for #<closed-issue>`. Body names:
 
@@ -54,6 +57,7 @@ That comment is the receipt. If it is missing on a closed implementation issue, 
 - **Owner docs claim current-state truth.** If a shipped change makes an owner-doc sentence false, outdated, or misleading, the sentence needs to change. Stylistic preference is not a reason to open a PR.
 - **Target-state and plan docs are not owner docs.** `docs/plans/*`, `docs/{CAPABILITY}/*` specs, and v6.0 target docs describe intent, not current-state truth. Do not open promotion PRs against them unless the merge itself changes target-state intent, which is rare.
 - **Prefer the smallest correct change.** A single sentence fix in `STATUS.md` beats a chapter rewrite. If the wording gap is small, just fix it (outcome 1). Only escalate to outcome 2 when the correct phrasing genuinely needs the user's judgment.
+- **Split immediate action from queued repair.** If the owner-doc claim is clearly wrong, open the docs PR now. If the claim is only plausibly wrong or needs interpretation, queue one bounded follow-up issue instead of creating churn or guessing.
 - **When unsure between outcomes 1 and 2, pick 2.** A follow-up issue is cheaper than an incorrect owner-doc PR.
 - **When unsure between outcomes 2 and 3, pick 2.** A false negative (silent drift) is worse than a spurious follow-up issue the user can close in ten seconds.
 - **Never open more than one PR or one issue per merge.** If multiple owner docs need changes, bundle them. If the bundle is too large to review, that is signal that the merge itself should have been split — file one follow-up issue noting the scope, not many.

--- a/.codex/skills/pr-integration/SKILL.md
+++ b/.codex/skills/pr-integration/SKILL.md
@@ -5,7 +5,7 @@ description: "Prepare a slice-implementation PR for verification by resolving me
 
 # PR Integration
 
-Use this skill after `publish-pr` and before the verification stage.
+Use this skill when a PR needs readiness/repair before verification; it is the conditional path after `publish-pr`, not a mandatory immediate publication step.
 
 Goal:
 produce a mergeable, policy-compliant PR with CI **green** on the latest head SHA so verification can run on truthful state.
@@ -16,6 +16,10 @@ This skill does NOT merge the PR. Merge is owned by the verification skill after
 
 ## Canonical workflow position
 
+Hot path:
+`Docs -> Feature issue -> Slice issue -> Agent -> Publish PR -> CI -> Slice verification -> Merge -> Feature validation -> Acceptance -> Owner Doc`
+
+Conditional / readiness-repair path:
 `Docs -> Feature issue -> Slice issue -> Agent -> Publish PR -> PR integration -> CI -> Slice verification -> Merge -> Feature validation -> Acceptance -> Owner Doc`
 
 ## First context to load
@@ -32,6 +36,7 @@ This skill does NOT merge the PR. Merge is owned by the verification skill after
 - A PR exists (draft or ready) and links the governing branch.
 - The PR was just created or updated by `.codex/skills/publish-pr/SKILL.md` or equivalent truthful publication flow.
 - Implementation changes are already in place.
+- Use this skill when the PR still needs mergeability, CI attachment, or review-feedback repair before verification.
 
 ## Exit conditions
 

--- a/.codex/skills/publish-pr/SKILL.md
+++ b/.codex/skills/publish-pr/SKILL.md
@@ -10,7 +10,7 @@ Use this skill when local work is complete enough to publish as a branch and pul
 Goal:
 turn validated local changes into a truthful branch, commit, pushed head, and PR artifact without mixing publication with implementation logic.
 
-⚠️ **CRITICAL: All publication steps (branch creation, staging, commit, push, PR creation) must be executed using explicit git/gh commands. Do not describe these steps—execute them and verify they succeeded. Hand off to pr-integration is mandatory.**
+⚠️ **CRITICAL: All publication steps (branch creation, staging, commit, push, PR creation) must be executed using explicit git/gh commands. Do not describe these steps—execute them and verify they succeeded. Treat pr-integration as a conditional readiness/repair path, not an automatic immediate handoff.**
 
 ## Canonical workflow position
 
@@ -40,7 +40,8 @@ turn validated local changes into a truthful branch, commit, pushed head, and PR
 - Do not publish unrelated local changes.
 - For implementation lane PRs, the body must include `Fixes #<id>`, `Closes #<id>`, or `Resolves #<id>`.
 - For docs-authoring or governance lane PRs, leave the linked Issue blank unless a governing Issue actually exists.
-- Default to opening a draft PR unless the work is explicitly ready for review handoff.
+- Default to opening an open PR.
+- Use `--draft` only with an explicit reason that the PR is not yet ready for review or still needs integration/repair.
 - Publication does not move work to `Done`.
 
 ## Publication workflow (all steps are executable)
@@ -115,7 +116,7 @@ Execute based on lane classification:
 
 **Implementation Lane (Fixes an Issue):**
 ```bash
-gh pr create --draft \
+gh pr create \
   --title "<bounded outcome>" \
   --body "$(cat <<'EOF'
 Fixes #<ISSUE_NUMBER>
@@ -133,7 +134,7 @@ EOF
 
 **Docs Authoring Lane:**
 ```bash
-gh pr create --draft \
+gh pr create \
   --title "<docs update title>" \
   --body "$(cat <<'EOF'
 - [x] Docs authoring lane
@@ -154,7 +155,7 @@ EOF
 
 **Governance Lane:**
 ```bash
-gh pr create --draft \
+gh pr create \
   --title "<governance change title>" \
   --body "$(cat <<'EOF'
 - [x] Governance lane
@@ -183,14 +184,14 @@ EOF
 
 ### Step 7: Hand Off to pr-integration
 
-After PR is created/updated, execute pr-integration skill:
+After PR is created/updated, use pr-integration only when the PR still needs readiness/repair work before verification:
 
 ```bash
 # Invoke pr-integration skill to verify, check CI, and prepare for verification
 echo "Handing off to pr-integration skill"
 ```
 
-**Do not skip this handoff.** PR integration resolves merge conflicts, verifies CI, and prepares the PR for verification/merge.
+**Do not force this as an immediate publication step.** PR integration resolves merge conflicts, verifies CI, and prepares the PR for verification/merge when the PR needs that readiness path.
 
 ## PR body requirements
 

--- a/.codex/skills/temporal-doc-governance/SKILL.md
+++ b/.codex/skills/temporal-doc-governance/SKILL.md
@@ -6,6 +6,7 @@ description: "Audit and update time-sensitive docs such as STATUS, ROADMAP, roll
 # Temporal Doc Governance
 
 Use this skill when the task is to audit or update documentation with a strong temporal component.
+This is a periodic maintenance pass, not a hot-path delivery step.
 
 Typical targets:
 
@@ -14,6 +15,8 @@ Typical targets:
 - `docs/DOCS_INDEX.md`
 - rollout, track, runbook, and current-state docs
 - any doc that can drift because code, issues, runtime posture, or operational state changed
+
+Use it to repair temporal drift, not to add one-off backlog intake or implementation chatter.
 
 ## First context to load
 
@@ -63,6 +66,7 @@ Use these classes:
 - Prefer correcting current-state claims over rewriting large sections.
 - Keep `ROADMAP` forward-looking; move delivered truth into the owner/current-state doc.
 - Keep `STATUS` explicitly operational; remove roadmap-like language when reality is already shipped or no longer active.
+- Batch repeated temporal corrections where the same claim appears across multiple docs, and avoid splitting one drift class into many micro-edits unless the surfaces truly diverge.
 - If a claim cannot be verified, mark the uncertainty instead of presenting it as current truth.
 - Update `Last reviewed` whenever the doc is intentionally checked.
 - Update `Last verified against` with the most local concrete verification anchor available.

--- a/.codex/skills/verification-and-closure/SKILL.md
+++ b/.codex/skills/verification-and-closure/SKILL.md
@@ -18,6 +18,7 @@ You operate after PR integration has produced a mergeable, CI-green PR.
 - ensure shipped truth moved to the right owner docs
 - ensure roadmap/plan wording no longer falsely reads as pending
 - detect false backlog/project states
+- honor automation-driven PR/Project `Done` projection first, and only fallback-set `Done` when needed
 - **merge the PR when the delivery contract is satisfied**
 - close the governing Issue and set Project Status to Done
 - unblock dependent issues
@@ -124,14 +125,14 @@ When all merge prerequisites are met:
    gh issue edit #<N> --remove-label agent:ready --remove-label agent:blocked --remove-label agent:needs-human
    ```
 
-6. **Set Issue Project Status to Done:**
+6. **Set Issue Project Status to Done if automation has not already projected it:**
    ```bash
    gh api graphql -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
      -f fieldId="$STATUS_FIELD_ID" -f optionId="$DONE_OPTION_ID" \
      -f query='mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!) { updateProjectV2ItemFieldValue(input:{projectId:$projectId itemId:$itemId fieldId:$fieldId value:{singleSelectOptionId:$optionId}}) { projectV2Item { id } } }'
    ```
 
-7. **Set PR Project Status to Done:**
+7. **Set PR Project Status to Done if automation has not already projected it:**
    ```bash
    gh api graphql -f projectId="$PROJECT_ID" -f itemId="$PR_ITEM_ID" \
      -f fieldId="$STATUS_FIELD_ID" -f optionId="$DONE_OPTION_ID" \
@@ -166,6 +167,7 @@ When all merge prerequisites are met:
 **Verification owns terminal delivery-state correction. All state changes must be executed, not just described.**
 
 - An open or draft PR without explicit review handoff remains `In Progress`; `Review` is reserved for the review handoff state.
+- If project/PR automation has already projected `Done`, verify that state rather than writing it again; only apply the fallback `Done` mutation when the item still needs terminal projection.
 
 ### Slice Issue Fully Delivered
 
@@ -202,7 +204,7 @@ If the feature issue is fully delivered and acceptance is satisfied:
 
 If a related PR was closed without merge but represents terminal tracked work:
 
-1. **Set PR Project Status to Done:**
+1. **Set PR Project Status to Done if automation has not already projected it:**
    ```bash
    gh api graphql -f projectId="$PROJECT_ID" -f itemId="$PR_ITEM_ID" \
      -f fieldId="$STATUS_FIELD_ID" -f optionId="$DONE_OPTION_ID" \

--- a/.github/workflows/project-pr-opened.yml
+++ b/.github/workflows/project-pr-opened.yml
@@ -1,0 +1,26 @@
+name: Project PR Opened
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+  repository-projects: write
+
+jobs:
+  project-pr-status:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Project PR state projection
+        # Draft PRs stay In Progress; non-draft PRs move to Review.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 scripts/project_status.py \
+            --repo "${{ github.repository }}" \
+            --pr "${{ github.event.pull_request.number }}" \
+            --action "${{ github.event.action }}" \
+            --draft "${{ github.event.pull_request.draft }}"

--- a/.github/workflows/project-pr-stage-change.yml
+++ b/.github/workflows/project-pr-stage-change.yml
@@ -1,0 +1,25 @@
+name: Project PR Stage Change
+
+on:
+  pull_request:
+    types: [ready_for_review, converted_to_draft]
+
+permissions:
+  contents: read
+  pull-requests: read
+  repository-projects: write
+
+jobs:
+  project-pr-status:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Project PR stage projection
+        # Stage-change events are deterministic: ready -> Review, draft -> In Progress.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 scripts/project_status.py \
+            --repo "${{ github.repository }}" \
+            --pr "${{ github.event.pull_request.number }}" \
+            --action "${{ github.event.action }}"

--- a/.github/workflows/project-status-reconcile.yml
+++ b/.github/workflows/project-status-reconcile.yml
@@ -3,8 +3,6 @@ name: Project Status Reconcile
 on:
   issues:
     types: [opened, reopened, closed, labeled, unlabeled]
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, review_requested, closed]
   schedule:
     - cron: '17 * * * *'
   workflow_dispatch:
@@ -28,24 +26,6 @@ jobs:
           python3 scripts/reconcile_project_status.py \
             --repo "${{ github.repository }}" \
             --issue "${{ github.event.issue.number }}"
-
-  reconcile-pr:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Reconcile PR project status
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          EXTRA_ARGS=""
-          if [ "${{ github.event.action }}" = "review_requested" ]; then
-            EXTRA_ARGS="--status Review"
-          fi
-          python3 scripts/reconcile_project_status.py \
-            --repo "${{ github.repository }}" \
-            --pr "${{ github.event.pull_request.number }}" \
-            ${EXTRA_ARGS}
 
   reconcile-scan:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,15 @@ For GitHub implementation work, loading `.codex/skills/issue-to-code/SKILL.md` i
 That skill owns the pickup rule:
 when active work begins, move the governing Issue/Project state to `In Progress` and remove `agent:ready` before local edits so another agent does not pick up the same task.
 
+Workflow state model:
+
+- Issue state is for claim/active/block/closure flow: `Ready`, `In Progress`, `Blocked`, `Done`.
+- PR/Project-item state is for review/integration/delivery projection: `Review`, `In Progress`, `Blocked`, `Done`.
+- Default PR mode is open (non-draft). Draft PR is opt-in and requires an explicit reason.
+- `Review` is the agent-review phase before verification; it is not a human-waiting synonym.
+- PR/project `Done` should be projected by automation where possible; skills should only fallback-correct when projection drifts.
+- `pr-integration` is a conditional repair/readiness step, not a mandatory hop after every publish.
+
 ## Change classification
 
 Before editing, classify the change:

--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -151,6 +151,17 @@ For implementation work, the delivery loop is:
 7. Feature validation continues on the parent issue until the operator/product path is proven.
 8. Acceptance closes the feature and triggers owner-doc promotion when the support claim changes.
 
+State model for lane-based delivery:
+
+- Issue state supports claim and bounded execution truth: `Ready`, `In Progress`, `Blocked`, `Done`.
+- PR/Project-item state supports review/integration projection: `Review`, `In Progress`, `Blocked`, `Done`.
+- Keep issue and PR state separate in multi-slice lanes where several implementation issues can feed the same lane PR.
+- `issue-to-code` owns fast issue claim (`Ready` -> `In Progress` and remove `agent:ready`) to prevent double-pick.
+- Open PR is the default publication mode. Draft PR is opt-in and requires an explicit reason.
+- `Review` is the agent-review gate before verification, not a generic waiting state.
+- `pr-integration` is conditional and should be used when mergeability/CI attachment/reviewability needs repair; it is not required after every publication.
+- Prefer automation for PR/project-item projection (especially `Done` on terminal PR state) and use manual skill writes as fallback correction when drift is detected.
+
 Execution rule:
 
 - do not start non-trivial implementation without a governing Issue

--- a/docs/development/GITHUB_GOVERNANCE_SETUP.md
+++ b/docs/development/GITHUB_GOVERNANCE_SETUP.md
@@ -39,8 +39,8 @@ Required fields:
 Status meanings:
 - `Backlog`: tracked work that is not yet ready for agent execution or has been moved out of active execution
 - `Ready`: bounded, testable, unblocked work that is eligible for pickup and labeled `agent:ready`
-- `In Progress`: active implementation, including draft PRs and open PRs before explicit review handoff
-- `Review`: explicit review handoff, normally after review is requested on the active PR
+- `In Progress`: active implementation issue state; on PR items this means draft/rework phase
+- `Review`: PR/project-item review/integration gate and default state for normal open PRs
 - `Done`: merged or otherwise fully delivered work; the Issue is closed and no `agent:*` labels remain
 
 Agent-label meanings:
@@ -61,8 +61,10 @@ Required views:
 Required automation:
 - new issue -> `Status=Backlog`
 - issue reopened or agent-label changed -> reconcile `Status` from the current Issue state and truthful agent label
-- PR opened -> `Status=In Progress`
-- PR review requested -> `Status=Review`
+- PR opened/reopened (non-draft) -> `Status=Review`
+- PR opened/reopened (draft) -> `Status=In Progress`
+- PR marked ready for review -> `Status=Review`
+- PR converted to draft -> `Status=In Progress`
 - PR merged -> `Status=Done`
 - PR closed -> `Status=Done` when the PR is terminal and no longer active
 - issue and PR Project items are reconciled by repo-side workflow so merged PR cards and closed Issue cards do not drift
@@ -73,7 +75,8 @@ Interpretation note:
 
 Lifecycle guardrails:
 - active implementation must not remain `Ready`
-- `Review` must not be used only because a PR exists; use it when review handoff is explicit
+- issues should not move to `Review` only because a PR exists; issue state remains claim/execution truth
+- normal open PRs should default to `Review`; draft is opt-in and should be used only with an explicit reason
 - closed issues must not retain `agent:ready`, `agent:blocked`, or `agent:needs-human`
 - merged or otherwise closed terminal PR items must not remain unset or non-terminal in the Project; they should reconcile to `Done`
 
@@ -90,6 +93,7 @@ Projection rule:
 - Governance-lane PRs may omit an Issue reference only when they are explicitly classified as governance lane and remain limited to approved governance surfaces.
 - Agents only pick Issues labeled `agent:ready`.
 - Agents only pick Issues when `Status=Ready` and the Issue is labeled `agent:ready`.
+- Issue claim (`Ready` -> `In Progress` plus `agent:ready` removal) remains a synchronous skill action, not PR automation.
 - Agents must stay within Issue scope, constraints, and acceptance criteria.
 - Blank/free-form Issues are disabled at repo level.
 

--- a/scripts/project_status.py
+++ b/scripts/project_status.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""
+Project PR status projection helper.
+
+Maps GitHub PR lifecycle events to a deterministic Project `Status` and then
+delegates the actual write to the existing reconcile script.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+
+
+def parse_bool(value: str) -> bool:
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def desired_status(action: str, draft: bool | None) -> str:
+    if action in {"opened", "reopened"}:
+        if draft is None:
+            raise ValueError("draft is required for opened/reopened events")
+        return "In Progress" if draft else "Review"
+    if action == "ready_for_review":
+        return "Review"
+    if action == "converted_to_draft":
+        return "In Progress"
+    raise ValueError(f"unsupported pull request action: {action}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", required=True, help="owner/repo")
+    parser.add_argument("--pr", type=int, required=True, help="Pull request number")
+    parser.add_argument("--action", required=True, help="GitHub pull_request action")
+    parser.add_argument("--draft", help="True when the PR is currently a draft")
+    args = parser.parse_args()
+
+    draft = None if args.draft is None else parse_bool(args.draft)
+    status = desired_status(args.action, draft)
+    cmd = [
+        sys.executable,
+        "scripts/reconcile_project_status.py",
+        "--repo",
+        args.repo,
+        "--pr",
+        str(args.pr),
+        "--status",
+        status,
+    ]
+    subprocess.run(cmd, check=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fixes #556
Fixes #557
Fixes #558
Fixes #559

## Summary
- codifies a lane-compatible workflow state model separating issue claim state from PR/project review state
- adds PR event automation for non-draft/draft projection to Project Status
- rewrites hot-path and cold-path repo skills for open-PR default, conditional integration, and lower-churn maintenance behavior

## Validation
- python3 -m py_compile scripts/project_status.py
- ruby -e 'require \"yaml\"; %w[.github/workflows/project-pr-opened.yml .github/workflows/project-pr-stage-change.yml .github/workflows/project-status-reconcile.yml].each{|f| YAML.load_file(f)}; puts \"yaml-ok\"'
- focused rg checks across updated policy/skill docs for required state-model and workflow language