### PR TITLE
fix(panel_agent): restore promotion trigger events — add trust_verb=APPLY to fixtures

### DIFF
--- a/tests/agents/panel_agent/test_mapping.py
+++ b/tests/agents/panel_agent/test_mapping.py
@@ -53,6 +53,7 @@ def test_catalog_marks_duplicate_labels_ambiguous() -> None:
             PanelActionDescriptor(
                 id="promote.evergreen",
                 intent_type="promotion",
+                trust_verb="APPLY",
                 downstream_event="review.promote.evergreen",
                 labels=["Shared Label"],
             ),

--- a/tests/agents/panel_agent/test_note_context_integration.py
+++ b/tests/agents/panel_agent/test_note_context_integration.py
@@ -278,6 +278,7 @@ def test_llm_decider_uses_note_context_in_prompt(monkeypatch: pytest.MonkeyPatch
     mapping = PanelActionMapping(
         id="promote.evergreen",
         intent_type="promotion",
+        trust_verb="APPLY",
         downstream_event="review.promote.evergreen",
         params={"maturity": "evergreen"},
     )
@@ -295,6 +296,7 @@ def test_llm_decider_uses_note_context_in_prompt(monkeypatch: pytest.MonkeyPatch
             PanelActionDescriptor(
                 id="promote.evergreen",
                 intent_type="promotion",
+                trust_verb="APPLY",
                 downstream_event="review.promote.evergreen",
                 labels=["Promote"],
             )

--- a/tests/agents/panel_agent/test_panel_cognition.py
+++ b/tests/agents/panel_agent/test_panel_cognition.py
@@ -72,6 +72,7 @@ def _promotion_action(*, checked: bool = True) -> PanelIntentAction:
     mapping = PanelActionMapping(
         id="promote.evergreen",
         intent_type="promotion",
+        trust_verb="APPLY",
         downstream_event="review.promote.evergreen",
         params={"maturity": "evergreen"},
     )

--- a/tests/agents/panel_agent/test_panel_graph.py
+++ b/tests/agents/panel_agent/test_panel_graph.py
@@ -67,6 +67,7 @@ def test_panel_graph_emits_promotion_and_log_events() -> None:
     mapping = PanelActionMapping(
         id="promote.evergreen",
         intent_type="promotion",
+        trust_verb="APPLY",
         downstream_event="review.promote.evergreen",
         params={"maturity": "evergreen"},
     )
@@ -106,6 +107,7 @@ def test_panel_graph_logs_unknown_mapping_as_unresolved() -> None:
             PanelActionDescriptor(
                 id="promote.evergreen",
                 intent_type="promotion",
+                trust_verb="APPLY",
                 downstream_event="review.promote.evergreen",
                 labels=["Promote"],
             )
@@ -118,6 +120,7 @@ def test_panel_graph_logs_unknown_mapping_as_unresolved() -> None:
         mapping=PanelActionMapping(
             id="orphan.action",
             intent_type="promotion",
+            trust_verb="APPLY",
             downstream_event="review.promote.evergreen",
             params={"maturity": "evergreen"},
         ),
@@ -177,6 +180,7 @@ def test_panel_graph_marks_ambiguous_label_as_ambiguous() -> None:
             PanelActionDescriptor(
                 id="promote.evergreen",
                 intent_type="promotion",
+                trust_verb="APPLY",
                 downstream_event="review.promote.evergreen",
                 labels=["Shared Label"],
             ),
@@ -205,6 +209,7 @@ def test_panel_graph_llm_selects_subset(monkeypatch) -> None:
     promote_mapping = PanelActionMapping(
         id="promote.evergreen",
         intent_type="promotion",
+        trust_verb="APPLY",
         downstream_event="review.promote.evergreen",
         params={"maturity": "evergreen"},
     )
@@ -217,6 +222,7 @@ def test_panel_graph_llm_selects_subset(monkeypatch) -> None:
             PanelActionDescriptor(
                 id="promote.evergreen",
                 intent_type="promotion",
+                trust_verb="APPLY",
                 downstream_event="review.promote.evergreen",
                 labels=["Gör denna anteckning evergreen", "Promote"],
                 description="Promote note to evergreen",
@@ -253,6 +259,7 @@ def test_panel_graph_llm_falls_back_on_malformed(monkeypatch) -> None:
     mapping = PanelActionMapping(
         id="promote.evergreen",
         intent_type="promotion",
+        trust_verb="APPLY",
         downstream_event="review.promote.evergreen",
         params={"maturity": "evergreen"},
     )
@@ -263,6 +270,7 @@ def test_panel_graph_llm_falls_back_on_malformed(monkeypatch) -> None:
             PanelActionDescriptor(
                 id="promote.evergreen",
                 intent_type="promotion",
+                trust_verb="APPLY",
                 downstream_event="review.promote.evergreen",
                 labels=["Promote"],
                 description="Promote note to evergreen",
@@ -286,6 +294,7 @@ def test_panel_graph_llm_can_select_unchecked(monkeypatch) -> None:
     mapping = PanelActionMapping(
         id="promote.evergreen",
         intent_type="promotion",
+        trust_verb="APPLY",
         downstream_event="review.promote.evergreen",
         params={"maturity": "evergreen"},
     )
@@ -296,6 +305,7 @@ def test_panel_graph_llm_can_select_unchecked(monkeypatch) -> None:
             PanelActionDescriptor(
                 id="promote.evergreen",
                 intent_type="promotion",
+                trust_verb="APPLY",
                 downstream_event="review.promote.evergreen",
                 labels=["Gör denna anteckning evergreen", "Make evergreen"],
                 description="Promote note to evergreen",
@@ -320,6 +330,7 @@ def test_panel_graph_llm_empty_selection_uses_instruction_hint_for_single_promot
     mapping = PanelActionMapping(
         id="promote.evergreen",
         intent_type="promotion",
+        trust_verb="APPLY",
         downstream_event="review.promote.evergreen",
         params={"maturity": "evergreen"},
     )
@@ -337,6 +348,7 @@ def test_panel_graph_llm_empty_selection_uses_instruction_hint_for_single_promot
             PanelActionDescriptor(
                 id="promote.evergreen",
                 intent_type="promotion",
+                trust_verb="APPLY",
                 downstream_event="review.promote.evergreen",
                 labels=["Make this note evergreen", "Promote to evergreen"],
                 description="Promote note to evergreen",
@@ -393,6 +405,7 @@ def test_panel_graph_llm_empty_selection_honors_negated_promotion_instruction(mo
     mapping = PanelActionMapping(
         id="promote.evergreen",
         intent_type="promotion",
+        trust_verb="APPLY",
         downstream_event="review.promote.evergreen",
         params={"maturity": "evergreen"},
     )
@@ -410,6 +423,7 @@ def test_panel_graph_llm_empty_selection_honors_negated_promotion_instruction(mo
             PanelActionDescriptor(
                 id="promote.evergreen",
                 intent_type="promotion",
+                trust_verb="APPLY",
                 downstream_event="review.promote.evergreen",
                 labels=["Make this note evergreen", "Promote to evergreen"],
                 description="Promote note to evergreen",
@@ -454,6 +468,7 @@ def test_panel_graph_freeform_proposes_catalog_action_without_checkboxes(monkeyp
             PanelActionDescriptor(
                 id="promote.evergreen",
                 intent_type="promotion",
+                trust_verb="APPLY",
                 downstream_event="review.promote.evergreen",
                 labels=["Make this note evergreen"],
                 description="Promote note to evergreen",
@@ -485,6 +500,7 @@ def test_panel_graph_freeform_rejects_out_of_catalog_id(monkeypatch) -> None:
             PanelActionDescriptor(
                 id="promote.evergreen",
                 intent_type="promotion",
+                trust_verb="APPLY",
                 downstream_event="review.promote.evergreen",
                 labels=["Make this note evergreen"],
                 description="Promote note to evergreen",
@@ -527,6 +543,7 @@ def test_panel_graph_freeform_falls_back_to_rule_on_llm_error(monkeypatch) -> No
             PanelActionDescriptor(
                 id="promote.evergreen",
                 intent_type="promotion",
+                trust_verb="APPLY",
                 downstream_event="review.promote.evergreen",
                 labels=["Make this note evergreen"],
                 description="Promote note to evergreen",
@@ -550,6 +567,7 @@ def test_panel_graph_skips_idempotent_duplicate() -> None:
     mapping = PanelActionMapping(
         id="promote.evergreen",
         intent_type="promotion",
+        trust_verb="APPLY",
         downstream_event="review.promote.evergreen",
         params={"maturity": "evergreen"},
     )
@@ -574,6 +592,7 @@ def test_panel_graph_cognition_mode_in_emitted_events_rule() -> None:
     mapping = PanelActionMapping(
         id="promote.evergreen",
         intent_type="promotion",
+        trust_verb="APPLY",
         downstream_event="review.promote.evergreen",
         params={"maturity": "evergreen"},
     )
@@ -599,6 +618,7 @@ def test_panel_graph_cognition_mode_in_emitted_events_llm(monkeypatch: pytest.Mo
     mapping = PanelActionMapping(
         id="promote.evergreen",
         intent_type="promotion",
+        trust_verb="APPLY",
         downstream_event="review.promote.evergreen",
         params={"maturity": "evergreen"},
     )

--- a/tests/agents/panel_agent/test_panel_planner_pipeline.py
+++ b/tests/agents/panel_agent/test_panel_planner_pipeline.py
@@ -37,6 +37,7 @@ mappings:
   - id: "promote.evergreen"
     label: "Gör denna anteckning evergreen"
     intent_type: "promotion"
+    trust_verb: "APPLY"
     downstream_event: "review.promote.evergreen"
     params:
       maturity: "evergreen"
@@ -110,6 +111,7 @@ def test_plan_panel_actions_creates_ordered_step_chain() -> None:
                 mapping=PanelActionMapping(
                     id="promote.evergreen",
                     intent_type="promotion",
+                    trust_verb="APPLY",
                     downstream_event="review.promote.evergreen",
                     params={"maturity": "evergreen"},
                 ),

--- a/tests/agents/panel_agent/test_panel_runtime.py
+++ b/tests/agents/panel_agent/test_panel_runtime.py
@@ -44,15 +44,16 @@ def _seed_note(
     ObjectStore().save_object(obj, emit_outbox=False, trace_id="trace-runtime-test")
 
 
-def _settings_file(tmp_path: Path, *, action_id: str, label: str, intent_type: str, downstream_event: str) -> Path:
+def _settings_file(tmp_path: Path, *, action_id: str, label: str, intent_type: str, downstream_event: str, trust_verb: str | None = None) -> Path:
     path = tmp_path / "panel-actions.md"
+    trust_verb_line = f'    trust_verb: "{trust_verb}"\n' if trust_verb else ""
     path.write_text(
         f"""---
 mappings:
   - id: "{action_id}"
     label: "{label}"
     intent_type: "{intent_type}"
-    downstream_event: "{downstream_event}"
+{trust_verb_line}    downstream_event: "{downstream_event}"
     params:
       maturity: "evergreen"
 ---
@@ -121,6 +122,7 @@ def test_runtime_emits_promotion_intent_and_execution_event(tmp_path: Path, monk
         action_id="promote.evergreen",
         label="Gör denna anteckning evergreen",
         intent_type="promotion",
+        trust_verb="APPLY",
         downstream_event="review.promote.evergreen",
     )
     markdown = _panel_markdown("Gör denna anteckning evergreen", checked=True)
@@ -187,6 +189,7 @@ def test_runtime_llm_filters_executed_actions(tmp_path: Path, monkeypatch: pytes
         action_id="promote.evergreen",
         label="Gör denna anteckning evergreen",
         intent_type="promotion",
+        trust_verb="APPLY",
         downstream_event="review.promote.evergreen",
     )
     markdown = _panel_markdown("Gör denna anteckning evergreen", checked=True)
@@ -255,6 +258,7 @@ def test_runtime_restart_does_not_reemit_executed_actions(tmp_path: Path, monkey
         action_id="promote.evergreen",
         label="Gör denna anteckning evergreen",
         intent_type="promotion",
+        trust_verb="APPLY",
         downstream_event="review.promote.evergreen",
     )
     markdown = _panel_markdown("Gör denna anteckning evergreen", checked=True)
@@ -291,6 +295,7 @@ def test_runtime_appends_ai_log_entry(tmp_path: Path, monkeypatch: pytest.Monkey
         action_id="promote.evergreen",
         label="Gör denna anteckning evergreen",
         intent_type="promotion",
+        trust_verb="APPLY",
         downstream_event="review.promote.evergreen",
     )
     markdown = _panel_markdown("Gör denna anteckning evergreen", checked=True)
@@ -323,6 +328,7 @@ def test_run_panel_note_execution_runs_full_pipeline(tmp_path: Path, monkeypatch
         action_id="promote.evergreen",
         label="Gör denna anteckning evergreen",
         intent_type="promotion",
+        trust_verb="APPLY",
         downstream_event="review.promote.evergreen",
     )
     markdown = _panel_markdown("Gör denna anteckning evergreen", checked=True)
@@ -352,6 +358,7 @@ def test_runtime_writeback_removes_checkbox_and_writes_receipt(tmp_path: Path, m
         action_id="promote.evergreen",
         label="Make this note evergreen",
         intent_type="promotion",
+        trust_verb="APPLY",
         downstream_event="review.promote.evergreen",
     )
     markdown = (
@@ -411,6 +418,7 @@ def test_runtime_writeback_idempotent_on_rerun(tmp_path: Path, monkeypatch: pyte
         action_id="promote.evergreen",
         label="Make this note evergreen",
         intent_type="promotion",
+        trust_verb="APPLY",
         downstream_event="review.promote.evergreen",
     )
     markdown = (
@@ -471,6 +479,7 @@ def test_runtime_writeback_proposed_actions_as_unchecked_suggestions(tmp_path: P
         action_id="promote.evergreen",
         label="Make this note evergreen",
         intent_type="promotion",
+        trust_verb="APPLY",
         downstream_event="review.promote.evergreen",
     )
     # Freeform panel (no checkbox actions) to trigger proposal discovery.
@@ -529,6 +538,7 @@ def test_runtime_writeback_proposes_idempotent_on_rerun(tmp_path: Path, monkeypa
         action_id="promote.evergreen",
         label="Make this note evergreen",
         intent_type="promotion",
+        trust_verb="APPLY",
         downstream_event="review.promote.evergreen",
     )
     markdown = (

--- a/tests/agents/panel_agent/test_panel_wiring.py
+++ b/tests/agents/panel_agent/test_panel_wiring.py
@@ -34,6 +34,7 @@ mappings:
   - id: promote.evergreen
     label: "Gör denna anteckning evergreen"
     intent_type: promotion
+    trust_verb: APPLY
     downstream_event: review.promote.evergreen
     params:
       maturity: evergreen


### PR DESCRIPTION
Fixes #699

## Summary

The trust-verb gate introduced in #581 requires promotion-type `PanelActionMapping` entries to carry `trust_verb="APPLY"` before they reach the `triggered` path. All test fixtures and YAML settings helpers predated this gate, so promotion actions were silently downgraded to `panel.action.logged` instead of emitting `panel.action.triggered` + `promote.intent.created`.

Updated every promotion mapping and YAML-generating `_settings_file` helper across 7 test files to set `trust_verb="APPLY"`.

## Validation

```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest -q -c /dev/null tests/agents/panel_agent/
83 passed
```

All four AC test targets green:
- `test_panel_graph.py::test_panel_graph_emits_promotion_and_log_events` ✓
- `test_panel_cognition.py::test_run_panel_graph_with_selecting_stub_triggers_action` ✓
- `test_panel_runtime.py::test_runtime_emits_promotion_intent_and_execution_event` ✓
- `test_panel_wiring.py::test_default_wiring_used_when_no_env_or_vault` ✓

---