### PR TITLE
docs: archive panel interaction design handoff

### DIFF
--- a/companion-ui/design_handoff/2026-05-15-panel-interaction/README.md
+++ b/companion-ui/design_handoff/2026-05-15-panel-interaction/README.md
@@ -1,4 +1,4 @@
-State: Handoff package — Crossing A. Design brief archived; interactive prototype (index.html) pending Claude Design session output.
+State: Handoff package — Crossing A. Design brief archived; interactive prototype (prototype.html) pending Claude Design session output.
 
 # Panel Interaction Design Handoff — 2026-05-15
 
@@ -27,7 +27,7 @@ The design problem is explicitly layered:
 | File | Role |
 |---|---|
 | `BRIEF.md` | Design session input brief — constraints, state machine spec, component inventory, open questions, non-goals |
-| `index.html` | Interactive prototype — Claude Design session output (**pending; not yet created**) |
+| `prototype.html` | Interactive prototype — Claude Design session output (**pending; not yet created**) |
 | `README.md` | This file — authority status and crossing target |
 | `implementation-contracts.md` | State enum, allowed transitions, data attributes, component inventory, design intent vocabulary |
 | `authority-boundaries.md` | What this design is and is not; invariants this package must honor |
@@ -75,7 +75,7 @@ This package targets **Crossing A → B**. Crossing B requires all of the follow
 
 ## Next steps
 
-1. Complete the Claude Design session using `BRIEF.md` as the input brief; export the output HTML as `index.html` in this folder.
+1. Complete the Claude Design session using `BRIEF.md` as the input brief; export the output HTML as `prototype.html` in this folder.
 2. Human reviews `open-questions.md`; confirms triage and resolves any blocking questions.
 3. Route to Crossing B when the maturity checklist is satisfied.
 4. After Crossing B: author a normalized spec in `companion-ui/docs/PANEL_INTERACTION_SPEC.md`.

--- a/companion-ui/design_handoff/2026-05-15-panel-interaction/README.md
+++ b/companion-ui/design_handoff/2026-05-15-panel-interaction/README.md
@@ -1,0 +1,94 @@
+State: Handoff package — Crossing A. Design brief archived; interactive prototype (index.html) pending Claude Design session output.
+
+# Panel Interaction Design Handoff — 2026-05-15
+
+**Design surface:** Panel interaction surface — vault-native AI panel fence + Companion UI render layer
+**Design date:** 2026-05-15
+**Authority status:** Visual guidance and design intent only — not architecture authority, not runtime truth.
+**Crossing status:** A — archived, maturity checklist not yet passed.
+**Governing chain:** `companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md`
+
+---
+
+## What this package is
+
+This package archives the design exploration for the **Panel interaction surface**: the human-to-agent channel built into vault notes using AI fences, and how the Companion UI should render it more richly alongside the vault-native Markdown layer.
+
+The design problem is explicitly layered:
+
+- **Vault-native layer** — the AI fence syntax (`%% AI:Start %%` / `%% AI:End %%`), heading structure (`## AI-instruktion`, `## AI-åtgärder`, `## AI-logg`), and AI status callout are the data contract. They remain readable and functional in Obsidian with or without Companion UI running. **This layer is not being redesigned.**
+- **Companion UI layer** — renders the same panel content more richly; presents proposals with explicit confirmation affordances; shows receipts in structured form. Writes back to the vault through the runtime API.
+- **The relationship** — both layers must stay coherent. A proposal confirmed in Companion UI must produce the same vault artifact as a checkbox checked in Obsidian. The vault is source of truth; the Companion UI is the richer interaction render.
+
+---
+
+## Package contents
+
+| File | Role |
+|---|---|
+| `BRIEF.md` | Design session input brief — constraints, state machine spec, component inventory, open questions, non-goals |
+| `index.html` | Interactive prototype — Claude Design session output (**pending; not yet created**) |
+| `README.md` | This file — authority status and crossing target |
+| `implementation-contracts.md` | State enum, allowed transitions, data attributes, component inventory, design intent vocabulary |
+| `authority-boundaries.md` | What this design is and is not; invariants this package must honor |
+| `open-questions.md` | Unresolved questions triaged into crossing-blocking / normalized-spec / deferred |
+| `state-gallery.md` | State-by-state descriptions for all declared Panel UI states |
+
+---
+
+## Authority status
+
+Design artifacts in this package are **guidance and input only**. They are not:
+
+- **Architecture authority.** Architecture authority lives in `docs/**` owner docs — specifically `docs/PANEL_AGENT.md`, `docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_PANEL_AUTHORITY_BOUNDARY.md`, `docs/CAPABILITY_CONTRACT_MODEL.md`, and `docs/SYSTEM_OF_SYSTEMS_ARCHITECTURE.md`.
+- **Runtime truth.** Runtime truth lives in shipped code, tests, `docs/STATUS.md`, and validation receipts.
+- **A schema declaration.** This design references fields and event names; it does not declare them.
+- **A claim about current behavior.** Unless a passage explicitly cites a shipped owner doc, treat it as target-state design intent.
+
+**The vault-native AI panel syntax is the ground truth this design renders from.** It is not being replaced or extended by this design.
+
+---
+
+## Crossing target
+
+This package targets **Crossing A → B**. Crossing B requires all of the following:
+
+- [x] README names the surface and declares authority status (this file)
+- [x] `authority-boundaries.md` present and distinguishes design / normalized-spec / architecture / runtime-truth layers
+- [x] `implementation-contracts.md` present with state enum, transitions, and data attributes
+- [x] `open-questions.md` present; all questions triaged into resolve-before-promotion / resolve-in-normalized-spec / defer
+- [ ] No crossing-B-blocking open questions remain unresolved — **pending human review of `open-questions.md`**
+- [x] State gallery covers all declared states
+- [x] Package does not assert current runtime behavior beyond shipped owner docs
+
+**Crossing B is not yet passed.** The open questions in `open-questions.md` must be reviewed by a human, and no blocking ones may remain unresolved before Crossing B can be signed off.
+
+---
+
+## Related issues
+
+- **#977** — Decision: should PanelAgent generate proposed AI actions from `AI-instruktion` or only execute existing checkbox actions?
+- **#978** — Task: align PanelAgent cognitive mediation with existing human-first architecture (parent hub)
+- **#981** — Task: define capability taxonomy for cognitive mediation (`agent:ready`)
+
+---
+
+## Next steps
+
+1. Complete the Claude Design session using `BRIEF.md` as the input brief; export the output HTML as `index.html` in this folder.
+2. Human reviews `open-questions.md`; confirms triage and resolves any blocking questions.
+3. Route to Crossing B when the maturity checklist is satisfied.
+4. After Crossing B: author a normalized spec in `companion-ui/docs/PANEL_INTERACTION_SPEC.md`.
+5. Create bounded GitHub issues from the normalized spec via the `docs-to-issue` skill.
+
+---
+
+## References
+
+- `companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md` — governing handoff chain
+- `companion-ui/docs/OVERLAY_GRAMMAR.md` — overlay structural rules
+- `companion-ui/docs/UI_RUNTIME_BOUNDARIES.md` — UI/runtime separation rules
+- `companion-ui/docs/CANVAS_SUGGESTION_FLOW.md` — normalized spec for the canvas suggestion surface (design reference quality bar)
+- `companion-ui/design_handoff/2026-05-11-canvas-suggestion-flow/` — canvas suggestion flow design (vocabulary reference)
+- `docs/PANEL_AGENT.md` — shipped runtime contract for the Panel surface (v5.6)
+- `docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_PANEL_AUTHORITY_BOUNDARY.md` — Panel authority boundary spec

