### PR TITLE
feat(canvas-01): add SessionLogWriter for canvas chat session logs

### DIFF
--- a/app/chat/__init__.py
+++ b/app/chat/__init__.py
@@ -1,5 +1,11 @@
-"""Read-only Chat cognition surfaces."""
+"""Chat cognition surfaces and canvas session log writer."""
 
 from app.chat.read_only_cognition import ReadOnlyChatCognition, ReadOnlyChatResponse
+from app.chat.session_log import SessionLog, SessionLogWriter
 
-__all__ = ["ReadOnlyChatCognition", "ReadOnlyChatResponse"]
+__all__ = [
+    "ReadOnlyChatCognition",
+    "ReadOnlyChatResponse",
+    "SessionLog",
+    "SessionLogWriter",
+]

--- a/app/chat/session_log.py
+++ b/app/chat/session_log.py
@@ -1,0 +1,161 @@
+"""Session log writer for canvas Chat sessions.
+
+Every canvas session produces an append-only provenance artifact under
+``vault/.chats/<note-slug>/`` with ``type: chat-session`` frontmatter.
+
+This module is pure file-system: no DB, no Docker required.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SessionLog:
+    """A single canvas session's log file handle."""
+
+    session_id: str
+    note_path: Path
+    log_path: Path
+    label: str
+    closed: bool = field(default=False)
+
+
+# ---------------------------------------------------------------------------
+# Writer
+# ---------------------------------------------------------------------------
+
+class SessionLogWriter:
+    """Write append-only session logs for canvas Chat sessions.
+
+    Usage::
+
+        writer = SessionLogWriter(vault_root=Path("vault"))
+        session = writer.open_session(
+            note_path=Path("vault/notes/my-note.md"),
+            session_label="restructure-decision-section",
+        )
+        writer.append_turn(session, "Can you move the rationale?", "Moved rationale")
+        writer.close_session(session, "One structural edit applied")
+    """
+
+    def __init__(self, vault_root: Path) -> None:
+        self._vault_root = vault_root
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def open_session(self, note_path: Path, session_label: str) -> SessionLog:
+        """Create the session log file and return a :class:`SessionLog` handle.
+
+        The log is written to::
+
+            <vault_root>/.chats/<note-slug>/<timestamp>-<label>.md
+
+        Frontmatter fields: ``type``, ``note``, ``date``, ``session_id``.
+        """
+        session_id = str(uuid.uuid4())
+        now = datetime.now(timezone.utc)
+        slug = _note_slug(note_path)
+        timestamp = _timestamp_for_path(now)
+        safe_label = _safe_label(session_label)
+
+        log_dir = self._vault_root / ".chats" / slug
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / f"{timestamp}-{safe_label}.md"
+
+        note_title = note_path.stem
+        date_iso = now.strftime("%Y-%m-%dT%H:%M")
+
+        frontmatter = (
+            "---\n"
+            f"type: chat-session\n"
+            f'note: "[[{note_title}]]"\n'
+            f"date: {date_iso}\n"
+            f"session_id: {session_id}\n"
+            "---\n"
+            "\n"
+            f"## Session: {session_label}\n"
+            "\n"
+        )
+        log_path.write_text(frontmatter, encoding="utf-8")
+
+        return SessionLog(
+            session_id=session_id,
+            note_path=note_path,
+            log_path=log_path,
+            label=session_label,
+        )
+
+    def append_turn(
+        self,
+        session: SessionLog,
+        user_prompt: str,
+        change_summary: str,
+    ) -> None:
+        """Append one turn (user prompt + change summary) to the session log.
+
+        Appends are strictly additive — prior content is never rewritten.
+        """
+        turn = (
+            f"**User:** {user_prompt}\n"
+            f"**Change:** {change_summary}\n"
+            "\n"
+        )
+        with session.log_path.open("a", encoding="utf-8") as fh:
+            fh.write(turn)
+
+    def close_session(self, session: SessionLog, total_summary: str) -> None:
+        """Append a final closure line and mark the session as closed."""
+        closure = f"---\n*Session closed. Total: {total_summary}*\n"
+        with session.log_path.open("a", encoding="utf-8") as fh:
+            fh.write(closure)
+        session.closed = True
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _note_slug(note_path: Path) -> str:
+    """Derive a filesystem-safe slug from the note filename.
+
+    Lowercased, spaces and underscores replaced with hyphens, other
+    non-alphanumeric characters stripped.
+    """
+    stem = note_path.stem
+    slug = stem.lower()
+    slug = re.sub(r"[\s_]+", "-", slug)
+    slug = re.sub(r"[^a-z0-9\-]", "", slug)
+    slug = re.sub(r"-{2,}", "-", slug).strip("-")
+    return slug or "note"
+
+
+def _timestamp_for_path(dt: datetime) -> str:
+    """ISO-8601 timestamp with colons replaced by hyphens for filesystem use.
+
+    Example: ``2026-04-22T14-30``
+    """
+    return dt.strftime("%Y-%m-%dT%H-%M")
+
+
+def _safe_label(label: str) -> str:
+    """Normalise a session label to a filesystem-safe hyphenated string."""
+    label = label.lower()
+    label = re.sub(r"[\s_]+", "-", label)
+    label = re.sub(r"[^a-z0-9\-]", "", label)
+    label = re.sub(r"-{2,}", "-", label).strip("-")
+    return label or "session"
+
+
+__all__ = ["SessionLog", "SessionLogWriter"]

