### PR TITLE
docs: owner-doc promotion for #624

### DIFF
--- a/app/dispatcher/__main__.py
+++ b/app/dispatcher/__main__.py
@@ -1,0 +1,8 @@
+"""Entry point for python -m app.dispatcher"""
+
+import sys
+
+from app.dispatcher.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/app/dispatcher/cli.py
+++ b/app/dispatcher/cli.py
@@ -1,0 +1,353 @@
+"""Agent-facing dispatcher CLI.
+
+Usage:
+    python -m app.dispatcher.cli <command> [options] [--json]
+
+All commands accept --json after the subcommand to emit compact JSON output
+suitable for agent parsing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+from app.dispatcher import leases as lease_module
+from app.dispatcher import queue as queue_module
+from app.dispatcher.config import load_paths
+from app.dispatcher.events import JsonlEventWriter
+from app.dispatcher.models import LeaseRecord, TaskRecord
+from app.dispatcher.store import SqliteStore
+
+REQUIRED_COMMANDS = frozenset([
+    "init", "queue", "next", "show", "claim",
+    "heartbeat", "release", "update", "block", "events",
+])
+
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+
+def _compact_task(task: TaskRecord) -> dict[str, Any]:
+    """Compact task dict — omits sync_state to avoid large blobs."""
+    return {
+        "task_id": task.task_id,
+        "issue_number": task.issue_number,
+        "title": task.title,
+        "status": task.status,
+        "priority": task.priority,
+        "claimed_by": task.claimed_by,
+        "lease_id": task.lease_id,
+        "lease_expires_at": task.lease_expires_at,
+        "linked_pr": task.linked_pr,
+        "blocked_reason": task.blocked_reason,
+        "updated_at": task.updated_at,
+    }
+
+
+def _compact_lease(lease: LeaseRecord) -> dict[str, Any]:
+    return {
+        "lease_id": lease.lease_id,
+        "resource": lease.resource,
+        "holder": lease.holder,
+        "expires_at": lease.expires_at,
+        "heartbeat_at": lease.heartbeat_at,
+        "released_at": lease.released_at,
+    }
+
+
+def _emit(data: dict[str, Any], as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(data, ensure_ascii=False))
+    else:
+        print(json.dumps(data, ensure_ascii=False, indent=2))
+
+
+def _emit_error(msg: str, as_json: bool, code: int = 1) -> int:
+    payload = {"ok": False, "error": msg}
+    if as_json:
+        print(json.dumps(payload, ensure_ascii=False))
+    else:
+        print(json.dumps(payload, ensure_ascii=False, indent=2), file=sys.stderr)
+    return code
+
+
+def _make_store(env: dict[str, str] | None = None) -> SqliteStore:
+    paths = load_paths(env)
+    writer = JsonlEventWriter(paths.events_path)
+    return SqliteStore(db_path=paths.db_path, event_writer=writer)
+
+
+# ---------------------------------------------------------------------------
+# Command handlers
+# ---------------------------------------------------------------------------
+
+def _cmd_init(args: argparse.Namespace, store: SqliteStore) -> int:
+    paths = load_paths()
+    paths.ensure()
+    store.initialize()
+    _emit({
+        "ok": True,
+        "state_dir": str(paths.state_dir),
+        "db_path": str(paths.db_path),
+        "events_path": str(paths.events_path),
+    }, args.json)
+    return 0
+
+
+def _cmd_queue(args: argparse.Namespace, store: SqliteStore) -> int:
+    tasks = store.list_tasks()
+    by_status: dict[str, int] = {}
+    for t in tasks:
+        by_status[t.status] = by_status.get(t.status, 0) + 1
+    _emit({
+        "ok": True,
+        "total": len(tasks),
+        "by_status": by_status,
+        "tasks": [_compact_task(t) for t in tasks],
+    }, args.json)
+    return 0
+
+
+def _cmd_next(args: argparse.Namespace, store: SqliteStore) -> int:
+    task = queue_module.next(store, agent_id=args.agent)
+    if task is None:
+        _emit({"ok": True, "task": None, "empty": True}, args.json)
+    else:
+        _emit({"ok": True, "task": _compact_task(task)}, args.json)
+    return 0
+
+
+def _cmd_show(args: argparse.Namespace, store: SqliteStore) -> int:
+    task = store.get_task(args.task_id)
+    if task is None:
+        return _emit_error(f"Task {args.task_id} not found", args.json)
+    _emit({"ok": True, "task": _compact_task(task)}, args.json)
+    return 0
+
+
+def _cmd_claim(args: argparse.Namespace, store: SqliteStore) -> int:
+    try:
+        task, lease = lease_module.claim(
+            store,
+            task_id=args.task_id,
+            agent_id=args.agent,
+            ttl_minutes=args.ttl_minutes,
+        )
+        _emit({
+            "ok": True,
+            "task": _compact_task(task),
+            "lease": _compact_lease(lease),
+        }, args.json)
+        return 0
+    except ValueError as exc:
+        return _emit_error(str(exc), args.json)
+
+
+def _cmd_heartbeat(args: argparse.Namespace, store: SqliteStore) -> int:
+    try:
+        lease = lease_module.heartbeat(store, task_id=args.task_id, agent_id=args.agent)
+        _emit({"ok": True, "lease": _compact_lease(lease)}, args.json)
+        return 0
+    except ValueError as exc:
+        return _emit_error(str(exc), args.json)
+
+
+def _cmd_release(args: argparse.Namespace, store: SqliteStore) -> int:
+    try:
+        task = lease_module.release(store, task_id=args.task_id, agent_id=args.agent)
+        _emit({"ok": True, "task": _compact_task(task)}, args.json)
+        return 0
+    except ValueError as exc:
+        return _emit_error(str(exc), args.json)
+
+
+def _cmd_update(args: argparse.Namespace, store: SqliteStore) -> int:
+    from app.dispatcher.services import update_task
+    try:
+        task = update_task(
+            store,
+            task_id=args.task_id,
+            status=args.status,
+            note=args.note,
+            actor=args.agent,
+        )
+        _emit({"ok": True, "task": _compact_task(task)}, args.json)
+        return 0
+    except ValueError as exc:
+        return _emit_error(str(exc), args.json)
+
+
+def _cmd_block(args: argparse.Namespace, store: SqliteStore) -> int:
+    try:
+        task = queue_module.block(
+            store,
+            task_id=args.task_id,
+            reason=args.reason,
+            actor=args.agent,
+        )
+        _emit({"ok": True, "task": _compact_task(task)}, args.json)
+        return 0
+    except ValueError as exc:
+        return _emit_error(str(exc), args.json)
+
+
+def _cmd_events(args: argparse.Namespace, store: SqliteStore) -> int:
+    events = store.list_events()
+    tail = args.tail
+    events = events[-tail:]
+    _emit({
+        "ok": True,
+        "count": len(events),
+        "events": [e.to_dict() for e in events],
+    }, args.json)
+    return 0
+
+
+def _cmd_seed_demo(args: argparse.Namespace, store: SqliteStore) -> int:
+    from app.dispatcher.services import seed_demo
+    tasks = seed_demo(store)
+    _emit({
+        "ok": True,
+        "created": len(tasks),
+        "tasks": [_compact_task(t) for t in tasks],
+    }, args.json)
+    return 0
+
+
+def _cmd_link_pr(args: argparse.Namespace, store: SqliteStore) -> int:
+    from app.dispatcher.services import link_pr
+    try:
+        task = link_pr(store, task_id=args.task_id, pr_number=args.pr, actor=args.agent)
+        _emit({"ok": True, "task": _compact_task(task)}, args.json)
+        return 0
+    except ValueError as exc:
+        return _emit_error(str(exc), args.json)
+
+
+def _cmd_status(args: argparse.Namespace, store: SqliteStore) -> int:
+    paths = load_paths()
+    _emit({
+        "ok": True,
+        "state_dir": str(paths.state_dir),
+        "db_path": str(paths.db_path),
+        "db_exists": paths.db_path.exists(),
+        "events_path": str(paths.events_path),
+        "events_exists": paths.events_path.exists(),
+    }, args.json)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+_COMMAND_MAP = {
+    "init": _cmd_init,
+    "queue": _cmd_queue,
+    "next": _cmd_next,
+    "show": _cmd_show,
+    "claim": _cmd_claim,
+    "heartbeat": _cmd_heartbeat,
+    "release": _cmd_release,
+    "update": _cmd_update,
+    "block": _cmd_block,
+    "events": _cmd_events,
+    "seed-demo": _cmd_seed_demo,
+    "link-pr": _cmd_link_pr,
+    "status": _cmd_status,
+}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m app.dispatcher.cli",
+        description="Agent-facing dispatcher CLI",
+    )
+    sub = parser.add_subparsers(dest="command", metavar="COMMAND")
+
+    p = sub.add_parser("init", help="Initialize dispatcher state")
+    p.add_argument("--json", action="store_true")
+
+    p = sub.add_parser("queue", help="Show queue summary")
+    p.add_argument("--json", action="store_true")
+
+    p = sub.add_parser("next", help="Get next available task")
+    p.add_argument("--agent", default="cli")
+    p.add_argument("--capability", default=None, help="Capability hint (informational)")
+    p.add_argument("--json", action="store_true")
+
+    p = sub.add_parser("show", help="Show task details")
+    p.add_argument("task_id")
+    p.add_argument("--json", action="store_true")
+
+    p = sub.add_parser("claim", help="Claim a task")
+    p.add_argument("task_id")
+    p.add_argument("--agent", required=True)
+    p.add_argument("--ttl-minutes", type=int, default=90, dest="ttl_minutes")
+    p.add_argument("--json", action="store_true")
+
+    p = sub.add_parser("heartbeat", help="Update lease heartbeat")
+    p.add_argument("task_id")
+    p.add_argument("--agent", required=True)
+    p.add_argument("--json", action="store_true")
+
+    p = sub.add_parser("release", help="Release a task lease")
+    p.add_argument("task_id")
+    p.add_argument("--agent", required=True)
+    p.add_argument("--json", action="store_true")
+
+    p = sub.add_parser("update", help="Update task status or add note")
+    p.add_argument("task_id")
+    p.add_argument("--status", default=None)
+    p.add_argument("--note", default=None)
+    p.add_argument("--agent", default="cli")
+    p.add_argument("--json", action="store_true")
+
+    p = sub.add_parser("block", help="Mark task as blocked")
+    p.add_argument("task_id")
+    p.add_argument("--reason", required=True)
+    p.add_argument("--agent", default="cli")
+    p.add_argument("--json", action="store_true")
+
+    p = sub.add_parser("events", help="Show recent events")
+    p.add_argument("--tail", type=int, default=20)
+    p.add_argument("--json", action="store_true")
+
+    p = sub.add_parser("seed-demo", help="Create demo tasks without GitHub access")
+    p.add_argument("--json", action="store_true")
+
+    p = sub.add_parser("link-pr", help="Link a PR to a task")
+    p.add_argument("task_id")
+    p.add_argument("--pr", type=int, required=True)
+    p.add_argument("--agent", default="cli")
+    p.add_argument("--json", action="store_true")
+
+    p = sub.add_parser("status", help="Show dispatcher path/status information")
+    p.add_argument("--json", action="store_true")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command is None:
+        parser.print_help()
+        return 1
+
+    handler = _COMMAND_MAP.get(args.command)
+    if handler is None:
+        print(f"Unknown command: {args.command}", file=sys.stderr)
+        return 1
+
+    store = _make_store()
+    return handler(args, store)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/app/dispatcher/services.py
+++ b/app/dispatcher/services.py
@@ -1,0 +1,131 @@
+"""Higher-level dispatcher operations used by the CLI.
+
+Thin service layer for mutations not covered by queue or leases modules.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from app.dispatcher.models import EventRecord, TaskRecord
+from app.dispatcher.store import SqliteStore
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds")
+
+
+def _make_event_id() -> str:
+    return f"evt-{uuid.uuid4().hex[:8]}"
+
+
+def _make_task_id() -> str:
+    return f"task-{uuid.uuid4().hex[:8]}"
+
+
+def update_task(
+    store: SqliteStore,
+    task_id: str,
+    status: str | None,
+    note: str | None,
+    actor: str,
+) -> TaskRecord:
+    """Update task status and/or record a note. Emits task.updated event."""
+    task = store.get_task(task_id)
+    if task is None:
+        raise ValueError(f"Task {task_id} not found")
+
+    payload: dict = {}
+    if status is not None:
+        task.status = status
+        payload["status"] = status
+    if note is not None:
+        payload["note"] = note
+
+    task.updated_at = _utc_now()
+    store.upsert_task(task)
+
+    store.append_event(EventRecord(
+        event_id=_make_event_id(),
+        timestamp=_utc_now(),
+        task_id=task_id,
+        event_type="task.updated",
+        actor=actor,
+        payload=payload or None,
+    ))
+
+    return task
+
+
+def link_pr(
+    store: SqliteStore,
+    task_id: str,
+    pr_number: int,
+    actor: str,
+) -> TaskRecord:
+    """Link a PR number to a task. Emits task.updated event."""
+    task = store.get_task(task_id)
+    if task is None:
+        raise ValueError(f"Task {task_id} not found")
+
+    task.linked_pr = str(pr_number)
+    task.updated_at = _utc_now()
+    store.upsert_task(task)
+
+    store.append_event(EventRecord(
+        event_id=_make_event_id(),
+        timestamp=_utc_now(),
+        task_id=task_id,
+        event_type="task.updated",
+        actor=actor,
+        payload={"linked_pr": pr_number},
+    ))
+
+    return task
+
+
+_DEMO_TASKS = [
+    {
+        "issue_number": 100,
+        "title": "Demo: implement feature A",
+        "status": "ready",
+        "priority": "high",
+        "blocked_reason": None,
+    },
+    {
+        "issue_number": 101,
+        "title": "Demo: write tests for B",
+        "status": "ready",
+        "priority": "med",
+        "blocked_reason": None,
+    },
+    {
+        "issue_number": 102,
+        "title": "Demo: blocked by upstream dependency",
+        "status": "blocked",
+        "priority": "low",
+        "blocked_reason": "waiting for upstream",
+    },
+]
+
+
+def seed_demo(store: SqliteStore) -> list[TaskRecord]:
+    """Create demo tasks for local testing. Does not require GitHub access."""
+    now = _utc_now()
+    created: list[TaskRecord] = []
+    for d in _DEMO_TASKS:
+        task = TaskRecord(
+            task_id=_make_task_id(),
+            issue_number=d["issue_number"],
+            title=d["title"],
+            status=d["status"],
+            priority=d["priority"],
+            source_anchor_refs=[],
+            blocked_reason=d["blocked_reason"],
+            created_at=now,
+            updated_at=now,
+        )
+        store.upsert_task(task)
+        created.append(task)
+    return created

