### PR TITLE
Implement Converse rail thread and composer states

### DIFF
--- a/companion-ui/src/converse_layout.css
+++ b/companion-ui/src/converse_layout.css
@@ -7,6 +7,7 @@
   --border: #2c3a46;
   --vault-online: #3fb37f;
   --agent: #4a9eff;
+  --cyan: #6edbff;
 }
 
 * {
@@ -75,6 +76,9 @@ body {
 .rail {
   background: var(--bg-surface);
   border-left: 1px solid var(--border);
+  display: grid;
+  grid-template-rows: 38px 1fr auto;
+  min-height: 0;
 }
 
 .rail--collapsed {
@@ -83,4 +87,161 @@ body {
 
 .rail--expanded {
   width: 288px;
+}
+
+.rail-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  border-bottom: 1px solid var(--border);
+  padding: 0 8px;
+}
+
+.hugin-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: rgba(74, 158, 255, 0.8);
+}
+
+.hugin-label,
+.turn-count {
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  color: var(--fg-3);
+}
+
+.turn-count {
+  margin-left: auto;
+  letter-spacing: 0;
+}
+
+.conversation-thread {
+  overflow-y: auto;
+  padding: 10px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.message {
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 7px 10px;
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.message--agent {
+  background: rgba(74, 158, 255, 0.06);
+  border-radius: 1px 3px 3px 3px;
+}
+
+.message--human {
+  background: var(--bg-raised);
+  border-radius: 3px 3px 1px 3px;
+  align-self: flex-end;
+  max-width: 88%;
+}
+
+.agent-context-label,
+.agent-source-line {
+  margin: 0 0 5px;
+  font-size: 8px;
+  color: var(--fg-3);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.agent-source-line {
+  margin-top: 6px;
+  margin-bottom: 0;
+  padding-top: 5px;
+  border-top: 1px solid var(--border);
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.thinking-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--fg-3);
+  font-size: 8px;
+  letter-spacing: 0.08em;
+}
+
+.thinking-label {
+  margin-right: 2px;
+}
+
+.thinking-dot {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--fg-3);
+  animation: pulse 1s ease-in-out infinite;
+}
+
+.thinking-dot:nth-child(3) {
+  animation-delay: 0.2s;
+}
+
+.thinking-dot:nth-child(4) {
+  animation-delay: 0.4s;
+}
+
+.composer-stack {
+  padding: 8px;
+  border-top: 1px solid var(--border);
+  display: grid;
+  gap: 8px;
+}
+
+.composer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 6px 8px;
+}
+
+.composer input {
+  flex: 1;
+  border: 0;
+  background: transparent;
+  color: var(--fg-2);
+  font-size: 12px;
+}
+
+.composer button {
+  border: 1px solid var(--cyan);
+  color: var(--cyan);
+  background: transparent;
+  border-radius: 2px;
+  padding: 3px 9px;
+  font-size: 10px;
+}
+
+.composer[data-composer-state="disabled"] {
+  opacity: 0.45;
+}
+
+.composer[data-composer-state="disabled"] button {
+  border-color: var(--border);
+  color: var(--fg-3);
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 0.3;
+    transform: scale(0.85);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1);
+  }
 }

--- a/companion-ui/src/converse_layout.css
+++ b/companion-ui/src/converse_layout.css
@@ -89,6 +89,44 @@ body {
   width: 288px;
 }
 
