### PR TITLE
fix(outbox): exclude context_dimensions: null from serialize_outbox_record() output

### DIFF
--- a/app/services/outbox.py
+++ b/app/services/outbox.py
@@ -154,13 +154,13 @@ def serialize_outbox_record(event: Any, *, default_source: str = "app") -> dict[
     if isinstance(event, dict):
         return dict(event)
     if hasattr(event, "model_dump"):
-        dumped = event.model_dump(mode="json")
+        dumped = event.model_dump(mode="json", exclude_none=True)
         if isinstance(dumped, dict):
             return dumped
     coerced = coerce_outbox_event(event, default_source=default_source)
     if coerced is None:
         return None
-    return coerced.model_dump(mode="json")
+    return coerced.model_dump(mode="json", exclude_none=True)
 
 
 def append_jsonl_outbox_event(outbox_path: Path, event: Any, *, default_source: str = "app") -> bool:

--- a/tests/test_outbox_contract.py
+++ b/tests/test_outbox_contract.py
@@ -3,8 +3,9 @@ from datetime import datetime, timezone
 
 from app.events.panel import NoteRef, PanelInfo, PanelIntentExecutedEvent, PanelIntentExecutedPayload
 from app.events.models import new_event
+from app.events.schema import OutboxEvent
 from app.events.types import INGEST_OBJECT_CREATED
-from app.services.outbox import append_jsonl_outbox_event, coerce_outbox_event, write_outbox_event
+from app.services.outbox import append_jsonl_outbox_event, coerce_outbox_event, serialize_outbox_record, write_outbox_event
 
 
 class FakeConn:
@@ -107,3 +108,63 @@ def test_coerce_outbox_event_preserves_context_dimensions_from_event() -> None:
     assert outbox_event.context_dimensions["scope"] == "work"
     assert outbox_event.context_dimensions["sphere_memberships"] == ["team"]
     assert outbox_event.context_dimensions["situated_identity"] == "maker"
+
+
+# --- AC: serialize_outbox_record null-omission contract (issue #756) ---
+
+
+def test_serialize_outbox_record_omits_context_dimensions_when_absent() -> None:
+    """OutboxEvent without context_dimensions must not emit the key at all."""
+    ev = OutboxEvent(event="test.event", source="app", payload={"x": 1})
+    assert ev.context_dimensions is None
+
+    result = serialize_outbox_record(ev)
+
+    assert result is not None
+    assert "context_dimensions" not in result, (
+        f"context_dimensions must be omitted when None, got: {result.get('context_dimensions')!r}"
+    )
+
+
+def test_serialize_outbox_record_includes_context_dimensions_when_present() -> None:
+    """OutboxEvent with context_dimensions must emit the block correctly."""
+    ev = OutboxEvent(
+        event="test.event",
+        source="app",
+        payload={"x": 1},
+        context_dimensions={"scope": "work", "sphere_memberships": ["team"], "situated_identity": "maker"},
+    )
+
+    result = serialize_outbox_record(ev)
+
+    assert result is not None
+    assert "context_dimensions" in result
+    assert result["context_dimensions"]["scope"] == "work"
+    assert result["context_dimensions"]["sphere_memberships"] == ["team"]
+    assert result["context_dimensions"]["situated_identity"] == "maker"
+
+
+def test_serialize_outbox_record_omits_context_dimensions_via_event_coercion() -> None:
+    """Event without context_dimensions coerced through serialize_outbox_record must not emit the key."""
+    event = new_event(event_type=INGEST_OBJECT_CREATED, payload={"uuid": "abc"})
+
+    result = serialize_outbox_record(event)
+
+    assert result is not None
+    assert "context_dimensions" not in result, (
+        f"context_dimensions must be omitted when None (coercion path), got: {result.get('context_dimensions')!r}"
+    )
+
+
+def test_append_jsonl_outbox_event_omits_context_dimensions_when_absent(tmp_path) -> None:
+    """JSONL audit path must also omit context_dimensions when absent."""
+    event = new_event(event_type=INGEST_OBJECT_CREATED, payload={"uuid": "abc"})
+    outbox_path = tmp_path / "outbox.jsonl"
+
+    assert append_jsonl_outbox_event(outbox_path, event) is True
+
+    records = [json.loads(line) for line in outbox_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert len(records) == 1
+    assert "context_dimensions" not in records[0], (
+        f"JSONL record must not include context_dimensions when absent, got: {records[0].get('context_dimensions')!r}"
+    )


### PR DESCRIPTION
## Summary

- `serialize_outbox_record()` was calling `model_dump(mode="json")` without `exclude_none=True`, causing `"context_dimensions": null` to be emitted when the field was absent
- This violated the SSI-01/SSI-03 omission contract documented in `docs/EVENTS.md`: consumers implementing the object-or-absent contract can reject or mishandle these records
- Fix adds `exclude_none=True` to both `model_dump` call sites in `serialize_outbox_record()` (direct model branch + coercion fallback), covering both the DB outbox and JSONL audit paths

## Changes

- [`app/services/outbox.py`](app/services/outbox.py): add `exclude_none=True` to both `model_dump` calls in `serialize_outbox_record()`
- [`tests/test_outbox_contract.py`](tests/test_outbox_contract.py): 4 new targeted tests for null-omission behavior across all code paths

## Test plan

- [x] `test_serialize_outbox_record_omits_context_dimensions_when_absent` — direct OutboxEvent path
- [x] `test_serialize_outbox_record_includes_context_dimensions_when_present` — populated block still included
- [x] `test_serialize_outbox_record_omits_context_dimensions_via_event_coercion` — Event coercion path
- [x] `test_append_jsonl_outbox_event_omits_context_dimensions_when_absent` — JSONL audit path
- [x] All 8 tests in `tests/test_outbox_contract.py` pass (4 pre-existing + 4 new)

**Dispatcher note:** Dispatcher unavailable (`yaml` module missing) — used GitHub-label-only claim.

Fixes #756

🤖 Generated with [Claude Code](https://claude.com/claude-code)