### PR TITLE
Consolidate companion temporal cognition and continuity semantics

### DIFF
--- a/companion-ui/docs/ATTENTIONAL_PHYSICS.md
+++ b/companion-ui/docs/ATTENTIONAL_PHYSICS.md
@@ -1,0 +1,37 @@
+# Attentional Physics
+
+## Purpose
+Define the higher-resolution attentional vocabulary used by the companion UI.
+
+## Metaphor boundary
+- `Weight`, `gravity`, and `pressure` are explanatory metaphors.
+- Their architectural meaning is always about attentional behavior, not simulated physics.
+
+## Core terms
+- **Attentional weight:** how much attention an object deserves in the current context.
+- **Visual weight:** how strongly the interface presents an object perceptually.
+- **Salience gradient:** the relative difference in attentional pull across adjacent objects or trajectories.
+- **Attentional gravity:** the tendency of an unresolved object or tension to pull attention back over time.
+- **Interruption pressure:** the cost imposed when a new signal competes with current focus.
+- **Ambient resurfacing:** low-disruption return of relevant material without demanding immediate action.
+- **Ambient cognition:** low-pressure cognitive support that stays available without insisting on immediate focus.
+- **Non-disruptive salience:** making relevance legible without escalating into alert-like behavior.
+
+## Rules
+- Visual weight should usually follow attentional weight, but never replace semantic justification.
+- Salience gradients should help the user perceive relative importance without forcing explicit ranking rituals.
+- Ambient resurfacing should minimize interruption pressure.
+- Attentional gravity should be traceable to tension, dependency, salience, or provenance, not invented urgency.
+- Low attentional load is preserved when resurfacing clarifies rather than competes.
+
+## Relations
+- Salience influences attentional weight.
+- Tension increases attentional gravity.
+- Provenance affects whether resurfaced weight is trustworthy.
+- Continuity payload quality reduces interruption cost during re-entry.
+
+## Related docs
+- `ATTENTION_MODEL.md`
+- `SALIENCE_AND_TENSION.md`
+- `RESURFACING_HEURISTICS.md`
+- `CONTINUITY_AND_DECAY.md`

--- a/companion-ui/docs/ATTENTION_MODEL.md
+++ b/companion-ui/docs/ATTENTION_MODEL.md
@@ -1,12 +1,17 @@
 # Attention Model
 
 ## Purpose
-Define explicit attention semantics for document-first cognitive interaction.
+Define explicit attention semantics for document-first cognitive interaction without collapsing attention into visual style, notification logic, or rigid priority scoring.
+
+## Boundary note
+- This document defines the semantic model of attention.
+- `ATTENTIONAL_PHYSICS.md` defines the newer sub-terms such as attentional weight, gravity, and interruption pressure.
+- Metaphorical language is allowed only when it maps back to explicit architectural semantics.
 
 ## Attention layers
-- **Focal:** currently active thread and immediate object set.
+- **Focal:** currently active trajectory and immediate object set.
 - **Peripheral:** nearby context relevant to the current trajectory.
-- **Dormant:** unresolved but currently inactive threads.
+- **Dormant:** unresolved but currently inactive trajectories with remaining resurfacing potential.
 
 ## Attention movement
 - Orientation expands peripheral visibility.
@@ -15,10 +20,17 @@ Define explicit attention semantics for document-first cognitive interaction.
 - Review stabilizes attention on decisions and commitments.
 - Recovery restores attention after interruption.
 
+## Core relations
+- Salience influences attention, but does not fully determine it.
+- Tension can pull attention back even when a trajectory is not currently focal.
+- Provenance affects trust and therefore affects whether resurfaced material deserves attention.
+- Persistence affects what can survive attention loss, but attention itself is not a persistence layer.
+
 ## Preservation rules
 - Interruptions must preserve at least one recoverable attention anchor.
 - Overlay changes must not silently move objects between durable and transient states.
 - Resurfacing should promote dormant objects only when salience and provenance justify it.
+- Attention support should minimize interruption cost rather than maximize visible cues.
 
 ## Attention loss risks
 - Context fragmentation from route-level resets.
@@ -32,6 +44,8 @@ Define explicit attention semantics for document-first cognitive interaction.
 
 ## Related docs
 - `TEMPORAL_COGNITION.md`
+- `COGNITIVE_TRAJECTORIES.md`
 - `POSTURE_TRANSITIONS.md`
 - `SALIENCE_AND_TENSION.md`
+- `ATTENTIONAL_PHYSICS.md`
 - `TEMPORAL_PROVENANCE.md`

--- a/companion-ui/docs/COGNITIVE_FAILURE_MODES.md
+++ b/companion-ui/docs/COGNITIVE_FAILURE_MODES.md
@@ -6,10 +6,12 @@ Name recurring cognitive breakdowns so architecture can prevent or recover from 
 ## Failure modes
 - **Interruption amnesia:** user returns and cannot recover prior intent or decision boundary.
 - **Posture thrash:** rapid posture switching without continuity preservation.
