### PR TITLE
Add dynamic MCP discovery seam with explicit policy admission

### DIFF
--- a/app/orchestrator/mcp_tool_provider.py
+++ b/app/orchestrator/mcp_tool_provider.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, Mapping, Protocol
+from typing import Any, Dict, Mapping, Protocol, Sequence
 
 from app.components.settings.tools_loader import load_tools
 from app.orchestrator.events import emit_mcp_tool_call_finished, emit_mcp_tool_call_started
@@ -34,17 +34,80 @@ class MCPToolProvider:
 
     def list_descriptors(self, tool_settings: Mapping[str, Any] | None = None) -> Dict[str, ToolDescriptor]:
         descriptors = self._list_local_descriptors()
-        if _remote_multiplex_enabled(tool_settings) and self.remote_provider is not None:
-            try:
-                remote = dict(self.remote_provider.list_descriptors())
-                descriptors.update(remote)
-            except Exception:
-                # Remote descriptor discovery is best-effort; keep local registry route available.
-                pass
+        discovery = self.get_discovery_diagnostics(tool_settings)
+        for entry in discovery.get("admitted", []):
+            tool_name = entry.get("tool")
+            descriptor = entry.get("descriptor")
+            if isinstance(tool_name, str) and isinstance(descriptor, ToolDescriptor):
+                descriptors[tool_name] = descriptor
         return self._filter_supported(descriptors)
 
     def get_descriptor(self, tool_name: str, tool_settings: Mapping[str, Any] | None = None) -> ToolDescriptor | None:
         return self.list_descriptors(tool_settings).get(tool_name)
