### PR TITLE
Ignore local vault and test hygiene artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,8 @@ verification_report.md
 # Local hygiene artifacts
 Archive/Trash/
 tmp-dev/
+vault-test/
+vaults/
+tests/__init__.py
+tests/orientation/__init__.py
+tests/retrieval/__init__.py


### PR DESCRIPTION
## Summary
Ignore repo-local generated test vault and local vault directories so `git status` stays focused on intentional source changes.
Also ignore temporary local `tests/__init__.py` package markers created during local experimentation.

## Validation
- `git check-ignore -v tests/__init__.py tests/orientation/__init__.py tests/retrieval/__init__.py vault-test vaults`
- `git status --short --branch`

---