### PR TITLE
fix(runtime): stabilize prod startup verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ prod-start-full: require-vault-root
 	COMPOSE_PROJECT_NAME="pkm-prod" \
 	PKM_ENVIRONMENT="prod" \
 	VAULT_ROOT="$(VAULT_ROOT)" \
+	VERIFY_RUNTIME_SERVICE_WAIT_SECONDS=60 \
 	scripts/start_full_system.sh
 
 test-up:

--- a/docs/runbooks/RUNBOOK_STARTUP_FULL_SYSTEM.md
+++ b/docs/runbooks/RUNBOOK_STARTUP_FULL_SYSTEM.md
@@ -8,10 +8,46 @@ Reading note:
 - not the full target-state architecture,
 - and not a claim that the current compose/runtime wiring is the permanent system decomposition.
 
-## Command-first startup
+## Prod startup (canonical)
+
+For the production runtime (`stable` channel against the real vault), use the `prod-start-full` target.
+This uses the prod compose overlay, the `pkm-prod` project namespace, explicit `prod` environment, and an
+operator-supplied `VAULT_ROOT`. Do not guess or substitute a dev/test vault path.
+
+```bash
+export VAULT_ROOT="/absolute/path/to/your/real/vault"
+make prod-start-full
+```
+
+- API is exposed on host port **18000**.
+- `VAULT_ROOT` must be set to the real operator vault path by the operator before startup.
+- The prod runtime root is the repo checkout directory (e.g., `/Users/rasmus/workspace`), not a sub-directory. Ensure the correct worktree is used.
+
+For LLM configuration when using a local Ollama endpoint via the OpenAI-compatible API (provider=`openai`):
+- Set `OPENAI_BASE_URL` to the reachable Ollama base URL (e.g., `http://host.docker.internal:11434/v1`).
+- Set `OPENAI_API_KEY` to a non-empty placeholder (e.g., `sk-local`).
+- The runtime env generator derives `OPENAI_BASE` from `OPENAI_BASE_URL` automatically when not explicitly set.
+
+## Startup success verification
+
+A successful startup writes a machine-readable receipt to `tmp/startup_status.json`.
+A startup is complete and healthy when:
+
+```json
+{
+  "startup_succeeded": true,
+  "runtime_verified": true,
+  "exit_code": 0,
+  "phase": "done"
+}
+```
+
+Check the receipt before enabling watcher auto-exec or accepting traffic.
+
+## Command-first startup (dev/test)
 1. From repo root, run:
 ```
-make alpha-up
+make start
 ```
 2. The script:
    - `scripts/start_full_system.sh` runs `docker compose up -d db api worker watcher`
@@ -19,11 +55,18 @@ make alpha-up
    - requires `LLM_PROVIDER` + `LLM_MODEL`; mock requires no endpoint, Ollama accepts `OLLAMA_URL` or `OPENAI_BASE_URL`, other providers require `OPENAI_BASE_URL`
    - waits for `/api/status` then `/api/health` to report runtime `db`/`worker`/`watcher` as ok (timeout 60s)
    - optional checks like `ffmpeg` are ignored by default via `STARTUP_IGNORE_CHECKS=ffmpeg` (set to `""` for strict mode)
-   - Obsidian compatibility check runs by default (`STARTUP_CHECK_OBSIDIAN=1`) and reports pass/warning in startup telemetry
+   - Obsidian compatibility check runs by default (`STARTUP_CHECK_OBSIDIAN=1`) and reports pass/warning in startup telemetry; an Obsidian warning is **not** a startup blocker when `required=false` in the health output
    - optional strict Obsidian gate: set `STARTUP_ENFORCE_OBSIDIAN=1` to fail fast unless host Obsidian dependency checks pass (`obsidian` CLI + installer floor)
    - vault read/write probe runs inside the `api` container before watcher/worker startup; set `STARTUP_REQUIRE_VAULT_RW=1` to make rw probe failures fatal outside verify mode
    - on failure, prints `docker compose ps`, tails api/worker/watcher logs, and dumps `/api/health`
    - startup summary prints `obsidian gate: enabled=<...> status=<...>` and `tmp/startup_status.json` includes `obsidian_gate_enabled|ok|detail`
+
+## Config externalization follow-up
+
+The current prod startup requires operators to supply LLM env vars (`OPENAI_BASE_URL`, `OPENAI_API_KEY`, etc.)
+manually before running the startup script. A separate settings/config gap-analysis PR will externalize
+configuration through the existing settings model (`vault/@Settings/providers.md` and related surfaces).
+Do not perform that gap analysis in this runbook; handle it through the standard docs-to-issue workflow.
 
 ## Alpha Compose Runtime (canonical)
 - Services: `db`, `api`, `watcher`, `worker`.

