### PR TITLE
docs: add CANVAS_CHAT_SURFACE specification directory

### DIFF
--- a/docs/CANVAS_CHAT_SURFACE/CO_AUTHOR_NOTE_BODY.md
+++ b/docs/CANVAS_CHAT_SURFACE/CO_AUTHOR_NOTE_BODY.md
@@ -1,0 +1,128 @@
+---
+name: Co-Author Note Body
+description: Implement the in-place body editing path for the currently-open note during a canvas session — authorized by user presence, written through KnowledgePort, scoped strictly to the note body.
+task_id: CANVAS-02
+source_anchor: docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CANVAS_COEDITING_MODEL.md :: The Canvas Co-Editing Posture
+parent_capability: Canvas Chat Surface
+prerequisites: [CANVAS-01]
+depends_on: [WRITE_SESSION_LOGS.md]
+can_parallelize_with: []
+---
+
+State: Specification. Not yet implemented.
+
+# Co-Author Note Body
+
+## Purpose
+
+This task implements the core canvas posture: edits apply to the note body directly during an active session, authorized by the fact that the user opened the session. The user experiences this as co-authoring, not as reviewing diffs.
+
+## What This Task Does
+
+Implements the co-authoring write path:
+
+1. **Session context** — a canvas session is open on exactly one note. The session object (from WRITE_SESSION_LOGS) carries the note path and the authorization signal.
+
+2. **Body-scoped writer** — `app/chat/canvas_writer.py` (new) with `CanvasWriter`:
+   - `apply_edit(session, new_body: str)` — replaces the note body while preserving frontmatter
+   - Writes through `app/knowledge/write_ops.py` (the existing KnowledgePort boundary) so vault-write policy, idempotency, and optimistic-lock semantics apply
+   - Appends a change summary to the session log via `SessionLogWriter.append_turn`
+
+3. **Scope enforcement** — `CanvasWriter` raises `GovernanceBearingMutationError` if:
+   - the caller attempts to modify frontmatter fields directly (classification, `type`, `maturity`, `review_state`, scope/sphere tags)
+   - the `new_body` targets a path other than `session.note_path`
+   - no session is open (no-session writes are not authorized)
+
+4. **Frontmatter preserved** — the writer reads the current note, separates frontmatter from body, applies the edit to the body only, and reassembles. Frontmatter is never touched by the co-authoring path.
+
+5. **Undo semantics** — because writes go to the vault file immediately, Obsidian's file watcher picks up saves normally. Undo is the user's own editor undo, not a system-level rollback mechanism.
+
+## Concretely
+
+```python
+from pathlib import Path
+from app.chat.session_log import SessionLogWriter
+from app.chat.canvas_writer import CanvasWriter
+
+log_writer = SessionLogWriter(vault_root=Path("vault"))
+canvas = CanvasWriter(vault_root=Path("vault"), log_writer=log_writer)
+
+session = log_writer.open_session(
+    note_path=Path("vault/notes/my-note.md"),
+    session_label="expand-context-section"
+)
+
+canvas.apply_edit(
+    session=session,
+    new_body="## Context\n\nExpanded rationale here...\n\n## Decision\n...",
+    change_summary="Expanded Context section with three new paragraphs"
+)
+```
+
+Attempting to write frontmatter via co-authoring path raises:
+```python
+canvas.apply_edit(session, new_body="---\nmaturity: evergreen\n---\n\nBody")
+# raises GovernanceBearingMutationError: frontmatter modification is governance-bearing
+```
+
+## Why This Matters
+
+The co-authoring path is the thing that makes canvas Chat feel like a collaborative editor rather than a chat interface. Without it, every edit is either a suggestion to approve or a mutation that bypasses the KnowledgePort boundary — both failure modes the spec names explicitly. This task ensures edits land in the vault via the same controlled boundary as all other system-originated writes, while staying strictly scoped to the note body.
+
+## Acceptance Criteria
+
+- [ ] `app/chat/canvas_writer.py` exists with `CanvasWriter` and `apply_edit`.
+  - Verify: `tests/chat/test_canvas_writer.py::test_apply_edit_writes_body_to_vault`
+- [ ] `apply_edit` preserves existing frontmatter unchanged.
+  - Verify: `tests/chat/test_canvas_writer.py::test_apply_edit_preserves_frontmatter`
+- [ ] `apply_edit` raises `GovernanceBearingMutationError` when the new body contains a frontmatter block.
+  - Verify: `tests/chat/test_canvas_writer.py::test_apply_edit_rejects_frontmatter_in_body`
+- [ ] `apply_edit` raises when `session.note_path` does not match the target path.
+  - Verify: `tests/chat/test_canvas_writer.py::test_apply_edit_rejects_cross_note_target`
+- [ ] `apply_edit` raises when called without an open session.
+  - Verify: `tests/chat/test_canvas_writer.py::test_apply_edit_requires_open_session`
+- [ ] Every `apply_edit` call appends a change summary to the session log.
+  - Verify: `tests/chat/test_canvas_writer.py::test_apply_edit_records_turn_in_session_log`
+- [ ] Writes route through `app/knowledge/write_ops.py` (KnowledgePort boundary).
+  - Verify: `tests/chat/test_canvas_writer.py::test_apply_edit_uses_knowledge_port`
+- [ ] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/chat/test_canvas_writer.py -m "not pg" -q` passes.
+
+## How to Verify (Pre-Merge)
+
+```bash
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/chat/test_canvas_writer.py -m "not pg" -q
+
+# Smoke: open session, apply an edit, confirm file updated, frontmatter intact
+python -c "
+from pathlib import Path
+from app.chat.session_log import SessionLogWriter
+from app.chat.canvas_writer import CanvasWriter
+vr = Path('vault-test')
+lw = SessionLogWriter(vault_root=vr)
+cw = CanvasWriter(vault_root=vr, log_writer=lw)
+note = vr / 'notes' / 'test-note.md'
+note.write_text('---\ntype: note\n---\n\nOriginal body.')
+s = lw.open_session(note, 'smoke-edit')
+cw.apply_edit(s, 'Rewritten body.', 'body replaced')
+lw.close_session(s, 'smoke done')
+print(note.read_text())
+# Confirm: frontmatter preserved, body = 'Rewritten body.'
+"
+```
+
+## Out of Scope
+
+- Governance-bearing mutations (frontmatter, cross-note, lifecycle) — those are GATE_GOVERNANCE_BEARING_MUTATIONS.
+- Streaming edits character-by-character — the write path applies a full body replacement per call; streaming is a UI concern deferred until the editor layer is chosen.
+- Multi-note sessions (workspace mode) — explicitly deferred per spec.
+- Conflict resolution or merge when the note has changed externally mid-session.
+
+## Related Docs
+
+- `docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CANVAS_COEDITING_MODEL.md` §The Canvas Co-Editing Posture, §The Authority Split :: Co-authoring
+- `app/knowledge/write_ops.py` — the KnowledgePort boundary this task writes through
+- `docs/CANVAS_CHAT_SURFACE/WRITE_SESSION_LOGS.md` — prerequisite
+
+## Related GitHub Issues
+
+When filed, the issue should reference "Implements CANVAS_CHAT_SURFACE/CO_AUTHOR_NOTE_BODY" and must not expand scope to include governance-bearing mutations or streaming.

--- a/docs/CANVAS_CHAT_SURFACE/EXPOSE_CANVAS_SESSION_API.md
+++ b/docs/CANVAS_CHAT_SURFACE/EXPOSE_CANVAS_SESSION_API.md
@@ -1,0 +1,125 @@
+---
+name: Expose Canvas Session API
+description: Add a bounded API surface for canvas session lifecycle (open, edit, close) so the canvas Chat surface can be driven from outside the process — CLI, API client, or future UI — without committing to an editor library or hosting location.
+task_id: CANVAS-04
+source_anchor: docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CANVAS_COEDITING_MODEL.md :: What This Spec Does Not Do
+parent_capability: Canvas Chat Surface
+prerequisites: [CANVAS-01, CANVAS-02, CANVAS-03]
+depends_on: [WRITE_SESSION_LOGS.md, CO_AUTHOR_NOTE_BODY.md, GATE_GOVERNANCE_BEARING_MUTATIONS.md]
+can_parallelize_with: []
+---
+
+State: Specification. Not yet implemented.
+
+# Expose Canvas Session API
+
+## Purpose
+
+The three prior tasks implement the canvas write path internally. This task makes it externally callable — a bounded API surface that can be driven from a CLI, a test, or a future UI without the caller needing to know about `SessionLogWriter`, `CanvasWriter`, or `GovernanceRouter` directly.
+
+## What This Task Does
+
+1. **FastAPI routes** under `/api/canvas/`:
+   - `POST /api/canvas/sessions` — open a session on a note; returns `session_id` and `note_path`
+   - `POST /api/canvas/sessions/{session_id}/edits` — apply a body edit; body: `{ "new_body": "...", "change_summary": "..." }`; returns updated note content
+   - `POST /api/canvas/sessions/{session_id}/governance` — request a governance action; body: `{ "action_type": "...", "payload": {...} }`; returns `pending_intent_id`
+   - `DELETE /api/canvas/sessions/{session_id}` — close the session; body: `{ "total_summary": "..." }`; returns session log path
+
+2. **CLI commands** (follow existing `python -m app.cli` conventions):
+   - `python -m app.cli canvas open <note-path> [--label <label>]`
+   - `python -m app.cli canvas edit <session-id> --body <body> [--summary <summary>]`
+   - `python -m app.cli canvas close <session-id> [--summary <summary>]`
+
+3. **Session store** — in-memory session registry (keyed by `session_id`) for the process lifetime. Sessions are not persisted to DB; the session log on disk is the durable artifact. If the process restarts, open sessions are lost (acceptable — session durability is a later concern).
+
+4. **Auth** — canvas routes respect the same API key auth as existing routes (`docs/SECURITY.md`).
+
+5. **Environment gate** — the canvas routes are available in `dev` and `test` environments; in `prod` the routes exist but return `403` if `CANVAS_ENABLED=0` (default in prod until the capability is promoted). This follows the existing feature-gate pattern.
+
+## Concretely
+
+```bash
+# CLI: open a session
+python -m app.cli canvas open vault/notes/my-note.md --label "expand-context"
+# → Session opened: session_id=<uuid>, note=vault/notes/my-note.md
+
+# CLI: apply an edit
+python -m app.cli canvas edit <uuid> --body "## Context\n\nExpanded..." --summary "Expanded context section"
+# → Edit applied. Note updated.
+
+# CLI: close the session
+python -m app.cli canvas close <uuid> --summary "Added context section, one governance action pending"
+# → Session closed. Log at vault/.chats/my-note/2026-04-22T14-30-expand-context.md
+```
+
+```bash
+# API: open, edit, close
+curl -X POST /api/canvas/sessions \
+  -d '{"note_path": "vault/notes/my-note.md", "session_label": "expand-context"}'
+# → {"session_id": "<uuid>", "note_path": "vault/notes/my-note.md"}
+
+curl -X POST /api/canvas/sessions/<uuid>/edits \
+  -d '{"new_body": "Expanded body...", "change_summary": "Expanded context section"}'
+# → {"ok": true, "note_path": "..."}
+
+curl -X DELETE /api/canvas/sessions/<uuid> \
+  -d '{"total_summary": "One edit applied"}'
+# → {"ok": true, "session_log_path": "vault/.chats/my-note/..."}
+```
+
+## Why This Matters
+
+Without this surface, the canvas write path is only usable in tests and internal code. The API and CLI are what make it possible to drive canvas sessions from an LLM agent, a future Obsidian plugin, or a web client — without any of those callers needing to change when the internal writer implementation evolves. The `CANVAS_ENABLED` gate also keeps prod conservative: the routes exist but stay off until the capability is promoted as supported.
+
+## Acceptance Criteria
+
+- [ ] `POST /api/canvas/sessions` opens a session and returns `session_id`.
+  - Verify: `tests/api/test_canvas_api.py::test_open_session_returns_session_id`
+- [ ] `POST /api/canvas/sessions/{id}/edits` applies a body edit and the vault file is updated.
+  - Verify: `tests/api/test_canvas_api.py::test_edit_updates_vault_file`
+- [ ] `DELETE /api/canvas/sessions/{id}` closes the session and the session log is on disk.
+  - Verify: `tests/api/test_canvas_api.py::test_close_session_writes_log`
+- [ ] Governance action route creates a Panel intent and returns `pending_intent_id`; does not mutate the note directly.
+  - Verify: `tests/api/test_canvas_api.py::test_governance_action_creates_intent_not_note_edit`
+- [ ] Canvas routes return `403` when `CANVAS_ENABLED=0` (default prod gate).
+  - Verify: `tests/api/test_canvas_api.py::test_canvas_disabled_returns_403`
+- [ ] `python -m app.cli canvas open / edit / close` round-trip works against `vault-test/`.
+  - Verify: `tests/cli/test_canvas_cli.py::test_canvas_cli_open_edit_close_roundtrip`
+- [ ] Existing routes and tests are not broken.
+  - Verify: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg"` passes.
+
+## How to Verify (Pre-Merge)
+
+```bash
+# Full canvas test suite
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/chat/ tests/api/test_canvas_api.py tests/cli/test_canvas_cli.py -m "not pg" -q
+
+# CLI smoke against vault-test
+SESSION=$(python -m app.cli canvas open vault-test/notes/test-note.md --label smoke | grep session_id | awk '{print $2}')
+python -m app.cli canvas edit $SESSION --body "Edited." --summary "smoke edit"
+python -m app.cli canvas close $SESSION --summary "smoke done"
+# Confirm vault-test/.chats/test-note/ contains the log
+
+# Regression: existing smoke commands still pass
+python -m app.cli health --json
+python -m app.cli status
+```
+
+## Out of Scope
+
+- Streaming edits over WebSocket (deferred to editor layer).
+- Persistent session storage across process restarts.
+- UI or editor library integration.
+- Workspace mode (multi-note sessions).
+- Hybrid Panel/Chat integration.
+
+## Related Docs
+
+- `docs/CANVAS_CHAT_SURFACE/CO_AUTHOR_NOTE_BODY.md` — co-authoring path this routes to
+- `docs/CANVAS_CHAT_SURFACE/GATE_GOVERNANCE_BEARING_MUTATIONS.md` — governance path this routes to
+- `docs/SECURITY.md` — API key auth
+- `docs/OPERATIONS.md` — environment posture and feature gates
+
+## Related GitHub Issues
+
+When filed, the issue should reference "Implements CANVAS_CHAT_SURFACE/EXPOSE_CANVAS_SESSION_API" and must not add streaming, persistent sessions, or UI to its scope.

