### PR TITLE
Define deterministic delivery-SLA outcomes and status reporting

### DIFF
--- a/app/observability/status_model.py
+++ b/app/observability/status_model.py
@@ -59,6 +59,11 @@ class EventCounters(BaseModel):
     source_path: str | None = None
 
 
+class DeliverySLAStatus(BaseModel):
+    outcomes_total: dict[str, int] = Field(default_factory=dict)
+    source_path: str | None = None
+
+
 class IndexStatus(BaseModel):
     status: str | None = None
     issues: list[str] = Field(default_factory=list)
@@ -155,6 +160,7 @@ class SystemStatus(BaseModel):
     ask: AskStatus
     intents: Optional[IntentStatus] = None
     events: Optional[EventCounters] = None
+    delivery_sla: Optional[DeliverySLAStatus] = None
     index: Optional[IndexStatus] = None
     panel_diagnostics: Optional[PanelDiagnostics] = None
     write_guard: Optional[WriteGuardStatus] = None
@@ -173,6 +179,7 @@ __all__ = [
     "AskStatus",
     "IntentStatus",
     "EventCounters",
+    "DeliverySLAStatus",
     "IndexStatus",
     "PanelDiagnostics",
     "WriteGuardStatus",

--- a/app/observability/status_service.py
+++ b/app/observability/status_service.py
@@ -10,9 +10,18 @@ from typing import Iterable
 
 from app.config.environment import active_environment
 from app.events.types import PROMOTE_INTENT_CREATED, PROMOTE_DONE
+from app.events.types import ORCHESTRATOR_STEP_ERROR, ORCHESTRATOR_STEP_FINISHED
 from app.observability.ingest_meta import get_ingest_status
+from app.orchestrator.delivery_sla import (
+    DELIVERY_SLA_DELIVERED,
+    DELIVERY_SLA_FAILED,
+    DELIVERY_SLA_ROLLED_BACK,
+    DELIVERY_SLA_TIMEOUT,
+    map_delivery_sla_from_event_record,
+)
 from app.observability.status_model import (
     AskStatus,
+    DeliverySLAStatus,
     EventCounters,
     EventsLogStatus,
     IngestionStatus,
@@ -259,6 +268,37 @@ def _count_events(outbox_path: Path) -> EventCounters:
         ingest_runs_by_plane={},
         source_path=source,
     )
+
+
+def _delivery_sla_status(outbox_path: Path) -> DeliverySLAStatus:
+    outcomes = {
+        DELIVERY_SLA_DELIVERED: 0,
+        DELIVERY_SLA_TIMEOUT: 0,
+        DELIVERY_SLA_FAILED: 0,
+        DELIVERY_SLA_ROLLED_BACK: 0,
+    }
+    try:
+        with outbox_path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except Exception:
+                    continue
+                event = record.get("event") or record.get("event_type") or record.get("topic") or ""
+                if event not in {ORCHESTRATOR_STEP_ERROR, ORCHESTRATOR_STEP_FINISHED}:
+                    continue
+                state = map_delivery_sla_from_event_record(record)
+                if not state:
+                    continue
+                outcomes[state] = outcomes.get(state, 0) + 1
+    except FileNotFoundError:
+        pass
+    except Exception:
+        pass
+    return DeliverySLAStatus(outcomes_total=outcomes, source_path=str(outbox_path))
 
 
 def _outbox_db_source() -> str:
@@ -740,6 +780,7 @@ def get_system_status() -> SystemStatus:
         ask=get_ask_status(),
         intents=intent_status,
         events=counters,
+        delivery_sla=_delivery_sla_status(Path(INDEX_OUTBOX_PATH)),
         index=_get_index_status(),
         panel_diagnostics=_get_panel_diagnostics(),
         write_guard=_get_write_guard_status(),

--- a/app/orchestrator/delivery_sla.py
+++ b/app/orchestrator/delivery_sla.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Mapping
+
+
+DELIVERY_SLA_DELIVERED = "delivered"
+DELIVERY_SLA_TIMEOUT = "timeout_terminal"
+DELIVERY_SLA_FAILED = "failed_terminal"
+DELIVERY_SLA_ROLLED_BACK = "rolled_back_terminal"
+
+_TIMEOUT_ERROR_TYPES = {"tool_timeout", "timeout", "plan_timeout"}
+
+
+def map_delivery_sla_terminal_state(*, status: str, error_type: str | None = None) -> str:
+    normalized_status = (status or "").strip().lower()
+    normalized_error = (error_type or "").strip().lower()
+
+    if normalized_status == "ok":
+        return DELIVERY_SLA_DELIVERED
+    if normalized_status == "rolled_back":
+        return DELIVERY_SLA_ROLLED_BACK
+    if normalized_error in _TIMEOUT_ERROR_TYPES:
+        return DELIVERY_SLA_TIMEOUT
+    return DELIVERY_SLA_FAILED
+
+
+def summarize_delivery_sla_outcomes(results: Iterable[Mapping[str, Any]]) -> Dict[str, int]:
+    summary: Dict[str, int] = {
+        DELIVERY_SLA_DELIVERED: 0,
+        DELIVERY_SLA_TIMEOUT: 0,
+        DELIVERY_SLA_FAILED: 0,
+        DELIVERY_SLA_ROLLED_BACK: 0,
+    }
+    for item in results:
+        if str(item.get("step_id") or "") == "__compensation__":
+            continue
+        state = map_delivery_sla_terminal_state(
+            status=str(item.get("status") or ""),
+            error_type=(str(item.get("error_type")) if item.get("error_type") is not None else None),
+        )
+        summary[state] = summary.get(state, 0) + 1
+    return summary
+
+
+def map_delivery_sla_from_event_record(record: Mapping[str, Any]) -> str | None:
+    payload = record.get("payload")
+    if not isinstance(payload, Mapping):
+        return None
+    details = payload.get("details")
+    if not isinstance(details, Mapping):
+        return None
+
+    raw_state = details.get("delivery_sla_state")
+    if isinstance(raw_state, str) and raw_state.strip():
+        return raw_state.strip()
+
+    error_type = details.get("error_type")
+    if isinstance(error_type, str) and error_type.strip():
+        return map_delivery_sla_terminal_state(status="error", error_type=error_type)
+    return None
+
+
+__all__ = [
+    "DELIVERY_SLA_DELIVERED",
+    "DELIVERY_SLA_TIMEOUT",
+    "DELIVERY_SLA_FAILED",
+    "DELIVERY_SLA_ROLLED_BACK",
+    "map_delivery_sla_terminal_state",
+    "summarize_delivery_sla_outcomes",
+    "map_delivery_sla_from_event_record",
+]

--- a/app/orchestrator/events.py
+++ b/app/orchestrator/events.py
@@ -16,6 +16,7 @@ from app.events.types import (
     ORCHESTRATOR_STEP_RETRY_EXHAUSTED,
     ORCHESTRATOR_STEP_STARTED,
 )
+from app.orchestrator.delivery_sla import map_delivery_sla_terminal_state
 from app.planner.schema import PlanStep
 
 ORCHESTRATOR_AGENT = "orchestrator.runtime"
@@ -45,6 +46,7 @@ def emit_step_finished(
 ) -> None:
     details = _base_step_details(plan_id, step)
     details["result"] = result
+    details["delivery_sla_state"] = map_delivery_sla_terminal_state(status="ok")
     _emit(ORCHESTRATOR_STEP_FINISHED, object_id=object_id, trace_id=trace_id, details=details)
 
 
@@ -59,6 +61,7 @@ def emit_step_error(
 ) -> None:
     details = _base_step_details(plan_id, step)
     details["error"] = error
+    details["delivery_sla_state"] = map_delivery_sla_terminal_state(status="error", error_type=error_type)
     if error_type:
         details["error_type"] = error_type
     _emit(ORCHESTRATOR_STEP_ERROR, object_id=object_id, trace_id=trace_id, details=details)

--- a/app/orchestrator/runtime.py
+++ b/app/orchestrator/runtime.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict, List, Mapping, MutableMapping, Set
 
 from app.planner.schema import Plan, PlanStep
 
+from .delivery_sla import map_delivery_sla_terminal_state
 from .events import emit_step_error, emit_step_finished, emit_step_started
 from .executor import MockPlanExecutor, PlanExecutor, StepContext, StepExecutionError
 
@@ -108,6 +109,10 @@ class Orchestrator:
                     "status": "error",
                     "error": "plan timeout budget exhausted",
                     "error_type": "plan_timeout",
+                    "delivery_sla_state": map_delivery_sla_terminal_state(
+                        status="error",
+                        error_type="plan_timeout",
+                    ),
                 })
                 break
             emit_step_started(plan_id=plan.id, step=step, object_id=object_id, trace_id=trace_id)
