### PR TITLE
docs: fix dispatcher SSH wrapper example

### DIFF
--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -268,7 +268,7 @@ Install a wrapper script that proxies dispatcher commands over SSH:
 ```bash
 cat > ~/.local/bin/dispatcher << 'EOF'
 #!/bin/zsh
-ssh rasmus@demerzel "cd ~/workspace && .venv/bin/python -m app.dispatcher $*"
+ssh rasmus@demerzel "cd ~/workspace && PYTHONPATH=. .venv/bin/python -m app.dispatcher \"\$@\"" -- "$@"
 EOF
 chmod +x ~/.local/bin/dispatcher
 ```

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -268,7 +268,7 @@ Install a wrapper script that proxies dispatcher commands over SSH:
 ```bash
 cat > ~/.local/bin/dispatcher << 'EOF'
 #!/bin/zsh
-ssh rasmus@demerzel "cd ~/workspace && PYTHONPATH=. .venv/bin/python -m app.dispatcher \"\$@\"" -- "$@"
+ssh rasmus@demerzel "cd ~/workspace && PYTHONPATH=. .venv/bin/python -m app.dispatcher \"\$@\"" "$@"
 EOF
 chmod +x ~/.local/bin/dispatcher
 ```


### PR DESCRIPTION
- [x] Docs authoring lane

## Summary
- update the dispatcher wrapper snippet to set `PYTHONPATH=.` so `app.dispatcher` resolves on Demerzel
- use safe argument forwarding with remote positional args (`"$@"`) and avoid the broken literal `--` prefix before dispatcher subcommands

## Validation
- verified `dispatcher status --json` returns `{"ok": true, "db_exists": true, ...}` after applying the wrapper locally
