### PR TITLE
docs: define chat-family interaction taxonomy

### DIFF
--- a/docs/INTERACTION_SURFACES_AND_AUTHORITY/CHAT_FAMILY_TAXONOMY.md
+++ b/docs/INTERACTION_SURFACES_AND_AUTHORITY/CHAT_FAMILY_TAXONOMY.md
@@ -1,0 +1,131 @@
+---
+name: Chat-Family Interaction Taxonomy
+description: Docs-only taxonomy that names the chat-family interaction surfaces in this system, distinguishes their authority/persistence/cognitive roles, and prevents collapse into a single generic chat product
+type: specification
+authority: SoT for naming and bounding chat-family interaction surfaces; subordinate to DEFINE_CHAT_AUTHORITY_BOUNDARY.md and STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md for authority semantics
+related_docs:
+  - docs/INTERACTION_SURFACES_AND_AUTHORITY/README.md
+  - docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CANVAS_COEDITING_MODEL.md
+  - docs/INTERACTION_SURFACES_AND_AUTHORITY/HYBRID_CHAT_INTEGRATION_SCHEMA.md
+  - docs/CANVAS_CHAT_SURFACE/README.md
+  - docs/HUMAN-FLOWS.md
+---
+
+State: Active docs-only specification. Names the chat-family taxonomy; does not introduce new runtime behavior. Canvas Chat remains gated behind `CANVAS_ENABLED`; all other chat-family surfaces described here are either current Panel behavior, current operator surfaces, or explicitly future capability work.
+
+# Chat-Family Interaction Taxonomy
+
+## Why this taxonomy exists
+
+"Chat" is **not a single architectural primitive in this system.** It is a family of dialogue-like or conversational interaction affordances that look superficially similar — line-oriented, turn-shaped, often LLM-mediated — but differ sharply in:
+
+- **Authority** — what each surface is allowed to do on the user's behalf.
+- **Persistence** — what is durable, what is provenance, and what is ephemeral.
+- **Cognitive role** — the human need each surface serves (command, co-authoring, recall, synthesis, operator inspection).
+
+Treating these as one surface produces predictable failures: ASK-style Q&A creeps back into the architectural center, the Panel command surface gets diluted, durable meaning gets stranded in transcripts, and governance-bearing mutations slip past the gated execution boundary. This document names the family members so future work cannot collapse them by accident.
+
+This taxonomy is subordinate to:
+
+- [DEFINE_CHAT_AUTHORITY_BOUNDARY.md](DEFINE_CHAT_AUTHORITY_BOUNDARY.md) — "Chat is canvas, not ASK."
+- [DEFINE_CANVAS_COEDITING_MODEL.md](DEFINE_CANVAS_COEDITING_MODEL.md) — note-as-artifact / session-as-provenance.
+- [STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md](STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md) — gated-execution invariant.
+
+If anything in this taxonomy appears to contradict those, the other documents win.
+
+## Family members
+
+### A. Panel command dialogue
+
+- **Shape:** Command-oriented, note-local, turn-shaped exchanges between user and PanelAgent inside the active note.
+- **Use:** Intent clarification, proposed actions, explicit commands, receipts, confirmations.
+- **Authority:** Panel remains the **primary command-oriented surface**. Governance-bearing actions originating in Panel route through the gated execution boundary (policy / validation / event pipeline). LLM reasoning in Panel does not by itself trigger execution.
+- **Persistence:** Receipts and command outcomes are durable in the note; the conversational scaffolding around them is provenance, not source of truth.
+- **Status:** Current runtime behavior.
+
+### B. Canvas co-authoring session
+
+- **Shape:** Canvas-shaped, note-first, user-present co-authoring of the currently open note.
+- **Use:** Externalize and manipulate thought in place; the user and the system co-edit the body of one note while the user is present.
+- **Authority:** Body edits to the currently open note may apply directly during an active session, authorized by user presence. Governance-bearing mutations (anything beyond the active note's body, or anything affecting graph/scheduled/system artifacts) remain gated.
+- **Persistence:** **The note is the durable artifact.** The `.chats/` session log is **subordinate provenance**, not source of truth. Promotion of session content into durable meaning happens explicitly, not by transcript accumulation.
+- **Status:** Materially implemented behind `CANVAS_ENABLED`. Hybrid Panel/Chat behavior remains future work.
+
+### C. Retrieval dialogue
+
+- **Shape:** ASK/RAG-like source-grounded inquiry — receive question, return answer with citations.
+- **Use:** Retrieval, orientation, question answering, source-backed recall over the existing vault and indexed sources.
+- **Authority:** **Read-only by default.** This surface must not become the architectural center again (see `docs/FINDING_AND_REORIENTING/DEPRECATE_ASK_AS_ARCHITECTURAL_CENTER.md`). If a retrieval dialogue ever needs to mutate durable state, it escalates to a governed mutation path; it does not gain mutation authority by virtue of being conversational.
+- **Persistence:** Answers cite sources; the dialogue itself is ephemeral or provenance-only. Citations preserve provenance back to the source notes.
+- **Status:** Conceptually allowed as a bounded surface; not the system's center. Any current ASK-shaped affordance is constrained to this role.
+
+### D. Workspace synthesis session
+
+- **Shape:** Multi-note or multi-source synthesis, reconciliation, and drafting across the workspace.
+- **Use:** Cross-note reasoning, reconciliation of overlapping notes, drafting new artifacts that integrate multiple existing ones.
+- **Authority:** Distinct from single-note canvas co-authoring. **Cross-note writes are governance-bearing by definition** and must route through the gated execution boundary; user presence in one note does not authorize edits to others.
+- **Persistence:** Outputs land in explicit artifacts (new notes, receipts, governed system artifacts), not in a workspace-wide transcript.
+- **Status:** **Future capability / not current runtime.** Listed here so future work does not silently fold it into Canvas co-authoring or into a generic chat product.
+
+### E. Operator / agent console
+
+- **Shape:** Developer/operator surface — CLI, Codex, Claude Code, runtime diagnostics, agent execution inspection. Often visually conversational.
+- **Use:** Building, debugging, operating, and inspecting the system itself.
+- **Authority:** Acts under operator/developer privileges, not end-user PKM cognition. Must not be promoted into the primary human-facing PKM chat surface; the operator surface and the user-facing cognitive surface are different products even if they share LLM mediation.
+- **Persistence:** Logs, transcripts, and agent traces are operator artifacts, not user-facing durable meaning.
+- **Status:** Current operator/dev tooling. Out of scope for the cognitive-prosthetic UX surface.
+
+## Comparison
+
+| Surface | Primary human need | Interaction shape | Persistence model | Mutation authority | Current status |
+| --- | --- | --- | --- | --- | --- |
+| A. Panel command dialogue | Issue commands, see what the system did on my behalf | Command-oriented, turn-shaped, note-local | Receipts durable in note; conversation is provenance | Primary command surface; mutations gated through governed execution | Current runtime |
+| B. Canvas co-authoring session | Externalize and manipulate thought with the system in the note I'm in | Canvas-shaped, note-first, user-present | Note is the artifact; `.chats/` session log is subordinate provenance | Body edits to active note authorized by presence; cross-boundary mutations gated | Behind `CANVAS_ENABLED`; hybrid behavior future |
+| C. Retrieval dialogue | Find and orient against what the vault already knows | Source-grounded Q&A with citations | Ephemeral or provenance-only; citations preserve source links | Read-only by default; mutation requires escalation to a governed path | Bounded role only; not the architectural center |
+| D. Workspace synthesis session | Reconcile and synthesize across many notes/sources | Multi-source drafting and reconciliation | Outputs land in explicit artifacts, not a workspace transcript | Cross-note writes governance-bearing; gated by definition | Future capability |
+| E. Operator / agent console | Build, debug, and operate the system | Conversational developer/operator interface | Logs and traces as operator artifacts | Operator/developer privilege; not end-user authority | Current dev tooling |
+
+## Shared rules across the chat family
+
+These rules apply to every member of the family. They are restatements of existing contracts, scoped to chat-family surfaces.
+
+1. **No chat transcript becomes the semantic source of truth by default.** Durable meaning belongs in notes, explicit artifacts, receipts, or governed system artifacts — not in transcripts.
+2. **Session logs are provenance, not authority.** Promotion of session content into durable meaning is a separate, governed step; transcript accumulation never silently promotes itself.
+3. **Governance-bearing mutation always uses the gated execution boundary.** No chat-family surface mutates durable state outside the active-note body of a present user without passing through policy / validation / event-pipeline governance. LLM reasoning alone never triggers execution. (See `STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md`.)
+4. **Retrieval/source-grounded dialogue must preserve provenance.** Citations and source links are not optional decoration; they are how the read-only contract is honored.
+5. **The surfaces must not collapse into one generic chat product.** Panel, Canvas, Retrieval, Workspace, and Operator have different authority, persistence, and cognitive roles. They may share UI primitives but must not share authority or persistence contracts.
+6. **No surface inherits authority from another by visual similarity.** A surface that looks like Panel does not gain Panel's command authority; a surface that looks like Canvas does not gain co-authoring write rights.
+
+## Modularity requirement
+
+The chat family must be implemented as **replaceable components, not as one monolithic chat product.**
+
+- **Shared UI primitives are allowed.** Message bubbles, input affordances, citation chips, streaming indicators, code blocks, and similar rendering/input components may be reused across surfaces.
+- **Surface-specific contracts must remain behind clear interfaces.** Authority, persistence, retrieval, and mutation contracts belong to the surface, not to the shared components. A reused message bubble does not import authority from the surface it was last used in.
+- **The taxonomy must support swapping** frontend components, agent runtimes, retrieval providers, event-stream protocols, and persistence adapters **without changing the semantic role of each surface.** If swapping the LLM provider or the streaming transport requires re-deciding what Canvas means, the abstraction is wrong.
+- **Do not couple the taxonomy to specific tech.** This document and the surfaces it names must not be coupled to any single UI library, agent harness, LLM provider, retrieval stack, or persistence format beyond the already-authoritative vault/session/receipt contracts. Naming a vendor in passing is fine; binding a surface's identity to a vendor is not.
+
+> **Companion UI principle.** The Companion UI should be modular by construction: shared rendering/input components may be reused across Panel command dialogue, Canvas co-authoring, Retrieval dialogue, Workspace synthesis, and Operator console, but each surface must bind to its own authority and persistence adapter so components can be replaced without changing system semantics.
+
+## Implications for future UI implementation
+
+- A future Companion UI **may host multiple chat-family surfaces** — possibly all of A–E in different views, modes, or panels. The taxonomy is the contract that keeps them distinct inside one shell.
+- **UI components may be shared across surfaces, but authority and persistence contracts must remain separate.** Each surface binds to its own authority adapter (what it is allowed to do) and its own persistence adapter (where its durable artifacts live and what is provenance).
+- **Generic OSS chat applications such as Open WebUI or LibreChat should not be imported as the primary foundation** of the Companion UI. Their conversation-first, transcript-as-product model conflicts directly with this taxonomy: it would re-promote the transcript to source of truth, blur Panel's command role into a generic chat field, and drag ASK-shaped semantics back into the architectural center.
+- **OSS libraries and references are still useful as UI primitives or pattern references** — message rendering, streaming, markdown, citation UX patterns — provided they do **not** own persistence, memory, retrieval, or mutation authority. Use them for pixels, not for product shape.
+
+## What this document is NOT
+
+- Not a runtime change. No code is being introduced or modified by this file.
+- Not a claim that Workspace synthesis exists today; it is named as a future surface so it is not retrofitted into Canvas.
+- Not a re-opening of the Chat mutation reconciliation; Candidate A in `RECONCILE_CHAT_MUTATION_AUTHORITY.md` stands.
+- Not a license for Retrieval dialogue to grow mutation rights; read-only-by-default is binding.
+- Not a UI design document. It constrains UI work without specifying it.
+
+## Related docs
+
+- [docs/INTERACTION_SURFACES_AND_AUTHORITY/README.md](README.md)
+- [docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CANVAS_COEDITING_MODEL.md](DEFINE_CANVAS_COEDITING_MODEL.md)
+- [docs/INTERACTION_SURFACES_AND_AUTHORITY/HYBRID_CHAT_INTEGRATION_SCHEMA.md](HYBRID_CHAT_INTEGRATION_SCHEMA.md)
+- [docs/CANVAS_CHAT_SURFACE/README.md](../CANVAS_CHAT_SURFACE/README.md)
+- [docs/HUMAN-FLOWS.md](../HUMAN-FLOWS.md)

--- a/docs/INTERACTION_SURFACES_AND_AUTHORITY/README.md
+++ b/docs/INTERACTION_SURFACES_AND_AUTHORITY/README.md
@@ -75,7 +75,7 @@ Crucially, "Chat as canvas" is not a revival of the ASK-style question-answering
 10. [DEFINE_PANEL_AS_THE_PRIMARY_COMMAND_SURFACE.md](DEFINE_PANEL_AS_THE_PRIMARY_COMMAND_SURFACE.md) — compatibility note that Panel is the primary command-oriented surface, not the exclusive authoritative intent surface.
 11. [HYBRID_CHAT_INTEGRATION_SCHEMA.md](HYBRID_CHAT_INTEGRATION_SCHEMA.md) — docs-only schema for how canvas Chat integrates with Panel, session provenance, and governed execution without becoming a second Panel.
 
-Tasks 2, 3, 4, 5, and 7 may proceed in parallel as docs drafts. Task 6 (reconcile) depends on tasks 2–5 naming the surfaces consistently and on task 7 stating the gated-execution invariant, because the reconcile task evaluates options against those contracts.
+Tasks 2, 3, 4, 5, 6, and 8 may proceed in parallel as docs drafts. Task 7 (reconcile) depends on tasks 2–6 naming the surfaces consistently and on task 8 stating the gated-execution invariant, because the reconcile task evaluates options against those contracts.
 
 ## Capability-level acceptance criteria
 

--- a/docs/INTERACTION_SURFACES_AND_AUTHORITY/README.md
+++ b/docs/INTERACTION_SURFACES_AND_AUTHORITY/README.md
@@ -66,13 +66,14 @@ Crucially, "Chat as canvas" is not a revival of the ASK-style question-answering
 1. [PARENT_FEATURE_ISSUE.md](PARENT_FEATURE_ISSUE.md) — capability-level context, scope, constraints, acceptance.
 2. [NAME_THE_THREE_INTERACTION_SURFACES.md](NAME_THE_THREE_INTERACTION_SURFACES.md) — the three surfaces and why they are not collapsible.
 3. [DEFINE_PANEL_AUTHORITY_BOUNDARY.md](DEFINE_PANEL_AUTHORITY_BOUNDARY.md) — Panel's current authority and mutation path.
-4. [DEFINE_CHAT_AUTHORITY_BOUNDARY.md](DEFINE_CHAT_AUTHORITY_BOUNDARY.md) — Chat as canvas-shaped thinking surface, with future mutation constrained by the recorded Candidate A decision.
-5. [DEFINE_AUTOMATION_SURFACE_AUTHORITY.md](DEFINE_AUTOMATION_SURFACE_AUTHORITY.md) — Automation as a distinct authority lane.
-6. [RECONCILE_CHAT_MUTATION_AUTHORITY.md](RECONCILE_CHAT_MUTATION_AUTHORITY.md) — the keystone decision task.
-7. [STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md](STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md) — the invariant that no surface mutates durable state without governance.
-8. [DEFINE_CANVAS_COEDITING_MODEL.md](DEFINE_CANVAS_COEDITING_MODEL.md) — the co-editing posture, co-authoring vs governance-bearing split, note-as-artifact / session-as-provenance, `.chats/` and `type:` conventions.
-9. [DEFINE_PANEL_AS_THE_PRIMARY_COMMAND_SURFACE.md](DEFINE_PANEL_AS_THE_PRIMARY_COMMAND_SURFACE.md) — compatibility note that Panel is the primary command-oriented surface, not the exclusive authoritative intent surface.
-10. [HYBRID_CHAT_INTEGRATION_SCHEMA.md](HYBRID_CHAT_INTEGRATION_SCHEMA.md) — docs-only schema for how canvas Chat integrates with Panel, session provenance, and governed execution without becoming a second Panel.
+4. [CHAT_FAMILY_TAXONOMY.md](CHAT_FAMILY_TAXONOMY.md) — names the chat-family interaction surfaces (Panel command dialogue, Canvas co-authoring, Retrieval dialogue, Workspace synthesis, Operator console) and the modularity requirement that prevents collapse into a generic chat product.
+5. [DEFINE_CHAT_AUTHORITY_BOUNDARY.md](DEFINE_CHAT_AUTHORITY_BOUNDARY.md) — Chat as canvas-shaped thinking surface, with future mutation constrained by the recorded Candidate A decision.
+6. [DEFINE_AUTOMATION_SURFACE_AUTHORITY.md](DEFINE_AUTOMATION_SURFACE_AUTHORITY.md) — Automation as a distinct authority lane.
+7. [RECONCILE_CHAT_MUTATION_AUTHORITY.md](RECONCILE_CHAT_MUTATION_AUTHORITY.md) — the keystone decision task.
+8. [STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md](STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md) — the invariant that no surface mutates durable state without governance.
+9. [DEFINE_CANVAS_COEDITING_MODEL.md](DEFINE_CANVAS_COEDITING_MODEL.md) — the co-editing posture, co-authoring vs governance-bearing split, note-as-artifact / session-as-provenance, `.chats/` and `type:` conventions.
+10. [DEFINE_PANEL_AS_THE_PRIMARY_COMMAND_SURFACE.md](DEFINE_PANEL_AS_THE_PRIMARY_COMMAND_SURFACE.md) — compatibility note that Panel is the primary command-oriented surface, not the exclusive authoritative intent surface.
+11. [HYBRID_CHAT_INTEGRATION_SCHEMA.md](HYBRID_CHAT_INTEGRATION_SCHEMA.md) — docs-only schema for how canvas Chat integrates with Panel, session provenance, and governed execution without becoming a second Panel.
 
 Tasks 2, 3, 4, 5, and 7 may proceed in parallel as docs drafts. Task 6 (reconcile) depends on tasks 2–5 naming the surfaces consistently and on task 7 stating the gated-execution invariant, because the reconcile task evaluates options against those contracts.
 


### PR DESCRIPTION
## Change Lane
- [ ] Implementation lane
- [x] Docs authoring lane
- [ ] Governance lane

Docs authoring applies only to docs-only changes in approved docs-authoring surfaces. It must not be used for code, runtime behavior, contracts, shipped reality, or implementation writeback.

## Linked Issue

(Docs authoring lane — no linked issue required.)

## Summary

Adds [docs/INTERACTION_SURFACES_AND_AUTHORITY/CHAT_FAMILY_TAXONOMY.md](docs/INTERACTION_SURFACES_AND_AUTHORITY/CHAT_FAMILY_TAXONOMY.md), a docs-only taxonomy that names the system's chat-family interaction surfaces and prevents them from collapsing into one generic chat product.

The taxonomy defines five family members with distinct authority, persistence, and cognitive roles:

- **A. Panel command dialogue** — current runtime; primary command-oriented surface; mutations gated.
- **B. Canvas co-authoring session** — behind `CANVAS_ENABLED`; note-as-artifact, `.chats/` as subordinate provenance; user-presence authorizes active-note body edits, cross-boundary mutations gated.
- **C. Retrieval dialogue** — ASK/RAG-shaped; read-only by default; not the architectural center; mutation requires escalation.
- **D. Workspace synthesis session** — future capability; cross-note writes governance-bearing by definition.
- **E. Operator / agent console** — current dev tooling; not the user-facing PKM surface.

Includes a comparison table, shared family-wide rules, an explicit modularity requirement (Companion UI principle: shared rendering primitives, surface-specific authority/persistence adapters), and guidance against importing generic OSS chat apps (Open WebUI, LibreChat) as the primary Companion UI foundation.

Also updates [docs/INTERACTION_SURFACES_AND_AUTHORITY/README.md](docs/INTERACTION_SURFACES_AND_AUTHORITY/README.md) reading order to insert the new file before `DEFINE_CHAT_AUTHORITY_BOUNDARY.md`, with subsequent items renumbered.

Subordinate to existing authority docs: `DEFINE_CHAT_AUTHORITY_BOUNDARY.md`, `DEFINE_CANVAS_COEDITING_MODEL.md`, `STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md`, and `RECONCILE_CHAT_MUTATION_AUTHORITY.md` (Candidate A stands).

## Docs Authoring Check
- [x] This PR only changes approved docs-authoring surfaces.
- [x] No code, runtime behavior, contracts, or shipped reality changed.
- [x] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Validation

Docs authoring lane:
- [x] Docs/governance checks run as appropriate for the touched surfaces.
- [x] Repo has no `make docs-test` / docs lint target (`make docs` is an echo); no other docs verification command available — stated explicitly.
- [x] README reading-order link to `CHAT_FAMILY_TAXONOMY.md` confirmed via grep; numbering 1–11 verified.
- [x] Cross-checked against existing "Chat is canvas, not ASK" language — taxonomy reaffirms it and does not contradict it.
- [x] Document explicitly avoids claiming new runtime behavior.

## Notes

- Canvas Chat status remains "behind `CANVAS_ENABLED`."
- Workspace synthesis is marked future.
- Hybrid Panel/Chat noted as future work.
- Reviewer confirms: taxonomy does not contradict `DEFINE_CHAT_AUTHORITY_BOUNDARY.md` or `RECONCILE_CHAT_MUTATION_AUTHORITY.md`; no runtime claims introduced; README numbering consistent (1–11).