### PR TITLE
docs(commitments): promote commitment-runtime baseline claims in owner docs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -343,10 +343,13 @@ Tests: `tests/architecture/test_architecture_tests_validation.py::test_import_bo
 - Execution plans are runtime orchestration artifacts. They must not be read as equivalent to the
   human commitment/project layer described in `docs/PROJECT_KERNEL.md` and the commitment concept
   contracts.
-- Minimal commitment-runtime seam: runtime now includes a bounded commitment read model for
-  `next`/`waiting` surfacing plus governed commitment transition metadata that links transition
-  receipts (`before_state`, `after_state`, `cause`, `receipt_event_id`, `trace_id`) without
-  collapsing commitments into note `review_state`/`maturity` semantics.
+<!-- commitment-first-class -->
+- Commitment-runtime surface (delivered baseline): runtime includes a bounded commitment read
+  model for `next`/`waiting` surfacing, governed transition metadata linking receipts
+  (`before_state`, `after_state`, `cause`, `receipt_event_id`, `trace_id`), a receipt-governed
+  APPLY gate that rejects state mutations not on the APPLY path (PR #703, issue #694), and
+  optional salience/staleness signal consumption in commitment query ranking (PR #705, issue #695).
+  Commitments remain distinct from note `review_state`/`maturity` semantics.
 - Derived / overlay metadata: system-owned overlays such as `zone`, recency, or salience are computed from signals and remain outside the core contract.
 - Agent reasoning operates on Core-6 + state axes + policy profiles (see `docs/NOTE_KIND_POLICIES.md`) + derived overlays.
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -81,10 +81,14 @@ governed by
 - Retrieval capability seam: salience/staleness signal payload exists as an optional diagnostics
   seam and is emitted only on explicit opt-in. Runtime does not source staleness from persisted
   state-axis labels in artifact payload (`review_state`, `maturity`).
-- Commitment-runtime minimal slice: bounded `next`/`waiting` commitment query surfacing is present
-  in the domain layer, commitment state values remain distinct from note state axes, and
-  commitment-state transitions now carry receipt-linkage metadata through the governed transition
-  path.
+<!-- commitment-runtime-baseline -->
+- Commitment-runtime baseline: bounded `next`/`waiting` commitment query surfacing is present in
+  the domain layer; commitment state values remain distinct from note state axes; commitment-state
+  transitions carry receipt-linkage metadata and are gated through the receipt-governed APPLY path
+  — state mutations not on the APPLY path are rejected (PR #703, issue #694); and the commitment
+  query surface consumes optional salience/staleness signals for priority surfacing (PR #705,
+  issue #695). Verification: `tests/commitments/test_commitment_receipt_gate.py`,
+  `tests/commitments/test_commitment_salience_queries.py`.
 - Minimal concurrency guarantees: DedupTaskQueue + event_id dedup guard watcher runs, optimistic writes protect note updates, and the promotion consumer uses an EventDedupStore to skip duplicate intents (`docs/CONCURRENCY.md`, `app/promotion/consumer.py`).
 - Settings compiler scope: panel action catalog, watcher settings, and outbox paths now compile with provenance (path/mtime/sha) via `vault/@Settings/watchers.md`, `docs/settings/panel-actions.md`, `python -m app.cli settings-validate`, and `python -m app.cli settings-explain`.
 - Operator enablement signals: `python -m app.cli settings-explain` surfaces watcher auto-exec state, allowlist validity, provenance, and write-guard context; `python -m app.cli status` exposes the same gate, watcher automation counters, last tick skips, last-run skip reasons, and panel-action/compiler provenance (source paths, mtimes, combined digest). Treat `allowlist`, `dedup/skipped_*`, `panel_skipped_policy`, and `writes_allowed` as the safe-to-enable checklist, not just the raw `WATCHER_AUTO_EXEC` value.


### PR DESCRIPTION
Fixes #696

## Summary

Promotes the delivered commitment-runtime capability into owner docs now that all child slices (#694, #695) have merged:

- `docs/STATUS.md` — expands the commitment-runtime entry and adds `<!-- commitment-runtime-baseline -->` anchor, naming the APPLY gate (PR #703) and salience/staleness signal consumption (PR #705) with inline test verification pointers.
- `docs/ARCHITECTURE.md` — expands the minimal-seam entry and adds `<!-- commitment-first-class -->` anchor with the same evidence linkage.

Feature acceptance receipt posted on #688 linking both child slice receipts and verification commands.

## Validation
```
rg -n "commitment-runtime-baseline" docs/STATUS.md
rg -n "commitment-first-class" docs/ARCHITECTURE.md
```
Both anchors resolve. No code changes — docs lane only.