### PR TITLE
feat(commitments): consume salience/staleness signals in next-waiting query surfacing

### DIFF
--- a/app/domain/commitments.py
+++ b/app/domain/commitments.py
@@ -109,17 +109,84 @@ def make_commitment_handle(
     )
 
 
+def _salience_rank_score(
+    commitment_id: str,
+    salience_scores: dict[str, float] | None,
+    staleness_scores: dict[str, float] | None,
+) -> float:
+    """Derive a composite ranking score from optional salience and staleness inputs.
+
+    Both signals are optional and may be absent or partial.  When a signal is
+    missing for a given commitment_id the contribution of that signal is treated
+    as 0.0 so the function never raises.  Higher scores sort earlier.
+
+    Ranking formula: salience_score + staleness_score (equally weighted).
+    Neither signal is required; an absent signal contributes 0.0.
+    """
+    salience = (salience_scores or {}).get(commitment_id, 0.0)
+    staleness = (staleness_scores or {}).get(commitment_id, 0.0)
+    return salience + staleness
+
+
 def query_next_and_waiting_commitments(
     commitments: tuple[CommitmentRecord, ...] | list[CommitmentRecord],
+    *,
+    salience_scores: dict[str, float] | None = None,
+    staleness_scores: dict[str, float] | None = None,
 ) -> CommitmentQueryResult:
-    next_items = tuple(item for item in commitments if item.state == "next")
-    waiting_items = tuple(item for item in commitments if item.state == "waiting")
+    """Return next and waiting commitments, optionally ranked by salience/staleness.
+
+    Parameters
+    ----------
+    commitments:
+        All commitment records to surface from.
+    salience_scores:
+        Optional mapping of commitment_id -> salience score (0.0–1.0).
+        When present, higher-salience next-items rank earlier.
+        Absent or partial maps degrade gracefully; no error is raised.
+    staleness_scores:
+        Optional mapping of commitment_id -> staleness score (0.0–1.0).
+        When present, higher-staleness next-items rank earlier, and staleness
+        metadata is included in operator_summary for waiting items.
+        Absent or partial maps degrade gracefully; no error is raised.
+
+    Returns
+    -------
+    CommitmentQueryResult
+        Results are commitment-typed (CommitmentRecord).  States remain within
+        the commitment state vocabulary and are never collapsed into note-state
+        axes (review_state / maturity).
+    """
+    raw_next = [item for item in commitments if item.state == "next"]
+    raw_waiting = [item for item in commitments if item.state == "waiting"]
+
+    # Rank next items when any signal is present; Python's sort is stable so
+    # items with equal scores (no signal → 0.0) retain their insertion order.
+    signals_present = salience_scores is not None or staleness_scores is not None
+    if signals_present:
+        raw_next.sort(
+            key=lambda c: _salience_rank_score(c.commitment_id, salience_scores, staleness_scores),
+            reverse=True,
+        )
+
+    next_items = tuple(raw_next)
+    waiting_items = tuple(raw_waiting)
+
     operator_summary: dict[str, object] = {
         "next_count": len(next_items),
         "waiting_count": len(waiting_items),
         "next_ids": [item.commitment_id for item in next_items],
         "waiting_ids": [item.commitment_id for item in waiting_items],
     }
