### PR TITLE
governance: close spec-state feedback-loop gap

### DIFF
--- a/.codex/skills/docs-to-issue/SKILL.md
+++ b/.codex/skills/docs-to-issue/SKILL.md
@@ -54,8 +54,13 @@ For every candidate doc item, determine exactly one state:
 2. Inspect open Issues.
 3. Inspect recent open and merged PRs.
 4. Check whether the work is already tracked, already delivered, superseded, partially delivered, or blocked.
-5. Decide whether the item should stay as one bounded issue or be turned into one parent feature issue plus child slices via `feature-breakdown`.
-6. If the candidate would only create bookkeeping churn, keep it out of the backlog and route it to the maintenance path instead.
+5. **Pre-flight code existence check** — for spec files that name a target module path (e.g. `app/chat/session_log.py`), verify that path does not already exist in the repo before filing:
+   ```bash
+   ls <target_module_path>   # if exists → mark candidate as `delivered`, do not file
+   ```
+   Also check whether the spec file's own `State:` line has already been promoted to "Implemented" — if so, classify as `delivered` and skip. If the code exists but `State:` still reads "Not yet implemented", treat the spec as stale, update the `State:` line (docs-authoring lane), and do not file a new issue.
+6. Decide whether the item should stay as one bounded issue or be turned into one parent feature issue plus child slices via `feature-breakdown`.
+7. If the candidate would only create bookkeeping churn, keep it out of the backlog and route it to the maintenance path instead.
 
 ## When a doc item becomes a new Issue
 

--- a/.codex/skills/verification-and-closure/SKILL.md
+++ b/.codex/skills/verification-and-closure/SKILL.md
@@ -155,6 +155,21 @@ When all merge prerequisites are met:
    gh pr view #<PR> --json state,projectItems
    ```
 
+8b. **Spec-state writeback** — for each spec file referenced in the closed issue's `Source Anchors` (pattern: `docs/<CAPABILITY>/<SPEC_FILE>.md`), check whether the file contains a `State:` line that still reads "Not yet implemented" or similar undelivered language. If it does, update that line in place to:
+   ```
+   State: Implemented. Delivered by PR #<PR> (issue #<N>, <YYYY-MM-DD>).
+   ```
+   Commit this writeback on the same branch or open a follow-up docs PR if the branch is already merged. This prevents `docs-to-issue` from re-filing already-delivered work.
+
+   ```bash
+   # Example: update State line in a spec file
+   sed -i '' 's/^State: Specification. Not yet implemented./State: Implemented. Delivered by PR #<PR> (issue #<N>, <date>)./' docs/<CAPABILITY>/<SPEC_FILE>.md
+   git add docs/<CAPABILITY>/<SPEC_FILE>.md
+   git commit -m "docs: mark <SPEC_FILE> as implemented (PR #<PR>)"
+   ```
+
+   If the branch is already merged, open a one-commit docs-authoring PR with the writeback instead.
+
 9. **Invoke `post-merge-owner-doc`** on the merged PR. It reads the diff and either opens a docs-only PR, files one bounded follow-up issue, or leaves an explicit "no owner-doc change implied" receipt comment on the closed issue. This is the only owner-doc promotion step; do not duplicate its judgment here.
 
 10. **Assert the receipt exists** before emitting `DELIVERY RECEIPT`. For each issue closed by the PR, run:

--- a/docs/CANVAS_CHAT_SURFACE/WRITE_SESSION_LOGS.md
+++ b/docs/CANVAS_CHAT_SURFACE/WRITE_SESSION_LOGS.md
@@ -9,7 +9,7 @@ depends_on: []
 can_parallelize_with: []
 ---
 
-State: Specification. Not yet implemented.
+State: Implemented. Delivered by PR #687 (issue #683, 2026-04-29).
 
 # Write Session Logs
 


### PR DESCRIPTION
- [x] Governance lane

## Summary
Two skills left the `State:` field in capability spec files perpetually reading "Not yet implemented" after delivery. This caused `docs-to-issue` to re-file issue #683 for work (`app/chat/session_log.py`) that already existed on `main`.

## Root cause
1. `verification-and-closure` wrote back to owner docs and roadmap wording but not to the source spec file's `State:` line.
2. `docs-to-issue` had no pre-flight check to verify a target module doesn't already exist before filing.
3. `post-merge-owner-doc` correctly excludes `docs/{CAPABILITY}/*` from owner-doc promotion — but that exclusion also silently swallowed the one stale claim that mattered.

## Changes

**`.codex/skills/verification-and-closure/SKILL.md`** — new step 8b: after projecting Done status, update the `State:` line in any source spec file referenced by the closed issue's `Source Anchors` to `State: Implemented. Delivered by PR #N (issue #M, date).`

**`.codex/skills/docs-to-issue/SKILL.md`** — new pre-flight step 5: before filing from a spec, `ls` the target module path; if it exists, classify as `delivered` and skip. Also check the spec's own `State:` line — if already promoted, do not file.

**`docs/CANVAS_CHAT_SURFACE/WRITE_SESSION_LOGS.md`** — backfills the `State:` promotion that should have happened at PR #687 merge.

## Validation
- Adoption evidence: next `docs-to-issue` run against `CANVAS_CHAT_SURFACE/` will find `WRITE_SESSION_LOGS.md` with `State: Implemented…` and skip it.
- Next `verification-and-closure` closure of a canvas slice will emit the spec writeback commit.
- No behavioral tests — governance lane acceptance shape is adoption evidence.

---