### PR TITLE
ops/runtime: backport removed changes from companion docs PR

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Prod-critical path owners — any PR touching these paths requires @RasmusTho review.
+
+docker-compose.yaml               @RasmusTho
+docker-compose.prod.yml           @RasmusTho
+docker-compose.test.yml           @RasmusTho
+/app/alembic/versions/            @RasmusTho
+/.codex/skills/execute-promotion/ @RasmusTho
+/.codex/skills/prepare-promotion/ @RasmusTho
+/.codex/skills/rollback-promotion/ @RasmusTho

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ SMOKE_E2E_WORKERS ?= 0
 COMPOSE_BASE := docker compose -f docker-compose.yaml
 COMPOSE_DEV := $(COMPOSE_BASE) -f docker-compose.dev.yml -p pkm-dev
 COMPOSE_TEST := $(COMPOSE_BASE) -f docker-compose.test.yml -p pkm-test
-COMPOSE_PROD := $(COMPOSE_BASE) -p pkm-prod
+COMPOSE_PROD := $(COMPOSE_BASE) -f docker-compose.prod.yml -p pkm-prod
+TEST_COMPOSE_ENV := COMPOSE_FILE=docker-compose.yaml:docker-compose.test.yml COMPOSE_PROJECT_NAME=pkm-test
 
 fmt:
 	rufflehog --version >/dev/null 2>&1 || true

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,13 @@ dev-down:
 	@$(COMPOSE_DEV) down --remove-orphans
 
 prod-up:
-	@docker volume inspect pkm-prod_pgdata >/dev/null 2>&1 || docker volume create pkm-prod_pgdata >/dev/null
+	@docker volume inspect pkm-prod_pgdata >/dev/null 2>&1 || { \
+		echo "ERROR: Missing required external Docker volume: pkm-prod_pgdata"; \
+		echo "Refusing to auto-create an empty prod volume."; \
+		echo "If migrating from legacy pkm-prod without a DB volume mount, copy/export data first."; \
+		echo "After migration, create the volume explicitly: docker volume create pkm-prod_pgdata"; \
+		exit 1; \
+	}
 	@$(COMPOSE_PROD) up -d --build
 
 prod-down:

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ dev-down:
 	@$(COMPOSE_DEV) down --remove-orphans
 
 prod-up:
+	@docker volume inspect pkm-prod_pgdata >/dev/null 2>&1 || docker volume create pkm-prod_pgdata >/dev/null
 	@$(COMPOSE_PROD) up -d --build
 
 prod-down:

--- a/app/db/dsn.py
+++ b/app/db/dsn.py
@@ -3,14 +3,14 @@ import typing as t
 
 
 def resolve_dsn(conninfo: t.Optional[str] = None) -> str:
-    url = (conninfo or os.getenv("DATABASE_URL", "")).strip()
+    url = (conninfo or os.getenv("DATABASE_URL") or os.getenv("DB_DSN") or "").strip()
     if url.startswith("postgresql+psycopg://"):
         url = "postgresql://" + url.split("postgresql+psycopg://", 1)[1]
     return url
 
 
 def resolve_sqlalchemy_url(conninfo: t.Optional[str] = None) -> str:
-    url = (conninfo or os.getenv("DATABASE_URL", "")).strip()
+    url = (conninfo or os.getenv("DATABASE_URL") or os.getenv("DB_DSN") or "").strip()
     if not url:
         return ""
     if url.startswith("postgresql+psycopg://"):

--- a/app/services/outbox.py
+++ b/app/services/outbox.py
@@ -27,9 +27,9 @@ def _open_conn():
             pass
     import psycopg
 
-    url = os.environ.get("DATABASE_URL")
+    url = os.environ.get("DATABASE_URL") or os.environ.get("DB_DSN")
     if not url:
-        raise RuntimeError("DATABASE_URL not set")
+        raise RuntimeError("DATABASE_URL or DB_DSN not set")
     try:
         from app.db.dsn import resolve_dsn
 

--- a/companion-ui/companion-app/README.md
+++ b/companion-ui/companion-app/README.md
@@ -4,7 +4,24 @@ This folder contains implementation staging artifacts for the companion UI.
 
 Current contents are prototype/reference shell files for converse layout behavior and should be treated as non-production until explicitly promoted.
 
-Boundaries:
+Files:
+- `converse_layout.html` / `.css` / `_state.py` — original converse layout shell.
+- `canvas_suggestion_flow.html` / `.css` — **Canvas Suggestion Flow staging prototype** (2026-05-11). Implements the 8-state UI model from the design spec at `design_handoff/2026-05-11-canvas-suggestion-flow/`. Open in a browser; use the lane-switcher tabs to walk the body-edit, governance, blocked, and idle states.
+- `colors_and_type.css` — Yggdrasil design token sheet (shared with design_handoff).
+
+## Prototype scope (canvas_suggestion_flow.html)
+
+This file is a **staging prototype** — not production runtime:
+
+- **No network side effects.** No real API calls are made.
+- **No durable mutations.** No data is written to the vault, database, or any external system.
+- **Console/demo calls only.** Backend interactions are simulated via `console.log` entries (e.g., `[canvas_writer.apply_edit]`, `[GovernanceRouter.request_governance_action]`, `[session-log:append_turn]`).
+- **Not production runtime.** The lane-switcher tab bar, hardcoded session paths, and simulated turn delays are demo scaffolding absent from any production implementation.
+- **Non-production until explicitly promoted.** No file in this folder becomes production code until a formal promotion decision is recorded in a PR.
+
+See `companion-ui/docs/CANVAS_SUGGESTION_FLOW.md` for the normalized implementation spec and `companion-ui/design_handoff/2026-05-11-canvas-suggestion-flow/` for the design handoff archive.
+
+## General boundaries
 - No production backend integrations in this workspace phase.
 - Keep overlay-first, document-first interaction behavior intact.
 - Keep runtime state ephemeral unless an explicit persistence contract is introduced.

--- a/companion-ui/companion-app/canvas_suggestion_flow.css
+++ b/companion-ui/companion-app/canvas_suggestion_flow.css
@@ -1,0 +1,603 @@
+/* ============================================================
+   Canvas Suggestion Flow — Component Styles
+   Extends converse_layout.css with suggestion lifecycle components.
+   Imports design tokens from colors_and_type.css.
+   ============================================================ */
+
+/* ---- Shell layout ---- */
+.canvas-shell {
+  height: 100vh;
+  display: grid;
+  grid-template-rows: 38px 1fr 36px;
+  background: var(--bg-base);
+  font-family: var(--font-ui);
+  color: var(--fg-1);
+}
+
+.canvas-top-bar {
+  background: var(--bg-surface);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: 0 var(--space-4);
+  font-size: var(--text-sm);
+}
+
+.canvas-top-bar .session-pill {
+  background: var(--bg-raised);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  color: var(--fg-2);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wide);
+  padding: 3px 10px;
+  cursor: pointer;
+}
+.canvas-top-bar .session-pill:hover { color: var(--fg-1); border-color: var(--cyan); }
+
+.canvas-top-bar .vault-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--fg-3);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wide);
+  margin-left: auto;
+}
+.canvas-top-bar .vault-dot {
+  width: 7px; height: 7px;
+  border-radius: 50%;
+  background: var(--vault);
+  box-shadow: 0 0 6px rgba(57,232,125,0.5);
+}
+
+/* ---- Stage: doc + rail ---- */
+.canvas-stage {
+  display: grid;
+  grid-template-columns: 1fr 288px;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.canvas-shell[data-rail-state="collapsed"] .canvas-stage {
+  grid-template-columns: 1fr 32px;
+}
+
+/* ---- Document pane ---- */
+.document-pane {
+  overflow-y: auto;
+  padding: 44px 32px;
+  border-right: 1px solid var(--border);
+}
+
+.document-pane .doc-note-path {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  letter-spacing: var(--tracking-wide);
+  margin-bottom: var(--space-5);
+}
+
+.document-pane .doc-frontmatter {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-2);
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 8px 12px;
+  margin-bottom: var(--space-5);
+  white-space: pre;
+}
+
+.document-pane h1 {
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  margin-bottom: var(--space-4);
+  color: var(--fg-1);
+}
+
+.document-pane h2 {
+  font-family: var(--font-display);
+  font-size: var(--text-lg);
+  margin: var(--space-6) 0 var(--space-2);
+  color: var(--fg-1);
+}
+
+.document-pane p {
+  font-size: var(--text-sm);
+  color: var(--fg-1);
+  line-height: 1.65;
+  max-width: 68ch;
+}
+
+/* ---- SuggestedInsertion ---- */
+.suggested-insertion {
+  display: block;
+  margin: var(--space-3) 0;
+  padding: 8px 12px;
+  border-left: 2px solid var(--amber);
+  background: rgba(240,144,48,0.06);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  font-size: var(--text-sm);
+  color: var(--fg-1);
+  line-height: 1.6;
+  position: relative;
+  text-decoration: none;
+  font-style: normal;
+  transition: border-left-color var(--duration-slow) var(--ease),
+              background var(--duration-slow) var(--ease);
+}
+
+.suggested-insertion::before {
+  content: 'PROPOSED · UNCOMMITTED';
+  position: absolute;
+  top: -8px;
+  left: 8px;
+  background: var(--bg-base);
+  padding: 0 6px;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: var(--tracking-wider);
+  color: var(--amber);
+  transition: color var(--duration-slow) var(--ease);
+}
+
+.suggested-insertion[data-state="applied"] {
+  border-left-color: var(--vault);
+  background: rgba(57,232,125,0.04);
+}
+.suggested-insertion[data-state="applied"]::before {
+  content: 'APPLIED · ' attr(data-receipt);
+  color: var(--vault);
+}
+
+.suggested-insertion[data-state="discarded"] {
+  display: none;
+}
+
+@media (prefers-reduced-motion) {
+  .suggested-insertion,
+  .suggested-insertion::before { transition: none; }
+}
+
+/* ---- Hugin rail ---- */
+.hugin-rail {
+  background: var(--bg-surface);
+  display: grid;
+  grid-template-rows: auto 1fr auto auto;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.canvas-shell[data-rail-state="collapsed"] .hugin-rail {
+  grid-template-rows: 1fr;
+}
+
+.rail-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px var(--space-4);
+  border-bottom: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wider);
+  color: var(--fg-3);
+  text-transform: uppercase;
+}
+
+.rail-header .hugin-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--agent);
+  box-shadow: 0 0 6px rgba(74,158,255,0.6);
+  flex-shrink: 0;
+}
+
+.rail-header .turn-meta { margin-left: auto; }
+
+.rail-collapsed-strip {
+  display: none;
+}
+
+.canvas-shell[data-rail-state="collapsed"] .rail-collapsed-strip {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: var(--space-3) 0;
+  gap: var(--space-3);
+  cursor: pointer;
+}
+
+.canvas-shell[data-rail-state="collapsed"] .rail-header,
+.canvas-shell[data-rail-state="collapsed"] .conversation-thread,
+.canvas-shell[data-rail-state="collapsed"] .receipts-strip,
+.canvas-shell[data-rail-state="collapsed"] .composer-wrap { display: none; }
+
+.collapsed-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--agent);
+  box-shadow: 0 0 6px rgba(74,158,255,0.6);
+}
+.collapsed-count {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--fg-3);
+  writing-mode: vertical-rl;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* ---- Conversation thread ---- */
+.conversation-thread {
+  overflow-y: auto;
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  min-height: 0;
+}
+
+/* ---- Messages ---- */
+.message {
+  border-radius: var(--radius-sm);
+  padding: 8px 10px;
+  font-size: var(--text-sm);
+  line-height: 1.5;
+  color: var(--fg-1);
+  max-width: 96%;
+}
+
+.message.agent {
+  background: var(--agent-muted);
+  border-left: 2px solid var(--agent);
+}
+
+.message.user {
+  background: var(--bg-raised);
+  border-left: 2px solid var(--fg-3);
+  align-self: flex-end;
+}
+
+.message .ctx-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  margin-bottom: 4px;
+  display: block;
+}
+
+/* ---- ThinkingIndicator ---- */
+.thinking-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--agent);
+}
+
+.thinking-indicator .ddot {
+  width: 5px; height: 5px;
+  border-radius: 50%;
+  background: var(--agent);
+  animation: tdot 1.2s ease-in-out infinite;
+  box-shadow: 0 0 4px rgba(74,158,255,0.7);
+}
+.thinking-indicator .ddot:nth-child(3) { animation-delay: 0.15s; }
+.thinking-indicator .ddot:nth-child(4) { animation-delay: 0.3s; }
+
+@keyframes tdot {
+  0%, 70%, 100% { opacity: 0.2; transform: scale(0.7); }
+  35% { opacity: 1; transform: scale(1); }
+}
+
+@media (prefers-reduced-motion) {
+  .thinking-indicator .ddot { animation: none; opacity: 1; }
+}
+
+.thinking-cancel {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0 0 0 var(--space-2);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+}
+.thinking-cancel:hover { color: var(--fg-1); }
+
+/* ---- SuggestionCard ---- */
+.suggestion-card {
+  border-radius: var(--radius-sm);
+  padding: 10px 12px;
+  font-size: var(--text-sm);
+  color: var(--fg-1);
+  line-height: 1.55;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.suggestion-card .card-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+}
+
+.suggestion-card .diff-hint {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+}
+
+.suggestion-card .card-classification {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wide);
+}
+
+/* Body variant */
+.suggestion-card[data-variant="body"] {
+  background: rgba(240,144,48,0.06);
+  border: 1px solid rgba(240,144,48,0.35);
+}
+.suggestion-card[data-variant="body"] .card-label { color: var(--amber); }
+
+/* Governance variant */
+.suggestion-card[data-variant="governance"] {
+  background: rgba(212,168,67,0.05);
+  border: 1px solid rgba(212,168,67,0.4);
+}
+.suggestion-card[data-variant="governance"] .card-label { color: var(--accent); }
+.suggestion-card[data-variant="governance"] .card-classification { color: var(--accent); }
+
+/* Applied (collapse to one-line log) */
+.suggestion-card[data-variant="applied"] {
+  background: rgba(57,232,125,0.04);
+  border: 1px solid rgba(57,232,125,0.3);
+  opacity: 0.85;
+}
+.suggestion-card[data-variant="applied"] .card-label { color: var(--vault); }
+
+/* Discarded */
+.suggestion-card[data-variant="discarded"] {
+  background: var(--bg-raised);
+  border: 1px dashed var(--border-strong);
+  opacity: 0.55;
+  text-decoration: line-through;
+  text-decoration-color: var(--fg-3);
+}
+
+/* Blocked */
+.suggestion-card[data-variant="blocked"] {
+  background: rgba(255,61,61,0.04);
+  border: 1px solid rgba(255,61,61,0.35);
+}
+.suggestion-card[data-variant="blocked"] .card-label { color: var(--destructive); }
+
+/* Card actions */
+.card-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 2px;
+}
+
+/* ---- Buttons ---- */
+.btn {
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  padding: 5px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-raised);
+  color: var(--fg-1);
+  border: 1px solid var(--border-strong);
+  cursor: pointer;
+  min-height: 28px;
+}
+.btn:hover { border-color: var(--cyan); color: var(--cyan); }
+.btn:disabled, .btn[disabled] {
+  opacity: 0.4;
+  cursor: not-allowed;
+  color: var(--fg-3);
+  pointer-events: none;
+}
+
+.btn.primary {
+  background: var(--amber-muted);
+  color: var(--amber);
+  border-color: rgba(240,144,48,0.5);
+}
+.btn.primary:hover { background: rgba(240,144,48,0.12); border-color: var(--amber); }
+
+.btn.governance {
+  background: rgba(212,168,67,0.06);
+  color: var(--accent);
+  border-color: rgba(212,168,67,0.5);
+}
+.btn.governance:hover { background: rgba(212,168,67,0.12); border-color: var(--accent); }
+
+.btn.ghost { background: transparent; }
+
+.btn .kbd {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  color: var(--fg-3);
+  margin-left: 6px;
+}
+
+@media (pointer: coarse) {
+  .btn { min-height: 44px; padding: 10px 14px; }
+}
+
+/* ---- ReceiptPill ---- */
+.receipt-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  border-radius: var(--radius-full);
+  background: var(--bg-raised);
+  border: 1px solid var(--border-strong);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-2);
+  letter-spacing: var(--tracking-wide);
+  cursor: pointer;
+  width: fit-content;
+}
+.receipt-pill:hover { border-color: var(--cyan); color: var(--fg-1); }
+
+.receipt-pill[data-status="queued"] { color: var(--accent); border-color: rgba(212,168,67,0.4); }
+.receipt-pill[data-status="applied"] { color: var(--vault); border-color: rgba(57,232,125,0.4); }
+.receipt-pill[data-status="pending"] { color: var(--amber); border-color: rgba(240,144,48,0.4); }
+
+.receipt-pill .recdot {
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 6px currentColor;
+  flex-shrink: 0;
+}
+
+.receipt-pill[data-status="queued"] .recdot {
+  animation: rcpulse 1.6s ease-in-out infinite;
+}
+
+@keyframes rcpulse { 0%, 100% { opacity: 0.4; } 50% { opacity: 1; } }
+@media (prefers-reduced-motion) {
+  .receipt-pill .recdot { animation: none; }
+}
+
+/* ---- ReceiptsStrip ---- */
+.receipts-strip {
+  padding: 8px 10px;
+  background: var(--bg-base);
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.receipts-strip .strip-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--fg-3);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+}
+
+.receipts-strip .strip-empty {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  font-style: italic;
+}
+
+/* ---- Composer ---- */
+.composer-wrap {
+  display: flex;
+  gap: 6px;
+  padding: 8px var(--space-4);
+  border-top: 1px solid var(--border);
+  background: var(--bg-surface);
+  align-items: center;
+}
+
+.composer-wrap input {
+  flex: 1;
+  background: var(--bg-raised);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  padding: 6px 10px;
+  color: var(--fg-1);
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  min-height: 32px;
+}
+.composer-wrap input:focus { outline: 1px solid var(--cyan); box-shadow: var(--cyan-glow); }
+.composer-wrap input::placeholder { color: var(--fg-3); }
+.composer-wrap input:disabled { color: var(--fg-3); cursor: not-allowed; }
+
+/* ---- ProvenanceFooter ---- */
+.provenance-footer {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: 0 var(--space-4);
+  border-top: 1px solid var(--border);
+  background: var(--bg-surface);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  letter-spacing: var(--tracking-wide);
+}
+
+.provenance-footer .prov-session {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--fg-2);
+}
+
+.provenance-footer .prov-dot {
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--vault);
+  box-shadow: 0 0 6px rgba(57,232,125,0.5);
+  flex-shrink: 0;
+}
+
+.provenance-footer .prov-state {
+  margin-left: auto;
+  color: var(--fg-3);
+}
+.provenance-footer .prov-state strong { color: var(--cyan); }
+
+/* ---- State-driven dimming ---- */
+.canvas-shell[data-suggestion-state="staged-body"] .document-pane > *:not(.suggested-insertion-zone),
+.canvas-shell[data-suggestion-state="staged-gov"] .document-pane > *:not(.suggested-insertion-zone),
+.canvas-shell[data-suggestion-state="pending-apply"] .document-pane > *:not(.suggested-insertion-zone) {
+  /* minimal dimming — document stays readable */
+  opacity: 0.85;
+  transition: opacity var(--duration-slow) var(--ease);
+}
+
+/* ---- Responsive: portrait bottom sheet ---- */
+@media (max-width: 899px) {
+  .canvas-stage { grid-template-columns: 1fr; }
+  .document-pane { border-right: none; }
+  .hugin-rail {
+    position: fixed;
+    bottom: 0; left: 0; right: 0;
+    height: 60px; /* peek */
+    grid-template-rows: auto 1fr auto auto;
+    border-top: 1px solid var(--border);
+    box-shadow: var(--shadow-float);
+    z-index: var(--z-overlay);
+    transition: height var(--duration-slow) var(--ease);
+  }
+  .hugin-rail[data-sheet="half"]  { height: 50vh; }
+  .hugin-rail[data-sheet="full"]  { height: calc(100vh - 64px); }
+  .hugin-rail[data-sheet="peek"]  { height: 60px; }
+  @media (prefers-reduced-motion) {
+    .hugin-rail { transition: none; }
+  }
+  .canvas-shell { grid-template-rows: 38px 1fr 36px; }
+  .canvas-top-bar { grid-column: 1; }
+}

