### PR TITLE
docs: promote canvas spec State: fields after delivery (#684/#685/#686)

### DIFF
--- a/docs/CANVAS_CHAT_SURFACE/CO_AUTHOR_NOTE_BODY.md
+++ b/docs/CANVAS_CHAT_SURFACE/CO_AUTHOR_NOTE_BODY.md
@@ -9,7 +9,7 @@ depends_on: [WRITE_SESSION_LOGS.md]
 can_parallelize_with: []
 ---
 
-State: Specification. Not yet implemented.
+State: Implemented. Delivered by issue #684 (2026-04-29).
 
 # Co-Author Note Body
 

--- a/docs/CANVAS_CHAT_SURFACE/EXPOSE_CANVAS_SESSION_API.md
+++ b/docs/CANVAS_CHAT_SURFACE/EXPOSE_CANVAS_SESSION_API.md
@@ -9,7 +9,7 @@ depends_on: [WRITE_SESSION_LOGS.md, CO_AUTHOR_NOTE_BODY.md, GATE_GOVERNANCE_BEAR
 can_parallelize_with: []
 ---
 
-State: Specification. Not yet implemented.
+State: Implemented. Delivered by issue #686 (2026-04-29).
 
 # Expose Canvas Session API
 

--- a/docs/CANVAS_CHAT_SURFACE/GATE_GOVERNANCE_BEARING_MUTATIONS.md
+++ b/docs/CANVAS_CHAT_SURFACE/GATE_GOVERNANCE_BEARING_MUTATIONS.md
@@ -9,7 +9,7 @@ depends_on: [WRITE_SESSION_LOGS.md, CO_AUTHOR_NOTE_BODY.md]
 can_parallelize_with: []
 ---
 
-State: Specification. Not yet implemented.
+State: Implemented. Delivered by issue #685 (2026-04-29).
 
 # Gate Governance-Bearing Mutations
 

--- a/docs/learning-log.md
+++ b/docs/learning-log.md
@@ -55,3 +55,8 @@ This lets `learning-retrospective` scope its next read to entries since the last
 **Source:** issue-to-code
 **Diverged:** The issue was filed for unimplemented work, but `app/chat/session_log.py` and all six acceptance tests already existed in the repo and passed on first run — no implementation was required.
 **Upstream artifact:** `docs-to-issue` / `issue-to-code` — before filing a new issue from a spec, verify that the spec's target module does not already exist in the repo; add a pre-flight check step to the docs-to-issue intake lane.
+
+## 2026-05-02 — #684/#685/#686 (CANVAS-02/03/04: Co-Author, Gate, API)
+**Source:** verification-and-closure
+**Diverged:** All three remaining canvas slices (#684 co-author body, #685 governance gate, #686 API/CLI) were filed as unimplemented, but `app/chat/canvas_writer.py`, `app/chat/governance_router.py`, API routes, and CLI commands already existed with 19 passing tests. All four spec files had `State: Specification. Not yet implemented.` despite the whole canvas surface having shipped via PRs #605/#618/#619/#626.
+**Upstream artifact:** `docs-to-issue` pre-flight check (now patched in PR #701) + spec-state writeback in `verification-and-closure` (PR #701) — confirms the governance repair was correctly scoped; the three previously-untracked spec State: lines are now promoted in the follow-up docs PR.


### PR DESCRIPTION
- [x] Docs authoring lane

## Summary
All four canvas slices were already fully implemented (shipped via PRs #605/#618/#619/#626) when we filed issues #683–686. PR #687 backfilled `WRITE_SESSION_LOGS.md`. This PR does the same for the three remaining spec files, applying the `verification-and-closure` step 8b spec-state writeback introduced in governance PR #701.

## Changes
- `docs/CANVAS_CHAT_SURFACE/CO_AUTHOR_NOTE_BODY.md` — `State:` promoted (issue #684)
- `docs/CANVAS_CHAT_SURFACE/GATE_GOVERNANCE_BEARING_MUTATIONS.md` — `State:` promoted (issue #685)
- `docs/CANVAS_CHAT_SURFACE/EXPOSE_CANVAS_SESSION_API.md` — `State:` promoted (issue #686)
- `docs/learning-log.md` — batch divergence entry for CANVAS-02/03/04

## Validation
19/19 canvas acceptance tests pass:
```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/chat/test_canvas_writer.py \
  tests/chat/test_governance_router.py tests/api/test_canvas_api.py \
  tests/cli/test_canvas_cli.py -m "not pg" -q
19 passed
```

After merge, `docs-to-issue` pre-flight check (PR #701) will find these specs with `State: Implemented…` and skip them correctly.