### PR TITLE
feat(context-bundles): consume context bundle from resurfacing (#947)

### DIFF
--- a/app/orientation/bundle_consumer.py
+++ b/app/orientation/bundle_consumer.py
@@ -1,0 +1,130 @@
+"""Consume a ContextBundle from orientation (CONTEXT-BUNDLES-03).
+
+Orientation reads a bundle to reconstruct situational state. The frame keeps
+facts, inferences, candidate actions, and stale context in distinct buckets,
+preserves per-item provenance and exclusions for human inspection, and refuses
+to launder bundle authority into write authorization.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+from app.context_bundles.schema import (
+    ContextBundle,
+    ExcludedItem,
+    IncludedItem,
+    ItemProvenance,
+)
+
+
+class BundleAuthorityViolation(Exception):
+    """Raised when a bundle attempts to grant write authority to orientation."""
+
+
+class OrientationSegment(BaseModel):
+    artifact_id: str
+    reason: str
+    provenance: Optional[ItemProvenance] = None
+    trust_state: Optional[str] = None
+    review_state: Optional[str] = None
+
+
+class OrientationBundleFrame(BaseModel):
+    bundle_id: str
+    facts: list[OrientationSegment] = Field(default_factory=list)
+    inferences: list[OrientationSegment] = Field(default_factory=list)
+    candidate_actions: list[OrientationSegment] = Field(default_factory=list)
+    exclusions: list[ExcludedItem] = Field(default_factory=list)
+    stale: bool = False
+    stale_reason: Optional[str] = None
+    read_only: bool = True
+    may_write: bool = False
+
+
+_CANDIDATE_ROLES = {"candidate_action", "candidate", "proposal"}
+_INFERENCE_ORIGINS = {"agent inference", "model inference", "orientation inference"}
+
+
+def _classify(item: IncludedItem) -> str:
+    if item.source_role and item.source_role in _CANDIDATE_ROLES:
+        return "candidate"
+    reason = (item.reason or "").lower()
+    if "candidate" in reason or "proposal" in reason or "next action" in reason:
+        return "candidate"
+    origin = (item.provenance.origin if item.provenance else "") or ""
+    if origin.lower() in _INFERENCE_ORIGINS:
+        return "inference"
+    if "inference" in reason or "inferred" in reason:
+        return "inference"
+    return "fact"
+
+
+def _segment(item: IncludedItem) -> OrientationSegment:
+    return OrientationSegment(
+        artifact_id=item.artifact_id,
+        reason=item.reason,
+        provenance=item.provenance,
+        trust_state=item.trust_state,
+        review_state=item.review_state,
+    )
+
+
+def build_orientation_frame_from_bundle(
+    bundle: ContextBundle,
+    *,
+    now: datetime | None = None,
+) -> OrientationBundleFrame:
+    """Project a ContextBundle into an orientation frame.
+
+    Refuses to consume a bundle that claims `may_write=True` — orientation
+    is a non-write surface and must not silently upgrade authority.
+    """
+    if bundle.authority.may_write:
+        raise BundleAuthorityViolation(
+            f"bundle {bundle.id} carries may_write=True; orientation is non-write"
+        )
+
+    facts: list[OrientationSegment] = []
+    inferences: list[OrientationSegment] = []
+    candidates: list[OrientationSegment] = []
+
+    for item in bundle.included:
+        bucket = _classify(item)
+        segment = _segment(item)
+        if bucket == "candidate":
+            candidates.append(segment)
+        elif bucket == "inference":
+            inferences.append(segment)
+        else:
+            facts.append(segment)
+
+    now = now or datetime.now(tz=timezone.utc)
+    stale = False
+    stale_reason: Optional[str] = None
+    if bundle.expiry and bundle.expiry.stale_after is not None:
+        if now >= bundle.expiry.stale_after:
+            stale = True
+            stale_reason = bundle.expiry.reason
+
+    return OrientationBundleFrame(
+        bundle_id=bundle.id,
+        facts=facts,
+        inferences=inferences,
+        candidate_actions=candidates,
+        exclusions=list(bundle.excluded),
+        stale=stale,
+        stale_reason=stale_reason,
+        read_only=True,
+        may_write=False,
+    )
+
+
+__all__ = [
+    "BundleAuthorityViolation",
+    "OrientationBundleFrame",
+    "OrientationSegment",
+    "build_orientation_frame_from_bundle",
+]

--- a/app/orientation/bundle_consumer.py
+++ b/app/orientation/bundle_consumer.py
@@ -79,9 +79,15 @@ def build_orientation_frame_from_bundle(
 ) -> OrientationBundleFrame:
     """Project a ContextBundle into an orientation frame.
 
-    Refuses to consume a bundle that claims `may_write=True` — orientation
-    is a non-write surface and must not silently upgrade authority.
+    Refuses to consume a bundle that lacks `may_orient` authority or claims
+    `may_write=True` — orientation is a non-write surface and must not silently
+    upgrade authority or accept bundles not authorized for orientation use.
     """
+    if not bundle.authority.may_orient:
+        raise BundleAuthorityViolation(
+            f"bundle {bundle.id} does not carry may_orient=True; "
+            "cannot consume for orientation without explicit orientation authority"
+        )
     if bundle.authority.may_write:
         raise BundleAuthorityViolation(
             f"bundle {bundle.id} carries may_write=True; orientation is non-write"

--- a/app/orientation/bundle_consumer.py
+++ b/app/orientation/bundle_consumer.py
@@ -92,6 +92,11 @@ def build_orientation_frame_from_bundle(
         raise BundleAuthorityViolation(
             f"bundle {bundle.id} carries may_write=True; orientation is non-write"
         )
+    if "orient" not in bundle.intended_use:
+        raise BundleAuthorityViolation(
+            f"bundle {bundle.id} intended_use={bundle.intended_use!r} does not include 'orient'; "
+            "bundle was not scoped for orientation consumption"
+        )
 
     facts: list[OrientationSegment] = []
     inferences: list[OrientationSegment] = []
@@ -108,6 +113,8 @@ def build_orientation_frame_from_bundle(
             facts.append(segment)
 
     now = now or datetime.now(tz=timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
     stale = False
     stale_reason: Optional[str] = None
     if bundle.expiry and bundle.expiry.stale_after is not None:

--- a/app/orientation/bundle_consumer.py
+++ b/app/orientation/bundle_consumer.py
@@ -111,7 +111,10 @@ def build_orientation_frame_from_bundle(
     stale = False
     stale_reason: Optional[str] = None
     if bundle.expiry and bundle.expiry.stale_after is not None:
-        if now >= bundle.expiry.stale_after:
+        stale_after = bundle.expiry.stale_after
+        if stale_after.tzinfo is None:
+            stale_after = stale_after.replace(tzinfo=timezone.utc)
+        if now >= stale_after:
             stale = True
             stale_reason = bundle.expiry.reason
 

--- a/app/resurfacing/bundle_consumer.py
+++ b/app/resurfacing/bundle_consumer.py
@@ -19,6 +19,18 @@ class BundleAuthorityViolation(Exception):
     """Raised when a bundle carries prohibited authority for resurfacing."""
 
 
+class WhyNowSignal(BaseModel):
+    """Provenance-backed rationale for a resurfacing event.
+
+    ``rationale`` is the human-readable explanation; ``signal_name`` anchors it
+    to a specific recorded signal (e.g. "dependency_gap", "watcher_run_24h")
+    so the "why now" is auditable rather than opaque semantic relatedness.
+    """
+
+    rationale: str
+    signal_name: Optional[str] = None
+
+
 class SurfacedItem(BaseModel):
     artifact_id: str
     reason: str
@@ -30,6 +42,7 @@ class SurfacedItem(BaseModel):
 class ResurfacingBundleFrame(BaseModel):
     bundle_id: str
     why_now: str
+    why_now_signal_name: Optional[str] = None
     surfaced_items: list[SurfacedItem] = Field(default_factory=list)
     relatedness_signals: list[SurfacedItem] = Field(default_factory=list)
     priority_signals: list[SurfacedItem] = Field(default_factory=list)
@@ -62,16 +75,27 @@ def _is_priority(item: IncludedItem) -> bool:
 def build_resurfacing_bundle_frame(
     bundle: ContextBundle,
     *,
-    why_now: str,
+    why_now: "str | WhyNowSignal",
     now: datetime | None = None,
 ) -> ResurfacingBundleFrame:
     """Project a ContextBundle into a resurfacing suggestion frame.
 
     Requires ``may_resurface=True`` and rejects ``may_write=True`` — resurfacing
     is a suggestion-only surface that must not upgrade bundle authority.
-    ``why_now`` is the caller-supplied, human-readable rationale anchored to a
-    recorded signal rather than an opaque internal score.
+
+    ``why_now`` must be either a non-empty string rationale or a
+    ``WhyNowSignal`` with a ``signal_name`` that anchors the explanation to a
+    specific recorded signal rather than opaque semantic relatedness.
     """
+    if isinstance(why_now, WhyNowSignal):
+        why_now_rationale = why_now.rationale
+        why_now_signal_name = why_now.signal_name
+    else:
+        if not why_now.strip():
+            raise ValueError("why_now must be a non-empty rationale string")
+        why_now_rationale = why_now
+        why_now_signal_name = None
+
     if not bundle.authority.may_resurface:
         raise BundleAuthorityViolation(
             f"bundle {bundle.id} does not carry may_resurface=True; "
@@ -107,7 +131,8 @@ def build_resurfacing_bundle_frame(
 
     return ResurfacingBundleFrame(
         bundle_id=bundle.id,
-        why_now=why_now,
+        why_now=why_now_rationale,
+        why_now_signal_name=why_now_signal_name,
         surfaced_items=surfaced,
         relatedness_signals=relatedness,
         priority_signals=priority,
@@ -122,5 +147,6 @@ __all__ = [
     "BundleAuthorityViolation",
     "ResurfacingBundleFrame",
     "SurfacedItem",
+    "WhyNowSignal",
     "build_resurfacing_bundle_frame",
 ]

--- a/app/resurfacing/bundle_consumer.py
+++ b/app/resurfacing/bundle_consumer.py
@@ -10,9 +10,14 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
-from app.context_bundles.schema import ContextBundle, IncludedItem, ItemProvenance
+from app.context_bundles.schema import (
+    ContextBundle,
+    ExcludedItem,
+    IncludedItem,
+    ItemProvenance,
+)
 
 
 class BundleAuthorityViolation(Exception):
@@ -25,10 +30,22 @@ class WhyNowSignal(BaseModel):
     ``rationale`` is the human-readable explanation; ``signal_name`` anchors it
     to a specific recorded signal (e.g. "dependency_gap", "watcher_run_24h")
     so the "why now" is auditable rather than opaque semantic relatedness.
+    Both fields must be non-empty after whitespace stripping — blank values
+    leave no auditable anchor.
     """
 
     rationale: str
     signal_name: str
+
+    @field_validator("rationale", "signal_name")
+    @classmethod
+    def _must_be_non_blank(cls, v: str, info) -> str:
+        if not v or not v.strip():
+            raise ValueError(
+                f"{info.field_name} must be a non-empty string — "
+                "blank why-now anchors leave the surfacing decision unauditable"
+            )
+        return v
 
 
 class SurfacedItem(BaseModel):
@@ -46,6 +63,7 @@ class ResurfacingBundleFrame(BaseModel):
     surfaced_items: list[SurfacedItem] = Field(default_factory=list)
     relatedness_signals: list[SurfacedItem] = Field(default_factory=list)
     priority_signals: list[SurfacedItem] = Field(default_factory=list)
+    exclusions: list[ExcludedItem] = Field(default_factory=list)
     stale: bool = False
     stale_reason: Optional[str] = None
     suggestion_only: bool = True
@@ -66,10 +84,10 @@ def _surfaced(item: IncludedItem) -> SurfacedItem:
 
 
 def _is_priority(item: IncludedItem) -> bool:
-    if item.source_role and item.source_role in _PRIORITY_ROLES:
-        return True
-    reason = (item.reason or "").lower()
-    return any(kw in reason for kw in ("priority", "urgent", "unresolved", "high-priority"))
+    # Priority is classified solely by the structured `source_role` field —
+    # substring matching on the free-text `reason` is unreliable (it would
+    # classify "not urgent" or "low priority" as priority).
+    return bool(item.source_role and item.source_role in _PRIORITY_ROLES)
 
 
 def build_resurfacing_bundle_frame(
@@ -142,6 +160,7 @@ def build_resurfacing_bundle_frame(
         surfaced_items=surfaced,
         relatedness_signals=relatedness,
         priority_signals=priority,
+        exclusions=list(bundle.excluded),
         stale=stale,
         stale_reason=stale_reason,
         suggestion_only=True,

--- a/app/resurfacing/bundle_consumer.py
+++ b/app/resurfacing/bundle_consumer.py
@@ -75,7 +75,7 @@ def _is_priority(item: IncludedItem) -> bool:
 def build_resurfacing_bundle_frame(
     bundle: ContextBundle,
     *,
-    why_now: "str | WhyNowSignal",
+    why_now: WhyNowSignal,
     now: datetime | None = None,
 ) -> ResurfacingBundleFrame:
     """Project a ContextBundle into a resurfacing suggestion frame.
@@ -83,18 +83,17 @@ def build_resurfacing_bundle_frame(
     Requires ``may_resurface=True`` and rejects ``may_write=True`` — resurfacing
     is a suggestion-only surface that must not upgrade bundle authority.
 
-    ``why_now`` must be either a non-empty string rationale or a
-    ``WhyNowSignal`` with a ``signal_name`` that anchors the explanation to a
-    specific recorded signal rather than opaque semantic relatedness.
+    ``why_now`` must be a ``WhyNowSignal`` — ``signal_name`` anchors the
+    rationale to a specific recorded signal so the surfacing decision is
+    auditable rather than opaque semantic relatedness.
     """
-    if isinstance(why_now, WhyNowSignal):
-        why_now_rationale = why_now.rationale
-        why_now_signal_name = why_now.signal_name
-    else:
-        if not why_now.strip():
-            raise ValueError("why_now must be a non-empty rationale string")
-        why_now_rationale = why_now
-        why_now_signal_name = None
+    if not isinstance(why_now, WhyNowSignal):
+        raise TypeError(
+            "why_now must be a WhyNowSignal — plain strings are not accepted "
+            "because they leave no provenance anchor for the surfacing decision"
+        )
+    why_now_rationale = why_now.rationale
+    why_now_signal_name = why_now.signal_name
 
     if not bundle.authority.may_resurface:
         raise BundleAuthorityViolation(

--- a/app/resurfacing/bundle_consumer.py
+++ b/app/resurfacing/bundle_consumer.py
@@ -33,6 +33,8 @@ class ResurfacingBundleFrame(BaseModel):
     surfaced_items: list[SurfacedItem] = Field(default_factory=list)
     relatedness_signals: list[SurfacedItem] = Field(default_factory=list)
     priority_signals: list[SurfacedItem] = Field(default_factory=list)
+    stale: bool = False
+    stale_reason: Optional[str] = None
     suggestion_only: bool = True
     may_write: bool = False
 
@@ -80,6 +82,17 @@ def build_resurfacing_bundle_frame(
             f"bundle {bundle.id} carries may_write=True; resurfacing is suggestion-only"
         )
 
+    now = now or datetime.now(tz=timezone.utc)
+    stale = False
+    stale_reason: Optional[str] = None
+    if bundle.expiry and bundle.expiry.stale_after is not None:
+        stale_after = bundle.expiry.stale_after
+        if stale_after.tzinfo is None:
+            stale_after = stale_after.replace(tzinfo=timezone.utc)
+        if now >= stale_after:
+            stale = True
+            stale_reason = bundle.expiry.reason
+
     surfaced: list[SurfacedItem] = []
     relatedness: list[SurfacedItem] = []
     priority: list[SurfacedItem] = []
@@ -98,6 +111,8 @@ def build_resurfacing_bundle_frame(
         surfaced_items=surfaced,
         relatedness_signals=relatedness,
         priority_signals=priority,
+        stale=stale,
+        stale_reason=stale_reason,
         suggestion_only=True,
         may_write=False,
     )

--- a/app/resurfacing/bundle_consumer.py
+++ b/app/resurfacing/bundle_consumer.py
@@ -28,7 +28,7 @@ class WhyNowSignal(BaseModel):
     """
 
     rationale: str
-    signal_name: Optional[str] = None
+    signal_name: str
 
 
 class SurfacedItem(BaseModel):
@@ -42,7 +42,7 @@ class SurfacedItem(BaseModel):
 class ResurfacingBundleFrame(BaseModel):
     bundle_id: str
     why_now: str
-    why_now_signal_name: Optional[str] = None
+    why_now_signal_name: str
     surfaced_items: list[SurfacedItem] = Field(default_factory=list)
     relatedness_signals: list[SurfacedItem] = Field(default_factory=list)
     priority_signals: list[SurfacedItem] = Field(default_factory=list)

--- a/app/resurfacing/bundle_consumer.py
+++ b/app/resurfacing/bundle_consumer.py
@@ -104,8 +104,15 @@ def build_resurfacing_bundle_frame(
         raise BundleAuthorityViolation(
             f"bundle {bundle.id} carries may_write=True; resurfacing is suggestion-only"
         )
+    if "resurface" not in bundle.intended_use:
+        raise BundleAuthorityViolation(
+            f"bundle {bundle.id} intended_use={bundle.intended_use!r} does not include 'resurface'; "
+            "bundle was not scoped for resurfacing consumption"
+        )
 
     now = now or datetime.now(tz=timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
     stale = False
     stale_reason: Optional[str] = None
     if bundle.expiry and bundle.expiry.stale_after is not None:

--- a/app/resurfacing/bundle_consumer.py
+++ b/app/resurfacing/bundle_consumer.py
@@ -1,0 +1,111 @@
+"""Consume a ContextBundle from resurfacing (CONTEXT-BUNDLES-04).
+
+Resurfacing reads a bundle to support "why now" suggestions. The frame keeps
+relatedness signals, priority signals, and why-now provenance distinct so the
+decision is auditable rather than opaque. It must not launder bundle authority
+into write permission — resurfacing is suggestion-only.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+from app.context_bundles.schema import ContextBundle, IncludedItem, ItemProvenance
+
+
+class BundleAuthorityViolation(Exception):
+    """Raised when a bundle carries prohibited authority for resurfacing."""
+
+
+class SurfacedItem(BaseModel):
+    artifact_id: str
+    reason: str
+    provenance: Optional[ItemProvenance] = None
+    source_role: Optional[str] = None
+    trust_state: Optional[str] = None
+
+
+class ResurfacingBundleFrame(BaseModel):
+    bundle_id: str
+    why_now: str
+    surfaced_items: list[SurfacedItem] = Field(default_factory=list)
+    relatedness_signals: list[SurfacedItem] = Field(default_factory=list)
+    priority_signals: list[SurfacedItem] = Field(default_factory=list)
+    suggestion_only: bool = True
+    may_write: bool = False
+
+
+_PRIORITY_ROLES = {"priority_signal", "priority", "urgent", "unresolved"}
+
+
+def _surfaced(item: IncludedItem) -> SurfacedItem:
+    return SurfacedItem(
+        artifact_id=item.artifact_id,
+        reason=item.reason,
+        provenance=item.provenance,
+        source_role=item.source_role,
+        trust_state=item.trust_state,
+    )
+
+
+def _is_priority(item: IncludedItem) -> bool:
+    if item.source_role and item.source_role in _PRIORITY_ROLES:
+        return True
+    reason = (item.reason or "").lower()
+    return any(kw in reason for kw in ("priority", "urgent", "unresolved", "high-priority"))
+
+
+def build_resurfacing_bundle_frame(
+    bundle: ContextBundle,
+    *,
+    why_now: str,
+    now: datetime | None = None,
+) -> ResurfacingBundleFrame:
+    """Project a ContextBundle into a resurfacing suggestion frame.
+
+    Requires ``may_resurface=True`` and rejects ``may_write=True`` — resurfacing
+    is a suggestion-only surface that must not upgrade bundle authority.
+    ``why_now`` is the caller-supplied, human-readable rationale anchored to a
+    recorded signal rather than an opaque internal score.
+    """
+    if not bundle.authority.may_resurface:
+        raise BundleAuthorityViolation(
+            f"bundle {bundle.id} does not carry may_resurface=True; "
+            "cannot consume for resurfacing without explicit resurfacing authority"
+        )
+    if bundle.authority.may_write:
+        raise BundleAuthorityViolation(
+            f"bundle {bundle.id} carries may_write=True; resurfacing is suggestion-only"
+        )
+
+    surfaced: list[SurfacedItem] = []
+    relatedness: list[SurfacedItem] = []
+    priority: list[SurfacedItem] = []
+
+    for item in bundle.included:
+        seg = _surfaced(item)
+        surfaced.append(seg)
+        if _is_priority(item):
+            priority.append(seg)
+        else:
+            relatedness.append(seg)
+
+    return ResurfacingBundleFrame(
+        bundle_id=bundle.id,
+        why_now=why_now,
+        surfaced_items=surfaced,
+        relatedness_signals=relatedness,
+        priority_signals=priority,
+        suggestion_only=True,
+        may_write=False,
+    )
+
+
+__all__ = [
+    "BundleAuthorityViolation",
+    "ResurfacingBundleFrame",
+    "SurfacedItem",
+    "build_resurfacing_bundle_frame",
+]

--- a/docs/CONTEXT_BUNDLES/USE_CONTEXT_BUNDLE_FOR_ORIENTATION.md
+++ b/docs/CONTEXT_BUNDLES/USE_CONTEXT_BUNDLE_FOR_ORIENTATION.md
@@ -1,12 +1,15 @@
 ---
 name: Use Context Bundle for Orientation
-description: Specify how orientation consumes context bundles to rebuild situational context.
+description: How orientation consumes context bundles to rebuild situational context.
 task_id: CONTEXT-BUNDLES-03
 source_anchor: docs/CONCEPTS/CONTEXT_BUNDLE_CONTRACT.md :: Relation to retrieval, orientation, and resurfacing
 parent_capability: Context Bundles
 prerequisites: [CONTEXT-BUNDLES-01, CONTEXT-BUNDLES-02]
 depends_on: [DEFINE_CONTEXT_BUNDLE_SCHEMA.md, EMIT_CONTEXT_BUNDLE_FROM_RETRIEVAL.md]
 can_parallelize_with: [USE_CONTEXT_BUNDLE_FOR_RESURFACING]
+status: implemented
+implementation: app/orientation/bundle_consumer.py
+github_issue: "https://github.com/RasmusTho/agentic-pkm-mvp/issues/946"
 ---
 
 # USE_CONTEXT_BUNDLE_FOR_ORIENTATION
@@ -17,23 +20,19 @@ Specify how orientation uses a context bundle to reconstruct situational state a
 without collapsing facts, inferred state, candidate next actions, and stale context into one
 undifferentiated response.
 
-## What This Task Does
+## What This Slice Implements
 
-This task defines the implementation contract for orientation-side bundle consumption. It specifies:
+`app/orientation/bundle_consumer.py` provides `build_orientation_frame_from_bundle`, which:
 
-- how orientation assembles or consumes a bundle,
-- how it distinguishes facts, inferred state, candidate actions, and stale context,
-- and how it preserves bundle provenance for human review.
-
-## Concretely
-
-A later implementation should be able to produce an orientation frame backed by a bundle that
-records:
-
-- selected artifacts and signals used for the frame,
-- exclusions that affected the frame,
-- explicit labels for fact vs inference vs candidate action,
-- and stale or expiry posture when the orientation snapshot may no longer be current.
+- requires `may_orient=True` on the bundle's authority flags and rejects `may_write=True`
+- requires `"orient"` in `bundle.intended_use` — authority flag alone is not sufficient
+- classifies each included item into `facts`, `inferences`, or `candidate_actions` based on
+  `source_role`, `reason` text, and `provenance.origin`
+- preserves per-item provenance and exclusions on the returned `OrientationBundleFrame`
+- checks bundle expiry and surfaces `stale=True` when `stale_after` has passed, normalizing
+  naive datetimes to UTC to prevent `TypeError` on comparison
+- normalizes a caller-provided naive `now` to UTC by the same convention
+- returns `read_only=True, may_write=False` — orientation never upgrades bundle authority
 
 ## Why This Matters
 
@@ -43,20 +42,19 @@ facts or stale signals as current state.
 
 ## Acceptance Criteria
 
-- [ ] Orientation consumption is specified as reading from a context bundle or bundle reference,
-  not from opaque prompt state alone. Verify: `tests/orientation/test_context_bundle_orientation.py::test_orientation_uses_context_bundle`
-- [ ] The orientation contract distinguishes facts, inferred state, candidate next actions, and
-  stale context in the assembled output. Verify: `tests/orientation/test_context_bundle_orientation.py::test_orientation_labels_fact_inference_candidate_and_stale_context`
-- [ ] Orientation preserves source and exclusion provenance strongly enough for a human to inspect
-  why the frame was assembled. Verify: `tests/orientation/test_context_bundle_orientation.py::test_orientation_exposes_bundle_provenance_and_exclusions`
-- [ ] Orientation does not silently upgrade bundle authority into write authorization. Verify: `tests/orientation/test_context_bundle_orientation.py::test_orientation_bundle_remains_non_write_authoritative`
-
-## How to Verify (Pre-Merge)
-
-- Add or update the orientation tests named in the acceptance criteria.
-- Confirm the orientation surface can explain what it used and what it left out.
-- Confirm any orientation "next step" remains a candidate or proposal unless a separate governed
-  action surface takes over.
+- [x] Orientation consumption reads from a context bundle, not from opaque prompt state alone.
+  Verify: `tests/orientation/test_context_bundle_orientation.py::test_orientation_uses_context_bundle`
+- [x] The frame distinguishes facts, inferred state, candidate next actions, and stale context.
+  Verify: `tests/orientation/test_context_bundle_orientation.py::test_orientation_labels_fact_inference_candidate_and_stale_context`
+- [x] Orientation preserves source and exclusion provenance for human inspection.
+  Verify: `tests/orientation/test_context_bundle_orientation.py::test_orientation_exposes_bundle_provenance_and_exclusions`
+- [x] Orientation does not silently upgrade bundle authority into write authorization.
+  Verify: `tests/orientation/test_context_bundle_orientation.py::test_orientation_bundle_remains_non_write_authoritative`
+- [x] Bundles not scoped for orientation (`"orient"` absent from `intended_use`) are rejected.
+  Verify: `tests/orientation/test_context_bundle_orientation.py::test_orientation_rejects_bundle_not_scoped_for_orient`
+- [x] Naive `stale_after` and naive caller-provided `now` are normalized to UTC without raising `TypeError`.
+  Verify: `tests/orientation/test_context_bundle_orientation.py::test_orientation_stale_check_handles_naive_expiry_timestamp`
+  Verify: `tests/orientation/test_context_bundle_orientation.py::test_orientation_normalizes_naive_caller_now`
 
 ## Out of Scope
 
@@ -64,6 +62,7 @@ facts or stale signals as current state.
 - Resurfacing-specific surfacing decisions.
 - Durable memory promotion from orientation outputs.
 - Write proposal execution.
+- API route wiring (production route integration is a follow-up slice).
 
 ## Related Docs
 
@@ -73,5 +72,6 @@ facts or stale signals as current state.
 
 ## Related GitHub Issues
 
-Not created in this PR. When filed later, use this task spec as the child implementation issue
-contract for orientation-side bundle usage.
+- Implementation issue: [#946](https://github.com/RasmusTho/agentic-pkm-mvp/issues/946)
+- Pull request: [#950](https://github.com/RasmusTho/agentic-pkm-mvp/pull/950)
+- Parent feature: [#894](https://github.com/RasmusTho/agentic-pkm-mvp/issues/894)

--- a/docs/CONTEXT_BUNDLES/USE_CONTEXT_BUNDLE_FOR_RESURFACING.md
+++ b/docs/CONTEXT_BUNDLES/USE_CONTEXT_BUNDLE_FOR_RESURFACING.md
@@ -23,12 +23,15 @@ semantic relatedness into urgency, authority, or write permission.
 
 `app/resurfacing/bundle_consumer.py` provides `build_resurfacing_bundle_frame`, which:
 
-- requires a `WhyNowSignal(rationale, signal_name)` — both fields are required; plain strings are
-  rejected to ensure the surfacing decision is anchored to a named, recorded signal
+- requires a `WhyNowSignal(rationale, signal_name)` — both fields are required and non-blank;
+  plain strings or empty/whitespace-only values are rejected so the surfacing decision is
+  always anchored to a named, recorded signal
 - requires `may_resurface=True` on the bundle's authority flags and rejects `may_write=True`
 - requires `"resurface"` in `bundle.intended_use` — authority flag alone is not sufficient
-- classifies included items into `relatedness_signals` and `priority_signals` based on
-  `source_role` and `reason` text
+- classifies included items into `priority_signals` (when the structured `source_role` field
+  marks them as priority) or `relatedness_signals` otherwise; free-text reason substrings are
+  not consulted because negated phrases like "not urgent" would otherwise be misclassified
+- preserves bundle `excluded` items on `ResurfacingBundleFrame.exclusions` for human inspection
 - checks bundle expiry and surfaces `stale=True` when `stale_after` has passed, normalizing
   naive datetimes to UTC to prevent `TypeError` on comparison
 - normalizes a caller-provided naive `now` to UTC by the same convention
@@ -55,6 +58,12 @@ hard to trust or dismiss.
 - [x] Naive `stale_after` and naive caller-provided `now` are normalized to UTC without raising `TypeError`.
   Verify: `tests/resurfacing/test_context_bundle_resurfacing.py::test_resurfacing_bundle_surfaces_stale_expiry_state`
   Verify: `tests/resurfacing/test_context_bundle_resurfacing.py::test_resurfacing_normalizes_naive_caller_now`
+- [x] Bundle exclusions are preserved on the frame for human inspection.
+  Verify: `tests/resurfacing/test_context_bundle_resurfacing.py::test_resurfacing_frame_preserves_exclusions`
+- [x] `WhyNowSignal` rejects blank or whitespace-only rationale/signal_name at construction.
+  Verify: `tests/resurfacing/test_context_bundle_resurfacing.py::test_resurfacing_rejects_blank_why_now_signal_fields`
+- [x] Priority classification relies on structured `source_role` only; free-text reason substrings are not consulted.
+  Verify: `tests/resurfacing/test_context_bundle_resurfacing.py::test_resurfacing_priority_classification_uses_source_role_not_reason_text`
 
 ## Out of Scope
 

--- a/docs/CONTEXT_BUNDLES/USE_CONTEXT_BUNDLE_FOR_RESURFACING.md
+++ b/docs/CONTEXT_BUNDLES/USE_CONTEXT_BUNDLE_FOR_RESURFACING.md
@@ -1,12 +1,15 @@
 ---
 name: Use Context Bundle for Resurfacing
-description: Specify how resurfacing uses context bundles to explain why-now suggestions.
+description: How resurfacing uses context bundles to explain why-now suggestions.
 task_id: CONTEXT-BUNDLES-04
 source_anchor: docs/CONCEPTS/CONTEXT_BUNDLE_CONTRACT.md :: Relation to retrieval, orientation, and resurfacing
 parent_capability: Context Bundles
 prerequisites: [CONTEXT-BUNDLES-01, CONTEXT-BUNDLES-02]
 depends_on: [DEFINE_CONTEXT_BUNDLE_SCHEMA.md, EMIT_CONTEXT_BUNDLE_FROM_RETRIEVAL.md]
 can_parallelize_with: [USE_CONTEXT_BUNDLE_FOR_ORIENTATION]
+status: implemented
+implementation: app/resurfacing/bundle_consumer.py
+github_issue: "https://github.com/RasmusTho/agentic-pkm-mvp/issues/947"
 ---
 
 # USE_CONTEXT_BUNDLE_FOR_RESURFACING
@@ -16,22 +19,20 @@ can_parallelize_with: [USE_CONTEXT_BUNDLE_FOR_ORIENTATION]
 Specify how resurfacing uses a context bundle to support "why now" explanations without collapsing
 semantic relatedness into urgency, authority, or write permission.
 
-## What This Task Does
+## What This Slice Implements
 
-This task defines the implementation contract for resurfacing-side bundle consumption. It specifies:
+`app/resurfacing/bundle_consumer.py` provides `build_resurfacing_bundle_frame`, which:
 
-- how resurfacing records the material it surfaced,
-- how it records the signal or rationale for why now,
-- and how it preserves the distinction between relevance and authority.
-
-## Concretely
-
-A later implementation should be able to emit a resurfacing result with:
-
-- a bundle of selected supporting items,
-- explicit "why now" rationale,
-- provenance for the signals that triggered resurfacing,
-- and clear authority posture showing that the bundle supports a suggestion, not a forced action.
+- requires a `WhyNowSignal(rationale, signal_name)` — both fields are required; plain strings are
+  rejected to ensure the surfacing decision is anchored to a named, recorded signal
+- requires `may_resurface=True` on the bundle's authority flags and rejects `may_write=True`
+- requires `"resurface"` in `bundle.intended_use` — authority flag alone is not sufficient
+- classifies included items into `relatedness_signals` and `priority_signals` based on
+  `source_role` and `reason` text
+- checks bundle expiry and surfaces `stale=True` when `stale_after` has passed, normalizing
+  naive datetimes to UTC to prevent `TypeError` on comparison
+- normalizes a caller-provided naive `now` to UTC by the same convention
+- returns `suggestion_only=True, may_write=False` — resurfacing never upgrades bundle authority
 
 ## Why This Matters
 
@@ -41,20 +42,19 @@ hard to trust or dismiss.
 
 ## Acceptance Criteria
 
-- [ ] Resurfacing consumption is specified as using a context bundle or stable bundle reference to
-  support the surfacing event. Verify: `tests/resurfacing/test_context_bundle_resurfacing.py::test_resurfacing_records_context_bundle`
-- [ ] The resurfacing contract requires an explicit "why now" explanation tied to provenance, not
-  only semantic relatedness. Verify: `tests/resurfacing/test_context_bundle_resurfacing.py::test_resurfacing_bundle_includes_why_now_explanation`
-- [ ] The resurfacing contract preserves the distinction between relatedness, priority, trust, and
-  authority. Verify: `tests/resurfacing/test_context_bundle_resurfacing.py::test_resurfacing_bundle_does_not_collapse_relatedness_into_priority_or_authority`
-- [ ] Resurfacing bundle usage does not authorize direct writeback or promotion by itself. Verify: `tests/resurfacing/test_context_bundle_resurfacing.py::test_resurfacing_bundle_remains_suggestion_only`
-
-## How to Verify (Pre-Merge)
-
-- Add or update the resurfacing tests named in the acceptance criteria.
-- Confirm the resurfacing output can be dismissed or ignored without affecting authority state.
-- Confirm "why now" is anchored to a recorded signal or relational change rather than opaque score
-  ordering alone.
+- [x] Resurfacing reads from a context bundle to support the surfacing event.
+  Verify: `tests/resurfacing/test_context_bundle_resurfacing.py::test_resurfacing_records_context_bundle`
+- [x] The "why now" explanation is anchored to a `WhyNowSignal` with a required `signal_name` — not an opaque score.
+  Verify: `tests/resurfacing/test_context_bundle_resurfacing.py::test_resurfacing_bundle_includes_why_now_explanation`
+- [x] Relatedness, priority, trust, and authority remain distinct on the returned frame.
+  Verify: `tests/resurfacing/test_context_bundle_resurfacing.py::test_resurfacing_bundle_does_not_collapse_relatedness_into_priority_or_authority`
+- [x] Resurfacing bundle usage does not authorize direct writeback or promotion.
+  Verify: `tests/resurfacing/test_context_bundle_resurfacing.py::test_resurfacing_bundle_remains_suggestion_only`
+- [x] Bundles not scoped for resurfacing (`"resurface"` absent from `intended_use`) are rejected.
+  Verify: `tests/resurfacing/test_context_bundle_resurfacing.py::test_resurfacing_rejects_bundle_not_scoped_for_resurface`
+- [x] Naive `stale_after` and naive caller-provided `now` are normalized to UTC without raising `TypeError`.
+  Verify: `tests/resurfacing/test_context_bundle_resurfacing.py::test_resurfacing_bundle_surfaces_stale_expiry_state`
+  Verify: `tests/resurfacing/test_context_bundle_resurfacing.py::test_resurfacing_normalizes_naive_caller_now`
 
 ## Out of Scope
 
@@ -62,6 +62,7 @@ hard to trust or dismiss.
 - Orientation-frame assembly.
 - Write proposal application.
 - Memory promotion or review queues.
+- API route wiring (production route integration is a follow-up slice).
 
 ## Related Docs
 
@@ -71,5 +72,6 @@ hard to trust or dismiss.
 
 ## Related GitHub Issues
 
-Not created in this PR. When filed later, use this task spec as the child implementation issue
-contract for resurfacing-side bundle usage.
+- Implementation issue: [#947](https://github.com/RasmusTho/agentic-pkm-mvp/issues/947)
+- Pull request: [#951](https://github.com/RasmusTho/agentic-pkm-mvp/pull/951)
+- Parent feature: [#894](https://github.com/RasmusTho/agentic-pkm-mvp/issues/894)

--- a/tests/orientation/test_context_bundle_orientation.py
+++ b/tests/orientation/test_context_bundle_orientation.py
@@ -171,3 +171,61 @@ def test_orientation_bundle_remains_non_write_authoritative():
     )
     with pytest.raises(BundleAuthorityViolation):
         build_orientation_frame_from_bundle(no_orient_bundle, now=_NOW)
+
+
+def test_orientation_rejects_bundle_not_scoped_for_orient():
+    # A bundle may carry may_orient=True but intended_use is part of the
+    # scoping contract — consuming it for orientation when it was scoped only
+    # for answering silently violates that contract.
+    answer_only_bundle = ContextBundle(
+        id="cb_answer_only",
+        created_at=_NOW,
+        trigger=BundleTrigger(type="retrieval"),
+        intended_use=["answer"],
+        scope=BundleScope(),
+        included=[_fact_item()],
+        excluded=[],
+        authority=AuthorityFlags(may_answer=True, may_orient=True),
+        expiry=ExpiryPosture(),
+    )
+    with pytest.raises(BundleAuthorityViolation, match="intended_use"):
+        build_orientation_frame_from_bundle(answer_only_bundle, now=_NOW)
+
+    # Multi-use bundles that include "orient" are accepted.
+    multi_bundle = ContextBundle(
+        id="cb_multi",
+        created_at=_NOW,
+        trigger=BundleTrigger(type="orientation"),
+        intended_use=["answer", "orient"],
+        scope=BundleScope(),
+        included=[_fact_item()],
+        excluded=[],
+        authority=AuthorityFlags(may_answer=True, may_orient=True),
+        expiry=ExpiryPosture(),
+    )
+    frame = build_orientation_frame_from_bundle(multi_bundle, now=_NOW)
+    assert frame.bundle_id == multi_bundle.id
+
+
+def test_orientation_normalizes_naive_caller_now():
+    # If the caller passes a naive `now`, the comparison must not raise TypeError.
+    # Naive now is treated as UTC — matches the same convention as stale_after.
+    naive_now = datetime(2026, 5, 15, 10, 0, 0)  # no tzinfo, 1h after _NOW
+    expiry = ExpiryPosture(
+        stale_after=_NOW + timedelta(hours=2),
+        reason="still fresh relative to naive now",
+    )
+    bundle = _bundle(included=[_fact_item()], expiry=expiry)
+    # Must not raise TypeError from naive vs. aware comparison.
+    frame = build_orientation_frame_from_bundle(bundle, now=naive_now)
+    assert frame.stale is False
+
+    # Naive now past stale_after also resolves correctly.
+    past_naive_now = datetime(2026, 5, 15, 8, 0, 0)  # 1h before _NOW
+    stale_expiry = ExpiryPosture(
+        stale_after=datetime(2026, 5, 15, 7, 30, 0, tzinfo=timezone.utc),
+        reason="stale relative to naive now",
+    )
+    stale_bundle = _bundle(included=[_fact_item()], expiry=stale_expiry)
+    stale_frame = build_orientation_frame_from_bundle(stale_bundle, now=past_naive_now)
+    assert stale_frame.stale is True

--- a/tests/orientation/test_context_bundle_orientation.py
+++ b/tests/orientation/test_context_bundle_orientation.py
@@ -133,6 +133,20 @@ def test_orientation_exposes_bundle_provenance_and_exclusions():
     assert frame.exclusions[0].reason == "trust state below threshold"
 
 
+def test_orientation_stale_check_handles_naive_expiry_timestamp():
+    # ExpiryPosture allows naive datetimes (no tzinfo). Comparison with an
+    # aware `now` must not raise TypeError — naive timestamps are assumed UTC.
+    naive_expiry = ExpiryPosture(
+        stale_after=datetime(2026, 5, 15, 8, 0, 0),  # no tzinfo
+        reason="naive expiry from JSON without offset",
+    )
+    bundle = _bundle(included=[_fact_item()], expiry=naive_expiry)
+    # _NOW is 09:00 UTC, naive stale_after is treated as 08:00 UTC → stale
+    frame = build_orientation_frame_from_bundle(bundle, now=_NOW)
+    assert frame.stale is True
+    assert "naive" in frame.stale_reason
+
+
 def test_orientation_bundle_remains_non_write_authoritative():
     # Building with may_write=False is fine and frame must remain read-only.
     bundle = _bundle(included=[_fact_item()])

--- a/tests/orientation/test_context_bundle_orientation.py
+++ b/tests/orientation/test_context_bundle_orientation.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.context_bundles.schema import (
+    AuthorityFlags,
+    BundleScope,
+    BundleTrigger,
+    ContextBundle,
+    ExcludedItem,
+    ExpiryPosture,
+    IncludedItem,
+    ItemProvenance,
+)
+from app.orientation.bundle_consumer import (
+    BundleAuthorityViolation,
+    OrientationBundleFrame,
+    build_orientation_frame_from_bundle,
+)
+
+
+_NOW = datetime(2026, 5, 15, 9, 0, 0, tzinfo=timezone.utc)
+
+
+def _bundle(
+    *,
+    included: list[IncludedItem] | None = None,
+    excluded: list[ExcludedItem] | None = None,
+    authority: AuthorityFlags | None = None,
+    expiry: ExpiryPosture | None = None,
+) -> ContextBundle:
+    return ContextBundle(
+        id="cb_orient_001",
+        created_at=_NOW,
+        trigger=BundleTrigger(type="orientation"),
+        intended_use=["orient"],
+        scope=BundleScope(),
+        included=included or [],
+        excluded=excluded or [],
+        authority=authority
+        or AuthorityFlags(may_answer=True, may_orient=True),
+        expiry=expiry or ExpiryPosture(),
+    )
+
+
+def _fact_item() -> IncludedItem:
+    return IncludedItem(
+        artifact_id="art_fact",
+        reason="direct evidence",
+        trust_state="reviewed",
+        review_state="confirmed",
+        provenance=ItemProvenance(origin="vault note"),
+    )
+
+
+def _inferred_item() -> IncludedItem:
+    return IncludedItem(
+        artifact_id="art_infer",
+        reason="model inference from related notes",
+        trust_state="unreviewed",
+        provenance=ItemProvenance(origin="agent inference", transformed_by="orientation"),
+    )
+
+
+def _candidate_item() -> IncludedItem:
+    return IncludedItem(
+        artifact_id="art_cand",
+        reason="candidate next action",
+        source_role="candidate_action",
+        provenance=ItemProvenance(origin="agent proposal"),
+    )
+
+
+def test_orientation_uses_context_bundle():
+    bundle = _bundle(included=[_fact_item()])
+
+    frame = build_orientation_frame_from_bundle(bundle, now=_NOW)
+
+    assert isinstance(frame, OrientationBundleFrame)
+    assert frame.bundle_id == bundle.id
+    # The frame must derive its facts from the bundle, not opaque prompt state.
+    assert any(seg.artifact_id == "art_fact" for seg in frame.facts)
+
+
+def test_orientation_labels_fact_inference_candidate_and_stale_context():
+    expiry = ExpiryPosture(
+        stale_after=_NOW - timedelta(hours=1),
+        reason="snapshot expired",
+    )
+    bundle = _bundle(
+        included=[_fact_item(), _inferred_item(), _candidate_item()],
+        expiry=expiry,
+    )
+
+    frame = build_orientation_frame_from_bundle(bundle, now=_NOW)
+
+    fact_ids = {s.artifact_id for s in frame.facts}
+    inference_ids = {s.artifact_id for s in frame.inferences}
+    candidate_ids = {s.artifact_id for s in frame.candidate_actions}
+
+    assert "art_fact" in fact_ids
+    assert "art_infer" in inference_ids
+    assert "art_cand" in candidate_ids
+    # The four buckets are distinct — no leakage between them.
+    assert fact_ids.isdisjoint(inference_ids)
+    assert fact_ids.isdisjoint(candidate_ids)
+    assert inference_ids.isdisjoint(candidate_ids)
+    # Stale context is surfaced explicitly, not silently treated as current.
+    assert frame.stale is True
+    assert frame.stale_reason == "snapshot expired"
+
+
+def test_orientation_exposes_bundle_provenance_and_exclusions():
+    excluded = ExcludedItem(
+        artifact_id="art_excluded",
+        reason="trust state below threshold",
+        trust_state="unreviewed",
+        provenance=ItemProvenance(origin="vault note"),
+    )
+    bundle = _bundle(included=[_fact_item()], excluded=[excluded])
+
+    frame = build_orientation_frame_from_bundle(bundle, now=_NOW)
+
+    # Per-item provenance survives onto the frame so a human can inspect why
+    # the orientation frame was assembled.
+    fact = next(s for s in frame.facts if s.artifact_id == "art_fact")
+    assert fact.provenance is not None
+    assert fact.provenance.origin == "vault note"
+    # Exclusions are visible on the frame, not dropped silently.
+    assert any(ex.artifact_id == "art_excluded" for ex in frame.exclusions)
+    assert frame.exclusions[0].reason == "trust state below threshold"
+
+
+def test_orientation_bundle_remains_non_write_authoritative():
+    # Building with may_write=False is fine and frame must remain read-only.
+    bundle = _bundle(included=[_fact_item()])
+    frame = build_orientation_frame_from_bundle(bundle, now=_NOW)
+    assert frame.read_only is True
+    assert frame.may_write is False
+
+    # Bundles arriving with may_write=True are rejected — orientation must not
+    # silently launder bundle authority into write authorization.
+    write_bundle = _bundle(
+        included=[_fact_item()],
+        authority=AuthorityFlags(may_answer=True, may_orient=True, may_write=True),
+    )
+    with pytest.raises(BundleAuthorityViolation):
+        build_orientation_frame_from_bundle(write_bundle, now=_NOW)

--- a/tests/orientation/test_context_bundle_orientation.py
+++ b/tests/orientation/test_context_bundle_orientation.py
@@ -148,3 +148,12 @@ def test_orientation_bundle_remains_non_write_authoritative():
     )
     with pytest.raises(BundleAuthorityViolation):
         build_orientation_frame_from_bundle(write_bundle, now=_NOW)
+
+    # Bundles without may_orient are rejected — orientation must not silently
+    # upgrade a bundle not authorized for orientation use (e.g. may_answer only).
+    no_orient_bundle = _bundle(
+        included=[_fact_item()],
+        authority=AuthorityFlags(may_answer=True, may_orient=False),
+    )
+    with pytest.raises(BundleAuthorityViolation):
+        build_orientation_frame_from_bundle(no_orient_bundle, now=_NOW)

--- a/tests/resurfacing/test_context_bundle_resurfacing.py
+++ b/tests/resurfacing/test_context_bundle_resurfacing.py
@@ -17,6 +17,7 @@ from app.context_bundles.schema import (
 from app.resurfacing.bundle_consumer import (
     BundleAuthorityViolation,
     ResurfacingBundleFrame,
+    WhyNowSignal,
     build_resurfacing_bundle_frame,
 )
 
@@ -102,13 +103,17 @@ def test_resurfacing_records_context_bundle():
 def test_resurfacing_bundle_includes_why_now_explanation():
     bundle = _bundle(included=[_item("art_b", "related note updated recently")])
 
-    frame = build_resurfacing_bundle_frame(
-        bundle, why_now="three related notes updated in last 24h", now=_NOW
+    # WhyNowSignal anchors the explanation to a named provenance signal so the
+    # "why now" decision is auditable, not just an opaque semantic score.
+    signal = WhyNowSignal(
+        rationale="three related notes updated in last 24h",
+        signal_name="watcher_run_24h",
     )
+    frame = build_resurfacing_bundle_frame(bundle, why_now=signal, now=_NOW)
 
-    # "Why now" is explicit and tied to the rationale, not hidden in a score.
-    assert frame.why_now is not None
+    # "Why now" rationale is explicit and the signal_name anchors it to provenance.
     assert "24h" in frame.why_now
+    assert frame.why_now_signal_name == "watcher_run_24h"
     # Provenance of the surfaced items is preserved for auditing.
     item = next(s for s in frame.surfaced_items if s.artifact_id == "art_b")
     assert item.provenance is not None

--- a/tests/resurfacing/test_context_bundle_resurfacing.py
+++ b/tests/resurfacing/test_context_bundle_resurfacing.py
@@ -223,3 +223,57 @@ def test_resurfacing_normalizes_naive_caller_now():
     stale_bundle = _bundle(included=[_item("art_k", "old note")], expiry=stale_expiry)
     stale_frame = build_resurfacing_bundle_frame(stale_bundle, why_now=_SIGNAL, now=past_naive_now)
     assert stale_frame.stale is True
+
+
+def test_resurfacing_frame_preserves_exclusions():
+    # Exclusions must survive onto the frame so a human can inspect why
+    # particular items were left out — silently dropping them hides the
+    # filtering decision and makes the surfacing unauditable.
+    excluded = ExcludedItem(
+        artifact_id="art_excluded",
+        reason="trust state below threshold",
+        trust_state="unreviewed",
+        provenance=ItemProvenance(origin="vault note"),
+    )
+    bundle = _bundle(included=[_item("art_l", "relevant now")], excluded=[excluded])
+    frame = build_resurfacing_bundle_frame(bundle, why_now=_SIGNAL, now=_NOW)
+
+    assert any(ex.artifact_id == "art_excluded" for ex in frame.exclusions)
+    assert frame.exclusions[0].reason == "trust state below threshold"
+
+
+def test_resurfacing_rejects_blank_why_now_signal_fields():
+    # Empty or whitespace-only rationale/signal_name leaves the surfacing
+    # decision without an auditable anchor — must be rejected at construction.
+    with pytest.raises(ValueError, match="signal_name"):
+        WhyNowSignal(rationale="valid", signal_name="")
+    with pytest.raises(ValueError, match="signal_name"):
+        WhyNowSignal(rationale="valid", signal_name="   ")
+    with pytest.raises(ValueError, match="rationale"):
+        WhyNowSignal(rationale="", signal_name="valid_signal")
+    with pytest.raises(ValueError, match="rationale"):
+        WhyNowSignal(rationale="\t\n  ", signal_name="valid_signal")
+
+
+def test_resurfacing_priority_classification_uses_source_role_not_reason_text():
+    # Free-text reasons containing "urgent", "priority", or "unresolved" must
+    # not by themselves classify items as priority — phrases like "not urgent"
+    # or "low priority" would otherwise be misclassified. Priority requires
+    # an explicit source_role.
+    negated_item = _item("art_neg", "not urgent and low priority — can wait")
+    no_role_item = _item("art_noroles", "unresolved blocker mentioned in note")
+    explicit_priority = _item(
+        "art_explicit", "active escalation", source_role="priority_signal"
+    )
+
+    bundle = _bundle(included=[negated_item, no_role_item, explicit_priority])
+    frame = build_resurfacing_bundle_frame(bundle, why_now=_SIGNAL, now=_NOW)
+
+    priority_ids = {s.artifact_id for s in frame.priority_signals}
+    relatedness_ids = {s.artifact_id for s in frame.relatedness_signals}
+
+    # Only the explicit source_role item is priority.
+    assert priority_ids == {"art_explicit"}
+    # Items lacking source_role fall to relatedness regardless of reason text.
+    assert "art_neg" in relatedness_ids
+    assert "art_noroles" in relatedness_ids

--- a/tests/resurfacing/test_context_bundle_resurfacing.py
+++ b/tests/resurfacing/test_context_bundle_resurfacing.py
@@ -169,3 +169,57 @@ def test_resurfacing_bundle_remains_suggestion_only():
     )
     with pytest.raises(BundleAuthorityViolation):
         build_resurfacing_bundle_frame(no_resurface_bundle, why_now=_SIGNAL, now=_NOW)
+
+
+def test_resurfacing_rejects_bundle_not_scoped_for_resurface():
+    # intended_use is part of the scoping contract — may_resurface alone is
+    # insufficient if the bundle was not assembled for resurfacing consumption.
+    answer_only_bundle = ContextBundle(
+        id="cb_answer_only",
+        created_at=_NOW,
+        trigger=BundleTrigger(type="retrieval"),
+        intended_use=["answer"],
+        scope=BundleScope(),
+        included=[_item("art_h", "relevant now")],
+        excluded=[],
+        authority=AuthorityFlags(may_answer=True, may_resurface=True),
+        expiry=ExpiryPosture(),
+    )
+    with pytest.raises(BundleAuthorityViolation, match="intended_use"):
+        build_resurfacing_bundle_frame(answer_only_bundle, why_now=_SIGNAL, now=_NOW)
+
+    # Multi-use bundles that include "resurface" are accepted.
+    multi_bundle = ContextBundle(
+        id="cb_multi",
+        created_at=_NOW,
+        trigger=BundleTrigger(type="resurfacing"),
+        intended_use=["answer", "resurface"],
+        scope=BundleScope(),
+        included=[_item("art_i", "relevant now")],
+        excluded=[],
+        authority=AuthorityFlags(may_answer=True, may_resurface=True),
+        expiry=ExpiryPosture(),
+    )
+    frame = build_resurfacing_bundle_frame(multi_bundle, why_now=_SIGNAL, now=_NOW)
+    assert frame.bundle_id == multi_bundle.id
+
+
+def test_resurfacing_normalizes_naive_caller_now():
+    # Naive caller-provided now must not raise TypeError — treated as UTC.
+    naive_now = datetime(2026, 5, 15, 11, 0, 0)  # no tzinfo, 1h after _NOW
+    fresh_expiry = ExpiryPosture(
+        stale_after=_NOW + timedelta(hours=2),
+        reason="still fresh",
+    )
+    bundle = _bundle(included=[_item("art_j", "relevant now")], expiry=fresh_expiry)
+    frame = build_resurfacing_bundle_frame(bundle, why_now=_SIGNAL, now=naive_now)
+    assert frame.stale is False
+
+    past_naive_now = datetime(2026, 5, 15, 9, 0, 0)  # 1h before _NOW
+    stale_expiry = ExpiryPosture(
+        stale_after=datetime(2026, 5, 15, 8, 30, 0, tzinfo=timezone.utc),
+        reason="stale relative to naive now",
+    )
+    stale_bundle = _bundle(included=[_item("art_k", "old note")], expiry=stale_expiry)
+    stale_frame = build_resurfacing_bundle_frame(stale_bundle, why_now=_SIGNAL, now=past_naive_now)
+    assert stale_frame.stale is True

--- a/tests/resurfacing/test_context_bundle_resurfacing.py
+++ b/tests/resurfacing/test_context_bundle_resurfacing.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -51,6 +51,41 @@ def _item(artifact_id: str, reason: str, source_role: str | None = None) -> Incl
         source_role=source_role,
         provenance=ItemProvenance(origin="vault note"),
     )
+
+
+def test_resurfacing_bundle_surfaces_stale_expiry_state():
+    # Stale bundles must be marked stale — callers must not reuse old evidence
+    # as if it were current. Naive timestamps are assumed UTC.
+    stale_expiry = ExpiryPosture(
+        stale_after=_NOW - timedelta(hours=2),
+        reason="resurfacing snapshot expired",
+    )
+    bundle = _bundle(included=[_item("art_stale", "old note")], expiry=stale_expiry)
+    frame = build_resurfacing_bundle_frame(bundle, why_now="stale context detected", now=_NOW)
+    assert frame.stale is True
+    assert frame.stale_reason == "resurfacing snapshot expired"
+
+    # Naive stale_after is treated as UTC — must not raise TypeError.
+    naive_expiry = ExpiryPosture(
+        stale_after=datetime(2026, 5, 15, 9, 0, 0),  # no tzinfo, 1h before _NOW
+        reason="naive expiry",
+    )
+    naive_bundle = _bundle(included=[_item("art_naive", "old note")], expiry=naive_expiry)
+    naive_frame = build_resurfacing_bundle_frame(
+        naive_bundle, why_now="naive expiry test", now=_NOW
+    )
+    assert naive_frame.stale is True
+
+    # Not-yet-stale bundles must not be flagged stale.
+    fresh_expiry = ExpiryPosture(
+        stale_after=_NOW + timedelta(hours=1),
+        reason="fresh",
+    )
+    fresh_bundle = _bundle(included=[_item("art_fresh", "recent note")], expiry=fresh_expiry)
+    fresh_frame = build_resurfacing_bundle_frame(
+        fresh_bundle, why_now="still current", now=_NOW
+    )
+    assert fresh_frame.stale is False
 
 
 def test_resurfacing_records_context_bundle():

--- a/tests/resurfacing/test_context_bundle_resurfacing.py
+++ b/tests/resurfacing/test_context_bundle_resurfacing.py
@@ -23,6 +23,7 @@ from app.resurfacing.bundle_consumer import (
 
 
 _NOW = datetime(2026, 5, 15, 10, 0, 0, tzinfo=timezone.utc)
+_SIGNAL = WhyNowSignal(rationale="test signal", signal_name="test_event")
 
 
 def _bundle(
@@ -55,14 +56,16 @@ def _item(artifact_id: str, reason: str, source_role: str | None = None) -> Incl
 
 
 def test_resurfacing_bundle_surfaces_stale_expiry_state():
-    # Stale bundles must be marked stale — callers must not reuse old evidence
-    # as if it were current. Naive timestamps are assumed UTC.
     stale_expiry = ExpiryPosture(
         stale_after=_NOW - timedelta(hours=2),
         reason="resurfacing snapshot expired",
     )
     bundle = _bundle(included=[_item("art_stale", "old note")], expiry=stale_expiry)
-    frame = build_resurfacing_bundle_frame(bundle, why_now="stale context detected", now=_NOW)
+    frame = build_resurfacing_bundle_frame(
+        bundle,
+        why_now=WhyNowSignal(rationale="stale context detected", signal_name="expiry_check"),
+        now=_NOW,
+    )
     assert frame.stale is True
     assert frame.stale_reason == "resurfacing snapshot expired"
 
@@ -73,18 +76,19 @@ def test_resurfacing_bundle_surfaces_stale_expiry_state():
     )
     naive_bundle = _bundle(included=[_item("art_naive", "old note")], expiry=naive_expiry)
     naive_frame = build_resurfacing_bundle_frame(
-        naive_bundle, why_now="naive expiry test", now=_NOW
+        naive_bundle,
+        why_now=WhyNowSignal(rationale="naive expiry test", signal_name="expiry_check"),
+        now=_NOW,
     )
     assert naive_frame.stale is True
 
     # Not-yet-stale bundles must not be flagged stale.
-    fresh_expiry = ExpiryPosture(
-        stale_after=_NOW + timedelta(hours=1),
-        reason="fresh",
-    )
+    fresh_expiry = ExpiryPosture(stale_after=_NOW + timedelta(hours=1), reason="fresh")
     fresh_bundle = _bundle(included=[_item("art_fresh", "recent note")], expiry=fresh_expiry)
     fresh_frame = build_resurfacing_bundle_frame(
-        fresh_bundle, why_now="still current", now=_NOW
+        fresh_bundle,
+        why_now=WhyNowSignal(rationale="still current", signal_name="expiry_check"),
+        now=_NOW,
     )
     assert fresh_frame.stale is False
 
@@ -92,11 +96,14 @@ def test_resurfacing_bundle_surfaces_stale_expiry_state():
 def test_resurfacing_records_context_bundle():
     bundle = _bundle(included=[_item("art_a", "recently updated in vault")])
 
-    frame = build_resurfacing_bundle_frame(bundle, why_now="dependency gap detected", now=_NOW)
+    frame = build_resurfacing_bundle_frame(
+        bundle,
+        why_now=WhyNowSignal(rationale="dependency gap detected", signal_name="dependency_gap"),
+        now=_NOW,
+    )
 
     assert isinstance(frame, ResurfacingBundleFrame)
     assert frame.bundle_id == bundle.id
-    # The frame must derive surfaced items from the bundle, not opaque internals.
     assert any(s.artifact_id == "art_a" for s in frame.surfaced_items)
 
 
@@ -111,10 +118,8 @@ def test_resurfacing_bundle_includes_why_now_explanation():
     )
     frame = build_resurfacing_bundle_frame(bundle, why_now=signal, now=_NOW)
 
-    # "Why now" rationale is explicit and the signal_name anchors it to provenance.
     assert "24h" in frame.why_now
     assert frame.why_now_signal_name == "watcher_run_24h"
-    # Provenance of the surfaced items is preserved for auditing.
     item = next(s for s in frame.surfaced_items if s.artifact_id == "art_b")
     assert item.provenance is not None
     assert item.provenance.origin == "vault note"
@@ -128,16 +133,16 @@ def test_resurfacing_bundle_does_not_collapse_relatedness_into_priority_or_autho
         ]
     )
 
-    frame = build_resurfacing_bundle_frame(bundle, why_now="semantic shift detected", now=_NOW)
+    frame = build_resurfacing_bundle_frame(
+        bundle,
+        why_now=WhyNowSignal(rationale="semantic shift detected", signal_name="salience_change"),
+        now=_NOW,
+    )
 
-    # relatedness, priority, and authority are distinct fields on the frame —
-    # the consumer cannot conflate them.
     assert hasattr(frame, "relatedness_signals")
     assert hasattr(frame, "priority_signals")
-    # Authority remains a suggestion posture — no write flag escalated.
     assert frame.suggestion_only is True
     assert frame.may_write is False
-    # Items classified as priority_signal appear in priority_signals, not relatedness.
     priority_ids = {s.artifact_id for s in frame.priority_signals}
     relatedness_ids = {s.artifact_id for s in frame.relatedness_signals}
     assert "art_d" in priority_ids
@@ -146,26 +151,21 @@ def test_resurfacing_bundle_does_not_collapse_relatedness_into_priority_or_autho
 
 
 def test_resurfacing_bundle_remains_suggestion_only():
-    # Normal bundle: suggestion_only=True, no write authority.
     bundle = _bundle(included=[_item("art_e", "relevant now")])
-    frame = build_resurfacing_bundle_frame(bundle, why_now="context shift", now=_NOW)
+    frame = build_resurfacing_bundle_frame(bundle, why_now=_SIGNAL, now=_NOW)
     assert frame.suggestion_only is True
     assert frame.may_write is False
 
-    # Bundles with may_write=True are rejected — resurfacing must not
-    # launder write authority from a bundle.
     write_bundle = _bundle(
         included=[_item("art_f", "relevant now")],
         authority=AuthorityFlags(may_resurface=True, may_write=True),
     )
     with pytest.raises(BundleAuthorityViolation):
-        build_resurfacing_bundle_frame(write_bundle, why_now="context shift", now=_NOW)
+        build_resurfacing_bundle_frame(write_bundle, why_now=_SIGNAL, now=_NOW)
 
-    # Bundles without may_resurface are rejected — resurfacing must not
-    # silently consume bundles not authorized for resurfacing.
     no_resurface_bundle = _bundle(
         included=[_item("art_g", "relevant now")],
         authority=AuthorityFlags(may_answer=True, may_resurface=False),
     )
     with pytest.raises(BundleAuthorityViolation):
-        build_resurfacing_bundle_frame(no_resurface_bundle, why_now="context shift", now=_NOW)
+        build_resurfacing_bundle_frame(no_resurface_bundle, why_now=_SIGNAL, now=_NOW)

--- a/tests/resurfacing/test_context_bundle_resurfacing.py
+++ b/tests/resurfacing/test_context_bundle_resurfacing.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.context_bundles.schema import (
+    AuthorityFlags,
+    BundleScope,
+    BundleTrigger,
+    ContextBundle,
+    ExcludedItem,
+    ExpiryPosture,
+    IncludedItem,
+    ItemProvenance,
+)
+from app.resurfacing.bundle_consumer import (
+    BundleAuthorityViolation,
+    ResurfacingBundleFrame,
+    build_resurfacing_bundle_frame,
+)
+
+
+_NOW = datetime(2026, 5, 15, 10, 0, 0, tzinfo=timezone.utc)
+
+
+def _bundle(
+    *,
+    included: list[IncludedItem] | None = None,
+    excluded: list[ExcludedItem] | None = None,
+    authority: AuthorityFlags | None = None,
+    expiry: ExpiryPosture | None = None,
+) -> ContextBundle:
+    return ContextBundle(
+        id="cb_resurface_001",
+        created_at=_NOW,
+        trigger=BundleTrigger(type="resurfacing"),
+        intended_use=["resurface"],
+        scope=BundleScope(),
+        included=included or [],
+        excluded=excluded or [],
+        authority=authority or AuthorityFlags(may_answer=True, may_resurface=True),
+        expiry=expiry or ExpiryPosture(),
+    )
+
+
+def _item(artifact_id: str, reason: str, source_role: str | None = None) -> IncludedItem:
+    return IncludedItem(
+        artifact_id=artifact_id,
+        reason=reason,
+        source_role=source_role,
+        provenance=ItemProvenance(origin="vault note"),
+    )
+
+
+def test_resurfacing_records_context_bundle():
+    bundle = _bundle(included=[_item("art_a", "recently updated in vault")])
+
+    frame = build_resurfacing_bundle_frame(bundle, why_now="dependency gap detected", now=_NOW)
+
+    assert isinstance(frame, ResurfacingBundleFrame)
+    assert frame.bundle_id == bundle.id
+    # The frame must derive surfaced items from the bundle, not opaque internals.
+    assert any(s.artifact_id == "art_a" for s in frame.surfaced_items)
+
+
+def test_resurfacing_bundle_includes_why_now_explanation():
+    bundle = _bundle(included=[_item("art_b", "related note updated recently")])
+
+    frame = build_resurfacing_bundle_frame(
+        bundle, why_now="three related notes updated in last 24h", now=_NOW
+    )
+
+    # "Why now" is explicit and tied to the rationale, not hidden in a score.
+    assert frame.why_now is not None
+    assert "24h" in frame.why_now
+    # Provenance of the surfaced items is preserved for auditing.
+    item = next(s for s in frame.surfaced_items if s.artifact_id == "art_b")
+    assert item.provenance is not None
+    assert item.provenance.origin == "vault note"
+
+
+def test_resurfacing_bundle_does_not_collapse_relatedness_into_priority_or_authority():
+    bundle = _bundle(
+        included=[
+            _item("art_c", "semantically related to active project"),
+            _item("art_d", "high-priority unresolved thread", source_role="priority_signal"),
+        ]
+    )
+
+    frame = build_resurfacing_bundle_frame(bundle, why_now="semantic shift detected", now=_NOW)
+
+    # relatedness, priority, and authority are distinct fields on the frame —
+    # the consumer cannot conflate them.
+    assert hasattr(frame, "relatedness_signals")
+    assert hasattr(frame, "priority_signals")
+    # Authority remains a suggestion posture — no write flag escalated.
+    assert frame.suggestion_only is True
+    assert frame.may_write is False
+    # Items classified as priority_signal appear in priority_signals, not relatedness.
+    priority_ids = {s.artifact_id for s in frame.priority_signals}
+    relatedness_ids = {s.artifact_id for s in frame.relatedness_signals}
+    assert "art_d" in priority_ids
+    assert "art_c" in relatedness_ids
+    assert priority_ids.isdisjoint(relatedness_ids)
+
+
+def test_resurfacing_bundle_remains_suggestion_only():
+    # Normal bundle: suggestion_only=True, no write authority.
+    bundle = _bundle(included=[_item("art_e", "relevant now")])
+    frame = build_resurfacing_bundle_frame(bundle, why_now="context shift", now=_NOW)
+    assert frame.suggestion_only is True
+    assert frame.may_write is False
+
+    # Bundles with may_write=True are rejected — resurfacing must not
+    # launder write authority from a bundle.
+    write_bundle = _bundle(
+        included=[_item("art_f", "relevant now")],
+        authority=AuthorityFlags(may_resurface=True, may_write=True),
+    )
+    with pytest.raises(BundleAuthorityViolation):
+        build_resurfacing_bundle_frame(write_bundle, why_now="context shift", now=_NOW)
+
+    # Bundles without may_resurface are rejected — resurfacing must not
+    # silently consume bundles not authorized for resurfacing.
+    no_resurface_bundle = _bundle(
+        included=[_item("art_g", "relevant now")],
+        authority=AuthorityFlags(may_answer=True, may_resurface=False),
+    )
+    with pytest.raises(BundleAuthorityViolation):
+        build_resurfacing_bundle_frame(no_resurface_bundle, why_now="context shift", now=_NOW)


### PR DESCRIPTION
## Summary

Implements CONTEXT-BUNDLES-04, closing #947.

- Adds `app/resurfacing/bundle_consumer.py` with `build_resurfacing_bundle_frame()`, `ResurfacingBundleFrame`, `SurfacedItem`, and `BundleAuthorityViolation`.
- Adds `tests/resurfacing/test_context_bundle_resurfacing.py` covering all 4 ACs.

The resurfacing projection:
- Records a `why_now` string supplied by the caller — anchored to a recorded signal, not an opaque internal score — making the "why now" decision auditable.
- Classifies included items into **relatedness_signals** and **priority_signals** based on `source_role` and `reason`, keeping the two distinct on the frame.
- Preserves per-item provenance so a human can inspect what material backed the suggestion.
- Is **suggestion-only** with `may_write=False` — rejects bundles that lack `may_resurface=True` or carry `may_write=True`, mirroring the orientation authority-check pattern from #946.

Dispatcher unavailable on this host — used GitHub-label-only claim.

## Acceptance Criteria

- [x] Resurfacing consumption uses a context bundle or stable bundle reference to support the surfacing event.
  `Verify: tests/resurfacing/test_context_bundle_resurfacing.py::test_resurfacing_records_context_bundle` ✅
- [x] An explicit "why now" explanation tied to provenance is required, not only semantic relatedness.
  `Verify: tests/resurfacing/test_context_bundle_resurfacing.py::test_resurfacing_bundle_includes_why_now_explanation` ✅
- [x] Relatedness, priority, trust, and authority are kept distinct — relatedness is not collapsed into priority or authority.
  `Verify: tests/resurfacing/test_context_bundle_resurfacing.py::test_resurfacing_bundle_does_not_collapse_relatedness_into_priority_or_authority` ✅
- [x] Resurfacing bundle usage does not authorize direct writeback or promotion.
  `Verify: tests/resurfacing/test_context_bundle_resurfacing.py::test_resurfacing_bundle_remains_suggestion_only` ✅

## Validation

```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/resurfacing/test_context_bundle_resurfacing.py -m "not pg"
# 4 passed in 1.80s

PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/resurfacing/ tests/context_bundles/ -m "not pg"
# 11 passed in 1.09s
```

## Note on parallelism

`docs/CONTEXT_BUNDLES/USE_CONTEXT_BUNDLE_FOR_RESURFACING.md` marks this slice `can_parallelize_with: [USE_CONTEXT_BUNDLE_FOR_ORIENTATION]`. This PR and #950 were developed in parallel on separate branches; neither depends on the other at the code level.

Fixes #947

🤖 Generated with [Claude Code](https://claude.ai/claude-code)