### PR TITLE
docs: Companion UI design handoff governance (closes #901)

### DIFF
--- a/companion-ui/design_handoff/2026-05-14-claude-design-package/CHANGELOG.md
+++ b/companion-ui/design_handoff/2026-05-14-claude-design-package/CHANGELOG.md
@@ -1,0 +1,110 @@
+# CHANGELOG — Claude Design Package · 2026-05-14
+
+## v2 · 2026-05-15 — Refinement pass
+
+Focused tightening rather than redesign. The visual language, folder shape, and
+authority-boundary architecture from v1 are unchanged.
+
+### Added
+
+- **New package 05 · Vault Action Layer / Agent Tool Authority.**
+  Designs the 9-step action pipeline (`intent → classify → bound → policy → guard →
+  idempotency → execute → receipt → event`), the 5-tier tool authority taxonomy (read-only,
+  proposal, bounded write, governance-bearing, forbidden), the Obsidian/MCP-as-adapter
+  boundary, and a concrete first action (`move_inbox_note_to_workbench`) with eight designed
+  states. Linked to issue **#910**.
+  - `companion-ui/design_handoff/2026-05-14-vault-action-layer/`
+
+- **Root README · Implementation Intake Summary table.**
+  Single table mapping each artifact to its repo issues, what may be implemented,
+  what must not, architecture dependencies, and open questions. Designed so a repo
+  maintainer can decide intake from a single read.
+
+- **Root README · "What to import" / "What should become issues" / "What must remain
+  design-only" lists.** Three short lists at the end of the README that complement the
+  intake table.
+
+### Tightened — Runtime Proof / Health Dashboard
+
+- **New §03 · Three planes: evidence · status · action.** Names the three planes the
+  dashboard renders and the invariant that they are never collapsed. Evidence = runtime
+  values; status = posture the runtime declares; action = the single recommendation the
+  operator explicitly triggers.
+- **Explicit "no automatic repair" rule** with an anti-pattern callout. Every write-shaped
+  affordance is the operator's explicit click; the dashboard never retries or escalates.
+- **Receipt-link pattern.** Every dashboard number that represents *governed events*
+  (proof runs, governance receipts, write-guard denials, dead-letters, watcher restarts)
+  hovers/clicks to a receipt-id list. Numbers that are pure measurements (heartbeat ms,
+  tick counts) do not link.
+- Sections 04–10 renumbered to 05–11 to accommodate the new §03.
+- All seven required states (watcher OOM, worker poison, stale heartbeat, proof not-yet-run,
+  proof failed-but-actionable, healthy, write-guard active) confirmed already present in
+  the v1 §05 state gallery (now §06).
+
+### Tightened — Context Bundle Inspector
+
+- **New §04 · Ranked candidates · compact mode · similarity is not authority.** Three
+  refinements:
+  - Visual distinction between **ranked candidates** (the retrieval list) and **selected
+    context** (the bundle). Adds a faded ranked column rendered to the left of the included
+    list, with included / excluded-visible / below-floor opacity tiers.
+  - **Compact mode vs expanded provenance view** with a side-by-side mock and a per-concern
+    table mapping which fields appear in which mode. Compact emits `bundle.expand` to
+    transition; never auto-expands.
+  - **Semantic similarity is not authority** invariant callout with concrete UI rules: a
+    high-score artifact in a `may_write: false` bundle still shows no apply affordance;
+    score is never rendered as a colour judgment.
+- Sections 04–10 renumbered to 05–11 to accommodate the new §04.
+- `may_write=false` default for retrieval bundles confirmed already present in v1 §03 and
+  §05 state gallery.
+
+### Tightened — Memory Candidate Review Queue
+
+- **Persistent in-UI authority banner.** A gold mono banner now sits between the queue
+  bar and the candidate list in the live prototype:
+  *"Unreviewed memory is not semantic authority. Candidate-state items in this queue
+  cannot be recalled into answers, orientation, or write proposals. Authority activates
+  only on accept or promote."* Persistent, never collapsing, never animating.
+- **New §04 · Queue posture &amp; anti-inbox mitigations.** Names nine explicit
+  mitigations against queue anxiety: pull-not-push, defer-as-first-class,
+  auto-archive-expired, pacing throttle on inferred candidates, default-action-by-confidence-band,
+  opt-in batch mode, reject-preserves-trail, operational-only as first-class outcome,
+  promote-is-rare-and-visible. Includes an anti-pattern callout against shell-level
+  notifications.
+- Sections 04–09 renumbered to 05–10 to accommodate the new §04.
+
+### Tightened — Handoff Governance Pack
+
+- No structural changes. The pack's role expanded (it now governs five sibling packages),
+  but its content is unchanged from v1.
+
+### Tightened — Claude Design Package index
+
+- **New 5th package card** (vault action layer) added to `index.html` §01.
+- **Implementation Intake Summary section** added to `index.html` §00, linking through to
+  the canonical table in the root README.
+- Summary stats updated: 5 packages, 45 UI states designed, 35 handoff docs.
+- Dependencies diagram in §02 extended to include `VAULT_ACTION_LAYER_CONTRACT` (future
+  owner-doc) and re-attributed read-only references.
+- "What this feeds" table extended with row 05.
+
+### Unchanged
+
+- The shared design system (`colors_and_type.css`, `spec_chrome.css`) is unchanged.
+- The authority-boundary architecture is unchanged: design proposes, does not promote;
+  runtime truth lives downstream; gated execution honored everywhere.
+- All four v1 prototypes' state galleries are unchanged — the brief's per-state requests
+  (watcher OOM, worker poison, conflict state, promoted-to-Markdown, etc.) were already
+  covered in v1.
+- Owner-docs are unchanged. This package modifies none.
+
+---
+
+## v1 · 2026-05-14 — Initial release
+
+Four governed handoff packages plus an index:
+
+- Design Handoff Governance Pack
+- Runtime Proof / Health Dashboard
+- Context Bundle Inspector
+- Memory Candidate Review Queue

--- a/companion-ui/design_handoff/2026-05-14-claude-design-package/README.md
+++ b/companion-ui/design_handoff/2026-05-14-claude-design-package/README.md
@@ -1,0 +1,103 @@
+# Claude Design Package — 2026-05-14
+
+**Date:** 2026-05-14 (v1) · 2026-05-15 (v2 refinement)
+**Status:** Design handoff · v2 · ready for review at crossing B (handoff → normalized spec)
+**Authority:** Visual guidance only — process pattern + four UI surfaces
+**Owner-docs touched:** read-only references; no owner-doc is modified by this package
+
+## What this is
+
+Five governed handoff packages, plus this index. Produced as a Claude Design exploration
+under the `claude-design-context` brief; conform to the folder shape proposed by Package 01
+(the Handoff Governance Pack — package 01 governs the process the other four were produced
+under).
+
+Open `index.html` for the executive summary, package cards, and the Implementation Intake
+Summary.
+
+## Implementation Intake Summary
+
+The table below is the only document a repo maintainer should need to read in order to
+decide what to import, what to schedule as issues, and what must remain design-only.
+
+| Design artifact | What it is for | Related repo issue(s) | What **may** be implemented later | What **must not** be implemented directly | Architecture dependencies | Open questions |
+|---|---|---|---|---|---|---|
+| **01 · Handoff Governance Pack** | Process pattern that turns design explorations into governed implementation inputs. Six-link chain (`exploration → handoff → normalized spec → issue → PR → receipt`), maturity bar, three templates, review console. | **#901** | Folder shape adoption across `companion-ui/design_handoff/`; static review console rendered from the folder; maturity-checklist front-matter on existing READMEs. | A runtime review service. A new authority over owner-docs. A blocking gate on PRs (only on crossing B). | `docs/INTERACTION_SURFACES_AND_AUTHORITY/` (read-only); the governance pack does not modify it. | Where the console lives (suggest: static HTML); single vs. dual reviewer; superseded-package handling. |
+| **02 · Runtime Proof / Health Dashboard** | Compact single-operator proof surface answering nine runtime-health questions; mirrors runtime state without acting on it. | **#865**, **#866**, **#850** + runtime stabilization issues | UI render against fixture snapshots; receipt-link disclosures on governed counts; nine state fixtures (incl. watcher OOM, worker poison, stale heartbeat, proof not-yet-run, proof failed-but-actionable). | Auto-remediation. UI-derived posture. A dashboard-as-control-plane direction. An ops-style alert channel. | `STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md` (invariant); future runtime-proof receipt contract (depends on, does not own). | Polling vs push transport; "blocked" terminology disambiguation (policy vs failure); proof history window. |
+| **03 · Context Bundle Inspector** | Inspectable bridge object between retrieval, orientation, resurfacing, and write proposals — authority flags, included/excluded artifacts, ranked candidates, compact vs expanded mode. | **#894**, **#895**, **#896** | UI render against three fixture bundles (retrieval, orientation, write-proposal); compact-mode embedding next to chat turns; ranked-candidate column with score+outcome; six fail-state fixtures. | Re-ranking. Apply / writeback affordance. Memory promotion. Modification of the bundle schema. | `docs/CONCEPTS/CONTEXT_BUNDLE_CONTRACT.md` (read-only). | Default exclusion-visibility threshold; bundle-receipt taxonomy; "why now" field location for resurfacing bundles. |
+| **04 · Memory Candidate Review Queue** | Pull-based queue for proposed agent memories with a persistent "unreviewed memory is not semantic authority" banner and explicit anti-inbox mitigations. | **#900** | UI render against ten fixture candidates; seven primary actions; conflict UI; promote-to-note path through governance; auto-archive policy implementation. | Auto-accept rules. A recall surface. Definition of memory class. Semantic-search across past memories. Notification badges in the shell. | `docs/CONCEPTS/AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT.md` (read-only). | Confidence presentation (numeric vs banded); conflict-resolution UI (`keep both` validity); pacing-throttle policy; auto-archive default interval. |
+| **05 · Vault Action Layer / Agent Tool Authority** | 9-step pipeline (`intent → classify → bound → policy → guard → idempotency → execute → receipt → event`), 5-tier tool taxonomy, Obsidian/MCP-as-adapter boundary, concrete first action (`move_inbox_note_to_workbench`). | **#910** + future tool-authority docs issue | First bounded action `move_inbox_note_to_workbench`; Tier-4 forbidden list as owner-doc; registry-write path; Obsidian adapter; MCP-exposed surface restricted to registry names. | A generic "agent tools" library decoupled from the registry. Obsidian/MCP as primary mutation authority. Runtime tier-elevation. Silent failure paths. | New owner-doc to author (`docs/CONCEPTS/VAULT_ACTION_LAYER_CONTRACT.md`); references `STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md` and `INTERACTION_SURFACES_AND_AUTHORITY/`. | Tier 1 vs Tier 3 distinction durability; idempotency window default; collision-rule taxonomy; cross-vault actions tier; classifier-confidence-to-tier coupling. |
+
+## Packages
+
+1. **`../2026-05-14-handoff-governance-pack/`** — Design Handoff Governance Pack.
+2. **`../2026-05-14-runtime-proof-dashboard/`** — Runtime Proof / Health Dashboard.
+3. **`../2026-05-14-context-bundle-inspector/`** — Context Bundle Inspector.
+4. **`../2026-05-14-memory-candidate-review/`** — Memory Candidate Review Queue.
+5. **`../2026-05-14-vault-action-layer/`** — Vault Action Layer / Agent Tool Authority. **(new in v2)**
+
+See `CHANGELOG.md` for the v1 → v2 diff.
+
+## What to import into the repo
+
+The minimum-viable import is a single owner-doc per package (where applicable) plus the
+prototype HTML as a design reference. Each package's prototype is self-contained — copy the
+folder into `companion-ui/design_handoff/` and the file shape works.
+
+- `companion-ui/design_handoff/2026-05-14-handoff-governance-pack/` → as-is.
+- `companion-ui/design_handoff/2026-05-14-runtime-proof-dashboard/` → as-is.
+- `companion-ui/design_handoff/2026-05-14-context-bundle-inspector/` → as-is.
+- `companion-ui/design_handoff/2026-05-14-memory-candidate-review/` → as-is.
+- `companion-ui/design_handoff/2026-05-14-vault-action-layer/` → as-is.
+- `companion-ui/design_handoff/2026-05-14-claude-design-package/` → the index, this README,
+  and the CHANGELOG.
+
+## What should become issues later
+
+These are the proposed normalized-spec authorings that the crossing-B reviewer would
+authorize, and the first follow-on implementation issue under each.
+
+| Package | Proposed normalized spec | First implementation issue |
+|---|---|---|
+| 01 | `docs/INTERACTION_SURFACES_AND_AUTHORITY/DESIGN_HANDOFF_GOVERNANCE.md` | Adopt folder shape across existing `companion-ui/design_handoff/` packages. |
+| 02 | `docs/RUNTIME_PROOF_DASHBOARD.md` (UI guidance, target-state) | Render dashboard against nine fixture snapshots. |
+| 03 | `docs/CONCEPTS/CONTEXT_BUNDLE_INSPECTOR_UI.md` (UI guidance) | Render inspector against three fixture bundles + six fail-state fixtures. |
+| 04 | `docs/CONCEPTS/MEMORY_CANDIDATE_REVIEW_UI.md` (UI guidance) | Render queue against ten fixture candidates; wire seven primary actions. |
+| 05 | `docs/CONCEPTS/VAULT_ACTION_LAYER_CONTRACT.md` (new owner-doc) | Register first bounded action `move_inbox_note_to_workbench@v1`; full pipeline against fixture vault. |
+
+## What must remain design-only
+
+These items are deliberately not in any of the proposed normalized specs and would be
+rejected if they appeared in an implementation PR.
+
+- Any **runtime claim** asserted by a design doc. The dashboard, inspector, queue, and
+  action layer all render target-state behavior; only owner-docs and shipped code may assert
+  current runtime behavior.
+- **Auto-remediation** for runtime-proof states. Every action is the operator's explicit
+  click.
+- **UI-derived posture, class, authority, or classification.** The server declares; the UI
+  renders.
+- **Bundle schema changes** from package 03. The inspector renders the bundle contract; it
+  does not modify it.
+- **Memory class set additions** from package 04. The contract owns the class taxonomy.
+- **Registry semantics** from package 05. Tier 4 stays empty; new bounded actions only via
+  registry PRs.
+- **Obsidian / MCP as the primary mutation path.** Adapter, not authority — this is a
+  cross-package design constraint, not a workspace preference.
+
+## How to read
+
+- **For a crossing-B reviewer:** read this README, then `index.html`, then walk the maturity
+  checklist in package 01 §03 against each of packages 02–05.
+- **For Claude Code / Codex:** read each package's `README.md` and
+  `implementation-contracts.md`, then `prototype.html` §07-§08 and the final "Handoff" section.
+- **For an owner-doc reviewer:** read each package's `authority-boundaries.md` and
+  `open-questions.md`; cross-reference the **Architecture dependencies** column above.
+
+## Disclaimers
+
+- Design exploration is not architecture authority. Architecture authority remains in repo
+  owner-docs and contracts.
+- Runtime truth remains in shipped code, tests, status docs, and validation receipts.
+- This package proposes; it does not promote. Promotion happens at crossing B.
+- The gated-execution invariant is honored across all five packages.

--- a/companion-ui/design_handoff/2026-05-14-claude-design-package/colors_and_type.css
+++ b/companion-ui/design_handoff/2026-05-14-claude-design-package/colors_and_type.css
@@ -1,0 +1,346 @@
+/* ============================================================
+   Yggdrasil Design System — Colors & Type
+   ============================================================
+   Import this file in any HTML artifact or UI kit.
+   Google Fonts are imported below; JetBrains Mono via bunny.net.
+   ============================================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Space+Grotesk:wght@300;400;500;600&display=swap');
+@import url('https://fonts.bunny.net/css?family=jetbrains-mono:400,500&display=swap');
+
+/* ============================================================
+   BASE COLOR TOKENS
+   ============================================================ */
+:root {
+  /* --- Backgrounds (cool blue-black — Tron grid) --- */
+  --bg-base:       #070b12;   /* deepest — page root, near black with blue cast */
+  --bg-surface:    #0c1220;   /* panels, sidebars */
+  --bg-raised:     #111a2e;   /* cards, inputs, raised surfaces */
+  --bg-overlay:    #162038;   /* hover states, popovers */
+  --bg-modal:      #0e1828;   /* modal / dialog backdrop content */
+
+  /* --- Foreground / Text --- */
+  --fg-1:          #dce8f0;   /* primary — cool blue-white */
+  --fg-2:          #7a9ab8;   /* secondary / muted */
+  --fg-3:          #3d5570;   /* tertiary / disabled / dim */
+  --fg-inverse:    #070b12;   /* text on light/accent backgrounds */
+
+  /* --- Borders (thin, slightly glowing) --- */
+  --border:        #152030;   /* default — subtle grid line */
+  --border-strong: #1e3050;   /* emphasis — dividers, active edges */
+  --border-focus:  #00d4e8;   /* focus ring — electric cyan */
+
+  /* --- Accent 1: Norse Gold (slightly electrified) --- */
+  --accent:        #d4a843;   /* primary accent — active, focus, key affordances */
+  --accent-dim:    #80621a;   /* dimmed gold */
+  --accent-muted:  #2a1e06;   /* gold at low opacity */
+
+  /* --- Accent 2: Tron Cyan (neon electric) --- */
+  --cyan:          #00d4e8;   /* electric cyan — Tron primary glow */
+  --cyan-dim:      #007a8a;   /* dimmed cyan */
+  --cyan-muted:    #001e28;   /* cyan tint background */
+  --cyan-glow:     0 0 12px rgba(0,212,232,0.35), 0 0 4px rgba(0,212,232,0.5);
+
+  /* --- Vault: Neon green (digital growth) --- */
+  --vault:         #39e87d;   /* vault-connected — electric green */
+  --vault-dim:     #1a7840;   /* vault hover */
+  --vault-muted:   #041a10;   /* vault background tint */
+  --vault-glow:    0 0 8px rgba(57,232,125,0.3);
+
+  /* --- Agent: Electric blue (machine voice) --- */
+  --agent:         #4a9eff;   /* agent-contributed UI and content */
+  --agent-dim:     #1e5a9a;   /* agent hover */
+  --agent-muted:   #051228;   /* agent background tint */
+  --agent-glow:    0 0 8px rgba(74,158,255,0.3);
+
+  /* --- Amber (staged / uncommitted) --- */
+  --amber:         #f09030;   /* warnings, uncommitted/staged state */
+  --amber-dim:     #805010;
+  --amber-muted:   #1a0e02;
+
+  /* --- Destructive --- */
+  --destructive:      #ff3d3d;
+  --destructive-dim:  #8a1a1a;
+  --destructive-muted:#160404;
+
+  /* --- Semantic UI colors --- */
+  --color-bg:        var(--bg-base);
+  --color-surface:   var(--bg-surface);
+  --color-text:      var(--fg-1);
+  --color-muted:     var(--fg-2);
+  --color-dim:       var(--fg-3);
+  --color-border:    var(--border);
+  --color-accent:    var(--accent);
+
+  /* ============================================================
+     TYPOGRAPHY
+     ============================================================ */
+
+  /* --- Font families --- */
+  --font-display:  'EB Garamond', Georgia, serif;
+  --font-ui:       'Space Grotesk', system-ui, sans-serif;
+  --font-mono:     'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+
+  /* --- Type scale (rem, base 16px) --- */
+  --text-xs:    0.6875rem;   /* 11px — metadata, timestamps */
+  --text-sm:    0.8125rem;   /* 13px — secondary labels, captions */
+  --text-base:  0.9375rem;   /* 15px — body / default UI */
+  --text-md:    1.0625rem;   /* 17px — slightly emphasized body */
+  --text-lg:    1.1875rem;   /* 19px — section headers */
+  --text-xl:    1.5rem;      /* 24px — page titles */
+  --text-2xl:   2rem;        /* 32px — display moments */
+  --text-3xl:   2.75rem;     /* 44px — wordmark / hero */
+  --text-4xl:   3.75rem;     /* 60px — large display */
+
+  /* --- Line heights --- */
+  --leading-tight:  1.25;
+  --leading-snug:   1.4;
+  --leading-normal: 1.55;
+  --leading-loose:  1.75;
+
+  /* --- Font weights --- */
+  --weight-light:   300;
+  --weight-regular: 400;
+  --weight-medium:  500;
+  --weight-semibold:600;
+
+  /* --- Letter spacing --- */
+  --tracking-tight: -0.02em;
+  --tracking-normal: 0em;
+  --tracking-wide:   0.04em;
+  --tracking-wider:  0.08em;
+
+  /* ============================================================
+     SPACING
+     ============================================================ */
+  --space-1:   4px;
+  --space-2:   8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  20px;
+  --space-6:  24px;
+  --space-8:  32px;
+  --space-10: 40px;
+  --space-12: 48px;
+  --space-16: 64px;
+
+  /* ============================================================
+     BORDER RADIUS — sharper for cyberpunk aesthetic
+     ============================================================ */
+  --radius-sm:   2px;
+  --radius-md:   4px;
+  --radius-lg:   6px;
+  --radius-xl:  10px;
+  --radius-full: 9999px;
+
+  /* ============================================================
+     SHADOWS / ELEVATION
+     ============================================================ */
+  --shadow-sm:  0 1px 3px rgba(0,0,0,0.3);
+  --shadow-md:  0 4px 12px rgba(0,0,0,0.4);
+  --shadow-lg:  0 8px 32px rgba(0,0,0,0.5);
+  --shadow-float: 0 4px 24px rgba(0,0,0,0.55), 0 1px 4px rgba(0,0,0,0.3);
+  --shadow-inset: inset 0 1px 3px rgba(0,0,0,0.35);
+
+  /* ============================================================
+     ANIMATION
+     ============================================================ */
+  --ease:        cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-linear: linear;
+  --duration-fast: 100ms;
+  --duration-base: 150ms;
+  --duration-slow: 250ms;
+
+  /* ============================================================
+     Z-INDEX SCALE
+     ============================================================ */
+  --z-base:    1;
+  --z-raised:  10;
+  --z-sticky:  100;
+  --z-overlay: 200;
+  --z-modal:   300;
+  --z-toast:   400;
+}
+
+/* ============================================================
+   SEMANTIC ELEMENT DEFAULTS
+   ============================================================ */
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+body {
+  background-color: var(--bg-base);
+  color: var(--fg-1);
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-normal);
+}
+
+/* --- Display headings (EB Garamond) --- */
+h1, .h1 {
+  font-family: var(--font-display);
+  font-size: var(--text-3xl);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  color: var(--fg-1);
+}
+
+h2, .h2 {
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  color: var(--fg-1);
+}
+
+/* --- UI headings (DM Sans) --- */
+h3, .h3 {
+  font-family: var(--font-ui);
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-snug);
+  color: var(--fg-1);
+}
+
+h4, .h4 {
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-snug);
+  color: var(--fg-1);
+}
+
+h5, h6, .h5, .h6 {
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-snug);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--fg-2);
+}
+
+p {
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
+  color: var(--fg-1);
+  text-wrap: pretty;
+}
+
+small, .text-sm {
+  font-size: var(--text-sm);
+  color: var(--fg-2);
+}
+
+.text-xs {
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  font-family: var(--font-mono);
+  letter-spacing: var(--tracking-wide);
+}
+
+code, kbd, pre, .mono {
+  font-family: var(--font-mono);
+  font-size: 0.875em; /* relative to surrounding text */
+}
+
+code {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.1em 0.35em;
+  color: var(--fg-1);
+}
+
+pre {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  overflow-x: auto;
+  font-size: var(--text-sm);
+  line-height: var(--leading-normal);
+  color: var(--fg-1);
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+a:hover {
+  color: var(--fg-1);
+  text-decoration: underline;
+}
+
+hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: var(--space-6) 0;
+}
+
+/* ============================================================
+   UTILITY CLASSES
+   ============================================================ */
+
+/* Text colors */
+.text-primary   { color: var(--fg-1); }
+.text-secondary { color: var(--fg-2); }
+.text-dim       { color: var(--fg-3); }
+.text-accent    { color: var(--accent); }
+.text-cyan      { color: var(--cyan); }
+.text-vault     { color: var(--vault); }
+.text-agent     { color: var(--agent); }
+.text-amber     { color: var(--amber); }
+.text-danger    { color: var(--destructive); }
+
+/* Font families */
+.font-display { font-family: var(--font-display); }
+.font-ui      { font-family: var(--font-ui); }
+.font-mono    { font-family: var(--font-mono); }
+
+/* Weights */
+.weight-light    { font-weight: var(--weight-light); }
+.weight-regular  { font-weight: var(--weight-regular); }
+.weight-medium   { font-weight: var(--weight-medium); }
+.weight-semibold { font-weight: var(--weight-semibold); }
+
+/* Glow effects */
+.glow-cyan   { box-shadow: var(--cyan-glow); }
+.glow-vault  { box-shadow: var(--vault-glow); }
+.glow-agent  { box-shadow: var(--agent-glow); }
+.text-glow-cyan  { text-shadow: 0 0 12px rgba(0,212,232,0.7); }
+.text-glow-gold  { text-shadow: 0 0 16px rgba(212,168,67,0.5); }
+
+/* Tron grid background */
+.grid-bg {
+  background-image:
+    linear-gradient(rgba(0,212,232,0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0,212,232,0.04) 1px, transparent 1px);
+  background-size: 32px 32px;
+}
+
+/* Neon border active state */
+.border-cyan { border-color: var(--cyan) !important; box-shadow: var(--cyan-glow); }
+.border-gold { border-color: var(--accent) !important; box-shadow: 0 0 8px rgba(212,168,67,0.3); }
+
+/* Focus ring */
+:focus-visible {
+  outline: 1px solid var(--cyan);
+  outline-offset: 2px;
+  box-shadow: var(--cyan-glow);
+}

--- a/companion-ui/design_handoff/2026-05-14-claude-design-package/index.html
+++ b/companion-ui/design_handoff/2026-05-14-claude-design-package/index.html
@@ -1,0 +1,622 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Claude Design Package — 2026-05-14 — Yggdrasil Companion UI</title>
+<link rel="stylesheet" href="./colors_and_type.css" />
+<link rel="stylesheet" href="./spec_chrome.css" />
+<style>
+  /* ============================================================
+     LOCAL — index page
+     ============================================================ */
+  .pkg-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-5);
+    margin: var(--space-3) 0 var(--space-6);
+  }
+  @media (max-width: 900px) { .pkg-grid { grid-template-columns: 1fr; } }
+  .pkg {
+    border: 1px solid var(--border);
+    background: var(--bg-surface);
+    border-radius: var(--radius-md);
+    padding: var(--space-5);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    text-decoration: none;
+    color: var(--fg-1);
+    border-top: 2px solid var(--cyan);
+    transition: border-color var(--duration-fast) var(--ease), background var(--duration-fast) var(--ease);
+  }
+  .pkg:hover {
+    border-color: var(--cyan);
+    background: var(--bg-overlay);
+    text-decoration: none;
+  }
+  .pkg .num {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--cyan);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+  }
+  .pkg h3 {
+    font-family: var(--font-display);
+    font-size: var(--text-xl);
+    color: var(--fg-1);
+    font-weight: var(--weight-regular);
+    line-height: 1.15;
+    letter-spacing: 0;
+    text-transform: none;
+    margin: 0;
+  }
+  .pkg p {
+    font-size: var(--text-sm);
+    color: var(--fg-2);
+    line-height: 1.5;
+    margin: 0;
+  }
+  .pkg .meta-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 16px;
+    margin-top: auto;
+    padding-top: 10px;
+    border-top: 1px dashed var(--border);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    color: var(--fg-3);
+  }
+  .pkg .meta-row .v { color: var(--fg-2); }
+  .pkg .open {
+    align-self: flex-start;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--cyan);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+  }
+  .pkg.gold { border-top-color: var(--accent); }
+  .pkg.gold .num { color: var(--accent); }
+  .pkg.gold .open { color: var(--accent); }
+  .pkg.green { border-top-color: var(--vault); }
+  .pkg.green .num { color: var(--vault); }
+  .pkg.green .open { color: var(--vault); }
+  .pkg.agent { border-top-color: var(--agent); }
+  .pkg.agent .num { color: var(--agent); }
+  .pkg.agent .open { color: var(--agent); }
+
+  /* dependency diagram */
+  .deps {
+    border: 1px solid var(--border);
+    background: var(--bg-surface);
+    border-radius: var(--radius-md);
+    padding: var(--space-5);
+    margin: var(--space-3) 0 var(--space-6);
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: var(--space-3);
+  }
+  @media (max-width: 900px) { .deps { grid-template-columns: 1fr; } }
+  .dep-node {
+    border: 1px solid var(--border-strong);
+    background: var(--bg-base);
+    border-radius: var(--radius-sm);
+    padding: 12px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .dep-node .lbl {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    color: var(--fg-3);
+  }
+  .dep-node .name {
+    font-family: var(--font-ui);
+    font-size: var(--text-sm);
+    color: var(--fg-1);
+    line-height: 1.3;
+    font-weight: var(--weight-medium);
+  }
+  .dep-node .src {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--fg-2);
+    letter-spacing: var(--tracking-wide);
+    line-height: 1.4;
+  }
+  .dep-node.contract { border-color: rgba(212,168,67,0.4); }
+  .dep-node.contract .lbl { color: var(--accent); }
+  .dep-node.package  { border-color: rgba(0,212,232,0.4); }
+  .dep-node.package  .lbl { color: var(--cyan); }
+  .dep-node.future   { border-color: rgba(74,158,255,0.35); }
+  .dep-node.future   .lbl { color: var(--agent); }
+
+  /* summary stats */
+  .summary-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: var(--space-3);
+    margin: var(--space-3) 0 var(--space-5);
+  }
+  @media (max-width: 900px) { .summary-grid { grid-template-columns: 1fr 1fr; } }
+  .summary-cell {
+    border: 1px solid var(--border);
+    background: var(--bg-surface);
+    border-radius: var(--radius-sm);
+    padding: 12px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .summary-cell .n {
+    font-family: var(--font-display);
+    font-size: var(--text-2xl);
+    color: var(--fg-1);
+    line-height: 1;
+  }
+  .summary-cell .l {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+  }
+  .summary-cell.gold .n  { color: var(--accent); }
+  .summary-cell.cyan .n  { color: var(--cyan); }
+  .summary-cell.vault .n { color: var(--vault); }
+  .summary-cell.agent .n { color: var(--agent); }
+</style>
+</head>
+<body>
+<div class="page">
+
+  <nav class="toc" aria-label="Index sections">
+    <div class="toc-label">Index</div>
+    <ol>
+      <li><a href="#summary"><span class="toc-num">00</span>Executive summary</a></li>
+      <li><a href="#packages"><span class="toc-num">01</span>Five packages</a></li>
+      <li><a href="#intake"><span class="toc-num">02</span>Implementation Intake</a></li>
+      <li><a href="#dependencies"><span class="toc-num">03</span>Owner-doc dependencies</a></li>
+      <li><a href="#feeds"><span class="toc-num">04</span>What this feeds</a></li>
+      <li><a href="#open"><span class="toc-num">05</span>What remains open</a></li>
+      <li><a href="#how-to-read"><span class="toc-num">06</span>How to read this package</a></li>
+    </ol>
+  </nav>
+
+  <main>
+    <header class="doc-header">
+      <div class="doc-eyebrow">Companion UI · Claude Design package · 2026-05-14</div>
+      <h1 class="doc-title">Design handoff package — four explorations</h1>
+      <p class="doc-lede">
+        Five governed handoff packages produced under the new <em>handoff governance pack</em>
+        folder shape. Four UI surfaces — Runtime Proof Dashboard, Context Bundle Inspector,
+        Memory Candidate Review Queue, Vault Action Layer / Agent Tool Authority — plus the
+        meta-process pack that gates them. Every package is target-state visual guidance, not
+        architecture authority. Runtime truth lives downstream in shipped code, tests,
+        status docs, and validation receipts.
+      </p>
+      <div class="doc-meta">
+        <span><strong>Package count:</strong> 5</span>
+        <span><strong>Visual prototypes:</strong> 5 (.html)</span>
+        <span><strong>Markdown docs:</strong> 35 (7 per package)</span>
+        <span><strong>Crossing target:</strong> B (handoff → normalized spec)</span>
+      </div>
+    </header>
+
+    <!-- ============== 00 Executive summary ============== -->
+    <section class="spec" id="summary">
+      <h2><span class="secnum">00 ·</span>Executive summary</h2>
+
+      <div class="summary-grid">
+        <div class="summary-cell gold"><span class="n">5</span><span class="l">Packages</span></div>
+        <div class="summary-cell cyan"><span class="n">45</span><span class="l">UI states designed</span></div>
+        <div class="summary-cell vault"><span class="n">35</span><span class="l">Handoff docs</span></div>
+        <div class="summary-cell agent"><span class="n">0</span><span class="l">Runtime claims</span></div>
+      </div>
+
+      <h3>What was designed</h3>
+      <p>
+        Five target-state design packages, each conforming to the folder shape declared by
+        the Handoff Governance Pack (package 1 in this set). Each package contains a visual
+        prototype, a complete state gallery, an implementation contract, an
+        authority-boundaries document, a text-mirror state gallery, an edge-state checklist,
+        and an open-questions log.
+      </p>
+
+      <h3>What this package is not</h3>
+      <ul>
+        <li>Not a runtime claim. The Runtime Proof Dashboard renders a snapshot the runtime
+          would emit; it does not assert that snapshot exists today.</li>
+        <li>Not a schema. The Context Bundle Inspector renders the bundle contract; it does not
+          modify it.</li>
+        <li>Not a memory store. The Memory Candidate Review Queue reviews proposals; it does not
+          recall, infer, or promote on its own.</li>
+        <li>Not a control plane. The dashboard mirrors; remediation routes through the existing
+          governed pipeline.</li>
+      </ul>
+
+      <h3>Posture across all four</h3>
+      <ul>
+        <li><strong>Sober.</strong> No alarm dashboards. Red is reserved for actual refusals.</li>
+        <li><strong>Evidence-bearing.</strong> Every mono caption corresponds to a runtime value
+          (or names itself as an inferred default that owner-docs would amend).</li>
+        <li><strong>Progressive disclosure.</strong> Exclusions, low-trust items, receipt history,
+          and conflict resolution are all one click away rather than always-on.</li>
+        <li><strong>Authority-aware.</strong> Authority flags are first-class headers; the UI
+          renders the bundle / candidate / proposal class as declared and never re-classifies.</li>
+        <li><strong>Calm.</strong> One animation pattern (receipt pulse + banner LED), respected
+          by <code>prefers-reduced-motion</code>. No emoji. Static stability across states.</li>
+      </ul>
+    </section>
+
+    <!-- ============== 01 Packages ============== -->
+    <section class="spec" id="packages">
+      <h2><span class="secnum">01 ·</span>Five packages</h2>
+      <p class="lede">
+        Click into any prototype HTML for the full spec, state gallery, and implementation
+        contract. The four packages are independently reviewable; package 1 governs the process
+        the others were produced under.
+      </p>
+
+      <div class="pkg-grid">
+        <a class="pkg gold" href="../2026-05-14-handoff-governance-pack/prototype.html">
+          <span class="num">01 · Meta-process pack</span>
+          <h3>Design Handoff Governance Pack</h3>
+          <p>How a Claude Design exploration becomes a governed implementation input — without
+            becoming architecture authority on the way. Defines the chain
+            <em>exploration → handoff → normalized spec → issue → PR → receipt</em>, the
+            maturity bar at crossing B, three templates, and a target-shape review console.</p>
+          <div class="meta-row">
+            <span><span class="v">authority</span> · process pattern</span>
+            <span><span class="v">owner-doc</span> · INTERACTION_SURFACES_AND_AUTHORITY</span>
+            <span><span class="v">crossing</span> · B</span>
+          </div>
+          <span class="open">Open prototype →</span>
+        </a>
+
+        <a class="pkg green" href="../2026-05-14-runtime-proof-dashboard/prototype.html">
+          <span class="num">02 · Operator surface</span>
+          <h3>Runtime Proof / Health Dashboard</h3>
+          <p>Compact single-operator proof surface. Nine questions, eight cards, a proof-receipt
+            panel, and a suggested-next-action strip. Mirror of runtime state, never a control
+            plane. Nine designed states from healthy to proof-failed.</p>
+          <div class="meta-row">
+            <span><span class="v">authority</span> · visual guidance</span>
+            <span><span class="v">depends on</span> · runtime-proof receipt contract</span>
+            <span><span class="v">states</span> · 9</span>
+          </div>
+          <span class="open">Open prototype →</span>
+        </a>
+
+        <a class="pkg" href="../2026-05-14-context-bundle-inspector/prototype.html">
+          <span class="num">03 · Inspector surface</span>
+          <h3>Context Bundle Inspector</h3>
+          <p>Inspectable bridge object between retrieval, orientation, resurfacing, and write
+            proposals. Authority flags are first-class header chips. Excluded artifacts are
+            surfaced when they affect interpretation. Desktop + portrait. Nine states.</p>
+          <div class="meta-row">
+            <span><span class="v">authority</span> · visual guidance</span>
+            <span><span class="v">owner-doc</span> · CONTEXT_BUNDLE_CONTRACT</span>
+            <span><span class="v">states</span> · 9</span>
+          </div>
+          <span class="open">Open prototype →</span>
+        </a>
+
+        <a class="pkg agent" href="../2026-05-14-memory-candidate-review/prototype.html">
+          <span class="num">04 · Review surface</span>
+          <h3>Memory Candidate Review Queue</h3>
+          <p>Quiet, pull-based review queue for proposed agent memories. Seven memory classes;
+            eight actions including promote-to-note and keep-operational-only. Conflict UI
+            shows prior memory side-by-side. Ten states. Never an inbox.</p>
+          <div class="meta-row">
+            <span><span class="v">authority</span> · review surface</span>
+            <span><span class="v">owner-doc</span> · AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT</span>
+            <span><span class="v">states</span> · 10</span>
+          </div>
+          <span class="open">Open prototype →</span>
+        </a>
+
+        <a class="pkg" href="../2026-05-14-vault-action-layer/prototype.html" style="border-top-color: var(--agent);">
+          <span class="num" style="color: var(--agent);">05 · Authority surface</span>
+          <h3>Vault Action Layer / Agent Tool Authority</h3>
+          <p>9-step action pipeline (intent → classify → bound → policy → guard →
+            idempotency → execute → receipt → event), 5-tier tool taxonomy, Obsidian/MCP-as-adapter
+            boundary, concrete first action <code style="font-size:0.9em;">move_inbox_note_to_workbench</code>.
+            Eight states.</p>
+          <div class="meta-row">
+            <span><span class="v">authority</span> · structural + visual</span>
+            <span><span class="v">linked issue</span> · #910</span>
+            <span><span class="v">states</span> · 8</span>
+          </div>
+          <span class="open" style="color: var(--agent);">Open prototype →</span>
+        </a>
+      </div>
+
+      <div class="callout invariant">
+        <span class="callout-label">Floor invariant across all five</span>
+        Design exploration is not architecture authority. Visual guidance is not runtime
+        behavior. Architecture authority remains in repo owner-docs and contracts. Runtime
+        truth remains in shipped code, tests, status docs, and validation receipts.
+      </div>
+    </section>
+
+    <!-- ============== 02 Implementation Intake ============== -->
+    <section class="spec" id="intake">
+      <h2><span class="secnum">02 ·</span>Implementation Intake Summary</h2>
+      <p class="lede">
+        One table mapping each design artifact to its repo issues, the implementation it may
+        feed, what it must not directly become, its architecture dependencies, and its open
+        questions. The full canonical version lives in <code>README.md</code>; this is the
+        in-page form.
+      </p>
+
+      <table class="spec">
+        <thead>
+          <tr>
+            <th>Artifact</th>
+            <th>Issues</th>
+            <th>May be implemented</th>
+            <th>Must not be implemented directly</th>
+            <th>Architecture dependencies</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>01 · Handoff Governance Pack</strong></td>
+            <td><code>#901</code></td>
+            <td>Folder shape adoption; static review console rendered from the folder; maturity-checklist front-matter on existing READMEs.</td>
+            <td>A runtime review service. New authority over owner-docs. Blocking PR gate.</td>
+            <td><code>INTERACTION_SURFACES_AND_AUTHORITY/</code> (read-only)</td>
+          </tr>
+          <tr>
+            <td><strong>02 · Runtime Proof / Health Dashboard</strong></td>
+            <td><code>#865</code>, <code>#866</code>, <code>#850</code> + stabilization issues</td>
+            <td>UI render against nine fixture snapshots; receipt-link disclosures; reduced-motion path; narrow layout.</td>
+            <td>Auto-remediation. UI-derived posture. Dashboard-as-control-plane direction. Ops-style alerts.</td>
+            <td><code>STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md</code>; future runtime-proof receipt contract</td>
+          </tr>
+          <tr>
+            <td><strong>03 · Context Bundle Inspector</strong></td>
+            <td><code>#894</code>, <code>#895</code>, <code>#896</code></td>
+            <td>UI render against three fixture bundles + six fail-state fixtures; compact-mode embedding; ranked-candidate column.</td>
+            <td>Re-ranking. Apply / writeback affordance. Memory promotion. Bundle schema modification.</td>
+            <td><code>docs/CONCEPTS/CONTEXT_BUNDLE_CONTRACT.md</code> (read-only)</td>
+          </tr>
+          <tr>
+            <td><strong>04 · Memory Candidate Review Queue</strong></td>
+            <td><code>#900</code></td>
+            <td>UI render against ten fixture candidates; seven primary actions; conflict UI; promote-to-note path; auto-archive policy.</td>
+            <td>Auto-accept rules. A recall surface. Memory class definition. Semantic-search across past memories. Shell-level notifications.</td>
+            <td><code>docs/CONCEPTS/AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT.md</code> (read-only)</td>
+          </tr>
+          <tr>
+            <td><strong>05 · Vault Action Layer</strong></td>
+            <td><code>#910</code> + future tool-authority docs issue</td>
+            <td>First bounded action <code>move_inbox_note_to_workbench</code>; Tier-4 forbidden list as owner-doc; registry-write path; Obsidian adapter; MCP-exposed surface limited to registry names.</td>
+            <td>Generic "agent tools" library decoupled from registry. Obsidian/MCP as primary mutation. Runtime tier-elevation. Silent failure.</td>
+            <td>New owner-doc to author (<code>VAULT_ACTION_LAYER_CONTRACT.md</code>); references <code>STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md</code></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p style="font-family:var(--font-mono); font-size:var(--text-xs); color:var(--fg-3); letter-spacing:var(--tracking-wide); margin-top:var(--space-3);">
+        Open questions per artifact — see <code>README.md</code> for the full column, and
+        each package's <code>open-questions.md</code> for the structured form.
+      </p>
+    </section>
+
+    <!-- ============== 03 Dependencies ============== -->
+    <section class="spec" id="dependencies">
+      <h2><span class="secnum">03 ·</span>Owner-doc dependencies</h2>
+      <p class="lede">
+        What each package depends on, what it does not own, and what it would feed if normalized.
+        These are read-only dependencies — none of the four packages amends an owner-doc.
+      </p>
+
+      <div class="deps">
+        <div class="dep-node contract">
+          <span class="lbl">Authority contract</span>
+          <span class="name">INTERACTION_SURFACES_AND_AUTHORITY</span>
+          <span class="src">read-only · feeds: package 1 (governance pack), packages 2–4 (gated-execution invariant)</span>
+        </div>
+        <div class="dep-node contract">
+          <span class="lbl">Authority contract</span>
+          <span class="name">CONTEXT_BUNDLE_CONTRACT</span>
+          <span class="src">read-only · feeds: package 3 (inspector schema)</span>
+        </div>
+        <div class="dep-node contract">
+          <span class="lbl">Authority contract</span>
+          <span class="name">AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT</span>
+          <span class="src">read-only · feeds: package 4 (queue lifecycle, classes, authority flags)</span>
+        </div>
+        <div class="dep-node contract">
+          <span class="lbl">Invariant</span>
+          <span class="name">STATE_EXECUTION_AUTHORITY_REMAINS_GATED</span>
+          <span class="src">read-only · honored by all four packages without modification</span>
+        </div>
+        <div class="dep-node contract">
+          <span class="lbl">UI boundary</span>
+          <span class="name">UI_RUNTIME_BOUNDARIES.md</span>
+          <span class="src">read-only · referenced for separation of cognition / UI runtime / persistence</span>
+        </div>
+        <div class="dep-node future">
+          <span class="lbl">Future contract</span>
+          <span class="name">runtime-proof receipt contract</span>
+          <span class="src">when normalized · feeds: package 2 (dashboard snapshot &amp; receipt rendering)</span>
+        </div>
+        <div class="dep-node future">
+          <span class="lbl">Future contract</span>
+          <span class="name">VAULT_ACTION_LAYER_CONTRACT</span>
+          <span class="src">to be authored from package 5 · references existing invariants; modifies none</span>
+        </div>
+      </div>
+
+      <h3>What this package set does not own</h3>
+      <ul>
+        <li>The bundle schema, the memory record schema, the runtime-proof receipt schema.</li>
+        <li>The retrieval ranking algorithm.</li>
+        <li>The classifier that decides body-edit vs governance-bearing proposals.</li>
+        <li>The runtime's posture algorithm.</li>
+        <li>The governance pipeline behavior.</li>
+      </ul>
+    </section>
+
+    <!-- ============== 04 Feeds ============== -->
+    <section class="spec" id="feeds">
+      <h2><span class="secnum">04 ·</span>What this feeds</h2>
+      <p class="lede">If accepted at crossing B, each package proposes a normalized spec path and a small set of follow-on issues. Promotion decisions are owner-doc owners' to make.</p>
+
+      <table class="spec">
+        <thead>
+          <tr><th>Package</th><th>Proposed normalized spec</th><th>First implementation issue</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>01 · Handoff Governance Pack</td>
+            <td><code>docs/INTERACTION_SURFACES_AND_AUTHORITY/DESIGN_HANDOFF_GOVERNANCE.md</code></td>
+            <td>Adopt the folder shape across existing <code>companion-ui/design_handoff/</code> packages.</td>
+          </tr>
+          <tr>
+            <td>02 · Runtime Proof Dashboard</td>
+            <td><code>docs/RUNTIME_PROOF_DASHBOARD.md</code> (UI guidance, target-state)</td>
+            <td>Render the dashboard against nine fixture snapshots (one per designed state).</td>
+          </tr>
+          <tr>
+            <td>03 · Context Bundle Inspector</td>
+            <td><code>docs/CONCEPTS/CONTEXT_BUNDLE_INSPECTOR_UI.md</code> (UI guidance only)</td>
+            <td>Render the inspector against three fixture bundles (retrieval, orientation, write proposal).</td>
+          </tr>
+          <tr>
+            <td>04 · Memory Candidate Review</td>
+            <td><code>docs/CONCEPTS/MEMORY_CANDIDATE_REVIEW_UI.md</code> (UI guidance only)</td>
+            <td>Render the queue against ten fixture candidates; wire seven primary actions.</td>
+          </tr>
+          <tr>
+            <td>05 · Vault Action Layer</td>
+            <td><code>docs/CONCEPTS/VAULT_ACTION_LAYER_CONTRACT.md</code> (new owner-doc)</td>
+            <td>Register first bounded action <code>move_inbox_note_to_workbench@v1</code>; full pipeline against fixture vault.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Validation expectations</h3>
+      <p>Each package's <code>implementation-contracts.md</code> names the passing-receipt
+        shape. Across all four:</p>
+      <ul>
+        <li>Every designed state renders correctly from a fixture.</li>
+        <li>Every declared intent emits the right effect (UI-local / read-only / governed).</li>
+        <li>No UI-derived posture, class, authority, or classification.</li>
+        <li><code>prefers-reduced-motion</code> respected.</li>
+        <li>Narrow / portrait layout passes the breakpoint acceptance.</li>
+      </ul>
+    </section>
+
+    <!-- ============== 05 Open ============== -->
+    <section class="spec" id="open">
+      <h2><span class="secnum">05 ·</span>What remains open</h2>
+      <p class="lede">
+        Cross-package open questions. Per-package open questions live in each prototype's §09
+        and the sibling <code>open-questions.md</code>.
+      </p>
+
+      <ol>
+        <li><strong>Where does the review console actually live?</strong> Package 1's review
+          console is target-shape. The recommendation is a static HTML rendered from the
+          folder, not a runtime surface.</li>
+        <li><strong>Do the four packages need a shared "validation receipt" schema?</strong>
+          Each implementation issue produces one. Suggest: a common receipt shape with
+          per-package extension fields. Owner-doc decides.</li>
+        <li><strong>How does the dashboard's "Run proof" interact with package 1's chain?</strong>
+          Should a passing proof on package 2's implementation auto-link back to its package
+          status? Recommended yes; that closes the loop between handoff and runtime truth.</li>
+        <li><strong>Conditional authority flags.</strong> Package 3 (bundle inspector) renders
+          <code>may_propose · conditional</code>; package 4 (memory queue) renders
+          <code>may_recall · maybe</code>. Owner-doc should normalize whether "conditional" is
+          a valid flag state and what it means at each surface.</li>
+        <li><strong>Cross-links between bundle inspector and memory queue.</strong> When a
+          bundle includes a memory candidate, should the inspector deep-link into the queue
+          card? Suggest yes, one-click, no data dependency.</li>
+        <li><strong>Notification quietness.</strong> Packages 2 and 4 both decline to add a
+          badge / counter by default. If the team wants a single quiet indicator anywhere in
+          the shell, owner-doc should decide where (suggest: nowhere; the surfaces are pull).</li>
+      </ol>
+    </section>
+
+    <!-- ============== 06 How to read ============== -->
+    <section class="spec" id="how-to-read">
+      <h2><span class="secnum">06 ·</span>How to read this package</h2>
+
+      <h3>For a reviewer at crossing B</h3>
+      <ol>
+        <li>Read this index, particularly the <a href="#intake">Implementation Intake</a> table.</li>
+        <li>Open each <code>prototype.html</code> and skim §01 (context &amp; boundary) and the
+          state gallery section of each.</li>
+        <li>Walk the maturity checklist in package 1 §03 against each of packages 2–5.</li>
+        <li>Triage each open-questions section into block / cite / defer.</li>
+      </ol>
+
+      <h3>For a Claude Code / Codex agent picking up implementation</h3>
+      <ol>
+        <li>Read the package's <code>README.md</code>.</li>
+        <li>Read the package's <code>implementation-contracts.md</code> — this is the only
+          document that promises anything to code.</li>
+        <li>Open <code>prototype.html</code>, jump to §07 (Implementation contract) and §10
+          (Handoff notes for Claude Code / Codex).</li>
+        <li>Use the state gallery (<code>prototype.html</code> §05) and <code>state-gallery.md</code>
+          to enumerate fixtures.</li>
+      </ol>
+
+      <h3>For an owner-doc reviewer</h3>
+      <ol>
+        <li>Read the package's <code>authority-boundaries.md</code> — this names exactly what
+          the design <em>may</em> influence in your doc and what it <em>may not</em> decide.</li>
+        <li>Read the package's <code>open-questions.md</code> — your doc may be the proposed
+          owner for one or more questions.</li>
+        <li>Read <code>prototype.html</code> §08 (Authority boundaries) for the structured
+          table.</li>
+      </ol>
+
+      <h3>Folder shape</h3>
+      <pre class="code">companion-ui/design_handoff/
+  2026-05-14-claude-design-package/    <span class="c">← this index</span>
+    index.html                         <span class="c">← you are here</span>
+    README.md                          <span class="c">← Implementation Intake Summary</span>
+    CHANGELOG.md                       <span class="c">← v1 → v2 diff</span>
+
+  2026-05-14-handoff-governance-pack/  <span class="c">← package 1 · meta-process</span>
+    README.md
+    prototype.html                     <span class="c">← rich content</span>
+    design-notes.md
+    state-gallery.md
+    implementation-contracts.md
+    authority-boundaries.md
+    edge-states.md
+    open-questions.md
+    colors_and_type.css                <span class="c">← shared with siblings</span>
+    spec_chrome.css
+
+  2026-05-14-runtime-proof-dashboard/  <span class="c">← package 2</span>
+    <span class="c">… same folder shape …</span>
+
+  2026-05-14-context-bundle-inspector/ <span class="c">← package 3</span>
+    <span class="c">… same folder shape …</span>
+
+  2026-05-14-memory-candidate-review/  <span class="c">← package 4</span>
+    <span class="c">… same folder shape …</span>
+
+  2026-05-14-vault-action-layer/       <span class="c">← package 5 · v2 refinement</span>
+    <span class="c">… same folder shape …</span></pre>
+    </section>
+
+  </main>
+</div>
+</body>
+</html>

--- a/companion-ui/design_handoff/2026-05-14-claude-design-package/spec_chrome.css
+++ b/companion-ui/design_handoff/2026-05-14-claude-design-package/spec_chrome.css
@@ -1,0 +1,423 @@
+/* ============================================================
+   Yggdrasil Design Handoff — Shared Spec Chrome
+   ============================================================
+   Page layout, TOC, sections, tables, callouts, chips, code,
+   gallery cards. Imported by each prototype.html after
+   colors_and_type.css.
+   ============================================================ */
+
+html, body { background: var(--bg-base); }
+body {
+  background-image:
+    linear-gradient(rgba(0,212,232,0.022) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0,212,232,0.022) 1px, transparent 1px);
+  background-size: 48px 48px;
+}
+
+.page {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: var(--space-12) var(--space-8) var(--space-16);
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: var(--space-12);
+}
+
+/* ---- Sidebar TOC ---- */
+.toc {
+  position: sticky;
+  top: var(--space-8);
+  align-self: start;
+  font-size: var(--text-sm);
+  border-left: 1px solid var(--border);
+  padding-left: var(--space-4);
+  max-height: calc(100vh - var(--space-12));
+  overflow-y: auto;
+}
+.toc-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  margin-bottom: var(--space-3);
+}
+.toc ol { list-style: none; display: flex; flex-direction: column; gap: 6px; }
+.toc a {
+  color: var(--fg-2);
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  display: block;
+  line-height: 1.4;
+}
+.toc a:hover { color: var(--cyan); text-decoration: none; }
+.toc-num {
+  font-family: var(--font-mono);
+  color: var(--fg-3);
+  margin-right: 6px;
+  font-size: var(--text-xs);
+}
+
+/* ---- Header ---- */
+.doc-header {
+  border-bottom: 1px solid var(--border);
+  padding-bottom: var(--space-6);
+  margin-bottom: var(--space-10);
+}
+.doc-eyebrow {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--cyan);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  margin-bottom: var(--space-3);
+}
+.doc-title {
+  font-family: var(--font-display);
+  font-size: var(--text-3xl);
+  line-height: 1.1;
+  margin-bottom: var(--space-4);
+  color: var(--fg-1);
+}
+.doc-lede {
+  color: var(--fg-2);
+  font-size: var(--text-md);
+  max-width: 70ch;
+  margin-bottom: var(--space-5);
+  line-height: var(--leading-snug);
+}
+.doc-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4) var(--space-6);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+}
+.doc-meta span strong {
+  color: var(--fg-2);
+  font-weight: var(--weight-regular);
+  margin-right: 6px;
+}
+
+/* ---- Sections ---- */
+section.spec {
+  margin-bottom: var(--space-12);
+  scroll-margin-top: var(--space-6);
+}
+section.spec > h2 {
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-regular);
+  color: var(--fg-1);
+  margin-bottom: var(--space-2);
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+}
+section.spec > h2 .secnum {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--cyan);
+  letter-spacing: var(--tracking-wide);
+}
+section.spec > .lede {
+  color: var(--fg-2);
+  font-size: var(--text-base);
+  margin-bottom: var(--space-5);
+  max-width: 72ch;
+}
+section.spec h3 {
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--fg-1);
+  margin: var(--space-6) 0 var(--space-3);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+}
+section.spec p {
+  color: var(--fg-1);
+  margin-bottom: var(--space-3);
+  max-width: 72ch;
+}
+section.spec ul, section.spec ol {
+  color: var(--fg-1);
+  margin: 0 0 var(--space-4) var(--space-5);
+  max-width: 72ch;
+}
+section.spec li { margin-bottom: 6px; line-height: 1.55; }
+
+/* ---- Tables ---- */
+table.spec {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+  margin: var(--space-3) 0 var(--space-5);
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+}
+table.spec th, table.spec td {
+  text-align: left;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+table.spec th {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--fg-2);
+  background: var(--bg-raised);
+  font-weight: var(--weight-medium);
+  border-bottom: 1px solid var(--border-strong);
+}
+table.spec tr:last-child td { border-bottom: none; }
+table.spec td code { font-size: 0.9em; }
+table.spec td.mono, table.spec th.mono { font-family: var(--font-mono); }
+table.spec td.yes { color: var(--vault); font-family: var(--font-mono); font-size: var(--text-xs); }
+table.spec td.no { color: var(--destructive); font-family: var(--font-mono); font-size: var(--text-xs); }
+table.spec td.maybe { color: var(--amber); font-family: var(--font-mono); font-size: var(--text-xs); }
+
+/* ---- Callouts ---- */
+.callout {
+  border-left: 2px solid var(--cyan);
+  background: rgba(0,212,232,0.04);
+  padding: var(--space-3) var(--space-4);
+  margin: var(--space-4) 0;
+  font-size: var(--text-sm);
+  color: var(--fg-1);
+  max-width: 72ch;
+}
+.callout.warn { border-left-color: var(--amber); background: rgba(240,144,48,0.05); }
+.callout.invariant { border-left-color: var(--accent); background: rgba(212,168,67,0.04); }
+.callout.danger { border-left-color: var(--destructive); background: rgba(255,61,61,0.04); }
+.callout.vault { border-left-color: var(--vault); background: rgba(57,232,125,0.04); }
+.callout-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--cyan);
+  display: block;
+  margin-bottom: 4px;
+}
+.callout.warn .callout-label { color: var(--amber); }
+.callout.invariant .callout-label { color: var(--accent); }
+.callout.danger .callout-label { color: var(--destructive); }
+.callout.vault .callout-label { color: var(--vault); }
+
+/* ---- Tag chips ---- */
+.chip {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wide);
+  padding: 1px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-raised);
+  color: var(--fg-2);
+}
+.chip.design  { color: var(--cyan); border-color: rgba(0,212,232,0.3); }
+.chip.impl    { color: var(--accent); border-color: rgba(212,168,67,0.3); }
+.chip.gated   { color: var(--amber); border-color: rgba(240,144,48,0.3); }
+.chip.agent   { color: var(--agent); border-color: rgba(74,158,255,0.3); }
+.chip.vault   { color: var(--vault); border-color: rgba(57,232,125,0.3); }
+.chip.danger  { color: var(--destructive); border-color: rgba(255,61,61,0.3); }
+
+/* ---- Code blocks ---- */
+pre.code {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--fg-1);
+  overflow-x: auto;
+  margin: var(--space-3) 0 var(--space-5);
+  line-height: 1.55;
+}
+pre.code .k { color: var(--cyan); }
+pre.code .s { color: var(--vault); }
+pre.code .c { color: var(--fg-3); font-style: italic; }
+pre.code .n { color: var(--accent); }
+pre.code .a { color: var(--agent); }
+
+/* ---- Gallery ---- */
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--space-5);
+  margin: var(--space-4) 0 var(--space-6);
+}
+.gallery.three { grid-template-columns: repeat(3, 1fr); }
+.gallery-card {
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  min-height: 240px;
+}
+.gallery-card header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  border-bottom: 1px dashed var(--border);
+  padding-bottom: 10px;
+}
+.gallery-card h4 {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--fg-2);
+}
+.gallery-card .note {
+  font-size: var(--text-sm);
+  color: var(--fg-2);
+  margin: 0;
+}
+
+/* ---- Receipt pill ---- */
+.receipt {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  border-radius: var(--radius-full);
+  background: var(--bg-raised);
+  border: 1px solid var(--border-strong);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-2);
+  letter-spacing: var(--tracking-wide);
+}
+.receipt.queued  { color: var(--accent); border-color: rgba(212,168,67,0.4); }
+.receipt.applied { color: var(--vault); border-color: rgba(57,232,125,0.4); }
+.receipt.pending { color: var(--amber); border-color: rgba(240,144,48,0.4); }
+.receipt.failed  { color: var(--destructive); border-color: rgba(255,61,61,0.4); }
+.receipt .recdot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 6px currentColor;
+}
+.receipt.queued .recdot { animation: pulse 1.6s ease-in-out infinite; }
+.receipt.pending .recdot { animation: pulse 1.6s ease-in-out infinite; }
+@keyframes pulse { 0%, 100% { opacity: 0.4; } 50% { opacity: 1; } }
+
+/* ---- Buttons ---- */
+.btn {
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  padding: 5px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-raised);
+  color: var(--fg-1);
+  border: 1px solid var(--border-strong);
+  cursor: pointer;
+}
+.btn:hover { border-color: var(--cyan); color: var(--cyan); }
+.btn.primary {
+  background: var(--amber-muted);
+  color: var(--amber);
+  border-color: rgba(240,144,48,0.5);
+}
+.btn.primary:hover { background: rgba(240,144,48,0.12); border-color: var(--amber); color: var(--amber); }
+.btn.governance {
+  background: rgba(212,168,67,0.06);
+  color: var(--accent);
+  border-color: rgba(212,168,67,0.5);
+}
+.btn.governance:hover { background: rgba(212,168,67,0.12); border-color: var(--accent); }
+.btn.vault {
+  background: rgba(57,232,125,0.06);
+  color: var(--vault);
+  border-color: rgba(57,232,125,0.4);
+}
+.btn.vault:hover { background: rgba(57,232,125,0.12); border-color: var(--vault); }
+.btn.danger {
+  background: rgba(255,61,61,0.05);
+  color: var(--destructive);
+  border-color: rgba(255,61,61,0.4);
+}
+.btn.ghost { background: transparent; }
+.btn[disabled], .btn.disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.btn .kbd {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  color: var(--fg-3);
+  margin-left: 6px;
+}
+
+/* ---- Bullet list with mono prefix (for checklists) ---- */
+ul.check {
+  list-style: none;
+  margin-left: 0 !important;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+ul.check li {
+  position: relative;
+  padding-left: 22px;
+  font-size: var(--text-sm);
+}
+ul.check li::before {
+  content: '[ ]';
+  position: absolute;
+  left: 0;
+  top: 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  letter-spacing: 0;
+}
+ul.check li.done::before { content: '[x]'; color: var(--vault); }
+ul.check li.skip::before { content: '[-]'; color: var(--amber); }
+
+/* ---- Doc-template card (for handoff templates) ---- */
+.template {
+  border: 1px solid var(--border-strong);
+  background: var(--bg-surface);
+  border-radius: var(--radius-md);
+  padding: var(--space-4) var(--space-5);
+  margin: var(--space-4) 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--fg-1);
+  white-space: pre-wrap;
+  line-height: 1.65;
+  overflow-x: auto;
+}
+.template .h { color: var(--cyan); }
+.template .v { color: var(--vault); }
+.template .g { color: var(--accent); }
+.template .c { color: var(--fg-3); font-style: italic; }
+.template .a { color: var(--agent); }
+
+/* ---- Responsive ---- */
+@media (max-width: 900px) {
+  .page { grid-template-columns: 1fr; padding: var(--space-6) var(--space-4); }
+  .toc {
+    position: static;
+    max-height: none;
+    border-left: none;
+    border-bottom: 1px solid var(--border);
+    padding: 0 0 var(--space-4);
+  }
+  .gallery, .gallery.three { grid-template-columns: 1fr; }
+}

--- a/companion-ui/design_handoff/2026-05-14-context-bundle-inspector/README.md
+++ b/companion-ui/design_handoff/2026-05-14-context-bundle-inspector/README.md
@@ -1,0 +1,48 @@
+# Context Bundle Inspector
+
+**Date:** 2026-05-14
+**Status:** Design handoff · v1 · ready for review at crossing B
+**Authority:** Visual guidance only — bundle schema not owned here
+**Owner-docs:** docs/CONCEPTS/CONTEXT_BUNDLE_CONTRACT.md, docs/INTERACTION_SURFACES_AND_AUTHORITY/
+**Crossing target:** B
+
+## What this is
+
+Inspector surface for the bundle bridge object — included artifacts, excluded artifacts, authority flags, receipts. Desktop + portrait. The bundle is the bridge object between retrieval, orientation, resurfacing, and write proposals; the inspector exposes it for human review.
+
+Nine designed states:
+
+1. Retrieval bundle (answering a question)
+2. Orientation bundle (where was I)
+3. Resurfacing bundle with "why now"
+4. Write-proposal bundle (authority flags differ)
+5. Stale bundle warning
+6. Excluded source visible because exclusion affects interpretation
+7. Degraded bundle (provenance incomplete)
+8. Empty (no sufficient context)
+9. Blocked (context exists but cannot support write proposal)
+
+See `prototype.html` §02 for the field model, §03 for the inspector prototype, §04 for the portrait layout, §05 for the 9-state gallery.
+
+## Influence
+
+- **May influence:** field grouping, authority-chip wording, staleness presentation, exclusion-visibility default, narrow layout, dominant-role colour cues.
+- **May not decide:** the bundle schema, the authority-flag set, expiry policy, the retrieval ranking, the apply / writeback flow.
+
+## Files
+
+- `prototype.html` — 10-section spec, inspector mock, portrait layout, 9-state gallery.
+- Sibling markdown docs per the handoff governance pack's folder shape.
+
+## Related
+
+- `docs/CONCEPTS/CONTEXT_BUNDLE_CONTRACT.md` — the bundle contract this inspector renders.
+- The Memory Candidate Review queue (sibling) — bundles may include memory items; promotion lives there, never here.
+- The Canvas Suggestion Flow handoff — context bundles attach to canvas proposals.
+
+## Authority &amp; disclaimers
+
+- **This design is visual guidance.** It is not architecture authority. Architecture authority lives in repo owner-docs.
+- **Runtime truth lives downstream.** It is not asserted in this package. Runtime truth comes from shipped code, tests, status docs, and validation receipts.
+- **This package proposes; it does not promote.** Promotion happens at crossing B (the maturity bar in the governance pack §03).
+- **The gated-execution invariant is honored throughout.** No interaction surface in this design mutates durable state outside the governed pipeline.

--- a/companion-ui/design_handoff/2026-05-14-context-bundle-inspector/authority-boundaries.md
+++ b/companion-ui/design_handoff/2026-05-14-context-bundle-inspector/authority-boundaries.md
@@ -1,0 +1,45 @@
+# Authority boundaries — Context Bundle Inspector
+
+## This design is
+
+- **Visual guidance** for the surface(s) named in this package's README.
+- **An interaction contract** limited to the fields, intents, and data attributes enumerated
+  in `implementation-contracts.md` and in `prototype.html` §07.
+- **A target-state proposal** until a normalized spec lands in owner-docs.
+
+## This design is not
+
+- **Architecture authority.** Authority lives in:
+  - `docs/CONCEPTS/CONTEXT_BUNDLE_CONTRACT.md`
+  - `docs/INTERACTION_SURFACES_AND_AUTHORITY/`
+- **Runtime truth.** Runtime truth lives in shipped code, tests, status docs, and validation
+  receipts.
+- **A schema.** This contract references fields the runtime exposes; it does not declare them.
+- **A claim about current runtime behavior** unless explicitly cited from owner-docs.
+
+## Invariants this design honors
+
+- **Gated execution.** No interaction surface in this design mutates durable state outside
+  the existing governed path: policy, validation, event pipeline, deterministic writer.
+- **Authority separation.** Chat is a canvas surface; Panel is the command surface;
+  Automation is its own lane. This design does not collapse them.
+- **Provenance visibility.** Where this design shows agent-contributed content, it shows
+  source, trust state, and authority flags.
+- **Bundle integrity.** Where this design shows context selection, it shows what was excluded
+  when exclusion affects interpretation.
+- **Memory candidacy.** Where this design touches agent memory, it never treats candidate
+  memory as semantic authority.
+
+## What this design may suggest to owner-docs
+
+See `prototype.html` §10 ("Handoff notes for Claude Code / Codex") of this package for the
+specific proposed normalized-spec path and follow-on issues. Owner-doc owners decide whether
+to accept any of those suggestions.
+
+## What this design must not suggest
+
+- Any loosening of the gated-execution invariant.
+- Any new authority surface that bypasses the existing pipeline.
+- Any new write path that bypasses policy / validation.
+- Any silent promotion of agent memory into semantic knowledge.
+- Any redefinition of authority flag semantics.

--- a/companion-ui/design_handoff/2026-05-14-context-bundle-inspector/colors_and_type.css
+++ b/companion-ui/design_handoff/2026-05-14-context-bundle-inspector/colors_and_type.css
@@ -1,0 +1,346 @@
+/* ============================================================
+   Yggdrasil Design System — Colors & Type
+   ============================================================
+   Import this file in any HTML artifact or UI kit.
+   Google Fonts are imported below; JetBrains Mono via bunny.net.
+   ============================================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Space+Grotesk:wght@300;400;500;600&display=swap');
+@import url('https://fonts.bunny.net/css?family=jetbrains-mono:400,500&display=swap');
+
+/* ============================================================
+   BASE COLOR TOKENS
+   ============================================================ */
+:root {
+  /* --- Backgrounds (cool blue-black — Tron grid) --- */
+  --bg-base:       #070b12;   /* deepest — page root, near black with blue cast */
+  --bg-surface:    #0c1220;   /* panels, sidebars */
+  --bg-raised:     #111a2e;   /* cards, inputs, raised surfaces */
+  --bg-overlay:    #162038;   /* hover states, popovers */
+  --bg-modal:      #0e1828;   /* modal / dialog backdrop content */
+
+  /* --- Foreground / Text --- */
+  --fg-1:          #dce8f0;   /* primary — cool blue-white */
+  --fg-2:          #7a9ab8;   /* secondary / muted */
+  --fg-3:          #3d5570;   /* tertiary / disabled / dim */
+  --fg-inverse:    #070b12;   /* text on light/accent backgrounds */
+
+  /* --- Borders (thin, slightly glowing) --- */
+  --border:        #152030;   /* default — subtle grid line */
+  --border-strong: #1e3050;   /* emphasis — dividers, active edges */
+  --border-focus:  #00d4e8;   /* focus ring — electric cyan */
+
+  /* --- Accent 1: Norse Gold (slightly electrified) --- */
+  --accent:        #d4a843;   /* primary accent — active, focus, key affordances */
+  --accent-dim:    #80621a;   /* dimmed gold */
+  --accent-muted:  #2a1e06;   /* gold at low opacity */
+
+  /* --- Accent 2: Tron Cyan (neon electric) --- */
+  --cyan:          #00d4e8;   /* electric cyan — Tron primary glow */
+  --cyan-dim:      #007a8a;   /* dimmed cyan */
+  --cyan-muted:    #001e28;   /* cyan tint background */
+  --cyan-glow:     0 0 12px rgba(0,212,232,0.35), 0 0 4px rgba(0,212,232,0.5);
+
+  /* --- Vault: Neon green (digital growth) --- */
+  --vault:         #39e87d;   /* vault-connected — electric green */
+  --vault-dim:     #1a7840;   /* vault hover */
+  --vault-muted:   #041a10;   /* vault background tint */
+  --vault-glow:    0 0 8px rgba(57,232,125,0.3);
+
+  /* --- Agent: Electric blue (machine voice) --- */
+  --agent:         #4a9eff;   /* agent-contributed UI and content */
+  --agent-dim:     #1e5a9a;   /* agent hover */
+  --agent-muted:   #051228;   /* agent background tint */
+  --agent-glow:    0 0 8px rgba(74,158,255,0.3);
+
+  /* --- Amber (staged / uncommitted) --- */
+  --amber:         #f09030;   /* warnings, uncommitted/staged state */
+  --amber-dim:     #805010;
+  --amber-muted:   #1a0e02;
+
+  /* --- Destructive --- */
+  --destructive:      #ff3d3d;
+  --destructive-dim:  #8a1a1a;
+  --destructive-muted:#160404;
+
+  /* --- Semantic UI colors --- */
+  --color-bg:        var(--bg-base);
+  --color-surface:   var(--bg-surface);
+  --color-text:      var(--fg-1);
+  --color-muted:     var(--fg-2);
+  --color-dim:       var(--fg-3);
+  --color-border:    var(--border);
+  --color-accent:    var(--accent);
+
+  /* ============================================================
+     TYPOGRAPHY
+     ============================================================ */
+
+  /* --- Font families --- */
+  --font-display:  'EB Garamond', Georgia, serif;
+  --font-ui:       'Space Grotesk', system-ui, sans-serif;
+  --font-mono:     'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+
+  /* --- Type scale (rem, base 16px) --- */
+  --text-xs:    0.6875rem;   /* 11px — metadata, timestamps */
+  --text-sm:    0.8125rem;   /* 13px — secondary labels, captions */
+  --text-base:  0.9375rem;   /* 15px — body / default UI */
+  --text-md:    1.0625rem;   /* 17px — slightly emphasized body */
+  --text-lg:    1.1875rem;   /* 19px — section headers */
+  --text-xl:    1.5rem;      /* 24px — page titles */
+  --text-2xl:   2rem;        /* 32px — display moments */
+  --text-3xl:   2.75rem;     /* 44px — wordmark / hero */
+  --text-4xl:   3.75rem;     /* 60px — large display */
+
+  /* --- Line heights --- */
+  --leading-tight:  1.25;
+  --leading-snug:   1.4;
+  --leading-normal: 1.55;
+  --leading-loose:  1.75;
+
+  /* --- Font weights --- */
+  --weight-light:   300;
+  --weight-regular: 400;
+  --weight-medium:  500;
+  --weight-semibold:600;
+
+  /* --- Letter spacing --- */
+  --tracking-tight: -0.02em;
+  --tracking-normal: 0em;
+  --tracking-wide:   0.04em;
+  --tracking-wider:  0.08em;
+
+  /* ============================================================
+     SPACING
+     ============================================================ */
+  --space-1:   4px;
+  --space-2:   8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  20px;
+  --space-6:  24px;
+  --space-8:  32px;
+  --space-10: 40px;
+  --space-12: 48px;
+  --space-16: 64px;
+
+  /* ============================================================
+     BORDER RADIUS — sharper for cyberpunk aesthetic
+     ============================================================ */
+  --radius-sm:   2px;
+  --radius-md:   4px;
+  --radius-lg:   6px;
+  --radius-xl:  10px;
+  --radius-full: 9999px;
+
+  /* ============================================================
+     SHADOWS / ELEVATION
+     ============================================================ */
+  --shadow-sm:  0 1px 3px rgba(0,0,0,0.3);
+  --shadow-md:  0 4px 12px rgba(0,0,0,0.4);
+  --shadow-lg:  0 8px 32px rgba(0,0,0,0.5);
+  --shadow-float: 0 4px 24px rgba(0,0,0,0.55), 0 1px 4px rgba(0,0,0,0.3);
+  --shadow-inset: inset 0 1px 3px rgba(0,0,0,0.35);
+
+  /* ============================================================
+     ANIMATION
+     ============================================================ */
+  --ease:        cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-linear: linear;
+  --duration-fast: 100ms;
+  --duration-base: 150ms;
+  --duration-slow: 250ms;
+
+  /* ============================================================
+     Z-INDEX SCALE
+     ============================================================ */
+  --z-base:    1;
+  --z-raised:  10;
+  --z-sticky:  100;
+  --z-overlay: 200;
+  --z-modal:   300;
+  --z-toast:   400;
+}
+
+/* ============================================================
+   SEMANTIC ELEMENT DEFAULTS
+   ============================================================ */
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+body {
+  background-color: var(--bg-base);
+  color: var(--fg-1);
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-normal);
+}
+
+/* --- Display headings (EB Garamond) --- */
+h1, .h1 {
+  font-family: var(--font-display);
+  font-size: var(--text-3xl);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  color: var(--fg-1);
+}
+
+h2, .h2 {
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  color: var(--fg-1);
+}
+
+/* --- UI headings (DM Sans) --- */
+h3, .h3 {
+  font-family: var(--font-ui);
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-snug);
+  color: var(--fg-1);
+}
+
+h4, .h4 {
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-snug);
+  color: var(--fg-1);
+}
+
+h5, h6, .h5, .h6 {
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-snug);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--fg-2);
+}
+
+p {
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
+  color: var(--fg-1);
+  text-wrap: pretty;
+}
+
+small, .text-sm {
+  font-size: var(--text-sm);
+  color: var(--fg-2);
+}
+
+.text-xs {
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  font-family: var(--font-mono);
+  letter-spacing: var(--tracking-wide);
+}
+
+code, kbd, pre, .mono {
+  font-family: var(--font-mono);
+  font-size: 0.875em; /* relative to surrounding text */
+}
+
+code {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.1em 0.35em;
+  color: var(--fg-1);
+}
+
+pre {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  overflow-x: auto;
+  font-size: var(--text-sm);
+  line-height: var(--leading-normal);
+  color: var(--fg-1);
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+a:hover {
+  color: var(--fg-1);
+  text-decoration: underline;
+}
+
+hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: var(--space-6) 0;
+}
+
+/* ============================================================
+   UTILITY CLASSES
+   ============================================================ */
+
+/* Text colors */
+.text-primary   { color: var(--fg-1); }
+.text-secondary { color: var(--fg-2); }
+.text-dim       { color: var(--fg-3); }
+.text-accent    { color: var(--accent); }
+.text-cyan      { color: var(--cyan); }
+.text-vault     { color: var(--vault); }
+.text-agent     { color: var(--agent); }
+.text-amber     { color: var(--amber); }
+.text-danger    { color: var(--destructive); }
+
+/* Font families */
+.font-display { font-family: var(--font-display); }
+.font-ui      { font-family: var(--font-ui); }
+.font-mono    { font-family: var(--font-mono); }
+
+/* Weights */
+.weight-light    { font-weight: var(--weight-light); }
+.weight-regular  { font-weight: var(--weight-regular); }
+.weight-medium   { font-weight: var(--weight-medium); }
+.weight-semibold { font-weight: var(--weight-semibold); }
+
+/* Glow effects */
+.glow-cyan   { box-shadow: var(--cyan-glow); }
+.glow-vault  { box-shadow: var(--vault-glow); }
+.glow-agent  { box-shadow: var(--agent-glow); }
+.text-glow-cyan  { text-shadow: 0 0 12px rgba(0,212,232,0.7); }
+.text-glow-gold  { text-shadow: 0 0 16px rgba(212,168,67,0.5); }
+
+/* Tron grid background */
+.grid-bg {
+  background-image:
+    linear-gradient(rgba(0,212,232,0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0,212,232,0.04) 1px, transparent 1px);
+  background-size: 32px 32px;
+}
+
+/* Neon border active state */
+.border-cyan { border-color: var(--cyan) !important; box-shadow: var(--cyan-glow); }
+.border-gold { border-color: var(--accent) !important; box-shadow: 0 0 8px rgba(212,168,67,0.3); }
+
+/* Focus ring */
+:focus-visible {
+  outline: 1px solid var(--cyan);
+  outline-offset: 2px;
+  box-shadow: var(--cyan-glow);
+}

--- a/companion-ui/design_handoff/2026-05-14-context-bundle-inspector/design-notes.md
+++ b/companion-ui/design_handoff/2026-05-14-context-bundle-inspector/design-notes.md
@@ -1,0 +1,68 @@
+# Design notes — Context Bundle Inspector
+
+## Visual language
+
+This package follows the shared Yggdrasil design system (`colors_and_type.css`) used across the
+2026-05 companion-ui handoffs:
+
+- **Dark, cool blue-black background** (`--bg-base`) with a subtle Tron grid.
+- **Cool blue-white text** (`--fg-1`); secondary copy in `--fg-2`; mono captions in `--fg-3`.
+- **Norse gold** (`--accent`) for governance and provenance accents.
+- **Electric cyan** (`--cyan`) for trigger / link / receipt-pending cues.
+- **Vault green** (`--vault`) for healthy, applied, reviewed.
+- **Amber** (`--amber`) for staged, stale, inferred, or attention-needed.
+- **Destructive red** (`--destructive`) for refusal, denial, conflict, and dead-letter.
+
+Type: **EB Garamond** for display, **Space Grotesk** for UI, **JetBrains Mono** for evidence
+captions, ids, scores, and timestamps. Mono is the load-bearing voice of "this is evidence,
+not summary."
+
+## Surface posture
+
+Inspector surface for the bundle bridge object — included artifacts, excluded artifacts, authority flags, receipts. Desktop + portrait.
+
+The surface is intentionally **calm**:
+
+- No alarm noise. Red is reserved for actual refusals.
+- No coloured tiles without evidence. Every mono caption is rooted in a runtime value.
+- Animation is restrained: receipt-pill pulse and the banner LED only. Both respect
+  `prefers-reduced-motion`.
+- No emoji. Status uses short words ("Running", "Backlogged", "Stale") rather than icons.
+
+## Component vocabulary
+
+The shared spec chrome (`spec_chrome.css`) carries:
+
+- `.callout` (cyan, amber, accent, destructive, vault variants) for invariants and notes.
+- `.chip` for tag-style metadata.
+- `.receipt` (queued, applied, pending, failed) for receipt pills.
+- `.btn` (primary, governance, vault, danger, ghost) for actions.
+- `.gallery` and `.gallery-card` for state galleries.
+- `table.spec` for evidence tables with mono headers.
+
+Each prototype adds local components on top — see `prototype.html` for inline styles.
+
+See `prototype.html` §02 for the field model, §03 for the inspector prototype, §04 for the portrait layout, §05 for the 9-state gallery.
+
+## Why the layout is the way it is
+
+- **TOC sidebar.** Specs are scanned, not read. The TOC is sticky so scanning stays cheap.
+- **Mono section numbers and metadata.** Visual contract: mono text means "this is a value
+  the runtime emits", not a designer's invented label.
+- **Section heads in EB Garamond.** Display serif at section boundaries marks the
+  transitions in attention; UI sans inside the section keeps reading dense.
+- **No hover-only affordances.** Every action is visible at rest; hover only adds an accent.
+
+## Copy conventions
+
+- Headlines: short verbs or adjectives.
+- Captions: mono, in `--fg-3`.
+- Action labels: uppercase, letter-spacing wide, never punctuated.
+- Status copy: second-person plain language. Never imperative-without-object ("Restart").
+
+## Out of scope for this package
+
+- Brand redesign.
+- New colour tokens (none added).
+- New type pairings.
+- Animation grammar beyond the existing receipt-pulse pattern.

--- a/companion-ui/design_handoff/2026-05-14-context-bundle-inspector/edge-states.md
+++ b/companion-ui/design_handoff/2026-05-14-context-bundle-inspector/edge-states.md
@@ -1,0 +1,30 @@
+# Edge states — Context Bundle Inspector
+
+This document is the edge-state checklist required by the Handoff Governance Pack §08.
+The full per-state visual treatment lives in **`prototype.html` §06 (Edge states)**. This
+document is the text checklist.
+
+## Required edges
+
+- **Empty** — designed (see `prototype.html` §06).
+- **Loading** — designed; static dim states, no skeleton animation.
+- **Degraded** — designed; partial function with explicit naming of what is degraded.
+- **Blocked** — designed; refusal is named, recorded, and never silently retried.
+- **Stale context** — designed; threshold and "why" rendered.
+- **Missing provenance** — designed; surfaced rather than hidden.
+- **Write-guard denial** — designed; denial reason visible; not retried.
+- **Reduced motion** — designed; receipt pulse + banner LED respect `prefers-reduced-motion`.
+- **Narrow / mobile layout** — designed; see `prototype.html` §06 (and §04 for the
+  portrait-specific layout in the bundle inspector).
+
+## Deferred-with-reason
+
+None for this package. If a future revision defers any edge, it must be tracked here with a
+reason and a follow-up issue link.
+
+## Validation expectations
+
+Per the implementation contract, every edge above must render correctly from a fixture and
+must satisfy the per-edge acceptance criteria in `prototype.html` §06. Reduced-motion is
+verified with the OS preference set; narrow layouts are verified at the documented
+breakpoints (`< 900px` for the standard collapse; `< 560px` where applicable).

--- a/companion-ui/design_handoff/2026-05-14-context-bundle-inspector/implementation-contracts.md
+++ b/companion-ui/design_handoff/2026-05-14-context-bundle-inspector/implementation-contracts.md
@@ -1,0 +1,70 @@
+# Implementation contract — Context Bundle Inspector
+
+**Status:** Contract for UI integration · target-state
+**Mutates:** nothing on its own
+**Depends on:** docs/CONCEPTS/CONTEXT_BUNDLE_CONTRACT.md, docs/INTERACTION_SURFACES_AND_AUTHORITY/, the gated-execution invariant.
+
+## Position in the chain
+
+This document is the part of the package that implementation reads. It is the only document
+that promises anything to code. Everything else in the package (README, design-notes,
+state-gallery, edge-states, authority-boundaries, open-questions) is guidance.
+
+## State enum
+
+The implementation must enumerate exactly the states described in **`prototype.html` §03 + §05**. Adding
+or removing a state without amending this document means the design no longer covers it.
+
+## Allowed transitions
+
+See **`prototype.html` §03 + §05** for the per-state transition table. Implementation must
+reject any transition not enumerated there.
+
+## Data attributes
+
+Stable attributes the design relies on for testids and behavioral selectors are listed in
+**`prototype.html` §07 (Implementation contract)** of this package. Required attributes are
+flagged in the prototype's code block. Adding new attributes is permitted; renaming is not.
+
+## Intents
+
+The full `data-intent` vocabulary is in **`prototype.html` §07**. Each intent declares:
+
+- the surface that emits it,
+- the effect (UI-local / read-only / governed / navigation),
+- whether it routes through the governance pipeline.
+
+Implementation must not emit intents not declared here. Adding a new intent requires an
+amendment to this document.
+
+## Server contract surface
+
+Endpoints / events / classifiers the UI consumes are bound to existing or proposed runtime
+contracts. The UI never re-classifies; the server's declared class wins.
+
+Specific contract references:
+
+- `docs/CONCEPTS/CONTEXT_BUNDLE_CONTRACT.md`
+- `docs/INTERACTION_SURFACES_AND_AUTHORITY/`
+
+## Validation expectations
+
+A passing validation receipt for this package would render the full state gallery against
+fixture inputs, verify every declared transition, and confirm:
+
+- no UI-derived posture / class / authority,
+- denied / blocked states emit the right receipts,
+- reduced-motion preference is respected,
+- narrow / portrait layout preserves all critical affordances.
+
+The exact fixture set is owned by the implementation issue, not this document.
+
+## What this contract does not say
+
+Explicit list of things implementation is free to choose:
+
+- framework (React, vanilla, web components — design works for any),
+- style technique (CSS, styled-components, CSS modules),
+- animation library (none needed; the design uses CSS),
+- persistence cache shape,
+- network transport.

--- a/companion-ui/design_handoff/2026-05-14-context-bundle-inspector/open-questions.md
+++ b/companion-ui/design_handoff/2026-05-14-context-bundle-inspector/open-questions.md
@@ -1,0 +1,32 @@
+# Open questions — Context Bundle Inspector
+
+The canonical list lives in **`prototype.html` §09 (Open questions)** of this package. This
+document is the structured version intended for issue creation at crossings C/D.
+
+## Status
+
+All open questions are tracked in the prototype. Owner-doc owners are proposed in the
+prototype; they are not assigned yet — assignment happens at crossing B during the
+maturity-checklist review.
+
+## Crossing-B blockers
+
+If any open question would, if answered, change the state machine declared in the
+implementation contract, that question is a crossing-B blocker per the governance pack §03.
+The reviewer at crossing B must triage each open question into one of:
+
+- **resolve before promotion** (blocker),
+- **resolve in normalized spec** (non-blocker, but cite),
+- **defer to implementation issue** (non-blocker, but acknowledge).
+
+## How to read
+
+Each open question in the prototype carries:
+
+- a short title (used as the issue title if escalated),
+- the rationale for the question,
+- a proposed default (the package's recommendation),
+- an implicit owner (the doc the question would amend if accepted).
+
+Detailed answers are deliberately not pre-decided here — the question list is the package's
+honest "we don't know yet, and we made a choice anyway" record.

--- a/companion-ui/design_handoff/2026-05-14-context-bundle-inspector/prototype.html
+++ b/companion-ui/design_handoff/2026-05-14-context-bundle-inspector/prototype.html
@@ -1,0 +1,1343 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Context Bundle Inspector — Yggdrasil Companion UI</title>
+<link rel="stylesheet" href="./colors_and_type.css" />
+<link rel="stylesheet" href="./spec_chrome.css" />
+<style>
+  /* ============================================================
+     LOCAL — bundle inspector layout
+     ============================================================ */
+  .inspector {
+    border: 1px solid var(--border);
+    background: var(--bg-surface);
+    border-radius: var(--radius-md);
+    margin: var(--space-3) 0 var(--space-6);
+    overflow: hidden;
+  }
+  .insp-bar {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: 10px 16px;
+    background: var(--bg-raised);
+    border-bottom: 1px solid var(--border);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+  }
+  .insp-bar .id { color: var(--cyan); }
+  .insp-bar .right { margin-left: auto; display: flex; gap: var(--space-3); align-items: center; }
+
+  .insp-body {
+    display: grid;
+    grid-template-columns: 1fr 320px;
+    min-height: 560px;
+  }
+  .insp-main {
+    padding: var(--space-5) var(--space-6);
+    overflow-y: auto;
+    max-height: 680px;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-5);
+  }
+  .insp-aside {
+    border-left: 1px solid var(--border);
+    background: var(--bg-base);
+    padding: var(--space-4) var(--space-5);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-5);
+    overflow-y: auto;
+    max-height: 680px;
+  }
+
+  /* bundle header */
+  .b-head {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .b-head .kicker {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--cyan);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+  }
+  .b-head h3 {
+    font-family: var(--font-display);
+    font-size: var(--text-2xl);
+    font-weight: var(--weight-regular);
+    line-height: 1.1;
+    color: var(--fg-1);
+    margin: 0;
+    letter-spacing: 0;
+    text-transform: none;
+  }
+  .b-head .trig {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--fg-2);
+  }
+  .b-head .trig .src { color: var(--accent); }
+
+  /* authority chips */
+  .auth-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 6px;
+  }
+  .auth {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    padding: 4px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-strong);
+    background: var(--bg-raised);
+    color: var(--fg-3);
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .auth.yes { color: var(--vault); border-color: rgba(57,232,125,0.35); background: rgba(57,232,125,0.04); }
+  .auth.no  { color: var(--destructive); border-color: rgba(255,61,61,0.35); background: rgba(255,61,61,0.04); }
+  .auth.maybe { color: var(--amber); border-color: rgba(240,144,48,0.35); background: rgba(240,144,48,0.04); }
+  .auth .mk { font-family: var(--font-mono); font-weight: var(--weight-medium); }
+
+  /* artifact list */
+  .art-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .art {
+    border: 1px solid var(--border);
+    border-left: 2px solid var(--cyan);
+    background: var(--bg-base);
+    border-radius: var(--radius-sm);
+    padding: 10px 12px;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    column-gap: var(--space-3);
+    row-gap: 4px;
+  }
+  .art.excluded {
+    border-left-color: var(--fg-3);
+    opacity: 0.7;
+    background: var(--bg-raised);
+  }
+  .art.evidence  { border-left-color: var(--cyan); }
+  .art.context   { border-left-color: var(--agent); }
+  .art.memory    { border-left-color: var(--accent); }
+  .art.companion { border-left-color: var(--vault); }
+  .art .row1 { display: flex; align-items: baseline; gap: 8px; }
+  .art .row1 .ttl {
+    font-family: var(--font-ui);
+    font-size: var(--text-sm);
+    color: var(--fg-1);
+    font-weight: var(--weight-medium);
+  }
+  .art .row1 .path {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wide);
+  }
+  .art .reason {
+    grid-column: 1 / 2;
+    font-size: var(--text-sm);
+    color: var(--fg-2);
+    line-height: 1.45;
+  }
+  .art .meta {
+    grid-column: 2 / 3;
+    grid-row: 1 / 3;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 4px;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    text-align: right;
+  }
+  .art .meta .score { color: var(--cyan); }
+  .art .meta .trust { color: var(--vault); }
+  .art .meta .trust.inferred { color: var(--amber); }
+  .art .meta .trust.untrusted { color: var(--destructive); }
+  .art .meta .role { color: var(--fg-2); }
+  .art .meta .role.evidence  { color: var(--cyan); }
+  .art .meta .role.context   { color: var(--agent); }
+  .art .meta .role.memory    { color: var(--accent); }
+  .art .meta .role.companion { color: var(--vault); }
+
+  /* excluded toggle */
+  .excl-block {
+    border: 1px dashed var(--border-strong);
+    border-radius: var(--radius-sm);
+    padding: 10px 14px;
+  }
+  .excl-block summary {
+    cursor: pointer;
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--fg-2);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+  }
+  .excl-block summary::before {
+    content: '▸';
+    color: var(--fg-3);
+    transition: transform var(--duration-fast) var(--ease);
+  }
+  .excl-block[open] summary::before { transform: rotate(90deg); }
+  .excl-block .excl-list { margin-top: 10px; display: flex; flex-direction: column; gap: 8px; }
+
+  /* section heads inside main */
+  .insp-sec h4 {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    color: var(--fg-2);
+    margin-bottom: var(--space-3);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .insp-sec h4 .count {
+    font-family: var(--font-mono);
+    color: var(--fg-3);
+    font-size: 10px;
+  }
+  .insp-sec h4 .badge {
+    margin-left: auto;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: var(--tracking-wide);
+    color: var(--cyan);
+    text-transform: uppercase;
+  }
+  .insp-sec h4 .badge.amber { color: var(--amber); }
+  .insp-sec h4 .badge.gold  { color: var(--accent); }
+  .insp-sec h4 .badge.dim   { color: var(--fg-3); }
+
+  /* aside blocks */
+  .aside-h {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    color: var(--fg-3);
+    margin-bottom: 8px;
+  }
+  .aside-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--fg-2);
+    padding: 4px 0;
+    border-bottom: 1px solid var(--border);
+    gap: 12px;
+  }
+  .aside-row:last-child { border-bottom: none; }
+  .aside-row .v { color: var(--fg-1); text-align: right; }
+  .aside-row .v.cyan  { color: var(--cyan); }
+  .aside-row .v.gold  { color: var(--accent); }
+  .aside-row .v.vault { color: var(--vault); }
+  .aside-row .v.amber { color: var(--amber); }
+  .aside-row .v.dang  { color: var(--destructive); }
+
+  .receipt-list { display: flex; flex-direction: column; gap: 6px; }
+
+  /* status banner above bundle */
+  .b-status {
+    padding: 8px 14px;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-base);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--fg-2);
+    letter-spacing: var(--tracking-wide);
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+  }
+  .b-status.stale  { color: var(--amber); background: rgba(240,144,48,0.04); border-bottom-color: rgba(240,144,48,0.25); }
+  .b-status.degraded { color: var(--accent); background: rgba(212,168,67,0.04); border-bottom-color: rgba(212,168,67,0.25); }
+  .b-status.blocked  { color: var(--destructive); background: rgba(255,61,61,0.04); border-bottom-color: rgba(255,61,61,0.25); }
+  .b-status .led {
+    width: 8px; height: 8px; border-radius: 50%;
+    background: var(--amber);
+    box-shadow: 0 0 6px var(--amber);
+  }
+  .b-status.degraded .led { background: var(--accent); box-shadow: 0 0 6px var(--accent); }
+  .b-status.blocked  .led { background: var(--destructive); box-shadow: 0 0 6px var(--destructive); }
+
+  /* gallery */
+  .gallery.bundle-gallery {
+    grid-template-columns: 1fr 1fr;
+  }
+  .bm {
+    border: 1px solid var(--border);
+    background: var(--bg-surface);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+  }
+  .bm-bar {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    padding: 8px 12px;
+    background: var(--bg-raised);
+    border-bottom: 1px solid var(--border);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    color: var(--fg-3);
+  }
+  .bm-bar .id { color: var(--cyan); }
+  .bm-body {
+    padding: 10px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .bm-body h5 {
+    font-family: var(--font-display);
+    font-size: var(--text-md);
+    color: var(--fg-1);
+    font-weight: var(--weight-regular);
+    line-height: 1.2;
+    margin: 0;
+  }
+  .bm-body .meta {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+  }
+  .bm-body .auth-row { margin-top: 2px; }
+  .bm-body .auth { padding: 2px 8px; font-size: 10px; }
+  .bm-body .narrative {
+    font-size: var(--text-sm);
+    color: var(--fg-2);
+    line-height: 1.45;
+  }
+
+  /* portrait/mobile mini */
+  .portrait {
+    width: 360px;
+    margin: var(--space-3) auto var(--space-5);
+    border: 1px solid var(--border-strong);
+    border-radius: 32px;
+    background: var(--bg-base);
+    overflow: hidden;
+    padding: 28px 14px 18px;
+    box-shadow: var(--shadow-lg);
+  }
+  .portrait .bar-port {
+    display: flex;
+    justify-content: space-between;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    margin-bottom: var(--space-3);
+  }
+  .portrait .ph-card {
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    padding: var(--space-3);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+  }
+  .portrait .ph-kicker {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    color: var(--cyan);
+  }
+  .portrait h4 {
+    font-family: var(--font-display);
+    font-size: var(--text-lg);
+    color: var(--fg-1);
+    font-weight: var(--weight-regular);
+    line-height: 1.15;
+    margin: 0;
+  }
+  .portrait .ph-fold {
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 8px 10px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--fg-2);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+  }
+  .portrait .ph-fold .v { color: var(--fg-1); }
+  .portrait .ph-art {
+    border: 1px solid var(--border);
+    border-left: 2px solid var(--cyan);
+    background: var(--bg-base);
+    border-radius: var(--radius-sm);
+    padding: 8px 10px;
+    font-size: var(--text-xs);
+    color: var(--fg-1);
+    line-height: 1.45;
+  }
+  .portrait .ph-art .reason { color: var(--fg-2); font-size: 11px; margin-top: 4px; }
+
+  @media (max-width: 900px) {
+    .insp-body { grid-template-columns: 1fr; }
+    .insp-aside { border-left: none; border-top: 1px solid var(--border); max-height: none; }
+    .gallery.bundle-gallery { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+<div class="page">
+
+  <!-- ============================ TOC ============================ -->
+  <nav class="toc" aria-label="Section index">
+    <div class="toc-label">Sections</div>
+    <ol>
+      <li><a href="#s1"><span class="toc-num">01</span>Context &amp; boundary</a></li>
+      <li><a href="#s2"><span class="toc-num">02</span>Field model</a></li>
+      <li><a href="#s3"><span class="toc-num">03</span>Inspector prototype</a></li>
+      <li><a href="#s4"><span class="toc-num">04</span>Candidates · compact · authority</a></li>
+      <li><a href="#s5"><span class="toc-num">05</span>Narrow / portrait layout</a></li>
+      <li><a href="#s6"><span class="toc-num">06</span>State gallery</a></li>
+      <li><a href="#s7"><span class="toc-num">07</span>Edge states</a></li>
+      <li><a href="#s8"><span class="toc-num">08</span>Implementation contract</a></li>
+      <li><a href="#s9"><span class="toc-num">09</span>Authority boundaries</a></li>
+      <li><a href="#s10"><span class="toc-num">10</span>Open questions</a></li>
+      <li><a href="#s11"><span class="toc-num">11</span>Handoff to Code/Codex</a></li>
+    </ol>
+  </nav>
+
+  <!-- ============================ MAIN ============================ -->
+  <main>
+    <header class="doc-header">
+      <div class="doc-eyebrow">Companion UI · Design Handoff · Inspector surface</div>
+      <h1 class="doc-title">Context Bundle Inspector</h1>
+      <p class="doc-lede">
+        A reviewable surface for the bridge object that sits between retrieval, orientation,
+        resurfacing, and write proposals. Shows what was selected, why it was selected, what
+        was excluded, what authority the bundle carries, and what receipts attach to it. The
+        bundle is the artifact; the inspector exposes it. Semantic similarity is not authority.
+      </p>
+      <div class="doc-meta">
+        <span><strong>Surface:</strong> CONTEXT_BUNDLE_INSPECTOR</span>
+        <span><strong>Owner-doc:</strong> CONTEXT_BUNDLE_CONTRACT</span>
+        <span><strong>Authority:</strong> Visual guidance only — bundle schema not owned here</span>
+        <span><strong>Status:</strong> Design handoff · v1 · 2026-05-14</span>
+      </div>
+    </header>
+
+    <!-- ============== 01 ============== -->
+    <section class="spec" id="s1">
+      <h2><span class="secnum">01 ·</span>Context &amp; boundary</h2>
+      <p class="lede">What the inspector is for, and what it must never become.</p>
+
+      <p>
+        The context bundle contract names a bridge object: an inspectable selection of
+        artifacts, snippets, reasons, exclusions, and authority flags, attached to a single
+        trigger (retrieval, orientation, resurfacing, or action). The inspector is the human's
+        review surface for that object. It exists so the operator can answer "<em>why</em> did
+        the system use these notes before answering, reorienting, resurfacing, or proposing?"
+      </p>
+
+      <h3>Design posture</h3>
+      <ul>
+        <li><strong>Inspect, not author.</strong> The inspector reads bundles. It does not
+          re-rank, re-classify, or rebuild them.</li>
+        <li><strong>Progressive disclosure.</strong> Excluded items, low-trust items, and
+          receipt history are collapsed by default. Their <em>presence</em> is always visible;
+          their <em>contents</em> are one click away.</li>
+        <li><strong>Authority is a first-class header.</strong> The five flags
+          (<code>may_answer</code>, <code>may_orient</code>, <code>may_resurface</code>,
+          <code>may_propose</code>, <code>may_write</code>) sit at the top of the bundle, not
+          buried in metadata.</li>
+        <li><strong>Exclusions are visible.</strong> If exclusion affects interpretation, the
+          excluded item is shown with its reason. The inspector exposes the negative space.</li>
+      </ul>
+
+      <div class="callout invariant">
+        <span class="callout-label">Floor invariant · Retrieval is not authority</span>
+        A bundle may support an answer without supporting writeback. The inspector renders the
+        bundle's declared authority flags; it never elevates them. If the bundle says
+        <code>may_write: false</code>, the inspector's writeback affordance is absent.
+        Re-classification in the UI is forbidden.
+      </div>
+
+      <h3>What the inspector is not</h3>
+      <ul>
+        <li>Not a search UI. Retrieval lives upstream; the inspector explains the result, it
+          does not run new queries.</li>
+        <li>Not a memory surface. Memory candidates have their own queue (Exploration 4).
+          The inspector may <em>reference</em> memory items the bundle includes, never promote
+          them.</li>
+        <li>Not a write surface. Where a bundle has <code>may_write: true</code>, the apply
+          affordance lives in the proposing surface (Panel, Canvas), not here.</li>
+        <li>Not a debugger. The inspector is the human's review surface, not a developer's
+          trace tool.</li>
+      </ul>
+    </section>
+
+    <!-- ============== 02 ============== -->
+    <section class="spec" id="s2">
+      <h2><span class="secnum">02 ·</span>Field model</h2>
+      <p class="lede">
+        Following <code>CONTEXT_BUNDLE_CONTRACT.md</code>. Required fields the inspector
+        always renders; optional fields it renders when present. Field names are illustrative;
+        owner-doc owns the schema.
+      </p>
+
+      <h3>Required surface</h3>
+      <table class="spec">
+        <thead><tr><th>Field</th><th>Display</th><th>Notes</th></tr></thead>
+        <tbody>
+          <tr><td><code>id</code></td><td>Top bar, monospace, copyable</td><td>Permalink anchor for receipts and audit trails.</td></tr>
+          <tr><td><code>created_at</code></td><td>Top bar, relative + absolute</td><td>Drives staleness banner.</td></tr>
+          <tr><td><code>trigger</code></td><td>Bundle header sub-line · "Retrieval from &lt;source&gt;"</td><td>Source path is clickable to the originating surface.</td></tr>
+          <tr><td><code>intended_use</code></td><td>Bundle header pill row</td><td>One pill per use; uses we do not have light up; others stay dim.</td></tr>
+          <tr><td><code>scope</code></td><td>Aside · sphere / project / vaults</td><td>Aside, because scope changes rarely affect interpretation.</td></tr>
+          <tr><td><code>included[]</code></td><td>Main column · artifact list</td><td>One card per artifact; role coloured left border.</td></tr>
+          <tr><td><code>excluded[]</code></td><td>Main column · collapsed disclosure</td><td>Count always visible. List collapsed unless exclusion affects interpretation.</td></tr>
+          <tr><td><code>authority</code></td><td>Bundle header · five flag chips</td><td><span class="auth yes">yes</span> / <span class="auth no">no</span> / <span class="auth maybe">conditional</span>.</td></tr>
+          <tr><td><code>expiry</code></td><td>Status banner above bundle when within / past stale window</td><td>Status banner; copy explains <em>why</em> stale.</td></tr>
+          <tr><td><code>receipts</code></td><td>Aside · receipt list, linked</td><td>Retrieval / orientation / write-proposal receipts grouped.</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Optional surface (rendered when present)</h3>
+      <table class="spec">
+        <thead><tr><th>Field</th><th>Display</th></tr></thead>
+        <tbody>
+          <tr><td>Human-readable summary</td><td>One-paragraph block under bundle header</td></tr>
+          <tr><td>Selection rationale</td><td>Italic line under the included list header</td></tr>
+          <tr><td>Dominant source role</td><td>Aside · "Dominant role · evidence"</td></tr>
+          <tr><td>Trust posture summary</td><td>Aside · trust mix bar (reviewed / inferred / untrusted)</td></tr>
+          <tr><td>Freshness note</td><td>Aside · "Indexed 4m ago"</td></tr>
+          <tr><td>Downstream write-proposal link</td><td>Aside · receipt-pill linking the proposal</td></tr>
+          <tr><td>Companion UI reference</td><td>Aside · note path link</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Per-artifact fields rendered in each card</h3>
+      <ul>
+        <li><strong>Title + path</strong> — vault path is monospace, dimmer.</li>
+        <li><strong>Source role</strong> — evidence / context / memory / companion · drives left border colour.</li>
+        <li><strong>Trust state</strong> — reviewed / inferred / untrusted · mono caption.</li>
+        <li><strong>Review state</strong> — confirmed / pending / rejected.</li>
+        <li><strong>Selection rationale / inclusion reason</strong> — one sentence, plain language.</li>
+        <li><strong>Score</strong> — when retrieval contributed; rendered as a small mono value, never a bar.</li>
+      </ul>
+    </section>
+
+    <!-- ============== 03 ============== -->
+    <section class="spec" id="s3">
+      <h2><span class="secnum">03 ·</span>Inspector prototype <span class="chip design" style="font-size:10px; margin-left:8px">retrieval bundle</span></h2>
+      <p class="lede">
+        Default state. A retrieval bundle that supports answering and proposing, but not
+        writing. Three included artifacts, two excluded.
+      </p>
+
+      <div class="inspector" aria-label="Context Bundle Inspector — retrieval bundle cb-2026-05-14-001">
+        <!-- top bar -->
+        <div class="insp-bar">
+          <span>bundle</span>
+          <span class="id">cb-2026-05-14-001</span>
+          <span>·</span>
+          <span>retrieval · companion-ui · Hugin turn 14</span>
+          <span class="right">
+            <span class="receipt queued"><span class="recdot"></span>linked to turn t-14</span>
+            <button class="btn ghost" type="button" data-intent="bundle.copy-id">Copy id</button>
+          </span>
+        </div>
+
+        <!-- status banner: fresh -->
+        <div class="b-status">
+          <span class="led" style="background:var(--vault); box-shadow:0 0 6px var(--vault)"></span>
+          fresh · stale after 12:00 · 4 minutes left
+        </div>
+
+        <div class="insp-body">
+          <!-- main column -->
+          <section class="insp-main">
+            <!-- bundle head -->
+            <header class="b-head">
+              <div class="kicker">Bundle · retrieval</div>
+              <h3>Re-ranking the canvas suggestion classifier</h3>
+              <div class="trig">trigger · retrieval · <span class="src">companion-ui / hugin / turn 14</span></div>
+              <div class="auth-row" aria-label="Authority flags">
+                <span class="auth yes"><span class="mk">✓</span>may_answer</span>
+                <span class="auth yes"><span class="mk">✓</span>may_orient</span>
+                <span class="auth yes"><span class="mk">✓</span>may_resurface</span>
+                <span class="auth maybe"><span class="mk">~</span>may_propose · conditional</span>
+                <span class="auth no"><span class="mk">✗</span>may_write</span>
+              </div>
+              <p style="font-size:var(--text-sm); color:var(--fg-2); margin:8px 0 0; max-width:60ch; line-height:1.5;">
+                Selected to support an answer about the classifier's body vs governance split.
+                Three artifacts from the canvas suggestion handoff and the interaction-surfaces
+                docs. Two artifacts excluded — one out-of-scope, one too stale.
+              </p>
+            </header>
+
+            <!-- included -->
+            <div class="insp-sec">
+              <h4>Included <span class="count">· 3</span> <span class="badge">role · evidence (dominant)</span></h4>
+              <div class="art-list">
+                <div class="art evidence">
+                  <div class="row1">
+                    <span class="ttl">Canvas Suggestion Flow §06</span>
+                    <span class="path">design_handoff/2026-05-11/…</span>
+                  </div>
+                  <p class="reason">Direct evidence for the classifier's split between body-edit and governance lanes — owner-doc citation for the answer.</p>
+                  <div class="meta">
+                    <span class="role evidence">evidence</span>
+                    <span class="trust">reviewed</span>
+                    <span class="score">score · 0.93</span>
+                  </div>
+                </div>
+                <div class="art evidence">
+                  <div class="row1">
+                    <span class="ttl">INTERACTION_SURFACES_AND_AUTHORITY · DEFINE_CANVAS_COEDITING_MODEL</span>
+                    <span class="path">docs/INTERACTION_SURFACES…</span>
+                  </div>
+                  <p class="reason">Authority contract for canvas co-editing; relied on for the "server is the classifier" rule the answer cites.</p>
+                  <div class="meta">
+                    <span class="role evidence">evidence</span>
+                    <span class="trust">reviewed</span>
+                    <span class="score">score · 0.88</span>
+                  </div>
+                </div>
+                <div class="art context">
+                  <div class="row1">
+                    <span class="ttl">CONTEXT_BUNDLE_CONTRACT · §Exclusion tracking</span>
+                    <span class="path">docs/CONCEPTS/…</span>
+                  </div>
+                  <p class="reason">Background context — why exclusions belong in this bundle's visible surface.</p>
+                  <div class="meta">
+                    <span class="role context">context</span>
+                    <span class="trust">reviewed</span>
+                    <span class="score">score · 0.71</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- excluded -->
+            <div class="insp-sec">
+              <h4>Excluded <span class="count">· 2</span> <span class="badge amber">visible · exclusion affects interpretation</span></h4>
+              <details class="excl-block" open>
+                <summary>Show excluded artifacts</summary>
+                <div class="excl-list">
+                  <div class="art excluded">
+                    <div class="row1">
+                      <span class="ttl">PanelAgent — current behavior</span>
+                      <span class="path">docs/PANEL_AGENT.md</span>
+                    </div>
+                    <p class="reason">Excluded — out of scope for the active sphere. The classifier in question is Canvas-side; PanelAgent's classifier is separate.</p>
+                    <div class="meta">
+                      <span class="role">excluded</span>
+                      <span class="trust inferred">scope · sphere mismatch</span>
+                    </div>
+                  </div>
+                  <div class="art excluded">
+                    <div class="row1">
+                      <span class="ttl">Converse v0 wireframes (deprecated)</span>
+                      <span class="path">design_handoff/2026-05-03-converse/</span>
+                    </div>
+                    <p class="reason">Excluded — superseded by Canvas Suggestion Flow v1. Included only as historical context.</p>
+                    <div class="meta">
+                      <span class="role">excluded</span>
+                      <span class="trust inferred">stale · superseded</span>
+                    </div>
+                  </div>
+                </div>
+              </details>
+            </div>
+
+            <!-- rationale -->
+            <div class="insp-sec">
+              <h4>Selection rationale</h4>
+              <p style="font-size:var(--text-sm); color:var(--fg-2); margin:0; line-height:1.55; max-width:60ch;">
+                The bundle prioritized owner-doc citations (canvas + authority) over implementation
+                artifacts (PanelAgent, Converse) because the question is about the contract, not
+                the runtime. Trust state is uniformly <em>reviewed</em>; no inferred or
+                untrusted material was included. Exclusions are visible because they change the
+                interpretation: the operator should see that PanelAgent was considered and
+                deliberately dropped.
+              </p>
+            </div>
+          </section>
+
+          <!-- aside -->
+          <aside class="insp-aside" aria-label="Bundle metadata, scope, receipts">
+            <div>
+              <div class="aside-h">Scope</div>
+              <div class="aside-row"><span>sphere</span><span class="v">work</span></div>
+              <div class="aside-row"><span>project</span><span class="v">agentic-pkm-mvp</span></div>
+              <div class="aside-row"><span>vault</span><span class="v">main</span></div>
+            </div>
+
+            <div>
+              <div class="aside-h">Trust posture</div>
+              <div class="aside-row"><span>reviewed</span><span class="v vault">3 / 3</span></div>
+              <div class="aside-row"><span>inferred</span><span class="v">0</span></div>
+              <div class="aside-row"><span>untrusted</span><span class="v">0</span></div>
+              <div class="aside-row"><span>dominant role</span><span class="v cyan">evidence</span></div>
+            </div>
+
+            <div>
+              <div class="aside-h">Freshness</div>
+              <div class="aside-row"><span>created</span><span class="v">11:56</span></div>
+              <div class="aside-row"><span>indexed</span><span class="v">4m ago</span></div>
+              <div class="aside-row"><span>stale after</span><span class="v amber">12:00</span></div>
+              <div class="aside-row"><span>why</span><span class="v" style="max-width:18ch">selection tied to a transient retrieval snapshot</span></div>
+            </div>
+
+            <div>
+              <div class="aside-h">Receipts</div>
+              <div class="receipt-list">
+                <span class="receipt"><span class="recdot" style="background:var(--cyan); box-shadow:0 0 6px var(--cyan)"></span>retrieval · r-0481</span>
+                <span class="receipt"><span class="recdot" style="background:var(--cyan); box-shadow:0 0 6px var(--cyan)"></span>orientation · r-0482</span>
+                <span class="receipt"><span class="recdot" style="background:var(--fg-3)"></span>write proposal · none</span>
+              </div>
+            </div>
+
+            <div>
+              <div class="aside-h">Companion reference</div>
+              <div class="aside-row"><span>session note</span><span class="v cyan">.chats/canvas-suggestion-flow/2026-05-14-1156.md</span></div>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============== 04 — REFINEMENT v2 — candidates vs selected · compact mode · similarity≠authority ============== -->
+    <section class="spec" id="s4">
+      <h2><span class="secnum">04 ·</span>Ranked candidates · compact mode · similarity is not authority</h2>
+      <p class="lede">
+        Three refinements that make the inspector's contract visually unambiguous:
+        (a) ranked candidates and selected context are not the same picture,
+        (b) provenance has a compact and an expanded view,
+        (c) semantic similarity score is rendered — but score never grants authority.
+      </p>
+
+      <h3>Ranked candidates → selected context</h3>
+      <p>
+        Retrieval returns a list of <em>candidates</em>. Selection produces the bundle's
+        <em>included</em> + <em>excluded</em> sets. The inspector renders the candidate list
+        as a faded ranked column on the left of the included list — visually subordinate, never
+        the primary surface — so the operator can see what was considered as well as what was
+        chosen.
+      </p>
+
+      <div style="display:grid; grid-template-columns: 280px 1fr; gap: var(--space-4); border: 1px solid var(--border); background: var(--bg-surface); border-radius: var(--radius-md); padding: var(--space-4); margin: var(--space-3) 0 var(--space-5);">
+        <!-- ranked candidates -->
+        <aside style="display:flex; flex-direction:column; gap:6px;" aria-label="Ranked candidates from retrieval">
+          <div style="font-family:var(--font-mono); font-size:10px; color:var(--fg-3); letter-spacing:var(--tracking-wider); text-transform:uppercase;">Retrieval candidates <span style="color:var(--fg-2);">· 8</span></div>
+          <div style="display:flex; align-items:center; gap:8px; padding:6px 8px; border-left:2px solid var(--cyan); background:var(--bg-base); border-radius:var(--radius-sm); font-size:var(--text-xs);">
+            <span style="font-family:var(--font-mono); color:var(--cyan);">0.93</span>
+            <span style="color:var(--fg-1); flex:1;">Canvas Suggestion Flow §06</span>
+            <span style="font-family:var(--font-mono); font-size:10px; color:var(--vault);">selected</span>
+          </div>
+          <div style="display:flex; align-items:center; gap:8px; padding:6px 8px; border-left:2px solid var(--cyan); background:var(--bg-base); border-radius:var(--radius-sm); font-size:var(--text-xs);">
+            <span style="font-family:var(--font-mono); color:var(--cyan);">0.88</span>
+            <span style="color:var(--fg-1); flex:1;">DEFINE_CANVAS_COEDITING…</span>
+            <span style="font-family:var(--font-mono); font-size:10px; color:var(--vault);">selected</span>
+          </div>
+          <div style="display:flex; align-items:center; gap:8px; padding:6px 8px; border-left:2px solid var(--fg-3); background:var(--bg-base); border-radius:var(--radius-sm); font-size:var(--text-xs); opacity:0.65;">
+            <span style="font-family:var(--font-mono); color:var(--fg-2);">0.81</span>
+            <span style="color:var(--fg-2); flex:1;">PanelAgent doc</span>
+            <span style="font-family:var(--font-mono); font-size:10px; color:var(--amber);">excluded</span>
+          </div>
+          <div style="display:flex; align-items:center; gap:8px; padding:6px 8px; border-left:2px solid var(--agent); background:var(--bg-base); border-radius:var(--radius-sm); font-size:var(--text-xs);">
+            <span style="font-family:var(--font-mono); color:var(--agent);">0.71</span>
+            <span style="color:var(--fg-1); flex:1;">CONTEXT_BUNDLE_CONTRACT §Excl…</span>
+            <span style="font-family:var(--font-mono); font-size:10px; color:var(--vault);">selected</span>
+          </div>
+          <div style="display:flex; align-items:center; gap:8px; padding:6px 8px; border-left:2px solid var(--fg-3); background:var(--bg-base); border-radius:var(--radius-sm); font-size:var(--text-xs); opacity:0.45;">
+            <span style="font-family:var(--font-mono); color:var(--fg-3);">0.64</span>
+            <span style="color:var(--fg-3); flex:1;">Converse v0 wireframes</span>
+            <span style="font-family:var(--font-mono); font-size:10px; color:var(--amber);">excluded</span>
+          </div>
+          <div style="display:flex; align-items:center; gap:8px; padding:6px 8px; border-left:2px solid var(--fg-3); background:var(--bg-base); border-radius:var(--radius-sm); font-size:var(--text-xs); opacity:0.35;">
+            <span style="font-family:var(--font-mono); color:var(--fg-3);">0.52</span>
+            <span style="color:var(--fg-3); flex:1;">RESURFACING_HEURISTICS</span>
+            <span style="font-family:var(--font-mono); font-size:10px; color:var(--fg-3);">below floor</span>
+          </div>
+          <div style="font-family:var(--font-mono); font-size:10px; color:var(--fg-3); padding:4px 8px;">+ 2 below floor (score &lt; 0.5)</div>
+        </aside>
+
+        <!-- selected context (summary card) -->
+        <div style="display:flex; flex-direction:column; gap:8px;">
+          <div style="font-family:var(--font-mono); font-size:10px; color:var(--cyan); letter-spacing:var(--tracking-wider); text-transform:uppercase;">Selected context (the bundle)</div>
+          <p style="font-size:var(--text-sm); color:var(--fg-2); margin:0; max-width:48ch; line-height:1.5;">
+            The bundle includes <strong style="color:var(--fg-1);">3 of 8</strong> candidates.
+            Two were excluded for reasons the operator must see (PanelAgent — sphere mismatch;
+            Converse — superseded). Three are below the score floor and rendered only as a
+            collapsed count.
+          </p>
+          <p style="font-size:var(--text-sm); color:var(--fg-2); margin:0; max-width:48ch; line-height:1.5;">
+            Selection is not a function of score alone — the 0.81 candidate was dropped
+            despite outranking the 0.71 candidate because the 0.81 was out of sphere. The
+            ranking column makes that visible at a glance.
+          </p>
+        </div>
+      </div>
+
+      <div class="callout">
+        <span class="callout-label">Visual rule</span>
+        Candidates that became <em>included</em> render at full opacity with a coloured
+        role-border. Candidates <em>excluded for a reason that affects interpretation</em>
+        render at 65% with an amber tag. Candidates <em>below the score floor</em> render at
+        35% with a neutral tag, and may collapse into a single “+N below floor” row.
+      </div>
+
+      <h3>Compact mode vs expanded provenance</h3>
+      <p>
+        The inspector has two modes. <strong>Compact</strong> is the default for inline
+        appearance — next to a chat turn, in the AI Panel side-rail, embedded in a write
+        proposal. <strong>Expanded</strong> is the standalone surface: full ranked column,
+        full aside, full per-artifact provenance.
+      </p>
+
+      <div style="display:grid; grid-template-columns: 1fr 1.4fr; gap: var(--space-4); margin: var(--space-3) 0 var(--space-5);">
+        <!-- compact -->
+        <div style="border:1px solid var(--border); background:var(--bg-surface); border-radius:var(--radius-md); overflow:hidden;">
+          <div style="padding:8px 14px; background:var(--bg-raised); border-bottom:1px solid var(--border); display:flex; gap:8px; align-items:center;">
+            <span style="font-family:var(--font-mono); font-size:10px; color:var(--fg-3); letter-spacing:var(--tracking-wider); text-transform:uppercase;">Compact mode</span>
+            <span style="font-family:var(--font-mono); font-size:10px; color:var(--cyan); margin-left:auto;">cb-…0001</span>
+          </div>
+          <div style="padding:12px 14px; display:flex; flex-direction:column; gap:8px;">
+            <div style="font-family:var(--font-display); font-size:var(--text-md); color:var(--fg-1); line-height:1.2;">Re-ranking the canvas suggestion classifier</div>
+            <div class="auth-row">
+              <span class="auth yes">✓ answer</span><span class="auth maybe">~ propose</span><span class="auth no">✗ write</span>
+            </div>
+            <div style="font-family:var(--font-mono); font-size:10px; color:var(--fg-3); letter-spacing:var(--tracking-wide); text-transform:uppercase;">3 included · 2 excluded · visible</div>
+            <button class="btn ghost" type="button" data-intent="bundle.expand" style="align-self:flex-start; font-size:10px;">Open inspector →</button>
+          </div>
+        </div>
+        <!-- expanded -->
+        <div style="border:1px solid var(--border); background:var(--bg-surface); border-radius:var(--radius-md); overflow:hidden;">
+          <div style="padding:8px 14px; background:var(--bg-raised); border-bottom:1px solid var(--border); display:flex; gap:8px; align-items:center;">
+            <span style="font-family:var(--font-mono); font-size:10px; color:var(--fg-3); letter-spacing:var(--tracking-wider); text-transform:uppercase;">Expanded mode</span>
+            <span style="font-family:var(--font-mono); font-size:10px; color:var(--cyan); margin-left:auto;">cb-…0001</span>
+          </div>
+          <div style="padding:12px 14px; display:flex; flex-direction:column; gap:8px;">
+            <div style="font-family:var(--font-display); font-size:var(--text-md); color:var(--fg-1); line-height:1.2;">Re-ranking the canvas suggestion classifier</div>
+            <div class="auth-row">
+              <span class="auth yes">✓ may_answer</span><span class="auth yes">✓ may_orient</span><span class="auth yes">✓ may_resurface</span><span class="auth maybe">~ may_propose</span><span class="auth no">✗ may_write</span>
+            </div>
+            <div style="font-family:var(--font-mono); font-size:10px; color:var(--fg-3); letter-spacing:var(--tracking-wide); text-transform:uppercase;">candidates 8 · included 3 · excluded (visible) 2 · below floor 3 · scope work / agentic-pkm-mvp · trust reviewed 3/3 · stale after 12:00 · receipts r-0481, r-0482</div>
+            <div style="font-size:var(--text-sm); color:var(--fg-2); margin:0;">Full ranked column, full aside, per-artifact provenance, exclusion reasons inline, receipts list, companion-note link — the default <span style="font-family:var(--font-mono); font-size:11px;">prototype.html §03</span> view.</div>
+          </div>
+        </div>
+      </div>
+
+      <table class="spec">
+        <thead><tr><th>Concern</th><th>Compact</th><th>Expanded</th></tr></thead>
+        <tbody>
+          <tr><td>Bundle id</td><td>visible</td><td>visible · copyable</td></tr>
+          <tr><td>Authority flags</td><td>3 most-relevant (shortened labels)</td><td>all 5, full labels</td></tr>
+          <tr><td>Included artifacts</td><td>count only</td><td>per-artifact card with role, trust, score, reason</td></tr>
+          <tr><td>Excluded artifacts</td><td>count + “visible” badge if exclusion affects interpretation</td><td>full list with reasons; collapsed by default unless interpretation-affecting</td></tr>
+          <tr><td>Ranked candidates</td><td>hidden</td><td>full faded column with score and outcome</td></tr>
+          <tr><td>Provenance / receipts</td><td>hidden</td><td>aside list</td></tr>
+          <tr><td>Stale banner</td><td>visible if stale</td><td>visible if stale</td></tr>
+          <tr><td>Compact → expanded</td><td colspan="2">single click; emits <code>bundle.expand</code>; never auto-expands</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Semantic similarity is not authority</h3>
+
+      <div class="callout invariant">
+        <span class="callout-label">Invariant</span>
+        Retrieval score answers “how textually similar was this candidate to the query.” It
+        does not answer “may the system use this as a basis to answer, orient, resurface,
+        propose, or write.” Those five permissions are declared by the bundle's authority
+        flags. The score is shown for transparency — so the operator can see selection
+        reasoning — but no UI affordance is gated on score.
+      </div>
+
+      <p>
+        Concretely, in this inspector:
+      </p>
+      <ul>
+        <li>A 0.93-score artifact in a bundle with <code>may_write: false</code> shows
+          <em>no</em> apply affordance. The score does not unlock writeback.</li>
+        <li>A 0.71-score artifact in a bundle with <code>may_propose: true</code> shows
+          the same propose affordance as a 0.93-score artifact. The score does not rank the
+          affordances either.</li>
+        <li>A bundle with no scores at all (e.g. an orientation bundle) renders the same
+          authority chips as a high-score retrieval bundle. Score is not a precondition.</li>
+        <li>A high-score candidate that was excluded by the selector still appears in the
+          ranked column — score did not buy it inclusion.</li>
+      </ul>
+
+      <div class="callout warn">
+        <span class="callout-label">Anti-pattern</span>
+        The inspector must never colour a high-score artifact “more green” than a low-score one.
+        Score is rendered in cyan mono as a value, not as a judgment. Authority is rendered
+        as discrete chips. Mixing the two would silently re-introduce the failure mode the
+        bundle contract exists to prevent.
+      </div>
+    </section>
+
+    <!-- ============== 05 ============== -->
+    <section class="spec" id="s5">
+      <h2><span class="secnum">05 ·</span>Narrow / portrait layout</h2>
+      <p class="lede">
+        Bundle review must be possible on a phone. The portrait layout stacks the bundle header,
+        authority chips, included list, and excluded disclosure. Aside content collapses into
+        accordion folds — scope, trust, freshness, receipts.
+      </p>
+
+      <div class="portrait" aria-label="Mobile / portrait — bundle inspector">
+        <div class="bar-port">
+          <span>bundle</span>
+          <span style="color:var(--cyan)">cb-…001</span>
+        </div>
+
+        <div class="ph-card">
+          <span class="ph-kicker">retrieval · turn 14</span>
+          <h4>Re-ranking the canvas suggestion classifier</h4>
+
+          <div class="auth-row">
+            <span class="auth yes"><span class="mk">✓</span>answer</span>
+            <span class="auth yes"><span class="mk">✓</span>orient</span>
+            <span class="auth maybe"><span class="mk">~</span>propose</span>
+            <span class="auth no"><span class="mk">✗</span>write</span>
+          </div>
+
+          <div class="ph-fold">
+            <span>included</span><span class="v">3</span>
+          </div>
+
+          <div class="ph-art">
+            <strong>Canvas Suggestion Flow §06</strong>
+            <div class="reason">Direct evidence for the body vs governance split.</div>
+          </div>
+          <div class="ph-art">
+            <strong>DEFINE_CANVAS_COEDITING_MODEL</strong>
+            <div class="reason">Authority contract for the answer's "server is classifier" rule.</div>
+          </div>
+
+          <div class="ph-fold">
+            <span>excluded</span>
+            <span class="v" style="color:var(--amber)">2 · visible</span>
+          </div>
+
+          <div class="ph-fold">
+            <span>trust</span>
+            <span class="v">reviewed 3 / 3</span>
+          </div>
+          <div class="ph-fold">
+            <span>scope</span>
+            <span class="v">work · agentic-pkm-mvp</span>
+          </div>
+          <div class="ph-fold">
+            <span>stale after</span>
+            <span class="v" style="color:var(--amber)">12:00</span>
+          </div>
+          <div class="ph-fold">
+            <span>receipts</span>
+            <span class="v" style="color:var(--cyan)">r-0481, r-0482</span>
+          </div>
+        </div>
+      </div>
+
+      <p>
+        Folds open in place. Authority chips never collapse to icons alone — at portrait sizes
+        they shorten ("answer", "write") but keep their <span class="auth yes" style="font-size:10px; padding:1px 6px">✓</span> /
+        <span class="auth no" style="font-size:10px; padding:1px 6px">✗</span> /
+        <span class="auth maybe" style="font-size:10px; padding:1px 6px">~</span> mark so the
+        denial is unambiguous. The excluded fold is highlighted amber when exclusion affects
+        interpretation, so an operator scanning never misses it.
+      </p>
+    </section>
+
+    <!-- ============== 06 ============== -->
+    <section class="spec" id="s6">
+      <h2><span class="secnum">06 ·</span>State gallery</h2>
+      <p class="lede">Nine bundle states. Each shows the bundle head + authority row + a one-line narrative — full inspector chrome is shared across all states.</p>
+
+      <div class="gallery bundle-gallery">
+        <!-- 1 retrieval -->
+        <div class="bm">
+          <div class="bm-bar"><span>cb-…001</span><span class="id">retrieval</span></div>
+          <div class="bm-body">
+            <h5>Re-ranking the canvas suggestion classifier</h5>
+            <span class="meta">trigger · companion-ui / turn 14 · 3 included · 2 excluded</span>
+            <div class="auth-row">
+              <span class="auth yes">✓ answer</span><span class="auth yes">✓ orient</span>
+              <span class="auth maybe">~ propose</span><span class="auth no">✗ write</span>
+            </div>
+            <p class="narrative">Supports an answer. Writeback is forbidden by the bundle's own
+              authority; the inspector hides apply affordances.</p>
+          </div>
+        </div>
+
+        <!-- 2 orientation -->
+        <div class="bm">
+          <div class="bm-bar"><span>cb-…002</span><span class="id" style="color:var(--cyan)">orientation</span></div>
+          <div class="bm-body">
+            <h5>Where was I — open loops in agentic-pkm-mvp</h5>
+            <span class="meta">trigger · re-entry · 5 included · 11 excluded</span>
+            <div class="auth-row">
+              <span class="auth yes">✓ answer</span><span class="auth yes">✓ orient</span>
+              <span class="auth yes">✓ resurface</span>
+              <span class="auth no">✗ propose</span><span class="auth no">✗ write</span>
+            </div>
+            <p class="narrative">Orientation only. Five open-loop notes; the rest of the
+              project explicitly excluded so the inspector can show what is being held back.</p>
+          </div>
+        </div>
+
+        <!-- 3 resurfacing -->
+        <div class="bm">
+          <div class="bm-bar"><span>cb-…003</span><span class="id" style="color:var(--accent)">resurfacing</span></div>
+          <div class="bm-body">
+            <h5>Why now — the watcher OOM repair note</h5>
+            <span class="meta">trigger · resurface · 1 included · "why now" present</span>
+            <div class="auth-row">
+              <span class="auth yes">✓ answer</span><span class="auth no">✗ orient</span>
+              <span class="auth yes">✓ resurface</span>
+              <span class="auth maybe">~ propose</span><span class="auth no">✗ write</span>
+            </div>
+            <p class="narrative">Resurfaced because the runtime-proof dashboard moved the
+              watcher card to amber. The "why now" rationale is required and rendered prominently.</p>
+          </div>
+        </div>
+
+        <!-- 4 write proposal -->
+        <div class="bm">
+          <div class="bm-bar"><span>cb-…004</span><span class="id" style="color:var(--accent)">write proposal</span></div>
+          <div class="bm-body">
+            <h5>Promote "context bundles are inspectable" to semantic knowledge</h5>
+            <span class="meta">trigger · propose · 4 included · 1 excluded</span>
+            <div class="auth-row">
+              <span class="auth yes">✓ answer</span><span class="auth no">✗ orient</span>
+              <span class="auth no">✗ resurface</span>
+              <span class="auth yes">✓ propose</span><span class="auth maybe">~ write · conditional on governance</span>
+            </div>
+            <p class="narrative">may_write is conditional — apply lives in Panel, gated on the
+              governance receipt. Inspector links to the proposal; never applies.</p>
+          </div>
+        </div>
+
+        <!-- 5 stale -->
+        <div class="bm">
+          <div class="bm-bar" style="color:var(--amber)"><span>cb-…005</span><span style="color:var(--amber)">stale</span></div>
+          <div class="bm-body">
+            <h5>Retrieval — re-ranking the canvas classifier (12 hours ago)</h5>
+            <span class="meta">created 02:14 · stale after 04:00 · expired 8h ago</span>
+            <div class="auth-row">
+              <span class="auth maybe">~ answer · stale</span>
+              <span class="auth no">✗ orient</span>
+              <span class="auth no">✗ resurface</span>
+              <span class="auth no">✗ propose</span>
+              <span class="auth no">✗ write</span>
+            </div>
+            <p class="narrative">Authority drops to stale-default. Status banner is amber.
+              Inspector is read-only; the bundle is preserved for audit, not reuse.</p>
+          </div>
+        </div>
+
+        <!-- 6 excluded visible -->
+        <div class="bm">
+          <div class="bm-bar"><span>cb-…006</span><span class="id">retrieval</span></div>
+          <div class="bm-body">
+            <h5>Answering about Hugin's safety posture</h5>
+            <span class="meta">3 included · 7 excluded · exclusion affects interpretation</span>
+            <div class="auth-row">
+              <span class="auth yes">✓ answer</span>
+              <span class="auth no">✗ orient</span>
+              <span class="auth no">✗ resurface</span>
+              <span class="auth no">✗ propose</span>
+              <span class="auth no">✗ write</span>
+            </div>
+            <p class="narrative">Excluded list is open by default because four of the
+              exclusions are by trust-state (low-trust agent memory); the operator must see
+              they were considered and dropped.</p>
+          </div>
+        </div>
+
+        <!-- 7 degraded provenance -->
+        <div class="bm">
+          <div class="bm-bar"><span>cb-…007</span><span style="color:var(--amber)">degraded · provenance incomplete</span></div>
+          <div class="bm-body">
+            <h5>Retrieval — partial vault scope</h5>
+            <span class="meta">2 included · 1 included without provenance</span>
+            <div class="auth-row">
+              <span class="auth maybe">~ answer · degraded</span>
+              <span class="auth no">✗ orient</span>
+              <span class="auth no">✗ resurface</span>
+              <span class="auth no">✗ propose</span>
+              <span class="auth no">✗ write</span>
+            </div>
+            <p class="narrative">One artifact has no source provenance. Inspector marks the
+              artifact <em>missing provenance</em> and downgrades may_propose to false. The
+              banner is amber.</p>
+          </div>
+        </div>
+
+        <!-- 8 empty -->
+        <div class="bm">
+          <div class="bm-bar"><span>cb-…008</span><span style="color:var(--fg-3)">empty</span></div>
+          <div class="bm-body">
+            <h5>No sufficient context</h5>
+            <span class="meta">0 included · 4 considered &amp; excluded · all out of scope</span>
+            <div class="auth-row">
+              <span class="auth no">✗ answer</span>
+              <span class="auth no">✗ orient</span>
+              <span class="auth no">✗ resurface</span>
+              <span class="auth no">✗ propose</span>
+              <span class="auth no">✗ write</span>
+            </div>
+            <p class="narrative">All authority off. The body is replaced with a single line
+              ("No sufficient context for this trigger") and the excluded list — which is
+              the only evidence the operator has that the system tried.</p>
+          </div>
+        </div>
+
+        <!-- 9 blocked -->
+        <div class="bm">
+          <div class="bm-bar"><span>cb-…009</span><span style="color:var(--destructive)">blocked</span></div>
+          <div class="bm-body">
+            <h5>Context exists but cannot support write proposal</h5>
+            <span class="meta">5 included · would-be-may_propose: true · blocked by trust</span>
+            <div class="auth-row">
+              <span class="auth yes">✓ answer</span>
+              <span class="auth yes">✓ orient</span>
+              <span class="auth yes">✓ resurface</span>
+              <span class="auth no">✗ propose · blocked</span>
+              <span class="auth no">✗ write</span>
+            </div>
+            <p class="narrative">The bundle could otherwise support a proposal, but trust
+              posture is too low. Inspector shows the blocked reason inline beside the
+              may_propose chip.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============== 07 ============== -->
+    <section class="spec" id="s7">
+      <h2><span class="secnum">07 ·</span>Edge states</h2>
+      <table class="spec">
+        <thead><tr><th>Edge</th><th>Behavior</th></tr></thead>
+        <tbody>
+          <tr><td>Empty</td><td>State 08. Body collapses to a single line; excluded list still rendered so the operator sees what was tried.</td></tr>
+          <tr><td>Loading</td><td>Bundle header skeletons render in static dim mono; authority chips are absent (never neutral-coloured, which would imply a yes).</td></tr>
+          <tr><td>Degraded provenance</td><td>State 07. Per-artifact missing-provenance label, banner amber, may_propose forced to false.</td></tr>
+          <tr><td>Blocked</td><td>State 09. The blocked authority chip carries an inline reason. No "fix it" affordance.</td></tr>
+          <tr><td>Stale</td><td>State 05. Banner amber. All authority chips downgrade to no, except may_answer which becomes <em>conditional · stale</em>.</td></tr>
+          <tr><td>Missing provenance</td><td>The artifact card carries the chip <span class="chip danger">missing provenance</span>; trust state is shown as <em>unknown</em>.</td></tr>
+          <tr><td>Write-guard denial</td><td>If the inspector is reached from a proposal that was denied, the banner reads "write guard refused — see receipt r-…" and the proposal receipt pill is the only receipt-list entry not dimmed.</td></tr>
+          <tr><td>Reduced motion</td><td>Receipt pill pulse and banner LED pulse respect <code>prefers-reduced-motion</code>; static colour preserved.</td></tr>
+          <tr><td>Narrow</td><td>§05. Single column, accordion folds for scope / trust / freshness / receipts.</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <!-- ============== 08 ============== -->
+    <section class="spec" id="s8">
+      <h2><span class="secnum">08 ·</span>Implementation contract</h2>
+      <p class="lede">
+        The UI consumes a bundle object that conforms to the target-state shape in
+        <code>CONTEXT_BUNDLE_CONTRACT.md</code>. The UI never re-classifies, re-ranks, or
+        derives authority flags.
+      </p>
+
+      <h3>Intents emitted by the inspector</h3>
+      <table class="spec">
+        <thead><tr><th class="mono">data-intent</th><th>Effect</th><th>Authority</th></tr></thead>
+        <tbody>
+          <tr><td class="mono">bundle.copy-id</td><td>Copy bundle id to clipboard</td><td>read-only</td></tr>
+          <tr><td class="mono">bundle.open-receipt</td><td>Open a receipt anchored in Panel</td><td>navigation only</td></tr>
+          <tr><td class="mono">bundle.open-session-note</td><td>Open the companion session note in Obsidian</td><td>navigation only</td></tr>
+          <tr><td class="mono">bundle.open-artifact</td><td>Open the included or excluded artifact in Obsidian / vault</td><td>navigation only</td></tr>
+          <tr><td class="mono">bundle.toggle-excluded</td><td>Open / close excluded disclosure</td><td>UI-local</td></tr>
+          <tr><td class="mono">bundle.copy-rationale</td><td>Copy selection rationale text</td><td>read-only</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Data attributes on the inspector root</h3>
+      <pre class="code">&lt;section
+  data-testid=<span class="s">"bundle-inspector"</span>
+  data-bundle-id=<span class="s">"cb-2026-05-14-001"</span>
+  data-trigger=<span class="s">"retrieval | orientation | resurfacing | action"</span>
+  data-staleness=<span class="s">"fresh | stale | expired"</span>
+  data-degraded=<span class="s">"none | provenance | trust"</span>
+  data-empty=<span class="s">"true | false"</span>&gt;</pre>
+
+      <h3>Per-artifact data attributes</h3>
+      <pre class="code">&lt;article
+  data-testid=<span class="s">"bundle-artifact"</span>
+  data-artifact-id=<span class="s">"art_123"</span>
+  data-role=<span class="s">"evidence | context | memory | companion"</span>
+  data-trust=<span class="s">"reviewed | inferred | untrusted | unknown"</span>
+  data-included=<span class="s">"true | false"</span>
+  data-provenance=<span class="s">"present | missing"</span>&gt;</pre>
+
+      <div class="callout warn">
+        <span class="callout-label">Authority flag rendering rule</span>
+        Every authority flag is rendered explicitly — never inferred. The UI's contract:
+        if the bundle carries five flags, the UI renders five chips. If the bundle adds a
+        sixth (e.g. <code>may_promote</code> for memory), the UI must render it before the
+        bundle is allowed into the inspector — adding silently is forbidden.
+      </div>
+    </section>
+
+    <!-- ============== 09 ============== -->
+    <section class="spec" id="s9">
+      <h2><span class="secnum">09 ·</span>Authority boundaries</h2>
+
+      <div class="callout invariant">
+        <span class="callout-label">Invariant · Semantic similarity is not authority</span>
+        Retrieval scores are shown for transparency, not as a justification for writeback.
+        The inspector never elevates a high-score artifact into a write proposal. Authority
+        flags govern; scores explain.
+      </div>
+
+      <div class="callout invariant">
+        <span class="callout-label">Invariant · Retrieval output must not authorize writeback</span>
+        Even when <code>may_propose: true</code>, the inspector links to the proposal — it
+        does not apply it. Apply lives in the proposing surface (Panel, Canvas), gated on the
+        governance receipt.
+      </div>
+
+      <div class="callout invariant">
+        <span class="callout-label">Invariant · Bundles are not memory</span>
+        The inspector may reference memory items the bundle includes. It must not promote
+        those items into memory or knowledge. Promotion routes through the memory candidate
+        queue (Exploration 4).
+      </div>
+
+      <table class="spec">
+        <thead>
+          <tr><th>Concern</th><th>May influence</th><th>May propose</th><th>May not decide</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Field grouping &amp; visual hierarchy</td><td class="yes">YES</td><td class="maybe">—</td><td class="no">—</td></tr>
+          <tr><td>Authority-chip wording &amp; colour</td><td class="yes">YES</td><td class="maybe">—</td><td class="no">cannot redefine flag semantics</td></tr>
+          <tr><td>Staleness presentation</td><td class="yes">YES</td><td class="maybe">propose default rendering</td><td class="no">cannot define expiry policy</td></tr>
+          <tr><td>Exclusion-visibility default</td><td class="yes">YES</td><td class="maybe">propose threshold ("affects interpretation")</td><td class="no">cannot decide what counts as affecting</td></tr>
+          <tr><td>Bundle schema</td><td class="no">—</td><td class="maybe">propose field additions to owner-doc</td><td class="no">cannot rename or remove fields</td></tr>
+          <tr><td>Authority flag set</td><td class="no">—</td><td class="maybe">propose new flag with rationale</td><td class="no">cannot loosen existing flags</td></tr>
+          <tr><td>Retrieval ranking</td><td class="no">—</td><td class="no">—</td><td class="no">runtime owns</td></tr>
+          <tr><td>Apply / writeback flow</td><td class="no">—</td><td class="no">—</td><td class="no">proposing surface owns</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <!-- ============== 10 ============== -->
+    <section class="spec" id="s10">
+      <h2><span class="secnum">10 ·</span>Open questions</h2>
+      <ol>
+        <li><strong>Default exclusion visibility.</strong> The design opens the excluded
+          disclosure when exclusion affects interpretation. The threshold for "affects
+          interpretation" is currently a heuristic. Owner-doc should make it normative — at
+          minimum: low-trust exclusion is always visible; sphere-mismatch is visible by default;
+          mere score-floor exclusion is hidden by default.</li>
+        <li><strong>Bundle-receipt shape.</strong> The inspector lists retrieval / orientation
+          / write-proposal receipts. If a bundle can carry more than these three receipt kinds,
+          the aside list will need a generic shape. We suggest owner-doc declare the receipt
+          taxonomy.</li>
+        <li><strong>"Why now" on resurfacing bundles.</strong> Resurfacing bundles must
+          render a "why now" rationale. Where does that field live in the bundle schema —
+          inside <code>selection_rationale</code>, or as its own <code>resurface_reason</code>?</li>
+        <li><strong>Cross-bundle navigation.</strong> If a write-proposal bundle was produced
+          from a retrieval bundle, should the inspector link between them? We suggest yes,
+          one-click, but the link belongs in <code>receipts</code> not in the body.</li>
+        <li><strong>Conditional may_propose semantics.</strong> We render
+          <code>may_propose: conditional</code> when the bundle's authority is contingent on
+          the proposing surface running its own write-guard. Owner-doc should normalize
+          whether "conditional" is a valid state for any of the five flags, or only for
+          <code>may_propose</code> and <code>may_write</code>.</li>
+        <li><strong>Memory-class included items.</strong> When an included item is an agent
+          memory candidate (not yet promoted), the inspector colours it gold (memory role).
+          Should that always force the bundle's <code>may_write</code> to false? We suggest
+          yes; candidate memory is not semantic authority.</li>
+      </ol>
+    </section>
+
+    <!-- ============== 11 ============== -->
+    <section class="spec" id="s11">
+      <h2><span class="secnum">11 ·</span>Handoff notes for Claude Code / Codex</h2>
+
+      <h3>Likely normalized spec</h3>
+      <ul>
+        <li>New doc: <code>docs/CONCEPTS/CONTEXT_BUNDLE_INSPECTOR_UI.md</code> — UI guidance only.
+          References <code>CONTEXT_BUNDLE_CONTRACT.md</code> for the schema.</li>
+      </ul>
+
+      <h3>Likely follow-on issues</h3>
+      <ul>
+        <li><em>Render the inspector against three fixture bundles.</em> Acceptance:
+          retrieval, orientation, write-proposal each render correctly, including
+          authority-chip states and exclusion disclosure default.</li>
+        <li><em>Render six fail-state fixtures.</em> Stale, empty, blocked, degraded,
+          missing-provenance, write-guard-denied. Acceptance: each renders with the right
+          banner colour, the right downgraded authority chips, and no apply affordance.</li>
+        <li><em>Narrow / portrait acceptance.</em> All folds work; authority chips never
+          collapse to icons alone.</li>
+        <li><em>Reduced-motion.</em> Pulses replaced with static colour. State changes still
+          readable.</li>
+        <li><em>Inspector→Panel handoff.</em> <code>bundle.open-receipt</code> opens Panel
+          anchored to the receipt id; no data dependency.</li>
+      </ul>
+
+      <h3>What this design must not feed</h3>
+      <ul>
+        <li>A retrieval re-rank surface. Re-ranking is upstream.</li>
+        <li>An apply affordance for write proposals. Apply lives in Panel / Canvas.</li>
+        <li>A memory-promotion surface. Promotion lives in the memory queue.</li>
+        <li>Any change to the bundle schema. The inspector renders; it does not declare.</li>
+      </ul>
+
+      <div class="callout vault">
+        <span class="callout-label">Validation expectation</span>
+        Passing receipt: nine state fixtures render correctly; authority chips match the bundle
+        verbatim; exclusion disclosure defaults match the threshold rule; narrow layout
+        preserves chip semantics; no UI-derived authority. Receipt id recorded in this
+        package's status field.
+      </div>
+    </section>
+
+  </main>
+</div>
+</body>
+</html>

--- a/companion-ui/design_handoff/2026-05-14-context-bundle-inspector/spec_chrome.css
+++ b/companion-ui/design_handoff/2026-05-14-context-bundle-inspector/spec_chrome.css
@@ -1,0 +1,423 @@
+/* ============================================================
+   Yggdrasil Design Handoff — Shared Spec Chrome
+   ============================================================
+   Page layout, TOC, sections, tables, callouts, chips, code,
+   gallery cards. Imported by each prototype.html after
+   colors_and_type.css.
+   ============================================================ */
+
+html, body { background: var(--bg-base); }
+body {
+  background-image:
+    linear-gradient(rgba(0,212,232,0.022) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0,212,232,0.022) 1px, transparent 1px);
+  background-size: 48px 48px;
+}
+
+.page {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: var(--space-12) var(--space-8) var(--space-16);
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: var(--space-12);
+}
+
+/* ---- Sidebar TOC ---- */
+.toc {
+  position: sticky;
+  top: var(--space-8);
+  align-self: start;
+  font-size: var(--text-sm);
+  border-left: 1px solid var(--border);
+  padding-left: var(--space-4);
+  max-height: calc(100vh - var(--space-12));
+  overflow-y: auto;
+}
+.toc-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  margin-bottom: var(--space-3);
+}
+.toc ol { list-style: none; display: flex; flex-direction: column; gap: 6px; }
+.toc a {
+  color: var(--fg-2);
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  display: block;
+  line-height: 1.4;
+}
+.toc a:hover { color: var(--cyan); text-decoration: none; }
+.toc-num {
+  font-family: var(--font-mono);
+  color: var(--fg-3);
+  margin-right: 6px;
+  font-size: var(--text-xs);
+}
+
+/* ---- Header ---- */
+.doc-header {
+  border-bottom: 1px solid var(--border);
+  padding-bottom: var(--space-6);
+  margin-bottom: var(--space-10);
+}
+.doc-eyebrow {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--cyan);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  margin-bottom: var(--space-3);
+}
+.doc-title {
+  font-family: var(--font-display);
+  font-size: var(--text-3xl);
+  line-height: 1.1;
+  margin-bottom: var(--space-4);
+  color: var(--fg-1);
+}
+.doc-lede {
+  color: var(--fg-2);
+  font-size: var(--text-md);
+  max-width: 70ch;
+  margin-bottom: var(--space-5);
+  line-height: var(--leading-snug);
+}
+.doc-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4) var(--space-6);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+}
+.doc-meta span strong {
+  color: var(--fg-2);
+  font-weight: var(--weight-regular);
+  margin-right: 6px;
+}
+
+/* ---- Sections ---- */
+section.spec {
+  margin-bottom: var(--space-12);
+  scroll-margin-top: var(--space-6);
+}
+section.spec > h2 {
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-regular);
+  color: var(--fg-1);
+  margin-bottom: var(--space-2);
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+}
+section.spec > h2 .secnum {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--cyan);
+  letter-spacing: var(--tracking-wide);
+}
+section.spec > .lede {
+  color: var(--fg-2);
+  font-size: var(--text-base);
+  margin-bottom: var(--space-5);
+  max-width: 72ch;
+}
+section.spec h3 {
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--fg-1);
+  margin: var(--space-6) 0 var(--space-3);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+}
+section.spec p {
+  color: var(--fg-1);
+  margin-bottom: var(--space-3);
+  max-width: 72ch;
+}
+section.spec ul, section.spec ol {
+  color: var(--fg-1);
+  margin: 0 0 var(--space-4) var(--space-5);
+  max-width: 72ch;
+}
+section.spec li { margin-bottom: 6px; line-height: 1.55; }
+
+/* ---- Tables ---- */
+table.spec {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+  margin: var(--space-3) 0 var(--space-5);
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+}
+table.spec th, table.spec td {
+  text-align: left;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+table.spec th {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--fg-2);
+  background: var(--bg-raised);
+  font-weight: var(--weight-medium);
+  border-bottom: 1px solid var(--border-strong);
+}
+table.spec tr:last-child td { border-bottom: none; }
+table.spec td code { font-size: 0.9em; }
+table.spec td.mono, table.spec th.mono { font-family: var(--font-mono); }
+table.spec td.yes { color: var(--vault); font-family: var(--font-mono); font-size: var(--text-xs); }
+table.spec td.no { color: var(--destructive); font-family: var(--font-mono); font-size: var(--text-xs); }
+table.spec td.maybe { color: var(--amber); font-family: var(--font-mono); font-size: var(--text-xs); }
+
+/* ---- Callouts ---- */
+.callout {
+  border-left: 2px solid var(--cyan);
+  background: rgba(0,212,232,0.04);
+  padding: var(--space-3) var(--space-4);
+  margin: var(--space-4) 0;
+  font-size: var(--text-sm);
+  color: var(--fg-1);
+  max-width: 72ch;
+}
+.callout.warn { border-left-color: var(--amber); background: rgba(240,144,48,0.05); }
+.callout.invariant { border-left-color: var(--accent); background: rgba(212,168,67,0.04); }
+.callout.danger { border-left-color: var(--destructive); background: rgba(255,61,61,0.04); }
+.callout.vault { border-left-color: var(--vault); background: rgba(57,232,125,0.04); }
+.callout-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--cyan);
+  display: block;
+  margin-bottom: 4px;
+}
+.callout.warn .callout-label { color: var(--amber); }
+.callout.invariant .callout-label { color: var(--accent); }
+.callout.danger .callout-label { color: var(--destructive); }
+.callout.vault .callout-label { color: var(--vault); }
+
+/* ---- Tag chips ---- */
+.chip {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wide);
+  padding: 1px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-raised);
+  color: var(--fg-2);
+}
+.chip.design  { color: var(--cyan); border-color: rgba(0,212,232,0.3); }
+.chip.impl    { color: var(--accent); border-color: rgba(212,168,67,0.3); }
+.chip.gated   { color: var(--amber); border-color: rgba(240,144,48,0.3); }
+.chip.agent   { color: var(--agent); border-color: rgba(74,158,255,0.3); }
+.chip.vault   { color: var(--vault); border-color: rgba(57,232,125,0.3); }
+.chip.danger  { color: var(--destructive); border-color: rgba(255,61,61,0.3); }
+
+/* ---- Code blocks ---- */
+pre.code {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--fg-1);
+  overflow-x: auto;
+  margin: var(--space-3) 0 var(--space-5);
+  line-height: 1.55;
+}
+pre.code .k { color: var(--cyan); }
+pre.code .s { color: var(--vault); }
+pre.code .c { color: var(--fg-3); font-style: italic; }
+pre.code .n { color: var(--accent); }
+pre.code .a { color: var(--agent); }
+
+/* ---- Gallery ---- */
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--space-5);
+  margin: var(--space-4) 0 var(--space-6);
+}
+.gallery.three { grid-template-columns: repeat(3, 1fr); }
+.gallery-card {
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  min-height: 240px;
+}
+.gallery-card header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  border-bottom: 1px dashed var(--border);
+  padding-bottom: 10px;
+}
+.gallery-card h4 {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--fg-2);
+}
+.gallery-card .note {
+  font-size: var(--text-sm);
+  color: var(--fg-2);
+  margin: 0;
+}
+
+/* ---- Receipt pill ---- */
+.receipt {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  border-radius: var(--radius-full);
+  background: var(--bg-raised);
+  border: 1px solid var(--border-strong);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-2);
+  letter-spacing: var(--tracking-wide);
+}
+.receipt.queued  { color: var(--accent); border-color: rgba(212,168,67,0.4); }
+.receipt.applied { color: var(--vault); border-color: rgba(57,232,125,0.4); }
+.receipt.pending { color: var(--amber); border-color: rgba(240,144,48,0.4); }
+.receipt.failed  { color: var(--destructive); border-color: rgba(255,61,61,0.4); }
+.receipt .recdot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 6px currentColor;
+}
+.receipt.queued .recdot { animation: pulse 1.6s ease-in-out infinite; }
+.receipt.pending .recdot { animation: pulse 1.6s ease-in-out infinite; }
+@keyframes pulse { 0%, 100% { opacity: 0.4; } 50% { opacity: 1; } }
+
+/* ---- Buttons ---- */
+.btn {
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  padding: 5px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-raised);
+  color: var(--fg-1);
+  border: 1px solid var(--border-strong);
+  cursor: pointer;
+}
+.btn:hover { border-color: var(--cyan); color: var(--cyan); }
+.btn.primary {
+  background: var(--amber-muted);
+  color: var(--amber);
+  border-color: rgba(240,144,48,0.5);
+}
+.btn.primary:hover { background: rgba(240,144,48,0.12); border-color: var(--amber); color: var(--amber); }
+.btn.governance {
+  background: rgba(212,168,67,0.06);
+  color: var(--accent);
+  border-color: rgba(212,168,67,0.5);
+}
+.btn.governance:hover { background: rgba(212,168,67,0.12); border-color: var(--accent); }
+.btn.vault {
+  background: rgba(57,232,125,0.06);
+  color: var(--vault);
+  border-color: rgba(57,232,125,0.4);
+}
+.btn.vault:hover { background: rgba(57,232,125,0.12); border-color: var(--vault); }
+.btn.danger {
+  background: rgba(255,61,61,0.05);
+  color: var(--destructive);
+  border-color: rgba(255,61,61,0.4);
+}
+.btn.ghost { background: transparent; }
+.btn[disabled], .btn.disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.btn .kbd {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  color: var(--fg-3);
+  margin-left: 6px;
+}
+
+/* ---- Bullet list with mono prefix (for checklists) ---- */
+ul.check {
+  list-style: none;
+  margin-left: 0 !important;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+ul.check li {
+  position: relative;
+  padding-left: 22px;
+  font-size: var(--text-sm);
+}
+ul.check li::before {
+  content: '[ ]';
+  position: absolute;
+  left: 0;
+  top: 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  letter-spacing: 0;
+}
+ul.check li.done::before { content: '[x]'; color: var(--vault); }
+ul.check li.skip::before { content: '[-]'; color: var(--amber); }
+
+/* ---- Doc-template card (for handoff templates) ---- */
+.template {
+  border: 1px solid var(--border-strong);
+  background: var(--bg-surface);
+  border-radius: var(--radius-md);
+  padding: var(--space-4) var(--space-5);
+  margin: var(--space-4) 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--fg-1);
+  white-space: pre-wrap;
+  line-height: 1.65;
+  overflow-x: auto;
+}
+.template .h { color: var(--cyan); }
+.template .v { color: var(--vault); }
+.template .g { color: var(--accent); }
+.template .c { color: var(--fg-3); font-style: italic; }
+.template .a { color: var(--agent); }
+
+/* ---- Responsive ---- */
+@media (max-width: 900px) {
+  .page { grid-template-columns: 1fr; padding: var(--space-6) var(--space-4); }
+  .toc {
+    position: static;
+    max-height: none;
+    border-left: none;
+    border-bottom: 1px solid var(--border);
+    padding: 0 0 var(--space-4);
+  }
+  .gallery, .gallery.three { grid-template-columns: 1fr; }
+}

--- a/companion-ui/design_handoff/2026-05-14-context-bundle-inspector/state-gallery.md
+++ b/companion-ui/design_handoff/2026-05-14-context-bundle-inspector/state-gallery.md
@@ -1,0 +1,37 @@
+# State gallery — Context Bundle Inspector
+
+The full visual gallery lives in **`prototype.html` §05**. This document is a text mirror
+intended for quick scanning in code review and for issue acceptance criteria.
+
+Every state is described as a (name, when, designed behavior) triple. The prototype is the
+authority on the visual; this document is the authority on the state list.
+
+See `prototype.html` §02 for the field model, §03 for the inspector prototype, §04 for the portrait layout, §05 for the 9-state gallery.
+
+## State list
+
+See the gallery cards in `prototype.html` §05 for the canonical visuals. Each state in the
+gallery includes:
+
+- A bar with the state name and a state-kind chip.
+- A title-row LED in the appropriate colour (vault / amber / destructive / dim / gold).
+- A one-paragraph narrative describing the state.
+- A meta line of mono captions naming the values that distinguish the state.
+- Where relevant, a next-action strip with the suggested operator action.
+
+## Transition table (illustrative)
+
+Detailed transitions for the UI state machine are owned by `implementation-contracts.md`;
+this gallery is descriptive, not normative. Implementation must enumerate the full set
+declared in the contract document.
+
+## Edge cases the gallery covers
+
+- **Empty** — the surface explains why there is nothing and what produces content.
+- **Loading** — inert, distinguishable from empty.
+- **Degraded** — partial function with explicit naming of what is degraded.
+- **Blocked** — refusal is named, recorded, and never silently retried.
+- **Stale** — staleness is shown with a "why" and an explicit threshold.
+- **Missing provenance** — surfaced, not hidden; never silently authoritative.
+
+For the full edge-state checklist see `edge-states.md`.

--- a/companion-ui/design_handoff/2026-05-14-handoff-governance-pack/README.md
+++ b/companion-ui/design_handoff/2026-05-14-handoff-governance-pack/README.md
@@ -1,0 +1,53 @@
+# Design Handoff Governance Pack
+
+**Date:** 2026-05-14
+**Status:** Design handoff · v1 · ready for review at crossing B (handoff → normalized spec)
+**Authority:** Process pattern only — not runtime, not architecture
+**Owner-docs:** docs/INTERACTION_SURFACES_AND_AUTHORITY/
+**Crossing target:** B
+
+## What this is
+
+A meta-handoff. How a Claude Design exploration becomes a governed implementation input — without becoming architecture authority on the way. Defines the chain:
+
+```
+design exploration → handoff package → normalized spec → GitHub issue → PR → validation receipt
+```
+
+Five artifacts inside the package:
+
+- **Governance flow diagram** with crossing-by-crossing evidence requirements.
+- **Maturity checklist** that decides when an exploration is allowed to become a normalized spec.
+- **Review console prototype** — a target-shape operator surface for walking packages through the chain.
+- **Three templates**: README, implementation-contract notes, authority-boundaries.
+- **State, edge-case, and influence inventories** every design must answer before promotion.
+
+See `prototype.html` §02 for the flow diagram, §03 for the maturity checklist, §04 for the review console prototype, §05–§07 for the README / implementation-contract / authority-boundaries templates.
+
+## Influence
+
+- **May influence:** the folder shape for every handoff in `companion-ui/design_handoff/`; the maturity bar at crossing B; the wording of README / implementation-contract / authority-boundaries templates.
+- **May not decide:** which docs are owner-docs; which contracts are authority; the gated-execution invariant; how a validation receipt is produced.
+
+## Files
+
+- `prototype.html` — full 12-section spec + interactive review-console mock.
+- `design-notes.md` — visual guidance and rationale.
+- `state-gallery.md` — every UI state in the prototype, with descriptions.
+- `implementation-contracts.md` — what implementation reads from this package.
+- `authority-boundaries.md` — what this design may / may not influence.
+- `edge-states.md` — empty / loading / degraded / blocked / stale / missing-provenance / write-guard / reduced-motion / narrow.
+- `open-questions.md` — unresolved, with proposed owners.
+
+## Related
+
+- `docs/INTERACTION_SURFACES_AND_AUTHORITY/` — the existing authority-boundary docs that this pack governs the contribution process for.
+- `companion-ui/design_handoff/README.md` — the handoff-folder index.
+- The four sibling 2026-05-14 packages, which are themselves the first packages produced under this pack's folder shape.
+
+## Authority &amp; disclaimers
+
+- **This design is visual guidance.** It is not architecture authority. Architecture authority lives in repo owner-docs.
+- **Runtime truth lives downstream.** It is not asserted in this package. Runtime truth comes from shipped code, tests, status docs, and validation receipts.
+- **This package proposes; it does not promote.** Promotion happens at crossing B (the maturity bar in the governance pack §03).
+- **The gated-execution invariant is honored throughout.** No interaction surface in this design mutates durable state outside the governed pipeline.

--- a/companion-ui/design_handoff/2026-05-14-handoff-governance-pack/authority-boundaries.md
+++ b/companion-ui/design_handoff/2026-05-14-handoff-governance-pack/authority-boundaries.md
@@ -1,0 +1,44 @@
+# Authority boundaries — Design Handoff Governance Pack
+
+## This design is
+
+- **Visual guidance** for the surface(s) named in this package's README.
+- **An interaction contract** limited to the fields, intents, and data attributes enumerated
+  in `implementation-contracts.md` and in `prototype.html` §07.
+- **A target-state proposal** until a normalized spec lands in owner-docs.
+
+## This design is not
+
+- **Architecture authority.** Authority lives in:
+  - `docs/INTERACTION_SURFACES_AND_AUTHORITY/`
+- **Runtime truth.** Runtime truth lives in shipped code, tests, status docs, and validation
+  receipts.
+- **A schema.** This contract references fields the runtime exposes; it does not declare them.
+- **A claim about current runtime behavior** unless explicitly cited from owner-docs.
+
+## Invariants this design honors
+
+- **Gated execution.** No interaction surface in this design mutates durable state outside
+  the existing governed path: policy, validation, event pipeline, deterministic writer.
+- **Authority separation.** Chat is a canvas surface; Panel is the command surface;
+  Automation is its own lane. This design does not collapse them.
+- **Provenance visibility.** Where this design shows agent-contributed content, it shows
+  source, trust state, and authority flags.
+- **Bundle integrity.** Where this design shows context selection, it shows what was excluded
+  when exclusion affects interpretation.
+- **Memory candidacy.** Where this design touches agent memory, it never treats candidate
+  memory as semantic authority.
+
+## What this design may suggest to owner-docs
+
+See `prototype.html` §10 ("Handoff notes for Claude Code / Codex") of this package for the
+specific proposed normalized-spec path and follow-on issues. Owner-doc owners decide whether
+to accept any of those suggestions.
+
+## What this design must not suggest
+
+- Any loosening of the gated-execution invariant.
+- Any new authority surface that bypasses the existing pipeline.
+- Any new write path that bypasses policy / validation.
+- Any silent promotion of agent memory into semantic knowledge.
+- Any redefinition of authority flag semantics.

--- a/companion-ui/design_handoff/2026-05-14-handoff-governance-pack/colors_and_type.css
+++ b/companion-ui/design_handoff/2026-05-14-handoff-governance-pack/colors_and_type.css
@@ -1,0 +1,346 @@
+/* ============================================================
+   Yggdrasil Design System — Colors & Type
+   ============================================================
+   Import this file in any HTML artifact or UI kit.
+   Google Fonts are imported below; JetBrains Mono via bunny.net.
+   ============================================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Space+Grotesk:wght@300;400;500;600&display=swap');
+@import url('https://fonts.bunny.net/css?family=jetbrains-mono:400,500&display=swap');
+
+/* ============================================================
+   BASE COLOR TOKENS
+   ============================================================ */
+:root {
+  /* --- Backgrounds (cool blue-black — Tron grid) --- */
+  --bg-base:       #070b12;   /* deepest — page root, near black with blue cast */
+  --bg-surface:    #0c1220;   /* panels, sidebars */
+  --bg-raised:     #111a2e;   /* cards, inputs, raised surfaces */
+  --bg-overlay:    #162038;   /* hover states, popovers */
+  --bg-modal:      #0e1828;   /* modal / dialog backdrop content */
+
+  /* --- Foreground / Text --- */
+  --fg-1:          #dce8f0;   /* primary — cool blue-white */
+  --fg-2:          #7a9ab8;   /* secondary / muted */
+  --fg-3:          #3d5570;   /* tertiary / disabled / dim */
+  --fg-inverse:    #070b12;   /* text on light/accent backgrounds */
+
+  /* --- Borders (thin, slightly glowing) --- */
+  --border:        #152030;   /* default — subtle grid line */
+  --border-strong: #1e3050;   /* emphasis — dividers, active edges */
+  --border-focus:  #00d4e8;   /* focus ring — electric cyan */
+
+  /* --- Accent 1: Norse Gold (slightly electrified) --- */
+  --accent:        #d4a843;   /* primary accent — active, focus, key affordances */
+  --accent-dim:    #80621a;   /* dimmed gold */
+  --accent-muted:  #2a1e06;   /* gold at low opacity */
+
+  /* --- Accent 2: Tron Cyan (neon electric) --- */
+  --cyan:          #00d4e8;   /* electric cyan — Tron primary glow */
+  --cyan-dim:      #007a8a;   /* dimmed cyan */
+  --cyan-muted:    #001e28;   /* cyan tint background */
+  --cyan-glow:     0 0 12px rgba(0,212,232,0.35), 0 0 4px rgba(0,212,232,0.5);
+
+  /* --- Vault: Neon green (digital growth) --- */
+  --vault:         #39e87d;   /* vault-connected — electric green */
+  --vault-dim:     #1a7840;   /* vault hover */
+  --vault-muted:   #041a10;   /* vault background tint */
+  --vault-glow:    0 0 8px rgba(57,232,125,0.3);
+
+  /* --- Agent: Electric blue (machine voice) --- */
+  --agent:         #4a9eff;   /* agent-contributed UI and content */
+  --agent-dim:     #1e5a9a;   /* agent hover */
+  --agent-muted:   #051228;   /* agent background tint */
+  --agent-glow:    0 0 8px rgba(74,158,255,0.3);
+
+  /* --- Amber (staged / uncommitted) --- */
+  --amber:         #f09030;   /* warnings, uncommitted/staged state */
+  --amber-dim:     #805010;
+  --amber-muted:   #1a0e02;
+
+  /* --- Destructive --- */
+  --destructive:      #ff3d3d;
+  --destructive-dim:  #8a1a1a;
+  --destructive-muted:#160404;
+
+  /* --- Semantic UI colors --- */
+  --color-bg:        var(--bg-base);
+  --color-surface:   var(--bg-surface);
+  --color-text:      var(--fg-1);
+  --color-muted:     var(--fg-2);
+  --color-dim:       var(--fg-3);
+  --color-border:    var(--border);
+  --color-accent:    var(--accent);
+
+  /* ============================================================
+     TYPOGRAPHY
+     ============================================================ */
+
+  /* --- Font families --- */
+  --font-display:  'EB Garamond', Georgia, serif;
+  --font-ui:       'Space Grotesk', system-ui, sans-serif;
+  --font-mono:     'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+
+  /* --- Type scale (rem, base 16px) --- */
+  --text-xs:    0.6875rem;   /* 11px — metadata, timestamps */
+  --text-sm:    0.8125rem;   /* 13px — secondary labels, captions */
+  --text-base:  0.9375rem;   /* 15px — body / default UI */
+  --text-md:    1.0625rem;   /* 17px — slightly emphasized body */
+  --text-lg:    1.1875rem;   /* 19px — section headers */
+  --text-xl:    1.5rem;      /* 24px — page titles */
+  --text-2xl:   2rem;        /* 32px — display moments */
+  --text-3xl:   2.75rem;     /* 44px — wordmark / hero */
+  --text-4xl:   3.75rem;     /* 60px — large display */
+
+  /* --- Line heights --- */
+  --leading-tight:  1.25;
+  --leading-snug:   1.4;
+  --leading-normal: 1.55;
+  --leading-loose:  1.75;
+
+  /* --- Font weights --- */
+  --weight-light:   300;
+  --weight-regular: 400;
+  --weight-medium:  500;
+  --weight-semibold:600;
+
+  /* --- Letter spacing --- */
+  --tracking-tight: -0.02em;
+  --tracking-normal: 0em;
+  --tracking-wide:   0.04em;
+  --tracking-wider:  0.08em;
+
+  /* ============================================================
+     SPACING
+     ============================================================ */
+  --space-1:   4px;
+  --space-2:   8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  20px;
+  --space-6:  24px;
+  --space-8:  32px;
+  --space-10: 40px;
+  --space-12: 48px;
+  --space-16: 64px;
+
+  /* ============================================================
+     BORDER RADIUS — sharper for cyberpunk aesthetic
+     ============================================================ */
+  --radius-sm:   2px;
+  --radius-md:   4px;
+  --radius-lg:   6px;
+  --radius-xl:  10px;
+  --radius-full: 9999px;
+
+  /* ============================================================
+     SHADOWS / ELEVATION
+     ============================================================ */
+  --shadow-sm:  0 1px 3px rgba(0,0,0,0.3);
+  --shadow-md:  0 4px 12px rgba(0,0,0,0.4);
+  --shadow-lg:  0 8px 32px rgba(0,0,0,0.5);
+  --shadow-float: 0 4px 24px rgba(0,0,0,0.55), 0 1px 4px rgba(0,0,0,0.3);
+  --shadow-inset: inset 0 1px 3px rgba(0,0,0,0.35);
+
+  /* ============================================================
+     ANIMATION
+     ============================================================ */
+  --ease:        cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-linear: linear;
+  --duration-fast: 100ms;
+  --duration-base: 150ms;
+  --duration-slow: 250ms;
+
+  /* ============================================================
+     Z-INDEX SCALE
+     ============================================================ */
+  --z-base:    1;
+  --z-raised:  10;
+  --z-sticky:  100;
+  --z-overlay: 200;
+  --z-modal:   300;
+  --z-toast:   400;
+}
+
+/* ============================================================
+   SEMANTIC ELEMENT DEFAULTS
+   ============================================================ */
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+body {
+  background-color: var(--bg-base);
+  color: var(--fg-1);
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-normal);
+}
+
+/* --- Display headings (EB Garamond) --- */
+h1, .h1 {
+  font-family: var(--font-display);
+  font-size: var(--text-3xl);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  color: var(--fg-1);
+}
+
+h2, .h2 {
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  color: var(--fg-1);
+}
+
+/* --- UI headings (DM Sans) --- */
+h3, .h3 {
+  font-family: var(--font-ui);
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-snug);
+  color: var(--fg-1);
+}
+
+h4, .h4 {
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-snug);
+  color: var(--fg-1);
+}
+
+h5, h6, .h5, .h6 {
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-snug);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--fg-2);
+}
+
+p {
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
+  color: var(--fg-1);
+  text-wrap: pretty;
+}
+
+small, .text-sm {
+  font-size: var(--text-sm);
+  color: var(--fg-2);
+}
+
+.text-xs {
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  font-family: var(--font-mono);
+  letter-spacing: var(--tracking-wide);
+}
+
+code, kbd, pre, .mono {
+  font-family: var(--font-mono);
+  font-size: 0.875em; /* relative to surrounding text */
+}
+
+code {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.1em 0.35em;
+  color: var(--fg-1);
+}
+
+pre {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  overflow-x: auto;
+  font-size: var(--text-sm);
+  line-height: var(--leading-normal);
+  color: var(--fg-1);
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+a:hover {
+  color: var(--fg-1);
+  text-decoration: underline;
+}
+
+hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: var(--space-6) 0;
+}
+
+/* ============================================================
+   UTILITY CLASSES
+   ============================================================ */
+
+/* Text colors */
+.text-primary   { color: var(--fg-1); }
+.text-secondary { color: var(--fg-2); }
+.text-dim       { color: var(--fg-3); }
+.text-accent    { color: var(--accent); }
+.text-cyan      { color: var(--cyan); }
+.text-vault     { color: var(--vault); }
+.text-agent     { color: var(--agent); }
+.text-amber     { color: var(--amber); }
+.text-danger    { color: var(--destructive); }
+
+/* Font families */
+.font-display { font-family: var(--font-display); }
+.font-ui      { font-family: var(--font-ui); }
+.font-mono    { font-family: var(--font-mono); }
+
+/* Weights */
+.weight-light    { font-weight: var(--weight-light); }
+.weight-regular  { font-weight: var(--weight-regular); }
+.weight-medium   { font-weight: var(--weight-medium); }
+.weight-semibold { font-weight: var(--weight-semibold); }
+
+/* Glow effects */
+.glow-cyan   { box-shadow: var(--cyan-glow); }
+.glow-vault  { box-shadow: var(--vault-glow); }
+.glow-agent  { box-shadow: var(--agent-glow); }
+.text-glow-cyan  { text-shadow: 0 0 12px rgba(0,212,232,0.7); }
+.text-glow-gold  { text-shadow: 0 0 16px rgba(212,168,67,0.5); }
+
+/* Tron grid background */
+.grid-bg {
+  background-image:
+    linear-gradient(rgba(0,212,232,0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0,212,232,0.04) 1px, transparent 1px);
+  background-size: 32px 32px;
+}
+
+/* Neon border active state */
+.border-cyan { border-color: var(--cyan) !important; box-shadow: var(--cyan-glow); }
+.border-gold { border-color: var(--accent) !important; box-shadow: 0 0 8px rgba(212,168,67,0.3); }
+
+/* Focus ring */
+:focus-visible {
+  outline: 1px solid var(--cyan);
+  outline-offset: 2px;
+  box-shadow: var(--cyan-glow);
+}

--- a/companion-ui/design_handoff/2026-05-14-handoff-governance-pack/design-notes.md
+++ b/companion-ui/design_handoff/2026-05-14-handoff-governance-pack/design-notes.md
@@ -1,0 +1,68 @@
+# Design notes — Design Handoff Governance Pack
+
+## Visual language
+
+This package follows the shared Yggdrasil design system (`colors_and_type.css`) used across the
+2026-05 companion-ui handoffs:
+
+- **Dark, cool blue-black background** (`--bg-base`) with a subtle Tron grid.
+- **Cool blue-white text** (`--fg-1`); secondary copy in `--fg-2`; mono captions in `--fg-3`.
+- **Norse gold** (`--accent`) for governance and provenance accents.
+- **Electric cyan** (`--cyan`) for trigger / link / receipt-pending cues.
+- **Vault green** (`--vault`) for healthy, applied, reviewed.
+- **Amber** (`--amber`) for staged, stale, inferred, or attention-needed.
+- **Destructive red** (`--destructive`) for refusal, denial, conflict, and dead-letter.
+
+Type: **EB Garamond** for display, **Space Grotesk** for UI, **JetBrains Mono** for evidence
+captions, ids, scores, and timestamps. Mono is the load-bearing voice of "this is evidence,
+not summary."
+
+## Surface posture
+
+How a Claude Design exploration becomes a governed implementation input — without becoming architecture authority on the way.
+
+The surface is intentionally **calm**:
+
+- No alarm noise. Red is reserved for actual refusals.
+- No coloured tiles without evidence. Every mono caption is rooted in a runtime value.
+- Animation is restrained: receipt-pill pulse and the banner LED only. Both respect
+  `prefers-reduced-motion`.
+- No emoji. Status uses short words ("Running", "Backlogged", "Stale") rather than icons.
+
+## Component vocabulary
+
+The shared spec chrome (`spec_chrome.css`) carries:
+
+- `.callout` (cyan, amber, accent, destructive, vault variants) for invariants and notes.
+- `.chip` for tag-style metadata.
+- `.receipt` (queued, applied, pending, failed) for receipt pills.
+- `.btn` (primary, governance, vault, danger, ghost) for actions.
+- `.gallery` and `.gallery-card` for state galleries.
+- `table.spec` for evidence tables with mono headers.
+
+Each prototype adds local components on top — see `prototype.html` for inline styles.
+
+See `prototype.html` §02 for the flow diagram, §03 for the maturity checklist, §04 for the review console prototype, §05–§07 for the README / implementation-contract / authority-boundaries templates.
+
+## Why the layout is the way it is
+
+- **TOC sidebar.** Specs are scanned, not read. The TOC is sticky so scanning stays cheap.
+- **Mono section numbers and metadata.** Visual contract: mono text means "this is a value
+  the runtime emits", not a designer's invented label.
+- **Section heads in EB Garamond.** Display serif at section boundaries marks the
+  transitions in attention; UI sans inside the section keeps reading dense.
+- **No hover-only affordances.** Every action is visible at rest; hover only adds an accent.
+
+## Copy conventions
+
+- Headlines: short verbs or adjectives.
+- Captions: mono, in `--fg-3`.
+- Action labels: uppercase, letter-spacing wide, never punctuated.
+- Status copy: second-person plain language. Never imperative-without-object ("Restart").
+
+## Out of scope for this package
+
+- Brand redesign.
+- New colour tokens (none added).
+- New type pairings.
+- Animation grammar beyond the existing receipt-pulse pattern.

--- a/companion-ui/design_handoff/2026-05-14-handoff-governance-pack/edge-states.md
+++ b/companion-ui/design_handoff/2026-05-14-handoff-governance-pack/edge-states.md
@@ -1,0 +1,30 @@
+# Edge states — Design Handoff Governance Pack
+
+This document is the edge-state checklist required by the Handoff Governance Pack §08.
+The full per-state visual treatment lives in **`prototype.html` §06 (Edge states)**. This
+document is the text checklist.
+
+## Required edges
+
+- **Empty** — designed (see `prototype.html` §06).
+- **Loading** — designed; static dim states, no skeleton animation.
+- **Degraded** — designed; partial function with explicit naming of what is degraded.
+- **Blocked** — designed; refusal is named, recorded, and never silently retried.
+- **Stale context** — designed; threshold and "why" rendered.
+- **Missing provenance** — designed; surfaced rather than hidden.
+- **Write-guard denial** — designed; denial reason visible; not retried.
+- **Reduced motion** — designed; receipt pulse + banner LED respect `prefers-reduced-motion`.
+- **Narrow / mobile layout** — designed; see `prototype.html` §06 (and §04 for the
+  portrait-specific layout in the bundle inspector).
+
+## Deferred-with-reason
+
+None for this package. If a future revision defers any edge, it must be tracked here with a
+reason and a follow-up issue link.
+
+## Validation expectations
+
+Per the implementation contract, every edge above must render correctly from a fixture and
+must satisfy the per-edge acceptance criteria in `prototype.html` §06. Reduced-motion is
+verified with the OS preference set; narrow layouts are verified at the documented
+breakpoints (`< 900px` for the standard collapse; `< 560px` where applicable).

--- a/companion-ui/design_handoff/2026-05-14-handoff-governance-pack/implementation-contracts.md
+++ b/companion-ui/design_handoff/2026-05-14-handoff-governance-pack/implementation-contracts.md
@@ -1,0 +1,69 @@
+# Implementation contract — Design Handoff Governance Pack
+
+**Status:** Contract for UI integration · target-state
+**Mutates:** nothing on its own
+**Depends on:** docs/INTERACTION_SURFACES_AND_AUTHORITY/, the gated-execution invariant.
+
+## Position in the chain
+
+This document is the part of the package that implementation reads. It is the only document
+that promises anything to code. Everything else in the package (README, design-notes,
+state-gallery, edge-states, authority-boundaries, open-questions) is guidance.
+
+## State enum
+
+The implementation must enumerate exactly the states described in **`prototype.html` §03 + §05**. Adding
+or removing a state without amending this document means the design no longer covers it.
+
+## Allowed transitions
+
+See **`prototype.html` §03 + §05** for the per-state transition table. Implementation must
+reject any transition not enumerated there.
+
+## Data attributes
+
+Stable attributes the design relies on for testids and behavioral selectors are listed in
+**`prototype.html` §07 (Implementation contract)** of this package. Required attributes are
+flagged in the prototype's code block. Adding new attributes is permitted; renaming is not.
+
+## Intents
+
+The full `data-intent` vocabulary is in **`prototype.html` §07**. Each intent declares:
+
+- the surface that emits it,
+- the effect (UI-local / read-only / governed / navigation),
+- whether it routes through the governance pipeline.
+
+Implementation must not emit intents not declared here. Adding a new intent requires an
+amendment to this document.
+
+## Server contract surface
+
+Endpoints / events / classifiers the UI consumes are bound to existing or proposed runtime
+contracts. The UI never re-classifies; the server's declared class wins.
+
+Specific contract references:
+
+- `docs/INTERACTION_SURFACES_AND_AUTHORITY/`
+
+## Validation expectations
+
+A passing validation receipt for this package would render the full state gallery against
+fixture inputs, verify every declared transition, and confirm:
+
+- no UI-derived posture / class / authority,
+- denied / blocked states emit the right receipts,
+- reduced-motion preference is respected,
+- narrow / portrait layout preserves all critical affordances.
+
+The exact fixture set is owned by the implementation issue, not this document.
+
+## What this contract does not say
+
+Explicit list of things implementation is free to choose:
+
+- framework (React, vanilla, web components — design works for any),
+- style technique (CSS, styled-components, CSS modules),
+- animation library (none needed; the design uses CSS),
+- persistence cache shape,
+- network transport.

--- a/companion-ui/design_handoff/2026-05-14-handoff-governance-pack/open-questions.md
+++ b/companion-ui/design_handoff/2026-05-14-handoff-governance-pack/open-questions.md
@@ -1,0 +1,32 @@
+# Open questions — Design Handoff Governance Pack
+
+The canonical list lives in **`prototype.html` §09 (Open questions)** of this package. This
+document is the structured version intended for issue creation at crossings C/D.
+
+## Status
+
+All open questions are tracked in the prototype. Owner-doc owners are proposed in the
+prototype; they are not assigned yet — assignment happens at crossing B during the
+maturity-checklist review.
+
+## Crossing-B blockers
+
+If any open question would, if answered, change the state machine declared in the
+implementation contract, that question is a crossing-B blocker per the governance pack §03.
+The reviewer at crossing B must triage each open question into one of:
+
+- **resolve before promotion** (blocker),
+- **resolve in normalized spec** (non-blocker, but cite),
+- **defer to implementation issue** (non-blocker, but acknowledge).
+
+## How to read
+
+Each open question in the prototype carries:
+
+- a short title (used as the issue title if escalated),
+- the rationale for the question,
+- a proposed default (the package's recommendation),
+- an implicit owner (the doc the question would amend if accepted).
+
+Detailed answers are deliberately not pre-decided here — the question list is the package's
+honest "we don't know yet, and we made a choice anyway" record.

--- a/companion-ui/design_handoff/2026-05-14-handoff-governance-pack/prototype.html
+++ b/companion-ui/design_handoff/2026-05-14-handoff-governance-pack/prototype.html
@@ -1,0 +1,1154 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Design Handoff Governance Pack — Yggdrasil Companion UI</title>
+<link rel="stylesheet" href="./colors_and_type.css" />
+<link rel="stylesheet" href="./spec_chrome.css" />
+<style>
+  /* ============================================================
+     LOCAL — governance flow diagram + template cards
+     ============================================================ */
+  .flow {
+    border: 1px solid var(--border);
+    background: var(--bg-surface);
+    border-radius: var(--radius-md);
+    padding: var(--space-5);
+    margin: var(--space-3) 0 var(--space-6);
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    gap: var(--space-3);
+    align-items: stretch;
+    position: relative;
+  }
+  .flow-node {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    background: var(--bg-base);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-sm);
+    padding: 10px 12px;
+    position: relative;
+    z-index: 1;
+  }
+  .flow-node .lbl {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    color: var(--fg-3);
+  }
+  .flow-node .name {
+    font-family: var(--font-ui);
+    font-size: var(--text-sm);
+    color: var(--fg-1);
+    font-weight: var(--weight-medium);
+    line-height: 1.3;
+  }
+  .flow-node .meta {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--fg-3);
+    margin-top: 2px;
+  }
+  .flow-node.design { border-color: rgba(0,212,232,0.5); }
+  .flow-node.design .lbl { color: var(--cyan); }
+  .flow-node.norm   { border-color: rgba(0,212,232,0.5); }
+  .flow-node.norm   .lbl { color: var(--cyan); }
+  .flow-node.gov    { border-color: rgba(212,168,67,0.5); }
+  .flow-node.gov    .lbl { color: var(--accent); }
+  .flow-node.impl   { border-color: rgba(74,158,255,0.4); }
+  .flow-node.impl   .lbl { color: var(--agent); }
+  .flow-node.proof  { border-color: rgba(57,232,125,0.4); }
+  .flow-node.proof  .lbl { color: var(--vault); }
+  .flow-arrow {
+    align-self: center;
+    text-align: center;
+    color: var(--cyan);
+    font-family: var(--font-mono);
+    font-size: 14px;
+  }
+  @media (max-width: 900px) {
+    .flow { grid-template-columns: 1fr; }
+    .flow-arrow { transform: rotate(90deg); }
+  }
+
+  /* maturity score */
+  .maturity-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--space-4);
+    margin: var(--space-3) 0 var(--space-5);
+  }
+  .maturity-col {
+    border: 1px solid var(--border);
+    background: var(--bg-surface);
+    border-radius: var(--radius-md);
+    padding: var(--space-4);
+  }
+  .maturity-col h4 {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    color: var(--fg-2);
+    margin-bottom: var(--space-3);
+  }
+  .maturity-col.ready { border-top: 2px solid var(--vault); }
+  .maturity-col.ready h4 { color: var(--vault); }
+  .maturity-col.hold  { border-top: 2px solid var(--amber); }
+  .maturity-col.hold h4 { color: var(--amber); }
+
+  /* console mock */
+  .console {
+    border: 1px solid var(--border);
+    background: var(--bg-surface);
+    border-radius: var(--radius-md);
+    margin: var(--space-3) 0 var(--space-6);
+    overflow: hidden;
+  }
+  .console-bar {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: 10px 14px;
+    background: var(--bg-raised);
+    border-bottom: 1px solid var(--border);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+  }
+  .console-bar .crumb { color: var(--fg-2); }
+  .console-bar .crumb.active { color: var(--cyan); }
+  .console-bar .sep { color: var(--fg-3); }
+  .console-bar .right { margin-left: auto; display: flex; gap: var(--space-3); align-items: center; }
+  .console-body {
+    display: grid;
+    grid-template-columns: 240px 1fr 280px;
+    min-height: 480px;
+  }
+  .console-list {
+    border-right: 1px solid var(--border);
+    padding: var(--space-3);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    background: var(--bg-base);
+    overflow-y: auto;
+    max-height: 580px;
+  }
+  .console-list .row {
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    border-left: 2px solid transparent;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .console-list .row[aria-selected="true"] {
+    background: var(--bg-raised);
+    border-left-color: var(--cyan);
+  }
+  .console-list .row .ttl {
+    font-size: var(--text-sm);
+    color: var(--fg-1);
+    line-height: 1.3;
+  }
+  .console-list .row .sub {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+  }
+  .console-list .row .sub.gov { color: var(--accent); }
+  .console-list .row .sub.norm { color: var(--cyan); }
+  .console-list .row .sub.impl { color: var(--agent); }
+  .console-list .row .sub.proof { color: var(--vault); }
+  .console-list .row .sub.design { color: var(--fg-2); }
+  .console-list .row .sub.held { color: var(--amber); }
+
+  .console-detail {
+    padding: var(--space-5);
+    overflow-y: auto;
+    max-height: 580px;
+  }
+  .console-detail h3 {
+    font-family: var(--font-display);
+    font-size: var(--text-xl);
+    color: var(--fg-1);
+    margin-bottom: var(--space-2);
+    text-transform: none;
+    letter-spacing: 0;
+    font-weight: var(--weight-regular);
+  }
+  .console-detail .crumb-line {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    margin-bottom: var(--space-3);
+  }
+  .console-detail .chain {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr auto 1fr auto 1fr auto 1fr auto 1fr;
+    gap: 6px;
+    align-items: center;
+    background: var(--bg-base);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: var(--space-3);
+    margin: var(--space-3) 0 var(--space-4);
+  }
+  .console-detail .chain .step {
+    padding: 6px 8px;
+    border-radius: var(--radius-sm);
+    background: var(--bg-raised);
+    border: 1px solid var(--border-strong);
+    text-align: center;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--fg-2);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    line-height: 1.3;
+  }
+  .console-detail .chain .step.done   { color: var(--vault); border-color: rgba(57,232,125,0.4); background: rgba(57,232,125,0.04); }
+  .console-detail .chain .step.active { color: var(--cyan); border-color: rgba(0,212,232,0.5); background: rgba(0,212,232,0.04); }
+  .console-detail .chain .step.pending{ color: var(--fg-3); }
+  .console-detail .chain .arr { color: var(--fg-3); font-family: var(--font-mono); }
+
+  .field-grid {
+    display: grid;
+    grid-template-columns: 130px 1fr;
+    row-gap: 8px;
+    column-gap: var(--space-3);
+    font-size: var(--text-sm);
+    margin: var(--space-3) 0;
+  }
+  .field-grid dt {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    padding-top: 3px;
+  }
+  .field-grid dd {
+    color: var(--fg-1);
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  .console-aside {
+    border-left: 1px solid var(--border);
+    background: var(--bg-base);
+    padding: var(--space-4);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+    overflow-y: auto;
+    max-height: 580px;
+  }
+  .aside-block h5 {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    color: var(--fg-3);
+    margin-bottom: 8px;
+  }
+  .aside-block ul.check { font-size: var(--text-xs); }
+  .aside-block ul.check li {
+    font-family: var(--font-ui);
+    font-size: var(--text-xs);
+    color: var(--fg-2);
+  }
+  .aside-block .stat {
+    display: flex;
+    justify-content: space-between;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--fg-2);
+    padding: 4px 0;
+    border-bottom: 1px solid var(--border);
+  }
+  .aside-block .stat:last-child { border-bottom: none; }
+  .aside-block .stat .v { color: var(--fg-1); }
+  .aside-block .stat .v.gov   { color: var(--accent); }
+  .aside-block .stat .v.vault { color: var(--vault); }
+  .aside-block .stat .v.cyan  { color: var(--cyan); }
+  .aside-block .stat .v.amber { color: var(--amber); }
+
+  @media (max-width: 900px) {
+    .console-body { grid-template-columns: 1fr; }
+    .console-list, .console-aside { border-right: none; border-left: none; border-bottom: 1px solid var(--border); max-height: none; }
+  }
+
+  /* edge-state grid (small) */
+  .edge-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--space-3);
+    margin: var(--space-3) 0 var(--space-5);
+  }
+  .edge-cell {
+    border: 1px solid var(--border);
+    background: var(--bg-surface);
+    border-radius: var(--radius-sm);
+    padding: 12px;
+    font-size: var(--text-sm);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .edge-cell .lbl {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    color: var(--fg-3);
+  }
+  .edge-cell .lbl.gold { color: var(--accent); }
+  .edge-cell .lbl.cyan { color: var(--cyan); }
+  .edge-cell .lbl.amber{ color: var(--amber); }
+  .edge-cell .lbl.dang { color: var(--destructive); }
+  .edge-cell .lbl.vault{ color: var(--vault); }
+  .edge-cell p { font-size: var(--text-sm); color: var(--fg-2); margin: 0; line-height: 1.5; }
+  @media (max-width: 900px) { .edge-grid { grid-template-columns: 1fr; } }
+</style>
+</head>
+<body>
+<div class="page">
+
+  <!-- ============================ TOC ============================ -->
+  <nav class="toc" aria-label="Section index">
+    <div class="toc-label">Sections</div>
+    <ol>
+      <li><a href="#s1"><span class="toc-num">01</span>Context &amp; boundary</a></li>
+      <li><a href="#s2"><span class="toc-num">02</span>Handoff governance flow</a></li>
+      <li><a href="#s3"><span class="toc-num">03</span>Maturity checklist</a></li>
+      <li><a href="#s4"><span class="toc-num">04</span>Review console (prototype)</a></li>
+      <li><a href="#s5"><span class="toc-num">05</span>README template</a></li>
+      <li><a href="#s6"><span class="toc-num">06</span>Implementation contract</a></li>
+      <li><a href="#s7"><span class="toc-num">07</span>Authority boundaries</a></li>
+      <li><a href="#s8"><span class="toc-num">08</span>Edge-state checklist</a></li>
+      <li><a href="#s9"><span class="toc-num">09</span>Influence table</a></li>
+      <li><a href="#s10"><span class="toc-num">10</span>Authority &amp; disclaimers</a></li>
+      <li><a href="#s11"><span class="toc-num">11</span>Open questions</a></li>
+      <li><a href="#s12"><span class="toc-num">12</span>Handoff to Code/Codex</a></li>
+    </ol>
+  </nav>
+
+  <!-- ============================ MAIN ============================ -->
+  <main>
+    <header class="doc-header">
+      <div class="doc-eyebrow">Companion UI · Design Handoff · Meta-governance</div>
+      <h1 class="doc-title">Design Handoff Governance Pack</h1>
+      <p class="doc-lede">
+        How a Claude Design exploration becomes a governed implementation input — without becoming
+        architecture authority on the way. Defines the chain
+        <span style="font-family:var(--font-mono); color:var(--cyan)">exploration → handoff package
+        → normalized spec → GitHub issue → PR → validation receipt</span>,
+        the maturity bar between each link, the templates each step produces, and the disclaimers
+        that keep design from being mistaken for runtime truth.
+      </p>
+      <div class="doc-meta">
+        <span><strong>Pack:</strong> HANDOFF_GOVERNANCE</span>
+        <span><strong>Authority:</strong> Process pattern only — not runtime</span>
+        <span><strong>Owner-docs:</strong> INTERACTION_SURFACES_AND_AUTHORITY</span>
+        <span><strong>Status:</strong> Design handoff · v1 · 2026-05-14</span>
+      </div>
+    </header>
+
+    <!-- ============== 01 ============== -->
+    <section class="spec" id="s1">
+      <h2><span class="secnum">01 ·</span>Context &amp; boundary</h2>
+      <p class="lede">What this pack is for, and what it deliberately is not.</p>
+
+      <h3>What this pack is</h3>
+      <p>
+        Yggdrasil already has a strong rule: design artifacts are not architecture authority,
+        runtime truth lives in shipped code, tests, status docs, and validation receipts. That rule
+        is healthy. It also means that <em>every</em> Claude Design exploration enters a system
+        where it is, by design, not allowed to mutate truth on its own. This pack defines the
+        intermediate path — the maturity bar, the templates, the affordances — so design work
+        actually <em>lands</em> as governed inputs instead of accumulating as well-intentioned
+        loose HTML.
+      </p>
+      <p>
+        Concretely, the pack covers five artifacts:
+      </p>
+      <ul>
+        <li>The <strong>governance flow diagram</strong> (§02) that names each link in the chain
+          and what evidence crosses each boundary.</li>
+        <li>The <strong>maturity checklist</strong> (§03) that decides when an exploration is
+          allowed to become a normalized spec.</li>
+        <li>The <strong>review console prototype</strong> (§04) — a single operator surface for
+          walking explorations through the chain.</li>
+        <li>Three <strong>templates</strong> (§05–07): README, implementation-contract notes,
+          authority boundaries.</li>
+        <li>The <strong>state, edge-case, and influence inventories</strong> (§08–09) that every
+          design must answer before promotion.</li>
+      </ul>
+
+      <h3>Surface boundaries we are honoring</h3>
+      <ul>
+        <li><strong>Repo docs &amp; contracts</strong> remain architecture authority. This pack
+          governs <em>process</em>, not architecture.</li>
+        <li><strong>GitHub issues &amp; PRs</strong> remain the place where work is committed to.
+          The pack proposes; it does not promote.</li>
+        <li><strong>Validation receipts</strong> remain runtime truth. The pack ends at handoff;
+          proof lives downstream in the runtime-proof surface (Exploration 2).</li>
+      </ul>
+
+      <div class="callout invariant">
+        <span class="callout-label">Floor invariant</span>
+        Design exploration is not architecture authority. Visual guidance is not runtime behavior.
+        Architecture authority remains in repo docs and contracts. Runtime truth remains in
+        shipped code, tests, status docs, and validation receipts. This pack expresses the
+        invariant; it does not loosen it.
+      </div>
+
+      <h3>What this pack is not</h3>
+      <ul>
+        <li>Not a new governance pipeline. Mutation continues to flow through the existing
+          policy → validation → event-pipeline → deterministic-writer path.</li>
+        <li>Not a new role or new authority surface. The human reviewer remains the
+          decision-maker; this pack only structures what they see.</li>
+        <li>Not a CI/CD spec. The chain ends at "validation receipt"; how that receipt is
+          produced is owned by runtime-proof, not by design handoff.</li>
+        <li>Not a tool requirement. The console in §04 is a target shape, not a claim that
+          such a console is shipped.</li>
+      </ul>
+    </section>
+
+    <!-- ============== 02 ============== -->
+    <section class="spec" id="s2">
+      <h2><span class="secnum">02 ·</span>Handoff governance flow</h2>
+      <p class="lede">
+        Six links. Each crossing is a deliberate maturity step with its own evidence requirement.
+        Each link emits an artifact the next link can refuse.
+      </p>
+
+      <div class="flow" role="img" aria-label="Handoff governance flow: design exploration → handoff package → normalized spec → GitHub issue → PR → validation receipt">
+        <div class="flow-node design">
+          <div class="lbl">01 · Explore</div>
+          <div class="name">Design exploration</div>
+          <div class="meta">claude.ai/design · HTML</div>
+        </div>
+        <div class="flow-node design">
+          <div class="lbl">02 · Hand off</div>
+          <div class="name">Handoff package</div>
+          <div class="meta">design_handoff/&lt;date-topic&gt;/</div>
+        </div>
+        <div class="flow-node norm">
+          <div class="lbl">03 · Normalize</div>
+          <div class="name">Normalized spec</div>
+          <div class="meta">docs/ · markdown · target-state</div>
+        </div>
+        <div class="flow-node gov">
+          <div class="lbl">04 · Schedule</div>
+          <div class="name">GitHub issue</div>
+          <div class="meta">references spec · acceptance contract</div>
+        </div>
+        <div class="flow-node impl">
+          <div class="lbl">05 · Build</div>
+          <div class="name">Pull request</div>
+          <div class="meta">code · tests · status doc updates</div>
+        </div>
+        <div class="flow-node proof">
+          <div class="lbl">06 · Prove</div>
+          <div class="name">Validation receipt</div>
+          <div class="meta">runtime proof · status doc · receipt id</div>
+        </div>
+      </div>
+
+      <h3>What crosses each boundary</h3>
+      <table class="spec">
+        <thead>
+          <tr>
+            <th>Crossing</th>
+            <th>From → To</th>
+            <th>Required evidence</th>
+            <th>Refusal condition</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>A</td>
+            <td>Exploration → Handoff package</td>
+            <td>State gallery, edge-case checklist, authority boundaries, open questions, influence table.</td>
+            <td>Missing any required section in the folder shape.</td>
+          </tr>
+          <tr>
+            <td>B</td>
+            <td>Handoff → Normalized spec</td>
+            <td>Maturity checklist (§03) passed. Spec written in repo voice (markdown, normative rules, contracts cited).</td>
+            <td>Open questions left unanswered. Conflict with an existing contract not reconciled.</td>
+          </tr>
+          <tr>
+            <td>C</td>
+            <td>Spec → GitHub issue</td>
+            <td>Issue references the spec by path. Acceptance criteria copied from the spec. Owner-doc declared.</td>
+            <td>Issue introduces scope the spec does not authorize.</td>
+          </tr>
+          <tr>
+            <td>D</td>
+            <td>Issue → PR</td>
+            <td>PR closes a single issue. Tests cover acceptance criteria. Status docs updated. No silent edits to authority docs.</td>
+            <td>PR mutates owner-docs beyond the issue's scope. Tests skip acceptance criteria.</td>
+          </tr>
+          <tr>
+            <td>E</td>
+            <td>PR → Validation receipt</td>
+            <td>Runtime proof run. Receipt id recorded in status doc. Skipped checks have stated reasons.</td>
+            <td>Runtime proof skipped without reason. Receipt not linked from the status doc.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="callout warn">
+        <span class="callout-label">Refusal is a feature, not a setback</span>
+        Each boundary is allowed to send the artifact back. A design that fails maturity is not
+        broken — it is correctly held. A PR that mutates owner-docs beyond scope is correctly
+        rejected. The point of the chain is that no single link can promote itself.
+      </div>
+    </section>
+
+    <!-- ============== 03 ============== -->
+    <section class="spec" id="s3">
+      <h2><span class="secnum">03 ·</span>Maturity checklist</h2>
+      <p class="lede">
+        A design exploration is mature enough to become a normalized spec when every item on the
+        left is satisfied <em>and</em> no item on the right is open. This is the only gate that
+        decides crossing B.
+      </p>
+
+      <div class="maturity-grid">
+        <div class="maturity-col ready">
+          <h4>Ready when all of these are true</h4>
+          <ul class="check">
+            <li class="done">Scope statement names what is being designed and what is explicitly not.</li>
+            <li class="done">State gallery covers every UI state — at minimum empty, loading, normal, degraded, blocked.</li>
+            <li class="done">Edge-case checklist (§08) is filled, with each item either designed or marked deferred-with-reason.</li>
+            <li class="done">Authority boundaries section names which owner-docs apply and which the design must not touch.</li>
+            <li class="done">Influence table (§09) declares what this design <em>may</em> influence and what it <em>must not</em> decide.</li>
+            <li class="done">Visual guidance is separated from interaction contract is separated from implementation assumptions.</li>
+            <li class="done">Every claim about runtime behavior is sourced or marked target-state.</li>
+            <li class="done">A narrow/mobile layout is at least sketched, even if portrait is deferred.</li>
+            <li class="done">Reduced-motion behavior is described or marked "no motion to reduce".</li>
+            <li class="done">Open questions are written down with proposed owners.</li>
+          </ul>
+        </div>
+        <div class="maturity-col hold">
+          <h4>Held when any of these are true</h4>
+          <ul class="check">
+            <li class="skip">An open question would change the state machine if answered.</li>
+            <li class="skip">A surface boundary is unclear (which surface owns this action?).</li>
+            <li class="skip">An authority boundary conflict with an existing contract is unresolved.</li>
+            <li class="skip">A state in the gallery has no described user action set.</li>
+            <li class="skip">The design relies on runtime behavior not yet specified in repo docs.</li>
+            <li class="skip">The design implicitly introduces a new authority surface.</li>
+            <li class="skip">Provenance is shown without saying how it would be produced.</li>
+            <li class="skip">Write-guard or denial states are visually absent.</li>
+            <li class="skip">Copy treats agent output as semantic authority.</li>
+            <li class="skip">No reviewer is named.</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="callout">
+        <span class="callout-label">Scoring posture</span>
+        The checklist is binary, not weighted. A single hold reason is enough to refuse promotion.
+        That is intentional — promotion is rarer than exploration, and the chain works because
+        the bar at crossing B is high.
+      </div>
+    </section>
+
+    <!-- ============== 04 ============== -->
+    <section class="spec" id="s4">
+      <h2><span class="secnum">04 ·</span>Review console <span class="chip design" style="font-size:10px; margin-left:8px">prototype</span></h2>
+      <p class="lede">
+        A target-shape operator surface for walking handoff packages through the chain. One list
+        of explorations, one detail pane showing where the package sits in the chain, one aside
+        showing the maturity checklist and downstream artifacts. This is the visual prototype;
+        the production form is whatever the team's existing review tools support.
+      </p>
+
+      <div class="console" aria-label="Review console — design exploration #ck-bundle-inspector selected">
+        <!-- top bar -->
+        <div class="console-bar">
+          <span class="crumb">design_handoff</span>
+          <span class="sep">/</span>
+          <span class="crumb active">2026-05-14-context-bundle-inspector</span>
+          <span class="sep">/</span>
+          <span class="crumb">crossing B</span>
+          <div class="right">
+            <span class="receipt queued"><span class="recdot"></span>maturity · 7 / 10</span>
+            <button class="btn ghost" type="button" data-intent="package.open-folder">Open folder</button>
+            <button class="btn governance" type="button" data-intent="package.request-normalization" disabled>Request normalize <span class="kbd">N</span></button>
+          </div>
+        </div>
+
+        <div class="console-body">
+          <!-- list -->
+          <aside class="console-list" aria-label="Handoff packages">
+            <div class="row">
+              <div class="ttl">Canvas Suggestion Flow</div>
+              <div class="sub vault">crossing E · receipt cb-2026-05-11-a</div>
+            </div>
+            <div class="row">
+              <div class="ttl">Cognitive Modes</div>
+              <div class="sub impl">crossing D · PR #482 open</div>
+            </div>
+            <div class="row">
+              <div class="ttl">Re-entry Mist Variants</div>
+              <div class="sub norm">crossing C · issue #501 drafted</div>
+            </div>
+            <div class="row" aria-selected="true">
+              <div class="ttl">Context Bundle Inspector</div>
+              <div class="sub gov">crossing B · maturity 7 / 10</div>
+            </div>
+            <div class="row">
+              <div class="ttl">Memory Candidate Review</div>
+              <div class="sub design">crossing A · package draft</div>
+            </div>
+            <div class="row">
+              <div class="ttl">Runtime Proof Dashboard</div>
+              <div class="sub gov">crossing B · maturity 9 / 10</div>
+            </div>
+            <div class="row">
+              <div class="ttl">Resurfacing Heuristics</div>
+              <div class="sub held">held · 2 hold reasons</div>
+            </div>
+            <div class="row">
+              <div class="ttl">Tension Patterns</div>
+              <div class="sub design">crossing A · exploration v2</div>
+            </div>
+          </aside>
+
+          <!-- detail -->
+          <section class="console-detail">
+            <div class="crumb-line">handoff · 2026-05-14 · context-bundle-inspector · v1</div>
+            <h3>Context Bundle Inspector</h3>
+
+            <div class="chain" aria-label="Position in the handoff chain">
+              <div class="step done">Explore</div>
+              <div class="arr">›</div>
+              <div class="step done">Hand off</div>
+              <div class="arr">›</div>
+              <div class="step active">Normalize</div>
+              <div class="arr">›</div>
+              <div class="step pending">Issue</div>
+              <div class="arr">›</div>
+              <div class="step pending">PR</div>
+              <div class="arr">›</div>
+              <div class="step pending">Receipt</div>
+            </div>
+
+            <dl class="field-grid">
+              <dt>Owner-docs</dt>
+              <dd>
+                <code>docs/CONCEPTS/CONTEXT_BUNDLE_CONTRACT.md</code>,
+                <code>docs/INTERACTION_SURFACES_AND_AUTHORITY/</code>
+              </dd>
+              <dt>Authority</dt>
+              <dd>Visual guidance only · may not loosen <code>may_write</code> semantics</dd>
+              <dt>Reviewer</dt>
+              <dd>—</dd>
+              <dt>Influence</dt>
+              <dd>Inspector layout · field grouping · staleness presentation</dd>
+              <dt>Must not decide</dt>
+              <dd>Bundle schema · authority-flag set · expiry policy</dd>
+              <dt>Edge states</dt>
+              <dd>9 designed · 0 deferred · 0 missing</dd>
+              <dt>Open questions</dt>
+              <dd>3 (see §11 of the package)</dd>
+            </dl>
+
+            <div class="callout warn">
+              <span class="callout-label">Hold reasons (3 of 10)</span>
+              Q1 about exclusion-visibility default is unresolved. Q2 about bundle-receipt-shape
+              would change the receipt list — must be answered before crossing B. Q3 about narrow
+              layout is a sketch, not a layout — acceptable as deferred-with-reason if the
+              reviewer agrees.
+            </div>
+
+            <h3 style="font-family:var(--font-ui); font-size:var(--text-sm); font-weight:var(--weight-semibold); text-transform:uppercase; letter-spacing:var(--tracking-wide); color:var(--fg-1); margin:var(--space-5) 0 var(--space-2);">Downstream artifacts</h3>
+            <ul style="margin:0 0 var(--space-4) var(--space-5); font-size:var(--text-sm); color:var(--fg-2);">
+              <li>Proposed normalized spec path: <code>docs/CONCEPTS/CONTEXT_BUNDLE_INSPECTOR_UI.md</code> (target-state · UI guidance only).</li>
+              <li>Proposed issue: <em>"Context bundle inspector — UI guidance + field-grouping contract"</em>.</li>
+              <li>Validation expectation: receipt on a render against three fixture bundles (retrieval, orientation, write-proposal).</li>
+            </ul>
+          </section>
+
+          <!-- aside -->
+          <aside class="console-aside" aria-label="Maturity + activity">
+            <div class="aside-block">
+              <h5>Maturity · 7 / 10</h5>
+              <ul class="check">
+                <li class="done">Scope</li>
+                <li class="done">State gallery</li>
+                <li class="done">Edge cases</li>
+                <li class="done">Authority boundaries</li>
+                <li class="done">Influence table</li>
+                <li class="done">Separation of guidance / contract / assumption</li>
+                <li class="done">Target-state markings</li>
+                <li>Narrow layout (sketch only)</li>
+                <li>Reduced-motion described</li>
+                <li>Open questions have owners</li>
+              </ul>
+            </div>
+
+            <div class="aside-block">
+              <h5>Owner-doc impact</h5>
+              <div class="stat"><span>CONTEXT_BUNDLE_CONTRACT.md</span><span class="v cyan">read-only</span></div>
+              <div class="stat"><span>INTERACTION_SURFACES…</span><span class="v cyan">read-only</span></div>
+              <div class="stat"><span>UI_RUNTIME_BOUNDARIES.md</span><span class="v cyan">read-only</span></div>
+              <div class="stat"><span>STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md</span><span class="v vault">invariant honored</span></div>
+            </div>
+
+            <div class="aside-block">
+              <h5>Activity</h5>
+              <div class="stat"><span>2026-05-14 · 14:08</span><span class="v">package committed</span></div>
+              <div class="stat"><span>2026-05-14 · 13:51</span><span class="v">edge-case review</span></div>
+              <div class="stat"><span>2026-05-14 · 11:02</span><span class="v">v1 draft</span></div>
+            </div>
+          </aside>
+        </div>
+      </div>
+
+      <p>
+        The console is intentionally compact. It does not animate. It does not draw the chain
+        on a pannable graph. It does not show contributor avatars. Its only job is to make the
+        chain visible and the maturity bar enforceable at a glance — which is precisely the
+        boundary work the pack is here to do.
+      </p>
+    </section>
+
+    <!-- ============== 05 ============== -->
+    <section class="spec" id="s5">
+      <h2><span class="secnum">05 ·</span>README template</h2>
+      <p class="lede">
+        Every handoff package opens with a README that the next reviewer reads first. The
+        template below is the minimum shape; fields are deliberately small.
+      </p>
+
+      <div class="template"><span class="c"># &lt;Design name&gt; — Design Handoff</span>
+
+<span class="h">Date:</span>           YYYY-MM-DD
+<span class="h">Status:</span>         Design handoff · v&lt;n&gt; · &lt;ready | held | superseded&gt;
+<span class="h">Authority:</span>      Visual guidance only — not runtime, not architecture
+<span class="h">Owner-docs:</span>     &lt;path/to/contract.md&gt;, &lt;…&gt;
+<span class="h">Crossing target:</span> &lt;A | B | C | D | E&gt;
+
+<span class="c">## What this is</span>
+
+One paragraph. Names the moment in the user's flow this design covers. Names what it
+deliberately is not.
+
+<span class="c">## Influence</span>
+
+<span class="v">May influence:</span>     layout, field grouping, copy, visual hierarchy, state coverage
+<span class="g">May not decide:</span>    schema shape, authority flags, mutation paths, runtime contracts
+<span class="g">Must not loosen:</span>   gated-execution invariant, owner-doc authority, write-guard semantics
+
+<span class="c">## Maturity</span>
+
+Linked checklist (§03 of the governance pack). Note any deferred-with-reason items.
+
+<span class="c">## Files</span>
+
+  prototype.html             — visual prototype + state gallery
+  design-notes.md            — visual guidance, rationale
+  state-gallery.md           — every UI state, screenshot or description
+  implementation-contracts.md — fields, intents, testids, classifier expectations
+  authority-boundaries.md    — what this design may / may not influence
+  edge-states.md             — empty / loading / degraded / blocked / stale / …
+  open-questions.md          — unresolved, with proposed owners
+
+<span class="c">## Related</span>
+
+Owner-doc citations. Adjacent handoff packages. Any prior version this supersedes.
+
+<span class="c">## Disclaimers</span>
+
+Design exploration is not architecture authority. Runtime truth lives in shipped code,
+tests, status docs, and validation receipts. This package proposes; it does not promote.
+</div>
+    </section>
+
+    <!-- ============== 06 ============== -->
+    <section class="spec" id="s6">
+      <h2><span class="secnum">06 ·</span>Implementation contract template</h2>
+      <p class="lede">
+        The contract document is the part of the package that implementation reads. It is the
+        only document that promises anything to code. Everything else in the package is
+        guidance.
+      </p>
+
+      <div class="template"><span class="c"># &lt;Design name&gt; — Implementation contract</span>
+
+<span class="c">## Status</span>
+
+<span class="h">Authority:</span>  Contract for UI integration · target-state
+<span class="h">Mutates:</span>    nothing on its own
+<span class="h">Depends on:</span> &lt;runtime contract path&gt;, &lt;runtime contract path&gt;
+
+<span class="c">## State enum</span>
+
+The implementation must enumerate exactly these states. Adding a state without
+amending this document means the design no longer covers it.
+
+  - &lt;state&gt;     description, allowed user actions
+  - &lt;state&gt;     …
+
+<span class="c">## Allowed transitions</span>
+
+Table of (from, trigger, to). Implementation must reject any other transition.
+
+<span class="c">## Data attributes</span>
+
+Stable attributes the design relies on for testids and behavioral selectors.
+
+  data-testid="&lt;node&gt;"
+  data-intent="&lt;verb.object&gt;"
+  data-&lt;state-axis&gt;="&lt;one-of&gt;"
+
+<span class="c">## Server contract surface</span>
+
+Endpoints / events / classifiers the UI consumes. The UI never re-classifies; the
+server's declared class wins.
+
+  &lt;endpoint or event&gt;          → &lt;ui effect&gt;
+  &lt;classifier&gt;                 → &lt;ui variant&gt;
+
+<span class="c">## Validation expectations</span>
+
+What a passing validation receipt looks like.
+
+  - render fixture &lt;name&gt; → state &lt;x&gt;
+  - intent &lt;name&gt; emits &lt;event&gt;
+  - denied state shows &lt;reason field&gt;
+
+<span class="c">## What this contract does not say</span>
+
+Explicit list of things implementation is free to choose: framework, style technique,
+animation library, persistence cache shape, network transport.
+</div>
+    </section>
+
+    <!-- ============== 07 ============== -->
+    <section class="spec" id="s7">
+      <h2><span class="secnum">07 ·</span>Authority &amp; runtime-truth disclaimer template</h2>
+      <p class="lede">
+        Every handoff carries this block verbatim — adjust only the lists. It exists so the
+        reader does not need to infer the disclaimer; it is on the page.
+      </p>
+
+      <div class="template"><span class="c"># Authority Boundaries &amp; Runtime-Truth Disclaimer</span>
+
+<span class="c">## This design is</span>
+
+  - Visual guidance for &lt;surface&gt;.
+  - An interaction contract limited to the fields enumerated in implementation-contracts.md.
+  - A target-state proposal until a normalized spec lands in owner-docs.
+
+<span class="c">## This design is not</span>
+
+  - Architecture authority. Authority lives in: &lt;owner-doc paths&gt;.
+  - Runtime truth. Runtime truth lives in shipped code, tests, status docs,
+    and validation receipts.
+  - A schema. The contract document references fields that the runtime exposes;
+    it does not declare them.
+  - A claim about current runtime behavior unless cited.
+
+<span class="c">## Invariants this design honors</span>
+
+  - <span class="g">Gated execution.</span> No interaction surface mutates durable state except through
+    the existing governed path: policy, validation, event pipeline, deterministic writer.
+  - <span class="g">Authority separation.</span> Chat is a canvas surface; Panel is the command surface;
+    Automation is its own lane. This design does not collapse them.
+  - <span class="g">Provenance visibility.</span> Where this design shows agent-contributed content,
+    it shows source, trust state, and authority flags.
+  - <span class="g">Bundle integrity.</span> Where this design shows context, it shows what was
+    excluded if exclusion affects interpretation.
+  - <span class="g">Memory candidacy.</span> Where this design shows agent memory, it never treats
+    candidate memory as semantic authority.
+
+<span class="c">## What changes this design may suggest to owner-docs</span>
+
+  - &lt;path&gt;  · &lt;suggested change · why · still subject to owner-doc review&gt;
+  - …
+
+<span class="c">## What changes this design must not suggest</span>
+
+  - Any loosening of the gated-execution invariant.
+  - Any new authority surface.
+  - Any new write path that bypasses policy / validation.
+  - Any silent promotion of agent memory into semantic knowledge.
+</div>
+    </section>
+
+    <!-- ============== 08 ============== -->
+    <section class="spec" id="s8">
+      <h2><span class="secnum">08 ·</span>State &amp; edge-case checklist</h2>
+      <p class="lede">
+        Every design must answer each of these — design it, or mark it
+        deferred-with-reason. Both are valid. Silence is not.
+      </p>
+
+      <div class="edge-grid">
+        <div class="edge-cell">
+          <span class="lbl">EMPTY</span>
+          <p>No content to show. Surface must explain why (no candidates, no context, no
+            history) and what produces content.</p>
+        </div>
+        <div class="edge-cell">
+          <span class="lbl cyan">LOADING</span>
+          <p>Awaiting an upstream operation. Surface must be inert (no actions enabled) and
+            distinguishable from <em>empty</em>.</p>
+        </div>
+        <div class="edge-cell">
+          <span class="lbl amber">DEGRADED</span>
+          <p>A subsystem is failing but the surface still functions partially. Must show what
+            is degraded and what is unaffected.</p>
+        </div>
+        <div class="edge-cell">
+          <span class="lbl dang">BLOCKED</span>
+          <p>An action is not allowed. Surface must name the reason in copy, and the denial
+            must be auditable (receipt or session-log turn).</p>
+        </div>
+        <div class="edge-cell">
+          <span class="lbl amber">STALE CONTEXT</span>
+          <p>Context shown is past its expiry. Authority flags drop to the stale-default set;
+            UI shows when it became stale and why.</p>
+        </div>
+        <div class="edge-cell">
+          <span class="lbl gold">MISSING PROVENANCE</span>
+          <p>An item is shown without a source. Must be labelled, must not be promotable,
+            must not be silently authoritative.</p>
+        </div>
+        <div class="edge-cell">
+          <span class="lbl dang">WRITE-GUARD DENIAL</span>
+          <p>A write was attempted and refused. Surface must show denial reason and the
+            receipt id, and must not retry silently.</p>
+        </div>
+        <div class="edge-cell">
+          <span class="lbl">REDUCED MOTION</span>
+          <p>All animation must have a static fallback. State changes must be readable
+            without motion cues alone.</p>
+        </div>
+        <div class="edge-cell">
+          <span class="lbl vault">NARROW LAYOUT</span>
+          <p>Designs ship a portrait/mobile sketch or declare portrait deferred-with-reason.
+            Authority labels never collapse to icons alone.</p>
+        </div>
+      </div>
+
+      <div class="callout">
+        <span class="callout-label">How to mark deferred</span>
+        Add <code>deferred-with-reason: &lt;reason&gt;</code> to the edge-states.md entry. A
+        deferred edge case is a tracked liability, not an oversight; it will be a hold reason
+        if the deferral persists past two packages.
+      </div>
+    </section>
+
+    <!-- ============== 09 ============== -->
+    <section class="spec" id="s9">
+      <h2><span class="secnum">09 ·</span>"May influence / may not decide" table</h2>
+      <p class="lede">
+        The single most-skipped section in every prior handoff, and the single most-protective
+        against accidental authority creep. Fill this in for the design at hand. Below is the
+        template shape.
+      </p>
+
+      <table class="spec">
+        <thead>
+          <tr>
+            <th>Concern</th>
+            <th>May influence</th>
+            <th>May propose</th>
+            <th>May not decide</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>UI layout</td>
+            <td class="yes">YES — full</td>
+            <td class="maybe">—</td>
+            <td class="no">—</td>
+          </tr>
+          <tr>
+            <td>Copy &amp; microcopy</td>
+            <td class="yes">YES — full</td>
+            <td class="maybe">—</td>
+            <td class="no">—</td>
+          </tr>
+          <tr>
+            <td>State machine (UI-side)</td>
+            <td class="maybe">subset — adds/removes only with owner-doc review</td>
+            <td class="yes">YES — propose to owner-doc</td>
+            <td class="no">cannot promote</td>
+          </tr>
+          <tr>
+            <td>Field naming on artifacts</td>
+            <td class="no">—</td>
+            <td class="yes">YES — propose to owner-doc</td>
+            <td class="no">cannot rename in owner-doc</td>
+          </tr>
+          <tr>
+            <td>Authority flags on bundles / memory</td>
+            <td class="no">—</td>
+            <td class="maybe">propose addition only with rationale</td>
+            <td class="no">cannot loosen existing flags</td>
+          </tr>
+          <tr>
+            <td>Endpoints / events</td>
+            <td class="no">—</td>
+            <td class="maybe">name UI affordances bound to existing endpoints</td>
+            <td class="no">cannot invent endpoints</td>
+          </tr>
+          <tr>
+            <td>Classifier outputs</td>
+            <td class="no">—</td>
+            <td class="no">—</td>
+            <td class="no">UI renders what server returns; never re-classifies</td>
+          </tr>
+          <tr>
+            <td>Validation receipt shape</td>
+            <td class="no">—</td>
+            <td class="maybe">may suggest fields the UI needs visible</td>
+            <td class="no">cannot define receipt schema</td>
+          </tr>
+          <tr>
+            <td>Persistence shape</td>
+            <td class="no">—</td>
+            <td class="no">—</td>
+            <td class="no">vault / mirror contracts own this</td>
+          </tr>
+          <tr>
+            <td>Runtime behavior</td>
+            <td class="no">—</td>
+            <td class="no">—</td>
+            <td class="no">runtime contracts and shipped code only</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <!-- ============== 10 ============== -->
+    <section class="spec" id="s10">
+      <h2><span class="secnum">10 ·</span>Authority &amp; disclaimers</h2>
+      <p class="lede">
+        Repeating the floor invariants where they cannot be skipped past.
+      </p>
+
+      <div class="callout invariant">
+        <span class="callout-label">Invariant · Design is not architecture authority</span>
+        Architecture authority lives in <code>docs/INTERACTION_SURFACES_AND_AUTHORITY/</code>,
+        <code>docs/CONCEPTS/CONTEXT_BUNDLE_CONTRACT.md</code>,
+        <code>docs/CONCEPTS/AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT.md</code>, and adjacent
+        owner-docs. This pack governs the process by which designs become inputs to those
+        docs. It does not become those docs.
+      </div>
+
+      <div class="callout invariant">
+        <span class="callout-label">Invariant · Runtime truth lives downstream</span>
+        Runtime truth lives in shipped code, tests, status docs, and validation receipts.
+        Nothing in this pack promotes runtime claims. A design may describe an interaction
+        contract; it may not assert that the runtime currently honors it.
+      </div>
+
+      <div class="callout invariant">
+        <span class="callout-label">Invariant · Gated execution</span>
+        No interaction surface — Panel, Canvas Chat, Automation, or any console proposed in
+        this pack — mutates durable state outside the governed pipeline. Review consoles
+        propose state transitions; they do not write owner-docs.
+      </div>
+
+      <div class="callout warn">
+        <span class="callout-label">Process risk · authority creep</span>
+        The single largest risk of a governance pack is the pack itself becoming authority.
+        Mitigation: every section of every handoff cites owner-docs and marks itself
+        target-state. The pack proposes process; owner-docs remain the contract.
+      </div>
+    </section>
+
+    <!-- ============== 11 ============== -->
+    <section class="spec" id="s11">
+      <h2><span class="secnum">11 ·</span>Open questions</h2>
+      <ol>
+        <li><strong>Where does the review console live?</strong> Is it a tab in the existing
+          AI Panel, a separate page in <code>design_handoff/</code>, or a static HTML rendered
+          from the folder shape? Recommended: static HTML rendered from the folder, no new
+          runtime surface.</li>
+        <li><strong>Who is the named reviewer at crossing B?</strong> The pack assumes a single
+          named reviewer; the team's review topology may want two (visual + contract).</li>
+        <li><strong>Should "hold" be visible in GitHub?</strong> If a package is held at
+          crossing B, should that surface as a label on a draft issue, or stay purely inside
+          the handoff folder?</li>
+        <li><strong>How are superseded packages handled?</strong> Soft delete, archive folder,
+          or status field on the README? Recommended: status field on the README, no folder
+          moves.</li>
+        <li><strong>Does the validation receipt link back to the package?</strong> If so,
+          the package becomes inspectable from the runtime-proof surface — closing the loop.
+          That cross-link is desirable but not a blocker for v1.</li>
+      </ol>
+    </section>
+
+    <!-- ============== 12 ============== -->
+    <section class="spec" id="s12">
+      <h2><span class="secnum">12 ·</span>Handoff notes for Claude Code / Codex</h2>
+      <p class="lede">What this package would feed if it were normalized.</p>
+
+      <h3>Likely normalized spec</h3>
+      <ul>
+        <li>New doc: <code>docs/INTERACTION_SURFACES_AND_AUTHORITY/DESIGN_HANDOFF_GOVERNANCE.md</code></li>
+        <li>Contents: the flow diagram (§02), the maturity checklist (§03), the
+          influence-table template (§09), the three template skeletons (§05–07).</li>
+        <li>Authority: process pattern. Owner-doc for the handoff process itself. Does not
+          modify any existing contract.</li>
+      </ul>
+
+      <h3>Likely follow-on issues</h3>
+      <ul>
+        <li><em>Adopt handoff folder shape across all <code>companion-ui/design_handoff/</code> entries.</em>
+          Acceptance: every folder contains README, prototype.html, design-notes.md,
+          state-gallery.md, implementation-contracts.md, authority-boundaries.md,
+          edge-states.md, open-questions.md.</li>
+        <li><em>Add maturity-checklist front-matter to existing handoff READMEs.</em>
+          Acceptance: existing handoffs declare which checklist items they pass.</li>
+        <li><em>Render the review console statically from the folder.</em> Acceptance: a
+          static page lists packages, their crossing position, and maturity score, with no
+          runtime dependency.</li>
+      </ul>
+
+      <h3>What this design must not feed</h3>
+      <ul>
+        <li>A runtime review service. The chain is a process pattern; it does not require a server.</li>
+        <li>A new authority over owner-docs. Reviewers and owner-doc owners remain the
+          decision-makers.</li>
+        <li>A blocking gate on PRs. Maturity blocks crossing B (handoff → spec). PRs are
+          gated by the issue's acceptance criteria, not by the handoff package.</li>
+      </ul>
+
+      <div class="callout vault">
+        <span class="callout-label">Validation expectation</span>
+        If this design is normalized and adopted, a passing receipt is: every package in
+        <code>companion-ui/design_handoff/</code> conforms to the folder shape, declares
+        maturity, and cites owner-docs. No claim of runtime behavior is made.
+      </div>
+    </section>
+
+  </main>
+</div>
+</body>
+</html>

--- a/companion-ui/design_handoff/2026-05-14-handoff-governance-pack/spec_chrome.css
+++ b/companion-ui/design_handoff/2026-05-14-handoff-governance-pack/spec_chrome.css
@@ -1,0 +1,423 @@
+/* ============================================================
+   Yggdrasil Design Handoff — Shared Spec Chrome
+   ============================================================
+   Page layout, TOC, sections, tables, callouts, chips, code,
+   gallery cards. Imported by each prototype.html after
+   colors_and_type.css.
+   ============================================================ */
+
+html, body { background: var(--bg-base); }
+body {
+  background-image:
+    linear-gradient(rgba(0,212,232,0.022) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0,212,232,0.022) 1px, transparent 1px);
+  background-size: 48px 48px;
+}
+
+.page {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: var(--space-12) var(--space-8) var(--space-16);
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: var(--space-12);
+}
+
+/* ---- Sidebar TOC ---- */
+.toc {
+  position: sticky;
+  top: var(--space-8);
+  align-self: start;
+  font-size: var(--text-sm);
+  border-left: 1px solid var(--border);
+  padding-left: var(--space-4);
+  max-height: calc(100vh - var(--space-12));
+  overflow-y: auto;
+}
+.toc-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  margin-bottom: var(--space-3);
+}
+.toc ol { list-style: none; display: flex; flex-direction: column; gap: 6px; }
+.toc a {
+  color: var(--fg-2);
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  display: block;
+  line-height: 1.4;
+}
+.toc a:hover { color: var(--cyan); text-decoration: none; }
+.toc-num {
+  font-family: var(--font-mono);
+  color: var(--fg-3);
+  margin-right: 6px;
+  font-size: var(--text-xs);
+}
+
+/* ---- Header ---- */
+.doc-header {
+  border-bottom: 1px solid var(--border);
+  padding-bottom: var(--space-6);
+  margin-bottom: var(--space-10);
+}
+.doc-eyebrow {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--cyan);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  margin-bottom: var(--space-3);
+}
+.doc-title {
+  font-family: var(--font-display);
+  font-size: var(--text-3xl);
+  line-height: 1.1;
+  margin-bottom: var(--space-4);
+  color: var(--fg-1);
+}
+.doc-lede {
+  color: var(--fg-2);
+  font-size: var(--text-md);
+  max-width: 70ch;
+  margin-bottom: var(--space-5);
+  line-height: var(--leading-snug);
+}
+.doc-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4) var(--space-6);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+}
+.doc-meta span strong {
+  color: var(--fg-2);
+  font-weight: var(--weight-regular);
+  margin-right: 6px;
+}
+
+/* ---- Sections ---- */
+section.spec {
+  margin-bottom: var(--space-12);
+  scroll-margin-top: var(--space-6);
+}
+section.spec > h2 {
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-regular);
+  color: var(--fg-1);
+  margin-bottom: var(--space-2);
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+}
+section.spec > h2 .secnum {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--cyan);
+  letter-spacing: var(--tracking-wide);
+}
+section.spec > .lede {
+  color: var(--fg-2);
+  font-size: var(--text-base);
+  margin-bottom: var(--space-5);
+  max-width: 72ch;
+}
+section.spec h3 {
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--fg-1);
+  margin: var(--space-6) 0 var(--space-3);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+}
+section.spec p {
+  color: var(--fg-1);
+  margin-bottom: var(--space-3);
+  max-width: 72ch;
+}
+section.spec ul, section.spec ol {
+  color: var(--fg-1);
+  margin: 0 0 var(--space-4) var(--space-5);
+  max-width: 72ch;
+}
+section.spec li { margin-bottom: 6px; line-height: 1.55; }
+
+/* ---- Tables ---- */
+table.spec {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+  margin: var(--space-3) 0 var(--space-5);
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+}
+table.spec th, table.spec td {
+  text-align: left;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+table.spec th {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--fg-2);
+  background: var(--bg-raised);
+  font-weight: var(--weight-medium);
+  border-bottom: 1px solid var(--border-strong);
+}
+table.spec tr:last-child td { border-bottom: none; }
+table.spec td code { font-size: 0.9em; }
+table.spec td.mono, table.spec th.mono { font-family: var(--font-mono); }
+table.spec td.yes { color: var(--vault); font-family: var(--font-mono); font-size: var(--text-xs); }
+table.spec td.no { color: var(--destructive); font-family: var(--font-mono); font-size: var(--text-xs); }
+table.spec td.maybe { color: var(--amber); font-family: var(--font-mono); font-size: var(--text-xs); }
+
+/* ---- Callouts ---- */
+.callout {
+  border-left: 2px solid var(--cyan);
+  background: rgba(0,212,232,0.04);
+  padding: var(--space-3) var(--space-4);
+  margin: var(--space-4) 0;
+  font-size: var(--text-sm);
+  color: var(--fg-1);
+  max-width: 72ch;
+}
+.callout.warn { border-left-color: var(--amber); background: rgba(240,144,48,0.05); }
+.callout.invariant { border-left-color: var(--accent); background: rgba(212,168,67,0.04); }
+.callout.danger { border-left-color: var(--destructive); background: rgba(255,61,61,0.04); }
+.callout.vault { border-left-color: var(--vault); background: rgba(57,232,125,0.04); }
+.callout-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--cyan);
+  display: block;
+  margin-bottom: 4px;
+}
+.callout.warn .callout-label { color: var(--amber); }
+.callout.invariant .callout-label { color: var(--accent); }
+.callout.danger .callout-label { color: var(--destructive); }
+.callout.vault .callout-label { color: var(--vault); }
+
+/* ---- Tag chips ---- */
+.chip {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wide);
+  padding: 1px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-raised);
+  color: var(--fg-2);
+}
+.chip.design  { color: var(--cyan); border-color: rgba(0,212,232,0.3); }
+.chip.impl    { color: var(--accent); border-color: rgba(212,168,67,0.3); }
+.chip.gated   { color: var(--amber); border-color: rgba(240,144,48,0.3); }
+.chip.agent   { color: var(--agent); border-color: rgba(74,158,255,0.3); }
+.chip.vault   { color: var(--vault); border-color: rgba(57,232,125,0.3); }
+.chip.danger  { color: var(--destructive); border-color: rgba(255,61,61,0.3); }
+
+/* ---- Code blocks ---- */
+pre.code {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--fg-1);
+  overflow-x: auto;
+  margin: var(--space-3) 0 var(--space-5);
+  line-height: 1.55;
+}
+pre.code .k { color: var(--cyan); }
+pre.code .s { color: var(--vault); }
+pre.code .c { color: var(--fg-3); font-style: italic; }
+pre.code .n { color: var(--accent); }
+pre.code .a { color: var(--agent); }
+
+/* ---- Gallery ---- */
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--space-5);
+  margin: var(--space-4) 0 var(--space-6);
+}
+.gallery.three { grid-template-columns: repeat(3, 1fr); }
+.gallery-card {
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  min-height: 240px;
+}
+.gallery-card header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  border-bottom: 1px dashed var(--border);
+  padding-bottom: 10px;
+}
+.gallery-card h4 {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--fg-2);
+}
+.gallery-card .note {
+  font-size: var(--text-sm);
+  color: var(--fg-2);
+  margin: 0;
+}
+
+/* ---- Receipt pill ---- */
+.receipt {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  border-radius: var(--radius-full);
+  background: var(--bg-raised);
+  border: 1px solid var(--border-strong);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-2);
+  letter-spacing: var(--tracking-wide);
+}
+.receipt.queued  { color: var(--accent); border-color: rgba(212,168,67,0.4); }
+.receipt.applied { color: var(--vault); border-color: rgba(57,232,125,0.4); }
+.receipt.pending { color: var(--amber); border-color: rgba(240,144,48,0.4); }
+.receipt.failed  { color: var(--destructive); border-color: rgba(255,61,61,0.4); }
+.receipt .recdot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 6px currentColor;
+}
+.receipt.queued .recdot { animation: pulse 1.6s ease-in-out infinite; }
+.receipt.pending .recdot { animation: pulse 1.6s ease-in-out infinite; }
+@keyframes pulse { 0%, 100% { opacity: 0.4; } 50% { opacity: 1; } }
+
+/* ---- Buttons ---- */
+.btn {
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  padding: 5px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-raised);
+  color: var(--fg-1);
+  border: 1px solid var(--border-strong);
+  cursor: pointer;
+}
+.btn:hover { border-color: var(--cyan); color: var(--cyan); }
+.btn.primary {
+  background: var(--amber-muted);
+  color: var(--amber);
+  border-color: rgba(240,144,48,0.5);
+}
+.btn.primary:hover { background: rgba(240,144,48,0.12); border-color: var(--amber); color: var(--amber); }
+.btn.governance {
+  background: rgba(212,168,67,0.06);
+  color: var(--accent);
+  border-color: rgba(212,168,67,0.5);
+}
+.btn.governance:hover { background: rgba(212,168,67,0.12); border-color: var(--accent); }
+.btn.vault {
+  background: rgba(57,232,125,0.06);
+  color: var(--vault);
+  border-color: rgba(57,232,125,0.4);
+}
+.btn.vault:hover { background: rgba(57,232,125,0.12); border-color: var(--vault); }
+.btn.danger {
+  background: rgba(255,61,61,0.05);
+  color: var(--destructive);
+  border-color: rgba(255,61,61,0.4);
+}
+.btn.ghost { background: transparent; }
+.btn[disabled], .btn.disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.btn .kbd {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  color: var(--fg-3);
+  margin-left: 6px;
+}
+
+/* ---- Bullet list with mono prefix (for checklists) ---- */
+ul.check {
+  list-style: none;
+  margin-left: 0 !important;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+ul.check li {
+  position: relative;
+  padding-left: 22px;
+  font-size: var(--text-sm);
+}
+ul.check li::before {
+  content: '[ ]';
+  position: absolute;
+  left: 0;
+  top: 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  letter-spacing: 0;
+}
+ul.check li.done::before { content: '[x]'; color: var(--vault); }
+ul.check li.skip::before { content: '[-]'; color: var(--amber); }
+
+/* ---- Doc-template card (for handoff templates) ---- */
+.template {
+  border: 1px solid var(--border-strong);
+  background: var(--bg-surface);
+  border-radius: var(--radius-md);
+  padding: var(--space-4) var(--space-5);
+  margin: var(--space-4) 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--fg-1);
+  white-space: pre-wrap;
+  line-height: 1.65;
+  overflow-x: auto;
+}
+.template .h { color: var(--cyan); }
+.template .v { color: var(--vault); }
+.template .g { color: var(--accent); }
+.template .c { color: var(--fg-3); font-style: italic; }
+.template .a { color: var(--agent); }
+
+/* ---- Responsive ---- */
+@media (max-width: 900px) {
+  .page { grid-template-columns: 1fr; padding: var(--space-6) var(--space-4); }
+  .toc {
+    position: static;
+    max-height: none;
+    border-left: none;
+    border-bottom: 1px solid var(--border);
+    padding: 0 0 var(--space-4);
+  }
+  .gallery, .gallery.three { grid-template-columns: 1fr; }
+}

--- a/companion-ui/design_handoff/2026-05-14-handoff-governance-pack/state-gallery.md
+++ b/companion-ui/design_handoff/2026-05-14-handoff-governance-pack/state-gallery.md
@@ -1,0 +1,37 @@
+# State gallery — Design Handoff Governance Pack
+
+The full visual gallery lives in **`prototype.html` §05**. This document is a text mirror
+intended for quick scanning in code review and for issue acceptance criteria.
+
+Every state is described as a (name, when, designed behavior) triple. The prototype is the
+authority on the visual; this document is the authority on the state list.
+
+See `prototype.html` §02 for the flow diagram, §03 for the maturity checklist, §04 for the review console prototype, §05–§07 for the README / implementation-contract / authority-boundaries templates.
+
+## State list
+
+See the gallery cards in `prototype.html` §05 for the canonical visuals. Each state in the
+gallery includes:
+
+- A bar with the state name and a state-kind chip.
+- A title-row LED in the appropriate colour (vault / amber / destructive / dim / gold).
+- A one-paragraph narrative describing the state.
+- A meta line of mono captions naming the values that distinguish the state.
+- Where relevant, a next-action strip with the suggested operator action.
+
+## Transition table (illustrative)
+
+Detailed transitions for the UI state machine are owned by `implementation-contracts.md`;
+this gallery is descriptive, not normative. Implementation must enumerate the full set
+declared in the contract document.
+
+## Edge cases the gallery covers
+
+- **Empty** — the surface explains why there is nothing and what produces content.
+- **Loading** — inert, distinguishable from empty.
+- **Degraded** — partial function with explicit naming of what is degraded.
+- **Blocked** — refusal is named, recorded, and never silently retried.
+- **Stale** — staleness is shown with a "why" and an explicit threshold.
+- **Missing provenance** — surfaced, not hidden; never silently authoritative.
+
+For the full edge-state checklist see `edge-states.md`.

--- a/companion-ui/design_handoff/2026-05-14-memory-candidate-review/README.md
+++ b/companion-ui/design_handoff/2026-05-14-memory-candidate-review/README.md
@@ -1,0 +1,48 @@
+# Memory Candidate Review Queue
+
+**Date:** 2026-05-14
+**Status:** Design handoff · v1 · ready for review at crossing B
+**Authority:** Review surface · state mutates through governed pipeline
+**Owner-docs:** docs/CONCEPTS/AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT.md
+**Crossing target:** B
+
+## What this is
+
+Review queue for proposed agent memories. Accept / edit / reject / defer / promote / keep-operational. Unreviewed memory is not semantic authority. Eight actions cover the lifecycle: accept, edit, promote-to-note, keep-operational, set-expiry, defer, reject, delete.
+
+Ten designed states:
+
+1. Single candidate card
+2. Batch review queue
+3. Strong source-backed candidate
+4. Inferred low-confidence candidate
+5. Candidate conflicting with existing memory
+6. Candidate that should expire
+7. Candidate rejected with reason
+8. Candidate revised by the user
+9. Candidate promoted to durable Markdown
+10. Candidate kept as operational memory only
+
+See `prototype.html` §02 for the memory classes, §03 for the queue prototype, §04 for the action vocabulary, §05 for the 10-state gallery.
+
+## Influence
+
+- **May influence:** queue layout, action bar, copy, default action by confidence band, batch-mode safety rails, conflict-resolution UI.
+- **May not decide:** the memory class set, the authority-flag set on memory records, recall behavior, auto-archive policy, promotion target paths.
+
+## Files
+
+- `prototype.html` — 10-section spec, queue mock, 10-state gallery.
+- Sibling markdown docs.
+
+## Related
+
+- `docs/CONCEPTS/AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT.md` — the contract this queue serves as the review surface for.
+- The Context Bundle Inspector (sibling) — bundles may reference memory items; promotion to durable knowledge happens here, not there.
+
+## Authority &amp; disclaimers
+
+- **This design is visual guidance.** It is not architecture authority. Architecture authority lives in repo owner-docs.
+- **Runtime truth lives downstream.** It is not asserted in this package. Runtime truth comes from shipped code, tests, status docs, and validation receipts.
+- **This package proposes; it does not promote.** Promotion happens at crossing B (the maturity bar in the governance pack §03).
+- **The gated-execution invariant is honored throughout.** No interaction surface in this design mutates durable state outside the governed pipeline.

--- a/companion-ui/design_handoff/2026-05-14-memory-candidate-review/authority-boundaries.md
+++ b/companion-ui/design_handoff/2026-05-14-memory-candidate-review/authority-boundaries.md
@@ -1,0 +1,44 @@
+# Authority boundaries — Memory Candidate Review Queue
+
+## This design is
+
+- **Visual guidance** for the surface(s) named in this package's README.
+- **An interaction contract** limited to the fields, intents, and data attributes enumerated
+  in `implementation-contracts.md` and in `prototype.html` §07.
+- **A target-state proposal** until a normalized spec lands in owner-docs.
+
+## This design is not
+
+- **Architecture authority.** Authority lives in:
+  - `docs/CONCEPTS/AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT.md`
+- **Runtime truth.** Runtime truth lives in shipped code, tests, status docs, and validation
+  receipts.
+- **A schema.** This contract references fields the runtime exposes; it does not declare them.
+- **A claim about current runtime behavior** unless explicitly cited from owner-docs.
+
+## Invariants this design honors
+
+- **Gated execution.** No interaction surface in this design mutates durable state outside
+  the existing governed path: policy, validation, event pipeline, deterministic writer.
+- **Authority separation.** Chat is a canvas surface; Panel is the command surface;
+  Automation is its own lane. This design does not collapse them.
+- **Provenance visibility.** Where this design shows agent-contributed content, it shows
+  source, trust state, and authority flags.
+- **Bundle integrity.** Where this design shows context selection, it shows what was excluded
+  when exclusion affects interpretation.
+- **Memory candidacy.** Where this design touches agent memory, it never treats candidate
+  memory as semantic authority.
+
+## What this design may suggest to owner-docs
+
+See `prototype.html` §10 ("Handoff notes for Claude Code / Codex") of this package for the
+specific proposed normalized-spec path and follow-on issues. Owner-doc owners decide whether
+to accept any of those suggestions.
+
+## What this design must not suggest
+
+- Any loosening of the gated-execution invariant.
+- Any new authority surface that bypasses the existing pipeline.
+- Any new write path that bypasses policy / validation.
+- Any silent promotion of agent memory into semantic knowledge.
+- Any redefinition of authority flag semantics.

--- a/companion-ui/design_handoff/2026-05-14-memory-candidate-review/colors_and_type.css
+++ b/companion-ui/design_handoff/2026-05-14-memory-candidate-review/colors_and_type.css
@@ -1,0 +1,346 @@
+/* ============================================================
+   Yggdrasil Design System — Colors & Type
+   ============================================================
+   Import this file in any HTML artifact or UI kit.
+   Google Fonts are imported below; JetBrains Mono via bunny.net.
+   ============================================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Space+Grotesk:wght@300;400;500;600&display=swap');
+@import url('https://fonts.bunny.net/css?family=jetbrains-mono:400,500&display=swap');
+
+/* ============================================================
+   BASE COLOR TOKENS
+   ============================================================ */
+:root {
+  /* --- Backgrounds (cool blue-black — Tron grid) --- */
+  --bg-base:       #070b12;   /* deepest — page root, near black with blue cast */
+  --bg-surface:    #0c1220;   /* panels, sidebars */
+  --bg-raised:     #111a2e;   /* cards, inputs, raised surfaces */
+  --bg-overlay:    #162038;   /* hover states, popovers */
+  --bg-modal:      #0e1828;   /* modal / dialog backdrop content */
+
+  /* --- Foreground / Text --- */
+  --fg-1:          #dce8f0;   /* primary — cool blue-white */
+  --fg-2:          #7a9ab8;   /* secondary / muted */
+  --fg-3:          #3d5570;   /* tertiary / disabled / dim */
+  --fg-inverse:    #070b12;   /* text on light/accent backgrounds */
+
+  /* --- Borders (thin, slightly glowing) --- */
+  --border:        #152030;   /* default — subtle grid line */
+  --border-strong: #1e3050;   /* emphasis — dividers, active edges */
+  --border-focus:  #00d4e8;   /* focus ring — electric cyan */
+
+  /* --- Accent 1: Norse Gold (slightly electrified) --- */
+  --accent:        #d4a843;   /* primary accent — active, focus, key affordances */
+  --accent-dim:    #80621a;   /* dimmed gold */
+  --accent-muted:  #2a1e06;   /* gold at low opacity */
+
+  /* --- Accent 2: Tron Cyan (neon electric) --- */
+  --cyan:          #00d4e8;   /* electric cyan — Tron primary glow */
+  --cyan-dim:      #007a8a;   /* dimmed cyan */
+  --cyan-muted:    #001e28;   /* cyan tint background */
+  --cyan-glow:     0 0 12px rgba(0,212,232,0.35), 0 0 4px rgba(0,212,232,0.5);
+
+  /* --- Vault: Neon green (digital growth) --- */
+  --vault:         #39e87d;   /* vault-connected — electric green */
+  --vault-dim:     #1a7840;   /* vault hover */
+  --vault-muted:   #041a10;   /* vault background tint */
+  --vault-glow:    0 0 8px rgba(57,232,125,0.3);
+
+  /* --- Agent: Electric blue (machine voice) --- */
+  --agent:         #4a9eff;   /* agent-contributed UI and content */
+  --agent-dim:     #1e5a9a;   /* agent hover */
+  --agent-muted:   #051228;   /* agent background tint */
+  --agent-glow:    0 0 8px rgba(74,158,255,0.3);
+
+  /* --- Amber (staged / uncommitted) --- */
+  --amber:         #f09030;   /* warnings, uncommitted/staged state */
+  --amber-dim:     #805010;
+  --amber-muted:   #1a0e02;
+
+  /* --- Destructive --- */
+  --destructive:      #ff3d3d;
+  --destructive-dim:  #8a1a1a;
+  --destructive-muted:#160404;
+
+  /* --- Semantic UI colors --- */
+  --color-bg:        var(--bg-base);
+  --color-surface:   var(--bg-surface);
+  --color-text:      var(--fg-1);
+  --color-muted:     var(--fg-2);
+  --color-dim:       var(--fg-3);
+  --color-border:    var(--border);
+  --color-accent:    var(--accent);
+
+  /* ============================================================
+     TYPOGRAPHY
+     ============================================================ */
+
+  /* --- Font families --- */
+  --font-display:  'EB Garamond', Georgia, serif;
+  --font-ui:       'Space Grotesk', system-ui, sans-serif;
+  --font-mono:     'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+
+  /* --- Type scale (rem, base 16px) --- */
+  --text-xs:    0.6875rem;   /* 11px — metadata, timestamps */
+  --text-sm:    0.8125rem;   /* 13px — secondary labels, captions */
+  --text-base:  0.9375rem;   /* 15px — body / default UI */
+  --text-md:    1.0625rem;   /* 17px — slightly emphasized body */
+  --text-lg:    1.1875rem;   /* 19px — section headers */
+  --text-xl:    1.5rem;      /* 24px — page titles */
+  --text-2xl:   2rem;        /* 32px — display moments */
+  --text-3xl:   2.75rem;     /* 44px — wordmark / hero */
+  --text-4xl:   3.75rem;     /* 60px — large display */
+
+  /* --- Line heights --- */
+  --leading-tight:  1.25;
+  --leading-snug:   1.4;
+  --leading-normal: 1.55;
+  --leading-loose:  1.75;
+
+  /* --- Font weights --- */
+  --weight-light:   300;
+  --weight-regular: 400;
+  --weight-medium:  500;
+  --weight-semibold:600;
+
+  /* --- Letter spacing --- */
+  --tracking-tight: -0.02em;
+  --tracking-normal: 0em;
+  --tracking-wide:   0.04em;
+  --tracking-wider:  0.08em;
+
+  /* ============================================================
+     SPACING
+     ============================================================ */
+  --space-1:   4px;
+  --space-2:   8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  20px;
+  --space-6:  24px;
+  --space-8:  32px;
+  --space-10: 40px;
+  --space-12: 48px;
+  --space-16: 64px;
+
+  /* ============================================================
+     BORDER RADIUS — sharper for cyberpunk aesthetic
+     ============================================================ */
+  --radius-sm:   2px;
+  --radius-md:   4px;
+  --radius-lg:   6px;
+  --radius-xl:  10px;
+  --radius-full: 9999px;
+
+  /* ============================================================
+     SHADOWS / ELEVATION
+     ============================================================ */
+  --shadow-sm:  0 1px 3px rgba(0,0,0,0.3);
+  --shadow-md:  0 4px 12px rgba(0,0,0,0.4);
+  --shadow-lg:  0 8px 32px rgba(0,0,0,0.5);
+  --shadow-float: 0 4px 24px rgba(0,0,0,0.55), 0 1px 4px rgba(0,0,0,0.3);
+  --shadow-inset: inset 0 1px 3px rgba(0,0,0,0.35);
+
+  /* ============================================================
+     ANIMATION
+     ============================================================ */
+  --ease:        cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-linear: linear;
+  --duration-fast: 100ms;
+  --duration-base: 150ms;
+  --duration-slow: 250ms;
+
+  /* ============================================================
+     Z-INDEX SCALE
+     ============================================================ */
+  --z-base:    1;
+  --z-raised:  10;
+  --z-sticky:  100;
+  --z-overlay: 200;
+  --z-modal:   300;
+  --z-toast:   400;
+}
+
+/* ============================================================
+   SEMANTIC ELEMENT DEFAULTS
+   ============================================================ */
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+body {
+  background-color: var(--bg-base);
+  color: var(--fg-1);
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-normal);
+}
+
+/* --- Display headings (EB Garamond) --- */
+h1, .h1 {
+  font-family: var(--font-display);
+  font-size: var(--text-3xl);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  color: var(--fg-1);
+}
+
+h2, .h2 {
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  color: var(--fg-1);
+}
+
+/* --- UI headings (DM Sans) --- */
+h3, .h3 {
+  font-family: var(--font-ui);
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-snug);
+  color: var(--fg-1);
+}
+
+h4, .h4 {
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-snug);
+  color: var(--fg-1);
+}
+
+h5, h6, .h5, .h6 {
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-snug);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--fg-2);
+}
+
+p {
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
+  color: var(--fg-1);
+  text-wrap: pretty;
+}
+
+small, .text-sm {
+  font-size: var(--text-sm);
+  color: var(--fg-2);
+}
+
+.text-xs {
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  font-family: var(--font-mono);
+  letter-spacing: var(--tracking-wide);
+}
+
+code, kbd, pre, .mono {
+  font-family: var(--font-mono);
+  font-size: 0.875em; /* relative to surrounding text */
+}
+
+code {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.1em 0.35em;
+  color: var(--fg-1);
+}
+
+pre {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  overflow-x: auto;
+  font-size: var(--text-sm);
+  line-height: var(--leading-normal);
+  color: var(--fg-1);
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+a:hover {
+  color: var(--fg-1);
+  text-decoration: underline;
+}
+
+hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: var(--space-6) 0;
+}
+
+/* ============================================================
+   UTILITY CLASSES
+   ============================================================ */
+
+/* Text colors */
+.text-primary   { color: var(--fg-1); }
+.text-secondary { color: var(--fg-2); }
+.text-dim       { color: var(--fg-3); }
+.text-accent    { color: var(--accent); }
+.text-cyan      { color: var(--cyan); }
+.text-vault     { color: var(--vault); }
+.text-agent     { color: var(--agent); }
+.text-amber     { color: var(--amber); }
+.text-danger    { color: var(--destructive); }
+
+/* Font families */
+.font-display { font-family: var(--font-display); }
+.font-ui      { font-family: var(--font-ui); }
+.font-mono    { font-family: var(--font-mono); }
+
+/* Weights */
+.weight-light    { font-weight: var(--weight-light); }
+.weight-regular  { font-weight: var(--weight-regular); }
+.weight-medium   { font-weight: var(--weight-medium); }
+.weight-semibold { font-weight: var(--weight-semibold); }
+
+/* Glow effects */
+.glow-cyan   { box-shadow: var(--cyan-glow); }
+.glow-vault  { box-shadow: var(--vault-glow); }
+.glow-agent  { box-shadow: var(--agent-glow); }
+.text-glow-cyan  { text-shadow: 0 0 12px rgba(0,212,232,0.7); }
+.text-glow-gold  { text-shadow: 0 0 16px rgba(212,168,67,0.5); }
+
+/* Tron grid background */
+.grid-bg {
+  background-image:
+    linear-gradient(rgba(0,212,232,0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0,212,232,0.04) 1px, transparent 1px);
+  background-size: 32px 32px;
+}
+
+/* Neon border active state */
+.border-cyan { border-color: var(--cyan) !important; box-shadow: var(--cyan-glow); }
+.border-gold { border-color: var(--accent) !important; box-shadow: 0 0 8px rgba(212,168,67,0.3); }
+
+/* Focus ring */
+:focus-visible {
+  outline: 1px solid var(--cyan);
+  outline-offset: 2px;
+  box-shadow: var(--cyan-glow);
+}

--- a/companion-ui/design_handoff/2026-05-14-memory-candidate-review/design-notes.md
+++ b/companion-ui/design_handoff/2026-05-14-memory-candidate-review/design-notes.md
@@ -1,0 +1,68 @@
+# Design notes — Memory Candidate Review Queue
+
+## Visual language
+
+This package follows the shared Yggdrasil design system (`colors_and_type.css`) used across the
+2026-05 companion-ui handoffs:
+
+- **Dark, cool blue-black background** (`--bg-base`) with a subtle Tron grid.
+- **Cool blue-white text** (`--fg-1`); secondary copy in `--fg-2`; mono captions in `--fg-3`.
+- **Norse gold** (`--accent`) for governance and provenance accents.
+- **Electric cyan** (`--cyan`) for trigger / link / receipt-pending cues.
+- **Vault green** (`--vault`) for healthy, applied, reviewed.
+- **Amber** (`--amber`) for staged, stale, inferred, or attention-needed.
+- **Destructive red** (`--destructive`) for refusal, denial, conflict, and dead-letter.
+
+Type: **EB Garamond** for display, **Space Grotesk** for UI, **JetBrains Mono** for evidence
+captions, ids, scores, and timestamps. Mono is the load-bearing voice of "this is evidence,
+not summary."
+
+## Surface posture
+
+Review queue for proposed agent memories. Accept / edit / reject / defer / promote / keep-operational. Unreviewed memory is not semantic authority.
+
+The surface is intentionally **calm**:
+
+- No alarm noise. Red is reserved for actual refusals.
+- No coloured tiles without evidence. Every mono caption is rooted in a runtime value.
+- Animation is restrained: receipt-pill pulse and the banner LED only. Both respect
+  `prefers-reduced-motion`.
+- No emoji. Status uses short words ("Running", "Backlogged", "Stale") rather than icons.
+
+## Component vocabulary
+
+The shared spec chrome (`spec_chrome.css`) carries:
+
+- `.callout` (cyan, amber, accent, destructive, vault variants) for invariants and notes.
+- `.chip` for tag-style metadata.
+- `.receipt` (queued, applied, pending, failed) for receipt pills.
+- `.btn` (primary, governance, vault, danger, ghost) for actions.
+- `.gallery` and `.gallery-card` for state galleries.
+- `table.spec` for evidence tables with mono headers.
+
+Each prototype adds local components on top — see `prototype.html` for inline styles.
+
+See `prototype.html` §02 for the memory classes, §03 for the queue prototype, §04 for the action vocabulary, §05 for the 10-state gallery.
+
+## Why the layout is the way it is
+
+- **TOC sidebar.** Specs are scanned, not read. The TOC is sticky so scanning stays cheap.
+- **Mono section numbers and metadata.** Visual contract: mono text means "this is a value
+  the runtime emits", not a designer's invented label.
+- **Section heads in EB Garamond.** Display serif at section boundaries marks the
+  transitions in attention; UI sans inside the section keeps reading dense.
+- **No hover-only affordances.** Every action is visible at rest; hover only adds an accent.
+
+## Copy conventions
+
+- Headlines: short verbs or adjectives.
+- Captions: mono, in `--fg-3`.
+- Action labels: uppercase, letter-spacing wide, never punctuated.
+- Status copy: second-person plain language. Never imperative-without-object ("Restart").
+
+## Out of scope for this package
+
+- Brand redesign.
+- New colour tokens (none added).
+- New type pairings.
+- Animation grammar beyond the existing receipt-pulse pattern.

--- a/companion-ui/design_handoff/2026-05-14-memory-candidate-review/edge-states.md
+++ b/companion-ui/design_handoff/2026-05-14-memory-candidate-review/edge-states.md
@@ -1,0 +1,30 @@
+# Edge states — Memory Candidate Review Queue
+
+This document is the edge-state checklist required by the Handoff Governance Pack §08.
+The full per-state visual treatment lives in **`prototype.html` §06 (Edge states)**. This
+document is the text checklist.
+
+## Required edges
+
+- **Empty** — designed (see `prototype.html` §06).
+- **Loading** — designed; static dim states, no skeleton animation.
+- **Degraded** — designed; partial function with explicit naming of what is degraded.
+- **Blocked** — designed; refusal is named, recorded, and never silently retried.
+- **Stale context** — designed; threshold and "why" rendered.
+- **Missing provenance** — designed; surfaced rather than hidden.
+- **Write-guard denial** — designed; denial reason visible; not retried.
+- **Reduced motion** — designed; receipt pulse + banner LED respect `prefers-reduced-motion`.
+- **Narrow / mobile layout** — designed; see `prototype.html` §06 (and §04 for the
+  portrait-specific layout in the bundle inspector).
+
+## Deferred-with-reason
+
+None for this package. If a future revision defers any edge, it must be tracked here with a
+reason and a follow-up issue link.
+
+## Validation expectations
+
+Per the implementation contract, every edge above must render correctly from a fixture and
+must satisfy the per-edge acceptance criteria in `prototype.html` §06. Reduced-motion is
+verified with the OS preference set; narrow layouts are verified at the documented
+breakpoints (`< 900px` for the standard collapse; `< 560px` where applicable).

--- a/companion-ui/design_handoff/2026-05-14-memory-candidate-review/implementation-contracts.md
+++ b/companion-ui/design_handoff/2026-05-14-memory-candidate-review/implementation-contracts.md
@@ -1,0 +1,69 @@
+# Implementation contract — Memory Candidate Review Queue
+
+**Status:** Contract for UI integration · target-state
+**Mutates:** nothing on its own
+**Depends on:** docs/CONCEPTS/AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT.md, the gated-execution invariant.
+
+## Position in the chain
+
+This document is the part of the package that implementation reads. It is the only document
+that promises anything to code. Everything else in the package (README, design-notes,
+state-gallery, edge-states, authority-boundaries, open-questions) is guidance.
+
+## State enum
+
+The implementation must enumerate exactly the states described in **`prototype.html` §03 + §05**. Adding
+or removing a state without amending this document means the design no longer covers it.
+
+## Allowed transitions
+
+See **`prototype.html` §03 + §05** for the per-state transition table. Implementation must
+reject any transition not enumerated there.
+
+## Data attributes
+
+Stable attributes the design relies on for testids and behavioral selectors are listed in
+**`prototype.html` §07 (Implementation contract)** of this package. Required attributes are
+flagged in the prototype's code block. Adding new attributes is permitted; renaming is not.
+
+## Intents
+
+The full `data-intent` vocabulary is in **`prototype.html` §07**. Each intent declares:
+
+- the surface that emits it,
+- the effect (UI-local / read-only / governed / navigation),
+- whether it routes through the governance pipeline.
+
+Implementation must not emit intents not declared here. Adding a new intent requires an
+amendment to this document.
+
+## Server contract surface
+
+Endpoints / events / classifiers the UI consumes are bound to existing or proposed runtime
+contracts. The UI never re-classifies; the server's declared class wins.
+
+Specific contract references:
+
+- `docs/CONCEPTS/AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT.md`
+
+## Validation expectations
+
+A passing validation receipt for this package would render the full state gallery against
+fixture inputs, verify every declared transition, and confirm:
+
+- no UI-derived posture / class / authority,
+- denied / blocked states emit the right receipts,
+- reduced-motion preference is respected,
+- narrow / portrait layout preserves all critical affordances.
+
+The exact fixture set is owned by the implementation issue, not this document.
+
+## What this contract does not say
+
+Explicit list of things implementation is free to choose:
+
+- framework (React, vanilla, web components — design works for any),
+- style technique (CSS, styled-components, CSS modules),
+- animation library (none needed; the design uses CSS),
+- persistence cache shape,
+- network transport.

--- a/companion-ui/design_handoff/2026-05-14-memory-candidate-review/open-questions.md
+++ b/companion-ui/design_handoff/2026-05-14-memory-candidate-review/open-questions.md
@@ -1,0 +1,32 @@
+# Open questions — Memory Candidate Review Queue
+
+The canonical list lives in **`prototype.html` §09 (Open questions)** of this package. This
+document is the structured version intended for issue creation at crossings C/D.
+
+## Status
+
+All open questions are tracked in the prototype. Owner-doc owners are proposed in the
+prototype; they are not assigned yet — assignment happens at crossing B during the
+maturity-checklist review.
+
+## Crossing-B blockers
+
+If any open question would, if answered, change the state machine declared in the
+implementation contract, that question is a crossing-B blocker per the governance pack §03.
+The reviewer at crossing B must triage each open question into one of:
+
+- **resolve before promotion** (blocker),
+- **resolve in normalized spec** (non-blocker, but cite),
+- **defer to implementation issue** (non-blocker, but acknowledge).
+
+## How to read
+
+Each open question in the prototype carries:
+
+- a short title (used as the issue title if escalated),
+- the rationale for the question,
+- a proposed default (the package's recommendation),
+- an implicit owner (the doc the question would amend if accepted).
+
+Detailed answers are deliberately not pre-decided here — the question list is the package's
+honest "we don't know yet, and we made a choice anyway" record.

--- a/companion-ui/design_handoff/2026-05-14-memory-candidate-review/prototype.html
+++ b/companion-ui/design_handoff/2026-05-14-memory-candidate-review/prototype.html
@@ -1,0 +1,1324 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Memory Candidate Review Queue — Yggdrasil Companion UI</title>
+<link rel="stylesheet" href="./colors_and_type.css" />
+<link rel="stylesheet" href="./spec_chrome.css" />
+<style>
+  /* ============================================================
+     LOCAL — memory candidate review queue
+     ============================================================ */
+  .queue {
+    border: 1px solid var(--border);
+    background: var(--bg-surface);
+    border-radius: var(--radius-md);
+    margin: var(--space-3) 0 var(--space-6);
+    overflow: hidden;
+  }
+  .q-bar {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: 10px 16px;
+    background: var(--bg-raised);
+    border-bottom: 1px solid var(--border);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+  }
+  .q-bar .count { color: var(--accent); }
+  .q-bar .filter {
+    margin-left: var(--space-3);
+    display: flex;
+    gap: 6px;
+  }
+  .q-bar .filter .pill {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    padding: 3px 8px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-strong);
+    background: var(--bg-base);
+    color: var(--fg-3);
+    cursor: pointer;
+    letter-spacing: var(--tracking-wide);
+  }
+  .q-bar .filter .pill[aria-pressed="true"] {
+    color: var(--cyan);
+    border-color: rgba(0,212,232,0.5);
+    background: rgba(0,212,232,0.05);
+  }
+  .q-bar .right { margin-left: auto; display: flex; gap: var(--space-3); align-items: center; }
+
+  .q-body {
+    display: grid;
+    grid-template-columns: 320px 1fr;
+    min-height: 620px;
+  }
+  .q-list {
+    border-right: 1px solid var(--border);
+    overflow-y: auto;
+    max-height: 720px;
+    background: var(--bg-base);
+  }
+  .q-row {
+    padding: 12px 14px;
+    border-bottom: 1px solid var(--border);
+    border-left: 2px solid transparent;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    cursor: pointer;
+  }
+  .q-row[aria-selected="true"] {
+    border-left-color: var(--cyan);
+    background: var(--bg-surface);
+  }
+  .q-row .top {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 6px;
+  }
+  .q-row .top .cls {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    color: var(--accent);
+  }
+  .q-row .top .cls.episodic    { color: var(--cyan); }
+  .q-row .top .cls.semantic    { color: var(--accent); }
+  .q-row .top .cls.prospective { color: var(--amber); }
+  .q-row .top .cls.procedural  { color: var(--agent); }
+  .q-row .top .cls.preference  { color: var(--vault); }
+  .q-row .top .cls.policy      { color: var(--accent); }
+  .q-row .top .cls.reflection  { color: var(--fg-2); }
+  .q-row .top .age {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--fg-3);
+  }
+  .q-row .summary {
+    font-family: var(--font-ui);
+    font-size: var(--text-sm);
+    color: var(--fg-1);
+    line-height: 1.35;
+  }
+  .q-row .row3 {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+  }
+  .q-row .row3 .conf { color: var(--cyan); }
+  .q-row .row3 .conf.low { color: var(--amber); }
+  .q-row .row3 .conf.high { color: var(--vault); }
+  .q-row .row3 .inferred { color: var(--amber); }
+  .q-row .row3 .reviewed { color: var(--vault); }
+  .q-row .row3 .conflict { color: var(--destructive); }
+  .q-row .row3 .superseded { color: var(--fg-3); }
+
+  /* candidate detail */
+  .q-detail {
+    padding: var(--space-5) var(--space-6);
+    overflow-y: auto;
+    max-height: 720px;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-5);
+  }
+  .cand-head {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .cand-head .row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+  }
+  .cand-head .cls-pill {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    padding: 3px 10px;
+    border-radius: var(--radius-sm);
+    background: var(--bg-raised);
+    border: 1px solid var(--border-strong);
+    color: var(--accent);
+  }
+  .cand-head .cls-pill.episodic    { color: var(--cyan); border-color: rgba(0,212,232,0.35); }
+  .cand-head .cls-pill.semantic    { color: var(--accent); border-color: rgba(212,168,67,0.4); }
+  .cand-head .cls-pill.prospective { color: var(--amber); border-color: rgba(240,144,48,0.4); }
+  .cand-head .cls-pill.procedural  { color: var(--agent); border-color: rgba(74,158,255,0.35); }
+  .cand-head .cls-pill.preference  { color: var(--vault); border-color: rgba(57,232,125,0.35); }
+  .cand-head .cls-pill.policy      { color: var(--accent); border-color: rgba(212,168,67,0.4); }
+  .cand-head .cls-pill.reflection  { color: var(--fg-2); }
+  .cand-head .id {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wide);
+  }
+  .cand-head h3 {
+    font-family: var(--font-display);
+    font-size: var(--text-2xl);
+    font-weight: var(--weight-regular);
+    line-height: 1.15;
+    color: var(--fg-1);
+    margin: 4px 0 0;
+    letter-spacing: 0;
+    text-transform: none;
+  }
+
+  .cand-body {
+    border: 1px solid var(--border);
+    background: var(--bg-base);
+    border-radius: var(--radius-md);
+    padding: var(--space-4);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .cand-body .lbl {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    color: var(--fg-3);
+  }
+  .cand-body .text {
+    font-family: var(--font-ui);
+    font-size: var(--text-md);
+    color: var(--fg-1);
+    line-height: 1.55;
+    max-width: 60ch;
+  }
+  .cand-body .inferred-tag {
+    align-self: flex-start;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    padding: 2px 8px;
+    border-radius: var(--radius-sm);
+    background: var(--amber-muted);
+    color: var(--amber);
+    border: 1px solid rgba(240,144,48,0.35);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+  }
+  .cand-body .reviewed-tag {
+    align-self: flex-start;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    padding: 2px 8px;
+    border-radius: var(--radius-sm);
+    background: rgba(57,232,125,0.06);
+    color: var(--vault);
+    border: 1px solid rgba(57,232,125,0.35);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+  }
+
+  /* why proposed */
+  .why {
+    border: 1px solid var(--border);
+    border-left: 2px solid var(--cyan);
+    background: rgba(0,212,232,0.03);
+    border-radius: var(--radius-sm);
+    padding: 12px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .why .lbl {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    color: var(--cyan);
+  }
+  .why p {
+    font-size: var(--text-sm);
+    color: var(--fg-1);
+    line-height: 1.5;
+    margin: 0;
+    max-width: 60ch;
+  }
+  .why .ev {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--fg-2);
+    letter-spacing: var(--tracking-wide);
+  }
+
+  /* authority preview */
+  .auth-preview {
+    border: 1px solid var(--border-strong);
+    background: var(--bg-raised);
+    border-radius: var(--radius-sm);
+    padding: 12px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .auth-preview .lbl {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    color: var(--accent);
+  }
+  .auth-preview .row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .auth-preview .ap {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    padding: 3px 8px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-strong);
+    color: var(--fg-3);
+    background: var(--bg-base);
+  }
+  .auth-preview .ap.yes   { color: var(--vault); border-color: rgba(57,232,125,0.35); }
+  .auth-preview .ap.no    { color: var(--destructive); border-color: rgba(255,61,61,0.35); }
+  .auth-preview .ap.maybe { color: var(--amber); border-color: rgba(240,144,48,0.35); }
+
+  /* conflict / source / receipts grid */
+  .meta-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-3);
+  }
+  .meta-card {
+    border: 1px solid var(--border);
+    background: var(--bg-surface);
+    border-radius: var(--radius-sm);
+    padding: 10px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .meta-card .lbl {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    color: var(--fg-3);
+  }
+  .meta-card .v {
+    font-size: var(--text-sm);
+    color: var(--fg-1);
+    line-height: 1.4;
+  }
+  .meta-card.conflict { border-color: rgba(255,61,61,0.35); }
+  .meta-card.conflict .lbl { color: var(--destructive); }
+
+  /* action bar */
+  .actions-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding-top: var(--space-3);
+    border-top: 1px solid var(--border);
+  }
+
+  /* outcome strip — terminal states */
+  .outcome {
+    padding: 10px 14px;
+    border-radius: var(--radius-sm);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    letter-spacing: var(--tracking-wide);
+    color: var(--fg-2);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background: var(--bg-base);
+    border: 1px solid var(--border-strong);
+  }
+  .outcome.accept    { color: var(--vault); border-color: rgba(57,232,125,0.4); background: rgba(57,232,125,0.04); }
+  .outcome.reject    { color: var(--destructive); border-color: rgba(255,61,61,0.4); background: rgba(255,61,61,0.04); }
+  .outcome.defer     { color: var(--amber); border-color: rgba(240,144,48,0.4); background: rgba(240,144,48,0.04); }
+  .outcome.promote   { color: var(--vault); border-color: rgba(57,232,125,0.4); background: rgba(57,232,125,0.06); }
+  .outcome.op-only   { color: var(--agent); border-color: rgba(74,158,255,0.35); background: rgba(74,158,255,0.04); }
+  .outcome.revised   { color: var(--cyan); border-color: rgba(0,212,232,0.4); background: rgba(0,212,232,0.04); }
+
+  /* gallery */
+  .gallery.mem-gallery { grid-template-columns: 1fr 1fr; }
+  .gm {
+    border: 1px solid var(--border);
+    background: var(--bg-surface);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+  }
+  .gm-bar {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    padding: 8px 12px;
+    background: var(--bg-raised);
+    border-bottom: 1px solid var(--border);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    color: var(--fg-3);
+  }
+  .gm-bar .cls { color: var(--accent); }
+  .gm-body { padding: 12px; display: flex; flex-direction: column; gap: 8px; }
+  .gm-body h5 {
+    font-family: var(--font-display);
+    font-size: var(--text-md);
+    color: var(--fg-1);
+    font-weight: var(--weight-regular);
+    line-height: 1.2;
+    margin: 0;
+  }
+  .gm-body p {
+    font-size: var(--text-sm);
+    color: var(--fg-2);
+    margin: 0;
+    line-height: 1.45;
+  }
+  .gm-body .meta-line {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+  }
+  .gm-body .meta-line .v { color: var(--fg-2); }
+  .gm-body .meta-line .v.cyan { color: var(--cyan); }
+  .gm-body .meta-line .v.gold { color: var(--accent); }
+  .gm-body .meta-line .v.amber { color: var(--amber); }
+  .gm-body .meta-line .v.dang  { color: var(--destructive); }
+  .gm-body .meta-line .v.vault { color: var(--vault); }
+  .gm-body .meta-line .v.agent { color: var(--agent); }
+
+  /* batch summary in gallery */
+  .batch-summary {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 6px;
+  }
+  .batch-summary .cell {
+    background: var(--bg-base);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 6px 8px;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .batch-summary .cell .n {
+    font-family: var(--font-display);
+    font-size: var(--text-lg);
+    color: var(--fg-1);
+  }
+  .batch-summary .cell.gold .n   { color: var(--accent); }
+  .batch-summary .cell.cyan .n   { color: var(--cyan); }
+  .batch-summary .cell.amber .n  { color: var(--amber); }
+  .batch-summary .cell.vault .n  { color: var(--vault); }
+
+  @media (max-width: 900px) {
+    .q-body { grid-template-columns: 1fr; }
+    .q-list { border-right: none; border-bottom: 1px solid var(--border); max-height: none; }
+    .meta-grid { grid-template-columns: 1fr; }
+    .gallery.mem-gallery { grid-template-columns: 1fr; }
+    .batch-summary { grid-template-columns: 1fr 1fr; }
+  }
+</style>
+</head>
+<body>
+<div class="page">
+
+  <!-- ============================ TOC ============================ -->
+  <nav class="toc" aria-label="Section index">
+    <div class="toc-label">Sections</div>
+    <ol>
+      <li><a href="#s1"><span class="toc-num">01</span>Context &amp; boundary</a></li>
+      <li><a href="#s2"><span class="toc-num">02</span>Memory classes</a></li>
+      <li><a href="#s3"><span class="toc-num">03</span>Queue prototype</a></li>
+      <li><a href="#s4"><span class="toc-num">04</span>Queue posture &amp; anti-inbox</a></li>
+      <li><a href="#s5"><span class="toc-num">05</span>Action vocabulary</a></li>
+      <li><a href="#s6"><span class="toc-num">06</span>State gallery</a></li>
+      <li><a href="#s7"><span class="toc-num">07</span>Edge states</a></li>
+      <li><a href="#s8"><span class="toc-num">08</span>Implementation contract</a></li>
+      <li><a href="#s9"><span class="toc-num">09</span>Authority boundaries</a></li>
+      <li><a href="#s10"><span class="toc-num">10</span>Open questions</a></li>
+      <li><a href="#s11"><span class="toc-num">11</span>Handoff to Code/Codex</a></li>
+    </ol>
+  </nav>
+
+  <!-- ============================ MAIN ============================ -->
+  <main>
+    <header class="doc-header">
+      <div class="doc-eyebrow">Companion UI · Design Handoff · Review surface</div>
+      <h1 class="doc-title">Memory Candidate Review Queue</h1>
+      <p class="doc-lede">
+        A review queue for proposed agent memories. Agents may observe, infer, or summarise —
+        and propose. The queue is where those proposals stop being agent state and start being
+        reviewable candidates. The human can accept, edit, reject, defer, expire, promote, or
+        keep-as-operational. Unreviewed memory is not semantic authority.
+      </p>
+      <div class="doc-meta">
+        <span><strong>Surface:</strong> MEMORY_CANDIDATE_REVIEW</span>
+        <span><strong>Owner-doc:</strong> AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT</span>
+        <span><strong>Authority:</strong> Review surface · review state mutates through governed pipeline</span>
+        <span><strong>Status:</strong> Design handoff · v1 · 2026-05-14</span>
+      </div>
+    </header>
+
+    <!-- ============== 01 ============== -->
+    <section class="spec" id="s1">
+      <h2><span class="secnum">01 ·</span>Context &amp; boundary</h2>
+      <p class="lede">What this queue is for, and the failure modes it must design against.</p>
+
+      <p>
+        The memory contract is intentionally explicit: agent memory supports the human, it does
+        not replace human judgment. Generated or inferred memory may not become trusted
+        knowledge automatically. The candidate → review → promote lifecycle has to be visible,
+        narrow, and bounded. That is the whole reason this queue exists.
+      </p>
+
+      <p>
+        It also has to <em>not</em> become a burdensome task inbox. If reviewing memory becomes
+        an obligation, the user will stop reviewing. The design posture is: <em>quiet by
+        default, batched, small, easy to defer, never noisy</em>.
+      </p>
+
+      <h3>Design posture</h3>
+      <ul>
+        <li><strong>Single candidate is the unit.</strong> A card with content, source, why-now,
+          confidence, authority preview, and seven actions. Everything else is queue chrome.</li>
+        <li><strong>Batch operations require an explicit batch mode.</strong> No accidental
+          bulk-accept.</li>
+        <li><strong>Promote is rare and visible.</strong> Promotion to durable vault knowledge
+          opens an inline preview of the resulting note before commit.</li>
+        <li><strong>Defer is a first-class action.</strong> Deferring is the default-friendly
+          answer to "I don't have time right now" — never a hidden snooze.</li>
+        <li><strong>Operational-only is a first-class outcome.</strong> Some memory belongs in
+          agent-side operational memory and should never become vault knowledge. That outcome
+          is a button, not a workaround.</li>
+      </ul>
+
+      <div class="callout invariant">
+        <span class="callout-label">Floor invariant · Candidacy is not authority</span>
+        A candidate in the queue has no semantic authority. The queue's posture defaults
+        prevent candidate-class items from being recalled into answers, orientation, or
+        write proposals. Recall authority is granted only by an explicit accept / promote.
+      </div>
+
+      <h3>What the queue is not</h3>
+      <ul>
+        <li>Not a memory store. Storage and recall belong to the runtime; the queue is the
+          review surface.</li>
+        <li>Not an editing surface for already-promoted memory. Revision after promotion
+          flows through the normal vault edit + governance pipeline.</li>
+        <li>Not a task tracker. Memory candidates expire on a schedule; they are not a list
+          of obligations.</li>
+        <li>Not an inbox. There is no notification badge. The queue exists where the user
+          chooses to visit.</li>
+      </ul>
+    </section>
+
+    <!-- ============== 02 ============== -->
+    <section class="spec" id="s2">
+      <h2><span class="secnum">02 ·</span>Memory classes</h2>
+      <p class="lede">
+        Following <code>AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT.md</code>. Class is set by the
+        proposing agent on the candidate — the queue renders the declared class, never
+        re-classifies.
+      </p>
+
+      <table class="spec">
+        <thead><tr><th>Class</th><th>Color cue</th><th>Common content</th><th>Promotion target</th></tr></thead>
+        <tbody>
+          <tr><td><strong>Semantic knowledge</strong></td><td><span class="chip impl">gold</span></td><td>Stabilized meanings, definitions, claims that should converge on vault truth.</td><td>Durable Markdown note (vault).</td></tr>
+          <tr><td><strong>Episodic</strong></td><td><span class="chip design">cyan</span></td><td>Records that something happened, when, and surrounding situation.</td><td>Operational memory or session log; rarely vault.</td></tr>
+          <tr><td><strong>Prospective</strong></td><td><span class="chip gated">amber</span></td><td>Commitments, reminders, waiting state, candidate actions.</td><td>Vault note with type=commitment, or operational memory.</td></tr>
+          <tr><td><strong>Procedural</strong></td><td><span class="chip agent">blue</span></td><td>Repeated ways of doing something; versioned if it drives action.</td><td>Vault procedure note, versioned.</td></tr>
+          <tr><td><strong>Preference</strong></td><td><span class="chip vault">green</span></td><td>Stable user defaults, style choices, settings.</td><td>Preference store · governed.</td></tr>
+          <tr><td><strong>Policy / authority</strong></td><td><span class="chip impl">gold</span></td><td>Boundaries, permissions, safety rules.</td><td>Policy doc · governed · never auto-promoted.</td></tr>
+          <tr><td><strong>Agent reflection</strong></td><td><span class="chip">neutral</span></td><td>Agent's own retrospective notes about its work.</td><td>Operational memory only; rarely promoted.</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <!-- ============== 03 ============== -->
+    <section class="spec" id="s3">
+      <h2><span class="secnum">03 ·</span>Queue prototype <span class="chip design" style="font-size:10px; margin-left:8px">single candidate selected</span></h2>
+      <p class="lede">
+        Default view. Twelve candidates waiting, one selected. The candidate detail shows
+        content, why-it-was-proposed, source, confidence, authority preview, and seven
+        actions. The queue list is on the left; filters are in the bar; batch mode is
+        explicit.
+      </p>
+
+      <div class="queue" aria-label="Memory Candidate Review Queue">
+        <div class="q-bar">
+          <span>queue</span>
+          <span class="count">12 pending</span>
+          <span class="filter">
+            <button class="pill" type="button" aria-pressed="true">all</button>
+            <button class="pill" type="button" aria-pressed="false">inferred</button>
+            <button class="pill" type="button" aria-pressed="false">conflict</button>
+            <button class="pill" type="button" aria-pressed="false">expiring</button>
+          </span>
+          <span class="right">
+            <span style="color:var(--fg-2);">batch mode</span>
+            <button class="btn ghost" type="button" data-intent="queue.toggle-batch">off <span class="kbd">B</span></button>
+          </span>
+        </div>
+
+        <!-- REFINEMENT v2 — persistent in-UI authority banner -->
+        <div role="note" aria-label="Authority banner" style="display:flex; align-items:center; gap:var(--space-3); padding:8px 16px; background:rgba(212,168,67,0.04); border-bottom:1px solid rgba(212,168,67,0.25); font-family:var(--font-mono); font-size:var(--text-xs); color:var(--fg-2); letter-spacing:var(--tracking-wide);">
+          <span aria-hidden="true" style="width:8px; height:8px; border-radius:50%; background:var(--accent); box-shadow:0 0 6px var(--accent); flex-shrink:0;"></span>
+          <span style="color:var(--accent); text-transform:uppercase; letter-spacing:var(--tracking-wider); font-size:10px;">Unreviewed memory is not semantic authority.</span>
+          <span style="color:var(--fg-3); text-transform:none; letter-spacing:0;">Candidate-state items in this queue cannot be recalled into answers, orientation, or write proposals. Authority activates only on accept or promote.</span>
+        </div>
+
+        <div class="q-body">
+          <!-- list -->
+          <aside class="q-list" aria-label="Pending candidates">
+            <div class="q-row" aria-selected="true">
+              <div class="top"><span class="cls semantic">semantic · candidate</span><span class="age">12m</span></div>
+              <div class="summary">"Context bundles must show exclusions when exclusion affects interpretation."</div>
+              <div class="row3">
+                <span class="inferred">inferred</span>
+                <span class="conf">conf · 0.68</span>
+                <span>· 3 sources</span>
+              </div>
+            </div>
+
+            <div class="q-row">
+              <div class="top"><span class="cls episodic">episodic</span><span class="age">28m</span></div>
+              <div class="summary">User worked on the canvas suggestion classifier between 11:40 and 12:08.</div>
+              <div class="row3">
+                <span class="reviewed">reviewed source</span>
+                <span class="conf high">conf · 0.92</span>
+                <span>· session note</span>
+              </div>
+            </div>
+
+            <div class="q-row">
+              <div class="top"><span class="cls prospective">prospective · commitment</span><span class="age">1h</span></div>
+              <div class="summary">Run the runtime proof before the 21:00 window.</div>
+              <div class="row3">
+                <span class="reviewed">explicit</span>
+                <span class="conf high">conf · 0.95</span>
+                <span>· user-stated</span>
+              </div>
+            </div>
+
+            <div class="q-row">
+              <div class="top"><span class="cls semantic">semantic</span><span class="age">1h</span></div>
+              <div class="summary">"Hugin is the canvas-side agent; Munin is the panel-side agent."</div>
+              <div class="row3">
+                <span class="reviewed">reviewed</span>
+                <span class="conflict">conflict</span>
+                <span class="conf">conf · 0.71</span>
+              </div>
+            </div>
+
+            <div class="q-row">
+              <div class="top"><span class="cls preference">preference</span><span class="age">3h</span></div>
+              <div class="summary">User prefers gold/amber for governance accents, never red.</div>
+              <div class="row3">
+                <span class="inferred">inferred · style</span>
+                <span class="conf low">conf · 0.54</span>
+              </div>
+            </div>
+
+            <div class="q-row">
+              <div class="top"><span class="cls procedural">procedural</span><span class="age">4h</span></div>
+              <div class="summary">"Start every design handoff with a context &amp; boundary section."</div>
+              <div class="row3">
+                <span class="inferred">pattern · 6 examples</span>
+                <span class="conf">conf · 0.74</span>
+              </div>
+            </div>
+
+            <div class="q-row">
+              <div class="top"><span class="cls policy">policy</span><span class="age">5h</span></div>
+              <div class="summary">"UI never re-classifies a server-declared proposal class."</div>
+              <div class="row3">
+                <span class="reviewed">reviewed</span>
+                <span class="conf high">conf · 0.96</span>
+                <span>· echo of contract</span>
+              </div>
+            </div>
+
+            <div class="q-row">
+              <div class="top"><span class="cls reflection">reflection</span><span class="age">8h</span></div>
+              <div class="summary">Hugin's draft suggestions were rejected 3× before user-edit-then-apply.</div>
+              <div class="row3">
+                <span class="inferred">agent self-report</span>
+                <span class="conf low">conf · 0.48</span>
+              </div>
+            </div>
+
+            <div class="q-row">
+              <div class="top"><span class="cls prospective">prospective · waiting</span><span class="age">14h</span></div>
+              <div class="summary">Waiting on validation receipt for canvas suggestion handoff.</div>
+              <div class="row3">
+                <span class="reviewed">explicit</span>
+                <span class="superseded">superseded?</span>
+              </div>
+            </div>
+
+            <div class="q-row">
+              <div class="top"><span class="cls episodic">episodic</span><span class="age">1d</span></div>
+              <div class="summary">User rejected 5 candidates in a row yesterday; pacing should slow.</div>
+              <div class="row3">
+                <span class="inferred">pacing inference</span>
+                <span class="conf low">conf · 0.41</span>
+              </div>
+            </div>
+
+            <div class="q-row">
+              <div class="top"><span class="cls semantic">semantic</span><span class="age">2d</span></div>
+              <div class="summary">"Receipts live in Panel locality. Companion mirrors but never owns them."</div>
+              <div class="row3">
+                <span class="reviewed">reviewed</span>
+                <span class="conf high">conf · 0.91</span>
+              </div>
+            </div>
+
+            <div class="q-row">
+              <div class="top"><span class="cls preference">preference</span><span class="age">2d</span></div>
+              <div class="summary">User opens session drawer with ⌘K rather than the top-bar button.</div>
+              <div class="row3">
+                <span class="inferred">behavior</span>
+                <span class="conf">conf · 0.66</span>
+              </div>
+            </div>
+          </aside>
+
+          <!-- detail -->
+          <section class="q-detail">
+            <header class="cand-head">
+              <div class="row">
+                <span class="cls-pill semantic">semantic · candidate</span>
+                <span class="id">mc-2026-05-14-0008</span>
+                <span style="font-family:var(--font-mono); font-size:10px; color:var(--fg-3); letter-spacing:var(--tracking-wide); text-transform:uppercase;">proposed by · Hugin · 12m ago</span>
+              </div>
+              <h3>"Context bundles must show exclusions when exclusion affects interpretation."</h3>
+            </header>
+
+            <!-- content -->
+            <div class="cand-body">
+              <span class="lbl">Proposed content</span>
+              <span class="inferred-tag">inferred</span>
+              <p class="text">Context bundles in the inspector should default to showing their
+                excluded artifacts whenever an exclusion would change how the operator
+                interprets the bundle — for example, when low-trust material was deliberately
+                dropped, or when a closely-related artifact was excluded for being out of
+                scope. Score-floor exclusions stay hidden.</p>
+            </div>
+
+            <!-- why proposed -->
+            <div class="why">
+              <span class="lbl">Why this was proposed</span>
+              <p>The agent observed three recent Hugin turns where the operator opened the
+                excluded disclosure manually and then asked a follow-up question about the
+                excluded artifact. Pattern frequency met the heuristic threshold.</p>
+              <p class="ev">evidence · session t-11, t-14, t-19 · context bundle inspector docs</p>
+            </div>
+
+            <!-- authority preview -->
+            <div class="auth-preview">
+              <span class="lbl">If accepted, the candidate will have this recall authority</span>
+              <div class="row">
+                <span class="ap yes">✓ may_recall</span>
+                <span class="ap yes">✓ may_answer</span>
+                <span class="ap maybe">~ may_propose · conditional</span>
+                <span class="ap no">✗ may_write</span>
+              </div>
+              <p style="font-size:var(--text-xs); color:var(--fg-2); margin:0;">
+                If promoted to vault knowledge, may_write becomes vault-edit authority,
+                not memory-write authority. Promotion is a separate action.
+              </p>
+            </div>
+
+            <!-- meta grid -->
+            <div class="meta-grid">
+              <div class="meta-card">
+                <span class="lbl">Source</span>
+                <span class="v">Inferred from three session-log turns. <br><span style="font-family:var(--font-mono); font-size:var(--text-xs); color:var(--fg-3)">.chats/canvas-suggestion-flow/2026-05-14-1140.md</span></span>
+              </div>
+              <div class="meta-card">
+                <span class="lbl">Confidence</span>
+                <span class="v">0.68 · medium · <span style="color:var(--amber); font-family:var(--font-mono); font-size:var(--text-xs)">heuristic threshold met, not user-stated</span></span>
+              </div>
+              <div class="meta-card">
+                <span class="lbl">Expiry</span>
+                <span class="v">No expiry proposed · operator may set on accept</span>
+              </div>
+              <div class="meta-card">
+                <span class="lbl">Receipts</span>
+                <span class="v">
+                  <span class="receipt"><span class="recdot" style="background:var(--cyan)"></span>candidate · r-0510</span>
+                </span>
+              </div>
+            </div>
+
+            <!-- actions -->
+            <div class="actions-bar">
+              <button class="btn vault" type="button" data-intent="memory.accept">Accept <span class="kbd">A</span></button>
+              <button class="btn" type="button" data-intent="memory.edit">Edit <span class="kbd">E</span></button>
+              <button class="btn governance" type="button" data-intent="memory.promote">Promote to note <span class="kbd">P</span></button>
+              <button class="btn" type="button" data-intent="memory.operational">Keep operational <span class="kbd">O</span></button>
+              <button class="btn" type="button" data-intent="memory.set-expiry">Set expiry…</button>
+              <button class="btn" type="button" data-intent="memory.defer">Defer <span class="kbd">D</span></button>
+              <button class="btn danger" type="button" data-intent="memory.reject">Reject <span class="kbd">R</span></button>
+            </div>
+          </section>
+        </div>
+      </div>
+
+      <p>
+        The action bar is intentionally seven options wide. Three of those (accept, defer,
+        reject) are the daily-driver. Four (edit, promote, keep-operational, set-expiry) are
+        rarer but visible — keeping them off-screen would push the user toward accept-or-reject
+        binaries, which is exactly the inbox-anti-pattern the queue is trying to avoid.
+      </p>
+    </section>
+
+    <!-- ============== 04 — REFINEMENT v2 — queue posture, anti-inbox mitigations, authority banner ============== -->
+    <section class="spec" id="s4">
+      <h2><span class="secnum">04 ·</span>Queue posture &amp; anti-inbox mitigations</h2>
+      <p class="lede">
+        The queue exists to prevent a specific failure mode: agent memory becoming hidden
+        semantic authority. It must do that without becoming a different failure mode: a
+        burdensome task inbox the user starts avoiding.
+      </p>
+
+      <h3>The persistent authority banner</h3>
+      <p>
+        Every queue view carries the gold banner shown above the candidate list in <a href="#s3">§03</a>:
+      </p>
+      <div class="callout invariant" style="max-width: 64ch;">
+        <span class="callout-label">In-UI invariant copy</span>
+        <strong>Unreviewed memory is not semantic authority.</strong> Candidate-state items in
+        this queue cannot be recalled into answers, orientation, or write proposals. Authority
+        activates only on accept or promote.
+      </div>
+      <p>
+        The banner is mono, gold, and persistent. It never animates. It never collapses. The
+        same banner appears at the top of the batch-mode view and on the single-candidate
+        detail page. It is the surface's <em>floor copy</em> — always present, never opt-out.
+      </p>
+
+      <h3>Anti-inbox mitigations</h3>
+      <p>
+        Queue anxiety has a known shape: the count climbs, the user feels obliged, the user
+        avoids the surface, the count climbs further. The design refuses each link of that chain.
+      </p>
+
+      <table class="spec">
+        <thead><tr><th>Mitigation</th><th>What it does</th><th>What it refuses to do</th></tr></thead>
+        <tbody>
+          <tr>
+            <td><strong>Pull, not push</strong></td>
+            <td>The user visits the queue when they choose. No notification, no badge.</td>
+            <td>No count anywhere in the shell. No “you have N pending” toast.</td>
+          </tr>
+          <tr>
+            <td><strong>Defer is first-class</strong></td>
+            <td>“I don’t have time right now” is a button (<code>memory.defer</code>), not a workaround. Re-queues after a chosen interval; no penalty.</td>
+            <td>No “snooze” shame state. No reappearing-twice-as-loud.</td>
+          </tr>
+          <tr>
+            <td><strong>Auto-archive expired</strong></td>
+            <td>Candidates past the review window are archived as a stated policy. They are auditable but no longer in the active queue.</td>
+            <td>The queue does not grow without bound. The user is not asked to reject yesterday's noise.</td>
+          </tr>
+          <tr>
+            <td><strong>Pacing throttle on inferred</strong></td>
+            <td>If rejection rate is high, the runtime is permitted (per policy) to throttle inferred-candidate proposals per day. (See open question #4.)</td>
+            <td>The queue does not punish a hard day with a louder tomorrow.</td>
+          </tr>
+          <tr>
+            <td><strong>Default action by confidence band</strong></td>
+            <td>Low-confidence inferred candidates show <em>defer</em> as the highlighted default — not <em>accept</em>. The frictionless path is the safe one.</td>
+            <td>No accept-first ordering for things the system isn’t sure about.</td>
+          </tr>
+          <tr>
+            <td><strong>Batch mode is opt-in</strong></td>
+            <td>Bulk operations exist for cleanup days. They are off by default and require an explicit toggle (<code>queue.toggle-batch</code>).</td>
+            <td>No accidental bulk-accept. Bulk-reject requires a one-line reason that applies to every selected row.</td>
+          </tr>
+          <tr>
+            <td><strong>Reject preserves the trail</strong></td>
+            <td>Rejected candidates are auditable, with the reason kept. The trail is the record; the queue is the work.</td>
+            <td>The user is not asked to second-guess past rejections to clean up.</td>
+          </tr>
+          <tr>
+            <td><strong>Operational-only is a first-class outcome</strong></td>
+            <td>Some memory belongs in agent-side operational memory and should never become vault knowledge. <em>Keep operational</em> is a button, not a workaround.</td>
+            <td>The user is not forced through accept/reject for things that don’t deserve either.</td>
+          </tr>
+          <tr>
+            <td><strong>Promote is rare and visible</strong></td>
+            <td>Promotion opens an inline preview of the resulting vault note before commit. The frequency expectation is set by making this the conspicuous action.</td>
+            <td>The queue is not a fast lane to durable knowledge.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="callout warn">
+        <span class="callout-label">Anti-pattern · “notifications would help”</span>
+        The temptation is to surface a count in the shell so the user remembers to review.
+        That is exactly the failure mode this design refuses. If review becomes obligation,
+        review stops happening, and unreviewed memory accumulates as silent authority — which
+        is the failure mode the queue exists to prevent in the first place.
+      </div>
+
+      <h3>Healthy posture summary</h3>
+      <p>
+        A healthy queue, by this design's lights, is one where:
+      </p>
+      <ul>
+        <li>the user visits the surface on their own schedule,</li>
+        <li>most candidates are deferred, rejected, or operational-only — not accepted,</li>
+        <li>promotion to durable knowledge is rare,</li>
+        <li>the candidate count does not appear anywhere else in the product,</li>
+        <li>and the gold banner stays visible the whole time.</li>
+      </ul>
+    </section>
+
+    <!-- ============== 05 ============== -->
+    <section class="spec" id="s5">
+      <h2><span class="secnum">05 ·</span>Action vocabulary</h2>
+      <p class="lede">Eight actions. Each names what changes on the candidate, and where the change is recorded.</p>
+
+      <table class="spec">
+        <thead>
+          <tr><th>Action</th><th>Effect on candidate</th><th>Effect on memory</th><th>Receipt</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Accept</strong></td>
+            <td>state → accepted</td>
+            <td>Becomes recallable as agent memory at the proposed class; authority flags activated</td>
+            <td>candidate_review_receipt</td>
+          </tr>
+          <tr>
+            <td><strong>Edit</strong></td>
+            <td>Inline edit on content; state → revised</td>
+            <td>Edited content replaces proposed content; preserves source provenance</td>
+            <td>candidate_revision_receipt</td>
+          </tr>
+          <tr>
+            <td><strong>Promote to note</strong></td>
+            <td>state → promoted</td>
+            <td>Creates a vault note (preview shown before commit); memory points at the note</td>
+            <td>promotion_receipt · note path · governance pipeline</td>
+          </tr>
+          <tr>
+            <td><strong>Keep operational</strong></td>
+            <td>state → accepted-operational</td>
+            <td>Recallable only as operational memory; never as semantic knowledge</td>
+            <td>candidate_review_receipt</td>
+          </tr>
+          <tr>
+            <td><strong>Set expiry</strong></td>
+            <td>Adds expiry to the candidate without changing its review state</td>
+            <td>None — until expiry, candidate stays in queue; on expiry, archived</td>
+            <td>candidate_expiry_receipt</td>
+          </tr>
+          <tr>
+            <td><strong>Defer</strong></td>
+            <td>state → deferred; reappears after a chosen interval</td>
+            <td>None</td>
+            <td>candidate_defer_receipt</td>
+          </tr>
+          <tr>
+            <td><strong>Reject</strong></td>
+            <td>state → rejected; requires a one-line reason</td>
+            <td>None — candidate stays inspectable for audit, not recall</td>
+            <td>candidate_reject_receipt · reason</td>
+          </tr>
+          <tr>
+            <td><strong>Delete</strong></td>
+            <td>state → deleted (rare; for spam/garbage only)</td>
+            <td>None — receipts preserved per memory contract</td>
+            <td>candidate_delete_receipt</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="callout warn">
+        <span class="callout-label">Reject &gt; Delete</span>
+        Reject is the default destructive action. Delete is reserved for spam / clearly-bad
+        candidates. The two are distinct because the memory contract requires evidence-trail
+        preservation for rejections; delete is the narrow escape hatch when the candidate
+        should not leave even a rejection trace.
+      </div>
+    </section>
+
+    <!-- ============== 06 ============== -->
+    <section class="spec" id="s6">
+      <h2><span class="secnum">06 ·</span>State gallery</h2>
+      <p class="lede">Ten states. Each shows the candidate card or queue header it represents.</p>
+
+      <div class="gallery mem-gallery">
+        <!-- 1 single -->
+        <div class="gm">
+          <div class="gm-bar"><span>01 · single candidate</span><span class="cls">semantic</span></div>
+          <div class="gm-body">
+            <h5>"Context bundles must show exclusions when exclusion affects interpretation."</h5>
+            <p>Inferred from three session turns. Confidence 0.68. No prior conflict. Default
+              candidate card shape.</p>
+            <div class="meta-line">
+              <span><span class="v gold">semantic</span></span>
+              <span><span class="v amber">inferred</span></span>
+              <span><span class="v cyan">conf · 0.68</span></span>
+            </div>
+          </div>
+        </div>
+
+        <!-- 2 batch review -->
+        <div class="gm">
+          <div class="gm-bar"><span>02 · batch review queue</span><span style="color:var(--cyan)">batch mode on</span></div>
+          <div class="gm-body">
+            <h5>12 pending · filtered by inferred</h5>
+            <div class="batch-summary">
+              <div class="cell amber"><span class="n">7</span><span>inferred</span></div>
+              <div class="cell cyan"><span class="n">3</span><span>episodic</span></div>
+              <div class="cell gold"><span class="n">1</span><span>conflict</span></div>
+              <div class="cell vault"><span class="n">1</span><span>preference</span></div>
+            </div>
+            <p>Batch mode adds checkboxes per row; bulk-accept is disabled until a per-row
+              confidence floor is set. Bulk-reject requires a one-line reason that applies to
+              every selected row.</p>
+          </div>
+        </div>
+
+        <!-- 3 strong source -->
+        <div class="gm">
+          <div class="gm-bar"><span>03 · strong source-backed</span><span class="cls" style="color:var(--vault)">reviewed source</span></div>
+          <div class="gm-body">
+            <h5>"Receipts live in Panel locality. Companion mirrors but never owns them."</h5>
+            <p>Source-backed by an owner-doc citation. The card carries a
+              <span class="reviewed-tag" style="font-size:9px; padding:1px 6px; vertical-align:middle">reviewed</span>
+              tag instead of the inferred tag. Accept is the highlighted default action.</p>
+            <div class="meta-line">
+              <span><span class="v gold">semantic</span></span>
+              <span><span class="v vault">reviewed · owner-doc cite</span></span>
+              <span><span class="v vault">conf · 0.91</span></span>
+            </div>
+          </div>
+        </div>
+
+        <!-- 4 inferred low conf -->
+        <div class="gm">
+          <div class="gm-bar"><span>04 · inferred · low confidence</span><span class="cls" style="color:var(--amber)">heuristic only</span></div>
+          <div class="gm-body">
+            <h5>User rejected 5 candidates in a row yesterday; pacing should slow.</h5>
+            <p>Confidence 0.41. Card renders with the inferred tag and an amber confidence
+              chip. Default action moves to defer, not accept. The why-now block names the
+              heuristic.</p>
+            <div class="meta-line">
+              <span><span class="v cyan">episodic</span></span>
+              <span><span class="v amber">inferred · pacing</span></span>
+              <span><span class="v amber">conf · 0.41</span></span>
+            </div>
+          </div>
+        </div>
+
+        <!-- 5 conflict -->
+        <div class="gm">
+          <div class="gm-bar"><span>05 · conflicts with existing memory</span><span style="color:var(--destructive)">conflict</span></div>
+          <div class="gm-body">
+            <h5>"Hugin is the canvas-side agent; Munin is the panel-side agent."</h5>
+            <p>A prior memory says <em>Hugin is the panel-side agent</em>. The card pins both
+              statements side-by-side and adds two extra actions: <em>supersede prior</em> and
+              <em>keep both as candidates</em>.</p>
+            <div class="meta-line">
+              <span><span class="v gold">semantic</span></span>
+              <span><span class="v dang">conflicts with mem-…0247</span></span>
+              <span><span class="v cyan">conf · 0.71</span></span>
+            </div>
+          </div>
+        </div>
+
+        <!-- 6 should expire -->
+        <div class="gm">
+          <div class="gm-bar"><span>06 · should expire</span><span style="color:var(--amber)">time-bounded</span></div>
+          <div class="gm-body">
+            <h5>Run the runtime proof before the 21:00 window.</h5>
+            <p>Prospective commitment with a natural expiry. The Set-expiry button is
+              pre-filled with the 21:00 timestamp and highlighted; accept-without-expiry shows
+              a warning.</p>
+            <div class="meta-line">
+              <span><span class="v amber">prospective · commitment</span></span>
+              <span><span class="v amber">expires 21:00</span></span>
+              <span><span class="v vault">explicit · user-stated</span></span>
+            </div>
+          </div>
+        </div>
+
+        <!-- 7 rejected -->
+        <div class="gm">
+          <div class="gm-bar"><span>07 · rejected with reason</span><span style="color:var(--destructive)">terminal · reject</span></div>
+          <div class="gm-body">
+            <h5>"User prefers Tron-style cyan over Norse gold."</h5>
+            <p>Rejected. Operator reason recorded: <em>"This was a one-off A/B test; not a
+              standing preference."</em> Candidate stays inspectable for audit; recall is off.</p>
+            <div class="outcome reject">REJECTED · reason · "one-off A/B test"</div>
+          </div>
+        </div>
+
+        <!-- 8 revised -->
+        <div class="gm">
+          <div class="gm-bar"><span>08 · revised by user</span><span style="color:var(--cyan)">revised → accepted</span></div>
+          <div class="gm-body">
+            <h5>"Context bundles default to showing exclusions when low-trust material is dropped."</h5>
+            <p>The user edited the proposed text — narrowed "when exclusion affects
+              interpretation" to "when low-trust material is dropped" — and accepted. The card
+              records both versions; promotion preserves the revision history.</p>
+            <div class="outcome revised">REVISED · accepted · prior version preserved</div>
+          </div>
+        </div>
+
+        <!-- 9 promoted -->
+        <div class="gm">
+          <div class="gm-bar"><span>09 · promoted to note</span><span style="color:var(--vault)">terminal · promoted</span></div>
+          <div class="gm-body">
+            <h5>"Receipts live in Panel locality. Companion mirrors but never owns them."</h5>
+            <p>Promoted to a durable Markdown note at
+              <code style="font-size:0.85em">notes/concepts/receipts-locality.md</code>.
+              Memory record now points at the note. Promotion went through the governance
+              pipeline; receipt visible in Panel.</p>
+            <div class="outcome promote">PROMOTED · notes/concepts/receipts-locality.md · receipt r-0521</div>
+          </div>
+        </div>
+
+        <!-- 10 operational only -->
+        <div class="gm">
+          <div class="gm-bar"><span>10 · operational only</span><span style="color:var(--agent)">terminal · operational</span></div>
+          <div class="gm-body">
+            <h5>Hugin's draft suggestions were rejected 3× before user-edit-then-apply.</h5>
+            <p>Kept as agent operational memory. Recallable to help Hugin's pacing; never
+              recalled as semantic knowledge. Will not appear in retrieval answers about the
+              system.</p>
+            <div class="outcome op-only">OPERATIONAL-ONLY · agent recall · no semantic authority</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============== 07 ============== -->
+    <section class="spec" id="s7">
+      <h2><span class="secnum">07 ·</span>Edge states</h2>
+      <table class="spec">
+        <thead><tr><th>Edge</th><th>Behavior</th></tr></thead>
+        <tbody>
+          <tr><td>Empty</td><td>Queue list shows "No candidates pending review." Detail area shows what kinds of candidates would appear here and how to find recent decisions.</td></tr>
+          <tr><td>Loading</td><td>Static dim row skeletons (no animation). Filter pills are disabled.</td></tr>
+          <tr><td>Degraded</td><td>If the candidate's source artifact has been deleted, the candidate renders with a <span class="chip danger">source missing</span> tag; default action is reject-or-delete.</td></tr>
+          <tr><td>Blocked</td><td>If the promotion target (vault note path) would conflict with an existing note, promote opens a dialog; the queue does not silently overwrite.</td></tr>
+          <tr><td>Stale</td><td>Candidates past their (system-default) review window render dimmed with a "stale · auto-archive in &lt;n&gt;d" line. Auto-archive is an explicit policy, not a hidden snooze.</td></tr>
+          <tr><td>Missing provenance</td><td>Candidate without source: card carries <span class="chip danger">no provenance</span>; cannot be accepted at semantic class; can be accepted at episodic only with a reason.</td></tr>
+          <tr><td>Write-guard denial</td><td>If promote fails write-guard (e.g. focus-mode policy), card shows the denial reason; the promotion attempt is preserved as a receipt.</td></tr>
+          <tr><td>Reduced motion</td><td>Receipt pill pulse, batch-mode toggle, and filter pill state changes use static colour only.</td></tr>
+          <tr><td>Narrow</td><td>List collapses above the detail; detail becomes the full screen; back button returns to list. Action bar wraps to two rows but never hides; reject keeps the danger styling.</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <!-- ============== 08 ============== -->
+    <section class="spec" id="s8">
+      <h2><span class="secnum">08 ·</span>Implementation contract</h2>
+      <p class="lede">
+        The UI consumes candidate records conforming to <code>AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT.md</code>.
+        It never derives confidence or trust; class is fixed by the proposing agent.
+      </p>
+
+      <h3>Intents emitted by the queue</h3>
+      <table class="spec">
+        <thead><tr><th class="mono">data-intent</th><th>Effect</th><th>Authority</th></tr></thead>
+        <tbody>
+          <tr><td class="mono">memory.accept</td><td>state → accepted; activates declared authority flags</td><td>governed</td></tr>
+          <tr><td class="mono">memory.edit</td><td>opens inline editor; state → revised on save</td><td>governed</td></tr>
+          <tr><td class="mono">memory.promote</td><td>opens vault-note preview; on confirm, routes through governance for write</td><td>governed · write</td></tr>
+          <tr><td class="mono">memory.operational</td><td>state → accepted-operational; semantic recall denied</td><td>governed</td></tr>
+          <tr><td class="mono">memory.set-expiry</td><td>adds expiry to candidate</td><td>governed</td></tr>
+          <tr><td class="mono">memory.defer</td><td>state → deferred; re-queues after interval</td><td>governed</td></tr>
+          <tr><td class="mono">memory.reject</td><td>state → rejected; requires one-line reason</td><td>governed</td></tr>
+          <tr><td class="mono">memory.delete</td><td>state → deleted; rare; for spam</td><td>governed</td></tr>
+          <tr><td class="mono">memory.supersede-prior</td><td>conflict state only; marks prior memory superseded; this candidate accepted in its place</td><td>governed</td></tr>
+          <tr><td class="mono">memory.keep-both</td><td>conflict state only; both prior and candidate kept; flagged for human resolution</td><td>governed</td></tr>
+          <tr><td class="mono">queue.toggle-batch</td><td>enables batch checkboxes</td><td>UI-local</td></tr>
+          <tr><td class="mono">queue.filter</td><td>filters list</td><td>UI-local</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Candidate data attributes</h3>
+      <pre class="code">&lt;article
+  data-testid=<span class="s">"memory-candidate"</span>
+  data-candidate-id=<span class="s">"mc-2026-05-14-0008"</span>
+  data-class=<span class="s">"semantic | episodic | prospective | procedural | preference | policy | reflection"</span>
+  data-state=<span class="s">"candidate | accepted | accepted-operational | revised | promoted | deferred | rejected | deleted"</span>
+  data-trust=<span class="s">"reviewed | inferred | untrusted"</span>
+  data-confidence=<span class="s">"0.0..1.0"</span>
+  data-conflict=<span class="s">"none | with:&lt;mem-id&gt;"</span>
+  data-provenance=<span class="s">"present | missing"</span>&gt;</pre>
+
+      <h3>Queue root attributes</h3>
+      <pre class="code">&lt;section
+  data-testid=<span class="s">"memory-queue"</span>
+  data-pending=<span class="s">"&lt;n&gt;"</span>
+  data-batch=<span class="s">"on | off"</span>
+  data-filter=<span class="s">"all | inferred | conflict | expiring | class:&lt;class&gt;"</span>&gt;</pre>
+
+      <div class="callout invariant">
+        <span class="callout-label">UI never derives memory class</span>
+        Class is set by the proposing agent on the candidate. The queue renders the declared
+        class. Re-classification at review time happens through edit (which records the
+        revision) — not silently.
+      </div>
+    </section>
+
+    <!-- ============== 09 ============== -->
+    <section class="spec" id="s9">
+      <h2><span class="secnum">09 ·</span>Authority boundaries</h2>
+
+      <div class="callout invariant">
+        <span class="callout-label">Invariant · Memory supports the human, not replaces judgment</span>
+        Every state transition in the queue is an explicit operator action. The system never
+        auto-accepts a candidate. Auto-archive on expiry is policy, not authority.
+      </div>
+
+      <div class="callout invariant">
+        <span class="callout-label">Invariant · Unreviewed memory is not semantic authority</span>
+        Candidate-state items cannot be recalled into answers, orientation, or write
+        proposals. Recall is bounded by the declared authority flags, which activate only on
+        accept / promote.
+      </div>
+
+      <div class="callout invariant">
+        <span class="callout-label">Invariant · Promotion is governed</span>
+        Promote-to-note routes through the existing policy + validation + event-pipeline +
+        deterministic-writer path. The queue triggers; it does not write.
+      </div>
+
+      <table class="spec">
+        <thead>
+          <tr><th>Concern</th><th>May influence</th><th>May propose</th><th>May not decide</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Queue layout, action bar, copy</td><td class="yes">YES</td><td class="maybe">—</td><td class="no">—</td></tr>
+          <tr><td>Action set (eight verbs)</td><td class="maybe">naming &amp; ordering</td><td class="yes">propose additions to owner-doc</td><td class="no">cannot define semantics</td></tr>
+          <tr><td>Confidence presentation</td><td class="yes">YES · render</td><td class="maybe">propose thresholds for default actions</td><td class="no">cannot define confidence</td></tr>
+          <tr><td>Memory class set</td><td class="no">—</td><td class="maybe">propose new class to owner-doc</td><td class="no">cannot rename or remove classes</td></tr>
+          <tr><td>Authority flag set on memory</td><td class="no">—</td><td class="maybe">propose new flag</td><td class="no">cannot loosen flags</td></tr>
+          <tr><td>Recall behavior</td><td class="no">—</td><td class="no">—</td><td class="no">runtime owns</td></tr>
+          <tr><td>Promotion target paths</td><td class="maybe">UI conventions only</td><td class="maybe">propose path patterns</td><td class="no">vault contract owns</td></tr>
+          <tr><td>Auto-archive policy</td><td class="no">—</td><td class="maybe">propose default interval</td><td class="no">owner-doc owns</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <!-- ============== 10 ============== -->
+    <section class="spec" id="s10">
+      <h2><span class="secnum">10 ·</span>Open questions</h2>
+      <ol>
+        <li><strong>Notification surface.</strong> The queue is intentionally pull, not push.
+          Should a small unobtrusive indicator (count badge somewhere quiet) appear when the
+          pending count crosses a threshold? We suggest no badge by default; an opt-in
+          preference is acceptable.</li>
+        <li><strong>Confidence presentation.</strong> Numeric (0.68) vs banded (low / medium /
+          high). We chose numeric because the operator should not infer authority from a
+          band. Owner-doc decides.</li>
+        <li><strong>Conflict resolution UI.</strong> When a candidate conflicts with a prior
+          memory, the design exposes <em>supersede</em> and <em>keep both</em>. Owner-doc
+          should declare whether "keep both" is a permitted memory state.</li>
+        <li><strong>Pacing.</strong> Should the queue throttle inferred candidates per day
+          when rejection rate is high? We suggest yes, as a runtime policy, not a UI feature.</li>
+        <li><strong>Promotion preview shape.</strong> When promoting to a vault note, what is
+          the preview shape — full note with frontmatter, body only, diff against an existing
+          file? Suggest: full preview, with the frontmatter editable.</li>
+        <li><strong>Auto-archive interval default.</strong> 30 days? 14 days? Per-class? The
+          design assumes a default but owner-doc owns the number.</li>
+        <li><strong>Cross-link to context bundles.</strong> If a candidate was inferred from
+          a context bundle, should the why-block link to the bundle inspector?
+          Suggest: yes, one-click.</li>
+      </ol>
+    </section>
+
+    <!-- ============== 11 ============== -->
+    <section class="spec" id="s11">
+      <h2><span class="secnum">11 ·</span>Handoff notes for Claude Code / Codex</h2>
+
+      <h3>Likely normalized spec</h3>
+      <ul>
+        <li>New doc: <code>docs/CONCEPTS/MEMORY_CANDIDATE_REVIEW_UI.md</code> — UI guidance only.
+          References <code>AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT.md</code>.</li>
+      </ul>
+
+      <h3>Likely follow-on issues</h3>
+      <ul>
+        <li><em>Render the queue against ten fixture candidates.</em> Acceptance: the ten
+          gallery states render from ten fixture records.</li>
+        <li><em>Wire seven primary actions.</em> Acceptance: each action emits the right
+          intent, records the right receipt, and updates the queue list.</li>
+        <li><em>Promote-to-note path.</em> Acceptance: promote opens a preview; confirmation
+          routes through governance; resulting note appears at the declared path; receipt
+          visible in Panel.</li>
+        <li><em>Conflict UI.</em> Acceptance: supersede / keep-both render only for
+          conflict-state candidates and emit the right intents.</li>
+        <li><em>Batch mode.</em> Acceptance: bulk-reject requires reason; bulk-accept is
+          disabled without a confidence floor.</li>
+        <li><em>Reduced-motion + narrow layout.</em> Per §06.</li>
+      </ul>
+
+      <h3>What this design must not feed</h3>
+      <ul>
+        <li>Auto-accept rules. Every accept is an explicit click.</li>
+        <li>A recall surface. Recall is a runtime property; this queue only governs
+          candidacy.</li>
+        <li>A definition of memory class. Owner-doc owns the classes; the queue renders them.</li>
+        <li>A semantic-search surface across past memories. That is its own design.</li>
+      </ul>
+
+      <div class="callout vault">
+        <span class="callout-label">Validation expectation</span>
+        Passing receipt: ten state fixtures render correctly; seven primary actions emit the
+        right intents and receipts; conflict UI renders only when conflict is declared;
+        promote-to-note routes through governance; no UI-derived class, confidence, or
+        authority. Receipt id recorded in this package's status field.
+      </div>
+    </section>
+
+  </main>
+</div>
+</body>
+</html>

--- a/companion-ui/design_handoff/2026-05-14-memory-candidate-review/spec_chrome.css
+++ b/companion-ui/design_handoff/2026-05-14-memory-candidate-review/spec_chrome.css
@@ -1,0 +1,423 @@
+/* ============================================================
+   Yggdrasil Design Handoff — Shared Spec Chrome
+   ============================================================
+   Page layout, TOC, sections, tables, callouts, chips, code,
+   gallery cards. Imported by each prototype.html after
+   colors_and_type.css.
+   ============================================================ */
+
+html, body { background: var(--bg-base); }
+body {
+  background-image:
+    linear-gradient(rgba(0,212,232,0.022) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0,212,232,0.022) 1px, transparent 1px);
+  background-size: 48px 48px;
+}
+
+.page {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: var(--space-12) var(--space-8) var(--space-16);
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: var(--space-12);
+}
+
+/* ---- Sidebar TOC ---- */
+.toc {
+  position: sticky;
+  top: var(--space-8);
+  align-self: start;
+  font-size: var(--text-sm);
+  border-left: 1px solid var(--border);
+  padding-left: var(--space-4);
+  max-height: calc(100vh - var(--space-12));
+  overflow-y: auto;
+}
+.toc-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  margin-bottom: var(--space-3);
+}
+.toc ol { list-style: none; display: flex; flex-direction: column; gap: 6px; }
+.toc a {
+  color: var(--fg-2);
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  display: block;
+  line-height: 1.4;
+}
+.toc a:hover { color: var(--cyan); text-decoration: none; }
+.toc-num {
+  font-family: var(--font-mono);
+  color: var(--fg-3);
+  margin-right: 6px;
+  font-size: var(--text-xs);
+}
+
+/* ---- Header ---- */
+.doc-header {
+  border-bottom: 1px solid var(--border);
+  padding-bottom: var(--space-6);
+  margin-bottom: var(--space-10);
+}
+.doc-eyebrow {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--cyan);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  margin-bottom: var(--space-3);
+}
+.doc-title {
+  font-family: var(--font-display);
+  font-size: var(--text-3xl);
+  line-height: 1.1;
+  margin-bottom: var(--space-4);
+  color: var(--fg-1);
+}
+.doc-lede {
+  color: var(--fg-2);
+  font-size: var(--text-md);
+  max-width: 70ch;
+  margin-bottom: var(--space-5);
+  line-height: var(--leading-snug);
+}
+.doc-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4) var(--space-6);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+}
+.doc-meta span strong {
+  color: var(--fg-2);
+  font-weight: var(--weight-regular);
+  margin-right: 6px;
+}
+
+/* ---- Sections ---- */
+section.spec {
+  margin-bottom: var(--space-12);
+  scroll-margin-top: var(--space-6);
+}
+section.spec > h2 {
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-regular);
+  color: var(--fg-1);
+  margin-bottom: var(--space-2);
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+}
+section.spec > h2 .secnum {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--cyan);
+  letter-spacing: var(--tracking-wide);
+}
+section.spec > .lede {
+  color: var(--fg-2);
+  font-size: var(--text-base);
+  margin-bottom: var(--space-5);
+  max-width: 72ch;
+}
+section.spec h3 {
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--fg-1);
+  margin: var(--space-6) 0 var(--space-3);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+}
+section.spec p {
+  color: var(--fg-1);
+  margin-bottom: var(--space-3);
+  max-width: 72ch;
+}
+section.spec ul, section.spec ol {
+  color: var(--fg-1);
+  margin: 0 0 var(--space-4) var(--space-5);
+  max-width: 72ch;
+}
+section.spec li { margin-bottom: 6px; line-height: 1.55; }
+
+/* ---- Tables ---- */
+table.spec {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+  margin: var(--space-3) 0 var(--space-5);
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+}
+table.spec th, table.spec td {
+  text-align: left;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+table.spec th {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--fg-2);
+  background: var(--bg-raised);
+  font-weight: var(--weight-medium);
+  border-bottom: 1px solid var(--border-strong);
+}
+table.spec tr:last-child td { border-bottom: none; }
+table.spec td code { font-size: 0.9em; }
+table.spec td.mono, table.spec th.mono { font-family: var(--font-mono); }
+table.spec td.yes { color: var(--vault); font-family: var(--font-mono); font-size: var(--text-xs); }
+table.spec td.no { color: var(--destructive); font-family: var(--font-mono); font-size: var(--text-xs); }
+table.spec td.maybe { color: var(--amber); font-family: var(--font-mono); font-size: var(--text-xs); }
+
+/* ---- Callouts ---- */
+.callout {
+  border-left: 2px solid var(--cyan);
+  background: rgba(0,212,232,0.04);
+  padding: var(--space-3) var(--space-4);
+  margin: var(--space-4) 0;
+  font-size: var(--text-sm);
+  color: var(--fg-1);
+  max-width: 72ch;
+}
+.callout.warn { border-left-color: var(--amber); background: rgba(240,144,48,0.05); }
+.callout.invariant { border-left-color: var(--accent); background: rgba(212,168,67,0.04); }
+.callout.danger { border-left-color: var(--destructive); background: rgba(255,61,61,0.04); }
+.callout.vault { border-left-color: var(--vault); background: rgba(57,232,125,0.04); }
+.callout-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--cyan);
+  display: block;
+  margin-bottom: 4px;
+}
+.callout.warn .callout-label { color: var(--amber); }
+.callout.invariant .callout-label { color: var(--accent); }
+.callout.danger .callout-label { color: var(--destructive); }
+.callout.vault .callout-label { color: var(--vault); }
+
+/* ---- Tag chips ---- */
+.chip {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wide);
+  padding: 1px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-raised);
+  color: var(--fg-2);
+}
+.chip.design  { color: var(--cyan); border-color: rgba(0,212,232,0.3); }
+.chip.impl    { color: var(--accent); border-color: rgba(212,168,67,0.3); }
+.chip.gated   { color: var(--amber); border-color: rgba(240,144,48,0.3); }
+.chip.agent   { color: var(--agent); border-color: rgba(74,158,255,0.3); }
+.chip.vault   { color: var(--vault); border-color: rgba(57,232,125,0.3); }
+.chip.danger  { color: var(--destructive); border-color: rgba(255,61,61,0.3); }
+
+/* ---- Code blocks ---- */
+pre.code {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--fg-1);
+  overflow-x: auto;
+  margin: var(--space-3) 0 var(--space-5);
+  line-height: 1.55;
+}
+pre.code .k { color: var(--cyan); }
+pre.code .s { color: var(--vault); }
+pre.code .c { color: var(--fg-3); font-style: italic; }
+pre.code .n { color: var(--accent); }
+pre.code .a { color: var(--agent); }
+
+/* ---- Gallery ---- */
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--space-5);
+  margin: var(--space-4) 0 var(--space-6);
+}
+.gallery.three { grid-template-columns: repeat(3, 1fr); }
+.gallery-card {
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  min-height: 240px;
+}
+.gallery-card header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  border-bottom: 1px dashed var(--border);
+  padding-bottom: 10px;
+}
+.gallery-card h4 {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--fg-2);
+}
+.gallery-card .note {
+  font-size: var(--text-sm);
+  color: var(--fg-2);
+  margin: 0;
+}
+
+/* ---- Receipt pill ---- */
+.receipt {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  border-radius: var(--radius-full);
+  background: var(--bg-raised);
+  border: 1px solid var(--border-strong);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-2);
+  letter-spacing: var(--tracking-wide);
+}
+.receipt.queued  { color: var(--accent); border-color: rgba(212,168,67,0.4); }
+.receipt.applied { color: var(--vault); border-color: rgba(57,232,125,0.4); }
+.receipt.pending { color: var(--amber); border-color: rgba(240,144,48,0.4); }
+.receipt.failed  { color: var(--destructive); border-color: rgba(255,61,61,0.4); }
+.receipt .recdot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 6px currentColor;
+}
+.receipt.queued .recdot { animation: pulse 1.6s ease-in-out infinite; }
+.receipt.pending .recdot { animation: pulse 1.6s ease-in-out infinite; }
+@keyframes pulse { 0%, 100% { opacity: 0.4; } 50% { opacity: 1; } }
+
+/* ---- Buttons ---- */
+.btn {
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  padding: 5px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-raised);
+  color: var(--fg-1);
+  border: 1px solid var(--border-strong);
+  cursor: pointer;
+}
+.btn:hover { border-color: var(--cyan); color: var(--cyan); }
+.btn.primary {
+  background: var(--amber-muted);
+  color: var(--amber);
+  border-color: rgba(240,144,48,0.5);
+}
+.btn.primary:hover { background: rgba(240,144,48,0.12); border-color: var(--amber); color: var(--amber); }
+.btn.governance {
+  background: rgba(212,168,67,0.06);
+  color: var(--accent);
+  border-color: rgba(212,168,67,0.5);
+}
+.btn.governance:hover { background: rgba(212,168,67,0.12); border-color: var(--accent); }
+.btn.vault {
+  background: rgba(57,232,125,0.06);
+  color: var(--vault);
+  border-color: rgba(57,232,125,0.4);
+}
+.btn.vault:hover { background: rgba(57,232,125,0.12); border-color: var(--vault); }
+.btn.danger {
+  background: rgba(255,61,61,0.05);
+  color: var(--destructive);
+  border-color: rgba(255,61,61,0.4);
+}
+.btn.ghost { background: transparent; }
+.btn[disabled], .btn.disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.btn .kbd {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  color: var(--fg-3);
+  margin-left: 6px;
+}
+
+/* ---- Bullet list with mono prefix (for checklists) ---- */
+ul.check {
+  list-style: none;
+  margin-left: 0 !important;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+ul.check li {
+  position: relative;
+  padding-left: 22px;
+  font-size: var(--text-sm);
+}
+ul.check li::before {
+  content: '[ ]';
+  position: absolute;
+  left: 0;
+  top: 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  letter-spacing: 0;
+}
+ul.check li.done::before { content: '[x]'; color: var(--vault); }
+ul.check li.skip::before { content: '[-]'; color: var(--amber); }
+
+/* ---- Doc-template card (for handoff templates) ---- */
+.template {
+  border: 1px solid var(--border-strong);
+  background: var(--bg-surface);
+  border-radius: var(--radius-md);
+  padding: var(--space-4) var(--space-5);
+  margin: var(--space-4) 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--fg-1);
+  white-space: pre-wrap;
+  line-height: 1.65;
+  overflow-x: auto;
+}
+.template .h { color: var(--cyan); }
+.template .v { color: var(--vault); }
+.template .g { color: var(--accent); }
+.template .c { color: var(--fg-3); font-style: italic; }
+.template .a { color: var(--agent); }
+
+/* ---- Responsive ---- */
+@media (max-width: 900px) {
+  .page { grid-template-columns: 1fr; padding: var(--space-6) var(--space-4); }
+  .toc {
+    position: static;
+    max-height: none;
+    border-left: none;
+    border-bottom: 1px solid var(--border);
+    padding: 0 0 var(--space-4);
+  }
+  .gallery, .gallery.three { grid-template-columns: 1fr; }
+}

--- a/companion-ui/design_handoff/2026-05-14-memory-candidate-review/state-gallery.md
+++ b/companion-ui/design_handoff/2026-05-14-memory-candidate-review/state-gallery.md
@@ -1,0 +1,37 @@
+# State gallery — Memory Candidate Review Queue
+
+The full visual gallery lives in **`prototype.html` §05**. This document is a text mirror
+intended for quick scanning in code review and for issue acceptance criteria.
+
+Every state is described as a (name, when, designed behavior) triple. The prototype is the
+authority on the visual; this document is the authority on the state list.
+
+See `prototype.html` §02 for the memory classes, §03 for the queue prototype, §04 for the action vocabulary, §05 for the 10-state gallery.
+
+## State list
+
+See the gallery cards in `prototype.html` §05 for the canonical visuals. Each state in the
+gallery includes:
+
+- A bar with the state name and a state-kind chip.
+- A title-row LED in the appropriate colour (vault / amber / destructive / dim / gold).
+- A one-paragraph narrative describing the state.
+- A meta line of mono captions naming the values that distinguish the state.
+- Where relevant, a next-action strip with the suggested operator action.
+
+## Transition table (illustrative)
+
+Detailed transitions for the UI state machine are owned by `implementation-contracts.md`;
+this gallery is descriptive, not normative. Implementation must enumerate the full set
+declared in the contract document.
+
+## Edge cases the gallery covers
+
+- **Empty** — the surface explains why there is nothing and what produces content.
+- **Loading** — inert, distinguishable from empty.
+- **Degraded** — partial function with explicit naming of what is degraded.
+- **Blocked** — refusal is named, recorded, and never silently retried.
+- **Stale** — staleness is shown with a "why" and an explicit threshold.
+- **Missing provenance** — surfaced, not hidden; never silently authoritative.
+
+For the full edge-state checklist see `edge-states.md`.

--- a/companion-ui/design_handoff/2026-05-14-runtime-proof-dashboard/README.md
+++ b/companion-ui/design_handoff/2026-05-14-runtime-proof-dashboard/README.md
@@ -1,0 +1,47 @@
+# Runtime Proof / Health Dashboard
+
+**Date:** 2026-05-14
+**Status:** Design handoff · v1 · ready for review at crossing B
+**Authority:** Visual guidance only — mirror of runtime state
+**Owner-docs:** STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md (invariant), runtime-proof receipt contract (when normalized)
+**Crossing target:** B
+
+## What this is
+
+Compact operator surface for proving whether the local-first runtime is actually working — watcher, worker, outbox, vault, write-guard, last proof receipt.
+
+The dashboard answers nine questions the local operator must be able to answer:
+
+1. Is the system running?
+2. Is the watcher healthy?
+3. Is the worker healthy?
+4. Are there stuck or poison outbox messages?
+5. Is the vault scope correct?
+6. Is indexing moving?
+7. Are writes allowed or blocked?
+8. What was the last successful proof receipt?
+9. What should I do next?
+
+See `prototype.html` §03 for the dashboard prototype, §04 for the section design, §05 for the 9-state gallery.
+
+## Influence
+
+- **May influence:** card layout, copy, LED palette, sparkline placement, next-action vocabulary, narrow-layout collapse order.
+- **May not decide:** the snapshot schema, posture algorithm (UI never derives `overall.posture`), receipt shape, polling interval, what counts as healthy.
+
+## Files
+
+- `prototype.html` — full 10-section spec, dashboard mock, 9-state gallery.
+- `design-notes.md`, `state-gallery.md`, `implementation-contracts.md`, `authority-boundaries.md`, `edge-states.md`, `open-questions.md`.
+
+## Related
+
+- Stabilization work this surface depends on landing first: watcher OOM repair, worker poison-message handling, startup sequencing, runtime-proof receipts.
+- `STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md` — the invariant the dashboard honors (mirror, never control plane).
+
+## Authority &amp; disclaimers
+
+- **This design is visual guidance.** It is not architecture authority. Architecture authority lives in repo owner-docs.
+- **Runtime truth lives downstream.** It is not asserted in this package. Runtime truth comes from shipped code, tests, status docs, and validation receipts.
+- **This package proposes; it does not promote.** Promotion happens at crossing B (the maturity bar in the governance pack §03).
+- **The gated-execution invariant is honored throughout.** No interaction surface in this design mutates durable state outside the governed pipeline.

--- a/companion-ui/design_handoff/2026-05-14-runtime-proof-dashboard/authority-boundaries.md
+++ b/companion-ui/design_handoff/2026-05-14-runtime-proof-dashboard/authority-boundaries.md
@@ -1,0 +1,45 @@
+# Authority boundaries — Runtime Proof / Health Dashboard
+
+## This design is
+
+- **Visual guidance** for the surface(s) named in this package's README.
+- **An interaction contract** limited to the fields, intents, and data attributes enumerated
+  in `implementation-contracts.md` and in `prototype.html` §07.
+- **A target-state proposal** until a normalized spec lands in owner-docs.
+
+## This design is not
+
+- **Architecture authority.** Authority lives in:
+  - `STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md (invariant)`
+  - `runtime-proof receipt contract (when normalized)`
+- **Runtime truth.** Runtime truth lives in shipped code, tests, status docs, and validation
+  receipts.
+- **A schema.** This contract references fields the runtime exposes; it does not declare them.
+- **A claim about current runtime behavior** unless explicitly cited from owner-docs.
+
+## Invariants this design honors
+
+- **Gated execution.** No interaction surface in this design mutates durable state outside
+  the existing governed path: policy, validation, event pipeline, deterministic writer.
+- **Authority separation.** Chat is a canvas surface; Panel is the command surface;
+  Automation is its own lane. This design does not collapse them.
+- **Provenance visibility.** Where this design shows agent-contributed content, it shows
+  source, trust state, and authority flags.
+- **Bundle integrity.** Where this design shows context selection, it shows what was excluded
+  when exclusion affects interpretation.
+- **Memory candidacy.** Where this design touches agent memory, it never treats candidate
+  memory as semantic authority.
+
+## What this design may suggest to owner-docs
+
+See `prototype.html` §10 ("Handoff notes for Claude Code / Codex") of this package for the
+specific proposed normalized-spec path and follow-on issues. Owner-doc owners decide whether
+to accept any of those suggestions.
+
+## What this design must not suggest
+
+- Any loosening of the gated-execution invariant.
+- Any new authority surface that bypasses the existing pipeline.
+- Any new write path that bypasses policy / validation.
+- Any silent promotion of agent memory into semantic knowledge.
+- Any redefinition of authority flag semantics.

--- a/companion-ui/design_handoff/2026-05-14-runtime-proof-dashboard/colors_and_type.css
+++ b/companion-ui/design_handoff/2026-05-14-runtime-proof-dashboard/colors_and_type.css
@@ -1,0 +1,346 @@
+/* ============================================================
+   Yggdrasil Design System — Colors & Type
+   ============================================================
+   Import this file in any HTML artifact or UI kit.
+   Google Fonts are imported below; JetBrains Mono via bunny.net.
+   ============================================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Space+Grotesk:wght@300;400;500;600&display=swap');
+@import url('https://fonts.bunny.net/css?family=jetbrains-mono:400,500&display=swap');
+
+/* ============================================================
+   BASE COLOR TOKENS
+   ============================================================ */
+:root {
+  /* --- Backgrounds (cool blue-black — Tron grid) --- */
+  --bg-base:       #070b12;   /* deepest — page root, near black with blue cast */
+  --bg-surface:    #0c1220;   /* panels, sidebars */
+  --bg-raised:     #111a2e;   /* cards, inputs, raised surfaces */
+  --bg-overlay:    #162038;   /* hover states, popovers */
+  --bg-modal:      #0e1828;   /* modal / dialog backdrop content */
+
+  /* --- Foreground / Text --- */
+  --fg-1:          #dce8f0;   /* primary — cool blue-white */
+  --fg-2:          #7a9ab8;   /* secondary / muted */
+  --fg-3:          #3d5570;   /* tertiary / disabled / dim */
+  --fg-inverse:    #070b12;   /* text on light/accent backgrounds */
+
+  /* --- Borders (thin, slightly glowing) --- */
+  --border:        #152030;   /* default — subtle grid line */
+  --border-strong: #1e3050;   /* emphasis — dividers, active edges */
+  --border-focus:  #00d4e8;   /* focus ring — electric cyan */
+
+  /* --- Accent 1: Norse Gold (slightly electrified) --- */
+  --accent:        #d4a843;   /* primary accent — active, focus, key affordances */
+  --accent-dim:    #80621a;   /* dimmed gold */
+  --accent-muted:  #2a1e06;   /* gold at low opacity */
+
+  /* --- Accent 2: Tron Cyan (neon electric) --- */
+  --cyan:          #00d4e8;   /* electric cyan — Tron primary glow */
+  --cyan-dim:      #007a8a;   /* dimmed cyan */
+  --cyan-muted:    #001e28;   /* cyan tint background */
+  --cyan-glow:     0 0 12px rgba(0,212,232,0.35), 0 0 4px rgba(0,212,232,0.5);
+
+  /* --- Vault: Neon green (digital growth) --- */
+  --vault:         #39e87d;   /* vault-connected — electric green */
+  --vault-dim:     #1a7840;   /* vault hover */
+  --vault-muted:   #041a10;   /* vault background tint */
+  --vault-glow:    0 0 8px rgba(57,232,125,0.3);
+
+  /* --- Agent: Electric blue (machine voice) --- */
+  --agent:         #4a9eff;   /* agent-contributed UI and content */
+  --agent-dim:     #1e5a9a;   /* agent hover */
+  --agent-muted:   #051228;   /* agent background tint */
+  --agent-glow:    0 0 8px rgba(74,158,255,0.3);
+
+  /* --- Amber (staged / uncommitted) --- */
+  --amber:         #f09030;   /* warnings, uncommitted/staged state */
+  --amber-dim:     #805010;
+  --amber-muted:   #1a0e02;
+
+  /* --- Destructive --- */
+  --destructive:      #ff3d3d;
+  --destructive-dim:  #8a1a1a;
+  --destructive-muted:#160404;
+
+  /* --- Semantic UI colors --- */
+  --color-bg:        var(--bg-base);
+  --color-surface:   var(--bg-surface);
+  --color-text:      var(--fg-1);
+  --color-muted:     var(--fg-2);
+  --color-dim:       var(--fg-3);
+  --color-border:    var(--border);
+  --color-accent:    var(--accent);
+
+  /* ============================================================
+     TYPOGRAPHY
+     ============================================================ */
+
+  /* --- Font families --- */
+  --font-display:  'EB Garamond', Georgia, serif;
+  --font-ui:       'Space Grotesk', system-ui, sans-serif;
+  --font-mono:     'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+
+  /* --- Type scale (rem, base 16px) --- */
+  --text-xs:    0.6875rem;   /* 11px — metadata, timestamps */
+  --text-sm:    0.8125rem;   /* 13px — secondary labels, captions */
+  --text-base:  0.9375rem;   /* 15px — body / default UI */
+  --text-md:    1.0625rem;   /* 17px — slightly emphasized body */
+  --text-lg:    1.1875rem;   /* 19px — section headers */
+  --text-xl:    1.5rem;      /* 24px — page titles */
+  --text-2xl:   2rem;        /* 32px — display moments */
+  --text-3xl:   2.75rem;     /* 44px — wordmark / hero */
+  --text-4xl:   3.75rem;     /* 60px — large display */
+
+  /* --- Line heights --- */
+  --leading-tight:  1.25;
+  --leading-snug:   1.4;
+  --leading-normal: 1.55;
+  --leading-loose:  1.75;
+
+  /* --- Font weights --- */
+  --weight-light:   300;
+  --weight-regular: 400;
+  --weight-medium:  500;
+  --weight-semibold:600;
+
+  /* --- Letter spacing --- */
+  --tracking-tight: -0.02em;
+  --tracking-normal: 0em;
+  --tracking-wide:   0.04em;
+  --tracking-wider:  0.08em;
+
+  /* ============================================================
+     SPACING
+     ============================================================ */
+  --space-1:   4px;
+  --space-2:   8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  20px;
+  --space-6:  24px;
+  --space-8:  32px;
+  --space-10: 40px;
+  --space-12: 48px;
+  --space-16: 64px;
+
+  /* ============================================================
+     BORDER RADIUS — sharper for cyberpunk aesthetic
+     ============================================================ */
+  --radius-sm:   2px;
+  --radius-md:   4px;
+  --radius-lg:   6px;
+  --radius-xl:  10px;
+  --radius-full: 9999px;
+
+  /* ============================================================
+     SHADOWS / ELEVATION
+     ============================================================ */
+  --shadow-sm:  0 1px 3px rgba(0,0,0,0.3);
+  --shadow-md:  0 4px 12px rgba(0,0,0,0.4);
+  --shadow-lg:  0 8px 32px rgba(0,0,0,0.5);
+  --shadow-float: 0 4px 24px rgba(0,0,0,0.55), 0 1px 4px rgba(0,0,0,0.3);
+  --shadow-inset: inset 0 1px 3px rgba(0,0,0,0.35);
+
+  /* ============================================================
+     ANIMATION
+     ============================================================ */
+  --ease:        cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-linear: linear;
+  --duration-fast: 100ms;
+  --duration-base: 150ms;
+  --duration-slow: 250ms;
+
+  /* ============================================================
+     Z-INDEX SCALE
+     ============================================================ */
+  --z-base:    1;
+  --z-raised:  10;
+  --z-sticky:  100;
+  --z-overlay: 200;
+  --z-modal:   300;
+  --z-toast:   400;
+}
+
+/* ============================================================
+   SEMANTIC ELEMENT DEFAULTS
+   ============================================================ */
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+body {
+  background-color: var(--bg-base);
+  color: var(--fg-1);
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-normal);
+}
+
+/* --- Display headings (EB Garamond) --- */
+h1, .h1 {
+  font-family: var(--font-display);
+  font-size: var(--text-3xl);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  color: var(--fg-1);
+}
+
+h2, .h2 {
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  color: var(--fg-1);
+}
+
+/* --- UI headings (DM Sans) --- */
+h3, .h3 {
+  font-family: var(--font-ui);
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-snug);
+  color: var(--fg-1);
+}
+
+h4, .h4 {
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-snug);
+  color: var(--fg-1);
+}
+
+h5, h6, .h5, .h6 {
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-snug);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--fg-2);
+}
+
+p {
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
+  color: var(--fg-1);
+  text-wrap: pretty;
+}
+
+small, .text-sm {
+  font-size: var(--text-sm);
+  color: var(--fg-2);
+}
+
+.text-xs {
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  font-family: var(--font-mono);
+  letter-spacing: var(--tracking-wide);
+}
+
+code, kbd, pre, .mono {
+  font-family: var(--font-mono);
+  font-size: 0.875em; /* relative to surrounding text */
+}
+
+code {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.1em 0.35em;
+  color: var(--fg-1);
+}
+
+pre {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  overflow-x: auto;
+  font-size: var(--text-sm);
+  line-height: var(--leading-normal);
+  color: var(--fg-1);
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+a:hover {
+  color: var(--fg-1);
+  text-decoration: underline;
+}
+
+hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: var(--space-6) 0;
+}
+
+/* ============================================================
+   UTILITY CLASSES
+   ============================================================ */
+
+/* Text colors */
+.text-primary   { color: var(--fg-1); }
+.text-secondary { color: var(--fg-2); }
+.text-dim       { color: var(--fg-3); }
+.text-accent    { color: var(--accent); }
+.text-cyan      { color: var(--cyan); }
+.text-vault     { color: var(--vault); }
+.text-agent     { color: var(--agent); }
+.text-amber     { color: var(--amber); }
+.text-danger    { color: var(--destructive); }
+
+/* Font families */
+.font-display { font-family: var(--font-display); }
+.font-ui      { font-family: var(--font-ui); }
+.font-mono    { font-family: var(--font-mono); }
+
+/* Weights */
+.weight-light    { font-weight: var(--weight-light); }
+.weight-regular  { font-weight: var(--weight-regular); }
+.weight-medium   { font-weight: var(--weight-medium); }
+.weight-semibold { font-weight: var(--weight-semibold); }
+
+/* Glow effects */
+.glow-cyan   { box-shadow: var(--cyan-glow); }
+.glow-vault  { box-shadow: var(--vault-glow); }
+.glow-agent  { box-shadow: var(--agent-glow); }
+.text-glow-cyan  { text-shadow: 0 0 12px rgba(0,212,232,0.7); }
+.text-glow-gold  { text-shadow: 0 0 16px rgba(212,168,67,0.5); }
+
+/* Tron grid background */
+.grid-bg {
+  background-image:
+    linear-gradient(rgba(0,212,232,0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0,212,232,0.04) 1px, transparent 1px);
+  background-size: 32px 32px;
+}
+
+/* Neon border active state */
+.border-cyan { border-color: var(--cyan) !important; box-shadow: var(--cyan-glow); }
+.border-gold { border-color: var(--accent) !important; box-shadow: 0 0 8px rgba(212,168,67,0.3); }
+
+/* Focus ring */
+:focus-visible {
+  outline: 1px solid var(--cyan);
+  outline-offset: 2px;
+  box-shadow: var(--cyan-glow);
+}

--- a/companion-ui/design_handoff/2026-05-14-runtime-proof-dashboard/design-notes.md
+++ b/companion-ui/design_handoff/2026-05-14-runtime-proof-dashboard/design-notes.md
@@ -1,0 +1,68 @@
+# Design notes — Runtime Proof / Health Dashboard
+
+## Visual language
+
+This package follows the shared Yggdrasil design system (`colors_and_type.css`) used across the
+2026-05 companion-ui handoffs:
+
+- **Dark, cool blue-black background** (`--bg-base`) with a subtle Tron grid.
+- **Cool blue-white text** (`--fg-1`); secondary copy in `--fg-2`; mono captions in `--fg-3`.
+- **Norse gold** (`--accent`) for governance and provenance accents.
+- **Electric cyan** (`--cyan`) for trigger / link / receipt-pending cues.
+- **Vault green** (`--vault`) for healthy, applied, reviewed.
+- **Amber** (`--amber`) for staged, stale, inferred, or attention-needed.
+- **Destructive red** (`--destructive`) for refusal, denial, conflict, and dead-letter.
+
+Type: **EB Garamond** for display, **Space Grotesk** for UI, **JetBrains Mono** for evidence
+captions, ids, scores, and timestamps. Mono is the load-bearing voice of "this is evidence,
+not summary."
+
+## Surface posture
+
+Compact operator surface for proving whether the local-first runtime is actually working — watcher, worker, outbox, vault, write-guard, last proof receipt.
+
+The surface is intentionally **calm**:
+
+- No alarm noise. Red is reserved for actual refusals.
+- No coloured tiles without evidence. Every mono caption is rooted in a runtime value.
+- Animation is restrained: receipt-pill pulse and the banner LED only. Both respect
+  `prefers-reduced-motion`.
+- No emoji. Status uses short words ("Running", "Backlogged", "Stale") rather than icons.
+
+## Component vocabulary
+
+The shared spec chrome (`spec_chrome.css`) carries:
+
+- `.callout` (cyan, amber, accent, destructive, vault variants) for invariants and notes.
+- `.chip` for tag-style metadata.
+- `.receipt` (queued, applied, pending, failed) for receipt pills.
+- `.btn` (primary, governance, vault, danger, ghost) for actions.
+- `.gallery` and `.gallery-card` for state galleries.
+- `table.spec` for evidence tables with mono headers.
+
+Each prototype adds local components on top — see `prototype.html` for inline styles.
+
+See `prototype.html` §03 for the dashboard prototype, §04 for the section design, §05 for the 9-state gallery.
+
+## Why the layout is the way it is
+
+- **TOC sidebar.** Specs are scanned, not read. The TOC is sticky so scanning stays cheap.
+- **Mono section numbers and metadata.** Visual contract: mono text means "this is a value
+  the runtime emits", not a designer's invented label.
+- **Section heads in EB Garamond.** Display serif at section boundaries marks the
+  transitions in attention; UI sans inside the section keeps reading dense.
+- **No hover-only affordances.** Every action is visible at rest; hover only adds an accent.
+
+## Copy conventions
+
+- Headlines: short verbs or adjectives.
+- Captions: mono, in `--fg-3`.
+- Action labels: uppercase, letter-spacing wide, never punctuated.
+- Status copy: second-person plain language. Never imperative-without-object ("Restart").
+
+## Out of scope for this package
+
+- Brand redesign.
+- New colour tokens (none added).
+- New type pairings.
+- Animation grammar beyond the existing receipt-pulse pattern.

--- a/companion-ui/design_handoff/2026-05-14-runtime-proof-dashboard/edge-states.md
+++ b/companion-ui/design_handoff/2026-05-14-runtime-proof-dashboard/edge-states.md
@@ -1,0 +1,30 @@
+# Edge states — Runtime Proof / Health Dashboard
+
+This document is the edge-state checklist required by the Handoff Governance Pack §08.
+The full per-state visual treatment lives in **`prototype.html` §06 (Edge states)**. This
+document is the text checklist.
+
+## Required edges
+
+- **Empty** — designed (see `prototype.html` §06).
+- **Loading** — designed; static dim states, no skeleton animation.
+- **Degraded** — designed; partial function with explicit naming of what is degraded.
+- **Blocked** — designed; refusal is named, recorded, and never silently retried.
+- **Stale context** — designed; threshold and "why" rendered.
+- **Missing provenance** — designed; surfaced rather than hidden.
+- **Write-guard denial** — designed; denial reason visible; not retried.
+- **Reduced motion** — designed; receipt pulse + banner LED respect `prefers-reduced-motion`.
+- **Narrow / mobile layout** — designed; see `prototype.html` §06 (and §04 for the
+  portrait-specific layout in the bundle inspector).
+
+## Deferred-with-reason
+
+None for this package. If a future revision defers any edge, it must be tracked here with a
+reason and a follow-up issue link.
+
+## Validation expectations
+
+Per the implementation contract, every edge above must render correctly from a fixture and
+must satisfy the per-edge acceptance criteria in `prototype.html` §06. Reduced-motion is
+verified with the OS preference set; narrow layouts are verified at the documented
+breakpoints (`< 900px` for the standard collapse; `< 560px` where applicable).

--- a/companion-ui/design_handoff/2026-05-14-runtime-proof-dashboard/implementation-contracts.md
+++ b/companion-ui/design_handoff/2026-05-14-runtime-proof-dashboard/implementation-contracts.md
@@ -1,0 +1,70 @@
+# Implementation contract — Runtime Proof / Health Dashboard
+
+**Status:** Contract for UI integration · target-state
+**Mutates:** nothing on its own
+**Depends on:** STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md (invariant), runtime-proof receipt contract (when normalized), the gated-execution invariant.
+
+## Position in the chain
+
+This document is the part of the package that implementation reads. It is the only document
+that promises anything to code. Everything else in the package (README, design-notes,
+state-gallery, edge-states, authority-boundaries, open-questions) is guidance.
+
+## State enum
+
+The implementation must enumerate exactly the states described in **`prototype.html` §03 + §05**. Adding
+or removing a state without amending this document means the design no longer covers it.
+
+## Allowed transitions
+
+See **`prototype.html` §03 + §05** for the per-state transition table. Implementation must
+reject any transition not enumerated there.
+
+## Data attributes
+
+Stable attributes the design relies on for testids and behavioral selectors are listed in
+**`prototype.html` §07 (Implementation contract)** of this package. Required attributes are
+flagged in the prototype's code block. Adding new attributes is permitted; renaming is not.
+
+## Intents
+
+The full `data-intent` vocabulary is in **`prototype.html` §07**. Each intent declares:
+
+- the surface that emits it,
+- the effect (UI-local / read-only / governed / navigation),
+- whether it routes through the governance pipeline.
+
+Implementation must not emit intents not declared here. Adding a new intent requires an
+amendment to this document.
+
+## Server contract surface
+
+Endpoints / events / classifiers the UI consumes are bound to existing or proposed runtime
+contracts. The UI never re-classifies; the server's declared class wins.
+
+Specific contract references:
+
+- `STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md (invariant)`
+- `runtime-proof receipt contract (when normalized)`
+
+## Validation expectations
+
+A passing validation receipt for this package would render the full state gallery against
+fixture inputs, verify every declared transition, and confirm:
+
+- no UI-derived posture / class / authority,
+- denied / blocked states emit the right receipts,
+- reduced-motion preference is respected,
+- narrow / portrait layout preserves all critical affordances.
+
+The exact fixture set is owned by the implementation issue, not this document.
+
+## What this contract does not say
+
+Explicit list of things implementation is free to choose:
+
+- framework (React, vanilla, web components — design works for any),
+- style technique (CSS, styled-components, CSS modules),
+- animation library (none needed; the design uses CSS),
+- persistence cache shape,
+- network transport.

--- a/companion-ui/design_handoff/2026-05-14-runtime-proof-dashboard/open-questions.md
+++ b/companion-ui/design_handoff/2026-05-14-runtime-proof-dashboard/open-questions.md
@@ -1,0 +1,32 @@
+# Open questions — Runtime Proof / Health Dashboard
+
+The canonical list lives in **`prototype.html` §09 (Open questions)** of this package. This
+document is the structured version intended for issue creation at crossings C/D.
+
+## Status
+
+All open questions are tracked in the prototype. Owner-doc owners are proposed in the
+prototype; they are not assigned yet — assignment happens at crossing B during the
+maturity-checklist review.
+
+## Crossing-B blockers
+
+If any open question would, if answered, change the state machine declared in the
+implementation contract, that question is a crossing-B blocker per the governance pack §03.
+The reviewer at crossing B must triage each open question into one of:
+
+- **resolve before promotion** (blocker),
+- **resolve in normalized spec** (non-blocker, but cite),
+- **defer to implementation issue** (non-blocker, but acknowledge).
+
+## How to read
+
+Each open question in the prototype carries:
+
+- a short title (used as the issue title if escalated),
+- the rationale for the question,
+- a proposed default (the package's recommendation),
+- an implicit owner (the doc the question would amend if accepted).
+
+Detailed answers are deliberately not pre-decided here — the question list is the package's
+honest "we don't know yet, and we made a choice anyway" record.

--- a/companion-ui/design_handoff/2026-05-14-runtime-proof-dashboard/prototype.html
+++ b/companion-ui/design_handoff/2026-05-14-runtime-proof-dashboard/prototype.html
@@ -1,0 +1,1221 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Runtime Proof / Health Dashboard — Yggdrasil Companion UI</title>
+<link rel="stylesheet" href="./colors_and_type.css" />
+<link rel="stylesheet" href="./spec_chrome.css" />
+<style>
+  /* ============================================================
+     LOCAL — operator dashboard
+     ============================================================ */
+  .dash {
+    border: 1px solid var(--border);
+    background: var(--bg-surface);
+    border-radius: var(--radius-md);
+    margin: var(--space-3) 0 var(--space-6);
+    overflow: hidden;
+  }
+  .dash-bar {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: 12px 16px;
+    background: var(--bg-raised);
+    border-bottom: 1px solid var(--border);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+  }
+  .dash-bar .vault-name {
+    color: var(--vault);
+    font-weight: var(--weight-medium);
+  }
+  .dash-bar .right { margin-left: auto; display: flex; gap: 10px; align-items: center; }
+  .dash-bar .ts { color: var(--fg-2); }
+
+  /* status banner */
+  .banner {
+    padding: var(--space-5) var(--space-6);
+    border-bottom: 1px solid var(--border);
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: var(--space-5);
+    align-items: center;
+  }
+  .banner .kicker {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    margin-bottom: 6px;
+  }
+  .banner .title {
+    font-family: var(--font-display);
+    font-size: var(--text-2xl);
+    color: var(--fg-1);
+    font-weight: var(--weight-regular);
+    line-height: 1.1;
+  }
+  .banner .title .led {
+    display: inline-block;
+    width: 10px; height: 10px;
+    border-radius: 50%;
+    margin-right: 10px;
+    vertical-align: middle;
+    background: var(--vault);
+    box-shadow: 0 0 8px var(--vault), 0 0 2px var(--vault);
+  }
+  .banner .sub {
+    font-size: var(--text-sm);
+    color: var(--fg-2);
+    margin-top: 8px;
+    max-width: 60ch;
+  }
+  .banner .next {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 6px;
+  }
+  .banner .next .lbl {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    color: var(--fg-3);
+  }
+  .banner .next .action {
+    font-family: var(--font-ui);
+    font-size: var(--text-sm);
+    color: var(--fg-1);
+    text-align: right;
+    max-width: 28ch;
+  }
+  .banner.healthy .title .led { background: var(--vault); box-shadow: 0 0 10px var(--vault); }
+  .banner.degraded .title .led { background: var(--amber); box-shadow: 0 0 10px var(--amber); animation: bpulse 2s ease-in-out infinite; }
+  .banner.blocked  .title .led { background: var(--destructive); box-shadow: 0 0 10px var(--destructive); animation: bpulse 1.4s ease-in-out infinite; }
+  .banner.unknown  .title .led { background: var(--fg-3); box-shadow: none; }
+  .banner.proof-pending .title .led { background: var(--accent); box-shadow: 0 0 10px var(--accent); animation: bpulse 2s ease-in-out infinite; }
+  @keyframes bpulse { 0%,100% { opacity: 0.55; } 50% { opacity: 1; } }
+
+  /* cards */
+  .dash-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1px;
+    background: var(--border);
+    border-bottom: 1px solid var(--border);
+  }
+  .dash-grid > .card {
+    background: var(--bg-surface);
+    padding: var(--space-4);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    min-height: 200px;
+  }
+  .card .hd {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+  .card .hd .name {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    color: var(--fg-2);
+  }
+  .card .hd .led {
+    width: 8px; height: 8px; border-radius: 50%;
+    background: var(--vault);
+    box-shadow: 0 0 6px var(--vault);
+  }
+  .card .hd .led.amber { background: var(--amber); box-shadow: 0 0 6px var(--amber); }
+  .card .hd .led.dang  { background: var(--destructive); box-shadow: 0 0 6px var(--destructive); }
+  .card .hd .led.dim   { background: var(--fg-3); box-shadow: none; }
+  .card .hd .led.cyan  { background: var(--cyan); box-shadow: 0 0 6px var(--cyan); }
+  .card .big {
+    font-family: var(--font-display);
+    font-size: var(--text-xl);
+    color: var(--fg-1);
+    line-height: 1.1;
+  }
+  .card .big.vault { color: var(--vault); }
+  .card .big.amber { color: var(--amber); }
+  .card .big.dang  { color: var(--destructive); }
+  .card .big.cyan  { color: var(--cyan); }
+  .card .row {
+    display: flex;
+    justify-content: space-between;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--fg-2);
+    padding: 3px 0;
+    border-bottom: 1px solid var(--border);
+  }
+  .card .row:last-of-type { border-bottom: none; }
+  .card .row .v { color: var(--fg-1); }
+  .card .row .v.vault { color: var(--vault); }
+  .card .row .v.amber { color: var(--amber); }
+  .card .row .v.dim   { color: var(--fg-3); }
+  .card .row .v.dang  { color: var(--destructive); }
+  .card .row .v.cyan  { color: var(--cyan); }
+  .card .row .v.gold  { color: var(--accent); }
+
+  .spark {
+    display: flex;
+    align-items: flex-end;
+    gap: 2px;
+    height: 22px;
+    margin-top: 2px;
+  }
+  .spark .b {
+    flex: 1;
+    background: var(--cyan-dim);
+    opacity: 0.7;
+    border-radius: 1px;
+    min-height: 2px;
+  }
+  .spark.flat .b { background: var(--fg-3); opacity: 0.45; }
+  .spark.gold .b { background: var(--accent); opacity: 0.55; }
+
+  /* proof receipt strip */
+  .proof {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1px;
+    background: var(--border);
+    border-bottom: 1px solid var(--border);
+  }
+  .proof > .card { min-height: 180px; }
+  .proof .recline {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--fg-2);
+    margin-top: 4px;
+  }
+  .proof .recline .ck {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 0;
+    border-bottom: 1px solid var(--border);
+  }
+  .proof .recline .ck:last-child { border-bottom: none; }
+  .proof .recline .ck .mark {
+    width: 14px; text-align: center;
+    color: var(--vault);
+  }
+  .proof .recline .ck .mark.skip { color: var(--amber); }
+  .proof .recline .ck .mark.fail { color: var(--destructive); }
+  .proof .recline .ck .desc { flex: 1; color: var(--fg-1); }
+  .proof .recline .ck .ts { color: var(--fg-3); }
+
+  /* next action */
+  .next-action {
+    padding: var(--space-4) var(--space-5);
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    background: var(--bg-base);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--fg-2);
+    letter-spacing: var(--tracking-wide);
+  }
+  .next-action .lbl {
+    color: var(--accent);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wider);
+  }
+  .next-action .copy {
+    color: var(--fg-1);
+    text-transform: none;
+    letter-spacing: 0;
+    font-family: var(--font-ui);
+    font-size: var(--text-sm);
+    flex: 1;
+  }
+  .next-action .actions { display: flex; gap: 8px; }
+
+  /* state gallery — mini dashboards */
+  .gallery.dash-gallery {
+    grid-template-columns: 1fr 1fr;
+  }
+  .gallery.dash-gallery .gallery-card {
+    padding: 0;
+    overflow: hidden;
+    min-height: 0;
+  }
+  .gallery.dash-gallery .gallery-card .hdr-cap {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-raised);
+  }
+  .gallery.dash-gallery .gallery-card .hdr-cap h4 { margin: 0; }
+  .mini {
+    padding: 12px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .mini .title-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .mini .title-row .led { width: 9px; height: 9px; border-radius: 50%; background: var(--vault); box-shadow: 0 0 6px var(--vault); }
+  .mini .title-row .led.amber { background: var(--amber); box-shadow: 0 0 6px var(--amber); }
+  .mini .title-row .led.dang  { background: var(--destructive); box-shadow: 0 0 6px var(--destructive); }
+  .mini .title-row .led.dim   { background: var(--fg-3); box-shadow: none; }
+  .mini .title-row .led.gold  { background: var(--accent); box-shadow: 0 0 6px var(--accent); }
+  .mini .title-row .ttl {
+    font-family: var(--font-display);
+    font-size: var(--text-md);
+    color: var(--fg-1);
+    line-height: 1.1;
+  }
+  .mini .desc {
+    font-size: var(--text-sm);
+    color: var(--fg-2);
+    line-height: 1.45;
+  }
+  .mini .sub-line {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 12px;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    padding-top: 4px;
+    border-top: 1px dashed var(--border);
+  }
+  .mini .sub-line .k { color: var(--fg-2); }
+  .mini .sub-line .vault { color: var(--vault); }
+  .mini .sub-line .amber { color: var(--amber); }
+  .mini .sub-line .dang  { color: var(--destructive); }
+  .mini .sub-line .cyan  { color: var(--cyan); }
+  .mini .sub-line .gold  { color: var(--accent); }
+
+  .mini .next-strip {
+    background: var(--bg-raised);
+    border: 1px solid var(--border-strong);
+    border-left: 2px solid var(--accent);
+    padding: 6px 10px;
+    font-size: var(--text-xs);
+    color: var(--fg-1);
+    line-height: 1.4;
+  }
+  .mini .next-strip.vault { border-left-color: var(--vault); }
+  .mini .next-strip.amber { border-left-color: var(--amber); }
+  .mini .next-strip.dang  { border-left-color: var(--destructive); }
+  .mini .next-strip.dim   { border-left-color: var(--fg-3); color: var(--fg-3); }
+  .mini .next-strip .lbl {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    color: var(--accent);
+    display: block;
+  }
+  .mini .next-strip.vault .lbl { color: var(--vault); }
+  .mini .next-strip.amber .lbl { color: var(--amber); }
+  .mini .next-strip.dang  .lbl { color: var(--destructive); }
+  .mini .next-strip.dim   .lbl { color: var(--fg-3); }
+
+  @media (max-width: 900px) {
+    .dash-grid { grid-template-columns: 1fr 1fr; }
+    .proof { grid-template-columns: 1fr; }
+    .banner { grid-template-columns: 1fr; }
+    .banner .next { align-items: flex-start; }
+    .gallery.dash-gallery { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+<div class="page">
+
+  <!-- ============================ TOC ============================ -->
+  <nav class="toc" aria-label="Section index">
+    <div class="toc-label">Sections</div>
+    <ol>
+      <li><a href="#s1"><span class="toc-num">01</span>Context &amp; boundary</a></li>
+      <li><a href="#s2"><span class="toc-num">02</span>What the operator must answer</a></li>
+      <li><a href="#s3"><span class="toc-num">03</span>Three planes: evidence · status · action</a></li>
+      <li><a href="#s4"><span class="toc-num">04</span>Dashboard prototype</a></li>
+      <li><a href="#s5"><span class="toc-num">05</span>Section design</a></li>
+      <li><a href="#s6"><span class="toc-num">06</span>State gallery</a></li>
+      <li><a href="#s7"><span class="toc-num">07</span>Edge states &amp; checklist</a></li>
+      <li><a href="#s8"><span class="toc-num">08</span>Implementation contract</a></li>
+      <li><a href="#s9"><span class="toc-num">09</span>Authority boundaries</a></li>
+      <li><a href="#s10"><span class="toc-num">10</span>Open questions</a></li>
+      <li><a href="#s11"><span class="toc-num">11</span>Handoff to Code/Codex</a></li>
+    </ol>
+  </nav>
+
+  <!-- ============================ MAIN ============================ -->
+  <main>
+    <header class="doc-header">
+      <div class="doc-eyebrow">Companion UI · Design Handoff · Operator surface</div>
+      <h1 class="doc-title">Runtime Proof / Health Dashboard</h1>
+      <p class="doc-lede">
+        A compact single-operator proof surface. Answers nine questions about whether the
+        local-first runtime is actually working — watcher, worker, outbox, vault scope, write
+        guard, last proof receipt — and points at the next useful action. Not an enterprise
+        observability product, not an alarm panel. Shows evidence, not just color.
+      </p>
+      <div class="doc-meta">
+        <span><strong>Surface:</strong> RUNTIME_PROOF_DASHBOARD</span>
+        <span><strong>Audience:</strong> the local operator (one human, their vault)</span>
+        <span><strong>Authority:</strong> Read-only mirror of runtime state</span>
+        <span><strong>Status:</strong> Design handoff · v1 · 2026-05-14</span>
+      </div>
+    </header>
+
+    <!-- ============== 01 ============== -->
+    <section class="spec" id="s1">
+      <h2><span class="secnum">01 ·</span>Context &amp; boundary</h2>
+      <p class="lede">What this surface is for, and the postures it must avoid.</p>
+
+      <p>
+        Current stabilization work includes watcher OOM repair, worker poison-message handling,
+        startup sequencing, and (later) runtime proof receipts. The dashboard exists to make the
+        outcome of that work <em>legible to the human who runs the vault</em>: not to ops staff,
+        not to a control plane, not to a CI bot. Single operator, one local install, one vault.
+      </p>
+
+      <h3>Postures we are designing toward</h3>
+      <ul>
+        <li><strong>Sober.</strong> No alarm noise. No red unless red is correct.</li>
+        <li><strong>Evidence-bearing.</strong> Every status line is rooted in a value the runtime
+          actually emits (last heartbeat ts, queue depth, receipt id), not a derived colour.</li>
+        <li><strong>Bounded scope.</strong> Watcher, worker, outbox/index, vault, write-guard,
+          proof receipt. Nothing else. No latency graphs, no agent traces, no dependency map.</li>
+        <li><strong>Action-aware.</strong> When the state suggests a useful next action, the
+          dashboard names it — but does not perform it without explicit trigger.</li>
+      </ul>
+
+      <h3>Postures we are designing against</h3>
+      <ul>
+        <li>Dashboard-as-control-plane. The dashboard mirrors; it does not orchestrate.</li>
+        <li>Auto-repair. State transitions that look like remediation must be the operator's
+          explicit click.</li>
+        <li>Coloured-tile theatre. A row that flashes amber without saying <em>why</em> is worse
+          than no row at all.</li>
+        <li>"Everything is fine" overcompensation. If the proof has not been run, the surface
+          says that — it does not invent a green check.</li>
+      </ul>
+
+      <div class="callout invariant">
+        <span class="callout-label">Floor invariant</span>
+        The dashboard reads state. It does not write state. Any affordance that looks
+        write-like — "restart watcher", "rebuild index", "run proof" — emits an intent through
+        the existing governed path. The dashboard never auto-triggers remediation.
+      </div>
+    </section>
+
+    <!-- ============== 02 ============== -->
+    <section class="spec" id="s2">
+      <h2><span class="secnum">02 ·</span>What the operator must answer</h2>
+      <p class="lede">
+        Nine questions. The whole layout is structured so that each is answerable from the
+        primary view, in a glance.
+      </p>
+
+      <table class="spec">
+        <thead><tr><th>Q</th><th>Question</th><th>Answered by</th></tr></thead>
+        <tbody>
+          <tr><td>Q1</td><td>Is the system running?</td><td>Overall banner</td></tr>
+          <tr><td>Q2</td><td>Is the watcher healthy?</td><td>Watcher card · heartbeat, scope, restarts</td></tr>
+          <tr><td>Q3</td><td>Is the worker healthy?</td><td>Worker card · queue depth, last processed, poison count</td></tr>
+          <tr><td>Q4</td><td>Are there stuck or poison outbox messages?</td><td>Outbox card · pending / dead-lettered counts</td></tr>
+          <tr><td>Q5</td><td>Is the vault scope correct?</td><td>Vault card · active vault, scoped folders, last change</td></tr>
+          <tr><td>Q6</td><td>Is indexing moving?</td><td>Outbox card · processed sparkline · last-event ts</td></tr>
+          <tr><td>Q7</td><td>Are writes allowed or blocked?</td><td>Write-guard card · allowed / denied · reason</td></tr>
+          <tr><td>Q8</td><td>What was the last successful proof receipt?</td><td>Proof receipt panel · pass/fail · skipped checks · receipt id</td></tr>
+          <tr><td>Q9</td><td>What should I do next?</td><td>Next-action strip · single recommendation · explicit trigger</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <!-- ============== 03 — REFINEMENT v2 — three planes + no auto-repair + receipt link pattern ============== -->
+    <section class="spec" id="s3">
+      <h2><span class="secnum">03 ·</span>Three planes: evidence · status · action</h2>
+      <p class="lede">
+        The dashboard renders three planes simultaneously and never lets them blur. Every card,
+        every row, every banner sits cleanly on one plane.
+      </p>
+
+      <table class="spec">
+        <thead>
+          <tr><th>Plane</th><th>What it is</th><th>Where it lives</th><th>Mutability</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Evidence</strong></td>
+            <td>Runtime values the system emits — heartbeat ts, queue depth, oldest pending age, restart count, receipt id. Numbers and timestamps.</td>
+            <td>Mono captions inside cards. Per-row values. Sparkline bars.</td>
+            <td>Read-only · never derived in the UI</td>
+          </tr>
+          <tr>
+            <td><strong>Status</strong></td>
+            <td>Posture the runtime declares from evidence — <em>running</em>, <em>backlogged</em>, <em>poisoned</em>, <em>stale</em>, <em>denied</em>, <em>pass</em>, <em>fail</em>. Short adjectives or verbs.</td>
+            <td>LED dots. Card headlines. Banner title.</td>
+            <td>Read-only · declared by the snapshot's <code>posture</code> field</td>
+          </tr>
+          <tr>
+            <td><strong>Suggested action</strong></td>
+            <td>The single recommendation for what to do next — including "no action needed". Plain second-person language with a verb and an object.</td>
+            <td>Banner sub-line · the bottom next-action strip · per-state gallery cards.</td>
+            <td>Operator-triggered · the dashboard never executes</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="callout invariant">
+        <span class="callout-label">Invariant · The three planes are never collapsed</span>
+        Evidence does not derive status (the runtime owns posture). Status does not derive
+        action (the suggested-next-action field is its own snapshot field). Action does not
+        execute itself (every action is the operator's explicit click). A coloured tile alone
+        is never a status; a status alone is never an action.
+      </div>
+
+      <h3>No automatic repair</h3>
+      <p>
+        Every affordance that looks write-like — <em>Run proof now</em>, <em>Restart watcher</em>,
+        <em>Replay dead-lettered event</em>, <em>Rebuild index</em> — is an explicit operator
+        click that emits a governed intent. The dashboard does not retry on its own. The
+        dashboard does not escalate on its own. The dashboard does not flip a subsystem from
+        amber to vault-green by acting; only the runtime does that, and only after the
+        operator triggered the action.
+      </p>
+
+      <div class="callout warn">
+        <span class="callout-label">Anti-pattern · auto-remediation</span>
+        If a state appears that wants automatic repair (e.g. "watcher dropped, restart it"),
+        the dashboard surfaces the suggestion in the action plane. The runtime — or, more
+        often, the operator — does the repair. The dashboard is not allowed to become a
+        control plane that hides what it does.
+      </div>
+
+      <h3>Receipt link pattern</h3>
+      <p>
+        Every status that has a receipt links to it. The pattern is one shape used in three
+        places:
+      </p>
+      <ul>
+        <li><strong>Proof receipt panel</strong> — the receipt pill is the canonical instance.
+          <span class="receipt applied"><span class="recdot"></span>PASS · rp-2026-05-14-09-14</span>
+          Click opens the receipt in audit view (read-only).</li>
+        <li><strong>Per-check rows</strong> — each check in the proof trace ends with a
+          timestamp that links to the check's own sub-receipt when one exists.</li>
+        <li><strong>Card receipt counts</strong> — when a card cites an action count (e.g.
+          <em>1 pending</em> in Governance, <em>0 denials · 24h</em> in Write guard), each
+          count is a hover-disclosure that lists the receipt ids; clicking any opens it.</li>
+      </ul>
+
+      <div class="callout">
+        <span class="callout-label">Receipt link rule</span>
+        Any number on the dashboard that represents <em>governed events</em> (proof runs,
+        governance receipts, write-guard denials, dead-letters, watcher restarts) must be
+        a link to the list of receipt ids it counts. Numbers without receipts (heartbeat ms,
+        tick counts) do not link. The pattern makes it impossible to look at a count without
+        being one click from the evidence behind it.
+      </div>
+    </section>
+
+    <!-- ============== 04 ============== -->
+    <section class="spec" id="s4">
+      <h2><span class="secnum">04 ·</span>Dashboard prototype <span class="chip design" style="font-size:10px; margin-left:8px">healthy state</span></h2>
+      <p class="lede">
+        Default view. All subsystems nominal, last proof passed this morning. The layout is the
+        same across every state — only the values and accent colours change.
+      </p>
+
+      <div class="dash" aria-label="Runtime Proof Dashboard — healthy state">
+        <!-- top bar -->
+        <div class="dash-bar">
+          <span class="vault-name">vault · main</span>
+          <span>scope · projects/, journal/, references/</span>
+          <span class="right">
+            <span class="ts">last poll · 14:08:32</span>
+            <button class="btn ghost" type="button" data-intent="dashboard.refresh">Refresh <span class="kbd">R</span></button>
+          </span>
+        </div>
+
+        <!-- banner -->
+        <div class="banner healthy">
+          <div>
+            <div class="kicker">overall · runtime</div>
+            <div class="title"><span class="led" aria-hidden="true"></span>Running · healthy</div>
+            <p class="sub">Watcher and worker are healthy, outbox is draining, write guard is open,
+              last proof receipt passed at 09:14 this morning with no skipped checks.</p>
+          </div>
+          <div class="next">
+            <span class="lbl">last proof</span>
+            <span class="action">PASS · receipt rp-2026-05-14-09-14 · 09:14</span>
+          </div>
+        </div>
+
+        <!-- main grid -->
+        <div class="dash-grid">
+          <!-- watcher -->
+          <div class="card">
+            <div class="hd">
+              <span class="name">Watcher</span>
+              <span class="led" aria-label="healthy"></span>
+            </div>
+            <div class="big vault">Running</div>
+            <div class="row"><span>last heartbeat</span><span class="v vault">2.1s ago</span></div>
+            <div class="row"><span>scope glob</span><span class="v">**/*.md</span></div>
+            <div class="row"><span>tick · 5m</span><span class="v">312</span></div>
+            <div class="row"><span>changed · 5m</span><span class="v">18</span></div>
+            <div class="row"><span>restarts · 24h</span><span class="v vault">0</span></div>
+          </div>
+
+          <!-- worker -->
+          <div class="card">
+            <div class="hd">
+              <span class="name">Worker</span>
+              <span class="led" aria-label="healthy"></span>
+            </div>
+            <div class="big vault">Running</div>
+            <div class="row"><span>queue depth</span><span class="v vault">0</span></div>
+            <div class="row"><span>last processed</span><span class="v">12s ago</span></div>
+            <div class="row"><span>poison · 24h</span><span class="v vault">0</span></div>
+            <div class="row"><span>dead-letter</span><span class="v vault">0</span></div>
+            <div class="spark" aria-label="processed events per minute, last 24 entries">
+              <span class="b" style="height:30%"></span><span class="b" style="height:60%"></span>
+              <span class="b" style="height:45%"></span><span class="b" style="height:80%"></span>
+              <span class="b" style="height:55%"></span><span class="b" style="height:35%"></span>
+              <span class="b" style="height:70%"></span><span class="b" style="height:90%"></span>
+              <span class="b" style="height:50%"></span><span class="b" style="height:60%"></span>
+              <span class="b" style="height:40%"></span><span class="b" style="height:75%"></span>
+              <span class="b" style="height:55%"></span><span class="b" style="height:65%"></span>
+              <span class="b" style="height:80%"></span><span class="b" style="height:45%"></span>
+              <span class="b" style="height:35%"></span><span class="b" style="height:50%"></span>
+              <span class="b" style="height:60%"></span><span class="b" style="height:40%"></span>
+              <span class="b" style="height:55%"></span><span class="b" style="height:70%"></span>
+              <span class="b" style="height:50%"></span><span class="b" style="height:35%"></span>
+            </div>
+          </div>
+
+          <!-- outbox / index -->
+          <div class="card">
+            <div class="hd">
+              <span class="name">Outbox / Index</span>
+              <span class="led" aria-label="healthy"></span>
+            </div>
+            <div class="big vault">Draining</div>
+            <div class="row"><span>pending</span><span class="v">3</span></div>
+            <div class="row"><span>delivered · 24h</span><span class="v">2,184</span></div>
+            <div class="row"><span>failed · 24h</span><span class="v vault">0</span></div>
+            <div class="row"><span>dead-lettered</span><span class="v vault">0</span></div>
+            <div class="row"><span>oldest pending</span><span class="v">800ms</span></div>
+          </div>
+
+          <!-- vault -->
+          <div class="card">
+            <div class="hd">
+              <span class="name">Vault</span>
+              <span class="led" aria-label="healthy"></span>
+            </div>
+            <div class="big">main</div>
+            <div class="row"><span>active path</span><span class="v">~/vault-main</span></div>
+            <div class="row"><span>scoped folders</span><span class="v">3</span></div>
+            <div class="row"><span>last change</span><span class="v">42s ago</span></div>
+            <div class="row"><span>notes indexed</span><span class="v">4,812</span></div>
+            <div class="row"><span>schema version</span><span class="v">v6.0</span></div>
+          </div>
+
+          <!-- write guard -->
+          <div class="card">
+            <div class="hd">
+              <span class="name">Write guard</span>
+              <span class="led" aria-label="healthy"></span>
+            </div>
+            <div class="big vault">Allowed</div>
+            <div class="row"><span>policy</span><span class="v">default</span></div>
+            <div class="row"><span>last denial · 24h</span><span class="v vault">0</span></div>
+            <div class="row"><span>governance queue</span><span class="v">1 pending</span></div>
+            <div class="row"><span>canvas writes · 24h</span><span class="v">14</span></div>
+          </div>
+
+          <!-- startup -->
+          <div class="card">
+            <div class="hd">
+              <span class="name">Startup</span>
+              <span class="led" aria-label="healthy"></span>
+            </div>
+            <div class="big">Sequenced</div>
+            <div class="row"><span>booted</span><span class="v">06:02</span></div>
+            <div class="row"><span>watcher up</span><span class="v">+1.4s</span></div>
+            <div class="row"><span>worker up</span><span class="v">+2.1s</span></div>
+            <div class="row"><span>scope loaded</span><span class="v">+2.6s</span></div>
+            <div class="row"><span>init proof</span><span class="v vault">PASS · 06:03</span></div>
+          </div>
+
+          <!-- agents -->
+          <div class="card">
+            <div class="hd">
+              <span class="name">Agents</span>
+              <span class="led cyan" aria-label="active"></span>
+            </div>
+            <div class="big">2 active</div>
+            <div class="row"><span>Hugin · canvas</span><span class="v cyan">idle</span></div>
+            <div class="row"><span>Munin · panel</span><span class="v cyan">idle</span></div>
+            <div class="row"><span>turns · 24h</span><span class="v">37</span></div>
+            <div class="row"><span>proposals · 24h</span><span class="v">12</span></div>
+          </div>
+
+          <!-- governance -->
+          <div class="card">
+            <div class="hd">
+              <span class="name">Governance</span>
+              <span class="led" style="background:var(--accent); box-shadow:0 0 6px var(--accent);" aria-label="active receipt"></span>
+            </div>
+            <div class="big" style="color:var(--accent)">1 pending</div>
+            <div class="row"><span>queued</span><span class="v gold">1</span></div>
+            <div class="row"><span>in-review</span><span class="v">0</span></div>
+            <div class="row"><span>applied · 24h</span><span class="v">6</span></div>
+            <div class="row"><span>rejected · 24h</span><span class="v">1</span></div>
+            <div class="row"><span>oldest receipt</span><span class="v">4m</span></div>
+          </div>
+        </div>
+
+        <!-- proof receipt -->
+        <div class="proof">
+          <div class="card">
+            <div class="hd">
+              <span class="name">Last proof receipt</span>
+              <span class="receipt applied"><span class="recdot"></span>PASS · rp-2026-05-14-09-14</span>
+            </div>
+            <div class="recline">
+              <div class="ck"><span class="mark">✓</span><span class="desc">watcher heartbeat &lt; 5s</span><span class="ts">09:14:01</span></div>
+              <div class="ck"><span class="mark">✓</span><span class="desc">worker drains test queue (10 events)</span><span class="ts">09:14:02</span></div>
+              <div class="ck"><span class="mark">✓</span><span class="desc">outbox commit-and-replay round-trip</span><span class="ts">09:14:03</span></div>
+              <div class="ck"><span class="mark">✓</span><span class="desc">vault scope resolves to 3 folders</span><span class="ts">09:14:03</span></div>
+              <div class="ck"><span class="mark">✓</span><span class="desc">write guard denies out-of-scope fixture</span><span class="ts">09:14:04</span></div>
+              <div class="ck"><span class="mark">✓</span><span class="desc">governance router round-trips fixture intent</span><span class="ts">09:14:05</span></div>
+            </div>
+          </div>
+          <div class="card">
+            <div class="hd">
+              <span class="name">Proof history · 14d</span>
+              <span style="font-family:var(--font-mono); font-size:10px; color:var(--fg-3); letter-spacing:var(--tracking-wide); text-transform:uppercase;">14 / 14 pass</span>
+            </div>
+            <div class="spark gold" style="height:34px" aria-label="proof history bars">
+              <span class="b" style="height:90%"></span><span class="b" style="height:88%"></span>
+              <span class="b" style="height:90%"></span><span class="b" style="height:86%"></span>
+              <span class="b" style="height:90%"></span><span class="b" style="height:88%"></span>
+              <span class="b" style="height:90%"></span><span class="b" style="height:88%"></span>
+              <span class="b" style="height:86%"></span><span class="b" style="height:90%"></span>
+              <span class="b" style="height:88%"></span><span class="b" style="height:90%"></span>
+              <span class="b" style="height:86%"></span><span class="b" style="height:90%"></span>
+            </div>
+            <div class="row"><span>median runtime</span><span class="v">4.2s</span></div>
+            <div class="row"><span>last skip · 14d</span><span class="v vault">0</span></div>
+            <div class="row"><span>last fail · 14d</span><span class="v vault">0</span></div>
+            <div class="row" style="margin-top:auto"><span>next scheduled</span><span class="v">21:00</span></div>
+          </div>
+        </div>
+
+        <!-- next action -->
+        <div class="next-action">
+          <span class="lbl">Suggested next action</span>
+          <span class="copy">No action needed. Next scheduled proof at 21:00. Governance queue has one
+            pending receipt waiting on you in AI Panel.</span>
+          <span class="actions">
+            <button class="btn ghost" type="button" data-intent="proof.run-now">Run proof now <span class="kbd">P</span></button>
+            <button class="btn governance" type="button" data-intent="panel.open-receipt">Open receipt</button>
+          </span>
+        </div>
+      </div>
+
+      <p>
+        Every line of mono text in the dashboard is wired to a single value the runtime emits.
+        The card layout never reflows between healthy and degraded states — only the LEDs, the
+        big-text headline, the row values, and the suggested-next-action strip change. That
+        stability is part of the calmness the surface is trying to maintain.
+      </p>
+    </section>
+
+    <!-- ============== 05 ============== -->
+    <section class="spec" id="s5">
+      <h2><span class="secnum">05 ·</span>Section design</h2>
+      <p class="lede">Each card's content rule, value sources, and copy conventions.</p>
+
+      <table class="spec">
+        <thead>
+          <tr><th>Card</th><th>Headline</th><th>Rows</th><th>Evidence</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Watcher</td>
+            <td><code>Running</code> · <code>Stopped</code> · <code>Restarting</code></td>
+            <td>last heartbeat · scope glob · tick/changed counts (5m window) · restarts (24h, distinguishes OOM)</td>
+            <td>watcher process heartbeat, restart event ledger</td>
+          </tr>
+          <tr>
+            <td>Worker</td>
+            <td><code>Running</code> · <code>Backlogged</code> · <code>Poisoned</code> · <code>Stopped</code></td>
+            <td>queue depth · last processed ts · poison count · dead-letter count · processed-per-minute sparkline</td>
+            <td>worker process state, queue counters, dead-letter ledger</td>
+          </tr>
+          <tr>
+            <td>Outbox / Index</td>
+            <td><code>Draining</code> · <code>Backlogged</code> · <code>Stalled</code></td>
+            <td>pending · delivered (24h) · failed (24h) · dead-lettered · oldest pending age</td>
+            <td>outbox table, index commit log</td>
+          </tr>
+          <tr>
+            <td>Vault</td>
+            <td>active vault name</td>
+            <td>active path · scoped folders count · last change ts · notes indexed · schema version</td>
+            <td>vault config, FS metadata, index head</td>
+          </tr>
+          <tr>
+            <td>Write guard</td>
+            <td><code>Allowed</code> · <code>Denied</code> · <code>Mixed</code></td>
+            <td>policy name · denials (24h) · governance queue size · canvas writes (24h)</td>
+            <td>write-guard policy, governance receipt store</td>
+          </tr>
+          <tr>
+            <td>Startup</td>
+            <td><code>Sequenced</code> · <code>Out-of-order</code> · <code>Init failed</code></td>
+            <td>booted · watcher-up offset · worker-up offset · scope-loaded offset · init proof result</td>
+            <td>startup sequence ledger, init proof receipt</td>
+          </tr>
+          <tr>
+            <td>Agents</td>
+            <td>count active</td>
+            <td>per-agent posture (idle / thinking / blocked) · turns (24h) · proposals (24h)</td>
+            <td>agent runtime state, session log counters</td>
+          </tr>
+          <tr>
+            <td>Governance</td>
+            <td>count pending</td>
+            <td>queued · in-review · applied (24h) · rejected (24h) · oldest receipt age</td>
+            <td>governance receipt store</td>
+          </tr>
+          <tr>
+            <td>Last proof receipt</td>
+            <td><code>PASS</code> · <code>FAIL · &lt;reason&gt;</code> · <code>NOT RUN</code></td>
+            <td>per-check pass / skip / fail with timestamp; receipt id; link to receipt</td>
+            <td>runtime-proof receipt store</td>
+          </tr>
+          <tr>
+            <td>Proof history</td>
+            <td>pass / fail ratio over 14 days</td>
+            <td>median runtime · skipped count · failed count · next scheduled</td>
+            <td>runtime-proof receipt store, scheduler</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Copy conventions</h3>
+      <ul>
+        <li>Headline strings are <em>short</em> verbs or adjectives. Never "OK", never "healthy ✓",
+          never emoji.</li>
+        <li>Counts that should be zero render in vault green; counts that should be non-zero
+          render in fg-1 (neutral). Amber and red are reserved for state that wants attention.</li>
+        <li>Timestamps prefer relative ("2.1s ago", "4m") for recent activity and absolute
+          ("09:14") for events that anchor a story.</li>
+        <li>No card shows a percentage. Percentages summarise; this surface does not summarise.</li>
+        <li>The next-action strip uses second-person plain language ("Inspect the poison
+          message", "Run the proof"). Never imperative without an object.</li>
+      </ul>
+    </section>
+
+    <!-- ============== 06 ============== -->
+    <section class="spec" id="s6">
+      <h2><span class="secnum">06 ·</span>State gallery</h2>
+      <p class="lede">
+        Nine states. Each is the banner + next-action strip the operator would see; the inner
+        grid stays structurally identical and is omitted here for compactness — see §04 for
+        the full layout.
+      </p>
+
+      <div class="gallery dash-gallery">
+        <!-- 1 healthy -->
+        <div class="gallery-card">
+          <div class="hdr-cap"><h4>01 · Healthy</h4><span class="chip vault">nominal</span></div>
+          <div class="mini">
+            <div class="title-row"><span class="led" aria-hidden="true"></span><span class="ttl">Running · healthy</span></div>
+            <p class="desc">Watcher and worker healthy. Outbox draining. Write guard open. Last
+              proof PASS this morning.</p>
+            <div class="next-strip vault">
+              <span class="lbl">Next action</span>
+              No action needed. Next scheduled proof at 21:00.
+            </div>
+            <div class="sub-line">
+              <span><span class="k">watcher</span> <span class="vault">running</span></span>
+              <span><span class="k">worker</span> <span class="vault">running</span></span>
+              <span><span class="k">proof</span> <span class="vault">pass · 09:14</span></span>
+            </div>
+          </div>
+        </div>
+
+        <!-- 2 degraded -->
+        <div class="gallery-card">
+          <div class="hdr-cap"><h4>02 · Degraded</h4><span class="chip gated">attention</span></div>
+          <div class="mini">
+            <div class="title-row"><span class="led amber" aria-hidden="true"></span><span class="ttl">Running · degraded</span></div>
+            <p class="desc">Indexing is moving but the outbox is backlogged: 312 pending,
+              oldest 7m. Watcher and worker are otherwise healthy.</p>
+            <div class="next-strip amber">
+              <span class="lbl">Next action</span>
+              Inspect the worker. Backlog growth suggests a slow handler or contention.
+            </div>
+            <div class="sub-line">
+              <span><span class="k">outbox</span> <span class="amber">backlog · 312</span></span>
+              <span><span class="k">worker</span> <span class="amber">slow</span></span>
+              <span><span class="k">proof</span> <span class="vault">pass · 09:14</span></span>
+            </div>
+          </div>
+        </div>
+
+        <!-- 3 watcher OOM -->
+        <div class="gallery-card">
+          <div class="hdr-cap"><h4>03 · Watcher OOM</h4><span class="chip danger">restart evidence</span></div>
+          <div class="mini">
+            <div class="title-row"><span class="led dang" aria-hidden="true"></span><span class="ttl">Watcher · restarted (OOM)</span></div>
+            <p class="desc">Watcher restarted 3 times in the last hour with OOM evidence. It is
+              currently up. Tick rate has recovered, but recent file events may be missing.</p>
+            <div class="next-strip dang">
+              <span class="lbl">Next action</span>
+              Inspect watcher restart ledger. Consider scope reduction. Re-run proof.
+            </div>
+            <div class="sub-line">
+              <span><span class="k">watcher</span> <span class="dang">3 restarts · OOM</span></span>
+              <span><span class="k">scope</span> <span class="amber">**/*</span></span>
+              <span><span class="k">proof</span> <span class="amber">stale · 09:14</span></span>
+            </div>
+          </div>
+        </div>
+
+        <!-- 4 poison -->
+        <div class="gallery-card">
+          <div class="hdr-cap"><h4>04 · Worker poison</h4><span class="chip danger">dead-letter</span></div>
+          <div class="mini">
+            <div class="title-row"><span class="led dang" aria-hidden="true"></span><span class="ttl">Worker · poison message</span></div>
+            <p class="desc">One poison message dead-lettered. Worker continued processing other
+              events. The DLQ row links to the offending event for inspection.</p>
+            <div class="next-strip dang">
+              <span class="lbl">Next action</span>
+              Inspect the dead-lettered event in the outbox view, then ack or replay.
+            </div>
+            <div class="sub-line">
+              <span><span class="k">worker</span> <span class="vault">running</span></span>
+              <span><span class="k">dlq</span> <span class="dang">1</span></span>
+              <span><span class="k">queue</span> <span class="amber">12</span></span>
+            </div>
+          </div>
+        </div>
+
+        <!-- 5 stale heartbeat -->
+        <div class="gallery-card">
+          <div class="hdr-cap"><h4>05 · Stale heartbeat</h4><span class="chip gated">unknown</span></div>
+          <div class="mini">
+            <div class="title-row"><span class="led amber" aria-hidden="true"></span><span class="ttl">Watcher · heartbeat stale</span></div>
+            <p class="desc">No watcher heartbeat for 42s. Threshold is 10s. We cannot confirm
+              whether the watcher is stopped or starved.</p>
+            <div class="next-strip amber">
+              <span class="lbl">Next action</span>
+              Restart watcher, or wait — the dashboard will re-check every 5s.
+            </div>
+            <div class="sub-line">
+              <span><span class="k">heartbeat</span> <span class="amber">42s ago</span></span>
+              <span><span class="k">restarts</span> <span class="vault">0</span></span>
+              <span><span class="k">proof</span> <span class="amber">stale</span></span>
+            </div>
+          </div>
+        </div>
+
+        <!-- 6 no recent changes -->
+        <div class="gallery-card">
+          <div class="hdr-cap"><h4>06 · No recent changes</h4><span class="chip">informational</span></div>
+          <div class="mini">
+            <div class="title-row"><span class="led" aria-hidden="true"></span><span class="ttl">Vault quiet</span></div>
+            <p class="desc">No vault change detected in the last hour. System is otherwise
+              healthy. This is fine; it is shown so the operator can decide whether the quiet
+              is expected.</p>
+            <div class="next-strip dim">
+              <span class="lbl">Next action</span>
+              No action needed.
+            </div>
+            <div class="sub-line">
+              <span><span class="k">last change</span> <span>62m ago</span></span>
+              <span><span class="k">scope</span> 3 folders</span>
+              <span><span class="k">proof</span> <span class="vault">pass</span></span>
+            </div>
+          </div>
+        </div>
+
+        <!-- 7 write guard active -->
+        <div class="gallery-card">
+          <div class="hdr-cap"><h4>07 · Write guard active</h4><span class="chip gated">policy</span></div>
+          <div class="mini">
+            <div class="title-row"><span class="led gold" aria-hidden="true"></span><span class="ttl">Writes blocked by policy</span></div>
+            <p class="desc">Write guard is denying writes outside <code>journal/</code>. Reason
+              is a deliberate policy <em>focus-mode</em>, not a failure. Eight intents queued.</p>
+            <div class="next-strip">
+              <span class="lbl">Next action</span>
+              Open AI Panel to review queued intents, or lift focus-mode in Settings.
+            </div>
+            <div class="sub-line">
+              <span><span class="k">policy</span> <span class="gold">focus-mode</span></span>
+              <span><span class="k">denials · 24h</span> <span class="amber">8</span></span>
+              <span><span class="k">canvas writes</span> 0</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- 8 proof not yet run -->
+        <div class="gallery-card">
+          <div class="hdr-cap"><h4>08 · Proof not yet run</h4><span class="chip">unknown</span></div>
+          <div class="mini">
+            <div class="title-row"><span class="led dim" aria-hidden="true"></span><span class="ttl">Runtime proof · not run</span></div>
+            <p class="desc">Runtime is up and looks healthy by individual cards, but a proof
+              receipt has not been produced this session. The dashboard does not infer green.</p>
+            <div class="next-strip">
+              <span class="lbl">Next action</span>
+              Run the proof now to produce a receipt.
+            </div>
+            <div class="sub-line">
+              <span><span class="k">last receipt</span> <span class="dim">none this session</span></span>
+              <span><span class="k">prior</span> 2026-05-13 · pass</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- 9 proof failed -->
+        <div class="gallery-card">
+          <div class="hdr-cap"><h4>09 · Proof failed</h4><span class="chip danger">actionable</span></div>
+          <div class="mini">
+            <div class="title-row"><span class="led dang" aria-hidden="true"></span><span class="ttl">Runtime proof · FAIL</span></div>
+            <p class="desc">Proof rp-2026-05-14-14-02 failed: outbox commit-and-replay
+              round-trip did not complete within 5s. Two other checks were skipped because they
+              depend on outbox health.</p>
+            <div class="next-strip dang">
+              <span class="lbl">Next action</span>
+              Inspect outbox commit log. Replay the failed fixture. Re-run the proof.
+            </div>
+            <div class="sub-line">
+              <span><span class="k">check</span> <span class="dang">outbox round-trip</span></span>
+              <span><span class="k">skipped</span> <span class="amber">2</span></span>
+              <span><span class="k">receipt</span> rp-…14-02</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============== 07 ============== -->
+    <section class="spec" id="s7">
+      <h2><span class="secnum">07 ·</span>Edge states &amp; checklist</h2>
+      <p class="lede">Per the governance pack checklist (§08 of that pack).</p>
+
+      <table class="spec">
+        <thead><tr><th>Edge</th><th>Designed behavior</th><th>Notes</th></tr></thead>
+        <tbody>
+          <tr><td>Empty</td><td>Cards still render with their zero-state row values; banner says <em>Awaiting first poll</em>.</td><td>Distinct from <em>Loading</em>.</td></tr>
+          <tr><td>Loading</td><td>Card values render as mono ellipses; LEDs are dim (fg-3). Banner says <em>Loading…</em>; refresh button is disabled.</td><td>No skeleton animation; the static dim state is the loading state.</td></tr>
+          <tr><td>Degraded</td><td>State 02 above. One or more cards in amber. Banner amber LED. Next action names the affected card.</td><td>Never red unless at least one subsystem is in a hard-fail state.</td></tr>
+          <tr><td>Blocked</td><td>State 07 above. Gold LED on write-guard card; banner says <em>Writes blocked by policy</em>.</td><td>"Blocked by policy" is not "blocked by failure". Distinct copy.</td></tr>
+          <tr><td>Stale context</td><td>The "last proof" timestamp grays out if older than 24h; banner sub-line says <em>Proof receipt is stale</em>.</td><td>Stale ≠ failed.</td></tr>
+          <tr><td>Missing provenance</td><td>A card with no source value renders <em>—</em> and a tooltip <em>Source not connected</em>; never green.</td><td>Cards never invent values to avoid an empty row.</td></tr>
+          <tr><td>Write-guard denial</td><td>Card shows the denial count and the most recent denial reason; banner unaffected unless denial count crosses threshold.</td><td>Denials are normal events, not alarms.</td></tr>
+          <tr><td>Reduced motion</td><td>LED pulse and queued-receipt dot animation respect <code>prefers-reduced-motion</code>: animations replaced with static color.</td><td>Sparkline bars are static; no animation to disable.</td></tr>
+          <tr><td>Narrow / mobile</td><td>4-column grid collapses to 2 columns &lt; 900px and to 1 column &lt; 560px. Banner stacks. Next-action strip becomes a sticky bottom card.</td><td>Card order is preserved. Watcher and Worker are always above the fold.</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <!-- ============== 08 ============== -->
+    <section class="spec" id="s8">
+      <h2><span class="secnum">08 ·</span>Implementation contract</h2>
+      <p class="lede">
+        The UI consumes a runtime-state snapshot. It does not derive subsystem health; the
+        snapshot's <code>posture</code> field is authoritative.
+      </p>
+
+      <h3>Snapshot shape (target-state)</h3>
+      <pre class="code"><span class="c">// Illustrative — exact field names owned by runtime-proof spec, not this design.</span>
+{
+  <span class="k">"polled_at"</span>: <span class="s">"2026-05-14T14:08:32Z"</span>,
+  <span class="k">"overall"</span>: { <span class="k">"posture"</span>: <span class="s">"healthy | degraded | blocked | unknown | proof-pending"</span>,
+               <span class="k">"summary"</span>: <span class="s">"…"</span> },
+  <span class="k">"watcher"</span>: { <span class="k">"posture"</span>: <span class="s">"running | stopped | restarting | unknown"</span>,
+               <span class="k">"last_heartbeat_ms"</span>: 2100,
+               <span class="k">"scope_glob"</span>: <span class="s">"**/*.md"</span>,
+               <span class="k">"tick_5m"</span>: 312, <span class="k">"changed_5m"</span>: 18,
+               <span class="k">"restarts_24h"</span>: 0, <span class="k">"oom_evidence"</span>: <span class="n">false</span> },
+  <span class="k">"worker"</span>: { <span class="k">"posture"</span>: <span class="s">"running | backlogged | poisoned | stopped"</span>,
+              <span class="k">"queue_depth"</span>: 0,
+              <span class="k">"last_processed_ms"</span>: 12000,
+              <span class="k">"poison_24h"</span>: 0,
+              <span class="k">"dead_letter_total"</span>: 0,
+              <span class="k">"processed_per_minute"</span>: [<span class="c">…24 values…</span>] },
+  <span class="k">"outbox"</span>: { <span class="k">"posture"</span>: <span class="s">"draining | backlogged | stalled"</span>,
+              <span class="k">"pending"</span>: 3, <span class="k">"delivered_24h"</span>: 2184,
+              <span class="k">"failed_24h"</span>: 0, <span class="k">"dead_lettered_total"</span>: 0,
+              <span class="k">"oldest_pending_ms"</span>: 800 },
+  <span class="k">"vault"</span>: { <span class="k">"name"</span>: <span class="s">"main"</span>, <span class="k">"path"</span>: <span class="s">"~/vault-main"</span>,
+             <span class="k">"scoped_folders"</span>: 3, <span class="k">"last_change_ms"</span>: 42000,
+             <span class="k">"notes_indexed"</span>: 4812, <span class="k">"schema_version"</span>: <span class="s">"v6.0"</span> },
+  <span class="k">"write_guard"</span>: { <span class="k">"posture"</span>: <span class="s">"allowed | denied | mixed"</span>,
+                   <span class="k">"policy"</span>: <span class="s">"default"</span>,
+                   <span class="k">"denials_24h"</span>: 0,
+                   <span class="k">"queued_governance"</span>: 1,
+                   <span class="k">"canvas_writes_24h"</span>: 14 },
+  <span class="k">"last_proof"</span>: { <span class="k">"posture"</span>: <span class="s">"pass | fail | not-run"</span>,
+                  <span class="k">"receipt_id"</span>: <span class="s">"rp-2026-05-14-09-14"</span>,
+                  <span class="k">"ran_at"</span>: <span class="s">"2026-05-14T09:14:00Z"</span>,
+                  <span class="k">"checks"</span>: [
+                    { <span class="k">"name"</span>: <span class="s">"watcher_heartbeat"</span>, <span class="k">"result"</span>: <span class="s">"pass"</span>, <span class="k">"at"</span>: <span class="s">"…"</span> }
+                  ] },
+  <span class="k">"suggested_next_action"</span>: { <span class="k">"kind"</span>: <span class="s">"none | inspect | restart | replay | rebuild | run-proof | open-panel"</span>,
+                            <span class="k">"copy"</span>: <span class="s">"…"</span>,
+                            <span class="k">"intents"</span>: [<span class="c">…</span>] }
+}</pre>
+
+      <h3>Intents emitted by the dashboard</h3>
+      <table class="spec">
+        <thead><tr><th class="mono">data-intent</th><th>Effect</th><th>Authority</th></tr></thead>
+        <tbody>
+          <tr><td class="mono">dashboard.refresh</td><td>Re-poll snapshot</td><td>read-only</td></tr>
+          <tr><td class="mono">proof.run-now</td><td>Trigger a runtime proof run</td><td>explicit user click; emits a governed run-request</td></tr>
+          <tr><td class="mono">watcher.restart</td><td>Request watcher restart</td><td>explicit user click; routed through governed pipeline</td></tr>
+          <tr><td class="mono">outbox.replay-dlq</td><td>Replay dead-lettered event</td><td>explicit user click; per-event confirmation</td></tr>
+          <tr><td class="mono">index.rebuild</td><td>Request scoped index rebuild</td><td>explicit user click; routed; confirmed</td></tr>
+          <tr><td class="mono">panel.open-receipt</td><td>Hand off to AI Panel anchored on receipt id</td><td>navigation only</td></tr>
+          <tr><td class="mono">vault.open-event</td><td>Open the offending event in the outbox view</td><td>navigation only</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Data attributes on the dashboard root</h3>
+      <pre class="code">&lt;section
+  data-testid=<span class="s">"runtime-dashboard"</span>
+  data-overall-posture=<span class="s">"healthy | degraded | blocked | unknown | proof-pending"</span>
+  data-proof-posture=<span class="s">"pass | fail | not-run"</span>
+  data-write-guard=<span class="s">"allowed | denied | mixed"</span>
+  data-polled-at=<span class="s">"&lt;ISO ts&gt;"</span>&gt;</pre>
+
+      <div class="callout">
+        <span class="callout-label">UI never derives posture</span>
+        The UI does not compute <code>overall.posture</code> from card values. The snapshot
+        declares it. This avoids the UI and the runtime quietly disagreeing about what counts
+        as healthy.
+      </div>
+    </section>
+
+    <!-- ============== 09 ============== -->
+    <section class="spec" id="s9">
+      <h2><span class="secnum">09 ·</span>Authority boundaries</h2>
+
+      <div class="callout invariant">
+        <span class="callout-label">Invariant · Mirror, not control plane</span>
+        The dashboard is a mirror of runtime state. Every write-shaped affordance routes through
+        the existing governed pipeline. The dashboard never auto-repairs. The dashboard never
+        derives a posture the runtime did not declare.
+      </div>
+
+      <table class="spec">
+        <thead>
+          <tr><th>Concern</th><th>May influence</th><th>May propose</th><th>May not decide</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Card layout, copy, LED palette</td><td class="yes">YES</td><td class="maybe">—</td><td class="no">—</td></tr>
+          <tr><td>Card inventory (which 8 cards)</td><td class="maybe">subset</td><td class="yes">propose to owner-doc</td><td class="no">cannot promote</td></tr>
+          <tr><td>Snapshot field names</td><td class="no">—</td><td class="yes">propose to runtime-proof spec</td><td class="no">cannot declare</td></tr>
+          <tr><td>Suggested-next-action vocabulary</td><td class="maybe">copy only</td><td class="yes">propose <code>kind</code> additions</td><td class="no">cannot define remediation behavior</td></tr>
+          <tr><td>Posture algorithm</td><td class="no">—</td><td class="no">—</td><td class="no">runtime owns; UI renders</td></tr>
+          <tr><td>Receipt schema</td><td class="no">—</td><td class="no">—</td><td class="no">runtime-proof contract owns</td></tr>
+          <tr><td>Refresh / poll interval</td><td class="maybe">UX recommendation</td><td class="maybe">propose default</td><td class="no">runtime owns</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <!-- ============== 10 ============== -->
+    <section class="spec" id="s10">
+      <h2><span class="secnum">10 ·</span>Open questions</h2>
+      <ol>
+        <li><strong>Polling vs push.</strong> The snapshot model assumes a poll. If runtime pushes,
+          the <em>polled_at</em> banner field becomes <em>received_at</em> and the refresh button
+          becomes "subscribe / unsubscribe". Either is acceptable to the design.</li>
+        <li><strong>Single vault scope.</strong> The design assumes one active vault per
+          dashboard. Multi-vault would need a vault switcher in the top bar; we have not designed
+          it because the product is single-operator-local.</li>
+        <li><strong>Proof-run confirmation.</strong> "Run proof now" — should it confirm? We
+          suggest no confirmation; proof runs are idempotent and free. Owner-doc decides.</li>
+        <li><strong>Agent card scope.</strong> Should the agent card list every agent (Hugin,
+          Munin, future Deep Agent) or only those with active sessions? Suggest: active sessions
+          and 0-state when none.</li>
+        <li><strong>What does "blocked" mean in the banner?</strong> We use it for policy-blocked
+          writes; we also need a name for "writes denied by failure". Suggest: <em>Running ·
+          writes refused</em> for the failure case, <em>Running · focus-mode</em> for the
+          policy case.</li>
+        <li><strong>How long does the proof history bar span?</strong> 14d, 30d, sliding? We
+          suggest 14d as the default; longer ranges live in an inspector linked from the receipt.</li>
+      </ol>
+    </section>
+
+    <!-- ============== 11 ============== -->
+    <section class="spec" id="s11">
+      <h2><span class="secnum">11 ·</span>Handoff notes for Claude Code / Codex</h2>
+
+      <h3>Likely normalized spec</h3>
+      <ul>
+        <li>New doc: <code>docs/RUNTIME_PROOF_DASHBOARD.md</code> — UI guidance only, target-state.</li>
+        <li>References: existing <em>runtime proof receipt</em> contract (when it lands),
+          <code>STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md</code>, panel locality for receipts.</li>
+      </ul>
+
+      <h3>Likely follow-on issues</h3>
+      <ul>
+        <li><em>Render the dashboard against a fixture snapshot.</em> Acceptance: dashboard
+          renders nine designed states from nine fixture snapshots without dynamic state.</li>
+        <li><em>Wire <code>proof.run-now</code> to the proof runner.</em> Acceptance: clicking
+          emits a governed run-request and the receipt id appears in the proof card on completion.</li>
+        <li><em>Wire <code>outbox.replay-dlq</code>.</em> Acceptance: a per-event confirm dialog
+          appears; replay routes through governance; receipt visible in the governance card.</li>
+        <li><em>Reduced-motion path.</em> Acceptance: with the OS pref set, no element animates.</li>
+        <li><em>Narrow layout.</em> Acceptance: 2-col and 1-col layouts preserve card order; the
+          next-action strip becomes a sticky bottom bar.</li>
+      </ul>
+
+      <h3>What this design must not feed</h3>
+      <ul>
+        <li>Auto-remediation. Every action is the operator's explicit click.</li>
+        <li>An ops-style alert channel. The dashboard does not page; it shows.</li>
+        <li>A definition of <em>healthy</em>. Runtime declares it; UI renders it.</li>
+      </ul>
+
+      <div class="callout vault">
+        <span class="callout-label">Validation expectation</span>
+        Passing receipt: dashboard renders all nine states from fixture snapshots; intents emit
+        through the governed pipeline; no UI-derived posture; reduced-motion respected; narrow
+        layout passes. Receipt id recorded in this package's status field.
+      </div>
+    </section>
+
+  </main>
+</div>
+</body>
+</html>

--- a/companion-ui/design_handoff/2026-05-14-runtime-proof-dashboard/spec_chrome.css
+++ b/companion-ui/design_handoff/2026-05-14-runtime-proof-dashboard/spec_chrome.css
@@ -1,0 +1,423 @@
+/* ============================================================
+   Yggdrasil Design Handoff — Shared Spec Chrome
+   ============================================================
+   Page layout, TOC, sections, tables, callouts, chips, code,
+   gallery cards. Imported by each prototype.html after
+   colors_and_type.css.
+   ============================================================ */
+
+html, body { background: var(--bg-base); }
+body {
+  background-image:
+    linear-gradient(rgba(0,212,232,0.022) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0,212,232,0.022) 1px, transparent 1px);
+  background-size: 48px 48px;
+}
+
+.page {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: var(--space-12) var(--space-8) var(--space-16);
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: var(--space-12);
+}
+
+/* ---- Sidebar TOC ---- */
+.toc {
+  position: sticky;
+  top: var(--space-8);
+  align-self: start;
+  font-size: var(--text-sm);
+  border-left: 1px solid var(--border);
+  padding-left: var(--space-4);
+  max-height: calc(100vh - var(--space-12));
+  overflow-y: auto;
+}
+.toc-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  margin-bottom: var(--space-3);
+}
+.toc ol { list-style: none; display: flex; flex-direction: column; gap: 6px; }
+.toc a {
+  color: var(--fg-2);
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  display: block;
+  line-height: 1.4;
+}
+.toc a:hover { color: var(--cyan); text-decoration: none; }
+.toc-num {
+  font-family: var(--font-mono);
+  color: var(--fg-3);
+  margin-right: 6px;
+  font-size: var(--text-xs);
+}
+
+/* ---- Header ---- */
+.doc-header {
+  border-bottom: 1px solid var(--border);
+  padding-bottom: var(--space-6);
+  margin-bottom: var(--space-10);
+}
+.doc-eyebrow {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--cyan);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  margin-bottom: var(--space-3);
+}
+.doc-title {
+  font-family: var(--font-display);
+  font-size: var(--text-3xl);
+  line-height: 1.1;
+  margin-bottom: var(--space-4);
+  color: var(--fg-1);
+}
+.doc-lede {
+  color: var(--fg-2);
+  font-size: var(--text-md);
+  max-width: 70ch;
+  margin-bottom: var(--space-5);
+  line-height: var(--leading-snug);
+}
+.doc-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4) var(--space-6);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+}
+.doc-meta span strong {
+  color: var(--fg-2);
+  font-weight: var(--weight-regular);
+  margin-right: 6px;
+}
+
+/* ---- Sections ---- */
+section.spec {
+  margin-bottom: var(--space-12);
+  scroll-margin-top: var(--space-6);
+}
+section.spec > h2 {
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-regular);
+  color: var(--fg-1);
+  margin-bottom: var(--space-2);
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+}
+section.spec > h2 .secnum {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--cyan);
+  letter-spacing: var(--tracking-wide);
+}
+section.spec > .lede {
+  color: var(--fg-2);
+  font-size: var(--text-base);
+  margin-bottom: var(--space-5);
+  max-width: 72ch;
+}
+section.spec h3 {
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--fg-1);
+  margin: var(--space-6) 0 var(--space-3);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+}
+section.spec p {
+  color: var(--fg-1);
+  margin-bottom: var(--space-3);
+  max-width: 72ch;
+}
+section.spec ul, section.spec ol {
+  color: var(--fg-1);
+  margin: 0 0 var(--space-4) var(--space-5);
+  max-width: 72ch;
+}
+section.spec li { margin-bottom: 6px; line-height: 1.55; }
+
+/* ---- Tables ---- */
+table.spec {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+  margin: var(--space-3) 0 var(--space-5);
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+}
+table.spec th, table.spec td {
+  text-align: left;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+table.spec th {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--fg-2);
+  background: var(--bg-raised);
+  font-weight: var(--weight-medium);
+  border-bottom: 1px solid var(--border-strong);
+}
+table.spec tr:last-child td { border-bottom: none; }
+table.spec td code { font-size: 0.9em; }
+table.spec td.mono, table.spec th.mono { font-family: var(--font-mono); }
+table.spec td.yes { color: var(--vault); font-family: var(--font-mono); font-size: var(--text-xs); }
+table.spec td.no { color: var(--destructive); font-family: var(--font-mono); font-size: var(--text-xs); }
+table.spec td.maybe { color: var(--amber); font-family: var(--font-mono); font-size: var(--text-xs); }
+
+/* ---- Callouts ---- */
+.callout {
+  border-left: 2px solid var(--cyan);
+  background: rgba(0,212,232,0.04);
+  padding: var(--space-3) var(--space-4);
+  margin: var(--space-4) 0;
+  font-size: var(--text-sm);
+  color: var(--fg-1);
+  max-width: 72ch;
+}
+.callout.warn { border-left-color: var(--amber); background: rgba(240,144,48,0.05); }
+.callout.invariant { border-left-color: var(--accent); background: rgba(212,168,67,0.04); }
+.callout.danger { border-left-color: var(--destructive); background: rgba(255,61,61,0.04); }
+.callout.vault { border-left-color: var(--vault); background: rgba(57,232,125,0.04); }
+.callout-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--cyan);
+  display: block;
+  margin-bottom: 4px;
+}
+.callout.warn .callout-label { color: var(--amber); }
+.callout.invariant .callout-label { color: var(--accent); }
+.callout.danger .callout-label { color: var(--destructive); }
+.callout.vault .callout-label { color: var(--vault); }
+
+/* ---- Tag chips ---- */
+.chip {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wide);
+  padding: 1px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-raised);
+  color: var(--fg-2);
+}
+.chip.design  { color: var(--cyan); border-color: rgba(0,212,232,0.3); }
+.chip.impl    { color: var(--accent); border-color: rgba(212,168,67,0.3); }
+.chip.gated   { color: var(--amber); border-color: rgba(240,144,48,0.3); }
+.chip.agent   { color: var(--agent); border-color: rgba(74,158,255,0.3); }
+.chip.vault   { color: var(--vault); border-color: rgba(57,232,125,0.3); }
+.chip.danger  { color: var(--destructive); border-color: rgba(255,61,61,0.3); }
+
+/* ---- Code blocks ---- */
+pre.code {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--fg-1);
+  overflow-x: auto;
+  margin: var(--space-3) 0 var(--space-5);
+  line-height: 1.55;
+}
+pre.code .k { color: var(--cyan); }
+pre.code .s { color: var(--vault); }
+pre.code .c { color: var(--fg-3); font-style: italic; }
+pre.code .n { color: var(--accent); }
+pre.code .a { color: var(--agent); }
+
+/* ---- Gallery ---- */
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--space-5);
+  margin: var(--space-4) 0 var(--space-6);
+}
+.gallery.three { grid-template-columns: repeat(3, 1fr); }
+.gallery-card {
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  min-height: 240px;
+}
+.gallery-card header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  border-bottom: 1px dashed var(--border);
+  padding-bottom: 10px;
+}
+.gallery-card h4 {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--fg-2);
+}
+.gallery-card .note {
+  font-size: var(--text-sm);
+  color: var(--fg-2);
+  margin: 0;
+}
+
+/* ---- Receipt pill ---- */
+.receipt {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  border-radius: var(--radius-full);
+  background: var(--bg-raised);
+  border: 1px solid var(--border-strong);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-2);
+  letter-spacing: var(--tracking-wide);
+}
+.receipt.queued  { color: var(--accent); border-color: rgba(212,168,67,0.4); }
+.receipt.applied { color: var(--vault); border-color: rgba(57,232,125,0.4); }
+.receipt.pending { color: var(--amber); border-color: rgba(240,144,48,0.4); }
+.receipt.failed  { color: var(--destructive); border-color: rgba(255,61,61,0.4); }
+.receipt .recdot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 6px currentColor;
+}
+.receipt.queued .recdot { animation: pulse 1.6s ease-in-out infinite; }
+.receipt.pending .recdot { animation: pulse 1.6s ease-in-out infinite; }
+@keyframes pulse { 0%, 100% { opacity: 0.4; } 50% { opacity: 1; } }
+
+/* ---- Buttons ---- */
+.btn {
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  padding: 5px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-raised);
+  color: var(--fg-1);
+  border: 1px solid var(--border-strong);
+  cursor: pointer;
+}
+.btn:hover { border-color: var(--cyan); color: var(--cyan); }
+.btn.primary {
+  background: var(--amber-muted);
+  color: var(--amber);
+  border-color: rgba(240,144,48,0.5);
+}
+.btn.primary:hover { background: rgba(240,144,48,0.12); border-color: var(--amber); color: var(--amber); }
+.btn.governance {
+  background: rgba(212,168,67,0.06);
+  color: var(--accent);
+  border-color: rgba(212,168,67,0.5);
+}
+.btn.governance:hover { background: rgba(212,168,67,0.12); border-color: var(--accent); }
+.btn.vault {
+  background: rgba(57,232,125,0.06);
+  color: var(--vault);
+  border-color: rgba(57,232,125,0.4);
+}
+.btn.vault:hover { background: rgba(57,232,125,0.12); border-color: var(--vault); }
+.btn.danger {
+  background: rgba(255,61,61,0.05);
+  color: var(--destructive);
+  border-color: rgba(255,61,61,0.4);
+}
+.btn.ghost { background: transparent; }
+.btn[disabled], .btn.disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.btn .kbd {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  color: var(--fg-3);
+  margin-left: 6px;
+}
+
+/* ---- Bullet list with mono prefix (for checklists) ---- */
+ul.check {
+  list-style: none;
+  margin-left: 0 !important;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+ul.check li {
+  position: relative;
+  padding-left: 22px;
+  font-size: var(--text-sm);
+}
+ul.check li::before {
+  content: '[ ]';
+  position: absolute;
+  left: 0;
+  top: 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  letter-spacing: 0;
+}
+ul.check li.done::before { content: '[x]'; color: var(--vault); }
+ul.check li.skip::before { content: '[-]'; color: var(--amber); }
+
+/* ---- Doc-template card (for handoff templates) ---- */
+.template {
+  border: 1px solid var(--border-strong);
+  background: var(--bg-surface);
+  border-radius: var(--radius-md);
+  padding: var(--space-4) var(--space-5);
+  margin: var(--space-4) 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--fg-1);
+  white-space: pre-wrap;
+  line-height: 1.65;
+  overflow-x: auto;
+}
+.template .h { color: var(--cyan); }
+.template .v { color: var(--vault); }
+.template .g { color: var(--accent); }
+.template .c { color: var(--fg-3); font-style: italic; }
+.template .a { color: var(--agent); }
+
+/* ---- Responsive ---- */
+@media (max-width: 900px) {
+  .page { grid-template-columns: 1fr; padding: var(--space-6) var(--space-4); }
+  .toc {
+    position: static;
+    max-height: none;
+    border-left: none;
+    border-bottom: 1px solid var(--border);
+    padding: 0 0 var(--space-4);
+  }
+  .gallery, .gallery.three { grid-template-columns: 1fr; }
+}

--- a/companion-ui/design_handoff/2026-05-14-runtime-proof-dashboard/state-gallery.md
+++ b/companion-ui/design_handoff/2026-05-14-runtime-proof-dashboard/state-gallery.md
@@ -1,0 +1,37 @@
+# State gallery — Runtime Proof / Health Dashboard
+
+The full visual gallery lives in **`prototype.html` §05**. This document is a text mirror
+intended for quick scanning in code review and for issue acceptance criteria.
+
+Every state is described as a (name, when, designed behavior) triple. The prototype is the
+authority on the visual; this document is the authority on the state list.
+
+See `prototype.html` §03 for the dashboard prototype, §04 for the section design, §05 for the 9-state gallery.
+
+## State list
+
+See the gallery cards in `prototype.html` §05 for the canonical visuals. Each state in the
+gallery includes:
+
+- A bar with the state name and a state-kind chip.
+- A title-row LED in the appropriate colour (vault / amber / destructive / dim / gold).
+- A one-paragraph narrative describing the state.
+- A meta line of mono captions naming the values that distinguish the state.
+- Where relevant, a next-action strip with the suggested operator action.
+
+## Transition table (illustrative)
+
+Detailed transitions for the UI state machine are owned by `implementation-contracts.md`;
+this gallery is descriptive, not normative. Implementation must enumerate the full set
+declared in the contract document.
+
+## Edge cases the gallery covers
+
+- **Empty** — the surface explains why there is nothing and what produces content.
+- **Loading** — inert, distinguishable from empty.
+- **Degraded** — partial function with explicit naming of what is degraded.
+- **Blocked** — refusal is named, recorded, and never silently retried.
+- **Stale** — staleness is shown with a "why" and an explicit threshold.
+- **Missing provenance** — surfaced, not hidden; never silently authoritative.
+
+For the full edge-state checklist see `edge-states.md`.

--- a/companion-ui/design_handoff/2026-05-14-vault-action-layer/README.md
+++ b/companion-ui/design_handoff/2026-05-14-vault-action-layer/README.md
@@ -1,0 +1,60 @@
+# Vault Action Layer / Agent Tool Authority
+
+**Date:** 2026-05-14
+**Status:** Design handoff · v1 · ready for review at crossing B
+**Authority:** Visual + structural guidance — proposes a tool-authority taxonomy
+**Owner-docs target:** `docs/CONCEPTS/VAULT_ACTION_LAYER_CONTRACT.md` (to be authored), `docs/INTERACTION_SURFACES_AND_AUTHORITY/`
+**Linked issue:** #910 — Tool authority taxonomy
+**Crossing target:** B
+
+## What this is
+
+Agents do not get raw filesystem powers. They get bounded, governed capabilities — named,
+classified, gated, and receipted. This package designs the contract between Panel-style
+agent instructions ("move this Inbox note to Workbench") and actual vault mutation.
+
+It defines:
+
+- a **9-step action pipeline** every vault mutation must pass through (intent → classify →
+  bound → policy → guard → idempotency → execute → receipt → event),
+- a **five-tier tool authority taxonomy** (read-only, proposal, bounded write,
+  governance-bearing, forbidden),
+- an explicit **Obsidian / MCP boundary** — adapter, not authority,
+- a **concrete first action** designed end to end: `move_inbox_note_to_workbench`,
+- **eight designed states**: allowed, denied (source), denied (destination), write-guard
+  block, idempotent no-op, collision-resolved, success-with-receipt, receipt-inspection.
+
+See `prototype.html` §02 for the pipeline diagram, §03 for the tier matrix, §04 for the
+Obsidian/MCP boundary, §05 for the live action prototype, §06 for the state gallery.
+
+## Influence
+
+- **May influence:** tier names and ordering, pipeline-step naming, UI for action invocation
+  and trace, receipt presentation, copy distinguishing refusal classes.
+- **May not decide:** the registry contents, classifier semantics, policy / write-guard
+  algorithms, idempotency key shape, collision-rule taxonomy, receipt schema.
+
+## Files
+
+- `prototype.html` — 11-section spec, 9-step pipeline, tier matrix, action prototype,
+  8-state gallery.
+- `design-notes.md`, `state-gallery.md`, `implementation-contracts.md`,
+  `authority-boundaries.md`, `edge-states.md`, `open-questions.md`.
+
+## Related
+
+- Issue **#910** — the trigger.
+- `docs/INTERACTION_SURFACES_AND_AUTHORITY/STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md` —
+  the invariant the pipeline enforces.
+- Sibling 2026-05-14 packages — this design depends on the
+  Handoff Governance Pack's folder shape; receipts produced here are visible in the
+  Runtime Proof Dashboard; promotion-to-action is the read-mode complement to
+  Memory Candidate Review's promote-to-note.
+
+## Disclaimers
+
+- Design exploration is not architecture authority.
+- Runtime truth lives in shipped code, tests, status docs, and validation receipts.
+- This package proposes the taxonomy and the pipeline shape; promotion to an owner-doc is a
+  separate decision.
+- The gated-execution invariant is honored throughout.

--- a/companion-ui/design_handoff/2026-05-14-vault-action-layer/authority-boundaries.md
+++ b/companion-ui/design_handoff/2026-05-14-vault-action-layer/authority-boundaries.md
@@ -1,0 +1,43 @@
+# Authority boundaries — Vault Action Layer
+
+## This design is
+
+- Visual + structural guidance for the agent tool authority surface.
+- A proposal for the **5-tier taxonomy** and the **9-step pipeline**.
+- A target-state interaction contract for the UI surface that renders action invocation
+  and trace.
+
+## This design is not
+
+- Architecture authority. Authority lives in (to be authored)
+  `docs/CONCEPTS/VAULT_ACTION_LAYER_CONTRACT.md` and the registry it points at.
+- Runtime truth. Runtime truth lives in shipped code, tests, status docs, and validation
+  receipts.
+- A schema. The contract references fields the runtime exposes; it does not declare them.
+- A claim about current runtime behavior.
+
+## Invariants this design honors
+
+- **Gated execution.** Every action passes the full 9-step pipeline. No step is optional.
+- **Bounded actions, not raw primitives.** Tier 4 is empty. Agents act only through
+  registry entries.
+- **Adapter, not authority.** Obsidian and MCP may implement bounded actions; they may not
+  bypass policy, write guard, idempotency, or receipts.
+- **Refusal is first-class.** Every refusal produces a receipt with the refusing step
+  named.
+- **Authority separation.** Panel issues instructions; the classifier is server-side; the
+  UI never re-classifies.
+
+## What this design may suggest to owner-docs
+
+- A new `VAULT_ACTION_LAYER_CONTRACT.md` owner-doc.
+- A taxonomy entry in `INTERACTION_SURFACES_AND_AUTHORITY/`.
+- Reference from `STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md` to the pipeline as the
+  enforcement surface.
+
+## What this design must not suggest
+
+- Loosening the gated-execution invariant for any step.
+- Tier-elevation at runtime.
+- Obsidian or MCP as the primary mutation surface.
+- Generic agent "tools" library decoupled from the registry.

--- a/companion-ui/design_handoff/2026-05-14-vault-action-layer/colors_and_type.css
+++ b/companion-ui/design_handoff/2026-05-14-vault-action-layer/colors_and_type.css
@@ -1,0 +1,346 @@
+/* ============================================================
+   Yggdrasil Design System — Colors & Type
+   ============================================================
+   Import this file in any HTML artifact or UI kit.
+   Google Fonts are imported below; JetBrains Mono via bunny.net.
+   ============================================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Space+Grotesk:wght@300;400;500;600&display=swap');
+@import url('https://fonts.bunny.net/css?family=jetbrains-mono:400,500&display=swap');
+
+/* ============================================================
+   BASE COLOR TOKENS
+   ============================================================ */
+:root {
+  /* --- Backgrounds (cool blue-black — Tron grid) --- */
+  --bg-base:       #070b12;   /* deepest — page root, near black with blue cast */
+  --bg-surface:    #0c1220;   /* panels, sidebars */
+  --bg-raised:     #111a2e;   /* cards, inputs, raised surfaces */
+  --bg-overlay:    #162038;   /* hover states, popovers */
+  --bg-modal:      #0e1828;   /* modal / dialog backdrop content */
+
+  /* --- Foreground / Text --- */
+  --fg-1:          #dce8f0;   /* primary — cool blue-white */
+  --fg-2:          #7a9ab8;   /* secondary / muted */
+  --fg-3:          #3d5570;   /* tertiary / disabled / dim */
+  --fg-inverse:    #070b12;   /* text on light/accent backgrounds */
+
+  /* --- Borders (thin, slightly glowing) --- */
+  --border:        #152030;   /* default — subtle grid line */
+  --border-strong: #1e3050;   /* emphasis — dividers, active edges */
+  --border-focus:  #00d4e8;   /* focus ring — electric cyan */
+
+  /* --- Accent 1: Norse Gold (slightly electrified) --- */
+  --accent:        #d4a843;   /* primary accent — active, focus, key affordances */
+  --accent-dim:    #80621a;   /* dimmed gold */
+  --accent-muted:  #2a1e06;   /* gold at low opacity */
+
+  /* --- Accent 2: Tron Cyan (neon electric) --- */
+  --cyan:          #00d4e8;   /* electric cyan — Tron primary glow */
+  --cyan-dim:      #007a8a;   /* dimmed cyan */
+  --cyan-muted:    #001e28;   /* cyan tint background */
+  --cyan-glow:     0 0 12px rgba(0,212,232,0.35), 0 0 4px rgba(0,212,232,0.5);
+
+  /* --- Vault: Neon green (digital growth) --- */
+  --vault:         #39e87d;   /* vault-connected — electric green */
+  --vault-dim:     #1a7840;   /* vault hover */
+  --vault-muted:   #041a10;   /* vault background tint */
+  --vault-glow:    0 0 8px rgba(57,232,125,0.3);
+
+  /* --- Agent: Electric blue (machine voice) --- */
+  --agent:         #4a9eff;   /* agent-contributed UI and content */
+  --agent-dim:     #1e5a9a;   /* agent hover */
+  --agent-muted:   #051228;   /* agent background tint */
+  --agent-glow:    0 0 8px rgba(74,158,255,0.3);
+
+  /* --- Amber (staged / uncommitted) --- */
+  --amber:         #f09030;   /* warnings, uncommitted/staged state */
+  --amber-dim:     #805010;
+  --amber-muted:   #1a0e02;
+
+  /* --- Destructive --- */
+  --destructive:      #ff3d3d;
+  --destructive-dim:  #8a1a1a;
+  --destructive-muted:#160404;
+
+  /* --- Semantic UI colors --- */
+  --color-bg:        var(--bg-base);
+  --color-surface:   var(--bg-surface);
+  --color-text:      var(--fg-1);
+  --color-muted:     var(--fg-2);
+  --color-dim:       var(--fg-3);
+  --color-border:    var(--border);
+  --color-accent:    var(--accent);
+
+  /* ============================================================
+     TYPOGRAPHY
+     ============================================================ */
+
+  /* --- Font families --- */
+  --font-display:  'EB Garamond', Georgia, serif;
+  --font-ui:       'Space Grotesk', system-ui, sans-serif;
+  --font-mono:     'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+
+  /* --- Type scale (rem, base 16px) --- */
+  --text-xs:    0.6875rem;   /* 11px — metadata, timestamps */
+  --text-sm:    0.8125rem;   /* 13px — secondary labels, captions */
+  --text-base:  0.9375rem;   /* 15px — body / default UI */
+  --text-md:    1.0625rem;   /* 17px — slightly emphasized body */
+  --text-lg:    1.1875rem;   /* 19px — section headers */
+  --text-xl:    1.5rem;      /* 24px — page titles */
+  --text-2xl:   2rem;        /* 32px — display moments */
+  --text-3xl:   2.75rem;     /* 44px — wordmark / hero */
+  --text-4xl:   3.75rem;     /* 60px — large display */
+
+  /* --- Line heights --- */
+  --leading-tight:  1.25;
+  --leading-snug:   1.4;
+  --leading-normal: 1.55;
+  --leading-loose:  1.75;
+
+  /* --- Font weights --- */
+  --weight-light:   300;
+  --weight-regular: 400;
+  --weight-medium:  500;
+  --weight-semibold:600;
+
+  /* --- Letter spacing --- */
+  --tracking-tight: -0.02em;
+  --tracking-normal: 0em;
+  --tracking-wide:   0.04em;
+  --tracking-wider:  0.08em;
+
+  /* ============================================================
+     SPACING
+     ============================================================ */
+  --space-1:   4px;
+  --space-2:   8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  20px;
+  --space-6:  24px;
+  --space-8:  32px;
+  --space-10: 40px;
+  --space-12: 48px;
+  --space-16: 64px;
+
+  /* ============================================================
+     BORDER RADIUS — sharper for cyberpunk aesthetic
+     ============================================================ */
+  --radius-sm:   2px;
+  --radius-md:   4px;
+  --radius-lg:   6px;
+  --radius-xl:  10px;
+  --radius-full: 9999px;
+
+  /* ============================================================
+     SHADOWS / ELEVATION
+     ============================================================ */
+  --shadow-sm:  0 1px 3px rgba(0,0,0,0.3);
+  --shadow-md:  0 4px 12px rgba(0,0,0,0.4);
+  --shadow-lg:  0 8px 32px rgba(0,0,0,0.5);
+  --shadow-float: 0 4px 24px rgba(0,0,0,0.55), 0 1px 4px rgba(0,0,0,0.3);
+  --shadow-inset: inset 0 1px 3px rgba(0,0,0,0.35);
+
+  /* ============================================================
+     ANIMATION
+     ============================================================ */
+  --ease:        cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-linear: linear;
+  --duration-fast: 100ms;
+  --duration-base: 150ms;
+  --duration-slow: 250ms;
+
+  /* ============================================================
+     Z-INDEX SCALE
+     ============================================================ */
+  --z-base:    1;
+  --z-raised:  10;
+  --z-sticky:  100;
+  --z-overlay: 200;
+  --z-modal:   300;
+  --z-toast:   400;
+}
+
+/* ============================================================
+   SEMANTIC ELEMENT DEFAULTS
+   ============================================================ */
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+body {
+  background-color: var(--bg-base);
+  color: var(--fg-1);
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-normal);
+}
+
+/* --- Display headings (EB Garamond) --- */
+h1, .h1 {
+  font-family: var(--font-display);
+  font-size: var(--text-3xl);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  color: var(--fg-1);
+}
+
+h2, .h2 {
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-regular);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  color: var(--fg-1);
+}
+
+/* --- UI headings (DM Sans) --- */
+h3, .h3 {
+  font-family: var(--font-ui);
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-snug);
+  color: var(--fg-1);
+}
+
+h4, .h4 {
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-snug);
+  color: var(--fg-1);
+}
+
+h5, h6, .h5, .h6 {
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-snug);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--fg-2);
+}
+
+p {
+  font-family: var(--font-ui);
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
+  color: var(--fg-1);
+  text-wrap: pretty;
+}
+
+small, .text-sm {
+  font-size: var(--text-sm);
+  color: var(--fg-2);
+}
+
+.text-xs {
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  font-family: var(--font-mono);
+  letter-spacing: var(--tracking-wide);
+}
+
+code, kbd, pre, .mono {
+  font-family: var(--font-mono);
+  font-size: 0.875em; /* relative to surrounding text */
+}
+
+code {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.1em 0.35em;
+  color: var(--fg-1);
+}
+
+pre {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  overflow-x: auto;
+  font-size: var(--text-sm);
+  line-height: var(--leading-normal);
+  color: var(--fg-1);
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+a:hover {
+  color: var(--fg-1);
+  text-decoration: underline;
+}
+
+hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: var(--space-6) 0;
+}
+
+/* ============================================================
+   UTILITY CLASSES
+   ============================================================ */
+
+/* Text colors */
+.text-primary   { color: var(--fg-1); }
+.text-secondary { color: var(--fg-2); }
+.text-dim       { color: var(--fg-3); }
+.text-accent    { color: var(--accent); }
+.text-cyan      { color: var(--cyan); }
+.text-vault     { color: var(--vault); }
+.text-agent     { color: var(--agent); }
+.text-amber     { color: var(--amber); }
+.text-danger    { color: var(--destructive); }
+
+/* Font families */
+.font-display { font-family: var(--font-display); }
+.font-ui      { font-family: var(--font-ui); }
+.font-mono    { font-family: var(--font-mono); }
+
+/* Weights */
+.weight-light    { font-weight: var(--weight-light); }
+.weight-regular  { font-weight: var(--weight-regular); }
+.weight-medium   { font-weight: var(--weight-medium); }
+.weight-semibold { font-weight: var(--weight-semibold); }
+
+/* Glow effects */
+.glow-cyan   { box-shadow: var(--cyan-glow); }
+.glow-vault  { box-shadow: var(--vault-glow); }
+.glow-agent  { box-shadow: var(--agent-glow); }
+.text-glow-cyan  { text-shadow: 0 0 12px rgba(0,212,232,0.7); }
+.text-glow-gold  { text-shadow: 0 0 16px rgba(212,168,67,0.5); }
+
+/* Tron grid background */
+.grid-bg {
+  background-image:
+    linear-gradient(rgba(0,212,232,0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0,212,232,0.04) 1px, transparent 1px);
+  background-size: 32px 32px;
+}
+
+/* Neon border active state */
+.border-cyan { border-color: var(--cyan) !important; box-shadow: var(--cyan-glow); }
+.border-gold { border-color: var(--accent) !important; box-shadow: 0 0 8px rgba(212,168,67,0.3); }
+
+/* Focus ring */
+:focus-visible {
+  outline: 1px solid var(--cyan);
+  outline-offset: 2px;
+  box-shadow: var(--cyan-glow);
+}

--- a/companion-ui/design_handoff/2026-05-14-vault-action-layer/design-notes.md
+++ b/companion-ui/design_handoff/2026-05-14-vault-action-layer/design-notes.md
@@ -1,0 +1,55 @@
+# Design notes — Vault Action Layer
+
+## Visual language
+
+Inherits the shared Yggdrasil design system. Tier and outcome colours are deliberate:
+
+- **Tier 0 (read-only)** uses **vault green** — safe, ambient, expected.
+- **Tier 1 (proposal)** uses **cyan** — the same colour as receipts in flight; signals
+  "queued for human".
+- **Tier 2 (bounded write)** uses **amber** — staged-but-real, the active surface.
+- **Tier 3 (governance-bearing)** uses **gold** — governance accent, matches Panel receipt vocabulary.
+- **Tier 4 (forbidden)** uses **destructive red** — and the row is intentionally rendered as
+  a non-action; it exists only to make the empty floor explicit.
+
+The 9-step pipeline uses a band of soft borders rather than arrows. The visual contract is
+"all nine steps run in order, every time". Arrows would imply some steps are skippable; the
+contract is that they are not.
+
+## Component vocabulary added by this package
+
+- `.pipe` — the 9-step pipeline strip. Step variants colour-code by stage class
+  (intent / classify / action / policy / guard / idempotency / execute / receipt / event).
+- `.tier-table` — the five-tier matrix with colour-coded tier column.
+- `.action-stage` — the live action sandbox: instruction (left) + resolved-action card +
+  trace stream (right) + receipt strip (bottom).
+- `.trace-line` (variants: `pass` `gate` `deny` `info` `idem`) — the per-step trace
+  entries the operator audits.
+- `.boundary` — two-column "allowed / not allowed" treatment for the Obsidian/MCP section.
+  Vault green vs destructive red to make the boundary unambiguous.
+
+## Why the action prototype is the way it is
+
+- **Instruction is natural language; everything else is structured.** The panel prompt
+  appears verbatim. From step 02 onward, the resolved-action card is mono — a structured
+  record the operator can audit before the trace ever fires.
+- **Trace is the receipt's narrative form.** Each `trace-line` corresponds 1:1 to a step
+  of the pipeline. The receipt object is the durable form; the trace is the readable form
+  of that same data.
+- **Refusal is shape-equal to success.** A denied action's trace pane has the same number of
+  lines as an allowed one, just with a refusal at the refusing step and the later steps
+  absent. The operator does not have to read a different shape to learn what happened.
+
+## Why Obsidian / MCP are deliberately not foregrounded
+
+This is an aesthetic choice, not just a structural one. The vault action layer is a
+contract; Obsidian and MCP are implementations. Rendering them as peer adapters in §04 —
+behind the boundary, not in front of it — keeps the design from making any single
+implementation look canonical.
+
+## Out of scope
+
+- Multi-action atomic transactions.
+- Cross-vault actions (deferred to Tier 3 per §10).
+- Action discovery / autocomplete UI in Panel.
+- A "tools" library decoupled from the registry.

--- a/companion-ui/design_handoff/2026-05-14-vault-action-layer/edge-states.md
+++ b/companion-ui/design_handoff/2026-05-14-vault-action-layer/edge-states.md
@@ -1,0 +1,21 @@
+# Edge states — Vault Action Layer
+
+Per the governance pack §08 checklist. Full visual treatment in **`prototype.html` §07**.
+
+- **Empty** — no action invoked; surface shows the action registry doc entry.
+- **Loading** — pipeline steps populate progressively, but the trace shape does not jump.
+- **Degraded** — if the outbox is degraded, step 09 emits a deferred-event receipt; the
+  action still succeeded.
+- **Blocked** — write guard refusal at step 05; auditable; never silently retried.
+- **Stale** — source note edited since the panel turn; step 03 refuses with
+  `source.stale`.
+- **Missing provenance** — source note without frontmatter; step 03 refuses with
+  `type.unknown`.
+- **Write-guard denial** — see Blocked above; rendered as state 04 in the gallery.
+- **Reduced motion** — trace lines are static; no sequential animation; state legible from
+  colour and copy.
+- **Narrow / mobile** — action stage stacks vertically; gallery is one column.
+
+## Deferred-with-reason
+
+None.

--- a/companion-ui/design_handoff/2026-05-14-vault-action-layer/implementation-contracts.md
+++ b/companion-ui/design_handoff/2026-05-14-vault-action-layer/implementation-contracts.md
@@ -1,0 +1,67 @@
+# Implementation contract — Vault Action Layer
+
+**Status:** Contract for UI integration · target-state
+**Mutates:** nothing on its own
+**Depends on:** action registry (owner-doc to be authored), policy contract,
+write-guard contract, receipt store contract, outbox contract.
+
+## Pipeline
+
+The full nine-step pipeline (intent → classify → bound → policy → guard → idempotency →
+execute → receipt → event) is defined in **`prototype.html` §02**. Implementation must run
+all nine steps in order. No step may be skipped; refusals do not skip subsequent receipt
+production.
+
+## Tier taxonomy
+
+Five tiers, defined in **`prototype.html` §03**. Tier is fixed at action registration; the
+runtime does not re-tier at invoke time. Tier 4 is intentionally empty; expanding it
+requires explicit per-agent policy.
+
+## Action object & trace entry
+
+See **`prototype.html` §08** for the target-state shape. Field names are illustrative;
+owner-doc owns the schema.
+
+## Data attributes
+
+```html
+<section
+  data-testid="action-stage"
+  data-action-id="va-..."
+  data-action-name="<registry name>"
+  data-tier="0 | 1 | 2 | 3"
+  data-outcome="applied | denied | blocked | noop | resolved | error"
+  data-step="<1..9>">
+```
+
+Per-trace-line:
+
+```html
+<div
+  data-testid="trace-line"
+  data-step="<1..9>"
+  data-result="pass | refuse | noop | resolved | error">
+```
+
+## Intents
+
+See **`prototype.html` §08** for the canonical intent table. Adding new intents requires
+amendment to this document.
+
+## Validation expectations
+
+A passing receipt for this package would:
+
+- Run all eight state fixtures through the pipeline.
+- Confirm every refusal produces a receipt at the refusing step.
+- Confirm the Obsidian adapter path executes the full pipeline.
+- Confirm the MCP-exposed surface offers only registry actions.
+- Confirm the receipt is durable and referenced from the status doc.
+
+## What this contract does not say
+
+- Which Obsidian / MCP library to use.
+- How the classifier model is trained.
+- How idempotency keys are computed (just that they exist and are deterministic).
+- How the deterministic collision rule is implemented per action.

--- a/companion-ui/design_handoff/2026-05-14-vault-action-layer/open-questions.md
+++ b/companion-ui/design_handoff/2026-05-14-vault-action-layer/open-questions.md
@@ -1,0 +1,25 @@
+# Open questions — Vault Action Layer
+
+The canonical list lives in **`prototype.html` §10**. This file is the structured version
+intended for issue creation at crossings C/D.
+
+## Open questions (summary)
+
+1. **Tier 1 vs Tier 3 distinction.** Both produce queued artifacts for human review. Owner-doc
+   should decide whether the split is durable.
+2. **Idempotency window.** 24h is a placeholder; per-action default or single fixed value.
+3. **Collision rule taxonomy.** `suffix` is the first rule. Future rules (`merge`,
+   `refuse`, `timestamp`) should be declared per registry entry, never inferred.
+4. **Cross-vault actions.** First action is single-vault. Suggest multi-vault always Tier 3.
+5. **Registry-write authority.** Are registry changes themselves governance-bearing? Suggest yes.
+6. **Classifier-confidence-to-tier coupling.** None proposed; render for transparency,
+   never gate on it.
+7. **Receipt retention.** Suggest: forever, in vault, as a subordinate artifact.
+
+## Crossing-B blocker triage
+
+The reviewer at crossing B must classify each question as:
+
+- **resolve before promotion** — likely #1, #4 (would change the tier matrix).
+- **resolve in normalized spec** — likely #2, #3, #5, #7.
+- **defer to implementation issue** — likely #6.

--- a/companion-ui/design_handoff/2026-05-14-vault-action-layer/prototype.html
+++ b/companion-ui/design_handoff/2026-05-14-vault-action-layer/prototype.html
@@ -1,0 +1,1180 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Vault Action Layer / Agent Tool Authority — Yggdrasil Companion UI</title>
+<link rel="stylesheet" href="./colors_and_type.css" />
+<link rel="stylesheet" href="./spec_chrome.css" />
+<style>
+  /* ============================================================
+     LOCAL — vault action pipeline, tier matrix, action card
+     ============================================================ */
+
+  /* === 9-step pipeline === */
+  .pipe {
+    border: 1px solid var(--border);
+    background: var(--bg-surface);
+    border-radius: var(--radius-md);
+    padding: var(--space-4) var(--space-5);
+    margin: var(--space-3) 0 var(--space-6);
+    display: grid;
+    grid-template-columns: repeat(9, 1fr);
+    gap: 4px;
+    position: relative;
+  }
+  .pipe .step {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 10px 8px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-strong);
+    background: var(--bg-base);
+    min-height: 78px;
+    text-align: left;
+  }
+  .pipe .step .n {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+  }
+  .pipe .step .label {
+    font-family: var(--font-ui);
+    font-size: var(--text-xs);
+    color: var(--fg-1);
+    font-weight: var(--weight-medium);
+    line-height: 1.25;
+  }
+  .pipe .step .sub {
+    font-family: var(--font-mono);
+    font-size: 9px;
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wide);
+    margin-top: auto;
+  }
+  .pipe .step.intent  { border-color: rgba(74,158,255,0.45); }
+  .pipe .step.intent  .n { color: var(--agent); }
+  .pipe .step.classify{ border-color: rgba(0,212,232,0.4); }
+  .pipe .step.classify .n { color: var(--cyan); }
+  .pipe .step.action  { border-color: rgba(0,212,232,0.4); }
+  .pipe .step.action .n { color: var(--cyan); }
+  .pipe .step.policy  { border-color: rgba(212,168,67,0.45); }
+  .pipe .step.policy .n { color: var(--accent); }
+  .pipe .step.guard   { border-color: rgba(212,168,67,0.45); }
+  .pipe .step.guard   .n { color: var(--accent); }
+  .pipe .step.idem    { border-color: rgba(212,168,67,0.45); }
+  .pipe .step.idem    .n { color: var(--accent); }
+  .pipe .step.exec    { border-color: rgba(57,232,125,0.4); }
+  .pipe .step.exec    .n { color: var(--vault); }
+  .pipe .step.receipt { border-color: rgba(57,232,125,0.4); }
+  .pipe .step.receipt .n { color: var(--vault); }
+  .pipe .step.event   { border-color: rgba(57,232,125,0.4); }
+  .pipe .step.event   .n { color: var(--vault); }
+  @media (max-width: 900px) {
+    .pipe { grid-template-columns: 1fr 1fr; }
+  }
+
+  /* === Tier matrix === */
+  .tier-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: var(--space-3) 0 var(--space-5);
+    border: 1px solid var(--border);
+    background: var(--bg-surface);
+  }
+  .tier-table th, .tier-table td {
+    text-align: left;
+    padding: 12px 14px;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+    font-size: var(--text-sm);
+  }
+  .tier-table th {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    color: var(--fg-2);
+    background: var(--bg-raised);
+    font-weight: var(--weight-medium);
+    border-bottom: 1px solid var(--border-strong);
+  }
+  .tier-table tr:last-child td { border-bottom: none; }
+  .tier-table td.tier {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    white-space: nowrap;
+    color: var(--fg-2);
+    width: 130px;
+  }
+  .tier-table tr.t0 td.tier { color: var(--vault); }
+  .tier-table tr.t1 td.tier { color: var(--cyan); }
+  .tier-table tr.t2 td.tier { color: var(--amber); }
+  .tier-table tr.t3 td.tier { color: var(--accent); }
+  .tier-table tr.t4 td.tier { color: var(--destructive); }
+  .tier-table tr.t4 { background: rgba(255,61,61,0.03); }
+  .tier-table td.ex {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wide);
+  }
+
+  /* === Live action card (the "Move Inbox → Workbench" sandbox) === */
+  .action-stage {
+    border: 1px solid var(--border);
+    background: var(--bg-surface);
+    border-radius: var(--radius-md);
+    margin: var(--space-3) 0 var(--space-6);
+    overflow: hidden;
+  }
+  .as-bar {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: 10px 16px;
+    background: var(--bg-raised);
+    border-bottom: 1px solid var(--border);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+  }
+  .as-bar .id { color: var(--cyan); }
+  .as-bar .right { margin-left: auto; display: flex; gap: var(--space-3); align-items: center; }
+  .as-body {
+    display: grid;
+    grid-template-columns: 1.3fr 1fr;
+    min-height: 460px;
+  }
+  .as-instruction {
+    padding: var(--space-5) var(--space-6);
+    border-right: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+  }
+  .as-trace {
+    background: var(--bg-base);
+    padding: var(--space-4);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    overflow-y: auto;
+    max-height: 600px;
+  }
+  .as-instruction .kicker {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    color: var(--agent);
+  }
+  .as-instruction h3 {
+    font-family: var(--font-display);
+    font-size: var(--text-xl);
+    line-height: 1.15;
+    color: var(--fg-1);
+    margin: 0;
+    text-transform: none;
+    letter-spacing: 0;
+    font-weight: var(--weight-regular);
+  }
+  .as-instruction .panel-prompt {
+    background: var(--bg-base);
+    border: 1px solid var(--border-strong);
+    border-left: 2px solid var(--agent);
+    border-radius: var(--radius-sm);
+    padding: 10px 14px;
+    font-family: var(--font-ui);
+    font-size: var(--text-sm);
+    color: var(--fg-1);
+    line-height: 1.5;
+    max-width: 50ch;
+  }
+  .as-instruction .panel-prompt .you {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    display: block;
+    margin-bottom: 4px;
+  }
+
+  .resolved {
+    background: var(--bg-raised);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 12px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .resolved .head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+  }
+  .resolved .head .cap { color: var(--cyan); }
+  .resolved dl {
+    display: grid;
+    grid-template-columns: 110px 1fr;
+    column-gap: var(--space-3);
+    row-gap: 6px;
+    font-size: var(--text-sm);
+    margin: 0;
+  }
+  .resolved dt {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    padding-top: 3px;
+  }
+  .resolved dd {
+    color: var(--fg-1);
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    word-break: break-all;
+    line-height: 1.5;
+  }
+  .resolved dd.cyan  { color: var(--cyan); }
+  .resolved dd.vault { color: var(--vault); }
+  .resolved dd.gold  { color: var(--accent); }
+  .resolved dd.dang  { color: var(--destructive); }
+
+  /* trace stream */
+  .trace-line {
+    display: grid;
+    grid-template-columns: 22px 1fr auto;
+    column-gap: 10px;
+    align-items: baseline;
+    padding: 5px 8px;
+    border-radius: var(--radius-sm);
+    border-left: 2px solid var(--border);
+    background: var(--bg-surface);
+  }
+  .trace-line .mark {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--fg-3);
+    text-align: center;
+  }
+  .trace-line .copy {
+    font-size: var(--text-xs);
+    color: var(--fg-1);
+    line-height: 1.5;
+    font-family: var(--font-ui);
+  }
+  .trace-line .copy code {
+    font-family: var(--font-mono);
+    font-size: 0.95em;
+    background: transparent;
+    border: none;
+    color: var(--fg-2);
+    padding: 0;
+  }
+  .trace-line .when {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wide);
+  }
+  .trace-line.pass { border-left-color: var(--vault); }
+  .trace-line.pass .mark { color: var(--vault); }
+  .trace-line.gate { border-left-color: var(--accent); }
+  .trace-line.gate .mark { color: var(--accent); }
+  .trace-line.deny { border-left-color: var(--destructive); }
+  .trace-line.deny .mark { color: var(--destructive); }
+  .trace-line.info { border-left-color: var(--cyan); }
+  .trace-line.info .mark { color: var(--cyan); }
+  .trace-line.idem { border-left-color: var(--amber); }
+  .trace-line.idem .mark { color: var(--amber); }
+
+  /* receipt strip */
+  .as-receipt {
+    padding: 12px 16px;
+    background: var(--bg-base);
+    border-top: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+  }
+  .as-receipt .lbl {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    color: var(--vault);
+  }
+  .as-receipt .copy {
+    font-size: var(--text-sm);
+    color: var(--fg-1);
+    line-height: 1.5;
+    flex: 1;
+    max-width: 70ch;
+  }
+  .as-receipt .actions { display: flex; gap: 8px; }
+
+  /* gallery for action states */
+  .gallery.act-gallery { grid-template-columns: 1fr 1fr; }
+  .am {
+    border: 1px solid var(--border);
+    background: var(--bg-surface);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+  }
+  .am-bar {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    padding: 8px 12px;
+    background: var(--bg-raised);
+    border-bottom: 1px solid var(--border);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+  }
+  .am-bar .cls.vault { color: var(--vault); }
+  .am-bar .cls.dang  { color: var(--destructive); }
+  .am-bar .cls.gold  { color: var(--accent); }
+  .am-bar .cls.amber { color: var(--amber); }
+  .am-bar .cls.cyan  { color: var(--cyan); }
+  .am-body { padding: 12px; display: flex; flex-direction: column; gap: 8px; }
+  .am-body h5 {
+    font-family: var(--font-display);
+    font-size: var(--text-md);
+    color: var(--fg-1);
+    font-weight: var(--weight-regular);
+    line-height: 1.2;
+    margin: 0;
+  }
+  .am-body p { font-size: var(--text-sm); color: var(--fg-2); margin: 0; line-height: 1.5; }
+  .am-body .meta {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--fg-3);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 14px;
+  }
+  .am-body .meta .v       { color: var(--fg-2); }
+  .am-body .meta .v.vault { color: var(--vault); }
+  .am-body .meta .v.cyan  { color: var(--cyan); }
+  .am-body .meta .v.gold  { color: var(--accent); }
+  .am-body .meta .v.amber { color: var(--amber); }
+  .am-body .meta .v.dang  { color: var(--destructive); }
+  .am-body .outcome {
+    margin-top: 4px;
+    padding: 6px 10px;
+    border-radius: var(--radius-sm);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    background: var(--bg-raised);
+    border: 1px solid var(--border-strong);
+    color: var(--fg-3);
+  }
+  .am-body .outcome.applied  { color: var(--vault); border-color: rgba(57,232,125,0.4); background: rgba(57,232,125,0.04); }
+  .am-body .outcome.denied   { color: var(--destructive); border-color: rgba(255,61,61,0.4); background: rgba(255,61,61,0.04); }
+  .am-body .outcome.blocked  { color: var(--accent); border-color: rgba(212,168,67,0.4); background: rgba(212,168,67,0.04); }
+  .am-body .outcome.noop     { color: var(--amber); border-color: rgba(240,144,48,0.4); background: rgba(240,144,48,0.04); }
+  .am-body .outcome.resolved { color: var(--cyan); border-color: rgba(0,212,232,0.4); background: rgba(0,212,232,0.04); }
+
+  /* boundary boxes — Obsidian/MCP */
+  .boundary {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-3);
+    margin: var(--space-3) 0 var(--space-5);
+  }
+  @media (max-width: 900px) { .boundary { grid-template-columns: 1fr; } }
+  .b-cell {
+    border: 1px solid var(--border);
+    background: var(--bg-surface);
+    border-radius: var(--radius-md);
+    padding: var(--space-4);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .b-cell h4 {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    letter-spacing: var(--tracking-wider);
+    text-transform: uppercase;
+    color: var(--fg-2);
+  }
+  .b-cell.good { border-top: 2px solid var(--vault); }
+  .b-cell.good h4 { color: var(--vault); }
+  .b-cell.bad  { border-top: 2px solid var(--destructive); }
+  .b-cell.bad h4 { color: var(--destructive); }
+  .b-cell ul { margin: 0; padding-left: 18px; }
+  .b-cell li { font-size: var(--text-sm); color: var(--fg-1); line-height: 1.5; }
+
+</style>
+</head>
+<body>
+<div class="page">
+
+  <!-- ============================ TOC ============================ -->
+  <nav class="toc" aria-label="Section index">
+    <div class="toc-label">Sections</div>
+    <ol>
+      <li><a href="#s1"><span class="toc-num">01</span>Context &amp; boundary</a></li>
+      <li><a href="#s2"><span class="toc-num">02</span>9-step action pipeline</a></li>
+      <li><a href="#s3"><span class="toc-num">03</span>Tool authority tiers</a></li>
+      <li><a href="#s4"><span class="toc-num">04</span>Obsidian / MCP boundary</a></li>
+      <li><a href="#s5"><span class="toc-num">05</span>Concrete action prototype</a></li>
+      <li><a href="#s6"><span class="toc-num">06</span>State gallery</a></li>
+      <li><a href="#s7"><span class="toc-num">07</span>Edge states</a></li>
+      <li><a href="#s8"><span class="toc-num">08</span>Implementation contract</a></li>
+      <li><a href="#s9"><span class="toc-num">09</span>Authority boundaries</a></li>
+      <li><a href="#s10"><span class="toc-num">10</span>Open questions</a></li>
+      <li><a href="#s11"><span class="toc-num">11</span>Handoff to Code/Codex</a></li>
+    </ol>
+  </nav>
+
+  <!-- ============================ MAIN ============================ -->
+  <main>
+    <header class="doc-header">
+      <div class="doc-eyebrow">Companion UI · Design Handoff · Authority surface</div>
+      <h1 class="doc-title">Vault Action Layer / Agent Tool Authority</h1>
+      <p class="doc-lede">
+        Agents do not get raw filesystem powers. They get bounded, governed capabilities,
+        named, classified, gated, and receipted. The vault action layer is the contract between
+        Panel-style instructions ("move this Inbox note to Workbench") and actual mutation. It
+        passes every action through nine steps — intent classification, bounded action,
+        policy, write guard, idempotency, collision-safe execution, receipt, observable event.
+        Obsidian and MCP may later sit as adapters; they may never be the primary mutation path.
+      </p>
+      <div class="doc-meta">
+        <span><strong>Surface:</strong> VAULT_ACTION_LAYER</span>
+        <span><strong>Linked issue:</strong> #910</span>
+        <span><strong>Authority:</strong> Visual + structural guidance — tool-authority taxonomy proposal</span>
+        <span><strong>Status:</strong> Design handoff · v1 · 2026-05-14</span>
+      </div>
+    </header>
+
+    <!-- ============== 01 ============== -->
+    <section class="spec" id="s1">
+      <h2><span class="secnum">01 ·</span>Context &amp; boundary</h2>
+      <p class="lede">Why a vault action layer is needed, and what it deliberately is not.</p>
+
+      <p>
+        Issue #910 made a broader need visible. Panel Agent — and any future agent — needs
+        <em>bounded vault actions</em>, not raw filesystem or generic Obsidian/MCP powers.
+        Generic write tools collapse the difference between "move a note to a known folder"
+        and "delete an arbitrary file"; they bypass policy, write guard, idempotency, and
+        receipt machinery; they make Obsidian/MCP look canonical when they are properly
+        adapters. The vault action layer is the boundary that fixes this.
+      </p>
+
+      <h3>What this design covers</h3>
+      <ul>
+        <li>The <strong>9-step pipeline</strong> every vault mutation must pass through.</li>
+        <li>The <strong>five-tier tool authority taxonomy</strong> agents are bound by.</li>
+        <li>The <strong>Obsidian / MCP boundary</strong>: adapter, not authority.</li>
+        <li>A <strong>concrete first action</strong> — "Move current Inbox note to Workbench" — designed end to end.</li>
+        <li>Eight <strong>designed states</strong>: allowed move, two denial classes, write-guard block, idempotent no-op, collision-resolved, success-with-receipt, receipt-inspection.</li>
+      </ul>
+
+      <div class="callout invariant">
+        <span class="callout-label">Floor invariant · Agents are bounded</span>
+        Agents act through declared vault actions. They do not act through generic write
+        primitives. Every action carries a tier, a policy check, a write-guard verdict, an
+        idempotency check, and a receipt. The runtime owns the action set; the design names
+        the shape that set must take.
+      </div>
+
+      <h3>What this design is not</h3>
+      <ul>
+        <li>Not a filesystem API. The pipeline is the contract; the FS calls underneath are
+          the runtime's choice.</li>
+        <li>Not an Obsidian plugin spec or an MCP integration spec. Those may later <em>sit
+          underneath</em> tier-2 bounded write tools as adapters, never as the primary
+          mutation path.</li>
+        <li>Not a UI for arbitrary file management. The vault action layer is for the
+          <em>named</em> actions agents are entitled to. Arbitrary file ops live in the
+          user's own tools.</li>
+        <li>Not a permission model for humans. Humans are the authority; the layer governs
+          what <em>agents</em> may do on the human's behalf.</li>
+      </ul>
+    </section>
+
+    <!-- ============== 02 ============== -->
+    <section class="spec" id="s2">
+      <h2><span class="secnum">02 ·</span>9-step action pipeline</h2>
+      <p class="lede">
+        Every vault action passes through nine ordered steps. Any step may refuse. Refusal is
+        first-class; it produces a receipt, not silence.
+      </p>
+
+      <div class="pipe" role="img" aria-label="9-step action pipeline: panel instruction, intent classification, bounded vault action, policy check, write guard, idempotency check, execution, durable receipt, observable event">
+        <div class="step intent">
+          <span class="n">01 · Intent</span>
+          <span class="label">Panel instruction</span>
+          <span class="sub">natural-language or structured</span>
+        </div>
+        <div class="step classify">
+          <span class="n">02 · Classify</span>
+          <span class="label">Intent → action name</span>
+          <span class="sub">router · server-side only</span>
+        </div>
+        <div class="step action">
+          <span class="n">03 · Bound</span>
+          <span class="label">Bounded vault action</span>
+          <span class="sub">named, tiered, parameterised</span>
+        </div>
+        <div class="step policy">
+          <span class="n">04 · Policy</span>
+          <span class="label">Authority check</span>
+          <span class="sub">agent tier · sphere · scope</span>
+        </div>
+        <div class="step guard">
+          <span class="n">05 · Guard</span>
+          <span class="label">Write guard</span>
+          <span class="sub">policy refusal · focus-mode</span>
+        </div>
+        <div class="step idem">
+          <span class="n">06 · Idempotent</span>
+          <span class="label">Idempotency check</span>
+          <span class="sub">no-op if already-applied</span>
+        </div>
+        <div class="step exec">
+          <span class="n">07 · Execute</span>
+          <span class="label">Collision-safe execution</span>
+          <span class="sub">deterministic resolver</span>
+        </div>
+        <div class="step receipt">
+          <span class="n">08 · Receipt</span>
+          <span class="label">Durable receipt</span>
+          <span class="sub">id · action · result · diff</span>
+        </div>
+        <div class="step event">
+          <span class="n">09 · Event</span>
+          <span class="label">Observable event/log</span>
+          <span class="sub">outbox + status doc</span>
+        </div>
+      </div>
+
+      <h3>Per-step rules</h3>
+      <table class="spec">
+        <thead><tr><th>Step</th><th>Owner</th><th>Refusal produces</th><th>Notes</th></tr></thead>
+        <tbody>
+          <tr><td>01 · Intent</td><td>Panel UI</td><td><em>n/a — input</em></td><td>Free text or structured form; nothing committed.</td></tr>
+          <tr><td>02 · Classify</td><td>Server-side router</td><td><code>unclassified_intent_receipt</code></td><td>UI never re-classifies (see §08).</td></tr>
+          <tr><td>03 · Bound</td><td>Action registry</td><td><code>unknown_action_receipt</code></td><td>If the action name is not in the registry, refuse.</td></tr>
+          <tr><td>04 · Policy</td><td>Authority policy</td><td><code>policy_denial_receipt</code></td><td>Agent tier, sphere, scope checked against the action's required authority.</td></tr>
+          <tr><td>05 · Guard</td><td>Write guard</td><td><code>write_guard_denial_receipt</code></td><td>Even if policy allows, write guard may refuse (focus-mode, degraded vault, etc).</td></tr>
+          <tr><td>06 · Idempotent</td><td>Idempotency check</td><td><code>idempotent_noop_receipt</code></td><td>Replaying the same action is a no-op, not a duplicate; receipt is still produced.</td></tr>
+          <tr><td>07 · Execute</td><td>Deterministic writer</td><td><code>collision_resolved_receipt</code> or <code>execution_error_receipt</code></td><td>Name collisions resolved by the registry's deterministic rule (e.g. <code>-1</code> suffix); never random.</td></tr>
+          <tr><td>08 · Receipt</td><td>Receipt store</td><td><em>n/a — receipt is the output</em></td><td>Every step that refused or succeeded contributes to the receipt trace.</td></tr>
+          <tr><td>09 · Event</td><td>Outbox + status doc</td><td><em>n/a — observability</em></td><td>Event durable in the outbox; status doc references the receipt id.</td></tr>
+        </tbody>
+      </table>
+
+      <div class="callout invariant">
+        <span class="callout-label">Invariant · Refusal is first-class</span>
+        Every refusal produces a receipt. There is no silent failure. There is no "tried and
+        nothing happened". A denied action is auditable in exactly the same shape as a
+        successful one — same id format, same trace structure, same status-doc link.
+      </div>
+    </section>
+
+    <!-- ============== 03 ============== -->
+    <section class="spec" id="s3">
+      <h2><span class="secnum">03 ·</span>Tool authority tiers</h2>
+      <p class="lede">
+        Five tiers. An agent's <em>maximum tier</em> is set by policy. An action's
+        <em>required tier</em> is fixed by the action registry. Tier mismatch is a policy
+        denial at step 04.
+      </p>
+
+      <table class="tier-table">
+        <thead>
+          <tr><th>Tier</th><th>Name</th><th>Examples</th><th>What it may do</th><th>Receipt required</th></tr>
+        </thead>
+        <tbody>
+          <tr class="t0">
+            <td class="tier">Tier 0</td>
+            <td>Read-only tools</td>
+            <td class="ex">read_note, list_inbox, search_vault, get_receipt</td>
+            <td>Read vault state. Return projections. Never mutate.</td>
+            <td>read-trace only</td>
+          </tr>
+          <tr class="t1">
+            <td class="tier">Tier 1</td>
+            <td>Proposal tools</td>
+            <td class="ex">propose_edit, propose_link, propose_move</td>
+            <td>Emit a proposal into the governance queue. Human or governed flow decides whether to apply. <em>Never mutates.</em></td>
+            <td>proposal-receipt</td>
+          </tr>
+          <tr class="t2">
+            <td class="tier">Tier 2</td>
+            <td>Bounded write tools</td>
+            <td class="ex">move_inbox_note_to_workbench, archive_completed_commitment, append_to_session_log</td>
+            <td>Named, parameter-bounded mutations. Each is a registry entry with declared source domain, destination domain, allowed types, idempotency key shape, collision rule.</td>
+            <td>write-receipt</td>
+          </tr>
+          <tr class="t3">
+            <td class="tier">Tier 3</td>
+            <td>Governance-bearing tools</td>
+            <td class="ex">apply_governance_intent, promote_memory_to_note, change_vault_scope</td>
+            <td>Routes through full governance (Panel review or human accept). Cannot be invoked silently by an agent — always produces a queued intent the human reviews.</td>
+            <td>governance-receipt</td>
+          </tr>
+          <tr class="t4">
+            <td class="tier">Tier 4</td>
+            <td>Forbidden initially</td>
+            <td class="ex">raw_write_file, raw_delete_file, run_shell, eval_javascript</td>
+            <td>Not in the registry. Cannot be invoked. Listed here so the boundary is explicit. Future capability is opt-in per-agent and never default.</td>
+            <td>—</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Rules</h3>
+      <ul>
+        <li>Every action in the registry declares a single tier. Tier is fixed at registration; the runtime does not re-tier at invoke time.</li>
+        <li>Agents declare a <em>maximum invocable tier</em>. Panel Agent's current ceiling is Tier 2 (bounded writes) plus Tier 3 (via human-reviewed governance).</li>
+        <li>Tier 4 is empty. It is named here so it is impossible to "discover" tier 4 by accident.</li>
+        <li>Adding a new bounded write tool (Tier 2) requires a registry entry with the full bounding contract; it is not done at agent runtime.</li>
+      </ul>
+
+      <div class="callout warn">
+        <span class="callout-label">Tier escalation is not implicit</span>
+        An agent at max-tier 2 cannot invoke a Tier 3 tool by phrasing its request differently.
+        The classifier (step 02) maps intent to action name; the registry (step 03) declares the
+        action's tier; policy (step 04) refuses if the agent's ceiling is below the action's
+        tier. There is no path that loosens this without explicit policy change.
+      </div>
+    </section>
+
+    <!-- ============== 04 ============== -->
+    <section class="spec" id="s4">
+      <h2><span class="secnum">04 ·</span>Obsidian / MCP boundary</h2>
+      <p class="lede">
+        Obsidian and MCP are valuable surfaces. They are <em>not</em> the primary mutation
+        authority. Where they appear in the stack, they sit underneath bounded vault actions
+        as adapters, with Yggdrasil's pipeline running first.
+      </p>
+
+      <div class="boundary">
+        <div class="b-cell good">
+          <h4>What is allowed</h4>
+          <ul>
+            <li>A Tier 2 bounded action — <code>move_inbox_note_to_workbench</code> — implemented internally by an Obsidian API call. Yggdrasil's pipeline still runs end to end; Obsidian is just the FS-level adapter.</li>
+            <li>An MCP server exposed by Yggdrasil that offers only Tier 0–2 action names from the registry. External callers see <em>actions</em>, not raw write primitives.</li>
+            <li>Read-only Obsidian/MCP tools at Tier 0 — fine as long as they read through the registry.</li>
+          </ul>
+        </div>
+        <div class="b-cell bad">
+          <h4>What is not allowed</h4>
+          <ul>
+            <li>Generic Obsidian MCP "write file" or "modify note" capability surfaced as an agent tool. That collapses bounding, policy, and write guard.</li>
+            <li>An agent reaching the FS through MCP that does not run Yggdrasil's policy, write guard, idempotency, and receipt steps.</li>
+            <li>An MCP adapter that produces no receipt for a successful or denied action.</li>
+            <li>Treating Obsidian as the source of truth for what an action means. The registry is the source of truth; Obsidian implements.</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="callout invariant">
+        <span class="callout-label">Invariant · Adapter, not authority</span>
+        Obsidian, MCP, or any future external mutation surface may participate as the
+        <em>execution adapter</em> for a registered Tier-2 action. They may not bypass
+        intent classification, action bounding, policy, write guard, idempotency, or receipt
+        production. The vault action layer runs first; the adapter runs second.
+      </div>
+    </section>
+
+    <!-- ============== 05 ============== -->
+    <section class="spec" id="s5">
+      <h2><span class="secnum">05 ·</span>Concrete action prototype <span class="chip design" style="font-size:10px; margin-left:8px">move inbox → workbench · allowed</span></h2>
+      <p class="lede">
+        First action: <em>Move the current Inbox note to Workbench.</em> A Tier 2 bounded
+        write. The panel issues an instruction; the pipeline classifies, bounds, checks,
+        executes, and produces a receipt. The trace pane shows every step.
+      </p>
+
+      <div class="action-stage" aria-label="Vault action — move inbox note to workbench, allowed">
+        <div class="as-bar">
+          <span>action</span>
+          <span class="id">va-2026-05-14-0014</span>
+          <span>·</span>
+          <span>move_inbox_note_to_workbench</span>
+          <span class="right">
+            <span class="receipt applied"><span class="recdot"></span>tier 2 · write</span>
+          </span>
+        </div>
+
+        <div class="as-body">
+          <!-- left: instruction + resolved action -->
+          <section class="as-instruction">
+            <span class="kicker">panel · munin · turn 28</span>
+            <h3>"Move the inbox note about the watcher OOM repair to Workbench."</h3>
+
+            <div class="panel-prompt">
+              <span class="you">user · panel</span>
+              I've cleared this one — move it to Workbench so it's out of Inbox.
+            </div>
+
+            <div class="resolved">
+              <div class="head"><span class="cap">resolved action</span><span>· step 03</span></div>
+              <dl>
+                <dt>name</dt><dd class="cyan">move_inbox_note_to_workbench</dd>
+                <dt>tier</dt><dd>2 · bounded write</dd>
+                <dt>source</dt><dd>vault/Inbox/watcher-oom-repair.md</dd>
+                <dt>destination</dt><dd>vault/Workbench/</dd>
+                <dt>note type</dt><dd>inbox-item · allowed</dd>
+                <dt>idempotency key</dt><dd class="gold">sha256(src+dst+content-hash)<br>→ ik-a91e3c…</dd>
+                <dt>collision rule</dt><dd>suffix · <code>-1</code> · <code>-2</code> · …</dd>
+              </dl>
+            </div>
+          </section>
+
+          <!-- right: pipeline trace -->
+          <aside class="as-trace" aria-label="Pipeline trace">
+            <div class="trace-line info">
+              <span class="mark">→</span>
+              <span class="copy">Step 01 · Intent received from Panel turn 28.</span>
+              <span class="when">14:08:01</span>
+            </div>
+            <div class="trace-line info">
+              <span class="mark">→</span>
+              <span class="copy">Step 02 · Classifier mapped intent to <code>move_inbox_note_to_workbench</code>. Confidence 0.94. UI did not re-classify.</span>
+              <span class="when">14:08:01</span>
+            </div>
+            <div class="trace-line info">
+              <span class="mark">→</span>
+              <span class="copy">Step 03 · Bound to registry entry <code>move_inbox_note_to_workbench@v3</code>. Tier 2. Source domain · Inbox; destination domain · Workbench.</span>
+              <span class="when">14:08:01</span>
+            </div>
+            <div class="trace-line gate">
+              <span class="mark">⊕</span>
+              <span class="copy">Step 04 · Policy check. Agent · munin · max tier 2. Action tier 2. Sphere · work. Scope · vault-main. <strong>Pass.</strong></span>
+              <span class="when">14:08:01</span>
+            </div>
+            <div class="trace-line gate">
+              <span class="mark">⊕</span>
+              <span class="copy">Step 05 · Write guard. Policy · default. Vault not in focus-mode. Watcher healthy. <strong>Allowed.</strong></span>
+              <span class="when">14:08:01</span>
+            </div>
+            <div class="trace-line gate">
+              <span class="mark">⊕</span>
+              <span class="copy">Step 06 · Idempotency check. Key <code>ik-a91e3c…</code> not seen in 24h window. <strong>Not a duplicate.</strong></span>
+              <span class="when">14:08:02</span>
+            </div>
+            <div class="trace-line pass">
+              <span class="mark">✓</span>
+              <span class="copy">Step 07 · Execute. Resolver inspected destination. No collision. Atomic rename via Obsidian adapter.</span>
+              <span class="when">14:08:02</span>
+            </div>
+            <div class="trace-line pass">
+              <span class="mark">✓</span>
+              <span class="copy">Step 08 · Receipt minted · <code>r-va-2026-05-14-0014</code>. Contains action, parameters, idempotency key, trace.</span>
+              <span class="when">14:08:02</span>
+            </div>
+            <div class="trace-line pass">
+              <span class="mark">✓</span>
+              <span class="copy">Step 09 · Event appended to outbox · <code>vault.note.moved</code>. Status doc updated.</span>
+              <span class="when">14:08:02</span>
+            </div>
+          </aside>
+        </div>
+
+        <div class="as-receipt">
+          <span class="lbl">Receipt · r-va-2026-05-14-0014</span>
+          <span class="copy">
+            Moved <code style="font-family:var(--font-mono); font-size:0.9em; color:var(--cyan)">Inbox/watcher-oom-repair.md</code>
+            → <code style="font-family:var(--font-mono); font-size:0.9em; color:var(--vault)">Workbench/watcher-oom-repair.md</code>.
+            Reversible · undo creates a new receipt referencing this one.
+          </span>
+          <span class="actions">
+            <button class="btn ghost" type="button" data-intent="receipt.open">Open receipt</button>
+            <button class="btn" type="button" data-intent="action.undo">Undo</button>
+          </span>
+        </div>
+      </div>
+
+      <p>
+        The instruction is natural language. Everything from step 02 onward is structured —
+        the resolved-action card on the left shows what the classifier and registry agreed on,
+        in mono, so the operator can audit the binding before reviewing the trace. The trace
+        on the right is the receipt's narrative form; the receipt itself is a structured
+        record durable in the receipt store.
+      </p>
+    </section>
+
+    <!-- ============== 06 ============== -->
+    <section class="spec" id="s6">
+      <h2><span class="secnum">06 ·</span>State gallery</h2>
+      <p class="lede">
+        Eight states. Each is a one-action card showing the same shape: action name + outcome
+        + the step at which the verdict was reached. The full action stage in §05 carries
+        every state; here the cards summarise.
+      </p>
+
+      <div class="gallery act-gallery">
+
+        <!-- 1 allowed move -->
+        <div class="am">
+          <div class="am-bar"><span>01 · allowed move</span><span class="cls vault">tier 2 · write</span></div>
+          <div class="am-body">
+            <h5>Inbox/watcher-oom-repair.md → Workbench/</h5>
+            <p>All nine steps pass. Destination is in the allowed Workbench domain. No collision.
+              Receipt minted; event durable.</p>
+            <div class="meta">
+              <span><span class="v">classify</span> <span class="v cyan">0.94</span></span>
+              <span><span class="v">policy</span> <span class="v vault">pass</span></span>
+              <span><span class="v">guard</span> <span class="v vault">allow</span></span>
+            </div>
+            <div class="outcome applied">APPLIED · receipt r-va-…0014</div>
+          </div>
+        </div>
+
+        <!-- 2 denied — source -->
+        <div class="am">
+          <div class="am-bar"><span>02 · denied · source</span><span class="cls dang">action denied</span></div>
+          <div class="am-body">
+            <h5>Inbox/promotion-of-X.md → Workbench/</h5>
+            <p>Action denied at step 03. The note is marked
+              <code style="font-family:var(--font-mono);font-size:0.9em">type: commitment</code>;
+              <code>move_inbox_note_to_workbench</code> requires <code>type: inbox-item</code>.
+              The action registry refused the binding.</p>
+            <div class="meta">
+              <span><span class="v">step</span> <span class="v dang">03 · bound</span></span>
+              <span><span class="v">reason</span> <span class="v dang">type · not inbox-item</span></span>
+            </div>
+            <div class="outcome denied">DENIED · receipt r-va-…0015 · action.refused</div>
+          </div>
+        </div>
+
+        <!-- 3 denied — destination -->
+        <div class="am">
+          <div class="am-bar"><span>03 · denied · destination</span><span class="cls dang">action denied</span></div>
+          <div class="am-body">
+            <h5>Inbox/note.md → ~/somewhere-else/</h5>
+            <p>Destination is outside any declared vault domain. The action is parameter-bounded
+              and refused at step 03 before policy ever runs.</p>
+            <div class="meta">
+              <span><span class="v">step</span> <span class="v dang">03 · bound</span></span>
+              <span><span class="v">reason</span> <span class="v dang">destination · arbitrary</span></span>
+            </div>
+            <div class="outcome denied">DENIED · receipt r-va-…0016 · destination.arbitrary</div>
+          </div>
+        </div>
+
+        <!-- 4 write guard -->
+        <div class="am">
+          <div class="am-bar"><span>04 · blocked · write guard</span><span class="cls gold">policy</span></div>
+          <div class="am-body">
+            <h5>Inbox/note.md → Workbench/</h5>
+            <p>Steps 03–04 pass. Write guard at step 05 refuses: vault is in focus-mode (writes
+              restricted to <code>journal/</code>). Refusal is policy, not failure.</p>
+            <div class="meta">
+              <span><span class="v">step</span> <span class="v gold">05 · guard</span></span>
+              <span><span class="v">policy</span> <span class="v gold">focus-mode</span></span>
+            </div>
+            <div class="outcome blocked">BLOCKED · receipt r-va-…0017 · guard.refused</div>
+          </div>
+        </div>
+
+        <!-- 5 idempotent noop -->
+        <div class="am">
+          <div class="am-bar"><span>05 · idempotent · no-op</span><span class="cls amber">noop · receipt produced</span></div>
+          <div class="am-body">
+            <h5>Inbox/note.md → Workbench/ · replayed</h5>
+            <p>Action with the same idempotency key was applied 12 minutes ago. Step 06 returns
+              no-op; no FS write occurs. A receipt is still produced and points at the original.</p>
+            <div class="meta">
+              <span><span class="v">step</span> <span class="v amber">06 · idempotent</span></span>
+              <span><span class="v">prior</span> <span class="v cyan">r-va-…0014</span></span>
+            </div>
+            <div class="outcome noop">NO-OP · receipt r-va-…0018 · idempotent.replay</div>
+          </div>
+        </div>
+
+        <!-- 6 collision resolved -->
+        <div class="am">
+          <div class="am-bar"><span>06 · collision · resolved</span><span class="cls cyan">deterministic suffix</span></div>
+          <div class="am-body">
+            <h5>Inbox/notes.md → Workbench/notes.md</h5>
+            <p>Step 07 detected an existing <code>Workbench/notes.md</code>. The registry's
+              deterministic rule (suffix <code>-1</code>) produced <code>notes-1.md</code>.
+              Not random; not destructive; auditable.</p>
+            <div class="meta">
+              <span><span class="v">step</span> <span class="v cyan">07 · execute</span></span>
+              <span><span class="v">rule</span> <span class="v cyan">suffix · -1</span></span>
+            </div>
+            <div class="outcome resolved">RESOLVED · receipt r-va-…0019 · executed as notes-1.md</div>
+          </div>
+        </div>
+
+        <!-- 7 success with receipt -->
+        <div class="am">
+          <div class="am-bar"><span>07 · success · with receipt</span><span class="cls vault">applied</span></div>
+          <div class="am-body">
+            <h5>Inbox/watcher-oom-repair.md → Workbench/</h5>
+            <p>Same as state 01 from the operator's view. Included here because "success with
+              receipt" is the canonical shape; the receipt is durable and inspectable in
+              Panel.</p>
+            <div class="meta">
+              <span><span class="v">step</span> <span class="v vault">07 · execute</span></span>
+              <span><span class="v">undo</span> <span class="v">available</span></span>
+            </div>
+            <div class="outcome applied">APPLIED · receipt r-va-…0020 · reversible</div>
+          </div>
+        </div>
+
+        <!-- 8 receipt inspection -->
+        <div class="am">
+          <div class="am-bar"><span>08 · receipt inspection</span><span class="cls cyan">audit view</span></div>
+          <div class="am-body">
+            <h5>Receipt r-va-…0014 · move_inbox_note_to_workbench</h5>
+            <p>Audit view: the same nine-step trace, plus the parameter dump, the idempotency
+              key, the resolved adapter (Obsidian), and the linked outbox event. Click-throughs
+              go to source / destination paths.</p>
+            <div class="meta">
+              <span><span class="v">store</span> <span class="v cyan">receipts/</span></span>
+              <span><span class="v">linked</span> <span class="v cyan">outbox event v.note.moved</span></span>
+            </div>
+            <div class="outcome resolved">INSPECTED · read-only · linkable</div>
+          </div>
+        </div>
+
+      </div>
+    </section>
+
+    <!-- ============== 07 ============== -->
+    <section class="spec" id="s7">
+      <h2><span class="secnum">07 ·</span>Edge states</h2>
+      <table class="spec">
+        <thead><tr><th>Edge</th><th>Designed behavior</th></tr></thead>
+        <tbody>
+          <tr><td>Empty</td><td>No action invoked — surface shows the action registry's documentation entry for the current scope.</td></tr>
+          <tr><td>Loading</td><td>Steps populate progressively; pre-step rows render dimmed but visible — the trace structure does not jump.</td></tr>
+          <tr><td>Degraded</td><td>If the outbox is degraded, step 09 emits a deferred-event receipt and the surface shows it; the action still succeeded.</td></tr>
+          <tr><td>Blocked</td><td>State 04 — write guard refuses. Banner gold; reason named. No retry without policy change.</td></tr>
+          <tr><td>Stale</td><td>If the action references a note that has been edited since the panel turn, step 03 refuses with <code>source.stale</code>; the operator re-issues the instruction.</td></tr>
+          <tr><td>Missing provenance</td><td>If the source note has no frontmatter (no type), step 03 refuses with <code>type.unknown</code>; the receipt names the reason.</td></tr>
+          <tr><td>Write-guard denial</td><td>State 04 above. Auditable. Never silently retried.</td></tr>
+          <tr><td>Reduced motion</td><td>Trace line markers are static; no sequential animation. State changes legible from colour and copy alone.</td></tr>
+          <tr><td>Narrow / mobile</td><td>Action stage stacks: instruction + resolved-action above, trace below, receipt strip at bottom. State gallery is one column.</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <!-- ============== 08 ============== -->
+    <section class="spec" id="s8">
+      <h2><span class="secnum">08 ·</span>Implementation contract</h2>
+      <p class="lede">
+        The UI consumes a structured <em>action</em> object and the live <em>trace</em>. It
+        never invents the action name; classification is the server's job.
+      </p>
+
+      <h3>Action object (target-state)</h3>
+      <pre class="code"><span class="c">// Illustrative — owner-doc owns the schema.</span>
+{
+  <span class="k">"id"</span>: <span class="s">"va-2026-05-14-0014"</span>,
+  <span class="k">"name"</span>: <span class="s">"move_inbox_note_to_workbench"</span>,
+  <span class="k">"version"</span>: <span class="s">"v3"</span>,
+  <span class="k">"tier"</span>: <span class="n">2</span>,
+  <span class="k">"params"</span>: {
+    <span class="k">"source"</span>:      <span class="s">"vault/Inbox/watcher-oom-repair.md"</span>,
+    <span class="k">"destination"</span>: <span class="s">"vault/Workbench/"</span>
+  },
+  <span class="k">"idempotency_key"</span>: <span class="s">"ik-a91e3c..."</span>,
+  <span class="k">"collision_rule"</span>: <span class="s">"suffix"</span>,
+  <span class="k">"agent"</span>: { <span class="k">"name"</span>: <span class="s">"munin"</span>, <span class="k">"max_tier"</span>: <span class="n">2</span> },
+  <span class="k">"sphere"</span>: <span class="s">"work"</span>,
+  <span class="k">"scope"</span>: <span class="s">"vault-main"</span>,
+  <span class="k">"trigger"</span>: { <span class="k">"surface"</span>: <span class="s">"panel"</span>, <span class="k">"turn"</span>: <span class="n">28</span> }
+}</pre>
+
+      <h3>Trace entry shape</h3>
+      <pre class="code">{
+  <span class="k">"step"</span>:    <span class="n">5</span>,
+  <span class="k">"name"</span>:    <span class="s">"write_guard"</span>,
+  <span class="k">"result"</span>:  <span class="s">"pass | refuse | noop | resolved | error"</span>,
+  <span class="k">"reason"</span>:  <span class="s">"policy=default; focus_mode=false"</span>,
+  <span class="k">"at"</span>:      <span class="s">"2026-05-14T14:08:01.812Z"</span>
+}</pre>
+
+      <h3>Intents emitted by the action surface</h3>
+      <table class="spec">
+        <thead><tr><th class="mono">data-intent</th><th>Effect</th><th>Authority</th></tr></thead>
+        <tbody>
+          <tr><td class="mono">action.invoke</td><td>Issues a panel-classified intent</td><td>governed · routes through full pipeline</td></tr>
+          <tr><td class="mono">action.undo</td><td>Inverse of last applied action; produces a new receipt</td><td>governed · explicit user click</td></tr>
+          <tr><td class="mono">receipt.open</td><td>Open the receipt in audit view</td><td>navigation only</td></tr>
+          <tr><td class="mono">action.open-source</td><td>Open source path in Obsidian</td><td>navigation only</td></tr>
+          <tr><td class="mono">action.open-destination</td><td>Open destination path in Obsidian</td><td>navigation only</td></tr>
+          <tr><td class="mono">action.copy-id</td><td>Copy action id</td><td>read-only</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Data attributes</h3>
+      <pre class="code">&lt;section
+  data-testid=<span class="s">"action-stage"</span>
+  data-action-id=<span class="s">"va-2026-05-14-0014"</span>
+  data-action-name=<span class="s">"move_inbox_note_to_workbench"</span>
+  data-tier=<span class="s">"0 | 1 | 2 | 3"</span>
+  data-outcome=<span class="s">"applied | denied | blocked | noop | resolved | error"</span>
+  data-step=<span class="s">"&lt;1..9&gt;"</span>&gt;</pre>
+
+      <div class="callout">
+        <span class="callout-label">UI never classifies</span>
+        Step 02 happens on the server. The UI renders the resolved-action card after the
+        classifier returns. The UI does not infer the action name from the panel prompt.
+      </div>
+    </section>
+
+    <!-- ============== 09 ============== -->
+    <section class="spec" id="s9">
+      <h2><span class="secnum">09 ·</span>Authority boundaries</h2>
+
+      <div class="callout invariant">
+        <span class="callout-label">Invariant · Bounded actions, not raw primitives</span>
+        Agents act only through named, tiered, parameter-bounded actions in the registry.
+        Generic write primitives are not exposed. Tier 4 is empty by design.
+      </div>
+
+      <div class="callout invariant">
+        <span class="callout-label">Invariant · Pipeline is mandatory</span>
+        Every successful action passes all nine steps. Every denied action produces a receipt
+        at the refusing step. No execution adapter — Obsidian, MCP, future — bypasses any step.
+      </div>
+
+      <div class="callout invariant">
+        <span class="callout-label">Invariant · Receipts are durable</span>
+        Every action — success, denial, no-op, resolution — produces a receipt. The receipt is
+        the audit primitive. Status docs reference the receipt id.
+      </div>
+
+      <table class="spec">
+        <thead>
+          <tr><th>Concern</th><th>May influence</th><th>May propose</th><th>May not decide</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>UI layout, copy, trace visual</td><td class="yes">YES</td><td class="maybe">—</td><td class="no">—</td></tr>
+          <tr><td>Tier taxonomy (5 tiers)</td><td class="maybe">naming / ordering</td><td class="yes">propose to owner-doc</td><td class="no">cannot define semantics in code</td></tr>
+          <tr><td>Action registry entries</td><td class="no">—</td><td class="maybe">propose new bounded actions</td><td class="no">cannot register; owner-doc / runtime owns</td></tr>
+          <tr><td>Classifier behavior</td><td class="no">—</td><td class="no">—</td><td class="no">runtime owns</td></tr>
+          <tr><td>Policy / write-guard semantics</td><td class="no">—</td><td class="no">—</td><td class="no">policy contract owns</td></tr>
+          <tr><td>Idempotency key shape</td><td class="no">—</td><td class="maybe">propose per-action conventions</td><td class="no">cannot define algorithm</td></tr>
+          <tr><td>Collision rule</td><td class="no">—</td><td class="maybe">propose deterministic defaults</td><td class="no">cannot choose runtime behavior</td></tr>
+          <tr><td>Receipt schema</td><td class="no">—</td><td class="maybe">propose UI-visible fields</td><td class="no">cannot declare schema</td></tr>
+          <tr><td>Obsidian / MCP integration</td><td class="no">—</td><td class="maybe">propose adapter boundary copy</td><td class="no">cannot make them authority</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <!-- ============== 10 ============== -->
+    <section class="spec" id="s10">
+      <h2><span class="secnum">10 ·</span>Open questions</h2>
+      <ol>
+        <li><strong>Are Tier 1 (proposal) and Tier 3 (governance-bearing) the same?</strong>
+          Both produce a queued artifact for human review. The design separates them because a
+          Tier 1 proposal is the agent saying "I would like to do X", whereas a Tier 3
+          governance-bearing action is the agent invoking a known action whose semantics
+          require governance (rename, scope change, memory promotion). Owner-doc decides
+          whether the distinction stays.</li>
+        <li><strong>Idempotency window.</strong> 24 hours is a placeholder. Per-action default?
+          Single fixed value? Owner-doc decides.</li>
+        <li><strong>Collision rule taxonomy.</strong> The design names <code>suffix</code> as
+          the first rule. Future rules — <code>merge</code>, <code>refuse</code>,
+          <code>timestamp</code> — should be enumerated in the registry. Suggest:
+          declarative-per-action, never inferred at invoke time.</li>
+        <li><strong>Cross-vault actions.</strong> The first action is single-vault. Multi-vault
+          moves are deferred. Should a Tier 2 multi-vault action be feasible at all, or always
+          Tier 3? Suggest Tier 3 (governance-bearing).</li>
+        <li><strong>Where do new actions come from?</strong> The flow we imagine: a need
+          surfaces (e.g. archive completed commitments), a design exploration proposes the
+          action shape, a normalized spec adds it to the registry. Owner-doc should declare
+          whether registry changes themselves are governance-bearing.</li>
+        <li><strong>Should classifier confidence affect tier?</strong> Currently no — confidence
+          is rendered for transparency but does not gate. If owner-doc wants a low-confidence
+          downgrade, that becomes a step-04 rule.</li>
+        <li><strong>Receipt retention.</strong> How long do action receipts live? Suggest:
+          forever, in vault, as a subordinate artifact. Owner-doc decides.</li>
+      </ol>
+    </section>
+
+    <!-- ============== 11 ============== -->
+    <section class="spec" id="s11">
+      <h2><span class="secnum">11 ·</span>Handoff notes for Claude Code / Codex</h2>
+
+      <h3>Linked issue</h3>
+      <ul>
+        <li><strong>#910 — Tool authority taxonomy.</strong> This package is the first-pass
+          design artifact for that issue.</li>
+      </ul>
+
+      <h3>Likely normalized spec</h3>
+      <ul>
+        <li>New owner-doc: <code>docs/CONCEPTS/VAULT_ACTION_LAYER_CONTRACT.md</code> — defines
+          the 9-step pipeline, the tier taxonomy, the registry contract, the receipt shape.</li>
+        <li>Referenced from <code>INTERACTION_SURFACES_AND_AUTHORITY/</code> and
+          <code>STATE_EXECUTION_AUTHORITY_REMAINS_GATED.md</code>.</li>
+      </ul>
+
+      <h3>Likely follow-on issues</h3>
+      <ul>
+        <li><em>Register the first bounded action.</em> <code>move_inbox_note_to_workbench@v1</code>.
+          Acceptance: full pipeline runs against a fixture vault; eight designed states render
+          from eight fixture inputs; receipts are durable and inspectable.</li>
+        <li><em>Define Tier 4 forbidden list.</em> Acceptance: owner-doc names the explicit
+          forbidden primitives (raw write, raw delete, shell, eval) so the boundary is auditable.</li>
+        <li><em>Define the registry write path.</em> Acceptance: adding a new action requires
+          a PR that lands an entry; the entry declares tier, source/destination domains,
+          allowed types, idempotency key, collision rule, undo strategy.</li>
+        <li><em>Obsidian adapter for <code>move_inbox_note_to_workbench</code>.</em>
+          Acceptance: action runs through the pipeline; Obsidian performs the FS move; receipt
+          referenced from the status doc.</li>
+        <li><em>MCP-server exposure boundary.</em> Acceptance: the MCP server exposes only
+          registry actions by name; raw FS primitives are absent.</li>
+      </ul>
+
+      <h3>What this design must not feed</h3>
+      <ul>
+        <li>A generic "agent tools" library decoupled from the registry.</li>
+        <li>An Obsidian-or-MCP-as-primary-mutation-surface direction.</li>
+        <li>Auto-elevation of an agent's tier at runtime.</li>
+        <li>Silent failure paths.</li>
+      </ul>
+
+      <div class="callout vault">
+        <span class="callout-label">Validation expectation</span>
+        Passing receipt: the pipeline runs end-to-end against fixture inputs for all eight
+        designed states; refusals produce receipts at the refusing step; the Obsidian adapter
+        path runs the full pipeline; the MCP-exposed surface offers only registry names.
+        Receipt id recorded in this package's status field.
+      </div>
+    </section>
+
+  </main>
+</div>
+</body>
+</html>

--- a/companion-ui/design_handoff/2026-05-14-vault-action-layer/spec_chrome.css
+++ b/companion-ui/design_handoff/2026-05-14-vault-action-layer/spec_chrome.css
@@ -1,0 +1,423 @@
+/* ============================================================
+   Yggdrasil Design Handoff — Shared Spec Chrome
+   ============================================================
+   Page layout, TOC, sections, tables, callouts, chips, code,
+   gallery cards. Imported by each prototype.html after
+   colors_and_type.css.
+   ============================================================ */
+
+html, body { background: var(--bg-base); }
+body {
+  background-image:
+    linear-gradient(rgba(0,212,232,0.022) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0,212,232,0.022) 1px, transparent 1px);
+  background-size: 48px 48px;
+}
+
+.page {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: var(--space-12) var(--space-8) var(--space-16);
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: var(--space-12);
+}
+
+/* ---- Sidebar TOC ---- */
+.toc {
+  position: sticky;
+  top: var(--space-8);
+  align-self: start;
+  font-size: var(--text-sm);
+  border-left: 1px solid var(--border);
+  padding-left: var(--space-4);
+  max-height: calc(100vh - var(--space-12));
+  overflow-y: auto;
+}
+.toc-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  margin-bottom: var(--space-3);
+}
+.toc ol { list-style: none; display: flex; flex-direction: column; gap: 6px; }
+.toc a {
+  color: var(--fg-2);
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  display: block;
+  line-height: 1.4;
+}
+.toc a:hover { color: var(--cyan); text-decoration: none; }
+.toc-num {
+  font-family: var(--font-mono);
+  color: var(--fg-3);
+  margin-right: 6px;
+  font-size: var(--text-xs);
+}
+
+/* ---- Header ---- */
+.doc-header {
+  border-bottom: 1px solid var(--border);
+  padding-bottom: var(--space-6);
+  margin-bottom: var(--space-10);
+}
+.doc-eyebrow {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--cyan);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  margin-bottom: var(--space-3);
+}
+.doc-title {
+  font-family: var(--font-display);
+  font-size: var(--text-3xl);
+  line-height: 1.1;
+  margin-bottom: var(--space-4);
+  color: var(--fg-1);
+}
+.doc-lede {
+  color: var(--fg-2);
+  font-size: var(--text-md);
+  max-width: 70ch;
+  margin-bottom: var(--space-5);
+  line-height: var(--leading-snug);
+}
+.doc-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4) var(--space-6);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+}
+.doc-meta span strong {
+  color: var(--fg-2);
+  font-weight: var(--weight-regular);
+  margin-right: 6px;
+}
+
+/* ---- Sections ---- */
+section.spec {
+  margin-bottom: var(--space-12);
+  scroll-margin-top: var(--space-6);
+}
+section.spec > h2 {
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-regular);
+  color: var(--fg-1);
+  margin-bottom: var(--space-2);
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+}
+section.spec > h2 .secnum {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--cyan);
+  letter-spacing: var(--tracking-wide);
+}
+section.spec > .lede {
+  color: var(--fg-2);
+  font-size: var(--text-base);
+  margin-bottom: var(--space-5);
+  max-width: 72ch;
+}
+section.spec h3 {
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--fg-1);
+  margin: var(--space-6) 0 var(--space-3);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+}
+section.spec p {
+  color: var(--fg-1);
+  margin-bottom: var(--space-3);
+  max-width: 72ch;
+}
+section.spec ul, section.spec ol {
+  color: var(--fg-1);
+  margin: 0 0 var(--space-4) var(--space-5);
+  max-width: 72ch;
+}
+section.spec li { margin-bottom: 6px; line-height: 1.55; }
+
+/* ---- Tables ---- */
+table.spec {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+  margin: var(--space-3) 0 var(--space-5);
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+}
+table.spec th, table.spec td {
+  text-align: left;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+table.spec th {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--fg-2);
+  background: var(--bg-raised);
+  font-weight: var(--weight-medium);
+  border-bottom: 1px solid var(--border-strong);
+}
+table.spec tr:last-child td { border-bottom: none; }
+table.spec td code { font-size: 0.9em; }
+table.spec td.mono, table.spec th.mono { font-family: var(--font-mono); }
+table.spec td.yes { color: var(--vault); font-family: var(--font-mono); font-size: var(--text-xs); }
+table.spec td.no { color: var(--destructive); font-family: var(--font-mono); font-size: var(--text-xs); }
+table.spec td.maybe { color: var(--amber); font-family: var(--font-mono); font-size: var(--text-xs); }
+
+/* ---- Callouts ---- */
+.callout {
+  border-left: 2px solid var(--cyan);
+  background: rgba(0,212,232,0.04);
+  padding: var(--space-3) var(--space-4);
+  margin: var(--space-4) 0;
+  font-size: var(--text-sm);
+  color: var(--fg-1);
+  max-width: 72ch;
+}
+.callout.warn { border-left-color: var(--amber); background: rgba(240,144,48,0.05); }
+.callout.invariant { border-left-color: var(--accent); background: rgba(212,168,67,0.04); }
+.callout.danger { border-left-color: var(--destructive); background: rgba(255,61,61,0.04); }
+.callout.vault { border-left-color: var(--vault); background: rgba(57,232,125,0.04); }
+.callout-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--cyan);
+  display: block;
+  margin-bottom: 4px;
+}
+.callout.warn .callout-label { color: var(--amber); }
+.callout.invariant .callout-label { color: var(--accent); }
+.callout.danger .callout-label { color: var(--destructive); }
+.callout.vault .callout-label { color: var(--vault); }
+
+/* ---- Tag chips ---- */
+.chip {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wide);
+  padding: 1px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-strong);
+  background: var(--bg-raised);
+  color: var(--fg-2);
+}
+.chip.design  { color: var(--cyan); border-color: rgba(0,212,232,0.3); }
+.chip.impl    { color: var(--accent); border-color: rgba(212,168,67,0.3); }
+.chip.gated   { color: var(--amber); border-color: rgba(240,144,48,0.3); }
+.chip.agent   { color: var(--agent); border-color: rgba(74,158,255,0.3); }
+.chip.vault   { color: var(--vault); border-color: rgba(57,232,125,0.3); }
+.chip.danger  { color: var(--destructive); border-color: rgba(255,61,61,0.3); }
+
+/* ---- Code blocks ---- */
+pre.code {
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--fg-1);
+  overflow-x: auto;
+  margin: var(--space-3) 0 var(--space-5);
+  line-height: 1.55;
+}
+pre.code .k { color: var(--cyan); }
+pre.code .s { color: var(--vault); }
+pre.code .c { color: var(--fg-3); font-style: italic; }
+pre.code .n { color: var(--accent); }
+pre.code .a { color: var(--agent); }
+
+/* ---- Gallery ---- */
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--space-5);
+  margin: var(--space-4) 0 var(--space-6);
+}
+.gallery.three { grid-template-columns: repeat(3, 1fr); }
+.gallery-card {
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  min-height: 240px;
+}
+.gallery-card header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  border-bottom: 1px dashed var(--border);
+  padding-bottom: 10px;
+}
+.gallery-card h4 {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wider);
+  text-transform: uppercase;
+  color: var(--fg-2);
+}
+.gallery-card .note {
+  font-size: var(--text-sm);
+  color: var(--fg-2);
+  margin: 0;
+}
+
+/* ---- Receipt pill ---- */
+.receipt {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  border-radius: var(--radius-full);
+  background: var(--bg-raised);
+  border: 1px solid var(--border-strong);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-2);
+  letter-spacing: var(--tracking-wide);
+}
+.receipt.queued  { color: var(--accent); border-color: rgba(212,168,67,0.4); }
+.receipt.applied { color: var(--vault); border-color: rgba(57,232,125,0.4); }
+.receipt.pending { color: var(--amber); border-color: rgba(240,144,48,0.4); }
+.receipt.failed  { color: var(--destructive); border-color: rgba(255,61,61,0.4); }
+.receipt .recdot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 6px currentColor;
+}
+.receipt.queued .recdot { animation: pulse 1.6s ease-in-out infinite; }
+.receipt.pending .recdot { animation: pulse 1.6s ease-in-out infinite; }
+@keyframes pulse { 0%, 100% { opacity: 0.4; } 50% { opacity: 1; } }
+
+/* ---- Buttons ---- */
+.btn {
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  padding: 5px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-raised);
+  color: var(--fg-1);
+  border: 1px solid var(--border-strong);
+  cursor: pointer;
+}
+.btn:hover { border-color: var(--cyan); color: var(--cyan); }
+.btn.primary {
+  background: var(--amber-muted);
+  color: var(--amber);
+  border-color: rgba(240,144,48,0.5);
+}
+.btn.primary:hover { background: rgba(240,144,48,0.12); border-color: var(--amber); color: var(--amber); }
+.btn.governance {
+  background: rgba(212,168,67,0.06);
+  color: var(--accent);
+  border-color: rgba(212,168,67,0.5);
+}
+.btn.governance:hover { background: rgba(212,168,67,0.12); border-color: var(--accent); }
+.btn.vault {
+  background: rgba(57,232,125,0.06);
+  color: var(--vault);
+  border-color: rgba(57,232,125,0.4);
+}
+.btn.vault:hover { background: rgba(57,232,125,0.12); border-color: var(--vault); }
+.btn.danger {
+  background: rgba(255,61,61,0.05);
+  color: var(--destructive);
+  border-color: rgba(255,61,61,0.4);
+}
+.btn.ghost { background: transparent; }
+.btn[disabled], .btn.disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.btn .kbd {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  color: var(--fg-3);
+  margin-left: 6px;
+}
+
+/* ---- Bullet list with mono prefix (for checklists) ---- */
+ul.check {
+  list-style: none;
+  margin-left: 0 !important;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+ul.check li {
+  position: relative;
+  padding-left: 22px;
+  font-size: var(--text-sm);
+}
+ul.check li::before {
+  content: '[ ]';
+  position: absolute;
+  left: 0;
+  top: 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--fg-3);
+  letter-spacing: 0;
+}
+ul.check li.done::before { content: '[x]'; color: var(--vault); }
+ul.check li.skip::before { content: '[-]'; color: var(--amber); }
+
+/* ---- Doc-template card (for handoff templates) ---- */
+.template {
+  border: 1px solid var(--border-strong);
+  background: var(--bg-surface);
+  border-radius: var(--radius-md);
+  padding: var(--space-4) var(--space-5);
+  margin: var(--space-4) 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--fg-1);
+  white-space: pre-wrap;
+  line-height: 1.65;
+  overflow-x: auto;
+}
+.template .h { color: var(--cyan); }
+.template .v { color: var(--vault); }
+.template .g { color: var(--accent); }
+.template .c { color: var(--fg-3); font-style: italic; }
+.template .a { color: var(--agent); }
+
+/* ---- Responsive ---- */
+@media (max-width: 900px) {
+  .page { grid-template-columns: 1fr; padding: var(--space-6) var(--space-4); }
+  .toc {
+    position: static;
+    max-height: none;
+    border-left: none;
+    border-bottom: 1px solid var(--border);
+    padding: 0 0 var(--space-4);
+  }
+  .gallery, .gallery.three { grid-template-columns: 1fr; }
+}

--- a/companion-ui/design_handoff/2026-05-14-vault-action-layer/state-gallery.md
+++ b/companion-ui/design_handoff/2026-05-14-vault-action-layer/state-gallery.md
@@ -1,0 +1,24 @@
+# State gallery — Vault Action Layer
+
+The full visual gallery lives in **`prototype.html` §06**. This file mirrors the state
+list for code review and acceptance-criteria use.
+
+## States
+
+1. **Allowed move** — Tier 2 success path. All nine steps pass. Receipt minted.
+2. **Denied · source** — refused at step 03 because the note type is not `inbox-item`.
+3. **Denied · destination** — refused at step 03 because destination is outside any declared
+   vault domain.
+4. **Blocked · write guard** — steps 03–04 pass; step 05 refuses (focus-mode policy).
+5. **Idempotent no-op** — same idempotency key as a prior action within window; step 06
+   returns no-op. A receipt is still produced.
+6. **Collision · resolved** — destination already exists; step 07 applies the deterministic
+   suffix rule. Auditable; not random.
+7. **Success with receipt** — canonical success shape; receipt durable, inspectable, undo
+   available.
+8. **Receipt inspection** — audit view of the same trace with parameter dump, idempotency
+   key, adapter, linked outbox event.
+
+Each gallery card shows: the resolved action name, the step at which the verdict was
+reached, the relevant evidence captions, and a terminal outcome tag (`APPLIED`, `DENIED`,
+`BLOCKED`, `NO-OP`, `RESOLVED`, `INSPECTED`).

--- a/companion-ui/design_handoff/README.md
+++ b/companion-ui/design_handoff/README.md
@@ -1,10 +1,32 @@
 # Design Handoff Archive
 
-Preserved external design artifacts and handoff packages.
+Preserved Claude Design artifacts and handoff packages. These are reference/handoff inputs, not production code.
 
-Current packages:
-- `2026-05-03-converse/` — converse surface wireframes/spec assets.
-- `2026-05-08-cognitive-temporal/` — cognitive modes, temporal cognition, and re-entry mist variant exploration files.
-- `2026-05-11-canvas-suggestion-flow/` — Canvas Suggestion Flow interaction spec: body-edit lane, governance-bearing lane, 8-state UI model, component inventory, and live interactive demo. Implementation-ready; contracts marked in §13.
+**Governance:** All packages follow the governed handoff chain defined in [`companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md`](../docs/DESIGN_HANDOFF_GOVERNANCE.md). Before any design exploration becomes implementation work, it must pass through that chain (exploration → handoff → normalized spec → issue → PR → validation receipt).
 
-These artifacts are reference/handoff inputs, not production code.
+**Term mapping:** When converting design language into architecture or implementation language, use [`companion-ui/docs/CORE_TERM_MAPPING.md`](../docs/CORE_TERM_MAPPING.md).
+
+## Current packages
+
+| Package | Date | Crossing | Related issue(s) | Notes |
+|---|---|---|---|---|
+| `2026-05-03-converse/` | 2026-05-03 | A (pre-governance) | — | Converse surface wireframes and spec assets. |
+| `2026-05-08-cognitive-temporal/` | 2026-05-08 | A (pre-governance) | — | Cognitive modes, temporal cognition, re-entry mist variants. |
+| `2026-05-11-canvas-suggestion-flow/` | 2026-05-11 | B+ | #868–#874 | Canvas Suggestion Flow: body-edit lane, governance-bearing lane, 8-state UI model, component inventory. Normalized spec: `companion-ui/docs/CANVAS_SUGGESTION_FLOW.md`. |
+| `2026-05-14-claude-design-package/` | 2026-05-14 | A (index) | #901 + others | Executive summary index for the 2026-05-14 design session. Five packages + implementation intake table. |
+| `2026-05-14-handoff-governance-pack/` | 2026-05-14 | B | **#901** | Meta-process: the six-link handoff chain, maturity checklist, review console prototype, templates. Normalized spec: `companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md`. |
+| `2026-05-14-runtime-proof-dashboard/` | 2026-05-14 | A | #865, #866, #850 | Compact single-operator proof surface. Design only — not yet a normalized spec. |
+| `2026-05-14-context-bundle-inspector/` | 2026-05-14 | A | #894, #895, #896 | Inspectable context-bundle bridge object. Design only. |
+| `2026-05-14-memory-candidate-review/` | 2026-05-14 | A | #900 | Pull-based memory candidate review queue. Design only. |
+| `2026-05-14-vault-action-layer/` | 2026-05-14 | A | #910 | 9-step vault action pipeline, 5-tier tool taxonomy. Design only. |
+
+**Crossing A** = archived, not yet through maturity checklist.
+**Crossing B** = maturity checklist passed; normalized spec exists in `companion-ui/docs/`.
+**Pre-governance** = archived before this governance doc existed; exempt from retroactive checklist.
+
+## Rules
+
+- Design artifacts in this folder are guidance only. They are not architecture authority and not runtime truth.
+- Do not implement production UI components directly from a handoff package. Route through the governed chain.
+- Do not let a design package modify or override an owner-doc in `docs/**`.
+- Implementation issues #868–#874 (canvas suggestion flow) and others remain their own task contracts. This folder does not absorb them.

--- a/companion-ui/docs/CORE_TERM_MAPPING.md
+++ b/companion-ui/docs/CORE_TERM_MAPPING.md
@@ -1,0 +1,137 @@
+State: Governance doc — term mapping for Companion UI design handoff normalization. Does not claim shipped runtime behavior.
+Doc role: Companion UI core term mapping
+Authority: Normalization reference for translating Claude Design language into Yggdrasil / Companion UI architecture language
+Owner: Companion UI / interaction model
+Temporal class: stable
+Review cadence: event-driven
+Source of truth: authoritative for term normalization
+Last reviewed: 2026-05-15
+Last verified against: companion-ui/docs/CANVAS_SUGGESTION_FLOW.md, companion-ui/docs/UI_RUNTIME_BOUNDARIES.md, companion-ui/design_handoff/2026-05-14-claude-design-package/, docs/COMPANION_UI_PRODUCT_SPEC.md, docs/SYSTEM_OF_SYSTEMS_ARCHITECTURE.md, companion-ui/design_handoff/2026-05-14-handoff-governance-pack/, issue #901
+
+# Core Term Mapping
+
+This document maps design-language terms (as they appear in Claude Design explorations, prototypes, and handoff packages) to the architecture and implementation language used in Yggdrasil owner-docs and Companion UI contracts.
+
+Use this mapping when:
+
+- Converting a design handoff into a normalized spec (`companion-ui/docs/`).
+- Writing a GitHub issue that references a design package.
+- Reviewing whether a PR correctly maps design intent to architecture terms.
+- Authoring new handoff packages to ensure they use consistent vocabulary.
+
+## Core term mapping
+
+### System and surface terms
+
+| Design language | Yggdrasil / implementation language | Authority source | Notes |
+|---|---|---|---|
+| **Companion UI** | Companion UI (same) | `docs/COMPANION_UI_PRODUCT_SPEC.md` | The human-facing product shell. Not a fourth interaction authority surface; it hosts Panel, Chat, and Automation. |
+| **Yggdrasil** | Yggdrasil (same) | `docs/ARCHITECTURE.md`, `docs/SYSTEM_OF_SYSTEMS_ARCHITECTURE.md` | The local-first cognitive prosthesis and agentic PKM runtime. The full system, not just the UI. |
+| **Panel** | Panel | `docs/INTERACTION_SURFACES_AND_AUTHORITY/NAME_THE_THREE_INTERACTION_SURFACES.md` | Command-oriented authority surface. Governance receipts surface here. |
+| **Chat** | Chat | Same as Panel source | Canvas-like conversation surface. Subordinate to document context. Not a source of truth. |
+| **Automation** | Automation | Same as Panel source | Background-execution lane. Separate from Panel and Chat. |
+| **vault** | vault / Obsidian vault | `docs/ARCHITECTURE.md` | The Obsidian Markdown vault that is the primary persistence layer. |
+| **note** / **document** | vault note / Markdown note | `docs/ARCHITECTURE.md` | A Markdown file in the vault. The document is the primary cognitive anchor. |
+| **companion note** | companion note | `docs/ARCHITECTURE.md` | A system-managed note that co-resides with its primary note. Not produced by a user. |
+| **Hugin** | Hugin (same) | `docs/COMPONENTS.md`, `docs/ARCHITECTURE.md` | The Panel agent. Command-oriented. Authority surface for governance-bearing mutations. |
+| **Munin** | Munin (same) | `docs/COMPONENTS.md` | Background/automation agent. Not a UI-facing agent by default. |
+| **margin rail** | margin rail / overlay rail | `companion-ui/docs/OVERLAY_GRAMMAR.md` | The right-margin conversation strip in document-first layouts. Hugin is "a margin voice" in this model. |
+| **bottom sheet** | bottom sheet | `companion-ui/docs/OVERLAY_GRAMMAR.md` | Portrait-mode slide-up overlay for suggestions. 3 snap points. |
+| **split pane** | split pane | `companion-ui/docs/` | Left conversation + right document layout. One of several layout modes. |
+
+### Mode and state terms
+
+| Design language | Yggdrasil / implementation language | Authority source | Notes |
+|---|---|---|---|
+| **Find mode** | Find | `docs/COMPANION_UI_PRODUCT_SPEC.md §Mode Model` | Product affordance for retrieval and source citation. |
+| **Reorient mode** | Reorient | Same | Product affordance for interruption recovery and situational context. |
+| **Resurface mode** | Resurface | Same | Product affordance for memory and prior-work discovery. |
+| **Act mode** | Act | Same | Product affordance for governed mutations and write actions. |
+| **cognitive mode** | cognitive mode | `companion-ui/docs/COGNITIVE_MODES.md` | The user's current cognitive posture (e.g., deep work, orientation, resurfacing). Declared by the runtime; rendered by UI. |
+| **orientation** | orientation / re-entry | `companion-ui/docs/COGNITIVE_MODES.md`, `companion-ui/docs/POSTURE_TRANSITIONS.md` | The moment of re-entering a context after interruption. |
+| **staged state** | staged / suggestion-staged | `companion-ui/docs/CANVAS_SUGGESTION_FLOW.md` | A proposal is visible and awaiting user action (apply or discard). |
+| **apply-pending** | `apply_pending` | `companion-ui/docs/CANVAS_SUGGESTION_FLOW.md` | Body edit is being written via `canvas_writer`. Composer disabled. |
+| **governance-pending** | `governance_pending` | `companion-ui/docs/CANVAS_SUGGESTION_FLOW.md` | Governance action being routed via `GovernanceRouter`. |
+| **receipt** | receipt / governance receipt | `companion-ui/docs/CANVAS_SUGGESTION_FLOW.md`, Panel contracts | A structured confirmation returned by the governance pipeline. Surfaces as `ReceiptPill` in UI. |
+| **dead-letter** | dead-letter / outbox dead-letter | `docs/ARCHITECTURE.md` | An outbox message that failed all retry attempts. |
+| **proof** / **runtime proof** | runtime proof / validation receipt | `docs/STATUS.md`, `docs/ARCHITECTURE.md` | Evidence that the system's current state matches declared invariants. Not a UI concept. |
+
+### Action and pipeline terms
+
+| Design language | Yggdrasil / implementation language | Authority source | Notes |
+|---|---|---|---|
+| **body edit** / **body-edit lane** | body-edit lane | `companion-ui/docs/CANVAS_SUGGESTION_FLOW.md` | User-present co-authoring of the active note body. Applies via `canvas_writer`. No governance receipt. |
+| **governance-bearing lane** | governance-bearing lane | `companion-ui/docs/CANVAS_SUGGESTION_FLOW.md` | Frontmatter, maturity, cross-note, lifecycle mutations. Queued via `GovernanceRouter`. Returns a receipt. |
+| **apply** | apply / `canvas_writer.apply_edit` | `companion-ui/docs/CANVAS_SUGGESTION_FLOW.md` | Writes a body edit to the active note. Does not generate a Panel receipt. |
+| **queue** | queue / `GovernanceRouter.request_governance_action` | `companion-ui/docs/CANVAS_SUGGESTION_FLOW.md` | Routes a governance-bearing intent through the governed pipeline. Returns `receipt_id`. |
+| **GovernanceRouter** | `GovernanceRouter` (same) | `companion-ui/docs/CANVAS_SUGGESTION_FLOW.md` | The runtime component that gates governance-bearing mutations. |
+| **canvas_writer** | `canvas_writer` (same) | `companion-ui/docs/CANVAS_SUGGESTION_FLOW.md` | The runtime component that applies body edits to the active note. |
+| **outbox** | outbox (same) | `docs/ARCHITECTURE.md` | The durable message queue for governance-bearing events. Not a UI concept. |
+| **vault action** / **tool action** | vault action / bounded action | `companion-ui/design_handoff/2026-05-14-vault-action-layer/` (design only) | A registered, policy-gated mutation of the vault via the 9-step pipeline. No owner-doc yet; see open issue #910. |
+| **tool tier** | tool tier (1–5) | Design only (Vault Action Layer package) | 5-tier authority taxonomy: read-only / proposal / bounded-write / governance-bearing / forbidden. Not yet in owner-docs. |
+| **action pipeline** | 9-step action pipeline | Design only (Vault Action Layer package) | `intent → classify → bound → policy → guard → idempotency → execute → receipt → event`. Not yet in owner-docs. |
+| **Obsidian / MCP** | Obsidian adapter / MCP adapter | Design intent (not yet an owner-doc) | Adapter layer, not primary mutation authority. Mutations must still pass through the governed pipeline. |
+
+### Design-system and visual terms
+
+| Design language | Yggdrasil / implementation language | Notes |
+|---|---|---|
+| **Norse gold** / `--accent` | governance / provenance accent color | Used for governance, Panel receipts, and provenance cues. |
+| **electric cyan** / `--cyan` | trigger / link / receipt-pending cue | Used for pending actions and navigation links. |
+| **vault green** / `--vault` | healthy / applied / reviewed state | Used for successful completion and vault-healthy states. |
+| **amber** / `--amber` | staged / stale / inferred / attention-needed | Used for proposals awaiting user action or content needing verification. |
+| **destructive red** / `--destructive` | refusal / denial / conflict / dead-letter | Used for hard failures and write-guard denials. |
+| **EB Garamond** / `--font-display` | display serif (section headers) | Marks section boundaries; not used for UI copy. |
+| **Space Grotesk** / `--font-ui` | UI sans-serif (body / labels) | Primary readable voice of the UI. |
+| **JetBrains Mono** / `--font-mono` | mono (evidence captions, ids, scores, timestamps) | The "this is evidence, not summary" voice. Used for values the runtime emits. |
+| **ReceiptPill** | `ReceiptPill` | UI component that surfaces a governance receipt. States: `queued`, `applied`, `pending`, `failed`. |
+| **callout** (cyan / amber / accent / destructive / vault) | callout variant | Design-system component for invariant and notes blocks. |
+
+### Authority-layer terms
+
+| Design language | Architecture language | Authority source |
+|---|---|---|
+| **design exploration** | design exploration | `companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md §Handoff chain` |
+| **handoff package** | handoff package | Same |
+| **normalized spec** | normalized spec | Same; lives in `companion-ui/docs/` |
+| **crossing B** | Crossing B (handoff → normalized spec) | Same; requires maturity checklist sign-off |
+| **crossing C** | Crossing C (normalized spec → issue) | Same |
+| **architecture authority** | owner-docs in `docs/**` | `docs/SYSTEM_OF_SYSTEMS_ARCHITECTURE.md` |
+| **runtime truth** | shipped code + tests + `docs/STATUS.md` | `docs/STATUS.md`, `docs/ARCHITECTURE.md` |
+| **design guidance** | design guidance (not authority) | `companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md §Authority boundary` |
+
+## Usage rules
+
+1. **Use architecture language in normalized specs, issues, and PRs.** Design language is acceptable inside a handoff package (README, prototype commentary) because it mirrors the exploration context. Outside the handoff folder, use architecture language.
+
+2. **Do not import design-only terms into owner-docs.** Terms marked "Design only" in the mapping above (vault action tier taxonomy, 9-step pipeline, etc.) must not appear in owner-docs until a separate normalized spec and issue land for them.
+
+3. **Server declares; UI renders.** When mapping design terms to implementation, never let a UI term carry authority over a runtime term. The runtime's declared class wins.
+
+4. **When in doubt, link to the authority source.** If a mapping is ambiguous, add a citation to the authority source rather than resolving the ambiguity unilaterally.
+
+## Open terms (not yet mapped to owner-docs)
+
+These design terms from the 2026-05-14 package lack a corresponding owner-doc entry and must not be treated as architecture authority until the relevant issues are resolved:
+
+| Design term | Design package | Governing issue | Status |
+|---|---|---|---|
+| 5-tier tool authority taxonomy | `2026-05-14-vault-action-layer` | #910 | Design only |
+| 9-step action pipeline | `2026-05-14-vault-action-layer` | #910 | Design only |
+| `move_inbox_note_to_workbench` (first bounded action) | `2026-05-14-vault-action-layer` | #910 | Design only |
+| `VAULT_ACTION_LAYER_CONTRACT.md` | `2026-05-14-vault-action-layer` | #910 | Future owner-doc; not yet authored |
+| Runtime Proof / Health Dashboard (9-question proof surface) | `2026-05-14-runtime-proof-dashboard` | #865, #866, #850 | Design only |
+| Context Bundle Inspector (ranked candidates, compact/expanded) | `2026-05-14-context-bundle-inspector` | #894, #895, #896 | Design only |
+| Memory Candidate Review Queue (anti-inbox mitigations, persistent banner) | `2026-05-14-memory-candidate-review` | #900 | Design only |
+| Static review console (handoff governance pack) | `2026-05-14-handoff-governance-pack` | #901 (follow-on) | Design only |
+
+## References
+
+- `companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md` — handoff chain and authority boundaries
+- `companion-ui/docs/CANVAS_SUGGESTION_FLOW.md` — example of a normalized spec; reference for canvas + suggestion terms
+- `companion-ui/docs/UI_RUNTIME_BOUNDARIES.md` — separation of concerns between UI, cognition, and persistence
+- `docs/COMPANION_UI_PRODUCT_SPEC.md` — product model; mode and surface authority
+- `docs/INTERACTION_SURFACES_AND_AUTHORITY/NAME_THE_THREE_INTERACTION_SURFACES.md` — Panel / Chat / Automation authority
+- `docs/SYSTEM_OF_SYSTEMS_ARCHITECTURE.md` — architecture spine
+- `docs/COMPONENTS.md` — Hugin, Munin, and component definitions
+- `companion-ui/design_handoff/2026-05-14-claude-design-package/README.md` — 2026-05-14 design session intake table

--- a/companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md
+++ b/companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md
@@ -1,0 +1,155 @@
+State: Governance doc — defines the design-handoff chain for Companion UI. Does not claim shipped runtime behavior.
+Doc role: Companion UI handoff governance
+Authority: Handoff chain and authority boundaries for design explorations entering the Yggdrasil implementation pipeline
+Owner: Companion UI / interaction model
+Temporal class: stable
+Review cadence: event-driven
+Source of truth: authoritative for the handoff chain
+Last reviewed: 2026-05-15
+Last verified against: companion-ui/design_handoff/, companion-ui/prompts/claude-design/README.md, docs/COMPANION_UI_PRODUCT_SPEC.md, docs/SYSTEM_OF_SYSTEMS_ARCHITECTURE.md, docs/INTEGRATION_FABRIC_CONTRACT.md, docs/CAPABILITY_CONTRACT_MODEL.md, companion-ui/design_handoff/2026-05-14-claude-design-package/README.md, companion-ui/design_handoff/2026-05-14-handoff-governance-pack/, issue #901
+
+# Design Handoff Governance
+
+This document defines how Claude Design explorations become normalized implementation inputs inside the Yggdrasil / Companion UI repo — without becoming architecture authority or runtime truth on the way.
+
+## Handoff chain
+
+Every Claude Design exploration that is intended to influence Companion UI implementation must travel the following chain before any production code or owner-doc changes are made:
+
+```
+exploration → handoff package → normalized spec → GitHub issue → PR → validation receipt
+```
+
+| Step | What it is | Who owns it | Lives in |
+|---|---|---|---|
+| **exploration** | Interactive Claude Design session; HTML prototype + chat transcripts; free exploration of ideas | Designer / operator | `companion-ui/design_handoff/<date>-<name>/` |
+| **handoff package** | Archived folder of the exploration output: prototype HTML, design notes, state gallery, implementation contracts, authority boundaries, open questions | Designer / operator | `companion-ui/design_handoff/<date>-<name>/` |
+| **normalized spec** | Human-reviewed summary that maps design intent to Yggdrasil architecture language; sits in `companion-ui/docs/` | Repo maintainer | `companion-ui/docs/*.md` |
+| **GitHub issue** | Bounded implementation task derived from the normalized spec; references source docs | Agent / maintainer | GitHub Issues (`agent:ready`, scoped scope) |
+| **PR** | Implementation of the issue; references the issue and the normalized spec | Agent / maintainer | GitHub PRs |
+| **validation receipt** | CI pass + acceptance criteria verified; closed issue; updated status docs | Agent / maintainer | GitHub + `docs/STATUS.md` |
+
+### Crossings
+
+Each step-to-step transition is a **crossing**. The crossings that require explicit review are:
+
+- **Crossing B (handoff → normalized spec):** A human reviewer or designated Codex agent verifies the maturity checklist (see below) and confirms that no design-only concerns leak into the normalized spec as architecture claims or runtime assertions.
+- **Crossing C (normalized spec → issue):** The issue author confirms scope is bounded, acceptance criteria are verifiable, and no out-of-scope work is included.
+- **Crossing D (PR → merge):** Standard CI + review; confirms no runtime behavior changed outside the issue scope.
+
+Crossings A (exploration → handoff) and E (merge → receipt) are automatic / no formal gate required.
+
+### Maturity checklist (Crossing B)
+
+A handoff package passes Crossing B when all of the following are true:
+
+- [ ] The package README names the surface it covers and declares its authority status ("Visual guidance only" or equivalent).
+- [ ] `authority-boundaries.md` is present and distinguishes: design guidance / normalized spec / architecture contract / runtime truth.
+- [ ] `implementation-contracts.md` is present and lists the state enum, allowed transitions, and data attributes.
+- [ ] `open-questions.md` is present; each open question is triaged into: resolve-before-promotion / resolve-in-normalized-spec / defer-to-implementation-issue.
+- [ ] No crossing-B-blocking open questions remain unresolved.
+- [ ] The state gallery covers every declared state.
+- [ ] The package does not assert current runtime behavior unless explicitly cited from a shipped owner-doc.
+
+If any item is missing, the package remains at Crossing A until the reviewer signs off.
+
+## Authority boundary
+
+Design artifacts are **guidance and input only**. They are not:
+
+- **Architecture authority.** Architecture authority lives in `docs/**` owner docs — specifically `docs/SYSTEM_OF_SYSTEMS_ARCHITECTURE.md`, `docs/INTEGRATION_FABRIC_CONTRACT.md`, `docs/CAPABILITY_CONTRACT_MODEL.md`, and the interaction-surface contracts under `docs/INTERACTION_SURFACES_AND_AUTHORITY/`.
+- **Runtime truth.** Runtime truth lives in shipped code, tests, `docs/STATUS.md`, `docs/ARCHITECTURE.md`, and validation receipts.
+- **A schema declaration.** Design prototypes reference fields and attributes; they do not declare them. Schema changes go through owner-doc PRs.
+- **A claim about current behavior.** Unless a design passage explicitly cites a shipped owner-doc, assume it is target-state.
+
+This boundary is absolute. A design artifact that appears to contradict an owner-doc does not win. The owner-doc wins and the design passage should be treated as a proposal, not a correction.
+
+### Invariants this governance honors
+
+The following invariants apply to every handoff package and every normalized spec derived from one:
+
+- **Gated execution.** No interaction surface designed in a handoff package may mutate durable state outside the existing governed path: policy, validation, event pipeline, deterministic writer.
+- **Authority separation.** Chat is a canvas surface; Panel is the command surface; Automation is its own lane. Handoff packages do not collapse them.
+- **Provenance visibility.** Where a design shows agent-contributed content, it shows source, trust state, and authority flags.
+- **Memory candidacy.** Where a design touches agent memory, it never treats candidate memory as semantic authority. "Unreviewed memory is not semantic authority."
+- **Server declares; UI renders.** The runtime declares class, posture, and authority. The UI renders what the server declares. The UI never re-classifies.
+
+## Folder shape
+
+Each handoff package lives at:
+
+```
+companion-ui/design_handoff/<YYYY-MM-DD>-<slug>/
+```
+
+Required files for a Crossing-B-eligible package:
+
+```
+README.md                   — what the package is, authority status, crossing target
+prototype.html              — self-contained interactive prototype
+design-notes.md             — visual rationale (optional for minimal packages)
+state-gallery.md            — every UI state described
+implementation-contracts.md — state enum, transitions, data attributes, intents
+authority-boundaries.md     — what this design is / is not
+open-questions.md           — unresolved questions with proposed owners
+```
+
+Optional:
+
+```
+colors_and_type.css         — shared design tokens (import from sibling packages if unchanged)
+spec_chrome.css             — shared spec layout (import from sibling packages if unchanged)
+edge-states.md              — degraded / empty / loading / blocked / narrow states
+```
+
+The index package `<date>-claude-design-package/` holds the executive summary, intake table, and CHANGELOG for a multi-package session. It is not a package itself — it does not require its own `prototype.html`.
+
+## Handoff archive
+
+Packages already archived in `companion-ui/design_handoff/`:
+
+| Package | Date | Crossing | Related issue(s) |
+|---|---|---|---|
+| `2026-05-03-converse` | 2026-05-03 | A (pre-governance) | — |
+| `2026-05-08-cognitive-temporal` | 2026-05-08 | A (pre-governance) | — |
+| `2026-05-11-canvas-suggestion-flow` | 2026-05-11 | B+ (normalized spec exists: `companion-ui/docs/CANVAS_SUGGESTION_FLOW.md`) | #868–#874 |
+| `2026-05-14-handoff-governance-pack` | 2026-05-14 | B (this governance doc is the normalized spec output) | **#901** |
+| `2026-05-14-runtime-proof-dashboard` | 2026-05-14 | A | #865, #866, #850 |
+| `2026-05-14-context-bundle-inspector` | 2026-05-14 | A | #894, #895, #896 |
+| `2026-05-14-memory-candidate-review` | 2026-05-14 | A | #900 |
+| `2026-05-14-vault-action-layer` | 2026-05-14 | A | #910 |
+| `2026-05-14-claude-design-package` | 2026-05-14 | A (index only) | #901 (governance), others per package |
+
+Pre-governance packages (`2026-05-03`, `2026-05-08`) do not require retroactive maturity-checklist completion. They remain valid exploration archives.
+
+## Do not implement yet
+
+The following are explicitly not authorized by this governance doc. They remain downstream:
+
+- **Production Companion UI components** for packages 02–05 (runtime-proof dashboard, context bundle inspector, memory candidate review, vault action layer). Each requires a separate normalized spec and bounded issue before implementation.
+- **The review console** described in the handoff governance pack. It is a design prototype; it is not production code. Implementation requires a dedicated issue.
+- **New owner-docs** for packages 02–05. These are proposed in the design package README but require human review before authoring.
+- **Implementation issues #868–#874** (canvas suggestion flow). These were defined prior to this governance doc and remain their own task contracts. This doc does not absorb or modify them.
+
+## How to introduce a new design exploration
+
+1. Run the Claude Design session using prompts from `companion-ui/prompts/claude-design/`.
+2. Export the output into a new dated folder under `companion-ui/design_handoff/`.
+3. Ensure the folder shape matches the requirements above (README, authority-boundaries, implementation-contracts, open-questions).
+4. Update `companion-ui/design_handoff/README.md` with the new entry.
+5. Route to Crossing B when the maturity checklist is complete.
+6. After Crossing B approval, author a normalized spec in `companion-ui/docs/`.
+7. Create a bounded GitHub issue from the normalized spec.
+8. Implement via the standard `issue-to-code` flow.
+
+## References
+
+- `companion-ui/docs/CORE_TERM_MAPPING.md` — maps design-language terms to architecture terms
+- `companion-ui/docs/CANVAS_SUGGESTION_FLOW.md` — example of a normalized spec derived from a handoff
+- `companion-ui/design_handoff/2026-05-14-claude-design-package/README.md` — intake summary for the 2026-05-14 design session
+- `companion-ui/design_handoff/2026-05-14-handoff-governance-pack/` — the design prototype that proposed this chain
+- `docs/COMPANION_UI_PRODUCT_SPEC.md` — product model; authority on Companion UI surfaces and modes
+- `docs/INTERACTION_SURFACES_AND_AUTHORITY/NAME_THE_THREE_INTERACTION_SURFACES.md` — interaction surface authority
+- `docs/SYSTEM_OF_SYSTEMS_ARCHITECTURE.md` — architecture spine
+- `docs/INTEGRATION_FABRIC_CONTRACT.md` — integration fabric contracts
+- `docs/CAPABILITY_CONTRACT_MODEL.md` — capability contract model

--- a/companion-ui/prompts/claude-design/README.md
+++ b/companion-ui/prompts/claude-design/README.md
@@ -1,8 +1,31 @@
 # Claude Design Prompts
 
-Use this folder for prompts that generate or refine interaction and visual handoff material.
+Use this folder for prompts that generate or refine interaction and visual handoff material for Yggdrasil / Companion UI.
 
-Prompt posture:
+## Governance
+
+Output from Claude Design sessions must land in the governed handoff chain before becoming implementation work. See:
+
+- [`companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md`](../../docs/DESIGN_HANDOFF_GOVERNANCE.md) — the full handoff chain (exploration → handoff → normalized spec → issue → PR → receipt), maturity checklist, and authority boundaries.
+- [`companion-ui/docs/CORE_TERM_MAPPING.md`](../../docs/CORE_TERM_MAPPING.md) — maps design-language terms to Yggdrasil architecture language.
+- [`companion-ui/design_handoff/README.md`](../../design_handoff/README.md) — the handoff archive index.
+
+**Design output is guidance only.** It is not architecture authority and not runtime truth. Architecture authority lives in `docs/**` owner-docs.
+
+## Prompt posture
+
 - Preserve document-first, overlay-first interaction.
 - Keep chat subordinate to document context.
 - Avoid dashboard-style AI UX.
+- Honor the gated-execution invariant: no interaction surface should mutate durable state outside the governed pipeline.
+- The server declares class, posture, and authority; the UI renders. Design prompts should reflect this — do not propose UI surfaces that re-classify runtime state.
+
+## Folder shape for exported packages
+
+When a Claude Design session produces a handoff package, export it to:
+
+```
+companion-ui/design_handoff/<YYYY-MM-DD>-<slug>/
+```
+
+Required files for a Crossing-B-eligible package: `README.md`, `prototype.html`, `implementation-contracts.md`, `authority-boundaries.md`, `open-questions.md`. See `DESIGN_HANDOFF_GOVERNANCE.md` for the full folder-shape spec.


### PR DESCRIPTION
Closes #901

## Summary

Defines the governed design handoff chain for Companion UI, archives the 2026-05-14 Claude Design package (v2, five packages), and establishes term normalization so future design explorations flow cleanly into implementation without becoming architecture authority.

This is docs/governance only. No production UI implemented. No runtime behavior changed. No `docs/**` owner-docs modified.

## Changes

| File | Change |
|---|---|
| `companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md` | **New** — six-link handoff chain, maturity checklist, crossing definitions, authority boundaries, folder shape, "do not implement yet" boundaries |
| `companion-ui/docs/CORE_TERM_MAPPING.md` | **New** — design language → Yggdrasil architecture language mapping across surface, mode, action/pipeline, visual, and authority-layer terms |
| `companion-ui/design_handoff/2026-05-14-claude-design-package/` | **New** — actual design package (v2): index.html, README.md, CHANGELOG.md, CSS; replaces earlier placeholder |
| `companion-ui/design_handoff/2026-05-14-handoff-governance-pack/` | **New** — governs the handoff chain process; 10 files |
| `companion-ui/design_handoff/2026-05-14-runtime-proof-dashboard/` | **New** — design only; issues #865/#866/#850 |
| `companion-ui/design_handoff/2026-05-14-context-bundle-inspector/` | **New** — design only; issues #894/#895/#896 |
| `companion-ui/design_handoff/2026-05-14-memory-candidate-review/` | **New** — design only; issue #900 |
| `companion-ui/design_handoff/2026-05-14-vault-action-layer/` | **New** — design only; issue #910 |
| `companion-ui/design_handoff/README.md` | **Updated** — package index table with crossing status, related issues, governance pointer |
| `companion-ui/prompts/claude-design/README.md` | **Updated** — governance pointer, invariant posture notes, folder-shape spec |

## Validation

```
✅ companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md exists
✅ § Authority boundary present + states design artifacts are not architecture authority / not runtime truth
✅ companion-ui/docs/CORE_TERM_MAPPING.md exists
✅ companion-ui/design_handoff/README.md references DESIGN_HANDOFF_GOVERNANCE
✅ companion-ui/prompts/claude-design/README.md references DESIGN_HANDOFF_GOVERNANCE
✅ companion-ui/design_handoff/README.md references CORE_TERM_MAPPING
✅ git diff --check: clean (no whitespace errors)
✅ No files changed outside companion-ui/
✅ No production UI components added
✅ No docs/** owner-docs modified
✅ Implementation issues #868–#874 remain downstream and untouched
```

## Review findings (three-angle review)

### 1. Architecture/governance review

- **Design guidance vs authority:** `DESIGN_HANDOFF_GOVERNANCE.md § Authority boundary` explicitly states design artifacts are "guidance and input only" and not architecture authority or runtime truth. The boundary is stated as absolute.
- **Architecture authority remains in repo docs:** All owner-doc references are read-only. No `docs/**` file was modified. Architecture authority remains in `docs/SYSTEM_OF_SYSTEMS_ARCHITECTURE.md`, `docs/INTEGRATION_FABRIC_CONTRACT.md`, `docs/CAPABILITY_CONTRACT_MODEL.md`, and the `INTERACTION_SURFACES_AND_AUTHORITY/` tree.
- **Runtime truth remains in runtime state/events/stores:** The governance doc explicitly names `docs/STATUS.md`, `docs/ARCHITECTURE.md`, shipped code, tests, and validation receipts as the home of runtime truth. Design packages do not claim runtime behavior.

### 2. Implementation-boundary review

- **No production Companion UI components implemented.** The handoff packages are prototype HTML design artifacts. They are archived under `companion-ui/design_handoff/`, not `companion-ui/companion-app/` or any production path.
- **No runtime behavior changed.** Zero application code touched.
- **Implementation issues #868–#874** are listed explicitly in `DESIGN_HANDOFF_GOVERNANCE.md § Do not implement yet` and `companion-ui/design_handoff/README.md`. The package `2026-05-14-handoff-governance-pack` is noted as Crossing B (normalized spec = this governance doc). Packages 02–05 remain at Crossing A — design only.

### 3. Documentation-quality review

- `DESIGN_HANDOFF_GOVERNANCE.md` defines all five chain steps, crossing definitions, maturity checklist (7 items), a handoff archive table, and a "do not implement yet" list. Sufficient for a future coding agent to determine which packages are implementation-ready vs. design-only.
- `CORE_TERM_MAPPING.md` maps 40+ terms across five categories. "Design only" terms (vault action tier, 9-step pipeline) are explicitly flagged with governing issue numbers and "no owner-doc yet" status.
- Open questions, risks, non-goals, and "do not implement yet" boundaries are explicit in both docs.
- Term consistency: design-language terms used in handoff package docs are mapped to the architecture terms used in Yggdrasil owner-docs.

## Dispatcher / claim notes

- Dispatcher unavailable (no local `app.dispatcher`); used GitHub-label-only claim via `scripts/issue_pickup_claim.sh`.
- Issue #901 moved to `In Progress` in Project `Agent Delivery Control Plane`.
- `agent:ready` label removed by claim script.

## No production UI / runtime changes

This PR changes no application code, no runtime behavior, and no `docs/**` owner-docs. It is exclusively:
- New governance docs in `companion-ui/docs/`
- Archived design artifacts in `companion-ui/design_handoff/`
- Updated README/prompt docs in `companion-ui/design_handoff/` and `companion-ui/prompts/`