### PR TITLE
Fix worker retry handling and isolate test runtime env

### DIFF
--- a/app/ingest/config.py
+++ b/app/ingest/config.py
@@ -83,6 +83,13 @@ def _append_universal_ignores(ignore_glob: List[str]) -> List[str]:
     return merged
 
 
+def _append_companion_ignore(ignore_glob: List[str], system_folder: str) -> List[str]:
+    pattern = f"{system_folder}/companions/**"
+    if pattern not in ignore_glob:
+        ignore_glob.append(pattern)
+    return ignore_glob
+
+
 def _fallback_include_folders(layout: VaultLayout) -> List[str]:
     values = [layout.inbox_folder, layout.desk_folder]
     values = [value for value in values if value]
@@ -129,6 +136,7 @@ def resolve_ingest_config(vault_root: Path) -> IngestConfig:
         ignore = _normalize_list(ignore_glob)
 
     ignore = _append_universal_ignores(ignore)
+    ignore = _append_companion_ignore(ignore, layout.system_folder)
 
     return IngestConfig(include_folders=include, ignore_glob=ignore)
 

--- a/app/ingest/vault_alpha.py
+++ b/app/ingest/vault_alpha.py
@@ -23,6 +23,7 @@ from app.retrieval.hybrid import get_store
 from app.search.service import ingest_object as index_ingest_object
 from app.services.companion_note import (
     CompanionNote,
+    companion_path,
     read_companion,
     scan_attachments,
     write_companion,
@@ -629,7 +630,7 @@ def _ingest_candidates(
     store = get_object_store()
 
     store_count = _store_object_count(store)
-    companions_dir = vault_root / "_system/companions"
+    companions_dir = (vault_root / companion_path("sentinel", vault_root)).parent
     has_companions = companions_dir.exists() and any(companions_dir.glob("*.md"))
     cold_rebuild = not force and store_count == 0 and has_companions
     if cold_rebuild:

--- a/app/services/companion_note.py
+++ b/app/services/companion_note.py
@@ -1,7 +1,7 @@
 """
 Companion note service — system-owned identity file per vault note.
 
-Path: vault/_system/companions/<uuid>.md
+Path: vault/<system_dir>/companions/<uuid>.md
 Contract: docs/CONCEPTS/COMPANION_NOTE_CONTRACT.md
 Plan: docs/plans/COMPANION_NOTE_AND_NOTE_CONTEXT.md
 
@@ -10,7 +10,7 @@ Bounded field set (must NOT include review_state, maturity, kind, origin):
   last_ingested, created_by_instance, attachments[],
   identity_history[] (bounded to IDENTITY_HISTORY_MAX entries)
 
-Healing log: vault/_system/heal_log.jsonl — append-only, conservative,
+Healing log: vault/<system_dir>/heal_log.jsonl — append-only, conservative,
   one line per healing event with before/after and reason.
 """
 from __future__ import annotations
@@ -21,10 +21,11 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
+from app.vault.paths import get_vault_system_dir_rel
 from scripts.yaml_roundtrip import dump_frontmatter, load_frontmatter
 
-_COMPANIONS_DIR = Path("_system/companions")
-_HEAL_LOG_PATH = Path("_system/heal_log.jsonl")
+_LEGACY_COMPANIONS_DIR = Path("_system/companions")
+_LEGACY_HEAL_LOG_PATH = Path("_system/heal_log.jsonl")
 
 # Matches ![[...]] embed syntax only — NOT plain [[note]] wiki-links.
 _EMBED_RE = re.compile(r"!\[\[([^\]]+)\]\]")
@@ -100,9 +101,21 @@ class ArtifactIdentity:
 # Path helper
 # ---------------------------------------------------------------------------
 
-def companion_path(uuid: str) -> Path:
-    """Return the vault-relative path for a companion file: _system/companions/<uuid>.md"""
-    return _COMPANIONS_DIR / f"{uuid}.md"
+def _companions_dir(vault_root: Path | None = None) -> Path:
+    if vault_root is None:
+        return _LEGACY_COMPANIONS_DIR
+    return Path(get_vault_system_dir_rel(vault_root)) / "companions"
+
+
+def _heal_log_path(vault_root: Path | None = None) -> Path:
+    if vault_root is None:
+        return _LEGACY_HEAL_LOG_PATH
+    return Path(get_vault_system_dir_rel(vault_root)) / "heal_log.jsonl"
+
+
+def companion_path(uuid: str, vault_root: Path | None = None) -> Path:
+    """Return the vault-relative path for a companion file."""
+    return _companions_dir(vault_root) / f"{uuid}.md"
 
 
 # ---------------------------------------------------------------------------
@@ -111,7 +124,7 @@ def companion_path(uuid: str) -> Path:
 
 def read_companion(vault_root: Path, uuid: str) -> CompanionNote | None:
     """Read companion note for uuid. Returns None if missing or unparseable."""
-    path = vault_root / companion_path(uuid)
+    path = vault_root / companion_path(uuid, vault_root)
     if not path.exists():
         return None
     try:
@@ -124,7 +137,7 @@ def read_companion(vault_root: Path, uuid: str) -> CompanionNote | None:
 
 def write_companion(vault_root: Path, companion: CompanionNote) -> None:
     """Write companion note to disk. Creates parent directories as needed."""
-    path = vault_root / companion_path(companion.uuid)
+    path = vault_root / companion_path(companion.uuid, vault_root)
     path.parent.mkdir(parents=True, exist_ok=True)
     fm = _companion_to_fm(companion)
     content = dump_frontmatter(fm, "")
@@ -137,7 +150,7 @@ def write_companion(vault_root: Path, companion: CompanionNote) -> None:
 
 def find_companion_by_content_hash(vault_root: Path, sha256: str) -> CompanionNote | None:
     """Scan all companions for one whose content_hash matches sha256."""
-    companions_dir = vault_root / _COMPANIONS_DIR
+    companions_dir = vault_root / _companions_dir(vault_root)
     if not companions_dir.exists():
         return None
     for cand in companions_dir.glob("*.md"):
@@ -235,7 +248,7 @@ def repair_companion(
     Conservative repair: valid existing fields are preserved; only missing/invalid
     required fields are filled with safe defaults.  Always writes the result to disk.
     """
-    path = vault_root / companion_path(uuid)
+    path = vault_root / companion_path(uuid, vault_root)
     existing_fm: dict = {}
 
     if path.exists():

--- a/app/workers/outbox_worker.py
+++ b/app/workers/outbox_worker.py
@@ -200,6 +200,37 @@ def _maybe_heal_uuid(note_path: Path, vault_root: Path) -> str:
             return ""
 
     return ""
+
+
+def _ensure_uuid_with_backoff(note_path: Path) -> str:
+    max_attempts = 5
+    base_sleep = 0.2
+
+    for attempt in range(max_attempts):
+        try:
+            healed = ensure_note_uuid(note_path)
+            if healed:
+                logger.info("ensured uuid for note note_path=%s", note_path)
+            return healed
+        except OSError as exc:
+            if exc.errno in {errno.EPERM, errno.EACCES, errno.EROFS}:
+                if attempt + 1 < max_attempts:
+                    time.sleep(base_sleep * (2**attempt))
+                    continue
+                _warn_once(
+                    f"uuid_ensure_perm:{note_path}",
+                    "uuid ensure skipped (permission) note_path=%s errno=%s",
+                    note_path,
+                    exc.errno,
+                )
+                return ""
+            logger.warning("failed to ensure uuid for %s: %s", note_path, exc)
+            return ""
+        except Exception as exc:
+            logger.warning("failed to ensure uuid for %s: %s", note_path, exc)
+            return ""
+
+    return ""
 def _write_markdown_if_changed(note_path: Path, original: str, updated: str) -> bool:
     if original == updated:
         return False
@@ -252,6 +283,10 @@ def _payload_retry_count(payload: Mapping[str, Any]) -> int:
         return max(int(raw), 0)
     except (TypeError, ValueError):
         return 0
+
+
+def _retry_exhausted(payload: Mapping[str, Any]) -> bool:
+    return _payload_retry_count(payload) >= _MAX_TRANSIENT_RETRY_ATTEMPTS
 
 
 def _queue_transient_retry(
@@ -329,6 +364,9 @@ def handle_panel_scan_requested(
             reason="file_unstable",
             trace_id=trace_id,
         ):
+            if _retry_exhausted(payload):
+                logger.warning("panel scan dropped after exhausted retries (file unstable) note_path=%s", note_path)
+                return WorkerPanelSummary(emitted=0, deferred=False)
             raise TransientRetryEnqueueError(f"failed to queue retry for unstable panel note: {note_path}")
         logger.info("panel scan deferred (file unstable) note_path=%s", note_path)
         return WorkerPanelSummary(emitted=0, deferred=True)
@@ -350,6 +388,9 @@ def handle_panel_scan_requested(
             reason="missing_uuid",
             trace_id=trace_id,
         ):
+            if _retry_exhausted(payload):
+                logger.warning("panel scan dropped after exhausted retries (missing uuid) note_path=%s", note_path)
+                return WorkerPanelSummary(emitted=0, deferred=False)
             raise TransientRetryEnqueueError(f"failed to queue retry for missing panel note uuid: {note_path}")
         logger.info("panel scan skipped (missing uuid) note_path=%s", note_path)
         return WorkerPanelSummary(emitted=0, deferred=True)
@@ -436,6 +477,9 @@ def handle_ingest_vault_changed(
             reason="missing_or_unstable_note",
             trace_id=trace_id,
         ):
+            if _retry_exhausted(payload):
+                logger.warning("ingest dropped after exhausted retries note_path=%s", note_path)
+                return WorkerIngestSummary(ingested=0)
             raise TransientRetryEnqueueError(f"failed to queue retry for missing or unstable note: {note_path}")
         logger.warning("ingest skipped (missing note) note_path=%s", note_path)
         return WorkerIngestSummary(ingested=0)
@@ -446,6 +490,11 @@ def handle_ingest_vault_changed(
     note_uuid = _normalize_uuid_value(frontmatter.get("uuid") or frontmatter.get("id"))
     if not note_uuid and healed_uuid:
         note_uuid = healed_uuid
+    if not note_uuid:
+        note_uuid = _ensure_uuid_with_backoff(note_path)
+        if note_uuid:
+            raw_text = _stabilized_note_text(note_path) or raw_text
+            frontmatter, body = load_frontmatter(raw_text)
 
     if not note_uuid:
         logger.debug("note missing uuid after heal attempt note_path=%s", note_path)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,16 @@
+# Production overlay — makes the Postgres data volume external so
+# `docker compose down` (even without -v) cannot destroy prod data.
+# Usage: docker compose -f docker-compose.yaml -f docker-compose.prod.yml -p pkm-prod up -d
+services:
+  api:
+    environment:
+      API_HEALTHCHECK_URL: http://host.docker.internal:18000/healthz
+
+  db:
+    volumes:
+      - pgdata_prod:/var/lib/postgresql/data
+
+volumes:
+  pgdata_prod:
+    external: true
+    name: pkm-prod_pgdata

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,10 +5,15 @@ services:
     ports: !override
       - "15434:5432"
 
+  ollama:
+    ports: !override
+      - "11435:11434"
+
   api:
     ports: !override
       - "18002:8000"
     environment:
+      API_HEALTHCHECK_URL: http://host.docker.internal:18002/healthz
       PKM_ENVIRONMENT: prod
       DATABASE_URL: postgresql+psycopg://app:app@db:5432/app_test
       DB_DSN: postgresql+psycopg://app:app@db:5432/app_test

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -117,6 +117,7 @@ Environment separation MUST be explicit across the following surfaces.
 **Implementation Status (Issue #266)**:
 - Watcher heartbeat, state files, and event logs are now environment-scoped.
 - Default behavior: `prod` uses base artifact paths (`tmp/watcher_state.json`), `dev` uses `-dev` subdirectories (`tmp-dev/watcher_state.json`).
+- The local `test` Compose/bootstrap lane uses `tmp-test/runtime.env` so regenerated service env does not leak into the default `prod` runtime env file.
 - Incidents and audit surfaces respect environment separation to prevent cross-environment contamination.
 - The `test` bootstrap path resets runtime state explicitly before startup and verification.
 

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -45,7 +45,7 @@ API and worker share the same Python image built from the repo.
 
 ## Startup Flow
 1. Ensure Colima/Docker is running.
-2. `make start` is the supported local startup path. It writes `tmp/runtime.env`, brings up the core services, auto-selects a Docker-reachable Ollama endpoint when needed, and verifies the live runtime from inside the `api` container before exiting `0`.
+2. `make start` is the supported local startup path. It writes `tmp/runtime.env` for the default/prod local stack, brings up the core services, auto-selects a Docker-reachable Ollama endpoint when needed, and verifies the live runtime from inside the `api` container before exiting `0`. The `pkm-test` Compose/bootstrap lane writes `tmp-test/runtime.env` instead.
 3. `docker compose up -d` remains available for low-level debugging, but it skips the startup wrapper's endpoint repair, vault probes, and authoritative runtime verification.
 3. `scripts/start_api.sh` (container entrypoint):
    - Normalizes the DSN from `DATABASE_URL` / `DB_DSN`.
@@ -67,7 +67,7 @@ API and worker share the same Python image built from the repo.
 - The check exits non-zero when required runtime health is not green, even if optional health checks still report warnings.
 
 ### Ollama endpoint selection
-- For `LLM_PROVIDER=ollama`, startup now probes candidate endpoints from inside the containerized runtime and persists the working endpoint into `tmp/runtime.env`.
+- For `LLM_PROVIDER=ollama`, startup now probes candidate endpoints from inside the containerized runtime and persists the working endpoint into the active runtime env file (`tmp/runtime.env` by default, `tmp-test/runtime.env` for `pkm-test`).
 - Candidate order:
   - configured endpoint
   - `DOCKER_OLLAMA_BASE_URL` when set

--- a/scripts/cold_boot.sh
+++ b/scripts/cold_boot.sh
@@ -5,7 +5,13 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
 startup_status_path="$ROOT/tmp/startup_status.json"
-runtime_env_path="${RUNTIME_ENV_PATH:-tmp/runtime.env}"
+runtime_env_path="${RUNTIME_ENV_PATH:-}"
+if [ -z "$runtime_env_path" ]; then
+  case "${COMPOSE_PROJECT_NAME:-}" in
+    pkm-test) runtime_env_path="tmp-test/runtime.env" ;;
+    *) runtime_env_path="tmp/runtime.env" ;;
+  esac
+fi
 
 log() {
   printf "[cold-start] %s\n" "$*"

--- a/scripts/export_runtime_env.sh
+++ b/scripts/export_runtime_env.sh
@@ -13,9 +13,22 @@ if [ -z "${VAULT_ROOT:-}" ]; then
   exit 2
 fi
 
-runtime_env_path="${RUNTIME_ENV_PATH:-tmp/runtime.env}"
+runtime_env_path="${RUNTIME_ENV_PATH:-}"
+if [ -z "$runtime_env_path" ]; then
+  case "${COMPOSE_PROJECT_NAME:-}" in
+    pkm-test) runtime_env_path="tmp-test/runtime.env" ;;
+    *) runtime_env_path="tmp/runtime.env" ;;
+  esac
+fi
 runtime_env_dir="$(dirname "$runtime_env_path")"
 mkdir -p "$runtime_env_dir"
+
+watcher_runtime_env_file="$runtime_env_path"
+case "$watcher_runtime_env_file" in
+  /*) ;;
+  ./*) ;;
+  *) watcher_runtime_env_file="./$watcher_runtime_env_file" ;;
+esac
 
 local_uid="${LOCAL_UID:-$(id -u)}"
 local_gid="${LOCAL_GID:-$(id -g)}"
@@ -33,6 +46,7 @@ fi
 export DATABASE_URL DB_DSN
 
 cat > "$runtime_env_path" <<ENV
+WATCHER_RUNTIME_ENV_FILE=$watcher_runtime_env_file
 VAULT_ROOT=$VAULT_ROOT
 LOCAL_UID=$local_uid
 LOCAL_GID=$local_gid

--- a/scripts/start_full_system.sh
+++ b/scripts/start_full_system.sh
@@ -699,7 +699,13 @@ if [ -z "${VAULT_LAYOUT_NOTE_REL:-}" ]; then
   fi
 fi
 
-runtime_env_path="${RUNTIME_ENV_PATH:-tmp/runtime.env}"
+runtime_env_path="${RUNTIME_ENV_PATH:-}"
+if [ -z "$runtime_env_path" ]; then
+  case "${COMPOSE_PROJECT_NAME:-}" in
+    pkm-test) runtime_env_path="tmp-test/runtime.env" ;;
+    *) runtime_env_path="tmp/runtime.env" ;;
+  esac
+fi
 RUNTIME_ENV_PATH="$runtime_env_path"
 bash scripts/export_runtime_env.sh
 scope_glob_raw="${WATCHER_SCOPE_GLOB:-}"

--- a/scripts/verify_runtime_stack.sh
+++ b/scripts/verify_runtime_stack.sh
@@ -13,7 +13,13 @@ source "scripts/lib/load_env_defaults.sh"
 load_env_defaults_file ".env"
 load_env_defaults_file "config/runtime.defaults.env"
 
-runtime_env_path="${RUNTIME_ENV_PATH:-${WATCHER_RUNTIME_ENV_FILE:-tmp/runtime.env}}"
+runtime_env_path="${RUNTIME_ENV_PATH:-${WATCHER_RUNTIME_ENV_FILE:-}}"
+if [ -z "$runtime_env_path" ]; then
+  case "${COMPOSE_PROJECT_NAME:-}" in
+    pkm-test) runtime_env_path="tmp-test/runtime.env" ;;
+    *) runtime_env_path="tmp/runtime.env" ;;
+  esac
+fi
 runtime_env=""
 if [ -f "$runtime_env_path" ]; then
   runtime_env="--env-file $runtime_env_path"

--- a/tests/ingest/test_vault_alpha_companion_skip.py
+++ b/tests/ingest/test_vault_alpha_companion_skip.py
@@ -144,3 +144,32 @@ def test_companion_notes_excluded_from_full_ingest(tmp_path: Path, _mock_env: No
     )
     # The real note should be ingested
     assert summary.ingested >= 1
+
+
+def test_layout_system_companion_dir_added_to_ignore_glob(tmp_path: Path, _mock_env: None) -> None:
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir()
+    _write_layout(vault_root)
+
+    note_uuid = "dddd4444-eeee-ffff-aaaa-bbbbbbbbbbbb"
+    note_path = vault_root / "Notes" / "real.md"
+    note_path.parent.mkdir(parents=True, exist_ok=True)
+    note_path.write_text(
+        f"---\nuuid: {note_uuid}\ntitle: Real Note\n---\nBody.\n",
+        encoding="utf-8",
+    )
+
+    companion = CompanionNote(
+        uuid=note_uuid,
+        source_ref="Notes/real.md",
+        title="Real Note",
+        content_hash="fakehash",
+        ingest_state="tracked",
+        last_ingested="2025-01-01T00:00:00+00:00",
+        created_by_instance="",
+    )
+    write_companion(vault_root, companion)
+
+    summary = run_vault_alpha_ingest(vault_root, max_notes=100, force=True)
+
+    assert f"⚙️ System/companions/{note_uuid}.md" not in summary.processed_notes

--- a/tests/ops/test_export_runtime_env.py
+++ b/tests/ops/test_export_runtime_env.py
@@ -29,6 +29,15 @@ def test_export_runtime_env_emits_uid_gid(tmp_path: Path) -> None:
     assert re.search(r"^LOCAL_GID=\d+$", text, re.M)
 
 
+def test_export_runtime_env_emits_watcher_runtime_env_file(tmp_path: Path) -> None:
+    repo_root, out_path, env = _runtime_env_base(tmp_path)
+
+    subprocess.check_call(["bash", "scripts/export_runtime_env.sh"], cwd=str(repo_root), env=env)
+
+    text = out_path.read_text(encoding="utf-8")
+    assert f"WATCHER_RUNTIME_ENV_FILE={out_path}\n" in text
+
+
 def test_export_runtime_env_derives_ollama_host_from_ollama_url(tmp_path: Path) -> None:
     repo_root, out_path, env = _runtime_env_base(tmp_path)
     env["LLM_PROVIDER"] = "ollama"

--- a/tests/ops/test_start_system_outbox_contract.py
+++ b/tests/ops/test_start_system_outbox_contract.py
@@ -144,6 +144,17 @@ def test_start_full_system_runs_runtime_verification_and_endpoint_probe() -> Non
     assert 'API_BASE_URL="${API_BASE_URL:-http://127.0.0.1:18000}"' in script
 
 
+def test_runtime_scripts_default_test_project_to_tmp_test_runtime_env() -> None:
+    for path in (
+        "scripts/start_full_system.sh",
+        "scripts/export_runtime_env.sh",
+        "scripts/verify_runtime_stack.sh",
+        "scripts/cold_boot.sh",
+    ):
+        script = Path(path).read_text(encoding="utf-8")
+        assert 'pkm-test) runtime_env_path="tmp-test/runtime.env"' in script
+
+
 def test_verify_runtime_stack_waits_for_service_health_transitions() -> None:
     script = Path("scripts/verify_runtime_stack.sh").read_text(encoding="utf-8")
     assert "wait_for_service_ok()" in script

--- a/tests/runtime/test_worker_dispatch_ingest_vault_changed.py
+++ b/tests/runtime/test_worker_dispatch_ingest_vault_changed.py
@@ -150,6 +150,45 @@ def test_worker_run_dispatches_panel_scan_requested(
     assert acked == ["panel-1"]
 
 
+def test_worker_run_acks_panel_scan_requested_after_retry_budget_exhausted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    acked: list[str] = []
+
+    def fake_handle(payload, *, vault_root=None, trace_id=None, scan_requested_ts=None):
+        return outbox_worker.WorkerPanelSummary(emitted=0, deferred=False)
+
+    monkeypatch.setattr(outbox_worker, "handle_panel_scan_requested", fake_handle)
+    monkeypatch.setattr(outbox_worker, "bootstrap", lambda: None)
+    monkeypatch.setattr(outbox_worker, "ack_outbox", lambda msg_id: acked.append(str(msg_id)) or True)
+    monkeypatch.setattr(outbox_worker, "write_worker_heartbeat", lambda **_: None)
+
+    messages = [
+        {
+            "id": "panel-exhausted-1",
+            "topic": PANEL_SCAN_REQUESTED,
+            "payload": {
+                "vault_path": "/tmp/vault/Inbox/panel.md",
+                "relative_path": "Inbox/panel.md",
+                "trace_id": "trace-panel-1",
+                "_worker_retry_count": 3,
+            },
+        }
+    ]
+
+    def fake_poll():
+        if messages:
+            return messages.pop(0)
+        return None
+
+    monkeypatch.setattr(outbox_worker, "poll_outbox_one", fake_poll)
+    monkeypatch.setenv("WORKER_HEARTBEAT_INTERVAL", "9999")
+
+    outbox_worker.run(interval=0.0, heartbeat_interval=9999, log_heartbeat_interval=None, stop_after_ticks=2)
+
+    assert acked == ["panel-exhausted-1"]
+
+
 def test_worker_run_dispatches_index_embedding_requested(monkeypatch: pytest.MonkeyPatch) -> None:
     called: list[dict] = []
     acked: list[str] = []

--- a/tests/runtime/test_worker_ingest_event.py
+++ b/tests/runtime/test_worker_ingest_event.py
@@ -152,6 +152,45 @@ def test_handle_ingest_vault_changed_creates_companion_for_existing_uuid(
     assert companion.source_ref == "📥 Inbox/existing-uuid.md"
 
 
+def test_handle_ingest_vault_changed_heals_uuid_outside_inbox(
+    tmp_path: Path, monkeypatch
+) -> None:
+    reset_memory_stores()
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+
+    vault_root = tmp_path / "vault"
+    workbench = vault_root / "🛠️ Workbench"
+    workbench.mkdir(parents=True, exist_ok=True)
+
+    note_path = workbench / "uuidless.md"
+    note_path.write_text(
+        "---\n"
+        "title: uuidless-workbench\n"
+        "---\n\n"
+        "Body\n",
+        encoding="utf-8",
+    )
+
+    payload = {
+        "vault_path": str(note_path),
+        "relative_path": "🛠️ Workbench/uuidless.md",
+        "hash": "test-hash",
+        "mtime": 123.0,
+    }
+
+    summary = outbox_worker.handle_ingest_vault_changed(payload, vault_root=vault_root)
+    assert summary.ingested == 1
+
+    healed_raw = note_path.read_text(encoding="utf-8")
+    frontmatter, _ = load_frontmatter(healed_raw)
+    assert isinstance(frontmatter, dict)
+    healed_uuid = str(frontmatter.get("uuid") or "").strip()
+    assert healed_uuid
+    companion = read_companion(vault_root, healed_uuid)
+    assert companion is not None
+    assert companion.source_ref == "🛠️ Workbench/uuidless.md"
+
+
 def test_handle_ingest_vault_changed_uses_relative_path_when_payload_path_is_host_absolute(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -397,6 +436,36 @@ def test_handle_panel_scan_requested_aborts_when_retry_enqueue_fails(
 
     with pytest.raises(outbox_worker.TransientRetryEnqueueError):
         outbox_worker.handle_panel_scan_requested(payload, vault_root=vault_root, trace_id="trace-panel-envelope")
+
+
+def test_handle_panel_scan_requested_drops_missing_uuid_after_retry_budget_exhausted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    reset_memory_stores()
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_DSN", raising=False)
+
+    vault_root = tmp_path / "vault"
+    inbox = vault_root / "📥 Inbox"
+    inbox.mkdir(parents=True, exist_ok=True)
+
+    note_path = inbox / "panel-note.md"
+    note_path.write_text("---\ntitle: No UUID\n---\nbody\n", encoding="utf-8")
+
+    monkeypatch.setattr(outbox_worker, "_maybe_heal_uuid", lambda *_args, **_kwargs: "")
+
+    payload = {
+        "vault_path": str(note_path),
+        "relative_path": "📥 Inbox/panel-note.md",
+        "hash": "test-hash",
+        "mtime": 123.0,
+        "_worker_retry_count": 3,
+    }
+
+    summary = outbox_worker.handle_panel_scan_requested(payload, vault_root=vault_root, trace_id="trace-panel-envelope")
+    assert summary.emitted == 0
+    assert summary.deferred is False
 
 
 def test_handle_ingest_vault_changed_queues_retry_for_missing_note(

--- a/tests/services/test_companion_note.py
+++ b/tests/services/test_companion_note.py
@@ -49,6 +49,20 @@ def _make_companion(
     )
 
 
+def _write_layout(vault_root: Path) -> None:
+    system = vault_root / "⚙️ System"
+    system.mkdir(parents=True, exist_ok=True)
+    (system / "vault.layout.md").write_text(
+        "---\n"
+        "version: '1'\n"
+        "system_folder: '⚙️ System'\n"
+        "inbox_folder: '📥 Inbox'\n"
+        "desk_folder: '🛠️ Workbench'\n"
+        "---\n",
+        encoding="utf-8",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Part 2 — companion_path
 # ---------------------------------------------------------------------------
@@ -57,6 +71,11 @@ class TestCompanionPath:
     def test_is_flat_uuid_path(self) -> None:
         p = companion_path("abc-123")
         assert p == Path("_system/companions/abc-123.md")
+
+    def test_uses_layout_aware_system_folder_when_vault_root_is_provided(self, tmp_path: Path) -> None:
+        _write_layout(tmp_path)
+        p = companion_path("abc-123", tmp_path)
+        assert p == Path("⚙️ System/companions/abc-123.md")
 
     def test_no_subdirectories(self) -> None:
         p = companion_path("some-uuid")
@@ -85,9 +104,10 @@ class TestReadWriteRoundtrip:
         assert result.created_by_instance == companion.created_by_instance
 
     def test_creates_parent_directories(self, tmp_path: Path) -> None:
+        _write_layout(tmp_path)
         companion = _make_companion()
         write_companion(tmp_path, companion)
-        expected = tmp_path / "_system" / "companions" / f"{companion.uuid}.md"
+        expected = tmp_path / "⚙️ System" / "companions" / f"{companion.uuid}.md"
         assert expected.exists()
 
     def test_roundtrip_with_attachments(self, tmp_path: Path) -> None:
@@ -116,9 +136,10 @@ class TestReadWriteRoundtrip:
 
     def test_written_file_has_no_forbidden_fields(self, tmp_path: Path) -> None:
         """review_state and maturity must never appear in a companion file."""
+        _write_layout(tmp_path)
         companion = _make_companion()
         write_companion(tmp_path, companion)
-        file_path = tmp_path / companion_path(companion.uuid)
+        file_path = tmp_path / companion_path(companion.uuid, tmp_path)
         text = file_path.read_text(encoding="utf-8")
         assert "review_state" not in text
         assert "maturity" not in text
@@ -320,6 +341,7 @@ class TestRepairCompanion:
 
     def test_repair_preserves_valid_fields(self, tmp_path: Path) -> None:
         """Conservative repair: valid fields are kept, only missing ones filled."""
+        _write_layout(tmp_path)
         companion = _make_companion(
             uuid="preserve-uuid",
             content_hash="original-hash",
@@ -327,7 +349,7 @@ class TestRepairCompanion:
         )
         write_companion(tmp_path, companion)
         # Corrupt the file slightly but keep uuid
-        p = tmp_path / companion_path("preserve-uuid")
+        p = tmp_path / companion_path("preserve-uuid", tmp_path)
         text = p.read_text(encoding="utf-8")
         # Simulate a field going missing by rewriting without last_ingested
         p.write_text(text.replace("last_ingested:", "# last_ingested:"), encoding="utf-8")

--- a/tests/settings/test_compile.py
+++ b/tests/settings/test_compile.py
@@ -13,7 +13,6 @@ pytestmark = pytest.mark.not_pg
 
 def test_compile_roundtrip_writes_artifacts(tmp_path, monkeypatch):
     runtime_dir = tmp_path / "runtime/settings"
-    monkeypatch.setenv("OTEL_TOKEN", "test-token")
     monkeypatch.setattr(compiler, "RUNTIME", runtime_dir)
     bus.clear("settings.changed")
     captured = []
@@ -32,7 +31,7 @@ def test_compile_roundtrip_writes_artifacts(tmp_path, monkeypatch):
     global_yaml = yaml.safe_load((runtime_dir / "global.yaml").read_text())
     assert global_yaml["timeout_ms"] == 8000
     assert global_yaml["note_moves_enable"] is False
-    assert global_yaml["secrets"]["telemetry_token"] == "test-token"
+    assert global_yaml["secrets"] == {}
     assert (runtime_dir / "agents" / "qa.yaml").exists()
     assert (runtime_dir / "agents" / "reviewer.yaml").exists()
 

--- a/vault/@Settings/global.md
+++ b/vault/@Settings/global.md
@@ -18,13 +18,19 @@ trust: internal
 ```yaml settings
 log_level: INFO
 profile: default
-secrets:
-  telemetry_token: ${SECRET:OTEL_TOKEN}
 ```
 
 ## Förklaringar & möjliga värden
 <!-- BEGIN:settings:reference -->
+### Reference — Global
+
 | key | type | default | allowed | description |
 |-----|------|---------|---------|-------------|
-| _pending | _ | _ | _ | Run `python -m app.cli settings compile --auto-heal` to update this table. |
+| `enable` | `bool` | `True` | `` | Enable this component for runtime pipelines. |
+| `dry_run` | `bool` | `False` | `` | Skip persistence and side-effects when true. |
+| `note_moves_enable` | `bool` | `False` | `` | Allow agents to move or rename notes as part of ingestion and promotion. |
+| `timeout_ms` | `int` | `8000` | `100-60000` | Per-operation timeout in milliseconds. |
+| `log_level` | `str` | `INFO` | `DEBUG, INFO, WARNING, ERROR` | Log level for agents (DEBUG|INFO|WARNING|ERROR). |
+| `profile` | `str` | `default` | `` | Active configuration profile name. |
+| `secrets` | `Dict` | `PydanticUndefined` | `` | Secret references resolved at compile time. |
 <!-- END:settings:reference -->


### PR DESCRIPTION
Fixes #890

## Summary
- make worker transient retry exhaustion non-fatal and heal UUID-less non-inbox notes during ingest
- resolve companion-note paths and ingest companion ignores against the active vault system folder
- isolate `pkm-test` runtime env artifacts from default/prod `tmp/runtime.env`, ensure compose env-file interpolation follows the generated runtime env file, and remove the unused telemetry secret placeholder blocking settings validation
- carry the bounded prod/test compose overlay fixes into repo state so they are not stranded in local worktrees

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/runtime/test_worker_ingest_event.py tests/runtime/test_worker_dispatch_ingest_vault_changed.py tests/services/test_companion_note.py tests/ingest/test_vault_alpha_companion_skip.py tests/ingest/test_vault_alpha_uuid_healing.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/settings/test_compile.py tests/settings/test_validate_settings.py tests/ops/test_start_system_outbox_contract.py tests/ops/test_export_runtime_env.py tests/scripts/test_start_script_does_not_inject_scope.py`
- `python -m app.cli settings compile --auto-heal`
- `docker compose -p pkm-prod run --rm --no-deps watcher python -m app.cli settings-validate --json`

## Ops Note
- This PR still does not resolve the separate prod checkout coherency problem where `api`/`worker` and `watcher` can be mounted from different worktrees if services are recreated from different directories.

---
