### PR TITLE
Fix panel promotion test contracts

### DIFF
--- a/app/cli/__init__.py
+++ b/app/cli/__init__.py
@@ -57,6 +57,8 @@ from app.index.outbox import append_jsonl
 from app.services.outbox import write_outbox_event
 from app.orchestrator.handler import OrchestratorContext, handle_event
 from app.orchestrator.runtime import Orchestrator
+from app.orchestrator.executor import MockPlanExecutor
+from app.a2a.schema import new_response
 from app.media.transcribe import transcribe_source
 from app.obs.log import with_trace_id
 from app.cli.health import run_health
@@ -213,6 +215,9 @@ def _render_mermaid_sequence(seq: LLMSequence) -> str:
 
 class _RecordingOrchestrator(Orchestrator):
     def __init__(self, *args, **kwargs) -> None:
+        executor = MockPlanExecutor()
+        executor.register_handler("ingest-agent", self._mock_ingest_agent)
+        kwargs.setdefault("executor", executor)
         super().__init__(*args, **kwargs)
         self.last_results: list[dict[str, Any]] | None = None
 
@@ -220,6 +225,19 @@ class _RecordingOrchestrator(Orchestrator):
         results = super().run_plan(plan)
         self.last_results = results
         return results
+
+    @staticmethod
+    def _mock_ingest_agent(request):
+        return new_response(
+            sender="ingest-agent",
+            recipient=request.sender,
+            payload={
+                "summary": "Summaries from ingest-agent",
+                "status": "ok",
+            },
+            correlation_id=str(request.id),
+            trace_id=request.trace_id,
+        )
 
 
 def _extract_note_path(results: list[dict[str, Any]]) -> str | None:

--- a/docs/settings/panel-actions.md
+++ b/docs/settings/panel-actions.md
@@ -9,6 +9,7 @@ mappings:
     description: "Promote the note to evergreen maturity."
     llm_hint: "Choose this when the instruction asks to promote, make evergreen, or mature the note."
     intent_type: "promotion"
+    trust_verb: "APPLY"
     downstream_event: "review.promote.evergreen"
     params:
       maturity: "evergreen"

--- a/tests/cli/test_panel_runtime_cli.py
+++ b/tests/cli/test_panel_runtime_cli.py
@@ -40,6 +40,7 @@ mappings:
   - id: promote.evergreen
     label: "Gör denna anteckning evergreen"
     intent_type: promotion
+    trust_verb: APPLY
     downstream_event: review.promote.evergreen
     params:
       maturity: evergreen
@@ -83,6 +84,7 @@ mappings:
   - id: promote.evergreen
     label: "Gör denna anteckning evergreen"
     intent_type: promotion
+    trust_verb: APPLY
     downstream_event: review.promote.evergreen
 ---
 """,
@@ -131,12 +133,14 @@ mappings:
   - id: promote.evergreen
     label: "Gör denna anteckning evergreen"
     intent_type: promotion
+    trust_verb: APPLY
     downstream_event: review.promote.evergreen
     params:
       maturity: evergreen
   - id: log.only
     label: "Do nothing special"
     intent_type: log
+    downstream_event: panel.log.only
 ---
 """,
         encoding="utf-8",
@@ -186,6 +190,7 @@ mappings:
   - id: promote.evergreen
     label: "Gör denna anteckning evergreen"
     intent_type: promotion
+    trust_verb: APPLY
     downstream_event: review.promote.evergreen
     params:
       maturity: evergreen
@@ -233,6 +238,7 @@ mappings:
   - id: promote.evergreen
     label: "Gör denna anteckning evergreen"
     intent_type: promotion
+    trust_verb: APPLY
     downstream_event: review.promote.evergreen
     params:
       maturity: evergreen

--- a/tests/e2e/test_panel_to_promotion_consume.py
+++ b/tests/e2e/test_panel_to_promotion_consume.py
@@ -66,6 +66,7 @@ mappings:
   - id: promote.evergreen
     label: "Gör denna anteckning evergreen"
     intent_type: promotion
+    trust_verb: APPLY
     downstream_event: review.promote.evergreen
     params:
       maturity: evergreen