--- a/companion-ui/companion-app/canvas_suggestion_flow.html
+++ b/companion-ui/companion-app/canvas_suggestion_flow.html
@@ -1,0 +1,686 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Canvas Suggestion Flow — Companion UI Staging</title>
+  <!--
+    Staging prototype for the Canvas Suggestion Flow.
+    Design spec: companion-ui/design_handoff/2026-05-11-canvas-suggestion-flow/
+    State machine from §3; components from §4; intents from §5.
+    This file is non-production until explicitly promoted.
+  -->
+  <link rel="stylesheet" href="./colors_and_type.css" />
+  <link rel="stylesheet" href="./canvas_suggestion_flow.css" />
+</head>
+<body>
+
+<!-- ================================================================
+     CANVAS SHELL
+     data-suggestion-state drives all per-component visibility rules.
+     data-rail-state drives the rail collapse geometry.
+     ================================================================ -->
+<div class="canvas-shell"
+     data-testid="canvas-shell"
+     data-rail-state="expanded"
+     data-suggestion-state="idle"
+     data-canvas-enabled="true"
+     data-session-id="s_4f81"
+     data-active-note-path="Projects/Q2-arch.md"
+     id="shell">
+
+  <!-- ---- Top bar ---- -->
+  <header class="canvas-top-bar">
+    <strong style="font-family:var(--font-display); font-size:var(--text-base); color:var(--fg-1);">Converse</strong>
+    <button class="session-pill"
+            type="button"
+            data-testid="session-pill"
+            data-intent="session-drawer.open"
+            aria-label="Open session list">
+      Decision capture scaffold ▾
+    </button>
+    <div class="vault-status" style="margin-left:auto; display:flex; align-items:center; gap:6px;">
+      <span class="vault-dot" aria-label="Vault online"></span>
+      <span style="font-family:var(--font-mono); font-size:var(--text-xs); letter-spacing:var(--tracking-wide); color:var(--fg-3);">Vault online</span>
+    </div>
+  </header>
+
+  <!-- ---- Stage: document + rail ---- -->
+  <div class="canvas-stage">
+
+    <!-- ===========================================================
+         DOCUMENT PANE — active note render
+         =========================================================== -->
+    <main class="document-pane" data-testid="document-pane" aria-label="Active note">
+
+      <div class="doc-note-path">Projects/Q2-arch.md · session #s_4f81</div>
+
+      <div class="doc-frontmatter">---
+type: decision
+maturity: draft
+tags: [arch, q2-planning]
+---</div>
+
+      <h1>Decision capture scaffold</h1>
+
+      <h2>Context</h2>
+      <p>We need a way for Hugin to propose body edits in this note without violating the gated
+         execution invariant. Anything beyond the note body must enter the governance pipeline.</p>
+
+      <!-- SuggestedInsertion — in-document preview marker -->
+      <div class="suggested-insertion-zone">
+        <h2>Current state</h2>
+        <p>The rail can stage proposals but doesn't yet route classification or render receipts.</p>
+
+        <ins class="suggested-insertion"
+             data-testid="suggested-insertion-block"
+             data-suggestion-id="suggestion-001"
+             data-state="staged"
+             aria-label="Proposed insertion, 3 lines after ## Current state"
+             id="doc-insertion">
+          Introduce explicit staged-suggestion actions with no direct persistence side effects;
+          classification (body vs governance) is server-set on the proposal payload.
+        </ins>
+      </div>
+
+      <h2>Open questions</h2>
+      <p>How are governance-bearing proposals surfaced when the user is mid-thought?</p>
+    </main>
+
+    <!-- ===========================================================
+         HUGIN RAIL — conversation thread + action surface
+         =========================================================== -->
+    <aside class="hugin-rail"
+           data-testid="margin-rail"
+           data-sheet="peek"
+           aria-label="Hugin conversation rail"
+           id="rail">
+
+      <!-- Collapsed strip (landscape) -->
+      <div class="rail-collapsed-strip"
+           aria-label="Expand Hugin rail"
+           role="button"
+           tabindex="0"
+           id="collapsed-strip">
+        <span class="collapsed-dot" aria-hidden="true"></span>
+        <span class="collapsed-count" aria-label="3 new messages">3</span>
+      </div>
+
+      <!-- Rail header -->
+      <div class="rail-header">
+        <span class="hugin-dot" aria-hidden="true"></span>
+        <span style="color:var(--fg-2); letter-spacing:var(--tracking-wider);">HUGIN</span>
+        <span class="turn-meta" id="turn-count">14 turns</span>
+      </div>
+
+      <!-- ---- Conversation thread ---- -->
+      <div class="conversation-thread"
+           data-testid="conversation-thread"
+           aria-live="polite"
+           id="thread">
+
+        <div class="message agent">
+          <span class="ctx-label">RE: Q2-arch.md</span>
+          I have a proposal for the <em>Current state</em> section. Preview is staged in the document.
+        </div>
+
+        <div class="message user">What should go after "Current state"?</div>
+
+        <!-- ThinkingIndicator — hidden by default, shown in thinking state -->
+        <div class="thinking-indicator"
+             data-testid="thinking-indicator"
+             data-thinking="inactive"
+             aria-label="Hugin is thinking"
+             id="thinking"
+             style="display:none;">
+          <span>HUGIN</span>
+          <span class="ddot" aria-hidden="true"></span>
+          <span class="ddot" aria-hidden="true"></span>
+          <span class="ddot" aria-hidden="true"></span>
+          <button class="thinking-cancel"
+                  type="button"
+                  data-intent="canvas.cancelTurn"
+                  aria-label="Cancel Hugin reasoning"
+                  id="btn-cancel">Cancel</button>
+        </div>
+
+        <!-- ---- SuggestionCard · body variant ---- -->
+        <div class="suggestion-card"
+             data-testid="suggestion-card"
+             data-variant="body"
+             data-suggestion-id="suggestion-001"
+             id="card-body">
+          <span class="card-label">HUGIN · PROPOSED ADDITION</span>
+          <span>Introduce explicit staged-suggestion actions with no direct persistence side effects.</span>
+          <span class="diff-hint">+3 lines after <code>## Current state</code></span>
+          <div class="card-actions">
+            <button class="btn primary"
+                    type="button"
+                    data-intent="suggestion.apply"
+                    data-testid="apply-suggestion"
+                    data-target-suggestion-id="suggestion-001"
+                    id="btn-apply"
+                    aria-keyshortcuts="a">
+              Apply <span class="kbd">A</span>
+            </button>
+            <button class="btn"
+                    type="button"
+                    data-intent="suggestion.discard"
+                    data-testid="discard-suggestion"
+                    data-target-suggestion-id="suggestion-001"
+                    id="btn-discard"
+                    aria-keyshortcuts="d">
+              Discard <span class="kbd">D</span>
+            </button>
+            <button class="btn ghost"
+                    type="button"
+                    data-intent="suggestion.inspect"
+                    id="btn-inspect"
+                    aria-keyshortcuts="i">
+              Inspect <span class="kbd">I</span>
+            </button>
+          </div>
+        </div>
+
+        <!-- ---- SuggestionCard · governance variant (hidden by default) ---- -->
+        <div class="suggestion-card"
+             data-testid="suggestion-card"
+             data-variant="governance"
+             data-suggestion-id="suggestion-002"
+             id="card-gov"
+             style="display:none;">
+          <span class="card-label">HUGIN · GOVERNANCE-BEARING PROPOSAL</span>
+          <span>Promote <code>maturity: draft → committed</code> and add tag <code>#arch/decision</code>.</span>
+          <span class="card-classification"
+                data-testid="suggestion-card-classification"
+                aria-describedby="gov-classification-help"
+                id="gov-classification">
+            Cannot be applied from chat — must be queued.
+          </span>
+          <div class="card-actions">
+            <button class="btn governance"
+                    type="button"
+                    data-intent="governance.queue"
+                    data-testid="queue-governance"
+                    data-target-suggestion-id="suggestion-002"
+                    id="btn-queue"
+                    aria-keyshortcuts="q"
+                    aria-describedby="gov-classification">
+              Queue for governance <span class="kbd">Q</span>
+            </button>
+            <button class="btn"
+                    type="button"
+                    data-intent="suggestion.discard"
+                    data-target-suggestion-id="suggestion-002"
+                    id="btn-discard-gov"
+                    aria-keyshortcuts="d">
+              Discard <span class="kbd">D</span>
+            </button>
+            <button class="btn ghost"
+                    type="button"
+                    data-intent="suggestion.inspect"
+                    id="btn-inspect-gov"
+                    aria-keyshortcuts="i">
+              Inspect classification <span class="kbd">I</span>
+            </button>
+          </div>
+        </div>
+
+        <!-- ---- SuggestionCard · blocked variant (hidden by default) ---- -->
+        <div class="suggestion-card"
+             data-testid="blocked-card"
+             data-variant="blocked"
+             data-suggestion-id="suggestion-003"
+             id="card-blocked"
+             role="alert"
+             style="display:none;">
+          <span class="card-label">⚠ NOT ALLOWED IN THIS ENVIRONMENT</span>
+          <span id="blocked-reason">
+            <code>CANVAS_ENABLED=0</code>. Canvas mutations are gated off in this environment.
+            The proposed intent has been logged as <code>governance_intent_blocked</code>.
+          </span>
+          <div class="card-actions">
+            <button class="btn"
+                    type="button"
+                    data-intent="blocked.acknowledge"
+                    id="btn-ack">
+              Acknowledge
+            </button>
+            <button class="btn ghost"
+                    type="button"
+                    data-intent="blocked.openPanel">
+              Open in Panel ›
+            </button>
+          </div>
+        </div>
+
+      </div><!-- /thread -->
+
+      <!-- ---- ReceiptsStrip — pending governance receipts ---- -->
+      <div class="receipts-strip"
+           data-testid="receipts-strip"
+           aria-live="polite"
+           id="receipts-strip">
+        <span class="strip-label">Pending receipts</span>
+        <span class="strip-empty" id="receipts-empty">— none —</span>
+      </div>
+
+      <!-- ---- Composer ---- -->
+      <div class="composer-wrap">
+        <input type="text"
+               placeholder="Message Hugin…"
+               aria-label="Message Hugin"
+               data-testid="composer-input"
+               id="composer-input" />
+        <button class="btn primary"
+                type="button"
+                id="btn-send"
+                data-intent="composer.send"
+                aria-label="Send message">
+          Send
+        </button>
+      </div>
+
+    </aside><!-- /hugin-rail -->
+
+  </div><!-- /canvas-stage -->
+
+  <!-- ================================================================
+       PROVENANCE FOOTER
+       ================================================================ -->
+  <footer class="provenance-footer"
+          data-testid="provenance-footer"
+          aria-label="Session provenance">
+
+    <span class="prov-session">
+      <span class="prov-dot" aria-hidden="true"></span>
+      <button class="btn ghost"
+              type="button"
+              data-intent="provenance.openSessionLog"
+              aria-label="Open session log in Obsidian"
+              style="padding:0; border:none; font-size:var(--text-xs); font-family:var(--font-mono); letter-spacing:var(--tracking-wide); color:var(--fg-2); cursor:pointer; text-decoration:underline; text-decoration-color:var(--border-strong);">
+        .chats/q2-arch/2026-05-11T1442.md
+      </button>
+      · <span id="prov-turns">14</span> turns
+    </span>
+
+    <button class="btn ghost"
+            type="button"
+            data-intent="canvas.undoLastEdit"
+            data-testid="undo-last-edit"
+            aria-label="Undo last body edit"
+            id="btn-undo"
+            disabled
+            style="font-size:var(--text-xs); font-family:var(--font-mono);">
+      Undo last edit
+    </button>
+
+    <span class="prov-state" id="prov-state">
+      state: <strong id="prov-state-label">idle</strong>
+    </span>
+
+  </footer>
+
+</div><!-- /canvas-shell -->
+
+<!-- Demo controls: lane switcher (would not be in production) -->
+<div style="position:fixed; top:46px; left:0; right:0; background:rgba(7,11,18,0.92); border-bottom:1px solid var(--border); display:flex; gap:0; z-index:var(--z-sticky); backdrop-filter:blur(4px);" role="tablist" aria-label="Demo: switch proposal lane">
+  <button class="btn" role="tab" aria-selected="true"  data-tab="body"    id="tab-body"    style="border-radius:0; border-top:none; border-left:none; font-size:10px;">Body-edit lane</button>
+  <button class="btn" role="tab" aria-selected="false" data-tab="gov"     id="tab-gov"     style="border-radius:0; border-top:none; font-size:10px;">Governance lane</button>
+  <button class="btn" role="tab" aria-selected="false" data-tab="blocked" id="tab-blocked" style="border-radius:0; border-top:none; font-size:10px;">Blocked (CANVAS_ENABLED=0)</button>
+  <button class="btn" role="tab" aria-selected="false" data-tab="idle"    id="tab-idle"    style="border-radius:0; border-top:none; font-size:10px;">Idle</button>
+  <button class="btn" role="tab" aria-selected="false" data-tab="thinking" id="tab-thinking" style="border-radius:0; border-top:none; border-right:none; font-size:10px;">Thinking</button>
+</div>
+
+<!-- ================================================================
+     STATE MACHINE
+     Implements §3 state enum and transitions.
+     Logs would-be backend calls to console per §9 turn kinds.
+     ================================================================ -->
+<script>
+(function () {
+  'use strict';
+
+  /* --- element refs --- */
+  const shell        = document.getElementById('shell');
+  const thread       = document.getElementById('thread');
+  const thinking     = document.getElementById('thinking');
+  const cardBody     = document.getElementById('card-body');
+  const cardGov      = document.getElementById('card-gov');
+  const cardBlocked  = document.getElementById('card-blocked');
+  const insertion    = document.getElementById('doc-insertion');
+  const receiptsStrip = document.getElementById('receipts-strip');
+  const receiptsEmpty = document.getElementById('receipts-empty');
+  const composerInput = document.getElementById('composer-input');
+  const btnSend      = document.getElementById('btn-send');
+  const btnApply     = document.getElementById('btn-apply');
+  const btnDiscard   = document.getElementById('btn-discard');
+  const btnQueue     = document.getElementById('btn-queue');
+  const btnDiscardGov = document.getElementById('btn-discard-gov');
+  const btnAck       = document.getElementById('btn-ack');
+  const btnUndo      = document.getElementById('btn-undo');
+  const btnCancel    = document.getElementById('btn-cancel');
+  const provState    = document.getElementById('prov-state-label');
+  const provTurns    = document.getElementById('prov-turns');
+  const turnCount    = document.getElementById('turn-count');
+
+  /* --- state --- */
+  let state       = 'idle';
+  let turns       = 14;
+  let lastApplied = null;
+
+  /* --- state machine --- */
+  function setState(s) {
+    state = s;
+    shell.dataset.suggestionState = s;
+    provState.textContent = s;
+
+    // map to CSS-friendly alias
+    const cssState = {
+      'idle':                    'idle',
+      'thinking':                'thinking',
+      'suggestion-staged:body':  'staged-body',
+      'suggestion-staged:gov':   'staged-gov',
+      'apply-pending':           'pending-apply',
+      'governance-pending':      'pending-gov',
+      'applied':                 'applied',
+      'discarded':               'discarded',
+      'blocked':                 'blocked',
+    }[s] || s;
+    shell.dataset.suggestionState = cssState;
+
+    // composer enablement: enabled only in idle
+    const composerEnabled = s === 'idle';
+    composerInput.disabled = !composerEnabled;
+    btnSend.disabled = !composerEnabled;
+    composerInput.placeholder = {
+      'idle':                   'Message Hugin…',
+      'thinking':               'Hugin is thinking…',
+      'suggestion-staged:body': 'Apply or discard to continue',
+      'suggestion-staged:gov':  'Queue or discard to continue',
+      'apply-pending':          'Applying edit…',
+      'governance-pending':     'Routing to governance…',
+      'applied':                'Message Hugin…',
+      'discarded':              'Message Hugin…',
+      'blocked':                'Canvas disabled in this environment',
+    }[s] || 'Message Hugin…';
+
+    console.log('[canvas-shell] state →', s);
+  }
+
+  function logTurn(kind, fields) {
+    turns += 1;
+    turnCount.textContent = turns + ' turns';
+    provTurns.textContent = turns;
+    const entry = { ts: new Date().toISOString(), kind, ...fields };
+    console.log('[session-log:append_turn]', entry);
+  }
+
+  /* --- lane switcher (demo only) --- */
+  function setTab(tab) {
+    document.querySelectorAll('[role="tab"][data-tab]').forEach(t => {
+      t.setAttribute('aria-selected', t.dataset.tab === tab ? 'true' : 'false');
+      t.style.borderBottomColor = t.dataset.tab === tab ? 'var(--cyan)' : 'transparent';
+      t.style.color = t.dataset.tab === tab ? 'var(--cyan)' : '';
+    });
+
+    // reset card states first
+    cardBody.style.display    = 'none';
+    cardGov.style.display     = 'none';
+    cardBlocked.style.display = 'none';
+    thinking.style.display    = 'none';
+    thinking.dataset.thinking = 'inactive';
+
+    if (tab === 'body') {
+      cardBody.style.display = 'flex';
+      cardBody.dataset.variant = 'body';
+      cardBody.querySelector('.card-label').textContent = 'HUGIN · PROPOSED ADDITION';
+      cardBody.querySelector('.card-actions').style.display = 'flex';
+      btnApply.disabled = false;
+      btnDiscard.disabled = false;
+      insertion.style.display = 'block';
+      insertion.dataset.state = 'staged';
+      insertion.removeAttribute('data-receipt');
+      btnUndo.disabled = lastApplied === null;
+      setState('suggestion-staged:body');
+
+    } else if (tab === 'gov') {
+      cardGov.style.display = 'flex';
+      insertion.style.display = 'none';
+      setState('suggestion-staged:gov');
+
+    } else if (tab === 'blocked') {
+      cardBlocked.style.display = 'flex';
+      insertion.style.display = 'none';
+      setState('blocked');
+
+    } else if (tab === 'thinking') {
+      thinking.style.display = 'inline-flex';
+      thinking.dataset.thinking = 'active';
+      insertion.style.display = 'block';
+      insertion.dataset.state = 'staged';
+      setState('thinking');
+
+    } else { // idle
+      insertion.style.display = 'none';
+      setState('idle');
+    }
+  }
+
+  document.querySelectorAll('[role="tab"][data-tab]').forEach(t => {
+    t.addEventListener('click', () => setTab(t.dataset.tab));
+  });
+
+  /* --- BODY LANE: apply --- */
+  btnApply.addEventListener('click', () => {
+    setState('apply-pending');
+    btnApply.disabled = true;
+    btnDiscard.disabled = true;
+    thinking.style.display = 'inline-flex';
+    thinking.dataset.thinking = 'active';
+    thinking.querySelector('.thinking-cancel').style.display = 'none';
+    thinking.querySelector('span').textContent = 'CANVAS_WRITER';
+
+    console.log('[canvas_writer.apply_edit]', {
+      session_id: 's_4f81',
+      suggestion_id: 'suggestion-001',
+      note_path: 'Projects/Q2-arch.md',
+    });
+
+    setTimeout(() => {
+      thinking.style.display = 'none';
+      thinking.querySelector('.thinking-cancel').style.display = '';
+      thinking.querySelector('span').textContent = 'HUGIN';
+
+      const receiptId = 'body_edit#a' + Math.random().toString(16).slice(2, 6);
+      lastApplied = receiptId;
+
+      // flip in-document marker to applied
+      insertion.dataset.state = 'applied';
+      insertion.setAttribute('data-receipt', receiptId);
+
+      // collapse rail card to one-line log
+      cardBody.dataset.variant = 'applied';
+      cardBody.querySelector('.card-label').textContent = '✓ APPLIED · ' + receiptId;
+      cardBody.querySelector('.card-actions').style.display = 'none';
+
+      logTurn('body_edit_applied', {
+        suggestion_id: 'suggestion-001',
+        receipt: receiptId,
+        anchor: '## Current state',
+        note_path: 'Projects/Q2-arch.md',
+      });
+
+      btnUndo.disabled = false;
+      setState('applied');
+      setTimeout(() => setState('idle'), 1400);
+    }, 900);
+  });
+
+  /* --- BODY LANE: discard --- */
+  btnDiscard.addEventListener('click', () => {
+    insertion.dataset.state = 'discarded';
+    cardBody.dataset.variant = 'discarded';
+    cardBody.querySelector('.card-label').textContent = 'DISCARDED · just now';
+    cardBody.querySelector('.card-actions').style.display = 'none';
+    logTurn('body_edit_discarded', { suggestion_id: 'suggestion-001' });
+    setState('discarded');
+    setTimeout(() => setState('idle'), 1400);
+  });
+
+  /* --- BODY LANE: undo --- */
+  btnUndo.addEventListener('click', () => {
+    if (!lastApplied) return;
+    insertion.dataset.state = 'staged';
+    insertion.removeAttribute('data-receipt');
+    cardBody.dataset.variant = 'body';
+    cardBody.querySelector('.card-label').textContent = 'HUGIN · PROPOSED ADDITION';
+    cardBody.querySelector('.card-actions').style.display = 'flex';
+    btnApply.disabled = false;
+    btnDiscard.disabled = false;
+    logTurn('body_edit_undone', { inverse_of: lastApplied });
+    lastApplied = null;
+    btnUndo.disabled = true;
+    setState('suggestion-staged:body');
+  });
+
+  /* --- GOVERNANCE LANE: queue --- */
+  btnQueue.addEventListener('click', () => {
+    setState('governance-pending');
+    btnQueue.disabled = true;
+    btnDiscardGov.disabled = true;
+
+    console.log('[GovernanceRouter.request_governance_action]', {
+      action_type: 'PROMOTE_MATURITY',
+      session_id: 's_4f81',
+      payload: { from: 'draft', to: 'committed', tag_add: ['arch/decision'] },
+    });
+
+    setTimeout(() => {
+      const rid = 'gov#' + Math.random().toString(16).slice(2, 6);
+
+      logTurn('governance_intent_queued', {
+        suggestion_id: 'suggestion-002',
+        action_type: 'PROMOTE_MATURITY',
+        receipt_id: rid,
+      });
+
+      // add receipt pill inline
+      const pillInline = document.createElement('span');
+      pillInline.className = 'receipt-pill';
+      pillInline.setAttribute('data-testid', 'receipt-pill');
+      pillInline.setAttribute('data-receipt-id', rid);
+      pillInline.setAttribute('data-status', 'queued');
+      pillInline.setAttribute('data-intent', 'governance.openReceipt');
+      pillInline.setAttribute('aria-label', 'Governance receipt ' + rid + ', queued. Open in Panel.');
+      pillInline.innerHTML = '<span class="recdot"></span>queued · ' + rid + ' · PROMOTE_MATURITY · open in panel ›';
+      thread.appendChild(pillInline);
+
+      // add to receipts strip
+      receiptsEmpty.style.display = 'none';
+      const pillStrip = pillInline.cloneNode(true);
+      receiptsStrip.appendChild(pillStrip);
+
+      // collapse gov card
+      cardGov.dataset.variant = 'applied';
+      cardGov.querySelector('.card-label').textContent = '✓ QUEUED · ' + rid;
+      const classEl = cardGov.querySelector('.card-classification');
+      if (classEl) classEl.textContent = 'awaiting governance review in AI Panel';
+      cardGov.querySelector('.card-actions').style.display = 'none';
+
+      setState('idle');
+    }, 700);
+  });
+
+  /* --- GOVERNANCE LANE: discard --- */
+  btnDiscardGov.addEventListener('click', () => {
+    cardGov.dataset.variant = 'discarded';
+    cardGov.querySelector('.card-label').textContent = 'DISCARDED · just now';
+    cardGov.querySelector('.card-actions').style.display = 'none';
+    logTurn('governance_intent_discarded', { suggestion_id: 'suggestion-002' });
+    setState('discarded');
+    setTimeout(() => setState('idle'), 1400);
+  });
+
+  /* --- BLOCKED: acknowledge --- */
+  btnAck.addEventListener('click', () => {
+    logTurn('governance_intent_blocked', {
+      suggestion_id: 'suggestion-003',
+      action_type: 'PROMOTE_MATURITY',
+      reason: 'CANVAS_ENABLED=0',
+    });
+    cardBlocked.style.opacity = '0.5';
+    btnAck.disabled = true;
+    setTimeout(() => setState('idle'), 2000);
+  });
+
+  /* --- CANCEL thinking --- */
+  btnCancel.addEventListener('click', () => {
+    thinking.style.display = 'none';
+    thinking.dataset.thinking = 'inactive';
+    setState('idle');
+  });
+
+  /* --- Rail collapse toggle --- */
+  document.getElementById('collapsed-strip').addEventListener('click', () => {
+    shell.dataset.railState = 'expanded';
+  });
+
+  /* --- Keyboard shortcuts — bound only in staged states (§11) --- */
+  document.addEventListener('keydown', (e) => {
+    if (e.target === composerInput) return;
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+
+    if (state === 'suggestion-staged:body') {
+      if (e.key === 'a' || e.key === 'A') { e.preventDefault(); btnApply.click(); }
+      if (e.key === 'd' || e.key === 'D') { e.preventDefault(); btnDiscard.click(); }
+      if (e.key === 'i' || e.key === 'I') { e.preventDefault(); console.log('[suggestion.inspect] diff expansion — UI-only'); }
+      if (e.key === 'e' || e.key === 'E') { e.preventDefault(); console.log('[suggestion.edit] inline edit before apply — UI-only'); }
+    } else if (state === 'suggestion-staged:gov') {
+      if (e.key === 'q' || e.key === 'Q') { e.preventDefault(); btnQueue.click(); }
+      if (e.key === 'd' || e.key === 'D') { e.preventDefault(); btnDiscardGov.click(); }
+      if (e.key === 'i' || e.key === 'I') { e.preventDefault(); console.log('[suggestion.inspect] classification rationale — UI-only'); }
+    }
+  });
+
+  /* --- Portrait bottom-sheet behavior --- */
+  function applySheetSnap(snap) {
+    const rail = document.getElementById('rail');
+    if (!rail) return;
+    rail.dataset.sheet = snap;
+    try { sessionStorage.setItem('canvas-sheet-' + shell.dataset.sessionId, snap); } catch (_) {}
+  }
+
+  function initSheet() {
+    const saved = (() => {
+      try { return sessionStorage.getItem('canvas-sheet-' + shell.dataset.sessionId); } catch (_) { return null; }
+    })();
+    applySheetSnap(saved || 'peek');
+  }
+
+  // auto-snap to half when a proposal arrives in portrait
+  function onProposalArrived() {
+    if (window.matchMedia('(max-width: 899px)').matches) {
+      applySheetSnap('half');
+    }
+  }
+
+  // hook proposal arrival to auto-snap
+  const _origSetState = setState;
+  function setState(s) {
+    _origSetState(s);
+    if (s === 'suggestion-staged:body' || s === 'suggestion-staged:gov') {
+      onProposalArrived();
+    }
+  }
+
+  initSheet();
+
+  /* --- initial state --- */
+  setTab('body');
+
+})();
+</script>
+
+</body>
+</html>

