### PR TITLE
feat(commitments): gate state mutations through receipt-governed APPLY path

### DIFF
--- a/app/domain/commitments.py
+++ b/app/domain/commitments.py
@@ -193,7 +193,7 @@ def apply_commitment_mutation(
         "transition_family": "commitment_state",
     }
     for field in _REQUIRED_RECEIPT_FIELDS:
-        receipt_metadata[field] = str(receipt_request[field])
+        receipt_metadata[field] = verb if field == "verb" else str(receipt_request[field])
     return CommitmentTransitionResult(updated=updated, receipt_metadata=receipt_metadata)
 
 

--- a/app/domain/commitments.py
+++ b/app/domain/commitments.py
@@ -151,6 +151,52 @@ def apply_commitment_state_transition(
     return CommitmentTransitionResult(updated=updated, receipt_metadata=receipt_metadata)
 
 
+_REQUIRED_RECEIPT_FIELDS: tuple[str, ...] = (
+    "verb",
+    "authority",
+    "basis",
+    "outcome",
+    "artifact_linkage",
+    "instance_provenance",
+)
+
+
+def apply_commitment_mutation(
+    commitment: CommitmentRecord,
+    *,
+    to_state: object,
+    receipt_request: dict[str, object],
+) -> CommitmentTransitionResult:
+    """Gate commitment state mutations through a receipt-bearing APPLY request.
+
+    Raises ValueError if the verb is not APPLY or if any required receipt field
+    is missing. Returns a CommitmentTransitionResult on success.
+    """
+    verb = str(receipt_request.get("verb") or "").strip().upper()
+    if verb != "APPLY":
+        raise ValueError(
+            f"commitment mutation requires trust verb APPLY; got '{verb or '(empty)'}'"
+        )
+
+    for field in _REQUIRED_RECEIPT_FIELDS:
+        if field not in receipt_request or receipt_request[field] is None or str(receipt_request[field]).strip() == "":
+            raise ValueError(
+                f"commitment mutation missing required receipt field '{field}'"
+            )
+
+    next_state = normalize_commitment_state(to_state)
+    updated = replace(commitment, state=next_state)
+    receipt_metadata: dict[str, str] = {
+        "commitment_id": commitment.commitment_id,
+        "before_state": commitment.state,
+        "after_state": next_state,
+        "transition_family": "commitment_state",
+    }
+    for field in _REQUIRED_RECEIPT_FIELDS:
+        receipt_metadata[field] = str(receipt_request[field])
+    return CommitmentTransitionResult(updated=updated, receipt_metadata=receipt_metadata)
+
+
 __all__ = [
     "COMMITMENT_STATE_VALUES",
     "CommitmentQueryResult",
@@ -160,6 +206,7 @@ __all__ = [
     "CommitmentTransitionResult",
     "CommitmentKind",
     "FIRST_WAVE_COMMITMENT_KINDS",
+    "apply_commitment_mutation",
     "apply_commitment_state_transition",
     "make_commitment_handle",
     "normalize_commitment_state",

--- a/tests/commitments/test_commitment_receipt_gate.py
+++ b/tests/commitments/test_commitment_receipt_gate.py
@@ -1,0 +1,113 @@
+"""Tests for the receipt-governed APPLY gate on commitment state mutations.
+
+AC source: GitHub issue #694
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.domain.commitments import (
+    CommitmentRecord,
+    CommitmentTransitionResult,
+    apply_commitment_mutation,
+)
+
+
+def _base_request() -> dict:
+    return {
+        "verb": "APPLY",
+        "authority": "user",
+        "basis": "user marked complete",
+        "outcome": "done",
+        "artifact_linkage": "note:abc",
+        "instance_provenance": "session:xyz",
+    }
+
+
+def _sample_commitment() -> CommitmentRecord:
+    return CommitmentRecord(
+        commitment_id="c-001",
+        commitment_kind="next_action",
+        state="next",
+        summary="Reply to Alice",
+        target_ref="note:abc",
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC 1: rejects non-APPLY trust verbs
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("verb", ["ASSERT", "SUGGEST", "assert", "suggest", "observe", ""])
+def test_commitment_write_rejects_non_apply_verb(verb: str) -> None:
+    req = {**_base_request(), "verb": verb}
+    with pytest.raises(ValueError, match="APPLY"):
+        apply_commitment_mutation(_sample_commitment(), to_state="done", receipt_request=req)
+
+
+# ---------------------------------------------------------------------------
+# AC 2: rejects missing required receipt fields
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("missing_field", [
+    "verb",
+    "authority",
+    "basis",
+    "outcome",
+    "artifact_linkage",
+    "instance_provenance",
+])
+def test_commitment_write_requires_receipt_fields(missing_field: str) -> None:
+    req = {k: v for k, v in _base_request().items() if k != missing_field}
+    with pytest.raises(ValueError, match=missing_field):
+        apply_commitment_mutation(_sample_commitment(), to_state="done", receipt_request=req)
+
+
+# ---------------------------------------------------------------------------
+# AC 3: successful mutation returns updated state + receipt-linkage metadata
+# ---------------------------------------------------------------------------
+
+def test_commitment_write_returns_transition_and_receipt_linkage() -> None:
+    result = apply_commitment_mutation(
+        _sample_commitment(),
+        to_state="done",
+        receipt_request=_base_request(),
+    )
+
+    assert isinstance(result, CommitmentTransitionResult)
+    assert result.updated.state == "done"
+    assert result.updated.commitment_id == "c-001"
+
+    meta = result.receipt_metadata
+    assert meta["verb"] == "APPLY"
+    assert meta["authority"] == "user"
+    assert meta["basis"] == "user marked complete"
+    assert meta["outcome"] == "done"
+    assert meta["artifact_linkage"] == "note:abc"
+    assert meta["instance_provenance"] == "session:xyz"
+    assert meta["before_state"] == "next"
+    assert meta["after_state"] == "done"
+    assert meta["commitment_id"] == "c-001"
+
+
+# ---------------------------------------------------------------------------
+# AC 4: mutation does not touch note-state axes
+# ---------------------------------------------------------------------------
+
+def test_commitment_write_does_not_touch_note_state_axes() -> None:
+    result = apply_commitment_mutation(
+        _sample_commitment(),
+        to_state="done",
+        receipt_request=_base_request(),
+    )
+
+    updated = result.updated
+    # CommitmentRecord must not gain maturity, review_state, or execution-plan fields
+    assert not hasattr(updated, "maturity")
+    assert not hasattr(updated, "review_state")
+    assert not hasattr(updated, "execution_plan")
+    assert not hasattr(updated, "note_state")
+
+    meta = result.receipt_metadata
+    for key in ("maturity", "review_state", "execution_plan", "note_state"):
+        assert key not in meta


### PR DESCRIPTION
Fixes #694

## Summary

Adds `apply_commitment_mutation()` — a bounded commitment mutation entrypoint that enforces receipt-governed APPLY semantics before allowing any state transition:

- Rejects any trust verb that is not `APPLY` (e.g. ASSERT, SUGGEST, empty)
- Rejects mutations missing any of the six required receipt fields: `verb`, `authority`, `basis`, `outcome`, `artifact_linkage`, `instance_provenance`
- Returns `CommitmentTransitionResult` with full receipt metadata on success
- Does not touch note-state axes (`maturity`, `review_state`, `execution_plan`)

## Validation

```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/commitments/
17 passed
```

All four AC `Verify:` targets green:
- `test_commitment_receipt_gate.py::test_commitment_write_rejects_non_apply_verb` ✓
- `test_commitment_receipt_gate.py::test_commitment_write_requires_receipt_fields` ✓
- `test_commitment_receipt_gate.py::test_commitment_write_returns_transition_and_receipt_linkage` ✓
- `test_commitment_receipt_gate.py::test_commitment_write_does_not_touch_note_state_axes` ✓

---