### PR TITLE
feat(panel): implement Panel confirmation endpoint

### DIFF
--- a/app/api/app.py
+++ b/app/api/app.py
@@ -73,6 +73,11 @@ try:
 except ImportError:
     canvas_router = None
 
+try:
+    from app.api.routes.panel import router as panel_router
+except ImportError:
+    panel_router = None
+
 static_dir = Path(__file__).resolve().parent.parent / "web" / "static"
 logger = logging.getLogger(__name__)
 
@@ -170,6 +175,8 @@ def _create_app() -> FastAPI:
         application.include_router(agent_router)
     if canvas_router is not None:
         application.include_router(canvas_router, prefix="/api")
+    if panel_router is not None:
+        application.include_router(panel_router, prefix="/api")
     return application
 
 

--- a/app/api/routes/panel.py
+++ b/app/api/routes/panel.py
@@ -11,7 +11,12 @@ from __future__ import annotations
 from fastapi import APIRouter, HTTPException
 
 import app.panel.confirmation as confirm_module
-from app.panel.confirmation import ConfirmRequest, ConfirmResponse, SameTurnExecutionError
+from app.panel.confirmation import (
+    ConfirmRequest,
+    ConfirmResponse,
+    SameTurnExecutionError,
+    UnknownProposalError,
+)
 
 router = APIRouter(prefix="/panel", tags=["panel"])
 
@@ -20,6 +25,11 @@ router = APIRouter(prefix="/panel", tags=["panel"])
 async def panel_confirm(request: ConfirmRequest) -> ConfirmResponse:
     try:
         return confirm_module._service.confirm(request)
+    except UnknownProposalError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail={"error": "unknown_proposal", "proposal_id": str(exc)},
+        )
     except SameTurnExecutionError as exc:
         raise HTTPException(status_code=422, detail=str(exc))
     except ValueError as exc:

