### PR TITLE
Add parallel dev/test/prod compose stack targets and overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
-.PHONY: fmt lint test eval docs smoke ci-smoke setup-merge-driver hygiene-logs indexer-run transcribe qa cold-boot start verify verify-runtime doctor persist-runtime-repairs install-skills test-vault-init start-test-system test-bootstrap
+.PHONY: fmt lint test eval docs smoke ci-smoke setup-merge-driver hygiene-logs indexer-run transcribe qa cold-boot start verify verify-runtime doctor persist-runtime-repairs install-skills test-vault-init start-test-system test-bootstrap dev-up dev-down prod-up prod-down test-up test-down
 
 PYTHON ?= $(shell if [ -x .venv/bin/python ]; then printf '%s' .venv/bin/python; elif command -v python3.12 >/dev/null 2>&1; then command -v python3.12; elif command -v python3 >/dev/null 2>&1; then command -v python3; elif command -v python >/dev/null 2>&1; then command -v python; fi)
 TEST_VAULT_ROOT ?= $(PWD)/vault-test
+COMPOSE_BASE := docker compose -f docker-compose.yaml
+COMPOSE_DEV := $(COMPOSE_BASE) -f docker-compose.dev.yml -p pkm-dev
+COMPOSE_TEST := $(COMPOSE_BASE) -f docker-compose.test.yml -p pkm-test
+COMPOSE_PROD := $(COMPOSE_BASE) -p pkm-prod
 
 fmt:
 	rufflehog --version >/dev/null 2>&1 || true
@@ -70,6 +74,24 @@ test-bootstrap: reset-zero-force test-vault-init
 	@VAULT_ROOT="$(TEST_VAULT_ROOT)" scripts/start_full_system.sh
 	@VAULT_ROOT="$(TEST_VAULT_ROOT)" bash scripts/verify_runtime_stack.sh
 	@VAULT_ROOT="$(TEST_VAULT_ROOT)" $(PYTHON) -m app.cli uat-run-vault-test --vault-root "$(TEST_VAULT_ROOT)" --assert
+
+dev-up:
+	@$(COMPOSE_DEV) up -d --build
+
+dev-down:
+	@$(COMPOSE_DEV) down --remove-orphans
+
+prod-up:
+	@$(COMPOSE_PROD) up -d --build
+
+prod-down:
+	@$(COMPOSE_PROD) down --remove-orphans
+
+test-up:
+	@$(COMPOSE_TEST) up -d --build
+
+test-down:
+	@$(COMPOSE_TEST) down --remove-orphans
 
 alpha-e2e-smoke:
 	@$(PYTHON) - <<'PY'

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,24 @@
+services:
+  db:
+    ports:
+      - "15433:5432"
+
+  api:
+    ports:
+      - "18001:8000"
+    environment:
+      PKM_ENVIRONMENT: dev
+      DATABASE_URL: postgresql+psycopg://app:app@db:5432/app
+      DB_DSN: postgresql+psycopg://app:app@db:5432/app
+
+  worker:
+    environment:
+      PKM_ENVIRONMENT: dev
+      DATABASE_URL: postgresql+psycopg://app:app@db:5432/app
+      DB_DSN: postgresql+psycopg://app:app@db:5432/app
+
+  watcher:
+    environment:
+      PKM_ENVIRONMENT: dev
+      DATABASE_URL: postgresql+psycopg://app:app@db:5432/app
+      DB_DSN: postgresql+psycopg://app:app@db:5432/app

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,24 @@
+services:
+  db:
+    ports:
+      - "15434:5432"
+
+  api:
+    ports:
+      - "18002:8000"
+    environment:
+      PKM_ENVIRONMENT: dev
+      DATABASE_URL: postgresql+psycopg://app:app@db:5432/app
+      DB_DSN: postgresql+psycopg://app:app@db:5432/app
+
+  worker:
+    environment:
+      PKM_ENVIRONMENT: dev
+      DATABASE_URL: postgresql+psycopg://app:app@db:5432/app
+      DB_DSN: postgresql+psycopg://app:app@db:5432/app
+
+  watcher:
+    environment:
+      PKM_ENVIRONMENT: dev
+      DATABASE_URL: postgresql+psycopg://app:app@db:5432/app
+      DB_DSN: postgresql+psycopg://app:app@db:5432/app

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -206,6 +206,33 @@ Operator note:
 - `test` is the current golden path for local verification and stabilization work.
 - `dev` remains the flexible development posture, and `prod` remains the conservative operator posture.
 
+## Parallel Local Stacks
+
+The repo supports parallel local Compose stacks for `dev`, `test`, and `prod` on one machine without host-port conflicts.
+
+Commands:
+
+```bash
+make prod-up
+make dev-up
+make test-up
+```
+
+Port map:
+- `prod`: Postgres `15432`, API `18000`
+- `dev`: Postgres `15433`, API `18001`
+- `test`: Postgres `15434`, API `18002`
+
+Compose files:
+- `docker-compose.yaml` (base + prod defaults)
+- `docker-compose.dev.yml` (dev overrides)
+- `docker-compose.test.yml` (test overrides)
+
+Notes:
+- `make start-test-system` and `make test-bootstrap` remain unchanged and are still the canonical local `test` verification workflow.
+- The `test` compose override uses the same runtime environment selector posture as `dev` (`PKM_ENVIRONMENT=dev`) because runtime selection currently supports `dev` and `prod`; test remains a workflow-defined environment in this baseline.
+- Full parallel isolation still depends on DB separation work tracked by Issue #594.
+
 ## Relation to Current Health, Write Guard, and Settings Direction
 
 ### Health and Write Guard

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -23,6 +23,7 @@ Reading order:
 4. Use `docs/INFRASTRUCTURE.md` when you need Docker/runtime topology, local startup flow, or the local monitoring stack.
 5. Use `docs/runbooks/` only for task-specific walkthroughs after you have identified the affected runtime surface.
 6. Use `docs/ENVIRONMENTS.md` when the question is whether behavior belongs to `dev`, `test`, `prod`, or a boundary between them.
+7. Use the parallel-stack recipe in `docs/ENVIRONMENTS.md` when you need to run `dev`, `test`, and `prod` Compose stacks simultaneously on one machine.
 
 CLI note:
 - `python -m app.cli --help` and `python -m app.cli <command> --help` remain the authoritative command discovery surface because the CLI evolves faster than the docs.


### PR DESCRIPTION
Fixes #595

## Summary
- add `make dev-up/dev-down`, `make prod-up/prod-down`, and `make test-up/test-down` targets using isolated compose project names
- add `docker-compose.dev.yml` and `docker-compose.test.yml` with non-conflicting host ports and environment-specific runtime variables
- document the parallel local stack recipe and port map in `docs/ENVIRONMENTS.md`
- add cross-reference in `docs/OPERATIONS.md`

## Validation
- make -n dev-up dev-down prod-up prod-down test-up test-down
- static checks:
  - rg -n "dev-up|prod-up|test-up|COMPOSE_DEV|COMPOSE_TEST|COMPOSE_PROD" Makefile
  - rg -n "Parallel Local Stacks|Issue #594" docs/ENVIRONMENTS.md
  - rg -n "parallel-stack recipe" docs/OPERATIONS.md
- Could not run `docker compose config` in this environment because `docker` is not installed on PATH.