### PR TITLE
Implement staged suggestion moment with apply/discard intents

### DIFF
--- a/companion-ui/src/converse_layout.css
+++ b/companion-ui/src/converse_layout.css
@@ -113,6 +113,10 @@ body {
   display: none;
 }
 
+.main-landscape[data-rail-state="collapsed"][data-suggestion-state="active"] {
+  grid-template-columns: 1fr 288px;
+}
+
 .main-landscape[data-rail-state="collapsed"][data-suggestion-state="active"] .conversation-thread {
   display: flex;
 }
@@ -199,8 +203,8 @@ body {
 
 .suggestion-card {
   opacity: 1;
-  border-left: 3px solid #f09030;
   border: 1px solid rgba(240, 144, 48, 0.3);
+  border-left: 3px solid #f09030;
   background: rgba(240, 144, 48, 0.07);
   border-radius: 2px;
   padding: 8px 10px;

--- a/companion-ui/src/converse_layout.css
+++ b/companion-ui/src/converse_layout.css
@@ -8,6 +8,7 @@
   --vault-online: #3fb37f;
   --agent: #4a9eff;
   --cyan: #6edbff;
+  --amber: #f09030;
 }
 
 * {
@@ -93,7 +94,7 @@ body {
   display: none;
 }
 
-.main-landscape[data-rail-state="collapsed"] .rail-collapsed-strip {
+.main-landscape[data-rail-state="collapsed"]:not([data-suggestion-state="active"]) .rail-collapsed-strip {
   display: grid;
   align-content: space-between;
   justify-items: center;
@@ -101,10 +102,23 @@ body {
   height: 100%;
 }
 
-.main-landscape[data-rail-state="collapsed"] .rail-header,
+.main-landscape[data-rail-state="collapsed"]:not([data-suggestion-state="active"]) .rail-header,
+.main-landscape[data-rail-state="collapsed"]:not([data-suggestion-state="active"]) .conversation-thread,
+.main-landscape[data-rail-state="collapsed"]:not([data-suggestion-state="active"]) .composer-stack {
+  display: none;
+}
+
 .main-landscape[data-rail-state="collapsed"] .conversation-thread,
 .main-landscape[data-rail-state="collapsed"] .composer-stack {
   display: none;
+}
+
+.main-landscape[data-rail-state="collapsed"][data-suggestion-state="active"] .conversation-thread {
+  display: flex;
+}
+
+.main-landscape[data-rail-state="collapsed"][data-suggestion-state="active"] .composer-stack {
+  display: grid;
 }
 
 .collapsed-unread {
@@ -160,6 +174,73 @@ body {
   display: flex;
   flex-direction: column;
   gap: 8px;
+}
+
+.main-landscape[data-suggestion-state="active"] .document-dimmed-region,
+.main-landscape[data-suggestion-state="active"] .message {
+  opacity: 0.35;
+}
+
+.suggested-insertion-block {
+  margin-top: 10px;
+  border-left: 3px solid #f09030;
+  background: rgba(240, 144, 48, 0.07);
+  border-radius: 0 2px 2px 0;
+  padding: 10px 12px;
+  position: relative;
+}
+
+.suggested-insertion-label {
+  margin: 0 0 6px;
+  font-size: 8px;
+  letter-spacing: 0.08em;
+  color: var(--amber);
+}
+
+.suggestion-card {
+  opacity: 1;
+  border-left: 3px solid #f09030;
+  border: 1px solid rgba(240, 144, 48, 0.3);
+  background: rgba(240, 144, 48, 0.07);
+  border-radius: 2px;
+  padding: 8px 10px;
+}
+
+.suggestion-card-label {
+  margin: 0 0 5px;
+  font-size: 8px;
+  letter-spacing: 0.08em;
+  color: var(--amber);
+}
+
+.suggestion-card-diff-hint {
+  margin: 6px 0 0;
+  font-size: 8px;
+  color: var(--fg-3);
+}
+
+.suggestion-actions {
+  margin-top: 8px;
+  display: flex;
+  gap: 8px;
+}
+
+.suggestion-actions button {
+  padding: 4px 12px;
+  border-radius: 2px;
+  background: rgba(240, 144, 48, 0.08);
+  font-size: 11px;
+}
+
+[data-testid="apply-suggestion"] {
+  border: 1px solid var(--amber);
+  color: var(--amber);
+}
+
+[data-testid="discard-suggestion"] {
+  border: 1px solid var(--border);
+  color: var(--fg-3);
+  background: transparent;
 }
 
 .message {

--- a/companion-ui/src/converse_layout.html
+++ b/companion-ui/src/converse_layout.html
@@ -16,11 +16,20 @@
         </div>
       </header>
 
-      <section class="main-landscape" data-testid="main-landscape" data-rail-state="collapsed">
+      <section class="main-landscape" data-testid="main-landscape" data-rail-state="collapsed" data-suggestion-state="active">
         <main class="document-pane" data-testid="document-pane">
           <article class="document-column" data-testid="document-column">
             <h1>Decision capture scaffold</h1>
-            <p>The document remains visually primary while the rail changes state.</p>
+            <p class="document-dimmed-region" data-testid="document-dimmed-region">The document remains visually primary while the rail changes state.</p>
+            <section
+              class="suggested-insertion-block"
+              data-testid="suggested-insertion-block"
+              data-suggestion-id="suggestion-001"
+              data-proposal-id="suggestion-001"
+            >
+              <p class="suggested-insertion-label" data-testid="suggested-insertion-label">PROPOSED ADDITION</p>
+              <p>Introduce explicit staged suggestion actions with no direct persistence side effects.</p>
+            </section>
           </article>
         </main>
 
@@ -46,6 +55,37 @@
 
             <article class="message message--human" data-testid="message-human">
               <p>Show me the proposed thread and composer states.</p>
+            </article>
+
+            <article
+              class="suggestion-card"
+              data-testid="suggestion-card"
+              data-suggestion-id="suggestion-001"
+              data-proposal-id="suggestion-001"
+            >
+              <p class="suggestion-card-label" data-testid="suggestion-card-label">HUGIN · PROPOSED ADDITION</p>
+              <p>Add a staged insertion for explicit user-controlled apply/discard flow.</p>
+              <p class="suggestion-card-diff-hint" data-testid="suggestion-card-diff-hint">+3 lines after ## Current state</p>
+              <div class="suggestion-actions">
+                <button
+                  type="button"
+                  data-testid="apply-suggestion"
+                  data-intent="suggestion.apply"
+                  data-target-suggestion-id="suggestion-001"
+                  data-persistence="none"
+                >
+                  Apply to note
+                </button>
+                <button
+                  type="button"
+                  data-testid="discard-suggestion"
+                  data-intent="suggestion.discard"
+                  data-target-suggestion-id="suggestion-001"
+                  data-persistence="none"
+                >
+                  Discard
+                </button>
+              </div>
             </article>
 
             <div class="thinking-indicator" data-testid="thinking-indicator" data-thinking="active" aria-label="Hugin thinking">

--- a/tests/companion_ui/test_converse_layout_shell.py
+++ b/tests/companion_ui/test_converse_layout_shell.py
@@ -84,3 +84,40 @@ def test_collapsed_rail_uses_compact_strip_affordances() -> None:
     assert '.main-landscape[data-rail-state="collapsed"] .conversation-thread' in css_text
     assert '.main-landscape[data-rail-state="collapsed"] .composer-stack' in css_text
     assert "display: none;" in css_text
+
+
+def test_suggestion_state_dimming_and_proposed_insertion_block() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    html_text = (repo_root / "companion-ui" / "src" / "converse_layout.html").read_text(encoding="utf-8")
+    css_text = (repo_root / "companion-ui" / "src" / "converse_layout.css").read_text(encoding="utf-8")
+
+    assert 'data-suggestion-state="active"' in html_text
+    assert 'data-testid="document-dimmed-region"' in html_text
+    assert 'data-testid="suggested-insertion-block"' in html_text
+    assert 'data-testid="suggested-insertion-label"' in html_text
+    assert "opacity: 0.35;" in css_text
+    assert "border-left: 3px solid #f09030;" in css_text
+
+
+def test_suggestion_card_mirrors_proposal_identity_cues() -> None:
+    html_path = Path(__file__).resolve().parents[2] / "companion-ui" / "src" / "converse_layout.html"
+    html_text = html_path.read_text(encoding="utf-8")
+
+    assert 'data-testid="suggestion-card"' in html_text
+    assert 'data-testid="suggestion-card-label"' in html_text
+    assert "HUGIN · PROPOSED ADDITION" in html_text
+    assert 'data-testid="suggestion-card-diff-hint"' in html_text
+    assert 'data-suggestion-id="suggestion-001"' in html_text
+    assert 'data-proposal-id="suggestion-001"' in html_text
+
+
+def test_apply_discard_controls_emit_bounded_ui_intents() -> None:
+    html_path = Path(__file__).resolve().parents[2] / "companion-ui" / "src" / "converse_layout.html"
+    html_text = html_path.read_text(encoding="utf-8")
+
+    assert 'data-testid="apply-suggestion"' in html_text
+    assert 'data-testid="discard-suggestion"' in html_text
+    assert 'data-intent="suggestion.apply"' in html_text
+    assert 'data-intent="suggestion.discard"' in html_text
+    assert 'data-target-suggestion-id="suggestion-001"' in html_text
+    assert 'data-persistence="none"' in html_text


### PR DESCRIPTION
Fixes #742

## Summary
- add active suggestion-state rendering in the document pane with dimmed non-focused region and highlighted proposed insertion block
- add mirrored rail suggestion card semantics with shared proposal identity and diff hint
- add apply/discard controls with bounded UI intent metadata and no direct persistence side effects

## Validation
- /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/pytest -q tests/companion_ui/test_converse_layout_shell.py

---