### PR TITLE
Tighten repo-hygiene skill checks and PR state matrix

### DIFF
--- a/.codex/skills/backlog-reconciliation-drift-audit/SKILL.md
+++ b/.codex/skills/backlog-reconciliation-drift-audit/SKILL.md
@@ -92,7 +92,7 @@ For each drift case, recommend one concrete corrective action only:
 - Treat `agent:ready` as the pickup qualifier for `Status=Ready`, not as a substitute for `In Progress`, `Review`, or `Done`.
 - For PR cards, treat open non-draft as `Review` and open draft as `In Progress`.
 - Prefer one repair action per drift class when the same correction repeats across multiple items; do not churn the board with separate micro-fixes when a batched audit can close the gap.
-- If full-project scan is slow or blocked by API latency, run a targeted audit for open issues, open PRs, and recently merged PRs, then report that fallback explicitly.
+- If full-project scan is slow or blocked by API latency, run a targeted audit for open issues, open PRs, recently merged PRs, and recently closed-unmerged PRs, then report that fallback explicitly.
 
 
 ## Capturing learning

--- a/.codex/skills/backlog-reconciliation-drift-audit/SKILL.md
+++ b/.codex/skills/backlog-reconciliation-drift-audit/SKILL.md
@@ -32,7 +32,9 @@ You must detect:
 - issues missing required contract sections
 - open implementation Issues missing a truthful agent-state label
 - stale `agent:ready` labels on work that is blocked or already done
-- draft PR work or open PR work that was moved to `Review` before explicit review handoff
+- open non-draft PR work that is not projected to `Review`
+- merged PR cards that remain non-terminal (`In Progress`/`Review`) after merge
+- fixes that were validated on a branch but are not yet present on `origin/main`
 - active work that still presents as `Ready`
 
 ## Authority order
@@ -52,6 +54,7 @@ You must detect:
 4. Inspect recent closed PRs that are not merged.
 5. Inspect current Project states.
 6. Match all of them by `Source Anchors`, doc items, and delivered reality.
+7. Confirm recently merged fix PRs are actually present on `origin/main` when they claim to resolve projection drift.
 
 For each inspected doc item or issue, classify exactly one state:
 
@@ -87,7 +90,9 @@ For each drift case, recommend one concrete corrective action only:
 - GitHub remains the canonical backlog-state surface.
 - Treat Project `Status` as the primary lifecycle signal.
 - Treat `agent:ready` as the pickup qualifier for `Status=Ready`, not as a substitute for `In Progress`, `Review`, or `Done`.
+- For PR cards, treat open non-draft as `Review` and open draft as `In Progress`.
 - Prefer one repair action per drift class when the same correction repeats across multiple items; do not churn the board with separate micro-fixes when a batched audit can close the gap.
+- If full-project scan is slow or blocked by API latency, run a targeted audit for open issues, open PRs, and recently merged PRs, then report that fallback explicitly.
 
 
 ## Capturing learning

--- a/.codex/skills/issue-maintenance-change-control/SKILL.md
+++ b/.codex/skills/issue-maintenance-change-control/SKILL.md
@@ -71,8 +71,7 @@ Project Status must match content state. Every other cell is drift and must be c
 | PR | MERGED | `Done` |
 | PR | CLOSED (unmerged) | `Done` |
 | PR | OPEN + Draft | `In Progress` |
-| PR | OPEN + review requested | `Review` |
-| PR | OPEN + no review requested | `In Progress` |
+| PR | OPEN + non-draft | `Review` |
 | Any | Present but no Project entry | Add to Project, apply row above |
 
 ### Drift patterns that must be flagged explicitly
@@ -83,6 +82,7 @@ These are the high-frequency drift patterns that are easy to miss. A maintenance
 - **Closed Issues stuck in `Review` or `In Progress`** — the Issue is Done; non-terminal status on closed Issues is drift, not a pending handoff.
 - **Open `agent:ready` Issues not in `Ready`** — the queue is lying about what is pickable. The `agent:ready ↔ Status=Ready` binding is a post-condition, not just a declarative rule.
 - **PRs with no Project Status (blank / not in Project)** — the board cannot reflect lifecycle if the PR isn't represented at all. Open and closed PRs both need Project entries.
+- **Open non-draft PRs stuck in `In Progress`** — this violates the shipped projection model where non-draft PRs default to `Review`.
 
 ## Change-control checklist (Core Runtime <-> Agentic Lab)
 


### PR DESCRIPTION
- [x] Governance lane

## Summary
- align issue-maintenance lifecycle matrix with shipped PR projection model (open non-draft PR -> Review)
- add drift checks for merged cards left non-terminal and fixes not yet present on origin/main
- add targeted-audit fallback guidance when full project scan is slow/API-latent

## Validation
- ran hygiene audit on open issues/PRs and recent merged PRs
- verified no current drift for issues #556-#559 and PRs #562/#565
- verified mapping fix is present on origin/main
