### PR TITLE
feat(context-bundles): emit context bundle from retrieval (#896)

### DIFF
--- a/app/retrieval/bundle_emission.py
+++ b/app/retrieval/bundle_emission.py
@@ -1,0 +1,97 @@
+"""Emit a ContextBundle from a RetrievalResponse (CONTEXT-BUNDLES-02)."""
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from app.context_bundles.schema import (
+    AuthorityFlags,
+    BundleScope,
+    BundleTrigger,
+    ContextBundle,
+    ExcludedItem,
+    ExpiryPosture,
+    IncludedItem,
+    ItemProvenance,
+)
+from app.retrieval.capability import RetrievalResponse
+
+
+@dataclass(frozen=True)
+class RetrievalBundleResult:
+    """Holds both the emitted bundle and the original ranked candidates.
+
+    Keeping ranked_candidates separate from bundle.included preserves the
+    contract boundary between "what matched" and "what was selected for
+    human-facing output."
+    """
+
+    bundle: ContextBundle
+    ranked_candidates: list[dict[str, Any]] = field(default_factory=list)
+
+
+def emit_retrieval_bundle(
+    response: RetrievalResponse,
+    selected_ids: list[str],
+    excluded: list[ExcludedItem] | None = None,
+    scope: BundleScope | None = None,
+) -> RetrievalBundleResult:
+    """Wrap retrieval results in an inspectable ContextBundle.
+
+    ``selected_ids`` names the hits chosen for human-facing output.
+    All ranked hits are preserved in ``ranked_candidates`` so callers
+    can inspect what was not selected without looking inside the bundle.
+
+    ``may_write`` is always False — retrieval output does not authorize
+    writeback without an explicit downstream governed action.
+    """
+    selected_set = set(selected_ids)
+
+    ranked_candidates: list[dict[str, Any]] = [
+        {
+            "artifact_id": hit.object_id,
+            "doc_id": hit.doc_id,
+            "score": hit.score,
+            "source_ref": hit.source_ref,
+        }
+        for hit in response.hits
+    ]
+
+    included: list[IncludedItem] = []
+    for hit in response.hits:
+        if hit.object_id not in selected_set:
+            continue
+        included.append(
+            IncludedItem(
+                artifact_id=hit.object_id,
+                path=hit.source_ref,
+                reason="selected from ranked retrieval results",
+                retrieval_score=hit.score,
+                provenance=ItemProvenance(origin="retrieval"),
+            )
+        )
+
+    bundle = ContextBundle(
+        id=str(uuid.uuid4()),
+        created_at=datetime.now(tz=timezone.utc),
+        trigger=BundleTrigger(
+            type="retrieval",
+            source=response.trace_id,
+        ),
+        intended_use=["answer"],
+        scope=scope or BundleScope(),
+        included=included,
+        excluded=excluded or [],
+        authority=AuthorityFlags(
+            may_answer=True,
+            may_orient=False,
+            may_resurface=False,
+            may_propose=False,
+            may_write=False,
+        ),
+        expiry=ExpiryPosture(),
+    )
+
+    return RetrievalBundleResult(bundle=bundle, ranked_candidates=ranked_candidates)

--- a/tests/retrieval/test_context_bundle_emission.py
+++ b/tests/retrieval/test_context_bundle_emission.py
@@ -1,8 +1,6 @@
 """Tests for retrieval-side context bundle emission (CONTEXT-BUNDLES-02, #896)."""
 from __future__ import annotations
 
-import pytest
-
 from app.context_bundles.schema import ContextBundle, ExcludedItem
 from app.retrieval.capability import RetrievalHit, RetrievalResponse
 from app.retrieval.bundle_emission import emit_retrieval_bundle, RetrievalBundleResult

--- a/tests/retrieval/test_context_bundle_emission.py
+++ b/tests/retrieval/test_context_bundle_emission.py
@@ -1,0 +1,73 @@
+"""Tests for retrieval-side context bundle emission (CONTEXT-BUNDLES-02, #896)."""
+from __future__ import annotations
+
+import pytest
+
+from app.context_bundles.schema import ContextBundle, ExcludedItem
+from app.retrieval.capability import RetrievalHit, RetrievalResponse
+from app.retrieval.bundle_emission import emit_retrieval_bundle, RetrievalBundleResult
+
+
+def _make_response(hit_ids: list[str], scores: list[float] | None = None) -> RetrievalResponse:
+    if scores is None:
+        scores = [1.0 - i * 0.1 for i in range(len(hit_ids))]
+    hits = [
+        RetrievalHit(
+            object_id=hid,
+            doc_id=hid,
+            text=f"text for {hid}",
+            score=s,
+            snippet=None,
+            source_ref=None,
+            payload={},
+        )
+        for hid, s in zip(hit_ids, scores)
+    ]
+    return RetrievalResponse(query="test query", hits=hits, trace_id="trace-1")
+
+
+def test_retrieval_emits_context_bundle():
+    response = _make_response(["doc-a", "doc-b", "doc-c"])
+    result = emit_retrieval_bundle(response, selected_ids=["doc-a", "doc-b"])
+    assert isinstance(result, RetrievalBundleResult)
+    assert isinstance(result.bundle, ContextBundle)
+    assert result.bundle.id
+    assert result.bundle.created_at is not None
+
+
+def test_retrieval_distinguishes_candidates_from_selected_context():
+    response = _make_response(["doc-a", "doc-b", "doc-c"])
+    result = emit_retrieval_bundle(response, selected_ids=["doc-a"])
+    included_ids = {item.artifact_id for item in result.bundle.included}
+    assert included_ids == {"doc-a"}, "only selected item should be in bundle.included"
+    candidate_ids = {c["artifact_id"] for c in result.ranked_candidates}
+    assert {"doc-a", "doc-b", "doc-c"} == candidate_ids, (
+        "all ranked candidates must be preserved separately, not collapsed into included"
+    )
+
+
+def test_retrieval_context_bundle_records_interpretation_affecting_exclusions():
+    response = _make_response(["doc-a", "doc-b", "doc-c"])
+    exclusions = [
+        ExcludedItem(
+            artifact_id="doc-b",
+            reason="trust_state=unverified; omission changes answer scope",
+        )
+    ]
+    result = emit_retrieval_bundle(
+        response,
+        selected_ids=["doc-a"],
+        excluded=exclusions,
+    )
+    excluded_ids = {item.artifact_id for item in result.bundle.excluded}
+    assert "doc-b" in excluded_ids
+    doc_b_exclusion = next(e for e in result.bundle.excluded if e.artifact_id == "doc-b")
+    assert doc_b_exclusion.reason, "exclusion must carry reason so omission is auditable"
+
+
+def test_retrieval_context_bundle_does_not_authorize_writeback():
+    response = _make_response(["doc-a", "doc-b"])
+    result = emit_retrieval_bundle(response, selected_ids=["doc-a", "doc-b"])
+    assert result.bundle.authority.may_write is False, (
+        "retrieval bundles must never authorize writeback without explicit downstream upgrade"
+    )


### PR DESCRIPTION
## Summary

Implements CONTEXT-BUNDLES-02, closing #896.

- Adds `app/retrieval/bundle_emission.py` with `emit_retrieval_bundle()` and `RetrievalBundleResult`
- 4 new tests in `tests/retrieval/test_context_bundle_emission.py` — all 4 ACs green
- Ranked candidates are kept in `RetrievalBundleResult.ranked_candidates` (separate from `bundle.included`) so the contract boundary between "what matched" and "what was selected for human-facing output" is explicit without expanding the ContextBundle schema
- `authority.may_write` is always `False` from retrieval; no downstream writeback authorization unless explicitly upgraded

**Depends on #895 / [PR #931](https://github.com/RasmusTho/agentic-pkm-mvp/pull/931) — base branch is `feat/895-context-bundle-schema`; retarget to `main` after that merges.**

Dispatcher unavailable (ModuleNotFoundError: yaml) — used GitHub-label-only claim.

## Acceptance Criteria

- [x] Retrieval emission produces a context bundle in addition to ranked results
  `Verify: tests/retrieval/test_context_bundle_emission.py::test_retrieval_emits_context_bundle` ✅
- [x] Emission contract distinguishes ranked candidates from selected included items
  `Verify: tests/retrieval/test_context_bundle_emission.py::test_retrieval_distinguishes_candidates_from_selected_context` ✅
- [x] Interpretation-affecting exclusions are preserved in the bundle
  `Verify: tests/retrieval/test_context_bundle_emission.py::test_retrieval_context_bundle_records_interpretation_affecting_exclusions` ✅
- [x] `may_write` is false unless explicitly upgraded downstream
  `Verify: tests/retrieval/test_context_bundle_emission.py::test_retrieval_context_bundle_does_not_authorize_writeback` ✅

## Validation

```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/retrieval/ -m "not pg"
# 36 passed
```

Fixes #896

🤖 Generated with [Claude Code](https://claude.ai/claude-code)