### PR TITLE
governance: path-filter legacy smoke workflow

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -29,6 +29,23 @@ jobs:
           python -m pip install -U pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if [ -f pyproject.toml ]; then pip install -e ".[dev]"; fi
+      - name: Detect heavy smoke surface
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            heavy_smoke:
+              - 'app/**'
+              - 'tests/**'
+              - 'scripts/**'
+              - '.github/workflows/**'
+              - 'pyproject.toml'
+              - 'requirements*.txt'
+              - 'Makefile'
+              - 'Dockerfile'
+              - 'docker-compose*.yaml'
+              - 'docker-compose*.yml'
+
       - name: Validate docs guardrails
         run: |
           python - <<'PY'
@@ -51,6 +68,7 @@ jobs:
           PY
 
       - name: Run smoke tests (mock LLM, no PG, fail-fast)
+        if: github.event_name != 'pull_request' || steps.changes.outputs.heavy_smoke == 'true'
         timeout-minutes: 12
         env:
           LLM_PROVIDER: mock
@@ -79,6 +97,10 @@ jobs:
             tests/services/test_vault_sync_lifecycle.py \
             --maxfail=1 -ra --durations=20
 
+      - name: Skip heavy smoke for docs-only PR
+        if: github.event_name == 'pull_request' && steps.changes.outputs.heavy_smoke != 'true'
+        run: echo "Docs-only PR detected; skipping heavy runtime smoke."
+
       - name: Ensure persisted vector index artifact exists
         env:
           INDEX_PERSIST_PATH: tmp/index.jsonl
@@ -88,6 +110,7 @@ jobs:
             echo '{"event":"smoke.index.persist.seed"}' > "$INDEX_PERSIST_PATH"
           fi
       - name: CLI smoke commands
+        if: github.event_name != 'pull_request' || steps.changes.outputs.heavy_smoke == 'true'
         env:
           PYTHONPATH: ${{ github.workspace }}
           STORE_BACKEND: memory

--- a/docs/learning-log.md
+++ b/docs/learning-log.md
@@ -110,3 +110,13 @@ Resolution note (2026-05-06): verified `app/orchestrator/v2_runtime.py` now cont
 **Source:** pr-integration
 **Diverged:** CI `smoke` failed on PR merge-ref with `NameError: _upsert_executed_ids is not defined` even though branch HEAD had the alias import locally. The merge-ref carried the call site while import context diverged during conflict churn, creating a CI-only failure mode.
 **Upstream artifact:** `.codex/skills/pr-integration/SKILL.md` — add a merge-ref validation step after review-fix pushes: fetch `pull/<id>/merge`, inspect touched symbols in that tree (not only branch HEAD), and run at least one target test against the same path before declaring PR ready.
+
+## 2026-05-14 — PR #922 (path-filter legacy smoke workflow)
+**Source:** pr-integration
+**Diverged:** The plan said a `## Direct Repair` block in the PR body is sufficient for `pr-contract` to pass; reality was that the block must not be the last section — the detection regex `## Direct Repair[\s\S]*?(?=\n## |\n---|\n$)` requires a following `\n##` or `\n---` lookahead, and the `\n$` alternative only fires if GitHub stores a trailing newline (it does not). Placing `## Direct Repair` last silently returns null and `isDirectRepair = false`.
+**Upstream artifact:** `.codex/skills/publish-pr/SKILL.md` — require `## Direct Repair` to be the first section of the PR body (not the last), matching the passing pattern in PR #921 and matching the regex contract in `.github/workflows/issue-pr-governance.yml`.
+
+## 2026-05-14 — PR #922 (governance lane file allowlist excludes most workflow files)
+**Source:** pr-integration
+**Diverged:** The governance lane's allowed-file set in `issue-pr-governance.yml` includes only `.github/workflows/issue-pr-governance.yml` by exact match; other workflow files (e.g. `smoke.yml`, `ci-smoke.yaml`) are not included. A PR that classifies as `Governance lane` but touches these files will fail the file-restriction check. The Direct Repair path bypasses file restrictions entirely and is the correct route for workflow-file repairs.
+**Upstream artifact:** `docs/development/PR_HOT_PATH.md` — add a note that workflow-file repairs (other than `issue-pr-governance.yml`) must use `Direct Repair`, not the `Governance lane` checkbox, because the governance lane allowlist is narrower than `.github/workflows/**`.


### PR DESCRIPTION
## Direct Repair
Type: governance
Reason: Align legacy smoke.yml with the lightweight PR hot path so docs/governance-only PRs do not run broad runtime smoke while runtime-surface PRs and push/main still do.
Validation: git diff --check; workflow inspection
Issue required: no — bounded immediate repair

## Summary

Add \`dorny/paths-filter@v3\` to \`smoke.yml\` so docs-only and governance-only PRs skip the heavy runtime pytest and CLI smoke steps, matching the path-awareness already in \`ci-smoke.yaml\`.

## Before / After

**Before:** every PR ran full runtime smoke regardless of what changed.

**After:**
- Docs/governance-only PRs: checkout → Python setup → system deps → doc guardrails check → skip message. No pytest, no CLI smoke.
- Runtime/code PRs (touching \`app/**\`, \`tests/**\`, \`scripts/**\`, workflows, deps, Docker): unchanged — full smoke runs.
- Push to \`main\`: unchanged — full smoke always runs.

The \`heavy_smoke\` path filter is identical to the one in \`ci-smoke.yaml\` (added in #921).

## Runtime behavior

CI trigger behavior changed. Application runtime behavior unchanged.