--- a/docs/runbooks/RUNBOOK_STARTUP_FULL_SYSTEM.md
+++ b/docs/runbooks/RUNBOOK_STARTUP_FULL_SYSTEM.md
@@ -26,7 +26,7 @@ make prod-start-full
 For LLM configuration when using a local Ollama endpoint via the OpenAI-compatible API (provider=`openai`):
 - Set `OPENAI_BASE_URL` to the reachable Ollama base URL (e.g., `http://host.docker.internal:11434/v1`).
 - Set `OPENAI_API_KEY` to a non-empty placeholder (e.g., `sk-local`).
-- The runtime env generator derives `OPENAI_BASE` from `OPENAI_BASE_URL` automatically when not explicitly set.
+- The runtime env generator derives `OPENAI_BASE` (the full chat-completions URL used by the adapter) from `OPENAI_BASE_URL` by appending `/chat/completions`. An explicitly set `OPENAI_BASE` is written as-is and takes precedence.
 
 ## Startup success verification
 

--- a/scripts/export_runtime_env.sh
+++ b/scripts/export_runtime_env.sh
@@ -95,6 +95,19 @@ if [ -n "$scope_glob_raw" ]; then
   printf "%s\n" "WATCHER_SCOPE_GLOB=$scope_glob_raw" >> "$runtime_env_path"
 fi
 
+# Compatibility shim: when OPENAI_BASE_URL is set for OpenAI-compatible local routing
+# and OPENAI_BASE is not explicitly set, derive OPENAI_BASE so that route health checks
+# and the adapter (which read OPENAI_BASE) can find the endpoint.
+# This is a one-way derivation — it does not override an explicitly set OPENAI_BASE.
+if [ -n "${OPENAI_BASE_URL:-}" ] && [ -z "${OPENAI_BASE:-}" ]; then
+  printf "%s\n" "OPENAI_BASE=${OPENAI_BASE_URL}" >> "$runtime_env_path"
+fi
+
+# Propagate OPENAI_API_KEY if set; required by route health checks for the openai provider.
+if [ -n "${OPENAI_API_KEY:-}" ]; then
+  printf "%s\n" "OPENAI_API_KEY=${OPENAI_API_KEY}" >> "$runtime_env_path"
+fi
+
 if [ "${LLM_PROVIDER:-}" = "ollama" ]; then
   python3 - <<'PY' >> "$runtime_env_path"
 from __future__ import annotations

--- a/scripts/export_runtime_env.sh
+++ b/scripts/export_runtime_env.sh
@@ -95,12 +95,16 @@ if [ -n "$scope_glob_raw" ]; then
   printf "%s\n" "WATCHER_SCOPE_GLOB=$scope_glob_raw" >> "$runtime_env_path"
 fi
 
-# Compatibility shim: when OPENAI_BASE_URL is set for OpenAI-compatible local routing
-# and OPENAI_BASE is not explicitly set, derive OPENAI_BASE so that route health checks
-# and the adapter (which read OPENAI_BASE) can find the endpoint.
-# This is a one-way derivation — it does not override an explicitly set OPENAI_BASE.
-if [ -n "${OPENAI_BASE_URL:-}" ] && [ -z "${OPENAI_BASE:-}" ]; then
-  printf "%s\n" "OPENAI_BASE=${OPENAI_BASE_URL}" >> "$runtime_env_path"
+# OPENAI_BASE is the full chat-completions URL used directly by the adapter and health checks
+# (e.g. http://host.docker.internal:11434/v1/chat/completions).
+# If the operator set it explicitly, write it as-is.
+# Otherwise, if OPENAI_BASE_URL is set (OpenAI-compatible base), derive the chat-completions
+# URL by stripping a trailing slash and appending /chat/completions.
+if [ -n "${OPENAI_BASE:-}" ]; then
+  printf "%s\n" "OPENAI_BASE=${OPENAI_BASE}" >> "$runtime_env_path"
+elif [ -n "${OPENAI_BASE_URL:-}" ]; then
+  _derived_openai_base="${OPENAI_BASE_URL%/}/chat/completions"
+  printf "%s\n" "OPENAI_BASE=${_derived_openai_base}" >> "$runtime_env_path"
 fi
 
 # Propagate OPENAI_API_KEY if set; required by route health checks for the openai provider.

