### PR TITLE
Add Priority 2b feature-breakdown specification directory

### DIFF
--- a/docs/SCOPE_SPHERE_SITUATED_IDENTITY/DEFINE_CONTEXT_DIMENSION_PAYLOAD_CONTRACT.md
+++ b/docs/SCOPE_SPHERE_SITUATED_IDENTITY/DEFINE_CONTEXT_DIMENSION_PAYLOAD_CONTRACT.md
@@ -1,0 +1,62 @@
+---
+name: Define Context Dimension Payload Contract
+description: Specify explicit runtime payload fields that separate scope, sphere, and situated identity.
+task_id: SSI-01
+source_anchor: docs/plans/V60_COGNITIVE_SUPPORT_PRIORITIES.md :: Priority 2b — Scope, sphere, and situated identity as distinct properties (v6.0 enabling)
+parent_capability: Scope, sphere, and situated identity as distinct properties
+prerequisites: []
+depends_on: []
+can_parallelize_with: [THREAD_SCOPE_SPHERE_IDENTITY_THROUGH_RUNTIME_PATHS, EXPOSE_CONTEXT_DIMENSIONS_IN_STATUS_AND_RECEIPTS]
+---
+
+# Define Context Dimension Payload Contract
+
+## Purpose
+
+Define one explicit payload contract that keeps scope, sphere, and situated identity distinct in runtime-facing context objects.
+
+## What This Task Does
+
+- Defines canonical field names and semantics for scope, sphere membership, and situated identity.
+- Defines required/optional rules and nullability semantics.
+- Defines backward-compatible mapping rules from existing context/domain surfaces.
+
+## Concretely
+
+- Add contract doc section and examples for payloads with separated dimensions.
+- Provide one migration mapping example from legacy single-domain context to separated dimensions.
+- Define invariant statements forbidding collapse of sphere/identity into scope.
+
+## Why This Matters
+
+Without an explicit payload contract, downstream implementation tasks will encode incompatible context shapes and reintroduce semantic collapse.
+
+## Acceptance Criteria
+
+- [ ] Canonical payload contract names and semantics are specified for scope, sphere, and situated identity.  
+  Verify: doc writeback at `docs/SCOPE_SPHERE_SITUATED_IDENTITY/DEFINE_CONTEXT_DIMENSION_PAYLOAD_CONTRACT.md`.
+- [ ] Nullability/optionality and backward-compatible mapping rules are specified.  
+  Verify: doc writeback at `docs/SCOPE_SPHERE_SITUATED_IDENTITY/DEFINE_CONTEXT_DIMENSION_PAYLOAD_CONTRACT.md`.
+- [ ] Invariants explicitly forbid collapsing these dimensions into one field.  
+  Verify: doc writeback at `docs/SCOPE_SPHERE_SITUATED_IDENTITY/DEFINE_CONTEXT_DIMENSION_PAYLOAD_CONTRACT.md`.
+
+## How to Verify (Pre-Merge)
+
+- `rg -n "scope|sphere|situated identity|invariant|backward" docs/SCOPE_SPHERE_SITUATED_IDENTITY/DEFINE_CONTEXT_DIMENSION_PAYLOAD_CONTRACT.md`
+- Reviewer confirms each AC has a concrete matching section in this doc.
+
+## Out of Scope
+
+- Runtime code changes.
+- Database schema changes.
+
+## Related Docs
+
+- `docs/CONCEPTS/CONTEXT_MODEL_DECISION_FRAME.md`
+- `docs/CONCEPTS/CONTEXT_TERMINOLOGY_CONTRACT.md`
+- `docs/CONCEPTS/COGNITIVE_AXES_AND_SPHERES.md`
+
+## Related GitHub Issues
+
+- Parent: `docs/SCOPE_SPHERE_SITUATED_IDENTITY/PARENT_FEATURE_ISSUE.md`
+- Follow-up implementation issue: to be created from this task spec.

