### PR TITLE
feat(governance): add companion-ui docs paths to docs-authoring lane allowlist

### DIFF
--- a/.github/workflows/issue-pr-governance.yml
+++ b/.github/workflows/issue-pr-governance.yml
@@ -128,6 +128,8 @@ jobs:
             const docsAllowedPrefixes = [
               "docs/",
               ".github/ISSUE_TEMPLATE/",
+              "companion-ui/docs/",
+              "companion-ui/design_handoff/",
             ];
             const governanceAllowedExact = new Set([
               "README.md",


### PR DESCRIPTION
## Summary

- Adds `companion-ui/docs/` and `companion-ui/design_handoff/` to the `docsAllowedPrefixes` array in the pr-contract CI check
- These directories contain design governance docs and handoff packages — they are docs surfaces, not production code
- PRs that only touch these paths are now valid under the docs-authoring lane without needing a governing Issue

## Checklist

- [x] Governance lane — this PR only touches `.github/workflows/issue-pr-governance.yml`, which is in the governance-lane allowlist

🤖 Generated with [Claude Code](https://claude.com/claude-code)