### PR TITLE
docs: add DISPATCHER_AGENT_ADOPTION specification directory

### DIFF
--- a/docs/DISPATCHER_AGENT_ADOPTION/AGENT_WORKFLOW_INTEGRATION.md
+++ b/docs/DISPATCHER_AGENT_ADOPTION/AGENT_WORKFLOW_INTEGRATION.md
@@ -1,0 +1,94 @@
+---
+name: Agent Workflow Integration
+description: Wire dispatcher claim/heartbeat/complete into issue-to-code skill execution and verify adoption
+task_id: DISPATCHER-ADOPTION-04
+source_anchor: docs/DISPATCHER_AGENT_ADOPTION/AGENT_WORKFLOW_INTEGRATION.md
+parent_capability: Dispatcher Agent Adoption
+prerequisites: [DISPATCHER-ADOPTION-01, DISPATCHER-ADOPTION-02, DISPATCHER-ADOPTION-03]
+depends_on: [BOOTSTRAP_AND_SYNC_WIRING.md, COMPLETE_COMMAND.md, FALLBACK_POLICY.md]
+can_parallelize_with: []
+---
+
+# Agent Workflow Integration
+
+## Purpose
+
+After the policy is written (FALLBACK_POLICY task) and the commands exist (BOOTSTRAP_AND_SYNC_WIRING + COMPLETE_COMMAND tasks), this task verifies that agents following `issue-to-code` actually call the dispatcher in practice. It also adds an architecture test that enforces the dispatcher step order so the skill cannot silently drift back to label-only pickup.
+
+This is the final adoption gate. It is explicitly evidence-based: "agents are using the dispatcher" cannot be proven by a unit test, so the acceptance path requires observed delivery receipts.
+
+## What This Task Does
+
+1. Adds `tests/architecture/test_dispatcher_skill_integration.py` — a lightweight static check that `issue-to-code/SKILL.md` references the required dispatcher steps (`dispatcher status`, `dispatcher next`, `dispatcher claim`, `dispatcher heartbeat`, `dispatcher complete`) in the correct order.
+2. Adds `tests/dispatcher/test_agent_loop.py` — an integration test that exercises the full agent loop (status check → next → claim → heartbeat → complete) against a temporary in-process dispatcher store, asserting event audit trail is correct.
+3. Records adoption evidence: after the first three issue-to-code deliveries post-merge, operator logs a short receipt on the parent feature issue confirming dispatcher was called (or fallback was used and why).
+
+No changes to `AGENTS.md` or `issue-to-code/SKILL.md` beyond what FALLBACK_POLICY already wrote — this task only adds the test layer and adoption evidence.
+
+## Concretely
+
+```sh
+# architecture test — verifies skill doc has correct dispatcher steps
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/architecture/test_dispatcher_skill_integration.py -v
+# => test_skill_references_dispatcher_status PASSED
+# => test_skill_references_dispatcher_next PASSED
+# => test_skill_references_dispatcher_claim PASSED
+# => test_skill_references_dispatcher_heartbeat PASSED
+# => test_skill_references_dispatcher_complete PASSED
+# => test_skill_dispatcher_steps_in_order PASSED
+
+# integration test — full agent loop against temp store
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/dispatcher/test_agent_loop.py -v
+# => test_full_agent_loop_status_next_claim_heartbeat_complete PASSED
+# => test_full_agent_loop_fallback_event_trail PASSED
+```
+
+Adoption receipt format (posted on parent feature issue after each delivery):
+
+```
+Dispatcher adoption receipt — delivery N
+- Issue: #<number>
+- Agent: <worktree/agent-id>
+- Dispatcher used: yes / no (fallback: <reason>)
+- Dispatcher events: task.claimed, task.heartbeat (N times), task.completed
+- Notes: <any anomaly>
+```
+
+## Why This Matters
+
+Without a static architecture test, the skill doc can drift. A developer updating the skill removes the dispatcher subsection and no test catches it. The integration test gives confidence the full loop works end-to-end in isolation. The adoption receipts give confidence agents are actually hitting the dispatcher, not just passing tests.
+
+## Acceptance Criteria
+
+- [ ] `tests/architecture/test_dispatcher_skill_integration.py` exists and asserts all five dispatcher step references present in `issue-to-code/SKILL.md` in correct order.
+  Verify: `tests/architecture/test_dispatcher_skill_integration.py::test_skill_dispatcher_steps_in_order`
+- [ ] `tests/dispatcher/test_agent_loop.py` exercises the full claim → heartbeat → complete loop against a temp store and asserts the event audit trail contains `task.claimed`, `task.heartbeat`, `task.completed` in order.
+  Verify: `tests/dispatcher/test_agent_loop.py::test_full_agent_loop_status_next_claim_heartbeat_complete`
+- [ ] All dispatcher tests pass.
+  Verify: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/dispatcher/ tests/architecture/test_dispatcher_skill_integration.py`
+- [ ] Three adoption receipts posted on the parent feature issue (operator closes adoption gate).
+  Verify: adoption evidence on parent feature issue body or comments
+
+## How to Verify (Pre-Merge)
+
+```sh
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/dispatcher/ tests/architecture/test_dispatcher_skill_integration.py
+ruff check tests/dispatcher/test_agent_loop.py tests/architecture/test_dispatcher_skill_integration.py
+mypy tests/dispatcher/test_agent_loop.py
+```
+
+## Out of Scope
+
+- Changing the pickup policy to dispatcher-only (removing GitHub fallback) — adoption shadow mode is the MVP target.
+- Adding dispatcher metrics or dashboards.
+- Multi-worktree concurrency testing.
+
+## Related Docs
+
+- `docs/AGENT_ISSUE_DISPATCHER.md :: Agent Interaction Contract` — the loop this task tests
+- `.codex/skills/issue-to-code/SKILL.md :: dispatcher-integration` — written by FALLBACK_POLICY task
+- `tests/architecture/` — existing architecture-enforcement test directory
+
+## Related GitHub Issues
+
+One issue. Adds two test files. Adoption evidence is recorded by operator post-merge on the parent feature issue, not by the agent in this PR.

--- a/docs/DISPATCHER_AGENT_ADOPTION/BOOTSTRAP_AND_SYNC_WIRING.md
+++ b/docs/DISPATCHER_AGENT_ADOPTION/BOOTSTRAP_AND_SYNC_WIRING.md
@@ -1,0 +1,98 @@
+---
+name: Bootstrap and Sync Wiring
+description: Add make dispatcher-init, make dispatcher-sync, a dispatcher pull CLI command, and a missing-DB guard
+task_id: DISPATCHER-ADOPTION-01
+source_anchor: docs/DISPATCHER_AGENT_ADOPTION/BOOTSTRAP_AND_SYNC_WIRING.md
+parent_capability: Dispatcher Agent Adoption
+prerequisites: []
+depends_on: []
+can_parallelize_with: [COMPLETE_COMMAND.md]
+---
+
+# Bootstrap and Sync Wiring
+
+## Purpose
+
+Agents cannot use the dispatcher without a live, populated SQLite DB. Currently nothing initialises or populates the DB as part of normal repo setup. This task wires a `dispatcher pull` CLI command and two `make` targets so a fresh checkout can have a working queue in one command, and so that re-syncing stale queue state is equally simple.
+
+It also adds a guard so that calling any dispatcher command on a missing or uninitialised DB produces a clear error rather than silently creating an empty queue.
+
+## What This Task Does
+
+1. Adds `python -m app.dispatcher pull --repo <owner/repo>` command to `cli.py` — calls `PullSyncAdapter.pull()` against open `agent:ready` issues using the `gh` CLI as the GitHub source, prints a compact sync receipt.
+2. Adds `make dispatcher-init` — runs `python -m app.dispatcher init` then `python -m app.dispatcher pull --repo <owner/repo>`.
+3. Adds `make dispatcher-sync` — runs `python -m app.dispatcher pull --repo <owner/repo>` only (no re-init).
+4. Adds a not-initialised guard: if `dispatcher status --json` shows `db_exists: false`, commands that require a live DB (`next`, `claim`, `queue`, `pull`) exit non-zero with `{"ok": false, "error": "dispatcher not initialised — run: make dispatcher-init"}`.
+
+The `gh`-backed `GitHubIssueSource` implementation lives in `app/dispatcher/sync_github.py` (or a thin wrapper); existing tests must not require `gh` access (offline protocol-based tests stay intact).
+
+## Concretely
+
+```sh
+# initialise and populate queue from GitHub on a fresh checkout
+make dispatcher-init
+# => {"ok": true, "state_dir": "runtime/dispatcher", "db_path": "...", ...}
+# => {"ok": true, "upserted": 7, "skipped": 0, "provider": "github"}
+
+# re-sync stale queue without reinitialising
+make dispatcher-sync
+# => {"ok": true, "upserted": 9, "skipped": 0, ...}
+
+# guard on missing DB
+python -m app.dispatcher next --json
+# => {"ok": false, "error": "dispatcher not initialised — run: make dispatcher-init"}
+# exit code 1
+
+# direct pull command
+python -m app.dispatcher pull --repo rasmusthornberg/agentic-pkm-mvp --json
+# => {"ok": true, "upserted": 9, "skipped": 0, ...}
+```
+
+## Why This Matters
+
+Without this, every agent in a fresh worktree starts with an empty dispatcher queue. The `next` command returns `{"empty": true}` and the agent falls through to GitHub label scanning — defeating the entire dispatcher. This task is the prerequisite for every other adoption task.
+
+## Acceptance Criteria
+
+- [ ] `python -m app.dispatcher pull --repo <repo> --json` upserts open `agent:ready` issues and prints a sync receipt.
+  Verify: `tests/dispatcher/test_cli.py::test_pull_command_upserts_issues`
+- [ ] `make dispatcher-init` runs `init` then `pull` and exits 0 on a clean state dir.
+  Verify: `tests/dispatcher/test_bootstrap.py::test_make_dispatcher_init`
+- [ ] `make dispatcher-sync` runs `pull` only (does not reinitialise schema) and exits 0.
+  Verify: `tests/dispatcher/test_bootstrap.py::test_make_dispatcher_sync`
+- [ ] `dispatcher next --json` on a missing DB exits 1 with `{"ok": false, "error": "..."}`.
+  Verify: `tests/dispatcher/test_cli.py::test_guard_missing_db`
+- [ ] `gh`-backed `GitHubIssueSource` implementation exists; offline unit tests remain green.
+  Verify: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/dispatcher/`
+
+## How to Verify (Pre-Merge)
+
+```sh
+# all dispatcher tests green
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/dispatcher/
+
+# lint and types
+ruff check app/dispatcher tests/dispatcher
+mypy app/dispatcher
+
+# manual smoke (requires gh auth)
+make dispatcher-init
+python -m app.dispatcher queue --json
+python -m app.dispatcher next --json
+```
+
+## Out of Scope
+
+- Scheduling sync on a cron/timer — manual `make dispatcher-sync` is sufficient for MVP adoption.
+- Push/write-back to GitHub — pull-only per the contract.
+- Multi-worktree shared DB coordination — single worktree use is the MVP target.
+
+## Related Docs
+
+- `docs/AGENT_ISSUE_DISPATCHER.md` — contract and non-goals
+- `app/dispatcher/sync_github.py` — PullSyncAdapter and GitHubIssueSource protocol
+- `app/dispatcher/cli.py` — existing CLI; `pull` command to be added here
+
+## Related GitHub Issues
+
+One issue. Implement `pull` command in `cli.py`, add `gh`-backed source, add `make` targets, add guard, add tests. All in one PR.

