### PR TITLE
docs(dispatcher): add operational deployment section

### DIFF
--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -223,6 +223,47 @@ The following are described as **optional projections only** and are not part of
 
 External boards and GitHub Projects are projections only and must not become required for core queue/lease/claim behavior.
 
+## Operational Deployment
+
+The dispatcher runs as a **central shared instance** on Demerzel (Mac mini) accessible to all agent machines via Tailscale.
+
+**Central host:** `demerzel`
+**Database path:** `~/workspace/runtime/dispatcher/dispatcher.sqlite3`
+**Event log:** `~/workspace/runtime/dispatcher/events.jsonl`
+
+### Setup on the central host (Demerzel)
+
+```bash
+cd ~/workspace
+python -m app.dispatcher init
+python -m app.dispatcher status --json   # verify db_exists: true
+```
+
+### Setup on each agent machine
+
+Install a wrapper script that proxies dispatcher commands over SSH:
+
+```bash
+cat > ~/.local/bin/dispatcher << 'EOF'
+#!/bin/zsh
+ssh rasmus@demerzel "cd ~/workspace && .venv/bin/python -m app.dispatcher $*"
+EOF
+chmod +x ~/.local/bin/dispatcher
+```
+
+Verify:
+
+```bash
+dispatcher queue --json
+```
+
+### Notes
+
+- Requires Tailscale connectivity to `demerzel` and SSH key access.
+- SQLite is the lock authority on Demerzel; all agents coordinate through the same database.
+- No daemon or server process runs — each CLI invocation is a stateless SSH call against the central database.
+- Service mode (HTTP API) is a future extension; the SSH wrapper is the current deployment model.
+
 ## Future Extensions (Not MVP)
 
 - GitHub pull-sync with richer conflict classification and reconciliation policies.


### PR DESCRIPTION
- [x] Docs authoring lane

## Summary
Documents the central dispatcher deployment model: Demerzel (Mac mini) as the central host, Tailscale SSH as the access layer, and a per-machine wrapper script that makes `dispatcher <command>` work transparently from any agent machine.

## Changes
- `docs/AGENT_ISSUE_DISPATCHER.md` — new `## Operational Deployment` section covering central host setup, SSH wrapper install, and deployment model notes

## Validation
Deployment was verified live: SSH wrapper installed on this machine calls Demerzel over Tailscale and returns the correct queue state.

---