### PR TITLE
docs(companion-ui): add EXPERIENTIAL_PATTERNS.md — experiential interaction vocabulary

### DIFF
--- a/companion-ui/design_handoff/2026-05-08-cognitive-temporal/Cognitive Modes.html
+++ b/companion-ui/design_handoff/2026-05-08-cognitive-temporal/Cognitive Modes.html
@@ -1,0 +1,378 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Companion UI — Cognitive Modes</title>
+<link rel="stylesheet" href="colors_and_type.css">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Kalam:wght@300;400;700&display=swap" rel="stylesheet">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<style>
+  html, body, #root { height: 100%; margin: 0; }
+  body { background: var(--bg-base); overflow: hidden; }
+  * { box-sizing: border-box; }
+  ::-webkit-scrollbar { width: 4px; height: 4px; }
+  ::-webkit-scrollbar-track { background: transparent; }
+  ::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 2px; }
+  @keyframes dotpulse {
+    0%,100% { opacity: 0.3; transform: scale(0.85); }
+    50% { opacity: 1; transform: scale(1); }
+  }
+</style>
+</head>
+<body>
+<div id="root"></div>
+
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="cognitive-primitives.jsx"></script>
+<script type="text/babel" src="mode-orientation.jsx"></script>
+<script type="text/babel" src="mode-exploration.jsx"></script>
+<script type="text/babel" src="mode-synthesis.jsx"></script>
+<script type="text/babel" src="mode-review.jsx"></script>
+<script type="text/babel" src="mode-resurfacing.jsx"></script>
+<script type="text/babel" src="mode-transitions.jsx"></script>
+
+<script type="text/babel">
+
+/* Title postit */
+function ModeTitle({ tone='var(--accent)', name, subtitle, body }) {
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      padding:'18px 22px', display:'flex', flexDirection:'column', gap:8 }}>
+      <div style={{ display:'flex', alignItems:'baseline', gap:10 }}>
+        <span style={{ ...T.disp, fontSize:32, color:'var(--fg-1)',
+          letterSpacing:'-0.02em', lineHeight:1 }}>{name}</span>
+      </div>
+      <div style={{ ...T.mono, fontSize:9, color:tone,
+        letterSpacing:'0.12em', textTransform:'uppercase' }}>
+        {subtitle}
+      </div>
+      <div style={{ height:1, background:tone, opacity:0.5,
+        width:60, marginTop:2 }} />
+      <div style={{ ...T.ui, fontSize:12.5, color:'var(--fg-2)',
+        lineHeight:1.55, marginTop:6 }}>
+        {body}
+      </div>
+    </div>
+  );
+}
+
+function App() {
+  return (
+    <DesignCanvas>
+
+      {/* ── Section: header / system frame ──────────────── */}
+      <DCSection id="frame" title="Cognitive Modes — Companion UI"
+        subtitle="extending the structural model with cognitive interaction semantics">
+
+        <DCArtboard id="readme" label="Premise" width={520} height={420}>
+          <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+            padding:'22px 24px', display:'flex', flexDirection:'column', gap:10 }}>
+            <div style={{ ...T.disp, fontSize:24, color:'var(--fg-1)',
+              letterSpacing:'-0.02em', lineHeight:1.15, marginBottom:2 }}>
+              Five modes, one document.
+            </div>
+            <div style={{ ...T.mono, fontSize:9, color:'var(--accent)',
+              textTransform:'uppercase', letterSpacing:'0.1em' }}>
+              cognitive prosthesis · vault-native · low attention load
+            </div>
+            <div style={{ height:1, background:'var(--border)', margin:'8px 0' }} />
+            <div style={{ ...T.ui, fontSize:12, color:'var(--fg-1)', lineHeight:1.6 }}>
+              The document is the cognitive anchor. Modes are <i>not</i> screens
+              — they are <strong style={{color:'var(--accent)'}}>postures</strong>
+              over the same document, expressed as overlays with predictable
+              grammar.
+            </div>
+            <div style={{ ...T.ui, fontSize:11, color:'var(--fg-2)',
+              lineHeight:1.55, marginTop:6 }}>
+              Each mode answers nine questions: overlay class · density ·
+              persistence · provenance · sources · AI visibility · spatial
+              behavior · interruption · transitions out.
+            </div>
+            <div style={{ flex:1 }} />
+            <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr',
+              gap:5 }}>
+              {[
+                { c:'var(--accent)', n:'Orientation' },
+                { c:'var(--cyan)',   n:'Exploration' },
+                { c:'var(--vault)',  n:'Synthesis' },
+                { c:'var(--amber)',  n:'Review' },
+                { c:'var(--vault)',  n:'Resurfacing' },
+              ].map(m => (
+                <div key={m.n} style={{ display:'flex', alignItems:'center',
+                  gap:6, padding:'4px 8px', background:'var(--bg-raised)',
+                  borderLeft:`2px solid ${m.c}`, borderRadius:2 }}>
+                  <IconDot size={5} color={m.c} />
+                  <span style={{ ...T.ui, fontSize:11, color:'var(--fg-1)' }}>{m.n}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </DCArtboard>
+
+        <DCArtboard id="overlay-hierarchy" label="Overlay hierarchy"
+          width={620} height={420}>
+          <OverlayHierarchy />
+        </DCArtboard>
+
+        <DCArtboard id="transitions" label="Mode transition map"
+          width={840} height={460}>
+          <ModeTransitionMap />
+        </DCArtboard>
+      </DCSection>
+
+      {/* ── 1. Orientation ──────────────────────────────── */}
+      <DCSection id="orient" title="1 · Orientation"
+        subtitle="user returns after interruption · reduce re-entry cost">
+        <DCArtboard id="orient-title" label="Posture" width={420} height={300}>
+          <ModeTitle tone="var(--accent)" name="Orientation"
+            subtitle="reconstruct active context · recover mental state"
+            body={<>
+              When the user sits down, the system answers
+              <strong style={{color:'var(--fg-1)'}}> "where was I?"</strong> —
+              not with a dashboard, but with a quiet mist over the document
+              that names the open loops, the last trace of thought, and one
+              suggested point of resumption. It clears on first interaction.
+            </>} />
+        </DCArtboard>
+        <DCArtboard id="orient-wire" label="Wireframe — re-entry overlay"
+          width={880} height={560}>
+          <ModeOrientation_Wire />
+        </DCArtboard>
+        <DCArtboard id="orient-spec" label="Semantic spec"
+          width={520} height={460}>
+          <ModeOrientation_Spec />
+        </DCArtboard>
+      </DCSection>
+
+      {/* ── 2. Exploration ──────────────────────────────── */}
+      <DCSection id="explore" title="2 · Exploration"
+        subtitle="divergent thinking · ephemeral cognition · low governance">
+        <DCArtboard id="explore-title" label="Posture" width={420} height={300}>
+          <ModeTitle tone="var(--cyan)" name="Exploration"
+            subtitle="divergent · speculative · transient"
+            body={<>
+              A canvas blooms beside the document, anchored to a phrase. Branches
+              are <em>cheap</em> — they cost nothing, persist nothing, vanish if
+              ignored. The document remains the gravitational center; exploration
+              is what happens at the edge before things crystallize.
+            </>} />
+        </DCArtboard>
+        <DCArtboard id="explore-wire" label="Wireframe — adjacent canvas"
+          width={880} height={560}>
+          <ModeExploration_Wire />
+        </DCArtboard>
+        <DCArtboard id="explore-spec" label="Semantic spec"
+          width={520} height={460}>
+          <ModeExploration_Spec />
+        </DCArtboard>
+      </DCSection>
+
+      {/* ── 3. Synthesis ────────────────────────────────── */}
+      <DCSection id="synth" title="3 · Synthesis"
+        subtitle="convergence · candidate evergreen · attributed claims">
+        <DCArtboard id="synth-title" label="Posture" width={420} height={300}>
+          <ModeTitle tone="var(--vault)" name="Synthesis"
+            subtitle="compare · converge · attribute"
+            body={<>
+              Multiple notes lay side-by-side. A draft assembles below. Every
+              paragraph carries flecks pointing back to the sources that
+              support it. Where sources <em>disagree</em>, an amber break
+              refuses to flatten the disagreement. Output is a candidate
+              evergreen — not yet canonical.
+            </>} />
+        </DCArtboard>
+        <DCArtboard id="synth-wire" label="Wireframe — comparison + draft"
+          width={880} height={560}>
+          <ModeSynthesis_Wire />
+        </DCArtboard>
+        <DCArtboard id="synth-spec" label="Semantic spec"
+          width={520} height={460}>
+          <ModeSynthesis_Spec />
+        </DCArtboard>
+      </DCSection>
+
+      {/* ── 4. Review ───────────────────────────────────── */}
+      <DCSection id="review" title="4 · Review / Governance"
+        subtitle="staged proposals · provenance · explicit human apply">
+        <DCArtboard id="review-title" label="Posture" width={420} height={300}>
+          <ModeTitle tone="var(--amber)" name="Review"
+            subtitle="suggest / apply / reject · with receipts"
+            body={<>
+              Proposals appear <em>where they would land</em>, never in a
+              separate inspector. Each carries diff, evidence chips, confidence,
+              and a receipt id linking to the vault audit trail. The agent
+              proposes; only the human applies. A bottom dock walks the queue
+              without disturbing the page.
+            </>} />
+        </DCArtboard>
+        <DCArtboard id="review-wire" label="Wireframe — inline staged + dock"
+          width={880} height={560}>
+          <ModeReview_Wire />
+        </DCArtboard>
+        <DCArtboard id="review-spec" label="Semantic spec"
+          width={520} height={460}>
+          <ModeReview_Spec />
+        </DCArtboard>
+      </DCSection>
+
+      {/* ── 5. Resurfacing ──────────────────────────────── */}
+      <DCSection id="resurf" title="5 · Resurfacing"
+        subtitle="ambient re-attentioning · salience without notifications">
+        <DCArtboard id="resurf-title" label="Posture" width={420} height={300}>
+          <ModeTitle tone="var(--vault)" name="Resurfacing"
+            subtitle="ambient · faint · never demanding"
+            body={<>
+              Latent knowledge appears as faint marks at the right edge of the
+              document — sized by salience, dimmed by recency, anchored to
+              passages. No popups, no badges, no chime. The user notices only
+              when their eye is ready; that is the correct latency for re-attentioning.
+            </>} />
+        </DCArtboard>
+        <DCArtboard id="resurf-wire" label="Wireframe — marginalia + tray"
+          width={880} height={560}>
+          <ModeResurfacing_Wire />
+        </DCArtboard>
+        <DCArtboard id="resurf-spec" label="Semantic spec"
+          width={520} height={460}>
+          <ModeResurfacing_Spec />
+        </DCArtboard>
+      </DCSection>
+
+      {/* ── Example flows ───────────────────────────────── */}
+      <DCSection id="flows" title="Example cognitive flows"
+        subtitle="four traces showing modes composed across a real session">
+        <DCArtboard id="flow-recover" label="Recovery: interrupt → review"
+          width={620} height={420}>
+          <FlowOrientationToReview />
+        </DCArtboard>
+        <DCArtboard id="flow-explore" label="Probe → durable evergreen"
+          width={620} height={460}>
+          <FlowExploreToEvergreen />
+        </DCArtboard>
+        <DCArtboard id="flow-resurf" label="Ambient resurfacing pattern"
+          width={620} height={420}>
+          <FlowResurfacingPattern />
+        </DCArtboard>
+        <DCArtboard id="flow-prov" label="Provenance interaction pattern"
+          width={620} height={400}>
+          <FlowProvenancePattern />
+        </DCArtboard>
+      </DCSection>
+
+      {/* ── Component responsibilities ──────────────────── */}
+      <DCSection id="components" title="Component responsibilities"
+        subtitle="who owns what · matched to overlay grammar">
+        <DCArtboard id="component-table" label="Responsibility table"
+          width={1000} height={520}>
+          <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+            padding:'16px 22px', overflow:'auto' }}>
+            <div style={{ ...T.disp, fontSize:18, color:'var(--fg-1)',
+              letterSpacing:'-0.01em', marginBottom:10 }}>
+              Component responsibilities
+            </div>
+            {[
+              { c:'Document surface', tone:'var(--fg-1)',
+                role:'Holds attention. Renders markdown + frontmatter + inline staged blocks. Source of truth for cursor position, scroll, and selection. Never replaced — only overlaid.',
+                modes:'all' },
+              { c:'Margin rail', tone:'var(--agent)',
+                role:'Conversation thread, anchored to passages. Collapses to 28px strip showing only Hugin dot + unread count. Same proposal-card shape as inline staged blocks.',
+                modes:'orient · review · converse' },
+              { c:'Re-entry overlay', tone:'var(--accent)',
+                role:'Floating card surfaced once on session start. Lists open loops + last cognitive trace. Self-dismisses on first document interaction.',
+                modes:'orient' },
+              { c:'Adjacent canvas', tone:'var(--cyan)',
+                role:'Splits the stage horizontally. Holds branches with dashed edges. State cached locally, never written to vault until promoted.',
+                modes:'explore' },
+              { c:'Comparison strip', tone:'var(--vault)',
+                role:'Three-column source view across the top. Tracks alignments and divergences. Drives provenance flecks in the draft below.',
+                modes:'synth' },
+              { c:'Provenance rail', tone:'var(--vault)',
+                role:'Right-side list of source notes with line numbers. Updates live as the draft references them. Click any source → SourcePeek.',
+                modes:'synth · review' },
+              { c:'Staged block (inline)', tone:'var(--amber)',
+                role:'Amber border-left, diff body, evidence chips, receipt id. Apply / Apply-with-edits / Defer / Reject. Lives in the document where it would land.',
+                modes:'review' },
+              { c:'Governance dock', tone:'var(--amber)',
+                role:'42px bottom strip. Walks queue with ←/→. Never obscures content. Closes with Esc.',
+                modes:'review' },
+              { c:'SourcePeek', tone:'var(--cyan)',
+                role:'Anchored card near its trigger. Shows source snippet, line, confidence. Click outside dismisses.',
+                modes:'all' },
+              { c:'Marginalia (right edge)', tone:'var(--vault)',
+                role:'Faint dots anchored to passages. Size = salience, opacity = recency. No tooltip until hover.',
+                modes:'resurf' },
+              { c:'Resurface tray', tone:'var(--vault)',
+                role:'Optional 200px sidebar listing latent items with reasons. Always optional, always dismissible.',
+                modes:'resurf' },
+              { c:'Bottom sheet (portrait)', tone:'var(--accent)',
+                role:'Mobile equivalent of margin rail + governance dock. Same content, different geometry.',
+                modes:'all (portrait)' },
+            ].map((r,i) => (
+              <div key={i} style={{ display:'grid',
+                gridTemplateColumns:'170px 1fr 130px',
+                gap:14, padding:'9px 0',
+                borderTop: i===0 ? '1px solid var(--border)' : '1px solid var(--border)' }}>
+                <div style={{ display:'flex', alignItems:'flex-start', gap:6 }}>
+                  <div style={{ width:3, alignSelf:'stretch', background:r.tone,
+                    marginTop:3 }} />
+                  <span style={{ ...T.ui, fontSize:11.5, color:'var(--fg-1)',
+                    fontWeight:500 }}>{r.c}</span>
+                </div>
+                <div style={{ ...T.ui, fontSize:11, color:'var(--fg-2)',
+                  lineHeight:1.5 }}>{r.role}</div>
+                <div style={{ ...T.mono, fontSize:9, color:'var(--fg-3)',
+                  letterSpacing:'0.06em' }}>{r.modes}</div>
+              </div>
+            ))}
+          </div>
+        </DCArtboard>
+
+        <DCArtboard id="grammar" label="Interaction semantics — invariants"
+          width={520} height={520}>
+          <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+            padding:'18px 22px', display:'flex', flexDirection:'column', gap:0 }}>
+            <div style={{ ...T.disp, fontSize:18, color:'var(--fg-1)',
+              letterSpacing:'-0.01em', marginBottom:2 }}>
+              Interaction invariants
+            </div>
+            <div style={{ ...T.mono, fontSize:9, color:'var(--fg-3)',
+              letterSpacing:'0.08em', textTransform:'uppercase', marginBottom:10 }}>
+              true across all five modes
+            </div>
+            {[
+              ['anchor preservation', 'Mode changes never alter scroll position, cursor, or selection.'],
+              ['reversibility',       'Every overlay can be dismissed without data loss.'],
+              ['no hard navigation',  'Mode transitions are overlay swaps, not route changes.'],
+              ['proposal duality',    'Any object shown in chat appears identically in the document with the same actions.'],
+              ['vault-canonical',     'Persisted state lives in the vault as markdown/receipts. App-local state is recoverable if deleted.'],
+              ['agent voice = one of many', 'Agent contributions are visually distinguished but never structurally privileged.'],
+              ['low attention default','Resurfacing and orientation never produce notifications; salience expresses itself through visual weight.'],
+              ['portrait equivalence','Bottom sheet preserves the same cognitive semantics as the margin rail.'],
+            ].map(([k,v], i) => (
+              <div key={k} style={{ padding:'8px 0',
+                borderTop: i===0 ? 'none' : '1px solid var(--border)' }}>
+                <div style={{ ...T.mono, fontSize:9, color:'var(--accent)',
+                  letterSpacing:'0.1em', textTransform:'uppercase', marginBottom:3 }}>
+                  {k}
+                </div>
+                <div style={{ ...T.ui, fontSize:11.5, color:'var(--fg-1)',
+                  lineHeight:1.5 }}>{v}</div>
+              </div>
+            ))}
+          </div>
+        </DCArtboard>
+      </DCSection>
+
+    </DesignCanvas>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+
+</script>
+</body>
+</html>