--- a/companion-ui/design_handoff/2026-05-15-panel-interaction/authority-boundaries.md
+++ b/companion-ui/design_handoff/2026-05-15-panel-interaction/authority-boundaries.md
@@ -1,0 +1,138 @@
+State: Handoff package governance doc — authority boundaries for the 2026-05-15 panel interaction design.
+
+# Authority Boundaries — Panel Interaction Design
+
+**Package:** `companion-ui/design_handoff/2026-05-15-panel-interaction/`
+**Crossing status:** A
+
+---
+
+## What this design is
+
+This package is a **design exploration** of how the Companion UI should render the Panel interaction surface — the vault-native AI panel fence (`%% AI:Start %% … %% AI:End %%`) — more richly for human interaction.
+
+Specifically, this design is:
+
+- **Visual guidance** — how states look, how components are laid out, which interaction gestures apply.
+- **Intent vocabulary** — proposed confirmation actions, proposed provenance display, proposed keyboard shortcut extensions.
+- **Vault/UI correspondence** — for each UI state, what the Markdown in Obsidian looks like at the same moment. This correspondence is the core design claim.
+- **Component reuse/diverge decisions** — which canvas suggestion flow components apply and which need panel-specific variants.
+
+---
+
+## What this design is not
+
+### Not architecture authority
+
+Architecture authority lives in:
+- `docs/PANEL_AGENT.md` — shipped runtime contract (v5.6 baseline)
+- `docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_PANEL_AUTHORITY_BOUNDARY.md` — Panel authority boundary spec
+- `docs/CAPABILITY_CONTRACT_MODEL.md` — capability contract shape
+- `docs/SYSTEM_OF_SYSTEMS_ARCHITECTURE.md` — subsystem map and kernel constraints
+
+If this design conflicts with those documents, **the owner docs win**. The design passage should be treated as a proposal, not a correction.
+
+### Not runtime truth
+
+Runtime truth lives in shipped code, tests, and `docs/STATUS.md`. Design states and proposed events are target-state; they are not claims about current behavior unless the relevant passage explicitly cites a shipped owner doc.
+
+The shipped Panel runtime is described in `docs/PANEL_AGENT.md §PanelAgent Runtime V1` and `§PanelAgent 2.0`. Those sections are current truth; this design renders from them and proposes richer UI rendering on top of them.
+
+### Not a schema or event declaration
+
+This design references event types (e.g., "a proposals-written event would be needed"), field names, and API paths. References here are **design dependencies to be confirmed by runtime**, not declarations. Schema and event contract changes go through owner-doc PRs and the governed issue pipeline.
+
+### Not a vault panel syntax change
+
+The current vault-native AI panel syntax is the data contract:
+
+```markdown
+%% AI:Start %%
+## AI-instruktion
+<freeform human instruction>
+
+## AI-åtgärder
+- [ ] <human-visible confirmable proposal>
+
+## AI-logg
+<optional append-only log>
+%% AI:End %%
+
+> [!info]- AI status
+> - ✅ executed receipt
+> - ⚠️ no-match/warning
+> - ⏳ pending
+```
+
+**This design does not replace this syntax.** It does not introduce HTML comment run blocks or any alternative envelope. The AI fence is a durable note-local communication envelope, not a closed action grammar. The Companion UI renders from this syntax; it does not own or replace it.
+
+### On HTML comment run blocks
+
+If an interactive prototype in this package (e.g., `index.html`) contains a block of the form:
+
+```html
+<!-- companion:panel:run ... -->
+```
+
+or similar, treat it **only as an internal prototype/rendering projection**, not as a proposed SoT runtime contract. No SoT decision has accepted such a syntax. If and when a runtime projection mechanism is proposed, it must go through the governed owner-doc PR lane with an explicit SoT decision.
+
+---
+
+## Invariants this package must honor
+
+The following invariants apply to every interpretation of this design package and to any normalized spec derived from it. They are restatements of kernel constraints from the shipped architecture.
+
+### Stable envelope, flexible protocol
+
+The vault-native panel syntax (`%% AI:Start %%` / headings / AI status callout) is the stable communication envelope. The interaction protocol — how the Companion UI renders proposals, how confirmation flows, how receipts display — may evolve. The envelope does not change with the protocol.
+
+### Panel surface is note-bound
+
+The Panel surface in the Companion UI is rendered in relation to the active note, not as a standalone inbox or notification surface. A Panel widget appears when a panel fence is detected in the active document. There is no persistent Panel inbox across all notes.
+
+### Companion UI does not own vault I/O
+
+The Companion UI renders vault artifacts more richly and supports interaction. It writes back to the vault through the runtime API. It is a client of the FastAPI runtime; it does not own vault I/O directly. Writes made in the Companion UI must produce the same vault artifact as the equivalent action taken in Obsidian.
+
+### Runtime owns: interpretation, policy, write guard, idempotency, execution, receipts, and inverse-action declaration
+
+The runtime (PanelAgent, note writer, event pipeline) owns:
+- Interpreting `AI-instruktion` into actions
+- Policy evaluation and write guard enforcement
+- Idempotency of action execution
+- Execution of confirmed actions
+- Writing receipts into the AI status callout
+- Declaring inverse actions (undo paths)
+
+The Companion UI renders outputs from the runtime and surfaces human confirmation affordances. It does not execute, classify, or evaluate policy locally.
+
+### UI never reclassifies actions locally
+
+The Companion UI renders action proposals and their provenance (catalog action ID, cognition mode) as declared by the runtime. It does not reclassify, upgrade, or downgrade actions locally. Classification authority lives in the action catalog and PanelAgent.
+
+### Proposals are not execution
+
+An unchecked proposal in `AI-åtgärder` is not an execution. A proposal row in the Companion UI is not an execution. Execution happens only after explicit human confirmation of a specific proposal, routed through the runtime.
+
+### No same-turn execution of newly generated proposals
+
+When PanelAgent generates proposals from `AI-instruktion` (PA2-FREEFORM path), those proposals are written as unchecked checkboxes into `AI-åtgärder`. They do not execute in the same run. Execution requires a subsequent explicit confirmation (check in Obsidian or confirm in Companion UI) followed by a new PanelAgent run.
+
+### No-match and blocked are first-class visible states
+
+When PanelAgent ran and found no catalog match (`no-match`), or when a write guard or policy prevented execution (`blocked`), these are first-class states that the Companion UI must render distinctly. They are not silence, not an empty proposal list, and not an error. The human must be able to read what happened and what to do next.
+
+### Future capability expansion is additive, not a replacement
+
+Future PanelAgent behavior may include: clarification states, plan-staging, partial completion, capability-needed states, and multi-step panel sessions. These are additive capabilities under the same envelope. This design should be extensible toward them without being redesigned for them now.
+
+---
+
+## Authority layer summary
+
+| Layer | Authority | Lives in |
+|---|---|---|
+| This design package | Visual guidance, interaction intent | `companion-ui/design_handoff/2026-05-15-panel-interaction/` |
+| Normalized spec | Mapped design intent → Yggdrasil architecture language | `companion-ui/docs/PANEL_INTERACTION_SPEC.md` (pending) |
+| Architecture contract | Capability model, surface authority, event contracts | `docs/PANEL_AGENT.md`, `docs/INTERACTION_SURFACES_AND_AUTHORITY/`, `docs/CAPABILITY_CONTRACT_MODEL.md` |
+| Runtime truth | Shipped behavior, test coverage, validation receipts | Code + tests + `docs/STATUS.md` |