+- **Trajectory fragmentation:** one line of thought splits into disconnected pieces without recoverable linkage.
 - **Salience collapse:** relevant dormant threads never resurface until too late.
 - **Resurfacing noise:** too many weakly relevant resurfacings drown true signals.
 - **Provenance opacity:** user sees suggestions without enough lineage to trust or reject quickly.
 - **Tension burial:** unresolved cognitive tension disappears from active context.
+- **Decay without payload:** reconstruction cost rises because insufficient continuity cues were preserved.
 - **Persistence ambiguity:** user cannot tell what is transient versus durable.
 - **Chat gravity:** thread UI becomes primary, displacing document-centered cognition.
 
@@ -28,6 +30,7 @@ Name recurring cognitive breakdowns so architecture can prevent or recover from 
 ## Related docs
 - `TEMPORAL_COGNITION.md`
 - `ATTENTION_MODEL.md`
+- `CONTINUITY_AND_DECAY.md`
 - `POSTURE_TRANSITIONS.md`
 - `SALIENCE_AND_TENSION.md`
 - `UI_RUNTIME_BOUNDARIES.md`

--- a/companion-ui/docs/COGNITIVE_MODES.md
+++ b/companion-ui/docs/COGNITIVE_MODES.md
@@ -13,6 +13,7 @@ This file keeps the historical filename `COGNITIVE_MODES.md`, but the canonical 
 - Postures are cognitive emphasis patterns, not route-level locks.
 - Multiple postures may coexist inside one document-centered session.
 - Resurfacing is a cross-posture operation, not a separate posture.
+- Trajectories persist across posture shifts; posture describes emphasis, not temporal identity.
 
 ## Transition constraints
 - Transitions must preserve document anchoring and provenance visibility.
@@ -23,4 +24,5 @@ This file keeps the historical filename `COGNITIVE_MODES.md`, but the canonical 
 - `POSTURE_TRANSITIONS.md`
 - `ATTENTION_MODEL.md`
 - `TEMPORAL_COGNITION.md`
+- `COGNITIVE_TRAJECTORIES.md`
 - `SALIENCE_AND_TENSION.md`

--- a/companion-ui/docs/COGNITIVE_OBJECTS.md
+++ b/companion-ui/docs/COGNITIVE_OBJECTS.md
@@ -10,6 +10,8 @@ Define the meaning-bearing objects used across document, overlays, and temporal 
 - **Provenance card:** compact lineage object describing source and rationale.
 - **Tension marker:** explicit unresolved pressure in a thread.
 - **Resurfacing cue:** contextual signal to re-open a dormant thread.
+- **Continuity payload:** bounded re-entry package carrying the minimum context needed to restore a trajectory.
+- **Temporal overlay:** a continuity-preserving overlay that exposes time-sensitive context without becoming notification UI.
 
 ## Object-level invariants
 - Every object must be inspectable in context.
@@ -27,9 +29,12 @@ Define the meaning-bearing objects used across document, overlays, and temporal 
 - Threads are anchored to documents.
 - Tension markers can attach to proposals, threads, or anchor documents.
 - Resurfacing cues should reference provenance and prior tension.
+- Continuity payloads bundle anchor, trajectory, provenance, and unresolved tension context for re-entry.
 
 ## Related docs
 - `TEMPORAL_PROVENANCE.md`
 - `TEMPORAL_COGNITION.md`
+- `CONTINUITY_AND_DECAY.md`
+- `TEMPORAL_OVERLAYS.md`
 - `SALIENCE_AND_TENSION.md`
 - `OVERLAY_GRAMMAR.md`

--- a/companion-ui/docs/COGNITIVE_PRINCIPLES.md
+++ b/companion-ui/docs/COGNITIVE_PRINCIPLES.md
@@ -6,10 +6,13 @@
 3. Continuity over novelty: every interaction should preserve orientation across interruptions.
 4. Explainable assistance: AI suggestions must be attributable and inspectable.
 5. Reversible cognition: proposed changes should be staged and reversible before persistence.
+6. Low attentional load: the interaction layer should preserve focus rather than compete for it.
+7. Cognitive prosthesis posture: the system supports thought continuity instead of becoming the thought object.
 
 ## Anti-principles
 - No hidden semantic state that exists only inside the app.
 - No AI-dashboard posture where agent outputs displace active documents.
+- No notification-centric cognition where resurfacing behaves like alerting.
 - No persistence of meaning-bearing state into app-local stores by default.
 
 ## Practical implication

