### PR TITLE
feat(settings): gate env threshold overrides on lab/dev profile (#810)

### DIFF
--- a/app/settings/health_settings.py
+++ b/app/settings/health_settings.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from app.settings.source import SettingsSource, build_source
+from app.settings.tiering import is_lab_profile
 
 import yaml
 
@@ -105,7 +106,22 @@ def load_health_settings(
     *,
     vault_root: Path | None = None,
     env_getter: Callable[[str], str | None] | None = None,
+    profile_env: Mapping[str, str] | None = None,
 ) -> HealthSettingsLoadResult:
+    """Load health settings from vault-backed Markdown.
+
+    Env-var threshold overrides (``HEALTH_THRESHOLDS_*``) are only applied when
+    the active settings profile is ``lab`` (``PKM_SETTINGS_PROFILE=lab``).  In
+    operator/prod profiles the overrides are silently ignored so that accidental
+    env vars cannot alter production thresholds.
+
+    Args:
+        vault_root: Optional vault root path (resolved automatically when omitted).
+        env_getter: Callable used to look up environment variables (defaults to
+            ``os.getenv``).  Inject a custom mapping in tests.
+        profile_env: Mapping used to determine the active settings profile
+            (defaults to ``os.environ``).  Inject a custom mapping in tests.
+    """
     vault_root = vault_root or resolve_vault_root()
     target = vault_root / _settings_rel_path(vault_root)
     source = build_source(target)
@@ -129,15 +145,27 @@ def load_health_settings(
         status = "fail"
         active_settings = HealthSettingsV1.defaults()
     else:
-        overrides, override_errors = _apply_env_overrides(thresholds_candidate, env_getter)
-        if override_errors:
-            errors.extend(override_errors)
-            status = "fail"
-            active_settings = HealthSettingsV1.defaults()
+        # Env-var threshold overrides are a lab/dev-only capability.
+        # In operator/prod profiles they are suppressed unconditionally so that
+        # stray environment variables cannot silently alter production thresholds.
+        if is_lab_profile(profile_env):
+            overrides, override_errors = _apply_env_overrides(thresholds_candidate, env_getter)
+            if override_errors:
+                errors.extend(override_errors)
+                status = "fail"
+                active_settings = HealthSettingsV1.defaults()
+            else:
+                status = "ok"
+                active_settings = HealthSettingsV1(
+                    thresholds=overrides,
+                    incident_capture=incident_capture,
+                    policy=policy,
+                    incident_log_path=incident_log_path,
+                )
         else:
             status = "ok"
             active_settings = HealthSettingsV1(
-                thresholds=overrides,
+                thresholds=thresholds_candidate,
                 incident_capture=incident_capture,
                 policy=policy,
                 incident_log_path=incident_log_path,

--- a/docs/HEALTH.md
+++ b/docs/HEALTH.md
@@ -42,4 +42,30 @@ The command is wrapped with `@span("health.check")`, so health check runs are re
 ## CI behavior
 - `.github/workflows/smoke.yml` runs the dependency check with `LLM_PROVIDER=mock`.
 - Run `python -m app.cli health status --json` after manual ingestion to confirm `state` is `running` and that `catch_up_progress["processing_mode"]` is `idle` (or `replay` while the worker catches up).
+## Health threshold env-var overrides (lab profile only)
+
+The four `HEALTH_THRESHOLDS_*` environment variables can override the threshold
+values that are normally read from the vault settings file:
+
+| Variable | Field | Type |
+| --- | --- | --- |
+| `HEALTH_THRESHOLDS_OUTBOX_DEGRADE_OLDEST_AGE_S` | `outbox_degrade_oldest_age_s` | `float` |
+| `HEALTH_THRESHOLDS_OUTBOX_RECOVER_OLDEST_AGE_S` | `outbox_recover_oldest_age_s` | `float` |
+| `HEALTH_THRESHOLDS_DEGRADE_SAMPLES` | `degrade_samples` | `int` |
+| `HEALTH_THRESHOLDS_RECOVER_SAMPLES` | `recover_samples` | `int` |
+
+**These overrides are only applied when `PKM_SETTINGS_PROFILE=lab`.**
+In operator/prod profiles (the default) the variables are silently ignored,
+so accidental environment state cannot alter production thresholds.
+
+To use threshold overrides locally:
+
+```bash
+export PKM_SETTINGS_PROFILE=lab
+export HEALTH_THRESHOLDS_OUTBOX_DEGRADE_OLDEST_AGE_S=5.0
+python -m app.cli health status --json
+```
+
+An invalid value for any override (e.g. non-numeric string) causes the load to
+fail with `status: "fail"` and the runtime falls back to built-in defaults.
 <!-- SECTION:HEALTH:END -->

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -61,6 +61,7 @@ High-impact examples:
   - `STORE_BACKEND`
   - watcher performance-tuning knobs
   - pipeline/decider/orchestrator/reasoning feature flags
+  - `HEALTH_THRESHOLDS_*` env-var threshold overrides (see `docs/HEALTH.md`)
 
 Target behavior:
 - operator mode should read/apply only operator-facing settings

--- a/tests/settings/test_health_settings.py
+++ b/tests/settings/test_health_settings.py
@@ -1,0 +1,233 @@
+"""Tests for app.settings.health_settings.
+
+Covers:
+- Missing settings file returns defaults with status "missing"
+- Malformed YAML / missing thresholds returns status "fail" with defaults
+- Valid thresholds load correctly
+- Env-var threshold overrides applied only when PKM_SETTINGS_PROFILE=lab
+- Env-var threshold overrides suppressed in operator/prod profile
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from app.settings.health_settings import (
+    HealthSettingsV1,
+    load_health_settings,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_VALID_FRONTMATTER = dedent("""\
+    ---
+    thresholds:
+      outbox_degrade_oldest_age_s: 20.0
+      outbox_recover_oldest_age_s: 8.0
+      degrade_samples: 4
+      recover_samples: 12
+    ---
+    # Health Settings
+""")
+
+_MISSING_THRESHOLD_FRONTMATTER = dedent("""\
+    ---
+    thresholds:
+      outbox_degrade_oldest_age_s: 20.0
+      outbox_recover_oldest_age_s: 8.0
+      degrade_samples: 4
+    ---
+""")
+
+_NO_THRESHOLD_BLOCK_FRONTMATTER = dedent("""\
+    ---
+    incident_capture:
+      enabled: false
+    ---
+""")
+
+
+def _write_health_file(vault_root: Path, content: str) -> None:
+    """Write health.md at the expected vault path using VAULT_SYSTEM_DIR_REL=@System."""
+    health_dir = vault_root / "@System" / "Settings"
+    health_dir.mkdir(parents=True, exist_ok=True)
+    (health_dir / "health.md").write_text(content, encoding="utf-8")
+
+
+def _load(
+    vault_root: Path,
+    env_vars: dict[str, str] | None = None,
+    profile: str = "operator",
+) -> "HealthSettingsLoadResult":  # noqa: F821 – returned by load_health_settings
+    """Thin wrapper that injects deterministic env and profile mappings."""
+    env_map: dict[str, str] = {"PKM_SETTINGS_PROFILE": profile}
+    if env_vars:
+        env_map.update(env_vars)
+
+    return load_health_settings(
+        vault_root=vault_root,
+        env_getter=env_map.get,
+        profile_env=env_map,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Basic load behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_missing_file_returns_defaults(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("VAULT_SYSTEM_DIR_REL", "@System")
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    result = _load(vault)
+    assert result.status == "missing"
+    assert result.settings == HealthSettingsV1.defaults()
+    assert result.errors == []
+
+
+def test_valid_thresholds_load_ok(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("VAULT_SYSTEM_DIR_REL", "@System")
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _write_health_file(vault, _VALID_FRONTMATTER)
+
+    result = _load(vault)
+    assert result.status == "ok"
+    assert result.errors == []
+    t = result.settings.thresholds
+    assert t.outbox_degrade_oldest_age_s == 20.0
+    assert t.outbox_recover_oldest_age_s == 8.0
+    assert t.degrade_samples == 4
+    assert t.recover_samples == 12
+
+
+def test_missing_threshold_key_returns_fail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("VAULT_SYSTEM_DIR_REL", "@System")
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _write_health_file(vault, _MISSING_THRESHOLD_FRONTMATTER)
+
+    result = _load(vault)
+    assert result.status == "fail"
+    assert any("missing thresholds.recover_samples" in e for e in result.errors)
+    assert result.settings == HealthSettingsV1.defaults()
+
+
+def test_no_threshold_block_returns_fail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("VAULT_SYSTEM_DIR_REL", "@System")
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _write_health_file(vault, _NO_THRESHOLD_BLOCK_FRONTMATTER)
+
+    result = _load(vault)
+    assert result.status == "fail"
+    assert any("missing thresholds block" in e for e in result.errors)
+    assert result.settings == HealthSettingsV1.defaults()
+
+
+# ---------------------------------------------------------------------------
+# Env-var override policy
+# ---------------------------------------------------------------------------
+
+
+def test_env_overrides_applied_in_lab_profile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """HEALTH_THRESHOLDS_* env vars MUST take effect under PKM_SETTINGS_PROFILE=lab."""
+    monkeypatch.setenv("VAULT_SYSTEM_DIR_REL", "@System")
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _write_health_file(vault, _VALID_FRONTMATTER)
+
+    env_overrides = {
+        "HEALTH_THRESHOLDS_OUTBOX_DEGRADE_OLDEST_AGE_S": "99.0",
+        "HEALTH_THRESHOLDS_OUTBOX_RECOVER_OLDEST_AGE_S": "33.0",
+        "HEALTH_THRESHOLDS_DEGRADE_SAMPLES": "7",
+        "HEALTH_THRESHOLDS_RECOVER_SAMPLES": "20",
+    }
+    result = _load(vault, env_vars=env_overrides, profile="lab")
+
+    assert result.status == "ok"
+    assert result.errors == []
+    t = result.settings.thresholds
+    assert t.outbox_degrade_oldest_age_s == 99.0
+    assert t.outbox_recover_oldest_age_s == 33.0
+    assert t.degrade_samples == 7
+    assert t.recover_samples == 20
+
+
+def test_env_overrides_suppressed_in_operator_profile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """HEALTH_THRESHOLDS_* env vars MUST NOT alter thresholds in operator profile."""
+    monkeypatch.setenv("VAULT_SYSTEM_DIR_REL", "@System")
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _write_health_file(vault, _VALID_FRONTMATTER)
+
+    env_overrides = {
+        "HEALTH_THRESHOLDS_OUTBOX_DEGRADE_OLDEST_AGE_S": "999.0",
+        "HEALTH_THRESHOLDS_DEGRADE_SAMPLES": "99",
+    }
+    result = _load(vault, env_vars=env_overrides, profile="operator")
+
+    assert result.status == "ok"
+    assert result.errors == []
+    # Thresholds must reflect the file values, NOT the env overrides.
+    t = result.settings.thresholds
+    assert t.outbox_degrade_oldest_age_s == 20.0
+    assert t.degrade_samples == 4
+
+
+def test_env_overrides_suppressed_when_profile_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With no PKM_SETTINGS_PROFILE set, env overrides must be suppressed (defaults to operator)."""
+    monkeypatch.setenv("VAULT_SYSTEM_DIR_REL", "@System")
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _write_health_file(vault, _VALID_FRONTMATTER)
+
+    # Profile defaults to operator when not set; pass empty mapping.
+    result = load_health_settings(
+        vault_root=vault,
+        env_getter={"HEALTH_THRESHOLDS_OUTBOX_DEGRADE_OLDEST_AGE_S": "999.0"}.get,
+        profile_env={},  # no PKM_SETTINGS_PROFILE → resolves to operator
+    )
+
+    assert result.status == "ok"
+    t = result.settings.thresholds
+    assert t.outbox_degrade_oldest_age_s == 20.0
+
+
+def test_invalid_env_override_in_lab_returns_fail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bad env-var value in lab mode must cause status='fail' and return defaults."""
+    monkeypatch.setenv("VAULT_SYSTEM_DIR_REL", "@System")
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _write_health_file(vault, _VALID_FRONTMATTER)
+
+    env_overrides = {
+        "HEALTH_THRESHOLDS_OUTBOX_DEGRADE_OLDEST_AGE_S": "not-a-float",
+    }
+    result = _load(vault, env_vars=env_overrides, profile="lab")
+
+    assert result.status == "fail"
+    assert any("HEALTH_THRESHOLDS_OUTBOX_DEGRADE_OLDEST_AGE_S" in e for e in result.errors)
+    assert result.settings == HealthSettingsV1.defaults()


### PR DESCRIPTION
Fixes #810

## Summary

- `_apply_env_overrides` in `app/settings/health_settings.py` is now guarded by `is_lab_profile()` — it is only invoked when `PKM_SETTINGS_PROFILE=lab`. In operator/prod profiles the `HEALTH_THRESHOLDS_*` env vars are silently ignored.
- A new `profile_env` parameter on `load_health_settings` accepts an arbitrary mapping so tests can inject a deterministic profile without touching `os.environ`.
- New test file `tests/settings/test_health_settings.py` with 8 tests covering: missing file, valid thresholds, missing threshold keys (two variants), env overrides applied in lab, env overrides suppressed in operator, env overrides suppressed when profile unset, and invalid env override value in lab.
- `docs/HEALTH.md` documents the profile-gated override policy and the four env vars.
- `docs/SETTINGS.md` adds `HEALTH_THRESHOLDS_*` to the dev/lab-only settings list.

## Validation

```
pytest -q tests/settings/test_health_settings.py
# 8 passed

ruff check app tests
# All checks passed!
```

Note: Dispatcher unavailable — used GitHub-label-only claim. GraphQL rate limited — Project status update deferred.