### PR TITLE
governance: enforce preflight at issue pickup claim

### DIFF
--- a/.codex/skills/issue-to-code/SKILL.md
+++ b/.codex/skills/issue-to-code/SKILL.md
@@ -101,7 +101,7 @@ python -m app.dispatcher status --json
 
 1. **Get next task:** `python -m app.dispatcher next --json --agent <agent_id>` — returns a candidate task.
 2. **Claim with dispatcher:** `python -m app.dispatcher claim <task_id> --agent <agent_id> --ttl-minutes 90 --json` — acquire 90-minute lease.
-3. **Confirm in GitHub:** `gh issue edit #<ISSUE_NUMBER> --remove-label agent:ready` — confirmation step (unchanged current behaviour).
+3. **Confirm in GitHub (mandatory preflight gate):** `scripts/issue_pickup_claim.sh --issue <ISSUE_NUMBER>` — this command runs workspace preflight and only then removes `agent:ready`.
 4. **Mid-work heartbeat** (~every 30 min of active execution): `python -m app.dispatcher heartbeat <task_id> --agent <agent_id> --json` — renew lease before 90-min expiry.
 5. **On closure:** `python -m app.dispatcher complete <task_id> --agent <agent_id> --json` (successful) or `python -m app.dispatcher release <task_id> --agent <agent_id> --json` (abandoned).
 6. **Fallback on dispatcher failure:** If any dispatcher command fails (non-zero exit) during work, log the failure and continue with local work (do not retry dispatcher commands in a loop). At closure, attempt `dispatcher complete`; if it fails, continue with PR closure via GitHub.
@@ -118,9 +118,9 @@ python -m app.dispatcher status --json
    gh api graphql -f query='query { repository(owner:"OWNER", name:"REPO") { issue(number:N) { projectItems(first:1) { nodes { id } } } } }'
    ```
 
-2. **Fast-claim the Issue by removing `agent:ready`:**
+2. **Fast-claim the Issue via mandatory preflight wrapper:**
    ```bash
