### PR TITLE
governance: add 4 release-channel promotion skills

### DIFF
--- a/.codex/skills/README.md
+++ b/.codex/skills/README.md
@@ -44,6 +44,14 @@ Conditional / maintenance path:
   - micro-skill: append one structured divergence entry to `docs/learning-log.md` when a plan divergence occurs; invoke on divergence, not on normal work
 - `learning-retrospective`
   - cadence-triggered: read `docs/learning-log.md` since last retro marker, cluster by upstream artifact, propose concrete edits for human review, append retro marker after human response
+- `prepare-promotion`
+  - release-channel operator skill: produce a promotion plan diffing `main` against `stable` with code delta, migration delta (reversible vs forward-only), config delta, and risk notes; always runs before `execute-promotion`; governed by `docs/RELEASE_CHANNELS/DEFINE_PROMOTION_PLAN_CONTRACT.md`
+- `execute-promotion`
+  - release-channel operator skill: consume a reviewed and operator-acknowledged promotion plan; move the `stable` ref, apply migrations to the prod DB, restart the prod process; always follow with `verify-promotion`
+- `verify-promotion`
+  - release-channel operator skill: verify prod is healthy after `execute-promotion` or `rollback-promotion`; runs health, status, settings-explain, and smoke checks; appends a verification receipt to the promotion plan; PASS/FAIL only
+- `rollback-promotion`
+  - release-channel operator skill: restore `stable` to `stable-prev`, reverse reversible migrations, restart prod; call after `execute-promotion` failure or `verify-promotion` FAIL; always follow with `verify-promotion`; governed by `docs/RELEASE_CHANNELS/DEFINE_ROLLBACK_CONTRACT.md`
 
 ## Connected execution paths
 
@@ -55,6 +63,8 @@ Conditional / maintenance path:
   `docs-authoring -> docs-to-issue`
 - Temporal audit path:
   `temporal-doc-governance` and, when GitHub state is involved, `backlog-reconciliation-drift-audit`
+- Release-channel promotion path:
+  `prepare-promotion -> (operator review) -> execute-promotion -> verify-promotion`; on failure: `rollback-promotion -> verify-promotion`
 
 If multiple skills seem relevant, prefer the narrower workflow skill over the generic repo-dev skill.
 

