### PR TITLE
Add Companion UI design handoff package and owner-doc references

### DIFF
--- a/companion-ui/design-handoff/2026-05-03-converse/Companion UI Wireframes.html
+++ b/companion-ui/design-handoff/2026-05-03-converse/Companion UI Wireframes.html
@@ -1,0 +1,1472 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Companion UI — Wireframes</title>
+<link rel="stylesheet" href="colors_and_type.css">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Kalam:wght@300;400;700&display=swap" rel="stylesheet">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<style>
+  html, body, #root { height: 100%; margin: 0; }
+  body { background: var(--bg-base); overflow: hidden; }
+  * { box-sizing: border-box; }
+  ::-webkit-scrollbar { width: 4px; }
+  ::-webkit-scrollbar-track { background: transparent; }
+  ::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 2px; }
+
+  .anno { font-family: 'Kalam', cursive; font-weight: 400; color: var(--accent); }
+  .anno-dim { font-family: 'Kalam', cursive; font-weight: 300; color: var(--fg-3); }
+
+  /* sketchy dashed border for placeholder regions */
+  .sketch-border { border: 1.5px dashed var(--border-strong) !important; }
+
+  @keyframes dotpulse {
+    0%,100% { opacity: 0.3; transform: scale(0.85); }
+    50% { opacity: 1; transform: scale(1); }
+  }
+  @keyframes bloom {
+    from { opacity: 0; transform: scaleX(0.85); }
+    to   { opacity: 1; transform: scaleX(1); }
+  }
+</style>
+</head>
+<body>
+<div id="root"></div>
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel">
+
+/* ─── shared sketch primitives ─────────────────────────── */
+
+const T = {
+  hand: { fontFamily: "'Kalam', cursive" },
+  mono: { fontFamily: 'var(--font-mono)' },
+  ui:   { fontFamily: 'var(--font-ui)' },
+  disp: { fontFamily: 'var(--font-display)' },
+};
+
+// Text block placeholder
+function Block({ w = '100%', h = 8, color = 'var(--border-strong)', style = {} }) {
+  return <div style={{ width: w, height: h, background: color, borderRadius: 2, ...style }} />;
+}
+
+// Stacked text lines placeholder
+function TextLines({ lines = 3, w = '100%', lastW = '70%', h = 7, gap = 7, color }) {
+  const c = color || 'var(--border-strong)';
+  return (
+    <div style={{ display:'flex', flexDirection:'column', gap }}>
+      {Array.from({length: lines}).map((_, i) =>
+        <Block key={i} w={i === lines-1 ? lastW : w} h={h} color={c} />
+      )}
+    </div>
+  );
+}
+
+// Annotation arrow + label
+function Anno({ children, style = {}, dim = false }) {
+  return (
+    <div style={{ ...T.hand, fontSize: 12, color: dim ? 'var(--fg-3)' : 'var(--accent)',
+      lineHeight: 1.3, ...style }}>
+      {children}
+    </div>
+  );
+}
+
+// Annotation callout bubble
+function Callout({ children, style = {} }) {
+  return (
+    <div style={{ background: 'rgba(212,168,67,0.06)', border: '1px dashed rgba(212,168,67,0.3)',
+      borderRadius: 4, padding: '5px 9px', ...T.hand, fontSize: 11, color: 'var(--accent)',
+      lineHeight: 1.4, maxWidth: 180, ...style }}>
+      {children}
+    </div>
+  );
+}
+
+// Tiny icon stand-in
+function IconBox({ size = 14, color = 'var(--fg-3)' }) {
+  return <div style={{ width: size, height: size, borderRadius: 2,
+    background: 'transparent', border: `1.5px solid ${color}`, flexShrink: 0 }} />;
+}
+
+// Divider
+function Div({ vertical = false, style = {} }) {
+  return <div style={vertical
+    ? { width: 1, alignSelf: 'stretch', background: 'var(--border)', ...style }
+    : { height: 1, width: '100%', background: 'var(--border)', ...style }} />;
+}
+
+/* ─── WF-A: Split Pane ──────────────────────────────────── */
+
+function WireframeA() {
+  const bg = { background: 'var(--bg-base)' };
+
+  /* left session rail */
+  const SessionRail = () => (
+    <div style={{ width: 208, height: '100%', background: 'var(--bg-surface)',
+      borderRight: '1px solid var(--border)', display: 'flex', flexDirection: 'column',
+      flexShrink: 0 }}>
+      {/* wordmark */}
+      <div style={{ padding: '14px 14px 10px', borderBottom: '1px solid var(--border)' }}>
+        <div style={{ ...T.disp, fontSize: 18, color: 'var(--fg-1)', letterSpacing: '-0.02em' }}>Yggdrasil</div>
+        <div style={{ ...T.mono, fontSize: 9, color: 'var(--fg-3)', marginTop: 2, letterSpacing: '0.1em', textTransform: 'uppercase' }}>v0 · Converse</div>
+      </div>
+      {/* nav */}
+      <div style={{ padding: '8px 6px' }}>
+        {['Converse','Orient','Capture','Synthesize','Resurface'].map((label, i) => (
+          <div key={label} style={{ display: 'flex', alignItems: 'center', gap: 8,
+            padding: '6px 8px', borderRadius: 3, marginBottom: 1,
+            background: i === 0 ? 'rgba(0,212,232,0.05)' : 'transparent',
+            border: i === 0 ? '1px solid rgba(0,212,232,0.2)' : '1px solid transparent' }}>
+            <IconBox size={12} color={i === 0 ? 'var(--cyan)' : 'var(--fg-3)'} />
+            <span style={{ ...T.ui, fontSize: 12, color: i === 0 ? 'var(--cyan)' : 'var(--fg-2)',
+              fontWeight: i === 0 ? 500 : 400 }}>{label}</span>
+            {i > 0 && <span style={{ ...T.mono, fontSize: 8, color: 'var(--fg-3)', marginLeft: 'auto',
+              background: 'var(--bg-raised)', border: '1px solid var(--border-strong)',
+              borderRadius: 2, padding: '1px 4px' }}>soon</span>}
+          </div>
+        ))}
+      </div>
+      <Div />
+      {/* sessions */}
+      <div style={{ padding: '8px 12px 4px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <span style={{ ...T.mono, fontSize: 9, color: 'var(--fg-3)', letterSpacing: '0.1em', textTransform: 'uppercase' }}>Sessions</span>
+        <div style={{ width: 12, height: 12, border: '1.5px solid var(--cyan)', borderRadius: 2 }} />
+      </div>
+      <div style={{ padding: '0 8px 6px' }}>
+        <div style={{ background: 'var(--bg-raised)', border: '1px solid var(--border-strong)',
+          borderRadius: 2, padding: '4px 8px 4px 22px', position: 'relative' }}>
+          <div style={{ position: 'absolute', left: 7, top: '50%', transform: 'translateY(-50%)' }}>
+            <IconBox size={10} color="var(--fg-3)" />
+          </div>
+          <Block w="80%" h={6} color="var(--bg-overlay)" />
+        </div>
+      </div>
+      <div style={{ flex: 1, overflowY: 'auto', padding: '0 6px' }}>
+        {[
+          { title: 'Q2 architecture review', path: 'Projects/Q2-arch.md', age: '2h ago', active: true },
+          { title: 'On the architecture of memory', path: 'Writing/memory-essay.md', age: '3d ago', active: false },
+          { title: 'Thornwall — session 12 prep', path: 'RPG/Thornwall/session-12.md', age: '1w ago', active: false },
+          { title: 'Weekly review 2026-W17', path: 'Reviews/2026-W17.md', age: '5d ago', active: false },
+        ].map(s => (
+          <div key={s.title} style={{ padding: '7px 8px', borderRadius: 2, marginBottom: 2,
+            background: s.active ? 'rgba(212,168,67,0.05)' : 'transparent',
+            border: `1px solid ${s.active ? 'rgba(212,168,67,0.3)' : 'transparent'}` }}>
+            <div style={{ ...T.ui, fontSize: 11, color: s.active ? 'var(--accent)' : 'var(--fg-2)',
+              fontWeight: s.active ? 500 : 400,
+              whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', marginBottom: 2 }}>
+              {s.title}
+            </div>
+            <div style={{ ...T.mono, fontSize: 9, color: 'var(--fg-3)',
+              whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+              {s.path} · {s.age}
+            </div>
+          </div>
+        ))}
+      </div>
+      {/* vault status */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px',
+        borderTop: '1px solid var(--border)', background: 'var(--bg-surface)' }}>
+        <div style={{ width: 5, height: 5, borderRadius: '50%', background: 'var(--vault)',
+          boxShadow: '0 0 5px var(--vault)', flexShrink: 0 }} />
+        <span style={{ ...T.mono, fontSize: 9, color: 'var(--vault)' }}>Vault online</span>
+      </div>
+    </div>
+  );
+
+  /* center thread */
+  const Thread = () => (
+    <div style={{ width: 400, height: '100%', display: 'flex', flexDirection: 'column',
+      borderRight: '1px solid var(--border)', background: 'var(--bg-base)', flexShrink: 0 }}>
+      {/* session header */}
+      <div style={{ padding: '10px 16px', borderBottom: '1px solid var(--border)',
+        background: 'rgba(7,11,18,0.9)', flexShrink: 0 }}>
+        <div style={{ ...T.disp, fontSize: 15, color: 'var(--fg-1)', letterSpacing: '-0.01em', marginBottom: 3 }}>
+          Q2 architecture review
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ ...T.mono, fontSize: 9, color: 'var(--cyan)', opacity: 0.7 }}>Projects/Q2-arch.md</span>
+          <span style={{ ...T.mono, fontSize: 8, color: 'var(--fg-3)' }}>18 turns · 2h ago</span>
+          <span style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 4,
+            padding: '2px 6px', background: 'var(--vault-muted)', border: '1px solid var(--vault-dim)',
+            borderRadius: 2 }}>
+            <div style={{ width: 4, height: 4, borderRadius: '50%', background: 'var(--vault)' }} />
+            <span style={{ ...T.mono, fontSize: 8, color: 'var(--vault)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>indexed</span>
+          </span>
+        </div>
+      </div>
+      {/* messages */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: '16px 16px', display: 'flex',
+        flexDirection: 'column', gap: 14,
+        backgroundImage: 'linear-gradient(rgba(0,212,232,0.02) 1px, transparent 1px), linear-gradient(90deg, rgba(0,212,232,0.02) 1px, transparent 1px)',
+        backgroundSize: '32px 32px' }}>
+        {/* human */}
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 3 }}>
+          <div style={{ background: 'var(--bg-raised)', border: '1px solid var(--border-strong)',
+            borderRadius: '4px 4px 1px 4px', padding: '8px 12px', maxWidth: 280 }}>
+            <TextLines lines={2} h={7} w="100%" lastW="55%" color="var(--fg-2)" />
+          </div>
+          <span style={{ ...T.mono, fontSize: 9, color: 'var(--fg-3)' }}>09:14</span>
+        </div>
+        {/* agent */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 3, maxWidth: 300 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+            <IconBox size={10} color="var(--agent)" />
+            <span style={{ ...T.mono, fontSize: 9, color: 'var(--agent)', textTransform: 'uppercase', letterSpacing: '0.08em' }}>Hugin</span>
+          </div>
+          <div style={{ background: 'var(--agent-muted)', border: '1px solid var(--agent-dim)',
+            borderLeft: '2px solid var(--agent)', borderRadius: '1px 4px 4px 4px',
+            padding: '8px 12px' }}>
+            <TextLines lines={3} h={7} w="100%" lastW="60%" color="rgba(74,158,255,0.25)" />
+          </div>
+          <div style={{ display: 'flex', gap: 4 }}>
+            <div style={{ ...T.mono, fontSize: 9, padding: '2px 6px',
+              background: 'var(--cyan-muted)', border: '1px solid var(--cyan-dim)',
+              borderRadius: 2, color: 'var(--cyan)', display: 'flex', alignItems: 'center', gap: 3 }}>
+              <IconBox size={8} color="var(--cyan)" /> Projects/Q2-arch.md
+            </div>
+          </div>
+        </div>
+        {/* human */}
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 3 }}>
+          <div style={{ background: 'var(--bg-raised)', border: '1px solid var(--border-strong)',
+            borderRadius: '4px 4px 1px 4px', padding: '8px 12px', maxWidth: 260 }}>
+            <TextLines lines={2} h={7} w="100%" lastW="40%" color="var(--fg-2)" />
+          </div>
+        </div>
+        {/* suggestion block */}
+        <div style={{ background: 'var(--agent-muted)', border: '1px solid var(--agent-dim)',
+          borderLeft: '2px solid var(--amber)', borderRadius: 3, padding: '10px 12px', maxWidth: 310 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 5, marginBottom: 7 }}>
+            <IconBox size={9} color="var(--amber)" />
+            <span style={{ ...T.mono, fontSize: 9, color: 'var(--amber)', textTransform: 'uppercase', letterSpacing: '0.1em' }}>Suggested edit</span>
+          </div>
+          <TextLines lines={2} h={7} w="100%" lastW="75%" color="rgba(240,144,48,0.2)" />
+          <div style={{ display: 'flex', gap: 6, marginTop: 10 }}>
+            <div style={{ padding: '3px 10px', border: '1px solid var(--amber)', borderRadius: 2,
+              ...T.ui, fontSize: 11, color: 'var(--amber)' }}>Apply to note</div>
+            <div style={{ padding: '3px 10px', border: '1px solid var(--border-strong)', borderRadius: 2,
+              ...T.ui, fontSize: 11, color: 'var(--fg-3)' }}>Discard</div>
+          </div>
+        </div>
+        {/* thinking */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+            <IconBox size={10} color="var(--agent)" />
+            <span style={{ ...T.mono, fontSize: 9, color: 'var(--agent)', textTransform: 'uppercase', letterSpacing: '0.08em' }}>Hugin</span>
+            {[0,1,2].map(i => <span key={i} style={{ width: 4, height: 4, borderRadius: '50%',
+              background: 'var(--agent)', animation: `dotpulse 1.4s ease ${i*0.2}s infinite` }} />)}
+          </div>
+        </div>
+      </div>
+      {/* staged bar */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '6px 12px',
+        background: 'var(--amber-muted)', borderTop: '1px solid var(--amber-dim)', flexShrink: 0 }}>
+        <div style={{ width: 5, height: 5, borderRadius: '50%', background: 'var(--amber)',
+          boxShadow: '0 0 6px var(--amber)' }} />
+        <span style={{ ...T.mono, fontSize: 10, color: 'var(--amber)' }}>Staged —</span>
+        <span style={{ ...T.mono, fontSize: 10, color: 'var(--fg-3)', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>Projects/Q2-arch.md</span>
+        <div style={{ padding: '2px 8px', border: '1px solid var(--amber-dim)', borderRadius: 2, ...T.ui, fontSize: 11, color: 'var(--amber)' }}>Apply</div>
+        <div style={{ padding: '2px 8px', border: '1px solid var(--border-strong)', borderRadius: 2, ...T.ui, fontSize: 11, color: 'var(--fg-3)' }}>Discard</div>
+      </div>
+      {/* composer */}
+      <div style={{ padding: '8px 12px 10px', borderTop: '1px solid var(--border)',
+        background: 'rgba(7,11,18,0.9)', flexShrink: 0 }}>
+        <div style={{ background: 'var(--bg-raised)', border: '1px solid rgba(0,212,232,0.2)',
+          borderRadius: 4, padding: '8px 10px', display: 'flex', gap: 8, alignItems: 'center' }}>
+          <Block w="100%" h={7} color="var(--bg-overlay)" style={{ flex: 1 }} />
+          <div style={{ padding: '4px 12px', border: '1px solid var(--cyan)', borderRadius: 2,
+            ...T.ui, fontSize: 11, color: 'var(--cyan)', flexShrink: 0 }}>Send</div>
+        </div>
+        <div style={{ ...T.mono, fontSize: 9, color: 'var(--fg-3)', textAlign: 'right', marginTop: 4 }}>↵ send · ⇧↵ newline</div>
+      </div>
+    </div>
+  );
+
+  /* right document pane */
+  const DocPane = () => (
+    <div style={{ flex: 1, height: '100%', display: 'flex', flexDirection: 'column',
+      background: 'var(--bg-base)' }}>
+      {/* doc header */}
+      <div style={{ padding: '10px 16px', borderBottom: '1px solid var(--border)',
+        background: 'rgba(7,11,18,0.9)', flexShrink: 0, display: 'flex', alignItems: 'center', gap: 10 }}>
+        <IconBox size={12} color="var(--fg-3)" />
+        <span style={{ ...T.mono, fontSize: 10, color: 'var(--fg-2)' }}>Projects/Q2-architecture.md</span>
+        <span style={{ ...T.mono, fontSize: 9, color: 'var(--vault)', marginLeft: 4,
+          display: 'flex', alignItems: 'center', gap: 4 }}>
+          <div style={{ width: 4, height: 4, borderRadius: '50%', background: 'var(--vault)' }} />
+          indexed 2h ago
+        </span>
+        <div style={{ marginLeft: 'auto', display: 'flex', gap: 8 }}>
+          <div style={{ padding: '3px 8px', border: '1px solid var(--border-strong)', borderRadius: 2,
+            ...T.mono, fontSize: 9, color: 'var(--fg-3)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>open in obsidian</div>
+        </div>
+      </div>
+      {/* markdown view */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: '24px 32px', display: 'flex', flexDirection: 'column', gap: 16 }}>
+        {/* frontmatter */}
+        <div style={{ background: 'var(--bg-raised)', border: '1px solid var(--border)',
+          borderRadius: 3, padding: '10px 14px' }}>
+          <div style={{ ...T.mono, fontSize: 10, color: 'var(--fg-3)', marginBottom: 6 }}>---</div>
+          {['title: Q2 architecture review', 'tags: [architecture, decisions]', 'status: active', 'last-session: 2026-04-24'].map(line => (
+            <div key={line} style={{ ...T.mono, fontSize: 10, color: 'var(--fg-3)', marginBottom: 2 }}>{line}</div>
+          ))}
+          <div style={{ ...T.mono, fontSize: 10, color: 'var(--fg-3)', marginTop: 4 }}>---</div>
+        </div>
+        {/* staged highlight */}
+        <div style={{ background: 'rgba(240,144,48,0.04)', border: '1px solid rgba(240,144,48,0.15)',
+          borderLeft: '3px solid var(--amber)', borderRadius: '0 3px 3px 0', padding: '10px 14px' }}>
+          <div style={{ ...T.mono, fontSize: 9, color: 'var(--amber)', textTransform: 'uppercase',
+            letterSpacing: '0.08em', marginBottom: 6 }}>## Decision record · staged changes</div>
+          <TextLines lines={3} h={7} w="100%" lastW="50%" color="rgba(240,144,48,0.15)" />
+          <div style={{ marginTop: 8, display: 'flex', gap: 6 }}>
+            <div style={{ padding: '2px 8px', border: '1px solid var(--amber-dim)', borderRadius: 2,
+              ...T.ui, fontSize: 11, color: 'var(--amber)' }}>Apply</div>
+            <div style={{ padding: '2px 8px', border: '1px solid var(--border-strong)', borderRadius: 2,
+              ...T.ui, fontSize: 11, color: 'var(--fg-3)' }}>Discard</div>
+          </div>
+        </div>
+        {/* normal content */}
+        {['## Current state', '### Network boundary', null, '### Runtime contract'].map((h, i) => (
+          <div key={i}>
+            {h && <div style={{ ...T.disp, fontSize: h.startsWith('##') ? 17 : 14,
+              color: 'var(--fg-1)', marginBottom: 8 }}>{h}</div>}
+            <TextLines lines={h ? 3 : 2} h={7} w="100%" lastW="65%" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+
+  return (
+    <div style={{ width: 1194, height: 834, display: 'flex', ...bg, position: 'relative', overflow: 'hidden' }}>
+      <SessionRail />
+      <Thread />
+      <DocPane />
+      {/* annotations */}
+      <div style={{ position: 'absolute', top: 20, left: 215, pointerEvents: 'none' }}>
+        <Anno style={{ fontSize: 11 }}>← session rail<br/>collapses on narrow viewport</Anno>
+      </div>
+      <div style={{ position: 'absolute', top: 20, left: 430, pointerEvents: 'none', textAlign: 'center' }}>
+        <Anno style={{ fontSize: 11 }}>conversation thread<br/>(400px) →</Anno>
+      </div>
+      <div style={{ position: 'absolute', top: 20, right: 20, pointerEvents: 'none', textAlign: 'right' }}>
+        <Anno style={{ fontSize: 11 }}>← artifact/document pane<br/>always present, fills rest</Anno>
+      </div>
+      <div style={{ position: 'absolute', bottom: 120, left: 450, pointerEvents: 'none' }}>
+        <Callout>staged bar sits between thread + composer — amber signals uncommitted state</Callout>
+      </div>
+      <div style={{ position: 'absolute', bottom: 120, right: 20, pointerEvents: 'none' }}>
+        <Callout>suggestion appears in doc pane with amber left-border + inline Apply/Discard</Callout>
+      </div>
+    </div>
+  );
+}
+
+/* ─── WF-B: Timeline Bloom ──────────────────────────────── */
+
+function WireframeB() {
+  return (
+    <div style={{ width: 1194, height: 834, background: 'var(--bg-base)', display: 'flex',
+      overflow: 'hidden', position: 'relative' }}>
+      {/* icon rail — minimal, 52px */}
+      <div style={{ width: 52, height: '100%', background: 'var(--bg-surface)',
+        borderRight: '1px solid var(--border)', display: 'flex', flexDirection: 'column',
+        alignItems: 'center', padding: '14px 0', gap: 12, flexShrink: 0 }}>
+        {/* logo mark */}
+        <svg width="22" height="28" viewBox="0 0 40 50" fill="none" style={{ marginBottom: 4 }}>
+          <line x1="20" y1="9" x2="20" y2="38" stroke="#d4a843" strokeWidth="1.5" strokeLinecap="round"/>
+          <path d="M20 24 Q11 19 6 15" stroke="var(--border-strong)" strokeWidth="1.2" strokeLinecap="round" fill="none"/>
+          <path d="M20 24 Q29 19 34 15" stroke="var(--border-strong)" strokeWidth="1.2" strokeLinecap="round" fill="none"/>
+          <circle cx="20" cy="6" r="2" fill="#d4a843"/>
+        </svg>
+        {['msg','compass','plus','layers','refresh'].map((ic, i) => (
+          <div key={i} style={{ width: 32, height: 32, borderRadius: 3, display: 'flex',
+            alignItems: 'center', justifyContent: 'center',
+            background: i === 0 ? 'rgba(0,212,232,0.07)' : 'transparent',
+            border: i === 0 ? '1px solid rgba(0,212,232,0.2)' : '1px solid transparent' }}>
+            <IconBox size={14} color={i === 0 ? 'var(--cyan)' : 'var(--fg-3)'} />
+          </div>
+        ))}
+        {/* vault dot */}
+        <div style={{ marginTop: 'auto', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4 }}>
+          <div style={{ width: 6, height: 6, borderRadius: '50%', background: 'var(--vault)',
+            boxShadow: '0 0 6px var(--vault)' }} />
+          <span style={{ ...T.mono, fontSize: 7, color: 'var(--vault)', letterSpacing: '0.05em' }}>live</span>
+        </div>
+      </div>
+
+      {/* session list — narrow collapsible, 180px */}
+      <div style={{ width: 188, height: '100%', background: 'var(--bg-surface)',
+        borderRight: '1px solid var(--border)', display: 'flex', flexDirection: 'column', flexShrink: 0 }}>
+        <div style={{ padding: '12px 12px 8px', borderBottom: '1px solid var(--border)',
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <span style={{ ...T.mono, fontSize: 9, color: 'var(--fg-3)', textTransform: 'uppercase', letterSpacing: '0.1em' }}>Sessions</span>
+          <div style={{ width: 14, height: 14, border: '1.5px solid var(--cyan)', borderRadius: 2 }} />
+        </div>
+        <div style={{ flex: 1, overflowY: 'auto', padding: '6px' }}>
+          {[
+            { active: true, title: 'Q2 architecture review', age: '2h' },
+            { active: false, title: 'On the architecture of memory', age: '3d' },
+            { active: false, title: 'Thornwall — session 12', age: '1w' },
+            { active: false, title: 'Weekly review W17', age: '5d' },
+          ].map(s => (
+            <div key={s.title} style={{ padding: '7px 8px', borderRadius: 2, marginBottom: 2,
+              background: s.active ? 'rgba(212,168,67,0.05)' : 'transparent',
+              border: `1px solid ${s.active ? 'rgba(212,168,67,0.25)' : 'transparent'}` }}>
+              <div style={{ ...T.ui, fontSize: 11, color: s.active ? 'var(--accent)' : 'var(--fg-2)',
+                fontWeight: s.active ? 500 : 400, marginBottom: 2,
+                whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{s.title}</div>
+              <span style={{ ...T.mono, fontSize: 9, color: 'var(--fg-3)' }}>{s.age} ago</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* main timeline canvas */}
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+        {/* session header — minimal, 1 line */}
+        <div style={{ padding: '10px 20px', borderBottom: '1px solid var(--border)',
+          background: 'rgba(7,11,18,0.9)', display: 'flex', alignItems: 'center', gap: 12, flexShrink: 0 }}>
+          <div style={{ ...T.disp, fontSize: 16, color: 'var(--fg-1)', letterSpacing: '-0.01em' }}>Q2 architecture review</div>
+          <div style={{ ...T.mono, fontSize: 9, color: 'var(--cyan)', opacity: 0.6, marginLeft: 4 }}>Projects/Q2-arch.md</div>
+          <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 8 }}>
+            <div style={{ ...T.mono, fontSize: 9, color: 'var(--fg-3)' }}>18 turns</div>
+            <div style={{ width: 5, height: 5, borderRadius: '50%', background: 'var(--vault)', boxShadow: '0 0 5px var(--vault)' }} />
+          </div>
+        </div>
+
+        {/* thread + bloom zone */}
+        <div style={{ flex: 1, overflowY: 'auto', padding: '20px 20px',
+          backgroundImage: 'linear-gradient(rgba(0,212,232,0.02) 1px, transparent 1px), linear-gradient(90deg, rgba(0,212,232,0.02) 1px, transparent 1px)',
+          backgroundSize: '32px 32px', display: 'flex', flexDirection: 'column', gap: 14 }}>
+          {/* human turn */}
+          <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+            <div style={{ background: 'var(--bg-raised)', border: '1px solid var(--border-strong)',
+              borderRadius: '4px 4px 1px 4px', padding: '8px 12px', maxWidth: 400 }}>
+              <TextLines lines={2} h={7} lastW="55%" color="var(--fg-2)" />
+            </div>
+          </div>
+          {/* agent turn */}
+          <div style={{ maxWidth: 460 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 5, marginBottom: 4 }}>
+              <IconBox size={10} color="var(--agent)" />
+              <span style={{ ...T.mono, fontSize: 9, color: 'var(--agent)', textTransform: 'uppercase', letterSpacing: '0.08em' }}>Hugin</span>
+            </div>
+            <div style={{ background: 'var(--agent-muted)', border: '1px solid var(--agent-dim)',
+              borderLeft: '2px solid var(--agent)', borderRadius: '1px 4px 4px 4px', padding: '8px 12px' }}>
+              <TextLines lines={3} h={7} lastW="70%" color="rgba(74,158,255,0.22)" />
+            </div>
+            <div style={{ marginTop: 5, display: 'flex', gap: 5 }}>
+              <div style={{ ...T.mono, fontSize: 9, color: 'var(--fg-3)', cursor: 'pointer',
+                display: 'flex', alignItems: 'center', gap: 3 }}>
+                <IconBox size={8} color="var(--fg-3)" /> 2 sources ▸
+              </div>
+            </div>
+          </div>
+          {/* human turn */}
+          <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+            <div style={{ background: 'var(--bg-raised)', border: '1px solid var(--border-strong)',
+              borderRadius: '4px 4px 1px 4px', padding: '8px 12px', maxWidth: 340 }}>
+              <TextLines lines={1} h={7} w="90%" lastW="90%" color="var(--fg-2)" />
+            </div>
+          </div>
+
+          {/* ── THE BLOOM ── */}
+          {/* suggestion triggers bloom: conversation continues on left, artifact blooms right */}
+          <div style={{ display: 'flex', gap: 0, borderRadius: 4, overflow: 'hidden',
+            border: '1px solid var(--amber-dim)', animation: 'bloom 0.3s ease' }}>
+            {/* left: the suggestion message */}
+            <div style={{ flex: '0 0 44%', background: 'rgba(240,144,48,0.04)',
+              borderRight: '2px solid var(--amber)', padding: '12px 14px', display: 'flex', flexDirection: 'column', gap: 8 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+                <IconBox size={10} color="var(--amber)" />
+                <span style={{ ...T.mono, fontSize: 9, color: 'var(--amber)', textTransform: 'uppercase', letterSpacing: '0.1em' }}>Suggested edit · Hugin</span>
+              </div>
+              <TextLines lines={3} h={7} lastW="65%" color="rgba(240,144,48,0.18)" />
+              <div style={{ display: 'flex', gap: 6, marginTop: 2 }}>
+                <div style={{ padding: '3px 9px', border: '1px solid var(--amber)', borderRadius: 2,
+                  ...T.ui, fontSize: 11, color: 'var(--amber)' }}>Apply to note</div>
+                <div style={{ padding: '3px 9px', border: '1px solid var(--border-strong)', borderRadius: 2,
+                  ...T.ui, fontSize: 11, color: 'var(--fg-3)' }}>Discard</div>
+              </div>
+            </div>
+            {/* right: artifact preview */}
+            <div style={{ flex: 1, background: 'var(--bg-raised)', padding: '12px 14px', display: 'flex', flexDirection: 'column', gap: 8 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                <IconBox size={10} color="var(--vault)" />
+                <span style={{ ...T.mono, fontSize: 9, color: 'var(--vault)', letterSpacing: '0.04em' }}>Projects/Q2-arch.md · diff preview</span>
+              </div>
+              {/* diff preview */}
+              {[
+                { sign: '+', color: 'rgba(57,232,125,0.25)', text: 'rgba(57,232,125,0.4)' },
+                { sign: '+', color: 'rgba(57,232,125,0.25)', text: 'rgba(57,232,125,0.4)' },
+                { sign: '+', color: 'rgba(57,232,125,0.25)', text: 'rgba(57,232,125,0.4)' },
+                { sign: ' ', color: 'transparent', text: 'var(--border-strong)' },
+                { sign: ' ', color: 'transparent', text: 'var(--border-strong)' },
+              ].map((row, i) => (
+                <div key={i} style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                  <span style={{ ...T.mono, fontSize: 10, color: row.sign === '+' ? 'rgba(57,232,125,0.6)' : 'var(--fg-3)', width: 10, flexShrink: 0 }}>{row.sign}</span>
+                  <div style={{ height: 7, flex: 1, background: row.text, borderRadius: 2,
+                    outline: row.sign === '+' ? '1px solid rgba(57,232,125,0.1)' : 'none' }} />
+                </div>
+              ))}
+              <div style={{ ...T.mono, fontSize: 9, color: 'var(--fg-3)', marginTop: 2 }}>+3 lines, ~0 removed · estimated diff</div>
+            </div>
+          </div>
+
+          {/* conversation continues after the bloom */}
+          <div style={{ maxWidth: 420 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 5, marginBottom: 4 }}>
+              <IconBox size={10} color="var(--agent)" />
+              <span style={{ ...T.mono, fontSize: 9, color: 'var(--agent)', textTransform: 'uppercase', letterSpacing: '0.08em' }}>Hugin</span>
+              {[0,1,2].map(i => <span key={i} style={{ width: 4, height: 4, borderRadius: '50%',
+                background: 'var(--agent)', animation: `dotpulse 1.4s ease ${i*0.2}s infinite` }} />)}
+            </div>
+          </div>
+        </div>
+
+        {/* composer */}
+        <div style={{ padding: '8px 16px 12px', borderTop: '1px solid var(--border)',
+          background: 'rgba(7,11,18,0.9)', flexShrink: 0 }}>
+          <div style={{ background: 'var(--bg-raised)', border: '1px solid rgba(0,212,232,0.2)',
+            borderRadius: 4, padding: '8px 10px', display: 'flex', gap: 8, alignItems: 'center' }}>
+            <Block w="100%" h={7} color="var(--bg-overlay)" style={{ flex: 1 }} />
+            <div style={{ padding: '4px 12px', border: '1px solid var(--cyan)', borderRadius: 2,
+              ...T.ui, fontSize: 11, color: 'var(--cyan)', flexShrink: 0 }}>Send</div>
+          </div>
+        </div>
+      </div>
+
+      {/* annotations */}
+      <div style={{ position: 'absolute', top: 18, left: 55, pointerEvents: 'none' }}>
+        <Anno style={{ fontSize: 11 }}>icon rail<br/>(52px) ↓</Anno>
+      </div>
+      <div style={{ position: 'absolute', top: 18, left: 250, pointerEvents: 'none' }}>
+        <Anno style={{ fontSize: 11 }}>↑ session list, collapses<br/>to icon-only on mobile</Anno>
+      </div>
+      <div style={{ position: 'absolute', bottom: 240, right: 28, pointerEvents: 'none' }}>
+        <Callout style={{ maxWidth: 200 }}>bloom moment: suggestion + diff preview expand inline, side by side. no separate pane — the doc blooms from the conversation.</Callout>
+      </div>
+      <div style={{ position: 'absolute', bottom: 140, left: 300, pointerEvents: 'none' }}>
+        <Anno style={{ fontSize: 11 }}>conversation resumes below bloom ↓<br/>artifact pane closes after apply/discard</Anno>
+      </div>
+    </div>
+  );
+}
+
+/* ─── WF-C: Document-First ──────────────────────────────── */
+
+function WireframeC() {
+  return (
+    <div style={{ width: 1194, height: 834, background: 'var(--bg-base)', display: 'flex',
+      flexDirection: 'column', overflow: 'hidden', position: 'relative' }}>
+      {/* top bar */}
+      <div style={{ height: 40, borderBottom: '1px solid var(--border)',
+        background: 'rgba(7,11,18,0.95)', display: 'flex', alignItems: 'center',
+        padding: '0 16px', gap: 16, flexShrink: 0 }}>
+        <div style={{ ...T.disp, fontSize: 14, color: 'var(--fg-1)', letterSpacing: '-0.01em' }}>Yggdrasil</div>
+        <div style={{ height: 14, width: 1, background: 'var(--border)' }} />
+        {/* surface nav — top tab bar style */}
+        {['Converse','Orient','Capture','Synthesize','Resurface'].map((s, i) => (
+          <div key={s} style={{ display: 'flex', alignItems: 'center', gap: 5, padding: '0 2px',
+            borderBottom: i === 0 ? '2px solid var(--cyan)' : '2px solid transparent',
+            paddingBottom: 2 }}>
+            <IconBox size={10} color={i === 0 ? 'var(--cyan)' : 'var(--fg-3)'} />
+            <span style={{ ...T.ui, fontSize: 12, color: i === 0 ? 'var(--cyan)' : 'var(--fg-3)', fontWeight: i === 0 ? 500 : 400 }}>{s}</span>
+          </div>
+        ))}
+        <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 8 }}>
+          {/* session picker */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 5, padding: '3px 10px',
+            background: 'var(--bg-raised)', border: '1px solid var(--border-strong)', borderRadius: 2 }}>
+            <IconBox size={9} color="var(--accent)" />
+            <span style={{ ...T.ui, fontSize: 11, color: 'var(--accent)' }}>Q2 architecture review</span>
+            <span style={{ ...T.mono, fontSize: 9, color: 'var(--fg-3)' }}>▾</span>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 5, padding: '3px 8px',
+            background: 'var(--vault-muted)', border: '1px solid var(--vault-dim)', borderRadius: 2 }}>
+            <div style={{ width: 4, height: 4, borderRadius: '50%', background: 'var(--vault)', boxShadow: '0 0 4px var(--vault)' }} />
+            <span style={{ ...T.mono, fontSize: 9, color: 'var(--vault)' }}>indexed</span>
+          </div>
+        </div>
+      </div>
+
+      {/* body: doc + margin */}
+      <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+        {/* document area */}
+        <div style={{ flex: 1, overflowY: 'auto', padding: '36px 60px 36px 80px',
+          backgroundImage: 'linear-gradient(rgba(0,212,232,0.015) 1px, transparent 1px), linear-gradient(90deg, rgba(0,212,232,0.015) 1px, transparent 1px)',
+          backgroundSize: '32px 32px', position: 'relative' }}>
+          {/* frontmatter */}
+          <div style={{ background: 'var(--bg-raised)', border: '1px solid var(--border)',
+            borderRadius: 3, padding: '8px 12px', marginBottom: 24, ...T.mono, fontSize: 10,
+            color: 'var(--fg-3)', lineHeight: 1.7 }}>
+            ---<br/>
+            title: Q2 architecture review<br/>
+            tags: [architecture, decisions]<br/>
+            ---
+          </div>
+
+          {/* heading */}
+          <div style={{ ...T.disp, fontSize: 28, color: 'var(--fg-1)', fontWeight: 400,
+            letterSpacing: '-0.02em', marginBottom: 8 }}>Q2 architecture review</div>
+          <div style={{ height: 1, background: 'var(--border)', marginBottom: 20 }} />
+
+          {/* normal section */}
+          <div style={{ ...T.ui, fontSize: 13, color: 'var(--fg-3)', marginBottom: 6,
+            textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 500 }}>## Decision record</div>
+          <TextLines lines={4} h={8} w="100%" lastW="60%" color="var(--border-strong)" />
+          <div style={{ height: 16 }} />
+
+          {/* agent-highlighted section — inline annotation */}
+          <div style={{ position: 'relative' }}>
+            <div style={{ ...T.ui, fontSize: 13, color: 'var(--fg-3)', marginBottom: 6,
+              textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 500 }}>## Current state</div>
+            {/* highlight overlay */}
+            <div style={{ background: 'rgba(74,158,255,0.05)', border: '1px solid rgba(74,158,255,0.12)',
+              borderLeft: '2px solid var(--agent)', borderRadius: '0 3px 3px 0',
+              padding: '10px 12px', marginBottom: 8, position: 'relative' }}>
+              <TextLines lines={3} h={8} w="100%" lastW="55%" color="rgba(74,158,255,0.18)" />
+              {/* margin annotation marker */}
+              <div style={{ position: 'absolute', right: -20, top: '50%', transform: 'translateY(-50%)',
+                width: 10, height: 10, borderRadius: '50%',
+                background: 'var(--agent)', boxShadow: '0 0 6px var(--agent)' }} />
+            </div>
+            <TextLines lines={2} h={8} w="100%" lastW="80%" color="var(--border-strong)" />
+          </div>
+          <div style={{ height: 16 }} />
+
+          {/* staged section */}
+          <div style={{ background: 'rgba(240,144,48,0.04)', border: '1px solid rgba(240,144,48,0.15)',
+            borderLeft: '3px solid var(--amber)', borderRadius: '0 3px 3px 0',
+            padding: '10px 12px', position: 'relative' }}>
+            <div style={{ ...T.mono, fontSize: 9, color: 'var(--amber)', textTransform: 'uppercase',
+              letterSpacing: '0.08em', marginBottom: 6 }}>## Staged addition</div>
+            <TextLines lines={3} h={8} w="100%" lastW="45%" color="rgba(240,144,48,0.15)" />
+            <div style={{ position: 'absolute', right: -20, top: '50%', transform: 'translateY(-50%)',
+              width: 10, height: 10, borderRadius: '50%',
+              background: 'var(--amber)', boxShadow: '0 0 6px var(--amber)' }} />
+          </div>
+          <div style={{ height: 16 }} />
+          <div style={{ ...T.ui, fontSize: 13, color: 'var(--fg-3)', marginBottom: 6,
+            textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 500 }}>### Network boundary</div>
+          <TextLines lines={3} h={8} w="100%" lastW="70%" color="var(--border-strong)" />
+        </div>
+
+        {/* conversation margin */}
+        <div style={{ width: 320, height: '100%', background: 'var(--bg-surface)',
+          borderLeft: '1px solid var(--border)', display: 'flex', flexDirection: 'column', flexShrink: 0 }}>
+          {/* margin header */}
+          <div style={{ padding: '10px 12px', borderBottom: '1px solid var(--border)',
+            display: 'flex', alignItems: 'center', gap: 8 }}>
+            <IconBox size={11} color="var(--agent)" />
+            <span style={{ ...T.mono, fontSize: 10, color: 'var(--agent)', textTransform: 'uppercase', letterSpacing: '0.08em' }}>Hugin</span>
+            <span style={{ ...T.mono, fontSize: 9, color: 'var(--fg-3)', marginLeft: 'auto' }}>18 turns</span>
+            {/* collapse handle */}
+            <div style={{ width: 14, height: 14, border: '1px solid var(--border-strong)', borderRadius: 2,
+              display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <span style={{ ...T.mono, fontSize: 8, color: 'var(--fg-3)' }}>›</span>
+            </div>
+          </div>
+          {/* thread — compact */}
+          <div style={{ flex: 1, overflowY: 'auto', padding: '10px 10px', display: 'flex',
+            flexDirection: 'column', gap: 10 }}>
+            {/* agent annotation — linked to highlight */}
+            <div style={{ background: 'var(--agent-muted)', border: '1px solid var(--agent-dim)',
+              borderLeft: '2px solid var(--agent)', borderRadius: '1px 4px 4px 4px',
+              padding: '8px 10px' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 5, marginBottom: 5 }}>
+                <div style={{ width: 6, height: 6, borderRadius: '50%', background: 'var(--agent)', boxShadow: '0 0 5px var(--agent)' }} />
+                <span style={{ ...T.mono, fontSize: 8, color: 'var(--agent)', letterSpacing: '0.08em' }}>re: ## Current state</span>
+              </div>
+              <TextLines lines={3} h={6} w="100%" lastW="60%" color="rgba(74,158,255,0.2)" />
+            </div>
+            {/* human reply */}
+            <div style={{ background: 'var(--bg-raised)', border: '1px solid var(--border-strong)',
+              borderRadius: '4px 4px 1px 4px', padding: '8px 10px', alignSelf: 'flex-end', maxWidth: '90%' }}>
+              <TextLines lines={1} h={6} w="100%" lastW="100%" color="var(--fg-2)" />
+            </div>
+            {/* staged suggestion */}
+            <div style={{ background: 'rgba(240,144,48,0.05)', border: '1px solid var(--amber-dim)',
+              borderLeft: '2px solid var(--amber)', borderRadius: '1px 4px 4px 4px', padding: '8px 10px' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 5, marginBottom: 5 }}>
+                <div style={{ width: 6, height: 6, borderRadius: '50%', background: 'var(--amber)' }} />
+                <span style={{ ...T.mono, fontSize: 8, color: 'var(--amber)', letterSpacing: '0.08em' }}>suggested addition</span>
+              </div>
+              <TextLines lines={2} h={6} w="100%" lastW="70%" color="rgba(240,144,48,0.18)" />
+              <div style={{ display: 'flex', gap: 5, marginTop: 7 }}>
+                <div style={{ padding: '2px 7px', border: '1px solid var(--amber-dim)', borderRadius: 2,
+                  ...T.ui, fontSize: 10, color: 'var(--amber)' }}>Apply</div>
+                <div style={{ padding: '2px 7px', border: '1px solid var(--border-strong)', borderRadius: 2,
+                  ...T.ui, fontSize: 10, color: 'var(--fg-3)' }}>Discard</div>
+              </div>
+            </div>
+            {/* thinking */}
+            <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+              <IconBox size={9} color="var(--agent)" />
+              <span style={{ ...T.mono, fontSize: 8, color: 'var(--agent)', textTransform: 'uppercase', letterSpacing: '0.08em' }}>Hugin</span>
+              {[0,1,2].map(i => <span key={i} style={{ width: 3, height: 3, borderRadius: '50%',
+                background: 'var(--agent)', animation: `dotpulse 1.4s ease ${i*0.2}s infinite` }} />)}
+            </div>
+          </div>
+          {/* composer */}
+          <div style={{ padding: '8px 10px 10px', borderTop: '1px solid var(--border)',
+            background: 'rgba(7,11,18,0.9)', flexShrink: 0 }}>
+            <div style={{ background: 'var(--bg-raised)', border: '1px solid rgba(0,212,232,0.15)',
+              borderRadius: 3, padding: '6px 8px', display: 'flex', gap: 6, alignItems: 'center' }}>
+              <Block w="100%" h={6} color="var(--bg-overlay)" style={{ flex: 1 }} />
+              <div style={{ padding: '3px 9px', border: '1px solid var(--cyan)', borderRadius: 2,
+                ...T.ui, fontSize: 10, color: 'var(--cyan)', flexShrink: 0 }}>Send</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* annotations */}
+      <div style={{ position: 'absolute', top: 50, left: 12, pointerEvents: 'none' }}>
+        <Anno style={{ fontSize: 11 }}>top bar: surface nav<br/>+ session picker</Anno>
+      </div>
+      <div style={{ position: 'absolute', top: 180, left: 12, pointerEvents: 'none' }}>
+        <Anno style={{ fontSize: 11 }}>document fills<br/>the stage ↗</Anno>
+      </div>
+      <div style={{ position: 'absolute', top: 350, left: 12, pointerEvents: 'none' }}>
+        <Callout style={{ maxWidth: 160 }}>agent highlights passage, leaves a dot in the margin. click dot to jump to annotation in conversation rail.</Callout>
+      </div>
+      <div style={{ position: 'absolute', top: 50, right: 330, pointerEvents: 'none' }}>
+        <Anno style={{ fontSize: 11 }}>← conversation rail<br/>(320px, collapsible)</Anno>
+      </div>
+      <div style={{ position: 'absolute', bottom: 110, right: 326, pointerEvents: 'none' }}>
+        <Callout style={{ maxWidth: 160 }}>rail collapses to a thin strip (32px) with only the Hugin dot visible + unread count</Callout>
+      </div>
+    </div>
+  );
+}
+
+/* ─── Canvas root ───────────────────────────────────────── */
+
+/* ── C deep-dive shared palette ─────────────────────── */
+const muted = {
+  bg:          'var(--bg-base)',
+  surface:     'var(--bg-surface)',
+  raised:      'var(--bg-raised)',
+  border:      'var(--border)',
+  borderSm:    'var(--border-strong)',
+  fg1:         'var(--fg-1)',
+  fg2:         'var(--fg-2)',
+  fg3:         'var(--fg-3)',
+  agent:       'rgba(74,158,255,0.06)',
+  amber:       'rgba(240,144,48,0.07)',
+  amberAccent: '#f09030',
+  cyan:        'var(--cyan)',
+};
+
+function DocLine({ w = '100%', dim = false, last = false }) {
+  return <div style={{ height: 8, width: last ? '62%' : w,
+    background: dim ? 'rgba(61,85,112,0.5)' : 'var(--border-strong)',
+    borderRadius: 2, marginBottom: 7 }} />;
+}
+function DocPara({ lines = 3, dim = false }) {
+  return (
+    <div style={{ marginBottom: 16 }}>
+      {Array.from({length: lines}).map((_, i) =>
+        <DocLine key={i} last={i === lines - 1} dim={dim} />
+      )}
+    </div>
+  );
+}
+function DocH({ level = 2, dim = false }) {
+  const h = level === 1 ? 18 : level === 2 ? 13 : 10;
+  const w = level === 1 ? '55%' : level === 2 ? '38%' : '28%';
+  return <div style={{ height: h, width: w,
+    background: dim ? 'rgba(61,85,112,0.4)' : 'rgba(220,232,240,0.25)',
+    borderRadius: 2, marginBottom: 10, marginTop: level === 2 ? 14 : 8 }} />;
+}
+
+function CTopBar({ sessionTitle = 'Q2 architecture review', vaultOk = true }) {
+  return (
+    <div style={{ height: 38, borderBottom: `1px solid ${muted.border}`,
+      background: muted.surface, display: 'flex', alignItems: 'center',
+      padding: '0 14px', gap: 14, flexShrink: 0 }}>
+      <svg width="14" height="18" viewBox="0 0 40 50" fill="none" style={{ flexShrink: 0 }}>
+        <line x1="20" y1="9" x2="20" y2="38" stroke="var(--accent)" strokeWidth="1.5" strokeLinecap="round"/>
+        <path d="M20 24 Q11 19 6 15" stroke="var(--border-strong)" strokeWidth="1.2" strokeLinecap="round" fill="none"/>
+        <path d="M20 24 Q29 19 34 15" stroke="var(--border-strong)" strokeWidth="1.2" strokeLinecap="round" fill="none"/>
+        <circle cx="20" cy="6" r="2.5" fill="var(--accent)"/>
+      </svg>
+      {['Converse','Orient','Capture','Synthesize','Resurface'].map((s, i) => (
+        <span key={s} style={{ ...T.ui, fontSize: 12, color: i === 0 ? muted.fg2 : muted.fg3,
+          fontWeight: i === 0 ? 500 : 400,
+          borderBottom: i === 0 ? `1px solid ${muted.fg2}` : 'none',
+          paddingBottom: 1 }}>{s}</span>
+      ))}
+      <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 6,
+        padding: '3px 8px', background: muted.raised, border: `1px solid ${muted.border}`,
+        borderRadius: 2 }}>
+        <span style={{ ...T.ui, fontSize: 11, color: muted.fg2 }}>{sessionTitle}</span>
+        <span style={{ ...T.mono, fontSize: 8, color: muted.fg3 }}>▾</span>
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+        <div style={{ width: 5, height: 5, borderRadius: '50%',
+          background: vaultOk ? 'var(--vault)' : 'var(--destructive)', flexShrink: 0 }} />
+        <span style={{ ...T.mono, fontSize: 9, color: muted.fg3 }}>
+          {vaultOk ? 'Projects/Q2-arch.md' : 'vault offline'}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/* ── C.1 Focus: rail collapsed ──────────────────────────── */
+function WireframeC1() {
+  return (
+    <div style={{ width: 1194, height: 834, background: muted.bg, display: 'flex',
+      flexDirection: 'column', overflow: 'hidden', position: 'relative' }}>
+      <CTopBar />
+      <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+        <div style={{ flex: 1, overflowY: 'auto', padding: '44px 0', display: 'flex',
+          justifyContent: 'center' }}>
+          <div style={{ width: 640, maxWidth: '100%', padding: '0 24px' }}>
+            <div style={{ ...T.mono, fontSize: 9, color: muted.fg3,
+              borderBottom: `1px solid ${muted.border}`, paddingBottom: 10, marginBottom: 28, lineHeight: 1.9 }}>
+              title: Q2 architecture review · tags: architecture, decisions · status: active
+            </div>
+            <div style={{ ...T.disp, fontSize: 30, color: muted.fg1, fontWeight: 400,
+              letterSpacing: '-0.02em', lineHeight: 1.25, marginBottom: 24 }}>
+              Q2 architecture review
+            </div>
+            <DocH level={2} /><DocPara lines={3} />
+            <DocH level={3} /><DocPara lines={2} />
+            <DocH level={2} /><DocPara lines={4} />
+            <DocH level={3} /><DocPara lines={2} />
+            <DocH level={2} /><DocPara lines={3} />
+            <DocH level={3} /><DocPara lines={2} />
+            <DocPara lines={3} dim={true} />
+          </div>
+        </div>
+        {/* collapsed rail — 32px strip */}
+        <div style={{ width: 32, height: '100%', background: muted.surface,
+          borderLeft: `1px solid ${muted.border}`, display: 'flex', flexDirection: 'column',
+          alignItems: 'center', paddingTop: 12, gap: 10, flexShrink: 0 }}>
+          <div style={{ width: 8, height: 8, borderRadius: '50%',
+            background: 'var(--agent)', opacity: 0.7 }} />
+          <div style={{ ...T.mono, fontSize: 8, color: muted.fg3,
+            writingMode: 'vertical-rl', letterSpacing: '0.08em' }}>3 new</div>
+          <div style={{ marginTop: 'auto', marginBottom: 10, width: 16, height: 16,
+            border: `1px solid ${muted.border}`, borderRadius: 2,
+            display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <span style={{ ...T.mono, fontSize: 9, color: muted.fg3 }}>‹</span>
+          </div>
+        </div>
+      </div>
+      <Anno style={{ position: 'absolute', top: 48, left: 16, fontSize: 11 }}>
+        document at optimal reading<br/>measure (~65ch / 640px) ↗
+      </Anno>
+      <Anno style={{ position: 'absolute', top: 48, right: 40, fontSize: 11, textAlign: 'right' }}>
+        32px strip ↑<br/>dot = Hugin present<br/>"3 new" = unread turns
+      </Anno>
+      <Callout style={{ position: 'absolute', bottom: 60, left: 16, maxWidth: 200 }}>
+        focus state: only the vault dot is coloured. everything else is foreground/border.
+      </Callout>
+      <Callout style={{ position: 'absolute', bottom: 60, right: 40, maxWidth: 170 }}>
+        tap strip or ‹ to expand rail. doc scrolls independently.
+      </Callout>
+    </div>
+  );
+}
+
+/* ── C.2 Dialogue: rail active ──────────────────────────── */
+function WireframeC2() {
+  return (
+    <div style={{ width: 1194, height: 834, background: muted.bg, display: 'flex',
+      flexDirection: 'column', overflow: 'hidden', position: 'relative' }}>
+      <CTopBar />
+      <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+        <div style={{ flex: 1, overflowY: 'auto', padding: '36px 0', display: 'flex',
+          justifyContent: 'center' }}>
+          <div style={{ width: 600, maxWidth: '100%', padding: '0 24px' }}>
+            <div style={{ ...T.disp, fontSize: 28, color: muted.fg1, fontWeight: 400,
+              letterSpacing: '-0.02em', lineHeight: 1.25, marginBottom: 22 }}>
+              Q2 architecture review
+            </div>
+            <DocH level={2} /><DocPara lines={3} />
+            {/* agent-annotated passage */}
+            <div style={{ borderLeft: `2px solid rgba(74,158,255,0.2)`,
+              paddingLeft: 10, marginLeft: -12, position: 'relative', marginBottom: 16 }}>
+              <DocPara lines={3} />
+              <div style={{ position: 'absolute', right: -26, top: 8,
+                width: 8, height: 8, borderRadius: '50%',
+                background: 'rgba(74,158,255,0.5)' }} />
+            </div>
+            <DocH level={3} /><DocPara lines={2} />
+            {/* staged passage */}
+            <div style={{ borderLeft: `2px solid rgba(240,144,48,0.35)`,
+              paddingLeft: 10, marginLeft: -12, background: muted.amber,
+              borderRadius: '0 2px 2px 0', position: 'relative', marginBottom: 16 }}>
+              <DocPara lines={2} />
+              <div style={{ position: 'absolute', right: -26, top: 8,
+                width: 8, height: 8, borderRadius: '50%',
+                background: 'rgba(240,144,48,0.7)' }} />
+            </div>
+            <DocH level={2} /><DocPara lines={3} />
+            <DocH level={3} /><DocPara lines={2} dim />
+          </div>
+        </div>
+        {/* margin rail */}
+        <div style={{ width: 288, height: '100%', background: muted.surface,
+          borderLeft: `1px solid ${muted.border}`, display: 'flex', flexDirection: 'column',
+          flexShrink: 0 }}>
+          <div style={{ padding: '9px 12px', borderBottom: `1px solid ${muted.border}`,
+            display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
+            <div style={{ width: 7, height: 7, borderRadius: '50%',
+              background: 'var(--agent)', opacity: 0.8 }} />
+            <span style={{ ...T.mono, fontSize: 10, color: muted.fg3,
+              textTransform: 'uppercase', letterSpacing: '0.1em' }}>Hugin</span>
+            <span style={{ ...T.mono, fontSize: 9, color: muted.fg3, marginLeft: 'auto' }}>18 turns</span>
+            <div style={{ width: 14, height: 14, border: `1px solid ${muted.border}`,
+              borderRadius: 2, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <span style={{ ...T.mono, fontSize: 9, color: muted.fg3 }}>›</span>
+            </div>
+          </div>
+          <div style={{ flex: 1, overflowY: 'auto', padding: '10px 10px',
+            display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <div style={{ background: muted.raised, border: `1px solid ${muted.border}`,
+              borderRadius: '3px 3px 1px 3px', padding: '7px 10px', alignSelf: 'flex-end', maxWidth: '88%' }}>
+              <TextLines lines={2} h={6} lastW="55%" color={muted.fg2} />
+            </div>
+            {/* agent — background tint only */}
+            <div style={{ background: muted.agent, border: `1px solid ${muted.border}`,
+              borderRadius: '1px 3px 3px 3px', padding: '7px 10px', maxWidth: '96%' }}>
+              <div style={{ ...T.mono, fontSize: 8, color: muted.fg3, marginBottom: 5,
+                textTransform: 'uppercase', letterSpacing: '0.1em' }}>re: Decision record</div>
+              <TextLines lines={3} h={6} lastW="65%" color={muted.fg2} />
+              <div style={{ ...T.mono, fontSize: 8, color: muted.fg3, marginTop: 5,
+                paddingTop: 5, borderTop: `1px solid ${muted.border}` }}>
+                ↳ Projects/Q2-arch.md
+              </div>
+            </div>
+            <div style={{ background: muted.raised, border: `1px solid ${muted.border}`,
+              borderRadius: '3px 3px 1px 3px', padding: '7px 10px', alignSelf: 'flex-end', maxWidth: '80%' }}>
+              <TextLines lines={1} h={6} w="100%" lastW="100%" color={muted.fg2} />
+            </div>
+            <div style={{ background: muted.agent, border: `1px solid ${muted.border}`,
+              borderRadius: '1px 3px 3px 3px', padding: '7px 10px', maxWidth: '96%' }}>
+              <div style={{ ...T.mono, fontSize: 8, color: muted.fg3, marginBottom: 5,
+                textTransform: 'uppercase', letterSpacing: '0.1em' }}>re: Current state</div>
+              <TextLines lines={4} h={6} lastW="50%" color={muted.fg2} />
+              <div style={{ ...T.mono, fontSize: 8, color: muted.fg3, marginTop: 5,
+                paddingTop: 5, borderTop: `1px solid ${muted.border}` }}>
+                ↳ Projects/Q2-arch.md · docs/ARCHITECTURE.md
+              </div>
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '4px 0' }}>
+              <span style={{ ...T.mono, fontSize: 8, color: muted.fg3,
+                textTransform: 'uppercase', letterSpacing: '0.1em' }}>Hugin</span>
+              {[0,1,2].map(i => <span key={i} style={{ width: 3, height: 3, borderRadius: '50%',
+                background: muted.fg3, animation: `dotpulse 1.4s ease ${i*0.2}s infinite` }} />)}
+            </div>
+          </div>
+          <div style={{ padding: '7px 10px 10px', borderTop: `1px solid ${muted.border}`,
+            background: muted.surface, flexShrink: 0 }}>
+            <div style={{ background: muted.raised, border: `1px solid ${muted.borderSm}`,
+              borderRadius: 3, padding: '6px 8px', display: 'flex', gap: 6, alignItems: 'center' }}>
+              <Block w="100%" h={6} color={muted.border} style={{ flex: 1 }} />
+              <div style={{ padding: '3px 9px', border: `1px solid ${muted.cyan}`,
+                borderRadius: 2, ...T.ui, fontSize: 10, color: muted.cyan, flexShrink: 0 }}>Send</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <Anno style={{ position: 'absolute', top: 200, left: 16, fontSize: 11 }}>
+        ← faint blue left-border =<br/>agent annotated this passage
+      </Anno>
+      <Anno style={{ position: 'absolute', top: 295, left: 16, fontSize: 11 }}>
+        ← amber tint = staged region
+      </Anno>
+      <Anno style={{ position: 'absolute', top: 76, right: 296, fontSize: 11, textAlign: 'right' }}>
+        agent: background tint only ↗<br/>no coloured border, no glow
+      </Anno>
+      <Anno style={{ position: 'absolute', top: 200, right: 296, fontSize: 11, textAlign: 'right' }}>
+        source as footnote path ref ↗<br/>not a coloured chip
+      </Anno>
+      <Callout style={{ position: 'absolute', bottom: 70, left: 16, maxWidth: 200 }}>
+        only two coloured elements: vault dot (green) and Send (cyan). everything else is monochrome.
+      </Callout>
+    </div>
+  );
+}
+
+/* ── C.3 Suggestion moment ──────────────────────────────── */
+function WireframeC3() {
+  return (
+    <div style={{ width: 1194, height: 834, background: muted.bg, display: 'flex',
+      flexDirection: 'column', overflow: 'hidden', position: 'relative' }}>
+      <CTopBar />
+      <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+        <div style={{ flex: 1, overflowY: 'auto', padding: '36px 0', display: 'flex',
+          justifyContent: 'center' }}>
+          <div style={{ width: 600, maxWidth: '100%', padding: '0 24px' }}>
+            <div style={{ ...T.disp, fontSize: 28, color: muted.fg1, fontWeight: 400,
+              letterSpacing: '-0.02em', lineHeight: 1.25, marginBottom: 22 }}>
+              Q2 architecture review
+            </div>
+            <div style={{ opacity: 0.35 }}><DocH level={2} dim /><DocPara lines={3} dim /></div>
+            <div style={{ opacity: 0.35 }}><DocH level={2} dim /></div>
+            <DocPara lines={2} />
+            {/* proposed insertion */}
+            <div style={{ borderLeft: `3px solid ${muted.amberAccent}`,
+              paddingLeft: 12, marginLeft: -15, background: muted.amber,
+              borderRadius: '0 2px 2px 0', padding: '10px 12px', marginBottom: 14,
+              position: 'relative' }}>
+              <div style={{ ...T.mono, fontSize: 8, color: muted.amberAccent,
+                textTransform: 'uppercase', letterSpacing: '0.1em', marginBottom: 6 }}>proposed addition</div>
+              <TextLines lines={3} h={7} lastW="55%" color="rgba(240,144,48,0.3)" />
+              <div style={{ position: 'absolute', right: -28, top: 14,
+                width: 10, height: 10, borderRadius: '50%',
+                background: muted.amberAccent, opacity: 0.8 }} />
+            </div>
+            <div style={{ opacity: 0.35 }}>
+              <DocPara lines={2} dim />
+              <DocH level={3} dim /><DocPara lines={2} dim />
+            </div>
+          </div>
+        </div>
+        {/* rail */}
+        <div style={{ width: 288, height: '100%', background: muted.surface,
+          borderLeft: `1px solid ${muted.border}`, display: 'flex', flexDirection: 'column',
+          flexShrink: 0 }}>
+          <div style={{ padding: '9px 12px', borderBottom: `1px solid ${muted.border}`,
+            display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
+            <div style={{ width: 7, height: 7, borderRadius: '50%', background: 'var(--agent)', opacity: 0.8 }} />
+            <span style={{ ...T.mono, fontSize: 10, color: muted.fg3,
+              textTransform: 'uppercase', letterSpacing: '0.1em' }}>Hugin</span>
+          </div>
+          <div style={{ flex: 1, overflowY: 'auto', padding: '10px 10px',
+            display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <div style={{ opacity: 0.3 }}>
+              <div style={{ background: muted.raised, border: `1px solid ${muted.border}`,
+                borderRadius: '3px 3px 1px 3px', padding: '7px 10px', alignSelf: 'flex-end',
+                marginLeft: 'auto', maxWidth: '88%' }}>
+                <TextLines lines={2} h={6} lastW="65%" color={muted.fg3} />
+              </div>
+            </div>
+            <div style={{ opacity: 0.3 }}>
+              <div style={{ background: muted.agent, border: `1px solid ${muted.border}`,
+                borderRadius: '1px 3px 3px 3px', padding: '7px 10px' }}>
+                <TextLines lines={3} h={6} lastW="70%" color={muted.fg3} />
+              </div>
+            </div>
+            {/* suggestion card — full opacity, single accent */}
+            <div style={{ border: `1px solid rgba(240,144,48,0.3)`,
+              borderLeft: `3px solid ${muted.amberAccent}`,
+              borderRadius: '1px 3px 3px 3px', padding: '10px 10px',
+              background: muted.amber }}>
+              <div style={{ ...T.mono, fontSize: 8, color: muted.amberAccent,
+                textTransform: 'uppercase', letterSpacing: '0.1em', marginBottom: 6 }}>Hugin · proposed addition</div>
+              <TextLines lines={3} h={6} lastW="60%" color={muted.fg2} />
+              <div style={{ ...T.mono, fontSize: 8, color: muted.fg3, marginTop: 5,
+                paddingTop: 5, borderTop: `1px solid rgba(240,144,48,0.2)` }}>
+                +3 lines after ## Current state
+              </div>
+              <div style={{ display: 'flex', gap: 6, marginTop: 10 }}>
+                <div style={{ padding: '4px 12px', border: `1px solid ${muted.amberAccent}`,
+                  borderRadius: 2, ...T.ui, fontSize: 11, color: muted.amberAccent,
+                  background: 'rgba(240,144,48,0.08)' }}>Apply to note</div>
+                <div style={{ padding: '4px 10px', border: `1px solid ${muted.border}`,
+                  borderRadius: 2, ...T.ui, fontSize: 11, color: muted.fg3 }}>Discard</div>
+              </div>
+            </div>
+          </div>
+          <div style={{ padding: '7px 10px 10px', borderTop: `1px solid ${muted.border}`, flexShrink: 0 }}>
+            <div style={{ background: muted.raised, border: `1px solid ${muted.borderSm}`,
+              borderRadius: 3, padding: '6px 8px', display: 'flex', gap: 6, alignItems: 'center',
+              opacity: 0.4 }}>
+              <Block w="100%" h={6} color={muted.border} style={{ flex: 1 }} />
+              <div style={{ padding: '3px 9px', border: `1px solid ${muted.border}`,
+                borderRadius: 2, ...T.ui, fontSize: 10, color: muted.fg3, flexShrink: 0 }}>Send</div>
+            </div>
+            <div style={{ ...T.mono, fontSize: 8, color: muted.fg3, marginTop: 4,
+              textAlign: 'center', letterSpacing: '0.04em' }}>apply or discard to continue</div>
+          </div>
+        </div>
+      </div>
+      <Anno style={{ position: 'absolute', top: 270, left: 16, fontSize: 11 }}>
+        proposed addition shown inline ↗<br/>rest of doc dims to 35% opacity
+      </Anno>
+      <Anno style={{ position: 'absolute', top: 80, right: 298, fontSize: 11, textAlign: 'right' }}>
+        prior turns dim ↗<br/>suggestion is full-opacity
+      </Anno>
+      <Callout style={{ position: 'absolute', bottom: 80, left: 16, maxWidth: 220 }}>
+        doc + margin card are the same object. same amber treatment, same label. one proposed change, two views.
+      </Callout>
+      <Callout style={{ position: 'absolute', bottom: 80, right: 296, maxWidth: 165 }}>
+        composer dims — "apply or discard to continue" prevents new input during staged state.
+      </Callout>
+    </div>
+  );
+}
+
+/* ── C.4 — Session drawer ───────────────────────────────── */
+function WireframeC4() {
+  const sessions = [
+    { title: 'Q2 architecture review', path: 'Projects/Q2-arch.md', age: '2h ago', turns: 18, active: true },
+    { title: 'On the architecture of memory', path: 'Writing/memory-essay.md', age: '3d ago', turns: 6, active: false },
+    { title: 'Thornwall — session 12 prep', path: 'RPG/Thornwall/session-12.md', age: '1w ago', turns: 4, active: false },
+    { title: 'Weekly review 2026-W17', path: 'Reviews/2026-W17.md', age: '5d ago', turns: 9, active: false },
+    { title: 'Untitled session', path: 'Inbox/untitled.md', age: '2w ago', turns: 2, active: false },
+  ];
+  return (
+    <div style={{ width: 1194, height: 834, background: muted.bg, display: 'flex',
+      flexDirection: 'column', overflow: 'hidden', position: 'relative' }}>
+      <CTopBar />
+      {/* document — dimmed behind drawer */}
+      <div style={{ flex: 1, display: 'flex', overflow: 'hidden', position: 'relative' }}>
+        <div style={{ flex: 1, overflowY: 'hidden', padding: '36px 0', display: 'flex',
+          justifyContent: 'center', opacity: 0.25, pointerEvents: 'none', userSelect: 'none' }}>
+          <div style={{ width: 600, padding: '0 24px' }}>
+            <div style={{ ...T.disp, fontSize: 28, color: muted.fg1, fontWeight: 400,
+              letterSpacing: '-0.02em', marginBottom: 22 }}>Q2 architecture review</div>
+            <DocH level={2} /><DocPara lines={3} />
+            <DocH level={3} /><DocPara lines={2} />
+            <DocH level={2} /><DocPara lines={3} />
+          </div>
+        </div>
+        {/* scrim */}
+        <div style={{ position: 'absolute', inset: 0, background: 'rgba(7,11,18,0.55)',
+          backdropFilter: 'blur(2px)' }} />
+        {/* session drawer — slides in from left */}
+        <div style={{ position: 'absolute', top: 0, left: 0, bottom: 0, width: 340,
+          background: muted.surface, borderRight: `1px solid ${muted.border}`,
+          display: 'flex', flexDirection: 'column', zIndex: 10,
+          boxShadow: '4px 0 32px rgba(0,0,0,0.5)' }}>
+          {/* drawer header */}
+          <div style={{ padding: '12px 14px', borderBottom: `1px solid ${muted.border}`,
+            display: 'flex', alignItems: 'center', gap: 10, flexShrink: 0 }}>
+            <span style={{ ...T.mono, fontSize: 9, color: muted.fg3, textTransform: 'uppercase',
+              letterSpacing: '0.1em', flex: 1 }}>Sessions</span>
+            {/* new session */}
+            <div style={{ display: 'flex', alignItems: 'center', gap: 5, padding: '3px 8px',
+              border: `1px solid ${muted.border}`, borderRadius: 2 }}>
+              <div style={{ width: 8, height: 8, border: `1px solid ${muted.fg3}`, borderRadius: 1,
+                display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <span style={{ ...T.mono, fontSize: 7, color: muted.fg3, lineHeight: 1 }}>+</span>
+              </div>
+              <span style={{ ...T.ui, fontSize: 11, color: muted.fg3 }}>New</span>
+            </div>
+            {/* close */}
+            <div style={{ width: 16, height: 16, border: `1px solid ${muted.border}`, borderRadius: 2,
+              display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <span style={{ ...T.mono, fontSize: 9, color: muted.fg3 }}>✕</span>
+            </div>
+          </div>
+          {/* search */}
+          <div style={{ padding: '8px 12px', borderBottom: `1px solid ${muted.border}`, flexShrink: 0 }}>
+            <div style={{ background: muted.raised, border: `1px solid ${muted.border}`,
+              borderRadius: 2, padding: '5px 10px', display: 'flex', alignItems: 'center', gap: 7 }}>
+              <Block w={10} h={10} color={muted.fg3} style={{ borderRadius: '50%', background: 'transparent',
+                border: `1.5px solid ${muted.fg3}`, flexShrink: 0 }} />
+              <Block w="70%" h={6} color={muted.border} />
+            </div>
+          </div>
+          {/* list */}
+          <div style={{ flex: 1, overflowY: 'auto', padding: '6px 8px' }}>
+            {sessions.map(s => (
+              <div key={s.title} style={{ padding: '8px 10px', borderRadius: 2, marginBottom: 2,
+                background: s.active ? 'rgba(212,168,67,0.05)' : 'transparent',
+                border: `1px solid ${s.active ? 'rgba(212,168,67,0.25)' : 'transparent'}` }}>
+                <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 3 }}>
+                  <span style={{ ...T.ui, fontSize: 12, color: s.active ? 'var(--accent)' : muted.fg2,
+                    fontWeight: s.active ? 500 : 400, flex: 1,
+                    whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{s.title}</span>
+                  <span style={{ ...T.mono, fontSize: 9, color: muted.fg3, flexShrink: 0 }}>{s.age}</span>
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <span style={{ ...T.mono, fontSize: 9, color: muted.fg3,
+                    flex: 1, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{s.path}</span>
+                  <span style={{ ...T.mono, fontSize: 9, color: muted.fg3 }}>{s.turns} turns</span>
+                </div>
+              </div>
+            ))}
+          </div>
+          {/* vault status at bottom */}
+          <div style={{ padding: '8px 14px', borderTop: `1px solid ${muted.border}`,
+            display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
+            <div style={{ width: 5, height: 5, borderRadius: '50%', background: 'var(--vault)' }} />
+            <span style={{ ...T.mono, fontSize: 9, color: muted.fg3 }}>Vault online · 4 sessions</span>
+          </div>
+        </div>
+      </div>
+      {/* annotations */}
+      <Anno style={{ position: 'absolute', top: 50, left: 352, fontSize: 11 }}>
+        ↑ drawer slides over doc<br/>doc stays visible at ~25% behind scrim
+      </Anno>
+      <Anno style={{ position: 'absolute', top: 50, right: 20, fontSize: 11, textAlign: 'right' }}>
+        no navigation away from the document ↑<br/>drawer is an overlay, not a page
+      </Anno>
+      <Callout style={{ position: 'absolute', bottom: 60, left: 352, maxWidth: 220 }}>
+        active session highlighted in gold. tap any session to close drawer and switch. tap scrim or ✕ to dismiss without switching.
+      </Callout>
+      <Callout style={{ position: 'absolute', bottom: 60, right: 20, maxWidth: 180 }}>
+        session picker in top bar (▾) is what triggers this drawer — same control, same result.
+      </Callout>
+    </div>
+  );
+}
+
+/* ── C.5 — Portrait (834×1194) ──────────────────────────── */
+function WireframeC5() {
+  return (
+    <div style={{ width: 834, height: 1194, background: muted.bg, display: 'flex',
+      flexDirection: 'column', overflow: 'hidden', position: 'relative' }}>
+      {/* top bar — tighter on portrait */}
+      <div style={{ height: 38, borderBottom: `1px solid ${muted.border}`,
+        background: muted.surface, display: 'flex', alignItems: 'center',
+        padding: '0 14px', gap: 10, flexShrink: 0 }}>
+        <svg width="14" height="18" viewBox="0 0 40 50" fill="none" style={{ flexShrink: 0 }}>
+          <line x1="20" y1="9" x2="20" y2="38" stroke="var(--accent)" strokeWidth="1.5" strokeLinecap="round"/>
+          <circle cx="20" cy="6" r="2.5" fill="var(--accent)"/>
+        </svg>
+        {/* abbreviated nav — icon only */}
+        {['Converse','Orient','Capture','Synthesize','Resurface'].map((s, i) => (
+          <div key={s} style={{ width: 22, height: 22, display: 'flex', alignItems: 'center',
+            justifyContent: 'center', borderRadius: 3,
+            background: i === 0 ? 'rgba(122,154,184,0.08)' : 'transparent',
+            border: i === 0 ? `1px solid ${muted.border}` : '1px solid transparent' }}>
+            <div style={{ width: 10, height: 10, border: `1.5px solid ${i === 0 ? muted.fg2 : muted.fg3}`,
+              borderRadius: 2 }} />
+          </div>
+        ))}
+        <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 4,
+          padding: '3px 8px', background: muted.raised, border: `1px solid ${muted.border}`,
+          borderRadius: 2, maxWidth: 160, overflow: 'hidden' }}>
+          <span style={{ ...T.ui, fontSize: 11, color: muted.fg2,
+            whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>Q2 architecture review</span>
+          <span style={{ ...T.mono, fontSize: 8, color: muted.fg3, flexShrink: 0 }}>▾</span>
+        </div>
+        <div style={{ width: 5, height: 5, borderRadius: '50%', background: 'var(--vault)', flexShrink: 0 }} />
+      </div>
+
+      {/* document — full width, more generous measure */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: '44px 0 160px', display: 'flex',
+        justifyContent: 'center' }}>
+        <div style={{ width: 560, maxWidth: '100%', padding: '0 28px' }}>
+          <div style={{ ...T.mono, fontSize: 9, color: muted.fg3,
+            borderBottom: `1px solid ${muted.border}`, paddingBottom: 8, marginBottom: 24, lineHeight: 1.9 }}>
+            Q2 architecture review · Projects/Q2-arch.md
+          </div>
+          <div style={{ ...T.disp, fontSize: 28, color: muted.fg1, fontWeight: 400,
+            letterSpacing: '-0.02em', lineHeight: 1.25, marginBottom: 22 }}>
+            Q2 architecture review
+          </div>
+          <DocH level={2} /><DocPara lines={3} />
+          <DocH level={3} /><DocPara lines={2} />
+          {/* agent-annotated */}
+          <div style={{ borderLeft: `2px solid rgba(74,158,255,0.2)`,
+            paddingLeft: 10, marginLeft: -12, position: 'relative', marginBottom: 16 }}>
+            <DocPara lines={3} />
+            <div style={{ position: 'absolute', right: -20, top: 8,
+              width: 8, height: 8, borderRadius: '50%', background: 'rgba(74,158,255,0.5)' }} />
+          </div>
+          <DocH level={2} /><DocPara lines={4} />
+          <DocH level={3} /><DocPara lines={2} />
+          <DocH level={2} /><DocPara lines={3} dim />
+        </div>
+      </div>
+
+      {/* rail as bottom sheet — partial, peekable */}
+      <div style={{ position: 'absolute', bottom: 0, left: 0, right: 0,
+        background: muted.surface, borderTop: `1px solid ${muted.border}`,
+        boxShadow: '0 -8px 32px rgba(0,0,0,0.4)' }}>
+        {/* drag handle + header */}
+        <div style={{ padding: '10px 14px 0', display: 'flex', flexDirection: 'column',
+          alignItems: 'stretch', gap: 0 }}>
+          {/* handle bar */}
+          <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 10 }}>
+            <div style={{ width: 36, height: 3, background: muted.borderSm, borderRadius: 2 }} />
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, paddingBottom: 8,
+            borderBottom: `1px solid ${muted.border}` }}>
+            <div style={{ width: 7, height: 7, borderRadius: '50%',
+              background: 'var(--agent)', opacity: 0.8 }} />
+            <span style={{ ...T.mono, fontSize: 10, color: muted.fg3,
+              textTransform: 'uppercase', letterSpacing: '0.1em' }}>Hugin</span>
+            <span style={{ ...T.mono, fontSize: 9, color: muted.fg3, marginLeft: 'auto' }}>18 turns · 3 new</span>
+          </div>
+        </div>
+        {/* peek of latest message */}
+        <div style={{ padding: '8px 14px' }}>
+          <div style={{ background: muted.agent, border: `1px solid ${muted.border}`,
+            borderRadius: '1px 3px 3px 3px', padding: '8px 10px', marginBottom: 8 }}>
+            <div style={{ ...T.mono, fontSize: 8, color: muted.fg3, marginBottom: 5,
+              textTransform: 'uppercase', letterSpacing: '0.1em' }}>re: Current state</div>
+            <TextLines lines={2} h={6} lastW="65%" color={muted.fg2} />
+            <div style={{ ...T.mono, fontSize: 8, color: muted.fg3, marginTop: 4 }}>↳ Projects/Q2-arch.md</div>
+          </div>
+          {/* composer */}
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center',
+            background: muted.raised, border: `1px solid ${muted.borderSm}`,
+            borderRadius: 3, padding: '6px 8px', marginBottom: 4 }}>
+            <Block w="100%" h={6} color={muted.border} style={{ flex: 1 }} />
+            <div style={{ padding: '3px 9px', border: `1px solid ${muted.cyan}`,
+              borderRadius: 2, ...T.ui, fontSize: 10, color: muted.cyan, flexShrink: 0 }}>Send</div>
+          </div>
+        </div>
+      </div>
+
+      {/* annotations */}
+      <Anno style={{ position: 'absolute', top: 50, left: 16, fontSize: 11 }}>
+        nav icons only ↗ — labels removed<br/>at portrait width
+      </Anno>
+      <Anno style={{ position: 'absolute', top: 50, right: 16, fontSize: 11, textAlign: 'right' }}>
+        doc fills full 834px ↑<br/>no margin compression
+      </Anno>
+      <Anno style={{ position: 'absolute', bottom: 230, left: 16, fontSize: 11 }}>
+        ↓ bottom sheet — drag handle<br/>peeks latest message + composer
+      </Anno>
+      <Callout style={{ position: 'absolute', bottom: 250, right: 16, maxWidth: 180 }}>
+        drag up to expand full thread. drag down to collapse to 32px strip (matches landscape collapsed state).
+      </Callout>
+    </div>
+  );
+}
+
+/* ── C.6 — Source peek ──────────────────────────────────── */
+function WireframeC6() {
+  return (
+    <div style={{ width: 1194, height: 834, background: muted.bg, display: 'flex',
+      flexDirection: 'column', overflow: 'hidden', position: 'relative' }}>
+      <CTopBar />
+      <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+        {/* document */}
+        <div style={{ flex: 1, overflowY: 'auto', padding: '36px 0', display: 'flex',
+          justifyContent: 'center', position: 'relative' }}>
+          <div style={{ width: 600, padding: '0 24px' }}>
+            <div style={{ ...T.disp, fontSize: 28, color: muted.fg1, fontWeight: 400,
+              letterSpacing: '-0.02em', marginBottom: 22 }}>Q2 architecture review</div>
+            <DocH level={2} /><DocPara lines={3} />
+            {/* agent-annotated — source referenced here */}
+            <div style={{ borderLeft: `2px solid rgba(74,158,255,0.2)`,
+              paddingLeft: 10, marginLeft: -12, position: 'relative', marginBottom: 8 }}>
+              <DocPara lines={3} />
+              {/* margin dot — active/highlighted state */}
+              <div style={{ position: 'absolute', right: -26, top: 8,
+                width: 10, height: 10, borderRadius: '50%',
+                background: 'rgba(74,158,255,0.8)',
+                boxShadow: '0 0 8px rgba(74,158,255,0.4)' }} />
+            </div>
+            {/* source peek popup — anchored to margin dot */}
+            <div style={{ position: 'relative', marginLeft: -12, marginBottom: 16 }}>
+              <div style={{ position: 'absolute', right: -310, top: -80, width: 288,
+                background: muted.raised, border: `1px solid ${muted.borderSm}`,
+                borderRadius: 3, padding: '10px 12px', zIndex: 20,
+                boxShadow: '0 4px 24px rgba(0,0,0,0.5), 0 1px 4px rgba(0,0,0,0.3)' }}>
+                {/* peek header */}
+                <div style={{ display: 'flex', alignItems: 'center', gap: 7, marginBottom: 8,
+                  paddingBottom: 7, borderBottom: `1px solid ${muted.border}` }}>
+                  <IconBox size={9} color={muted.fg3} />
+                  <span style={{ ...T.mono, fontSize: 9, color: muted.fg3, flex: 1,
+                    whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>docs/ARCHITECTURE.md</span>
+                  <span style={{ ...T.mono, fontSize: 8, color: muted.fg3 }}>✕</span>
+                </div>
+                {/* referenced section — highlighted */}
+                <div style={{ ...T.mono, fontSize: 8, color: muted.fg3,
+                  textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: 6 }}>## Runtime contract</div>
+                {/* highlighted passage — the actual referenced span */}
+                <div style={{ background: 'rgba(74,158,255,0.07)',
+                  borderLeft: `2px solid rgba(74,158,255,0.3)`,
+                  padding: '5px 7px', marginBottom: 6, borderRadius: '0 2px 2px 0' }}>
+                  <TextLines lines={2} h={6} lastW="75%" color="rgba(74,158,255,0.3)" />
+                </div>
+                <TextLines lines={2} h={6} lastW="60%" color={muted.border} />
+                {/* footer — navigation */}
+                <div style={{ display: 'flex', gap: 8, marginTop: 9, paddingTop: 7,
+                  borderTop: `1px solid ${muted.border}` }}>
+                  <span style={{ ...T.mono, fontSize: 8, color: muted.fg3, flex: 1 }}>1 of 2 references</span>
+                  <span style={{ ...T.mono, fontSize: 8, color: muted.fg3 }}>← →</span>
+                  <span style={{ ...T.mono, fontSize: 8, color: muted.fg2 }}>open full note</span>
+                </div>
+              </div>
+            </div>
+            <DocH level={3} /><DocPara lines={2} />
+            <DocH level={2} /><DocPara lines={3} />
+            <DocH level={3} /><DocPara lines={2} dim />
+          </div>
+        </div>
+        {/* margin rail — collapsed, nothing to distract */}
+        <div style={{ width: 32, height: '100%', background: muted.surface,
+          borderLeft: `1px solid ${muted.border}`, display: 'flex', flexDirection: 'column',
+          alignItems: 'center', paddingTop: 12, gap: 10, flexShrink: 0 }}>
+          <div style={{ width: 8, height: 8, borderRadius: '50%',
+            background: 'var(--agent)', opacity: 0.7 }} />
+          <div style={{ marginTop: 'auto', marginBottom: 10, width: 16, height: 16,
+            border: `1px solid ${muted.border}`, borderRadius: 2,
+            display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <span style={{ ...T.mono, fontSize: 9, color: muted.fg3 }}>‹</span>
+          </div>
+        </div>
+      </div>
+
+      {/* annotations */}
+      <Anno style={{ position: 'absolute', top: 180, left: 16, fontSize: 11 }}>
+        tap margin dot to peek ↗<br/>source overlays at the dot
+      </Anno>
+      <Anno style={{ position: 'absolute', top: 100, right: 46, fontSize: 11, textAlign: 'right' }}>
+        peek card: referenced passage<br/>highlighted, full context below ↑
+      </Anno>
+      <Callout style={{ position: 'absolute', bottom: 60, left: 16, maxWidth: 220 }}>
+        no new pane. no modal. the source peek is a transient card anchored to the margin dot. dismissed by tapping ✕ or anywhere outside.
+      </Callout>
+      <Callout style={{ position: 'absolute', bottom: 60, right: 46, maxWidth: 180 }}>
+        "1 of 2 references" — dots accumulate when a passage references multiple sources. ← → navigates between them.
+      </Callout>
+    </div>
+  );
+}
+
+/* ─── App ────────────────────────────────────────────────── */
+function App() {
+  return (
+    <DesignCanvas title="Companion UI — Converse surface wireframes">
+      <DCSection id="directions" title="Initial directions — iPad 11&quot; landscape (1194×834)">
+        <DCArtboard id="wf-a" label="A — Split pane" width={1194} height={834}>
+          <WireframeA />
+        </DCArtboard>
+        <DCArtboard id="wf-b" label="B — Timeline bloom" width={1194} height={834}>
+          <WireframeB />
+        </DCArtboard>
+        <DCArtboard id="wf-c" label="C — Document-first (initial)" width={1194} height={834}>
+          <WireframeC />
+        </DCArtboard>
+      </DCSection>
+      <DCSection id="c-deep" title="Direction C — deep dive">
+        <DCArtboard id="c1" label="C.1 — Focus (rail collapsed)" width={1194} height={834}>
+          <WireframeC1 />
+        </DCArtboard>
+        <DCArtboard id="c2" label="C.2 — Dialogue (rail active)" width={1194} height={834}>
+          <WireframeC2 />
+        </DCArtboard>
+        <DCArtboard id="c3" label="C.3 — Suggestion moment" width={1194} height={834}>
+          <WireframeC3 />
+        </DCArtboard>
+        <DCArtboard id="c4" label="C.4 — Session drawer" width={1194} height={834}>
+          <WireframeC4 />
+        </DCArtboard>
+        <DCArtboard id="c5" label="C.5 — Portrait (834×1194)" width={834} height={1194}>
+          <WireframeC5 />
+        </DCArtboard>
+        <DCArtboard id="c6" label="C.6 — Source peek" width={1194} height={834}>
+          <WireframeC6 />
+        </DCArtboard>
+      </DCSection>
+    </DesignCanvas>
+  );
+}
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);
+</script>
+</body>
+</html>

--- a/companion-ui/design-handoff/2026-05-03-converse/README.md
+++ b/companion-ui/design-handoff/2026-05-03-converse/README.md
@@ -1,0 +1,444 @@
+# Handoff: Companion UI — Converse Surface
+
+**Target location:** `<repo root>/companion-ui/`  
+**Design fidelity:** Low-to-mid fidelity wireframes. Structure, layout, IA, and interaction patterns are specified precisely. Visual polish (exact shadows, animation curves, final copy) is left to implementation. Color tokens are specified; use them or the nearest equivalent in your stack.
+
+---
+
+## About the Design Files
+
+The files bundled here (`Companion UI Wireframes.html`, `design-canvas.jsx`, `colors_and_type.css`) are **HTML design prototypes** — not production code. They exist to show intended structure, states, and interactions. Do not ship them directly.
+
+Your task: implement the designs described in this README inside `companion-ui/` using whatever framework fits the existing codebase (React + Vite is the natural choice given the runtime is FastAPI + Python). The wireframe HTML is reference material; this README is the spec.
+
+---
+
+## Project context
+
+The Companion UI is a **PWA client** for a personal agentic PKM system. The backing runtime is a FastAPI server, reachable on a personal network (Tailscale). The vault is a folder of markdown files, Obsidian-compatible. All persistent state lives as markdown in the vault; the UI is a client onto that, not the source of truth.
+
+**v0 scope:** implement the **Converse surface only.** Other surfaces (Orient, Capture, Synthesize, Resurface) appear in navigation as disabled placeholders — do not implement them.
+
+**User:** one senior software architect. Fluent with Obsidian, markdown, agent tooling. Design for this user; do not import onboarding or discoverability patterns intended for strangers.
+
+---
+
+## Design direction: Document-first (Direction C)
+
+The chosen direction treats the **vault note as the primary object** on screen. The conversation with Hugin (the agent) lives in a collapsible margin rail. The document is always visible; everything else is an overlay or a strip alongside it.
+
+### Core layout — landscape iPad (1194×834) / Mac desktop
+
+```
+┌─────────────────────────────────────────────┬──────────────┐
+│  TOP BAR (38px)                             │              │
+├─────────────────────────────────────────────┤              │
+│                                             │  MARGIN RAIL │
+│           DOCUMENT PANE                     │  (288px)     │
+│           (fills remainder)                 │  or          │
+│                                             │  32px strip  │
+│                                             │              │
+└─────────────────────────────────────────────┴──────────────┘
+```
+
+The margin rail has **three sizes** — collapsed strip, active panel, and portrait bottom sheet:
+
+| State | Width / Height | Trigger |
+|---|---|---|
+| Collapsed strip | 32px right edge | Default / focus mode |
+| Active panel | 288px right edge | Tap strip or drag |
+| Portrait bottom sheet | Full width, ~240px peek | iPad portrait / iPhone |
+
+---
+
+## Screens and states
+
+### State C.1 — Focus (rail collapsed)
+
+The reading/writing state. Nothing competes with the document.
+
+**Layout:**
+- Top bar: 38px, `--bg-surface`, 1px border-bottom
+- Document pane: fills entire width minus 32px strip
+- Document inner width: max 640px, centered horizontally, 44px vertical padding
+- Collapsed strip: 32px wide, full height, `--bg-surface`, 1px border-left
+
+**Strip contents (top to bottom):**
+- Hugin presence dot: 8×8px circle, `--agent` color at 70% opacity, 12px from top
+- Unread count label: `font-mono`, 8px, `--fg-3`, `writing-mode: vertical-rl`, rotated text e.g. "3 new"
+- Expand handle: 16×16px box, 1px border `--border`, borderRadius 2px, "‹" character, pinned to bottom, 10px margin
+
+**Document:**
+- Frontmatter block: `font-mono` 9px `--fg-3`, 1px border-bottom `--border`, `padding-bottom: 10px`, `margin-bottom: 28px`, single line summary of key fields
+- Title: `font-display` 30px `--fg-1`, weight 400, `letter-spacing: -0.02em`, `line-height: 1.25`
+- Headings H2: height placeholder 13px, width 38%, `rgba(220,232,240,0.25)` 
+- Headings H3: height placeholder 10px, width 28%
+- Body paragraphs: stacked lines at 8px height, 7px gap, last line 62% width, `--border-strong` color
+
+**Color rule for this state:** only the vault status dot in the top bar carries colour (green = online). Everything else is foreground/border.
+
+---
+
+### State C.2 — Dialogue (rail active)
+
+Rail expands to 288px. Document narrows to fill remaining width, inner column stays ~600px centered.
+
+**Rail structure:**
+```
+┌─────────────────────┐
+│ ● Hugin   18 turns ›│  ← header 38px
+├─────────────────────┤
+│                     │
+│  [conversation      │
+│   thread]           │  ← flex-1, overflow-y scroll
+│                     │
+├─────────────────────┤
+│  [composer]         │  ← 44px
+└─────────────────────┘
+```
+
+**Rail header:** 9px padding, `--border` bottom, flex row: Hugin dot (7px circle, `--agent` 80% opacity) + "HUGIN" label (`font-mono` 10px `--fg-3` uppercase 0.1em tracking) + turn count (`font-mono` 9px `--fg-3` right-aligned) + collapse handle (14×14 box, "›")
+
+**Message types in thread:**
+
+*Human message:*
+- Background: `--bg-raised`
+- Border: 1px `--border`
+- Border-radius: `3px 3px 1px 3px` (right-hand bubble)
+- Padding: 7px 10px
+- Align: `align-self: flex-end`, max-width 88%
+- Content: text lines placeholder
+
+*Agent message (Hugin):*
+- Background: `rgba(74,158,255,0.06)` — tint only, no coloured border
+- Border: 1px `--border`
+- Border-radius: `1px 3px 3px 3px`
+- Padding: 7px 10px
+- Context label: `font-mono` 8px `--fg-3` uppercase, e.g. "re: Decision record", margin-bottom 5px
+- Source line: below content, `font-mono` 8px `--fg-3`, `↳ Projects/Q2-arch.md`, separated by 1px `--border` top
+
+*Thinking indicator:*
+- "HUGIN" label + three dots, dot pulse animation (opacity 0.3→1→0.3, scale 0.85→1→0.85, staggered 0.2s)
+
+**Composer:**
+- Background: `--bg-raised`
+- Border: 1px `--border-strong`
+- Border-radius: 3px
+- Padding: 6px 8px
+- Input: flex-1, no border, background transparent, `font-ui` 13px
+- Send button: right-aligned, `padding: 3px 9px`, border 1px `--cyan`, border-radius 2px, `font-ui` 10px `--cyan` color
+- **Send is the only cyan element on screen**
+
+**Document annotations while rail is active:**
+- Agent-referenced passages: `border-left: 2px solid rgba(74,158,255,0.2)`, `padding-left: 10px`, `margin-left: -12px`
+- Margin dot at right edge: 8×8px circle, `rgba(74,158,255,0.5)`, `position: absolute, right: -26px`
+- Staged/uncommitted passages: `border-left: 2px solid rgba(240,144,48,0.35)`, `background: rgba(240,144,48,0.07)`, margin dot `rgba(240,144,48,0.7)`
+
+---
+
+### State C.3 — Suggestion moment
+
+A proposed addition exists. Everything except the suggestion recedes.
+
+**Document behaviour:**
+- All document sections NOT involved in the suggestion: `opacity: 0.35`
+- Proposed insertion block:
+  - `border-left: 3px solid #f09030`
+  - `background: rgba(240,144,48,0.07)`
+  - `border-radius: 0 2px 2px 0`
+  - `padding: 10px 12px`
+  - Label: `font-mono` 8px `#f09030` uppercase "proposed addition"
+  - Content: text placeholder lines
+  - Margin dot: 10×10px circle, `#f09030` 80% opacity, `right: -28px top: 14px`
+
+**Rail behaviour:**
+- Prior conversation turns: `opacity: 0.3`
+- Suggestion card: full opacity, same amber treatment as document block
+  - `border-left: 3px solid #f09030`
+  - `border: 1px solid rgba(240,144,48,0.3)`
+  - `background: rgba(240,144,48,0.07)`
+  - Label: `font-mono` 8px `#f09030` uppercase "Hugin · proposed addition"
+  - Content placeholder
+  - Diff hint: `font-mono` 8px `--fg-3`, e.g. "+3 lines after ## Current state"
+  - **Apply to note** button: `padding: 4px 12px`, `border: 1px solid #f09030`, `border-radius: 2px`, `font-ui` 11px `#f09030`, `background: rgba(240,144,48,0.08)`
+  - **Discard** button: `padding: 4px 10px`, `border: 1px solid --border`, `font-ui` 11px `--fg-3`
+
+**Composer behaviour during staged state:**
+- Composer opacity: 0.4
+- Input disabled
+- Below composer: `font-mono` 8px `--fg-3` centered text: "apply or discard to continue"
+
+**Key principle:** the document block and the rail card are the same object shown twice. Same amber, same label, same action. The user should feel they are acting on one thing.
+
+---
+
+### State C.4 — Session drawer
+
+Triggered by: tapping the session pill in the top bar (shows current session title + ▾).
+
+**Behaviour:** a drawer slides in from the left as a full-height overlay. It does not navigate away from the document — the document stays visible behind it.
+
+**Scrim:** `background: rgba(7,11,18,0.55)`, `backdrop-filter: blur(2px)`, covers full viewport behind drawer. Tapping scrim dismisses without switching session.
+
+**Drawer:** 340px wide, full height, `--bg-surface`, `border-right: 1px --border`, `box-shadow: 4px 0 32px rgba(0,0,0,0.5)`
+
+**Drawer header:** `padding: 12px 14px`
+- "SESSIONS" label: `font-mono` 9px `--fg-3` uppercase
+- New session button: icon box + "New" label, `border: 1px --border`, `border-radius: 2px`
+- Close ✕: 16×16 box
+
+**Search bar:** `padding: 8px 12px`, `border-bottom: 1px --border`
+- Input: `--bg-raised`, `border: 1px --border`, `border-radius: 2px`, `padding: 5px 10px`
+
+**Session list items:**
+- Padding: 8px 10px, `border-radius: 2px`, `margin-bottom: 2px`
+- Active session: `background: rgba(212,168,67,0.05)`, `border: 1px solid rgba(212,168,67,0.25)`
+- Active title: `font-ui` 12px `--accent` weight 500
+- Inactive title: `font-ui` 12px `--fg-2` weight 400
+- Path: `font-mono` 9px `--fg-3`
+- Age + turn count: `font-mono` 9px `--fg-3`, right-aligned
+
+**Drawer footer:** vault status dot + "Vault online · N sessions", `font-mono` 9px `--fg-3`
+
+---
+
+### State C.5 — Portrait (iPad portrait 834×1194 / iPhone)
+
+**Top bar:** same 38px bar. Nav labels drop — show icon boxes only (no text labels). Session pill truncates to fit. Vault dot only (no path text).
+
+**Document:** fills full 834px width. Inner column ~560px centered. Bottom padding ~160px to clear the sheet.
+
+**Conversation rail → bottom sheet:**
+- Collapsed: a `~240px` sheet docked to the bottom edge
+- Drag handle: 36×3px pill, `--border-strong`, centered, 10px from top of sheet
+- Header: same Hugin dot + label + turn count as landscape
+- Peek area: shows latest agent message + composer
+- Drag up: expands to full-height sheet covering most of screen
+- Drag down: collapses to 32px strip at bottom (equivalent to landscape collapsed state)
+- On iPhone: this is the only rail presentation — no side panel
+
+---
+
+### State C.6 — Source peek
+
+**Trigger:** tap any margin dot (blue or amber circle at right edge of annotated passage).
+
+**Peek card:** a floating card anchored to the dot position. Not a modal; not a new pane.
+- Width: 288px
+- Position: `position: absolute`, `right: -310px` (to the right of the document column), vertically centred on the dot
+- Background: `--bg-raised`
+- Border: 1px `--border-strong`
+- Border-radius: 3px
+- Box-shadow: `0 4px 24px rgba(0,0,0,0.5), 0 1px 4px rgba(0,0,0,0.3)`
+
+**Peek card contents:**
+- Header: source file path (`font-mono` 9px `--fg-3`) + ✕ close button, separated by 1px `--border` bottom
+- Section heading: `font-mono` 8px `--fg-3` uppercase
+- Referenced passage: `background: rgba(74,158,255,0.07)`, `border-left: 2px solid rgba(74,158,255,0.3)`, `padding: 5px 7px` — this is the exact span the agent cited
+- Context lines: dimmed placeholder lines above/below
+- Footer: "N of M references" count + ← → navigation between refs + "open full note" link
+
+**Dismiss:** tap ✕ or anywhere outside the card. No modal backdrop needed.
+
+**Note on positioning:** on iPad portrait or narrow viewports, the peek card should shift to appear above or below the dot (not off-screen right). On iPhone, use a bottom sheet for the peek.
+
+---
+
+## Component inventory
+
+| Component | Description |
+|---|---|
+| `TopBar` | 38px app shell bar: logo glyph, surface nav tabs, session pill, vault dot |
+| `DocumentPane` | Scrollable document area, centered column, renders markdown |
+| `MarginRail` | Right-side panel: collapsed strip (32px) ↔ active panel (288px) |
+| `BottomSheet` | Portrait-mode rail, draggable, three snap points |
+| `ConversationThread` | Scrollable message list inside the rail |
+| `HumanMessage` | Right-aligned bubble, `--bg-raised` |
+| `AgentMessage` | Left-aligned, faint blue tint, context label + source footnote |
+| `ThinkingIndicator` | Three-dot pulse animation |
+| `Composer` | Textarea + Send button (only cyan element in dialogue state) |
+| `SuggestionCard` | Amber card in thread, mirrors document insertion block |
+| `DocumentInsertionBlock` | Amber annotated region in the document |
+| `MarginDot` | 8–10px circle at right edge of annotated passage, tappable |
+| `SourcePeekCard` | Floating card anchored to a margin dot |
+| `SessionDrawer` | Left overlay: session list, search, new session |
+| `SessionListItem` | Single row: title, path, age, turn count |
+
+---
+
+## Interaction patterns
+
+### Rail expand/collapse
+- Collapsed → active: tap strip or drag from right edge. Animate width 32px → 288px, `ease-out 200ms`.
+- Active → collapsed: tap collapse handle "›" or drag. Same animation reversed.
+- Rail and document animate simultaneously; document column narrows as rail expands.
+
+### Session switching
+1. Tap session pill in top bar → session drawer slides in from left (`translateX(-340px → 0`, `ease-out 220ms`)
+2. Tap session in list → drawer slides out, document transitions to new session's note
+3. Tap scrim → drawer slides out, no session change
+4. Keyboard: Escape closes drawer
+
+### Suggestion flow
+1. Agent produces suggestion → `SuggestionCard` appears in thread at full opacity; prior messages dim to 0.3
+2. Simultaneously: `DocumentInsertionBlock` appears at correct location in document; surrounding sections dim to 0.35
+3. Composer disables, hint text "apply or discard to continue" appears
+4. **Apply:** POST to runtime `SUGGEST` endpoint → on success, document re-renders with insertion applied, amber regions clear, composer re-enables
+5. **Discard:** suggestion card + document insertion block both clear, full opacity restored, composer re-enables
+6. The amber treatment on the card and document block must be visually identical — same colour, same label — they are the same object
+
+### Source peek
+1. Tap margin dot → peek card appears anchored to dot, animated `opacity 0 → 1, translateY(4px → 0), 150ms ease-out`
+2. Multiple dots can be on screen; tapping a second dot closes the first, opens the new one
+3. ← → in footer navigates between references within the same cited passage
+4. "open full note" → opens the referenced note in a new session or document view (TBD; for v0, could be a no-op or link to Obsidian URI)
+5. Tap ✕ or outside card → card closes, `opacity 1 → 0, 100ms`
+
+### Portrait bottom sheet snap points
+- **Snap 0 (collapsed):** 32px strip, drag handle barely visible. Sheet has `box-shadow: 0 -4px 20px rgba(0,0,0,0.3)`.
+- **Snap 1 (peek):** ~240px — drag handle + header + one agent message + composer visible.
+- **Snap 2 (full):** ~80% of viewport height — full thread + composer. Document visible above as a sliver.
+- Drag velocity determines which snap point to settle on. Use spring physics or `ease-out`.
+
+---
+
+## Runtime API integration
+
+The UI is a client of the existing FastAPI runtime. All vault I/O goes through it.
+
+| Action | API call |
+|---|---|
+| Load session thread | `GET /sessions/{id}/messages` |
+| Send message | `POST /sessions/{id}/messages` |
+| Load document | `GET /vault/notes/{path}` |
+| Apply suggestion | `POST /sessions/{id}/suggestions/{suggestion_id}/apply` |
+| Discard suggestion | `DELETE /sessions/{id}/suggestions/{suggestion_id}` |
+| List sessions | `GET /sessions` |
+| Create session | `POST /sessions` with `{ title, vault_path }` |
+| Vault status | `GET /health` or websocket event |
+
+Endpoints are illustrative — match to your actual runtime schema. The contract is: the UI proposes (SUGGEST), the runtime owns vault writes (APPLY). No direct vault file I/O from the client.
+
+**Vault unreachable state:**
+- Show a non-blocking banner at top of document pane: `--destructive` colour dot + `font-mono` message "Vault unreachable. Sessions are read-only."
+- Disable composer Send, Apply buttons
+- Do not interrupt the user's reading or discard any composed text
+
+---
+
+## Design tokens
+
+These come from `colors_and_type.css` in the bundled reference files. Implement them as CSS custom properties, Tailwind config keys, or your equivalent.
+
+### Backgrounds
+```
+--bg-base:     #070b12   /* page root */
+--bg-surface:  #0c1220   /* panels, top bar, rail */
+--bg-raised:   #111a2e   /* cards, inputs */
+--bg-overlay:  #162038   /* hover states */
+```
+
+### Foreground
+```
+--fg-1:  #dce8f0   /* primary text */
+--fg-2:  #7a9ab8   /* secondary */
+--fg-3:  #3d5570   /* tertiary / disabled */
+```
+
+### Borders
+```
+--border:        #152030   /* default */
+--border-strong: #1e3050   /* emphasis */
+```
+
+### Semantic accent colours
+```
+--accent:      #d4a843   /* Norse gold — active session highlight */
+--cyan:        #00d4e8   /* Send button, primary action only */
+--vault:       #39e87d   /* vault-connected dot */
+--agent:       #4a9eff   /* Hugin presence dot (used sparingly, mostly as tint) */
+--amber:       #f09030   /* staged/suggested state */
+--destructive: #ff3d3d   /* vault unreachable, errors */
+```
+
+### Typography
+```
+--font-display: 'EB Garamond', Georgia, serif      /* document title */
+--font-ui:      'Space Grotesk', system-ui, sans   /* UI labels, buttons */
+--font-mono:    'JetBrains Mono', monospace         /* metadata, paths, code */
+```
+
+**Font loading:**
+- EB Garamond + Space Grotesk: Google Fonts
+- JetBrains Mono: `https://fonts.bunny.net/css?family=jetbrains-mono:400,500`
+
+### Spacing and radius
+```
+border-radius default: 2–4px (sharp, not pill-shaped)
+border-radius modal/card: 3–4px
+no border-radius > 6px in the UI
+```
+
+---
+
+## Colour discipline
+
+**The most important design constraint:** at any given moment, only the single most actionable element on screen carries a saturated colour. Everything else is monochrome (`--fg-*`, `--border-*`, `--bg-*`).
+
+| Moment | Coloured element |
+|---|---|
+| Focus (reading) | Vault dot only |
+| Dialogue | Vault dot + Send button (cyan) |
+| Suggestion | Vault dot + Apply button + amber tints |
+| Vault unreachable | Destructive banner dot |
+
+Never use glow effects, drop shadows, or `text-shadow` on primary UI elements. The neon/Tron references in the design system exist — use them with restraint, only where they communicate state (e.g. vault dot glow when connected).
+
+---
+
+## What not to build in v0
+
+- Any surface other than Converse (Orient, Capture, Triage, Resurface, Synthesize) — show as disabled nav tabs
+- Direct vault file writes from the UI — all writes go through the runtime
+- Multi-agent UI
+- Onboarding, tooltips, empty-state coaching for a new user
+- Light mode
+- Any modal dialog except possibly the "New session" form (and even that could be inline)
+
+---
+
+## Files in this bundle
+
+| File | Purpose |
+|---|---|
+| `README.md` | This document — the implementation spec |
+| `Companion UI Wireframes.html` | Interactive wireframe canvas — 9 screen states |
+| `design-canvas.jsx` | Canvas component used by wireframes (reference only) |
+| `colors_and_type.css` | Full design token stylesheet |
+
+Open `Companion UI Wireframes.html` in a browser and navigate the canvas. Scroll right for the C deep-dive states (C.1–C.6). Double-click any artboard to fullscreen it.
+
+---
+
+## Prompt to paste into Claude Code
+
+Paste this at the start of your Claude Code session:
+
+```
+I'm implementing a new PWA surface at companion-ui/ in this repo. 
+
+The design is fully specified in companion-ui/design_handoff/README.md — please read that first before writing any code.
+
+Also open companion-ui/design_handoff/Companion UI Wireframes.html in a browser so you can see the 9 wireframe states.
+
+Start by:
+1. Reading README.md in full
+2. Scaffolding the companion-ui/ directory with a React + Vite PWA setup (or adapt to whatever the repo already uses)
+3. Implementing the TopBar, DocumentPane, and MarginRail (collapsed state) first — get the shell right before adding interaction
+4. Then implement State C.2 (Dialogue) end-to-end: real API calls to the FastAPI runtime, real message rendering, working composer
+5. Then the suggestion flow (C.3): SuggestionCard + DocumentInsertionBlock + Apply/Discard wired to the API
+
+Work screen-state by screen-state. Ask me when the API schema is ambiguous.
+
+The runtime base URL is configurable — default to http://localhost:8000 for local dev. I'll tell you the Tailscale address for device testing.
+```

--- a/companion-ui/design-handoff/2026-05-03-converse/colors_and_type.css
+++ b/companion-ui/design-handoff/2026-05-03-converse/colors_and_type.css
@@ -1,0 +1,346 @@
+/* ============================================================
+   Yggdrasil Design System — Colors & Type
+   ============================================================
+   Import this file in any HTML artifact or UI kit.
+   Google Fonts are imported below; JetBrains Mono via bunny.net.
+   ============================================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Space+Grotesk:wght@300;400;500;600&display=swap');
+@import url('https://fonts.bunny.net/css?family=jetbrains-mono:400,500&display=swap');
+
+/* ============================================================
+   BASE COLOR TOKENS
+   ============================================================ */
+:root {
+  /* --- Backgrounds (cool blue-black — Tron grid) --- */
+  --bg-base:       #070b12;   /* deepest — page root, near black with blue cast */
+  --bg-surface:    #0c1220;   /* panels, sidebars */
+  --bg-raised:     #111a2e;   /* cards, inputs, raised surfaces */
+  --bg-overlay:    #162038;   /* hover states, popovers */
+  --bg-modal:      #0e1828;   /* modal / dialog backdrop content */
+
+  /* --- Foreground / Text --- */
+  --fg-1:          #dce8f0;   /* primary — cool blue-white */
+  --fg-2:          #7a9ab8;   /* secondary / muted */
+  --fg-3:          #3d5570;   /* tertiary / disabled / dim */
+  --fg-inverse:    #070b12;   /* text on light/accent backgrounds */
+
+  /* --- Borders (thin, slightly glowing) --- */
+  --border:        #152030;   /* default — subtle grid line */
+  --border-strong: #1e3050;   /* emphasis — dividers, active edges */
+  --border-focus:  #00d4e8;   /* focus ring — electric cyan */
+
+  /* --- Accent 1: Norse Gold (slightly electrified) --- */
+  --accent:        #d4a843;   /* primary accent — active, focus, key affordances */
+  --accent-dim:    #80621a;   /* dimmed gold */
+  --accent-muted:  #2a1e06;   /* gold at low opacity */
+
+  /* --- Accent 2: Tron Cyan (neon electric) --- */
+  --cyan:          #00d4e8;   /* electric cyan — Tron primary glow */
+  --cyan-dim:      #007a8a;   /* dimmed cyan */
+  --cyan-muted:    #001e28;   /* cyan tint background */
+  --cyan-glow:     0 0 12px rgba(0,212,232,0.35), 0 0 4px rgba(0,212,232,0.5);
+
+  /* --- Vault: Neon green (digital growth) --- */
+  --vault:         #39e87d;   /* vault-connected — electric green */
+  --vault-dim:     #1a7840;   /* vault hover */
+  --vault-muted:   #041a10;   /* vault background tint */
+  --vault-glow:    0 0 8px rgba(57,232,125,0.3);
+
+  /* --- Agent: Electric blue (machine voice) --- */
+  --agent:         #4a9eff;   /* agent-contributed UI and content */
+  --agent-dim:     #1e5a9a;   /* agent hover */
+  --agent-muted:   #051228;   /* agent background tint */
+  --agent-glow:    0 0 8px rgba(74,158,255,0.3);
+
+  /* --- Amber (staged / uncommitted) --- */
+  --amber:         #f09030;   /* warnings, uncommitted/staged state */
+  --amber-dim:     #805010;
+  --amber-muted:   #1a0e02;
+
+  /* --- Destructive --- */
+  --destructive:      #ff3d3d;
+  --destructive-dim:  #8a1a1a;
+  --destructive-muted:#160404;
+
+  /* --- Semantic UI colors --- */
+  --color-bg:        var(--bg-base);
+  --color-surface:   var(--bg-surface);
+  --color-text:      var(--fg-1);
+  --color-muted:     var(--fg-2);
+  --color-dim:       var(--fg-3);
+  --color-border:    var(--border);
+  --color-accent:    var(--accent);
+
+  /* ============================================================
+     TYPOGRAPHY
+     ============================================================ */
+
+  /* --- Font families --- */
+  --font-display:  'EB Garamond', Georgia, serif;
+  --font-ui:       'Space Grotesk', system-ui, sans-serif;
+  --font-mono:     'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+
+  /* --- Type scale (rem, base 16px) --- */
+  --text-xs:    0.6875rem;   /* 11px — metadata, timestamps */
+  --text-sm:    0.8125rem;   /* 13px — secondary labels, captions */
+  --text-base:  0.9375rem;   /* 15px — body / default UI */
+  --text-md:    1.0625rem;   /* 17px — slightly emphasized body */
+  --text-lg:    1.1875rem;   /* 19px — section headers */
+  --text-xl:    1.5rem;      /* 24px — page titles */
+  --text-2xl:   2rem;        /* 32px — display moments */
+  --text-3xl:   2.75rem;     /* 44px — wordmark / hero */
+  --text-4xl:   3.75rem;     /* 60px — large display */
+
+  /* --- Line heights --- */
+  --leading-tight:  1.25;
+  --leading-snug:   1.4;
+  --leading-normal: 1.55;
+  --leading-loose:  1.75;
+
+  /* --- Font weights --- */
+  --weight-light:   300;
+  --weight-regular: 400;
+  --weight-medium:  500;
+  --weight-semibold:600;
+
+  /* --- Letter spacing --- */
+  --tracking-tight: -0.02em;
+  --tracking-normal: 0em;
+  --tracking-wide:   0.04em;
+  --tracking-wider:  0.08em;
+
+  /* ============================================================
+     SPACING
+     ============================================================ */
+  --space-1:   4px;
+  --space-2:   8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  20px;
+  --space-6:  24px;
+  --space-8:  32px;
+  --space-10: 40px;
+  --space-12: 48px;
+  --space-16: 64px;
+
+  /* ============================================================
+     BORDER RADIUS — sharper for cyberpunk aesthetic
+     ============================================================ */
+  --radius-sm:   2px;
+  --radius-md:   4px;
+  --radius-lg:   6px;
+  --radius-xl:  10px;
+  --radius-full: 9999px;
+
+  /* ============================================================
+     SHADOWS / ELEVATION
+     ============================================================ */
+  --shadow-sm:  0 1px 3px rgba(0,0,0,0.3);
+  --shadow-md:  0 4px 12px rgba(0,0,0,0.4);
+  --shadow-lg:  0 8px 32px rgba(0,0,0,0.5);
+  --shadow-float: 0 4px 24px rgba(0,0,0,0.55), 0 1px 4px rgba(0,0,0,0.3);
+  --shadow-inset: inset 0 1px 3px rgba(0,0,0,0.35);
+
+  /* ============================================================
+     ANIMATION
+     ============================================================ */
+  --ease:        cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-linear: linear;
+  --duration-fast: 100ms;
+  --duration-base: 150ms;
+  --duration-slow: 250ms;
+
+  /* ============================================================
+     Z-INDEX SCALE
+     ============================================================ */
+  --z-base:    1;
+  --z-raised:  10;
+  --z-sticky:  100;
+  --z-overlay: 200;
+  --z-modal:   300;
+  --z-toast:   400;
+}
+
+/* ============================================================
+   SEMANTIC ELEMENT DEFAULTS
+   ============================================================ */
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+body {
+  background-color: var(--bg-base);
+  color: var(--fg-1);
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-normal);
+}
+
+/* --- Display headings (EB Garamond) --- */
+h1, .h1 {
+  font-family: var(--font-display);
+  font-size: var(--text-3xl);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  color: var(--fg-1);
+}
+
+h2, .h2 {
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  color: var(--fg-1);
+}
+
+/* --- UI headings (DM Sans) --- */
+h3, .h3 {
+  font-family: var(--font-ui);
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-snug);
+  color: var(--fg-1);
+}
+
+h4, .h4 {
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-snug);
+  color: var(--fg-1);
+}
+
+h5, h6, .h5, .h6 {
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-snug);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--fg-2);
+}
+
+p {
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
+  color: var(--fg-1);
+  text-wrap: pretty;
+}
+
+small, .text-sm {
+  font-size: var(--text-sm);
+  color: var(--fg-2);
+}
+
+.text-xs {
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  font-family: var(--font-mono);
+  letter-spacing: var(--tracking-wide);
+}
+
+code, kbd, pre, .mono {
+  font-family: var(--font-mono);
+  font-size: 0.875em; /* relative to surrounding text */
+}
+
+code {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.1em 0.35em;
+  color: var(--fg-1);
+}
+
+pre {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  overflow-x: auto;
+  font-size: var(--text-sm);
+  line-height: var(--leading-normal);
+  color: var(--fg-1);
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+a:hover {
+  color: var(--fg-1);
+  text-decoration: underline;
+}
+
+hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: var(--space-6) 0;
+}
+
+/* ============================================================
+   UTILITY CLASSES
+   ============================================================ */
+
+/* Text colors */
+.text-primary   { color: var(--fg-1); }
+.text-secondary { color: var(--fg-2); }
+.text-dim       { color: var(--fg-3); }
+.text-accent    { color: var(--accent); }
+.text-cyan      { color: var(--cyan); }
+.text-vault     { color: var(--vault); }
+.text-agent     { color: var(--agent); }
+.text-amber     { color: var(--amber); }
+.text-danger    { color: var(--destructive); }
+
+/* Font families */
+.font-display { font-family: var(--font-display); }
+.font-ui      { font-family: var(--font-ui); }
+.font-mono    { font-family: var(--font-mono); }
+
+/* Weights */
+.weight-light    { font-weight: var(--weight-light); }
+.weight-regular  { font-weight: var(--weight-regular); }
+.weight-medium   { font-weight: var(--weight-medium); }
+.weight-semibold { font-weight: var(--weight-semibold); }
+
+/* Glow effects */
+.glow-cyan   { box-shadow: var(--cyan-glow); }
+.glow-vault  { box-shadow: var(--vault-glow); }
+.glow-agent  { box-shadow: var(--agent-glow); }
+.text-glow-cyan  { text-shadow: 0 0 12px rgba(0,212,232,0.7); }
+.text-glow-gold  { text-shadow: 0 0 16px rgba(212,168,67,0.5); }
+
+/* Tron grid background */
+.grid-bg {
+  background-image:
+    linear-gradient(rgba(0,212,232,0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0,212,232,0.04) 1px, transparent 1px);
+  background-size: 32px 32px;
+}
+
+/* Neon border active state */
+.border-cyan { border-color: var(--cyan) !important; box-shadow: var(--cyan-glow); }
+.border-gold { border-color: var(--accent) !important; box-shadow: 0 0 8px rgba(212,168,67,0.3); }
+
+/* Focus ring */
+:focus-visible {
+  outline: 1px solid var(--cyan);
+  outline-offset: 2px;
+  box-shadow: var(--cyan-glow);
+}

--- a/companion-ui/design-handoff/2026-05-03-converse/design-canvas.jsx
+++ b/companion-ui/design-handoff/2026-05-03-converse/design-canvas.jsx
@@ -1,0 +1,622 @@
+
+// DesignCanvas.jsx — Figma-ish design canvas wrapper
+// Warm gray grid bg + Sections + Artboards + PostIt notes.
+// Artboards are reorderable (grip-drag), labels/titles are inline-editable,
+// and any artboard can be opened in a fullscreen focus overlay (←/→/Esc).
+// State persists to a .design-canvas.state.json sidecar via the host
+// bridge. No assets, no deps.
+//
+// Usage:
+//   <DesignCanvas>
+//     <DCSection id="onboarding" title="Onboarding" subtitle="First-run variants">
+//       <DCArtboard id="a" label="A · Dusk" width={260} height={480}>…</DCArtboard>
+//       <DCArtboard id="b" label="B · Minimal" width={260} height={480}>…</DCArtboard>
+//     </DCSection>
+//   </DesignCanvas>
+
+const DC = {
+  bg: '#f0eee9',
+  grid: 'rgba(0,0,0,0.06)',
+  label: 'rgba(60,50,40,0.7)',
+  title: 'rgba(40,30,20,0.85)',
+  subtitle: 'rgba(60,50,40,0.6)',
+  postitBg: '#fef4a8',
+  postitText: '#5a4a2a',
+  font: '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+};
+
+// One-time CSS injection (classes are dc-prefixed so they don't collide with
+// the hosted design's own styles).
+if (typeof document !== 'undefined' && !document.getElementById('dc-styles')) {
+  const s = document.createElement('style');
+  s.id = 'dc-styles';
+  s.textContent = [
+    '.dc-editable{cursor:text;outline:none;white-space:nowrap;border-radius:3px;padding:0 2px;margin:0 -2px}',
+    '.dc-editable:focus{background:#fff;box-shadow:0 0 0 1.5px #c96442}',
+    '[data-dc-slot]{transition:transform .18s cubic-bezier(.2,.7,.3,1)}',
+    '[data-dc-slot].dc-dragging{transition:none;z-index:10;pointer-events:none}',
+    '[data-dc-slot].dc-dragging .dc-card{box-shadow:0 12px 40px rgba(0,0,0,.25),0 0 0 2px #c96442;transform:scale(1.02)}',
+    '.dc-card{transition:box-shadow .15s,transform .15s}',
+    '.dc-card *{scrollbar-width:none}',
+    '.dc-card *::-webkit-scrollbar{display:none}',
+    '.dc-labelrow{display:flex;align-items:center;gap:4px;height:24px}',
+    '.dc-grip{cursor:grab;display:flex;align-items:center;padding:5px 4px;border-radius:4px;transition:background .12s}',
+    '.dc-grip:hover{background:rgba(0,0,0,.08)}',
+    '.dc-grip:active{cursor:grabbing}',
+    '.dc-labeltext{cursor:pointer;border-radius:4px;padding:3px 6px;display:flex;align-items:center;transition:background .12s}',
+    '.dc-labeltext:hover{background:rgba(0,0,0,.05)}',
+    '.dc-expand{position:absolute;bottom:100%;right:0;margin-bottom:5px;z-index:2;opacity:0;transition:opacity .12s,background .12s;',
+    '  width:22px;height:22px;border-radius:5px;border:none;cursor:pointer;padding:0;',
+    '  background:transparent;color:rgba(60,50,40,.7);display:flex;align-items:center;justify-content:center}',
+    '.dc-expand:hover{background:rgba(0,0,0,.06);color:#2a251f}',
+    '[data-dc-slot]:hover .dc-expand{opacity:1}',
+  ].join('\n');
+  document.head.appendChild(s);
+}
+
+const DCCtx = React.createContext(null);
+
+// ─────────────────────────────────────────────────────────────
+// DesignCanvas — stateful wrapper around the pan/zoom viewport.
+// Owns runtime state (per-section order, renamed titles/labels, focused
+// artboard). Order/titles/labels persist to a .design-canvas.state.json
+// sidecar next to the HTML. Reads go via plain fetch() so the saved
+// arrangement is visible anywhere the HTML + sidecar are served together
+// (omelette preview, direct link, downloaded zip). Writes go through the
+// host's window.omelette bridge — editing requires the omelette runtime.
+// Focus is ephemeral.
+// ─────────────────────────────────────────────────────────────
+const DC_STATE_FILE = '.design-canvas.state.json';
+
+function DesignCanvas({ children, minScale, maxScale, style }) {
+  const [state, setState] = React.useState({ sections: {}, focus: null });
+  // Hold rendering until the sidecar read settles so the saved order/titles
+  // appear on first paint (no source-order flash). didRead gates writes until
+  // the read settles so the empty initial state can't clobber a slow read;
+  // skipNextWrite suppresses the one echo-write that would otherwise follow
+  // hydration.
+  const [ready, setReady] = React.useState(false);
+  const didRead = React.useRef(false);
+  const skipNextWrite = React.useRef(false);
+
+  React.useEffect(() => {
+    let off = false;
+    fetch('./' + DC_STATE_FILE)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((saved) => {
+        if (off || !saved || !saved.sections) return;
+        skipNextWrite.current = true;
+        setState((s) => ({ ...s, sections: saved.sections }));
+      })
+      .catch(() => {})
+      .finally(() => { didRead.current = true; if (!off) setReady(true); });
+    const t = setTimeout(() => { if (!off) setReady(true); }, 150);
+    return () => { off = true; clearTimeout(t); };
+  }, []);
+
+  React.useEffect(() => {
+    if (!didRead.current) return;
+    if (skipNextWrite.current) { skipNextWrite.current = false; return; }
+    const t = setTimeout(() => {
+      window.omelette?.writeFile(DC_STATE_FILE, JSON.stringify({ sections: state.sections })).catch(() => {});
+    }, 250);
+    return () => clearTimeout(t);
+  }, [state.sections]);
+
+  // Build registries synchronously from children so FocusOverlay can read
+  // them in the same render. Only direct DCSection > DCArtboard children are
+  // walked — wrapping them in other elements opts out of focus/reorder.
+  const registry = {};     // slotId -> { sectionId, artboard }
+  const sectionMeta = {};  // sectionId -> { title, subtitle, slotIds[] }
+  const sectionOrder = [];
+  React.Children.forEach(children, (sec) => {
+    if (!sec || sec.type !== DCSection) return;
+    const sid = sec.props.id ?? sec.props.title;
+    if (!sid) return;
+    sectionOrder.push(sid);
+    const persisted = state.sections[sid] || {};
+    const srcIds = [];
+    React.Children.forEach(sec.props.children, (ab) => {
+      if (!ab || ab.type !== DCArtboard) return;
+      const aid = ab.props.id ?? ab.props.label;
+      if (!aid) return;
+      registry[`${sid}/${aid}`] = { sectionId: sid, artboard: ab };
+      srcIds.push(aid);
+    });
+    const kept = (persisted.order || []).filter((k) => srcIds.includes(k));
+    sectionMeta[sid] = {
+      title: persisted.title ?? sec.props.title,
+      subtitle: sec.props.subtitle,
+      slotIds: [...kept, ...srcIds.filter((k) => !kept.includes(k))],
+    };
+  });
+
+  const api = React.useMemo(() => ({
+    state,
+    section: (id) => state.sections[id] || {},
+    patchSection: (id, p) => setState((s) => ({
+      ...s,
+      sections: { ...s.sections, [id]: { ...s.sections[id], ...(typeof p === 'function' ? p(s.sections[id] || {}) : p) } },
+    })),
+    setFocus: (slotId) => setState((s) => ({ ...s, focus: slotId })),
+  }), [state]);
+
+  // Esc exits focus; any outside pointerdown commits an in-progress rename.
+  React.useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') api.setFocus(null); };
+    const onPd = (e) => {
+      const ae = document.activeElement;
+      if (ae && ae.isContentEditable && !ae.contains(e.target)) ae.blur();
+    };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('pointerdown', onPd, true);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('pointerdown', onPd, true);
+    };
+  }, [api]);
+
+  return (
+    <DCCtx.Provider value={api}>
+      <DCViewport minScale={minScale} maxScale={maxScale} style={style}>{ready && children}</DCViewport>
+      {state.focus && registry[state.focus] && (
+        <DCFocusOverlay entry={registry[state.focus]} sectionMeta={sectionMeta} sectionOrder={sectionOrder} />
+      )}
+    </DCCtx.Provider>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCViewport — transform-based pan/zoom (internal)
+//
+// Input mapping (Figma-style):
+//   • trackpad pinch  → zoom   (ctrlKey wheel; Safari gesture* events)
+//   • trackpad scroll → pan    (two-finger)
+//   • mouse wheel     → zoom   (notched; distinguished from trackpad scroll)
+//   • middle-drag / primary-drag-on-bg → pan
+//
+// Transform state lives in a ref and is written straight to the DOM
+// (translate3d + will-change) so wheel ticks don't go through React —
+// keeps pans at 60fps on dense canvases.
+// ─────────────────────────────────────────────────────────────
+function DCViewport({ children, minScale = 0.1, maxScale = 8, style = {} }) {
+  const vpRef = React.useRef(null);
+  const worldRef = React.useRef(null);
+  const tf = React.useRef({ x: 0, y: 0, scale: 1 });
+
+  const apply = React.useCallback(() => {
+    const { x, y, scale } = tf.current;
+    const el = worldRef.current;
+    if (el) el.style.transform = `translate3d(${x}px, ${y}px, 0) scale(${scale})`;
+  }, []);
+
+  React.useEffect(() => {
+    const vp = vpRef.current;
+    if (!vp) return;
+
+    const zoomAt = (cx, cy, factor) => {
+      const r = vp.getBoundingClientRect();
+      const px = cx - r.left, py = cy - r.top;
+      const t = tf.current;
+      const next = Math.min(maxScale, Math.max(minScale, t.scale * factor));
+      const k = next / t.scale;
+      // keep the world point under the cursor fixed
+      t.x = px - (px - t.x) * k;
+      t.y = py - (py - t.y) * k;
+      t.scale = next;
+      apply();
+    };
+
+    // Mouse-wheel vs trackpad-scroll heuristic. A physical wheel sends
+    // line-mode deltas (Firefox) or large integer pixel deltas with no X
+    // component (Chrome/Safari, typically multiples of 100/120). Trackpad
+    // two-finger scroll sends small/fractional pixel deltas, often with
+    // non-zero deltaX. ctrlKey is set by the browser for trackpad pinch.
+    const isMouseWheel = (e) =>
+      e.deltaMode !== 0 ||
+      (e.deltaX === 0 && Number.isInteger(e.deltaY) && Math.abs(e.deltaY) >= 40);
+
+    const onWheel = (e) => {
+      e.preventDefault();
+      if (isGesturing) return; // Safari: gesture* owns the pinch — discard concurrent wheels
+      if (e.ctrlKey) {
+        // trackpad pinch (or explicit ctrl+wheel)
+        zoomAt(e.clientX, e.clientY, Math.exp(-e.deltaY * 0.01));
+      } else if (isMouseWheel(e)) {
+        // notched mouse wheel — fixed-ratio step per click
+        zoomAt(e.clientX, e.clientY, Math.exp(-Math.sign(e.deltaY) * 0.18));
+      } else {
+        // trackpad two-finger scroll — pan
+        tf.current.x -= e.deltaX;
+        tf.current.y -= e.deltaY;
+        apply();
+      }
+    };
+
+    // Safari sends native gesture* events for trackpad pinch with a smooth
+    // e.scale; preferring these over the ctrl+wheel fallback gives a much
+    // better feel there. No-ops on other browsers. Safari also fires
+    // ctrlKey wheel events during the same pinch — isGesturing makes
+    // onWheel drop those entirely so they neither zoom nor pan.
+    let gsBase = 1;
+    let isGesturing = false;
+    const onGestureStart = (e) => { e.preventDefault(); isGesturing = true; gsBase = tf.current.scale; };
+    const onGestureChange = (e) => {
+      e.preventDefault();
+      zoomAt(e.clientX, e.clientY, (gsBase * e.scale) / tf.current.scale);
+    };
+    const onGestureEnd = (e) => { e.preventDefault(); isGesturing = false; };
+
+    // Drag-pan: middle button anywhere, or primary button on canvas
+    // background (anything that isn't an artboard or an inline editor).
+    let drag = null;
+    const onPointerDown = (e) => {
+      const onBg = !e.target.closest('[data-dc-slot], .dc-editable');
+      if (!(e.button === 1 || (e.button === 0 && onBg))) return;
+      e.preventDefault();
+      vp.setPointerCapture(e.pointerId);
+      drag = { id: e.pointerId, lx: e.clientX, ly: e.clientY };
+      vp.style.cursor = 'grabbing';
+    };
+    const onPointerMove = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      tf.current.x += e.clientX - drag.lx;
+      tf.current.y += e.clientY - drag.ly;
+      drag.lx = e.clientX; drag.ly = e.clientY;
+      apply();
+    };
+    const onPointerUp = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      vp.releasePointerCapture(e.pointerId);
+      drag = null;
+      vp.style.cursor = '';
+    };
+
+    vp.addEventListener('wheel', onWheel, { passive: false });
+    vp.addEventListener('gesturestart', onGestureStart, { passive: false });
+    vp.addEventListener('gesturechange', onGestureChange, { passive: false });
+    vp.addEventListener('gestureend', onGestureEnd, { passive: false });
+    vp.addEventListener('pointerdown', onPointerDown);
+    vp.addEventListener('pointermove', onPointerMove);
+    vp.addEventListener('pointerup', onPointerUp);
+    vp.addEventListener('pointercancel', onPointerUp);
+    return () => {
+      vp.removeEventListener('wheel', onWheel);
+      vp.removeEventListener('gesturestart', onGestureStart);
+      vp.removeEventListener('gesturechange', onGestureChange);
+      vp.removeEventListener('gestureend', onGestureEnd);
+      vp.removeEventListener('pointerdown', onPointerDown);
+      vp.removeEventListener('pointermove', onPointerMove);
+      vp.removeEventListener('pointerup', onPointerUp);
+      vp.removeEventListener('pointercancel', onPointerUp);
+    };
+  }, [apply, minScale, maxScale]);
+
+  const gridSvg = `url("data:image/svg+xml,%3Csvg width='120' height='120' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M120 0H0v120' fill='none' stroke='${encodeURIComponent(DC.grid)}' stroke-width='1'/%3E%3C/svg%3E")`;
+  return (
+    <div
+      ref={vpRef}
+      className="design-canvas"
+      style={{
+        height: '100vh', width: '100vw',
+        background: DC.bg,
+        overflow: 'hidden',
+        overscrollBehavior: 'none',
+        touchAction: 'none',
+        position: 'relative',
+        fontFamily: DC.font,
+        boxSizing: 'border-box',
+        ...style,
+      }}
+    >
+      <div
+        ref={worldRef}
+        style={{
+          position: 'absolute', top: 0, left: 0,
+          transformOrigin: '0 0',
+          willChange: 'transform',
+          width: 'max-content', minWidth: '100%',
+          minHeight: '100%',
+          padding: '60px 0 80px',
+        }}
+      >
+        <div style={{ position: 'absolute', inset: -6000, backgroundImage: gridSvg, backgroundSize: '120px 120px', pointerEvents: 'none', zIndex: -1 }} />
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCSection — editable title + h-row of artboards in persisted order
+// ─────────────────────────────────────────────────────────────
+function DCSection({ id, title, subtitle, children, gap = 48 }) {
+  const ctx = React.useContext(DCCtx);
+  const sid = id ?? title;
+  const all = React.Children.toArray(children);
+  const artboards = all.filter((c) => c && c.type === DCArtboard);
+  const rest = all.filter((c) => !(c && c.type === DCArtboard));
+  const srcOrder = artboards.map((a) => a.props.id ?? a.props.label);
+  const sec = (ctx && sid && ctx.section(sid)) || {};
+
+  const order = React.useMemo(() => {
+    const kept = (sec.order || []).filter((k) => srcOrder.includes(k));
+    return [...kept, ...srcOrder.filter((k) => !kept.includes(k))];
+  }, [sec.order, srcOrder.join('|')]);
+
+  const byId = Object.fromEntries(artboards.map((a) => [a.props.id ?? a.props.label, a]));
+
+  return (
+    <div data-dc-section={sid} style={{ marginBottom: 80, position: 'relative' }}>
+      <div style={{ padding: '0 60px 56px' }}>
+        <DCEditable tag="div" value={sec.title ?? title}
+          onChange={(v) => ctx && sid && ctx.patchSection(sid, { title: v })}
+          style={{ fontSize: 28, fontWeight: 600, color: DC.title, letterSpacing: -0.4, marginBottom: 6, display: 'inline-block' }} />
+        {subtitle && <div style={{ fontSize: 16, color: DC.subtitle }}>{subtitle}</div>}
+      </div>
+      <div style={{ display: 'flex', gap, padding: '0 60px', alignItems: 'flex-start', width: 'max-content' }}>
+        {order.map((k) => (
+          <DCArtboardFrame key={k} sectionId={sid} artboard={byId[k]} order={order}
+            label={(sec.labels || {})[k] ?? byId[k].props.label}
+            onRename={(v) => ctx && ctx.patchSection(sid, (x) => ({ labels: { ...x.labels, [k]: v } }))}
+            onReorder={(next) => ctx && ctx.patchSection(sid, { order: next })}
+            onFocus={() => ctx && ctx.setFocus(`${sid}/${k}`)} />
+        ))}
+      </div>
+      {rest}
+    </div>
+  );
+}
+
+// DCArtboard — marker; rendered by DCArtboardFrame via DCSection.
+function DCArtboard() { return null; }
+
+function DCArtboardFrame({ sectionId, artboard, label, order, onRename, onReorder, onFocus }) {
+  const { id: rawId, label: rawLabel, width = 260, height = 480, children, style = {} } = artboard.props;
+  const id = rawId ?? rawLabel;
+  const ref = React.useRef(null);
+
+  // Live drag-reorder: dragged card sticks to cursor; siblings slide into
+  // their would-be slots in real time via transforms. DOM order only
+  // changes on drop.
+  const onGripDown = (e) => {
+    e.preventDefault(); e.stopPropagation();
+    const me = ref.current;
+    // translateX is applied in local (pre-scale) space but pointer deltas and
+    // getBoundingClientRect().left are screen-space — divide by the viewport's
+    // current scale so the dragged card tracks the cursor at any zoom level.
+    const scale = me.getBoundingClientRect().width / me.offsetWidth || 1;
+    const peers = Array.from(document.querySelectorAll(`[data-dc-section="${sectionId}"] [data-dc-slot]`));
+    const homes = peers.map((el) => ({ el, id: el.dataset.dcSlot, x: el.getBoundingClientRect().left }));
+    const slotXs = homes.map((h) => h.x);
+    const startIdx = order.indexOf(id);
+    const startX = e.clientX;
+    let liveOrder = order.slice();
+    me.classList.add('dc-dragging');
+
+    const layout = () => {
+      for (const h of homes) {
+        if (h.id === id) continue;
+        const slot = liveOrder.indexOf(h.id);
+        h.el.style.transform = `translateX(${(slotXs[slot] - h.x) / scale}px)`;
+      }
+    };
+
+    const move = (ev) => {
+      const dx = ev.clientX - startX;
+      me.style.transform = `translateX(${dx / scale}px)`;
+      const cur = homes[startIdx].x + dx;
+      let nearest = 0, best = Infinity;
+      for (let i = 0; i < slotXs.length; i++) {
+        const d = Math.abs(slotXs[i] - cur);
+        if (d < best) { best = d; nearest = i; }
+      }
+      if (liveOrder.indexOf(id) !== nearest) {
+        liveOrder = order.filter((k) => k !== id);
+        liveOrder.splice(nearest, 0, id);
+        layout();
+      }
+    };
+
+    const up = () => {
+      document.removeEventListener('pointermove', move);
+      document.removeEventListener('pointerup', up);
+      const finalSlot = liveOrder.indexOf(id);
+      me.classList.remove('dc-dragging');
+      me.style.transform = `translateX(${(slotXs[finalSlot] - homes[startIdx].x) / scale}px)`;
+      // After the settle transition, kill transitions + clear transforms +
+      // commit the reorder in the same frame so there's no visual snap-back.
+      setTimeout(() => {
+        for (const h of homes) { h.el.style.transition = 'none'; h.el.style.transform = ''; }
+        if (liveOrder.join('|') !== order.join('|')) onReorder(liveOrder);
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+          for (const h of homes) h.el.style.transition = '';
+        }));
+      }, 180);
+    };
+    document.addEventListener('pointermove', move);
+    document.addEventListener('pointerup', up);
+  };
+
+  return (
+    <div ref={ref} data-dc-slot={id} style={{ position: 'relative', flexShrink: 0 }}>
+      <div className="dc-labelrow" style={{ position: 'absolute', bottom: '100%', left: -4, marginBottom: 4, color: DC.label }}>
+        <div className="dc-grip" onPointerDown={onGripDown} title="Drag to reorder">
+          <svg width="9" height="13" viewBox="0 0 9 13" fill="currentColor"><circle cx="2" cy="2" r="1.1"/><circle cx="7" cy="2" r="1.1"/><circle cx="2" cy="6.5" r="1.1"/><circle cx="7" cy="6.5" r="1.1"/><circle cx="2" cy="11" r="1.1"/><circle cx="7" cy="11" r="1.1"/></svg>
+        </div>
+        <div className="dc-labeltext" onClick={onFocus} title="Click to focus">
+          <DCEditable value={label} onChange={onRename} onClick={(e) => e.stopPropagation()}
+            style={{ fontSize: 15, fontWeight: 500, color: DC.label, lineHeight: 1 }} />
+        </div>
+      </div>
+      <button className="dc-expand" onClick={onFocus} onPointerDown={(e) => e.stopPropagation()} title="Focus">
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"><path d="M7 1h4v4M5 11H1V7M11 1L7.5 4.5M1 11l3.5-3.5"/></svg>
+      </button>
+      <div className="dc-card"
+        style={{ borderRadius: 2, boxShadow: '0 1px 3px rgba(0,0,0,.08),0 4px 16px rgba(0,0,0,.06)', overflow: 'hidden', width, height, background: '#fff', ...style }}>
+        {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb', fontSize: 13, fontFamily: DC.font }}>{id}</div>}
+      </div>
+    </div>
+  );
+}
+
+// Inline rename — commits on blur or Enter.
+function DCEditable({ value, onChange, style, tag = 'span', onClick }) {
+  const T = tag;
+  return (
+    <T className="dc-editable" contentEditable suppressContentEditableWarning
+      onClick={onClick}
+      onPointerDown={(e) => e.stopPropagation()}
+      onBlur={(e) => onChange && onChange(e.currentTarget.textContent)}
+      onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); e.currentTarget.blur(); } }}
+      style={style}>{value}</T>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Focus mode — overlay one artboard; ←/→ within section, ↑/↓ across
+// sections, Esc or backdrop click to exit.
+// ─────────────────────────────────────────────────────────────
+function DCFocusOverlay({ entry, sectionMeta, sectionOrder }) {
+  const ctx = React.useContext(DCCtx);
+  const { sectionId, artboard } = entry;
+  const sec = ctx.section(sectionId);
+  const meta = sectionMeta[sectionId];
+  const peers = meta.slotIds;
+  const aid = artboard.props.id ?? artboard.props.label;
+  const idx = peers.indexOf(aid);
+  const secIdx = sectionOrder.indexOf(sectionId);
+
+  const go = (d) => { const n = peers[(idx + d + peers.length) % peers.length]; if (n) ctx.setFocus(`${sectionId}/${n}`); };
+  const goSection = (d) => {
+    const ns = sectionOrder[(secIdx + d + sectionOrder.length) % sectionOrder.length];
+    const first = sectionMeta[ns] && sectionMeta[ns].slotIds[0];
+    if (first) ctx.setFocus(`${ns}/${first}`);
+  };
+
+  React.useEffect(() => {
+    const k = (e) => {
+      if (e.key === 'ArrowLeft') { e.preventDefault(); go(-1); }
+      if (e.key === 'ArrowRight') { e.preventDefault(); go(1); }
+      if (e.key === 'ArrowUp') { e.preventDefault(); goSection(-1); }
+      if (e.key === 'ArrowDown') { e.preventDefault(); goSection(1); }
+    };
+    document.addEventListener('keydown', k);
+    return () => document.removeEventListener('keydown', k);
+  });
+
+  const { width = 260, height = 480, children } = artboard.props;
+  const [vp, setVp] = React.useState({ w: window.innerWidth, h: window.innerHeight });
+  React.useEffect(() => { const r = () => setVp({ w: window.innerWidth, h: window.innerHeight }); window.addEventListener('resize', r); return () => window.removeEventListener('resize', r); }, []);
+  const scale = Math.max(0.1, Math.min((vp.w - 200) / width, (vp.h - 260) / height, 2));
+
+  const [ddOpen, setDd] = React.useState(false);
+  const Arrow = ({ dir, onClick }) => (
+    <button onClick={(e) => { e.stopPropagation(); onClick(); }}
+      style={{ position: 'absolute', top: '50%', [dir]: 28, transform: 'translateY(-50%)',
+        border: 'none', background: 'rgba(255,255,255,.08)', color: 'rgba(255,255,255,.9)',
+        width: 44, height: 44, borderRadius: 22, fontSize: 18, cursor: 'pointer',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'background .15s' }}
+      onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.18)')}
+      onMouseLeave={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.08)')}>
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+        <path d={dir === 'left' ? 'M11 3L5 9l6 6' : 'M7 3l6 6-6 6'} /></svg>
+    </button>
+  );
+
+  // Portal to body so position:fixed is the real viewport regardless of any
+  // transform on DesignCanvas's ancestors (including the canvas zoom itself).
+  return ReactDOM.createPortal(
+    <div onClick={() => ctx.setFocus(null)}
+      onWheel={(e) => e.preventDefault()}
+      style={{ position: 'fixed', inset: 0, zIndex: 100, background: 'rgba(24,20,16,.6)', backdropFilter: 'blur(14px)',
+        fontFamily: DC.font, color: '#fff' }}>
+
+      {/* top bar: section dropdown (left) · close (right) */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 72, display: 'flex', alignItems: 'flex-start', padding: '16px 20px 0', gap: 16 }}>
+        <div style={{ position: 'relative' }}>
+          <button onClick={() => setDd((o) => !o)}
+            style={{ border: 'none', background: 'transparent', color: '#fff', cursor: 'pointer', padding: '6px 8px',
+              borderRadius: 6, textAlign: 'left', fontFamily: 'inherit' }}>
+            <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span style={{ fontSize: 18, fontWeight: 600, letterSpacing: -0.3 }}>{meta.title}</span>
+              <svg width="11" height="11" viewBox="0 0 11 11" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" style={{ opacity: .7 }}><path d="M2 4l3.5 3.5L9 4"/></svg>
+            </span>
+            {meta.subtitle && <span style={{ display: 'block', fontSize: 13, opacity: .6, fontWeight: 400, marginTop: 2 }}>{meta.subtitle}</span>}
+          </button>
+          {ddOpen && (
+            <div style={{ position: 'absolute', top: '100%', left: 0, marginTop: 4, background: '#2a251f', borderRadius: 8,
+              boxShadow: '0 8px 32px rgba(0,0,0,.4)', padding: 4, minWidth: 200, zIndex: 10 }}>
+              {sectionOrder.map((sid) => (
+                <button key={sid} onClick={() => { setDd(false); const f = sectionMeta[sid].slotIds[0]; if (f) ctx.setFocus(`${sid}/${f}`); }}
+                  style={{ display: 'block', width: '100%', textAlign: 'left', border: 'none', cursor: 'pointer',
+                    background: sid === sectionId ? 'rgba(255,255,255,.1)' : 'transparent', color: '#fff',
+                    padding: '8px 12px', borderRadius: 5, fontSize: 14, fontWeight: sid === sectionId ? 600 : 400, fontFamily: 'inherit' }}>
+                  {sectionMeta[sid].title}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <div style={{ flex: 1 }} />
+        <button onClick={() => ctx.setFocus(null)}
+          onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.12)')}
+          onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+          style={{ border: 'none', background: 'transparent', color: 'rgba(255,255,255,.7)', width: 32, height: 32,
+            borderRadius: 16, fontSize: 20, cursor: 'pointer', lineHeight: 1, transition: 'background .12s' }}>×</button>
+      </div>
+
+      {/* card centered, label + index below — only the card itself stops
+          propagation so any backdrop click (including the margins around
+          the card) exits focus */}
+      <div
+        style={{ position: 'absolute', top: 64, bottom: 56, left: 100, right: 100, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 16 }}>
+        <div onClick={(e) => e.stopPropagation()} style={{ width: width * scale, height: height * scale, position: 'relative' }}>
+          <div style={{ width, height, transform: `scale(${scale})`, transformOrigin: 'top left', background: '#fff', borderRadius: 2, overflow: 'hidden',
+            boxShadow: '0 20px 80px rgba(0,0,0,.4)' }}>
+            {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb' }}>{aid}</div>}
+          </div>
+        </div>
+        <div onClick={(e) => e.stopPropagation()} style={{ fontSize: 14, fontWeight: 500, opacity: .85, textAlign: 'center' }}>
+          {(sec.labels || {})[aid] ?? artboard.props.label}
+          <span style={{ opacity: .5, marginLeft: 10, fontVariantNumeric: 'tabular-nums' }}>{idx + 1} / {peers.length}</span>
+        </div>
+      </div>
+
+      <Arrow dir="left" onClick={() => go(-1)} />
+      <Arrow dir="right" onClick={() => go(1)} />
+
+      {/* dots */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', bottom: 20, left: '50%', transform: 'translateX(-50%)', display: 'flex', gap: 8 }}>
+        {peers.map((p, i) => (
+          <button key={p} onClick={() => ctx.setFocus(`${sectionId}/${p}`)}
+            style={{ border: 'none', padding: 0, cursor: 'pointer', width: 6, height: 6, borderRadius: 3,
+              background: i === idx ? '#fff' : 'rgba(255,255,255,.3)' }} />
+        ))}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Post-it — absolute-positioned sticky note
+// ─────────────────────────────────────────────────────────────
+function DCPostIt({ children, top, left, right, bottom, rotate = -2, width = 180 }) {
+  return (
+    <div style={{
+      position: 'absolute', top, left, right, bottom, width,
+      background: DC.postitBg, padding: '14px 16px',
+      fontFamily: '"Comic Sans MS", "Marker Felt", "Segoe Print", cursive',
+      fontSize: 14, lineHeight: 1.4, color: DC.postitText,
+      boxShadow: '0 2px 8px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08)',
+      transform: `rotate(${rotate}deg)`,
+      zIndex: 5,
+    }}>{children}</div>
+  );
+}
+
+Object.assign(window, { DesignCanvas, DCSection, DCArtboard, DCPostIt });
+

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -148,3 +148,9 @@ Normalization note:
 - the active runtime still compresses `promote_to_evergreen` and `update_review_state` toward the
   same mutation path, which is precisely why promotion/review/maturity remain distinct in the
   ontology work.
+
+## Companion UI design handoff (2026-05-03)
+
+- Imported handoff package path: `companion-ui/design-handoff/2026-05-03-converse/`.
+- Treat `companion-ui/design-handoff/2026-05-03-converse/README.md` as the current converse-surface implementation spec.
+- Included HTML/CSS/JSX files are design reference artifacts and should not be shipped as production runtime code.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -616,3 +616,13 @@ The channel layer is orthogonal to the existing `dev`/`prod` environment layer:
 - Downstream features (promotion, rollback, DB isolation) resolve channel identity through `app.config.channel` rather than scattering individual env-var lookups.
 
 See [`docs/RELEASE_CHANNELS/DEFINE_CHANNEL_IDENTITY.md`](RELEASE_CHANNELS/DEFINE_CHANNEL_IDENTITY.md) for the full contract spec.
+
+## Companion UI design handoff reference (2026-05-03)
+
+A new Companion UI converse-surface design handoff was added at `companion-ui/design-handoff/2026-05-03-converse/`.
+This handoff is a design reference package (wireframe HTML, style tokens, and prototype JSX) for implementation inside the companion UI module, not production runtime code.
+
+Architecture boundary reminder:
+- the companion UI remains a client of the existing FastAPI runtime,
+- vault markdown remains the durable source of truth,
+- chat/session/suggestion durability should continue to map to vault-compatible markdown contracts.

--- a/docs/HUMAN-FLOWS.md
+++ b/docs/HUMAN-FLOWS.md
@@ -861,3 +861,8 @@ document should continue to hold.
 - Zhang, J. & Norman, D. A. (1994). [Representations in Distributed Cognitive Tasks](https://pages.ucsd.edu/~scoulson/203/zhang.pdf)
 - Kirsh, D. & Maglio, P. (1994). [On Distinguishing Epistemic from Pragmatic Action](https://philpapers.org/archive/KIRODE.pdf)
 - Zimmerman, B. J. (2002). [Becoming a Self-Regulated Learner: An Overview](https://mathedseminar.pbworks.com/w/file/fetch/94760840/Zimmerman_-_2002_-_Becoming_a_SelfRegulated_Learner_An_Overview.pdf)
+
+## Companion UI converse handoff update (2026-05-03)
+
+Converse interaction design handoff materials are now available at `companion-ui/design-handoff/2026-05-03-converse/`.
+The handoff reinforces the document-first Converse behavior: vault note remains primary, dialogue operates as a secondary rail/sheet, and suggestion moments are staged for explicit user action.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -304,3 +304,9 @@ All six task specs are complete and closed; promotion and rollback skills are au
 ### Outstanding follow-up
 
 **Operational acceptance** — running a stable build against the real vault with a recorded promotion and rehearsed rollback. This is the remaining step before the channel model is treated as fully live in production.
+
+## Companion UI design artifact intake (2026-05-03)
+
+- Converse wireframe/package intake completed at `companion-ui/design-handoff/2026-05-03-converse/`.
+- Package includes implementation-spec README plus reference HTML/CSS/JSX prototypes.
+- Next delivery work should map this handoff into the `companion-ui` implementation while preserving current architecture constraints (runtime-client model, vault-first durability).


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Fixes #744

## Summary
- import Companion UI handoff assets into `companion-ui/design-handoff/2026-05-03-converse/`
- add owner-doc references describing this handoff as implementation reference input
- keep scope to artifact intake and documentation alignment only

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [ ] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [ ] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [ ] `ruff check app tests`
- [ ] `mypy app`
- [ ] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg"`
- [x] Additional targeted checks run as needed

Targeted checks run:
- `rg "2026-05-03-converse|design handoff" docs/AGENTS.md docs/ARCHITECTURE.md docs/HUMAN-FLOWS.md docs/ROADMAP.md`
- `git diff --name-status origin/main...HEAD`

## Notes
- This slice intentionally imports external design reference files and documents where they should be consumed.