### PR TITLE
Thread scope/sphere/identity through runtime paths

### DIFF
--- a/app/events/models.py
+++ b/app/events/models.py
@@ -39,6 +39,7 @@ class Event(BaseModel):
     event_id: str = Field(default_factory=new_event_id)
     trace_id: str | None = None
     payload: Dict[str, Any] = Field(default_factory=dict)
+    context_dimensions: Dict[str, Any] | None = None
     created_at: str = Field(default_factory=_now_iso)
     source: str | None = None
     instance_id: str = Field(default_factory=_default_instance_id)
@@ -48,6 +49,7 @@ def new_event(
     *,
     event_type: str,
     payload: Dict[str, Any] | None = None,
+    context_dimensions: Dict[str, Any] | None = None,
     trace_id: str | None = None,
     source: str | None = None,
     event_id: str | None = None,
@@ -60,6 +62,7 @@ def new_event(
         event_id=event_id or new_event_id(),
         trace_id=trace_id,
         payload=data,
+        context_dimensions=context_dimensions,
         created_at=created_at or _now_iso(),
         source=source,
     )

--- a/app/events/schema.py
+++ b/app/events/schema.py
@@ -40,6 +40,24 @@ def _build_meta(meta: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     return resolved
 
 
+def _normalize_context_dimensions(value: Any) -> Dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    if "scope" not in value or "sphere_memberships" not in value:
+        return None
+    scope = value.get("scope")
+    spheres = value.get("sphere_memberships")
+    if scope is None or not isinstance(scope, str):
+        return None
+    if not isinstance(spheres, list):
+        return None
+    return {
+        "scope": scope.strip() or "default",
+        "sphere_memberships": [str(item) for item in spheres],
+        "situated_identity": value.get("situated_identity", None),
+    }
+
+
 class OutboxEvent(BaseModel):
     """Canonical outbox event envelope."""
 
@@ -51,6 +69,7 @@ class OutboxEvent(BaseModel):
     source: str
     timestamp: str = Field(default_factory=_now_iso)
     payload: Dict[str, Any] = Field(default_factory=dict)
+    context_dimensions: Dict[str, Any] | None = None
     meta: Dict[str, Any] = Field(default_factory=_default_meta)
 
     @property
@@ -64,16 +83,22 @@ def make_outbox_event(
     *,
     source: str,
     payload: Optional[Dict[str, Any]] = None,
+    context_dimensions: Optional[Dict[str, Any]] = None,
     trace_id: Optional[str] = None,
     timestamp: Optional[str] = None,
     meta: Optional[Dict[str, Any]] = None,
 ) -> OutboxEvent:
+    resolved_payload = payload or {}
+    resolved_context = _normalize_context_dimensions(context_dimensions)
+    if resolved_context is None:
+        resolved_context = _normalize_context_dimensions(resolved_payload.get("context_dimensions"))
     return OutboxEvent(
         event=event,
         trace_id=trace_id or uuid4().hex,
         source=source,
         timestamp=timestamp or _now_iso(),
-        payload=payload or {},
+        payload=resolved_payload,
+        context_dimensions=resolved_context,
         meta=_build_meta(meta),
     )
 

--- a/app/observability/status_model.py
+++ b/app/observability/status_model.py
@@ -120,6 +120,12 @@ class InstanceProvenanceStatus(BaseModel):
     environment: str
 
 
+class ContextDimensionsStatus(BaseModel):
+    scope: str
+    sphere_memberships: list[str] = Field(default_factory=list)
+    situated_identity: str | None = None
+
+
 class WatcherAutomationStatus(BaseModel):
     auto_exec_enabled: bool = False
     mode: str = "emit-only"
@@ -170,6 +176,7 @@ class SystemStatus(BaseModel):
     view_freshness: Optional[ViewFreshnessStatus] = None
     watcher_automation: Optional[WatcherAutomationStatus] = None
     instance_provenance: Optional[InstanceProvenanceStatus] = None
+    context_dimensions: Optional[ContextDimensionsStatus] = None
 
 
 __all__ = [
@@ -189,5 +196,6 @@ __all__ = [
     "ViewFreshnessStatus",
     "InstanceProvenanceStatus",
     "WatcherAutomationStatus",
+    "ContextDimensionsStatus",
     "SystemStatus",
 ]

--- a/app/observability/status_service.py
+++ b/app/observability/status_service.py
@@ -36,6 +36,7 @@ from app.observability.status_model import (
     WatcherAutomationStatus,
     WorkerQueueStatus,
     WriteGuardStatus,
+    ContextDimensionsStatus,
 )
 from app.outbox.events import INDEX_OUTBOX_PATH
 from app.runtime.worker_heartbeat import resolve_worker_heartbeat_path
@@ -753,6 +754,47 @@ def _get_instance_provenance_status() -> InstanceProvenanceStatus | None:
     )
 
 
+def _normalize_context_dimensions(value: object) -> ContextDimensionsStatus | None:
+    if not isinstance(value, dict):
+        return None
+    if "scope" not in value or "sphere_memberships" not in value:
+        return None
+    scope = value.get("scope")
+    spheres = value.get("sphere_memberships")
+    if not isinstance(scope, str) or scope is None:
+        return None
+    if not isinstance(spheres, list):
+        return None
+    return ContextDimensionsStatus(
+        scope=scope.strip() or "default",
+        sphere_memberships=[str(item) for item in spheres],
+        situated_identity=value.get("situated_identity", None),
+    )
+
+
+def _status_context_dimensions(outbox_path: Path) -> ContextDimensionsStatus | None:
+    try:
+        lines = outbox_path.read_text(encoding="utf-8").splitlines()
+    except Exception:
+        return None
+    for line in reversed(lines):
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except Exception:
+            continue
+        top_level = _normalize_context_dimensions(record.get("context_dimensions"))
+        if top_level is not None:
+            return top_level
+        payload = record.get("payload")
+        if isinstance(payload, dict):
+            nested = _normalize_context_dimensions(payload.get("context_dimensions"))
+            if nested is not None:
+                return nested
+    return None
+
+
 def get_system_status() -> SystemStatus:
     sot_meta = get_sot_metadata()
     ingestion = get_ingestion_status()
@@ -794,6 +836,7 @@ def get_system_status() -> SystemStatus:
         ),
         watcher_automation=_get_watcher_automation_status(),
         instance_provenance=_get_instance_provenance_status(),
+        context_dimensions=_status_context_dimensions(Path(INDEX_OUTBOX_PATH)),
     )
 
 

