### PR TITLE
feat(canvas-ui): implement bounded suggestion Batch 2 models

### DIFF
--- a/companion-ui/companion-app/companion_ui/canvas_suggestion_flow/keyboard_shortcuts.py
+++ b/companion-ui/companion-app/companion_ui/canvas_suggestion_flow/keyboard_shortcuts.py
@@ -37,7 +37,7 @@ class ShortcutAction(Enum):
     QUEUE_GOVERNANCE_SUGGESTION = "governance.queue"
     DISCARD_SUGGESTION = "suggestion.discard"
     INSPECT_SUGGESTION = "suggestion.inspect"
-    DISMISS_RAIL = "composer.enable"
+    DISMISS_RAIL = "suggestion.edit"
 
 
 # Canonical key bindings for each action (issue #872 table).
@@ -87,6 +87,11 @@ _MUTATING_ACTIONS: frozenset[ShortcutAction] = frozenset({
     ShortcutAction.DISCARD_SUGGESTION,
 })
 
+# Rail states in which a suggestion is staged and awaiting user action.
+# Mutating shortcuts (APPLY, QUEUE, DISCARD) are only offered when the rail
+# is in one of these states — matches CANVAS_SUGGESTION_FLOW.md §States.
+_STAGED_STATES: frozenset[str] = frozenset({"staged_body", "staged_governance"})
+
 
 class SuggestionShortcutMap:
     """Keyboard shortcut map for the bounded suggestion rail.
@@ -133,12 +138,14 @@ class SuggestionShortcutMap:
     def available_actions(self) -> list[ShortcutAction]:
         """Return the list of available ShortcutActions for this variant/state.
 
