### PR TITLE
Stabilize test bootstrap runtime wiring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,16 @@
 PYTHON ?= $(shell if [ -x .venv/bin/python ]; then printf '%s' .venv/bin/python; elif command -v python3.12 >/dev/null 2>&1; then command -v python3.12; elif command -v python3 >/dev/null 2>&1; then command -v python3; elif command -v python >/dev/null 2>&1; then command -v python; fi)
 TEST_VAULT_ROOT ?= $(PWD)/vault-test
 TEST_DATABASE_URL ?= postgresql+psycopg://app:app@db:5432/app_test
+TEST_API_BASE_URL ?= http://127.0.0.1:18002
+TEST_LLM_PROVIDER ?= mock
+TEST_LLM_MODEL ?= llama3.1:8b
 SMOKE_WORKERS ?= auto
 SMOKE_E2E_WORKERS ?= 0
 COMPOSE_BASE := docker compose -f docker-compose.yaml
 COMPOSE_DEV := $(COMPOSE_BASE) -f docker-compose.dev.yml -p pkm-dev
 COMPOSE_TEST := $(COMPOSE_BASE) -f docker-compose.test.yml -p pkm-test
 COMPOSE_PROD := $(COMPOSE_BASE) -p pkm-prod
+TEST_COMPOSE_ENV := COMPOSE_FILE=docker-compose.yaml:docker-compose.test.yml COMPOSE_PROJECT_NAME=pkm-test
 
 fmt:
 	rufflehog --version >/dev/null 2>&1 || true
@@ -83,12 +87,14 @@ reset-zero-force:
 	@RESET_FORCE=1 bash scripts/reset_to_zero.sh
 
 start-test-system:
-	@VAULT_ROOT="$(TEST_VAULT_ROOT)" DATABASE_URL="$(TEST_DATABASE_URL)" DB_DSN="$(TEST_DATABASE_URL)" scripts/start_full_system.sh
+	@$(TEST_COMPOSE_ENV) VAULT_ROOT="$(TEST_VAULT_ROOT)" DATABASE_URL="$(TEST_DATABASE_URL)" DB_DSN="$(TEST_DATABASE_URL)" API_BASE_URL="$(TEST_API_BASE_URL)" HEALTH_ENDPOINT="$(TEST_API_BASE_URL)/healthz" LLM_PROVIDER="$(TEST_LLM_PROVIDER)" LLM_MODEL="$(TEST_LLM_MODEL)" scripts/start_full_system.sh
 
-test-bootstrap: reset-zero-force test-vault-init
-	@VAULT_ROOT="$(TEST_VAULT_ROOT)" DATABASE_URL="$(TEST_DATABASE_URL)" DB_DSN="$(TEST_DATABASE_URL)" scripts/start_full_system.sh
-	@VAULT_ROOT="$(TEST_VAULT_ROOT)" DATABASE_URL="$(TEST_DATABASE_URL)" DB_DSN="$(TEST_DATABASE_URL)" bash scripts/verify_runtime_stack.sh
-	@VAULT_ROOT="$(TEST_VAULT_ROOT)" DATABASE_URL="$(TEST_DATABASE_URL)" DB_DSN="$(TEST_DATABASE_URL)" $(PYTHON) -m app.cli uat-run-vault-test --vault-root "$(TEST_VAULT_ROOT)" --assert
+test-bootstrap:
+	@$(TEST_COMPOSE_ENV) RESET_FORCE=1 bash scripts/reset_to_zero.sh
+	@bash scripts/init_test_vault.sh
+	@$(TEST_COMPOSE_ENV) VAULT_ROOT="$(TEST_VAULT_ROOT)" DATABASE_URL="$(TEST_DATABASE_URL)" DB_DSN="$(TEST_DATABASE_URL)" API_BASE_URL="$(TEST_API_BASE_URL)" HEALTH_ENDPOINT="$(TEST_API_BASE_URL)/healthz" LLM_PROVIDER="$(TEST_LLM_PROVIDER)" LLM_MODEL="$(TEST_LLM_MODEL)" VERIFY_RUNTIME_SERVICE_WAIT_SECONDS=30 scripts/start_full_system.sh
+	@$(TEST_COMPOSE_ENV) VAULT_ROOT="$(TEST_VAULT_ROOT)" DATABASE_URL="$(TEST_DATABASE_URL)" DB_DSN="$(TEST_DATABASE_URL)" API_BASE_URL="$(TEST_API_BASE_URL)" LLM_PROVIDER="$(TEST_LLM_PROVIDER)" LLM_MODEL="$(TEST_LLM_MODEL)" VERIFY_RUNTIME_SERVICE_WAIT_SECONDS=30 bash scripts/verify_runtime_stack.sh
+	@$(TEST_COMPOSE_ENV) VAULT_ROOT="$(TEST_VAULT_ROOT)" DATABASE_URL="$(TEST_DATABASE_URL)" DB_DSN="$(TEST_DATABASE_URL)" LLM_PROVIDER="$(TEST_LLM_PROVIDER)" LLM_MODEL="$(TEST_LLM_MODEL)" $(PYTHON) -m app.cli uat-run-vault-test --vault-root "$(TEST_VAULT_ROOT)" --assert
 
 dev-up:
 	@$(COMPOSE_DEV) up -d --build

--- a/scripts/verify_runtime_stack.sh
+++ b/scripts/verify_runtime_stack.sh
@@ -31,12 +31,12 @@ extract_json_payload() {
   python3 -c '
 import sys
 
-text = sys.stdin.read()
-start = text.find("{")
-end = text.rfind("}")
-if start == -1 or end == -1 or end < start:
-    raise SystemExit("health json payload not found in output")
-print(text[start : end + 1])
+lines = [line.strip() for line in sys.stdin.read().splitlines() if line.strip()]
+for line in reversed(lines):
+    if line.startswith("{") and line.endswith("}"):
+        print(line)
+        raise SystemExit(0)
+raise SystemExit("health json payload not found in output")
 '
 }
 


### PR DESCRIPTION
Fixes #829

## Summary
Align the repo-supported test bootstrap path with the explicit test Compose project and test runtime inputs.
Harden runtime verification by extracting the trailing health JSON payload safely from mixed command output.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/ops/test_start_system_outbox_contract.py tests/quality_wave/test_bootstrap_start.py tests/ops/test_test_channel_compose_contract.py`
- `make --dry-run test-bootstrap`

---