### PR TITLE
docs(human-flows): ground memory compilation in core functions

### DIFF
--- a/docs/HUMAN-FLOWS.md
+++ b/docs/HUMAN-FLOWS.md
@@ -174,6 +174,12 @@ This includes:
 Knowledge development is one function among several.
 It must not erase the existence of creative, reflective, or commitment-oriented material.
 
+### Compile and curate memory
+
+The system should help the human compile and curate memory by weaving together `Source -> interpret -> stabilize`, `Capture -> clarify -> place`, `Review -> reclassify -> promote/archive`, and `Retrieve -> orient -> act`.
+Compilation should reduce cognitive load while preserving human authorship, provenance, uncertainty, and review posture across the resulting working artifacts.
+Generated compiled artifacts are not automatically canonical truth; they remain reviewable outputs until the human decides what to keep, promote, revise, or archive.
+
 ### Support commitments and action
 
 The system must help the human manage open loops, commitments, projects, waiting states, and next


### PR DESCRIPTION
Fixes #805

## Summary
- add a concise `Compile and curate memory` subsection under Core human functions in `docs/HUMAN-FLOWS.md`
- connect compilation and curation to the existing canonical human loops while preserving authorship, provenance, uncertainty, and review posture
- state explicitly that generated compiled artifacts are not automatically canonical truth

## Validation
- `python3 scripts/docs_guard.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m \"not pg\"`  
  fails during collection on pre-existing duplicate test-module basenames (`tests/retrieval/test_context_dimension_threading.py` vs `tests/orientation/test_context_dimension_threading.py`, and `tests/test_write_guard.py` vs `tests/services/test_write_guard.py`)
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q --import-mode=importlib -m \"not pg\"`  
  passes (`2552 passed, 102 skipped, 9 deselected`)