### PR TITLE
Add flagged remote MCP multiplex route in ToolProvider

### DIFF
--- a/.codex/skills/backlog-reconciliation-drift-audit/SKILL.md
+++ b/.codex/skills/backlog-reconciliation-drift-audit/SKILL.md
@@ -92,7 +92,7 @@ For each drift case, recommend one concrete corrective action only:
 - Treat `agent:ready` as the pickup qualifier for `Status=Ready`, not as a substitute for `In Progress`, `Review`, or `Done`.
 - For PR cards, treat open non-draft as `Review` and open draft as `In Progress`.
 - Prefer one repair action per drift class when the same correction repeats across multiple items; do not churn the board with separate micro-fixes when a batched audit can close the gap.
-- If full-project scan is slow or blocked by API latency, run a targeted audit for open issues, open PRs, and recently merged PRs, then report that fallback explicitly.
+- If full-project scan is slow or blocked by API latency, run a targeted audit for open issues, open PRs, recently merged PRs, and recently closed-unmerged PRs, then report that fallback explicitly.
 
 
 ## Capturing learning

--- a/.codex/skills/backlog-reconciliation-drift-audit/SKILL.md
+++ b/.codex/skills/backlog-reconciliation-drift-audit/SKILL.md
@@ -32,7 +32,9 @@ You must detect:
 - issues missing required contract sections
 - open implementation Issues missing a truthful agent-state label
 - stale `agent:ready` labels on work that is blocked or already done
-- draft PR work or open PR work that was moved to `Review` before explicit review handoff
+- open non-draft PR work that is not projected to `Review`
+- merged PR cards that remain non-terminal (`In Progress`/`Review`) after merge
+- fixes that were validated on a branch but are not yet present on `origin/main`
 - active work that still presents as `Ready`
 
 ## Authority order
@@ -52,6 +54,7 @@ You must detect:
 4. Inspect recent closed PRs that are not merged.
 5. Inspect current Project states.
 6. Match all of them by `Source Anchors`, doc items, and delivered reality.
+7. Confirm recently merged fix PRs are actually present on `origin/main` when they claim to resolve projection drift.
 
 For each inspected doc item or issue, classify exactly one state:
 
@@ -87,7 +90,9 @@ For each drift case, recommend one concrete corrective action only:
 - GitHub remains the canonical backlog-state surface.
 - Treat Project `Status` as the primary lifecycle signal.
 - Treat `agent:ready` as the pickup qualifier for `Status=Ready`, not as a substitute for `In Progress`, `Review`, or `Done`.
+- For PR cards, treat open non-draft as `Review` and open draft as `In Progress`.
 - Prefer one repair action per drift class when the same correction repeats across multiple items; do not churn the board with separate micro-fixes when a batched audit can close the gap.
+- If full-project scan is slow or blocked by API latency, run a targeted audit for open issues, open PRs, and recently merged PRs, then report that fallback explicitly.
 
 
 ## Capturing learning

--- a/.codex/skills/issue-maintenance-change-control/SKILL.md
+++ b/.codex/skills/issue-maintenance-change-control/SKILL.md
@@ -71,8 +71,7 @@ Project Status must match content state. Every other cell is drift and must be c
 | PR | MERGED | `Done` |
 | PR | CLOSED (unmerged) | `Done` |
 | PR | OPEN + Draft | `In Progress` |
-| PR | OPEN + review requested | `Review` |
-| PR | OPEN + no review requested | `In Progress` |
+| PR | OPEN + non-draft | `Review` |
 | Any | Present but no Project entry | Add to Project, apply row above |
 
 ### Drift patterns that must be flagged explicitly
@@ -83,6 +82,7 @@ These are the high-frequency drift patterns that are easy to miss. A maintenance
 - **Closed Issues stuck in `Review` or `In Progress`** — the Issue is Done; non-terminal status on closed Issues is drift, not a pending handoff.
 - **Open `agent:ready` Issues not in `Ready`** — the queue is lying about what is pickable. The `agent:ready ↔ Status=Ready` binding is a post-condition, not just a declarative rule.
 - **PRs with no Project Status (blank / not in Project)** — the board cannot reflect lifecycle if the PR isn't represented at all. Open and closed PRs both need Project entries.
+- **Open non-draft PRs stuck in `In Progress`** — this violates the shipped projection model where non-draft PRs default to `Review`.
 
 ## Change-control checklist (Core Runtime <-> Agentic Lab)
 