+
+    # Expose staleness metadata for waiting items when staleness scores are present.
+    if staleness_scores is not None:
+        waiting_staleness: dict[str, float] = {
+            item.commitment_id: staleness_scores.get(item.commitment_id, 0.0)
+            for item in waiting_items
+        }
+        operator_summary["waiting_staleness"] = waiting_staleness
+
     return CommitmentQueryResult(
         next_items=next_items,
         waiting_items=waiting_items,

--- a/tests/commitments/test_commitment_salience_queries.py
+++ b/tests/commitments/test_commitment_salience_queries.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+"""Tests for salience/staleness-aware commitment query surfacing (Issue #695).
+
+Each test corresponds to one AC in the issue contract.
+"""
+
+from app.domain.commitments import (
+    CommitmentRecord,
+    query_next_and_waiting_commitments,
+)
+
+
+# ---------------------------------------------------------------------------
+# AC 1: next query consumes salience and staleness signals for ranking
+# ---------------------------------------------------------------------------
+
+
+def test_next_query_consumes_salience_and_staleness() -> None:
+    """Verify that salience and staleness inputs influence ranking of next items.
+
+    High salience / high staleness commitment must appear before a low salience /
+    low staleness commitment in the returned next_items tuple.
+    """
+    commitments = (
+        CommitmentRecord(
+            commitment_id="c-next-low",
+            commitment_kind="next_action",
+            state="next",
+            summary="Low priority next action",
+        ),
+        CommitmentRecord(
+            commitment_id="c-next-high",
+            commitment_kind="next_action",
+            state="next",
+            summary="High priority next action",
+        ),
+    )
+    salience_scores = {
+        "c-next-low": 0.2,
+        "c-next-high": 0.9,
+    }
+    staleness_scores = {
+        "c-next-low": 0.1,
+        "c-next-high": 0.8,
+    }
+
+    result = query_next_and_waiting_commitments(
+        commitments,
+        salience_scores=salience_scores,
+        staleness_scores=staleness_scores,
+    )
+
+    assert len(result.next_items) == 2
+    # High salience/staleness item must rank first
+    assert result.next_items[0].commitment_id == "c-next-high"
+    assert result.next_items[1].commitment_id == "c-next-low"
+
+
+# ---------------------------------------------------------------------------
+# AC 2: waiting query exposes staleness metadata for operator follow-up
+# ---------------------------------------------------------------------------
+
+
+def test_waiting_query_exposes_staleness_metadata() -> None:
+    """Verify that waiting-state items expose staleness metadata in operator_summary."""
+    commitments = (
+        CommitmentRecord(
+            commitment_id="c-wait-fresh",
+            commitment_kind="waiting",
+            state="waiting",
+            summary="Fresh waiting item",
+        ),
+        CommitmentRecord(
+            commitment_id="c-wait-stale",
+            commitment_kind="waiting",
+            state="waiting",
+            summary="Stale waiting item — needs follow-up",
+        ),
+    )
+    staleness_scores = {
+        "c-wait-fresh": 0.1,
+        "c-wait-stale": 0.95,
+    }
+
+    result = query_next_and_waiting_commitments(
+        commitments,
+        staleness_scores=staleness_scores,
+    )
+
+    assert len(result.waiting_items) == 2
+    # operator_summary must include staleness metadata for waiting items
+    assert "waiting_staleness" in result.operator_summary
+    staleness_map = result.operator_summary["waiting_staleness"]
+    assert isinstance(staleness_map, dict)
+    assert staleness_map.get("c-wait-stale") == 0.95
+    assert staleness_map.get("c-wait-fresh") == 0.1
+
+
+# ---------------------------------------------------------------------------
+# AC 3: query remains safe when salience/staleness signals are missing or partial
+# ---------------------------------------------------------------------------
+
+
+def test_query_allows_missing_signal_inputs() -> None:
+    """Verify graceful degradation when salience/staleness inputs are absent or partial.
+
+    The query must not raise and must return all next/waiting items without ranking
+    by signals that are absent.
+    """
+    commitments = (
+        CommitmentRecord(
+            commitment_id="c-next-1",
+            commitment_kind="next_action",
+            state="next",
+            summary="Next action, no signals",
+        ),
+        CommitmentRecord(
+            commitment_id="c-wait-1",
+            commitment_kind="waiting",
+            state="waiting",
+            summary="Waiting item, no signals",
+        ),
+    )
+
+    # No signals at all — must not raise
+    result_none = query_next_and_waiting_commitments(commitments)
+    assert len(result_none.next_items) == 1
+    assert len(result_none.waiting_items) == 1
+
+    # Partial salience only — must not raise
+    result_partial = query_next_and_waiting_commitments(
+        commitments,
+        salience_scores={"c-next-1": 0.7},
+    )
+    assert len(result_partial.next_items) == 1
+    assert len(result_partial.waiting_items) == 1
+
+    # Empty dicts — must not raise
+    result_empty = query_next_and_waiting_commitments(
+        commitments,
+        salience_scores={},
+        staleness_scores={},
+    )
+    assert len(result_empty.next_items) == 1
+    assert len(result_empty.waiting_items) == 1
+
+
+# ---------------------------------------------------------------------------
+# AC 4: returned surfaces remain commitment-typed (not note-state values)
+# ---------------------------------------------------------------------------
+
+
+def test_query_results_remain_commitment_typed() -> None:
+    """Verify that query results are CommitmentRecord objects, not note-state scalars.
+
+    Returned items must be CommitmentRecord instances and their state must come
+    from the commitment state vocabulary, not note-state axes.
+    """
+    from app.domain.commitments import CommitmentRecord, COMMITMENT_STATE_VALUES
+    from app.domain.state_axes import CANONICAL_REVIEW_STATES, CANONICAL_MATURITY_VALUES
+
+    note_axis_values = set(CANONICAL_REVIEW_STATES) | set(CANONICAL_MATURITY_VALUES)
+
+    commitments = (
+        CommitmentRecord(
+            commitment_id="c-next-typed",
+            commitment_kind="next_action",
+            state="next",
+            summary="Typed next action",
+        ),
+        CommitmentRecord(
+            commitment_id="c-wait-typed",
+            commitment_kind="waiting",
+            state="waiting",
+            summary="Typed waiting item",
+        ),
+    )
+
+    result = query_next_and_waiting_commitments(
+        commitments,
+        salience_scores={"c-next-typed": 0.5},
+        staleness_scores={"c-wait-typed": 0.6},
+    )
+
+    for item in result.next_items:
+        assert isinstance(item, CommitmentRecord), f"Expected CommitmentRecord, got {type(item)}"
+        assert item.state in COMMITMENT_STATE_VALUES, f"state '{item.state}' not in commitment vocabulary"
+        assert item.state not in note_axis_values, f"state '{item.state}' leaked note-axis value"
+
+    for item in result.waiting_items:
+        assert isinstance(item, CommitmentRecord), f"Expected CommitmentRecord, got {type(item)}"
+        assert item.state in COMMITMENT_STATE_VALUES, f"state '{item.state}' not in commitment vocabulary"
+        assert item.state not in note_axis_values, f"state '{item.state}' leaked note-axis value"


### PR DESCRIPTION
Fixes #695

## Summary

Adds optional `salience_scores` and `staleness_scores` keyword arguments to `query_next_and_waiting_commitments()` in `app/domain/commitments.py`. When signals are provided, next-state commitments are ranked by combined score; waiting-state items expose staleness metadata in `operator_summary`. Absent/partial signals degrade gracefully with no behaviour change for existing callers.

Parent feature: #688 (Priority 5 minimal commitment-runtime surface).

## Changes

- `app/domain/commitments.py` — extended `query_next_and_waiting_commitments()` with optional `salience_scores` / `staleness_scores` kwargs and helper `_salience_rank_score()`; results remain commitment-typed throughout.
- `tests/commitments/test_commitment_salience_queries.py` — 4 new tests covering all 4 ACs.

## Validation

```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/commitments/test_commitment_salience_queries.py
# 4 passed

PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/commitments/test_commitment_queries.py tests/commitments/test_commitment_state_boundaries.py
# 2 passed

PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/commitments/
# 21 passed, 0 regressions
```

All 4 AC `Verify:` targets green:
- [x] `test_next_query_consumes_salience_and_staleness`
- [x] `test_waiting_query_exposes_staleness_metadata`
- [x] `test_query_allows_missing_signal_inputs`
- [x] `test_query_results_remain_commitment_typed`

---