--- a/companion-ui/docs/COGNITIVE_TRAJECTORIES.md
+++ b/companion-ui/docs/COGNITIVE_TRAJECTORIES.md
@@ -1,0 +1,41 @@
+# Cognitive Trajectories
+
+## Purpose
+Define trajectories as the canonical temporal unit of cognition in the companion UI.
+
+## Metaphor boundary
+- `Trajectory` is architectural semantics, not decorative language.
+- It means a continuity-bearing line of thought that can be resumed, cooled, resurfaced, fragmented, or converged over time.
+
+## Core rule
+- Sessions are interaction slices.
+- Trajectories are the longer-lived semantic unit.
+- A posture shift may happen within one trajectory.
+- A trajectory may span multiple sessions, overlays, and interruptions.
+
+## Canonical trajectory states
+- **Active trajectory:** currently focal and being worked directly.
+- **Warm trajectory:** not focal now, but re-entry cost remains low.
+- **Dormant trajectory:** inactive but still semantically unresolved and resurfacing-eligible.
+- **Cold trajectory:** inactive long enough that reconstruction cost is high.
+- **Interrupted trajectory:** paused by external break before semantic closure.
+- **Decaying trajectory:** continuity signals are weakening and re-entry cost is rising.
+- **Fragmented trajectory:** continuity exists only in partial, weakly linked pieces.
+- **Converging trajectory:** multiple partial lines of thought are moving toward one synthesis.
+
+## Transition rules
+- Active trajectories can cool into warm or dormant states.
+- Dormant trajectories can resurface into warm or active states.
+- Interrupted trajectories should preserve enough continuity payload to avoid fragmentation.
+- Converging trajectories should preserve provenance from each contributing line.
+
+## Architectural consequences
+- Document remains the anchor for durable trajectory meaning.
+- Resurfacing should target trajectories, not just isolated snippets.
+- Continuity support should preserve unresolved synthesis, not only last-visible text.
+
+## Related docs
+- `TEMPORAL_COGNITION.md`
+- `CONTINUITY_AND_DECAY.md`
+- `ATTENTION_MODEL.md`
+- `EPISTEMIC_EVOLUTION.md`

--- a/companion-ui/docs/CONTINUITY_AND_DECAY.md
+++ b/companion-ui/docs/CONTINUITY_AND_DECAY.md
@@ -1,0 +1,40 @@
+# Continuity and Decay
+
+## Purpose
+Define what must be preserved for low-cost re-entry and how that preservation weakens over time.
+
+## Metaphor boundary
+- `Payload`, `decay`, and `latency ladder` are allowed shorthand.
+- Architecturally they mean reconstructive sufficiency, continuity loss, and increasing re-entry effort.
+
+## Core terms
+- **Continuity payload:** the minimum bounded context needed to restore a trajectory.
+- **Cognitive re-entry:** return to a trajectory after interruption or dormancy.
+- **Interruption cost:** the amount of effort required to regain useful continuity.
+- **Temporal context reconstruction:** rebuilding enough prior meaning to continue without false certainty.
+- **Unresolved synthesis preservation:** keeping partially integrated thinking recoverable before final stabilization.
+- **Latency ladder:** the ordered rise in reconstruction effort as a trajectory cools, dorms, or decays.
+
+## Continuity payload contents
+- Anchor document
+- Prior intent
+- Current or last unresolved tension
+- Relevant provenance
+- Last meaningful transition or decision boundary
+
+## Decay rules
+- Decay is not deletion; it is loss of reconstructive clarity.
+- Weak provenance accelerates interpretive decay.
+- Missing tension markers increase ambiguity during re-entry.
+- Good continuity payloads slow decay and flatten the latency ladder.
+
+## Architectural constraints
+- Continuity support must not become hidden app-only state.
+- Re-entry should restore trajectory meaning before inviting new branching.
+- Overlays may expose continuity payloads, but the vault remains the durable anchor.
+
+## Related docs
+- `TEMPORAL_COGNITION.md`
+- `COGNITIVE_TRAJECTORIES.md`
+- `TEMPORAL_OVERLAYS.md`
+- `TEMPORAL_PROVENANCE.md`

--- a/companion-ui/docs/DESIGN_BRIEF.md
+++ b/companion-ui/docs/DESIGN_BRIEF.md
@@ -5,6 +5,7 @@ A user-facing module for a personal agentic PKM system. The system already exist
 
 ## Terminology note (current architecture)
 This brief is preserved as a source artifact from earlier exploration. Where it says "modes," the current canonical term in this workspace is **cognitive postures**.
+Terms such as `trajectory`, `payload`, `gravity`, or `temperature` in newer docs are architectural vocabulary only when explicitly defined there; otherwise treat them as exploratory language, not binding interaction requirements.
 
 ## Who uses it
 One user: a senior software architect who lives in the vault daily across iPhone, iPad, and Mac. Thinks at system level. Uses the vault for capture, synthesis, decision tracking, and long-running thought. Already fluent with Obsidian, markdown, and agent tooling. Not a consumer; not a novice.

--- a/companion-ui/docs/EPISTEMIC_EVOLUTION.md
+++ b/companion-ui/docs/EPISTEMIC_EVOLUTION.md
@@ -1,0 +1,32 @@
+# Epistemic Evolution
+
+## Purpose
+Define how understanding changes over time without collapsing change into simple persistence or freshness semantics.
+
+## Metaphor boundary
+- `Evolution` means change in interpretation, confidence, framing, or synthesis quality.
+- It does not imply autonomous self-updating knowledge.
+
+## Core terms
+- **Epistemic evolution:** change in what the human understands or how strongly they hold it.
+- **Provenance evolution:** change in how supporting lineage is interpreted over time.
+- **Confidence shift:** increase or decrease in how strongly a claim should be trusted.
+- **Interpretive revision:** reframing earlier material without erasing its historical state.
+
+## Rules
+- Later understanding should not silently overwrite earlier provenance.
+- Resurfacing may happen because understanding changed, not only because relevance changed.
+- Persistence preserves artifacts; epistemic evolution explains how their meaning changes.
+- Evolution should stay inspectable and attributable.
+
+## Relations
+- Trajectories evolve epistemically as synthesis matures or is revised.
+- Provenance enables confidence shifts to be legible.
+- Decay can obscure prior epistemic states if continuity is weak.
+- Tension often drives epistemic evolution by forcing reinterpretation or revision.
+
+## Related docs
+- `TEMPORAL_PROVENANCE.md`
+- `TEMPORAL_COGNITION.md`
+- `COGNITIVE_TRAJECTORIES.md`
+- `RESURFACING_HEURISTICS.md`

