### PR TITLE
governance: apply learning-retrospective skill updates

### DIFF
--- a/.codex/skills/issue-to-code/SKILL.md
+++ b/.codex/skills/issue-to-code/SKILL.md
@@ -253,21 +253,26 @@ When continuing through anchor drift:
 ## Implementation workflow
 
 1. Select the Issue according to priority and readiness rules.
-2. **Execute Action: Begin Implementation Work** (update labels, Issue Project Status, verify).
-3. Restate the bounded outcome from the Issue.
-4. Read source-anchored docs and owning code paths.
-5. If anchor drift exists, resolve it using the rules above before coding.
-6. **Verify acceptance verifiability**: every Acceptance Criterion must carry a resolvable `Verify:` target. If any AC lacks one, stop implementation and route through `issue-maintenance-change-control` to repair the contract before coding.
-7. **Test-first for behavioral ACs**: for each AC whose `Verify:` names a test, ensure that test exists in the repo and currently fails against the unchanged code path. If the test is missing, write it first from the AC; if it is present but does not fail, either the AC is already satisfied (stop and validate) or the test does not actually exercise the AC (fix the test).
-8. Implement the smallest complete change that turns every behavioral `Verify:` test green without breaking unrelated tests.
-9. **Writeback for non-behavioral ACs**: perform each non-behavioral `Verify:` target in the same change (doc anchor writeback, roadmap wording cleanup, runtime receipt, etc.).
-10. Update owner docs if shipped behavior/contracts changed.
-11. Rewrite roadmap/plan wording if the delivered work was previously listed as pending.
-12. Run `Suggested Validation` plus any obviously necessary focused checks. Confirm every AC's `Verify:` target now resolves green.
-13. Run `.codex/skills/publish-pr/SKILL.md` to create or update the implementation PR linked to the governing Issue unless a concrete blocker or explicit user instruction prevents it.
-14. Run `.codex/skills/pr-integration/SKILL.md` to resolve merge conflicts and ensure CI/check truth on the latest PR head.
-15. **Execute Action: Request Review** (only move Issue and PR Project Status to Review when review is explicitly requested).
-16. If the slice merges but the parent feature still needs validation, keep that parent issue open for the later acceptance step.
+2. Run delivered-state preflight before claim when target implementation paths are explicit:
+   - Verify whether referenced target modules already exist in the repo.
+   - If core implementation already exists, do not proceed as fresh implementation; route to `issue-maintenance-change-control` to correct stale or drifted contract state.
+   - Treat passing acceptance tests as supporting evidence, not the sole gate for delivered classification.
+   - If source specs still say "Not yet implemented" while shipped code exists, route the spec-state writeback through docs/governance repair rather than opening duplicate implementation work.
+3. **Execute Action: Begin Implementation Work** (update labels, Issue Project Status, verify).
+4. Restate the bounded outcome from the Issue.
+5. Read source-anchored docs and owning code paths.
+6. If anchor drift exists, resolve it using the rules above before coding.
+7. **Verify acceptance verifiability**: every Acceptance Criterion must carry a resolvable `Verify:` target. If any AC lacks one, stop implementation and route through `issue-maintenance-change-control` to repair the contract before coding.
+8. **Test-first for behavioral ACs**: for each AC whose `Verify:` names a test, ensure that test exists in the repo and currently fails against the unchanged code path. If the test is missing, write it first from the AC; if it is present but does not fail, either the AC is already satisfied (stop and validate) or the test does not actually exercise the AC (fix the test).
+9. Implement the smallest complete change that turns every behavioral `Verify:` test green without breaking unrelated tests.
+10. **Writeback for non-behavioral ACs**: perform each non-behavioral `Verify:` target in the same change (doc anchor writeback, roadmap wording cleanup, runtime receipt, etc.).
+11. Update owner docs if shipped behavior/contracts changed.
+12. Rewrite roadmap/plan wording if the delivered work was previously listed as pending.
+13. Run `Suggested Validation` plus any obviously necessary focused checks. Confirm every AC's `Verify:` target now resolves green.
+14. Run `.codex/skills/publish-pr/SKILL.md` to create or update the implementation PR linked to the governing Issue unless a concrete blocker or explicit user instruction prevents it.
+15. Run `.codex/skills/pr-integration/SKILL.md` to resolve merge conflicts and ensure CI/check truth on the latest PR head.
+16. **Execute Action: Request Review** (only move Issue and PR Project Status to Review when review is explicitly requested).
+17. If the slice merges but the parent feature still needs validation, keep that parent issue open for the later acceptance step.
 
 ## PR handoff requirements
 

