### PR TITLE
governance: run hot path governance test in CI

### DIFF
--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -99,6 +99,10 @@ jobs:
           grep -q "Fitness Functions Enforced in CI" docs/ROADMAP.md
           grep -q "CI & Test Markers" docs/STATUS.md
 
+      - name: Hot path governance architecture test
+        run: |
+          pytest -c /dev/null tests/architecture/test_pr_hot_path_governance.py -ra
+
       - name: Prepare tmp dir
         run: mkdir -p tmp
 


### PR DESCRIPTION
## Direct Repair
Type: governance
Reason: Wire the cheap hot-path governance architecture test into CI so Direct Repair and PR hot path invariants are checked without running heavy runtime smoke.
Validation: git diff --check; PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/architecture/test_pr_hot_path_governance.py
Issue required: no — bounded immediate repair

## Summary
- Adds an unconditional `pytest -c /dev/null tests/architecture/test_pr_hot_path_governance.py -ra` step to the `smoke` job in `.github/workflows/ci-smoke.yaml`
- Placed after the cheap docs/governance checks and before the `Detect heavy smoke surface` path-filter step, so it runs for all PRs including docs-only ones
- No `if:` condition — the test is cheap (6 tests, text-based, ~0.04s) and always relevant

## Validation
- `git diff --check` → clean
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/architecture/test_pr_hot_path_governance.py` → 6 passed in 0.04s
- Step has no `heavy_smoke` condition; confirmed by inspection of ci-smoke.yaml lines 102–104

## Runtime behavior
No runtime behavior changed. `smoke.yml` untouched. No new governance process added. Direct Repair policy unchanged.