### PR TITLE
fix: write queued receipt for zone_move panel actions, not ✅ done

### DIFF
--- a/app/agents/panel_agent/runtime.py
+++ b/app/agents/panel_agent/runtime.py
@@ -322,11 +322,16 @@ def _apply_note_writeback(
             if action_id_hash not in executed_ids:
                 proposed_labels.append((action.id, action.label))
 
+    queued_labels: list[str] = []  # async actions (zone_move): queued, not yet executed
+
     for result in state.action_results:
         if result.checked and result.status in {"triggered", "logged"}:
-            executed_labels.append(result.label)
+            if (result.intent_type or "").lower() == "zone_move":
+                queued_labels.append(result.label)
+            else:
+                executed_labels.append(result.label)
 
-    if not executed_labels and not proposed_labels:
+    if not executed_labels and not queued_labels and not proposed_labels:
         return
 
     note_uuid = state.note.uuid
@@ -362,8 +367,12 @@ def _apply_note_writeback(
     annotated = annotate_action_ids(current_text)
 
     # Build the set of ai:id annotation IDs to remove, mapping from label -> stable hash.
+    # Both synchronously executed and async-queued (zone_move) checkboxes are removed;
+    # only their receipt text differs.
     ids_to_remove: set[str] = set()
     for label in executed_labels:
+        ids_to_remove.add(stable_action_id(label))
+    for label in queued_labels:
         ids_to_remove.add(stable_action_id(label))
 
     updated = remove_actions_from_markdown(annotated, ids_to_remove)
@@ -373,8 +382,11 @@ def _apply_note_writeback(
         updated = _write_proposals_to_panel(updated, proposed_labels)
 
     # Build receipt lines.
+    # zone_move actions are asynchronous: the Vault Action Layer is the authoritative
+    # execution receipt.  Write "queued" here so the panel receipt never claims completion.
     now_str = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M")
     receipts = [f"\u2705 {label} ({now_str})" for label in executed_labels]
+    receipts += [f"\u23f3 {label} (queued, {now_str})" for label in queued_labels]
 
     # Find preferred insert position (after last panel fence).
     parsed = parse_panel(updated)
@@ -392,8 +404,9 @@ def _apply_note_writeback(
         logger.warning("panel writeback failed (write error) note_path=%s", note_file)
         return
 
-    # Persist executed IDs so reruns are idempotent.
-    upsert_executed_ids(note_uuid, [stable_action_id(label) for label in executed_labels])
+    # Persist executed/queued IDs so reruns are idempotent.
+    all_done_labels = executed_labels + queued_labels
+    upsert_executed_ids(note_uuid, [stable_action_id(label) for label in all_done_labels])
 
     # Refresh companion content_hash so it reflects the post-writeback content.
     _refresh_companion_hash(note_uuid, updated, vault_root, note_file)

--- a/app/vault/actions.py
+++ b/app/vault/actions.py
@@ -44,12 +44,11 @@ is defined and multiple kinds are supported.
 
 Panel-writeback note
 --------------------
-The panel runtime writes a human-visible "✅ {label}" receipt to the note
-as soon as the downstream ``note.move.workbench`` event is *queued* — not
-after the worker successfully executes the move.  The Vault Action Layer
-receipt (HTML comment appended to the moved note) is the authoritative
-execution receipt.  A future slice should align panel-receipt semantics
-with execution reality (e.g. "🔄 queued" vs "✅ done").
+The panel runtime writes a human-visible "⏳ {label} (queued, …)" receipt
+to the note as soon as the downstream ``note.move.workbench`` event is
+*queued*.  The Vault Action Layer receipt (HTML comment appended to the
+moved note) is the authoritative execution receipt — written only after
+the worker successfully completes the move.
 """
 from __future__ import annotations
 

--- a/tests/agents/panel_agent/test_panel_runtime.py
+++ b/tests/agents/panel_agent/test_panel_runtime.py
@@ -621,3 +621,57 @@ def test_runtime_writeback_proposal_dedupe_is_scoped_to_last_panel() -> None:
     # Verify the last panel now contains the proposal suggestion.
     last_panel = "%% AI:Start %%\n" + updated.split("%% AI:Start %%\n")[-1]
     assert "- [ ] Make this note evergreen" in last_panel
+
+
+def test_runtime_writeback_zone_move_writes_queued_receipt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Panel writeback for zone_move must write a queued receipt, not ✅ executed."""
+    note_uuid = str(uuid4())
+    outbox_path = tmp_path / "index-outbox.jsonl"
+    settings_path = _settings_file(
+        tmp_path,
+        action_id="note.move.workbench",
+        label="Flytta till Workbench",
+        intent_type="zone_move",
+        downstream_event="note.move.workbench",
+    )
+    markdown = (
+        "---\n"
+        f"uuid: {note_uuid}\n"
+        "---\n"
+        "# Test Note\n"
+        "\n"
+        "%% AI:Start %%\n"
+        "## AI-instruktion\n"
+        "Flytta till Workbench\n"
+        "## AI-åtgärder\n"
+        "- [x] Flytta till Workbench\n"
+        "%% AI:End %%\n"
+    )
+    vault_dir = tmp_path / "vault"
+    vault_dir.mkdir()
+    note_file = vault_dir / "test-note.md"
+    note_file.write_text(markdown, encoding="utf-8")
+    _seed_note(note_uuid, markdown, source_ref=str(note_file))
+
+    monkeypatch.setenv("PANEL_ACTIONS_PATH", str(settings_path))
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    monkeypatch.setenv("VAULT_ROOT", str(vault_dir))
+    monkeypatch.setattr("app.agents.panel_agent.agent.INDEX_OUTBOX_PATH", outbox_path, raising=False)
+
+    events = run_panel_intent_for_note(note_uuid, trace_id="trace-zone-move-receipt", trigger="watcher")
+    assert len(events) == 1
+
+    result = execute_panel_intent(events[0], outbox_path=outbox_path)
+    assert isinstance(result, PanelRuntimeResult)
+
+    updated = note_file.read_text(encoding="utf-8")
+
+    # Checkbox must be removed — action was triggered/queued.
+    assert "- [x] Flytta till Workbench" not in updated
+
+    # Panel receipt must NOT say ✅ — that would imply execution, not queuing.
+    assert "✅ Flytta till Workbench" not in updated
+
+    # Panel receipt MUST indicate the action is queued, not executed.
+    assert "queued" in updated.lower() or "requested" in updated.lower()
+    assert "Flytta till Workbench" in updated


### PR DESCRIPTION
Fixes #919

## Summary

The panel writeback was writing `✅ {label}` for all triggered actions including `zone_move` (Workbench move). That receipt is premature — the actual move happens asynchronously in the outbox worker; the Vault Action Layer receipt appended to the moved note is the authoritative execution signal.

## Changes

- `app/agents/panel_agent/runtime.py` — `_apply_note_writeback()`: split `zone_move` results into a separate `queued_labels` bucket; write `⏳ {label} (queued, …)` receipts for those actions. Checkbox removal and idempotency ID persistence unchanged.
- `app/vault/actions.py` — module docstring updated: removed "future slice should align" note (now shipped).
- `tests/agents/panel_agent/test_panel_runtime.py` — added `test_runtime_writeback_zone_move_writes_queued_receipt` (fails before fix, passes after).

## Validation

- New test fails on unchanged code, passes after fix.
- `tests/agents/panel_agent/ tests/panel/ tests/services/` — 503 passed, 0 failed.

---
Dispatcher unavailable (ModuleNotFoundError: yaml) — used GitHub-label-only claim.