### PR TITLE
Deliver v6 enabling slices for promotion receipts, instance provenance, and artifact-kind routing

### DIFF
--- a/.codex/skills/README.md
+++ b/.codex/skills/README.md
@@ -8,7 +8,11 @@ These skills are workflow helpers, not replacements for the canonical builder-ag
 
 ## Workflow map
 
-`Docs -> Issue -> Project -> Issue maintenance -> Agent -> Publish PR -> PR integration -> CI -> Verification -> Merge -> Project/doc closure -> Owner Doc`
+Hot path:
+`Docs -> Issue -> Project -> Issue maintenance -> Agent -> issue-to-code fast claim -> Publish PR -> CI -> Verification -> Merge -> Project/doc closure -> Owner Doc`
+
+Conditional / maintenance path:
+`Issue maintenance -> Agent` for stale or false backlog state, and `Publish PR -> pr-integration` only when readiness/repair work is still needed before verification.
 
 ## Skill routing
 
@@ -17,6 +21,7 @@ These skills are workflow helpers, not replacements for the canonical builder-ag
 - `issue-to-code`
   - implementation entrypoint for bounded GitHub Issue work
   - before coding, update lifecycle state truthfully: move active work to `In Progress` and remove `agent:ready`
+  - use that transition as the minimal shared claim/lease compatibility signal in multi-agent environments
 - `issue-maintenance-change-control`
   - repair stale or false Issue / PR / label / Project state before or during execution
 - `docs-authoring`
@@ -28,9 +33,9 @@ These skills are workflow helpers, not replacements for the canonical builder-ag
 - `publish-pr`
   - publication boundary for branch, commit, push, and PR creation after local work is ready
 - `pr-integration`
-  - run after `publish-pr` and before verification to make the PR mergeable and CI-attached
+  - readiness/repair path after `publish-pr` when the PR still needs mergeability, CI attachment, or review-feedback repair before verification
 - `verification-and-closure`
-  - final verification, merge, and delivery-state closure after implementation / PR work
+  - final verification, merge, and delivery-state closure after implementation / PR work; honors automation-driven `Done` projection and only fallback-writes it when needed
 - `post-merge-owner-doc`
   - invoked by `verification-and-closure` at merge time; reads the diff and decides whether any owner doc needs promotion, then acts on it
 - `backlog-reconciliation-drift-audit`

--- a/.codex/skills/backlog-reconciliation-drift-audit/SKILL.md
+++ b/.codex/skills/backlog-reconciliation-drift-audit/SKILL.md
@@ -12,6 +12,7 @@ Treat closed PR cards as part of lifecycle truth, not as an afterthought.
 
 This is not feature planning.
 This is anti-drift maintenance.
+It is a cold-path audit, not a hot-path intake workflow.
 
 ## Audit model
 
@@ -24,6 +25,7 @@ You must detect:
 - Issues whose `Source Anchors` no longer match current docs
 - roadmap/plan items that still read as pending after merge
 - delivered code with missing owner-doc writeback
+- backlog items that should have been repaired in a batch but were instead handled one-by-one
 - duplicate Issues covering the same anchored source item
 - Issues in false Project status
 - closed PR cards that still have blank or non-terminal Project status
@@ -85,6 +87,7 @@ For each drift case, recommend one concrete corrective action only:
 - GitHub remains the canonical backlog-state surface.
 - Treat Project `Status` as the primary lifecycle signal.
 - Treat `agent:ready` as the pickup qualifier for `Status=Ready`, not as a substitute for `In Progress`, `Review`, or `Done`.
+- Prefer one repair action per drift class when the same correction repeats across multiple items; do not churn the board with separate micro-fixes when a batched audit can close the gap.
 
 
 ## Capturing learning

--- a/.codex/skills/bug-to-issue/SKILL.md
+++ b/.codex/skills/bug-to-issue/SKILL.md
@@ -8,6 +8,7 @@ description: "Create a GitHub Issue whenever a bug is discovered during analysis
 ## Overview
 
 Turn any discovered bug into a compliant GitHub Issue that matches the repo's contract shape and labels. Default to creating issues in the current repo unless the user specifies a different one.
+This is the hot-path defect intake lane, not the cold-path maintenance lane.
 
 ## Workflow
 
@@ -27,6 +28,7 @@ Turn any discovered bug into a compliant GitHub Issue that matches the repo's co
      - `## Suggested Validation`
      - `## Source Docs`
    - Include exact repro steps and observed/expected results when available.
+   - Do not create a micro-issue for routine repair, reconciliation, or bookkeeping churn; route those signals to the maintenance skills instead.
    - Acceptance Criteria must carry `Verify:` markers:
      - The primary behavioral AC ("bug no longer reproduces") points to a regression test the fix will add: `Verify: \`tests/<path>::test_<bug_name>\`` — the test should fail against current code and go green after the fix.
      - Any non-behavioral AC (doc clarifications, roadmap/status wording) points to its observable target.
@@ -46,6 +48,7 @@ Set `agent:ready` when all are true:
 - Every AC carries a resolvable `Verify:` target; the repro is expressible as a named failing test.
 - Source anchors point to specific files or docs.
 - No unresolved decisions or missing contract inputs.
+- The bug is a real defect, not a low-signal maintenance correction that should be batched into audit or retrospective work.
 
 Force `agent:needs-human` when:
 - It is a Core Runtime ↔ Agentic Lab boundary move without explicit direction and module paths.

--- a/.codex/skills/capture-learning/SKILL.md
+++ b/.codex/skills/capture-learning/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: capture-learning
-description: "Append one structured divergence entry to docs/learning-log.md. Invoke when you do something you did not expect to do, or discover an earlier artifact was wrong — not on normal work."
+description: "Append one structured divergence entry to docs/learning-log.md when a concrete divergence is worth immediate upstream repair; defer low-signal cases to retrospective batching."
 ---
 
 # Capture Learning
 
-Single-job micro-skill. Appends one entry to `docs/learning-log.md` when a plan divergence occurs during delivery.
+Maintenance-path repair skill. Appends one entry to `docs/learning-log.md` when a plan divergence is concrete enough to name an upstream artifact now.
 
 ## When to invoke
 
@@ -14,6 +14,8 @@ Invoke only when:
 - you discovered an earlier artifact was wrong
 
 Do NOT invoke when work went exactly as planned.
+
+This is not a hot-path routine for every small divergence. If the signal is minor, repetitive, or not yet actionable, batch it for `learning-retrospective` instead of interrupting the current task.
 
 The "name an artifact" gate: you must name an upstream artifact before logging. If you cannot name one, do not log.
 
