### PR TITLE
docs: name context_dimensions in OBSERVABILITY.md and EVENTS.md owner docs

### DIFF
--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -39,6 +39,11 @@ All outbox records MUST include this minimal envelope:
 - `timestamp` (`string`, ISO-8601 UTC): emission time.
 - `payload` (`object`): event-specific content.
 - `meta` (`object`, optional): non-semantic metadata; when omitted it is treated as `{}`.
+- `context_dimensions` (`object`, optional): named optional top-level field carrying separated
+  scope/sphere/identity dimensions with SSI-01 canonical shape (`scope`, `sphere_memberships`,
+  `situated_identity`). Omit entirely when the invocation had no separated-dimension context; do
+  not emit an all-null block. Distinct from generic unknown additionals — this field has a defined
+  contract. See `docs/SCOPE_SPHERE_SITUATED_IDENTITY/EXPOSE_CONTEXT_DIMENSIONS_IN_STATUS_AND_RECEIPTS.md` (SSI-03) for field semantics and guardrail notes.
 
 Notes:
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -59,6 +59,10 @@ Architectural reading note:
   operator-facing honesty signal for stale or partial runtime views; it is not distributed
   consensus, replica conflict resolution, or a guarantee that every retrieval result is globally
   fresh.
+- **`context_dimensions`** (optional): present when a separated-dimension context is active;
+  contains `scope`, `sphere_memberships`, and `situated_identity` with SSI-01 canonical semantics.
+  Omitted entirely when no separated-dimension context is active — a block of all-null values is
+  not permitted. See `docs/SCOPE_SPHERE_SITUATED_IDENTITY/EXPOSE_CONTEXT_DIMENSIONS_IN_STATUS_AND_RECEIPTS.md` (SSI-03) for field semantics and guardrail notes.
 
 ## Feature-line and Event Counters
 - **SoT baseline vs forward line**: `sot_baseline_version` is the locked baseline (v5.5). `sot_forward_line_version` / `feature_line_version` represent the active forward line (v5.6: LangGraph/Reasoning rollouts on top of the v5.5 baseline). `active_features` enumerates which forward-line capabilities are present (PanelAgent runtime, watcher snapshot/policy track, config-driven panel wiring).


### PR DESCRIPTION
## Change Lane
- [ ] Implementation lane
- [x] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Closes #753

## Summary
- Extend `docs/OBSERVABILITY.md` Status snapshot (CLI) section to name `context_dimensions` as an optional status field present when a separated-dimension context is active and omitted otherwise.
- Extend `docs/EVENTS.md` Outbox envelope section to name `context_dimensions` as a recognized optional top-level field (distinct from generic unknown additionals) with SSI-01 canonical shape and a pointer to SSI-03 for semantics.

## Docs Authoring Check
- [x] This PR only changes approved docs-authoring surfaces.
- [x] No code, runtime behavior, contracts, or shipped reality changed.
- [x] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [ ] Docs were updated in the same change when behavior/contracts changed.
- [ ] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Validation
Docs authoring lane:
- [x] `grep "context_dimensions" docs/OBSERVABILITY.md` → non-empty match ✅
- [x] `grep "context_dimensions" docs/EVENTS.md` → non-empty match ✅
- [x] No code changes; no runtime behavior changed.

## Notes
- Docs-only PR. Extends the two owner docs that were incomplete against shipped reality from PR #751 (closing #732).
- Full field semantics, required/allowed-omission table, and guardrail notes are in SSI-03 (`docs/SCOPE_SPHERE_SITUATED_IDENTITY/EXPOSE_CONTEXT_DIMENSIONS_IN_STATUS_AND_RECEIPTS.md`); the owner doc additions link to it rather than duplicating the schema.