### PR TITLE
fix(panel-agent): suppress repeated no-match receipts on rerun

### DIFF
--- a/app/agents/panel_agent/runtime.py
+++ b/app/agents/panel_agent/runtime.py
@@ -45,6 +45,20 @@ def _has_no_match_marker(text: str, instruction: str) -> bool:
     return _no_match_marker(instruction) in text
 
 
+def _resolve_note_file(note_path_str: str | None, vault_root: Path | None) -> Path | None:
+    """Resolve the vault file path for a note, or return None if unresolvable."""
+    if not note_path_str:
+        return None
+    candidate = Path(note_path_str)
+    if candidate.is_absolute() and candidate.exists():
+        return candidate
+    if vault_root:
+        candidate = vault_root / note_path_str
+        if candidate.exists():
+            return candidate
+    return None
+
+
 def _resolve_outbox_path(path: Path | None = None) -> Path:
     if path is not None:
         return Path(path)
@@ -208,8 +222,16 @@ def execute_panel_intent(
                 )
             )
     # Suppress duplicate no-match events when the instruction is unchanged (#1012).
+    # Use the live file as the source of truth (ObjectStore may lag post-writeback).
     _instruction = intent_event.payload.panel.instruction or ""
-    if _has_no_match_marker(note_text, _instruction):
+    _note_file_for_dedup = _resolve_note_file(intent_event.payload.note.path, vault_root)
+    _dedup_text = note_text
+    if _note_file_for_dedup is not None:
+        try:
+            _dedup_text = _note_file_for_dedup.read_text(encoding="utf-8")
+        except OSError:
+            pass
+    if _has_no_match_marker(_dedup_text, _instruction):
         emitted_events = [
             e for e in emitted_events
             if not (
@@ -430,17 +452,7 @@ def _apply_note_writeback(
     note_uuid = state.note.uuid
     note_path_str = state.note.path
 
-    # Resolve the vault file path for writing.
-    note_file: Path | None = None
-    if note_path_str:
-        candidate = Path(note_path_str)
-        if candidate.is_absolute() and candidate.exists():
-            note_file = candidate
-        elif vault_root:
-            candidate = vault_root / note_path_str
-            if candidate.exists():
-                note_file = candidate
-
+    note_file = _resolve_note_file(note_path_str, vault_root)
     if note_file is None:
         logger.warning(
             "panel writeback skipped (cannot resolve note file) note_uuid=%s note_path=%s",

--- a/app/agents/panel_agent/runtime.py
+++ b/app/agents/panel_agent/runtime.py
@@ -32,6 +32,18 @@ from app.store.object_store import ObjectStore
 
 logger = logging.getLogger(__name__)
 
+# No-match dedup marker (issue #1012). Char class follows #979 pattern: [A-Za-z0-9_.-]+
+_NO_MATCH_MARKER_TPL = "<!--ai:no-match={hash}-->"
+
+
+def _no_match_marker(instruction: str) -> str:
+    h = hashlib.sha256(instruction.encode("utf-8")).hexdigest()[:16]
+    return _NO_MATCH_MARKER_TPL.format(hash=h)
+
+
+def _has_no_match_marker(text: str, instruction: str) -> bool:
+    return _no_match_marker(instruction) in text
+
 
 def _resolve_outbox_path(path: Path | None = None) -> Path:
     if path is not None:
@@ -195,6 +207,17 @@ def execute_panel_intent(
                     source="panel_agent.runtime",
                 )
             )
+    # Suppress duplicate no-match events when the instruction is unchanged (#1012).
+    _instruction = intent_event.payload.panel.instruction or ""
+    if _has_no_match_marker(note_text, _instruction):
+        emitted_events = [
+            e for e in emitted_events
+            if not (
+                getattr(e, "event", None) == "panel.action.logged"
+                and (getattr(e, "payload", {}) or {}).get("reason") == "no_actions_matched"
+            )
+        ]
+
     _write_db_outbox_events(emitted_events)
     for event in emitted_events:
         append_jsonl_outbox_event(resolved_outbox, event, default_source="panel_agent.runtime")
@@ -433,6 +456,27 @@ def _apply_note_writeback(
         logger.warning("panel writeback skipped (cannot read note) note_path=%s", note_file)
         return
 
+    # Suppress duplicate no-match receipt when instruction is unchanged (#1012).
+    _instruction = state.panel.instruction or ""
+    if no_match_visible and _has_no_match_marker(current_text, _instruction):
+        no_match_visible = False
+
+    # Filter fallback labels already visible in the current receipt block (#1012).
+    fallback_labels = [
+        (label, reason) for label, reason in fallback_labels
+        if f"⚠️ {label} ({reason}," not in current_text
+    ]
+
+    # Early return if dedup eliminated all remaining work.
+    if (
+        not executed_labels
+        and not queued_labels
+        and not proposed_labels
+        and not fallback_labels
+        and not no_match_visible
+    ):
+        return
+
     # Annotate checkbox lines with ai:id so removal works correctly.
     annotated = annotate_action_ids(current_text)
 
@@ -484,9 +528,11 @@ def _apply_note_writeback(
         f"\u26a0\ufe0f {label} ({reason}, {now_str})"
         for label, reason in fallback_labels
     ]
-    # No-match / no-op receipt: one bounded line, only when nothing else surfaced.
+    # No-match / no-op receipt: one bounded line with an instruction-hash marker so
+    # reruns over unchanged input are idempotent (#1012).
     if no_match_visible:
-        receipts.append(f"\u2139\ufe0f Inga \u00e5tg\u00e4rder matchade ({now_str})")
+        _marker = _no_match_marker(state.panel.instruction or "")
+        receipts.append(f"\u2139\ufe0f Inga \u00e5tg\u00e4rder matchade ({now_str}) {_marker}")
 
     # Find preferred insert position (after last panel fence).
     parsed = parse_panel(updated)

--- a/tests/agents/panel_agent/test_panel_receipts.py
+++ b/tests/agents/panel_agent/test_panel_receipts.py
@@ -308,3 +308,176 @@ def test_receipts_remain_bounded(
     assert len(receipt_lines) <= MAX_RECEIPTS, (
         f"AI status callout exceeded MAX_RECEIPTS={MAX_RECEIPTS}: {len(receipt_lines)} lines"
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #1012: suppress repeated no-match receipts on rerun
+# ---------------------------------------------------------------------------
+
+def _no_match_setup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, note_uuid: str) -> tuple[Path, Path]:
+    """Shared setup for no-match rerun tests. Returns (note_file, outbox_path)."""
+    settings_path = _settings_file(
+        tmp_path,
+        action_id="promote.evergreen",
+        label="Make this note evergreen",
+        intent_type="promotion",
+        trust_verb="APPLY",
+        downstream_event="review.promote.evergreen",
+    )
+    markdown = (
+        "---\n"
+        f"uuid: {note_uuid}\n"
+        "---\n"
+        "%% AI:Start %%\n"
+        "## AI-instruktion\n"
+        "Please do something that has no canonical action.\n"
+        "%% AI:End %%\n"
+    )
+    note_file = _vault_note(tmp_path, note_uuid, markdown)
+    outbox_path = tmp_path / "outbox.jsonl"
+
+    monkeypatch.setenv("PANEL_ACTIONS_PATH", str(settings_path))
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    monkeypatch.setenv("VAULT_ROOT", str(note_file.parent))
+    monkeypatch.setenv("PANEL_AGENT_DECIDER", "llm")
+    monkeypatch.setattr("app.agents.panel_agent.agent.INDEX_OUTBOX_PATH", outbox_path, raising=False)
+    monkeypatch.setattr(
+        "app.agents.panel_agent.cognition.get_reasoning_facade",
+        lambda: _StubReasoningFacade({"actions": []}),
+    )
+    return note_file, outbox_path
+
+
+def test_no_match_rerun_unchanged_input_is_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC #1012-1 + #1012-2: rerun with unchanged instruction must not append
+    another 'Inga åtgärder matchade' line or emit another panel.action.logged event.
+    """
+    note_uuid = str(uuid4())
+    note_file, outbox_path = _no_match_setup(tmp_path, monkeypatch, note_uuid)
+
+    # First run.
+    events = run_panel_intent_for_note(note_uuid, trace_id="trace-1012-a", trigger="watcher")
+    execute_panel_intent(events[0], outbox_path=outbox_path)
+
+    after_first = note_file.read_text(encoding="utf-8")
+    assert "Inga åtgärder matchade" in after_first
+    no_match_count_1 = after_first.count("Inga åtgärder matchade")
+
+    logged_events_1 = [
+        r for r in _read_outbox(outbox_path)
+        if r.get("event") == "panel.action.logged"
+        and (r.get("payload") or {}).get("reason") == "no_actions_matched"
+    ]
+    assert logged_events_1, "expected a no_actions_matched event on first run"
+
+    # Simulate watcher re-index: update ObjectStore with the post-writeback content.
+    _seed_note(note_uuid, after_first, source_ref=str(note_file))
+
+    # Second run — same instruction.
+    events2 = run_panel_intent_for_note(note_uuid, trace_id="trace-1012-b", trigger="watcher")
+    execute_panel_intent(events2[0], outbox_path=outbox_path)
+
+    after_second = note_file.read_text(encoding="utf-8")
+    assert after_second.count("Inga åtgärder matchade") == no_match_count_1, (
+        "rerun appended a duplicate no-match receipt line"
+    )
+
+    logged_events_2 = [
+        r for r in _read_outbox(outbox_path)
+        if r.get("event") == "panel.action.logged"
+        and (r.get("payload") or {}).get("reason") == "no_actions_matched"
+    ]
+    assert len(logged_events_2) == len(logged_events_1), (
+        "rerun emitted an extra panel.action.logged(no_actions_matched) event"
+    )
+
+
+def test_no_match_changed_input_writes_fresh_receipt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC #1012-3: if the panel instruction changes between runs and still resolves
+    to no-match, a new receipt IS written.
+    """
+    note_uuid = str(uuid4())
+    note_file, outbox_path = _no_match_setup(tmp_path, monkeypatch, note_uuid)
+
+    # First run.
+    events = run_panel_intent_for_note(note_uuid, trace_id="trace-1012-c", trigger="watcher")
+    execute_panel_intent(events[0], outbox_path=outbox_path)
+
+    after_first = note_file.read_text(encoding="utf-8")
+    assert "Inga åtgärder matchade" in after_first
+
+    # Simulate instruction change: replace the panel instruction.
+    changed_markdown = after_first.replace(
+        "Please do something that has no canonical action.",
+        "Please do something different that also has no canonical action.",
+    )
+    note_file.write_text(changed_markdown, encoding="utf-8")
+    _seed_note(note_uuid, changed_markdown, source_ref=str(note_file))
+
+    # Second run — different instruction.
+    events2 = run_panel_intent_for_note(note_uuid, trace_id="trace-1012-d", trigger="watcher")
+    execute_panel_intent(events2[0], outbox_path=outbox_path)
+
+    after_second = note_file.read_text(encoding="utf-8")
+    assert after_second.count("Inga åtgärder matchade") > after_first.count("Inga åtgärder matchade"), (
+        "expected a fresh no-match receipt for changed instruction"
+    )
+
+
+def test_fallback_rerun_unchanged_input_is_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AC #1012-4: a rerun of an unmapped checked action must not append a duplicate
+    fallback receipt or emit an extra event when the action and reason are unchanged.
+    """
+    note_uuid = str(uuid4())
+    settings_path = _settings_file(
+        tmp_path,
+        action_id="promote.evergreen",
+        label="Make this note evergreen",
+        intent_type="promotion",
+        trust_verb="APPLY",
+        downstream_event="review.promote.evergreen",
+    )
+    markdown = (
+        "---\n"
+        f"uuid: {note_uuid}\n"
+        "---\n"
+        "%% AI:Start %%\n"
+        "## AI-instruktion\n"
+        "Do something\n"
+        "## AI-åtgärder\n"
+        "- [x] Some unmapped freeform request\n"
+        "%% AI:End %%\n"
+    )
+    note_file = _vault_note(tmp_path, note_uuid, markdown)
+    outbox_path = tmp_path / "outbox.jsonl"
+
+    monkeypatch.setenv("PANEL_ACTIONS_PATH", str(settings_path))
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    monkeypatch.setenv("VAULT_ROOT", str(note_file.parent))
+    monkeypatch.setattr("app.agents.panel_agent.agent.INDEX_OUTBOX_PATH", outbox_path, raising=False)
+
+    # First run.
+    events = run_panel_intent_for_note(note_uuid, trace_id="trace-1012-e", trigger="watcher")
+    execute_panel_intent(events[0], outbox_path=outbox_path)
+
+    after_first = note_file.read_text(encoding="utf-8")
+    assert "unmapped_action" in after_first
+    fallback_count_1 = after_first.count("unmapped_action")
+
+    # Simulate re-index with same content (fallback action was removed from panel).
+    _seed_note(note_uuid, after_first, source_ref=str(note_file))
+
+    # Second run — same note, no new checked action.
+    events2 = run_panel_intent_for_note(note_uuid, trace_id="trace-1012-f", trigger="watcher")
+    execute_panel_intent(events2[0], outbox_path=outbox_path)
+
+    after_second = note_file.read_text(encoding="utf-8")
+    assert after_second.count("unmapped_action") == fallback_count_1, (
+        "rerun appended a duplicate fallback receipt"
+    )


### PR DESCRIPTION
Fixes #1012

## Summary

PanelAgent no-match receipts were written on every watcher rerun when the instruction was unchanged, creating a churn loop. This fix makes the no-match path idempotent.

**Strategy chosen:** instruction-hash marker (`<!--ai:no-match=<16-char-sha256>-->`) embedded in the receipt line. Follows the `[A-Za-z0-9_.-]+` char class from the #979 marker pattern. Chosen over a separate persistent-marker or text-only check because it is self-contained (no extra state), survives receipt-block pruning via content presence, and is deterministic per-instruction.

Fallback diagnostic receipts (`unmapped_action`, `ambiguous_action`, etc.) gain analogous idempotency via text-presence check on the current note content.

**Dispatcher:** unavailable (db_exists: false) — used GitHub-label-only claim.

## Changes

- `app/agents/panel_agent/runtime.py`: helpers `_no_match_marker` / `_has_no_match_marker`; suppression in `execute_panel_intent` (event path) and `_apply_note_writeback` (receipt path); marker embedded in new no-match receipt lines; fallback label dedup via text-presence check.
- `tests/agents/panel_agent/test_panel_receipts.py`: 3 new tests covering rerun idempotency, changed-input fresh receipt, and fallback rerun idempotency.

## Validation

```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/agents/panel_agent/test_panel_receipts.py
# 7 passed (4 pre-existing + 3 new)
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/agents/panel_agent/
# 106 passed, 1 pre-existing failure (test_proposal_outputs_remain_bounded — confirmed failing on main before this branch)
```

---