--- a/companion-ui/companion-app/colors_and_type.css
+++ b/companion-ui/companion-app/colors_and_type.css
@@ -1,0 +1,346 @@
+/* ============================================================
+   Yggdrasil Design System — Colors & Type
+   ============================================================
+   Import this file in any HTML artifact or UI kit.
+   Google Fonts are imported below; JetBrains Mono via bunny.net.
+   ============================================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Space+Grotesk:wght@300;400;500;600&display=swap');
+@import url('https://fonts.bunny.net/css?family=jetbrains-mono:400,500&display=swap');
+
+/* ============================================================
+   BASE COLOR TOKENS
+   ============================================================ */
+:root {
+  /* --- Backgrounds (cool blue-black — Tron grid) --- */
+  --bg-base:       #070b12;   /* deepest — page root, near black with blue cast */
+  --bg-surface:    #0c1220;   /* panels, sidebars */
+  --bg-raised:     #111a2e;   /* cards, inputs, raised surfaces */
+  --bg-overlay:    #162038;   /* hover states, popovers */
+  --bg-modal:      #0e1828;   /* modal / dialog backdrop content */
+
+  /* --- Foreground / Text --- */
+  --fg-1:          #dce8f0;   /* primary — cool blue-white */
+  --fg-2:          #7a9ab8;   /* secondary / muted */
+  --fg-3:          #3d5570;   /* tertiary / disabled / dim */
+  --fg-inverse:    #070b12;   /* text on light/accent backgrounds */
+
+  /* --- Borders (thin, slightly glowing) --- */
+  --border:        #152030;   /* default — subtle grid line */
+  --border-strong: #1e3050;   /* emphasis — dividers, active edges */
+  --border-focus:  #00d4e8;   /* focus ring — electric cyan */
+
+  /* --- Accent 1: Norse Gold (slightly electrified) --- */
+  --accent:        #d4a843;   /* primary accent — active, focus, key affordances */
+  --accent-dim:    #80621a;   /* dimmed gold */
+  --accent-muted:  #2a1e06;   /* gold at low opacity */
+
+  /* --- Accent 2: Tron Cyan (neon electric) --- */
+  --cyan:          #00d4e8;   /* electric cyan — Tron primary glow */
+  --cyan-dim:      #007a8a;   /* dimmed cyan */
+  --cyan-muted:    #001e28;   /* cyan tint background */
+  --cyan-glow:     0 0 12px rgba(0,212,232,0.35), 0 0 4px rgba(0,212,232,0.5);
+
+  /* --- Vault: Neon green (digital growth) --- */
+  --vault:         #39e87d;   /* vault-connected — electric green */
+  --vault-dim:     #1a7840;   /* vault hover */
+  --vault-muted:   #041a10;   /* vault background tint */
+  --vault-glow:    0 0 8px rgba(57,232,125,0.3);
+
+  /* --- Agent: Electric blue (machine voice) --- */
+  --agent:         #4a9eff;   /* agent-contributed UI and content */
+  --agent-dim:     #1e5a9a;   /* agent hover */
+  --agent-muted:   #051228;   /* agent background tint */
+  --agent-glow:    0 0 8px rgba(74,158,255,0.3);
+
+  /* --- Amber (staged / uncommitted) --- */
+  --amber:         #f09030;   /* warnings, uncommitted/staged state */
+  --amber-dim:     #805010;
+  --amber-muted:   #1a0e02;
+
+  /* --- Destructive --- */
+  --destructive:      #ff3d3d;
+  --destructive-dim:  #8a1a1a;
+  --destructive-muted:#160404;
+
+  /* --- Semantic UI colors --- */
+  --color-bg:        var(--bg-base);
+  --color-surface:   var(--bg-surface);
+  --color-text:      var(--fg-1);
+  --color-muted:     var(--fg-2);
+  --color-dim:       var(--fg-3);
+  --color-border:    var(--border);
+  --color-accent:    var(--accent);
+
+  /* ============================================================
+     TYPOGRAPHY
+     ============================================================ */
+
+  /* --- Font families --- */
+  --font-display:  'EB Garamond', Georgia, serif;
+  --font-ui:       'Space Grotesk', system-ui, sans-serif;
+  --font-mono:     'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+
+  /* --- Type scale (rem, base 16px) --- */
+  --text-xs:    0.6875rem;   /* 11px — metadata, timestamps */
+  --text-sm:    0.8125rem;   /* 13px — secondary labels, captions */
+  --text-base:  0.9375rem;   /* 15px — body / default UI */
+  --text-md:    1.0625rem;   /* 17px — slightly emphasized body */
+  --text-lg:    1.1875rem;   /* 19px — section headers */
+  --text-xl:    1.5rem;      /* 24px — page titles */
+  --text-2xl:   2rem;        /* 32px — display moments */
+  --text-3xl:   2.75rem;     /* 44px — wordmark / hero */
+  --text-4xl:   3.75rem;     /* 60px — large display */
+
+  /* --- Line heights --- */
+  --leading-tight:  1.25;
+  --leading-snug:   1.4;
+  --leading-normal: 1.55;
+  --leading-loose:  1.75;
+
+  /* --- Font weights --- */
+  --weight-light:   300;
+  --weight-regular: 400;
+  --weight-medium:  500;
+  --weight-semibold:600;
+
+  /* --- Letter spacing --- */
+  --tracking-tight: -0.02em;
+  --tracking-normal: 0em;
+  --tracking-wide:   0.04em;
+  --tracking-wider:  0.08em;
+
+  /* ============================================================
+     SPACING
+     ============================================================ */
+  --space-1:   4px;
+  --space-2:   8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  20px;
+  --space-6:  24px;
+  --space-8:  32px;
+  --space-10: 40px;
+  --space-12: 48px;
+  --space-16: 64px;
+
+  /* ============================================================
+     BORDER RADIUS — sharper for cyberpunk aesthetic
+     ============================================================ */
+  --radius-sm:   2px;
+  --radius-md:   4px;
+  --radius-lg:   6px;
+  --radius-xl:  10px;
+  --radius-full: 9999px;
+
+  /* ============================================================
+     SHADOWS / ELEVATION
+     ============================================================ */
+  --shadow-sm:  0 1px 3px rgba(0,0,0,0.3);
+  --shadow-md:  0 4px 12px rgba(0,0,0,0.4);
+  --shadow-lg:  0 8px 32px rgba(0,0,0,0.5);
+  --shadow-float: 0 4px 24px rgba(0,0,0,0.55), 0 1px 4px rgba(0,0,0,0.3);
+  --shadow-inset: inset 0 1px 3px rgba(0,0,0,0.35);
+
+  /* ============================================================
+     ANIMATION
+     ============================================================ */
+  --ease:        cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-linear: linear;
+  --duration-fast: 100ms;
+  --duration-base: 150ms;
+  --duration-slow: 250ms;
+
+  /* ============================================================
+     Z-INDEX SCALE
+     ============================================================ */
+  --z-base:    1;
+  --z-raised:  10;
+  --z-sticky:  100;
+  --z-overlay: 200;
+  --z-modal:   300;
+  --z-toast:   400;
+}
+
+/* ============================================================
+   SEMANTIC ELEMENT DEFAULTS
+   ============================================================ */
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+body {
+  background-color: var(--bg-base);
+  color: var(--fg-1);
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-normal);
+}
+
+/* --- Display headings (EB Garamond) --- */
+h1, .h1 {
+  font-family: var(--font-display);
+  font-size: var(--text-3xl);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  color: var(--fg-1);
+}
+
+h2, .h2 {
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  color: var(--fg-1);
+}
+
+/* --- UI headings (DM Sans) --- */
+h3, .h3 {
+  font-family: var(--font-ui);
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-snug);
+  color: var(--fg-1);
+}
+
+h4, .h4 {
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-snug);
+  color: var(--fg-1);
+}
+
+h5, h6, .h5, .h6 {
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-snug);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--fg-2);
+}
+
+p {
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
+  color: var(--fg-1);
+  text-wrap: pretty;
+}
+
+small, .text-sm {
+  font-size: var(--text-sm);
+  color: var(--fg-2);
+}
+
+.text-xs {
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  font-family: var(--font-mono);
+  letter-spacing: var(--tracking-wide);
+}
+
+code, kbd, pre, .mono {
+  font-family: var(--font-mono);
+  font-size: 0.875em; /* relative to surrounding text */
+}
+
+code {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.1em 0.35em;
+  color: var(--fg-1);
+}
+
+pre {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  overflow-x: auto;
+  font-size: var(--text-sm);
+  line-height: var(--leading-normal);
+  color: var(--fg-1);
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+a:hover {
+  color: var(--fg-1);
+  text-decoration: underline;
+}
+
+hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: var(--space-6) 0;
+}
+
+/* ============================================================
+   UTILITY CLASSES
+   ============================================================ */
+
+/* Text colors */
+.text-primary   { color: var(--fg-1); }
+.text-secondary { color: var(--fg-2); }
+.text-dim       { color: var(--fg-3); }
+.text-accent    { color: var(--accent); }
+.text-cyan      { color: var(--cyan); }
+.text-vault     { color: var(--vault); }
+.text-agent     { color: var(--agent); }
+.text-amber     { color: var(--amber); }
+.text-danger    { color: var(--destructive); }
+
+/* Font families */
+.font-display { font-family: var(--font-display); }
+.font-ui      { font-family: var(--font-ui); }
+.font-mono    { font-family: var(--font-mono); }
+
+/* Weights */
+.weight-light    { font-weight: var(--weight-light); }
+.weight-regular  { font-weight: var(--weight-regular); }
+.weight-medium   { font-weight: var(--weight-medium); }
+.weight-semibold { font-weight: var(--weight-semibold); }
+
+/* Glow effects */
+.glow-cyan   { box-shadow: var(--cyan-glow); }
+.glow-vault  { box-shadow: var(--vault-glow); }
+.glow-agent  { box-shadow: var(--agent-glow); }
+.text-glow-cyan  { text-shadow: 0 0 12px rgba(0,212,232,0.7); }
+.text-glow-gold  { text-shadow: 0 0 16px rgba(212,168,67,0.5); }
+
+/* Tron grid background */
+.grid-bg {
+  background-image:
+    linear-gradient(rgba(0,212,232,0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0,212,232,0.04) 1px, transparent 1px);
+  background-size: 32px 32px;
+}
+
+/* Neon border active state */
+.border-cyan { border-color: var(--cyan) !important; box-shadow: var(--cyan-glow); }
+.border-gold { border-color: var(--accent) !important; box-shadow: 0 0 8px rgba(212,168,67,0.3); }
+
+/* Focus ring */
+:focus-visible {
+  outline: 1px solid var(--cyan);
+  outline-offset: 2px;
+  box-shadow: var(--cyan-glow);
+}

