### PR TITLE
feat(dispatcher): add complete command for terminal task signal

### DIFF
--- a/app/dispatcher/cli.py
+++ b/app/dispatcher/cli.py
@@ -23,7 +23,7 @@ from app.dispatcher.store import SqliteStore
 
 REQUIRED_COMMANDS = frozenset([
     "init", "queue", "next", "show", "claim",
-    "heartbeat", "release", "update", "block", "events",
+    "heartbeat", "release", "update", "block", "complete", "events",
 ])
 
 
@@ -195,6 +195,19 @@ def _cmd_block(args: argparse.Namespace, store: SqliteStore) -> int:
         return _emit_error(str(exc), args.json)
 
 
+def _cmd_complete(args: argparse.Namespace, store: SqliteStore) -> int:
+    try:
+        task = queue_module.complete(
+            store,
+            task_id=args.task_id,
+            actor=args.agent,
+        )
+        _emit({"ok": True, "task": _compact_task(task)}, args.json)
+        return 0
+    except ValueError as exc:
+        return _emit_error(str(exc), args.json)
+
+
 def _cmd_events(args: argparse.Namespace, store: SqliteStore) -> int:
     events = store.list_events()
     tail = args.tail
@@ -255,6 +268,7 @@ _COMMAND_MAP = {
     "release": _cmd_release,
     "update": _cmd_update,
     "block": _cmd_block,
+    "complete": _cmd_complete,
     "events": _cmd_events,
     "seed-demo": _cmd_seed_demo,
     "link-pr": _cmd_link_pr,
@@ -311,6 +325,11 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("task_id")
     p.add_argument("--reason", required=True)
     p.add_argument("--agent", default="cli")
+    p.add_argument("--json", action="store_true")
+
+    p = sub.add_parser("complete", help="Complete a task (terminal)")
+    p.add_argument("task_id")
+    p.add_argument("--agent", required=True)
     p.add_argument("--json", action="store_true")
 
     p = sub.add_parser("events", help="Show recent events")

--- a/app/dispatcher/queue.py
+++ b/app/dispatcher/queue.py
@@ -117,6 +117,57 @@ def unblock(
     return task
 
 
+def complete(
+    store: SqliteStore,
+    task_id: str,
+    actor: str,
+) -> TaskRecord:
+    """Mark a task as completed, releasing its lease.
+
+    Only the current lease holder can complete the task.
+    Emits a task.completed event.
+    """
+    task = store.get_task(task_id)
+    if task is None:
+        raise ValueError(f"Task {task_id} not found")
+
+    if task.lease_id is None:
+        raise ValueError(f"Task {task_id} has no active lease")
+
+    lease = store.get_lease(task.lease_id)
+    if lease is None:
+        raise ValueError(f"Lease {task.lease_id} not found")
+
+    if lease.holder != actor:
+        raise ValueError(
+            f"Cannot complete task {task_id}: held by {lease.holder}, not {actor}"
+        )
+
+    now = _utc_now()
+    lease.released_at = now
+    lease.release_reason = "completed"
+    store.upsert_lease(lease)
+
+    task.status = "completed"
+    task.lease_id = None
+    task.claimed_by = None
+    task.last_heartbeat_at = None
+    task.updated_at = now
+    store.upsert_task(task)
+
+    event = EventRecord(
+        event_id=_make_event_id(),
+        timestamp=now,
+        task_id=task_id,
+        event_type="task.completed",
+        actor=actor,
+        lease_id=lease.lease_id,
+    )
+    store.append_event(event)
+
+    return task
+
+
 def _row_to_task(row: sqlite3.Row) -> TaskRecord:
     """Convert a sqlite3.Row to a TaskRecord."""
     import json

--- a/tests/dispatcher/test_cli.py
+++ b/tests/dispatcher/test_cli.py
@@ -326,3 +326,83 @@ def test_status_command(tmp_env):
     assert code == 0
     assert data["ok"] is True
     assert "db_path" in data
+
+
+# ---------------------------------------------------------------------------
+# AC: dispatcher complete <task_id> --agent <id> sets status to completed,
+#     releases the lease, and emits task.completed
+# Verify: test_complete_command
+# ---------------------------------------------------------------------------
+
+def test_complete_command(tmp_env, store):
+    from app.dispatcher.services import seed_demo
+    tasks = seed_demo(store)
+    ready = next(t for t in tasks if t.status == "ready")
+
+    _run(["claim", ready.task_id, "--agent", "codex", "--json"], tmp_env)
+    code, data = _run(["complete", ready.task_id, "--agent", "codex", "--json"], tmp_env)
+    assert code == 0
+    assert data["ok"] is True
+    assert data["task"]["status"] == "completed"
+    assert data["task"]["lease_id"] is None
+    assert data["task"]["claimed_by"] is None
+
+
+# ---------------------------------------------------------------------------
+# AC: Completing a task by a non-holder agent exits 1 with
+#     {"ok": false, "error": "..."}
+# Verify: test_complete_wrong_holder
+# ---------------------------------------------------------------------------
+
+def test_complete_wrong_holder(tmp_env, store):
+    from app.dispatcher.services import seed_demo
+    tasks = seed_demo(store)
+    ready = next(t for t in tasks if t.status == "ready")
+
+    _run(["claim", ready.task_id, "--agent", "codex", "--json"], tmp_env)
+    code, data = _run(["complete", ready.task_id, "--agent", "other-agent", "--json"], tmp_env)
+    assert code == 1
+    assert data["ok"] is False
+    assert "error" in data
+
+
+# ---------------------------------------------------------------------------
+# AC: dispatcher next does not return a completed task
+# Verify: test_next_skips_completed
+# ---------------------------------------------------------------------------
+
+def test_next_skips_completed(tmp_env, store):
+    from app.dispatcher.services import seed_demo
+    tasks = seed_demo(store)
+    ready = next(t for t in tasks if t.status == "ready")
+
+    _run(["claim", ready.task_id, "--agent", "codex", "--json"], tmp_env)
+    _run(["complete", ready.task_id, "--agent", "codex", "--json"], tmp_env)
+
+    code, data = _run(["next", "--agent", "codex", "--json"], tmp_env)
+    assert code == 0
+    assert data["ok"] is True
+    if data.get("task"):
+        assert data["task"]["task_id"] != ready.task_id
+
+
+# ---------------------------------------------------------------------------
+# AC: task.completed event appears in dispatcher events --json
+# Verify: test_complete_event_emitted
+# ---------------------------------------------------------------------------
+
+def test_complete_event_emitted(tmp_env, store):
+    from app.dispatcher.services import seed_demo
+    tasks = seed_demo(store)
+    ready = next(t for t in tasks if t.status == "ready")
+
+    _run(["claim", ready.task_id, "--agent", "codex", "--json"], tmp_env)
+    _run(["complete", ready.task_id, "--agent", "codex", "--json"], tmp_env)
+
+    code, data = _run(["events", "--tail", "20", "--json"], tmp_env)
+    assert code == 0
+    assert data["ok"] is True
+    events = data.get("events", [])
+    completed_events = [e for e in events if e.get("event_type") == "task.completed"]
+    assert len(completed_events) > 0
+    assert completed_events[0]["task_id"] == ready.task_id


### PR DESCRIPTION
Fixes #638

## Summary
Adds `queue.complete()` function and `dispatcher complete` CLI subcommand as the clean terminal signal for agents finishing a task after PR merge. Complete verifies lease holder, releases the lease with `release_reason=completed`, sets task status to `completed`, and emits `task.completed` event. Completed tasks are filtered out by `dispatcher next`.

## Implementation
- **queue.complete()**: Verifies task exists, checks actor holds lease, releases lease with completed reason, sets status=completed, emits task.completed event
- **CLI subcommand**: `dispatcher complete <task_id> --agent <id>` with --json output
- **CLI integration**: Added to REQUIRED_COMMANDS, _COMMAND_MAP, and parser
- **Test coverage**: 4 acceptance criteria tests covering happy path, wrong-holder rejection, next filtering, and event emission

## Validation
- All 4 acceptance criteria tests pass: test_complete_command, test_complete_wrong_holder, test_next_skips_completed, test_complete_event_emitted
- Full dispatcher test suite passes: 74 tests
- No regressions in existing queue/CLI tests

---