### PR TITLE
fix(observability): expose watcher panel/ingest lifecycle counters in health status and CLI

### DIFF
--- a/app/cli/__init__.py
+++ b/app/cli/__init__.py
@@ -1250,6 +1250,43 @@ def status() -> None:
                 f"writes_blocked={watcher_automation.last_run_skipped_writes_blocked or 0} "
                 f"allowed_actions={watcher_automation.last_run_skipped_allowed_actions or 0}"
             )
+    watcher_lifecycle = getattr(status, "watcher_lifecycle", None)
+    if watcher_lifecycle:
+        click.echo("Watcher lifecycle:")
+        panel_changed = watcher_lifecycle.panel_changed_total
+        panel_emitted = watcher_lifecycle.panel_emitted_total
+        panel_rate_limited = watcher_lifecycle.panel_rate_limited_total
+        if any(v is not None for v in (panel_changed, panel_emitted, panel_rate_limited)):
+            click.echo(
+                "  panel watcher: "
+                f"changed={panel_changed if panel_changed is not None else '-'} "
+                f"emitted={panel_emitted if panel_emitted is not None else '-'} "
+                f"rate_limited={panel_rate_limited if panel_rate_limited is not None else '-'}"
+            )
+            if watcher_lifecycle.panel_last_emitted_event_at:
+                click.echo(f"  panel last_emitted_at: {watcher_lifecycle.panel_last_emitted_event_at}")
+        ingest_changed = watcher_lifecycle.ingest_changed_total
+        ingest_emitted = watcher_lifecycle.ingest_emitted_total
+        ingest_rate_limited = watcher_lifecycle.ingest_rate_limited_total
+        if any(v is not None for v in (ingest_changed, ingest_emitted, ingest_rate_limited)):
+            click.echo(
+                "  ingest watcher: "
+                f"changed={ingest_changed if ingest_changed is not None else '-'} "
+                f"emitted={ingest_emitted if ingest_emitted is not None else '-'} "
+                f"rate_limited={ingest_rate_limited if ingest_rate_limited is not None else '-'}"
+            )
+        if watcher_lifecycle.last_panel_run_at is not None:
+            actions_count = watcher_lifecycle.last_panel_run_actions_count
+            executed_count = watcher_lifecycle.last_panel_run_executed_count
+            click.echo(
+                f"  last_panel_run: at={watcher_lifecycle.last_panel_run_at} "
+                f"actions={actions_count if actions_count is not None else '-'} "
+                f"executed={executed_count if executed_count is not None else '-'}"
+            )
+            if watcher_lifecycle.last_panel_run_summary:
+                click.echo(f"  last_panel_run_summary: {watcher_lifecycle.last_panel_run_summary}")
+        else:
+            click.echo("  last_panel_run: none")
     click.echo("ASK:")
     avg_latency = (
         f"{status.ask.avg_latency_ms_24h:.0f} ms" if status.ask.avg_latency_ms_24h is not None else "-"

--- a/app/cli/health.py
+++ b/app/cli/health.py
@@ -421,6 +421,9 @@ def _heartbeat_status(
     ):
         if key in raw:
             payload[key] = raw[key]
+    watchers_raw = raw.get("watchers")
+    if isinstance(watchers_raw, dict):
+        payload["watchers"] = watchers_raw
     return payload
 
 

--- a/app/observability/status_model.py
+++ b/app/observability/status_model.py
@@ -126,6 +126,21 @@ class ContextDimensionsStatus(BaseModel):
     situated_identity: str | None = None
 
 
+class WatcherLifecycleStatus(BaseModel):
+    panel_changed_total: int | None = None
+    panel_emitted_total: int | None = None
+    panel_rate_limited_total: int | None = None
+    panel_last_emitted_event_at: str | None = None
+    panel_last_trace_id: str | None = None
+    ingest_changed_total: int | None = None
+    ingest_emitted_total: int | None = None
+    ingest_rate_limited_total: int | None = None
+    last_panel_run_at: str | None = None
+    last_panel_run_actions_count: int | None = None
+    last_panel_run_executed_count: int | None = None
+    last_panel_run_summary: str | None = None
+
+
 class WatcherAutomationStatus(BaseModel):
     auto_exec_enabled: bool = False
     mode: str = "emit-only"
@@ -175,6 +190,7 @@ class SystemStatus(BaseModel):
     worker_queue: Optional[WorkerQueueStatus] = None
     view_freshness: Optional[ViewFreshnessStatus] = None
     watcher_automation: Optional[WatcherAutomationStatus] = None
+    watcher_lifecycle: Optional[WatcherLifecycleStatus] = None
     instance_provenance: Optional[InstanceProvenanceStatus] = None
     context_dimensions: Optional[ContextDimensionsStatus] = None
     v6_0_seams: Optional[Dict[str, str]] = None
@@ -197,6 +213,7 @@ __all__ = [
     "ViewFreshnessStatus",
     "InstanceProvenanceStatus",
     "WatcherAutomationStatus",
+    "WatcherLifecycleStatus",
     "ContextDimensionsStatus",
     "SystemStatus",
 ]

--- a/app/observability/status_service.py
+++ b/app/observability/status_service.py
@@ -858,6 +858,20 @@ def _last_panel_log_record(path: Path) -> dict | None:
         return None
 
 
+def _newer_panel_record(a: dict | None, b: dict | None) -> dict | None:
+    if a is None:
+        return b
+    if b is None:
+        return a
+    ts_a = _parse_timestamp(a.get("timestamp") or a.get("created_at"))
+    ts_b = _parse_timestamp(b.get("timestamp") or b.get("created_at"))
+    if ts_a is None:
+        return b
+    if ts_b is None:
+        return a
+    return a if ts_a >= ts_b else b
+
+
 def _get_watcher_lifecycle_status() -> WatcherLifecycleStatus | None:
     try:
         watcher_settings = load_watcher_settings()
@@ -880,13 +894,15 @@ def _get_watcher_lifecycle_status() -> WatcherLifecycleStatus | None:
     outbox_path = Path(INDEX_OUTBOX_PATH) if INDEX_OUTBOX_PATH else None
     panel_event_log = watcher_settings.paths.panel_event_log
 
-    executed_record = _last_panel_run_record(panel_event_log)
-    if executed_record is None and outbox_path:
-        executed_record = _last_panel_run_record(outbox_path)
+    executed_record = _newer_panel_record(
+        _last_panel_run_record(panel_event_log),
+        _last_panel_run_record(outbox_path) if outbox_path else None,
+    )
 
-    log_record = _last_panel_log_record(panel_event_log)
-    if log_record is None and outbox_path:
-        log_record = _last_panel_log_record(outbox_path)
+    log_record = _newer_panel_record(
+        _last_panel_log_record(panel_event_log),
+        _last_panel_log_record(outbox_path) if outbox_path else None,
+    )
 
     last_panel_run_at: str | None = None
     last_panel_run_actions_count: int | None = None

--- a/app/observability/status_service.py
+++ b/app/observability/status_service.py
@@ -11,6 +11,7 @@ from typing import Iterable
 from app.config.environment import active_environment
 from app.events.types import PROMOTE_INTENT_CREATED, PROMOTE_DONE
 from app.events.types import ORCHESTRATOR_STEP_ERROR, ORCHESTRATOR_STEP_FINISHED
+from app.events.types import PANEL_INTENT_EXECUTED, PANEL_LOG_CREATED
 from app.observability.ingest_meta import get_ingest_status
 from app.orchestrator.delivery_sla import (
     DELIVERY_SLA_DELIVERED,
@@ -36,6 +37,7 @@ from app.observability.status_model import (
     WatcherAutomationStatus,
     WorkerQueueStatus,
     WriteGuardStatus,
+    WatcherLifecycleStatus,
     ContextDimensionsStatus,
 )
 from app.outbox.events import INDEX_OUTBOX_PATH
@@ -795,6 +797,132 @@ def _status_context_dimensions(outbox_path: Path) -> ContextDimensionsStatus | N
     return None
 
 
+def _read_watcher_heartbeat_watchers() -> dict[str, dict]:
+    try:
+        from app.watcher.heartbeat import resolve_heartbeat_path
+        path = resolve_heartbeat_path()
+        if not path.exists():
+            return {}
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        watchers = raw.get("watchers")
+        return watchers if isinstance(watchers, dict) else {}
+    except Exception:
+        return {}
+
+
+def _last_panel_run_record(path: Path) -> dict | None:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            last: dict | None = None
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    payload = json.loads(line)
+                except Exception:
+                    continue
+                if not isinstance(payload, dict):
+                    continue
+                topic = payload.get("event") or payload.get("event_type") or payload.get("topic")
+                if topic == PANEL_INTENT_EXECUTED:
+                    last = payload
+            return last
+    except FileNotFoundError:
+        return None
+    except Exception:
+        return None
+
+
+def _last_panel_log_record(path: Path) -> dict | None:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            last: dict | None = None
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    payload = json.loads(line)
+                except Exception:
+                    continue
+                if not isinstance(payload, dict):
+                    continue
+                topic = payload.get("event") or payload.get("event_type") or payload.get("topic")
+                if topic == PANEL_LOG_CREATED:
+                    last = payload
+            return last
+    except FileNotFoundError:
+        return None
+    except Exception:
+        return None
+
+
+def _get_watcher_lifecycle_status() -> WatcherLifecycleStatus | None:
+    try:
+        watcher_settings = load_watcher_settings()
+    except Exception:
+        return None
+
+    watchers = _read_watcher_heartbeat_watchers()
+    panel_w = watchers.get("panel") or {}
+    ingest_w = watchers.get("ingest") or {}
+
+    panel_emitted_at_raw = panel_w.get("last_emitted_event_at")
+    panel_last_emitted_iso: str | None = None
+    if panel_emitted_at_raw is not None:
+        try:
+            from datetime import timezone
+            panel_last_emitted_iso = datetime.fromtimestamp(float(panel_emitted_at_raw), tz=timezone.utc).isoformat()
+        except Exception:
+            pass
+
+    outbox_path = Path(INDEX_OUTBOX_PATH) if INDEX_OUTBOX_PATH else None
+    panel_event_log = watcher_settings.paths.panel_event_log
+
+    executed_record = _last_panel_run_record(panel_event_log)
+    if executed_record is None and outbox_path:
+        executed_record = _last_panel_run_record(outbox_path)
+
+    log_record = _last_panel_log_record(panel_event_log)
+    if log_record is None and outbox_path:
+        log_record = _last_panel_log_record(outbox_path)
+
+    last_panel_run_at: str | None = None
+    last_panel_run_actions_count: int | None = None
+    last_panel_run_executed_count: int | None = None
+    last_panel_run_summary: str | None = None
+
+    if executed_record is not None:
+        last_panel_run_at = str(executed_record.get("timestamp") or executed_record.get("created_at") or "")
+        payload = executed_record.get("payload") or {}
+        if isinstance(payload, dict):
+            actions = payload.get("actions")
+            executed_ids = payload.get("executed_action_ids")
+            last_panel_run_actions_count = len(actions) if isinstance(actions, list) else 0
+            last_panel_run_executed_count = len(executed_ids) if isinstance(executed_ids, list) else 0
+
+    if log_record is not None:
+        log_payload = log_record.get("payload") or {}
+        if isinstance(log_payload, dict):
+            last_panel_run_summary = log_payload.get("summary")
+
+    return WatcherLifecycleStatus(
+        panel_changed_total=int(panel_w["changed_total"]) if "changed_total" in panel_w else None,
+        panel_emitted_total=int(panel_w["emitted_total"]) if "emitted_total" in panel_w else None,
+        panel_rate_limited_total=int(panel_w["rate_limited_total"]) if "rate_limited_total" in panel_w else None,
+        panel_last_emitted_event_at=panel_last_emitted_iso,
+        panel_last_trace_id=str(panel_w["last_trace_id"]) if "last_trace_id" in panel_w else None,
+        ingest_changed_total=int(ingest_w["changed_total"]) if "changed_total" in ingest_w else None,
+        ingest_emitted_total=int(ingest_w["emitted_total"]) if "emitted_total" in ingest_w else None,
+        ingest_rate_limited_total=int(ingest_w["rate_limited_total"]) if "rate_limited_total" in ingest_w else None,
+        last_panel_run_at=last_panel_run_at or None,
+        last_panel_run_actions_count=last_panel_run_actions_count,
+        last_panel_run_executed_count=last_panel_run_executed_count,
+        last_panel_run_summary=last_panel_run_summary,
+    )
+
+
 def _get_v6_seams() -> dict | None:
     try:
         from app.cli.health import _check_v6_seams  # lazy to avoid circular import
@@ -843,6 +971,7 @@ def get_system_status() -> SystemStatus:
             worker_queue=worker_queue,
         ),
         watcher_automation=_get_watcher_automation_status(),
+        watcher_lifecycle=_get_watcher_lifecycle_status(),
         instance_provenance=_get_instance_provenance_status(),
         context_dimensions=_status_context_dimensions(Path(INDEX_OUTBOX_PATH)),
         v6_0_seams=_get_v6_seams(),

--- a/app/watcher/registry.py
+++ b/app/watcher/registry.py
@@ -634,6 +634,8 @@ def _build_watchers_payload(
         }
         if state.last_trace_id:
             payload[spec.name]["last_trace_id"] = state.last_trace_id
+        if state.last_emitted_event_at is not None:
+            payload[spec.name]["last_emitted_event_at"] = state.last_emitted_event_at
     return payload
 
 
@@ -807,6 +809,7 @@ def _emit_panel_events(
         )
         return None
     state.intents_emitted += 1
+    state.last_emitted_event_at = now
     state.record_rate_event(now)
     state.update_file_state(str(rel), mtime=mtime, content_hash=digest, emitted_at=now)
     trace_id = uuid4().hex
@@ -937,6 +940,7 @@ def _emit_changed_entry(
         return None
     state.last_trace_id = trace_id
     state.intents_emitted += 1
+    state.last_emitted_event_at = now
     state.record_rate_event(now)
     state.update_file_state(str(entry.rel_path), mtime=current_mtime, content_hash=current_digest, emitted_at=now)
     if spec.emit_event == PANEL_SCAN_REQUESTED and process_panel_notes_inline:

--- a/app/watcher/state.py
+++ b/app/watcher/state.py
@@ -78,6 +78,7 @@ class WatcherState:
     bad_ticks: int = 0
     outbox_offset: int = 0
     dynamic_sleep_seconds: float | None = None
+    last_emitted_event_at: float | None = None
 
     @classmethod
     def load(cls, path: Path) -> WatcherState:
@@ -103,6 +104,7 @@ class WatcherState:
             bad_ticks=int(data.get("bad_ticks") or 0),
             outbox_offset=int(data.get("outbox_offset") or 0),
             dynamic_sleep_seconds=_sanitize_ts(data.get("dynamic_sleep_seconds")),
+            last_emitted_event_at=_sanitize_ts(data.get("last_emitted_event_at")),
         )
 
     def save(self, path: Path) -> None:
@@ -123,6 +125,7 @@ class WatcherState:
             "bad_ticks": self.bad_ticks,
             "outbox_offset": self.outbox_offset,
             "dynamic_sleep_seconds": self.dynamic_sleep_seconds,
+            "last_emitted_event_at": self.last_emitted_event_at,
         }
         path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
 

