### PR TITLE
Add per-environment Postgres DB separation for dev/test/prod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 PYTHON ?= $(shell if [ -x .venv/bin/python ]; then printf '%s' .venv/bin/python; elif command -v python3.12 >/dev/null 2>&1; then command -v python3.12; elif command -v python3 >/dev/null 2>&1; then command -v python3; elif command -v python >/dev/null 2>&1; then command -v python; fi)
 TEST_VAULT_ROOT ?= $(PWD)/vault-test
+TEST_DATABASE_URL ?= postgresql+psycopg://app:app@db:5432/app_test
 COMPOSE_BASE := docker compose -f docker-compose.yaml
 COMPOSE_DEV := $(COMPOSE_BASE) -f docker-compose.dev.yml -p pkm-dev
 COMPOSE_TEST := $(COMPOSE_BASE) -f docker-compose.test.yml -p pkm-test
@@ -68,12 +69,12 @@ reset-zero-force:
 	@RESET_FORCE=1 bash scripts/reset_to_zero.sh
 
 start-test-system:
-	@VAULT_ROOT="$(TEST_VAULT_ROOT)" scripts/start_full_system.sh
+	@VAULT_ROOT="$(TEST_VAULT_ROOT)" DATABASE_URL="$(TEST_DATABASE_URL)" DB_DSN="$(TEST_DATABASE_URL)" scripts/start_full_system.sh
 
 test-bootstrap: reset-zero-force test-vault-init
-	@VAULT_ROOT="$(TEST_VAULT_ROOT)" scripts/start_full_system.sh
-	@VAULT_ROOT="$(TEST_VAULT_ROOT)" bash scripts/verify_runtime_stack.sh
-	@VAULT_ROOT="$(TEST_VAULT_ROOT)" $(PYTHON) -m app.cli uat-run-vault-test --vault-root "$(TEST_VAULT_ROOT)" --assert
+	@VAULT_ROOT="$(TEST_VAULT_ROOT)" DATABASE_URL="$(TEST_DATABASE_URL)" DB_DSN="$(TEST_DATABASE_URL)" scripts/start_full_system.sh
+	@VAULT_ROOT="$(TEST_VAULT_ROOT)" DATABASE_URL="$(TEST_DATABASE_URL)" DB_DSN="$(TEST_DATABASE_URL)" bash scripts/verify_runtime_stack.sh
+	@VAULT_ROOT="$(TEST_VAULT_ROOT)" DATABASE_URL="$(TEST_DATABASE_URL)" DB_DSN="$(TEST_DATABASE_URL)" $(PYTHON) -m app.cli uat-run-vault-test --vault-root "$(TEST_VAULT_ROOT)" --assert
 
 dev-up:
 	@$(COMPOSE_DEV) up -d --build

--- a/app/cli/settings_explain.py
+++ b/app/cli/settings_explain.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import json
+import os
 from typing import Any, Sequence
 
+from app.config.database import resolve_runtime_database_url
 from app.config.environment import active_environment
 from app.health_contract import DEFAULT_CONTRACT
 from app.settings.panel_actions_settings import load_panel_actions_settings, panel_action_ids
@@ -10,6 +12,7 @@ from app.settings.watcher_settings import invalid_allowed_actions, load_watcher_
 
 
 def build_settings_explain_payload() -> dict[str, Any]:
+    db_url = resolve_runtime_database_url(os.environ)
     panel_settings = load_panel_actions_settings()
     watcher_settings = load_watcher_settings()
     auto_exec = resolve_auto_exec_state()
