### PR TITLE
Extract retrieval capability seam and add minimal read-only resurfacing

### DIFF
--- a/app/agents/ask/graph.py
+++ b/app/agents/ask/graph.py
@@ -7,7 +7,7 @@ from langgraph.graph import END, START, StateGraph
 from app.agents.ask.state import AgentState, RetrievedHit
 from app.agents.ask.utils import build_ask_context, get_ask_settings, llm_answer, reasoning_enabled, score_hit
 from app.components.rerankers import get_reranker
-from app.retrieval.hybrid import hybrid_search
+from app.retrieval.capability import RetrievalRequest, retrieve
 
 TOP_K_INITIAL = 40
 
@@ -29,9 +29,10 @@ def _to_retrieved_hit(hit: dict[str, Any], ask_score: float | None = None) -> Re
 
 
 def _retrieve_node(state: AgentState, *, k: int, ask_settings) -> AgentState:
-    hits = hybrid_search(state.query, k=k)
+    response = retrieve(RetrievalRequest(query=state.query, k=k, trace_id=state.trace_id))
     enriched: list[RetrievedHit] = []
-    for hit in hits:
+    for retrieval_hit in response.hits:
+        hit = retrieval_hit.to_hybrid_dict()
         ask_score = score_hit(hit)
         enriched.append(_to_retrieved_hit(hit, ask_score=ask_score))
     state.hits = enriched

--- a/app/resurfacing/__init__.py
+++ b/app/resurfacing/__init__.py
@@ -1,0 +1,15 @@
+from app.resurfacing.runtime import (
+    ResurfacingCandidate,
+    ResurfacingEvaluation,
+    ResurfacingSignal,
+    ResurfacingWhyNow,
+    evaluate_resurfacing_candidates,
+)
+
+__all__ = [
+    "ResurfacingSignal",
+    "ResurfacingWhyNow",
+    "ResurfacingCandidate",
+    "ResurfacingEvaluation",
+    "evaluate_resurfacing_candidates",
+]