--- a/companion-ui/docs/EVENT_MODEL_SUMMARY.md
+++ b/companion-ui/docs/EVENT_MODEL_SUMMARY.md
@@ -7,9 +7,12 @@ Keep companion UI compatible with event-driven runtime evolution while preservin
 - `ui.intent.*`: user interaction intents (open drawer, expand rail, accept/discard proposal).
 - `ui.state.*`: non-durable runtime transitions for local rendering.
 - `posture.*`: cognitive posture entry/exit and transition hints.
+- `trajectory.*`: trajectory activation, cooling, interruption, convergence, and recovery hints.
+- `continuity.*`: continuity payload and re-entry support cues.
 - `proposal.*`: staged suggestion lifecycle (`created`, `accepted`, `discarded`).
 - `provenance.*`: citation/context linkage events.
 - `resurface.*`: contextual resurfacing and re-entry cues.
+- `epistemic.*`: understanding-change and confidence-change cues.
 - `persistence.*`: explicit durable writes through runtime contracts.
 
 ## Contract posture
@@ -24,4 +27,6 @@ This file defines conceptual event boundaries only. It does not define runtime i
 ## Related docs
 - `TEMPORAL_COGNITION.md`
 - `ATTENTION_MODEL.md`
+- `COGNITIVE_TRAJECTORIES.md`
+- `CONTINUITY_AND_DECAY.md`
 - `POSTURE_TRANSITIONS.md`

--- a/companion-ui/docs/FUTURE_RESEARCH.md
+++ b/companion-ui/docs/FUTURE_RESEARCH.md
@@ -1,16 +1,17 @@
 # Future Research
 
 ## Open questions
-- How should orientation and resurfacing share primitives without collapsing into dashboard UX?
+- How should orientation and resurfacing share primitives without collapsing into dashboard UX or notification-centric behavior?
 - What is the right default granularity for provenance overlays on mobile?
 - Which staged proposal workflows best preserve agency while minimizing friction?
 - How should cross-session continuity be represented when chat is subordinate to documents?
 - Which cognitive tension signals are most useful for re-entry guidance?
+- Which continuity payload shapes minimize interruption cost without inflating UI complexity?
 
 ## Exploration priorities
 1. Interruption-recovery ergonomics that preserve trajectory continuity.
 2. Resurfacing interactions that stay citation-first and non-intrusive.
-3. Salience evolution models that avoid noisy resurfacing.
+3. Salience evolution and attentional-weight models that avoid noisy resurfacing.
 4. Mobile continuity patterns for bottom sheet + source peek behavior.
 
 ## Research constraints
@@ -22,4 +23,5 @@
 ## Related docs
 - `TEMPORAL_COGNITION.md`
 - `COGNITIVE_FAILURE_MODES.md`
+- `RESURFACING_HEURISTICS.md`
 - `SALIENCE_AND_TENSION.md`

--- a/companion-ui/docs/INTERACTION_PRINCIPLES.md
+++ b/companion-ui/docs/INTERACTION_PRINCIPLES.md
@@ -7,6 +7,7 @@
 ## Overlay-first
 - Prefer local overlays (rail, drawer, bottom sheet, source peek) over route changes.
 - Preserve context anchoring: where the user was, what was being referenced, and why.
+- Use overlays to preserve temporal continuity, not to create ambient interruption pressure.
 
 ## Posture continuity
 - Favor cognitive postures over hard mode switching.
@@ -21,6 +22,11 @@
 - Keep citations, proposal anchors, and contextual lineage legible at interaction time.
 - Avoid provenance hidden only in late audit surfaces.
 
+## Attentional simplicity
+- Preserve low attentional load by default.
+- Favor non-disruptive salience over notifications, badges, or urgency theater.
+- Let resurfacing compete through contextual relevance, not through interruption-heavy prompts.
+
 ## Explicit persistence
 - Clearly distinguish transient interaction state from persisted artifacts.
 - Persist only with explicit user intent and vault-compatible representation.
@@ -29,4 +35,5 @@
 - `COGNITIVE_MODES.md`
 - `OVERLAY_GRAMMAR.md`
 - `ATTENTION_MODEL.md`
+- `ATTENTIONAL_PHYSICS.md`
 - `POSTURE_TRANSITIONS.md`

