### PR TITLE
governance: enforce workspace isolation preflight and safe cleanup

### DIFF
--- a/.codex/skills/issue-to-code/SKILL.md
+++ b/.codex/skills/issue-to-code/SKILL.md
@@ -253,26 +253,29 @@ When continuing through anchor drift:
 ## Implementation workflow
 
 1. Select the Issue according to priority and readiness rules.
-2. Run delivered-state preflight before claim when target implementation paths are explicit:
+2. Run workspace isolation preflight before claim:
+   - `scripts/agent_workspace_preflight.sh --expected-branch "$(git branch --show-current)" --expected-worktree "$(git rev-parse --show-toplevel)"`
+   - If preflight fails, stop and resolve branch/worktree collisions before claiming.
+3. Run delivered-state preflight before claim when target implementation paths are explicit:
    - Verify whether referenced target modules already exist in the repo.
    - If core implementation already exists, do not proceed as fresh implementation; route to `issue-maintenance-change-control` to correct stale or drifted contract state.
    - Treat passing acceptance tests as supporting evidence, not the sole gate for delivered classification.
    - If source specs still say "Not yet implemented" while shipped code exists, route the spec-state writeback through docs/governance repair rather than opening duplicate implementation work.
-3. **Execute Action: Begin Implementation Work** (update labels, Issue Project Status, verify).
-4. Restate the bounded outcome from the Issue.
-5. Read source-anchored docs and owning code paths.
-6. If anchor drift exists, resolve it using the rules above before coding.
-7. **Verify acceptance verifiability**: every Acceptance Criterion must carry a resolvable `Verify:` target. If any AC lacks one, stop implementation and route through `issue-maintenance-change-control` to repair the contract before coding.
-8. **Test-first for behavioral ACs**: for each AC whose `Verify:` names a test, ensure that test exists in the repo and currently fails against the unchanged code path. If the test is missing, write it first from the AC; if it is present but does not fail, either the AC is already satisfied (stop and validate) or the test does not actually exercise the AC (fix the test).
-9. Implement the smallest complete change that turns every behavioral `Verify:` test green without breaking unrelated tests.
-10. **Writeback for non-behavioral ACs**: perform each non-behavioral `Verify:` target in the same change (doc anchor writeback, roadmap wording cleanup, runtime receipt, etc.).
-11. Update owner docs if shipped behavior/contracts changed.
-12. Rewrite roadmap/plan wording if the delivered work was previously listed as pending.
-13. Run `Suggested Validation` plus any obviously necessary focused checks. Confirm every AC's `Verify:` target now resolves green.
-14. Run `.codex/skills/publish-pr/SKILL.md` to create or update the implementation PR linked to the governing Issue unless a concrete blocker or explicit user instruction prevents it.
-15. Run `.codex/skills/pr-integration/SKILL.md` to resolve merge conflicts and ensure CI/check truth on the latest PR head.
-16. **Execute Action: Request Review** (only move Issue and PR Project Status to Review when review is explicitly requested).
-17. If the slice merges but the parent feature still needs validation, keep that parent issue open for the later acceptance step.
+4. **Execute Action: Begin Implementation Work** (update labels, Issue Project Status, verify).
+5. Restate the bounded outcome from the Issue.
+6. Read source-anchored docs and owning code paths.
+7. If anchor drift exists, resolve it using the rules above before coding.
+8. **Verify acceptance verifiability**: every Acceptance Criterion must carry a resolvable `Verify:` target. If any AC lacks one, stop implementation and route through `issue-maintenance-change-control` to repair the contract before coding.
+9. **Test-first for behavioral ACs**: for each AC whose `Verify:` names a test, ensure that test exists in the repo and currently fails against the unchanged code path. If the test is missing, write it first from the AC; if it is present but does not fail, either the AC is already satisfied (stop and validate) or the test does not actually exercise the AC (fix the test).
+10. Implement the smallest complete change that turns every behavioral `Verify:` test green without breaking unrelated tests.
+11. **Writeback for non-behavioral ACs**: perform each non-behavioral `Verify:` target in the same change (doc anchor writeback, roadmap wording cleanup, runtime receipt, etc.).
+12. Update owner docs if shipped behavior/contracts changed.
+13. Rewrite roadmap/plan wording if the delivered work was previously listed as pending.
+14. Run `Suggested Validation` plus any obviously necessary focused checks. Confirm every AC's `Verify:` target now resolves green.
+15. Run `.codex/skills/publish-pr/SKILL.md` to create or update the implementation PR linked to the governing Issue unless a concrete blocker or explicit user instruction prevents it.
+16. Run `.codex/skills/pr-integration/SKILL.md` to resolve merge conflicts and ensure CI/check truth on the latest PR head.
+17. **Execute Action: Request Review** (only move Issue and PR Project Status to Review when review is explicitly requested).
+18. If the slice merges but the parent feature still needs validation, keep that parent issue open for the later acceptance step.
 
 ## PR handoff requirements
 

