### PR TITLE
Implement context_dimensions status and receipt outputs

### DIFF
--- a/app/events/models.py
+++ b/app/events/models.py
@@ -39,6 +39,7 @@ class Event(BaseModel):
     event_id: str = Field(default_factory=new_event_id)
     trace_id: str | None = None
     payload: Dict[str, Any] = Field(default_factory=dict)
+    context_dimensions: Dict[str, Any] | None = None
     created_at: str = Field(default_factory=_now_iso)
     source: str | None = None
     instance_id: str = Field(default_factory=_default_instance_id)
@@ -48,6 +49,7 @@ def new_event(
     *,
     event_type: str,
     payload: Dict[str, Any] | None = None,
+    context_dimensions: Dict[str, Any] | None = None,
     trace_id: str | None = None,
     source: str | None = None,
     event_id: str | None = None,
@@ -60,6 +62,7 @@ def new_event(
         event_id=event_id or new_event_id(),
         trace_id=trace_id,
         payload=data,
+        context_dimensions=context_dimensions,
         created_at=created_at or _now_iso(),
         source=source,
     )

--- a/app/events/schema.py
+++ b/app/events/schema.py
@@ -40,6 +40,24 @@ def _build_meta(meta: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     return resolved
 
 
+def _normalize_context_dimensions(value: Any) -> Dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    if "scope" not in value or "sphere_memberships" not in value:
+        return None
+    scope = value.get("scope")
+    spheres = value.get("sphere_memberships")
+    if scope is None or not isinstance(scope, str):
+        return None
+    if not isinstance(spheres, list):
+        return None
+    return {
+        "scope": scope.strip() or "default",
+        "sphere_memberships": [str(item) for item in spheres],
+        "situated_identity": value.get("situated_identity", None),
+    }
+
+
 class OutboxEvent(BaseModel):
     """Canonical outbox event envelope."""
 
@@ -51,6 +69,7 @@ class OutboxEvent(BaseModel):
     source: str
     timestamp: str = Field(default_factory=_now_iso)
     payload: Dict[str, Any] = Field(default_factory=dict)
+    context_dimensions: Dict[str, Any] | None = None
     meta: Dict[str, Any] = Field(default_factory=_default_meta)
 
     @property
@@ -64,16 +83,22 @@ def make_outbox_event(
     *,
     source: str,
     payload: Optional[Dict[str, Any]] = None,
+    context_dimensions: Optional[Dict[str, Any]] = None,
     trace_id: Optional[str] = None,
     timestamp: Optional[str] = None,
     meta: Optional[Dict[str, Any]] = None,
 ) -> OutboxEvent:
+    resolved_payload = payload or {}
+    resolved_context = _normalize_context_dimensions(context_dimensions)
+    if resolved_context is None:
+        resolved_context = _normalize_context_dimensions(resolved_payload.get("context_dimensions"))
     return OutboxEvent(
         event=event,
         trace_id=trace_id or uuid4().hex,
         source=source,
         timestamp=timestamp or _now_iso(),
-        payload=payload or {},
+        payload=resolved_payload,
+        context_dimensions=resolved_context,
         meta=_build_meta(meta),
     )
 

--- a/app/observability/status_model.py
+++ b/app/observability/status_model.py
@@ -120,6 +120,12 @@ class InstanceProvenanceStatus(BaseModel):
     environment: str
 
 
+class ContextDimensionsStatus(BaseModel):
+    scope: str
+    sphere_memberships: list[str] = Field(default_factory=list)
+    situated_identity: str | None = None
+
+
 class WatcherAutomationStatus(BaseModel):
     auto_exec_enabled: bool = False
     mode: str = "emit-only"
@@ -170,6 +176,7 @@ class SystemStatus(BaseModel):
     view_freshness: Optional[ViewFreshnessStatus] = None
     watcher_automation: Optional[WatcherAutomationStatus] = None
     instance_provenance: Optional[InstanceProvenanceStatus] = None
+    context_dimensions: Optional[ContextDimensionsStatus] = None
 
 
 __all__ = [
@@ -189,5 +196,6 @@ __all__ = [
     "ViewFreshnessStatus",
     "InstanceProvenanceStatus",
     "WatcherAutomationStatus",
+    "ContextDimensionsStatus",
     "SystemStatus",
 ]

--- a/app/observability/status_service.py
+++ b/app/observability/status_service.py
@@ -36,6 +36,7 @@ from app.observability.status_model import (
     WatcherAutomationStatus,
     WorkerQueueStatus,
     WriteGuardStatus,
+    ContextDimensionsStatus,
 )
 from app.outbox.events import INDEX_OUTBOX_PATH
 from app.runtime.worker_heartbeat import resolve_worker_heartbeat_path
@@ -753,6 +754,47 @@ def _get_instance_provenance_status() -> InstanceProvenanceStatus | None:
     )
 
 
+def _normalize_context_dimensions(value: object) -> ContextDimensionsStatus | None:
+    if not isinstance(value, dict):
+        return None
+    if "scope" not in value or "sphere_memberships" not in value:
+        return None
+    scope = value.get("scope")
+    spheres = value.get("sphere_memberships")
+    if not isinstance(scope, str) or scope is None:
+        return None
+    if not isinstance(spheres, list):
+        return None
+    return ContextDimensionsStatus(
+        scope=scope.strip() or "default",
+        sphere_memberships=[str(item) for item in spheres],
+        situated_identity=value.get("situated_identity", None),
+    )
+
+
+def _status_context_dimensions(outbox_path: Path) -> ContextDimensionsStatus | None:
+    try:
+        lines = outbox_path.read_text(encoding="utf-8").splitlines()
+    except Exception:
+        return None
+    for line in reversed(lines):
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except Exception:
+            continue
+        top_level = _normalize_context_dimensions(record.get("context_dimensions"))
+        if top_level is not None:
+            return top_level
+        payload = record.get("payload")
+        if isinstance(payload, dict):
+            nested = _normalize_context_dimensions(payload.get("context_dimensions"))
+            if nested is not None:
+                return nested
+    return None
+
+
 def get_system_status() -> SystemStatus:
     sot_meta = get_sot_metadata()
     ingestion = get_ingestion_status()
@@ -794,6 +836,7 @@ def get_system_status() -> SystemStatus:
         ),
         watcher_automation=_get_watcher_automation_status(),
         instance_provenance=_get_instance_provenance_status(),
+        context_dimensions=_status_context_dimensions(Path(INDEX_OUTBOX_PATH)),
     )
 
 