-        When in a terminal state, mutating shortcuts (APPLY, QUEUE, DISCARD) are
-        suppressed — only INSPECT and DISMISS remain.
+        Mutating shortcuts (APPLY, QUEUE, DISCARD) are suppressed when:
+        - the rail is in a terminal presentation state, OR
+        - the rail_state is not a staged state (idle, thinking, apply_pending, etc.)
+
+        Only INSPECT and DISMISS remain when shortcuts are gated out.
         """
         base = _VARIANT_ACTIONS[self._variant]
-        if self._terminal_state:
-            # Remove mutating actions; terminal state is read-only.
+        if self._terminal_state or self._rail_state not in _STAGED_STATES:
             base = base - _MUTATING_ACTIONS
         return sorted(base, key=lambda a: a.value)
 

--- a/companion-ui/companion-app/companion_ui/canvas_suggestion_flow/keyboard_shortcuts.py
+++ b/companion-ui/companion-app/companion_ui/canvas_suggestion_flow/keyboard_shortcuts.py
@@ -1,0 +1,166 @@
+"""Keyboard shortcut mapping model for the Canvas bounded suggestion rail (#872).
+
+Scoped shortcuts active only when the rail is in a staged state awaiting user
+action on a suggestion.  Shortcuts produce intent tokens / render hints only.
+
+No DOM event listeners, no global hotkey registration, no runtime side effects.
+
+Rules from issue #872:
+- body variant: APPLY_BODY_SUGGESTION (A), DISCARD (D), INSPECT (I), DISMISS (E)
+- governance variant: QUEUE_GOVERNANCE_SUGGESTION (Q), DISCARD (D), INSPECT (I), DISMISS (E)
+- blocked variant: INSPECT (I), DISMISS_RAIL (E) only — cannot APPLY or QUEUE
+- terminal state: no mutating shortcuts (no APPLY, QUEUE, DISCARD)
+
+Hard invariants:
+- APPLY_BODY_SUGGESTION is NEVER available for the governance variant.
+- QUEUE_GOVERNANCE_SUGGESTION is NEVER available for the body variant.
+- Blocked and terminal states cannot APPLY or QUEUE.
+- Composer always has keyboard focus unless rail is in a staged state.
+- Shortcuts do not fire if a text input is focused elsewhere (caller responsibility).
+
+Boundary:
+- No imports from companion_ui.canvas_core, companion_ui.panel, or any runtime writer.
+- No vault writes, no event dispatch, no DOM interaction.
+"""
+
+from __future__ import annotations
+
+from enum import Enum, unique
+from typing import Optional
+
+
+@unique
+class ShortcutAction(Enum):
+    """Available shortcut actions in the canvas suggestion rail."""
+
+    APPLY_BODY_SUGGESTION = "suggestion.apply"
+    QUEUE_GOVERNANCE_SUGGESTION = "governance.queue"
+    DISCARD_SUGGESTION = "suggestion.discard"
+    INSPECT_SUGGESTION = "suggestion.inspect"
+    DISMISS_RAIL = "composer.enable"
+
+
+# Canonical key bindings for each action (issue #872 table).
+_ACTION_KEY: dict[ShortcutAction, str] = {
+    ShortcutAction.APPLY_BODY_SUGGESTION:      "A",
+    ShortcutAction.QUEUE_GOVERNANCE_SUGGESTION: "Q",
+    ShortcutAction.DISCARD_SUGGESTION:         "D",
+    ShortcutAction.INSPECT_SUGGESTION:         "I",
+    ShortcutAction.DISMISS_RAIL:               "E",
+}
+
+# Valid rail variant names accepted by SuggestionShortcutMap.
+SHORTCUT_VARIANTS: frozenset[str] = frozenset({"body", "governance", "blocked", "terminal"})
+
+# Actions available per variant when NOT in a terminal state.
+# Hard invariant: governance variant MUST NOT include APPLY_BODY_SUGGESTION.
+# Hard invariant: body variant MUST NOT include QUEUE_GOVERNANCE_SUGGESTION.
+# Hard invariant: blocked variant MUST NOT include APPLY or QUEUE.
+_VARIANT_ACTIONS: dict[str, frozenset[ShortcutAction]] = {
+    "body": frozenset({
+        ShortcutAction.APPLY_BODY_SUGGESTION,
+        ShortcutAction.DISCARD_SUGGESTION,
+        ShortcutAction.INSPECT_SUGGESTION,
+        ShortcutAction.DISMISS_RAIL,
+    }),
+    "governance": frozenset({
+        ShortcutAction.QUEUE_GOVERNANCE_SUGGESTION,
+        ShortcutAction.DISCARD_SUGGESTION,
+        ShortcutAction.INSPECT_SUGGESTION,
+        ShortcutAction.DISMISS_RAIL,
+    }),
+    "blocked": frozenset({
+        ShortcutAction.INSPECT_SUGGESTION,
+        ShortcutAction.DISMISS_RAIL,
+    }),
+    # "terminal" is handled separately: no mutating shortcuts regardless of other state.
+    "terminal": frozenset({
+        ShortcutAction.INSPECT_SUGGESTION,
+        ShortcutAction.DISMISS_RAIL,
+    }),
+}
+
+# Mutating actions — forbidden in terminal state and blocked variant.
+_MUTATING_ACTIONS: frozenset[ShortcutAction] = frozenset({
+    ShortcutAction.APPLY_BODY_SUGGESTION,
+    ShortcutAction.QUEUE_GOVERNANCE_SUGGESTION,
+    ShortcutAction.DISCARD_SUGGESTION,
+})
+
+
+class SuggestionShortcutMap:
+    """Keyboard shortcut map for the bounded suggestion rail.
+
+    Takes a variant (body | governance | blocked | terminal) and an optional
+    rail state string (pass-through from the rail state machine — not coupled
+    to its internals beyond accepting a string).
+
+    terminal_state — if True, all mutating shortcuts (APPLY, QUEUE, DISCARD) are
+    suppressed regardless of variant.  This mirrors the terminal-presentation-state
+    lock in the rail state machine.
+
+    Shortcuts produce intent tokens / render hints only — no DOM wiring here.
+    """
+
+    def __init__(
+        self,
+        variant: str,
+        rail_state: str = "idle",
+        *,
+        terminal_state: bool = False,
+    ) -> None:
+        if variant not in SHORTCUT_VARIANTS:
+            raise ValueError(
+                f"Unknown shortcut variant: {variant!r}. "
+                f"Must be one of {sorted(SHORTCUT_VARIANTS)}."
+            )
+        self._variant = variant
+        self._rail_state = rail_state
+        self._terminal_state = terminal_state or (variant == "terminal")
+
+    @property
+    def variant(self) -> str:
+        return self._variant
+
+    @property
+    def rail_state(self) -> str:
+        return self._rail_state
+
+    @property
+    def is_terminal(self) -> bool:
+        return self._terminal_state
+
+    def available_actions(self) -> list[ShortcutAction]:
+        """Return the list of available ShortcutActions for this variant/state.
+
+        When in a terminal state, mutating shortcuts (APPLY, QUEUE, DISCARD) are
+        suppressed — only INSPECT and DISMISS remain.
+        """
+        base = _VARIANT_ACTIONS[self._variant]
+        if self._terminal_state:
+            # Remove mutating actions; terminal state is read-only.
+            base = base - _MUTATING_ACTIONS
+        return sorted(base, key=lambda a: a.value)
+
+    def key_for(self, action: ShortcutAction) -> Optional[str]:
+        """Return the key string for action if it is available, else None."""
+        if action in self.available_actions():
+            return _ACTION_KEY[action]
+        return None
+
+    def to_render_dict(self) -> dict:
+        """Serialisable dict for the UI layer.
+
+        Contains the variant, rail state, terminal flag, and a mapping of
+        available action intent tokens to their key bindings.  The UI layer
+        uses this to render keyboard shortcut hints and to gate intent dispatch.
+        """
+        actions = self.available_actions()
+        bindings = {a.value: _ACTION_KEY[a] for a in actions}
+        return {
+            "variant": self._variant,
+            "rail_state": self._rail_state,
+            "is_terminal": self._terminal_state,
+            "available_actions": [a.value for a in actions],
+            "key_bindings": bindings,
+        }

--- a/companion-ui/companion-app/companion_ui/canvas_suggestion_flow/portrait_sheet.py
+++ b/companion-ui/companion-app/companion_ui/canvas_suggestion_flow/portrait_sheet.py
@@ -1,0 +1,137 @@
+"""Portrait/mobile bottom sheet model for the bounded suggestion rail (#873).
+
+At viewport widths < 900 px, the Hugin rail becomes a bottom sheet replacing
+the side rail.  This module models the snap state and transition rules without
+any CSS, React, DOM, localStorage, or gesture handling.
+
+Snap points (from issue #873 §Snap points):
+  PEEK             60 px  Default / collapsed; shows Hugin dot + turn count.
+  HALF             50vh   Expanded conversation; document still visible above.
+  FULL_MINUS_CHROME calc(100vh - 64px)  Full conversation.
+  CLOSED           Not visible at all.
+
+Auto-snap rule (contract §873):
+  When a proposal arrives (state → staged-body or staged-gov), the sheet
+  auto-snaps from PEEK → HALF.  Auto-snap to FULL_MINUS_CHROME is FORBIDDEN —
+  the document must remain visible at the insertion point.
+
+Body remains primary; the sheet is an overlay/secondary surface.
+
+Immutable transition model: transition_to() returns a NEW PortraitSheet
+instance rather than mutating state in place.
+
+Boundary:
+  - No CSS, React, DOM, localStorage, or gesture handling.
+  - No imports from companion_ui.canvas_core, companion_ui.panel, or runtime writers.
+  - No vault writes, no watcher code, no backend API calls.
+  - rail_state is accepted as a plain string (pass-through from the rail state
+    machine) — no import coupling to rail_state_machine.py.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, unique
+
+
+@unique
+class SheetSnap(Enum):
+    """Snap points for the portrait bottom sheet.
+
+    Ordering reflects sheet height from smallest to largest, excluding CLOSED.
+    """
+
+    PEEK = "peek"
+    HALF = "half"
+    FULL_MINUS_CHROME = "full"
+    CLOSED = "closed"
+
+
+# Auto-snap policy: auto-snap target when a proposal arrives.
+# FULL_MINUS_CHROME is the forbidden auto-snap target (document must stay visible).
+AUTO_SNAP_ON_PROPOSAL: SheetSnap = SheetSnap.HALF
+FORBIDDEN_AUTO_SNAP: SheetSnap = SheetSnap.FULL_MINUS_CHROME
+
+# Height hints (design reference — not CSS; caller uses these as hints).
+_SNAP_HEIGHT_HINT: dict[SheetSnap, str] = {
+    SheetSnap.PEEK:             "60px",
+    SheetSnap.HALF:             "50vh",
+    SheetSnap.FULL_MINUS_CHROME: "calc(100vh - 64px)",
+    SheetSnap.CLOSED:           "0",
+}
+
+
+@dataclass(frozen=True)
+class PortraitSheet:
+    """Immutable render model for the portrait bottom sheet.
+
+    suggestion_id  — the active suggestion this sheet is presenting.
+    current_snap   — current snap point (SheetSnap enum).
+    rail_state     — pass-through from rail state machine (plain string,
+                     no import coupling to rail_state_machine internals).
+
+    Body content remains primary; the sheet is an overlay/secondary surface.
+    All interactive elements should be ≥ 44 px height in portrait (touch targets).
+
+    Use transition_to() to obtain a new instance with an updated snap point.
+    """
+
+    suggestion_id: str
+    current_snap: SheetSnap
+    rail_state: str = "idle"
+
+    def transition_to(self, snap: SheetSnap) -> "PortraitSheet":
+        """Return a new PortraitSheet with current_snap set to snap.
+
+        Immutable: this instance is unchanged.
+        """
+        return PortraitSheet(
+            suggestion_id=self.suggestion_id,
+            current_snap=snap,
+            rail_state=self.rail_state,
+        )
+
+    def auto_snap_on_proposal(self) -> "PortraitSheet":
+        """Return a new PortraitSheet auto-snapped to HALF on proposal arrival.
+
+        Implements the contract: auto-snap from PEEK → HALF when a proposal
+        arrives.  FULL_MINUS_CHROME is forbidden as an auto-snap target.
+        """
+        return self.transition_to(AUTO_SNAP_ON_PROPOSAL)
+
+    def is_visible(self) -> bool:
+        """True unless current_snap is CLOSED."""
+        return self.current_snap is not SheetSnap.CLOSED
+
+    def height_hint(self) -> str:
+        """Design-reference height string for the current snap point."""
+        return _SNAP_HEIGHT_HINT[self.current_snap]
+
+    def to_render_dict(self) -> dict:
+        """Serialisable dict for the UI layer.
+
+        The dict carries rendering hints for the sheet component:
+        - current_snap: snap point enum value string
+        - height_hint: design reference height
+        - is_visible: whether the sheet is shown
+        - body_is_primary: True — document body is always the primary surface;
+          this sheet is overlay/secondary
+        - auto_snap_target: the permitted auto-snap target (always HALF)
+        - forbidden_auto_snap: auto-snap to FULL is forbidden (document must stay visible)
+        - touch_target_min_height: minimum interactive element height (44px, §873 contract)
+        - receipts_strip_position: sticky top (ReceiptsStrip renders at top of sheet)
+        """
+        return {
+            "data_testid": "portrait-sheet",
+            "suggestion_id": self.suggestion_id,
+            "rail_state": self.rail_state,
+            "current_snap": self.current_snap.value,
+            "height_hint": self.height_hint(),
+            "is_visible": self.is_visible(),
+            "body_is_primary": True,
+            "is_overlay": True,
+            "auto_snap_target": AUTO_SNAP_ON_PROPOSAL.value,
+            "forbidden_auto_snap": FORBIDDEN_AUTO_SNAP.value,
+            "touch_target_min_height": "44px",
+            "receipts_strip_position": "sticky-top",
+        }

--- a/companion-ui/companion-app/companion_ui/canvas_suggestion_flow/provenance_footer.py
+++ b/companion-ui/companion-app/companion_ui/canvas_suggestion_flow/provenance_footer.py
@@ -1,0 +1,148 @@
+"""ProvenanceFooter UI model for the Canvas bounded suggestion flow (#874).
+
+Displays backend/session-provided provenance fields and surfaces intent tokens
+for the UI layer to dispatch.  This model is a pure display/intent model:
+
+- It does NOT write files.
+- It does NOT call SessionLogWriter, WriteGuard, GovernanceRouter, or any
+  vault/runtime writer.
+- It does NOT compute inverse patches.
+- It does NOT append body_edit_undone to the session log.
+- It does NOT open files in Obsidian directly.
+- It does NOT derive authoritative session history.
+
+The footer dispatches exactly two intent tokens:
+  provenance.openSessionLog  — hands off to the application intent mechanism to
+                               open the .chats/... note in Obsidian.
+  canvas.undoLastEdit        — dispatches an undo intent for the active session's
+                               last applied body edit; backend handles the actual
+                               inverse-patch computation and application.
+
+Cross-session undo MUST NOT be dispatched by this footer.  The model captures
+whether undo is available via can_undo_last_body_edit supplied by the caller.
+
+Conceptual links (string references only, no import coupling):
+  SuggestionCard    — the card whose suggestion was applied triggering a body edit.
+  SuggestedInsertion — the in-document preview marker for the body edit.
+  ReceiptPill       — the receipt displayed after a governance queue event.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+# Intent tokens dispatched by the footer (read-only references, not routers).
+INTENT_OPEN_SESSION_LOG = "provenance.openSessionLog"
+INTENT_UNDO_LAST_EDIT = "canvas.undoLastEdit"
+
+
+@dataclass
+class ProvenanceFooter:
+    """Render model for the ProvenanceFooter UI component.
+
+    All fields are supplied by the backend/session context.  The footer renders
+    and dispatches intents; it owns no runtime truth.
+
+    Fields
+    ------
+    suggestion_id          ID of the paired suggestion (string reference only).
+    artifact_id            ID of the artifact being edited (string reference).
+    source_summary         Human-readable summary of the provenance source,
+                           e.g. ".chats/<note-slug>/<timestamp>.md".
+    route_summary          Human-readable summary of the route, e.g. "canvas direct body edit".
+    receipt_id             Optional receipt ID if a governance receipt was produced.
+    session_ref            Optional session reference string (e.g. session slug or ID).
+    session_log_path       Path supplied by backend/session context for the session log.
+                           MUST NOT be hardcoded.  None means unavailable.
+    turn_count             Number of turns in the session, supplied by session state.
+    can_undo_last_body_edit Whether the undo button should be enabled.
+    last_body_edit_id      Optional ID of the last applied body edit (for undo intent context).
+    """
+
+    suggestion_id: str
+    artifact_id: str
+    source_summary: str
+    route_summary: str
+    receipt_id: Optional[str] = None
+    session_ref: Optional[str] = None
+    session_log_path: Optional[str] = None
+    turn_count: int = 0
+    can_undo_last_body_edit: bool = False
+    last_body_edit_id: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not self.suggestion_id:
+            raise ValueError("suggestion_id is required")
+        if not self.artifact_id:
+            raise ValueError("artifact_id is required")
+        if not self.source_summary:
+            raise ValueError("source_summary is required")
+        if not self.route_summary:
+            raise ValueError("route_summary is required")
+        if self.turn_count < 0:
+            raise ValueError("turn_count must be non-negative")
+
+    @property
+    def undo_intent(self) -> Optional[dict]:
+        """The undo intent payload when undo is available, or None.
+
+        Returns None when can_undo_last_body_edit is False, ensuring the
+        footer cannot dispatch cross-session or unavailable undo intents.
+        """
+        if not self.can_undo_last_body_edit:
+            return None
+        return {
+            "intent": INTENT_UNDO_LAST_EDIT,
+            "session_ref": self.session_ref,
+            "last_body_edit_id": self.last_body_edit_id,
+        }
+
+    @property
+    def open_session_log_intent(self) -> Optional[dict]:
+        """The open-session-log intent payload when a path is available, or None."""
+        if not self.session_log_path:
+            return None
+        return {
+            "intent": INTENT_OPEN_SESSION_LOG,
+            "session_log_path": self.session_log_path,
+        }
+
+    def to_render_dict(self) -> dict:
+        """Serialisable dict for the UI layer.
+
+        Maps to the ProvenanceFooter HTML element defined in issue #874:
+          data-testid="provenance-footer"
+          aria-label="Session provenance"
+
+        The undo button is disabled when can_undo_last_body_edit is False.
+        The session log path button is disabled when session_log_path is None.
+
+        This dict carries no runtime write operations.
+        """
+        d: dict = {
+            "data_testid": "provenance-footer",
+            "aria_label": "Session provenance",
+            "suggestion_id": self.suggestion_id,
+            "artifact_id": self.artifact_id,
+            "source_summary": self.source_summary,
+            "route_summary": self.route_summary,
+            "turn_count": self.turn_count,
+            # Session log path button
+            "session_log_path": self.session_log_path,
+            "session_log_button_disabled": self.session_log_path is None,
+            "open_session_log_intent": INTENT_OPEN_SESSION_LOG,
+            "open_session_log_intent_payload": self.open_session_log_intent,
+            # Undo button
+            "undo_button_disabled": not self.can_undo_last_body_edit,
+            "undo_intent": INTENT_UNDO_LAST_EDIT,
+            "undo_intent_payload": self.undo_intent,
+            "data_testid_undo": "undo-last-edit",
+        }
+        if self.receipt_id is not None:
+            d["receipt_id"] = self.receipt_id
+        if self.session_ref is not None:
+            d["session_ref"] = self.session_ref
+        if self.last_body_edit_id is not None:
+            d["last_body_edit_id"] = self.last_body_edit_id
+        return d

--- a/companion-ui/companion-app/companion_ui/canvas_suggestion_flow/receipt_strip.py
+++ b/companion-ui/companion-app/companion_ui/canvas_suggestion_flow/receipt_strip.py
@@ -1,0 +1,160 @@
+"""ReceiptPill and ReceiptsStrip display models for the Canvas bounded suggestion flow (#871).
+
+ReceiptPill — inline pill rendered in the conversation thread when a governance
+intent is queued.  Links to Panel via the governance.openReceipt intent.
+
+ReceiptsStrip — sticky strip at the bottom of the rail listing non-terminal
+pending governance receipts for the session.  Has aria-live="polite" so
+upstream status transitions are announced.
+
+Receipts are display/status objects only.
+
+Boundary invariants:
+- These models MUST NOT write to the vault.
+- These models MUST NOT call GovernanceRouter, SessionLogWriter, WriteGuard,
+  or any runtime writer.
+- Body-edit applies do NOT generate a receipt (body edits are co-authoring, not
+  governance events).
+- The Companion UI NEVER auto-applies or auto-rejects a governance receipt; the
+  status shown here is read-only.
+- governance.openReceipt hands off to AI Panel anchored to the receipt_id.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+# Supported outcome values for a ReceiptPill.
+RECEIPT_OUTCOMES: frozenset[str] = frozenset({"applied", "queued", "discarded", "blocked"})
+
+# Terminal outcomes — pills with these outcomes are removed from ReceiptsStrip.
+_TERMINAL_OUTCOMES: frozenset[str] = frozenset({"applied", "discarded"})
+
+
+@dataclass
+class ReceiptPill:
+    """Render model for a single governance receipt pill.
+
+    Links to Panel via the ``governance.openReceipt`` intent token.
+
+    Fields
+    ------
+    receipt_id        Unique receipt identifier (UUID or slug).
+    suggestion_id     Paired suggestion that triggered the governance event.
+    artifact_id       Artifact the governance event targets.
+    outcome           One of: applied | queued | discarded | blocked.
+    label             Short human-readable label (e.g. "queued · rec-001 · move").
+    display_timestamp ISO-8601 or display-formatted timestamp string.
+    message           Optional extra context surfaced by the governance layer.
+    """
+
+    receipt_id: str
+    suggestion_id: str
+    artifact_id: str
+    outcome: str
+    label: str
+    display_timestamp: str
+    message: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not self.receipt_id:
+            raise ValueError("receipt_id is required")
+        if not self.suggestion_id:
+            raise ValueError("suggestion_id is required")
+        if not self.artifact_id:
+            raise ValueError("artifact_id is required")
+        if self.outcome not in RECEIPT_OUTCOMES:
+            raise ValueError(
+                f"Unknown receipt outcome: {self.outcome!r}. "
+                f"Must be one of {sorted(RECEIPT_OUTCOMES)}."
+            )
+        if not self.label:
+            raise ValueError("label is required for user-facing display")
+        if not self.display_timestamp:
+            raise ValueError("display_timestamp is required")
+
+    @property
+    def is_terminal(self) -> bool:
+        """True when the outcome is terminal (applied or discarded)."""
+        return self.outcome in _TERMINAL_OUTCOMES
+
+    def to_render_dict(self) -> dict:
+        """Serialisable dict for the UI layer.
+
+        Maps to the ReceiptPill HTML element attributes defined in issue #871:
+          data-testid="receipt-pill"
+          data-receipt-id="<uuid>"
+          data-status="<outcome>"
+          data-intent="governance.openReceipt"
+        """
+        d: dict = {
+            "data_testid": "receipt-pill",
+            "data_receipt_id": self.receipt_id,
+            "data_suggestion_id": self.suggestion_id,
+            "data_artifact_id": self.artifact_id,
+            "data_status": self.outcome,
+            "data_intent": "governance.openReceipt",
+            "aria_label": (
+                f"Governance receipt {self.receipt_id}, {self.outcome}. Open in Panel."
+            ),
+            "label": self.label,
+            "display_timestamp": self.display_timestamp,
+            "is_terminal": self.is_terminal,
+        }
+        if self.message is not None:
+            d["message"] = self.message
+        return d
+
+
+@dataclass
+class ReceiptsStrip:
+    """Render model for the sticky governance receipts strip in the rail.
+
+    Holds a list of ReceiptPill objects.  The strip renders only non-terminal
+    receipts (queued and blocked) when filtering for display; callers may also
+    access the full list.
+
+    aria-live="polite" is included in to_render_dict() so upstream status
+    transitions are announced to assistive technology.
+
+    The strip MUST NOT write to the vault.  It reads receipt state supplied
+    by the Panel locality (preventing orphaned pills when a Panel record is
+    dismissed elsewhere).
+    """
+
+    pills: list[ReceiptPill] = field(default_factory=list)
+
+    @property
+    def is_empty(self) -> bool:
+        """True when there are no pills at all."""
+        return len(self.pills) == 0
+
+    @property
+    def latest(self) -> Optional[ReceiptPill]:
+        """The most recently added ReceiptPill, or None if empty."""
+        if self.is_empty:
+            return None
+        return self.pills[-1]
+
+    @property
+    def non_terminal_pills(self) -> list[ReceiptPill]:
+        """Pills with non-terminal outcomes (queued, blocked) — shown in the strip."""
+        return [p for p in self.pills if not p.is_terminal]
+
+    def to_render_dict(self) -> dict:
+        """Serialisable dict for the UI layer.
+
+        Maps to the ReceiptsStrip HTML element attributes defined in issue #871:
+          data-testid="receipts-strip"
+          aria-live="polite"
+        """
+        return {
+            "data_testid": "receipts-strip",
+            "aria_live": "polite",
+            "is_empty": self.is_empty,
+            "pill_count": len(self.pills),
+            "non_terminal_pill_count": len(self.non_terminal_pills),
+            "pills": [p.to_render_dict() for p in self.pills],
+            "non_terminal_pills": [p.to_render_dict() for p in self.non_terminal_pills],
+        }

--- a/tests/companion_ui/test_canvas_portrait_sheet.py
+++ b/tests/companion_ui/test_canvas_portrait_sheet.py
@@ -1,0 +1,370 @@
+"""Tests for PortraitSheet model (#873).
+
+Verifies:
+- Construction with each snap state
+- transition_to produces new instance with correct snap
+- is_visible correct for each snap
+- render dict structure
+- auto_snap_on_proposal lands at HALF, never FULL
+- FULL_MINUS_CHROME is forbidden as auto-snap target
+- Immutability: transition_to does not mutate original
+- No dependency on Canvas Core, Panel, backend runtime, or vault writes.
+"""
+
+import pytest
+
+from companion_ui.canvas_suggestion_flow.portrait_sheet import (
+    AUTO_SNAP_ON_PROPOSAL,
+    FORBIDDEN_AUTO_SNAP,
+    SheetSnap,
+    PortraitSheet,
+)
+
+
+# ---------------------------------------------------------------------------
+# SheetSnap enum
+# ---------------------------------------------------------------------------
+
+class TestSheetSnap:
+    def test_peek_value(self) -> None:
+        assert SheetSnap.PEEK.value == "peek"
+
+    def test_half_value(self) -> None:
+        assert SheetSnap.HALF.value == "half"
+
+    def test_full_minus_chrome_value(self) -> None:
+        assert SheetSnap.FULL_MINUS_CHROME.value == "full"
+
+    def test_closed_value(self) -> None:
+        assert SheetSnap.CLOSED.value == "closed"
+
+    def test_all_four_snap_points(self) -> None:
+        """AC: Three snap points (peek/half/full) plus closed."""
+        values = {s.value for s in SheetSnap}
+        assert values == {"peek", "half", "full", "closed"}
+
+    def test_auto_snap_target_is_half(self) -> None:
+        assert AUTO_SNAP_ON_PROPOSAL is SheetSnap.HALF
+
+    def test_forbidden_auto_snap_is_full(self) -> None:
+        assert FORBIDDEN_AUTO_SNAP is SheetSnap.FULL_MINUS_CHROME
+
+
+# ---------------------------------------------------------------------------
+# Construction with each snap state
+# ---------------------------------------------------------------------------
+
+class TestPortraitSheetConstruction:
+    def test_peek_construction(self) -> None:
+        sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.PEEK)
+        assert sheet.current_snap is SheetSnap.PEEK
+
+    def test_half_construction(self) -> None:
+        sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.HALF)
+        assert sheet.current_snap is SheetSnap.HALF
+
+    def test_full_construction(self) -> None:
+        sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.FULL_MINUS_CHROME)
+        assert sheet.current_snap is SheetSnap.FULL_MINUS_CHROME
+
+    def test_closed_construction(self) -> None:
+        sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.CLOSED)
+        assert sheet.current_snap is SheetSnap.CLOSED
+
+    def test_default_rail_state(self) -> None:
+        sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.PEEK)
+        assert sheet.rail_state == "idle"
+
+    def test_custom_rail_state(self) -> None:
+        sheet = PortraitSheet(
+            suggestion_id="s1",
+            current_snap=SheetSnap.HALF,
+            rail_state="staged_body",
+        )
+        assert sheet.rail_state == "staged_body"
+
+
+# ---------------------------------------------------------------------------
+# transition_to produces new instance with correct snap
+# ---------------------------------------------------------------------------
+
+class TestTransitionTo:
+    def test_transition_to_half(self) -> None:
+        sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.PEEK)
+        new_sheet = sheet.transition_to(SheetSnap.HALF)
+        assert new_sheet.current_snap is SheetSnap.HALF
+
+    def test_transition_to_full(self) -> None:
+        sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.HALF)
+        new_sheet = sheet.transition_to(SheetSnap.FULL_MINUS_CHROME)
+        assert new_sheet.current_snap is SheetSnap.FULL_MINUS_CHROME
+
+    def test_transition_to_closed(self) -> None:
+        sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.HALF)
+        new_sheet = sheet.transition_to(SheetSnap.CLOSED)
+        assert new_sheet.current_snap is SheetSnap.CLOSED
+
+    def test_transition_to_peek(self) -> None:
+        sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.HALF)
+        new_sheet = sheet.transition_to(SheetSnap.PEEK)
+        assert new_sheet.current_snap is SheetSnap.PEEK
+
+    def test_transition_returns_new_instance(self) -> None:
+        """Immutable: transition_to must return a NEW instance."""
+        sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.PEEK)
+        new_sheet = sheet.transition_to(SheetSnap.HALF)
+        assert new_sheet is not sheet
+
+    def test_original_unchanged_after_transition(self) -> None:
+        """Immutable: original instance snap must not change."""
+        sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.PEEK)
+        _ = sheet.transition_to(SheetSnap.HALF)
+        assert sheet.current_snap is SheetSnap.PEEK
+
+    def test_transition_preserves_suggestion_id(self) -> None:
+        sheet = PortraitSheet(suggestion_id="sugg-42", current_snap=SheetSnap.PEEK)
+        new_sheet = sheet.transition_to(SheetSnap.HALF)
+        assert new_sheet.suggestion_id == "sugg-42"
+
+    def test_transition_preserves_rail_state(self) -> None:
+        sheet = PortraitSheet(
+            suggestion_id="s1",
+            current_snap=SheetSnap.PEEK,
+            rail_state="staged_body",
+        )
+        new_sheet = sheet.transition_to(SheetSnap.HALF)
+        assert new_sheet.rail_state == "staged_body"
+
+
+# ---------------------------------------------------------------------------
+# is_visible correct for each snap
+# ---------------------------------------------------------------------------
+
+class TestIsVisible:
+    def test_peek_is_visible(self) -> None:
+        sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.PEEK)
+        assert sheet.is_visible() is True
+
+    def test_half_is_visible(self) -> None:
+        sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.HALF)
+        assert sheet.is_visible() is True
+
+    def test_full_is_visible(self) -> None:
+        sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.FULL_MINUS_CHROME)
+        assert sheet.is_visible() is True
+
+    def test_closed_is_not_visible(self) -> None:
+        sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.CLOSED)
+        assert sheet.is_visible() is False
+
+
+# ---------------------------------------------------------------------------
+# Auto-snap on proposal: PEEK → HALF (never FULL)
+# ---------------------------------------------------------------------------
+
+class TestAutoSnapOnProposal:
+    def test_auto_snap_peek_to_half_on_proposal(self) -> None:
+        """AC: Auto-snap from peek → half on proposal arrival."""
+        sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.PEEK)
+        new_sheet = sheet.auto_snap_on_proposal()
+        assert new_sheet.current_snap is SheetSnap.HALF
+
+    def test_auto_snap_never_reaches_full(self) -> None:
+        """AC: Auto-snap never reaches FULL (document must remain visible)."""
+        sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.PEEK)
+        new_sheet = sheet.auto_snap_on_proposal()
+        assert new_sheet.current_snap is not SheetSnap.FULL_MINUS_CHROME
+
+    def test_auto_snap_target_is_half_constant(self) -> None:
+        """Contract: AUTO_SNAP_ON_PROPOSAL is always HALF."""
+        assert AUTO_SNAP_ON_PROPOSAL is SheetSnap.HALF
+        assert FORBIDDEN_AUTO_SNAP is SheetSnap.FULL_MINUS_CHROME
+
+    def test_auto_snap_returns_new_instance(self) -> None:
+        sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.PEEK)
+        new_sheet = sheet.auto_snap_on_proposal()
+        assert new_sheet is not sheet
+
+
+# ---------------------------------------------------------------------------
+# render dict structure
+# ---------------------------------------------------------------------------
+
+class TestRenderDict:
+    def test_render_dict_keys(self) -> None:
+        sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.PEEK)
+        d = sheet.to_render_dict()
+        assert d["data_testid"] == "portrait-sheet"
+        assert "current_snap" in d
+        assert "height_hint" in d
+        assert "is_visible" in d
+        assert "body_is_primary" in d
+        assert "auto_snap_target" in d
+        assert "forbidden_auto_snap" in d
+        assert "touch_target_min_height" in d
+        assert "receipts_strip_position" in d
+
+    def test_render_dict_snap_value(self) -> None:
+        sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.HALF)
+        d = sheet.to_render_dict()
+        assert d["current_snap"] == "half"
+
+    def test_render_dict_is_visible_peek(self) -> None:
+        sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.PEEK)
+        assert sheet.to_render_dict()["is_visible"] is True
+
+    def test_render_dict_is_visible_closed(self) -> None:
+        sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.CLOSED)
+        assert sheet.to_render_dict()["is_visible"] is False
+
+    def test_render_dict_body_is_primary(self) -> None:
+        """Contract: body content is primary; sheet is overlay/secondary."""
+        sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.HALF)
+        d = sheet.to_render_dict()
+        assert d["body_is_primary"] is True
+        assert d.get("is_overlay") is True
+
+    def test_render_dict_auto_snap_target(self) -> None:
+        sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.PEEK)
+        d = sheet.to_render_dict()
+        assert d["auto_snap_target"] == "half"
+        assert d["forbidden_auto_snap"] == "full"
+
+    def test_render_dict_touch_target_min_height(self) -> None:
+        """AC: Touch targets ≥ 44 px in portrait."""
+        sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.PEEK)
+        d = sheet.to_render_dict()
+        assert d["touch_target_min_height"] == "44px"
+
+    def test_render_dict_receipts_strip_position(self) -> None:
+        """AC: ReceiptsStrip renders at the top of the sheet (sticky)."""
+        sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.HALF)
+        d = sheet.to_render_dict()
+        assert d["receipts_strip_position"] == "sticky-top"
+
+    def test_render_dict_height_hints(self) -> None:
+        for snap, expected_hint in [
+            (SheetSnap.PEEK, "60px"),
+            (SheetSnap.HALF, "50vh"),
+            (SheetSnap.FULL_MINUS_CHROME, "calc(100vh - 64px)"),
+            (SheetSnap.CLOSED, "0"),
+        ]:
+            sheet = PortraitSheet(suggestion_id="s1", current_snap=snap)
+            d = sheet.to_render_dict()
+            assert d["height_hint"] == expected_hint, f"Wrong hint for {snap}"
+
+    def test_render_dict_contains_suggestion_id(self) -> None:
+        sheet = PortraitSheet(suggestion_id="sugg-99", current_snap=SheetSnap.PEEK)
+        d = sheet.to_render_dict()
+        assert d["suggestion_id"] == "sugg-99"
+
+    def test_render_dict_contains_rail_state(self) -> None:
+        sheet = PortraitSheet(
+            suggestion_id="s1",
+            current_snap=SheetSnap.HALF,
+            rail_state="staged_governance",
+        )
+        d = sheet.to_render_dict()
+        assert d["rail_state"] == "staged_governance"
+
+
+# ---------------------------------------------------------------------------
+# Boundary: no Canvas Core / Panel / runtime coupling
+# ---------------------------------------------------------------------------
+
+class TestNoBoundaryCrossing:
+    def test_no_canvas_core_import(self) -> None:
+        """canvas_core must not be imported (docstring mentions are OK)."""
+        import companion_ui.canvas_suggestion_flow.portrait_sheet as mod
+        import_lines = [
+            line for line in open(mod.__file__).read().splitlines()
+            if line.lstrip().startswith("import ") or line.lstrip().startswith("from ")
+        ]
+        assert all("canvas_core" not in line for line in import_lines)
+
+    def test_no_panel_import(self) -> None:
+        import companion_ui.canvas_suggestion_flow.portrait_sheet as mod
+        src = open(mod.__file__).read()
+        assert "from companion_ui.panel" not in src
+
+    def test_no_vault_write_imports(self) -> None:
+        """No runtime writer symbols are imported (docstring mentions are OK)."""
+        import companion_ui.canvas_suggestion_flow.portrait_sheet as mod
+        assert not hasattr(mod, "WriteGuard")
+        assert not hasattr(mod, "SessionLogWriter")
+        assert not hasattr(mod, "GovernanceRouter")
+
+    def test_no_rail_state_machine_import(self) -> None:
+        """Portrait sheet must NOT import rail_state_machine internals."""
+        import companion_ui.canvas_suggestion_flow.portrait_sheet as mod
+        import_lines = [
+            line for line in open(mod.__file__).read().splitlines()
+            if line.lstrip().startswith("import ") or line.lstrip().startswith("from ")
+        ]
+        assert all("rail_state_machine" not in line for line in import_lines)
+        assert not hasattr(mod, "CanvasRailStateMachine")
+
+
+# ---------------------------------------------------------------------------
+# AC entry points from issue #873
+# ---------------------------------------------------------------------------
+
+def test_snap_points_peek_half_full() -> None:
+    """AC: Three snap points: peek / half / full."""
+    sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.PEEK)
+    assert sheet.transition_to(SheetSnap.HALF).current_snap is SheetSnap.HALF
+    assert sheet.transition_to(SheetSnap.FULL_MINUS_CHROME).current_snap is SheetSnap.FULL_MINUS_CHROME
+
+
+def test_auto_snap_peek_to_half_on_proposal() -> None:
+    """AC: Auto-snap from peek → half on proposal arrival."""
+    sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.PEEK)
+    new_sheet = sheet.auto_snap_on_proposal()
+    assert new_sheet.current_snap is SheetSnap.HALF
+
+
+def test_auto_snap_never_reaches_full() -> None:
+    """AC: Auto-snap never reaches full."""
+    sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.PEEK)
+    new_sheet = sheet.auto_snap_on_proposal()
+    assert new_sheet.current_snap is not SheetSnap.FULL_MINUS_CHROME
+    assert FORBIDDEN_AUTO_SNAP is SheetSnap.FULL_MINUS_CHROME
+
+
+def test_snap_state_persisted() -> None:
+    """AC: Snap state persisted to localStorage per session id (model-level stub).
+
+    The model captures snap state via current_snap.  localStorage persistence
+    is a UI-layer responsibility; the model provides the serialisable state dict.
+    """
+    sheet = PortraitSheet(suggestion_id="session-abc", current_snap=SheetSnap.HALF)
+    d = sheet.to_render_dict()
+    # The render dict contains the snap state for the UI layer to persist.
+    assert d["current_snap"] == "half"
+    assert d["suggestion_id"] == "session-abc"
+
+
+def test_reduced_motion_respected() -> None:
+    """AC: prefers-reduced-motion: no auto-snap, no transition (model contract).
+
+    The model does not auto-snap automatically — auto_snap_on_proposal() must
+    be explicitly called by the UI layer.  If the UI layer detects prefers-reduced-motion,
+    it simply does not call auto_snap_on_proposal().  The model never auto-mutates.
+    """
+    sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.PEEK)
+    # Not calling auto_snap_on_proposal() simulates reduced-motion suppression.
+    assert sheet.current_snap is SheetSnap.PEEK
+
+
+def test_touch_targets_44px() -> None:
+    """AC: All interactive elements ≥ 44 px height in portrait."""
+    sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.PEEK)
+    d = sheet.to_render_dict()
+    assert d["touch_target_min_height"] == "44px"
+
+
+def test_receipts_strip_sticky_top() -> None:
+    """AC: ReceiptsStrip renders at the top of the sheet (sticky) in portrait."""
+    sheet = PortraitSheet(suggestion_id="s1", current_snap=SheetSnap.HALF)
+    d = sheet.to_render_dict()
+    assert d["receipts_strip_position"] == "sticky-top"

