### PR TITLE
Issue #576: Add minimal read-only orientation runtime surface

### DIFF
--- a/.codex/skills/backlog-reconciliation-drift-audit/SKILL.md
+++ b/.codex/skills/backlog-reconciliation-drift-audit/SKILL.md
@@ -92,7 +92,7 @@ For each drift case, recommend one concrete corrective action only:
 - Treat `agent:ready` as the pickup qualifier for `Status=Ready`, not as a substitute for `In Progress`, `Review`, or `Done`.
 - For PR cards, treat open non-draft as `Review` and open draft as `In Progress`.
 - Prefer one repair action per drift class when the same correction repeats across multiple items; do not churn the board with separate micro-fixes when a batched audit can close the gap.
-- If full-project scan is slow or blocked by API latency, run a targeted audit for open issues, open PRs, and recently merged PRs, then report that fallback explicitly.
+- If full-project scan is slow or blocked by API latency, run a targeted audit for open issues, open PRs, recently merged PRs, and recently closed-unmerged PRs, then report that fallback explicitly.
 
 
 ## Capturing learning

--- a/.codex/skills/backlog-reconciliation-drift-audit/SKILL.md
+++ b/.codex/skills/backlog-reconciliation-drift-audit/SKILL.md
@@ -32,7 +32,9 @@ You must detect:
 - issues missing required contract sections
 - open implementation Issues missing a truthful agent-state label
 - stale `agent:ready` labels on work that is blocked or already done
-- draft PR work or open PR work that was moved to `Review` before explicit review handoff
+- open non-draft PR work that is not projected to `Review`
+- merged PR cards that remain non-terminal (`In Progress`/`Review`) after merge
+- fixes that were validated on a branch but are not yet present on `origin/main`
 - active work that still presents as `Ready`
 
 ## Authority order
@@ -52,6 +54,7 @@ You must detect:
 4. Inspect recent closed PRs that are not merged.
 5. Inspect current Project states.
 6. Match all of them by `Source Anchors`, doc items, and delivered reality.
+7. Confirm recently merged fix PRs are actually present on `origin/main` when they claim to resolve projection drift.
 
 For each inspected doc item or issue, classify exactly one state:
 
@@ -87,7 +90,9 @@ For each drift case, recommend one concrete corrective action only:
 - GitHub remains the canonical backlog-state surface.
 - Treat Project `Status` as the primary lifecycle signal.
 - Treat `agent:ready` as the pickup qualifier for `Status=Ready`, not as a substitute for `In Progress`, `Review`, or `Done`.
+- For PR cards, treat open non-draft as `Review` and open draft as `In Progress`.
 - Prefer one repair action per drift class when the same correction repeats across multiple items; do not churn the board with separate micro-fixes when a batched audit can close the gap.
+- If full-project scan is slow or blocked by API latency, run a targeted audit for open issues, open PRs, and recently merged PRs, then report that fallback explicitly.
 
 
 ## Capturing learning

--- a/.codex/skills/issue-maintenance-change-control/SKILL.md
+++ b/.codex/skills/issue-maintenance-change-control/SKILL.md
@@ -71,8 +71,7 @@ Project Status must match content state. Every other cell is drift and must be c
 | PR | MERGED | `Done` |
 | PR | CLOSED (unmerged) | `Done` |
 | PR | OPEN + Draft | `In Progress` |
-| PR | OPEN + review requested | `Review` |
-| PR | OPEN + no review requested | `In Progress` |
+| PR | OPEN + non-draft | `Review` |
 | Any | Present but no Project entry | Add to Project, apply row above |
 
 ### Drift patterns that must be flagged explicitly
@@ -83,6 +82,7 @@ These are the high-frequency drift patterns that are easy to miss. A maintenance
 - **Closed Issues stuck in `Review` or `In Progress`** — the Issue is Done; non-terminal status on closed Issues is drift, not a pending handoff.
 - **Open `agent:ready` Issues not in `Ready`** — the queue is lying about what is pickable. The `agent:ready ↔ Status=Ready` binding is a post-condition, not just a declarative rule.
 - **PRs with no Project Status (blank / not in Project)** — the board cannot reflect lifecycle if the PR isn't represented at all. Open and closed PRs both need Project entries.