--- a/docs/SCOPE_SPHERE_SITUATED_IDENTITY/EXPOSE_CONTEXT_DIMENSIONS_IN_STATUS_AND_RECEIPTS.md
+++ b/docs/SCOPE_SPHERE_SITUATED_IDENTITY/EXPOSE_CONTEXT_DIMENSIONS_IN_STATUS_AND_RECEIPTS.md
@@ -1,0 +1,62 @@
+---
+name: Expose Context Dimensions in Status and Receipts
+description: Specify operator-visible reporting for separated scope/sphere/identity context dimensions.
+task_id: SSI-03
+source_anchor: docs/plans/V60_COGNITIVE_SUPPORT_PRIORITIES.md :: Priority 2b — Scope, sphere, and situated identity as distinct properties (v6.0 enabling)
+parent_capability: Scope, sphere, and situated identity as distinct properties
+prerequisites: [SSI-01]
+depends_on: [DEFINE_CONTEXT_DIMENSION_PAYLOAD_CONTRACT.md]
+can_parallelize_with: [THREAD_SCOPE_SPHERE_IDENTITY_THROUGH_RUNTIME_PATHS]
+---
+
+# Expose Context Dimensions in Status and Receipts
+
+## Purpose
+
+Define how separated context dimensions become operator-visible in receipts/status surfaces without mutating user artifacts.
+
+## What This Task Does
+
+- Specifies status surface fields for context-dimension visibility.
+- Specifies receipt/event metadata representation for scope/sphere/identity.
+- Defines redaction/safety posture for operator-facing outputs.
+
+## Concretely
+
+- Add one status payload example and one receipt payload example.
+- Define required reporting fields and allowed omissions.
+- Define privacy/guardrail notes for identity-related outputs.
+
+## Why This Matters
+
+If context dimensions are not visible in operator surfaces, drift cannot be detected and downstream priorities lose auditability.
+
+## Acceptance Criteria
+
+- [ ] Status/receipt representation of scope/sphere/identity is explicitly specified.  
+  Verify: doc writeback at `docs/SCOPE_SPHERE_SITUATED_IDENTITY/EXPOSE_CONTEXT_DIMENSIONS_IN_STATUS_AND_RECEIPTS.md`.
+- [ ] Required fields and allowed omissions are defined.  
+  Verify: doc writeback at `docs/SCOPE_SPHERE_SITUATED_IDENTITY/EXPOSE_CONTEXT_DIMENSIONS_IN_STATUS_AND_RECEIPTS.md`.
+- [ ] Guardrail notes for operator-visible identity semantics are documented.  
+  Verify: doc writeback at `docs/SCOPE_SPHERE_SITUATED_IDENTITY/EXPOSE_CONTEXT_DIMENSIONS_IN_STATUS_AND_RECEIPTS.md`.
+
+## How to Verify (Pre-Merge)
+
+- `rg -n "status|receipt|required|omission|guardrail|identity" docs/SCOPE_SPHERE_SITUATED_IDENTITY/EXPOSE_CONTEXT_DIMENSIONS_IN_STATUS_AND_RECEIPTS.md`
+- Reviewer confirms examples match SSI-01 contract semantics.
+
+## Out of Scope
+
+- Building UI/UX surfaces.
+- Runtime telemetry implementation.
+
+## Related Docs
+
+- `docs/OBSERVABILITY.md`
+- `docs/OPERATIONS.md`
+- `docs/CONCEPTS/CONTEXT_TERMINOLOGY_CONTRACT.md`
+
+## Related GitHub Issues
+
+- Parent: `docs/SCOPE_SPHERE_SITUATED_IDENTITY/PARENT_FEATURE_ISSUE.md`
+- Follow-up implementation issue: to be created from this task spec.