@@ -130,6 +135,10 @@ class Orchestrator:
                     "status": "error",
                     "error": "step budget exhausted",
                     "error_type": "budget_exhausted",
+                    "delivery_sla_state": map_delivery_sla_terminal_state(
+                        status="error",
+                        error_type="budget_exhausted",
+                    ),
                 })
                 break
 
@@ -164,6 +173,7 @@ class Orchestrator:
                 entry = {"step_id": step.id, "status": "error", "error": error_message}
                 if error_type:
                     entry["error_type"] = error_type
+                entry["delivery_sla_state"] = map_delivery_sla_terminal_state(status="error", error_type=error_type)
                 results.append(entry)
                 break
             else:
@@ -175,7 +185,14 @@ class Orchestrator:
                     trace_id=trace_id,
                 )
                 plan_results[step.id] = output
-                results.append({"step_id": step.id, "status": "ok", "result": output})
+                results.append(
+                    {
+                        "step_id": step.id,
+                        "status": "ok",
+                        "result": output,
+                        "delivery_sla_state": map_delivery_sla_terminal_state(status="ok"),
+                    }
+                )
         return results
 
     def _validate_plan(self, plan: Plan) -> None:

--- a/app/orchestrator/v2_runtime.py
+++ b/app/orchestrator/v2_runtime.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Set
 
 from app.planner.schema import Plan, PlanMetadata, PlanStep
 
