### PR TITLE
feat: clarify v6.0 seams baseline in startup script and health surfaces

### DIFF
--- a/app/api/app.py
+++ b/app/api/app.py
@@ -122,7 +122,8 @@ def _log_v6_seam_status() -> None:
     orientation = _seam("app.api.routes.orientation")
     resurfacing = _seam("app.resurfacing")
     commitments = _seam("app.domain.commitments")
-    canvas = "enabled" if _truthy_env("CANVAS_ENABLED") else "disabled"
+    canvas_importable = _seam("app.api.routes.canvas") == "enabled"
+    canvas = "enabled" if (_truthy_env("CANVAS_ENABLED") and canvas_importable) else "disabled"
     logger.info(
         "v6.0 seams: orientation=%s, resurfacing=%s, commitments=%s, canvas=%s",
         orientation,

--- a/app/api/app.py
+++ b/app/api/app.py
@@ -110,9 +110,32 @@ async def _run_index_preflight() -> None:
     )
 
 
+def _log_v6_seam_status() -> None:
+    def _seam(module: str) -> str:
+        try:
+            import importlib
+            importlib.import_module(module)
+            return "enabled"
+        except Exception:
+            return "disabled"
+
+    orientation = _seam("app.api.routes.orientation")
+    resurfacing = _seam("app.resurfacing")
+    commitments = _seam("app.domain.commitments")
+    canvas = "enabled" if _truthy_env("CANVAS_ENABLED") else "disabled"
+    logger.info(
+        "v6.0 seams: orientation=%s, resurfacing=%s, commitments=%s, canvas=%s",
+        orientation,
+        resurfacing,
+        commitments,
+        canvas,
+    )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     await _run_index_preflight()
+    _log_v6_seam_status()
     yield
 
 

--- a/app/cli/health.py
+++ b/app/cli/health.py
@@ -586,12 +586,17 @@ def _check_v6_seams() -> Dict[str, str]:
         except Exception:
             return "disabled"
 
-    canvas_raw = os.getenv("CANVAS_ENABLED", "0").strip().lower()
+    canvas_gate_on = os.getenv("CANVAS_ENABLED", "0").strip().lower() in _TRUE_VALUES
+    canvas_importable = _seam("app.api.routes.canvas") == "enabled"
+    # Canvas is only truly "enabled" when both the gate is on AND the router imports.
+    # If the gate is on but the import fails, surface "disabled" so the misleading
+    # appearance of an active route does not mask the broken-import case.
+    canvas_state = "enabled" if (canvas_gate_on and canvas_importable) else "disabled"
     return {
         "orientation": _seam("app.api.routes.orientation"),
         "resurfacing": _seam("app.resurfacing"),
         "commitments": _seam("app.domain.commitments"),
-        "canvas": "enabled" if canvas_raw in _TRUE_VALUES else "disabled",
+        "canvas": canvas_state,
     }
 
 