--- a/.codex/skills/pr-integration/SKILL.md
+++ b/.codex/skills/pr-integration/SKILL.md
@@ -52,6 +52,18 @@ If any exit condition is not met, do not hand off. Loop or block.
 
 ## Required gates (all executable)
 
+### 0) Workspace Isolation Gate
+
+**Action: enforce clean single-session workspace before integration**
+
+```bash
+scripts/agent_workspace_preflight.sh \
+  --expected-branch "$(git branch --show-current)" \
+  --expected-worktree "$(git rev-parse --show-toplevel)"
+```
+
+If this gate fails, stop immediately. Resolve concurrent-session drift before continuing.
+
 ### 1) Contract and Metadata Gate
 
 **Action: Verify PR Contract**

--- a/.github/workflows/issue-pr-governance.yml
+++ b/.github/workflows/issue-pr-governance.yml
@@ -122,6 +122,8 @@ jobs:
               "Makefile",
               "scripts/docs_guard.py",
               "scripts/install_skills.sh",
+              "scripts/agent_workspace_preflight.sh",
+              "scripts/agent_workspace_cleanup.sh",
               "scripts/reconcile_project_status.py",
               "scripts/validate_source_anchors.py",
               "tests/architecture/test_agent_skill_entrypoints.py",

--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -160,6 +160,7 @@ State model for lane-based delivery:
 - Open PR is the default publication mode. Draft PR is opt-in and requires an explicit reason.
 - `Review` is the agent-review gate before verification, not a generic waiting state.
 - `pr-integration` is conditional and should be used when mergeability/CI attachment/reviewability needs repair; it is not required after every publication.
+- Workspace isolation is mandatory for multi-agent work: one active Codex session per worktree/branch checkout.
 - Prefer automation for PR/project-item projection (especially `Done` on terminal PR state) and use manual skill writes as fallback correction when drift is detected.
 
 Execution rule:
@@ -214,6 +215,16 @@ Enforcement surfaces:
 - Creation: `docs-to-issue`, `feature-breakdown`, and `bug-to-issue` must produce ACs with `Verify:` lines.
 - Repair: `issue-maintenance-change-control` treats missing `Verify:` as malformed contract shape.
 - Consumption: `issue-to-code` gates on `Verify:` presence and implements test-first for behavioral ACs, writeback-first for non-behavioral ACs.
+
+## Multi-Agent Workspace Guardrails
+
+- Preflight before claim/integration:
+  - `scripts/agent_workspace_preflight.sh --expected-branch "$(git branch --show-current)" --expected-worktree "$(git rev-parse --show-toplevel)"`
+- Safe cleanup report:
+  - `scripts/agent_workspace_cleanup.sh --report`
+- Safe cleanup apply (clean tree required):
+  - `scripts/agent_workspace_cleanup.sh --apply`
+- Cleanup apply only removes merged `codex/` branches/worktrees and old `preserve-local-drift` stashes; it skips the current checkout.
 - Closure: `verification-and-closure` resolves every AC's `Verify:` target and blocks merge if any behavioral test is missing, skipped, or xfailed.
 
 The builder-agent effect: test-first discipline emerges automatically for behavioral work — the failing test is the AC's declared proof, so the agent writes or confirms it before code, then implements the smallest change to turn it green.

--- a/scripts/agent_workspace_cleanup.sh
+++ b/scripts/agent_workspace_cleanup.sh
@@ -52,7 +52,7 @@ CURRENT_TOP="$(git rev-parse --show-toplevel)"
 # 1) Prune stale worktree metadata.
 git worktree prune
 
-# 2) Remove local worktrees whose branch is already merged to origin/main.
+# 2) Remove only codex-owned local worktrees whose branch is already merged to origin/main.
 #    Never remove current worktree.
 while IFS= read -r wt; do
   [[ -z "$wt" ]] && continue
@@ -60,10 +60,15 @@ while IFS= read -r wt; do
   WT_BRANCH="$(awk '{print $2}' <<<"$wt")"
   [[ "$WT_PATH" == "$CURRENT_TOP" ]] && continue
   [[ "$WT_BRANCH" == "$CURRENT_BRANCH" ]] && continue