--- a/app/resurfacing/runtime.py
+++ b/app/resurfacing/runtime.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from pydantic import BaseModel, Field
+
+from app.observability.status_service import get_orientation_signals
+
+
+class ResurfacingSignal(BaseModel):
+    name: str
+    value: int | str
+    source: str
+
+
+class ResurfacingWhyNow(BaseModel):
+    explanation: str
+    signals: list[ResurfacingSignal] = Field(default_factory=list)
+
+
+class ResurfacingCandidate(BaseModel):
+    candidate_id: str
+    label: str
+    why_now: ResurfacingWhyNow
+
+
+class ResurfacingEvaluation(BaseModel):
+    generated_at: str
+    status_summary: str
+    candidates: list[ResurfacingCandidate] = Field(default_factory=list)
+    receipt: list[str] = Field(default_factory=list)
+    read_only: bool = True
+    mutation_intents: list[str] = Field(default_factory=list)
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def evaluate_resurfacing_candidates() -> ResurfacingEvaluation:
+    """Produce resurfacing candidates from derived relevance-change runtime signals.
+
+    This seam is intentionally query-independent and read-only.
+    """
+
+    orientation = get_orientation_signals()
+    events = orientation.events
+    ingestion = orientation.ingestion
+    queue = orientation.worker_queue
+
+    pending_promotions = max((events.promote_created_total or 0) - (events.promotion_executed_total or 0), 0)
+    pending_worker_items = max(queue.pending or 0, 0)
+
+    candidates: list[ResurfacingCandidate] = []
+
+    if pending_promotions > 0:
+        candidates.append(
+            ResurfacingCandidate(
+                candidate_id="resurface-pending-promotions",
+                label="Pending promotion intents need review",
+                why_now=ResurfacingWhyNow(
+                    explanation=(
+                        "This is back in view now because derived relevance changed: "
+                        "more promotion intents exist than executed transitions."
+                    ),
+                    signals=[
+                        ResurfacingSignal(
+                            name="pending_promotions",
+                            value=pending_promotions,
+                            source=events.source_path or "status.events",
+                        ),
+                        ResurfacingSignal(
+                            name="promote_created_total",
+                            value=events.promote_created_total or 0,
+                            source=events.source_path or "status.events",
+                        ),
+                        ResurfacingSignal(
+                            name="promotion_executed_total",
+                            value=events.promotion_executed_total or 0,
+                            source=events.source_path or "status.events",
+                        ),
+                    ],
+                ),
+            )
+        )
+
+    if pending_worker_items > 0:
+        candidates.append(
+            ResurfacingCandidate(
+                candidate_id="resurface-worker-queue",
+                label="Queued runtime work remains unresolved",
+                why_now=ResurfacingWhyNow(
+                    explanation=(
+                        "This is back in view now because derived relevance changed: "
+                        "worker queue has unresolved pending items."
+                    ),
+                    signals=[
+                        ResurfacingSignal(
+                            name="worker_queue_pending",
+                            value=pending_worker_items,
+                            source=queue.source_path or "status.worker_queue",
+                        ),
+                    ],
+                ),
+            )
+        )
+
+    if (events.watcher_runs_24h or 0) > 0 and (events.promote_created_24h or 0) > 0:
+        candidates.append(
+            ResurfacingCandidate(
+                candidate_id="resurface-new-activity",
+                label="Recent watcher + intent activity may have changed priorities",
+                why_now=ResurfacingWhyNow(
+                    explanation=(
+                        "This is back in view now because derived relevance changed in the last 24h: "
+                        "watcher activity and promotion-intent creation both increased."
+                    ),
+                    signals=[
+                        ResurfacingSignal(
+                            name="watcher_runs_24h",
+                            value=events.watcher_runs_24h or 0,
+                            source=events.source_path or "status.events",
+                        ),
+                        ResurfacingSignal(
+                            name="promote_created_24h",
+                            value=events.promote_created_24h or 0,
+                            source=events.source_path or "status.events",
+                        ),
+                    ],
+                ),
+            )
+        )
+
+    status_summary = (
+        f"resurfacing_candidates={len(candidates)}; "
+        f"pending_promotions={pending_promotions}; "
+        f"pending_worker_items={pending_worker_items}; "
+        f"last_ingest_at={ingestion.last_run_at.isoformat().replace('+00:00', 'Z') if ingestion.last_run_at else 'unknown'}"
+    )
+
+    receipt = [
+        "resurfacing runtime evaluated derived relevance-change signals",
+        "read_only=true (no writes performed)",
+        status_summary,
+    ]
+
+    return ResurfacingEvaluation(
+        generated_at=_iso_now(),
+        status_summary=status_summary,
+        candidates=candidates,
+        receipt=receipt,
+    )
+
+
+__all__ = [
+    "ResurfacingSignal",
+    "ResurfacingWhyNow",
+    "ResurfacingCandidate",
+    "ResurfacingEvaluation",
+    "evaluate_resurfacing_candidates",
+]

--- a/app/retrieval/capability.py
+++ b/app/retrieval/capability.py
@@ -97,6 +97,7 @@ class RetrievalResponse:
     query: str
     hits: list[RetrievalHit]
     trace_id: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
     diagnostics: dict[str, Any] = field(default_factory=dict)
 
 
@@ -121,10 +122,32 @@ def retrieve(request: RetrievalRequest) -> RetrievalResponse:
         diagnostics["view_freshness"] = request.view_freshness.to_dict()
     if request.include_signal_payload and request.signal_payload is not None:
         diagnostics["signal_payload"] = request.signal_payload.to_dict()
+    view_freshness_state = request.view_freshness.state if request.view_freshness is not None else "unknown"
+    metadata: dict[str, Any] = {
+        "provenance": {
+            "capability": "retrieval",
+            "adapter": "hybrid_search",
+            "trace_id": request.trace_id,
+            "request": {
+                "scope": request.scope,
+                "domain": request.domain,
+            },
+        },
+        "temporal_validity": {
+            "state": view_freshness_state,
+            "is_fresh": view_freshness_state == "fresh",
+            "is_stale": view_freshness_state == "stale",
+            "is_partial": view_freshness_state == "partial",
+            "is_unknown": view_freshness_state == "unknown",
+        },
+    }
+    if request.provenance_metadata:
+        metadata["provenance"]["hints"] = dict(request.provenance_metadata)
     return RetrievalResponse(
         query=request.query,
         hits=[RetrievalHit.from_hybrid(hit) for hit in raw_hits],
         trace_id=request.trace_id,
+        metadata=metadata,
         diagnostics=diagnostics,
     )
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -510,9 +510,12 @@ hybrid Chat/Panel crossings are bounded by
 - Retrieval must be reusable across Panel, Chat, and future cognition surfaces without creating another agent-specific control center.
 - The shipped capability boundary preserves current hybrid retrieval behavior and result ordering;
   additive relation/provenance inputs and stale/partial-view diagnostics are observable metadata,