--- a/companion-ui/design_handoff/2026-05-08-cognitive-temporal/Re-entry Mist Variants.html
+++ b/companion-ui/design_handoff/2026-05-08-cognitive-temporal/Re-entry Mist Variants.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Re-entry Mist — Three Variants</title>
+<link rel="stylesheet" href="colors_and_type.css">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Kalam:wght@300;400;700&display=swap" rel="stylesheet">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<style>
+  html, body, #root { height: 100%; margin: 0; }
+  body { background: var(--bg-base); overflow: hidden; }
+  * { box-sizing: border-box; }
+  ::-webkit-scrollbar { width: 4px; height: 4px; }
+  ::-webkit-scrollbar-track { background: transparent; }
+  ::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 2px; }
+</style>
+</head>
+<body>
+<div id="root"></div>
+
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="temporal-primitives.jsx"></script>
+<script type="text/babel" src="reentry-variants.jsx"></script>
+<script type="text/babel" src="reentry-analysis.jsx"></script>
+
+<script type="text/babel">
+function App() {
+  return (
+    <DesignCanvas>
+
+      <DCSection id="frame" title="Re-entry mist · phenomenology refinement"
+        subtitle="returning to an interrupted thought after ~3 days · three variants">
+        <DCArtboard id="premise" label="Premise" width={560} height={520}>
+          <RM_Premise />
+        </DCArtboard>
+      </DCSection>
+
+      <DCSection id="variants" title="Three variants"
+        subtitle="A · margin whisper   B · resumption breath   C · atmospheric recall">
+        <DCArtboard id="variant-a" label="A · margin whisper — wireframe"
+          width={920} height={580}>
+          <VariantA_Wire />
+        </DCArtboard>
+        <DCArtboard id="variant-b" label="B · resumption breath — wireframe"
+          width={920} height={580}>
+          <VariantB_Wire />
+        </DCArtboard>
+        <DCArtboard id="variant-c" label="C · atmospheric recall — wireframe"
+          width={920} height={580}>
+          <VariantC_Wire />
+        </DCArtboard>
+      </DCSection>
+
+      <DCSection id="cadence" title="Attentional cadence"
+        subtitle="what surfaces when · what fades first · what persists longest">
+        <DCArtboard id="cadence" label="Cadence comparison"
+          width={920} height={560}>
+          <RM_Cadence />
+        </DCArtboard>
+      </DCSection>
+
+      <DCSection id="density" title="Density &amp; dissolve"
+        subtitle="payload weight · how each variant lets go">
+        <DCArtboard id="density" label="Density comparison"
+          width={780} height={520}>
+          <RM_Density />
+        </DCArtboard>
+        <DCArtboard id="dissolve" label="Dissolve semantics"
+          width={920} height={520}>
+          <RM_Dissolve />
+        </DCArtboard>
+      </DCSection>
+
+      <DCSection id="persistence" title="Ambient persistence &amp; recommendation"
+        subtitle="what remains · which variant to ship">
+        <DCArtboard id="persistence" label="Ambient persistence"
+          width={780} height={560}>
+          <RM_Persistence />
+        </DCArtboard>
+        <DCArtboard id="recommendation" label="Recommendation"
+          width={680} height={560}>
+          <RM_Recommendation />
+        </DCArtboard>
+      </DCSection>
+
+    </DesignCanvas>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+</script>
+</body>
+</html>

--- a/companion-ui/design_handoff/2026-05-08-cognitive-temporal/Temporal Cognition.html
+++ b/companion-ui/design_handoff/2026-05-08-cognitive-temporal/Temporal Cognition.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Companion UI — Temporal Cognition</title>
+<link rel="stylesheet" href="colors_and_type.css">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Kalam:wght@300;400;700&display=swap" rel="stylesheet">
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+<style>
+  html, body, #root { height: 100%; margin: 0; }
+  body { background: var(--bg-base); overflow: hidden; }
+  * { box-sizing: border-box; }
+  ::-webkit-scrollbar { width: 4px; height: 4px; }
+  ::-webkit-scrollbar-track { background: transparent; }
+  ::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 2px; }
+</style>
+</head>
+<body>
+<div id="root"></div>
+
+<script type="text/babel" src="design-canvas.jsx"></script>
+<script type="text/babel" src="temporal-primitives.jsx"></script>
+<script type="text/babel" src="temporal-s1.jsx"></script>
+<script type="text/babel" src="temporal-s2.jsx"></script>
+<script type="text/babel" src="temporal-s3.jsx"></script>
+<script type="text/babel" src="temporal-s4.jsx"></script>
+<script type="text/babel" src="temporal-s5.jsx"></script>
+<script type="text/babel" src="temporal-s6.jsx"></script>
+
+<script type="text/babel">
+
+function App() {
+  return (
+    <DesignCanvas>
+
+      {/* ── frame ─────────────────────────────────────────── */}
+      <DCSection id="frame" title="Temporal Cognition — Companion UI"
+        subtitle="continuity of thought across interruption · ambient, document-anchored, non-disruptive">
+        <DCArtboard id="premise" label="Premise" width={520} height={460}>
+          <S0_Premise />
+        </DCArtboard>
+        <DCArtboard id="hierarchy" label="Semantic overlay hierarchy"
+          width={620} height={520}>
+          <S6_OverlayHierarchy />
+        </DCArtboard>
+        <DCArtboard id="rules" label="Attention rules · invariants"
+          width={520} height={520}>
+          <S6_AttentionRules />
+        </DCArtboard>
+      </DCSection>
+
+      {/* ── 1 · Interrupted trajectories ─────────────────── */}
+      <DCSection id="trajectories" title="1 · Interrupted trajectories"
+        subtitle="how thought is preserved when the user steps away">
+        <DCArtboard id="traj-states" label="Trajectory states"
+          width={620} height={460}>
+          <S1_Model />
+        </DCArtboard>
+        <DCArtboard id="traj-preserved" label="Continuity payload"
+          width={520} height={460}>
+          <S1_Preserved />
+        </DCArtboard>
+        <DCArtboard id="traj-wire" label="Wireframe — moment of interruption"
+          width={880} height={580}>
+          <S1_InterruptWire />
+        </DCArtboard>
+      </DCSection>
+
+      {/* ── 2 · Re-entry ergonomics ──────────────────────── */}
+      <DCSection id="reentry" title="2 · Re-entry ergonomics"
+        subtitle="the mist · the four questions · how absence scales">
+        <DCArtboard id="reentry-wire" label="Wireframe — re-entry mist"
+          width={880} height={580}>
+          <S2_MistWire />
+        </DCArtboard>
+        <DCArtboard id="reentry-questions" label="Four questions, four shapes"
+          width={520} height={520}>
+          <S2_FourQuestions />
+        </DCArtboard>
+        <DCArtboard id="reentry-ladder" label="Latency ladder"
+          width={620} height={480}>
+          <S2_LatencyLadder />
+        </DCArtboard>
+      </DCSection>
+
+      {/* ── 3 · Temporal resurfacing ─────────────────────── */}
+      <DCSection id="resurfacing" title="3 · Temporal resurfacing"
+        subtitle="ambient marginalia · decay envelopes · non-disruptive triggers">
+        <DCArtboard id="resurf-wire" label="Wireframe — marginalia field"
+          width={880} height={620}>
+          <S3_MarginaliaWire />
+        </DCArtboard>
+        <DCArtboard id="resurf-decay" label="Decay envelope"
+          width={620} height={460}>
+          <S3_DecayEnvelope />
+        </DCArtboard>
+        <DCArtboard id="resurf-triggers" label="Resurfacing triggers"
+          width={620} height={460}>
+          <S3_Triggers />
+        </DCArtboard>
+      </DCSection>
+
+      {/* ── 4 · Cognitive tension ────────────────────────── */}
+      <DCSection id="tension" title="4 · Cognitive tension"
+        subtitle="unresolvedness · conflict · incomplete synthesis · dormant pressure">
+        <DCArtboard id="tension-topology" label="Tension topology"
+          width={680} height={520}>
+          <S4_Topology />
+        </DCArtboard>
+        <DCArtboard id="tension-wire" label="Wireframe — tension inline"
+          width={880} height={580}>
+          <S4_InlineWire />
+        </DCArtboard>
+        <DCArtboard id="tension-dial" label="Pressure dial"
+          width={520} height={520}>
+          <S4_PressureDial />
+        </DCArtboard>
+      </DCSection>
+
+      {/* ── 5 · Temporal provenance ──────────────────────── */}
+      <DCSection id="provenance" title="5 · Temporal provenance"
+        subtitle="how understanding evolved · what changed · where uncertainty moved">
+        <DCArtboard id="prov-genealogy" label="Wireframe — paragraph genealogy"
+          width={920} height={580}>
+          <S5_GenealogyWire />
+        </DCArtboard>
+        <DCArtboard id="prov-uncertainty" label="Uncertainty trace"
+          width={620} height={420}>
+          <S5_UncertaintyTrace />
+        </DCArtboard>
+        <DCArtboard id="prov-diff" label="Wireframe — diff lens"
+          width={780} height={520}>
+          <S5_DiffLens />
+        </DCArtboard>
+      </DCSection>
+
+      {/* ── 6 · Composition ──────────────────────────────── */}
+      <DCSection id="composition" title="End-to-end"
+        subtitle="one open loop, from interruption to resolution">
+        <DCArtboard id="flow" label="Composition flow"
+          width={680} height={560}>
+          <S6_CompositionFlow />
+        </DCArtboard>
+      </DCSection>
+
+    </DesignCanvas>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+
+</script>
+</body>
+</html>

--- a/companion-ui/design_handoff/2026-05-08-cognitive-temporal/cognitive-primitives.jsx
+++ b/companion-ui/design_handoff/2026-05-08-cognitive-temporal/cognitive-primitives.jsx
@@ -1,0 +1,262 @@
+/* Cognitive Modes — shared primitives + the canonical "stage"
+   (document with margin rail) that every mode wireframe builds on top of.
+   Loaded as type="text/babel" before the per-mode files. */
+
+const T = {
+  hand: { fontFamily: "'Kalam', cursive" },
+  mono: { fontFamily: 'var(--font-mono)' },
+  ui:   { fontFamily: 'var(--font-ui)' },
+  disp: { fontFamily: 'var(--font-display)' },
+};
+
+/* ── micro primitives ─────────────────────────────────────── */
+function Bar({ w='100%', h=7, c='var(--border-strong)', style={} }) {
+  return <div style={{ width:w, height:h, background:c, borderRadius:2, ...style }} />;
+}
+function Lines({ n=3, w='100%', last='65%', h=7, gap=7, c }) {
+  const col = c || 'var(--border-strong)';
+  return (
+    <div style={{ display:'flex', flexDirection:'column', gap }}>
+      {Array.from({length:n}).map((_,i)=>
+        <Bar key={i} w={i===n-1?last:w} h={h} c={col} />)}
+    </div>
+  );
+}
+function IconBox({ size=12, color='var(--fg-3)', style={} }) {
+  return <div style={{ width:size, height:size, borderRadius:2,
+    border:`1.5px solid ${color}`, flexShrink:0, ...style }} />;
+}
+function IconDot({ size=6, color='var(--fg-3)', glow=false }) {
+  return <div style={{ width:size, height:size, borderRadius:'50%',
+    background:color, boxShadow: glow ? `0 0 6px ${color}` : 'none', flexShrink:0 }} />;
+}
+function Pill({ children, color='var(--fg-3)', bg='transparent', border, style={} }) {
+  return (
+    <span style={{ display:'inline-flex', alignItems:'center', gap:4,
+      padding:'2px 7px', borderRadius:2, background:bg,
+      border:`1px solid ${border||color}`, ...T.mono, fontSize:9,
+      color, letterSpacing:'0.06em', textTransform:'uppercase', ...style }}>
+      {children}
+    </span>
+  );
+}
+function Btn({ children, color='var(--fg-3)', filled=false, style={} }) {
+  return (
+    <span style={{ padding:'3px 9px', borderRadius:2,
+      border:`1px solid ${color}`,
+      background: filled ? color : 'transparent',
+      color: filled ? 'var(--fg-inverse)' : color,
+      ...T.ui, fontSize:11, ...style }}>{children}</span>
+  );
+}
+
+/* ── annotation marks (Kalam hand) ────────────────────────── */
+function Anno({ children, style={}, dim=false, size=11 }) {
+  return <div style={{ ...T.hand, fontSize:size, lineHeight:1.3,
+    color: dim ? 'var(--fg-3)' : 'var(--accent)', ...style }}>{children}</div>;
+}
+function Callout({ children, w=180, style={} }) {
+  return (
+    <div style={{ background:'rgba(212,168,67,0.06)',
+      border:'1px dashed rgba(212,168,67,0.35)', borderRadius:4,
+      padding:'5px 9px', ...T.hand, fontSize:11, color:'var(--accent)',
+      lineHeight:1.4, maxWidth:w, ...style }}>{children}</div>
+  );
+}
+/* Curved arrow drawn as an SVG so we can point at things from anywhere. */
+function Arrow({ d, color='var(--accent)', style={}, head=true, dashed=false }) {
+  return (
+    <svg style={{ position:'absolute', overflow:'visible', pointerEvents:'none', ...style }}
+      width="100%" height="100%">
+      <path d={d} stroke={color} strokeWidth="1.2" fill="none"
+        strokeLinecap="round"
+        strokeDasharray={dashed ? '3 3' : 'none'}
+        markerEnd={head ? `url(#ah-${color.replace(/[^a-z0-9]/gi,'')})` : 'none'} />
+      {head && (
+        <defs>
+          <marker id={`ah-${color.replace(/[^a-z0-9]/gi,'')}`} viewBox="0 0 8 8" refX="7" refY="4"
+            markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+            <path d="M0,0 L7,4 L0,8" fill="none" stroke={color} strokeWidth="1.2" />
+          </marker>
+        </defs>
+      )}
+    </svg>
+  );
+}
+
+/* ── document body — used by every mode ───────────────────── */
+function DocFrontmatter({ title='Q2 architecture review', tags='architecture, decisions', status='active' }) {
+  return (
+    <div style={{ ...T.mono, fontSize:9, color:'var(--fg-3)', lineHeight:1.8,
+      borderBottom:'1px solid var(--border)', paddingBottom:8, marginBottom:18 }}>
+      title: {title} · tags: {tags} · status: {status}
+    </div>
+  );
+}
+function DocTitle({ children='Q2 architecture review' }) {
+  return <div style={{ ...T.disp, fontSize:24, color:'var(--fg-1)',
+    fontWeight:400, letterSpacing:'-0.02em', lineHeight:1.2,
+    marginBottom:18 }}>{children}</div>;
+}
+function DocH({ level=2, children, style={} }) {
+  const sizes = { 1:18, 2:13, 3:11 };
+  const sz = sizes[level] || 13;
+  return <div style={{ ...T.ui, fontSize:sz, color:'var(--fg-2)',
+    textTransform:'uppercase', letterSpacing:'0.08em', fontWeight:500,
+    marginTop: level===2 ? 14 : 8, marginBottom:8, ...style }}>{children}</div>;
+}
+function DocPara({ n=3, last='62%', dim=false }) {
+  return (
+    <div style={{ marginBottom:14 }}>
+      <Lines n={n} last={last} h={7}
+        c={dim ? 'rgba(61,85,112,0.4)' : 'var(--border-strong)'} />
+    </div>
+  );
+}
+
+/* ── stage chrome — top bar + base layout ─────────────────── */
+function StageTopBar({ surface='Converse', vault=true, sessionTitle='Q2 architecture review' }) {
+  return (
+    <div style={{ height:34, borderBottom:'1px solid var(--border)',
+      background:'var(--bg-surface)', display:'flex', alignItems:'center',
+      padding:'0 12px', gap:12, flexShrink:0 }}>
+      <svg width="13" height="16" viewBox="0 0 40 50" fill="none" style={{flexShrink:0}}>
+        <line x1="20" y1="9" x2="20" y2="38" stroke="var(--accent)" strokeWidth="1.5" strokeLinecap="round"/>
+        <path d="M20 24 Q11 19 6 15" stroke="var(--border-strong)" strokeWidth="1.2" fill="none"/>
+        <path d="M20 24 Q29 19 34 15" stroke="var(--border-strong)" strokeWidth="1.2" fill="none"/>
+        <circle cx="20" cy="6" r="2.5" fill="var(--accent)"/>
+      </svg>
+      {['Converse','Orient','Capture','Synthesize','Resurface'].map(s => (
+        <span key={s} style={{ ...T.ui, fontSize:11,
+          color: s===surface ? 'var(--fg-1)' : 'var(--fg-3)',
+          fontWeight: s===surface ? 500 : 400,
+          borderBottom: s===surface ? '1px solid var(--accent)' : 'none',
+          paddingBottom:1 }}>{s}</span>
+      ))}
+      <div style={{ marginLeft:'auto', display:'flex', alignItems:'center', gap:6,
+        padding:'2px 8px', background:'var(--bg-raised)',
+        border:'1px solid var(--border)', borderRadius:2 }}>
+        <span style={{ ...T.ui, fontSize:10, color:'var(--fg-2)' }}>{sessionTitle}</span>
+        <span style={{ ...T.mono, fontSize:8, color:'var(--fg-3)' }}>▾</span>
+      </div>
+      <div style={{ display:'flex', alignItems:'center', gap:4 }}>
+        <IconDot size={5} color={vault ? 'var(--vault)' : 'var(--destructive)'} glow />
+        <span style={{ ...T.mono, fontSize:9,
+          color: vault ? 'var(--vault)' : 'var(--destructive)' }}>
+          {vault ? 'vault online' : 'vault offline'}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/* ── spec card — semantic overlay description ─────────────── */
+function SpecCard({ rows, color='var(--cyan)' }) {
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      padding:'18px 20px', overflow:'hidden', display:'flex',
+      flexDirection:'column', gap:0 }}>
+      {rows.map(([k,v], i) => (
+        <div key={k} style={{ display:'grid', gridTemplateColumns:'132px 1fr',
+          gap:14, padding:'9px 0',
+          borderTop: i===0 ? 'none' : '1px solid var(--border)' }}>
+          <div style={{ ...T.mono, fontSize:9, color,
+            letterSpacing:'0.08em', textTransform:'uppercase', paddingTop:1 }}>
+            {k}
+          </div>
+          <div style={{ ...T.ui, fontSize:11.5, color:'var(--fg-1)',
+            lineHeight:1.5 }}>{v}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ── shared overlay primitives ────────────────────────────── */
+
+/* MarginRail — collapsed by default, expanded for converse-heavy modes */
+function MarginRail({ collapsed=false, color='var(--agent)', label='Hugin', count=null, children }) {
+  if (collapsed) {
+    return (
+      <div style={{ width:28, height:'100%', background:'var(--bg-surface)',
+        borderLeft:'1px solid var(--border)', display:'flex',
+        flexDirection:'column', alignItems:'center', paddingTop:10, gap:8, flexShrink:0 }}>
+        <IconDot size={6} color={color} glow />
+        {count!=null && <span style={{ ...T.mono, fontSize:9, color }}>{count}</span>}
+        <span style={{ writingMode:'vertical-rl', ...T.mono, fontSize:9,
+          color:'var(--fg-3)', letterSpacing:'0.1em', marginTop:'auto', marginBottom:14 }}>
+          rail collapsed →
+        </span>
+      </div>
+    );
+  }
+  return (
+    <div style={{ width:280, height:'100%', background:'var(--bg-surface)',
+      borderLeft:'1px solid var(--border)', display:'flex',
+      flexDirection:'column', flexShrink:0 }}>
+      <div style={{ padding:'9px 12px', borderBottom:'1px solid var(--border)',
+        display:'flex', alignItems:'center', gap:8 }}>
+        <IconDot size={6} color={color} glow />
+        <span style={{ ...T.mono, fontSize:9, color, textTransform:'uppercase',
+          letterSpacing:'0.08em' }}>{label}</span>
+        <span style={{ marginLeft:'auto', ...T.mono, fontSize:8,
+          color:'var(--fg-3)' }}>›</span>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+/* SourcePeek — anchored provenance card */
+function SourcePeek({ anchor, source, snippet, confidence='0.84', style={} }) {
+  return (
+    <div style={{ position:'absolute', background:'var(--bg-overlay)',
+      border:'1px solid var(--cyan-dim)', borderLeft:'2px solid var(--cyan)',
+      borderRadius:3, padding:'8px 10px', width:230,
+      boxShadow:'var(--shadow-md)', ...style }}>
+      <div style={{ display:'flex', alignItems:'center', gap:5, marginBottom:5 }}>
+        <IconBox size={9} color="var(--cyan)" />
+        <span style={{ ...T.mono, fontSize:9, color:'var(--cyan)' }}>{source}</span>
+        <span style={{ marginLeft:'auto', ...T.mono, fontSize:8,
+          color:'var(--fg-3)' }}>conf {confidence}</span>
+      </div>
+      <Lines n={2} h={5} last="55%" c="rgba(0,212,232,0.18)" />
+      <div style={{ ...T.mono, fontSize:8, color:'var(--fg-3)',
+        marginTop:6, fontStyle:'italic' }}>{snippet}</div>
+    </div>
+  );
+}
+
+/* Used by MarginRail children */
+function RailMessage({ from='agent', anchor, color='var(--agent)', children, staged=false }) {
+  const tint = staged
+    ? { bg:'rgba(240,144,48,0.05)', border:'var(--amber-dim)', accent:'var(--amber)' }
+    : from === 'agent'
+      ? { bg:'var(--agent-muted)', border:'var(--agent-dim)', accent:color }
+      : { bg:'var(--bg-raised)', border:'var(--border-strong)', accent:'transparent' };
+  return (
+    <div style={{ background:tint.bg, border:`1px solid ${tint.border}`,
+      borderLeft: tint.accent==='transparent' ? `1px solid ${tint.border}` : `2px solid ${tint.accent}`,
+      borderRadius:'1px 4px 4px 4px', padding:'7px 9px',
+      alignSelf: from==='human' ? 'flex-end' : 'stretch',
+      maxWidth: from==='human' ? '88%' : '100%' }}>
+      {anchor && (
+        <div style={{ display:'flex', alignItems:'center', gap:4, marginBottom:5 }}>
+          <IconDot size={5} color={tint.accent} />
+          <span style={{ ...T.mono, fontSize:8, color:tint.accent,
+            letterSpacing:'0.06em' }}>re: {anchor}</span>
+        </div>
+      )}
+      {children || <Lines n={2} h={5} last="60%"
+        c={from==='agent' ? 'rgba(74,158,255,0.2)' : 'rgba(220,232,240,0.25)'} />}
+    </div>
+  );
+}
+
+/* Make available to per-mode files. */
+Object.assign(window, {
+  T, Bar, Lines, IconBox, IconDot, Pill, Btn,
+  Anno, Callout, Arrow,
+  DocFrontmatter, DocTitle, DocH, DocPara,
+  StageTopBar, SpecCard, MarginRail, SourcePeek, RailMessage,
+});

--- a/companion-ui/design_handoff/2026-05-08-cognitive-temporal/colors_and_type.css
+++ b/companion-ui/design_handoff/2026-05-08-cognitive-temporal/colors_and_type.css
@@ -1,0 +1,346 @@
+/* ============================================================
+   Yggdrasil Design System — Colors & Type
+   ============================================================
+   Import this file in any HTML artifact or UI kit.
+   Google Fonts are imported below; JetBrains Mono via bunny.net.
+   ============================================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Space+Grotesk:wght@300;400;500;600&display=swap');
+@import url('https://fonts.bunny.net/css?family=jetbrains-mono:400,500&display=swap');
+
+/* ============================================================
+   BASE COLOR TOKENS
+   ============================================================ */
+:root {
+  /* --- Backgrounds (cool blue-black — Tron grid) --- */
+  --bg-base:       #070b12;   /* deepest — page root, near black with blue cast */
+  --bg-surface:    #0c1220;   /* panels, sidebars */
+  --bg-raised:     #111a2e;   /* cards, inputs, raised surfaces */
+  --bg-overlay:    #162038;   /* hover states, popovers */
+  --bg-modal:      #0e1828;   /* modal / dialog backdrop content */
+
+  /* --- Foreground / Text --- */
+  --fg-1:          #dce8f0;   /* primary — cool blue-white */
+  --fg-2:          #7a9ab8;   /* secondary / muted */
+  --fg-3:          #3d5570;   /* tertiary / disabled / dim */
+  --fg-inverse:    #070b12;   /* text on light/accent backgrounds */
+
+  /* --- Borders (thin, slightly glowing) --- */
+  --border:        #152030;   /* default — subtle grid line */
+  --border-strong: #1e3050;   /* emphasis — dividers, active edges */
+  --border-focus:  #00d4e8;   /* focus ring — electric cyan */
+
+  /* --- Accent 1: Norse Gold (slightly electrified) --- */
+  --accent:        #d4a843;   /* primary accent — active, focus, key affordances */
+  --accent-dim:    #80621a;   /* dimmed gold */
+  --accent-muted:  #2a1e06;   /* gold at low opacity */
+
+  /* --- Accent 2: Tron Cyan (neon electric) --- */
+  --cyan:          #00d4e8;   /* electric cyan — Tron primary glow */
+  --cyan-dim:      #007a8a;   /* dimmed cyan */
+  --cyan-muted:    #001e28;   /* cyan tint background */
+  --cyan-glow:     0 0 12px rgba(0,212,232,0.35), 0 0 4px rgba(0,212,232,0.5);
+
+  /* --- Vault: Neon green (digital growth) --- */
+  --vault:         #39e87d;   /* vault-connected — electric green */
+  --vault-dim:     #1a7840;   /* vault hover */
+  --vault-muted:   #041a10;   /* vault background tint */
+  --vault-glow:    0 0 8px rgba(57,232,125,0.3);
+
+  /* --- Agent: Electric blue (machine voice) --- */
+  --agent:         #4a9eff;   /* agent-contributed UI and content */
+  --agent-dim:     #1e5a9a;   /* agent hover */
+  --agent-muted:   #051228;   /* agent background tint */
+  --agent-glow:    0 0 8px rgba(74,158,255,0.3);
+
+  /* --- Amber (staged / uncommitted) --- */
+  --amber:         #f09030;   /* warnings, uncommitted/staged state */
+  --amber-dim:     #805010;
+  --amber-muted:   #1a0e02;
+
+  /* --- Destructive --- */
+  --destructive:      #ff3d3d;
+  --destructive-dim:  #8a1a1a;
+  --destructive-muted:#160404;
+
+  /* --- Semantic UI colors --- */
+  --color-bg:        var(--bg-base);
+  --color-surface:   var(--bg-surface);
+  --color-text:      var(--fg-1);
+  --color-muted:     var(--fg-2);
+  --color-dim:       var(--fg-3);
+  --color-border:    var(--border);
+  --color-accent:    var(--accent);
+
+  /* ============================================================
+     TYPOGRAPHY
+     ============================================================ */
+
+  /* --- Font families --- */
+  --font-display:  'EB Garamond', Georgia, serif;
+  --font-ui:       'Space Grotesk', system-ui, sans-serif;
+  --font-mono:     'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+
+  /* --- Type scale (rem, base 16px) --- */
+  --text-xs:    0.6875rem;   /* 11px — metadata, timestamps */
+  --text-sm:    0.8125rem;   /* 13px — secondary labels, captions */
+  --text-base:  0.9375rem;   /* 15px — body / default UI */
+  --text-md:    1.0625rem;   /* 17px — slightly emphasized body */
+  --text-lg:    1.1875rem;   /* 19px — section headers */
+  --text-xl:    1.5rem;      /* 24px — page titles */
+  --text-2xl:   2rem;        /* 32px — display moments */
+  --text-3xl:   2.75rem;     /* 44px — wordmark / hero */
+  --text-4xl:   3.75rem;     /* 60px — large display */
+
+  /* --- Line heights --- */
+  --leading-tight:  1.25;
+  --leading-snug:   1.4;
+  --leading-normal: 1.55;
+  --leading-loose:  1.75;
+
+  /* --- Font weights --- */
+  --weight-light:   300;
+  --weight-regular: 400;
+  --weight-medium:  500;
+  --weight-semibold:600;
+
+  /* --- Letter spacing --- */
+  --tracking-tight: -0.02em;
+  --tracking-normal: 0em;
+  --tracking-wide:   0.04em;
+  --tracking-wider:  0.08em;
+
+  /* ============================================================
+     SPACING
+     ============================================================ */
+  --space-1:   4px;
+  --space-2:   8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  20px;
+  --space-6:  24px;
+  --space-8:  32px;
+  --space-10: 40px;
+  --space-12: 48px;
+  --space-16: 64px;
+
+  /* ============================================================
+     BORDER RADIUS — sharper for cyberpunk aesthetic
+     ============================================================ */
+  --radius-sm:   2px;
+  --radius-md:   4px;
+  --radius-lg:   6px;
+  --radius-xl:  10px;
+  --radius-full: 9999px;
+
+  /* ============================================================
+     SHADOWS / ELEVATION
+     ============================================================ */
+  --shadow-sm:  0 1px 3px rgba(0,0,0,0.3);
+  --shadow-md:  0 4px 12px rgba(0,0,0,0.4);
+  --shadow-lg:  0 8px 32px rgba(0,0,0,0.5);
+  --shadow-float: 0 4px 24px rgba(0,0,0,0.55), 0 1px 4px rgba(0,0,0,0.3);
+  --shadow-inset: inset 0 1px 3px rgba(0,0,0,0.35);
+
+  /* ============================================================
+     ANIMATION
+     ============================================================ */
+  --ease:        cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-linear: linear;
+  --duration-fast: 100ms;
+  --duration-base: 150ms;
+  --duration-slow: 250ms;
+
+  /* ============================================================
+     Z-INDEX SCALE
+     ============================================================ */
+  --z-base:    1;
+  --z-raised:  10;
+  --z-sticky:  100;
+  --z-overlay: 200;
+  --z-modal:   300;
+  --z-toast:   400;
+}
+
+/* ============================================================
+   SEMANTIC ELEMENT DEFAULTS
+   ============================================================ */
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+body {
+  background-color: var(--bg-base);
+  color: var(--fg-1);
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-normal);
+}
+
+/* --- Display headings (EB Garamond) --- */
+h1, .h1 {
+  font-family: var(--font-display);
+  font-size: var(--text-3xl);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  color: var(--fg-1);
+}
+
+h2, .h2 {
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  color: var(--fg-1);
+}
+
+/* --- UI headings (DM Sans) --- */
+h3, .h3 {
+  font-family: var(--font-ui);
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-snug);
+  color: var(--fg-1);
+}
+
+h4, .h4 {
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-snug);
+  color: var(--fg-1);
+}
+
+h5, h6, .h5, .h6 {
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-snug);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--fg-2);
+}
+
+p {
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
+  color: var(--fg-1);
+  text-wrap: pretty;
+}
+
+small, .text-sm {
+  font-size: var(--text-sm);
+  color: var(--fg-2);
+}
+
+.text-xs {
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  font-family: var(--font-mono);
+  letter-spacing: var(--tracking-wide);
+}
+
+code, kbd, pre, .mono {
+  font-family: var(--font-mono);
+  font-size: 0.875em; /* relative to surrounding text */
+}
+
+code {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.1em 0.35em;
+  color: var(--fg-1);
+}
+
+pre {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  overflow-x: auto;
+  font-size: var(--text-sm);
+  line-height: var(--leading-normal);
+  color: var(--fg-1);
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+a:hover {
+  color: var(--fg-1);
+  text-decoration: underline;
+}
+
+hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: var(--space-6) 0;
+}
+
+/* ============================================================
+   UTILITY CLASSES
+   ============================================================ */
+
+/* Text colors */
+.text-primary   { color: var(--fg-1); }
+.text-secondary { color: var(--fg-2); }
+.text-dim       { color: var(--fg-3); }
+.text-accent    { color: var(--accent); }
+.text-cyan      { color: var(--cyan); }
+.text-vault     { color: var(--vault); }
+.text-agent     { color: var(--agent); }
+.text-amber     { color: var(--amber); }
+.text-danger    { color: var(--destructive); }
+
+/* Font families */
+.font-display { font-family: var(--font-display); }
+.font-ui      { font-family: var(--font-ui); }
+.font-mono    { font-family: var(--font-mono); }
+
+/* Weights */
+.weight-light    { font-weight: var(--weight-light); }
+.weight-regular  { font-weight: var(--weight-regular); }
+.weight-medium   { font-weight: var(--weight-medium); }
+.weight-semibold { font-weight: var(--weight-semibold); }
+
+/* Glow effects */
+.glow-cyan   { box-shadow: var(--cyan-glow); }
+.glow-vault  { box-shadow: var(--vault-glow); }
+.glow-agent  { box-shadow: var(--agent-glow); }
+.text-glow-cyan  { text-shadow: 0 0 12px rgba(0,212,232,0.7); }
+.text-glow-gold  { text-shadow: 0 0 16px rgba(212,168,67,0.5); }
+
+/* Tron grid background */
+.grid-bg {
+  background-image:
+    linear-gradient(rgba(0,212,232,0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0,212,232,0.04) 1px, transparent 1px);
+  background-size: 32px 32px;
+}
+
+/* Neon border active state */
+.border-cyan { border-color: var(--cyan) !important; box-shadow: var(--cyan-glow); }
+.border-gold { border-color: var(--accent) !important; box-shadow: 0 0 8px rgba(212,168,67,0.3); }
+
+/* Focus ring */
+:focus-visible {
+  outline: 1px solid var(--cyan);
+  outline-offset: 2px;
+  box-shadow: var(--cyan-glow);
+}

--- a/companion-ui/design_handoff/2026-05-08-cognitive-temporal/design-canvas.jsx
+++ b/companion-ui/design_handoff/2026-05-08-cognitive-temporal/design-canvas.jsx
@@ -1,0 +1,622 @@
+
+// DesignCanvas.jsx — Figma-ish design canvas wrapper
+// Warm gray grid bg + Sections + Artboards + PostIt notes.
+// Artboards are reorderable (grip-drag), labels/titles are inline-editable,
+// and any artboard can be opened in a fullscreen focus overlay (←/→/Esc).
+// State persists to a .design-canvas.state.json sidecar via the host
+// bridge. No assets, no deps.
+//
+// Usage:
+//   <DesignCanvas>
+//     <DCSection id="onboarding" title="Onboarding" subtitle="First-run variants">
+//       <DCArtboard id="a" label="A · Dusk" width={260} height={480}>…</DCArtboard>
+//       <DCArtboard id="b" label="B · Minimal" width={260} height={480}>…</DCArtboard>
+//     </DCSection>
+//   </DesignCanvas>
+
+const DC = {
+  bg: '#f0eee9',
+  grid: 'rgba(0,0,0,0.06)',
+  label: 'rgba(60,50,40,0.7)',
+  title: 'rgba(40,30,20,0.85)',
+  subtitle: 'rgba(60,50,40,0.6)',
+  postitBg: '#fef4a8',
+  postitText: '#5a4a2a',
+  font: '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+};
+
+// One-time CSS injection (classes are dc-prefixed so they don't collide with
+// the hosted design's own styles).
+if (typeof document !== 'undefined' && !document.getElementById('dc-styles')) {
+  const s = document.createElement('style');
+  s.id = 'dc-styles';
+  s.textContent = [
+    '.dc-editable{cursor:text;outline:none;white-space:nowrap;border-radius:3px;padding:0 2px;margin:0 -2px}',
+    '.dc-editable:focus{background:#fff;box-shadow:0 0 0 1.5px #c96442}',
+    '[data-dc-slot]{transition:transform .18s cubic-bezier(.2,.7,.3,1)}',
+    '[data-dc-slot].dc-dragging{transition:none;z-index:10;pointer-events:none}',
+    '[data-dc-slot].dc-dragging .dc-card{box-shadow:0 12px 40px rgba(0,0,0,.25),0 0 0 2px #c96442;transform:scale(1.02)}',
+    '.dc-card{transition:box-shadow .15s,transform .15s}',
+    '.dc-card *{scrollbar-width:none}',
+    '.dc-card *::-webkit-scrollbar{display:none}',
+    '.dc-labelrow{display:flex;align-items:center;gap:4px;height:24px}',
+    '.dc-grip{cursor:grab;display:flex;align-items:center;padding:5px 4px;border-radius:4px;transition:background .12s}',
+    '.dc-grip:hover{background:rgba(0,0,0,.08)}',
+    '.dc-grip:active{cursor:grabbing}',
+    '.dc-labeltext{cursor:pointer;border-radius:4px;padding:3px 6px;display:flex;align-items:center;transition:background .12s}',
+    '.dc-labeltext:hover{background:rgba(0,0,0,.05)}',
+    '.dc-expand{position:absolute;bottom:100%;right:0;margin-bottom:5px;z-index:2;opacity:0;transition:opacity .12s,background .12s;',
+    '  width:22px;height:22px;border-radius:5px;border:none;cursor:pointer;padding:0;',
+    '  background:transparent;color:rgba(60,50,40,.7);display:flex;align-items:center;justify-content:center}',
+    '.dc-expand:hover{background:rgba(0,0,0,.06);color:#2a251f}',
+    '[data-dc-slot]:hover .dc-expand{opacity:1}',
+  ].join('\n');
+  document.head.appendChild(s);
+}
+
+const DCCtx = React.createContext(null);
+
+// ─────────────────────────────────────────────────────────────
+// DesignCanvas — stateful wrapper around the pan/zoom viewport.
+// Owns runtime state (per-section order, renamed titles/labels, focused
+// artboard). Order/titles/labels persist to a .design-canvas.state.json
+// sidecar next to the HTML. Reads go via plain fetch() so the saved
+// arrangement is visible anywhere the HTML + sidecar are served together
+// (omelette preview, direct link, downloaded zip). Writes go through the
+// host's window.omelette bridge — editing requires the omelette runtime.
+// Focus is ephemeral.
+// ─────────────────────────────────────────────────────────────
+const DC_STATE_FILE = '.design-canvas.state.json';
+
+function DesignCanvas({ children, minScale, maxScale, style }) {
+  const [state, setState] = React.useState({ sections: {}, focus: null });
+  // Hold rendering until the sidecar read settles so the saved order/titles
+  // appear on first paint (no source-order flash). didRead gates writes until
+  // the read settles so the empty initial state can't clobber a slow read;
+  // skipNextWrite suppresses the one echo-write that would otherwise follow
+  // hydration.
+  const [ready, setReady] = React.useState(false);
+  const didRead = React.useRef(false);
+  const skipNextWrite = React.useRef(false);
+
+  React.useEffect(() => {
+    let off = false;
+    fetch('./' + DC_STATE_FILE)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((saved) => {
+        if (off || !saved || !saved.sections) return;
+        skipNextWrite.current = true;
+        setState((s) => ({ ...s, sections: saved.sections }));
+      })
+      .catch(() => {})
+      .finally(() => { didRead.current = true; if (!off) setReady(true); });
+    const t = setTimeout(() => { if (!off) setReady(true); }, 150);
+    return () => { off = true; clearTimeout(t); };
+  }, []);
+
+  React.useEffect(() => {
+    if (!didRead.current) return;
+    if (skipNextWrite.current) { skipNextWrite.current = false; return; }
+    const t = setTimeout(() => {
+      window.omelette?.writeFile(DC_STATE_FILE, JSON.stringify({ sections: state.sections })).catch(() => {});
+    }, 250);
+    return () => clearTimeout(t);
+  }, [state.sections]);
+
+  // Build registries synchronously from children so FocusOverlay can read
+  // them in the same render. Only direct DCSection > DCArtboard children are
+  // walked — wrapping them in other elements opts out of focus/reorder.
+  const registry = {};     // slotId -> { sectionId, artboard }
+  const sectionMeta = {};  // sectionId -> { title, subtitle, slotIds[] }
+  const sectionOrder = [];
+  React.Children.forEach(children, (sec) => {
+    if (!sec || sec.type !== DCSection) return;
+    const sid = sec.props.id ?? sec.props.title;
+    if (!sid) return;
+    sectionOrder.push(sid);
+    const persisted = state.sections[sid] || {};
+    const srcIds = [];
+    React.Children.forEach(sec.props.children, (ab) => {
+      if (!ab || ab.type !== DCArtboard) return;
+      const aid = ab.props.id ?? ab.props.label;
+      if (!aid) return;
+      registry[`${sid}/${aid}`] = { sectionId: sid, artboard: ab };
+      srcIds.push(aid);
+    });
+    const kept = (persisted.order || []).filter((k) => srcIds.includes(k));
+    sectionMeta[sid] = {
+      title: persisted.title ?? sec.props.title,
+      subtitle: sec.props.subtitle,
+      slotIds: [...kept, ...srcIds.filter((k) => !kept.includes(k))],
+    };
+  });
+
+  const api = React.useMemo(() => ({
+    state,
+    section: (id) => state.sections[id] || {},
+    patchSection: (id, p) => setState((s) => ({
+      ...s,
+      sections: { ...s.sections, [id]: { ...s.sections[id], ...(typeof p === 'function' ? p(s.sections[id] || {}) : p) } },
+    })),
+    setFocus: (slotId) => setState((s) => ({ ...s, focus: slotId })),
+  }), [state]);
+
+  // Esc exits focus; any outside pointerdown commits an in-progress rename.
+  React.useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') api.setFocus(null); };
+    const onPd = (e) => {
+      const ae = document.activeElement;
+      if (ae && ae.isContentEditable && !ae.contains(e.target)) ae.blur();
+    };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('pointerdown', onPd, true);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('pointerdown', onPd, true);
+    };
+  }, [api]);
+
+  return (
+    <DCCtx.Provider value={api}>
+      <DCViewport minScale={minScale} maxScale={maxScale} style={style}>{ready && children}</DCViewport>
+      {state.focus && registry[state.focus] && (
+        <DCFocusOverlay entry={registry[state.focus]} sectionMeta={sectionMeta} sectionOrder={sectionOrder} />
+      )}
+    </DCCtx.Provider>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCViewport — transform-based pan/zoom (internal)
+//
+// Input mapping (Figma-style):
+//   • trackpad pinch  → zoom   (ctrlKey wheel; Safari gesture* events)
+//   • trackpad scroll → pan    (two-finger)
+//   • mouse wheel     → zoom   (notched; distinguished from trackpad scroll)
+//   • middle-drag / primary-drag-on-bg → pan
+//
+// Transform state lives in a ref and is written straight to the DOM
+// (translate3d + will-change) so wheel ticks don't go through React —
+// keeps pans at 60fps on dense canvases.
+// ─────────────────────────────────────────────────────────────
+function DCViewport({ children, minScale = 0.1, maxScale = 8, style = {} }) {
+  const vpRef = React.useRef(null);
+  const worldRef = React.useRef(null);
+  const tf = React.useRef({ x: 0, y: 0, scale: 1 });
+
+  const apply = React.useCallback(() => {
+    const { x, y, scale } = tf.current;
+    const el = worldRef.current;
+    if (el) el.style.transform = `translate3d(${x}px, ${y}px, 0) scale(${scale})`;
+  }, []);
+
+  React.useEffect(() => {
+    const vp = vpRef.current;
+    if (!vp) return;
+
+    const zoomAt = (cx, cy, factor) => {
+      const r = vp.getBoundingClientRect();
+      const px = cx - r.left, py = cy - r.top;
+      const t = tf.current;
+      const next = Math.min(maxScale, Math.max(minScale, t.scale * factor));
+      const k = next / t.scale;
+      // keep the world point under the cursor fixed
+      t.x = px - (px - t.x) * k;
+      t.y = py - (py - t.y) * k;
+      t.scale = next;
+      apply();
+    };
+
+    // Mouse-wheel vs trackpad-scroll heuristic. A physical wheel sends
+    // line-mode deltas (Firefox) or large integer pixel deltas with no X
+    // component (Chrome/Safari, typically multiples of 100/120). Trackpad
+    // two-finger scroll sends small/fractional pixel deltas, often with
+    // non-zero deltaX. ctrlKey is set by the browser for trackpad pinch.
+    const isMouseWheel = (e) =>
+      e.deltaMode !== 0 ||
+      (e.deltaX === 0 && Number.isInteger(e.deltaY) && Math.abs(e.deltaY) >= 40);
+
+    const onWheel = (e) => {
+      e.preventDefault();
+      if (isGesturing) return; // Safari: gesture* owns the pinch — discard concurrent wheels
+      if (e.ctrlKey) {
+        // trackpad pinch (or explicit ctrl+wheel)
+        zoomAt(e.clientX, e.clientY, Math.exp(-e.deltaY * 0.01));
+      } else if (isMouseWheel(e)) {
+        // notched mouse wheel — fixed-ratio step per click
+        zoomAt(e.clientX, e.clientY, Math.exp(-Math.sign(e.deltaY) * 0.18));
+      } else {
+        // trackpad two-finger scroll — pan
+        tf.current.x -= e.deltaX;
+        tf.current.y -= e.deltaY;
+        apply();
+      }
+    };
+
+    // Safari sends native gesture* events for trackpad pinch with a smooth
+    // e.scale; preferring these over the ctrl+wheel fallback gives a much
+    // better feel there. No-ops on other browsers. Safari also fires
+    // ctrlKey wheel events during the same pinch — isGesturing makes
+    // onWheel drop those entirely so they neither zoom nor pan.
+    let gsBase = 1;
+    let isGesturing = false;
+    const onGestureStart = (e) => { e.preventDefault(); isGesturing = true; gsBase = tf.current.scale; };
+    const onGestureChange = (e) => {
+      e.preventDefault();
+      zoomAt(e.clientX, e.clientY, (gsBase * e.scale) / tf.current.scale);
+    };
+    const onGestureEnd = (e) => { e.preventDefault(); isGesturing = false; };
+
+    // Drag-pan: middle button anywhere, or primary button on canvas
+    // background (anything that isn't an artboard or an inline editor).
+    let drag = null;
+    const onPointerDown = (e) => {
+      const onBg = !e.target.closest('[data-dc-slot], .dc-editable');
+      if (!(e.button === 1 || (e.button === 0 && onBg))) return;
+      e.preventDefault();
+      vp.setPointerCapture(e.pointerId);
+      drag = { id: e.pointerId, lx: e.clientX, ly: e.clientY };
+      vp.style.cursor = 'grabbing';
+    };
+    const onPointerMove = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      tf.current.x += e.clientX - drag.lx;
+      tf.current.y += e.clientY - drag.ly;
+      drag.lx = e.clientX; drag.ly = e.clientY;
+      apply();
+    };
+    const onPointerUp = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      vp.releasePointerCapture(e.pointerId);
+      drag = null;
+      vp.style.cursor = '';
+    };
+
+    vp.addEventListener('wheel', onWheel, { passive: false });
+    vp.addEventListener('gesturestart', onGestureStart, { passive: false });
+    vp.addEventListener('gesturechange', onGestureChange, { passive: false });
+    vp.addEventListener('gestureend', onGestureEnd, { passive: false });
+    vp.addEventListener('pointerdown', onPointerDown);
+    vp.addEventListener('pointermove', onPointerMove);
+    vp.addEventListener('pointerup', onPointerUp);
+    vp.addEventListener('pointercancel', onPointerUp);
+    return () => {
+      vp.removeEventListener('wheel', onWheel);
+      vp.removeEventListener('gesturestart', onGestureStart);
+      vp.removeEventListener('gesturechange', onGestureChange);
+      vp.removeEventListener('gestureend', onGestureEnd);
+      vp.removeEventListener('pointerdown', onPointerDown);
+      vp.removeEventListener('pointermove', onPointerMove);
+      vp.removeEventListener('pointerup', onPointerUp);
+      vp.removeEventListener('pointercancel', onPointerUp);
+    };
+  }, [apply, minScale, maxScale]);
+
+  const gridSvg = `url("data:image/svg+xml,%3Csvg width='120' height='120' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M120 0H0v120' fill='none' stroke='${encodeURIComponent(DC.grid)}' stroke-width='1'/%3E%3C/svg%3E")`;
+  return (
+    <div
+      ref={vpRef}
+      className="design-canvas"
+      style={{
+        height: '100vh', width: '100vw',
+        background: DC.bg,
+        overflow: 'hidden',
+        overscrollBehavior: 'none',
+        touchAction: 'none',
+        position: 'relative',
+        fontFamily: DC.font,
+        boxSizing: 'border-box',
+        ...style,
+      }}
+    >
+      <div
+        ref={worldRef}
+        style={{
+          position: 'absolute', top: 0, left: 0,
+          transformOrigin: '0 0',
+          willChange: 'transform',
+          width: 'max-content', minWidth: '100%',
+          minHeight: '100%',
+          padding: '60px 0 80px',
+        }}
+      >
+        <div style={{ position: 'absolute', inset: -6000, backgroundImage: gridSvg, backgroundSize: '120px 120px', pointerEvents: 'none', zIndex: -1 }} />
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCSection — editable title + h-row of artboards in persisted order
+// ─────────────────────────────────────────────────────────────
+function DCSection({ id, title, subtitle, children, gap = 48 }) {
+  const ctx = React.useContext(DCCtx);
+  const sid = id ?? title;
+  const all = React.Children.toArray(children);
+  const artboards = all.filter((c) => c && c.type === DCArtboard);
+  const rest = all.filter((c) => !(c && c.type === DCArtboard));
+  const srcOrder = artboards.map((a) => a.props.id ?? a.props.label);
+  const sec = (ctx && sid && ctx.section(sid)) || {};
+
+  const order = React.useMemo(() => {
+    const kept = (sec.order || []).filter((k) => srcOrder.includes(k));
+    return [...kept, ...srcOrder.filter((k) => !kept.includes(k))];
+  }, [sec.order, srcOrder.join('|')]);
+
+  const byId = Object.fromEntries(artboards.map((a) => [a.props.id ?? a.props.label, a]));
+
+  return (
+    <div data-dc-section={sid} style={{ marginBottom: 80, position: 'relative' }}>
+      <div style={{ padding: '0 60px 56px' }}>
+        <DCEditable tag="div" value={sec.title ?? title}
+          onChange={(v) => ctx && sid && ctx.patchSection(sid, { title: v })}
+          style={{ fontSize: 28, fontWeight: 600, color: DC.title, letterSpacing: -0.4, marginBottom: 6, display: 'inline-block' }} />
+        {subtitle && <div style={{ fontSize: 16, color: DC.subtitle }}>{subtitle}</div>}
+      </div>
+      <div style={{ display: 'flex', gap, padding: '0 60px', alignItems: 'flex-start', width: 'max-content' }}>
+        {order.map((k) => (
+          <DCArtboardFrame key={k} sectionId={sid} artboard={byId[k]} order={order}
+            label={(sec.labels || {})[k] ?? byId[k].props.label}
+            onRename={(v) => ctx && ctx.patchSection(sid, (x) => ({ labels: { ...x.labels, [k]: v } }))}
+            onReorder={(next) => ctx && ctx.patchSection(sid, { order: next })}
+            onFocus={() => ctx && ctx.setFocus(`${sid}/${k}`)} />
+        ))}
+      </div>
+      {rest}
+    </div>
+  );
+}
+
+// DCArtboard — marker; rendered by DCArtboardFrame via DCSection.
+function DCArtboard() { return null; }
+
+function DCArtboardFrame({ sectionId, artboard, label, order, onRename, onReorder, onFocus }) {
+  const { id: rawId, label: rawLabel, width = 260, height = 480, children, style = {} } = artboard.props;
+  const id = rawId ?? rawLabel;
+  const ref = React.useRef(null);
+
+  // Live drag-reorder: dragged card sticks to cursor; siblings slide into
+  // their would-be slots in real time via transforms. DOM order only
+  // changes on drop.
+  const onGripDown = (e) => {
+    e.preventDefault(); e.stopPropagation();
+    const me = ref.current;
+    // translateX is applied in local (pre-scale) space but pointer deltas and
+    // getBoundingClientRect().left are screen-space — divide by the viewport's
+    // current scale so the dragged card tracks the cursor at any zoom level.
+    const scale = me.getBoundingClientRect().width / me.offsetWidth || 1;
+    const peers = Array.from(document.querySelectorAll(`[data-dc-section="${sectionId}"] [data-dc-slot]`));
+    const homes = peers.map((el) => ({ el, id: el.dataset.dcSlot, x: el.getBoundingClientRect().left }));
+    const slotXs = homes.map((h) => h.x);
+    const startIdx = order.indexOf(id);
+    const startX = e.clientX;
+    let liveOrder = order.slice();
+    me.classList.add('dc-dragging');
+
+    const layout = () => {
+      for (const h of homes) {
+        if (h.id === id) continue;
+        const slot = liveOrder.indexOf(h.id);
+        h.el.style.transform = `translateX(${(slotXs[slot] - h.x) / scale}px)`;
+      }
+    };
+
+    const move = (ev) => {
+      const dx = ev.clientX - startX;
+      me.style.transform = `translateX(${dx / scale}px)`;
+      const cur = homes[startIdx].x + dx;
+      let nearest = 0, best = Infinity;
+      for (let i = 0; i < slotXs.length; i++) {
+        const d = Math.abs(slotXs[i] - cur);
+        if (d < best) { best = d; nearest = i; }
+      }
+      if (liveOrder.indexOf(id) !== nearest) {
+        liveOrder = order.filter((k) => k !== id);
+        liveOrder.splice(nearest, 0, id);
+        layout();
+      }
+    };
+
+    const up = () => {
+      document.removeEventListener('pointermove', move);
+      document.removeEventListener('pointerup', up);
+      const finalSlot = liveOrder.indexOf(id);
+      me.classList.remove('dc-dragging');
+      me.style.transform = `translateX(${(slotXs[finalSlot] - homes[startIdx].x) / scale}px)`;
+      // After the settle transition, kill transitions + clear transforms +
+      // commit the reorder in the same frame so there's no visual snap-back.
+      setTimeout(() => {
+        for (const h of homes) { h.el.style.transition = 'none'; h.el.style.transform = ''; }
+        if (liveOrder.join('|') !== order.join('|')) onReorder(liveOrder);
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+          for (const h of homes) h.el.style.transition = '';
+        }));
+      }, 180);
+    };
+    document.addEventListener('pointermove', move);
+    document.addEventListener('pointerup', up);
+  };
+
+  return (
+    <div ref={ref} data-dc-slot={id} style={{ position: 'relative', flexShrink: 0 }}>
+      <div className="dc-labelrow" style={{ position: 'absolute', bottom: '100%', left: -4, marginBottom: 4, color: DC.label }}>
+        <div className="dc-grip" onPointerDown={onGripDown} title="Drag to reorder">
+          <svg width="9" height="13" viewBox="0 0 9 13" fill="currentColor"><circle cx="2" cy="2" r="1.1"/><circle cx="7" cy="2" r="1.1"/><circle cx="2" cy="6.5" r="1.1"/><circle cx="7" cy="6.5" r="1.1"/><circle cx="2" cy="11" r="1.1"/><circle cx="7" cy="11" r="1.1"/></svg>
+        </div>
+        <div className="dc-labeltext" onClick={onFocus} title="Click to focus">
+          <DCEditable value={label} onChange={onRename} onClick={(e) => e.stopPropagation()}
+            style={{ fontSize: 15, fontWeight: 500, color: DC.label, lineHeight: 1 }} />
+        </div>
+      </div>
+      <button className="dc-expand" onClick={onFocus} onPointerDown={(e) => e.stopPropagation()} title="Focus">
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"><path d="M7 1h4v4M5 11H1V7M11 1L7.5 4.5M1 11l3.5-3.5"/></svg>
+      </button>
+      <div className="dc-card"
+        style={{ borderRadius: 2, boxShadow: '0 1px 3px rgba(0,0,0,.08),0 4px 16px rgba(0,0,0,.06)', overflow: 'hidden', width, height, background: '#fff', ...style }}>
+        {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb', fontSize: 13, fontFamily: DC.font }}>{id}</div>}
+      </div>
+    </div>
+  );
+}
+
+// Inline rename — commits on blur or Enter.
+function DCEditable({ value, onChange, style, tag = 'span', onClick }) {
+  const T = tag;
+  return (
+    <T className="dc-editable" contentEditable suppressContentEditableWarning
+      onClick={onClick}
+      onPointerDown={(e) => e.stopPropagation()}
+      onBlur={(e) => onChange && onChange(e.currentTarget.textContent)}
+      onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); e.currentTarget.blur(); } }}
+      style={style}>{value}</T>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Focus mode — overlay one artboard; ←/→ within section, ↑/↓ across
+// sections, Esc or backdrop click to exit.
+// ─────────────────────────────────────────────────────────────
+function DCFocusOverlay({ entry, sectionMeta, sectionOrder }) {
+  const ctx = React.useContext(DCCtx);
+  const { sectionId, artboard } = entry;
+  const sec = ctx.section(sectionId);
+  const meta = sectionMeta[sectionId];
+  const peers = meta.slotIds;
+  const aid = artboard.props.id ?? artboard.props.label;
+  const idx = peers.indexOf(aid);
+  const secIdx = sectionOrder.indexOf(sectionId);
+
+  const go = (d) => { const n = peers[(idx + d + peers.length) % peers.length]; if (n) ctx.setFocus(`${sectionId}/${n}`); };
+  const goSection = (d) => {
+    const ns = sectionOrder[(secIdx + d + sectionOrder.length) % sectionOrder.length];
+    const first = sectionMeta[ns] && sectionMeta[ns].slotIds[0];
+    if (first) ctx.setFocus(`${ns}/${first}`);
+  };
+
+  React.useEffect(() => {
+    const k = (e) => {
+      if (e.key === 'ArrowLeft') { e.preventDefault(); go(-1); }
+      if (e.key === 'ArrowRight') { e.preventDefault(); go(1); }
+      if (e.key === 'ArrowUp') { e.preventDefault(); goSection(-1); }
+      if (e.key === 'ArrowDown') { e.preventDefault(); goSection(1); }
+    };
+    document.addEventListener('keydown', k);
+    return () => document.removeEventListener('keydown', k);
+  });
+
+  const { width = 260, height = 480, children } = artboard.props;
+  const [vp, setVp] = React.useState({ w: window.innerWidth, h: window.innerHeight });
+  React.useEffect(() => { const r = () => setVp({ w: window.innerWidth, h: window.innerHeight }); window.addEventListener('resize', r); return () => window.removeEventListener('resize', r); }, []);
+  const scale = Math.max(0.1, Math.min((vp.w - 200) / width, (vp.h - 260) / height, 2));
+
+  const [ddOpen, setDd] = React.useState(false);
+  const Arrow = ({ dir, onClick }) => (
+    <button onClick={(e) => { e.stopPropagation(); onClick(); }}
+      style={{ position: 'absolute', top: '50%', [dir]: 28, transform: 'translateY(-50%)',
+        border: 'none', background: 'rgba(255,255,255,.08)', color: 'rgba(255,255,255,.9)',
+        width: 44, height: 44, borderRadius: 22, fontSize: 18, cursor: 'pointer',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'background .15s' }}
+      onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.18)')}
+      onMouseLeave={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.08)')}>
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+        <path d={dir === 'left' ? 'M11 3L5 9l6 6' : 'M7 3l6 6-6 6'} /></svg>
+    </button>
+  );
+
+  // Portal to body so position:fixed is the real viewport regardless of any
+  // transform on DesignCanvas's ancestors (including the canvas zoom itself).
+  return ReactDOM.createPortal(
+    <div onClick={() => ctx.setFocus(null)}
+      onWheel={(e) => e.preventDefault()}
+      style={{ position: 'fixed', inset: 0, zIndex: 100, background: 'rgba(24,20,16,.6)', backdropFilter: 'blur(14px)',
+        fontFamily: DC.font, color: '#fff' }}>
+
+      {/* top bar: section dropdown (left) · close (right) */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 72, display: 'flex', alignItems: 'flex-start', padding: '16px 20px 0', gap: 16 }}>
+        <div style={{ position: 'relative' }}>
+          <button onClick={() => setDd((o) => !o)}
+            style={{ border: 'none', background: 'transparent', color: '#fff', cursor: 'pointer', padding: '6px 8px',
+              borderRadius: 6, textAlign: 'left', fontFamily: 'inherit' }}>
+            <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span style={{ fontSize: 18, fontWeight: 600, letterSpacing: -0.3 }}>{meta.title}</span>
+              <svg width="11" height="11" viewBox="0 0 11 11" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" style={{ opacity: .7 }}><path d="M2 4l3.5 3.5L9 4"/></svg>
+            </span>
+            {meta.subtitle && <span style={{ display: 'block', fontSize: 13, opacity: .6, fontWeight: 400, marginTop: 2 }}>{meta.subtitle}</span>}
+          </button>
+          {ddOpen && (
+            <div style={{ position: 'absolute', top: '100%', left: 0, marginTop: 4, background: '#2a251f', borderRadius: 8,
+              boxShadow: '0 8px 32px rgba(0,0,0,.4)', padding: 4, minWidth: 200, zIndex: 10 }}>
+              {sectionOrder.map((sid) => (
+                <button key={sid} onClick={() => { setDd(false); const f = sectionMeta[sid].slotIds[0]; if (f) ctx.setFocus(`${sid}/${f}`); }}
+                  style={{ display: 'block', width: '100%', textAlign: 'left', border: 'none', cursor: 'pointer',
+                    background: sid === sectionId ? 'rgba(255,255,255,.1)' : 'transparent', color: '#fff',
+                    padding: '8px 12px', borderRadius: 5, fontSize: 14, fontWeight: sid === sectionId ? 600 : 400, fontFamily: 'inherit' }}>
+                  {sectionMeta[sid].title}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <div style={{ flex: 1 }} />
+        <button onClick={() => ctx.setFocus(null)}
+          onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.12)')}
+          onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+          style={{ border: 'none', background: 'transparent', color: 'rgba(255,255,255,.7)', width: 32, height: 32,
+            borderRadius: 16, fontSize: 20, cursor: 'pointer', lineHeight: 1, transition: 'background .12s' }}>×</button>
+      </div>
+
+      {/* card centered, label + index below — only the card itself stops
+          propagation so any backdrop click (including the margins around
+          the card) exits focus */}
+      <div
+        style={{ position: 'absolute', top: 64, bottom: 56, left: 100, right: 100, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 16 }}>
+        <div onClick={(e) => e.stopPropagation()} style={{ width: width * scale, height: height * scale, position: 'relative' }}>
+          <div style={{ width, height, transform: `scale(${scale})`, transformOrigin: 'top left', background: '#fff', borderRadius: 2, overflow: 'hidden',
+            boxShadow: '0 20px 80px rgba(0,0,0,.4)' }}>
+            {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb' }}>{aid}</div>}
+          </div>
+        </div>
+        <div onClick={(e) => e.stopPropagation()} style={{ fontSize: 14, fontWeight: 500, opacity: .85, textAlign: 'center' }}>
+          {(sec.labels || {})[aid] ?? artboard.props.label}
+          <span style={{ opacity: .5, marginLeft: 10, fontVariantNumeric: 'tabular-nums' }}>{idx + 1} / {peers.length}</span>
+        </div>
+      </div>
+
+      <Arrow dir="left" onClick={() => go(-1)} />
+      <Arrow dir="right" onClick={() => go(1)} />
+
+      {/* dots */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', bottom: 20, left: '50%', transform: 'translateX(-50%)', display: 'flex', gap: 8 }}>
+        {peers.map((p, i) => (
+          <button key={p} onClick={() => ctx.setFocus(`${sectionId}/${p}`)}
+            style={{ border: 'none', padding: 0, cursor: 'pointer', width: 6, height: 6, borderRadius: 3,
+              background: i === idx ? '#fff' : 'rgba(255,255,255,.3)' }} />
+        ))}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Post-it — absolute-positioned sticky note
+// ─────────────────────────────────────────────────────────────
+function DCPostIt({ children, top, left, right, bottom, rotate = -2, width = 180 }) {
+  return (
+    <div style={{
+      position: 'absolute', top, left, right, bottom, width,
+      background: DC.postitBg, padding: '14px 16px',
+      fontFamily: '"Comic Sans MS", "Marker Felt", "Segoe Print", cursive',
+      fontSize: 14, lineHeight: 1.4, color: DC.postitText,
+      boxShadow: '0 2px 8px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08)',
+      transform: `rotate(${rotate}deg)`,
+      zIndex: 5,
+    }}>{children}</div>
+  );
+}
+
+Object.assign(window, { DesignCanvas, DCSection, DCArtboard, DCPostIt });
+

--- a/companion-ui/design_handoff/2026-05-08-cognitive-temporal/mode-exploration.jsx
+++ b/companion-ui/design_handoff/2026-05-08-cognitive-temporal/mode-exploration.jsx
@@ -1,0 +1,143 @@
+/* Mode 2: Exploration
+   ─ divergent thinking; speculative associations; ephemeral cognition.
+   Wireframe: temporary canvas blooms beside document. Branches without
+   committing. Cyan-toned (signal of probe/transient). Has a soft event
+   horizon — close it and ideas dissolve unless explicitly saved. */
+
+function ModeExploration_Wire() {
+  return (
+    <div style={{ width:880, height:560, background:'var(--bg-base)',
+      display:'flex', flexDirection:'column', overflow:'hidden',
+      position:'relative' }}>
+      <StageTopBar surface="Converse" />
+
+      <div style={{ flex:1, display:'flex', overflow:'hidden' }}>
+        {/* document — narrower; explore canvas takes the right half */}
+        <div style={{ flex:'0 0 42%', padding:'26px 32px',
+          borderRight:'1px solid var(--border)', overflow:'hidden' }}>
+          <DocFrontmatter />
+          <DocTitle />
+          <DocH level={2}>## Decision record</DocH>
+          {/* highlighted phrase — anchor of the exploration */}
+          <div style={{ position:'relative', marginBottom:14 }}>
+            <Lines n={3} h={7} last="62%" c="var(--border-strong)" />
+            <div style={{ position:'absolute', top:6, left:0, width:'58%', height:9,
+              background:'rgba(0,212,232,0.12)',
+              border:'1px solid rgba(0,212,232,0.35)', borderRadius:2 }} />
+          </div>
+          <DocH level={3}>### Network boundary</DocH>
+          <DocPara n={2} dim />
+        </div>
+
+        {/* Explore canvas — temporary, dotted edge to signal ephemerality */}
+        <div style={{ flex:1, position:'relative',
+          background:'rgba(0,212,232,0.025)',
+          backgroundImage:'radial-gradient(rgba(0,212,232,0.18) 1px, transparent 1px)',
+          backgroundSize:'12px 12px', overflow:'hidden' }}>
+
+          {/* canvas header */}
+          <div style={{ position:'absolute', top:0, left:0, right:0,
+            display:'flex', alignItems:'center', gap:8, padding:'8px 12px',
+            background:'rgba(7,11,18,0.7)',
+            borderBottom:'1px dashed var(--cyan-dim)' }}>
+            <IconBox size={10} color="var(--cyan)" />
+            <span style={{ ...T.mono, fontSize:9, color:'var(--cyan)',
+              textTransform:'uppercase', letterSpacing:'0.1em' }}>
+              Exploration · ephemeral
+            </span>
+            <span style={{ ...T.mono, fontSize:9, color:'var(--fg-3)' }}>
+              anchored to “runtime contract”
+            </span>
+            <span style={{ marginLeft:'auto', ...T.mono, fontSize:9,
+              color:'var(--fg-3)' }}>5 min · auto-fade</span>
+          </div>
+
+          {/* the seed prompt — small, lower-left */}
+          <div style={{ position:'absolute', left:14, top:46, width:170,
+            background:'var(--bg-raised)', border:'1px solid var(--border-strong)',
+            borderRadius:'4px 4px 1px 4px', padding:'7px 9px' }}>
+            <Lines n={2} h={6} last="50%" c="rgba(220,232,240,0.3)" />
+          </div>
+
+          {/* three speculative branches — different angles */}
+          {[
+            { x:200, y:62, w:175, h:84, c:'var(--cyan)', label:'angle a · constraints',
+              n:3 },
+            { x:200, y:170, w:200, h:74, c:'var(--cyan)', label:'angle b · analogy',
+              n:2, dashed:true },
+            { x:36,  y:188, w:160, h:78, c:'var(--cyan)', label:'angle c · counter',
+              n:2 },
+          ].map(b => (
+            <div key={b.label} style={{ position:'absolute', left:b.x, top:b.y,
+              width:b.w, padding:'7px 9px',
+              background:'rgba(0,30,40,0.5)',
+              border:`1px ${b.dashed?'dashed':'solid'} rgba(0,212,232,0.35)`,
+              borderLeft:`2px solid ${b.c}`, borderRadius:3 }}>
+              <div style={{ display:'flex', alignItems:'center', gap:5, marginBottom:5 }}>
+                <IconBox size={8} color={b.c} />
+                <span style={{ ...T.mono, fontSize:8, color:b.c,
+                  letterSpacing:'0.06em' }}>{b.label}</span>
+              </div>
+              <Lines n={b.n} h={5} last="55%" c="rgba(0,212,232,0.22)" />
+            </div>
+          ))}
+
+          {/* faint connector lines from anchor to branches */}
+          <Arrow d="M 12,40 C 80,40 100,80 195,90"
+            color="rgba(0,212,232,0.4)" head={false} dashed
+            style={{ left:0, top:0, right:0, bottom:0 }} />
+          <Arrow d="M 12,40 C 80,40 100,180 195,200"
+            color="rgba(0,212,232,0.3)" head={false} dashed
+            style={{ left:0, top:0, right:0, bottom:0 }} />
+          <Arrow d="M 12,40 C 30,80 60,150 100,200"
+            color="rgba(0,212,232,0.25)" head={false} dashed
+            style={{ left:0, top:0, right:0, bottom:0 }} />
+
+          {/* footer — keep / dissolve */}
+          <div style={{ position:'absolute', bottom:0, left:0, right:0,
+            display:'flex', alignItems:'center', gap:6, padding:'7px 12px',
+            background:'rgba(7,11,18,0.85)',
+            borderTop:'1px dashed var(--cyan-dim)' }}>
+            <span style={{ ...T.mono, fontSize:9, color:'var(--fg-3)' }}>
+              3 branches · nothing persisted
+            </span>
+            <Btn color="var(--cyan)" style={{ marginLeft:'auto' }}>
+              Promote to companion note
+            </Btn>
+            <Btn color="var(--fg-3)">Dissolve</Btn>
+          </div>
+        </div>
+      </div>
+
+      {/* annotations */}
+      <Anno style={{ position:'absolute', top:50, left:340 }}>
+        ← anchor highlight in doc<br/>→ canvas blooms from it
+      </Anno>
+      <Callout style={{ position:'absolute', right:14, top:48, maxWidth:160 }}>
+        cyan = transient. nothing here is in the vault until the user promotes it.
+      </Callout>
+      <Anno style={{ position:'absolute', left:380, bottom:80, fontSize:11 }}>
+        ↑ branches are reorderable, deletable, mergeable
+      </Anno>
+    </div>
+  );
+}
+
+function ModeExploration_Spec() {
+  return (
+    <SpecCard color="var(--cyan)" rows={[
+      ['Overlay class',  'Adjacent canvas · siblings to document, not modal'],
+      ['Density',        'Low governance · cards float, edges dashed'],
+      ['Persistence',    'Ephemeral by default · auto-fade after inactivity unless promoted'],
+      ['Provenance',     'Each branch tracks origin anchor; no commit until promotion'],
+      ['Sources',        'Soft surfacing · suggested links appear as ghost chips, not citations'],
+      ['AI visibility',  'Mid · agent contributes branches but is one voice among the user\'s'],
+      ['Spatial',        'Splits the stage horizontally; document remains anchored'],
+      ['Interruption',   'Canvas state cached locally · re-opens with same branches for ~24h'],
+      ['Transitions',    'Promote → Synthesis · Anchor branch → in-doc edit (Review) · Dissolve → return to Converse'],
+    ]} />
+  );
+}
+
+window.ModeExploration_Wire = ModeExploration_Wire;
+window.ModeExploration_Spec = ModeExploration_Spec;

--- a/companion-ui/design_handoff/2026-05-08-cognitive-temporal/mode-orientation.jsx
+++ b/companion-ui/design_handoff/2026-05-08-cognitive-temporal/mode-orientation.jsx
@@ -1,0 +1,130 @@
+/* Mode 1: Orientation
+   ─ user returns after interruption; reconstruct active context.
+   Wireframe: document underneath, soft "re-entry" overlay floats above
+   showing unresolved threads, last edits, open loops. Not a dashboard —
+   a brief mist that clears when dismissed. */
+
+function ModeOrientation_Wire() {
+  return (
+    <div style={{ width:880, height:560, background:'var(--bg-base)',
+      display:'flex', flexDirection:'column', overflow:'hidden',
+      position:'relative' }}>
+      <StageTopBar surface="Orient" />
+
+      {/* document is live underneath — slightly desaturated/dimmed */}
+      <div style={{ flex:1, display:'flex', overflow:'hidden', position:'relative' }}>
+        <div style={{ flex:1, padding:'28px 56px', overflow:'hidden',
+          opacity:0.42, filter:'blur(0.4px)' }}>
+          <DocFrontmatter />
+          <DocTitle />
+          <DocH level={2}>## Decision record</DocH>
+          <DocPara n={3} />
+          <DocH level={3}>### Network boundary</DocH>
+          <DocPara n={2} />
+          <DocPara n={3} dim />
+        </div>
+
+        {/* Re-entry overlay — floats centered, doesn't replace doc */}
+        <div style={{ position:'absolute', top:24, left:'50%',
+          transform:'translateX(-50%)', width:540,
+          background:'rgba(14,24,40,0.94)',
+          border:'1px solid rgba(212,168,67,0.35)',
+          borderTop:'2px solid var(--accent)',
+          borderRadius:4, padding:'14px 18px',
+          boxShadow:'var(--shadow-float)', backdropFilter:'blur(4px)' }}>
+          <div style={{ display:'flex', alignItems:'center', gap:8, marginBottom:10 }}>
+            <Pill color="var(--accent)" border="rgba(212,168,67,0.4)"
+              bg="rgba(212,168,67,0.06)">re-entry</Pill>
+            <span style={{ ...T.ui, fontSize:11, color:'var(--fg-2)' }}>
+              You were last here <span style={{color:'var(--fg-1)'}}>3 days ago</span>
+            </span>
+            <span style={{ marginLeft:'auto', ...T.mono, fontSize:9,
+              color:'var(--fg-3)' }}>Esc · dismiss</span>
+          </div>
+
+          {/* unresolved threads */}
+          <div style={{ ...T.mono, fontSize:9, color:'var(--fg-3)',
+            textTransform:'uppercase', letterSpacing:'0.1em', marginBottom:6 }}>
+            Open loops · 3
+          </div>
+          <div style={{ display:'flex', flexDirection:'column', gap:5, marginBottom:12 }}>
+            {[
+              { c:'var(--amber)', t:'staged edit · ## Decision record',
+                m:'awaiting your review · 2d' },
+              { c:'var(--agent)', t:'unanswered prompt · "should we keep boundary X?"',
+                m:'thread paused mid-turn' },
+              { c:'var(--cyan)',  t:'unresolved link · [[Q1-arch]] cited but not opened',
+                m:'1 source unread' },
+            ].map(x => (
+              <div key={x.t} style={{ display:'flex', alignItems:'center', gap:8,
+                padding:'5px 8px', background:'var(--bg-raised)',
+                border:'1px solid var(--border)', borderLeft:`2px solid ${x.c}`,
+                borderRadius:2 }}>
+                <IconDot size={5} color={x.c} />
+                <span style={{ ...T.ui, fontSize:11, color:'var(--fg-1)' }}>{x.t}</span>
+                <span style={{ marginLeft:'auto', ...T.mono, fontSize:9,
+                  color:'var(--fg-3)' }}>{x.m}</span>
+              </div>
+            ))}
+          </div>
+
+          {/* last cognitive trace */}
+          <div style={{ ...T.mono, fontSize:9, color:'var(--fg-3)',
+            textTransform:'uppercase', letterSpacing:'0.1em', marginBottom:6 }}>
+            Last trace
+          </div>
+          <div style={{ ...T.ui, fontSize:11, color:'var(--fg-2)',
+            lineHeight:1.5, marginBottom:10, fontStyle:'italic' }}>
+            “…we were comparing the runtime contract against the network
+            boundary; you stopped mid-edit at line 47.”
+          </div>
+
+          <div style={{ display:'flex', gap:6 }}>
+            <Btn color="var(--accent)" filled>Resume here</Btn>
+            <Btn color="var(--fg-3)">Show all threads</Btn>
+            <Btn color="var(--fg-3)" style={{ marginLeft:'auto' }}>Dismiss</Btn>
+          </div>
+        </div>
+
+        {/* tiny gutter beacons that persist after dismissal */}
+        <div style={{ position:'absolute', left:8, top:140,
+          display:'flex', flexDirection:'column', gap:14 }}>
+          <IconDot size={6} color="var(--amber)" glow />
+          <IconDot size={6} color="var(--agent)" glow />
+          <IconDot size={6} color="var(--cyan)" glow />
+        </div>
+
+        {/* annotations */}
+        <Anno style={{ position:'absolute', left:14, top:108 }}>
+          beacons remain<br/>after dismiss ↓
+        </Anno>
+        <Callout style={{ position:'absolute', right:14, top:42, maxWidth:140 }}>
+          document stays loaded underneath — orientation is a mist, not a wall
+        </Callout>
+        <Anno style={{ position:'absolute', left:'50%', top:380,
+          transform:'translateX(-50%)', textAlign:'center' }}>
+          ↑ overlay self-dismisses on first click in document
+        </Anno>
+      </div>
+    </div>
+  );
+}
+
+function ModeOrientation_Spec() {
+  return (
+    <SpecCard color="var(--accent)" rows={[
+      ['Overlay class',  'Floating re-entry card · centered, dismissible'],
+      ['Density',        'High info, low chrome · 3–7 items max'],
+      ['Persistence',    'Ephemeral · auto-dismiss on first interaction with document'],
+      ['Provenance',     'Each loop links to its anchor (note·section·turn)'],
+      ['Sources',        'Cited but unread links surface as a class of loop'],
+      ['AI visibility',  'Low · Hugin authored the trace summary, attributed inline'],
+      ['Spatial',        'Document remains in its last position; overlay floats above, blurs nothing'],
+      ['Interruption',   'Survives reload via vault-side `orientation/last-trace.md`'],
+      ['Transitions',    'Resume → Converse · Show all threads → Review · Dismiss → free reading'],
+    ]} />
+  );
+}
+
+window.ModeOrientation_Wire = ModeOrientation_Wire;
+window.ModeOrientation_Spec = ModeOrientation_Spec;

--- a/companion-ui/design_handoff/2026-05-08-cognitive-temporal/mode-resurfacing.jsx
+++ b/companion-ui/design_handoff/2026-05-08-cognitive-temporal/mode-resurfacing.jsx
@@ -1,0 +1,133 @@
+/* Mode 5: Resurfacing
+   ─ reintroduce previously relevant knowledge · ambient · non-disruptive.
+   Wireframe: thin marginalia on the side of the document. Items appear
+   like a faint constellation. No pop-ups, no notifications. The user
+   notices when ready. Vault-green at low intensity. */
+
+function ModeResurfacing_Wire() {
+  return (
+    <div style={{ width:880, height:560, background:'var(--bg-base)',
+      display:'flex', flexDirection:'column', overflow:'hidden',
+      position:'relative' }}>
+      <StageTopBar surface="Converse" />
+
+      <div style={{ flex:1, display:'flex', overflow:'hidden' }}>
+        {/* document — full attention */}
+        <div style={{ flex:1, padding:'28px 56px 28px 36px', overflow:'hidden',
+          position:'relative' }}>
+          <DocFrontmatter />
+          <DocTitle />
+          <DocH level={2}>## Decision record</DocH>
+          <DocPara n={3} />
+          <DocH level={3}>### Network boundary</DocH>
+          <DocPara n={2} />
+          <DocH level={3}>### Runtime contract</DocH>
+          <DocPara n={3} dim />
+
+          {/* faint right-edge marks anchored to passages */}
+          {[
+            { top:140, label:'Q1-arch · network',  c:'var(--vault)', size:5, align:0 },
+            { top:200, label:'memory-essay · §2',  c:'var(--vault)', size:7, align:1 },
+            { top:266, label:'session 2026-04-12', c:'var(--agent)', size:5, align:0 },
+            { top:340, label:'evergreen · contracts', c:'var(--vault)', size:9, align:2 },
+            { top:410, label:'Thornwall analogy',  c:'var(--cyan)',  size:5, align:0 },
+          ].map((m,i) => (
+            <div key={i} style={{ position:'absolute',
+              right: 18 + m.align*4, top: m.top,
+              display:'flex', alignItems:'center', gap:6 }}>
+              <IconDot size={m.size} color={m.c}
+                glow={m.size > 6}
+                style={{ opacity: 0.4 + (m.size/15) }} />
+            </div>
+          ))}
+        </div>
+
+        {/* gentle resurface tray — collapsed by default, peeking */}
+        <div style={{ width:200, background:'var(--bg-surface)',
+          borderLeft:'1px dashed var(--border-strong)',
+          display:'flex', flexDirection:'column', flexShrink:0,
+          opacity:0.92 }}>
+          <div style={{ padding:'9px 12px',
+            borderBottom:'1px solid var(--border)',
+            display:'flex', alignItems:'center', gap:6 }}>
+            <IconDot size={5} color="var(--vault)" />
+            <span style={{ ...T.mono, fontSize:9, color:'var(--vault)',
+              textTransform:'uppercase', letterSpacing:'0.08em' }}>
+              resurface
+            </span>
+            <span style={{ marginLeft:'auto', ...T.mono, fontSize:8,
+              color:'var(--fg-3)' }}>5 latent</span>
+          </div>
+          <div style={{ flex:1, padding:'8px 10px',
+            display:'flex', flexDirection:'column', gap:7 }}>
+            {[
+              { c:'var(--vault)', s:0.95, t:'Q1 arch · network',
+                why:'cited in current doc · same boundary' },
+              { c:'var(--vault)', s:0.78, t:'memory-essay · §2',
+                why:'shared concept: contract' },
+              { c:'var(--vault)', s:0.55, t:'evergreen · contracts',
+                why:'high alignment · 3 weeks dormant' },
+              { c:'var(--agent)', s:0.40, t:'session 2026-04-12',
+                why:'you stopped here mid-thought' },
+              { c:'var(--cyan)',  s:0.22, t:'Thornwall analogy',
+                why:'distant · possibly useful' },
+            ].map((r,i) => (
+              <div key={i} style={{ padding:'5px 7px',
+                background:'transparent',
+                borderLeft:`2px solid ${r.c}`,
+                opacity: 0.4 + r.s*0.6 }}>
+                <div style={{ display:'flex', alignItems:'baseline', gap:4 }}>
+                  <span style={{ ...T.ui, fontSize:11,
+                    color:'var(--fg-1)', fontWeight: r.s > 0.7 ? 500 : 400 }}>
+                    {r.t}
+                  </span>
+                </div>
+                <span style={{ ...T.mono, fontSize:9, color:'var(--fg-3)',
+                  fontStyle:'italic', display:'block', marginTop:2,
+                  lineHeight:1.3 }}>
+                  {r.why}
+                </span>
+              </div>
+            ))}
+          </div>
+          <div style={{ padding:'8px 10px',
+            borderTop:'1px solid var(--border)' }}>
+            <span style={{ ...T.mono, fontSize:9, color:'var(--fg-3)' }}>
+              salience falls with distance · no notifications
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* annotations */}
+      <Callout style={{ position:'absolute', top:50, left:14, maxWidth:170 }}>
+        marks at right-edge of doc anchor each resurface to its passage
+      </Callout>
+      <Anno style={{ position:'absolute', left:280, top:160 }}>
+        dot size = salience<br/>opacity = recency ↗
+      </Anno>
+      <Anno style={{ position:'absolute', left:200, bottom:80 }}>
+        ↑ never interrupts — the user&apos;s eye finds it when ready
+      </Anno>
+    </div>
+  );
+}
+
+function ModeResurfacing_Spec() {
+  return (
+    <SpecCard color="var(--vault)" rows={[
+      ['Overlay class',  'Marginalia + soft tray · always present, never demanding'],
+      ['Density',        'Very low · 3–7 items max, sized by salience not equal weight'],
+      ['Persistence',    'Salience model lives in runtime; the items themselves are vault notes'],
+      ['Provenance',     'Each resurface shows reason ("cited", "dormant", "high alignment")'],
+      ['Sources',        'Item IS the source · clicking opens SourcePeek anchored to its passage'],
+      ['AI visibility',  'Background · agent computes salience; no agent voice or chat presence'],
+      ['Spatial',        'Right-edge dots map 1:1 to passages; tray is the legend'],
+      ['Interruption',   'Zero · no notifications, no badges, no popups; survives reload silently'],
+      ['Transitions',    'Click item → SourcePeek (Converse) · Pin item → Synthesis comparison strip · Dismiss → fades for 7 days'],
+    ]} />
+  );
+}
+
+window.ModeResurfacing_Wire = ModeResurfacing_Wire;
+window.ModeResurfacing_Spec = ModeResurfacing_Spec;

--- a/companion-ui/design_handoff/2026-05-08-cognitive-temporal/mode-review.jsx
+++ b/companion-ui/design_handoff/2026-05-08-cognitive-temporal/mode-review.jsx
@@ -1,0 +1,148 @@
+/* Mode 4: Review / Governance
+   ─ human review of AI-generated proposals · provenance · staged accept/reject.
+   Wireframe: document is the surface; staged proposals appear as inline
+   amber blocks with diff + receipts. A small governance dock anchors at
+   the bottom showing the queue. Non-intrusive: nothing applies until
+   the human clicks. Amber tones throughout. */
+
+function ModeReview_Wire() {
+  return (
+    <div style={{ width:880, height:560, background:'var(--bg-base)',
+      display:'flex', flexDirection:'column', overflow:'hidden',
+      position:'relative' }}>
+      <StageTopBar surface="Converse" />
+
+      <div style={{ flex:1, display:'flex', overflow:'hidden' }}>
+        {/* document with staged blocks inline */}
+        <div style={{ flex:1, padding:'24px 36px 60px', overflow:'hidden',
+          position:'relative' }}>
+          <DocFrontmatter />
+          <DocTitle />
+          <DocH level={2}>## Decision record</DocH>
+          <DocPara n={2} />
+
+          {/* staged proposal — inline amber block with receipt */}
+          <div style={{ background:'rgba(240,144,48,0.05)',
+            border:'1px solid rgba(240,144,48,0.25)',
+            borderLeft:'3px solid var(--amber)',
+            borderRadius:'0 3px 3px 0', padding:'10px 12px', marginBottom:14,
+            position:'relative' }}>
+            <div style={{ display:'flex', alignItems:'center', gap:8, marginBottom:8 }}>
+              <Pill color="var(--amber)" bg="rgba(240,144,48,0.06)"
+                border="var(--amber-dim)">SUGGEST</Pill>
+              <span style={{ ...T.mono, fontSize:9, color:'var(--fg-2)' }}>
+                Hugin · 2 changes · receipt #r-2026-05-07-014
+              </span>
+              <span style={{ marginLeft:'auto', ...T.mono, fontSize:9,
+                color:'var(--fg-3)' }}>conf 0.82</span>
+            </div>
+            {/* diff lines */}
+            {[
+              { s:'+', c:'rgba(57,232,125,0.4)', w:'80%' },
+              { s:'+', c:'rgba(57,232,125,0.4)', w:'62%' },
+              { s:'-', c:'rgba(255,61,61,0.4)',  w:'58%' },
+              { s:' ', c:'var(--border-strong)', w:'70%' },
+            ].map((r,i) => (
+              <div key={i} style={{ display:'flex', gap:8, alignItems:'center',
+                marginBottom:4 }}>
+                <span style={{ ...T.mono, fontSize:10,
+                  color: r.s==='+' ? 'rgba(57,232,125,0.7)'
+                    : r.s==='-' ? 'rgba(255,61,61,0.7)' : 'var(--fg-3)',
+                  width:10 }}>{r.s}</span>
+                <div style={{ flex:1, height:6, background:r.c,
+                  borderRadius:1, maxWidth:r.w }} />
+              </div>
+            ))}
+            {/* evidence trail */}
+            <div style={{ marginTop:10, display:'flex', gap:6,
+              flexWrap:'wrap', alignItems:'center' }}>
+              <span style={{ ...T.mono, fontSize:9, color:'var(--fg-3)',
+                textTransform:'uppercase', letterSpacing:'0.08em' }}>
+                evidence
+              </span>
+              {['Q1-arch.md:44', 'memory-essay.md:9', 'session 2026-05-04']
+                .map(e => (
+                  <span key={e} style={{ ...T.mono, fontSize:9,
+                    color:'var(--cyan)', background:'var(--cyan-muted)',
+                    border:'1px solid var(--cyan-dim)', borderRadius:2,
+                    padding:'1px 6px' }}>{e}</span>
+              ))}
+            </div>
+            {/* governance row */}
+            <div style={{ display:'flex', gap:6, marginTop:10 }}>
+              <Btn color="var(--vault)" filled>Apply</Btn>
+              <Btn color="var(--amber)">Apply w/ edits</Btn>
+              <Btn color="var(--fg-3)">Defer</Btn>
+              <Btn color="var(--destructive)">Reject</Btn>
+              <span style={{ marginLeft:'auto', ...T.mono, fontSize:9,
+                color:'var(--fg-3)', alignSelf:'center' }}>
+                ⌘↵ apply · ⌘⌫ reject
+              </span>
+            </div>
+          </div>
+
+          <DocH level={2}>## Network boundary</DocH>
+          <DocPara n={2} dim />
+        </div>
+      </div>
+
+      {/* governance dock — bottom strip */}
+      <div style={{ position:'absolute', bottom:0, left:0, right:0,
+        height:42, background:'var(--bg-surface)',
+        borderTop:'1px solid var(--amber-dim)', display:'flex',
+        alignItems:'center', gap:10, padding:'0 14px' }}>
+        <Pill color="var(--amber)" bg="rgba(240,144,48,0.08)"
+          border="var(--amber-dim)">queue · 4</Pill>
+        {/* mini queue items */}
+        {[
+          { c:'var(--amber)', t:'## Decision record',  active:true },
+          { c:'var(--amber)', t:'frontmatter · status' },
+          { c:'var(--agent)', t:'new wikilink → [[Q1-arch]]' },
+          { c:'var(--vault)', t:'evergreen draft ready' },
+        ].map((q,i) => (
+          <div key={i} style={{ display:'flex', alignItems:'center', gap:5,
+            padding:'4px 9px', borderRadius:2,
+            background: q.active ? 'rgba(240,144,48,0.08)' : 'transparent',
+            border: `1px solid ${q.active ? 'var(--amber-dim)' : 'transparent'}` }}>
+            <IconDot size={5} color={q.c} />
+            <span style={{ ...T.ui, fontSize:11,
+              color: q.active ? 'var(--amber)' : 'var(--fg-2)',
+              fontWeight: q.active ? 500 : 400 }}>{q.t}</span>
+          </div>
+        ))}
+        <span style={{ marginLeft:'auto', ...T.mono, fontSize:9,
+          color:'var(--fg-3)' }}>← / → walks queue · esc closes</span>
+      </div>
+
+      {/* annotations */}
+      <Callout style={{ position:'absolute', top:50, right:14, maxWidth:160 }}>
+        proposal lives where it would land — not in a sidebar. inspect-in-place.
+      </Callout>
+      <Anno style={{ position:'absolute', right:18, top:240, textAlign:'right' }}>
+        ↖ receipt id<br/>links to vault<br/>audit trail
+      </Anno>
+      <Anno style={{ position:'absolute', left:14, bottom:60 }}>
+        ↓ governance dock — non-modal, walks queue without losing place
+      </Anno>
+    </div>
+  );
+}
+
+function ModeReview_Spec() {
+  return (
+    <SpecCard color="var(--amber)" rows={[
+      ['Overlay class',  'Inline staged blocks · governance dock at bottom'],
+      ['Density',        'Calm · one proposal expanded at a time, others compact in queue'],
+      ['Persistence',    'Vault-side · receipts written to `/receipts/`; status survives reload'],
+      ['Provenance',     'Mandatory · every proposal carries receipt id, evidence chips, confidence'],
+      ['Sources',        'Linked from evidence chips · click opens SourcePeek without leaving page'],
+      ['AI visibility',  'Bounded · agent proposes only; verbs are SUGGEST. APPLY is human-only.'],
+      ['Spatial',        'Document at full width; dock is 42px chrome that never obscures content'],
+      ['Interruption',   'Defer puts proposal in queue with timestamp; nothing is lost or auto-applied'],
+      ['Transitions',    'Apply → back to Converse · Reject → recorded in receipt · Defer → Orientation surfaces it later'],
+    ]} />
+  );
+}
+
+window.ModeReview_Wire = ModeReview_Wire;
+window.ModeReview_Spec = ModeReview_Spec;

--- a/companion-ui/design_handoff/2026-05-08-cognitive-temporal/mode-synthesis.jsx
+++ b/companion-ui/design_handoff/2026-05-08-cognitive-temporal/mode-synthesis.jsx
@@ -1,0 +1,177 @@
+/* Mode 3: Synthesis
+   ─ convergence · compare concepts · candidate evergreen knowledge.
+   Wireframe: side-by-side comparison strip across top, candidate
+   evergreen draft below. Document still visible but inset (it is the
+   substrate being synthesized FROM). Vault-green tones — synthesis
+   is heading toward durable knowledge. */
+
+function ModeSynthesis_Wire() {
+  return (
+    <div style={{ width:880, height:560, background:'var(--bg-base)',
+      display:'flex', flexDirection:'column', overflow:'hidden',
+      position:'relative' }}>
+      <StageTopBar surface="Synthesize" />
+
+      <div style={{ flex:1, display:'flex', flexDirection:'column', overflow:'hidden' }}>
+        {/* comparison strip — three source notes side by side */}
+        <div style={{ display:'flex', gap:10, padding:'12px 14px 10px',
+          borderBottom:'1px solid var(--border)',
+          background:'var(--bg-surface)' }}>
+          {[
+            { t:'Q2 architecture', c:'var(--accent)', tag:'active' },
+            { t:'Q1 architecture', c:'var(--vault)', tag:'evergreen' },
+            { t:'memory-essay',    c:'var(--vault)', tag:'evergreen' },
+          ].map(s => (
+            <div key={s.t} style={{ flex:1, background:'var(--bg-raised)',
+              border:'1px solid var(--border)', borderTop:`2px solid ${s.c}`,
+              borderRadius:'0 0 3px 3px', padding:'8px 10px' }}>
+              <div style={{ display:'flex', alignItems:'center', gap:5, marginBottom:5 }}>
+                <IconBox size={9} color={s.c} />
+                <span style={{ ...T.mono, fontSize:9, color:'var(--fg-2)' }}>{s.t}</span>
+                <Pill color={s.c} bg="transparent" border={s.c}
+                  style={{ marginLeft:'auto', fontSize:8 }}>{s.tag}</Pill>
+              </div>
+              <Lines n={3} h={5} last="60%" c="rgba(220,232,240,0.18)" />
+              {/* tiny "matches" markers */}
+              <div style={{ display:'flex', gap:4, marginTop:6 }}>
+                {[0,1,2].map(i => <div key={i} style={{ height:3,
+                  flex:1, background:i===1?'var(--vault)':'rgba(57,232,125,0.3)',
+                  borderRadius:1 }} />)}
+              </div>
+              <span style={{ ...T.mono, fontSize:8, color:'var(--vault)',
+                marginTop:4, display:'inline-block' }}>3 alignments</span>
+            </div>
+          ))}
+        </div>
+
+        {/* candidate evergreen — main work surface */}
+        <div style={{ flex:1, display:'flex', overflow:'hidden' }}>
+          <div style={{ flex:1, padding:'18px 26px', overflow:'hidden',
+            position:'relative' }}>
+            <div style={{ display:'flex', alignItems:'center', gap:8, marginBottom:10 }}>
+              <Pill color="var(--vault)" bg="var(--vault-muted)"
+                border="var(--vault-dim)">candidate evergreen</Pill>
+              <span style={{ ...T.mono, fontSize:9, color:'var(--fg-3)' }}>
+                /Evergreens/runtime-contract.md · draft
+              </span>
+              <span style={{ marginLeft:'auto', ...T.mono, fontSize:9,
+                color:'var(--fg-3)' }}>3 sources synthesized</span>
+            </div>
+
+            <div style={{ ...T.disp, fontSize:18, color:'var(--fg-1)',
+              marginBottom:12, letterSpacing:'-0.01em' }}>
+              The runtime contract as boundary, not surface
+            </div>
+
+            {/* paragraphs with provenance flecks */}
+            {[
+              { n:3, sources:[1,2] },
+              { n:2, sources:[0,2] },
+              { n:3, sources:[0,1] },
+            ].map((p, i) => (
+              <div key={i} style={{ display:'flex', gap:8, marginBottom:12 }}>
+                <div style={{ flex:1 }}>
+                  <Lines n={p.n} h={7} last="58%" c="var(--border-strong)" />
+                </div>
+                <div style={{ display:'flex', flexDirection:'column', gap:3,
+                  paddingTop:2, flexShrink:0 }}>
+                  {p.sources.map(s => (
+                    <div key={s} style={{ display:'flex', alignItems:'center', gap:3 }}>
+                      <IconDot size={4} color="var(--vault)" />
+                      <span style={{ ...T.mono, fontSize:8,
+                        color:'var(--vault)' }}>s{s+1}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+
+            {/* divergence note — where sources disagree */}
+            <div style={{ background:'rgba(240,144,48,0.05)',
+              border:'1px solid var(--amber-dim)',
+              borderLeft:'2px solid var(--amber)', borderRadius:'1px 3px 3px 1px',
+              padding:'7px 10px', marginTop:6 }}>
+              <span style={{ ...T.mono, fontSize:9, color:'var(--amber)',
+                textTransform:'uppercase', letterSpacing:'0.08em' }}>
+                divergence · s1 vs s3
+              </span>
+              <div style={{ ...T.ui, fontSize:11, color:'var(--fg-2)',
+                marginTop:3 }}>
+                Q2 frames the contract as <i>negotiated</i>; the memory essay treats it as <i>imposed</i>. Reconcile?
+              </div>
+            </div>
+          </div>
+
+          {/* side rail — provenance + accept/refine */}
+          <div style={{ width:200, background:'var(--bg-surface)',
+            borderLeft:'1px solid var(--border)', display:'flex',
+            flexDirection:'column', flexShrink:0 }}>
+            <div style={{ padding:'9px 12px',
+              borderBottom:'1px solid var(--border)' }}>
+              <span style={{ ...T.mono, fontSize:9, color:'var(--vault)',
+                textTransform:'uppercase', letterSpacing:'0.08em' }}>
+                Provenance
+              </span>
+            </div>
+            <div style={{ flex:1, padding:'8px 10px',
+              display:'flex', flexDirection:'column', gap:6 }}>
+              {[
+                { s:'s1', n:'Q2 architecture', l:[12,18] },
+                { s:'s2', n:'Q1 architecture', l:[44] },
+                { s:'s3', n:'memory-essay',    l:[8,9,71] },
+              ].map(p => (
+                <div key={p.s} style={{ background:'var(--bg-raised)',
+                  border:'1px solid var(--border)', borderRadius:2,
+                  padding:'5px 7px' }}>
+                  <div style={{ display:'flex', alignItems:'center', gap:4 }}>
+                    <IconDot size={4} color="var(--vault)" />
+                    <span style={{ ...T.mono, fontSize:9,
+                      color:'var(--fg-2)' }}>{p.s} · {p.n}</span>
+                  </div>
+                  <span style={{ ...T.mono, fontSize:8, color:'var(--fg-3)' }}>
+                    lines {p.l.join(', ')}
+                  </span>
+                </div>
+              ))}
+            </div>
+            <div style={{ padding:'8px 10px', borderTop:'1px solid var(--border)',
+              display:'flex', flexDirection:'column', gap:5 }}>
+              <Btn color="var(--vault)" filled>Stage as evergreen</Btn>
+              <Btn color="var(--fg-3)">Refine with Hugin</Btn>
+              <Btn color="var(--fg-3)">Discard draft</Btn>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <Callout style={{ position:'absolute', top:50, left:14, maxWidth:170 }}>
+        sources align across the top — the comparison itself is the work surface
+      </Callout>
+      <Anno style={{ position:'absolute', right:218, top:200 }}>
+        green flecks =<br/>which sources<br/>back each para →
+      </Anno>
+      <Anno style={{ position:'absolute', left:160, bottom:90 }}>
+        amber breaks ↑ where sources disagree — refusal to flatten
+      </Anno>
+    </div>
+  );
+}
+
+function ModeSynthesis_Spec() {
+  return (
+    <SpecCard color="var(--vault)" rows={[
+      ['Overlay class',  'Comparison strip + draft surface · replaces document temporarily'],
+      ['Density',        'High structure · precise alignment markers, per-paragraph provenance'],
+      ['Persistence',    'Draft persists as `*.draft.md` in vault (not yet evergreen)'],
+      ['Provenance',     'Always visible · per-paragraph source flecks; full provenance rail to the right'],
+      ['Sources',        'Primary surface · sources are first-class peers'],
+      ['AI visibility',  'High · agent generates draft, but every claim is attributed and questionable'],
+      ['Spatial',        'Three-zone: comparison top, draft center, provenance right'],
+      ['Interruption',   'Draft auto-saves; resume picks up in-place. Sources re-fetched on open.'],
+      ['Transitions',    'Stage as evergreen → Review · Refine → Converse · Discard → back to source doc'],
+    ]} />
+  );
+}
+
+window.ModeSynthesis_Wire = ModeSynthesis_Wire;
+window.ModeSynthesis_Spec = ModeSynthesis_Spec;

--- a/companion-ui/design_handoff/2026-05-08-cognitive-temporal/mode-transitions.jsx
+++ b/companion-ui/design_handoff/2026-05-08-cognitive-temporal/mode-transitions.jsx
@@ -1,0 +1,334 @@
+/* Cross-mode artboards: transition map, overlay hierarchy, example flows,
+   interruption/recovery, provenance interaction, resurfacing patterns. */
+
+/* ── Transition map ───────────────────────────────────────── */
+function ModeTransitionMap() {
+  // node positions
+  const nodes = [
+    { id:'orient',  label:'Orientation',  x:140, y:100, c:'var(--accent)' },
+    { id:'explore', label:'Exploration',  x:380, y:80,  c:'var(--cyan)'   },
+    { id:'synth',   label:'Synthesis',    x:620, y:120, c:'var(--vault)'  },
+    { id:'review',  label:'Review',       x:540, y:300, c:'var(--amber)'  },
+    { id:'resurf',  label:'Resurfacing',  x:220, y:320, c:'var(--vault)'  },
+  ];
+  const edges = [
+    { from:'orient',  to:'explore', label:'resume + branch'   },
+    { from:'orient',  to:'review',  label:'show all threads'  },
+    { from:'orient',  to:'resurf',  label:'return without intent' },
+    { from:'explore', to:'synth',   label:'promote'           },
+    { from:'explore', to:'review',  label:'anchor branch'     },
+    { from:'synth',   to:'review',  label:'stage as evergreen'},
+    { from:'review',  to:'orient',  label:'defer'             },
+    { from:'resurf',  to:'synth',   label:'pin to comparison' },
+    { from:'resurf',  to:'explore', label:'follow + diverge'  },
+  ];
+  const get = id => nodes.find(n => n.id === id);
+
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      position:'relative', overflow:'hidden' }}>
+      {/* grid */}
+      <div style={{ position:'absolute', inset:0,
+        backgroundImage:'linear-gradient(rgba(0,212,232,0.03) 1px, transparent 1px), linear-gradient(90deg, rgba(0,212,232,0.03) 1px, transparent 1px)',
+        backgroundSize:'24px 24px' }} />
+
+      <div style={{ position:'relative', padding:'16px 20px' }}>
+        <div style={{ ...T.disp, fontSize:18, color:'var(--fg-1)',
+          letterSpacing:'-0.01em', marginBottom:2 }}>
+          Mode transitions
+        </div>
+        <div style={{ ...T.mono, fontSize:9, color:'var(--fg-3)',
+          letterSpacing:'0.08em', textTransform:'uppercase' }}>
+          all transitions preserve document anchor
+        </div>
+      </div>
+
+      <svg style={{ position:'absolute', inset:0, pointerEvents:'none' }}
+        width="100%" height="100%" viewBox="0 0 800 440"
+        preserveAspectRatio="none">
+        <defs>
+          <marker id="ah-mode" viewBox="0 0 8 8" refX="7" refY="4"
+            markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+            <path d="M0,0 L7,4 L0,8" fill="none" stroke="var(--fg-3)" strokeWidth="1.2"/>
+          </marker>
+        </defs>
+        {edges.map((e,i) => {
+          const a = get(e.from), b = get(e.to);
+          const mx = (a.x + b.x)/2;
+          const my = (a.y + b.y)/2 - 18;
+          const d = `M ${a.x},${a.y} Q ${mx},${my} ${b.x},${b.y}`;
+          return (
+            <g key={i}>
+              <path d={d} stroke="var(--border-strong)" strokeWidth="1.2"
+                fill="none" markerEnd="url(#ah-mode)" />
+              <text x={mx} y={my+2} fill="var(--fg-3)" fontSize="10"
+                fontFamily="JetBrains Mono" textAnchor="middle"
+                style={{ paintOrder:'stroke', stroke:'var(--bg-base)', strokeWidth:4,
+                  strokeLinejoin:'round' }}>
+                {e.label}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+
+      {nodes.map(n => (
+        <div key={n.id} style={{ position:'absolute',
+          left: `${(n.x/800)*100}%`, top: `${(n.y/440)*100}%`,
+          transform:'translate(-50%, -50%)',
+          padding:'8px 14px', background:'var(--bg-raised)',
+          border:`1px solid ${n.c}`, borderLeft:`3px solid ${n.c}`,
+          borderRadius:3, ...T.ui, fontSize:12, color:n.c,
+          letterSpacing:'0.02em', whiteSpace:'nowrap',
+          boxShadow:`0 0 0 4px var(--bg-base)` }}>
+          {n.label}
+        </div>
+      ))}
+
+      {/* legend */}
+      <div style={{ position:'absolute', right:16, bottom:14,
+        ...T.mono, fontSize:9, color:'var(--fg-3)', textAlign:'right',
+        lineHeight:1.7 }}>
+        gold = governance · cyan = transient · green = vault · amber = staged
+      </div>
+    </div>
+  );
+}
+
+/* ── Overlay hierarchy diagram ────────────────────────────── */
+function OverlayHierarchy() {
+  const layers = [
+    { z:6, label:'Toast/system',     hint:'errors, vault offline, never blocks' },
+    { z:5, label:'Re-entry overlay', hint:'orientation only · centered, dismissible' },
+    { z:4, label:'Source peek',      hint:'anchored card · click outside dismisses' },
+    { z:3, label:'Bottom sheet / governance dock', hint:'review queue · portrait rail' },
+    { z:2, label:'Margin rail · tray',    hint:'conversation · resurface tray' },
+    { z:1, label:'Adjacent canvas',  hint:'exploration · synthesis comparison' },
+    { z:0, label:'Document',         hint:'always present · cognitive anchor' },
+  ];
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      padding:'16px 20px', display:'flex', flexDirection:'column' }}>
+      <div style={{ ...T.disp, fontSize:18, color:'var(--fg-1)',
+        letterSpacing:'-0.01em', marginBottom:2 }}>
+        Overlay hierarchy
+      </div>
+      <div style={{ ...T.mono, fontSize:9, color:'var(--fg-3)',
+        letterSpacing:'0.08em', textTransform:'uppercase', marginBottom:14 }}>
+        higher = more transient · all dismissible without losing anchor
+      </div>
+      <div style={{ flex:1, display:'flex', flexDirection:'column',
+        justifyContent:'space-between', position:'relative' }}>
+        {layers.map((l,i) => {
+          const inset = l.z * 14;
+          const tone = l.z === 0
+            ? { bg:'var(--bg-raised)', bd:'var(--border-strong)',
+                fg:'var(--fg-1)', accent:'var(--accent)' }
+            : l.z === 1
+              ? { bg:'rgba(0,212,232,0.04)', bd:'var(--cyan-dim)',
+                  fg:'var(--cyan)', accent:'var(--cyan)' }
+              : l.z === 2
+                ? { bg:'var(--agent-muted)', bd:'var(--agent-dim)',
+                    fg:'var(--agent)', accent:'var(--agent)' }
+                : l.z === 3
+                  ? { bg:'rgba(240,144,48,0.04)', bd:'var(--amber-dim)',
+                      fg:'var(--amber)', accent:'var(--amber)' }
+                  : l.z === 4
+                    ? { bg:'var(--cyan-muted)', bd:'var(--cyan-dim)',
+                        fg:'var(--cyan)', accent:'var(--cyan)' }
+                    : l.z === 5
+                      ? { bg:'rgba(212,168,67,0.06)', bd:'rgba(212,168,67,0.4)',
+                          fg:'var(--accent)', accent:'var(--accent)' }
+                      : { bg:'var(--bg-raised)', bd:'var(--border-strong)',
+                          fg:'var(--fg-2)', accent:'var(--fg-2)' };
+          return (
+            <div key={l.z} style={{ marginLeft:inset, marginRight:inset,
+              padding:'8px 12px', background:tone.bg,
+              border:`1px solid ${tone.bd}`,
+              borderLeft:`2px solid ${tone.accent}`,
+              borderRadius:3, display:'flex', alignItems:'center', gap:10 }}>
+              <span style={{ ...T.mono, fontSize:9, color:tone.fg,
+                width:18 }}>z{l.z}</span>
+              <span style={{ ...T.ui, fontSize:11.5, color:'var(--fg-1)',
+                fontWeight: l.z===0 ? 500 : 400 }}>{l.label}</span>
+              <span style={{ marginLeft:'auto', ...T.mono, fontSize:9,
+                color:'var(--fg-3)' }}>{l.hint}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/* ── Example flow trace ───────────────────────────────────── */
+function FlowTrace({ title, subtitle, steps, color='var(--accent)' }) {
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      padding:'16px 20px', display:'flex', flexDirection:'column' }}>
+      <div style={{ ...T.disp, fontSize:16, color:'var(--fg-1)',
+        letterSpacing:'-0.01em', marginBottom:2 }}>{title}</div>
+      <div style={{ ...T.mono, fontSize:9, color:'var(--fg-3)',
+        letterSpacing:'0.08em', textTransform:'uppercase', marginBottom:14 }}>
+        {subtitle}
+      </div>
+      <div style={{ flex:1, display:'flex', flexDirection:'column',
+        gap:0, position:'relative' }}>
+        {steps.map((s, i) => (
+          <div key={i} style={{ display:'flex', gap:12, padding:'7px 0',
+            borderTop: i===0 ? 'none' : '1px solid var(--border)' }}>
+            <div style={{ display:'flex', flexDirection:'column',
+              alignItems:'center', width:60, flexShrink:0 }}>
+              <div style={{ width:18, height:18, borderRadius:2,
+                border:`1px solid ${s.mode_color || color}`,
+                background:'var(--bg-raised)',
+                display:'flex', alignItems:'center', justifyContent:'center',
+                ...T.mono, fontSize:9, color: s.mode_color || color }}>
+                {String(i+1).padStart(2,'0')}
+              </div>
+              <span style={{ ...T.mono, fontSize:8, color:'var(--fg-3)',
+                marginTop:3, textAlign:'center', letterSpacing:'0.04em' }}>
+                {s.mode}
+              </span>
+            </div>
+            <div style={{ flex:1 }}>
+              <div style={{ ...T.ui, fontSize:11.5, color:'var(--fg-1)',
+                lineHeight:1.45 }}>{s.action}</div>
+              {s.detail && <div style={{ ...T.mono, fontSize:9,
+                color:'var(--fg-3)', marginTop:3, lineHeight:1.4 }}>
+                {s.detail}
+              </div>}
+            </div>
+            {s.surface && (
+              <Pill color={s.mode_color || color} bg="transparent"
+                border={s.mode_color || color}
+                style={{ alignSelf:'flex-start', marginTop:1 }}>
+                {s.surface}
+              </Pill>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function FlowOrientationToReview() {
+  return <FlowTrace
+    title="Recovery: interrupt → resume → review"
+    subtitle="user closed laptop mid-thought · returns 3 days later"
+    steps={[
+      { mode:'orient',  mode_color:'var(--accent)',
+        action:'Re-entry overlay surfaces 3 open loops + last trace.',
+        detail:'overlay floats; document already loaded underneath',
+        surface:'overlay' },
+      { mode:'orient',  mode_color:'var(--accent)',
+        action:'User clicks "Resume here".',
+        detail:'overlay dismisses; gutter beacons remain at line 47, frontmatter, [[Q1-arch]]',
+        surface:'document' },
+      { mode:'converse',mode_color:'var(--agent)',
+        action:'Margin rail expands with last 3 turns of conversation.',
+        detail:'thread is continuous, not a fresh session',
+        surface:'rail' },
+      { mode:'review',  mode_color:'var(--amber)',
+        action:'User clicks the amber gutter beacon at line 47.',
+        detail:'staged proposal expands inline with full diff + receipt #r-014',
+        surface:'inline block' },
+      { mode:'review',  mode_color:'var(--amber)',
+        action:'User applies the proposal (⌘↵).',
+        detail:'receipt updated · new beacon for next item in queue',
+        surface:'governance dock' },
+    ]} />;
+}
+
+function FlowExploreToEvergreen() {
+  return <FlowTrace
+    title="Cognition: probe → converge → durable"
+    subtitle="exploratory thought becomes vault-canonical"
+    color="var(--cyan)"
+    steps={[
+      { mode:'converse',mode_color:'var(--agent)',
+        action:'User highlights the phrase "runtime contract" in document.',
+        surface:'document' },
+      { mode:'explore', mode_color:'var(--cyan)',
+        action:'User opens an exploration canvas anchored to that phrase.',
+        detail:'three speculative branches generated · nothing persists yet',
+        surface:'adjacent canvas' },
+      { mode:'explore', mode_color:'var(--cyan)',
+        action:'User merges branches B and C; deletes A.',
+        detail:'canvas state cached locally for 24h',
+        surface:'adjacent canvas' },
+      { mode:'synth',   mode_color:'var(--vault)',
+        action:'"Promote to companion note" → Synthesis surface opens.',
+        detail:'comparison strip auto-pulls Q1-arch + memory-essay as related',
+        surface:'compare strip' },
+      { mode:'synth',   mode_color:'var(--vault)',
+        action:'User authors candidate evergreen with provenance flecks live.',
+        detail:'each para tagged with backing source ids',
+        surface:'draft surface' },
+      { mode:'review',  mode_color:'var(--amber)',
+        action:'"Stage as evergreen" — proposal lands in governance queue.',
+        detail:'final apply still requires explicit human action',
+        surface:'review queue' },
+    ]} />;
+}
+
+function FlowResurfacingPattern() {
+  return <FlowTrace
+    title="Ambient: latent knowledge re-attentioning"
+    subtitle="non-disruptive resurfacing during normal reading"
+    color="var(--vault)"
+    steps={[
+      { mode:'converse',mode_color:'var(--agent)',
+        action:'User opens Q2-arch.md to read.',
+        detail:'no agent action requested',
+        surface:'document' },
+      { mode:'resurf',  mode_color:'var(--vault)',
+        action:'Right-edge of doc shows 5 faint dots, sized by salience.',
+        detail:'computed silently · no notification, no badge, no chrome flash',
+        surface:'marginalia' },
+      { mode:'resurf',  mode_color:'var(--vault)',
+        action:'User notices a larger dot near "## Network boundary".',
+        detail:'their eye finds it · we never demanded attention',
+        surface:'marginalia' },
+      { mode:'converse',mode_color:'var(--agent)',
+        action:'Click → SourcePeek opens with [[Q1-arch · network]] excerpt.',
+        detail:'inline, not a navigation · doc unchanged',
+        surface:'source peek' },
+      { mode:'synth',   mode_color:'var(--vault)',
+        action:'"Pin to comparison" — adds to Synthesis strip for next session.',
+        detail:'durable but lazy · nothing forced',
+        surface:'compare strip' },
+    ]} />;
+}
+
+function FlowProvenancePattern() {
+  return <FlowTrace
+    title="Provenance: claim → evidence → audit"
+    subtitle="every agent claim is inspectable without leaving page"
+    color="var(--cyan)"
+    steps={[
+      { mode:'review',  mode_color:'var(--amber)',
+        action:'Inline proposal shows 3 evidence chips: [Q1-arch:44] [memory-essay:9] [session 2026-05-04].',
+        surface:'staged block' },
+      { mode:'review',  mode_color:'var(--cyan)',
+        action:'Hover an evidence chip → SourcePeek slides in next to it.',
+        detail:'shows snippet + confidence + line number · doc untouched',
+        surface:'source peek' },
+      { mode:'review',  mode_color:'var(--cyan)',
+        action:'Click "open in vault" → Obsidian receives uri scheme.',
+        detail:'companion UI does not navigate · vault is canonical',
+        surface:'external' },
+      { mode:'review',  mode_color:'var(--amber)',
+        action:'Receipt id #r-014 links to /receipts/2026-05-07/r-014.md',
+        detail:'full prompt, model, sources, confidence, accept/reject status',
+        surface:'vault file' },
+    ]} />;
+}
+
+window.ModeTransitionMap = ModeTransitionMap;
+window.OverlayHierarchy = OverlayHierarchy;
+window.FlowOrientationToReview = FlowOrientationToReview;
+window.FlowExploreToEvergreen = FlowExploreToEvergreen;
+window.FlowResurfacingPattern = FlowResurfacingPattern;
+window.FlowProvenancePattern = FlowProvenancePattern;

--- a/companion-ui/design_handoff/2026-05-08-cognitive-temporal/reentry-analysis.jsx
+++ b/companion-ui/design_handoff/2026-05-08-cognitive-temporal/reentry-analysis.jsx
@@ -1,0 +1,398 @@
+/* ============================================================
+   Re-entry mist — analysis & comparison artboards
+   ============================================================ */
+
+/* ── Premise / cover ──────────────────────────────────── */
+function RM_Premise() {
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      padding:'22px 26px', display:'flex', flexDirection:'column', gap:14 }}>
+      <ABHead tone="var(--accent)" sub="re-entry mist · phenomenology study">
+        Returning, after three days
+      </ABHead>
+      <div style={{ ...TT.disp, fontStyle:'italic', fontSize:15,
+        color:'var(--fg-2)', lineHeight:1.55, maxWidth:'94%' }}>
+        The user opens a document they last touched seventy-six hours ago.
+        The system must reconstitute continuity — gently — without claiming
+        their attention.
+      </div>
+      <Hairline />
+      <div>
+        <Caption color="var(--accent)" size={8.5}>refining</Caption>
+        <div style={{ ...TT.ui, fontSize:12, color:'var(--fg-1)',
+          lineHeight:1.55, marginTop:6 }}>
+          The phenomenology of three alternative re-entry mists. Each makes
+          a different bet about what a returning thinker actually needs.
+        </div>
+      </div>
+      <Hairline />
+      <div style={{ display:'grid', gridTemplateColumns:'auto 1fr', gap:'8px 16px',
+        ...TT.ui, fontSize:11, color:'var(--fg-2)', lineHeight:1.45 }}>
+        <Caption color="var(--accent)" size={8.5}>A · whisper</Caption>
+        <span>continuity lives in the margin · doc readable from t=0</span>
+        <Caption color="var(--cyan)" size={8.5}>B · breath</Caption>
+        <span>continuity is one half-finished sentence · everything else latent</span>
+        <Caption color="var(--vault)" size={8.5}>C · recall</Caption>
+        <span>continuity is atmospheric · the room remembers, not the UI</span>
+      </div>
+      <Hairline />
+      <div style={{ ...TT.mono, fontSize:9.5, color:'var(--fg-3)',
+        lineHeight:1.55, letterSpacing:'0.02em' }}>
+        constraints held: no dashboards · no badges · no notifications · no
+        productivity chrome · no chat surface · calmness above density
+      </div>
+    </div>
+  );
+}
+
+/* ── Attentional cadence — three columns ──────────────── */
+function RM_Cadence() {
+  const phases = [
+    { t:'t=0', label:'opens doc' },
+    { t:'+200ms', label:'first breath' },
+    { t:'+1.5s', label:'orient' },
+    { t:'+3s', label:'read' },
+    { t:'first key', label:'commit' },
+    { t:'+30s', label:'session settles' },
+  ];
+  const A = [
+    'doc fully visible, dimmed 5%',
+    'gold breath behind last line · caret echo',
+    'four whispers fade in column-right, staggered',
+    'whispers stable · doc primary',
+    'breath dissolves · whispers dim to 30%',
+    'whispers fade to ambient marginalia dots',
+  ];
+  const B = [
+    'doc dim 45% · headline visible',
+    'half-sentence ghosts in at cursor',
+    'silence · only caret breathes',
+    'three numerals fade in below margin',
+    'sentence becomes editable · numerals hold',
+    'numerals contract to 3 dots in lower margin',
+  ];
+  const C = [
+    'doc full opacity · warm tint over page',
+    'four corner glyphs glow once, then settle',
+    'gravity well rises in lower margin',
+    'tint stabilises · glyphs dim to ambient',
+    'tint fades to baseline · glyphs hold',
+    'only gravity well + caret breath remain',
+  ];
+
+  const Col = ({ title, tone, items }) => (
+    <div style={{ display:'flex', flexDirection:'column', gap:0 }}>
+      <div style={{ ...TT.ui, fontSize:11, fontWeight:500, color:tone,
+        marginBottom:8, paddingBottom:6,
+        borderBottom:`1px solid ${tone}`, opacity:0.95 }}>{title}</div>
+      {items.map((s,i) => (
+        <div key={i} style={{ padding:'8px 0',
+          borderTop: i === 0 ? 'none' : '1px solid var(--border)',
+          ...TT.ui, fontSize:10.5, color:'var(--fg-1)', lineHeight:1.4 }}>
+          {s}
+        </div>
+      ))}
+    </div>
+  );
+
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      padding:'20px 22px', display:'flex', flexDirection:'column', gap:10 }}>
+      <ABHead tone="var(--accent)" sub="what surfaces when · what fades first">
+        Attentional cadence
+      </ABHead>
+      <div style={{ display:'grid', gridTemplateColumns:'90px 1fr 1fr 1fr',
+        gap:14 }}>
+        <div>
+          <div style={{ height:25 }} />
+          {phases.map((p,i) => (
+            <div key={i} style={{ padding:'8px 0',
+              borderTop: i === 0 ? 'none' : '1px solid var(--border)' }}>
+              <Caption color="var(--cyan)" size={9}>{p.t}</Caption>
+              <div style={{ ...TT.ui, fontSize:10, color:'var(--fg-2)',
+                marginTop:2 }}>{p.label}</div>
+            </div>
+          ))}
+        </div>
+        <Col title="A · whisper" tone="var(--accent)" items={A} />
+        <Col title="B · breath"  tone="var(--cyan)"   items={B} />
+        <Col title="C · recall"  tone="var(--vault)"  items={C} />
+      </div>
+    </div>
+  );
+}
+
+/* ── Density comparison — payload weight ──────────────── */
+function RM_Density() {
+  const rows = [
+    { aspect:'words on screen', A:'~38', B:'~22', C:'~6' },
+    { aspect:'distinct surfaces', A:'1 column', B:'1 sentence', C:'4 glyphs + tint' },
+    { aspect:'numerals shown', A:'3', B:'3 (delayed)', C:'0' },
+    { aspect:'labels shown',  A:'4', B:'3 (delayed)', C:'4 glyphs' },
+    { aspect:'doc dimming',   A:'5%',  B:'45%', C:'0%' },
+    { aspect:'modal feel',    A:'low',  B:'medium', C:'none' },
+    { aspect:'time to read',  A:'3-4s', B:'1-2s', C:'0s' },
+    { aspect:'overload risk', A:'medium · 4 streams in periphery',
+      B:'low · single focus', C:'very low · entirely felt' },
+  ];
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      padding:'20px 22px', display:'flex', flexDirection:'column', gap:10 }}>
+      <ABHead tone="var(--cyan)" sub="minimum viable continuity payload">
+        Density comparison
+      </ABHead>
+      <div style={{ display:'grid',
+        gridTemplateColumns:'150px 1fr 1fr 1fr', gap:8,
+        ...TT.ui, fontSize:11 }}>
+        <div />
+        <div style={{ color:'var(--accent)', ...TT.mono, fontSize:9,
+          letterSpacing:'0.1em', textTransform:'uppercase' }}>A · whisper</div>
+        <div style={{ color:'var(--cyan)', ...TT.mono, fontSize:9,
+          letterSpacing:'0.1em', textTransform:'uppercase' }}>B · breath</div>
+        <div style={{ color:'var(--vault)', ...TT.mono, fontSize:9,
+          letterSpacing:'0.1em', textTransform:'uppercase' }}>C · recall</div>
+        {rows.map((r,i) => (
+          <React.Fragment key={i}>
+            <div style={{ borderTop:'1px solid var(--border)', padding:'7px 0',
+              color:'var(--fg-3)', ...TT.mono, fontSize:9.5,
+              letterSpacing:'0.05em' }}>{r.aspect}</div>
+            <div style={{ borderTop:'1px solid var(--border)', padding:'7px 0',
+              color:'var(--fg-1)' }}>{r.A}</div>
+            <div style={{ borderTop:'1px solid var(--border)', padding:'7px 0',
+              color:'var(--fg-1)' }}>{r.B}</div>
+            <div style={{ borderTop:'1px solid var(--border)', padding:'7px 0',
+              color:'var(--fg-1)' }}>{r.C}</div>
+          </React.Fragment>
+        ))}
+      </div>
+      <div style={{ marginTop:6, ...TT.mono, fontSize:9, color:'var(--fg-3)',
+        letterSpacing:'0.06em', lineHeight:1.55 }}>
+        all three resolve the same four questions · they differ in how much
+        of the answer is told vs. felt · C tells almost nothing and trusts
+        memory to do the rest
+      </div>
+    </div>
+  );
+}
+
+/* ── Dissolve behavior comparison ─────────────────────── */
+function RM_Dissolve() {
+  const rows = [
+    { phase:'first keystroke',
+      A:'gold breath fades in 240ms · whispers desaturate to 30%',
+      B:'sentence becomes black-ink editable · numerals hold',
+      C:'warm tint slides to baseline over 600ms · glyphs unchanged' },
+    { phase:'first scroll',
+      A:'whispers detach from doc, become margin sticky',
+      B:'numerals follow viewport bottom-left',
+      C:'glyphs stay anchored to viewport corners' },
+    { phase:'first selection',
+      A:'whispers dim further to 15%',
+      B:'numerals shrink to lone digit-dots',
+      C:'no change · selection dominates instead' },
+    { phase:'after 30s of work',
+      A:'whispers → marginalia dots (3-6px) at original positions',
+      B:'numerals → 3 small dots in lower-left margin',
+      C:'tint baseline · gravity well dims to 20% but persists' },
+    { phase:'esc / dismiss',
+      A:'whispers gone · marginalia dots remain ambient',
+      B:'numerals gone · sentence-anchor underline remains',
+      C:'corner glyphs disappear · gravity well + tint persist' },
+  ];
+
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      padding:'20px 22px', display:'flex', flexDirection:'column', gap:10 }}>
+      <ABHead tone="var(--amber)" sub="how each variant lets go">
+        Dissolve semantics
+      </ABHead>
+      <div style={{ display:'grid',
+        gridTemplateColumns:'120px 1fr 1fr 1fr', gap:10,
+        ...TT.ui, fontSize:10.5 }}>
+        <div />
+        <div style={{ color:'var(--accent)', ...TT.mono, fontSize:9,
+          letterSpacing:'0.1em', textTransform:'uppercase' }}>A · whisper</div>
+        <div style={{ color:'var(--cyan)', ...TT.mono, fontSize:9,
+          letterSpacing:'0.1em', textTransform:'uppercase' }}>B · breath</div>
+        <div style={{ color:'var(--vault)', ...TT.mono, fontSize:9,
+          letterSpacing:'0.1em', textTransform:'uppercase' }}>C · recall</div>
+        {rows.map((r,i) => (
+          <React.Fragment key={i}>
+            <div style={{ borderTop:'1px solid var(--border)', padding:'8px 0',
+              color:'var(--amber)', ...TT.mono, fontSize:9,
+              letterSpacing:'0.06em' }}>{r.phase}</div>
+            <div style={{ borderTop:'1px solid var(--border)', padding:'8px 0',
+              color:'var(--fg-1)', lineHeight:1.45 }}>{r.A}</div>
+            <div style={{ borderTop:'1px solid var(--border)', padding:'8px 0',
+              color:'var(--fg-1)', lineHeight:1.45 }}>{r.B}</div>
+            <div style={{ borderTop:'1px solid var(--border)', padding:'8px 0',
+              color:'var(--fg-1)', lineHeight:1.45 }}>{r.C}</div>
+          </React.Fragment>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ── Ambient persistence — what remains ──────────────── */
+function RM_Persistence() {
+  const items = [
+    { v:'A',  tone:'var(--accent)',
+      keeps:[
+        'marginalia dots at every prior whisper position',
+        'caret echo (a tiny gold tick) where you stopped',
+        'one open-loop glyph for each unresolved synthesis',
+      ],
+      removes:[
+        'all whisper text',
+        'gold breath',
+        'numeric counts',
+      ] },
+    { v:'B',  tone:'var(--cyan)',
+      keeps:[
+        'underline at sentence-anchor (resume jump)',
+        'three faint dots in lower-left margin',
+        'caret breathing at original line',
+      ],
+      removes:[
+        'the half-sentence itself',
+        'numerals',
+        'doc dimming',
+      ] },
+    { v:'C',  tone:'var(--vault)',
+      keeps:[
+        'warm room tint, dimmed 60%',
+        'gravity well at 20% (unresolved still pulls)',
+        'caret breath at last line',
+      ],
+      removes:[
+        'corner glyphs',
+        'all explicit answers',
+        'tooltips on hover',
+      ] },
+  ];
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      padding:'20px 22px', display:'flex', flexDirection:'column', gap:14 }}>
+      <ABHead tone="var(--vault)" sub="what stays after dissolve · ambient layer">
+        Ambient persistence
+      </ABHead>
+      <div style={{ ...TT.ui, fontSize:11, color:'var(--fg-2)',
+        lineHeight:1.5, marginBottom:2 }}>
+        The mist is gone, but the document is not the same as a fresh document.
+        Each variant leaves a different kind of trace — something the user can
+        return to without summoning a card.
+      </div>
+      {items.map((r) => (
+        <div key={r.v} style={{ display:'grid',
+          gridTemplateColumns:'70px 1fr 1fr', gap:12,
+          paddingTop:12, borderTop:'1px solid var(--border)' }}>
+          <div>
+            <div style={{ ...TT.disp, fontSize:22, color:r.tone,
+              lineHeight:1 }}>{r.v}</div>
+            <Caption color={r.tone} size={8.5} style={{ marginTop:4,
+              display:'block' }}>variant</Caption>
+          </div>
+          <div>
+            <Caption color="var(--fg-3)" size={8.5}>keeps</Caption>
+            <ul style={{ margin:'4px 0 0 14px', padding:0,
+              ...TT.ui, fontSize:11, color:'var(--fg-1)', lineHeight:1.55 }}>
+              {r.keeps.map((k,i) => <li key={i}>{k}</li>)}
+            </ul>
+          </div>
+          <div>
+            <Caption color="var(--fg-3)" size={8.5}>lets go</Caption>
+            <ul style={{ margin:'4px 0 0 14px', padding:0,
+              ...TT.ui, fontSize:11, color:'var(--fg-2)', lineHeight:1.55 }}>
+              {r.removes.map((k,i) => <li key={i}>{k}</li>)}
+            </ul>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ── Recommendation ───────────────────────────────────── */
+function RM_Recommendation() {
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      padding:'22px 26px', display:'flex', flexDirection:'column', gap:14 }}>
+      <ABHead tone="var(--vault)" sub="quietest · highest continuity">
+        Recommendation — Variant C, tempered by B
+      </ABHead>
+
+      <div style={{ ...TT.disp, fontStyle:'italic', fontSize:15,
+        color:'var(--fg-1)', lineHeight:1.55, maxWidth:'96%' }}>
+        The room should remember before the UI does.
+      </div>
+
+      <Hairline />
+
+      <div>
+        <Caption color="var(--vault)" size={8.5}>why C wins on quietness</Caption>
+        <div style={{ ...TT.ui, fontSize:11.5, color:'var(--fg-1)',
+          lineHeight:1.55, marginTop:6 }}>
+          C is the only variant where the document is fully readable with
+          zero text added. The four questions are still answered — but
+          atmospherically: warm tint = "you have been here before"; gravity
+          well = "something is still pulling"; caret breath = "you stopped
+          here"; corner glyphs = "ask if you want to know more."
+          Cognition does not have to read anything to feel oriented.
+        </div>
+      </div>
+
+      <div>
+        <Caption color="var(--cyan)" size={8.5}>where C is too thin · borrow from B</Caption>
+        <div style={{ ...TT.ui, fontSize:11.5, color:'var(--fg-1)',
+          lineHeight:1.55, marginTop:6 }}>
+          On returns where momentum was mid-sentence, atmosphere is not
+          enough — the user needs the literal half-thought back. Adopt
+          B's single ghost-sentence at the cursor, but only when the
+          stop-state was textual. If the user paused on a thought (no
+          unfinished sentence), C alone is sufficient.
+        </div>
+      </div>
+
+      <div>
+        <Caption color="var(--accent)" size={8.5}>where A belongs</Caption>
+        <div style={{ ...TT.ui, fontSize:11.5, color:'var(--fg-1)',
+          lineHeight:1.55, marginTop:6 }}>
+          A is the right shape for absences past 14 days, when atmosphere
+          alone cannot reconstitute context. Promote A automatically once
+          the latency ladder crosses "long mist."
+        </div>
+      </div>
+
+      <Hairline />
+
+      <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:14 }}>
+        <div>
+          <Caption color="var(--fg-3)" size={8.5}>composite default</Caption>
+          <div style={{ ...TT.ui, fontSize:11, color:'var(--fg-1)',
+            lineHeight:1.55, marginTop:6 }}>
+            <b>2h – 3d</b> · C alone<br/>
+            <b>3d – 14d</b> · C + B's ghost-sentence (if mid-text)<br/>
+            <b>&gt; 14d</b> · A's column appears in addition
+          </div>
+        </div>
+        <div>
+          <Caption color="var(--fg-3)" size={8.5}>invariant</Caption>
+          <div style={{ ...TT.ui, fontSize:11, color:'var(--fg-1)',
+            lineHeight:1.55, marginTop:6 }}>
+            no card ever centers on the document.
+            re-entry is felt at the periphery.
+            cognition returns to the document, not to the system.
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+window.RM_Premise = RM_Premise;
+window.RM_Cadence = RM_Cadence;
+window.RM_Density = RM_Density;
+window.RM_Dissolve = RM_Dissolve;
+window.RM_Persistence = RM_Persistence;
+window.RM_Recommendation = RM_Recommendation;

--- a/companion-ui/design_handoff/2026-05-08-cognitive-temporal/reentry-variants.jsx
+++ b/companion-ui/design_handoff/2026-05-08-cognitive-temporal/reentry-variants.jsx
@@ -1,0 +1,376 @@
+/* ============================================================
+   Re-entry mist — three phenomenological variants
+   ============================================================
+   A: Margin Whisper      lateral · spatial · marginalia
+   B: Resumption Breath   single sentence · gravity · progressive
+   C: Atmospheric Recall  no card · room-like · ambient fixtures
+   ============================================================ */
+
+/* shared bits ─────────────────────────────────────────── */
+function DocBody({ dim = 0.45, title = 'Network boundary' }) {
+  return (
+    <div style={{ opacity: dim }}>
+      <div style={{ ...TT.disp, fontSize:18, color:'var(--fg-1)',
+        marginBottom:10, letterSpacing:'-0.01em' }}>{title}</div>
+      <Lines rows={3} last="58%" h={5.5} gap={8} />
+      <div style={{ height:14 }} />
+      <Lines rows={4} last="42%" h={5.5} gap={8} />
+      <div style={{ height:14 }} />
+      <Lines rows={2} last="74%" h={5.5} gap={8} />
+    </div>
+  );
+}
+
+function DocChrome({ where = 'Projects/Q2-arch.md', resume = '3d 4h ago' }) {
+  return (
+    <div style={{ padding:'9px 18px', borderBottom:'1px solid var(--border)',
+      display:'flex', alignItems:'center', gap:10 }}>
+      <Caption color="var(--fg-3)">{where}</Caption>
+      <Caption color="var(--vault)">·  re-entry · {resume}</Caption>
+      <div style={{ flex:1 }} />
+      <Caption color="var(--fg-3)" size={8.5}>esc dissolves</Caption>
+    </div>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────
+   VARIANT A — MARGIN WHISPER
+   ─────────────────────────────────────────────────────────
+   Phenomenology: the four answers do not aggregate into a
+   card. They surface as faint, position-anchored whispers
+   in the right margin — each pinned to where in the doc the
+   thought lived. The document is fully readable from first
+   pixel; the mist is just a horizontal gold breath at the
+   last cursor line.
+   ─────────────────────────────────────────────────────────*/
+function VariantA_Wire() {
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      display:'flex', flexDirection:'column', position:'relative', overflow:'hidden' }}>
+      <DocChrome />
+      <div style={{ flex:1, display:'grid',
+        gridTemplateColumns:'1fr 220px', position:'relative',
+        backgroundImage:
+          'linear-gradient(rgba(0,212,232,0.012) 1px, transparent 1px),' +
+          'linear-gradient(90deg, rgba(0,212,232,0.012) 1px, transparent 1px)',
+        backgroundSize:'32px 32px' }}>
+
+        {/* doc body, fully readable from first pixel */}
+        <div style={{ padding:'18px 22px 18px 28px', position:'relative' }}>
+          <div>
+            <div style={{ ...TT.disp, fontSize:18, color:'var(--fg-1)',
+              marginBottom:10, letterSpacing:'-0.01em' }}>Network boundary</div>
+            <Lines rows={3} last="58%" h={5.5} gap={8} />
+            <div style={{ height:14 }} />
+            {/* the line where momentum stopped — lit, not hidden */}
+            <div style={{ position:'relative' }}>
+              <Lines rows={2} last="74%" h={5.5} gap={8} />
+              {/* gold breath behind the last line — the only "mist" */}
+              <div style={{ position:'absolute', left:-12, right:-220, top:-4,
+                height:32,
+                background:'linear-gradient(90deg, rgba(212,168,67,0.10) 0%, rgba(212,168,67,0.04) 60%, transparent 100%)',
+                pointerEvents:'none' }} />
+              {/* caret echo */}
+              <div style={{ position:'absolute', left:'58%', top:14, width:1,
+                height:14, background:'var(--accent)',
+                boxShadow:'0 0 6px var(--accent)', animation:'tcbreathe 3.2s ease infinite' }} />
+            </div>
+            <div style={{ height:14 }} />
+            <Lines rows={4} last="42%" h={5.5} gap={8} />
+          </div>
+        </div>
+
+        {/* margin column — four whispers, position-pinned */}
+        <div style={{ borderLeft:'1px dashed var(--border)',
+          padding:'18px 16px', position:'relative' }}>
+          <div style={{ position:'absolute', top:18, left:-1, height:46,
+            width:2, background:'var(--accent)', opacity:0.5 }} />
+
+          {/* doing */}
+          <div style={{ marginBottom:22 }}>
+            <Caption color="var(--accent)" size={8.5}>doing</Caption>
+            <div style={{ ...TT.disp, fontStyle:'italic', fontSize:12,
+              color:'var(--fg-1)', lineHeight:1.4, marginTop:3, opacity:0.85 }}>
+              reconciling three sources on partition tolerance
+            </div>
+          </div>
+
+          {/* stopped — pinned to the lit line */}
+          <div style={{ marginBottom:22, marginTop:38 }}>
+            <Caption color="var(--cyan)" size={8.5}>stopped at</Caption>
+            <div style={{ ...TT.disp, fontStyle:'italic', fontSize:11,
+              color:'var(--fg-2)', lineHeight:1.4, marginTop:3 }}>
+              "…does this hold when latency exceeds 200ms?"
+            </div>
+          </div>
+
+          {/* unresolved — counts only */}
+          <div style={{ marginBottom:22 }}>
+            <Caption color="var(--amber)" size={8.5}>unresolved</Caption>
+            <div style={{ display:'flex', gap:8, marginTop:5,
+              alignItems:'baseline' }}>
+              <span style={{ ...TT.disp, fontSize:18, color:'var(--amber)',
+                lineHeight:1 }}>1</span>
+              <span style={{ ...TT.ui, fontSize:10, color:'var(--fg-2)' }}>open synthesis</span>
+            </div>
+            <div style={{ display:'flex', gap:8, marginTop:3,
+              alignItems:'baseline' }}>
+              <span style={{ ...TT.disp, fontSize:14, color:'var(--fg-2)',
+                lineHeight:1 }}>2</span>
+              <span style={{ ...TT.ui, fontSize:10, color:'var(--fg-2)' }}>staged edits</span>
+            </div>
+          </div>
+
+          {/* changed */}
+          <div>
+            <Caption color="var(--vault)" size={8.5}>since</Caption>
+            <div style={{ ...TT.ui, fontSize:10.5, color:'var(--fg-2)',
+              lineHeight:1.45, marginTop:3 }}>
+              vault sync 2h ago.<br/>
+              Hugin found 1 adjacent note.
+            </div>
+          </div>
+        </div>
+
+        {/* ─ annotations ─ */}
+        <div style={{ position:'absolute', top:14, left:14, pointerEvents:'none' }}>
+          <HandNote color="var(--accent)" size={11}>doc readable from t=0<br/>no card to dismiss</HandNote>
+        </div>
+        <div style={{ position:'absolute', bottom:36, left:36, pointerEvents:'none' }}>
+          <HandNote color="var(--cyan)" size={10.5}>gold breath = where you stopped<br/>only "mist" in the doc</HandNote>
+        </div>
+        <div style={{ position:'absolute', top:74, right:240, pointerEvents:'none',
+          textAlign:'right' }}>
+          <HandNote color="var(--accent)" size={10.5}>whispers stay during<br/>the whole session,<br/>fade after 30s</HandNote>
+        </div>
+      </div>
+      <div style={{ position:'absolute', bottom:8, left:'50%',
+        transform:'translateX(-50%)', ...TT.mono, fontSize:9,
+        color:'var(--fg-3)', letterSpacing:'0.1em', textTransform:'uppercase',
+        opacity:0.55 }}>
+        A · margin whisper — lateral, spatial, never modal
+      </div>
+    </div>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────
+   VARIANT B — RESUMPTION BREATH
+   ─────────────────────────────────────────────────────────
+   Phenomenology: a single sentence appears in place — the
+   exact half-finished thought, ghosted, with a quiet caret.
+   Nothing else for ~3 seconds. If the user pauses, three
+   numerals quietly emerge in the lower margin: open / staged
+   / changed. No labels, no card edge, no separators.
+   ─────────────────────────────────────────────────────────*/
+function VariantB_Wire() {
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      display:'flex', flexDirection:'column', position:'relative', overflow:'hidden' }}>
+      <DocChrome />
+      <div style={{ flex:1, padding:'24px 38px', position:'relative',
+        backgroundImage:
+          'linear-gradient(rgba(0,212,232,0.012) 1px, transparent 1px),' +
+          'linear-gradient(90deg, rgba(0,212,232,0.012) 1px, transparent 1px)',
+        backgroundSize:'32px 32px' }}>
+
+        {/* doc body — readable, dimmed only along the path of attention */}
+        <div style={{ opacity:0.55 }}>
+          <div style={{ ...TT.disp, fontSize:18, color:'var(--fg-1)',
+            marginBottom:10, letterSpacing:'-0.01em' }}>Network boundary</div>
+          <Lines rows={3} last="58%" h={5.5} gap={8} />
+          <div style={{ height:14 }} />
+          <Lines rows={2} last="74%" h={5.5} gap={8} />
+        </div>
+
+        {/* the single sentence — ghosted in situ */}
+        <div style={{ marginTop:18, position:'relative' }}>
+          <div style={{ ...TT.disp, fontStyle:'italic', fontSize:18,
+            color:'var(--fg-1)', lineHeight:1.5, opacity:0.78,
+            letterSpacing:'-0.005em', maxWidth:'78%' }}>
+            …does this hold when latency exceeds 200ms,
+            <span style={{ color:'var(--fg-2)' }}>&nbsp;or are we partitioning past the consistency budget</span>
+            <span style={{ display:'inline-block', verticalAlign:'-2px',
+              width:1.5, height:18, background:'var(--accent)',
+              marginLeft:3, boxShadow:'0 0 6px var(--accent)',
+              animation:'tcbreathe 2.4s ease infinite' }} />
+          </div>
+          {/* a single faint underline marking the resume point */}
+          <div style={{ height:1, width:42, background:'var(--accent)',
+            opacity:0.45, marginTop:10 }} />
+        </div>
+
+        {/* document continues, dimmer */}
+        <div style={{ opacity:0.32, marginTop:22 }}>
+          <Lines rows={4} last="42%" h={5.5} gap={8} />
+        </div>
+
+        {/* the latent triplet — emerges only after ~3s pause */}
+        <div style={{ position:'absolute', bottom:30, left:38, right:38,
+          display:'flex', alignItems:'baseline', gap:32, opacity:0.78 }}>
+          <div style={{ display:'flex', alignItems:'baseline', gap:8 }}>
+            <span style={{ ...TT.disp, fontSize:24, color:'var(--amber)',
+              lineHeight:1 }}>1</span>
+            <span style={{ ...TT.ui, fontSize:10, color:'var(--fg-3)',
+              letterSpacing:'0.04em' }}>open</span>
+          </div>
+          <div style={{ display:'flex', alignItems:'baseline', gap:8 }}>
+            <span style={{ ...TT.disp, fontSize:24, color:'var(--cyan)',
+              lineHeight:1 }}>2</span>
+            <span style={{ ...TT.ui, fontSize:10, color:'var(--fg-3)',
+              letterSpacing:'0.04em' }}>staged</span>
+          </div>
+          <div style={{ display:'flex', alignItems:'baseline', gap:8 }}>
+            <span style={{ ...TT.disp, fontSize:24, color:'var(--vault)',
+              lineHeight:1 }}>1</span>
+            <span style={{ ...TT.ui, fontSize:10, color:'var(--fg-3)',
+              letterSpacing:'0.04em' }}>since</span>
+          </div>
+          <div style={{ marginLeft:'auto', ...TT.mono, fontSize:8.5,
+            color:'var(--fg-3)', letterSpacing:'0.1em',
+            textTransform:'uppercase', opacity:0.7 }}>
+            tap any number to expand
+          </div>
+        </div>
+
+        {/* annotations */}
+        <div style={{ position:'absolute', top:90, right:18,
+          textAlign:'right', pointerEvents:'none' }}>
+          <HandNote color="var(--accent)" size={11}>one sentence<br/>no chrome, no card</HandNote>
+        </div>
+        <div style={{ position:'absolute', bottom:74, left:18,
+          pointerEvents:'none' }}>
+          <HandNote color="var(--cyan)" size={10.5}>numerals fade in only<br/>after 3s of stillness<br/>otherwise: never seen</HandNote>
+        </div>
+        <div style={{ position:'absolute', top:170, right:170,
+          pointerEvents:'none', textAlign:'right' }}>
+          <HandNote color="var(--amber)" size={10}>greyed continuation<br/>= what AI heard you<br/>not-yet-say</HandNote>
+        </div>
+      </div>
+      <div style={{ position:'absolute', bottom:8, left:'50%',
+        transform:'translateX(-50%)', ...TT.mono, fontSize:9,
+        color:'var(--fg-3)', letterSpacing:'0.1em', textTransform:'uppercase',
+        opacity:0.55 }}>
+        B · resumption breath — one sentence, then silence
+      </div>
+    </div>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────
+   VARIANT C — ATMOSPHERIC RECALL
+   ─────────────────────────────────────────────────────────
+   Phenomenology: no card, no margin column. The page
+   itself remembers — a faint warm tint, a single gravity
+   well at the bottom margin (unresolved synthesis pulling),
+   and the cursor breathing at its last position. The four
+   answers are accessible only by hovering the corner glyphs;
+   otherwise nothing speaks.
+   ─────────────────────────────────────────────────────────*/
+function VariantC_Wire() {
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      display:'flex', flexDirection:'column', position:'relative', overflow:'hidden' }}>
+      <DocChrome />
+      <div style={{ flex:1, position:'relative',
+        backgroundImage:
+          'radial-gradient(ellipse at 50% 50%, rgba(212,168,67,0.04) 0%, transparent 70%),' +
+          'linear-gradient(rgba(0,212,232,0.012) 1px, transparent 1px),' +
+          'linear-gradient(90deg, rgba(0,212,232,0.012) 1px, transparent 1px)',
+        backgroundSize:'auto, 32px 32px, 32px 32px' }}>
+
+        {/* doc body, full opacity except where attention rests */}
+        <div style={{ padding:'22px 60px' }}>
+          <div style={{ ...TT.disp, fontSize:18, color:'var(--fg-1)',
+            marginBottom:10, letterSpacing:'-0.01em', opacity:0.95 }}>
+            Network boundary
+          </div>
+          <div style={{ opacity:0.85 }}>
+            <Lines rows={3} last="58%" h={5.5} gap={8} />
+          </div>
+          <div style={{ height:14 }} />
+          <div style={{ position:'relative' }}>
+            <div style={{ opacity:0.95 }}>
+              <Lines rows={2} last="74%" h={5.5} gap={8} />
+            </div>
+            <div style={{ position:'absolute', left:'74%', top:8, width:1.5,
+              height:14, background:'var(--accent)',
+              boxShadow:'0 0 8px var(--accent)',
+              animation:'tcbreathe 2.8s ease infinite' }} />
+          </div>
+          <div style={{ height:14 }} />
+          <div style={{ opacity:0.85 }}>
+            <Lines rows={4} last="42%" h={5.5} gap={8} />
+          </div>
+        </div>
+
+        {/* gravity well — unresolved synthesis felt as weight */}
+        <div style={{ position:'absolute', left:0, right:0, bottom:0, height:120,
+          background:
+            'radial-gradient(ellipse 280px 90px at 30% 100%, rgba(240,144,48,0.14) 0%, transparent 70%),' +
+            'radial-gradient(ellipse 200px 60px at 70% 100%, rgba(57,232,125,0.06) 0%, transparent 70%)',
+          pointerEvents:'none' }} />
+
+        {/* corner fixtures — four glyphs, one per question, no labels */}
+        {/* top-left: doing */}
+        <div style={{ position:'absolute', top:18, left:18,
+          display:'flex', flexDirection:'column', alignItems:'flex-start', gap:6 }}>
+          <div style={{ display:'flex', alignItems:'center', gap:8 }}>
+            <div style={{ width:6, height:6, background:'var(--accent)',
+              boxShadow:'0 0 8px var(--accent)' }} />
+            <Caption color="var(--accent)" size={8.5}>thread</Caption>
+          </div>
+        </div>
+
+        {/* top-right: changed */}
+        <div style={{ position:'absolute', top:18, right:18,
+          display:'flex', flexDirection:'column', alignItems:'flex-end', gap:6 }}>
+          <div style={{ display:'flex', alignItems:'center', gap:8 }}>
+            <Caption color="var(--vault)" size={8.5}>since</Caption>
+            <div style={{ width:6, height:6, borderRadius:'50%',
+              background:'var(--vault)', boxShadow:'0 0 8px var(--vault)' }} />
+          </div>
+        </div>
+
+        {/* bottom-left: unresolved (visible weight, not number) */}
+        <div style={{ position:'absolute', bottom:18, left:18,
+          display:'flex', alignItems:'center', gap:8 }}>
+          <TensionHalo size={26} level={0.55} color="var(--amber)" />
+          <Caption color="var(--amber)" size={8.5}>weight</Caption>
+        </div>
+
+        {/* bottom-right: stopped — a small caret echo */}
+        <div style={{ position:'absolute', bottom:18, right:18,
+          display:'flex', alignItems:'center', gap:8 }}>
+          <Caption color="var(--cyan)" size={8.5}>caret</Caption>
+          <div style={{ width:1, height:11, background:'var(--cyan)',
+            boxShadow:'0 0 6px var(--cyan)',
+            animation:'tcbreathe 3.6s ease infinite' }} />
+        </div>
+
+        {/* annotations */}
+        <div style={{ position:'absolute', top:54, left:60, pointerEvents:'none' }}>
+          <HandNote color="var(--accent)" size={11}>warm tint = "this room<br/>has been used before"</HandNote>
+        </div>
+        <div style={{ position:'absolute', bottom:78, left:'46%',
+          pointerEvents:'none' }}>
+          <HandNote color="var(--amber)" size={11}>gravity well<br/>= unresolved pulling<br/>(felt, not labeled)</HandNote>
+        </div>
+        <div style={{ position:'absolute', top:38, right:88,
+          pointerEvents:'none', textAlign:'right' }}>
+          <HandNote color="var(--vault)" size={10.5}>hover any corner<br/>to read its answer<br/>otherwise: silent</HandNote>
+        </div>
+      </div>
+      <div style={{ position:'absolute', bottom:8, left:'50%',
+        transform:'translateX(-50%)', ...TT.mono, fontSize:9,
+        color:'var(--fg-3)', letterSpacing:'0.1em', textTransform:'uppercase',
+        opacity:0.55 }}>
+        C · atmospheric recall — a room that remembers
+      </div>
+    </div>
+  );
+}
+
+window.VariantA_Wire = VariantA_Wire;
+window.VariantB_Wire = VariantB_Wire;
+window.VariantC_Wire = VariantC_Wire;

--- a/companion-ui/design_handoff/2026-05-08-cognitive-temporal/temporal-primitives.jsx
+++ b/companion-ui/design_handoff/2026-05-08-cognitive-temporal/temporal-primitives.jsx
@@ -1,0 +1,270 @@
+/* ============================================================
+   Temporal cognition — shared primitives
+   ============================================================
+   Visual vocabulary specific to time, decay, dormancy, and
+   continuity. Builds on the cyberpunk/Tron design system.
+   ============================================================ */
+
+const TT = {
+  hand: { fontFamily: "'Kalam', cursive" },
+  mono: { fontFamily: 'var(--font-mono)' },
+  ui:   { fontFamily: 'var(--font-ui)' },
+  disp: { fontFamily: 'var(--font-display)' },
+};
+
+/* ── Hairline divider with optional inline label ───────── */
+function Hairline({ label, color = 'var(--border)', labelColor = 'var(--fg-3)', style = {} }) {
+  if (!label) return <div style={{ height:1, background:color, ...style }} />;
+  return (
+    <div style={{ display:'flex', alignItems:'center', gap:8, ...style }}>
+      <div style={{ height:1, flex:1, background:color }} />
+      <span style={{ ...TT.mono, fontSize:8.5, color:labelColor,
+        letterSpacing:'0.12em', textTransform:'uppercase' }}>{label}</span>
+      <div style={{ height:1, flex:1, background:color }} />
+    </div>
+  );
+}
+
+/* ── Annotation in handwriting (Kalam) ─────────────────── */
+function HandNote({ children, color = 'var(--accent)', size = 12, style = {} }) {
+  return (
+    <div style={{ ...TT.hand, fontSize:size, color, lineHeight:1.35,
+      letterSpacing:'0.005em', ...style }}>{children}</div>
+  );
+}
+
+/* ── Mono caption (uppercase, tracked) ─────────────────── */
+function Caption({ children, color = 'var(--fg-3)', size = 9, style = {} }) {
+  return (
+    <span style={{ ...TT.mono, fontSize:size, color,
+      letterSpacing:'0.1em', textTransform:'uppercase', ...style }}>{children}</span>
+  );
+}
+
+/* ── Faint marginalia dot — salience by size, recency by opacity ── */
+function MargDot({ size = 6, opacity = 1, color = 'var(--vault)', glow = true }) {
+  return (
+    <div style={{ width:size, height:size, borderRadius:'50%',
+      background:color, opacity,
+      boxShadow: glow ? `0 0 ${size*1.4}px ${color}` : 'none',
+      flexShrink:0 }} />
+  );
+}
+
+/* ── Skeleton text line — placeholder for body copy ───── */
+function Line({ w = '100%', h = 6, color = 'var(--border-strong)',
+  opacity = 1, style = {} }) {
+  return <div style={{ width:w, height:h, background:color,
+    borderRadius:1, opacity, ...style }} />;
+}
+function Lines({ rows = 3, last = '60%', h = 6, gap = 6,
+  color = 'var(--border-strong)', opacity = 1 }) {
+  return (
+    <div style={{ display:'flex', flexDirection:'column', gap }}>
+      {Array.from({length:rows}).map((_,i) =>
+        <Line key={i} h={h} w={i === rows-1 ? last : '100%'}
+          color={color} opacity={opacity} />)}
+    </div>
+  );
+}
+
+/* ── Document panel — used as a stage for overlay demos ─ */
+function DocStage({ children, width = '100%', height = '100%',
+  pad = '20px 28px', style = {} }) {
+  return (
+    <div style={{ width, height, background:'var(--bg-base)',
+      backgroundImage:
+        'linear-gradient(rgba(0,212,232,0.018) 1px, transparent 1px),' +
+        'linear-gradient(90deg, rgba(0,212,232,0.018) 1px, transparent 1px)',
+      backgroundSize:'32px 32px',
+      padding:pad, position:'relative', overflow:'hidden', ...style }}>
+      {children}
+    </div>
+  );
+}
+
+/* ── Time-decay arc — small SVG that draws a fading curve ── */
+function DecayArc({ w = 120, h = 32, color = 'var(--vault)',
+  highlight = 0.7, style = {} }) {
+  // highlight = 0..1 position of "now"
+  const points = [];
+  for (let i = 0; i <= 40; i++) {
+    const x = (i/40) * (w - 6) + 3;
+    const y = h - 4 - (h - 8) * Math.exp(-i/12);
+    points.push([x,y]);
+  }
+  const path = points.map((p,i) => `${i===0?'M':'L'}${p[0].toFixed(1)} ${p[1].toFixed(1)}`).join(' ');
+  const nowX = highlight * (w - 6) + 3;
+  const nowI = Math.round(highlight * 40);
+  const nowY = points[nowI] ? points[nowI][1] : h - 4;
+  return (
+    <svg width={w} height={h} style={style}>
+      <path d={path} fill="none" stroke={color} strokeWidth="1.2"
+        opacity="0.45" strokeLinecap="round" />
+      <circle cx={nowX} cy={nowY} r="2.5" fill={color} />
+      <circle cx={nowX} cy={nowY} r="5" fill="none" stroke={color}
+        strokeWidth="0.8" opacity="0.4" />
+    </svg>
+  );
+}
+
+/* ── Tension halo — radial pressure indicator ─────────── */
+function TensionHalo({ size = 40, level = 0.6, color = 'var(--amber)' }) {
+  // level 0..1 pressure intensity
+  const r = size/2 - 2;
+  return (
+    <svg width={size} height={size}>
+      <defs>
+        <radialGradient id={`th-${level}`}>
+          <stop offset="0%" stopColor={color} stopOpacity={0.45 * level} />
+          <stop offset="60%" stopColor={color} stopOpacity={0.15 * level} />
+          <stop offset="100%" stopColor={color} stopOpacity="0" />
+        </radialGradient>
+      </defs>
+      <circle cx={size/2} cy={size/2} r={r} fill={`url(#th-${level})`} />
+      <circle cx={size/2} cy={size/2} r="1.5" fill={color} opacity={0.7 + 0.3*level} />
+    </svg>
+  );
+}
+
+/* ── Trajectory thread — broken / dashed line indicating  ─
+       a thought that paused and may resume                ── */
+function TrajectoryThread({ w = 200, h = 14, color = 'var(--accent)',
+  broken = true, intensity = 0.6 }) {
+  return (
+    <svg width={w} height={h}>
+      <line x1="2" y1={h/2} x2={w*0.4} y2={h/2}
+        stroke={color} strokeWidth="1.5" opacity={intensity}
+        strokeLinecap="round" />
+      {broken && Array.from({length:5}).map((_,i) =>
+        <circle key={i} cx={w*0.4 + 8 + i*8} cy={h/2} r="0.9"
+          fill={color} opacity={intensity * (1 - i*0.15)} />
+      )}
+      <line x1={broken ? w*0.4 + 56 : w*0.4} y1={h/2} x2={w-2} y2={h/2}
+        stroke={color} strokeWidth="1.5" opacity={intensity * 0.5}
+        strokeLinecap="round" strokeDasharray={broken ? '0' : '0'} />
+      <circle cx={w-2} cy={h/2} r="1.6" fill={color} opacity={intensity * 0.6} />
+    </svg>
+  );
+}
+
+/* ── Time spine — horizontal axis with tick markers ────── */
+function TimeSpine({ w = 540, h = 28, marks = [], style = {} }) {
+  // marks: [{ at: 0..1, label, color, ring }]
+  return (
+    <svg width={w} height={h} style={style}>
+      <line x1="2" y1={h-7} x2={w-2} y2={h-7} stroke="var(--border-strong)"
+        strokeWidth="0.8" />
+      {marks.map((m, i) => {
+        const x = m.at * (w - 4) + 2;
+        return (
+          <g key={i}>
+            <line x1={x} y1={h-12} x2={x} y2={h-2} stroke={m.color || 'var(--fg-3)'}
+              strokeWidth="0.8" opacity="0.5" />
+            <circle cx={x} cy={h-7} r={m.ring ? 3 : 2}
+              fill={m.color || 'var(--fg-2)'}
+              stroke={m.ring ? m.color : 'none'} strokeWidth={m.ring ? 0.5 : 0}
+              opacity={m.opacity ?? 1} />
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+/* ── Mist gradient overlay — orientation drift ────────── */
+function MistOverlay({ children, side = 'top', color = 'var(--accent)',
+  intensity = 0.05, style = {} }) {
+  const grad = side === 'top'
+    ? `linear-gradient(180deg, rgba(212,168,67,${intensity}) 0%, transparent 60%)`
+    : `linear-gradient(0deg, rgba(212,168,67,${intensity}) 0%, transparent 60%)`;
+  return (
+    <div style={{ position:'absolute', inset:0, background:grad,
+      pointerEvents:'none', ...style }}>{children}</div>
+  );
+}
+
+/* ── Open-loop chip — compact "unresolved" token ───────── */
+function OpenLoop({ children, age = '3d', tone = 'var(--accent)', soft = false }) {
+  return (
+    <div style={{ display:'inline-flex', alignItems:'center', gap:6,
+      padding:'3px 8px 3px 7px',
+      background: soft ? 'transparent' : 'rgba(212,168,67,0.04)',
+      border:`1px solid ${soft ? 'var(--border)' : 'rgba(212,168,67,0.25)'}`,
+      borderLeft:`2px solid ${tone}`, borderRadius:2 }}>
+      <div style={{ width:4, height:4, borderRadius:'50%', background:tone,
+        boxShadow:`0 0 4px ${tone}` }} />
+      <span style={{ ...TT.ui, fontSize:11, color:'var(--fg-1)',
+        whiteSpace:'nowrap', overflow:'hidden', textOverflow:'ellipsis',
+        maxWidth:240 }}>{children}</span>
+      <span style={{ ...TT.mono, fontSize:8.5, color:'var(--fg-3)',
+        letterSpacing:'0.05em', marginLeft:4 }}>{age}</span>
+    </div>
+  );
+}
+
+/* ── Pulse — subtle ambient indicator ──────────────────── */
+function Pulse({ size = 8, color = 'var(--vault)', delay = 0 }) {
+  return (
+    <div style={{ position:'relative', width:size, height:size }}>
+      <div style={{ position:'absolute', inset:0, borderRadius:'50%',
+        background:color, animation:`tcpulse 2.4s ease ${delay}s infinite`,
+        opacity:0.7 }} />
+      <div style={{ position:'absolute', inset:size*0.25, borderRadius:'50%',
+        background:color, boxShadow:`0 0 ${size}px ${color}` }} />
+    </div>
+  );
+}
+
+/* ── Section heading inside an artboard ────────────────── */
+function ABHead({ children, tone = 'var(--accent)', sub }) {
+  return (
+    <div style={{ display:'flex', flexDirection:'column', gap:4, marginBottom:12 }}>
+      <div style={{ ...TT.disp, fontSize:18, color:'var(--fg-1)',
+        letterSpacing:'-0.01em', lineHeight:1.15 }}>{children}</div>
+      {sub && <div style={{ ...TT.mono, fontSize:9, color:tone,
+        letterSpacing:'0.1em', textTransform:'uppercase' }}>{sub}</div>}
+      <div style={{ height:1, background:tone, opacity:0.4, width:48 }} />
+    </div>
+  );
+}
+
+/* ── Pill — generic small label ────────────────────────── */
+function Pill({ children, tone = 'var(--fg-3)', filled = false, style = {} }) {
+  return (
+    <span style={{ display:'inline-flex', alignItems:'center', gap:4,
+      padding:'2px 7px',
+      background: filled ? `color-mix(in srgb, ${tone} 12%, transparent)` : 'transparent',
+      border:`1px solid ${tone}`, borderRadius:2,
+      ...TT.mono, fontSize:9, color:tone,
+      letterSpacing:'0.06em', textTransform:'uppercase', ...style }}>{children}</span>
+  );
+}
+
+/* ── inject keyframes once ─────────────────────────────── */
+(function ensureKeyframes(){
+  if (document.getElementById('tc-keyframes')) return;
+  const s = document.createElement('style');
+  s.id = 'tc-keyframes';
+  s.textContent = `
+    @keyframes tcpulse {
+      0%, 100% { transform: scale(1); opacity: 0.8; }
+      50% { transform: scale(2.1); opacity: 0; }
+    }
+    @keyframes tcdrift {
+      0%, 100% { transform: translateY(0px); }
+      50% { transform: translateY(-2px); }
+    }
+    @keyframes tcbreathe {
+      0%, 100% { opacity: 0.45; }
+      50% { opacity: 0.75; }
+    }
+  `;
+  document.head.appendChild(s);
+})();
+
+Object.assign(window, {
+  TT, Hairline, HandNote, Caption, MargDot, Line, Lines,
+  DocStage, DecayArc, TensionHalo, TrajectoryThread, TimeSpine,
+  MistOverlay, OpenLoop, Pulse, ABHead, Pill,
+});

--- a/companion-ui/design_handoff/2026-05-08-cognitive-temporal/temporal-s1.jsx
+++ b/companion-ui/design_handoff/2026-05-08-cognitive-temporal/temporal-s1.jsx
@@ -1,0 +1,214 @@
+/* ============================================================
+   Section 1 — Interrupted trajectories
+   How thought is preserved when the user steps away
+   ============================================================ */
+
+/* ── 1A · Trajectory preservation model ─────────────────── */
+function S1_Model() {
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      padding:'20px 24px', display:'flex', flexDirection:'column', gap:10 }}>
+      <ABHead tone="var(--accent)" sub="four states · one anchor">
+        Trajectory states
+      </ABHead>
+      <div style={{ ...TT.ui, fontSize:11.5, color:'var(--fg-2)', lineHeight:1.55,
+        marginBottom:6 }}>
+        Every thought-in-progress occupies one of four states. The system
+        preserves all four invisibly, surfaces them only when the user looks for them.
+      </div>
+
+      {[
+        { name:'Active', tone:'var(--cyan)',
+          desc:'Cursor present in last 90 seconds. Living, hot.',
+          mark:'cursor pulse · live caret · breath' },
+        { name:'Warm', tone:'var(--accent)',
+          desc:'Untouched 90s–2hr. Still in working memory. Still unfinished.',
+          mark:'gold spine · open-loop chip · momentum trail' },
+        { name:'Dormant', tone:'var(--vault)',
+          desc:'2hr–14d quiet. Submerged but recoverable. Decay envelope.',
+          mark:'faint marginalia · decay arc · tension halo if pressured' },
+        { name:'Cold', tone:'var(--fg-3)',
+          desc:'>14d. Vault-canonical only. Re-entry through search.',
+          mark:'no surface trace · provenance only' },
+      ].map((s, i) => (
+        <div key={s.name} style={{ display:'grid',
+          gridTemplateColumns:'82px 1fr 180px', gap:14, alignItems:'flex-start',
+          padding:'9px 0',
+          borderTop: i === 0 ? '1px solid var(--border)' : '1px solid var(--border)' }}>
+          <div style={{ display:'flex', alignItems:'center', gap:6 }}>
+            <div style={{ width:3, height:24, background:s.tone }} />
+            <div>
+              <div style={{ ...TT.ui, fontSize:12, color:'var(--fg-1)',
+                fontWeight:500 }}>{s.name}</div>
+              <div style={{ ...TT.mono, fontSize:8.5, color:s.tone,
+                letterSpacing:'0.08em', textTransform:'uppercase' }}>state {i+1}</div>
+            </div>
+          </div>
+          <div style={{ ...TT.ui, fontSize:11, color:'var(--fg-2)',
+            lineHeight:1.5 }}>{s.desc}</div>
+          <div style={{ ...TT.mono, fontSize:9, color:'var(--fg-3)',
+            letterSpacing:'0.04em', lineHeight:1.5 }}>{s.mark}</div>
+        </div>
+      ))}
+
+      <div style={{ marginTop:8, padding:'8px 10px',
+        background:'rgba(212,168,67,0.04)', border:'1px solid rgba(212,168,67,0.2)',
+        borderLeft:'2px solid var(--accent)' }}>
+        <Caption color="var(--accent)">invariant</Caption>
+        <div style={{ ...TT.ui, fontSize:11, color:'var(--fg-1)',
+          lineHeight:1.5, marginTop:4 }}>
+          State changes are <em>derived</em>, never declared. The user never
+          marks something dormant; the system never asks. Time does the work.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── 1B · What gets preserved when user steps away ──────── */
+function S1_Preserved() {
+  const items = [
+    { k:'Cursor + selection', v:'Last caret line:col + selection range, per file.' },
+    { k:'Scroll trail', v:'Last 40 viewport positions (sparse). Reveals what user lingered on.' },
+    { k:'Open loops', v:'Sentences ending in question mark, "TODO", "?", or unresolved bracket. Auto-detected.' },
+    { k:'Last query', v:'Most recent question to Hugin. Lives in the trajectory, not just chat history.' },
+    { k:'Adjacent canvas', v:'Branches, even unsaved. Cached locally with last-touched timestamp.' },
+    { k:'Staged proposals', v:'Pending review-mode blocks remain in place. Amber persists.' },
+    { k:'Reading thread', v:'Sequence of notes opened in this session. Order matters for reconstruction.' },
+    { k:'Tension graph', v:'Which passages had unresolved synthesis or conflicting sources.' },
+  ];
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      padding:'20px 24px', display:'flex', flexDirection:'column', gap:10 }}>
+      <ABHead tone="var(--cyan)" sub="continuity payload">
+        What is preserved
+      </ABHead>
+      <div style={{ ...TT.ui, fontSize:11, color:'var(--fg-2)', lineHeight:1.55 }}>
+        Every interruption captures a small structured snapshot. Stored locally,
+        keyed to the active document. Vault remains canonical; this is volatile
+        cognitive scaffolding.
+      </div>
+      <div style={{ flex:1, display:'flex', flexDirection:'column', gap:0,
+        marginTop:6 }}>
+        {items.map((it, i) => (
+          <div key={it.k} style={{ display:'grid',
+            gridTemplateColumns:'140px 1fr', gap:12, padding:'7px 0',
+            borderTop: i === 0 ? '1px solid var(--border)' : '1px solid var(--border)' }}>
+            <Caption color="var(--cyan)">{it.k}</Caption>
+            <div style={{ ...TT.ui, fontSize:11, color:'var(--fg-1)',
+              lineHeight:1.45 }}>{it.v}</div>
+          </div>
+        ))}
+      </div>
+      <div style={{ marginTop:6, ...TT.mono, fontSize:9, color:'var(--fg-3)',
+        letterSpacing:'0.06em' }}>
+        snapshot.json · ~6kb · written every 4s when dirty · purged at 30 days
+      </div>
+    </div>
+  );
+}
+
+/* ── 1C · Wireframe: document at moment of interruption ── */
+function S1_InterruptWire() {
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      display:'flex', flexDirection:'column', position:'relative', overflow:'hidden' }}>
+      {/* doc header */}
+      <div style={{ padding:'10px 18px', borderBottom:'1px solid var(--border)',
+        display:'flex', alignItems:'center', gap:10 }}>
+        <Caption color="var(--fg-3)">Projects/Q2-arch.md</Caption>
+        <Caption color="var(--accent)" size={9}>·  warm  ·  18m idle</Caption>
+        <div style={{ marginLeft:'auto' }}>
+          <Pill tone="var(--accent)">trajectory live</Pill>
+        </div>
+      </div>
+
+      {/* doc body w/ persistent state */}
+      <div style={{ flex:1, padding:'18px 32px', position:'relative',
+        backgroundImage:
+          'linear-gradient(rgba(0,212,232,0.018) 1px, transparent 1px),' +
+          'linear-gradient(90deg, rgba(0,212,232,0.018) 1px, transparent 1px)',
+        backgroundSize:'32px 32px' }}>
+
+        {/* ## heading */}
+        <div style={{ ...TT.disp, fontSize:20, color:'var(--fg-1)',
+          marginBottom:12, letterSpacing:'-0.01em' }}>Network boundary</div>
+        <Lines rows={3} last="58%" h={6.5} gap={9} />
+
+        <div style={{ height:18 }} />
+
+        {/* paragraph w/ inline cursor + open question */}
+        <div style={{ position:'relative' }}>
+          <Lines rows={2} last="100%" h={6.5} gap={9} />
+          <div style={{ display:'flex', alignItems:'center', gap:1, marginTop:9,
+            ...TT.ui, fontSize:13, color:'var(--fg-1)', lineHeight:1.55 }}>
+            <span style={{ color:'var(--fg-2)' }}>...does this hold when latency exceeds 200ms</span>
+            <span style={{ ...TT.disp, color:'var(--accent)', fontSize:18,
+              marginLeft:1 }}>?</span>
+            <span style={{ display:'inline-block', width:1.5, height:14,
+              background:'var(--cyan)', marginLeft:2,
+              animation:'tcbreathe 1.4s ease infinite' }} />
+          </div>
+          <Caption color="var(--accent)" style={{ position:'absolute', right:-10,
+            top:32 }}>open loop · captured</Caption>
+        </div>
+
+        <div style={{ height:18 }} />
+
+        {/* trajectory bar — visible only when dormant overlay is hovered */}
+        <div style={{ display:'flex', alignItems:'center', gap:10,
+          padding:'8px 12px', background:'rgba(212,168,67,0.03)',
+          border:'1px dashed rgba(212,168,67,0.25)', borderRadius:2 }}>
+          <Caption color="var(--accent)">momentum trail</Caption>
+          <TimeSpine w={360} h={22} marks={[
+            { at:0.05, color:'var(--fg-3)', opacity:0.6 },
+            { at:0.18, color:'var(--vault)', opacity:0.6 },
+            { at:0.32, color:'var(--accent)', opacity:0.7 },
+            { at:0.48, color:'var(--accent)', opacity:0.85 },
+            { at:0.62, color:'var(--cyan)', opacity:0.9, ring:true },
+            { at:0.78, color:'var(--accent)', opacity:1, ring:true },
+            { at:0.92, color:'var(--cyan)', opacity:1, ring:true },
+          ]} />
+          <Caption color="var(--fg-3)">9:14 → now</Caption>
+        </div>
+
+        <div style={{ height:14 }} />
+
+        {/* unresolved synthesis stub */}
+        <div style={{ background:'rgba(57,232,125,0.03)',
+          borderLeft:'2px solid var(--vault)',
+          padding:'10px 12px', borderRadius:'0 2px 2px 0', position:'relative' }}>
+          <Caption color="var(--vault)">synthesis · unfinished</Caption>
+          <div style={{ ...TT.ui, fontSize:12, color:'var(--fg-1)',
+            marginTop:5, lineHeight:1.5 }}>
+            Two sources align on consistency model; <span style={{ color:'var(--amber)' }}>
+            third disagrees on partition tolerance</span> — draft paragraph
+            pending reconciliation.
+          </div>
+          <div style={{ display:'flex', gap:6, marginTop:7 }}>
+            <Pill tone="var(--vault)" filled>3 sources</Pill>
+            <Pill tone="var(--amber)">1 conflict</Pill>
+            <Pill tone="var(--fg-3)">draft 60%</Pill>
+          </div>
+        </div>
+      </div>
+
+      {/* annotations */}
+      <div style={{ position:'absolute', top:62, right:14, pointerEvents:'none',
+        textAlign:'right' }}>
+        <HandNote color="var(--accent)" size={11}>cursor + last query<br/>persist verbatim</HandNote>
+      </div>
+      <div style={{ position:'absolute', bottom:88, right:14, pointerEvents:'none',
+        textAlign:'right' }}>
+        <HandNote color="var(--vault)" size={11}>unresolved synthesis<br/>holds shape, not flattens</HandNote>
+      </div>
+      <div style={{ position:'absolute', bottom:170, left:14, pointerEvents:'none' }}>
+        <HandNote color="var(--accent)" size={11}>momentum trail —<br/>scroll dwell + edit pulses</HandNote>
+      </div>
+    </div>
+  );
+}
+
+window.S1_Model = S1_Model;
+window.S1_Preserved = S1_Preserved;
+window.S1_InterruptWire = S1_InterruptWire;

--- a/companion-ui/design_handoff/2026-05-08-cognitive-temporal/temporal-s2.jsx
+++ b/companion-ui/design_handoff/2026-05-08-cognitive-temporal/temporal-s2.jsx
@@ -1,0 +1,213 @@
+/* ============================================================
+   Section 2 — Re-entry ergonomics
+   The mist, the resumption shapes, the four questions
+   ============================================================ */
+
+/* ── 2A · Re-entry mist overlay ─────────────────────────── */
+function S2_MistWire() {
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      display:'flex', flexDirection:'column', position:'relative', overflow:'hidden' }}>
+
+      {/* doc header */}
+      <div style={{ padding:'10px 18px', borderBottom:'1px solid var(--border)',
+        display:'flex', alignItems:'center', gap:10 }}>
+        <Caption color="var(--fg-3)">Projects/Q2-arch.md</Caption>
+        <Caption color="var(--vault)">·  resuming after 3 days</Caption>
+      </div>
+
+      {/* doc — slightly dimmed under mist */}
+      <div style={{ flex:1, padding:'18px 32px', position:'relative',
+        backgroundImage:
+          'linear-gradient(rgba(0,212,232,0.012) 1px, transparent 1px),' +
+          'linear-gradient(90deg, rgba(0,212,232,0.012) 1px, transparent 1px)',
+        backgroundSize:'32px 32px' }}>
+
+        <div style={{ opacity:0.45 }}>
+          <div style={{ ...TT.disp, fontSize:20, color:'var(--fg-1)',
+            marginBottom:12, letterSpacing:'-0.01em' }}>Network boundary</div>
+          <Lines rows={3} last="58%" h={6.5} gap={9} />
+          <div style={{ height:18 }} />
+          <Lines rows={4} last="40%" h={6.5} gap={9} />
+        </div>
+
+        {/* the mist itself — top gradient + center re-entry card */}
+        <div style={{ position:'absolute', inset:0, pointerEvents:'none',
+          background:'radial-gradient(ellipse at 50% 35%, rgba(212,168,67,0.06) 0%, transparent 55%)' }} />
+
+        {/* re-entry card — floats over mist */}
+        <div style={{ position:'absolute', top:60, left:'50%',
+          transform:'translateX(-50%)', width:540,
+          background:'rgba(7,11,18,0.92)',
+          backdropFilter:'blur(8px)',
+          border:'1px solid rgba(212,168,67,0.35)',
+          boxShadow:'0 0 24px rgba(212,168,67,0.15), 0 8px 32px rgba(0,0,0,0.5)',
+          padding:'18px 22px', borderRadius:3 }}>
+          <div style={{ display:'flex', alignItems:'baseline', gap:10,
+            marginBottom:4 }}>
+            <span style={{ ...TT.disp, fontSize:22, color:'var(--fg-1)',
+              letterSpacing:'-0.01em' }}>Where you were</span>
+            <Caption color="var(--accent)">3d 4h ago</Caption>
+          </div>
+          <div style={{ height:1, background:'var(--accent)', opacity:0.4,
+            width:42, marginBottom:14 }} />
+
+          {/* the four questions answered as a stack */}
+          {[
+            { q:'doing', a:'Reconciling three sources on partition tolerance.',
+              tone:'var(--accent)' },
+            { q:'stopped', a:'Mid-sentence: "...does this hold when latency exceeds 200ms?"',
+              tone:'var(--cyan)' },
+            { q:'unresolved', a:'1 open synthesis · 2 staged edits · 1 conflicting claim.',
+              tone:'var(--amber)' },
+            { q:'changed', a:'Hugin found 1 related note; vault sync 2h ago.',
+              tone:'var(--vault)' },
+          ].map((row, i) => (
+            <div key={row.q} style={{ display:'grid',
+              gridTemplateColumns:'90px 1fr', gap:12, padding:'7px 0',
+              borderTop: i === 0 ? 'none' : '1px solid var(--border)' }}>
+              <div style={{ display:'flex', alignItems:'center', gap:6 }}>
+                <div style={{ width:2, height:14, background:row.tone }} />
+                <Caption color={row.tone} size={9}>{row.q}</Caption>
+              </div>
+              <div style={{ ...TT.ui, fontSize:12, color:'var(--fg-1)',
+                lineHeight:1.45 }}>{row.a}</div>
+            </div>
+          ))}
+
+          <div style={{ display:'flex', gap:6, marginTop:14 }}>
+            <div style={{ padding:'4px 12px', border:'1px solid var(--accent)',
+              borderRadius:2, ...TT.ui, fontSize:11, color:'var(--accent)' }}>
+              Resume here
+            </div>
+            <div style={{ padding:'4px 12px', border:'1px solid var(--border-strong)',
+              borderRadius:2, ...TT.ui, fontSize:11, color:'var(--fg-2)' }}>
+              Show what changed
+            </div>
+            <div style={{ marginLeft:'auto', padding:'4px 8px',
+              ...TT.mono, fontSize:9, color:'var(--fg-3)' }}>esc · dismiss</div>
+          </div>
+        </div>
+
+        {/* dismissal hint */}
+        <div style={{ position:'absolute', bottom:18, left:'50%',
+          transform:'translateX(-50%)', ...TT.mono, fontSize:9,
+          color:'var(--fg-3)', letterSpacing:'0.1em', textTransform:'uppercase',
+          opacity:0.6 }}>
+          first keystroke clears the mist
+        </div>
+      </div>
+
+      {/* annotations */}
+      <div style={{ position:'absolute', top:50, left:14, pointerEvents:'none' }}>
+        <HandNote color="var(--accent)" size={11}>document dims, never hides<br/>spatial position preserved</HandNote>
+      </div>
+      <div style={{ position:'absolute', top:50, right:14, pointerEvents:'none',
+        textAlign:'right' }}>
+        <HandNote color="var(--accent)" size={11}>card surfaces once<br/>then dissolves on action</HandNote>
+      </div>
+    </div>
+  );
+}
+
+/* ── 2B · The four questions, formalized ────────────────── */
+function S2_FourQuestions() {
+  const qs = [
+    { q:'What was I doing?',
+      a:'Reconstructed from edit pulses + last query + active selection. One sentence summary, never analytical.',
+      tone:'var(--accent)',
+      shape:'one line · summary · always present' },
+    { q:'Where did momentum stop?',
+      a:'Cursor position + last 30s of edits expressed as a quoted fragment. Resume button jumps to exact caret.',
+      tone:'var(--cyan)',
+      shape:'verbatim quote · jumpable' },
+    { q:'What remains unresolved?',
+      a:'Open loops + staged proposals + tension halos. Counted, not enumerated. Click expands to inline list.',
+      tone:'var(--amber)',
+      shape:'counts only · expandable' },
+    { q:'What changed since last engagement?',
+      a:'Vault diffs touching this trajectory, agent-found context, decayed items. Diff summary, never timeline.',
+      tone:'var(--vault)',
+      shape:'delta only · never since-zero' },
+  ];
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      padding:'20px 24px', display:'flex', flexDirection:'column', gap:8 }}>
+      <ABHead tone="var(--accent)" sub="re-entry ergonomics">
+        Four questions, four shapes
+      </ABHead>
+      <div style={{ ...TT.ui, fontSize:11, color:'var(--fg-2)',
+        lineHeight:1.55, marginBottom:6 }}>
+        The mist card answers exactly four questions. No more. The shape of
+        each answer is fixed — not negotiable per session.
+      </div>
+      {qs.map((row, i) => (
+        <div key={row.q} style={{ padding:'10px 0',
+          borderTop: i === 0 ? '1px solid var(--border)' : '1px solid var(--border)' }}>
+          <div style={{ display:'flex', alignItems:'baseline', gap:10,
+            marginBottom:4 }}>
+            <div style={{ width:2, alignSelf:'stretch', background:row.tone }} />
+            <span style={{ ...TT.disp, fontSize:14, color:'var(--fg-1)',
+              fontStyle:'italic' }}>"{row.q}"</span>
+          </div>
+          <div style={{ ...TT.ui, fontSize:11, color:'var(--fg-2)',
+            lineHeight:1.5, marginLeft:12, marginBottom:4 }}>{row.a}</div>
+          <div style={{ marginLeft:12 }}>
+            <Caption color={row.tone}>shape · {row.shape}</Caption>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ── 2C · Re-entry latency ladder ──────────────────────── */
+function S2_LatencyLadder() {
+  const stages = [
+    { gap:'< 90s', name:'no mist',
+      desc:'Active state. Cursor still pulsing. Returning is identity.',
+      visual:'cursor breath' },
+    { gap:'90s – 15m', name:'thread fade',
+      desc:'Conversation pane fades a fraction. No card. The trajectory is implicit.',
+      visual:'ambient dim' },
+    { gap:'15m – 2h', name:'soft mist',
+      desc:'Re-entry card appears compact: just "where you stopped" sentence + cursor jump. No metadata.',
+      visual:'1-line card' },
+    { gap:'2h – 3d', name:'full mist',
+      desc:'All four questions answered. This is the canonical re-entry shape.',
+      visual:'4-question card' },
+    { gap:'3d – 14d', name:'long mist',
+      desc:'Adds: what changed in vault, what Hugin learned, decayed adjacent canvas branches.',
+      visual:'card + delta strip' },
+    { gap:'> 14d', name:'cold start',
+      desc:'No mist. The document is ambient context only. User searches.',
+      visual:'no overlay' },
+  ];
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      padding:'20px 24px', display:'flex', flexDirection:'column', gap:6 }}>
+      <ABHead tone="var(--cyan)" sub="how re-entry scales with absence">
+        Latency ladder
+      </ABHead>
+      {stages.map((s, i) => (
+        <div key={s.gap} style={{ display:'grid',
+          gridTemplateColumns:'90px 1fr 110px', gap:10, alignItems:'flex-start',
+          padding:'8px 0',
+          borderTop: i === 0 ? '1px solid var(--border)' : '1px solid var(--border)' }}>
+          <Caption color="var(--cyan)">{s.gap}</Caption>
+          <div>
+            <div style={{ ...TT.ui, fontSize:11.5, color:'var(--fg-1)',
+              fontWeight:500, marginBottom:2 }}>{s.name}</div>
+            <div style={{ ...TT.ui, fontSize:10.5, color:'var(--fg-2)',
+              lineHeight:1.45 }}>{s.desc}</div>
+          </div>
+          <Caption color="var(--fg-3)" size={8.5}>{s.visual}</Caption>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+window.S2_MistWire = S2_MistWire;
+window.S2_FourQuestions = S2_FourQuestions;
+window.S2_LatencyLadder = S2_LatencyLadder;

--- a/companion-ui/design_handoff/2026-05-08-cognitive-temporal/temporal-s3.jsx
+++ b/companion-ui/design_handoff/2026-05-08-cognitive-temporal/temporal-s3.jsx
@@ -1,0 +1,215 @@
+/* ============================================================
+   Section 3 — Temporal resurfacing
+   Decay, salience, marginalia evolution
+   ============================================================ */
+
+/* ── 3A · The marginalia field ─────────────────────────── */
+function S3_MarginaliaWire() {
+  // simulated marks down the right edge of a document
+  const marks = [
+    { y:60,  size:7,  op:0.95, c:'var(--vault)',  label:'related note · 4d',          state:'fresh' },
+    { y:108, size:5,  op:0.7,  c:'var(--vault)',  label:'echo · seen 12d ago',        state:'warm' },
+    { y:162, size:9,  op:1,    c:'var(--amber)',  label:'tension — sources disagree', state:'pressured' },
+    { y:228, size:4,  op:0.45, c:'var(--vault)',  label:'dormant evergreen · 41d',    state:'cold' },
+    { y:284, size:6,  op:0.85, c:'var(--cyan)',   label:'returning question · 3d',    state:'recurrent' },
+    { y:340, size:3,  op:0.3,  c:'var(--vault)',  label:'faint · 70d',                state:'fading' },
+    { y:402, size:8,  op:0.95, c:'var(--accent)', label:'open loop · yours · 6d',     state:'self-trace' },
+    { y:472, size:4,  op:0.5,  c:'var(--vault)',  label:'adjacent vault edit · 9d',   state:'warm' },
+  ];
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      display:'flex', flexDirection:'column', position:'relative', overflow:'hidden' }}>
+      <div style={{ padding:'10px 18px', borderBottom:'1px solid var(--border)',
+        display:'flex', alignItems:'center', gap:10 }}>
+        <Caption color="var(--fg-3)">Writing/memory-essay.md</Caption>
+        <Caption color="var(--vault)">·  marginalia field active</Caption>
+        <div style={{ marginLeft:'auto' }}>
+          <Pill tone="var(--vault)">8 latent marks</Pill>
+        </div>
+      </div>
+
+      <div style={{ flex:1, display:'flex', position:'relative' }}>
+        {/* doc body */}
+        <div style={{ flex:1, padding:'24px 40px 24px 60px',
+          backgroundImage:
+            'linear-gradient(rgba(0,212,232,0.012) 1px, transparent 1px),' +
+            'linear-gradient(90deg, rgba(0,212,232,0.012) 1px, transparent 1px)',
+          backgroundSize:'32px 32px', opacity:0.85 }}>
+          <div style={{ ...TT.disp, fontSize:22, color:'var(--fg-1)',
+            marginBottom:14, letterSpacing:'-0.01em' }}>
+            On the architecture of memory
+          </div>
+          <Lines rows={3} last="62%" h={6.5} gap={9} />
+          <div style={{ height:14 }} />
+          <Lines rows={2} last="84%" h={6.5} gap={9} />
+          <div style={{ height:14 }} />
+          <div style={{ ...TT.disp, fontSize:15, color:'var(--fg-2)',
+            marginBottom:9 }}>The retention envelope</div>
+          <Lines rows={4} last="48%" h={6.5} gap={9} />
+          <div style={{ height:14 }} />
+          <Lines rows={3} last="70%" h={6.5} gap={9} />
+          <div style={{ height:14 }} />
+          <div style={{ ...TT.disp, fontSize:15, color:'var(--fg-2)',
+            marginBottom:9 }}>Decay, not deletion</div>
+          <Lines rows={3} last="58%" h={6.5} gap={9} />
+        </div>
+
+        {/* the right-edge marginalia rail */}
+        <div style={{ width:46, position:'relative',
+          borderLeft:'1px solid var(--border)' }}>
+          {marks.map((m, i) => (
+            <div key={i} style={{ position:'absolute',
+              top:m.y, left:'50%', transform:'translateX(-50%)',
+              display:'flex', alignItems:'center' }}>
+              <MargDot size={m.size} opacity={m.op} color={m.c}
+                glow={m.state !== 'fading'} />
+            </div>
+          ))}
+          {/* hover preview anchored to one dot */}
+          <div style={{ position:'absolute', top:152, right:50,
+            width:200, padding:'8px 10px',
+            background:'rgba(7,11,18,0.94)',
+            backdropFilter:'blur(6px)',
+            border:'1px solid var(--amber-dim)',
+            borderLeft:'2px solid var(--amber)',
+            boxShadow:'0 4px 16px rgba(0,0,0,0.5)' }}>
+            <Caption color="var(--amber)">tension · 2 sources disagree</Caption>
+            <div style={{ ...TT.ui, fontSize:11, color:'var(--fg-1)',
+              lineHeight:1.45, marginTop:6 }}>
+              "Memory consolidation timing" — Squire (1994) vs.
+              Frankland (2005). Unreconciled in your draft.
+            </div>
+            <div style={{ display:'flex', gap:6, marginTop:8 }}>
+              <Pill tone="var(--amber)" filled>open</Pill>
+              <Pill tone="var(--fg-3)">14d unresolved</Pill>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* annotations */}
+      <div style={{ position:'absolute', top:60, right:60,
+        pointerEvents:'none', textAlign:'right' }}>
+        <HandNote color="var(--vault)" size={11}>size = salience<br/>opacity = recency</HandNote>
+      </div>
+      <div style={{ position:'absolute', bottom:80, right:60,
+        pointerEvents:'none', textAlign:'right' }}>
+        <HandNote color="var(--vault)" size={11}>no tooltip until hover<br/>no badges, no count, no chime</HandNote>
+      </div>
+      <div style={{ position:'absolute', top:148, left:14,
+        pointerEvents:'none' }}>
+        <HandNote color="var(--amber)" size={11}>tension marks pulse<br/>once per session</HandNote>
+      </div>
+    </div>
+  );
+}
+
+/* ── 3B · Decay envelope ──────────────────────────────── */
+function S3_DecayEnvelope() {
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      padding:'20px 24px', display:'flex', flexDirection:'column', gap:10 }}>
+      <ABHead tone="var(--vault)" sub="how marks fade · how tension persists">
+        Decay envelope
+      </ABHead>
+      <div style={{ ...TT.ui, fontSize:11, color:'var(--fg-2)',
+        lineHeight:1.55 }}>
+        Marginalia opacity follows a curve, not a clock. Recency, salience,
+        and tension each pull on the curve differently.
+      </div>
+
+      {/* the three decay curves stacked */}
+      <div style={{ marginTop:8 }}>
+        {[
+          { name:'Recency only', tone:'var(--vault)', highlight:0.78,
+            note:'pure exponential. 50% at 7d, 10% at 30d.' },
+          { name:'Salience-weighted', tone:'var(--accent)', highlight:0.55,
+            note:'half-life doubles per uniqueness tier. evergreens persist.' },
+          { name:'Tension-bound', tone:'var(--amber)', highlight:0.32,
+            note:'no decay until resolved. unresolved synthesis stays bright.' },
+        ].map((row, i) => (
+          <div key={row.name} style={{ display:'grid',
+            gridTemplateColumns:'140px 1fr 1fr', gap:14, padding:'10px 0',
+            alignItems:'center', borderTop:'1px solid var(--border)' }}>
+            <div>
+              <div style={{ ...TT.ui, fontSize:11.5, color:'var(--fg-1)',
+                fontWeight:500 }}>{row.name}</div>
+              <div style={{ ...TT.mono, fontSize:9, color:row.tone,
+                letterSpacing:'0.06em', marginTop:2 }}>curve {i+1}</div>
+            </div>
+            <DecayArc w={140} h={36} color={row.tone}
+              highlight={row.highlight} />
+            <div style={{ ...TT.ui, fontSize:10.5, color:'var(--fg-2)',
+              lineHeight:1.45 }}>{row.note}</div>
+          </div>
+        ))}
+      </div>
+
+      <div style={{ marginTop:6, padding:'8px 10px',
+        background:'rgba(57,232,125,0.04)', border:'1px solid rgba(57,232,125,0.2)',
+        borderLeft:'2px solid var(--vault)' }}>
+        <Caption color="var(--vault)">composition rule</Caption>
+        <div style={{ ...TT.ui, fontSize:11, color:'var(--fg-1)',
+          lineHeight:1.5, marginTop:4 }}>
+          A mark's final opacity is <code style={{ ...TT.mono,
+            background:'transparent', border:'none', padding:0,
+            color:'var(--fg-2)' }}>min(recency, salience) · tension_bonus</code>.
+          Tension never lets a mark go fully dark while a loop is open.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── 3C · Resurfacing triggers ─────────────────────────── */
+function S3_Triggers() {
+  const rows = [
+    { trig:'Contextual proximity',
+      when:'User reads a passage; vault has neighbors within k=3 hops.',
+      surf:'Faint vault dot at line. Dim until eye lingers >2s.' },
+    { trig:'Temporal echo',
+      when:'Today\'s date matches a prior session anniversary, or recurring date frame.',
+      surf:'Cyan recurrent mark. Surfaces once per matching day.' },
+    { trig:'Unresolved tension',
+      when:'Open loop or conflicting source persists across sessions.',
+      surf:'Amber tension halo. Pulses once per session entry.' },
+    { trig:'Synthesis drift',
+      when:'Vault edit elsewhere contradicts a claim in current draft.',
+      surf:'Amber margin mark + provenance fleck on affected paragraph.' },
+    { trig:'Self-trace',
+      when:'Returning to a passage the user last edited mid-thought.',
+      surf:'Gold momentum trail under the paragraph for 1 session.' },
+    { trig:'Decayed adjacent',
+      when:'Old exploration branch touches current cursor topic.',
+      surf:'Faint cyan dot in marginalia. Click reanimates branch.' },
+  ];
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      padding:'20px 24px', display:'flex', flexDirection:'column', gap:6 }}>
+      <ABHead tone="var(--vault)" sub="non-disruptive surfacing only">
+        Resurfacing triggers
+      </ABHead>
+      <div style={{ ...TT.ui, fontSize:11, color:'var(--fg-2)',
+        lineHeight:1.55, marginBottom:4 }}>
+        Six conditions can make a latent item surface. None of them produce
+        a notification. All resolve to a visual weight on something already
+        on screen.
+      </div>
+      {rows.map((r, i) => (
+        <div key={r.trig} style={{ display:'grid',
+          gridTemplateColumns:'130px 1fr 1fr', gap:12, padding:'8px 0',
+          borderTop:'1px solid var(--border)' }}>
+          <Caption color="var(--vault)">{r.trig}</Caption>
+          <div style={{ ...TT.ui, fontSize:10.5, color:'var(--fg-2)',
+            lineHeight:1.45 }}>{r.when}</div>
+          <div style={{ ...TT.ui, fontSize:10.5, color:'var(--fg-1)',
+            lineHeight:1.45 }}>{r.surf}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+window.S3_MarginaliaWire = S3_MarginaliaWire;
+window.S3_DecayEnvelope = S3_DecayEnvelope;
+window.S3_Triggers = S3_Triggers;

--- a/companion-ui/design_handoff/2026-05-08-cognitive-temporal/temporal-s4.jsx
+++ b/companion-ui/design_handoff/2026-05-08-cognitive-temporal/temporal-s4.jsx
@@ -1,0 +1,325 @@
+/* ============================================================
+   Section 4 — Cognitive tension
+   Visualizing unresolvedness, conflict, dormant pressure
+   ============================================================ */
+
+/* ── 4A · Tension topology ──────────────────────────────── */
+function S4_Topology() {
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      padding:'20px 24px', display:'flex', flexDirection:'column', gap:8 }}>
+      <ABHead tone="var(--amber)" sub="four shapes of unresolvedness">
+        Tension topology
+      </ABHead>
+      <div style={{ ...TT.ui, fontSize:11, color:'var(--fg-2)',
+        lineHeight:1.55, marginBottom:4 }}>
+        Tension is not a number. It has a shape. The shape determines the
+        visual.
+      </div>
+
+      <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:14,
+        marginTop:6 }}>
+        {/* loop */}
+        <div style={{ padding:'12px 14px',
+          background:'rgba(212,168,67,0.04)',
+          border:'1px solid rgba(212,168,67,0.25)',
+          borderLeft:'2px solid var(--accent)' }}>
+          <div style={{ display:'flex', alignItems:'center', gap:8 }}>
+            <TensionHalo size={32} level={0.55} color="var(--accent)" />
+            <div>
+              <div style={{ ...TT.ui, fontSize:12, color:'var(--fg-1)',
+                fontWeight:500 }}>Open loop</div>
+              <Caption color="var(--accent)">single thread · unfinished</Caption>
+            </div>
+          </div>
+          <div style={{ ...TT.ui, fontSize:10.5, color:'var(--fg-2)',
+            lineHeight:1.5, marginTop:8 }}>
+            One question waits for an answer. Linear shape: trajectory dotted
+            line, gold dot at the open end.
+          </div>
+        </div>
+        {/* conflict */}
+        <div style={{ padding:'12px 14px',
+          background:'rgba(240,144,48,0.04)',
+          border:'1px solid rgba(240,144,48,0.25)',
+          borderLeft:'2px solid var(--amber)' }}>
+          <div style={{ display:'flex', alignItems:'center', gap:8 }}>
+            <svg width="32" height="32" viewBox="0 0 32 32">
+              <line x1="6" y1="10" x2="26" y2="22" stroke="var(--amber)"
+                strokeWidth="1.5" />
+              <line x1="6" y1="22" x2="26" y2="10" stroke="var(--amber)"
+                strokeWidth="1.5" />
+              <circle cx="6" cy="10" r="2" fill="var(--amber)" />
+              <circle cx="26" cy="22" r="2" fill="var(--amber)" />
+              <circle cx="6" cy="22" r="2" fill="var(--amber)" />
+              <circle cx="26" cy="10" r="2" fill="var(--amber)" />
+            </svg>
+            <div>
+              <div style={{ ...TT.ui, fontSize:12, color:'var(--fg-1)',
+                fontWeight:500 }}>Conflict</div>
+              <Caption color="var(--amber)">two interpretations · refused merge</Caption>
+            </div>
+          </div>
+          <div style={{ ...TT.ui, fontSize:10.5, color:'var(--fg-2)',
+            lineHeight:1.5, marginTop:8 }}>
+            Sources or claims disagree. X shape. Amber break in the draft, both
+            sides preserved with provenance.
+          </div>
+        </div>
+        {/* incomplete synthesis */}
+        <div style={{ padding:'12px 14px',
+          background:'rgba(57,232,125,0.04)',
+          border:'1px solid rgba(57,232,125,0.25)',
+          borderLeft:'2px solid var(--vault)' }}>
+          <div style={{ display:'flex', alignItems:'center', gap:8 }}>
+            <svg width="32" height="32" viewBox="0 0 32 32">
+              <circle cx="8" cy="10" r="2" fill="var(--vault)" />
+              <circle cx="20" cy="8" r="2" fill="var(--vault)" />
+              <circle cx="14" cy="22" r="2" fill="var(--vault)" />
+              <line x1="8" y1="10" x2="14" y2="22" stroke="var(--vault)"
+                strokeWidth="1" opacity="0.6" />
+              <line x1="20" y1="8" x2="14" y2="22" stroke="var(--vault)"
+                strokeWidth="1" opacity="0.6" />
+              <line x1="8" y1="10" x2="20" y2="8" stroke="var(--vault)"
+                strokeWidth="1" opacity="0.3" strokeDasharray="2 2" />
+            </svg>
+            <div>
+              <div style={{ ...TT.ui, fontSize:12, color:'var(--fg-1)',
+                fontWeight:500 }}>Incomplete synthesis</div>
+              <Caption color="var(--vault)">three nodes · one unbridged</Caption>
+            </div>
+          </div>
+          <div style={{ ...TT.ui, fontSize:10.5, color:'var(--fg-2)',
+            lineHeight:1.5, marginTop:8 }}>
+            Sources gathered, draft started, one connection still missing.
+            Triangle with a dashed edge. Provenance flecks show progress.
+          </div>
+        </div>
+        {/* dormant pressure */}
+        <div style={{ padding:'12px 14px',
+          background:'rgba(74,158,255,0.04)',
+          border:'1px solid rgba(74,158,255,0.25)',
+          borderLeft:'2px solid var(--agent)' }}>
+          <div style={{ display:'flex', alignItems:'center', gap:8 }}>
+            <svg width="32" height="32" viewBox="0 0 32 32">
+              <circle cx="16" cy="16" r="3" fill="var(--agent)" />
+              <circle cx="16" cy="16" r="7" fill="none" stroke="var(--agent)"
+                strokeWidth="0.8" opacity="0.4" />
+              <circle cx="16" cy="16" r="11" fill="none" stroke="var(--agent)"
+                strokeWidth="0.5" opacity="0.25" strokeDasharray="2 3" />
+              <circle cx="16" cy="16" r="14" fill="none" stroke="var(--agent)"
+                strokeWidth="0.4" opacity="0.15" strokeDasharray="1 4" />
+            </svg>
+            <div>
+              <div style={{ ...TT.ui, fontSize:12, color:'var(--fg-1)',
+                fontWeight:500 }}>Dormant pressure</div>
+              <Caption color="var(--agent)">conceptual mass · unattended</Caption>
+            </div>
+          </div>
+          <div style={{ ...TT.ui, fontSize:10.5, color:'var(--fg-2)',
+            lineHeight:1.5, marginTop:8 }}>
+            Cluster of related notes building up around an unaddressed theme.
+            Nested rings, faint. Never alerts; surfaces only via marginalia.
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── 4B · Tension as inline visual on the document ─────── */
+function S4_InlineWire() {
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      display:'flex', flexDirection:'column', position:'relative', overflow:'hidden' }}>
+      <div style={{ padding:'10px 18px', borderBottom:'1px solid var(--border)',
+        display:'flex', alignItems:'center', gap:10 }}>
+        <Caption color="var(--fg-3)">Writing/memory-essay.md</Caption>
+        <Caption color="var(--amber)">·  3 unresolved · 1 conflict</Caption>
+      </div>
+
+      <div style={{ flex:1, padding:'22px 36px', position:'relative',
+        backgroundImage:
+          'linear-gradient(rgba(0,212,232,0.012) 1px, transparent 1px),' +
+          'linear-gradient(90deg, rgba(0,212,232,0.012) 1px, transparent 1px)',
+        backgroundSize:'32px 32px' }}>
+
+        <div style={{ ...TT.disp, fontSize:18, color:'var(--fg-1)',
+          marginBottom:14 }}>The retention envelope</div>
+
+        {/* paragraph w/ open loop halo around terminal "?" */}
+        <div style={{ ...TT.ui, fontSize:13.5, color:'var(--fg-1)',
+          lineHeight:1.65, marginBottom:14, position:'relative' }}>
+          Memory does not store; it reconstructs. The interesting question is
+          not what persists, but what reliably reassembles
+          <span style={{ position:'relative', display:'inline-block',
+            width:14, height:14, marginLeft:1, verticalAlign:'-3px' }}>
+            <span style={{ position:'absolute', inset:-9 }}>
+              <TensionHalo size={32} level={0.7} color="var(--accent)" />
+            </span>
+            <span style={{ position:'absolute', inset:0,
+              ...TT.disp, color:'var(--accent)', fontStyle:'italic',
+              fontSize:14 }}>?</span>
+          </span>
+        </div>
+
+        {/* conflict block — amber break, both sides */}
+        <div style={{ ...TT.ui, fontSize:13, color:'var(--fg-1)',
+          lineHeight:1.65, marginBottom:14 }}>
+          Standard model holds consolidation completes within hours.
+        </div>
+        <div style={{ display:'grid', gridTemplateColumns:'1fr 28px 1fr',
+          gap:0, marginBottom:14, alignItems:'stretch' }}>
+          <div style={{ padding:'10px 12px',
+            background:'rgba(240,144,48,0.04)',
+            borderLeft:'2px solid var(--amber)',
+            borderRight:'1px dashed rgba(240,144,48,0.4)' }}>
+            <Caption color="var(--amber)">Squire 1994</Caption>
+            <div style={{ ...TT.ui, fontSize:11.5, color:'var(--fg-1)',
+              lineHeight:1.5, marginTop:4 }}>
+              Hippocampal binding decays as cortical traces solidify.
+              Hours, not years.
+            </div>
+          </div>
+          <div style={{ display:'flex', alignItems:'center',
+            justifyContent:'center', position:'relative' }}>
+            <svg width="20" height="60" style={{ position:'absolute' }}>
+              <line x1="10" y1="6" x2="10" y2="54" stroke="var(--amber)"
+                strokeWidth="0.6" strokeDasharray="2 3" opacity="0.6" />
+              <circle cx="10" cy="30" r="6" fill="var(--bg-base)"
+                stroke="var(--amber)" strokeWidth="1" />
+              <text x="10" y="33" textAnchor="middle"
+                fill="var(--amber)" fontSize="9"
+                style={{ fontFamily:'var(--font-mono)' }}>×</text>
+            </svg>
+          </div>
+          <div style={{ padding:'10px 12px',
+            background:'rgba(240,144,48,0.04)',
+            borderRight:'2px solid var(--amber)' }}>
+            <Caption color="var(--amber)">Frankland 2005</Caption>
+            <div style={{ ...TT.ui, fontSize:11.5, color:'var(--fg-1)',
+              lineHeight:1.5, marginTop:4 }}>
+              Remote memories remain hippocampus-dependent decades on.
+              The timing is wrong.
+            </div>
+          </div>
+        </div>
+        <div style={{ ...TT.mono, fontSize:9, color:'var(--amber)',
+          letterSpacing:'0.08em', textTransform:'uppercase',
+          marginBottom:14, opacity:0.8 }}>
+          ↑ refused merge · 14d unresolved · click to reconcile
+        </div>
+
+        {/* incomplete synthesis stub */}
+        <div style={{ ...TT.ui, fontSize:13, color:'var(--fg-1)',
+          lineHeight:1.65, position:'relative' }}>
+          A workable synthesis would need to account for both —
+          <span style={{ background:'rgba(57,232,125,0.06)',
+            borderBottom:'1px dashed var(--vault)',
+            padding:'0 3px', borderRadius:1 }}>
+            possibly via dual-trace consolidation
+          </span>
+          — but the literature on this is still
+          <span style={{ ...TT.disp, color:'var(--vault)',
+            fontStyle:'italic' }}> incomplete</span>.
+          <span style={{ display:'inline-block', marginLeft:6,
+            verticalAlign:'middle' }}>
+            <Pulse size={6} color="var(--vault)" />
+          </span>
+        </div>
+      </div>
+
+      {/* annotations */}
+      <div style={{ position:'absolute', top:80, right:14,
+        pointerEvents:'none', textAlign:'right' }}>
+        <HandNote color="var(--accent)" size={11}>halo around the question<br/>marks an open loop</HandNote>
+      </div>
+      <div style={{ position:'absolute', top:240, right:14,
+        pointerEvents:'none', textAlign:'right' }}>
+        <HandNote color="var(--amber)" size={11}>amber break refuses to flatten<br/>the disagreement</HandNote>
+      </div>
+      <div style={{ position:'absolute', bottom:24, right:14,
+        pointerEvents:'none', textAlign:'right' }}>
+        <HandNote color="var(--vault)" size={11}>pulse = synthesis<br/>still active in background</HandNote>
+      </div>
+    </div>
+  );
+}
+
+/* ── 4C · Pressure dial — global tension at a glance ──── */
+function S4_PressureDial() {
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      padding:'20px 24px', display:'flex', flexDirection:'column', gap:10 }}>
+      <ABHead tone="var(--amber)" sub="never demanded · always queryable">
+        Cognitive pressure
+      </ABHead>
+      <div style={{ ...TT.ui, fontSize:11, color:'var(--fg-2)',
+        lineHeight:1.55 }}>
+        A small ambient indicator the user can <em>choose</em> to look at,
+        in the corner of the document. Never appears unsolicited.
+      </div>
+
+      {/* the dial */}
+      <div style={{ display:'flex', justifyContent:'center', marginTop:10 }}>
+        <div style={{ position:'relative', width:200, height:200 }}>
+          <svg width="200" height="200" viewBox="0 0 200 200">
+            {/* faint outer ring */}
+            <circle cx="100" cy="100" r="86" fill="none"
+              stroke="var(--border)" strokeWidth="0.6" />
+            {/* tension arcs — one per topology */}
+            {[
+              { color:'var(--accent)', from:0,    span:60, intensity:0.7,  label:'open loops · 3' },
+              { color:'var(--amber)',  from:90,   span:38, intensity:0.85, label:'conflicts · 1' },
+              { color:'var(--vault)',  from:160,  span:75, intensity:0.55, label:'incomplete · 4' },
+              { color:'var(--agent)',  from:255,  span:90, intensity:0.4,  label:'dormant · 7' },
+            ].map((a, i) => {
+              const r = 78;
+              const a1 = (a.from - 90) * Math.PI / 180;
+              const a2 = (a.from + a.span - 90) * Math.PI / 180;
+              const x1 = 100 + r * Math.cos(a1);
+              const y1 = 100 + r * Math.sin(a1);
+              const x2 = 100 + r * Math.cos(a2);
+              const y2 = 100 + r * Math.sin(a2);
+              const large = a.span > 180 ? 1 : 0;
+              return (
+                <path key={i}
+                  d={`M ${x1.toFixed(1)} ${y1.toFixed(1)} A ${r} ${r} 0 ${large} 1 ${x2.toFixed(1)} ${y2.toFixed(1)}`}
+                  fill="none" stroke={a.color}
+                  strokeWidth={3 + a.intensity*3} opacity={a.intensity}
+                  strokeLinecap="round" />
+              );
+            })}
+            {/* center pulse */}
+            <circle cx="100" cy="100" r="5" fill="var(--accent)" opacity="0.6" />
+            <circle cx="100" cy="100" r="2.5" fill="var(--accent)" />
+          </svg>
+        </div>
+      </div>
+
+      {/* legend */}
+      <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:8,
+        marginTop:6 }}>
+        {[
+          { c:'var(--accent)', l:'Open loops',     n:'3' },
+          { c:'var(--amber)',  l:'Conflicts',      n:'1' },
+          { c:'var(--vault)',  l:'Incomplete syn.', n:'4' },
+          { c:'var(--agent)',  l:'Dormant mass',   n:'7' },
+        ].map(r => (
+          <div key={r.l} style={{ display:'flex', alignItems:'center', gap:8,
+            padding:'5px 8px', background:'var(--bg-raised)',
+            borderLeft:`2px solid ${r.c}` }}>
+            <div style={{ width:5, height:5, borderRadius:'50%', background:r.c }} />
+            <span style={{ ...TT.ui, fontSize:11, color:'var(--fg-1)' }}>{r.l}</span>
+            <span style={{ marginLeft:'auto', ...TT.mono, fontSize:11,
+              color:r.c }}>{r.n}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+window.S4_Topology = S4_Topology;
+window.S4_InlineWire = S4_InlineWire;
+window.S4_PressureDial = S4_PressureDial;

--- a/companion-ui/design_handoff/2026-05-08-cognitive-temporal/temporal-s5.jsx
+++ b/companion-ui/design_handoff/2026-05-08-cognitive-temporal/temporal-s5.jsx
@@ -1,0 +1,285 @@
+/* ============================================================
+   Section 5 — Temporal provenance
+   How understanding evolved · what changed · when
+   ============================================================ */
+
+/* ── 5A · The genealogy strip ──────────────────────────── */
+function S5_GenealogyWire() {
+  // a single paragraph's evolution over time
+  const stages = [
+    { at:'09 Mar', tone:'var(--fg-3)', state:'seed',
+      text:'Memory does not persist; it reassembles.',
+      meta:'first capture · Hugin · suggested phrasing' },
+    { at:'12 Mar', tone:'var(--cyan)', state:'expanded',
+      text:'Memory does not store; it reconstructs from cue and context.',
+      meta:'user revision · added "from cue and context"' },
+    { at:'24 Mar', tone:'var(--amber)', state:'contested',
+      text:'Memory does not store; it reconstructs — though the literature disagrees on timing.',
+      meta:'conflict introduced · Frankland 2005' },
+    { at:'02 Apr', tone:'var(--vault)', state:'synthesized',
+      text:'Memory does not store; it reconstructs. The interesting question is what reliably reassembles.',
+      meta:'user reframing · resolved by elision' },
+    { at:'now',    tone:'var(--accent)', state:'active',
+      text:'Memory does not store; it reconstructs. The interesting question is not what persists, but what reliably reassembles?',
+      meta:'open loop · question form · 2h idle' },
+  ];
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      display:'flex', flexDirection:'column', position:'relative', overflow:'hidden' }}>
+      <div style={{ padding:'10px 18px', borderBottom:'1px solid var(--border)',
+        display:'flex', alignItems:'center', gap:10 }}>
+        <Caption color="var(--fg-3)">Writing/memory-essay.md  ·  ¶ 4</Caption>
+        <Caption color="var(--accent)">·  genealogy</Caption>
+        <div style={{ marginLeft:'auto' }}>
+          <Pill tone="var(--accent)">5 revisions over 28 days</Pill>
+        </div>
+      </div>
+
+      <div style={{ flex:1, padding:'22px 28px', overflow:'auto' }}>
+        {/* time spine across the top */}
+        <div style={{ marginBottom:18 }}>
+          <Caption color="var(--fg-3)">temporal spine</Caption>
+          <div style={{ marginTop:6 }}>
+            <TimeSpine w={780} h={28} marks={[
+              { at:0.04, color:'var(--fg-3)' },
+              { at:0.22, color:'var(--cyan)' },
+              { at:0.5,  color:'var(--amber)', ring:true },
+              { at:0.74, color:'var(--vault)' },
+              { at:0.96, color:'var(--accent)', ring:true },
+            ]} />
+          </div>
+          <div style={{ display:'flex', justifyContent:'space-between',
+            marginTop:0, paddingRight:8 }}>
+            {stages.map((s,i) =>
+              <Caption key={i} color={s.tone}>{s.at}</Caption>)}
+          </div>
+        </div>
+
+        {/* stacked revisions */}
+        <div style={{ display:'flex', flexDirection:'column', gap:0 }}>
+          {stages.map((s, i) => (
+            <div key={i} style={{ display:'grid',
+              gridTemplateColumns:'72px 1fr 200px', gap:14,
+              alignItems:'flex-start', padding:'12px 0',
+              borderTop:'1px solid var(--border)' }}>
+              <div>
+                <div style={{ ...TT.mono, fontSize:9, color:s.tone,
+                  letterSpacing:'0.08em', textTransform:'uppercase' }}>
+                  {s.state}
+                </div>
+                <div style={{ ...TT.mono, fontSize:9, color:'var(--fg-3)',
+                  marginTop:2 }}>{s.at}</div>
+              </div>
+              <div style={{ paddingLeft:12, borderLeft:`2px solid ${s.tone}`,
+                opacity: i === stages.length-1 ? 1 : 0.7 }}>
+                <div style={{ ...TT.disp, fontSize:14, color:'var(--fg-1)',
+                  fontStyle:'italic', lineHeight:1.5 }}>"{s.text}"</div>
+              </div>
+              <div style={{ ...TT.ui, fontSize:10.5, color:'var(--fg-2)',
+                lineHeight:1.45 }}>{s.meta}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div style={{ position:'absolute', top:60, right:14,
+        pointerEvents:'none', textAlign:'right' }}>
+        <HandNote color="var(--accent)" size={11}>genealogy = paragraph<br/>not document</HandNote>
+      </div>
+      <div style={{ position:'absolute', bottom:24, right:14,
+        pointerEvents:'none', textAlign:'right' }}>
+        <HandNote color="var(--amber)" size={11}>note when conflict<br/>entered the trace</HandNote>
+      </div>
+    </div>
+  );
+}
+
+/* ── 5B · Uncertainty trace ────────────────────────────── */
+function S5_UncertaintyTrace() {
+  // tracks confidence over time for a claim
+  const w = 480, h = 110;
+  const points = [
+    [0.02, 0.30], [0.10, 0.45], [0.18, 0.55], [0.28, 0.40],
+    [0.36, 0.25], [0.46, 0.55], [0.58, 0.70], [0.68, 0.62],
+    [0.78, 0.78], [0.88, 0.72], [0.96, 0.85],
+  ];
+  const path = points.map(([x,y],i) =>
+    `${i===0?'M':'L'}${(x*(w-20)+10).toFixed(1)} ${(h - 12 - y*(h-30)).toFixed(1)}`
+  ).join(' ');
+  const events = [
+    { x:0.18, label:'Squire',     tone:'var(--cyan)' },
+    { x:0.36, label:'Frankland',  tone:'var(--amber)' },
+    { x:0.58, label:'reframing',  tone:'var(--vault)' },
+    { x:0.88, label:'now',        tone:'var(--accent)' },
+  ];
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      padding:'20px 24px', display:'flex', flexDirection:'column', gap:8 }}>
+      <ABHead tone="var(--cyan)" sub="confidence over time, claim-scoped">
+        Uncertainty trace
+      </ABHead>
+      <div style={{ ...TT.ui, fontSize:11, color:'var(--fg-2)',
+        lineHeight:1.55, marginBottom:6 }}>
+        Per-claim: how sure the user has been, when sources entered, when
+        rephrasings shifted the ground.
+      </div>
+
+      <div style={{ background:'var(--bg-raised)',
+        border:'1px solid var(--border)', padding:'12px 8px 6px',
+        borderRadius:2, marginTop:4 }}>
+        <svg width={w} height={h}>
+          {/* horizontal guides */}
+          {[0.25, 0.5, 0.75].map(y => (
+            <line key={y} x1="10" y1={h - 12 - y*(h-30)} x2={w-10}
+              y2={h - 12 - y*(h-30)} stroke="var(--border)"
+              strokeWidth="0.5" strokeDasharray="2 4" />
+          ))}
+          {/* baseline */}
+          <line x1="10" y1={h-12} x2={w-10} y2={h-12}
+            stroke="var(--border-strong)" strokeWidth="0.8" />
+          {/* curve */}
+          <path d={path} fill="none" stroke="var(--cyan)"
+            strokeWidth="1.4" opacity="0.85" strokeLinecap="round" />
+          {/* events */}
+          {events.map((e,i) => {
+            const x = e.x * (w-20) + 10;
+            const idx = Math.round(e.x * (points.length-1));
+            const y = h - 12 - points[idx][1] * (h - 30);
+            return (
+              <g key={i}>
+                <line x1={x} y1="6" x2={x} y2={h-12} stroke={e.tone}
+                  strokeWidth="0.5" strokeDasharray="2 3" opacity="0.5" />
+                <circle cx={x} cy={y} r="3" fill={e.tone} />
+                <circle cx={x} cy={y} r="6" fill="none" stroke={e.tone}
+                  strokeWidth="0.6" opacity="0.4" />
+              </g>
+            );
+          })}
+          {/* labels */}
+          <text x="14" y="14" fill="var(--fg-3)" fontSize="9"
+            style={{ fontFamily:'var(--font-mono)',
+              letterSpacing:'0.08em', textTransform:'uppercase' }}>certain</text>
+          <text x="14" y={h-2} fill="var(--fg-3)" fontSize="9"
+            style={{ fontFamily:'var(--font-mono)',
+              letterSpacing:'0.08em', textTransform:'uppercase' }}>uncertain</text>
+        </svg>
+        <div style={{ display:'flex', justifyContent:'space-between',
+          padding:'0 6px', marginTop:2 }}>
+          {events.map(e =>
+            <Caption key={e.label} color={e.tone}>{e.label}</Caption>)}
+        </div>
+      </div>
+
+      <div style={{ marginTop:8, padding:'8px 10px',
+        background:'var(--cyan-muted)', border:'1px solid var(--cyan-dim)',
+        borderLeft:'2px solid var(--cyan)' }}>
+        <Caption color="var(--cyan)">reading rule</Caption>
+        <div style={{ ...TT.ui, fontSize:11, color:'var(--fg-1)',
+          lineHeight:1.5, marginTop:4 }}>
+          Dips reveal where doubt entered. Lifts reveal where evidence
+          consolidated. The trace is a memory of <em>how you came to think this</em>,
+          not a chart of facts.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ── 5C · Diff lens — what changed since X ─────────────── */
+function S5_DiffLens() {
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      display:'flex', flexDirection:'column', position:'relative', overflow:'hidden' }}>
+      <div style={{ padding:'10px 18px', borderBottom:'1px solid var(--border)',
+        display:'flex', alignItems:'center', gap:10 }}>
+        <Caption color="var(--fg-3)">Writing/memory-essay.md</Caption>
+        <Caption color="var(--accent)">·  diff lens · since 3d ago</Caption>
+        <div style={{ marginLeft:'auto', display:'flex', gap:6 }}>
+          <Pill tone="var(--accent)">3d</Pill>
+          <Pill tone="var(--fg-3)">7d</Pill>
+          <Pill tone="var(--fg-3)">30d</Pill>
+          <Pill tone="var(--fg-3)">all</Pill>
+        </div>
+      </div>
+
+      <div style={{ flex:1, padding:'22px 36px', position:'relative' }}>
+
+        <div style={{ ...TT.disp, fontSize:18, color:'var(--fg-1)',
+          marginBottom:14 }}>The retention envelope</div>
+
+        {/* paragraph w/ inline diff highlights */}
+        <div style={{ ...TT.ui, fontSize:13.5, color:'var(--fg-1)',
+          lineHeight:1.7, marginBottom:14 }}>
+          Memory does not <span style={{
+            background:'rgba(255,61,61,0.08)',
+            textDecoration:'line-through',
+            textDecorationColor:'var(--destructive)',
+            color:'var(--fg-3)', padding:'0 2px' }}>persist</span>{' '}
+          <span style={{ background:'rgba(57,232,125,0.1)',
+            borderBottom:'1px solid var(--vault)',
+            padding:'0 2px' }}>store</span>; it reconstructs.{' '}
+          <span style={{ background:'rgba(57,232,125,0.08)',
+            borderBottom:'1px solid var(--vault)',
+            padding:'0 2px' }}>The interesting question is not what persists,
+            but what reliably reassembles?</span>
+        </div>
+
+        <div style={{ ...TT.ui, fontSize:13, color:'var(--fg-1)',
+          lineHeight:1.7, marginBottom:14, opacity:0.45 }}>
+          Standard model holds consolidation completes within hours.
+          Hippocampal binding decays as cortical traces solidify.
+        </div>
+
+        {/* changed elsewhere — pulled in for context */}
+        <div style={{ background:'rgba(74,158,255,0.04)',
+          border:'1px solid rgba(74,158,255,0.2)',
+          borderLeft:'2px solid var(--agent)',
+          padding:'10px 12px', marginBottom:14 }}>
+          <div style={{ display:'flex', alignItems:'center', gap:6,
+            marginBottom:6 }}>
+            <Caption color="var(--agent)">elsewhere in vault · 1d ago</Caption>
+          </div>
+          <div style={{ ...TT.ui, fontSize:11.5, color:'var(--fg-1)',
+            lineHeight:1.5 }}>
+            <span style={{ color:'var(--fg-2)' }}>Atomic notes/Reconstruction.md</span>
+            {' — '}you wrote: "Reconstruction implies cue-dependence; the cue
+            is the interesting object." This may relate to your open loop above.
+          </div>
+        </div>
+
+        {/* delta summary */}
+        <div style={{ display:'flex', gap:8, alignItems:'center',
+          padding:'8px 12px', background:'var(--bg-raised)',
+          border:'1px solid var(--border)', marginTop:6 }}>
+          <Caption color="var(--accent)">delta · 3d</Caption>
+          <span style={{ ...TT.ui, fontSize:11, color:'var(--fg-1)' }}>
+            +1 sentence
+          </span>
+          <span style={{ width:1, height:14, background:'var(--border-strong)' }} />
+          <span style={{ ...TT.ui, fontSize:11, color:'var(--vault)' }}>
+            "store" → "reconstruct"
+          </span>
+          <span style={{ width:1, height:14, background:'var(--border-strong)' }} />
+          <span style={{ ...TT.ui, fontSize:11, color:'var(--agent)' }}>
+            1 vault echo
+          </span>
+          <div style={{ marginLeft:'auto', ...TT.mono, fontSize:9,
+            color:'var(--fg-3)' }}>esc · close lens</div>
+        </div>
+      </div>
+
+      <div style={{ position:'absolute', top:80, right:14,
+        pointerEvents:'none', textAlign:'right' }}>
+        <HandNote color="var(--accent)" size={11}>diffs inline,<br/>not in a sidebar</HandNote>
+      </div>
+      <div style={{ position:'absolute', bottom:90, right:14,
+        pointerEvents:'none', textAlign:'right' }}>
+        <HandNote color="var(--agent)" size={11}>vault changes elsewhere<br/>that touch this trajectory</HandNote>
+      </div>
+    </div>
+  );
+}
+
+window.S5_GenealogyWire = S5_GenealogyWire;
+window.S5_UncertaintyTrace = S5_UncertaintyTrace;
+window.S5_DiffLens = S5_DiffLens;