--- a/companion-ui/docs/OVERLAY_GRAMMAR.md
+++ b/companion-ui/docs/OVERLAY_GRAMMAR.md
@@ -3,6 +3,10 @@
 ## Why grammar
 Overlay behavior needs a shared contract so interaction remains predictable across cognitive postures.
 
+## Boundary note
+- Overlay is an architectural surface, not a synonym for notification.
+- `TEMPORAL_OVERLAYS.md` owns the temporal semantics for overlays used in re-entry, resurfacing, and decay mitigation.
+
 ## Overlay classes
 - Margin rail: conversation context and composer.
 - Session drawer: session switching and history.
@@ -17,6 +21,7 @@ Overlay behavior needs a shared contract so interaction remains predictable acro
 - Trigger and dismiss actions should be explicit and reversible.
 - If an overlay is unavailable (viewport/runtime limits), fallback must keep the same cognitive semantics.
 - Overlay content must never become hidden semantic state.
+- Overlays should preserve low attentional load and avoid notification-centric escalation patterns.
 
 ## Continuity rules
 - Any proposal object shown in chat must map to the same object in document context with identical status and actions.
@@ -26,5 +31,6 @@ Overlay behavior needs a shared contract so interaction remains predictable acro
 ## Related docs
 - `COGNITIVE_OBJECTS.md`
 - `TEMPORAL_PROVENANCE.md`
+- `TEMPORAL_OVERLAYS.md`
 - `ATTENTION_MODEL.md`
 - `SALIENCE_AND_TENSION.md`

--- a/companion-ui/docs/POSTURE_TRANSITIONS.md
+++ b/companion-ui/docs/POSTURE_TRANSITIONS.md
@@ -14,6 +14,7 @@ Formalize how cognitive postures change while preserving continuity.
 - Transitions are explicit shifts in cognitive emphasis, not page-level locks.
 - Any transition must preserve anchor document, provenance context, and unresolved tension.
 - Recovery can enter from any posture and should restore prior trajectory before new branching.
+- Transition cost should stay low enough that postures do not fragment trajectories.
 
 ## Minimal transition contract
 - **From posture:** current emphasis context.
@@ -30,4 +31,5 @@ Formalize how cognitive postures change while preserving continuity.
 - `COGNITIVE_MODES.md`
 - `ATTENTION_MODEL.md`
 - `TEMPORAL_COGNITION.md`
+- `COGNITIVE_TRAJECTORIES.md`
 - `COGNITIVE_FAILURE_MODES.md`

--- a/companion-ui/docs/README.md
+++ b/companion-ui/docs/README.md
@@ -15,19 +15,46 @@ Foundational documents for cognitive interaction architecture.
 
 ## Cognitive architecture consolidation set
 - `TEMPORAL_COGNITION.md`
+- `COGNITIVE_TRAJECTORIES.md`
 - `COGNITIVE_FAILURE_MODES.md`
 - `ATTENTION_MODEL.md`
+- `ATTENTIONAL_PHYSICS.md`
 - `POSTURE_TRANSITIONS.md`
 - `SALIENCE_AND_TENSION.md`
+- `TENSION_PATTERNS.md`
+- `CONTINUITY_AND_DECAY.md`
+- `RESURFACING_HEURISTICS.md`
+- `TEMPORAL_OVERLAYS.md`
+- `EPISTEMIC_EVOLUTION.md`
 - `COGNITIVE_OBJECTS.md`
 - `TEMPORAL_PROVENANCE.md`
 
+## Conceptual hierarchy
+- `SYSTEM_OVERVIEW.md` defines overall architectural posture and invariants.
+- `TEMPORAL_COGNITION.md`, `ATTENTION_MODEL.md`, and `SALIENCE_AND_TENSION.md` define the top-level semantic frame.
+- `COGNITIVE_TRAJECTORIES.md`, `CONTINUITY_AND_DECAY.md`, `ATTENTIONAL_PHYSICS.md`, `TENSION_PATTERNS.md`, `RESURFACING_HEURISTICS.md`, `TEMPORAL_OVERLAYS.md`, and `EPISTEMIC_EVOLUTION.md` own the newer temporal vocabulary.
+- `COGNITIVE_OBJECTS.md`, `TEMPORAL_PROVENANCE.md`, and `POSTURE_TRANSITIONS.md` define object, lineage, and transition relationships across that frame.
+
 ## Lightweight glossary (canonical terminology)
 - **Cognitive posture:** a temporary emphasis of cognition (orientation, exploration, synthesis, review, recovery), not a locked UI mode.
+- **Cognitive trajectory:** a continuity-bearing line of thought across time, interruption, and resurfacing.
 - **Overlay:** a continuity surface layered on the active document, never a hidden semantic store.
+- **Temporal overlay:** an overlay whose purpose is temporal continuity rather than navigation chrome.
 - **Resurfacing:** contextual return of latent material based on relevance, salience, and provenance.
+- **Resurfacing heuristic:** a bounded rule for when dormant material should return without becoming notification pressure.
 - **Provenance:** traceable lineage of why content is shown, suggested, or resurfaced.
+- **Epistemic evolution:** change in understanding, confidence, framing, or interpretation over time.
 - **Interruption recovery:** explicit re-entry support that restores trajectory without synthetic recap drift.
