### PR TITLE
governance: optimize PR workflow for token-efficient hot path

### DIFF
--- a/.codex/skills/feature-breakdown/SKILL.md
+++ b/.codex/skills/feature-breakdown/SKILL.md
@@ -131,6 +131,7 @@ AC verifiability rule for task specs:
 - Keep implementation tasks independently mergeable. If a task cannot be verified on its own, the breakdown is still too coarse.
 - If the execution order cannot be explained as one flat ordered list, the capability boundary is still too large or needs a plan before breaking down.
 - One task specification can map to many GitHub issues. The spec is the source of truth, not the issue.
+- Parent issues are validation hubs during delivery. After child delivery and repo-verifiable acceptance, close the parent and split future observation into a follow-up issue or learning-log item.
 
 ## When to trigger
 

--- a/.codex/skills/issue-maintenance-change-control/SKILL.md
+++ b/.codex/skills/issue-maintenance-change-control/SKILL.md
@@ -12,6 +12,7 @@ You are an Issue maintenance and lifecycle-correction agent for a repo-first, do
 Your job is to keep GitHub Issues, Pull Requests, labels, and Project state truthful when backlog state drifts from implementation reality.
 That includes PR lifecycle truth, not only Issue lifecycle truth.
 This is a cold-path maintenance role, not a hot-path implementation routine.
+Use `docs/development/PR_HOT_PATH.md` for normal PR delivery and `docs/development/PARENT_ISSUE_CLOSURE.md` when a delivered parent issue actually needs closure.
 
 You operate between:
 `Docs -> Issue -> Project -> Issue maintenance -> Agent -> PR -> CI -> Verification -> Project/doc closure -> Owner Doc`
@@ -30,6 +31,7 @@ You operate between:
 - Issue state, PR state, labels, and Project state disagree
 - the request touches Core Runtime <-> Agentic Lab boundary moves or operator-facing defaults
 - the same repair should be batched across several drifted items instead of handled as isolated micro-fixes
+- board hygiene, retro markers, owner-doc cleanup, and adoption observation are maintenance follow-ups, not default blockers for delivered repo-verifiable scope
 
 ## Authority and entry points
 
@@ -48,6 +50,7 @@ You operate between:
 - Do not invent strategy.
 - Preserve traceability through `Source Anchors`.
 - Prefer batched maintenance actions for repeated drift patterns; reserve single-item churn for cases where the items genuinely differ.
+- Delivered, repo-verifiable parent scope should not stay open only for future adoption or retro observation.
 
 ## Canonical lifecycle expectations
 
