### PR TITLE
docs: align README and DOCS_INDEX with shipped v6.0 seams baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-State: SoT v5.5 Reality-MVP baseline (locked); v5.6 delivered and closed; v6 is the active design and planning direction.
+State: SoT v5.5 Reality-MVP baseline (locked); v5.6 delivered and closed; v6.0 seams baseline shipped at capability-seam level; broader v6 runtime/product consumption is v6.1+.
 # Agentic PKM — Vault-First, Event-Driven PKM Runtime
 
 Agentic PKM is a vault-first, event-driven PKM runtime:
@@ -7,7 +7,7 @@ Agentic PKM is a vault-first, event-driven PKM runtime:
 - The runtime is guarded by CI fitness gates and explicit safety switches (watcher auto-run, dedup/idempotency, optimistic writes).
 
 Start here:
-- `docs/STATUS.md` — current baseline reality (v5.5); v5.6 delivered; v6 active design direction
+- `docs/STATUS.md` — current baseline reality (v5.5); v5.6 delivered and closed; v6.0 seams baseline shipped; broader v6 runtime/product consumption is v6.1+
 - `docs/ARCHITECTURE.md` — active runtime architecture source of truth
 - `docs/HUMAN-FLOWS.md` — user-facing behavior contract
 - `docs/DOCS_INDEX.md` — map of the wider documentation set, including reference and historical docs
@@ -45,7 +45,7 @@ Prereqs:
 ## Documentation Reading Order
 - Core SoT: `docs/STATUS.md`, `docs/ARCHITECTURE.md`, `docs/HUMAN-FLOWS.md`, `docs/COMPONENTS.md`, `docs/EVENTS.md`, `docs/TESTING.md`, `docs/OPERATIONS.md`
 - Reference docs: use `docs/DOCS_INDEX.md` to find implementation, operator, and development guidance outside the core set
-- Plan docs: `docs/ROADMAP.md`, `docs/plans/V60_ARCHITECTURE_TARGET.md`, `docs/plans/V60_CAPABILITY_AND_AGENT_EVOLUTION.md`, `docs/plans/PROTOCOL_SATELLITE_SYNC.md`, and the docs under `docs/tracks/`
+- Plan docs (target-state / future-direction — not current baseline): `docs/ROADMAP.md`, `docs/plans/V60_ARCHITECTURE_TARGET.md`, `docs/plans/V60_CAPABILITY_AND_AGENT_EVOLUTION.md`, `docs/plans/PROTOCOL_SATELLITE_SYNC.md`, and the docs under `docs/tracks/`
 - Historical plan docs: `docs/plans/V56_FORWARD_LINE.md` (delivered/closed)
 - Historical docs: read only for background after the core docs; they are not current truth
 
@@ -95,4 +95,4 @@ SoT v4.10 is the historical Reality-MVP foundation snapshot and is not current r
 - `docs/archive/architecture/SYSTEM_DESIGN_v4.10.md`
 - `docs/history/SOT_4X_HISTORY.md`
 
-The current baseline is v5.5; v5.6 is delivered and closed. Active design and planning direction is v6 — see `docs/plans/V60_ARCHITECTURE_TARGET.md` and `docs/plans/V60_CAPABILITY_AND_AGENT_EVOLUTION.md`.
+The current baseline is v5.5; v5.6 is delivered and closed; v6.0 seams baseline is shipped at capability-seam level. Broader v6 runtime/product consumption is v6.1+ work — see `docs/plans/V60_ARCHITECTURE_TARGET.md` and `docs/plans/V60_CAPABILITY_AND_AGENT_EVOLUTION.md` for target-state design direction.

--- a/docs/DOCS_INDEX.md
+++ b/docs/DOCS_INDEX.md
@@ -87,13 +87,13 @@ The 2026 docs cleanup work is archived under `docs/archive/docs-refactor/`. The 
 - v4.10 — locked Reality-MVP baseline (foundation only).
 - v5.0 — PanelAgent Runtime V1 baseline on top of v4.10.
 - v5.x — **SoT delivery line** (v5.5 locked baseline plus delivered v5.6 enablement); v5.6 is closed. Unresolved work is post-v5.6 follow-up unless an owner issue reclassifies it.
