### PR TITLE
Add fail-closed coverage for compiled settings

### DIFF
--- a/app/settings/validate.py
+++ b/app/settings/validate.py
@@ -35,6 +35,8 @@ class ValidationIssue:
 
 _ACTION_ID_PATTERN = re.compile(r"^[a-z0-9]+(?:[._-][a-z0-9]+)*$")
 _MEASUREMENT_ONLY_ACTIONS = {"ingest.summary.create"}
+_MISSING_SECRET_PREFIX = "missing:"
+COMPILED_RUNTIME_DIR = Path("runtime/settings")
 
 
 def _panel_action_catalog_paths() -> list[Path]:
@@ -182,6 +184,53 @@ def _validate_panel_action_wiring() -> list[ValidationIssue]:
         return [ValidationIssue(code="panel_wiring.invalid", message=str(exc), ref="panel_wiring")]
 
 
+def _iter_missing_secret_refs(payload: Any, *, prefix: str = "") -> list[tuple[str, str]]:
+    hits: list[tuple[str, str]] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            child = f"{prefix}.{key}" if prefix else str(key)
+            hits.extend(_iter_missing_secret_refs(value, prefix=child))
+        return hits
+    if isinstance(payload, list):
+        for idx, value in enumerate(payload):
+            child = f"{prefix}[{idx}]"
+            hits.extend(_iter_missing_secret_refs(value, prefix=child))
+        return hits
+    if isinstance(payload, str) and payload.startswith(_MISSING_SECRET_PREFIX):
+        hits.append((prefix or "<root>", payload))
+    return hits
+
+
+def _validate_compiled_runtime_settings() -> list[ValidationIssue]:
+    issues: list[ValidationIssue] = []
+    if not COMPILED_RUNTIME_DIR.exists():
+        return issues
+    for path in sorted(COMPILED_RUNTIME_DIR.rglob("*.yaml")):
+        try:
+            payload = load_wiring_yaml(path)
+        except Exception as exc:
+            issues.append(
+                ValidationIssue(
+                    code="runtime_settings.invalid_yaml",
+                    message=f"{path}: failed to load compiled runtime settings: {exc}",
+                    ref=f"runtime_settings:{path.name}",
+                )
+            )
+            continue
+        for keypath, value in _iter_missing_secret_refs(payload):
+            issues.append(
+                ValidationIssue(
+                    code="runtime_settings.missing_secret",
+                    message=(
+                        f"{path}: unresolved secret placeholder at {keypath} -> {value}. "
+                        "Missing secrets must not silently become active credentials."
+                    ),
+                    ref=f"runtime_settings:{path.name}:{keypath}",
+                )
+            )
+    return issues
+
+
 def validate_settings() -> List[ValidationIssue]:
     issues: List[ValidationIssue] = []
 
@@ -320,6 +369,7 @@ def validate_settings() -> List[ValidationIssue]:
                     ref="watcher_settings:auto_run",
                 )
             )
+    issues.extend(_validate_compiled_runtime_settings())
     return issues
 
 

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -28,7 +28,9 @@ Primary source folder:
 Compiler:
 - `python -m app.cli settings compile`
 
-Runtime settings cover the panel action catalog and watcher policy; provenance (path/mtime/sha) and precedence follow the vault-first compiler plus `python -m app.cli settings-validate` / `python -m app.cli settings-explain` and are also surfaced in `python -m app.cli status --json` under `panel_diagnostics` and `watcher_automation`.
+Runtime settings cover the panel action catalog, watcher policy, and compiled runtime bundles under `runtime/settings/`.
+Today, `python -m app.cli settings-explain` is a narrow operator-facing diagnostics surface for environment/database state plus panel-action and watcher provenance/gating; it is not a full dump of every compiled runtime YAML.
+Compiled bundle files such as `runtime/settings/llm_routing.yaml` remain the direct artifact for the broader runtime payload, while `python -m app.cli settings-validate` checks registries, panel/watcher source artifacts, and any compiled-runtime unresolved-secret sentinels visible locally.
 They also include task-specific LLM routing policy via `vault/@Settings/llm_routing.md` -> `runtime/settings/llm_routing.yaml`.
 
 Settings tiering guidance (operator-facing vs dev/lab-only), inventory, and migration targets are described below.
@@ -43,7 +45,7 @@ The active settings model separates:
 Core rules:
 - normal runtime defaults to `PKM_SETTINGS_PROFILE=operator`
 - lab/experimental controls require explicit `PKM_SETTINGS_PROFILE=lab`
-- provenance and precedence should remain visible through `settings-validate` and `settings-explain`
+- provenance and precedence should remain inspectable, with `settings-explain` focused on watcher/panel operator diagnostics and `settings-validate` covering registry/source consistency plus local unresolved-secret checks
 
 High-impact examples:
 - Operator-facing:
@@ -144,7 +146,7 @@ Events are settings-backed artifacts:
 The registry lists canonical event IDs, producers/consumers, and optional schema refs. Other registries (e.g., graphs) must reference these IDs.
 
 ## Operational guidance
-- Use `python -m app.cli settings-validate --json` to validate compiled settings and registry consistency.
-- Use `python -m app.cli settings-explain --json` to inspect precedence and provenance.
+- Use `python -m app.cli settings-validate --json` to validate registries, panel/watcher source artifacts, and locally compiled unresolved-secret sentinels.
+- Use `python -m app.cli settings-explain --json` to inspect environment/database resolution plus watcher/panel provenance and gate state.
 - When changing a registry or settings artifact, update the owning doc and validation expectations in the same change.
 - Treat `vault/@Settings/llm_routing.md` as the user-facing source of truth for chat, reasoning, embedding, and eval model choices. The compiler derives providers from the model registry.

--- a/tests/settings/test_compile.py
+++ b/tests/settings/test_compile.py
@@ -70,3 +70,53 @@ def test_compile_includes_panel_and_watcher_metadata(tmp_path: Path, monkeypatch
     source = watchers_yaml["source"]
     assert source.get("path", "").endswith("watchers.md")
     assert source.get("sha256")
+
+
+def test_compile_marks_missing_secret_placeholders_explicitly(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    vault = tmp_path / "vault" / "@Settings"
+    runtime_dir = tmp_path / "runtime" / "settings"
+    vault.mkdir(parents=True, exist_ok=True)
+
+    (vault / "global.md").write_text(
+        "---\n"
+        "uuid: global\n"
+        "---\n"
+        "## Runtime\n"
+        "```yaml settings\n"
+        "secrets:\n"
+        "  api_token: ${SECRET:API_TOKEN}\n"
+        "```\n",
+        encoding="utf-8",
+    )
+    (vault / "providers.md").write_text(
+        "---\n"
+        "uuid: providers\n"
+        "---\n"
+        "## Providers\n"
+        "```yaml settings\n"
+        "llm: {}\n"
+        "```\n",
+        encoding="utf-8",
+    )
+    (vault / "llm_routing.md").write_text(
+        "---\n"
+        "uuid: routing\n"
+        "---\n"
+        "## Routing\n"
+        "```yaml settings\n"
+        "default_chat:\n"
+        "  primary:\n"
+        "    model_id: openai.chat.gpt_5_4_mini\n"
+        "```\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.delenv("API_TOKEN", raising=False)
+    monkeypatch.setattr(compiler, "VAULT", vault)
+    monkeypatch.setattr(compiler, "RUNTIME", runtime_dir)
+
+    bundle = compiler.compile_all(auto_heal=False)
+
+    assert bundle.global_.secrets["api_token"] == "missing:API_TOKEN"
+    global_yaml = yaml.safe_load((runtime_dir / "global.yaml").read_text(encoding="utf-8"))
+    assert global_yaml["secrets"]["api_token"] == "missing:API_TOKEN"

--- a/tests/settings/test_runtime.py
+++ b/tests/settings/test_runtime.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import yaml
 import pytest
 
+from app.events import bus
 from app.settings import runtime
-from app.settings.models import QaSettings
+from app.settings.models import EmbeddingProfiles
 
 pytestmark = pytest.mark.not_pg
 
@@ -12,6 +13,12 @@ pytestmark = pytest.mark.not_pg
 def _write_yaml(path, data):
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(yaml.safe_dump(data, sort_keys=True), encoding="utf-8")
+
+
+def _reset_runtime(monkeypatch, runtime_dir):
+    monkeypatch.setattr(runtime, "RUNTIME", runtime_dir)
+    monkeypatch.setattr(runtime, "_SUBSCRIBERS", [])
+    monkeypatch.setattr(runtime, "_CURRENT", None)
 
 
 def test_runtime_subscriber_gets_updates(tmp_path, monkeypatch):
@@ -25,9 +32,7 @@ def test_runtime_subscriber_gets_updates(tmp_path, monkeypatch):
     )
     _write_yaml(agents_dir / "qa.yaml", {"llm": {"provider": "mock"}})
 
-    monkeypatch.setattr(runtime, "RUNTIME", runtime_dir)
-    monkeypatch.setattr(runtime, "_SUBSCRIBERS", [])
-    monkeypatch.setattr(runtime, "_CURRENT", None)
+    _reset_runtime(monkeypatch, runtime_dir)
 
     seen = []
 
@@ -73,9 +78,7 @@ def test_runtime_loads_llm_routing_settings(tmp_path, monkeypatch):
         },
     )
 
-    monkeypatch.setattr(runtime, "RUNTIME", runtime_dir)
-    monkeypatch.setattr(runtime, "_SUBSCRIBERS", [])
-    monkeypatch.setattr(runtime, "_CURRENT", None)
+    _reset_runtime(monkeypatch, runtime_dir)
 
     bundle = runtime.reload_settings_bundle(notify=False)
 
