### PR TITLE
governance(pr-integration): add merge-ref validation gate after review-fix push [PIH-03]

### DIFF
--- a/.codex/skills/pr-integration/SKILL.md
+++ b/.codex/skills/pr-integration/SKILL.md
@@ -458,6 +458,46 @@ echo "New PR head SHA: $NEW_HEAD"
 
 **Do not carry forward check results from a previous SHA.**
 
+### 6) Merge-Ref Validation (mandatory after any review-fix push) [merge-ref-validation]
+
+After pushing a review-fix, GitHub assembles a merge-ref at `refs/pull/<PR_NUMBER>/merge`.
+Branch HEAD may be clean while the merge-ref carries a divergent context that causes CI-only failures (learning-log 2026-05-07 — PR #800).
+
+**Action: Fetch and inspect the merge-ref tree**
+
+```bash
+PR_NUMBER=<PR_NUMBER>
+git fetch origin refs/pull/${PR_NUMBER}/merge:refs/merge_validation
+
+# Inspect touched symbols using git show — do NOT checkout into the active worktree
+git show refs/merge_validation:app/<changed_module>.py | grep -n "<changed_symbol>"
+```
+
+Do not use `git checkout refs/merge_validation -- .`: that mutates the active working tree and index, leaving the PR branch dirty and risking accidental commits.
+
+**Action: Run a targeted smoke check against the merge-ref in a temporary worktree**
+
+```bash
+MERGE_WORKTREE=$(mktemp -d)
+git worktree add --detach "$MERGE_WORKTREE" refs/merge_validation
+(cd "$MERGE_WORKTREE" && PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/<relevant_test_file>.py -k "<key_test>")
+git worktree remove --force "$MERGE_WORKTREE"
+```
+
+**If the symbol is absent in the merge-ref or any test fails:**
+
+- Do NOT declare `ready-for-verification`.
+- Report `blocked-ci-failure` with the merge-ref tree context.
+- Push a corrective fix to the branch and repeat this section from the fetch step.
+
+**If both checks pass:**
+
+```bash
+echo "✅ Merge-ref validation passed — merge-ref tree consistent with branch HEAD"
+```
+
+Proceed to the Handoff Decision.
+
 ## Quick Reference: Integration Outcomes
 
 | Gate | Condition | Action | Outcome |

--- a/.codex/skills/pr-integration/SKILL.md
+++ b/.codex/skills/pr-integration/SKILL.md
@@ -467,7 +467,7 @@ Branch HEAD may be clean while the merge-ref carries a divergent context that ca
 
 ```bash
 PR_NUMBER=<PR_NUMBER>
-git fetch origin refs/pull/${PR_NUMBER}/merge:refs/merge_validation
+git fetch origin +refs/pull/${PR_NUMBER}/merge:refs/merge_validation
 
 # Inspect touched symbols using git show — do NOT checkout into the active worktree
 git show refs/merge_validation:app/<changed_module>.py | grep -n "<changed_symbol>"
@@ -481,7 +481,9 @@ Do not use `git checkout refs/merge_validation -- .`: that mutates the active wo
 MERGE_WORKTREE=$(mktemp -d)
 git worktree add --detach "$MERGE_WORKTREE" refs/merge_validation
 (cd "$MERGE_WORKTREE" && PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/<relevant_test_file>.py -k "<key_test>")
+SMOKE_EXIT=$?
 git worktree remove --force "$MERGE_WORKTREE"
+[ $SMOKE_EXIT -ne 0 ] && echo "❌ Merge-ref smoke test failed (exit $SMOKE_EXIT)" && exit $SMOKE_EXIT
 ```
 
 **If the symbol is absent in the merge-ref or any test fails:**


### PR DESCRIPTION
## Change Lane
- [ ] Implementation lane
- [ ] Docs authoring lane
- [x] Governance lane

## Linked Issue
Fixes #838

## Summary
- Adds Section 6 `[merge-ref-validation]` to `.codex/skills/pr-integration/SKILL.md`
- Section is positioned after the review-fix push section (Gate Re-Entry After Any Push) and before the Handoff Decision exit-condition checklist
- Section mandates: fetch `refs/pull/<PR>/merge`, inspect touched symbols via `git show` (never `git checkout`), run a targeted smoke test in a temporary detached worktree, and report `blocked-ci-failure` on any failure
- Prevents false-green `ready-for-verification` declarations caused by merge-ref divergence invisible on branch HEAD (learning-log 2026-05-07 PR #800)

## Governance Lane Check
- [x] This PR only changes approved governance surfaces.
- [x] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [x] No product/runtime implementation or shipped feature behavior changed.

## Validation
Governance lane:
- [x] `grep -n "merge-ref-validation\|refs/pull.*merge" .codex/skills/pr-integration/SKILL.md` returns hits for anchor label (line 461) and fetch pattern (lines 463, 470)
- [x] Section confirmed positioned after Gate 5 / Gate Re-Entry After Any Push and before Handoff Decision section
- [x] Branch-truth gates passed (pre-commit and pre-push)

## Notes
- Dispatcher unavailable (ModuleNotFoundError: `yaml` not in active Python env) — used GitHub-label-only claim.
- PIH-03; sequenced after PIH-02 (#837) which merged 2026-05-10.
- No code, tests, or CI workflows changed — governance surface only.