### PR TITLE
feat: add PKM_ENVIRONMENT=test as valid runtime environment value

### DIFF
--- a/app/config/database.py
+++ b/app/config/database.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from urllib.parse import quote
 
-from app.config.environment import ENV_DEV, ENV_PROD, active_environment
+from app.config.environment import ENV_DEV, ENV_PROD, ENV_TEST, active_environment
 
 
 def _clean(env: Mapping[str, str], key: str) -> str:
@@ -13,6 +13,8 @@ def _clean(env: Mapping[str, str], key: str) -> str:
 def default_database_name(env_name: str) -> str:
     if env_name == ENV_DEV:
         return "app_dev"
+    if env_name == ENV_TEST:
+        return "app_test"
     if env_name == ENV_PROD:
         return "app"
     return "app"
@@ -26,6 +28,8 @@ def resolve_runtime_database_url(env: Mapping[str, str]) -> str:
     env_name = active_environment(env)
     if env_name == ENV_DEV:
         db_name = _clean(env, "PKM_DB_NAME_DEV") or default_database_name(env_name)
+    elif env_name == ENV_TEST:
+        db_name = _clean(env, "PKM_DB_NAME_TEST") or default_database_name(env_name)
     else:
         db_name = _clean(env, "PKM_DB_NAME_PROD") or default_database_name(env_name)
 

--- a/app/config/environment.py
+++ b/app/config/environment.py
@@ -1,10 +1,10 @@
 """Runtime environment selection and resolution.
 
-This module provides explicit first-class environment selection for `dev` and `prod`,
+This module provides explicit first-class environment selection for `dev`, `prod`, and `test`,
 mapping existing partial controls such as PKM_SETTINGS_PROFILE into the environment model.
 
 Environment selection hierarchy:
-1. Explicit PKM_ENVIRONMENT env var (if set to 'dev' or 'prod')
+1. Explicit PKM_ENVIRONMENT env var (if set to 'dev', 'prod', or 'test')
 2. Implicit from PKM_SETTINGS_PROFILE (lab → dev, operator → prod)
 3. Default to prod
 
@@ -23,6 +23,7 @@ from typing import Literal
 # Environment values
 ENV_DEV = "dev"
 ENV_PROD = "prod"
+ENV_TEST = "test"
 
 # Environment variable for explicit selection
 ENVIRONMENT_ENV = "PKM_ENVIRONMENT"
@@ -33,11 +34,11 @@ OPERATOR_PROFILE = "operator"
 LAB_PROFILE = "lab"
 
 
-def active_environment(env: Mapping[str, str] | None = None) -> Literal["dev", "prod"]:
+def active_environment(env: Mapping[str, str] | None = None) -> Literal["dev", "prod", "test"]:
     """Resolve the active runtime environment.
 
     Priority:
-    1. Explicit PKM_ENVIRONMENT (if set to 'dev' or 'prod')
+    1. Explicit PKM_ENVIRONMENT (if set to 'dev', 'prod', or 'test')
     2. Implicit from PKM_SETTINGS_PROFILE ('lab' → dev, 'operator' → prod)
     3. Default to 'prod'
 