--- a/docs/SCOPE_SPHERE_SITUATED_IDENTITY/PARENT_FEATURE_ISSUE.md
+++ b/docs/SCOPE_SPHERE_SITUATED_IDENTITY/PARENT_FEATURE_ISSUE.md
@@ -1,0 +1,77 @@
+## Context
+
+Priority 2b in `docs/plans/V60_COGNITIVE_SUPPORT_PRIORITIES.md` requires separating scope, sphere, and situated identity as distinct properties. The capability currently has no specification directory, so implementation cannot be safely decomposed into bounded, independently verifiable tasks.
+
+This parent issue draft defines the capability-level contract and acceptance path for the new `docs/SCOPE_SPHERE_SITUATED_IDENTITY/` specification.
+
+## Scope
+
+- establish one capability specification directory for scope/sphere/situated-identity separation,
+- define bounded implementation tasks with explicit acceptance and verification markers,
+- define parent-level verification and validation/acceptance path,
+- keep this slice docs-only (no runtime/schema changes).
+
+## Source Anchors
+
+- `docs/plans/V60_COGNITIVE_SUPPORT_PRIORITIES.md` :: Priority 2b — Scope, sphere, and situated identity as distinct properties (v6.0 enabling)
+- `docs/plans/V60_COGNITIVE_SUPPORT_PRIORITIES.md` :: Relation To Existing Capability Specifications
+- `docs/CONCEPTS/CONTEXT_MODEL_DECISION_FRAME.md`
+- `docs/CONCEPTS/CONTEXT_TERMINOLOGY_CONTRACT.md`
+- `docs/CONCEPTS/COGNITIVE_AXES_AND_SPHERES.md`
+- `.codex/skills/feature-breakdown/SKILL.md`
+
+## Constraints
+
+- docs-only for this feature-breakdown slice,
+- task specs must satisfy feature-breakdown frontmatter and section contracts,
+- task specs must be independently mergeable/verifiable,
+- no duplication of concept-contract semantics where references are sufficient.
+
+## Acceptance Criteria
+
+- [ ] Specification directory exists with capability README, execution order, and acceptance path.  
+  Verify: `docs/SCOPE_SPHERE_SITUATED_IDENTITY/README.md`.
+- [ ] Bounded task files exist with required frontmatter and required sections.  
+  Verify: `docs/SCOPE_SPHERE_SITUATED_IDENTITY/*.md` task files.
+- [ ] Parent issue draft exists with full feature-issue section contract and linked implementation tasks.  
+  Verify: `docs/SCOPE_SPHERE_SITUATED_IDENTITY/PARENT_FEATURE_ISSUE.md`.
+- [ ] Dependency notes identify gating impact on Priorities 3–5.  
+  Verify: `docs/SCOPE_SPHERE_SITUATED_IDENTITY/README.md` dependency notes section.
+
+## Out of Scope
+
+- runtime code, migrations, schema updates,
+- creation of child implementation issues,
+- owner-doc promotion claiming capability support as shipped.
+
+## Suggested Validation
+
+- `rg -n "^---$|^task_id:|^source_anchor:|^parent_capability:" docs/SCOPE_SPHERE_SITUATED_IDENTITY/*.md`
+- `rg -n "^## (Purpose|What This Task Does|Concretely|Why This Matters|Acceptance Criteria|How to Verify \(Pre-Merge\)|Out of Scope|Related Docs|Related GitHub Issues)" docs/SCOPE_SPHERE_SITUATED_IDENTITY/*.md`
+- `rg -n "^## (Context|Scope|Source Anchors|Constraints|Acceptance Criteria|Out of Scope|Suggested Validation|Source Docs|Implementation Tasks|Verification Path|Validation / Acceptance Path)" docs/SCOPE_SPHERE_SITUATED_IDENTITY/PARENT_FEATURE_ISSUE.md`
+
+## Source Docs
+
+- `docs/plans/V60_COGNITIVE_SUPPORT_PRIORITIES.md`
+- `docs/CONCEPTS/CONTEXT_MODEL_DECISION_FRAME.md`
+- `docs/CONCEPTS/CONTEXT_TERMINOLOGY_CONTRACT.md`
+- `docs/CONCEPTS/COGNITIVE_AXES_AND_SPHERES.md`
+- `.codex/skills/feature-breakdown/SKILL.md`
+
+## Implementation Tasks
+
+- `docs/SCOPE_SPHERE_SITUATED_IDENTITY/DEFINE_CONTEXT_DIMENSION_PAYLOAD_CONTRACT.md`
+- `docs/SCOPE_SPHERE_SITUATED_IDENTITY/THREAD_SCOPE_SPHERE_IDENTITY_THROUGH_RUNTIME_PATHS.md`
+- `docs/SCOPE_SPHERE_SITUATED_IDENTITY/EXPOSE_CONTEXT_DIMENSIONS_IN_STATUS_AND_RECEIPTS.md`
+- `docs/SCOPE_SPHERE_SITUATED_IDENTITY/VALIDATE_SCOPE_SPHERE_IDENTITY_SEPARATION.md`
+
+## Verification Path
+
+- Task-level verification follows each task's `How to Verify (Pre-Merge)` section.
+- Verification evidence is recorded on child task PRs before merge.
+
+## Validation / Acceptance Path
+
+- Parent issue remains open while task slices land.
+- Cross-surface validation scenarios are executed per `VALIDATE_SCOPE_SPHERE_IDENTITY_SEPARATION.md`.
+- Owner-doc promotion occurs only after parent acceptance criteria and validation receipts are complete.