--- a/companion-ui/design_handoff/2026-05-11-canvas-suggestion-flow/Canvas Suggestion Flow.html
+++ b/companion-ui/design_handoff/2026-05-11-canvas-suggestion-flow/Canvas Suggestion Flow.html
@@ -1,0 +1,1797 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Canvas Suggestion Flow — Companion UI Spec</title>
+<link rel="stylesheet" href="./colors_and_type.css" />
+<style>
+  /* ---- Page chrome ---- */
+  html, body { background: var(--bg-base); }
+  body {
+    background-image:
+      linear-gradient(rgba(0,212,232,0.025) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(0,212,232,0.025) 1px, transparent 1px);
+    background-size: 48px 48px;
+  }
+
+  .page {
+    max-width: 1180px;
+    margin: 0 auto;
+    padding: var(--space-12) var(--space-8) var(--space-16);
+    display: grid;
+    grid-template-columns: 220px 1fr;
+    gap: var(--space-12);
+  }
+
+  /* ---- Sidebar TOC ---- */
+  .toc {
+    position: sticky;
+    top: var(--space-8);
+    align-self: start;
+    font-size: var(--text-sm);
+    border-left: 1px solid var(--border);
+    padding-left: var(--space-4);
+    max-height: calc(100vh - var(--space-12));
+    overflow-y: auto;
+  }
+  .toc-label {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    margin-bottom: var(--space-3);
+  }
+  .toc ol { list-style: none; display: flex; flex-direction: column; gap: 6px; }
+  .toc a {
+    color: var(--fg-2);
+    font-family: var(--font-ui);
+    font-size: var(--text-sm);
+    display: block;
+    line-height: 1.4;
+  }
+  .toc a:hover { color: var(--cyan); text-decoration: none; }
+  .toc-num {
+    font-family: var(--font-mono);
+    color: var(--fg-3);
+    margin-right: 6px;
+    font-size: var(--text-xs);
+  }
+
+  /* ---- Header ---- */
+  .doc-header {
+    border-bottom: 1px solid var(--border);
+    padding-bottom: var(--space-6);
+    margin-bottom: var(--space-10);
+  }
+  .doc-eyebrow {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--cyan);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    margin-bottom: var(--space-3);
+  }
+  .doc-title {
+    font-family: var(--font-display);
+    font-size: var(--text-3xl);
+    line-height: 1.1;
+    margin-bottom: var(--space-4);
+    color: var(--fg-1);
+  }
+  .doc-meta {
+    display: flex;
+    gap: var(--space-6);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+  }
+  .doc-meta span strong {
+    color: var(--fg-2);
+    font-weight: var(--weight-regular);
+    margin-right: 6px;
+  }
+
+  /* ---- Sections ---- */
+  section.spec {
+    margin-bottom: var(--space-12);
+    scroll-margin-top: var(--space-6);
+  }
+  section.spec > h2 {
+    font-family: var(--font-display);
+    font-size: var(--text-2xl);
+    font-weight: var(--weight-regular);
+    color: var(--fg-1);
+    margin-bottom: var(--space-2);
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-3);
+  }
+  section.spec > h2 .secnum {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--cyan);
+    letter-spacing: var(--tracking-wide);
+  }
+  section.spec > .lede {
+    color: var(--fg-2);
+    font-size: var(--text-base);
+    margin-bottom: var(--space-5);
+    max-width: 70ch;
+  }
+  section.spec h3 {
+    font-family: var(--font-ui);
+    font-size: var(--text-base);
+    font-weight: var(--weight-semibold);
+    color: var(--fg-1);
+    margin: var(--space-6) 0 var(--space-3);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    font-size: var(--text-sm);
+  }
+  section.spec p { color: var(--fg-1); margin-bottom: var(--space-3); max-width: 72ch; }
+  section.spec p + p { margin-top: var(--space-2); }
+  section.spec ul, section.spec ol {
+    color: var(--fg-1);
+    margin: 0 0 var(--space-4) var(--space-5);
+    max-width: 72ch;
+  }
+  section.spec li { margin-bottom: 6px; line-height: 1.55; }
+  section.spec li code, section.spec p code { font-size: 0.9em; }
+
+  /* ---- Tables ---- */
+  table.spec {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--text-sm);
+    margin: var(--space-3) 0 var(--space-5);
+    border: 1px solid var(--border);
+    background: var(--bg-surface);
+  }
+  table.spec th, table.spec td {
+    text-align: left;
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+  }
+  table.spec th {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    color: var(--fg-2);
+    background: var(--bg-raised);
+    font-weight: var(--weight-medium);
+    border-bottom: 1px solid var(--border-strong);
+  }
+  table.spec tr:last-child td { border-bottom: none; }
+  table.spec td code { font-size: 0.9em; }
+  table.spec td.mono, table.spec th.mono { font-family: var(--font-mono); }
+
+  /* ---- Callouts ---- */
+  .callout {
+    border-left: 2px solid var(--cyan);
+    background: rgba(0,212,232,0.04);
+    padding: var(--space-3) var(--space-4);
+    margin: var(--space-4) 0;
+    font-size: var(--text-sm);
+    color: var(--fg-1);
+    max-width: 72ch;
+  }
+  .callout.warn { border-left-color: var(--amber); background: rgba(240,144,48,0.05); }
+  .callout.invariant { border-left-color: var(--accent); background: rgba(212,168,67,0.04); }
+  .callout-label {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    color: var(--cyan);
+    display: block;
+    margin-bottom: 4px;
+  }
+  .callout.warn .callout-label { color: var(--amber); }
+  .callout.invariant .callout-label { color: var(--accent); }
+
+  /* ---- Tag chips ---- */
+  .chip {
+    display: inline-block;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    letter-spacing: var(--tracking-wide);
+    padding: 1px 8px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-strong);
+    background: var(--bg-raised);
+    color: var(--fg-2);
+  }
+  .chip.design { color: var(--cyan); border-color: rgba(0,212,232,0.3); }
+  .chip.impl   { color: var(--accent); border-color: rgba(212,168,67,0.3); }
+  .chip.gated  { color: var(--amber); border-color: rgba(240,144,48,0.3); }
+  .chip.agent  { color: var(--agent); border-color: rgba(74,158,255,0.3); }
+  .chip.vault  { color: var(--vault); border-color: rgba(57,232,125,0.3); }
+
+  /* ---- Code blocks ---- */
+  pre.code {
+    background: var(--bg-raised);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    padding: var(--space-4);
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--fg-1);
+    overflow-x: auto;
+    margin: var(--space-3) 0 var(--space-5);
+    line-height: 1.55;
+  }
+  pre.code .k { color: var(--cyan); }
+  pre.code .s { color: var(--vault); }
+  pre.code .c { color: var(--fg-3); font-style: italic; }
+  pre.code .n { color: var(--accent); }
+
+  /* ============================================================
+     STATE GALLERY (Section 5 visual states)
+     ============================================================ */
+  .gallery {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--space-5);
+    margin: var(--space-4) 0 var(--space-6);
+  }
+  .gallery-card {
+    border: 1px solid var(--border);
+    background: var(--bg-surface);
+    border-radius: var(--radius-md);
+    padding: var(--space-4);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+  }
+  .gallery-card header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+    border-bottom: 1px dashed var(--border);
+    padding-bottom: 10px;
+  }
+  .gallery-card h4 {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    color: var(--fg-2);
+  }
+  .gallery-card p.note {
+    font-size: var(--text-sm);
+    color: var(--fg-2);
+    margin: 0;
+  }
+
+  /* ----- Rail viz primitives shared by all gallery cards ----- */
+  .rail-mock {
+    background: var(--bg-base);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: var(--space-3);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    min-height: 220px;
+    font-size: var(--text-sm);
+  }
+  .rail-mock .hdr {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    letter-spacing: var(--tracking-wider);
+    color: var(--fg-3);
+    text-transform: uppercase;
+  }
+  .rail-mock .hdr .dot {
+    width: 8px; height: 8px; border-radius: 50%;
+    background: var(--agent);
+    box-shadow: 0 0 6px rgba(74,158,255,0.6);
+  }
+  .rail-mock .turn-meta { margin-left: auto; color: var(--fg-3); }
+
+  .msg {
+    border-radius: var(--radius-sm);
+    padding: 8px 10px;
+    font-size: var(--text-sm);
+    line-height: 1.5;
+    color: var(--fg-1);
+    max-width: 92%;
+  }
+  .msg.agent {
+    background: var(--agent-muted);
+    border-left: 2px solid var(--agent);
+  }
+  .msg.user {
+    background: var(--bg-raised);
+    border-left: 2px solid var(--fg-3);
+    align-self: flex-end;
+  }
+  .msg .ctx-label {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    margin-bottom: 4px;
+  }
+
+  /* Suggestion card variants */
+  .sugg {
+    border-radius: var(--radius-sm);
+    padding: 10px 12px;
+    font-size: var(--text-sm);
+    color: var(--fg-1);
+    line-height: 1.55;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .sugg .sugg-label {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+  }
+  .sugg .diff-hint {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--fg-3);
+  }
+  .sugg.body {
+    background: rgba(240,144,48,0.06);
+    border: 1px solid rgba(240,144,48,0.35);
+  }
+  .sugg.body .sugg-label { color: var(--amber); }
+  .sugg.governance {
+    background: rgba(212,168,67,0.05);
+    border: 1px solid rgba(212,168,67,0.4);
+  }
+  .sugg.governance .sugg-label { color: var(--accent); }
+  .sugg.applied {
+    background: rgba(57,232,125,0.04);
+    border: 1px solid rgba(57,232,125,0.3);
+    opacity: 0.85;
+  }
+  .sugg.applied .sugg-label { color: var(--vault); }
+  .sugg.discarded {
+    background: var(--bg-raised);
+    border: 1px dashed var(--border-strong);
+    opacity: 0.55;
+    text-decoration: line-through;
+    text-decoration-color: var(--fg-3);
+  }
+  .sugg.blocked {
+    background: rgba(255,61,61,0.04);
+    border: 1px solid rgba(255,61,61,0.35);
+  }
+  .sugg.blocked .sugg-label { color: var(--destructive); }
+
+  .sugg-actions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-top: 2px;
+  }
+  .btn {
+    font-family: var(--font-ui);
+    font-size: var(--text-xs);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    padding: 5px 10px;
+    border-radius: var(--radius-sm);
+    background: var(--bg-raised);
+    color: var(--fg-1);
+    border: 1px solid var(--border-strong);
+    cursor: pointer;
+  }
+  .btn:hover { border-color: var(--cyan); color: var(--cyan); }
+  .btn.primary {
+    background: var(--amber-muted);
+    color: var(--amber);
+    border-color: rgba(240,144,48,0.5);
+  }
+  .btn.primary:hover { background: rgba(240,144,48,0.12); border-color: var(--amber); color: var(--amber); }
+  .btn.governance {
+    background: rgba(212,168,67,0.06);
+    color: var(--accent);
+    border-color: rgba(212,168,67,0.5);
+  }
+  .btn.governance:hover { background: rgba(212,168,67,0.12); border-color: var(--accent); }
+  .btn.ghost { background: transparent; }
+  .btn[disabled], .btn.disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    color: var(--fg-3);
+  }
+  .btn .kbd {
+    font-family: var(--font-mono);
+    font-size: 0.85em;
+    color: var(--fg-3);
+    margin-left: 6px;
+  }
+
+  /* Thinking dots */
+  .thinking {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    color: var(--agent);
+  }
+  .thinking .ddot {
+    width: 5px; height: 5px;
+    border-radius: 50%;
+    background: var(--agent);
+    animation: tdot 1.2s ease-in-out infinite;
+    box-shadow: 0 0 4px rgba(74,158,255,0.7);
+  }
+  .thinking .ddot:nth-child(3) { animation-delay: 0.15s; }
+  .thinking .ddot:nth-child(4) { animation-delay: 0.3s; }
+  @keyframes tdot {
+    0%, 70%, 100% { opacity: 0.2; transform: scale(0.7); }
+    35% { opacity: 1; transform: scale(1); }
+  }
+
+  /* Receipt pill */
+  .receipt {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 10px;
+    border-radius: var(--radius-full);
+    background: var(--bg-raised);
+    border: 1px solid var(--border-strong);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--fg-2);
+    letter-spacing: var(--tracking-wide);
+  }
+  .receipt.queued { color: var(--accent); border-color: rgba(212,168,67,0.4); }
+  .receipt.applied { color: var(--vault); border-color: rgba(57,232,125,0.4); }
+  .receipt.pending { color: var(--amber); border-color: rgba(240,144,48,0.4); }
+  .receipt .recdot {
+    width: 6px; height: 6px; border-radius: 50%;
+    background: currentColor;
+    box-shadow: 0 0 6px currentColor;
+  }
+  .receipt.queued .recdot { animation: pulse 1.6s ease-in-out infinite; }
+  @keyframes pulse { 0%, 100% { opacity: 0.4; } 50% { opacity: 1; } }
+
+  .doc-note-mock {
+    background: var(--bg-base);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 10px 12px;
+    font-size: var(--text-sm);
+    color: var(--fg-2);
+    line-height: 1.55;
+  }
+  .doc-note-mock .h {
+    font-family: var(--font-display);
+    color: var(--fg-1);
+    font-size: 1.05rem;
+    margin-bottom: 6px;
+  }
+  .doc-note-mock .ins {
+    background: rgba(240,144,48,0.08);
+    border-left: 2px solid var(--amber);
+    padding: 4px 8px;
+    margin: 6px 0;
+    color: var(--fg-1);
+  }
+  .doc-note-mock .ins-applied {
+    background: rgba(57,232,125,0.06);
+    border-left: 2px solid var(--vault);
+    padding: 4px 8px;
+    margin: 6px 0;
+    color: var(--fg-1);
+  }
+  .doc-note-mock .ins-ghost {
+    background: transparent;
+    border-left: 2px dashed var(--fg-3);
+    padding: 4px 8px;
+    margin: 6px 0;
+    color: var(--fg-3);
+    font-style: italic;
+  }
+
+  /* Composer */
+  .composer-mock {
+    margin-top: auto;
+    display: flex;
+    gap: 6px;
+    padding-top: 8px;
+    border-top: 1px solid var(--border);
+  }
+  .composer-mock input {
+    flex: 1;
+    background: var(--bg-raised);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    padding: 6px 10px;
+    color: var(--fg-1);
+    font-family: var(--font-ui);
+    font-size: var(--text-sm);
+  }
+  .composer-mock input[disabled] { color: var(--fg-3); }
+  .composer-mock input::placeholder { color: var(--fg-3); }
+
+  /* ============================================================
+     INTERACTIVE PROTOTYPE
+     ============================================================ */
+  .proto-frame {
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: var(--bg-surface);
+    margin: var(--space-4) 0 var(--space-6);
+    overflow: hidden;
+  }
+  .proto-tabs {
+    display: flex;
+    gap: 0;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-raised);
+  }
+  .proto-tab {
+    padding: 10px 16px;
+    background: transparent;
+    border: none;
+    color: var(--fg-2);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+  }
+  .proto-tab[aria-selected="true"] {
+    color: var(--cyan);
+    border-bottom-color: var(--cyan);
+    background: var(--bg-surface);
+  }
+  .proto-stage {
+    display: grid;
+    grid-template-columns: 1.4fr 1fr;
+    min-height: 460px;
+  }
+  .proto-doc {
+    padding: var(--space-5) var(--space-6);
+    border-right: 1px solid var(--border);
+    overflow-y: auto;
+    max-height: 540px;
+  }
+  .proto-doc h1 {
+    font-family: var(--font-display);
+    font-size: var(--text-2xl);
+    margin-bottom: var(--space-3);
+  }
+  .proto-doc h2 {
+    font-family: var(--font-display);
+    font-size: var(--text-lg);
+    margin: var(--space-5) 0 var(--space-2);
+    color: var(--fg-1);
+  }
+  .proto-doc p, .proto-doc li { font-size: var(--text-sm); color: var(--fg-1); line-height: 1.65; }
+  .proto-doc .note-path {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wide);
+    margin-bottom: var(--space-4);
+  }
+  .proto-doc .frontmatter {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--fg-2);
+    background: var(--bg-base);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 8px 12px;
+    margin-bottom: var(--space-4);
+    white-space: pre;
+  }
+  .proto-doc .insertion {
+    display: block;
+    margin: var(--space-3) 0;
+    padding: 8px 12px;
+    border-left: 2px solid var(--amber);
+    background: rgba(240,144,48,0.06);
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+    font-size: var(--text-sm);
+    color: var(--fg-1);
+    position: relative;
+    transition: all var(--duration-slow) var(--ease);
+  }
+  .proto-doc .insertion::before {
+    content: 'PROPOSED · UNCOMMITTED';
+    position: absolute;
+    top: -8px;
+    left: 8px;
+    background: var(--bg-surface);
+    padding: 0 6px;
+    font-family: var(--font-mono);
+    font-size: 9px;
+    letter-spacing: var(--tracking-wider);
+    color: var(--amber);
+  }
+  .proto-doc .insertion[data-state="applied"] {
+    border-left-color: var(--vault);
+    background: rgba(57,232,125,0.04);
+  }
+  .proto-doc .insertion[data-state="applied"]::before {
+    content: 'APPLIED · ' attr(data-receipt);
+    color: var(--vault);
+  }
+  .proto-doc .insertion[data-state="discarded"] {
+    display: none;
+  }
+
+  .proto-rail {
+    display: flex;
+    flex-direction: column;
+    padding: var(--space-4);
+    gap: var(--space-3);
+    background: var(--bg-surface);
+    max-height: 540px;
+    overflow-y: auto;
+  }
+  .proto-rail .hdr {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 10px;
+  }
+  .proto-rail .hdr .dot {
+    width: 8px; height: 8px; border-radius: 50%;
+    background: var(--agent);
+    box-shadow: 0 0 6px rgba(74,158,255,0.6);
+  }
+  .proto-rail .turn-meta { margin-left: auto; color: var(--fg-3); }
+
+  .receipts-strip {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px 10px;
+    background: var(--bg-base);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+  }
+  .receipts-strip .rlbl {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+  }
+  .receipts-strip .empty {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--fg-3);
+    font-style: italic;
+  }
+
+  .proto-controls {
+    display: flex;
+    gap: 8px;
+    padding: var(--space-3) var(--space-5);
+    background: var(--bg-base);
+    border-top: 1px solid var(--border);
+    align-items: center;
+    flex-wrap: wrap;
+  }
+  .proto-controls .label {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    margin-right: 8px;
+  }
+
+  /* responsive: collapse columns */
+  @media (max-width: 900px) {
+    .page { grid-template-columns: 1fr; padding: var(--space-6) var(--space-4); }
+    .toc { position: static; max-height: none; border-left: none; border-bottom: 1px solid var(--border); padding: 0 0 var(--space-4); }
+    .gallery { grid-template-columns: 1fr; }
+    .proto-stage { grid-template-columns: 1fr; }
+    .proto-doc { border-right: none; border-bottom: 1px solid var(--border); max-height: none; }
+  }
+</style>
+</head>
+<body>
+<div class="page">
+
+  <!-- =========================== TOC =========================== -->
+  <nav class="toc" aria-label="Section index">
+    <div class="toc-label">Spec sections</div>
+    <ol>
+      <li><a href="#s1"><span class="toc-num">01</span>Context interpretation</a></li>
+      <li><a href="#s2"><span class="toc-num">02</span>Interaction sequence</a></li>
+      <li><a href="#s3"><span class="toc-num">03</span>UI state model</a></li>
+      <li><a href="#s4"><span class="toc-num">04</span>Component inventory</a></li>
+      <li><a href="#s5"><span class="toc-num">05</span>Data-intent &amp; testid</a></li>
+      <li><a href="#s6"><span class="toc-num">06</span>API concept mapping</a></li>
+      <li><a href="#s7"><span class="toc-num">07</span>Body-edit lane</a></li>
+      <li><a href="#s8"><span class="toc-num">08</span>Governance lane</a></li>
+      <li><a href="#s9"><span class="toc-num">09</span>Receipts &amp; provenance</a></li>
+      <li><a href="#s10"><span class="toc-num">10</span>Responsive behavior</a></li>
+      <li><a href="#s11"><span class="toc-num">11</span>Accessibility</a></li>
+      <li><a href="#s12"><span class="toc-num">12</span>Prototype</a></li>
+      <li><a href="#s13"><span class="toc-num">13</span>Design vs contract</a></li>
+      <li><a href="#s14"><span class="toc-num">14</span>Open questions</a></li>
+    </ol>
+  </nav>
+
+  <!-- =========================== MAIN =========================== -->
+  <main>
+    <header class="doc-header">
+      <div class="doc-eyebrow">Companion UI · Design Handoff · Canvas / Hugin</div>
+      <h1 class="doc-title">Canvas Suggestion Flow</h1>
+      <p style="color: var(--fg-2); font-size: var(--text-md); max-width: 70ch; margin-bottom: var(--space-5);">
+        A narrow, implementation-ready slice covering the moment Hugin proposes a change to the active note,
+        the user previews it, and the system either co-authors the body in place or routes the intent into
+        the governed pipeline. Document is the artifact; chat is the canvas; mutation is gated.
+      </p>
+      <div class="doc-meta">
+        <span><strong>Capability:</strong> CANVAS_CHAT_SURFACE</span>
+        <span><strong>Gate:</strong> CANVAS_ENABLED</span>
+        <span><strong>Owner-docs:</strong> INTERACTION_SURFACES_AND_AUTHORITY</span>
+        <span><strong>Status:</strong> Design handoff · v1</span>
+      </div>
+    </header>
+
+    <!-- ============== SECTION 1 ============== -->
+    <section class="spec" id="s1">
+      <h2><span class="secnum">01 ·</span>Context interpretation</h2>
+      <p class="lede">
+        What this slice is asked to design — and explicitly what it is not.
+      </p>
+
+      <h3>What is being designed</h3>
+      <p>
+        A document-first co-authoring moment inside the Companion UI rail (or, in portrait, a bottom sheet)
+        anchored to an active vault note. Hugin proposes a change. The user previews it. The user accepts or
+        rejects. The outcome is one of two paths:
+      </p>
+      <ul>
+        <li><strong>Body-edit lane.</strong> A scoped insertion inside the open note's body during a
+          user-present canvas session. Applied in place by <code>canvas_writer</code>; audited in the
+          subordinate <code>.chats/</code> session log; reversible by undo.</li>
+        <li><strong>Governance lane.</strong> Anything outside the active note's body — frontmatter,
+          tags, maturity, ontology, cross-note links, file moves, multi-note ops. Routed through
+          <code>GovernanceRouter</code> as a queued intent. Returns a receipt; never mutates from chat.</li>
+      </ul>
+
+      <h3>Surface boundaries we are honoring</h3>
+      <ul>
+        <li><strong>Obsidian / vault</strong> remains the canonical durable knowledge surface. The note is the artifact.</li>
+        <li><strong>AI Panel</strong> remains the primary command-oriented governance surface. Receipt locality lives there.</li>
+        <li><strong>Companion UI / Canvas Chat</strong> is the thinking and co-authoring surface. It is not a second source of truth.</li>
+      </ul>
+
+      <div class="callout invariant">
+        <span class="callout-label">Floor invariant (quoted from STATE_EXECUTION_AUTHORITY_REMAINS_GATED)</span>
+        No interaction surface mutates durable state except through the existing governed path: policy,
+        validation, event pipeline, and the deterministic note writer. LLM reasoning alone never triggers
+        execution. This slice expresses the invariant; it does not loosen it.
+      </div>
+
+      <h3>What this slice is not</h3>
+      <ul>
+        <li>Not a redesign of the Companion UI shell. The converse layout, session drawer, and rail
+          collapse states stay as shipped.</li>
+        <li>Not a dashboard, not a chat-as-primary-artifact, not a separate semantic store.</li>
+        <li>Not a new governance pipeline. Governance-bearing intents enter the existing pipeline as
+          a queued request.</li>
+        <li>Not a runtime spec for the writer, router, or session log — those are already specified in
+          <code>CANVAS_CHAT_SURFACE/</code>.</li>
+      </ul>
+    </section>
+
+    <!-- ============== SECTION 2 ============== -->
+    <section class="spec" id="s2">
+      <h2><span class="secnum">02 ·</span>Interaction sequence</h2>
+      <p class="lede">
+        The two flows side-by-side. Each row is a discrete UI state with a single allowed user action set.
+      </p>
+
+      <h3>Flow A · Body-edit (co-authoring)</h3>
+      <table class="spec">
+        <thead>
+          <tr><th>Step</th><th>System</th><th>UI state</th><th>User action set</th><th>Resulting state</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>A0</td><td>Note open; canvas session attached</td><td><code>idle</code></td><td>Type in composer · open session drawer</td><td><code>thinking</code></td></tr>
+          <tr><td>A1</td><td>Hugin reasoning</td><td><code>thinking</code></td><td>Cancel · keep typing</td><td><code>suggestion-staged · body</code></td></tr>
+          <tr><td>A2</td><td>Body proposal emitted</td><td><code>suggestion-staged · body</code></td><td><strong>Apply</strong> · <strong>Discard</strong> · Inspect diff · Edit before applying</td><td><code>apply-pending</code> / <code>discarded</code></td></tr>
+          <tr><td>A3</td><td><code>canvas_writer.apply_edit()</code></td><td><code>apply-pending</code></td><td>—</td><td><code>applied</code></td></tr>
+          <tr><td>A4</td><td>Session log appended; in-note marker flips to applied</td><td><code>applied</code></td><td>Undo · continue session</td><td><code>idle</code></td></tr>
+        </tbody>
+      </table>
+
+      <h3>Flow B · Governance-bearing</h3>
+      <table class="spec">
+        <thead>
+          <tr><th>Step</th><th>System</th><th>UI state</th><th>User action set</th><th>Resulting state</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>B0</td><td>Note open; canvas session attached</td><td><code>idle</code></td><td>Same as A0</td><td><code>thinking</code></td></tr>
+          <tr><td>B1</td><td>Hugin reasoning</td><td><code>thinking</code></td><td>Cancel</td><td><code>suggestion-staged · governance</code></td></tr>
+          <tr><td>B2</td><td>Proposal classified as governance-bearing</td><td><code>suggestion-staged · governance</code></td><td><strong>Queue for governance</strong> · Discard · Inspect classification</td><td><code>governance-pending</code> / <code>discarded</code></td></tr>
+          <tr><td>B3</td><td><code>GovernanceRouter.request_governance_action()</code> returns receipt</td><td><code>governance-pending</code></td><td>Open receipt in Panel · continue session</td><td><code>idle</code> (with pending receipt visible)</td></tr>
+          <tr><td>B*</td><td>If <code>CANVAS_ENABLED=0</code> or write-guard fires</td><td><code>blocked</code></td><td>Acknowledge · open Panel</td><td><code>idle</code></td></tr>
+        </tbody>
+      </table>
+
+      <div class="callout">
+        <span class="callout-label">Classification authority</span>
+        Classification (body vs governance) is determined by <code>GovernanceRouter</code> on the server,
+        not by the UI. The UI renders whichever class the server returned on the proposal payload. The UI
+        never <em>upgrades</em> a body edit into a governance action or <em>downgrades</em> a governance
+        action into a body edit.
+      </div>
+    </section>
+
+    <!-- ============== SECTION 3 ============== -->
+    <section class="spec" id="s3">
+      <h2><span class="secnum">03 ·</span>UI state model</h2>
+      <p class="lede">
+        Eight states. Two orthogonal axes: <em>session activity</em> (idle / thinking) and
+        <em>proposal lifecycle</em> (staged / pending / resolved / blocked).
+      </p>
+
+      <h3>State enum</h3>
+      <pre class="code"><span class="c">// canvas-rail state machine, one-of:</span>
+<span class="k">type</span> <span class="n">RailState</span> =
+  | <span class="s">"idle"</span>                    <span class="c">// no proposal; composer enabled</span>
+  | <span class="s">"thinking"</span>                <span class="c">// agent generating; composer disabled</span>
+  | <span class="s">"suggestion-staged:body"</span>  <span class="c">// preview ready; apply/discard enabled</span>
+  | <span class="s">"suggestion-staged:gov"</span>   <span class="c">// preview ready; queue/discard enabled</span>
+  | <span class="s">"apply-pending"</span>           <span class="c">// canvas_writer in flight</span>
+  | <span class="s">"governance-pending"</span>      <span class="c">// router accepted; receipt returned</span>
+  | <span class="s">"applied"</span>                 <span class="c">// terminal-success for body lane</span>
+  | <span class="s">"discarded"</span>               <span class="c">// terminal-reject for either lane</span>
+  | <span class="s">"blocked"</span>;                <span class="c">// gated / not allowed</span></pre>
+
+      <h3>Allowed transitions</h3>
+      <table class="spec">
+        <thead>
+          <tr><th>From</th><th>Trigger</th><th>To</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>idle</code></td><td>user.send or agent-initiated turn</td><td><code>thinking</code></td></tr>
+          <tr><td><code>thinking</code></td><td>proposal.received (class = body)</td><td><code>suggestion-staged:body</code></td></tr>
+          <tr><td><code>thinking</code></td><td>proposal.received (class = governance)</td><td><code>suggestion-staged:gov</code></td></tr>
+          <tr><td><code>thinking</code></td><td>turn.completed (no proposal)</td><td><code>idle</code></td></tr>
+          <tr><td><code>thinking</code></td><td>cancel</td><td><code>idle</code></td></tr>
+          <tr><td><code>suggestion-staged:body</code></td><td>suggestion.apply</td><td><code>apply-pending</code></td></tr>
+          <tr><td><code>suggestion-staged:body</code></td><td>suggestion.discard</td><td><code>discarded</code> → <code>idle</code></td></tr>
+          <tr><td><code>suggestion-staged:gov</code></td><td>governance.queue</td><td><code>governance-pending</code></td></tr>
+          <tr><td><code>suggestion-staged:gov</code></td><td>suggestion.discard</td><td><code>discarded</code> → <code>idle</code></td></tr>
+          <tr><td><code>apply-pending</code></td><td>canvas-writer.success</td><td><code>applied</code> → <code>idle</code></td></tr>
+          <tr><td><code>apply-pending</code></td><td>canvas-writer.error</td><td><code>blocked</code></td></tr>
+          <tr><td><code>governance-pending</code></td><td>router.receipt-accepted</td><td><code>idle</code> (receipt visible)</td></tr>
+          <tr><td><code>governance-pending</code></td><td>router.write-guard-denied</td><td><code>blocked</code></td></tr>
+          <tr><td>any</td><td><code>CANVAS_ENABLED=0</code></td><td><code>blocked</code></td></tr>
+        </tbody>
+      </table>
+
+      <h3>Composer enablement</h3>
+      <p>
+        The composer is enabled in <code>idle</code> only. In every other state the input is read-only
+        with state-appropriate placeholder copy (e.g. <em>"Hugin is thinking…"</em>,
+        <em>"Apply or discard to continue"</em>, <em>"Queue or discard to continue"</em>,
+        <em>"Canvas disabled in this environment"</em>).
+      </p>
+    </section>
+
+    <!-- ============== SECTION 4 ============== -->
+    <section class="spec" id="s4">
+      <h2><span class="secnum">04 ·</span>Component inventory</h2>
+      <p class="lede">
+        One tree. Components map 1:1 to the existing converse layout where possible — new components
+        are introduced only for the suggestion lifecycle.
+      </p>
+
+      <table class="spec">
+        <thead>
+          <tr><th>Component</th><th>Role</th><th>Status</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>&lt;CanvasShell&gt;</code></td><td>Landscape rail / portrait sheet container; carries <code>data-rail-state</code> and <code>data-suggestion-state</code></td><td>existing</td></tr>
+          <tr><td><code>&lt;DocumentPane&gt;</code></td><td>Read-only render of the active note. Hosts <code>&lt;SuggestedInsertion&gt;</code> in place.</td><td>existing</td></tr>
+          <tr><td><code>&lt;SuggestedInsertion&gt;</code></td><td>The in-document preview marker (orange tint, "PROPOSED" label) that flips to applied (vault green, "APPLIED · &lt;receipt&gt;") or removes itself on discard</td><td><span class="chip impl">new</span></td></tr>
+          <tr><td><code>&lt;HuginRail&gt;</code></td><td>Conversation thread + composer; mounts <code>&lt;SuggestionCard&gt;</code></td><td>existing</td></tr>
+          <tr><td><code>&lt;ConversationThread&gt;</code></td><td>Ordered list of <code>&lt;Message&gt;</code>, <code>&lt;SuggestionCard&gt;</code>, <code>&lt;ThinkingIndicator&gt;</code>, <code>&lt;ReceiptPill&gt;</code></td><td>existing</td></tr>
+          <tr><td><code>&lt;SuggestionCard variant="body"&gt;</code></td><td>Body-edit proposal card with <em>Apply</em> / <em>Discard</em></td><td><span class="chip impl">new variant</span></td></tr>
+          <tr><td><code>&lt;SuggestionCard variant="governance"&gt;</code></td><td>Governance proposal card with <em>Queue for governance</em> / <em>Discard</em> and an explicit "cannot be applied here" sub-label</td><td><span class="chip impl">new variant</span></td></tr>
+          <tr><td><code>&lt;SuggestionCard variant="blocked"&gt;</code></td><td>Not-allowed card (CANVAS_ENABLED off, write-guard denied, or unknown class)</td><td><span class="chip impl">new variant</span></td></tr>
+          <tr><td><code>&lt;ReceiptPill&gt;</code></td><td>Compact pill rendered inline in thread when an action is queued / applied; links to Panel for governance receipts</td><td><span class="chip impl">new</span></td></tr>
+          <tr><td><code>&lt;ReceiptsStrip&gt;</code></td><td>Sticky footer strip in the rail that lists the session's outstanding pending governance receipts (so they remain visible after scroll)</td><td><span class="chip impl">new</span></td></tr>
+          <tr><td><code>&lt;ThinkingIndicator&gt;</code></td><td>Three-dot pulse; <code>data-thinking="active"</code></td><td>existing</td></tr>
+          <tr><td><code>&lt;Composer&gt;</code></td><td>Input + send; respects <code>data-composer-state</code></td><td>existing</td></tr>
+          <tr><td><code>&lt;SessionDrawer&gt;</code></td><td>Existing session list overlay; unchanged by this slice</td><td>existing</td></tr>
+          <tr><td><code>&lt;ProvenanceFooter&gt;</code></td><td>One-line footer showing session log path and turn count; clickable to open <code>.chats/&lt;slug&gt;/…</code> in Obsidian</td><td><span class="chip impl">new</span></td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <!-- ============== SECTION 5 ============== -->
+    <section class="spec" id="s5">
+      <h2><span class="secnum">05 ·</span>Data-intent &amp; data-testid</h2>
+      <p class="lede">
+        Every interactive node carries a <code>data-intent</code> (semantic action name) and a
+        <code>data-testid</code> (stable selector). Names extend the prototype convention already in
+        <code>converse_layout.html</code>.
+      </p>
+
+      <h3>Intent vocabulary</h3>
+      <table class="spec">
+        <thead><tr><th class="mono">data-intent</th><th>Surface</th><th>Effect</th></tr></thead>
+        <tbody>
+          <tr><td class="mono">suggestion.apply</td><td>SuggestionCard · body</td><td>POST <code>/canvas/sessions/:id/edits</code> via <code>canvas_writer</code></td></tr>
+          <tr><td class="mono">suggestion.discard</td><td>SuggestionCard · any</td><td>Local-only: removes preview, appends discard turn to session log</td></tr>
+          <tr><td class="mono">suggestion.inspect</td><td>SuggestionCard · any</td><td>Expands diff / classification rationale (no side effect)</td></tr>
+          <tr><td class="mono">suggestion.edit</td><td>SuggestionCard · body</td><td>Opens inline editor on the proposed text before apply (no side effect until apply)</td></tr>
+          <tr><td class="mono">governance.queue</td><td>SuggestionCard · governance</td><td>POST <code>GovernanceRouter.request_governance_action</code>; returns receipt</td></tr>
+          <tr><td class="mono">governance.openReceipt</td><td>ReceiptPill · queued</td><td>Hands off to AI Panel anchored to the receipt id</td></tr>
+          <tr><td class="mono">canvas.cancelTurn</td><td>ThinkingIndicator</td><td>Aborts in-flight reasoning; returns to <code>idle</code></td></tr>
+          <tr><td class="mono">canvas.undoLastEdit</td><td>ProvenanceFooter</td><td>Inverse of the last applied body edit; appends undo turn to session log</td></tr>
+          <tr><td class="mono">provenance.openSessionLog</td><td>ProvenanceFooter</td><td>Opens the <code>.chats/&lt;slug&gt;/&lt;ts&gt;.md</code> note in Obsidian</td></tr>
+          <tr><td class="mono">blocked.acknowledge</td><td>SuggestionCard · blocked</td><td>Dismisses the blocked card; logs the denial reason</td></tr>
+          <tr><td class="mono">session-drawer.open</td><td>top-bar</td><td>Existing; unchanged</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Testid map</h3>
+      <table class="spec">
+        <thead><tr><th class="mono">data-testid</th><th>Node</th></tr></thead>
+        <tbody>
+          <tr><td class="mono">canvas-shell</td><td>Outer container; carries <code>data-rail-state</code>, <code>data-suggestion-state</code></td></tr>
+          <tr><td class="mono">document-pane</td><td>Active-note render</td></tr>
+          <tr><td class="mono">suggested-insertion-block</td><td>In-document preview; carries <code>data-suggestion-id</code></td></tr>
+          <tr><td class="mono">suggestion-card</td><td>Rail card; carries <code>data-suggestion-id</code> and <code>data-variant</code></td></tr>
+          <tr><td class="mono">suggestion-card-classification</td><td>Sub-label declaring body vs governance</td></tr>
+          <tr><td class="mono">apply-suggestion</td><td>Primary action button (body lane)</td></tr>
+          <tr><td class="mono">queue-governance</td><td>Primary action button (governance lane)</td></tr>
+          <tr><td class="mono">discard-suggestion</td><td>Secondary action button (either lane)</td></tr>
+          <tr><td class="mono">receipt-pill</td><td>Inline pill in thread; carries <code>data-receipt-id</code></td></tr>
+          <tr><td class="mono">receipts-strip</td><td>Sticky strip with pending governance receipts</td></tr>
+          <tr><td class="mono">provenance-footer</td><td>Session-log path + turn count</td></tr>
+          <tr><td class="mono">thinking-indicator</td><td>Three-dot pulse; carries <code>data-thinking</code></td></tr>
+          <tr><td class="mono">blocked-card</td><td>Not-allowed variant</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Data attributes on the shell</h3>
+      <pre class="code">&lt;section
+  data-testid=<span class="s">"canvas-shell"</span>
+  data-rail-state=<span class="s">"expanded | collapsed"</span>
+  data-suggestion-state=<span class="s">"idle | thinking | staged-body | staged-gov | pending-apply | pending-gov | applied | discarded | blocked"</span>
+  data-canvas-enabled=<span class="s">"true | false"</span>
+  data-session-id=<span class="s">"&lt;uuid&gt;"</span>
+  data-active-note-path=<span class="s">"Projects/Q2-arch.md"</span>&gt;</pre>
+    </section>
+
+    <!-- ============== SECTION 6 ============== -->
+    <section class="spec" id="s6">
+      <h2><span class="secnum">06 ·</span>API / backend concept mapping</h2>
+      <p class="lede">
+        UI affordances bound to existing backend concepts. The UI does not invent new endpoints; it
+        renders the existing canvas-session surface.
+      </p>
+
+      <table class="spec">
+        <thead><tr><th>UI affordance</th><th>Backend concept</th><th>Module / contract</th></tr></thead>
+        <tbody>
+          <tr><td>Open note → start session</td><td>Canvas session lifecycle (open)</td><td><code>SessionLogWriter.open_session</code> via <code>/canvas/sessions</code></td></tr>
+          <tr><td>Apply body suggestion</td><td>Canvas edit</td><td><code>canvas_writer.apply_edit</code></td></tr>
+          <tr><td>Queue governance suggestion</td><td>Governance routing</td><td><code>GovernanceRouter.request_governance_action(GovernanceActionType, …)</code></td></tr>
+          <tr><td>Receipt pill / receipts strip</td><td>Receipts &amp; status</td><td>Receipt id returned by the router; status polled from Panel locality</td></tr>
+          <tr><td>Provenance footer</td><td>Session log / provenance</td><td><code>SessionLogWriter.append_turn</code>; path <code>vault/.chats/&lt;slug&gt;/&lt;ts&gt;.md</code></td></tr>
+          <tr><td>Blocked variant</td><td>Feature gating &amp; write-guard</td><td><code>CANVAS_ENABLED</code> env gate; <code>governance_router</code> write-guard</td></tr>
+          <tr><td>End session</td><td>Session close</td><td><code>SessionLogWriter.close_session</code></td></tr>
+        </tbody>
+      </table>
+
+      <div class="callout">
+        <span class="callout-label">Server is the classifier</span>
+        Whether a proposal is body-class or governance-class is set by the server on the proposal payload
+        — derived by <code>GovernanceRouter</code> classification. The UI's job is to render the variant
+        the server declared and offer only the actions valid for that variant. Re-classification in the
+        UI is forbidden.
+      </div>
+    </section>
+
+    <!-- ============== SECTION 7 ============== -->
+    <section class="spec" id="s7">
+      <h2><span class="secnum">07 ·</span>Body-edit lane</h2>
+      <p class="lede">
+        User-present, in-place co-authoring of the open note's body. Authorized by presence. Audited by
+        session log. Reversible by undo.
+      </p>
+
+      <h3>Preview semantics</h3>
+      <ul>
+        <li>The proposed text is shown <em>inline at the insertion point</em> in the document pane
+          (orange marker, "PROPOSED · UNCOMMITTED" label) and as a mirrored card in the rail thread.</li>
+        <li>Both visualizations share a <code>data-suggestion-id</code> so DOM events on one can drive
+          highlight states on the other.</li>
+        <li>The user may <em>Inspect diff</em> (expands the rail card) or <em>Edit before applying</em>
+          (inline edit on the proposed text in the rail). Edits do not mutate the note until <em>Apply</em>.</li>
+      </ul>
+
+      <h3>Apply semantics</h3>
+      <ul>
+        <li>Single round-trip: UI calls <code>canvas_writer.apply_edit(session_id, edit)</code>. On
+          success, the in-document marker flips to vault green with the applied receipt id;
+          the rail card collapses to a one-line "applied" log entry.</li>
+        <li>The session log gains a turn entry: <code>kind: body_edit_applied</code>,
+          <code>note_path</code>, <code>anchor</code>, <code>byte_range</code>, <code>preview_hash</code>.</li>
+        <li>Apply is <em>not</em> a governance event; no receipt is queued in the Panel pipeline.</li>
+      </ul>
+
+      <h3>Discard semantics</h3>
+      <ul>
+        <li>Local-only. The preview is removed from the document pane and the rail card is rendered
+          struck-through and dimmed.</li>
+        <li>A turn entry <code>kind: body_edit_discarded</code> is appended to the session log so
+          provenance still captures the proposed-but-rejected suggestion.</li>
+      </ul>
+
+      <h3>Undo semantics</h3>
+      <ul>
+        <li>The provenance footer exposes <code>data-intent="canvas.undoLastEdit"</code>. Undo inverts
+          the last applied body edit by calling <code>canvas_writer.apply_edit</code> with the inverse
+          patch; the session log records <code>kind: body_edit_undone</code>.</li>
+        <li>Undo is bounded to the active session. Cross-session undo is out of scope and explicitly
+          deferred to a later capability.</li>
+      </ul>
+    </section>
+
+    <!-- ============== SECTION 8 ============== -->
+    <section class="spec" id="s8">
+      <h2><span class="secnum">08 ·</span>Governance-bearing lane</h2>
+      <p class="lede">
+        Anything outside the active note's body. Cannot be applied from chat. Must enter the governed
+        pipeline as a queued intent.
+      </p>
+
+      <h3>What qualifies as governance-bearing (UI surface copy)</h3>
+      <ul>
+        <li>Frontmatter changes (tags, maturity, type, ontology).</li>
+        <li>Note lifecycle (rename, move, archive, delete, promote).</li>
+        <li>Cross-note operations (link, merge, split, create-and-link).</li>
+        <li>System-owned artifacts (automations, watchers, scheduled jobs, agent instructions).</li>
+        <li>Edits to notes other than the active one.</li>
+      </ul>
+
+      <div class="callout warn">
+        <span class="callout-label">Hard UI rule</span>
+        The governance variant has <strong>no Apply button</strong>. The primary action is
+        <em>Queue for governance</em>. The card carries a visible classification label —
+        <em>"Cannot be applied from chat — must be queued"</em> — anchored to a help target that opens
+        the Panel governance docs.
+      </div>
+
+      <h3>Queue semantics</h3>
+      <ul>
+        <li>UI calls <code>GovernanceRouter.request_governance_action(action_type, payload, session_id)</code>.</li>
+        <li>On success: the router returns a receipt id; the rail renders a queued
+          <code>&lt;ReceiptPill&gt;</code> inline, and adds it to <code>&lt;ReceiptsStrip&gt;</code> at the
+          bottom of the rail. Session log gains <code>kind: governance_intent_queued</code> with the receipt
+          id and action type.</li>
+        <li>On write-guard denial (e.g. <code>CANVAS_ENABLED=0</code>, policy refusal): the card
+          transitions to <code>blocked</code>; the session log gains <code>kind: governance_intent_blocked</code>
+          with a <code>reason</code> field.</li>
+      </ul>
+
+      <h3>Status after queue</h3>
+      <ul>
+        <li>The pending receipt remains visible in the rail's receipts strip until status changes upstream.</li>
+        <li>Status transitions (<em>queued → in-review → applied</em> or <em>rejected</em>) are read-only in
+          the canvas — the user inspects and acts on them in <strong>AI Panel</strong>.
+          <code>data-intent="governance.openReceipt"</code> hands off to Panel.</li>
+        <li>The Companion UI never auto-applies or auto-rejects a governance receipt.</li>
+      </ul>
+    </section>
+
+    <!-- ============== SECTION 9 ============== -->
+    <section class="spec" id="s9">
+      <h2><span class="secnum">09 ·</span>Receipts &amp; provenance behavior</h2>
+      <p class="lede">
+        Two distinct artifacts: in-pipeline <em>receipts</em> (Panel locality) and the per-session
+        <em>session log</em> (subordinate vault artifact).
+      </p>
+
+      <h3>Receipts</h3>
+      <ul>
+        <li>Lifecycle: <code>queued → in-review → applied | rejected</code>.</li>
+        <li>Locality: Panel's receipt store, unchanged. Companion UI <em>mirrors</em> but never owns.</li>
+        <li>Rendered as a <code>&lt;ReceiptPill&gt;</code> inline in the thread at the moment of queue, and
+          as a row in <code>&lt;ReceiptsStrip&gt;</code> for as long as the receipt is non-terminal.</li>
+        <li>Body-edit applies do <em>not</em> generate a receipt. They are not governance events.</li>
+      </ul>
+
+      <h3>Session log</h3>
+      <ul>
+        <li>Path: <code>vault/.chats/&lt;note-slug&gt;/&lt;timestamp&gt;.md</code> (per <code>WRITE_SESSION_LOGS</code>).</li>
+        <li>Frontmatter: <code>type: chat-session</code>, <code>note_path</code>, <code>opened_at</code>,
+          <code>closed_at</code>.</li>
+        <li>Append-only. Turns are appended via <code>SessionLogWriter.append_turn</code>. The UI never
+          rewrites prior content.</li>
+        <li>Subordinate, not canonical. The active note remains the artifact. The session log is
+          provenance.</li>
+      </ul>
+
+      <h3>Turn kinds emitted from this slice</h3>
+      <table class="spec">
+        <thead><tr><th class="mono">kind</th><th>Emitted when</th><th>Required fields</th></tr></thead>
+        <tbody>
+          <tr><td class="mono">turn.user</td><td>User sends a composer message</td><td><code>text</code>, <code>ts</code></td></tr>
+          <tr><td class="mono">turn.agent</td><td>Hugin reply (incl. proposals)</td><td><code>text</code>, <code>proposal?</code>, <code>ts</code></td></tr>
+          <tr><td class="mono">body_edit_applied</td><td>Body suggestion accepted</td><td><code>suggestion_id</code>, <code>anchor</code>, <code>preview_hash</code></td></tr>
+          <tr><td class="mono">body_edit_discarded</td><td>Body suggestion discarded</td><td><code>suggestion_id</code>, <code>preview_hash</code></td></tr>
+          <tr><td class="mono">body_edit_undone</td><td>User undoes last apply</td><td><code>suggestion_id</code>, <code>inverse_of</code></td></tr>
+          <tr><td class="mono">governance_intent_queued</td><td>User queues a governance proposal</td><td><code>suggestion_id</code>, <code>action_type</code>, <code>receipt_id</code></td></tr>
+          <tr><td class="mono">governance_intent_blocked</td><td>Write-guard denied or CANVAS_ENABLED=0</td><td><code>suggestion_id</code>, <code>action_type</code>, <code>reason</code></td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <!-- ============== SECTION 10 ============== -->
+    <section class="spec" id="s10">
+      <h2><span class="secnum">10 ·</span>Responsive behavior</h2>
+      <p class="lede">
+        Two layouts, one state model. The rail collapses to a bottom sheet at portrait widths; the
+        suggestion-card lives in whichever container is mounted.
+      </p>
+
+      <h3>Landscape (≥ 900 px wide)</h3>
+      <ul>
+        <li>Two columns. Document pane primary; rail on the right (collapsed strip / expanded).</li>
+        <li><code>&lt;SuggestedInsertion&gt;</code> renders inline in the document pane.</li>
+        <li><code>&lt;SuggestionCard&gt;</code> renders in the rail thread.</li>
+        <li><code>&lt;ReceiptsStrip&gt;</code> sticks to the bottom of the rail, above the composer.</li>
+      </ul>
+
+      <h3>Portrait / narrow (&lt; 900 px wide)</h3>
+      <ul>
+        <li>Document pane fills viewport; rail replaced by <code>&lt;BottomSheet&gt;</code> with three snap points:
+          <code>peek</code> (60 px, shows hugin dot + turn count), <code>half</code> (50vh), <code>full</code> (calc(100vh - 64px)).</li>
+        <li>When a proposal arrives the sheet auto-snaps from <code>peek</code> → <code>half</code>; never
+          to <code>full</code> (so the document is still visible at the insertion point).</li>
+        <li><code>&lt;SuggestedInsertion&gt;</code> in the document pane is the user's primary read of
+          the change; the sheet card is the action surface.</li>
+        <li><code>&lt;ReceiptsStrip&gt;</code> renders at the top of the sheet (sticky) so pending
+          governance items remain visible when the user scrolls the thread.</li>
+      </ul>
+
+      <h3>Cross-cutting</h3>
+      <ul>
+        <li>Hit targets ≥ 44 px in portrait. <em>Apply</em> and <em>Queue</em> are always the primary
+          (color-distinct) action; <em>Discard</em> is always secondary.</li>
+        <li>Sheet snap state is persisted to <code>localStorage</code> per session id so refresh keeps
+          context.</li>
+        <li>Reduced-motion users skip the thinking pulse and the sheet auto-snap; the proposal still
+          arrives, just statically.</li>
+      </ul>
+    </section>
+
+    <!-- ============== SECTION 11 ============== -->
+    <section class="spec" id="s11">
+      <h2><span class="secnum">11 ·</span>Accessibility requirements</h2>
+
+      <h3>Keyboard</h3>
+      <ul>
+        <li>Composer focused by default in <code>idle</code>. <kbd>Esc</kbd> from the composer collapses
+          the rail (landscape) or snaps the sheet to <code>peek</code> (portrait).</li>
+        <li>On <code>suggestion-staged</code>, focus moves to the primary action of the suggestion card
+          (Apply or Queue). <kbd>A</kbd> applies (body lane only); <kbd>Q</kbd> queues (governance lane
+          only); <kbd>D</kbd> discards; <kbd>I</kbd> inspects; <kbd>E</kbd> edits-before-applying (body
+          only). Composer is removed from the tab order while staged.</li>
+        <li>The receipts strip is reachable from the rail header with a single tab; pills expose
+          <code>aria-label</code> with action type and receipt status.</li>
+      </ul>
+
+      <h3>Live regions</h3>
+      <ul>
+        <li><code>&lt;ConversationThread&gt;</code> has <code>aria-live="polite"</code> with relevant
+          updates announcing only new messages and proposals (suppress the thinking pulse).</li>
+        <li><code>&lt;ReceiptsStrip&gt;</code> has <code>aria-live="polite"</code> on its row list so
+          status transitions from upstream are announced even when focus is on the document.</li>
+      </ul>
+
+      <h3>Labels &amp; semantics</h3>
+      <ul>
+        <li><code>&lt;SuggestedInsertion&gt;</code> is a <code>&lt;ins&gt;</code> in the DOM with a
+          <code>data-state</code> attribute and an <code>aria-label</code> announcing
+          <em>"Proposed insertion, &lt;n&gt; lines after &lt;anchor&gt;"</em>.</li>
+        <li><code>&lt;SuggestionCard variant="governance"&gt;</code> has
+          <code>aria-describedby</code> pointing at the classification label so screen readers always
+          announce the "must be queued" constraint.</li>
+        <li><code>&lt;SuggestionCard variant="blocked"&gt;</code> has <code>role="alert"</code> and an
+          <code>aria-describedby</code> for the denial reason.</li>
+      </ul>
+
+      <h3>Contrast &amp; reduced motion</h3>
+      <ul>
+        <li>All state colors (amber staged, vault applied, accent governance, destructive blocked) meet
+          ≥ 4.5:1 against the surface they sit on. The Yggdrasil tokens already satisfy this.</li>
+        <li><code>@media (prefers-reduced-motion)</code> disables the thinking dot pulse and the
+          receipt-pill pulse; transitions resolve to instantaneous.</li>
+      </ul>
+    </section>
+
+    <!-- ============== SECTION 12 ============== -->
+    <section class="spec" id="s12">
+      <h2><span class="secnum">12 ·</span>Prototype</h2>
+      <p class="lede">
+        Two artifacts: a state gallery covering all eight states, and a small live demo of the flow
+        end-to-end. Both render with the Yggdrasil tokens; no framework. This is design-only — the
+        layout, hierarchy, and state machine are contract; the styling is a reference render.
+      </p>
+
+      <h3>State gallery</h3>
+      <div class="gallery" data-testid="state-gallery">
+
+        <!-- idle -->
+        <div class="gallery-card">
+          <header>
+            <h4>① idle</h4>
+            <span class="chip">composer enabled</span>
+          </header>
+          <p class="note">No proposal. Composer ready. Provenance footer shows session log path.</p>
+          <div class="rail-mock">
+            <div class="hdr"><span class="dot"></span><span>HUGIN</span><span class="turn-meta">12 turns</span></div>
+            <div class="msg agent"><div class="ctx-label">RE: Q2-arch.md</div>Picked up where you left off — the decision capture scaffold.</div>
+            <div class="msg user">What should go after "Current state"?</div>
+            <div class="composer-mock">
+              <input placeholder="Message Hugin…" />
+              <button class="btn primary">Send</button>
+            </div>
+          </div>
+        </div>
+
+        <!-- thinking -->
+        <div class="gallery-card">
+          <header>
+            <h4>② thinking</h4>
+            <span class="chip agent">composer locked</span>
+          </header>
+          <p class="note">Agent reasoning. Composer disabled with state placeholder. Cancellable.</p>
+          <div class="rail-mock">
+            <div class="hdr"><span class="dot"></span><span>HUGIN</span><span class="turn-meta">12 turns</span></div>
+            <div class="msg user">What should go after "Current state"?</div>
+            <div class="thinking"><span>HUGIN</span><span class="ddot"></span><span class="ddot"></span><span class="ddot"></span></div>
+            <div class="composer-mock">
+              <input value="Hugin is thinking…" disabled />
+              <button class="btn" disabled>Send</button>
+            </div>
+          </div>
+        </div>
+
+        <!-- staged body -->
+        <div class="gallery-card">
+          <header>
+            <h4>③ suggestion staged · body</h4>
+            <span class="chip" style="color: var(--amber); border-color: rgba(240,144,48,0.4);">co-author</span>
+          </header>
+          <p class="note">Body-class proposal. Apply / Discard offered. In-document preview is amber.</p>
+          <div class="rail-mock">
+            <div class="hdr"><span class="dot"></span><span>HUGIN</span><span class="turn-meta">13 turns</span></div>
+            <div class="doc-note-mock">
+              <div class="h">## Current state</div>
+              <div class="ins">Introduce explicit staged-suggestion actions with no direct persistence side effects.</div>
+            </div>
+            <div class="sugg body">
+              <div class="sugg-label">HUGIN · PROPOSED ADDITION</div>
+              Add a staged insertion for explicit user-controlled apply/discard flow.
+              <div class="diff-hint">+3 lines after ## Current state</div>
+              <div class="sugg-actions">
+                <button class="btn primary">Apply <span class="kbd">A</span></button>
+                <button class="btn">Discard <span class="kbd">D</span></button>
+                <button class="btn ghost">Inspect <span class="kbd">I</span></button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- apply pending -->
+        <div class="gallery-card">
+          <header>
+            <h4>④ apply pending</h4>
+            <span class="chip agent">writer in flight</span>
+          </header>
+          <p class="note">canvas_writer.apply_edit() in flight. Buttons disabled. No receipt — body lane.</p>
+          <div class="rail-mock">
+            <div class="hdr"><span class="dot"></span><span>HUGIN</span><span class="turn-meta">13 turns</span></div>
+            <div class="sugg body">
+              <div class="sugg-label">HUGIN · APPLYING…</div>
+              Add a staged insertion for explicit user-controlled apply/discard flow.
+              <div class="diff-hint">writing to Projects/Q2-arch.md</div>
+              <div class="sugg-actions">
+                <button class="btn primary" disabled>Apply</button>
+                <button class="btn" disabled>Discard</button>
+              </div>
+            </div>
+            <div class="thinking"><span>CANVAS_WRITER</span><span class="ddot"></span><span class="ddot"></span><span class="ddot"></span></div>
+          </div>
+        </div>
+
+        <!-- applied -->
+        <div class="gallery-card">
+          <header>
+            <h4>⑤ applied</h4>
+            <span class="chip vault">in note</span>
+          </header>
+          <p class="note">In-document marker flips to vault green with applied tag. Session log gains <code>body_edit_applied</code>.</p>
+          <div class="rail-mock">
+            <div class="hdr"><span class="dot"></span><span>HUGIN</span><span class="turn-meta">14 turns</span></div>
+            <div class="doc-note-mock">
+              <div class="h">## Current state</div>
+              <div class="ins-applied">Introduce explicit staged-suggestion actions with no direct persistence side effects.</div>
+            </div>
+            <div class="sugg applied">
+              <div class="sugg-label">✓ APPLIED · body_edit#a4f2</div>
+              <div class="diff-hint">.chats/q2-arch/2026-05-11T1442.md · turn 14</div>
+            </div>
+            <div class="composer-mock">
+              <input placeholder="Message Hugin…" />
+              <button class="btn primary">Send</button>
+            </div>
+          </div>
+        </div>
+
+        <!-- discarded -->
+        <div class="gallery-card">
+          <header>
+            <h4>⑥ discarded</h4>
+            <span class="chip">no mutation</span>
+          </header>
+          <p class="note">Local-only. Preview removed from document. Card dims and strikes. Audit kept.</p>
+          <div class="rail-mock">
+            <div class="hdr"><span class="dot"></span><span>HUGIN</span><span class="turn-meta">14 turns</span></div>
+            <div class="doc-note-mock">
+              <div class="h">## Current state</div>
+              <div class="ins-ghost">— proposal discarded —</div>
+            </div>
+            <div class="sugg discarded">
+              <div class="sugg-label">DISCARDED · 2s ago</div>
+              Add a staged insertion for explicit user-controlled apply/discard flow.
+            </div>
+            <div class="composer-mock">
+              <input placeholder="Message Hugin…" />
+              <button class="btn primary">Send</button>
+            </div>
+          </div>
+        </div>
+
+        <!-- governance pending -->
+        <div class="gallery-card">
+          <header>
+            <h4>⑦ governance action pending</h4>
+            <span class="chip" style="color: var(--accent); border-color: rgba(212,168,67,0.4);">queued</span>
+          </header>
+          <p class="note">Frontmatter / cross-note / lifecycle. No Apply button — only <em>Queue for governance</em>. Receipt returned and surfaced.</p>
+          <div class="rail-mock">
+            <div class="hdr"><span class="dot"></span><span>HUGIN</span><span class="turn-meta">15 turns</span></div>
+            <div class="sugg governance">
+              <div class="sugg-label">HUGIN · GOVERNANCE-BEARING PROPOSAL</div>
+              Promote maturity from <code>draft</code> → <code>committed</code>; add tag <code>#arch/decision</code>.
+              <div class="diff-hint" style="color: var(--accent);">Cannot be applied from chat — must be queued.</div>
+              <div class="sugg-actions">
+                <button class="btn governance">Queue for governance <span class="kbd">Q</span></button>
+                <button class="btn">Discard <span class="kbd">D</span></button>
+                <button class="btn ghost">Inspect classification <span class="kbd">I</span></button>
+              </div>
+            </div>
+            <span class="receipt queued"><span class="recdot"></span>queued · gov#7b1c · open in panel ›</span>
+          </div>
+        </div>
+
+        <!-- blocked -->
+        <div class="gallery-card">
+          <header>
+            <h4>⑧ blocked / not allowed</h4>
+            <span class="chip" style="color: var(--destructive); border-color: rgba(255,61,61,0.4);">denied</span>
+          </header>
+          <p class="note">CANVAS_ENABLED=0 or write-guard denied. No primary action. Reason explicit. Logged.</p>
+          <div class="rail-mock">
+            <div class="hdr"><span class="dot"></span><span>HUGIN</span><span class="turn-meta">15 turns</span></div>
+            <div class="sugg blocked" role="alert">
+              <div class="sugg-label">⚠ NOT ALLOWED IN THIS ENVIRONMENT</div>
+              Canvas mutations are disabled (<code>CANVAS_ENABLED=0</code>). Open this intent in the AI Panel to proceed.
+              <div class="sugg-actions">
+                <button class="btn">Acknowledge</button>
+                <button class="btn ghost">Open in Panel ›</button>
+              </div>
+            </div>
+            <div class="composer-mock">
+              <input value="Canvas disabled in this environment" disabled />
+              <button class="btn" disabled>Send</button>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+      <h3>Live demo</h3>
+      <p>
+        Walk the flow end-to-end. The buttons drive a small in-page state machine that mirrors the
+        contract in §3 and emits the same session-log turn kinds enumerated in §9. Open the browser
+        console to see the would-be backend calls and turn-log entries; no network or storage side
+        effects fire.
+      </p>
+
+      <div class="proto-frame" data-testid="canvas-shell" id="proto">
+        <div class="proto-tabs" role="tablist">
+          <button class="proto-tab" role="tab" aria-selected="true" data-tab="body">Body-edit lane</button>
+          <button class="proto-tab" role="tab" aria-selected="false" data-tab="gov">Governance lane</button>
+          <button class="proto-tab" role="tab" aria-selected="false" data-tab="blocked">Blocked (CANVAS_ENABLED=0)</button>
+        </div>
+
+        <div class="proto-stage">
+          <article class="proto-doc" data-testid="document-pane">
+            <div class="note-path">Projects/Q2-arch.md · session #s_4f81</div>
+            <div class="frontmatter">---
+type: decision
+maturity: draft
+tags: [arch, q2-planning]
+---</div>
+            <h1>Decision capture scaffold</h1>
+            <h2>Context</h2>
+            <p>We need a way for Hugin to propose body edits in this note without violating the gated
+              execution invariant. Anything beyond the note body must enter the governance pipeline.</p>
+            <h2>Current state</h2>
+            <p>The rail can stage proposals but doesn't yet route classification or render receipts.</p>
+            <div id="proto-insertion" class="insertion" data-state="staged"
+                 data-testid="suggested-insertion-block"
+                 data-suggestion-id="suggestion-001">
+              Introduce explicit staged-suggestion actions with no direct persistence side effects;
+              classification (body vs governance) is server-set on the proposal payload.
+            </div>
+            <h2>Open questions</h2>
+            <p>How are governance-bearing proposals surfaced when the user is mid-thought?</p>
+          </article>
+
+          <aside class="proto-rail">
+            <div class="hdr"><span class="dot"></span><span>HUGIN</span><span class="turn-meta" id="proto-turns">14 turns</span></div>
+
+            <div class="msg agent">
+              <div class="ctx-label">RE: Q2-arch.md</div>
+              I have a proposal for the <em>Current state</em> section. Preview is staged below.
+            </div>
+
+            <div id="proto-card-body" class="sugg body" data-testid="suggestion-card" data-variant="body" data-suggestion-id="suggestion-001">
+              <div class="sugg-label">HUGIN · PROPOSED ADDITION</div>
+              <span>Introduce explicit staged-suggestion actions with no direct persistence side effects.</span>
+              <div class="diff-hint">+3 lines after <code>## Current state</code></div>
+              <div class="sugg-actions">
+                <button class="btn primary" data-intent="suggestion.apply" data-testid="apply-suggestion" id="btn-apply">Apply <span class="kbd">A</span></button>
+                <button class="btn" data-intent="suggestion.discard" data-testid="discard-suggestion" id="btn-discard">Discard <span class="kbd">D</span></button>
+                <button class="btn ghost" data-intent="suggestion.inspect">Inspect <span class="kbd">I</span></button>
+              </div>
+            </div>
+
+            <div id="proto-card-gov" class="sugg governance" data-testid="suggestion-card" data-variant="governance" data-suggestion-id="suggestion-002" style="display:none;">
+              <div class="sugg-label">HUGIN · GOVERNANCE-BEARING PROPOSAL</div>
+              <span>Promote <code>maturity: draft → committed</code> and add tag <code>#arch/decision</code>.</span>
+              <div class="diff-hint" style="color: var(--accent);">Cannot be applied from chat — must be queued.</div>
+              <div class="sugg-actions">
+                <button class="btn governance" data-intent="governance.queue" data-testid="queue-governance" id="btn-queue">Queue for governance <span class="kbd">Q</span></button>
+                <button class="btn" data-intent="suggestion.discard" id="btn-discard-gov">Discard <span class="kbd">D</span></button>
+                <button class="btn ghost" data-intent="suggestion.inspect">Inspect classification</button>
+              </div>
+            </div>
+
+            <div id="proto-card-blocked" class="sugg blocked" data-testid="blocked-card" role="alert" style="display:none;">
+              <div class="sugg-label">⚠ NOT ALLOWED IN THIS ENVIRONMENT</div>
+              <span><code>CANVAS_ENABLED=0</code>. Canvas mutations are gated off in this environment. The proposed intent has been logged as <code>governance_intent_blocked</code>.</span>
+              <div class="sugg-actions">
+                <button class="btn" data-intent="blocked.acknowledge" id="btn-ack">Acknowledge</button>
+                <button class="btn ghost">Open in Panel ›</button>
+              </div>
+            </div>
+
+            <div id="proto-thinking" class="thinking" style="display:none;"><span>CANVAS_WRITER</span><span class="ddot"></span><span class="ddot"></span><span class="ddot"></span></div>
+
+            <div class="receipts-strip" data-testid="receipts-strip" id="proto-receipts">
+              <div class="rlbl">Pending receipts</div>
+              <div class="empty" id="receipts-empty">— none —</div>
+            </div>
+          </aside>
+        </div>
+
+        <div class="proto-controls">
+          <span class="label">Provenance</span>
+          <span class="receipt" id="proto-prov" data-testid="provenance-footer">
+            <span class="recdot" style="background: var(--vault); box-shadow: 0 0 6px var(--vault);"></span>
+            .chats/q2-arch/2026-05-11T1442.md · <span id="proto-turncount">14</span> turns
+          </span>
+          <button class="btn ghost" data-intent="canvas.undoLastEdit" id="btn-undo" disabled>Undo last edit</button>
+          <button class="btn ghost" data-intent="provenance.openSessionLog">Open session log</button>
+          <span style="margin-left: auto; font-family: var(--font-mono); font-size: var(--text-xs); color: var(--fg-3);" id="proto-state">state: <strong style="color: var(--cyan);">suggestion-staged:body</strong></span>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============== SECTION 13 ============== -->
+    <section class="spec" id="s13">
+      <h2><span class="secnum">13 ·</span>Design-only vs implementation contract</h2>
+      <p class="lede">
+        Codex should normalize the contract chips into repo docs / implementation tasks. The design
+        chips are reference renders — sober defaults, not constraints.
+      </p>
+
+      <table class="spec">
+        <thead><tr><th>Element</th><th>Classification</th><th>Notes</th></tr></thead>
+        <tbody>
+          <tr><td>UI state enum (§3) and allowed transitions</td><td><span class="chip impl">contract</span></td><td>Implementations must enumerate exactly these states; new states require an INTERACTION-* task.</td></tr>
+          <tr><td>Two-lane split: body-edit vs governance-bearing</td><td><span class="chip impl">contract</span></td><td>Derived from <code>DEFINE_CANVAS_COEDITING_MODEL</code>. UI must surface both lanes distinctly.</td></tr>
+          <tr><td>Server-set classification on proposals</td><td><span class="chip impl">contract</span></td><td>UI must not re-classify or upgrade/downgrade lanes.</td></tr>
+          <tr><td><code>data-intent</code> vocabulary (§5)</td><td><span class="chip impl">contract</span></td><td>Stable names; new intents go through this table.</td></tr>
+          <tr><td><code>data-testid</code> map (§5)</td><td><span class="chip impl">contract</span></td><td>Stable selectors for tests and future automation.</td></tr>
+          <tr><td>Session-log turn kinds (§9)</td><td><span class="chip impl">contract</span></td><td>Must round-trip through <code>SessionLogWriter.append_turn</code>; backend owns the schema, this slice just enumerates which kinds this UI emits.</td></tr>
+          <tr><td>Governance card has no Apply button (§8)</td><td><span class="chip impl">contract</span></td><td>Hard rule. Removing the constraint would breach the gated-execution invariant in the UI.</td></tr>
+          <tr><td>Apply does not generate a Panel receipt (§7, §9)</td><td><span class="chip impl">contract</span></td><td>Body edits are co-authoring, not governance events.</td></tr>
+          <tr><td>Three sheet snap points; auto-snap to half on proposal (§10)</td><td><span class="chip impl">contract</span></td><td>Auto-full is forbidden — must leave anchor visible.</td></tr>
+          <tr><td>Keyboard shortcuts (§11 A/Q/D/I/E)</td><td><span class="chip impl">contract</span></td><td>Bind only when a suggestion is staged. Globals would conflict with composer typing.</td></tr>
+          <tr><td>Composer disabled outside <code>idle</code> (§3)</td><td><span class="chip impl">contract</span></td><td>Sends from non-idle would race the in-flight proposal.</td></tr>
+          <tr><td>Yggdrasil token palette &amp; type</td><td><span class="chip design">design-only</span></td><td>Visual tone; can evolve without changing contracts.</td></tr>
+          <tr><td>Tron-grid background, glow effects</td><td><span class="chip design">design-only</span></td><td>Aesthetic. Reduced-motion overrides take precedence.</td></tr>
+          <tr><td>Specific copy in state placeholders</td><td><span class="chip design">design-only</span></td><td>Tone is sober; exact wording is a string-table concern.</td></tr>
+          <tr><td>State gallery presentation</td><td><span class="chip design">design-only</span></td><td>Documentation artifact; not shipped in product.</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <!-- ============== SECTION 14 ============== -->
+    <section class="spec" id="s14">
+      <h2><span class="secnum">14 ·</span>Open questions &amp; risks</h2>
+
+      <h3>Open questions</h3>
+      <ol>
+        <li><strong>Multi-suggestion threading.</strong> If a turn returns more than one proposal,
+          does the UI batch them into one card or stack independent cards? Defaulting to stacked,
+          one-at-a-time apply; needs confirmation.</li>
+        <li><strong>Receipt status freshness.</strong> Polling vs push from Panel for governance receipt
+          status. Polling is fine for the v1 slice; push is deferred.</li>
+        <li><strong>Inline edit-before-apply provenance.</strong> If the user edits the proposed text
+          before applying, is the original proposal still logged, the final text logged, or both?
+          Recommended: both (with <code>proposal_hash</code> and <code>applied_hash</code>).</li>
+        <li><strong>Undo scope.</strong> Confirmed bounded to the active session. Cross-session undo
+          is explicitly deferred — needs a follow-up capability.</li>
+        <li><strong>Sheet behavior on incoming proposal mid-composer-typing.</strong> Auto-snap risks
+          stealing focus. Recommendation: surface a non-stealing indicator in the peek strip and let
+          the user choose to expand. Needs UX validation.</li>
+        <li><strong>Concurrent edits.</strong> If the active note is edited in Obsidian during a canvas
+          session, what happens to staged suggestions whose anchors moved? Recommendation: invalidate
+          and re-stage from server; needs confirmation with <code>canvas_writer</code> semantics.</li>
+      </ol>
+
+      <h3>Risks</h3>
+      <ol>
+        <li><strong>Surface drift.</strong> If the UI ever offers an Apply button on a governance
+          proposal — even as a "shortcut" — the gated-execution invariant breaks. Lint the component:
+          governance variant must never render an apply intent.</li>
+        <li><strong>Session-log inflation.</strong> Discarded proposals are appended to provenance.
+          Verbose sessions could bloat <code>.chats/</code>. Mitigation: <code>append_turn</code> writes
+          summaries, not full proposal bodies, when the proposal was rejected.</li>
+        <li><strong>Receipt orphaning.</strong> A receipt queued from canvas whose Panel record is
+          dismissed elsewhere leaves a stale pill in the rail. Mitigation: receipts strip reads from
+          Panel locality, not from a canvas-local cache.</li>
+        <li><strong>Classification drift.</strong> If the server's classifier and the UI's lane
+          rendering diverge in vocabulary, blocked-card reasons become unparseable. Mitigation: share
+          a single enum <code>GovernanceActionType</code> across both sides.</li>
+      </ol>
+    </section>
+
+  </main>
+</div>
+
+<!-- =========================== PROTOTYPE SCRIPT =========================== -->
+<script>
+(function() {
+  const $ = (id) => document.getElementById(id);
+  const stateLabel = $('proto-state').querySelector('strong');
+  const insertion = $('proto-insertion');
+  const cardBody = $('proto-card-body');
+  const cardGov = $('proto-card-gov');
+  const cardBlocked = $('proto-card-blocked');
+  const thinking = $('proto-thinking');
+  const receiptsStrip = $('proto-receipts');
+  const receiptsEmpty = $('receipts-empty');
+  const turnCount = $('proto-turncount');
+  const btnApply = $('btn-apply');
+  const btnDiscard = $('btn-discard');
+  const btnQueue = $('btn-queue');
+  const btnDiscardGov = $('btn-discard-gov');
+  const btnAck = $('btn-ack');
+  const btnUndo = $('btn-undo');
+
+  let turns = 14;
+  let state = 'suggestion-staged:body';
+  let lastApplied = null;
+
+  function setState(s) {
+    state = s;
+    stateLabel.textContent = s;
+    document.querySelector('.proto-frame').setAttribute('data-suggestion-state', s);
+    console.log('[canvas-shell] state →', s);
+  }
+
+  function logTurn(kind, fields) {
+    turns += 1;
+    turnCount.textContent = turns;
+    const entry = { ts: new Date().toISOString(), kind, ...fields };
+    console.log('[session-log:append_turn]', entry);
+  }
+
+  function setTab(tab) {
+    document.querySelectorAll('.proto-tab').forEach(t => {
+      t.setAttribute('aria-selected', t.dataset.tab === tab ? 'true' : 'false');
+    });
+    cardBody.style.display = tab === 'body' ? 'flex' : 'none';
+    cardGov.style.display = tab === 'gov' ? 'flex' : 'none';
+    cardBlocked.style.display = tab === 'blocked' ? 'flex' : 'none';
+
+    if (tab === 'body') {
+      insertion.style.display = 'block';
+      insertion.dataset.state = 'staged';
+      insertion.removeAttribute('data-receipt');
+      setState('suggestion-staged:body');
+      btnApply.disabled = false;
+      btnDiscard.disabled = false;
+      btnUndo.disabled = lastApplied === null;
+    } else if (tab === 'gov') {
+      insertion.style.display = 'none';
+      setState('suggestion-staged:gov');
+    } else {
+      insertion.style.display = 'none';
+      setState('blocked');
+    }
+  }
+
+  document.querySelectorAll('.proto-tab').forEach(t => {
+    t.addEventListener('click', () => setTab(t.dataset.tab));
+  });
+
+  // BODY LANE — apply
+  btnApply.addEventListener('click', () => {
+    setState('apply-pending');
+    btnApply.disabled = true; btnDiscard.disabled = true;
+    thinking.style.display = 'inline-flex';
+    console.log('[canvas_writer.apply_edit]', { session_id: 's_4f81', suggestion_id: 'suggestion-001' });
+    setTimeout(() => {
+      thinking.style.display = 'none';
+      const receiptId = 'body_edit#a' + Math.random().toString(16).slice(2, 6);
+      lastApplied = receiptId;
+      insertion.dataset.state = 'applied';
+      insertion.setAttribute('data-receipt', receiptId);
+      cardBody.classList.remove('body');
+      cardBody.classList.add('applied');
+      cardBody.querySelector('.sugg-label').textContent = '✓ APPLIED · ' + receiptId;
+      cardBody.querySelector('.sugg-actions').style.display = 'none';
+      logTurn('body_edit_applied', { suggestion_id: 'suggestion-001', receipt: receiptId, anchor: '## Current state' });
+      btnUndo.disabled = false;
+      setState('applied');
+      setTimeout(() => setState('idle'), 1200);
+    }, 900);
+  });
+
+  // BODY LANE — discard
+  btnDiscard.addEventListener('click', () => {
+    insertion.dataset.state = 'discarded';
+    cardBody.classList.remove('body');
+    cardBody.classList.add('discarded');
+    cardBody.querySelector('.sugg-actions').style.display = 'none';
+    cardBody.querySelector('.sugg-label').textContent = 'DISCARDED · just now';
+    logTurn('body_edit_discarded', { suggestion_id: 'suggestion-001' });
+    setState('discarded');
+    setTimeout(() => setState('idle'), 1200);
+  });
+
+  // UNDO
+  btnUndo.addEventListener('click', () => {
+    if (!lastApplied) return;
+    insertion.dataset.state = 'staged';
+    insertion.removeAttribute('data-receipt');
+    cardBody.classList.remove('applied');
+    cardBody.classList.add('body');
+    cardBody.querySelector('.sugg-label').textContent = 'HUGIN · PROPOSED ADDITION';
+    cardBody.querySelector('.sugg-actions').style.display = 'flex';
+    btnApply.disabled = false; btnDiscard.disabled = false;
+    logTurn('body_edit_undone', { inverse_of: lastApplied });
+    lastApplied = null;
+    btnUndo.disabled = true;
+    setState('suggestion-staged:body');
+  });
+
+  // GOVERNANCE LANE — queue
+  let pendingReceipts = 0;
+  btnQueue.addEventListener('click', () => {
+    setState('governance-pending');
+    btnQueue.disabled = true; btnDiscardGov.disabled = true;
+    console.log('[GovernanceRouter.request_governance_action]', {
+      action_type: 'PROMOTE_MATURITY',
+      session_id: 's_4f81',
+      payload: { from: 'draft', to: 'committed', tag_add: ['arch/decision'] }
+    });
+    setTimeout(() => {
+      const rid = 'gov#' + Math.random().toString(16).slice(2, 6);
+      logTurn('governance_intent_queued', { suggestion_id: 'suggestion-002', action_type: 'PROMOTE_MATURITY', receipt_id: rid });
+      pendingReceipts += 1;
+      receiptsEmpty.style.display = 'none';
+      const pill = document.createElement('span');
+      pill.className = 'receipt queued';
+      pill.setAttribute('data-testid', 'receipt-pill');
+      pill.setAttribute('data-receipt-id', rid);
+      pill.innerHTML = '<span class="recdot"></span>queued · ' + rid + ' · PROMOTE_MATURITY · open in panel ›';
+      receiptsStrip.appendChild(pill);
+      cardGov.classList.remove('governance');
+      cardGov.classList.add('applied');
+      cardGov.querySelector('.sugg-label').textContent = '✓ QUEUED · ' + rid;
+      cardGov.querySelector('.diff-hint').textContent = 'awaiting governance review in AI Panel';
+      cardGov.querySelector('.sugg-actions').style.display = 'none';
+      setState('idle');
+    }, 700);
+  });
+
+  btnDiscardGov.addEventListener('click', () => {
+    cardGov.classList.remove('governance');
+    cardGov.classList.add('discarded');
+    cardGov.querySelector('.sugg-actions').style.display = 'none';
+    cardGov.querySelector('.sugg-label').textContent = 'DISCARDED · just now';
+    logTurn('governance_intent_discarded', { suggestion_id: 'suggestion-002' });
+    setState('discarded');
+    setTimeout(() => setState('idle'), 1200);
+  });
+
+  btnAck.addEventListener('click', () => {
+    logTurn('governance_intent_blocked', {
+      suggestion_id: 'suggestion-003',
+      action_type: 'PROMOTE_MATURITY',
+      reason: 'CANVAS_ENABLED=0'
+    });
+    cardBlocked.style.opacity = '0.5';
+    btnAck.disabled = true;
+  });
+
+  // keyboard shortcuts on staged
+  document.addEventListener('keydown', (e) => {
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+    if (state === 'suggestion-staged:body') {
+      if (e.key === 'a' || e.key === 'A') { e.preventDefault(); btnApply.click(); }
+      if (e.key === 'd' || e.key === 'D') { e.preventDefault(); btnDiscard.click(); }
+    } else if (state === 'suggestion-staged:gov') {
+      if (e.key === 'q' || e.key === 'Q') { e.preventDefault(); btnQueue.click(); }
+      if (e.key === 'd' || e.key === 'D') { e.preventDefault(); btnDiscardGov.click(); }
+    }
+  });
+
+  setTab('body');
+})();
+</script>
+</body>
+</html>