+- **Continuity payload:** the minimal context package required for low-cost cognitive re-entry.
+- **Latency ladder:** the ordered increase in reconstruction effort as a trajectory cools or decays.
 - **Salience:** evolving attentional relevance, not a static priority flag.
+- **Salience gradient:** relative difference in attentional pull across nearby cognitive objects.
+- **Attentional weight:** how much attention an object meaningfully deserves in context.
+- **Attentional gravity:** the tendency of some objects or tensions to pull attention back over time.
 - **Cognitive tension:** unresolved pressure (question, contradiction, decision debt) that should remain visible until resolved.
+- **Dormant pressure:** unresolved tension that is not focal now but still capable of resurfacing later.
+- **Decay:** loss of continuity, retrievability, or interpretive clarity over time.
 - **Cognitive object:** a meaning-bearing unit (thread, proposal, provenance card, tension marker) that can be reasoned about across time.
+
+## Terminology boundary
+- Terms such as `gravity`, `payload`, `ladder`, and `temperature` may be used as helpful metaphors, but the architecture remains defined by explicit semantics, not by metaphor alone.

--- a/companion-ui/docs/RESURFACING_HEURISTICS.md
+++ b/companion-ui/docs/RESURFACING_HEURISTICS.md
@@ -1,0 +1,34 @@
+# Resurfacing Heuristics
+
+## Purpose
+Define when and why dormant material should return to attention.
+
+## Metaphor boundary
+- `Heuristic` here means bounded architectural guidance, not hidden ranking machinery or implementation scoring.
+
+## Core rule
+- Resurfacing is contextual return, not notification delivery.
+
+## Heuristic signals
+- Meaningful salience increase
+- Unresolved tension with renewed relevance
+- Interruption return to an interrupted trajectory
+- New provenance or epistemic change affecting prior understanding
+- Downstream dependency on a dormant trajectory
+
+## Negative heuristics
+- Do not resurface only because something is old.
+- Do not resurface low-provenance material as strong guidance.
+- Do not resurface in ways that displace the anchor document.
+- Do not convert resurfacing into chat-centric or badge-centric pressure.
+
+## Contextual resurfacing
+- Prefer warm trajectories over cold ones when several candidates are relevant.
+- Prefer unresolved synthesis over generic historical recap.
+- Favor ambient resurfacing when attentional load is already high.
+
+## Related docs
+- `SALIENCE_AND_TENSION.md`
+- `ATTENTIONAL_PHYSICS.md`
+- `COGNITIVE_TRAJECTORIES.md`
+- `EPISTEMIC_EVOLUTION.md`

--- a/companion-ui/docs/SALIENCE_AND_TENSION.md
+++ b/companion-ui/docs/SALIENCE_AND_TENSION.md
@@ -1,17 +1,24 @@
 # Salience and Tension
 
 ## Purpose
-Define how attentional relevance and unresolved cognitive pressure evolve over time.
+Define how attentional relevance and unresolved cognitive pressure evolve over time while keeping salience and tension distinct from notification urgency or simple priority schemes.
+
+## Boundary note
+- This document defines the top-level relationship between salience and tension.
+- `TENSION_PATTERNS.md` owns the deeper taxonomy of unresolved pressure.
+- `RESURFACING_HEURISTICS.md` owns when salience and tension should trigger contextual return.
 
 ## Salience semantics
 - Salience is the evolving relevance of a cognitive object to current or near-future thinking.
 - Salience is temporal, contextual, and revisable.
 - Salience is not equivalent to static priority.
+- Salience may vary by gradient, not only by binary relevance.
 
 ## Tension semantics
 - Cognitive tension is unresolved pressure in a thread.
 - Typical tension forms: unanswered question, contradiction, deferred decision, incomplete synthesis.
 - Tension should remain visible until explicitly resolved, reframed, or retired.
+- Dormant pressure is unresolved tension that is not focal now but still capable of future resurfacing.
 
 ## Evolution model
 - Objects can rise in salience via new context, interruption return, or downstream dependency.
@@ -22,6 +29,7 @@ Define how attentional relevance and unresolved cognitive pressure evolve over t
 - Resurfacing should target unresolved tension and meaningful salience shifts.
 - Low-provenance resurfacing should be treated as weak guidance.
 - Salience promotion should preserve trajectory continuity, not reset context.
+- Tension without continuity context should not be amplified into interruption-heavy interaction.
 
 ## Design constraints
 - Do not collapse salience into rigid score-only logic.
@@ -31,5 +39,8 @@ Define how attentional relevance and unresolved cognitive pressure evolve over t
 ## Related docs
 - `ATTENTION_MODEL.md`
 - `TEMPORAL_COGNITION.md`
+- `COGNITIVE_TRAJECTORIES.md`
+- `TENSION_PATTERNS.md`
+- `RESURFACING_HEURISTICS.md`
 - `COGNITIVE_OBJECTS.md`
 - `TEMPORAL_PROVENANCE.md`

