### PR TITLE
Add ASK adapter state contract coverage

### DIFF
--- a/tests/agents/ask/test_agent_state_contract.py
+++ b/tests/agents/ask/test_agent_state_contract.py
@@ -1,0 +1,54 @@
+"""Adapter-internal ASK state contract tests.
+
+These tests lock the ASK adapter boundary only. They are not assertions about
+public `/api/ask` product contracts.
+"""
+
+from app.agents.ask.graph import _to_retrieved_hit
+from app.agents.ask.state import AgentState
+
+
+def test_agent_state_minimal_valid_shape_and_documented_fields() -> None:
+    """Validate the minimal adapter-internal AgentState shape and fields."""
+    state = AgentState(query="what is yggdrasil")
+
+    assert state.trace_id is None
+    assert state.query == "what is yggdrasil"
+    assert state.hits == []
+    assert state.answer is None
+    assert state.reasoning is None
+    assert state.llm_route is None
+
+
+def test_retrieved_hit_fields_and_trace_id_carry_through_behavior() -> None:
+    """Verify adapter-internal RetrievedHit mapping plus trace_id carry-through."""
+    raw_hit = {
+        "id": "doc-123",
+        "score": 0.72,
+        "source_ref": "docs/ARCHITECTURE.md",
+        "snippet": "Yggdrasil routes through ASK.",
+        "payload": {
+            "origin": "vault",
+            "trust": "high",
+            "title": "Architecture",
+            "source_ref": "docs/ARCHITECTURE.md",
+            "extra": "kept",
+        },
+    }
+
+    mapped = _to_retrieved_hit(raw_hit, ask_score=0.88)
+
+    assert mapped.object_id == "doc-123"
+    assert mapped.score == 0.72
+    assert mapped.ask_score == 0.88
+    assert mapped.origin == "vault"
+    assert mapped.zone is None
+    assert mapped.trust == "high"
+    assert mapped.title == "Architecture"
+    assert mapped.path == "docs/ARCHITECTURE.md"
+    assert mapped.snippet == "Yggdrasil routes through ASK."
+    assert mapped.payload["extra"] == "kept"
+
+    state = AgentState(trace_id="trace-ask-1", query="ask query", hits=[mapped])
+    assert state.trace_id == "trace-ask-1"
+    assert state.hits[0].object_id == "doc-123"


### PR DESCRIPTION
Fixes #776

## Summary
Add adapter-internal contract tests for ASK `AgentState` and `RetrievedHit`, including minimal valid state shape and explicit trace-id carry-through assertions.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/agents/ask/test_agent_state_contract.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/api/test_ask_contract.py tests/api/test_ask_api.py tests/api/test_ask_llm_answer.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/retrieval/test_retrieval_capability.py`
- `.venv/bin/ruff check app tests`