### PR TITLE
ci: align pr-smoke lint and settings-validation checks

### DIFF
--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -52,6 +52,23 @@ jobs:
           if [ -f pyproject.toml ]; then pip install -e ".[dev]"; fi
           pip install pytest-xdist
 
+      - name: Lint (ruff)
+        run: |
+          ruff check app tests
+
+      - name: Validate settings
+        run: |
+          mkdir -p tmp
+          python -m app.cli settings-validate --json | tee tmp/settings-validate.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          payload = json.loads(Path("tmp/settings-validate.json").read_text(encoding="utf-8"))
+          if not payload.get("ok", False):
+              raise SystemExit(f"settings-validate failed: {payload}")
+          PY
+
       - name: Validate docs guardrails
         shell: bash
         run: |

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -184,7 +184,7 @@ Human-need acceptance scenarios should map onto those roles explicitly instead o
 Older overlapping workflows may still exist while the surface is being consolidated, but new coverage should map to these roles instead of adding more partial gates.
 
 Current implementation:
-- `.github/workflows/ci-smoke.yaml` — PR smoke with explicit system dependency parity (`ffmpeg`, `ripgrep`), split baseline pytest and deterministic Quality Wave UAT harness steps, and path-based skipping of the heavy pytest slices for docs-only PRs that do not touch code, tests, scripts, workflow, Docker, dependency, or Makefile surfaces.
+- `.github/workflows/ci-smoke.yaml` — PR smoke with explicit system dependency parity (`ffmpeg`, `ripgrep`), required `ruff check app tests` and `settings-validate` checks, split baseline pytest and deterministic Quality Wave UAT harness steps, and path-based skipping of the heavy pytest slices for docs-only PRs that do not touch code, tests, scripts, workflow, Docker, dependency, or Makefile surfaces.
 - `.github/workflows/integration-nightly.yaml` — full suite nightly at 02:00 UTC, explicit deterministic acceptance harness coverage via `tests/quality_wave/test_uat_harness.py`, first bounded PG contracts lane (`tests/int/test_pg_backend.py`, `tests/api/test_status_store_pg.py`, `tests/indexer/test_outbox_roundtrip_pg.py`), runtime contract regressions, and fitness gates.
 - `.github/workflows/release-uat.yaml` — UAT harness + golden vault + full QW suite + fitness gates; triggered on version tags and manual dispatch.
 


### PR DESCRIPTION
Fixes #781

## Summary
- add `ruff check app tests` to `.github/workflows/ci-smoke.yaml`
- add explicit `python -m app.cli settings-validate --json` gate in `ci-smoke`, including `ok` assertion from JSON payload
- update `docs/TESTING.md` to match the implemented `pr-smoke` ownership and checks

## Validation
- `.venv/bin/ruff check app tests`
- `PYTHONPATH=$(pwd) STORE_BACKEND=memory LLM_PROVIDER=mock REASONING_PROVIDER=mock PLANNER_PROVIDER=mock REASONING_ENABLE=1 .venv/bin/python -m app.cli settings-validate --json`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest -q -m "not pg"` *(fails during collection due pre-existing duplicate test module names: `tests/retrieval/test_context_dimension_threading.py` vs `tests/orientation/test_context_dimension_threading.py`, and `tests/test_write_guard.py` vs `tests/services/test_write_guard.py`)*