### PR TITLE
feat(canvas-core): Batch C safety and re-entry

### DIFF
--- a/companion-ui/companion-app/companion_ui/canvas_core/escape_hatch.py
+++ b/companion-ui/companion-app/companion_ui/canvas_core/escape_hatch.py
@@ -1,0 +1,168 @@
+"""Canvas Core governance-bearing escape hatch routing (#1029).
+
+When a Canvas co-authoring session encounters a governance-bearing operation,
+the operation must not be applied directly through the Canvas body-edit path.
+This module classifies the operation and produces a routing decision so the
+caller can surface blocked/routed status without pretending the action was applied.
+
+Route targets:
+  "panel"                   — artifact-local intent manifestation (Panel surface,
+                              #995/#996/#1019); for lifecycle/maturity/commitment decisions.
+  "canvas_bounded_suggestion" — Canvas bounded suggestion queue (#868–#874);
+                              for frontmatter/classification adjacent to body content.
+  "governed_execution"      — runtime governed execution boundary; for system-owned
+                              artifacts (receipts, session logs, companion notes, cross-note ops).
+
+Ambiguous or unrecognised edit classes default to governance-bearing and are
+routed to governed_execution.
+
+This module does NOT:
+  - implement Panel UI,
+  - implement Canvas bounded suggestion components,
+  - execute governance-bearing mutations,
+  - import or couple to staging-prototype files or staged-proposal concepts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# ---------------------------------------------------------------------------
+# Governance-bearing edit class registry
+# ---------------------------------------------------------------------------
+
+# All classes that are governance-bearing and must not pass through the
+# Canvas direct body-edit path.  Extends the body_edit.GOVERNANCE_BEARING_EDIT_CLASSES
+# set with additional classes that require escape-hatch routing.
+GOVERNANCE_BEARING_CLASSES: frozenset[str] = frozenset(
+    {
+        "frontmatter",
+        "classification",
+        "cross_note",
+        "lifecycle",
+        "promotion",
+        "commitment_state",
+        "companion_note",
+        "receipt",
+        "session_log",
+        "system_artifact",
+    }
+)
+
+# Classes that indicate the operation is non-governance-bearing (safe for direct body edit).
+# Any class not in this set and not in GOVERNANCE_BEARING_CLASSES is treated as
+# ambiguous and defaults to governance-bearing.
+SAFE_EDIT_CLASSES: frozenset[str] = frozenset({"body"})
+
+# ---------------------------------------------------------------------------
+# Route target registry
+# ---------------------------------------------------------------------------
+
+# Routing heuristic for governance-bearing classes:
+#   Panel:                    artifact-local intent/lifecycle decisions.
+#   canvas_bounded_suggestion: frontmatter/classification, adjacent to body editing.
+#   governed_execution:        system-owned artifacts, cross-note, and all ambiguous cases.
+
+_PANEL_CLASSES: frozenset[str] = frozenset({"lifecycle", "promotion", "commitment_state"})
+_CANVAS_SUGGESTION_CLASSES: frozenset[str] = frozenset({"frontmatter", "classification"})
+# Everything else → governed_execution (includes cross_note, companion_note, receipt,
+# session_log, system_artifact, and any unrecognised class).
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EscapeHatchResult:
+    """Classification and routing decision for a governance-bearing operation.
+
+    Callers must surface this status to the user.  The action is NOT applied;
+    this result declares what happened and where the request should go.
+    """
+
+    edit_class: str
+    is_governance_bearing: bool
+    route_target: str  # "panel" | "canvas_bounded_suggestion" | "governed_execution"
+    status_message: str
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+
+class CanvasEscapeHatchRouter:
+    """Routes governance-bearing Canvas operations to the appropriate governed path.
+
+    Usage:
+        router = CanvasEscapeHatchRouter()
+        result = router.route("lifecycle")
+        # result.is_governance_bearing → True
+        # result.route_target → "panel"
+        # result.status_message → human-readable blocked/routed explanation
+    """
+
+    def route(self, edit_class: str) -> EscapeHatchResult:
+        """Classify an operation and return the routing decision.
+
+        A non-governance-bearing class (e.g., "body") returns a result where
+        is_governance_bearing is False and route_target is "none" — callers
+        may proceed with the direct body-edit path.
+
+        An unrecognised class is treated as ambiguous and defaults to
+        governance-bearing (governed_execution route).
+        """
+        if edit_class in SAFE_EDIT_CLASSES:
+            return EscapeHatchResult(
+                edit_class=edit_class,
+                is_governance_bearing=False,
+                route_target="none",
+                status_message=f"Edit class {edit_class!r} is safe for direct Canvas body-edit.",
+            )
+
+        is_governance_bearing = True
+        route_target = self._resolve_route(edit_class)
+        status_message = self._build_status_message(edit_class, route_target)
+
+        return EscapeHatchResult(
+            edit_class=edit_class,
+            is_governance_bearing=is_governance_bearing,
+            route_target=route_target,
+            status_message=status_message,
+        )
+
+    def is_governance_bearing(self, edit_class: str) -> bool:
+        """Return True if the edit class is governance-bearing or ambiguous."""
+        return edit_class not in SAFE_EDIT_CLASSES
+
+    def _resolve_route(self, edit_class: str) -> str:
+        if edit_class in _PANEL_CLASSES:
+            return "panel"
+        if edit_class in _CANVAS_SUGGESTION_CLASSES:
+            return "canvas_bounded_suggestion"
+        return "governed_execution"
+
+    def _build_status_message(self, edit_class: str, route_target: str) -> str:
+        descriptions = {
+            "panel": "routed to Panel for artifact-local intent confirmation",
+            "canvas_bounded_suggestion": (
+                "routed to Canvas bounded suggestion queue for staged review"
+            ),
+            "governed_execution": (
+                "routed to governed execution boundary — direct mutation blocked"
+            ),
+        }
+        description = descriptions.get(route_target, "blocked from direct Canvas body-edit path")
+        return (
+            f"Operation class {edit_class!r} is governance-bearing and was blocked from "
+            f"the Canvas direct body-edit path: {description}."
+        )
+
+
+__all__ = [
+    "GOVERNANCE_BEARING_CLASSES",
+    "SAFE_EDIT_CLASSES",
+    "CanvasEscapeHatchRouter",
+    "EscapeHatchResult",
+]

--- a/companion-ui/companion-app/companion_ui/canvas_core/session_recovery.py
+++ b/companion-ui/companion-app/companion_ui/canvas_core/session_recovery.py
@@ -1,0 +1,224 @@
+"""Canvas Core paused-session recovery payload (#1030).
+
+When a Canvas session is interrupted or paused, the session recovery module
+captures the minimum payload needed for safe low-cost re-entry:
+  - session and artifact identity,
+  - last known body version hash (conflict detection marker),
+  - pending edit count from the undo stack,
+  - session log path for provenance continuity.
+
+Recovery blocks new assistant body edits until the user has acknowledged
+the re-entry state and any body conflict has been surfaced and resolved.
+
+This module does NOT:
+  - redefine session-log write timing (logs open at session start and append
+    per turn; that contract lives in docs/CANVAS_CHAT_SURFACE/WRITE_SESSION_LOGS.md
+    and app/chat/session_log.py),
+  - silently merge external body changes during recovery,
+  - make the session transcript canonical,
+  - implement multi-note or workspace recovery,
+  - implement Panel state recovery or bounded-suggestion recovery.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Body version marker
+# ---------------------------------------------------------------------------
+
+
+def _body_hash(body: str) -> str:
+    """Return a short SHA-256 hex digest of the body text for conflict detection."""
+    return hashlib.sha256(body.encode()).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# Recovery payload
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RecoveryPayload:
+    """Minimum data needed to re-enter a paused or interrupted Canvas session.
+
+    All fields are set at capture time (when the session enters paused/interrupted
+    state) and are immutable.  body_version_hash is used to detect whether the
+    active artifact body has changed externally during the interruption.
+    """
+
+    session_id: str
+    artifact_id: str
+    body_version_hash: str
+    session_log_path: Path | None
+    pending_edit_count: int
+
+
+# ---------------------------------------------------------------------------
+# Recovery status
+# ---------------------------------------------------------------------------
+
+
+class RecoveryStatus(str, Enum):
+    """State of a paused/interrupted Canvas session re-entry."""
+
+    NEEDS_REVIEW = "needs_review"
+    CONFLICT_DETECTED = "conflict_detected"
+    RECOVERED = "recovered"
+
+
+# ---------------------------------------------------------------------------
+# CanvasSessionRecovery
+# ---------------------------------------------------------------------------
+
+
+class CanvasSessionRecovery:
+    """Manages the recovery payload for a paused or interrupted Canvas session.
+
+    Usage:
+        recovery = CanvasSessionRecovery()
+        recovery.capture(
+            session_id="s-001",
+            artifact_id="note-abc",
+            body="current body text",
+            session_log_path=prov.session_log_path,
+            applied_edit_count=len(undo_stack.applied_edits),
+        )
+
+        # When re-entering:
+        status = recovery.check_for_conflict(current_body)
+        if status == RecoveryStatus.CONFLICT_DETECTED:
+            # surface conflict to user
+            ...
+        recovery.mark_recovered()
+    """
+
+    def __init__(self) -> None:
+        self._payload: RecoveryPayload | None = None
+        self._status: RecoveryStatus | None = None
+
+    # ------------------------------------------------------------------
+    # Capture
+    # ------------------------------------------------------------------
+
+    def capture(
+        self,
+        *,
+        session_id: str,
+        artifact_id: str,
+        body: str,
+        session_log_path: Path | None = None,
+        applied_edit_count: int = 0,
+    ) -> RecoveryPayload:
+        """Capture recovery state at the moment the session enters paused/interrupted.
+
+        The body_version_hash is computed from the body text at capture time.
+        The session_log_path must be the path already opened by the provenance
+        writer — recovery does not open a second log.
+
+        Returns the captured payload for inspection.
+        """
+        payload = RecoveryPayload(
+            session_id=session_id,
+            artifact_id=artifact_id,
+            body_version_hash=_body_hash(body),
+            session_log_path=session_log_path,
+            pending_edit_count=applied_edit_count,
+        )
+        self._payload = payload
+        self._status = RecoveryStatus.NEEDS_REVIEW
+        return payload
+
+    # ------------------------------------------------------------------
+    # Conflict detection
+    # ------------------------------------------------------------------
+
+    def check_for_conflict(self, current_body: str) -> RecoveryStatus:
+        """Compare the current artifact body to the captured version hash.
+
+        If the body has changed externally (vault/Obsidian edit during interruption),
+        transitions to CONFLICT_DETECTED rather than silently applying stale edits.
+
+        Returns the resulting recovery status.  The caller is responsible for
+        surfacing the conflict/review-needed state to the user before proceeding.
+
+        Raises:
+            RuntimeError: if capture() has not been called.
+        """
+        self._require_payload()
+        assert self._payload is not None
+        if _body_hash(current_body) != self._payload.body_version_hash:
+            self._status = RecoveryStatus.CONFLICT_DETECTED
+        return self._status  # type: ignore[return-value]
+
+    # ------------------------------------------------------------------
+    # Recovery completion
+    # ------------------------------------------------------------------
+
+    def mark_recovered(self) -> None:
+        """Mark the session recovery as complete.
+
+        After this call, blocks_new_edits returns False and the session
+        may resume direct body co-authoring.
+
+        Raises:
+            RuntimeError: if capture() has not been called.
+        """
+        self._require_payload()
+        self._status = RecoveryStatus.RECOVERED
+
+    # ------------------------------------------------------------------
+    # Read / inspect
+    # ------------------------------------------------------------------
+
+    @property
+    def payload(self) -> RecoveryPayload | None:
+        """The captured recovery payload; None if capture() has not been called."""
+        return self._payload
+
+    @property
+    def recovery_status(self) -> RecoveryStatus | None:
+        """Current recovery status; None if capture() has not been called."""
+        return self._status
+
+    @property
+    def blocks_new_edits(self) -> bool:
+        """True when recovery is pending and new assistant body edits must be blocked."""
+        return self._status is not None and self._status != RecoveryStatus.RECOVERED
+
+    @property
+    def reentry_state(self) -> str:
+        """Human-readable re-entry state for surface/UI display.
+
+        Values:
+          "not_captured"    — no interruption has been captured yet.
+          "needs_review"    — interruption captured; user must acknowledge re-entry.
+          "conflict_detected" — artifact body changed externally; user must review conflict.
+          "recovered"       — recovery complete; normal co-authoring may resume.
+        """
+        if self._status is None:
+            return "not_captured"
+        return self._status.value
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _require_payload(self) -> None:
+        if self._payload is None:
+            raise RuntimeError(
+                "No recovery payload captured. Call capture() first when the session "
+                "enters paused or interrupted state."
+            )
+
+
+__all__ = [
+    "CanvasSessionRecovery",
+    "RecoveryPayload",
+    "RecoveryStatus",
+]

--- a/tests/companion_ui/test_canvas_escape_hatch.py
+++ b/tests/companion_ui/test_canvas_escape_hatch.py
@@ -1,0 +1,186 @@
+"""Tests for Canvas Core governance-bearing escape hatch routing (#1029).
+
+These tests verify that governance-bearing edit classes are classified correctly,
+blocked from the direct body-edit path, routed to the appropriate governed surface,
+and that the module does not couple to Canvas bounded suggestion flow internals.
+
+ACs from #1029:
+- test_frontmatter_change_routes_to_governed_path
+- test_cross_note_operation_routes_to_governed_path
+- test_lifecycle_operation_routes_to_governed_path
+- test_system_artifact_operation_blocked_from_canvas_core
+- test_ambiguous_operation_defaults_to_governance_bearing
+- test_escape_hatch_status_visible
+- test_escape_hatch_preserves_surface_distinctions
+"""
+
+import pytest
+
+from companion_ui.canvas_core.escape_hatch import (
+    GOVERNANCE_BEARING_CLASSES,
+    CanvasEscapeHatchRouter,
+    EscapeHatchResult,
+)
+
+
+# ---------------------------------------------------------------------------
+# AC: frontmatter/classification changes are rejected from direct path and routed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("edit_class", ["frontmatter", "classification"])
+def test_frontmatter_change_routes_to_governed_path(edit_class: str) -> None:
+    router = CanvasEscapeHatchRouter()
+    result = router.route(edit_class)
+
+    assert isinstance(result, EscapeHatchResult)
+    assert result.is_governance_bearing is True
+    assert result.route_target in ("canvas_bounded_suggestion", "panel", "governed_execution")
+    assert result.route_target != "none"
+    assert result.status_message
+    assert edit_class in GOVERNANCE_BEARING_CLASSES
+
+
+# ---------------------------------------------------------------------------
+# AC: cross-note operations are rejected from direct path and routed
+# ---------------------------------------------------------------------------
+
+
+def test_cross_note_operation_routes_to_governed_path() -> None:
+    router = CanvasEscapeHatchRouter()
+    result = router.route("cross_note")
+
+    assert result.is_governance_bearing is True
+    assert result.route_target == "governed_execution"
+    assert "cross_note" in GOVERNANCE_BEARING_CLASSES
+
+
+# ---------------------------------------------------------------------------
+# AC: note lifecycle operations are rejected from direct path and routed
+# ---------------------------------------------------------------------------
+
+
+def test_lifecycle_operation_routes_to_governed_path() -> None:
+    router = CanvasEscapeHatchRouter()
+    result = router.route("lifecycle")
+
+    assert result.is_governance_bearing is True
+    assert result.route_target == "panel"
+
+
+@pytest.mark.parametrize("edit_class", ["promotion", "commitment_state"])
+def test_lifecycle_adjacent_routes_to_panel(edit_class: str) -> None:
+    router = CanvasEscapeHatchRouter()
+    result = router.route(edit_class)
+
+    assert result.is_governance_bearing is True
+    assert result.route_target == "panel"
+
+
+# ---------------------------------------------------------------------------
+# AC: companion note, receipt, and system artifact operations are blocked
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "edit_class",
+    ["companion_note", "receipt", "system_artifact", "session_log"],
+)
+def test_system_artifact_operation_blocked_from_canvas_core(edit_class: str) -> None:
+    router = CanvasEscapeHatchRouter()
+    result = router.route(edit_class)
+
+    assert result.is_governance_bearing is True
+    assert result.route_target == "governed_execution"
+    assert edit_class in GOVERNANCE_BEARING_CLASSES
+
+
+# ---------------------------------------------------------------------------
+# AC: ambiguous operations default to governance-bearing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "edit_class",
+    ["unknown_class", "future_class_not_yet_defined", "", "some_ambiguous_op"],
+)
+def test_ambiguous_operation_defaults_to_governance_bearing(edit_class: str) -> None:
+    router = CanvasEscapeHatchRouter()
+    result = router.route(edit_class)
+
+    assert result.is_governance_bearing is True, (
+        f"Ambiguous edit class {edit_class!r} must default to governance-bearing"
+    )
+    assert result.route_target == "governed_execution"
+    assert result.status_message
+
+
+def test_safe_body_edit_is_not_governance_bearing() -> None:
+    router = CanvasEscapeHatchRouter()
+    result = router.route("body")
+
+    assert result.is_governance_bearing is False
+    assert result.route_target == "none"
+
+
+# ---------------------------------------------------------------------------
+# AC: routed/blocked status is visible and does not claim the action was applied
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("edit_class", sorted(GOVERNANCE_BEARING_CLASSES))
+def test_escape_hatch_status_visible(edit_class: str) -> None:
+    router = CanvasEscapeHatchRouter()
+    result = router.route(edit_class)
+
+    assert result.status_message, "status_message must be non-empty"
+    # These phrases positively claim the action was applied — must not appear.
+    positive_applied_phrases = (
+        "successfully applied",
+        "action was applied",
+        "has been applied",
+        "mutation was applied",
+        "edit was applied",
+        "change was applied",
+    )
+    lower_msg = result.status_message.lower()
+    for phrase in positive_applied_phrases:
+        assert phrase not in lower_msg, (
+            f"status_message must not claim the action was applied; got: {result.status_message!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC: routing boundary preserves distinction between Panel, Canvas bounded
+#     suggestion flow, and governed execution
+# ---------------------------------------------------------------------------
+
+
+def test_escape_hatch_preserves_surface_distinctions() -> None:
+    router = CanvasEscapeHatchRouter()
+
+    panel_result = router.route("lifecycle")
+    suggestion_result = router.route("frontmatter")
+    governed_result = router.route("cross_note")
+
+    assert panel_result.route_target == "panel"
+    assert suggestion_result.route_target == "canvas_bounded_suggestion"
+    assert governed_result.route_target == "governed_execution"
+
+    # All three targets are distinct.
+    targets = {panel_result.route_target, suggestion_result.route_target, governed_result.route_target}
+    assert len(targets) == 3, "All three route targets must be distinct"
+
+
+def test_escape_hatch_does_not_reference_suggestion_flow_internals() -> None:
+    """Escape hatch module must not couple to Canvas bounded suggestion flow internals."""
+    import inspect
+    from companion_ui.canvas_core import escape_hatch as mod
+
+    src = inspect.getsource(mod)
+    # The staging prototype HTML file must not be imported or referenced.
+    assert "canvas_suggestion_flow.html" not in src
+    assert "staged_body" not in src
+    assert "staged_governance" not in src
+    assert "SuggestionDiscard" not in src
+    assert "discard_suggestion" not in src

--- a/tests/companion_ui/test_canvas_session_recovery.py
+++ b/tests/companion_ui/test_canvas_session_recovery.py
@@ -1,0 +1,231 @@
+"""Tests for Canvas Core paused-session recovery payload (#1030).
+
+These tests verify that interrupted/paused Canvas sessions produce a recovery
+payload with the minimum data needed for safe re-entry, block new edits until
+recovery is complete, detect external body changes, and preserve existing
+provenance rather than creating a second canonical log.
+
+ACs from #1030:
+- test_interrupted_session_recovery_payload_contains_identity
+- test_recovery_payload_contains_body_version_marker
+- test_interrupted_session_blocks_new_edits_until_recovered
+- test_reentry_state_visible_for_interrupted_session
+- test_changed_artifact_requires_recovery_review
+- test_recovery_uses_existing_session_log_provenance
+"""
+
+from pathlib import Path
+
+import pytest
+
+from companion_ui.canvas_core.session_recovery import (
+    CanvasSessionRecovery,
+    RecoveryPayload,
+    RecoveryStatus,
+)
+
+SESSION_ID = "session-recovery-001"
+ARTIFACT_ID = "note-recovery-test"
+BODY_TEXT = "# Test Note\n\nOriginal body content."
+
+
+# ---------------------------------------------------------------------------
+# AC: interrupted session stores recovery payload with session id, artifact id, log path
+# ---------------------------------------------------------------------------
+
+
+def test_interrupted_session_recovery_payload_contains_identity() -> None:
+    recovery = CanvasSessionRecovery()
+    log_path = Path(".chats/test-note/2026-05-17T10-00-session.md")
+
+    payload = recovery.capture(
+        session_id=SESSION_ID,
+        artifact_id=ARTIFACT_ID,
+        body=BODY_TEXT,
+        session_log_path=log_path,
+    )
+
+    assert isinstance(payload, RecoveryPayload)
+    assert payload.session_id == SESSION_ID
+    assert payload.artifact_id == ARTIFACT_ID
+    assert payload.session_log_path == log_path
+
+
+def test_recovery_payload_accessible_via_property() -> None:
+    recovery = CanvasSessionRecovery()
+    payload = recovery.capture(
+        session_id=SESSION_ID,
+        artifact_id=ARTIFACT_ID,
+        body=BODY_TEXT,
+    )
+    assert recovery.payload is payload
+
+
+# ---------------------------------------------------------------------------
+# AC: recovery payload includes last known body version hash or conflict marker
+# ---------------------------------------------------------------------------
+
+
+def test_recovery_payload_contains_body_version_marker() -> None:
+    recovery = CanvasSessionRecovery()
+    payload = recovery.capture(
+        session_id=SESSION_ID,
+        artifact_id=ARTIFACT_ID,
+        body=BODY_TEXT,
+    )
+
+    assert payload.body_version_hash, "body_version_hash must be non-empty"
+    assert isinstance(payload.body_version_hash, str)
+
+
+def test_body_version_hash_differs_for_different_bodies() -> None:
+    recovery1 = CanvasSessionRecovery()
+    recovery2 = CanvasSessionRecovery()
+
+    payload1 = recovery1.capture(session_id=SESSION_ID, artifact_id=ARTIFACT_ID, body="body A")
+    payload2 = recovery2.capture(session_id=SESSION_ID, artifact_id=ARTIFACT_ID, body="body B")
+
+    assert payload1.body_version_hash != payload2.body_version_hash
+
+
+def test_body_version_hash_stable_for_same_body() -> None:
+    recovery1 = CanvasSessionRecovery()
+    recovery2 = CanvasSessionRecovery()
+
+    payload1 = recovery1.capture(session_id=SESSION_ID, artifact_id=ARTIFACT_ID, body=BODY_TEXT)
+    payload2 = recovery2.capture(session_id=SESSION_ID, artifact_id=ARTIFACT_ID, body=BODY_TEXT)
+
+    assert payload1.body_version_hash == payload2.body_version_hash
+
+
+# ---------------------------------------------------------------------------
+# AC: paused/interrupted session blocks new assistant body edits until recovery
+# ---------------------------------------------------------------------------
+
+
+def test_interrupted_session_blocks_new_edits_until_recovered() -> None:
+    recovery = CanvasSessionRecovery()
+    recovery.capture(session_id=SESSION_ID, artifact_id=ARTIFACT_ID, body=BODY_TEXT)
+
+    assert recovery.blocks_new_edits is True, (
+        "New edits must be blocked until recovery is complete"
+    )
+
+    recovery.mark_recovered()
+    assert recovery.blocks_new_edits is False, (
+        "New edits must be allowed after recovery is marked complete"
+    )
+
+
+def test_no_payload_means_no_block() -> None:
+    recovery = CanvasSessionRecovery()
+    assert recovery.blocks_new_edits is False
+
+
+# ---------------------------------------------------------------------------
+# AC: UI/runtime exposes a re-entry state for interrupted session
+# ---------------------------------------------------------------------------
+
+
+def test_reentry_state_visible_for_interrupted_session() -> None:
+    recovery = CanvasSessionRecovery()
+    assert recovery.reentry_state == "not_captured"
+
+    recovery.capture(session_id=SESSION_ID, artifact_id=ARTIFACT_ID, body=BODY_TEXT)
+    assert recovery.reentry_state == "needs_review"
+
+    recovery.mark_recovered()
+    assert recovery.reentry_state == "recovered"
+
+
+def test_reentry_state_conflict_detected() -> None:
+    recovery = CanvasSessionRecovery()
+    recovery.capture(session_id=SESSION_ID, artifact_id=ARTIFACT_ID, body=BODY_TEXT)
+
+    recovery.check_for_conflict("# Externally Modified\n\nDifferent content.")
+    assert recovery.reentry_state == "conflict_detected"
+    assert recovery.blocks_new_edits is True
+
+
+# ---------------------------------------------------------------------------
+# AC: recovery detects changed artifact body and surfaces conflict rather than
+#     silently applying stale edits
+# ---------------------------------------------------------------------------
+
+
+def test_changed_artifact_requires_recovery_review() -> None:
+    recovery = CanvasSessionRecovery()
+    recovery.capture(session_id=SESSION_ID, artifact_id=ARTIFACT_ID, body=BODY_TEXT)
+
+    status = recovery.check_for_conflict("# Externally changed body")
+
+    assert status == RecoveryStatus.CONFLICT_DETECTED
+    assert recovery.recovery_status == RecoveryStatus.CONFLICT_DETECTED
+
+
+def test_unchanged_artifact_stays_needs_review() -> None:
+    recovery = CanvasSessionRecovery()
+    recovery.capture(session_id=SESSION_ID, artifact_id=ARTIFACT_ID, body=BODY_TEXT)
+
+    status = recovery.check_for_conflict(BODY_TEXT)
+
+    assert status == RecoveryStatus.NEEDS_REVIEW
+
+
+def test_conflict_detected_still_blocks_edits() -> None:
+    recovery = CanvasSessionRecovery()
+    recovery.capture(session_id=SESSION_ID, artifact_id=ARTIFACT_ID, body=BODY_TEXT)
+    recovery.check_for_conflict("changed body")
+
+    assert recovery.blocks_new_edits is True
+
+
+def test_mark_recovered_without_capture_raises() -> None:
+    recovery = CanvasSessionRecovery()
+    with pytest.raises(RuntimeError, match="capture"):
+        recovery.mark_recovered()
+
+
+def test_check_for_conflict_without_capture_raises() -> None:
+    recovery = CanvasSessionRecovery()
+    with pytest.raises(RuntimeError, match="capture"):
+        recovery.check_for_conflict("body")
+
+
+# ---------------------------------------------------------------------------
+# AC: recovery preserves append-during-session provenance and does not create
+#     a second canonical transcript
+# ---------------------------------------------------------------------------
+
+
+def test_recovery_uses_existing_session_log_provenance() -> None:
+    """Recovery must use the session log path already opened by the provenance writer.
+
+    It must not open a second log.  The session_log_path in the payload is the
+    same path as the one the provenance writer opened at session start.
+    """
+    existing_log_path = Path(".chats/test-note/2026-05-17T10-00-session.md")
+
+    recovery = CanvasSessionRecovery()
+    payload = recovery.capture(
+        session_id=SESSION_ID,
+        artifact_id=ARTIFACT_ID,
+        body=BODY_TEXT,
+        session_log_path=existing_log_path,
+    )
+
+    assert payload.session_log_path == existing_log_path, (
+        "Recovery payload must carry the existing provenance log path, not open a new one"
+    )
+
+
+def test_recovery_payload_carries_pending_edit_count() -> None:
+    recovery = CanvasSessionRecovery()
+    payload = recovery.capture(
+        session_id=SESSION_ID,
+        artifact_id=ARTIFACT_ID,
+        body=BODY_TEXT,
+        applied_edit_count=3,
+    )
+
+    assert payload.pending_edit_count == 3


### PR DESCRIPTION
Batch: Canvas Core Batch C — safety and re-entry

Base branch:
`feature/companion-ui-canvas-core`

Head branch:
`feature/canvas-core-batch-c`

Issues:
- Closes #1029 — canvas-core: implement governance-bearing escape hatch routing
- Closes #1030 — canvas-core: implement paused-session recovery payload

## Summary

**`escape_hatch.py`** — `CanvasEscapeHatchRouter.route()` classifies any edit class and returns an `EscapeHatchResult` carrying `is_governance_bearing`, `route_target`, and `status_message`. `GOVERNANCE_BEARING_CLASSES` is the full expanded set: `frontmatter`, `classification`, `cross_note`, `lifecycle`, `promotion`, `commitment_state`, `companion_note`, `receipt`, `session_log`, `system_artifact`. Ambiguous/unknown classes default to governance-bearing and are routed to `governed_execution`. The three route targets (`panel`, `canvas_bounded_suggestion`, `governed_execution`) map to the three distinct governed surfaces. Status messages surface the blocked/routed state without claiming the action was applied.

**`session_recovery.py`** — `CanvasSessionRecovery.capture()` records the minimum re-entry payload when a Canvas session enters paused/interrupted state: `session_id`, `artifact_id`, `body_version_hash` (SHA-256 of body at capture time), `session_log_path` (existing provenance path — no second log opened), and `pending_edit_count`. `check_for_conflict()` detects external artifact body changes and transitions to `CONFLICT_DETECTED` rather than silently accepting stale edits. `blocks_new_edits` is `True` until `mark_recovered()` is called. `reentry_state` exposes the human-readable surface state.

## Surface boundary

Canvas Core only. Not Panel (#1019/#995/#996). Not Canvas bounded suggestion flow (#868–#874). Staging prototypes (`canvas_suggestion_flow.html`) remain non-production and untouched.

## Source docs/issues read

- `companion-ui/docs/CANVAS_AGENT_MVP_CONTRACT.md` (Governance-Bearing Escape Hatch, Session Lifecycle, Implementation-Readiness Boundaries)
- `companion-ui/docs/UI_RUNTIME_BOUNDARIES.md`
- `companion-ui/companion-app/companion_ui/canvas_core/session_state.py`
- `companion-ui/companion-app/companion_ui/canvas_core/body_edit.py`
- `companion-ui/companion-app/companion_ui/canvas_core/session_provenance.py`
- `app/chat/session_log.py`
- GitHub #1022, #1029, #1030

## Validation level

Level 1 — targeted unit tests only. No runtime, no backend wiring, no vault writes, no real file I/O.

## Commands run

```bash
git diff --check                                                                           # clean
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_canvas_escape_hatch.py     # 43 passed
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_canvas_session_recovery.py # 16 passed
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/ tests/architecture/            # 175 passed, 0 failed
```

## Full-smoke rationale

Full smoke not required. Changes are isolated UI-layer Python helpers inside `companion_ui/canvas_core/`. No runtime startup changes, no backend API wiring, no real vault write paths, no watcher execution, no DB/migrations/DSNs, no environment or release-channel behavior, no production/stable promotion. The `CanvasSessionRecovery` module uses `hashlib` and `pathlib.Path` from the standard library only.

## Remaining follow-up

- Escape-hatch routing is a routing-decision layer only. Actual Panel presentation (#995/#996/#1019) and Canvas bounded suggestion UI (#868–#874) remain their own work streams.
- Session recovery provides the payload contract; vault-write re-entry and Obsidian live-editor integration are deferred to later milestones.
- Final feature PR `feature/companion-ui-canvas-core` → `main` is created separately once this PR merges.