### PR TITLE
feat(canvas-core): complete Canvas Core MVP implementation

### DIFF
--- a/companion-ui/companion-app/companion_ui/canvas_core/body_edit.py
+++ b/companion-ui/companion-app/companion_ui/canvas_core/body_edit.py
@@ -20,13 +20,24 @@ from companion_ui.canvas_core.active_artifact_shell import CanvasArtifactShell
 from companion_ui.canvas_core.session_state import CanvasSessionState
 
 
-# Mutation classes that are governance-bearing and must not pass through this path.
+# The only edit class that is safe for the direct Canvas body-edit path.
+# Any class not in this set is treated as governance-bearing or ambiguous and
+# is rejected — this includes all named governance-bearing classes below and
+# any future/unknown class (ambiguous-defaults-to-governance-bearing).
+SAFE_EDIT_CLASSES: frozenset[str] = frozenset({"body"})
+
+# Named mutation classes that are known to be governance-bearing.
+# Used for documentation, testing, and routing classification.  Enforcement
+# in apply_edit() uses SAFE_EDIT_CLASSES (allowlist), not this blocklist,
+# so unrecognised classes are also blocked.
 GOVERNANCE_BEARING_EDIT_CLASSES: frozenset[str] = frozenset(
     {
         "frontmatter",
+        "classification",
         "cross_note",
         "lifecycle",
         "promotion",
+        "commitment_state",
         "companion_note",
         "receipt",
         "session_log",
@@ -76,8 +87,8 @@ class CanvasBodyEditor:
 
     Enforces:
     - session must be active/user-present (delegated to CanvasSessionState),
-    - edit_class must not be governance-bearing,
-    - artifact_id must match the active shell.
+    - edit_class must be in SAFE_EDIT_CLASSES (allowlist — ambiguous classes blocked),
+    - session, shell, and request must all refer to the same artifact.
 
     Does not produce Panel receipts or governance receipts.
     Does not implement undo execution (see undo_stack module).
@@ -96,16 +107,23 @@ class CanvasBodyEditor:
 
         Raises:
             PermissionError: session is not active/user-present.
-            GovernanceBearingEditError: edit_class is governance-bearing.
-            ValueError: artifact_id mismatch.
+            GovernanceBearingEditError: edit_class is not in SAFE_EDIT_CLASSES.
+            ValueError: artifact_id mismatch between session, shell, or request.
         """
         session.assert_body_edit_allowed()
 
-        if request.edit_class in GOVERNANCE_BEARING_EDIT_CLASSES:
+        if request.edit_class not in SAFE_EDIT_CLASSES:
             raise GovernanceBearingEditError(
-                f"Edit class {request.edit_class!r} is governance-bearing and must not "
-                "be applied through the Canvas direct body-edit path. "
-                "Route through the governance-bearing escape hatch instead."
+                f"Edit class {request.edit_class!r} is not permitted on the Canvas direct "
+                "body-edit path. Only 'body' edits may be applied in place. "
+                "Route governance-bearing or ambiguous classes through the escape hatch."
+            )
+
+        if shell.artifact_id != session.artifact_id:
+            raise ValueError(
+                f"Shell artifact_id {shell.artifact_id!r} does not match "
+                f"session artifact_id {session.artifact_id!r}. "
+                "A Canvas session is bound to a single artifact."
             )
 
         if request.artifact_id != shell.artifact_id:
@@ -130,6 +148,7 @@ class CanvasBodyEditor:
 
 __all__ = [
     "GOVERNANCE_BEARING_EDIT_CLASSES",
+    "SAFE_EDIT_CLASSES",
     "AppliedEdit",
     "BodyEditRequest",
     "CanvasBodyEditor",

--- a/companion-ui/companion-app/companion_ui/canvas_core/body_edit.py
+++ b/companion-ui/companion-app/companion_ui/canvas_core/body_edit.py
@@ -1,0 +1,137 @@
+"""Canvas Core direct body-edit apply path (#1026).
+
+Direct in-place body editing is the default Canvas Core co-authoring posture.
+Body edits apply during an active user-present Canvas session without pre-commit
+approval.  Undo is the rollback mechanism.  Governance-bearing mutations are
+blocked and must be routed through the escape hatch.
+
+This module is NOT:
+- Panel confirmation or Panel receipt generation.
+- Canvas bounded suggestion flow apply path.
+- Governance receipt production.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import uuid4
+
+from companion_ui.canvas_core.active_artifact_shell import CanvasArtifactShell
+from companion_ui.canvas_core.session_state import CanvasSessionState
+
+
+# Mutation classes that are governance-bearing and must not pass through this path.
+GOVERNANCE_BEARING_EDIT_CLASSES: frozenset[str] = frozenset(
+    {
+        "frontmatter",
+        "cross_note",
+        "lifecycle",
+        "promotion",
+        "companion_note",
+        "receipt",
+        "session_log",
+        "system_artifact",
+    }
+)
+
+
+class GovernanceBearingEditError(ValueError):
+    """Raised when a governance-bearing mutation is attempted via the direct body-edit path.
+
+    These must be routed through the governance-bearing escape hatch, not applied
+    directly through Canvas Core body co-authoring.
+    """
+
+
+@dataclass
+class BodyEditRequest:
+    """A request to apply an assistant body edit to the active artifact."""
+
+    artifact_id: str
+    new_body: str
+    edit_class: str = "body"
+    edit_summary: str = ""
+    user_prompt: str = ""
+
+
+@dataclass
+class AppliedEdit:
+    """Record of an assistant body edit that was successfully applied.
+
+    Carries enough metadata for undo (body_before/body_after) and session
+    provenance (edit_summary, user_prompt, edit_id, session_id).
+    """
+
+    edit_id: str
+    session_id: str
+    artifact_id: str
+    body_before: str
+    body_after: str
+    edit_summary: str
+    user_prompt: str
+
+
+class CanvasBodyEditor:
+    """Applies assistant body edits directly to the active Canvas artifact shell.
+
+    Enforces:
+    - session must be active/user-present (delegated to CanvasSessionState),
+    - edit_class must not be governance-bearing,
+    - artifact_id must match the active shell.
+
+    Does not produce Panel receipts or governance receipts.
+    Does not implement undo execution (see undo_stack module).
+    Does not write session provenance (see session_provenance module).
+    """
+
+    def apply_edit(
+        self,
+        shell: CanvasArtifactShell,
+        session: CanvasSessionState,
+        request: BodyEditRequest,
+        *,
+        session_id: str,
+    ) -> AppliedEdit:
+        """Apply a body edit and return the record needed for undo and provenance.
+
+        Raises:
+            PermissionError: session is not active/user-present.
+            GovernanceBearingEditError: edit_class is governance-bearing.
+            ValueError: artifact_id mismatch.
+        """
+        session.assert_body_edit_allowed()
+
+        if request.edit_class in GOVERNANCE_BEARING_EDIT_CLASSES:
+            raise GovernanceBearingEditError(
+                f"Edit class {request.edit_class!r} is governance-bearing and must not "
+                "be applied through the Canvas direct body-edit path. "
+                "Route through the governance-bearing escape hatch instead."
+            )
+
+        if request.artifact_id != shell.artifact_id:
+            raise ValueError(
+                f"Edit artifact_id {request.artifact_id!r} does not match "
+                f"active shell artifact_id {shell.artifact_id!r}."
+            )
+
+        body_before = shell.body
+        shell.body = request.new_body
+
+        return AppliedEdit(
+            edit_id=str(uuid4()),
+            session_id=session_id,
+            artifact_id=request.artifact_id,
+            body_before=body_before,
+            body_after=request.new_body,
+            edit_summary=request.edit_summary,
+            user_prompt=request.user_prompt,
+        )
+
+
+__all__ = [
+    "GOVERNANCE_BEARING_EDIT_CLASSES",
+    "AppliedEdit",
+    "BodyEditRequest",
+    "CanvasBodyEditor",
+    "GovernanceBearingEditError",
+]

--- a/companion-ui/companion-app/companion_ui/canvas_core/escape_hatch.py
+++ b/companion-ui/companion-app/companion_ui/canvas_core/escape_hatch.py
@@ -1,0 +1,168 @@
+"""Canvas Core governance-bearing escape hatch routing (#1029).
+
+When a Canvas co-authoring session encounters a governance-bearing operation,
+the operation must not be applied directly through the Canvas body-edit path.
+This module classifies the operation and produces a routing decision so the
+caller can surface blocked/routed status without pretending the action was applied.
+
+Route targets:
+  "panel"                   — artifact-local intent manifestation (Panel surface,
+                              #995/#996/#1019); for lifecycle/maturity/commitment decisions.
+  "canvas_bounded_suggestion" — Canvas bounded suggestion queue (#868–#874);
+                              for frontmatter/classification adjacent to body content.
+  "governed_execution"      — runtime governed execution boundary; for system-owned
+                              artifacts (receipts, session logs, companion notes, cross-note ops).
+
+Ambiguous or unrecognised edit classes default to governance-bearing and are
+routed to governed_execution.
+
+This module does NOT:
+  - implement Panel UI,
+  - implement Canvas bounded suggestion components,
+  - execute governance-bearing mutations,
+  - import or couple to staging-prototype files or staged-proposal concepts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# ---------------------------------------------------------------------------
+# Governance-bearing edit class registry
+# ---------------------------------------------------------------------------
+
+# All classes that are governance-bearing and must not pass through the
+# Canvas direct body-edit path.  Extends the body_edit.GOVERNANCE_BEARING_EDIT_CLASSES
+# set with additional classes that require escape-hatch routing.
+GOVERNANCE_BEARING_CLASSES: frozenset[str] = frozenset(
+    {
+        "frontmatter",
+        "classification",
+        "cross_note",
+        "lifecycle",
+        "promotion",
+        "commitment_state",
+        "companion_note",
+        "receipt",
+        "session_log",
+        "system_artifact",
+    }
+)
+
+# Classes that indicate the operation is non-governance-bearing (safe for direct body edit).
+# Any class not in this set and not in GOVERNANCE_BEARING_CLASSES is treated as
+# ambiguous and defaults to governance-bearing.
+SAFE_EDIT_CLASSES: frozenset[str] = frozenset({"body"})
+
+# ---------------------------------------------------------------------------
+# Route target registry
+# ---------------------------------------------------------------------------
+
+# Routing heuristic for governance-bearing classes:
+#   Panel:                    artifact-local intent/lifecycle decisions.
+#   canvas_bounded_suggestion: frontmatter/classification, adjacent to body editing.
+#   governed_execution:        system-owned artifacts, cross-note, and all ambiguous cases.
+
+_PANEL_CLASSES: frozenset[str] = frozenset({"lifecycle", "promotion", "commitment_state"})
+_CANVAS_SUGGESTION_CLASSES: frozenset[str] = frozenset({"frontmatter", "classification"})
+# Everything else → governed_execution (includes cross_note, companion_note, receipt,
+# session_log, system_artifact, and any unrecognised class).
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EscapeHatchResult:
+    """Classification and routing decision for a governance-bearing operation.
+
+    Callers must surface this status to the user.  The action is NOT applied;
+    this result declares what happened and where the request should go.
+    """
+
+    edit_class: str
+    is_governance_bearing: bool
+    route_target: str  # "panel" | "canvas_bounded_suggestion" | "governed_execution"
+    status_message: str
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+
+class CanvasEscapeHatchRouter:
+    """Routes governance-bearing Canvas operations to the appropriate governed path.
+
+    Usage:
+        router = CanvasEscapeHatchRouter()
+        result = router.route("lifecycle")
+        # result.is_governance_bearing → True
+        # result.route_target → "panel"
+        # result.status_message → human-readable blocked/routed explanation
+    """
+
+    def route(self, edit_class: str) -> EscapeHatchResult:
+        """Classify an operation and return the routing decision.
+
+        A non-governance-bearing class (e.g., "body") returns a result where
+        is_governance_bearing is False and route_target is "none" — callers
+        may proceed with the direct body-edit path.
+
+        An unrecognised class is treated as ambiguous and defaults to
+        governance-bearing (governed_execution route).
+        """
+        if edit_class in SAFE_EDIT_CLASSES:
+            return EscapeHatchResult(
+                edit_class=edit_class,
+                is_governance_bearing=False,
+                route_target="none",
+                status_message=f"Edit class {edit_class!r} is safe for direct Canvas body-edit.",
+            )
+
+        is_governance_bearing = True
+        route_target = self._resolve_route(edit_class)
+        status_message = self._build_status_message(edit_class, route_target)
+
+        return EscapeHatchResult(
+            edit_class=edit_class,
+            is_governance_bearing=is_governance_bearing,
+            route_target=route_target,
+            status_message=status_message,
+        )
+
+    def is_governance_bearing(self, edit_class: str) -> bool:
+        """Return True if the edit class is governance-bearing or ambiguous."""
+        return edit_class not in SAFE_EDIT_CLASSES
+
+    def _resolve_route(self, edit_class: str) -> str:
+        if edit_class in _PANEL_CLASSES:
+            return "panel"
+        if edit_class in _CANVAS_SUGGESTION_CLASSES:
+            return "canvas_bounded_suggestion"
+        return "governed_execution"
+
+    def _build_status_message(self, edit_class: str, route_target: str) -> str:
+        descriptions = {
+            "panel": "routed to Panel for artifact-local intent confirmation",
+            "canvas_bounded_suggestion": (
+                "routed to Canvas bounded suggestion queue for staged review"
+            ),
+            "governed_execution": (
+                "routed to governed execution boundary — direct mutation blocked"
+            ),
+        }
+        description = descriptions.get(route_target, "blocked from direct Canvas body-edit path")
+        return (
+            f"Operation class {edit_class!r} is governance-bearing and was blocked from "
+            f"the Canvas direct body-edit path: {description}."
+        )
+
+
+__all__ = [
+    "GOVERNANCE_BEARING_CLASSES",
+    "SAFE_EDIT_CLASSES",
+    "CanvasEscapeHatchRouter",
+    "EscapeHatchResult",
+]

--- a/companion-ui/companion-app/companion_ui/canvas_core/session_provenance.py
+++ b/companion-ui/companion-app/companion_ui/canvas_core/session_provenance.py
@@ -1,0 +1,204 @@
+"""Canvas Core session provenance write/read integration (#1028).
+
+Session provenance is the append-only intent trail captured alongside the note
+during an active Canvas session.  The note is the canonical artifact; provenance
+is subordinate.
+
+Provenance semantics (anchored to docs/CANVAS_CHAT_SURFACE/WRITE_SESSION_LOGS.md
+and app/chat/session_log.py):
+- Open at session start; do not defer until close.
+- Append per edit/turn; do not rewrite prior content.
+- Mark undone edits without deleting the original append.
+- Expose session log path for read/inspection.
+- Close at session close with a total summary.
+
+This module defines a ProvenanceWriter protocol so Canvas Core does not take a
+hard import dependency on app/chat.  Callers inject a SessionLogWriter (or any
+compatible writer) at construction time.
+
+This module is NOT:
+- Panel receipt rendering.
+- Governance execution receipt production.
+- Retention policy enforcement.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from companion_ui.canvas_core.body_edit import AppliedEdit
+from companion_ui.canvas_core.undo_stack import UndoneEdit
+
+
+# ---------------------------------------------------------------------------
+# ProvenanceWriter protocol — structurally compatible with SessionLogWriter.
+# ---------------------------------------------------------------------------
+
+
+class _ProvenanceSession(Protocol):
+    """Structural match for app.chat.session_log.SessionLog."""
+
+    log_path: Path
+    session_id: str
+
+
+class ProvenanceWriter(Protocol):
+    """Structural protocol for session log writers.
+
+    Matches the interface of app.chat.session_log.SessionLogWriter so a real
+    SessionLogWriter can be injected without this module importing app/.
+    """
+
+    def open_session(self, note_path: Path, session_label: str) -> _ProvenanceSession:
+        ...
+
+    def append_turn(
+        self, session: Any, user_prompt: str, change_summary: str
+    ) -> None:
+        ...
+
+    def close_session(self, session: Any, total_summary: str) -> None:
+        ...
+
+
+# ---------------------------------------------------------------------------
+# CanvasSessionProvenance — Canvas Core provenance coordinator.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProvenanceSummary:
+    """Read-only snapshot of the active provenance state for inspection."""
+
+    session_log_path: Path
+    session_id: str
+    is_open: bool
+
+
+class CanvasSessionProvenance:
+    """Manages session provenance for a single Canvas Core session.
+
+    Usage:
+        writer = SessionLogWriter(vault_root=vault_root)
+        prov = CanvasSessionProvenance(
+            writer=writer,
+            note_path=Path("vault/notes/my-note.md"),
+            session_label="editing-intro",
+        )
+        prov.open()                            # call at Canvas session start
+        prov.record_edit(applied_edit)         # call after each body edit
+        prov.record_undo(undone_edit)          # call after each undo
+        prov.record_interruption("paused")     # call when session pauses/interrupts
+        prov.close("Total: one intro edit")    # call at session close
+        path = prov.session_log_path           # expose for inspection
+    """
+
+    def __init__(
+        self,
+        *,
+        writer: ProvenanceWriter,
+        note_path: Path,
+        session_label: str,
+    ) -> None:
+        self._writer = writer
+        self._note_path = note_path
+        self._session_label = session_label
+        self._session: _ProvenanceSession | None = None
+        self._closed = False
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def open(self) -> None:
+        """Open/create the session log.  Must be called at Canvas session start."""
+        if self._session is not None:
+            raise RuntimeError("Provenance session is already open.")
+        self._session = self._writer.open_session(self._note_path, self._session_label)
+        self._closed = False
+
+    def close(self, total_summary: str) -> None:
+        """Close the session log with a total summary."""
+        self._require_open()
+        self._writer.close_session(self._session, total_summary)
+        self._closed = True
+
+    # ------------------------------------------------------------------
+    # Append operations (during session)
+    # ------------------------------------------------------------------
+
+    def record_edit(self, edit: AppliedEdit) -> None:
+        """Append an assistant-applied body edit entry to provenance."""
+        self._require_open()
+        summary = edit.edit_summary or "(body edit)"
+        self._writer.append_turn(
+            self._session,
+            user_prompt=edit.user_prompt or "(assistant-initiated)",
+            change_summary=f"[edit:{edit.edit_id}] {summary}",
+        )
+
+    def record_undo(self, undone: UndoneEdit) -> None:
+        """Append an undo marker for a rolled-back edit without deleting history."""
+        self._require_open()
+        original_id = undone.original_edit.edit_id
+        self._writer.append_turn(
+            self._session,
+            user_prompt="(undo)",
+            change_summary=f"[undo:{undone.undo_id}] reverted edit:{original_id}",
+        )
+
+    def record_interruption(self, state: str) -> None:
+        """Append an interruption marker when the session pauses or is interrupted."""
+        self._require_open()
+        self._writer.append_turn(
+            self._session,
+            user_prompt="(session interrupted)",
+            change_summary=f"[session:{state}] provenance retained up to this point",
+        )
+
+    # ------------------------------------------------------------------
+    # Read / inspect
+    # ------------------------------------------------------------------
+
+    @property
+    def session_log_path(self) -> Path | None:
+        """Path to the active session log file; None if not yet opened."""
+        return self._session.log_path if self._session is not None else None
+
+    @property
+    def session_id(self) -> str | None:
+        """Session ID assigned by the writer; None if not yet opened."""
+        return self._session.session_id if self._session is not None else None
+
+    @property
+    def is_open(self) -> bool:
+        return self._session is not None and not self._closed
+
+    def summary(self) -> ProvenanceSummary | None:
+        """Return a read-only snapshot for inspection; None if not yet opened."""
+        if self._session is None:
+            return None
+        return ProvenanceSummary(
+            session_log_path=self._session.log_path,
+            session_id=self._session.session_id,
+            is_open=self.is_open,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _require_open(self) -> None:
+        if self._session is None:
+            raise RuntimeError("Provenance session is not open. Call open() first.")
+        if self._closed:
+            raise RuntimeError("Provenance session is already closed.")
+
+
+__all__ = [
+    "CanvasSessionProvenance",
+    "ProvenanceSummary",
+    "ProvenanceWriter",
+]

--- a/companion-ui/companion-app/companion_ui/canvas_core/session_recovery.py
+++ b/companion-ui/companion-app/companion_ui/canvas_core/session_recovery.py
@@ -1,0 +1,224 @@
+"""Canvas Core paused-session recovery payload (#1030).
+
+When a Canvas session is interrupted or paused, the session recovery module
+captures the minimum payload needed for safe low-cost re-entry:
+  - session and artifact identity,
+  - last known body version hash (conflict detection marker),
+  - pending edit count from the undo stack,
+  - session log path for provenance continuity.
+
+Recovery blocks new assistant body edits until the user has acknowledged
+the re-entry state and any body conflict has been surfaced and resolved.
+
+This module does NOT:
+  - redefine session-log write timing (logs open at session start and append
+    per turn; that contract lives in docs/CANVAS_CHAT_SURFACE/WRITE_SESSION_LOGS.md
+    and app/chat/session_log.py),
+  - silently merge external body changes during recovery,
+  - make the session transcript canonical,
+  - implement multi-note or workspace recovery,
+  - implement Panel state recovery or bounded-suggestion recovery.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Body version marker
+# ---------------------------------------------------------------------------
+
+
+def _body_hash(body: str) -> str:
+    """Return a short SHA-256 hex digest of the body text for conflict detection."""
+    return hashlib.sha256(body.encode()).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# Recovery payload
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RecoveryPayload:
+    """Minimum data needed to re-enter a paused or interrupted Canvas session.
+
+    All fields are set at capture time (when the session enters paused/interrupted
+    state) and are immutable.  body_version_hash is used to detect whether the
+    active artifact body has changed externally during the interruption.
+    """
+
+    session_id: str
+    artifact_id: str
+    body_version_hash: str
+    session_log_path: Path | None
+    pending_edit_count: int
+
+
+# ---------------------------------------------------------------------------
+# Recovery status
+# ---------------------------------------------------------------------------
+
+
+class RecoveryStatus(str, Enum):
+    """State of a paused/interrupted Canvas session re-entry."""
+
+    NEEDS_REVIEW = "needs_review"
+    CONFLICT_DETECTED = "conflict_detected"
+    RECOVERED = "recovered"
+
+
+# ---------------------------------------------------------------------------
+# CanvasSessionRecovery
+# ---------------------------------------------------------------------------
+
+
+class CanvasSessionRecovery:
+    """Manages the recovery payload for a paused or interrupted Canvas session.
+
+    Usage:
+        recovery = CanvasSessionRecovery()
+        recovery.capture(
+            session_id="s-001",
+            artifact_id="note-abc",
+            body="current body text",
+            session_log_path=prov.session_log_path,
+            applied_edit_count=len(undo_stack.applied_edits),
+        )
+
+        # When re-entering:
+        status = recovery.check_for_conflict(current_body)
+        if status == RecoveryStatus.CONFLICT_DETECTED:
+            # surface conflict to user
+            ...
+        recovery.mark_recovered()
+    """
+
+    def __init__(self) -> None:
+        self._payload: RecoveryPayload | None = None
+        self._status: RecoveryStatus | None = None
+
+    # ------------------------------------------------------------------
+    # Capture
+    # ------------------------------------------------------------------
+
+    def capture(
+        self,
+        *,
+        session_id: str,
+        artifact_id: str,
+        body: str,
+        session_log_path: Path | None = None,
+        applied_edit_count: int = 0,
+    ) -> RecoveryPayload:
+        """Capture recovery state at the moment the session enters paused/interrupted.
+
+        The body_version_hash is computed from the body text at capture time.
+        The session_log_path must be the path already opened by the provenance
+        writer — recovery does not open a second log.
+
+        Returns the captured payload for inspection.
+        """
+        payload = RecoveryPayload(
+            session_id=session_id,
+            artifact_id=artifact_id,
+            body_version_hash=_body_hash(body),
+            session_log_path=session_log_path,
+            pending_edit_count=applied_edit_count,
+        )
+        self._payload = payload
+        self._status = RecoveryStatus.NEEDS_REVIEW
+        return payload
+
+    # ------------------------------------------------------------------
+    # Conflict detection
+    # ------------------------------------------------------------------
+
+    def check_for_conflict(self, current_body: str) -> RecoveryStatus:
+        """Compare the current artifact body to the captured version hash.
+
+        If the body has changed externally (vault/Obsidian edit during interruption),
+        transitions to CONFLICT_DETECTED rather than silently applying stale edits.
+
+        Returns the resulting recovery status.  The caller is responsible for
+        surfacing the conflict/review-needed state to the user before proceeding.
+
+        Raises:
+            RuntimeError: if capture() has not been called.
+        """
+        self._require_payload()
+        assert self._payload is not None
+        if _body_hash(current_body) != self._payload.body_version_hash:
+            self._status = RecoveryStatus.CONFLICT_DETECTED
+        return self._status  # type: ignore[return-value]
+
+    # ------------------------------------------------------------------
+    # Recovery completion
+    # ------------------------------------------------------------------
+
+    def mark_recovered(self) -> None:
+        """Mark the session recovery as complete.
+
+        After this call, blocks_new_edits returns False and the session
+        may resume direct body co-authoring.
+
+        Raises:
+            RuntimeError: if capture() has not been called.
+        """
+        self._require_payload()
+        self._status = RecoveryStatus.RECOVERED
+
+    # ------------------------------------------------------------------
+    # Read / inspect
+    # ------------------------------------------------------------------
+
+    @property
+    def payload(self) -> RecoveryPayload | None:
+        """The captured recovery payload; None if capture() has not been called."""
+        return self._payload
+
+    @property
+    def recovery_status(self) -> RecoveryStatus | None:
+        """Current recovery status; None if capture() has not been called."""
+        return self._status
+
+    @property
+    def blocks_new_edits(self) -> bool:
+        """True when recovery is pending and new assistant body edits must be blocked."""
+        return self._status is not None and self._status != RecoveryStatus.RECOVERED
+
+    @property
+    def reentry_state(self) -> str:
+        """Human-readable re-entry state for surface/UI display.
+
+        Values:
+          "not_captured"    — no interruption has been captured yet.
+          "needs_review"    — interruption captured; user must acknowledge re-entry.
+          "conflict_detected" — artifact body changed externally; user must review conflict.
+          "recovered"       — recovery complete; normal co-authoring may resume.
+        """
+        if self._status is None:
+            return "not_captured"
+        return self._status.value
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _require_payload(self) -> None:
+        if self._payload is None:
+            raise RuntimeError(
+                "No recovery payload captured. Call capture() first when the session "
+                "enters paused or interrupted state."
+            )
+
+
+__all__ = [
+    "CanvasSessionRecovery",
+    "RecoveryPayload",
+    "RecoveryStatus",
+]

--- a/companion-ui/companion-app/companion_ui/canvas_core/undo_stack.py
+++ b/companion-ui/companion-app/companion_ui/canvas_core/undo_stack.py
@@ -1,0 +1,118 @@
+"""Canvas Core undo stack for assistant-applied body edits (#1027).
+
+Undo is the rollback path for direct body co-authoring edits.  The stack is
+scoped to a single session and a single artifact.  Provenance markers are
+preserved — undo does not delete history.
+
+This module is NOT:
+- Panel rejection or confirmation.
+- Canvas bounded suggestion discard.
+- Governance execution rollback.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import uuid4
+
+from companion_ui.canvas_core.active_artifact_shell import CanvasArtifactShell
+from companion_ui.canvas_core.body_edit import AppliedEdit
+
+
+@dataclass
+class UndoneEdit:
+    """Provenance record for a rolled-back assistant body edit.
+
+    Preserved in the undo stack's undone list so provenance is never erased.
+    """
+
+    undo_id: str
+    session_id: str
+    artifact_id: str
+    original_edit: AppliedEdit
+
+
+class CanvasUndoStack:
+    """Session-scoped, artifact-scoped undo stack for assistant-applied body edits.
+
+    Design invariants:
+    - push() validates session_id and artifact_id match the stack's scope.
+    - undo() reverts the shell body and records an UndoneEdit for provenance.
+    - Undone edits are retained in undone_edits; history is never deleted.
+    - Cross-session and cross-artifact undo are explicitly blocked.
+    """
+
+    def __init__(self, *, session_id: str, artifact_id: str) -> None:
+        self._session_id = session_id
+        self._artifact_id = artifact_id
+        self._applied: list[AppliedEdit] = []
+        self._undone: list[UndoneEdit] = []
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+    @property
+    def artifact_id(self) -> str:
+        return self._artifact_id
+
+    @property
+    def can_undo(self) -> bool:
+        return bool(self._applied)
+
+    @property
+    def applied_edits(self) -> list[AppliedEdit]:
+        return list(self._applied)
+
+    @property
+    def undone_edits(self) -> list[UndoneEdit]:
+        return list(self._undone)
+
+    def push(self, edit: AppliedEdit) -> None:
+        """Record an applied edit so it can be undone later.
+
+        Raises:
+            ValueError: edit session_id or artifact_id does not match stack scope.
+        """
+        if edit.session_id != self._session_id:
+            raise ValueError(
+                f"Edit session_id {edit.session_id!r} does not match "
+                f"stack session_id {self._session_id!r}. Undo is session-scoped."
+            )
+        if edit.artifact_id != self._artifact_id:
+            raise ValueError(
+                f"Edit artifact_id {edit.artifact_id!r} does not match "
+                f"stack artifact_id {self._artifact_id!r}. Undo is artifact-scoped."
+            )
+        self._applied.append(edit)
+
+    def undo(self, shell: CanvasArtifactShell) -> UndoneEdit:
+        """Undo the most recent assistant-applied body edit.
+
+        Reverts shell.body to the state before the edit and records an UndoneEdit
+        for provenance.  The original AppliedEdit remains visible in undone_edits.
+
+        Raises:
+            IndexError: nothing to undo.
+            ValueError: shell artifact_id does not match stack scope.
+        """
+        if not self._applied:
+            raise IndexError("Nothing to undo: the Canvas undo stack is empty.")
+        if shell.artifact_id != self._artifact_id:
+            raise ValueError(
+                f"Shell artifact_id {shell.artifact_id!r} does not match "
+                f"stack artifact_id {self._artifact_id!r}."
+            )
+        edit = self._applied.pop()
+        shell.body = edit.body_before
+        undone = UndoneEdit(
+            undo_id=str(uuid4()),
+            session_id=self._session_id,
+            artifact_id=self._artifact_id,
+            original_edit=edit,
+        )
+        self._undone.append(undone)
+        return undone
+
+
+__all__ = ["CanvasUndoStack", "UndoneEdit"]

--- a/companion-ui/companion-app/companion_ui/canvas_core/undo_stack.py
+++ b/companion-ui/companion-app/companion_ui/canvas_core/undo_stack.py
@@ -19,6 +19,15 @@ from companion_ui.canvas_core.active_artifact_shell import CanvasArtifactShell
 from companion_ui.canvas_core.body_edit import AppliedEdit
 
 
+class UndoDivergenceError(RuntimeError):
+    """Raised when undo cannot safely revert because the body has diverged.
+
+    The body has changed since the assistant edit was applied (e.g., a user
+    keystroke landed after the edit).  Silently overwriting user work is
+    unsafe; the caller must surface this as a conflict before proceeding.
+    """
+
+
 @dataclass
 class UndoneEdit:
     """Provenance record for a rolled-back assistant body edit.
@@ -95,6 +104,9 @@ class CanvasUndoStack:
         Raises:
             IndexError: nothing to undo.
             ValueError: shell artifact_id does not match stack scope.
+            UndoDivergenceError: the body has changed since the edit was applied
+                (e.g., an intervening user keystroke); reverts the pop so the
+                edit remains on the stack and the caller can surface the conflict.
         """
         if not self._applied:
             raise IndexError("Nothing to undo: the Canvas undo stack is empty.")
@@ -104,6 +116,14 @@ class CanvasUndoStack:
                 f"stack artifact_id {self._artifact_id!r}."
             )
         edit = self._applied.pop()
+        if shell.body != edit.body_after:
+            self._applied.append(edit)
+            raise UndoDivergenceError(
+                f"Cannot undo edit {edit.edit_id!r}: the current body differs from the "
+                "body after the assistant edit was applied. An intervening change (e.g., "
+                "a user keystroke) may have landed. Surface this as a conflict before "
+                "proceeding with undo."
+            )
         shell.body = edit.body_before
         undone = UndoneEdit(
             undo_id=str(uuid4()),
@@ -115,4 +135,4 @@ class CanvasUndoStack:
         return undone
 
 
-__all__ = ["CanvasUndoStack", "UndoneEdit"]
+__all__ = ["CanvasUndoStack", "UndoDivergenceError", "UndoneEdit"]

--- a/tests/companion_ui/test_canvas_direct_body_edit.py
+++ b/tests/companion_ui/test_canvas_direct_body_edit.py
@@ -18,6 +18,7 @@ import pytest
 from companion_ui.canvas_core.active_artifact_shell import CanvasArtifactShell
 from companion_ui.canvas_core.body_edit import (
     GOVERNANCE_BEARING_EDIT_CLASSES,
+    SAFE_EDIT_CLASSES,
     AppliedEdit,
     BodyEditRequest,
     CanvasBodyEditor,
@@ -182,3 +183,52 @@ def test_direct_body_edit_is_not_bounded_suggestion_flow() -> None:
     assert "staged_governance" not in src
     assert "GovernanceBearingEditError" in src
     assert "GOVERNANCE_BEARING_EDIT_CLASSES" in src
+
+
+# ---------------------------------------------------------------------------
+# Review fix: allowlist blocks ambiguous/unknown classes (not just named blocklist)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "edit_class",
+    ["unknown_class", "some_ambiguous_op", "future_class", ""],
+)
+def test_ambiguous_edit_class_is_blocked_by_allowlist(edit_class: str) -> None:
+    shell = _active_shell()
+    session = _active_session()
+    editor = CanvasBodyEditor()
+
+    request = BodyEditRequest(artifact_id=ARTIFACT_ID, new_body="should not apply", edit_class=edit_class)
+    with pytest.raises(GovernanceBearingEditError):
+        editor.apply_edit(shell, session, request, session_id=SESSION_ID)
+
+    assert shell.body == "original body"
+
+
+def test_safe_edit_classes_constant_contains_only_body() -> None:
+    assert SAFE_EDIT_CLASSES == frozenset({"body"})
+
+
+def test_governance_bearing_edit_classes_includes_classification_and_commitment() -> None:
+    assert "classification" in GOVERNANCE_BEARING_EDIT_CLASSES
+    assert "commitment_state" in GOVERNANCE_BEARING_EDIT_CLASSES
+
+
+# ---------------------------------------------------------------------------
+# Review fix: session/shell artifact binding — wrong session rejected
+# ---------------------------------------------------------------------------
+
+
+def test_body_edit_rejected_when_session_artifact_mismatches_shell() -> None:
+    shell = _active_shell()  # artifact_id = ARTIFACT_ID
+    other_artifact_id = "note-other"
+    session = CanvasSessionState(artifact_id=other_artifact_id)
+    session.transition("active")
+    editor = CanvasBodyEditor()
+
+    request = BodyEditRequest(artifact_id=ARTIFACT_ID, new_body="should not apply")
+    with pytest.raises(ValueError, match="artifact_id"):
+        editor.apply_edit(shell, session, request, session_id=SESSION_ID)
+
+    assert shell.body == "original body"

--- a/tests/companion_ui/test_canvas_direct_body_edit.py
+++ b/tests/companion_ui/test_canvas_direct_body_edit.py
@@ -178,6 +178,7 @@ def test_direct_body_edit_is_not_bounded_suggestion_flow() -> None:
     src = inspect.getsource(mod)
     assert "canvas_suggestion_flow" not in src
     assert "suggestion_flow" not in src
-    assert "staged" not in src.lower() or "staged" not in src  # no staged-proposal language
+    assert "staged_body" not in src
+    assert "staged_governance" not in src
     assert "GovernanceBearingEditError" in src
     assert "GOVERNANCE_BEARING_EDIT_CLASSES" in src

--- a/tests/companion_ui/test_canvas_direct_body_edit.py
+++ b/tests/companion_ui/test_canvas_direct_body_edit.py
@@ -1,0 +1,183 @@
+"""Tests for Canvas Core direct body-edit apply path (#1026).
+
+Canvas Core is direct in-place co-authoring of the active note body during a
+user-present session.  These tests verify the body-edit apply path, governance
+blocking, and metadata recording.
+
+ACs from #1026:
+- test_assistant_body_edit_applies_when_session_active
+- test_body_edit_rejected_when_session_not_active
+- test_body_edit_records_undo_and_provenance_metadata
+- test_body_edit_does_not_create_governance_receipt
+- test_governance_bearing_edit_is_not_applied_directly
+- test_direct_body_edit_is_not_bounded_suggestion_flow
+"""
+
+import pytest
+
+from companion_ui.canvas_core.active_artifact_shell import CanvasArtifactShell
+from companion_ui.canvas_core.body_edit import (
+    GOVERNANCE_BEARING_EDIT_CLASSES,
+    AppliedEdit,
+    BodyEditRequest,
+    CanvasBodyEditor,
+    GovernanceBearingEditError,
+)
+from companion_ui.canvas_core.session_state import CanvasSessionState
+
+SESSION_ID = "test-session-001"
+ARTIFACT_ID = "note-test"
+
+
+def _active_shell() -> CanvasArtifactShell:
+    return CanvasArtifactShell(
+        artifact_id=ARTIFACT_ID,
+        artifact_title="Test Note",
+        body="original body",
+    )
+
+
+def _active_session() -> CanvasSessionState:
+    s = CanvasSessionState(artifact_id=ARTIFACT_ID)
+    s.transition("active")
+    return s
+
+
+# ---------------------------------------------------------------------------
+# AC: assistant body edit applies when session is active and user-present
+# ---------------------------------------------------------------------------
+
+
+def test_assistant_body_edit_applies_when_session_active() -> None:
+    shell = _active_shell()
+    session = _active_session()
+    editor = CanvasBodyEditor()
+
+    request = BodyEditRequest(
+        artifact_id=ARTIFACT_ID,
+        new_body="updated body",
+        edit_summary="Rewrote intro",
+        user_prompt="Can you rewrite the intro?",
+    )
+    result = editor.apply_edit(shell, session, request, session_id=SESSION_ID)
+
+    assert shell.body == "updated body"
+    assert isinstance(result, AppliedEdit)
+    assert result.body_after == "updated body"
+    assert result.artifact_id == ARTIFACT_ID
+
+
+# ---------------------------------------------------------------------------
+# AC: body edit is rejected when session is not active or user-present
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("initial_state", ["start", "paused", "interrupted", "closed"])
+def test_body_edit_rejected_when_session_not_active(initial_state: str) -> None:
+    shell = _active_shell()
+    editor = CanvasBodyEditor()
+    request = BodyEditRequest(artifact_id=ARTIFACT_ID, new_body="should not apply")
+
+    s = CanvasSessionState(artifact_id=ARTIFACT_ID, initial_state="start")
+    if initial_state in ("paused", "interrupted"):
+        s.transition("active")
+        s.transition(initial_state)
+    elif initial_state == "closed":
+        s.transition("active")
+        s.transition("closed")
+    # "start" is already the initial state
+
+    with pytest.raises(PermissionError):
+        editor.apply_edit(shell, s, request, session_id=SESSION_ID)
+
+    assert shell.body == "original body", "Body must not be mutated on rejected edit"
+
+
+# ---------------------------------------------------------------------------
+# AC: applied body edit records edit id / metadata sufficient for undo and provenance
+# ---------------------------------------------------------------------------
+
+
+def test_body_edit_records_undo_and_provenance_metadata() -> None:
+    shell = _active_shell()
+    session = _active_session()
+    editor = CanvasBodyEditor()
+
+    request = BodyEditRequest(
+        artifact_id=ARTIFACT_ID,
+        new_body="new content",
+        edit_summary="Added conclusion",
+        user_prompt="Add a conclusion section",
+    )
+    result = editor.apply_edit(shell, session, request, session_id=SESSION_ID)
+
+    assert result.edit_id, "edit_id must be non-empty"
+    assert result.session_id == SESSION_ID
+    assert result.artifact_id == ARTIFACT_ID
+    assert result.body_before == "original body"
+    assert result.body_after == "new content"
+    assert result.edit_summary == "Added conclusion"
+    assert result.user_prompt == "Add a conclusion section"
+
+
+# ---------------------------------------------------------------------------
+# AC: body edit path does not create Panel/governance receipt
+# ---------------------------------------------------------------------------
+
+
+def test_body_edit_does_not_create_governance_receipt() -> None:
+    shell = _active_shell()
+    session = _active_session()
+    editor = CanvasBodyEditor()
+
+    request = BodyEditRequest(artifact_id=ARTIFACT_ID, new_body="new body")
+    result = editor.apply_edit(shell, session, request, session_id=SESSION_ID)
+
+    # The result is a plain AppliedEdit dataclass with no receipt fields.
+    assert isinstance(result, AppliedEdit)
+    assert not hasattr(result, "receipt")
+    assert not hasattr(result, "governance_receipt")
+    assert not hasattr(result, "panel_receipt")
+
+
+# ---------------------------------------------------------------------------
+# AC: governance-bearing edit requests are rejected, not applied directly
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "edit_class",
+    sorted(GOVERNANCE_BEARING_EDIT_CLASSES),
+)
+def test_governance_bearing_edit_is_not_applied_directly(edit_class: str) -> None:
+    shell = _active_shell()
+    session = _active_session()
+    editor = CanvasBodyEditor()
+
+    request = BodyEditRequest(
+        artifact_id=ARTIFACT_ID,
+        new_body="governance mutation attempt",
+        edit_class=edit_class,
+    )
+    with pytest.raises(GovernanceBearingEditError):
+        editor.apply_edit(shell, session, request, session_id=SESSION_ID)
+
+    assert shell.body == "original body", "Body must not be mutated on governance-bearing edit"
+
+
+# ---------------------------------------------------------------------------
+# AC: direct body-edit path is separate from Canvas bounded suggestion apply path
+# ---------------------------------------------------------------------------
+
+
+def test_direct_body_edit_is_not_bounded_suggestion_flow() -> None:
+    """Canvas Core body-edit path must not reference suggestion flow concepts."""
+    import inspect
+    from companion_ui.canvas_core import body_edit as mod
+
+    src = inspect.getsource(mod)
+    assert "canvas_suggestion_flow" not in src
+    assert "suggestion_flow" not in src
+    assert "staged" not in src.lower() or "staged" not in src  # no staged-proposal language
+    assert "GovernanceBearingEditError" in src
+    assert "GOVERNANCE_BEARING_EDIT_CLASSES" in src

--- a/tests/companion_ui/test_canvas_escape_hatch.py
+++ b/tests/companion_ui/test_canvas_escape_hatch.py
@@ -1,0 +1,186 @@
+"""Tests for Canvas Core governance-bearing escape hatch routing (#1029).
+
+These tests verify that governance-bearing edit classes are classified correctly,
+blocked from the direct body-edit path, routed to the appropriate governed surface,
+and that the module does not couple to Canvas bounded suggestion flow internals.
+
+ACs from #1029:
+- test_frontmatter_change_routes_to_governed_path
+- test_cross_note_operation_routes_to_governed_path
+- test_lifecycle_operation_routes_to_governed_path
+- test_system_artifact_operation_blocked_from_canvas_core
+- test_ambiguous_operation_defaults_to_governance_bearing
+- test_escape_hatch_status_visible
+- test_escape_hatch_preserves_surface_distinctions
+"""
+
+import pytest
+
+from companion_ui.canvas_core.escape_hatch import (
+    GOVERNANCE_BEARING_CLASSES,
+    CanvasEscapeHatchRouter,
+    EscapeHatchResult,
+)
+
+
+# ---------------------------------------------------------------------------
+# AC: frontmatter/classification changes are rejected from direct path and routed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("edit_class", ["frontmatter", "classification"])
+def test_frontmatter_change_routes_to_governed_path(edit_class: str) -> None:
+    router = CanvasEscapeHatchRouter()
+    result = router.route(edit_class)
+
+    assert isinstance(result, EscapeHatchResult)
+    assert result.is_governance_bearing is True
+    assert result.route_target in ("canvas_bounded_suggestion", "panel", "governed_execution")
+    assert result.route_target != "none"
+    assert result.status_message
+    assert edit_class in GOVERNANCE_BEARING_CLASSES
+
+
+# ---------------------------------------------------------------------------
+# AC: cross-note operations are rejected from direct path and routed
+# ---------------------------------------------------------------------------
+
+
+def test_cross_note_operation_routes_to_governed_path() -> None:
+    router = CanvasEscapeHatchRouter()
+    result = router.route("cross_note")
+
+    assert result.is_governance_bearing is True
+    assert result.route_target == "governed_execution"
+    assert "cross_note" in GOVERNANCE_BEARING_CLASSES
+
+
+# ---------------------------------------------------------------------------
+# AC: note lifecycle operations are rejected from direct path and routed
+# ---------------------------------------------------------------------------
+
+
+def test_lifecycle_operation_routes_to_governed_path() -> None:
+    router = CanvasEscapeHatchRouter()
+    result = router.route("lifecycle")
+
+    assert result.is_governance_bearing is True
+    assert result.route_target == "panel"
+
+
+@pytest.mark.parametrize("edit_class", ["promotion", "commitment_state"])
+def test_lifecycle_adjacent_routes_to_panel(edit_class: str) -> None:
+    router = CanvasEscapeHatchRouter()
+    result = router.route(edit_class)
+
+    assert result.is_governance_bearing is True
+    assert result.route_target == "panel"
+
+
+# ---------------------------------------------------------------------------
+# AC: companion note, receipt, and system artifact operations are blocked
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "edit_class",
+    ["companion_note", "receipt", "system_artifact", "session_log"],
+)
+def test_system_artifact_operation_blocked_from_canvas_core(edit_class: str) -> None:
+    router = CanvasEscapeHatchRouter()
+    result = router.route(edit_class)
+
+    assert result.is_governance_bearing is True
+    assert result.route_target == "governed_execution"
+    assert edit_class in GOVERNANCE_BEARING_CLASSES
+
+
+# ---------------------------------------------------------------------------
+# AC: ambiguous operations default to governance-bearing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "edit_class",
+    ["unknown_class", "future_class_not_yet_defined", "", "some_ambiguous_op"],
+)
+def test_ambiguous_operation_defaults_to_governance_bearing(edit_class: str) -> None:
+    router = CanvasEscapeHatchRouter()
+    result = router.route(edit_class)
+
+    assert result.is_governance_bearing is True, (
+        f"Ambiguous edit class {edit_class!r} must default to governance-bearing"
+    )
+    assert result.route_target == "governed_execution"
+    assert result.status_message
+
+
+def test_safe_body_edit_is_not_governance_bearing() -> None:
+    router = CanvasEscapeHatchRouter()
+    result = router.route("body")
+
+    assert result.is_governance_bearing is False
+    assert result.route_target == "none"
+
+
+# ---------------------------------------------------------------------------
+# AC: routed/blocked status is visible and does not claim the action was applied
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("edit_class", sorted(GOVERNANCE_BEARING_CLASSES))
+def test_escape_hatch_status_visible(edit_class: str) -> None:
+    router = CanvasEscapeHatchRouter()
+    result = router.route(edit_class)
+
+    assert result.status_message, "status_message must be non-empty"
+    # These phrases positively claim the action was applied — must not appear.
+    positive_applied_phrases = (
+        "successfully applied",
+        "action was applied",
+        "has been applied",
+        "mutation was applied",
+        "edit was applied",
+        "change was applied",
+    )
+    lower_msg = result.status_message.lower()
+    for phrase in positive_applied_phrases:
+        assert phrase not in lower_msg, (
+            f"status_message must not claim the action was applied; got: {result.status_message!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC: routing boundary preserves distinction between Panel, Canvas bounded
+#     suggestion flow, and governed execution
+# ---------------------------------------------------------------------------
+
+
+def test_escape_hatch_preserves_surface_distinctions() -> None:
+    router = CanvasEscapeHatchRouter()
+
+    panel_result = router.route("lifecycle")
+    suggestion_result = router.route("frontmatter")
+    governed_result = router.route("cross_note")
+
+    assert panel_result.route_target == "panel"
+    assert suggestion_result.route_target == "canvas_bounded_suggestion"
+    assert governed_result.route_target == "governed_execution"
+
+    # All three targets are distinct.
+    targets = {panel_result.route_target, suggestion_result.route_target, governed_result.route_target}
+    assert len(targets) == 3, "All three route targets must be distinct"
+
+
+def test_escape_hatch_does_not_reference_suggestion_flow_internals() -> None:
+    """Escape hatch module must not couple to Canvas bounded suggestion flow internals."""
+    import inspect
+    from companion_ui.canvas_core import escape_hatch as mod
+
+    src = inspect.getsource(mod)
+    # The staging prototype HTML file must not be imported or referenced.
+    assert "canvas_suggestion_flow.html" not in src
+    assert "staged_body" not in src
+    assert "staged_governance" not in src
+    assert "SuggestionDiscard" not in src
+    assert "discard_suggestion" not in src

--- a/tests/companion_ui/test_canvas_session_provenance.py
+++ b/tests/companion_ui/test_canvas_session_provenance.py
@@ -1,0 +1,303 @@
+"""Tests for Canvas Core session provenance write/read integration (#1028).
+
+Session provenance is the append-only intent trail subordinate to the note.
+These tests verify open-at-start, append-during-session, undo marking, path
+exposure, interruption retention, and note-as-artifact primacy.
+
+ACs from #1028:
+- test_session_log_opened_at_session_start
+- test_session_log_appends_during_session
+- test_assistant_edit_summary_recorded
+- test_undone_edit_marker_recorded
+- test_session_log_path_exposed_for_inspection
+- test_interrupted_session_retains_provenance
+- test_provenance_is_subordinate_to_note
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from companion_ui.canvas_core.body_edit import AppliedEdit
+from companion_ui.canvas_core.session_provenance import CanvasSessionProvenance
+from companion_ui.canvas_core.undo_stack import UndoneEdit
+
+# ---------------------------------------------------------------------------
+# In-memory fake ProvenanceWriter (no file I/O, no app/ imports in tests)
+# Structurally matches SessionLogWriter API.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeSession:
+    log_path: Path
+    session_id: str
+
+
+@dataclass
+class _FakeWriter:
+    """In-memory test double for ProvenanceWriter / SessionLogWriter."""
+
+    _sessions: list[_FakeSession] = field(default_factory=list)
+    _turns: dict[str, list[dict]] = field(default_factory=dict)
+    _closures: dict[str, str] = field(default_factory=dict)
+
+    def open_session(self, note_path: Path, session_label: str) -> _FakeSession:
+        sid = f"fake-session-{len(self._sessions) + 1:03d}"
+        log_path = Path(f"/fake/.chats/{note_path.stem}/{session_label}.md")
+        sess = _FakeSession(log_path=log_path, session_id=sid)
+        self._sessions.append(sess)
+        self._turns[sid] = []
+        return sess
+
+    def append_turn(self, session: _FakeSession, user_prompt: str, change_summary: str) -> None:
+        self._turns[session.session_id].append(
+            {"user_prompt": user_prompt, "change_summary": change_summary}
+        )
+
+    def close_session(self, session: _FakeSession, total_summary: str) -> None:
+        self._closures[session.session_id] = total_summary
+
+    # --- test helpers ---
+
+    def turns_for(self, session_id: str) -> list[dict]:
+        return self._turns.get(session_id, [])
+
+    def is_closed(self, session_id: str) -> bool:
+        return session_id in self._closures
+
+
+NOTE_PATH = Path("/vault/notes/my-note.md")
+SESSION_LABEL = "editing-intro"
+
+
+def _make_provenance(writer: _FakeWriter | None = None) -> CanvasSessionProvenance:
+    return CanvasSessionProvenance(
+        writer=writer or _FakeWriter(),
+        note_path=NOTE_PATH,
+        session_label=SESSION_LABEL,
+    )
+
+
+def _applied_edit(edit_id: str = "e-001", session_id: str = "s-001") -> AppliedEdit:
+    return AppliedEdit(
+        edit_id=edit_id,
+        session_id=session_id,
+        artifact_id="note-test",
+        body_before="before",
+        body_after="after",
+        edit_summary="Rewrote intro",
+        user_prompt="Rewrite the intro",
+    )
+
+
+def _undone_edit(original: AppliedEdit) -> UndoneEdit:
+    return UndoneEdit(
+        undo_id="u-001",
+        session_id=original.session_id,
+        artifact_id=original.artifact_id,
+        original_edit=original,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC: Canvas session opens/creates a session log at session start
+# ---------------------------------------------------------------------------
+
+
+def test_session_log_opened_at_session_start() -> None:
+    writer = _FakeWriter()
+    prov = _make_provenance(writer)
+
+    assert prov.session_log_path is None, "Log path must not exist before open()"
+    prov.open()
+
+    assert prov.session_log_path is not None
+    assert prov.is_open
+    assert len(writer._sessions) == 1
+
+
+def test_open_raises_if_called_twice() -> None:
+    prov = _make_provenance()
+    prov.open()
+    with pytest.raises(RuntimeError):
+        prov.open()
+
+
+# ---------------------------------------------------------------------------
+# AC: Canvas session appends turn/edit summaries during the session (not only at close)
+# ---------------------------------------------------------------------------
+
+
+def test_session_log_appends_during_session() -> None:
+    writer = _FakeWriter()
+    prov = _make_provenance(writer)
+    prov.open()
+
+    sid = prov.session_id
+    assert len(writer.turns_for(sid)) == 0
+
+    edit = _applied_edit()
+    prov.record_edit(edit)
+    assert len(writer.turns_for(sid)) == 1
+
+    prov.record_edit(_applied_edit(edit_id="e-002"))
+    assert len(writer.turns_for(sid)) == 2
+
+    assert not writer.is_closed(sid), "Session must not be closed after recording turns"
+
+
+# ---------------------------------------------------------------------------
+# AC: assistant-applied body edits include provenance markers/summary
+# ---------------------------------------------------------------------------
+
+
+def test_assistant_edit_summary_recorded() -> None:
+    writer = _FakeWriter()
+    prov = _make_provenance(writer)
+    prov.open()
+
+    edit = _applied_edit(edit_id="e-abc")
+    prov.record_edit(edit)
+
+    turns = writer.turns_for(prov.session_id)
+    assert len(turns) == 1
+    turn = turns[0]
+    assert "e-abc" in turn["change_summary"], "Edit ID must appear in provenance"
+    assert "Rewrote intro" in turn["change_summary"]
+    assert turn["user_prompt"] == "Rewrite the intro"
+
+
+# ---------------------------------------------------------------------------
+# AC: undone assistant edits are marked in provenance without deleting history
+# ---------------------------------------------------------------------------
+
+
+def test_undone_edit_marker_recorded() -> None:
+    writer = _FakeWriter()
+    prov = _make_provenance(writer)
+    prov.open()
+
+    edit = _applied_edit(edit_id="e-001")
+    prov.record_edit(edit)
+
+    undone = _undone_edit(edit)
+    prov.record_undo(undone)
+
+    turns = writer.turns_for(prov.session_id)
+    assert len(turns) == 2, "Both the original edit and the undo must be recorded"
+
+    undo_turn = turns[1]
+    assert "undo" in undo_turn["change_summary"].lower()
+    assert "e-001" in undo_turn["change_summary"], "Original edit ID must appear in undo marker"
+    assert undo_turn["user_prompt"] == "(undo)"
+
+
+# ---------------------------------------------------------------------------
+# AC: UI/runtime exposes an inspectable session log path for the active session
+# ---------------------------------------------------------------------------
+
+
+def test_session_log_path_exposed_for_inspection() -> None:
+    prov = _make_provenance()
+    assert prov.session_log_path is None
+
+    prov.open()
+
+    path = prov.session_log_path
+    assert path is not None
+    assert isinstance(path, Path)
+
+    summary = prov.summary()
+    assert summary is not None
+    assert summary.session_log_path == path
+    assert summary.is_open
+
+
+# ---------------------------------------------------------------------------
+# AC: paused/interrupted sessions retain provenance up to interruption
+# ---------------------------------------------------------------------------
+
+
+def test_interrupted_session_retains_provenance() -> None:
+    writer = _FakeWriter()
+    prov = _make_provenance(writer)
+    prov.open()
+
+    edit = _applied_edit()
+    prov.record_edit(edit)
+
+    prov.record_interruption("paused")
+
+    sid = prov.session_id
+    turns = writer.turns_for(sid)
+    assert len(turns) == 2, "Edit and interruption marker must both be recorded"
+
+    interruption_turn = turns[1]
+    assert "paused" in interruption_turn["change_summary"]
+    assert not writer.is_closed(sid), "Session must not be auto-closed on interruption"
+
+
+def test_interrupted_session_provenance_not_lost() -> None:
+    writer = _FakeWriter()
+    prov = _make_provenance(writer)
+    prov.open()
+
+    prov.record_edit(_applied_edit(edit_id="e-1"))
+    prov.record_edit(_applied_edit(edit_id="e-2"))
+    prov.record_interruption("interrupted")
+
+    # After interruption, all previously recorded turns are still accessible.
+    turns = writer.turns_for(prov.session_id)
+    summaries = " ".join(t["change_summary"] for t in turns)
+    assert "e-1" in summaries
+    assert "e-2" in summaries
+
+
+# ---------------------------------------------------------------------------
+# AC: session provenance is subordinate to note artifact and not rendered as body
+# ---------------------------------------------------------------------------
+
+
+def test_provenance_is_subordinate_to_note() -> None:
+    """Provenance module must not treat session log as canonical body content."""
+    import inspect
+    from companion_ui.canvas_core import session_provenance as mod
+
+    src = inspect.getsource(mod)
+
+    assert "canonical" not in src or "subordinate" in src, (
+        "If 'canonical' appears, 'subordinate' must also appear to preserve framing"
+    )
+    assert "session_log" not in src.split("from")[0] or "subordinate" in src
+
+    # ProvenanceSummary must not carry a 'body' field — provenance is not body content.
+    from companion_ui.canvas_core.session_provenance import ProvenanceSummary
+    import dataclasses
+
+    field_names = {f.name for f in dataclasses.fields(ProvenanceSummary)}
+    assert "body" not in field_names
+    assert "artifact_body" not in field_names
+
+
+def test_provenance_record_operations_require_open() -> None:
+    prov = _make_provenance()
+
+    with pytest.raises(RuntimeError):
+        prov.record_edit(_applied_edit())
+
+    with pytest.raises(RuntimeError):
+        prov.record_undo(_undone_edit(_applied_edit()))
+
+    with pytest.raises(RuntimeError):
+        prov.record_interruption("paused")
+
+
+def test_provenance_close_requires_open() -> None:
+    prov = _make_provenance()
+
+    with pytest.raises(RuntimeError):
+        prov.close("done")

--- a/tests/companion_ui/test_canvas_session_recovery.py
+++ b/tests/companion_ui/test_canvas_session_recovery.py
@@ -1,0 +1,231 @@
+"""Tests for Canvas Core paused-session recovery payload (#1030).
+
+These tests verify that interrupted/paused Canvas sessions produce a recovery
+payload with the minimum data needed for safe re-entry, block new edits until
+recovery is complete, detect external body changes, and preserve existing
+provenance rather than creating a second canonical log.
+
+ACs from #1030:
+- test_interrupted_session_recovery_payload_contains_identity
+- test_recovery_payload_contains_body_version_marker
+- test_interrupted_session_blocks_new_edits_until_recovered
+- test_reentry_state_visible_for_interrupted_session
+- test_changed_artifact_requires_recovery_review
+- test_recovery_uses_existing_session_log_provenance
+"""
+
+from pathlib import Path
+
+import pytest
+
+from companion_ui.canvas_core.session_recovery import (
+    CanvasSessionRecovery,
+    RecoveryPayload,
+    RecoveryStatus,
+)
+
+SESSION_ID = "session-recovery-001"
+ARTIFACT_ID = "note-recovery-test"
+BODY_TEXT = "# Test Note\n\nOriginal body content."
+
+
+# ---------------------------------------------------------------------------
+# AC: interrupted session stores recovery payload with session id, artifact id, log path
+# ---------------------------------------------------------------------------
+
+
+def test_interrupted_session_recovery_payload_contains_identity() -> None:
+    recovery = CanvasSessionRecovery()
+    log_path = Path(".chats/test-note/2026-05-17T10-00-session.md")
+
+    payload = recovery.capture(
+        session_id=SESSION_ID,
+        artifact_id=ARTIFACT_ID,
+        body=BODY_TEXT,
+        session_log_path=log_path,
+    )
+
+    assert isinstance(payload, RecoveryPayload)
+    assert payload.session_id == SESSION_ID
+    assert payload.artifact_id == ARTIFACT_ID
+    assert payload.session_log_path == log_path
+
+
+def test_recovery_payload_accessible_via_property() -> None:
+    recovery = CanvasSessionRecovery()
+    payload = recovery.capture(
+        session_id=SESSION_ID,
+        artifact_id=ARTIFACT_ID,
+        body=BODY_TEXT,
+    )
+    assert recovery.payload is payload
+
+
+# ---------------------------------------------------------------------------
+# AC: recovery payload includes last known body version hash or conflict marker
+# ---------------------------------------------------------------------------
+
+
+def test_recovery_payload_contains_body_version_marker() -> None:
+    recovery = CanvasSessionRecovery()
+    payload = recovery.capture(
+        session_id=SESSION_ID,
+        artifact_id=ARTIFACT_ID,
+        body=BODY_TEXT,
+    )
+
+    assert payload.body_version_hash, "body_version_hash must be non-empty"
+    assert isinstance(payload.body_version_hash, str)
+
+
+def test_body_version_hash_differs_for_different_bodies() -> None:
+    recovery1 = CanvasSessionRecovery()
+    recovery2 = CanvasSessionRecovery()
+
+    payload1 = recovery1.capture(session_id=SESSION_ID, artifact_id=ARTIFACT_ID, body="body A")
+    payload2 = recovery2.capture(session_id=SESSION_ID, artifact_id=ARTIFACT_ID, body="body B")
+
+    assert payload1.body_version_hash != payload2.body_version_hash
+
+
+def test_body_version_hash_stable_for_same_body() -> None:
+    recovery1 = CanvasSessionRecovery()
+    recovery2 = CanvasSessionRecovery()
+
+    payload1 = recovery1.capture(session_id=SESSION_ID, artifact_id=ARTIFACT_ID, body=BODY_TEXT)
+    payload2 = recovery2.capture(session_id=SESSION_ID, artifact_id=ARTIFACT_ID, body=BODY_TEXT)
+
+    assert payload1.body_version_hash == payload2.body_version_hash
+
+
+# ---------------------------------------------------------------------------
+# AC: paused/interrupted session blocks new assistant body edits until recovery
+# ---------------------------------------------------------------------------
+
+
+def test_interrupted_session_blocks_new_edits_until_recovered() -> None:
+    recovery = CanvasSessionRecovery()
+    recovery.capture(session_id=SESSION_ID, artifact_id=ARTIFACT_ID, body=BODY_TEXT)
+
+    assert recovery.blocks_new_edits is True, (
+        "New edits must be blocked until recovery is complete"
+    )
+
+    recovery.mark_recovered()
+    assert recovery.blocks_new_edits is False, (
+        "New edits must be allowed after recovery is marked complete"
+    )
+
+
+def test_no_payload_means_no_block() -> None:
+    recovery = CanvasSessionRecovery()
+    assert recovery.blocks_new_edits is False
+
+
+# ---------------------------------------------------------------------------
+# AC: UI/runtime exposes a re-entry state for interrupted session
+# ---------------------------------------------------------------------------
+
+
+def test_reentry_state_visible_for_interrupted_session() -> None:
+    recovery = CanvasSessionRecovery()
+    assert recovery.reentry_state == "not_captured"
+
+    recovery.capture(session_id=SESSION_ID, artifact_id=ARTIFACT_ID, body=BODY_TEXT)
+    assert recovery.reentry_state == "needs_review"
+
+    recovery.mark_recovered()
+    assert recovery.reentry_state == "recovered"
+
+
+def test_reentry_state_conflict_detected() -> None:
+    recovery = CanvasSessionRecovery()
+    recovery.capture(session_id=SESSION_ID, artifact_id=ARTIFACT_ID, body=BODY_TEXT)
+
+    recovery.check_for_conflict("# Externally Modified\n\nDifferent content.")
+    assert recovery.reentry_state == "conflict_detected"
+    assert recovery.blocks_new_edits is True
+
+
+# ---------------------------------------------------------------------------
+# AC: recovery detects changed artifact body and surfaces conflict rather than
+#     silently applying stale edits
+# ---------------------------------------------------------------------------
+
+
+def test_changed_artifact_requires_recovery_review() -> None:
+    recovery = CanvasSessionRecovery()
+    recovery.capture(session_id=SESSION_ID, artifact_id=ARTIFACT_ID, body=BODY_TEXT)
+
+    status = recovery.check_for_conflict("# Externally changed body")
+
+    assert status == RecoveryStatus.CONFLICT_DETECTED
+    assert recovery.recovery_status == RecoveryStatus.CONFLICT_DETECTED
+
+
+def test_unchanged_artifact_stays_needs_review() -> None:
+    recovery = CanvasSessionRecovery()
+    recovery.capture(session_id=SESSION_ID, artifact_id=ARTIFACT_ID, body=BODY_TEXT)
+
+    status = recovery.check_for_conflict(BODY_TEXT)
+
+    assert status == RecoveryStatus.NEEDS_REVIEW
+
+
+def test_conflict_detected_still_blocks_edits() -> None:
+    recovery = CanvasSessionRecovery()
+    recovery.capture(session_id=SESSION_ID, artifact_id=ARTIFACT_ID, body=BODY_TEXT)
+    recovery.check_for_conflict("changed body")
+
+    assert recovery.blocks_new_edits is True
+
+
+def test_mark_recovered_without_capture_raises() -> None:
+    recovery = CanvasSessionRecovery()
+    with pytest.raises(RuntimeError, match="capture"):
+        recovery.mark_recovered()
+
+
+def test_check_for_conflict_without_capture_raises() -> None:
+    recovery = CanvasSessionRecovery()
+    with pytest.raises(RuntimeError, match="capture"):
+        recovery.check_for_conflict("body")
+
+
+# ---------------------------------------------------------------------------
+# AC: recovery preserves append-during-session provenance and does not create
+#     a second canonical transcript
+# ---------------------------------------------------------------------------
+
+
+def test_recovery_uses_existing_session_log_provenance() -> None:
+    """Recovery must use the session log path already opened by the provenance writer.
+
+    It must not open a second log.  The session_log_path in the payload is the
+    same path as the one the provenance writer opened at session start.
+    """
+    existing_log_path = Path(".chats/test-note/2026-05-17T10-00-session.md")
+
+    recovery = CanvasSessionRecovery()
+    payload = recovery.capture(
+        session_id=SESSION_ID,
+        artifact_id=ARTIFACT_ID,
+        body=BODY_TEXT,
+        session_log_path=existing_log_path,
+    )
+
+    assert payload.session_log_path == existing_log_path, (
+        "Recovery payload must carry the existing provenance log path, not open a new one"
+    )
+
+
+def test_recovery_payload_carries_pending_edit_count() -> None:
+    recovery = CanvasSessionRecovery()
+    payload = recovery.capture(
+        session_id=SESSION_ID,
+        artifact_id=ARTIFACT_ID,
+        body=BODY_TEXT,
+        applied_edit_count=3,
+    )
+
+    assert payload.pending_edit_count == 3

--- a/tests/companion_ui/test_canvas_undo_stack.py
+++ b/tests/companion_ui/test_canvas_undo_stack.py
@@ -1,0 +1,202 @@
+"""Tests for Canvas Core undo stack (#1027).
+
+Undo is the rollback path for direct body co-authoring edits in an active
+Canvas session.  These tests verify session-scope, artifact-scope, provenance
+preservation, and distinction from bounded-suggestion discard.
+
+ACs from #1027:
+- test_assistant_edits_recorded_in_undo_stack
+- test_undo_reverts_latest_assistant_body_edit
+- test_undo_is_session_scoped
+- test_undo_is_artifact_scoped
+- test_undo_preserves_provenance_marker
+- test_undo_is_not_bounded_suggestion_discard
+"""
+
+import pytest
+
+from companion_ui.canvas_core.active_artifact_shell import CanvasArtifactShell
+from companion_ui.canvas_core.body_edit import (
+    AppliedEdit,
+    BodyEditRequest,
+    CanvasBodyEditor,
+)
+from companion_ui.canvas_core.undo_stack import CanvasUndoStack, UndoneEdit
+
+SESSION_ID = "session-undo-001"
+OTHER_SESSION_ID = "session-other-999"
+ARTIFACT_ID = "note-undo"
+OTHER_ARTIFACT_ID = "note-other"
+
+
+def _active_shell(artifact_id: str = ARTIFACT_ID, body: str = "original") -> CanvasArtifactShell:
+    from companion_ui.canvas_core.session_state import CanvasSessionState
+
+    _ = CanvasSessionState(artifact_id=artifact_id)
+    return CanvasArtifactShell(
+        artifact_id=artifact_id,
+        artifact_title="Undo Test Note",
+        body=body,
+    )
+
+
+def _make_edit(
+    body_before: str = "before",
+    body_after: str = "after",
+    session_id: str = SESSION_ID,
+    artifact_id: str = ARTIFACT_ID,
+) -> AppliedEdit:
+    return AppliedEdit(
+        edit_id="edit-001",
+        session_id=session_id,
+        artifact_id=artifact_id,
+        body_before=body_before,
+        body_after=body_after,
+        edit_summary="test edit",
+        user_prompt="test prompt",
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC: assistant-applied body edits are recorded in an undo stack for the session
+# ---------------------------------------------------------------------------
+
+
+def test_assistant_edits_recorded_in_undo_stack() -> None:
+    stack = CanvasUndoStack(session_id=SESSION_ID, artifact_id=ARTIFACT_ID)
+    edit1 = _make_edit(body_before="v0", body_after="v1")
+    edit2 = _make_edit(body_before="v1", body_after="v2")
+
+    stack.push(edit1)
+    stack.push(edit2)
+
+    assert stack.can_undo
+    assert len(stack.applied_edits) == 2
+    assert stack.applied_edits[0].body_after == "v1"
+    assert stack.applied_edits[1].body_after == "v2"
+
+
+# ---------------------------------------------------------------------------
+# AC: undo reverts the latest assistant-applied body edit for the active artifact
+# ---------------------------------------------------------------------------
+
+
+def test_undo_reverts_latest_assistant_body_edit() -> None:
+    shell = _active_shell(body="v1")
+    stack = CanvasUndoStack(session_id=SESSION_ID, artifact_id=ARTIFACT_ID)
+    edit = _make_edit(body_before="original", body_after="v1")
+    stack.push(edit)
+
+    undone = stack.undo(shell)
+
+    assert shell.body == "original", "Body must be reverted to pre-edit state"
+    assert isinstance(undone, UndoneEdit)
+    assert undone.original_edit is edit
+    assert not stack.can_undo
+
+
+def test_undo_reverts_latest_edit_when_multiple_pushed() -> None:
+    shell = _active_shell(body="v2")
+    stack = CanvasUndoStack(session_id=SESSION_ID, artifact_id=ARTIFACT_ID)
+
+    edit1 = AppliedEdit(
+        edit_id="e1", session_id=SESSION_ID, artifact_id=ARTIFACT_ID,
+        body_before="v0", body_after="v1", edit_summary="", user_prompt="",
+    )
+    edit2 = AppliedEdit(
+        edit_id="e2", session_id=SESSION_ID, artifact_id=ARTIFACT_ID,
+        body_before="v1", body_after="v2", edit_summary="", user_prompt="",
+    )
+    stack.push(edit1)
+    stack.push(edit2)
+
+    undone = stack.undo(shell)
+    assert shell.body == "v1"
+    assert undone.original_edit.edit_id == "e2"
+    assert stack.can_undo  # edit1 still present
+
+    undone2 = stack.undo(shell)
+    assert shell.body == "v0"
+    assert undone2.original_edit.edit_id == "e1"
+    assert not stack.can_undo
+
+
+# ---------------------------------------------------------------------------
+# AC: undo is scoped to active session and cannot undo edits from another session
+# ---------------------------------------------------------------------------
+
+
+def test_undo_is_session_scoped() -> None:
+    stack = CanvasUndoStack(session_id=SESSION_ID, artifact_id=ARTIFACT_ID)
+    foreign_edit = _make_edit(session_id=OTHER_SESSION_ID)
+
+    with pytest.raises(ValueError, match="session_id"):
+        stack.push(foreign_edit)
+
+
+# ---------------------------------------------------------------------------
+# AC: undo is scoped to active artifact and cannot affect another note/artifact
+# ---------------------------------------------------------------------------
+
+
+def test_undo_is_artifact_scoped() -> None:
+    stack = CanvasUndoStack(session_id=SESSION_ID, artifact_id=ARTIFACT_ID)
+    foreign_edit = _make_edit(artifact_id=OTHER_ARTIFACT_ID)
+
+    with pytest.raises(ValueError, match="artifact_id"):
+        stack.push(foreign_edit)
+
+
+def test_undo_rejects_shell_from_different_artifact() -> None:
+    stack = CanvasUndoStack(session_id=SESSION_ID, artifact_id=ARTIFACT_ID)
+    stack.push(_make_edit())
+
+    wrong_shell = _active_shell(artifact_id=OTHER_ARTIFACT_ID)
+    with pytest.raises(ValueError, match="artifact_id"):
+        stack.undo(wrong_shell)
+
+
+def test_undo_raises_when_stack_empty() -> None:
+    stack = CanvasUndoStack(session_id=SESSION_ID, artifact_id=ARTIFACT_ID)
+    shell = _active_shell()
+
+    with pytest.raises(IndexError):
+        stack.undo(shell)
+
+
+# ---------------------------------------------------------------------------
+# AC: undo creates/marks provenance for an undone edit rather than deleting history
+# ---------------------------------------------------------------------------
+
+
+def test_undo_preserves_provenance_marker() -> None:
+    shell = _active_shell(body="v1")
+    stack = CanvasUndoStack(session_id=SESSION_ID, artifact_id=ARTIFACT_ID)
+    edit = _make_edit(body_before="original", body_after="v1")
+    stack.push(edit)
+
+    undone = stack.undo(shell)
+
+    assert undone in stack.undone_edits, "UndoneEdit must be in undone_edits list"
+    assert undone.original_edit == edit, "Original edit must be preserved in UndoneEdit"
+    assert undone.undo_id, "undo_id must be non-empty"
+    assert undone.session_id == SESSION_ID
+    assert undone.artifact_id == ARTIFACT_ID
+
+
+# ---------------------------------------------------------------------------
+# AC: undo is distinct from Canvas bounded suggestion discard
+# ---------------------------------------------------------------------------
+
+
+def test_undo_is_not_bounded_suggestion_discard() -> None:
+    """Canvas Core undo stack must not couple to suggestion flow concepts."""
+    import inspect
+    from companion_ui.canvas_core import undo_stack as mod
+
+    src = inspect.getsource(mod)
+    assert "canvas_suggestion_flow" not in src
+    assert "suggestion_flow" not in src
+    # The module must not import or invoke bounded-suggestion discard logic.
+    assert "SuggestionDiscard" not in src
+    assert "discard_suggestion" not in src

--- a/tests/companion_ui/test_canvas_undo_stack.py
+++ b/tests/companion_ui/test_canvas_undo_stack.py
@@ -16,11 +16,7 @@ ACs from #1027:
 import pytest
 
 from companion_ui.canvas_core.active_artifact_shell import CanvasArtifactShell
-from companion_ui.canvas_core.body_edit import (
-    AppliedEdit,
-    BodyEditRequest,
-    CanvasBodyEditor,
-)
+from companion_ui.canvas_core.body_edit import AppliedEdit
 from companion_ui.canvas_core.undo_stack import CanvasUndoStack, UndoneEdit
 
 SESSION_ID = "session-undo-001"

--- a/tests/companion_ui/test_canvas_undo_stack.py
+++ b/tests/companion_ui/test_canvas_undo_stack.py
@@ -17,7 +17,7 @@ import pytest
 
 from companion_ui.canvas_core.active_artifact_shell import CanvasArtifactShell
 from companion_ui.canvas_core.body_edit import AppliedEdit
-from companion_ui.canvas_core.undo_stack import CanvasUndoStack, UndoneEdit
+from companion_ui.canvas_core.undo_stack import CanvasUndoStack, UndoDivergenceError, UndoneEdit
 
 SESSION_ID = "session-undo-001"
 OTHER_SESSION_ID = "session-other-999"
@@ -196,3 +196,35 @@ def test_undo_is_not_bounded_suggestion_discard() -> None:
     # The module must not import or invoke bounded-suggestion discard logic.
     assert "SuggestionDiscard" not in src
     assert "discard_suggestion" not in src
+
+
+# ---------------------------------------------------------------------------
+# Review fix: undo surfaces conflict when body has diverged since assistant edit
+# ---------------------------------------------------------------------------
+
+
+def test_undo_raises_divergence_error_when_body_changed_after_edit() -> None:
+    shell = _active_shell(body="v1")
+    stack = CanvasUndoStack(session_id=SESSION_ID, artifact_id=ARTIFACT_ID)
+    edit = _make_edit(body_before="original", body_after="v1")
+    stack.push(edit)
+
+    shell.body = "v1 plus user keystroke"
+
+    with pytest.raises(UndoDivergenceError):
+        stack.undo(shell)
+
+    assert shell.body == "v1 plus user keystroke", "Body must not be mutated when undo diverges"
+    assert stack.can_undo, "Edit must remain on stack after divergence error"
+
+
+def test_undo_succeeds_when_body_matches_edit_after() -> None:
+    shell = _active_shell(body="v1")
+    stack = CanvasUndoStack(session_id=SESSION_ID, artifact_id=ARTIFACT_ID)
+    edit = _make_edit(body_before="original", body_after="v1")
+    stack.push(edit)
+
+    undone = stack.undo(shell)
+
+    assert shell.body == "original"
+    assert isinstance(undone, UndoneEdit)


### PR DESCRIPTION
## Summary

Complete Canvas Core MVP — the minimum co-authoring surface contract for direct in-place note body editing during a user-present Canvas session.

Canvas Core is the primary reason Companion UI exists: it provides the live-editor environment (session context, undo stack, active-user-presence signal, provenance trail, and governance escape hatch) that plain Obsidian markdown cannot provide without plugin-level UI infrastructure.

This PR delivers all five Canvas Core issues across three batches, plus post-review fixes:

**Batch A (PR #1032, already in main):** Scaffold and shell foundation.
- Session lifecycle state machine (`session_state.py`, #1024)
- Active artifact body shell with layout regions (`active_artifact_shell.py`, #1025)

**Batch B (PR #1033):** Direct edit loop.
- `body_edit.py` — `CanvasBodyEditor.apply_edit()` enforces active/user-present session state, blocks governance-bearing and ambiguous edit classes via `SAFE_EDIT_CLASSES` allowlist, binds session/shell/request to the same artifact, applies body mutation in place on `CanvasArtifactShell`, returns `AppliedEdit` with full undo+provenance metadata. (#1026)
- `undo_stack.py` — `CanvasUndoStack`: session-scoped, artifact-scoped, history-preserving undo. Detects body divergence (intervening user keystrokes) before reverting via `UndoDivergenceError`. Undone edits remain in `undone_edits` for provenance. (#1027)
- `session_provenance.py` — `CanvasSessionProvenance` wraps a `ProvenanceWriter` protocol (structurally compatible with `app/chat/session_log.py`) without hard-importing `app/`. Open at session start, append per edit/undo/interruption, close at session close. Note remains canonical. (#1028)

**Batch C (PR #1034):** Safety and re-entry.
- `escape_hatch.py` — `CanvasEscapeHatchRouter` classifies all operations against `GOVERNANCE_BEARING_CLASSES` (10 named classes), routes to the appropriate governed surface (`panel` / `canvas_bounded_suggestion` / `governed_execution`), returns `EscapeHatchResult` with visible status. Ambiguous classes default to `governed_execution`. (#1029)
- `session_recovery.py` — `CanvasSessionRecovery` captures the minimum re-entry payload (session/artifact identity, SHA-256 body version hash, existing session log path, pending edit count). Conflict detection on re-entry: body changes during interruption surface `CONFLICT_DETECTED` rather than silently accepting stale edits. `blocks_new_edits` gates new co-authoring until `mark_recovered()` is called. (#1030)

**Review fixes (commit 04bae39):** Three Codex review comments addressed.
- P1: `body_edit.py` — switched from governance blocklist to `SAFE_EDIT_CLASSES = {"body"}` allowlist. Any edit class outside the allowlist (including `classification`, `commitment_state`, and any future/ambiguous class) is rejected. `GOVERNANCE_BEARING_EDIT_CLASSES` expanded to 10 named classes for documentation and routing.
- P2: `body_edit.py` — added session/shell artifact binding: `apply_edit()` verifies `shell.artifact_id == session.artifact_id` before touching the body. A session for note A cannot drive edits on a shell for note B.
- P2: `undo_stack.py` — added `UndoDivergenceError` and pre-revert body check: `undo()` detects `shell.body != edit.body_after` (intervening user keystroke), restores the edit to the stack, and raises rather than silently overwriting user work.

## Issues closed

- Closes #1026 — canvas-core: assistant direct body-edit apply path
- Closes #1027 — canvas-core: undo stack for assistant-applied body edits
- Closes #1028 — canvas-core: session provenance write/read integration
- Closes #1029 — canvas-core: governance-bearing escape hatch routing
- Closes #1030 — canvas-core: paused-session recovery payload
- Advances #1022 — [Epic] Companion UI / UX surface implementation map

## Surface boundary

Canvas Core only. Not Panel (#1019/#995/#996). Not Canvas bounded suggestion flow (#868–#874). `canvas_suggestion_flow.html` staging prototype is non-production and untouched throughout.

## Owner doc / writeback assessment

No existing owner doc needed updating — the Canvas Agent MVP Contract (`companion-ui/docs/CANVAS_AGENT_MVP_CONTRACT.md`) already describes the shipped reality. `canvas_core/__init__.py` updated with a module index for discoverability.

## Validation commands

```bash
git diff --check                                                                               # clean
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_canvas_direct_body_edit.py    # 25 passed
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_canvas_undo_stack.py          # 11 passed
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_canvas_session_provenance.py  # 13 passed
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_canvas_escape_hatch.py        # 43 passed
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_canvas_session_recovery.py    # 16 passed
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/ tests/architecture/               # 186 passed, 0 failed
```

## Full-smoke rationale

Full smoke not required. All Canvas Core modules are isolated UI-layer Python helpers inside `companion_ui/canvas_core/`. No runtime startup changes, no backend API wiring, no real vault write paths, no watcher execution, no DB/migrations/DSNs, no environment or release-channel behavior, no production/stable promotion. Standard library only (`hashlib`, `pathlib`, `dataclasses`, `uuid`, `typing`).

## Remaining follow-up

- **Panel surface** (#1019/#995/#996): escape-hatch routing declares `"panel"` as a route target but Panel UI and confirmation writeback are separate work streams.
- **Canvas bounded suggestion flow** (#868–#874): escape-hatch routing declares `"canvas_bounded_suggestion"` as a route target but the staged suggestion UI remains its own work stream.
- **Vault-write re-entry**: `session_recovery.py` provides the recovery payload contract; live Obsidian/vault-write integration on re-entry is deferred to later milestones.
- **Session recovery conflict resolution**: conflict is detected and surfaced; the merge/resolution UI is deferred.