--- a/companion-ui/design_handoff/2026-05-11-canvas-suggestion-flow/README.md
+++ b/companion-ui/design_handoff/2026-05-11-canvas-suggestion-flow/README.md
@@ -1,0 +1,47 @@
+# Design Handoff — Canvas Suggestion Flow
+
+**Date:** 2026-05-11
+**Status:** Design handoff v1 · ready for implementation
+
+## What this is
+
+A narrow, implementation-ready interaction spec for the Canvas Suggestion Flow in the Companion UI. Covers the moment Hugin proposes a change to the active note, the user previews it, and the system either co-authors the body in place or routes the intent into the governed pipeline.
+
+Produced in Claude Design (claude.ai/design) using repo context as constraints.
+
+## Files
+
+- `Canvas Suggestion Flow.html` — full 14-section spec with state gallery and live interactive demo. Open in a browser.
+- `colors_and_type.css` — Yggdrasil design tokens (same as the cognitive-temporal handoff).
+
+## Implementation scope
+
+Two lanes, one state machine:
+
+1. **Body-edit lane** — user-present co-authoring of the active note's body. Apply in place via `canvas_writer`. No governance receipt.
+2. **Governance-bearing lane** — frontmatter, maturity, cross-note ops, lifecycle. Cannot be applied from chat. Queued via `GovernanceRouter`; returns a receipt.
+
+Eight UI states: `idle`, `thinking`, `suggestion-staged:body`, `suggestion-staged:gov`, `apply-pending`, `governance-pending`, `applied`, `discarded`, `blocked`.
+
+## Key contracts (from §13)
+
+See `Canvas Suggestion Flow.html §13` for the full design-vs-contract split. High-signal contracts:
+
+- **State enum + transitions** — implementations must enumerate exactly these states.
+- **Two-lane split** — body vs governance must surface distinctly; UI never re-classifies.
+- **No Apply on governance card** — hard rule enforcing gated-execution invariant.
+- **Apply ≠ governance event** — body edits do not generate Panel receipts.
+- **Composer disabled outside `idle`** — prevents send-race with in-flight proposals.
+- **Keyboard shortcuts A/Q/D/I/E** — bound only during `suggestion-staged:*` states.
+- **Portrait bottom sheet** — 3 snap points; auto-snap to `half` on proposal; never auto-full.
+
+## Related implementation
+
+See `companion-ui/companion-app/canvas_suggestion_flow.html` for the staged prototype.
+
+## Related docs
+
+- `companion-ui/docs/OVERLAY_GRAMMAR.md`
+- `companion-ui/docs/UI_RUNTIME_BOUNDARIES.md`
+- `docs/CANVAS_CHAT_SURFACE/` (full backend contract)
+- `docs/INTERACTION_SURFACES_AND_AUTHORITY/`