--- a/companion-ui/docs/SYSTEM_OVERVIEW.md
+++ b/companion-ui/docs/SYSTEM_OVERVIEW.md
@@ -8,18 +8,21 @@
 - Companion UI augments human cognition; it does not replace human reasoning.
 - AI remains contextual, provenance-aware, and subordinate to document-centered work.
 - Interaction stays document-first and overlay-first.
+- The system should behave as a cognitive prosthesis and continuity-preserving cognition environment for continuity of thought, not as a productivity dashboard, task system, or AI workspace.
 
 ## Cognitive architecture baseline
 - Document is the cognitive anchor.
 - Overlays are continuity surfaces, not separate semantic worlds.
 - Cognitive postures replace hard mode framing.
+- Cognitive trajectories replace session-fragmented thinking as the main temporal frame.
 - Resurfacing is contextual and provenance-aware.
 - Attention and interruption semantics are explicit.
+- Low attentional load is a design constraint, not an optimization after the fact.
 - Hidden semantic state is prohibited.
 
 ## System boundary
 - In scope: interaction architecture, design artifacts, UI prototyping, prompts, and implementation staging.
-- Out of scope here: production backend integrations, hidden persistence systems, and dashboard-style autonomous AI UX.
+- Out of scope here: production backend integrations, hidden persistence systems, dashboard-style autonomous AI UX, notification-centric interaction design, and implementation-coupled runtime modeling.
 
 ## Runtime relationship
 - Companion UI is a client to the existing runtime (FastAPI + event surfaces).
@@ -37,5 +40,6 @@
 - `COGNITIVE_PRINCIPLES.md`
 - `INTERACTION_PRINCIPLES.md`
 - `TEMPORAL_COGNITION.md`
+- `COGNITIVE_TRAJECTORIES.md`
 - `ATTENTION_MODEL.md`
 - `COGNITIVE_OBJECTS.md`

--- a/companion-ui/docs/TEMPORAL_COGNITION.md
+++ b/companion-ui/docs/TEMPORAL_COGNITION.md
@@ -3,10 +3,17 @@
 ## Purpose
 Define how cognition is preserved across time in a document-first, interruption-prone workflow.
 
+## Boundary note
+- This document is the top-level temporal contract.
+- `COGNITIVE_TRAJECTORIES.md` defines trajectory states and transitions.
+- `CONTINUITY_AND_DECAY.md` defines continuity payloads, interruption cost, decay, and reconstruction effort.
+- `EPISTEMIC_EVOLUTION.md` defines how understanding changes across time.
+
 ## Temporal cognition model
 - Cognition unfolds as a trajectory, not isolated sessions.
 - Each trajectory moves through active, latent, and resurfaced phases.
 - Time changes meaning: relevance, urgency, and interpretation evolve.
+- Temporal cognition is about continuity of understanding, not just continuity of session state.
 
 ## Core concepts
 - **Active thread:** currently attended trajectory.
@@ -14,6 +21,7 @@ Define how cognition is preserved across time in a document-first, interruption-
 - **Re-entry window:** period where minimal cues can recover full context.
 - **Cognitive decay:** loss of context fidelity over time when cues are weak.
 - **Continuity residue:** preserved traces (anchors, provenance, tension markers) that support recovery.
+- **Continuity payload:** the minimal reconstructive package required for low-cost re-entry.
 
 ## Temporal invariants
 - Document remains the cognitive anchor across all temporal phases.
@@ -33,7 +41,10 @@ Define how cognition is preserved across time in a document-first, interruption-
 
 ## Related docs
 - `ATTENTION_MODEL.md`
+- `COGNITIVE_TRAJECTORIES.md`
+- `CONTINUITY_AND_DECAY.md`
 - `POSTURE_TRANSITIONS.md`
 - `SALIENCE_AND_TENSION.md`
+- `EPISTEMIC_EVOLUTION.md`
 - `TEMPORAL_PROVENANCE.md`
 - `COGNITIVE_FAILURE_MODES.md`

--- a/companion-ui/docs/TEMPORAL_OVERLAYS.md
+++ b/companion-ui/docs/TEMPORAL_OVERLAYS.md
@@ -1,0 +1,33 @@
+# Temporal Overlays
+
+## Purpose
+Define overlays whose role is preserving continuity across time rather than simply exposing controls.
+
+## Metaphor boundary
+- `Temporal overlay` is an architectural classification.
+- It does not imply background automation, notification feeds, or hidden timing state.
+
+## Canonical temporal overlay functions
+- Re-entry cueing
+- Continuity payload exposure
+- Provenance glanceability
+- Resurfacing without route replacement
+- Decay mitigation through compact context reconstruction
+
+## Rules
+- Temporal overlays must preserve the document as anchor.
+- Temporal overlays must be dismissible without semantic loss.
+- Temporal overlays must reduce interruption cost, not amplify it.
+- Temporal overlays must not become notification-centric or dashboard-like.
+- Temporal overlays must not hide meaning-bearing state from the vault.
+
+## Examples of temporal overlay roles
+- Recovery strip showing prior intent and unresolved tension
+- Provenance peek explaining why something resurfaced now
+- Compact continuity card for warm trajectory re-entry
+
+## Related docs
+- `OVERLAY_GRAMMAR.md`
+- `CONTINUITY_AND_DECAY.md`
+- `TEMPORAL_PROVENANCE.md`
+- `ATTENTIONAL_PHYSICS.md`