--- a/tests/ops/test_export_runtime_env.py
+++ b/tests/ops/test_export_runtime_env.py
@@ -67,10 +67,21 @@ def test_export_runtime_env_derives_openai_base_from_openai_base_url(tmp_path: P
     subprocess.check_call(["bash", "scripts/export_runtime_env.sh"], cwd=str(repo_root), env=env)
 
     text = out_path.read_text(encoding="utf-8")
-    assert re.search(r"^OPENAI_BASE=http://host\.docker\.internal:11434/v1$", text, re.M)
+    assert re.search(r"^OPENAI_BASE=http://host\.docker\.internal:11434/v1/chat/completions$", text, re.M)
 
 
-def test_export_runtime_env_does_not_override_explicit_openai_base(tmp_path: Path) -> None:
+def test_export_runtime_env_propagates_explicit_openai_base(tmp_path: Path) -> None:
+    repo_root, out_path, env = _runtime_env_with_db(tmp_path)
+    env["OPENAI_BASE"] = "https://api.example.invalid/v1/chat/completions"
+    env.pop("OPENAI_BASE_URL", None)
+
+    subprocess.check_call(["bash", "scripts/export_runtime_env.sh"], cwd=str(repo_root), env=env)
+
+    text = out_path.read_text(encoding="utf-8")
+    assert re.search(r"^OPENAI_BASE=https://api\.example\.invalid/v1/chat/completions$", text, re.M)
+
+
+def test_export_runtime_env_explicit_openai_base_wins_over_url(tmp_path: Path) -> None:
     repo_root, out_path, env = _runtime_env_with_db(tmp_path)
     env["OPENAI_BASE_URL"] = "http://host.docker.internal:11434/v1"
     env["OPENAI_BASE"] = "https://api.example.invalid/v1/chat/completions"
@@ -78,6 +89,7 @@ def test_export_runtime_env_does_not_override_explicit_openai_base(tmp_path: Pat
     subprocess.check_call(["bash", "scripts/export_runtime_env.sh"], cwd=str(repo_root), env=env)
 
     text = out_path.read_text(encoding="utf-8")
+    assert re.search(r"^OPENAI_BASE=https://api\.example\.invalid/v1/chat/completions$", text, re.M)
     assert "OPENAI_BASE=http://host.docker.internal:11434/v1" not in text
 
 

--- a/tests/ops/test_export_runtime_env.py
+++ b/tests/ops/test_export_runtime_env.py
@@ -51,3 +51,41 @@ def test_export_runtime_env_derives_ollama_host_from_ollama_url(tmp_path: Path) 
     text = out_path.read_text(encoding="utf-8")
     assert re.search(r"^OLLAMA_HOST=http://ollama:11434$", text, re.M)
     assert re.search(r"^OLLAMA_URL=http://ollama:11434$", text, re.M)
+
+
+def _runtime_env_with_db(tmp_path: Path) -> tuple[Path, Path, dict[str, str]]:
+    repo_root, out_path, env = _runtime_env_base(tmp_path)
+    env.setdefault("DATABASE_URL", "postgresql+psycopg://app:app@db:5432/app")
+    return repo_root, out_path, env
+
+
+def test_export_runtime_env_derives_openai_base_from_openai_base_url(tmp_path: Path) -> None:
+    repo_root, out_path, env = _runtime_env_with_db(tmp_path)
+    env["OPENAI_BASE_URL"] = "http://host.docker.internal:11434/v1"
+    env.pop("OPENAI_BASE", None)
+
+    subprocess.check_call(["bash", "scripts/export_runtime_env.sh"], cwd=str(repo_root), env=env)
+
+    text = out_path.read_text(encoding="utf-8")
+    assert re.search(r"^OPENAI_BASE=http://host\.docker\.internal:11434/v1$", text, re.M)
+
+
+def test_export_runtime_env_does_not_override_explicit_openai_base(tmp_path: Path) -> None:
+    repo_root, out_path, env = _runtime_env_with_db(tmp_path)
+    env["OPENAI_BASE_URL"] = "http://host.docker.internal:11434/v1"
+    env["OPENAI_BASE"] = "https://api.example.invalid/v1/chat/completions"
+
+    subprocess.check_call(["bash", "scripts/export_runtime_env.sh"], cwd=str(repo_root), env=env)
+
+    text = out_path.read_text(encoding="utf-8")
+    assert "OPENAI_BASE=http://host.docker.internal:11434/v1" not in text
+
+
+def test_export_runtime_env_propagates_openai_api_key(tmp_path: Path) -> None:
+    repo_root, out_path, env = _runtime_env_with_db(tmp_path)
+    env["OPENAI_API_KEY"] = "sk-local"
+
+    subprocess.check_call(["bash", "scripts/export_runtime_env.sh"], cwd=str(repo_root), env=env)
+
+    text = out_path.read_text(encoding="utf-8")
+    assert re.search(r"^OPENAI_API_KEY=sk-local$", text, re.M)

--- a/tests/ops/test_runtime_verify_contract.py
+++ b/tests/ops/test_runtime_verify_contract.py
@@ -25,3 +25,23 @@ def test_verify_runtime_stack_parses_multiline_health_meta() -> None:
     assert "sed -n '1p'" in script
     assert "sed -n '2p'" in script
     assert "sed -n '3p'" in script
+
+
+def test_prod_start_full_sets_verify_runtime_service_wait_seconds() -> None:
+    makefile = Path("Makefile").read_text(encoding="utf-8")
+    prod_block_start = makefile.find("prod-start-full:")
+    assert prod_block_start != -1, "prod-start-full target not found in Makefile"
+    prod_block_end = makefile.find("\n\n", prod_block_start)
+    prod_block = makefile[prod_block_start:prod_block_end if prod_block_end != -1 else None]
+    assert "VERIFY_RUNTIME_SERVICE_WAIT_SECONDS" in prod_block, (
+        "prod-start-full must set VERIFY_RUNTIME_SERVICE_WAIT_SECONDS to avoid false "
+        "runtime verification failures caused by worker Docker healthcheck timing"
+    )
+    import re
+    match = re.search(r"VERIFY_RUNTIME_SERVICE_WAIT_SECONDS=(\d+)", prod_block)
+    assert match is not None
+    wait_seconds = int(match.group(1))
+    assert wait_seconds >= 20, (
+        f"VERIFY_RUNTIME_SERVICE_WAIT_SECONDS={wait_seconds} is less than the worker "
+        "Docker healthcheck interval (20s); prod verification will produce false failures"
+    )


### PR DESCRIPTION
## Direct Repair

Type: code
Reason: Two false failures blocked the first prod bootstrap session. This PR removes them with minimal targeted changes — no settings redesign, no architecture changes.
Validation: unit tests pass; pre-existing docs-index failures unrelated to this PR.
Issue required: no

## Summary

Removes two false prod-startup failures identified during the first prod bootstrap:

1. **OPENAI_BASE compatibility shim** — `scripts/export_runtime_env.sh` now derives `OPENAI_BASE` from `OPENAI_BASE_URL` when only the latter is set. Route health checks (`_provider_env_check`) and the LLM adapter read `OPENAI_BASE`; operators using local Ollama via the OpenAI-compatible API set `OPENAI_BASE_URL`, causing route health to fail. The shim is a one-way derivation only (does not override an explicit `OPENAI_BASE`). `OPENAI_API_KEY` is also propagated to the runtime env file.

2. **prod-start-full verification wait** — `VERIFY_RUNTIME_SERVICE_WAIT_SECONDS=60` added to the `prod-start-full` Makefile target. The worker Docker healthcheck interval is 20s; the previous default of 10s caused false `runtime_verify_failed` on first start before the worker could pass its first healthcheck.

Docs: `RUNBOOK_STARTUP_FULL_SYSTEM.md` updated with a prod startup section covering canonical startup command, startup success criteria (`tmp/startup_status.json` fields), API port 18000, non-blocking optional Obsidian warnings, and a config-externalization follow-up note.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg"` — 2673 passed, 2 pre-existing docs-index failures unrelated to this PR (`docs/security/SECURITY_ALERT_TRIAGE_2026-05-15.md` not in DOCS_INDEX).
- Dispatcher unavailable — used GitHub-label-only claim (no dispatcher DB in this worktree).

## Files changed

| File | Change |
|---|---|
| `scripts/export_runtime_env.sh` | OPENAI_BASE shim + OPENAI_API_KEY propagation |
| `Makefile` | `VERIFY_RUNTIME_SERVICE_WAIT_SECONDS=60` in `prod-start-full` |
| `tests/ops/test_export_runtime_env.py` | 3 new tests for OPENAI_BASE derivation |
| `tests/ops/test_runtime_verify_contract.py` | 1 new test for prod-start-full wait |
| `docs/runbooks/RUNBOOK_STARTUP_FULL_SYSTEM.md` | Prod startup section + success criteria + follow-up note |

## Out of scope

- Settings/config gap analysis and externalization — tracked in #985.
- Redesign of the env var naming inconsistency between `OPENAI_BASE` and `OPENAI_BASE_URL` — tracked for the config gap-analysis PR.

---