### PR TITLE
[Canvas Chat] write-session-logs: session log writer and chat-session artifact class

### DIFF
--- a/app/chat/session_log.py
+++ b/app/chat/session_log.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+import re
+from typing import Callable
+from uuid import uuid4
+
+
+@dataclass(frozen=True)
+class SessionLog:
+    log_path: Path
+    session_id: str
+    note_path: Path
+    label: str
+
+
+class SessionLogWriter:
+    def __init__(
+        self,
+        *,
+        vault_root: Path,
+        now_fn: Callable[[], datetime] | None = None,
+        uuid_fn: Callable[[], str] | None = None,
+    ) -> None:
+        self._vault_root = vault_root
+        self._now_fn = now_fn or datetime.now
+        self._uuid_fn = uuid_fn or (lambda: str(uuid4()))
+
+    def open_session(self, note_path: Path, session_label: str) -> SessionLog:
+        now = self._now_fn()
+        note_slug = _slugify(note_path.stem)
+        label_slug = _slugify(session_label)
+        ts_file = now.strftime("%Y-%m-%dT%H-%M")
+        ts_frontmatter = now.strftime("%Y-%m-%dT%H:%M")
+        session_id = self._uuid_fn()
+
+        session_dir = self._vault_root / ".chats" / note_slug
+        session_dir.mkdir(parents=True, exist_ok=True)
+        log_path = session_dir / f"{ts_file}-{label_slug}.md"
+
+        note_title = note_path.stem
+        frontmatter = (
+            "---\n"
+            "type: chat-session\n"
+            f'note: "[[{note_title}]]"\n'
+            f"date: {ts_frontmatter}\n"
+            f"session_id: {session_id}\n"
+            "---\n\n"
+            f"## Session: {label_slug}\n\n"
+        )
+        log_path.write_text(frontmatter, encoding="utf-8")
+        return SessionLog(log_path=log_path, session_id=session_id, note_path=note_path, label=label_slug)
+
+    def append_turn(self, session: SessionLog, user_prompt: str, change_summary: str) -> None:
+        with session.log_path.open("a", encoding="utf-8") as handle:
+            handle.write(f"**User:** {user_prompt}\n")
+            handle.write(f"**Change:** {change_summary}\n\n")
+
+    def close_session(self, session: SessionLog, total_summary: str) -> None:
+        with session.log_path.open("a", encoding="utf-8") as handle:
+            handle.write("---\n")
+            handle.write(f"*Session closed. Total: {total_summary}.*\n")
+
+
+def _slugify(value: str) -> str:
+    lowered = value.strip().lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", lowered)
+    slug = slug.strip("-")
+    return slug or "session"
+
+
+__all__ = ["SessionLog", "SessionLogWriter"]

--- a/tests/chat/test_session_log_writer.py
+++ b/tests/chat/test_session_log_writer.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from app.chat.session_log import SessionLogWriter
+
+pytestmark = pytest.mark.not_pg
+
+
+def _writer(vault_root: Path) -> SessionLogWriter:
+    fixed_now = datetime(2026, 4, 24, 7, 30)
+    return SessionLogWriter(vault_root=vault_root, now_fn=lambda: fixed_now, uuid_fn=lambda: "session-uuid")
+
+
+def test_open_creates_file_in_chats_namespace(tmp_path: Path) -> None:
+    writer = _writer(tmp_path)
+    note = tmp_path / "notes" / "My Design Decision.md"
+    session = writer.open_session(note, "restructure decision section")
+
+    assert session.log_path.exists()
+    assert "/.chats/" in str(session.log_path)
+
+
+def test_log_path_uses_note_slug_and_timestamp(tmp_path: Path) -> None:
+    writer = _writer(tmp_path)
+    note = tmp_path / "notes" / "My Design Decision.md"
+    session = writer.open_session(note, "restructure decision section")
+
+    assert session.log_path.parent == tmp_path / ".chats" / "my-design-decision"
+    assert session.log_path.name.startswith("2026-04-24T07-30-")
+    assert session.log_path.name.endswith("restructure-decision-section.md")
+
+
+def test_frontmatter_fields_present(tmp_path: Path) -> None:
+    writer = _writer(tmp_path)
+    note = tmp_path / "notes" / "My Design Decision.md"
+    session = writer.open_session(note, "restructure decision section")
+
+    text = session.log_path.read_text(encoding="utf-8")
+    assert "type: chat-session" in text
+    assert 'note: "[[My Design Decision]]"' in text
+    assert "date: 2026-04-24T07:30" in text
+    assert "session_id: session-uuid" in text
+
+
+def test_type_field_is_chat_session_only(tmp_path: Path) -> None:
+    writer = _writer(tmp_path)
+    note = tmp_path / "notes" / "My Design Decision.md"
+    session = writer.open_session(note, "session")
+
+    text = session.log_path.read_text(encoding="utf-8")
+    assert text.count("type: chat-session") == 1
+
+
+def test_append_does_not_rewrite_prior_content(tmp_path: Path) -> None:
+    writer = _writer(tmp_path)
+    note = tmp_path / "notes" / "My Design Decision.md"
+    session = writer.open_session(note, "session")
+    baseline = session.log_path.read_text(encoding="utf-8")
+
+    writer.append_turn(session, "Can you move the rationale?", "Moved rationale to dedicated section")
+
+    updated = session.log_path.read_text(encoding="utf-8")
+    assert baseline in updated
+    assert "**User:** Can you move the rationale?" in updated
+    assert "**Change:** Moved rationale to dedicated section" in updated
+
+
+def test_close_session_appends_closure_line(tmp_path: Path) -> None:
+    writer = _writer(tmp_path)
+    note = tmp_path / "notes" / "My Design Decision.md"
+    session = writer.open_session(note, "session")
+
+    writer.close_session(session, "One structural edit")
+
+    text = session.log_path.read_text(encoding="utf-8")
+    assert "*Session closed. Total: One structural edit.*" in text


### PR DESCRIPTION
Fixes #598

## Summary
- add `app/chat/session_log.py` with `SessionLogWriter`, `open_session`, `append_turn`, `close_session`
- write append-only session logs under `vault/.chats/<note-slug>/<timestamp>-<label>.md`
- include required frontmatter fields (`type: chat-session`, `note`, `date`, `session_id`)
- add acceptance tests in `tests/chat/test_session_log_writer.py`

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/chat/test_session_log_writer.py -m "not pg" -q`