-- v6 — **active design and planning direction**; target operating model under active design but not yet runtime baseline. Governing docs: `docs/ROADMAP.md`, `docs/plans/V60_ARCHITECTURE_TARGET.md`, `docs/plans/V60_CAPABILITY_AND_AGENT_EVOLUTION.md`. See `docs/STATUS.md#version-framing-consistency-note` for the authoritative framing map.
+- v6.0 seams — **shipped at capability-seam level** (orientation/resurfacing/commitment-domain/context-dimensions runtimes plus closed capability spec dirs); broader v6 runtime/product consumption is v6.1+. Governing docs: `docs/ROADMAP.md`, `docs/plans/V60_ARCHITECTURE_TARGET.md`, `docs/plans/V60_CAPABILITY_AND_AGENT_EVOLUTION.md`. See `docs/STATUS.md#version-framing-consistency-note` for the authoritative framing map.
 
 ## Root and Repo Docs
 - `docs/EMBEDDINGS.md` — Normative embeddings spec (identity, guardrails, rebuild policy).
 | Path | Scope | Review status | Last reviewed | Notes |
 | --- | --- | --- | --- | --- |
-| README.md | Top-level overview | Aligned (forward line v5.x) | 2026-04-02 | v5.5 baseline quickstart + invariants; points readers to DOCS_INDEX/STATUS/ARCHITECTURE and the wider active docs set. |
+| README.md | Top-level overview | Aligned (v6.0 seams shipped; v6.1+ framing) | 2026-05-17 | v5.5 baseline quickstart + invariants; v6.0 seams baseline shipped; broader v6 consumption is v6.1+; points readers to DOCS_INDEX/STATUS/ARCHITECTURE and the wider active docs set. |
 | docs/archive/docs-refactor/DOCS_REFACTOR_PLAN.md | Documentation simplification plan | Legacy (archived) | 2026-03-14 | Archived planning record for the 2026 docs cleanup effort; no longer an active decision surface. |
 | docs/archive/docs-refactor/DOCS_SECOND_WAVE_CLEANUP.md | Second-wave cleanup matrix | Legacy (archived) | 2026-03-14 | Archived execution matrix for the completed cleanup wave. |
 | docs/archive/docs-refactor/HISTORICAL_EXTRACTION_REVIEW.md | Historical extraction review | Legacy (archived) | 2026-03-14 | Archived extraction review used during the historical-doc cleanup pass. |

--- a/docs/DOCS_INDEX.md
+++ b/docs/DOCS_INDEX.md
@@ -1,7 +1,7 @@
-State: SoT v5.5 Reality-MVP baseline locked (watcher safety, panel action provenance, and concurrency guardrails); v5.6 delivery line closed; v6 is the active design and planning direction. Post-v5.6 follow-ups are tracked separately; see `docs/STATUS.md#version-framing-consistency-note` for the authoritative framing map.
+State: SoT v5.5 Reality-MVP baseline locked (watcher safety, panel action provenance, and concurrency guardrails); v5.6 delivery line closed; v6.0 seams baseline shipped at capability-seam level; broader v6 runtime/product consumption is v6.1+. Post-v5.6 follow-ups are tracked separately; see `docs/STATUS.md#version-framing-consistency-note` for the authoritative framing map.
 Doc role: Core SoT
 Authority: Canonical map of document roles and review status for the current repo; use it to determine whether a document is Core SoT, Reference, Plan, or Historical.
-# Documentation Review Index — SoT v5.5 baseline + v6 active planning
+# Documentation Review Index — SoT v5.5 baseline + v6.0 seams shipped; v6.1+ broader consumption
 
 Central map of active and archived documentation artifacts in this repo. Use this index before treating any document as decision input.
 


### PR DESCRIPTION
Closes #1052

## Summary

- `README.md` state header, "Start here" blurb, and bottom paragraph all framed v6 as the "active design and planning direction" while `docs/STATUS.md` and `docs/ROADMAP.md` already reflected the shipped v6.0 seams baseline. Aligns all README touch-points.
- `docs/DOCS_INDEX.md` state header and h1 title carried the same stale framing; updated to match.
- v6 plan docs in the Documentation Reading Order section now carry an explicit "(target-state / future-direction — not current baseline)" qualifier.

## Verify targets (all pass)

\`\`\`
grep -n "v6.0 seams baseline shipped" README.md   # lines 1, 10, 98
grep -n "v6.1+" README.md                          # lines 1, 10, 98
grep -n "v6 is the active design" README.md docs/DOCS_INDEX.md || true  # no output
git diff --check                                   # clean
\`\`\`

## Scope

Docs-only. No runtime changes, no new issues.