--- a/app/orchestrator/executor.py
+++ b/app/orchestrator/executor.py
@@ -76,6 +76,9 @@ class StepContext:
     tool_settings: Mapping[str, Any] | None = None
     budget_state: MutableMapping[str, int] | None = None
     agent_id: str | None = None
+    scope: str | None = None
+    sphere_memberships: list[str] = field(default_factory=list)
+    situated_identity: str | None = None
 
 
 class PlanExecutor(Protocol):

--- a/app/orchestrator/runtime.py
+++ b/app/orchestrator/runtime.py
@@ -42,6 +42,16 @@ def _default_agent_id_for_flow(flow_id: str | None) -> str | None:
     return None
 
 
+def _context_dimensions_from_plan_context(plan_context: Mapping[str, Any] | None) -> tuple[str | None, list[str], str | None]:
+    if not isinstance(plan_context, Mapping):
+        return None, [], None
+    return (
+        plan_context.get("scope") if isinstance(plan_context.get("scope"), str) else None,
+        [str(item) for item in (plan_context.get("sphere_memberships") or [])] if isinstance(plan_context.get("sphere_memberships"), list) else [],
+        plan_context.get("situated_identity") if isinstance(plan_context.get("situated_identity"), str) or plan_context.get("situated_identity") is None else None,
+    )
+
+
 def _resolve_step_agent_id(step: PlanStep, flow_id: str | None, plan_context: Mapping[str, Any] | None) -> str | None:
     if getattr(step, "agent_id", None):
         return step.agent_id