+from .delivery_sla import map_delivery_sla_terminal_state
 from .events import (
     emit_compensation_started,
     emit_compensation_step_completed,
@@ -230,6 +231,10 @@ class OrchestratorV2:
                             "status": "error",
                             "error": "plan timeout budget exhausted",
                             "error_type": "plan_timeout",
+                            "delivery_sla_state": map_delivery_sla_terminal_state(
+                                status="error",
+                                error_type="plan_timeout",
+                            ),
                         })
                         emit_step_error(
                             plan_id=plan.id,
@@ -249,6 +254,10 @@ class OrchestratorV2:
                             "status": "error",
                             "error": "step budget exhausted",
                             "error_type": "budget_exhausted",
+                            "delivery_sla_state": map_delivery_sla_terminal_state(
+                                status="error",
+                                error_type="budget_exhausted",
+                            ),
                         })
                         completed_steps.add(step_id)
                         continue
@@ -289,7 +298,14 @@ class OrchestratorV2:
                                 trace_id=trace_id,
                             )
                             plan_results[step_id] = output
-                            results.append({"step_id": step_id, "status": "ok", "result": output})
+                            results.append(
+                                {
+                                    "step_id": step_id,
+                                    "status": "ok",
+                                    "result": output,
+                                    "delivery_sla_state": map_delivery_sla_terminal_state(status="ok"),
+                                }
+                            )
                             completed_steps.add(step_id)
                             execution_order.append(step_id)
 
@@ -310,6 +326,10 @@ class OrchestratorV2:
                             entry = {"step_id": step_id, "status": "error", "error": error_message}
                             if error_type:
                                 entry["error_type"] = error_type
+                            entry["delivery_sla_state"] = map_delivery_sla_terminal_state(
+                                status="error",
+                                error_type=error_type,
+                            )
                             results.append(entry)
                             completed_steps.add(step_id)
                             failed_step_id = step_id
@@ -328,6 +348,10 @@ class OrchestratorV2:
                                 "status": "error",
                                 "error": error_message,
                                 "error_type": "unexpected_error",
+                                "delivery_sla_state": map_delivery_sla_terminal_state(
+                                    status="error",
+                                    error_type="unexpected_error",
+                                ),
                             })
                             completed_steps.add(step_id)
                             failed_step_id = step_id