@@ -44,7 +46,7 @@ Append after the last existing entry (or after the `---` separator if the log is
 
 ## Timing
 
-Invoke before continuing with remaining task work. Context is freshest at the moment of divergence — do not batch to end of task.
+Invoke before continuing only when the divergence needs immediate upstream repair. Otherwise, collect the signal and let the next retrospective convert batched notes into a concrete edit.
 
 ## Output format
 

--- a/.codex/skills/docs-to-issue/SKILL.md
+++ b/.codex/skills/docs-to-issue/SKILL.md
@@ -8,12 +8,15 @@ description: "Convert active repo documentation into bounded GitHub Issues witho
 You are a repository backlog-orchestration agent for a repo-first, docs-as-code software system.
 
 Your job is to convert active documentation into bounded GitHub Issues without inventing strategy.
+This is the backlog-intake lane, not the maintenance repair lane.
 
 ## Canonical workflow
 
 `Docs -> Feature issue or slice issue -> Project -> Issue maintenance -> Agent -> PR -> PR integration -> CI -> Slice verification -> Merge -> Feature validation -> Acceptance -> Owner Doc`
 
 Plus: periodic reconciliation.
+
+Use maintenance skills instead of this lane when the work is a repair, audit, or periodic drift correction.
 
 ## Authority order
 
@@ -31,6 +34,7 @@ Plus: periodic reconciliation.
 - Inline doc markers such as `Tracked by: #123` and `Backlog: #123` are secondary convenience notes only.
 - New backlog work must use stable `Source Anchors`.
 - Do not create duplicate Issues.
+- Do not create micro-issues or churn Project state for routine maintenance notes that can be batched into one bounded repair item.
 - If a docs item is larger than one bounded implementation issue or clearly needs post-merge validation before owner docs should change, route it through `feature-breakdown` instead of flattening it into one issue.
 - Do not create Issues for vague aspirations, broad cleanup, philosophy, or already delivered work.
 - If an item is too large, split it into multiple bounded Issues with explicit dependency order.
@@ -51,6 +55,7 @@ For every candidate doc item, determine exactly one state:
 3. Inspect recent open and merged PRs.
 4. Check whether the work is already tracked, already delivered, superseded, partially delivered, or blocked.
 5. Decide whether the item should stay as one bounded issue or be turned into one parent feature issue plus child slices via `feature-breakdown`.
+6. If the candidate would only create bookkeeping churn, keep it out of the backlog and route it to the maintenance path instead.
 
 ## When a doc item becomes a new Issue
 

--- a/.codex/skills/issue-maintenance-change-control/SKILL.md
+++ b/.codex/skills/issue-maintenance-change-control/SKILL.md
@@ -11,6 +11,7 @@ You are an Issue maintenance and lifecycle-correction agent for a repo-first, do
 
 Your job is to keep GitHub Issues, Pull Requests, labels, and Project state truthful when backlog state drifts from implementation reality.
 That includes PR lifecycle truth, not only Issue lifecycle truth.
+This is a cold-path maintenance role, not a hot-path implementation routine.
 
 You operate between:
 `Docs -> Issue -> Project -> Issue maintenance -> Agent -> PR -> CI -> Verification -> Project/doc closure -> Owner Doc`
@@ -28,6 +29,7 @@ You operate between:
 - owner-doc writeback or roadmap cleanup is missing after delivery
 - Issue state, PR state, labels, and Project state disagree
 - the request touches Core Runtime <-> Agentic Lab boundary moves or operator-facing defaults
+- the same repair should be batched across several drifted items instead of handled as isolated micro-fixes
 
 ## Authority and entry points
 
@@ -45,6 +47,7 @@ You operate between:
 - Correct Project drift opportunistically, but do not block delivery solely because a personal Project v2 board cannot be updated.
 - Do not invent strategy.
 - Preserve traceability through `Source Anchors`.
+- Prefer batched maintenance actions for repeated drift patterns; reserve single-item churn for cases where the items genuinely differ.
 
 ## Canonical lifecycle expectations
 
@@ -171,6 +174,12 @@ If an open implementation Issue is malformed, stale, or no longer safely executa
    ```
 
 3. **Post comment with required action**
+
+### Maintenance path versus hot path
+
+- Hot path: active implementation work that is ready to be picked up and executed by an agent.
+- Maintenance path: repairs, audits, reconciliation, and cleanup that exist to restore truth in docs, issues, projects, or receipts.
+- If the task is on the maintenance path, do not force it into `agent:ready` just to make it look executable.
 
 ### Action: Issue Delivered but Still Open
 

--- a/.codex/skills/issue-to-code/SKILL.md
+++ b/.codex/skills/issue-to-code/SKILL.md
@@ -14,7 +14,11 @@ Only execute bounded implementation work from a GitHub Issue that is the canonic
 
 ## Canonical workflow
 
-`Docs -> Feature issue -> Slice issue -> Agent -> Publish PR -> PR integration -> CI -> Slice verification -> Merge -> Feature validation -> Acceptance -> Owner Doc`
+Hot path:
+`Docs -> Feature issue -> Slice issue -> Agent -> Fast claim (Ready -> In Progress + remove agent:ready) -> Publish PR -> PR integration (conditional readiness/repair) -> CI -> Slice verification -> Merge -> Feature validation -> Acceptance -> Owner Doc`
+
+Conditional / maintenance path:
+`Issue maintenance -> Agent` and `Publish PR -> PR integration` only when mergeability, CI attachment, or review repair is still needed.
 
 Treat these Issue sections as binding for the governing slice issue:
 
@@ -35,6 +39,8 @@ Treat these Issue sections as binding for the governing slice issue:
 - Do not leave actively worked Issues in `Ready`.
 - Do not leave blocked Issues in `In Progress`.
 - Do not use `Review` only because a PR exists; keep work `In Progress` until review handoff is explicit.
+- Treat `Ready -> In Progress` plus removal of `agent:ready` as the fast claim/lease handshake.
+- Keep that claim minimal and compatible with multi-agent environments: one active lease per Issue, with the label/status transition as the shared signal.
 
 Allowed labels:
 
@@ -85,7 +91,7 @@ When you start active work on an Issue:
    gh api graphql -f query='query { repository(owner:"OWNER", name:"REPO") { issue(number:N) { projectItems(first:1) { nodes { id } } } } }'
    ```
 
-2. **Remove `agent:ready` label:**
+2. **Fast-claim the Issue by removing `agent:ready`:**
    ```bash
    gh issue edit #<N> --remove-label agent:ready
    ```

--- a/.codex/skills/learning-retrospective/SKILL.md
+++ b/.codex/skills/learning-retrospective/SKILL.md
@@ -5,13 +5,15 @@ description: "Read docs/learning-log.md since the last retro marker, cluster sig
 
 # Learning Retrospective
 
-Cadence-triggered (manual, or roughly every 10 deliveries). Reads divergence signals logged since the last retrospective and converts them into concrete, actionable edit proposals for upstream artifacts.
+Periodic maintenance pass. Reads batched divergence signals logged since the last retrospective and converts them into concrete, actionable edit proposals for upstream artifacts.
 
 **Does NOT execute edits.** All proposals go to human review first.
 
 ## Trigger
 
 Run when the human requests a retrospective, or after approximately 10 deliveries have accumulated entries in `docs/learning-log.md`.
+
+This is a cold-path repair step, not a hot-path delivery routine.
 
 ## Workflow
 
@@ -33,6 +35,8 @@ Group entries by their `**Upstream artifact:**` field. Example clusters:
 - `.codex/skills/issue-to-code/SKILL.md` — entries pointing to the issue-to-code skill
 - `task-contract template` — entries pointing to the issue body template
 - `unknown — flag for retro` — entries where the artifact was unresolved at log time
+
+Prefer batching similar low-signal entries into one repair proposal when they point at the same upstream artifact.
 
 ### Step 3: Propose concrete edits
 

--- a/.codex/skills/post-merge-owner-doc/SKILL.md
+++ b/.codex/skills/post-merge-owner-doc/SKILL.md
@@ -8,6 +8,7 @@ description: "After an implementation PR merges, read the diff and decide whethe
 You are invoked at the end of `verification-and-closure`, after a PR has merged. Your job is one question: **did this merge change something an owner doc currently claims?**
 
 You act on the answer. You do not ask the user to classify, attest, or unblock.
+This is a cold-path maintenance check, not a hot-path implementation step.
 
 ## The one question
 
@@ -28,11 +29,13 @@ The receipt comment always goes on the **closed issue** that the PR fixes. If th
 
 ## Three outcomes
 
-**1. Yes, and the wording change is clear.**
+Classify the claim into one of three lanes: immediate action, queued follow-up, or no change.
+
+**1. Yes, and the wording change is clear. Immediate action.**
 
 Open a docs-only PR via `docs-authoring` that updates the owner doc(s). Title: `docs: owner-doc promotion for #<closed-issue>`. Body links back to the closed issue and names the specific claim(s) being corrected. Add a comment on the closed issue: `post-merge owner-doc check: docs PR opened at #<docs-pr>`.
 
-**2. Yes, but the right wording needs human judgment.**
+**2. Yes, but the right wording needs human judgment. Queue a follow-up.**
 
 Open one bounded follow-up issue. Title: `docs: owner-doc promotion needed for #<closed-issue>`. Body names:
 
@@ -54,6 +57,7 @@ That comment is the receipt. If it is missing on a closed implementation issue, 
 - **Owner docs claim current-state truth.** If a shipped change makes an owner-doc sentence false, outdated, or misleading, the sentence needs to change. Stylistic preference is not a reason to open a PR.
 - **Target-state and plan docs are not owner docs.** `docs/plans/*`, `docs/{CAPABILITY}/*` specs, and v6.0 target docs describe intent, not current-state truth. Do not open promotion PRs against them unless the merge itself changes target-state intent, which is rare.
 - **Prefer the smallest correct change.** A single sentence fix in `STATUS.md` beats a chapter rewrite. If the wording gap is small, just fix it (outcome 1). Only escalate to outcome 2 when the correct phrasing genuinely needs the user's judgment.
+- **Split immediate action from queued repair.** If the owner-doc claim is clearly wrong, open the docs PR now. If the claim is only plausibly wrong or needs interpretation, queue one bounded follow-up issue instead of creating churn or guessing.
 - **When unsure between outcomes 1 and 2, pick 2.** A follow-up issue is cheaper than an incorrect owner-doc PR.
 - **When unsure between outcomes 2 and 3, pick 2.** A false negative (silent drift) is worse than a spurious follow-up issue the user can close in ten seconds.
 - **Never open more than one PR or one issue per merge.** If multiple owner docs need changes, bundle them. If the bundle is too large to review, that is signal that the merge itself should have been split — file one follow-up issue noting the scope, not many.

--- a/.codex/skills/pr-integration/SKILL.md
+++ b/.codex/skills/pr-integration/SKILL.md
@@ -5,7 +5,7 @@ description: "Prepare a slice-implementation PR for verification by resolving me
 
 # PR Integration
 
-Use this skill after `publish-pr` and before the verification stage.
+Use this skill when a PR needs readiness/repair before verification; it is the conditional path after `publish-pr`, not a mandatory immediate publication step.
 
 Goal:
 produce a mergeable, policy-compliant PR with CI **green** on the latest head SHA so verification can run on truthful state.
@@ -16,6 +16,10 @@ This skill does NOT merge the PR. Merge is owned by the verification skill after
 
 ## Canonical workflow position
 
+Hot path:
+`Docs -> Feature issue -> Slice issue -> Agent -> Publish PR -> CI -> Slice verification -> Merge -> Feature validation -> Acceptance -> Owner Doc`
+
+Conditional / readiness-repair path:
 `Docs -> Feature issue -> Slice issue -> Agent -> Publish PR -> PR integration -> CI -> Slice verification -> Merge -> Feature validation -> Acceptance -> Owner Doc`
 
 ## First context to load
@@ -32,6 +36,7 @@ This skill does NOT merge the PR. Merge is owned by the verification skill after
 - A PR exists (draft or ready) and links the governing branch.
 - The PR was just created or updated by `.codex/skills/publish-pr/SKILL.md` or equivalent truthful publication flow.
 - Implementation changes are already in place.
+- Use this skill when the PR still needs mergeability, CI attachment, or review-feedback repair before verification.
 
 ## Exit conditions
 

--- a/.codex/skills/publish-pr/SKILL.md
+++ b/.codex/skills/publish-pr/SKILL.md
@@ -10,7 +10,7 @@ Use this skill when local work is complete enough to publish as a branch and pul
 Goal:
 turn validated local changes into a truthful branch, commit, pushed head, and PR artifact without mixing publication with implementation logic.
 
-⚠️ **CRITICAL: All publication steps (branch creation, staging, commit, push, PR creation) must be executed using explicit git/gh commands. Do not describe these steps—execute them and verify they succeeded. Hand off to pr-integration is mandatory.**
+⚠️ **CRITICAL: All publication steps (branch creation, staging, commit, push, PR creation) must be executed using explicit git/gh commands. Do not describe these steps—execute them and verify they succeeded. Treat pr-integration as a conditional readiness/repair path, not an automatic immediate handoff.**
 
 ## Canonical workflow position
 
@@ -40,7 +40,8 @@ turn validated local changes into a truthful branch, commit, pushed head, and PR
 - Do not publish unrelated local changes.
 - For implementation lane PRs, the body must include `Fixes #<id>`, `Closes #<id>`, or `Resolves #<id>`.
 - For docs-authoring or governance lane PRs, leave the linked Issue blank unless a governing Issue actually exists.
-- Default to opening a draft PR unless the work is explicitly ready for review handoff.
+- Default to opening an open PR.
+- Use `--draft` only with an explicit reason that the PR is not yet ready for review or still needs integration/repair.
 - Publication does not move work to `Done`.
 
 ## Publication workflow (all steps are executable)
@@ -115,7 +116,7 @@ Execute based on lane classification:
 
 **Implementation Lane (Fixes an Issue):**
 ```bash
-gh pr create --draft \
+gh pr create \
   --title "<bounded outcome>" \
   --body "$(cat <<'EOF'
 Fixes #<ISSUE_NUMBER>
@@ -133,7 +134,7 @@ EOF
 
 **Docs Authoring Lane:**
 ```bash
-gh pr create --draft \
+gh pr create \
   --title "<docs update title>" \
   --body "$(cat <<'EOF'
 - [x] Docs authoring lane
@@ -154,7 +155,7 @@ EOF
 
 **Governance Lane:**
 ```bash
-gh pr create --draft \
+gh pr create \
   --title "<governance change title>" \
   --body "$(cat <<'EOF'
 - [x] Governance lane
@@ -183,14 +184,14 @@ EOF
 
 ### Step 7: Hand Off to pr-integration
 
-After PR is created/updated, execute pr-integration skill:
+After PR is created/updated, use pr-integration only when the PR still needs readiness/repair work before verification:
 
 ```bash
 # Invoke pr-integration skill to verify, check CI, and prepare for verification
 echo "Handing off to pr-integration skill"
 ```
 
-**Do not skip this handoff.** PR integration resolves merge conflicts, verifies CI, and prepares the PR for verification/merge.
+**Do not force this as an immediate publication step.** PR integration resolves merge conflicts, verifies CI, and prepares the PR for verification/merge when the PR needs that readiness path.
 
 ## PR body requirements
 

--- a/.codex/skills/temporal-doc-governance/SKILL.md
+++ b/.codex/skills/temporal-doc-governance/SKILL.md
@@ -6,6 +6,7 @@ description: "Audit and update time-sensitive docs such as STATUS, ROADMAP, roll
 # Temporal Doc Governance
 
 Use this skill when the task is to audit or update documentation with a strong temporal component.
+This is a periodic maintenance pass, not a hot-path delivery step.
 
 Typical targets:
 
@@ -14,6 +15,8 @@ Typical targets:
 - `docs/DOCS_INDEX.md`
 - rollout, track, runbook, and current-state docs
 - any doc that can drift because code, issues, runtime posture, or operational state changed
+
+Use it to repair temporal drift, not to add one-off backlog intake or implementation chatter.
 
 ## First context to load
 
@@ -63,6 +66,7 @@ Use these classes:
 - Prefer correcting current-state claims over rewriting large sections.
 - Keep `ROADMAP` forward-looking; move delivered truth into the owner/current-state doc.
 - Keep `STATUS` explicitly operational; remove roadmap-like language when reality is already shipped or no longer active.
+- Batch repeated temporal corrections where the same claim appears across multiple docs, and avoid splitting one drift class into many micro-edits unless the surfaces truly diverge.
 - If a claim cannot be verified, mark the uncertainty instead of presenting it as current truth.
 - Update `Last reviewed` whenever the doc is intentionally checked.
 - Update `Last verified against` with the most local concrete verification anchor available.

--- a/.codex/skills/verification-and-closure/SKILL.md
+++ b/.codex/skills/verification-and-closure/SKILL.md
@@ -18,6 +18,7 @@ You operate after PR integration has produced a mergeable, CI-green PR.
 - ensure shipped truth moved to the right owner docs
 - ensure roadmap/plan wording no longer falsely reads as pending
 - detect false backlog/project states
+- honor automation-driven PR/Project `Done` projection first, and only fallback-set `Done` when needed
 - **merge the PR when the delivery contract is satisfied**
 - close the governing Issue and set Project Status to Done
 - unblock dependent issues
@@ -124,14 +125,14 @@ When all merge prerequisites are met:
    gh issue edit #<N> --remove-label agent:ready --remove-label agent:blocked --remove-label agent:needs-human
    ```
 
-6. **Set Issue Project Status to Done:**
+6. **Set Issue Project Status to Done if automation has not already projected it:**
    ```bash
    gh api graphql -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
      -f fieldId="$STATUS_FIELD_ID" -f optionId="$DONE_OPTION_ID" \
      -f query='mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!) { updateProjectV2ItemFieldValue(input:{projectId:$projectId itemId:$itemId fieldId:$fieldId value:{singleSelectOptionId:$optionId}}) { projectV2Item { id } } }'
    ```
 
-7. **Set PR Project Status to Done:**
+7. **Set PR Project Status to Done if automation has not already projected it:**
    ```bash
    gh api graphql -f projectId="$PROJECT_ID" -f itemId="$PR_ITEM_ID" \
      -f fieldId="$STATUS_FIELD_ID" -f optionId="$DONE_OPTION_ID" \
@@ -166,6 +167,7 @@ When all merge prerequisites are met:
 **Verification owns terminal delivery-state correction. All state changes must be executed, not just described.**
 
 - An open or draft PR without explicit review handoff remains `In Progress`; `Review` is reserved for the review handoff state.
+- If project/PR automation has already projected `Done`, verify that state rather than writing it again; only apply the fallback `Done` mutation when the item still needs terminal projection.
 
 ### Slice Issue Fully Delivered
 
@@ -202,7 +204,7 @@ If the feature issue is fully delivered and acceptance is satisfied:
 
 If a related PR was closed without merge but represents terminal tracked work:
 
-1. **Set PR Project Status to Done:**
+1. **Set PR Project Status to Done if automation has not already projected it:**
    ```bash
    gh api graphql -f projectId="$PROJECT_ID" -f itemId="$PR_ITEM_ID" \
      -f fieldId="$STATUS_FIELD_ID" -f optionId="$DONE_OPTION_ID" \

--- a/.github/workflows/project-pr-opened.yml
+++ b/.github/workflows/project-pr-opened.yml
@@ -1,0 +1,26 @@
+name: Project PR Opened
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+  repository-projects: write
+
+jobs:
+  project-pr-status:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Project PR state projection
+        # Draft PRs stay In Progress; non-draft PRs move to Review.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 scripts/project_status.py \
+            --repo "${{ github.repository }}" \
+            --pr "${{ github.event.pull_request.number }}" \
+            --action "${{ github.event.action }}" \
+            --draft "${{ github.event.pull_request.draft }}"

--- a/.github/workflows/project-pr-stage-change.yml
+++ b/.github/workflows/project-pr-stage-change.yml
@@ -1,0 +1,25 @@
+name: Project PR Stage Change
+
+on:
+  pull_request:
+    types: [ready_for_review, converted_to_draft]
+
+permissions:
+  contents: read
+  pull-requests: read
+  repository-projects: write
+
+jobs:
+  project-pr-status:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Project PR stage projection
+        # Stage-change events are deterministic: ready -> Review, draft -> In Progress.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 scripts/project_status.py \
+            --repo "${{ github.repository }}" \
+            --pr "${{ github.event.pull_request.number }}" \
+            --action "${{ github.event.action }}"

--- a/.github/workflows/project-status-reconcile.yml
+++ b/.github/workflows/project-status-reconcile.yml
@@ -3,8 +3,6 @@ name: Project Status Reconcile
 on:
   issues:
     types: [opened, reopened, closed, labeled, unlabeled]
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, review_requested, closed]
   schedule:
     - cron: '17 * * * *'
   workflow_dispatch:
