### PR TITLE
fix: reconcile indexer JSONL queue with DB-outbox canonical contract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,8 @@ alpha-e2e-smoke:
 ci-smoke: smoke
 
 indexer-run:
+	@echo "indexer-run no longer consumes INDEX_OUTBOX_PATH as a queue."
+	@echo "Use the DB outbox worker path instead: PYTHONPATH=\"$(PWD)\" $(PYTHON) -m app.workers.outbox_worker"
 	PYTHONPATH="$(PWD)" $(PYTHON) -m app.indexer.runner
 
 setup-merge-driver:

--- a/app/indexer/runner.py
+++ b/app/indexer/runner.py
@@ -1,73 +1,13 @@
 from __future__ import annotations
 
-import json
-from pathlib import Path
-from typing import List
-
-from app.components.concurrency import EventDedupStore, SystemClock
-from app.indexer.consumer import process_event
 from app.outbox import events as outbox_events
 
-_EVENT_DEDUP = EventDedupStore(SystemClock(), ttl_seconds=3600.0)
-
-
-def _load_events(path: Path) -> List[dict]:
-    if not path.exists():
-        return []
-
-    to_process: list[dict] = []
-    retained: list[dict] = []
-
-    with path.open("r", encoding="utf-8") as fh:
-        for line in fh:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                evt = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            if not isinstance(evt, dict):
-                continue
-
-            event_type = str(evt.get("event") or "").strip()
-            is_request = event_type == outbox_events.INDEX_EMBEDDING_REQUESTED
-            is_legacy_embedded = "embedding" in evt and "object_id" in evt
-
-            if is_request or is_legacy_embedded:
-                to_process.append(evt)
-            else:
-                retained.append(evt)
-
-    # Rewrite file with retained events only (acts as an append-only log for non-queue records).
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as fh:
-        for evt in retained:
-            fh.write(json.dumps(evt, ensure_ascii=False) + "\n")
-
-    return to_process
-
-
-def _event_id_from_record(evt: dict) -> str:
-    event_id = evt.get("event_id")
-    return str(event_id).strip() if event_id else ""
-
-
 def main() -> None:
-    path = outbox_events.INDEX_OUTBOX_PATH
-    events = _load_events(path)
-    if not events:
-        print("indexer: no events found")
-        return
-
-    processed = 0
-    for evt in events:
-        event_id = _event_id_from_record(evt)
-        if event_id and _EVENT_DEDUP.seen(event_id):
-            continue
-        process_event(evt)
-        processed += 1
-    print(f"indexer: processed {processed} events")
+    path = outbox_events.get_index_outbox_path()
+    print(
+        "indexer: JSONL queue consumption disabled; use DB outbox worker for "
+        f"{outbox_events.INDEX_EMBEDDING_REQUESTED} events (audit log at {path})"
+    )
 
 
 if __name__ == "__main__":

--- a/app/outbox/events.py
+++ b/app/outbox/events.py
@@ -106,12 +106,7 @@ def emit_index_embedding_requested(event: Dict[str, Any]) -> None:
     )
 
     record: Dict[str, Any] = dict(envelope.model_dump())
-    try:
-        write_outbox_event(envelope, idempotency_key=str(record.get("event_id") or ""))
-    except Exception:
-        # Compatibility fallback: keep audit emission even when DB outbox is unavailable
-        # (e.g. unit tests or local flows without Postgres).
-        pass
+    write_outbox_event(envelope, idempotency_key=str(record.get("event_id") or ""))
     _append_record(record)
 
 

--- a/app/outbox/events.py
+++ b/app/outbox/events.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Any, Dict
@@ -11,6 +12,8 @@ from app.events.schema import make_outbox_event
 from app.llm.embeddings import EMBED_MODEL
 from app.services.outbox import write_outbox_event
 from app.settings.watcher_settings import load_watcher_settings
+
+logger = logging.getLogger(__name__)
 
 def _try_writable_path(path: Path) -> bool:
     try:
@@ -88,6 +91,13 @@ def _append_record(record: Dict[str, Any]) -> None:
         fh.write(json.dumps(record, ensure_ascii=False) + "\n")
 
 
+def _append_record_best_effort(record: Dict[str, Any], *, event_name: str) -> None:
+    try:
+        _append_record(record)
+    except Exception:
+        logger.warning("outbox audit append failed event=%s path=%s", event_name, INDEX_OUTBOX_PATH, exc_info=True)
+
+
 def emit_index_embedding_requested(event: Dict[str, Any]) -> None:
     if "object_id" not in event:
         raise ValueError("index.embedding.requested missing field: object_id")