--- a/app/services/outbox.py
+++ b/app/services/outbox.py
@@ -180,6 +180,7 @@ def _coerce_event(event: Event | OutboxEvent) -> Event:
     return new_event(
         event_type=event.event,
         payload=dict(payload),
+        context_dimensions=getattr(event, "context_dimensions", None),
         trace_id=event.trace_id,
         source=event_source_name(getattr(event, "source", None), default="app"),
         event_id=event.event_id,

--- a/tests/events/test_context_dimensions_in_receipts.py
+++ b/tests/events/test_context_dimensions_in_receipts.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from app.events.schema import make_outbox_event
+
+
+def test_receipt_includes_context_dimensions() -> None:
+    event = make_outbox_event(
+        "watcher.run.completed",
+        source="watcher",
+        payload={"changed": 1},
+        context_dimensions={
+            "scope": "work",
+            "sphere_memberships": ["team"],
+            "situated_identity": None,
+        },
+    )
+    dumped = event.model_dump(exclude_none=True)
+    assert dumped["context_dimensions"]["scope"] == "work"
+    assert dumped["context_dimensions"]["sphere_memberships"] == ["team"]
+    assert "situated_identity" in dumped["context_dimensions"]
+    assert dumped["context_dimensions"]["situated_identity"] is None
+
+
+def test_receipt_omits_context_dimensions_when_absent() -> None:
+    event = make_outbox_event(
+        "watcher.run.completed",
+        source="watcher",
+        payload={"changed": 1},
+    )
+    dumped = event.model_dump(exclude_none=True)
+    assert "context_dimensions" not in dumped

--- a/tests/observability/test_context_dimensions_in_status.py
+++ b/tests/observability/test_context_dimensions_in_status.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+
+from app.observability.status_service import get_system_status
+
+
+def test_status_includes_context_dimensions_block(monkeypatch, tmp_path) -> None:
+    outbox = tmp_path / "outbox.jsonl"
+    outbox.write_text(
+        json.dumps(
+            {
+                "event": "watcher.run.completed",
+                "context_dimensions": {
+                    "scope": "work",
+                    "sphere_memberships": ["team"],
+                    "situated_identity": "maker",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox))
+    monkeypatch.setattr("app.observability.status_service.INDEX_OUTBOX_PATH", outbox)
+
+    status = get_system_status()
+    assert status.context_dimensions is not None
+    assert status.context_dimensions.scope == "work"
+    assert status.context_dimensions.sphere_memberships == ["team"]
+    assert status.context_dimensions.situated_identity == "maker"
+
+
+def test_status_omits_block_when_no_context(monkeypatch, tmp_path) -> None:
+    outbox = tmp_path / "outbox.jsonl"
+    outbox.write_text(json.dumps({"event": "watcher.run.completed"}) + "\n", encoding="utf-8")
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox))
+    monkeypatch.setattr("app.observability.status_service.INDEX_OUTBOX_PATH", outbox)
+
+    status = get_system_status()
+    dumped = status.model_dump(exclude_none=True)
+    assert "context_dimensions" not in dumped
+
+
+def test_null_situated_identity_explicit_not_omitted(monkeypatch, tmp_path) -> None:
+    outbox = tmp_path / "outbox.jsonl"
+    outbox.write_text(
+        json.dumps(
+            {
+                "event": "watcher.run.completed",
+                "context_dimensions": {
+                    "scope": "work",
+                    "sphere_memberships": [],
+                    "situated_identity": None,
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox))
+    monkeypatch.setattr("app.observability.status_service.INDEX_OUTBOX_PATH", outbox)
+
+    status = get_system_status()
+    assert status.context_dimensions is not None
+    dumped = status.context_dimensions.model_dump()
+    assert "situated_identity" in dumped
+    assert dumped["situated_identity"] is None
+
+
+def test_no_all_null_context_dimensions_block(monkeypatch, tmp_path) -> None:
+    outbox = tmp_path / "outbox.jsonl"
+    outbox.write_text(
+        json.dumps(
+            {
+                "event": "watcher.run.completed",
+                "context_dimensions": {
+                    "scope": None,
+                    "sphere_memberships": None,
+                    "situated_identity": None,
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox))
+    monkeypatch.setattr("app.observability.status_service.INDEX_OUTBOX_PATH", outbox)
+
+    status = get_system_status()
+    dumped = status.model_dump(exclude_none=True)
+    assert "context_dimensions" not in dumped


### PR DESCRIPTION
## Summary
- add canonical `context_dimensions` support to outbox event envelopes
- expose `context_dimensions` on system status when active context data is present
- add issue-scoped tests for status omission/presence and receipt payload behavior

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/observability/test_context_dimensions_in_status.py tests/events/test_context_dimensions_in_receipts.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg" tests/observability/ tests/events/`

Fixes #732

Dispatcher fallback: dispatcher reported `empty: true` for `next` despite ready issues, so pickup used GitHub label/status claim flow.
