### PR TITLE
Fix prod and test compose overlay drift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ SMOKE_E2E_WORKERS ?= 0
 COMPOSE_BASE := docker compose -f docker-compose.yaml
 COMPOSE_DEV := $(COMPOSE_BASE) -f docker-compose.dev.yml -p pkm-dev
 COMPOSE_TEST := $(COMPOSE_BASE) -f docker-compose.test.yml -p pkm-test
-COMPOSE_PROD := $(COMPOSE_BASE) -p pkm-prod
+COMPOSE_PROD := $(COMPOSE_BASE) -f docker-compose.prod.yml -p pkm-prod
 TEST_COMPOSE_ENV := COMPOSE_FILE=docker-compose.yaml:docker-compose.test.yml COMPOSE_PROJECT_NAME=pkm-test
 
 fmt:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,16 @@
+# Production overlay — makes the Postgres data volume external so
+# `docker compose down` (even without -v) cannot destroy prod data.
+# Usage: docker compose -f docker-compose.yaml -f docker-compose.prod.yml -p pkm-prod up -d
+services:
+  api:
+    environment:
+      API_HEALTHCHECK_URL: http://host.docker.internal:18000/healthz
+
+  db:
+    volumes:
+      - pgdata_prod:/var/lib/postgresql/data
+
+volumes:
+  pgdata_prod:
+    external: true
+    name: pkm-prod_pgdata

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,10 +5,15 @@ services:
     ports: !override
       - "15434:5432"
 
+  ollama:
+    ports: !override
+      - "11435:11434"
+
   api:
     ports: !override
       - "18002:8000"
     environment:
+      API_HEALTHCHECK_URL: http://host.docker.internal:18002/healthz
       PKM_ENVIRONMENT: prod
       DATABASE_URL: postgresql+psycopg://app:app@db:5432/app_test
       DB_DSN: postgresql+psycopg://app:app@db:5432/app_test


### PR DESCRIPTION
Fixes #845

## Summary
Add the prod compose overlay that is currently required on mac mini and bring the test overlay in main up to the working state used by the `pkm-test` stack.

## Validation
- `diff -u docker-compose.prod.yml /Users/rasmus/workspace-prod/docker-compose.prod.yml`
- `diff -u docker-compose.test.yml /Users/rasmus/workspace-test/docker-compose.test.yml`
- `docker compose -f docker-compose.yaml -f docker-compose.prod.yml config | grep -A5 pgdata`
- `docker compose -f docker-compose.yaml -f docker-compose.test.yml config | grep -n '11435\\|18002\\|15434\\|API_HEALTHCHECK_URL'`

## Notes
- Issue text said `PKM_ENVIRONMENT` should be corrected to `test`, but the live working test overlay keeps `PKM_ENVIRONMENT: prod` because the current code only accepts `dev` or `prod`.
- The test overlay also includes the Ollama host-port remap to `11435` and the API healthcheck override required by the live mac mini runtime.