### PR TITLE
Fix code injection risk in issue source-anchor workflow

### DIFF
--- a/.github/workflows/issue-pr-governance.yml
+++ b/.github/workflows/issue-pr-governance.yml
@@ -67,11 +67,13 @@ jobs:
   issue-source-anchors:
     if: github.event_name == 'issues' && (contains(github.event.issue.labels.*.name, 'agent:ready') || contains(github.event.issue.labels.*.name, 'agent:blocked'))
     runs-on: ubuntu-latest
+    env:
+      BODY: ${{ github.event.issue.body }}
     steps:
       - uses: actions/checkout@v4
       - name: Validate Source Anchors
         run: |
-          python3 scripts/validate_source_anchors.py "${{ github.event.issue.body }}"
+          python3 scripts/validate_source_anchors.py "$BODY"
 
   pr-contract:
     if: github.event_name == 'pull_request'

--- a/scripts/validate_source_anchors.py
+++ b/scripts/validate_source_anchors.py
@@ -4,11 +4,13 @@ Validate that GitHub Issues have a Source Anchors section with valid references.
 
 Usage:
   python3 scripts/validate_source_anchors.py "issue body text"
+  BODY="issue body text" python3 scripts/validate_source_anchors.py
   python3 scripts/validate_source_anchors.py < issue_body.txt
 
 Exits with code 0 if valid, 1 if invalid.
 """
 
+import os
 import re
 import sys
 from pathlib import Path
@@ -128,11 +130,13 @@ def validate_issue_body(body: str) -> Tuple[bool, List[str]]:
 
 
 def main():
-    # Read input from arguments or stdin
+    # Read input from args, then env var (for workflow-safe injection), then stdin.
     if len(sys.argv) > 1:
         body = sys.argv[1]
     else:
-        body = sys.stdin.read()
+        body = os.getenv("BODY", "")
+        if not body:
+            body = sys.stdin.read()
 
     if not body.strip():
         print("Error: No issue body provided")


### PR DESCRIPTION
Fixes #767

## Summary
- move issue body handoff into a job-level `env` binding (`BODY`)
- pass `BODY` into `validate_source_anchors.py` using shell-safe quoting
- allow validator to read issue body from `BODY` env var when argv is absent

## Validation
- `BODY=... python3 scripts/validate_source_anchors.py`
- `python3 scripts/validate_source_anchors.py ...`