### PR TITLE
feat(canvas-02): add CanvasWriter for in-place note body editing

### DIFF
--- a/app/chat/__init__.py
+++ b/app/chat/__init__.py
@@ -1,5 +1,14 @@
-"""Read-only Chat cognition surfaces."""
+"""Chat cognition surfaces, canvas session log writer, and body editor."""
 
+from app.chat.canvas_writer import CanvasWriter, GovernanceBearingMutationError
 from app.chat.read_only_cognition import ReadOnlyChatCognition, ReadOnlyChatResponse
+from app.chat.session_log import SessionLog, SessionLogWriter
 
-__all__ = ["ReadOnlyChatCognition", "ReadOnlyChatResponse"]
+__all__ = [
+    "CanvasWriter",
+    "GovernanceBearingMutationError",
+    "ReadOnlyChatCognition",
+    "ReadOnlyChatResponse",
+    "SessionLog",
+    "SessionLogWriter",
+]

--- a/app/chat/canvas_writer.py
+++ b/app/chat/canvas_writer.py
@@ -96,7 +96,7 @@ class CanvasWriter:
 
         # Reassemble: original frontmatter + new body
         if frontmatter_block is not None:
-            new_content = f"---\n{frontmatter_block}---\n\n{new_body}\n"
+            new_content = f"---{frontmatter_block}\n---\n{new_body}"
         else:
             new_content = new_body if new_body.endswith("\n") else new_body + "\n"
 
@@ -126,18 +126,19 @@ def _split_frontmatter(content: str) -> tuple[str | None, str]:
 
     Returns ``(None, content)`` if there is no frontmatter block.
     ``frontmatter_inner`` is the text between the opening and closing ``---``
