### PR TITLE
feat(canvas-01): verify session log writer — already implemented

### DIFF
--- a/docs/learning-log.md
+++ b/docs/learning-log.md
@@ -50,3 +50,8 @@ This lets `learning-retrospective` scope its next read to entries since the last
 **Source:** temporal-doc-governance
 **Diverged:** The audit expected high-risk docs to be clean after recent temporal refreshes, but `docs/ARCHITECTURE.md` still contained a merge-conflict marker on `main`.
 **Upstream artifact:** `.codex/skills/pr-integration/SKILL.md` and CI docs checks — add conflict-marker detection to doc validation before merge.
+
+## 2026-04-29 — #683 (CANVAS-01: Write Session Logs)
+**Source:** issue-to-code
+**Diverged:** The issue was filed for unimplemented work, but `app/chat/session_log.py` and all six acceptance tests already existed in the repo and passed on first run — no implementation was required.
+**Upstream artifact:** `docs-to-issue` / `issue-to-code` — before filing a new issue from a spec, verify that the spec's target module does not already exist in the repo; add a pre-flight check step to the docs-to-issue intake lane.


### PR DESCRIPTION
Fixes #683

## Summary
CANVAS-01 (`Write Session Logs`) is already implemented. `app/chat/session_log.py` and all six acceptance tests in `tests/chat/test_session_log_writer.py` existed on `main` before the issue was filed. All 6 tests pass with no code changes.

This PR only adds a `docs/learning-log.md` entry capturing the divergence: the docs-to-issue intake lane should check for pre-existing implementations before filing new issues from spec docs.

## Validation
```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/chat/test_session_log_writer.py -m "not pg" -q
6 passed in 39.76s
```

All CANVAS-01 `Verify:` targets green:
- `test_open_creates_file_in_chats_namespace` ✓
- `test_log_path_uses_note_slug_and_timestamp` ✓
- `test_frontmatter_fields_present` ✓
- `test_type_field_is_chat_session_only` ✓
- `test_append_does_not_rewrite_prior_content` ✓
- `test_close_session_appends_closure_line` ✓

## Dispatcher
Claimed via dispatcher lease `lease-d8904462` (agent: claude-code).