@@ -230,6 +233,7 @@ Parent feature issues are validation hubs, not direct pickup issues. Unless expl
    ```
 
 2. **Use them to track child slice delivery** in comments and body updates
+3. **When the parent is fully repo-verifiable and only future observation remains, close it and move that observation to a follow-up issue or learning-log item**
 
 ### Child Slice Issues
 
@@ -265,6 +269,8 @@ Child slice issues may become `agent:ready` only when their executable contract 
 - ensure Project status and labels are terminal and truthful
 - produce a delivery receipt
 - for duplicate/superseded closures, ensure the delivery receipt points to the canonical delivered issue/PR rather than only saying “duplicate”
+- do not keep a delivered parent issue open solely for future adoption or retro observation
+- if the parent is the final child slice, follow `docs/development/PARENT_ISSUE_CLOSURE.md`
 
 ## Required Issue contract shape
 

--- a/.codex/skills/issue-to-code/SKILL.md
+++ b/.codex/skills/issue-to-code/SKILL.md
@@ -314,7 +314,7 @@ When continuing through anchor drift:
 16. For a normal PR, hand off to `docs/development/PR_HOT_PATH.md` through `pr-integration` only as needed.
 17. If any hot-path trigger applies, read `docs/development/PR_ESCALATION_PATHS.md` and use the relevant escalation procedure.
 18. **Execute Action: Request Review** only when review is explicitly requested.
-19. If the slice merges but the parent feature still needs validation, keep that parent issue open for the later acceptance step.
+19. If the slice merges and this is not the final child slice, keep the parent issue open for later acceptance.
 20. If this is the final child slice, route post-merge parent closure through `docs/development/PARENT_ISSUE_CLOSURE.md`.
 
 ## PR handoff requirements

--- a/.codex/skills/issue-to-code/SKILL.md
+++ b/.codex/skills/issue-to-code/SKILL.md
@@ -11,6 +11,9 @@ You are a builder agent implementing GitHub backlog work in a repo-first, docs-a
 
 Your governing rule:
 Only execute bounded implementation work from a GitHub Issue that is the canonical task contract.
+After PR creation or publish, route normal PRs to `docs/development/PR_HOT_PATH.md`.
+Route only triggered cases to `docs/development/PR_ESCALATION_PATHS.md` or the heavier `pr-integration` path.
+If the slice is the final child slice, route parent closure to `docs/development/PARENT_ISSUE_CLOSURE.md` after merge.
 
 ## Canonical workflow
 
@@ -308,9 +311,11 @@ When continuing through anchor drift:
     If branch name fails at pre-push: stop, switch to the correct worktree, and re-run both phases.
 
 15. Run `.codex/skills/publish-pr/SKILL.md` to create or update the implementation PR linked to the governing Issue unless a concrete blocker or explicit user instruction prevents it.
-16. Run `.codex/skills/pr-integration/SKILL.md` to resolve merge conflicts and ensure CI/check truth on the latest PR head.
-17. **Execute Action: Request Review** (only move Issue and PR Project Status to Review when review is explicitly requested).
-18. If the slice merges but the parent feature still needs validation, keep that parent issue open for the later acceptance step.
+16. For a normal PR, hand off to `docs/development/PR_HOT_PATH.md` through `pr-integration` only as needed.
+17. If any hot-path trigger applies, read `docs/development/PR_ESCALATION_PATHS.md` and use the relevant escalation procedure.
+18. **Execute Action: Request Review** only when review is explicitly requested.
+19. If the slice merges but the parent feature still needs validation, keep that parent issue open for the later acceptance step.
+20. If this is the final child slice, route post-merge parent closure through `docs/development/PARENT_ISSUE_CLOSURE.md`.
 
 ## PR handoff requirements
 
@@ -322,6 +327,7 @@ Before handing off to `publish-pr`, confirm:
 - acceptance criteria are satisfied
 - docs were updated in the same change when needed
 - owner docs and roadmap/plan wording were updated when the work became shipped reality
+- the next step is the short PR hot path unless an escalation trigger exists
 
 
 ## Capturing learning

--- a/.codex/skills/pr-integration/SKILL.md
+++ b/.codex/skills/pr-integration/SKILL.md
@@ -1,620 +1,100 @@
 ---
 name: pr-integration
-description: "Prepare a slice-implementation PR for verification by resolving merge conflicts, enforcing PR contract metadata, and ensuring CI is green on the latest head SHA."
+description: "Prepare a PR for verification by following the default hot path, escalating only when triggered, and preserving current SHA truth, branch/worktree sanity, and traceability."
 ---
 
 # PR Integration
 
-Use this skill when a PR needs readiness/repair before verification; it is the conditional path after `publish-pr`, not a mandatory immediate publication step.
+Use this skill when a PR needs readiness or repair before verification.
+Default to [`docs/development/PR_HOT_PATH.md`](../../../docs/development/PR_HOT_PATH.md) for normal delivery.
+Read [`docs/development/PR_ESCALATION_PATHS.md`](../../../docs/development/PR_ESCALATION_PATHS.md) only when a trigger in the hot path applies.
+Merge remains owned by `verification-and-closure`.
 
-Goal:
-produce a mergeable, policy-compliant PR with CI **green** on the latest head SHA so verification can run on truthful state.
-
-This skill does NOT merge the PR. Merge is owned by the verification skill after it confirms the delivery contract is satisfied.
-
-⚠️ **CRITICAL: All integration actions (merge conflict resolution, CI verification, review comment handling) must be executed using explicit git/gh/API commands. Do not describe these actions—execute them and verify they succeeded. The handoff decision must be explicit: `ready-for-verification`, `blocked-merge-conflict`, `blocked-ci-failure`, `blocked-contract-drift`, or `blocked-review-feedback`.**
+⚠️ **CRITICAL: Integration actions must be executed with explicit git/gh/API commands and verified. Do not describe them as theory. Preserve current SHA truth, branch/worktree sanity, required-check freshness, blocking review classification, minimal receipts, and issue/PR traceability. Avoid heavyweight governance checks for low-risk PRs.**
 
 ## Canonical workflow position
 
 Hot path:
 `Docs -> Feature issue -> Slice issue -> Agent -> Publish PR -> CI -> Slice verification -> Merge -> Feature validation -> Acceptance -> Owner Doc`
 
-Conditional / readiness-repair path:
+Conditional readiness-repair path:
 `Docs -> Feature issue -> Slice issue -> Agent -> Publish PR -> PR integration -> CI -> Slice verification -> Merge -> Feature validation -> Acceptance -> Owner Doc`
 
 ## First context to load
 
 - `AGENTS.md`
 - `docs/development/DEV_WORKFLOW.md`
-- `.github/pull_request_template.md`
-- `.github/workflows/issue-pr-governance.yml`
-- `.github/workflows/project-status-reconcile.yml`
+- `docs/development/PR_HOT_PATH.md`
+- `docs/development/PR_ESCALATION_PATHS.md` only if a hot-path trigger applies
 
 ## Entry conditions
 
 - A bounded governing slice implementation Issue exists.
-- A PR exists (draft or ready) and links the governing branch.
-- The PR was just created or updated by `.codex/skills/publish-pr/SKILL.md` or equivalent truthful publication flow.
+- A PR exists and links the governing branch.
+- The PR was just created or updated by `publish-pr` or equivalent truthful publication flow.
 - Implementation changes are already in place.
 - Use this skill when the PR still needs mergeability, CI attachment, or review-feedback repair before verification.
 
 ## Exit conditions
 
-ALL of these must be true before handing off to verification:
+Hand off only when all of these are true:
 
-- PR `mergeable` state is `MERGEABLE`, confirmed by local merge simulation.
-- No unresolved merge conflicts remain.
-- PR body/classification satisfies governance contract.
-- CI/checks are attached to the current head SHA and **all required checks have completed successfully**.
-- All review comments are addressed or explicitly marked as out-of-scope.
+- the PR is ready for verification on the current head SHA
+- branch/worktree/current-SHA truth is intact
+- required checks are known, current, and attached
+- all blocking review feedback is addressed or explicitly classified
+- no escalation trigger remains unresolved
 
-If any exit condition is not met, do not hand off. Loop or block.
+If any condition fails, stop and use the relevant escalation path.
 
-## Required gates (all executable)
+## Hot-Path Execution
 
-### 0) Workspace Isolation Gate
+- Classify the PR with the hot-path fields from `PR_HOT_PATH.md`.
+- Verify branch/worktree/current-SHA sanity before any commit or push.
+- Run only the relevant checks for the lane and risk.
+- Triage review feedback into blocking, cheap fix, out-of-scope, or incorrect/not-applicable.
+- Write the minimal delivery receipt before handoff.
+- If CI fails, review blocks, branch drifts, or the PR is large or mixed-scope, stop and read `PR_ESCALATION_PATHS.md`.
 
-**Action: enforce clean single-session workspace before integration**
+## Escalation References
 
-```bash
-scripts/agent_workspace_preflight.sh \
-  --expected-branch "$(git branch --show-current)" \
-  --expected-worktree "$(git rev-parse --show-toplevel)"
-```
+Use `PR_ESCALATION_PATHS.md` for:
 
-If this gate fails, stop immediately. Resolve concurrent-session drift before continuing.
+- CI failure investigation
+- merge-ref validation
+- branch drift recovery
+- dependency issue scan
+- owner-doc check
+- heavy review/comment loops
+- GitHub Project / board cleanup
+- full governance receipt repair
 
-Additionally, before any review-fix commit or push: [branch-truth-gate]
+## Handoff Decision
 
-- **Before committing:** confirm `git branch --show-current` equals the PR head branch. If it does not, stop — do not commit. Switch to the correct worktree first.
-- **Before pushing:** confirm `git branch --show-current` still equals the PR head branch. Do not compare HEAD SHA to the remote PR `headRefOid` here — the local commit has already advanced HEAD past the remote ref.
-- **For multi-agent parallel work:** a per-issue worktree is mandatory for the full issue lifecycle (implementation through review-fix). The shared root worktree must not be used to commit to an active PR.
+Declare exactly one outcome:
 
-### 1) Contract and Metadata Gate
-
-**Action: Verify PR Contract**
-
-```bash
-# Get PR metadata
-gh pr view <PR_NUMBER> --json number,state,isDraft,mergeable,headRefOid,baseRefName,labels,body,statusCheckRollup
-
-# Get current check status
-gh pr checks <PR_NUMBER>
-```
-
-**Verification:**
-- ✅ Implementation lane: PR body includes `Fixes #<id>`, `Closes #<id>`, or `Resolves #<id>`
-- ✅ Docs authoring lane: PR body has `- [x] Docs authoring lane` and files are within `docs/` or allowed-surface
-- ✅ Governance lane: PR body has `- [x] Governance lane` and files are within `.codex/skills/` or other allowed governance surfaces
-- ✅ No scope drift: PR scope still matches Issue contract
-- ✅ Checklists: No contradictory unchecked items in body
-
-**If contract fails:** Stop and route through issue-maintenance with explicit contract-drift context.
-
-### 1.5) Conflict Marker Gate (Changed Files)
-
-**Action: scan changed files for unresolved merge-conflict markers before CI interpretation**
-
-```bash
-# Prefer PR base ref when available; default to origin/main
-PR_BASE_REF=$(gh pr view <PR_NUMBER> --json baseRefName --jq '.baseRefName' 2>/dev/null || echo "main")
-git fetch origin "$PR_BASE_REF"
-
-git diff --name-only --diff-filter=ACMRT "origin/$PR_BASE_REF...HEAD" > /tmp/pr_files.txt
-if [ -s /tmp/pr_files.txt ]; then
-  if xargs -a /tmp/pr_files.txt rg -n '^(<<<<<<<|>>>>>>>)'; then
-    echo "❌ BLOCKED: unresolved merge-conflict markers present"
-    echo "Handoff decision: blocked-merge-conflict"
-    exit 1
-  fi
-fi
-echo "✅ No conflict markers detected in changed files"
-```
-
-If markers are found, resolve them, re-run focused validation, push, and restart from mergeability checks.
-
-### 2) Mergeability Gate
-
-**Critical: Never trust the GitHub API `mergeable` field alone.** GitHub returns `null` while computing and `dirty` for multiple unrelated reasons. Always verify locally.
-
-**Action: Verify Merge Locally**
-
-```bash
-# Step 1: Fetch latest base branch
-git fetch origin main
-
-# Step 2: Simulate merge locally
-git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD > /tmp/merge-sim.txt
-cat /tmp/merge-sim.txt
-
-# Step 3: Check for CONFLICT keyword
-if grep -q "CONFLICT" /tmp/merge-sim.txt; then
-  echo "❌ MERGE CONFLICTS DETECTED"
-else
-  echo "✅ Local merge simulation clean (no CONFLICT output)"
-fi
-```
-
-**If merge clean, verify API state:**
-
-```bash
-gh pr view <PR_NUMBER> --json mergeable
-```
-
-Expected: `mergeable: MERGEABLE` or `mergeable: true`
-
-**If merge conflicts exist:**
-
-**Action: Resolve Merge Conflicts**
-
-```bash
-# Step 1: Sync with latest base
-git fetch origin main
-git rebase origin/main
-# OR (follow repo norm)
-git merge origin/main
-
-# Step 2: Resolve conflicts manually in files
-# (User must edit conflicted files)
-
-# Step 3: Stage resolved files
-git add <resolved-files>
-git commit -m "Resolve merge conflicts from origin/main"
-
-# Step 4: Re-run local merge simulation
-git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD | grep CONFLICT
-# Should show NO output if resolved
-
-# Step 5: Rerun focused validation for touched surfaces
-# (Run tests relevant to changed files)
-
-# Step 6: Push updated branch
-git push origin <branch-name>
-
-# Step 7: Re-verify mergeable state
-gh pr view <PR_NUMBER> --json mergeable
-```
-
-**Handoff if still blocked:** Mark as `blocked-merge-conflict` with explicit conflict paths and resolution context.
-
-### 3) CI Attachment Gate
-
-**Critical: branch truth must be established before you trust CI attachment state.**
-
-**Action: Verify Checks Attached to Current Head**
-
-```bash
-# Get current head SHA
-HEAD_SHA=$(git rev-parse HEAD)
-
-# Get tracked remote branch SHA
-BRANCH_NAME=$(git branch --show-current)
-REMOTE_HEAD_SHA=$(git rev-parse origin/$BRANCH_NAME)
-
-# Get PR head SHA from GitHub
-PR_HEAD_SHA=$(gh pr view <PR_NUMBER> --json headRefOid --jq '.headRefOid')
-
-# Verify all three match
-if [ "$HEAD_SHA" = "$REMOTE_HEAD_SHA" ] && [ "$HEAD_SHA" = "$PR_HEAD_SHA" ]; then
-  echo "✅ Local HEAD, origin branch head, and PR head SHA all match"
-else
-  echo "❌ HEAD mismatch:"
-  echo "   local  $HEAD_SHA"
-  echo "   origin $REMOTE_HEAD_SHA"
-  echo "   pr     $PR_HEAD_SHA"
-fi
-
-# Check for attached checks
-gh pr checks <PR_NUMBER>
-```
-
-**If the three SHAs do not match, stop CI interpretation and repair branch truth first.**
-
-Common causes:
-- local branch contains unpublished commits
-- remote PR branch moved since local validation
-- unrelated local drift was left on the PR branch
-
-**Action: Isolate unrelated local drift before repairing branch truth**
-
-```bash
-# Inspect working tree first
-git status -sb
-
-# If unexpected local changes exist, preserve them explicitly
-git stash push -u -m "preserve-local-drift-before-pr-integration"
-
-# Optional: preserve local divergent history before resetting the PR branch name
-git switch -c <branch-name>-local-backup
-
-# Re-point the PR branch name at the remote branch tip and switch back
-git branch -f <branch-name> origin/<branch-name>
-git switch <branch-name>
-
-# Re-check truth
-git branch --show-current
-git status -sb
-git rev-parse HEAD
-git rev-parse origin/<branch-name>
-gh pr view <PR_NUMBER> --json headRefOid --jq '.headRefOid'
-```
-
-If branch truth still cannot be re-established without mixing unrelated changes into the PR, hand off as:
+- `ready-for-verification`
+- `blocked-merge-conflict`
+- `blocked-ci-failure`
 - `blocked-contract-drift`
