### PR TITLE
Implement minimal commitment-runtime query surface for next/waiting

### DIFF
--- a/app/domain/commitments.py
+++ b/app/domain/commitments.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Literal, cast
 
 
@@ -12,12 +12,30 @@ CommitmentKind = Literal[
     "review_return",
 ]
 
+CommitmentState = Literal[
+    "unknown",
+    "open",
+    "next",
+    "waiting",
+    "blocked",
+    "done",
+]
+
 FIRST_WAVE_COMMITMENT_KINDS: tuple[CommitmentKind, ...] = (
     "open_loop",
     "project",
     "next_action",
     "waiting",
     "review_return",
+)
+
+COMMITMENT_STATE_VALUES: tuple[CommitmentState, ...] = (
+    "unknown",
+    "open",
+    "next",
+    "waiting",
+    "blocked",
+    "done",
 )
 
 
@@ -39,11 +57,41 @@ class CommitmentHandle:
         return payload
 
 
+@dataclass(frozen=True)
+class CommitmentRecord:
+    commitment_id: str
+    commitment_kind: CommitmentKind
+    state: CommitmentState = "unknown"
+    target_ref: str | None = None
+    summary: str | None = None
+    source_goal: str | None = None
+
+
+@dataclass(frozen=True)
+class CommitmentQueryResult:
+    next_items: tuple[CommitmentRecord, ...]
+    waiting_items: tuple[CommitmentRecord, ...]
+    operator_summary: dict[str, object]
+
+
+@dataclass(frozen=True)
+class CommitmentTransitionResult:
+    updated: CommitmentRecord
+    receipt_metadata: dict[str, str]
+
+
 def normalize_commitment_kind(value: object) -> CommitmentKind:
     cleaned = str(value or "").strip().lower()
     if cleaned not in FIRST_WAVE_COMMITMENT_KINDS:
         raise ValueError(f"unsupported commitment_kind '{value}'")
     return cast(CommitmentKind, cleaned)