@@ -45,7 +46,7 @@ def active_environment(env: Mapping[str, str] | None = None) -> Literal["dev", "
         env: Optional environment mapping (defaults to os.environ)
 
     Returns:
-        Either 'dev' or 'prod'
+        'dev', 'prod', or 'test'
 
     Raises:
         ValueError: If PKM_ENVIRONMENT has an invalid value
@@ -59,8 +60,10 @@ def active_environment(env: Mapping[str, str] | None = None) -> Literal["dev", "
             return ENV_DEV
         if explicit == ENV_PROD:
             return ENV_PROD
+        if explicit == ENV_TEST:
+            return ENV_TEST
         raise ValueError(
-            f"Invalid {ENVIRONMENT_ENV}={explicit}; must be 'dev' or 'prod'"
+            f"Invalid {ENVIRONMENT_ENV}={explicit}; must be 'dev', 'prod', or 'test'"
         )
 
     # Fall back to settings profile-based inference
@@ -80,9 +83,15 @@ def is_prod_environment(env: Mapping[str, str] | None = None) -> bool:
     return active_environment(env) == ENV_PROD
 
 
+def is_test_environment(env: Mapping[str, str] | None = None) -> bool:
+    """Check if the active environment is 'test'."""
+    return active_environment(env) == ENV_TEST
+
+
 __all__ = [
     "ENV_DEV",
     "ENV_PROD",
+    "ENV_TEST",
     "ENVIRONMENT_ENV",
     "PROFILE_ENV",
     "OPERATOR_PROFILE",
@@ -90,4 +99,5 @@ __all__ = [
     "active_environment",
     "is_dev_environment",
     "is_prod_environment",
+    "is_test_environment",
 ]

--- a/app/config/paths.py
+++ b/app/config/paths.py
@@ -33,7 +33,7 @@ def resolve_vault_root(cli_override: Path | None = None, *, environment: Literal
 
     Args:
         cli_override: Explicit override (takes precedence)
-        environment: If 'dev', appends '-dev' suffix; if 'prod' or None, uses base path
+        environment: If 'dev' or 'test', appends matching suffix; if 'prod' or None, uses base path
 
     Returns:
         Vault root path, environment-scoped if requested
@@ -42,7 +42,12 @@ def resolve_vault_root(cli_override: Path | None = None, *, environment: Literal
         return Path(cli_override)
 
     env_root = _clean_path(os.getenv("VAULT_ROOT"))
-    env_specific = _clean_path(os.getenv("VAULT_ROOT_DEV") if environment == "dev" else None)
+    if environment == "dev":
+        env_specific = _clean_path(os.getenv("VAULT_ROOT_DEV"))
+    elif environment == "test":
+        env_specific = _clean_path(os.getenv("VAULT_ROOT_TEST"))
+    else:
+        env_specific = None
 
     if env_specific is not None:
         return env_specific
@@ -52,9 +57,10 @@ def resolve_vault_root(cli_override: Path | None = None, *, environment: Literal
     else:
         base = _DEFAULT_VAULT
 
-    # If dev environment and no explicit env-specific path, append -dev suffix
     if environment == "dev":
         return base.parent / f"{base.name}-dev"
+    if environment == "test":
+        return base.parent / f"{base.name}-test"
 
     return base
 
@@ -124,27 +130,26 @@ def resolve_runtime_artifact_path(
     """Resolve a runtime artifact path, optionally scoped to environment.
 
     For dev environment, artifacts go into 'tmp-dev/' subdirectories.
+    For test environment, artifacts go into 'tmp-test/' subdirectories.
     For prod or unspecified, uses the base path.
 
     Args:
         artifact_path: Base artifact path (e.g., Path('tmp/index-outbox.jsonl'))
-        environment: If 'dev', paths resolve to environment-scoped location
+        environment: If 'dev' or 'test', paths resolve to environment-scoped location
 
     Returns:
         Environment-scoped artifact path
     """
     base = Path(artifact_path)
 
-    if environment == "dev":
-        # For dev, redirect to -dev suffixed directories
+    if environment in ("dev", "test"):
+        suffix = environment
         parent = base.parent
         name = base.name
-        # Replace 'tmp' with 'tmp-dev', or append '-dev' to parent dir name
         if parent == Path("tmp"):
-            return Path("tmp-dev") / name
-        # For nested paths, append -dev to the immediate parent if it exists
-        dev_parent_name = f"{parent.name}-dev" if parent.name else "tmp-dev"
-        return parent.parent / dev_parent_name / name if parent.parent != Path(".") else Path(dev_parent_name) / name
+            return Path(f"tmp-{suffix}") / name
+        suffixed_parent_name = f"{parent.name}-{suffix}" if parent.name else f"tmp-{suffix}"
+        return parent.parent / suffixed_parent_name / name if parent.parent != Path(".") else Path(suffixed_parent_name) / name
 
     return base
 

--- a/app/config/paths.py
+++ b/app/config/paths.py
@@ -13,7 +13,7 @@ class ResolvedPaths:
     vault_root: Path
     yggdrasil_root: Optional[Path]
     system_settings_path: Optional[Path]
-    environment: Literal["dev", "prod"] = "prod"
+    environment: Literal["dev", "prod", "test"] = "prod"
 
 
 _DEFAULT_VAULT = Path("vault")
@@ -28,7 +28,7 @@ def _clean_path(value: str | Path | None) -> Optional[Path]:
     return Path(value) if value else None
 
 
-def resolve_vault_root(cli_override: Path | None = None, *, environment: Literal["dev", "prod"] | None = None) -> Path:
+def resolve_vault_root(cli_override: Path | None = None, *, environment: Literal["dev", "prod", "test"] | None = None) -> Path:
     """Resolve vault root path, optionally scoped to environment.
 
     Args:
@@ -119,7 +119,7 @@ def resolve_flow_settings_path(path: Path | None = None, vault_root: Path | None
 def resolve_runtime_artifact_path(
     artifact_path: Path | str,
     *,
-    environment: Literal["dev", "prod"] | None = None,
+    environment: Literal["dev", "prod", "test"] | None = None,
 ) -> Path:
     """Resolve a runtime artifact path, optionally scoped to environment.
 
@@ -154,7 +154,7 @@ def resolve_paths(
     vault_root: Path | None = None,
     settings_path: Path | None = None,
     yggdrasil_root: Path | None = None,
-    environment: Literal["dev", "prod"] | None = None,
+    environment: Literal["dev", "prod", "test"] | None = None,
 ) -> ResolvedPaths:
     env = environment or active_environment()
     vault = resolve_vault_root(vault_root, environment=env)

--- a/app/settings/models.py
+++ b/app/settings/models.py
@@ -264,7 +264,7 @@ class InstanceSettings(BaseModel):
         default="master",
         description="Instance role; 'master' is canonical, 'satellite' runs a partial view.",
     )
-    environment: Literal["dev", "prod"] = Field(
+    environment: Literal["dev", "prod", "test"] = Field(
         default="prod",
         description="Runtime environment; 'prod' is production-safe default, 'dev' enables development features.",
     )

--- a/app/settings/watcher_settings.py
+++ b/app/settings/watcher_settings.py
@@ -54,7 +54,7 @@ def _read_frontmatter(path: Path) -> dict[str, Any]:
 
 
 def _resolve_path_setting(
-    candidate: Any, env_key: str, default: Path, *, environment: Literal["dev", "prod"] | None = None
+    candidate: Any, env_key: str, default: Path, *, environment: Literal["dev", "prod", "test"] | None = None
 ) -> Path:
     """Resolve a path setting with optional environment scoping.
 
@@ -109,7 +109,7 @@ class AutoExecResolution:
     raw_value: str | None
 
 
-def load_watcher_settings(vault_root: Path | None = None, *, environment: Literal["dev", "prod"] | None = None) -> WatcherSettings:
+def load_watcher_settings(vault_root: Path | None = None, *, environment: Literal["dev", "prod", "test"] | None = None) -> WatcherSettings:
     """Load watcher settings with optional environment scoping.
 
     Args:

--- a/tests/config/test_database_resolution.py
+++ b/tests/config/test_database_resolution.py
@@ -12,6 +12,17 @@ def test_runtime_database_url_differs_between_dev_and_prod_without_explicit_over
     assert dev != prod
 
 
+def test_runtime_database_url_test_environment_uses_app_test() -> None:
+    """PKM_ENVIRONMENT=test must use the isolated app_test database name."""
+    url = resolve_runtime_database_url({"PKM_ENVIRONMENT": "test"})
+    assert url.endswith("/app_test")
+
+    overridden = resolve_runtime_database_url(
+        {"PKM_ENVIRONMENT": "test", "PKM_DB_NAME_TEST": "custom_test_db"}
+    )
+    assert overridden.endswith("/custom_test_db")
+
+
 def test_explicit_database_url_override_bypasses_environment_convention() -> None:
     explicit = "postgresql+psycopg://custom:pw@localhost:5432/custom_db"
     resolved = resolve_runtime_database_url(

--- a/tests/config/test_environment.py
+++ b/tests/config/test_environment.py
@@ -7,6 +7,7 @@ import pytest
 from app.config.environment import (
     ENV_DEV,
     ENV_PROD,
+    ENV_TEST,
     ENVIRONMENT_ENV,
     LAB_PROFILE,
     OPERATOR_PROFILE,
@@ -14,6 +15,7 @@ from app.config.environment import (
     active_environment,
     is_dev_environment,
     is_prod_environment,
+    is_test_environment,
 )
 
 pytestmark = pytest.mark.not_pg
@@ -176,8 +178,45 @@ class TestDocumentedControlSurface:
         """Constants should be defined for environment values."""
         assert ENV_DEV == "dev"
         assert ENV_PROD == "prod"
+        assert ENV_TEST == "test"
 
     def test_constants_for_all_profile_values(self) -> None:
         """Constants should be defined for profile values."""
         assert OPERATOR_PROFILE == "operator"
         assert LAB_PROFILE == "lab"
+
+
+class TestTestEnvironment:
+    """Test the 'test' environment value added for test compose overlays."""
+
+    def test_explicit_test_environment_accepted(self) -> None:
+        """PKM_ENVIRONMENT=test should be accepted without raising ValueError."""
+        env = {ENVIRONMENT_ENV: "test"}
+        assert active_environment(env) == ENV_TEST
+
+    def test_explicit_test_environment_case_insensitive(self) -> None:
+        """test environment selection should be case-insensitive."""
+        assert active_environment({ENVIRONMENT_ENV: "TEST"}) == ENV_TEST
+        assert active_environment({ENVIRONMENT_ENV: "Test"}) == ENV_TEST
+
+    def test_test_environment_not_dev(self) -> None:
+        """test environment should not register as dev."""
+        env = {ENVIRONMENT_ENV: "test"}
+        assert not is_dev_environment(env)
+
+    def test_test_environment_not_prod(self) -> None:
+        """test environment should not register as prod."""
+        env = {ENVIRONMENT_ENV: "test"}
+        assert not is_prod_environment(env)
+
+    def test_is_test_environment(self) -> None:
+        """is_test_environment() should return True for PKM_ENVIRONMENT=test."""
+        assert is_test_environment({ENVIRONMENT_ENV: "test"})
+        assert not is_test_environment({ENVIRONMENT_ENV: "dev"})
+        assert not is_test_environment({ENVIRONMENT_ENV: "prod"})
+        assert not is_test_environment({})
+
+    def test_invalid_env_still_raises(self) -> None:
+        """Non-'test' invalid values should still raise ValueError."""
+        with pytest.raises(ValueError):
+            active_environment({ENVIRONMENT_ENV: "staging"})

--- a/tests/settings/test_paths_resolver.py
+++ b/tests/settings/test_paths_resolver.py
@@ -8,6 +8,7 @@ from app.config.paths import (
     ResolvedPaths,
     resolve_flow_settings_path,
     resolve_paths,
+    resolve_runtime_artifact_path,
     resolve_system_settings_path,
     resolve_vault_root,
 )
@@ -19,6 +20,22 @@ def test_resolve_vault_root_prefers_cli(monkeypatch: pytest.MonkeyPatch, tmp_pat
     cli_root = tmp_path / "cli_vault"
     result = resolve_vault_root(cli_override=cli_root)
     assert result == cli_root
+
+
+def test_resolve_vault_root_test_environment_appends_test_suffix(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("VAULT_ROOT", raising=False)
+    monkeypatch.delenv("VAULT_ROOT_TEST", raising=False)
+    assert resolve_vault_root(environment="test") == Path("vault-test")
+
+
+def test_resolve_vault_root_test_environment_honours_explicit_override(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    test_root = tmp_path / "custom_test_vault"
+    monkeypatch.setenv("VAULT_ROOT_TEST", str(test_root))
+    assert resolve_vault_root(environment="test") == test_root
+
+
+def test_resolve_runtime_artifact_path_scopes_test_environment() -> None:
+    assert resolve_runtime_artifact_path(Path("tmp/index-outbox.jsonl"), environment="test") == Path("tmp-test/index-outbox.jsonl")
 
 
 def test_system_settings_explicit_beats_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Adds `ENV_TEST = "test"` constant to `app/config/environment.py`
- `active_environment()` now accepts `"test"` without raising `ValueError`; return type broadened to `Literal["dev", "prod", "test"]`
- Adds `is_test_environment()` helper
- Updates all `Literal["dev", "prod"]` annotations in `app/config/paths.py`, `app/settings/models.py`, `app/settings/watcher_settings.py`
- `test` environment self-identifies and is neither dev nor prod for feature-flag purposes

## Test plan

- [x] `tests/config/test_environment.py` — 6 new test cases added for `test` environment; 28 total pass
- [x] Full environment-related test suite: 64 tests pass

## Notes

Dispatcher unavailable — used GitHub-label-only claim.

Closes #848

🤖 Generated with [Claude Code](https://claude.com/claude-code)