--- a/app/orchestrator/events.py
+++ b/app/orchestrator/events.py
@@ -164,16 +164,33 @@ def emit_orchestration_rolled_back(
 
 
 def emit_mcp_tool_call_started(
-    *, plan_id: str, step_id: str, tool_name: str, object_id: str | None, trace_id: str | None
+    *,
+    plan_id: str,
+    step_id: str,
+    tool_name: str,
+    object_id: str | None,
+    trace_id: str | None,
+    route: Dict[str, Any] | None = None,
 ) -> None:
     details = {"plan_id": plan_id, "step_id": step_id, "tool": tool_name}
+    if route:
+        details.update(route)
     _emit(MCP_TOOL_CALL_STARTED, object_id=object_id, trace_id=trace_id, details=details)
 
 
 def emit_mcp_tool_call_finished(
-    *, plan_id: str, step_id: str, tool_name: str, result: Dict[str, Any], object_id: str | None, trace_id: str | None
+    *,
+    plan_id: str,
+    step_id: str,
+    tool_name: str,
+    result: Dict[str, Any],
+    object_id: str | None,
+    trace_id: str | None,
+    route: Dict[str, Any] | None = None,
 ) -> None:
     details = {"plan_id": plan_id, "step_id": step_id, "tool": tool_name, "result": result}
+    if route:
+        details.update(route)
     _emit(MCP_TOOL_CALL_FINISHED, object_id=object_id, trace_id=trace_id, details=details)
 
 

--- a/app/orchestrator/mcp_tool_provider.py
+++ b/app/orchestrator/mcp_tool_provider.py
@@ -1,25 +1,47 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, Mapping
+from typing import Any, Dict, Mapping, Protocol
 
 from app.components.settings.tools_loader import load_tools
+from app.orchestrator.events import emit_mcp_tool_call_finished, emit_mcp_tool_call_started
 from app.planner.tools import MCP_TOOL_DESCRIPTORS
 from app.orchestrator.executor import MockPlanExecutor, StepContext, StepExecutionError
 from app.planner.schema import ToolDescriptor
+
+
+class RemoteMCPProvider(Protocol):
+    def list_descriptors(self) -> Mapping[str, ToolDescriptor]:
+        ...
+
+    def execute_tool_call(
+        self,
+        *,
+        tool_name: str,
+        tool_args: Mapping[str, Any] | None,
+        context: StepContext,
+        step_id: str,
+        description: str,
+    ) -> Dict[str, Any]:
+        ...
 
 
 @dataclass
 class MCPToolProvider:
     """Registry-backed tool provider that executes via existing executor paths."""
 
-    def list_descriptors(self) -> Dict[str, ToolDescriptor]:
+    remote_provider: RemoteMCPProvider | None = None
+
+    def list_descriptors(self, tool_settings: Mapping[str, Any] | None = None) -> Dict[str, ToolDescriptor]:
         descriptors = _load_registry_descriptors()
+        if _remote_multiplex_enabled(tool_settings) and self.remote_provider is not None:
+            remote = dict(self.remote_provider.list_descriptors())
+            descriptors.update(remote)
         supported = set(MCP_TOOL_DESCRIPTORS.keys())
         return {name: descriptor for name, descriptor in descriptors.items() if name in supported}
 
-    def get_descriptor(self, tool_name: str) -> ToolDescriptor | None:
-        return self.list_descriptors().get(tool_name)
+    def get_descriptor(self, tool_name: str, tool_settings: Mapping[str, Any] | None = None) -> ToolDescriptor | None:
+        return self.list_descriptors(tool_settings).get(tool_name)
 
     def execute_tool_call(
         self,
@@ -31,7 +53,8 @@ class MCPToolProvider:
         description: str,
         executor: MockPlanExecutor | None = None,
     ) -> Dict[str, Any]:
-        descriptor = self.get_descriptor(tool_name)
+        route = self._resolve_route(context.tool_settings)
+        descriptor = self.get_descriptor(tool_name, context.tool_settings)
         if descriptor is None:
             raise StepExecutionError(f"unknown MCP tool '{tool_name}'", error_type="invalid_tool")
 
@@ -46,10 +69,70 @@ class MCPToolProvider:
                 timeout_value = float(settings["tool_timeout_seconds"])
             except Exception:
                 timeout_value = None
-        result_payload = active_executor._invoke_tool(  # noqa: SLF001 - preserve executor runtime path
-            descriptor, call_args, context, timeout_value
+        emit_mcp_tool_call_started(
+            plan_id=context.plan_id,
+            step_id=step_id,
+            tool_name=descriptor.name,
+            object_id=context.object_id,
+            trace_id=context.trace_id,
+            route=route,
+        )
+        result_payload = self._execute_with_route(
+            route=route,
+            descriptor=descriptor,
+            call_args=call_args,
+            context=context,
+            step_id=step_id,
+            description=description,
+            timeout_value=timeout_value,
+            executor=active_executor,
+        )
+        emit_mcp_tool_call_finished(
+            plan_id=context.plan_id,
+            step_id=step_id,
+            tool_name=descriptor.name,
+            result=result_payload,
+            object_id=context.object_id,
+            trace_id=context.trace_id,
+            route=route,
         )
         return {"tool": descriptor.name, "result": result_payload}
+
+    def _resolve_route(self, tool_settings: Mapping[str, Any] | None) -> Dict[str, str]:
+        if not _remote_multiplex_enabled(tool_settings):
+            return {"provider_route": "local_registry", "provider_route_reason": "remote_disabled"}
+        if self.remote_provider is None:
+            return {"provider_route": "local_registry", "provider_route_reason": "remote_unavailable"}
+        return {"provider_route": "remote_multiplex"}
+
+    def _execute_with_route(
+        self,
+        *,
+        route: Dict[str, str],
+        descriptor: ToolDescriptor,
+        call_args: Dict[str, Any],
+        context: StepContext,
+        step_id: str,
+        description: str,
+        timeout_value: float | None,
+        executor: MockPlanExecutor,
+    ) -> Dict[str, Any]:
+        if route.get("provider_route") == "remote_multiplex" and self.remote_provider is not None:
+            try:
+                response = self.remote_provider.execute_tool_call(
+                    tool_name=descriptor.name,
+                    tool_args=call_args,
+                    context=context,
+                    step_id=step_id,
+                    description=description,
+                )
+                return dict(response.get("result") if isinstance(response, Mapping) and "result" in response else response)
+            except Exception:
+                route["provider_route"] = "local_registry"
+                route["provider_route_reason"] = "remote_provider_error"
+                route["provider_route_attempted"] = "remote_multiplex"
+
+        return executor._invoke_tool(descriptor, call_args, context, timeout_value)  # noqa: SLF001
 
 
 def _load_registry_descriptors() -> Dict[str, ToolDescriptor]:
@@ -100,4 +183,17 @@ def _normalize_kind(protocol: str) -> str:
     return "cli"
 
 
-__all__ = ["MCPToolProvider"]
+def _remote_multiplex_enabled(tool_settings: Mapping[str, Any] | None) -> bool:
+    if not isinstance(tool_settings, Mapping):
+        return False
+    raw = tool_settings.get("mcp_remote_multiplex_enable")
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, str):
+        return raw.strip().lower() in {"1", "true", "yes", "on"}
+    if isinstance(raw, (int, float)):
+        return raw != 0
+    return False
+
+
+__all__ = ["MCPToolProvider", "RemoteMCPProvider"]

--- a/docs/contracts/TOOL_POLICY_AND_MCP_ADAPTER_CONTRACT.md
+++ b/docs/contracts/TOOL_POLICY_AND_MCP_ADAPTER_CONTRACT.md
@@ -6,7 +6,7 @@ Authority: Canonical current-state contract for the repo's tool descriptor regis
 
 This document describes the current tool descriptor registry, validation rules, timeout handling, and the MCP adapter boundary inside the repository for bounded tool execution.
 It is a current-state contract for tool descriptor completeness, allowed-argument validation, mock/deterministic test behavior, and audit expectations.
-It does not claim rich descriptor versioning, remote multiplexing, or future permission-model expansion as shipped.
+It does not claim rich descriptor versioning, dynamic remote discovery, or future permission-model expansion as shipped.
 
 Use this document with:
 - `docs/ARCHITECTURE.md` for current runtime boundaries and the planner/orchestrator pipeline.
@@ -22,7 +22,8 @@ Use this document with:
 - Tool validation happens at execution time in the orchestrator (MockPlanExecutor) and includes argument type checking, required-field validation, and agent authorization checks via `POLICY_ENFORCE`.
 - Tool execution supports deterministic/mock behavior for CI and development, real vault append for enabled MCP tools, and internal step handlers for repo-specific operations.
 - A local MCP ToolProvider boundary exposes registry-loaded descriptors and delegates execution through the existing executor validation/policy/timeout/mock-real paths.
-- Remote MCP server multiplexing and dynamic descriptor discovery are not shipped.
+- A bounded remote multiplex seam is available behind explicit flag `mcp_remote_multiplex_enable`; default behavior remains local registry execution.
+- If remote multiplex is enabled but unavailable or failing, execution deterministically falls back to local registry with route reason codes.
 
 ## Descriptor sources and structure
 
@@ -176,8 +177,8 @@ The executor emits outbox events for tool execution:
 
 | Event | Source | Timing | Fields |
 | --- | --- | --- | --- |
-| `mcp.tool.call.started` | `emit_mcp_tool_call_started(...)` (line 165-171) | Before tool execution | `plan_id`, `step_id`, `tool_name`, `object_id`, `trace_id` |
-| `mcp.tool.call.finished` | `emit_mcp_tool_call_finished(...)` (line 194-201) | After successful tool execution | `plan_id`, `step_id`, `tool_name`, `result`, `object_id`, `trace_id` |
+| `mcp.tool.call.started` | `emit_mcp_tool_call_started(...)` | Before tool execution | `plan_id`, `step_id`, `tool_name`, `object_id`, `trace_id`, `provider_route`, optional route reason metadata |
+| `mcp.tool.call.finished` | `emit_mcp_tool_call_finished(...)` | After successful tool execution | `plan_id`, `step_id`, `tool_name`, `result`, `object_id`, `trace_id`, `provider_route`, optional route reason metadata |
 | (vault-specific) `mcp.vault.append_note` | `OutboxEvent(event=..., source="orchestrator.runtime", ...)` (line 276-283) | After real vault append | `trace_id` if available |
 
 ### Trace propagation
@@ -201,12 +202,14 @@ The executor defines built-in handlers for `internal` protocol tools:
 
 Both are handled synchronously during plan execution and do not support real vs. mock branching (they always execute).
 
-## Future MCP integration boundary
+## MCP integration boundary
 
 This contract explicitly bounds the current tool execution behavior and reserves future expansion space:
 
-- **Not currently implemented**: dynamic tool discovery, remote MCP server multiplexing, or tool versioning/evolution policies.
-- **Current implementation boundary**: ToolProvider support is local and registry-backed; execution semantics still run through the existing executor contract.
+- **Currently implemented**: local registry-backed ToolProvider default path, plus optional remote multiplex seam behind `mcp_remote_multiplex_enable`.
+- **Fallback behavior**: when remote multiplex is enabled but no remote adapter is present or the adapter errors, route falls back to local registry with deterministic reason codes (`remote_unavailable`, `remote_provider_error`).
+- **Not currently implemented**: dynamic tool discovery or tool versioning/evolution policies.
+- **Current implementation boundary**: execution semantics still run through the existing executor contract and policy checks.
 - **Planned**: The repo still tracks broader LangGraph and remote MCP integration work in the v5.6 forward line (see `docs/tracks/TRACK_AGENTOPS_A2A_MCP.md`).
 - **Scope boundary**: This contract describes enacted descriptor-registry, ToolProvider boundary, validation, and executor behavior only.
 - **Descriptor stability**: Adding new tools via the YAML registry does not require changes to this contract; only changes to the descriptor format, validation rules, or execution semantics should trigger contract updates.

--- a/tests/events/test_tool_execution_route_metadata.py
+++ b/tests/events/test_tool_execution_route_metadata.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+
+from app.events.types import MCP_TOOL_CALL_FINISHED, MCP_TOOL_CALL_STARTED
+from app.orchestrator.executor import StepContext
+from app.orchestrator.mcp_tool_provider import MCPToolProvider
+from app.planner.schema import PlanMetadata, ToolDescriptor
+
+pytestmark = pytest.mark.not_pg
+
+
+def _context(tool_settings: dict[str, object] | None = None) -> StepContext:
+    return StepContext(
+        plan_id="plan-route-metadata",
+        object_id="obj-route-metadata",
+        trace_id="trace-route-metadata",
+        metadata=PlanMetadata(goal="test", source_object_uuid="obj-route-metadata", created_by="tester"),
+        results={},
+        tool_settings=tool_settings or {},
+        agent_id="ask.v1",
+    )
+
+
+class _RemoteProviderOK:
+    def list_descriptors(self) -> dict[str, ToolDescriptor]:
+        return {
+            "mcp.search.objects": ToolDescriptor(
+                name="mcp.search.objects",
+                kind="mcp",
+                schema={"type": "object", "required": ["query"]},
+                allowed_args={"query": "string"},
+                mock_result={"status": "ok"},
+            )
+        }
+
+    def execute_tool_call(self, **_: object) -> dict[str, object]:
+        return {"tool": "mcp.search.objects", "result": {"status": "remote-ok"}}
+
+
+def test_tool_execution_records_provider_route(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: list[tuple[str, dict[str, object]]] = []
+
+    def _fake_audit_log(*, action: str, details: dict, **kwargs: object) -> None:
+        captured.append((action, details))
+
+    monkeypatch.setattr("app.orchestrator.events.audit_log", _fake_audit_log)
+
+    provider = MCPToolProvider(remote_provider=_RemoteProviderOK())
+    provider.execute_tool_call(
+        tool_name="mcp.search.objects",
+        tool_args={"query": "agentic"},
+        context=_context({"mcp_remote_multiplex_enable": True}),
+        step_id="s-route",
+        description="Route metadata",
+    )
+
+    started = [details for action, details in captured if action == MCP_TOOL_CALL_STARTED]
+    finished = [details for action, details in captured if action == MCP_TOOL_CALL_FINISHED]
+    assert started
+    assert finished
+    assert started[-1]["provider_route"] == "remote_multiplex"
+    assert finished[-1]["provider_route"] == "remote_multiplex"

--- a/tests/tools/test_mcp_tool_provider.py
+++ b/tests/tools/test_mcp_tool_provider.py
@@ -6,7 +6,7 @@ import pytest
 
 from app.orchestrator.executor import MockPlanExecutor, StepContext, StepExecutionError
 from app.orchestrator.mcp_tool_provider import MCPToolProvider
-from app.planner.schema import PlanMetadata, PlanStep
+from app.planner.schema import PlanMetadata, PlanStep, ToolDescriptor
 
 pytestmark = pytest.mark.not_pg
 
@@ -119,3 +119,60 @@ def test_tool_provider_vault_append_respects_existing_gates(tmp_path: Path) -> N
     )
     assert allowed_result["result"]["note_path"] != "vault/_mcp/mock-note.md"
     assert any(tmp_path.rglob("*.md"))
+
+
+class _RemoteProviderOK:
+    def list_descriptors(self) -> dict[str, ToolDescriptor]:
+        return {
+            "mcp.search.objects": ToolDescriptor(
+                name="mcp.search.objects",
+                kind="mcp",
+                schema={"type": "object", "required": ["query"]},
+                allowed_args={"query": "string"},
+                mock_result={"status": "ok"},
+            )
+        }
+
+    def execute_tool_call(self, **_: object) -> dict[str, object]:
+        return {"tool": "mcp.search.objects", "result": {"status": "remote-ok", "route": "remote"}}
+
+
+class _RemoteProviderError(_RemoteProviderOK):
+    def execute_tool_call(self, **_: object) -> dict[str, object]:
+        raise RuntimeError("remote unavailable")
+
+
+def test_remote_multiplex_path_flagged() -> None:
+    provider = MCPToolProvider(remote_provider=_RemoteProviderOK())
+    executor = MockPlanExecutor()
+    context = _context({"mcp_remote_multiplex_enable": True})
+
+    result = provider.execute_tool_call(
+        tool_name="mcp.search.objects",
+        tool_args={"query": "agentic"},
+        context=context,
+        step_id="s-remote",
+        description="Remote path",
+        executor=executor,
+    )
+
+    assert result["result"]["status"] == "remote-ok"
+    assert result["result"]["route"] == "remote"
+
+
+def test_remote_multiplex_fallback_on_provider_error() -> None:
+    provider = MCPToolProvider(remote_provider=_RemoteProviderError())
+    executor = MockPlanExecutor()
+    context = _context({"mcp_remote_multiplex_enable": True})
+
+    result = provider.execute_tool_call(
+        tool_name="mcp.search.objects",
+        tool_args={"query": "agentic"},
+        context=context,
+        step_id="s-fallback",
+        description="Fallback path",
+        executor=executor,
+    )
+
+    assert result["tool"] == "mcp.search.objects"
+    assert result["result"]["status"] == "ok"


### PR DESCRIPTION
Fixes #568

## Summary
- add a bounded remote multiplex adapter seam in MCP ToolProvider behind mcp_remote_multiplex_enable
- preserve local registry as default path, with deterministic fallback reason codes when remote is unavailable or errors
- include provider-route attribution metadata in MCP tool start/finish audit events
- add multiplex/fallback and route-metadata tests, plus contract doc writeback

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/tools/test_mcp_tool_provider.py -k multiplex
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/events/test_tool_execution_route_metadata.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/tools/test_mcp_tool_provider.py
- .venv/bin/python -m app.cli status