--- a/companion-ui/design_handoff/2026-05-11-canvas-suggestion-flow/colors_and_type.css
+++ b/companion-ui/design_handoff/2026-05-11-canvas-suggestion-flow/colors_and_type.css
@@ -1,0 +1,346 @@
+/* ============================================================
+   Yggdrasil Design System — Colors & Type
+   ============================================================
+   Import this file in any HTML artifact or UI kit.
+   Google Fonts are imported below; JetBrains Mono via bunny.net.
+   ============================================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Space+Grotesk:wght@300;400;500;600&display=swap');
+@import url('https://fonts.bunny.net/css?family=jetbrains-mono:400,500&display=swap');
+
+/* ============================================================
+   BASE COLOR TOKENS
+   ============================================================ */
+:root {
+  /* --- Backgrounds (cool blue-black — Tron grid) --- */
+  --bg-base:       #070b12;   /* deepest — page root, near black with blue cast */
+  --bg-surface:    #0c1220;   /* panels, sidebars */
+  --bg-raised:     #111a2e;   /* cards, inputs, raised surfaces */
+  --bg-overlay:    #162038;   /* hover states, popovers */
+  --bg-modal:      #0e1828;   /* modal / dialog backdrop content */
+
+  /* --- Foreground / Text --- */
+  --fg-1:          #dce8f0;   /* primary — cool blue-white */
+  --fg-2:          #7a9ab8;   /* secondary / muted */
+  --fg-3:          #3d5570;   /* tertiary / disabled / dim */
+  --fg-inverse:    #070b12;   /* text on light/accent backgrounds */
+
+  /* --- Borders (thin, slightly glowing) --- */
+  --border:        #152030;   /* default — subtle grid line */
+  --border-strong: #1e3050;   /* emphasis — dividers, active edges */
+  --border-focus:  #00d4e8;   /* focus ring — electric cyan */
+
+  /* --- Accent 1: Norse Gold (slightly electrified) --- */
+  --accent:        #d4a843;   /* primary accent — active, focus, key affordances */
+  --accent-dim:    #80621a;   /* dimmed gold */
+  --accent-muted:  #2a1e06;   /* gold at low opacity */
+
+  /* --- Accent 2: Tron Cyan (neon electric) --- */
+  --cyan:          #00d4e8;   /* electric cyan — Tron primary glow */
+  --cyan-dim:      #007a8a;   /* dimmed cyan */
+  --cyan-muted:    #001e28;   /* cyan tint background */
+  --cyan-glow:     0 0 12px rgba(0,212,232,0.35), 0 0 4px rgba(0,212,232,0.5);
+
+  /* --- Vault: Neon green (digital growth) --- */
+  --vault:         #39e87d;   /* vault-connected — electric green */
+  --vault-dim:     #1a7840;   /* vault hover */
+  --vault-muted:   #041a10;   /* vault background tint */
+  --vault-glow:    0 0 8px rgba(57,232,125,0.3);
+
+  /* --- Agent: Electric blue (machine voice) --- */
+  --agent:         #4a9eff;   /* agent-contributed UI and content */
+  --agent-dim:     #1e5a9a;   /* agent hover */
+  --agent-muted:   #051228;   /* agent background tint */
+  --agent-glow:    0 0 8px rgba(74,158,255,0.3);
+
+  /* --- Amber (staged / uncommitted) --- */
+  --amber:         #f09030;   /* warnings, uncommitted/staged state */
+  --amber-dim:     #805010;
+  --amber-muted:   #1a0e02;
+
+  /* --- Destructive --- */
+  --destructive:      #ff3d3d;
+  --destructive-dim:  #8a1a1a;
+  --destructive-muted:#160404;
+
+  /* --- Semantic UI colors --- */
+  --color-bg:        var(--bg-base);
+  --color-surface:   var(--bg-surface);
+  --color-text:      var(--fg-1);
+  --color-muted:     var(--fg-2);
+  --color-dim:       var(--fg-3);
+  --color-border:    var(--border);
+  --color-accent:    var(--accent);
+
+  /* ============================================================
+     TYPOGRAPHY
+     ============================================================ */
+
+  /* --- Font families --- */
+  --font-display:  'EB Garamond', Georgia, serif;
+  --font-ui:       'Space Grotesk', system-ui, sans-serif;
+  --font-mono:     'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+
+  /* --- Type scale (rem, base 16px) --- */
+  --text-xs:    0.6875rem;   /* 11px — metadata, timestamps */
+  --text-sm:    0.8125rem;   /* 13px — secondary labels, captions */
+  --text-base:  0.9375rem;   /* 15px — body / default UI */
+  --text-md:    1.0625rem;   /* 17px — slightly emphasized body */
+  --text-lg:    1.1875rem;   /* 19px — section headers */
+  --text-xl:    1.5rem;      /* 24px — page titles */
+  --text-2xl:   2rem;        /* 32px — display moments */
+  --text-3xl:   2.75rem;     /* 44px — wordmark / hero */
+  --text-4xl:   3.75rem;     /* 60px — large display */
+
+  /* --- Line heights --- */
+  --leading-tight:  1.25;
+  --leading-snug:   1.4;
+  --leading-normal: 1.55;
+  --leading-loose:  1.75;
+
+  /* --- Font weights --- */
+  --weight-light:   300;
+  --weight-regular: 400;
+  --weight-medium:  500;
+  --weight-semibold:600;
+
+  /* --- Letter spacing --- */
+  --tracking-tight: -0.02em;
+  --tracking-normal: 0em;
+  --tracking-wide:   0.04em;
+  --tracking-wider:  0.08em;
+
+  /* ============================================================
+     SPACING
+     ============================================================ */
+  --space-1:   4px;
+  --space-2:   8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  20px;
+  --space-6:  24px;
+  --space-8:  32px;
+  --space-10: 40px;
+  --space-12: 48px;
+  --space-16: 64px;
+
+  /* ============================================================
+     BORDER RADIUS — sharper for cyberpunk aesthetic
+     ============================================================ */
+  --radius-sm:   2px;
+  --radius-md:   4px;
+  --radius-lg:   6px;
+  --radius-xl:  10px;
+  --radius-full: 9999px;
+
+  /* ============================================================
+     SHADOWS / ELEVATION
+     ============================================================ */
+  --shadow-sm:  0 1px 3px rgba(0,0,0,0.3);
+  --shadow-md:  0 4px 12px rgba(0,0,0,0.4);
+  --shadow-lg:  0 8px 32px rgba(0,0,0,0.5);
+  --shadow-float: 0 4px 24px rgba(0,0,0,0.55), 0 1px 4px rgba(0,0,0,0.3);
+  --shadow-inset: inset 0 1px 3px rgba(0,0,0,0.35);
+
+  /* ============================================================
+     ANIMATION
+     ============================================================ */
+  --ease:        cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-linear: linear;
+  --duration-fast: 100ms;
+  --duration-base: 150ms;
+  --duration-slow: 250ms;
+
+  /* ============================================================
+     Z-INDEX SCALE
+     ============================================================ */
+  --z-base:    1;
+  --z-raised:  10;
+  --z-sticky:  100;
+  --z-overlay: 200;
+  --z-modal:   300;
+  --z-toast:   400;
+}
+
+/* ============================================================
+   SEMANTIC ELEMENT DEFAULTS
+   ============================================================ */
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+body {
+  background-color: var(--bg-base);
+  color: var(--fg-1);
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-normal);
+}
+
+/* --- Display headings (EB Garamond) --- */
+h1, .h1 {
+  font-family: var(--font-display);
+  font-size: var(--text-3xl);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  color: var(--fg-1);
+}
+
+h2, .h2 {
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  color: var(--fg-1);
+}
+
+/* --- UI headings (DM Sans) --- */
+h3, .h3 {
+  font-family: var(--font-ui);
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-snug);
+  color: var(--fg-1);
+}
+
+h4, .h4 {
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-snug);
+  color: var(--fg-1);
+}
+
+h5, h6, .h5, .h6 {
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-snug);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--fg-2);
+}
+
+p {
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
+  color: var(--fg-1);
+  text-wrap: pretty;
+}
+
+small, .text-sm {
+  font-size: var(--text-sm);
+  color: var(--fg-2);
+}
+
+.text-xs {
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  font-family: var(--font-mono);
+  letter-spacing: var(--tracking-wide);
+}
+
+code, kbd, pre, .mono {
+  font-family: var(--font-mono);
+  font-size: 0.875em; /* relative to surrounding text */
+}
+
+code {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.1em 0.35em;
+  color: var(--fg-1);
+}
+
+pre {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  overflow-x: auto;
+  font-size: var(--text-sm);
+  line-height: var(--leading-normal);
+  color: var(--fg-1);
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+a:hover {
+  color: var(--fg-1);
+  text-decoration: underline;
+}
+
+hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: var(--space-6) 0;
+}
+
+/* ============================================================
+   UTILITY CLASSES
+   ============================================================ */
+
+/* Text colors */
+.text-primary   { color: var(--fg-1); }
+.text-secondary { color: var(--fg-2); }
+.text-dim       { color: var(--fg-3); }
+.text-accent    { color: var(--accent); }
+.text-cyan      { color: var(--cyan); }
+.text-vault     { color: var(--vault); }
+.text-agent     { color: var(--agent); }
+.text-amber     { color: var(--amber); }
+.text-danger    { color: var(--destructive); }
+
+/* Font families */
+.font-display { font-family: var(--font-display); }
+.font-ui      { font-family: var(--font-ui); }
+.font-mono    { font-family: var(--font-mono); }
+
+/* Weights */
+.weight-light    { font-weight: var(--weight-light); }
+.weight-regular  { font-weight: var(--weight-regular); }
+.weight-medium   { font-weight: var(--weight-medium); }
+.weight-semibold { font-weight: var(--weight-semibold); }
+
+/* Glow effects */
+.glow-cyan   { box-shadow: var(--cyan-glow); }
+.glow-vault  { box-shadow: var(--vault-glow); }
+.glow-agent  { box-shadow: var(--agent-glow); }
+.text-glow-cyan  { text-shadow: 0 0 12px rgba(0,212,232,0.7); }
+.text-glow-gold  { text-shadow: 0 0 16px rgba(212,168,67,0.5); }
+
+/* Tron grid background */
+.grid-bg {
+  background-image:
+    linear-gradient(rgba(0,212,232,0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0,212,232,0.04) 1px, transparent 1px);
+  background-size: 32px 32px;
+}
+
+/* Neon border active state */
+.border-cyan { border-color: var(--cyan) !important; box-shadow: var(--cyan-glow); }
+.border-gold { border-color: var(--accent) !important; box-shadow: 0 0 8px rgba(212,168,67,0.3); }
+
+/* Focus ring */
+:focus-visible {
+  outline: 1px solid var(--cyan);
+  outline-offset: 2px;
+  box-shadow: var(--cyan-glow);
+}

