### PR TITLE
docs: owner-doc promotion for #910

### DIFF
--- a/docs/CODE_INVENTORY.md
+++ b/docs/CODE_INVENTORY.md
@@ -29,7 +29,7 @@ Primary runtime packages that form the active data path. These are the packages 
 | `app/outbox` | DB outbox: write, consume, and ack |
 | `app/settings` | Settings compiler and registry |
 | `app/health` | Health check surface |
-| `app/vault` | Vault abstraction (path resolution, UUID, companion notes) |
+| `app/vault` | Vault abstraction (path resolution, UUID, companion notes) and Vault Action Layer (governed artifact placement and lifecycle) |
 | `app/ingest` | Note ingestion pipeline |
 | `app/search` | Hybrid search surface |
 | `app/db` | Database session and migration bootstrap |


### PR DESCRIPTION
## Direct Repair

Type: docs
Reason: PR #915 (closes #910) introduced `app/vault/actions.py` as the first slice of the Vault Action Layer — governed artifact placement and lifecycle. The `docs/CODE_INVENTORY.md` entry for `app/vault` only described "path resolution, UUID, companion notes" and did not reflect the new capability.
Validation: single-cell table update; no tests changed; no runtime code modified.
Issue required: no — bounded immediate repair

## Change

`docs/CODE_INVENTORY.md` line 32: updated `app/vault` description to include "Vault Action Layer (governed artifact placement and lifecycle)".

Relates to: #910, merged PR #915.