### PR TITLE
Add git hygiene guardrails for multi-agent workflows

### DIFF
--- a/.codex/skills/README.md
+++ b/.codex/skills/README.md
@@ -68,3 +68,18 @@ The invariant is enforced across the chain:
 - Repair: `issue-maintenance-change-control` treats missing `Verify:` as malformed contract.
 - Consumption: `issue-to-code` gates on `Verify:` presence and runs test-first for behavioral ACs.
 - Closure: `verification-and-closure` resolves every `Verify:` target before merge.
+
+## Cross-cutting invariant: minimal shared leases
+
+GitHub lifecycle state remains the human-visible projection, not the live operational store for
+multi-agent exclusion. Hot-path workflows should use the smallest available shared issue or lane
+lease check, then keep the rest of execution local and deterministic.
+
+- `issue-to-code` owns fast issue claiming and should consult shared issue/lane leases when that
+  surface is available.
+- `publish-pr` and lane-aware workflows may consult lane or branch/worktree reservations when they
+  share an active PR or workspace.
+- `git-hygiene-preflight` is the read-only hot-path check for dirty tree, in-progress git
+  operations, branch/worktree mismatch, and relevant lease conflicts.
+- `git-hygiene-janitor` is a cold-path, report-first cleanup helper. It must respect active leases
+  and must not perform destructive cleanup automatically in v1.

--- a/.github/github-governance.yml
+++ b/.github/github-governance.yml
@@ -69,6 +69,30 @@ project:
     review_requires_explicit_review_handoff: true
     done_requires_closed_issue_or_terminal_pr_card: true
     project_may_drift_when_platform_access_is_limited: true
+shared_operational_state:
+  purpose: minimal multi-agent exclusion, not lifecycle projection
+  allowed_resources:
+    - issue_claim
+    - lane_claim
+    - ttl_lease
+    - heartbeat_renewal
+    - optional_branch_or_worktree_reservation
+  forbidden_uses:
+    - general_workflow_metadata_registry
+    - repo_file_live_status
+    - large_operational_database_model
+    - mcp_first_control_plane
+    - free_form_agent_queries
+  tool_surface:
+    - claim_issue
+    - release_issue
+    - claim_lane
+    - renew_lease
+    - get_claim
+  git_hygiene:
+    preflight: read_only_hot_path
+    janitor: report_first_cold_path
+    destructive_cleanup_default: false
 pull_requests:
   implementation:
     issue_reference_required: true
