### PR TITLE
fix: redact password query params in settings_explain DSN

### DIFF
--- a/app/cli/settings_explain.py
+++ b/app/cli/settings_explain.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 from typing import Any, Sequence
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from app.config.database import resolve_runtime_database_url
 from app.config.environment import active_environment
@@ -12,18 +13,33 @@ from app.settings.watcher_settings import invalid_allowed_actions, load_watcher_
 
 
 def mask_dsn(dsn: str) -> str:
-    if "@" not in dsn or "://" not in dsn:
+    if "://" not in dsn:
         return dsn
-    prefix, rest = dsn.split("://", 1)
-    if "@" not in rest:
-        return f"{prefix}://***@"
-    credentials, host_part = rest.split("@", 1)
-    if ":" in credentials:
-        user, _ = credentials.split(":", 1)
-        masked_credentials = f"{user}:***"
+    parsed = urlsplit(dsn)
+    netloc = parsed.netloc
+    query_pairs = parse_qsl(parsed.query, keep_blank_values=True)
+
+    if "@" in netloc:
+        credentials, host_part = netloc.rsplit("@", 1)
+        if ":" in credentials:
+            user, _ = credentials.split(":", 1)
+            masked_credentials = f"{user}:***"
+        else:
+            masked_credentials = "***"
+        netloc = f"{masked_credentials}@{host_part}"
+
+    if query_pairs:
+        masked_pairs: list[tuple[str, str]] = []
+        for key, value in query_pairs:
+            if "password" in key.lower() or key.lower() in {"pwd", "pass"}:
+                masked_pairs.append((key, "***"))
+            else:
+                masked_pairs.append((key, value))
+        query = urlencode(masked_pairs, doseq=True)
     else:
-        masked_credentials = "***"
-    return f"{prefix}://{masked_credentials}@{host_part}"
+        query = parsed.query
+
+    return urlunsplit((parsed.scheme, netloc, parsed.path, query, parsed.fragment))
 
 
 def build_settings_explain_payload() -> dict[str, Any]:

--- a/tests/cli/test_settings_explain_cli.py
+++ b/tests/cli/test_settings_explain_cli.py
@@ -106,3 +106,34 @@ def test_settings_explain_respects_explicit_database_override(monkeypatch, tmp_p
     assert payload["database_url"] == "postgresql+psycopg://custom:***@db:5432/custom_db"
     assert "pw" not in payload["database_url"]
     assert payload["database_url"].endswith("/custom_db")
+
+
+def test_settings_explain_masks_password_query_params(monkeypatch, tmp_path) -> None:
+    vault = tmp_path / "vault"
+    settings_dir = vault / "@Settings"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    (settings_dir / "watchers.md").write_text("---\n---\n", encoding="utf-8")
+    panel_actions = tmp_path / "panel-actions.md"
+    panel_actions.write_text(
+        "---\n"
+        "mappings:\n"
+        "  - id: promote.evergreen\n"
+        "    label: Promote\n"
+        "    intent_type: promotion\n"
+        "    downstream_event: promote.intent.created\n"
+        "    params:\n"
+        "      maturity: evergreen\n"
+        "---\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("VAULT_ROOT", str(vault))
+    monkeypatch.setenv("PANEL_ACTIONS_PATH", str(panel_actions))
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "postgresql+psycopg://db:5432/custom_db?user=custom&password=secret",
+    )
+
+    payload = build_settings_explain_payload()
+    assert payload["database_url"] == "postgresql+psycopg://db:5432/custom_db?user=custom&password=%2A%2A%2A"
+    assert "secret" not in payload["database_url"]


### PR DESCRIPTION
Fixes #772

## Summary
- redact password-like DSN query parameters (for example password, pass, pwd) in settings_explain output
- preserve existing masking for userinfo credentials and DSN structure
- add regression test covering query-param credential leakage case from Codex review

## Validation
- ./.venv/bin/pytest -q tests/cli/test_settings_explain_cli.py

## Dispatcher
- Claimed via dispatcher task github-issue-772 before implementation.