--- a/docs/SCOPE_SPHERE_SITUATED_IDENTITY/README.md
+++ b/docs/SCOPE_SPHERE_SITUATED_IDENTITY/README.md
@@ -1,0 +1,57 @@
+# Scope, Sphere, and Situated Identity
+
+## Capability Boundary
+
+This specification directory defines the v6.0 enabling capability that separates:
+- operational scope,
+- sphere membership,
+- situated identity,
+
+as distinct, non-collapsed runtime properties.
+
+The purpose is to prevent context semantics from collapsing back into a single `domain` concept while preserving current shipped v5.x behavior until bounded implementation tasks land.
+
+## Execution Order
+
+1. `DEFINE_CONTEXT_DIMENSION_PAYLOAD_CONTRACT.md`
+2. `THREAD_SCOPE_SPHERE_IDENTITY_THROUGH_RUNTIME_PATHS.md`
+3. `EXPOSE_CONTEXT_DIMENSIONS_IN_STATUS_AND_RECEIPTS.md`
+4. `VALIDATE_SCOPE_SPHERE_IDENTITY_SEPARATION.md`
+
+## Acceptance Path
+
+This capability is accepted when:
+- all task-level acceptance criteria in this directory are merged with passing verification receipts,
+- parent feature validation evidence confirms scope/sphere/identity remain distinct across runtime surfaces,
+- downstream priority consumers can bind to explicit context dimensions without reintroducing single-domain collapse.
+
+## Verification Path
+
+- Task-level verification runs on each task issue/PR using each task file's `How to Verify (Pre-Merge)` section.
+- Parent validation evidence is collected on the parent feature issue before owner-doc promotion.
+
+## Validation / Acceptance Path
+
+- Keep parent feature issue open as the validation hub while task issues merge.
+- After all task issues merge, run cross-surface acceptance checks from `VALIDATE_SCOPE_SPHERE_IDENTITY_SEPARATION.md`.
+- Promote owner-doc claims only after validation receipts show the capability is supported truthfully.
+
+## Dependency Notes (Priority 3-5)
+
+This capability gates later priorities in `docs/plans/V60_COGNITIVE_SUPPORT_PRIORITIES.md`:
+- Priority 3 (receipts + SUGGEST/APPLY gating) depends on context dimensions being explicit so receipts can report correct context provenance.
+- Priority 4 (retrieval capability extraction) depends on distinct scope/sphere/identity inputs rather than one overloaded context field.
+- Priority 5 (commitment runtime minimum) depends on stable context dimensions so commitment semantics do not inherit ambiguous domain-like context.
+
+## Related Docs
+
+- `docs/plans/V60_COGNITIVE_SUPPORT_PRIORITIES.md`
+- `docs/CONCEPTS/CONTEXT_MODEL_DECISION_FRAME.md`
+- `docs/CONCEPTS/CONTEXT_TERMINOLOGY_CONTRACT.md`
+- `docs/CONCEPTS/COGNITIVE_AXES_AND_SPHERES.md`
+- `.codex/skills/feature-breakdown/SKILL.md`
+
+## Related GitHub Issues
+
+- Parent feature issue draft: `PARENT_FEATURE_ISSUE.md` in this directory.
+- Task implementation issues are intentionally not created in this slice; they are follow-up backlog work.