@@ -145,6 +155,7 @@ class Orchestrator:
             budget_state["steps"] = budget_state.get("steps", 0) + 1
 
             agent_id = _resolve_step_agent_id(step, plan_flow_id, plan.context)
+            scope, sphere_memberships, situated_identity = _context_dimensions_from_plan_context(plan.context)
             context = StepContext(
                 plan_id=plan.id,
                 object_id=object_id,
@@ -156,6 +167,9 @@ class Orchestrator:
                 tool_settings=context_tool_settings,
                 budget_state=budget_state,
                 agent_id=agent_id,
+                scope=scope,
+                sphere_memberships=sphere_memberships,
+                situated_identity=situated_identity,
             )
             try:
                 output = self._executor.execute_step(step, context)

--- a/app/orchestrator/v2_runtime.py
+++ b/app/orchestrator/v2_runtime.py
@@ -82,6 +82,16 @@ def _default_agent_id_for_flow(flow_id: str | None) -> str | None:
     return None
 
 
+def _context_dimensions_from_plan_context(plan_context: Mapping[str, Any] | None) -> tuple[str | None, list[str], str | None]:
+    if not isinstance(plan_context, Mapping):
+        return None, [], None
+    return (
+        plan_context.get("scope") if isinstance(plan_context.get("scope"), str) else None,
+        [str(item) for item in (plan_context.get("sphere_memberships") or [])] if isinstance(plan_context.get("sphere_memberships"), list) else [],
+        plan_context.get("situated_identity") if isinstance(plan_context.get("situated_identity"), str) or plan_context.get("situated_identity") is None else None,
+    )
+
+
 def _resolve_step_agent_id(step: PlanStep, flow_id: str | None, plan_context: Mapping[str, Any] | None) -> str | None:
     if getattr(step, "agent_id", None):
         return step.agent_id
@@ -268,6 +278,7 @@ class OrchestratorV2:
                     emit_step_started(plan_id=plan.id, step=step, object_id=object_id, trace_id=trace_id)
 
                     agent_id = _resolve_step_agent_id(step, plan_flow_id, plan.context)
+                    scope, sphere_memberships, situated_identity = _context_dimensions_from_plan_context(plan.context)
                     context = StepContext(
                         plan_id=plan.id,
                         object_id=object_id,
@@ -279,6 +290,9 @@ class OrchestratorV2:
                         tool_settings=context_tool_settings,
                         budget_state=budget_state,
                         agent_id=agent_id,
+                        scope=scope,
+                        sphere_memberships=sphere_memberships,
+                        situated_identity=situated_identity,
                     )
 
                     future = executor.submit(self._execute_step_safe, step, context)

--- a/app/orientation/runtime.py
+++ b/app/orientation/runtime.py
@@ -26,6 +26,15 @@ def _iso(dt: datetime | None) -> str:
     return dt.isoformat().replace("+00:00", "Z")
 
 
+def pass_through_context_dimensions(record: dict[str, object]) -> dict[str, object]:
+    payload = dict(record.get("context_dimensions") or {})
+    return {
+        "scope": payload.get("scope"),
+        "sphere_memberships": list(payload.get("sphere_memberships") or []),
+        "situated_identity": payload.get("situated_identity"),
+    }
+
+
 def build_orientation_frame() -> OrientationFrame:
     signals = get_orientation_signals()
     events = signals.events
@@ -72,4 +81,4 @@ def build_orientation_frame() -> OrientationFrame:
     )
 
 
-__all__ = ["OrientationExplanation", "OrientationFrame", "build_orientation_frame"]
+__all__ = ["OrientationExplanation", "OrientationFrame", "build_orientation_frame", "pass_through_context_dimensions"]

--- a/app/services/outbox.py
+++ b/app/services/outbox.py
@@ -180,6 +180,7 @@ def _coerce_event(event: Event | OutboxEvent) -> Event:
     return new_event(
         event_type=event.event,
         payload=dict(payload),
+        context_dimensions=getattr(event, "context_dimensions", None),
         trace_id=event.trace_id,
         source=event_source_name(getattr(event, "source", None), default="app"),
         event_id=event.event_id,

--- a/app/services/outbox.py
+++ b/app/services/outbox.py
@@ -131,6 +131,7 @@ def coerce_outbox_event(event: Any, *, default_source: str = "app") -> OutboxEve
             source=event_source_name(event.source, default=default_source),
             timestamp=event.created_at,
             payload=event_payload_dict(event.payload),
+            context_dimensions=getattr(event, "context_dimensions", None),
         )
     event_name = getattr(event, "event", None) or getattr(event, "event_type", None)
     if not event_name:

--- a/app/watcher/vault_watcher.py
+++ b/app/watcher/vault_watcher.py
@@ -221,6 +221,29 @@ def _auto_exec_enabled(vault_root: Path) -> bool:
     return resolve_auto_exec_enabled(vault_root=vault_root)
 
 
+def _resolve_note_scope(frontmatter: dict[str, object], global_scope: str | None) -> str | None:
+    for key in ("scope", "domain"):
+        value = frontmatter.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return global_scope
+
+
+def extract_context_dimensions_for_note(frontmatter: dict[str, object], *, global_scope: str | None = None) -> dict[str, object]:
+    scope = _resolve_note_scope(frontmatter, global_scope)
+    spheres = frontmatter.get("sphere_memberships")
+    if not isinstance(spheres, list):
+        spheres = []
+    identity = frontmatter.get("situated_identity")
+    if not isinstance(identity, str):
+        identity = None
+    return {
+        "scope": scope,
+        "sphere_memberships": [str(item) for item in spheres],
+        "situated_identity": identity,
+    }
+
+
 def compute_changes(
     vault_root: Path, snapshot: Snapshot
 ) -> tuple[list[Path], list[Path], Snapshot]:

--- a/tests/events/test_context_dimensions_in_receipts.py
+++ b/tests/events/test_context_dimensions_in_receipts.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from app.events.schema import make_outbox_event
+
+
+def test_receipt_includes_context_dimensions() -> None:
+    event = make_outbox_event(
+        "watcher.run.completed",
+        source="watcher",
+        payload={"changed": 1},
+        context_dimensions={
+            "scope": "work",
+            "sphere_memberships": ["team"],
+            "situated_identity": None,
+        },
+    )
+    dumped = event.model_dump(exclude_none=True)
+    assert dumped["context_dimensions"]["scope"] == "work"
+    assert dumped["context_dimensions"]["sphere_memberships"] == ["team"]
+    assert "situated_identity" in dumped["context_dimensions"]
+    assert dumped["context_dimensions"]["situated_identity"] is None
+
+
+def test_receipt_omits_context_dimensions_when_absent() -> None:
+    event = make_outbox_event(
+        "watcher.run.completed",
+        source="watcher",
+        payload={"changed": 1},
+    )
+    dumped = event.model_dump(exclude_none=True)
+    assert "context_dimensions" not in dumped

