### PR TITLE
docs: owner-doc promotion for companion fingerprint-skip policy (#989)

### DIFF
--- a/docs/CONCEPTS/COMPANION_NOTE_CONTRACT.md
+++ b/docs/CONCEPTS/COMPANION_NOTE_CONTRACT.md
@@ -84,8 +84,11 @@ order. Skipped companions are logged; they are never silently dropped.
 
 Settings precedence: vault `@Settings/watchers.md` companion section → env vars → defaults.
 
-When a companion is not created, the ingest fingerprint stored in the object store is used as the
-fallback skip-check signal so unchanged content is not re-ingested on subsequent runs.
+When a companion is not created for a **permanently ineligible** note (`system_path` or
+`placeholder_title`), the ingest fingerprint stored in the object store is used as the fallback
+skip-check signal so unchanged content is not re-ingested on subsequent runs. Transiently ineligible
+notes (`cooldown_active`) are not skipped via this fallback — the ingest pipeline retries them on
+each run until the cooldown expires and companion creation succeeds.
 ## Minimal field set
 
 The companion note must carry a bounded field set sufficient for continuity and repair.


### PR DESCRIPTION
- [x] Docs authoring lane

## Summary

PR #989 restricted the object-store fingerprint fallback skip to permanently ineligible notes only (`system_path`, `placeholder_title`). The previous claim in `COMPANION_NOTE_CONTRACT.md` — *"When a companion is not created, the ingest fingerprint stored in the object store is used as the fallback skip-check signal"* — was too broad and conflicted with the shipped behavior.

Updated to distinguish permanently ineligible notes (where the skip still applies) from transiently ineligible notes (`cooldown_active`) where the pipeline now retries on each run until the cooldown expires.

## Related

Owner-doc promotion companion to merged PR #989 (direct repair of companion ingest bugs).

## Test plan

- [ ] Docs-only — no test changes
- [ ] Single sentence in `docs/CONCEPTS/COMPANION_NOTE_CONTRACT.md` updated to match shipped behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)