-    delimiters (not including the delimiters themselves).
+    delimiters (not including the delimiters or trailing newline).
     """
     if not content.startswith("---"):
         return None, content
 
-    # Find the closing --- after the opening
+    # Find the closing --- after the opening (handle both with body and EOF cases)
     rest = content[3:]
-    close = re.search(r"\n---\s*\n", rest)
+    # Try matching with newline after --- (has body)
+    close = re.search(r"\n---(?:\s*\n|\s*$)", rest)
     if close is None:
         return None, content
 
-    frontmatter_inner = rest[: close.start() + 1]  # include trailing newline
+    frontmatter_inner = rest[: close.start()]  # exclude trailing newline
     body = rest[close.end() :]
     return frontmatter_inner, body
 

--- a/app/chat/canvas_writer.py
+++ b/app/chat/canvas_writer.py
@@ -1,0 +1,145 @@
+"""Canvas writer: in-place body editing for canvas Chat sessions.
+
+Edits are authorized by the presence of an open session and applied
+directly to the note body. Frontmatter is always preserved unchanged.
+Governance-bearing mutations (frontmatter edits, cross-note writes)
+are explicitly rejected and must use ``GovernanceRouter`` instead.
+
+Writes route through ``app/knowledge/write_ops.py`` (KnowledgePort
+boundary) — no direct file-system writes from this module.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from app.chat.session_log import SessionLog, SessionLogWriter
+from app.knowledge.write_ops import write_note_from_absolute
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+class GovernanceBearingMutationError(Exception):
+    """Raised when a canvas write would bypass the governance pipeline.
+
+    Callers should route governance-bearing mutations (frontmatter edits,
+    cross-note writes, lifecycle transitions) through ``GovernanceRouter``.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Writer
+# ---------------------------------------------------------------------------
+
+class CanvasWriter:
+    """Apply in-place body edits to a note during an active canvas session.
+
+    All writes route through ``app/knowledge/write_ops.write_note_from_absolute``
+    (the KnowledgePort boundary). Frontmatter is separated before writing and
+    reattached unchanged.
+
+    Usage::
+
+        lw = SessionLogWriter(vault_root=Path("vault"))
+        cw = CanvasWriter(vault_root=Path("vault"), log_writer=lw)
+        session = lw.open_session(note_path, "expand-context")
+        cw.apply_edit(session, "New body content.", "added context section")
+        lw.close_session(session, "one edit applied")
+    """
+
+    def __init__(self, vault_root: Path, log_writer: SessionLogWriter) -> None:
+        self._vault_root = vault_root.resolve()
+        self._log_writer = log_writer
+
+    def apply_edit(
+        self,
+        session: SessionLog | None,
+        new_body: str,
+        change_summary: str,
+    ) -> None:
+        """Replace the body of ``session.note_path`` with ``new_body``.
+
+        Raises ``GovernanceBearingMutationError`` when:
+        - ``session`` is ``None`` (no active session)
+        - ``session.note_path`` is outside ``vault_root`` (cross-note/vault write)
+        - ``new_body`` contains a frontmatter block (``---`` at start)
+        """
+        # Guard: open session required
+        if session is None:
+            raise GovernanceBearingMutationError(
+                "No open session — canvas writes require an active session"
+            )
+
+        # Guard: note path must be within vault_root (no cross-vault writes)
+        note_abs = session.note_path.resolve()
+        try:
+            note_abs.relative_to(self._vault_root)
+        except ValueError:
+            raise GovernanceBearingMutationError(
+                f"Cross-note write blocked: {session.note_path} is outside "
+                f"vault root {self._vault_root}"
+            )
+
+        # Guard: new_body must not contain a frontmatter block
+        if _body_contains_frontmatter(new_body):
+            raise GovernanceBearingMutationError(
+                "Frontmatter modification is governance-bearing — "
+                "use GovernanceRouter for frontmatter changes"
+            )
+
+        # Read current note and split frontmatter from body
+        current = session.note_path.read_text(encoding="utf-8")
+        frontmatter_block, _ = _split_frontmatter(current)
+
+        # Reassemble: original frontmatter + new body
+        if frontmatter_block is not None:
+            new_content = f"---\n{frontmatter_block}---\n\n{new_body}\n"
+        else:
+            new_content = new_body if new_body.endswith("\n") else new_body + "\n"
+
+        # Write through KnowledgePort boundary
+        write_note_from_absolute(note_abs, new_content, vault_root=self._vault_root)
+
+        # Append to session log (change summary; user prompt not captured at this layer)
+        self._log_writer.append_turn(session, user_prompt="", change_summary=change_summary)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _body_contains_frontmatter(body: str) -> bool:
+    """Return True if ``body`` starts with a YAML frontmatter block (``---``)."""
+    stripped = body.lstrip()
+    if not stripped.startswith("---"):
+        return False
+    # Must have a closing --- line to count as frontmatter
+    rest = stripped[3:]
+    return bool(re.search(r"\n---", rest))
+
+
+def _split_frontmatter(content: str) -> tuple[str | None, str]:
+    """Split a note's content into (frontmatter_inner, body).
+
+    Returns ``(None, content)`` if there is no frontmatter block.
+    ``frontmatter_inner`` is the text between the opening and closing ``---``
+    delimiters (not including the delimiters themselves).
+    """
+    if not content.startswith("---"):
+        return None, content
+
+    # Find the closing --- after the opening
+    rest = content[3:]
+    close = re.search(r"\n---\s*\n", rest)
+    if close is None:
+        return None, content
+
+    frontmatter_inner = rest[: close.start() + 1]  # include trailing newline
+    body = rest[close.end() :]
+    return frontmatter_inner, body
+
+
+__all__ = ["CanvasWriter", "GovernanceBearingMutationError"]

--- a/tests/chat/test_canvas_writer.py
+++ b/tests/chat/test_canvas_writer.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from app.chat.canvas_writer import CanvasWriter, GovernanceBearingMutationError
+from app.chat.session_log import SessionLog, SessionLogWriter
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _log_writer(vault_root: Path) -> SessionLogWriter:
+    fixed_now = datetime(2026, 4, 24, 10, 0)
+    return SessionLogWriter(vault_root=vault_root, now_fn=lambda: fixed_now, uuid_fn=lambda: "test-uuid")
+
+
+def _note(vault_root: Path, name: str = "my-note.md", body: str = "Original body.") -> Path:
+    note = vault_root / "notes" / name
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text(f"---\ntype: note\nmaturity: draft\n---\n\n{body}\n", encoding="utf-8")
+    return note
+
+
+def _open_session(vault_root: Path, note: Path, label: str = "smoke") -> SessionLog:
+    lw = _log_writer(vault_root)
+    return lw.open_session(note, label)
+
+
+# ---------------------------------------------------------------------------
+# AC1: apply_edit writes body to vault via KnowledgePort
+# ---------------------------------------------------------------------------
+
+def test_apply_edit_writes_body_to_vault(tmp_path: Path) -> None:
+    note = _note(tmp_path)
+    session = _open_session(tmp_path, note)
+    lw = _log_writer(tmp_path)
+    writer = CanvasWriter(vault_root=tmp_path, log_writer=lw)
+
+    writer.apply_edit(session, "New body content.", "replaced body")
+
+    content = note.read_text(encoding="utf-8")
+    assert "New body content." in content
+
+
+# ---------------------------------------------------------------------------
+# AC2: apply_edit preserves frontmatter unchanged
+# ---------------------------------------------------------------------------
+
+def test_apply_edit_preserves_frontmatter(tmp_path: Path) -> None:
+    note = _note(tmp_path)
+    session = _open_session(tmp_path, note)
+    lw = _log_writer(tmp_path)
+    writer = CanvasWriter(vault_root=tmp_path, log_writer=lw)
+
+    writer.apply_edit(session, "Brand new body.", "body replaced")
+
+    content = note.read_text(encoding="utf-8")
+    assert "type: note" in content
+    assert "maturity: draft" in content
+    # Original body replaced
+    assert "Original body." not in content
+    assert "Brand new body." in content
+
+
+# ---------------------------------------------------------------------------
+# AC3: apply_edit raises GovernanceBearingMutationError on frontmatter in body
+# ---------------------------------------------------------------------------
+
+def test_apply_edit_rejects_frontmatter_in_body(tmp_path: Path) -> None:
+    note = _note(tmp_path)
+    session = _open_session(tmp_path, note)
+    lw = _log_writer(tmp_path)
+    writer = CanvasWriter(vault_root=tmp_path, log_writer=lw)
+
+    with pytest.raises(GovernanceBearingMutationError):
+        writer.apply_edit(session, "---\nmaturity: evergreen\n---\n\nBody", "frontmatter sneak")
+
+
+# ---------------------------------------------------------------------------
+# AC4: apply_edit raises on cross-note target (note_path outside vault_root)
+# ---------------------------------------------------------------------------
+
+def test_apply_edit_rejects_cross_note_target(tmp_path: Path) -> None:
+    vault_a = tmp_path / "vault_a"
+    vault_b = tmp_path / "vault_b"
+    note_b = vault_b / "notes" / "other-note.md"
+    note_b.parent.mkdir(parents=True, exist_ok=True)
+    note_b.write_text("---\ntype: note\n---\n\nOther vault body.\n", encoding="utf-8")
+
+    lw_a = _log_writer(vault_a)
+    # Session was opened with a note path outside vault_a
+    fake_session = SessionLog(
+        log_path=vault_a / ".chats" / "other-note" / "2026-04-24T10-00-smoke.md",
+        session_id="cross-note-test",
+        note_path=note_b,
+        label="cross",
+    )
+    writer = CanvasWriter(vault_root=vault_a, log_writer=lw_a)
+
+    with pytest.raises(GovernanceBearingMutationError):
+        writer.apply_edit(fake_session, "Sneaky body.", "cross-vault write attempt")
+
+
+# ---------------------------------------------------------------------------
+# AC5: apply_edit raises without open session
+# ---------------------------------------------------------------------------
+
+def test_apply_edit_requires_open_session(tmp_path: Path) -> None:
+    lw = _log_writer(tmp_path)
+    writer = CanvasWriter(vault_root=tmp_path, log_writer=lw)
+
+    with pytest.raises(GovernanceBearingMutationError):
+        writer.apply_edit(None, "body", "no session")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# AC6: apply_edit records change summary in session log
+# ---------------------------------------------------------------------------
+
+def test_apply_edit_records_turn_in_session_log(tmp_path: Path) -> None:
+    note = _note(tmp_path)
+    lw = _log_writer(tmp_path)
+    session = lw.open_session(note, "record-turn")
+    writer = CanvasWriter(vault_root=tmp_path, log_writer=lw)
+
+    writer.apply_edit(session, "Updated body.", "added three paragraphs")
+
+    log_content = session.log_path.read_text(encoding="utf-8")
+    assert "added three paragraphs" in log_content
+
+
+# ---------------------------------------------------------------------------
+# Extra: multiple edits each append to the log
+# ---------------------------------------------------------------------------
+
+def test_multiple_edits_each_append_to_log(tmp_path: Path) -> None:
+    note = _note(tmp_path)
+    lw = _log_writer(tmp_path)
+    session = lw.open_session(note, "multi-edit")
+    writer = CanvasWriter(vault_root=tmp_path, log_writer=lw)
+
+    writer.apply_edit(session, "Body v1.", "first edit")
+    writer.apply_edit(session, "Body v2.", "second edit")
+
+    log_content = session.log_path.read_text(encoding="utf-8")
+    assert "first edit" in log_content
+    assert "second edit" in log_content
+    # Latest body is what's in the note
+    assert "Body v2." in note.read_text(encoding="utf-8")


### PR DESCRIPTION
Fixes #599

## Summary
- Adds `app/chat/canvas_writer.py` with `CanvasWriter` and `GovernanceBearingMutationError`
- `apply_edit(session, new_body, change_summary)` reads the current note, preserves frontmatter unchanged, writes the new body through `write_note_from_absolute` (KnowledgePort boundary), and appends a turn to the session log
- Raises `GovernanceBearingMutationError` for: frontmatter block in new_body, note path outside vault_root, or no session (None)
- Exports `CanvasWriter` and `GovernanceBearingMutationError` from `app.chat`

## Test plan
- [ ] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/chat/test_canvas_writer.py -m "not pg" -q` → 7 passed
- [ ] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/chat/ -m "not pg" -q` → 18 passed (session log tests unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)