+
+    def get_discovery_diagnostics(self, tool_settings: Mapping[str, Any] | None = None) -> Dict[str, Any]:
+        diagnostics: Dict[str, Any] = {
+            "provider": "remote_multiplex",
+            "enabled": _remote_multiplex_enabled(tool_settings),
+            "discovered": [],
+            "admitted": [],
+            "rejected": [],
+        }
+        if not diagnostics["enabled"]:
+            diagnostics["reason_code"] = "remote_disabled"
+            return diagnostics
+        if self.remote_provider is None:
+            diagnostics["reason_code"] = "remote_unavailable"
+            return diagnostics
+
+        try:
+            remote = dict(self.remote_provider.list_descriptors())
+        except Exception:
+            diagnostics["reason_code"] = "remote_discovery_error"
+            return diagnostics
+
+        admitted_provider = _remote_provider_admitted(tool_settings)
+        diagnostics["provider_admitted"] = admitted_provider
+        if not admitted_provider:
+            diagnostics["reason_code"] = "policy_admission_required"
+        else:
+            diagnostics["reason_code"] = "ok"
+
+        supported = set(MCP_TOOL_DESCRIPTORS.keys())
+        for tool_name, descriptor in remote.items():
+            if not isinstance(tool_name, str) or not isinstance(descriptor, ToolDescriptor):
+                continue
+            discovered_entry = {"tool": tool_name, "provider": "remote_multiplex"}
+            diagnostics["discovered"].append(discovered_entry)
+
+            if tool_name not in supported:
+                diagnostics["rejected"].append(
+                    {
+                        "tool": tool_name,
+                        "provider": "remote_multiplex",
+                        "reason_code": "unsupported_tool",
+                    }
+                )
+                continue
+            if not admitted_provider:
+                diagnostics["rejected"].append(
+                    {
+                        "tool": tool_name,
+                        "provider": "remote_multiplex",
+                        "reason_code": "policy_admission_required",
+                    }
+                )
+                continue
+            diagnostics["admitted"].append(
+                {
+                    "tool": tool_name,
+                    "provider": "remote_multiplex",
+                    "reason_code": "admitted",
+                    "descriptor": descriptor,
+                }
+            )
+
+        return diagnostics
 
     def execute_tool_call(
         self,
@@ -117,17 +180,15 @@ class MCPToolProvider:
         local_descriptors = self._filter_supported(self._list_local_descriptors())
         if route.get("provider_route") != "remote_multiplex" or self.remote_provider is None:
             return local_descriptors.get(tool_name)
-
-        try:
-            remote_descriptors = dict(self.remote_provider.list_descriptors())
-        except Exception:
-            route["provider_route"] = "local_registry"
-            route["provider_route_reason"] = "remote_descriptor_list_error"
-            route["provider_route_attempted"] = "remote_multiplex"
-            return local_descriptors.get(tool_name)
-
+        discovery = self.get_discovery_diagnostics(tool_settings)
+        admitted_descriptors: Dict[str, ToolDescriptor] = {}
+        for entry in discovery.get("admitted", []):
+            admitted_tool = entry.get("tool")
+            admitted_descriptor = entry.get("descriptor")
+            if isinstance(admitted_tool, str) and isinstance(admitted_descriptor, ToolDescriptor):
+                admitted_descriptors[admitted_tool] = admitted_descriptor
         merged = dict(local_descriptors)
-        merged.update(self._filter_supported(remote_descriptors))
+        merged.update(admitted_descriptors)
         return merged.get(tool_name)
 
     def _resolve_route(self, tool_settings: Mapping[str, Any] | None) -> Dict[str, str]:
@@ -135,6 +196,8 @@ class MCPToolProvider:
             return {"provider_route": "local_registry", "provider_route_reason": "remote_disabled"}
         if self.remote_provider is None:
             return {"provider_route": "local_registry", "provider_route_reason": "remote_unavailable"}
+        if not _remote_provider_admitted(tool_settings):
+            return {"provider_route": "local_registry", "provider_route_reason": "policy_admission_required"}
         return {"provider_route": "remote_multiplex"}
 
     def _execute_with_route(
@@ -244,6 +307,25 @@ def _remote_multiplex_enabled(tool_settings: Mapping[str, Any] | None) -> bool:
     if isinstance(raw, (int, float)):
         return raw != 0
     return False
+
+
+def _remote_provider_admitted(tool_settings: Mapping[str, Any] | None) -> bool:
+    if not isinstance(tool_settings, Mapping):
+        return False
+    allowlist = tool_settings.get("mcp_remote_allowed_providers")
+    return "remote_multiplex" in _normalize_string_list(allowlist)
+
+
+def _normalize_string_list(raw: Any) -> Sequence[str]:
+    if isinstance(raw, str):
+        return [part.strip() for part in raw.split(",") if part.strip()]
+    if isinstance(raw, Sequence) and not isinstance(raw, (str, bytes)):
+        result: list[str] = []
+        for item in raw:
+            if isinstance(item, str) and item.strip():
+                result.append(item.strip())
+        return result
+    return []
 
 
 __all__ = ["MCPToolProvider", "RemoteMCPProvider"]

--- a/docs/contracts/TOOL_POLICY_AND_MCP_ADAPTER_CONTRACT.md
+++ b/docs/contracts/TOOL_POLICY_AND_MCP_ADAPTER_CONTRACT.md
@@ -6,7 +6,7 @@ Authority: Canonical current-state contract for the repo's tool descriptor regis
 
 This document describes the current tool descriptor registry, validation rules, timeout handling, and the MCP adapter boundary inside the repository for bounded tool execution.
 It is a current-state contract for tool descriptor completeness, allowed-argument validation, mock/deterministic test behavior, and audit expectations.
-It does not claim rich descriptor versioning, dynamic remote discovery, or future permission-model expansion as shipped.
+It does not claim rich descriptor versioning or future permission-model expansion as shipped.
 
 Use this document with:
 - `docs/ARCHITECTURE.md` for current runtime boundaries and the planner/orchestrator pipeline.
@@ -24,6 +24,8 @@ Use this document with:
 - A local MCP ToolProvider boundary exposes registry-loaded descriptors and delegates execution through the existing executor validation/policy/timeout/mock-real paths.
 - A bounded remote multiplex seam is available behind explicit flag `mcp_remote_multiplex_enable`; default behavior remains local registry execution.
 - If remote multiplex is enabled but unavailable or failing, execution deterministically falls back to local registry with route reason codes.
+- Dynamic remote descriptor discovery is available behind explicit enablement and policy admission (`mcp_remote_allowed_providers` must admit `remote_multiplex`).
+- Operator-facing discovery diagnostics expose `discovered`, `admitted`, and `rejected` tool sets with deterministic reason codes.
 
 ## Descriptor sources and structure
 
@@ -202,13 +204,30 @@ The executor defines built-in handlers for `internal` protocol tools:
 
 Both are handled synchronously during plan execution and do not support real vs. mock branching (they always execute).
 
+## MCP discovery and admission
+
+Dynamic MCP discovery is deterministic and bounded:
+
+- Discovery runs only when `mcp_remote_multiplex_enable` is truthy.
+- Discovery enumerates descriptors from the remote provider into a diagnostics surface (`discovered`).
+- Discovered tools are not routable by default. Admission requires policy allowlist entry: `mcp_remote_allowed_providers` including `remote_multiplex`.
+- Unsupported discovered tools are rejected with reason `unsupported_tool`.
+- When admission is missing, supported discovered tools are rejected with reason `policy_admission_required`.
+- When admitted, supported discovered tools appear in `admitted` and can be routed via `provider_route=remote_multiplex`.
+- When discovery is disabled/unavailable/failing, reason codes are deterministic:
+  - `remote_disabled`
+  - `remote_unavailable`
+  - `remote_discovery_error`
+  - `policy_admission_required`
+  - `ok`
+
 ## MCP integration boundary
 
-This contract explicitly bounds the current tool execution behavior and reserves future expansion space:
+This contract explicitly bounds current tool execution behavior and reserves future expansion space:
 
-- **Currently implemented**: local registry-backed ToolProvider default path, plus optional remote multiplex seam behind `mcp_remote_multiplex_enable`.
+- **Currently implemented**: local registry-backed ToolProvider default path, plus optional remote multiplex seam with explicit discovery + admission gating.
 - **Fallback behavior**: when remote multiplex is enabled but no remote adapter is present or the adapter errors, route falls back to local registry with deterministic reason codes (`remote_unavailable`, `remote_provider_error`).
-- **Not currently implemented**: dynamic tool discovery or tool versioning/evolution policies.
+- **Not currently implemented**: descriptor versioning/evolution policies across remote providers.
 - **Current implementation boundary**: execution semantics still run through the existing executor contract and policy checks.
 - **Planned**: The repo still tracks broader LangGraph and remote MCP integration work in the v5.6 forward line (see `docs/tracks/TRACK_AGENTOPS_A2A_MCP.md`).
 - **Scope boundary**: This contract describes enacted descriptor-registry, ToolProvider boundary, validation, and executor behavior only.

--- a/tests/events/test_tool_execution_route_metadata.py
+++ b/tests/events/test_tool_execution_route_metadata.py
@@ -55,7 +55,12 @@ def test_tool_execution_records_provider_route(monkeypatch: pytest.MonkeyPatch) 
     provider.execute_tool_call(
         tool_name="mcp.search.objects",
         tool_args={"query": "agentic"},
-        context=_context({"mcp_remote_multiplex_enable": True}),
+        context=_context(
+            {
+                "mcp_remote_multiplex_enable": True,
+                "mcp_remote_allowed_providers": ["remote_multiplex"],
+            }
+        ),
         step_id="s-route",
         description="Route metadata",
     )
@@ -80,7 +85,12 @@ def test_tool_execution_records_remote_error_fallback_reason(monkeypatch: pytest
     provider.execute_tool_call(
         tool_name="mcp.search.objects",
         tool_args={"query": "agentic"},
-        context=_context({"mcp_remote_multiplex_enable": True}),
+        context=_context(
+            {
+                "mcp_remote_multiplex_enable": True,
+                "mcp_remote_allowed_providers": ["remote_multiplex"],
+            }
+        ),
         step_id="s-route-fallback",
         description="Route metadata fallback",
     )

--- a/tests/observability/test_tool_discovery_diagnostics.py
+++ b/tests/observability/test_tool_discovery_diagnostics.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pytest
+
+from app.orchestrator.mcp_tool_provider import MCPToolProvider
+from app.planner.schema import ToolDescriptor
+
+pytestmark = pytest.mark.not_pg
+
+
+class _RemoteProviderMixed:
+    def list_descriptors(self) -> dict[str, ToolDescriptor]:
+        return {
+            "mcp.search.objects": ToolDescriptor(
+                name="mcp.search.objects",
+                kind="mcp",
+                schema={"type": "object", "required": ["query"]},
+                allowed_args={"query": "string"},
+                mock_result={"status": "remote-ok"},
+            ),
+            "mcp.unsupported.remote": ToolDescriptor(
+                name="mcp.unsupported.remote",
+                kind="mcp",
+                schema={"type": "object", "required": []},
+                allowed_args={},
+                mock_result={"status": "remote-unsupported"},
+            ),
+        }
+
+    def execute_tool_call(self, **_: object) -> dict[str, object]:
+        return {"result": {"status": "remote-ok"}}
+
+
+def test_discovery_diagnostics_reason_codes() -> None:
+    provider = MCPToolProvider(remote_provider=_RemoteProviderMixed())
+
+    disabled = provider.get_discovery_diagnostics({})
+    assert disabled["reason_code"] == "remote_disabled"
+
+    blocked = provider.get_discovery_diagnostics({"mcp_remote_multiplex_enable": True})
+    assert blocked["reason_code"] == "policy_admission_required"
+    blocked_reasons = {entry["tool"]: entry["reason_code"] for entry in blocked["rejected"]}
+    assert blocked_reasons["mcp.search.objects"] == "policy_admission_required"
+
+    admitted = provider.get_discovery_diagnostics(
+        {
+            "mcp_remote_multiplex_enable": True,
+            "mcp_remote_allowed_providers": ["remote_multiplex"],
+        }
+    )
+    assert admitted["reason_code"] == "ok"
+    admitted_tools = {entry["tool"] for entry in admitted["admitted"]}
+    assert "mcp.search.objects" in admitted_tools
+    rejected_reasons = {entry["tool"]: entry["reason_code"] for entry in admitted["rejected"]}
+    assert rejected_reasons["mcp.unsupported.remote"] == "unsupported_tool"

--- a/tests/tools/test_mcp_discovery.py
+++ b/tests/tools/test_mcp_discovery.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import pytest
+
+from app.orchestrator.mcp_tool_provider import MCPToolProvider
+from app.planner.schema import ToolDescriptor
+
+pytestmark = pytest.mark.not_pg
+
+
+class _RemoteProviderMixed:
+    def list_descriptors(self) -> dict[str, ToolDescriptor]:
+        return {
+            "mcp.search.objects": ToolDescriptor(
+                name="mcp.search.objects",
+                kind="mcp",
+                schema={"type": "object", "required": ["query"]},
+                allowed_args={"query": "string"},
+                mock_result={"status": "remote-ok"},
+            ),
+            "mcp.unknown.tool": ToolDescriptor(
+                name="mcp.unknown.tool",
+                kind="mcp",
+                schema={"type": "object", "required": []},
+                allowed_args={},
+                mock_result={"status": "unknown"},
+            ),
+        }
+
+    def execute_tool_call(self, **_: object) -> dict[str, object]:
+        return {"result": {"status": "remote-ok"}}
+
+
+def test_discovery_enumerates_providers_when_enabled() -> None:
+    provider = MCPToolProvider(remote_provider=_RemoteProviderMixed())
+
+    diagnostics = provider.get_discovery_diagnostics(
+        {
+            "mcp_remote_multiplex_enable": True,
+            "mcp_remote_allowed_providers": ["remote_multiplex"],
+        }
+    )
+
+    assert diagnostics["enabled"] is True
+    assert diagnostics["reason_code"] == "ok"
+    discovered_tools = {entry["tool"] for entry in diagnostics["discovered"]}
+    assert "mcp.search.objects" in discovered_tools
+    assert "mcp.unknown.tool" in discovered_tools
+
+
+def test_discovered_provider_requires_policy_admission() -> None:
+    provider = MCPToolProvider(remote_provider=_RemoteProviderMixed())
+
+    diagnostics = provider.get_discovery_diagnostics({"mcp_remote_multiplex_enable": True})
+    assert diagnostics["reason_code"] == "policy_admission_required"
+    rejected = {entry["tool"]: entry["reason_code"] for entry in diagnostics["rejected"]}
+    assert rejected["mcp.search.objects"] == "policy_admission_required"
+
+    descriptors = provider.list_descriptors({"mcp_remote_multiplex_enable": True})
+    assert "mcp.search.objects" in descriptors
+    assert descriptors["mcp.search.objects"].mock_result.get("status") == "ok"

--- a/tests/tools/test_mcp_tool_provider.py
+++ b/tests/tools/test_mcp_tool_provider.py
@@ -179,7 +179,12 @@ class _RemoteProviderMismatchedDescriptor(_RemoteProviderError):
 def test_remote_multiplex_path_flagged() -> None:
     provider = MCPToolProvider(remote_provider=_RemoteProviderOK())
     executor = MockPlanExecutor()
-    context = _context({"mcp_remote_multiplex_enable": True})
+    context = _context(
+        {
+            "mcp_remote_multiplex_enable": True,
+            "mcp_remote_allowed_providers": ["remote_multiplex"],
+        }
+    )
 
     result = provider.execute_tool_call(
         tool_name="mcp.search.objects",
@@ -197,7 +202,12 @@ def test_remote_multiplex_path_flagged() -> None:
 def test_remote_multiplex_fallback_on_provider_error() -> None:
     provider = MCPToolProvider(remote_provider=_RemoteProviderError())
     executor = MockPlanExecutor()
-    context = _context({"mcp_remote_multiplex_enable": True})
+    context = _context(
+        {
+            "mcp_remote_multiplex_enable": True,
+            "mcp_remote_allowed_providers": ["remote_multiplex"],
+        }
+    )
 
     result = provider.execute_tool_call(
         tool_name="mcp.search.objects",
@@ -212,9 +222,14 @@ def test_remote_multiplex_fallback_on_provider_error() -> None:
     assert result["result"]["status"] == "ok"
 
 
-def test_remote_multiplex_fallback_when_descriptor_lookup_fails() -> None:
+def test_remote_descriptor_list_error_falls_back_to_local_registry() -> None:
     provider = MCPToolProvider(remote_provider=_RemoteProviderListError())
-    context = _context({"mcp_remote_multiplex_enable": True})
+    context = _context(
+        {
+            "mcp_remote_multiplex_enable": True,
+            "mcp_remote_allowed_providers": ["remote_multiplex"],
+        }
+    )
 
     result = provider.execute_tool_call(
         tool_name="mcp.search.objects",
@@ -228,9 +243,14 @@ def test_remote_multiplex_fallback_when_descriptor_lookup_fails() -> None:
     assert result["result"]["status"] == "ok"
 
 
-def test_remote_fallback_revalidates_against_local_descriptor() -> None:
+def test_remote_error_fallback_re_resolves_local_descriptor() -> None:
     provider = MCPToolProvider(remote_provider=_RemoteProviderMismatchedDescriptor())
-    context = _context({"mcp_remote_multiplex_enable": True})
+    context = _context(
+        {
+            "mcp_remote_multiplex_enable": True,
+            "mcp_remote_allowed_providers": ["remote_multiplex"],
+        }
+    )
 
     result = provider.execute_tool_call(
         tool_name="mcp.search.objects",
@@ -249,7 +269,12 @@ def test_remote_error_without_local_descriptor_raises_tool_unavailable(
 ) -> None:
     monkeypatch.setattr("app.orchestrator.mcp_tool_provider._load_registry_descriptors", lambda: {})
     provider = MCPToolProvider(remote_provider=_RemoteProviderMismatchedDescriptor())
-    context = _context({"mcp_remote_multiplex_enable": True})
+    context = _context(
+        {
+            "mcp_remote_multiplex_enable": True,
+            "mcp_remote_allowed_providers": ["remote_multiplex"],
+        }
+    )
 
     with pytest.raises(StepExecutionError) as exc:
         provider.execute_tool_call(


### PR DESCRIPTION
Fixes #575

## Summary
- add a deterministic MCP discovery seam with explicit enablement and allowlist-based provider admission
- keep local registry as default routing path when discovery is disabled or not admitted
- expose discovery diagnostics for discovered/admitted/rejected providers with reason codes
- update tool policy contract docs for discovery boundary and guardrails

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/pytest -q tests/tools/test_mcp_discovery.py::test_discovery_enumerates_providers_when_enabled tests/tools/test_mcp_discovery.py::test_discovered_provider_requires_policy_admission tests/observability/test_tool_discovery_diagnostics.py::test_discovery_diagnostics_reason_codes tests/tools/test_mcp_tool_provider.py tests/events/test_tool_execution_route_metadata.py
