### PR TITLE
docs: add PR_INTEGRATION_HARDENING spec directory

### DIFF
--- a/docs/PR_INTEGRATION_HARDENING/ADD_BRANCH_TRUTH_GATE.md
+++ b/docs/PR_INTEGRATION_HARDENING/ADD_BRANCH_TRUTH_GATE.md
@@ -1,0 +1,102 @@
+---
+name: Add Branch Truth Gate
+description: Add a mandatory branch-truth check and per-issue worktree mandate to issue-to-code and pr-integration before any commit/push action.
+task_id: PIH-02
+source_anchor: docs/learning-log.md :: 2026-05-07 — #775
+parent_capability: PR_INTEGRATION_HARDENING
+prerequisites: []
+depends_on: []
+can_parallelize_with: [ADD_PLUGIN_LOAD_GUARD]
+---
+
+# Add Branch Truth Gate
+
+## Purpose
+
+During PR #796/#775 delivery, commits repeatedly landed on unrelated local branches because edits and commits were run from the shared root worktree where the active branch context had silently changed. This happens in multi-agent parallel work when an agent reuses the root worktree for a PR that is not on the root worktree's branch.
+
+## What This Task Does
+
+1. Adds a mandatory **branch-truth gate** step to `.codex/skills/issue-to-code/SKILL.md` (before any `git add/commit/push` action) that requires:
+   - `git branch --show-current` must equal the expected PR head branch name.
+   - `git rev-parse HEAD` must equal the head SHA reported by `gh pr view <PR> --json headRefOid`.
+   If either check fails, the agent must stop and switch to the correct worktree before continuing.
+
+2. Adds the same gate as a required preflight step to `.codex/skills/pr-integration/SKILL.md` (in its existing "Workspace Isolation Gate" section or as an addition to it), with the additional rule: **for active PRs in multi-agent parallel work, a dedicated per-issue worktree is mandatory for the full issue lifecycle (implementation through review-fix); committing from the shared root worktree for an active PR is prohibited.**
+
+## Concretely
+
+**issue-to-code/SKILL.md** addition (before the first commit action):
+
+```
+### Branch-Truth Gate (mandatory before any git add/commit/push)
+
+```bash
+EXPECTED_BRANCH="<PR head branch name>"
+ACTUAL_BRANCH=$(git branch --show-current)
+PR_HEAD_SHA=$(gh pr view <PR_NUMBER> --json headRefOid --jq '.headRefOid')
+LOCAL_HEAD=$(git rev-parse HEAD)
+
+if [ "$ACTUAL_BRANCH" != "$EXPECTED_BRANCH" ] || [ "$LOCAL_HEAD" != "$PR_HEAD_SHA" ]; then
+  echo "BRANCH-TRUTH GATE FAILED: on $ACTUAL_BRANCH (expected $EXPECTED_BRANCH), HEAD=$LOCAL_HEAD (PR head=$PR_HEAD_SHA)"
+  echo "Switch to the correct worktree before committing."
+  exit 1
+fi
+```
+
+Both conditions must pass. If either fails: stop, switch worktree, re-run gate.
+
+For multi-agent parallel work: use a dedicated per-issue worktree (via `git worktree add`) for the full lifecycle — from initial implementation through every review-fix push. Do NOT commit to an active PR from the shared root worktree.
+[branch-truth-gate]
+```
+
+**pr-integration/SKILL.md** addition (to the existing Workspace Isolation Gate section):
+
+```
+Additionally, before any review-fix commit or push:
+- Confirm `git branch --show-current` equals the PR head branch.
+- Confirm `git rev-parse HEAD` equals the PR `headRefOid` reported by `gh pr view`.
+- For multi-agent parallel work, a per-issue worktree is mandatory. The shared root worktree must not be used to commit to an active PR.
+[branch-truth-gate]
+```
+
+## Why This Matters
+
+Commits landing on the wrong branch are hard to detect until CI fails on the intended PR. A branch-truth gate makes the error loud and immediate, preventing silent drift that causes CI-only failures hours later.
+
+## Acceptance Criteria
+
+- [ ] `.codex/skills/issue-to-code/SKILL.md` contains a branch-truth gate block with both the `git branch --show-current` and `git rev-parse HEAD` equality checks, labeled `[branch-truth-gate]`.
+  Verify: doc writeback at `.codex/skills/issue-to-code/SKILL.md :: branch-truth-gate`
+- [ ] `.codex/skills/issue-to-code/SKILL.md` states that per-issue worktrees are mandatory for multi-agent parallel work.
+  Verify: doc writeback at `.codex/skills/issue-to-code/SKILL.md :: branch-truth-gate`
+- [ ] `.codex/skills/pr-integration/SKILL.md` Workspace Isolation Gate section contains the branch-truth confirmation steps and the per-issue worktree mandate, labeled `[branch-truth-gate]`.
+  Verify: doc writeback at `.codex/skills/pr-integration/SKILL.md :: branch-truth-gate`
+
+## How to Verify (Pre-Merge)
+
+```bash
+grep -n "branch-truth-gate" .codex/skills/issue-to-code/SKILL.md
+grep -n "branch-truth-gate" .codex/skills/pr-integration/SKILL.md
+grep -n "per-issue worktree" .codex/skills/issue-to-code/SKILL.md
+```
+
+All commands must return hits. Confirm the gate block contains both equality checks.
+
+## Out of Scope
+
+- Automating worktree creation — the mandate is doctrinal, not enforced by a script.
+- Adding the gate to skills other than `issue-to-code` and `pr-integration`.
+- Changing `scripts/agent_workspace_preflight.sh` (that script is out of scope here).
+
+## Related Docs
+
+- [.codex/skills/issue-to-code/SKILL.md](../../.codex/skills/issue-to-code/SKILL.md)
+- [.codex/skills/pr-integration/SKILL.md](../../.codex/skills/pr-integration/SKILL.md)
+- [docs/learning-log.md](../learning-log.md) (entry 2026-05-07 — #775)
+- [docs/PR_INTEGRATION_HARDENING/README.md](README.md)
+
+## Related GitHub Issues
+
+Create one bounded governance issue: `[PR-Integration-Hardening] add-branch-truth-gate: mandate branch check before commit/push`.
+Label: `lane:governance`, `agent:ready`, `Status=Ready`.

--- a/docs/PR_INTEGRATION_HARDENING/ADD_BRANCH_TRUTH_GATE.md
+++ b/docs/PR_INTEGRATION_HARDENING/ADD_BRANCH_TRUTH_GATE.md
@@ -6,7 +6,7 @@ source_anchor: docs/learning-log.md :: 2026-05-07 — #775
 parent_capability: PR_INTEGRATION_HARDENING
 prerequisites: []
 depends_on: []
-can_parallelize_with: [ADD_PLUGIN_LOAD_GUARD]
+can_parallelize_with: []
 ---
 
 # Add Branch Truth Gate
@@ -17,10 +17,10 @@ During PR #796/#775 delivery, commits repeatedly landed on unrelated local branc
 
 ## What This Task Does
 
-1. Adds a mandatory **branch-truth gate** step to `.codex/skills/issue-to-code/SKILL.md` (before any `git add/commit/push` action) that requires:
-   - `git branch --show-current` must equal the expected PR head branch name.
-   - `git rev-parse HEAD` must equal the head SHA reported by `gh pr view <PR> --json headRefOid`.
-   If either check fails, the agent must stop and switch to the correct worktree before continuing.
+1. Adds a **branch-truth gate** to `.codex/skills/issue-to-code/SKILL.md` in two phases:
+   - **Pre-commit** (before `git add/commit`): verify `git branch --show-current` equals the expected PR head branch name. A local commit advances HEAD beyond the remote PR ref, so the SHA-equality check does not apply here.
+   - **Pre-push** (after local commit, before `git push`): verify both that `git branch --show-current` still equals the expected branch AND that `git rev-parse HEAD` is the commit intended for the PR branch.
+   If the branch-name check fails at either phase, the agent must stop and switch to the correct worktree before continuing.
 
 2. Adds the same gate as a required preflight step to `.codex/skills/pr-integration/SKILL.md` (in its existing "Workspace Isolation Gate" section or as an addition to it), with the additional rule: **for active PRs in multi-agent parallel work, a dedicated per-issue worktree is mandatory for the full issue lifecycle (implementation through review-fix); committing from the shared root worktree for an active PR is prohibited.**
 
@@ -29,22 +29,35 @@ During PR #796/#775 delivery, commits repeatedly landed on unrelated local branc
 **issue-to-code/SKILL.md** addition (before the first commit action):
 
 ```
-### Branch-Truth Gate (mandatory before any git add/commit/push)
+### Branch-Truth Gate — Phase 1: Pre-Commit (mandatory before git add/commit)
 
 ```bash
 EXPECTED_BRANCH="<PR head branch name>"
 ACTUAL_BRANCH=$(git branch --show-current)
-PR_HEAD_SHA=$(gh pr view <PR_NUMBER> --json headRefOid --jq '.headRefOid')
-LOCAL_HEAD=$(git rev-parse HEAD)
 
-if [ "$ACTUAL_BRANCH" != "$EXPECTED_BRANCH" ] || [ "$LOCAL_HEAD" != "$PR_HEAD_SHA" ]; then
-  echo "BRANCH-TRUTH GATE FAILED: on $ACTUAL_BRANCH (expected $EXPECTED_BRANCH), HEAD=$LOCAL_HEAD (PR head=$PR_HEAD_SHA)"
+if [ "$ACTUAL_BRANCH" != "$EXPECTED_BRANCH" ]; then
+  echo "BRANCH-TRUTH GATE FAILED (pre-commit): on $ACTUAL_BRANCH (expected $EXPECTED_BRANCH)"
   echo "Switch to the correct worktree before committing."
   exit 1
 fi
 ```
 
-Both conditions must pass. If either fails: stop, switch worktree, re-run gate.
+Branch name must match. Do not check the remote PR head SHA here — a new local commit will advance HEAD past the remote ref before push.
+
+### Branch-Truth Gate — Phase 2: Pre-Push (mandatory before git push)
+
+```bash
+EXPECTED_BRANCH="<PR head branch name>"
+ACTUAL_BRANCH=$(git branch --show-current)
+
+if [ "$ACTUAL_BRANCH" != "$EXPECTED_BRANCH" ]; then
+  echo "BRANCH-TRUTH GATE FAILED (pre-push): on $ACTUAL_BRANCH (expected $EXPECTED_BRANCH)"
+  exit 1
+fi
+echo "Branch-truth gate passed — pushing to origin/$EXPECTED_BRANCH"
+```
+
+If branch name fails at pre-push: stop, switch worktree, re-run both phases.
 
 For multi-agent parallel work: use a dedicated per-issue worktree (via `git worktree add`) for the full lifecycle — from initial implementation through every review-fix push. Do NOT commit to an active PR from the shared root worktree.
 [branch-truth-gate]
@@ -54,8 +67,8 @@ For multi-agent parallel work: use a dedicated per-issue worktree (via `git work
 
 ```
 Additionally, before any review-fix commit or push:
-- Confirm `git branch --show-current` equals the PR head branch.
-- Confirm `git rev-parse HEAD` equals the PR `headRefOid` reported by `gh pr view`.
+- Before committing: confirm `git branch --show-current` equals the PR head branch.
+- Before pushing: confirm `git branch --show-current` still equals the PR head branch (do not compare HEAD SHA to the remote PR headRefOid here — the local commit has already advanced HEAD past the remote ref).
 - For multi-agent parallel work, a per-issue worktree is mandatory. The shared root worktree must not be used to commit to an active PR.
 [branch-truth-gate]
 ```
@@ -66,7 +79,7 @@ Commits landing on the wrong branch are hard to detect until CI fails on the int
 
 ## Acceptance Criteria
 
-- [ ] `.codex/skills/issue-to-code/SKILL.md` contains a branch-truth gate block with both the `git branch --show-current` and `git rev-parse HEAD` equality checks, labeled `[branch-truth-gate]`.
+- [ ] `.codex/skills/issue-to-code/SKILL.md` contains a two-phase branch-truth gate block (pre-commit: branch name check; pre-push: branch name check), labeled `[branch-truth-gate]`.
   Verify: doc writeback at `.codex/skills/issue-to-code/SKILL.md :: branch-truth-gate`
 - [ ] `.codex/skills/issue-to-code/SKILL.md` states that per-issue worktrees are mandatory for multi-agent parallel work.
   Verify: doc writeback at `.codex/skills/issue-to-code/SKILL.md :: branch-truth-gate`
@@ -81,7 +94,7 @@ grep -n "branch-truth-gate" .codex/skills/pr-integration/SKILL.md
 grep -n "per-issue worktree" .codex/skills/issue-to-code/SKILL.md
 ```
 
-All commands must return hits. Confirm the gate block contains both equality checks.
+All commands must return hits. Confirm the gate block contains the two-phase split (pre-commit: branch name only; pre-push: branch name).
 
 ## Out of Scope
 

--- a/docs/PR_INTEGRATION_HARDENING/ADD_MERGE_REF_VALIDATION.md
+++ b/docs/PR_INTEGRATION_HARDENING/ADD_MERGE_REF_VALIDATION.md
@@ -1,0 +1,102 @@
+---
+name: Add Merge-Ref Validation
+description: Add an explicit merge-ref fetch-and-verify step to pr-integration after any review-fix push.
+task_id: PIH-03
+source_anchor: docs/learning-log.md :: 2026-05-07 — PR #800
+parent_capability: PR_INTEGRATION_HARDENING
+prerequisites: [PIH-02]
+depends_on: [ADD_BRANCH_TRUTH_GATE.md]
+can_parallelize_with: []
+---
+
+# Add Merge-Ref Validation
+
+## Purpose
+
+PR #800 had a `NameError` on the CI merge-ref that was invisible on the branch HEAD, because the merge-ref was assembled by GitHub from a base that diverged during conflict churn. Validating only the branch HEAD gave a false green before merge.
+
+## What This Task Does
+
+Adds a **merge-ref validation step** to `.codex/skills/pr-integration/SKILL.md` that runs after any review-fix push and before the skill declares `ready-for-verification`. The step:
+
+1. Fetches `refs/pull/<PR_NUMBER>/merge` from origin.
+2. Checks out that ref in a temporary detached state (or uses `git fetch` + `git show`).
+3. Inspects touched symbols in that tree — specifically verifies that import sites and call sites for any symbols changed in the review-fix are consistent in the merge-ref, not only on the branch HEAD.
+4. Runs at least one target test from the PR's test suite against the merge-ref tree.
+5. If step 3 or 4 fails, the skill must report `blocked-ci-failure` and require another fix push rather than declaring ready.
+
+## Concretely
+
+**pr-integration/SKILL.md** addition (after the review-fix push section, before the exit-condition checklist):
+
+```
+### Merge-Ref Validation (mandatory after any review-fix push)
+
+After pushing a review-fix, GitHub assembles a merge-ref at `refs/pull/<PR_NUMBER>/merge`.
+Branch HEAD may be clean while the merge-ref carries a divergent context that causes CI-only failures.
+
+```bash
+PR_NUMBER=<PR_NUMBER>
+git fetch origin refs/pull/${PR_NUMBER}/merge:refs/merge_validation
+git checkout refs/merge_validation -- . 2>/dev/null || git show refs/merge_validation:<changed_file> | head -50
+```
+
+Then run a targeted smoke check against the merge-ref tree:
+
+```bash
+# Example: confirm the key symbol exists and is importable in the merge-ref tree
+git show refs/merge_validation:app/<changed_module>.py | grep -n "<changed_symbol>"
+
+# Run at least one target test against the merge-ref
+git stash  # preserve branch HEAD
+git checkout refs/merge_validation
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/<relevant_test_file>.py -k "<key_test>"
+git checkout -  # return to branch HEAD
+git stash pop
+```
+
+If the test fails or the symbol is absent in the merge-ref:
+- Do NOT declare `ready-for-verification`.
+- Report `blocked-ci-failure` with the merge-ref tree context.
+- Push a corrective fix to the branch and repeat this step.
+[merge-ref-validation]
+```
+
+## Why This Matters
+
+Declaring a PR ready based only on branch HEAD is insufficient when the merge-ref differs. CI fails on a tree that the agent never validated, creating a CI-only failure mode that is hard to diagnose and forces another integration loop.
+
+## Acceptance Criteria
+
+- [ ] `.codex/skills/pr-integration/SKILL.md` contains a merge-ref validation section, labeled `[merge-ref-validation]`, after the review-fix push section.
+  Verify: doc writeback at `.codex/skills/pr-integration/SKILL.md :: merge-ref-validation`
+- [ ] The section specifies: fetch `refs/pull/<PR>/merge`, inspect touched symbols in that tree, run at least one target test against it, and block on failure.
+  Verify: doc writeback at `.codex/skills/pr-integration/SKILL.md :: merge-ref-validation`
+
+## How to Verify (Pre-Merge)
+
+```bash
+grep -n "merge-ref-validation\|refs/pull.*merge" .codex/skills/pr-integration/SKILL.md
+```
+
+Must return at least one hit for the anchor label and at least one hit for the fetch command pattern.
+
+Confirm the section appears after any review-fix section and before the exit-condition checklist.
+
+## Out of Scope
+
+- Automating the merge-ref fetch in CI (the validation is a skill-level manual step).
+- Validating merge-refs in skills other than `pr-integration`.
+- Changing GitHub Actions workflows.
+
+## Related Docs
+
+- [.codex/skills/pr-integration/SKILL.md](../../.codex/skills/pr-integration/SKILL.md)
+- [docs/learning-log.md](../learning-log.md) (entry 2026-05-07 — PR #800)
+- [docs/PR_INTEGRATION_HARDENING/README.md](README.md)
+
+## Related GitHub Issues
+
+Create one bounded governance issue: `[PR-Integration-Hardening] add-merge-ref-validation: verify merge-ref tree after review-fix push`.
+Label: `lane:governance`, `agent:ready`, `Status=Ready`.
+Sequence after PIH-02 issue closes to avoid `pr-integration/SKILL.md` diff conflicts.

--- a/docs/PR_INTEGRATION_HARDENING/ADD_MERGE_REF_VALIDATION.md
+++ b/docs/PR_INTEGRATION_HARDENING/ADD_MERGE_REF_VALIDATION.md
@@ -38,21 +38,20 @@ Branch HEAD may be clean while the merge-ref carries a divergent context that ca
 ```bash
 PR_NUMBER=<PR_NUMBER>
 git fetch origin refs/pull/${PR_NUMBER}/merge:refs/merge_validation
-git checkout refs/merge_validation -- . 2>/dev/null || git show refs/merge_validation:<changed_file> | head -50
+
+# Inspect touched symbols using git show — do NOT checkout into the active worktree
+git show refs/merge_validation:app/<changed_module>.py | grep -n "<changed_symbol>"
 ```
 
-Then run a targeted smoke check against the merge-ref tree:
+Do not use `git checkout refs/merge_validation -- .`: that mutates the active working tree and index, leaving the PR branch dirty and risking accidental commits.
+
+Then run a targeted smoke check in a **temporary separate worktree** to avoid touching the active branch state:
 
 ```bash
-# Example: confirm the key symbol exists and is importable in the merge-ref tree
-git show refs/merge_validation:app/<changed_module>.py | grep -n "<changed_symbol>"
-
-# Run at least one target test against the merge-ref
-git stash  # preserve branch HEAD
-git checkout refs/merge_validation
-PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/<relevant_test_file>.py -k "<key_test>"
-git checkout -  # return to branch HEAD
-git stash pop
+MERGE_WORKTREE=$(mktemp -d)
+git worktree add --detach "$MERGE_WORKTREE" refs/merge_validation
+(cd "$MERGE_WORKTREE" && PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/<relevant_test_file>.py -k "<key_test>")
+git worktree remove --force "$MERGE_WORKTREE"
 ```
 
 If the test fails or the symbol is absent in the merge-ref:

--- a/docs/PR_INTEGRATION_HARDENING/ADD_PLUGIN_LOAD_GUARD.md
+++ b/docs/PR_INTEGRATION_HARDENING/ADD_PLUGIN_LOAD_GUARD.md
@@ -1,0 +1,88 @@
+---
+name: Add Plugin Load Guard
+description: Add a caution about explicit pytest plugin loading to docs/TESTING.md and the pr-integration skill CI triage section.
+task_id: PIH-01
+source_anchor: docs/learning-log.md :: 2026-05-06 — #783
+parent_capability: PR_INTEGRATION_HARDENING
+prerequisites: []
+depends_on: []
+can_parallelize_with: [ADD_BRANCH_TRUTH_GATE]
+---
+
+# Add Plugin Load Guard
+
+## Purpose
+
+When `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` is set, pytest flags provided by plugins (e.g. `-n`/`--dist` from `pytest-xdist`) silently fail or error unless the plugin is explicitly loaded via `-p <plugin_name>`. This was discovered during PR #783 and was not documented anywhere in the repo.
+
+## What This Task Does
+
+1. Adds a caution block to `docs/TESTING.md` explaining that plugin-provided pytest flags require explicit plugin loading when `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` is active, with a concrete example for `xdist`.
+2. Adds a short CI triage note to `.codex/skills/pr-integration/SKILL.md` (in its CI failure triage section) so agents diagnosing a "flag not recognised" or "no such option" CI failure know to check for missing explicit plugin load before adding dependencies.
+
+## Concretely
+
+**docs/TESTING.md** addition (under the relevant pytest invocation section):
+
+```
+> **Plugin-load guard:** When `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` is set, flags provided by
+> plugins are not available unless the plugin is also explicitly loaded with `-p <plugin_name>`.
+> For example, to use `pytest-xdist` with autoload disabled:
+> ```
+> PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p xdist.plugin -n auto ...
+> ```
+> Do not assume installing a plugin is sufficient — verify the flag resolves with an explicit
+> `-p` load if autoload is disabled.
+```
+
+**.codex/skills/pr-integration/SKILL.md** CI triage addition:
+
+```
+- If CI reports "unrecognised option" or "no such option" for a pytest flag that corresponds to
+  an installed plugin, check whether `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` is set and the plugin
+  is not explicitly loaded. Add `-p <plugin_name>` to the pytest invocation.
+  [plugin-load-guard]
+```
+
+## Why This Matters
+
+Without this guard, an agent diagnosing a CI failure on a flag like `-n`/`--dist` will try adding/upgrading the dependency instead of adding the `-p` load, wasting CI cycles and potentially introducing unneeded dependency changes.
+
+## Acceptance Criteria
+
+- [ ] `docs/TESTING.md` contains a caution block about explicit plugin loading under `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` with a concrete xdist example.
+  Verify: doc writeback at `docs/TESTING.md :: plugin-load-guard`
+- [ ] `.codex/skills/pr-integration/SKILL.md` CI triage section contains the `[plugin-load-guard]` note.
+  Verify: doc writeback at `.codex/skills/pr-integration/SKILL.md :: plugin-load-guard`
+
+## How to Verify (Pre-Merge)
+
+```bash
+grep -n "plugin-load-guard\|PYTEST_DISABLE_PLUGIN_AUTOLOAD" docs/TESTING.md
+grep -n "plugin-load-guard\|PYTEST_DISABLE_PLUGIN_AUTOLOAD" .codex/skills/pr-integration/SKILL.md
+```
+
+Both commands must return at least one hit. Confirm the text matches the spec above.
+
+Run the repo docs validation check:
+```bash
+python scripts/docs_guard.py 2>/dev/null || echo "no docs guard"
+```
+
+## Out of Scope
+
+- Changing any pytest invocation in CI workflows.
+- Adding `-p xdist.plugin` to any existing test commands.
+- Documenting any plugins other than xdist as the concrete example.
+
+## Related Docs
+
+- [docs/TESTING.md](../TESTING.md)
+- [.codex/skills/pr-integration/SKILL.md](../../.codex/skills/pr-integration/SKILL.md)
+- [docs/learning-log.md](../learning-log.md) (entry 2026-05-06 — #783)
+- [docs/PR_INTEGRATION_HARDENING/README.md](README.md)
+
+## Related GitHub Issues
+
+Create one bounded governance issue: `[PR-Integration-Hardening] add-plugin-load-guard: document xdist explicit load requirement`.
+Label: `lane:governance`, `agent:ready`, `Status=Ready`.

--- a/docs/PR_INTEGRATION_HARDENING/ADD_PLUGIN_LOAD_GUARD.md
+++ b/docs/PR_INTEGRATION_HARDENING/ADD_PLUGIN_LOAD_GUARD.md
@@ -6,7 +6,7 @@ source_anchor: docs/learning-log.md :: 2026-05-06 — #783
 parent_capability: PR_INTEGRATION_HARDENING
 prerequisites: []
 depends_on: []
-can_parallelize_with: [ADD_BRANCH_TRUTH_GATE]
+can_parallelize_with: []
 ---
 
 # Add Plugin Load Guard
@@ -74,6 +74,11 @@ python scripts/docs_guard.py 2>/dev/null || echo "no docs guard"
 - Changing any pytest invocation in CI workflows.
 - Adding `-p xdist.plugin` to any existing test commands.
 - Documenting any plugins other than xdist as the concrete example.
+
+## Constraints
+
+- Touch only `docs/TESTING.md` and `.codex/skills/pr-integration/SKILL.md`.
+- Must complete and merge before PIH-02 begins — all three tasks touch `pr-integration/SKILL.md` and must be serialized.
 
 ## Related Docs
 

--- a/docs/PR_INTEGRATION_HARDENING/README.md
+++ b/docs/PR_INTEGRATION_HARDENING/README.md
@@ -32,13 +32,13 @@ Add three concrete hardening steps to the integration and implementation lane sk
 
 ## Execution order
 
-Tasks are independent and can be parallelized. Suggested order to avoid skill file conflicts:
+All three tasks touch `.codex/skills/pr-integration/SKILL.md` and must be serialized to avoid diff conflicts:
 
-1. `ADD_PLUGIN_LOAD_GUARD` (touches `docs/TESTING.md` only — no skill overlap)
-2. `ADD_BRANCH_TRUTH_GATE` (touches `issue-to-code/SKILL.md` + `pr-integration/SKILL.md`)
-3. `ADD_MERGE_REF_VALIDATION` (touches `pr-integration/SKILL.md` only — sequence after 2 to avoid conflict)
+1. `ADD_PLUGIN_LOAD_GUARD` — touches `docs/TESTING.md` + `pr-integration/SKILL.md`
+2. `ADD_BRANCH_TRUTH_GATE` — touches `issue-to-code/SKILL.md` + `pr-integration/SKILL.md`; sequence after 1
+3. `ADD_MERGE_REF_VALIDATION` — touches `pr-integration/SKILL.md` only; sequence after 2
 
-Tasks 1 and 2 can run in parallel. Task 3 should follow task 2 to avoid diff conflicts in the same skill file.
+No two tasks may be worked in parallel. Each must merge before the next is picked up.
 
 ## GitHub issues
 

--- a/docs/PR_INTEGRATION_HARDENING/README.md
+++ b/docs/PR_INTEGRATION_HARDENING/README.md
@@ -1,0 +1,78 @@
+State: Specification. Active — parent issue #835, implementation issues #836 #837 #838.
+Doc role: Capability specification
+Authority: Feature specification; governed by docs/development/DEV_WORKFLOW.md
+Owner: docs/development/DEV_WORKFLOW.md
+Source: docs/learning-log.md (entries 2026-05-06 through 2026-05-07)
+
+# PR Integration Hardening
+
+Three divergences logged after the 2026-05-06 retrospective all point at the same surface: the `pr-integration` skill (and its upstream neighbor `issue-to-code`) lacks explicit guards against the most common failure modes encountered in recent delivery. This capability repairs those gaps.
+
+## Capability intent
+
+Add three concrete hardening steps to the integration and implementation lane skills and supporting docs:
+
+1. **Plugin-load guard** — document that pytest flags provided by plugins (e.g. `-n`/`--dist` from `pytest-xdist`) require explicit plugin loading when `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` is set; add this caution to `docs/TESTING.md` and to the `pr-integration` skill CI triage section.
+2. **Branch-truth gate** — mandate a hard branch-truth check (`git branch --show-current` + PR head SHA equality) before any `git add/commit/push` in `issue-to-code` and `pr-integration`; mandate a per-issue worktree for the full issue lifecycle in multi-agent work.
+3. **Merge-ref validation** — add an explicit post-push merge-ref fetch-and-verify step to `pr-integration`: after review-fix pushes, fetch `pull/<id>/merge`, inspect touched symbols, and run at least one target test against that tree before declaring PR ready.
+
+## Source entries
+
+| Entry date | Issue/PR | Upstream artifact |
+|---|---|---|
+| 2026-05-06 | #783 | `docs/TESTING.md` + `pr-integration/SKILL.md` |
+| 2026-05-07 | #775 | `issue-to-code/SKILL.md` + `pr-integration/SKILL.md` |
+| 2026-05-07 | PR #800 | `pr-integration/SKILL.md` |
+
+## Specification files
+
+- [ADD_PLUGIN_LOAD_GUARD.md](ADD_PLUGIN_LOAD_GUARD.md) — xdist explicit-load caution in TESTING.md + pr-integration
+- [ADD_BRANCH_TRUTH_GATE.md](ADD_BRANCH_TRUTH_GATE.md) — branch-truth gate + worktree isolation mandate in issue-to-code + pr-integration
+- [ADD_MERGE_REF_VALIDATION.md](ADD_MERGE_REF_VALIDATION.md) — merge-ref validation step in pr-integration
+
+## Execution order
+
+Tasks are independent and can be parallelized. Suggested order to avoid skill file conflicts:
+
+1. `ADD_PLUGIN_LOAD_GUARD` (touches `docs/TESTING.md` only — no skill overlap)
+2. `ADD_BRANCH_TRUTH_GATE` (touches `issue-to-code/SKILL.md` + `pr-integration/SKILL.md`)
+3. `ADD_MERGE_REF_VALIDATION` (touches `pr-integration/SKILL.md` only — sequence after 2 to avoid conflict)
+
+Tasks 1 and 2 can run in parallel. Task 3 should follow task 2 to avoid diff conflicts in the same skill file.
+
+## GitHub issues
+
+| Task | Issue |
+|---|---|
+| Parent feature | [#835](https://github.com/RasmusTho/agentic-pkm-mvp/issues/835) |
+| PIH-01: Add Plugin Load Guard | [#836](https://github.com/RasmusTho/agentic-pkm-mvp/issues/836) — `agent:ready` |
+| PIH-02: Add Branch Truth Gate | [#837](https://github.com/RasmusTho/agentic-pkm-mvp/issues/837) — `agent:ready` |
+| PIH-03: Add Merge-Ref Validation | [#838](https://github.com/RasmusTho/agentic-pkm-mvp/issues/838) — blocked on #837 |
+
+## Acceptance criteria
+
+- [ ] `docs/TESTING.md` contains a caution about explicit plugin loading under `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`.
+  Verify: doc writeback at `docs/TESTING.md :: plugin-load-guard`
+- [ ] `pr-integration/SKILL.md` contains a CI triage note about plugin-provided flags requiring explicit load.
+  Verify: doc writeback at `.codex/skills/pr-integration/SKILL.md :: plugin-load-guard`
+- [ ] `issue-to-code/SKILL.md` contains a branch-truth gate step before any commit action.
+  Verify: doc writeback at `.codex/skills/issue-to-code/SKILL.md :: branch-truth-gate`
+- [ ] `pr-integration/SKILL.md` contains a merge-ref fetch-and-verify step after review-fix pushes.
+  Verify: doc writeback at `.codex/skills/pr-integration/SKILL.md :: merge-ref-validation`
+- [ ] `docs/learning-log.md` retro marker appended after all three tasks merge.
+  Verify: retro marker entry in `docs/learning-log.md` referencing this capability.
+
+## Validation / acceptance path
+
+After all three implementation issues close:
+
+1. Manually confirm the four skill/doc changes are present in the merged state.
+2. Observe adoption over the next 2–3 deliveries to confirm the guards prevent recurrence.
+3. Append the retro marker to `docs/learning-log.md`.
+4. Close the parent feature issue.
+
+Owner-doc promotion: not required — this capability repairs skill/doc text, not shipped product behavior.
+
+## Change lane
+
+Governance lane — all changes stay within `.codex/skills/**` and `docs/**`.


### PR DESCRIPTION
## Summary

- Adds `docs/PR_INTEGRATION_HARDENING/` specification directory with README + 3 task files.
- Converts 3 unretro'd learning-log entries (2026-05-06–07) into bounded governance repair tasks before backlog execution.
- Files parent feature issue [#835](https://github.com/RasmusTho/agentic-pkm-mvp/issues/835) and implementation issues [#836](https://github.com/RasmusTho/agentic-pkm-mvp/issues/836) / [#837](https://github.com/RasmusTho/agentic-pkm-mvp/issues/837) / [#838](https://github.com/RasmusTho/agentic-pkm-mvp/issues/838).

## Change Lane

- [x] Docs authoring lane — changes limited to `docs/**`; no code, runtime behavior, or shipped reality changed.

## Test plan

- [ ] `grep` for the spec directory in merged state: `ls docs/PR_INTEGRATION_HARDENING/`
- [ ] Confirm all 4 files (README + 3 tasks) are present.
- [ ] Confirm GitHub issues #835–#838 exist and reference back to the spec directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)