--- a/tests/companion_ui/test_canvas_portrait_sheet.py
+++ b/tests/companion_ui/test_canvas_portrait_sheet.py
@@ -11,8 +11,6 @@ Verifies:
 - No dependency on Canvas Core, Panel, backend runtime, or vault writes.
 """
 
-import pytest
-
 from companion_ui.canvas_suggestion_flow.portrait_sheet import (
     AUTO_SNAP_ON_PROPOSAL,
     FORBIDDEN_AUTO_SNAP,

--- a/tests/companion_ui/test_canvas_suggestion_shortcuts.py
+++ b/tests/companion_ui/test_canvas_suggestion_shortcuts.py
@@ -1,0 +1,401 @@
+"""Tests for keyboard shortcut mapping model (#872).
+
+Verifies:
+- Each variant's available actions
+- Blocked variant cannot APPLY or QUEUE
+- Terminal state has no mutating shortcuts (no APPLY, QUEUE, DISCARD)
+- key_for returns something for valid actions
+- render dict structure
+- Hard invariant: governance variant NEVER has APPLY_BODY_SUGGESTION
+- No dependency on Canvas Core, Panel, backend runtime, or vault writes.
+"""
+
+import pytest
+
+from companion_ui.canvas_suggestion_flow.keyboard_shortcuts import (
+    SHORTCUT_VARIANTS,
+    ShortcutAction,
+    SuggestionShortcutMap,
+)
+
+
+# ---------------------------------------------------------------------------
+# ShortcutAction enum values
+# ---------------------------------------------------------------------------
+
+class TestShortcutActions:
+    def test_all_actions_defined(self) -> None:
+        expected_values = {
+            "suggestion.apply",
+            "governance.queue",
+            "suggestion.discard",
+            "suggestion.inspect",
+            "composer.enable",
+        }
+        actual_values = {a.value for a in ShortcutAction}
+        assert actual_values == expected_values
+
+    def test_apply_body_suggestion(self) -> None:
+        assert ShortcutAction.APPLY_BODY_SUGGESTION.value == "suggestion.apply"
+
+    def test_queue_governance_suggestion(self) -> None:
+        assert ShortcutAction.QUEUE_GOVERNANCE_SUGGESTION.value == "governance.queue"
+
+    def test_discard_suggestion(self) -> None:
+        assert ShortcutAction.DISCARD_SUGGESTION.value == "suggestion.discard"
+
+    def test_inspect_suggestion(self) -> None:
+        assert ShortcutAction.INSPECT_SUGGESTION.value == "suggestion.inspect"
+
+    def test_dismiss_rail(self) -> None:
+        assert ShortcutAction.DISMISS_RAIL.value == "composer.enable"
+
+
+# ---------------------------------------------------------------------------
+# SHORTCUT_VARIANTS set
+# ---------------------------------------------------------------------------
+
+class TestShortcutVariants:
+    def test_all_variants_defined(self) -> None:
+        assert SHORTCUT_VARIANTS == frozenset({"body", "governance", "blocked", "terminal"})
+
+    def test_unknown_variant_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown shortcut variant"):
+            SuggestionShortcutMap(variant="unknown")
+
+
+# ---------------------------------------------------------------------------
+# Body variant available actions
+# ---------------------------------------------------------------------------
+
+class TestBodyVariantActions:
+    def test_body_has_apply(self) -> None:
+        sm = SuggestionShortcutMap(variant="body", rail_state="staged_body")
+        assert ShortcutAction.APPLY_BODY_SUGGESTION in sm.available_actions()
+
+    def test_body_has_discard(self) -> None:
+        sm = SuggestionShortcutMap(variant="body", rail_state="staged_body")
+        assert ShortcutAction.DISCARD_SUGGESTION in sm.available_actions()
+
+    def test_body_has_inspect(self) -> None:
+        sm = SuggestionShortcutMap(variant="body", rail_state="staged_body")
+        assert ShortcutAction.INSPECT_SUGGESTION in sm.available_actions()
+
+    def test_body_has_dismiss(self) -> None:
+        sm = SuggestionShortcutMap(variant="body", rail_state="staged_body")
+        assert ShortcutAction.DISMISS_RAIL in sm.available_actions()
+
+    def test_body_does_not_have_queue(self) -> None:
+        sm = SuggestionShortcutMap(variant="body", rail_state="staged_body")
+        assert ShortcutAction.QUEUE_GOVERNANCE_SUGGESTION not in sm.available_actions()
+
+    def test_a_applies_in_body_only(self) -> None:
+        """AC: A applies suggestion in body variant only."""
+        body_sm = SuggestionShortcutMap(variant="body")
+        gov_sm = SuggestionShortcutMap(variant="governance")
+        assert body_sm.key_for(ShortcutAction.APPLY_BODY_SUGGESTION) == "A"
+        assert gov_sm.key_for(ShortcutAction.APPLY_BODY_SUGGESTION) is None
+
+
+# ---------------------------------------------------------------------------
+# Governance variant available actions
+# ---------------------------------------------------------------------------
+
+class TestGovernanceVariantActions:
+    def test_governance_has_queue(self) -> None:
+        sm = SuggestionShortcutMap(variant="governance", rail_state="staged_governance")
+        assert ShortcutAction.QUEUE_GOVERNANCE_SUGGESTION in sm.available_actions()
+
+    def test_governance_has_discard(self) -> None:
+        sm = SuggestionShortcutMap(variant="governance", rail_state="staged_governance")
+        assert ShortcutAction.DISCARD_SUGGESTION in sm.available_actions()
+
+    def test_governance_has_inspect(self) -> None:
+        sm = SuggestionShortcutMap(variant="governance", rail_state="staged_governance")
+        assert ShortcutAction.INSPECT_SUGGESTION in sm.available_actions()
+
+    def test_governance_has_dismiss(self) -> None:
+        sm = SuggestionShortcutMap(variant="governance", rail_state="staged_governance")
+        assert ShortcutAction.DISMISS_RAIL in sm.available_actions()
+
+    def test_governance_does_not_have_apply(self) -> None:
+        """Hard invariant: governance MUST NOT expose suggestion.apply."""
+        sm = SuggestionShortcutMap(variant="governance", rail_state="staged_governance")
+        assert ShortcutAction.APPLY_BODY_SUGGESTION not in sm.available_actions()
+
+    def test_q_queues_governance_only(self) -> None:
+        """AC: Q queues governance in staged_gov only; no effect in other variants."""
+        gov_sm = SuggestionShortcutMap(variant="governance")
+        body_sm = SuggestionShortcutMap(variant="body")
+        assert gov_sm.key_for(ShortcutAction.QUEUE_GOVERNANCE_SUGGESTION) == "Q"
+        assert body_sm.key_for(ShortcutAction.QUEUE_GOVERNANCE_SUGGESTION) is None
+
+
+# ---------------------------------------------------------------------------
+# Blocked variant cannot APPLY or QUEUE
+# ---------------------------------------------------------------------------
+
+class TestBlockedVariantActions:
+    def test_blocked_cannot_apply(self) -> None:
+        """AC: Blocked variant cannot APPLY."""
+        sm = SuggestionShortcutMap(variant="blocked")
+        assert ShortcutAction.APPLY_BODY_SUGGESTION not in sm.available_actions()
+
+    def test_blocked_cannot_queue(self) -> None:
+        """AC: Blocked variant cannot QUEUE."""
+        sm = SuggestionShortcutMap(variant="blocked")
+        assert ShortcutAction.QUEUE_GOVERNANCE_SUGGESTION not in sm.available_actions()
+
+    def test_blocked_cannot_discard(self) -> None:
+        """Blocked variant also cannot DISCARD (only INSPECT and DISMISS)."""
+        sm = SuggestionShortcutMap(variant="blocked")
+        assert ShortcutAction.DISCARD_SUGGESTION not in sm.available_actions()
+
+    def test_blocked_has_inspect(self) -> None:
+        sm = SuggestionShortcutMap(variant="blocked")
+        assert ShortcutAction.INSPECT_SUGGESTION in sm.available_actions()
+
+    def test_blocked_has_dismiss(self) -> None:
+        sm = SuggestionShortcutMap(variant="blocked")
+        assert ShortcutAction.DISMISS_RAIL in sm.available_actions()
+
+    def test_blocked_key_for_apply_is_none(self) -> None:
+        sm = SuggestionShortcutMap(variant="blocked")
+        assert sm.key_for(ShortcutAction.APPLY_BODY_SUGGESTION) is None
+
+    def test_blocked_key_for_queue_is_none(self) -> None:
+        sm = SuggestionShortcutMap(variant="blocked")
+        assert sm.key_for(ShortcutAction.QUEUE_GOVERNANCE_SUGGESTION) is None
+
+
+# ---------------------------------------------------------------------------
+# Terminal state has no mutating shortcuts
+# ---------------------------------------------------------------------------
+
+class TestTerminalStateActions:
+    def test_terminal_has_no_apply(self) -> None:
+        """AC: Terminal state has no APPLY shortcut."""
+        sm = SuggestionShortcutMap(variant="body", terminal_state=True)
+        assert ShortcutAction.APPLY_BODY_SUGGESTION not in sm.available_actions()
+
+    def test_terminal_has_no_queue(self) -> None:
+        """AC: Terminal state has no QUEUE shortcut."""
+        sm = SuggestionShortcutMap(variant="governance", terminal_state=True)
+        assert ShortcutAction.QUEUE_GOVERNANCE_SUGGESTION not in sm.available_actions()
+
+    def test_terminal_has_no_discard(self) -> None:
+        """AC: Terminal state has no DISCARD shortcut."""
+        sm = SuggestionShortcutMap(variant="body", terminal_state=True)
+        assert ShortcutAction.DISCARD_SUGGESTION not in sm.available_actions()
+
+    def test_terminal_retains_inspect(self) -> None:
+        sm = SuggestionShortcutMap(variant="body", terminal_state=True)
+        assert ShortcutAction.INSPECT_SUGGESTION in sm.available_actions()
+
+    def test_terminal_retains_dismiss(self) -> None:
+        sm = SuggestionShortcutMap(variant="body", terminal_state=True)
+        assert ShortcutAction.DISMISS_RAIL in sm.available_actions()
+
+    def test_terminal_variant_is_terminal(self) -> None:
+        """Passing variant='terminal' sets terminal_state=True automatically."""
+        sm = SuggestionShortcutMap(variant="terminal")
+        assert sm.is_terminal is True
+        assert ShortcutAction.APPLY_BODY_SUGGESTION not in sm.available_actions()
+        assert ShortcutAction.DISCARD_SUGGESTION not in sm.available_actions()
+
+    def test_terminal_flag_overrides_body_variant(self) -> None:
+        sm = SuggestionShortcutMap(variant="body", terminal_state=True)
+        assert sm.is_terminal is True
+        assert ShortcutAction.APPLY_BODY_SUGGESTION not in sm.available_actions()
+
+
+# ---------------------------------------------------------------------------
+# key_for returns something for valid actions
+# ---------------------------------------------------------------------------
+
+class TestKeyFor:
+    def test_key_for_apply_in_body(self) -> None:
+        sm = SuggestionShortcutMap(variant="body")
+        key = sm.key_for(ShortcutAction.APPLY_BODY_SUGGESTION)
+        assert key is not None
+        assert isinstance(key, str)
+        assert len(key) > 0
+
+    def test_key_for_queue_in_governance(self) -> None:
+        sm = SuggestionShortcutMap(variant="governance")
+        key = sm.key_for(ShortcutAction.QUEUE_GOVERNANCE_SUGGESTION)
+        assert key is not None
+
+    def test_key_for_discard_in_body(self) -> None:
+        sm = SuggestionShortcutMap(variant="body")
+        key = sm.key_for(ShortcutAction.DISCARD_SUGGESTION)
+        assert key is not None
+
+    def test_key_for_inspect_in_any_variant(self) -> None:
+        for variant in ["body", "governance", "blocked", "terminal"]:
+            sm = SuggestionShortcutMap(variant=variant)
+            key = sm.key_for(ShortcutAction.INSPECT_SUGGESTION)
+            assert key is not None, f"INSPECT key missing for {variant}"
+
+    def test_key_for_dismiss_in_any_variant(self) -> None:
+        for variant in ["body", "governance", "blocked", "terminal"]:
+            sm = SuggestionShortcutMap(variant=variant)
+            key = sm.key_for(ShortcutAction.DISMISS_RAIL)
+            assert key is not None, f"DISMISS key missing for {variant}"
+
+    def test_key_for_unavailable_action_returns_none(self) -> None:
+        sm = SuggestionShortcutMap(variant="governance")
+        assert sm.key_for(ShortcutAction.APPLY_BODY_SUGGESTION) is None
+
+    def test_canonical_key_bindings(self) -> None:
+        """Verify canonical keys match issue #872 table."""
+        body_sm = SuggestionShortcutMap(variant="body")
+        gov_sm = SuggestionShortcutMap(variant="governance")
+        assert body_sm.key_for(ShortcutAction.APPLY_BODY_SUGGESTION) == "A"
+        assert gov_sm.key_for(ShortcutAction.QUEUE_GOVERNANCE_SUGGESTION) == "Q"
+        assert body_sm.key_for(ShortcutAction.DISCARD_SUGGESTION) == "D"
+        assert body_sm.key_for(ShortcutAction.INSPECT_SUGGESTION) == "I"
+        assert body_sm.key_for(ShortcutAction.DISMISS_RAIL) == "E"
+
+
+# ---------------------------------------------------------------------------
+# render dict structure
+# ---------------------------------------------------------------------------
+
+class TestRenderDict:
+    def test_render_dict_keys(self) -> None:
+        sm = SuggestionShortcutMap(variant="body", rail_state="staged_body")
+        d = sm.to_render_dict()
+        assert "variant" in d
+        assert "rail_state" in d
+        assert "is_terminal" in d
+        assert "available_actions" in d
+        assert "key_bindings" in d
+
+    def test_render_dict_variant(self) -> None:
+        sm = SuggestionShortcutMap(variant="governance", rail_state="staged_governance")
+        d = sm.to_render_dict()
+        assert d["variant"] == "governance"
+        assert d["rail_state"] == "staged_governance"
+
+    def test_render_dict_available_actions_are_strings(self) -> None:
+        sm = SuggestionShortcutMap(variant="body")
+        d = sm.to_render_dict()
+        for action_val in d["available_actions"]:
+            assert isinstance(action_val, str)
+
+    def test_render_dict_key_bindings_are_strings(self) -> None:
+        sm = SuggestionShortcutMap(variant="body")
+        d = sm.to_render_dict()
+        for key in d["key_bindings"].values():
+            assert isinstance(key, str)
+
+    def test_render_dict_governance_no_apply(self) -> None:
+        """Render dict for governance must not include suggestion.apply."""
+        sm = SuggestionShortcutMap(variant="governance")
+        d = sm.to_render_dict()
+        assert "suggestion.apply" not in d["available_actions"]
+        assert "suggestion.apply" not in d["key_bindings"]
+
+    def test_render_dict_terminal_no_mutating(self) -> None:
+        sm = SuggestionShortcutMap(variant="body", terminal_state=True)
+        d = sm.to_render_dict()
+        assert "suggestion.apply" not in d["available_actions"]
+        assert "suggestion.discard" not in d["available_actions"]
+        assert d["is_terminal"] is True
+
+    def test_render_dict_blocked_no_apply_no_queue(self) -> None:
+        sm = SuggestionShortcutMap(variant="blocked")
+        d = sm.to_render_dict()
+        assert "suggestion.apply" not in d["available_actions"]
+        assert "governance.queue" not in d["available_actions"]
+
+
+# ---------------------------------------------------------------------------
+# Boundary: no Canvas Core / Panel / runtime coupling
+# ---------------------------------------------------------------------------
+
+class TestNoBoundaryCrossing:
+    def test_no_canvas_core_import(self) -> None:
+        """canvas_core must not be imported (docstring mentions are OK)."""
+        import companion_ui.canvas_suggestion_flow.keyboard_shortcuts as mod
+        # Check no canvas_core in actual import lines (not docstrings)
+        import_lines = [
+            line for line in open(mod.__file__).read().splitlines()
+            if line.lstrip().startswith("import ") or line.lstrip().startswith("from ")
+        ]
+        assert all("canvas_core" not in line for line in import_lines)
+
+    def test_no_panel_import(self) -> None:
+        import companion_ui.canvas_suggestion_flow.keyboard_shortcuts as mod
+        src = open(mod.__file__).read()
+        assert "from companion_ui.panel" not in src
+
+    def test_no_vault_write_imports(self) -> None:
+        """No runtime writer symbols are imported (docstring mentions are OK)."""
+        import companion_ui.canvas_suggestion_flow.keyboard_shortcuts as mod
+        assert not hasattr(mod, "WriteGuard")
+        assert not hasattr(mod, "SessionLogWriter")
+        assert not hasattr(mod, "GovernanceRouter")
+
+
+# ---------------------------------------------------------------------------
+# AC entry points from issue #872
+# ---------------------------------------------------------------------------
+
+def test_a_applies_in_body_only() -> None:
+    """AC: A applies suggestion in body only; no effect in other states."""
+    body = SuggestionShortcutMap(variant="body")
+    gov = SuggestionShortcutMap(variant="governance")
+    blocked = SuggestionShortcutMap(variant="blocked")
+    assert body.key_for(ShortcutAction.APPLY_BODY_SUGGESTION) == "A"
+    assert gov.key_for(ShortcutAction.APPLY_BODY_SUGGESTION) is None
+    assert blocked.key_for(ShortcutAction.APPLY_BODY_SUGGESTION) is None
+
+
+def test_q_queues_governance_only() -> None:
+    """AC: Q queues governance in staged_gov only."""
+    gov = SuggestionShortcutMap(variant="governance")
+    body = SuggestionShortcutMap(variant="body")
+    assert gov.key_for(ShortcutAction.QUEUE_GOVERNANCE_SUGGESTION) == "Q"
+    assert body.key_for(ShortcutAction.QUEUE_GOVERNANCE_SUGGESTION) is None
+
+
+def test_d_discards_in_staged() -> None:
+    """AC: D discards in any staged variant; no effect if blocked or terminal."""
+    body = SuggestionShortcutMap(variant="body")
+    gov = SuggestionShortcutMap(variant="governance")
+    blocked = SuggestionShortcutMap(variant="blocked")
+    terminal = SuggestionShortcutMap(variant="body", terminal_state=True)
+    assert body.key_for(ShortcutAction.DISCARD_SUGGESTION) == "D"
+    assert gov.key_for(ShortcutAction.DISCARD_SUGGESTION) == "D"
+    assert blocked.key_for(ShortcutAction.DISCARD_SUGGESTION) is None
+    assert terminal.key_for(ShortcutAction.DISCARD_SUGGESTION) is None
+
+
+def test_i_focuses_suggestion() -> None:
+    """AC: I focuses suggestion details in staged states."""
+    for variant in ["body", "governance", "blocked", "terminal"]:
+        sm = SuggestionShortcutMap(variant=variant)
+        assert sm.key_for(ShortcutAction.INSPECT_SUGGESTION) == "I"
+
+
+def test_e_enables_composer_in_thinking() -> None:
+    """AC: E re-enables composer (DISMISS_RAIL maps to composer.enable)."""
+    # E is mapped to DISMISS_RAIL / composer.enable in all variants
+    for variant in ["body", "governance", "blocked", "terminal"]:
+        sm = SuggestionShortcutMap(variant=variant)
+        assert sm.key_for(ShortcutAction.DISMISS_RAIL) == "E"
+
+
+def test_shortcuts_disabled_in_input() -> None:
+    """AC: Shortcuts disabled when text input is focused — caller responsibility.
+
+    The model surfaces no key bindings when terminal_state=True and variant signals
+    no active staged state (simulating idle/input-focus condition).
+    No DOM wiring here; the model is intent/render-hint only.
+    """
+    # When terminal_state=True, mutating shortcuts are suppressed.
+    sm = SuggestionShortcutMap(variant="body", terminal_state=True)
+    assert ShortcutAction.APPLY_BODY_SUGGESTION not in sm.available_actions()
+    assert ShortcutAction.DISCARD_SUGGESTION not in sm.available_actions()

--- a/tests/companion_ui/test_canvas_suggestion_shortcuts.py
+++ b/tests/companion_ui/test_canvas_suggestion_shortcuts.py
@@ -30,7 +30,7 @@ class TestShortcutActions:
             "governance.queue",
             "suggestion.discard",
             "suggestion.inspect",
-            "composer.enable",
+            "suggestion.edit",
         }
         actual_values = {a.value for a in ShortcutAction}
         assert actual_values == expected_values