-  not ranking authority.
+  not ranking authority. Response metadata now includes explicit provenance and temporal-validity
+  flags as part of the retrieval capability contract.
 - Capabilities are reusable, composable, and testable.
 - Agents and orchestration layers invoke capabilities through explicit planning and state transitions.
+- ASK remains functional as a consumer of the extracted retrieval capability seam; this is a runtime
+  wiring extraction, not a full Chat rollout.
 - ASK remains a valid current runtime/API surface in the v5.x line, but it is deprecated as the architectural center for v6 direction. New design work should not rebuild retrieval around a special central agent, even if bounded agents remain common elsewhere in the system.
 
 ## Historical Material

--- a/docs/RETRIEVAL.md
+++ b/docs/RETRIEVAL.md
@@ -43,10 +43,12 @@ Interpretation note:
 Entry point: `app/retrieval/hybrid.py:hybrid_search(query, k=8, ...)`
 
 Capability wrapper: `app/retrieval/capability.py:retrieve(RetrievalRequest)` exposes the same
-current hybrid path through typed request/response objects for non-ASK callers. The wrapper carries
-query, scope/domain inputs, trace id, hit metadata, and optional diagnostics for relation/provenance
-inputs, view freshness, or an opt-in salience/staleness signal payload seam. It adapts the current results; it does not introduce relation-aware
-ranking, orientation, resurfacing, or a new retrieval agent.
+current hybrid path through typed request/response objects. ASK now consumes this capability seam,
+and other surfaces can call the same contract without depending on ASK internals. The wrapper carries
+query, scope/domain inputs, trace id, hit metadata, response `metadata.provenance`, response
+`metadata.temporal_validity` flags, and optional diagnostics for relation/provenance inputs, view
+freshness, or an opt-in salience/staleness signal payload seam. It adapts the current results; it
+does not introduce relation-aware ranking, orientation, resurfacing, or a new retrieval agent.
 
 ### Scoring
 Per document, we compute:
@@ -108,3 +110,7 @@ Interpretation:
   from persisted artifact payload or state-axis labels.
 - Stale/partial/unknown view reporting is runtime honesty from existing status signals. It is not a
   multi-replica freshness guarantee and does not fail retrieval by itself.
+- Query-independent resurfacing now has a separate read-only runtime seam
+  (`app/resurfacing/runtime.py`) that derives relevance-change candidates from runtime status signals
+  and emits operator-visible receipt/status summaries with explicit "why now" signal provenance.
+  It does not write artifact state and does not run on the active retrieval query path.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -19,6 +19,10 @@ Concept anchors: layering, portability, archive exposure, trust semantics, event
 - `/api/health` reports watcher and worker heartbeat freshness plus the runtime DB/LLM probes so operators see deterministic health signals.
 - `scripts/start_full_system.sh` and `scripts/gap_test_alpha.sh` drive the registry watcher → DB outbox → worker → index → `/api/ask` chain, emit `watcher.run` audit rows plus `index.embedding.created` / `index.embedding.failed` (legacy alias: `index.object.embedded`), and log diagnostics when sources are missing.
 - `/api/orientation` now provides a minimal read-only orientation runtime seam that returns a situational frame without a query term; explanation remains bounded to `leave_point`, `open_items`, and `notable_change` derived from runtime signals.
+- `app/resurfacing/runtime.py` now provides a minimal non-mutating resurfacing evaluator seam that
+  does not require a query, derives relevance-change candidates from runtime status signals, emits
+  explicit "why now" explanations with signal provenance, and exposes operator-visible receipt/status
+  summaries without automatic writes.
 - The interim GUI and Status service consume these heartbeats/events so the dashboard shows ingest health, counts, and incidents in one place.
 - The local `test` bootstrap path is now treated as a first-class verification concern: parts of the path work today, but the repo-supported clean-state path is not yet fully self-contained end to end.
 - `python -m app.cli sync-latency-harness` now defaults to provider-free `PANEL_AGENT_DECIDER=rule` for deterministic operator validation, emits progress before long-running watcher work, and fails within a bounded timeout instead of hanging indefinitely when a live LLM provider is unavailable.