--- a/app/api/routes/panel.py
+++ b/app/api/routes/panel.py
@@ -1,0 +1,26 @@
+"""Panel confirmation API route.
+
+POST /api/panel/confirm — submits a user's explicit confirm or reject decision
+for a staged Panel proposal. The runtime owns policy evaluation, WriteGuard,
+idempotency, execution, receipts, and event emission. The Companion UI must
+not write vault files directly.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+
+import app.panel.confirmation as confirm_module
+from app.panel.confirmation import ConfirmRequest, ConfirmResponse, SameTurnExecutionError
+
+router = APIRouter(prefix="/panel", tags=["panel"])
+
+
+@router.post("/confirm", response_model=ConfirmResponse)
+async def panel_confirm(request: ConfirmRequest) -> ConfirmResponse:
+    try:
+        return confirm_module._service.confirm(request)
+    except SameTurnExecutionError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))

--- a/app/panel/confirmation.py
+++ b/app/panel/confirmation.py
@@ -1,0 +1,223 @@
+"""Panel confirmation service — runtime-mediated confirm/reject for Panel proposals.
+
+The Companion UI must not write vault files directly. This module owns policy
+evaluation, WriteGuard, idempotency, execution delegation, receipts, and the
+typed response contract.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel, Field, model_validator
+
+from app.agents.panel_agent.runtime import execute_panel_intent  # noqa: F401 — patchable by tests
+from app.events.panel import PanelIntentEvent
+from app.write_guard import DEFAULT_WRITE_GUARD, WriteGuard, WritesBlockedError
+
+SAME_TURN_TTL_SECONDS = 5.0
+
+
+class SameTurnExecutionError(RuntimeError):
+    pass
+
+
+@dataclass
+class StagedProposal:
+    artifact_id: str
+    intent_event: PanelIntentEvent
+    proposed_at: float = field(default_factory=time.time)
+    trace_id: str = ""
+
+
+class CorrectionFields(BaseModel):
+    enabled: bool = False
+    corrected_action_id: str | None = None
+    corrected_parameters: dict[str, Any] | None = None
+
+    @model_validator(mode="after")
+    def _require_correction_payload(self) -> "CorrectionFields":
+        if self.enabled and self.corrected_action_id is None and self.corrected_parameters is None:
+            raise ValueError(
+                "correction.enabled=true requires corrected_action_id or corrected_parameters"
+            )
+        return self
+
+
+class ConfirmRequest(BaseModel):
+    proposal_id: str = Field(min_length=1)
+    artifact_id: str = Field(min_length=1)
+    action: str
+    idempotency_key: str = Field(min_length=1)
+    correction: CorrectionFields | None = None
+
+    @model_validator(mode="after")
+    def _validate_action(self) -> "ConfirmRequest":
+        if self.action not in ("confirm", "reject"):
+            raise ValueError(f"action must be 'confirm' or 'reject', got '{self.action}'")
+        return self
+
+
+class Receipt(BaseModel):
+    action_taken: str
+    outcome: str
+    timestamp: str
+    message: str | None = None
+    inverse_action: str | None = None
+
+
+class BlockReason(BaseModel):
+    gate: str
+    message: str
+    code: str | None = None
+
+
+class ConfirmResponse(BaseModel):
+    proposal_id: str
+    artifact_id: str
+    status: str
+    outcome: str
+    receipt: Receipt | None = None
+    block_reason: BlockReason | None = None
+    error: str | None = None
+    idempotency_key: str
+    events_emitted: list[str] = Field(default_factory=list)
+
+
+class ProposalStore:
+    def __init__(self) -> None:
+        self._proposals: dict[str, StagedProposal] = {}
+
+    def stage(self, proposal_id: str, proposal: StagedProposal) -> None:
+        self._proposals[proposal_id] = proposal
+
+    def get(self, proposal_id: str) -> StagedProposal | None:
+        return self._proposals.get(proposal_id)
+
+    def clear(self) -> None:
+        self._proposals.clear()
+
+
+class ConfirmIdempotencyStore:
+    def __init__(self) -> None:
+        self._cache: dict[str, ConfirmResponse] = {}
+
+    def get(self, key: str) -> ConfirmResponse | None:
+        return self._cache.get(key)
+
+    def set(self, key: str, response: ConfirmResponse) -> None:
+        self._cache[key] = response
+
+    def clear(self) -> None:
+        self._cache.clear()
+
+
+class PanelConfirmationService:
+    def __init__(
+        self,
+        proposal_store: ProposalStore,
+        idempotency_store: ConfirmIdempotencyStore,
+        write_guard: WriteGuard | None = None,
+        same_turn_ttl: float = SAME_TURN_TTL_SECONDS,
+    ) -> None:
+        self._proposals = proposal_store
+        self._idempotency = idempotency_store
+        self._guard = write_guard or DEFAULT_WRITE_GUARD
+        self._ttl = same_turn_ttl
+
+    def confirm(self, request: ConfirmRequest) -> ConfirmResponse:
+        cached = self._idempotency.get(request.idempotency_key)
+        if cached is not None:
+            return cached
+
+        proposal = self._proposals.get(request.proposal_id)
+        if proposal is None:
+            return ConfirmResponse(
+                proposal_id=request.proposal_id,
+                artifact_id=request.artifact_id,
+                status="error",
+                outcome="error",
+                error="unknown_proposal",
+                idempotency_key=request.idempotency_key,
+            )
+
+        if proposal.artifact_id != request.artifact_id:
+            raise ValueError("proposal does not belong to artifact_id")
+
+        if (time.time() - proposal.proposed_at) < self._ttl:
+            raise SameTurnExecutionError(
+                "same-turn execution is not allowed — proposal was staged in the current interaction window"
+            )
+
+        if request.action == "reject":
+            resp = ConfirmResponse(
+                proposal_id=request.proposal_id,
+                artifact_id=request.artifact_id,
+                status="rejected",
+                outcome="rejected",
+                idempotency_key=request.idempotency_key,
+                events_emitted=[],
+            )
+            self._idempotency.set(request.idempotency_key, resp)
+            return resp
+
+        try:
+            self._guard.assert_writes_allowed("panel.confirm")
+        except WritesBlockedError as exc:
+            resp = ConfirmResponse(
+                proposal_id=request.proposal_id,
+                artifact_id=request.artifact_id,
+                status="blocked",
+                outcome="blocked",
+                block_reason=BlockReason(gate="writeguard", message=str(exc)),
+                idempotency_key=request.idempotency_key,
+            )
+            self._idempotency.set(request.idempotency_key, resp)
+            return resp
+
+        import app.panel.confirmation as _self_mod
+
+        result = _self_mod.execute_panel_intent(proposal.intent_event)
+        events: list[str] = []
+        for e in result.emitted_events:
+            if isinstance(e, dict):
+                events.append(e.get("event", ""))
+            else:
+                events.append(getattr(e, "event", str(e)))
+
+        now_iso = datetime.now(tz=timezone.utc).isoformat().replace("+00:00", "Z")
+        receipt = Receipt(action_taken="confirm", outcome="success", timestamp=now_iso)
+        resp = ConfirmResponse(
+            proposal_id=request.proposal_id,
+            artifact_id=request.artifact_id,
+            status="executed",
+            outcome="success",
+            receipt=receipt,
+            idempotency_key=request.idempotency_key,
+            events_emitted=events,
+        )
+        self._idempotency.set(request.idempotency_key, resp)
+        return resp
+
+
+_proposal_store = ProposalStore()
+_idempotency_store = ConfirmIdempotencyStore()
+_service = PanelConfirmationService(_proposal_store, _idempotency_store)
+
+__all__ = [
+    "BlockReason",
+    "ConfirmIdempotencyStore",
+    "ConfirmRequest",
+    "ConfirmResponse",
+    "PanelConfirmationService",
+    "ProposalStore",
+    "Receipt",
+    "SameTurnExecutionError",
+    "StagedProposal",
+    "_idempotency_store",
+    "_proposal_store",
+    "_service",
+]