--- a/companion-ui/design_handoff/2026-05-15-panel-interaction/implementation-contracts.md
+++ b/companion-ui/design_handoff/2026-05-15-panel-interaction/implementation-contracts.md
@@ -1,0 +1,176 @@
+State: Handoff package governance doc — implementation contracts derived from design intent. Not a runtime contract. Requires normalized spec before becoming authoritative.
+
+# Implementation Contracts — Panel Interaction Design
+
+**Package:** `companion-ui/design_handoff/2026-05-15-panel-interaction/`
+**Crossing status:** A
+**Authority:** Design intent only. These contracts become authoritative only after Crossing B and a normalized spec PR.
+
+---
+
+## Scope of this file
+
+This file captures what the design governs and what it explicitly does not govern, the state enum and allowed transitions, proposed component inventory, and the proposed design intent vocabulary. Nothing here is a runtime contract; everything here is design-layer input to the normalized spec.
+
+---
+
+## What this design governs
+
+- Visual states and allowed transitions for the Panel UI surface.
+- Interaction gestures and their confirmation semantics (what confirm/discard/acknowledge mean in this surface).
+- Vault Markdown ↔ Companion UI render correspondence (for each state, what Obsidian shows and what the UI renders).
+- Component shapes and reuse/diverge decisions relative to the canvas suggestion flow.
+- Provenance display depth: what proposal metadata is shown at a glance vs. on expand.
+
+## What this design does not govern
+
+- The action catalog or capability taxonomy — see `docs/CAPABILITY_CONTRACT_MODEL.md` and issue #981.
+- Runtime event names or payload shapes — see `docs/EVENTS.md` and `docs/PANEL_AGENT.md`.
+- Policy gates, write guards, or idempotency windows — runtime owns those.
+- Whether a `proposals-written` event or a dedicated confirm API endpoint exists — design names these as dependencies; runtime confirms or rejects.
+- The PA2-FREEFORM catalog lookup logic — see `docs/PANEL_AGENT.md §PA2-FREEFORM`.
+- PanelAgent cognition mode selection (rule vs LLM) — see `docs/PANEL_AGENT.md §PanelAgent 2.0`.
+
+---
+
+## State enum (canonical names)
+
+These names are proposed by the design. Canonical implementation names must be confirmed in the normalized spec.
+
+| State | Description |
+|---|---|
+| `idle` | Panel fence present; no pending proposals; no active run |
+| `running` | PanelAgent run in flight (triggered by watcher or explicit action) |
+| `proposals-staged` | Unchecked proposals written into `AI-åtgärder`; awaiting confirmation |
+| `confirming` | Human is actively reviewing proposals (one or more selected) |
+| `executing` | Confirmed proposals submitted; execution in flight |
+| `receipt-displayed` | Execution complete; AI status callout updated; receipts shown |
+| `no-match` | PanelAgent ran; no catalog match found; instruction echoed with reason |
+| `blocked` | Write guard or policy prevented execution; reason surfaced with recovery path |
+
+Future states (not in scope for this design; named for extensibility):
+
+| State | Description |
+|---|---|
+| `clarifying` | PanelAgent is requesting clarification before generating proposals |
+| `plan-staged` | A multi-step plan is staged; human reviews steps before committing |
+| `partial-complete` | Some proposals executed; others failed or were skipped |
+| `capability-needed` | A proposed action requires a capability that is not currently available |
+
+---
+
+## Allowed state transitions
+
+```
+idle ──────────────────► running         (watcher tick or explicit run)
+running ───────────────► proposals-staged (PanelAgent writes unchecked checkboxes)
+running ───────────────► no-match        (PanelAgent: no catalog match)
+running ───────────────► blocked         (write guard or policy gate prevents execution)
+running ───────────────► idle            (cancel or no instruction present)
+proposals-staged ──────► confirming      (human selects ≥1 proposal)
+proposals-staged ──────► idle            (human discards all proposals)
+confirming ────────────► executing       (human submits confirmation)
+confirming ────────────► proposals-staged (human cancels confirmation step)
+executing ─────────────► receipt-displayed (execution complete)
+executing ─────────────► blocked         (write guard activates mid-execution)
+receipt-displayed ─────► idle            (auto after brief receipt display, ~1.5s; or explicit dismiss)
+no-match ──────────────► idle            (human acknowledges)
+no-match ──────────────► running         (human edits instruction and re-runs)
+blocked ───────────────► idle            (human acknowledges)
+blocked ───────────────► running         (human resolves block reason and re-runs)
+```
+
+Forbidden transitions:
+- `running` → `executing` (proposals must be confirmed before execution; no auto-execute)
+- `proposals-staged` → `executing` (same; gated execution invariant)
+- Any transition that bypasses explicit human confirmation for execution
+
+---
+
+## Vault Markdown ↔ Companion UI correspondence (design intent)
+
+For each state, the two layers must remain coherent.
+
+| State | Vault Markdown (Obsidian) | Companion UI render |
+|---|---|---|
+| `idle` | Panel fence with `AI-instruktion`; `AI-åtgärder` empty or has only prior receipts | Panel widget shows instruction; no pending proposals; run affordance available |
+| `running` | No vault change yet | Running indicator (reuse ThinkingIndicator or new PanelRunningIndicator); action inputs disabled |
+| `proposals-staged` | Unchecked checkboxes written into `AI-åtgärder` by PanelAgent | Proposal list with individual confirm/discard affordances; provenance badge on each row |
+| `confirming` | No vault change yet | Selected proposals highlighted; submit/cancel affordances; composer/other actions disabled |
+| `executing` | Checkboxes now checked (confirmed by Companion UI write-back); execution in flight | Executing indicator; confirmed proposals locked (not dismissible) |
+| `receipt-displayed` | AI status callout updated; executed checkboxes removed from panel | Receipt strip showing `✅` entries; proposal list cleared |
+| `no-match` | AI status callout: `⚠️ No match for: "<instruction snippet>"` | No-match state: instruction echoed, reason surfaced, next-step affordance (edit instruction / view catalog) |
+| `blocked` | AI status callout: `⚠️ Blocked: <reason>` | Blocked state: reason displayed; recovery path (view details, acknowledge) |
+
+---
+
+## Component inventory (design intent)
+
+### New components (Panel-specific)
+
+| Component | Role | data-testid (proposed) |
+|---|---|---|
+| `PanelWidget` | Container that renders a single panel fence; root of the Panel surface in Companion UI | `panel-widget` |
+| `ProposalRow` | A single unchecked proposal with confirm/discard affordances and a provenance badge | `panel-proposal-row` |
+| `PanelNoMatchState` | State display when no catalog match was found; echoes instruction, shows reason, offers next step | `panel-no-match` |
+| `PanelBlockedState` | State display when write guard or policy blocked execution; shows reason and recovery | `panel-blocked` |
+| `PanelRunningIndicator` | Visual indicator for an in-flight PanelAgent run | `panel-running` |
+| `PanelReceiptStrip` | Renders AI status callout entries in companion UI; `✅`/`⚠️`/`⏳` rows | `panel-receipt-strip` |
+
+### Reuse candidates from canvas suggestion flow
+
+| Canvas component | Proposed reuse decision | Notes |
+|---|---|---|
+| `ThinkingIndicator` | **Reuse or extend** — running/executing indicator semantics are similar | Confirm during normalized spec |
+| `ReceiptPill` / `ReceiptsStrip` | **Likely diverge** — Panel receipts are AI status callout entries, not governance route receipts | Confirm during normalized spec |
+| `SuggestionCard` | **Diverge** — Panel proposals are proposal rows inside a widget, not top-level card in rail | Panel context and vault/UI correspondence are different |
+| `ProvenanceBadge` (if extracted) | **Reuse** — catalog action ID + cognition mode badge applies to both surfaces | Confirm if extractable |
+
+Design principle: extend the canvas suggestion flow vocabulary; do not fork. Name divergences explicitly rather than silently.
+
+---
+
+## Proposed design intent vocabulary
+
+These are design-layer intent tokens proposed for the Panel surface. They are **not runtime contracts**. Normalized spec must confirm which become `data-intent` tokens and which map to API calls.
+
+| Intent token | Triggered by | Description |
+|---|---|---|
+| `panel.proposal.confirm` | Confirm button / keyboard shortcut | Confirm selected proposal(s); route through runtime for vault write-back |
+| `panel.proposal.discard` | Discard button / keyboard shortcut | Discard a proposal without writing to vault |
+| `panel.run.request` | Explicit run affordance | Request a new PanelAgent run on the active note |
+| `panel.run.cancel` | Cancel button during `running` | Cancel an in-flight run |
+| `panel.nomatch.acknowledge` | Acknowledge button in `no-match` state | Dismiss no-match state; return to `idle` |
+| `panel.nomatch.editInstruction` | Edit link in `no-match` state | Return focus to `AI-instruktion` for editing |
+| `panel.blocked.acknowledge` | Acknowledge button in `blocked` state | Dismiss blocked state; return to `idle` |
+| `panel.blocked.openDetails` | Details link in `blocked` state | Show full block reason and recovery path |
+
+Keyboard shortcut candidates (proposed; confirm against canvas flow conventions):
+- `C` — confirm selected proposal (scoped to `confirming` state)
+- `D` — discard focused proposal (scoped to `proposals-staged` / `confirming` states)
+- `A` — acknowledge (scoped to `no-match` / `blocked` states)
+
+---
+
+## Data attributes (design intent)
+
+| Attribute | Element | Values |
+|---|---|---|
+| `data-panel-state` | `PanelWidget` root | `idle`, `running`, `proposals-staged`, `confirming`, `executing`, `receipt-displayed`, `no-match`, `blocked` |
+| `data-proposal-id` | `ProposalRow` | Catalog action ID (e.g., `promote.evergreen`) |
+| `data-cognition-mode` | `ProposalRow` provenance badge | `rule`, `llm` |
+| `data-receipt-status` | `PanelReceiptStrip` row | `executed`, `warning`, `pending` |
+
+---
+
+## Runtime dependencies named by this design
+
+The following items are design **dependencies** that must be confirmed or resolved by the runtime before a Companion UI implementation is possible. They are not assumed; they are named so the normalized spec can address them explicitly.
+
+1. **Proposals-written signal:** Does the runtime emit a distinguishable event or API response when proposals are written back to `AI-åtgärder` (vs. execution complete)? The Companion UI needs this to transition from `running` to `proposals-staged` rather than polling the vault.
+
+2. **Confirmation write-back contract:** When a human confirms a proposal in Companion UI, what is the exact write-back sequence? Options: (a) check the vault checkbox and trigger a re-run; (b) route through a dedicated confirm API endpoint that marks the proposal confirmed and triggers execution. Design preference: option (b) — a dedicated endpoint — but this must be confirmed by runtime. See `open-questions.md` Q2.
+
+3. **Run-state detection:** How does Companion UI know a watcher-triggered panel run has started and completed? Options: polling `/api/status`, an event subscription, or a panel-state endpoint. Design preference: short-poll on active-note panel state while Panel widget is visible. See `open-questions.md` Q3.
+
+4. **Cognition mode in response:** The runtime must include `cognition_mode` (`rule` / `llm`) in the proposals payload so the Companion UI can display the provenance badge. This is already in `panel.intent.executed` per `docs/PANEL_AGENT.md §PanelAgent 2.0` — confirm the payload path during normalized spec.

