### PR TITLE
docs: owner-doc promotion for #742 — staged suggestion moment delivered

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -620,7 +620,7 @@ See [`docs/RELEASE_CHANNELS/DEFINE_CHANNEL_IDENTITY.md`](RELEASE_CHANNELS/DEFINE
 ## Companion UI design handoff reference (2026-05-03)
 
 A new Companion UI converse-surface design handoff was added at `companion-ui/design-handoff/2026-05-03-converse/`.
-This handoff remains a design reference package (wireframe HTML, style tokens, and prototype JSX), and the first bounded implementation slice now exists in `companion-ui/src/` as a document-first layout shell with deterministic rail-state geometry. These assets remain companion-UI reference code, not production runtime code.
+This handoff remains a design reference package (wireframe HTML, style tokens, and prototype JSX), and a bounded implementation now exists in `companion-ui/src/` covering rail-state geometry, thread/composer states, and a staged suggestion moment with apply/discard intents (delivered by PR #750). These assets remain companion-UI reference code, not production runtime code.
 
 Architecture boundary reminder:
 - the companion UI remains a client of the existing FastAPI runtime,

--- a/docs/HUMAN-FLOWS.md
+++ b/docs/HUMAN-FLOWS.md
@@ -866,4 +866,4 @@ document should continue to hold.
 
 Converse interaction design handoff materials are now available at `companion-ui/design-handoff/2026-05-03-converse/`.
 The handoff reinforces the document-first Converse behavior: vault note remains primary, dialogue operates as a secondary rail/sheet, and suggestion moments are staged for explicit user action.
-That direction is no longer handoff-only: a first bounded shell implementation now exists in `companion-ui/src/`, while the richer thread/composer, staged-suggestion, and portrait/session-drawer interaction slices remain tracked follow-up work.
+That direction is no longer handoff-only: a bounded shell implementation now exists in `companion-ui/src/` with rail-state geometry, thread/composer states, and a staged suggestion moment (apply/discard intents, mirrored proposal identity cues, and dimmed non-focused region — delivered by PR #750). The portrait/session-drawer interaction slices remain tracked follow-up work.


### PR DESCRIPTION
## Summary

Owner-doc promotion for closed Issue #742 (delivered by PR #750).

**Claim corrected in `docs/HUMAN-FLOWS.md:869`**: The sentence listed `staged-suggestion` alongside `portrait/session-drawer` as "remain tracked follow-up work." PR #750 delivered the staged suggestion moment, so this was false.

**Claim updated in `docs/ARCHITECTURE.md:623`**: The description of `companion-ui/src/` only mentioned "layout shell with deterministic rail-state geometry." Updated to include the staged suggestion moment now present in the codebase.

Both are docs-authoring lane changes (no code, no behavior change).

- [x] Docs authoring lane