### PR TITLE
Speed up smoke tests with safe parallel execution

### DIFF
--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -104,7 +104,7 @@ jobs:
         if: github.event_name != 'pull_request' || steps.changes.outputs.heavy_smoke == 'true'
         timeout-minutes: 12
         run: |
-          pytest -c /dev/null -m "not pg and not alpha_llm" \
+          pytest -p xdist.plugin -c /dev/null -m "not pg and not alpha_llm" \
             tests/smoke \
             tests/agents/test_indexer.py::test_indexer_builds_embeddings_and_fts \
             tests/watcher/test_fs_watcher.py \
@@ -121,7 +121,7 @@ jobs:
         if: github.event_name != 'pull_request' || steps.changes.outputs.heavy_smoke == 'true'
         timeout-minutes: 8
         run: |
-          pytest -c /dev/null -m "not pg and not alpha_llm" \
+          pytest -p xdist.plugin -c /dev/null -m "not pg and not alpha_llm" \
             tests/quality_wave/test_uat_harness.py \
             --maxfail=1 -ra --durations=20 -n auto --dist=loadfile
 

--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -48,6 +48,7 @@ jobs:
           python -m pip install -U pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f pyproject.toml ]; then pip install -e ".[dev]"; fi
+          pip install pytest-xdist
 
       - name: Validate docs guardrails
         shell: bash

--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -114,7 +114,7 @@ jobs:
             tests/ports/test_vault_port_contract.py \
             tests/services/test_filesystem_vault_adapter.py \
             tests/services/test_vault_sync_lifecycle.py \
-            --maxfail=1 -ra --durations=20
+            --maxfail=1 -ra --durations=20 -n auto --dist=loadfile
 
       - name: Pytest Quality Wave smoke (memory, fail-fast)
         if: github.event_name != 'pull_request' || steps.changes.outputs.heavy_smoke == 'true'
@@ -122,7 +122,7 @@ jobs:
         run: |
           pytest -c /dev/null -m "not pg and not alpha_llm" \
             tests/quality_wave/test_uat_harness.py \
-            --maxfail=1 -ra --durations=20
+            --maxfail=1 -ra --durations=20 -n auto --dist=loadfile
 
       - name: Skip heavy pytest smoke for docs-only PR
         if: github.event_name == 'pull_request' && steps.changes.outputs.heavy_smoke != 'true'

--- a/Makefile
+++ b/Makefile
@@ -59,18 +59,18 @@ persist-runtime-repairs:
 
 smoke:
 	@XDIST_ARGS=""; \
-	if $(PYTHON) -m pytest --help 2>/dev/null | rg -q -- "^-n "; then \
+	if $(PYTHON) -m pytest -p xdist.plugin --help 2>/dev/null | rg -q -- "^-n "; then \
 		XDIST_ARGS="-n $(SMOKE_WORKERS) --dist=loadfile"; \
 	fi; \
 	PYTHONPATH="$(PWD)" PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 STORE_BACKEND=memory \
-	$(PYTHON) -m pytest -q -c /dev/null -k "not slow and not e2e" $$XDIST_ARGS
+	$(PYTHON) -m pytest -p xdist.plugin -q -c /dev/null -k "not slow and not e2e" $$XDIST_ARGS
 	@if [ "$(SMOKE_E2E_WORKERS)" != "0" ]; then \
 		XDIST_E2E_ARGS=""; \
-		if $(PYTHON) -m pytest --help 2>/dev/null | rg -q -- "^-n "; then \
+		if $(PYTHON) -m pytest -p xdist.plugin --help 2>/dev/null | rg -q -- "^-n "; then \
 			XDIST_E2E_ARGS="-n $(SMOKE_E2E_WORKERS) --dist=loadfile"; \
 		fi; \
 		PYTHONPATH="$(PWD)" PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 STORE_BACKEND=memory \
-		$(PYTHON) -m pytest -q -c /dev/null -k "e2e and not slow" $$XDIST_E2E_ARGS ; \
+		$(PYTHON) -m pytest -p xdist.plugin -q -c /dev/null -k "e2e and not slow" $$XDIST_E2E_ARGS ; \
 	fi
 
 test-vault-init:

--- a/Makefile
+++ b/Makefile
@@ -58,11 +58,19 @@ persist-runtime-repairs:
 	@bash scripts/persist_runtime_repairs.sh
 
 smoke:
