### PR TITLE
Fix PR #581 review feedback on MCP remote fallback

### DIFF
--- a/app/orchestrator/mcp_tool_provider.py
+++ b/app/orchestrator/mcp_tool_provider.py
@@ -33,10 +33,14 @@ class MCPToolProvider:
     remote_provider: RemoteMCPProvider | None = None
 
     def list_descriptors(self, tool_settings: Mapping[str, Any] | None = None) -> Dict[str, ToolDescriptor]:
-        descriptors = _load_registry_descriptors()
+        descriptors = self._list_local_descriptors()
         if _remote_multiplex_enabled(tool_settings) and self.remote_provider is not None:
-            remote = dict(self.remote_provider.list_descriptors())
-            descriptors.update(remote)
+            try:
+                remote = dict(self.remote_provider.list_descriptors())
+                descriptors.update(remote)
+            except Exception:
+                # Remote descriptor discovery is best-effort; keep local registry route available.
+                pass
         supported = set(MCP_TOOL_DESCRIPTORS.keys())
         return {name: descriptor for name, descriptor in descriptors.items() if name in supported}
 
@@ -131,8 +135,16 @@ class MCPToolProvider:
                 route["provider_route"] = "local_registry"
                 route["provider_route_reason"] = "remote_provider_error"
                 route["provider_route_attempted"] = "remote_multiplex"
+                local_descriptor = self._list_local_descriptors().get(descriptor.name)
+                if local_descriptor is not None:
+                    descriptor = local_descriptor
+                    executor._validate_tool_args(call_args, descriptor.allowed_args)  # noqa: SLF001
+                    executor._validate_required_args(call_args, descriptor.schema.get("required", []))  # noqa: SLF001
 
         return executor._invoke_tool(descriptor, call_args, context, timeout_value)  # noqa: SLF001
+
+    def _list_local_descriptors(self) -> Dict[str, ToolDescriptor]:
+        return _load_registry_descriptors()
 
 
 def _load_registry_descriptors() -> Dict[str, ToolDescriptor]:

--- a/app/orchestrator/mcp_tool_provider.py
+++ b/app/orchestrator/mcp_tool_provider.py
@@ -58,7 +58,11 @@ class MCPToolProvider:
         executor: MockPlanExecutor | None = None,
     ) -> Dict[str, Any]:
         route = self._resolve_route(context.tool_settings)
-        descriptor = self.get_descriptor(tool_name, context.tool_settings)
+        descriptor = self._resolve_descriptor_for_execution(
+            tool_name=tool_name,
+            tool_settings=context.tool_settings,
+            route=route,
+        )
         if descriptor is None:
             raise StepExecutionError(f"unknown MCP tool '{tool_name}'", error_type="invalid_tool")
 
@@ -102,6 +106,29 @@ class MCPToolProvider:
         )
         return {"tool": descriptor.name, "result": result_payload}
 
+    def _resolve_descriptor_for_execution(
+        self,
+        *,
+        tool_name: str,
+        tool_settings: Mapping[str, Any] | None,
+        route: Dict[str, str],
+    ) -> ToolDescriptor | None:
+        local_descriptors = self._list_local_descriptors()
+        if route.get("provider_route") != "remote_multiplex" or self.remote_provider is None:
+            return local_descriptors.get(tool_name)
+
+        try:
+            remote_descriptors = dict(self.remote_provider.list_descriptors())
+        except Exception:
+            route["provider_route"] = "local_registry"
+            route["provider_route_reason"] = "remote_descriptor_list_error"
+            route["provider_route_attempted"] = "remote_multiplex"
+            return local_descriptors.get(tool_name)
+
+        merged = dict(local_descriptors)
+        merged.update(remote_descriptors)
+        return merged.get(tool_name)
+
     def _resolve_route(self, tool_settings: Mapping[str, Any] | None) -> Dict[str, str]:
         if not _remote_multiplex_enabled(tool_settings):
             return {"provider_route": "local_registry", "provider_route_reason": "remote_disabled"}
@@ -136,10 +163,14 @@ class MCPToolProvider:
                 route["provider_route_reason"] = "remote_provider_error"
                 route["provider_route_attempted"] = "remote_multiplex"
                 local_descriptor = self._list_local_descriptors().get(descriptor.name)
-                if local_descriptor is not None:
-                    descriptor = local_descriptor
-                    executor._validate_tool_args(call_args, descriptor.allowed_args)  # noqa: SLF001
-                    executor._validate_required_args(call_args, descriptor.schema.get("required", []))  # noqa: SLF001
+                if local_descriptor is None:
+                    raise StepExecutionError(
+                        f"remote provider failed and no local fallback is available for '{descriptor.name}'",
+                        error_type="tool_unavailable",
+                    ) from None
+                descriptor = local_descriptor
+                executor._validate_tool_args(call_args, descriptor.allowed_args)  # noqa: SLF001
+                executor._validate_required_args(call_args, descriptor.schema.get("required", []))  # noqa: SLF001
 
         return executor._invoke_tool(descriptor, call_args, context, timeout_value)  # noqa: SLF001
 