--- a/tests/chat/test_session_log_writer.py
+++ b/tests/chat/test_session_log_writer.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from app.chat.session_log import SessionLog, SessionLogWriter
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _writer(tmp_path: Path) -> SessionLogWriter:
+    return SessionLogWriter(vault_root=tmp_path)
+
+
+def _note(tmp_path: Path, name: str = "my-design-decision.md") -> Path:
+    note = tmp_path / "notes" / name
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text("---\ntype: note\n---\n\nBody.\n", encoding="utf-8")
+    return note
+
+
+# ---------------------------------------------------------------------------
+# AC1: open_session creates a file under .chats/<slug>/
+# ---------------------------------------------------------------------------
+
+def test_open_creates_file_in_chats_namespace(tmp_path: Path) -> None:
+    writer = _writer(tmp_path)
+    note = _note(tmp_path)
+    session = writer.open_session(note, "restructure-decision-section")
+
+    assert session.log_path.exists()
+    assert ".chats" in session.log_path.parts
+    # Parent dir is the note slug
+    assert session.log_path.parent.name == "my-design-decision"
+
+
+# ---------------------------------------------------------------------------
+# AC2: path follows vault/.chats/<note-slug>/<timestamp>-<label>.md
+# ---------------------------------------------------------------------------
+
+def test_log_path_uses_note_slug_and_timestamp(tmp_path: Path) -> None:
+    writer = _writer(tmp_path)
+    note = _note(tmp_path, "My Design Decision.md")
+    session = writer.open_session(note, "expand-context")
+
+    # slug directory
+    assert session.log_path.parent.parent == tmp_path / ".chats"
+    # filename contains the label
+    assert "expand-context" in session.log_path.name
+    # filename contains a timestamp-like prefix (digits and hyphens before label)
+    assert re.match(r"\d{4}-\d{2}-\d{2}T\d{2}-\d{2}", session.log_path.stem)
+    assert session.log_path.suffix == ".md"
+
+
+# ---------------------------------------------------------------------------
+# AC3: frontmatter contains type, note, date, session_id
+# ---------------------------------------------------------------------------
+
+def test_frontmatter_fields_present(tmp_path: Path) -> None:
+    writer = _writer(tmp_path)
+    note = _note(tmp_path)
+    session = writer.open_session(note, "smoke")
+
+    content = session.log_path.read_text(encoding="utf-8")
+    assert "type: chat-session" in content
+    assert "note:" in content
+    assert "date:" in content
+    assert "session_id:" in content
+
+
+# ---------------------------------------------------------------------------
+# AC4: type: chat-session — no collision test
+# ---------------------------------------------------------------------------
+
+def test_type_field_is_chat_session_only(tmp_path: Path) -> None:
+    writer = _writer(tmp_path)
+    note = _note(tmp_path)
+    session = writer.open_session(note, "smoke")
+
+    content = session.log_path.read_text(encoding="utf-8")
+    # The frontmatter block type value must be exactly chat-session
+    fm_match = re.search(r"^type:\s*(.+)$", content, re.MULTILINE)
+    assert fm_match is not None
+    assert fm_match.group(1).strip() == "chat-session"
+
+
+# ---------------------------------------------------------------------------
+# AC5: appends are additive; prior content preserved
+# ---------------------------------------------------------------------------
+
+def test_append_does_not_rewrite_prior_content(tmp_path: Path) -> None:
+    writer = _writer(tmp_path)
+    note = _note(tmp_path)
+    session = writer.open_session(note, "multi-turn")
+
+    writer.append_turn(session, "first prompt", "first change")
+    after_first = session.log_path.read_text(encoding="utf-8")
+
+    writer.append_turn(session, "second prompt", "second change")
+    after_second = session.log_path.read_text(encoding="utf-8")
+
+    # All prior content still present
+    assert "first prompt" in after_second
+    assert "first change" in after_second
+    # New content appended
+    assert "second prompt" in after_second
+    assert "second change" in after_second
+    # File only grew
+    assert len(after_second) > len(after_first)
+
+
+# ---------------------------------------------------------------------------
+# AC6: close_session appends a closure line with total summary
+# ---------------------------------------------------------------------------
+
+def test_close_session_appends_closure_line(tmp_path: Path) -> None:
+    writer = _writer(tmp_path)
+    note = _note(tmp_path)
+    session = writer.open_session(note, "smoke")
+    writer.append_turn(session, "a prompt", "a change")
+    writer.close_session(session, "One structural edit: rationale section added")
+
+    content = session.log_path.read_text(encoding="utf-8")
+    assert "One structural edit: rationale section added" in content
+    # Session should be marked closed
+    assert session.closed
+
+
+# ---------------------------------------------------------------------------
+# Extra: SessionLog carries expected fields
+# ---------------------------------------------------------------------------
+
+def test_session_log_carries_session_id_and_note_path(tmp_path: Path) -> None:
+    writer = _writer(tmp_path)
+    note = _note(tmp_path)
+    session = writer.open_session(note, "smoke")
+
+    assert session.session_id  # non-empty UUID string
+    assert session.note_path == note
+    assert not session.closed
+
+
+def test_append_records_user_prompt_and_change_summary(tmp_path: Path) -> None:
+    writer = _writer(tmp_path)
+    note = _note(tmp_path)
+    session = writer.open_session(note, "smoke")
+    writer.append_turn(session, "Can you move the rationale?", "Moved rationale under ## Rationale")
+
+    content = session.log_path.read_text(encoding="utf-8")
+    assert "Can you move the rationale?" in content
+    assert "Moved rationale under ## Rationale" in content


### PR DESCRIPTION
Fixes #598

## Summary
- Adds `app/chat/session_log.py` with `SessionLogWriter` and `SessionLog` dataclass
- Session logs written to `vault/.chats/<note-slug>/<timestamp>-<label>.md` with `type: chat-session`, `note`, `date`, `session_id` frontmatter
- Append-only: `append_turn` only appends, never rewrites; `close_session` marks the session closed with a total summary line
- Pure file-system: no DB, no Docker required
- Exports `SessionLog` and `SessionLogWriter` from `app/chat`

## Test plan
- [ ] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/chat/test_session_log_writer.py -m "not pg" -q` → 8 passed
- [ ] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/chat/ -m "not pg" -q` → 13 passed (existing read-only cognition tests unaffected)
- [ ] Smoke: session log file created at correct path with correct frontmatter (verified manually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)