### PR TITLE
Implement dispatcher queue selection and lease lifecycle (#623)

### DIFF
--- a/app/dispatcher/__init__.py
+++ b/app/dispatcher/__init__.py
@@ -4,6 +4,7 @@ Operational coordination layer for multi-agent issue pickup. See
 ``docs/AGENT_ISSUE_DISPATCHER.md`` for the contract.
 """
 
+from app.dispatcher import leases, queue
 from app.dispatcher.config import DispatcherPaths, load_paths
 from app.dispatcher.events import JsonlEventWriter
 from app.dispatcher.models import EventRecord, LeaseRecord, SyncState, TaskRecord
@@ -18,5 +19,7 @@ __all__ = [
     "SqliteStore",
     "SyncState",
     "TaskRecord",
+    "leases",
     "load_paths",
+    "queue",
 ]

--- a/app/dispatcher/leases.py
+++ b/app/dispatcher/leases.py
@@ -1,0 +1,246 @@
+"""Lease and claim management for the dispatcher MVP."""
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from app.dispatcher.models import EventRecord, LeaseRecord, TaskRecord
+from app.dispatcher.store import SqliteStore
+
+
+def _utc_now() -> str:
+    """Return current UTC timestamp in RFC3339 format."""
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds")
+
+
+def _make_lease_id() -> str:
+    """Generate a unique lease ID."""
+    return f"lease-{uuid.uuid4().hex[:8]}"
+
+
+def _make_event_id() -> str:
+    """Generate a unique event ID."""
+    return f"evt-{uuid.uuid4().hex[:8]}"
+
+
+def _parse_rfc3339(timestamp_str: str) -> datetime:
+    """Parse RFC3339 timestamp to datetime."""
+    return datetime.fromisoformat(timestamp_str.replace("Z", "+00:00"))
+
+
+def _expires_at(ttl_seconds: int) -> str:
+    """Calculate expiry timestamp given TTL in seconds."""
+    now = datetime.now(timezone.utc)
+    expires = now + timedelta(seconds=ttl_seconds)
+    return expires.isoformat(timespec="seconds")
+
+
+def claim(
+    store: SqliteStore,
+    task_id: str,
+    agent_id: str,
+    ttl_minutes: int = 90,
+) -> tuple[TaskRecord, LeaseRecord]:
+    """Claim a task by creating a lease and updating task state.
+
+    Atomically:
+    1. Check if task is ready and unleased
+    2. Create lease
+    3. Update task with lease reference and claimed_by
+    4. Emit task.claimed event
+
+    Raises ValueError if task doesn't exist, is not ready, or is already claimed.
+    """
+    task = store.get_task(task_id)
+    if task is None:
+        raise ValueError(f"Task {task_id} not found")
+
+    if task.lease_id is not None:
+        raise ValueError(f"Cannot claim task {task_id}: already has active lease")
+
+    if task.status != "ready":
+        raise ValueError(
+            f"Cannot claim task {task_id}: not in ready status (current: {task.status})"
+        )
+
+    lease_id = _make_lease_id()
+    ttl_seconds = ttl_minutes * 60
+    now = _utc_now()
+    expires = _expires_at(ttl_seconds)
+
+    lease = LeaseRecord(
+        lease_id=lease_id,
+        resource=f"issue:{task.issue_number}",
+        holder=agent_id,
+        ttl_seconds=ttl_seconds,
+        acquired_at=now,
+        expires_at=expires,
+        heartbeat_at=now,
+    )
+
+    store.upsert_lease(lease)
+
+    task.lease_id = lease_id
+    task.claimed_by = agent_id
+    task.status = "claimed"
+    task.updated_at = now
+    store.upsert_task(task)
+
+    event = EventRecord(
+        event_id=_make_event_id(),
+        timestamp=now,
+        task_id=task_id,
+        event_type="task.claimed",
+        actor=agent_id,
+        lease_id=lease_id,
+        payload={"ttl_minutes": ttl_minutes},
+    )
+    store.append_event(event)
+
+    return task, lease
+
+
+def heartbeat(
+    store: SqliteStore,
+    task_id: str,
+    agent_id: str,
+) -> LeaseRecord:
+    """Update the heartbeat timestamp of an active lease.
+
+    The lease TTL is not extended; heartbeat only updates the last-seen timestamp
+    and can be used to track activity.
+
+    Raises ValueError if task/lease not found or held by a different agent.
+    """
+    task = store.get_task(task_id)
+    if task is None:
+        raise ValueError(f"Task {task_id} not found")
+
+    if task.lease_id is None:
+        raise ValueError(f"Task {task_id} has no active lease")
+
+    lease = store.get_lease(task.lease_id)
+    if lease is None:
+        raise ValueError(f"Lease {task.lease_id} not found")
+
+    if lease.holder != agent_id:
+        raise ValueError(
+            f"Cannot heartbeat lease {task.lease_id}: held by {lease.holder}, not {agent_id}"
+        )
+
+    now = _utc_now()
+    lease.heartbeat_at = now
+    store.upsert_lease(lease)
+
+    task.last_heartbeat_at = now
+    task.updated_at = now
+    store.upsert_task(task)
+
+    event = EventRecord(
+        event_id=_make_event_id(),
+        timestamp=now,
+        task_id=task_id,
+        event_type="task.heartbeat",
+        actor=agent_id,
+        lease_id=lease.lease_id,
+    )
+    store.append_event(event)
+
+    return lease
+
+
+def release(
+    store: SqliteStore,
+    task_id: str,
+    agent_id: str,
+    reason: str = "manual",
+) -> TaskRecord:
+    """Release a task by removing its lease.
+
+    After release, the task returns to ready status if not blocked, or stays blocked.
+
+    Raises ValueError if task/lease not found or held by a different agent.
+    """
+    task = store.get_task(task_id)
+    if task is None:
+        raise ValueError(f"Task {task_id} not found")
+
+    if task.lease_id is None:
+        raise ValueError(f"Task {task_id} has no active lease to release")
+
+    lease = store.get_lease(task.lease_id)
+    if lease is None:
+        raise ValueError(f"Lease {task.lease_id} not found")
+
+    if lease.holder != agent_id:
+        raise ValueError(
+            f"Cannot release lease {task.lease_id}: held by {lease.holder}, not {agent_id}"
+        )
+
+    now = _utc_now()
+    lease.released_at = now
+    lease.release_reason = reason
+    store.upsert_lease(lease)
+
+    task.lease_id = None
+    task.claimed_by = None
+    task.last_heartbeat_at = None
+
+    if task.blocked_reason is None:
+        task.status = "ready"
+    else:
+        task.status = "blocked"
+
+    task.updated_at = now
+    store.upsert_task(task)
+
+    event = EventRecord(
+        event_id=_make_event_id(),
+        timestamp=now,
+        task_id=task_id,
+        event_type="task.released",
+        actor=agent_id,
+        lease_id=lease.lease_id,
+        payload={"reason": reason},
+    )
+    store.append_event(event)
+
+    return task
+
+
+def reclaim_expired_leases(
+    store: SqliteStore,
+    actor: str = "dispatcher-gc",
+) -> list[str]:
+    """Find and release all expired leases.
+
+    Returns list of task_ids that had leases reclaimed.
+    """
+    now = _utc_now()
+
+    with store._connect() as conn:
+        rows = conn.execute(
+            """
+            SELECT t.task_id, t.lease_id, l.expires_at, l.holder
+            FROM dispatcher_tasks t
+            JOIN dispatcher_leases l ON t.lease_id = l.lease_id
+            WHERE l.released_at IS NULL AND l.expires_at < ?
+            ORDER BY l.expires_at
+            """,
+            (now,)
+        ).fetchall()
+
+    reclaimed = []
+    for row in rows:
+        task_id = row["task_id"]
+        holder = row["holder"]
+        try:
+            release(store, task_id, holder, reason="expired")
+            reclaimed.append(task_id)
+        except (ValueError, Exception):
+            pass
+
+    return reclaimed

--- a/app/dispatcher/leases.py
+++ b/app/dispatcher/leases.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-import sqlite3
 import uuid
 from datetime import datetime, timedelta, timezone
-from typing import Any
 
 from app.dispatcher.models import EventRecord, LeaseRecord, TaskRecord
 from app.dispatcher.store import SqliteStore
@@ -260,7 +258,6 @@ def reclaim_expired_leases(
     reclaimed = []
     for row in rows:
         task_id = row["task_id"]
-        holder = row["holder"]
         lease_id = row["lease_id"]
         try:
             task = store.get_task(task_id)

--- a/app/dispatcher/leases.py
+++ b/app/dispatcher/leases.py
@@ -46,7 +46,7 @@ def claim(
 ) -> tuple[TaskRecord, LeaseRecord]:
     """Claim a task by creating a lease and updating task state.
 
-    Atomically:
+    Atomically within a single transaction:
     1. Check if task is ready and unleased
     2. Create lease
     3. Update task with lease reference and claimed_by
@@ -54,26 +54,51 @@ def claim(
 
     Raises ValueError if task doesn't exist, is not ready, or is already claimed.
     """
-    task = store.get_task(task_id)
-    if task is None:
-        raise ValueError(f"Task {task_id} not found")
-
-    if task.lease_id is not None:
-        raise ValueError(f"Cannot claim task {task_id}: already has active lease")
-
-    if task.status != "ready":
-        raise ValueError(
-            f"Cannot claim task {task_id}: not in ready status (current: {task.status})"
-        )
-
     lease_id = _make_lease_id()
     ttl_seconds = ttl_minutes * 60
     now = _utc_now()
     expires = _expires_at(ttl_seconds)
 
+    with store._connect() as conn:
+        task_row = conn.execute(
+            "SELECT * FROM dispatcher_tasks WHERE task_id = ?",
+            (task_id,)
+        ).fetchone()
+
+        if task_row is None:
+            raise ValueError(f"Task {task_id} not found")
+
+        if task_row["lease_id"] is not None:
+            raise ValueError(f"Cannot claim task {task_id}: already has active lease")
+
+        if task_row["status"] != "ready":
+            raise ValueError(
+                f"Cannot claim task {task_id}: not in ready status (current: {task_row['status']})"
+            )
+
+        conn.execute(
+            """
+            INSERT INTO dispatcher_leases (
+                lease_id, resource, holder, ttl_seconds, acquired_at, expires_at, heartbeat_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (lease_id, f"issue:{task_row['issue_number']}", agent_id, ttl_seconds, now, expires, now)
+        )
+
+        conn.execute(
+            """
+            UPDATE dispatcher_tasks
+            SET lease_id = ?, claimed_by = ?, status = 'claimed', updated_at = ?
+            WHERE task_id = ?
+            """,
+            (lease_id, agent_id, now, task_id)
+        )
+
+        conn.commit()
+
     lease = LeaseRecord(
         lease_id=lease_id,
-        resource=f"issue:{task.issue_number}",
+        resource=f"issue:{task_row['issue_number']}",
         holder=agent_id,
         ttl_seconds=ttl_seconds,
         acquired_at=now,
@@ -81,13 +106,7 @@ def claim(
         heartbeat_at=now,
     )
 
-    store.upsert_lease(lease)
-
-    task.lease_id = lease_id
-    task.claimed_by = agent_id
-    task.status = "claimed"
-    task.updated_at = now
-    store.upsert_task(task)
+    task = store.get_task(task_id)
 
     event = EventRecord(
         event_id=_make_event_id(),

--- a/app/dispatcher/leases.py
+++ b/app/dispatcher/leases.py
@@ -85,14 +85,17 @@ def claim(
             (lease_id, f"issue:{task_row['issue_number']}", agent_id, ttl_seconds, now, expires, now)
         )
 
-        conn.execute(
+        result = conn.execute(
             """
             UPDATE dispatcher_tasks
             SET lease_id = ?, claimed_by = ?, status = 'claimed', updated_at = ?
-            WHERE task_id = ?
+            WHERE task_id = ? AND status = 'ready' AND lease_id IS NULL
             """,
             (lease_id, agent_id, now, task_id)
         )
+
+        if result.rowcount == 0:
+            raise ValueError(f"Cannot claim task {task_id}: preconditions changed (concurrent claim or status change)")
 
         conn.commit()
 
@@ -236,6 +239,8 @@ def reclaim_expired_leases(
 ) -> list[str]:
     """Find and release all expired leases.
 
+    Reclaims expired leases with audit trail attribution to the specified actor.
+
     Returns list of task_ids that had leases reclaimed.
     """
     now = _utc_now()
@@ -256,8 +261,39 @@ def reclaim_expired_leases(
     for row in rows:
         task_id = row["task_id"]
         holder = row["holder"]
+        lease_id = row["lease_id"]
         try:
-            release(store, task_id, holder, reason="expired")
+            task = store.get_task(task_id)
+            lease = store.get_lease(lease_id)
+
+            if task is None or lease is None:
+                continue
+
+            lease.released_at = now
+            lease.release_reason = "expired"
+            store.upsert_lease(lease)
+
+            task.lease_id = None
+            task.claimed_by = None
+            task.last_heartbeat_at = None
+            if task.blocked_reason is None:
+                task.status = "ready"
+            else:
+                task.status = "blocked"
+            task.updated_at = now
+            store.upsert_task(task)
+
+            event = EventRecord(
+                event_id=_make_event_id(),
+                timestamp=now,
+                task_id=task_id,
+                event_type="task.released",
+                actor=actor,
+                lease_id=lease_id,
+                payload={"reason": "expired"},
+            )
+            store.append_event(event)
+
             reclaimed.append(task_id)
         except (ValueError, Exception):
             pass

--- a/app/dispatcher/queue.py
+++ b/app/dispatcher/queue.py
@@ -1,0 +1,144 @@
+"""Queue selection and task blocking for the dispatcher MVP."""
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from app.dispatcher.models import EventRecord, TaskRecord
+from app.dispatcher.store import SqliteStore
+
+
+def _utc_now() -> str:
+    """Return current UTC timestamp in RFC3339 format."""
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds")
+
+
+def _make_event_id() -> str:
+    """Generate a unique event ID."""
+    return f"evt-{uuid.uuid4().hex[:8]}"
+
+
+def next(store: SqliteStore, agent_id: str) -> TaskRecord | None:
+    """Return the next ready, unblocked, unleased task.
+
+    Tasks are ordered by priority first, then by creation/update time (age).
+    """
+    with store._connect() as conn:
+        row = conn.execute(
+            """
+            SELECT * FROM dispatcher_tasks
+            WHERE status = 'ready'
+              AND blocked_reason IS NULL
+              AND lease_id IS NULL
+            ORDER BY
+              CASE priority
+                WHEN 'critical' THEN 0
+                WHEN 'high' THEN 1
+                WHEN 'med' THEN 2
+                WHEN 'medium' THEN 2
+                WHEN 'low' THEN 3
+                ELSE 4
+              END,
+              updated_at ASC,
+              created_at ASC
+            LIMIT 1
+            """
+        ).fetchone()
+
+    if row is None:
+        return None
+
+    return _row_to_task(row)
+
+
+def block(
+    store: SqliteStore,
+    task_id: str,
+    reason: str,
+    actor: str,
+) -> TaskRecord:
+    """Mark a task as blocked with an explicit reason.
+
+    Emits a task.blocked event.
+    """
+    task = store.get_task(task_id)
+    if task is None:
+        raise ValueError(f"Task {task_id} not found")
+
+    task.blocked_reason = reason
+    task.updated_at = _utc_now()
+    store.upsert_task(task)
+
+    event = EventRecord(
+        event_id=_make_event_id(),
+        timestamp=_utc_now(),
+        task_id=task_id,
+        event_type="task.blocked",
+        actor=actor,
+        payload={"reason": reason},
+    )
+    store.append_event(event)
+
+    return task
+
+
+def unblock(
+    store: SqliteStore,
+    task_id: str,
+    actor: str,
+) -> TaskRecord:
+    """Clear the blocked_reason and return task to ready (if not also leased/claimed)."""
+    task = store.get_task(task_id)
+    if task is None:
+        raise ValueError(f"Task {task_id} not found")
+
+    task.blocked_reason = None
+    task.updated_at = _utc_now()
+
+    if task.status == "blocked":
+        task.status = "ready"
+
+    store.upsert_task(task)
+
+    event = EventRecord(
+        event_id=_make_event_id(),
+        timestamp=_utc_now(),
+        task_id=task_id,
+        event_type="task.updated",
+        actor=actor,
+        payload={"action": "unblocked"},
+    )
+    store.append_event(event)
+
+    return task
+
+
+def _row_to_task(row: sqlite3.Row) -> TaskRecord:
+    """Convert a sqlite3.Row to a TaskRecord."""
+    import json
+
+    def _loads(value: str | None) -> Any:
+        if value is None or value == "":
+            return None
+        return json.loads(value)
+
+    return TaskRecord(
+        task_id=row["task_id"],
+        issue_number=row["issue_number"],
+        title=row["title"],
+        status=row["status"],
+        priority=row["priority"],
+        source_anchor_refs=list(_loads(row["source_anchor_refs"]) or []),
+        claimed_by=row["claimed_by"],
+        lease_id=row["lease_id"],
+        lease_expires_at=row["lease_expires_at"],
+        linked_pr=row["linked_pr"],
+        blocked_reason=row["blocked_reason"],
+        last_heartbeat_at=row["last_heartbeat_at"],
+        sync_state=_loads(row["sync_state"]),
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )

--- a/app/dispatcher/queue.py
+++ b/app/dispatcher/queue.py
@@ -69,6 +69,7 @@ def block(
         raise ValueError(f"Task {task_id} not found")
 
     task.blocked_reason = reason
+    task.status = "blocked"
     task.updated_at = _utc_now()
     store.upsert_task(task)
 

--- a/tests/dispatcher/test_events.py
+++ b/tests/dispatcher/test_events.py
@@ -48,6 +48,48 @@ def test_jsonl_writer_creates_parent_dir(tmp_path: Path) -> None:
     assert target.exists()
 
 
+def test_mutations_emit_events(tmp_path: Path) -> None:
+    from app.dispatcher.models import TaskRecord
+    from app.dispatcher.queue import block
+    from app.dispatcher.leases import claim, heartbeat, release
+
+    db = tmp_path / "dispatcher.sqlite3"
+    events_file = tmp_path / "events.jsonl"
+    store = SqliteStore(db, JsonlEventWriter(events_file))
+    store.initialize()
+
+    task = TaskRecord(
+        task_id="task-test",
+        issue_number=623,
+        title="Test mutations",
+        status="ready",
+        priority="high",
+        source_anchor_refs=["#617"],
+        created_at="2026-04-25T10:00:00Z",
+        updated_at="2026-04-25T10:00:00Z",
+    )
+    store.upsert_task(task)
+
+    claim(store, "task-test", "agent-1", ttl_minutes=30)
+    heartbeat(store, "task-test", "agent-1")
+    release(store, "task-test", "agent-1", reason="manual")
+    block(store, "task-test", "test reason", "agent-2")
+
+    events = store.list_events("task-test")
+    assert len(events) == 4
+    event_types = {e.event_type for e in events}
+    assert "task.claimed" in event_types
+    assert "task.heartbeat" in event_types
+    assert "task.released" in event_types
+    assert "task.blocked" in event_types
+
+    lines = events_file.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 4
+    for ln in lines:
+        parsed = json.loads(ln)
+        assert parsed["task_id"] == "task-test"
+
+
 def test_store_appends_to_jsonl_and_sqlite(tmp_path: Path) -> None:
     db = tmp_path / "d.sqlite3"
     events_path = tmp_path / "events.jsonl"

--- a/tests/dispatcher/test_leases.py
+++ b/tests/dispatcher/test_leases.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import pytest
 
-from app.dispatcher.config import load_paths
 from app.dispatcher.events import JsonlEventWriter
 from app.dispatcher.leases import claim, heartbeat, reclaim_expired_leases, release
 from app.dispatcher.models import TaskRecord

--- a/tests/dispatcher/test_leases.py
+++ b/tests/dispatcher/test_leases.py
@@ -1,0 +1,224 @@
+"""Tests for dispatcher lease and claim lifecycle."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.dispatcher.config import load_paths
+from app.dispatcher.events import JsonlEventWriter
+from app.dispatcher.leases import claim, heartbeat, reclaim_expired_leases, release
+from app.dispatcher.models import TaskRecord
+from app.dispatcher.store import SqliteStore
+
+
+def _task(**overrides) -> TaskRecord:
+    base = dict(
+        task_id="task-1",
+        issue_number=623,
+        title="Test task",
+        status="ready",
+        priority="high",
+        source_anchor_refs=["#617"],
+        created_at="2026-04-25T10:00:00Z",
+        updated_at="2026-04-25T10:00:00Z",
+    )
+    base.update(overrides)
+    return TaskRecord(**base)
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> SqliteStore:
+    db = tmp_path / "dispatcher.sqlite3"
+    events = tmp_path / "events.jsonl"
+    s = SqliteStore(db, JsonlEventWriter(events))
+    s.initialize()
+    return s
+
+
+def test_claim_creates_active_lease(store: SqliteStore) -> None:
+    task = _task()
+    store.upsert_task(task)
+
+    claimed_task, lease = claim(store, "task-1", "agent-1", ttl_minutes=60)
+
+    assert claimed_task.lease_id == lease.lease_id
+    assert claimed_task.claimed_by == "agent-1"
+    assert claimed_task.status == "claimed"
+    assert lease.holder == "agent-1"
+    assert lease.ttl_seconds == 3600
+
+
+def test_duplicate_claim_rejected(store: SqliteStore) -> None:
+    task = _task()
+    store.upsert_task(task)
+
+    claim(store, "task-1", "agent-1", ttl_minutes=60)
+
+    with pytest.raises(ValueError, match="already has active lease"):
+        claim(store, "task-1", "agent-2", ttl_minutes=60)
+
+
+def test_claim_not_ready_rejected(store: SqliteStore) -> None:
+    task = _task(status="blocked")
+    store.upsert_task(task)
+
+    with pytest.raises(ValueError, match="not in ready status"):
+        claim(store, "task-1", "agent-1", ttl_minutes=60)
+
+
+def test_claim_missing_task_rejected(store: SqliteStore) -> None:
+    with pytest.raises(ValueError, match="not found"):
+        claim(store, "nonexistent", "agent-1", ttl_minutes=60)
+
+
+def test_heartbeat_updates_lease(store: SqliteStore) -> None:
+    task = _task()
+    store.upsert_task(task)
+
+    _, lease = claim(store, "task-1", "agent-1", ttl_minutes=60)
+    original_heartbeat = lease.heartbeat_at
+
+    updated_lease = heartbeat(store, "task-1", "agent-1")
+
+    assert updated_lease.expires_at == lease.expires_at
+    assert updated_lease.heartbeat_at >= original_heartbeat
+
+
+def test_heartbeat_wrong_agent_rejected(store: SqliteStore) -> None:
+    task = _task()
+    store.upsert_task(task)
+
+    claim(store, "task-1", "agent-1", ttl_minutes=60)
+
+    with pytest.raises(ValueError, match="held by agent-1"):
+        heartbeat(store, "task-1", "agent-2")
+
+
+def test_heartbeat_no_lease_rejected(store: SqliteStore) -> None:
+    task = _task()
+    store.upsert_task(task)
+
+    with pytest.raises(ValueError, match="no active lease"):
+        heartbeat(store, "task-1", "agent-1")
+
+
+def test_release_removes_lease(store: SqliteStore) -> None:
+    task = _task()
+    store.upsert_task(task)
+
+    _, lease = claim(store, "task-1", "agent-1", ttl_minutes=60)
+
+    released_task = release(store, "task-1", "agent-1", reason="completed")
+
+    assert released_task.lease_id is None
+    assert released_task.claimed_by is None
+    assert released_task.status == "ready"
+
+    fetched_lease = store.get_lease(lease.lease_id)
+    assert fetched_lease.released_at is not None
+
+
+def test_release_wrong_agent_rejected(store: SqliteStore) -> None:
+    task = _task()
+    store.upsert_task(task)
+
+    claim(store, "task-1", "agent-1", ttl_minutes=60)
+
+    with pytest.raises(ValueError, match="held by agent-1"):
+        release(store, "task-1", "agent-2")
+
+
+def test_release_no_lease_rejected(store: SqliteStore) -> None:
+    task = _task()
+    store.upsert_task(task)
+
+    with pytest.raises(ValueError, match="no active lease"):
+        release(store, "task-1", "agent-1")
+
+
+def test_release_blocked_task_stays_blocked(store: SqliteStore) -> None:
+    task = _task()
+    store.upsert_task(task)
+
+    claim(store, "task-1", "agent-1", ttl_minutes=60)
+
+    from app.dispatcher.queue import block
+    block(store, "task-1", "waiting for review", "blocker")
+
+    released_task = release(store, "task-1", "agent-1")
+
+    assert released_task.status == "blocked"
+    assert released_task.blocked_reason == "waiting for review"
+
+
+def test_claim_emits_event(store: SqliteStore) -> None:
+    task = _task()
+    store.upsert_task(task)
+
+    claim(store, "task-1", "agent-1", ttl_minutes=60)
+
+    events = store.list_events("task-1")
+    assert len(events) == 1
+    assert events[0].event_type == "task.claimed"
+    assert events[0].actor == "agent-1"
+
+
+def test_heartbeat_emits_event(store: SqliteStore) -> None:
+    task = _task()
+    store.upsert_task(task)
+
+    claim(store, "task-1", "agent-1", ttl_minutes=60)
+    heartbeat(store, "task-1", "agent-1")
+
+    events = store.list_events("task-1")
+    assert len(events) == 2
+    event_types = [e.event_type for e in events]
+    assert "task.claimed" in event_types
+    assert "task.heartbeat" in event_types
+
+
+def test_release_emits_event(store: SqliteStore) -> None:
+    task = _task()
+    store.upsert_task(task)
+
+    claim(store, "task-1", "agent-1", ttl_minutes=60)
+    release(store, "task-1", "agent-1", reason="completed")
+
+    events = store.list_events("task-1")
+    assert len(events) == 2
+    assert events[1].event_type == "task.released"
+    assert events[1].payload["reason"] == "completed"
+
+
+def test_expired_lease_reclaim(store: SqliteStore) -> None:
+    from app.dispatcher.models import LeaseRecord
+    from datetime import datetime, timezone, timedelta
+
+    task = _task()
+    store.upsert_task(task)
+
+    claimed_task, lease = claim(store, "task-1", "agent-1", ttl_minutes=1)
+
+    past_time = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat(timespec="microseconds")
+
+    old_lease = LeaseRecord(
+        lease_id=lease.lease_id,
+        resource=lease.resource,
+        holder=lease.holder,
+        ttl_seconds=lease.ttl_seconds,
+        acquired_at=past_time,
+        expires_at=past_time,
+        heartbeat_at=past_time,
+    )
+    store.upsert_lease(old_lease)
+
+    reclaimed = reclaim_expired_leases(store, actor="dispatcher")
+
+    assert "task-1" in reclaimed
+
+    refetched = store.get_task("task-1")
+    assert refetched.lease_id is None
+    assert refetched.claimed_by is None
+    assert refetched.status == "ready"

--- a/tests/dispatcher/test_queue.py
+++ b/tests/dispatcher/test_queue.py
@@ -1,0 +1,181 @@
+"""Tests for dispatcher queue selection and blocking."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.dispatcher.config import load_paths
+from app.dispatcher.events import JsonlEventWriter
+from app.dispatcher.models import TaskRecord
+from app.dispatcher.queue import block, next, unblock
+from app.dispatcher.store import SqliteStore
+
+
+def _task(**overrides) -> TaskRecord:
+    base = dict(
+        task_id="task-1",
+        issue_number=623,
+        title="Test task",
+        status="ready",
+        priority="high",
+        source_anchor_refs=["#617"],
+        created_at="2026-04-25T10:00:00Z",
+        updated_at="2026-04-25T10:00:00Z",
+    )
+    base.update(overrides)
+    return TaskRecord(**base)
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> SqliteStore:
+    db = tmp_path / "dispatcher.sqlite3"
+    events = tmp_path / "events.jsonl"
+    s = SqliteStore(db, JsonlEventWriter(events))
+    s.initialize()
+    return s
+
+
+def test_next_returns_ready_unblocked_unleased(store: SqliteStore) -> None:
+    task = _task()
+    store.upsert_task(task)
+
+    result = next(store, agent_id="test-agent")
+    assert result is not None
+    assert result.task_id == "task-1"
+
+
+def test_next_excludes_blocked_tasks(store: SqliteStore) -> None:
+    task = _task(blocked_reason="waiting for feedback")
+    store.upsert_task(task)
+
+    result = next(store, agent_id="test-agent")
+    assert result is None
+
+
+def test_next_excludes_claimed_tasks(store: SqliteStore) -> None:
+    task = _task(lease_id="lease-1", claimed_by="other-agent")
+    store.upsert_task(task)
+
+    result = next(store, agent_id="test-agent")
+    assert result is None
+
+
+def test_next_excludes_non_ready_tasks(store: SqliteStore) -> None:
+    task = _task(status="completed")
+    store.upsert_task(task)
+
+    result = next(store, agent_id="test-agent")
+    assert result is None
+
+
+def test_queue_ordering_priority_then_age(store: SqliteStore) -> None:
+    from app.dispatcher.leases import claim
+
+    store.upsert_task(_task(
+        task_id="low-old",
+        issue_number=1,
+        priority="low",
+        created_at="2026-04-25T08:00:00Z",
+        updated_at="2026-04-25T08:00:00Z",
+    ))
+    store.upsert_task(_task(
+        task_id="high-new",
+        issue_number=2,
+        priority="high",
+        created_at="2026-04-25T11:00:00Z",
+        updated_at="2026-04-25T11:00:00Z",
+    ))
+    store.upsert_task(_task(
+        task_id="high-old",
+        issue_number=3,
+        priority="high",
+        created_at="2026-04-25T09:00:00Z",
+        updated_at="2026-04-25T09:00:00Z",
+    ))
+
+    first = next(store, "agent")
+    assert first.task_id == "high-old"
+    claim(store, first.task_id, "agent-1")
+
+    second = next(store, "agent")
+    assert second.task_id == "high-new"
+    claim(store, second.task_id, "agent-1")
+
+    third = next(store, "agent")
+    assert third.task_id == "low-old"
+
+
+def test_block_marks_blocked(store: SqliteStore) -> None:
+    task = _task()
+    store.upsert_task(task)
+
+    blocked_task = block(store, "task-1", "waiting for dependency", "agent-1")
+
+    assert blocked_task.blocked_reason == "waiting for dependency"
+    assert blocked_task.updated_at != task.updated_at
+
+    events = store.list_events("task-1")
+    assert len(events) == 1
+    assert events[0].event_type == "task.blocked"
+    assert events[0].payload["reason"] == "waiting for dependency"
+
+
+def test_blocked_excluded_from_next(store: SqliteStore) -> None:
+    task = _task()
+    store.upsert_task(task)
+    block(store, "task-1", "waiting", "agent-1")
+
+    result = next(store, "agent-2")
+    assert result is None
+
+
+def test_unblock_clears_reason(store: SqliteStore) -> None:
+    task = _task()
+    store.upsert_task(task)
+    block(store, "task-1", "waiting", "agent-1")
+
+    unblocked = unblock(store, "task-1", "agent-1")
+    assert unblocked.blocked_reason is None
+    assert unblocked.status == "ready"
+
+    result = next(store, "agent-2")
+    assert result is not None
+
+
+def test_block_emits_event(store: SqliteStore) -> None:
+    task = _task()
+    store.upsert_task(task)
+
+    block(store, "task-1", "blocked reason", "blocker-agent")
+
+    events = store.list_events()
+    assert len(events) == 1
+    assert events[0].event_type == "task.blocked"
+    assert events[0].actor == "blocker-agent"
+    assert events[0].payload["reason"] == "blocked reason"
+
+
+def test_multiple_ready_tasks_returns_in_order(store: SqliteStore) -> None:
+    from app.dispatcher.leases import claim
+
+    for i in range(3):
+        store.upsert_task(_task(
+            task_id=f"task-{i}",
+            issue_number=100 + i,
+            priority="high",
+            created_at=f"2026-04-25T{10+i:02d}:00:00Z",
+            updated_at=f"2026-04-25T{10+i:02d}:00:00Z",
+        ))
+
+    result1 = next(store, "agent")
+    assert result1.task_id == "task-0"
+    claim(store, result1.task_id, "agent-1")
+
+    result2 = next(store, "agent")
+    assert result2.task_id == "task-1"
+    claim(store, result2.task_id, "agent-1")
+
+    result3 = next(store, "agent")
+    assert result3.task_id == "task-2"

--- a/tests/dispatcher/test_queue.py
+++ b/tests/dispatcher/test_queue.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import pytest
 
-from app.dispatcher.config import load_paths
 from app.dispatcher.events import JsonlEventWriter
 from app.dispatcher.models import TaskRecord
 from app.dispatcher.queue import block, next, unblock


### PR DESCRIPTION
## Summary

Implements dispatcher queue selection with deterministic priority ordering and lease/claim lifecycle management for multi-agent task coordination.

### Changes

**Queue Selection** (`app/dispatcher/queue.py`):
- `next(store, agent_id)`: Returns next ready, unblocked, unleased task ordered by priority (critical → high → med → low) then by age (created_at, updated_at)
- `block(store, task_id, reason, actor)`: Marks task blocked with explicit reason and sets status="blocked"
- `unblock(store, task_id, actor)`: Clears blocked reason, returns task to ready

**Lease Lifecycle** (`app/dispatcher/leases.py`):
- `claim(store, task_id, agent_id, ttl_minutes=90)`: Creates lease atomically within single transaction, preventing race conditions
- `heartbeat(store, task_id, agent_id)`: Updates lease heartbeat timestamp without extending TTL
- `release(store, task_id, agent_id, reason)`: Removes lease, returns task to ready or preserves blocked status
- `reclaim_expired_leases(store, actor)`: Finds and releases all expired leases (gc operation)

**Event Emission**:
All mutations emit correlated events to both SQLite and JSONL audit trail: task.claimed, task.heartbeat, task.released, task.blocked

### Review Feedback Addressed

✅ **P1: Enforce atomic claim** — claim() now executes all constraint checks and writes within a single SQLite transaction, preventing race conditions where multiple agents could claim the same task

✅ **P1: Set blocked status on block()** — block() now transitions task.status to "blocked" in addition to setting blocked_reason, preventing blocked tasks from being claimed

### Verification

| Aspect | Details |
|--------|---------|
| Tests | 26 tests, all passing |
| Queue Selection | ✓ Priority ordering with intermediate tasks |
| Lease Lifecycle | ✓ Claim/heartbeat/release with TTL |
| Conflict Detection | ✓ Duplicate claims rejected, atomic enforcement |
| Event Emission | ✓ All mutations logged |
| Block Safety | ✓ Blocked tasks excluded from queue |
| Test Coverage | ✓ Block/unblock behavior, wrong agent rejection, expired lease reclaim |

### Closes
Resolves #623