@@ -28,24 +26,6 @@ jobs:
           python3 scripts/reconcile_project_status.py \
             --repo "${{ github.repository }}" \
             --issue "${{ github.event.issue.number }}"
-
-  reconcile-pr:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Reconcile PR project status
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          EXTRA_ARGS=""
-          if [ "${{ github.event.action }}" = "review_requested" ]; then
-            EXTRA_ARGS="--status Review"
-          fi
-          python3 scripts/reconcile_project_status.py \
-            --repo "${{ github.repository }}" \
-            --pr "${{ github.event.pull_request.number }}" \
-            ${EXTRA_ARGS}
 
   reconcile-scan:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,15 @@ For GitHub implementation work, loading `.codex/skills/issue-to-code/SKILL.md` i
 That skill owns the pickup rule:
 when active work begins, move the governing Issue/Project state to `In Progress` and remove `agent:ready` before local edits so another agent does not pick up the same task.
 
+Workflow state model:
+
+- Issue state is for claim/active/block/closure flow: `Ready`, `In Progress`, `Blocked`, `Done`.
+- PR/Project-item state is for review/integration/delivery projection: `Review`, `In Progress`, `Blocked`, `Done`.
+- Default PR mode is open (non-draft). Draft PR is opt-in and requires an explicit reason.
+- `Review` is the agent-review phase before verification; it is not a human-waiting synonym.
+- PR/project `Done` should be projected by automation where possible; skills should only fallback-correct when projection drifts.
+- `pr-integration` is a conditional repair/readiness step, not a mandatory hop after every publish.
+
 ## Change classification
 
 Before editing, classify the change:

--- a/app/agents/normalizer/agent.py
+++ b/app/agents/normalizer/agent.py
@@ -6,21 +6,66 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 from app.events.types import INGEST_NORMALIZE_DONE
 from app.store.object_store import ObjectStore
 from app.services.audit import audit_event
 
 
 AGENT = "normalizer"
+_ALLOWED_ARTIFACT_KINDS = {"note", "task", "knowledge", "reference", "log"}
 
 
-def _read_file(path: str) -> tuple[str, str]:
+def _split_frontmatter(raw: str) -> tuple[dict[str, Any], str]:
+    if not raw.startswith("---"):
+        return {}, raw
+    lines = raw.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}, raw
+    end_idx: int | None = None
+    for idx in range(1, len(lines)):
+        if lines[idx].strip() == "---":
+            end_idx = idx
+            break
+    if end_idx is None:
+        return {}, raw
+    frontmatter_text = "\n".join(lines[1:end_idx])
+    body = "\n".join(lines[end_idx + 1 :])
+    try:
+        frontmatter = yaml.safe_load(frontmatter_text) or {}
+        if not isinstance(frontmatter, dict):
+            frontmatter = {}
+    except Exception:
+        frontmatter = {}
+    return frontmatter, body
+
+
+def _resolve_artifact_kind(frontmatter: dict[str, Any], explicit_kind: str | None) -> tuple[str, list[dict[str, str]]]:
+    diagnostics: list[dict[str, str]] = []
+    requested = str(explicit_kind or frontmatter.get("artifact_kind") or frontmatter.get("kind") or "").strip().lower()
+    if not requested:
+        return "note", diagnostics
+    if requested in _ALLOWED_ARTIFACT_KINDS:
+        return requested, diagnostics
+    diagnostics.append(
+        {
+            "code": "unsupported_artifact_kind",
+            "requested_kind": requested,
+            "fallback_kind": "note",
+        }
+    )
+    return "note", diagnostics
+
+
+def _read_file(path: str) -> tuple[str, str, dict[str, Any]]:
     """
     Return (title, body_text) from a markdown-ish file.
     """
     p = Path(path)
     raw = p.read_text(encoding="utf-8")
