### PR TITLE
feat(panel-agent): add LLM route and fallback observability (#984)

### DIFF
--- a/app/agents/panel_agent/cognition.py
+++ b/app/agents/panel_agent/cognition.py
@@ -206,6 +206,42 @@ def _select_actions_from_instruction_hint(
     return {action.id}, {action.id: "instruction_hint_fallback"}
 
 
+def _record_cognition_metadata(state: PanelAgentState, **fields: Any) -> None:
+    """Merge bounded cognition-route observability fields onto state.
+
+    Only known scalar/bounded fields are stored. Callers must never pass prompt
+    bodies, raw LLM output, or secret material. See docs/PANEL_AGENT.md for the
+    canonical key set (#984).
+    """
+    meta = dict(state.cognition_metadata or {})
+    for key, value in fields.items():
+        # Allow explicit None to clear a key only when caller passes it as
+        # `fallback_reason=None`; otherwise treat None as "no update".
+        if value is None and key not in {"fallback_reason", "provider", "model"}:
+            continue
+        meta[key] = value
+    state.cognition_metadata = meta
+
+
+def _facade_route_info(facade: Any) -> tuple[str | None, str | None]:
+    """Pull provider/model from the most recent telemetry record on the facade.
+
+    Returns ``(provider, model)``. Either may be ``None`` when telemetry is
+    unavailable (e.g. router resolution failed before a record was written).
+    """
+    try:
+        records = getattr(facade, "telemetry", None) or []
+        if not records:
+            return None, None
+        last = records[-1]
+        return (
+            getattr(last, "provider", None) or None,
+            getattr(last, "model", None) or None,
+        )
+    except Exception:  # noqa: BLE001
+        return None, None
+
+
 def _select_actions_from_catalog(
     state: PanelAgentState,
     catalog: PanelActionCatalog,
@@ -219,6 +255,16 @@ def _select_actions_from_catalog(
     """
     available = catalog.actions
     if not available:
+        _record_cognition_metadata(
+            state,
+            cognition_mode="llm",
+            route="freeform",
+            fallback_used=True,
+            fallback_reason="no_catalog_available",
+            proposal_candidate_count=0,
+            proposal_accepted_count=0,
+            proposal_rejected_count=0,
+        )
         return set(), {}
 
     action_lines = []
@@ -251,8 +297,8 @@ def _select_actions_from_catalog(
     ]
 
     valid_ids = {d.id for d in available}
+    facade = get_reasoning_facade()
     try:
-        facade = get_reasoning_facade()
         parsed = facade.structured(
             messages,
             schema=_PANEL_DECIDER_SCHEMA,
@@ -269,6 +315,7 @@ def _select_actions_from_catalog(
 
         selected: set[str] = set()
         reasons: dict[str, str] = {}
+        rejected = 0
         for item in candidates:
             action_id: str | None = None
             reason: str | None = None
@@ -278,16 +325,45 @@ def _select_actions_from_catalog(
                 action_id = item.get("id") or item.get("action_id")
                 reason = item.get("reason") or item.get("why")
             if not action_id:
+                rejected += 1
                 continue
             action_id = str(action_id).strip()
             if action_id not in valid_ids:
                 logger.debug("Freeform proposal %r rejected: not in active catalog", action_id)
+                rejected += 1
                 continue
             selected.add(action_id)
             if reason:
                 reasons[action_id] = reason
+        provider, model = _facade_route_info(facade)
+        _record_cognition_metadata(
+            state,
+            cognition_mode="llm",
+            route="freeform",
+            provider=provider,
+            model=model,
+            fallback_used=False,
+            fallback_reason=None,
+            proposal_candidate_count=len(candidates),
+            proposal_accepted_count=len(selected),
+            proposal_rejected_count=rejected,
+            no_match=(len(selected) == 0),
+        )
         return selected, reasons
-    except Exception:
+    except Exception as exc:  # noqa: BLE001
+        provider, model = _facade_route_info(facade)
+        _record_cognition_metadata(
+            state,
+            cognition_mode="llm",
+            route="freeform",
+            provider=provider,
+            model=model,
+            fallback_used=True,
+            fallback_reason=f"llm_error:{type(exc).__name__}",
+            proposal_candidate_count=0,
+            proposal_accepted_count=0,
+            proposal_rejected_count=0,
+        )
         return None
 
 
@@ -349,8 +425,8 @@ def _run_llm_selection(state: PanelAgentState) -> tuple[set[str], dict[str, str]
         {"role": "system", "content": system},
         {"role": "user", "content": "\n".join(user_parts)},
     ]
+    facade = get_reasoning_facade()
     try:
-        facade = get_reasoning_facade()
         parsed = facade.structured(
             messages,
             schema=_PANEL_DECIDER_SCHEMA,
@@ -365,8 +441,11 @@ def _run_llm_selection(state: PanelAgentState) -> tuple[set[str], dict[str, str]
         selected: set[str] = set()
         reasons: dict[str, str] = {}
         valid_ids = {a.id for a in actions}
+        candidate_total = 0
+        rejected = 0
 
         if isinstance(candidates, list):
+            candidate_total = len(candidates)
             for item in candidates:
                 action_id: str | None = None
                 reason: str | None = None
@@ -376,13 +455,16 @@ def _run_llm_selection(state: PanelAgentState) -> tuple[set[str], dict[str, str]
                     action_id = item.get("id") or item.get("action_id")
                     reason = item.get("reason") or item.get("why")
                 if not action_id:
+                    rejected += 1
                     continue
                 action_id = str(action_id).strip()
                 if action_id not in valid_ids:
+                    rejected += 1
                     continue
                 selected.add(action_id)
                 if reason:
                     reasons[action_id] = reason
+        provider, model = _facade_route_info(facade)
         if not selected:
             hinted = _select_actions_from_instruction_hint(
                 actions=actions,
@@ -390,10 +472,49 @@ def _run_llm_selection(state: PanelAgentState) -> tuple[set[str], dict[str, str]
                 instruction=state.panel.instruction or "",
             )
             if hinted is not None:
+                _record_cognition_metadata(
+                    state,
+                    cognition_mode="llm",
+                    route="checkbox",
+                    provider=provider,
+                    model=model,
+                    fallback_used=True,
+                    fallback_reason="instruction_hint_fallback",
+                    proposal_candidate_count=candidate_total,
+                    proposal_accepted_count=len(hinted[0]),
+                    proposal_rejected_count=rejected,
+                    no_match=False,
+                )
                 return hinted
+        _record_cognition_metadata(
+            state,
+            cognition_mode="llm",
+            route="checkbox",
+            provider=provider,
+            model=model,
+            fallback_used=False,
+            fallback_reason=None,
+            proposal_candidate_count=candidate_total,
+            proposal_accepted_count=len(selected),
+            proposal_rejected_count=rejected,
+            no_match=(len(selected) == 0),
+        )
         # Empty set is a valid decision (LLM chose to run nothing).
         return selected, reasons
-    except Exception:
+    except Exception as exc:  # noqa: BLE001
+        provider, model = _facade_route_info(facade)
+        _record_cognition_metadata(
+            state,
+            cognition_mode="llm",
+            route="checkbox",
+            provider=provider,
+            model=model,
+            fallback_used=True,
+            fallback_reason=f"llm_error:{type(exc).__name__}",
+            proposal_candidate_count=0,
+            proposal_accepted_count=0,
+            proposal_rejected_count=0,
+        )
         return None
 
 
@@ -412,6 +533,15 @@ class RuleCognitionBackend:
     def select_actions(
         self, state: PanelAgentState
     ) -> tuple[set[str], dict[str, str]] | None:
+        _record_cognition_metadata(
+            state,
+            cognition_mode="rule",
+            route="rule",
+            provider=None,
+            model=None,
+            fallback_used=False,
+            fallback_reason=None,
+        )
         return None
 
 

--- a/app/agents/panel_agent/graph.py
+++ b/app/agents/panel_agent/graph.py
@@ -184,7 +184,13 @@ def _action_triggered_event(intent_event: PanelIntentEvent, action: PanelIntentA
     )
 
 
-def _logged_event(intent_event: PanelIntentEvent, action: PanelIntentAction, reason: str) -> PanelActionLoggedEvent:
+def _logged_event(
+    intent_event: PanelIntentEvent,
+    action: PanelIntentAction,
+    reason: str,
+    *,
+    cognition_metadata: dict[str, Any] | None = None,
+) -> PanelActionLoggedEvent:
     payload = {
         "note": intent_event.payload.note.model_dump(mode="json"),
         "panel_id": intent_event.payload.panel.panel_id,
@@ -193,6 +199,10 @@ def _logged_event(intent_event: PanelIntentEvent, action: PanelIntentAction, rea
     }
     if action.mapping:
         payload["mapping"] = action.mapping.model_dump(mode="json")
+    if cognition_metadata:
+        # #984 attach bounded cognition-route observability so receipts surface
+        # provider/model/fallback alongside the reason code.
+        payload["cognition_metadata"] = dict(cognition_metadata)
     return PanelActionLoggedEvent(trace_id=intent_event.trace_id, source=_build_panel_source(), payload=payload)
 
 
@@ -208,6 +218,7 @@ def _handle_action(
     if override_checked is not None:
         action_to_use = action.model_copy(update={"checked": override_checked})
 
+    cognition_metadata = state.cognition_metadata or None
     emitted: list[Any] = []
     emitted_names: list[str] = []
     if not action_to_use.checked:
@@ -217,7 +228,12 @@ def _handle_action(
         # for human confirmation without executing.
         if reason == "proposal_offered":
             assert state.intent_event is not None
-            logged = _logged_event(state.intent_event, action_to_use, "proposal_offered")
+            logged = _logged_event(
+                state.intent_event,
+                action_to_use,
+                "proposal_offered",
+                cognition_metadata=cognition_metadata,
+            )
             emitted.append(logged)
             return _build_action_result(
                 action_to_use,
@@ -253,7 +269,12 @@ def _handle_action(
         "trust_verb_invalid",
         "admission_required",
     }:
-        logged = _logged_event(intent_event, action_to_use, resolution_reason)
+        logged = _logged_event(
+            intent_event,
+            action_to_use,
+            resolution_reason,
+            cognition_metadata=cognition_metadata,
+        )
         emitted.append(logged)
         emitted_names.append(logged.event)
         _IDEMPOTENCY_GUARD.mark_action(note_id, action_to_use.id)
@@ -277,7 +298,12 @@ def _handle_action(
         return _build_action_result(action_to_use, status="triggered", emitted=emitted_names), emitted
 
     logged_reason = reason or "unhandled_action"
-    logged = _logged_event(intent_event, action_to_use, logged_reason)
+    logged = _logged_event(
+        intent_event,
+        action_to_use,
+        logged_reason,
+        cognition_metadata=cognition_metadata,
+    )
     emitted.append(logged)
     emitted_names.append(logged.event)
     _IDEMPOTENCY_GUARD.mark_action(note_id, action_to_use.id)
@@ -423,16 +449,19 @@ def _apply_actions(state: PanelAgentState, *, selected_ids: set[str] | None, rea
             instruction = (intent_event.payload.panel.instruction or "").strip()
         except Exception:
             instruction = ""
+        no_match_payload: dict[str, Any] = {
+            "note": intent_event.payload.note.model_dump(mode="json"),
+            "panel_id": intent_event.payload.panel.panel_id,
+            "action": None,
+            "reason": "no_actions_matched",
+            "instruction": instruction,
+        }
+        if state.cognition_metadata:
+            no_match_payload["cognition_metadata"] = dict(state.cognition_metadata)
         no_match_event = PanelActionLoggedEvent(
             trace_id=intent_event.trace_id,
             source=_build_panel_source(),
-            payload={
-                "note": intent_event.payload.note.model_dump(mode="json"),
-                "panel_id": intent_event.payload.panel.panel_id,
-                "action": None,
-                "reason": "no_actions_matched",
-                "instruction": instruction,
-            },
+            payload=no_match_payload,
         )
         emitted.append(no_match_event)
 
@@ -460,6 +489,7 @@ def _decide_actions_with_backend(state: PanelAgentState, backend: PanelCognition
 def _emit_events(state: PanelAgentState) -> PanelAgentState:
     assert state.intent_event is not None, "PanelAgentState must include intent_event"
     cognition_mode: str | None = state.decider_mode
+    cognition_metadata = dict(state.cognition_metadata or {})
     executed_event = PanelIntentExecutedEvent(
         trace_id=state.intent_event.trace_id,
         source=_build_panel_source(),
@@ -469,6 +499,7 @@ def _emit_events(state: PanelAgentState) -> PanelAgentState:
             actions=state.action_results,
             executed_action_ids=list(state.executed_action_ids or []),
             cognition_mode=cognition_mode,
+            cognition_metadata=cognition_metadata,
         ),
     )
 
@@ -479,6 +510,7 @@ def _emit_events(state: PanelAgentState) -> PanelAgentState:
         summary=_build_summary(state.action_results),
         actions=state.action_results,
         cognition_mode=cognition_mode,
+        cognition_metadata=cognition_metadata,
     )
     log_event = PanelLogEvent(trace_id=state.intent_event.trace_id, source=_build_panel_source(), payload=log_entry)
 

--- a/app/agents/panel_agent/state.py
+++ b/app/agents/panel_agent/state.py
@@ -47,6 +47,11 @@ class PanelAgentState(BaseModel):
     # decision (including empty). Distinguishes freeform LLM no-match (decision
     # was made: nothing fits) from rule-mode pass-through (no decision invoked).
     cognition_decision_made: bool = False
+    # Bounded LLM-route / fallback observability surfaced by the cognition seam (#984).
+    # Populated by LLMCognitionBackend so emit_events can attach provider/model,
+    # fallback path, and proposal accept/reject counts to outbound events. Keys are
+    # intentionally bounded and free of prompt bodies or secrets.
+    cognition_metadata: dict[str, Any] = Field(default_factory=dict)
     vault_root: Path | None = None
 
     # Runtime-populated fields

--- a/app/events/panel.py
+++ b/app/events/panel.py
@@ -83,6 +83,12 @@ class PanelIntentExecutedPayload(BaseModel):
     actions: list[PanelRuntimeActionResult] = Field(default_factory=list)
     executed_action_ids: list[str] = Field(default_factory=list)
     cognition_mode: str | None = None
+    # #984 bounded cognition-route observability. Optional dict of bounded scalar
+    # fields (provider, model, route, fallback_used, fallback_reason,
+    # proposal_candidate_count, proposal_accepted_count,
+    # proposal_rejected_count, no_match). Must not contain prompt bodies or
+    # secrets. See docs/PANEL_AGENT.md and docs/EVENTS.md.
+    cognition_metadata: Dict[str, Any] = Field(default_factory=dict)
 
 
 class PanelIntentExecutedEvent(BaseModel):
@@ -117,6 +123,9 @@ class PanelLogEntry(BaseModel):
     summary: str
     actions: list[PanelRuntimeActionResult] = Field(default_factory=list)
     cognition_mode: str | None = None
+    # #984 bounded cognition-route observability mirror of
+    # PanelIntentExecutedPayload.cognition_metadata.
+    cognition_metadata: Dict[str, Any] = Field(default_factory=dict)
 
 
 class PanelLogEvent(BaseModel):

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -190,6 +190,26 @@ Payload highlights:
 - `note`, `panel`
 - `actions[]`: `id`, `label`, `checked`, `status` (e.g. triggered/logged/skipped), optional `intent_type`, `emitted_events[]`
 - `executed_action_ids[]`: stable `ai:id` values recorded for idempotency
+- `cognition_mode`: `"rule"` or `"llm"` — top-level mirror of the cognition route used this pass.
+- `cognition_metadata`: bounded LLM-route observability (see below). Same shape is mirrored on `panel.log.created` and on `panel.action.logged` receipts.
+
+<!-- panel-agent-cognition-observability-metadata -->
+#### PanelAgent cognition observability metadata
+
+Bounded, scalar-only dictionary used to surface the LLM cognition route and fallback path. It is attached to:
+- `panel.intent.executed` (`payload.cognition_metadata`)
+- `panel.log.created` (`payload.cognition_metadata`)
+- `panel.action.logged` receipts with `reason` in {`proposal_offered`, `no_actions_matched`, and other receipt reasons emitted via the runtime path}
+
+Fields (all optional, defaults are empty dict / null):
+- `cognition_mode` — `"rule"` or `"llm"`.
+- `route` — `"rule"`, `"checkbox"`, or `"freeform"`.
+- `provider` / `model` — provider and model identifier from the most recent `ReasoningFacade` telemetry record. `null` when the route did not invoke the facade.
+- `fallback_used` (bool), `fallback_reason` (string or `null`) — one of `instruction_hint_fallback`, `llm_error:<ExcType>`, `no_catalog_available`.
+- `proposal_candidate_count`, `proposal_accepted_count`, `proposal_rejected_count` — bounded counts of raw LLM-returned candidates and how many mapped to canonical catalog IDs.
+- `no_match` (bool) — `true` when the cognition decision produced zero accepted catalog actions; drives the `no_actions_matched` receipt.
+
+Backward compatibility: existing consumers that only read `cognition_mode` continue to work. The metadata dictionary is additive and intentionally bounded — it must not carry prompt bodies, raw LLM output, or secret material. See `docs/PANEL_AGENT.md` for the producer-side contract (#984).
 
 ### `promote.intent.created`
 

--- a/docs/PANEL_AGENT.md
+++ b/docs/PANEL_AGENT.md
@@ -50,6 +50,15 @@ Other implementation notes:
 - PanelAgent Runtime V1 remains the baseline until the PanelAgent 2.0 path is fully implemented and operationally accepted. The real-vault acceptance receipt for #240 now closes that line for the shipped v5.6 path.
 - LangGraph control flow supports a decider mode (`PANEL_AGENT_DECIDER=rule|llm`); `llm` is the default runtime posture for LLM-backed intent interpretation, while `rule` is an explicit opt-out for unit tests, CI, and other bounded deterministic validation lanes. Both modes route through the shared `ReasoningFacade` with the canonical `decide` task kind.
 - The executed `cognition_mode` is included in the `panel.intent.executed` event payload and in `panel.log.created` entries so external consumers can observe which interpretation path was used.
+- <!-- panel-agent-cognition-observability --> Bounded LLM-route observability (`cognition_metadata`) accompanies `cognition_mode` on `panel.intent.executed` and `panel.log.created`, and is mirrored onto the `panel.action.logged` receipts (`proposal_offered`, `no_actions_matched`) so runtime decisions stay debuggable. The metadata dictionary is bounded to scalar fields only and intentionally excludes prompt bodies, raw LLM output, and any secret material:
+  - `cognition_mode` — `"rule"` or `"llm"`, mirrors the top-level field.
+  - `route` — `"rule"`, `"checkbox"`, or `"freeform"`; identifies which selection pathway ran.
+  - `provider` / `model` — taken from the most recent `ReasoningFacade` telemetry record for the call; `null` when the route did not invoke the facade.
+  - `fallback_used` (bool) and `fallback_reason` (string or `null`) — `fallback_reason` is one of `instruction_hint_fallback`, `llm_error:<ExcType>`, or `no_catalog_available`.
+  - `proposal_candidate_count` — raw count of action entries returned by the LLM.
+  - `proposal_accepted_count` — count that mapped to canonical catalog IDs.
+  - `proposal_rejected_count` — count dropped because they were missing/blank IDs or out of catalog.
+  - `no_match` (bool) — `true` when the cognition decision produced zero accepted catalog actions (drives the `no_actions_matched` receipt).
 - LLM-driven contract tests live under `tests/e2e/test_panel_llm_e2e.py` (gated by `@pytest.mark.panel_llm_e2e` and `PANEL_AGENT_LLM_E2E=1`) to validate end-to-end promotion/non-promotion scenarios (including the freeform no-checkbox path) using the real decider. Tests requiring deterministic rule-mode behavior explicitly set `PANEL_AGENT_DECIDER=rule`.
 - Any future PanelAgent expansion beyond the current shipped slices should be decomposed via the issue/track flow first so the remaining work stays bounded and reviewable.
 

--- a/tests/agents/panel_agent/test_panel_cognition_observability.py
+++ b/tests/agents/panel_agent/test_panel_cognition_observability.py
@@ -1,0 +1,292 @@
+"""Issue #984: PanelAgent LLM route and fallback observability.
+
+These tests exercise the real PanelAgent LangGraph to confirm that the
+cognition seam emits bounded route/provider/fallback metadata on:
+
+- ``panel.intent.executed`` (via ``PanelIntentExecutedPayload.cognition_metadata``)
+- ``panel.log.created`` (via ``PanelLogEntry.cognition_metadata``)
+- ``panel.action.logged`` receipts (``proposal_offered``, ``no_actions_matched``)
+
+Metadata fields covered:
+
+- ``cognition_mode`` — ``"rule" | "llm"``
+- ``route`` — ``"rule" | "checkbox" | "freeform"``
+- ``provider`` / ``model`` — taken from the reasoning facade's telemetry
+- ``fallback_used`` / ``fallback_reason``
+- ``proposal_candidate_count`` / ``proposal_accepted_count`` /
+  ``proposal_rejected_count``
+- ``no_match``
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from app.agents.panel_agent.graph import run_panel_graph
+from app.agents.panel_agent.state import PanelAgentState
+from app.components.concurrency import IdempotencyGuard
+from app.components.settings.panel_actions_loader import (
+    PanelActionCatalog,
+    PanelActionDescriptor,
+)
+from app.events.panel import (
+    NoteRef,
+    PanelActionLoggedEvent,
+    PanelInfo,
+    PanelIntentEvent,
+    PanelIntentExecutedEvent,
+    PanelIntentPayload,
+    PanelLogEvent,
+)
+
+TEST_NOTE_UUID = "panel-obs-00000000-0000-4000-8000-000000000001"
+TEST_NOTE_PATH = "vault/Observability.md"
+
+
+@pytest.fixture(autouse=True)
+def _avoid_wiring_io(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.agents.panel_agent.graph.get_default_action_wiring", lambda: {}
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_idempotency_guard(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.agents.panel_agent.graph._IDEMPOTENCY_GUARD",
+        IdempotencyGuard(ttl_seconds=86400.0),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stub reasoning facade with telemetry shape used by `_facade_route_info`.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _TelemetryRecord:
+    provider: str
+    model: str
+
+
+class _StubReasoningFacade:
+    """Reasoning facade stub that mimics provider/model telemetry."""
+
+    def __init__(
+        self,
+        response: object,
+        *,
+        provider: str = "anthropic",
+        model: str = "claude-stub",
+        raise_exc: Exception | None = None,
+    ) -> None:
+        self._response = response
+        self._provider = provider
+        self._model = model
+        self._raise = raise_exc
+        self.telemetry: list[_TelemetryRecord] = []
+
+    def structured(self, messages, schema, *, task_kind: str, trace_id: str | None = None):
+        # Telemetry is appended in the real facade's `finally` block — emulate
+        # the same contract here (record happens whether or not we raise).
+        self.telemetry.append(_TelemetryRecord(provider=self._provider, model=self._model))
+        if self._raise is not None:
+            raise self._raise
+        return self._response
+
+
+def _catalog() -> PanelActionCatalog:
+    return PanelActionCatalog.from_descriptors(
+        [
+            PanelActionDescriptor(
+                id="promote.evergreen",
+                intent_type="promotion",
+                trust_verb="APPLY",
+                downstream_event="review.promote.evergreen",
+                labels=["Make this note evergreen"],
+                description="Promote note to evergreen",
+                llm_hint="Use for promotion to evergreen.",
+                params={"maturity": "evergreen"},
+            )
+        ]
+    )
+
+
+def _freeform_state(instruction: str = "Make this note evergreen.") -> PanelAgentState:
+    note = NoteRef(uuid=TEST_NOTE_UUID, path=TEST_NOTE_PATH, origin="vault")
+    panel = PanelInfo(panel_id="p1", instruction=instruction, raw_block=None)
+    payload = PanelIntentPayload(note=note, panel=panel, actions=[])
+    intent = PanelIntentEvent(payload=payload, trace_id="trace-#984")
+    return PanelAgentState(
+        trace_id=intent.trace_id,
+        note=note,
+        panel=panel,
+        actions=[],
+        intent_event=intent,
+        action_catalog=_catalog(),
+    )
+
+
+def _executed_payload(events: list[object]):
+    for evt in events:
+        if isinstance(evt, PanelIntentExecutedEvent):
+            return evt.payload
+    raise AssertionError("PanelIntentExecutedEvent not found in emitted events")
+
+
+def _log_entry(events: list[object]):
+    for evt in events:
+        if isinstance(evt, PanelLogEvent):
+            return evt.payload
+    raise AssertionError("PanelLogEvent not found in emitted events")
+
+
+def _logged_events_by_reason(events: list[object], reason: str) -> list[PanelActionLoggedEvent]:
+    return [
+        evt
+        for evt in events
+        if isinstance(evt, PanelActionLoggedEvent)
+        and (evt.payload or {}).get("reason") == reason
+    ]
+
+
+# ---------------------------------------------------------------------------
+# AC 1: cognition_mode metadata emitted on executed event and log entry.
+# ---------------------------------------------------------------------------
+
+
+def test_cognition_mode_metadata_emitted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """LLM route stamps cognition_mode='llm' and route='freeform' onto the executed payload."""
+    state = _freeform_state()
+    facade = _StubReasoningFacade({"actions": [{"id": "promote.evergreen"}]})
+    monkeypatch.setattr(
+        "app.agents.panel_agent.cognition.get_reasoning_facade", lambda: facade
+    )
+
+    result = run_panel_graph(state, decider_mode="llm")
+
+    executed = _executed_payload(result.emitted_events)
+    assert executed.cognition_mode == "llm"
+    assert executed.cognition_metadata["cognition_mode"] == "llm"
+    assert executed.cognition_metadata["route"] == "freeform"
+
+    log_entry = _log_entry(result.emitted_events)
+    assert log_entry.cognition_metadata["cognition_mode"] == "llm"
+
+    # Rule mode: same fields populated with rule values.
+    state2 = _freeform_state()
+    result2 = run_panel_graph(state2, decider_mode="rule")
+    executed2 = _executed_payload(result2.emitted_events)
+    assert executed2.cognition_metadata.get("cognition_mode") == "rule"
+    assert executed2.cognition_metadata.get("route") == "rule"
+
+
+# ---------------------------------------------------------------------------
+# AC 2: provider/model metadata for freeform proposal paths.
+# ---------------------------------------------------------------------------
+
+
+def test_provider_and_model_metadata_emitted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provider/model from the reasoning facade telemetry surface on the executed payload."""
+    state = _freeform_state()
+    facade = _StubReasoningFacade(
+        {"actions": [{"id": "promote.evergreen"}]},
+        provider="anthropic",
+        model="claude-sonnet-test",
+    )
+    monkeypatch.setattr(
+        "app.agents.panel_agent.cognition.get_reasoning_facade", lambda: facade
+    )
+
+    result = run_panel_graph(state, decider_mode="llm")
+
+    executed = _executed_payload(result.emitted_events)
+    assert executed.cognition_metadata["provider"] == "anthropic"
+    assert executed.cognition_metadata["model"] == "claude-sonnet-test"
+
+    # proposal_offered receipt carries the same provider/model so receipt
+    # consumers can correlate proposal surfacing with the cognition route.
+    offered = _logged_events_by_reason(result.emitted_events, "proposal_offered")
+    assert offered, "expected a proposal_offered receipt for the governance-bearing proposal"
+    meta = offered[0].payload.get("cognition_metadata") or {}
+    assert meta.get("provider") == "anthropic"
+    assert meta.get("model") == "claude-sonnet-test"
+
+
+# ---------------------------------------------------------------------------
+# AC 3: fallback / no-match metadata.
+# ---------------------------------------------------------------------------
+
+
+def test_fallback_and_no_match_metadata_emitted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """LLM error -> rule fallback surfaces fallback_used/fallback_reason; empty LLM result -> no_match."""
+    # (a) LLM raises -> fallback_used=True, fallback_reason starts with "llm_error:".
+    state_err = _freeform_state()
+    facade_err = _StubReasoningFacade(
+        response={},
+        provider="anthropic",
+        model="claude-sonnet-test",
+        raise_exc=RuntimeError("simulated provider outage"),
+    )
+    monkeypatch.setattr(
+        "app.agents.panel_agent.cognition.get_reasoning_facade", lambda: facade_err
+    )
+    result_err = run_panel_graph(state_err, decider_mode="llm")
+    executed_err = _executed_payload(result_err.emitted_events)
+    assert executed_err.cognition_metadata["fallback_used"] is True
+    assert executed_err.cognition_metadata["fallback_reason"].startswith("llm_error:")
+    assert executed_err.cognition_metadata["provider"] == "anthropic"
+
+    # (b) LLM returns no candidates -> no_match True, no_actions_matched receipt
+    #     carries the cognition metadata.
+    state_empty = _freeform_state(instruction="Do something unrelated.")
+    facade_empty = _StubReasoningFacade(
+        response={"actions": []},
+        provider="anthropic",
+        model="claude-sonnet-test",
+    )
+    monkeypatch.setattr(
+        "app.agents.panel_agent.cognition.get_reasoning_facade", lambda: facade_empty
+    )
+    result_empty = run_panel_graph(state_empty, decider_mode="llm")
+    executed_empty = _executed_payload(result_empty.emitted_events)
+    assert executed_empty.cognition_metadata["no_match"] is True
+    assert executed_empty.cognition_metadata["fallback_used"] is False
+
+    no_match = _logged_events_by_reason(result_empty.emitted_events, "no_actions_matched")
+    assert no_match, "expected a no_actions_matched receipt when LLM returned no candidates"
+    meta = no_match[0].payload.get("cognition_metadata") or {}
+    assert meta.get("no_match") is True
+    assert meta.get("route") == "freeform"
+
+
+# ---------------------------------------------------------------------------
+# AC 4: bounded proposal accept/reject counts.
+# ---------------------------------------------------------------------------
+
+
+def test_proposal_acceptance_rejection_metadata_emitted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Out-of-catalog IDs increment the rejected count; in-catalog IDs increment the accepted count."""
+    state = _freeform_state()
+    facade = _StubReasoningFacade(
+        {
+            "actions": [
+                {"id": "promote.evergreen", "reason": "instruction asks for evergreen"},
+                {"id": "not.in.catalog"},
+                {"id": "also.unknown"},
+            ]
+        }
+    )
+    monkeypatch.setattr(
+        "app.agents.panel_agent.cognition.get_reasoning_facade", lambda: facade
+    )
+
+    result = run_panel_graph(state, decider_mode="llm")
+    executed = _executed_payload(result.emitted_events)
+    meta = executed.cognition_metadata
+    assert meta["proposal_candidate_count"] == 3
+    assert meta["proposal_accepted_count"] == 1
+    assert meta["proposal_rejected_count"] == 2
+    assert meta["no_match"] is False


### PR DESCRIPTION
## Summary

- Adds bounded `cognition_metadata` observability through the PanelAgent runtime so the LLM cognition route (rule | llm), provider/model, fallback path, and proposal accept/reject counts become visible on emitted events and receipts.
- Plumbs the metadata into `panel.intent.executed`, `panel.log.created`, and the `panel.action.logged` receipts (including `proposal_offered` and `no_actions_matched`).
- Owner-doc updates in `docs/PANEL_AGENT.md` and `docs/EVENTS.md` pin the bounded scalar field set and backward-compatibility expectations.

Fixes #984.

## AC coverage

All four behavioral ACs map to `tests/agents/panel_agent/test_panel_cognition_observability.py`:

- `test_cognition_mode_metadata_emitted` — cognition mode metadata on executed/log payloads.
- `test_provider_and_model_metadata_emitted` — provider/model from facade telemetry on executed payload and on `proposal_offered` receipts.
- `test_fallback_and_no_match_metadata_emitted` — `fallback_used` / `fallback_reason` on LLM error; `no_match` plus `no_actions_matched` receipt carries metadata.
- `test_proposal_acceptance_rejection_metadata_emitted` — bounded candidate/accepted/rejected counts.

Non-behavioral AC writeback:
- `docs/EVENTS.md :: PanelAgent cognition observability metadata` section added.
- `docs/PANEL_AGENT.md` documents the producer-side bounded field set under the `<!-- panel-agent-cognition-observability -->` anchor.

## Test plan

- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/agents/panel_agent/test_panel_cognition_observability.py` (4 new tests pass)
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/agents/panel_agent/ tests/events/ tests/runtime/` (170 passed, 1 skipped)
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/architecture/` (54 passed)
- [x] `python scripts/docs_guard.py` OK

## Constraints honoured

- No prompt bodies, raw LLM output, or secret material enter event payloads.
- `cognition_metadata` is additive — existing consumers reading only `cognition_mode` continue to work.
- No new external observability dependencies introduced.
- Real graph used in tests (no graph mocking); only the `ReasoningFacade` is stubbed with a telemetry-shaped fake.

Dispatcher unavailable check skipped — used standard `scripts/issue_pickup_claim.sh` GitHub-label claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)