### PR TITLE
fix: set PKM_ENVIRONMENT=test in docker-compose.test.yml

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -9,18 +9,18 @@ services:
     ports:
       - "18002:8000"
     environment:
-      PKM_ENVIRONMENT: dev
+      PKM_ENVIRONMENT: test
       DATABASE_URL: postgresql+psycopg://app:app@db:5432/app_test
       DB_DSN: postgresql+psycopg://app:app@db:5432/app_test
 
   worker:
     environment:
-      PKM_ENVIRONMENT: dev
+      PKM_ENVIRONMENT: test
       DATABASE_URL: postgresql+psycopg://app:app@db:5432/app_test
       DB_DSN: postgresql+psycopg://app:app@db:5432/app_test
 
   watcher:
     environment:
-      PKM_ENVIRONMENT: dev
+      PKM_ENVIRONMENT: test
       DATABASE_URL: postgresql+psycopg://app:app@db:5432/app_test
       DB_DSN: postgresql+psycopg://app:app@db:5432/app_test


### PR DESCRIPTION
## Summary
- All three service definitions (`api`, `worker`, `watcher`) in `docker-compose.test.yml` had `PKM_ENVIRONMENT: dev` — a copy-paste error from the dev override file
- Fixed to `PKM_ENVIRONMENT: test` so the test stack correctly identifies itself at runtime (feature flags, vault path selection, environment diagnostics all key off this value)

## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Fixes #620

## Test plan
- [ ] `rg -n "PKM_ENVIRONMENT" docker-compose.test.yml` → all lines show `test`
- [ ] `rg -n "PKM_ENVIRONMENT" docker-compose.dev.yml` → all lines still show `dev` (unchanged)
- [ ] `python -m app.cli health --json` against a test stack confirms `"environment": "test"`