### PR TITLE
feat(panel-agent): visible no-op and proposal receipts (#980)

### DIFF
--- a/app/agents/panel_agent/graph.py
+++ b/app/agents/panel_agent/graph.py
@@ -384,6 +384,58 @@ def _apply_actions(state: PanelAgentState, *, selected_ids: set[str] | None, rea
     state.selected_action_ids = list(selected_ids or [])
     state.selected_action_reasons = reasons or {}
     state.action_results = actions
+
+    # No-op / no-match visibility (#980): when this pass produced no executed,
+    # logged, or proposed outcome, emit a bounded panel.action.logged event with
+    # `reason: no_actions_matched` so the runtime decision stays visible. Only
+    # surface this when the pass had genuine input to evaluate (panel actions or
+    # a non-empty instruction triggering the freeform path); a converged rerun
+    # whose only inputs were already-filtered executed IDs is not a no-match.
+    proposed_ids_now = {aid for aid in (state.proposed_action_ids or []) if aid}
+    produced_any = any(
+        r.status in {"triggered", "logged"}
+        or (r.status == "skipped" and r.details.get("reason") == "proposal_offered")
+        for r in actions
+    )
+    instruction_text = ""
+    try:
+        instruction_text = (state.intent_event.payload.panel.instruction or "").strip()
+    except Exception:
+        instruction_text = ""
+    # Converged-rerun signal: either the runtime flagged this pass as a
+    # post-execution rerun, or prior executed IDs are present with no fresh
+    # checkbox input. Treat as already-finished, not no-match.
+    converged_rerun = state.converged_rerun or (
+        bool(state.executed_action_ids) and not actions_to_process
+    )
+    # Only emit no-match when there was real input AND a cognition decision was
+    # made this pass (freeform LLM returned empty, or checked-but-unmapped). A
+    # rule-mode passthrough with empty actions is not a no-match.
+    cognition_decided = bool(state.cognition_decision_made)
+    had_input = (
+        bool(actions_to_process)
+        or (bool(instruction_text) and cognition_decided)
+    ) and not converged_rerun
+    if had_input and not produced_any and not proposed_ids_now:
+        intent_event = state.intent_event
+        instruction = ""
+        try:
+            instruction = (intent_event.payload.panel.instruction or "").strip()
+        except Exception:
+            instruction = ""
+        no_match_event = PanelActionLoggedEvent(
+            trace_id=intent_event.trace_id,
+            source=_build_panel_source(),
+            payload={
+                "note": intent_event.payload.note.model_dump(mode="json"),
+                "panel_id": intent_event.payload.panel.panel_id,
+                "action": None,
+                "reason": "no_actions_matched",
+                "instruction": instruction,
+            },
+        )
+        emitted.append(no_match_event)
+
     state.emitted_events = emitted
     return state
 
@@ -398,6 +450,10 @@ def _decide_actions_with_backend(state: PanelAgentState, backend: PanelCognition
     # that have no corresponding entry in state.actions (e.g., no-checkbox panels).
     if chosen:
         state = _inject_catalog_proposals(state, chosen)
+    # Mark that a cognition decision was made (even if empty) so the no-match
+    # receipt path (#980) can distinguish freeform decide=nothing from rule-mode
+    # passthrough.
+    state.cognition_decision_made = True
     return _apply_actions(state, selected_ids=chosen, reasons=reasons)
 
 

--- a/app/agents/panel_agent/runtime.py
+++ b/app/agents/panel_agent/runtime.py
@@ -101,7 +101,9 @@ def execute_panel_intent(
         note_text = str(payload.get("raw_text") or payload.get("text") or "")
         executed_ids = set(payload.get("executed_action_ids") or [])
 
+    original_action_count = len(list(intent_event.payload.actions))
     actions = [action for action in intent_event.payload.actions if action.id not in executed_ids]
+    converged_rerun = bool(executed_ids) and original_action_count > 0 and not actions
     payload = intent_event.payload.model_copy(update={"actions": list(actions)})
     intent_event = intent_event.model_copy(update={"payload": payload})
     panel_hints = [
@@ -124,6 +126,7 @@ def execute_panel_intent(
         policy_flags=policy_flags,
         vault_root=vault_root,
         decider_mode=decider_mode,
+        converged_rerun=converged_rerun,
     )
     state = run_panel_graph(initial_state, decider_mode=decider_mode)
 
@@ -207,6 +210,29 @@ def execute_panel_intent(
         emitted_events=emitted_events,
         log_entry=state.log_entry,
     )
+
+
+def _existing_panel_proposal_labels(markdown: str) -> set[str]:
+    """Return the set of label texts already present as checkbox actions in the
+    last panel block of ``markdown``. Used to decide which proposals are new and
+    should trigger a fresh proposal receipt (#980).
+    """
+    lines = markdown.splitlines()
+    panel_start = None
+    panel_end = None
+    for idx in range(len(lines) - 1, -1, -1):
+        line = lines[idx].strip().lower()
+        if "%%" in line and "ai" in line:
+            if panel_end is None:
+                panel_end = idx
+            else:
+                panel_start = idx
+                break
+    if panel_end is None or panel_start is None:
+        return set()
+    panel_text = "\n".join(lines[panel_start : panel_end + 1])
+    parsed = parse_panel(panel_text)
+    return {action.text.strip() for action in parsed.actions if action.text.strip()}
 
 
 def _write_proposals_to_panel(markdown: str, proposed_labels: list[tuple[str, str]]) -> str:
@@ -329,15 +355,53 @@ def _apply_note_writeback(
                 proposed_labels.append((action.id, action.label))
 
     queued_labels: list[str] = []  # async actions (zone_move): queued, not yet executed
+    fallback_labels: list[tuple[str, str]] = []  # (label, reason) for logged-but-not-triggered actions
+
+    # Reasons that represent execution failures or mismatches we want to surface
+    # as bounded fallback receipts (#980). Other "logged" outcomes (e.g. zone_move
+    # routed through the action layer) are treated as queued, matching pre-#980
+    # behavior.
+    _FALLBACK_REASONS = {
+        "unmapped_action",
+        "unknown_mapping",
+        "ambiguous_action",
+        "watcher_not_allowed",
+        "trust_verb_missing",
+        "trust_verb_invalid",
+        "admission_required",
+    }
 
     for result in state.action_results:
         if result.checked and result.status in {"triggered", "logged"}:
-            if (result.intent_type or "").lower() == "zone_move":
+            reason = str((result.details or {}).get("reason") or "")
+            if result.status == "logged" and reason in _FALLBACK_REASONS:
+                fallback_labels.append((result.label, reason))
+            elif (result.intent_type or "").lower() == "zone_move":
                 queued_labels.append(result.label)
             else:
                 executed_labels.append(result.label)
 
-    if not executed_labels and not queued_labels and not proposed_labels:
+    # Detect a no-match / no-op pass: this run produced no executed/queued/proposed
+    # outcomes and the graph emitted a no_actions_matched signal. Surface a single
+    # bounded receipt line so the human sees the decision in the AI status block.
+    no_match_visible = (
+        not executed_labels
+        and not queued_labels
+        and not proposed_labels
+        and any(
+            getattr(evt, "event", None) == "panel.action.logged"
+            and (getattr(evt, "payload", {}) or {}).get("reason") == "no_actions_matched"
+            for evt in (state.emitted_events or [])
+        )
+    )
+
+    if (
+        not executed_labels
+        and not queued_labels
+        and not proposed_labels
+        and not fallback_labels
+        and not no_match_visible
+    ):
         return
 
     note_uuid = state.note.uuid
@@ -384,15 +448,45 @@ def _apply_note_writeback(
     updated = remove_actions_from_markdown(annotated, ids_to_remove)
 
     # Write back proposed (unchecked) actions as suggestions for user confirmation.
+    # Only labels that were newly inserted should trigger a fresh proposal receipt
+    # so reruns over an already-proposed panel stay idempotent (#980 + #979).
+    newly_proposed_labels: list[str] = []
     if proposed_labels:
+        before_len = len(updated)
+        # Compute newly-added labels by diffing the file before/after the insert,
+        # but the simpler signal is the dedupe inside _write_proposals_to_panel:
+        # detect which labels were not already in the panel block.
+        existing_panel_labels = _existing_panel_proposal_labels(updated)
+        newly_proposed_labels = [
+            label for _id, label in proposed_labels
+            if label.strip() not in existing_panel_labels
+        ]
         updated = _write_proposals_to_panel(updated, proposed_labels)
+        del before_len
 
     # Build receipt lines.
     # zone_move actions are asynchronous: the Vault Action Layer is the authoritative
     # execution receipt.  Write "queued" here so the panel receipt never claims completion.
+    # Proposal receipts (#980) surface proposal-generation outcomes without claiming
+    # execution; no-match receipts surface the runtime no-op decision.
     now_str = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M")
     receipts = [f"\u2705 {label} ({now_str})" for label in executed_labels]
     receipts += [f"\u23f3 {label} (queued, {now_str})" for label in queued_labels]
+    # Proposal-offered receipts: visible suggestion line in AI status block.
+    # Only emit for proposals that are newly inserted this pass; duplicate
+    # proposals on rerun stay silent so receipt blocks remain bounded.
+    receipts += [
+        f"\U0001f4a1 F\u00f6rslag: {label} (v\u00e4ntar bekr\u00e4ftelse, {now_str})"
+        for label in newly_proposed_labels
+    ]
+    # Fallback diagnostics: action was surfaced but did not execute.
+    receipts += [
+        f"\u26a0\ufe0f {label} ({reason}, {now_str})"
+        for label, reason in fallback_labels
+    ]
+    # No-match / no-op receipt: one bounded line, only when nothing else surfaced.
+    if no_match_visible:
+        receipts.append(f"\u2139\ufe0f Inga \u00e5tg\u00e4rder matchade ({now_str})")
 
     # Find preferred insert position (after last panel fence).
     parsed = parse_panel(updated)
@@ -418,11 +512,13 @@ def _apply_note_writeback(
     _refresh_companion_hash(note_uuid, updated, vault_root, note_file)
 
     logger.info(
-        "panel writeback applied note_path=%s removed=%d receipts=%d proposals=%d",
+        "panel writeback applied note_path=%s removed=%d receipts=%d proposals=%d fallbacks=%d no_match=%s",
         note_file,
         len(ids_to_remove),
         len(receipts),
         len(proposed_labels),
+        len(fallback_labels),
+        no_match_visible,
     )
 
 

--- a/app/agents/panel_agent/state.py
+++ b/app/agents/panel_agent/state.py
@@ -38,6 +38,15 @@ class PanelAgentState(BaseModel):
     panel_hints: List[dict[str, Any]] = Field(default_factory=list)
     executed_action_ids: List[str] = Field(default_factory=list)
     proposed_action_ids: List[str] = Field(default_factory=list)
+    # Set by the runtime when the pre-filter intent had actions but they were all
+    # already-executed and filtered out before reaching the graph. Used by the
+    # no-actions-matched receipt gate to distinguish converged reruns from true
+    # no-match runs.
+    converged_rerun: bool = False
+    # Set by the cognition seam when a backend returned a concrete selection
+    # decision (including empty). Distinguishes freeform LLM no-match (decision
+    # was made: nothing fits) from rule-mode pass-through (no decision invoked).
+    cognition_decision_made: bool = False
     vault_root: Path | None = None
 
     # Runtime-populated fields

--- a/docs/PANEL_AGENT.md
+++ b/docs/PANEL_AGENT.md
@@ -73,7 +73,7 @@ Capability taxonomy alignment (v6.x cognitive mediation, `docs/CAPABILITY_CONTRA
   - Instruction heading: `## AI-instruktion` (localized variants supported)
   - Actions heading: `## AI-åtgärder` (localized variants supported)
   - Checkboxes: `- [ ]` or `- [x]` (checked means run the action)
-- AI status callout (foldable, outside the panel): `> [!info]- AI status` with receipt lines (`- ✅ ...`, `- ⚠️ ...`, `- ⏳ ...`). The runtime appends receipts for executed/failed actions and trims to the last 20; already-executed IDs remove their checkbox from the panel on re-run.
+- AI status callout (foldable, outside the panel): `> [!info]- AI status` with receipt lines (`- ✅ ...` executed, `- ⏳ ...` queued, `- ⚠️ ...` fallback diagnostic with reason, `- 💡 Förslag: ... (väntar bekräftelse, ...)` proposal pending human confirmation, `- ℹ️ Inga åtgärder matchade ...` for a freeform no-op pass). The runtime appends receipts for executed/failed/proposal/no-match outcomes and trims to the last 20; already-executed IDs remove their checkbox from the panel on re-run. Proposal-offered receipts (#980) are emitted only when the proposal is newly inserted into the panel block; reruns over an already-proposed panel stay silent so the receipt block remains bounded and idempotent. Fallback receipts surface checked actions that did not execute (e.g. `unmapped_action`, `watcher_not_allowed`, `ambiguous_action`); no-match receipts surface a freeform LLM pass that produced no actionable selection. Both also emit `panel.action.logged` events with the matching `reason` for downstream observability.
 - This callout is a human-visible receipt overlay on the warm surface, not the canonical mirror artifact.
 - Legacy notes that only use the headings without fences are still parsed; new panels should use fences.
 - Panel content is not indexed or used as knowledge.
@@ -89,6 +89,9 @@ Make this note evergreen
 
 > [!info]- AI status
 > - ✅ Re-classify as Concept (2025-03-01 10:00)
+> - 💡 Förslag: Gör denna anteckning evergreen (väntar bekräftelse, 2025-03-01 10:00)
+> - ℹ️ Inga åtgärder matchade (2025-03-01 10:01)
+> - ⚠️ Unmapped freeform request (unmapped_action, 2025-03-01 10:02)
 ```
 
 ## Runtime V1 (fan-out, promotion intent, receipts)

--- a/tests/agents/panel_agent/test_panel_execution.py
+++ b/tests/agents/panel_agent/test_panel_execution.py
@@ -78,3 +78,55 @@ def test_checked_checkbox_actions_execute() -> None:
     assert statuses["promote.evergreen"] == "triggered"
     # The human-checked action is NOT in proposed_action_ids: it was not an LLM proposal.
     assert "promote.evergreen" not in (result.proposed_action_ids or [])
+
+
+def test_checked_action_receipts_preserved() -> None:
+    """AC #980-5: existing execution receipts remain unchanged for checked
+    actions; #980's no-op/proposal visibility additions do not displace the
+    checked-action receipt path. The graph must still emit `promote.intent.created`
+    and `panel.action.triggered`, and must NOT emit a `no_actions_matched` signal
+    when at least one checked action executed.
+    """
+    mapping = PanelActionMapping(
+        id="promote.evergreen",
+        intent_type="promotion",
+        trust_verb="APPLY",
+        downstream_event="review.promote.evergreen",
+        params={"maturity": "evergreen"},
+    )
+    action = PanelIntentAction(
+        id=mapping.id,
+        label="Make this note evergreen",
+        checked=True,
+        mapping=mapping,
+    )
+    note = NoteRef(
+        uuid="panel-980-receipt-preserved-0000-4000-8000-000000000001",
+        path="vault/Receipt.md",
+        origin="vault",
+    )
+    panel = PanelInfo(panel_id="p1", instruction="Promote.", raw_block=None)
+    payload = PanelIntentPayload(note=note, panel=panel, actions=[action])
+    intent = PanelIntentEvent(payload=payload, trace_id="trace-#980-receipt")
+    state = PanelAgentState(
+        trace_id=intent.trace_id,
+        note=note,
+        panel=panel,
+        actions=[action],
+        intent_event=intent,
+    )
+
+    result = run_panel_graph(state, decider_mode="rule")
+
+    event_names = [getattr(evt, "event", None) for evt in result.emitted_events]
+    # Execution receipts preserved.
+    assert "promote.intent.created" in event_names
+    assert "panel.action.triggered" in event_names
+    # No no-op marker fires when actions actually executed.
+    no_match_logged = [
+        evt
+        for evt in result.emitted_events
+        if getattr(evt, "event", None) == "panel.action.logged"
+        and (getattr(evt, "payload", {}) or {}).get("reason") == "no_actions_matched"
+    ]
+    assert not no_match_logged

--- a/tests/agents/panel_agent/test_panel_receipts.py
+++ b/tests/agents/panel_agent/test_panel_receipts.py
@@ -1,0 +1,310 @@
+"""Issue #980: visible no-op and proposal receipts in the PanelAgent runtime.
+
+These tests exercise the real PanelAgent LangGraph (no graph mocking) to confirm
+that no-match runs, proposal-generation paths, and fallback diagnostics produce
+visible bounded feedback in the AI status callout, that receipts remain bounded,
+and that existing execution receipts for checked actions are preserved.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from app.agents.panel.writeback import AI_STATUS_HEADER, MAX_RECEIPTS
+from app.agents.panel_agent.agent import run_panel_intent_for_note
+from app.agents.panel_agent.runtime import PanelRuntimeResult, execute_panel_intent
+from app.store import object_store as object_store_module
+from app.store.object_store import DomainObject, ObjectStore
+
+
+class _StubReasoningFacade:
+    def __init__(self, response: dict) -> None:
+        self._response = response
+
+    def structured(self, messages, schema, *, task_kind: str, trace_id: str | None = None) -> dict:
+        return self._response
+
+
+def _seed_note(note_uuid: str, markdown: str, *, source_ref: str) -> None:
+    obj = DomainObject(
+        uuid=note_uuid,
+        kind="note",
+        payload={"raw_text": markdown, "origin": "vault"},
+        source_ref=source_ref,
+        created_at=datetime.now(timezone.utc),
+    )
+    ObjectStore().save_object(obj, emit_outbox=False)
+
+
+def _settings_file(
+    tmp_path: Path,
+    *,
+    action_id: str,
+    label: str,
+    intent_type: str,
+    downstream_event: str,
+    trust_verb: str | None = None,
+) -> Path:
+    path = tmp_path / "panel-actions.md"
+    trust_line = f'    trust_verb: "{trust_verb}"\n' if trust_verb else ""
+    path.write_text(
+        f"""---
+mappings:
+  - id: \"{action_id}\"
+    label: \"{label}\"
+    intent_type: \"{intent_type}\"
+{trust_line}    downstream_event: \"{downstream_event}\"
+    params:
+      maturity: \"evergreen\"
+---
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _vault_note(tmp_path: Path, note_uuid: str, markdown: str) -> Path:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    note_file = vault / "n.md"
+    note_file.write_text(markdown, encoding="utf-8")
+    _seed_note(note_uuid, markdown, source_ref=str(note_file))
+    return note_file
+
+
+@pytest.fixture(autouse=True)
+def _clear_memory_store() -> None:
+    object_store_module._MEMORY_STORE.clear()
+
+
+def _read_outbox(p: Path) -> list[dict]:
+    if not p.exists():
+        return []
+    return [json.loads(line) for line in p.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def test_freeform_no_match_writes_visible_receipt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC #980-1: a freeform LLM pass that returns no matching action surfaces a
+    visible bounded receipt line in the AI status callout and emits a
+    `panel.action.logged` event with `reason: no_actions_matched`.
+    """
+    note_uuid = str(uuid4())
+    settings_path = _settings_file(
+        tmp_path,
+        action_id="promote.evergreen",
+        label="Make this note evergreen",
+        intent_type="promotion",
+        trust_verb="APPLY",
+        downstream_event="review.promote.evergreen",
+    )
+    # Freeform panel with an instruction the LLM cannot map to anything.
+    markdown = (
+        "---\n"
+        f"uuid: {note_uuid}\n"
+        "---\n"
+        "%% AI:Start %%\n"
+        "## AI-instruktion\n"
+        "Please do something that has no canonical action.\n"
+        "%% AI:End %%\n"
+    )
+    note_file = _vault_note(tmp_path, note_uuid, markdown)
+    outbox_path = tmp_path / "outbox.jsonl"
+
+    monkeypatch.setenv("PANEL_ACTIONS_PATH", str(settings_path))
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    monkeypatch.setenv("VAULT_ROOT", str(note_file.parent))
+    monkeypatch.setenv("PANEL_AGENT_DECIDER", "llm")
+    monkeypatch.setattr("app.agents.panel_agent.agent.INDEX_OUTBOX_PATH", outbox_path, raising=False)
+    # LLM returns empty selection: nothing fits.
+    monkeypatch.setattr(
+        "app.agents.panel_agent.cognition.get_reasoning_facade",
+        lambda: _StubReasoningFacade({"actions": []}),
+    )
+
+    events = run_panel_intent_for_note(note_uuid, trace_id="trace-980-1", trigger="watcher")
+    assert len(events) == 1
+    result = execute_panel_intent(events[0], outbox_path=outbox_path)
+    assert isinstance(result, PanelRuntimeResult)
+
+    # Visible receipt in the AI status callout.
+    updated = note_file.read_text(encoding="utf-8")
+    assert AI_STATUS_HEADER in updated
+    assert "Inga åtgärder matchade" in updated
+
+    # Bounded event signal for downstream observability.
+    records = _read_outbox(outbox_path)
+    logged = [
+        r for r in records
+        if r.get("event") == "panel.action.logged"
+        and (r.get("payload") or {}).get("reason") == "no_actions_matched"
+    ]
+    assert logged, "expected a panel.action.logged event with reason=no_actions_matched"
+
+
+def test_proposal_generation_writes_receipt_without_execution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC #980-2: a freeform proposal-generation pass for a governance-bearing
+    capability writes a visible proposal receipt line in the AI status callout
+    while NOT executing the governed effect in the same pass (preserves #979).
+    """
+    note_uuid = str(uuid4())
+    settings_path = _settings_file(
+        tmp_path,
+        action_id="promote.evergreen",
+        label="Make this note evergreen",
+        intent_type="promotion",
+        trust_verb="APPLY",
+        downstream_event="review.promote.evergreen",
+    )
+    markdown = (
+        "---\n"
+        f"uuid: {note_uuid}\n"
+        "---\n"
+        "%% AI:Start %%\n"
+        "## AI-instruktion\n"
+        "Make this note evergreen\n"
+        "%% AI:End %%\n"
+    )
+    note_file = _vault_note(tmp_path, note_uuid, markdown)
+    outbox_path = tmp_path / "outbox.jsonl"
+
+    monkeypatch.setenv("PANEL_ACTIONS_PATH", str(settings_path))
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    monkeypatch.setenv("VAULT_ROOT", str(note_file.parent))
+    monkeypatch.setenv("PANEL_AGENT_DECIDER", "llm")
+    monkeypatch.setattr("app.agents.panel_agent.agent.INDEX_OUTBOX_PATH", outbox_path, raising=False)
+    monkeypatch.setattr(
+        "app.agents.panel_agent.cognition.get_reasoning_facade",
+        lambda: _StubReasoningFacade({"actions": [{"id": "promote.evergreen"}]}),
+    )
+
+    events = run_panel_intent_for_note(note_uuid, trace_id="trace-980-2", trigger="watcher")
+    execute_panel_intent(events[0], outbox_path=outbox_path)
+
+    updated = note_file.read_text(encoding="utf-8")
+    # Visible proposal receipt line.
+    assert AI_STATUS_HEADER in updated
+    assert "Förslag: Make this note evergreen" in updated
+    assert "väntar bekräftelse" in updated
+
+    # No governance-bearing execution event fires from a proposal-only pass.
+    records = _read_outbox(outbox_path)
+    topics = {r.get("event") for r in records}
+    assert "promote.intent.created" not in topics
+    # Proposal_offered event IS emitted.
+    proposal_offered = [
+        r for r in records
+        if r.get("event") == "panel.action.logged"
+        and (r.get("payload") or {}).get("reason") == "proposal_offered"
+    ]
+    assert proposal_offered
+
+
+def test_fallback_and_no_match_are_visible(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC #980-3: a checked action that has no canonical mapping surfaces a
+    bounded fallback receipt in the AI status callout (visible diagnostic for
+    'AI status or AI-log fallback/no-match outcomes').
+    """
+    note_uuid = str(uuid4())
+    settings_path = _settings_file(
+        tmp_path,
+        action_id="promote.evergreen",
+        label="Make this note evergreen",
+        intent_type="promotion",
+        trust_verb="APPLY",
+        downstream_event="review.promote.evergreen",
+    )
+    # Checkbox labelled with a string that does NOT match the catalog label, so
+    # the action falls into the unmapped_action bucket and produces a logged
+    # outcome the human should see.
+    markdown = (
+        "---\n"
+        f"uuid: {note_uuid}\n"
+        "---\n"
+        "%% AI:Start %%\n"
+        "## AI-instruktion\n"
+        "Do something\n"
+        "## AI-åtgärder\n"
+        "- [x] Some unmapped freeform request\n"
+        "%% AI:End %%\n"
+    )
+    note_file = _vault_note(tmp_path, note_uuid, markdown)
+    outbox_path = tmp_path / "outbox.jsonl"
+
+    monkeypatch.setenv("PANEL_ACTIONS_PATH", str(settings_path))
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    monkeypatch.setenv("VAULT_ROOT", str(note_file.parent))
+    monkeypatch.setattr("app.agents.panel_agent.agent.INDEX_OUTBOX_PATH", outbox_path, raising=False)
+
+    events = run_panel_intent_for_note(note_uuid, trace_id="trace-980-3", trigger="watcher")
+    execute_panel_intent(events[0], outbox_path=outbox_path)
+
+    updated = note_file.read_text(encoding="utf-8")
+    assert AI_STATUS_HEADER in updated
+    # The unmapped action surfaces as a visible warning receipt with a reason.
+    assert "Some unmapped freeform request" in updated
+    assert "unmapped_action" in updated
+
+
+def test_receipts_remain_bounded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC #980-4: receipt block stays bounded — total receipts in AI status
+    callout never exceed MAX_RECEIPTS, even after many runs.
+    """
+    note_uuid = str(uuid4())
+    settings_path = _settings_file(
+        tmp_path,
+        action_id="promote.evergreen",
+        label="Make this note evergreen",
+        intent_type="promotion",
+        trust_verb="APPLY",
+        downstream_event="review.promote.evergreen",
+    )
+    # Seed an AI status callout that already has MAX_RECEIPTS + 5 lines.
+    receipts_block = "\n".join(
+        f"> - ✅ historic-{i} (2026-01-01 00:00)" for i in range(MAX_RECEIPTS + 5)
+    )
+    markdown = (
+        "---\n"
+        f"uuid: {note_uuid}\n"
+        "---\n"
+        "%% AI:Start %%\n"
+        "## AI-instruktion\n"
+        "Please do something that has no canonical action.\n"
+        "%% AI:End %%\n"
+        f"{AI_STATUS_HEADER}\n"
+        f"{receipts_block}\n"
+    )
+    note_file = _vault_note(tmp_path, note_uuid, markdown)
+    outbox_path = tmp_path / "outbox.jsonl"
+
+    monkeypatch.setenv("PANEL_ACTIONS_PATH", str(settings_path))
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    monkeypatch.setenv("VAULT_ROOT", str(note_file.parent))
+    monkeypatch.setenv("PANEL_AGENT_DECIDER", "llm")
+    monkeypatch.setattr("app.agents.panel_agent.agent.INDEX_OUTBOX_PATH", outbox_path, raising=False)
+    monkeypatch.setattr(
+        "app.agents.panel_agent.cognition.get_reasoning_facade",
+        lambda: _StubReasoningFacade({"actions": []}),
+    )
+
+    events = run_panel_intent_for_note(note_uuid, trace_id="trace-980-4", trigger="watcher")
+    execute_panel_intent(events[0], outbox_path=outbox_path)
+
+    updated = note_file.read_text(encoding="utf-8")
+    # Count receipt lines (lines starting with `> - ` inside the AI status block).
+    receipt_lines = [ln for ln in updated.splitlines() if ln.startswith("> - ")]
+    assert len(receipt_lines) <= MAX_RECEIPTS, (
+        f"AI status callout exceeded MAX_RECEIPTS={MAX_RECEIPTS}: {len(receipt_lines)} lines"
+    )


### PR DESCRIPTION
## Summary

Implements #980 (parent #978): make PanelAgent runtime decisions humanly visible without changing mutation authority. Builds on #979's proposal-vs-execution boundary.

Adds three bounded receipt classes to the in-note AI status callout (`> [!info]- AI status`), each also emitted as a `panel.action.logged` event with the matching `reason`:

- **proposal**: `💡 Förslag: <label> (väntar bekräftelse, <ts>)` — only inserted when the proposal is newly written this pass (idempotent on rerun)
- **fallback**: `⚠️ <label> (<reason>, <ts>)` — checked-but-unmapped, ambiguous, watcher-not-allowed, trust-verb-missing
- **no-match**: `ℹ️ Inga åtgärder matchade (<ts>)` — freeform LLM pass produced no actionable selection (gated to skip converged reruns and rule-mode passthroughs)

Existing executed (`✅`) and queued (`⏳`) receipts plus the #979 governance boundary are preserved unchanged.

## AC mapping

- AC1 freeform no-match writes visible receipt → `tests/agents/panel_agent/test_panel_receipts.py::test_freeform_no_match_writes_visible_receipt`
- AC2 proposal-generation writes receipt without execution → `::test_proposal_generation_writes_receipt_without_execution`
- AC3 fallback/no-match visible in AI status → `::test_fallback_and_no_match_are_visible`
- AC4 receipts remain bounded (MAX_RECEIPTS=20 trim) → `::test_receipts_remain_bounded`
- AC5 existing execution receipts preserved → `tests/agents/panel_agent/test_panel_execution.py::test_checked_action_receipts_preserved`

## Surfaces

- `app/agents/panel_agent/graph.py` — emit `panel.action.logged` reason=`no_actions_matched` when the pass produced no executed/logged/proposed outcome (gated by cognition_decision_made + converged_rerun flags)
- `app/agents/panel_agent/runtime.py` — extend writeback to emit visible proposal / fallback / no-match receipt lines; new `_existing_panel_proposal_labels` helper keeps proposal receipts idempotent on rerun
- `app/agents/panel_agent/state.py` — `converged_rerun` and `cognition_decision_made` flags
- `docs/PANEL_AGENT.md` — owner doc receipt-class taxonomy and example updated

## Test plan

- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/agents/panel_agent/test_panel_receipts.py` (4 tests)
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/agents/panel_agent/test_panel_execution.py` (2 tests, includes preservation AC)
- [x] Full `tests/agents/` suite (400 passed, 8 skipped — no regressions)
- [ ] manual vault UAT with empty `AI-åtgärder`, unmapped freeform, successful proposal, checked execution

Closes #980

🤖 Generated with [Claude Code](https://claude.com/claude-code)