--- a/docs/DISPATCHER_AGENT_ADOPTION/COMPLETE_COMMAND.md
+++ b/docs/DISPATCHER_AGENT_ADOPTION/COMPLETE_COMMAND.md
@@ -1,0 +1,76 @@
+---
+name: Complete Command
+description: Add dispatcher complete as a clean terminal signal for agents finishing a task
+task_id: DISPATCHER-ADOPTION-02
+source_anchor: docs/DISPATCHER_AGENT_ADOPTION/COMPLETE_COMMAND.md
+parent_capability: Dispatcher Agent Adoption
+prerequisites: []
+depends_on: []
+can_parallelize_with: [BOOTSTRAP_AND_SYNC_WIRING.md]
+---
+
+# Complete Command
+
+## Purpose
+
+The dispatcher CLI has `release` and `update --status completed` but no single `complete` command. Agents need one unambiguous terminal call to close out a task after a PR merges. Without it, the closure step in `issue-to-code` would require two commands and would be easy to skip or miscall.
+
+## What This Task Does
+
+1. Adds `python -m app.dispatcher complete <task_id> --agent <id>` to `cli.py`.
+2. `complete` must: verify the task exists and is held by `agent_id`; release the lease (set `released_at`, `release_reason=completed`); set task `status=completed`; emit `task.completed` event.
+3. `complete` is terminal — a completed task is not re-queued by `next`.
+4. Adds `queue.complete()` function in `queue.py` (parallel to `block`/`release` in `leases.py`).
+
+## Concretely
+
+```sh
+python -m app.dispatcher complete github-issue-614 --agent claude-worktree-abc --json
+# => {"ok": true, "task": {"task_id": "github-issue-614", "status": "completed", ...}}
+
+# completed task does not appear in next
+python -m app.dispatcher next --json
+# => {"ok": true, "task": <next uncompleted task or null>}
+
+# completed task appears in queue summary under by_status.completed
+python -m app.dispatcher queue --json
+# => {"ok": true, "total": N, "by_status": {"completed": 1, "ready": M, ...}, ...}
+```
+
+## Why This Matters
+
+Agents closing out a task need one unambiguous command. `update --status completed` leaves the lease in place. `release` sets status back to `ready`. Neither is the correct terminal signal. Without `complete`, every agent closure either leaves a dangling lease or re-queues a finished task.
+
+## Acceptance Criteria
+
+- [ ] `dispatcher complete <task_id> --agent <id>` sets status to `completed`, releases the lease, and emits `task.completed`.
+  Verify: `tests/dispatcher/test_cli.py::test_complete_command`
+- [ ] Completing a task by a non-holder agent exits 1 with `{"ok": false, "error": "..."}`.
+  Verify: `tests/dispatcher/test_cli.py::test_complete_wrong_holder`
+- [ ] `dispatcher next` does not return a completed task.
+  Verify: `tests/dispatcher/test_cli.py::test_next_skips_completed`
+- [ ] `task.completed` event appears in `dispatcher events --json`.
+  Verify: `tests/dispatcher/test_cli.py::test_complete_event_emitted`
+
+## How to Verify (Pre-Merge)
+
+```sh
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/dispatcher/
+ruff check app/dispatcher tests/dispatcher
+mypy app/dispatcher
+```
+
+## Out of Scope
+
+- Reopening or uncompleting tasks — not in MVP scope.
+- Cascade actions on completion (e.g. auto-projecting GitHub Project status) — projection is optional and not in the hot path.
+
+## Related Docs
+
+- `docs/AGENT_ISSUE_DISPATCHER.md :: Status Model` — `completed` is listed as a terminal status
+- `app/dispatcher/queue.py` — `block` is the closest analogue; `complete` follows the same pattern
+- `app/dispatcher/cli.py` — `complete` subcommand added here
+
+## Related GitHub Issues
+
+One issue. Add `queue.complete()`, add `complete` subcommand in `cli.py`, add tests. One PR.