@@ -356,6 +380,7 @@ class OrchestratorV2:
             for entry in results:
                 if entry["step_id"] in compensation_result["compensated_steps"] and entry["status"] == "ok":
                     entry["status"] = "rolled_back"
+                    entry["delivery_sla_state"] = map_delivery_sla_terminal_state(status="rolled_back")
             results.append({
                 "step_id": "__compensation__",
                 "status": "rolled_back",

--- a/docs/contracts/A2A_CONTRACT_AND_TRACE.md
+++ b/docs/contracts/A2A_CONTRACT_AND_TRACE.md
@@ -75,6 +75,7 @@ Current runtime truth:
 - Responses and errors are represented by schema objects and can be emitted to audit via `emit_agent_response_event(...)` and `emit_agent_error_event(...)`.
 - There is no shipped repo-wide timeout scheduler, retry loop, dead-letter queue, or delivery SLA for A2A messages.
 - If a caller needs timeout behavior today, that policy lives in the owning caller/agent/orchestrator code path rather than in a central A2A runtime.
+- Delivery-SLA terminal-state reporting for timeouts/failures is owned by orchestrator runtime/status surfaces, not by A2A transport.
 
 Error taxonomy posture:
 

--- a/docs/contracts/TIMEOUT_AND_SLA_CONTRACT.md
+++ b/docs/contracts/TIMEOUT_AND_SLA_CONTRACT.md
@@ -22,7 +22,8 @@ Use this document with:
 - V1 executes steps sequentially (no parallel execution); V2 uses ThreadPoolExecutor for dependency-aware parallel scheduling.
 - Timeout is observable: caught errors are emitted with error_type `tool_timeout`.
 - Plan budget exhaustion is observable with `error_type` `plan_timeout`.
-- No repo-wide A2A/runtime timeout policy, retry queue, or delivery SLA exists.
+- Delivery-SLA terminal state mapping is deterministic for orchestrator step outcomes and exposed in status/trace surfaces.
+- No repo-wide A2A transport delivery queue or retry-SLA scheduler exists.
 
 ## Timeout handling by surface
 
@@ -106,6 +107,25 @@ When a configured plan timeout budget is exhausted:
 1. The orchestrator marks the next unstarted executable step as failed with `error_type="plan_timeout"`.
 2. V1 stops scheduling additional steps.
 3. V2 stops scheduling and runs compensation for previously completed predecessors.
+
+## Delivery-SLA terminal state contract
+
+Delivery-SLA status is a deterministic terminal mapping for orchestrator step outcomes:
+
+| Input runtime state | Mapping output |
+| --- | --- |
+| `status="ok"` | `delivered` |
+| `status="rolled_back"` | `rolled_back_terminal` |
+| `status="error"` and `error_type in {"tool_timeout","timeout","plan_timeout"}` | `timeout_terminal` |
+| any other `status="error"` | `failed_terminal` |
+
+Current exposure:
+- Orchestrator step trace events (`orchestrator.step.finished`, `orchestrator.step.error`) include `details.delivery_sla_state`.
+- Status surface includes aggregate delivery-SLA outcome totals under `delivery_sla.outcomes_total`.
+
+Compatibility posture:
+- Existing `error_type` semantics and per-tool timeout behavior are unchanged.
+- Plan-timeout budget behavior is unchanged (`error_type="plan_timeout"` remains canonical).
 
 ## Constraints and non-claims
 

--- a/tests/observability/test_status_delivery_sla_reporting.py
+++ b/tests/observability/test_status_delivery_sla_reporting.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+
+from app.observability.status_service import get_system_status
+import app.observability.status_service as status_service
+
+
+def test_status_exposes_delivery_sla_outcomes(monkeypatch, tmp_path) -> None:
+    outbox = tmp_path / "status-sla-outbox.jsonl"
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox))
+    monkeypatch.setattr(status_service, "INDEX_OUTBOX_PATH", outbox, raising=False)
+
+    records = [
+        {
+            "event": "orchestrator.step.finished",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "payload": {"details": {"delivery_sla_state": "delivered"}},
+        },
+        {
+            "event": "orchestrator.step.error",
+            "timestamp": "2026-01-01T00:00:01Z",
+            "payload": {"details": {"delivery_sla_state": "failed_terminal", "error_type": "handler_error"}},
+        },
+        {
+            "event": "orchestrator.step.error",
+            "timestamp": "2026-01-01T00:00:02Z",
+            "payload": {"details": {"error_type": "plan_timeout"}},
+        },
+    ]
+    outbox.write_text("\n".join(json.dumps(r) for r in records), encoding="utf-8")
+
+    status = get_system_status()
+    assert status.delivery_sla is not None
+    assert status.delivery_sla.outcomes_total["delivered"] == 1
+    assert status.delivery_sla.outcomes_total["failed_terminal"] == 1
+    assert status.delivery_sla.outcomes_total["timeout_terminal"] == 1
+    assert status.delivery_sla.source_path == str(outbox)