--- a/.codex/skills/execute-promotion/SKILL.md
+++ b/.codex/skills/execute-promotion/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: execute-promotion
+description: "Execute a reviewed promotion plan: move the stable ref, apply migrations to the prod DB, and restart the prod process from the updated checkout. Requires a complete, operator-acknowledged promotion plan from prepare-promotion."
+---
+
+# Execute Promotion
+
+Use this skill only after `prepare-promotion` has produced a complete plan and the operator has reviewed and ticked all acknowledgment checkboxes.
+
+Do not use this skill to:
+- produce the promotion plan (use `prepare-promotion`)
+- verify that prod is healthy after execution (use `verify-promotion`)
+- roll back a failed promotion (use `rollback-promotion`)
+
+## Capability boundary
+
+Read `docs/RELEASE_CHANNELS/README.md` (Promotion contract) and `docs/RELEASE_CHANNELS/DEFINE_PROMOTION_PLAN_CONTRACT.md` before running. The plan is the contract. If the plan is incomplete or has un-ticked acknowledgment checkboxes, abort.
+
+## What this skill does
+
+1. Reads the promotion plan at the path provided by the operator (output of `prepare-promotion`).
+2. Validates the plan: all seven required sections present, all operator acknowledgment checkboxes ticked. Abort if validation fails.
+3. Records the current `stable` ref as `stable-prev` (annotated tag or pointer file in `ops/promotions/`) before moving anything.
+4. Moves the `stable` ref to the promotion target commit (`git tag -f stable <target-sha>` or equivalent).
+5. Updates the prod checkout's HEAD to the new `stable` (`git -C <prod-checkout> fetch && git -C <prod-checkout> checkout stable`).
+6. Applies reversible migrations to the prod DB (port 15432) in forward order. Applies forward-only migrations only after confirming the operator acknowledged them in the plan. Stops and calls for rollback if any migration fails.
+7. Restarts the prod process (`make prod-down && make prod-up` or equivalent).
+8. Appends the promotion execution receipt to the plan file: timestamp, operator, which ref moved, which migrations applied, process restart confirmation.
+9. Reports to the operator: "Promotion executed. Run verify-promotion to confirm health."
+
+## Pre-conditions
+
+- A complete promotion plan produced by `prepare-promotion` exists and all operator acknowledgments are ticked.
+- The prod Postgres container is running (`make prod-up` healthy).
+- The prod checkout (separate worktree, per `DEFINE_CONCURRENCY_RULE`) is available.
+- `git tag stable` resolves to the current prod commit.
+
+## Operator steps
+
+```
+# After reviewing and ticking all checkboxes in the plan:
+execute-promotion --plan ops/promotions/YYYY-MM-DD-<short-sha>.md
+
+# Then verify:
+verify-promotion
+```
+
+## Failure handling
+
+- If plan validation fails: abort, report the missing section or un-ticked checkbox. Do not move `stable`.
+- If `stable-prev` recording fails: abort. Moving `stable` before recording the previous ref makes rollback ambiguous.
+- If a migration fails: stop immediately, do not apply subsequent migrations. Report which migration failed. Call `rollback-promotion`.
+- If process restart fails: the ref has moved and some migrations may be applied. Report the partial state explicitly. Call `rollback-promotion` — the operator must decide whether rollback is safe given any forward-only migrations already applied.
+
+## Key constraints
+
+- Never execute without a complete, operator-acknowledged plan.
+- Always record `stable-prev` before moving `stable`. This is the rollback anchor.
+- Never skip a migration that the plan lists. Never apply a migration the plan does not list.
+- Never use the dev checkout for prod operations — separate worktrees per `DEFINE_CONCURRENCY_RULE`.
+
+## Authority order for decisions
+
+1. The promotion plan produced by `prepare-promotion` — the immediate contract
+2. `docs/RELEASE_CHANNELS/DEFINE_PROMOTION_PLAN_CONTRACT.md` — plan shape
+3. `docs/RELEASE_CHANNELS/DEFINE_ROLLBACK_CONTRACT.md` — failure and rollback posture
+4. `docs/RELEASE_CHANNELS/DEFINE_MIGRATION_REVERSIBILITY_CLASSIFICATION.md` — migration safety
+5. `docs/RELEASE_CHANNELS/README.md` — invariants
+
+## Routing
+
+- Produced by: `prepare-promotion`
+- On success → `verify-promotion`
+- On failure → `rollback-promotion`

--- a/.codex/skills/prepare-promotion/SKILL.md
+++ b/.codex/skills/prepare-promotion/SKILL.md
@@ -44,6 +44,7 @@ Per `docs/RELEASE_CHANNELS/DEFINE_PROMOTION_PLAN_CONTRACT.md`:
 
 ## Pre-conditions
 