--- a/companion-ui/design_handoff/README.md
+++ b/companion-ui/design_handoff/README.md
@@ -5,5 +5,6 @@ Preserved external design artifacts and handoff packages.
 Current packages:
 - `2026-05-03-converse/` — converse surface wireframes/spec assets.
 - `2026-05-08-cognitive-temporal/` — cognitive modes, temporal cognition, and re-entry mist variant exploration files.
+- `2026-05-11-canvas-suggestion-flow/` — Canvas Suggestion Flow interaction spec: body-edit lane, governance-bearing lane, 8-state UI model, component inventory, and live interactive demo. Implementation-ready; contracts marked in §13.
 
 These artifacts are reference/handoff inputs, not production code.

--- a/companion-ui/docs/CANVAS_SUGGESTION_FLOW.md
+++ b/companion-ui/docs/CANVAS_SUGGESTION_FLOW.md
@@ -1,0 +1,289 @@
+# Canvas Suggestion Flow — Normalized Implementation Spec
+
+**Design source:** `companion-ui/design_handoff/2026-05-11-canvas-suggestion-flow/`
+**Staging prototype:** `companion-ui/companion-app/canvas_suggestion_flow.html`
+**Governing issue:** #876
+**Implementation issues:** #868 (SuggestionCard), #869 (SuggestedInsertion), #870 (state machine), #871 (ReceiptPill/ReceiptsStrip), #872 (keyboard shortcuts), #873 (portrait bottom sheet), #874 (ProvenanceFooter)
+
+---
+
+## Purpose and scope
+
+The Canvas Suggestion Flow is the interaction pattern for the moment Hugin proposes a change to the active note:
+
+1. A proposal arrives from the server with a pre-declared classification (body-edit or governance-bearing).
+2. The user previews the proposal and decides to apply, queue, or discard it.
+3. The system either co-authors the note body in place or routes the intent through the governed pipeline.
+
+Scope boundary: this spec covers the UI state machine, component contracts, intent vocabulary, and wiring to backend concepts. It does not prescribe the editor library, the streaming protocol, or the session-log retention window.
+
+---
+
+## Surface boundaries
+
+The Canvas Suggestion Flow operates within the companion UI overlay surface (margin rail, portrait bottom sheet). It augments the active document — the document pane remains the primary cognitive anchor.
+
+- **Design reference:** `companion-ui/design_handoff/2026-05-11-canvas-suggestion-flow/` — 14-section Claude Design handoff. Use for visual intent, rationale, and edge-case notes. Not an implementation contract by itself.
+- **Staging prototype:** `companion-ui/companion-app/canvas_suggestion_flow.html` — interactive browser demo, no network side effects, no durable mutations. Not production runtime. Explicitly non-production until formally promoted.
+- **Implementation contract:** this file (`CANVAS_SUGGESTION_FLOW.md`) — the normalized spec that implementation issues reference.
+
+---
+
+## Hard invariants
+
+These invariants must be present in implementation and must not be violated:
+
+1. **Server-declared classification.** The UI renders the proposal type (body vs governance) from the server-returned payload. The UI never re-classifies. Classification logic lives in the backend.
+2. **No Apply action on governance-bearing proposals.** The governance `SuggestionCard` variant must not render an Apply button under any condition. The only actions are Queue and Discard.
+3. **Body-edit Apply does not create a Panel governance receipt.** Applying a body edit routes through `canvas_writer.apply_edit`, not through `GovernanceRouter`. No Panel receipt is generated.
+4. **Body-edit Apply creates a session-log provenance entry.** Every body edit apply must produce a `body_edit_applied` turn in the session log.
+5. **Governance proposals are queued, not executed directly.** Queue routes through `GovernanceRouter.request_governance_action` and returns a receipt/status. The receipt is surfaced as a `ReceiptPill`.
+6. **Session log path from backend, not hardcoded.** `ProvenanceFooter` displays the session log path from backend-returned session data. Hardcoded paths are prototype-only.
+7. **Canvas/Chat must not become a second source of truth.** Session logs are provenance (intent trail), not the primary artifact. The note is the artifact.
+
+---
+
+## UI state model
+
+### Canonical state names (snake_case — use these in docs and contracts)
+
+| Canonical name | Description |
+|---|---|
+| `idle` | No active proposal; composer enabled |
+| `thinking` | Agent is processing; composer disabled |
+| `staged_body` | Body-edit proposal staged; Apply/Discard available |
+| `staged_governance` | Governance-bearing proposal staged; Queue/Discard available |
+| `apply_pending` | Body edit being written via `canvas_writer` |
+| `governance_pending` | Governance action being routed via `GovernanceRouter` |
+| `applied` | Body edit confirmed; transitions to `idle` |
+| `discarded` | Proposal discarded; transitions to `idle` |
+| `blocked` | `CANVAS_ENABLED=0`; proposal blocked; Acknowledge available |
+
+### Prototype DOM state name mapping
+
+The prototype stores state in `data-suggestion-state` on `[data-testid="canvas-shell"]`. The DOM attribute uses CSS-friendly names that differ from canonical contract names. Implementations must use canonical names internally; DOM names are an acceptable rendering alias.
+
+| Canonical (contract) | Prototype DOM (`data-suggestion-state`) | Prototype internal JS |
+|---|---|---|
+| `idle` | `idle` | `idle` |
+| `thinking` | `thinking` | `thinking` |
+| `staged_body` | `staged-body` | `suggestion-staged:body` |
+| `staged_governance` | `staged-gov` | `suggestion-staged:gov` |
+| `apply_pending` | `pending-apply` | `apply-pending` |
+| `governance_pending` | `pending-gov` | `governance-pending` |
+| `applied` | `applied` | `applied` |
+| `discarded` | `discarded` | `discarded` |
+| `blocked` | `blocked` | `blocked` |
+
+---
+
+## Allowed state transitions
+
+```
+idle ──────────────► thinking
+thinking ──────────► staged_body
+thinking ──────────► staged_governance
+thinking ──────────► blocked
+thinking ──────────► idle (cancel)
+staged_body ───────► apply_pending (Apply)
+staged_body ───────► discarded (Discard)
+staged_governance ─► governance_pending (Queue)
+staged_governance ─► discarded (Discard)
+apply_pending ─────► applied (canvas_writer confirms)
+governance_pending ► idle (receipt returned)
+applied ───────────► idle (auto, ~1.4s)
+discarded ─────────► idle (auto, ~1.4s)
+blocked ───────────► idle (Acknowledge)
+```
+
+Forbidden: no transition may skip `apply_pending` or `governance_pending` to jump directly from `staged_*` to `applied`/`idle`.
+
+---
+
+## Body-edit lane
+
+1. Server sends a proposal classified as `body` with insertion anchor, preview text, and `suggestion_id`.
+2. State transitions: `idle` → `thinking` → `staged_body`.
+3. `SuggestionCard` (body variant) renders in the rail; `SuggestedInsertion` renders in the document pane at the insertion anchor.
+4. User presses Apply (or keyboard `A`): state → `apply_pending`. `canvas_writer.apply_edit` is called. Composer disabled.
+5. On confirm: `SuggestedInsertion` flips to `applied` appearance. Session log receives `body_edit_applied` turn. State → `applied` → `idle`.
+6. `ProvenanceFooter` Undo button becomes active after apply; pressing Undo calls `canvas.undoLastEdit` and restores `staged_body`.
+7. No Panel receipt is generated. No governance routing.
+
+---
+
+## Governance-bearing lane
+
+1. Server sends a proposal classified as `governance` (frontmatter, maturity, cross-note, lifecycle op) with `action_type`, payload, and `suggestion_id`.
+2. State transitions: `idle` → `thinking` → `staged_governance`.
+3. `SuggestionCard` (governance variant) renders with classification label "Cannot be applied from chat — must be queued." **No Apply button.**
+4. User presses Queue (or keyboard `Q`): state → `governance_pending`. `GovernanceRouter.request_governance_action` is called.
+5. On receipt return: a `ReceiptPill` appears in the thread and in `ReceiptsStrip`. Session log receives `governance_intent_queued` turn. State → `idle`.
+6. `SuggestedInsertion` does not render for governance proposals (no in-document preview for governance mutations).
+
+---
+
+## Component inventory
+
+| Component | Variants | data-testid | Description |
+|---|---|---|---|
+| `SuggestionCard` | `body`, `governance`, `blocked` | `suggestion-card` | Proposal card in the rail thread |
+| `SuggestedInsertion` | `staged`, `applied`, `discarded` | `suggested-insertion-block` | In-document inline preview marker |
+| `ReceiptPill` | `queued`, (future: `approved`, `rejected`) | `receipt-pill` | Governance receipt pill in thread and strip |
+| `ReceiptsStrip` | — | `receipts-strip` | Strip of pending governance receipts above composer |
+| `ProvenanceFooter` | — | `provenance-footer` | Session log path, turn count, undo intent |
+| `ThinkingIndicator` | `active`, `inactive` | `thinking-indicator` | Animated dots shown during `thinking` and `apply_pending` |
+| `ComposerInput` | — | `composer-input` | Text input; disabled outside `idle` |
+
+---
+
+## data-intent vocabulary
+
+| Intent token | Triggered by | Description |
+|---|---|---|
+| `suggestion.apply` | Apply button / keyboard `A` | Apply body edit via `canvas_writer` |
+| `suggestion.discard` | Discard button / keyboard `D` | Discard proposal without writing |
+| `suggestion.inspect` | Inspect button / keyboard `I` | Expand diff or classification rationale (UI-only) |
+| `suggestion.edit` | keyboard `E` | Inline edit before apply (UI-only) |
+| `governance.queue` | Queue button / keyboard `Q` | Route governance intent via `GovernanceRouter` |
+| `governance.openReceipt` | ReceiptPill click | Open governance receipt in Panel |
+| `blocked.acknowledge` | Acknowledge button | Log `governance_intent_blocked` and return to idle |
+| `blocked.openPanel` | Open in Panel button | Route blocked intent to Panel surface |
+| `canvas.cancelTurn` | Cancel button in ThinkingIndicator | Cancel in-flight agent turn |
+| `canvas.undoLastEdit` | Undo button in ProvenanceFooter | Undo last applied body edit |
+| `provenance.openSessionLog` | Session path link in ProvenanceFooter | Open session log in vault |
+| `composer.send` | Send button | Send composer message (idle only) |
+| `session-drawer.open` | Session pill in top bar | Open session drawer |
+
+---
+
+## data-testid vocabulary
+
+| data-testid | Element | Notes |
+|---|---|---|
+| `canvas-shell` | Root container | Carries `data-suggestion-state` (DOM name) |
+| `document-pane` | Active note render area | |
+| `margin-rail` | Hugin conversation rail | |
+| `conversation-thread` | Thread scroll container | |
+| `suggestion-card` | SuggestionCard | Carries `data-variant` |
+| `suggestion-card-classification` | Classification label (governance variant) | |
+| `suggested-insertion-block` | In-document inline preview | Carries `data-state` |
+| `apply-suggestion` | Apply button (body variant) | |
+| `discard-suggestion` | Discard button (body or governance variant) | |
+| `queue-governance` | Queue button (governance variant) | |
+| `receipt-pill` | ReceiptPill | Carries `data-receipt-id`, `data-status` |
+| `receipts-strip` | ReceiptsStrip | |
+| `thinking-indicator` | ThinkingIndicator | |
+| `composer-input` | ComposerInput | |
+| `provenance-footer` | ProvenanceFooter | |
+| `undo-last-edit` | Undo button in ProvenanceFooter | |
+| `session-pill` | Session drawer opener in top bar | |
+
+---
+
+## Backend and API concept mapping
+
+| UI concept | Backend concept | Notes |
+|---|---|---|
+| Body-edit apply | `canvas_writer.apply_edit` | Writes to active note body; no governance receipt |
+| Governance queue | `GovernanceRouter.request_governance_action` | Returns `receipt_id` and status |
+| Session log append | `session_log.append_turn` | Turn kinds below |
+| Session log path | Returned from session context | Never hardcoded in production UI |
+| Canvas enabled check | `CANVAS_ENABLED` flag | Flag is server-side; UI renders `blocked` variant when server signals disabled |
+
+### Session log turn kinds
+
+| Kind | When |
+|---|---|
+| `body_edit_applied` | Body edit confirmed by `canvas_writer` |
+| `body_edit_discarded` | Body proposal discarded |
+| `body_edit_undone` | Undo of a previously applied body edit |
+| `governance_intent_queued` | Governance proposal queued via `GovernanceRouter` |
+| `governance_intent_discarded` | Governance proposal discarded |
+| `governance_intent_blocked` | Governance intent blocked by `CANVAS_ENABLED=0` |
+
+---
+
+## Receipt and provenance behavior
+
+- Governance proposals produce a `ReceiptPill` with `data-receipt-id` and `data-status="queued"` on routing.
+- `ReceiptPill` appears inline in the thread and is cloned into `ReceiptsStrip`.
+- `ReceiptsStrip` is visible whenever one or more governance receipts are pending.
+- Body-edit proposals do not produce receipts. The provenance record is the session-log `body_edit_applied` turn.
+- `ProvenanceFooter` displays: session log path (from backend), turn count, undo button, and current state label.
+- In the staging prototype, the session log path (`.chats/q2-arch/2026-05-11T1442.md`) is hardcoded for demo purposes. In real implementation, it must come from the server-returned session context.
+
+---
+
+## Responsive behavior
+
+| Viewport | Rail shape | Transition trigger |
+|---|---|---|
+| ≥900px (landscape) | Side margin rail | Static; no sheet behavior |
+| <900px (portrait) | Bottom sheet | Auto-snap to `half` when a proposal is staged |
+
+### Portrait bottom-sheet snap points
+
+| Name | Height |
+|---|---|
+| `peek` | ~72px — visible tip only |
+| `half` | ~50% viewport — proposal readable |
+| `full` | ~90% viewport — **never auto-snap to full; document must remain visible** |
+
+Auto-snap to `full` is forbidden. The document must remain partly visible at the insertion point during staging.
+
+---
+
+## Accessibility requirements
+
+- Keyboard shortcuts `A` (apply), `Q` (queue), `D` (discard), `I` (inspect), `E` (edit) are active **only** when `data-suggestion-state` is `staged-body` or `staged-gov`.
+- Shortcuts must not fire when focus is inside `ComposerInput` or any `<input>`/`<textarea>`.
+- Buttons with keyboard shortcuts carry `aria-keyshortcuts` attribute.
+- `ComposerInput` is `disabled` (not hidden) outside `idle` to preserve focus management and indicate unavailability.
+- `ReceiptsStrip` and `conversation-thread` carry `aria-live="polite"`.
+- Blocked `SuggestionCard` variant carries `role="alert"`.
+- All major interactive regions carry `aria-label`.
+
+---
+
+## Implementation-contract vs design-reference split
+
+Items below are **contracts** — implementations must satisfy them exactly:
+
+- State enum and canonical names (9 states as listed).
+- Two-lane split: `body` vs `governance`; UI never re-classifies.
+- No Apply button on governance-bearing `SuggestionCard`.
+- Apply ≠ governance receipt: body-edit applies do not generate Panel governance receipts.
+- `ComposerInput` disabled outside `idle`.
+- Session-log provenance turn on every body-edit apply.
+- Keyboard shortcuts `A/Q/D/I/E` scoped to `staged_*` states only.
+- Portrait bottom-sheet: 3 snap points; auto-snap `half` on proposal; never auto-full.
+
+Items below are **design guidance** — rationale and visual intent from the handoff, not hard contracts:
+
+- Exact color tokens, spacing, and typography (see `companion-ui/design_handoff/2026-05-11-canvas-suggestion-flow/colors_and_type.css`).
+- Specific animation durations (current prototype uses 900ms apply, 700ms governance pending).
+- Exact copy strings in card labels and classification notices.
+- The lane-switcher tab bar (present in prototype for demo; absent in production).
+
+---
+
+## Open questions and deferred items
+
+- **Panel receipt shape for governance mutations:** what fields does the `ReceiptPill` carry when the Panel pipeline returns a decision? Deferred to the canvas-commit capability lane.
+- **`CANVAS_ENABLED` propagation:** when and how the server signals the `blocked` condition to the UI. Likely via session context payload; contract not yet specified.
+- **Undo scope:** whether undo restores only the last body edit or a full stack. Prototype supports single-step undo; multi-step undo deferred.
+- **Retention window for session logs:** duration and soft-deletion policy not yet named. Deferred to the retention-policy lane.
+- **Workspace mode (multi-note):** cross-note synthesis sessions. Out of scope for this flow; inherits the same governance-bearing classification when it ships.
+- **Conflict resolution:** what happens if another session applies an edit to the same anchor while a proposal is staged. No protocol defined yet.
+
+---
+
+## Related docs
+
+- `companion-ui/docs/OVERLAY_GRAMMAR.md`
+- `companion-ui/docs/UI_RUNTIME_BOUNDARIES.md`
+- `companion-ui/docs/INTERACTION_PRINCIPLES.md`
+- `docs/CANVAS_CHAT_SURFACE/` — backend contract for the canvas-Chat runtime
+- `docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_CANVAS_COEDITING_MODEL.md` — co-authoring vs governance-bearing authority split
+- `docs/INTERACTION_SURFACES_AND_AUTHORITY/STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md` — gated-execution invariant