--- a/.codex/skills/pr-integration/SKILL.md
+++ b/.codex/skills/pr-integration/SKILL.md
@@ -84,7 +84,7 @@ git fetch origin "$PR_BASE_REF"
 
 git diff --name-only --diff-filter=ACMRT "origin/$PR_BASE_REF...HEAD" > /tmp/pr_files.txt
 if [ -s /tmp/pr_files.txt ]; then
-  if xargs -a /tmp/pr_files.txt rg -n '^(<<<<<<<|=======|>>>>>>>)'; then
+  if xargs -a /tmp/pr_files.txt rg -n '^(<<<<<<<|>>>>>>>)'; then
     echo "❌ BLOCKED: unresolved merge-conflict markers present"
     echo "Handoff decision: blocked-merge-conflict"
     exit 1

--- a/.codex/skills/pr-integration/SKILL.md
+++ b/.codex/skills/pr-integration/SKILL.md
@@ -73,6 +73,28 @@ gh pr checks <PR_NUMBER>
 
 **If contract fails:** Stop and route through issue-maintenance with explicit contract-drift context.
 
+### 1.5) Conflict Marker Gate (Changed Files)
+
+**Action: scan changed files for unresolved merge-conflict markers before CI interpretation**
+
+```bash
+# Prefer PR base ref when available; default to origin/main
+PR_BASE_REF=$(gh pr view <PR_NUMBER> --json baseRefName --jq '.baseRefName' 2>/dev/null || echo "main")
+git fetch origin "$PR_BASE_REF"
+
+git diff --name-only --diff-filter=ACMRT "origin/$PR_BASE_REF...HEAD" > /tmp/pr_files.txt
+if [ -s /tmp/pr_files.txt ]; then
+  if xargs -a /tmp/pr_files.txt rg -n '^(<<<<<<<|=======|>>>>>>>)'; then
+    echo "❌ BLOCKED: unresolved merge-conflict markers present"
+    echo "Handoff decision: blocked-merge-conflict"
+    exit 1
+  fi
+fi
+echo "✅ No conflict markers detected in changed files"
+```
+
+If markers are found, resolve them, re-run focused validation, push, and restart from mergeability checks.
+
 ### 2) Mergeability Gate
 
 **Critical: Never trust the GitHub API `mergeable` field alone.** GitHub returns `null` while computing and `dirty` for multiple unrelated reasons. Always verify locally.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,12 @@ For GitHub implementation work, loading `.codex/skills/issue-to-code/SKILL.md` i
 That skill owns the pickup rule:
 when active work begins, move the governing Issue/Project state to `In Progress` and remove `agent:ready` before local edits so another agent does not pick up the same task.
 
+Execution discipline:
+
+- When a task clearly matches a repo-local workflow skill, load that skill before workflow-boundary actions in that lane.
+- Publication actions (branch creation, commit creation, push, PR creation/update) route through `.codex/skills/publish-pr/SKILL.md` as the canonical publication boundary.
+- Do not perform ad hoc publication flow first and retroactively map it to a skill; route through the matching skill before executing boundary actions.
+
 Workflow state model:
 
 - Issue state is for claim/active/block/closure flow: `Ready`, `In Progress`, `Blocked`, `Done`.
@@ -140,6 +146,9 @@ Builder-agent rules:
 - Prefer Issues plus truthful agent labels and linked PR state as harder authority than Project state if they drift.
 - Use Project `Status` as the pickup and coordination projection. `agent:ready` is only the pickup qualifier for `Status=Ready`; blocked labels belong on non-active work, and closed issues must not retain `agent:*` labels.
 - When a PR delivers a tracked backlog item, update the owner doc to describe shipped reality and rewrite roadmap/plan wording so it no longer reads as pending work.
