### PR TITLE
feat(canvas-ui): Canvas bounded suggestion flow Batch 1 — rail state machine, SuggestionCard, SuggestedInsertion

### DIFF
--- a/companion-ui/companion-app/companion_ui/canvas_suggestion_flow/__init__.py
+++ b/companion-ui/companion-app/companion_ui/canvas_suggestion_flow/__init__.py
@@ -1,0 +1,5 @@
+# canvas_suggestion_flow — Canvas bounded suggestion flow UI models (#868–#874).
+# Staged discrete suggestion flow: propose → preview → apply/queue/discard.
+# This is NOT Canvas Core direct in-place co-authoring.
+# This is NOT Panel artifact-local intent manifestation.
+# UI does not write vault files. Runtime owns WriteGuard and durable projection.

--- a/companion-ui/companion-app/companion_ui/canvas_suggestion_flow/rail_state_machine.py
+++ b/companion-ui/companion-app/companion_ui/canvas_suggestion_flow/rail_state_machine.py
@@ -1,0 +1,125 @@
+"""Canvas rail state machine for the Canvas bounded suggestion flow (#870).
+
+Implements the 9-state machine defined in CANVAS_SUGGESTION_FLOW.md.
+Internal state names use the canonical snake_case contract names.
+DOM alias names are rendering-only; they must not become internal contract names.
+
+This is NOT Canvas Core session state. Canvas Core applies body edits directly
+in-place. The suggestion flow requires user approval at each proposal before any
+write occurs.
+"""
+
+from __future__ import annotations
+
+# Canonical internal state names (snake_case). Source: CANVAS_SUGGESTION_FLOW.md.
+RAIL_STATES: frozenset[str] = frozenset({
+    "idle",
+    "thinking",
+    "staged_body",
+    "staged_governance",
+    "apply_pending",
+    "governance_pending",
+    "applied",
+    "discarded",
+    "blocked",
+})
+
+# DOM alias names for CSS/HTML rendering. Internal code must use canonical names.
+DOM_ALIAS: dict[str, str] = {
+    "idle":               "idle",
+    "thinking":           "thinking",
+    "staged_body":        "staged-body",
+    "staged_governance":  "staged-gov",
+    "apply_pending":      "pending-apply",
+    "governance_pending": "pending-gov",
+    "applied":            "applied",
+    "discarded":          "discarded",
+    "blocked":            "blocked",
+}
+
+# States that prevent further user action until auto-transition or acknowledgement.
+TERMINAL_PRESENTATION_STATES: frozenset[str] = frozenset({"applied", "discarded", "blocked"})
+
+# States in which the user has a staged proposal to act on.
+STAGED_STATES: frozenset[str] = frozenset({"staged_body", "staged_governance"})
+
+# Legal transitions: canonical from_state → set of reachable to_states.
+# Forbidden invariants encoded here:
+#   - No skip from staged_* directly to applied/idle without the pending state.
+#   - Governance proposals never enter apply_pending.
+_LEGAL_TRANSITIONS: dict[str, frozenset[str]] = {
+    "idle":               frozenset({"thinking"}),
+    "thinking":           frozenset({"staged_body", "staged_governance", "blocked", "idle"}),
+    "staged_body":        frozenset({"apply_pending", "discarded"}),
+    "staged_governance":  frozenset({"governance_pending", "discarded"}),
+    "apply_pending":      frozenset({"applied", "staged_body"}),      # staged_body on error
+    "governance_pending": frozenset({"idle", "staged_governance"}),   # staged_governance on error
+    "applied":            frozenset({"idle"}),
+    "discarded":          frozenset({"idle"}),
+    "blocked":            frozenset({"idle"}),
+}
+
+
+class CanvasRailStateMachine:
+    """State machine for the Canvas bounded suggestion flow rail.
+
+    Tracks the single active state of the suggestion rail and enforces the
+    allowed-transition table from CANVAS_SUGGESTION_FLOW.md.
+
+    Does not call canvas_writer, GovernanceRouter, or session_log.
+    Caller is responsible for performing the associated side-effect and then
+    calling transition() with the result state.
+    """
+
+    def __init__(self, initial_state: str = "idle") -> None:
+        if initial_state not in RAIL_STATES:
+            raise ValueError(f"Unknown initial rail state: {initial_state!r}")
+        self._state = initial_state
+        self._error: str | None = None
+
+    @property
+    def state(self) -> str:
+        return self._state
+
+    @property
+    def dom_alias(self) -> str:
+        return DOM_ALIAS[self._state]
+
+    @property
+    def error(self) -> str | None:
+        return self._error
+
+    @property
+    def is_terminal_presentation(self) -> bool:
+        return self._state in TERMINAL_PRESENTATION_STATES
+
+    @property
+    def is_staged(self) -> bool:
+        return self._state in STAGED_STATES
+
+    @property
+    def composer_enabled(self) -> bool:
+        return self._state == "idle"
+
+    def transition(self, to_state: str, *, error: str | None = None) -> None:
+        """Transition to to_state, raising ValueError on illegal moves.
+
+        error is only meaningful on error-path transitions back to staged_* states.
+        """
+        if to_state not in RAIL_STATES:
+            raise ValueError(f"Unknown rail state: {to_state!r}")
+        if to_state not in _LEGAL_TRANSITIONS[self._state]:
+            raise ValueError(
+                f"Illegal canvas rail transition: {self._state!r} → {to_state!r}"
+            )
+        self._state = to_state
+        self._error = error
+
+    def allowed_transitions(self) -> frozenset[str]:
+        """Return the set of states reachable from the current state."""
+        return _LEGAL_TRANSITIONS[self._state]
+
+
+def make_stub_rail(initial_state: str = "idle") -> CanvasRailStateMachine:
+    """Return a CanvasRailStateMachine in the given initial state for testing."""
+    return CanvasRailStateMachine(initial_state=initial_state)