--- a/tests/orchestration/test_delivery_sla_outcomes.py
+++ b/tests/orchestration/test_delivery_sla_outcomes.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import time
+
+from app.orchestrator.delivery_sla import (
+    DELIVERY_SLA_DELIVERED,
+    DELIVERY_SLA_FAILED,
+    DELIVERY_SLA_ROLLED_BACK,
+    DELIVERY_SLA_TIMEOUT,
+    map_delivery_sla_terminal_state,
+)
+from app.orchestrator.runtime import Orchestrator
+from app.planner.schema import Plan, PlanMetadata, PlanStep
+
+
+def _plan() -> Plan:
+    return Plan(
+        id="plan-delivery-sla",
+        meta=PlanMetadata(goal="sla", source_object_uuid="obj-sla", created_by="test", trace_id="trace-sla"),
+        steps=[
+            PlanStep(id="step-1", kind="agent_call", description="slow", agent="agent"),
+            PlanStep(id="step-2", kind="agent_call", description="next", agent="agent"),
+        ],
+        context={},
+    )
+
+
+class _SlowExecutor:
+    def execute_step(self, step, context):
+        if step.id == "step-1":
+            time.sleep(0.05)
+        return {"ok": step.id}
+
+
+def test_delivery_sla_terminal_state_mapping() -> None:
+    assert map_delivery_sla_terminal_state(status="ok") == DELIVERY_SLA_DELIVERED
+    assert map_delivery_sla_terminal_state(status="rolled_back") == DELIVERY_SLA_ROLLED_BACK
+    assert map_delivery_sla_terminal_state(status="error", error_type="tool_timeout") == DELIVERY_SLA_TIMEOUT
+    assert map_delivery_sla_terminal_state(status="error", error_type="plan_timeout") == DELIVERY_SLA_TIMEOUT
+    assert map_delivery_sla_terminal_state(status="error", error_type="budget_exhausted") == DELIVERY_SLA_FAILED
+
+    orchestrator = Orchestrator(
+        executor=_SlowExecutor(),
+        tool_settings={"plan_timeout_seconds": 0.01, "tool_timeout_seconds": 99},
+    )
+    results = orchestrator.run_plan(_plan())
+
+    assert results[0]["delivery_sla_state"] == DELIVERY_SLA_DELIVERED
+    assert results[1]["error_type"] == "plan_timeout"
+    assert results[1]["delivery_sla_state"] == DELIVERY_SLA_TIMEOUT


### PR DESCRIPTION
Fixes #569

## Summary
- add a canonical delivery-SLA outcome mapper for orchestrator/runtime flows
- map timeout/failure paths to explicit terminal SLA states in v1 and flagged v2 flows
- expose delivery-SLA outcomes in trace/status surfaces for operator inspection
- update SLA/A2A contract docs with boundaries and expected outcomes

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/pytest -q tests/orchestration/test_delivery_sla_outcomes.py::test_delivery_sla_terminal_state_mapping tests/observability/test_status_delivery_sla_reporting.py::test_status_exposes_delivery_sla_outcomes tests/orchestration/test_plan_timeout_budget.py::test_v1_plan_timeout_budget_stops_plan_without_changing_tool_timeout tests/orchestration/v2/test_plan_timeout_budget.py::test_v2_plan_timeout_budget_uses_distinct_error_type_and_compensates