-    lines = [ln.strip() for ln in raw.splitlines()]
+    frontmatter, body = _split_frontmatter(raw)
+    lines = [ln.strip() for ln in body.splitlines()]
     title = ""
     for ln in lines:
         if ln.startswith("#"):
@@ -33,17 +78,18 @@ def _read_file(path: str) -> tuple[str, str]:
             break
     if not title:
         title = p.stem
-    return title, raw
+    return title, raw, frontmatter
 
 
-def normalize_file(path: str, *, trace_id: str) -> dict[str, Any]:
+def normalize_file(path: str, *, trace_id: str, artifact_kind: str | None = None) -> dict[str, Any]:
     """
     Build a 'domain object' from a source file:
     - uuid
     - core6 metadata
     - payload with raw_text + source_path
     """
-    title, raw_text = _read_file(path)
+    title, raw_text, frontmatter = _read_file(path)
+    normalized_artifact_kind, diagnostics = _resolve_artifact_kind(frontmatter, artifact_kind)
 
     object_uuid = str(_uuid.uuid4())
 
@@ -58,6 +104,9 @@ def normalize_file(path: str, *, trace_id: str) -> dict[str, Any]:
         "core6": core6,
         "raw_text": raw_text,
         "source_path": path,
+        "artifact_kind": normalized_artifact_kind,
+        "policy_profile_kind": normalized_artifact_kind,
+        "ingest_diagnostics": diagnostics,
     }
 
     domain_object = {
@@ -89,7 +138,7 @@ class _DomainObjectShim:
     source_ref: str | None
 
 
-def run(path: str, *, trace_id: str) -> dict[str, Any]:
+def run(path: str, *, trace_id: str, artifact_kind: str | None = None) -> dict[str, Any]:
     """
     End-to-end:
     - normalize file into domain_object
@@ -97,7 +146,7 @@ def run(path: str, *, trace_id: str) -> dict[str, Any]:
     - save via ObjectStore (memory + DB if available)
     """
     store = ObjectStore()
-    dom = normalize_file(path, trace_id=trace_id)
+    dom = normalize_file(path, trace_id=trace_id, artifact_kind=artifact_kind)
 
     shim = _DomainObjectShim(
         uuid=dom["uuid"],
@@ -116,6 +165,10 @@ def run(path: str, *, trace_id: str) -> dict[str, Any]:
     out = {
         "event": INGEST_NORMALIZE_DONE,
         "object_id": dom["uuid"],
+        "uuid": dom["uuid"],
+        "kind": dom["kind"],
+        "payload": dom["payload"],
+        "source_ref": dom["source_ref"],
         "core6": dom["payload"]["core6"],
         "trace_id": trace_id,
         "ts": datetime.now(timezone.utc).isoformat(),

--- a/app/events/schema.py
+++ b/app/events/schema.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Optional
 from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
+from app.settings.runtime import get_settings_bundle
 
 
 def _now_iso() -> str:
@@ -13,6 +14,30 @@ def _now_iso() -> str:
 
 def _default_meta() -> Dict[str, Any]:
     return {"version": "1.0"}
+
+
+def _instance_provenance() -> Dict[str, str] | None:
+    try:
+        bundle = get_settings_bundle()
+        instance = getattr(bundle, "instance", None)
+        if instance is None:
+            return None
+        return {
+            "instance_id": str(getattr(instance, "id", "home")),
+            "instance_role": str(getattr(instance, "role", "master")),
+            "environment": str(getattr(instance, "environment", "prod")),
+        }
+    except Exception:
+        return None
+
+
+def _build_meta(meta: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    resolved = dict(meta or _default_meta())
+    resolved.setdefault("version", "1.0")
+    instance = _instance_provenance()
+    if instance is not None:
+        resolved["instance_provenance"] = instance
+    return resolved
 
 
 class OutboxEvent(BaseModel):
@@ -49,7 +74,7 @@ def make_outbox_event(
         source=source,
         timestamp=timestamp or _now_iso(),
         payload=payload or {},
-        meta=meta or _default_meta(),
+        meta=_build_meta(meta),
     )
 
 

--- a/app/events/types.py
+++ b/app/events/types.py
@@ -62,6 +62,7 @@ PROMOTE_SKIP_ORPHAN = "promote.skip.orphan"
 PROMOTE_SKIP_DECODE = "promote.skip.decode"
 PROMOTE_ERROR = "promote.error"
 PROMOTE_DONE = "promote.done"
+PROMOTION_TRANSITION_APPLIED = "promotion.transition.applied"
 PROMOTE_ORPHAN_OVERRIDE = "promote.orphan.override"
 PROMOTION_DECISION_PENDING = "promotion.pending_move"
 PROMOTE_SKIP_MOVE = "promote.skip.move"
@@ -136,6 +137,7 @@ __all__ = [
     "PROMOTE_SKIP_DECODE",
     "PROMOTE_ERROR",
     "PROMOTE_DONE",
+    "PROMOTION_TRANSITION_APPLIED",
     "PROMOTE_ORPHAN_OVERRIDE",
     "PROMOTION_DECISION_PENDING",
     "PROMOTE_SKIP_MOVE",

--- a/app/observability/status_model.py
+++ b/app/observability/status_model.py
@@ -109,6 +109,12 @@ class ViewFreshnessStatus(BaseModel):
     sources: list[str] = Field(default_factory=list)
 
 
+class InstanceProvenanceStatus(BaseModel):
+    instance_id: str
+    instance_role: str
+    environment: str
+
+
 class WatcherAutomationStatus(BaseModel):
     auto_exec_enabled: bool = False
     mode: str = "emit-only"
@@ -157,6 +163,7 @@ class SystemStatus(BaseModel):
     worker_queue: Optional[WorkerQueueStatus] = None
     view_freshness: Optional[ViewFreshnessStatus] = None
     watcher_automation: Optional[WatcherAutomationStatus] = None
+    instance_provenance: Optional[InstanceProvenanceStatus] = None
 
 
 __all__ = [
@@ -173,6 +180,7 @@ __all__ = [
     "EventsLogStatus",
     "WorkerQueueStatus",
     "ViewFreshnessStatus",
+    "InstanceProvenanceStatus",
     "WatcherAutomationStatus",
     "SystemStatus",
 ]

--- a/app/observability/status_service.py
+++ b/app/observability/status_service.py
@@ -15,6 +15,7 @@ from app.observability.status_model import (
     EventCounters,
     EventsLogStatus,
     IngestionStatus,
+    InstanceProvenanceStatus,
     IntentStatus,
     IndexStatus,
     PanelDiagnostics,
@@ -28,6 +29,7 @@ from app.observability.status_model import (
 )
 from app.outbox.events import INDEX_OUTBOX_PATH
 from app.runtime.worker_heartbeat import resolve_worker_heartbeat_path
+from app.settings.runtime import get_settings_bundle
 from app.settings.panel_actions_settings import load_panel_actions_settings, panel_action_ids
 from app.settings.watcher_settings import invalid_allowed_actions, load_watcher_settings, resolve_auto_exec_state
 from app.settings.panel_actions import get_panel_actions_diagnostics
@@ -688,6 +690,21 @@ def _get_watcher_automation_status() -> WatcherAutomationStatus:
     )
 
 
+def _get_instance_provenance_status() -> InstanceProvenanceStatus | None:
+    try:
+        bundle = get_settings_bundle()
+    except Exception:
+        return None
+    instance = getattr(bundle, "instance", None)
+    if instance is None:
+        return None
+    return InstanceProvenanceStatus(
+        instance_id=str(getattr(instance, "id", "home")),
+        instance_role=str(getattr(instance, "role", "master")),
+        environment=str(getattr(instance, "environment", active_environment())),
+    )
+
+
 def get_system_status() -> SystemStatus:
     sot_meta = get_sot_metadata()
     ingestion = get_ingestion_status()
@@ -727,6 +744,7 @@ def get_system_status() -> SystemStatus:
             worker_queue=worker_queue,
         ),
         watcher_automation=_get_watcher_automation_status(),
+        instance_provenance=_get_instance_provenance_status(),
     )
 
 

--- a/app/promotion/consumer.py
+++ b/app/promotion/consumer.py
@@ -7,7 +7,7 @@ from typing import Iterable, Mapping
 
 from app.domain.state_axes import normalize_promotion_payload, resolve_promotion_axes
 from app.events.schema import OutboxEvent, make_outbox_event
-from app.events.types import PROMOTE_DONE, PROMOTE_ERROR, PROMOTE_INTENT_CREATED
+from app.events.types import PROMOTE_DONE, PROMOTE_ERROR, PROMOTE_INTENT_CREATED, PROMOTION_TRANSITION_APPLIED
 from app.events.models import new_event
 from app.outbox.events import INDEX_OUTBOX_PATH
 from app.services.note_update import apply_promotion_frontmatter
@@ -192,6 +192,28 @@ def _handle_promotion_payload(
             "state": axes.maturity or axes.review_state,
             "maturity": axes.maturity,
             "review_state": axes.review_state,
+            "source_event": event_id,
+        },
+        trace_id,
+    )
+    summary["emitted"] += 1
+    transition = payload.get("transition") if isinstance(payload, Mapping) else None
+    transition_family = "promotion"
+    target_maturity = axes.maturity
+    if isinstance(transition, Mapping):
+        transition_family = str(transition.get("family") or transition_family)
+        target_maturity = str(transition.get("target_maturity") or target_maturity or "") or target_maturity
+    emit(
+        PROMOTION_TRANSITION_APPLIED,
+        {
+            "intent_event_id": event_id,
+            "trace_id": trace_id,
+            "note_uuid": note_uuid,
+            "note_path": str(note_path),
+            "transition_family": transition_family,
+            "target_maturity": target_maturity,
+            "executor": "promotion.consumer",
+            "effect": "applied",
             "source_event": event_id,
         },
         trace_id,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -135,6 +135,9 @@ At minimum, the following must stay true:
 - Defaults when nothing is configured: `id="home"`, `role="master"`, `environment="prod"`, matching the Reality-MVP single-runtime focus and production-safe baseline.
 - Environment selection: resolved from `PKM_ENVIRONMENT` (explicit), `PKM_SETTINGS_PROFILE` mapping (lab→dev, operator→prod), or default (prod). See `docs/ENVIRONMENTS.md`.
 - Scope: internal plumbing that informs events/logs, feature gates, and future sync topology; no change to the Obsidian surface or frontmatter.
+- Runtime event/status attachment: common outbox event helpers attach `meta.instance_provenance` (`instance_id`, `instance_role`, `environment`) so runtime telemetry can attribute execution context without per-caller wiring.
+- Identity boundary: this provenance is operational metadata only and must not alter artifact identity fields (`uuid`, `source_ref`, vault path identity, companion identity).
+- Replica posture boundary: recording instance provenance is shipped baseline behavior; replica conflict resolution, transport semantics, and distributed authority remain future work.
 
 ## Contracts (concept anchors)
 
@@ -328,6 +331,9 @@ Tests: `tests/architecture/test_architecture_tests_validation.py::test_import_bo
 - Planner/orchestrator normalization keeps external event compatibility (`promote.intent.created`)
   while routing internal promotion work through explicit transition semantics (`request_promotion_transition`
   with `transition.family = promotion` and `transition.target_maturity`).
+- Promotion consumer apply paths now emit `promotion.transition.applied` as a human-legible applied-transition
+  receipt linked to the triggering intent/trace, while preserving `promote.done` / `promote.error` as
+  execution-result compatibility events.
 - Compatibility-only legacy `review_state` inputs still accepted at normalization boundaries are:
   `evergreen`, `processed`, `promoted`, `inbox`, and `logged`. Current runtime callers should not
   produce those values as new canonical state-axis outputs.
@@ -344,6 +350,13 @@ Tests: `tests/architecture/test_architecture_tests_validation.py::test_import_bo
 - Note kinds are policy profiles, not schemas. `kind` routes policy and does not define structure.
 - State axes are orthogonal and selectively enabled by policy per kind.
 - Policies can lock axis values and gate agent read/write permissions; defaults live in vault settings (vault-as-GUI).
+- Current ingest normalization is conservative: explicit `artifact_kind` values from frontmatter or
+  normalized ingest input are accepted only for a small allowlist (`note`, `task`, `knowledge`,
+  `reference`, `log`) and then exposed as policy-routing metadata (`artifact_kind` /
+  `policy_profile_kind`) while runtime object identity remains `kind="note"`.
+- Missing or unsupported explicit kinds degrade to `note` with ingest diagnostics; no path-derived
+  kind inference is performed.
+- This shipped behavior is intentionally not the full v6 artifact taxonomy.
 - See `docs/NOTE_KIND_POLICIES.md` for policy profile examples.
 
 ## Planes and Metadata Surfaces

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -217,6 +217,7 @@ Examples in the current runtime:
 - `panel.intent.created` = intent-creation layer
 - `promote.intent.created` = transition intent layer
 - `promote.done` / `promote.error` = execution-result layer
+- `promotion.transition.applied` = human-legible transition receipt layer for admitted promotion applies
 
 The event stream is not, by itself, the complete receipt model.
 It is primarily an operational trace surface that may support later receipt or audit construction.

--- a/docs/NOTE_KIND_POLICIES.md
+++ b/docs/NOTE_KIND_POLICIES.md
@@ -21,6 +21,12 @@ Related docs:
 - State axes are orthogonal and selectively enabled by policy.
 - Policies can lock or force axis values and gate agent read/write permissions.
 - Derived overlays (e.g., `zone`, recency, salience) remain system-owned and never become core axes.
+- Current ingest normalization is conservative: explicit `artifact_kind` may be supplied from
+  frontmatter or normalized ingest input and is accepted for a limited allowlist
+  (`note`, `task`, `knowledge`, `reference`, `log`) for policy routing only.
+- Runtime identity remains `kind="note"` in this slice; missing/unknown explicit kinds degrade to
+  `note` with diagnostics and without path-based inference.
+- This is a bounded normalization slice, not a full artifact taxonomy rollout.
 
 Axis interpretation:
 - `review_state` should be read as review/mutation posture.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -118,6 +118,8 @@ High-level design rules for this direction now live in `docs/DESIGN_PRINCIPLES.m
 ## Current Snapshot
 
 - Runtime uses the registry watcher, DB outbox, worker, ASK API, and status/health surfaces as the canonical operational path.
+- Runtime event envelopes emitted through the shared outbox helper now include `meta.instance_provenance` (`instance_id`, `instance_role`, `environment`) as backward-compatible operational metadata.
+- Status summaries now expose instance provenance (`instance_id`, `instance_role`, `environment`) for runtime attribution; this does not change artifact identity or companion note identity semantics.
 - Production-facing path is the active current-state default; lab/dev-only flows remain explicitly non-production.
 - The local test stack can be started successfully against a separate test vault, and `uat-seed-vault-test` works.
 - The repo-supported local bootstrap/UAT path is still not fully self-contained end to end; several concrete blocker issues already exist for that work.
@@ -128,6 +130,7 @@ High-level design rules for this direction now live in `docs/DESIGN_PRINCIPLES.m
 - PanelAgent runtime V1 is part of the active baseline; planner pipeline and LangGraph expansion remain opt-in.
 - Legacy snapshot watchers remain available only for lab/dev workflows and are not part of the runtime default.
 - Eval suites remain opt-in diagnostics; they do not define baseline health by themselves.
+- Full replica-aware behavior (conflict handling, distributed authority, sync transport semantics) remains post-baseline work.
 
 ## Forward-Line Tracking
 

--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -151,6 +151,17 @@ For implementation work, the delivery loop is:
 7. Feature validation continues on the parent issue until the operator/product path is proven.
 8. Acceptance closes the feature and triggers owner-doc promotion when the support claim changes.
 
+State model for lane-based delivery:
+
+- Issue state supports claim and bounded execution truth: `Ready`, `In Progress`, `Blocked`, `Done`.
+- PR/Project-item state supports review/integration projection: `Review`, `In Progress`, `Blocked`, `Done`.
+- Keep issue and PR state separate in multi-slice lanes where several implementation issues can feed the same lane PR.
+- `issue-to-code` owns fast issue claim (`Ready` -> `In Progress` and remove `agent:ready`) to prevent double-pick.
+- Open PR is the default publication mode. Draft PR is opt-in and requires an explicit reason.
+- `Review` is the agent-review gate before verification, not a generic waiting state.
+- `pr-integration` is conditional and should be used when mergeability/CI attachment/reviewability needs repair; it is not required after every publication.
+- Prefer automation for PR/project-item projection (especially `Done` on terminal PR state) and use manual skill writes as fallback correction when drift is detected.
+
 Execution rule:
 
 - do not start non-trivial implementation without a governing Issue

--- a/docs/development/GITHUB_GOVERNANCE_SETUP.md
+++ b/docs/development/GITHUB_GOVERNANCE_SETUP.md
@@ -39,8 +39,8 @@ Required fields:
 Status meanings:
 - `Backlog`: tracked work that is not yet ready for agent execution or has been moved out of active execution
 - `Ready`: bounded, testable, unblocked work that is eligible for pickup and labeled `agent:ready`
-- `In Progress`: active implementation, including draft PRs and open PRs before explicit review handoff
-- `Review`: explicit review handoff, normally after review is requested on the active PR
+- `In Progress`: active implementation issue state; on PR items this means draft/rework phase
+- `Review`: PR/project-item review/integration gate and default state for normal open PRs
 - `Done`: merged or otherwise fully delivered work; the Issue is closed and no `agent:*` labels remain
 
 Agent-label meanings:
@@ -61,8 +61,10 @@ Required views:
 Required automation:
 - new issue -> `Status=Backlog`
 - issue reopened or agent-label changed -> reconcile `Status` from the current Issue state and truthful agent label
-- PR opened -> `Status=In Progress`
-- PR review requested -> `Status=Review`
+- PR opened/reopened (non-draft) -> `Status=Review`
+- PR opened/reopened (draft) -> `Status=In Progress`
+- PR marked ready for review -> `Status=Review`
+- PR converted to draft -> `Status=In Progress`
 - PR merged -> `Status=Done`
 - PR closed -> `Status=Done` when the PR is terminal and no longer active
 - issue and PR Project items are reconciled by repo-side workflow so merged PR cards and closed Issue cards do not drift
@@ -73,7 +75,8 @@ Interpretation note:
 
 Lifecycle guardrails:
 - active implementation must not remain `Ready`
-- `Review` must not be used only because a PR exists; use it when review handoff is explicit
+- issues should not move to `Review` only because a PR exists; issue state remains claim/execution truth
+- normal open PRs should default to `Review`; draft is opt-in and should be used only with an explicit reason
 - closed issues must not retain `agent:ready`, `agent:blocked`, or `agent:needs-human`
 - merged or otherwise closed terminal PR items must not remain unset or non-terminal in the Project; they should reconcile to `Done`
 
@@ -90,6 +93,7 @@ Projection rule:
 - Governance-lane PRs may omit an Issue reference only when they are explicitly classified as governance lane and remain limited to approved governance surfaces.
 - Agents only pick Issues labeled `agent:ready`.
 - Agents only pick Issues when `Status=Ready` and the Issue is labeled `agent:ready`.
+- Issue claim (`Ready` -> `In Progress` plus `agent:ready` removal) remains a synchronous skill action, not PR automation.
 - Agents must stay within Issue scope, constraints, and acceptance criteria.
 - Blank/free-form Issues are disabled at repo level.
 

--- a/scripts/project_status.py
+++ b/scripts/project_status.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""
+Project PR status projection helper.
+
+Maps GitHub PR lifecycle events to a deterministic Project `Status` and then
+delegates the actual write to the existing reconcile script.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+
+
+def parse_bool(value: str) -> bool:
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def desired_status(action: str, draft: bool | None) -> str:
+    if action in {"opened", "reopened"}:
+        if draft is None:
+            raise ValueError("draft is required for opened/reopened events")
+        return "In Progress" if draft else "Review"
+    if action == "ready_for_review":
+        return "Review"
+    if action == "converted_to_draft":
+        return "In Progress"
+    raise ValueError(f"unsupported pull request action: {action}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", required=True, help="owner/repo")
+    parser.add_argument("--pr", type=int, required=True, help="Pull request number")
+    parser.add_argument("--action", required=True, help="GitHub pull_request action")
+    parser.add_argument("--draft", help="True when the PR is currently a draft")
+    args = parser.parse_args()
+
+    draft = None if args.draft is None else parse_bool(args.draft)
+    status = desired_status(args.action, draft)
+    cmd = [
+        sys.executable,
+        "scripts/reconcile_project_status.py",
+        "--repo",
+        args.repo,
+        "--pr",
+        str(args.pr),
+        "--status",
+        status,
+    ]
+    subprocess.run(cmd, check=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/events/test_instance_provenance.py
+++ b/tests/events/test_instance_provenance.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from uuid import uuid4
+
+from app.events.schema import make_outbox_event
+from app.outbox.events import emit_index_object_embedded
+
+
+def test_runtime_events_include_instance_provenance_from_settings(monkeypatch) -> None:
+    bundle = SimpleNamespace(instance=SimpleNamespace(id="work-laptop", role="satellite", environment="dev"))
+    monkeypatch.setattr("app.events.schema.get_settings_bundle", lambda: bundle, raising=False)
+
+    event = make_outbox_event("runtime.test", source="test", payload={"ok": True})
+    record = event.model_dump(mode="json")
+
+    assert record["meta"]["instance_provenance"] == {
+        "instance_id": "work-laptop",
+        "instance_role": "satellite",
+        "environment": "dev",
+    }
+
+
+def test_instance_provenance_does_not_modify_artifact_identity(tmp_path, monkeypatch) -> None:
+    outbox = tmp_path / "index-outbox.jsonl"
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox))
+
+    bundle = SimpleNamespace(instance=SimpleNamespace(id="home", role="master", environment="prod"))
+    monkeypatch.setattr("app.events.schema.get_settings_bundle", lambda: bundle, raising=False)
+
+    object_id = str(uuid4())
+    source_ref = "vault/Notes/identity.md"
+    emit_index_object_embedded(object_id=object_id, source_ref=source_ref)
+
+    record = json.loads(outbox.read_text(encoding="utf-8").strip())
+    assert record["uuid"] == object_id
+    assert record["payload"]["object_id"] == object_id
+    assert record["meta"]["source_ref"] == source_ref
+    assert record["meta"]["instance_provenance"] == {
+        "instance_id": "home",
+        "instance_role": "master",
+        "environment": "prod",
+    }

--- a/tests/ingest/test_artifact_kind_routing.py
+++ b/tests/ingest/test_artifact_kind_routing.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.agents.normalizer.agent import normalize_file
+
+
+def _write_note(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+def test_missing_kind_preserves_current_note_default(tmp_path: Path) -> None:
+    note = tmp_path / "note.md"
+    _write_note(note, "# Sample\n\nBody")
+
+    result = normalize_file(str(note), trace_id="test-missing-kind")
+
+    assert result["kind"] == "note"
+    assert result["payload"]["artifact_kind"] == "note"
+    assert result["payload"]["policy_profile_kind"] == "note"
+    assert result["payload"].get("ingest_diagnostics", []) == []
+
+
+def test_explicit_allowed_kind_routes_policy_without_identity_change(tmp_path: Path) -> None:
+    note = tmp_path / "task-note.md"
+    _write_note(
+        note,
+        "---\nartifact_kind: task\n---\n# Task note\n\nBody",
+    )
+
+    result = normalize_file(str(note), trace_id="test-explicit-kind")
+
+    assert result["kind"] == "note"
+    assert result["payload"]["artifact_kind"] == "task"
+    assert result["payload"]["policy_profile_kind"] == "task"
+    assert result["payload"].get("ingest_diagnostics", []) == []
+
+
+def test_unknown_kind_fails_closed_without_path_inference(tmp_path: Path) -> None:
+    note = tmp_path / "tasks" / "unknown.md"
+    _write_note(
+        note,
+        "---\nartifact_kind: mystery\n---\n# Unknown\n\nBody",
+    )
+
+    result = normalize_file(str(note), trace_id="test-unknown-kind")
+
+    assert result["kind"] == "note"
+    assert result["payload"]["artifact_kind"] == "note"
+    assert result["payload"]["policy_profile_kind"] == "note"
+    diagnostics = result["payload"].get("ingest_diagnostics", [])
+    assert diagnostics
+    assert diagnostics[0]["code"] == "unsupported_artifact_kind"
+    assert diagnostics[0]["requested_kind"] == "mystery"
+    assert diagnostics[0]["fallback_kind"] == "note"

--- a/tests/observability/test_instance_provenance_status.py
+++ b/tests/observability/test_instance_provenance_status.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from app.observability.status_service import get_system_status
+
+
+def test_status_summary_reports_instance_provenance(monkeypatch) -> None:
+    bundle = SimpleNamespace(instance=SimpleNamespace(id="office", role="satellite", environment="dev"))
+    monkeypatch.setattr("app.observability.status_service.get_settings_bundle", lambda: bundle, raising=False)
+
+    status = get_system_status()
+
+    assert status.instance_provenance is not None
+    assert status.instance_provenance.instance_id == "office"
+    assert status.instance_provenance.instance_role == "satellite"
+    assert status.instance_provenance.environment == "dev"

--- a/tests/promotion/test_promotion_receipts.py
+++ b/tests/promotion/test_promotion_receipts.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.events.types import PROMOTE_ERROR, PROMOTE_INTENT_CREATED
+from app.promotion.consumer import consume_promotion_intents, reset_promotion_dedup_store
+
+
+def _write_note(path: Path, uuid: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"---\nuuid: {uuid}\nreview_state: draft\n---\nBody\n", encoding="utf-8")
+
+
+def _intent_event(note_path: Path, note_uuid: str, *, event_id: str = "evt-1", trace_id: str = "trace-1") -> dict:
+    return {
+        "event": PROMOTE_INTENT_CREATED,
+        "trace_id": trace_id,
+        "event_id": event_id,
+        "source": "panel_agent",
+        "payload": {
+            "note": {"uuid": note_uuid, "path": str(note_path)},
+            "transition": {"family": "promotion", "target_maturity": "evergreen"},
+        },
+    }
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def test_applied_promotion_writes_transition_receipt(tmp_path: Path) -> None:
+    reset_promotion_dedup_store()
+    note_path = tmp_path / "vault" / "N.md"
+    note_uuid = "00000000-0000-0000-0000-000000000101"
+    _write_note(note_path, note_uuid)
+
+    outbox = tmp_path / "outbox.jsonl"
+    event = _intent_event(note_path, note_uuid, event_id="evt-applied", trace_id="trace-applied")
+    outbox.write_text(json.dumps(event, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    summary = consume_promotion_intents(outbox_path=outbox)
+    assert summary["applied"] == 1
+
+    records = _read_jsonl(outbox)
+    receipts = [r for r in records if r.get("event") == "promotion.transition.applied"]
+    assert len(receipts) == 1
+    payload = receipts[0]["payload"]
+    assert payload["intent_event_id"] == "evt-applied"
+    assert payload["trace_id"] == "trace-applied"
+    assert payload["note_uuid"] == note_uuid
+    assert payload["transition_family"] == "promotion"
+    assert payload["target_maturity"] == "evergreen"
+    assert payload["executor"] == "promotion.consumer"
+    assert payload["effect"] == "applied"
+
+
+def test_replayed_promotion_intent_does_not_duplicate_receipt(tmp_path: Path) -> None:
+    reset_promotion_dedup_store()
+    note_path = tmp_path / "vault" / "N.md"
+    note_uuid = "00000000-0000-0000-0000-000000000102"
+    _write_note(note_path, note_uuid)
+
+    outbox = tmp_path / "outbox.jsonl"
+    event = _intent_event(note_path, note_uuid, event_id="evt-dup", trace_id="trace-dup")
+    outbox.write_text(
+        json.dumps(event, ensure_ascii=False) + "\n" + json.dumps(event, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    summary = consume_promotion_intents(outbox_path=outbox)
+    assert summary["applied"] == 1
+    assert summary["skipped_duplicates"] == 1
+
+    records = _read_jsonl(outbox)
+    receipts = [r for r in records if r.get("event") == "promotion.transition.applied"]
+    assert len(receipts) == 1
+
+
+def test_failed_or_skipped_promotion_does_not_emit_applied_receipt(tmp_path: Path) -> None:
+    reset_promotion_dedup_store()
+    outbox = tmp_path / "outbox.jsonl"
+    bad_event = {
+        "event": PROMOTE_INTENT_CREATED,
+        "trace_id": "trace-bad",
+        "event_id": "evt-bad",
+        "source": "panel_agent",
+        "payload": {"note": {"uuid": "00000000-0000-0000-0000-000000000103"}},
+    }
+    outbox.write_text(json.dumps(bad_event, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    summary = consume_promotion_intents(outbox_path=outbox)
+    assert summary["errors"] == 1
+
+    records = _read_jsonl(outbox)
+    assert any(r.get("event") == PROMOTE_ERROR for r in records)
+    assert all(r.get("event") != "promotion.transition.applied" for r in records)


### PR DESCRIPTION
## Summary
- implement #535 by adding applied promotion transition receipts (`promotion.transition.applied`) with idempotent replay behavior
- implement #536 by attaching runtime instance provenance centrally to event meta and exposing it in status summaries
- implement #538 by adding conservative artifact-kind normalization/routing with fail-closed diagnostics
- update architecture/status/events/policy docs to reflect shipped behavior without over-claiming full v6 taxonomy/replica posture

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/promotion/test_promotion_receipts.py tests/promotion/test_consumer_idempotency.py tests/events/test_instance_provenance.py tests/observability/test_instance_provenance_status.py tests/ingest/test_artifact_kind_routing.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/ingest tests/agents/test_normalizer.py tests/events/test_event_envelope_versioning.py tests/architecture/test_events_outbox_contracts.py

Fixes #535
Fixes #536
Fixes #538
