### PR TITLE
Remediate Dependabot alert #22 (python-dotenv CVE-2026-28684)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ pydantic-settings==2.6.1
 pydantic_core==2.41.1
 pytest==9.0.3
 pytest-cov==5.0.0
-python-dotenv==1.1.1
+python-dotenv>=1.2.2
 PyYAML==6.0.3
 requests==2.33.0
 requests-toolbelt==1.0.0


### PR DESCRIPTION
Fixes #725

## Summary
Updated python-dotenv from 1.1.1 to >=1.2.2 to remediate CVE-2026-28684 (GHSA-mf9w-mj56-hr94) reported in Dependabot alert #22.

## Validation
- Ran 20 environment/config integration tests: all pass
- Verified startup behavior unchanged
- No behavioral changes expected

## Files Changed
- requirements.txt: python-dotenv version constraint updated

---