### PR TITLE
feat(canvas-03): add GovernanceRouter for canvas governance-bearing mutations

### DIFF
--- a/app/chat/__init__.py
+++ b/app/chat/__init__.py
@@ -1,12 +1,16 @@
-"""Chat cognition surfaces, canvas session log writer, and body editor."""
+"""Chat cognition surfaces, canvas session log writer, body editor, and governance router."""
 
 from app.chat.canvas_writer import CanvasWriter, GovernanceBearingMutationError
+from app.chat.governance_router import GovernanceActionType, GovernanceRouter, PendingAction
 from app.chat.read_only_cognition import ReadOnlyChatCognition, ReadOnlyChatResponse
 from app.chat.session_log import SessionLog, SessionLogWriter
 
 __all__ = [
     "CanvasWriter",
+    "GovernanceActionType",
     "GovernanceBearingMutationError",
+    "GovernanceRouter",
+    "PendingAction",
     "ReadOnlyChatCognition",
     "ReadOnlyChatResponse",
     "SessionLog",

--- a/app/chat/governance_router.py
+++ b/app/chat/governance_router.py
@@ -1,0 +1,148 @@
+"""Governance router: canvas-to-Panel bridge for governance-bearing mutations.
+
+Canvas sessions may request governance-bearing mutations (frontmatter changes,
+maturity transitions, cross-note operations). These must NOT go through
+``CanvasWriter``; they must enter the Panel admission pipeline with the full
+write-guard, allowlist, and receipt-generation path intact.
+
+This module provides ``GovernanceRouter`` as the positive complement to
+``CanvasWriter``'s rejection guards: instead of just raising
+``GovernanceBearingMutationError``, the canvas surface can route here to
+create a Panel intent and record it as pending.
+
+The note is **never** mutated directly by this module. Execution happens
+later, through the normal Panel pipeline.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Protocol
+
+from app.chat.session_log import SessionLog, SessionLogWriter
+from app.write_guard import DEFAULT_WRITE_GUARD
+
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+class GovernanceActionType(str, Enum):
+    """Governance action types recognised by the canvas-to-Panel bridge."""
+
+    FRONTMATTER_UPDATE = "frontmatter_update"
+    MATURITY_TRANSITION = "maturity_transition"
+    NOTE_LIFECYCLE = "note_lifecycle"
+    CROSS_NOTE = "cross_note"
+
+
+@dataclass
+class PendingAction:
+    """Receipt returned when a governance action is successfully queued.
+
+    ``intent_id`` links back to the Panel pipeline entry; the session log
+    records this ID so the provenance trail is traceable.
+    """
+
+    intent_id: str
+    session_id: str
+    action_type: GovernanceActionType
+    payload: dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# Pipeline Protocol (injectable for test isolation)
+# ---------------------------------------------------------------------------
+
+class PanelPipeline(Protocol):
+    """Minimal interface the router needs from the Panel admission path."""
+
+    def submit_intent(self, action_type: str, payload: dict, session_id: str) -> str:
+        """Submit a governance intent. Returns the intent_id receipt."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+class GovernanceRouter:
+    """Route canvas-originated governance requests into the Panel pipeline.
+
+    Usage::
+
+        router = GovernanceRouter(
+            panel_pipeline=my_pipeline,
+            session_log_writer=log_writer,
+        )
+        pending = router.request_governance_action(
+            session=session,
+            action_type=GovernanceActionType.FRONTMATTER_UPDATE,
+            payload={"field": "maturity", "value": "evergreen"},
+        )
+        # pending.intent_id links to the Panel entry
+        # Note is NOT mutated — intent is queued for Panel admission
+
+    The ``panel_pipeline`` and ``write_guard`` arguments are injectable so the
+    router is fully testable without Postgres or a live Panel runtime.
+    """
+
+    def __init__(
+        self,
+        panel_pipeline: PanelPipeline,
+        session_log_writer: SessionLogWriter,
+        write_guard: Any = None,
+    ) -> None:
+        self._pipeline = panel_pipeline
+        self._log_writer = session_log_writer
+        self._write_guard = write_guard if write_guard is not None else DEFAULT_WRITE_GUARD
+
+    def request_governance_action(
+        self,
+        session: SessionLog,
+        action_type: GovernanceActionType,
+        payload: dict[str, Any],
+    ) -> PendingAction:
+        """Queue a governance action in the Panel pipeline and return a receipt.
+
+        Steps:
+        1. Assert write-guard is open (raises ``WritesBlockedError`` if not).
+        2. Submit the intent to the Panel pipeline — returns ``intent_id``.
+        3. Append a pending-action record to the session log.
+        4. Return ``PendingAction`` with the intent receipt.
+
+        The note is **never** touched directly; callers must not assume the
+        mutation has been applied.
+        """
+        # Step 1: write-guard check (respects system-wide lock)
+        self._write_guard.assert_writes_allowed("canvas.governance_action")
+
+        # Step 2: submit to Panel pipeline
+        intent_id = self._pipeline.submit_intent(
+            action_type=action_type.value,
+            payload=payload,
+            session_id=session.session_id,
+        )
+
+        # Step 3: record in session log as pending (not executed)
+        pending_record = (
+            f"Governance action pending: {action_type.value} "
+            f"payload={payload} (intent: {intent_id})"
+        )
+        self._log_writer.append_turn(
+            session,
+            user_prompt="",
+            change_summary=pending_record,
+        )
+
+        # Step 4: return receipt
+        return PendingAction(
+            intent_id=intent_id,
+            session_id=session.session_id,
+            action_type=action_type,
+            payload=payload,
+        )
+
+
+__all__ = ["GovernanceActionType", "GovernanceRouter", "PanelPipeline", "PendingAction"]

--- a/tests/chat/test_governance_router.py
+++ b/tests/chat/test_governance_router.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from app.chat.canvas_writer import GovernanceBearingMutationError
+from app.chat.governance_router import (
+    GovernanceActionType,
+    GovernanceRouter,
+    PendingAction,
+)
+from app.chat.session_log import SessionLog, SessionLogWriter
+from app.write_guard import WritesBlockedError
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _MockPipeline:
+    """Stub Panel pipeline for test isolation — no DB, no outbox."""
+
+    def __init__(self, intent_id: str = "intent-abc123") -> None:
+        self._intent_id = intent_id
+        self.submitted: list[dict[str, Any]] = []
+
+    def submit_intent(self, action_type: str, payload: dict, session_id: str) -> str:
+        self.submitted.append({"action_type": action_type, "payload": payload, "session_id": session_id})
+        return self._intent_id
+
+
+class _BlockedWriteGuard:
+    """Write guard stub that always blocks writes."""
+
+    def assert_writes_allowed(self, action: str) -> None:
+        raise WritesBlockedError(state="blocked", reason="test lock", action=action)
+
+
+class _OpenWriteGuard:
+    """Write guard stub that always permits writes."""
+
+    def assert_writes_allowed(self, action: str) -> None:
+        pass  # always open
+
+
+def _log_writer(vault_root: Path) -> SessionLogWriter:
+    fixed_now = datetime(2026, 4, 24, 10, 0)
+    return SessionLogWriter(vault_root=vault_root, now_fn=lambda: fixed_now, uuid_fn=lambda: "test-uuid")
+
+
+def _session(vault_root: Path) -> SessionLog:
+    note = vault_root / "notes" / "my-note.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text("---\ntype: note\n---\n\nOriginal body.\n", encoding="utf-8")
+    lw = _log_writer(vault_root)
+    return lw.open_session(note, "governance-test")
+
+
+# ---------------------------------------------------------------------------
+# AC1: request_governance_action routes to Panel pipeline (not note directly)
+# ---------------------------------------------------------------------------
+
+def test_request_routes_to_panel_pipeline(tmp_path: Path) -> None:
+    pipeline = _MockPipeline()
+    lw = _log_writer(tmp_path)
+    session = _session(tmp_path)
+    router = GovernanceRouter(panel_pipeline=pipeline, session_log_writer=lw, write_guard=_OpenWriteGuard())
+
+    result = router.request_governance_action(
+        session=session,
+        action_type=GovernanceActionType.FRONTMATTER_UPDATE,
+        payload={"field": "maturity", "value": "evergreen"},
+    )
+
+    assert len(pipeline.submitted) == 1
+    assert pipeline.submitted[0]["action_type"] == GovernanceActionType.FRONTMATTER_UPDATE
+    assert isinstance(result, PendingAction)
+    assert result.intent_id == "intent-abc123"
+
+
+# ---------------------------------------------------------------------------
+# AC2: governance request does not immediately mutate the note
+# ---------------------------------------------------------------------------
+
+def test_request_does_not_write_note_directly(tmp_path: Path) -> None:
+    pipeline = _MockPipeline()
+    lw = _log_writer(tmp_path)
+    session = _session(tmp_path)
+    note = session.note_path
+    original = note.read_text(encoding="utf-8")
+
+    router = GovernanceRouter(panel_pipeline=pipeline, session_log_writer=lw, write_guard=_OpenWriteGuard())
+    router.request_governance_action(
+        session=session,
+        action_type=GovernanceActionType.FRONTMATTER_UPDATE,
+        payload={"field": "maturity", "value": "evergreen"},
+    )
+
+    # Note must be byte-for-byte unchanged
+    assert note.read_text(encoding="utf-8") == original
+
+
+# ---------------------------------------------------------------------------
+# AC3: session log records pending governance action with Panel intent ID
+# ---------------------------------------------------------------------------
+
+def test_session_log_records_pending_intent(tmp_path: Path) -> None:
+    pipeline = _MockPipeline(intent_id="intent-xyz999")
+    lw = _log_writer(tmp_path)
+    session = _session(tmp_path)
+    router = GovernanceRouter(panel_pipeline=pipeline, session_log_writer=lw, write_guard=_OpenWriteGuard())
+
+    router.request_governance_action(
+        session=session,
+        action_type=GovernanceActionType.FRONTMATTER_UPDATE,
+        payload={"field": "maturity", "value": "evergreen"},
+    )
+
+    log_content = session.log_path.read_text(encoding="utf-8")
+    assert "intent-xyz999" in log_content
+    assert "pending" in log_content.lower()
+
+
+# ---------------------------------------------------------------------------
+# AC4 (regression): CanvasWriter.apply_edit still raises on frontmatter
+# ---------------------------------------------------------------------------
+
+def test_apply_edit_rejects_frontmatter_in_body_regression(tmp_path: Path) -> None:
+    """Regression: GovernanceBearingMutationError guard in CanvasWriter must not be removed."""
+    from app.chat.canvas_writer import CanvasWriter
+
+    note = tmp_path / "notes" / "reg-note.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text("---\ntype: note\n---\n\nBody.\n", encoding="utf-8")
+    lw = _log_writer(tmp_path)
+    session = lw.open_session(note, "regression")
+    writer = CanvasWriter(vault_root=tmp_path, log_writer=lw)
+
+    with pytest.raises(GovernanceBearingMutationError):
+        writer.apply_edit(session, "---\nmaturity: evergreen\n---\n\nBody", "frontmatter sneak")
+
+
+# ---------------------------------------------------------------------------
+# AC5: request_governance_action respects write_guard
+# ---------------------------------------------------------------------------
+
+def test_request_respects_write_guard(tmp_path: Path) -> None:
+    pipeline = _MockPipeline()
+    lw = _log_writer(tmp_path)
+    session = _session(tmp_path)
+    router = GovernanceRouter(
+        panel_pipeline=pipeline,
+        session_log_writer=lw,
+        write_guard=_BlockedWriteGuard(),
+    )
+
+    with pytest.raises(WritesBlockedError):
+        router.request_governance_action(
+            session=session,
+            action_type=GovernanceActionType.FRONTMATTER_UPDATE,
+            payload={"field": "maturity", "value": "evergreen"},
+        )
+
+    # Pipeline must not have been called
+    assert len(pipeline.submitted) == 0
+
+
+# ---------------------------------------------------------------------------
+# Extra: PendingAction carries session linkage
+# ---------------------------------------------------------------------------
+
+def test_pending_action_carries_session_id(tmp_path: Path) -> None:
+    pipeline = _MockPipeline(intent_id="intent-link-test")
+    lw = _log_writer(tmp_path)
+    session = _session(tmp_path)
+    router = GovernanceRouter(panel_pipeline=pipeline, session_log_writer=lw, write_guard=_OpenWriteGuard())
+
+    result = router.request_governance_action(
+        session=session,
+        action_type=GovernanceActionType.FRONTMATTER_UPDATE,
+        payload={"field": "maturity", "value": "evergreen"},
+    )
+
+    assert result.session_id == session.session_id
+    assert result.intent_id == "intent-link-test"


### PR DESCRIPTION
Fixes #600

Depends on #618 (canvas-02 CanvasWriter).

## Summary
- Adds `app/chat/governance_router.py` with `GovernanceRouter`, `GovernanceActionType` enum, and `PendingAction` dataclass
- `request_governance_action(session, action_type, payload)` checks the write-guard, submits to an injectable `PanelPipeline`, records the pending intent ID in the session log, and returns a `PendingAction` receipt — the note is never touched
- Fully injectable: `panel_pipeline` and `write_guard` take stub implementations in tests — no Postgres required
- Regression: `CanvasWriter.apply_edit` frontmatter guard still raises (AC4 regression test included)

## Test plan
- [ ] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/chat/ -m "not pg" -q` → 24 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)