### PR TITLE
feat(dispatcher): add SQLite store, schema, and JSONL event log foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,5 @@ tmp/index-outbox.jsonl
 *.jsonl
 tmp/index.jsonl
 runtime/settings/
+runtime/dispatcher/
 verification_report.md

--- a/app/dispatcher/__init__.py
+++ b/app/dispatcher/__init__.py
@@ -1,0 +1,22 @@
+"""Local Agent Issue Dispatcher MVP.
+
+Operational coordination layer for multi-agent issue pickup. See
+``docs/AGENT_ISSUE_DISPATCHER.md`` for the contract.
+"""
+
+from app.dispatcher.config import DispatcherPaths, load_paths
+from app.dispatcher.events import JsonlEventWriter
+from app.dispatcher.models import EventRecord, LeaseRecord, SyncState, TaskRecord
+from app.dispatcher.store import DispatcherStore, SqliteStore
+
+__all__ = [
+    "DispatcherPaths",
+    "DispatcherStore",
+    "EventRecord",
+    "JsonlEventWriter",
+    "LeaseRecord",
+    "SqliteStore",
+    "SyncState",
+    "TaskRecord",
+    "load_paths",
+]

--- a/app/dispatcher/config.py
+++ b/app/dispatcher/config.py
@@ -1,0 +1,35 @@
+"""Runtime path configuration for the dispatcher MVP."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_STATE_DIR = Path("runtime/dispatcher")
+DEFAULT_DB_NAME = "dispatcher.sqlite3"
+DEFAULT_EVENTS_NAME = "events.jsonl"
+
+
+@dataclass(frozen=True)
+class DispatcherPaths:
+    state_dir: Path
+    db_path: Path
+    events_path: Path
+
+    def ensure(self) -> None:
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self.events_path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def load_paths(env: dict[str, str] | None = None) -> DispatcherPaths:
+    src = env if env is not None else os.environ
+    state_dir = Path(src.get("DISPATCHER_STATE_DIR", str(DEFAULT_STATE_DIR))).expanduser()
+    db_path = Path(
+        src.get("DISPATCHER_DB_PATH", str(state_dir / DEFAULT_DB_NAME))
+    ).expanduser()
+    events_path = Path(
+        src.get("DISPATCHER_EVENTS_PATH", str(state_dir / DEFAULT_EVENTS_NAME))
+    ).expanduser()
+    return DispatcherPaths(state_dir=state_dir, db_path=db_path, events_path=events_path)

--- a/app/dispatcher/events.py
+++ b/app/dispatcher/events.py
@@ -1,0 +1,40 @@
+"""Append-only JSONL event writer for the dispatcher MVP."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from app.dispatcher.models import EventRecord
+
+
+class JsonlEventWriter:
+    """Append events as one JSON object per line.
+
+    JSONL is the audit trail; SQLite remains the live current-state authority.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = Path(path)
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def append(self, event: EventRecord) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(event.to_dict(), sort_keys=True, ensure_ascii=False)
+        with self._path.open("a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+
+    def read_all(self) -> list[dict[str, Any]]:
+        if not self._path.exists():
+            return []
+        rows: list[dict[str, Any]] = []
+        for ln in self._path.read_text(encoding="utf-8").splitlines():
+            ln = ln.strip()
+            if not ln:
+                continue
+            rows.append(json.loads(ln))
+        return rows

--- a/app/dispatcher/models.py
+++ b/app/dispatcher/models.py
@@ -1,0 +1,78 @@
+"""Dispatcher MVP data model.
+
+Mirrors the contract in ``docs/AGENT_ISSUE_DISPATCHER.md``. Persistence is
+intentionally minimal: the dispatcher is operational coordination state, not a
+durable lifecycle replacement for GitHub.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+@dataclass
+class TaskRecord:
+    task_id: str
+    issue_number: int
+    title: str
+    status: str
+    priority: str
+    source_anchor_refs: list[str]
+    created_at: str
+    updated_at: str
+    claimed_by: str | None = None
+    lease_id: str | None = None
+    lease_expires_at: str | None = None
+    linked_pr: str | None = None
+    blocked_reason: str | None = None
+    last_heartbeat_at: str | None = None
+    sync_state: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class LeaseRecord:
+    lease_id: str
+    resource: str
+    holder: str
+    ttl_seconds: int
+    acquired_at: str
+    expires_at: str
+    heartbeat_at: str | None = None
+    released_at: str | None = None
+    release_reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class EventRecord:
+    event_id: str
+    timestamp: str
+    task_id: str
+    event_type: str
+    actor: str
+    lease_id: str | None = None
+    payload: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class SyncState:
+    last_pull_at: str | None = None
+    source_version: str | None = None
+    sync_result: str | None = None
+    sync_note: str | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        extra = data.pop("extra", {}) or {}
+        data.update(extra)
+        return data