--- a/companion-ui/design_handoff/2026-05-15-panel-interaction/open-questions.md
+++ b/companion-ui/design_handoff/2026-05-15-panel-interaction/open-questions.md
@@ -1,0 +1,162 @@
+State: Handoff package governance doc — open questions for the 2026-05-15 panel interaction design. All questions triaged; no crossing-B-blocking items confirmed resolved yet.
+
+# Open Questions — Panel Interaction Design
+
+**Package:** `companion-ui/design_handoff/2026-05-15-panel-interaction/`
+**Crossing status:** A
+
+Triage categories (per `companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md §Maturity checklist`):
+- **Resolve-before-promotion** — must be resolved before this package can reach Crossing B.
+- **Resolve-in-normalized-spec** — can proceed to Crossing B with proposed defaults; normalized spec must nail down the answer.
+- **Defer-to-implementation-issue** — safe to leave open until a bounded implementation issue takes it up.
+
+---
+
+## Q1 — Panel surface placement
+
+**Question:** Is the Panel widget rendered inline with the active note (appearing when a panel fence is detected), or as a persistent sidebar/overlay?
+
+**Proposed default:** Inline with the active note — Panel widget appears when a panel fence is detected in the active document, rendered in relation to the note content, not as a persistent sidebar that exists for notes without a panel fence.
+
+**Why it matters:** Determines whether the Panel surface is an overlay (per `companion-ui/docs/OVERLAY_GRAMMAR.md`) or an in-document affordance. Affects how multi-panel notes are handled and how the Panel widget is dismissed or collapsed.
+
+**Triage:** Resolve-in-normalized-spec.
+
+**Owner doc:** `companion-ui/docs/OVERLAY_GRAMMAR.md` and the normalized spec for this package.
+
+---
+
+## Q2 — Companion UI → vault confirmation write-back path
+
+**Question:** When the human confirms a proposal in Companion UI, what is the exact write-back sequence?
+
+**Option A (checkbox + re-run):** Companion UI checks the vault checkbox for the confirmed proposal (via `PATCH /api/notes/{id}` or equivalent) and triggers a new PanelAgent run. Confirmation happens through the normal watcher/CLI run path.
+
+**Option B (dedicated confirm endpoint):** A dedicated API endpoint (e.g., `POST /api/panel/confirm`) marks the proposal as confirmed and triggers execution without requiring a separate note-save + watcher cycle.
+
+**Proposed default:** Option B — a dedicated confirm endpoint is cleaner and avoids the race between writing the checkbox and triggering execution. However, this endpoint does not yet exist in the runtime, and creating it is a non-trivial implementation decision.
+
+**Why it matters:** This is a blocking implementation dependency. Without a confirmed write-back contract, the Companion UI cannot implement the `confirming → executing` transition safely. The normalized spec must address this.
+
+**Related invariant:** Whatever path is chosen, the vault must end up with the same artifact as if the human had checked the checkbox in Obsidian and run PanelAgent from the CLI. The vault is the source of truth.
+
+**Triage:** Resolve-in-normalized-spec. **This is a primary normalized-spec deliverable.**
+
+**Owner doc:** Normalized spec (`companion-ui/docs/PANEL_INTERACTION_SPEC.md`, pending) and runtime API docs.
+
+---
+
+## Q3 — How Companion UI detects panel run state
+
+**Question:** How does Companion UI know when a watcher-triggered or explicitly triggered PanelAgent run has started and completed on the active note?
+
+**Option A (polling):** Companion UI polls `/api/status` or a panel-state endpoint while the Panel widget is visible, on a short interval (~500ms).
+
+**Option B (event subscription):** Companion UI subscribes to a server-sent event (SSE) or WebSocket stream and receives run-state transitions.
+
+**Option C (panel-state endpoint):** A dedicated `/api/panel/state?note_uuid=...` endpoint returns the current panel state for the active note; Companion UI polls this while Panel widget is visible.
+
+**Proposed default:** Option A (polling) — short-poll on active-note panel state while Panel widget is visible. This aligns with the existing polling posture of the Companion UI and does not require a new transport mechanism.
+
+**Why it matters:** If the Companion UI cannot detect run state, it cannot transition from `running` → `proposals-staged` or `running` → `no-match` without a manual refresh. The `running` state would be invisible to the user.
+
+**Triage:** Resolve-in-normalized-spec.
+
+**Owner doc:** Normalized spec and runtime transport contract.
+
+---
+
+## Q4 — Multi-panel notes presentation
+
+**Question:** A vault note may contain multiple AI panel fences. How does Companion UI present them?
+
+**Option A (list):** All panel fences are rendered as a list of Panel widgets in document order, each with its own state.
+
+**Option B (tabs):** Panel fences are presented as tabs; one active at a time.
+
+**Option C (single active):** Only the panel with the most recent activity is shown as active; others collapsed.
+
+**Proposed default:** Option A — a list in document order, each Panel widget with its own state. This preserves the vault-native multi-panel structure and avoids imposing an artificial active/inactive distinction.
+
+**Why it matters:** Multi-panel notes are not a rare edge case. The design must not silently break for notes with multiple fences.
+
+**Triage:** Resolve-in-normalized-spec.
+
+**Owner doc:** Normalized spec.
+
+---
+
+## Q5 — Proposal provenance depth
+
+**Question:** How much provenance does a proposal row show at a glance vs. on expand?
+
+**Proposed default:**
+- **Always visible:** catalog action label (human-readable name) + cognition mode badge (`rule` / `llm`).
+- **On expand:** catalog action ID (machine ID, e.g., `promote.evergreen`), `llm_hint` text, confidence signal if available.
+
+**Why it matters:** The `authority-boundaries.md` invariant states "provenance visible at confirmation time, not only in the audit log." The always-visible level must be sufficient for the human to understand the proposal's origin before confirming.
+
+**Triage:** Resolve-in-normalized-spec.
+
+**Owner doc:** This design and the normalized spec.
+
+---
+
+## Q6 — No-match and blocked state representation: vault side
+
+**Question:** The AI status callout receives `⚠️ No match for: "..."` and `⚠️ Blocked: <reason>` entries when these states occur. Is the current callout format sufficient, or does the runtime need to emit richer structured data for the Companion UI to render the full no-match/blocked state?
+
+**Proposed default:** The current callout format (`⚠️ No match for: "..."`) is sufficient for the vault-native surface. The Companion UI renders its `no-match` / `blocked` states from the runtime event payload (`panel.intent.executed` with `actions: []` and a reason field), not by parsing the callout text. The runtime must include a reason field in the event payload.
+
+**Why it matters:** If the Companion UI parses callout text to derive state, it creates a brittle dependency on vault Markdown formatting. If it relies on event payload, the payload must include the reason.
+
+**Open sub-question:** Does `panel.intent.executed` currently include a `no_match_reason` or `block_reason` field? If not, this is a runtime extension that must go through the events/owner-doc pipeline. **This must be confirmed during the normalized spec.**
+
+**Triage:** Resolve-in-normalized-spec.
+
+**Owner doc:** `docs/PANEL_AGENT.md §Event payload`, normalized spec.
+
+---
+
+## Q7 — Whether an internal runtime projection mechanism is needed
+
+**Question:** Should the runtime emit a `<!-- companion:panel:run ... -->` HTML comment or equivalent structured projection into the vault note to communicate panel run state to the Companion UI?
+
+**Context:** Some design patterns use inline annotations in the rendered document to carry state from the server to the UI client. This would be a vault write, which means it must go through the note writer / write guard path.
+
+**Proposed default:** No. The Companion UI should derive panel run state from the runtime event stream or polling (see Q3), not from vault content mutations. Injecting runtime projection content into vault notes would contaminate the vault-native surface and violate the principle that vault artifacts remain readable in Obsidian with or without Companion UI running.
+
+**Governing invariant:** The current vault-native panel syntax is the stable communication envelope. It is not being extended with runtime-projection annotations. See `authority-boundaries.md §On HTML comment run blocks`.
+
+**Resolution:** This question is answered by policy: **no HTML comment run block is accepted as a vault communication channel**. If a future SoT decision reverses this, it requires an explicit owner-doc PR.
+
+**Triage:** Resolved — no internal projection mechanism via vault content mutations. No further action needed.
+
+---
+
+## Q8 — Companion UI write-back and idempotency
+
+**Question:** If the human confirms a proposal in Companion UI and the network call fails or is retried, what prevents double-execution?
+
+**Proposed default:** Idempotency is owned by the runtime (write guard + `executed_action_ids` tracking per `docs/PANEL_AGENT.md §Runtime V1`). The Companion UI must present errors visibly and allow manual retry; it must not implement its own idempotency layer.
+
+**Triage:** Defer-to-implementation-issue.
+
+**Owner doc:** `docs/PANEL_AGENT.md §Runtime V1`, normalized spec.
+
+---
+
+## Summary table
+
+| # | Question | Triage | Crossing-B blocking? |
+|---|---|---|---|
+| Q1 | Panel surface placement (inline vs. sidebar) | Resolve-in-normalized-spec | No |
+| Q2 | Companion UI → vault confirmation write-back path | Resolve-in-normalized-spec | No (needed for implementation, not Crossing B) |
+| Q3 | How Companion UI detects panel run state | Resolve-in-normalized-spec | No |
+| Q4 | Multi-panel notes presentation | Resolve-in-normalized-spec | No |
+| Q5 | Proposal provenance depth | Resolve-in-normalized-spec | No |
+| Q6 | No-match/blocked vault representation and event payload | Resolve-in-normalized-spec | No |
+| Q7 | Internal runtime projection mechanism | **Resolved** — no HTML comment run block | N/A |
+| Q8 | Confirmation idempotency ownership | Defer-to-implementation-issue | No |
+
+**No crossing-B-blocking open questions** — Crossing B requires human review to confirm this assessment and sign off.