@@ -60,6 +64,9 @@ co-editing and hybrid Panel/Chat integration remain v6 future surfaces, governed
 - Storage baseline: `store_objects` is the canonical object table; legacy `objects` rows are best-effort migrated when needed so runtime avoids dual-table selection. Legacy `app/store/object_store.py` now delegates to canonical `app/stores` providers (compat mirror retained for tests), and `index rebuild` reads via `ObjectStore` rather than separate memory/DB query branches.
 - ASK warm-load boundary: `/api/ask` hydrates HybridStore through the canonical store interface (`list_objects`) instead of backend-specific `_objects`/raw SQL introspection.
 - Orientation posture: `/api/orientation` is additive to ASK and not a full cognitive rollout; it is a bounded read-only runtime surface with no mutation intents.
+- Resurfacing posture: `app/resurfacing/runtime.py` is additive and read-only; resurfacing outputs are
+  candidate summaries plus provenance-bearing explanations/receipts, not mutation intents or artifact
+  writes.
 - DB outbox is canonical in runtime; JSONL (`INDEX_OUTBOX_PATH`) is audit only and should not be used as the worker queue.
 - Required contracts: event compatibility/outbox envelope (`docs/EVENTS.md`), trust semantics, config-as-product, and PanelAgent wiring (`docs/PANEL_AGENT.md` + `docs/settings/panel-actions.md`).
 - State-axis normalization posture: `maturity` is the canonical standing sink, `review_state` is the canonical review/mutation posture field, and legacy values such as `evergreen`, `processed`, `promoted`, `inbox`, and `logged` are compatibility-only inputs rather than preferred runtime outputs.

--- a/tests/api/test_ask_route.py
+++ b/tests/api/test_ask_route.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.api.app import app
+from app.api.routes import ask as ask_module
+from app.retrieval.capability import RetrievalHit, RetrievalResponse
+from app.retrieval.hybrid import get_store
+
+
+def test_ask_route_uses_retrieval_capability_contract(monkeypatch) -> None:
+    monkeypatch.setattr("app.api.routes.ask._ensure_hybrid_store_loaded", lambda: None)
+    ask_module._HYBRID_WARMED = True
+
+    called = {"count": 0}
+
+    def _fake_retrieve(request):  # type: ignore[no-untyped-def]
+        called["count"] += 1
+        return RetrievalResponse(
+            query=request.query,
+            trace_id=request.trace_id,
+            metadata={
+                "provenance": {"capability": "retrieval", "adapter": "hybrid_search"},
+                "temporal_validity": {
+                    "state": "fresh",
+                    "is_fresh": True,
+                    "is_stale": False,
+                    "is_partial": False,
+                    "is_unknown": False,
+                },
+            },
+            hits=[
+                RetrievalHit(
+                    object_id="contract-ask-1",
+                    doc_id="contract-ask-1",
+                    text="retrieval capability answer context",
+                    score=0.9,
+                    snippet="retrieval capability answer context",
+                    source_ref="vault/contract-ask-1.md",
+                    payload={"title": "Contract Ask", "origin": "vault"},
+                )
+            ],
+        )
+
+    monkeypatch.setattr("app.agents.ask.graph.retrieve", _fake_retrieve)
+    monkeypatch.setattr("app.agents.ask.graph.reasoning_enabled", lambda: False)
+
+    client = TestClient(app)
+    try:
+        response = client.post("/api/ask", json={"question": "contract path"})
+        assert response.status_code == 200
+        body = response.json()
+        assert called["count"] == 1
+        assert body["answer"] == "retrieval capability answer context"
+        assert body["sources"][0]["uuid"] == "contract-ask-1"
+    finally:
+        ask_module._HYBRID_WARMED = False
+        get_store().set_documents([])

