### PR TITLE
docs: owner-doc promotion for #838 — PIH-03 merge-ref validation shipped

### DIFF
--- a/docs/PR_INTEGRATION_HARDENING/ADD_MERGE_REF_VALIDATION.md
+++ b/docs/PR_INTEGRATION_HARDENING/ADD_MERGE_REF_VALIDATION.md
@@ -98,6 +98,4 @@ Confirm the section appears after any review-fix section and before the exit-con
 
 ## Related GitHub Issues
 
-Create one bounded governance issue: `[PR-Integration-Hardening] add-merge-ref-validation: verify merge-ref tree after review-fix push`.
-Label: `lane:governance`, `agent:ready`, `Status=Ready`.
-Sequence after PIH-02 issue closes to avoid `pr-integration/SKILL.md` diff conflicts.
+Delivered. Governing issue: [#838](https://github.com/RasmusTho/agentic-pkm-mvp/issues/838) — closed by PR [#861](https://github.com/RasmusTho/agentic-pkm-mvp/pull/861) (merged 2026-05-11). No further issue creation needed.

--- a/docs/PR_INTEGRATION_HARDENING/ADD_MERGE_REF_VALIDATION.md
+++ b/docs/PR_INTEGRATION_HARDENING/ADD_MERGE_REF_VALIDATION.md
@@ -67,10 +67,12 @@ Declaring a PR ready based only on branch HEAD is insufficient when the merge-re
 
 ## Acceptance Criteria
 
-- [ ] `.codex/skills/pr-integration/SKILL.md` contains a merge-ref validation section, labeled `[merge-ref-validation]`, after the review-fix push section.
+- [x] `.codex/skills/pr-integration/SKILL.md` contains a merge-ref validation section, labeled `[merge-ref-validation]`, after the review-fix push section.
   Verify: doc writeback at `.codex/skills/pr-integration/SKILL.md :: merge-ref-validation`
-- [ ] The section specifies: fetch `refs/pull/<PR>/merge`, inspect touched symbols in that tree, run at least one target test against it, and block on failure.
+- [x] The section specifies: fetch `refs/pull/<PR>/merge`, inspect touched symbols in that tree, run at least one target test against it, and block on failure.
   Verify: doc writeback at `.codex/skills/pr-integration/SKILL.md :: merge-ref-validation`
+
+Delivered by PR #861 (merged 2026-05-11).
 
 ## How to Verify (Pre-Merge)
 

--- a/docs/PR_INTEGRATION_HARDENING/README.md
+++ b/docs/PR_INTEGRATION_HARDENING/README.md
@@ -45,19 +45,19 @@ No two tasks may be worked in parallel. Each must merge before the next is picke
 | Task | Issue |
 |---|---|
 | Parent feature | [#835](https://github.com/RasmusTho/agentic-pkm-mvp/issues/835) |
-| PIH-01: Add Plugin Load Guard | [#836](https://github.com/RasmusTho/agentic-pkm-mvp/issues/836) — `agent:ready` |
-| PIH-02: Add Branch Truth Gate | [#837](https://github.com/RasmusTho/agentic-pkm-mvp/issues/837) — `agent:ready` |
-| PIH-03: Add Merge-Ref Validation | [#838](https://github.com/RasmusTho/agentic-pkm-mvp/issues/838) — blocked on #837 |
+| PIH-01: Add Plugin Load Guard | [#836](https://github.com/RasmusTho/agentic-pkm-mvp/issues/836) — merged |
+| PIH-02: Add Branch Truth Gate | [#837](https://github.com/RasmusTho/agentic-pkm-mvp/issues/837) — merged |
+| PIH-03: Add Merge-Ref Validation | [#838](https://github.com/RasmusTho/agentic-pkm-mvp/issues/838) — merged (PR [#861](https://github.com/RasmusTho/agentic-pkm-mvp/pull/861), 2026-05-11) |
 
 ## Acceptance criteria
 
-- [ ] `docs/TESTING.md` contains a caution about explicit plugin loading under `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`.
+- [x] `docs/TESTING.md` contains a caution about explicit plugin loading under `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`.
   Verify: doc writeback at `docs/TESTING.md :: plugin-load-guard`
-- [ ] `pr-integration/SKILL.md` contains a CI triage note about plugin-provided flags requiring explicit load.
+- [x] `pr-integration/SKILL.md` contains a CI triage note about plugin-provided flags requiring explicit load.
   Verify: doc writeback at `.codex/skills/pr-integration/SKILL.md :: plugin-load-guard`
-- [ ] `issue-to-code/SKILL.md` contains a branch-truth gate step before any commit action.
+- [x] `issue-to-code/SKILL.md` contains a branch-truth gate step before any commit action.
   Verify: doc writeback at `.codex/skills/issue-to-code/SKILL.md :: branch-truth-gate`
-- [ ] `pr-integration/SKILL.md` contains a merge-ref fetch-and-verify step after review-fix pushes.
+- [x] `pr-integration/SKILL.md` contains a merge-ref fetch-and-verify step after review-fix pushes.
   Verify: doc writeback at `.codex/skills/pr-integration/SKILL.md :: merge-ref-validation`
 - [ ] `docs/learning-log.md` retro marker appended after all three tasks merge.
   Verify: retro marker entry in `docs/learning-log.md` referencing this capability.


### PR DESCRIPTION
## Change Lane
- [ ] Implementation lane
- [x] Docs authoring lane
- [ ] Governance lane

## Summary
- Marks acceptance criteria in `ADD_MERGE_REF_VALIDATION.md` as checked — PR #861 merged 2026-05-11
- Updates `README.md` GitHub issues table: all three PIH tasks (#836, #837, #838) shown as merged
- Checks four of five README-level ACs; retro marker AC deferred to `learning-retrospective` skill

## Docs Authoring Check
- [x] This PR only changes approved docs-authoring surfaces.
- [x] No code, runtime behavior, contracts, or shipped reality changed.
- [x] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Validation
Docs authoring lane:
- [x] All four skill/doc delivery ACs confirmed present in merged main (`grep` verified plugin-load-guard, branch-truth-gate ×2, merge-ref-validation)
- [x] Branch-truth gates passed (pre-commit and pre-push)

## Notes
- Post-merge owner doc triggered by PR #861 (issue #838 PIH-03).
- Retro marker for the full PR_INTEGRATION_HARDENING capability is deferred — per README validation path, it requires observing adoption over 2–3 deliveries before the learning-retrospective skill closes it out.