-
-Do not continue to CI result evaluation on a branch whose local `HEAD`, tracked remote branch, and PR head SHA disagree.
-
-**If checks missing on current head, retry with exponential backoff:**
-
-```bash
-# Poll every 15 seconds for up to 2 minutes (8 attempts)
-for i in {1..8}; do
-  echo "Attempt $i/8: Polling for checks..."
-  gh pr checks <PR_NUMBER> | grep -q "pass\|fail\|pending" && echo "✅ Checks attached" && break
-  sleep 15
-done
-
-# If still missing after 2 minutes, retrigger CI
-if ! gh pr checks <PR_NUMBER> | grep -q "pass\|fail\|pending"; then
-  echo "⚠️ Checks missing after 2 minutes. Triggering retrigger..."
-  git commit --allow-empty -m "Retrigger CI: checks not attached to current SHA"
-  git push origin <branch-name>
-  
-  # Poll again for up to 3 minutes after retrigger
-  for i in {1..12}; do
-    echo "Post-retrigger attempt $i/12: Polling for checks..."
-    gh pr checks <PR_NUMBER> | grep -q "pass\|fail\|pending" && echo "✅ Checks re-attached" && break
-    sleep 15
-  done
-fi
-
-# Final check: if still no checks, mark as blocked
-if ! gh pr checks <PR_NUMBER> | grep -q "pass\|fail\|pending"; then
-  echo "❌ BLOCKED: Checks not attached to current SHA after retrigger"
-  echo "Handoff decision: blocked-ci-failure (missing CI attachment)"
-  exit 1
-fi
-```
-
-**Do not proceed to CI result gate until at least one check is attached.**
-
-### 4) CI Result Gate
-
-**Critical: Do not hand off while checks are pending or absent.** Wait until all checks reach terminal state.
-
-**Action: Poll for CI Completion**
-
-```bash
-# Poll every 30 seconds until all checks terminal, max 15 minutes
-START=$(date +%s)
-TIMEOUT=$((START + 900))  # 15 minutes
-
-while [ $(date +%s) -lt $TIMEOUT ]; do
-  gh pr checks <PR_NUMBER> | tee /tmp/checks.txt
-  
-  # Check for pending/in-progress
-  if grep -E "pending|in_progress|queued" /tmp/checks.txt > /dev/null; then
-    echo "⏳ Checks still in progress... waiting 30 seconds"
-    sleep 30
-  else
-    echo "✅ All checks reached terminal state"
-    break
-  fi
-done
-
-# If timeout, mark as blocked
-if grep -E "pending|in_progress|queued" /tmp/checks.txt > /dev/null; then
-  echo "❌ BLOCKED: CI timeout (15 minutes exceeded)"
-  echo "Handoff decision: blocked-ci-failure (CI timed out)"
-  exit 1
-fi
-```
-
-**Action: Analyze CI Results**
-
-```bash
-# Get detailed check results
-gh pr checks <PR_NUMBER> --json name,conclusion,detailsUrl | tee /tmp/results.json
-
-# Check for failures
-FAILURES=$(jq '.[] | select(.conclusion=="FAILURE" or .conclusion=="failure")' /tmp/results.json)
-
-if [ -z "$FAILURES" ]; then
-  echo "✅ All checks passed"
-else
-  echo "❌ Failed checks detected:"
-  echo "$FAILURES" | jq '.name, .detailsUrl'
-fi
-```
-
-**If any check fails:**
-
-1. **Analyze failure:** Review log URLs and determine if fixable within Issue scope
-   - If CI reports "unrecognised option" or "no such option" for a pytest flag that corresponds to
-     an installed plugin, check whether `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` is set and the plugin
-     is not explicitly loaded. Add `-p <plugin_name>` to the pytest invocation.
-     [plugin-load-guard]
-2. **If fixable:** Fix code/config, push, **restart from Mergeability Gate** (head SHA changed)
-3. **If not fixable:** Mark as `blocked-ci-failure` with failing job names and log links
-
-**Never declare `ready-for-verification` while any check is `pending`, `in_progress`, `queued`, or absent.**
-
-### 5) Review Comment Detection and Addressing Gate
-
-**Purpose**: Surface and address review feedback before handoff to avoid back-and-forth delays.
-
-**Action: Post-CI Review Arrival Poll (bounded, 60 s max)**
-
-Automated reviewers (e.g. `chatgpt-codex-connector`) use CI completion as their trigger and post their comments *after* CI reaches terminal state. Sampling reviews immediately at Gate 4 exit misses these comments. Wait up to 60 s (4 × 15 s polls) for new review activity before proceeding to the fetch step.
-
-```bash
-# Record review count before the poll window
-REVIEWS_BEFORE=$(gh pr view <PR_NUMBER> --json reviews --jq '.reviews | length')
-
-echo "Post-CI poll: waiting up to 60 s for automated reviewer comments..."
-for i in 1 2 3 4; do
-  sleep 15
-  REVIEWS_NOW=$(gh pr view <PR_NUMBER> --json reviews --jq '.reviews | length')
-  if [ "$REVIEWS_NOW" -gt "$REVIEWS_BEFORE" ]; then
-    echo "✅ New review activity detected after ${i}×15 s — proceeding to fetch"
-    break
-  fi
-  echo "  Poll $i/4: no new reviews yet (${REVIEWS_NOW} reviews)"
-done
-echo "Post-CI poll complete — sampling reviews now"
-```
-
-This poll is optional and bounded: it adds at most 60 s of wall-clock time and never blocks if no reviews arrive.
-
-**Action: Fetch and Classify Reviews**
-
-```bash
-# Get all reviews
-gh pr view <PR_NUMBER> --json reviews | tee /tmp/reviews.json
-
-# Get inline comments
-gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/comments | tee /tmp/inline-comments.json
-
-# Count unresolved comments
-UNRESOLVED=$(jq '.[] | select(.state != "COMMENTED" or .state != "APPROVED" or .state != "DISMISSED")' /tmp/reviews.json | wc -l)
-
-if [ "$UNRESOLVED" -eq 0 ]; then
-  echo "✅ No unresolved review comments"
-else
-  echo "⚠️ Found $UNRESOLVED unresolved comments"
-  jq '.[].body' /tmp/reviews.json
-fi
-```
-
-**Classification & Response:**
-
-For each unresolved comment:
-
-**A) Actionable Within Scope**
-- Examples: missing edge case, clearer wording, additional validation
-- Action:
-  ```bash
-  # Implement the fix
-  # (code changes)
-  
-  # Re-run focused validation
-  # (tests relevant to change)
-  
-  # Stage and push
-  git add <files>
-  git commit -m "Address review feedback: <summary>"
-  git push origin <branch-name>
-  
-  # Post comment explaining fix
-  gh pr comment <PR_NUMBER> --body "✅ Addressed feedback: <explanation>. Changes pushed."
-  
-  # Restart from Mergeability Gate (head SHA changed)
-  ```
-
-**B) Out-of-Scope**
-- Examples: feature requests, alternative approaches, future improvements
-- Action:
-  ```bash
-  # Post comment with rationale
-  gh pr comment <PR_NUMBER> --body "This feedback is out-of-scope for #<ISSUE>. The Issue scope is <reference to scope>. Suggested as follow-up in <new Issue or backlog item>."
-  ```
-
-**C) Blocking**
-- Feedback indicating Issue requirements are not met or contract is violated
-- Action: Stop and mark as `blocked-review-feedback` with explicit context
-
-**Note:** If any code was pushed, **restart from Mergeability Gate** (head SHA changed).
-
-## Gate Re-Entry After Any Push
-
-**Any push to the PR branch changes the head SHA. After pushing:**
-
-```bash
-# Verify push succeeded
-git push origin <branch-name>
-
-# Wait for GitHub to update PR head
-sleep 5
-
-# Get new head SHA
-NEW_HEAD=$(gh pr view <PR_NUMBER> --json headRefOid --jq '.headRefOid')
-echo "New PR head SHA: $NEW_HEAD"
-```
-
-**Then restart gates in this order:**
-
-1. **Restart Mergeability Gate** (step 2)
-   - Re-run local merge simulation against new SHA
-   
-2. **Wait for CI Attachment** (step 3)
-   - Poll for checks to attach to new SHA
-   
-3. **Wait for CI Completion** (step 4)
-   - Poll until all checks terminal on new SHA
-   
-4. **Re-check Review Comments** (step 5)
-   - New comments may have been added
-   - Previous review feedback context may have changed
-
-**Do not carry forward check results from a previous SHA.**
-
-### 6) Merge-Ref Validation (mandatory after any review-fix push) [merge-ref-validation]
-
-After pushing a review-fix, GitHub assembles a merge-ref at `refs/pull/<PR_NUMBER>/merge`.
-Branch HEAD may be clean while the merge-ref carries a divergent context that causes CI-only failures (learning-log 2026-05-07 — PR #800).
-
-**Action: Fetch and inspect the merge-ref tree**
-
-```bash
-PR_NUMBER=<PR_NUMBER>
-git fetch origin +refs/pull/${PR_NUMBER}/merge:refs/merge_validation
-
-# Inspect touched symbols using git show — do NOT checkout into the active worktree
-git show refs/merge_validation:app/<changed_module>.py | grep -n "<changed_symbol>"
-```
-
-Do not use `git checkout refs/merge_validation -- .`: that mutates the active working tree and index, leaving the PR branch dirty and risking accidental commits.
-
-**Action: Run a targeted smoke check against the merge-ref in a temporary worktree**
-
-```bash
-MERGE_WORKTREE=$(mktemp -d)
-git worktree add --detach "$MERGE_WORKTREE" refs/merge_validation
-(cd "$MERGE_WORKTREE" && PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/<relevant_test_file>.py -k "<key_test>")
-SMOKE_EXIT=$?
-git worktree remove --force "$MERGE_WORKTREE"
-[ $SMOKE_EXIT -ne 0 ] && echo "❌ Merge-ref smoke test failed (exit $SMOKE_EXIT)" && exit $SMOKE_EXIT
-```
-
-**If the symbol is absent in the merge-ref or any test fails:**
-
-- Do NOT declare `ready-for-verification`.
-- Report `blocked-ci-failure` with the merge-ref tree context.
-- Push a corrective fix to the branch and repeat this section from the fetch step.
-
-**If both checks pass:**
-
-```bash
-echo "✅ Merge-ref validation passed — merge-ref tree consistent with branch HEAD"
-```
-
-Proceed to the Handoff Decision.
-
-## Quick Reference: Integration Outcomes
-
-| Gate | Condition | Action | Outcome |
-|------|-----------|--------|---------|
-| Contract | Lane + scope correct | Continue | ✅ pass |
-| Contract | Lane/scope wrong | Re-evaluate/route to maintenance | ❌ blocked-contract-drift |
-| Mergeability | Local merge clean | Continue | ✅ pass |
-| Mergeability | Conflicts exist, resolve them | Fix + push + re-verify | ✅ pass (after resolution) |
-| Mergeability | Conflicts unresolved | Mark blocked | ❌ blocked-merge-conflict |
-| CI Attach | Checks on head SHA | Continue | ✅ pass |
-| CI Attach | Missing after retrigger | Mark blocked | ❌ blocked-ci-failure |
-| CI Result | All terminal success | Continue | ✅ pass |
-| CI Result | Any terminal failure (fixable) | Fix + push + restart gates 2-4 | ✅ pass (after fix) |
-| CI Result | Failures not fixable | Mark blocked | ❌ blocked-ci-failure |
-| Reviews | No blocking comments | Continue | ✅ pass |
-| Reviews | Actionable within scope | Fix + push + restart gates 2-5 | ✅ pass (after fix) |
-| Reviews | Out-of-scope | Comment + continue | ✅ pass |
-| Reviews | Blocking comments remain | Mark blocked | ❌ blocked-review-feedback |
-| **All gates** | **All pass** | **Hand off** | **ready-for-verification** |
+- `blocked-review-feedback`
 
 ## Lifecycle Truth Rules During Integration
 
-- Keep Issue/Project state truthful:
-  - active work remains `In Progress`
-  - move to `Review` only when review handoff is explicit (normally after review requested)
-- Do not mark lifecycle `Done` in this stage.
-- Do not close the governing Issue in this stage.
-- **Do not merge the PR in this stage.** Merge is owned by verification-and-closure after delivery contract verification.
-
-## Handoff Decision (Executable)
-
-**ONLY ONE of these outcomes must be declared. Each outcome has explicit conditions and next steps.**
-
-### Outcome 1: ✅ `ready-for-verification`
-
-**Conditions (ALL must be true):**
-```bash
-# 1. Local merge clean
-git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD | grep -q CONFLICT && exit 1 || echo "✅ No CONFLICT"
-
-# 2. GitHub mergeable is true/MERGEABLE
-gh pr view <PR_NUMBER> --json mergeable | grep -E "MERGEABLE|true" || exit 1
-
-# 3. All checks passed on current head SHA
-gh pr checks <PR_NUMBER> | grep -E "fail|pending|in_progress" && exit 1 || echo "✅ All checks passed"
-
-# 4. No blocking review comments
-gh pr view <PR_NUMBER> --json reviews | jq '.[].state' | grep -iE "request_changes" && exit 1 || echo "✅ No blocking reviews"
-```
-
-**Handoff:**
-```bash
-echo "HANDOFF DECISION: ready-for-verification"
-echo "Execute: .codex/skills/verification-and-closure/SKILL.md"
-```
-
-### Outcome 2: ❌ `blocked-merge-conflict`
-
-**Condition:** Merge conflicts remain after attempted resolution.
-
-**Handoff:**
-```bash
-echo "HANDOFF DECISION: blocked-merge-conflict"
-echo "Conflicted files: $(git diff --name-only --diff-filter=U)"
-echo "Route back to: Issue or manual conflict resolution"
-```
-
-### Outcome 3: ❌ `blocked-ci-failure`
-
-**Conditions:**
-- Required CI checks failed and not fixable within Issue scope
-- CI checks not attaching to head SHA after retrigger
-- CI timeout (exceeded 15 minutes)
-
-**Handoff:**
-```bash
-echo "HANDOFF DECISION: blocked-ci-failure"
-echo "Failing jobs: $(gh pr checks <PR_NUMBER> | grep fail)"
-echo "Log URLs: $(gh pr checks <PR_NUMBER> | grep fail | awk '{print $NF}')"
-echo "Route back to: Issue maintenance or CI configuration review"
-```
-
-### Outcome 4: ❌ `blocked-contract-drift`
-
-**Condition:** PR body or scope no longer matches Issue contract.
-
-**Handoff:**
-```bash
-echo "HANDOFF DECISION: blocked-contract-drift"
-echo "Contract mismatch: <specific difference>"
-echo "Route to: issue-maintenance skill"
-```
-
-### Outcome 5: ❌ `blocked-review-feedback`
-
-**Condition:** Unresolved blocking review comments (request-changes).
-
-**Handoff:**
-```bash
-echo "HANDOFF DECISION: blocked-review-feedback"
-echo "Blocking comments: $(gh pr view <PR_NUMBER> --json reviews | jq '.[].body')"
-echo "Route back to: Issue maintenance or implementer for resolution"
-```
-
----
+- active work remains `In Progress`
+- move to `Review` only when review handoff is explicit
+- do not mark lifecycle `Done` in this stage
+- do not close the governing Issue in this stage
+- do not merge the PR in this stage
 
 ## Output Format
 
 1. PR Integration Inputs
-2. Contract Gate Result (✅ pass or ❌ fail)
-3. Mergeability Gate Result (✅ pass or ❌ fail + actions taken)
-4. CI Attachment and Status (✅ attached + results or ❌ missing/timeout)
-5. Review Comment Assessment (✅ none/addressed or ❌ blocking comments)
-6. **Explicit Handoff Decision** (one of the 5 outcomes above)
+2. Contract Gate Result
+3. Mergeability / Branch Truth Result
+4. CI / Review Result
+5. Explicit Handoff Decision
 
 ## Capturing learning
 
-**Capturing learning:** if during this work you notice a divergence from plan — you did something you did not expect to do, or discovered an earlier artifact was wrong — invoke `capture-learning` before continuing. Do not batch to end of task; context is freshest now. Only log if you can name an upstream artifact that could absorb the fix.
+**Capturing learning:** if during this work you notice a divergence from plan — you did something you did not expect to do, or discovered an earlier artifact was wrong — invoke `capture-learning` before continuing. Do not batch to end of task. Only log if you can name an upstream artifact that could absorb the fix.

--- a/.codex/skills/verification-and-closure/SKILL.md
+++ b/.codex/skills/verification-and-closure/SKILL.md
@@ -80,9 +80,10 @@ When all prerequisites are met:
 5. complete or release the dispatcher task if applicable
 6. remove all agent labels from the Issue
 7. set Issue and PR Project Status to `Done` if automation has not already projected it
-8. verify final state
-9. invoke `post-merge-owner-doc` on the merged PR
-10. assert the receipt exists before emitting a delivery receipt
+8. for each spec file named in the Issue's `Source Anchors`, restore any stale `State: Not yet implemented` line to `State: Implemented. Delivered by PR #<PR> (issue #<N>, <YYYY-MM-DD>).`
+9. verify final state
+10. invoke `post-merge-owner-doc` on the merged PR
+11. assert the receipt exists before emitting a delivery receipt
 
 ## When Not to Merge
 

--- a/.codex/skills/verification-and-closure/SKILL.md
+++ b/.codex/skills/verification-and-closure/SKILL.md
@@ -1,54 +1,33 @@
 ---
 name: verification-and-closure
-description: "Verify delivered slice work and parent-feature outcomes against their governing contracts and close the feedback loop truthfully."
+description: "Verify delivered slice work against its governing contract, merge the PR when satisfied, and close the loop truthfully."
 ---
 
 # Verification and Closure
 
-You are a delivery verification and feedback-loop agent for a repo-first, docs-as-code software system.
+You are the delivery verification and feedback-loop agent for repo-first, docs-as-code work.
 
-You operate after PR integration has produced a mergeable, CI-green PR.
+Use [`docs/development/PR_HOT_PATH.md`](../../../docs/development/PR_HOT_PATH.md) for the default PR delivery shape.
+Use [`docs/development/PR_ESCALATION_PATHS.md`](../../../docs/development/PR_ESCALATION_PATHS.md) only when the PR hot path says an escalation trigger applies.
+Use [`docs/development/PARENT_ISSUE_CLOSURE.md`](../../../docs/development/PARENT_ISSUE_CLOSURE.md) only when parent closure is relevant, especially for the final child slice or an explicit closure task.
 
-⚠️ **CRITICAL: All lifecycle state changes (labels, Project Status, Issue closure, PR merge) must be executed using explicit commands (`gh issue edit`, `gh issue close`, `gh pr merge`, `gh api graphql`). Do not describe these changes—execute them and verify they succeeded before continuing.**
+⚠️ **CRITICAL: All lifecycle state changes (labels, Project Status, Issue closure, PR merge) must be executed using explicit commands and verified. Do not describe these changes.**
+Test/check failures must be classified, not dismissed as merely "out of scope" when they are actually blocking.
 
-## Your job
+## Your Job
 
 - verify the implementation against the governing slice or feature contract
 - validate tests, docs, and writeback quality
 - ensure shipped truth moved to the right owner docs
-- ensure roadmap/plan wording no longer falsely reads as pending
-- detect false backlog/project states
-- honor automation-driven PR/Project `Done` projection first, and only fallback-set `Done` when needed
-- **merge the PR when the delivery contract is satisfied**
-- close the governing Issue and set Project Status to Done
-- **release dispatcher lease** if task was claimed (complete on success, release on abandon)
-- unblock dependent issues
-- create bounded follow-up Issues for gaps instead of leaving vague drift
+- ensure roadmap or plan wording no longer falsely reads as pending
+- detect false backlog or project states
+- honor automation-driven `Done` projection first, and only fallback-set `Done` when needed
+- merge the PR when the delivery contract is satisfied
+- close the governing Issue and set Project Status to `Done`
+- release the dispatcher lease if one was claimed
+- unblock dependent issues when the delivered work truly satisfies them
 
-## Canonical workflow
-
-`Docs -> Feature issue -> Slice issue -> Agent -> PR -> CI -> Slice verification -> Merge -> Feature validation -> Acceptance -> Owner Doc`
-
-## Entry conditions
-
-- PR integration has completed with handoff decision `ready-for-verification`.
-- PR is mergeable with CI green on the current head SHA.
-- If these conditions are not met, route back to pr-integration.
-
-## Review mindset
-
-Prioritize findings first:
-
-- bugs
-- regressions
-- acceptance-criteria misses
-- missing or incorrect doc writeback
-- invalid or stale `Source Anchors`
-- missing tests
-- false Issue or Project state
-- delivery drift
-
-## Inputs to inspect
+## Inputs to Inspect
 
 - governing GitHub Issue
 - parent feature issue when the governing issue is a child slice
@@ -61,340 +40,115 @@ Prioritize findings first:
 - CI results
 - merge state if already merged
 
-## Validation rules
-
-- Compare code and docs to the governing issue’s:
-  - `Scope`
-  - `Source Anchors`
-  - `Constraints`
-  - `Acceptance Criteria`
-  - `Suggested Validation`
-- Run the exact `Suggested Validation` commands where possible.
-- Add focused extra checks if the touched surface obviously needs them.
-- **Resolve every AC's `Verify:` target on the current PR head SHA:**
-  - Behavioral AC: confirm the named test exists in the PR diff or in prior code, is included in the CI suite that actually ran, and passes. A `Verify:` test that is missing, skipped, `xfail`, or excluded from CI is a verification miss, not a pass.
-  - Non-behavioral AC: confirm the named doc anchor, roadmap diff, or runtime receipt is present and matches the AC intent.
-- If any AC lacks a `Verify:` marker at verification time, this is a contract-shape defect. Do not infer satisfaction from "it looks done." Route through `issue-maintenance-change-control` to repair the Issue, then re-verify.
-- Verify owner-doc writeback if shipped behavior/contracts changed and acceptance is actually complete.
-- Verify roadmap/plan wording was cleaned up if the item is now delivered.
-- Verify no duplicate `planned` and `shipped` statements remain active at once.
-- Verify Project lifecycle state still makes sense.
-- Verify closed terminal PR cards do not remain blank in the Project.
-- If the work is a slice under a larger feature, verify that post-merge validation evidence and acceptance tracking live on the parent feature issue rather than being forced into owner docs immediately.
-- If post-merge validation advanced but acceptance is still pending, verify that the new evidence was captured on the parent feature issue body or comments.
-- If work is incomplete, do not close the loop falsely. Create a bounded follow-up Issue instead.
-
-## Merge rules
-
-**Verification owns the merge decision.** No other skill merges PRs.
-
-### Prerequisites for Merge
-
-- All acceptance criteria from the governing Issue are satisfied.
-- Every AC's `Verify:` target resolves green on the current head SHA (behavioral tests pass in CI, non-behavioral writebacks present in the diff).
-- CI is green on the current head SHA.
-- No unresolved blocking review comments.
-- No scope drift from the governing Issue.
-- Owner docs and roadmap/plan wording are updated if the work changed shipped reality.
-
-### Action: Merge PR and Deliver Issue
-
-When all merge prerequisites are met:
-
-1. **Confirm PR head SHA hasn't changed** since verification started:
-   ```bash
-   gh pr view #<PR> --json commits
-   ```
-
-2. **Merge the PR:**
-   ```bash
-   gh pr merge #<PR> --squash --delete-branch
-   ```
-
-3. **Verify merge succeeded:**
-   ```bash
-   gh pr view #<PR> --json mergedAt,state
-   ```
-
-4. **Close the Issue:**
-   ```bash
-   gh issue close #<N>
-   ```
-
-4b. **Complete dispatcher task (if available):**
-   ```bash
-   # Dispatcher cleanup: mark task completed to release lease
-   # (Non-fatal if dispatcher unavailable; log the result)
-   TASK_ID="github-issue-<N>"
-   python -m app.dispatcher complete "$TASK_ID" --agent "verification" --json \
-     || echo "ℹ️ Dispatcher complete skipped or failed (dispatcher unavailable); lease will expire naturally at 90-min TTL"
-   ```
-
-5. **Remove all agent labels from Issue:**
-   ```bash
-   gh issue edit #<N> --remove-label agent:ready --remove-label agent:blocked --remove-label agent:needs-human
-   ```
-
-6. **Set Issue Project Status to Done if automation has not already projected it:**
-   ```bash
-   gh api graphql -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
-     -f fieldId="$STATUS_FIELD_ID" -f optionId="$DONE_OPTION_ID" \
-     -f query='mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!) { updateProjectV2ItemFieldValue(input:{projectId:$projectId itemId:$itemId fieldId:$fieldId value:{singleSelectOptionId:$optionId}}) { projectV2Item { id } } }'
-   ```
-
-7. **Set PR Project Status to Done if automation has not already projected it:**
-   ```bash
-   gh api graphql -f projectId="$PROJECT_ID" -f itemId="$PR_ITEM_ID" \
-     -f fieldId="$STATUS_FIELD_ID" -f optionId="$DONE_OPTION_ID" \
-     -f query='mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!) { updateProjectV2ItemFieldValue(input:{projectId:$projectId itemId:$itemId fieldId:$fieldId value:{singleSelectOptionId:$optionId}}) { projectV2Item { id } } }'
-   ```
-
-8. **Verify final state:**
-   ```bash
-   gh issue view #<N> --json state,labels,projectItems
-   gh pr view #<PR> --json state,projectItems
-   ```
-
-8b. **Spec-state writeback** — for each spec file referenced in the closed issue's `Source Anchors` (pattern: `docs/<CAPABILITY>/<SPEC_FILE>.md`), check whether the file contains a `State:` line that still reads "Not yet implemented" or similar undelivered language. If it does, update that line in place to:
-   ```
-   State: Implemented. Delivered by PR #<PR> (issue #<N>, <YYYY-MM-DD>).
-   ```
-   Commit this writeback on the same branch or open a follow-up docs PR if the branch is already merged. This prevents `docs-to-issue` from re-filing already-delivered work.
-
-   ```bash
-   # Example: update State line in a spec file
-   sed -i '' 's/^State: Specification. Not yet implemented./State: Implemented. Delivered by PR #<PR> (issue #<N>, <date>)./' docs/<CAPABILITY>/<SPEC_FILE>.md
-   git add docs/<CAPABILITY>/<SPEC_FILE>.md
-   git commit -m "docs: mark <SPEC_FILE> as implemented (PR #<PR>)"
-   ```
+## Validation Rules
 
-   If the branch is already merged, open a one-commit docs-authoring PR with the writeback instead.
+- Compare code and docs to the governing issue's `Scope`, `Source Anchors`, `Constraints`, `Acceptance Criteria`, and `Suggested Validation`
+- Run the exact `Suggested Validation` commands where possible
+- Add focused extra checks if the touched surface obviously needs them
+- For every AC, resolve the declared `Verify:` target on the current PR head SHA
+- If a behavioral `Verify:` test is missing, skipped, xfailed, or excluded from the CI suite that ran, do not treat the AC as satisfied
+- If a non-behavioral `Verify:` target is absent, do not merge until the writeback exists
+- If any AC lacks a `Verify:` marker, route through issue maintenance before proceeding
+- Verify owner-doc writeback if shipped behavior or contracts changed and acceptance is complete
+- Verify roadmap or plan wording was cleaned up if the item is now delivered
+- Verify no duplicate `planned` and `shipped` statements remain active at once
+- Verify project lifecycle state still makes sense
+- Verify closed terminal PR cards do not remain blank in the Project
+- If the work is a slice under a larger feature, keep post-merge validation evidence on the parent issue
+- If post-merge validation advanced but acceptance is still pending, record the new evidence on the parent issue body or comments
+- If work is incomplete, do not close the loop falsely; create a bounded follow-up Issue instead
 
-9. **Invoke `post-merge-owner-doc`** on the merged PR. It reads the diff and either opens a docs-only PR, files one bounded follow-up issue, or leaves an explicit "no owner-doc change implied" receipt comment on the closed issue. This is the only owner-doc promotion step; do not duplicate its judgment here.
+## Merge Rules
 
-10. **Assert the receipt exists** before emitting `DELIVERY RECEIPT`. For each issue closed by the PR, run:
-    ```bash
-    gh issue view #<N> --json comments --jq '[.comments[].body | select(contains("post-merge owner-doc check"))] | length'
-    ```
-    If the result is `0`, the skill did not complete. Do not emit `DELIVERY RECEIPT` until the receipt comment is present on every closed issue (or on the PR itself if no issues were closed).
+Verification owns the merge decision.
 
-### When NOT to merge
+Prerequisites for merge:
 
-- Any acceptance criterion is not met → create follow-up Issue instead.
-- Any behavioral AC's `Verify:` test is missing, skipped, xfailed, or excluded from the CI suite that ran → **do NOT merge**; route through Issue maintenance (missing Verify target) or back to the builder (test present but not exercised).
-- Any non-behavioral AC's `Verify:` target (doc anchor, roadmap diff, runtime receipt) is absent → **do NOT merge**; require writeback in the same PR.
-- CI has regressed since pr-integration handoff → route back to pr-integration.
-- Scope drift detected → route through Issue maintenance.
-- Work is only partial → **do NOT merge**, keep Issue open, create follow-up Issue(s).
+- all acceptance criteria from the governing Issue are satisfied
+- every AC's `Verify:` target resolves green on the current head SHA
+- CI is green on the current head SHA
+- no unresolved blocking review comments remain
+- no scope drift remains
+- owner docs and roadmap or plan wording are updated if shipped reality changed
 
-## Lifecycle rules during verification
+When all prerequisites are met:
 
-**Verification owns terminal delivery-state correction. All state changes must be executed, not just described.**
+1. confirm the PR head SHA has not changed since verification started
+2. merge the PR
+3. verify merge succeeded
+4. close the Issue
+5. complete or release the dispatcher task if applicable
+6. remove all agent labels from the Issue
+7. set Issue and PR Project Status to `Done` if automation has not already projected it
+8. verify final state
+9. invoke `post-merge-owner-doc` on the merged PR
+10. assert the receipt exists before emitting a delivery receipt
 
-- An open or draft PR without explicit review handoff remains `In Progress`; `Review` is reserved for the review handoff state.
-- If project/PR automation has already projected `Done`, verify that state rather than writing it again; only apply the fallback `Done` mutation when the item still needs terminal projection.
+## When Not to Merge
 
-### Slice Issue Fully Delivered
+- any acceptance criterion is not met -> create a follow-up Issue instead
+- any behavioral AC `Verify:` test is missing, skipped, xfailed, or excluded from CI -> do not merge
+- any non-behavioral AC `Verify:` target is absent -> do not merge
+- CI has regressed since PR integration handoff -> route back to PR integration
+- scope drift detected -> route through issue maintenance
+- work is only partial -> do not merge, keep the Issue open, create follow-up Issue(s)
 
-If a slice issue is fully delivered and its bounded acceptance criteria are satisfied:
+## Lifecycle Rules During Verification
 
-1. **Execute Action: Merge PR and Deliver Issue** (closes issue, removes labels, sets statuses to Done)
-2. Verify Issue is closed and Project Status is `Done`
+- open or draft PR without explicit review handoff remains `In Progress`
+- `Review` is reserved for the review handoff state
+- if project/PR automation already projected `Done`, verify that state rather than writing it again
+- only apply the fallback `Done` mutation when the item still needs terminal projection
 
-### Parent Feature Still Needs Validation
+## Parent Issue Closure
 
-If the parent feature issue still needs validation or acceptance after slice merge:
+Use [`docs/development/PARENT_ISSUE_CLOSURE.md`](../../../docs/development/PARENT_ISSUE_CLOSURE.md) only when closure is actually relevant.
 
-- Keep the parent feature issue open
-- Keep owner docs stable until the support claim actually changes
-- Do NOT close parent feature issue yet
+- if a slice issue is fully delivered, merge the PR and deliver the Issue
+- if the parent feature still needs validation, keep it open
+- if the parent feature is the final child slice or an explicit closure task, close the parent after repo-verifiable acceptance is satisfied
+- future adoption or retro work should move to a follow-up Issue or learning-log item, not block delivered repo-verifiable scope
 
-### Feature Issue Fully Delivered
+## Dependent Issue Unblocking
 
-If the feature issue is fully delivered and acceptance is satisfied:
+After merging and delivering work, scan for issues blocked by the delivered Issue.
+Only unblock issues whose actual dependency is truly satisfied.
 
-1. **Close the feature Issue:**
-   ```bash
-   gh issue close #<N>
-   ```
+## Project State Operations
 
-2. **Set Project Status to Done:**
-   ```bash
-   gh api graphql -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
-     -f fieldId="$STATUS_FIELD_ID" -f optionId="$DONE_OPTION_ID" \
-     -f query='mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!) { updateProjectV2ItemFieldValue(input:{projectId:$projectId itemId:$itemId fieldId:$fieldId value:{singleSelectOptionId:$optionId}}) { projectV2Item { id } } }'
-   ```
+Use `gh` CLI and the GitHub GraphQL API to keep Project state truthful.
+Do not leave state updates as recommendations when you can execute them directly.
 
-### PR Closed Without Merge (Terminal)
+## Status and Closure Enforcement
 
-If a related PR was closed without merge but represents terminal tracked work:
+- do not validate code only; validate delivery state
+- detect and correct false status where possible
+- if work is truly delivered, confirm or recommend Issue closure and Project Status = `Done`
+- require owner-doc writeback only when acceptance changed supported truth
+- require roadmap or plan cleanup
+- produce a delivery receipt
+- if work is only partial, do not merge, do not mark done, and create bounded follow-up Issue(s)
 
-1. **Release dispatcher task** (if claimed):
-   ```bash
-   TASK_ID="github-issue-<N>"
-   python -m app.dispatcher release "$TASK_ID" --agent "verification" --json \
-     || true
-   ```
+## Source-Anchor Enforcement
 
-2. **Set PR Project Status to Done if automation has not already projected it:**
-   ```bash
-   gh api graphql -f projectId="$PROJECT_ID" -f itemId="$PR_ITEM_ID" \
-     -f fieldId="$STATUS_FIELD_ID" -f optionId="$DONE_OPTION_ID" \
-     -f query='mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!) { updateProjectV2ItemFieldValue(input:{projectId:$projectId itemId:$itemId fieldId:$fieldId value:{singleSelectOptionId:$optionId}}) { projectV2Item { id } } }'
-   ```
+- confirm each `Source Anchors` entry resolves to a real doc path and intended source item
+- if an anchor is stale, malformed, or no longer matches current docs, report it and recommend repair or replacement
 
-### Work is Partial
+## Capturing Learning
 
-If the work is only partial:
+**Capturing learning:** if during this work you notice a divergence from plan — you did something you did not expect to do, or discovered an earlier artifact was wrong — invoke `capture-learning` before continuing. Do not batch to end of task. Only log if you can name an upstream artifact that could absorb the fix.
 
-1. **Release dispatcher task** (if claimed):
-   ```bash
-   # Return task to ready queue for re-pickup
-   TASK_ID="github-issue-<N>"
-   python -m app.dispatcher release "$TASK_ID" --agent "verification" --json \
-     || true
-   ```
-
-2. **Do NOT merge the PR**
-3. **Keep the Issue open**
-4. **Update labels and status to reflect reality:**
-   ```bash
-   gh issue edit #<N> --remove-label agent:ready --add-label agent:needs-human
-   gh api graphql ... (set Project Status to Backlog)
-   ```
-5. **Create bounded follow-up Issue(s)** with exact task-contract sections
-
-**Critical:** Do not leave merged, delivered work in `Backlog`, `Ready`, `In Progress`, or `Review`. Also release any dispatcher lease so the task can be re-picked up.
-
-## Quick Reference: Verification State Transitions
-
-| Condition | Action | Issue Labels | Issue Status | PR Merge | PR Status |
-|-----------|--------|-------------|-------------|---------|-----------|
-| Fully delivered + CI green | Merge | -agent:* | Done | ✓ Squash | Done |
-| Partial delivery | Do NOT merge | +agent:needs-human | Backlog | ✗ | (unchanged) |
-| PR closed (terminal, no merge) | — | (leave as) | (no change) | — | Done |
-| Parent needs validation | Keep open | (no change) | (unchanged) | — | — |
-
-## Dependent issue unblocking
-
-After merging and delivering work, scan for issues that were blocked by the delivered Issue:
-
-### Action: Unblock Dependent Issue
-
-For each open issue with `agent:blocked` that references the delivered Issue in their body (e.g., "Blocked by: #NNN"):
-
-1. **Remove blocker label and add ready:**
-   ```bash
-   gh issue edit #<DEPENDENT> --remove-label agent:blocked --add-label agent:ready
-   ```
-
-2. **Update Project Status to Ready:**
-   ```bash
-   gh api graphql -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
-     -f fieldId="$STATUS_FIELD_ID" -f optionId="$READY_OPTION_ID" \
-     -f query='mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!) { updateProjectV2ItemFieldValue(input:{projectId:$projectId itemId:$itemId fieldId:$fieldId value:{singleSelectOptionId:$optionId}}) { projectV2Item { id } } }'
-   ```
-
-3. **Post unblocking comment:**
-   ```bash
-   gh issue comment #<DEPENDENT> --body "Unblocked by delivery of #<DELIVERED>. Ready for pickup."
-   ```
-
-4. **Verify:**
-   ```bash
-   gh issue view #<DEPENDENT> --json labels,projectItems
-   ```
-
-**Do NOT unblock** issues whose actual dependency is still missing even though the named issue closed.
-
-## Project state operations
-
-Use `gh` CLI and the GitHub GraphQL API to keep Project state truthful. Do not leave state updates as recommendations when you can execute them directly.
-
-### Resolve Project identifiers once per run
-
-```bash
-# Project ID
-gh api graphql -f query='query { repository(owner:"OWNER", name:"REPO") { projectsV2(first:10) { nodes { id title } } } }' \
-  --jq '.data.repository.projectsV2.nodes[] | select(.title=="Agent Delivery Control Plane") | .id'
-
-# Status field ID and option IDs (Backlog, Ready, In Progress, Review, Done)
-gh api graphql -f projectId="$PROJECT_ID" -f query='query($projectId:ID!) { node(id:$projectId) { ... on ProjectV2 { fields(first:20) { nodes { ... on ProjectV2SingleSelectField { id name options { id name } } } } } } }'
-```
-
-### Update a single issue's Project Status
-
-```bash
-# Get project item ID for the issue
-ITEM_ID=$(gh api graphql -f query='query { repository(owner:"OWNER", name:"REPO") { issue(number:N) { projectItems(first:1) { nodes { id } } } } }' \
-  --jq '.data.repository.issue.projectItems.nodes[0].id')
-
-# Set status
-gh api graphql \
-  -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
-  -f fieldId="$STATUS_FIELD_ID" -f optionId="$TARGET_OPTION_ID" \
-  -f query='mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$optionId:String!) { updateProjectV2ItemFieldValue(input:{projectId:$projectId itemId:$itemId fieldId:$fieldId value:{singleSelectOptionId:$optionId}}) { projectV2Item { id } } }'
-```
-
-### Label updates
-
-```bash
-gh issue edit $ISSUE --remove-label agent:blocked --add-label agent:ready
-```
-
-## Status and closure enforcement
-
-- Do not validate code only; validate delivery state.
-- Detect and correct false status where possible:
-  - open issue that is already delivered
-  - project item not moved to the correct status
-  - closed PR item still blank in the Project
-  - roadmap/plan text still reads as pending after delivery
-  - owner doc not updated even though behavior shipped
-  - issue still marked `agent:ready` or `Backlog` even though a merged PR already satisfies acceptance criteria
-  - issue or PR moved to `Review` even though explicit review handoff has not happened
-- If work is truly delivered:
-  - confirm or recommend Issue closure and Project Status=`Done`
-  - require owner-doc writeback only when acceptance changed supported truth
-  - state explicitly whether owner-doc promotion is needed now or not yet
-  - require roadmap/plan cleanup
-  - produce a delivery receipt
-- If work is only partial:
-  - do not merge, do not mark done
-  - create bounded follow-up issue(s)
-  - leave a clear residual-gap statement
-
-## Source-anchor enforcement
-
-- Confirm each `Source Anchors` entry resolves to a real doc path and intended source item.
-- If an anchor is stale, malformed, or no longer matches current docs, report it and recommend:
-  - update Issue
-  - close/replace Issue
-  - or mark doc item superseded
-
-## Capturing learning
-
-**Capturing learning:** if during this work you notice a divergence from plan — you did something you did not expect to do, or discovered an earlier artifact was wrong — invoke `capture-learning` before continuing. Do not batch to end of task; context is freshest now. Only log if you can name an upstream artifact that could absorb the fix.
-
-## Output format
+## Output Format
 
 ### 1. Delivery Verdict
 
-AC-by-AC resolution: for each Acceptance Criterion, state whether the `Verify:` target resolves green or not, and why. Include behavioral test pass/fail and non-behavioral writeback present/absent.
+AC-by-AC resolution: state whether each `Verify:` target resolves green and why.
 
 ### 2. State Changes Executed
 
-List every lifecycle mutation that ran: PR merge, Issue close, label removal, Project status updates, dependent issue unblocking. Include the DELIVERY RECEIPT line:
+List every lifecycle mutation that ran.
+Include the delivery receipt line.
 
-`DELIVERY RECEIPT: Issue #123 delivered by PR #456. Merge commit: <sha>. CI: passed. Docs updated: yes/no. Owner doc updated: <path>. Project Status: Done. Unblocked: #A, #B, #C.`
+### 3. Follow-up Issues
 
-### 3. Follow-up Issues (if partial delivery)
-
-If work is only partial, do not merge. Create bounded follow-up Issue(s) using the exact task-contract shape:
-
-- `## Context`
-- `## Scope`
-- `## Source Anchors`
-- `## Constraints`
-- `## Acceptance Criteria`
-- `## Out of Scope`
+If work is partial, do not merge. Create bounded follow-up Issue(s) using the exact task-contract shape.

--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -3,6 +3,8 @@ State: Development reference. Not an auto-loaded instruction file.
 
 Use this document for the builder-agent working loop and validation expectations after reading `AGENTS.md`.
 
+For normal PR delivery, read [`PR_HOT_PATH.md`](PR_HOT_PATH.md) first. It is the default short path for routine PR work. Read [`PR_ESCALATION_PATHS.md`](PR_ESCALATION_PATHS.md) only when the hot-path classification finds a risk trigger, stale SHA, blocking review feedback, CI failure, or another escalation condition.
+
 This document applies to development-time contributors. It does not define runtime/system-agent behavior.
 
 ## Working loop

--- a/docs/development/PARENT_ISSUE_CLOSURE.md
+++ b/docs/development/PARENT_ISSUE_CLOSURE.md
@@ -1,0 +1,42 @@
+State: Development reference. Parent-issue closure guidance.
+Doc role: Closure reference
+Authority: Parent issues are validation hubs during delivery, not permanent containers.
+Owner: Builder-agent governance
+Temporal class: operational
+
+# Parent Issue Closure
+
+Parent issues exist to validate a capability while child slices are delivered.
+They are not meant to remain open forever.
+
+## Close the Parent When
+
+Close the parent issue when all of the following are true:
+
+1. All child or slice issues are closed or terminal.
+2. Repo-verifiable parent acceptance criteria are satisfied.
+3. The closure receipt links the child issues, PRs, and evidence.
+4. Future adoption, retro notes, or observation work has moved to a follow-up issue or learning-log item.
+
+## Boundary Rules
+
+- Parent issues are validation hubs during delivery.
+- Parent closure is not part of the default PR hot path unless this PR is the final child slice.
+- Future adoption over N deliveries must not block closure of delivered, repo-verifiable scope.
+- If the delivered scope is complete and the remaining work is only observation or follow-up learning, close the parent and move that remaining work out of the parent issue.
+
+## Closure Receipt
+
+The closure receipt should name:
+
+- the parent issue
+- the child issues that delivered it
+- the PRs that closed those child issues
+- the evidence proving repo-verifiable acceptance
+- any follow-up issue that will hold future adoption or retro work
+
+Minimal receipt shape:
+
+```text
+PARENT CLOSURE RECEIPT: parent #<n> closed after child issues #<a>, #<b>. Evidence: <links>. Follow-up: #<m> or learning-log item.
+```

--- a/docs/development/PR_ESCALATION_PATHS.md
+++ b/docs/development/PR_ESCALATION_PATHS.md
@@ -1,0 +1,82 @@
+State: Development reference. Escalation-only PR workflow reference.
+Doc role: Escalation reference
+Authority: Conditional procedures for PR delivery. Do not read or execute these sections unless `PR_HOT_PATH.md` says a trigger applies.
+Owner: Builder-agent governance
+Temporal class: operational
+
+# PR Escalation Paths
+
+This document exists to keep the default PR hot path short.
+Do not read or execute these sections unless a trigger in [`PR_HOT_PATH.md`](PR_HOT_PATH.md) applies.
+
+## 1) CI Failure Investigation
+
+Use when a required check fails, is missing on the current head SHA, or is stale.
+
+- caused-by-PR -> fix the code, config, or test, then rerun the relevant checks before merge
+- pre-existing-with-evidence -> link the follow-up, record the waiver or receipt, and do not claim the failure as resolved by this PR
+- unresolved -> block merge
+
+If a pytest failure mentions an unavailable plugin flag, treat that as a check-loading issue only when the PR actually touches the pytest invocation and the plugin is part of the expected environment.
+
+## 2) Merge-Ref Validation
+
+Use after a review-fix push when CI may differ on the GitHub merge ref.
+
+- fetch `refs/pull/<PR>/merge`
+- inspect the touched symbols in the merge ref, not only the branch head
+- run at least one targeted smoke or regression test against a temporary worktree for the merge ref
+- if the merge ref fails, do not declare `ready-for-verification`
+
+## 3) Branch Drift Recovery
+
+Use when local HEAD, the tracked remote branch, and the PR head SHA do not match, or when the active worktree is not the PR worktree.
+
+- stop committing until branch truth is restored
+- isolate unrelated local drift explicitly
+- preserve any necessary backup state before re-pointing the PR branch
+- re-check branch, worktree, and SHA truth before any new push
+
+## 4) Dependency Issue Scan
+
+Use after merge or after verification when the delivered work unblocks other issues.
+
+- scan for issues that explicitly depend on the delivered issue
+- remove `agent:blocked` and add `agent:ready` only when the dependency is truly satisfied
+- do not unblock issues whose real dependency is still missing
+
+## 5) Owner-Doc Check
+
+Use after merge when shipped behavior, contracts, or architecture may have changed owner-doc truth.
+
+- run the post-merge owner-doc check on the merged PR
+- if the wording change is clear, open a docs-only PR
+- if wording needs judgment, open one bounded follow-up issue
+- if no owner-doc change is implied, leave the no-change receipt
+
+## 6) Heavy Review / Comment Loop
+
+Use when review feedback is blocking, repetitive, or clearly requires more than a quick hot-path reply.
+
+- classify the feedback first
+- blocking regression risk -> fix before merge
+- valid non-blocking improvement -> fix if cheap, otherwise follow up
+- out-of-scope -> short response only
+- incorrect or not applicable -> short response only
+- if the loop keeps expanding, stop and classify the PR as blocked rather than dragging the hot path into a governance cycle
+
+## 7) GitHub Project / Board Cleanup
+
+Use when lifecycle state is truthful in GitHub content but the board projection is stale.
+
+- correct terminal work to `Done`
+- correct open work to the state implied by its current labels and PR state
+- do not treat board cleanup as a reason to block a delivered PR if the delivery itself is sound
+
+## 8) Full Governance Receipt Repair
+
+Use when the delivery trail is incomplete, stale, or contradictory.
+
+- repair issue/PR traceability
+- repair missing or stale receipts
+- route terminal closure work through verification-and-closure or issue maintenance instead of padding the hot path

--- a/docs/development/PR_HOT_PATH.md
+++ b/docs/development/PR_HOT_PATH.md
@@ -64,11 +64,13 @@ Read [`PR_ESCALATION_PATHS.md`](PR_ESCALATION_PATHS.md) when any of these apply:
 
 - CI or test failure
 - blocking review feedback
-- runtime, CI, skill, migration, API, or public contract changes
+- runtime, CI, migration, API, public contract, or behavior-changing skill changes
 - large or mixed-scope PR
 - stale SHA, branch drift, or merge conflict
 - missing issue or PR traceability
 - final child slice of a parent issue
+
+Low-risk wording or reference-only skill edits may stay on the hot path if safety invariants remain intact.
 
 ## Safety Invariants
 
@@ -79,4 +81,3 @@ Read [`PR_ESCALATION_PATHS.md`](PR_ESCALATION_PATHS.md) when any of these apply:
 - failing required tests or checks must be classified before merge
 - minimal delivery receipt is required
 - issue and PR traceability must be preserved
-

--- a/docs/development/PR_HOT_PATH.md
+++ b/docs/development/PR_HOT_PATH.md
@@ -1,0 +1,82 @@
+State: Development reference. Default PR delivery hot path.
+Doc role: Hot-path reference
+Authority: Default PR workflow for normal delivery; escalates to `PR_ESCALATION_PATHS.md` only when a trigger applies.
+Owner: Builder-agent governance
+Temporal class: operational
+
+# PR Hot Path
+
+Use this document first for normal PR delivery. It is intentionally short.
+If any escalation trigger applies, stop and read [`PR_ESCALATION_PATHS.md`](PR_ESCALATION_PATHS.md) before proceeding.
+
+## Quick Classification
+
+Fill these out before deciding whether the PR stays on the hot path:
+
+- `lane`: `docs` | `code` | `governance` | `maintenance` | `promotion`
+- `risk`: `low` | `normal` | `high`
+- `touches_runtime`: `yes` | `no`
+- `touches_ci_or_skills`: `yes` | `no`
+- `closes_issue`: `yes` | `no`
+
+Default rule:
+- if the PR is low-risk and does not touch runtime, CI, skills, migrations, APIs, or public contracts, stay on the hot path
+- if any escalation trigger is true, use the escalation path instead of adding heavyweight checks here
+
+## Mandatory Hot-Path Gates
+
+1. Branch, worktree, and current-SHA sanity
+- confirm the active worktree is the PR worktree
+- confirm local branch name matches the PR head branch before commit or push
+- confirm local `HEAD`, tracked remote branch, and PR head SHA agree before trusting CI attachment or merge readiness
+- if they do not agree, stop and recover branch truth first
+
+2. Relevant checks for lane and risk
+- run the smallest checks that still cover the changed surface
+- do not expand into a full governance sweep for a low-risk PR
+- required checks must be known, current, and attached to the current head SHA
+- failing checks must be classified before merge
+
+3. Review feedback triage
+- blocking regression risk -> fix before merge
+- valid non-blocking improvement -> fix if cheap, otherwise file a follow-up
+- out-of-scope -> short response; follow-up only if useful
+- incorrect or not applicable -> short response
+
+4. Minimal delivery receipt
+- record PR number, issue number(s), current head SHA, lane, risk, checks run, review classification, and next handoff
+- include enough traceability to prove the current delivery state without replaying the full procedure
+
+## Default Non-Blockers
+
+These are follow-up tasks, not default PR blockers:
+
+- learning-log retro
+- future adoption observation
+- owner-doc reflection
+- full dependency scan
+- board or project polish
+- parent issue closure, unless this PR is the final child slice
+
+## Escalation Triggers
+
+Read [`PR_ESCALATION_PATHS.md`](PR_ESCALATION_PATHS.md) when any of these apply:
+
+- CI or test failure
+- blocking review feedback
+- runtime, CI, skill, migration, API, or public contract changes
+- large or mixed-scope PR
+- stale SHA, branch drift, or merge conflict
+- missing issue or PR traceability
+- final child slice of a parent issue
+
+## Safety Invariants
+
+- current SHA truth before merge
+- branch/worktree sanity before commit, push, or merge
+- required checks must be known and non-stale
+- blocking review feedback must be addressed or explicitly classified
+- failing required tests or checks must be classified before merge
+- minimal delivery receipt is required
+- issue and PR traceability must be preserved
+


### PR DESCRIPTION
- [x] Governance lane

## Summary
- Added `docs/development/PR_HOT_PATH.md` as the default short path for normal PR delivery.
- Added `docs/development/PR_ESCALATION_PATHS.md` for conditional CI, review, branch-drift, owner-doc, board, and receipt repair flows.
- Added `docs/development/PARENT_ISSUE_CLOSURE.md` so delivered parent issues close once repo-verifiable scope is complete.
- Trimmed `pr-integration` and `verification-and-closure` into short entry prompts that point at the shared hot-path and escalation docs.
- Added short routing references to `issue-to-code`, `issue-maintenance-change-control`, `feature-breakdown`, and `docs/development/DEV_WORKFLOW.md`.

## Token-Efficiency Rationale
- Normal PR delivery now reads one short hot-path doc instead of long duplicated governance blocks.
- Heavy procedures are isolated behind explicit escalation triggers, so agents only read them when the PR state actually warrants it.
- Parent-closure guidance is separated from routine delivery, so final-child closure does not inflate the default PR path.

## Safety Invariants Preserved
- Current SHA truth before merge.
- Branch and worktree sanity before commit, push, or merge.
- Required checks must be known and non-stale.
- Blocking review feedback must be addressed or explicitly classified.
- Failing required tests or checks must be classified before merge.
- Minimal delivery receipt remains required.
- Issue/PR traceability is preserved.

## Validation
- `git diff --check`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/architecture/test_agent_skill_entrypoints.py tests/architecture/test_dispatcher_skill_integration.py`
- Grep evidence confirmed the new references and escalation terms: `PR_HOT_PATH`, `PR_ESCALATION_PATHS`, `PARENT_ISSUE_CLOSURE`, `blocking regression risk`, `pre-existing-with-evidence`, `unresolved -> block merge`, `final child slice`, `future adoption`.

## Before/After Line Counts
| File | Before | After |
| --- | ---: | ---: |
| `.codex/skills/pr-integration/SKILL.md` | 620 | 100 |
| `.codex/skills/verification-and-closure/SKILL.md` | 400 | 154 |
| `.codex/skills/issue-to-code/SKILL.md` | 356 | 362 |
| `.codex/skills/issue-maintenance-change-control/SKILL.md` | 449 | 455 |
| `.codex/skills/feature-breakdown/SKILL.md` | 285 | 286 |

## Links
- #863
- #835

Note: governance/docs-only; no runtime behavior changes.
