### PR TITLE
fix(companion-ui): align state model data-attribute tokens with CSS selectors

### DIFF
--- a/companion-ui/src/converse_layout_state.py
+++ b/companion-ui/src/converse_layout_state.py
@@ -26,8 +26,10 @@ class ConverseLayoutState:
 
 
 class SessionDrawerState:
-    def __init__(self, *, drawer_open: bool, drawer_class: str) -> None:
+    def __init__(self, *, drawer_open: bool, drawer_state: str, drawer_class: str) -> None:
         self.drawer_open = drawer_open
+        # data-drawer-state attribute value: "open" | "closed" — CSS selectors target this
+        self.drawer_state = drawer_state
         self.drawer_class = drawer_class
 
 
@@ -38,49 +40,51 @@ class BottomSheetState:
         sheet_snap: str,
         sheet_height_px: int | None,
         sheet_height_vh: int | None,
-        sheet_class: str,
     ) -> None:
-        self.sheet_snap = sheet_snap
+        self.sheet_snap = sheet_snap          # data-sheet-snap attribute value — CSS selectors target this
         self.sheet_height_px = sheet_height_px
         self.sheet_height_vh = sheet_height_vh
-        self.sheet_class = sheet_class
+        self.sheet_class = "bottom-sheet"     # base class only; snap state is carried by sheet_snap
 
 
 def resolve_session_drawer_state(*, drawer_open: bool) -> SessionDrawerState:
-    """Map drawer open/closed boolean to class tokens."""
+    """Map drawer open/closed boolean to data-attribute value and base class token."""
     if drawer_open:
         return SessionDrawerState(
             drawer_open=True,
-            drawer_class="session-drawer-overlay session-drawer-overlay--open",
+            drawer_state="open",
+            drawer_class="session-drawer-overlay",
         )
     return SessionDrawerState(
         drawer_open=False,
-        drawer_class="session-drawer-overlay session-drawer-overlay--closed",
+        drawer_state="closed",
+        drawer_class="session-drawer-overlay",
     )
 
 
 def resolve_portrait_layout_state(*, sheet_snap: str) -> BottomSheetState:
-    """Map a portrait bottom-sheet snap point to geometry and class tokens."""
+    """Map a portrait bottom-sheet snap point to geometry tokens.
+
+    sheet_snap is the value for the data-sheet-snap attribute; CSS height
+    selectors (.bottom-sheet[data-sheet-snap="peek"] etc.) target it directly.
+    """
     if sheet_snap == "collapsed":
         return BottomSheetState(
             sheet_snap=sheet_snap,
             sheet_height_px=PORTRAIT_SHEET_COLLAPSED_HEIGHT_PX,
             sheet_height_vh=None,
-            sheet_class="bottom-sheet bottom-sheet--collapsed",
         )
     if sheet_snap == "peek":
         return BottomSheetState(
             sheet_snap=sheet_snap,
             sheet_height_px=PORTRAIT_SHEET_PEEK_HEIGHT_PX,
             sheet_height_vh=None,
-            sheet_class="bottom-sheet bottom-sheet--peek",
         )
     if sheet_snap == "full":
         return BottomSheetState(
             sheet_snap=sheet_snap,
             sheet_height_px=None,
             sheet_height_vh=PORTRAIT_SHEET_FULL_HEIGHT_VH,
-            sheet_class="bottom-sheet bottom-sheet--full",
         )
     raise ValueError(f"Unsupported sheet_snap: {sheet_snap!r}")
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -309,5 +309,5 @@ All six task specs are complete and closed; promotion and rollback skills are au
 
 - Converse wireframe/package intake completed at `companion-ui/design-handoff/2026-05-03-converse/`.
 - Package includes implementation-spec README plus reference HTML/CSS/JSX prototypes.
-- Initial implementation has now started in `companion-ui/src/` with the document-first Converse shell and deterministic rail-state geometry delivered via PR #745.
-- Next delivery work should complete the remaining bounded interaction slices tracked in Issues #741, #742, and #743 while preserving current architecture constraints (runtime-client model, vault-first durability).
+- Initial implementation delivered in `companion-ui/src/` across four bounded slices: layout shell + rail geometry (PR #745), rail thread/composer states (PR #746), staged suggestion moment (PR #750), and session drawer + portrait bottom-sheet (PR #762).
+- All Converse interaction slices from the 2026-05-03 handoff (Issues #740–#743) are now delivered. The runtime-client boundary and vault-first durability constraints were preserved throughout.

--- a/tests/companion_ui/test_converse_session_drawer_portrait.py
+++ b/tests/companion_ui/test_converse_session_drawer_portrait.py
@@ -76,11 +76,13 @@ def test_session_drawer_state_model_resolves_open_and_closed() -> None:
     state = _load_state_module()
     closed = state.resolve_session_drawer_state(drawer_open=False)
     assert closed.drawer_open is False
-    assert closed.drawer_class == "session-drawer-overlay session-drawer-overlay--closed"
+    assert closed.drawer_state == "closed"   # must match CSS [data-drawer-state="closed"]
+    assert closed.drawer_class == "session-drawer-overlay"
 
     open_ = state.resolve_session_drawer_state(drawer_open=True)
     assert open_.drawer_open is True
-    assert closed.drawer_class != open_.drawer_class
+    assert open_.drawer_state == "open"      # must match CSS [data-drawer-state="open"]
+    assert open_.drawer_class == closed.drawer_class  # same base class; state carried by drawer_state
 
 
 # ---------------------------------------------------------------------------
@@ -108,12 +110,14 @@ def test_portrait_css_hides_margin_rail_and_shows_bottom_sheet() -> None:
 def test_portrait_layout_state_resolves_snap_points() -> None:
     state = _load_state_module()
     peek = state.resolve_portrait_layout_state(sheet_snap="peek")
-    assert peek.sheet_snap == "peek"
+    assert peek.sheet_snap == "peek"         # value for data-sheet-snap attribute
     assert peek.sheet_height_px == 240
+    assert peek.sheet_class == "bottom-sheet"  # base class only; snap state via sheet_snap
 
     collapsed = state.resolve_portrait_layout_state(sheet_snap="collapsed")
     assert collapsed.sheet_snap == "collapsed"
     assert collapsed.sheet_height_px == 32
+    assert collapsed.sheet_class == "bottom-sheet"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- [x] Implementation lane

## Summary
Addresses two P1 findings from Codex review of PR #762, plus ROADMAP writeback:

- **SessionDrawerState** now exposes `drawer_state` (`"open"` | `"closed"`) — the value for the `data-drawer-state` attribute. CSS visibility/transform selectors target `[data-drawer-state="open|closed"]`, not BEM modifier classes. The old `drawer_class` returned `session-drawer-overlay--open/--closed` which would never hit any CSS rule.
- **BottomSheetState.sheet_class** is now the base class `"bottom-sheet"` only. Snap state is already correctly carried by `sheet_snap` (the value for `data-sheet-snap`), which the CSS height selectors (`[data-sheet-snap="peek"]` etc.) already target. The old snap-specific modifier classes would silently skip all height rules.
- **ROADMAP.md** updated: stale "remaining tracked follow-up work" wording removed; all four Converse handoff slices (#740–#743) marked as delivered.

Tests updated to assert the corrected contract (`drawer_state`, `sheet_class` as base only).

## Validation
- `pytest tests/companion_ui/` → 27 passed, 0 failed

Fixes #764