+  [[ "$WT_BRANCH" != codex/* ]] && continue
 
   if git show-ref --verify --quiet "refs/heads/$WT_BRANCH"; then
     if git merge-base --is-ancestor "$WT_BRANCH" origin/main; then
-      git worktree remove "$WT_PATH" --force || true
+      if [[ -n "$(git -C "$WT_PATH" status --porcelain 2>/dev/null || true)" ]]; then
+        echo "Skipping dirty worktree: $WT_PATH ($WT_BRANCH)"
+        continue
+      fi
+      git worktree remove "$WT_PATH" || true
       git branch -d "$WT_BRANCH" || true
     fi
   fi

--- a/scripts/agent_workspace_cleanup.sh
+++ b/scripts/agent_workspace_cleanup.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Safe cleanup helper for multi-agent worktree workflows.
+# Default: report-only. Use --apply to execute safe cleanup actions.
+
+MODE="report"
+STALE_DAYS=14
+CWD="$(pwd)"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply)
+      MODE="apply"
+      shift
+      ;;
+    --report)
+      MODE="report"
+      shift
+      ;;
+    --stale-days)
+      STALE_DAYS="$2"
+      shift 2
+      ;;
+    --cwd)
+      CWD="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+cd "$CWD"
+
+if [[ "$MODE" == "report" ]]; then
+  python3 scripts/git_hygiene_janitor.py --cwd "$CWD" --stale-after-days "$STALE_DAYS"
+  exit 0
+fi
+
+# Apply mode: require clean tree in the current checkout.
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Refusing cleanup: current worktree is dirty." >&2
+  exit 1
+fi
+
+CURRENT_BRANCH="$(git branch --show-current)"
+CURRENT_TOP="$(git rev-parse --show-toplevel)"
+
+# 1) Prune stale worktree metadata.
+git worktree prune
+
+# 2) Remove local worktrees whose branch is already merged to origin/main.
+#    Never remove current worktree.
+while IFS= read -r wt; do
+  [[ -z "$wt" ]] && continue
+  WT_PATH="$(awk '{print $1}' <<<"$wt")"
+  WT_BRANCH="$(awk '{print $2}' <<<"$wt")"
+  [[ "$WT_PATH" == "$CURRENT_TOP" ]] && continue
+  [[ "$WT_BRANCH" == "$CURRENT_BRANCH" ]] && continue
+
+  if git show-ref --verify --quiet "refs/heads/$WT_BRANCH"; then
+    if git merge-base --is-ancestor "$WT_BRANCH" origin/main; then
+      git worktree remove "$WT_PATH" --force || true
+      git branch -d "$WT_BRANCH" || true
+    fi
+  fi
+done < <(git worktree list --porcelain | awk '
+  /^worktree / {path=$2}
+  /^branch / {sub("refs/heads/", "", $2); print path " " $2}
+')
+
+# 3) Delete merged local codex/ branches not checked out anywhere.
+while IFS= read -r branch; do
+  [[ -z "$branch" ]] && continue
+  [[ "$branch" == "$CURRENT_BRANCH" ]] && continue
+  if git merge-base --is-ancestor "$branch" origin/main; then
+    git branch -d "$branch" || true
+  fi
+done < <(git for-each-ref --format='%(refname:short)' refs/heads/codex/)
+
+# 4) Drop old stash entries created for integration drift isolation.
+#    Only drops entries older than STALE_DAYS containing preserve-local-drift.
+CUTOFF_EPOCH="$(( $(date +%s) - STALE_DAYS*24*60*60 ))"
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  REF="$(cut -d: -f1 <<<"$line")"
+  EPOCH="$(grep -Eo '[0-9]{10}' <<<"$line" | head -n1 || true)"
+  if [[ -n "$EPOCH" && "$EPOCH" -lt "$CUTOFF_EPOCH" ]]; then
+    if grep -q "preserve-local-drift" <<<"$line"; then
+      git stash drop "$REF" || true
+    fi
+  fi
+done < <(git stash list --date=unix)
+
+echo "Cleanup apply complete."

--- a/scripts/agent_workspace_preflight.sh
+++ b/scripts/agent_workspace_preflight.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CWD="$(pwd)"
+EXPECTED_BRANCH=""
+EXPECTED_WORKTREE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cwd)
+      CWD="$2"
+      shift 2
+      ;;
+    --expected-branch)
+      EXPECTED_BRANCH="$2"
+      shift 2
+      ;;
+    --expected-worktree)
+      EXPECTED_WORKTREE="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+cd "$CWD"
+
+ARGS=(--cwd "$CWD")
+if [[ -n "$EXPECTED_BRANCH" ]]; then
+  ARGS+=(--expected-branch "$EXPECTED_BRANCH")
+fi
+if [[ -n "$EXPECTED_WORKTREE" ]]; then
+  ARGS+=(--expected-worktree "$EXPECTED_WORKTREE")
+fi
+
+python3 scripts/git_hygiene_preflight.py "${ARGS[@]}"


### PR DESCRIPTION
- [x] Governance lane

## Summary
- require workspace isolation preflight in issue-to-code and pr-integration
- add scripts/agent_workspace_preflight.sh wrapper for consistent preflight invocation
- add scripts/agent_workspace_cleanup.sh with report/apply modes for safe post-work cleanup
- document multi-agent guardrails and cleanup commands in docs/development/DEV_WORKFLOW.md

## Validation
- bash -n scripts/agent_workspace_preflight.sh scripts/agent_workspace_cleanup.sh (pass)
- scripts/agent_workspace_cleanup.sh --report --stale-days 7 (pass)

## Notes
- cleanup --apply requires a clean working tree and only removes merged codex/ branches/worktrees plus old preserve-local-drift stashes.