--- a/docs/DISPATCHER_AGENT_ADOPTION/FALLBACK_POLICY.md
+++ b/docs/DISPATCHER_AGENT_ADOPTION/FALLBACK_POLICY.md
@@ -1,0 +1,104 @@
+---
+name: Fallback Policy
+description: Document dispatcher fallback contract in AGENTS.md and issue-to-code skill
+task_id: DISPATCHER-ADOPTION-03
+source_anchor: docs/DISPATCHER_AGENT_ADOPTION/FALLBACK_POLICY.md
+parent_capability: Dispatcher Agent Adoption
+prerequisites: [DISPATCHER-ADOPTION-01]
+depends_on: [BOOTSTRAP_AND_SYNC_WIRING.md]
+can_parallelize_with: []
+---
+
+# Fallback Policy
+
+## Purpose
+
+Agents need to know what to do when the dispatcher is unavailable. The dispatcher is a local SQLite file — it can be absent (fresh worktree, deleted state dir, wrong `DISPATCHER_STATE_DIR`), corrupted, or stale. Without a documented fallback, agents either block on a broken tool or skip coordination silently.
+
+This task writes the dispatcher policy and fallback contract into the two authoritative agent instruction surfaces: `AGENTS.md` and `issue-to-code/SKILL.md`.
+
+## What This Task Does
+
+1. Adds a `## Dispatcher policy` section to `AGENTS.md` (under GitHub delivery governance) covering:
+   - where the DB lives (`runtime/dispatcher/`), configurable via `DISPATCHER_STATE_DIR`
+   - expected agent loop: `status` check → `next` → `claim` → work → `heartbeat` (every ~30 min) → `complete` or `release`
+   - TTL: 90 minutes default; agents must heartbeat before expiry
+   - fallback rule: if `dispatcher status --json` returns `db_exists: false` or exits non-zero, skip dispatcher and fall back to GitHub-label-only claim (remove `agent:ready`)
+   - log the fallback in the PR body with reason
+2. Adds a `### Dispatcher integration` subsection to `issue-to-code/SKILL.md` under the "Begin Implementation Work" action, covering:
+   - pre-claim: `python -m app.dispatcher status --json` — check `db_exists`
+   - if available: `dispatcher next --json` to get candidate, then `dispatcher claim <task_id> --agent <agent_id>`; GitHub label removal is the confirmation step, not the primary claim
+   - if unavailable: fall back to `gh issue edit --remove-label agent:ready` (current behaviour unchanged)
+   - mid-work: `dispatcher heartbeat <task_id> --agent <agent_id>` approximately every 30 minutes of active execution
+   - on closure: `dispatcher complete <task_id> --agent <agent_id>` (or `dispatcher release` if work is abandoned)
+   - if any dispatcher command fails during work (non-zero exit): log it, continue with GitHub-only state, do not retry in a loop
+
+No new code in this task — docs-only. Uses the governance lane because it changes agent workflow instruction surfaces.
+
+## Concretely
+
+After this task, an agent running `issue-to-code` does:
+
+```sh
+# 1. pre-claim check
+python -m app.dispatcher status --json
+# => {"ok": true, "db_exists": true} → proceed with dispatcher
+# => {"ok": false} or db_exists: false → fall back to gh label only
+
+# 2. dispatcher-first claim
+python -m app.dispatcher next --json          # get candidate task
+python -m app.dispatcher claim github-issue-614 --agent claude-worktree-abc --json
+gh issue edit 614 --remove-label agent:ready  # confirmation
+
+# 3. mid-work heartbeat (~every 30 min)
+python -m app.dispatcher heartbeat github-issue-614 --agent claude-worktree-abc --json
+
+# 4. closure
+python -m app.dispatcher complete github-issue-614 --agent claude-worktree-abc --json
+```
+
+Fallback (dispatcher unavailable):
+```sh
+gh issue edit 614 --remove-label agent:ready  # unchanged current behaviour
+# log in PR body: "Dispatcher unavailable (db_exists: false) — used GitHub-label-only claim"
+```
+
+## Why This Matters
+
+Without explicit fallback policy, agents either hard-fail on a missing DB (blocking work) or call both claim paths inconsistently (leaving ghost leases or dangling labels). Explicit fallback preserves single-agent delivery unblocked while multi-agent lease coordination remains the happy path.
+
+## Acceptance Criteria
+
+- [ ] `AGENTS.md` contains a `## Dispatcher policy` section under GitHub delivery governance with: DB location, agent loop, TTL/heartbeat cadence, fallback rule, and PR-body log instruction.
+  Verify: doc writeback at `AGENTS.md :: dispatcher-policy`
+- [ ] `issue-to-code/SKILL.md` contains a `### Dispatcher integration` subsection in the "Begin Implementation Work" action with: status check, dispatcher-first claim, fallback path, heartbeat cadence, and closure call.
+  Verify: doc writeback at `.codex/skills/issue-to-code/SKILL.md :: dispatcher-integration`
+- [ ] Both doc sections are internally consistent: same TTL (90 min), same heartbeat cadence (~30 min), same fallback trigger (`db_exists: false` or non-zero exit).
+  Verify: human review — cross-read both sections for consistency before merge
+
+## How to Verify (Pre-Merge)
+
+```sh
+# docs lint if available
+python scripts/docs_guard.py 2>/dev/null || echo "no docs guard"
+
+# spot-check consistency
+grep -A 30 "dispatcher-policy" AGENTS.md
+grep -A 40 "dispatcher-integration" .codex/skills/issue-to-code/SKILL.md
+```
+
+## Out of Scope
+
+- Changing the GitHub-label fallback implementation — it already exists and works.
+- Adding enforcement/automation for the dispatcher call — adoption evidence is sufficient for MVP.
+- Documenting future dispatcher modes (service, MCP) — not in scope.
+
+## Related Docs
+
+- `AGENTS.md` — builder-agent canonical instruction file
+- `.codex/skills/issue-to-code/SKILL.md` — implementation pickup skill
+- `docs/AGENT_ISSUE_DISPATCHER.md :: Agent Interaction Contract` — canonical loop definition
+
+## Related GitHub Issues
+
+One issue. Governance lane (no code changes). Docs-only edits to `AGENTS.md` and `issue-to-code/SKILL.md`. One PR.

