### PR TITLE
feat(panel-ui): add Panel visual shell stub

### DIFF
--- a/companion-ui/companion-app/companion_ui/panel/visual_shell.py
+++ b/companion-ui/companion-app/companion_ui/panel/visual_shell.py
@@ -1,0 +1,207 @@
+"""Panel visual shell stub — renderer-agnostic shell model (#1045).
+
+Prototype/staging only.  Not production.  Stub/in-memory data.
+No runtime endpoint calls.  No vault writes.  No Canvas Core imports.
+
+This module assembles a PanelShellView from the existing Panel model layer
+(render_model, proposal_row, interactions) and exposes the 8 required Panel
+states with stub data so a renderer layer (HTML, CLI, or test) can consume
+a single dict without knowing the underlying models.
+
+Boundary:
+- Panel in Companion UI only.
+- NOT Canvas Core.  NOT Canvas bounded suggestion flow.
+- No runtime calls.  No vault writes.  Stub data only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional
+
+from companion_ui.panel.render_model import PanelRenderState, render_panel_state
+from companion_ui.panel.proposal_row import (
+    ProposalRow,
+    ProposalReceipt,
+    ProposalEvidence,
+    make_stub_proposal_row,
+    make_stub_receipt,
+)
+from companion_ui.panel.interactions import (
+    PanelInteractionSession,
+    ProposalInteractionState,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shell view dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PanelShellView:
+    """Renderer-agnostic view snapshot for the Panel surface.
+
+    Consumers (HTML renderer, test, CLI) read this dict-serialisable
+    snapshot without calling model internals directly.
+
+    All data is stub/in-memory.  No runtime calls are made.
+    """
+
+    render: dict
+    proposals: list[dict] = field(default_factory=list)
+    receipts: list[dict] = field(default_factory=list)
+    interaction_summary: Optional[dict] = None
+
+    def as_dict(self) -> dict:
+        return {
+            "render": self.render,
+            "proposals": self.proposals,
+            "receipts": self.receipts,
+            "interaction_summary": self.interaction_summary,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Stub fixture builders (in-memory, no network/vault)
+# ---------------------------------------------------------------------------
+
+
+def _stub_proposals(artifact_id: str) -> list[ProposalRow]:
+    return [
+        make_stub_proposal_row(
+            proposal_id="prop-001",
+            artifact_id=artifact_id,
+            description="Move note to Projects",
+            cognition_route="rule",
+        ),
+        make_stub_proposal_row(
+            proposal_id="prop-002",
+            artifact_id=artifact_id,
+            description="Add #active tag",
+            cognition_route="llm",
+        ),
+    ]
+
+
+def _stub_receipt(artifact_id: str, outcome: str = "success") -> ProposalReceipt:
+    return make_stub_receipt(
+        proposal_id="prop-001",
+        artifact_id=artifact_id,
+        action_taken="lifecycle.move",
+        outcome=outcome,
+        message="Note moved to Projects/Q2-arch.md" if outcome == "success" else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-state shell view builders
+# ---------------------------------------------------------------------------
+
+
+def build_idle_view(artifact_id: str) -> PanelShellView:
+    rs = PanelRenderState(artifact_id=artifact_id, state="idle")
+    return PanelShellView(render=render_panel_state(rs))
+
+
+def build_running_view(artifact_id: str) -> PanelShellView:
+    rs = PanelRenderState(artifact_id=artifact_id, state="running")
+    return PanelShellView(render=render_panel_state(rs))
+
+
+def build_proposals_staged_view(artifact_id: str) -> PanelShellView:
+    proposals = _stub_proposals(artifact_id)
+    rs = PanelRenderState(
+        artifact_id=artifact_id,
+        state="proposals-staged",
+        proposal_count=len(proposals),
+    )
+    session = PanelInteractionSession(artifact_id=artifact_id)
+    for p in proposals:
+        session.register_proposal(p.proposal_id)
+    return PanelShellView(
+        render=render_panel_state(rs),
+        proposals=[p.as_render_dict() for p in proposals],
+        interaction_summary=session.summary(),
+    )
+
+
+def build_confirming_view(artifact_id: str) -> PanelShellView:
+    proposals = _stub_proposals(artifact_id)
+    rs = PanelRenderState(
+        artifact_id=artifact_id,
+        state="confirming",
+        proposal_count=len(proposals),
+    )
+    session = PanelInteractionSession(artifact_id=artifact_id)
+    for p in proposals:
+        s = session.register_proposal(p.proposal_id)
+    # Simulate user confirming prop-001
+    session.get("prop-001").confirm()
+    return PanelShellView(
+        render=render_panel_state(rs),
+        proposals=[p.as_render_dict() for p in proposals],
+        interaction_summary=session.summary(),
+    )
+
+
+def build_executing_view(artifact_id: str) -> PanelShellView:
+    rs = PanelRenderState(artifact_id=artifact_id, state="executing")
+    return PanelShellView(render=render_panel_state(rs))
+
+
+def build_receipt_displayed_view(artifact_id: str) -> PanelShellView:
+    rs = PanelRenderState(artifact_id=artifact_id, state="receipt-displayed")
+    receipt = _stub_receipt(artifact_id, outcome="success")
+    return PanelShellView(
+        render=render_panel_state(rs),
+        receipts=[receipt.as_render_dict()],
+    )
+
+
+def build_no_match_view(artifact_id: str, reason: Optional[str] = None) -> PanelShellView:
+    msg = reason or "Panel ran but found no actionable proposals for this note."
+    rs = PanelRenderState(artifact_id=artifact_id, state="no-match", message=msg)
+    return PanelShellView(render=render_panel_state(rs))
+
+
+def build_blocked_view(artifact_id: str, reason: Optional[str] = None) -> PanelShellView:
+    msg = reason or "Execution blocked: WriteGuard denied (tag allowlist)."
+    rs = PanelRenderState(artifact_id=artifact_id, state="blocked", message=msg)
+    receipt = _stub_receipt(artifact_id, outcome="blocked")
+    return PanelShellView(
+        render=render_panel_state(rs),
+        receipts=[receipt.as_render_dict()],
+    )
+
+
+# ---------------------------------------------------------------------------
+# All-states stub catalogue (for visual inspection and tests)
+# ---------------------------------------------------------------------------
+
+
+_PANEL_SHELL_BUILDERS: dict[str, object] = {
+    "idle": build_idle_view,
+    "running": build_running_view,
+    "proposals-staged": build_proposals_staged_view,
+    "confirming": build_confirming_view,
+    "executing": build_executing_view,
+    "receipt-displayed": build_receipt_displayed_view,
+    "no-match": build_no_match_view,
+    "blocked": build_blocked_view,
+}
+
+REQUIRED_PANEL_STATES: frozenset[str] = frozenset(_PANEL_SHELL_BUILDERS)
+
+
+def build_all_states(artifact_id: str = "note-stub-a") -> dict[str, PanelShellView]:
+    """Build stub shell views for all 8 required Panel states.
+
+    Returns a mapping state_name → PanelShellView.
+    Stub/in-memory only.  No runtime calls.
+    """
+    return {
+        state: builder(artifact_id)  # type: ignore[operator]
+        for state, builder in _PANEL_SHELL_BUILDERS.items()
+    }

--- a/companion-ui/companion-app/companion_ui/panel/visual_shell.py
+++ b/companion-ui/companion-app/companion_ui/panel/visual_shell.py
@@ -96,6 +96,28 @@ def _stub_receipt(artifact_id: str, outcome: str = "success") -> ProposalReceipt
 
 
 # ---------------------------------------------------------------------------
+# Interaction-aware proposal render helper
+# ---------------------------------------------------------------------------
+
+
+def _proposal_render_dict_with_interaction(
+    row: ProposalRow,
+    interaction: ProposalInteractionState,
+) -> dict:
+    """Merge ProposalRow render dict with live interaction state.
+
+    Affordances are suppressed when the interaction is awaiting the runtime or
+    is terminal, preventing duplicate confirm/reject actions on in-flight rows.
+    """
+    d = row.as_render_dict()
+    if interaction.awaiting_runtime or interaction.is_terminal:
+        d["affordances"] = {"confirm": False, "correct": False, "reject": False}
+    d["interaction_state"] = interaction.state
+    d["user_action_required"] = interaction.user_action_required
+    return d
+
+
+# ---------------------------------------------------------------------------
 # Per-state shell view builders
 # ---------------------------------------------------------------------------
 
@@ -141,7 +163,10 @@ def build_confirming_view(artifact_id: str) -> PanelShellView:
     session.get("prop-001").confirm()
     return PanelShellView(
         render=render_panel_state(rs),
-        proposals=[p.as_render_dict() for p in proposals],
+        proposals=[
+            _proposal_render_dict_with_interaction(p, session.get(p.proposal_id))
+            for p in proposals
+        ],
         interaction_summary=session.summary(),
     )
 

--- a/companion-ui/companion-app/panel_visual_shell.html
+++ b/companion-ui/companion-app/panel_visual_shell.html
@@ -1,0 +1,505 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Panel Visual Shell — Companion UI Staging (PROTOTYPE)</title>
+  <!--
+    PROTOTYPE / STAGING — non-production.
+    Renders all 8 required Panel states with stub/in-memory data only.
+    No runtime endpoint calls.  No vault writes.  No Canvas Core imports.
+    Closes #1045.  Governed by companion-ui/docs/PANEL_COMPANION_UI_CONTRACT.md.
+
+    Surface boundary:
+      Panel in Companion UI only.
+      NOT Canvas Core.  NOT Canvas bounded suggestion flow.
+      Stub data only.  Confirm/correct/reject affordances are slots only —
+      no POST /api/panel/confirm wiring in this file.
+  -->
+  <link rel="stylesheet" href="./colors_and_type.css" />
+  <style>
+    /* ----------------------------------------------------------------
+       Panel shell variables
+    ---------------------------------------------------------------- */
+    :root {
+      --panel-bg:          #1a1a2e;
+      --panel-surface:     #16213e;
+      --panel-border:      #0f3460;
+      --panel-accent:      #e94560;
+      --panel-accent-ok:   #2ecc71;
+      --panel-accent-warn: #f39c12;
+      --panel-accent-err:  #e74c3c;
+      --panel-text:        #eaeaea;
+      --panel-muted:       #888;
+      --panel-radius:      8px;
+      --panel-gap:         16px;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: "Inter", system-ui, sans-serif;
+      font-size: 14px;
+      background: var(--panel-bg);
+      color: var(--panel-text);
+      padding: var(--panel-gap);
+    }
+
+    h1 { font-size: 1.1rem; margin-bottom: 4px; }
+    .prototype-banner {
+      background: var(--panel-accent);
+      color: #fff;
+      font-size: 0.75rem;
+      font-weight: 700;
+      padding: 4px 10px;
+      border-radius: 4px;
+      display: inline-block;
+      margin-bottom: 20px;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+
+    /* ----------------------------------------------------------------
+       State grid
+    ---------------------------------------------------------------- */
+    .state-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+      gap: var(--panel-gap);
+    }
+
+    /* ----------------------------------------------------------------
+       Panel card
+    ---------------------------------------------------------------- */
+    .panel-card {
+      background: var(--panel-surface);
+      border: 1px solid var(--panel-border);
+      border-radius: var(--panel-radius);
+      overflow: hidden;
+    }
+
+    .panel-card-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 14px;
+      border-bottom: 1px solid var(--panel-border);
+      font-size: 0.72rem;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: var(--panel-muted);
+    }
+
+    .panel-card-header .state-badge {
+      font-family: monospace;
+      color: var(--panel-accent);
+    }
+
+    .panel-card-body { padding: 14px; }
+
+    /* ----------------------------------------------------------------
+       Panel state label row
+    ---------------------------------------------------------------- */
+    .panel-state-label {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 10px;
+      font-size: 0.9rem;
+      font-weight: 600;
+    }
+
+    .spinner {
+      width: 14px; height: 14px;
+      border: 2px solid var(--panel-border);
+      border-top-color: var(--panel-accent);
+      border-radius: 50%;
+      animation: spin 0.7s linear infinite;
+      flex-shrink: 0;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+
+    .icon { font-size: 1rem; line-height: 1; }
+
+    /* ----------------------------------------------------------------
+       Artifact context bar
+    ---------------------------------------------------------------- */
+    .artifact-context {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 10px;
+      background: rgba(255,255,255,0.04);
+      border-radius: 4px;
+      margin-bottom: 12px;
+      font-size: 0.75rem;
+      color: var(--panel-muted);
+    }
+    .artifact-context strong { color: var(--panel-text); }
+
+    /* ----------------------------------------------------------------
+       Proposal row
+    ---------------------------------------------------------------- */
+    .proposal-list { display: flex; flex-direction: column; gap: 10px; }
+
+    .proposal-row {
+      background: rgba(255,255,255,0.03);
+      border: 1px solid var(--panel-border);
+      border-radius: 6px;
+      padding: 10px 12px;
+    }
+
+    .proposal-description {
+      font-size: 0.875rem;
+      margin-bottom: 6px;
+    }
+
+    .proposal-evidence {
+      font-size: 0.72rem;
+      color: var(--panel-muted);
+      margin-bottom: 8px;
+    }
+
+    .affordance-row {
+      display: flex;
+      gap: 6px;
+      flex-wrap: wrap;
+    }
+
+    /* Affordance buttons are slots — no onclick wiring in this stub */
+    .btn {
+      font-size: 0.75rem;
+      padding: 4px 10px;
+      border-radius: 4px;
+      border: 1px solid transparent;
+      cursor: not-allowed;   /* stub: not wired */
+      font-weight: 600;
+      opacity: 0.85;
+    }
+    .btn:hover { opacity: 1; }
+    .btn[data-affordance="confirm"] {
+      background: var(--panel-accent-ok);
+      color: #fff;
+      border-color: var(--panel-accent-ok);
+    }
+    .btn[data-affordance="correct"] {
+      background: transparent;
+      color: var(--panel-accent-warn);
+      border-color: var(--panel-accent-warn);
+    }
+    .btn[data-affordance="reject"] {
+      background: transparent;
+      color: var(--panel-accent-err);
+      border-color: var(--panel-accent-err);
+    }
+    .btn-stub-label {
+      font-size: 0.65rem;
+      color: var(--panel-muted);
+      margin-top: 4px;
+    }
+
+    /* ----------------------------------------------------------------
+       Receipt row
+    ---------------------------------------------------------------- */
+    .receipt-row {
+      padding: 8px 12px;
+      background: rgba(46,204,113,0.08);
+      border: 1px solid rgba(46,204,113,0.25);
+      border-radius: 6px;
+      font-size: 0.8rem;
+    }
+
+    .receipt-row.blocked {
+      background: rgba(231,76,60,0.08);
+      border-color: rgba(231,76,60,0.25);
+    }
+
+    .receipt-row .outcome-tag {
+      font-weight: 700;
+      margin-bottom: 4px;
+      font-size: 0.72rem;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    .outcome-tag.success { color: var(--panel-accent-ok); }
+    .outcome-tag.blocked  { color: var(--panel-accent-err); }
+
+    .receipt-row .receipt-detail { color: var(--panel-muted); font-size: 0.72rem; }
+
+    /* ----------------------------------------------------------------
+       Failure state callout (no-match / blocked)
+    ---------------------------------------------------------------- */
+    .failure-callout {
+      padding: 10px 12px;
+      border-radius: 6px;
+      font-size: 0.82rem;
+    }
+    .failure-callout.no-match {
+      background: rgba(243,156,18,0.08);
+      border: 1px solid rgba(243,156,18,0.3);
+      color: var(--panel-accent-warn);
+    }
+    .failure-callout.blocked {
+      background: rgba(231,76,60,0.08);
+      border: 1px solid rgba(231,76,60,0.3);
+      color: var(--panel-accent-err);
+    }
+    .failure-callout .reason-label {
+      font-size: 0.7rem;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      margin-bottom: 4px;
+      opacity: 0.75;
+    }
+  </style>
+</head>
+<body>
+
+<h1>Panel Visual Shell</h1>
+<div class="prototype-banner">Prototype — stub data — not production</div>
+<p style="color:var(--panel-muted); font-size:0.78rem; margin-bottom:24px;">
+  All 8 required Panel states rendered with in-memory stub data.
+  No runtime calls. No vault writes. Affordance buttons are visual slots only.
+  Governed by <code>companion-ui/docs/PANEL_COMPANION_UI_CONTRACT.md</code>.
+</p>
+
+<!-- ================================================================
+     STATE GRID — one card per required Panel state
+     data-panel-state mirrors the PanelRenderState.state values
+     ================================================================ -->
+<div class="state-grid">
+
+  <!-- ── 1. idle ─────────────────────────────────────────────────── -->
+  <div class="panel-card" data-panel-state="idle" data-testid="panel-state-idle">
+    <div class="panel-card-header">
+      Panel — <span class="state-badge">idle</span>
+    </div>
+    <div class="panel-card-body">
+      <div class="artifact-context">
+        <span>📄</span>
+        <strong>Projects/Q2-arch.md</strong>
+        <span style="margin-left:auto;">artifact-local</span>
+      </div>
+      <div class="panel-state-label">
+        <span class="icon">⬜</span> Panel ready
+      </div>
+    </div>
+  </div>
+
+  <!-- ── 2. running ──────────────────────────────────────────────── -->
+  <div class="panel-card" data-panel-state="running" data-testid="panel-state-running">
+    <div class="panel-card-header">
+      Panel — <span class="state-badge">running</span>
+    </div>
+    <div class="panel-card-body">
+      <div class="artifact-context">
+        <span>📄</span>
+        <strong>Projects/Q2-arch.md</strong>
+        <span style="margin-left:auto;">artifact-local</span>
+      </div>
+      <div class="panel-state-label">
+        <span class="spinner"></span> Thinking…
+      </div>
+    </div>
+  </div>
+
+  <!-- ── 3. proposals-staged ─────────────────────────────────────── -->
+  <div class="panel-card" data-panel-state="proposals-staged"
+       data-testid="panel-state-proposals-staged">
+    <div class="panel-card-header">
+      Panel — <span class="state-badge">proposals-staged</span>
+    </div>
+    <div class="panel-card-body">
+      <div class="artifact-context">
+        <span>📄</span>
+        <strong>Projects/Q2-arch.md</strong>
+        <span style="margin-left:auto;">artifact-local</span>
+      </div>
+      <div class="panel-state-label">
+        <span class="icon">📋</span> 2 proposal(s) ready
+      </div>
+      <div class="proposal-list">
+
+        <!-- prop-001 -->
+        <div class="proposal-row" data-proposal-id="prop-001"
+             data-testid="proposal-row">
+          <div class="proposal-description">Move note to Projects</div>
+          <div class="proposal-evidence">
+            rule · lifecycle.move ·
+            "Note has active project tag and no lifecycle classification"
+          </div>
+          <div class="affordance-row">
+            <button class="btn" data-affordance="confirm"
+                    data-testid="affordance-confirm"
+                    title="Stub — not wired to runtime">Confirm</button>
+            <button class="btn" data-affordance="correct"
+                    data-testid="affordance-correct"
+                    title="Stub — not wired to runtime">Correct</button>
+            <button class="btn" data-affordance="reject"
+                    data-testid="affordance-reject"
+                    title="Stub — not wired to runtime">Reject</button>
+          </div>
+          <div class="btn-stub-label">Stub — no POST /api/panel/confirm wired</div>
+        </div>
+
+        <!-- prop-002 -->
+        <div class="proposal-row" data-proposal-id="prop-002"
+             data-testid="proposal-row">
+          <div class="proposal-description">Add #active tag</div>
+          <div class="proposal-evidence">
+            llm · lifecycle.move ·
+            "Note has active project tag and no lifecycle classification"
+          </div>
+          <div class="affordance-row">
+            <button class="btn" data-affordance="confirm"
+                    title="Stub — not wired to runtime">Confirm</button>
+            <button class="btn" data-affordance="correct"
+                    title="Stub — not wired to runtime">Correct</button>
+            <button class="btn" data-affordance="reject"
+                    title="Stub — not wired to runtime">Reject</button>
+          </div>
+          <div class="btn-stub-label">Stub — no POST /api/panel/confirm wired</div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  <!-- ── 4. confirming ───────────────────────────────────────────── -->
+  <div class="panel-card" data-panel-state="confirming"
+       data-testid="panel-state-confirming">
+    <div class="panel-card-header">
+      Panel — <span class="state-badge">confirming</span>
+    </div>
+    <div class="panel-card-body">
+      <div class="artifact-context">
+        <span>📄</span>
+        <strong>Projects/Q2-arch.md</strong>
+        <span style="margin-left:auto;">artifact-local</span>
+      </div>
+      <div class="panel-state-label">
+        <span class="spinner"></span> Confirming…
+      </div>
+      <div class="proposal-list">
+        <div class="proposal-row" data-proposal-id="prop-001"
+             data-interaction-state="confirming">
+          <div class="proposal-description">Move note to Projects</div>
+          <div class="proposal-evidence">
+            rule · lifecycle.move · awaiting runtime response
+          </div>
+          <div class="affordance-row">
+            <button class="btn" data-affordance="confirm" disabled>Confirm</button>
+            <button class="btn" data-affordance="correct" disabled>Correct</button>
+            <button class="btn" data-affordance="reject" disabled>Reject</button>
+          </div>
+          <div class="btn-stub-label">Stub — awaiting runtime (simulated)</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── 5. executing ────────────────────────────────────────────── -->
+  <div class="panel-card" data-panel-state="executing"
+       data-testid="panel-state-executing">
+    <div class="panel-card-header">
+      Panel — <span class="state-badge">executing</span>
+    </div>
+    <div class="panel-card-body">
+      <div class="artifact-context">
+        <span>📄</span>
+        <strong>Projects/Q2-arch.md</strong>
+        <span style="margin-left:auto;">artifact-local</span>
+      </div>
+      <div class="panel-state-label">
+        <span class="spinner"></span> Executing…
+      </div>
+      <p style="font-size:0.78rem; color:var(--panel-muted); margin-top:8px;">
+        Runtime is applying governed vault write.
+        Companion UI does not write vault files directly.
+      </p>
+    </div>
+  </div>
+
+  <!-- ── 6. receipt-displayed ────────────────────────────────────── -->
+  <div class="panel-card" data-panel-state="receipt-displayed"
+       data-testid="panel-state-receipt-displayed">
+    <div class="panel-card-header">
+      Panel — <span class="state-badge">receipt-displayed</span>
+    </div>
+    <div class="panel-card-body">
+      <div class="artifact-context">
+        <span>📄</span>
+        <strong>Projects/Q2-arch.md</strong>
+        <span style="margin-left:auto;">artifact-local</span>
+      </div>
+      <div class="panel-state-label">
+        <span class="icon">✅</span> Done — see receipt
+      </div>
+      <div class="receipt-row" data-testid="receipt-row">
+        <div class="outcome-tag success">success</div>
+        <div>prop-001 · lifecycle.move</div>
+        <div class="receipt-detail">
+          Note moved to Projects/Q2-arch.md · 2026-05-17T12:00:00Z
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── 7. no-match ─────────────────────────────────────────────── -->
+  <div class="panel-card" data-panel-state="no-match"
+       data-testid="panel-state-no-match">
+    <div class="panel-card-header">
+      Panel — <span class="state-badge">no-match</span>
+    </div>
+    <div class="panel-card-body">
+      <div class="artifact-context">
+        <span>📄</span>
+        <strong>Projects/Q2-arch.md</strong>
+        <span style="margin-left:auto;">artifact-local</span>
+      </div>
+      <div class="panel-state-label">
+        <span class="icon">🔍</span> No proposals for this note
+      </div>
+      <div class="failure-callout no-match" data-testid="failure-callout-no-match">
+        <div class="reason-label">Reason</div>
+        Panel ran but found no actionable proposals for this note.
+      </div>
+    </div>
+  </div>
+
+  <!-- ── 8. blocked ──────────────────────────────────────────────── -->
+  <div class="panel-card" data-panel-state="blocked"
+       data-testid="panel-state-blocked">
+    <div class="panel-card-header">
+      Panel — <span class="state-badge">blocked</span>
+    </div>
+    <div class="panel-card-body">
+      <div class="artifact-context">
+        <span>📄</span>
+        <strong>Projects/Q2-arch.md</strong>
+        <span style="margin-left:auto;">artifact-local</span>
+      </div>
+      <div class="panel-state-label">
+        <span class="icon">🚫</span> Blocked
+      </div>
+      <div class="failure-callout blocked" data-testid="failure-callout-blocked">
+        <div class="reason-label">Reason</div>
+        Execution blocked: WriteGuard denied (tag allowlist).
+      </div>
+      <div class="receipt-row blocked" style="margin-top:10px;" data-testid="receipt-row">
+        <div class="outcome-tag blocked">blocked</div>
+        <div>prop-001 · lifecycle.move</div>
+        <div class="receipt-detail">
+          2026-05-17T12:00:00Z · Runtime receipt (stub)
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div><!-- /state-grid -->
+
+</body>
+</html>

--- a/tests/companion_ui/test_panel_visual_shell.py
+++ b/tests/companion_ui/test_panel_visual_shell.py
@@ -13,8 +13,6 @@ No runtime startup, no backend API, no vault write path.
 
 from __future__ import annotations
 
-import pytest
-
 from companion_ui.panel.visual_shell import (
     REQUIRED_PANEL_STATES,
     PanelShellView,
@@ -120,6 +118,22 @@ def test_confirming_state():
     assert prop_states["prop-001"]["state"] == "confirming"
 
 
+def test_confirming_state_disables_affordances_for_in_flight_proposal():
+    v = build_confirming_view(ARTIFACT_ID)
+    rows_by_id = {r["proposal_id"]: r for r in v.proposals}
+    # prop-001 is awaiting_runtime — all affordances must be False
+    p001 = rows_by_id["prop-001"]
+    assert p001["affordances"]["confirm"] is False, "in-flight confirm must be disabled"
+    assert p001["affordances"]["correct"] is False, "in-flight correct must be disabled"
+    assert p001["affordances"]["reject"] is False, "in-flight reject must be disabled"
+    assert p001["interaction_state"] == "confirming"
+    assert p001["user_action_required"] is False
+    # prop-002 is still staged — affordances remain available
+    p002 = rows_by_id["prop-002"]
+    assert p002["affordances"]["confirm"] is True
+    assert p002["interaction_state"] == "staged"
+
+
 def test_executing_state_has_loading_flag():
     v = build_executing_view(ARTIFACT_ID)
     assert v.render["state"] == "executing"
@@ -171,7 +185,6 @@ def test_blocked_state_custom_reason():
 
 
 def test_no_match_is_visible_failure():
-    v = build_no_match_view(ARTIFACT_ID)
     from companion_ui.panel.render_model import PanelRenderState
     rs = PanelRenderState(artifact_id=ARTIFACT_ID, state="no-match")
     assert rs.is_visible_failure is True

--- a/tests/companion_ui/test_panel_visual_shell.py
+++ b/tests/companion_ui/test_panel_visual_shell.py
@@ -1,0 +1,228 @@
+"""Tests for Panel visual shell stub (#1045).
+
+Validates:
+- All 8 required Panel states are buildable from stub data.
+- Each shell view is serialisable and contains the expected keys.
+- Proposal rows carry confirm/correct/reject affordance slots.
+- no-match and blocked states carry a visible reason string.
+- No runtime imports, no vault writes, no Canvas Core imports.
+
+Validation level: Level 1 — isolated Companion UI Panel shell.
+No runtime startup, no backend API, no vault write path.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from companion_ui.panel.visual_shell import (
+    REQUIRED_PANEL_STATES,
+    PanelShellView,
+    build_all_states,
+    build_blocked_view,
+    build_confirming_view,
+    build_executing_view,
+    build_idle_view,
+    build_no_match_view,
+    build_proposals_staged_view,
+    build_receipt_displayed_view,
+    build_running_view,
+)
+from companion_ui.panel.render_model import PANEL_STATES_REQUIRED
+
+ARTIFACT_ID = "note-stub-test-01"
+
+
+# ---------------------------------------------------------------------------
+# Required states coverage
+# ---------------------------------------------------------------------------
+
+
+def test_required_panel_states_match_render_model():
+    assert REQUIRED_PANEL_STATES == PANEL_STATES_REQUIRED
+
+
+def test_build_all_states_returns_all_required():
+    views = build_all_states(ARTIFACT_ID)
+    assert set(views.keys()) == REQUIRED_PANEL_STATES
+
+
+def test_all_views_are_panel_shell_view_instances():
+    views = build_all_states(ARTIFACT_ID)
+    for state, view in views.items():
+        assert isinstance(view, PanelShellView), f"{state} returned {type(view)}"
+
+
+def test_all_views_serialisable():
+    views = build_all_states(ARTIFACT_ID)
+    for state, view in views.items():
+        d = view.as_dict()
+        assert isinstance(d, dict), f"{state} as_dict() not a dict"
+        assert "render" in d
+        assert "proposals" in d
+        assert "receipts" in d
+
+
+# ---------------------------------------------------------------------------
+# Per-state render assertions
+# ---------------------------------------------------------------------------
+
+
+def test_idle_state():
+    v = build_idle_view(ARTIFACT_ID)
+    assert v.render["state"] == "idle"
+    assert v.render["artifact_id"] == ARTIFACT_ID
+    assert not v.proposals
+    assert not v.receipts
+
+
+def test_running_state_has_loading_flag():
+    v = build_running_view(ARTIFACT_ID)
+    assert v.render["state"] == "running"
+    assert v.render.get("loading") is True
+
+
+def test_proposals_staged_has_proposal_rows():
+    v = build_proposals_staged_view(ARTIFACT_ID)
+    assert v.render["state"] == "proposals-staged"
+    assert len(v.proposals) == 2
+    assert v.render["proposal_count"] == 2
+
+
+def test_proposals_staged_rows_have_affordances():
+    v = build_proposals_staged_view(ARTIFACT_ID)
+    for row in v.proposals:
+        affordances = row["affordances"]
+        assert affordances["confirm"] is True, "confirm affordance must be available"
+        assert affordances["correct"] is True, "correct affordance must be available"
+        assert affordances["reject"] is True, "reject affordance must be available"
+
+
+def test_proposals_staged_rows_have_artifact_id():
+    v = build_proposals_staged_view(ARTIFACT_ID)
+    for row in v.proposals:
+        assert row["artifact_id"] == ARTIFACT_ID
+
+
+def test_proposals_staged_has_interaction_summary():
+    v = build_proposals_staged_view(ARTIFACT_ID)
+    assert v.interaction_summary is not None
+    assert v.interaction_summary["artifact_id"] == ARTIFACT_ID
+    assert v.interaction_summary["proposal_count"] == 2
+
+
+def test_confirming_state():
+    v = build_confirming_view(ARTIFACT_ID)
+    assert v.render["state"] == "confirming"
+    assert v.interaction_summary is not None
+    # prop-001 should be in 'confirming' interaction state
+    prop_states = v.interaction_summary["proposals"]
+    assert prop_states["prop-001"]["state"] == "confirming"
+
+
+def test_executing_state_has_loading_flag():
+    v = build_executing_view(ARTIFACT_ID)
+    assert v.render["state"] == "executing"
+    assert v.render.get("loading") is True
+
+
+def test_receipt_displayed_has_receipt():
+    v = build_receipt_displayed_view(ARTIFACT_ID)
+    assert v.render["state"] == "receipt-displayed"
+    assert len(v.receipts) == 1
+    receipt = v.receipts[0]
+    assert receipt["outcome"] == "success"
+    assert receipt["artifact_id"] == ARTIFACT_ID
+
+
+# ---------------------------------------------------------------------------
+# Visible failure states
+# ---------------------------------------------------------------------------
+
+
+def test_no_match_state_has_visible_reason():
+    v = build_no_match_view(ARTIFACT_ID)
+    assert v.render["state"] == "no-match"
+    assert v.render.get("message"), "no-match must carry a non-empty reason message"
+
+
+def test_no_match_state_custom_reason():
+    reason = "Note has no applicable rules or LLM proposals."
+    v = build_no_match_view(ARTIFACT_ID, reason=reason)
+    assert v.render["message"] == reason
+
+
+def test_blocked_state_has_visible_reason():
+    v = build_blocked_view(ARTIFACT_ID)
+    assert v.render["state"] == "blocked"
+    assert v.render.get("message"), "blocked must carry a non-empty reason message"
+
+
+def test_blocked_state_has_blocked_receipt():
+    v = build_blocked_view(ARTIFACT_ID)
+    assert len(v.receipts) == 1
+    assert v.receipts[0]["outcome"] == "blocked"
+
+
+def test_blocked_state_custom_reason():
+    reason = "WriteGuard denied: capability not in allowlist."
+    v = build_blocked_view(ARTIFACT_ID, reason=reason)
+    assert v.render["message"] == reason
+
+
+def test_no_match_is_visible_failure():
+    v = build_no_match_view(ARTIFACT_ID)
+    from companion_ui.panel.render_model import PanelRenderState
+    rs = PanelRenderState(artifact_id=ARTIFACT_ID, state="no-match")
+    assert rs.is_visible_failure is True
+
+
+def test_blocked_is_visible_failure():
+    from companion_ui.panel.render_model import PanelRenderState
+    rs = PanelRenderState(artifact_id=ARTIFACT_ID, state="blocked")
+    assert rs.is_visible_failure is True
+
+
+# ---------------------------------------------------------------------------
+# Stub data only — no network, no vault writes
+# ---------------------------------------------------------------------------
+
+
+def test_no_runtime_api_imports():
+    """visual_shell must not import runtime/vault/Canvas Core modules.
+
+    Checks the module's own namespace — not sys.modules globally, since other
+    tests in the suite legitimately load canvas_core modules.
+    """
+    import types
+    import companion_ui.panel.visual_shell as vs
+
+    forbidden_prefixes = (
+        "companion_ui.canvas_core",
+        "companion_ui.canvas_suggestion_flow",
+        "runtime",
+        "vault",
+    )
+
+    violations = []
+    for attr_name, attr_val in vars(vs).items():
+        if isinstance(attr_val, types.ModuleType):
+            mod_name = getattr(attr_val, "__name__", "")
+            if any(mod_name.startswith(p) for p in forbidden_prefixes):
+                violations.append(mod_name)
+
+    assert not violations, f"visual_shell directly imports forbidden modules: {violations}"
+
+
+def test_all_states_use_stub_artifact_id():
+    views = build_all_states(ARTIFACT_ID)
+    for state, view in views.items():
+        assert view.render["artifact_id"] == ARTIFACT_ID, (
+            f"State {state!r} render artifact_id mismatch"
+        )
+
+
+def test_default_artifact_id_accepted():
+    # build_all_states has a default — must not raise
+    views = build_all_states()
+    assert len(views) == len(REQUIRED_PANEL_STATES)


### PR DESCRIPTION
## Summary

Implements #1045 as a renderer-agnostic Panel visual shell stub over the existing Panel models.

- `companion_ui/panel/visual_shell.py` — Python shell model assembling `PanelShellView` from `PanelRenderState`, `ProposalRow`, `ProposalReceipt`, and `PanelInteractionSession`; exposes per-state builder functions and `build_all_states()` catalogue
- `panel_visual_shell.html` — staging HTML prototype (non-production, stub data, prototype banner) rendering all 8 states with confirm/correct/reject affordance slots
- `tests/companion_ui/test_panel_visual_shell.py` — 23 tests covering state coverage, proposal affordances, visible failure states, and no-forbidden-import assertion

## Issues

- Closes #1045
- Advances #1022

## Surface boundary

Panel in Companion UI only.
Not Canvas Core.
Not Canvas bounded suggestion flow.
Stub/in-memory data only.
No runtime endpoint implementation.
No backend API wiring.
No watcher behavior.
No direct vault writes.

## Validation level

Level 1 — isolated Companion UI Panel shell tests.

## Commands run

```bash
git diff --check
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_panel_visual_shell.py
# 23 passed in 0.03s
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/
# 254 passed in 0.12s (up from 231 — no regressions)
```

## Full-smoke rationale

Full smoke not required. Isolated Companion UI helper/model test only. No runtime startup, backend API, vault write path, watcher, DB/migration, environment/release-channel, or prod/stable behavior changed.

## Follow-up

- Runtime implementation issue for `POST /api/panel/confirm`
- Runtime-mediated durable projection implementation
- Canvas bounded suggestion Batch 1 after Panel shell is validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)