--- a/app/panel/confirmation.py
+++ b/app/panel/confirmation.py
@@ -25,6 +25,10 @@ class SameTurnExecutionError(RuntimeError):
     pass
 
 
+class UnknownProposalError(LookupError):
+    pass
+
+
 @dataclass
 class StagedProposal:
     artifact_id: str
@@ -135,14 +139,7 @@ class PanelConfirmationService:
 
         proposal = self._proposals.get(request.proposal_id)
         if proposal is None:
-            return ConfirmResponse(
-                proposal_id=request.proposal_id,
-                artifact_id=request.artifact_id,
-                status="error",
-                outcome="error",
-                error="unknown_proposal",
-                idempotency_key=request.idempotency_key,
-            )
+            raise UnknownProposalError(request.proposal_id)
 
         if proposal.artifact_id != request.artifact_id:
             raise ValueError("proposal does not belong to artifact_id")
@@ -177,6 +174,12 @@ class PanelConfirmationService:
             )
             self._idempotency.set(request.idempotency_key, resp)
             return resp
+
+        if request.correction and request.correction.enabled:
+            raise ValueError(
+                "correction.enabled=true is not supported in this slice — "
+                "corrected confirmations are not yet implemented"
+            )
 
         import app.panel.confirmation as _self_mod
 