@@ -48,7 +48,7 @@ class TestShortcutActions:
         assert ShortcutAction.INSPECT_SUGGESTION.value == "suggestion.inspect"
 
     def test_dismiss_rail(self) -> None:
-        assert ShortcutAction.DISMISS_RAIL.value == "composer.enable"
+        assert ShortcutAction.DISMISS_RAIL.value == "suggestion.edit"
 
 
 # ---------------------------------------------------------------------------
@@ -91,8 +91,8 @@ class TestBodyVariantActions:
 
     def test_a_applies_in_body_only(self) -> None:
         """AC: A applies suggestion in body variant only."""
-        body_sm = SuggestionShortcutMap(variant="body")
-        gov_sm = SuggestionShortcutMap(variant="governance")
+        body_sm = SuggestionShortcutMap(variant="body", rail_state="staged_body")
+        gov_sm = SuggestionShortcutMap(variant="governance", rail_state="staged_governance")
         assert body_sm.key_for(ShortcutAction.APPLY_BODY_SUGGESTION) == "A"
         assert gov_sm.key_for(ShortcutAction.APPLY_BODY_SUGGESTION) is None
 
@@ -124,9 +124,9 @@ class TestGovernanceVariantActions:
         assert ShortcutAction.APPLY_BODY_SUGGESTION not in sm.available_actions()
 
     def test_q_queues_governance_only(self) -> None:
-        """AC: Q queues governance in staged_gov only; no effect in other variants."""
-        gov_sm = SuggestionShortcutMap(variant="governance")
-        body_sm = SuggestionShortcutMap(variant="body")
+        """AC: Q queues governance in staged_governance only; no effect in other variants."""
+        gov_sm = SuggestionShortcutMap(variant="governance", rail_state="staged_governance")
+        body_sm = SuggestionShortcutMap(variant="body", rail_state="staged_body")
         assert gov_sm.key_for(ShortcutAction.QUEUE_GOVERNANCE_SUGGESTION) == "Q"
         assert body_sm.key_for(ShortcutAction.QUEUE_GOVERNANCE_SUGGESTION) is None
 
@@ -215,19 +215,19 @@ class TestTerminalStateActions:
 
 class TestKeyFor:
     def test_key_for_apply_in_body(self) -> None:
-        sm = SuggestionShortcutMap(variant="body")
+        sm = SuggestionShortcutMap(variant="body", rail_state="staged_body")
         key = sm.key_for(ShortcutAction.APPLY_BODY_SUGGESTION)
         assert key is not None
         assert isinstance(key, str)
         assert len(key) > 0
 
     def test_key_for_queue_in_governance(self) -> None:
-        sm = SuggestionShortcutMap(variant="governance")
+        sm = SuggestionShortcutMap(variant="governance", rail_state="staged_governance")
         key = sm.key_for(ShortcutAction.QUEUE_GOVERNANCE_SUGGESTION)
         assert key is not None
 
     def test_key_for_discard_in_body(self) -> None:
