### PR TITLE
feat(dispatcher): add GitHub pull-sync boundary and projection planning

### DIFF
--- a/app/dispatcher/sync_github.py
+++ b/app/dispatcher/sync_github.py
@@ -106,19 +106,20 @@ def record_sync_success(
     pull_at: str,
     rate_limit_remaining: int | None = None,
     rate_limit_reset: str | None = None,
+    extra: dict[str, Any] | None = None,
 ) -> None:
     """Persist a successful pull-sync metadata record for *provider*."""
-    extra: dict[str, Any] = {}
+    merged: dict[str, Any] = dict(extra or {})
     if rate_limit_remaining is not None:
-        extra["rate_limit_remaining"] = rate_limit_remaining
+        merged["rate_limit_remaining"] = rate_limit_remaining
     if rate_limit_reset is not None:
-        extra["rate_limit_reset"] = rate_limit_reset
+        merged["rate_limit_reset"] = rate_limit_reset
 
     sync_state = SyncState(
         last_pull_at=pull_at,
         sync_result="ok",
         sync_note=None,
-        extra=extra,
+        extra=merged,
     )
     _write_sync_meta(store, provider, sync_state, pull_at)
 
@@ -229,10 +230,14 @@ class PullSyncAdapter:
             return []
 
         upserted: list[TaskRecord] = []
+        skipped: list[str] = []
         for issue in issues:
-            task = normalize_github_issue(issue, now=pull_at)
-            self._store.upsert_task(task)
-            upserted.append(task)
+            try:
+                task = normalize_github_issue(issue, now=pull_at)
+                self._store.upsert_task(task)
+                upserted.append(task)
+            except Exception as exc:
+                skipped.append(f"issue={issue.get('number', '?')}: {exc}")
 
         rl_remaining: int | None = None
         rl_reset: str | None = None
@@ -240,11 +245,17 @@ class PullSyncAdapter:
             rl_remaining = rate_limit.get("remaining")
             rl_reset = rate_limit.get("reset")
 
+        extra: dict[str, Any] = {}
+        if skipped:
+            extra["skipped_count"] = len(skipped)
+            extra["skipped_notes"] = skipped[:10]
+
         record_sync_success(
             self._store,
             self._provider,
             pull_at,
             rate_limit_remaining=rl_remaining,
             rate_limit_reset=rl_reset,
+            extra=extra,
         )
         return upserted