--- a/docs/learning-log.md
+++ b/docs/learning-log.md
@@ -120,3 +120,8 @@ Resolution note (2026-05-06): verified `app/orchestrator/v2_runtime.py` now cont
 **Source:** pr-integration
 **Diverged:** The governance lane's allowed-file set in `issue-pr-governance.yml` includes only `.github/workflows/issue-pr-governance.yml` by exact match; other workflow files (e.g. `smoke.yml`, `ci-smoke.yaml`) are not included. A PR that classifies as `Governance lane` but touches these files will fail the file-restriction check. The Direct Repair path bypasses file restrictions entirely and is the correct route for workflow-file repairs.
 **Upstream artifact:** `docs/development/PR_HOT_PATH.md` — add a note that workflow-file repairs (other than `issue-pr-governance.yml`) must use `Direct Repair`, not the `Governance lane` checkbox, because the governance lane allowlist is narrower than `.github/workflows/**`.
+
+## 2026-05-15 — #973 (watcher lifecycle observability)
+**Source:** issue-to-code / pr-integration
+**Diverged:** After CI went green on PR #988, the plan (hot-path step 3) required triaging review feedback before handoff — instead the agent declared "awaiting human review" without checking whether a review was already posted. A Codex P2 comment (stale-log masking in `_get_watcher_lifecycle_status`) was present and needed addressing before merge.
+**Upstream artifact:** `docs/development/PR_HOT_PATH.md` §"Review feedback triage" — make explicit that the agent must check for existing review comments immediately after CI is confirmed green, before any handoff or merge recommendation. The normal next step after CI green + review triage is `verification-and-closure`, not a park for human review.