--- a/companion-ui/design_handoff/2026-05-15-panel-interaction/state-gallery.md
+++ b/companion-ui/design_handoff/2026-05-15-panel-interaction/state-gallery.md
@@ -1,0 +1,285 @@
+State: Handoff package governance doc — state gallery for the 2026-05-15 panel interaction design.
+
+# State Gallery — Panel Interaction Design
+
+**Package:** `companion-ui/design_handoff/2026-05-15-panel-interaction/`
+**Crossing status:** A
+
+This file describes every declared Panel UI state: what the vault Markdown looks like in Obsidian at that moment, and what the Companion UI renders. The vault/UI correspondence is the core design claim.
+
+---
+
+## State: `idle`
+
+**When:** Panel fence is present in the active note; no active run; no pending proposals.
+
+**Vault Markdown (Obsidian):**
+```markdown
+%% AI:Start %%
+## AI-instruktion
+Diagnose this note and propose safe next actions.
+
+## AI-åtgärder
+
+## AI-logg
+%% AI:End %%
+```
+_(AI status callout may be absent or show only past receipts.)_
+
+**Companion UI:**
+- Panel widget visible, showing the `AI-instruktion` text.
+- `AI-åtgärder` section is empty — no proposal rows shown.
+- A "Run" or equivalent affordance is available.
+- Composer input (if present) is enabled.
+- No indicators, no receipt strip.
+
+**Notes:** The `AI-åtgärder` section may be empty because no proposals have been generated yet, or because prior proposals were confirmed/discarded and the panel is clean.
+
+---
+
+## State: `running`
+
+**When:** A PanelAgent run has been triggered (by watcher, by explicit Companion UI action, or by CLI) and is in flight.
+
+**Vault Markdown (Obsidian):**
+```markdown
+%% AI:Start %%
+## AI-instruktion
+Diagnose this note and propose safe next actions.
+
+## AI-åtgärder
+
+## AI-logg
+%% AI:End %%
+```
+_(No vault change yet during this state.)_
+
+**Companion UI:**
+- `PanelRunningIndicator` shown (animated; reuse of canvas `ThinkingIndicator` or panel-specific variant).
+- All interaction affordances disabled — cannot confirm, discard, or re-run while running.
+- Optional: "Cancel" affordance to abort the run.
+
+**Notes:** The Companion UI must transition out of this state when the run completes — to `proposals-staged`, `no-match`, or `blocked`. Run detection method is an open question (see `open-questions.md` Q3).
+
+---
+
+## State: `proposals-staged`
+
+**When:** PanelAgent ran and wrote unchecked proposals into `AI-åtgärder` (PA2-FREEFORM path or proposal-generation path).
+
+**Vault Markdown (Obsidian):**
+```markdown
+%% AI:Start %%
+## AI-instruktion
+Diagnose this note and propose safe next actions.
+
+## AI-åtgärder
+- [ ] Make this note evergreen
+- [ ] Add missing frontmatter: `tags`, `domain`
+- [ ] Summarize for review
+
+## AI-logg
+%% AI:End %%
+```
+
+**Companion UI:**
+- Panel widget shows a list of `ProposalRow` components, one per unchecked checkbox.
+- Each `ProposalRow` shows:
+  - Proposal label (human-readable catalog action label)
+  - Provenance badge: catalog action ID + cognition mode (`rule` / `llm`)
+  - Confirm affordance (button or keyboard shortcut)
+  - Discard affordance (button or keyboard shortcut)
+- The human can select proposals individually; a "Confirm selected" affordance submits the selection.
+- **No "confirm all" or "accept all" affordance** — each proposal requires individual selection.
+
+**Key invariant:** These proposals have not executed. Showing them in the Companion UI is not execution.
+
+---
+
+## State: `confirming`
+
+**When:** The human has selected one or more proposals and is reviewing before submitting.
+
+**Vault Markdown (Obsidian):**
+```markdown
+%% AI:Start %%
+## AI-instruktion
+Diagnose this note and propose safe next actions.
+
+## AI-åtgärder
+- [ ] Make this note evergreen
+- [ ] Add missing frontmatter: `tags`, `domain`
+- [ ] Summarize for review
+
+## AI-logg
+%% AI:End %%
+```
+_(No vault change yet — selected proposals are not yet confirmed.)_
+
+**Companion UI:**
+- Selected proposals highlighted.
+- Non-selected proposals visible but dimmed.
+- "Submit confirmation" and "Cancel" affordances shown prominently.
+- Other actions disabled to prevent mid-confirmation changes.
+- Provenance still visible on selected proposals.
+
+**Notes:** This state is a UI-local staging step before the write-back API call. The vault does not change until the Companion UI sends the confirmed proposals to the runtime.
+
+---
+
+## State: `executing`
+
+**When:** Confirmed proposals have been submitted to the runtime; execution is in flight.
+
+**Vault Markdown (Obsidian):**
+```markdown
+%% AI:Start %%
+## AI-instruktion
+Diagnose this note and propose safe next actions.
+
+## AI-åtgärder
+- [x] Make this note evergreen
+- [ ] Add missing frontmatter: `tags`, `domain`
+- [ ] Summarize for review
+
+## AI-logg
+%% AI:End %%
+```
+_(Confirmed proposals have been written back as checked checkboxes by the runtime. Execution of the checked actions is now in flight.)_
+
+**Companion UI:**
+- `PanelRunningIndicator` shown (or a distinct executing indicator).
+- Confirmed proposals shown as locked/committed (not dismissible).
+- Non-confirmed proposals remain visible but passive.
+- All other actions disabled.
+
+---
+
+## State: `receipt-displayed`
+
+**When:** Execution complete; AI status callout has been updated by the runtime; executed checkboxes have been removed from `AI-åtgärder`.
+
+**Vault Markdown (Obsidian):**
+```markdown
+%% AI:Start %%
+## AI-instruktion
+Diagnose this note and propose safe next actions.
+
+## AI-åtgärder
+- [ ] Add missing frontmatter: `tags`, `domain`
+- [ ] Summarize for review
+
+## AI-logg
+%% AI:End %%
+
+> [!info]- AI status
+> - ✅ Make this note evergreen (2026-05-15 17:30)
+```
+_(Executed checkbox removed; AI status callout updated.)_
+
+**Companion UI:**
+- `PanelReceiptStrip` shown with `✅` entry for the executed proposal.
+- The proposal list is updated — confirmed+executed proposals removed; remaining unchecked proposals still shown.
+- Receipt transitions to `idle` after a brief display period (~1.5s), or on explicit dismiss.
+
+---
+
+## State: `no-match`
+
+**When:** PanelAgent ran; the `AI-instruktion` did not match any catalog action; `AI-åtgärder` remains empty; the runtime wrote a `⚠️` entry into the AI status callout.
+
+**Vault Markdown (Obsidian):**
+```markdown
+%% AI:Start %%
+## AI-instruktion
+Diagnose this note and propose safe next actions.
+
+## AI-åtgärder
+
+## AI-logg
+%% AI:End %%
+
+> [!info]- AI status
+> - ⚠️ No match for: "Diagnose this note and propose safe next actions."
+```
+
+**Companion UI:**
+- `PanelNoMatchState` shown (not silence, not an empty proposal list).
+- Content:
+  - Instruction text echoed (so the human can read what was interpreted)
+  - Reason surfaced: "No catalog match found" or more specific reason if available
+  - Next-step affordance: edit instruction and re-run, or view the action catalog
+- `PanelReceiptStrip` may show the `⚠️` entry.
+- Acknowledge affordance returns to `idle`.
+
+**This is the most critical state to design correctly.** The `no-match` state is not silence. When PanelAgent ran and found no match, the human must be able to read what happened without any ambiguity. The prod-UAT evidence on 2026-05-15 showed this state as invisible — the Companion UI exists precisely to make it legible.
+
+---
+
+## State: `blocked`
+
+**When:** A write guard, policy gate, or runtime constraint prevented execution. The runtime wrote a `⚠️ Blocked: <reason>` entry into the AI status callout.
+
+**Vault Markdown (Obsidian):**
+```markdown
+%% AI:Start %%
+## AI-instruktion
+Diagnose this note and propose safe next actions.
+
+## AI-åtgärder
+- [ ] Make this note evergreen
+
+## AI-logg
+%% AI:End %%
+
+> [!info]- AI status
+> - ⚠️ Blocked: write guard active (WATCHER_AUTO_EXEC=0)
+```
+
+**Companion UI:**
+- `PanelBlockedState` shown.
+- Content:
+  - Block reason displayed (write guard, policy, or operator setting)
+  - Recovery path: how to resolve the block (e.g., operator must enable `WATCHER_AUTO_EXEC=1`)
+  - "View details" affordance for full block context
+  - Acknowledge affordance returns to `idle` without executing
+- Proposals may still be visible but all action affordances are disabled.
+
+**Notes:** Blocked is a first-class state, not an error. The human should be able to understand why execution was blocked and what to do next, without needing to read runtime logs.
+
+---
+
+## Future states (named for extensibility; not in scope for this design)
+
+### `clarifying`
+
+PanelAgent needs clarification before generating proposals. Renders a clarification prompt in the Panel widget; human responds before proposals are generated.
+
+### `plan-staged`
+
+A multi-step plan is staged; human reviews the step sequence before committing. Individual steps may have per-step confirm/discard affordances.
+
+### `partial-complete`
+
+Some proposals executed successfully; others failed or were skipped. Receipt strip shows mixed `✅` / `⚠️` entries; partial receipt is distinct from full receipt.
+
+### `capability-needed`
+
+A proposed action requires a capability (e.g., a connected tool, an enabled feature flag) that is not currently available. Companion UI surfaces what is missing and how to enable it.
+
+---
+
+## Coverage check (maturity checklist)
+
+| State | Vault side described? | Companion UI side described? |
+|---|---|---|
+| `idle` | ✓ | ✓ |
+| `running` | ✓ | ✓ |
+| `proposals-staged` | ✓ | ✓ |
+| `confirming` | ✓ | ✓ |
+| `executing` | ✓ | ✓ |
+| `receipt-displayed` | ✓ | ✓ |
+| `no-match` | ✓ | ✓ |
+| `blocked` | ✓ | ✓ |
+
+All declared states covered. ✓

