### PR TITLE
fix(companion): cooldown-skip bypass and rename-cooldown setting

### DIFF
--- a/app/ingest/vault_alpha.py
+++ b/app/ingest/vault_alpha.py
@@ -427,11 +427,13 @@ def _ingest_single(path: Path, *, vault_root: Path, trace_id: str, raw_text: str
         note_uuid = _derive_note_uuid(frontmatter_uuid, companion_uuid or fingerprint_uuid, rel_path)
 
     companion_settings = load_companion_settings(vault_root)
+    is_rename = companion is not None and companion.source_ref != str(rel_path)
+    cooldown = companion_settings.rename_cooldown_seconds if is_rename else companion_settings.create_cooldown_seconds
     eligibility = check_companion_eligibility(
         path,
         vault_root,
         raw_body=stripped_text,
-        cooldown_seconds=companion_settings.create_cooldown_seconds,
+        cooldown_seconds=cooldown,
     )
     if eligibility.eligible:
         try:
@@ -757,7 +759,18 @@ def _ingest_candidates(
                     if not companion_hash:
                         stored_payload = (existing.get("payload") or {})
                         stored_fp = stored_payload.get("ingest_fingerprint") or {}
-                        companion_hash = str(stored_fp.get("text_sha256") or "") or None
+                        fallback_hash = str(stored_fp.get("text_sha256") or "") or None
+                        if fallback_hash:
+                            # Only permanently ineligible notes (system_path,
+                            # placeholder_title) may be skipped via the object-store
+                            # fallback. Cooldown-deferred notes must stay eligible for
+                            # retry once the cooldown expires; using the stored hash
+                            # would prevent the companion from ever being created.
+                            perm_check = check_companion_eligibility(
+                                path, vault_root, raw_body=stripped_text, cooldown_seconds=0.0
+                            )
+                            if perm_check.reason in ("system_path", "placeholder_title"):
+                                companion_hash = fallback_hash
                     # Skip fingerprint-equal notes, but not if source_ref changed (rename case).
                     if companion_hash and companion_hash == text_sha256:
                         source_ref_changed = (

--- a/tests/ingest/test_companion_lifecycle.py
+++ b/tests/ingest/test_companion_lifecycle.py
@@ -13,7 +13,9 @@ These tests go through the vault_alpha ingest path end-to-end.
 """
 from __future__ import annotations
 
+import os
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -136,6 +138,54 @@ class TestRealNoteGetsCompanion:
         companion = read_companion(vault_root, note_uuid)
         assert companion is not None
         assert companion.source_ref == "Notes/My Real Note.md"
+
+
+# ---------------------------------------------------------------------------
+# Cooldown-deferred note gets companion after cooldown expires (P1 regression)
+# ---------------------------------------------------------------------------
+
+class TestCooldownDeferredNoteGetsCompanionOnRetry:
+    def test_companion_created_on_second_ingest_after_cooldown_expires(
+        self, tmp_path: Path, _mock_env: None
+    ) -> None:
+        """
+        A note ingested during the cooldown window must get its companion on the
+        next run once the cooldown has expired, even if content is unchanged.
+
+        Regression: the object-store fingerprint fallback was skipping these notes
+        permanently, preventing companion creation after cooldown expiry.
+        """
+        vault_root = tmp_path / "vault"
+        vault_root.mkdir()
+        _write_layout(vault_root)
+
+        note_uuid = "aa112233-bb44-cc55-dd66-ee7788990011"
+        note = vault_root / "Notes" / "Deferred Note.md"
+        note.parent.mkdir()
+        note.write_text(
+            f"---\nuuid: {note_uuid}\ntitle: Deferred Note\n---\n"
+            "Real content that survives cooldown.\n",
+            encoding="utf-8",
+        )
+
+        # First ingest: cooldown active (mtime = now) → companion not created,
+        # but object stored with ingest_fingerprint.
+        with patch.dict(os.environ, {"COMPANION_CREATE_COOLDOWN_SECONDS": "9999"}):
+            run_vault_alpha_ingest_paths(vault_root, [note])
+
+        companion_after_first = read_companion(vault_root, note_uuid)
+        assert companion_after_first is None, "companion must not exist while cooldown is active"
+
+        # Second ingest: cooldown disabled → companion must be created even
+        # though content (and thus fingerprint) is unchanged.
+        with patch.dict(os.environ, {"COMPANION_CREATE_COOLDOWN_SECONDS": "0"}):
+            run_vault_alpha_ingest_paths(vault_root, [note])
+
+        companion_after_second = read_companion(vault_root, note_uuid)
+        assert companion_after_second is not None, (
+            "companion must be created on retry after cooldown expires"
+        )
+        assert companion_after_second.source_ref == "Notes/Deferred Note.md"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Direct Repair

Type: code
Reason: Two bugs found by Codex review of merged PR #986 (issue #971)
Validation: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3.12 -m pytest tests/ingest/test_companion_lifecycle.py -q -m "not pg"` — 10 tests pass including new P1 regression test
Issue required: no

## Summary

Two bugs in the companion note ingest path, both on `app/ingest/vault_alpha.py`.

**P1 (line 760, permanent skip regression):** When a note was ingested during the 60s create cooldown, `_ingest_single` stored the object but companion creation was deferred. On subsequent runs, the fingerprint-fallback skip path used the stored `ingest_fingerprint.text_sha256` as if it were a companion hash — permanently skipping the note before `_ingest_single` could retry eligibility after the cooldown expired. Companion was never created unless content changed or `--force` was used.

Fix: the fingerprint-fallback only applies when the note is permanently ineligible (`system_path` or `placeholder_title`). For notes that may become eligible after cooldown (or that have content), the fallback is bypassed and `_ingest_single` runs normally.

**P2 (line 435, rename cooldown ignored):** `check_companion_eligibility` always received `create_cooldown_seconds` regardless of whether the call was a creation or a rename event. Notes with an existing companion at a different `source_ref` (rename scenario) were subject to the 60s create cooldown instead of the 20s rename cooldown.

Fix: detect rename via `companion is not None and companion.source_ref != str(rel_path)` and pass `rename_cooldown_seconds` in that case.

## Test plan

- [x] `tests/ingest/test_companion_lifecycle.py::TestCooldownDeferredNoteGetsCompanionOnRetry` — new regression test: note ingested during cooldown → no companion; second ingest with cooldown disabled → companion created
- [x] All existing lifecycle tests pass (10 total)
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)