### PR TITLE
test: strengthen ASK trace/no-hit contract coverage

### DIFF
--- a/app/api/routes/ask.py
+++ b/app/api/routes/ask.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import time
 from typing import Any
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 from pydantic import AliasChoices, BaseModel, Field
 
 from app.agents.ask.graph import run_ask_graph
 from app.agents.ask.utils import get_ask_settings
+from app.events.models import new_trace_id
 from app.observability.status_service import record_ask_error, record_ask_query
 from app.retrieval.hybrid import get_store as get_hybrid_store
 from app.stores import get_object_store
@@ -101,13 +102,14 @@ def _to_source(hit: Any) -> AskSource:
 
 
 @router.post("/ask", response_model=AskResponse)
-async def ask(req: AskRequest) -> AskResponse:
+async def ask(req: AskRequest, request: Request) -> AskResponse:
     if not _HYBRID_WARMED:
         _ensure_hybrid_store_loaded()
     start = time.perf_counter()
     ask_settings = get_ask_settings()
+    trace_id = getattr(request.state, "trace_id", None) or request.headers.get("x-trace-id") or new_trace_id()
     try:
-        state = run_ask_graph(req.question, ask_settings=ask_settings)
+        state = run_ask_graph(req.question, trace_id=trace_id, ask_settings=ask_settings)
     except Exception:
         record_ask_error()
         raise

