### PR TITLE
Fix follow-up review comments from #578 #579 #580

### DIFF
--- a/app/observability/status_service.py
+++ b/app/observability/status_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import time
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Iterable
@@ -50,6 +51,13 @@ _WATCHER_EVENT_NAMES = {"watcher.run", "watcher.run.completed"}
 
 
 _TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+@dataclass(frozen=True)
+class OrientationSignals:
+    events: EventCounters
+    ingestion: IngestionStatus
+    worker_queue: WorkerQueueStatus
 
 
 def record_ask_query(latency_ms: float) -> None:
@@ -748,8 +756,25 @@ def get_system_status() -> SystemStatus:
     )
 
 
+def get_orientation_signals() -> OrientationSignals:
+    ingestion = get_ingestion_status()
+    queue_mode = _worker_queue_mode()
+    counters: EventCounters | None = None
+    if queue_mode == "db":
+        counters = _count_events_db()
+    if counters is None:
+        counters = _count_events(Path(INDEX_OUTBOX_PATH)) if INDEX_OUTBOX_PATH else EventCounters()
+    counters = _fill_ingest_run_counts(counters, ingestion)
+    return OrientationSignals(
+        events=counters,
+        ingestion=ingestion,
+        worker_queue=_get_worker_queue_status(),
+    )
+
+
 __all__ = [
     "get_system_status",
+    "get_orientation_signals",
     "get_store_status",
     "get_ingestion_status",
     "get_ask_status",

--- a/app/orchestrator/mcp_tool_provider.py
+++ b/app/orchestrator/mcp_tool_provider.py
@@ -57,8 +57,12 @@ class MCPToolProvider:
         executor: MockPlanExecutor | None = None,
     ) -> Dict[str, Any]:
         route = self._resolve_route(context.tool_settings)
+        supported = set(MCP_TOOL_DESCRIPTORS.keys())
+        if tool_name not in supported:
+            raise StepExecutionError(f"unknown MCP tool '{tool_name}'", error_type="invalid_tool")
+
         local_descriptor = _load_registry_descriptors().get(tool_name)
-        descriptor = local_descriptor or self.get_descriptor(tool_name, context.tool_settings)
+        descriptor = self.get_descriptor(tool_name, context.tool_settings)
         if descriptor is None:
             raise StepExecutionError(f"unknown MCP tool '{tool_name}'", error_type="invalid_tool")
 

--- a/app/orchestrator/mcp_tool_provider.py
+++ b/app/orchestrator/mcp_tool_provider.py
@@ -35,7 +35,10 @@ class MCPToolProvider:
     def list_descriptors(self, tool_settings: Mapping[str, Any] | None = None) -> Dict[str, ToolDescriptor]:
         descriptors = _load_registry_descriptors()
         if _remote_multiplex_enabled(tool_settings) and self.remote_provider is not None:
-            remote = dict(self.remote_provider.list_descriptors())
+            try:
+                remote = dict(self.remote_provider.list_descriptors())
+            except Exception:
+                remote = {}
             descriptors.update(remote)
         supported = set(MCP_TOOL_DESCRIPTORS.keys())
         return {name: descriptor for name, descriptor in descriptors.items() if name in supported}
@@ -54,14 +57,20 @@ class MCPToolProvider:
         executor: MockPlanExecutor | None = None,
     ) -> Dict[str, Any]:
         route = self._resolve_route(context.tool_settings)
-        descriptor = self.get_descriptor(tool_name, context.tool_settings)
+        local_descriptor = _load_registry_descriptors().get(tool_name)
+        descriptor = local_descriptor or self.get_descriptor(tool_name, context.tool_settings)
         if descriptor is None:
             raise StepExecutionError(f"unknown MCP tool '{tool_name}'", error_type="invalid_tool")
 
         active_executor = executor or MockPlanExecutor()
         call_args = dict(tool_args or {})
-        active_executor._validate_tool_args(call_args, descriptor.allowed_args)  # noqa: SLF001 - parity with executor
-        active_executor._validate_required_args(call_args, descriptor.schema.get("required", []))  # noqa: SLF001
+        validation_descriptor = local_descriptor or descriptor
+        active_executor._validate_tool_args(  # noqa: SLF001 - parity with executor
+            call_args, validation_descriptor.allowed_args
+        )
+        active_executor._validate_required_args(  # noqa: SLF001
+            call_args, validation_descriptor.schema.get("required", [])
+        )
         timeout_value = None
         settings = context.tool_settings or {}
         if "tool_timeout_seconds" in settings:
@@ -132,7 +141,9 @@ class MCPToolProvider:
                 route["provider_route_reason"] = "remote_provider_error"
                 route["provider_route_attempted"] = "remote_multiplex"
 
-        return executor._invoke_tool(descriptor, call_args, context, timeout_value)  # noqa: SLF001
+        local_descriptor = _load_registry_descriptors().get(descriptor.name)
+        fallback_descriptor = local_descriptor or descriptor
+        return executor._invoke_tool(fallback_descriptor, call_args, context, timeout_value)  # noqa: SLF001
 
 
 def _load_registry_descriptors() -> Dict[str, ToolDescriptor]:

--- a/app/orientation/runtime.py
+++ b/app/orientation/runtime.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
-from app.observability.status_service import get_system_status
+from app.observability.status_service import get_orientation_signals
 
 
 class OrientationExplanation(BaseModel):
@@ -27,10 +27,10 @@ def _iso(dt: datetime | None) -> str:
 
 
 def build_orientation_frame() -> OrientationFrame:
-    status = get_system_status()
-    events = status.events
-    ingestion = status.ingestion
-    queue = status.worker_queue
+    signals = get_orientation_signals()
+    events = signals.events
+    ingestion = signals.ingestion
+    queue = signals.worker_queue
 
     leave_point = (
         "Last known runtime leave-point: "

--- a/tests/events/test_tool_execution_route_metadata.py
+++ b/tests/events/test_tool_execution_route_metadata.py
@@ -38,6 +38,14 @@ class _RemoteProviderOK:
         return {"tool": "mcp.search.objects", "result": {"status": "remote-ok"}}
 
 
+class _RemoteProviderError(_RemoteProviderOK):
+    def list_descriptors(self) -> dict[str, ToolDescriptor]:
+        raise RuntimeError("remote descriptor lookup failed")
+
+    def execute_tool_call(self, **_: object) -> dict[str, object]:
+        raise RuntimeError("remote execute failed")
+
+
 def test_tool_execution_records_provider_route(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: list[tuple[str, dict[str, object]]] = []
 
@@ -61,3 +69,27 @@ def test_tool_execution_records_provider_route(monkeypatch: pytest.MonkeyPatch) 
     assert finished
     assert started[-1]["provider_route"] == "remote_multiplex"
     assert finished[-1]["provider_route"] == "remote_multiplex"
+
+
+def test_tool_execution_records_remote_error_fallback_reason(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: list[tuple[str, dict[str, object]]] = []
+
+    def _fake_audit_log(*, action: str, details: dict, **kwargs: object) -> None:
+        captured.append((action, details))
+
+    monkeypatch.setattr("app.orchestrator.events.audit_log", _fake_audit_log)
+
+    provider = MCPToolProvider(remote_provider=_RemoteProviderError())
+    provider.execute_tool_call(
+        tool_name="mcp.search.objects",
+        tool_args={"query": "agentic"},
+        context=_context({"mcp_remote_multiplex_enable": True}),
+        step_id="s-route-fallback",
+        description="Route metadata fallback",
+    )
+
+    finished = [details for action, details in captured if action == MCP_TOOL_CALL_FINISHED]
+    assert finished
+    assert finished[-1]["provider_route"] == "local_registry"
+    assert finished[-1]["provider_route_reason"] == "remote_provider_error"
+    assert finished[-1]["provider_route_attempted"] == "remote_multiplex"

--- a/tests/orientation/test_orientation_runtime.py
+++ b/tests/orientation/test_orientation_runtime.py
@@ -1,6 +1,7 @@
 from fastapi.testclient import TestClient
 
 from app.api.app import app
+from app.orientation.runtime import build_orientation_frame
 
 
 def test_orientation_returns_frame_without_query() -> None:
@@ -28,3 +29,12 @@ def test_orientation_is_read_only() -> None:
     body = resp.json()
     assert body.get('read_only') is True
     assert body.get('mutation_intents') == []
+
+
+def test_orientation_does_not_evaluate_write_guard(monkeypatch) -> None:
+    def _fail() -> None:
+        raise AssertionError("write guard should not be evaluated for orientation frame")
+
+    monkeypatch.setattr("app.observability.status_service.DEFAULT_CONTRACT.evaluate", _fail)
+    frame = build_orientation_frame()
+    assert frame.read_only is True

--- a/tests/tools/test_mcp_tool_provider.py
+++ b/tests/tools/test_mcp_tool_provider.py
@@ -142,6 +142,24 @@ class _RemoteProviderError(_RemoteProviderOK):
         raise RuntimeError("remote unavailable")
 
 
+class _RemoteProviderListError(_RemoteProviderError):
+    def list_descriptors(self) -> dict[str, ToolDescriptor]:
+        raise RuntimeError("remote descriptor lookup failed")
+
+
+class _RemoteProviderMismatchedDescriptor(_RemoteProviderError):
+    def list_descriptors(self) -> dict[str, ToolDescriptor]:
+        return {
+            "mcp.search.objects": ToolDescriptor(
+                name="mcp.search.objects",
+                kind="mcp",
+                schema={"type": "object", "required": ["query", "tenant"]},
+                allowed_args={"query": "string", "tenant": "string"},
+                mock_result={"status": "remote-schema"},
+            )
+        }
+
+
 def test_remote_multiplex_path_flagged() -> None:
     provider = MCPToolProvider(remote_provider=_RemoteProviderOK())
     executor = MockPlanExecutor()
@@ -172,6 +190,38 @@ def test_remote_multiplex_fallback_on_provider_error() -> None:
         step_id="s-fallback",
         description="Fallback path",
         executor=executor,
+    )
+
+    assert result["tool"] == "mcp.search.objects"
+    assert result["result"]["status"] == "ok"
+
+
+def test_remote_multiplex_fallback_when_descriptor_lookup_fails() -> None:
+    provider = MCPToolProvider(remote_provider=_RemoteProviderListError())
+    context = _context({"mcp_remote_multiplex_enable": True})
+
+    result = provider.execute_tool_call(
+        tool_name="mcp.search.objects",
+        tool_args={"query": "agentic"},
+        context=context,
+        step_id="s-fallback-descriptor",
+        description="Fallback path when descriptor lookup fails",
+    )
+
+    assert result["tool"] == "mcp.search.objects"
+    assert result["result"]["status"] == "ok"
+
+
+def test_remote_fallback_revalidates_against_local_descriptor() -> None:
+    provider = MCPToolProvider(remote_provider=_RemoteProviderMismatchedDescriptor())
+    context = _context({"mcp_remote_multiplex_enable": True})
+
+    result = provider.execute_tool_call(
+        tool_name="mcp.search.objects",
+        tool_args={"query": "agentic"},
+        context=context,
+        step_id="s-fallback-local-descriptor",
+        description="Fallback should use local descriptor semantics",
     )
 
     assert result["tool"] == "mcp.search.objects"

--- a/tests/tools/test_mcp_tool_provider.py
+++ b/tests/tools/test_mcp_tool_provider.py
@@ -121,6 +121,22 @@ def test_tool_provider_vault_append_respects_existing_gates(tmp_path: Path) -> N
     assert any(tmp_path.rglob("*.md"))
 
 
+def test_tool_provider_rejects_registry_only_tool_not_in_supported_allowlist() -> None:
+    provider = MCPToolProvider()
+    context = _context()
+
+    with pytest.raises(StepExecutionError) as exc:
+        provider.execute_tool_call(
+            tool_name="vault.read_note.v1",
+            tool_args={"path": "x.md"},
+            context=context,
+            step_id="s-unsupported",
+            description="Unsupported tool",
+        )
+
+    assert exc.value.error_type == "invalid_tool"
+
+
 class _RemoteProviderOK:
     def list_descriptors(self) -> dict[str, ToolDescriptor]:
         return {


### PR DESCRIPTION
Fixes #586

## Summary
- harden MCP ToolProvider against remote descriptor lookup failures by preserving local fallback behavior
- enforce MCP supported-tool allowlist in execute path so registry-only tools cannot bypass contract
- ensure fallback executes with locally resolved descriptor semantics when remote path fails
- make orientation runtime use a non-mutating observability snapshot path (no write-guard evaluation side effects)
- add regression tests for descriptor-failure fallback, local-descriptor fallback semantics, allowlist enforcement, fallback route metadata, and orientation read-only guard

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/tools/test_mcp_tool_provider.py -k "remote_multiplex or rejects_registry_only_tool"
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/events/test_tool_execution_route_metadata.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/orientation/test_orientation_runtime.py

## Context
Addresses unaddressed review comments left on merged PRs #578, #579, #580.