--- a/docs/SCOPE_SPHERE_SITUATED_IDENTITY/THREAD_SCOPE_SPHERE_IDENTITY_THROUGH_RUNTIME_PATHS.md
+++ b/docs/SCOPE_SPHERE_SITUATED_IDENTITY/THREAD_SCOPE_SPHERE_IDENTITY_THROUGH_RUNTIME_PATHS.md
@@ -1,0 +1,62 @@
+---
+name: Thread Scope, Sphere, and Identity Through Runtime Paths
+description: Specify where the separated context dimensions enter, transform, and exit runtime surfaces.
+task_id: SSI-02
+source_anchor: docs/plans/V60_COGNITIVE_SUPPORT_PRIORITIES.md :: Priority 2b — Scope, sphere, and situated identity as distinct properties (v6.0 enabling)
+parent_capability: Scope, sphere, and situated identity as distinct properties
+prerequisites: [SSI-01]
+depends_on: [DEFINE_CONTEXT_DIMENSION_PAYLOAD_CONTRACT.md]
+can_parallelize_with: [EXPOSE_CONTEXT_DIMENSIONS_IN_STATUS_AND_RECEIPTS]
+---
+
+# Thread Scope, Sphere, and Identity Through Runtime Paths
+
+## Purpose
+
+Define a bounded runtime threading map so separated context dimensions survive through ingest/orchestrator/panel paths without semantic collapse.
+
+## What This Task Does
+
+- Enumerates runtime entrypoints where context is read.
+- Enumerates transformation points where context must preserve dimension separation.
+- Enumerates output surfaces where context dimensions must remain explicit.
+
+## Concretely
+
+- Add path map for watcher/orchestrator/panel/receipts surfaces.
+- Add explicit "must preserve" checkpoints and failure modes.
+- Add compatibility notes for incremental rollout.
+
+## Why This Matters
+
+Without a threading map, implementation can partially preserve dimensions in one path and lose them in another, creating hidden regressions.
+
+## Acceptance Criteria
+
+- [ ] Runtime path map names entry, transform, and output points that touch context semantics.  
+  Verify: doc writeback at `docs/SCOPE_SPHERE_SITUATED_IDENTITY/THREAD_SCOPE_SPHERE_IDENTITY_THROUGH_RUNTIME_PATHS.md`.
+- [ ] Each path stage includes preservation checkpoints for scope/sphere/identity separation.  
+  Verify: doc writeback at `docs/SCOPE_SPHERE_SITUATED_IDENTITY/THREAD_SCOPE_SPHERE_IDENTITY_THROUGH_RUNTIME_PATHS.md`.
+- [ ] Incremental rollout and compatibility notes are explicit.  
+  Verify: doc writeback at `docs/SCOPE_SPHERE_SITUATED_IDENTITY/THREAD_SCOPE_SPHERE_IDENTITY_THROUGH_RUNTIME_PATHS.md`.
+
+## How to Verify (Pre-Merge)
+
+- `rg -n "entry|transform|output|checkpoint|compatibility" docs/SCOPE_SPHERE_SITUATED_IDENTITY/THREAD_SCOPE_SPHERE_IDENTITY_THROUGH_RUNTIME_PATHS.md`
+- Reviewer confirms each AC has explicit corresponding passages.
+
+## Out of Scope
+
+- Implementing runtime code.
+- Updating owner-doc support claims.
+
+## Related Docs
+
+- `docs/ARCHITECTURE.md`
+- `docs/CONCEPTS/CONTEXT_MODEL_DECISION_FRAME.md`
+- `docs/plans/V60_COGNITIVE_SUPPORT_PRIORITIES.md`
+
+## Related GitHub Issues
+
+- Parent: `docs/SCOPE_SPHERE_SITUATED_IDENTITY/PARENT_FEATURE_ISSUE.md`
+- Follow-up implementation issue: to be created from this task spec.