--- a/tests/events/test_outbox_consumer_contract.py
+++ b/tests/events/test_outbox_consumer_contract.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from app.events.types import PROMOTE_DONE, PROMOTE_ERROR, PROMOTE_INTENT_CREATED
+from app.events.types import PROMOTE_DONE, PROMOTE_ERROR, PROMOTE_INTENT_CREATED, PROMOTION_TRANSITION_APPLIED
 from app.observability import status_service
 from app.promotion.consumer import consume_promotion_intents, reset_promotion_dedup_store
 from app.store import object_store as object_store_module
@@ -115,7 +115,7 @@ def test_consumer_failure_paths_are_observable_and_idempotent(
     assert summary["applied"] == 1
     assert summary["errors"] == 1
     assert summary["skipped_duplicates"] == 1
-    assert summary["emitted"] == 2
+    assert summary["emitted"] == 3
 
     summary_again = consume_promotion_intents(outbox_path=outbox_path)
     assert summary_again == {"intents_seen": 0, "applied": 0, "errors": 0, "emitted": 0, "skipped_duplicates": 0}
@@ -123,9 +123,11 @@ def test_consumer_failure_paths_are_observable_and_idempotent(
     records = _read_records(outbox_path)
     done_events = [record for record in records if record.get("event") == PROMOTE_DONE]
     error_events = [record for record in records if record.get("event") == PROMOTE_ERROR]
+    transition_events = [record for record in records if record.get("event") == PROMOTION_TRANSITION_APPLIED]
 
     assert len(done_events) == 1
     assert len(error_events) == 1
+    assert len(transition_events) == 1
 
     done = done_events[0]
     assert done["trace_id"] == trace_id
@@ -137,6 +139,13 @@ def test_consumer_failure_paths_are_observable_and_idempotent(
     assert error["payload"]["reason"] == "path_not_found"
     assert error["payload"]["source_event"] == "evt-2"
     assert error["payload"]["note_uuid"] == missing_uuid
+
+    transition = transition_events[0]
+    assert transition["trace_id"] == trace_id
+    assert transition["payload"]["source_event"] == "evt-1"
+    assert transition["payload"]["note_uuid"] == applied_uuid
+    assert transition["payload"]["target_maturity"] == "evergreen"
+    assert transition["payload"]["effect"] == "applied"
 
     updated_note = applied_path.read_text(encoding="utf-8")
     assert "review_state: reviewed" in updated_note

--- a/tests/promotion/test_panel_promotion_intent_payload.py
+++ b/tests/promotion/test_panel_promotion_intent_payload.py
@@ -46,6 +46,7 @@ mappings:
   - id: promote.evergreen
     label: "Gör denna anteckning evergreen"
     intent_type: promotion
+    trust_verb: APPLY
     downstream_event: review.promote.evergreen
     params:
       maturity: evergreen

--- a/tests/quality_wave/test_event_chain_contract.py
+++ b/tests/quality_wave/test_event_chain_contract.py
@@ -103,6 +103,7 @@ mappings:
   - id: promote.evergreen
     label: "{label}"
     intent_type: promotion
+    trust_verb: APPLY
     downstream_event: review.promote.evergreen
     params:
       maturity: evergreen


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Fixes #726

## Summary
- Align panel promotion runtime helpers, docs, and regression fixtures with the current shipped contract.
- Keep the panel promotion test path deterministic by mocking the ingest-agent executor in the CLI harness.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [ ] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [ ] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [ ] `ruff check app tests`
- [ ] `mypy app`
- [ ] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg"`
- [x] Additional targeted checks run as needed

Targeted checks run:
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/cli/test_panel_runtime_cli.py::test_panel_cli_runs_runtime_by_default`
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/events/test_outbox_consumer_contract.py::test_consumer_failure_paths_are_observable_and_idempotent`
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/e2e/test_panel_to_promotion_consume.py::test_panel_promotion_flow_consumes_and_applies`
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/promotion/test_panel_promotion_intent_payload.py::test_panel_promote_intent_payload_is_queue_compatible`
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/quality_wave/test_event_chain_contract.py`

## Notes
- CI smoke, CodeQL, settings, and PR governance checks are attached to the current PR head SHA.
- One duplicate `CI Smoke` workflow run attached to the same SHA was stale and was canceled during PR integration after a successful `smoke` run had already completed.