### PR TITLE
fix(companions): add duplicate-companion detection and canonical-path enforcement

### DIFF
--- a/app/cli/health.py
+++ b/app/cli/health.py
@@ -12,6 +12,7 @@ from typing import Any, Dict
 import httpx
 
 from app.components.llm.fabric import describe_default_route_policies, describe_default_routes
+from app.services.companion_diagnostics import companion_diagnostics_summary
 from app.config.environment import active_environment
 from app.eval.llm_client import DEFAULT_MODE as DEFAULT_EVAL_MODE
 from app.knowledge.errors import KnowledgeConfigError
@@ -582,6 +583,18 @@ def _suggested_actions(checks: dict[str, dict[str, Any]], runtime: dict[str, dic
     return actions
 
 
+def _check_companion_diagnostics() -> Dict[str, Any]:
+    vault_root = Path(os.getenv("VAULT_ROOT") or "vault").expanduser()
+    try:
+        summary = companion_diagnostics_summary(vault_root)
+    except Exception as exc:
+        return _result(True, f"companion diagnostics skipped: {exc}", data={"skipped": True})
+    count = summary["duplicate_companion_count"]
+    ok = count == 0
+    detail = "no duplicate companion notes" if ok else f"{count} duplicate companion note(s) detected"
+    return _result(ok, detail, data=dict(summary))
+
+
 def _check_v6_seams() -> Dict[str, str]:
     def _seam(module: str) -> str:
         try:
@@ -619,6 +632,7 @@ def run_health(*, trace_id: str | None = None, **kwargs: Any) -> Dict[str, Any]:
     checks["llm_task_routes"] = _annotate_required(_check_llm_task_routes(checks["llm_router"]), required=True)
     checks["llm_providers"] = _annotate_required(_check_llm_providers(checks["ollama"]), required=False)
     checks["embedding_index"] = _annotate_required(_check_embedding_index(), required=True)
+    checks["companion_diagnostics"] = _annotate_required(_check_companion_diagnostics(), required=False)
 
     runtime = {
         "watcher": _watcher_runtime_status(),

--- a/app/services/companion_diagnostics.py
+++ b/app/services/companion_diagnostics.py
@@ -1,0 +1,49 @@
+"""
+Companion diagnostics — health summary for companion note integrity.
+
+Reports duplicate companion notes (same UUID in both canonical and legacy locations)
+so operators can safely resolve them via an explicit migration path.
+
+Issue #974: prod ingest writes duplicate companion notes in two system locations.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TypedDict
+
+from app.services.companion_note import find_duplicate_companions
+
+
+class CompanionDiagnosticsSummary(TypedDict):
+    """Health summary for companion note integrity checks."""
+    duplicate_companion_count: int
+    duplicate_companion_uuids: list[str]
+
+
+def companion_diagnostics_summary(vault_root: Path) -> CompanionDiagnosticsSummary:
+    """
+    Return a health summary for companion notes in the vault.
+
+    Currently reports:
+    - duplicate_companion_count: number of UUIDs present in both canonical and legacy locations
+    - duplicate_companion_uuids: list of those UUIDs (sorted for determinism)
+
+    This function is read-only. It does not delete, move, or modify any files.
+
+    Args:
+        vault_root: Absolute path to the vault root.
+
+    Returns:
+        CompanionDiagnosticsSummary with counts and UUIDs of duplicated companions.
+    """
+    duplicates = find_duplicate_companions(vault_root)
+    return CompanionDiagnosticsSummary(
+        duplicate_companion_count=len(duplicates),
+        duplicate_companion_uuids=[d.uuid for d in duplicates],
+    )
+
+
+__all__ = [
+    "CompanionDiagnosticsSummary",
+    "companion_diagnostics_summary",
+]

--- a/app/services/companion_note.py
+++ b/app/services/companion_note.py
@@ -155,6 +155,52 @@ def write_companion(vault_root: Path, companion: CompanionNote) -> None:
 # Lookup
 # ---------------------------------------------------------------------------
 
+@dataclass(frozen=True)
+class DuplicateCompanion:
+    """A UUID that exists in both canonical and legacy companion locations."""
+    uuid: str
+    canonical_path: Path   # absolute path to the canonical companion
+    legacy_path: Path      # absolute path to the legacy companion
+
+
+def find_duplicate_companions(vault_root: Path) -> list[DuplicateCompanion]:
+    """
+    Detect companion UUIDs that exist in both the canonical and legacy locations.
+
+    A duplicate is defined as a UUID with a file in BOTH:
+    - canonical: vault/<system_dir>/companions/<uuid>.md
+    - legacy:    vault/_system/companions/<uuid>.md
+
+    This function is read-only. It does not delete or modify any files.
+    Use the result for human review or explicit guarded migration.
+
+    Returns:
+        List of DuplicateCompanion records for UUIDs present in both locations.
+    """
+    canonical_dir = vault_root / _companions_dir(vault_root)
+    legacy_dir = vault_root / _LEGACY_COMPANIONS_DIR
+
+    # If canonical and legacy resolve to the same directory, there can be no duplicates.
+    if canonical_dir.resolve() == legacy_dir.resolve():
+        return []
+
+    if not canonical_dir.exists() or not legacy_dir.exists():
+        return []
+
+    canonical_uuids = {p.stem for p in canonical_dir.glob("*.md")}
+    legacy_uuids = {p.stem for p in legacy_dir.glob("*.md")}
+    duplicated = canonical_uuids & legacy_uuids
+
+    return [
+        DuplicateCompanion(
+            uuid=uuid,
+            canonical_path=canonical_dir / f"{uuid}.md",
+            legacy_path=legacy_dir / f"{uuid}.md",
+        )
+        for uuid in sorted(duplicated)
+    ]
+
+
 def find_companion_by_content_hash(vault_root: Path, sha256: str) -> CompanionNote | None:
     """Scan all companions for one whose content_hash matches sha256."""
     companions_dir = vault_root / _companions_dir(vault_root)
@@ -408,10 +454,12 @@ __all__ = [
     "AttachmentRef",
     "CompanionNote",
     "ConflictLog",
+    "DuplicateCompanion",
     "IDENTITY_HISTORY_MAX",
     "IdentityHistoryEntry",
     "companion_path",
     "find_companion_by_content_hash",
+    "find_duplicate_companions",
     "read_companion",
     "rebuild_companion_from_db",
     "repair_companion",

--- a/tests/companions/test_companion_path_resolution.py
+++ b/tests/companions/test_companion_path_resolution.py
@@ -1,0 +1,172 @@
+"""
+Tests for canonical companion path resolution and duplicate detection.
+
+Issue #974: prod ingest writes duplicate companion notes in two system locations.
+
+Covers:
+- companion_path() returns exactly one canonical path for a UUID
+- find_duplicate_companions() detects when both legacy and canonical paths exist
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.services.companion_note import (
+    CompanionNote,
+    companion_path,
+    find_duplicate_companions,
+    write_companion,
+)
+
+
+def _write_layout(vault_root: Path, system_folder: str = "⚙️ System") -> None:
+    layout_path = vault_root / system_folder / "vault.layout.md"
+    layout_path.parent.mkdir(parents=True, exist_ok=True)
+    layout_path.write_text(
+        f"---\nversion: '1'\nsystem_folder: '{system_folder}'\n"
+        "inbox_folder: '📥 Inbox'\ndesk_folder: '🛠️ Workbench'\n---\n",
+        encoding="utf-8",
+    )
+
+
+def _make_companion(uuid: str) -> CompanionNote:
+    return CompanionNote(
+        uuid=uuid,
+        source_ref=f"Notes/note-{uuid[:8]}.md",
+        title="Test Note",
+        content_hash="abc123",
+        ingest_state="tracked",
+        last_ingested="2026-05-16T00:00:00+00:00",
+        created_by_instance="test",
+    )
+
+
+class TestCanonicalCompanionPathIsSingleSourceOfTruth:
+    """AC: deterministic resolver returns exactly one canonical path."""
+
+    def test_canonical_companion_path_is_single_source_of_truth(
+        self, tmp_path: Path
+    ) -> None:
+        """companion_path() must return exactly one deterministic path per UUID."""
+        vault_root = tmp_path / "vault"
+        vault_root.mkdir()
+        _write_layout(vault_root)
+
+        uuid = "aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+        path = companion_path(uuid, vault_root)
+
+        # Must return a single Path (not a list)
+        assert isinstance(path, Path)
+
+        # Must be under the canonical system folder (⚙️ System), not legacy _system
+        parts = path.parts
+        assert "_system" not in parts, (
+            f"canonical path must not use legacy _system, got: {path}"
+        )
+        assert "⚙️ System" in parts, (
+            f"canonical path must use the layout-configured system folder, got: {path}"
+        )
+
+        # Must end with <uuid>.md
+        assert path.name == f"{uuid}.md"
+
+        # Must be deterministic: calling again returns the same path
+        path2 = companion_path(uuid, vault_root)
+        assert path == path2, "companion_path() must be deterministic"
+
+    def test_canonical_path_does_not_vary_between_calls(self, tmp_path: Path) -> None:
+        """Repeated calls for the same UUID and vault always produce the same path."""
+        vault_root = tmp_path / "vault"
+        vault_root.mkdir()
+        _write_layout(vault_root)
+
+        uuid = "11112222-3333-4444-5555-666677778888"
+        paths = {companion_path(uuid, vault_root) for _ in range(5)}
+        assert len(paths) == 1, "companion_path must be stable across calls"
+
+
+class TestDuplicateCompanionLocationsAreDetected:
+    """AC: when both legacy and canonical exist, detect duplicates."""
+
+    def test_duplicate_companion_locations_are_detected(
+        self, tmp_path: Path
+    ) -> None:
+        """find_duplicate_companions() finds UUIDs present in both locations."""
+        vault_root = tmp_path / "vault"
+        vault_root.mkdir()
+        _write_layout(vault_root)
+
+        uuid = "dddd1111-2222-3333-4444-555566667777"
+        companion = _make_companion(uuid)
+
+        # Write to canonical location
+        write_companion(vault_root, companion)
+
+        # Also write to legacy location (simulates the bug)
+        legacy_path = vault_root / "_system" / "companions" / f"{uuid}.md"
+        legacy_path.parent.mkdir(parents=True, exist_ok=True)
+        legacy_path.write_text(
+            (vault_root / companion_path(uuid, vault_root)).read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+
+        duplicates = find_duplicate_companions(vault_root)
+        duplicate_uuids = [d.uuid for d in duplicates]
+        assert uuid in duplicate_uuids, (
+            f"UUID {uuid} present in both canonical and legacy must be reported as duplicate"
+        )
+
+    def test_no_duplicate_when_only_canonical_exists(self, tmp_path: Path) -> None:
+        """find_duplicate_companions() returns empty list when only canonical exists."""
+        vault_root = tmp_path / "vault"
+        vault_root.mkdir()
+        _write_layout(vault_root)
+
+        uuid = "eeee2222-3333-4444-5555-666677778888"
+        write_companion(vault_root, _make_companion(uuid))
+
+        duplicates = find_duplicate_companions(vault_root)
+        assert duplicates == [], "no duplicates when only canonical companion exists"
+
+    def test_no_duplicate_when_only_legacy_exists(self, tmp_path: Path) -> None:
+        """find_duplicate_companions() returns empty when only legacy exists (no canonical)."""
+        vault_root = tmp_path / "vault"
+        vault_root.mkdir()
+        _write_layout(vault_root)
+
+        uuid = "ffff3333-4444-5555-6666-777788889999"
+        legacy_path = vault_root / "_system" / "companions" / f"{uuid}.md"
+        legacy_path.parent.mkdir(parents=True, exist_ok=True)
+        legacy_path.write_text(
+            "---\nuuid: ffff3333-4444-5555-6666-777788889999\n"
+            "source_ref: Notes/old.md\ntitle: Old\ncontent_hash: abc\n"
+            "ingest_state: tracked\nlast_ingested: 2026-01-01T00:00:00+00:00\n"
+            "created_by_instance: test\n---\n",
+            encoding="utf-8",
+        )
+
+        duplicates = find_duplicate_companions(vault_root)
+        assert duplicates == [], (
+            "only a legacy companion (no canonical counterpart) is not a duplicate"
+        )
+
+    def test_find_duplicate_companions_is_read_only(self, tmp_path: Path) -> None:
+        """find_duplicate_companions() must not delete or modify any files."""
+        vault_root = tmp_path / "vault"
+        vault_root.mkdir()
+        _write_layout(vault_root)
+
+        uuid = "aaaa4444-5555-6666-7777-888899990000"
+        write_companion(vault_root, _make_companion(uuid))
+
+        canonical_path = vault_root / companion_path(uuid, vault_root)
+        legacy_path = vault_root / "_system" / "companions" / f"{uuid}.md"
+        legacy_path.parent.mkdir(parents=True, exist_ok=True)
+        legacy_path.write_text(
+            canonical_path.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+
+        find_duplicate_companions(vault_root)
+
+        assert canonical_path.exists(), "canonical companion must not be deleted"
+        assert legacy_path.exists(), "legacy companion must not be deleted"

--- a/tests/health/test_companion_diagnostics.py
+++ b/tests/health/test_companion_diagnostics.py
@@ -1,0 +1,84 @@
+"""
+Tests that the health/diagnostics surface reports duplicate companion notes.
+
+Issue #974: prod ingest writes duplicate companion notes in two system locations.
+
+The health surface must expose duplicate companions so operators can act on them.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.services.companion_note import (
+    CompanionNote,
+    companion_path,
+    write_companion,
+)
+from app.services.companion_diagnostics import companion_diagnostics_summary
+
+
+def _write_layout(vault_root: Path, system_folder: str = "⚙️ System") -> None:
+    layout_path = vault_root / system_folder / "vault.layout.md"
+    layout_path.parent.mkdir(parents=True, exist_ok=True)
+    layout_path.write_text(
+        f"---\nversion: '1'\nsystem_folder: '{system_folder}'\n"
+        "inbox_folder: '📥 Inbox'\ndesk_folder: '🛠️ Workbench'\n---\n",
+        encoding="utf-8",
+    )
+
+
+def _make_companion(uuid: str) -> CompanionNote:
+    return CompanionNote(
+        uuid=uuid,
+        source_ref=f"Notes/note-{uuid[:8]}.md",
+        title="Test Note",
+        content_hash="abc123",
+        ingest_state="tracked",
+        last_ingested="2026-05-16T00:00:00+00:00",
+        created_by_instance="test",
+    )
+
+
+class TestDuplicateCompanionsAreReported:
+    def test_duplicate_companions_are_reported(self, tmp_path: Path) -> None:
+        """companion_diagnostics_summary() reports duplicates in its output."""
+        vault_root = tmp_path / "vault"
+        vault_root.mkdir()
+        _write_layout(vault_root)
+
+        uuid = "dddd7777-8888-9999-aaaa-bbbbccccdddd"
+        companion = _make_companion(uuid)
+
+        # Write canonical companion
+        write_companion(vault_root, companion)
+
+        # Inject legacy duplicate (simulates the bug)
+        legacy_path = vault_root / "_system" / "companions" / f"{uuid}.md"
+        legacy_path.parent.mkdir(parents=True, exist_ok=True)
+        legacy_path.write_text(
+            (vault_root / companion_path(uuid, vault_root)).read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+
+        summary = companion_diagnostics_summary(vault_root)
+
+        assert summary["duplicate_companion_count"] > 0, (
+            "health summary must report at least one duplicate"
+        )
+        assert uuid in summary["duplicate_companion_uuids"], (
+            f"UUID {uuid} must appear in duplicate_companion_uuids"
+        )
+
+    def test_no_duplicates_reported_on_clean_vault(self, tmp_path: Path) -> None:
+        """companion_diagnostics_summary() reports zero duplicates on a clean vault."""
+        vault_root = tmp_path / "vault"
+        vault_root.mkdir()
+        _write_layout(vault_root)
+
+        uuid = "eeee8888-9999-aaaa-bbbb-ccccddddeeee"
+        write_companion(vault_root, _make_companion(uuid))
+
+        summary = companion_diagnostics_summary(vault_root)
+
+        assert summary["duplicate_companion_count"] == 0
+        assert summary["duplicate_companion_uuids"] == []

--- a/tests/ingest/test_companion_tracking_writer.py
+++ b/tests/ingest/test_companion_tracking_writer.py
@@ -1,0 +1,104 @@
+"""
+Tests that ingest/tracking writer does not create duplicate companion notes.
+
+Issue #974: prod ingest writes duplicate companion notes in two system locations.
+
+The tracking writer must write companion notes to exactly one canonical location
+and never to the legacy _system/companions/ path.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.ingest.vault_alpha import run_vault_alpha_ingest_paths
+from app.services.companion_note import companion_path, find_duplicate_companions
+from app.stores import reset_store_backends
+
+
+@pytest.fixture()
+def _mock_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv("LLM_PROVIDER", "mock")
+    monkeypatch.setenv(
+        "LLM_MOCK_RESPONSE",
+        '{"type":"note","trust":"own","tags":["topic/test"],"confidence":0.95}',
+    )
+    monkeypatch.setenv("COMPANION_CREATE_COOLDOWN_SECONDS", "0")
+    monkeypatch.setenv("COMPANION_RENAME_COOLDOWN_SECONDS", "0")
+    reset_store_backends()
+
+
+def _write_layout(vault_root: Path, system_folder: str = "⚙️ System") -> None:
+    layout_path = vault_root / system_folder / "vault.layout.md"
+    layout_path.parent.mkdir(parents=True, exist_ok=True)
+    layout_path.write_text(
+        f"---\nversion: '1'\nsystem_folder: '{system_folder}'\n"
+        "inbox_folder: '📥 Inbox'\ndesk_folder: '🛠️ Workbench'\n---\n",
+        encoding="utf-8",
+    )
+
+
+class TestTrackingWriterDoesNotCreateDuplicateCompanions:
+    def test_tracking_writer_does_not_create_duplicate_companions(
+        self, tmp_path: Path, _mock_env: None
+    ) -> None:
+        """Clean vault ingest must write companion to exactly one location."""
+        vault_root = tmp_path / "vault"
+        vault_root.mkdir()
+        _write_layout(vault_root)
+
+        uuid = "bbbb5555-6666-7777-8888-999900001111"
+        note = vault_root / "Notes" / "Tracking Test Note.md"
+        note.parent.mkdir()
+        note.write_text(
+            f"---\nuuid: {uuid}\ntitle: Tracking Test Note\n---\nSome content.\n",
+            encoding="utf-8",
+        )
+
+        run_vault_alpha_ingest_paths(vault_root, [note])
+
+        # Canonical companion must exist
+        canonical = vault_root / companion_path(uuid, vault_root)
+        assert canonical.exists(), "canonical companion must be written after ingest"
+
+        # Legacy companion must NOT exist
+        legacy = vault_root / "_system" / "companions" / f"{uuid}.md"
+        assert not legacy.exists(), (
+            "_system/companions/ companion must not be written — dual-write removed"
+        )
+
+        # No duplicates via the detection API
+        duplicates = find_duplicate_companions(vault_root)
+        duplicate_uuids = [d.uuid for d in duplicates]
+        assert uuid not in duplicate_uuids, (
+            "find_duplicate_companions must not report a clean single-write as duplicate"
+        )
+
+    def test_second_ingest_does_not_create_duplicate(
+        self, tmp_path: Path, _mock_env: None
+    ) -> None:
+        """Re-ingesting an already-tracked note must not create a second companion."""
+        vault_root = tmp_path / "vault"
+        vault_root.mkdir()
+        _write_layout(vault_root)
+
+        uuid = "cccc6666-7777-8888-9999-000011112222"
+        note = vault_root / "Notes" / "Idempotent Note.md"
+        note.parent.mkdir()
+        note.write_text(
+            f"---\nuuid: {uuid}\ntitle: Idempotent Note\n---\nContent.\n",
+            encoding="utf-8",
+        )
+
+        run_vault_alpha_ingest_paths(vault_root, [note])
+        run_vault_alpha_ingest_paths(vault_root, [note])
+
+        # Canonical companion directory should have exactly one file for this uuid
+        canonical_dir = (vault_root / companion_path(uuid, vault_root)).parent
+        uuid_files = list(canonical_dir.glob(f"{uuid}.md"))
+        assert len(uuid_files) == 1, f"expected exactly 1 companion, found {len(uuid_files)}"
+
+        duplicates = find_duplicate_companions(vault_root)
+        assert not any(d.uuid == uuid for d in duplicates)


### PR DESCRIPTION
## Summary

Fixes #974 — prod ingest writes duplicate companion notes in two system locations.

- Adds `find_duplicate_companions(vault_root)` to `app/services/companion_note.py`: detects UUIDs present in both the canonical `⚙️ System/companions/` and legacy `_system/companions/` paths. Read-only; does not delete files.
- Adds `app/services/companion_diagnostics.py` with `companion_diagnostics_summary(vault_root)`: health surface that returns `duplicate_companion_count` and `duplicate_companion_uuids` for operator visibility.
- The write path already uses only the canonical location (dual-write was removed in an earlier change); this PR adds the detection and reporting layer for existing duplicates.

**Dispatcher unavailable (db_exists: false) — used GitHub-label-only claim.**

## Acceptance Criteria

- [x] `tests/companions/test_companion_path_resolution.py::test_canonical_companion_path_is_single_source_of_truth` — passes
- [x] `tests/companions/test_companion_path_resolution.py::test_duplicate_companion_locations_are_detected` — passes
- [x] `tests/ingest/test_companion_tracking_writer.py::test_tracking_writer_does_not_create_duplicate_companions` — passes
- [x] `tests/health/test_companion_diagnostics.py::test_duplicate_companions_are_reported` — passes

## Test plan

- [ ] Run `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companions tests/ingest/test_companion_tracking_writer.py tests/health/test_companion_diagnostics.py` — 10 passed
- [ ] Run `ruff check app/services/companion_note.py app/services/companion_diagnostics.py` — all checks passed
- [ ] Run `mypy app/services/companion_note.py app/services/companion_diagnostics.py` — no issues found
- [ ] Manual prod validation: create UAT note in Inbox, wait for watcher ingest, confirm `companion_diagnostics_summary()` reports 0 duplicates for new notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)