### PR TITLE
ops: add docker-compose.prod.yml prod safety overlay

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,12 @@
+# Production overlay — makes the Postgres data volume external so
+# `docker compose down` (even without -v) cannot destroy prod data.
+# Usage: docker compose -f docker-compose.yaml -f docker-compose.prod.yml -p pkm-prod up -d
+services:
+  db:
+    volumes:
+      - pgdata_prod:/var/lib/postgresql/data
+
+volumes:
+  pgdata_prod:
+    external: true
+    name: pkm-prod_pgdata


### PR DESCRIPTION
## Summary

- Adds `docker-compose.prod.yml` overlay that declares the Postgres data volume as `external: true`
- Prevents `docker compose down` (with or without `-v`) from destroying prod data
- Volume name: `pkm-prod_pgdata` (already exists on mac mini prod host)

Closes #834

## Usage

```bash
docker compose -f docker-compose.yaml -f docker-compose.prod.yml -p pkm-prod up -d
```

Or via `.env`:
```
COMPOSE_FILE=docker-compose.yaml:docker-compose.prod.yml
```

## Test plan

- [ ] `docker compose -f docker-compose.yaml -f docker-compose.prod.yml config | grep external` → `external: true`
- [ ] Prod stack starts cleanly on mac mini with COMPOSE_FILE set
- [ ] `docker compose -p pkm-prod down` does NOT remove `pkm-prod_pgdata` volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)