### PR TITLE
fix(test-up): wire test-vault-root and vault dir env vars for test channel startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ prod-down:
 	@$(COMPOSE_PROD) down --remove-orphans
 
 test-up:
-	@$(COMPOSE_TEST) up -d --build
+	@VAULT_ROOT="$(TEST_VAULT_ROOT)" $(COMPOSE_TEST) up -d --build
 
 test-down:
 	@$(COMPOSE_TEST) down --remove-orphans

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -12,15 +12,24 @@ services:
       PKM_ENVIRONMENT: prod
       DATABASE_URL: postgresql+psycopg://app:app@db:5432/app_test
       DB_DSN: postgresql+psycopg://app:app@db:5432/app_test
+      VAULT_SYSTEM_DIR_REL: "⚙️ System"
+      VAULT_INBOX_DIR_REL: "📥 Inbox"
+      VAULT_DESK_DIR_REL: "🛠️ Workbench"
 
   worker:
     environment:
       PKM_ENVIRONMENT: prod
       DATABASE_URL: postgresql+psycopg://app:app@db:5432/app_test
       DB_DSN: postgresql+psycopg://app:app@db:5432/app_test
+      VAULT_SYSTEM_DIR_REL: "⚙️ System"
+      VAULT_INBOX_DIR_REL: "📥 Inbox"
+      VAULT_DESK_DIR_REL: "🛠️ Workbench"
 
   watcher:
     environment:
       PKM_ENVIRONMENT: prod
       DATABASE_URL: postgresql+psycopg://app:app@db:5432/app_test
       DB_DSN: postgresql+psycopg://app:app@db:5432/app_test
+      VAULT_SYSTEM_DIR_REL: "⚙️ System"
+      VAULT_INBOX_DIR_REL: "📥 Inbox"
+      VAULT_DESK_DIR_REL: "🛠️ Workbench"

--- a/tests/quality_wave/test_bootstrap_start.py
+++ b/tests/quality_wave/test_bootstrap_start.py
@@ -122,14 +122,17 @@ class TestBootstrapStartContract:
         )
 
     def test_make_start_test_system_uses_test_vault_root(self) -> None:
-        """make start-test-system passes TEST_VAULT_ROOT as VAULT_ROOT."""
-        result = subprocess.run(
-            ["make", "--dry-run", "start-test-system"],
-            capture_output=True,
-            text=True,
-        )
-        assert result.returncode == 0
-        combined = result.stdout + result.stderr
-        assert "vault-test" in combined, (
-            f"Expected vault-test path in dry-run output; got: {combined[:500]}"
-        )
+        """make start-test-system and make test-up both pass TEST_VAULT_ROOT as VAULT_ROOT."""
+        for target in ("start-test-system", "test-up"):
+            result = subprocess.run(
+                ["make", "--dry-run", target],
+                capture_output=True,
+                text=True,
+            )
+            assert result.returncode == 0, (
+                f"make --dry-run {target} failed: {result.stderr}"
+            )
+            combined = result.stdout + result.stderr
+            assert "vault-test" in combined, (
+                f"Expected vault-test path in make --dry-run {target} output; got: {combined[:500]}"
+            )


### PR DESCRIPTION
Fixes #718

## Summary

`make test-up` was calling docker compose without setting `VAULT_ROOT`, causing the worker to mount the operator's default `./vault` instead of the isolated `./vault-test`. The worker then failed while processing `panel.scan.requested` events because the default vault either lacked `vault.layout.md` or had one with missing required fields.

Two-part fix:
- **Makefile**: `test-up` now passes `VAULT_ROOT="$(TEST_VAULT_ROOT)"` to the compose command, mirroring the pattern already used in `start-test-system` and `test-bootstrap`.
- **docker-compose.test.yml**: All three services (api, worker, watcher) now set `VAULT_SYSTEM_DIR_REL`, `VAULT_INBOX_DIR_REL`, and `VAULT_DESK_DIR_REL` to the default layout values so the worker can resolve vault layout even when `vault.layout.md` does not yet exist in the test vault root.

## Validation

- `tests/quality_wave/test_bootstrap_start.py::TestBootstrapStartContract::test_make_start_test_system_uses_test_vault_root` — updated to cover both `start-test-system` and `test-up`; fails before the Makefile fix, passes after.
- Full quality_wave test class: 2 passed, 3 skipped (docker-dependent, expected in CI).
- `make --dry-run test-up` now emits `VAULT_ROOT=".../vault-test"` confirming the wiring.
- Pre-existing `test_ask_cli_dry_run` failure confirmed unrelated to this change (fails on unmodified main).

---

> Dispatcher unavailable for issue #718 (dispatcher returned demo task #100 — state out of sync with GitHub). Used GitHub-label-only claim.