### PR TITLE
Fix scan-mode PR status mapping for draft vs review

### DIFF
--- a/scripts/reconcile_project_status.py
+++ b/scripts/reconcile_project_status.py
@@ -136,7 +136,7 @@ def desired_pr_status(pr: dict[str, Any], explicit_status: str | None) -> str | 
     if pr.get("mergedAt"):
         return "Done"
     if pr.get("state") == "OPEN":
-        return "In Progress"
+        return "In Progress" if pr.get("isDraft") else "Review"
     if pr.get("state") == "CLOSED":
         # Closed PR cards are terminal Project artifacts and must not remain blank.
         return "Done"


### PR DESCRIPTION
- [x] Governance lane

## Summary
- align scripts/reconcile_project_status.py scan-mode PR mapping with the new workflow model
- keep OPEN non-draft PRs at Review
- keep OPEN draft PRs at In Progress

## Why
PR #562 introduced event-based projection with this mapping, but hourly scan-mode reconciliation on main still treated all open PRs as In Progress, causing drift.

## Validation
- python3 -m py_compile scripts/reconcile_project_status.py
- manual function check for OPEN draft/non-draft mapping