-        sm = SuggestionShortcutMap(variant="body")
+        sm = SuggestionShortcutMap(variant="body", rail_state="staged_body")
         key = sm.key_for(ShortcutAction.DISCARD_SUGGESTION)
         assert key is not None
 
@@ -249,8 +249,8 @@ class TestKeyFor:
 
     def test_canonical_key_bindings(self) -> None:
         """Verify canonical keys match issue #872 table."""
-        body_sm = SuggestionShortcutMap(variant="body")
-        gov_sm = SuggestionShortcutMap(variant="governance")
+        body_sm = SuggestionShortcutMap(variant="body", rail_state="staged_body")
+        gov_sm = SuggestionShortcutMap(variant="governance", rail_state="staged_governance")
         assert body_sm.key_for(ShortcutAction.APPLY_BODY_SUGGESTION) == "A"
         assert gov_sm.key_for(ShortcutAction.QUEUE_GOVERNANCE_SUGGESTION) == "Q"
         assert body_sm.key_for(ShortcutAction.DISCARD_SUGGESTION) == "D"
@@ -344,9 +344,9 @@ class TestNoBoundaryCrossing:
 # ---------------------------------------------------------------------------
 
 def test_a_applies_in_body_only() -> None:
-    """AC: A applies suggestion in body only; no effect in other states."""
-    body = SuggestionShortcutMap(variant="body")
-    gov = SuggestionShortcutMap(variant="governance")
+    """AC: A applies suggestion in staged body only; no effect in other states."""
+    body = SuggestionShortcutMap(variant="body", rail_state="staged_body")
+    gov = SuggestionShortcutMap(variant="governance", rail_state="staged_governance")
     blocked = SuggestionShortcutMap(variant="blocked")
     assert body.key_for(ShortcutAction.APPLY_BODY_SUGGESTION) == "A"
     assert gov.key_for(ShortcutAction.APPLY_BODY_SUGGESTION) is None
@@ -354,17 +354,17 @@ def test_a_applies_in_body_only() -> None:
 
 
 def test_q_queues_governance_only() -> None:
-    """AC: Q queues governance in staged_gov only."""
-    gov = SuggestionShortcutMap(variant="governance")
-    body = SuggestionShortcutMap(variant="body")
+    """AC: Q queues governance in staged_governance only; no effect elsewhere."""
+    gov = SuggestionShortcutMap(variant="governance", rail_state="staged_governance")
+    body = SuggestionShortcutMap(variant="body", rail_state="staged_body")
     assert gov.key_for(ShortcutAction.QUEUE_GOVERNANCE_SUGGESTION) == "Q"
     assert body.key_for(ShortcutAction.QUEUE_GOVERNANCE_SUGGESTION) is None
 
 
 def test_d_discards_in_staged() -> None:
-    """AC: D discards in any staged variant; no effect if blocked or terminal."""
-    body = SuggestionShortcutMap(variant="body")
-    gov = SuggestionShortcutMap(variant="governance")
+    """AC: D discards in staged variants only; no effect if blocked, terminal, or unstaged."""
+    body = SuggestionShortcutMap(variant="body", rail_state="staged_body")
+    gov = SuggestionShortcutMap(variant="governance", rail_state="staged_governance")
     blocked = SuggestionShortcutMap(variant="blocked")
     terminal = SuggestionShortcutMap(variant="body", terminal_state=True)
     assert body.key_for(ShortcutAction.DISCARD_SUGGESTION) == "D"
@@ -381,8 +381,8 @@ def test_i_focuses_suggestion() -> None:
 
 
 def test_e_enables_composer_in_thinking() -> None:
-    """AC: E re-enables composer (DISMISS_RAIL maps to composer.enable)."""
-    # E is mapped to DISMISS_RAIL / composer.enable in all variants
+    """AC: E dismisses rail / edits suggestion (DISMISS_RAIL maps to suggestion.edit)."""
+    # E is mapped to DISMISS_RAIL / suggestion.edit in all variants
     for variant in ["body", "governance", "blocked", "terminal"]:
         sm = SuggestionShortcutMap(variant=variant)
         assert sm.key_for(ShortcutAction.DISMISS_RAIL) == "E"