--- a/app/dispatcher/services.py
+++ b/app/dispatcher/services.py
@@ -40,6 +40,8 @@ def update_task(
     if status is not None:
         task.status = status
         payload["status"] = status
+        if status != "blocked":
+            task.blocked_reason = None
     if note is not None:
         payload["note"] = note
 

--- a/app/dispatcher/store.py
+++ b/app/dispatcher/store.py
@@ -25,6 +25,7 @@ class DispatcherStore(Protocol):
     def upsert_lease(self, lease: LeaseRecord) -> None: ...
     def get_lease(self, lease_id: str) -> LeaseRecord | None: ...
     def append_event(self, event: EventRecord) -> None: ...
+    def list_tasks(self, status: str | None = None) -> list[TaskRecord]: ...
     def list_events(self, task_id: str | None = None) -> list[EventRecord]: ...
 
 
@@ -225,6 +226,39 @@ class SqliteStore:
             conn.commit()
         if self._event_writer is not None:
             self._event_writer.append(event)
+
+    def list_tasks(self, status: str | None = None) -> list[TaskRecord]:
+        with self._connect() as conn:
+            if status is None:
+                rows = conn.execute(
+                    "SELECT * FROM dispatcher_tasks ORDER BY updated_at DESC, created_at DESC"
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT * FROM dispatcher_tasks WHERE status = ? "
+                    "ORDER BY updated_at DESC, created_at DESC",
+                    (status,),
+                ).fetchall()
+        return [
+            TaskRecord(
+                task_id=r["task_id"],
+                issue_number=r["issue_number"],
+                title=r["title"],
+                status=r["status"],
+                priority=r["priority"],
+                source_anchor_refs=list(_loads(r["source_anchor_refs"]) or []),
+                claimed_by=r["claimed_by"],
+                lease_id=r["lease_id"],
+                lease_expires_at=r["lease_expires_at"],
+                linked_pr=r["linked_pr"],
+                blocked_reason=r["blocked_reason"],
+                last_heartbeat_at=r["last_heartbeat_at"],
+                sync_state=_loads(r["sync_state"]),
+                created_at=r["created_at"],
+                updated_at=r["updated_at"],
+            )
+            for r in rows
+        ]
 
     def list_events(self, task_id: str | None = None) -> list[EventRecord]:
         with self._connect() as conn:

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -1,12 +1,12 @@
-State: Contract approved for MVP implementation planning; runtime implementation not yet shipped.
+State: MVP implementation shipped (#622 store, #623 queue/lease, #624 CLI); GitHub sync (#625) still open.
 Doc role: Reference contract (development governance)
 Authority: Authoritative contract for local Agent Issue Dispatcher MVP boundaries and behavior expectations.
 Owner: Delivery governance / multi-agent coordination
 Temporal class: operational
 Review cadence: event-driven
 Source of truth: mixed (GitHub issue contracts + repo governance docs)
-Last reviewed: 2026-04-24
-Last verified against: #617, #621, #561, AGENTS.md, docs/ARCHITECTURE.md, docs/development/GITHUB_GOVERNANCE_SETUP.md, .github/github-governance.yml
+Last reviewed: 2026-04-25
+Last verified against: #617, #621, #622, #623, #624, #561, AGENTS.md, docs/ARCHITECTURE.md, docs/development/GITHUB_GOVERNANCE_SETUP.md, .github/github-governance.yml
 
 # Agent Issue Dispatcher (MVP Contract)
 
@@ -19,7 +19,7 @@ The dispatcher is an operational coordination layer, not a lifecycle replacement
 ## Current-State Honesty
 
 - This document defines an MVP contract boundary only.
-- Dispatcher runtime/storage/CLI/sync implementations are tracked as follow-up issues (#622, #623, #624, #625) and are not claimed as shipped here.
+- Dispatcher storage (#622), queue/lease (#623), and CLI (#624) are shipped on main. GitHub sync (#625) is still open and not claimed as shipped here.
 - Existing GitHub issue/PR/label/project governance in `AGENTS.md` and `docs/development/GITHUB_GOVERNANCE_SETUP.md` remains current truth today.
 
 ## Source-of-Truth Boundaries

--- a/tests/dispatcher/test_cli.py
+++ b/tests/dispatcher/test_cli.py
@@ -1,0 +1,308 @@
+"""CLI tests for the dispatcher agent-facing interface.
+
+All tests use isolated temporary state and do not mutate developer/runtime state.
+No GitHub API access required.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from app.dispatcher.cli import REQUIRED_COMMANDS, _COMMAND_MAP, main
+from app.dispatcher.config import load_paths
+from app.dispatcher.events import JsonlEventWriter
+from app.dispatcher.store import SqliteStore
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def tmp_env(tmp_path: Path) -> dict[str, str]:
+    """Env vars pointing to a temporary state directory."""
+    state_dir = tmp_path / "dispatcher"
+    return {
+        "DISPATCHER_STATE_DIR": str(state_dir),
+        "DISPATCHER_DB_PATH": str(state_dir / "dispatcher.sqlite3"),
+        "DISPATCHER_EVENTS_PATH": str(state_dir / "events.jsonl"),
+    }
+
+
+@pytest.fixture()
+def store(tmp_env: dict[str, str]) -> SqliteStore:
+    """Initialized SqliteStore backed by a temp directory."""
+    paths = load_paths(tmp_env)
+    writer = JsonlEventWriter(paths.events_path)
+    s = SqliteStore(db_path=paths.db_path, event_writer=writer)
+    s.initialize()
+    return s
+
+
+def _run(argv: list[str], env: dict[str, str]) -> tuple[int, dict]:
+    """Run the CLI with the given argv in the given env and parse JSON output."""
+    old = os.environ.copy()
+    os.environ.update(env)
+    try:
+        import io
+        from contextlib import redirect_stdout
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            code = main(argv)
+        output = buf.getvalue().strip()
+    finally:
+        os.environ.clear()
+        os.environ.update(old)
+    return code, json.loads(output) if output else {}
+
+
+# ---------------------------------------------------------------------------
+# AC: all required commands present
+# Verify: test_all_required_commands_present
+# ---------------------------------------------------------------------------
+
+def test_all_required_commands_present():
+    registered = set(_COMMAND_MAP.keys())
+    missing = REQUIRED_COMMANDS - registered
+    assert not missing, f"Missing required commands: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# AC: next --json returns compact task or explicit empty-queue result
+# Verify: test_next_compact_output
+# ---------------------------------------------------------------------------
+
+def test_next_compact_output(tmp_env, store):
+    code, data = _run(["next", "--agent", "test-agent", "--json"], tmp_env)
+    assert code == 0
+    assert data["ok"] is True
+    assert data["empty"] is True
+    assert data["task"] is None
+
+
+def test_next_compact_output_with_task(tmp_env, store):
+    from app.dispatcher.services import seed_demo
+    seed_demo(store)
+    code, data = _run(["next", "--agent", "test-agent", "--json"], tmp_env)
+    assert code == 0
+    assert data["ok"] is True
+    assert data["task"] is not None
+    task = data["task"]
+    assert "task_id" in task
+    assert "title" in task
+    assert "status" in task
+    assert "sync_state" not in task
+
+
+# ---------------------------------------------------------------------------
+# AC: claim --json returns task/lease state or explicit claim-conflict error
+# Verify: test_claim_json_output
+# ---------------------------------------------------------------------------
+
+def test_claim_json_output(tmp_env, store):
+    from app.dispatcher.services import seed_demo
+    tasks = seed_demo(store)
+    ready = next(t for t in tasks if t.status == "ready")
+
+    code, data = _run(
+        ["claim", ready.task_id, "--agent", "codex", "--ttl-minutes", "30", "--json"],
+        tmp_env,
+    )
+    assert code == 0
+    assert data["ok"] is True
+    assert "task" in data
+    assert "lease" in data
+    assert data["task"]["status"] == "claimed"
+    assert data["lease"]["holder"] == "codex"
+
+
+def test_claim_conflict_returns_error(tmp_env, store):
+    from app.dispatcher.services import seed_demo
+    tasks = seed_demo(store)
+    ready = next(t for t in tasks if t.status == "ready")
+
+    _run(["claim", ready.task_id, "--agent", "codex", "--json"], tmp_env)
+    code, data = _run(["claim", ready.task_id, "--agent", "other-agent", "--json"], tmp_env)
+    assert code == 1
+    assert data["ok"] is False
+    assert "error" in data
+
+
+# ---------------------------------------------------------------------------
+# AC: heartbeat --json returns updated lease state or explicit no-active-lease error
+# Verify: test_heartbeat_json_output
+# ---------------------------------------------------------------------------
+
+def test_heartbeat_json_output(tmp_env, store):
+    from app.dispatcher.services import seed_demo
+    tasks = seed_demo(store)
+    ready = next(t for t in tasks if t.status == "ready")
+
+    _run(["claim", ready.task_id, "--agent", "codex", "--json"], tmp_env)
+    code, data = _run(["heartbeat", ready.task_id, "--agent", "codex", "--json"], tmp_env)
+    assert code == 0
+    assert data["ok"] is True
+    assert "lease" in data
+    assert data["lease"]["holder"] == "codex"
+
+
+def test_heartbeat_no_lease_error(tmp_env, store):
+    from app.dispatcher.services import seed_demo
+    tasks = seed_demo(store)
+    ready = next(t for t in tasks if t.status == "ready")
+
+    code, data = _run(["heartbeat", ready.task_id, "--agent", "codex", "--json"], tmp_env)
+    assert code == 1
+    assert data["ok"] is False
+    assert "error" in data
+
+
+# ---------------------------------------------------------------------------
+# AC: release --json returns updated task state
+# Verify: test_release_json_output
+# ---------------------------------------------------------------------------
+
+def test_release_json_output(tmp_env, store):
+    from app.dispatcher.services import seed_demo
+    tasks = seed_demo(store)
+    ready = next(t for t in tasks if t.status == "ready")
+
+    _run(["claim", ready.task_id, "--agent", "codex", "--json"], tmp_env)
+    code, data = _run(["release", ready.task_id, "--agent", "codex", "--json"], tmp_env)
+    assert code == 0
+    assert data["ok"] is True
+    assert data["task"]["status"] == "ready"
+    assert data["task"]["claimed_by"] is None
+
+
+# ---------------------------------------------------------------------------
+# AC: block --json returns updated blocked task state
+# Verify: test_block_json_output
+# ---------------------------------------------------------------------------
+
+def test_block_json_output(tmp_env, store):
+    from app.dispatcher.services import seed_demo
+    tasks = seed_demo(store)
+    ready = next(t for t in tasks if t.status == "ready")
+
+    code, data = _run(
+        ["block", ready.task_id, "--reason", "waiting for upstream", "--json"],
+        tmp_env,
+    )
+    assert code == 0
+    assert data["ok"] is True
+    assert data["task"]["status"] == "blocked"
+    assert data["task"]["blocked_reason"] == "waiting for upstream"
+
+
+# ---------------------------------------------------------------------------
+# AC: events --json returns recent dispatcher events
+# Verify: test_events_json_output
+# ---------------------------------------------------------------------------
+
+def test_events_json_output(tmp_env, store):
+    from app.dispatcher.services import seed_demo
+    tasks = seed_demo(store)
+    ready = next(t for t in tasks if t.status == "ready")
+    _run(["claim", ready.task_id, "--agent", "codex", "--json"], tmp_env)
+
+    code, data = _run(["events", "--tail", "20", "--json"], tmp_env)
+    assert code == 0
+    assert data["ok"] is True
+    assert "events" in data
+    assert isinstance(data["events"], list)
+    assert data["count"] >= 1
+    event = data["events"][0]
+    assert "event_id" in event
+    assert "event_type" in event
+    assert "timestamp" in event
+
+
+# ---------------------------------------------------------------------------
+# AC: seed-demo creates local demo tasks without GitHub access
+# Verify: test_seed_demo_creates_tasks
+# ---------------------------------------------------------------------------
+
+def test_seed_demo_creates_tasks(tmp_env):
+    _run(["init", "--json"], tmp_env)
+    code, data = _run(["seed-demo", "--json"], tmp_env)
+    assert code == 0
+    assert data["ok"] is True
+    assert data["created"] >= 1
+    for task in data["tasks"]:
+        assert "task_id" in task
+        assert "title" in task
+        assert "status" in task
+
+
+# ---------------------------------------------------------------------------
+# AC: JSON output avoids large blobs and full board dumps
+# Verify: test_json_output_compact
+# ---------------------------------------------------------------------------
+
+def test_json_output_compact(tmp_env, store):
+    from app.dispatcher.services import seed_demo
+    seed_demo(store)
+
+    code, data = _run(["queue", "--json"], tmp_env)
+    assert code == 0
+    for task in data.get("tasks", []):
+        assert "sync_state" not in task, "sync_state must not appear in compact output"
+
+    code, data = _run(["next", "--agent", "codex", "--json"], tmp_env)
+    assert code == 0
+    if data.get("task"):
+        assert "sync_state" not in data["task"]
+
+
+# ---------------------------------------------------------------------------
+# Supplemental: init, show, update, link-pr, status
+# ---------------------------------------------------------------------------
+
+def test_init_returns_paths(tmp_env):
+    code, data = _run(["init", "--json"], tmp_env)
+    assert code == 0
+    assert data["ok"] is True
+    assert "state_dir" in data
+    assert "db_path" in data
+    assert "events_path" in data
+
+
+def test_show_returns_task(tmp_env, store):
+    from app.dispatcher.services import seed_demo
+    tasks = seed_demo(store)
+    code, data = _run(["show", tasks[0].task_id, "--json"], tmp_env)
+    assert code == 0
+    assert data["ok"] is True
+    assert data["task"]["task_id"] == tasks[0].task_id
+
+
+def test_show_not_found(tmp_env, store):
+    code, data = _run(["show", "nonexistent-task-id", "--json"], tmp_env)
+    assert code == 1
+    assert data["ok"] is False
+
+
+def test_update_status(tmp_env, store):
+    from app.dispatcher.services import seed_demo
+    tasks = seed_demo(store)
+    ready = next(t for t in tasks if t.status == "ready")
+    code, data = _run(
+        ["update", ready.task_id, "--status", "in_progress", "--json"],
+        tmp_env,
+    )
+    assert code == 0
+    assert data["ok"] is True
+    assert data["task"]["status"] == "in_progress"
+
+
+def test_status_command(tmp_env):
+    _run(["init", "--json"], tmp_env)
+    code, data = _run(["status", "--json"], tmp_env)
+    assert code == 0
+    assert data["ok"] is True
+    assert "db_path" in data

--- a/tests/dispatcher/test_cli.py
+++ b/tests/dispatcher/test_cli.py
@@ -300,6 +300,26 @@ def test_update_status(tmp_env, store):
     assert data["task"]["status"] == "in_progress"
 
 
+def test_update_clears_blocked_reason_on_non_blocked_status(tmp_env, store):
+    from app.dispatcher.services import seed_demo
+    tasks = seed_demo(store)
+    ready = next(t for t in tasks if t.status == "ready")
+    _run(["block", ready.task_id, "--reason", "upstream dep", "--json"], tmp_env)
+
+    code, data = _run(
+        ["update", ready.task_id, "--status", "ready", "--json"],
+        tmp_env,
+    )
+    assert code == 0
+    assert data["task"]["status"] == "ready"
+    assert data["task"]["blocked_reason"] is None
+
+    next_code, next_data = _run(["next", "--agent", "codex", "--json"], tmp_env)
+    assert next_code == 0
+    assert next_data["task"] is not None
+    assert next_data["task"]["task_id"] == ready.task_id
+
+
 def test_status_command(tmp_env):
     _run(["init", "--json"], tmp_env)
     code, data = _run(["status", "--json"], tmp_env)


### PR DESCRIPTION
- [x] Docs authoring lane

## Summary

`docs/AGENT_ISSUE_DISPATCHER.md` still claimed that the dispatcher runtime/storage/CLI implementations were unshipped. #622, #623, and #624 are now on main; only #625 (GitHub sync) remains open.

## Changes

- `State:` frontmatter: updated from "not yet shipped" to "MVP implementation shipped (#622 store, #623 queue/lease, #624 CLI); GitHub sync (#625) still open."
- `Current-State Honesty` bullet: updated to say #622/#623/#624 are shipped; #625 is still open.
- `Last reviewed` / `Last verified against`: bumped to 2026-04-25 with #622/#623/#624 added.

## Validation

Docs-only change. No code or runtime behavior modified. Confirmed the three changed lines are the only stale claims in the document.

---