+	@XDIST_ARGS=""; \
+	if $(PYTHON) -m pytest --help 2>/dev/null | rg -q -- "^-n "; then \
+		XDIST_ARGS="-n $(SMOKE_WORKERS) --dist=loadfile"; \
+	fi; \
 	PYTHONPATH="$(PWD)" PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 STORE_BACKEND=memory \
-	$(PYTHON) -m pytest -q -c /dev/null -k "not slow and not e2e" -n $(SMOKE_WORKERS) --dist=loadfile
+	$(PYTHON) -m pytest -q -c /dev/null -k "not slow and not e2e" $$XDIST_ARGS
 	@if [ "$(SMOKE_E2E_WORKERS)" != "0" ]; then \
+		XDIST_E2E_ARGS=""; \
+		if $(PYTHON) -m pytest --help 2>/dev/null | rg -q -- "^-n "; then \
+			XDIST_E2E_ARGS="-n $(SMOKE_E2E_WORKERS) --dist=loadfile"; \
+		fi; \
 		PYTHONPATH="$(PWD)" PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 STORE_BACKEND=memory \
-		$(PYTHON) -m pytest -q -c /dev/null -k "e2e and not slow" -n $(SMOKE_E2E_WORKERS) --dist=loadfile ; \
+		$(PYTHON) -m pytest -q -c /dev/null -k "e2e and not slow" $$XDIST_E2E_ARGS ; \
 	fi
 
 test-vault-init:

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 PYTHON ?= $(shell if [ -x .venv/bin/python ]; then printf '%s' .venv/bin/python; elif command -v python3.12 >/dev/null 2>&1; then command -v python3.12; elif command -v python3 >/dev/null 2>&1; then command -v python3; elif command -v python >/dev/null 2>&1; then command -v python; fi)
 TEST_VAULT_ROOT ?= $(PWD)/vault-test
 TEST_DATABASE_URL ?= postgresql+psycopg://app:app@db:5432/app_test
+SMOKE_WORKERS ?= auto
+SMOKE_E2E_WORKERS ?= 0
 COMPOSE_BASE := docker compose -f docker-compose.yaml
 COMPOSE_DEV := $(COMPOSE_BASE) -f docker-compose.dev.yml -p pkm-dev
 COMPOSE_TEST := $(COMPOSE_BASE) -f docker-compose.test.yml -p pkm-test
@@ -57,7 +59,11 @@ persist-runtime-repairs:
 
 smoke:
 	PYTHONPATH="$(PWD)" PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 STORE_BACKEND=memory \
-	$(PYTHON) -m pytest -q -c /dev/null -k "not slow"
+	$(PYTHON) -m pytest -q -c /dev/null -k "not slow and not e2e" -n $(SMOKE_WORKERS) --dist=loadfile
+	@if [ "$(SMOKE_E2E_WORKERS)" != "0" ]; then \
+		PYTHONPATH="$(PWD)" PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 STORE_BACKEND=memory \
+		$(PYTHON) -m pytest -q -c /dev/null -k "e2e and not slow" -n $(SMOKE_E2E_WORKERS) --dist=loadfile ; \
+	fi
 
 test-vault-init:
 	@PYTHON="$(PYTHON)" bash scripts/init_test_vault.sh

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -232,6 +232,7 @@ First-green definition:
 
 For fast local runs that bypass workspace/global pytest configuration, prefer:
 - `STORE_BACKEND=memory PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg" -c /dev/null`
+- `make smoke` (parallel by default via `pytest-xdist`; override workers with `SMOKE_WORKERS=<n|auto>`, and include e2e lane with `SMOKE_E2E_WORKERS=<n>`)
 
 ## Concurrency Tests (docs-only)
 These regression suites live in `docs/CONCURRENCY.md` and the new watcher/promotion/test libraries.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0",
+    "pytest-xdist>=3.6",
     "ruff>=0.5",
     "mypy>=1.9",
     "deepeval>=0.20.60",


### PR DESCRIPTION
Fixes #783

## Summary
- add `pytest-xdist` to dev dependencies
- run `make smoke` in parallel by default for non-e2e smoke (`-n <workers> --dist=loadfile`)
- keep e2e in an optional separate smoke lane via `SMOKE_E2E_WORKERS`
- enable xdist parallelism in CI smoke pytest steps
- document the new smoke worker knobs in testing docs

## Validation
- `git diff` review of all changed files
- runtime validation not executed in this shell (no local pytest module in available interpreter)