+- **Open non-draft PRs stuck in `In Progress`** — this violates the shipped projection model where non-draft PRs default to `Review`.
 
 ## Change-control checklist (Core Runtime <-> Agentic Lab)
 

--- a/app/api/app.py
+++ b/app/api/app.py
@@ -34,6 +34,11 @@ except ImportError:
     ask_router = None
 
 try:
+    from app.api.routes.orientation import router as orientation_router
+except ImportError:
+    orientation_router = None
+
+try:
     from app.api.routes.health import router as health_router
 except ImportError:
     health_router = None
@@ -120,6 +125,8 @@ def _create_app() -> FastAPI:
         application.include_router(status_router, prefix="/api")
     if ask_router is not None:
         application.include_router(ask_router, prefix="/api")
+    if orientation_router is not None:
+        application.include_router(orientation_router, prefix="/api")
     if health_router is not None:
         application.include_router(health_router, prefix="/api")
     if health_contract_router is not None:
@@ -143,5 +150,4 @@ async def index() -> HTMLResponse:
     """Interim dashboard for status visibility and manual ASK checks."""
     index_path = static_dir / "index.html"
     return HTMLResponse(index_path.read_text(encoding="utf-8"))
-
 

--- a/app/api/routes/orientation.py
+++ b/app/api/routes/orientation.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.orientation.runtime import OrientationFrame, build_orientation_frame
+
+router = APIRouter()
+
+
+@router.get("/orientation", response_model=OrientationFrame)
+async def orientation() -> OrientationFrame:
+    return build_orientation_frame()
+
+
+__all__ = ["router", "OrientationFrame"]

--- a/app/orientation/runtime.py
+++ b/app/orientation/runtime.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from app.observability.status_service import get_system_status
+
+
+class OrientationExplanation(BaseModel):
+    leave_point: str
+    open_items: list[str]
+    notable_change: str
+
+
+class OrientationFrame(BaseModel):
+    frame: str
+    explanation: OrientationExplanation
+    read_only: bool = True
+    mutation_intents: list[str] = Field(default_factory=list)
+
+
+def _iso(dt: datetime | None) -> str:
+    if dt is None:
+        return "unknown"
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def build_orientation_frame() -> OrientationFrame:
+    status = get_system_status()
+    events = status.events
+    ingestion = status.ingestion
+    queue = status.worker_queue
+
+    leave_point = (
+        "Last known runtime leave-point: "
+        f"watcher_runs_24h={events.watcher_runs_24h if events else 0}, "
+        f"panel_runs_24h={events.panel_runs_24h if events else 0}, "
+        f"last_ingest_at={_iso(ingestion.last_run_at)}."
+    )
+
+    open_items: list[str] = []
+    if queue and (queue.pending or 0) > 0:
+        open_items.append(f"Worker queue pending runtime changes: {queue.pending}.")
+    if events and events.promote_created_total > events.promotion_executed_total:
+        remaining = events.promote_created_total - events.promotion_executed_total
+        open_items.append(f"Promotion intents created but not executed: {remaining}.")
+    if not open_items:
+        open_items.append("No unresolved runtime loops detected in current snapshot.")
+
+    notable_change = (
+        "Recent notable change: "
+        f"ingest_total={ingestion.total_ingested}, "
+        f"watcher_runs_total={events.watcher_runs_total if events else 0}, "
+        f"promotion_executed_total={events.promotion_executed_total if events else 0}."
+    )
+
+    frame = (
+        "Orientation frame: "
+        "where you were is reconstructed from recent runtime activity, "
+        "what is still open is listed as unresolved loops, "
+        "and notable changes are summarized from current derived counters."
+    )
+
+    return OrientationFrame(
+        frame=frame,
+        explanation=OrientationExplanation(
+            leave_point=leave_point,
+            open_items=open_items,
+            notable_change=notable_change,
+        ),
+    )
+
+
+__all__ = ["OrientationExplanation", "OrientationFrame", "build_orientation_frame"]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -81,7 +81,7 @@ The current runtime sits inside a small local system boundary:
 - Human-facing surfaces:
   - the Obsidian vault as the canonical writing and reading surface,
   - the CLI for operator and developer workflows,
-  - the HTTP API for ASK, health, and status.
+  - the HTTP API for ASK, orientation, health, and status.
 - Runtime components in this repository:
   - ingestion, watcher, panel, ASK, promotion, worker, and store-facing application code,
   - event emission and observability hooks,