@@ -217,6 +220,7 @@ __all__ = [
     "Receipt",
     "SameTurnExecutionError",
     "StagedProposal",
+    "UnknownProposalError",
     "_idempotency_store",
     "_proposal_store",
     "_service",

--- a/tests/api/test_panel_confirm_api.py
+++ b/tests/api/test_panel_confirm_api.py
@@ -145,11 +145,10 @@ def test_panel_confirm_endpoint_rejects_invalid_action(client: TestClient) -> No
 
 
 def test_panel_confirm_endpoint_rejects_unknown_proposal_id(client: TestClient) -> None:
-    # No proposal staged — proposal_id is unknown
+    # No proposal staged — proposal_id is unknown; contract requires 4xx
     resp = client.post("/api/panel/confirm", json=_valid_body(proposal_id="nonexistent"))
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["error"] == "unknown_proposal"
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["error"] == "unknown_proposal"
 
 
 def test_panel_confirm_endpoint_blocked_on_writeguard(client: TestClient) -> None:

--- a/tests/api/test_panel_confirm_api.py
+++ b/tests/api/test_panel_confirm_api.py
@@ -1,0 +1,231 @@
+"""Panel confirmation endpoint acceptance tests (no Postgres required).
+
+All behavioral ACs from issue #1053, run against the module-level stores so
+each test starts with a clean slate.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.panel.confirmation as confirm_module
+from app.api.app import app
+from app.events.panel import NoteRef, PanelInfo, PanelIntentEvent, PanelIntentPayload
+from app.panel.confirmation import StagedProposal
+from app.write_guard import WritesBlockedError
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_stores():
+    confirm_module._proposal_store.clear()
+    confirm_module._idempotency_store.clear()
+    yield
+    confirm_module._proposal_store.clear()
+    confirm_module._idempotency_store.clear()
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_intent(proposal_id: str = "prop-1", artifact_id: str = "note-uuid-1") -> PanelIntentEvent:
+    return PanelIntentEvent(
+        payload=PanelIntentPayload(
+            note=NoteRef(uuid=artifact_id, path="notes/test.md"),
+            panel=PanelInfo(panel_id=proposal_id, instruction="do the thing"),
+        )
+    )
+
+
+def _stage(
+    proposal_id: str = "prop-1",
+    artifact_id: str = "note-uuid-1",
+    proposed_at: float | None = None,
+) -> None:
+    """Stage a proposal. proposed_at=0.0 (default) puts it safely outside same-turn window."""
+    confirm_module._proposal_store.stage(
+        proposal_id,
+        StagedProposal(
+            artifact_id=artifact_id,
+            intent_event=_make_intent(proposal_id, artifact_id),
+            proposed_at=0.0 if proposed_at is None else proposed_at,
+        ),
+    )
+
+
+def _mock_execute(monkeypatch, events: list[str] | None = None) -> MagicMock:
+    events = events or ["panel.intent.executed"]
+    mock_result = MagicMock()
+    mock_result.emitted_events = [{"event": e} for e in events]
+    mock_fn = MagicMock(return_value=mock_result)
+    monkeypatch.setattr(confirm_module, "execute_panel_intent", mock_fn)
+    return mock_fn
+
+
+def _valid_body(
+    proposal_id: str = "prop-1",
+    artifact_id: str = "note-uuid-1",
+    action: str = "confirm",
+    idempotency_key: str = "idem-key-1",
+) -> dict:
+    return {
+        "proposal_id": proposal_id,
+        "artifact_id": artifact_id,
+        "action": action,
+        "idempotency_key": idempotency_key,
+    }
+
+
+# ---------------------------------------------------------------------------
+# AC tests
+# ---------------------------------------------------------------------------
+
+
+def test_panel_confirm_endpoint_returns_receipt_on_success(
+    client: TestClient, monkeypatch
+) -> None:
+    _stage()
+    _mock_execute(monkeypatch)
+    resp = client.post("/api/panel/confirm", json=_valid_body())
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "executed"
+    assert data["receipt"] is not None
+    assert data["receipt"]["outcome"] == "success"
+    assert data["proposal_id"] == "prop-1"
+
+
+def test_panel_confirm_endpoint_idempotent(client: TestClient, monkeypatch) -> None:
+    _stage()
+    mock_fn = _mock_execute(monkeypatch)
+    body = _valid_body()
+
+    first = client.post("/api/panel/confirm", json=body)
+    second = client.post("/api/panel/confirm", json=body)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json() == second.json()
+    assert mock_fn.call_count == 1  # executed only once
+
+
+def test_panel_confirm_endpoint_rejects_missing_proposal_id(client: TestClient) -> None:
+    body = _valid_body()
+    del body["proposal_id"]
+    resp = client.post("/api/panel/confirm", json=body)
+    assert resp.status_code == 422
+
+
+def test_panel_confirm_endpoint_rejects_missing_artifact_id(client: TestClient) -> None:
+    body = _valid_body()
+    del body["artifact_id"]
+    resp = client.post("/api/panel/confirm", json=body)
+    assert resp.status_code == 422
+
+
+def test_panel_confirm_endpoint_rejects_invalid_action(client: TestClient) -> None:
+    body = _valid_body(action="execute")
+    resp = client.post("/api/panel/confirm", json=body)
+    assert resp.status_code == 422
+
+
+def test_panel_confirm_endpoint_rejects_unknown_proposal_id(client: TestClient) -> None:
+    # No proposal staged — proposal_id is unknown
+    resp = client.post("/api/panel/confirm", json=_valid_body(proposal_id="nonexistent"))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["error"] == "unknown_proposal"
+
+
+def test_panel_confirm_endpoint_blocked_on_writeguard(client: TestClient) -> None:
+    _stage()
+    from app.write_guard import DEFAULT_WRITE_GUARD, WriteGuard
+    mock_guard = MagicMock(spec=WriteGuard)
+    mock_guard.assert_writes_allowed.side_effect = WritesBlockedError(
+        "blocked", "write guard active", "panel.confirm"
+    )
+    confirm_module._service._guard = mock_guard
+
+    resp = client.post("/api/panel/confirm", json=_valid_body())
+    confirm_module._service._guard = DEFAULT_WRITE_GUARD
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "blocked"
+    assert data["block_reason"]["gate"] == "writeguard"
+
+
+def test_panel_confirm_endpoint_reject_action_no_execution(
+    client: TestClient, monkeypatch
+) -> None:
+    _stage()
+    mock_fn = _mock_execute(monkeypatch)
+    resp = client.post("/api/panel/confirm", json=_valid_body(action="reject"))
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "rejected"
+    assert data["receipt"] is None
+    assert mock_fn.call_count == 0  # no vault execution
+
+
+def test_panel_confirm_endpoint_does_not_allow_same_turn_execution(
+    client: TestClient, monkeypatch
+) -> None:
+    _stage(proposed_at=time.time())  # staged right now — same-turn window
+    _mock_execute(monkeypatch)
+    resp = client.post("/api/panel/confirm", json=_valid_body())
+    assert resp.status_code == 422
+    assert "same-turn" in resp.json()["detail"].lower()
+
+
+def test_panel_confirm_endpoint_events_emitted_in_response(
+    client: TestClient, monkeypatch
+) -> None:
+    _stage()
+    _mock_execute(monkeypatch, events=["panel.intent.executed", "panel.action.triggered"])
+    resp = client.post("/api/panel/confirm", json=_valid_body())
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "panel.intent.executed" in data["events_emitted"]
+    assert "panel.action.triggered" in data["events_emitted"]
+
+
+def test_companion_ui_does_not_write_vault_directly() -> None:
+    """Architecture guard: no vault-write code in companion_ui/ modules."""
+    import ast
+    import pathlib
+
+    vault_write_calls = {"write_text", "write_bytes", "open"}
+    companion_ui_root = pathlib.Path(__file__).parents[2] / "companion-ui"
+    if not companion_ui_root.exists():
+        pytest.skip("companion-ui directory not present")
+
+    violations: list[str] = []
+    for py_file in companion_ui_root.rglob("*.py"):
+        try:
+            tree = ast.parse(py_file.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and node.attr in vault_write_calls:
+                violations.append(f"{py_file}:{node.col_offset} uses .{node.attr}")
+
+    assert not violations, (
+        "companion_ui modules must not write vault files directly:\n"
+        + "\n".join(violations)
+    )


### PR DESCRIPTION
Fixes #1053
Advances #1022

## Summary

- `POST /api/panel/confirm` — new route in `app/api/routes/panel.py`; registered in `app/api/app.py` with prefix `/api`
- `app/panel/confirmation.py` — `ProposalStore`, `ConfirmIdempotencyStore`, `PanelConfirmationService`; module-level singletons for route use
- `tests/api/test_panel_confirm_api.py` — 11 acceptance tests (all AC Verify targets)

## Dispatcher note

Dispatcher unavailable (db_exists: false) — used GitHub-label-only claim.

## Validation

```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/api/test_panel_confirm_api.py   # 11 passed
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/api -m "not pg"                 # 62 passed, 2 deselected
git diff --check                                                                   # clean
```

## Constraints honored

- No same-turn execution (TTL guard on `proposed_at`)
- WriteGuard checked before every `confirm` action
- Idempotency key is client-owned; runtime returns original response on duplicate
- `correction.enabled=true` without `corrected_action_id` or `corrected_parameters` → 422
- Companion UI writes no vault files directly (architecture test)
- ProposalStore is in-memory (no DB migration required)
- Durable vault-visible projection NOT implemented here (tracked in companion issue)