--- a/tests/observability/test_context_dimensions_in_status.py
+++ b/tests/observability/test_context_dimensions_in_status.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+
+from app.observability.status_service import get_system_status
+
+
+def test_status_includes_context_dimensions_block(monkeypatch, tmp_path) -> None:
+    outbox = tmp_path / "outbox.jsonl"
+    outbox.write_text(
+        json.dumps(
+            {
+                "event": "watcher.run.completed",
+                "context_dimensions": {
+                    "scope": "work",
+                    "sphere_memberships": ["team"],
+                    "situated_identity": "maker",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox))
+    monkeypatch.setattr("app.observability.status_service.INDEX_OUTBOX_PATH", outbox)
+
+    status = get_system_status()
+    assert status.context_dimensions is not None
+    assert status.context_dimensions.scope == "work"
+    assert status.context_dimensions.sphere_memberships == ["team"]
+    assert status.context_dimensions.situated_identity == "maker"
+
+
+def test_status_omits_block_when_no_context(monkeypatch, tmp_path) -> None:
+    outbox = tmp_path / "outbox.jsonl"
+    outbox.write_text(json.dumps({"event": "watcher.run.completed"}) + "\n", encoding="utf-8")
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox))
+    monkeypatch.setattr("app.observability.status_service.INDEX_OUTBOX_PATH", outbox)
+
+    status = get_system_status()
+    dumped = status.model_dump(exclude_none=True)
+    assert "context_dimensions" not in dumped
+
+
+def test_null_situated_identity_explicit_not_omitted(monkeypatch, tmp_path) -> None:
+    outbox = tmp_path / "outbox.jsonl"
+    outbox.write_text(
+        json.dumps(
+            {
+                "event": "watcher.run.completed",
+                "context_dimensions": {
+                    "scope": "work",
+                    "sphere_memberships": [],
+                    "situated_identity": None,
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox))
+    monkeypatch.setattr("app.observability.status_service.INDEX_OUTBOX_PATH", outbox)
+
+    status = get_system_status()
+    assert status.context_dimensions is not None
+    dumped = status.context_dimensions.model_dump()
+    assert "situated_identity" in dumped
+    assert dumped["situated_identity"] is None
+
+
+def test_no_all_null_context_dimensions_block(monkeypatch, tmp_path) -> None:
+    outbox = tmp_path / "outbox.jsonl"
+    outbox.write_text(
+        json.dumps(
+            {
+                "event": "watcher.run.completed",
+                "context_dimensions": {
+                    "scope": None,
+                    "sphere_memberships": None,
+                    "situated_identity": None,
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox))
+    monkeypatch.setattr("app.observability.status_service.INDEX_OUTBOX_PATH", outbox)
+
+    status = get_system_status()
+    dumped = status.model_dump(exclude_none=True)
+    assert "context_dimensions" not in dumped

--- a/tests/orchestration/test_context_dimension_threading.py
+++ b/tests/orchestration/test_context_dimension_threading.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from app.orchestrator.runtime import Orchestrator
+from app.planner.schema import Plan, PlanMetadata, PlanStep
+
+
+class _CaptureExecutor:
+    def __init__(self) -> None:
+        self.contexts = []
+
+    def execute_step(self, step, context):
+        self.contexts.append(context)
+        return {"ok": True}
+
+
+def test_context_dimensions_in_step_context() -> None:
+    executor = _CaptureExecutor()
+    orchestrator = Orchestrator(executor=executor)
+    plan = Plan(
+        id="plan-ctx-dims",
+        meta=PlanMetadata(goal="ctx", source_object_uuid="obj-1", created_by="test", trace_id="trace-1"),
+        steps=[PlanStep(id="step-1", kind="note", description="noop")],
+        context={
+            "scope": "work",
+            "sphere_memberships": ["team", "learning"],
+            "situated_identity": "maker",
+        },
+    )
+
+    results = orchestrator.run_plan(plan)
+
+    assert results[0]["status"] == "ok"
+    assert len(executor.contexts) == 1
+    ctx = executor.contexts[0]
+    assert ctx.scope == "work"
+    assert ctx.sphere_memberships == ["team", "learning"]
+    assert ctx.situated_identity == "maker"

--- a/tests/orientation/test_context_dimension_threading.py
+++ b/tests/orientation/test_context_dimension_threading.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from app.orientation.runtime import pass_through_context_dimensions
+
+
+def test_orientation_does_not_collapse_dimensions() -> None:
+    record = {
+        "context_dimensions": {
+            "scope": "work",
+            "sphere_memberships": ["team", "learning"],
+            "situated_identity": "maker",
+        }
+    }
+
+    dims = pass_through_context_dimensions(record)
+
+    assert dims["scope"] == "work"
+    assert dims["sphere_memberships"] == ["team", "learning"]
+    assert dims["situated_identity"] == "maker"
+    assert "domain" not in dims

--- a/tests/retrieval/test_context_dimension_threading.py
+++ b/tests/retrieval/test_context_dimension_threading.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from app.retrieval.hybrid import get_store, hybrid_search
+
+
+def _patch_embeddings(monkeypatch) -> None:
+    monkeypatch.setattr("app.retrieval.hybrid.embed_text", lambda text, language=None: [0.1, 0.1, 0.1])
+    monkeypatch.setattr("app.retrieval.hybrid.embed_docs", lambda texts: ([[0.1, 0.1, 0.1] for _ in texts], {}))
+
+
+def test_scope_flows_through_retrieval_unchanged(monkeypatch) -> None:
+    _patch_embeddings(monkeypatch)
+    calls: list[str] = []
+
+    monkeypatch.setattr("app.retrieval.hybrid._resolve_domain_scope", lambda: "work")
+
+    def _tracking_doc_in_scope(doc, scope: str) -> bool:
+        calls.append(scope)
+        return bool(doc.payload and doc.payload.get("domain") == scope)
+
+    monkeypatch.setattr("app.retrieval.hybrid._doc_in_scope", _tracking_doc_in_scope)
+
+    store = get_store()
+    store.set_documents(
+        [
+            {"doc_id": "a", "text": "alpha", "payload": {"domain": "work"}},
+            {"doc_id": "b", "text": "beta", "payload": {"domain": "personal"}},
+        ]
+    )
+    try:
+        hits = hybrid_search("alpha", k=5)
+        assert [h["doc_id"] for h in hits] == ["a"]
+        assert calls
+        assert set(calls) == {"work"}
+    finally:
+        store.set_documents([])

--- a/tests/test_outbox_contract.py
+++ b/tests/test_outbox_contract.py
@@ -86,3 +86,24 @@ def test_coerce_outbox_event_uses_typed_payload_not_full_event_envelope(tmp_path
     assert append_jsonl_outbox_event(outbox_path, event, default_source="panel_agent.runtime") is True
     records = [json.loads(line) for line in outbox_path.read_text(encoding="utf-8").splitlines() if line.strip()]
     assert records[0]["payload"]["panel"]["panel_id"] == "panel-1"
+
+
+def test_coerce_outbox_event_preserves_context_dimensions_from_event() -> None:
+    event = new_event(
+        event_type=INGEST_OBJECT_CREATED,
+        payload={"uuid": "abc-123"},
+        trace_id="trace-ctx",
+        context_dimensions={
+            "scope": "work",
+            "sphere_memberships": ["team"],
+            "situated_identity": "maker",
+        },
+    )
+
+    outbox_event = coerce_outbox_event(event)
+
+    assert outbox_event is not None
+    assert outbox_event.context_dimensions is not None
+    assert outbox_event.context_dimensions["scope"] == "work"
+    assert outbox_event.context_dimensions["sphere_memberships"] == ["team"]
+    assert outbox_event.context_dimensions["situated_identity"] == "maker"

--- a/tests/watcher/test_context_dimension_threading.py
+++ b/tests/watcher/test_context_dimension_threading.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from app.watcher.vault_watcher import extract_context_dimensions_for_note
+
+
+def test_per_note_scope_not_overridden_by_global() -> None:
+    frontmatter = {"scope": "note-scope", "domain": "legacy-scope"}
+
+    dims = extract_context_dimensions_for_note(frontmatter, global_scope="global-scope")
+
+    assert dims["scope"] == "note-scope"
+
+
+def test_scope_glob_stays_separate_from_operational_scope() -> None:
+    frontmatter = {"scope_glob": "Inbox/**", "domain": "work"}
+
+    dims = extract_context_dimensions_for_note(frontmatter, global_scope="global-scope")
+
+    assert dims["scope"] == "work"
+    assert dims["scope"] != frontmatter["scope_glob"]


### PR DESCRIPTION
Fixes #731

## Summary
- thread context dimensions into StepContext in orchestrator v1/v2 from plan.context
- add watcher frontmatter extraction helper that prioritizes per-note scope over global scope and keeps scope_glob separate
- add orientation pass-through helper for context dimensions without collapsing into legacy keys
- add acceptance tests for retrieval/orchestration/watcher/orientation threading paths

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest -q --import-mode=importlib tests/retrieval/test_context_dimension_threading.py tests/orchestration/test_context_dimension_threading.py tests/watcher/test_context_dimension_threading.py tests/orientation/test_context_dimension_threading.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest -q --import-mode=importlib -m "not pg" tests/retrieval/ tests/orchestration/ tests/watcher/ tests/orientation/`

---
