### PR TITLE
governance: harden hot-path governance — Direct Repair detection, workflow-file lane, CI step ordering

### DIFF
--- a/.codex/skills/publish-pr/SKILL.md
+++ b/.codex/skills/publish-pr/SKILL.md
@@ -223,7 +223,10 @@ Pre-push PR-body contract gate:
   - implementation lane: `Fixes #<id>` or `Closes #<id>` or `Resolves #<id>`
   - docs lane: `- [x] Docs authoring lane`
   - governance lane: `- [x] Governance lane`
+  - direct repair: a complete `## Direct Repair` block with `Type:`, `Reason:`, `Validation:`, and `Issue required: no`
 - If none is present, stop and repair the PR body before publication.
+
+Direct Repair block placement: prefer placing the `## Direct Repair` block as the first section of the PR body (before `## Summary`). The governance check accepts the block in any position — first, middle, or last — but first placement is preferred for reviewer clarity.
 
 ### Step 7: Hand Off to pr-integration
 

--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -40,7 +40,27 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Detect heavy smoke surface
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            heavy_smoke:
+              - 'app/**'
+              - 'tests/**'
+              - 'scripts/**'
+              - 'config/**'
+              - 'configs/**'
+              - '.github/workflows/**'
+              - 'pyproject.toml'
+              - 'requirements*.txt'
+              - 'Makefile'
+              - 'Dockerfile'
+              - 'docker-compose*.yaml'
+              - 'docker-compose*.yml'
+
       - name: Install system deps (ffmpeg, ripgrep)
+        if: github.event_name != 'pull_request' || steps.changes.outputs.heavy_smoke == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y ffmpeg ripgrep
@@ -105,25 +125,6 @@ jobs:
 
       - name: Prepare tmp dir
         run: mkdir -p tmp
-
-      - name: Detect heavy smoke surface
-        id: changes
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            heavy_smoke:
-              - 'app/**'
-              - 'tests/**'
-              - 'scripts/**'
-              - 'config/**'
-              - 'configs/**'
-              - '.github/workflows/**'
-              - 'pyproject.toml'
-              - 'requirements*.txt'
-              - 'Makefile'
-              - 'Dockerfile'
-              - 'docker-compose*.yaml'
-              - 'docker-compose*.yml'
 
       - name: Pytest smoke baseline (memory, fail-fast)
         if: github.event_name != 'pull_request' || steps.changes.outputs.heavy_smoke == 'true'

--- a/.github/workflows/issue-pr-governance.yml
+++ b/.github/workflows/issue-pr-governance.yml
@@ -92,7 +92,12 @@ jobs:
             if (issueLinkPattern.test(body)) {
               return;
             }
