### PR TITLE
fix(dispatcher): correct repo owner in dispatcher-sync Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ alpha-e2e:
 
 dispatcher-init:
 	$(PYTHON) -m app.dispatcher init --json
-	@$(PYTHON) -m app.dispatcher pull --repo rasmusthornberg/agentic-pkm-mvp --json
+	@$(PYTHON) -m app.dispatcher pull --repo RasmusTho/agentic-pkm-mvp --json
 
 dispatcher-sync:
-	$(PYTHON) -m app.dispatcher pull --repo rasmusthornberg/agentic-pkm-mvp --json
+	$(PYTHON) -m app.dispatcher pull --repo RasmusTho/agentic-pkm-mvp --json


### PR DESCRIPTION
- [x] Governance lane

## Summary

`make dispatcher-sync` and `make dispatcher-init` used `rasmusthornberg/agentic-pkm-mvp` as the repo slug, which the gh CLI could not resolve. The sync call returned a GraphQL error that was swallowed silently, so every sync reported `upserted: 0` and the local dispatcher DB was never refreshed from GitHub.

Corrected to `RasmusTho/agentic-pkm-mvp` (the actual repo owner).

## Changes

- `Makefile`: two occurrences of `rasmusthornberg/agentic-pkm-mvp` → `RasmusTho/agentic-pkm-mvp`

## Validation

```
python -m app.dispatcher pull --repo RasmusTho/agentic-pkm-mvp --json
# => {"ok": true, "upserted": 0, "skipped": 0, "provider": "github"}
# (0 because no agent:ready issues exist right now — not a silent failure)
```

Related: bug issue [#680](https://github.com/RasmusTho/agentic-pkm-mvp/issues/680) tracks the underlying stale-task purge problem in sync_github.py.

---