--- a/companion-ui/design_handoff/2026-05-08-cognitive-temporal/temporal-s6.jsx
+++ b/companion-ui/design_handoff/2026-05-08-cognitive-temporal/temporal-s6.jsx
@@ -1,0 +1,224 @@
+/* ============================================================
+   Section 6 — Attention rules + semantic hierarchy update
+   The grammar that holds it all together
+   ============================================================ */
+
+/* ── 6A · Attention-preserving interaction rules ───────── */
+function S6_AttentionRules() {
+  const rules = [
+    ['no notification', 'No badge, chime, popup, or modal ever surfaces resurfaced material. Salience is visual weight, not interruption.'],
+    ['surface on dwell', 'Latent items reveal detail only when the eye lingers — hover ≥1.2s or cursor proximity. No click required to know what something is.'],
+    ['dim, never hide',  'Mist, decay, and overlays reduce contrast. Nothing in the trajectory layer ever hides document content.'],
+    ['anchor preservation', 'Mode and overlay changes never alter scroll, cursor, or selection. Re-entry lands you at the same caret.'],
+    ['reversibility',    'Every overlay closes with esc. No state survives that the user did not author or apply.'],
+    ['idempotent surfacing', 'Tension halos and resurfacing marks pulse at most once per session entry. They do not re-attract attention they already gave.'],
+    ['ambient over analytical', 'Default presentation is shape, color, weight. Numbers and timelines surface only when explicitly queried.'],
+    ['no since-zero', 'Diffs and deltas always frame "since last engagement" or "since X". Never since the document\'s creation.'],
+    ['proposal duality', 'Anything shown in the chat appears identically in the document with the same actions. Nothing exists chat-only.'],
+    ['agent voice = one of many', 'Hugin\'s contributions are visually distinct (agent blue) but never structurally privileged over user trace.'],
+  ];
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      padding:'20px 24px', display:'flex', flexDirection:'column' }}>
+      <ABHead tone="var(--accent)" sub="invariants · all temporal patterns">
+        Attention rules
+      </ABHead>
+      <div style={{ ...TT.ui, fontSize:11, color:'var(--fg-2)',
+        lineHeight:1.55, marginBottom:8 }}>
+        Ten invariants that preserve low attentional load across every
+        temporal pattern in this document.
+      </div>
+      <div style={{ flex:1, overflow:'auto' }}>
+        {rules.map(([k,v], i) => (
+          <div key={k} style={{ padding:'8px 0',
+            borderTop:'1px solid var(--border)' }}>
+            <Caption color="var(--accent)">{k}</Caption>
+            <div style={{ ...TT.ui, fontSize:11, color:'var(--fg-1)',
+              lineHeight:1.5, marginTop:3 }}>{v}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ── 6B · Semantic overlay hierarchy update ────────────── */
+function S6_OverlayHierarchy() {
+  const layers = [
+    { z:0, name:'Document surface',
+      what:'Markdown body. The cognitive anchor. Never altered by overlays.',
+      tone:'var(--fg-1)' },
+    { z:1, name:'Trajectory layer',
+      what:'Cursor pulse, momentum trail, edit pulses. Active state only.',
+      tone:'var(--cyan)' },
+    { z:2, name:'Marginalia field',
+      what:'Right-edge dots: salience-sized, recency-faded. Resurfacing ambient.',
+      tone:'var(--vault)' },
+    { z:3, name:'Tension layer',
+      what:'Halos, amber breaks, dormant pressure rings. Inline only.',
+      tone:'var(--amber)' },
+    { z:4, name:'Provenance flecks',
+      what:'Source links per paragraph. Hover-only detail.',
+      tone:'var(--vault)' },
+    { z:5, name:'Re-entry mist',
+      what:'Session-start gradient + four-question card. Self-dismisses.',
+      tone:'var(--accent)' },
+    { z:6, name:'Diff lens / genealogy',
+      what:'On demand. Inline highlights or stacked revisions. esc closes.',
+      tone:'var(--accent)' },
+    { z:7, name:'Conversation rail',
+      what:'Hugin thread. Anchored to passages. Collapsible to 28px.',
+      tone:'var(--agent)' },
+    { z:8, name:'Governance dock',
+      what:'Bottom strip during review. Walks staged proposals.',
+      tone:'var(--amber)' },
+  ];
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      padding:'20px 24px', display:'flex', flexDirection:'column', gap:8 }}>
+      <ABHead tone="var(--cyan)" sub="z-order · what may overlap what">
+        Semantic overlay hierarchy
+      </ABHead>
+      <div style={{ ...TT.ui, fontSize:11, color:'var(--fg-2)',
+        lineHeight:1.55, marginBottom:4 }}>
+        The full stack with temporal layers added. Layers above can dim
+        layers below, never replace them.
+      </div>
+      <div style={{ flex:1, overflow:'auto' }}>
+        {layers.map((l, i) => (
+          <div key={l.name} style={{ display:'grid',
+            gridTemplateColumns:'40px 170px 1fr', gap:10,
+            alignItems:'flex-start', padding:'8px 0',
+            borderTop:'1px solid var(--border)' }}>
+            <Caption color={l.tone} size={9.5}>z{l.z}</Caption>
+            <div>
+              <div style={{ ...TT.ui, fontSize:11.5, color:'var(--fg-1)',
+                fontWeight:500 }}>{l.name}</div>
+              <div style={{ width:24, height:2, background:l.tone,
+                marginTop:3, opacity:0.5 }} />
+            </div>
+            <div style={{ ...TT.ui, fontSize:10.5, color:'var(--fg-2)',
+              lineHeight:1.45 }}>{l.what}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ── 6C · Composition flow — interrupt → resume → resolve ─ */
+function S6_CompositionFlow() {
+  const steps = [
+    { t:'T0',     label:'active editing',
+      tone:'var(--cyan)',
+      detail:'cursor present · trajectory live · open loop forming' },
+    { t:'T0+5m',  label:'user steps away',
+      tone:'var(--fg-3)',
+      detail:'snapshot written · cursor + selection + open loops captured' },
+    { t:'+15m',   label:'thread fade',
+      tone:'var(--fg-3)',
+      detail:'conversation pane dims slightly · no card yet' },
+    { t:'+3d',    label:'return',
+      tone:'var(--accent)',
+      detail:'mist appears · 4 questions answered · esc clears' },
+    { t:'+3d',    label:'resume here',
+      tone:'var(--cyan)',
+      detail:'cursor jumps to last caret · momentum trail visible' },
+    { t:'+3d 5m', label:'tension resolves',
+      tone:'var(--vault)',
+      detail:'open loop closes · halo dissolves · genealogy stamps it' },
+    { t:'+3d 7m', label:'paragraph stable',
+      tone:'var(--vault)',
+      detail:'staged → applied · receipt logged · marginalia recomputes' },
+  ];
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      padding:'20px 24px', display:'flex', flexDirection:'column', gap:10 }}>
+      <ABHead tone="var(--accent)" sub="one trace · seven moments">
+        End-to-end flow
+      </ABHead>
+      <div style={{ ...TT.ui, fontSize:11, color:'var(--fg-2)',
+        lineHeight:1.55, marginBottom:4 }}>
+        The full life of one open loop, from interruption to resolution. Each
+        step uses only the temporal patterns defined above.
+      </div>
+      <div style={{ flex:1, position:'relative', paddingLeft:24 }}>
+        {/* spine */}
+        <div style={{ position:'absolute', left:7, top:6, bottom:6,
+          width:1, background:'var(--border-strong)' }} />
+        {steps.map((s, i) => (
+          <div key={i} style={{ position:'relative', padding:'8px 0',
+            display:'grid', gridTemplateColumns:'70px 1fr', gap:12 }}>
+            <div style={{ position:'absolute', left:-21, top:11,
+              width:11, height:11, borderRadius:'50%',
+              background:s.tone, border:`2px solid var(--bg-base)`,
+              boxShadow:`0 0 6px ${s.tone}` }} />
+            <Caption color={s.tone}>{s.t}</Caption>
+            <div>
+              <div style={{ ...TT.ui, fontSize:12, color:'var(--fg-1)',
+                fontWeight:500 }}>{s.label}</div>
+              <div style={{ ...TT.ui, fontSize:10.5, color:'var(--fg-2)',
+                lineHeight:1.45, marginTop:2 }}>{s.detail}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ── 6D · Premise card ─────────────────────────────────── */
+function S0_Premise() {
+  return (
+    <div style={{ width:'100%', height:'100%', background:'var(--bg-base)',
+      padding:'22px 24px', display:'flex', flexDirection:'column', gap:10 }}>
+      <div style={{ ...TT.disp, fontSize:24, color:'var(--fg-1)',
+        letterSpacing:'-0.02em', lineHeight:1.15 }}>
+        Continuity of thought, across time.
+      </div>
+      <Caption color="var(--accent)">temporal cognition · interruption recovery</Caption>
+      <div style={{ height:1, background:'var(--border)', margin:'6px 0' }} />
+      <div style={{ ...TT.ui, fontSize:12, color:'var(--fg-1)',
+        lineHeight:1.6 }}>
+        The companion remembers <em>how you were thinking</em>, not just what
+        you wrote. When you return, the document is the anchor — but the
+        trajectory, the open loops, the unresolved tension, and the genealogy
+        of every paragraph are quietly within reach.
+      </div>
+      <div style={{ ...TT.ui, fontSize:11, color:'var(--fg-2)',
+        lineHeight:1.55 }}>
+        Five concerns, one grammar:
+      </div>
+      <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:5,
+        marginTop:2 }}>
+        {[
+          { c:'var(--accent)', n:'Interrupted trajectories' },
+          { c:'var(--cyan)',   n:'Re-entry ergonomics' },
+          { c:'var(--vault)',  n:'Temporal resurfacing' },
+          { c:'var(--amber)',  n:'Cognitive tension' },
+          { c:'var(--accent)', n:'Temporal provenance' },
+          { c:'var(--cyan)',   n:'Attention rules' },
+        ].map(m => (
+          <div key={m.n} style={{ display:'flex', alignItems:'center',
+            gap:6, padding:'4px 8px', background:'var(--bg-raised)',
+            borderLeft:`2px solid ${m.c}`, borderRadius:1 }}>
+            <div style={{ width:5, height:5, borderRadius:'50%',
+              background:m.c, boxShadow:`0 0 4px ${m.c}` }} />
+            <span style={{ ...TT.ui, fontSize:11, color:'var(--fg-1)' }}>{m.n}</span>
+          </div>
+        ))}
+      </div>
+      <div style={{ flex:1 }} />
+      <div style={{ ...TT.mono, fontSize:9, color:'var(--fg-3)',
+        letterSpacing:'0.08em', textTransform:'uppercase' }}>
+        the goal is not task management.<br/>
+        the goal is preserving continuity of thought.
+      </div>
+    </div>
+  );
+}
+
+window.S6_AttentionRules = S6_AttentionRules;
+window.S6_OverlayHierarchy = S6_OverlayHierarchy;
+window.S6_CompositionFlow = S6_CompositionFlow;
+window.S0_Premise = S0_Premise;

--- a/companion-ui/design_handoff/README.md
+++ b/companion-ui/design_handoff/README.md
@@ -2,7 +2,8 @@
 
 Preserved external design artifacts and handoff packages.
 
-Current package:
+Current packages:
 - `2026-05-03-converse/` — converse surface wireframes/spec assets.
+- `2026-05-08-cognitive-temporal/` — cognitive modes, temporal cognition, and re-entry mist variant exploration files.
 
 These artifacts are reference/handoff inputs, not production code.

--- a/companion-ui/docs/ATTENTIONAL_PHYSICS.md
+++ b/companion-ui/docs/ATTENTIONAL_PHYSICS.md
@@ -1,13 +1,41 @@
-# Attentional Physics
+---
+name: Attentional Physics
+description: "Interaction-layer rules for attentional weight, the overlay grammar, and the eight interaction invariants that hold across all five cognitive modes. Sourced from the 2026-05-08 Claude Design exploration."
+type: design-reference
+authority: Design vocabulary for attentional weight and interaction invariants; not an implementation spec
+related_docs:
+  - companion-ui/docs/EXPERIENTIAL_PATTERNS.md
+  - companion-ui/docs/CONTINUITY_AND_DECAY.md
+  - companion-ui/docs/TEMPORAL_OVERLAYS.md
+  - companion-ui/docs/RESURFACING_HEURISTICS.md
+  - companion-ui/docs/ATTENTION_MODEL.md
+  - companion-ui/docs/SALIENCE_AND_TENSION.md
+  - companion-ui/design_handoff/2026-05-08-cognitive-temporal/Cognitive Modes.html
+  - docs/CONCEPTS/SALIENCE_AND_ATTENTIONAL_RELEVANCE_CONTRACT.md
+---
+
+State: Active design vocabulary reference. Sourced from the 2026-05-08 Claude Design exploration (Cognitive Modes.html, interaction invariants section). Does not prescribe layout, components, animation values, or frontend architecture.
+
+# Attentional Physics — Companion UI
+
+This document names the rules governing how elements carry attentional weight and how the overlay grammar works across the five cognitive modes. These are interaction-quality constraints, not layout specifications.
+
+The term "physics" names the felt consistency that makes a surface predictable at low attention — the user develops a tacit model of how things move, recede, and surface without consciously learning it.
+
+---
 
 ## Purpose
-Define the higher-resolution attentional vocabulary used by the companion UI.
+
+Define the principles governing how attentional signals are weighted and composed.
 
 ## Metaphor boundary
+
+- `Attentional physics` describes interaction principles, not simulation or physical modelling.
 - `Weight`, `gravity`, and `pressure` are explanatory metaphors.
 - Their architectural meaning is always about attentional behavior, not simulated physics.
 
 ## Core terms
+
 - **Attentional weight:** how much attention an object deserves in the current context.
 - **Visual weight:** how strongly the interface presents an object perceptually.
 - **Salience gradient:** the relative difference in attentional pull across adjacent objects or trajectories.
@@ -18,6 +46,7 @@ Define the higher-resolution attentional vocabulary used by the companion UI.
 - **Non-disruptive salience:** making relevance legible without escalating into alert-like behavior.
 
 ## Rules
+
 - Visual weight should usually follow attentional weight, but never replace semantic justification.
 - Salience gradients should help the user perceive relative importance without forcing explicit ranking rituals.
 - Ambient resurfacing should minimize interruption pressure.
@@ -25,13 +54,101 @@ Define the higher-resolution attentional vocabulary used by the companion UI.
 - Low attentional load is preserved when resurfacing clarifies rather than competes.
 
 ## Relations
+
 - Salience influences attentional weight.
 - Tension increases attentional gravity.
-- Provenance affects whether resurfaced weight is trustworthy.
-- Continuity payload quality reduces interruption cost during re-entry.
+- Interruption pressure accumulates when multiple overlays compete without clear salience ordering.
 
-## Related docs
-- `ATTENTION_MODEL.md`
-- `SALIENCE_AND_TENSION.md`
-- `RESURFACING_HEURISTICS.md`
-- `CONTINUITY_AND_DECAY.md`
+---
+
+## The Overlay Grammar
+
+Modes are postures over the same document, expressed as overlays. From the `Cognitive Modes.html` design premise: *"The document is the cognitive anchor. Modes are not screens — they are postures over the same document, expressed as overlays with predictable grammar."*
+
+Each mode answers nine questions: overlay class · density · persistence · provenance · sources · AI visibility · spatial behavior · interruption · transitions out.
+
+The grammar has one rule above all others: **mode changes are overlay swaps, not route changes.** Scroll position, cursor, and selection are never altered when a mode transition occurs. The user's place in the document is sacred.
+
+---
+
+## Eight Interaction Invariants
+
+From the Cognitive Modes design — invariants that hold across all five modes.
+
+**1. Anchor preservation.** Mode changes never alter scroll position, cursor, or selection. The document is the anchor; modes are placed on top of it.
+
+**2. Reversibility.** Every overlay can be dismissed without data loss. No overlay commits the user to a path. Leaving is free.
+
+**3. No hard navigation.** Mode transitions are overlay swaps. They do not navigate to a new route or destroy the current view. The document remains visible behind every overlay.
+
+**4. Proposal duality.** Any object shown in the agent rail appears identically in the document with the same actions. A suggestion card in the margin and the inline staged block in the document are the same object — same amber treatment, same label, same apply/discard actions. The user should feel they are acting on one thing, not two representations.
+
+**5. Vault-canonical.** Persisted state lives in the vault as markdown and receipts. App-local state (canvas branches, trajectory snapshots, re-entry mist data) is recoverable if deleted. Nothing critical lives only in UI state.
+
+**6. Agent voice is one of many.** Agent contributions are visually distinguished but never structurally privileged. The agent does not own a pane, a primary surface, or a dominant position. Its presence is visible; its contributions are offers.
+
+**7. Low attention default.** Resurfacing and orientation never produce notifications. Salience expresses itself through visual weight — dot size, opacity, border weight — not through alerts, badges, or sounds.
+
+**8. Portrait equivalence.** The bottom sheet on mobile preserves the same cognitive semantics as the margin rail on desktop. Same content, different geometry. Orientation mode, dialogue, suggestion flow, and resurfacing are all available on portrait without degradation.
+
+---
+
+## Attentional Weight
+
+Every visible element carries implicit attentional weight: the claim it makes on focus simply by being present.
+
+**Weight should match function.** The document carries the most weight. Agent contributions and contextual signals carry less. System state and navigation carry least. When weight is inverted, the surface fights the user's actual task.
+
+**Cumulative weight is real.** Many light elements accumulate weight. A surface with few heavy elements but many peripheral signals can become cognitively demanding. Total attentional load must be managed, not just per-element salience.
+
+**Colour discipline is an attentional physics principle.** At any given moment, only the single most actionable element carries a saturated colour. Everything else is monochrome. This makes colour a reliable state signal rather than decoration, which is itself a low-attentional-load technique.
+
+| Moment | Coloured element |
+|---|---|
+| Focus (reading) | Vault dot only |
+| Dialogue | Vault dot + Send button (cyan) |
+| Suggestion | Vault dot + Apply + amber tints |
+| Vault unreachable | Destructive banner dot |
+
+---
+
+## Peripheral Presence
+
+Peripheral presence describes the state of elements that are visible but not focal.
+
+**Peripheral does not mean hidden.** A peripheral element is available; it is not absent. Reading it requires a minimal attention shift, not a navigation action.
+
+**Periphery is not a notification zone.** Peripheral elements do not animate, pulse, count, or signal urgency at rest. They are available without demanding. The one exception: tension marks pulse once per session entry, then settle.
+
+**Peripheral legibility degrades gracefully.** A marginalia dot is partially readable at low attention (size/colour conveys rough salience) and fully readable at moderate attention (hover reveals label and state). It does not require full focus to parse at the first level.
+
+---
+
+## Focal vs. Ambient Modes
+
+The surface supports two cognitive postures without an explicit mode toggle.
+
+**Focal mode:** the user is composing, reading, or directly engaging with content. Peripheral elements should recede. The document fills available attention. Agent contributions arriving during focal mode appear in the margin at ambient weight — they do not reposition layout or demand acknowledgment.
+
+**Ambient mode:** the user is paused, thinking, or reading at low intensity. Peripheral elements are more present. Contextual signals, trajectory marks, and marginalia are more legible.
+
+The transition between these postures should be driven by user behavior (typing, scrolling speed, pause duration) rather than an explicit toggle. The surface adapts; the user does not switch.
+
+---
+
+## AI Presence and Attentional Weight
+
+**Agent contributions should not interrupt focal mode.** A response arriving while the user is composing does not reposition layout, demand acknowledgment, or pull focus. It becomes available in the margin.
+
+**Agent presence should be readable, not announced.** The user can tell whether the system is active, idle, or recently responded without the system drawing attention to its state.
+
+**Agent contributions decay in peripheral weight over time.** An unengaged response gradually moves toward the far periphery. It remains available but does not compete for attention indefinitely.
+
+---
+
+## Non-Goals
+
+- Component names, animation durations, or specific layout behavior — those belong to design specifications
+- Salience scores, ranking algorithms, or runtime attention models — those belong to `ATTENTION_MODEL.md` and `docs/CONCEPTS/SALIENCE_AND_ATTENTIONAL_RELEVANCE_CONTRACT.md`
+- Which elements appear in which surface states — that belongs to per-surface interaction design specifications
+- Accessibility requirements — governed separately

--- a/companion-ui/docs/CONTINUITY_AND_DECAY.md
+++ b/companion-ui/docs/CONTINUITY_AND_DECAY.md
@@ -1,40 +1,165 @@
-# Continuity and Decay
+---
+name: Continuity and Decay
+description: "Trajectory states and latency ladder for the Companion UI: how thought continuity degrades over time and what re-entry support the surface offers per gap. Sourced from the 2026-05-08 Claude Design exploration."
+type: design-reference
+authority: Design vocabulary for continuity modeling; not an implementation spec or data model
+related_docs:
+  - companion-ui/docs/EXPERIENTIAL_PATTERNS.md
+  - companion-ui/docs/ATTENTIONAL_PHYSICS.md
+  - companion-ui/docs/TEMPORAL_OVERLAYS.md
+  - companion-ui/docs/RESURFACING_HEURISTICS.md
+  - companion-ui/docs/COGNITIVE_TRAJECTORIES.md
+  - companion-ui/docs/TEMPORAL_COGNITION.md
+  - companion-ui/design_handoff/2026-05-08-cognitive-temporal/temporal-s1.jsx
+  - companion-ui/design_handoff/2026-05-08-cognitive-temporal/temporal-s2.jsx
+  - docs/CONCEPTS/SALIENCE_AND_ATTENTIONAL_RELEVANCE_CONTRACT.md
+  - docs/FINDING_AND_REORIENTING/README.md
+---
+
+State: Active design vocabulary reference. Sourced from the 2026-05-08 Claude Design exploration (temporal-s1.jsx, temporal-s2.jsx). Does not prescribe session schemas, decay algorithms, or storage formats.
+
+# Continuity and Decay — Companion UI
+
+This document defines trajectory states, the continuity payload, and the latency ladder that governs what re-entry support the surface provides per gap length.
+
+---
 
 ## Purpose
+
 Define what must be preserved for low-cost re-entry and how that preservation weakens over time.
 
 ## Metaphor boundary
-- `Payload`, `decay`, and `latency ladder` are allowed shorthand.
-- Architecturally they mean reconstructive sufficiency, continuity loss, and increasing re-entry effort.
+
+- `Decay` here means loss of continuity, retrievability, or interpretive clarity, not data deletion.
+- `Latency ladder` is a named sequence of re-entry shapes, not a background timing service.
 
 ## Core terms
-- **Continuity payload:** the minimum bounded context needed to restore a trajectory.
-- **Cognitive re-entry:** return to a trajectory after interruption or dormancy.
-- **Interruption cost:** the amount of effort required to regain useful continuity.
-- **Temporal context reconstruction:** rebuilding enough prior meaning to continue without false certainty.
-- **Unresolved synthesis preservation:** keeping partially integrated thinking recoverable before final stabilization.
-- **Latency ladder:** the ordered rise in reconstruction effort as a trajectory cools, dorms, or decays.
 
-## Continuity payload contents
-- Anchor document
-- Prior intent
-- Current or last unresolved tension
-- Relevant provenance
-- Last meaningful transition or decision boundary
+- **Continuity payload:** the minimal context package required for low-cost cognitive re-entry.
+- **Cognitive re-entry:** restoring enough context to resume a trajectory without requiring full reconstruction from scratch.
+- **Interruption cost:** the attentional and cognitive effort required to resume a trajectory after a gap.
+- **Temporal context reconstruction:** assembling a usable picture of prior state from preserved signals.
+- **Unresolved synthesis preservation:** maintaining visibility of open cognitive tensions across session gaps so they remain addressable.
+- **Latency ladder:** the ordered increase in reconstruction effort as a trajectory cools or decays.
 
 ## Decay rules
-- Decay is not deletion; it is loss of reconstructive clarity.
-- Weak provenance accelerates interpretive decay.
-- Missing tension markers increase ambiguity during re-entry.
-- Good continuity payloads slow decay and flatten the latency ladder.
+
+- The longer the gap, the higher the re-entry cost.
+- Re-entry cost should be offset proportionally by the surface — not minimized at all gaps, but calibrated.
+- Cold trajectories (>14 days) receive no re-entry overlay. Re-entry is through the vault and search.
+- Tension does not decay on the standard curve. Open synthesis and conflicting sources hold ambient visibility until resolved.
 
 ## Architectural constraints
-- Continuity support must not become hidden app-only state.
-- Re-entry should restore trajectory meaning before inviting new branching.
-- Overlays may expose continuity payloads, but the vault remains the durable anchor.
 
-## Related docs
-- `TEMPORAL_COGNITION.md`
-- `COGNITIVE_TRAJECTORIES.md`
-- `TEMPORAL_OVERLAYS.md`
-- `TEMPORAL_PROVENANCE.md`
+- Continuity payload is derived automatically. The user never declares a trajectory state.
+- State transitions (Active → Warm → Dormant → Cold) are time-driven.
+- The surface must never claim to reconstruct full continuity for cold trajectories.
+
+---
+
+## Trajectory States
+
+Every thought-in-progress occupies one of four states. The system derives state from time and interaction; the user never declares it. From `temporal-s1.jsx` (Section 1: Interrupted trajectories).
+
+| State | Time since last interaction | Surface expression |
+|---|---|---|
+| **Active** | < 90 seconds | Cursor pulse · live caret · breath animation |
+| **Warm** | 90s – 2 hours | Gold spine · open-loop chip · momentum trail |
+| **Dormant** | 2 hours – 14 days | Faint marginalia · decay arc · tension halo if pressured |
+| **Cold** | > 14 days | No surface trace · vault-canonical only · re-entry through search |
+
+**Invariant:** State transitions are derived, never declared. The user never marks something dormant; the system never asks. Time does the work.
+
+Cold trajectories have no re-entry overlay. The document is ambient context only.
+
+---
+
+## Continuity Payload
+
+When the user steps away, the surface captures a structured snapshot keyed to the active document. This is volatile cognitive scaffolding — not vault state — and informs re-entry reconstruction.
+
+| Payload item | What it captures |
+|---|---|
+| Cursor + selection | Last caret line:col and selection range, per file |
+| Scroll trail | Last ~40 viewport positions (sparse); reveals what the user lingered on |
+| Open loops | Sentences ending in question, "TODO", "?", or unresolved bracket; auto-detected |
+| Last query | Most recent question to the agent; lives in the trajectory, not only chat history |
+| Adjacent canvas | Branches, even unsaved; cached locally with last-touched timestamp |
+| Staged proposals | Pending review-mode blocks remain in place; amber treatment persists |
+| Reading thread | Sequence of notes opened in this session; order matters for reconstruction |
+| Tension graph | Which passages had unresolved synthesis or conflicting sources |
+
+The snapshot is local, ~6kb, written every ~4 seconds when dirty, and purged at 30 days.
+
+---
+
+## Latency Ladder
+
+The latency ladder governs which re-entry shape the surface uses per gap. From `temporal-s2.jsx` (Section 2: Re-entry ergonomics).
+
+| Gap | Stage name | Re-entry shape |
+|---|---|---|
+| < 90s | **No mist** | Active state. Cursor still pulsing. Returning is identity. |
+| 90s – 15m | **Thread fade** | Conversation pane fades a fraction. No card. Trajectory implicit. |
+| 15m – 2h | **Soft mist** | 1-line card: "where you stopped" sentence + cursor jump. No metadata. |
+| 2h – 3d | **Full mist** | All four questions answered. This is the canonical re-entry shape. |
+| 3d – 14d | **Long mist** | Card + delta strip: what changed in vault, agent-found context, decayed branches. |
+| > 14d | **Cold start** | No overlay. Document is ambient context only. User searches. |
+
+---
+
+## The Four Re-entry Questions
+
+The full-mist card answers exactly four questions. No more. The shape of each answer is fixed, not negotiable per session.
+
+1. **"What was I doing?"** — Reconstructed from edit pulses + last query + active selection. One sentence summary, never analytical. Always present.
+
+2. **"Where did momentum stop?"** — Cursor position + last 30 seconds of edits expressed as a verbatim quoted fragment. Resume button jumps to exact caret position.
+
+3. **"What remains unresolved?"** — Open loops + staged proposals + tension halos. Counts only, not enumerated. Click expands to inline list.
+
+4. **"What changed since last engagement?"** — Vault diffs touching this trajectory, agent-found context, decayed items. Delta summary only, never a timeline from zero.
+
+---
+
+## Re-entry Mist Shape Per Gap
+
+From `reentry-analysis.jsx`, the settled composite recommendation.
+
+**2h – 3d:** Variant C alone — atmospheric recall. Warm tint over the document, corner glyphs glow once, gravity well at lower margin. Zero text added. The four questions are answered atmospherically, not structurally.
+
+**3d – 14d:** Variant C + Variant B's ghost sentence, but only when the stop-state was mid-text (unfinished sentence at cursor). If the user paused on a thought without an unfinished sentence, C alone is sufficient.
+
+**> 14d:** Variant A's whisper column appears in addition to C — four named items in a right-margin column, staggered in.
+
+**Invariant (from the design):** No card ever centers on the document. Re-entry is felt at the periphery. Cognition returns to the document, not to the system.
+
+---
+
+## What Decays vs What Stays Stable
+
+Not everything about a trajectory decays at the same rate.
+
+**Stays stable indefinitely:**
+- The vault document and its content
+- The session transcript (if persisted to vault as markdown)
+- Committed decisions and explicitly captured material
+
+**Decays at the trajectory state transitions:**
+- Active → Warm (90s): The live caret pulse transitions to a gold-spine warm marker
+- Warm → Dormant (2h): The open-loop chips and momentum trail contract to faint marginalia
+- Dormant → Cold (14d): Surface trace disappears entirely; vault-canonical only
+
+**Tension does not decay on the standard curve.** An unresolved synthesis or conflicting source holds a mark at ambient visibility until the tension is resolved. See `RESURFACING_HEURISTICS.md` for the decay envelope model.
+
+---
+
+## Ambient Persistence After Re-entry
+
+After the mist dissolves (on first keystroke or interaction), a residual ambient layer persists. Each re-entry variant leaves a different trace:
+
+**After Variant A (whisper):** Marginalia dots remain at every prior whisper position. Caret echo (a small gold tick) marks where the user stopped. Whisper text is gone.
+
+**After Variant B (breath):** A faint underline at the sentence-anchor remains as a resume jump target. Three faint dots in the lower-left margin. The ghost sentence is gone.
+
+**After Variant C (atmospheric):** The warm tint persists at reduced intensity (~60% of entry level). The gravity well persists at 20% opacity if the loop is still open. Corner glyphs disappear. The caret continues its breath animation at the last-stopped line.

--- a/companion-ui/docs/EXPERIENTIAL_PATTERNS.md
+++ b/companion-ui/docs/EXPERIENTIAL_PATTERNS.md
@@ -1,0 +1,169 @@
+---
+name: Experiential Patterns
+description: "Phenomenological interaction vocabulary for the Companion UI: attentional feel, continuity restoration, and ambient cognition. Distinguishes experiential metaphors from architectural semantics."
+type: design-reference
+authority: Design vocabulary for Companion UI interaction quality; not an implementation specification
+related_docs:
+  - companion-ui/DESIGN_BRIEF.md
+  - companion-ui/docs/ATTENTIONAL_PHYSICS.md (planned)
+  - companion-ui/docs/TEMPORAL_OVERLAYS.md (planned)
+  - companion-ui/docs/CONTINUITY_AND_DECAY.md (planned)
+  - companion-ui/docs/RESURFACING_HEURISTICS.md (planned)
+  - docs/CONCEPTS/SALIENCE_AND_ATTENTIONAL_RELEVANCE_CONTRACT.md
+  - docs/FINDING_AND_REORIENTING/README.md
+---
+
+State: Active design vocabulary reference. Documents phenomenological insights from interaction exploration; does not prescribe implementation, UI components, or runtime behavior.
+
+# Experiential Patterns — Companion UI
+
+This document records the interaction-quality vocabulary that emerged from design exploration around interruption, continuity, and ambient cognition. Its purpose is to preserve phenomenological precision while keeping these concepts clearly distinct from architectural semantics, implementation contracts, and feature specifications.
+
+Nothing in this document is a feature. These are attentional qualities and interaction goals that should inform how the surface *feels*, not what it *does*.
+
+---
+
+## Vocabulary Disambiguation
+
+Four layers of language appear in Companion UI design work. Conflating them produces drift.
+
+| Layer | What it names | Examples |
+|---|---|---|
+| **Architectural semantics** | Durable system concepts with runtime consequences | document, overlay, salience, resurfacing, continuity |
+| **Interaction patterns** | Repeatable design moves with observable UX shape | ambient reveal, progressive disclosure, context anchoring |
+| **Experiential metaphors** | Phenomenological descriptions of attentional feel | atmospheric recall, resumption breath, margin whisper |
+| **Exploration terminology** | Provisional language from design investigation | dormant trajectory presence, continuity gradients |
+
+Architectural semantics live in `docs/CONCEPTS/` and the companion architecture docs. They carry invariants.
+
+Interaction patterns describe *how* the surface moves and behaves. They are design decisions.
+
+Experiential metaphors describe *what the interaction should feel like*. They guide design judgment without specifying implementation.
+
+Exploration terminology is provisional. Some of it crystallizes into one of the three layers above; the rest dissolves once its insight is captured.
+
+---
+
+## Experiential Goals
+
+The Companion UI exists as a thinking surface, not a dashboard. The following experiential goals describe the intended attentional register across all states.
+
+**Low attentional load.** The surface should not compete for the user's attention. It should receive attention when offered and recede when not needed. Nothing demands acknowledgment.
+
+**Document-centered cognition.** The document — the vault artifact — is the primary cognitive object. The UI's job is to make the document easy to inhabit. Agent contributions, temporal context, and navigation are secondary.
+
+**AI as ambient presence.** The system should feel like a contextually aware collaborator, not a tool being wielded. Its contributions arrive; they do not interrupt.
+
+**Continuity over freshness.** The interaction should favor the experience of returning to familiar ground over the experience of encountering new information. Sessions are resumed, not restarted.
+
+**No notification-centric interaction.** Nothing in the surface should organize the user's attention around alerts, counters, or urgency signals. The rhythm is set by the user.
+
+---
+
+## Attentional Feel
+
+These describe the *quality of attention* the surface should cultivate.
+
+**Attentional softness.** The surface should accommodate diffuse, peripheral attention, not only focal engagement. A user glancing at the UI while thinking should receive ambient orientation without being pulled into a task. This is distinct from attention management as a feature — it is a felt property of the design.
+
+**Peripheral legibility.** Context, thread state, and agent presence should be readable at low attention cost. Information that requires focus to parse belongs in a detail layer, not in the ambient view.
+
+**Interruptibility without cost.** The user should be able to leave mid-thought and return without penalty. The surface does not punish pauses. It holds state legibly without drawing attention to the gap.
+
+---
+
+## Interaction Atmosphere
+
+The interaction atmosphere is the overall register in which the surface operates.
+
+**Contemplative, not reactive.** The surface is built for sustained, exploratory thinking. It should not feel like a messaging app or a task manager. Response latency and visual tempo should reinforce this.
+
+**Spatial continuity.** Elements should feel positioned, not floating. A user returning to the surface after time away should find the same spatial structure they left. Predictable layout reduces re-orientation cost.
+
+**Quiet legibility.** Typography, contrast, and density should favor reading and composition over scanning. The surface is for thinking, not information triage.
+
+---
+
+## Continuity Restoration Principles
+
+Continuity restoration describes what happens when a user returns after interruption — whether that interruption is five minutes or five days. These principles describe the *experiential shape* of good re-entry, not the mechanism.
+
+**The session should be findable, not reconstructed.** The user should feel that their thread is still present and locatable, not that they must rebuild it from evidence. The surface holds the thread; the user retrieves it.
+
+**Re-entry should breathe.** There is a moment when a user returns to a session and orients. Good design creates space for that moment rather than filling it immediately with information. The surface does not rush the user back to work.
+
+**Continuity is graduated, not binary.** A user who was away for ten minutes needs different re-entry support than one who returns after two weeks. The surface should be sensitive to this without asking the user to declare which case they are in.
+
+**The document anchors re-entry.** On return, the document itself — its content, state, and recent activity — is the primary orientation surface. System-level context (thread state, agent contributions) supports the document rather than replacing it.
+
+---
+
+## Ambient Cognition Patterns
+
+These describe how the surface supports cognition that does not require direct engagement.
+
+**Atmospheric recall.** The surface should evoke the cognitive atmosphere of a previous session, not merely display its data. A user returning should feel the context of where they were, not only see a log of what happened. This is a quality of presentation, not a data requirement.
+
+**Ambient resurfacing.** Material that has become relevant again should be able to surface without active querying. The surface should occasionally make something visible at the periphery rather than waiting for the user to search. This is a presence quality — the system makes gentle, non-intrusive contact with material the user has not explicitly asked for.
+
+**Margin whisper.** Soft contextual signals — related threads, dormant artifacts, nearby material — belong at the periphery of the working surface, not in the center. They should be visible without being legible at low attention; readable when the user shifts focus toward them.
+
+**Dormant trajectory presence.** An abandoned or paused thread should feel present in the surface even when not active. This is not a UI state indicator. It is the felt quality of the system holding the thread — a sense that the work is still there, waiting.
+
+---
+
+## Re-entry Ergonomics
+
+Re-entry ergonomics covers the interaction cost of resuming work after an interruption. These are design quality criteria, not feature requirements.
+
+**Resumption breath.** The moment of return should be a moment of orientation, not immediate engagement pressure. Design decisions that reduce this space — immediate focus trapping, autoplay on load, aggressive information density — should be avoided. Good re-entry design creates the breath; it does not skip past it.
+
+**Progressive context reveal.** On re-entry, orient before elaborating. Show the user where they are before showing them everything that happened while they were away. Temporal context, agent activity, and related material should be available but not foregrounded at the moment of arrival.
+
+**Low cost abandonment.** The user should be able to leave a session at any point without cleanup, without a decision to make, without a form to complete. The surface manages its own state. Leaving is free.
+
+**Legible thread state.** A user should be able to read the thread state — active, paused, complete, abandoned — at a glance without investigation. This is not a status badge; it is a design responsibility.
+
+---
+
+## Environmental Cognition Concepts
+
+Environmental cognition describes thinking that uses the surface as extended mind — where the UI holds structure, state, and context that the user does not need to carry internally.
+
+**The surface as memory prosthetic.** The surface should hold thread state, context, and history so the user does not have to. This is not about persistence as a feature; it is about the designed experience of cognitive offloading being reliable and legible.
+
+**Contextual re-entry.** The surface should know where the user was and make that information available at re-entry without requiring the user to find it. The environment restores context; the user does not reconstruct it.
+
+**The vault as cognitive ground.** All artifacts visible in the surface are, or derive from, vault documents. The vault is the stable cognitive substrate beneath the interaction. This grounds the environmental metaphor: the surface is not an ephemeral app state — it is a window into durable personal knowledge.
+
+**Interruption ergonomics.** The full shape of interruption — from cognitive load at interruption time, through the gap, to re-entry — is a design unit. The surface should be designed for this whole arc, not only for the active-engagement moment.
+
+---
+
+## Architectural Invariants
+
+These experiential patterns must remain consistent with the following architectural positions. Nothing in this document is intended to modify or override them.
+
+- **The document is the primary cognitive anchor.** Agent contributions, overlays, and contextual material are always secondary to the vault artifact itself.
+- **Overlays preserve continuity.** Temporal overlays, contextual signals, and resurfacing cues reinforce the user's thread; they do not fragment it.
+- **AI remains ambient and contextual.** The system does not initiate, demand, or redirect. Its presence is felt; its interventions are offered.
+- **Avoid dashboard UX.** No part of the surface should organize the user's attention around metrics, counters, statuses, or alerts.
+- **Avoid notification-centric interaction.** The user sets the rhythm. The surface does not interrupt.
+- **Preserve low attentional load.** Complexity lives in depth layers, not in the ambient view.
+
+For architectural salience semantics, see `docs/CONCEPTS/SALIENCE_AND_ATTENTIONAL_RELEVANCE_CONTRACT.md`.
+
+For the capability contracts governing orientation, resurfacing, and retrieval, see `docs/FINDING_AND_REORIENTING/README.md`.
+
+---
+
+## Planned Companion Documents
+
+These documents are not yet authored. They are the anticipated specification surfaces for the more precise design contracts that this vocabulary anticipates.
+
+- `companion-ui/docs/ATTENTIONAL_PHYSICS.md` — interaction-layer rules for attentional weight, peripheral presence, and focus transitions
+- `companion-ui/docs/TEMPORAL_OVERLAYS.md` — design contracts for time-aware contextual signals and how temporal context is surfaced without becoming a timeline UI
+- `companion-ui/docs/CONTINUITY_AND_DECAY.md` — design contracts for how thread continuity degrades over time and how the surface responds to different gap lengths
+- `companion-ui/docs/RESURFACING_HEURISTICS.md` — design heuristics for ambient resurfacing decisions: when, how soft, at what cost to ambient legibility
+
+This document should be read before authoring any of the above. It establishes the vocabulary those documents will use and the architectural invariants they must preserve.

--- a/companion-ui/docs/RESURFACING_HEURISTICS.md
+++ b/companion-ui/docs/RESURFACING_HEURISTICS.md
@@ -1,15 +1,43 @@
-# Resurfacing Heuristics
+---
+name: Resurfacing Heuristics
+description: "Marginalia field, decay envelope, and resurfacing triggers for the Companion UI. Sourced from the 2026-05-08 Claude Design exploration (temporal-s3.jsx)."
+type: design-reference
+authority: Design vocabulary for ambient resurfacing; not an implementation spec or ranking algorithm
+related_docs:
+  - companion-ui/docs/EXPERIENTIAL_PATTERNS.md
+  - companion-ui/docs/ATTENTIONAL_PHYSICS.md
+  - companion-ui/docs/TEMPORAL_OVERLAYS.md
+  - companion-ui/docs/CONTINUITY_AND_DECAY.md
+  - companion-ui/docs/SALIENCE_AND_TENSION.md
+  - companion-ui/docs/COGNITIVE_TRAJECTORIES.md
+  - companion-ui/docs/EPISTEMIC_EVOLUTION.md
+  - companion-ui/design_handoff/2026-05-08-cognitive-temporal/temporal-s3.jsx
+  - docs/CONCEPTS/SALIENCE_AND_ATTENTIONAL_RELEVANCE_CONTRACT.md
+  - docs/FINDING_AND_REORIENTING/README.md
+---
+
+State: Active design vocabulary reference. Sourced from the 2026-05-08 Claude Design exploration (temporal-s3.jsx, Section 3: Temporal resurfacing). Does not prescribe ranking algorithms, salience scores, ML models, or data schemas.
+
+# Resurfacing Heuristics — Companion UI
+
+This document defines the marginalia field, decay envelope, and resurfacing triggers that govern ambient resurfacing in the Companion UI. From `temporal-s3.jsx`.
+
+---
 
 ## Purpose
+
 Define when and why dormant material should return to attention.
 
 ## Metaphor boundary
+
 - `Heuristic` here means bounded architectural guidance, not hidden ranking machinery or implementation scoring.
 
 ## Core rule
+
 - Resurfacing is contextual return, not notification delivery.
 
 ## Heuristic signals
+
 - Meaningful salience increase
 - Unresolved tension with renewed relevance
 - Interruption return to an interrupted trajectory
@@ -17,18 +45,122 @@ Define when and why dormant material should return to attention.
 - Downstream dependency on a dormant trajectory
 
 ## Negative heuristics
+
 - Do not resurface only because something is old.
 - Do not resurface low-provenance material as strong guidance.
 - Do not resurface in ways that displace the anchor document.
 - Do not convert resurfacing into chat-centric or badge-centric pressure.
 
 ## Contextual resurfacing
+
 - Prefer warm trajectories over cold ones when several candidates are relevant.
 - Prefer unresolved synthesis over generic historical recap.
 - Favor ambient resurfacing when attentional load is already high.
 
-## Related docs
-- `SALIENCE_AND_TENSION.md`
-- `ATTENTIONAL_PHYSICS.md`
-- `COGNITIVE_TRAJECTORIES.md`
-- `EPISTEMIC_EVOLUTION.md`
+---
+
+## What Resurfacing Is
+
+From `EXPERIENTIAL_PATTERNS.md` and `docs/FINDING_AND_REORIENTING/README.md`:
+
+Resurfacing answers: "this has quietly become relevant again and I would not have thought to ask."
+
+It is not retrieval (user has a query, returns results), and it is not orientation (user has lost place, needs to be led back). It is the surface noticing, and gently making something present, without interruption.
+
+**In the Companion UI, resurfacing is expressed specifically as the marginalia field.** From the design: "Latent knowledge appears as faint marks at the right edge of the document — sized by salience, dimmed by recency, anchored to passages. No popups, no badges, no chime. The user notices only when their eye is ready; that is the correct latency for re-attentioning."
+
+---
+
+## The Marginalia Field
+
+The marginalia field is a narrow rail at the right edge of the document. It holds faint dots (MargDot) anchored to specific passages.
+
+**Size encodes salience.** A highly salient item has a larger dot. A faint, distant item has a smaller dot.
+
+**Opacity encodes recency.** Fresh items are at full opacity. Items that haven't been relevant for longer are progressively dimmer.
+
+**No tooltip until hover.** The dots are visible but not legible until the user directs attention toward them. Hovering reveals the source, label, and state.
+
+**No badge, count, or chime.** The marginalia field never announces itself. There is no counter of how many items are present. The user discovers the field by glancing at the right edge.
+
+**Tension marks pulse once per session entry.** An unresolved tension mark pulses once when the session starts, then settles to static ambient.
+
+Colour of marginalia dots:
+- `--vault` (green): related notes, decayed items, adjacent vault edits
+- `--amber`: unresolved tension, conflicting sources, synthesis drift
+- `--cyan`: returning questions, recurrent echoes, decayed adjacent canvas
+- `--accent` (gold): open loops anchored to the user's own prior writing
+
+---
+
+## Six Resurfacing Triggers
+
+From the design, six conditions can cause a latent item to gain a marginalia mark. None produce a notification. All resolve to a visual weight on something already on screen.
+
+| Trigger | When it fires | Surface expression |
+|---|---|---|
+| **Contextual proximity** | User reads a passage; vault has neighbors within k=3 hops | Faint vault dot at line; dims until eye lingers >2 seconds |
+| **Temporal echo** | Today's date matches a prior session anniversary or recurring date frame | Cyan recurrent mark; surfaces once per matching day |
+| **Unresolved tension** | Open loop or conflicting source persists across sessions | Amber tension halo; pulses once per session entry |
+| **Synthesis drift** | A vault edit elsewhere contradicts a claim in the current draft | Amber margin mark + provenance fleck on the affected paragraph |
+| **Self-trace** | Returning to a passage the user last edited mid-thought | Gold momentum trail under the paragraph for one session |
+| **Decayed adjacent** | An old exploration branch touches the current cursor topic | Faint cyan dot; clicking reanimates the branch |
+
+---
+
+## Decay Envelope
+
+Marginalia opacity follows a curve, not a clock. Three decay curves compose the final opacity. From `temporal-s3.jsx` (Decay envelope artboard).
+
+**Curve 1 — Recency only:** Pure exponential. ~50% opacity at 7 days, ~10% at 30 days.
+
+**Curve 2 — Salience-weighted:** Half-life doubles per uniqueness tier. Evergreen items persist longer; ephemeral ones fade faster.
+
+**Curve 3 — Tension-bound:** No decay until resolved. An unresolved synthesis or conflicting source stays at ambient visibility regardless of recency. Tension never lets a mark go fully dark while a loop is open.
+
+**Composition rule:** `final_opacity = min(recency, salience) · tension_bonus`
+
+Tension bonus prevents the floor from reaching zero while an open loop exists.
+
+---
+
+## Optional Resurface Tray
+
+From the Cognitive Modes design: the marginalia field has an optional companion, the **Resurface tray** — a ~200px sidebar listing latent items with their reason for surfacing. It is always optional and always dismissible. It is a depth layer, not the primary resurfacing surface.
+
+The tray exists for when the user wants to engage explicitly with what the marginalia field is showing. It does not replace the ambient behavior; it supplements it for users who want to understand the full resurfacing pool.
+
+---
+
+## Attentional Cost Discipline
+
+Calmness above density. The constraints held throughout the design exploration were: no dashboards, no badges, no notifications, no productivity chrome, no chat surface.
+
+**False positives are expensive.** A dot that surfaces for an item the user finds irrelevant costs attention to register and dismiss. Repeated false positives train the user to ignore the marginalia field entirely.
+
+**Cumulative load is real.** Many low-opacity dots still accumulate attentional weight. The design limits concurrent marks and uses opacity to signal which are most worth attention now.
+
+**Hover is the interaction gate.** The user must direct attention to a dot to read it. This is the deliberate gate — the marginalia field should never force its content on the user.
+
+---
+
+## What Resurfacing Is Not
+
+**Not a notification system.** No sound, no badge, no counter, no banner. Resurfacing is silent.
+
+**Not retrieval.** The user did not ask a question. The surface is acting on the user's behalf, not answering a query.
+
+**Not a timeline.** The marginalia field is not organized chronologically. It is organized spatially — anchored to the passages it relates to.
+
+**Not a queue to be processed.** Marginalia marks are not tasks. The user is not expected to act on them. They are ambient availability, not pending items.
+
+**Not system-generated operational artifacts.** Receipts, logs, intermediate projections, and agent-internal traces do not enter the resurfacing pool. Only vault-native human-authored material and companion notes belong there.
+
+---
+
+## Non-Goals
+
+- Defining salience scores, ranking weights, or ML model specifications — those belong to implementation and `docs/CONCEPTS/SALIENCE_AND_ATTENTIONAL_RELEVANCE_CONTRACT.md`
+- Specifying vault queries for resurfacing candidate generation — implementation concern
+- Prescribing UI components for tray layout — design decisions per surface
+- Managing notification or alert delivery — resurfacing is explicitly not a notification system

--- a/companion-ui/docs/TEMPORAL_OVERLAYS.md
+++ b/companion-ui/docs/TEMPORAL_OVERLAYS.md
@@ -1,13 +1,44 @@
-# Temporal Overlays
+---
+name: Temporal Overlays
+description: "Temporal cognition design vocabulary for the Companion UI: cognitive tension, temporal provenance, and how time-aware context is incorporated without producing timeline UIs. Sourced from the 2026-05-08 Claude Design exploration."
+type: design-reference
+authority: Design vocabulary for temporal context surfacing; not an implementation spec
+related_docs:
+  - companion-ui/docs/EXPERIENTIAL_PATTERNS.md
+  - companion-ui/docs/ATTENTIONAL_PHYSICS.md
+  - companion-ui/docs/CONTINUITY_AND_DECAY.md
+  - companion-ui/docs/RESURFACING_HEURISTICS.md
+  - companion-ui/docs/OVERLAY_GRAMMAR.md
+  - companion-ui/docs/TEMPORAL_PROVENANCE.md
+  - companion-ui/docs/TEMPORAL_COGNITION.md
+  - companion-ui/design_handoff/2026-05-08-cognitive-temporal/Temporal Cognition.html
+  - companion-ui/design_handoff/2026-05-08-cognitive-temporal/temporal-s4.jsx
+  - companion-ui/design_handoff/2026-05-08-cognitive-temporal/temporal-s5.jsx
+  - docs/CONCEPTS/TEMPORAL_VALIDITY_AND_STALENESS_CONTRACT.md
+  - docs/FINDING_AND_REORIENTING/README.md
+---
+
+State: Active design vocabulary reference. Sourced from the 2026-05-08 Claude Design exploration (Temporal Cognition.html, temporal-s4.jsx, temporal-s5.jsx). Does not prescribe data models, event schemas, or frontend components.
+
+# Temporal Overlays — Companion UI
+
+This document defines how temporal context is expressed in the Companion UI. The design frames this as **temporal cognition** — a broader concern than simply showing timestamps or activity recency. It covers: trajectory states, re-entry ergonomics, temporal resurfacing (covered in depth in companion docs), cognitive tension, and temporal provenance.
+
+The organizing principle from the design: *"continuity of thought across interruption · ambient, document-anchored, non-disruptive."*
+
+---
 
 ## Purpose
+
 Define overlays whose role is preserving continuity across time rather than simply exposing controls.
 
 ## Metaphor boundary
+
 - `Temporal overlay` is an architectural classification.
 - It does not imply background automation, notification feeds, or hidden timing state.
 
 ## Canonical temporal overlay functions
+
 - Re-entry cueing
 - Continuity payload exposure
 - Provenance glanceability
@@ -15,6 +46,7 @@ Define overlays whose role is preserving continuity across time rather than simp
 - Decay mitigation through compact context reconstruction
 
 ## Rules
+
 - Temporal overlays must preserve the document as anchor.
 - Temporal overlays must be dismissible without semantic loss.
 - Temporal overlays must reduce interruption cost, not amplify it.
@@ -22,12 +54,141 @@ Define overlays whose role is preserving continuity across time rather than simp
 - Temporal overlays must not hide meaning-bearing state from the vault.
 
 ## Examples of temporal overlay roles
+
 - Recovery strip showing prior intent and unresolved tension
 - Provenance peek explaining why something resurfaced now
 - Compact continuity card for warm trajectory re-entry
 
-## Related docs
-- `OVERLAY_GRAMMAR.md`
-- `CONTINUITY_AND_DECAY.md`
-- `TEMPORAL_PROVENANCE.md`
-- `ATTENTIONAL_PHYSICS.md`
+---
+
+## What Temporal Overlays Are Not
+
+**Not a timeline.** A timeline makes time the primary navigation axis. Temporal overlays are contextual signals subordinate to the document.
+
+**Not an activity feed.** An activity feed presents events as content to be consumed in reverse-chronological order. Temporal overlays exist as background to the document, not as content.
+
+**Not a notification layer.** Temporal overlays do not alert, pulse, badge, or count. They express state through visual weight.
+
+**Not timestamps on every element.** Stamping times on all visible content makes time a constant low-level noise. Temporal context surfaces only where it changes the user's interpretation.
+
+---
+
+## Temporal Context Scope
+
+The temporal cognition design covers five areas. The first three are documented in depth in companion docs; the last two are documented here.
+
+1. **Interrupted trajectories** — trajectory states (Active/Warm/Dormant/Cold) and the continuity payload. See `CONTINUITY_AND_DECAY.md`.
+2. **Re-entry ergonomics** — the mist variants, latency ladder, and the four re-entry questions. See `CONTINUITY_AND_DECAY.md` and `EXPERIENTIAL_PATTERNS.md`.
+3. **Temporal resurfacing** — the marginalia field, decay envelope, and six triggers. See `RESURFACING_HEURISTICS.md`.
+4. **Cognitive tension** — unresolvedness, conflict, incomplete synthesis. Documented here.
+5. **Temporal provenance** — how understanding evolved, what changed, where uncertainty moved. Documented here.
+
+---
+
+## Cognitive Tension
+
+Cognitive tension is the design vocabulary for unresolvedness that persists across sessions. From `temporal-s4.jsx` (Section 4: Cognitive tension). The design's framing: *"Tension is not a number. It has a shape. The shape determines the visual."*
+
+Four shapes of cognitive tension, each with a distinct visual treatment:
+
+### Open Loop
+
+*"One question waits for an answer."*
+
+A single thread that is explicitly unfinished. Shape: a dotted trajectory line with a gold dot at the open end.
+
+Surface expression: an open-loop chip (`OpenLoop` component from `temporal-primitives.jsx`) anchored to the passage it belongs to. Shows the loop text and its age. Persists in the marginalia field until resolved.
+
+The tension halo (radial amber glow) scales with pressure intensity — how long the loop has been open and how many other sessions touched it without resolving it.
+
+### Conflict
+
+*"Two interpretations, refused merge."*
+
+Sources or claims actively disagree. The draft cannot proceed by picking one silently. Shape: an X — two lines crossing, endpoints marked.
+
+Surface expression: an amber break in the draft where the two sides diverge, both sides preserved with provenance. No merge is forced. The conflict stays legible until the user resolves it deliberately.
+
+### Incomplete Synthesis
+
+*"Multiple sources drawn in; draft incomplete."*
+
+Several sources are in play, draft is partially assembled, but the synthesis has not landed. Shape: a triangle with one side open.
+
+Surface expression: a green-bordered synthesis block showing source count, conflict count, and draft completion percentage. Persists until the synthesis either closes or is abandoned.
+
+### Dormant Pressure
+
+*"Something is pulling without being named."*
+
+Not a specific question or conflict — a diffuse sense that a body of material has unresolved weight. Often the result of several smaller tensions that were never individually surfaced.
+
+Surface expression: the gravity well in Variant C of the re-entry mist — a radial pressure indicator in the lower margin, present whenever dormant pressure is above threshold.
+
+---
+
+## Tension Does Not Decay
+
+Tension marks in the marginalia field do not follow the standard recency curve. From the design: *"Tension never lets a mark go fully dark while a loop is open."*
+
+The decay composition rule: `final_opacity = min(recency, salience) · tension_bonus`. The tension bonus prevents the mark from reaching zero until the tension is explicitly resolved.
+
+This is what makes tension visually distinct from ordinary resurfacing marks: tension marks stay bright even when old.
+
+---
+
+## Temporal Provenance
+
+Temporal provenance is the design vocabulary for the evolution of understanding over time. From `temporal-s5.jsx` (Section 5: Temporal provenance): *"how understanding evolved · what changed · where uncertainty moved."*
+
+The design presents provenance as a **paragraph genealogy**: a single paragraph's evolution across revisions, each revision state named and attributed.
+
+From the design's example, a paragraph can move through states:
+- **Seed** — first capture, often from an agent suggestion or rough phrase
+- **Expanded** — user revision, elaboration
+- **Contested** — a conflict introduced from a new source, both sides preserved
+- **Synthesized** — user reframing that resolves the conflict, often by elision or reframing
+- **Active** — current state, possibly with an open loop if the synthesis is still incomplete
+
+Each state is attributed: user revision, agent suggestion, source citation, conflict introduced by which note.
+
+### What Provenance Enables
+
+Provenance allows the user to answer:
+- *How did I arrive at this claim?*
+- *What was I uncertain about here, and did I resolve it?*
+- *This looks odd — when did I change this, and why?*
+- *What would I lose if I accepted Hugin's suggestion here?*
+
+### Provenance in the Surface
+
+The design shows two provenance interaction forms:
+
+**Genealogy strip:** A depth-layer view of a paragraph's revision history. Not ambient — accessed deliberately. Shows the temporal spine, revision states, text at each state, and attributions.
+
+**Diff lens:** A focused comparison between two states — what changed, what was preserved, what provenance tags moved. Also a depth-layer view, not ambient.
+
+**Provenance flecks:** Small marks on the current paragraph that signal it has provenance depth available. Visible in the ambient view; tapping opens the genealogy.
+
+### What Provenance Is Not
+
+Provenance is not a version control UI. The user is not expected to review diffs as a workflow. Provenance is available when the user wants to understand the history of a claim; it does not announce itself or demand engagement.
+
+---
+
+## Temporal Language
+
+The surface should use natural temporal language rather than exact timestamps in the ambient view.
+
+Exact timestamps belong in detail layers. Ambient temporal language ("4 days ago," "last month," "2 hours idle") provides orientation without requiring arithmetic.
+
+Temporal language should be consistent across the surface: "3 days ago" not "72 hours ago" for the same item. The design uses natural time spans throughout.
+
+---
+
+## Non-Goals
+
+- Designing a version control or audit log UI
+- Specifying timestamp schemas, event models, or how the runtime tracks session timing
+- Real-time synchronization indicators or live-update patterns
+- Animation or transition behavior for temporal context arrival — those are implementation decisions


### PR DESCRIPTION
## Change Lane
- [ ] Implementation lane
- [x] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Closes #824

## Summary
- Adds the 2026-05-08 Claude Design exploration files to `companion-ui/design_handoff/2026-05-08-cognitive-temporal/`: three interactive HTML canvases (Cognitive Modes, Temporal Cognition, Re-entry Mist Variants) and their supporting JSX source files
- Adds `EXPERIENTIAL_PATTERNS.md` — phenomenological interaction vocabulary covering the five cognitive modes, three re-entry mist variants, attentional feel, continuity restoration principles
- Revises four companion vocabulary docs to align precisely with the design source material:
  - `ATTENTIONAL_PHYSICS.md` — eight interaction invariants, overlay grammar, colour discipline, focal/ambient mode distinction
  - `CONTINUITY_AND_DECAY.md` — trajectory states (Active/Warm/Dormant/Cold), latency ladder, four re-entry questions, mist shapes per gap, continuity payload
  - `RESURFACING_HEURISTICS.md` — marginalia field spec, six resurfacing triggers, three-curve decay envelope, composition rule
  - `TEMPORAL_OVERLAYS.md` — cognitive tension shapes (open loop/conflict/incomplete synthesis/dormant pressure), temporal provenance as paragraph genealogy
- All four revised docs merge main's concise architectural vocabulary sections with the richer design-grounded content from the actual Claude Design files

## Docs Authoring Check
- [x] This PR only changes approved docs-authoring surfaces.
- [x] No code, runtime behavior, contracts, or shipped reality changed.
- [x] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Validation
Docs authoring lane:
- [x] All changes in `companion-ui/` — design handoff files and docs surface
- [x] No ruff/mypy/pytest concerns — docs-only change
- [x] Vocabulary documents verified against actual design file content (temporal-s1–s5.jsx, reentry-analysis.jsx, Cognitive Modes.html) before final commit
- [x] Architectural invariants from existing repo docs (`SALIENCE_AND_ATTENTIONAL_RELEVANCE_CONTRACT.md`, `FINDING_AND_REORIENTING/README.md`) preserved and linked