### PR TITLE
docs: cross-reference v6.x memory compilation in roadmap and plans (#806)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -70,6 +70,7 @@ This roadmap is forward-looking and skimmable. History lives in `docs/history/SO
     - Clarify authority across writing, retention, system, runtime, and execution-record surfaces so receipt-bearing actions remain inspectable.
     - Treat current domain/zone/mirror/promotion findings as current-state bug fixes or enabling changes unless a later implementation slice explicitly realizes the v6 target state.
   - `docs/plans/V60_COGNITIVE_SUPPORT_PRIORITIES.md` remains the active sequencing plan for turning the v6 capability specs into cognitive-support work. Priority 1 (salience/staleness), Priority 2 (scope/sphere/identity), Priority 3 (receipts plus SUGGEST/APPLY gating), and Priority 4 (retrieval capability extraction) are now closed on GitHub; Priority 5 (minimal commitment runtime) is now closed on GitHub (#688).
+  - **v6.x — Knowledge Compilation and Memory Curation** (follow-up after v6.0 structural separation): a bounded planning line for how the system supports knowledge compilation and memory curation over time, grounded in the `Capture -> clarify -> place`, `Retrieve -> orient -> act`, and `Review -> reclassify -> promote/archive` human loops from `docs/HUMAN-FLOWS.md`. Semantic boundaries, artifact classes, review/promotion posture, and suggested event families are defined in `docs/plans/V6X_KNOWLEDGE_COMPILATION_AND_MEMORY_CURATION.md` under parent feature #803. Implementation and test slices are not yet filed; no runtime behavior is claimed.
 
 ## Capability-Based Architecture & Agent Evolution
 

--- a/docs/plans/V60_CAPABILITY_AND_AGENT_EVOLUTION.md
+++ b/docs/plans/V60_CAPABILITY_AND_AGENT_EVOLUTION.md
@@ -38,6 +38,7 @@ The broader target operating model lives in `docs/plans/V60_ARCHITECTURE_TARGET.
 - `docs/ROADMAP.md` — high-level migration sequence.
 - `docs/STATUS.md` — present-tense operational posture.
 - `docs/plans/V60_ARCHITECTURE_TARGET.md` — broader v6 target operating model context.
+- `docs/plans/V6X_KNOWLEDGE_COMPILATION_AND_MEMORY_CURATION.md` — v6.x follow-up planning line for knowledge compilation and memory curation; not part of the v6.0 baseline, but a post-separation capability lane grounded in the human flows and retrieval/orientation/resurfacing capability split established here.
 
 ## Reading Order
 


### PR DESCRIPTION
## Summary

- Added `v6.x — Knowledge Compilation and Memory Curation` as a named follow-up item in `docs/ROADMAP.md` under the **Later** section, positioned after the v6.0 cognitive-support priorities line. Explicitly scoped as post-v6.0 separation; no runtime claims.
- Added a cross-reference entry for `docs/plans/V6X_KNOWLEDGE_COMPILATION_AND_MEMORY_CURATION.md` in the **Related Docs** section of `docs/plans/V60_CAPABILITY_AND_AGENT_EVOLUTION.md`, clearly noting it is a v6.x follow-up lane and not part of the v6.0 baseline.
- `docs/DOCS_INDEX.md` already contains an entry for the V6X plan doc at line 341 (added in #804). No change required — **DOCS_INDEX update: n/a (already present)**.

## Acceptance Criteria Verification

- `docs/ROADMAP.md` now names Knowledge Compilation and Memory Curation as a v6.x follow-up after v6.0 separation. ✓
- `docs/plans/V60_CAPABILITY_AND_AGENT_EVOLUTION.md` cross-references the v6.x plan doc without making it the v6.0 baseline. ✓
- `docs/DOCS_INDEX.md` tracks plan docs and already has the V6X entry; no additional change needed. ✓
- No language in changed sections claims implementation exists — grepped for 'shipped', 'delivered', 'implemented' in changed sections: no hits. ✓

## Test plan

- [ ] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg"` — two pre-existing collection errors (`test_context_dimension_threading.py`, `test_write_guard.py`) exist on main; not introduced by this change (verified by stash-pop check). Docs-only PR.
- [ ] Grep changed sections for false implementation claims: clean.

Fixes #806

Dispatcher unavailable — used GitHub-label-only claim. GraphQL rate limit exceeded — Project status update deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)