### PR TITLE
fix: switch pytest to importlib mode to resolve test basename collision

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,7 @@ testpaths =
     tests
     dev/tests
 pythonpath = .
-addopts = -p faulthandler
+addopts = -p faulthandler --import-mode=importlib
 markers =
     integration: tests that require Postgres
     pg: store-contract tests that require Postgres backend


### PR DESCRIPTION
Fixes #832

## Summary

Pytest collection was crashing with `import file mismatch` errors because multiple test subdirectories share files with identical basenames (e.g. four copies of `test_context_dimension_threading.py`, two copies of `test_write_guard.py`). Under pytest's default `prepend` import mode, this causes a fatal collision.

Adding `--import-mode=importlib` to `addopts` in `pytest.ini` resolves this without requiring `__init__.py` in every `tests/` subdirectory.

## Validation

- `pytest --collect-only tests/` → **0 errors, 2675 tests collected** (was 2 errors, 2670 collected)
- `test_context_dimension_threading` appears **5 times** in collected output (≥4 required)
- `tests/smoke/` → **2 passed**

## Note
Dispatcher unavailable (db_exists: false) — used GitHub-label-only claim.