--- a/tests/tools/test_mcp_tool_provider.py
+++ b/tests/tools/test_mcp_tool_provider.py
@@ -208,6 +208,24 @@ def test_remote_descriptor_list_error_falls_back_to_local_registry() -> None:
     assert descriptors["mcp.search.objects"].mock_result.get("status") == "ok"
 
 
+def test_remote_descriptor_list_error_during_execute_forces_local_route() -> None:
+    provider = MCPToolProvider(remote_provider=_RemoteProviderListError())
+    executor = MockPlanExecutor()
+    context = _context({"mcp_remote_multiplex_enable": True})
+
+    result = provider.execute_tool_call(
+        tool_name="mcp.search.objects",
+        tool_args={"query": "agentic"},
+        context=context,
+        step_id="s-list-error-execute",
+        description="Descriptor list should force local route",
+        executor=executor,
+    )
+
+    assert result["tool"] == "mcp.search.objects"
+    assert result["result"]["status"] == "ok"
+
+
 def test_remote_error_fallback_re_resolves_local_descriptor() -> None:
     provider = MCPToolProvider(remote_provider=_RemoteProviderOverrideThenError())
     executor = MockPlanExecutor()
@@ -224,3 +242,24 @@ def test_remote_error_fallback_re_resolves_local_descriptor() -> None:
 
     assert result["tool"] == "mcp.search.objects"
     assert result["result"]["status"] == "ok"
+
+
+def test_remote_error_without_local_descriptor_raises_tool_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("app.orchestrator.mcp_tool_provider._load_registry_descriptors", lambda: {})
+    provider = MCPToolProvider(remote_provider=_RemoteProviderOverrideThenError())
+    executor = MockPlanExecutor()
+    context = _context({"mcp_remote_multiplex_enable": True})
+
+    with pytest.raises(StepExecutionError) as exc:
+        provider.execute_tool_call(
+            tool_name="mcp.search.objects",
+            tool_args={"query": "agentic"},
+            context=context,
+            step_id="s-no-local-fallback",
+            description="No local descriptor available",
+            executor=executor,
+        )
+
+    assert exc.value.error_type == "tool_unavailable"

--- a/tests/tools/test_mcp_tool_provider.py
+++ b/tests/tools/test_mcp_tool_provider.py
@@ -142,6 +142,27 @@ class _RemoteProviderError(_RemoteProviderOK):
         raise RuntimeError("remote unavailable")
 
 
+class _RemoteProviderListError(_RemoteProviderOK):
+    def list_descriptors(self) -> dict[str, ToolDescriptor]:
+        raise RuntimeError("remote descriptor list unavailable")
+
+
+class _RemoteProviderOverrideThenError(_RemoteProviderOK):
+    def list_descriptors(self) -> dict[str, ToolDescriptor]:
+        return {
+            "mcp.search.objects": ToolDescriptor(
+                name="mcp.search.objects",
+                kind="mcp",
+                schema={"type": "object", "required": ["query"]},
+                allowed_args={"query": "string"},
+                mock_result={"status": "remote-override"},
+            )
+        }
+
+    def execute_tool_call(self, **_: object) -> dict[str, object]:
+        raise RuntimeError("remote unavailable")
+
+
 def test_remote_multiplex_path_flagged() -> None:
     provider = MCPToolProvider(remote_provider=_RemoteProviderOK())
     executor = MockPlanExecutor()
@@ -171,6 +192,33 @@ def test_remote_multiplex_fallback_on_provider_error() -> None:
         context=context,
         step_id="s-fallback",
         description="Fallback path",
+        executor=executor,
+    )
+
+    assert result["tool"] == "mcp.search.objects"
+    assert result["result"]["status"] == "ok"
+
+
+def test_remote_descriptor_list_error_falls_back_to_local_registry() -> None:
+    provider = MCPToolProvider(remote_provider=_RemoteProviderListError())
+
+    descriptors = provider.list_descriptors({"mcp_remote_multiplex_enable": True})
+
+    assert "mcp.search.objects" in descriptors
+    assert descriptors["mcp.search.objects"].mock_result.get("status") == "ok"
+
+
+def test_remote_error_fallback_re_resolves_local_descriptor() -> None:
+    provider = MCPToolProvider(remote_provider=_RemoteProviderOverrideThenError())
+    executor = MockPlanExecutor()
+    context = _context({"mcp_remote_multiplex_enable": True})
+
+    result = provider.execute_tool_call(
+        tool_name="mcp.search.objects",
+        tool_args={"query": "agentic"},
+        context=context,
+        step_id="s-local-fallback",
+        description="Fallback should use local descriptor",
         executor=executor,
     )
 


### PR DESCRIPTION
Fixes #580

Follow-up to review comments on #581.

## Summary
- catch remote `list_descriptors()` errors and keep local registry descriptors available
- on remote execution failure, re-resolve the descriptor from local registry before fallback invocation
- re-validate args against the local descriptor on fallback
- add regression tests covering both failure modes

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest -q tests/tools/test_mcp_tool_provider.py`