--- a/docs/SCOPE_SPHERE_SITUATED_IDENTITY/VALIDATE_SCOPE_SPHERE_IDENTITY_SEPARATION.md
+++ b/docs/SCOPE_SPHERE_SITUATED_IDENTITY/VALIDATE_SCOPE_SPHERE_IDENTITY_SEPARATION.md
@@ -1,0 +1,62 @@
+---
+name: Validate Scope, Sphere, and Identity Separation
+description: Specify cross-surface validation scenarios proving context dimensions stay distinct.
+task_id: SSI-04
+source_anchor: docs/plans/V60_COGNITIVE_SUPPORT_PRIORITIES.md :: Priority 2b — Scope, sphere, and situated identity as distinct properties (v6.0 enabling)
+parent_capability: Scope, sphere, and situated identity as distinct properties
+prerequisites: [SSI-01, SSI-02, SSI-03]
+depends_on: [DEFINE_CONTEXT_DIMENSION_PAYLOAD_CONTRACT.md, THREAD_SCOPE_SPHERE_IDENTITY_THROUGH_RUNTIME_PATHS.md, EXPOSE_CONTEXT_DIMENSIONS_IN_STATUS_AND_RECEIPTS.md]
+can_parallelize_with: []
+---
+
+# Validate Scope, Sphere, and Identity Separation
+
+## Purpose
+
+Define validation scenarios and acceptance receipts that prove separated context dimensions remain distinct across implemented runtime surfaces.
+
+## What This Task Does
+
+- Defines scenario matrix that would catch dimension collapse.
+- Defines expected outputs per scenario in status/receipt/runtime surfaces.
+- Defines parent-issue acceptance evidence requirements.
+
+## Concretely
+
+- Add at least three scenario classes: scope-only change, sphere-only change, identity-only change.
+- Add failure signatures indicating collapse into one field.
+- Add receipt checklist for parent feature issue closure.
+
+## Why This Matters
+
+Capability acceptance requires proof of separation under realistic scenarios, not just contract text.
+
+## Acceptance Criteria
+
+- [ ] Validation scenarios cover independent variation of scope, sphere, and identity.  
+  Verify: doc writeback at `docs/SCOPE_SPHERE_SITUATED_IDENTITY/VALIDATE_SCOPE_SPHERE_IDENTITY_SEPARATION.md`.
+- [ ] Expected outputs and collapse failure signatures are specified.  
+  Verify: doc writeback at `docs/SCOPE_SPHERE_SITUATED_IDENTITY/VALIDATE_SCOPE_SPHERE_IDENTITY_SEPARATION.md`.
+- [ ] Parent feature acceptance receipt checklist is defined.  
+  Verify: doc writeback at `docs/SCOPE_SPHERE_SITUATED_IDENTITY/VALIDATE_SCOPE_SPHERE_IDENTITY_SEPARATION.md`.
+
+## How to Verify (Pre-Merge)
+
+- `rg -n "scenario|scope-only|sphere-only|identity-only|failure signature|receipt checklist" docs/SCOPE_SPHERE_SITUATED_IDENTITY/VALIDATE_SCOPE_SPHERE_IDENTITY_SEPARATION.md`
+- Reviewer confirms all scenario classes map to acceptance criteria.
+
+## Out of Scope
+
+- Running implementation validation itself.
+- Closing the parent feature issue in this docs-only slice.
+
+## Related Docs
+
+- `docs/TESTING.md`
+- `docs/plans/V60_COGNITIVE_SUPPORT_PRIORITIES.md`
+- `docs/SCOPE_SPHERE_SITUATED_IDENTITY/README.md`
+
+## Related GitHub Issues
+
+- Parent: `docs/SCOPE_SPHERE_SITUATED_IDENTITY/PARENT_FEATURE_ISSUE.md`
+- Follow-up implementation issue: to be created from this task spec.


### PR DESCRIPTION
Fixes #567

## Summary
- add docs/SCOPE_SPHERE_SITUATED_IDENTITY/ as the Priority 2b capability specification directory
- add capability README with execution order, acceptance path, and Priority 3-5 dependency notes
- add four bounded task specification files with required frontmatter/section contracts
- add PARENT_FEATURE_ISSUE.md draft with the full parent issue section contract

## Validation
- rg -n "^---$|^task_id:|^source_anchor:|^parent_capability:" docs/SCOPE_SPHERE_SITUATED_IDENTITY/*.md
- rg -n "^## (Purpose|What This Task Does|Concretely|Why This Matters|Acceptance Criteria|How to Verify \(Pre-Merge\)|Out of Scope|Related Docs|Related GitHub Issues)" docs/SCOPE_SPHERE_SITUATED_IDENTITY/*.md
- rg -n "^## (Context|Scope|Source Anchors|Constraints|Acceptance Criteria|Out of Scope|Suggested Validation|Source Docs|Implementation Tasks|Verification Path|Validation / Acceptance Path)" docs/SCOPE_SPHERE_SITUATED_IDENTITY/PARENT_FEATURE_ISSUE.md