+
+
+def normalize_commitment_state(value: object) -> CommitmentState:
+    cleaned = str(value or "").strip().lower()
+    if cleaned not in COMMITMENT_STATE_VALUES:
+        raise ValueError(f"unsupported commitment_state '{value}'")
+    return cast(CommitmentState, cleaned)
 
 
 def make_commitment_handle(
@@ -61,10 +109,60 @@ def make_commitment_handle(
     )
 
 
+def query_next_and_waiting_commitments(
+    commitments: tuple[CommitmentRecord, ...] | list[CommitmentRecord],
+) -> CommitmentQueryResult:
+    next_items = tuple(item for item in commitments if item.state == "next")
+    waiting_items = tuple(item for item in commitments if item.state == "waiting")
+    operator_summary: dict[str, object] = {
+        "next_count": len(next_items),
+        "waiting_count": len(waiting_items),
+        "next_ids": [item.commitment_id for item in next_items],
+        "waiting_ids": [item.commitment_id for item in waiting_items],
+    }
+    return CommitmentQueryResult(
+        next_items=next_items,
+        waiting_items=waiting_items,
+        operator_summary=operator_summary,
+    )
+
+
+def apply_commitment_state_transition(
+    commitment: CommitmentRecord,
+    *,
+    to_state: object,
+    receipt_event_id: str,
+    trace_id: str,
+    cause: str,
+    executor: str = "commitment.runtime",
+) -> CommitmentTransitionResult:
+    next_state = normalize_commitment_state(to_state)
+    updated = replace(commitment, state=next_state)
+    receipt_metadata = {
+        "commitment_id": commitment.commitment_id,
+        "receipt_event_id": str(receipt_event_id),
+        "trace_id": str(trace_id),
+        "before_state": commitment.state,
+        "after_state": next_state,
+        "transition_family": "commitment_state",
+        "cause": str(cause),
+        "executor": executor,
+    }
+    return CommitmentTransitionResult(updated=updated, receipt_metadata=receipt_metadata)
+
+
 __all__ = [
+    "COMMITMENT_STATE_VALUES",
+    "CommitmentQueryResult",
     "CommitmentHandle",
+    "CommitmentRecord",
+    "CommitmentState",
+    "CommitmentTransitionResult",
     "CommitmentKind",
     "FIRST_WAVE_COMMITMENT_KINDS",
+    "apply_commitment_state_transition",
     "make_commitment_handle",
+    "normalize_commitment_state",
     "normalize_commitment_kind",
+    "query_next_and_waiting_commitments",
 ]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -343,6 +343,10 @@ Tests: `tests/architecture/test_architecture_tests_validation.py::test_import_bo
 - Execution plans are runtime orchestration artifacts. They must not be read as equivalent to the
   human commitment/project layer described in `docs/PROJECT_KERNEL.md` and the commitment concept
   contracts.
+- Minimal commitment-runtime seam: runtime now includes a bounded commitment read model for
+  `next`/`waiting` surfacing plus governed commitment transition metadata that links transition
+  receipts (`before_state`, `after_state`, `cause`, `receipt_event_id`, `trace_id`) without
+  collapsing commitments into note `review_state`/`maturity` semantics.
 - Derived / overlay metadata: system-owned overlays such as `zone`, recency, or salience are computed from signals and remain outside the core contract.
 - Agent reasoning operates on Core-6 + state axes + policy profiles (see `docs/NOTE_KIND_POLICIES.md`) + derived overlays.
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -64,6 +64,13 @@ co-editing and hybrid Panel/Chat integration remain v6 future surfaces, governed
 - Context enablement posture: the relation store now supports optional `sphere_membership`
   memberships as broader belonging metadata. This seam is additive only; operational scope still
   governs conservative runtime behavior and retrieval is not relation-driven by default.
+- Retrieval capability seam: salience/staleness signal payload exists as an optional diagnostics
+  seam and is emitted only on explicit opt-in. Runtime does not source staleness from persisted
+  state-axis labels in artifact payload (`review_state`, `maturity`).
+- Commitment-runtime minimal slice: bounded `next`/`waiting` commitment query surfacing is present
+  in the domain layer, commitment state values remain distinct from note state axes, and
+  commitment-state transitions now carry receipt-linkage metadata through the governed transition
+  path.
 - Minimal concurrency guarantees: DedupTaskQueue + event_id dedup guard watcher runs, optimistic writes protect note updates, and the promotion consumer uses an EventDedupStore to skip duplicate intents (`docs/CONCURRENCY.md`, `app/promotion/consumer.py`).
 - Settings compiler scope: panel action catalog, watcher settings, and outbox paths now compile with provenance (path/mtime/sha) via `vault/@Settings/watchers.md`, `docs/settings/panel-actions.md`, `python -m app.cli settings-validate`, and `python -m app.cli settings-explain`.
 - Operator enablement signals: `python -m app.cli settings-explain` surfaces watcher auto-exec state, allowlist validity, provenance, and write-guard context; `python -m app.cli status` exposes the same gate, watcher automation counters, last tick skips, last-run skip reasons, and panel-action/compiler provenance (source paths, mtimes, combined digest). Treat `allowlist`, `dedup/skipped_*`, `panel_skipped_policy`, and `writes_allowed` as the safe-to-enable checklist, not just the raw `WATCHER_AUTO_EXEC` value.
@@ -119,6 +126,8 @@ High-level design rules for this direction now live in `docs/DESIGN_PRINCIPLES.m
 
 - Runtime uses the registry watcher, DB outbox, worker, ASK API, and status/health surfaces as the canonical operational path.
 - Runtime event envelopes emitted through the shared outbox helper now include `meta.instance_provenance` (`instance_id`, `instance_role`, `environment`) as backward-compatible operational metadata.
+- Panel mutation gating now enforces explicit trust-verb classification on mutation-capable panel actions: only admitted `APPLY` actions can emit promotion mutation intents; `SUGGEST` remains non-mutating unless promoted through the governed execution path.
+- APPLY transition receipts (`promotion.transition.applied`) now include accountability fields (`verb`, `authority`, `basis`, `outcome`, `artifact_linkage`, `instance_provenance`) as backward-compatible payload extensions.
 - Status summaries now expose instance provenance (`instance_id`, `instance_role`, `environment`) for runtime attribution; this does not change artifact identity or companion note identity semantics.
 - Production-facing path is the active current-state default; lab/dev-only flows remain explicitly non-production.
 - The local test stack can be started successfully against a separate test vault, and `uat-seed-vault-test` works.

--- a/tests/commitments/test_commitment_queries.py
+++ b/tests/commitments/test_commitment_queries.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from app.domain.commitments import CommitmentRecord, query_next_and_waiting_commitments
+
+
+def test_query_next_and_waiting_commitments() -> None:
+    commitments = (
+        CommitmentRecord(commitment_id="c-next-1", commitment_kind="next_action", state="next", summary="Ship PR"),
+        CommitmentRecord(commitment_id="c-wait-1", commitment_kind="waiting", state="waiting", summary="Await legal"),
+        CommitmentRecord(commitment_id="c-open-1", commitment_kind="open_loop", state="open", summary="Clarify scope"),
+    )
+
+    result = query_next_and_waiting_commitments(commitments)
+
+    assert [item.commitment_id for item in result.next_items] == ["c-next-1"]
+    assert [item.commitment_id for item in result.waiting_items] == ["c-wait-1"]
+    assert result.operator_summary["next_count"] == 1
+    assert result.operator_summary["waiting_count"] == 1
+    assert result.operator_summary["next_ids"] == ["c-next-1"]
+    assert result.operator_summary["waiting_ids"] == ["c-wait-1"]

--- a/tests/commitments/test_commitment_receipts.py
+++ b/tests/commitments/test_commitment_receipts.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from app.domain.commitments import (
+    CommitmentRecord,
+    apply_commitment_state_transition,
+)
+
+
+def test_commitment_transition_links_receipt_metadata() -> None:
+    commitment = CommitmentRecord(
+        commitment_id="c-123",
+        commitment_kind="next_action",
+        state="next",
+        summary="Send status update",
+        target_ref="note:abc",
+    )
+
+    transition = apply_commitment_state_transition(
+        commitment,
+        to_state="waiting",
+        receipt_event_id="evt-commit-1",
+        trace_id="trace-commit-1",
+        cause="waiting on reply from Alice",
+    )
+
+    assert transition.updated.state == "waiting"
+    assert transition.receipt_metadata["commitment_id"] == "c-123"
+    assert transition.receipt_metadata["receipt_event_id"] == "evt-commit-1"
+    assert transition.receipt_metadata["trace_id"] == "trace-commit-1"
+    assert transition.receipt_metadata["before_state"] == "next"
+    assert transition.receipt_metadata["after_state"] == "waiting"
+    assert transition.receipt_metadata["transition_family"] == "commitment_state"
+    assert transition.receipt_metadata["cause"] == "waiting on reply from Alice"

--- a/tests/commitments/test_commitment_state_boundaries.py
+++ b/tests/commitments/test_commitment_state_boundaries.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from app.domain.commitments import COMMITMENT_STATE_VALUES
+from app.domain.state_axes import CANONICAL_MATURITY_VALUES, CANONICAL_REVIEW_STATES, LEGACY_REVIEW_STATES
+
+
+def test_commitment_states_do_not_reuse_state_axes() -> None:
+    commitment_states = set(COMMITMENT_STATE_VALUES)
+    note_axis_values = set(CANONICAL_REVIEW_STATES) | set(CANONICAL_MATURITY_VALUES) | set(LEGACY_REVIEW_STATES)
+
+    overlap = commitment_states & note_axis_values
+    assert overlap == set()


### PR DESCRIPTION
Fixes #574

## Summary
- add a bounded commitment runtime read/query seam for next and waiting commitment surfacing
- add governed commitment-state transition metadata with receipt linkage fields
- add AC verification tests for query surfacing, state-axis boundary separation, and receipt linkage
- update architecture/status docs with the minimal commitment-runtime scope and non-collapse guardrails

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/commitments/test_commitment_queries.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/commitments/test_commitment_state_boundaries.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/commitments/test_commitment_receipts.py