@@ -83,3 +86,50 @@ def test_runtime_loads_llm_routing_settings(tmp_path, monkeypatch):
     assert bundle.llm_routing.default_chat.primary.model_id == "openai.chat.gpt_5_4_mini"
     assert bundle.llm_routing.default_chat.fallback.mode == "local"
     assert bundle.llm_routing.default_embedding.require_compatible_identity is True
+
+
+def test_runtime_defaults_invalid_optional_compiled_settings(tmp_path, monkeypatch):
+    runtime_dir = tmp_path / "runtime/settings"
+    _write_yaml(runtime_dir / "global.yaml", {})
+    _write_yaml(runtime_dir / "providers.yaml", {})
+    _write_yaml(runtime_dir / "llm_routing.yaml", {})
+    _write_yaml(runtime_dir / "embeddings.yaml", {"profiles": {"default": {"dim": "invalid"}}})
+    _write_yaml(runtime_dir / "instance.yaml", {"id": "laptop", "role": "invalid"})
+    _write_yaml(runtime_dir / "yggdrasil.yaml", {"yggdrasil_root": "/tmp/ygg", "mimer_root": ["invalid"]})
+
+    _reset_runtime(monkeypatch, runtime_dir)
+
+    bundle = runtime.reload_settings_bundle(notify=False)
+
+    assert bundle.embedding_profiles == EmbeddingProfiles()
+    assert bundle.instance.id == "home"
+    assert bundle.instance.role == "master"
+    assert bundle.yggdrasil_paths is None
+
+
+def test_hot_reload_keeps_last_good_bundle_on_invalid_update(tmp_path, monkeypatch):
+    runtime_dir = tmp_path / "runtime/settings"
+    _write_yaml(runtime_dir / "global.yaml", {"log_level": "INFO"})
+    _write_yaml(runtime_dir / "providers.yaml", {})
+    _write_yaml(
+        runtime_dir / "llm_routing.yaml",
+        {"default_chat": {"primary": {"provider": "openai", "model": "gpt-5.4-mini"}}},
+    )
+
+    _reset_runtime(monkeypatch, runtime_dir)
+    bus.clear("settings.changed")
+    bus.subscribe("settings.changed", runtime._handle_hot_reload)
+
+    runtime.reload_settings_bundle(notify=False)
+    before = runtime.get_settings_bundle()
+
+    seen: list[str] = []
+    runtime.subscribe_settings(lambda bundle: seen.append(bundle.global_.log_level), replay=False)
+
+    _write_yaml(runtime_dir / "llm_routing.yaml", {"default_chat": {"primary": "invalid"}})
+    bus.emit("settings.changed", {"sha": "bad-update"})
+
+    after = runtime.get_settings_bundle()
+    assert after.global_.log_level == before.global_.log_level
+    assert after.llm_routing.default_chat.primary.provider == before.llm_routing.default_chat.primary.provider
+    assert seen == []

--- a/tests/settings/test_validate_settings.py
+++ b/tests/settings/test_validate_settings.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+import app.settings.validate as validate_module
 from app.settings.validate import validate_settings
 
 
@@ -23,3 +24,20 @@ def test_validate_settings_includes_watcher_unknown_action(tmp_path: Path, monke
 
     issues = validate_settings()
     assert any(issue.code == "watcher_settings.unknown_action" for issue in issues)
+
+
+def test_validate_settings_flags_missing_secret_in_compiled_runtime(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime_dir = tmp_path / "runtime" / "settings"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    (runtime_dir / "global.yaml").write_text(
+        "secrets:\n  api_token: missing:API_TOKEN\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(validate_module, "COMPILED_RUNTIME_DIR", runtime_dir)
+
+    issues = validate_settings()
+
+    assert any(issue.code == "runtime_settings.missing_secret" for issue in issues)


### PR DESCRIPTION
Fixes #798

## Summary
Add executable coverage for unresolved secret placeholder handling, fail-closed fallback on invalid optional compiled settings, and hot-reload retention of the last good bundle.
Narrow `docs/SETTINGS.md` so `settings-explain` and `settings-validate` claims match the current diagnostics surface.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/settings/test_compile.py tests/settings/test_runtime.py tests/settings/test_validate_settings.py tests/cli/test_settings_explain_cli.py tests/cli/test_settings_validate_cli.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/settings`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/cli -k settings`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m \"not pg\"` *(blocked by pre-existing import-file-mismatch collection errors in `tests/orientation/test_context_dimension_threading.py` vs `tests/retrieval/test_context_dimension_threading.py`, and `tests/services/test_write_guard.py` vs `tests/test_write_guard.py`)*
- `ruff check app/settings/validate.py tests/settings/test_compile.py tests/settings/test_runtime.py tests/settings/test_validate_settings.py` *(not runnable here: `ruff` is not installed on PATH and `python3 -m ruff` is unavailable)*

---