### PR TITLE
docs(governance): add plugin-load-guard for xdist under PYTEST_DISABLE_PLUGIN_AUTOLOAD=1

### DIFF
--- a/.codex/skills/pr-integration/SKILL.md
+++ b/.codex/skills/pr-integration/SKILL.md
@@ -324,6 +324,10 @@ fi
 **If any check fails:**
 
 1. **Analyze failure:** Review log URLs and determine if fixable within Issue scope
+   - If CI reports "unrecognised option" or "no such option" for a pytest flag that corresponds to
+     an installed plugin, check whether `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` is set and the plugin
+     is not explicitly loaded. Add `-p <plugin_name>` to the pytest invocation.
+     [plugin-load-guard]
 2. **If fixable:** Fix code/config, push, **restart from Mergeability Gate** (head SHA changed)
 3. **If not fixable:** Mark as `blocked-ci-failure` with failing job names and log links
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -230,6 +230,15 @@ First-green definition:
 - `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg"`
 - `python -m app.cli settings-validate --json`
 
+> **Plugin-load guard:** <!-- plugin-load-guard --> When `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` is set, flags provided by
+> plugins are not available unless the plugin is also explicitly loaded with `-p <plugin_name>`.
+> For example, to use `pytest-xdist` with autoload disabled:
+> ```
+> PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p xdist.plugin -n auto ...
+> ```
+> Do not assume installing a plugin is sufficient — verify the flag resolves with an explicit
+> `-p` load if autoload is disabled.
+
 For fast local runs that bypass workspace/global pytest configuration, prefer:
 - `STORE_BACKEND=memory PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg" -c /dev/null`
 - `make smoke` (parallel by default via `pytest-xdist`; override workers with `SMOKE_WORKERS=<n|auto>`, and include e2e lane with `SMOKE_E2E_WORKERS=<n>`)


### PR DESCRIPTION
- [x] Governance lane

Fixes #836

## Summary

Documents that pytest plugin flags (e.g. `-n`/`--dist` from `pytest-xdist`) are silently unavailable when `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` is set unless the plugin is also explicitly loaded with `-p <plugin_name>`. Implements PIH-01 per `docs/PR_INTEGRATION_HARDENING/ADD_PLUGIN_LOAD_GUARD.md`.

## Changes

- `docs/TESTING.md` — caution block added in the "Required baseline checks" section under anchor `plugin-load-guard`
- `.codex/skills/pr-integration/SKILL.md` — `[plugin-load-guard]` triage note added under the CI failure analysis step

## Validation

```
grep -n "plugin-load-guard" docs/TESTING.md
# => 233:> **Plugin-load guard:** <!-- plugin-load-guard --> ...

grep -n "plugin-load-guard" .codex/skills/pr-integration/SKILL.md
# => 330:     [plugin-load-guard]

python3 scripts/docs_guard.py
# => Docs guard: OK
```

Both AC `Verify:` targets resolved green. Dispatcher unavailable (yaml module missing) — used GitHub-label-only claim.

---