--- a/companion-ui/companion-app/companion_ui/canvas_suggestion_flow/suggested_insertion.py
+++ b/companion-ui/companion-app/companion_ui/canvas_suggestion_flow/suggested_insertion.py
@@ -1,0 +1,142 @@
+"""SuggestedInsertion in-document preview marker model (#869).
+
+Represents the <ins> element placed inline at the insertion anchor while a
+body-edit proposal is staged.  Tracks the three lifecycle states defined in
+CANVAS_SUGGESTION_FLOW.md:
+
+  staged    — Amber left-border; label "PROPOSED · UNCOMMITTED".
+  applied   — Vault-green left-border; label "APPLIED · <receipt-id>".
+  discarded — Element removed from DOM (display:none / not rendered).
+
+Only rendered for body-edit proposals.  Governance proposals do not produce a
+SuggestedInsertion (no in-document preview for governance mutations).
+
+This model does not write to the vault.  canvas_writer owns durable writes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+INSERTION_STATES: frozenset[str] = frozenset({"staged", "applied", "discarded"})
+
+# CSS class and colour-hint tokens (design guidance).
+_STATE_COLOR_HINT: dict[str, Optional[str]] = {
+    "staged":    "amber",
+    "applied":   "vault-green",
+    "discarded": None,
+}
+
+_STATE_LABEL: dict[str, str] = {
+    "staged":    "PROPOSED · UNCOMMITTED",
+    "applied":   "APPLIED",       # caller appends · <receipt-id>
+    "discarded": "",
+}
+
+# Allowed state transitions for the insertion block.
+_LEGAL_INSERTION_TRANSITIONS: dict[str, frozenset[str]] = {
+    "staged":    frozenset({"applied", "discarded"}),
+    "applied":   frozenset(),
+    "discarded": frozenset(),
+}
+
+
+@dataclass
+class SuggestedInsertion:
+    """Render model for the inline in-document preview marker.
+
+    suggestion_id must match the paired SuggestionCard's suggestion_id.
+    anchor_description describes the insertion point (e.g. "3 lines after ## Summary").
+    proposed_text is the full text to be inserted.
+    receipt_id is populated on apply; empty string otherwise.
+    """
+
+    suggestion_id: str
+    anchor_description: str
+    proposed_text: str
+    _state: str = "staged"
+    _receipt_id: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.suggestion_id:
+            raise ValueError("suggestion_id is required")
+        if not self.anchor_description:
+            raise ValueError("anchor_description is required for aria-label")
+        if not self.proposed_text:
+            raise ValueError("proposed_text is required")
+        if self._state not in INSERTION_STATES:
+            raise ValueError(f"Unknown SuggestedInsertion state: {self._state!r}")
+
+    @property
+    def state(self) -> str:
+        return self._state
+
+    @property
+    def receipt_id(self) -> str:
+        return self._receipt_id
+
+    @property
+    def color_hint(self) -> Optional[str]:
+        return _STATE_COLOR_HINT[self._state]
+
+    @property
+    def label(self) -> str:
+        if self._state == "applied" and self._receipt_id:
+            return f"APPLIED · {self._receipt_id}"
+        return _STATE_LABEL[self._state]
+
+    @property
+    def aria_label(self) -> str:
+        return f"Proposed insertion, {self.anchor_description}"
+
+    @property
+    def is_visible(self) -> bool:
+        """False when discarded — element should be removed/hidden from DOM."""
+        return self._state != "discarded"
+
+    def apply(self, receipt_id: str = "") -> None:
+        """Transition staged → applied, populating receipt_id."""
+        if "applied" not in _LEGAL_INSERTION_TRANSITIONS[self._state]:
+            raise ValueError(
+                f"Cannot apply SuggestedInsertion from state {self._state!r}"
+            )
+        self._state = "applied"
+        self._receipt_id = receipt_id
+
+    def discard(self) -> None:
+        """Transition staged → discarded."""
+        if "discarded" not in _LEGAL_INSERTION_TRANSITIONS[self._state]:
+            raise ValueError(
+                f"Cannot discard SuggestedInsertion from state {self._state!r}"
+            )
+        self._state = "discarded"
+
+    def as_render_dict(self) -> dict:
+        """Serialisable dict for the UI layer (maps to <ins> element attributes)."""
+        return {
+            "element": "ins",
+            "css_class": "suggested-insertion",
+            "data_testid": "suggested-insertion-block",
+            "data_suggestion_id": self.suggestion_id,
+            "data_state": self._state,
+            "data_receipt": self._receipt_id,
+            "aria_label": self.aria_label,
+            "color_hint": self.color_hint,
+            "label": self.label,
+            "proposed_text": self.proposed_text,
+            "is_visible": self.is_visible,
+        }
+
+
+def make_stub_insertion(
+    suggestion_id: str = "sugg-001",
+    anchor_description: str = "3 lines after ## Summary",
+    proposed_text: str = "The project has entered the active phase.\n",
+) -> SuggestedInsertion:
+    """Stub SuggestedInsertion in staged state for testing."""
+    return SuggestedInsertion(
+        suggestion_id=suggestion_id,
+        anchor_description=anchor_description,
+        proposed_text=proposed_text,
+    )

--- a/companion-ui/companion-app/companion_ui/canvas_suggestion_flow/suggestion_card.py
+++ b/companion-ui/companion-app/companion_ui/canvas_suggestion_flow/suggestion_card.py
@@ -1,0 +1,171 @@
+"""SuggestionCard render model for the Canvas bounded suggestion flow (#868).
+
+Three variants driven by server-declared proposal class:
+  body       — body-edit proposal; Apply + Discard + Inspect.
+  governance — governance-bearing proposal; Queue + Discard + Inspect; NO Apply.
+  blocked    — CANVAS_ENABLED=0 or write-guard; Acknowledge only; role="alert".
+
+Hard invariant: the governance variant MUST NOT expose the suggestion.apply intent.
+The UI never re-classifies the server-declared variant.
+
+This model does not call canvas_writer, GovernanceRouter, or session_log.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+CARD_VARIANTS: frozenset[str] = frozenset({"body", "governance", "blocked"})
+
+# Intent tokens per variant. Canonical names from CANVAS_SUGGESTION_FLOW.md §data-intent.
+_BODY_INTENTS: tuple[str, ...] = ("suggestion.apply", "suggestion.discard", "suggestion.inspect")
+_GOVERNANCE_INTENTS: tuple[str, ...] = ("governance.queue", "suggestion.discard", "suggestion.inspect")
+_BLOCKED_INTENTS: tuple[str, ...] = ("blocked.acknowledge",)
+
+# data-testid tokens for primary action buttons.
+_BODY_TESTIDS: dict[str, str] = {
+    "suggestion.apply":   "apply-suggestion",
+    "suggestion.discard": "discard-suggestion",
+}
+_GOVERNANCE_TESTIDS: dict[str, str] = {
+    "governance.queue":   "queue-governance",
+    "suggestion.discard": "discard-suggestion",
+}
+
+# Colour hint tokens (design guidance, not hard contract).
+_VARIANT_COLOR_HINT: dict[str, str] = {
+    "body":       "amber",
+    "governance": "gold",
+    "blocked":    "neutral",
+}
+
+# ARIA role override for the blocked variant (§Contracts).
+_VARIANT_ARIA_ROLE: dict[str, Optional[str]] = {
+    "body":       None,
+    "governance": None,
+    "blocked":    "alert",
+}
+
+# Governance classification notice text (design reference copy).
+_GOVERNANCE_CLASSIFICATION_NOTICE = (
+    "Cannot be applied from chat — must be queued."
+)
+
+
+@dataclass
+class SuggestionCard:
+    """Render model for a single SuggestionCard in the rail thread.
+
+    suggestion_id must match the data-suggestion-id on the paired SuggestedInsertion.
+    variant is server-declared; this model does not change it.
+    denial_reason is required for the blocked variant (surfaced in aria-describedby).
+    """
+
+    suggestion_id: str
+    variant: str
+    title: str
+    preview_text: str
+    denial_reason: Optional[str] = None
+    _intents: tuple[str, ...] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if not self.suggestion_id:
+            raise ValueError("suggestion_id is required")
+        if self.variant not in CARD_VARIANTS:
+            raise ValueError(f"Unknown SuggestionCard variant: {self.variant!r}")
+        if not self.title:
+            raise ValueError("title is required for user-facing display")
+        if self.variant == "blocked" and not self.denial_reason:
+            raise ValueError("denial_reason is required for the blocked variant")
+        if self.variant == "governance":
+            object.__setattr__(self, "_intents", _GOVERNANCE_INTENTS)
+        elif self.variant == "body":
+            object.__setattr__(self, "_intents", _BODY_INTENTS)
+        else:
+            object.__setattr__(self, "_intents", _BLOCKED_INTENTS)
+
+    @property
+    def available_intents(self) -> tuple[str, ...]:
+        """Intent tokens available for this card variant."""
+        return self._intents
+
+    @property
+    def has_apply_intent(self) -> bool:
+        """True only for body variant; governance and blocked must return False."""
+        return "suggestion.apply" in self._intents
+
+    @property
+    def aria_role(self) -> Optional[str]:
+        return _VARIANT_ARIA_ROLE[self.variant]
+
+    @property
+    def color_hint(self) -> str:
+        return _VARIANT_COLOR_HINT[self.variant]
+
+    @property
+    def classification_notice(self) -> Optional[str]:
+        return _GOVERNANCE_CLASSIFICATION_NOTICE if self.variant == "governance" else None
+
+    def as_render_dict(self) -> dict:
+        """Serialisable dict for the UI layer."""
+        d: dict = {
+            "data_testid": "suggestion-card",
+            "data_variant": self.variant,
+            "data_suggestion_id": self.suggestion_id,
+            "title": self.title,
+            "preview_text": self.preview_text,
+            "color_hint": self.color_hint,
+            "available_intents": list(self._intents),
+            "aria_role": self.aria_role,
+        }
+        if self.variant == "governance":
+            d["classification_notice"] = self.classification_notice
+            d["data_testid_classification"] = "suggestion-card-classification"
+        if self.variant == "blocked":
+            d["denial_reason"] = self.denial_reason
+        return d
+
+
+def make_stub_body_card(
+    suggestion_id: str = "sugg-001",
+    title: str = "Add summary paragraph",
+    preview_text: str = "The project has entered...",
+) -> SuggestionCard:
+    """Stub body-variant SuggestionCard for testing."""
+    return SuggestionCard(
+        suggestion_id=suggestion_id,
+        variant="body",
+        title=title,
+        preview_text=preview_text,
+    )
+
+
+def make_stub_governance_card(
+    suggestion_id: str = "sugg-002",
+    title: str = "Move note to Projects",
+    preview_text: str = "lifecycle.move → Projects/",
+) -> SuggestionCard:
+    """Stub governance-variant SuggestionCard for testing."""
+    return SuggestionCard(
+        suggestion_id=suggestion_id,
+        variant="governance",
+        title=title,
+        preview_text=preview_text,
+    )
+
+
+def make_stub_blocked_card(
+    suggestion_id: str = "sugg-003",
+    title: str = "Edit blocked",
+    preview_text: str = "CANVAS_ENABLED=0",
+    denial_reason: str = "Canvas writes are currently disabled.",
+) -> SuggestionCard:
+    """Stub blocked-variant SuggestionCard for testing."""
+    return SuggestionCard(
+        suggestion_id=suggestion_id,
+        variant="blocked",
+        title=title,
+        preview_text=preview_text,
+        denial_reason=denial_reason,
+    )

--- a/tests/companion_ui/test_canvas_core_composition.py
+++ b/tests/companion_ui/test_canvas_core_composition.py
@@ -239,14 +239,19 @@ class TestCanvasCoreComposition:
         assert recovery.reentry_state == "recovered"
         assert recovery.blocks_new_edits is False
 
-        # 12. canvas_suggestion_flow must not appear anywhere in this test module
-        # (static assertion via import guard in the module docstring and below)
-        import sys
-        loaded = set(sys.modules.keys())
-        assert not any("canvas_suggestion_flow" in name for name in loaded), (
-            "canvas_suggestion_flow was imported — this violates the Canvas Core "
-            "surface boundary. It must not be referenced in Canvas Core code."
-        )
+        # 12. canvas_core source files must not reference canvas_suggestion_flow.
+        # Checking sys.modules is unreliable in a shared test session because
+        # other test modules import canvas_suggestion_flow during collection.
+        # Source-file inspection is the correct check for the stated invariant.
+        import pathlib
+        canvas_core_dir = pathlib.Path(__file__).resolve().parents[2] / \
+            "companion-ui" / "companion-app" / "companion_ui" / "canvas_core"
+        for src_file in canvas_core_dir.glob("*.py"):
+            content = src_file.read_text()
+            assert "canvas_suggestion_flow" not in content, (
+                f"{src_file.name} references canvas_suggestion_flow — this violates "
+                "the Canvas Core surface boundary."
+            )
 
     def test_governance_bearing_edit_classes_are_routed(self) -> None:
         """Every known governance-bearing class routes away from the direct edit path."""

--- a/tests/companion_ui/test_canvas_rail_state_machine.py
+++ b/tests/companion_ui/test_canvas_rail_state_machine.py
@@ -1,0 +1,281 @@
+"""Tests for the Canvas rail state machine (#870).
+
+Verifies:
+- All 9 canonical states are defined.
+- Internal state names are canonical snake_case, not DOM alias names.
+- Illegal transitions are rejected (governance→apply, staged→terminal without pending).
+- Error paths return to the matching staged state.
+- governance_pending returns to idle when a receipt is returned.
+- Terminal presentation states (applied, discarded, blocked) lock further action.
+- No dependency on Canvas Core, Panel, backend runtime, or vault writes.
+"""
+
+import pytest
+
+from companion_ui.canvas_suggestion_flow.rail_state_machine import (
+    RAIL_STATES,
+    DOM_ALIAS,
+    TERMINAL_PRESENTATION_STATES,
+    CanvasRailStateMachine,
+    make_stub_rail,
+)
+
+
+# ---------------------------------------------------------------------------
+# AC: all 9 canonical states defined
+# ---------------------------------------------------------------------------
+
+class TestAllStatesDefined:
+    def test_all_states_defined(self) -> None:
+        expected = {
+            "idle",
+            "thinking",
+            "staged_body",
+            "staged_governance",
+            "apply_pending",
+            "governance_pending",
+            "applied",
+            "discarded",
+            "blocked",
+        }
+        assert RAIL_STATES == expected
+
+    def test_exactly_nine_states(self) -> None:
+        assert len(RAIL_STATES) == 9
+
+    def test_dom_alias_covers_all_states(self) -> None:
+        assert set(DOM_ALIAS.keys()) == RAIL_STATES
+
+
+# ---------------------------------------------------------------------------
+# AC: canonical state names used internally; DOM aliases are rendering-only
+# ---------------------------------------------------------------------------
+
+class TestCanonicalStateNamesUsed:
+    def test_initial_state_is_canonical(self) -> None:
+        sm = make_stub_rail()
+        assert sm.state == "idle"
+        assert sm.state in RAIL_STATES
+
+    def test_dom_alias_differs_from_canonical_for_staged_body(self) -> None:
+        assert DOM_ALIAS["staged_body"] == "staged-body"
+        assert "staged_body" != "staged-body"
+
+    def test_dom_alias_differs_from_canonical_for_staged_governance(self) -> None:
+        assert DOM_ALIAS["staged_governance"] == "staged-gov"
+
+    def test_dom_alias_differs_from_canonical_for_apply_pending(self) -> None:
+        assert DOM_ALIAS["apply_pending"] == "pending-apply"
+
+    def test_dom_alias_differs_from_canonical_for_governance_pending(self) -> None:
+        assert DOM_ALIAS["governance_pending"] == "pending-gov"
+
+    def test_state_machine_state_property_returns_canonical(self) -> None:
+        sm = make_stub_rail("staged_body")
+        assert sm.state == "staged_body"
+        assert "-" not in sm.state  # canonical names use underscore, not hyphen
+
+    def test_dom_alias_property_returns_alias(self) -> None:
+        sm = make_stub_rail("staged_body")
+        assert sm.dom_alias == "staged-body"
+
+    def test_unknown_initial_state_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown initial rail state"):
+            CanvasRailStateMachine(initial_state="staged-body")  # DOM name, not canonical
+
+    def test_unknown_transition_target_raises(self) -> None:
+        sm = make_stub_rail()
+        with pytest.raises(ValueError, match="Unknown rail state"):
+            sm.transition("staged-body")  # DOM name, not canonical
+
+
+# ---------------------------------------------------------------------------
+# AC: illegal transitions are rejected
+# ---------------------------------------------------------------------------
+
+class TestIllegalTransitionsRejected:
+    def test_governance_cannot_enter_apply_pending(self) -> None:
+        sm = make_stub_rail("staged_governance")
+        with pytest.raises(ValueError, match="Illegal canvas rail transition"):
+            sm.transition("apply_pending")
+
+    def test_staged_body_cannot_jump_to_applied(self) -> None:
+        sm = make_stub_rail("staged_body")
+        with pytest.raises(ValueError, match="Illegal canvas rail transition"):
+            sm.transition("applied")
+
+    def test_staged_body_cannot_jump_to_idle(self) -> None:
+        sm = make_stub_rail("staged_body")
+        with pytest.raises(ValueError, match="Illegal canvas rail transition"):
+            sm.transition("idle")
+
+    def test_staged_governance_cannot_jump_to_idle(self) -> None:
+        sm = make_stub_rail("staged_governance")
+        with pytest.raises(ValueError, match="Illegal canvas rail transition"):
+            sm.transition("idle")
+
+    def test_idle_cannot_jump_to_staged_body(self) -> None:
+        sm = make_stub_rail()
+        with pytest.raises(ValueError, match="Illegal canvas rail transition"):
+            sm.transition("staged_body")
+
+    def test_applied_cannot_transition_to_thinking(self) -> None:
+        sm = make_stub_rail("applied")
+        with pytest.raises(ValueError, match="Illegal canvas rail transition"):
+            sm.transition("thinking")
+
+    def test_discarded_cannot_transition_to_thinking(self) -> None:
+        sm = make_stub_rail("discarded")
+        with pytest.raises(ValueError, match="Illegal canvas rail transition"):
+            sm.transition("thinking")
+
+    def test_blocked_cannot_transition_to_thinking(self) -> None:
+        sm = make_stub_rail("blocked")
+        with pytest.raises(ValueError, match="Illegal canvas rail transition"):
+            sm.transition("thinking")
+
+
+# ---------------------------------------------------------------------------
+# AC: error paths return to matching staged state
+# ---------------------------------------------------------------------------
+
+class TestErrorPathsReturnToStaged:
+    def test_apply_error_returns_to_staged_body(self) -> None:
+        sm = make_stub_rail("apply_pending")
+        sm.transition("staged_body", error="canvas_writer failed: timeout")
+        assert sm.state == "staged_body"
+        assert sm.error == "canvas_writer failed: timeout"
+
+    def test_governance_error_returns_to_staged_governance(self) -> None:
+        sm = make_stub_rail("governance_pending")
+        sm.transition("staged_governance", error="GovernanceRouter unavailable")
+        assert sm.state == "staged_governance"
+        assert sm.error == "GovernanceRouter unavailable"
+
+    def test_error_is_cleared_on_next_transition(self) -> None:
+        sm = make_stub_rail("apply_pending")
+        sm.transition("staged_body", error="fail")
+        sm.transition("apply_pending")
+        assert sm.error is None
+
+    def test_happy_path_has_no_error(self) -> None:
+        sm = make_stub_rail("apply_pending")
+        sm.transition("applied")
+        assert sm.error is None
+
+
+# ---------------------------------------------------------------------------
+# AC: governance_pending returns to idle when receipt returned
+# ---------------------------------------------------------------------------
+
+class TestGovernanceReceiptReturnsToIdle:
+    def test_governance_pending_to_idle(self) -> None:
+        sm = make_stub_rail("governance_pending")
+        sm.transition("idle")
+        assert sm.state == "idle"
+
+    def test_governance_pending_does_not_produce_receipt_in_state_machine(self) -> None:
+        sm = make_stub_rail("governance_pending")
+        # state machine is receipt-agnostic; receipt handling is in receipt components
+        sm.transition("idle")
+        assert sm.state == "idle"
+
+    def test_full_governance_lane(self) -> None:
+        sm = make_stub_rail()
+        sm.transition("thinking")
+        sm.transition("staged_governance")
+        sm.transition("governance_pending")
+        sm.transition("idle")
+        assert sm.state == "idle"
+
+    def test_governance_lane_error_then_retry(self) -> None:
+        sm = make_stub_rail("governance_pending")
+        sm.transition("staged_governance", error="router error")
+        assert sm.state == "staged_governance"
+        sm.transition("governance_pending")
+        sm.transition("idle")
+        assert sm.state == "idle"
+
+
+# ---------------------------------------------------------------------------
+# AC: terminal presentation states lock further action
+# ---------------------------------------------------------------------------
+
+class TestTerminalStatesLocked:
+    def test_applied_is_terminal_presentation(self) -> None:
+        assert "applied" in TERMINAL_PRESENTATION_STATES
+
+    def test_discarded_is_terminal_presentation(self) -> None:
+        assert "discarded" in TERMINAL_PRESENTATION_STATES
+
+    def test_blocked_is_terminal_presentation(self) -> None:
+        assert "blocked" in TERMINAL_PRESENTATION_STATES
+
+    def test_applied_only_allows_idle(self) -> None:
+        sm = make_stub_rail("applied")
+        assert sm.is_terminal_presentation is True
+        assert sm.allowed_transitions() == frozenset({"idle"})
+
+    def test_discarded_only_allows_idle(self) -> None:
+        sm = make_stub_rail("discarded")
+        assert sm.is_terminal_presentation is True
+        assert sm.allowed_transitions() == frozenset({"idle"})
+
+    def test_blocked_only_allows_idle(self) -> None:
+        sm = make_stub_rail("blocked")
+        assert sm.is_terminal_presentation is True
+        assert sm.allowed_transitions() == frozenset({"idle"})
+
+    def test_applied_cannot_transition_to_staged(self) -> None:
+        sm = make_stub_rail("applied")
+        with pytest.raises(ValueError):
+            sm.transition("staged_body")
+
+    def test_idle_is_not_terminal(self) -> None:
+        sm = make_stub_rail("idle")
+        assert sm.is_terminal_presentation is False
+
+    def test_composer_enabled_only_in_idle(self) -> None:
+        assert make_stub_rail("idle").composer_enabled is True
+        assert make_stub_rail("thinking").composer_enabled is False
+        assert make_stub_rail("staged_body").composer_enabled is False
+        assert make_stub_rail("applied").composer_enabled is False
+
+    def test_full_body_lane(self) -> None:
+        sm = make_stub_rail()
+        sm.transition("thinking")
+        sm.transition("staged_body")
+        sm.transition("apply_pending")
+        sm.transition("applied")
+        sm.transition("idle")
+        assert sm.state == "idle"
+
+    def test_full_discard_lane(self) -> None:
+        sm = make_stub_rail()
+        sm.transition("thinking")
+        sm.transition("staged_body")
+        sm.transition("discarded")
+        sm.transition("idle")
+        assert sm.state == "idle"
+
+
+# ---------------------------------------------------------------------------
+# Boundary: no Canvas Core / Panel / runtime coupling
+# ---------------------------------------------------------------------------
+
+class TestNoBoundaryCrossing:
+    def test_no_canvas_core_import(self) -> None:
+        import companion_ui.canvas_suggestion_flow.rail_state_machine as mod
+        src = open(mod.__file__).read()
+        assert "canvas_core" not in src
+
+    def test_no_panel_import(self) -> None:
+        import companion_ui.canvas_suggestion_flow.rail_state_machine as mod
+        src = open(mod.__file__).read()
+        assert "from companion_ui.panel" not in src
+
+    def test_no_vault_write(self) -> None:
+        import companion_ui.canvas_suggestion_flow.rail_state_machine as mod
+        src = open(mod.__file__).read()
+        assert "WriteGuard" not in src
+        assert "SessionLogWriter" not in src

--- a/tests/companion_ui/test_canvas_rail_state_machine.py
+++ b/tests/companion_ui/test_canvas_rail_state_machine.py
@@ -279,3 +279,52 @@ class TestNoBoundaryCrossing:
         src = open(mod.__file__).read()
         assert "WriteGuard" not in src
         assert "SessionLogWriter" not in src
+
+
+# ---------------------------------------------------------------------------
+# Top-level AC entry points — exact Verify: targets from issue #870
+# ---------------------------------------------------------------------------
+
+def test_all_states_defined() -> None:
+    """AC: state machine reflects all 9 canonical states."""
+    TestAllStatesDefined().test_all_states_defined()
+
+
+def test_canonical_state_names_used() -> None:
+    """AC: internal state names use canonical snake_case; DOM aliases are rendering-only."""
+    t = TestCanonicalStateNamesUsed()
+    t.test_state_machine_state_property_returns_canonical()
+    t.test_dom_alias_property_returns_alias()
+    t.test_unknown_initial_state_raises()
+    t.test_unknown_transition_target_raises()
+
+
+def test_illegal_transitions_rejected() -> None:
+    """AC: illegal transitions including governance→apply and staged→terminal are rejected."""
+    t = TestIllegalTransitionsRejected()
+    t.test_governance_cannot_enter_apply_pending()
+    t.test_staged_body_cannot_jump_to_applied()
+    t.test_staged_governance_cannot_jump_to_idle()
+
+
+def test_error_paths_return_to_staged() -> None:
+    """AC: error paths return to the matching staged state."""
+    t = TestErrorPathsReturnToStaged()
+    t.test_apply_error_returns_to_staged_body()
+    t.test_governance_error_returns_to_staged_governance()
+
+
+def test_governance_receipt_returns_to_idle() -> None:
+    """AC: governance_pending returns to idle when a receipt is returned."""
+    t = TestGovernanceReceiptReturnsToIdle()
+    t.test_governance_pending_to_idle()
+    t.test_full_governance_lane()
+
+
+def test_terminal_states_locked() -> None:
+    """AC: terminal presentation states prevent further action."""
+    t = TestTerminalStatesLocked()
+    t.test_applied_only_allows_idle()
+    t.test_discarded_only_allows_idle()
+    t.test_blocked_only_allows_idle()
+    t.test_applied_cannot_transition_to_staged()

--- a/tests/companion_ui/test_suggested_insertion.py
+++ b/tests/companion_ui/test_suggested_insertion.py
@@ -1,0 +1,249 @@
+"""Tests for SuggestedInsertion in-document preview marker (#869).
+
+Verifies:
+- <ins> element renders with correct staging attributes (amber tint hint).
+- data-state transitions: staged→applied on apply; staged→discarded on discard.
+- data-receipt populated after apply; aria-label includes anchor reference.
+- Discarded state removes element from DOM (is_visible=False).
+- Governance proposals do not produce a SuggestedInsertion (boundary note).
+- No Canvas Core / Panel / runtime dependency.
+"""
+
+import pytest
+
+from companion_ui.canvas_suggestion_flow.suggested_insertion import (
+    INSERTION_STATES,
+    SuggestedInsertion,
+    make_stub_insertion,
+)
+
+
+# ---------------------------------------------------------------------------
+# AC: staged styling — amber colour hint, correct label, ins element
+# ---------------------------------------------------------------------------
+
+class TestSuggestedInsertionStagedStyling:
+    def test_suggested_insertion_staged_styling(self) -> None:
+        ins = make_stub_insertion()
+        assert ins.state == "staged"
+        assert ins.color_hint == "amber"
+
+    def test_staged_label(self) -> None:
+        ins = make_stub_insertion()
+        assert ins.label == "PROPOSED · UNCOMMITTED"
+
+    def test_staged_is_visible(self) -> None:
+        ins = make_stub_insertion()
+        assert ins.is_visible is True
+
+    def test_staged_render_dict_element_is_ins(self) -> None:
+        ins = make_stub_insertion()
+        d = ins.as_render_dict()
+        assert d["element"] == "ins"
+
+    def test_staged_render_dict_css_class(self) -> None:
+        ins = make_stub_insertion()
+        d = ins.as_render_dict()
+        assert d["css_class"] == "suggested-insertion"
+
+    def test_staged_render_dict_data_testid(self) -> None:
+        ins = make_stub_insertion()
+        d = ins.as_render_dict()
+        assert d["data_testid"] == "suggested-insertion-block"
+
+    def test_staged_render_dict_data_state(self) -> None:
+        ins = make_stub_insertion()
+        d = ins.as_render_dict()
+        assert d["data_state"] == "staged"
+
+    def test_staged_render_dict_color_hint(self) -> None:
+        ins = make_stub_insertion()
+        d = ins.as_render_dict()
+        assert d["color_hint"] == "amber"
+
+    def test_staged_receipt_is_empty(self) -> None:
+        ins = make_stub_insertion()
+        assert ins.receipt_id == ""
+        d = ins.as_render_dict()
+        assert d["data_receipt"] == ""
+
+
+# ---------------------------------------------------------------------------
+# AC: state transitions staged→applied and staged→discarded
+# ---------------------------------------------------------------------------
+
+class TestSuggestedInsertionStateTransitions:
+    def test_suggested_insertion_state_transitions_apply(self) -> None:
+        ins = make_stub_insertion()
+        ins.apply(receipt_id="rcpt-001")
+        assert ins.state == "applied"
+
+    def test_suggested_insertion_state_transitions_discard(self) -> None:
+        ins = make_stub_insertion()
+        ins.discard()
+        assert ins.state == "discarded"
+
+    def test_applied_color_hint_is_vault_green(self) -> None:
+        ins = make_stub_insertion()
+        ins.apply()
+        assert ins.color_hint == "vault-green"
+
+    def test_discarded_color_hint_is_none(self) -> None:
+        ins = make_stub_insertion()
+        ins.discard()
+        assert ins.color_hint is None
+
+    def test_cannot_apply_from_applied(self) -> None:
+        ins = make_stub_insertion()
+        ins.apply()
+        with pytest.raises(ValueError, match="Cannot apply"):
+            ins.apply()
+
+    def test_cannot_discard_from_applied(self) -> None:
+        ins = make_stub_insertion()
+        ins.apply()
+        with pytest.raises(ValueError, match="Cannot discard"):
+            ins.discard()
+
+    def test_cannot_apply_from_discarded(self) -> None:
+        ins = make_stub_insertion()
+        ins.discard()
+        with pytest.raises(ValueError, match="Cannot apply"):
+            ins.apply()
+
+    def test_all_states_defined(self) -> None:
+        assert INSERTION_STATES == {"staged", "applied", "discarded"}
+
+
+# ---------------------------------------------------------------------------
+# AC: data-receipt populated after apply; aria-label includes anchor
+# ---------------------------------------------------------------------------
+
+class TestSuggestedInsertionReceiptPopulated:
+    def test_suggested_insertion_receipt_populated(self) -> None:
+        ins = make_stub_insertion()
+        ins.apply(receipt_id="rcpt-abc")
+        assert ins.receipt_id == "rcpt-abc"
+        d = ins.as_render_dict()
+        assert d["data_receipt"] == "rcpt-abc"
+
+    def test_applied_label_includes_receipt_id(self) -> None:
+        ins = make_stub_insertion()
+        ins.apply(receipt_id="rcpt-xyz")
+        assert "rcpt-xyz" in ins.label
+
+    def test_applied_label_without_receipt_id(self) -> None:
+        ins = make_stub_insertion()
+        ins.apply()
+        assert ins.label == "APPLIED"
+
+    def test_aria_label_includes_anchor(self) -> None:
+        ins = make_stub_insertion(anchor_description="3 lines after ## Summary")
+        assert "3 lines after ## Summary" in ins.aria_label
+
+    def test_aria_label_prefix(self) -> None:
+        ins = make_stub_insertion(anchor_description="after the intro paragraph")
+        assert ins.aria_label.startswith("Proposed insertion")
+
+    def test_aria_label_in_render_dict(self) -> None:
+        ins = make_stub_insertion(anchor_description="after heading")
+        d = ins.as_render_dict()
+        assert "after heading" in d["aria_label"]
+
+    def test_suggestion_id_in_render_dict(self) -> None:
+        ins = make_stub_insertion(suggestion_id="sugg-test-99")
+        d = ins.as_render_dict()
+        assert d["data_suggestion_id"] == "sugg-test-99"
+
+
+# ---------------------------------------------------------------------------
+# AC: discarded state removes element from DOM
+# ---------------------------------------------------------------------------
+
+class TestSuggestedInsertionDiscardedRemoved:
+    def test_suggested_insertion_discarded_removed(self) -> None:
+        ins = make_stub_insertion()
+        ins.discard()
+        assert ins.is_visible is False
+
+    def test_discarded_render_dict_is_visible_false(self) -> None:
+        ins = make_stub_insertion()
+        ins.discard()
+        d = ins.as_render_dict()
+        assert d["is_visible"] is False
+
+    def test_discarded_data_state_in_render_dict(self) -> None:
+        ins = make_stub_insertion()
+        ins.discard()
+        d = ins.as_render_dict()
+        assert d["data_state"] == "discarded"
+
+    def test_staged_is_visible_true(self) -> None:
+        ins = make_stub_insertion()
+        d = ins.as_render_dict()
+        assert d["is_visible"] is True
+
+    def test_applied_is_visible_true(self) -> None:
+        ins = make_stub_insertion()
+        ins.apply()
+        assert ins.is_visible is True
+
+
+# ---------------------------------------------------------------------------
+# Required fields
+# ---------------------------------------------------------------------------
+
+class TestSuggestedInsertionRequiredFields:
+    def test_suggestion_id_required(self) -> None:
+        with pytest.raises(ValueError, match="suggestion_id is required"):
+            SuggestedInsertion(
+                suggestion_id="",
+                anchor_description="after intro",
+                proposed_text="text",
+            )
+
+    def test_anchor_description_required(self) -> None:
+        with pytest.raises(ValueError, match="anchor_description is required"):
+            SuggestedInsertion(
+                suggestion_id="s1",
+                anchor_description="",
+                proposed_text="text",
+            )
+
+    def test_proposed_text_required(self) -> None:
+        with pytest.raises(ValueError, match="proposed_text is required"):
+            SuggestedInsertion(
+                suggestion_id="s1",
+                anchor_description="after intro",
+                proposed_text="",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Boundary: governance proposals do not produce SuggestedInsertion
+# ---------------------------------------------------------------------------
+
+class TestGovernanceBoundary:
+    def test_governance_does_not_render_insertion_module_note(self) -> None:
+        import companion_ui.canvas_suggestion_flow.suggested_insertion as mod
+        src = open(mod.__file__).read()
+        assert "governance proposals do not produce" in src.lower() or \
+               "no in-document preview for governance" in src.lower()
+
+    def test_no_canvas_core_import(self) -> None:
+        import companion_ui.canvas_suggestion_flow.suggested_insertion as mod
+        src = open(mod.__file__).read()
+        assert "canvas_core" not in src
+
+    def test_no_panel_import(self) -> None:
+        import companion_ui.canvas_suggestion_flow.suggested_insertion as mod
+        src = open(mod.__file__).read()
+        assert "from companion_ui.panel" not in src
+
+    def test_no_vault_write(self) -> None:
+        import companion_ui.canvas_suggestion_flow.suggested_insertion as mod
+        src = open(mod.__file__).read()
+        assert "WriteGuard" not in src
+        # canvas_writer may appear in docstring explanation; ensure it is not imported
+        assert "import canvas_writer" not in src
+        assert "canvas_writer." not in src

--- a/tests/companion_ui/test_suggested_insertion.py
+++ b/tests/companion_ui/test_suggested_insertion.py
@@ -247,3 +247,34 @@ class TestGovernanceBoundary:
         # canvas_writer may appear in docstring explanation; ensure it is not imported
         assert "import canvas_writer" not in src
         assert "canvas_writer." not in src
+
+
+# ---------------------------------------------------------------------------
+# Top-level AC entry points — exact Verify: targets from issue #869
+# ---------------------------------------------------------------------------
+
+def test_suggested_insertion_staged_styling() -> None:
+    """AC: <ins> element renders with correct staging attributes (amber colour hint)."""
+    t = TestSuggestedInsertionStagedStyling()
+    t.test_suggested_insertion_staged_styling()
+    t.test_staged_render_dict_element_is_ins()
+    t.test_staged_render_dict_data_state()
+
+
+def test_suggested_insertion_state_transitions() -> None:
+    """AC: data-state transitions staged→applied on apply; staged→discarded on discard."""
+    t = TestSuggestedInsertionStateTransitions()
+    t.test_suggested_insertion_state_transitions_apply()
+    t.test_suggested_insertion_state_transitions_discard()
+
+
+def test_suggested_insertion_receipt_populated() -> None:
+    """AC: data-receipt populated after apply; aria-label includes anchor reference."""
+    t = TestSuggestedInsertionReceiptPopulated()
+    t.test_suggested_insertion_receipt_populated()
+    t.test_aria_label_includes_anchor()
+
+
+def test_suggested_insertion_discarded_removed() -> None:
+    """AC: discarded state removes element from DOM (is_visible=False)."""
+    TestSuggestedInsertionDiscardedRemoved().test_suggested_insertion_discarded_removed()

--- a/tests/companion_ui/test_suggestion_card.py
+++ b/tests/companion_ui/test_suggestion_card.py
@@ -1,0 +1,230 @@
+"""Tests for SuggestionCard render model (#868).
+
+Verifies:
+- Body variant renders Apply + Discard + Inspect intents.
+- Governance variant has NO Apply intent in DOM — hard invariant.
+- Blocked variant carries role="alert" and denial reason.
+- suggestion_id matches between card and SuggestedInsertion (consistency check).
+- No Canvas Core / Panel / runtime dependency.
+- No vault writes.
+"""
+
+import pytest
+
+from companion_ui.canvas_suggestion_flow.suggestion_card import (
+    CARD_VARIANTS,
+    SuggestionCard,
+    make_stub_body_card,
+    make_stub_governance_card,
+    make_stub_blocked_card,
+)
+
+
+# ---------------------------------------------------------------------------
+# AC: Body variant renders Apply button
+# ---------------------------------------------------------------------------
+
+class TestSuggestionCardBodyVariant:
+    def test_suggestion_card_body_variant_renders_apply_button(self) -> None:
+        card = make_stub_body_card()
+        assert "suggestion.apply" in card.available_intents
+
+    def test_body_variant_has_apply_intent_flag(self) -> None:
+        card = make_stub_body_card()
+        assert card.has_apply_intent is True
+
+    def test_body_variant_has_discard(self) -> None:
+        card = make_stub_body_card()
+        assert "suggestion.discard" in card.available_intents
+
+    def test_body_variant_has_inspect(self) -> None:
+        card = make_stub_body_card()
+        assert "suggestion.inspect" in card.available_intents
+
+    def test_body_variant_color_hint_is_amber(self) -> None:
+        card = make_stub_body_card()
+        assert card.color_hint == "amber"
+
+    def test_body_variant_no_aria_role(self) -> None:
+        card = make_stub_body_card()
+        assert card.aria_role is None
+
+    def test_body_variant_no_classification_notice(self) -> None:
+        card = make_stub_body_card()
+        assert card.classification_notice is None
+
+    def test_body_render_dict_includes_apply_in_intents(self) -> None:
+        card = make_stub_body_card()
+        d = card.as_render_dict()
+        assert "suggestion.apply" in d["available_intents"]
+
+    def test_body_render_dict_data_variant(self) -> None:
+        card = make_stub_body_card()
+        d = card.as_render_dict()
+        assert d["data_variant"] == "body"
+
+    def test_body_render_dict_testid(self) -> None:
+        card = make_stub_body_card()
+        d = card.as_render_dict()
+        assert d["data_testid"] == "suggestion-card"
+
+
+# ---------------------------------------------------------------------------
+# AC: Governance variant has NO Apply button
+# ---------------------------------------------------------------------------
+
+class TestGovernanceVariantHasNoApplyButton:
+    def test_governance_variant_has_no_apply_button(self) -> None:
+        card = make_stub_governance_card()
+        assert "suggestion.apply" not in card.available_intents
+
+    def test_governance_has_apply_intent_flag_false(self) -> None:
+        card = make_stub_governance_card()
+        assert card.has_apply_intent is False
+
+    def test_governance_variant_has_queue(self) -> None:
+        card = make_stub_governance_card()
+        assert "governance.queue" in card.available_intents
+
+    def test_governance_variant_has_discard(self) -> None:
+        card = make_stub_governance_card()
+        assert "suggestion.discard" in card.available_intents
+
+    def test_governance_variant_has_inspect(self) -> None:
+        card = make_stub_governance_card()
+        assert "suggestion.inspect" in card.available_intents
+
+    def test_governance_render_dict_no_apply(self) -> None:
+        card = make_stub_governance_card()
+        d = card.as_render_dict()
+        assert "suggestion.apply" not in d["available_intents"]
+
+    def test_governance_color_hint_is_gold(self) -> None:
+        card = make_stub_governance_card()
+        assert card.color_hint == "gold"
+
+    def test_governance_has_classification_notice(self) -> None:
+        card = make_stub_governance_card()
+        assert card.classification_notice is not None
+        assert "queued" in card.classification_notice.lower()
+
+    def test_governance_render_dict_classification_testid(self) -> None:
+        card = make_stub_governance_card()
+        d = card.as_render_dict()
+        assert d.get("data_testid_classification") == "suggestion-card-classification"
+
+    def test_governance_render_dict_data_variant(self) -> None:
+        card = make_stub_governance_card()
+        d = card.as_render_dict()
+        assert d["data_variant"] == "governance"
+
+
+# ---------------------------------------------------------------------------
+# AC: Blocked variant is alert role
+# ---------------------------------------------------------------------------
+
+class TestBlockedVariantIsAlertRole:
+    def test_blocked_variant_is_alert_role(self) -> None:
+        card = make_stub_blocked_card()
+        assert card.aria_role == "alert"
+
+    def test_blocked_variant_carries_denial_reason(self) -> None:
+        card = make_stub_blocked_card(denial_reason="Canvas writes are currently disabled.")
+        d = card.as_render_dict()
+        assert d["denial_reason"] == "Canvas writes are currently disabled."
+
+    def test_blocked_has_no_apply_intent(self) -> None:
+        card = make_stub_blocked_card()
+        assert "suggestion.apply" not in card.available_intents
+
+    def test_blocked_has_acknowledge_intent(self) -> None:
+        card = make_stub_blocked_card()
+        assert "blocked.acknowledge" in card.available_intents
+
+    def test_blocked_requires_denial_reason(self) -> None:
+        with pytest.raises(ValueError, match="denial_reason is required"):
+            SuggestionCard(
+                suggestion_id="sugg-x",
+                variant="blocked",
+                title="Blocked",
+                preview_text="...",
+                denial_reason=None,
+            )
+
+    def test_blocked_color_hint_is_neutral(self) -> None:
+        card = make_stub_blocked_card()
+        assert card.color_hint == "neutral"
+
+
+# ---------------------------------------------------------------------------
+# AC: suggestion_id consistency
+# ---------------------------------------------------------------------------
+
+class TestSuggestionIdConsistency:
+    def test_suggestion_id_consistency(self) -> None:
+        from companion_ui.canvas_suggestion_flow.suggested_insertion import (
+            make_stub_insertion,
+        )
+        sid = "sugg-abc-123"
+        card = make_stub_body_card(suggestion_id=sid)
+        insertion = make_stub_insertion(suggestion_id=sid)
+        assert card.suggestion_id == insertion.suggestion_id
+
+    def test_suggestion_id_in_render_dict(self) -> None:
+        card = make_stub_body_card(suggestion_id="sugg-xyz")
+        d = card.as_render_dict()
+        assert d["data_suggestion_id"] == "sugg-xyz"
+
+    def test_suggestion_id_required(self) -> None:
+        with pytest.raises(ValueError, match="suggestion_id is required"):
+            SuggestionCard(
+                suggestion_id="",
+                variant="body",
+                title="title",
+                preview_text="text",
+            )
+
+    def test_title_required(self) -> None:
+        with pytest.raises(ValueError, match="title is required"):
+            SuggestionCard(
+                suggestion_id="s1",
+                variant="body",
+                title="",
+                preview_text="text",
+            )
+
+    def test_unknown_variant_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown SuggestionCard variant"):
+            SuggestionCard(
+                suggestion_id="s1",
+                variant="unknown",
+                title="title",
+                preview_text="text",
+            )
+
+    def test_all_variants_defined(self) -> None:
+        assert CARD_VARIANTS == {"body", "governance", "blocked"}
+
+
+# ---------------------------------------------------------------------------
+# Boundary: no Canvas Core / Panel / runtime coupling
+# ---------------------------------------------------------------------------
+
+class TestNoBoundaryCrossing:
+    def test_no_canvas_core_import(self) -> None:
+        import companion_ui.canvas_suggestion_flow.suggestion_card as mod
+        src = open(mod.__file__).read()
+        assert "canvas_core" not in src
+
+    def test_no_panel_import(self) -> None:
+        import companion_ui.canvas_suggestion_flow.suggestion_card as mod
+        src = open(mod.__file__).read()
+        assert "from companion_ui.panel" not in src
+
+    def test_no_vault_write(self) -> None:
+        import companion_ui.canvas_suggestion_flow.suggestion_card as mod
+        src = open(mod.__file__).read()
+        assert "WriteGuard" not in src
+        # canvas_writer may appear in docstring explanation; ensure it is not imported
+        assert "import canvas_writer" not in src
+        assert "canvas_writer." not in src

--- a/tests/companion_ui/test_suggestion_card.py
+++ b/tests/companion_ui/test_suggestion_card.py
@@ -228,3 +228,31 @@ class TestNoBoundaryCrossing:
         # canvas_writer may appear in docstring explanation; ensure it is not imported
         assert "import canvas_writer" not in src
         assert "canvas_writer." not in src
+
+
+# ---------------------------------------------------------------------------
+# Top-level AC entry points — exact Verify: targets from issue #868
+# ---------------------------------------------------------------------------
+
+def test_suggestion_card_body_variant_renders_apply_button() -> None:
+    """AC: body variant renders Apply button (suggestion.apply intent)."""
+    TestSuggestionCardBodyVariant().test_suggestion_card_body_variant_renders_apply_button()
+
+
+def test_governance_variant_has_no_apply_button() -> None:
+    """AC: governance variant has no Apply button in DOM."""
+    t = TestGovernanceVariantHasNoApplyButton()
+    t.test_governance_variant_has_no_apply_button()
+    t.test_governance_render_dict_no_apply()
+
+
+def test_blocked_variant_is_alert_role() -> None:
+    """AC: blocked variant carries role='alert' and denial reason."""
+    t = TestBlockedVariantIsAlertRole()
+    t.test_blocked_variant_is_alert_role()
+    t.test_blocked_variant_carries_denial_reason()
+
+
+def test_suggestion_id_consistency() -> None:
+    """AC: data-suggestion-id matches between card and SuggestedInsertion block."""
+    TestSuggestionIdConsistency().test_suggestion_id_consistency()


### PR DESCRIPTION
## Summary

Implements the first batch of Canvas bounded suggestion flow UI models as isolated Companion UI Python modules — no backend, runtime, vault, or Canvas Core coupling.

- **`canvas_suggestion_flow/rail_state_machine.py`** (`#870`): 9-state machine with canonical snake_case names, DOM alias map, transition guard, error-path return to `staged_*`, and terminal-state locking. Hard invariants: governance proposals never enter `apply_pending`; no skip from `staged_*` to terminal without the pending state.
- **`canvas_suggestion_flow/suggestion_card.py`** (`#868`): `SuggestionCard` render model with `body`, `governance`, and `blocked` variants. Hard invariant: governance variant exposes **no** `suggestion.apply` intent. Blocked variant carries `role="alert"` and `denial_reason`.
- **`canvas_suggestion_flow/suggested_insertion.py`** (`#869`): `SuggestedInsertion` `<ins>` render model with `staged`/`applied`/`discarded` lifecycle, amber/vault-green colour hints, `data-receipt` population on apply, and `is_visible=False` on discard. Governance proposals do not produce an insertion block.

Also fixes `test_canvas_core_composition.py::test_full_composition_flow` to inspect Canvas Core **source files** for the surface-boundary check instead of `sys.modules`, which was unreliable in a shared pytest session once the `canvas_suggestion_flow` test files are collected.

Advances #870, #868, #869.

## Files

| File | Role |
|---|---|
| `companion-ui/companion-app/companion_ui/canvas_suggestion_flow/__init__.py` | Package marker |
| `companion-ui/companion-app/companion_ui/canvas_suggestion_flow/rail_state_machine.py` | #870 |
| `companion-ui/companion-app/companion_ui/canvas_suggestion_flow/suggestion_card.py` | #868 |
| `companion-ui/companion-app/companion_ui/canvas_suggestion_flow/suggested_insertion.py` | #869 |
| `tests/companion_ui/test_canvas_rail_state_machine.py` | AC tests for #870 |
| `tests/companion_ui/test_suggestion_card.py` | AC tests for #868 |
| `tests/companion_ui/test_suggested_insertion.py` | AC tests for #869 |
| `tests/companion_ui/test_canvas_core_composition.py` | Surface-boundary check fix |

## Test plan

- [x] `python -m pytest tests/companion_ui/ -v` — 368 passed, 0 failed
- [x] All 6 named AC test functions from issue contracts present and passing
- [x] Pre-existing Canvas Core and Panel tests unaffected
- [x] No imports of `canvas_core`, `panel`, `canvas_writer`, `WriteGuard`, or `GovernanceRouter` in new modules

## Out of scope (not implemented)

- Panel runtime, Panel confirmation endpoint, vault writes, watcher behavior
- Governance execution, backend/runtime integration, durable projection
- ReceiptPill/ReceiptsStrip (#871), keyboard shortcuts (#872), portrait bottom sheet (#873), ProvenanceFooter (#874)

🤖 Generated with [Claude Code](https://claude.com/claude-code)