--- a/companion-ui/design_handoff/README.md
+++ b/companion-ui/design_handoff/README.md
@@ -19,6 +19,7 @@ Preserved Claude Design artifacts and handoff packages. These are reference/hand
 | `2026-05-14-context-bundle-inspector/` | 2026-05-14 | A | #894, #895, #896 | Inspectable context-bundle bridge object. Design only. |
 | `2026-05-14-memory-candidate-review/` | 2026-05-14 | A | #900 | Pull-based memory candidate review queue. Design only. |
 | `2026-05-14-vault-action-layer/` | 2026-05-14 | A | #910 | 9-step vault action pipeline, 5-tier tool taxonomy. Design only. |
+| `2026-05-15-panel-interaction/` | 2026-05-15 | A | #977, #978, #981 | Panel interaction surface: vault-native AI fence + Companion UI render layer. State machine (8 states), component inventory, authority boundaries, open questions. Interactive prototype (index.html) pending. |
 
 **Crossing A** = archived, not yet through maturity checklist.
 **Crossing B** = maturity checklist passed; normalized spec exists in `companion-ui/docs/`.

--- a/companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md
+++ b/companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md
@@ -119,6 +119,7 @@ Packages already archived in `companion-ui/design_handoff/`:
 | `2026-05-14-memory-candidate-review` | 2026-05-14 | A | #900 |
 | `2026-05-14-vault-action-layer` | 2026-05-14 | A | #910 |
 | `2026-05-14-claude-design-package` | 2026-05-14 | A (index only) | #901 (governance), others per package |
