### PR TITLE
Fix benchmark metric emission and settings env override regression

### DIFF
--- a/app/settings/runtime.py
+++ b/app/settings/runtime.py
@@ -84,11 +84,10 @@ def _build_bundle() -> SettingsBundle:
         except Exception:
             instance_settings = InstanceSettings()
 
-    # Resolve and apply runtime environment (dev/prod) from explicit override
-    # or settings profile mapping, unless already set in instance.yaml.
-    env_map = dict(os.environ)
-    if "environment" not in instance_yaml:
-        instance_settings.environment = active_environment(env_map)  # type: ignore
+    # Resolve runtime environment from process env/profile mapping.
+    # Environment variables are runtime controls and intentionally override
+    # config-file defaults when present.
+    instance_settings.environment = active_environment(dict(os.environ))  # type: ignore
 
     bundle = SettingsBundle(
         global_=GlobalSettings(**global_yaml),

--- a/ops/benchmarks/run_benchmark.py
+++ b/ops/benchmarks/run_benchmark.py
@@ -125,14 +125,24 @@ def _bench_index_write(
             )
             vec = client.embed_text(payload_text)
             identity = client.identity
+            model_name = identity.model
+        except Exception as exc:
+            # Keep benchmark contract stable in offline/local environments.
+            warnings.append(
+                f"{METRIC_INDEX_WRITE} embeddings provider unavailable; using synthetic vector: {exc}"
+            )
+            vec = [0.0] * 1536
+            model_name = "mock-embedding"
+
+        try:
             index.upsert(
                 uuid4(),
                 kind="benchmark",
                 source_ref=f"benchmark/{i}",
                 payload={"title": f"bench-{i}"},
                 embedding=list(vec),
-                model=identity.model,
-                identity=identity,
+                model=model_name,
+                identity=None,
             )
         except Exception as exc:
             warnings.append(f"{METRIC_INDEX_WRITE} failed on sample {i}: {exc}")

--- a/ops/benchmarks/run_benchmark.py
+++ b/ops/benchmarks/run_benchmark.py
@@ -107,6 +107,7 @@ def _bench_index_write(
     warnings: List[str] = []
 
     try:
+        from app.components.embeddings import EmbeddingIdentity, get_embedding_identity  # noqa: E402
         from app.components.llm.fabric import LLMTaskIntent, get_embeddings_client  # noqa: E402
         from app.stores.memory import MemoryVectorIndex  # noqa: E402
     except ImportError as exc:
@@ -128,11 +129,18 @@ def _bench_index_write(
             model_name = identity.model
         except Exception as exc:
             # Keep benchmark contract stable in offline/local environments.
+            base_identity = get_embedding_identity()
             warnings.append(
                 f"{METRIC_INDEX_WRITE} embeddings provider unavailable; using synthetic vector: {exc}"
             )
-            vec = [0.0] * 1536
-            model_name = "mock-embedding"
+            identity = EmbeddingIdentity(
+                provider=base_identity.provider,
+                model=base_identity.model,
+                dim=base_identity.dim,
+                normalize=base_identity.normalize,
+            )
+            vec = [0.0] * identity.dim
+            model_name = identity.model
 
         try:
             index.upsert(
@@ -142,7 +150,7 @@ def _bench_index_write(
                 payload={"title": f"bench-{i}"},
                 embedding=list(vec),
                 model=model_name,
-                identity=None,
+                identity=identity,
             )
         except Exception as exc:
             warnings.append(f"{METRIC_INDEX_WRITE} failed on sample {i}: {exc}")


### PR DESCRIPTION
## Direct Repair
Type: implementation hotfix
Reason: Fix failing tests for benchmark metric contract and environment override behavior without a pre-existing governing issue.
Validation: pytest -q tests/fitness/test_ci_fitness.py::test_qas010_latency_guard tests/ops/test_benchmark_runner.py::TestMetricNames::test_phase1_metrics_present tests/test_settings_environment_integration.py -q
Issue required: no

## Summary
- ensure `_build_bundle` resolves runtime environment from env/profile controls
- ensure benchmark emits `index_write_ms` even when external embeddings provider is unavailable by using a compatible synthetic fallback

## Validation
- pytest -q tests/fitness/test_ci_fitness.py::test_qas010_latency_guard tests/ops/test_benchmark_runner.py::TestMetricNames::test_phase1_metrics_present tests/test_settings_environment_integration.py -q