--- a/companion-ui/docs/TEMPORAL_PROVENANCE.md
+++ b/companion-ui/docs/TEMPORAL_PROVENANCE.md
@@ -7,6 +7,7 @@ Define provenance semantics that preserve trust and continuity across time, inte
 - **Source lineage:** where a claim or suggestion originates.
 - **Temporal lineage:** when and in what sequence context changed.
 - **Interpretive lineage:** why an object was surfaced, staged, or deferred.
+- **Evolution lineage:** how understanding or confidence changed across the life of a trajectory.
 
 ## Provenance requirements
 - Resurfaced objects must include enough lineage for rapid trust evaluation.
@@ -17,6 +18,7 @@ Define provenance semantics that preserve trust and continuity across time, inte
 - Historical validity and current validity can diverge; provenance must keep both intelligible.
 - Provenance should survive salience decay and thread dormancy.
 - Provenance should remain inspectable without forcing deep navigation.
+- Provenance should support epistemic evolution without pretending that later framing erases earlier states.
 
 ## Re-entry semantics
 - Re-entry cues should state prior intent, unresolved tension, and recent lineage.
@@ -27,4 +29,5 @@ Define provenance semantics that preserve trust and continuity across time, inte
 - `TEMPORAL_COGNITION.md`
 - `COGNITIVE_OBJECTS.md`
 - `ATTENTION_MODEL.md`
+- `EPISTEMIC_EVOLUTION.md`
 - `COGNITIVE_FAILURE_MODES.md`

--- a/companion-ui/docs/TENSION_PATTERNS.md
+++ b/companion-ui/docs/TENSION_PATTERNS.md
@@ -1,0 +1,32 @@
+# Tension Patterns
+
+## Purpose
+Define the recurring shapes of unresolved cognitive pressure.
+
+## Metaphor boundary
+- `Pressure` is a semantic shorthand for unresolved cognitive force.
+- It does not imply that the UI should behave like an alerting system.
+
+## Canonical patterns
+- **Question tension:** open inquiry without stable answer.
+- **Contradiction tension:** conflicting claims, framings, or sources remain unresolved.
+- **Decision tension:** a choice boundary exists but has not been accepted.
+- **Synthesis tension:** multiple pieces are present but not yet coherently integrated.
+- **Deferred tension:** resolution is intentionally postponed.
+- **Dormant pressure:** unresolved tension is inactive now but remains resurfacing-relevant.
+
+## Behavioral rules
+- Tension should stay legible until resolved, reframed, retired, or explicitly deprioritized.
+- Dormant pressure should not disappear merely because it is not currently focal.
+- Resurfacing should privilege unresolved synthesis and contradiction over low-value repetition.
+
+## Failure risks
+- Tension burial hides meaningful unresolved work.
+- Artificial urgency overloads attention.
+- Missing provenance weakens confidence in whether the tension is still real.
+
+## Related docs
+- `SALIENCE_AND_TENSION.md`
+- `RESURFACING_HEURISTICS.md`
+- `COGNITIVE_TRAJECTORIES.md`
+- `TEMPORAL_PROVENANCE.md`

--- a/companion-ui/docs/UI_RUNTIME_BOUNDARIES.md
+++ b/companion-ui/docs/UI_RUNTIME_BOUNDARIES.md
@@ -15,7 +15,8 @@
 - Document remains the cognitive anchor.
 - Overlays preserve continuity and provenance visibility.
 - AI remains contextual rather than dominant.
-- No runtime contract should require chat-centric or dashboard-centric interaction.
+- No runtime contract should require chat-centric, dashboard-centric, or notification-centric interaction.
+- No interface contract should depend on hidden semantic state for continuity recovery.
 
 ## Integration boundary (future-safe)
 - Keep transport and event contracts explicit.
@@ -26,4 +27,5 @@
 ## Related docs
 - `SYSTEM_OVERVIEW.md`
 - `EVENT_MODEL_SUMMARY.md`
+- `CONTINUITY_AND_DECAY.md`
 - `TEMPORAL_PROVENANCE.md`


### PR DESCRIPTION
Fixes #815

## Summary
Consolidates the companion-ui cognitive architecture docs around temporal cognition, continuity, trajectories, attentional semantics, and epistemic evolution.

## Changes
- Added seven new concept docs for trajectories, attentional physics, continuity and decay, tension patterns, resurfacing heuristics, temporal overlays, and epistemic evolution.
- Refactored the existing companion semantic docs so the top-level contracts are cleaner and the newer vocabulary has explicit ownership instead of being duplicated across multiple files.
- Expanded the companion glossary and hierarchy notes to distinguish architectural semantics from metaphorical UX language while preserving the system's document-first, low-attentional-load, non-dashboard posture.

## Validation
- `python3 scripts/docs_guard.py` (pass)
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/architecture/test_docs_index.py::test_all_docs_are_listed_in_docs_index` (pass)

---