--- a/app/dispatcher/schema.py
+++ b/app/dispatcher/schema.py
@@ -1,0 +1,59 @@
+"""SQLite schema DDL for the dispatcher MVP."""
+
+from __future__ import annotations
+
+SCHEMA_VERSION = 1
+
+DDL_STATEMENTS: tuple[str, ...] = (
+    """
+    CREATE TABLE IF NOT EXISTS dispatcher_tasks (
+        task_id TEXT PRIMARY KEY,
+        issue_number INTEGER NOT NULL,
+        title TEXT NOT NULL,
+        status TEXT NOT NULL,
+        priority TEXT NOT NULL,
+        source_anchor_refs TEXT NOT NULL,
+        claimed_by TEXT,
+        lease_id TEXT,
+        lease_expires_at TEXT,
+        linked_pr TEXT,
+        blocked_reason TEXT,
+        last_heartbeat_at TEXT,
+        sync_state TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS dispatcher_leases (
+        lease_id TEXT PRIMARY KEY,
+        resource TEXT NOT NULL,
+        holder TEXT NOT NULL,
+        ttl_seconds INTEGER NOT NULL,
+        acquired_at TEXT NOT NULL,
+        expires_at TEXT NOT NULL,
+        heartbeat_at TEXT,
+        released_at TEXT,
+        release_reason TEXT
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS dispatcher_events (
+        event_id TEXT PRIMARY KEY,
+        timestamp TEXT NOT NULL,
+        task_id TEXT NOT NULL,
+        event_type TEXT NOT NULL,
+        actor TEXT NOT NULL,
+        lease_id TEXT,
+        payload TEXT
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS dispatcher_meta (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_dispatcher_events_task ON dispatcher_events(task_id)",
+    "CREATE INDEX IF NOT EXISTS idx_dispatcher_leases_resource ON dispatcher_leases(resource)",
+)

--- a/app/dispatcher/store.py
+++ b/app/dispatcher/store.py
@@ -1,0 +1,252 @@
+"""SQLite-backed dispatcher store.
+
+The store is intentionally narrow: persist task, lease, and event rows behind
+an interface so a Postgres implementation can replace it later without
+rewriting callers. Queue selection and claim lifecycle are out of scope for the
+foundation slice.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any, Protocol
+
+from app.dispatcher.events import JsonlEventWriter
+from app.dispatcher.models import EventRecord, LeaseRecord, TaskRecord
+from app.dispatcher.schema import DDL_STATEMENTS, SCHEMA_VERSION
+
+
+class DispatcherStore(Protocol):
+    def initialize(self) -> None: ...
+    def upsert_task(self, task: TaskRecord) -> None: ...
+    def get_task(self, task_id: str) -> TaskRecord | None: ...
+    def upsert_lease(self, lease: LeaseRecord) -> None: ...
+    def get_lease(self, lease_id: str) -> LeaseRecord | None: ...
+    def append_event(self, event: EventRecord) -> None: ...
+    def list_events(self, task_id: str | None = None) -> list[EventRecord]: ...
+
+
+def _dumps(value: Any) -> str | None:
+    if value is None:
+        return None
+    return json.dumps(value, sort_keys=True, ensure_ascii=False)
+
+
+def _loads(value: str | None) -> Any:
+    if value is None or value == "":
+        return None
+    return json.loads(value)
+
+
+class SqliteStore:
+    """SQLite implementation of :class:`DispatcherStore`.
+
+    Pairs with a :class:`JsonlEventWriter`; ``append_event`` writes to both so
+    the SQLite row and JSONL audit line stay correlated by ``event_id``.
+    """
+
+    def __init__(
+        self,
+        db_path: Path,
+        event_writer: JsonlEventWriter | None = None,
+    ) -> None:
+        self._db_path = Path(db_path)
+        self._event_writer = event_writer
+
+    @property
+    def db_path(self) -> Path:
+        return self._db_path
+
+    def _connect(self) -> sqlite3.Connection:
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(self._db_path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+        return conn
+
+    def initialize(self) -> None:
+        with self._connect() as conn:
+            for stmt in DDL_STATEMENTS:
+                conn.execute(stmt)
+            conn.execute(
+                "INSERT OR REPLACE INTO dispatcher_meta(key, value) VALUES (?, ?)",
+                ("schema_version", str(SCHEMA_VERSION)),
+            )
+            conn.commit()
+
+    # ----- tasks -----
+
+    def upsert_task(self, task: TaskRecord) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO dispatcher_tasks (
+                    task_id, issue_number, title, status, priority,
+                    source_anchor_refs, claimed_by, lease_id, lease_expires_at,
+                    linked_pr, blocked_reason, last_heartbeat_at, sync_state,
+                    created_at, updated_at
+                ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                ON CONFLICT(task_id) DO UPDATE SET
+                    issue_number=excluded.issue_number,
+                    title=excluded.title,
+                    status=excluded.status,
+                    priority=excluded.priority,
+                    source_anchor_refs=excluded.source_anchor_refs,
+                    claimed_by=excluded.claimed_by,
+                    lease_id=excluded.lease_id,
+                    lease_expires_at=excluded.lease_expires_at,
+                    linked_pr=excluded.linked_pr,
+                    blocked_reason=excluded.blocked_reason,
+                    last_heartbeat_at=excluded.last_heartbeat_at,
+                    sync_state=excluded.sync_state,
+                    updated_at=excluded.updated_at
+                """,
+                (
+                    task.task_id,
+                    task.issue_number,
+                    task.title,
+                    task.status,
+                    task.priority,
+                    _dumps(list(task.source_anchor_refs)),
+                    task.claimed_by,
+                    task.lease_id,
+                    task.lease_expires_at,
+                    task.linked_pr,
+                    task.blocked_reason,
+                    task.last_heartbeat_at,
+                    _dumps(task.sync_state),
+                    task.created_at,
+                    task.updated_at,
+                ),
+            )
+            conn.commit()
+
+    def get_task(self, task_id: str) -> TaskRecord | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM dispatcher_tasks WHERE task_id = ?", (task_id,)
+            ).fetchone()
+        if row is None:
+            return None
+        return TaskRecord(
+            task_id=row["task_id"],
+            issue_number=row["issue_number"],
+            title=row["title"],
+            status=row["status"],
+            priority=row["priority"],
+            source_anchor_refs=list(_loads(row["source_anchor_refs"]) or []),
+            claimed_by=row["claimed_by"],
+            lease_id=row["lease_id"],
+            lease_expires_at=row["lease_expires_at"],
+            linked_pr=row["linked_pr"],
+            blocked_reason=row["blocked_reason"],
+            last_heartbeat_at=row["last_heartbeat_at"],
+            sync_state=_loads(row["sync_state"]),
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+        )
+
+    # ----- leases -----
+
+    def upsert_lease(self, lease: LeaseRecord) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO dispatcher_leases (
+                    lease_id, resource, holder, ttl_seconds, acquired_at,
+                    expires_at, heartbeat_at, released_at, release_reason
+                ) VALUES (?,?,?,?,?,?,?,?,?)
+                ON CONFLICT(lease_id) DO UPDATE SET
+                    resource=excluded.resource,
+                    holder=excluded.holder,
+                    ttl_seconds=excluded.ttl_seconds,
+                    acquired_at=excluded.acquired_at,
+                    expires_at=excluded.expires_at,
+                    heartbeat_at=excluded.heartbeat_at,
+                    released_at=excluded.released_at,
+                    release_reason=excluded.release_reason
+                """,
+                (
+                    lease.lease_id,
+                    lease.resource,
+                    lease.holder,
+                    lease.ttl_seconds,
+                    lease.acquired_at,
+                    lease.expires_at,
+                    lease.heartbeat_at,
+                    lease.released_at,
+                    lease.release_reason,
+                ),
+            )
+            conn.commit()
+
+    def get_lease(self, lease_id: str) -> LeaseRecord | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM dispatcher_leases WHERE lease_id = ?", (lease_id,)
+            ).fetchone()
+        if row is None:
+            return None
+        return LeaseRecord(
+            lease_id=row["lease_id"],
+            resource=row["resource"],
+            holder=row["holder"],
+            ttl_seconds=row["ttl_seconds"],
+            acquired_at=row["acquired_at"],
+            expires_at=row["expires_at"],
+            heartbeat_at=row["heartbeat_at"],
+            released_at=row["released_at"],
+            release_reason=row["release_reason"],
+        )
+
+    # ----- events -----
+
+    def append_event(self, event: EventRecord) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO dispatcher_events (
+                    event_id, timestamp, task_id, event_type, actor,
+                    lease_id, payload
+                ) VALUES (?,?,?,?,?,?,?)
+                """,
+                (
+                    event.event_id,
+                    event.timestamp,
+                    event.task_id,
+                    event.event_type,
+                    event.actor,
+                    event.lease_id,
+                    _dumps(event.payload),
+                ),
+            )
+            conn.commit()
+        if self._event_writer is not None:
+            self._event_writer.append(event)
+
+    def list_events(self, task_id: str | None = None) -> list[EventRecord]:
+        with self._connect() as conn:
+            if task_id is None:
+                rows = conn.execute(
+                    "SELECT * FROM dispatcher_events ORDER BY timestamp, event_id"
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT * FROM dispatcher_events WHERE task_id = ? "
+                    "ORDER BY timestamp, event_id",
+                    (task_id,),
+                ).fetchall()
+        return [
+            EventRecord(
+                event_id=r["event_id"],
+                timestamp=r["timestamp"],
+                task_id=r["task_id"],
+                event_type=r["event_type"],
+                actor=r["actor"],
+                lease_id=r["lease_id"],
+                payload=_loads(r["payload"]),
+            )
+            for r in rows
+        ]

--- a/tests/dispatcher/test_events.py
+++ b/tests/dispatcher/test_events.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.dispatcher.events import JsonlEventWriter
+from app.dispatcher.models import EventRecord
+from app.dispatcher.store import SqliteStore
+
+
+def _event(**overrides) -> EventRecord:
+    base = dict(
+        event_id="evt-1",
+        timestamp="2026-04-25T10:00:00Z",
+        task_id="task-1",
+        event_type="task.discovered",
+        actor="agent-a",
+    )
+    base.update(overrides)
+    return EventRecord(**base)
+
+
+def test_jsonl_writer_appends_one_object_per_line(tmp_path: Path) -> None:
+    target = tmp_path / "events.jsonl"
+    writer = JsonlEventWriter(target)
+
+    writer.append(_event())
+    writer.append(
+        _event(
+            event_id="evt-2",
+            event_type="task.claimed",
+            lease_id="lease-1",
+            payload={"resource": "issue:622"},
+        )
+    )
+
+    lines = target.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    parsed = [json.loads(ln) for ln in lines]
+    assert parsed[0]["event_id"] == "evt-1"
+    assert parsed[1]["event_type"] == "task.claimed"
+    assert parsed[1]["payload"] == {"resource": "issue:622"}
+
+
+def test_jsonl_writer_creates_parent_dir(tmp_path: Path) -> None:
+    target = tmp_path / "nested" / "events.jsonl"
+    JsonlEventWriter(target).append(_event())
+    assert target.exists()
+
+
+def test_store_appends_to_jsonl_and_sqlite(tmp_path: Path) -> None:
+    db = tmp_path / "d.sqlite3"
+    events_path = tmp_path / "events.jsonl"
+    writer = JsonlEventWriter(events_path)
+    store = SqliteStore(db, writer)
+    store.initialize()
+
+    store.append_event(_event())
+    store.append_event(_event(event_id="evt-2", event_type="task.completed",
+                              timestamp="2026-04-25T10:00:01Z"))
+
+    sqlite_rows = store.list_events()
+    jsonl_rows = writer.read_all()
+
+    assert [r.event_id for r in sqlite_rows] == ["evt-1", "evt-2"]
+    assert [r["event_id"] for r in jsonl_rows] == ["evt-1", "evt-2"]
+    # JSONL audit trail and SQLite current-state are correlation-friendly
+    assert {r.event_id for r in sqlite_rows} == {r["event_id"] for r in jsonl_rows}

--- a/tests/dispatcher/test_store.py
+++ b/tests/dispatcher/test_store.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.dispatcher.config import load_paths
+from app.dispatcher.events import JsonlEventWriter
+from app.dispatcher.models import EventRecord, LeaseRecord, TaskRecord
+from app.dispatcher.schema import SCHEMA_VERSION
+from app.dispatcher.store import SqliteStore
+
+
+def _task(**overrides) -> TaskRecord:
+    base = dict(
+        task_id="task-1",
+        issue_number=622,
+        title="Implement dispatcher store",
+        status="ready",
+        priority="high",
+        source_anchor_refs=["#617", "#621"],
+        created_at="2026-04-25T10:00:00Z",
+        updated_at="2026-04-25T10:00:00Z",
+    )
+    base.update(overrides)
+    return TaskRecord(**base)
+
+
+def _lease(**overrides) -> LeaseRecord:
+    base = dict(
+        lease_id="lease-1",
+        resource="issue:622",
+        holder="agent-a",
+        ttl_seconds=300,
+        acquired_at="2026-04-25T10:00:00Z",
+        expires_at="2026-04-25T10:05:00Z",
+    )
+    base.update(overrides)
+    return LeaseRecord(**base)
+
+
+def _event(**overrides) -> EventRecord:
+    base = dict(
+        event_id="evt-1",
+        timestamp="2026-04-25T10:00:00Z",
+        task_id="task-1",
+        event_type="task.discovered",
+        actor="agent-a",
+    )
+    base.update(overrides)
+    return EventRecord(**base)
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> SqliteStore:
+    db = tmp_path / "dispatcher.sqlite3"
+    events = tmp_path / "events.jsonl"
+    s = SqliteStore(db, JsonlEventWriter(events))
+    s.initialize()
+    return s
+
+
+def test_initialize_creates_schema(tmp_path: Path) -> None:
+    db = tmp_path / "d.sqlite3"
+    store = SqliteStore(db)
+    store.initialize()
+    assert db.exists()
+    # second init must be idempotent
+    store.initialize()
+    import sqlite3
+
+    with sqlite3.connect(db) as conn:
+        names = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        assert {
+            "dispatcher_tasks",
+            "dispatcher_leases",
+            "dispatcher_events",
+            "dispatcher_meta",
+        } <= names
+        version = conn.execute(
+            "SELECT value FROM dispatcher_meta WHERE key='schema_version'"
+        ).fetchone()[0]
+        assert version == str(SCHEMA_VERSION)
+
+
+def test_task_round_trip(store: SqliteStore) -> None:
+    task = _task(
+        sync_state={"sync_result": "ok", "source_version": "etag-1"},
+        linked_pr="PR-1",
+    )
+    store.upsert_task(task)
+    fetched = store.get_task(task.task_id)
+    assert fetched == task
+
+
+def test_task_upsert_updates_required_fields(store: SqliteStore) -> None:
+    store.upsert_task(_task())
+    store.upsert_task(
+        _task(status="in_progress", claimed_by="agent-a", lease_id="lease-1",
+              lease_expires_at="2026-04-25T10:05:00Z",
+              updated_at="2026-04-25T10:01:00Z")
+    )
+    t = store.get_task("task-1")
+    assert t is not None
+    assert t.status == "in_progress"
+    assert t.claimed_by == "agent-a"
+    assert t.lease_id == "lease-1"
+
+
+def test_lease_round_trip(store: SqliteStore) -> None:
+    lease = _lease(heartbeat_at="2026-04-25T10:02:00Z")
+    store.upsert_lease(lease)
+    assert store.get_lease(lease.lease_id) == lease
+
+
+def test_event_persistence_in_sqlite(store: SqliteStore) -> None:
+    e1 = _event()
+    e2 = _event(event_id="evt-2", event_type="task.claimed", lease_id="lease-1",
+                payload={"resource": "issue:622"},
+                timestamp="2026-04-25T10:00:01Z")
+    store.append_event(e1)
+    store.append_event(e2)
+
+    rows = store.list_events()
+    assert [r.event_id for r in rows] == ["evt-1", "evt-2"]
+    assert rows[1].payload == {"resource": "issue:622"}
+    assert rows[1].lease_id == "lease-1"
+
+    only_task = store.list_events(task_id="task-1")
+    assert len(only_task) == 2
+
+
+def test_missing_records_return_none(store: SqliteStore) -> None:
+    assert store.get_task("missing") is None
+    assert store.get_lease("missing") is None
+
+
+def test_load_paths_env_overrides(tmp_path: Path) -> None:
+    env = {
+        "DISPATCHER_STATE_DIR": str(tmp_path / "state"),
+        "DISPATCHER_DB_PATH": str(tmp_path / "custom.sqlite3"),
+        "DISPATCHER_EVENTS_PATH": str(tmp_path / "custom.jsonl"),
+    }
+    paths = load_paths(env)
+    assert paths.state_dir == tmp_path / "state"
+    assert paths.db_path == tmp_path / "custom.sqlite3"
+    assert paths.events_path == tmp_path / "custom.jsonl"
+    paths.ensure()
+    assert paths.state_dir.is_dir()
+
+
+def test_load_paths_defaults_under_state_dir(tmp_path: Path) -> None:
+    env = {"DISPATCHER_STATE_DIR": str(tmp_path / "rt")}
+    paths = load_paths(env)
+    assert paths.db_path == tmp_path / "rt" / "dispatcher.sqlite3"
+    assert paths.events_path == tmp_path / "rt" / "events.jsonl"


### PR DESCRIPTION
Fixes #622

## Summary
First runtime slice of the local Agent Issue Dispatcher MVP per `docs/AGENT_ISSUE_DISPATCHER.md`: deterministic local persistence for tasks, leases, and events with no GitHub API, Postgres, Docker, FastAPI, or LLM dependencies.

## Changes
- `app/dispatcher/` skeleton: `models.py`, `config.py`, `schema.py`, `store.py`, `events.py`
- `SqliteStore` behind a `DispatcherStore` Protocol so Postgres can replace it later without rewriting callers
- `JsonlEventWriter` for append-only audit trail; `SqliteStore.append_event` writes both stores so they stay correlation-friendly by `event_id`
- Required task/lease/event fields from the dispatcher contract are persisted; optional fields (`linked_pr`, `blocked_reason`, `last_heartbeat_at`, `sync_state`, lease heartbeat/release) round-trip too
- Runtime paths configurable via `DISPATCHER_STATE_DIR`, `DISPATCHER_DB_PATH`, `DISPATCHER_EVENTS_PATH` (defaults under `runtime/dispatcher/`)
- `runtime/dispatcher/` added to `.gitignore`

## Out of Scope (explicit)
Queue selection, claim conflict, lease expiry, GitHub sync, FastAPI/MCP service mode — tracked under sibling slices.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/dispatcher/test_store.py tests/dispatcher/test_events.py` → 11 passed
- `git diff --check` → clean
- `ruff` not available locally; CI will run it

## Notes for review
The governing Issue's Acceptance Criteria do not declare per-AC `Verify:` markers as required by `AGENTS.md :: GitHub delivery governance`. The Suggested Validation block named the two test files used here, so scope was unambiguous and implementation proceeded; the contract gap should be repaired via `issue-maintenance-change-control` as follow-up.

---