### PR TITLE
governance: allow direct repair PRs without issues

### DIFF
--- a/.codex/skills/issue-to-code/SKILL.md
+++ b/.codex/skills/issue-to-code/SKILL.md
@@ -14,6 +14,7 @@ Only execute bounded implementation work from a GitHub Issue that is the canonic
 After PR creation or publish, route normal PRs to `docs/development/PR_HOT_PATH.md`.
 Route only triggered cases to `docs/development/PR_ESCALATION_PATHS.md` or the heavier `pr-integration` path.
 If the slice is the final child slice, route parent closure to `docs/development/PARENT_ISSUE_CLOSURE.md` after merge.
+Bounded direct repair PRs may proceed without a governing Issue when the PR body supplies the full contract via direct repair rationale and validation.
 
 ## Canonical workflow
 
@@ -218,6 +219,7 @@ Only move to Review when the PR is the **explicit review handoff artifact** (nor
 ## Execution rules
 
 - Read the full Issue first.
+- For a bounded direct repair PR, treat the PR body as the contract and validate it directly instead of requiring a governing Issue.
 - Read the owner docs and source docs referenced by `Source Anchors` before editing code.
 - Stay strictly within Issue scope.
 - Do not expand scope without updating the Issue contract first.

--- a/.codex/skills/pr-integration/SKILL.md
+++ b/.codex/skills/pr-integration/SKILL.md
@@ -29,11 +29,13 @@ Conditional readiness-repair path:
 
 ## Entry conditions
 
-- A bounded governing slice implementation Issue exists.
+- Either:
+  - an issue-backed PR exists with a bounded governing slice Issue, or
+  - a bounded direct repair PR exists whose body contains `Direct PR Rationale` and `Validation`.
 - A PR exists and links the governing branch.
 - The PR was just created or updated by `publish-pr` or equivalent truthful publication flow.
 - Implementation changes are already in place.
-- Use this skill when the PR still needs mergeability, CI attachment, or review-feedback repair before verification.
+- Use this skill when the PR still needs mergeability, CI attachment, branch drift repair, review-feedback repair, or other triggered integration work before verification.
 
 ## Exit conditions
 
@@ -55,7 +57,7 @@ If any condition fails, stop and use the relevant escalation path.
 - Triage review feedback into blocking, cheap fix, out-of-scope, or incorrect/not-applicable.
 - Write the minimal delivery receipt before handoff.
 - A governing issue is required for normal planned workflow; a bounded direct repair PR may proceed without one if the PR body includes direct repair rationale and validation.
-- Missing issue traceability is an escalation trigger only when the PR is not a valid direct repair PR.
+- Missing issue traceability is an escalation trigger only when the PR is neither issue-backed nor a valid direct repair PR.
 - If CI fails, review blocks, branch drifts, or the PR is large or mixed-scope, stop and read `PR_ESCALATION_PATHS.md`.
 
 ## Escalation References

--- a/.codex/skills/pr-integration/SKILL.md
+++ b/.codex/skills/pr-integration/SKILL.md
@@ -54,6 +54,8 @@ If any condition fails, stop and use the relevant escalation path.
 - Run only the relevant checks for the lane and risk.
 - Triage review feedback into blocking, cheap fix, out-of-scope, or incorrect/not-applicable.
 - Write the minimal delivery receipt before handoff.
+- A governing issue is required for normal planned workflow; a bounded direct repair PR may proceed without one if the PR body includes direct repair rationale and validation.
+- Missing issue traceability is an escalation trigger only when the PR is not a valid direct repair PR.
 - If CI fails, review blocks, branch drifts, or the PR is large or mixed-scope, stop and read `PR_ESCALATION_PATHS.md`.
 
 ## Escalation References

--- a/.codex/skills/verification-and-closure/SKILL.md
+++ b/.codex/skills/verification-and-closure/SKILL.md
@@ -58,6 +58,12 @@ Test/check failures must be classified, not dismissed as merely "out of scope" w
 - If post-merge validation advanced but acceptance is still pending, record the new evidence on the parent issue body or comments
 - If work is incomplete, do not close the loop falsely; create a bounded follow-up Issue instead
 
+## Direct Repair PRs
+
+- For issue-backed PRs, close or update the governing Issue as usual.
+- For direct repair PRs, verify the PR body contract and validation instead of issue closure.
+- Do not create an Issue after the fact solely for a bounded direct repair.
+
 ## Merge Rules
 
 Verification owns the merge decision.

--- a/.codex/skills/verification-and-closure/SKILL.md
+++ b/.codex/skills/verification-and-closure/SKILL.md
@@ -64,38 +64,52 @@ Test/check failures must be classified, not dismissed as merely "out of scope" w
 - For direct repair PRs, verify the PR body contract and validation instead of issue closure.
 - Do not create an Issue after the fact solely for a bounded direct repair.
 
+## Verification Modes
+
+- Issue-backed PR:
+  - verify governing issue ACs
+  - close/update the governing Issue after merge
+- Direct repair PR:
+  - verify the PR body contract, `Direct PR Rationale`, and `Validation`
+  - do not require issue ACs
+  - do not close or mutate a governing Issue
+  - write a direct repair delivery receipt instead
+
 ## Merge Rules
 
 Verification owns the merge decision.
 
 Prerequisites for merge:
 
-- all acceptance criteria from the governing Issue are satisfied
-- every AC's `Verify:` target resolves green on the current head SHA
-- CI is green on the current head SHA
+- current SHA truth is intact
+- required checks are green on the current head SHA
 - no unresolved blocking review comments remain
 - no scope drift remains
-- owner docs and roadmap or plan wording are updated if shipped reality changed
+- the PR fits one of the two verification modes above
+- if issue-backed, all acceptance criteria from the governing Issue are satisfied and every AC's `Verify:` target resolves green on the current head SHA
+- if direct repair, the PR body contract, `Direct PR Rationale`, and `Validation` are satisfied on the current head SHA
+- if the direct repair expands beyond bounded scope, stop and require, create, or link an issue before merge
 
 When all prerequisites are met:
 
 1. confirm the PR head SHA has not changed since verification started
 2. merge the PR
 3. verify merge succeeded
-4. close the Issue
-5. complete or release the dispatcher task if applicable
-6. remove all agent labels from the Issue
-7. set Issue and PR Project Status to `Done` if automation has not already projected it
-8. for each spec file named in the Issue's `Source Anchors`, restore any stale `State: Not yet implemented` line to `State: Implemented. Delivered by PR #<PR> (issue #<N>, <YYYY-MM-DD>).`
+4. if issue-backed, close the Issue
+5. if issue-backed, complete or release the dispatcher task if applicable
+6. if issue-backed, remove all agent labels from the Issue
+7. if issue-backed, set Issue and PR Project Status to `Done` if automation has not already projected it
+8. if issue-backed, for each spec file named in the Issue's `Source Anchors`, restore any stale `State: Not yet implemented` line to `State: Implemented. Delivered by PR #<PR> (issue #<N>, <YYYY-MM-DD>).`
 9. verify final state
-10. invoke `post-merge-owner-doc` on the merged PR
+10. if issue-backed, invoke `post-merge-owner-doc` on the merged PR
 11. assert the receipt exists before emitting a delivery receipt
+12. if direct repair, write a direct repair delivery receipt instead of issue-closure state changes
 
 ## When Not to Merge
 
-- any acceptance criterion is not met -> create a follow-up Issue instead
-- any behavioral AC `Verify:` test is missing, skipped, xfailed, or excluded from CI -> do not merge
-- any non-behavioral AC `Verify:` target is absent -> do not merge
+- any issue-backed acceptance criterion is not met -> create a follow-up Issue instead
+- any issue-backed behavioral AC `Verify:` test is missing, skipped, xfailed, or excluded from CI -> do not merge
+- any issue-backed non-behavioral AC `Verify:` target is absent -> do not merge
 - CI has regressed since PR integration handoff -> route back to PR integration
 - scope drift detected -> route through issue maintenance
 - work is only partial -> do not merge, keep the Issue open, create follow-up Issue(s)
@@ -130,7 +144,8 @@ Do not leave state updates as recommendations when you can execute them directly
 
 - do not validate code only; validate delivery state
 - detect and correct false status where possible
-- if work is truly delivered, confirm or recommend Issue closure and Project Status = `Done`
+- if issue-backed work is truly delivered, confirm or recommend Issue closure and Project Status = `Done`
+- if direct repair work is truly delivered, write the direct repair delivery receipt and do not create or mutate a governing Issue
 - require owner-doc writeback only when acceptance changed supported truth
 - require roadmap or plan cleanup
 - produce a delivery receipt

--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -141,6 +141,8 @@ Governance-lane rules:
 - governance lane is for repository policy and workflow maintenance, not backlog delivery
 - if the change starts affecting implementation or delivered behavior, switch back to the Issue-first implementation lane
 
+Issues are the normal workflow contract. Direct repair PRs are allowed for bounded immediate fixes when the PR body is the contract, but they should stay narrow and avoid inventing backlog work after the fact.
+
 ## Runtime separation
 
 - Builder-agent instruction lives in `AGENTS.md` and the development reference docs.

--- a/docs/development/PR_HOT_PATH.md
+++ b/docs/development/PR_HOT_PATH.md
@@ -58,6 +58,42 @@ These are follow-up tasks, not default PR blockers:
 - board or project polish
 - parent issue closure, unless this PR is the final child slice
 
+## Issue-Backed vs Direct Repair PRs
+
+Issue-backed PRs are required for normal planned work, delegated agent work, feature slices, runtime behavior changes, architecture changes, multi-step refactors, dependency-bearing work, and anything needing backlog tracking or parent/child acceptance.
+
+Direct repair PRs are allowed without a governing issue when the change is bounded, immediate, and the PR body can serve as the full contract.
+
+Direct repair examples:
+
+- typo or wording fix
+- small docs correction
+- broken link
+- minor skill routing clarification
+- small review-fix
+- small governance friction fix
+- obvious cleanup discovered during current work
+
+Direct repair guardrails:
+
+- bounded change
+- clear rationale in PR body
+- validation listed in PR body
+- no parent/child tracking needed
+- no long-lived acceptance needed
+- if scope expands, create or link an issue
+
+Minimal PR body shape:
+
+## Direct PR Rationale
+No governing issue is used because this is a bounded immediate repair.
+
+Reason:
+- ...
+
+Validation:
+- ...
+
 ## Escalation Triggers
 
 Read [`PR_ESCALATION_PATHS.md`](PR_ESCALATION_PATHS.md) when any of these apply:
@@ -67,7 +103,7 @@ Read [`PR_ESCALATION_PATHS.md`](PR_ESCALATION_PATHS.md) when any of these apply:
 - runtime, CI, migration, API, public contract, or behavior-changing skill changes
 - large or mixed-scope PR
 - stale SHA, branch drift, or merge conflict
-- missing issue or PR traceability
+- missing delivery traceability for a PR that is not a valid direct repair PR
 - final child slice of a parent issue
 
 Low-risk wording or reference-only skill edits may stay on the hot path if safety invariants remain intact.
@@ -80,4 +116,4 @@ Low-risk wording or reference-only skill edits may stay on the hot path if safet
 - blocking review feedback must be addressed or explicitly classified
 - failing required tests or checks must be classified before merge
 - minimal delivery receipt is required
-- issue and PR traceability must be preserved
+- delivery traceability must be preserved through either an issue-backed PR or a direct repair PR rationale


### PR DESCRIPTION
## Classification
- [x] Governance lane

## Direct PR Rationale
No governing issue is used because this is a bounded immediate repair.

Reason:
- Clarify the direct repair PR path so issue-backed and direct repair PRs are both executable.
- Keep the patch limited to the two skill files and their merge/receipt rules.

Validation:
- `git diff --check`
- `grep -n "Direct PR Rationale" .codex/skills/pr-integration/SKILL.md .codex/skills/verification-and-closure/SKILL.md`
- `grep -n "issue-backed" .codex/skills/pr-integration/SKILL.md .codex/skills/verification-and-closure/SKILL.md`
- `grep -n "direct repair delivery receipt" .codex/skills/verification-and-closure/SKILL.md`

## Summary
- Clarify when issue-backed PRs are required versus when bounded direct repair PRs may proceed without a governing issue.
- Update PR integration and verification guidance to recognize direct repair PR rationale as the contract for small immediate fixes.

## Note
- governance/docs-only; no runtime behavior changes