### PR TITLE
feat(context-bundles): consume context bundle from orientation (#946)

### DIFF
--- a/app/orientation/bundle_consumer.py
+++ b/app/orientation/bundle_consumer.py
@@ -1,0 +1,130 @@
+"""Consume a ContextBundle from orientation (CONTEXT-BUNDLES-03).
+
+Orientation reads a bundle to reconstruct situational state. The frame keeps
+facts, inferences, candidate actions, and stale context in distinct buckets,
+preserves per-item provenance and exclusions for human inspection, and refuses
+to launder bundle authority into write authorization.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+from app.context_bundles.schema import (
+    ContextBundle,
+    ExcludedItem,
+    IncludedItem,
+    ItemProvenance,
+)
+
+
+class BundleAuthorityViolation(Exception):
+    """Raised when a bundle attempts to grant write authority to orientation."""
+
+
+class OrientationSegment(BaseModel):
+    artifact_id: str
+    reason: str
+    provenance: Optional[ItemProvenance] = None
+    trust_state: Optional[str] = None
+    review_state: Optional[str] = None
+
+
+class OrientationBundleFrame(BaseModel):
+    bundle_id: str
+    facts: list[OrientationSegment] = Field(default_factory=list)
+    inferences: list[OrientationSegment] = Field(default_factory=list)
+    candidate_actions: list[OrientationSegment] = Field(default_factory=list)
+    exclusions: list[ExcludedItem] = Field(default_factory=list)
+    stale: bool = False
+    stale_reason: Optional[str] = None
+    read_only: bool = True
+    may_write: bool = False
+
+
+_CANDIDATE_ROLES = {"candidate_action", "candidate", "proposal"}
+_INFERENCE_ORIGINS = {"agent inference", "model inference", "orientation inference"}
+
+
+def _classify(item: IncludedItem) -> str:
+    if item.source_role and item.source_role in _CANDIDATE_ROLES:
+        return "candidate"
+    reason = (item.reason or "").lower()
+    if "candidate" in reason or "proposal" in reason or "next action" in reason:
+        return "candidate"
+    origin = (item.provenance.origin if item.provenance else "") or ""
+    if origin.lower() in _INFERENCE_ORIGINS:
+        return "inference"
+    if "inference" in reason or "inferred" in reason:
+        return "inference"
+    return "fact"
+
+
+def _segment(item: IncludedItem) -> OrientationSegment:
+    return OrientationSegment(
+        artifact_id=item.artifact_id,
+        reason=item.reason,
+        provenance=item.provenance,
+        trust_state=item.trust_state,
+        review_state=item.review_state,
+    )
+
+
+def build_orientation_frame_from_bundle(
+    bundle: ContextBundle,
+    *,
+    now: datetime | None = None,
+) -> OrientationBundleFrame:
+    """Project a ContextBundle into an orientation frame.
+
+    Refuses to consume a bundle that claims `may_write=True` — orientation
+    is a non-write surface and must not silently upgrade authority.
+    """
+    if bundle.authority.may_write:
+        raise BundleAuthorityViolation(
+            f"bundle {bundle.id} carries may_write=True; orientation is non-write"
+        )
+
+    facts: list[OrientationSegment] = []
+    inferences: list[OrientationSegment] = []
+    candidates: list[OrientationSegment] = []
+
+    for item in bundle.included:
+        bucket = _classify(item)
+        segment = _segment(item)
+        if bucket == "candidate":
+            candidates.append(segment)
+        elif bucket == "inference":
+            inferences.append(segment)
+        else:
+            facts.append(segment)
+
+    now = now or datetime.now(tz=timezone.utc)
+    stale = False
+    stale_reason: Optional[str] = None
+    if bundle.expiry and bundle.expiry.stale_after is not None:
+        if now >= bundle.expiry.stale_after:
+            stale = True
+            stale_reason = bundle.expiry.reason
+
+    return OrientationBundleFrame(
+        bundle_id=bundle.id,
+        facts=facts,
+        inferences=inferences,
+        candidate_actions=candidates,
+        exclusions=list(bundle.excluded),
+        stale=stale,
+        stale_reason=stale_reason,
+        read_only=True,
+        may_write=False,
+    )
+
+
+__all__ = [
+    "BundleAuthorityViolation",
+    "OrientationBundleFrame",
+    "OrientationSegment",
+    "build_orientation_frame_from_bundle",
+]

--- a/app/orientation/bundle_consumer.py
+++ b/app/orientation/bundle_consumer.py
@@ -79,9 +79,15 @@ def build_orientation_frame_from_bundle(
 ) -> OrientationBundleFrame:
     """Project a ContextBundle into an orientation frame.
 
-    Refuses to consume a bundle that claims `may_write=True` — orientation
-    is a non-write surface and must not silently upgrade authority.
+    Refuses to consume a bundle that lacks `may_orient` authority or claims
+    `may_write=True` — orientation is a non-write surface and must not silently
+    upgrade authority or accept bundles not authorized for orientation use.
     """
+    if not bundle.authority.may_orient:
+        raise BundleAuthorityViolation(
+            f"bundle {bundle.id} does not carry may_orient=True; "
+            "cannot consume for orientation without explicit orientation authority"
+        )
     if bundle.authority.may_write:
         raise BundleAuthorityViolation(
             f"bundle {bundle.id} carries may_write=True; orientation is non-write"

--- a/app/orientation/bundle_consumer.py
+++ b/app/orientation/bundle_consumer.py
@@ -92,6 +92,11 @@ def build_orientation_frame_from_bundle(
         raise BundleAuthorityViolation(
             f"bundle {bundle.id} carries may_write=True; orientation is non-write"
         )
+    if "orient" not in bundle.intended_use:
+        raise BundleAuthorityViolation(
+            f"bundle {bundle.id} intended_use={bundle.intended_use!r} does not include 'orient'; "
+            "bundle was not scoped for orientation consumption"
+        )
 
     facts: list[OrientationSegment] = []
     inferences: list[OrientationSegment] = []
@@ -108,6 +113,8 @@ def build_orientation_frame_from_bundle(
             facts.append(segment)
 
     now = now or datetime.now(tz=timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
     stale = False
     stale_reason: Optional[str] = None
     if bundle.expiry and bundle.expiry.stale_after is not None:

--- a/app/orientation/bundle_consumer.py
+++ b/app/orientation/bundle_consumer.py
@@ -111,7 +111,10 @@ def build_orientation_frame_from_bundle(
     stale = False
     stale_reason: Optional[str] = None
     if bundle.expiry and bundle.expiry.stale_after is not None:
-        if now >= bundle.expiry.stale_after:
+        stale_after = bundle.expiry.stale_after
+        if stale_after.tzinfo is None:
+            stale_after = stale_after.replace(tzinfo=timezone.utc)
+        if now >= stale_after:
             stale = True
             stale_reason = bundle.expiry.reason
 

--- a/docs/CONTEXT_BUNDLES/USE_CONTEXT_BUNDLE_FOR_ORIENTATION.md
+++ b/docs/CONTEXT_BUNDLES/USE_CONTEXT_BUNDLE_FOR_ORIENTATION.md
@@ -1,12 +1,15 @@
 ---
 name: Use Context Bundle for Orientation
-description: Specify how orientation consumes context bundles to rebuild situational context.
+description: How orientation consumes context bundles to rebuild situational context.
 task_id: CONTEXT-BUNDLES-03
 source_anchor: docs/CONCEPTS/CONTEXT_BUNDLE_CONTRACT.md :: Relation to retrieval, orientation, and resurfacing
 parent_capability: Context Bundles
 prerequisites: [CONTEXT-BUNDLES-01, CONTEXT-BUNDLES-02]
 depends_on: [DEFINE_CONTEXT_BUNDLE_SCHEMA.md, EMIT_CONTEXT_BUNDLE_FROM_RETRIEVAL.md]
 can_parallelize_with: [USE_CONTEXT_BUNDLE_FOR_RESURFACING]
+status: implemented
+implementation: app/orientation/bundle_consumer.py
+github_issue: "https://github.com/RasmusTho/agentic-pkm-mvp/issues/946"
 ---
 
 # USE_CONTEXT_BUNDLE_FOR_ORIENTATION
@@ -17,23 +20,19 @@ Specify how orientation uses a context bundle to reconstruct situational state a
 without collapsing facts, inferred state, candidate next actions, and stale context into one
 undifferentiated response.
 
-## What This Task Does
+## What This Slice Implements
 
-This task defines the implementation contract for orientation-side bundle consumption. It specifies:
+`app/orientation/bundle_consumer.py` provides `build_orientation_frame_from_bundle`, which:
 
-- how orientation assembles or consumes a bundle,
-- how it distinguishes facts, inferred state, candidate actions, and stale context,
-- and how it preserves bundle provenance for human review.
-
-## Concretely
-
-A later implementation should be able to produce an orientation frame backed by a bundle that
-records:
-
-- selected artifacts and signals used for the frame,
-- exclusions that affected the frame,
-- explicit labels for fact vs inference vs candidate action,
-- and stale or expiry posture when the orientation snapshot may no longer be current.
+- requires `may_orient=True` on the bundle's authority flags and rejects `may_write=True`
+- requires `"orient"` in `bundle.intended_use` — authority flag alone is not sufficient
+- classifies each included item into `facts`, `inferences`, or `candidate_actions` based on
+  `source_role`, `reason` text, and `provenance.origin`
+- preserves per-item provenance and exclusions on the returned `OrientationBundleFrame`
+- checks bundle expiry and surfaces `stale=True` when `stale_after` has passed, normalizing
+  naive datetimes to UTC to prevent `TypeError` on comparison
+- normalizes a caller-provided naive `now` to UTC by the same convention
+- returns `read_only=True, may_write=False` — orientation never upgrades bundle authority
 
 ## Why This Matters
 
@@ -43,20 +42,19 @@ facts or stale signals as current state.
 
 ## Acceptance Criteria
 
-- [ ] Orientation consumption is specified as reading from a context bundle or bundle reference,
-  not from opaque prompt state alone. Verify: `tests/orientation/test_context_bundle_orientation.py::test_orientation_uses_context_bundle`
-- [ ] The orientation contract distinguishes facts, inferred state, candidate next actions, and
-  stale context in the assembled output. Verify: `tests/orientation/test_context_bundle_orientation.py::test_orientation_labels_fact_inference_candidate_and_stale_context`
-- [ ] Orientation preserves source and exclusion provenance strongly enough for a human to inspect
-  why the frame was assembled. Verify: `tests/orientation/test_context_bundle_orientation.py::test_orientation_exposes_bundle_provenance_and_exclusions`
-- [ ] Orientation does not silently upgrade bundle authority into write authorization. Verify: `tests/orientation/test_context_bundle_orientation.py::test_orientation_bundle_remains_non_write_authoritative`
-
-## How to Verify (Pre-Merge)
-
-- Add or update the orientation tests named in the acceptance criteria.
-- Confirm the orientation surface can explain what it used and what it left out.
-- Confirm any orientation "next step" remains a candidate or proposal unless a separate governed
-  action surface takes over.
+- [x] Orientation consumption reads from a context bundle, not from opaque prompt state alone.
+  Verify: `tests/orientation/test_context_bundle_orientation.py::test_orientation_uses_context_bundle`
+- [x] The frame distinguishes facts, inferred state, candidate next actions, and stale context.
+  Verify: `tests/orientation/test_context_bundle_orientation.py::test_orientation_labels_fact_inference_candidate_and_stale_context`
+- [x] Orientation preserves source and exclusion provenance for human inspection.
+  Verify: `tests/orientation/test_context_bundle_orientation.py::test_orientation_exposes_bundle_provenance_and_exclusions`
+- [x] Orientation does not silently upgrade bundle authority into write authorization.
+  Verify: `tests/orientation/test_context_bundle_orientation.py::test_orientation_bundle_remains_non_write_authoritative`
+- [x] Bundles not scoped for orientation (`"orient"` absent from `intended_use`) are rejected.
+  Verify: `tests/orientation/test_context_bundle_orientation.py::test_orientation_rejects_bundle_not_scoped_for_orient`
+- [x] Naive `stale_after` and naive caller-provided `now` are normalized to UTC without raising `TypeError`.
+  Verify: `tests/orientation/test_context_bundle_orientation.py::test_orientation_stale_check_handles_naive_expiry_timestamp`
+  Verify: `tests/orientation/test_context_bundle_orientation.py::test_orientation_normalizes_naive_caller_now`
 
 ## Out of Scope
 
@@ -64,6 +62,7 @@ facts or stale signals as current state.
 - Resurfacing-specific surfacing decisions.
 - Durable memory promotion from orientation outputs.
 - Write proposal execution.
+- API route wiring (production route integration is a follow-up slice).
 
 ## Related Docs
 
@@ -73,5 +72,6 @@ facts or stale signals as current state.
 
 ## Related GitHub Issues
 
-Not created in this PR. When filed later, use this task spec as the child implementation issue
-contract for orientation-side bundle usage.
+- Implementation issue: [#946](https://github.com/RasmusTho/agentic-pkm-mvp/issues/946)
+- Pull request: [#950](https://github.com/RasmusTho/agentic-pkm-mvp/pull/950)
+- Parent feature: [#894](https://github.com/RasmusTho/agentic-pkm-mvp/issues/894)

--- a/tests/orientation/test_context_bundle_orientation.py
+++ b/tests/orientation/test_context_bundle_orientation.py
@@ -171,3 +171,61 @@ def test_orientation_bundle_remains_non_write_authoritative():
     )
     with pytest.raises(BundleAuthorityViolation):
         build_orientation_frame_from_bundle(no_orient_bundle, now=_NOW)
+
+
+def test_orientation_rejects_bundle_not_scoped_for_orient():
+    # A bundle may carry may_orient=True but intended_use is part of the
+    # scoping contract — consuming it for orientation when it was scoped only
+    # for answering silently violates that contract.
+    answer_only_bundle = ContextBundle(
+        id="cb_answer_only",
+        created_at=_NOW,
+        trigger=BundleTrigger(type="retrieval"),
+        intended_use=["answer"],
+        scope=BundleScope(),
+        included=[_fact_item()],
+        excluded=[],
+        authority=AuthorityFlags(may_answer=True, may_orient=True),
+        expiry=ExpiryPosture(),
+    )
+    with pytest.raises(BundleAuthorityViolation, match="intended_use"):
+        build_orientation_frame_from_bundle(answer_only_bundle, now=_NOW)
+
+    # Multi-use bundles that include "orient" are accepted.
+    multi_bundle = ContextBundle(
+        id="cb_multi",
+        created_at=_NOW,
+        trigger=BundleTrigger(type="orientation"),
+        intended_use=["answer", "orient"],
+        scope=BundleScope(),
+        included=[_fact_item()],
+        excluded=[],
+        authority=AuthorityFlags(may_answer=True, may_orient=True),
+        expiry=ExpiryPosture(),
+    )
+    frame = build_orientation_frame_from_bundle(multi_bundle, now=_NOW)
+    assert frame.bundle_id == multi_bundle.id
+
+
+def test_orientation_normalizes_naive_caller_now():
+    # If the caller passes a naive `now`, the comparison must not raise TypeError.
+    # Naive now is treated as UTC — matches the same convention as stale_after.
+    naive_now = datetime(2026, 5, 15, 10, 0, 0)  # no tzinfo, 1h after _NOW
+    expiry = ExpiryPosture(
+        stale_after=_NOW + timedelta(hours=2),
+        reason="still fresh relative to naive now",
+    )
+    bundle = _bundle(included=[_fact_item()], expiry=expiry)
+    # Must not raise TypeError from naive vs. aware comparison.
+    frame = build_orientation_frame_from_bundle(bundle, now=naive_now)
+    assert frame.stale is False
+
+    # Naive now past stale_after also resolves correctly.
+    past_naive_now = datetime(2026, 5, 15, 8, 0, 0)  # 1h before _NOW
+    stale_expiry = ExpiryPosture(
+        stale_after=datetime(2026, 5, 15, 7, 30, 0, tzinfo=timezone.utc),
+        reason="stale relative to naive now",
+    )
+    stale_bundle = _bundle(included=[_fact_item()], expiry=stale_expiry)
+    stale_frame = build_orientation_frame_from_bundle(stale_bundle, now=past_naive_now)
+    assert stale_frame.stale is True

--- a/tests/orientation/test_context_bundle_orientation.py
+++ b/tests/orientation/test_context_bundle_orientation.py
@@ -133,6 +133,20 @@ def test_orientation_exposes_bundle_provenance_and_exclusions():
     assert frame.exclusions[0].reason == "trust state below threshold"
 
 
+def test_orientation_stale_check_handles_naive_expiry_timestamp():
+    # ExpiryPosture allows naive datetimes (no tzinfo). Comparison with an
+    # aware `now` must not raise TypeError — naive timestamps are assumed UTC.
+    naive_expiry = ExpiryPosture(
+        stale_after=datetime(2026, 5, 15, 8, 0, 0),  # no tzinfo
+        reason="naive expiry from JSON without offset",
+    )
+    bundle = _bundle(included=[_fact_item()], expiry=naive_expiry)
+    # _NOW is 09:00 UTC, naive stale_after is treated as 08:00 UTC → stale
+    frame = build_orientation_frame_from_bundle(bundle, now=_NOW)
+    assert frame.stale is True
+    assert "naive" in frame.stale_reason
+
+
 def test_orientation_bundle_remains_non_write_authoritative():
     # Building with may_write=False is fine and frame must remain read-only.
     bundle = _bundle(included=[_fact_item()])

--- a/tests/orientation/test_context_bundle_orientation.py
+++ b/tests/orientation/test_context_bundle_orientation.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.context_bundles.schema import (
+    AuthorityFlags,
+    BundleScope,
+    BundleTrigger,
+    ContextBundle,
+    ExcludedItem,
+    ExpiryPosture,
+    IncludedItem,
+    ItemProvenance,
+)
+from app.orientation.bundle_consumer import (
+    BundleAuthorityViolation,
+    OrientationBundleFrame,
+    build_orientation_frame_from_bundle,
+)
+
+
+_NOW = datetime(2026, 5, 15, 9, 0, 0, tzinfo=timezone.utc)
+
+
+def _bundle(
+    *,
+    included: list[IncludedItem] | None = None,
+    excluded: list[ExcludedItem] | None = None,
+    authority: AuthorityFlags | None = None,
+    expiry: ExpiryPosture | None = None,
+) -> ContextBundle:
+    return ContextBundle(
+        id="cb_orient_001",
+        created_at=_NOW,
+        trigger=BundleTrigger(type="orientation"),
+        intended_use=["orient"],
+        scope=BundleScope(),
+        included=included or [],
+        excluded=excluded or [],
+        authority=authority
+        or AuthorityFlags(may_answer=True, may_orient=True),
+        expiry=expiry or ExpiryPosture(),
+    )
+
+
+def _fact_item() -> IncludedItem:
+    return IncludedItem(
+        artifact_id="art_fact",
+        reason="direct evidence",
+        trust_state="reviewed",
+        review_state="confirmed",
+        provenance=ItemProvenance(origin="vault note"),
+    )
+
+
+def _inferred_item() -> IncludedItem:
+    return IncludedItem(
+        artifact_id="art_infer",
+        reason="model inference from related notes",
+        trust_state="unreviewed",
+        provenance=ItemProvenance(origin="agent inference", transformed_by="orientation"),
+    )
+
+
+def _candidate_item() -> IncludedItem:
+    return IncludedItem(
+        artifact_id="art_cand",
+        reason="candidate next action",
+        source_role="candidate_action",
+        provenance=ItemProvenance(origin="agent proposal"),
+    )
+
+
+def test_orientation_uses_context_bundle():
+    bundle = _bundle(included=[_fact_item()])
+
+    frame = build_orientation_frame_from_bundle(bundle, now=_NOW)
+
+    assert isinstance(frame, OrientationBundleFrame)
+    assert frame.bundle_id == bundle.id
+    # The frame must derive its facts from the bundle, not opaque prompt state.
+    assert any(seg.artifact_id == "art_fact" for seg in frame.facts)
+
+
+def test_orientation_labels_fact_inference_candidate_and_stale_context():
+    expiry = ExpiryPosture(
+        stale_after=_NOW - timedelta(hours=1),
+        reason="snapshot expired",
+    )
+    bundle = _bundle(
+        included=[_fact_item(), _inferred_item(), _candidate_item()],
+        expiry=expiry,
+    )
+
+    frame = build_orientation_frame_from_bundle(bundle, now=_NOW)
+
+    fact_ids = {s.artifact_id for s in frame.facts}
+    inference_ids = {s.artifact_id for s in frame.inferences}
+    candidate_ids = {s.artifact_id for s in frame.candidate_actions}
+
+    assert "art_fact" in fact_ids
+    assert "art_infer" in inference_ids
+    assert "art_cand" in candidate_ids
+    # The four buckets are distinct — no leakage between them.
+    assert fact_ids.isdisjoint(inference_ids)
+    assert fact_ids.isdisjoint(candidate_ids)
+    assert inference_ids.isdisjoint(candidate_ids)
+    # Stale context is surfaced explicitly, not silently treated as current.
+    assert frame.stale is True
+    assert frame.stale_reason == "snapshot expired"
+
+
+def test_orientation_exposes_bundle_provenance_and_exclusions():
+    excluded = ExcludedItem(
+        artifact_id="art_excluded",
+        reason="trust state below threshold",
+        trust_state="unreviewed",
+        provenance=ItemProvenance(origin="vault note"),
+    )
+    bundle = _bundle(included=[_fact_item()], excluded=[excluded])
+
+    frame = build_orientation_frame_from_bundle(bundle, now=_NOW)
+
+    # Per-item provenance survives onto the frame so a human can inspect why
+    # the orientation frame was assembled.
+    fact = next(s for s in frame.facts if s.artifact_id == "art_fact")
+    assert fact.provenance is not None
+    assert fact.provenance.origin == "vault note"
+    # Exclusions are visible on the frame, not dropped silently.
+    assert any(ex.artifact_id == "art_excluded" for ex in frame.exclusions)
+    assert frame.exclusions[0].reason == "trust state below threshold"
+
+
+def test_orientation_bundle_remains_non_write_authoritative():
+    # Building with may_write=False is fine and frame must remain read-only.
+    bundle = _bundle(included=[_fact_item()])
+    frame = build_orientation_frame_from_bundle(bundle, now=_NOW)
+    assert frame.read_only is True
+    assert frame.may_write is False
+
+    # Bundles arriving with may_write=True are rejected — orientation must not
+    # silently launder bundle authority into write authorization.
+    write_bundle = _bundle(
+        included=[_fact_item()],
+        authority=AuthorityFlags(may_answer=True, may_orient=True, may_write=True),
+    )
+    with pytest.raises(BundleAuthorityViolation):
+        build_orientation_frame_from_bundle(write_bundle, now=_NOW)

--- a/tests/orientation/test_context_bundle_orientation.py
+++ b/tests/orientation/test_context_bundle_orientation.py
@@ -148,3 +148,12 @@ def test_orientation_bundle_remains_non_write_authoritative():
     )
     with pytest.raises(BundleAuthorityViolation):
         build_orientation_frame_from_bundle(write_bundle, now=_NOW)
+
+    # Bundles without may_orient are rejected — orientation must not silently
+    # upgrade a bundle not authorized for orientation use (e.g. may_answer only).
+    no_orient_bundle = _bundle(
+        included=[_fact_item()],
+        authority=AuthorityFlags(may_answer=True, may_orient=False),
+    )
+    with pytest.raises(BundleAuthorityViolation):
+        build_orientation_frame_from_bundle(no_orient_bundle, now=_NOW)


### PR DESCRIPTION
## Summary

Implements CONTEXT-BUNDLES-03, closing #946.

- Adds `app/orientation/bundle_consumer.py` with `build_orientation_frame_from_bundle()`, `OrientationBundleFrame`, `OrientationSegment`, and `BundleAuthorityViolation`.
- Adds `tests/orientation/test_context_bundle_orientation.py` covering all 4 ACs.
- The orientation projection of a `ContextBundle`:
  - keeps **facts**, **inferences**, and **candidate actions** in distinct buckets, classified from `source_role`, `reason`, and `provenance.origin`;
  - exposes the bundle's **exclusions** and per-item provenance on the frame so a human can inspect *why* the frame was assembled;
  - surfaces **stale** posture explicitly when `now >= bundle.expiry.stale_after`, with the bundle's reason;
  - is **read-only** with `may_write=False`, and **rejects** bundles arriving with `may_write=True` rather than silently laundering write authority.

Dispatcher unavailable on this host — used GitHub-label-only claim.

## Acceptance Criteria

- [x] Orientation consumption is specified as reading from a context bundle or bundle reference, not from opaque prompt state alone.
  `Verify: tests/orientation/test_context_bundle_orientation.py::test_orientation_uses_context_bundle` ✅
- [x] The orientation contract distinguishes facts, inferred state, candidate next actions, and stale context in the assembled output.
  `Verify: tests/orientation/test_context_bundle_orientation.py::test_orientation_labels_fact_inference_candidate_and_stale_context` ✅
- [x] Orientation preserves source and exclusion provenance strongly enough for a human to inspect why the frame was assembled.
  `Verify: tests/orientation/test_context_bundle_orientation.py::test_orientation_exposes_bundle_provenance_and_exclusions` ✅
- [x] Orientation does not silently upgrade bundle authority into write authorization.
  `Verify: tests/orientation/test_context_bundle_orientation.py::test_orientation_bundle_remains_non_write_authoritative` ✅

## Validation

```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/orientation/test_context_bundle_orientation.py -m "not pg"
# 4 passed in 0.29s

PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/orientation/ tests/context_bundles/ -m "not pg"
# 13 passed in 3.75s
```

## Scope discipline

- Pure new surface — does not edit `app/orientation/runtime.py` or any existing orientation API. Wiring orientation routes / runtime to consume bundles is out of scope for this slice and left to a follow-up child if/when needed.
- No retrieval, resurfacing, write-proposal, or receipt behavior touched.
- Single-vault/local-scope only.

Fixes #946

🤖 Generated with [Claude Code](https://claude.ai/claude-code)