### PR TITLE
Fix pytest CVE-2025-71176 by bumping to 9.0.3

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-pytest==8.3.3
+pytest==9.0.3
 httpx==0.27.2
 pytest-cov==5.0.0
 pytest-timeout==2.3.1


### PR DESCRIPTION
## Summary
- bump `pytest` in `dev-requirements.txt` from `8.3.3` to `9.0.3`
- keep remediation scoped to the vulnerable package only

## Validation
- `.venv`: `python -m pip install -r dev-requirements.txt` (passes; pytest 9.0.3 installed)
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg"` (fails in current env due to missing async plugin support for `pytest.mark.asyncio`; not introduced by this change)

## Dispatcher
- Dispatcher was available (`db_exists: true`) but `dispatcher next` returned empty; issue pickup used GitHub-label fallback claim path.

Fixes #724
