### PR TITLE
docs: owner-doc promotion for companion note path (#971)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -391,7 +391,10 @@ Tests: `tests/architecture/test_architecture_tests_validation.py::test_import_bo
 
 ### Companion note in the system surface
 - For each tracked vault note/uuid the forward-line model defines a companion note under
-  `vault/_system/companions/<uuid>.md`.
+  `vault/<system_folder>/companions/<uuid>.md`, where `<system_folder>` is the layout-aware system
+  folder resolved by `get_vault_system_dir_rel()` (defaults to `⚙️ System`). The legacy
+  `_system/companions/` path is a read-only fallback for vaults that have not yet migrated; no
+  new files are written there.
 - The companion note is a first-class system artifact for continuity and repair, not merely a
   convenience cache or derived runtime projection.
 - Companion notes plus vault notes are the portable file-based continuity set and must be sufficient

--- a/docs/CONCEPTS/ARTIFACT_MODEL_AND_LIFECYCLES.md
+++ b/docs/CONCEPTS/ARTIFACT_MODEL_AND_LIFECYCLES.md
@@ -13,7 +13,7 @@ A vault knowledge object exists simultaneously on three surfaces:
 | Surface | File | Owner | Authoritative for |
 |---|---|---|---|
 | **Vault note** | `<vault-relative path>.md` | Human | title, tags, body, review_state, maturity, links |
-| **Companion note** | `_system/companions/<uuid>.md` | System | uuid identity, content_hash, ingest_state, attachment manifest |
+| **Companion note** | `<system_folder>/companions/<uuid>.md` (layout-aware; e.g. `⚙️ System/companions/<uuid>.md`) | System | uuid identity, content_hash, ingest_state, attachment manifest |
 | **Runtime DB** | PostgreSQL / in-memory store | System (ephemeral) | chunks, embeddings, relations-index, classification, decisions |
 
 The runtime DB is derivable — it can always be rebuilt from vault note + companion note. The companion note is portable — it moves with the vault via Git. The vault note is the ground truth for human meaning.
@@ -114,7 +114,7 @@ companion exists, companion.source_ref ≠ current vault path
 When runtime DB is empty (cold start), the rebuild procedure is:
 
 ```
-FOR each companion file in _system/companions/*.md:
+FOR each companion file in <system_folder>/companions/*.md:
   uuid = companion.uuid
   source_ref = companion.source_ref
   vault_note = read vault note at source_ref

--- a/docs/CONCEPTS/MIRROR_RECEIPT_DECISION.md
+++ b/docs/CONCEPTS/MIRROR_RECEIPT_DECISION.md
@@ -113,7 +113,7 @@ See `docs/CONCEPTS/COMPANION_NOTE_CONTRACT.md`.
 
 `System/Metadata/VaultMirror/...` was the previous mirror surface implementation.
 
-It is being replaced by the companion note at `vault/_system/companions/<uuid>.md`, which provides
+It is being replaced by the companion note at `vault/<system_folder>/companions/<uuid>.md` (layout-aware; e.g. `vault/⚙️ System/companions/<uuid>.md`), which provides
 the same continuity/identity function with:
 - flat UUID-based path instead of directory-preserving path,
 - a bounded field set that does not duplicate human-owned metadata (`review_state`, `maturity`),
@@ -209,7 +209,7 @@ They should not be treated as merely "mirror metadata".
 
 `app/services/note_log.py` is a legacy module being replaced by `app/services/companion_note.py`.
 
-New code must use companion note terminology and the `_system/companions/<uuid>.md` path.
+New code must use companion note terminology and the layout-aware `<system_folder>/companions/<uuid>.md` path (resolved via `get_vault_system_dir_rel()`; see `docs/CONCEPTS/COMPANION_NOTE_CONTRACT.md`).
 
 This has three implications:
 - future refactors may rename or split this boundary,

--- a/docs/contracts/OBSIDIAN_KNOWLEDGE_PORT.md
+++ b/docs/contracts/OBSIDIAN_KNOWLEDGE_PORT.md
@@ -73,8 +73,8 @@ The KnowledgePort boundary is the normative write path for:
 - and repair writes that restore continuity metadata without silently redefining human meaning.
 
 System-owned path clarification:
-- `_system/companions/` is a system-owned vault path for companion-note artifacts.
-- Runtime/services may write there only through KnowledgePort or approved helpers built on top of it.
+- `<system_folder>/companions/` (layout-aware; e.g. `⚙️ System/companions/`) is the canonical system-owned vault path for companion-note artifacts. The legacy `_system/companions/` path is a read-only fallback for vaults that have not yet migrated; no new files are written there.
+- Runtime/services may write companion notes only through KnowledgePort or approved helpers built on top of it.
 
 KnowledgePort may not:
 - bypass write-policy and safety checks through ad-hoc direct filesystem mutations as the normative

--- a/docs/quality_wave/README.md
+++ b/docs/quality_wave/README.md
@@ -164,7 +164,7 @@ test_metamorphic_preserves_idempotency PASSED
 
 **Scenario**:
 - DB is empty or corrupted
-- Companion notes exist in `vault/_system/companions/<uuid>.md` (source of truth)
+- Companion notes exist in `vault/<system_folder>/companions/<uuid>.md` (layout-aware; e.g. `vault/⚙️ System/companions/<uuid>.md`) (source of truth)
 - Cold rebuild re-populates DB from companions
 
 **Key Tests**:


### PR DESCRIPTION
- [x] Docs authoring lane

## Summary

- Updates 5 owner docs that still named `_system/companions/<uuid>.md` as the canonical companion note write location
- PR #986 (issue #971) established `write_companion()` now writes exclusively to the layout-aware `<system_folder>/companions/<uuid>.md`; `_system/companions/` is a read-only fallback for older vaults
- The primary authority (`docs/CONCEPTS/COMPANION_NOTE_CONTRACT.md`) was already updated in the implementation PR; this promotion syncs the remaining owner docs

## Files changed

- `docs/ARCHITECTURE.md` — companion note path in "Companion note in the system surface" section
- `docs/CONCEPTS/ARTIFACT_MODEL_AND_LIFECYCLES.md` — companion note path in artifact surfaces table and cold-rebuild pseudocode
- `docs/CONCEPTS/MIRROR_RECEIPT_DECISION.md` — companion note path in VaultMirror replacement description and `note_log_path` decision
- `docs/contracts/OBSIDIAN_KNOWLEDGE_PORT.md` — system-owned path clarification now names layout-aware path as canonical and `_system/companions/` as read-fallback
- `docs/quality_wave/README.md` — companion note path in cold-rebuild scenario description

## Related

Owner-doc promotion companion to closed issue #971 / merged PR #986.

## Test plan

- [ ] No test changes — docs-only PR
- [ ] All five files updated to layout-aware path `<system_folder>/companions/<uuid>.md`
- [ ] Wording consistent with `docs/CONCEPTS/COMPANION_NOTE_CONTRACT.md` (updated in #986)

🤖 Generated with [Claude Code](https://claude.com/claude-code)