### PR TITLE
refactor(indexer): route embedding through component seam, remove allowlist exception (#811)

### DIFF
--- a/app/services/indexer.py
+++ b/app/services/indexer.py
@@ -6,8 +6,7 @@ import uuid as _uuid
 from datetime import datetime, timezone
 from typing import Dict
 
-from app.components.embeddings import get_embedding_identity
-from app.index.embeddings import llm_embed_text
+from app.components.embeddings import get_embedding_client
 from app.observability.tracer import start_span
 from app.outbox.events import DEFAULT_EMBEDDING_VIEW, emit_index_embedding_failed, emit_index_object_embedded
 from app.store.object_store import DomainObject, ObjectStore
@@ -73,18 +72,13 @@ def handle_ingest_object_created(obj: Dict[str, object]) -> None:
         )
     store.save_object(domain, emit_outbox=False, trace_id=trace_id)
 
-    identity = get_embedding_identity()
+    client = get_embedding_client()
+    identity = client.identity
     embedding: list[float] | None = None
     actual_dim: int | None = None
 
     try:
-        embedding = llm_embed_text(
-            text=content,
-            provider=identity.provider,
-            model=identity.model,
-            dim=identity.dim,
-            normalize=identity.normalize,
-        )
+        embedding = client.embed_text(content)
         actual_dim = len(embedding)
     except Exception as exc:
         actual_dim = _infer_dim_from_error(exc)

--- a/tests/architecture/test_component_boundaries.py
+++ b/tests/architecture/test_component_boundaries.py
@@ -21,7 +21,6 @@ FORBIDDEN_MODULE_PREFIXES = (
 # Intentional seams that may import low-level modules directly.
 ALLOWLISTED_IMPORTERS = {
     "app/components/",
-    "app/services/indexer.py",
 }
 
 
@@ -80,7 +79,6 @@ def test_high_level_layers_do_not_import_forbidden_low_level_modules_directly() 
 def test_allowlist_scope_covers_component_adapter_seams_only() -> None:
     assert ALLOWLISTED_IMPORTERS == {
         "app/components/",
-        "app/services/indexer.py",
     }
 
 


### PR DESCRIPTION
Fixes #811

## Summary
Routes `app/services/indexer.py` embedding calls through the canonical `app.components.embeddings` seam (`get_embedding_client`) instead of calling `llm_embed_text` from `app.index.embeddings` directly. Removes the corresponding allowlist exception from the component boundary test.

## Changes
- `app/services/indexer.py`: replace `get_embedding_identity()` + `llm_embed_text(...)` with `get_embedding_client()` and `client.embed_text(content)`. Embedding identity still available via `client.identity`.
- `tests/architecture/test_component_boundaries.py`: remove `"app/services/indexer.py"` from `ALLOWLISTED_IMPORTERS`; update the scope assertion test to match.

## Validation
- `grep -n "llm_embed_text|app.index.embeddings" app/services/indexer.py` → no matches ✓
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/architecture/test_component_boundaries.py` → 3 passed ✓
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/architecture/test_import_rules.py` → 4 passed ✓
- `ruff check app/services/indexer.py tests/architecture/test_component_boundaries.py` → All checks passed ✓

Note: Dispatcher unavailable (db_exists: false) — used GitHub-label-only claim. GraphQL rate limit exceeded — Project status update deferred.

---