--- a/docs/CANVAS_CHAT_SURFACE/GATE_GOVERNANCE_BEARING_MUTATIONS.md
+++ b/docs/CANVAS_CHAT_SURFACE/GATE_GOVERNANCE_BEARING_MUTATIONS.md
@@ -1,0 +1,106 @@
+---
+name: Gate Governance-Bearing Mutations
+description: Ensure that mutations originating from a canvas session that are governance-bearing (frontmatter classification, cross-note, lifecycle transitions) route through the same gated-execution pipeline as Panel, not through the co-authoring path.
+task_id: CANVAS-03
+source_anchor: docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CANVAS_COEDITING_MODEL.md :: The Authority Split :: Governance-bearing
+parent_capability: Canvas Chat Surface
+prerequisites: [CANVAS-01, CANVAS-02]
+depends_on: [WRITE_SESSION_LOGS.md, CO_AUTHOR_NOTE_BODY.md]
+can_parallelize_with: []
+---
+
+State: Specification. Not yet implemented.
+
+# Gate Governance-Bearing Mutations
+
+## Purpose
+
+Canvas Chat has two mutation classes with different authorization models. The co-authoring path (CANVAS-02) handles body edits authorized by user presence. This task handles everything else: mutations that carry governance meaning must not bypass the gated pipeline, even during an active canvas session.
+
+## What This Task Does
+
+1. **Formalizes the governance-bearing set** — canonically defined in the spec; this task makes that set machine-enforceable from a canvas session context:
+   - Frontmatter field writes where the field carries classification or governance meaning: `type`, `maturity`, `review_state`, `kind`, scope/sphere tags, any field named in the Panel action catalog as governance-bearing
+   - Cross-note operations: writes to any note other than `session.note_path`
+   - Note lifecycle transitions: creation, deletion, rename, move, archival
+   - Promotion of maturity or commitment state
+
+2. **Canvas-to-Panel bridge** — `app/chat/governance_router.py` (new):
+   - `request_governance_action(session, action_type, payload) -> PendingAction`
+   - Converts a canvas-originated governance request into a Panel-compatible intent
+   - Routes it through the existing admission path (`allowlist`, `write_guard`, `policy gate`, `event_id` dedup)
+   - Returns a `PendingAction` with receipt linkage — canvas session can record the pending action in its session log
+   - Does **not** execute immediately; respects the `observation -> normalization/contract -> admission -> execution` boundary
+
+3. **Session log records pending actions** — when a governance action is requested, the session log records it as pending with the Panel intent ID, not as an executed change.
+
+4. **Explicit rejection in CanvasWriter** — `CanvasWriter.apply_edit` (CANVAS-02) already raises `GovernanceBearingMutationError` for frontmatter writes; this task adds the complementary positive path: instead of just rejecting, the canvas surface can route to `GovernanceRouter.request_governance_action`.
+
+## Concretely
+
+```python
+from app.chat.governance_router import GovernanceRouter, GovernanceActionType
+
+router = GovernanceRouter(panel_pipeline=..., session_log_writer=log_writer)
+
+# User says: "mark this note as evergreen"
+pending = router.request_governance_action(
+    session=session,
+    action_type=GovernanceActionType.FRONTMATTER_UPDATE,
+    payload={"field": "maturity", "value": "evergreen"}
+)
+# pending.intent_id links to the Panel pipeline entry
+# session log records: "Governance action pending: maturity=evergreen (intent: <id>)"
+# The note is NOT updated until admission completes through the normal Panel path
+```
+
+Attempting to bypass via `apply_edit` still raises:
+```python
+canvas.apply_edit(session, "---\nmaturity: evergreen\n---\n\nBody")
+# GovernanceBearingMutationError — use GovernanceRouter for this
+```
+
+## Why This Matters
+
+The gated-execution invariant is the core safety property of the whole system. If canvas Chat can write classification fields, create notes, or promote maturity by going through the co-authoring path, the invariant collapses. The Panel admission path exists precisely to enforce allowlist checks, write-guard state, idempotency, and receipt generation for these actions. Canvas Chat must use it — this is not a convenience integration, it is the architectural constraint named in `STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md`.
+
+## Acceptance Criteria
+
+- [ ] `app/chat/governance_router.py` exists with `GovernanceRouter` and `request_governance_action`.
+  - Verify: `tests/chat/test_governance_router.py::test_request_routes_to_panel_pipeline`
+- [ ] A governance action request does not immediately mutate the note; it creates a Panel intent and returns a receipt reference.
+  - Verify: `tests/chat/test_governance_router.py::test_request_does_not_write_note_directly`
+- [ ] The session log records the pending governance action with the Panel intent ID.
+  - Verify: `tests/chat/test_governance_router.py::test_session_log_records_pending_intent`
+- [ ] `CanvasWriter.apply_edit` (from CANVAS-02) continues to raise `GovernanceBearingMutationError` for frontmatter in body; this task does not remove that guard.
+  - Verify: `tests/chat/test_canvas_writer.py::test_apply_edit_rejects_frontmatter_in_body` (regression)
+- [ ] `GovernanceRouter` passes the action through `write_guard` before creating the Panel intent; if write-guard is not open, the action is rejected with a clear error.
+  - Verify: `tests/chat/test_governance_router.py::test_request_respects_write_guard`
+- [ ] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/chat/test_governance_router.py tests/chat/test_canvas_writer.py -m "not pg" -q` passes.
+
+## How to Verify (Pre-Merge)
+
+```bash
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/chat/ -m "not pg" -q
+
+# Confirm CANVAS-02 regression test still passes
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/chat/test_canvas_writer.py::test_apply_edit_rejects_frontmatter_in_body -m "not pg" -q
+```
+
+## Out of Scope
+
+- Changes to the Panel admission pipeline itself.
+- UI for the user to approve or reject the pending governance action (deferred to the editor layer).
+- Cross-note synthesis or workspace mode (explicitly deferred per spec).
+- Implementing new governance action types beyond what Panel already supports.
+
+## Related Docs
+
+- `docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CANVAS_COEDITING_MODEL.md` §The Authority Split :: Governance-bearing
+- `docs/INTERACTION_SURFACES_AND_AUTHORITY/STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md`
+- `docs/PANEL_AGENT.md` — the admission pipeline this task routes through
+- `docs/CANVAS_CHAT_SURFACE/CO_AUTHOR_NOTE_BODY.md` — prerequisite
+
+## Related GitHub Issues
+
+When filed, the issue should reference "Implements CANVAS_CHAT_SURFACE/GATE_GOVERNANCE_BEARING_MUTATIONS" and must not change the Panel admission pipeline's existing behavior.

--- a/docs/CANVAS_CHAT_SURFACE/README.md
+++ b/docs/CANVAS_CHAT_SURFACE/README.md
@@ -1,0 +1,95 @@
+---
+name: Canvas Chat Surface
+description: Implementation specification for the canvas-Chat co-editing surface — the user-facing capability that lets a user work on a note with an agent editing in place, like a collaborative editor.
+type: specification
+authority: SoT for the canvas-Chat runtime implementation; the authority spec for the co-editing posture, mutation split, and session-log conventions is docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CANVAS_COEDITING_MODEL.md
+source_of_truth: docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CANVAS_COEDITING_MODEL.md
+related_docs:
+  - docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CANVAS_COEDITING_MODEL.md
+  - docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CHAT_AUTHORITY_BOUNDARY.md
+  - docs/INTERACTION_SURFACES_AND_AUTHORITY/STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md
+  - docs/HUMAN-FLOWS.md :: Case: I want to think on a note with a writing partner
+  - docs/CONCEPTS/COMPANION_NOTE_CONTRACT.md
+  - app/chat/read_only_cognition.py
+  - app/knowledge/write_ops.py
+---
+
+State: Active specification. Implementation not started. Spec source is docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CANVAS_COEDITING_MODEL.md (merged via PR #533).
+Owner: v6.0 architecture owner
+Last reviewed: 2026-04-22
+
+# Canvas Chat Surface
+
+## What This Capability Builds
+
+A user opens a note in the vault and starts a canvas session. The agent edits the note body directly, in place, as they collaborate — the way a second author would. The user does not review a diff; they see edits appear. The session closes. The note retains the result. A session log in `.chats/<note-slug>/` captures the intent trail.
+
+This is the human flow described in `docs/HUMAN-FLOWS.md` §8: "I want to think on a note with a writing partner."
+
+## What This Capability Does Not Build
+
+- A UI or editor library. Hosting location (Obsidian, standalone, web) is deferred.
+- Workspace mode (multi-note sessions across related notes).
+- Hybrid Panel/Chat integration. That is a separate downstream capability.
+- Retention policy enforcement. Retention window duration is a policy decision deferred to a later slice.
+- The full Deep Agent cognition stack. The read-only cognition scaffold (`app/chat/read_only_cognition.py`) is the starting point; this capability adds the write path and session lifecycle on top.
+
+## Governing Authority
+
+**Do not reopen or contradict these decisions while implementing:**
+
+- `DEFINE_CANVAS_COEDITING_MODEL.md` — the posture, mutation split, `.chats/` conventions, and note↔session cardinality. This spec does not override any of it.
+- `STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md` — governance-bearing mutations (frontmatter, cross-note, lifecycle) always go through the gated pipeline regardless of user presence.
+- `DEFINE_CHAT_AUTHORITY_BOUNDARY.md` — Chat is canvas, not Q&A. Co-authoring is authorized by user presence; it does not bypass gated execution.
+
+## Implementation Tasks
+
+Execute in this order. Each task is independently mergeable.
+
+| Order | Task File | What It Builds | T-shirt | Parallelizable |
+|-------|-----------|----------------|---------|----------------|
+| 1 | [WRITE_SESSION_LOGS.md](WRITE_SESSION_LOGS.md) | Session log writer + `type: chat-session` artifact class | XS | — |
+| 2 | [CO_AUTHOR_NOTE_BODY.md](CO_AUTHOR_NOTE_BODY.md) | In-place body editing path through KnowledgePort | M | — |
+| 3 | [GATE_GOVERNANCE_BEARING_MUTATIONS.md](GATE_GOVERNANCE_BEARING_MUTATIONS.md) | Canvas-session mutations routed through gated pipeline | S | — |
+| 4 | [EXPOSE_CANVAS_SESSION_API.md](EXPOSE_CANVAS_SESSION_API.md) | Bounded API surface for canvas session open/edit/close | S | — |
+
+## Execution Order
+
+```
+WRITE_SESSION_LOGS
+        ↓
+CO_AUTHOR_NOTE_BODY
+        ↓
+GATE_GOVERNANCE_BEARING_MUTATIONS
+        ↓
+EXPOSE_CANVAS_SESSION_API
+```
+
+No task in this capability is parallel-safe with another within this capability; each builds on the writer path established by the previous.
+
+## Acceptance
+
+The parent capability is accepted when all of the following are true:
+
+- [ ] A canvas session can be opened on a vault note and body edits apply in place without a diff-review gate.
+- [ ] Session logs are written to `vault/.chats/<note-slug>/<timestamp>-<label>.md` with correct `type: chat-session` frontmatter.
+- [ ] Governance-bearing mutations (frontmatter, cross-note, lifecycle) from a canvas session route through the gated-execution pipeline — not through the co-authoring path.
+- [ ] The co-authoring path is blocked from writing frontmatter classification fields, creating/deleting/renaming notes, or writing to notes other than the currently-open one.
+- [ ] A bounded API surface exists for session open, body edit, and session close.
+- [ ] The existing read-only cognition scaffold (`app/chat/read_only_cognition.py`) is not broken.
+- [ ] Focused tests cover each of the four surfaces above.
+- [ ] `docs/HUMAN-FLOWS.md` §14 moves canvas-Chat from "Emerging but not yet fully realized" to the "Already materially supported" list.
+- [ ] `docs/STATUS.md` records the delivery receipt.
+
+## Pointer to Parent Feature Issue
+
+Parent feature issue: **#597** — live validation hub; closes only after owner-doc promotion.
+
+Implementation task issues (in execution order):
+
+| Task | Issue | Status |
+|------|-------|--------|
+| WRITE_SESSION_LOGS | #598 | `agent:ready` |
+| CO_AUTHOR_NOTE_BODY | #599 | `agent:blocked` on #598 |
+| GATE_GOVERNANCE_BEARING_MUTATIONS | #600 | `agent:blocked` on #599 |
+| EXPOSE_CANVAS_SESSION_API | #601 | `agent:blocked` on #600 |

--- a/docs/CANVAS_CHAT_SURFACE/WRITE_SESSION_LOGS.md
+++ b/docs/CANVAS_CHAT_SURFACE/WRITE_SESSION_LOGS.md
@@ -1,0 +1,141 @@
+---
+name: Write Session Logs
+description: Implement the session log writer and the chat-session artifact class — the subordinate provenance trail captured alongside the note during a canvas session.
+task_id: CANVAS-01
+source_anchor: docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CANVAS_COEDITING_MODEL.md :: Artifact Classes
+parent_capability: Canvas Chat Surface
+prerequisites: []
+depends_on: []
+can_parallelize_with: []
+---
+
+State: Specification. Not yet implemented.
+
+# Write Session Logs
+
+## Purpose
+
+Every canvas session produces a session log: an append-only provenance artifact that captures what the user intended and what changed. This task creates the writer and the artifact class that all downstream canvas tasks depend on.
+
+## What This Task Does
+
+Implements the session log writer:
+
+1. **Artifact location** — `vault/.chats/<note-slug>/<timestamp>-<short-label>.md` where:
+   - `<note-slug>` is the note's filename without extension, lowercased and hyphenated
+   - `<timestamp>` is ISO-8601 with colons replaced by hyphens (`2026-04-22T14-30`)
+   - `<short-label>` is a max-5-word human description of the session intent, hyphenated (e.g. `restructure-decision-section`)
+
+2. **Frontmatter** — every session log carries:
+   ```yaml
+   ---
+   type: chat-session
+   note: "[[<note-title>]]"
+   date: <ISO-8601 timestamp>
+   session_id: <uuid4>
+   ---
+   ```
+
+3. **Append-only during session** — the session log is opened at session start and appended to as the session progresses. It is not rewritten. Appends record: user prompt, brief change summary (not full LLM response body).
+
+4. **Closed at session end** — a final append records the session-close event with a summary of total changes.
+
+5. **Writer module** — `app/chat/session_log.py` (new), with `SessionLogWriter` class:
+   - `open_session(note_path, session_label) -> SessionLog`
+   - `append_turn(session, user_prompt, change_summary)`
+   - `close_session(session, total_summary)`
+
+6. **No retention enforcement** — this task only writes logs. Retention policy (soft-delete after window) is a later slice.
+
+## Concretely
+
+```python
+from app.chat.session_log import SessionLogWriter
+
+writer = SessionLogWriter(vault_root=Path("vault"))
+session = writer.open_session(
+    note_path=Path("vault/notes/my-design-decision.md"),
+    session_label="restructure-decision-section"
+)
+writer.append_turn(
+    session,
+    user_prompt="Can you move the rationale into a dedicated subsection?",
+    change_summary="Moved three paragraphs under new ## Rationale heading"
+)
+writer.close_session(session, total_summary="One structural edit: rationale section added")
+```
+
+Expected output file at `vault/.chats/my-design-decision/2026-04-22T14-30-restructure-decision-section.md`:
+```markdown
+---
+type: chat-session
+note: "[[my-design-decision]]"
+date: 2026-04-22T14:30
+session_id: <uuid>
+---
+
+## Session: restructure-decision-section
+
+**User:** Can you move the rationale into a dedicated subsection?
+**Change:** Moved three paragraphs under new ## Rationale heading
+
+---
+*Session closed. Total: One structural edit: rationale section added.*
+```
+
+## Why This Matters
+
+The session log is the provenance contract. Without it, co-authored notes have no intent trail — the user cannot later ask "why did this section appear?" and get a useful answer. The `.chats/` namespace and `type: chat-session` field also ensure session logs are distinguishable from vault notes in Dataview, graph view, and system retrieval, so they never pollute the human writing surface.
+
+## Acceptance Criteria
+
+- [ ] `app/chat/session_log.py` exists with `SessionLogWriter`, `open_session`, `append_turn`, and `close_session`.
+  - Verify: `tests/chat/test_session_log_writer.py::test_open_creates_file_in_chats_namespace`
+- [ ] Session log files are created under `vault/.chats/<note-slug>/` with correct path structure.
+  - Verify: `tests/chat/test_session_log_writer.py::test_log_path_uses_note_slug_and_timestamp`
+- [ ] Session log frontmatter contains `type: chat-session`, `note`, `date`, and `session_id` fields.
+  - Verify: `tests/chat/test_session_log_writer.py::test_frontmatter_fields_present`
+- [ ] `type: chat-session` is not present in any existing vault note class (no collision with user artifacts).
+  - Verify: `tests/chat/test_session_log_writer.py::test_type_field_is_chat_session_only`
+- [ ] Appends are additive; prior content is not rewritten.
+  - Verify: `tests/chat/test_session_log_writer.py::test_append_does_not_rewrite_prior_content`
+- [ ] `close_session` records a final closure line with the total summary.
+  - Verify: `tests/chat/test_session_log_writer.py::test_close_session_appends_closure_line`
+- [ ] The writer does not require Docker or Postgres (pure file-system operation).
+  - Verify: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/chat/test_session_log_writer.py -m "not pg" -q` passes.
+
+## How to Verify (Pre-Merge)
+
+```bash
+# Unit tests — no PG, no Docker
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/chat/test_session_log_writer.py -m "not pg" -q
+
+# Smoke: create a session log manually
+python -c "
+from pathlib import Path
+from app.chat.session_log import SessionLogWriter
+w = SessionLogWriter(vault_root=Path('vault-test'))
+s = w.open_session(Path('vault-test/notes/test-note.md'), 'smoke-test-session')
+w.append_turn(s, 'test prompt', 'test change')
+w.close_session(s, 'smoke complete')
+print('Log at:', s.log_path)
+"
+# Confirm: vault-test/.chats/test-note/ contains the log file with correct frontmatter
+```
+
+## Out of Scope
+
+- Retention policy enforcement (soft-delete window).
+- Session log retrieval or search.
+- Rendering session logs in any UI.
+- Integration with the co-authoring write path (that is CO_AUTHOR_NOTE_BODY).
+- The full session schema beyond the minimum fields listed above.
+
+## Related Docs
+
+- `docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CANVAS_COEDITING_MODEL.md` §Artifact Classes, §File-System Conventions, §Retention and Reversibility
+- `docs/CANVAS_CHAT_SURFACE/README.md`
+
+## Related GitHub Issues
+
+When filed, the issue should reference "Implements CANVAS_CHAT_SURFACE/WRITE_SESSION_LOGS" and must not add retention policy enforcement to its scope.


### PR DESCRIPTION
## Summary
- Adds `docs/CANVAS_CHAT_SURFACE/` with the full four-task spec for the canvas Chat co-editing capability
- Four task specs in execution order: WRITE_SESSION_LOGS → CO_AUTHOR_NOTE_BODY → GATE_GOVERNANCE_BEARING_MUTATIONS → EXPOSE_CANVAS_SESSION_API
- README ties the tasks together: acceptance criteria, execution order diagram, issue links (#598–#601), parent issue #597

Spec source of truth: `docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CANVAS_COEDITING_MODEL.md` (merged PR #533). This directory is the implementation spec; it does not override the authority doc.

## Change Lane
- [ ] Implementation lane
- [x] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Fixes #

Docs authoring lane — no linked issue required.

## Docs Authoring Check
- [x] This PR only changes approved docs-authoring surfaces.
- [x] No code, runtime behavior, contracts, or shipped reality changed.
- [x] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Test plan
- [ ] All four task files exist under `docs/CANVAS_CHAT_SURFACE/`
- [ ] README acceptance checklist references the correct issues (#597–#601)
- [ ] No existing code or tests touched