### PR TITLE
docs: owner-doc promotion for #895 — STATUS.md CONTEXT-BUNDLES-01 delivery

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -258,3 +258,10 @@ those issues are delivered and validated. Agent Memory remains local spec-only u
 searches find or create active implementation issues. The bridge-map reference to the agent-memory
 contract was corrected from a local stale "future" reference to the active
 `docs/CONCEPTS/AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT.md` contract.
+
+Update (2026-05-14): `CONTEXT-BUNDLES-01` (#895) delivered by PR #931. Adds the minimal
+`ContextBundle` pydantic schema (`app/context_bundles/schema.py`) covering identity, trigger,
+intended use, scope, included/excluded items with per-item provenance and trust posture, distinct
+authority flags, stale/expiry posture, and receipt linkage. No runtime behavior changed; the schema
+is a typed contract surface only. The broader context-bundle capability (#894) and remaining child
+slices (#896 and later) remain future work.


### PR DESCRIPTION
- [x] Docs authoring lane

## Summary

Records delivery of `CONTEXT-BUNDLES-01` (#895) in `docs/STATUS.md`. The existing update at line 254–258 stated "implementation remains future work until those issues are delivered" — #895 is now closed and merged via PR #931. Adds a dated update line that notes the schema was delivered, no runtime behavior changed, and the broader capability (#894) plus remaining slices remain future work.

Triggered by post-merge owner-doc check on #895.

## Changes

- `docs/STATUS.md` — one dated update paragraph added after the 2026-05-13 context-bundles backlog note.

## Validation

Docs-only change, no tests required. Content checked against `docs/CONTEXT_BUNDLES/README.md` and the closed issue #895.

---