--- a/companion-ui/docs/README.md
+++ b/companion-ui/docs/README.md
@@ -13,6 +13,9 @@ Foundational documents for cognitive interaction architecture.
 - `FUTURE_RESEARCH.md`
 - `DESIGN_BRIEF.md` (preserved source brief)
 
+## Feature implementation specs
+- `CANVAS_SUGGESTION_FLOW.md` — normalized implementation spec for the Canvas Suggestion Flow: state machine, component inventory, intent vocabulary, backend mapping, invariants. Derived from design handoff `companion-ui/design_handoff/2026-05-11-canvas-suggestion-flow/`. Implementation contracts for #868–#874.
+
 ## Cognitive architecture consolidation set
 - `TEMPORAL_COGNITION.md`
 - `COGNITIVE_TRAJECTORIES.md`

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,6 +2,10 @@
 # `docker compose down` (even without -v) cannot destroy prod data.
 # Usage: docker compose -f docker-compose.yaml -f docker-compose.prod.yml -p pkm-prod up -d
 services:
+  api:
+    environment:
+      API_HEALTHCHECK_URL: http://host.docker.internal:18000/healthz
+
   db:
     volumes:
       - pgdata_prod:/var/lib/postgresql/data

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,12 @@
+# Production overlay — makes the Postgres data volume external so
+# `docker compose down` (even without -v) cannot destroy prod data.
+# Usage: docker compose -f docker-compose.yaml -f docker-compose.prod.yml -p pkm-prod up -d
+services:
+  db:
+    volumes:
+      - pgdata_prod:/var/lib/postgresql/data
+
+volumes:
+  pgdata_prod:
+    external: true
+    name: pkm-prod_pgdata

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,10 +5,15 @@ services:
     ports: !override
       - "15434:5432"
 
+  ollama:
+    ports: !override
+      - "11435:11434"
+
   api:
     ports: !override
       - "18002:8000"
     environment:
+      API_HEALTHCHECK_URL: http://host.docker.internal:18002/healthz
       PKM_ENVIRONMENT: prod
       DATABASE_URL: postgresql+psycopg://app:app@db:5432/app_test
       DB_DSN: postgresql+psycopg://app:app@db:5432/app_test

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,7 @@ testpaths =
     tests
     dev/tests
 pythonpath = .
-addopts = -p faulthandler
+addopts = -p faulthandler --import-mode=importlib
 markers =
     integration: tests that require Postgres
     pg: store-contract tests that require Postgres backend

--- a/tests/db/test_dsn.py
+++ b/tests/db/test_dsn.py
@@ -1,3 +1,4 @@
+from app.services import outbox as outbox_service
 from app.db.dsn import resolve_dsn, resolve_sqlalchemy_url
 
 
@@ -20,3 +21,42 @@ def test_resolve_sqlalchemy_url_preserves_psycopg_driver() -> None:
         resolve_sqlalchemy_url("postgresql+psycopg://app:app@db:5432/app")
         == "postgresql+psycopg://app:app@db:5432/app"
     )
+
+
+def test_resolve_dsn_uses_db_dsn_env(monkeypatch) -> None:
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("DB_DSN", "postgresql+psycopg://app:app@db:5432/app")
+
+    assert resolve_dsn() == "postgresql://app:app@db:5432/app"
+
+
+def test_resolve_sqlalchemy_url_uses_db_dsn_env(monkeypatch) -> None:
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("DB_DSN", "postgresql://app:app@db:5432/app")
+
+    assert resolve_sqlalchemy_url() == "postgresql+psycopg://app:app@db:5432/app"
+
+
+def test_outbox_open_conn_uses_db_dsn_env(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class DummyConn:
+        pass
+
+    def fake_connect(url: str, autocommit: bool = True):
+        captured["url"] = url
+        captured["autocommit"] = autocommit
+        return DummyConn()
+
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("DB_DSN", "postgresql+psycopg://app:app@db:5432/app")
+    monkeypatch.setattr(outbox_service, "conn_rw", None)
+    monkeypatch.setattr("psycopg.connect", fake_connect)
+
+    conn = outbox_service._open_conn()
+
+    assert isinstance(conn, DummyConn)
+    assert captured == {
+        "url": "postgresql://app:app@db:5432/app",
+        "autocommit": True,
+    }


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Resolves #888

## Summary
- Backports non-doc changes that were unintentionally dropped when PR #886 was rebased onto `stable`.
- Includes compose overlay alignment, watcher `DB_DSN` fallback fix, `CODEOWNERS` for prod-critical files, and Companion UI design handoff assets/docs.
- Handles inline review concern by refusing unsafe auto-create of `pkm-prod_pgdata` and requiring explicit migration/volume-creation steps.

## Runtime Impact
- Runtime-affecting changes included (compose/runtime wiring + watcher DB_DSN fallback).

## Validation
- `git diff --check`
- CI required checks on PR
- Local pytest unavailable in this shell (`python3: No module named pytest`)

## Notes
- This PR intentionally contains non-doc scope that was removed from #886 to keep that PR docs-only and reviewable.