@@ -107,7 +117,7 @@ def emit_index_embedding_requested(event: Dict[str, Any]) -> None:
 
     record: Dict[str, Any] = dict(envelope.model_dump())
     write_outbox_event(envelope, idempotency_key=str(record.get("event_id") or ""))
-    _append_record(record)
+    _append_record_best_effort(record, event_name=INDEX_EMBEDDING_REQUESTED)
 
 
 def _build_index_record(
@@ -138,7 +148,7 @@ def emit_index_embedding_created(*, object_id: UUID, trace_id: str | None = None
     metrics = {"vectors": 1, "dim": get_embed_dim(), "view": DEFAULT_EMBEDDING_VIEW}
     provenance = {"model": EMBED_MODEL, "version": "1.0"}
     record = _build_index_record(envelope, object_id=str(object_id), metrics=metrics, provenance=provenance)
-    _append_record(record)
+    _append_record_best_effort(record, event_name=INDEX_EMBEDDING_CREATED)
 
 
 def emit_index_object_embedded(
@@ -171,7 +181,7 @@ def emit_index_object_embedded(
     )
     if source_ref is not None:
         record.setdefault("meta", {})["source_ref"] = source_ref
-    _append_record(record)
+    _append_record_best_effort(record, event_name=INDEX_OBJECT_EMBEDDED)
 
 
 def emit_index_embedding_failed(
@@ -209,7 +219,7 @@ def emit_index_embedding_failed(
         metrics={"vectors": 0, "dim": expected_dim if expected_dim is not None else actual_dim or get_embed_dim(), "view": DEFAULT_EMBEDDING_VIEW},
         provenance={"model": model or EMBED_MODEL, "provider": provider or "indexer"},
     )
-    _append_record(record)
+    _append_record_best_effort(record, event_name=INDEX_EMBEDDING_FAILED)
 
 
 __all__ = [

--- a/app/outbox/events.py
+++ b/app/outbox/events.py
@@ -9,6 +9,7 @@ from uuid import UUID
 from app.embedding_config import get_embed_dim
 from app.events.schema import make_outbox_event
 from app.llm.embeddings import EMBED_MODEL
+from app.services.outbox import write_outbox_event
 from app.settings.watcher_settings import load_watcher_settings
 
 def _try_writable_path(path: Path) -> bool:
@@ -105,6 +106,12 @@ def emit_index_embedding_requested(event: Dict[str, Any]) -> None:
     )
 
     record: Dict[str, Any] = dict(envelope.model_dump())
+    try:
+        write_outbox_event(envelope, idempotency_key=str(record.get("event_id") or ""))
+    except Exception:
+        # Compatibility fallback: keep audit emission even when DB outbox is unavailable
+        # (e.g. unit tests or local flows without Postgres).
+        pass
     _append_record(record)
 
 

--- a/app/workers/outbox_worker.py
+++ b/app/workers/outbox_worker.py
@@ -15,6 +15,8 @@ from app.agents.panel_agent.execution import refresh_panel_note_object, run_pane
 from app.components.concurrency import OptimisticWriteGuard, VersionMismatch
 from app.events.sync import SyncChainCorrelationData, SyncLatencySummaryEvent
 from app.events.types import INGEST_OBJECT_CREATED, INGEST_OBJECT_DELETED, INGEST_VAULT_CHANGED, PANEL_SCAN_REQUESTED, PROMOTE_INTENT_CREATED
+from app.indexer.consumer import process_event as process_indexer_event
+from app.outbox.events import INDEX_EMBEDDING_REQUESTED
 from app.observability.tracer import start_span
 from app.runtime.worker_heartbeat import resolve_worker_heartbeat_path, write_worker_heartbeat
 from app.services.indexer import handle_ingest_object_created
@@ -591,6 +593,14 @@ def run(
                                 payload,
                                 trace_id=trace_id,
                                 event_id=event_id,
+                            )
+                        elif topic == INDEX_EMBEDDING_REQUESTED:
+                            process_indexer_event(
+                                {
+                                    "event": INDEX_EMBEDDING_REQUESTED,
+                                    "payload": dict(payload),
+                                    "trace_id": trace_id,
+                                }
                             )
                         else:
                             logger.debug("worker skipping unsupported topic=%s trace_id=%s", topic, trace_id)

--- a/app/workers/outbox_worker.py
+++ b/app/workers/outbox_worker.py
@@ -565,7 +565,8 @@ def run(
                     continue
 
                 payload = message.get("payload") or {}
-                trace_id = payload.get("trace_id") or message.get("trace_id") or "-"
+                envelope = message.get("event") if isinstance(message.get("event"), dict) else {}
+                trace_id = payload.get("trace_id") or message.get("trace_id") or envelope.get("trace_id") or "-"
 
                 handler_note_path: str | None = None
                 if topic == INGEST_VAULT_CHANGED:

--- a/app/workers/outbox_worker.py
+++ b/app/workers/outbox_worker.py
@@ -48,6 +48,14 @@ class WorkerPanelSummary:
     deferred: bool = False
 
 
+def _trace_id_from_envelope(envelope: object) -> str | None:
+    if isinstance(envelope, dict):
+        raw = envelope.get("trace_id")
+        return str(raw) if raw else None
+    raw = getattr(envelope, "trace_id", None)
+    return str(raw) if raw else None
+
+
 def handle_ingest_object_deleted(payload: Mapping[str, Any]) -> None:
     # Explicit no-op cleanup hook for delete events. Downstream index cleanup can
     # be added here later without changing worker dispatch contracts.
@@ -565,8 +573,12 @@ def run(
                     continue
 
                 payload = message.get("payload") or {}
-                envelope = message.get("event") if isinstance(message.get("event"), dict) else {}
-                trace_id = payload.get("trace_id") or message.get("trace_id") or envelope.get("trace_id") or "-"
+                trace_id = (
+                    payload.get("trace_id")
+                    or message.get("trace_id")
+                    or _trace_id_from_envelope(message.get("event"))
+                    or "-"
+                )
 
                 handler_note_path: str | None = None
                 if topic == INGEST_VAULT_CHANGED:

--- a/tests/architecture/test_events_outbox_contracts.py
+++ b/tests/architecture/test_events_outbox_contracts.py
@@ -110,6 +110,7 @@ def test_outbox_event_envelope_has_required_fields(tmp_path: Path, monkeypatch) 
     outbox_path = tmp_path / "index-outbox.jsonl"
     monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
     monkeypatch.setattr("app.outbox.events.INDEX_OUTBOX_PATH", outbox_path, raising=False)
+    monkeypatch.setattr("app.outbox.events.write_outbox_event", lambda *args, **kwargs: "1")
 
     emit_index_embedding_requested(
         {

--- a/tests/indexer/test_outbox_roundtrip.py
+++ b/tests/indexer/test_outbox_roundtrip.py
@@ -11,6 +11,18 @@ from app.stores import get_vector_index, reset_store_backends
 from app.store.object_store import DomainObject, ObjectStore
 
 
+def test_emit_index_embedding_requested_writes_db_outbox_and_audit(tmp_path, monkeypatch) -> None:
+    fake_path = tmp_path / "index-outbox.jsonl"
+    monkeypatch.setattr(events, "INDEX_OUTBOX_PATH", fake_path, raising=False)
+    db_writes: list[object] = []
+    monkeypatch.setattr(events, "write_outbox_event", lambda evt, idempotency_key=None: db_writes.append((evt, idempotency_key)) or "1")
+
+    events.emit_index_embedding_requested({"object_id": uuid4(), "trace_id": "trace-db-audit", "source": "test"})
+
+    assert db_writes
+    assert fake_path.exists()
+
+
 def test_indexer_runner_does_not_consume_jsonl_outbox_queue(tmp_path, monkeypatch, capsys) -> None:
     reset_store_backends()
 

--- a/tests/indexer/test_outbox_roundtrip.py
+++ b/tests/indexer/test_outbox_roundtrip.py
@@ -5,6 +5,8 @@ import json
 from datetime import datetime, timezone
 from uuid import uuid4
 
+import pytest
+
 from app.components.embeddings import get_embedding_client
 from app.outbox import events
 from app.stores import get_vector_index, reset_store_backends
@@ -23,6 +25,17 @@ def test_emit_index_embedding_requested_writes_db_outbox_and_audit(tmp_path, mon
     assert fake_path.exists()
 
 
+def test_emit_index_embedding_requested_raises_when_db_outbox_write_fails(tmp_path, monkeypatch) -> None:
+    fake_path = tmp_path / "index-outbox.jsonl"
+    monkeypatch.setattr(events, "INDEX_OUTBOX_PATH", fake_path, raising=False)
+    monkeypatch.setattr(events, "write_outbox_event", lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("db down")))
+
+    with pytest.raises(RuntimeError, match="db down"):
+        events.emit_index_embedding_requested({"object_id": uuid4(), "trace_id": "trace-db-fail", "source": "test"})
+
+    assert not fake_path.exists()
+
+
 def test_indexer_runner_does_not_consume_jsonl_outbox_queue(tmp_path, monkeypatch, capsys) -> None:
     reset_store_backends()
 
@@ -32,6 +45,7 @@ def test_indexer_runner_does_not_consume_jsonl_outbox_queue(tmp_path, monkeypatc
 
     fake_path = tmp_path / "index-outbox.jsonl"
     monkeypatch.setattr(events, "INDEX_OUTBOX_PATH", fake_path, raising=False)
+    monkeypatch.setattr(events, "write_outbox_event", lambda evt, idempotency_key=None: "1")
 
     import app.store.object_store as legacy_object_store
 

--- a/tests/indexer/test_outbox_roundtrip.py
+++ b/tests/indexer/test_outbox_roundtrip.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import importlib
 import json
 from datetime import datetime, timezone
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -34,6 +34,23 @@ def test_emit_index_embedding_requested_raises_when_db_outbox_write_fails(tmp_pa
         events.emit_index_embedding_requested({"object_id": uuid4(), "trace_id": "trace-db-fail", "source": "test"})
 
     assert not fake_path.exists()
+
+
+def test_emit_index_embedding_requested_tolerates_audit_append_failure(tmp_path, monkeypatch) -> None:
+    fake_path = tmp_path / "index-outbox.jsonl"
+    monkeypatch.setattr(events, "INDEX_OUTBOX_PATH", fake_path, raising=False)
+    db_writes: list[object] = []
+    monkeypatch.setattr(events, "write_outbox_event", lambda evt, idempotency_key=None: db_writes.append((evt, idempotency_key)) or "1")
+    monkeypatch.setattr(events, "_append_record", lambda record: (_ for _ in ()).throw(OSError("disk full")))
+
+    events.emit_index_embedding_requested({"object_id": uuid4(), "trace_id": "trace-db-audit-fail", "source": "test"})
+
+    assert db_writes
+
+
+def test_emit_index_embedding_created_tolerates_audit_append_failure(monkeypatch) -> None:
+    monkeypatch.setattr(events, "_append_record", lambda record: (_ for _ in ()).throw(OSError("audit sink unavailable")))
+    events.emit_index_embedding_created(object_id=UUID("11111111-1111-1111-1111-111111111111"), trace_id="trace-created")
 
 
 def test_indexer_runner_does_not_consume_jsonl_outbox_queue(tmp_path, monkeypatch, capsys) -> None:

--- a/tests/indexer/test_outbox_roundtrip.py
+++ b/tests/indexer/test_outbox_roundtrip.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 import importlib
 import json
 from datetime import datetime, timezone
-from pathlib import Path
 from uuid import uuid4
-
-from jsonschema import validate
 
 from app.components.embeddings import get_embedding_client
 from app.outbox import events
@@ -14,12 +11,7 @@ from app.stores import get_vector_index, reset_store_backends
 from app.store.object_store import DomainObject, ObjectStore
 
 
-def _load_schema(name: str) -> dict:
-    schema_path = Path("app/events/schemas") / f"{name}.schema.json"
-    return json.loads(schema_path.read_text(encoding="utf-8"))
-
-
-def test_indexer_runner_consumes_outbox_without_vectors(tmp_path, monkeypatch) -> None:
+def test_indexer_runner_does_not_consume_jsonl_outbox_queue(tmp_path, monkeypatch, capsys) -> None:
     reset_store_backends()
 
     monkeypatch.setenv("STORE_BACKEND", "memory")
@@ -63,25 +55,18 @@ def test_indexer_runner_consumes_outbox_without_vectors(tmp_path, monkeypatch) -
         events.emit_index_embedding_requested({"object_id": oid, "trace_id": "trace-123", "source": "test"})
 
     runner.main()
+    output = capsys.readouterr().out
+    assert "JSONL queue consumption disabled" in output
 
     idx = get_vector_index()
     embedder = get_embedding_client()
     query = embedder.embed_text("payload-0")
     results = idx.search(query, k=2)
 
-    assert results
-    assert results[0].payload["text"] == "payload-0"
-
-    # Indexer emitted a schema-aligned index.embedding.created record (no embedding vectors).
+    assert not results
     lines = fake_path.read_text(encoding="utf-8").splitlines()
-    assert lines
     records = [json.loads(line) for line in lines if line.strip()]
+    requested = [rec for rec in records if rec.get("event") == "index.embedding.requested"]
     created = [rec for rec in records if rec.get("event") == "index.embedding.created"]
-    assert created, "Expected an index.embedding.created record"
-
-    rec = created[-1]
-    assert "embedding" not in rec
-    assert "embedding" not in rec.get("payload", {})
-
-    schema = _load_schema("index.embedding.created")
-    validate(instance=rec, schema=schema)
+    assert requested, "Expected request records in JSONL audit log"
+    assert not created, "Runner must not process JSONL request records into created events"

--- a/tests/indexer/test_outbox_roundtrip_pg.py
+++ b/tests/indexer/test_outbox_roundtrip_pg.py
@@ -26,7 +26,7 @@ def _pg_available() -> bool:
 
 
 @pytest.mark.pg
-def test_indexer_runner_consumes_outbox_pg_without_vectors(tmp_path, monkeypatch) -> None:
+def test_indexer_runner_pg_does_not_consume_jsonl_outbox_queue(tmp_path, monkeypatch, capsys) -> None:
     if not _pg_available():
         pytest.skip("Postgres backend not available")
 
@@ -64,12 +64,13 @@ def test_indexer_runner_consumes_outbox_pg_without_vectors(tmp_path, monkeypatch
         events.emit_index_embedding_requested({"object_id": oid, "trace_id": "trace-123", "source": "test"})
 
     runner.main()
+    output = capsys.readouterr().out
+    assert "JSONL queue consumption disabled" in output
 
     idx = get_vector_index()
     query = get_embedding_client().embed_text("payload-0")
     hits = idx.search(query, k=2)
 
-    assert hits
-    assert hits[0].payload.get("text") == "payload-0"
+    assert not hits
 
     reset_store_backends()

--- a/tests/runtime/test_worker_dispatch_ingest_vault_changed.py
+++ b/tests/runtime/test_worker_dispatch_ingest_vault_changed.py
@@ -188,3 +188,42 @@ def test_worker_run_dispatches_index_embedding_requested(monkeypatch: pytest.Mon
         }
     ]
     assert acked == ["embed-1"]
+
+
+def test_worker_run_preserves_trace_id_from_db_event_envelope(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: list[dict] = []
+
+    def fake_process(evt):
+        called.append(dict(evt))
+
+    monkeypatch.setattr(outbox_worker, "process_indexer_event", fake_process)
+    monkeypatch.setattr(outbox_worker, "bootstrap", lambda: None)
+    monkeypatch.setattr(outbox_worker, "ack_outbox", lambda _msg_id: True)
+    monkeypatch.setattr(outbox_worker, "write_worker_heartbeat", lambda **_: None)
+
+    messages = [
+        {
+            "id": "embed-2",
+            "topic": INDEX_EMBEDDING_REQUESTED,
+            "payload": {"object_id": "22222222-2222-2222-2222-222222222222"},
+            "event": {"trace_id": "trace-from-envelope"},
+        }
+    ]
+
+    def fake_poll():
+        if messages:
+            return messages.pop(0)
+        return None
+
+    monkeypatch.setattr(outbox_worker, "poll_outbox_one", fake_poll)
+    monkeypatch.setenv("WORKER_HEARTBEAT_INTERVAL", "9999")
+
+    outbox_worker.run(interval=0.0, heartbeat_interval=9999, log_heartbeat_interval=None, stop_after_ticks=2)
+
+    assert called == [
+        {
+            "event": INDEX_EMBEDDING_REQUESTED,
+            "payload": {"object_id": "22222222-2222-2222-2222-222222222222"},
+            "trace_id": "trace-from-envelope",
+        }
+    ]

--- a/tests/runtime/test_worker_dispatch_ingest_vault_changed.py
+++ b/tests/runtime/test_worker_dispatch_ingest_vault_changed.py
@@ -227,3 +227,45 @@ def test_worker_run_preserves_trace_id_from_db_event_envelope(monkeypatch: pytes
             "trace_id": "trace-from-envelope",
         }
     ]
+
+
+def test_worker_run_preserves_trace_id_from_db_event_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: list[dict] = []
+
+    class EventEnvelope:
+        trace_id = "trace-from-model"
+
+    def fake_process(evt):
+        called.append(dict(evt))
+
+    monkeypatch.setattr(outbox_worker, "process_indexer_event", fake_process)
+    monkeypatch.setattr(outbox_worker, "bootstrap", lambda: None)
+    monkeypatch.setattr(outbox_worker, "ack_outbox", lambda _msg_id: True)
+    monkeypatch.setattr(outbox_worker, "write_worker_heartbeat", lambda **_: None)
+
+    messages = [
+        {
+            "id": "embed-3",
+            "topic": INDEX_EMBEDDING_REQUESTED,
+            "payload": {"object_id": "33333333-3333-3333-3333-333333333333"},
+            "event": EventEnvelope(),
+        }
+    ]
+
+    def fake_poll():
+        if messages:
+            return messages.pop(0)
+        return None
+
+    monkeypatch.setattr(outbox_worker, "poll_outbox_one", fake_poll)
+    monkeypatch.setenv("WORKER_HEARTBEAT_INTERVAL", "9999")
+
+    outbox_worker.run(interval=0.0, heartbeat_interval=9999, log_heartbeat_interval=None, stop_after_ticks=2)
+
+    assert called == [
+        {
+            "event": INDEX_EMBEDDING_REQUESTED,
+            "payload": {"object_id": "33333333-3333-3333-3333-333333333333"},
+            "trace_id": "trace-from-model",
+        }
+    ]

--- a/tests/runtime/test_worker_dispatch_ingest_vault_changed.py
+++ b/tests/runtime/test_worker_dispatch_ingest_vault_changed.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from app.events.types import INGEST_OBJECT_DELETED, INGEST_VAULT_CHANGED, PANEL_SCAN_REQUESTED
+from app.outbox.events import INDEX_EMBEDDING_REQUESTED
 from app.workers import outbox_worker
 
 pytestmark = pytest.mark.not_pg
@@ -147,3 +148,43 @@ def test_worker_run_dispatches_panel_scan_requested(
 
     assert called == [{"vault_path": "/tmp/vault/Inbox/panel.md", "relative_path": "Inbox/panel.md", "event_id": "evt-panel-1", "trace_id": "trace-panel-1"}]
     assert acked == ["panel-1"]
+
+
+def test_worker_run_dispatches_index_embedding_requested(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: list[dict] = []
+    acked: list[str] = []
+
+    def fake_process(evt):
+        called.append(dict(evt))
+
+    monkeypatch.setattr(outbox_worker, "process_indexer_event", fake_process)
+    monkeypatch.setattr(outbox_worker, "bootstrap", lambda: None)
+    monkeypatch.setattr(outbox_worker, "ack_outbox", lambda msg_id: acked.append(str(msg_id)) or True)
+    monkeypatch.setattr(outbox_worker, "write_worker_heartbeat", lambda **_: None)
+
+    messages = [
+        {
+            "id": "embed-1",
+            "topic": INDEX_EMBEDDING_REQUESTED,
+            "payload": {"object_id": "11111111-1111-1111-1111-111111111111", "trace_id": "trace-embed-1"},
+        }
+    ]
+
+    def fake_poll():
+        if messages:
+            return messages.pop(0)
+        return None
+
+    monkeypatch.setattr(outbox_worker, "poll_outbox_one", fake_poll)
+    monkeypatch.setenv("WORKER_HEARTBEAT_INTERVAL", "9999")
+
+    outbox_worker.run(interval=0.0, heartbeat_interval=9999, log_heartbeat_interval=None, stop_after_ticks=2)
+
+    assert called == [
+        {
+            "event": INDEX_EMBEDDING_REQUESTED,
+            "payload": {"object_id": "11111111-1111-1111-1111-111111111111", "trace_id": "trace-embed-1"},
+            "trace_id": "trace-embed-1",
+        }
+    ]
+    assert acked == ["embed-1"]


### PR DESCRIPTION
Fixes #775

## Summary
- disable JSONL queue consumption in `app/indexer/runner.py`
- keep JSONL path as audit-only surface with explicit runtime message
- update indexer roundtrip test to assert runner does not consume JSONL request events

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/indexer/test_outbox_roundtrip.py tests/events/test_outbox_consumer_contract.py tests/architecture/test_events_outbox_contracts.py`
- `.venv/bin/ruff check app/indexer/runner.py tests/indexer/test_outbox_roundtrip.py`