+.rail-collapsed-strip {
+  display: none;
+}
+
+.main-landscape[data-rail-state="collapsed"] .rail-collapsed-strip {
+  display: grid;
+  align-content: space-between;
+  justify-items: center;
+  padding: 10px 4px;
+  height: 100%;
+}
+
+.main-landscape[data-rail-state="collapsed"] .rail-header,
+.main-landscape[data-rail-state="collapsed"] .conversation-thread,
+.main-landscape[data-rail-state="collapsed"] .composer-stack {
+  display: none;
+}
+
+.collapsed-unread {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  font-size: 8px;
+  letter-spacing: 0.08em;
+  color: var(--fg-3);
+}
+
+.collapsed-expand-handle {
+  width: 16px;
+  height: 16px;
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  background: transparent;
+  color: var(--fg-2);
+  font-size: 11px;
+  padding: 0;
+  line-height: 1;
+}
+
 .rail-header {
   display: flex;
   align-items: center;

--- a/companion-ui/src/converse_layout.html
+++ b/companion-ui/src/converse_layout.html
@@ -25,6 +25,12 @@
         </main>
 
         <aside class="rail rail--collapsed" data-testid="margin-rail" aria-label="Hugin rail">
+          <div class="rail-collapsed-strip" data-testid="rail-collapsed-strip" aria-label="Collapsed rail strip">
+            <span class="hugin-dot" aria-hidden="true"></span>
+            <span class="collapsed-unread">3 new</span>
+            <button class="collapsed-expand-handle" type="button" aria-label="Expand rail">‹</button>
+          </div>
+
           <header class="rail-header">
             <span class="hugin-dot" aria-hidden="true"></span>
             <span class="hugin-label">HUGIN</span>

--- a/companion-ui/src/converse_layout.html
+++ b/companion-ui/src/converse_layout.html
@@ -24,7 +24,43 @@
           </article>
         </main>
 
-        <aside class="rail rail--collapsed" data-testid="margin-rail" aria-label="Hugin rail"></aside>
+        <aside class="rail rail--collapsed" data-testid="margin-rail" aria-label="Hugin rail">
+          <header class="rail-header">
+            <span class="hugin-dot" aria-hidden="true"></span>
+            <span class="hugin-label">HUGIN</span>
+            <span class="turn-count">18 turns</span>
+          </header>
+
+          <section class="conversation-thread" data-testid="conversation-thread" aria-label="Conversation thread">
+            <article class="message message--agent" data-testid="message-agent">
+              <p class="agent-context-label" data-testid="agent-context-label">RE: Decision record</p>
+              <p>We can keep this bounded to visual state and thread rendering.</p>
+              <p class="agent-source-line" data-testid="agent-source-line">↳ Projects/Q2-arch.md</p>
+            </article>
+
+            <article class="message message--human" data-testid="message-human">
+              <p>Show me the proposed thread and composer states.</p>
+            </article>
+
+            <div class="thinking-indicator" data-testid="thinking-indicator" data-thinking="active" aria-label="Hugin thinking">
+              <span class="thinking-label">HUGIN</span>
+              <span class="thinking-dot"></span>
+              <span class="thinking-dot"></span>
+              <span class="thinking-dot"></span>
+            </div>
+          </section>
+
+          <footer class="composer-stack">
+            <div class="composer" data-testid="composer" data-composer-state="enabled">
+              <input type="text" value="Draft response..." aria-label="Compose message" readonly />
+              <button type="button" data-testid="composer-send-enabled">Send</button>
+            </div>
+            <div class="composer" data-composer-state="disabled">
+              <input type="text" value="apply or discard to continue" aria-label="Compose message disabled" readonly disabled />
+              <button type="button" data-testid="composer-send-disabled" disabled>Send</button>
+            </div>
+          </footer>
+        </aside>
       </section>
     </div>
   </body>

--- a/tests/companion_ui/test_converse_layout_shell.py
+++ b/tests/companion_ui/test_converse_layout_shell.py
@@ -40,3 +40,35 @@ def test_landscape_shell_contains_top_bar_document_and_rail_container() -> None:
     assert 'data-testid="document-pane"' in html_text
     assert 'data-testid="margin-rail"' in html_text
     assert 'data-rail-state="collapsed"' in html_text
+
+
+def test_thread_contains_human_and_agent_message_variants() -> None:
+    html_path = Path(__file__).resolve().parents[2] / "companion-ui" / "src" / "converse_layout.html"
+    html_text = html_path.read_text(encoding="utf-8")
+
+    assert 'data-testid="conversation-thread"' in html_text
+    assert 'data-testid="message-human"' in html_text
+    assert 'data-testid="message-agent"' in html_text
+    assert 'data-testid="agent-context-label"' in html_text
+    assert 'data-testid="agent-source-line"' in html_text
+
+
+def test_composer_exposes_enabled_and_disabled_state_hooks() -> None:
+    html_path = Path(__file__).resolve().parents[2] / "companion-ui" / "src" / "converse_layout.html"
+    html_text = html_path.read_text(encoding="utf-8")
+
+    assert 'data-testid="composer"' in html_text
+    assert 'data-composer-state="enabled"' in html_text
+    assert 'data-composer-state="disabled"' in html_text
+    assert 'data-testid="composer-send-enabled"' in html_text
+    assert 'data-testid="composer-send-disabled"' in html_text
+    assert 'disabled' in html_text
+
+
+def test_thinking_indicator_row_present_and_distinct() -> None:
+    html_path = Path(__file__).resolve().parents[2] / "companion-ui" / "src" / "converse_layout.html"
+    html_text = html_path.read_text(encoding="utf-8")
+
+    assert 'data-testid="thinking-indicator"' in html_text
+    assert 'data-thinking="active"' in html_text
+    assert "thinking-dot" in html_text

--- a/tests/companion_ui/test_converse_layout_shell.py
+++ b/tests/companion_ui/test_converse_layout_shell.py
@@ -72,3 +72,15 @@ def test_thinking_indicator_row_present_and_distinct() -> None:
     assert 'data-testid="thinking-indicator"' in html_text
     assert 'data-thinking="active"' in html_text
     assert "thinking-dot" in html_text
+
+
+def test_collapsed_rail_uses_compact_strip_affordances() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    html_text = (repo_root / "companion-ui" / "src" / "converse_layout.html").read_text(encoding="utf-8")
+    css_text = (repo_root / "companion-ui" / "src" / "converse_layout.css").read_text(encoding="utf-8")
+
+    assert 'data-testid="rail-collapsed-strip"' in html_text
+    assert 'data-rail-state="collapsed"' in html_text
+    assert '.main-landscape[data-rail-state="collapsed"] .conversation-thread' in css_text
+    assert '.main-landscape[data-rail-state="collapsed"] .composer-stack' in css_text
+    assert "display: none;" in css_text


### PR DESCRIPTION
Fixes #741

## Summary
- add dialogue-state rail scaffolding with agent/human message variants, source line, thinking indicator, and enabled/disabled composer hooks
- style the rail thread/composer surfaces to match State C.2 interaction tokens (including cyan-only send emphasis)
- add companion-ui AC tests covering message variants, composer state hooks, and thinking indicator rendering
- dispatcher returned no candidate task (empty true), so this used GitHub-label/project claim path

## Validation
- .venv/bin/pytest -q tests/companion_ui/test_converse_layout_shell.py

---