@@ -393,9 +393,10 @@ Tests: `tests/architecture/test_architecture_tests_validation.py::test_import_bo
    - Legacy snapshot watcher (`vault-watcher-run`) is dev-only and not used in runtime start-system flows.
 2) **External corpus ingest (minimal)** — a small drop folder/pipeline for real external documents ingested as `external_raw` runtime objects, stored in ObjectStore and indexed without surfacing as vault notes (txt/md drop-folder CLI implemented; newsletters/PDFs can extend the same path).
 3) **ASK API** — FastAPI endpoint returning answer text plus sources `{uuid, title, origin (vault/external), zone overlay if known, path/source_ref}` and latency; uses hybrid retrieval over both planes with an in-process HybridStore warmed from `store_objects` on first use. `zone` is passed through when present on the hit payload, but derived zone coverage is not guaranteed baseline behavior.
-4) **Observability backend** — status service that aggregates per-store projection counts (vault vs external), ingest timestamps/errors, and ASK query counts/latency; exposed via CLI and interim GUI.
-5) **Interim GUI** — simple FastAPI-served page (root `/`) that shows status (object counts, last ingest, ASK stats) and an ASK input with answers + visible sources; explicitly a temporary observability/interaction surface.
-6) **Panel action catalog & watcher settings** — the canonical action catalog (`docs/settings/panel-actions.md`) + `vault/@Settings/watchers.md` describe allowed `watcher_allowed` actions, auto-run env (`WATCHER_AUTO_EXEC`), and outbox paths; `python -m app.cli settings-explain` and `python -m app.cli settings-validate` emit provenance + validation output for reviews.
+4) **Orientation API (read-only seam)** — FastAPI endpoint returning a situational frame without requiring a query term. It composes only derived runtime signals (recent activity, open-loop proxies, and context-change hints) and exposes explicit explanation fields (`leave_point`, `open_items`, `notable_change`) with no mutation intents.
+5) **Observability backend** — status service that aggregates per-store projection counts (vault vs external), ingest timestamps/errors, and ASK query counts/latency; exposed via CLI and interim GUI.
+6) **Interim GUI** — simple FastAPI-served page (root `/`) that shows status (object counts, last ingest, ASK stats) and an ASK input with answers + visible sources; explicitly a temporary observability/interaction surface.
+7) **Panel action catalog & watcher settings** — the canonical action catalog (`docs/settings/panel-actions.md`) + `vault/@Settings/watchers.md` describe allowed `watcher_allowed` actions, auto-run env (`WATCHER_AUTO_EXEC`), and outbox paths; `python -m app.cli settings-explain` and `python -m app.cli settings-validate` emit provenance + validation output for reviews.
 All current runtime surfaces build on the same Store abstraction (ObjectStore, VectorIndex, RelationIndex), event envelope, and vault-first write boundary.
 
 ## Current vs Planned Status

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -18,6 +18,7 @@ Concept anchors: layering, portability, archive exposure, trust semantics, event
 ## Runtime verification
 - `/api/health` reports watcher and worker heartbeat freshness plus the runtime DB/LLM probes so operators see deterministic health signals.
 - `scripts/start_full_system.sh` and `scripts/gap_test_alpha.sh` drive the registry watcher → DB outbox → worker → index → `/api/ask` chain, emit `watcher.run` audit rows plus `index.embedding.created` / `index.embedding.failed` (legacy alias: `index.object.embedded`), and log diagnostics when sources are missing.
+- `/api/orientation` now provides a minimal read-only orientation runtime seam that returns a situational frame without a query term; explanation remains bounded to `leave_point`, `open_items`, and `notable_change` derived from runtime signals.
 - The interim GUI and Status service consume these heartbeats/events so the dashboard shows ingest health, counts, and incidents in one place.
 - The local `test` bootstrap path is now treated as a first-class verification concern: parts of the path work today, but the repo-supported clean-state path is not yet fully self-contained end to end.
 - `python -m app.cli sync-latency-harness` now defaults to provider-free `PANEL_AGENT_DECIDER=rule` for deterministic operator validation, emits progress before long-running watcher work, and fails within a bounded timeout instead of hanging indefinitely when a live LLM provider is unavailable.
@@ -58,6 +59,7 @@ co-editing and hybrid Panel/Chat integration remain v6 future surfaces, governed
 - Settings tiering (watcher controls): runtime defaults to `PKM_SETTINGS_PROFILE=operator` (which maps to `prod` environment); dev/lab-only watcher tuning env vars are applied only when `PKM_SETTINGS_PROFILE=lab` (which maps to `dev` environment).
 - Storage baseline: `store_objects` is the canonical object table; legacy `objects` rows are best-effort migrated when needed so runtime avoids dual-table selection. Legacy `app/store/object_store.py` now delegates to canonical `app/stores` providers (compat mirror retained for tests), and `index rebuild` reads via `ObjectStore` rather than separate memory/DB query branches.
 - ASK warm-load boundary: `/api/ask` hydrates HybridStore through the canonical store interface (`list_objects`) instead of backend-specific `_objects`/raw SQL introspection.
+- Orientation posture: `/api/orientation` is additive to ASK and not a full cognitive rollout; it is a bounded read-only runtime surface with no mutation intents.
 - DB outbox is canonical in runtime; JSONL (`INDEX_OUTBOX_PATH`) is audit only and should not be used as the worker queue.
 - Required contracts: event compatibility/outbox envelope (`docs/EVENTS.md`), trust semantics, config-as-product, and PanelAgent wiring (`docs/PANEL_AGENT.md` + `docs/settings/panel-actions.md`).
 - State-axis normalization posture: `maturity` is the canonical standing sink, `review_state` is the canonical review/mutation posture field, and legacy values such as `evergreen`, `processed`, `promoted`, `inbox`, and `logged` are compatibility-only inputs rather than preferred runtime outputs.

--- a/tests/api/test_openapi_endpoints.py
+++ b/tests/api/test_openapi_endpoints.py
@@ -8,5 +8,5 @@ def test_openapi_includes_operator_endpoints() -> None:
     resp = client.get("/openapi.json")
     assert resp.status_code == 200
     paths = resp.json().get("paths") or {}
-    for route in ["/api/health", "/api/settings/validate", "/api/events/tail", "/api/status"]:
+    for route in ["/api/health", "/api/settings/validate", "/api/events/tail", "/api/status", "/api/orientation"]:
         assert route in paths

--- a/tests/architecture/test_openapi_sync.py
+++ b/tests/architecture/test_openapi_sync.py
@@ -11,6 +11,6 @@ def test_openapi_includes_documented_routes():
     assert resp.status_code == 200
     data = resp.json()
     paths = set((data.get("paths") or {}).keys())
-    expected = {"/api/status", "/api/ask"}
+    expected = {"/api/status", "/api/ask", "/api/orientation"}
     missing = expected - paths
     assert not missing, f"Documented API routes missing from OpenAPI: {missing}"

--- a/tests/orientation/test_orientation_runtime.py
+++ b/tests/orientation/test_orientation_runtime.py
@@ -1,0 +1,30 @@
+from fastapi.testclient import TestClient
+
+from app.api.app import app
+
+
+def test_orientation_returns_frame_without_query() -> None:
+    client = TestClient(app)
+    resp = client.get('/api/orientation')
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body.get('frame')
+
+
+def test_orientation_explanation_shape() -> None:
+    client = TestClient(app)
+    resp = client.get('/api/orientation')
+    assert resp.status_code == 200
+    explanation = (resp.json().get('explanation') or {})
+    assert 'leave_point' in explanation
+    assert 'open_items' in explanation
+    assert 'notable_change' in explanation
+
+
+def test_orientation_is_read_only() -> None:
+    client = TestClient(app)
+    resp = client.get('/api/orientation')
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body.get('read_only') is True
+    assert body.get('mutation_intents') == []


### PR DESCRIPTION
## Summary
- add a minimal read-only `/api/orientation` runtime seam distinct from query-driven ASK/retrieval
- build an orientation frame from derived runtime signals and return explicit explanation fields: `leave_point`, `open_items`, `notable_change`
- add issue-scoped orientation runtime tests and update OpenAPI route coverage tests
- write back architecture/status docs to mark orientation runtime posture as additive, bounded, and non-mutating

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/orientation/test_orientation_runtime.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/api/test_openapi_endpoints.py tests/architecture/test_openapi_sync.py`

Fixes #576