+- Prefer GitHub REST endpoints for routine issue/label/PR operations; use GraphQL when REST does not express the required operation.
+- When GraphQL is required, resolve stable identifiers once per run and reuse cached values instead of repeating lookup queries.
+- Batch project-field GraphQL mutations into one bounded pass near workflow completion, rather than interleaving repeated mutations throughout intake.
 
 ## Dispatcher policy
 

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -268,7 +268,7 @@ Install a wrapper script that proxies dispatcher commands over SSH:
 ```bash
 cat > ~/.local/bin/dispatcher << 'EOF'
 #!/bin/zsh
-ssh rasmus@demerzel "cd ~/workspace && .venv/bin/python -m app.dispatcher $*"
+ssh rasmus@demerzel "cd ~/workspace && PYTHONPATH=. .venv/bin/python -m app.dispatcher \"\$@\"" -- "$@"
 EOF
 chmod +x ~/.local/bin/dispatcher
 ```

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -268,7 +268,7 @@ Install a wrapper script that proxies dispatcher commands over SSH:
 ```bash
 cat > ~/.local/bin/dispatcher << 'EOF'
 #!/bin/zsh
-ssh rasmus@demerzel "cd ~/workspace && PYTHONPATH=. .venv/bin/python -m app.dispatcher \"\$@\"" -- "$@"
+ssh rasmus@demerzel "cd ~/workspace && PYTHONPATH=. .venv/bin/python -m app.dispatcher \"\$@\"" "$@"
 EOF
 chmod +x ~/.local/bin/dispatcher
 ```

--- a/docs/learning-log.md
+++ b/docs/learning-log.md
@@ -60,3 +60,15 @@ This lets `learning-retrospective` scope its next read to entries since the last
 **Source:** verification-and-closure
 **Diverged:** All three remaining canvas slices (#684 co-author body, #685 governance gate, #686 API/CLI) were filed as unimplemented, but `app/chat/canvas_writer.py`, `app/chat/governance_router.py`, API routes, and CLI commands already existed with 19 passing tests. All four spec files had `State: Specification. Not yet implemented.` despite the whole canvas surface having shipped via PRs #605/#618/#619/#626.
 **Upstream artifact:** `docs-to-issue` pre-flight check (now patched in PR #701) + spec-state writeback in `verification-and-closure` (PR #701) — confirms the governance repair was correctly scoped; the three previously-untracked spec State: lines are now promoted in the follow-up docs PR.
+
+## 2026-05-03 — #748 (Dispatcher wrapper docs fix)
+**Source:** human
+**Diverged:** I performed PR creation and local-memory updates ad hoc before explicitly routing through the repo workflow skill boundary, while the expected process is to use the matching in-repo skill for each workflow step.
+**Upstream artifact:** `AGENTS.md` + `.codex/skills/publish-pr/SKILL.md` / `.codex/skills/pr-integration/SKILL.md` usage discipline in agent execution.
+
+## 2026-05-03 — #748 (PR workflow skill routing)
+**Source:** human
+**Diverged:** The process question clarified that PR creation should have been routed explicitly through `publish-pr` as the publication boundary instead of being treated as a generic git/gh step.
+**Upstream artifact:** `.codex/skills/publish-pr/SKILL.md` (canonical PR creation workflow) and `AGENTS.md` workflow sequencing discipline.
+
+--- retro 2026-05-03: applied 4/4 proposals ---


### PR DESCRIPTION
- [x] Governance lane

## Summary
Applies approved learning-retrospective outcomes to governance guidance and workflow skills.

## Changes
- Add workflow-boundary skill routing and REST/GraphQL discipline in `AGENTS.md`
- Add conflict-marker gate to `.codex/skills/pr-integration/SKILL.md`
- Add delivered-state preflight guidance to `.codex/skills/issue-to-code/SKILL.md`
- Append retrospective marker in `docs/learning-log.md`

## Validation
- Docs/skill governance edits only; no runtime code paths changed
- Manual verification of updated sections and retro marker append

---