@@ -18,6 +21,7 @@ def build_settings_explain_payload() -> dict[str, Any]:
     write_guard = DEFAULT_CONTRACT.evaluate()
     return {
         "environment": active_environment(),
+        "database_url": db_url,
         "panel_actions": {
             "action_count": len(panel_settings.catalog.actions),
             "action_ids": sorted(panel_settings.catalog.ids()),

--- a/app/config/database.py
+++ b/app/config/database.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from urllib.parse import quote
+
+from app.config.environment import ENV_DEV, ENV_PROD, active_environment
+
+
+def _clean(env: Mapping[str, str], key: str) -> str:
+    return str(env.get(key, "") or "").strip()
+
+
+def default_database_name(env_name: str) -> str:
+    if env_name == ENV_DEV:
+        return "app_dev"
+    if env_name == ENV_PROD:
+        return "app"
+    return "app"
+
+
+def resolve_runtime_database_url(env: Mapping[str, str]) -> str:
+    explicit = _clean(env, "DATABASE_URL") or _clean(env, "DB_DSN")
+    if explicit:
+        return explicit
+
+    env_name = active_environment(env)
+    if env_name == ENV_DEV:
+        db_name = _clean(env, "PKM_DB_NAME_DEV") or default_database_name(env_name)
+    else:
+        db_name = _clean(env, "PKM_DB_NAME_PROD") or default_database_name(env_name)
+
+    user = _clean(env, "POSTGRES_USER") or "app"
+    password = _clean(env, "POSTGRES_PASSWORD") or "app"
+    host = _clean(env, "PKM_DB_HOST") or "db"
+    port = _clean(env, "PKM_DB_PORT") or "5432"
+
+    return f"postgresql+psycopg://{quote(user)}:{quote(password)}@{host}:{port}/{db_name}"
+
+
+__all__ = ["default_database_name", "resolve_runtime_database_url"]

--- a/app/db/db.py
+++ b/app/db/db.py
@@ -9,6 +9,7 @@ from psycopg import Error
 from psycopg.errors import DependentObjectsStillExist, DuplicateObject, InsufficientPrivilege
 from psycopg.rows import dict_row
 
+from app.config.database import resolve_runtime_database_url
 from app.db.dsn import connect as _connect, resolve_dsn
 from app.settings import settings
 
@@ -19,7 +20,7 @@ _SCHEMA_INITIALIZED = False
 
 def _psycopg_dsn() -> str:
     """Allow DATABASE_URL overrides while keeping Pydantic defaults."""
-    url = os.getenv("DATABASE_URL")
+    url = resolve_runtime_database_url(os.environ)
     return resolve_dsn(url or settings.db_dsn)
 
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,7 @@
 services:
   db:
+    environment:
+      POSTGRES_DB: app_dev
     ports:
       - "15433:5432"
 
@@ -8,17 +10,17 @@ services:
       - "18001:8000"
     environment:
       PKM_ENVIRONMENT: dev
-      DATABASE_URL: postgresql+psycopg://app:app@db:5432/app
-      DB_DSN: postgresql+psycopg://app:app@db:5432/app
+      DATABASE_URL: postgresql+psycopg://app:app@db:5432/app_dev
+      DB_DSN: postgresql+psycopg://app:app@db:5432/app_dev
 
   worker:
     environment:
       PKM_ENVIRONMENT: dev
-      DATABASE_URL: postgresql+psycopg://app:app@db:5432/app
-      DB_DSN: postgresql+psycopg://app:app@db:5432/app
+      DATABASE_URL: postgresql+psycopg://app:app@db:5432/app_dev
+      DB_DSN: postgresql+psycopg://app:app@db:5432/app_dev
 
   watcher:
     environment:
       PKM_ENVIRONMENT: dev
-      DATABASE_URL: postgresql+psycopg://app:app@db:5432/app
-      DB_DSN: postgresql+psycopg://app:app@db:5432/app
+      DATABASE_URL: postgresql+psycopg://app:app@db:5432/app_dev
+      DB_DSN: postgresql+psycopg://app:app@db:5432/app_dev

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,5 +1,7 @@
 services:
   db:
+    environment:
+      POSTGRES_DB: app_test
     ports:
       - "15434:5432"
 
@@ -8,17 +10,17 @@ services:
       - "18002:8000"
     environment:
       PKM_ENVIRONMENT: dev
-      DATABASE_URL: postgresql+psycopg://app:app@db:5432/app
-      DB_DSN: postgresql+psycopg://app:app@db:5432/app
+      DATABASE_URL: postgresql+psycopg://app:app@db:5432/app_test
+      DB_DSN: postgresql+psycopg://app:app@db:5432/app_test
 
   worker:
     environment:
       PKM_ENVIRONMENT: dev
-      DATABASE_URL: postgresql+psycopg://app:app@db:5432/app
-      DB_DSN: postgresql+psycopg://app:app@db:5432/app
+      DATABASE_URL: postgresql+psycopg://app:app@db:5432/app_test
+      DB_DSN: postgresql+psycopg://app:app@db:5432/app_test
 
   watcher:
     environment:
       PKM_ENVIRONMENT: dev
-      DATABASE_URL: postgresql+psycopg://app:app@db:5432/app
-      DB_DSN: postgresql+psycopg://app:app@db:5432/app
+      DATABASE_URL: postgresql+psycopg://app:app@db:5432/app_test
+      DB_DSN: postgresql+psycopg://app:app@db:5432/app_test

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -96,11 +96,15 @@ Environment separation MUST be explicit across the following surfaces.
 - `test` runtime state may be reset and rebuilt as part of the supported bootstrap contract; repeatability is more important than persistence.
 - Rebuildable does not mean disposable in `prod`; recovery and audit expectations still apply.
 
-**Implementation Status (Issue #266)**:
+**Implementation Status (Issue #266 + #594)**:
 - Index outbox and store paths are now environment-scoped via `app.config.paths.resolve_runtime_artifact_path()`.
 - Default behavior: `prod` uses `tmp/` subdirectories, `dev` uses `tmp-dev/` subdirectories.
 - Watcher settings automatically apply environment scoping to all artifact paths via `load_watcher_settings(environment=...)`.
-- DB outbox (PostgreSQL) is shared; file-based audit logs respect environment separation.
+- PostgreSQL now follows per-environment database naming conventions for runtime stacks:
+  - `prod`: `app`
+  - `dev`: `app_dev`
+  - `test` bootstrap/runtime lane: `app_test`
+- Explicit `DATABASE_URL` / `DB_DSN` still overrides environment-derived conventions.
 - The `test` path currently relies on explicit reset/bootstrap commands and test-specific runtime artifacts rather than a separate runtime selector.
 
 ### Runtime State and Process Surfaces

--- a/tests/cli/test_settings_explain_cli.py
+++ b/tests/cli/test_settings_explain_cli.py
@@ -29,6 +29,7 @@ def test_settings_explain_surfaces_explicit_environment(monkeypatch, tmp_path) -
     payload = build_settings_explain_payload()
 
     assert payload["environment"] == "dev"
+    assert payload["database_url"].endswith("/app_dev")
 
 
 def test_settings_explain_includes_watcher_gate_and_allowlist(monkeypatch, tmp_path) -> None:
@@ -75,3 +76,31 @@ def test_settings_explain_includes_watcher_gate_and_allowlist(monkeypatch, tmp_p
     assert "watcher_heartbeat" in watcher["paths"]
     assert "worker_heartbeat" in watcher["paths"]
     assert "write_guard" in watcher
+
+
+def test_settings_explain_respects_explicit_database_override(monkeypatch, tmp_path) -> None:
+    vault = tmp_path / "vault"
+    settings_dir = vault / "@Settings"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    (settings_dir / "watchers.md").write_text("---\n---\n", encoding="utf-8")
+    panel_actions = tmp_path / "panel-actions.md"
+    panel_actions.write_text(
+        "---\n"
+        "mappings:\n"
+        "  - id: promote.evergreen\n"
+        "    label: Promote\n"
+        "    intent_type: promotion\n"
+        "    downstream_event: promote.intent.created\n"
+        "    params:\n"
+        "      maturity: evergreen\n"
+        "---\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("VAULT_ROOT", str(vault))
+    monkeypatch.setenv("PANEL_ACTIONS_PATH", str(panel_actions))
+    monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+    monkeypatch.setenv("DATABASE_URL", "postgresql+psycopg://custom:pw@db:5432/custom_db")
+
+    payload = build_settings_explain_payload()
+    assert payload["database_url"].endswith("/custom_db")

--- a/tests/config/test_database_resolution.py
+++ b/tests/config/test_database_resolution.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from app.config.database import resolve_runtime_database_url
+
+
+def test_runtime_database_url_differs_between_dev_and_prod_without_explicit_override() -> None:
+    dev = resolve_runtime_database_url({"PKM_ENVIRONMENT": "dev"})
+    prod = resolve_runtime_database_url({"PKM_ENVIRONMENT": "prod"})
+
+    assert dev.endswith("/app_dev")
+    assert prod.endswith("/app")
+    assert dev != prod
+
+
+def test_explicit_database_url_override_bypasses_environment_convention() -> None:
+    explicit = "postgresql+psycopg://custom:pw@localhost:5432/custom_db"
+    resolved = resolve_runtime_database_url(
+        {
+            "PKM_ENVIRONMENT": "dev",
+            "DATABASE_URL": explicit,
+            "PKM_DB_NAME_DEV": "ignored_db",
+        }
+    )
+    assert resolved == explicit


### PR DESCRIPTION
Fixes #594

## Summary
- add runtime DB URL resolver with environment convention (`prod=app`, `dev=app_dev`) and explicit override precedence
- wire DB resolver into runtime DB connection path and `settings-explain` payload
- set `docker-compose.dev.yml` to `app_dev` and `docker-compose.test.yml` to `app_test`
- make `start-test-system` and `test-bootstrap` explicitly use `app_test`
- update environment docs to remove the shared-DB caveat and document per-environment DB convention

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/pytest -q tests/config/ -m "not pg"`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/pytest -q tests/config/test_database_resolution.py tests/cli/test_settings_explain_cli.py`