--- a/tests/cli/test_status_cli.py
+++ b/tests/cli/test_status_cli.py
@@ -12,6 +12,7 @@ from app.observability.status_model import (
     StoreStatus,
     SystemStatus,
     WatcherAutomationStatus,
+    WatcherLifecycleStatus,
 )
 
 
@@ -123,3 +124,83 @@ def test_status_cli_prints_snapshot(monkeypatch):
     assert "last_run_skips: dedup=1" in result.output
     assert "ingest runs by plane:" in result.output
     assert "source: /tmp/outbox.jsonl" in result.output
+
+
+def _minimal_system_status(**overrides) -> SystemStatus:
+    base = dict(
+        timestamp=datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+        environment="prod",
+        sot_version="vX",
+        sot_baseline_version="v5.5",
+        sot_forward_line_version="v5.6",
+        sot_label="test",
+        active_features=[],
+        stores=[],
+        ingestion=IngestionStatus(),
+        ask=AskStatus(total_queries_24h=0),
+    )
+    base.update(overrides)
+    return SystemStatus(**base)
+
+
+def test_status_reports_last_panel_run_when_latest_tick_has_zero_candidates(monkeypatch):
+    lifecycle = WatcherLifecycleStatus(
+        panel_changed_total=2162,
+        panel_emitted_total=41,
+        panel_rate_limited_total=2114,
+        last_panel_run_at="2026-05-15T17:49:16Z",
+        last_panel_run_actions_count=2,
+        last_panel_run_executed_count=1,
+        last_panel_run_summary="triggered: promote.evergreen",
+    )
+    automation = WatcherAutomationStatus(
+        last_tick_timestamp="2026-05-15T17:50:00Z",
+        last_tick_panel_candidates=0,
+    )
+    snapshot = _minimal_system_status(
+        watcher_automation=automation,
+        watcher_lifecycle=lifecycle,
+    )
+    monkeypatch.setattr("app.cli.get_system_status", lambda: snapshot)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["status"])
+
+    assert result.exit_code == 0, result.output
+    assert "Watcher lifecycle:" in result.output
+    assert "last_panel_run:" in result.output
+    assert "2026-05-15T17:49:16Z" in result.output
+    assert "actions=2" in result.output
+    assert "executed=1" in result.output
+
+
+def test_status_distinguishes_zero_action_panel_run_from_no_run(monkeypatch):
+    lifecycle_zero = WatcherLifecycleStatus(
+        panel_changed_total=10,
+        panel_emitted_total=1,
+        panel_rate_limited_total=0,
+        last_panel_run_at="2026-05-15T12:00:00Z",
+        last_panel_run_actions_count=0,
+        last_panel_run_executed_count=0,
+    )
+    snapshot_zero = _minimal_system_status(watcher_lifecycle=lifecycle_zero)
+    monkeypatch.setattr("app.cli.get_system_status", lambda: snapshot_zero)
+
+    runner = CliRunner()
+    result_zero = runner.invoke(cli, ["status"])
+    assert result_zero.exit_code == 0, result_zero.output
+    assert "actions=0" in result_zero.output
+
+    lifecycle_no_run = WatcherLifecycleStatus(
+        panel_changed_total=10,
+        panel_emitted_total=0,
+        panel_rate_limited_total=0,
+        last_panel_run_at=None,
+    )
+    snapshot_no_run = _minimal_system_status(watcher_lifecycle=lifecycle_no_run)
+    monkeypatch.setattr("app.cli.get_system_status", lambda: snapshot_no_run)
+
+    result_no_run = runner.invoke(cli, ["status"])
+    assert result_no_run.exit_code == 0, result_no_run.output
+    assert "last_panel_run: none" in result_no_run.output
+    assert "actions=0" not in result_no_run.output