-            const directRepairSectionMatch = body.match(/## Direct Repair[\s\S]*?(?=\n## |\n---|\n$)/i);
+            // Regex handles Direct Repair block in any position:
+            //   - First: block followed by another ## section or --- separator
+            //   - Middle: block between two ## sections or separators
+            //   - Last: block at end of string with no trailing newline (GitHub strips trailing newlines)
+            // The alternation tries the bounded match first; if no following ## or --- exists, falls back to match to end.
+            const directRepairSectionMatch = body.match(/## Direct Repair[\s\S]*?(?=\n##\s|\n---)|## Direct Repair[\s\S]*/i);
             const directRepairSection = directRepairSectionMatch ? directRepairSectionMatch[0] : "";
             const isDirectRepair =
               Boolean(directRepairSection) &&

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -13,22 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: "pip"
-
-      - name: Install system deps (ffmpeg, ripgrep)
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ffmpeg ripgrep
-
-      - name: Install Python deps
-        run: |
-          python -m pip install -U pip
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          if [ -f pyproject.toml ]; then pip install -e ".[dev]"; fi
       - name: Detect heavy smoke surface
         id: changes
         uses: dorny/paths-filter@v3
@@ -48,26 +32,36 @@ jobs:
               - 'docker-compose*.yaml'
               - 'docker-compose*.yml'
 
-      - name: Validate docs guardrails
+      - name: Set up Python 3.12
+        if: github.event_name != 'pull_request' || steps.changes.outputs.heavy_smoke == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install system deps (ffmpeg, ripgrep)
+        if: github.event_name != 'pull_request' || steps.changes.outputs.heavy_smoke == 'true'
         run: |
-          python - <<'PY'
-          from pathlib import Path
-          import re
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg ripgrep
 
-          diagrams = Path('docs/DIAGRAMS.md').read_text(encoding='utf-8')
-          readme = Path('README.md').read_text(encoding='utf-8')
+      - name: Install Python deps
+        if: github.event_name != 'pull_request' || steps.changes.outputs.heavy_smoke == 'true'
+        run: |
+          python -m pip install -U pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f pyproject.toml ]; then pip install -e ".[dev]"; fi
 
-          if '```mermaid' not in diagrams:
-              raise SystemExit('docs/DIAGRAMS.md must contain at least one ```mermaid block')
-          if '<!-- DOCS-LINKS:BEGIN -->' not in readme or '<!-- DOCS-LINKS:END -->' not in readme:
-              raise SystemExit('README.md missing DOCS-LINKS markers')
-          if re.search(r"\\n", diagrams):
-              raise SystemExit('docs/DIAGRAMS.md must not contain literal \n sequences')
-          if re.search(r"^[ \t]+```mermaid", diagrams, re.MULTILINE):
-              raise SystemExit('Mermaid fences must not be indented')
-          if re.search(r"->\|[^|]*\$begin:math:text\$[^|]*\$end:math:text\$\|", diagrams, re.MULTILINE):
-              raise SystemExit('Forbidden math fence syntax inside table detected')
-          PY
+      - name: Validate docs guardrails
+        shell: bash
+        run: |
+          set -euo pipefail
+          grep -q '```mermaid' docs/DIAGRAMS.md || { echo "docs/DIAGRAMS.md must contain at least one \`\`\`mermaid block"; exit 1; }
+          grep -q '<!-- DOCS-LINKS:BEGIN -->' README.md || { echo "README.md missing DOCS-LINKS:BEGIN marker"; exit 1; }
+          grep -q '<!-- DOCS-LINKS:END -->' README.md || { echo "README.md missing DOCS-LINKS:END marker"; exit 1; }
+          grep -qF '\n' docs/DIAGRAMS.md && { echo "docs/DIAGRAMS.md must not contain literal \\n sequences"; exit 1; } || true
+          grep -qE '^[[:space:]]+```mermaid' docs/DIAGRAMS.md && { echo "Mermaid fences must not be indented"; exit 1; } || true
+          grep -qF '$begin:math:text$' docs/DIAGRAMS.md && { echo "Forbidden math fence syntax inside table detected"; exit 1; } || true
 
       - name: Run smoke tests (mock LLM, no PG, fail-fast)
         if: github.event_name != 'pull_request' || steps.changes.outputs.heavy_smoke == 'true'

--- a/docs/development/PR_HOT_PATH.md
+++ b/docs/development/PR_HOT_PATH.md
@@ -96,6 +96,8 @@ This block is the contract for bounded direct repair PRs.
 - The merge receipt may reference this block instead of restating it.
 - If the repair expands beyond bounded scope, create or link an issue.
 
+Placement: prefer placing the `## Direct Repair` block first in the PR body (before `## Summary`) so it is immediately visible to reviewers. The governance check accepts the block in any position — first, middle, or last — regardless of whether a trailing newline follows.
+
 ## Governance Lane vs Direct Repair for Workflow Files
 
 The Governance lane checkbox (`- [x] Governance lane`) has a narrow allowed-file set in `issue-pr-governance.yml`. It covers `docs/`, `.codex/skills/`, and a small set of exact files. It does **not** cover `.github/workflows/*.yml` files broadly — only `issue-pr-governance.yml` itself is in the exact-file allowlist.

--- a/docs/development/PR_HOT_PATH.md
+++ b/docs/development/PR_HOT_PATH.md
@@ -96,6 +96,17 @@ This block is the contract for bounded direct repair PRs.
 - The merge receipt may reference this block instead of restating it.
 - If the repair expands beyond bounded scope, create or link an issue.
 
+## Governance Lane vs Direct Repair for Workflow Files
+
+The Governance lane checkbox (`- [x] Governance lane`) has a narrow allowed-file set in `issue-pr-governance.yml`. It covers `docs/`, `.codex/skills/`, and a small set of exact files. It does **not** cover `.github/workflows/*.yml` files broadly — only `issue-pr-governance.yml` itself is in the exact-file allowlist.
+
+Rule: any PR that changes `.github/workflows/` files other than `issue-pr-governance.yml` must use **Direct Repair** (not the Governance lane checkbox). Direct Repair bypasses the file restriction and is the correct path for bounded CI/workflow repairs.
+
+Summary:
+- `issue-pr-governance.yml` change → Governance lane or Direct Repair both work
+- Any other `.github/workflows/*.yml` change → Direct Repair required
+- `docs/**` or `.codex/skills/**` change → Governance lane or Direct Repair both work
+
 ## Escalation Triggers
 
 Read [`PR_ESCALATION_PATHS.md`](PR_ESCALATION_PATHS.md) when any of these apply:

--- a/tests/architecture/test_pr_hot_path_governance.py
+++ b/tests/architecture/test_pr_hot_path_governance.py
@@ -91,6 +91,79 @@ def test_issue_pr_governance_accepts_direct_repair_block_without_lane_checkbox()
     assert text.index("if (isDirectRepair) {") < text.index("const docsAuthoringPattern =")
 
 
+import re as _re
+
+
+_REQUIRED_FIELDS_PATTERNS = [
+    _re.compile(r"(?:^|\n)Type:\s*(docs|governance|code)\s*(?:\n|$)", _re.IGNORECASE),
+    _re.compile(r"(?:^|\n)Reason:\s*\S", _re.IGNORECASE),
+    _re.compile(r"(?:^|\n)Validation:\s*\S", _re.IGNORECASE),
+    _re.compile(r"(?:^|\n)Issue required:\s*no\b", _re.IGNORECASE),
+]
+
+_DIRECT_REPAIR_REGEX = _re.compile(
+    r"## Direct Repair[\s\S]*?(?=\n##\s|\n---)|## Direct Repair[\s\S]*",
+    _re.IGNORECASE,
+)
+
+
+def _is_direct_repair(body: str) -> bool:
+    """Python port of the JavaScript `isDirectRepair` logic in issue-pr-governance.yml."""
+    m = _DIRECT_REPAIR_REGEX.search(body)
+    if not m:
+        return False
+    section = m.group(0)
+    return all(p.search(section) for p in _REQUIRED_FIELDS_PATTERNS)
+
+
+_VALID_DIRECT_REPAIR_FIELDS = (
+    "Type: governance\nReason: bounded fix\nValidation: git diff --check\nIssue required: no"
+)
+
+
+def test_direct_repair_accepted_when_block_is_first_section() -> None:
+    """AC1: Direct Repair block followed by another section."""
+    body = f"## Direct Repair\n{_VALID_DIRECT_REPAIR_FIELDS}\n\n## Summary\nSome summary here."
+    assert _is_direct_repair(body), "Expected direct repair to be accepted when block is first"
+
+
+def test_direct_repair_accepted_when_block_is_last_section_no_trailing_newline() -> None:
+    """AC2: Direct Repair block at end with no trailing newline (GitHub strips trailing whitespace)."""
+    body = f"## Summary\nSome summary here.\n\n## Direct Repair\n{_VALID_DIRECT_REPAIR_FIELDS}"
+    # No trailing newline — this was the failing case before the regex fix
+    assert not body.endswith("\n"), "Fixture must have no trailing newline to reproduce the bug"
+    assert _is_direct_repair(body), "Expected direct repair to be accepted when block is last with no trailing newline"
+
+
+def test_direct_repair_accepted_when_block_is_middle_section() -> None:
+    """AC3: Direct Repair block surrounded by other sections."""
+    body = (
+        "## Summary\nSome summary.\n\n"
+        f"## Direct Repair\n{_VALID_DIRECT_REPAIR_FIELDS}\n\n"
+        "## Runtime behavior\nNo change."
+    )
+    assert _is_direct_repair(body), "Expected direct repair to be accepted when block is in the middle"
+
+
+def test_direct_repair_rejected_when_fields_incomplete() -> None:
+    """AC4: Body with Direct Repair block but missing required fields is rejected."""
+    # Missing 'Issue required: no'
+    body = "## Direct Repair\nType: governance\nReason: bounded fix\nValidation: git diff --check"
+    assert not _is_direct_repair(body), "Expected direct repair to be rejected when fields are incomplete"
+
+    # Missing 'Validation:'
+    body2 = "## Direct Repair\nType: governance\nReason: bounded fix\nIssue required: no"
+    assert not _is_direct_repair(body2), "Expected direct repair to be rejected when Validation is missing"
+
+    # Missing 'Reason:'
+    body3 = "## Direct Repair\nType: governance\nValidation: git diff\nIssue required: no"
+    assert not _is_direct_repair(body3), "Expected direct repair to be rejected when Reason is missing"
+
+    # Invalid Type value
+    body4 = "## Direct Repair\nType: feature\nReason: fix\nValidation: git diff\nIssue required: no"
+    assert not _is_direct_repair(body4), "Expected direct repair to be rejected when Type value is invalid"
+
+
 def test_parent_issue_closure_keeps_delivery_scope_above_future_adoption() -> None:
     text = _read("docs/development/PARENT_ISSUE_CLOSURE.md")
 


### PR DESCRIPTION
## Direct Repair
Type: governance
Reason: Three bounded governance repairs from PR #922 learnings: harden Direct Repair body detection, document workflow-file repair lane, and move path-filter before dep setup in smoke workflows.
Validation: git diff --check; 10/10 governance architecture tests pass; workflow inspection
Issue required: no — bounded immediate repair

## Summary

- **#923** — Fix the Direct Repair detection regex in `issue-pr-governance.yml` so the block is accepted first, middle, or last in the PR body. Add 4 Python fixture tests covering all layout variants. Add placement guidance to `PR_HOT_PATH.md` and `publish-pr/SKILL.md`.
- **#924** — Add a `## Governance Lane vs Direct Repair for Workflow Files` section to `PR_HOT_PATH.md` clarifying that `.github/workflows/*.yml` repairs (other than `issue-pr-governance.yml`) must use Direct Repair.
- **#925** — Move `Detect heavy smoke surface` to immediately after checkout in `smoke.yml`; guard Python setup, system dep install, and dep install with `heavy_smoke` condition; convert docs guardrail to shell greps so it runs without Python. Guard `ffmpeg/ripgrep` install in `ci-smoke.yaml`.

Closes #923
Closes #924
Closes #925

## Before / After

**Direct Repair detection (#923):**
Before: `## Direct Repair` last in body → regex returns null → `isDirectRepair = false` → pr-contract failure.
After: alternation regex matches bounded section or falls back to end-of-string; all three positions accepted.

**Workflow-file lane (#924):**
Before: no guidance; agents could pick Governance lane for `smoke.yml` and get rejected.
After: explicit rule documented in `PR_HOT_PATH.md`.

**CI step ordering (#925):**
Before: docs-only PRs ran checkout → Python setup → ffmpeg/ripgrep → pip install → then detected docs-only.
After: docs-only PRs run checkout → detect → skip all dep setup and heavy steps.

## Runtime behavior

CI trigger behavior changed for docs-only PRs (fewer steps run). Application runtime behavior unchanged.