@@ -97,9 +121,13 @@ pull_requests:
       - .github/ISSUE_TEMPLATE/*.yml
       - .github/pull_request_template.md
       - .github/workflows/issue-pr-governance.yml
+      - scripts/git_hygiene.py
+      - scripts/git_hygiene_preflight.py
+      - scripts/git_hygiene_janitor.py
       - scripts/docs_guard.py
       - scripts/reconcile_project_status.py
       - scripts/validate_source_anchors.py
+      - tests/ops/test_git_hygiene.py
       - tests/ops/test_project_status_reconcile.py
 rules:
   pr_must_reference_issue_for_implementation: true

--- a/docs/development/GITHUB_GOVERNANCE_SETUP.md
+++ b/docs/development/GITHUB_GOVERNANCE_SETUP.md
@@ -84,6 +84,29 @@ Projection rule:
 - When Project state disagrees with Issue state, PR state, or merged delivery reality, treat the Issue/PR state as authoritative and correct the Project opportunistically.
 - Do not block delivery solely because a personal Project v2 card could not be updated by repo automation.
 
+## Shared operational lease boundary
+
+GitHub Issues, labels, PRs, and Project status are the shared human-visible lifecycle projection.
+They are not the live operational store for fast multi-agent exclusion. Multiple agent
+environments should use only a minimal shared lease layer for operational coordination:
+
+- issue claims such as `issue:<number>`
+- lane claims such as `lane:<id>`
+- TTL, heartbeat/renewal, and explicit release by `execution_id`
+- optional branch or worktree reservation when needed to avoid active-work collision
+
+The lease layer must stay behind a tiny deterministic API or tool surface such as `claim_issue`,
+`release_issue`, `claim_lane`, `renew_lease`, and `get_claim`. Agents and skills should consume
+that surface instead of querying a backend store directly. This boundary excludes a general
+workflow metadata registry, repo-file-based live status, a large operational database model,
+MCP-first control-plane behavior, and free-form agent queries over operational data.
+
+Git hygiene remains local first. Hot-path preflight is read-only and checks dirty tree,
+in-progress git operations, branch/worktree mismatch, and relevant lease conflicts before local
+mutation. Broader cleanup belongs to a cold-path janitor flow that reports stale merged branches,
+orphaned worktrees, old stashes, and prune candidates while respecting active leases. Destructive
+cleanup is not automatic in v1.
+
 ## Enforcement intent
 
 - Issues are the canonical delivery task contract for implementation work.
@@ -137,8 +160,12 @@ Approved governance surfaces:
 - `.github/pull_request_template.md`
 - `.github/workflows/issue-pr-governance.yml`
 - `scripts/docs_guard.py`
+- `scripts/git_hygiene.py`
+- `scripts/git_hygiene_preflight.py`
+- `scripts/git_hygiene_janitor.py`
 - `scripts/reconcile_project_status.py`
 - `scripts/validate_source_anchors.py`
+- `tests/ops/test_git_hygiene.py`
 - `tests/ops/test_project_status_reconcile.py`
 
 Rules:

--- a/scripts/git_hygiene.py
+++ b/scripts/git_hygiene.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""
+Report-only git hygiene checks for multi-agent repo workflows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_PROTECTED_BRANCHES = {"main", "master", "develop", "dev"}
+IN_PROGRESS_MARKERS = {
+    "MERGE_HEAD": "merge",
+    "CHERRY_PICK_HEAD": "cherry-pick",
+    "REVERT_HEAD": "revert",
+}
+
+
+def run_git(args: list[str], cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def load_active_leases(path: str | None) -> list[dict[str, Any]]:
+    if not path:
+        return []
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def lease_is_active(lease: dict[str, Any], now: float | None = None) -> bool:
+    expires_at = lease.get("expires_at")
+    if expires_at is None:
+        return True
+    return float(expires_at) > (time.time() if now is None else now)
+
+
+def lease_conflicts(
+    leases: list[dict[str, Any]],
+    resource_ids: set[str],
+    execution_id: str | None,
+    now: float | None = None,
+) -> list[dict[str, Any]]:
+    conflicts = []
+    for lease in leases:
+        resource_id = str(lease.get("resource_id", ""))
+        if resource_id not in resource_ids:
+            continue
+        if execution_id and lease.get("execution_id") == execution_id:
+            continue
+        if not lease_is_active(lease, now=now):
+            continue
+        conflicts.append(lease)
+    return conflicts
+
+
+def _git_dir(cwd: Path) -> Path:
+    raw = run_git(["rev-parse", "--git-dir"], cwd)
+    git_dir = Path(raw)
+    if not git_dir.is_absolute():
+        git_dir = cwd / git_dir
+    return git_dir
+
+
+def _in_progress_operations(cwd: Path) -> list[str]:
+    git_dir = _git_dir(cwd)
+    operations = [
+        name for marker, name in IN_PROGRESS_MARKERS.items() if (git_dir / marker).exists()
+    ]
+    if (git_dir / "rebase-merge").exists() or (git_dir / "rebase-apply").exists():
+        operations.append("rebase")
+    return sorted(operations)
+
+
+def preflight_report(
+    cwd: Path,
+    *,
+    expected_branch: str | None = None,
+    expected_worktree: str | None = None,
+    active_leases: list[dict[str, Any]] | None = None,
+    resource_ids: set[str] | None = None,
+    execution_id: str | None = None,
+    now: float | None = None,
+) -> dict[str, Any]:
+    active_leases = active_leases or []
+    resource_ids = resource_ids or set()
+    status = run_git(["status", "--porcelain"], cwd)
+    branch = run_git(["branch", "--show-current"], cwd)
+    worktree = run_git(["rev-parse", "--show-toplevel"], cwd)
+    operations = _in_progress_operations(cwd)
+    conflicts = lease_conflicts(active_leases, resource_ids, execution_id, now=now)
+
+    checks = {
+        "dirty_tree": bool(status),
+        "in_progress_operations": operations,
+        "branch": branch,
+        "branch_mismatch": bool(expected_branch and branch != expected_branch),
+        "worktree": worktree,
+        "worktree_mismatch": bool(
+            expected_worktree and Path(worktree).resolve() != Path(expected_worktree).resolve()
+        ),
+        "lease_conflicts": conflicts,
+    }
+    ok = not (
+        checks["dirty_tree"]
+        or checks["in_progress_operations"]
+        or checks["branch_mismatch"]
+        or checks["worktree_mismatch"]
+        or checks["lease_conflicts"]
+    )
+    return {"ok": ok, "checks": checks}
+
+
+def _parse_worktrees(output: str) -> list[dict[str, str]]:
+    worktrees: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+    for line in output.splitlines():
+        if not line.strip():
+            if current:
+                worktrees.append(current)
+                current = {}
+            continue
+        key, _, value = line.partition(" ")
+        current[key] = value
+    if current:
+        worktrees.append(current)
+    return worktrees
+
+
+def _lease_resources(active_leases: list[dict[str, Any]], now: float | None = None) -> set[str]:
+    return {
+        str(lease.get("resource_id"))
+        for lease in active_leases
+        if lease.get("resource_id") and lease_is_active(lease, now=now)
+    }
+
+
+def janitor_report(
+    cwd: Path,
+    *,
+    active_leases: list[dict[str, Any]] | None = None,
+    stale_after_days: int = 14,
+    now: float | None = None,
+) -> dict[str, Any]:
+    active_leases = active_leases or []
+    active_resources = _lease_resources(active_leases, now=now)
+    current_branch = run_git(["branch", "--show-current"], cwd)
+    merged_output = run_git(["branch", "--merged"], cwd)
+    stale_merged_branches = []
+    for line in merged_output.splitlines():
+        branch = line.replace("*", "", 1).strip()
+        if not branch or branch == current_branch or branch in DEFAULT_PROTECTED_BRANCHES:
+            continue
+        if f"branch:{branch}" in active_resources:
+            continue
+        stale_merged_branches.append(branch)
+
+    worktrees = _parse_worktrees(run_git(["worktree", "list", "--porcelain"], cwd))
+    orphaned_worktrees = []
+    for worktree in worktrees:
+        path = worktree.get("worktree")
+        branch = worktree.get("branch", "").removeprefix("refs/heads/")
+        if not path or Path(path).exists():
+            continue
+        if f"worktree:{path}" in active_resources or f"branch:{branch}" in active_resources:
+            continue
+        orphaned_worktrees.append({"path": path, "branch": branch})
+
+    cutoff = (time.time() if now is None else now) - stale_after_days * 24 * 60 * 60
+    old_stashes = []
+    stash_output = run_git(["stash", "list", "--date=unix"], cwd)
+    for line in stash_output.splitlines():
+        match = re.search(r"(\d{10})", line)
+        if match and int(match.group(1)) < cutoff:
+            old_stashes.append(line)
+
+    prune_candidates = {
+        "worktree": run_git(["worktree", "prune", "--dry-run"], cwd).splitlines(),
+        "remote": run_git(["remote", "prune", "origin", "--dry-run"], cwd).splitlines(),
+    }
+    return {
+        "mode": "report-only",
+        "destructive_actions": [],
+        "stale_merged_branches": stale_merged_branches,
+        "orphaned_worktrees": orphaned_worktrees,
+        "old_stashes": old_stashes,
+        "prune_candidates": prune_candidates,
+        "active_leases_respected": sorted(active_resources),
+    }
+
+
+def _print_json(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cwd", default=".")
+    parser.add_argument("--lease-file", help="Read-only JSON list of active lease claims")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    preflight = subparsers.add_parser("preflight")
+    preflight.add_argument("--expected-branch")
+    preflight.add_argument("--expected-worktree")
+    preflight.add_argument("--resource-id", action="append", default=[])
+    preflight.add_argument("--execution-id")
+
+    janitor = subparsers.add_parser("janitor")
+    janitor.add_argument("--stale-after-days", type=int, default=14)
+
+    args = parser.parse_args(argv)
+    cwd = Path(args.cwd).resolve()
+    leases = load_active_leases(args.lease_file)
+    if args.command == "preflight":
+        report = preflight_report(
+            cwd,
+            expected_branch=args.expected_branch,
+            expected_worktree=args.expected_worktree,
+            active_leases=leases,
+            resource_ids=set(args.resource_id),
+            execution_id=args.execution_id,
+        )
+        _print_json(report)
+        return 0 if report["ok"] else 1
+
+    report = janitor_report(
+        cwd,
+        active_leases=leases,
+        stale_after_days=args.stale_after_days,
+    )
+    _print_json(report)
+    return 0
+
+
+def main_with_default_command(command: str, argv: list[str] | None = None) -> int:
+    """Run a compatibility entrypoint while preserving global CLI options."""
+
+    raw_args = list(argv or [])
+    if command in raw_args:
+        return main(raw_args)
+
+    global_args: list[str] = []
+    remaining: list[str] = []
+    index = 0
+    while index < len(raw_args):
+        arg = raw_args[index]
+        if arg in {"--cwd", "--lease-file"} and index + 1 < len(raw_args):
+            global_args.extend([arg, raw_args[index + 1]])
+            index += 2
+            continue
+        remaining.append(arg)
+        index += 1
+    return main([*global_args, command, *remaining])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/git_hygiene_janitor.py
+++ b/scripts/git_hygiene_janitor.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Compatibility entrypoint for the report-only git hygiene janitor."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.git_hygiene import main_with_default_command
+
+
+if __name__ == "__main__":
+    raise SystemExit(main_with_default_command("janitor", sys.argv[1:]))

--- a/scripts/git_hygiene_preflight.py
+++ b/scripts/git_hygiene_preflight.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Compatibility entrypoint for the git hygiene preflight report."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.git_hygiene import main_with_default_command
+
+
+if __name__ == "__main__":
+    raise SystemExit(main_with_default_command("preflight", sys.argv[1:]))

--- a/tests/ops/test_git_hygiene.py
+++ b/tests/ops/test_git_hygiene.py
@@ -1,0 +1,200 @@
+from pathlib import Path
+
+from scripts import git_hygiene
+
+
+def test_preflight_reports_dirty_tree_and_in_progress_operation(
+    tmp_path, monkeypatch
+) -> None:
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+    (git_dir / "MERGE_HEAD").write_text("abc123\n", encoding="utf-8")
+
+    def fake_run_git(args: list[str], cwd: Path) -> str:
+        assert cwd == tmp_path
+        if args == ["status", "--porcelain"]:
+            return " M docs/development/GITHUB_GOVERNANCE_SETUP.md"
+        if args == ["branch", "--show-current"]:
+            return "feature/work"
+        if args == ["rev-parse", "--show-toplevel"]:
+            return str(tmp_path)
+        if args == ["rev-parse", "--git-dir"]:
+            return str(git_dir)
+        raise AssertionError(f"unexpected git command: {args}")
+
+    monkeypatch.setattr(git_hygiene, "run_git", fake_run_git)
+
+    report = git_hygiene.preflight_report(
+        tmp_path,
+        expected_branch="main",
+        expected_worktree=str(tmp_path / "other"),
+    )
+
+    assert report["ok"] is False
+    assert report["checks"]["dirty_tree"] is True
+    assert report["checks"]["in_progress_operations"] == ["merge"]
+    assert report["checks"]["branch_mismatch"] is True
+    assert report["checks"]["worktree_mismatch"] is True
+
+
+def test_preflight_reports_active_lease_conflict(tmp_path, monkeypatch) -> None:
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+
+    def fake_run_git(args: list[str], _cwd: Path) -> str:
+        if args == ["status", "--porcelain"]:
+            return ""
+        if args == ["branch", "--show-current"]:
+            return "main"
+        if args == ["rev-parse", "--show-toplevel"]:
+            return str(tmp_path)
+        if args == ["rev-parse", "--git-dir"]:
+            return str(git_dir)
+        raise AssertionError(f"unexpected git command: {args}")
+
+    monkeypatch.setattr(git_hygiene, "run_git", fake_run_git)
+
+    report = git_hygiene.preflight_report(
+        tmp_path,
+        active_leases=[
+            {
+                "resource_id": "issue:561",
+                "execution_id": "other-agent",
+                "expires_at": 2000,
+            },
+            {
+                "resource_id": "lane:governance",
+                "execution_id": "expired-agent",
+                "expires_at": 1000,
+            },
+        ],
+        resource_ids={"issue:561", "lane:governance"},
+        execution_id="this-agent",
+        now=1500,
+    )
+
+    assert report["ok"] is False
+    assert report["checks"]["lease_conflicts"] == [
+        {
+            "resource_id": "issue:561",
+            "execution_id": "other-agent",
+            "expires_at": 2000,
+        }
+    ]
+
+
+def test_janitor_report_respects_active_lease_and_reports_candidates(
+    tmp_path, monkeypatch
+) -> None:
+    missing_worktree = tmp_path / "missing-worktree"
+
+    def fake_run_git(args: list[str], _cwd: Path) -> str:
+        if args == ["branch", "--show-current"]:
+            return "main"
+        if args == ["branch", "--merged"]:
+            return "\n".join(
+                [
+                    "* main",
+                    "  delivered-safe",
+                    "  active-lane",
+                    "  develop",
+                ]
+            )
+        if args == ["worktree", "list", "--porcelain"]:
+            return (
+                f"worktree {missing_worktree}\n"
+                "HEAD abc123\n"
+                "branch refs/heads/orphaned-worktree\n\n"
+            )
+        if args == ["stash", "list", "--date=unix"]:
+            return "\n".join(
+                [
+                    "stash@{0}: WIP on main 1000000000: old work",
+                    "stash@{1}: WIP on main 1999999999: current work",
+                ]
+            )
+        if args == ["worktree", "prune", "--dry-run"]:
+            return f"Removing worktrees/{missing_worktree.name}: gitdir file points to non-existent location"
+        if args == ["remote", "prune", "origin", "--dry-run"]:
+            return " * [would prune] origin/stale-remote"
+        raise AssertionError(f"unexpected git command: {args}")
+
+    monkeypatch.setattr(git_hygiene, "run_git", fake_run_git)
+
+    report = git_hygiene.janitor_report(
+        tmp_path,
+        active_leases=[
+            {
+                "resource_id": "branch:active-lane",
+                "execution_id": "agent-1",
+                "expires_at": 3000000000,
+            }
+        ],
+        stale_after_days=1,
+        now=2000000000,
+    )
+
+    assert report["mode"] == "report-only"
+    assert report["destructive_actions"] == []
+    assert report["stale_merged_branches"] == ["delivered-safe"]
+    assert report["orphaned_worktrees"] == [
+        {"path": str(missing_worktree), "branch": "orphaned-worktree"}
+    ]
+    assert report["old_stashes"] == [
+        "stash@{0}: WIP on main 1000000000: old work"
+    ]
+    assert report["prune_candidates"]["worktree"]
+    assert report["prune_candidates"]["remote"] == [
+        " * [would prune] origin/stale-remote"
+    ]
+    assert report["active_leases_respected"] == ["branch:active-lane"]
+
+
+def test_default_command_entrypoint_preserves_global_and_subcommand_args(
+    monkeypatch,
+) -> None:
+    captured = {}
+
+    def fake_main(argv: list[str]) -> int:
+        captured["argv"] = argv
+        return 0
+
+    monkeypatch.setattr(git_hygiene, "main", fake_main)
+
+    assert (
+        git_hygiene.main_with_default_command(
+            "preflight",
+            [
+                "--cwd",
+                "/repo",
+                "--lease-file",
+                "/leases.json",
+                "--expected-branch",
+                "main",
+            ],
+        )
+        == 0
+    )
+
+    assert captured["argv"] == [
+        "--cwd",
+        "/repo",
+        "--lease-file",
+        "/leases.json",
+        "preflight",
+        "--expected-branch",
+        "main",
+    ]
+
+
+def test_default_command_entrypoint_keeps_explicit_command(monkeypatch) -> None:
+    captured = {}
+
+    def fake_main(argv: list[str]) -> int:
+        captured["argv"] = argv
+        return 0
+
+    monkeypatch.setattr(git_hygiene, "main", fake_main)
+
+    assert git_hygiene.main_with_default_command("janitor", ["janitor"]) == 0
+    assert captured["argv"] == ["janitor"]


### PR DESCRIPTION
Fixes #561

- [x] Governance lane

## Summary
Adds a minimal shared operational-state boundary for multi-agent repo execution and introduces report-only git hygiene helpers for hot-path preflight and cold-path janitor checks.

## Changes
- Documents shared issue/lane lease boundaries separately from GitHub lifecycle projection.
- Adds `scripts/git_hygiene.py` with `preflight` and `janitor` report modes plus compatibility entrypoints.
- Adds focused tests for dirty/in-progress preflight, active lease conflicts, and report-only janitor behavior.
- Updates governance allowed surfaces for the new scripts and tests.

## Validation
- `ruff check scripts/git_hygiene.py scripts/git_hygiene_preflight.py scripts/git_hygiene_janitor.py tests/ops/test_git_hygiene.py tests/ops/test_project_status_reconcile.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/ops/test_git_hygiene.py tests/ops/test_project_status_reconcile.py`

## Notes
Project V2 status could not be updated from this environment because the local `gh` token lacks Project scope. Issue label claiming was still executed by removing `agent:ready` before edits.