--- a/tests/companion_ui/test_provenance_footer.py
+++ b/tests/companion_ui/test_provenance_footer.py
@@ -1,0 +1,336 @@
+"""Tests for ProvenanceFooter (#874).
+
+Verifies:
+- Construction with and without optional fields
+- render dict structure
+- session log path displayed from supplied context (not hardcoded)
+- open session log intent dispatched when path available
+- turn count renders from session state
+- undo button disabled when can_undo_last_body_edit=False
+- undo button enabled when can_undo_last_body_edit=True
+- undo session-bounded (cross-session undo cannot be dispatched)
+- footer has no runtime write side effects
+- No dependency on Canvas Core, Panel, backend runtime, or vault writes.
+"""
+
+import pytest
+
+from companion_ui.canvas_suggestion_flow.provenance_footer import (
+    INTENT_OPEN_SESSION_LOG,
+    INTENT_UNDO_LAST_EDIT,
+    ProvenanceFooter,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_footer(
+    suggestion_id: str = "sugg-001",
+    artifact_id: str = "art-001",
+    source_summary: str = ".chats/my-note/2026-05-17T10.md",
+    route_summary: str = "canvas direct body edit",
+    receipt_id: str | None = None,
+    session_ref: str | None = None,
+    session_log_path: str | None = None,
+    turn_count: int = 3,
+    can_undo_last_body_edit: bool = False,
+    last_body_edit_id: str | None = None,
+) -> ProvenanceFooter:
+    return ProvenanceFooter(
+        suggestion_id=suggestion_id,
+        artifact_id=artifact_id,
+        source_summary=source_summary,
+        route_summary=route_summary,
+        receipt_id=receipt_id,
+        session_ref=session_ref,
+        session_log_path=session_log_path,
+        turn_count=turn_count,
+        can_undo_last_body_edit=can_undo_last_body_edit,
+        last_body_edit_id=last_body_edit_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Construction with required fields only
+# ---------------------------------------------------------------------------
+
+class TestProvenanceFooterConstruction:
+    def test_required_fields_only(self) -> None:
+        footer = make_footer()
+        assert footer.suggestion_id == "sugg-001"
+        assert footer.artifact_id == "art-001"
+        assert footer.source_summary == ".chats/my-note/2026-05-17T10.md"
+        assert footer.route_summary == "canvas direct body edit"
+
+    def test_optional_fields_default_to_none(self) -> None:
+        footer = make_footer()
+        assert footer.receipt_id is None
+        assert footer.session_ref is None
+        assert footer.session_log_path is None
+        assert footer.last_body_edit_id is None
+
+    def test_optional_fields_can_be_set(self) -> None:
+        footer = make_footer(
+            receipt_id="rec-001",
+            session_ref="session-abc",
+            session_log_path=".chats/note/2026-05-17.md",
+            last_body_edit_id="edit-xyz",
+        )
+        assert footer.receipt_id == "rec-001"
+        assert footer.session_ref == "session-abc"
+        assert footer.session_log_path == ".chats/note/2026-05-17.md"
+        assert footer.last_body_edit_id == "edit-xyz"
+
+    def test_missing_suggestion_id_raises(self) -> None:
+        with pytest.raises(ValueError, match="suggestion_id"):
+            make_footer(suggestion_id="")
+
+    def test_missing_artifact_id_raises(self) -> None:
+        with pytest.raises(ValueError, match="artifact_id"):
+            make_footer(artifact_id="")
+
+    def test_negative_turn_count_raises(self) -> None:
+        with pytest.raises(ValueError, match="turn_count"):
+            make_footer(turn_count=-1)
+
+    def test_zero_turn_count_allowed(self) -> None:
+        footer = make_footer(turn_count=0)
+        assert footer.turn_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Render dict structure
+# ---------------------------------------------------------------------------
+
+class TestProvenanceFooterRenderDict:
+    def test_render_dict_keys(self) -> None:
+        footer = make_footer()
+        d = footer.to_render_dict()
+        assert d["data_testid"] == "provenance-footer"
+        assert d["aria_label"] == "Session provenance"
+        assert "undo_button_disabled" in d
+        assert "session_log_button_disabled" in d
+        assert d["open_session_log_intent"] == INTENT_OPEN_SESSION_LOG
+        assert d["undo_intent"] == INTENT_UNDO_LAST_EDIT
+        assert d["data_testid_undo"] == "undo-last-edit"
+
+    def test_render_dict_contains_turn_count(self) -> None:
+        footer = make_footer(turn_count=7)
+        d = footer.to_render_dict()
+        assert d["turn_count"] == 7
+
+    def test_render_dict_contains_source_and_route(self) -> None:
+        footer = make_footer(
+            source_summary="src-summary",
+            route_summary="route-summary",
+        )
+        d = footer.to_render_dict()
+        assert d["source_summary"] == "src-summary"
+        assert d["route_summary"] == "route-summary"
+
+    def test_optional_receipt_id_in_render_dict(self) -> None:
+        footer = make_footer(receipt_id="rec-99")
+        d = footer.to_render_dict()
+        assert d.get("receipt_id") == "rec-99"
+
+    def test_optional_fields_absent_when_none(self) -> None:
+        footer = make_footer()
+        d = footer.to_render_dict()
+        assert "receipt_id" not in d
+        assert "session_ref" not in d
+        assert "last_body_edit_id" not in d
+
+
+# ---------------------------------------------------------------------------
+# AC: session log path displayed from session context; no hardcoded path
+# ---------------------------------------------------------------------------
+
+class TestSessionLogPath:
+    def test_session_log_path_displayed(self) -> None:
+        """AC: session_log_path displayed from supplied session context."""
+        path = ".chats/my-note/2026-05-17T10-00.md"
+        footer = make_footer(session_log_path=path)
+        d = footer.to_render_dict()
+        assert d["session_log_path"] == path
+        assert d["session_log_button_disabled"] is False
+
+    def test_session_log_path_none_disables_button(self) -> None:
+        footer = make_footer(session_log_path=None)
+        d = footer.to_render_dict()
+        assert d["session_log_path"] is None
+        assert d["session_log_button_disabled"] is True
+
+    def test_no_hardcoded_path_in_source(self) -> None:
+        """AC: production code must not hardcode the .chats/... path fixture."""
+        import companion_ui.canvas_suggestion_flow.provenance_footer as mod
+        src = open(mod.__file__).read()
+        # The path shape is documented in the module but must not be hardcoded as a literal value.
+        assert ".chats/my-note" not in src
+        assert ".chats/note-slug" not in src
+
+
+# ---------------------------------------------------------------------------
+# AC: open session log intent dispatched
+# ---------------------------------------------------------------------------
+
+class TestOpenSessionLogIntent:
+    def test_open_session_log_intent_dispatched(self) -> None:
+        """AC: provenance.openSessionLog intent returned when path available."""
+        path = ".chats/slug/2026.md"
+        footer = make_footer(session_log_path=path)
+        intent = footer.open_session_log_intent
+        assert intent is not None
+        assert intent["intent"] == INTENT_OPEN_SESSION_LOG
+        assert intent["session_log_path"] == path
+
+    def test_no_intent_when_path_missing(self) -> None:
+        footer = make_footer(session_log_path=None)
+        assert footer.open_session_log_intent is None
+
+    def test_render_dict_intent_payload(self) -> None:
+        footer = make_footer(session_log_path=".chats/x/t.md")
+        d = footer.to_render_dict()
+        assert d["open_session_log_intent_payload"] is not None
+        assert d["open_session_log_intent_payload"]["intent"] == INTENT_OPEN_SESSION_LOG
+
+
+# ---------------------------------------------------------------------------
+# AC: turn count renders from session state
+# ---------------------------------------------------------------------------
+
+class TestTurnCount:
+    def test_turn_count_renders_from_session_state(self) -> None:
+        """AC: turn count renders from supplied session state."""
+        footer = make_footer(turn_count=12)
+        d = footer.to_render_dict()
+        assert d["turn_count"] == 12
+
+    def test_turn_count_updates_correctly(self) -> None:
+        """AC: turn count updates when state changes (via new instance)."""
+        footer_a = make_footer(turn_count=5)
+        footer_b = make_footer(turn_count=6)
+        assert footer_a.to_render_dict()["turn_count"] == 5
+        assert footer_b.to_render_dict()["turn_count"] == 6
+
+
+# ---------------------------------------------------------------------------
+# AC: undo button disabled initially
+# ---------------------------------------------------------------------------
+
+class TestUndoButtonDisabled:
+    def test_undo_button_disabled_initially(self) -> None:
+        """AC: Undo button disabled when can_undo_last_body_edit=False."""
+        footer = make_footer(can_undo_last_body_edit=False)
+        d = footer.to_render_dict()
+        assert d["undo_button_disabled"] is True
+        assert d["undo_intent_payload"] is None
+
+    def test_undo_intent_is_none_when_disabled(self) -> None:
+        footer = make_footer(can_undo_last_body_edit=False)
+        assert footer.undo_intent is None
+
+    def test_undo_button_disabled_when_no_body_edit_id(self) -> None:
+        """Undo stays disabled even if session_ref is set but can_undo=False."""
+        footer = make_footer(
+            can_undo_last_body_edit=False,
+            session_ref="s1",
+            last_body_edit_id=None,
+        )
+        assert footer.undo_intent is None
+
+
+# ---------------------------------------------------------------------------
+# AC: undo dispatches intent when available
+# ---------------------------------------------------------------------------
+
+class TestUndoDispatchesIntent:
+    def test_undo_dispatches_intent_when_available(self) -> None:
+        """AC: canvas.undoLastEdit intent returned when can_undo_last_body_edit=True."""
+        footer = make_footer(
+            can_undo_last_body_edit=True,
+            session_ref="sess-1",
+            last_body_edit_id="edit-42",
+        )
+        intent = footer.undo_intent
+        assert intent is not None
+        assert intent["intent"] == INTENT_UNDO_LAST_EDIT
+
+    def test_undo_intent_payload_in_render_dict(self) -> None:
+        footer = make_footer(
+            can_undo_last_body_edit=True,
+            session_ref="sess-1",
+            last_body_edit_id="edit-42",
+        )
+        d = footer.to_render_dict()
+        assert d["undo_button_disabled"] is False
+        assert d["undo_intent_payload"] is not None
+        assert d["undo_intent_payload"]["intent"] == INTENT_UNDO_LAST_EDIT
+
+    def test_undo_intent_includes_session_ref(self) -> None:
+        footer = make_footer(
+            can_undo_last_body_edit=True,
+            session_ref="sess-abc",
+        )
+        intent = footer.undo_intent
+        assert intent["session_ref"] == "sess-abc"
+
+
+# ---------------------------------------------------------------------------
+# AC: undo session-bounded
+# ---------------------------------------------------------------------------
+
+class TestUndoSessionBounded:
+    def test_undo_session_bounded(self) -> None:
+        """AC: undo intent bounded to active session; cross-session dispatch impossible.
+
+        The footer only includes the session_ref passed in.  Since session_ref
+        is an opaque string from the caller, cross-session undo would require
+        the caller to supply a different session_ref — the footer never looks
+        up or injects a different session.
+        """
+        footer = make_footer(
+            can_undo_last_body_edit=True,
+            session_ref="session-current",
+        )
+        intent = footer.undo_intent
+        # The intent only carries the session_ref supplied at construction.
+        assert intent["session_ref"] == "session-current"
+
+    def test_footer_cannot_access_other_sessions(self) -> None:
+        """Footer has no mechanism to enumerate or switch sessions."""
+        import companion_ui.canvas_suggestion_flow.provenance_footer as mod
+        src = open(mod.__file__).read()
+        # No session enumeration or cross-session lookup symbols
+        assert "all_sessions" not in src
+        assert "get_sessions" not in src
+
+
+# ---------------------------------------------------------------------------
+# AC: footer has no runtime write side effects
+# ---------------------------------------------------------------------------
+
+class TestFooterHasNoRuntimeWriteSideEffects:
+    def test_footer_has_no_runtime_write_side_effects(self) -> None:
+        """AC: footer is display/intent model only — no runtime writes.
+
+        Checks that none of these runtime writer symbols are importable from
+        the module (mentions in docstrings explaining what's forbidden are OK).
+        """
+        import companion_ui.canvas_suggestion_flow.provenance_footer as mod
+        assert not hasattr(mod, "WriteGuard")
+        assert not hasattr(mod, "SessionLogWriter")
+        assert not hasattr(mod, "GovernanceRouter")
+        assert not hasattr(mod, "canvas_writer")
+
+    def test_no_canvas_core_import(self) -> None:
+        import companion_ui.canvas_suggestion_flow.provenance_footer as mod
+        src = open(mod.__file__).read()
+        assert "import companion_ui.canvas_core" not in src
+        assert "from companion_ui.canvas_core" not in src
+
+    def test_no_panel_import(self) -> None:
+        import companion_ui.canvas_suggestion_flow.provenance_footer as mod
+        src = open(mod.__file__).read()
+        assert "from companion_ui.panel" not in src

--- a/tests/companion_ui/test_receipt_strip.py
+++ b/tests/companion_ui/test_receipt_strip.py
@@ -277,7 +277,6 @@ class TestNoBoundaryCrossing:
     def test_no_vault_write_imports(self) -> None:
         """No runtime writer symbols are imported (mentions in docstrings are OK)."""
         import companion_ui.canvas_suggestion_flow.receipt_strip as mod
-        import importlib
         # Check that none of these are importable attributes (i.e. not imported)
         assert not hasattr(mod, "WriteGuard")
         assert not hasattr(mod, "SessionLogWriter")

--- a/tests/companion_ui/test_receipt_strip.py
+++ b/tests/companion_ui/test_receipt_strip.py
@@ -1,0 +1,330 @@
+"""Tests for ReceiptPill and ReceiptsStrip (#871).
+
+Verifies:
+- ReceiptPill creation with each outcome (applied, queued, discarded, blocked)
+- ReceiptsStrip empty/non-empty state
+- latest receipt access
+- render dicts
+- terminal vs non-terminal outcome classification
+- non_terminal_pills filtering
+- No dependency on Canvas Core, Panel, backend runtime, or vault writes.
+"""
+
+import pytest
+
+from companion_ui.canvas_suggestion_flow.receipt_strip import (
+    RECEIPT_OUTCOMES,
+    ReceiptPill,
+    ReceiptsStrip,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_pill(
+    receipt_id: str = "rec-001",
+    suggestion_id: str = "sugg-001",
+    artifact_id: str = "art-001",
+    outcome: str = "queued",
+    label: str = "queued · rec-001 · move",
+    display_timestamp: str = "2026-05-17T10:00:00Z",
+    message: str | None = None,
+) -> ReceiptPill:
+    return ReceiptPill(
+        receipt_id=receipt_id,
+        suggestion_id=suggestion_id,
+        artifact_id=artifact_id,
+        outcome=outcome,
+        label=label,
+        display_timestamp=display_timestamp,
+        message=message,
+    )
+
+
+# ---------------------------------------------------------------------------
+# RECEIPT_OUTCOMES set
+# ---------------------------------------------------------------------------
+
+class TestReceiptOutcomes:
+    def test_all_four_outcomes_defined(self) -> None:
+        assert RECEIPT_OUTCOMES == frozenset({"applied", "queued", "discarded", "blocked"})
+
+    def test_unknown_outcome_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown receipt outcome"):
+            make_pill(outcome="in-review")
+
+
+# ---------------------------------------------------------------------------
+# ReceiptPill creation with each outcome
+# ---------------------------------------------------------------------------
+
+class TestReceiptPillCreation:
+    def test_queued_outcome(self) -> None:
+        pill = make_pill(outcome="queued")
+        assert pill.outcome == "queued"
+        assert pill.is_terminal is False
+
+    def test_blocked_outcome(self) -> None:
+        pill = make_pill(outcome="blocked", label="blocked · rec-002")
+        assert pill.outcome == "blocked"
+        assert pill.is_terminal is False
+
+    def test_applied_outcome(self) -> None:
+        pill = make_pill(outcome="applied", label="applied · rec-003")
+        assert pill.outcome == "applied"
+        assert pill.is_terminal is True
+
+    def test_discarded_outcome(self) -> None:
+        pill = make_pill(outcome="discarded", label="discarded · rec-004")
+        assert pill.outcome == "discarded"
+        assert pill.is_terminal is True
+
+    def test_all_four_outcomes_construction(self) -> None:
+        for outcome in ["applied", "queued", "discarded", "blocked"]:
+            pill = make_pill(outcome=outcome, label=f"{outcome} · rec-x")
+            assert pill.outcome == outcome
+
+    def test_required_fields(self) -> None:
+        with pytest.raises(ValueError, match="receipt_id"):
+            ReceiptPill(
+                receipt_id="",
+                suggestion_id="s",
+                artifact_id="a",
+                outcome="queued",
+                label="x",
+                display_timestamp="t",
+            )
+
+    def test_optional_message_none(self) -> None:
+        pill = make_pill()
+        assert pill.message is None
+
+    def test_optional_message_set(self) -> None:
+        pill = make_pill(message="Awaiting governance review")
+        assert pill.message == "Awaiting governance review"
+
+
+# ---------------------------------------------------------------------------
+# ReceiptPill render dict
+# ---------------------------------------------------------------------------
+
+class TestReceiptPillRenderDict:
+    def test_render_dict_keys(self) -> None:
+        pill = make_pill()
+        d = pill.to_render_dict()
+        assert d["data_testid"] == "receipt-pill"
+        assert d["data_receipt_id"] == pill.receipt_id
+        assert d["data_status"] == pill.outcome
+        assert d["data_intent"] == "governance.openReceipt"
+        assert d["is_terminal"] == pill.is_terminal
+
+    def test_aria_label_includes_receipt_id_and_outcome(self) -> None:
+        pill = make_pill(receipt_id="rec-xyz", outcome="queued")
+        d = pill.to_render_dict()
+        assert "rec-xyz" in d["aria_label"]
+        assert "queued" in d["aria_label"]
+        assert "Panel" in d["aria_label"]
+
+    def test_render_dict_includes_message_when_set(self) -> None:
+        pill = make_pill(message="Extra context")
+        d = pill.to_render_dict()
+        assert d["message"] == "Extra context"
+
+    def test_render_dict_omits_message_when_none(self) -> None:
+        pill = make_pill(message=None)
+        d = pill.to_render_dict()
+        assert "message" not in d
+
+    def test_terminal_outcomes_flag_is_terminal(self) -> None:
+        for outcome in ["applied", "discarded"]:
+            d = make_pill(outcome=outcome, label=f"{outcome}").to_render_dict()
+            assert d["is_terminal"] is True
+
+    def test_non_terminal_outcomes_flag_not_terminal(self) -> None:
+        for outcome in ["queued", "blocked"]:
+            d = make_pill(outcome=outcome).to_render_dict()
+            assert d["is_terminal"] is False
+
+
+# ---------------------------------------------------------------------------
+# ReceiptsStrip empty/non-empty state
+# ---------------------------------------------------------------------------
+
+class TestReceiptsStripEmpty:
+    def test_empty_strip_on_default(self) -> None:
+        strip = ReceiptsStrip()
+        assert strip.is_empty is True
+
+    def test_empty_strip_explicit(self) -> None:
+        strip = ReceiptsStrip(pills=[])
+        assert strip.is_empty is True
+
+    def test_non_empty_strip(self) -> None:
+        strip = ReceiptsStrip(pills=[make_pill()])
+        assert strip.is_empty is False
+
+    def test_empty_latest_is_none(self) -> None:
+        strip = ReceiptsStrip()
+        assert strip.latest is None
+
+
+# ---------------------------------------------------------------------------
+# latest receipt access
+# ---------------------------------------------------------------------------
+
+class TestReceiptsStripLatest:
+    def test_latest_is_last_pill(self) -> None:
+        p1 = make_pill(receipt_id="rec-001")
+        p2 = make_pill(receipt_id="rec-002")
+        strip = ReceiptsStrip(pills=[p1, p2])
+        assert strip.latest is p2
+
+    def test_latest_single_pill(self) -> None:
+        p = make_pill(receipt_id="rec-solo")
+        strip = ReceiptsStrip(pills=[p])
+        assert strip.latest is p
+
+    def test_latest_after_appending(self) -> None:
+        p1 = make_pill(receipt_id="rec-001")
+        p2 = make_pill(receipt_id="rec-002")
+        strip = ReceiptsStrip(pills=[p1])
+        strip.pills.append(p2)
+        assert strip.latest is p2
+
+
+# ---------------------------------------------------------------------------
+# non_terminal_pills filtering
+# ---------------------------------------------------------------------------
+
+class TestNonTerminalPills:
+    def test_non_terminal_excludes_applied(self) -> None:
+        applied = make_pill(outcome="applied", receipt_id="r1", label="x")
+        queued = make_pill(outcome="queued", receipt_id="r2")
+        strip = ReceiptsStrip(pills=[applied, queued])
+        assert queued in strip.non_terminal_pills
+        assert applied not in strip.non_terminal_pills
+
+    def test_non_terminal_excludes_discarded(self) -> None:
+        discarded = make_pill(outcome="discarded", receipt_id="r1", label="x")
+        blocked = make_pill(outcome="blocked", receipt_id="r2", label="b")
+        strip = ReceiptsStrip(pills=[discarded, blocked])
+        assert blocked in strip.non_terminal_pills
+        assert discarded not in strip.non_terminal_pills
+
+    def test_non_terminal_empty_when_all_terminal(self) -> None:
+        strip = ReceiptsStrip(pills=[
+            make_pill(outcome="applied", receipt_id="r1", label="x"),
+            make_pill(outcome="discarded", receipt_id="r2", label="y"),
+        ])
+        assert strip.non_terminal_pills == []
+
+
+# ---------------------------------------------------------------------------
+# ReceiptsStrip render dict
+# ---------------------------------------------------------------------------
+
+class TestReceiptsStripRenderDict:
+    def test_render_dict_keys(self) -> None:
+        strip = ReceiptsStrip()
+        d = strip.to_render_dict()
+        assert d["data_testid"] == "receipts-strip"
+        assert d["aria_live"] == "polite"
+        assert d["is_empty"] is True
+        assert d["pill_count"] == 0
+        assert d["pills"] == []
+
+    def test_render_dict_with_pills(self) -> None:
+        p = make_pill()
+        strip = ReceiptsStrip(pills=[p])
+        d = strip.to_render_dict()
+        assert d["is_empty"] is False
+        assert d["pill_count"] == 1
+        assert len(d["pills"]) == 1
+        assert d["pills"][0]["data_receipt_id"] == p.receipt_id
+
+    def test_render_dict_non_terminal_pill_count(self) -> None:
+        strip = ReceiptsStrip(pills=[
+            make_pill(outcome="queued", receipt_id="r1"),
+            make_pill(outcome="applied", receipt_id="r2", label="x"),
+        ])
+        d = strip.to_render_dict()
+        assert d["non_terminal_pill_count"] == 1
+        assert len(d["non_terminal_pills"]) == 1
+
+    def test_aria_live_polite_present(self) -> None:
+        """AC: ReceiptsStrip aria-live='polite' present (issue #871)."""
+        d = ReceiptsStrip().to_render_dict()
+        assert d.get("aria_live") == "polite"
+
+
+# ---------------------------------------------------------------------------
+# Boundary: no Canvas Core / Panel / runtime coupling
+# ---------------------------------------------------------------------------
+
+class TestNoBoundaryCrossing:
+    def test_no_canvas_core_import(self) -> None:
+        import companion_ui.canvas_suggestion_flow.receipt_strip as mod
+        src = open(mod.__file__).read()
+        assert "canvas_core" not in src
+
+    def test_no_panel_import(self) -> None:
+        import companion_ui.canvas_suggestion_flow.receipt_strip as mod
+        src = open(mod.__file__).read()
+        assert "from companion_ui.panel" not in src
+
+    def test_no_vault_write_imports(self) -> None:
+        """No runtime writer symbols are imported (mentions in docstrings are OK)."""
+        import companion_ui.canvas_suggestion_flow.receipt_strip as mod
+        import importlib
+        # Check that none of these are importable attributes (i.e. not imported)
+        assert not hasattr(mod, "WriteGuard")
+        assert not hasattr(mod, "SessionLogWriter")
+        assert not hasattr(mod, "GovernanceRouter")
+
+
+# ---------------------------------------------------------------------------
+# Top-level AC entry points — exact Verify: targets from issue #871
+# ---------------------------------------------------------------------------
+
+def test_receipt_pill_renders_on_governance_queue() -> None:
+    """AC: ReceiptPill renders after governance.queue resolves."""
+    pill = make_pill(outcome="queued")
+    d = pill.to_render_dict()
+    assert d["data_status"] == "queued"
+    assert d["data_intent"] == "governance.openReceipt"
+
+
+def test_receipts_strip_aria_live() -> None:
+    """AC: ReceiptsStrip has aria-live='polite'."""
+    d = ReceiptsStrip().to_render_dict()
+    assert d["aria_live"] == "polite"
+
+
+def test_receipt_pill_status_transitions() -> None:
+    """AC: Pill reflects each status outcome without reload."""
+    for outcome in ["queued", "applied", "discarded", "blocked"]:
+        pill = make_pill(outcome=outcome, label=outcome)
+        assert pill.outcome == outcome
+        assert pill.to_render_dict()["data_status"] == outcome
+
+
+def test_terminal_receipts_removed() -> None:
+    """AC: Terminal receipts (applied/discarded) absent from non_terminal_pills."""
+    strip = ReceiptsStrip(pills=[
+        make_pill(outcome="applied", receipt_id="r1", label="x"),
+        make_pill(outcome="discarded", receipt_id="r2", label="y"),
+        make_pill(outcome="queued", receipt_id="r3"),
+    ])
+    ids = {p.receipt_id for p in strip.non_terminal_pills}
+    assert "r3" in ids
+    assert "r1" not in ids
+    assert "r2" not in ids
+
+
+def test_no_receipt_on_body_edit() -> None:
+    """AC: Body-edit applies do not generate a receipt — strip is empty by default."""
+    # The ReceiptsStrip is not populated by body edits; it requires explicit pill construction.
+    strip = ReceiptsStrip()
+    assert strip.is_empty is True


### PR DESCRIPTION
## Summary

- Implements four pure Python dataclass/model modules for the Canvas bounded suggestion flow (`receipt_strip.py`, `provenance_footer.py`, `keyboard_shortcuts.py`, `portrait_sheet.py`) with 177 new tests, 559 total passing.
- All modules are stdlib + dataclasses only; no new dependencies introduced.
- Immutable/functional style used throughout (e.g. `PortraitSheet.transition_to()` returns new instances).

## Issues

- Closes #871 — `ReceiptPill` and `ReceiptsStrip` pure Python models with all four outcomes, `is_terminal` classification, `non_terminal_pills` filtering, `aria-live="polite"` in render dict, and `governance.openReceipt` intent token.
- Closes #872 — `ShortcutAction` enum and `SuggestionShortcutMap` covering body/governance/blocked/terminal variants, key bindings A/Q/D/I/E, staged-rail-state gating for mutating shortcuts, terminal-state suppression, and `to_render_dict()` with intent tokens.
- Closes #873 — `SheetSnap` enum (PEEK/HALF/FULL_MINUS_CHROME/CLOSED), immutable `PortraitSheet` with `transition_to()`, `auto_snap_on_proposal()` (PEEK→HALF, FULL forbidden), `is_visible()`, touch-target hint, receipts-strip-position hint, and `to_render_dict()`.
- Closes #874 — `ProvenanceFooter` with `session_log_path`, `turn_count`, `can_undo_last_body_edit`, `provenance.openSessionLog` and `canvas.undoLastEdit` intent payloads, undo session-bounded by construction.
- Advances #1022 — Canvas bounded suggestion flow workstream, Batch 2 models delivered.

## Surface boundary statement

All code in this PR lives entirely within the **Canvas bounded suggestion flow** surface:

- `companion-ui/companion-app/companion_ui/canvas_suggestion_flow/`
- `tests/companion_ui/`

No imports from `companion_ui.canvas_core`, `companion_ui.panel`, `app/`, runtime writers, vault writers, or FastAPI routers. No vault writes, no watcher code, no endpoint/API implementation, no DB/migration changes. Forbidden symbols (`WriteGuard`, `SessionLogWriter`, `GovernanceRouter`, `canvas_writer`) do not appear in any import statement.

## Docs and issues read

- `companion-ui/docs/CANVAS_SUGGESTION_FLOW.md`
- `companion-ui/docs/CANVAS_AGENT_MVP_CONTRACT.md`
- `companion-ui/docs/UI_RUNTIME_BOUNDARIES.md`
- Issues #871, #872, #873, #874, #1022 (full body + comments)
- Existing modules: `rail_state_machine.py`, `suggestion_card.py`, `suggested_insertion.py`
- Existing tests: `test_canvas_rail_state_machine.py`, `test_suggestion_card.py`, `test_suggested_insertion.py`

## Validation level

**Level 1 — isolated Companion UI model/helper tests**

Full smoke is not required: this PR contains only isolated Python helper/model modules. No runtime startup, no backend API wiring, no vault write paths, no watcher execution, no DB migrations, no release-channel behavior.

## Commands run and results

```
git diff --check
# Exit 0 — no whitespace errors

PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_receipt_strip.py
# 38 passed

PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_provenance_footer.py
# 36 passed

PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_canvas_suggestion_shortcuts.py
# 55 passed

PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_canvas_portrait_sheet.py
# 48 passed

PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/
# 559 passed in 0.26s
```

## Full-smoke rationale

Not required. Isolated Companion UI Python helpers only. No runtime startup, backend API, real vault write path, watcher, DB/migration, environment/release-channel, or prod/stable behavior changed.