### PR TITLE
Implement Converse layout shell (document-first pane + collapsible rail)

### DIFF
--- a/companion-ui/src/converse_layout.css
+++ b/companion-ui/src/converse_layout.css
@@ -1,0 +1,86 @@
+:root {
+  --bg-surface: #121820;
+  --bg-raised: #17212b;
+  --fg-1: #e7edf3;
+  --fg-2: #c7d4de;
+  --fg-3: #8d9cab;
+  --border: #2c3a46;
+  --vault-online: #3fb37f;
+  --agent: #4a9eff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #0d131a;
+  color: var(--fg-1);
+  font-family: "SF Pro Text", "Segoe UI", sans-serif;
+}
+
+.converse-shell {
+  height: 100vh;
+  display: grid;
+  grid-template-rows: 38px 1fr;
+  background: radial-gradient(circle at 20% 0%, rgba(74, 158, 255, 0.08), transparent 35%), #0d131a;
+}
+
+.top-bar {
+  background: var(--bg-surface);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 12px;
+}
+
+.vault-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--fg-3);
+  font-size: 12px;
+}
+
+.vault-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--vault-online);
+}
+
+.main-landscape {
+  display: grid;
+  grid-template-columns: 1fr 32px;
+  min-height: 0;
+}
+
+.main-landscape[data-rail-state="expanded"] {
+  grid-template-columns: 1fr 288px;
+}
+
+.document-pane {
+  overflow: auto;
+  padding: 44px 24px;
+}
+
+.document-column {
+  max-width: 640px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.rail {
+  background: var(--bg-surface);
+  border-left: 1px solid var(--border);
+}
+
+.rail--collapsed {
+  width: 32px;
+}
+
+.rail--expanded {
+  width: 288px;
+}

--- a/companion-ui/src/converse_layout.html
+++ b/companion-ui/src/converse_layout.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Companion UI Converse Layout Shell</title>
+    <link rel="stylesheet" href="./converse_layout.css" />
+  </head>
+  <body>
+    <div class="converse-shell">
+      <header class="top-bar" data-testid="top-bar">
+        <strong>Converse</strong>
+        <div class="vault-status" data-testid="vault-status">
+          <span class="vault-status-dot" aria-label="Vault online"></span>
+          <span>Vault online</span>
+        </div>
+      </header>
+
+      <section class="main-landscape" data-testid="main-landscape" data-rail-state="collapsed">
+        <main class="document-pane" data-testid="document-pane">
+          <article class="document-column" data-testid="document-column">
+            <h1>Decision capture scaffold</h1>
+            <p>The document remains visually primary while the rail changes state.</p>
+          </article>
+        </main>
+
+        <aside class="rail rail--collapsed" data-testid="margin-rail" aria-label="Hugin rail"></aside>
+      </section>
+    </div>
+  </body>
+</html>

--- a/companion-ui/src/converse_layout_state.py
+++ b/companion-ui/src/converse_layout_state.py
@@ -1,0 +1,40 @@
+"""Converse layout shell state contract for landscape layouts."""
+
+COLLAPSED_RAIL_WIDTH_PX = 32
+EXPANDED_RAIL_WIDTH_PX = 288
+DOCUMENT_MAX_WIDTH_PX = 640
+TOP_BAR_HEIGHT_PX = 38
+
+
+class ConverseLayoutState:
+    def __init__(
+        self,
+        *,
+        rail_state: str,
+        rail_width_px: int,
+        document_max_width_px: int,
+        rail_class: str,
+    ) -> None:
+        self.rail_state = rail_state
+        self.rail_width_px = rail_width_px
+        self.document_max_width_px = document_max_width_px
+        self.rail_class = rail_class
+
+
+def resolve_layout_state(rail_state: str) -> ConverseLayoutState:
+    """Map a landscape rail state to deterministic geometry and class tokens."""
+    if rail_state == "collapsed":
+        return ConverseLayoutState(
+            rail_state=rail_state,
+            rail_width_px=COLLAPSED_RAIL_WIDTH_PX,
+            document_max_width_px=DOCUMENT_MAX_WIDTH_PX,
+            rail_class="rail rail--collapsed",
+        )
+    if rail_state == "expanded":
+        return ConverseLayoutState(
+            rail_state=rail_state,
+            rail_width_px=EXPANDED_RAIL_WIDTH_PX,
+            document_max_width_px=DOCUMENT_MAX_WIDTH_PX,
+            rail_class="rail rail--expanded",
+        )
+    raise ValueError(f"Unsupported rail_state: {rail_state}")

--- a/tests/companion_ui/test_converse_layout_shell.py
+++ b/tests/companion_ui/test_converse_layout_shell.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+import importlib.util
+
+
+def _load_state_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    module_path = repo_root / "companion-ui" / "src" / "converse_layout_state.py"
+    spec = importlib.util.spec_from_file_location("converse_layout_state", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_layout_state_switch_and_geometry_tokens() -> None:
+    state = _load_state_module()
+
+    collapsed = state.resolve_layout_state("collapsed")
+    assert collapsed.rail_width_px == 32
+    assert collapsed.rail_class == "rail rail--collapsed"
+
+    expanded = state.resolve_layout_state("expanded")
+    assert expanded.rail_width_px == 288
+    assert expanded.rail_class == "rail rail--expanded"
+
+
+def test_document_column_is_constrained_and_centered() -> None:
+    css_path = Path(__file__).resolve().parents[2] / "companion-ui" / "src" / "converse_layout.css"
+    css_text = css_path.read_text(encoding="utf-8")
+
+    assert "max-width: 640px;" in css_text
+    assert "margin: 0 auto;" in css_text
+
+
+def test_landscape_shell_contains_top_bar_document_and_rail_container() -> None:
+    html_path = Path(__file__).resolve().parents[2] / "companion-ui" / "src" / "converse_layout.html"
+    html_text = html_path.read_text(encoding="utf-8")
+
+    assert 'data-testid="top-bar"' in html_text
+    assert 'data-testid="document-pane"' in html_text
+    assert 'data-testid="margin-rail"' in html_text
+    assert 'data-rail-state="collapsed"' in html_text


### PR DESCRIPTION
Fixes #740

## Summary
- implement a document-first Converse landscape shell with top bar, vault status indicator, centered document column, and right-side rail container
- add deterministic layout-state contract for collapsed (32px) and expanded (288px) rail geometries
- add focused tests for shell composition, rail state geometry toggles, and centered/constrained document column behavior
- Dispatcher unavailable (`python3 -m app.dispatcher status --json` failed due missing `yaml`) so this run used GitHub-label-only claim fallback

## Validation
- `pytest -q tests/companion_ui/test_converse_layout_shell.py`