+- `docs/RELEASE_CHANNELS/` is present on `main` (docs capability PR merged; originally PR #602). If those docs are not on `main`, do not run this skill.
 - `make prod-up` is running and the prod Postgres container is healthy on port 15432.
 - The `stable` ref resolves without ambiguity (`git rev-parse stable` succeeds).
 - The operator has specified the target commit (defaults to `HEAD` on `main` if not provided).

--- a/.codex/skills/prepare-promotion/SKILL.md
+++ b/.codex/skills/prepare-promotion/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: prepare-promotion
+description: "Produce a promotion plan that diffs main against stable, enumerates code delta, migration delta, config delta, and risk notes, and surfaces every forward-only migration for operator acknowledgment before execution."
+---
+
+# Prepare Promotion
+
+Use this skill before any `execute-promotion` run. Its sole job is to produce a reviewable promotion plan. It does not move any ref, apply any migration, or restart any process.
+
+Do not use this skill to:
+- execute the promotion (use `execute-promotion`)
+- verify that prod came up cleanly after promotion (use `verify-promotion`)
+- roll back a failed promotion (use `rollback-promotion`)
+
+## Capability boundary
+
+The release-channels capability spec lives at `docs/RELEASE_CHANNELS/`. Read `docs/RELEASE_CHANNELS/DEFINE_PROMOTION_PLAN_CONTRACT.md` before running this skill — it is the authoritative contract for what a promotion plan must contain.
+
+## What this skill does
+
+1. Resolves the current `stable` ref (the commit prod is running from).
+2. Resolves the target `main` commit the operator wants to promote to.
+3. Diffs the two refs and enumerates every PR merged since `stable`.
+4. For each included PR: extracts title, link, and any associated GitHub Issue; checks whether ACs are marked satisfied on the Issue; notes any open verification gaps.
+5. Enumerates migration files committed since `stable` that have not yet been applied to the prod DB (`pkm_prod` container, port 15432). For each migration: reads its reversibility marker (per `docs/RELEASE_CHANNELS/DEFINE_MIGRATION_REVERSIBILITY_CLASSIFICATION.md`) and flags forward-only ones explicitly.
+6. Diffs settings/env defaults between the two refs and notes any operator-visible config changes.
+7. Assembles risk notes: forward-only migrations, PRs without full AC verification, any cross-channel touchpoints visible in the diff.
+8. Writes the promotion plan to `ops/promotions/YYYY-MM-DD-<short-sha>.md` using the required sections from `DEFINE_PROMOTION_PLAN_CONTRACT`.
+9. Prints a summary to the operator: plan path, number of PRs, number of migrations (N reversible, M forward-only), and any blocking risks.
+
+The skill does not proceed past step 9 without operator review. It exits after producing the plan.
+
+## Required sections in the output plan
+
+Per `docs/RELEASE_CHANNELS/DEFINE_PROMOTION_PLAN_CONTRACT.md`:
+
+1. **Promotion target** — from-commit, to-commit, and timestamp.
+2. **Code delta** — ordered PR list with AC status and verification receipt links.
+3. **Migration delta** — each migration with reversibility classification.
+4. **Config / settings delta** — operator-visible changes.
+5. **Risk notes** — forward-only migrations, AC gaps, cross-channel concerns.
+6. **Rollback path** — previous `stable` ref and migration reversal sequence.
+7. **Operator acknowledgments** — checkboxes for forward-only migrations and any AC gaps.
+
+## Pre-conditions
+
+- `make prod-up` is running and the prod Postgres container is healthy on port 15432.
+- The `stable` ref resolves without ambiguity (`git rev-parse stable` succeeds).
+- The operator has specified the target commit (defaults to `HEAD` on `main` if not provided).
+
+## Operator steps
+
+```
+# From the prod checkout (not the dev checkout — separate worktree per DEFINE_CONCURRENCY_RULE)
+prepare-promotion [--target <sha-or-ref>]
+
+# Review the produced plan at ops/promotions/YYYY-MM-DD-<short-sha>.md
+# Tick all operator-acknowledgment checkboxes
+# Then hand off to execute-promotion
+```
+
+## Output
+
+A single markdown file at `ops/promotions/YYYY-MM-DD-<short-sha>.md` satisfying the promotion plan contract. Also printed to stdout as a human-readable summary.
+
+## Key constraints
+
+- Never move the `stable` ref. That is `execute-promotion`'s job.
+- Never apply migrations. Plan only.
+- Never restart any process.
+- If the `stable` ref is ambiguous or missing, abort and report — do not guess.
+- If a migration lacks a reversibility marker, flag it as a blocking risk in the plan and do not classify it silently.
+
+## Authority order for decisions
+
+1. `docs/RELEASE_CHANNELS/DEFINE_PROMOTION_PLAN_CONTRACT.md` — plan shape
+2. `docs/RELEASE_CHANNELS/DEFINE_MIGRATION_REVERSIBILITY_CLASSIFICATION.md` — migration classification
+3. `docs/RELEASE_CHANNELS/README.md` — invariants
+4. `docs/ENVIRONMENTS.md` — environment model
+
+## Routing
+
+- To execute: `execute-promotion` (pass it the plan path produced here)
+- To roll back after a failed execute: `rollback-promotion`
+- To verify post-execution: `verify-promotion`

--- a/.codex/skills/rollback-promotion/SKILL.md
+++ b/.codex/skills/rollback-promotion/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: rollback-promotion
+description: "Roll prod back to the previous stable ref: restore the stable pointer, reverse reversible migrations on the prod DB, and restart the prod process. Call verify-promotion after completion."
+---
+
+# Rollback Promotion
+
+Use this skill when `execute-promotion` fails or when `verify-promotion` returns FAIL after a promotion. Its job is to return prod to the last known-good state as defined by the rollback contract.
+
+Do not use this skill to:
+- produce the promotion plan (use `prepare-promotion`)
+- execute a new promotion (use `execute-promotion`)
+- verify health after rollback (use `verify-promotion` — always call it after rollback)
+
+## Capability boundary
+
+Read `docs/RELEASE_CHANNELS/DEFINE_ROLLBACK_CONTRACT.md` before running. That document is the authority for what rollback restores and what it cannot restore. Key limits stated there:
+
+- **Vault is not rewound.** The real vault is never touched by rollback.
+- **Forward-only migrations are not reversed.** If the promotion applied forward-only migrations and they succeeded, the DB schema may not return to its pre-promotion shape. This was acknowledged by the operator at promotion time.
+- **External side-effects are not reversed.** Anything triggered outside the channel boundary is out of scope.
+
+## What this skill does
+
+1. Reads the promotion plan (`ops/promotions/YYYY-MM-DD-<short-sha>.md`) to determine: the previous `stable` ref (`stable-prev`), the migration delta, and which migrations were applied before the failure.
+2. Confirms `stable-prev` is resolvable and is different from the current `stable`. Abort if not — the rollback anchor is missing and operator intervention is required.
+3. Reverses applied reversible migrations against the prod DB (port 15432) in reverse order. Skips forward-only migrations with an explicit log entry: "forward-only migration X was applied; reversal not available per classification."
+4. Moves `stable` back to `stable-prev`.
+5. Updates the prod checkout's HEAD to `stable-prev`.
+6. Restarts the prod process (`make prod-down && make prod-up`).
+7. Appends the rollback receipt to the promotion plan file: timestamp, which ref was restored, which migrations were reversed, which were skipped (forward-only), process restart confirmation.
+8. Reports to the operator: "Rollback complete. Run verify-promotion."
+
+## Pre-conditions
+
+- A promotion plan file exists with a recorded `stable-prev` and migration delta.
+- `stable-prev` resolves to a valid commit.
+- The prod Postgres container is running or can be started.
+
+## Operator steps
+
+```
+rollback-promotion --plan ops/promotions/YYYY-MM-DD-<short-sha>.md
+
+# Always verify after rollback:
+verify-promotion --plan ops/promotions/YYYY-MM-DD-<short-sha>.md
+```
+
+## Failure handling
+
+- If `stable-prev` is missing or ambiguous: **abort and escalate to the operator**. Do not guess at a rollback target. The operator must identify the correct previous ref manually.
+- If a reversible migration reversal fails: stop, report which step failed and the current DB state. Do not continue reversing subsequent migrations. Escalate to the operator for manual DB triage.
+- If process restart fails after rollback: report the state explicitly — ref is restored, migrations are (partially) reversed, process is not running. Operator must start it manually.
+- If `verify-promotion` returns FAIL after rollback: do **not** attempt a second automated rollback. Escalate immediately.
+
+## What rollback does NOT do
+
+Per `docs/RELEASE_CHANNELS/DEFINE_ROLLBACK_CONTRACT.md`:
+
+- Does not rewind the real vault (authored content is never touched).
+- Does not reverse forward-only migrations (acknowledged at promotion time).
+- Does not undo external side-effects (emails sent, external API calls, etc.).
+- Does not restore runtime artifacts to a pre-promotion snapshot (`tmp/` is regenerated, not restored).
+
+The operator must have acknowledged these limits at promotion time via the operator acknowledgment checkboxes in the plan.
+
+## Key constraints
+
+- Always call `verify-promotion` after rollback completes — rollback is not accepted until verification passes.
+- Always append the rollback receipt to the promotion plan file — it is evidence for the parent feature issue.
+- Never attempt to reverse a forward-only migration. Log it and move on.
+- Never roll back without a resolved `stable-prev` anchor.
+
+## Authority order for decisions
+
+1. `docs/RELEASE_CHANNELS/DEFINE_ROLLBACK_CONTRACT.md` — what rollback restores and what it does not
+2. The promotion plan file — which migrations were applied and in what order
+3. `docs/RELEASE_CHANNELS/DEFINE_MIGRATION_REVERSIBILITY_CLASSIFICATION.md` — which migrations can be reversed
+4. `docs/RELEASE_CHANNELS/README.md` — invariants
+
+## Routing
+
+- Called after: `execute-promotion` failure, or `verify-promotion` FAIL post-promotion
+- After completion → always call `verify-promotion`
+- If verify fails after rollback → escalate to operator; do not loop

--- a/.codex/skills/verify-promotion/SKILL.md
+++ b/.codex/skills/verify-promotion/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: verify-promotion
+description: "Verify that prod is healthy and functionally correct after a promotion or rollback: run health checks, status checks, and smoke assertions against the running prod channel."
+---
+
+# Verify Promotion
+
+Use this skill immediately after `execute-promotion` succeeds, and again after `rollback-promotion`. Its sole job is to confirm the running prod channel is healthy and report any failures clearly.
+
+Do not use this skill to:
+- produce the promotion plan (use `prepare-promotion`)
+- execute the promotion (use `execute-promotion`)
+- roll back a failed promotion (use `rollback-promotion`)
+
+## Capability boundary
+
+Read `docs/HEALTH.md` before running — it owns the health contract that this skill exercises. The release-channels validation path in `docs/RELEASE_CHANNELS/README.md` (Validation / acceptance path) defines what "accepted" means at the capability level; this skill covers the runtime verification step.
+
+## What this skill does
+
+1. Confirms the running prod process's code ref matches `stable` (`git rev-parse stable` == reported version in health endpoint or settings-explain output).
+2. Confirms the prod Postgres container is healthy (port 15432 responsive, outbox consumer running, no error state in worker heartbeat).
+3. Runs `python -m app.cli status` against the prod channel and confirms all components report healthy.
+4. Runs `python -m app.cli settings-explain` against the prod channel and confirms the resolved environment is `prod`, the vault root is the real vault, and the DB resolves to the prod DB.
+5. Runs the repo smoke gate (`pytest -q -m "not pg and not alpha_llm"`) against prod config if the environment supports it; records the result.
+6. Checks the watcher heartbeat and confirms it is ticking within expected cadence.
+7. Reads the latest outbox state and confirms no stuck or errored events from the promotion.
+8. Reports a clear PASS / FAIL with the checks run and their results.
+9. Appends the verification receipt (timestamp, checks run, outcome) to the promotion plan file at `ops/promotions/YYYY-MM-DD-<short-sha>.md`.
+
+## Pre-conditions
+
+- `execute-promotion` or `rollback-promotion` has completed.
+- The prod Postgres container is running (`make prod-up`).
+- The prod process is running.
+
+## Operator steps
+
+```
+verify-promotion [--plan ops/promotions/YYYY-MM-DD-<short-sha>.md]
+```
+
+If `--plan` is provided, the verification receipt is appended to it. If not, it is written to stdout only.
+
+## What PASS means
+
+All of the following are true:
+- Code ref matches `stable`.
+- Status and settings-explain both report env=prod, correct vault, correct DB.
+- Postgres healthy, outbox consumer healthy, watcher heartbeat within cadence.
+- No stuck or errored events from the promotion window.
+- Smoke gate green (or explicitly waived with a reason).
+
+Any single failure is a FAIL. FAIL after `execute-promotion` → call `rollback-promotion`. FAIL after `rollback-promotion` → escalate to the operator for manual triage; do not attempt automated recovery.
+
+## Key constraints
+
+- Never interpret partial health as acceptable. Report FAIL and route to rollback.
+- Never mark PASS without checking all seven items above.
+- Always append the receipt to the plan file if one is provided — this is the capability-level validation evidence.
+
+## Authority order for decisions
+
+1. `docs/HEALTH.md` — health contract
+2. `docs/RELEASE_CHANNELS/README.md` — what constitutes post-promotion acceptance
+3. `docs/ENVIRONMENTS.md` — environment contract (settings-explain expected outputs)
+
+## Routing
+
+- Called after: `execute-promotion` or `rollback-promotion`
+- On PASS after execute: promotion is accepted; update the parent feature issue with a validation receipt
+- On FAIL after execute: call `rollback-promotion`
+- On FAIL after rollback: escalate to operator; do not loop

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,14 @@ Repo-local workflow helpers live under `.codex/skills/`. They do not replace thi
   `.codex/skills/capture-learning/SKILL.md`
 - Retrospective over divergence log to improve upstream artifacts:
   `.codex/skills/learning-retrospective/SKILL.md`
+- Promote a reviewed commit from dev to stable prod (produce plan):
+  `.codex/skills/prepare-promotion/SKILL.md`
+- Execute an operator-acknowledged promotion plan:
+  `.codex/skills/execute-promotion/SKILL.md`
+- Verify prod health after promotion or rollback:
+  `.codex/skills/verify-promotion/SKILL.md`
+- Roll prod back to the previous stable ref:
+  `.codex/skills/rollback-promotion/SKILL.md`
 
 For GitHub implementation work, loading `.codex/skills/issue-to-code/SKILL.md` is mandatory before coding.
 That skill owns the pickup rule:


### PR DESCRIPTION
## Change Lane
- [ ] Implementation lane
- [ ] Docs authoring lane
- [x] Governance lane

## Linked Issue
N/A — governance lane. Depends on: #602 (release-channels capability spec — merge first).

## Summary
- Adds 4 bounded operator skills for the release-channel promotion lifecycle, each with one job:
  - `prepare-promotion` — produce promotion plan (code/migration/config delta, risk notes); no ref or DB changes.
  - `execute-promotion` — consume acknowledged plan; move stable ref, apply migrations to prod DB (port 15432), restart prod.
  - `verify-promotion` — health/status/settings-explain/smoke checks; PASS/FAIL with receipt appended to plan file.
  - `rollback-promotion` — restore stable to stable-prev, reverse reversible migrations, restart prod.
- Adds skill routing to `.codex/skills/README.md` and `AGENTS.md`.

## Governance Lane Check
- [x] Only changes approved governance surfaces (`.codex/skills/**`, `AGENTS.md`).
- [x] Limited to repo governance / agent workflow.
- [x] No product/runtime implementation changed.

## Validation
- [x] `python3 scripts/docs_guard.py` passes.
- [x] Each skill has one bounded job; routes to siblings for adjacent operations.
- [x] All four skills indexed in `.codex/skills/README.md` and `AGENTS.md`.

## Notes
- Merge #602 first; skills reference spec paths only stable on main after #602 merges.
- Implementation mechanics (resolver extension, migration tooling) are follow-up issues from `docs/RELEASE_CHANNELS/` task specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)