--- a/tests/agents/ask/test_agent_state_contract.py
+++ b/tests/agents/ask/test_agent_state_contract.py
@@ -5,7 +5,9 @@ public `/api/ask` product contracts.
 """
 
 from app.agents.ask.graph import _to_retrieved_hit
+from app.agents.ask.graph import run_ask_graph
 from app.agents.ask.state import AgentState
+from app.retrieval.capability import RetrievalResponse
 
 
 def test_agent_state_minimal_valid_shape_and_documented_fields() -> None:
@@ -52,3 +54,19 @@ def test_retrieved_hit_fields_and_trace_id_carry_through_behavior() -> None:
     state = AgentState(trace_id="trace-ask-1", query="ask query", hits=[mapped])
     assert state.trace_id == "trace-ask-1"
     assert state.hits[0].object_id == "doc-123"
+
+
+def test_ask_trace_id_forwards_into_retrieval_request(monkeypatch) -> None:
+    """Verify run_ask_graph propagates trace_id into retrieval capability input."""
+    captured: dict[str, str | None] = {"trace_id": None}
+
+    def _fake_retrieve(request):
+        captured["trace_id"] = request.trace_id
+        return RetrievalResponse(query=request.query, hits=[], trace_id=request.trace_id)
+
+    monkeypatch.setattr("app.agents.ask.graph.retrieve", _fake_retrieve)
+
+    state = run_ask_graph("trace contract", trace_id="trace-ask-propagation-1")
+
+    assert captured["trace_id"] == "trace-ask-propagation-1"
+    assert state.trace_id == "trace-ask-propagation-1"

--- a/tests/api/test_ask_contract.py
+++ b/tests/api/test_ask_contract.py
@@ -1,16 +1,14 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 from fastapi.testclient import TestClient
 
+from app.agents.ask.state import AgentState
 from app.api.app import app
 from app.api.routes import ask as ask_module
 from app.retrieval.hybrid import get_store
 
 
-def test_ask_contract_structure(monkeypatch) -> None:
-    # Minimal embeddings stub to keep determinism
+def _stub_embeddings(monkeypatch) -> None:
     monkeypatch.setattr("app.index.embeddings.embed_texts", lambda texts, **_kwargs: [[0.1, 0.1, 0.1] for _ in texts])
     monkeypatch.setattr("app.index.embeddings.embed_text", lambda text, **_kwargs: [0.1, 0.1, 0.1])
     monkeypatch.setattr("app.retrieval.hybrid.embed_text", lambda text, language=None: [0.1, 0.1, 0.1])
@@ -18,6 +16,11 @@ def test_ask_contract_structure(monkeypatch) -> None:
         "app.retrieval.hybrid.embed_batches",
         lambda texts, batch_size=32: ([[0.1, 0.1, 0.1] for _ in list(texts[:batch_size])],),
     )
+
+
+def test_ask_contract_structure(monkeypatch) -> None:
+    # Minimal embeddings stub to keep determinism
+    _stub_embeddings(monkeypatch)
 
     hybrid = get_store()
     hybrid.set_documents(
@@ -50,6 +53,73 @@ def test_ask_contract_structure(monkeypatch) -> None:
         assert hit.get("zone") is None, "Zone should not be derived from artifact payload"
         if hit.get("title") is not None:
             assert isinstance(hit.get("title"), str)
+    finally:
+        hybrid.set_documents([])
+        ask_module._HYBRID_WARMED = False
+
+
+def test_ask_contract_no_hits_returns_default_answer_and_empty_sources(monkeypatch) -> None:
+    _stub_embeddings(monkeypatch)
+
+    hybrid = get_store()
+    hybrid.set_documents([])
+    ask_module._HYBRID_WARMED = True
+    client = TestClient(app)
+    try:
+        resp = client.post("/api/ask", json={"question": "no matching docs"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data.get("answer") == "No results found."
+        assert data.get("sources") == []
+    finally:
+        hybrid.set_documents([])
+        ask_module._HYBRID_WARMED = False
+
+
+def test_ask_contract_propagates_trace_id_from_header(monkeypatch) -> None:
+    _stub_embeddings(monkeypatch)
+    ask_module._HYBRID_WARMED = True
+    hybrid = get_store()
+    hybrid.set_documents([])
+    captured: dict[str, str | None] = {"trace_id": None}
+
+    def _fake_run_ask_graph(query: str, trace_id: str | None = None, ask_settings=None) -> AgentState:
+        captured["trace_id"] = trace_id
+        return AgentState(trace_id=trace_id, query=query, hits=[], answer="No results found.")
+
+    monkeypatch.setattr(ask_module, "run_ask_graph", _fake_run_ask_graph)
+    client = TestClient(app)
+    try:
+        resp = client.post("/api/ask", json={"question": "trace header"}, headers={"x-trace-id": "trace-ask-header-1"})
+        assert resp.status_code == 200
+        assert captured["trace_id"] == "trace-ask-header-1"
+    finally:
+        hybrid.set_documents([])
+        ask_module._HYBRID_WARMED = False
+
+
+def test_ask_contract_generates_trace_id_when_missing(monkeypatch) -> None:
+    _stub_embeddings(monkeypatch)
+    ask_module._HYBRID_WARMED = True
+    hybrid = get_store()
+    hybrid.set_documents([])
+    captured: dict[str, str | None] = {"trace_id": None}
+
+    def _fake_run_ask_graph(query: str, trace_id: str | None = None, ask_settings=None) -> AgentState:
+        captured["trace_id"] = trace_id
+        return AgentState(trace_id=trace_id, query=query, hits=[], answer="No results found.")
+
+    class _FakeUuid:
+        hex = "generated-ask-trace-1"
+
+    monkeypatch.setattr(ask_module, "run_ask_graph", _fake_run_ask_graph)
+    monkeypatch.setattr("app.middleware.trace.uuid.uuid4", lambda: _FakeUuid())
+    client = TestClient(app)
+    try:
+        resp = client.post("/api/ask", json={"question": "trace generated"})
+        assert resp.status_code == 200
+        assert captured["trace_id"] == "generated-ask-trace-1"
+        assert resp.headers.get("x-trace-id") == "generated-ask-trace-1"
     finally:
         hybrid.set_documents([])
         ask_module._HYBRID_WARMED = False


### PR DESCRIPTION
Fixes #774

## Summary
- add ASK API contract tests for no-hit behavior and trace propagation from request context/header
- forward request trace IDs from `/api/ask` into `run_ask_graph`
- add ASK agent contract coverage to verify `run_ask_graph` forwards `trace_id` into retrieval requests

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest -q tests/api/test_ask_contract.py tests/api/test_ask_api.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest -q tests/agents -k "ask and trace"`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest -q tests/agents -k "ask or AgentState or trace"`
- `.venv/bin/ruff check app tests`