--- a/docs/DISPATCHER_AGENT_ADOPTION/README.md
+++ b/docs/DISPATCHER_AGENT_ADOPTION/README.md
@@ -1,0 +1,74 @@
+---
+name: Dispatcher Agent Adoption
+description: Specification for wiring the local Agent Issue Dispatcher into agent pickup workflow
+doc_role: Specification directory
+authority: Canonical specification for dispatcher adoption — wiring, fallback policy, and agent workflow integration
+temporal_class: operational
+review_cadence: event-driven
+source_of_truth: mixed (code + AGENTS.md + issue-to-code skill)
+last_reviewed: 2026-04-25
+last_verified_against: docs/AGENT_ISSUE_DISPATCHER.md, app/dispatcher/cli.py, AGENTS.md, .codex/skills/issue-to-code/SKILL.md
+---
+
+# Dispatcher Agent Adoption — Specification
+
+## Purpose
+
+The local Agent Issue Dispatcher MVP is complete (all child issues #621–#625 merged). The dispatcher CLI exists and all primitives (init, queue, next, claim, heartbeat, release, block, events, pull-sync) are implemented. This specification defines the remaining work to make agents actually use it.
+
+The gap: no agent workflow (AGENTS.md, issue-to-code skill) calls the dispatcher. Agents still coordinate via GitHub label mutation alone, which gives no lease coordination, no heartbeat tracking, and no queue ordering.
+
+## Capability boundary
+
+Agents use the dispatcher as the hot-path claim primitive for picking up and executing GitHub Issues. GitHub Issues remain the durable source of truth. The dispatcher owns local operational coordination state: queue ordering, lease exclusivity, heartbeat liveness, and event audit trail. If the dispatcher is unavailable, agents fall back to GitHub-label-only claim.
+
+## Implementation tasks
+
+In dependency order:
+
+1. [BOOTSTRAP_AND_SYNC_WIRING](BOOTSTRAP_AND_SYNC_WIRING.md) — `make dispatcher-init`, `make dispatcher-sync`, and a CLI guard when DB is missing; adds `dispatcher pull` command
+2. [COMPLETE_COMMAND](COMPLETE_COMMAND.md) — adds `dispatcher complete` as a clean terminal signal for agents
+3. [FALLBACK_POLICY](FALLBACK_POLICY.md) — documents the fallback contract in AGENTS.md and the issue-to-code skill
+4. [AGENT_WORKFLOW_INTEGRATION](AGENT_WORKFLOW_INTEGRATION.md) — wires claim/heartbeat/complete into issue-to-code skill (shadow mode first, then dispatcher-first)
+
+Tasks 1–2 can proceed in parallel. Task 3 can proceed after task 1 (needs the status command to be reliable). Task 4 depends on 1–3.
+
+## Execution order
+
+```
+BOOTSTRAP_AND_SYNC_WIRING  ─┐
+COMPLETE_COMMAND            ─┤─→ FALLBACK_POLICY ─→ AGENT_WORKFLOW_INTEGRATION
+```
+
+## Acceptance criteria
+
+- [ ] `make dispatcher-init` initialises the DB and runs a pull-sync against open `agent:ready` issues.
+  Verify: `tests/dispatcher/test_bootstrap.py::test_make_dispatcher_init`
+- [ ] `make dispatcher-sync` re-syncs the queue without reinitialising.
+  Verify: `tests/dispatcher/test_bootstrap.py::test_make_dispatcher_sync`
+- [ ] `python -m app.dispatcher status --json` returns `db_exists: true` or a clear error if not initialised.
+  Verify: `tests/dispatcher/test_cli.py::test_status_not_initialized`
+- [ ] `python -m app.dispatcher complete <task_id> --agent <id>` marks the task completed and emits `task.completed`.
+  Verify: `tests/dispatcher/test_cli.py::test_complete_command`
+- [ ] `AGENTS.md` contains a Dispatcher policy section describing the agent loop, TTL, heartbeat cadence, and fallback rule.
+  Verify: doc writeback at `AGENTS.md :: dispatcher-policy`
+- [ ] `issue-to-code/SKILL.md` includes dispatcher claim/heartbeat/complete steps with explicit fallback path.
+  Verify: doc writeback at `.codex/skills/issue-to-code/SKILL.md :: dispatcher-integration`
+- [ ] An agent running issue-to-code calls `dispatcher claim` before starting work when the dispatcher is available.
+  Verify: adoption evidence in next 3 deliveries after merge (recorded on parent issue)
+
+## Validation / acceptance path
+
+Acceptance requires:
+1. All four tasks merged with their per-task acceptance criteria green.
+2. Three consecutive issue-to-code deliveries where the dispatcher claim/heartbeat/complete loop is called (adoption evidence logged on the parent feature issue).
+3. Owner doc (`docs/AGENT_ISSUE_DISPATCHER.md`) updated to reflect dispatcher as active, not "contract approved for planning."
+
+## Source anchors
+
+- `docs/AGENT_ISSUE_DISPATCHER.md` — dispatcher MVP contract
+- `app/dispatcher/cli.py` — CLI implementation
+- `app/dispatcher/sync_github.py` — pull-sync adapter
+- `AGENTS.md :: GitHub delivery governance`
+- `.codex/skills/issue-to-code/SKILL.md`
+- Parent feature issue: #617 (closed — dispatcher MVP complete; this workstream is post-MVP adoption)


### PR DESCRIPTION
## Change Lane
- [ ] Implementation lane
- [ ] Docs authoring lane
- [x] Governance lane

## Linked Issue

Leave blank for governance lane — this PR stays within approved governance surfaces.

## Summary

- Adds `docs/DISPATCHER_AGENT_ADOPTION/` specification directory with README and four bounded task specs
- Creates GitHub issues #637–#640 from those specs, with parent feature issue #636
- Sets Project board status: Ready for #637–639, Backlog for #636 and #640

## Governance Lane Check
- [x] This PR only changes approved governance surfaces.
- [x] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [x] No product/runtime implementation or shipped feature behavior changed.

## Validation

Governance lane:
- [x] Docs/governance checks run as appropriate for the touched surfaces
- All changed files are under `docs/` — within approved governance surfaces

## Notes

Four child issues ready for agent pickup in parallel (#637, #638, #639). Issue #640 blocked on #637–639.