+| `2026-05-15-panel-interaction` | 2026-05-15 | A | #977, #978, #981 |
 
 Pre-governance packages (`2026-05-03`, `2026-05-08`) do not require retroactive maturity-checklist completion. They remain valid exploration archives.
 


### PR DESCRIPTION
## Direct Repair
Type: docs
Reason: companion-ui/design_handoff/ and companion-ui/docs/ are design-governance docs surfaces. The pr-contract allowlist for the docs-authoring lane only covers docs/ and .github/ISSUE_TEMPLATE/; companion-ui/ has not been added yet. Adding it requires a separate governance PR. This PR is docs-only with no code, runtime, or behavior changes.
Validation: git diff --check clean; python3 scripts/docs_guard.py → Docs guard: OK; all 7 files are docs/handoff governance content in companion-ui/design_handoff/ and companion-ui/docs/
Issue required: no

## Summary

Archives the 2026-05-15 panel interaction design handoff package as a governed Crossing-A design artifact. Creates the five required governance docs for the package and updates both archive indexes.

**docs/design-handoff only — no runtime implementation, no production UI implementation.**

## What this PR does

- Adds `companion-ui/design_handoff/2026-05-15-panel-interaction/` governance docs:
  - `README.md` — authority status, crossing target, package contents, next steps
  - `authority-boundaries.md` — what this design is/is not; all required architecture invariants preserved
  - `implementation-contracts.md` — state enum (8 states + 4 future), allowed transitions, component inventory, design intent vocabulary, runtime dependencies named
  - `open-questions.md` — 8 questions triaged (resolve-before-promotion / resolve-in-normalized-spec / defer); Q7 (HTML comment run block) resolved by policy
  - `state-gallery.md` — vault Markdown ↔ Companion UI correspondence for all 8 declared states