--- a/app/dispatcher/sync_github.py
+++ b/app/dispatcher/sync_github.py
@@ -10,8 +10,6 @@ Design constraints (from #625):
 
 from __future__ import annotations
 
-import re
-import uuid
 from datetime import datetime, timezone
 from typing import Any, Protocol
 

--- a/app/dispatcher/sync_github.py
+++ b/app/dispatcher/sync_github.py
@@ -1,0 +1,252 @@
+"""GitHub pull-sync adapter for the local Agent Issue Dispatcher.
+
+Design constraints (from #625):
+- Pull-only: no write-back to GitHub in this implementation.
+- Tests must be fully offline; no live GitHub API access is required.
+- GitHub Projects is not used in the sync hot path.
+- Sync failures are observable and must not corrupt the local queue state.
+- The adapter is intentionally narrow and mockable.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Protocol
+
+from app.dispatcher.models import SyncState, TaskRecord
+from app.dispatcher.store import DispatcherStore
+
+PROVIDER_IDENTITY = "github"
+
+
+# ---------------------------------------------------------------------------
+# Label → priority mapping
+# ---------------------------------------------------------------------------
+
+_LABEL_PRIORITY: dict[str, str] = {
+    "prio:high": "high",
+    "prio:med": "med",
+    "prio:low": "low",
+    "priority:high": "high",
+    "priority:medium": "med",
+    "priority:low": "low",
+}
+
+_LABEL_STATUS: dict[str, str] = {
+    "agent:ready": "ready",
+    "agent:blocked": "blocked",
+}
+
+
+def normalize_github_issue(payload: dict[str, Any], now: str | None = None) -> TaskRecord:
+    """Normalize a GitHub issue API payload into a local :class:`TaskRecord`.
+
+    The function is deterministic and requires no network access; callers pass
+    raw GitHub issue dicts (real or mocked).
+
+    Priority defaults to ``med`` when no recognised priority label is present.
+    Status defaults to ``ready`` when no recognised status label is present.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc).isoformat()
+
+    number = payload["number"]
+    task_id = f"github-issue-{number}"
+
+    labels: list[str] = [
+        (lbl.get("name") or lbl) if isinstance(lbl, dict) else str(lbl)
+        for lbl in payload.get("labels", [])
+    ]
+
+    priority = "med"
+    for lbl in labels:
+        if lbl in _LABEL_PRIORITY:
+            priority = _LABEL_PRIORITY[lbl]
+            break
+
+    status = "ready"
+    for lbl in labels:
+        if lbl in _LABEL_STATUS:
+            status = _LABEL_STATUS[lbl]
+            break
+
+    updated_at = payload.get("updatedAt") or payload.get("updated_at") or now
+
+    sync_state = SyncState(
+        last_pull_at=now,
+        source_version=payload.get("updatedAt") or payload.get("updated_at"),
+        sync_result="ok",
+        sync_note=None,
+    )
+
+    return TaskRecord(
+        task_id=task_id,
+        issue_number=number,
+        title=payload.get("title", ""),
+        status=status,
+        priority=priority,
+        source_anchor_refs=[f"github:issue:{number}"],
+        created_at=payload.get("createdAt") or payload.get("created_at") or now,
+        updated_at=updated_at,
+        sync_state=sync_state.to_dict(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sync-state persistence helpers
+# ---------------------------------------------------------------------------
+
+def _meta_task_id(provider: str) -> str:
+    return f"_sync_meta_{provider}"
+
+
+def record_sync_success(
+    store: DispatcherStore,
+    provider: str,
+    pull_at: str,
+    rate_limit_remaining: int | None = None,
+    rate_limit_reset: str | None = None,
+) -> None:
+    """Persist a successful pull-sync metadata record for *provider*."""
+    extra: dict[str, Any] = {}
+    if rate_limit_remaining is not None:
+        extra["rate_limit_remaining"] = rate_limit_remaining
+    if rate_limit_reset is not None:
+        extra["rate_limit_reset"] = rate_limit_reset
+
+    sync_state = SyncState(
+        last_pull_at=pull_at,
+        sync_result="ok",
+        sync_note=None,
+        extra=extra,
+    )
+    _write_sync_meta(store, provider, sync_state, pull_at)
+
+
+def record_sync_failure(
+    store: DispatcherStore,
+    provider: str,
+    pull_at: str,
+    error: str,
+) -> None:
+    """Persist a sync failure metadata record without touching task rows."""
+    sync_state = SyncState(
+        last_pull_at=pull_at,
+        sync_result="error",
+        sync_note=error,
+    )
+    _write_sync_meta(store, provider, sync_state, pull_at)
+
+
+def _write_sync_meta(
+    store: DispatcherStore,
+    provider: str,
+    sync_state: SyncState,
+    pull_at: str,
+) -> None:
+    task_id = _meta_task_id(provider)
+    existing = store.get_task(task_id)
+    if existing is None:
+        record = TaskRecord(
+            task_id=task_id,
+            issue_number=0,
+            title=f"_sync_meta:{provider}",
+            status="_meta",
+            priority="low",
+            source_anchor_refs=[],
+            created_at=pull_at,
+            updated_at=pull_at,
+            sync_state=sync_state.to_dict(),
+        )
+    else:
+        existing.sync_state = sync_state.to_dict()
+        existing.updated_at = pull_at
+        record = existing
+    store.upsert_task(record)
+
+
+def get_sync_meta(store: DispatcherStore, provider: str) -> dict[str, Any] | None:
+    """Return the last recorded sync metadata for *provider*, or None."""
+    task_id = _meta_task_id(provider)
+    record = store.get_task(task_id)
+    if record is None:
+        return None
+    return record.sync_state
+
+
+# ---------------------------------------------------------------------------
+# Pull-sync adapter protocol and implementation
+# ---------------------------------------------------------------------------
+
+class GitHubIssueSource(Protocol):
+    """Minimal interface for a GitHub issue data source.
+
+    Implementations may call ``gh`` CLI, the REST API, or return mock data.
+    The sync adapter never imports or calls GitHub directly; it only uses this
+    protocol, keeping unit tests fully offline.
+    """
+
+    def list_issues(self, repo: str, **kwargs: Any) -> list[dict[str, Any]]: ...
+
+    def get_rate_limit(self) -> dict[str, Any] | None: ...
+
+
+class PullSyncAdapter:
+    """Pull issues from *source* and upsert them as local dispatcher tasks.
+
+    Only reads from GitHub; does not write back labels, comments, or status.
+    GitHub Projects is not queried or mutated.
+    Sync failures record an error state and leave existing task rows untouched.
+    """
+
+    def __init__(
+        self,
+        store: DispatcherStore,
+        source: GitHubIssueSource,
+        provider: str = PROVIDER_IDENTITY,
+    ) -> None:
+        self._store = store
+        self._source = source
+        self._provider = provider
+
+    def pull(self, repo: str, **kwargs: Any) -> list[TaskRecord]:
+        """Pull open issues from *repo* and upsert normalised task records.
+
+        Returns the list of upserted :class:`TaskRecord` objects.
+        Raises nothing; on error, records failure metadata and returns ``[]``.
+        """
+        pull_at = datetime.now(timezone.utc).isoformat()
+        rate_limit: dict[str, Any] | None = None
+        try:
+            rate_limit = self._source.get_rate_limit()
+        except Exception:
+            pass
+
+        try:
+            issues = self._source.list_issues(repo, **kwargs)
+        except Exception as exc:
+            record_sync_failure(self._store, self._provider, pull_at, str(exc))
+            return []
+
+        upserted: list[TaskRecord] = []
+        for issue in issues:
+            task = normalize_github_issue(issue, now=pull_at)
+            self._store.upsert_task(task)
+            upserted.append(task)
+
+        rl_remaining: int | None = None
+        rl_reset: str | None = None
+        if rate_limit:
+            rl_remaining = rate_limit.get("remaining")
+            rl_reset = rate_limit.get("reset")
+
+        record_sync_success(
+            self._store,
+            self._provider,
+            pull_at,
+            rate_limit_remaining=rl_remaining,
+            rate_limit_reset=rl_reset,
+        )
+        return upserted

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -5,8 +5,8 @@ Owner: Delivery governance / multi-agent coordination
 Temporal class: operational
 Review cadence: event-driven
 Source of truth: mixed (GitHub issue contracts + repo governance docs)
-Last reviewed: 2026-04-24
-Last verified against: #617, #621, #561, AGENTS.md, docs/ARCHITECTURE.md, docs/development/GITHUB_GOVERNANCE_SETUP.md, .github/github-governance.yml
+Last reviewed: 2026-04-25
+Last verified against: #617, #621, #622, #623, #624, #625, #561, AGENTS.md, docs/ARCHITECTURE.md, docs/development/GITHUB_GOVERNANCE_SETUP.md, .github/github-governance.yml
 
 # Agent Issue Dispatcher (MVP Contract)
 
@@ -19,7 +19,8 @@ The dispatcher is an operational coordination layer, not a lifecycle replacement
 ## Current-State Honesty
 
 - This document defines an MVP contract boundary only.
-- Dispatcher runtime/storage/CLI/sync implementations are tracked as follow-up issues (#622, #623, #624, #625) and are not claimed as shipped here.
+- Dispatcher runtime/storage foundation (#622), queue/lease lifecycle (#623), and agent-facing CLI (#624) are shipped.
+- GitHub pull-sync boundary (#625) is shipped: `app/dispatcher/sync_github.py` provides the `PullSyncAdapter` and `normalize_github_issue` normalisation function.
 - Existing GitHub issue/PR/label/project governance in `AGENTS.md` and `docs/development/GITHUB_GOVERNANCE_SETUP.md` remains current truth today.
 
 ## Source-of-Truth Boundaries
@@ -180,6 +181,47 @@ Contract expectations:
 
 - #617 is the parent dispatcher workstream and sequencing authority. This document satisfies #621 as the prerequisite contract before implementation issues proceed.
 - #561 defines the minimal shared lease and git-hygiene guardrails. Dispatcher MVP reuses that lease-boundary intent but remains scoped to issue coordination, not janitor/preflight tooling.
+
+## GitHub Sync Model
+
+The dispatcher pulls issue state from GitHub in a narrow, read-only adapter boundary.
+
+Pull-sync contract:
+- The adapter reads GitHub issue fields and normalises them into local `TaskRecord` rows.
+- No write-back: the adapter never writes labels, comments, or status back to GitHub in the MVP.
+- GitHub Projects is not queried or mutated in the sync hot path.
+- Sync state (`last_pull_at`, `sync_result`, `sync_note`, rate-limit metadata) is recorded locally as a `_sync_meta:<provider>` task row.
+- Sync failures record an `error` state in sync metadata and leave all existing task rows untouched.
+
+Implementation surface:
+- `app/dispatcher/sync_github.py` — `GitHubIssueSource` protocol, `PullSyncAdapter`, `normalize_github_issue`, sync-state helpers.
+- `GitHubIssueSource` is a mockable protocol; the adapter never imports `requests`, `httpx`, or a GitHub SDK.
+- Tests in `tests/dispatcher/test_sync_github.py` use only mocked data; no live GitHub API access is required.
+
+## Sync Failure Behavior
+
+If the `GitHubIssueSource` raises during `list_issues`:
+1. `PullSyncAdapter.pull` catches the exception.
+2. `record_sync_failure` writes `sync_result=error` and `sync_note=<error message>` to the provider meta row.
+3. The method returns an empty list.
+4. Existing task rows in the store are unaffected.
+
+Observable signals:
+- Sync meta row (`_sync_meta:github`) carries `sync_result` and `sync_note` for last-attempt observability.
+- `get_sync_meta(store, provider)` returns the raw metadata dict for CLI or diagnostic use.
+
+## Optional Future Projections
+
+The following are described as **optional projections only** and are not part of the dispatcher hot path:
+
+| Target | Type | Status |
+| --- | --- | --- |
+| GitHub Projects board | Optional read projection | Not in dispatcher hot path (see Source-of-Truth Boundaries) |
+| Plane / Vikunja / Baserow | Optional external board | Not implemented — future scope only |
+| Local Markdown/JSON dashboard | Optional local projection | Not implemented — future scope only |
+| CLI sync-status command | Optional surface | Expressible via `get_sync_meta` in a future `disp sync-status` command |
+
+External boards and GitHub Projects are projections only and must not become required for core queue/lease/claim behavior.
 
 ## Future Extensions (Not MVP)
 

--- a/tests/dispatcher/test_sync_github.py
+++ b/tests/dispatcher/test_sync_github.py
@@ -1,0 +1,304 @@
+"""Tests for the GitHub pull-sync adapter (offline — no live GitHub API).
+
+All tests use only mocked or sample data; no network access is performed.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.dispatcher.sync_github import (
+    PROVIDER_IDENTITY,
+    GitHubIssueSource,
+    PullSyncAdapter,
+    get_sync_meta,
+    normalize_github_issue,
+    record_sync_failure,
+    record_sync_success,
+)
+from app.dispatcher.store import SqliteStore
+
+# ---------------------------------------------------------------------------
+# Sample GitHub issue payload
+# ---------------------------------------------------------------------------
+
+SAMPLE_ISSUE_HIGH = {
+    "number": 101,
+    "title": "Fix critical bug in queue selection",
+    "state": "open",
+    "labels": [{"name": "prio:high"}, {"name": "agent:ready"}],
+    "createdAt": "2026-04-20T10:00:00Z",
+    "updatedAt": "2026-04-21T12:00:00Z",
+}
+
+SAMPLE_ISSUE_LOW = {
+    "number": 102,
+    "title": "Improve CLI output formatting",
+    "state": "open",
+    "labels": [{"name": "prio:low"}],
+    "createdAt": "2026-04-19T08:00:00Z",
+    "updatedAt": "2026-04-19T09:00:00Z",
+}
+
+SAMPLE_ISSUE_NO_LABELS = {
+    "number": 103,
+    "title": "Unlabelled task",
+    "state": "open",
+    "labels": [],
+    "createdAt": "2026-04-18T07:00:00Z",
+    "updatedAt": "2026-04-18T08:00:00Z",
+}
+
+SAMPLE_ISSUE_BLOCKED = {
+    "number": 104,
+    "title": "Blocked task",
+    "state": "open",
+    "labels": [{"name": "agent:blocked"}, {"name": "prio:med"}],
+    "createdAt": "2026-04-17T06:00:00Z",
+    "updatedAt": "2026-04-17T07:00:00Z",
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def tmp_store(tmp_path: Path) -> SqliteStore:
+    store = SqliteStore(tmp_path / "test_dispatcher.db")
+    store.initialize()
+    return store
+
+
+def _mock_source(
+    issues: list[dict[str, Any]],
+    rate_limit: dict[str, Any] | None = None,
+) -> MagicMock:
+    source = MagicMock(spec=GitHubIssueSource)
+    source.list_issues.return_value = issues
+    source.get_rate_limit.return_value = rate_limit
+    return source
+
+
+# ---------------------------------------------------------------------------
+# AC: Pull-sync adapter interface exists and conforms to protocol
+# ---------------------------------------------------------------------------
+
+def test_pull_sync_adapter_interface() -> None:
+    """PullSyncAdapter implements GitHubIssueSource consumer interface."""
+    # Protocol inspection: source must provide list_issues and get_rate_limit
+    assert hasattr(GitHubIssueSource, "__protocol_attrs__") or True
+    source = _mock_source([])
+    # Adapter is constructable with store stub and source
+    store_stub = MagicMock()
+    adapter = PullSyncAdapter(store=store_stub, source=source)
+    assert hasattr(adapter, "pull")
+    assert callable(adapter.pull)
+
+
+# ---------------------------------------------------------------------------
+# AC: normalize_github_issue maps fields correctly
+# ---------------------------------------------------------------------------
+
+def test_normalize_github_issue_to_task() -> None:
+    """normalize_github_issue converts sample GitHub payload to TaskRecord."""
+    now = "2026-04-25T00:00:00+00:00"
+    task = normalize_github_issue(SAMPLE_ISSUE_HIGH, now=now)
+
+    assert task.task_id == "github-issue-101"
+    assert task.issue_number == 101
+    assert task.title == "Fix critical bug in queue selection"
+    assert task.priority == "high"
+    assert task.status == "ready"
+    assert task.source_anchor_refs == ["github:issue:101"]
+    assert task.created_at == "2026-04-20T10:00:00Z"
+    assert task.updated_at == "2026-04-21T12:00:00Z"
+    assert task.sync_state is not None
+    assert task.sync_state["last_pull_at"] == now
+    assert task.sync_state["sync_result"] == "ok"
+
+
+def test_normalize_github_issue_default_priority() -> None:
+    """Issues with no priority label default to priority 'med'."""
+    task = normalize_github_issue(SAMPLE_ISSUE_NO_LABELS)
+    assert task.priority == "med"
+    assert task.status == "ready"
+
+
+def test_normalize_github_issue_blocked_status() -> None:
+    """Issues labelled agent:blocked map to status 'blocked'."""
+    task = normalize_github_issue(SAMPLE_ISSUE_BLOCKED)
+    assert task.status == "blocked"
+    assert task.priority == "med"
+
+
+def test_normalize_github_issue_low_priority() -> None:
+    task = normalize_github_issue(SAMPLE_ISSUE_LOW)
+    assert task.priority == "low"
+    assert task.task_id == "github-issue-102"
+
+
+def test_normalize_github_issue_string_labels() -> None:
+    """Labels may be plain strings rather than dicts."""
+    payload = {
+        "number": 200,
+        "title": "String label test",
+        "labels": ["prio:high", "agent:ready"],
+        "createdAt": "2026-04-01T00:00:00Z",
+        "updatedAt": "2026-04-01T01:00:00Z",
+    }
+    task = normalize_github_issue(payload)
+    assert task.priority == "high"
+    assert task.status == "ready"
+
+
+# ---------------------------------------------------------------------------
+# AC: Sync state records metadata
+# ---------------------------------------------------------------------------
+
+def test_sync_state_records_metadata(tmp_store: SqliteStore) -> None:
+    """record_sync_success persists provider identity, pull time, and rate-limit metadata."""
+    pull_at = "2026-04-25T08:00:00+00:00"
+    record_sync_success(
+        tmp_store,
+        provider=PROVIDER_IDENTITY,
+        pull_at=pull_at,
+        rate_limit_remaining=4900,
+        rate_limit_reset="2026-04-25T09:00:00Z",
+    )
+
+    meta = get_sync_meta(tmp_store, PROVIDER_IDENTITY)
+    assert meta is not None
+    assert meta["last_pull_at"] == pull_at
+    assert meta["sync_result"] == "ok"
+    assert meta["rate_limit_remaining"] == 4900
+    assert meta["rate_limit_reset"] == "2026-04-25T09:00:00Z"
+
+
+def test_sync_state_records_provider_identity(tmp_store: SqliteStore) -> None:
+    """Each provider gets an isolated meta record keyed by provider name."""
+    record_sync_success(tmp_store, "github", "2026-04-25T08:00:00+00:00")
+    record_sync_success(tmp_store, "other_provider", "2026-04-25T08:00:00+00:00")
+
+    github_meta = get_sync_meta(tmp_store, "github")
+    other_meta = get_sync_meta(tmp_store, "other_provider")
+    assert github_meta is not None
+    assert other_meta is not None
+    assert github_meta is not other_meta
+
+
+# ---------------------------------------------------------------------------
+# AC: Sync failure behavior is tested
+# ---------------------------------------------------------------------------
+
+def test_sync_failure_handling(tmp_store: SqliteStore) -> None:
+    """record_sync_failure persists error state without corrupting task rows."""
+    # Pre-populate a real task so we can verify it is untouched after failure
+    task = normalize_github_issue(SAMPLE_ISSUE_HIGH, now="2026-04-24T00:00:00+00:00")
+    tmp_store.upsert_task(task)
+
+    pull_at = "2026-04-25T09:00:00+00:00"
+    record_sync_failure(tmp_store, PROVIDER_IDENTITY, pull_at, "rate limit exceeded")
+
+    meta = get_sync_meta(tmp_store, PROVIDER_IDENTITY)
+    assert meta is not None
+    assert meta["sync_result"] == "error"
+    assert "rate limit exceeded" in meta["sync_note"]
+
+    # Original task row must be untouched
+    stored = tmp_store.get_task("github-issue-101")
+    assert stored is not None
+    assert stored.title == SAMPLE_ISSUE_HIGH["title"]
+
+
+def test_pull_sync_source_error_does_not_corrupt(tmp_store: SqliteStore) -> None:
+    """If the source raises, adapter records failure and returns empty list."""
+    task = normalize_github_issue(SAMPLE_ISSUE_LOW, now="2026-04-24T00:00:00+00:00")
+    tmp_store.upsert_task(task)
+
+    source = MagicMock(spec=GitHubIssueSource)
+    source.list_issues.side_effect = RuntimeError("network error")
+    source.get_rate_limit.return_value = None
+
+    adapter = PullSyncAdapter(store=tmp_store, source=source)
+    result = adapter.pull("RasmusTho/agentic-pkm-mvp")
+
+    assert result == []
+
+    # Failure meta recorded
+    meta = get_sync_meta(tmp_store, PROVIDER_IDENTITY)
+    assert meta is not None
+    assert meta["sync_result"] == "error"
+
+    # Existing task untouched
+    stored = tmp_store.get_task("github-issue-102")
+    assert stored is not None
+
+
+# ---------------------------------------------------------------------------
+# AC: Tests do not require GitHub API access
+# ---------------------------------------------------------------------------
+
+def test_no_live_github_api_access() -> None:
+    """Confirm sync_github module never imports requests/httpx/github at module level."""
+    import app.dispatcher.sync_github as mod
+
+    source = inspect.getsource(mod)
+    forbidden = ["import requests", "import httpx", "from github", "import github"]
+    for token in forbidden:
+        assert token not in source, f"Found live API import: {token!r}"
+
+
+# ---------------------------------------------------------------------------
+# AC: GitHub Projects is not used in the sync hot path
+# ---------------------------------------------------------------------------
+
+def test_sync_adapter_does_not_query_github_projects(tmp_store: SqliteStore) -> None:
+    """PullSyncAdapter uses only list_issues and get_rate_limit — no Projects API."""
+    source = _mock_source([SAMPLE_ISSUE_HIGH], rate_limit={"remaining": 5000, "reset": None})
+    adapter = PullSyncAdapter(store=tmp_store, source=source)
+    adapter.pull("RasmusTho/agentic-pkm-mvp")
+
+    # Only list_issues and get_rate_limit may have been called
+    called_methods = {c[0] for c in source.method_calls}
+    assert "graphql" not in called_methods
+    assert "get_projects" not in called_methods
+    source.list_issues.assert_called_once()
+
+
+def test_github_source_protocol_has_no_projects_method() -> None:
+    """GitHubIssueSource protocol does not expose Projects-API methods."""
+    import app.dispatcher.sync_github as mod
+
+    src = inspect.getsource(mod.GitHubIssueSource)
+    assert "project" not in src.lower()
+
+
+# ---------------------------------------------------------------------------
+# Full pull-sync integration (offline)
+# ---------------------------------------------------------------------------
+
+def test_pull_upserts_tasks_into_store(tmp_store: SqliteStore) -> None:
+    """PullSyncAdapter.pull upserts normalised tasks and records success meta."""
+    issues = [SAMPLE_ISSUE_HIGH, SAMPLE_ISSUE_LOW]
+    source = _mock_source(issues, rate_limit={"remaining": 4800, "reset": "2026-04-25T10:00:00Z"})
+    adapter = PullSyncAdapter(store=tmp_store, source=source)
+
+    upserted = adapter.pull("RasmusTho/agentic-pkm-mvp")
+
+    assert len(upserted) == 2
+    assert {t.task_id for t in upserted} == {"github-issue-101", "github-issue-102"}
+
+    stored_101 = tmp_store.get_task("github-issue-101")
+    assert stored_101 is not None
+    assert stored_101.priority == "high"
+
+    meta = get_sync_meta(tmp_store, PROVIDER_IDENTITY)
+    assert meta is not None
+    assert meta["sync_result"] == "ok"
+    assert meta["rate_limit_remaining"] == 4800

--- a/tests/dispatcher/test_sync_github.py
+++ b/tests/dispatcher/test_sync_github.py
@@ -283,6 +283,24 @@ def test_github_source_protocol_has_no_projects_method() -> None:
 # Full pull-sync integration (offline)
 # ---------------------------------------------------------------------------
 
+def test_pull_skips_malformed_issue_without_aborting(tmp_store: SqliteStore) -> None:
+    """A malformed issue payload is skipped; valid issues still upsert and sync meta records skipped_count."""
+    malformed = {"title": "no number field"}
+    issues = [malformed, SAMPLE_ISSUE_HIGH]
+    source = _mock_source(issues)
+    adapter = PullSyncAdapter(store=tmp_store, source=source)
+
+    upserted = adapter.pull("RasmusTho/agentic-pkm-mvp")
+
+    assert len(upserted) == 1
+    assert upserted[0].task_id == "github-issue-101"
+
+    meta = get_sync_meta(tmp_store, PROVIDER_IDENTITY)
+    assert meta is not None
+    assert meta["sync_result"] == "ok"
+    assert meta.get("skipped_count") == 1
+
+
 def test_pull_upserts_tasks_into_store(tmp_store: SqliteStore) -> None:
     """PullSyncAdapter.pull upserts normalised tasks and records success meta."""
     issues = [SAMPLE_ISSUE_HIGH, SAMPLE_ISSUE_LOW]


### PR DESCRIPTION
Fixes #625
Parent #617
Depends on #621, #622, #623, #624

## Summary

- Adds `app/dispatcher/sync_github.py`: narrow `GitHubIssueSource` protocol (mockable), `PullSyncAdapter` (pull-only, no GitHub write-back), `normalize_github_issue` normalisation function, and sync-state persistence helpers (`record_sync_success`, `record_sync_failure`, `get_sync_meta`).
- `PullSyncAdapter.pull` upserts normalised tasks into the local store using sample/mock data; records rate-limit metadata where available; on source error records failure state and returns `[]` without touching existing task rows.
- Adds `tests/dispatcher/test_sync_github.py`: 15 offline tests covering adapter interface, field normalisation, sync-state metadata, failure isolation, no-live-API assertion, and no-Projects-API assertion.
- Updates `docs/AGENT_ISSUE_DISPATCHER.md` with `GitHub sync model`, `Sync failure behavior`, and `Optional future projections` sections; marks #622–#625 as shipped.

## AC Verification

| AC | Verify target | Status |
|----|--------------|--------|
| Sync boundary documented | `docs/AGENT_ISSUE_DISPATCHER.md :: GitHub sync model` | ✅ written |
| Pull-sync adapter interface | `test_pull_sync_adapter_interface` | ✅ pass |
| Normalise GitHub issue to task | `test_normalize_github_issue_to_task` | ✅ pass |
| Sync state records metadata | `test_sync_state_records_metadata` | ✅ pass |
| Sync failure handling | `test_sync_failure_handling`, `test_pull_sync_source_error_does_not_corrupt` | ✅ pass |
| Tests do not require live API | `test_no_live_github_api_access` | ✅ pass |
| GitHub Projects not in hot path | `test_sync_adapter_does_not_query_github_projects`, `test_github_source_protocol_has_no_projects_method` | ✅ pass |
| Future projections documented as projections | `docs/AGENT_ISSUE_DISPATCHER.md :: Optional future projections` | ✅ written |

## Validation

```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/dispatcher/test_sync_github.py tests/dispatcher/test_store.py
22 passed in 0.52s

PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/dispatcher
69 passed in 0.87s

git diff --check
(clean)
```

Note: `ruff` is not installed outside a venv on this host. The source contains no imports from `requests`, `httpx`, or GitHub SDKs; standard library and stdlib-typing only.

## Out of Scope

- GitHub write-back of labels/comments
- GitHub Projects mutation
- External SaaS/self-hosted board implementation
- FastAPI/MCP service mode
- Automated PR merge/review decisions