--- a/tests/resurfacing/test_resurfacing_runtime.py
+++ b/tests/resurfacing/test_resurfacing_runtime.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from app.observability.status_model import EventCounters, IngestionStatus, WorkerQueueStatus
+from app.observability.status_service import OrientationSignals
+from app.resurfacing.runtime import evaluate_resurfacing_candidates
+
+
+def _signals() -> OrientationSignals:
+    return OrientationSignals(
+        events=EventCounters(
+            watcher_runs_24h=2,
+            promote_created_total=4,
+            promotion_executed_total=1,
+            promote_created_24h=2,
+            source_path="tmp/events.jsonl",
+        ),
+        ingestion=IngestionStatus(last_run_at=datetime(2026, 4, 23, 12, 0, tzinfo=timezone.utc)),
+        worker_queue=WorkerQueueStatus(mode="db", pending=3, source_path="tmp/queue.db"),
+    )
+
+
+def test_resurfacing_without_query(monkeypatch) -> None:
+    monkeypatch.setattr("app.resurfacing.runtime.get_orientation_signals", _signals)
+
+    result = evaluate_resurfacing_candidates()
+
+    assert result.read_only is True
+    assert "resurfacing_candidates=" in result.status_summary
+    assert isinstance(result.candidates, list)
+
+
+def test_resurfacing_includes_why_now_explanation(monkeypatch) -> None:
+    monkeypatch.setattr("app.resurfacing.runtime.get_orientation_signals", _signals)
+
+    result = evaluate_resurfacing_candidates()
+
+    assert result.candidates
+    candidate = result.candidates[0]
+    assert "because" in candidate.why_now.explanation.lower()
+    assert candidate.why_now.signals
+    assert all(signal.source for signal in candidate.why_now.signals)
+
+
+def test_resurfacing_is_read_only(monkeypatch) -> None:
+    monkeypatch.setattr("app.resurfacing.runtime.get_orientation_signals", _signals)
+
+    result = evaluate_resurfacing_candidates()
+
+    assert result.read_only is True
+    assert result.mutation_intents == []
+    assert any("no writes" in line.lower() for line in result.receipt)

--- a/tests/retrieval/test_relation_provenance_metadata.py
+++ b/tests/retrieval/test_relation_provenance_metadata.py
@@ -82,3 +82,26 @@ def test_missing_relation_provenance_metadata_preserves_current_behavior(monkeyp
         assert response.hits
     finally:
         get_store().set_documents([])
+
+
+def test_retrieval_response_contains_temporal_validity_flags(monkeypatch) -> None:
+    _patch_embeddings(monkeypatch)
+    _seed_store()
+    try:
+        stale = retrieve(
+            RetrievalRequest(
+                query="relation provenance",
+                k=1,
+                provenance_metadata={"requested_by": "ask"},
+            )
+        )
+        assert stale.metadata["temporal_validity"] == {
+            "state": "unknown",
+            "is_fresh": False,
+            "is_stale": False,
+            "is_partial": False,
+            "is_unknown": True,
+        }
+        assert stale.metadata["provenance"]["hints"] == {"requested_by": "ask"}
+    finally:
+        get_store().set_documents([])

--- a/tests/retrieval/test_retrieval_capability.py
+++ b/tests/retrieval/test_retrieval_capability.py
@@ -82,6 +82,31 @@ def test_retrieval_capability_accepts_surface_neutral_request(monkeypatch) -> No
         get_store().set_documents([])
 
 
+def test_retrieval_contract_objects_are_surface_independent(monkeypatch) -> None:
+    _patch_embeddings(monkeypatch)
+    _seed_store()
+    try:
+        response = retrieve(
+            RetrievalRequest(
+                query="alpha retrieval",
+                k=1,
+                scope="operator",
+                domain="core",
+                trace_id="contract-1",
+            )
+        )
+
+        assert response.query == "alpha retrieval"
+        assert response.trace_id == "contract-1"
+        assert response.metadata["provenance"]["capability"] == "retrieval"
+        assert response.metadata["provenance"]["adapter"] == "hybrid_search"
+        assert response.metadata["provenance"]["request"] == {"scope": "operator", "domain": "core"}
+        assert response.hits
+        assert response.hits[0].doc_id == "alpha"
+    finally:
+        get_store().set_documents([])
+
+
 def test_retrieval_signal_payload_opt_in(monkeypatch) -> None:
     _patch_embeddings(monkeypatch)
     _seed_store()


### PR DESCRIPTION
Fixes #573
Fixes #577

## Summary
- extract an explicit retrieval capability request/response seam and route ASK through it
- include retrieval response temporal-validity + provenance metadata in a stable contract shape
- add a minimal read-only resurfacing runtime that emits query-independent candidates with "why now" signal provenance
- update docs to capture shipped seam boundaries and rollout limits

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/pytest -q tests/retrieval/test_retrieval_capability.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/pytest -q tests/retrieval/test_relation_provenance_metadata.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/pytest -q tests/resurfacing/test_resurfacing_runtime.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/pytest -q tests/api/test_ask_route.py -k retrieval_capability
