### PR TITLE
[PIH-02] governance: add branch-truth gate to issue-to-code and pr-integration

### DIFF
--- a/.codex/skills/issue-to-code/SKILL.md
+++ b/.codex/skills/issue-to-code/SKILL.md
@@ -275,6 +275,38 @@ When continuing through anchor drift:
 12. Update owner docs if shipped behavior/contracts changed.
 13. Rewrite roadmap/plan wording if the delivered work was previously listed as pending.
 14. Run `Suggested Validation` plus any obviously necessary focused checks. Confirm every AC's `Verify:` target now resolves green.
+14a. **Branch-Truth Gate — Phase 1: Pre-Commit (mandatory before `git add`/`git commit`)** [branch-truth-gate]
+
+    For multi-agent parallel work, a dedicated per-issue worktree (via `git worktree add`) is mandatory for the full issue lifecycle — from initial implementation through every review-fix push. Do NOT commit to an active PR from the shared root worktree.
+
+    ```bash
+    EXPECTED_BRANCH="<PR head branch name>"
+    ACTUAL_BRANCH=$(git branch --show-current)
+
+    if [ "$ACTUAL_BRANCH" != "$EXPECTED_BRANCH" ]; then
+      echo "BRANCH-TRUTH GATE FAILED (pre-commit): on $ACTUAL_BRANCH (expected $EXPECTED_BRANCH)"
+      echo "Switch to the correct worktree before committing."
+      exit 1
+    fi
+    ```
+
+    Branch name must match. Do not check the remote PR head SHA here — a new local commit will advance HEAD past the remote ref before push.
+
+14b. **Branch-Truth Gate — Phase 2: Pre-Push (mandatory before `git push`)** [branch-truth-gate]
+
+    ```bash
+    EXPECTED_BRANCH="<PR head branch name>"
+    ACTUAL_BRANCH=$(git branch --show-current)
+
+    if [ "$ACTUAL_BRANCH" != "$EXPECTED_BRANCH" ]; then
+      echo "BRANCH-TRUTH GATE FAILED (pre-push): on $ACTUAL_BRANCH (expected $EXPECTED_BRANCH)"
+      exit 1
+    fi
+    echo "Branch-truth gate passed — pushing to origin/$EXPECTED_BRANCH"
+    ```
+
+    If branch name fails at pre-push: stop, switch to the correct worktree, and re-run both phases.
+
 15. Run `.codex/skills/publish-pr/SKILL.md` to create or update the implementation PR linked to the governing Issue unless a concrete blocker or explicit user instruction prevents it.
 16. Run `.codex/skills/pr-integration/SKILL.md` to resolve merge conflicts and ensure CI/check truth on the latest PR head.
 17. **Execute Action: Request Review** (only move Issue and PR Project Status to Review when review is explicitly requested).

--- a/.codex/skills/pr-integration/SKILL.md
+++ b/.codex/skills/pr-integration/SKILL.md
@@ -64,6 +64,12 @@ scripts/agent_workspace_preflight.sh \
 
 If this gate fails, stop immediately. Resolve concurrent-session drift before continuing.
 
+Additionally, before any review-fix commit or push: [branch-truth-gate]
+
+- **Before committing:** confirm `git branch --show-current` equals the PR head branch. If it does not, stop — do not commit. Switch to the correct worktree first.
+- **Before pushing:** confirm `git branch --show-current` still equals the PR head branch. Do not compare HEAD SHA to the remote PR `headRefOid` here — the local commit has already advanced HEAD past the remote ref.
+- **For multi-agent parallel work:** a per-issue worktree is mandatory for the full issue lifecycle (implementation through review-fix). The shared root worktree must not be used to commit to an active PR.
+
 ### 1) Contract and Metadata Gate
 
 **Action: Verify PR Contract**


### PR DESCRIPTION
- [x] Governance lane

Fixes #837

## Summary

Adds a mandatory two-phase branch-truth gate (`[branch-truth-gate]`) to `.codex/skills/issue-to-code/SKILL.md` and `.codex/skills/pr-integration/SKILL.md` to prevent commits silently landing on the wrong branch during multi-agent parallel work (root cause: learning-log entry 2026-05-07 #775).

## Changes

- **`issue-to-code/SKILL.md`**: New steps 14a and 14b inserted before the `publish-pr` handoff — Phase 1 (pre-commit: branch name check) and Phase 2 (pre-push: branch name check), both labeled `[branch-truth-gate]`. Per-issue worktree mandate for multi-agent work is stated in step 14a.
- **`pr-integration/SKILL.md`**: Workspace Isolation Gate (section 0) extended with the two-phase branch-truth confirmation steps and the per-issue worktree mandate, labeled `[branch-truth-gate]`.

## Validation

```
grep -n "branch-truth-gate" .codex/skills/issue-to-code/SKILL.md
# => 278: 14a. **Branch-Truth Gate — Phase 1: Pre-Commit ...** [branch-truth-gate]
# => 295: 14b. **Branch-Truth Gate — Phase 2: Pre-Push ...** [branch-truth-gate]

grep -n "branch-truth-gate" .codex/skills/pr-integration/SKILL.md
# => 67: Additionally, before any review-fix commit or push: [branch-truth-gate]

grep -n "per-issue worktree" .codex/skills/issue-to-code/SKILL.md
# => 280: per-issue worktree (via `git worktree add`) is mandatory ...
```

All acceptance criteria verify targets resolve green.

---

**Note:** Dispatcher unavailable (db_exists: false) — used GitHub-label-only claim.