### PR TITLE
Link memory and context bundle contracts from authority docs

### DIFF
--- a/docs/CONCEPTS/COGNITIVE_ONTOLOGY.md
+++ b/docs/CONCEPTS/COGNITIVE_ONTOLOGY.md
@@ -620,9 +620,9 @@ An authority boundary defines what the system may:
 
 A trust boundary defines when the human may rely on system outputs without losing control, understanding, or the ability to audit what happened.
 
-## 8. Memory, knowledge, and context companions
+## Companion contracts: memory, knowledge, and context bundles
 
-The ontology names actors, artifacts, commitments, provenance, and authority. Two companion contracts extend it for agent operational memory and for the inspectable envelope used when selected context drives orientation, resurfacing, or action. They are pointers, not new sources of truth — the ontology rules above remain authoritative.
+This section is not an additional ontology layer. The canonical ontology remains the seven layers above (and as restated in `docs/PROJECT_KERNEL.md`). The pointers below name companion contracts that extend the ontology for agent operational memory and for the inspectable envelope used when selected context drives orientation, resurfacing, or action. They are pointers only — the ontology rules above remain authoritative.
 
 - `docs/CONCEPTS/AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT.md` separates human second-brain memory from agent operational memory, distinguishes semantic knowledge from episodic, prospective, procedural, working, preference, policy, and reflective memory classes, and defines candidate/review/promotion semantics so generated or inferred memory is not automatically trusted knowledge.
 - `docs/CONCEPTS/CONTEXT_BUNDLE_CONTRACT.md` defines the inspectable bridge object that records what context was selected, why, for what intended use, with what authority limits and provenance, across retrieval, orientation, resurfacing, and write-proposal use cases. Semantic similarity alone is not authority; context that drives writeback or action must still pass authority and provenance constraints recorded here.

--- a/docs/CONCEPTS/COGNITIVE_ONTOLOGY.md
+++ b/docs/CONCEPTS/COGNITIVE_ONTOLOGY.md
@@ -620,6 +620,13 @@ An authority boundary defines what the system may:
 
 A trust boundary defines when the human may rely on system outputs without losing control, understanding, or the ability to audit what happened.
 
+## 8. Memory, knowledge, and context companions
+
+The ontology names actors, artifacts, commitments, provenance, and authority. Two companion contracts extend it for agent operational memory and for the inspectable envelope used when selected context drives orientation, resurfacing, or action. They are pointers, not new sources of truth — the ontology rules above remain authoritative.
+
+- `docs/CONCEPTS/AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT.md` separates human second-brain memory from agent operational memory, distinguishes semantic knowledge from episodic, prospective, procedural, working, preference, policy, and reflective memory classes, and defines candidate/review/promotion semantics so generated or inferred memory is not automatically trusted knowledge.
+- `docs/CONCEPTS/CONTEXT_BUNDLE_CONTRACT.md` defines the inspectable bridge object that records what context was selected, why, for what intended use, with what authority limits and provenance, across retrieval, orientation, resurfacing, and write-proposal use cases. Semantic similarity alone is not authority; context that drives writeback or action must still pass authority and provenance constraints recorded here.
+
 ## Roles, states, properties, and transitions
 
 ### Roles

--- a/docs/INTERACTION_SURFACES_AND_AUTHORITY/README.md
+++ b/docs/INTERACTION_SURFACES_AND_AUTHORITY/README.md
@@ -96,6 +96,15 @@ Owner-doc promotion (updates to `docs/DESIGN_PRINCIPLES.md`, `docs/plans/V60_CAP
 
 This directory is the source of truth. GitHub issues that implement or validate downstream slices reference task specs with "Implements INTERACTION_SURFACES_AND_AUTHORITY/{TASK_NAME}" and use the task's acceptance criteria as the issue contract. Creating those issues does not by itself promote future canvas Chat or Chat-originated mutation into current runtime behavior.
 
+## Related contracts: context bundles and write authority
+
+Interaction surfaces never act on raw semantic similarity. When a surface — Panel, Chat-as-canvas, or Automation — uses retrieved or remembered material to propose a writeback or trigger an action, that material crosses an authority boundary defined elsewhere:
+
+- `docs/CONCEPTS/CONTEXT_BUNDLE_CONTRACT.md` defines the inspectable envelope around the selected context (intended use, scope, included/excluded artifacts, authority limits, provenance, expiry, receipt relationship). A surface that mutates durable state must carry a context bundle whose authority and provenance constraints are satisfied; LLM reasoning over similarity hits is not, by itself, authority to write.
+- `docs/CONCEPTS/AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT.md` separates human second-brain memory from agent operational memory and keeps candidate/review/promotion as the route from generated memory to trusted knowledge, so a surface cannot quietly elevate agent-side memory into writeback authority.
+
+These are docs-only contracts. They do not change any current Panel, Chat, or Automation runtime behavior, and they do not alter the gated execution invariant recorded in `STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md`.
+
 ## Navigation
 
 - Parent plan: `docs/plans/V60_ARCHITECTURE_TARGET.md` §Pillar 10, §Pillar 10A


### PR DESCRIPTION
Fixes #880

## Summary
Closes the remaining doc-writeback gap for #880 AC #7. The two core contracts (`AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT.md`, `CONTEXT_BUNDLE_CONTRACT.md`) shipped via #884, but `docs/CONCEPTS/COGNITIVE_ONTOLOGY.md` and `docs/INTERACTION_SURFACES_AND_AUTHORITY/README.md` were not yet linking them. This PR adds short, scoped pointers in both — no duplication of contract content and no claim of runtime implementation.

## Changes
- `docs/CONCEPTS/COGNITIVE_ONTOLOGY.md`: new section "8. Memory, knowledge, and context companions" with pointers to the two contracts. Existing ontology rules remain authoritative.
- `docs/INTERACTION_SURFACES_AND_AUTHORITY/README.md`: new "Related contracts: context bundles and write authority" section tying the two contracts to the gated-execution invariant; no surface-runtime change.

## Validation
- `git diff --check` — clean
- `grep -l AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT\|CONTEXT_BUNDLE_CONTRACT docs/CONCEPTS/COGNITIVE_ONTOLOGY.md docs/FINDING_AND_REORIENTING/README.md docs/INTERACTION_SURFACES_AND_AUTHORITY/README.md docs/DOCS_INDEX.md` — all four target docs now reference the contracts (AC #7 satisfied).

## Out of scope
Per #880 constraints: docs-only. No runtime, schema, API, UI, retrieval, write-guard, or memory-storage changes.