-   gh issue edit #<N> --remove-label agent:ready
+   scripts/issue_pickup_claim.sh --issue <N>
    ```
 
 3. **Set Issue Project Status to In Progress:**
@@ -253,8 +253,9 @@ When continuing through anchor drift:
 ## Implementation workflow
 
 1. Select the Issue according to priority and readiness rules.
-2. Run workspace isolation preflight before claim:
-   - `scripts/agent_workspace_preflight.sh --expected-branch "$(git branch --show-current)" --expected-worktree "$(git rev-parse --show-toplevel)"`
+2. Run mandatory pickup claim wrapper before any lifecycle mutation:
+   - `scripts/issue_pickup_claim.sh --issue <N>`
+   - This wrapper enforces workspace isolation preflight before removing `agent:ready`.
    - If preflight fails, stop and resolve branch/worktree collisions before claiming.
 3. Run delivered-state preflight before claim when target implementation paths are explicit:
    - Verify whether referenced target modules already exist in the repo.

--- a/.codex/skills/issue-to-code/SKILL.md
+++ b/.codex/skills/issue-to-code/SKILL.md
@@ -100,11 +100,13 @@ python -m app.dispatcher status --json
 **If dispatcher is available (db_exists: true):**
 
 1. **Get next task:** `python -m app.dispatcher next --json --agent <agent_id>` — returns a candidate task.
-2. **Claim with dispatcher:** `python -m app.dispatcher claim <task_id> --agent <agent_id> --ttl-minutes 90 --json` — acquire 90-minute lease.
-3. **Confirm in GitHub (mandatory preflight gate):** `scripts/issue_pickup_claim.sh --issue <ISSUE_NUMBER>` — this command runs workspace preflight and only then removes `agent:ready`.
-4. **Mid-work heartbeat** (~every 30 min of active execution): `python -m app.dispatcher heartbeat <task_id> --agent <agent_id> --json` — renew lease before 90-min expiry.
-5. **On closure:** `python -m app.dispatcher complete <task_id> --agent <agent_id> --json` (successful) or `python -m app.dispatcher release <task_id> --agent <agent_id> --json` (abandoned).
-6. **Fallback on dispatcher failure:** If any dispatcher command fails (non-zero exit) during work, log the failure and continue with local work (do not retry dispatcher commands in a loop). At closure, attempt `dispatcher complete`; if it fails, continue with PR closure via GitHub.
+2. **Run pickup preflight before lease acquisition:** `scripts/issue_pickup_claim.sh --issue <ISSUE_NUMBER> --preflight-only`
+3. **Claim with dispatcher:** `python -m app.dispatcher claim <task_id> --agent <agent_id> --ttl-minutes 90 --json` — acquire 90-minute lease.
+4. **Confirm in GitHub (label mutation after successful preflight):** `scripts/issue_pickup_claim.sh --issue <ISSUE_NUMBER> --skip-preflight`
+5. **If step 4 fails, immediately release lease:** `python -m app.dispatcher release <task_id> --agent <agent_id> --json`
+6. **Mid-work heartbeat** (~every 30 min of active execution): `python -m app.dispatcher heartbeat <task_id> --agent <agent_id> --json` — renew lease before 90-min expiry.
+7. **On closure:** `python -m app.dispatcher complete <task_id> --agent <agent_id> --json` (successful) or `python -m app.dispatcher release <task_id> --agent <agent_id> --json` (abandoned).
+8. **Fallback on dispatcher failure:** If any dispatcher command fails (non-zero exit) during work, log the failure and continue with local work (do not retry dispatcher commands in a loop). At closure, attempt `dispatcher complete`; if it fails, continue with PR closure via GitHub.
 
 **If dispatcher is unavailable (db_exists: false or dispatcher status fails):**
 

--- a/.github/workflows/issue-pr-governance.yml
+++ b/.github/workflows/issue-pr-governance.yml
@@ -126,6 +126,7 @@ jobs:
               "scripts/install_skills.sh",
               "scripts/agent_workspace_preflight.sh",
               "scripts/agent_workspace_cleanup.sh",
+              "scripts/issue_pickup_claim.sh",
               "scripts/reconcile_project_status.py",
               "scripts/validate_source_anchors.py",
               "tests/architecture/test_agent_skill_entrypoints.py",

--- a/.github/workflows/issue-pr-governance.yml
+++ b/.github/workflows/issue-pr-governance.yml
@@ -67,11 +67,13 @@ jobs:
   issue-source-anchors:
     if: github.event_name == 'issues' && (contains(github.event.issue.labels.*.name, 'agent:ready') || contains(github.event.issue.labels.*.name, 'agent:blocked'))
     runs-on: ubuntu-latest
+    env:
+      BODY: ${{ github.event.issue.body }}
     steps:
       - uses: actions/checkout@v4
       - name: Validate Source Anchors
         run: |
-          python3 scripts/validate_source_anchors.py "${{ github.event.issue.body }}"
+          python3 scripts/validate_source_anchors.py "$BODY"
 
   pr-contract:
     if: github.event_name == 'pull_request'

--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -164,6 +164,7 @@ State model for lane-based delivery:
 - PR/Project-item state supports review/integration projection: `Review`, `In Progress`, `Blocked`, `Done`.
 - Keep issue and PR state separate in multi-slice lanes where several implementation issues can feed the same lane PR.
 - `issue-to-code` owns fast issue claim (`Ready` -> `In Progress` and remove `agent:ready`) to prevent double-pick.
+  - Claim must run through `scripts/issue_pickup_claim.sh --issue <N>` so workspace preflight is enforced before label mutation.
 - Open PR is the default publication mode. Draft PR is opt-in and requires an explicit reason.
 - `Review` is the agent-review gate before verification, not a generic waiting state.
 - `pr-integration` is conditional and should be used when mergeability/CI attachment/reviewability needs repair; it is not required after every publication.

--- a/scripts/issue_pickup_claim.sh
+++ b/scripts/issue_pickup_claim.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 ISSUE_NUMBER=""
 REPO=""
+PREFLIGHT_ONLY=0
+SKIP_PREFLIGHT=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -13,6 +15,14 @@ while [[ $# -gt 0 ]]; do
     --repo)
       REPO="$2"
       shift 2
+      ;;
+    --preflight-only)
+      PREFLIGHT_ONLY=1
+      shift
+      ;;
+    --skip-preflight)
+      SKIP_PREFLIGHT=1
+      shift
       ;;
     *)
       echo "Unknown arg: $1" >&2
@@ -29,9 +39,16 @@ fi
 EXPECTED_BRANCH="$(git branch --show-current)"
 EXPECTED_WORKTREE="$(git rev-parse --show-toplevel)"
 
-scripts/agent_workspace_preflight.sh \
-  --expected-branch "$EXPECTED_BRANCH" \
-  --expected-worktree "$EXPECTED_WORKTREE"
+if [[ "$SKIP_PREFLIGHT" -ne 1 ]]; then
+  scripts/agent_workspace_preflight.sh \
+    --expected-branch "$EXPECTED_BRANCH" \
+    --expected-worktree "$EXPECTED_WORKTREE"
+fi
+
+if [[ "$PREFLIGHT_ONLY" -eq 1 ]]; then
+  echo "pickup-preflight-complete issue=$ISSUE_NUMBER branch=$EXPECTED_BRANCH worktree=$EXPECTED_WORKTREE"
+  exit 0
+fi
 
 if [[ -n "$REPO" ]]; then
   gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --remove-label agent:ready

--- a/scripts/issue_pickup_claim.sh
+++ b/scripts/issue_pickup_claim.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ISSUE_NUMBER=""
+REPO=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --issue)
+      ISSUE_NUMBER="$2"
+      shift 2
+      ;;
+    --repo)
+      REPO="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$ISSUE_NUMBER" ]]; then
+  echo "--issue is required" >&2
+  exit 2
+fi
+
+EXPECTED_BRANCH="$(git branch --show-current)"
+EXPECTED_WORKTREE="$(git rev-parse --show-toplevel)"
+
+scripts/agent_workspace_preflight.sh \
+  --expected-branch "$EXPECTED_BRANCH" \
+  --expected-worktree "$EXPECTED_WORKTREE"
+
+if [[ -n "$REPO" ]]; then
+  gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --remove-label agent:ready
+else
+  gh issue edit "$ISSUE_NUMBER" --remove-label agent:ready
+fi
+
+echo "pickup-claim-complete issue=$ISSUE_NUMBER branch=$EXPECTED_BRANCH worktree=$EXPECTED_WORKTREE"

--- a/scripts/validate_source_anchors.py
+++ b/scripts/validate_source_anchors.py
@@ -4,11 +4,13 @@ Validate that GitHub Issues have a Source Anchors section with valid references.
 
 Usage:
   python3 scripts/validate_source_anchors.py "issue body text"
+  BODY="issue body text" python3 scripts/validate_source_anchors.py
   python3 scripts/validate_source_anchors.py < issue_body.txt
 
 Exits with code 0 if valid, 1 if invalid.
 """
 
+import os
 import re
 import sys
 from pathlib import Path
@@ -128,11 +130,13 @@ def validate_issue_body(body: str) -> Tuple[bool, List[str]]:
 
 
 def main():
-    # Read input from arguments or stdin
+    # Read input from args, then env var (for workflow-safe injection), then stdin.
     if len(sys.argv) > 1:
         body = sys.argv[1]
     else:
-        body = sys.stdin.read()
+        body = os.getenv("BODY", "")
+        if not body:
+            body = sys.stdin.read()
 
     if not body.strip():
         print("Error: No issue body provided")


### PR DESCRIPTION
- [x] Governance lane

## Summary
- add `scripts/issue_pickup_claim.sh` as mandatory claim wrapper
- run workspace preflight before any `agent:ready` label removal
- update `issue-to-code` and DEV workflow docs to require wrapper usage

## Validation
- `bash -n scripts/issue_pickup_claim.sh scripts/agent_workspace_preflight.sh`