--- a/tests/health/test_watcher_lifecycle_status.py
+++ b/tests/health/test_watcher_lifecycle_status.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from app.cli.health import run_health
+
+
+def _write_registry_heartbeat(path: Path, *, watchers: dict, now: float | None = None) -> None:
+    ts = now if now is not None else time.time()
+    payload = {
+        "ts": ts,
+        "pid": 12345,
+        "status": "running",
+        "watchers": watchers,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_health_status_exposes_watcher_emission_and_rate_limit_counters(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    heartbeat_path = tmp_path / "watcher_heartbeat.json"
+    _write_registry_heartbeat(
+        heartbeat_path,
+        watchers={
+            "panel": {
+                "scope_glob": "📥 Inbox/**",
+                "ticks_total": 100,
+                "changed_total": 42,
+                "emitted_total": 15,
+                "rate_limited_total": 27,
+                "errors_total": 0,
+                "last_trace_id": "abc123",
+                "last_emitted_event_at": 1_700_000_000.0,
+            },
+            "ingest": {
+                "scope_glob": "/**",
+                "ticks_total": 80,
+                "changed_total": 10,
+                "emitted_total": 9,
+                "rate_limited_total": 1,
+                "errors_total": 0,
+            },
+        },
+        now=time.time(),
+    )
+
+    monkeypatch.setenv("WATCHER_HEARTBEAT_PATH", str(heartbeat_path))
+
+    result = run_health()
+
+    watcher_runtime = result.get("runtime", {}).get("watcher", {})
+    assert "watchers" in watcher_runtime, (
+        f"Expected 'watchers' in runtime.watcher; got keys: {list(watcher_runtime.keys())}"
+    )
+    panel = watcher_runtime["watchers"].get("panel", {})
+    assert panel.get("changed_total") == 42
+    assert panel.get("emitted_total") == 15
+    assert panel.get("rate_limited_total") == 27
+
+    ingest = watcher_runtime["watchers"].get("ingest", {})
+    assert ingest.get("emitted_total") == 9
+    assert ingest.get("rate_limited_total") == 1


### PR DESCRIPTION
Fixes #973

## Summary
Adds watcher panel and ingest lifecycle counters to `health status --json` and `status` CLI output so operators can distinguish: watcher alive but idle, notes detected and emitted, panel ran with zero actions, panel ran with actions, and rate-limit pressure is high — rather than all appearing as the same `candidates=0` state.

## Changes
- **`WatcherState`**: new `last_emitted_event_at` field — set on every successful watcher emit, persisted in state JSON and forwarded through `_build_watchers_payload()` into the registry heartbeat
- **`app/cli/health.py`**: `_heartbeat_status()` now forwards the full `watchers` sub-dict, so `health status --json` exposes `runtime.watcher.watchers.{panel,ingest}.{changed_total,emitted_total,rate_limited_total,last_emitted_event_at,...}`
- **`WatcherLifecycleStatus`** (new model): panel/ingest counters + last panel run fields (`last_panel_run_at`, `last_panel_run_actions_count`, `last_panel_run_executed_count`, `last_panel_run_summary`)
- **`_get_watcher_lifecycle_status()`**: reads the registry heartbeat watchers payload + last `panel.intent.executed` / `panel.log.created` events from the outbox/panel_event_log
- **`SystemStatus`**: `watcher_lifecycle` field wired in `get_system_status()`
- **CLI `status`**: new "Watcher lifecycle:" section with panel/ingest watcher counters, `last_emitted_at`, and last panel run details — with explicit "last_panel_run: none" when no run has occurred

## Validation
```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/health tests/cli
# 150 passed, 3 skipped

PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg" tests/watcher/
# 74 passed

ruff check (all changed files): All checks passed
```

All three ACs verified green:
- `tests/health/test_watcher_lifecycle_status.py::test_health_status_exposes_watcher_emission_and_rate_limit_counters` ✓
- `tests/cli/test_status_cli.py::test_status_reports_last_panel_run_when_latest_tick_has_zero_candidates` ✓
- `tests/cli/test_status_cli.py::test_status_distinguishes_zero_action_panel_run_from_no_run` ✓

Dispatcher unavailable (module import failure) — used GitHub-label-only claim.