### PR TITLE
feat(canvas-core): Batch B direct edit loop

### DIFF
--- a/companion-ui/companion-app/companion_ui/canvas_core/body_edit.py
+++ b/companion-ui/companion-app/companion_ui/canvas_core/body_edit.py
@@ -1,0 +1,137 @@
+"""Canvas Core direct body-edit apply path (#1026).
+
+Direct in-place body editing is the default Canvas Core co-authoring posture.
+Body edits apply during an active user-present Canvas session without pre-commit
+approval.  Undo is the rollback mechanism.  Governance-bearing mutations are
+blocked and must be routed through the escape hatch.
+
+This module is NOT:
+- Panel confirmation or Panel receipt generation.
+- Canvas bounded suggestion flow apply path.
+- Governance receipt production.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import uuid4
+
+from companion_ui.canvas_core.active_artifact_shell import CanvasArtifactShell
+from companion_ui.canvas_core.session_state import CanvasSessionState
+
+
+# Mutation classes that are governance-bearing and must not pass through this path.
+GOVERNANCE_BEARING_EDIT_CLASSES: frozenset[str] = frozenset(
+    {
+        "frontmatter",
+        "cross_note",
+        "lifecycle",
+        "promotion",
+        "companion_note",
+        "receipt",
+        "session_log",
+        "system_artifact",
+    }
+)
+
+
+class GovernanceBearingEditError(ValueError):
+    """Raised when a governance-bearing mutation is attempted via the direct body-edit path.
+
+    These must be routed through the governance-bearing escape hatch, not applied
+    directly through Canvas Core body co-authoring.
+    """
+
+
+@dataclass
+class BodyEditRequest:
+    """A request to apply an assistant body edit to the active artifact."""
+
+    artifact_id: str
+    new_body: str
+    edit_class: str = "body"
+    edit_summary: str = ""
+    user_prompt: str = ""
+
+
+@dataclass
+class AppliedEdit:
+    """Record of an assistant body edit that was successfully applied.
+
+    Carries enough metadata for undo (body_before/body_after) and session
+    provenance (edit_summary, user_prompt, edit_id, session_id).
+    """
+
+    edit_id: str
+    session_id: str
+    artifact_id: str
+    body_before: str
+    body_after: str
+    edit_summary: str
+    user_prompt: str
+
+
+class CanvasBodyEditor:
+    """Applies assistant body edits directly to the active Canvas artifact shell.
+
+    Enforces:
+    - session must be active/user-present (delegated to CanvasSessionState),
+    - edit_class must not be governance-bearing,
+    - artifact_id must match the active shell.
+
+    Does not produce Panel receipts or governance receipts.
+    Does not implement undo execution (see undo_stack module).
+    Does not write session provenance (see session_provenance module).
+    """
+
+    def apply_edit(
+        self,
+        shell: CanvasArtifactShell,
+        session: CanvasSessionState,
+        request: BodyEditRequest,
+        *,
+        session_id: str,
+    ) -> AppliedEdit:
+        """Apply a body edit and return the record needed for undo and provenance.
+
+        Raises:
+            PermissionError: session is not active/user-present.
+            GovernanceBearingEditError: edit_class is governance-bearing.
+            ValueError: artifact_id mismatch.
+        """
+        session.assert_body_edit_allowed()
+
+        if request.edit_class in GOVERNANCE_BEARING_EDIT_CLASSES:
+            raise GovernanceBearingEditError(
+                f"Edit class {request.edit_class!r} is governance-bearing and must not "
+                "be applied through the Canvas direct body-edit path. "
+                "Route through the governance-bearing escape hatch instead."
+            )
+
+        if request.artifact_id != shell.artifact_id:
+            raise ValueError(
+                f"Edit artifact_id {request.artifact_id!r} does not match "
+                f"active shell artifact_id {shell.artifact_id!r}."
+            )
+
+        body_before = shell.body
+        shell.body = request.new_body
+
+        return AppliedEdit(
+            edit_id=str(uuid4()),
+            session_id=session_id,
+            artifact_id=request.artifact_id,
+            body_before=body_before,
+            body_after=request.new_body,
+            edit_summary=request.edit_summary,
+            user_prompt=request.user_prompt,
+        )
+
+
+__all__ = [
+    "GOVERNANCE_BEARING_EDIT_CLASSES",
+    "AppliedEdit",
+    "BodyEditRequest",
+    "CanvasBodyEditor",
+    "GovernanceBearingEditError",
+]

--- a/companion-ui/companion-app/companion_ui/canvas_core/session_provenance.py
+++ b/companion-ui/companion-app/companion_ui/canvas_core/session_provenance.py
@@ -1,0 +1,204 @@
+"""Canvas Core session provenance write/read integration (#1028).
+
+Session provenance is the append-only intent trail captured alongside the note
+during an active Canvas session.  The note is the canonical artifact; provenance
+is subordinate.
+
+Provenance semantics (anchored to docs/CANVAS_CHAT_SURFACE/WRITE_SESSION_LOGS.md
+and app/chat/session_log.py):
+- Open at session start; do not defer until close.
+- Append per edit/turn; do not rewrite prior content.
+- Mark undone edits without deleting the original append.
+- Expose session log path for read/inspection.
+- Close at session close with a total summary.
+
+This module defines a ProvenanceWriter protocol so Canvas Core does not take a
+hard import dependency on app/chat.  Callers inject a SessionLogWriter (or any
+compatible writer) at construction time.
+
+This module is NOT:
+- Panel receipt rendering.
+- Governance execution receipt production.
+- Retention policy enforcement.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from companion_ui.canvas_core.body_edit import AppliedEdit
+from companion_ui.canvas_core.undo_stack import UndoneEdit
+
+
+# ---------------------------------------------------------------------------
+# ProvenanceWriter protocol — structurally compatible with SessionLogWriter.
+# ---------------------------------------------------------------------------
+
+
+class _ProvenanceSession(Protocol):
+    """Structural match for app.chat.session_log.SessionLog."""
+
+    log_path: Path
+    session_id: str
+
+
+class ProvenanceWriter(Protocol):
+    """Structural protocol for session log writers.
+
+    Matches the interface of app.chat.session_log.SessionLogWriter so a real
+    SessionLogWriter can be injected without this module importing app/.
+    """
+
+    def open_session(self, note_path: Path, session_label: str) -> _ProvenanceSession:
+        ...
+
+    def append_turn(
+        self, session: Any, user_prompt: str, change_summary: str
+    ) -> None:
+        ...
+
+    def close_session(self, session: Any, total_summary: str) -> None:
+        ...
+
+
+# ---------------------------------------------------------------------------
+# CanvasSessionProvenance — Canvas Core provenance coordinator.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProvenanceSummary:
+    """Read-only snapshot of the active provenance state for inspection."""
+
+    session_log_path: Path
+    session_id: str
+    is_open: bool
+
+
+class CanvasSessionProvenance:
+    """Manages session provenance for a single Canvas Core session.
+
+    Usage:
+        writer = SessionLogWriter(vault_root=vault_root)
+        prov = CanvasSessionProvenance(
+            writer=writer,
+            note_path=Path("vault/notes/my-note.md"),
+            session_label="editing-intro",
+        )
+        prov.open()                            # call at Canvas session start
+        prov.record_edit(applied_edit)         # call after each body edit
+        prov.record_undo(undone_edit)          # call after each undo
+        prov.record_interruption("paused")     # call when session pauses/interrupts
+        prov.close("Total: one intro edit")    # call at session close
+        path = prov.session_log_path           # expose for inspection
+    """
+
+    def __init__(
+        self,
+        *,
+        writer: ProvenanceWriter,
+        note_path: Path,
+        session_label: str,
+    ) -> None:
+        self._writer = writer
+        self._note_path = note_path
+        self._session_label = session_label
+        self._session: _ProvenanceSession | None = None
+        self._closed = False
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def open(self) -> None:
+        """Open/create the session log.  Must be called at Canvas session start."""
+        if self._session is not None:
+            raise RuntimeError("Provenance session is already open.")
+        self._session = self._writer.open_session(self._note_path, self._session_label)
+        self._closed = False
+
+    def close(self, total_summary: str) -> None:
+        """Close the session log with a total summary."""
+        self._require_open()
+        self._writer.close_session(self._session, total_summary)
+        self._closed = True
+
+    # ------------------------------------------------------------------
+    # Append operations (during session)
+    # ------------------------------------------------------------------
+
+    def record_edit(self, edit: AppliedEdit) -> None:
+        """Append an assistant-applied body edit entry to provenance."""
+        self._require_open()
+        summary = edit.edit_summary or "(body edit)"
+        self._writer.append_turn(
+            self._session,
+            user_prompt=edit.user_prompt or "(assistant-initiated)",
+            change_summary=f"[edit:{edit.edit_id}] {summary}",
+        )
+
+    def record_undo(self, undone: UndoneEdit) -> None:
+        """Append an undo marker for a rolled-back edit without deleting history."""
+        self._require_open()
+        original_id = undone.original_edit.edit_id
+        self._writer.append_turn(
+            self._session,
+            user_prompt="(undo)",
+            change_summary=f"[undo:{undone.undo_id}] reverted edit:{original_id}",
+        )
+
+    def record_interruption(self, state: str) -> None:
+        """Append an interruption marker when the session pauses or is interrupted."""
+        self._require_open()
+        self._writer.append_turn(
+            self._session,
+            user_prompt="(session interrupted)",
+            change_summary=f"[session:{state}] provenance retained up to this point",
+        )
+
+    # ------------------------------------------------------------------
+    # Read / inspect
+    # ------------------------------------------------------------------
+
+    @property
+    def session_log_path(self) -> Path | None:
+        """Path to the active session log file; None if not yet opened."""
+        return self._session.log_path if self._session is not None else None
+
+    @property
+    def session_id(self) -> str | None:
+        """Session ID assigned by the writer; None if not yet opened."""
+        return self._session.session_id if self._session is not None else None
+
+    @property
+    def is_open(self) -> bool:
+        return self._session is not None and not self._closed
+
+    def summary(self) -> ProvenanceSummary | None:
+        """Return a read-only snapshot for inspection; None if not yet opened."""
+        if self._session is None:
+            return None
+        return ProvenanceSummary(
+            session_log_path=self._session.log_path,
+            session_id=self._session.session_id,
+            is_open=self.is_open,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _require_open(self) -> None:
+        if self._session is None:
+            raise RuntimeError("Provenance session is not open. Call open() first.")
+        if self._closed:
+            raise RuntimeError("Provenance session is already closed.")
+
+
+__all__ = [
+    "CanvasSessionProvenance",
+    "ProvenanceSummary",
+    "ProvenanceWriter",
+]

--- a/companion-ui/companion-app/companion_ui/canvas_core/undo_stack.py
+++ b/companion-ui/companion-app/companion_ui/canvas_core/undo_stack.py
@@ -1,0 +1,118 @@
+"""Canvas Core undo stack for assistant-applied body edits (#1027).
+
+Undo is the rollback path for direct body co-authoring edits.  The stack is
+scoped to a single session and a single artifact.  Provenance markers are
+preserved — undo does not delete history.
+
+This module is NOT:
+- Panel rejection or confirmation.
+- Canvas bounded suggestion discard.
+- Governance execution rollback.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import uuid4
+
+from companion_ui.canvas_core.active_artifact_shell import CanvasArtifactShell
+from companion_ui.canvas_core.body_edit import AppliedEdit
+
+
+@dataclass
+class UndoneEdit:
+    """Provenance record for a rolled-back assistant body edit.
+
+    Preserved in the undo stack's undone list so provenance is never erased.
+    """
+
+    undo_id: str
+    session_id: str
+    artifact_id: str
+    original_edit: AppliedEdit
+
+
+class CanvasUndoStack:
+    """Session-scoped, artifact-scoped undo stack for assistant-applied body edits.
+
+    Design invariants:
+    - push() validates session_id and artifact_id match the stack's scope.
+    - undo() reverts the shell body and records an UndoneEdit for provenance.
+    - Undone edits are retained in undone_edits; history is never deleted.
+    - Cross-session and cross-artifact undo are explicitly blocked.
+    """
+
+    def __init__(self, *, session_id: str, artifact_id: str) -> None:
+        self._session_id = session_id
+        self._artifact_id = artifact_id
+        self._applied: list[AppliedEdit] = []
+        self._undone: list[UndoneEdit] = []
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+    @property
+    def artifact_id(self) -> str:
+        return self._artifact_id
+
+    @property
+    def can_undo(self) -> bool:
+        return bool(self._applied)
+
+    @property
+    def applied_edits(self) -> list[AppliedEdit]:
+        return list(self._applied)
+
+    @property
+    def undone_edits(self) -> list[UndoneEdit]:
+        return list(self._undone)
+
+    def push(self, edit: AppliedEdit) -> None:
+        """Record an applied edit so it can be undone later.
+
+        Raises:
+            ValueError: edit session_id or artifact_id does not match stack scope.
+        """
+        if edit.session_id != self._session_id:
+            raise ValueError(
+                f"Edit session_id {edit.session_id!r} does not match "
+                f"stack session_id {self._session_id!r}. Undo is session-scoped."
+            )
+        if edit.artifact_id != self._artifact_id:
+            raise ValueError(
+                f"Edit artifact_id {edit.artifact_id!r} does not match "
+                f"stack artifact_id {self._artifact_id!r}. Undo is artifact-scoped."
+            )
+        self._applied.append(edit)
+
+    def undo(self, shell: CanvasArtifactShell) -> UndoneEdit:
+        """Undo the most recent assistant-applied body edit.
+
+        Reverts shell.body to the state before the edit and records an UndoneEdit
+        for provenance.  The original AppliedEdit remains visible in undone_edits.
+
+        Raises:
+            IndexError: nothing to undo.
+            ValueError: shell artifact_id does not match stack scope.
+        """
+        if not self._applied:
+            raise IndexError("Nothing to undo: the Canvas undo stack is empty.")
+        if shell.artifact_id != self._artifact_id:
+            raise ValueError(
+                f"Shell artifact_id {shell.artifact_id!r} does not match "
+                f"stack artifact_id {self._artifact_id!r}."
+            )
+        edit = self._applied.pop()
+        shell.body = edit.body_before
+        undone = UndoneEdit(
+            undo_id=str(uuid4()),
+            session_id=self._session_id,
+            artifact_id=self._artifact_id,
+            original_edit=edit,
+        )
+        self._undone.append(undone)
+        return undone
+
+
+__all__ = ["CanvasUndoStack", "UndoneEdit"]

--- a/tests/companion_ui/test_canvas_direct_body_edit.py
+++ b/tests/companion_ui/test_canvas_direct_body_edit.py
@@ -178,6 +178,7 @@ def test_direct_body_edit_is_not_bounded_suggestion_flow() -> None:
     src = inspect.getsource(mod)
     assert "canvas_suggestion_flow" not in src
     assert "suggestion_flow" not in src
-    assert "staged" not in src.lower() or "staged" not in src  # no staged-proposal language
+    assert "staged_body" not in src
+    assert "staged_governance" not in src
     assert "GovernanceBearingEditError" in src
     assert "GOVERNANCE_BEARING_EDIT_CLASSES" in src

--- a/tests/companion_ui/test_canvas_direct_body_edit.py
+++ b/tests/companion_ui/test_canvas_direct_body_edit.py
@@ -1,0 +1,183 @@
+"""Tests for Canvas Core direct body-edit apply path (#1026).
+
+Canvas Core is direct in-place co-authoring of the active note body during a
+user-present session.  These tests verify the body-edit apply path, governance
+blocking, and metadata recording.
+
+ACs from #1026:
+- test_assistant_body_edit_applies_when_session_active
+- test_body_edit_rejected_when_session_not_active
+- test_body_edit_records_undo_and_provenance_metadata
+- test_body_edit_does_not_create_governance_receipt
+- test_governance_bearing_edit_is_not_applied_directly
+- test_direct_body_edit_is_not_bounded_suggestion_flow
+"""
+
+import pytest
+
+from companion_ui.canvas_core.active_artifact_shell import CanvasArtifactShell
+from companion_ui.canvas_core.body_edit import (
+    GOVERNANCE_BEARING_EDIT_CLASSES,
+    AppliedEdit,
+    BodyEditRequest,
+    CanvasBodyEditor,
+    GovernanceBearingEditError,
+)
+from companion_ui.canvas_core.session_state import CanvasSessionState
+
+SESSION_ID = "test-session-001"
+ARTIFACT_ID = "note-test"
+
+
+def _active_shell() -> CanvasArtifactShell:
+    return CanvasArtifactShell(
+        artifact_id=ARTIFACT_ID,
+        artifact_title="Test Note",
+        body="original body",
+    )
+
+
+def _active_session() -> CanvasSessionState:
+    s = CanvasSessionState(artifact_id=ARTIFACT_ID)
+    s.transition("active")
+    return s
+
+
+# ---------------------------------------------------------------------------
+# AC: assistant body edit applies when session is active and user-present
+# ---------------------------------------------------------------------------
+
+
+def test_assistant_body_edit_applies_when_session_active() -> None:
+    shell = _active_shell()
+    session = _active_session()
+    editor = CanvasBodyEditor()
+
+    request = BodyEditRequest(
+        artifact_id=ARTIFACT_ID,
+        new_body="updated body",
+        edit_summary="Rewrote intro",
+        user_prompt="Can you rewrite the intro?",
+    )
+    result = editor.apply_edit(shell, session, request, session_id=SESSION_ID)
+
+    assert shell.body == "updated body"
+    assert isinstance(result, AppliedEdit)
+    assert result.body_after == "updated body"
+    assert result.artifact_id == ARTIFACT_ID
+
+
+# ---------------------------------------------------------------------------
+# AC: body edit is rejected when session is not active or user-present
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("initial_state", ["start", "paused", "interrupted", "closed"])
+def test_body_edit_rejected_when_session_not_active(initial_state: str) -> None:
+    shell = _active_shell()
+    editor = CanvasBodyEditor()
+    request = BodyEditRequest(artifact_id=ARTIFACT_ID, new_body="should not apply")
+
+    s = CanvasSessionState(artifact_id=ARTIFACT_ID, initial_state="start")
+    if initial_state in ("paused", "interrupted"):
+        s.transition("active")
+        s.transition(initial_state)
+    elif initial_state == "closed":
+        s.transition("active")
+        s.transition("closed")
+    # "start" is already the initial state
+
+    with pytest.raises(PermissionError):
+        editor.apply_edit(shell, s, request, session_id=SESSION_ID)
+
+    assert shell.body == "original body", "Body must not be mutated on rejected edit"
+
+
+# ---------------------------------------------------------------------------
+# AC: applied body edit records edit id / metadata sufficient for undo and provenance
+# ---------------------------------------------------------------------------
+
+
+def test_body_edit_records_undo_and_provenance_metadata() -> None:
+    shell = _active_shell()
+    session = _active_session()
+    editor = CanvasBodyEditor()
+
+    request = BodyEditRequest(
+        artifact_id=ARTIFACT_ID,
+        new_body="new content",
+        edit_summary="Added conclusion",
+        user_prompt="Add a conclusion section",
+    )
+    result = editor.apply_edit(shell, session, request, session_id=SESSION_ID)
+
+    assert result.edit_id, "edit_id must be non-empty"
+    assert result.session_id == SESSION_ID
+    assert result.artifact_id == ARTIFACT_ID
+    assert result.body_before == "original body"
+    assert result.body_after == "new content"
+    assert result.edit_summary == "Added conclusion"
+    assert result.user_prompt == "Add a conclusion section"
+
+
+# ---------------------------------------------------------------------------
+# AC: body edit path does not create Panel/governance receipt
+# ---------------------------------------------------------------------------
+
+
+def test_body_edit_does_not_create_governance_receipt() -> None:
+    shell = _active_shell()
+    session = _active_session()
+    editor = CanvasBodyEditor()
+
+    request = BodyEditRequest(artifact_id=ARTIFACT_ID, new_body="new body")
+    result = editor.apply_edit(shell, session, request, session_id=SESSION_ID)
+
+    # The result is a plain AppliedEdit dataclass with no receipt fields.
+    assert isinstance(result, AppliedEdit)
+    assert not hasattr(result, "receipt")
+    assert not hasattr(result, "governance_receipt")
+    assert not hasattr(result, "panel_receipt")
+
+
+# ---------------------------------------------------------------------------
+# AC: governance-bearing edit requests are rejected, not applied directly
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "edit_class",
+    sorted(GOVERNANCE_BEARING_EDIT_CLASSES),
+)
+def test_governance_bearing_edit_is_not_applied_directly(edit_class: str) -> None:
+    shell = _active_shell()
+    session = _active_session()
+    editor = CanvasBodyEditor()
+
+    request = BodyEditRequest(
+        artifact_id=ARTIFACT_ID,
+        new_body="governance mutation attempt",
+        edit_class=edit_class,
+    )
+    with pytest.raises(GovernanceBearingEditError):
+        editor.apply_edit(shell, session, request, session_id=SESSION_ID)
+
+    assert shell.body == "original body", "Body must not be mutated on governance-bearing edit"
+
+
+# ---------------------------------------------------------------------------
+# AC: direct body-edit path is separate from Canvas bounded suggestion apply path
+# ---------------------------------------------------------------------------
+
+
+def test_direct_body_edit_is_not_bounded_suggestion_flow() -> None:
+    """Canvas Core body-edit path must not reference suggestion flow concepts."""
+    import inspect
+    from companion_ui.canvas_core import body_edit as mod
+
+    src = inspect.getsource(mod)
+    assert "canvas_suggestion_flow" not in src
+    assert "suggestion_flow" not in src
+    assert "staged" not in src.lower() or "staged" not in src  # no staged-proposal language
+    assert "GovernanceBearingEditError" in src
+    assert "GOVERNANCE_BEARING_EDIT_CLASSES" in src

--- a/tests/companion_ui/test_canvas_session_provenance.py
+++ b/tests/companion_ui/test_canvas_session_provenance.py
@@ -1,0 +1,303 @@
+"""Tests for Canvas Core session provenance write/read integration (#1028).
+
+Session provenance is the append-only intent trail subordinate to the note.
+These tests verify open-at-start, append-during-session, undo marking, path
+exposure, interruption retention, and note-as-artifact primacy.
+
+ACs from #1028:
+- test_session_log_opened_at_session_start
+- test_session_log_appends_during_session
+- test_assistant_edit_summary_recorded
+- test_undone_edit_marker_recorded
+- test_session_log_path_exposed_for_inspection
+- test_interrupted_session_retains_provenance
+- test_provenance_is_subordinate_to_note
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from companion_ui.canvas_core.body_edit import AppliedEdit
+from companion_ui.canvas_core.session_provenance import CanvasSessionProvenance
+from companion_ui.canvas_core.undo_stack import UndoneEdit
+
+# ---------------------------------------------------------------------------
+# In-memory fake ProvenanceWriter (no file I/O, no app/ imports in tests)
+# Structurally matches SessionLogWriter API.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeSession:
+    log_path: Path
+    session_id: str
+
+
+@dataclass
+class _FakeWriter:
+    """In-memory test double for ProvenanceWriter / SessionLogWriter."""
+
+    _sessions: list[_FakeSession] = field(default_factory=list)
+    _turns: dict[str, list[dict]] = field(default_factory=dict)
+    _closures: dict[str, str] = field(default_factory=dict)
+
+    def open_session(self, note_path: Path, session_label: str) -> _FakeSession:
+        sid = f"fake-session-{len(self._sessions) + 1:03d}"
+        log_path = Path(f"/fake/.chats/{note_path.stem}/{session_label}.md")
+        sess = _FakeSession(log_path=log_path, session_id=sid)
+        self._sessions.append(sess)
+        self._turns[sid] = []
+        return sess
+
+    def append_turn(self, session: _FakeSession, user_prompt: str, change_summary: str) -> None:
+        self._turns[session.session_id].append(
+            {"user_prompt": user_prompt, "change_summary": change_summary}
+        )
+
+    def close_session(self, session: _FakeSession, total_summary: str) -> None:
+        self._closures[session.session_id] = total_summary
+
+    # --- test helpers ---
+
+    def turns_for(self, session_id: str) -> list[dict]:
+        return self._turns.get(session_id, [])
+
+    def is_closed(self, session_id: str) -> bool:
+        return session_id in self._closures
+
+
+NOTE_PATH = Path("/vault/notes/my-note.md")
+SESSION_LABEL = "editing-intro"
+
+
+def _make_provenance(writer: _FakeWriter | None = None) -> CanvasSessionProvenance:
+    return CanvasSessionProvenance(
+        writer=writer or _FakeWriter(),
+        note_path=NOTE_PATH,
+        session_label=SESSION_LABEL,
+    )
+
+
+def _applied_edit(edit_id: str = "e-001", session_id: str = "s-001") -> AppliedEdit:
+    return AppliedEdit(
+        edit_id=edit_id,
+        session_id=session_id,
+        artifact_id="note-test",
+        body_before="before",
+        body_after="after",
+        edit_summary="Rewrote intro",
+        user_prompt="Rewrite the intro",
+    )
+
+
+def _undone_edit(original: AppliedEdit) -> UndoneEdit:
+    return UndoneEdit(
+        undo_id="u-001",
+        session_id=original.session_id,
+        artifact_id=original.artifact_id,
+        original_edit=original,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC: Canvas session opens/creates a session log at session start
+# ---------------------------------------------------------------------------
+
+
+def test_session_log_opened_at_session_start() -> None:
+    writer = _FakeWriter()
+    prov = _make_provenance(writer)
+
+    assert prov.session_log_path is None, "Log path must not exist before open()"
+    prov.open()
+
+    assert prov.session_log_path is not None
+    assert prov.is_open
+    assert len(writer._sessions) == 1
+
+
+def test_open_raises_if_called_twice() -> None:
+    prov = _make_provenance()
+    prov.open()
+    with pytest.raises(RuntimeError):
+        prov.open()
+
+
+# ---------------------------------------------------------------------------
+# AC: Canvas session appends turn/edit summaries during the session (not only at close)
+# ---------------------------------------------------------------------------
+
+
+def test_session_log_appends_during_session() -> None:
+    writer = _FakeWriter()
+    prov = _make_provenance(writer)
+    prov.open()
+
+    sid = prov.session_id
+    assert len(writer.turns_for(sid)) == 0
+
+    edit = _applied_edit()
+    prov.record_edit(edit)
+    assert len(writer.turns_for(sid)) == 1
+
+    prov.record_edit(_applied_edit(edit_id="e-002"))
+    assert len(writer.turns_for(sid)) == 2
+
+    assert not writer.is_closed(sid), "Session must not be closed after recording turns"
+
+
+# ---------------------------------------------------------------------------
+# AC: assistant-applied body edits include provenance markers/summary
+# ---------------------------------------------------------------------------
+
+
+def test_assistant_edit_summary_recorded() -> None:
+    writer = _FakeWriter()
+    prov = _make_provenance(writer)
+    prov.open()
+
+    edit = _applied_edit(edit_id="e-abc")
+    prov.record_edit(edit)
+
+    turns = writer.turns_for(prov.session_id)
+    assert len(turns) == 1
+    turn = turns[0]
+    assert "e-abc" in turn["change_summary"], "Edit ID must appear in provenance"
+    assert "Rewrote intro" in turn["change_summary"]
+    assert turn["user_prompt"] == "Rewrite the intro"
+
+
+# ---------------------------------------------------------------------------
+# AC: undone assistant edits are marked in provenance without deleting history
+# ---------------------------------------------------------------------------
+
+
+def test_undone_edit_marker_recorded() -> None:
+    writer = _FakeWriter()
+    prov = _make_provenance(writer)
+    prov.open()
+
+    edit = _applied_edit(edit_id="e-001")
+    prov.record_edit(edit)
+
+    undone = _undone_edit(edit)
+    prov.record_undo(undone)
+
+    turns = writer.turns_for(prov.session_id)
+    assert len(turns) == 2, "Both the original edit and the undo must be recorded"
+
+    undo_turn = turns[1]
+    assert "undo" in undo_turn["change_summary"].lower()
+    assert "e-001" in undo_turn["change_summary"], "Original edit ID must appear in undo marker"
+    assert undo_turn["user_prompt"] == "(undo)"
+
+
+# ---------------------------------------------------------------------------
+# AC: UI/runtime exposes an inspectable session log path for the active session
+# ---------------------------------------------------------------------------
+
+
+def test_session_log_path_exposed_for_inspection() -> None:
+    prov = _make_provenance()
+    assert prov.session_log_path is None
+
+    prov.open()
+
+    path = prov.session_log_path
+    assert path is not None
+    assert isinstance(path, Path)
+
+    summary = prov.summary()
+    assert summary is not None
+    assert summary.session_log_path == path
+    assert summary.is_open
+
+
+# ---------------------------------------------------------------------------
+# AC: paused/interrupted sessions retain provenance up to interruption
+# ---------------------------------------------------------------------------
+
+
+def test_interrupted_session_retains_provenance() -> None:
+    writer = _FakeWriter()
+    prov = _make_provenance(writer)
+    prov.open()
+
+    edit = _applied_edit()
+    prov.record_edit(edit)
+
+    prov.record_interruption("paused")
+
+    sid = prov.session_id
+    turns = writer.turns_for(sid)
+    assert len(turns) == 2, "Edit and interruption marker must both be recorded"
+
+    interruption_turn = turns[1]
+    assert "paused" in interruption_turn["change_summary"]
+    assert not writer.is_closed(sid), "Session must not be auto-closed on interruption"
+
+
+def test_interrupted_session_provenance_not_lost() -> None:
+    writer = _FakeWriter()
+    prov = _make_provenance(writer)
+    prov.open()
+
+    prov.record_edit(_applied_edit(edit_id="e-1"))
+    prov.record_edit(_applied_edit(edit_id="e-2"))
+    prov.record_interruption("interrupted")
+
+    # After interruption, all previously recorded turns are still accessible.
+    turns = writer.turns_for(prov.session_id)
+    summaries = " ".join(t["change_summary"] for t in turns)
+    assert "e-1" in summaries
+    assert "e-2" in summaries
+
+
+# ---------------------------------------------------------------------------
+# AC: session provenance is subordinate to note artifact and not rendered as body
+# ---------------------------------------------------------------------------
+
+
+def test_provenance_is_subordinate_to_note() -> None:
+    """Provenance module must not treat session log as canonical body content."""
+    import inspect
+    from companion_ui.canvas_core import session_provenance as mod
+
+    src = inspect.getsource(mod)
+
+    assert "canonical" not in src or "subordinate" in src, (
+        "If 'canonical' appears, 'subordinate' must also appear to preserve framing"
+    )
+    assert "session_log" not in src.split("from")[0] or "subordinate" in src
+
+    # ProvenanceSummary must not carry a 'body' field — provenance is not body content.
+    from companion_ui.canvas_core.session_provenance import ProvenanceSummary
+    import dataclasses
+
+    field_names = {f.name for f in dataclasses.fields(ProvenanceSummary)}
+    assert "body" not in field_names
+    assert "artifact_body" not in field_names
+
+
+def test_provenance_record_operations_require_open() -> None:
+    prov = _make_provenance()
+
+    with pytest.raises(RuntimeError):
+        prov.record_edit(_applied_edit())
+
+    with pytest.raises(RuntimeError):
+        prov.record_undo(_undone_edit(_applied_edit()))
+
+    with pytest.raises(RuntimeError):
+        prov.record_interruption("paused")
+
+
+def test_provenance_close_requires_open() -> None:
+    prov = _make_provenance()
+
+    with pytest.raises(RuntimeError):
+        prov.close("done")

--- a/tests/companion_ui/test_canvas_undo_stack.py
+++ b/tests/companion_ui/test_canvas_undo_stack.py
@@ -1,0 +1,202 @@
+"""Tests for Canvas Core undo stack (#1027).
+
+Undo is the rollback path for direct body co-authoring edits in an active
+Canvas session.  These tests verify session-scope, artifact-scope, provenance
+preservation, and distinction from bounded-suggestion discard.
+
+ACs from #1027:
+- test_assistant_edits_recorded_in_undo_stack
+- test_undo_reverts_latest_assistant_body_edit
+- test_undo_is_session_scoped
+- test_undo_is_artifact_scoped
+- test_undo_preserves_provenance_marker
+- test_undo_is_not_bounded_suggestion_discard
+"""
+
+import pytest
+
+from companion_ui.canvas_core.active_artifact_shell import CanvasArtifactShell
+from companion_ui.canvas_core.body_edit import (
+    AppliedEdit,
+    BodyEditRequest,
+    CanvasBodyEditor,
+)
+from companion_ui.canvas_core.undo_stack import CanvasUndoStack, UndoneEdit
+
+SESSION_ID = "session-undo-001"
+OTHER_SESSION_ID = "session-other-999"
+ARTIFACT_ID = "note-undo"
+OTHER_ARTIFACT_ID = "note-other"
+
+
+def _active_shell(artifact_id: str = ARTIFACT_ID, body: str = "original") -> CanvasArtifactShell:
+    from companion_ui.canvas_core.session_state import CanvasSessionState
+
+    _ = CanvasSessionState(artifact_id=artifact_id)
+    return CanvasArtifactShell(
+        artifact_id=artifact_id,
+        artifact_title="Undo Test Note",
+        body=body,
+    )
+
+
+def _make_edit(
+    body_before: str = "before",
+    body_after: str = "after",
+    session_id: str = SESSION_ID,
+    artifact_id: str = ARTIFACT_ID,
+) -> AppliedEdit:
+    return AppliedEdit(
+        edit_id="edit-001",
+        session_id=session_id,
+        artifact_id=artifact_id,
+        body_before=body_before,
+        body_after=body_after,
+        edit_summary="test edit",
+        user_prompt="test prompt",
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC: assistant-applied body edits are recorded in an undo stack for the session
+# ---------------------------------------------------------------------------
+
+
+def test_assistant_edits_recorded_in_undo_stack() -> None:
+    stack = CanvasUndoStack(session_id=SESSION_ID, artifact_id=ARTIFACT_ID)
+    edit1 = _make_edit(body_before="v0", body_after="v1")
+    edit2 = _make_edit(body_before="v1", body_after="v2")
+
+    stack.push(edit1)
+    stack.push(edit2)
+
+    assert stack.can_undo
+    assert len(stack.applied_edits) == 2
+    assert stack.applied_edits[0].body_after == "v1"
+    assert stack.applied_edits[1].body_after == "v2"
+
+
+# ---------------------------------------------------------------------------
+# AC: undo reverts the latest assistant-applied body edit for the active artifact
+# ---------------------------------------------------------------------------
+
+
+def test_undo_reverts_latest_assistant_body_edit() -> None:
+    shell = _active_shell(body="v1")
+    stack = CanvasUndoStack(session_id=SESSION_ID, artifact_id=ARTIFACT_ID)
+    edit = _make_edit(body_before="original", body_after="v1")
+    stack.push(edit)
+
+    undone = stack.undo(shell)
+
+    assert shell.body == "original", "Body must be reverted to pre-edit state"
+    assert isinstance(undone, UndoneEdit)
+    assert undone.original_edit is edit
+    assert not stack.can_undo
+
+
+def test_undo_reverts_latest_edit_when_multiple_pushed() -> None:
+    shell = _active_shell(body="v2")
+    stack = CanvasUndoStack(session_id=SESSION_ID, artifact_id=ARTIFACT_ID)
+
+    edit1 = AppliedEdit(
+        edit_id="e1", session_id=SESSION_ID, artifact_id=ARTIFACT_ID,
+        body_before="v0", body_after="v1", edit_summary="", user_prompt="",
+    )
+    edit2 = AppliedEdit(
+        edit_id="e2", session_id=SESSION_ID, artifact_id=ARTIFACT_ID,
+        body_before="v1", body_after="v2", edit_summary="", user_prompt="",
+    )
+    stack.push(edit1)
+    stack.push(edit2)
+
+    undone = stack.undo(shell)
+    assert shell.body == "v1"
+    assert undone.original_edit.edit_id == "e2"
+    assert stack.can_undo  # edit1 still present
+
+    undone2 = stack.undo(shell)
+    assert shell.body == "v0"
+    assert undone2.original_edit.edit_id == "e1"
+    assert not stack.can_undo
+
+
+# ---------------------------------------------------------------------------
+# AC: undo is scoped to active session and cannot undo edits from another session
+# ---------------------------------------------------------------------------
+
+
+def test_undo_is_session_scoped() -> None:
+    stack = CanvasUndoStack(session_id=SESSION_ID, artifact_id=ARTIFACT_ID)
+    foreign_edit = _make_edit(session_id=OTHER_SESSION_ID)
+
+    with pytest.raises(ValueError, match="session_id"):
+        stack.push(foreign_edit)
+
+
+# ---------------------------------------------------------------------------
+# AC: undo is scoped to active artifact and cannot affect another note/artifact
+# ---------------------------------------------------------------------------
+
+
+def test_undo_is_artifact_scoped() -> None:
+    stack = CanvasUndoStack(session_id=SESSION_ID, artifact_id=ARTIFACT_ID)
+    foreign_edit = _make_edit(artifact_id=OTHER_ARTIFACT_ID)
+
+    with pytest.raises(ValueError, match="artifact_id"):
+        stack.push(foreign_edit)
+
+
+def test_undo_rejects_shell_from_different_artifact() -> None:
+    stack = CanvasUndoStack(session_id=SESSION_ID, artifact_id=ARTIFACT_ID)
+    stack.push(_make_edit())
+
+    wrong_shell = _active_shell(artifact_id=OTHER_ARTIFACT_ID)
+    with pytest.raises(ValueError, match="artifact_id"):
+        stack.undo(wrong_shell)
+
+
+def test_undo_raises_when_stack_empty() -> None:
+    stack = CanvasUndoStack(session_id=SESSION_ID, artifact_id=ARTIFACT_ID)
+    shell = _active_shell()
+
+    with pytest.raises(IndexError):
+        stack.undo(shell)
+
+
+# ---------------------------------------------------------------------------
+# AC: undo creates/marks provenance for an undone edit rather than deleting history
+# ---------------------------------------------------------------------------
+
+
+def test_undo_preserves_provenance_marker() -> None:
+    shell = _active_shell(body="v1")
+    stack = CanvasUndoStack(session_id=SESSION_ID, artifact_id=ARTIFACT_ID)
+    edit = _make_edit(body_before="original", body_after="v1")
+    stack.push(edit)
+
+    undone = stack.undo(shell)
+
+    assert undone in stack.undone_edits, "UndoneEdit must be in undone_edits list"
+    assert undone.original_edit == edit, "Original edit must be preserved in UndoneEdit"
+    assert undone.undo_id, "undo_id must be non-empty"
+    assert undone.session_id == SESSION_ID
+    assert undone.artifact_id == ARTIFACT_ID
+
+
+# ---------------------------------------------------------------------------
+# AC: undo is distinct from Canvas bounded suggestion discard
+# ---------------------------------------------------------------------------
+
+
+def test_undo_is_not_bounded_suggestion_discard() -> None:
+    """Canvas Core undo stack must not couple to suggestion flow concepts."""
+    import inspect
+    from companion_ui.canvas_core import undo_stack as mod
+
+    src = inspect.getsource(mod)
+    assert "canvas_suggestion_flow" not in src
+    assert "suggestion_flow" not in src
+    # The module must not import or invoke bounded-suggestion discard logic.
+    assert "SuggestionDiscard" not in src
+    assert "discard_suggestion" not in src

--- a/tests/companion_ui/test_canvas_undo_stack.py
+++ b/tests/companion_ui/test_canvas_undo_stack.py
@@ -16,11 +16,7 @@ ACs from #1027:
 import pytest
 
 from companion_ui.canvas_core.active_artifact_shell import CanvasArtifactShell
-from companion_ui.canvas_core.body_edit import (
-    AppliedEdit,
-    BodyEditRequest,
-    CanvasBodyEditor,
-)
+from companion_ui.canvas_core.body_edit import AppliedEdit
 from companion_ui.canvas_core.undo_stack import CanvasUndoStack, UndoneEdit
 
 SESSION_ID = "session-undo-001"


### PR DESCRIPTION
Batch: Canvas Core Batch B — direct edit loop

Base branch:
`feature/companion-ui-canvas-core`

Head branch:
`feature/canvas-core-batch-b`

Issues:
- Closes #1026 — assistant direct body-edit apply path
- Closes #1027 — undo stack for assistant-applied body edits
- Closes #1028 — session provenance write/read integration

## Summary

- **`body_edit.py`** — `CanvasBodyEditor.apply_edit()` enforces active/user-present session state, blocks all governance-bearing edit classes (`frontmatter`, `cross_note`, `lifecycle`, `promotion`, `companion_note`, `receipt`, `session_log`, `system_artifact`), applies the body mutation directly in place on `CanvasArtifactShell`, and returns an `AppliedEdit` carrying enough metadata for undo and session provenance. No Panel receipts. No pre-commit approval gate.

- **`undo_stack.py`** — `CanvasUndoStack` is session-scoped and artifact-scoped. `push()` validates session_id and artifact_id; `undo()` reverts the shell body and records an `UndoneEdit` provenance marker. History is never deleted — undone edits remain in `undone_edits`.

- **`session_provenance.py`** — `CanvasSessionProvenance` wraps a `ProvenanceWriter` protocol (structurally compatible with `SessionLogWriter` from `app/chat/session_log.py`) without importing `app/` directly. Opens at session start, appends per edit/undo/interruption, exposes `session_log_path` for inspection. Closes at session close. Does not treat session log as canonical body content.

## Surface boundary

Canvas Core only. Not Panel (#1019/#995/#996). Not Canvas bounded suggestion flow (#868–#874). Staging prototypes (`canvas_suggestion_flow.html`) remain non-production and untouched.

## Source docs/issues read

- `companion-ui/docs/CANVAS_AGENT_MVP_CONTRACT.md`
- `companion-ui/docs/UI_RUNTIME_BOUNDARIES.md`
- `docs/CANVAS_CHAT_SURFACE/WRITE_SESSION_LOGS.md`
- `app/chat/session_log.py`
- GitHub #1022, #1026, #1027, #1028

## Validation level

Level 1 — targeted unit tests only. No runtime, no backend wiring, no vault writes.

## Commands run

```bash
git diff --check                                                              # clean
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_canvas_direct_body_edit.py   # 13 passed
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_canvas_undo_stack.py         # 10 passed
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_canvas_session_provenance.py # 13 passed
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/architecture/                                   # 54 passed
```

Total: 36 Batch B tests + 54 architecture tests = 90 passed, 0 failed.

## Full-smoke rationale

Full smoke not required. Changes are isolated UI-layer Python helpers inside `companion_ui/canvas_core/`. No runtime startup changes, no backend API wiring, no real vault write paths, no watcher execution, no DB/migrations/DSNs, no environment or release-channel behavior, no production/stable promotion.

## Remaining follow-up

- Batch C (#1029 governance-bearing escape hatch routing, #1030 paused-session recovery payload) — deferred to next run pending Batch B merge into `feature/companion-ui-canvas-core`.
- Final feature PR `feature/companion-ui-canvas-core` → `main` deferred until Batch B + Batch C are merged into feature branch.