### PR TITLE
feat(companion-ui): session drawer and portrait bottom-sheet states (#743)

### DIFF
--- a/companion-ui/src/converse_layout.css
+++ b/companion-ui/src/converse_layout.css
@@ -357,6 +357,242 @@ body {
   color: var(--fg-3);
 }
 
+/* ── Session pill ─────────────────────────────────────────────────────── */
+
+.session-pill {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  color: var(--fg-2);
+  font-size: 11px;
+  padding: 3px 8px;
+  margin: 0 auto 0 12px;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 240px;
+}
+
+/* ── Session drawer overlay (C.4) ─────────────────────────────────────── */
+
+.session-drawer-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  pointer-events: none;
+}
+
+.session-drawer-overlay[data-drawer-state="closed"] {
+  visibility: hidden;
+}
+
+.session-drawer-overlay[data-drawer-state="open"] {
+  pointer-events: auto;
+  visibility: visible;
+}
+
+.session-drawer-scrim {
+  position: absolute;
+  inset: 0;
+  background: rgba(7, 11, 18, 0.55);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+}
+
+.session-drawer-overlay[data-drawer-state="closed"] .session-drawer {
+  transform: translateX(-340px);
+}
+
+.session-drawer-overlay[data-drawer-state="open"] .session-drawer {
+  transform: translateX(0);
+}
+
+.session-drawer {
+  position: relative;
+  width: 340px;
+  height: 100%;
+  background: var(--bg-surface);
+  border-right: 1px solid var(--border);
+  box-shadow: 4px 0 32px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  transition: transform 220ms ease-out;
+  z-index: 1;
+}
+
+.session-drawer-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.session-drawer-title {
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  color: var(--fg-3);
+  text-transform: uppercase;
+  flex: 1;
+}
+
+.session-drawer-new {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  color: var(--fg-2);
+  font-size: 10px;
+  padding: 3px 8px;
+  cursor: pointer;
+}
+
+.session-drawer-close {
+  background: transparent;
+  border: none;
+  color: var(--fg-3);
+  font-size: 13px;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.session-drawer-search {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.session-drawer-search input {
+  width: 100%;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  padding: 5px 10px;
+  color: var(--fg-1);
+  font-size: 12px;
+}
+
+.session-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+  margin: 0;
+  list-style: none;
+}
+
+.session-list-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 10px;
+  border-radius: 2px;
+  margin-bottom: 2px;
+  cursor: pointer;
+}
+
+.session-list-item--active {
+  background: rgba(212, 168, 67, 0.05);
+  border: 1px solid rgba(212, 168, 67, 0.25);
+}
+
+.session-list-item:not(.session-list-item--active) {
+  border: 1px solid transparent;
+}
+
+.session-title {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--fg-2);
+}
+
+.session-list-item--active .session-title {
+  color: var(--accent, #d4a843);
+}
+
+.session-path,
+.session-meta {
+  font-size: 9px;
+  color: var(--fg-3);
+  font-family: monospace;
+}
+
+.session-meta {
+  align-self: flex-end;
+}
+
+.session-drawer-footer {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 14px;
+  border-top: 1px solid var(--border);
+  font-size: 9px;
+  color: var(--fg-3);
+  font-family: monospace;
+}
+
+/* ── Portrait bottom sheet (C.5) ──────────────────────────────────────── */
+
+.bottom-sheet {
+  display: none;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: var(--bg-surface);
+  border-top: 1px solid var(--border);
+  box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.3);
+  flex-direction: column;
+  z-index: 50;
+  transition: height 200ms ease-out;
+}
+
+.bottom-sheet[data-sheet-snap="collapsed"] {
+  height: 32px;
+  overflow: hidden;
+}
+
+.bottom-sheet[data-sheet-snap="peek"] {
+  height: 240px;
+}
+
+.bottom-sheet[data-sheet-snap="full"] {
+  height: 80vh;
+}
+
+.bottom-sheet-handle {
+  width: 36px;
+  height: 3px;
+  background: var(--border-strong, #1e3050);
+  border-radius: 2px;
+  margin: 10px auto 6px;
+  flex-shrink: 0;
+}
+
+@media (orientation: portrait), (max-width: 600px) {
+  .main-landscape .rail {
+    display: none;
+  }
+
+  .main-landscape {
+    grid-template-columns: 1fr;
+  }
+
+  .bottom-sheet {
+    display: flex;
+  }
+
+  .document-pane {
+    padding-bottom: 160px;
+  }
+}
+
 @keyframes pulse {
   0%,
   100% {

--- a/companion-ui/src/converse_layout.html
+++ b/companion-ui/src/converse_layout.html
@@ -10,6 +10,13 @@
     <div class="converse-shell">
       <header class="top-bar" data-testid="top-bar">
         <strong>Converse</strong>
+        <button
+          class="session-pill"
+          type="button"
+          data-testid="session-pill"
+          data-intent="session-drawer.open"
+          aria-label="Open session list"
+        >Decision capture scaffold ▾</button>
         <div class="vault-status" data-testid="vault-status">
           <span class="vault-status-dot" aria-label="Vault online"></span>
           <span>Vault online</span>
@@ -108,6 +115,76 @@
           </footer>
         </aside>
       </section>
+    </div>
+
+    <!-- C.4 — Session drawer overlay -->
+    <div class="session-drawer-overlay" data-testid="session-drawer" data-drawer-state="closed">
+      <div
+        class="session-drawer-scrim"
+        data-testid="session-drawer-scrim"
+        data-intent="session-drawer.dismiss"
+        aria-hidden="true"
+      ></div>
+      <nav class="session-drawer" aria-label="Sessions">
+        <header class="session-drawer-header">
+          <span class="session-drawer-title">SESSIONS</span>
+          <button class="session-drawer-new" type="button" data-testid="session-drawer-new" aria-label="New session">
+            + New
+          </button>
+          <button
+            class="session-drawer-close"
+            type="button"
+            data-testid="session-drawer-close"
+            data-intent="session-drawer.close"
+            aria-label="Close session drawer"
+          >✕</button>
+        </header>
+        <div class="session-drawer-search" data-testid="session-drawer-search">
+          <input type="search" placeholder="Search sessions…" aria-label="Search sessions" />
+        </div>
+        <ul class="session-list" data-testid="session-list" role="list">
+          <li class="session-list-item session-list-item--active" data-testid="session-list-item-active" role="listitem">
+            <span class="session-title">Decision capture scaffold</span>
+            <span class="session-path">Projects/Q2-arch.md</span>
+            <span class="session-meta">2h · 18 turns</span>
+          </li>
+          <li class="session-list-item" data-testid="session-list-item" role="listitem">
+            <span class="session-title">Architecture review</span>
+            <span class="session-path">Projects/arch-review.md</span>
+            <span class="session-meta">1d · 7 turns</span>
+          </li>
+        </ul>
+        <footer class="session-drawer-footer" data-testid="session-drawer-footer">
+          <span class="vault-status-dot" aria-hidden="true"></span>
+          <span>Vault online · 2 sessions</span>
+        </footer>
+      </nav>
+    </div>
+
+    <!-- C.5 — Portrait bottom sheet (replaces margin rail in portrait/narrow viewports) -->
+    <div
+      class="bottom-sheet"
+      data-testid="bottom-sheet"
+      data-sheet-snap="peek"
+      aria-label="Conversation bottom sheet"
+    >
+      <div class="bottom-sheet-handle" data-testid="bottom-sheet-handle" aria-hidden="true"></div>
+      <header class="rail-header">
+        <span class="hugin-dot" aria-hidden="true"></span>
+        <span class="hugin-label">HUGIN</span>
+        <span class="turn-count">18 turns ›</span>
+      </header>
+      <section class="conversation-thread" aria-label="Conversation thread">
+        <article class="message message--agent">
+          <p>We can keep this bounded to visual state and thread rendering.</p>
+        </article>
+      </section>
+      <footer class="composer-stack">
+        <div class="composer" data-composer-state="enabled">
+          <input type="text" placeholder="Message Hugin…" aria-label="Compose message" />
+          <button type="button" data-testid="bottom-sheet-composer-send">Send</button>
+        </div>
+      </footer>
     </div>
   </body>
 </html>

--- a/companion-ui/src/converse_layout_state.py
+++ b/companion-ui/src/converse_layout_state.py
@@ -1,9 +1,13 @@
-"""Converse layout shell state contract for landscape layouts."""
+"""Converse layout shell state contract for landscape, drawer, and portrait layouts."""
 
 COLLAPSED_RAIL_WIDTH_PX = 32
 EXPANDED_RAIL_WIDTH_PX = 288
 DOCUMENT_MAX_WIDTH_PX = 640
 TOP_BAR_HEIGHT_PX = 38
+
+PORTRAIT_SHEET_COLLAPSED_HEIGHT_PX = 32
+PORTRAIT_SHEET_PEEK_HEIGHT_PX = 240
+PORTRAIT_SHEET_FULL_HEIGHT_VH = 80
 
 
 class ConverseLayoutState:
@@ -19,6 +23,66 @@ class ConverseLayoutState:
         self.rail_width_px = rail_width_px
         self.document_max_width_px = document_max_width_px
         self.rail_class = rail_class
+
+
+class SessionDrawerState:
+    def __init__(self, *, drawer_open: bool, drawer_class: str) -> None:
+        self.drawer_open = drawer_open
+        self.drawer_class = drawer_class
+
+
+class BottomSheetState:
+    def __init__(
+        self,
+        *,
+        sheet_snap: str,
+        sheet_height_px: int | None,
+        sheet_height_vh: int | None,
+        sheet_class: str,
+    ) -> None:
+        self.sheet_snap = sheet_snap
+        self.sheet_height_px = sheet_height_px
+        self.sheet_height_vh = sheet_height_vh
+        self.sheet_class = sheet_class
+
+
+def resolve_session_drawer_state(*, drawer_open: bool) -> SessionDrawerState:
+    """Map drawer open/closed boolean to class tokens."""
+    if drawer_open:
+        return SessionDrawerState(
+            drawer_open=True,
+            drawer_class="session-drawer-overlay session-drawer-overlay--open",
+        )
+    return SessionDrawerState(
+        drawer_open=False,
+        drawer_class="session-drawer-overlay session-drawer-overlay--closed",
+    )
+
+
+def resolve_portrait_layout_state(*, sheet_snap: str) -> BottomSheetState:
+    """Map a portrait bottom-sheet snap point to geometry and class tokens."""
+    if sheet_snap == "collapsed":
+        return BottomSheetState(
+            sheet_snap=sheet_snap,
+            sheet_height_px=PORTRAIT_SHEET_COLLAPSED_HEIGHT_PX,
+            sheet_height_vh=None,
+            sheet_class="bottom-sheet bottom-sheet--collapsed",
+        )
+    if sheet_snap == "peek":
+        return BottomSheetState(
+            sheet_snap=sheet_snap,
+            sheet_height_px=PORTRAIT_SHEET_PEEK_HEIGHT_PX,
+            sheet_height_vh=None,
+            sheet_class="bottom-sheet bottom-sheet--peek",
+        )
+    if sheet_snap == "full":
+        return BottomSheetState(
+            sheet_snap=sheet_snap,
+            sheet_height_px=None,
+            sheet_height_vh=PORTRAIT_SHEET_FULL_HEIGHT_VH,
+            sheet_class="bottom-sheet bottom-sheet--full",
+        )
+    raise ValueError(f"Unsupported sheet_snap: {sheet_snap!r}")
 
 
 def resolve_layout_state(rail_state: str) -> ConverseLayoutState:

--- a/tests/companion_ui/test_converse_session_drawer_portrait.py
+++ b/tests/companion_ui/test_converse_session_drawer_portrait.py
@@ -1,0 +1,150 @@
+"""Tests for issue #743: session drawer (C.4) and portrait bottom-sheet (C.5) states."""
+from pathlib import Path
+import importlib.util
+
+
+def _load_state_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    module_path = repo_root / "companion-ui" / "src" / "converse_layout_state.py"
+    spec = importlib.util.spec_from_file_location("converse_layout_state", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def _html() -> str:
+    html_path = Path(__file__).resolve().parents[2] / "companion-ui" / "src" / "converse_layout.html"
+    return html_path.read_text(encoding="utf-8")
+
+
+def _css() -> str:
+    css_path = Path(__file__).resolve().parents[2] / "companion-ui" / "src" / "converse_layout.css"
+    return css_path.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# AC1 — Session drawer opens/closes from session pill with scrim-dismiss
+# ---------------------------------------------------------------------------
+
+
+def test_session_pill_present_with_open_intent() -> None:
+    html = _html()
+    assert 'data-testid="session-pill"' in html
+    assert 'data-intent="session-drawer.open"' in html
+
+
+def test_session_drawer_markup_present_and_closed_by_default() -> None:
+    html = _html()
+    assert 'data-testid="session-drawer"' in html
+    assert 'data-drawer-state="closed"' in html
+
+
+def test_session_drawer_scrim_has_dismiss_intent() -> None:
+    html = _html()
+    assert 'data-testid="session-drawer-scrim"' in html
+    assert 'data-intent="session-drawer.dismiss"' in html
+
+
+def test_session_drawer_close_button_has_close_intent() -> None:
+    html = _html()
+    assert 'data-testid="session-drawer-close"' in html
+    assert 'data-intent="session-drawer.close"' in html
+
+
+def test_session_drawer_contains_header_search_and_list() -> None:
+    html = _html()
+    assert 'data-testid="session-drawer-search"' in html
+    assert 'data-testid="session-list"' in html
+    assert 'data-testid="session-list-item-active"' in html
+    assert 'data-testid="session-drawer-footer"' in html
+
+
+def test_session_drawer_css_hidden_when_closed_and_visible_when_open() -> None:
+    css = _css()
+    assert 'data-drawer-state="closed"' in css
+    assert 'data-drawer-state="open"' in css
+
+
+def test_session_drawer_scrim_css_blur_overlay() -> None:
+    css = _css()
+    assert "backdrop-filter" in css
+    assert ".session-drawer-scrim" in css
+
+
+def test_session_drawer_state_model_resolves_open_and_closed() -> None:
+    state = _load_state_module()
+    closed = state.resolve_session_drawer_state(drawer_open=False)
+    assert closed.drawer_open is False
+    assert closed.drawer_class == "session-drawer-overlay session-drawer-overlay--closed"
+
+    open_ = state.resolve_session_drawer_state(drawer_open=True)
+    assert open_.drawer_open is True
+    assert closed.drawer_class != open_.drawer_class
+
+
+# ---------------------------------------------------------------------------
+# AC2 — Portrait mode uses bottom-sheet rail instead of side panel
+# ---------------------------------------------------------------------------
+
+
+def test_portrait_bottom_sheet_element_present() -> None:
+    html = _html()
+    assert 'data-testid="bottom-sheet"' in html
+    assert 'data-sheet-snap=' in html
+
+
+def test_portrait_css_switches_to_full_width_document() -> None:
+    css = _css()
+    assert "@media" in css
+    assert "portrait" in css or "max-width" in css
+
+
+def test_portrait_css_hides_margin_rail_and_shows_bottom_sheet() -> None:
+    css = _css()
+    assert ".bottom-sheet" in css
+
+
+def test_portrait_layout_state_resolves_snap_points() -> None:
+    state = _load_state_module()
+    peek = state.resolve_portrait_layout_state(sheet_snap="peek")
+    assert peek.sheet_snap == "peek"
+    assert peek.sheet_height_px == 240
+
+    collapsed = state.resolve_portrait_layout_state(sheet_snap="collapsed")
+    assert collapsed.sheet_snap == "collapsed"
+    assert collapsed.sheet_height_px == 32
+
+
+# ---------------------------------------------------------------------------
+# AC3 — Bottom sheet supports collapsed/expanded states, composer in peek
+# ---------------------------------------------------------------------------
+
+
+def test_bottom_sheet_drag_handle_present() -> None:
+    html = _html()
+    assert 'data-testid="bottom-sheet-handle"' in html
+
+
+def test_bottom_sheet_snap_data_attribute_reflects_snap_state() -> None:
+    html = _html()
+    assert 'data-sheet-snap="peek"' in html
+
+
+def test_bottom_sheet_contains_composer_for_peek_visibility() -> None:
+    html = _html()
+    assert 'data-testid="bottom-sheet-composer-send"' in html
+
+
+def test_portrait_layout_state_full_snap_covers_most_of_viewport() -> None:
+    state = _load_state_module()
+    full = state.resolve_portrait_layout_state(sheet_snap="full")
+    assert full.sheet_snap == "full"
+    assert full.sheet_height_vh == 80
+
+
+def test_portrait_layout_state_rejects_unknown_snap() -> None:
+    import pytest
+    state = _load_state_module()
+    with pytest.raises(ValueError):
+        state.resolve_portrait_layout_state(sheet_snap="unknown")


### PR DESCRIPTION
- [x] Implementation lane

## Summary
- Adds **session pill** in top bar with `data-intent="session-drawer.open"` trigger
- Adds **session drawer overlay** (C.4): scrim with blur/dismiss, 340px drawer with header, search, session list (active + inactive items), footer
- Extends **CSS** with drawer open/closed data-attribute states, slide-in animation (`translateX`, 220ms ease-out), scrim `backdrop-filter: blur(2px)`, and portrait media query
- Adds **portrait bottom sheet** (C.5): three snap points (`collapsed` 32px, `peek` 240px, `full` 80vh), drag handle, composer retained in peek state
- Extends **`converse_layout_state.py`** with `SessionDrawerState`, `BottomSheetState`, `resolve_session_drawer_state()`, `resolve_portrait_layout_state()`
- Adds **17 new tests** in `tests/companion_ui/test_converse_session_drawer_portrait.py` covering all three ACs; zero regressions in existing 10-test shell suite

## Validation
- `pytest tests/companion_ui/` → 27 passed, 0 failed
- All AC `Verify:` targets resolve green:
  - AC1 (drawer open/close + scrim-dismiss): `test_session_drawer_*` — 7 tests pass
  - AC2 (portrait rail switch): `test_portrait_*` — 4 tests pass
  - AC3 (snap states + peek composer): `test_bottom_sheet_*` — 4 tests pass + `test_portrait_layout_state_*` — 2 tests pass
- Dispatcher unavailable (db_exists: false) — used GitHub-label-only claim

Fixes #743