- Updates `companion-ui/design_handoff/README.md` — adds package to archive table
- Updates `companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md` — adds package to handoff archive index

## Invariants explicitly preserved in this package

- **Stable envelope, flexible protocol** — the vault-native AI fence syntax is the durable envelope; the interaction protocol may evolve without changing it.
- **Panel surface is note-bound** — no standalone Panel inbox; Panel widget renders inline with the active note when a panel fence is detected.
- **Companion UI does not own vault I/O** — writes back through the runtime API only.
- **Runtime owns** interpretation, policy, write guard, idempotency, execution, receipts, and inverse-action declaration.
- **UI never reclassifies actions locally** — classification authority lives in the action catalog and PanelAgent.
- **Proposals are not execution** — unchecked proposals do not execute; no same-turn auto-execution.
- **No-match and blocked are first-class visible states** — not silence, not empty proposal lists.
- **Future capability expansion is additive** — clarification, plan-staging, partial completion, capability-needed states are named for extensibility only.

## What this PR explicitly does not do

- No runtime implementation.
- No production Companion UI components.
- No PanelAgent behavior changes.
- No event name changes.
- No vault panel syntax changes (`%% AI:Start %%` / headings / AI status callout remain unchanged).
- No standalone Panel inbox.
- **The HTML-comment run block (`<!-- companion:panel:run ... -->`) is not accepted as a replacement contract.** `authority-boundaries.md §On HTML comment run blocks` records this explicitly as policy: no SoT decision has accepted such a syntax.

## Follow-up issues required (not in scope here)

- Normalized spec: `companion-ui/docs/PANEL_INTERACTION_SPEC.md` — Crossing B deliverable
- UI render contract — once normalized spec is authored
- Confirmation write-back contract (open-questions.md Q2) — runtime API decision needed
- Run-state detection contract (open-questions.md Q3)
- Runtime event payload extension for no-match/blocked reason (open-questions.md Q6)
- Governance PR to add `companion-ui/docs/` and `companion-ui/design_handoff/` to the docs-authoring allowed surfaces in pr-contract

## Related issues

- #977 — Decision: PanelAgent proposal generation (open; this package records design intent pending SoT decision)
- #978 — PanelAgent cognitive mediation alignment (parent hub; blocked)
- #981 — Capability taxonomy for cognitive mediation (`agent:ready`)

## Validation

- `git diff --check` — clean (no whitespace errors)
- `python3 scripts/docs_guard.py` — `Docs guard: OK`
- All staged files are docs-only in `companion-ui/design_handoff/` and `companion-ui/docs/`
- No code, tests, or runtime behavior changed

---