--- a/app/cli/health.py
+++ b/app/cli/health.py
@@ -578,6 +578,23 @@ def _suggested_actions(checks: dict[str, dict[str, Any]], runtime: dict[str, dic
     return actions
 
 
+def _check_v6_seams() -> Dict[str, str]:
+    def _seam(module: str) -> str:
+        try:
+            importlib.import_module(module)
+            return "enabled"
+        except Exception:
+            return "disabled"
+
+    canvas_raw = os.getenv("CANVAS_ENABLED", "0").strip().lower()
+    return {
+        "orientation": _seam("app.api.routes.orientation"),
+        "resurfacing": _seam("app.resurfacing"),
+        "commitments": _seam("app.domain.commitments"),
+        "canvas": "enabled" if canvas_raw in _TRUE_VALUES else "disabled",
+    }
+
+
 @span("health.check")
 def run_health(*, trace_id: str | None = None, **kwargs: Any) -> Dict[str, Any]:
     trace_id = with_trace_id(trace_id)
@@ -605,5 +622,5 @@ def run_health(*, trace_id: str | None = None, **kwargs: Any) -> Dict[str, Any]:
     ok = bool(checks_ok and runtime_ok)
     required_ok = bool(_required_checks_ok(checks) and runtime_ok)
     suggested_actions = _suggested_actions(checks, runtime)
-    return {"environment": active_environment(), "ok": ok, "required_ok": required_ok, "checks": checks, "runtime": runtime, "trace_id": trace_id, "suggested_actions": suggested_actions}
+    return {"environment": active_environment(), "ok": ok, "required_ok": required_ok, "checks": checks, "runtime": runtime, "trace_id": trace_id, "suggested_actions": suggested_actions, "v6_0_seams": _check_v6_seams()}
 __all__ = ["run_health"]

--- a/app/observability/status_model.py
+++ b/app/observability/status_model.py
@@ -177,6 +177,7 @@ class SystemStatus(BaseModel):
     watcher_automation: Optional[WatcherAutomationStatus] = None
     instance_provenance: Optional[InstanceProvenanceStatus] = None
     context_dimensions: Optional[ContextDimensionsStatus] = None
+    v6_0_seams: Optional[Dict[str, str]] = None
 
 
 __all__ = [

--- a/app/observability/status_service.py
+++ b/app/observability/status_service.py
@@ -795,6 +795,14 @@ def _status_context_dimensions(outbox_path: Path) -> ContextDimensionsStatus | N
     return None
 
 
+def _get_v6_seams() -> dict | None:
+    try:
+        from app.cli.health import _check_v6_seams  # lazy to avoid circular import
+        return _check_v6_seams()
+    except Exception:
+        return None
+
+
 def get_system_status() -> SystemStatus:
     sot_meta = get_sot_metadata()
     ingestion = get_ingestion_status()
@@ -837,6 +845,7 @@ def get_system_status() -> SystemStatus:
         watcher_automation=_get_watcher_automation_status(),
         instance_provenance=_get_instance_provenance_status(),
         context_dimensions=_status_context_dimensions(Path(INDEX_OUTBOX_PATH)),
+        v6_0_seams=_get_v6_seams(),
     )
 
 

--- a/config/runtime.defaults.env
+++ b/config/runtime.defaults.env
@@ -25,3 +25,5 @@ WATCHER_STOP_FILE=/app/tmp/WATCHER_STOP
 WATCHER_MAX_SCANNED_FILES_PER_TICK=500
 INDEX_OUTBOX_PATH=/app/tmp/index-outbox.jsonl
 API_HEALTHCHECK_URL=http://127.0.0.1:8000/api/status
+# v6.0 canvas seam — deliberately gated until canvas feature is stable enough for default-on
+CANVAS_ENABLED=0

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -259,6 +259,12 @@ searches find or create active implementation issues. The bridge-map reference t
 contract was corrected from a local stale "future" reference to the active
 `docs/CONCEPTS/AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT.md` contract.
 
+Update (2026-05-14): Issue #850 delivered v6.0 seam observability: `config/runtime.defaults.env`
+now explicitly declares `CANVAS_ENABLED=0` (canvas seam deliberately gated until stable);
+startup logs report v6.0 seam readiness at INFO level; `/api/health` and `/api/status` include
+an informational `v6_0_seams` field surfacing `orientation`, `resurfacing`, `commitments`, and
+`canvas` status. This field is informational only and does not affect health pass/fail.
+
 Update (2026-05-14): `CONTEXT-BUNDLES-01` (#895) delivered by PR #931. Adds the minimal
 `ContextBundle` pydantic schema (`app/context_bundles/schema.py`) covering identity, trigger,
 intended use, scope, included/excluded items with per-item provenance and trust posture, distinct

--- a/tests/api/test_health_api.py
+++ b/tests/api/test_health_api.py
@@ -245,6 +245,30 @@ def test_health_requires_task_route_configuration(monkeypatch, tmp_path) -> None
     assert data["checks"]["llm_task_routes"]["routes"]["decide"]["status"] == "fail"
 
 
+def test_health_includes_v6_0_seams_optional(monkeypatch, tmp_path) -> None:
+    client = _health_client(monkeypatch, tmp_path, worker_enabled=False)
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "v6_0_seams" in data
+    seams = data["v6_0_seams"]
+    assert isinstance(seams, dict)
+    for key in ("orientation", "resurfacing", "commitments", "canvas"):
+        assert key in seams
+        assert seams[key] in ("enabled", "disabled")
+
+
+def test_disabled_seam_not_blocking(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("CANVAS_ENABLED", raising=False)
+    client = _health_client(monkeypatch, tmp_path, worker_enabled=False)
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data.get("required_ok") is True
+    seams = data.get("v6_0_seams") or {}
+    assert seams.get("canvas") == "disabled"
+
+
 def test_health_skips_eval_route_by_default(monkeypatch, tmp_path) -> None:
     heartbeat = tmp_path / "watcher-heartbeat.json"
     _write_watcher_heartbeat(heartbeat, ts=time.time())

--- a/tests/api/test_health_api.py
+++ b/tests/api/test_health_api.py
@@ -269,6 +269,26 @@ def test_disabled_seam_not_blocking(monkeypatch, tmp_path) -> None:
     assert seams.get("canvas") == "disabled"
 
 
+def test_canvas_seam_disabled_when_router_import_fails(monkeypatch, tmp_path) -> None:
+    """Gate-on but import-broken canvas must report disabled, not enabled."""
+    import importlib
+
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name: str, *args, **kwargs):
+        if name == "app.api.routes.canvas":
+            raise ImportError("simulated broken canvas import")
+        return real_import_module(name, *args, **kwargs)
+
+    monkeypatch.setenv("CANVAS_ENABLED", "1")
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+    client = _health_client(monkeypatch, tmp_path, worker_enabled=False)
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    seams = resp.json().get("v6_0_seams") or {}
+    assert seams.get("canvas") == "disabled"
+
+
 def test_health_skips_eval_route_by_default(monkeypatch, tmp_path) -> None:
     heartbeat = tmp_path / "watcher-heartbeat.json"
     _write_watcher_heartbeat(heartbeat, ts=time.time())

--- a/tests/api/test_status_api.py
+++ b/tests/api/test_status_api.py
@@ -103,6 +103,19 @@ def test_status_counts_align_with_events(tmp_path: Path, monkeypatch) -> None:
     assert events_log.get("total_lines") == len(events)
 
 
+def test_status_includes_v6_0_seams_optional():
+    client = TestClient(app)
+    resp = client.get("/api/status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "v6_0_seams" in body
+    seams = body["v6_0_seams"]
+    if seams is not None:
+        assert isinstance(seams, dict)
+        for key in ("orientation", "resurfacing", "commitments", "canvas"):
+            assert key in seams
+
+
 def test_status_exposes_panel_provenance():
     """Verify status snapshot exposes panel actions compiler provenance."""
     client = TestClient(app)

--- a/tests/architecture/test_runtime_config.py
+++ b/tests/architecture/test_runtime_config.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_canvas_enabled_default_explicit() -> None:
+    config_path = Path(__file__).resolve().parents[2] / "config" / "runtime.defaults.env"
+    content = config_path.read_text(encoding="utf-8")
+    assert "CANVAS_ENABLED=0" in content


### PR DESCRIPTION
## Summary

- `config/runtime.defaults.env` — adds explicit `CANVAS_ENABLED=0` with inline comment documenting the deliberate gate
- `app/api/app.py` — startup lifespan now logs v6.0 seam readiness at INFO: `v6.0 seams: orientation=…, resurfacing=…, commitments=…, canvas=…`
- `app/cli/health.py` — adds `_check_v6_seams()` and includes informational `v6_0_seams` map in `/api/health` payload (does not affect `ok` / `required_ok`)
- `app/observability/status_model.py` / `status_service.py` — adds optional `v6_0_seams` field to `SystemStatus`, mirroring health
- `docs/STATUS.md` — references the new control surfaces
- Tests added: `test_health_includes_v6_0_seams_optional`, `test_disabled_seam_not_blocking`, `test_status_includes_v6_0_seams_optional`, `tests/architecture/test_runtime_config.py::test_canvas_enabled_default_explicit`

## Test plan

- [x] 4 new acceptance-criteria tests pass
- [x] Full `tests/api/test_health_api.py` + `tests/api/test_status_api.py` + `tests/architecture/test_runtime_config.py` (16 tests) pass

## Notes

`v6_0_seams` is informational only — disabled seams do NOT trigger non-2xx or affect `required_ok`. No functional changes to seam behavior or canvas gating.

Dispatcher unavailable — used GitHub-label-only claim.

Closes #850

🤖 Generated with [Claude Code](https://claude.com/claude-code)