### PR TITLE
feat(panel-runtime): implement durable vault-visible Panel projection (#1054)

### DIFF
--- a/app/events/panel.py
+++ b/app/events/panel.py
@@ -115,6 +115,18 @@ class PanelActionLoggedEvent(BaseModel):
     payload: Dict[str, Any] = Field(default_factory=dict)
 
 
+class PanelActionBlockedEvent(BaseModel):
+    event: str = "panel.action.blocked"
+    version: str = "1.0"
+    timestamp: str = Field(default_factory=_now_iso)
+    trace_id: str = Field(default_factory=lambda: uuid4().hex)
+    event_id: str = Field(default_factory=lambda: uuid4().hex)
+    source: PanelEventSource = Field(
+        default_factory=lambda: PanelEventSource(trigger="runtime", component="panel_agent", sot="v5.0-runtime1")
+    )
+    payload: Dict[str, Any] = Field(default_factory=dict)
+
+
 class PanelLogEntry(BaseModel):
     timestamp: str = Field(default_factory=_now_iso)
     trace_id: str | None = None
@@ -152,6 +164,7 @@ __all__ = [
     "PanelIntentExecutedEvent",
     "PanelIntentExecutedPayload",
     "PanelActionLoggedEvent",
+    "PanelActionBlockedEvent",
     "PanelLogEntry",
     "PanelLogEvent",
 ]

--- a/app/events/types.py
+++ b/app/events/types.py
@@ -69,7 +69,9 @@ PROMOTE_SKIP_MOVE = "promote.skip.move"
 
 PANEL_INTENT_CREATED = "panel.intent.created"
 PANEL_INTENT_EXECUTED = "panel.intent.executed"
+PANEL_ACTION_TRIGGERED = "panel.action.triggered"
 PANEL_ACTION_LOGGED = "panel.action.logged"
+PANEL_ACTION_BLOCKED = "panel.action.blocked"
 PANEL_LOG_CREATED = "panel.log.created"
 PANEL_SCAN_REQUESTED = "panel.scan.requested"
 
@@ -145,7 +147,9 @@ __all__ = [
     "PROMOTE_SKIP_MOVE",
     "PANEL_INTENT_CREATED",
     "PANEL_INTENT_EXECUTED",
+    "PANEL_ACTION_TRIGGERED",
     "PANEL_ACTION_LOGGED",
+    "PANEL_ACTION_BLOCKED",
     "PANEL_LOG_CREATED",
     "PANEL_SCAN_REQUESTED",
     "NOTE_MOVE_WORKBENCH",

--- a/app/panel/confirmation.py
+++ b/app/panel/confirmation.py
@@ -27,7 +27,7 @@ from app.agents.panel.writeback import (
 from app.events.panel import PanelIntentEvent
 from app.events.schema import make_outbox_event
 from app.outbox.events import INDEX_OUTBOX_PATH
-from app.services.outbox import append_jsonl_outbox_event
+from app.services.outbox import append_jsonl_outbox_event, coerce_outbox_event, write_outbox_event
 from app.write_guard import DEFAULT_WRITE_GUARD, WriteGuard, WritesBlockedError
 
 logger = logging.getLogger(__name__)
@@ -152,11 +152,22 @@ def _emit_projection_event(
         payload=payload,
         trace_id=trace_id,
     )
+    # Write to JSONL audit log
     resolved = outbox_path or _resolve_outbox_path()
     try:
         append_jsonl_outbox_event(resolved, evt, default_source="panel_agent.confirmation")
     except Exception:
-        logger.debug("projection event outbox write skipped event=%s", event_name)
+        logger.debug("projection event jsonl write skipped event=%s", event_name)
+    # Mirror to DB outbox when backend is pg (same pattern as panel_agent/runtime.py)
+    backend = (os.getenv("STORE_BACKEND") or "").strip().lower()
+    db_url = os.getenv("DATABASE_URL") or os.getenv("DB_DSN")
+    if backend == "pg" or db_url:
+        outbox_evt = coerce_outbox_event(evt, default_source="panel_agent.confirmation")
+        if outbox_evt is not None:
+            try:
+                write_outbox_event(outbox_evt, idempotency_key=outbox_evt.event_id)
+            except Exception as exc:
+                logger.debug("projection event db outbox write skipped event=%s err=%s", event_name, exc)
 
 
 def _resolve_note_file(note_path: str | None) -> Path | None:
@@ -265,22 +276,23 @@ class PanelConfirmationService:
                 "same-turn execution is not allowed — proposal was staged in the current interaction window"
             )
 
-        if request.action == "reject":
-            _write_rejected_projection(proposal)
-            resp = ConfirmResponse(
-                proposal_id=request.proposal_id,
-                artifact_id=request.artifact_id,
-                status="rejected",
-                outcome="rejected",
-                idempotency_key=request.idempotency_key,
-                events_emitted=[],
-            )
-            self._idempotency.set(request.idempotency_key, resp)
-            return resp
-
         try:
             self._guard.assert_writes_allowed("panel.confirm")
         except WritesBlockedError as exc:
+            if request.action == "reject":
+                # Rejection is a user decision, not an execution; vault write is safe even when
+                # execution is blocked, but we still honour WriteGuard to keep the single-writer
+                # rule uniform. Skip vault write; record rejected outcome without receipt.
+                resp = ConfirmResponse(
+                    proposal_id=request.proposal_id,
+                    artifact_id=request.artifact_id,
+                    status="rejected",
+                    outcome="rejected",
+                    idempotency_key=request.idempotency_key,
+                    events_emitted=[],
+                )
+                self._idempotency.set(request.idempotency_key, resp)
+                return resp
             _write_blocked_projection(
                 proposal,
                 gate="writeguard",
@@ -305,6 +317,19 @@ class PanelConfirmationService:
                 block_reason=BlockReason(gate="writeguard", message=str(exc)),
                 idempotency_key=request.idempotency_key,
                 events_emitted=["panel.action.blocked"],
+            )
+            self._idempotency.set(request.idempotency_key, resp)
+            return resp
+
+        if request.action == "reject":
+            _write_rejected_projection(proposal)
+            resp = ConfirmResponse(
+                proposal_id=request.proposal_id,
+                artifact_id=request.artifact_id,
+                status="rejected",
+                outcome="rejected",
+                idempotency_key=request.idempotency_key,
+                events_emitted=[],
             )
             self._idempotency.set(request.idempotency_key, resp)
             return resp

--- a/app/panel/confirmation.py
+++ b/app/panel/confirmation.py
@@ -7,16 +7,30 @@ typed response contract.
 
 from __future__ import annotations
 
+import logging
+import os
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 from pydantic import BaseModel, Field, model_validator
 
 from app.agents.panel_agent.runtime import execute_panel_intent  # noqa: F401 — patchable by tests
+from app.agents.panel.writeback import (
+    annotate_action_ids,
+    remove_actions_from_markdown,
+    stable_action_id,
+    write_receipts,
+)
 from app.events.panel import PanelIntentEvent
+from app.events.schema import make_outbox_event
+from app.outbox.events import INDEX_OUTBOX_PATH
+from app.services.outbox import append_jsonl_outbox_event
 from app.write_guard import DEFAULT_WRITE_GUARD, WriteGuard, WritesBlockedError
+
+logger = logging.getLogger(__name__)
 
 SAME_TURN_TTL_SECONDS = 5.0
 
@@ -119,6 +133,108 @@ class ConfirmIdempotencyStore:
         self._cache.clear()
 
 
+def _resolve_outbox_path() -> Path:
+    env_path = os.getenv("INDEX_OUTBOX_PATH")
+    if env_path:
+        return Path(env_path)
+    return Path(INDEX_OUTBOX_PATH)
+
+
+def _emit_projection_event(
+    event_name: str,
+    payload: dict[str, Any],
+    trace_id: str,
+    outbox_path: Path | None = None,
+) -> None:
+    evt = make_outbox_event(
+        event=event_name,
+        source="panel_agent.confirmation",
+        payload=payload,
+        trace_id=trace_id,
+    )
+    resolved = outbox_path or _resolve_outbox_path()
+    try:
+        append_jsonl_outbox_event(resolved, evt, default_source="panel_agent.confirmation")
+    except Exception:
+        logger.debug("projection event outbox write skipped event=%s", event_name)
+
+
+def _resolve_note_file(note_path: str | None) -> Path | None:
+    if not note_path:
+        return None
+    vault_root_env = os.getenv("VAULT_ROOT") or os.getenv("WATCHER_VAULT_PATH")
+    candidate = Path(note_path)
+    if candidate.is_absolute() and candidate.exists():
+        return candidate
+    if vault_root_env:
+        candidate = Path(vault_root_env).expanduser() / note_path
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _write_rejected_projection(proposal: StagedProposal) -> None:
+    """Remove the proposed checkbox from the vault on rejection (no execution receipt)."""
+    note_path = proposal.intent_event.payload.note.path
+    note_file = _resolve_note_file(note_path)
+    if note_file is None:
+        return
+    try:
+        current = note_file.read_text(encoding="utf-8")
+    except OSError:
+        return
+
+    action_ids = {
+        stable_action_id(a.label)
+        for a in proposal.intent_event.payload.actions
+    }
+    annotated = annotate_action_ids(current)
+    updated = remove_actions_from_markdown(annotated, action_ids)
+
+    now_iso = datetime.now(tz=timezone.utc).isoformat().replace("+00:00", "Z")
+    receipt_lines = [
+        f"❌ {a.label} — dismissed — {now_iso}"
+        for a in proposal.intent_event.payload.actions
+    ]
+    if receipt_lines:
+        updated = write_receipts(updated, receipt_lines)
+
+    try:
+        note_file.write_text(updated, encoding="utf-8")
+    except OSError:
+        logger.debug("rejected projection vault write failed note_path=%s", note_path)
+
+
+def _write_blocked_projection(
+    proposal: StagedProposal,
+    gate: str,
+    reason: str,
+) -> None:
+    """Write blocked receipt to AI status callout; preserve the proposed checkbox."""
+    note_path = proposal.intent_event.payload.note.path
+    note_file = _resolve_note_file(note_path)
+    if note_file is None:
+        return
+    try:
+        current = note_file.read_text(encoding="utf-8")
+    except OSError:
+        return
+
+    now_iso = datetime.now(tz=timezone.utc).isoformat().replace("+00:00", "Z")
+    receipt_lines = [
+        f"🚫 {a.label} — blocked — gate: {gate} — {now_iso}"
+        for a in proposal.intent_event.payload.actions
+    ]
+    if reason:
+        receipt_lines.append(f"Reason: {reason}")
+
+    updated = write_receipts(current, receipt_lines)
+    try:
+        note_file.write_text(updated, encoding="utf-8")
+    except OSError:
+        logger.debug("blocked projection vault write failed note_path=%s", note_path)
+
+
 class PanelConfirmationService:
     def __init__(
         self,
@@ -150,6 +266,7 @@ class PanelConfirmationService:
             )
 
         if request.action == "reject":
+            _write_rejected_projection(proposal)
             resp = ConfirmResponse(
                 proposal_id=request.proposal_id,
                 artifact_id=request.artifact_id,
@@ -164,6 +281,22 @@ class PanelConfirmationService:
         try:
             self._guard.assert_writes_allowed("panel.confirm")
         except WritesBlockedError as exc:
+            _write_blocked_projection(
+                proposal,
+                gate="writeguard",
+                reason=str(exc),
+            )
+            _emit_projection_event(
+                "panel.action.blocked",
+                {
+                    "note_uuid": proposal.intent_event.payload.note.uuid,
+                    "note_path": proposal.intent_event.payload.note.path,
+                    "gate": "writeguard",
+                    "reason": str(exc),
+                    "proposal_id": request.proposal_id,
+                },
+                trace_id=proposal.trace_id or request.idempotency_key,
+            )
             resp = ConfirmResponse(
                 proposal_id=request.proposal_id,
                 artifact_id=request.artifact_id,
@@ -171,6 +304,7 @@ class PanelConfirmationService:
                 outcome="blocked",
                 block_reason=BlockReason(gate="writeguard", message=str(exc)),
                 idempotency_key=request.idempotency_key,
+                events_emitted=["panel.action.blocked"],
             )
             self._idempotency.set(request.idempotency_key, resp)
             return resp
@@ -191,17 +325,61 @@ class PanelConfirmationService:
             else:
                 events.append(getattr(e, "event", str(e)))
 
+        # Classify outcome: if all checked actions were logged (not triggered), surface as logged.
+        checked_actions = [a for a in result.actions if a.checked]
+        all_logged = bool(checked_actions) and all(a.status == "logged" for a in checked_actions)
+        any_triggered = any(a.status == "triggered" for a in checked_actions)
+
         now_iso = datetime.now(tz=timezone.utc).isoformat().replace("+00:00", "Z")
-        receipt = Receipt(action_taken="confirm", outcome="success", timestamp=now_iso)
-        resp = ConfirmResponse(
-            proposal_id=request.proposal_id,
-            artifact_id=request.artifact_id,
-            status="executed",
-            outcome="success",
-            receipt=receipt,
-            idempotency_key=request.idempotency_key,
-            events_emitted=events,
-        )
+
+        if all_logged and not any_triggered:
+            # Logged outcome: emit panel.action.logged if not already present
+            if "panel.action.logged" not in events:
+                _emit_projection_event(
+                    "panel.action.logged",
+                    {
+                        "note_uuid": proposal.intent_event.payload.note.uuid,
+                        "note_path": proposal.intent_event.payload.note.path,
+                        "proposal_id": request.proposal_id,
+                    },
+                    trace_id=proposal.trace_id or request.idempotency_key,
+                )
+                events.append("panel.action.logged")
+            receipt = Receipt(action_taken="confirm", outcome="logged", timestamp=now_iso)
+            resp = ConfirmResponse(
+                proposal_id=request.proposal_id,
+                artifact_id=request.artifact_id,
+                status="logged",
+                outcome="logged",
+                receipt=receipt,
+                idempotency_key=request.idempotency_key,
+                events_emitted=events,
+            )
+        else:
+            # Executed outcome: extract inverse_action from result if declared.
+            inverse_action: str | None = None
+            for action_result in result.actions:
+                inv = (action_result.details or {}).get("inverse_action_id")
+                if inv:
+                    inverse_action = str(inv)
+                    break
+
+            receipt = Receipt(
+                action_taken="confirm",
+                outcome="success",
+                timestamp=now_iso,
+                inverse_action=inverse_action,
+            )
+            resp = ConfirmResponse(
+                proposal_id=request.proposal_id,
+                artifact_id=request.artifact_id,
+                status="executed",
+                outcome="success",
+                receipt=receipt,
+                idempotency_key=request.idempotency_key,
+                events_emitted=events,
+            )
+
         self._idempotency.set(request.idempotency_key, resp)
         return resp
 

--- a/tests/panel/test_panel_confirm_blocked.py
+++ b/tests/panel/test_panel_confirm_blocked.py
@@ -5,9 +5,6 @@ from __future__ import annotations
 import pathlib
 from unittest.mock import MagicMock
 
-import pytest
-
-import app.panel.confirmation as confirm_module
 from app.agents.panel.writeback import AI_STATUS_HEADER, stable_action_id
 from app.events.panel import (
     NoteRef,

--- a/tests/panel/test_panel_confirm_blocked.py
+++ b/tests/panel/test_panel_confirm_blocked.py
@@ -1,0 +1,152 @@
+"""Panel confirmation blocked-state projection tests (issue #1054)."""
+
+from __future__ import annotations
+
+import pathlib
+from unittest.mock import MagicMock
+
+import pytest
+
+import app.panel.confirmation as confirm_module
+from app.agents.panel.writeback import AI_STATUS_HEADER, stable_action_id
+from app.events.panel import (
+    NoteRef,
+    PanelInfo,
+    PanelIntentAction,
+    PanelIntentEvent,
+    PanelIntentPayload,
+)
+from app.panel.confirmation import (
+    ConfirmIdempotencyStore,
+    ConfirmRequest,
+    PanelConfirmationService,
+    ProposalStore,
+    StagedProposal,
+)
+from app.write_guard import WriteGuard, WritesBlockedError
+
+
+def _make_intent(
+    note_uuid: str = "note-uuid-1",
+    note_path: str | None = None,
+    action_label: str = "send report",
+) -> PanelIntentEvent:
+    aid = stable_action_id(action_label)
+    return PanelIntentEvent(
+        payload=PanelIntentPayload(
+            note=NoteRef(uuid=note_uuid, path=note_path),
+            panel=PanelInfo(panel_id="panel-1", instruction="do it"),
+            actions=[PanelIntentAction(id=aid, label=action_label, checked=True)],
+        )
+    )
+
+
+def _service_with_blocked_guard() -> tuple[PanelConfirmationService, ProposalStore, ConfirmIdempotencyStore]:
+    mock_guard = MagicMock(spec=WriteGuard)
+    mock_guard.assert_writes_allowed.side_effect = WritesBlockedError(
+        "blocked", "tag allowlist check failed", "panel.confirm"
+    )
+    ps = ProposalStore()
+    ids = ConfirmIdempotencyStore()
+    svc = PanelConfirmationService(ps, ids, write_guard=mock_guard)
+    return svc, ps, ids
+
+
+# ---------------------------------------------------------------------------
+# Blocked: preserves checkbox
+# ---------------------------------------------------------------------------
+
+def test_panel_projection_blocked_preserves_checkbox(tmp_path: pathlib.Path) -> None:
+    action_label = "send report"
+    aid = stable_action_id(action_label)
+    note_file = tmp_path / "test.md"
+    note_file.write_text(
+        f"# Note\n- [ ] {action_label} <!--ai:id={aid}-->\n",
+        encoding="utf-8",
+    )
+
+    svc, ps, _ = _service_with_blocked_guard()
+    ps.stage(
+        "prop-1",
+        StagedProposal(
+            artifact_id="note-uuid-1",
+            intent_event=_make_intent(note_path=str(note_file), action_label=action_label),
+            proposed_at=0.0,
+        ),
+    )
+
+    svc.confirm(ConfirmRequest(
+        proposal_id="prop-1",
+        artifact_id="note-uuid-1",
+        action="confirm",
+        idempotency_key="ikey-b1",
+    ))
+
+    content = note_file.read_text(encoding="utf-8")
+    assert f"- [ ] {action_label}" in content
+
+
+# ---------------------------------------------------------------------------
+# Blocked: writes blocked receipt
+# ---------------------------------------------------------------------------
+
+def test_panel_projection_blocked_writes_blocked_receipt(tmp_path: pathlib.Path) -> None:
+    action_label = "send report"
+    aid = stable_action_id(action_label)
+    note_file = tmp_path / "test.md"
+    note_file.write_text(
+        f"# Note\n- [ ] {action_label} <!--ai:id={aid}-->\n",
+        encoding="utf-8",
+    )
+
+    svc, ps, _ = _service_with_blocked_guard()
+    ps.stage(
+        "prop-1",
+        StagedProposal(
+            artifact_id="note-uuid-1",
+            intent_event=_make_intent(note_path=str(note_file), action_label=action_label),
+            proposed_at=0.0,
+        ),
+    )
+
+    svc.confirm(ConfirmRequest(
+        proposal_id="prop-1",
+        artifact_id="note-uuid-1",
+        action="confirm",
+        idempotency_key="ikey-b2",
+    ))
+
+    content = note_file.read_text(encoding="utf-8")
+    assert "🚫" in content
+    assert AI_STATUS_HEADER in content
+    assert "writeguard" in content.lower() or "blocked" in content.lower()
+
+
+# ---------------------------------------------------------------------------
+# Blocked: emits panel.action.blocked event
+# ---------------------------------------------------------------------------
+
+def test_panel_projection_blocked_emits_blocked_event(tmp_path: pathlib.Path) -> None:
+    action_label = "send report"
+    note_file = tmp_path / "test.md"
+    note_file.write_text(f"# Note\n- [ ] {action_label}\n", encoding="utf-8")
+
+    svc, ps, _ = _service_with_blocked_guard()
+    ps.stage(
+        "prop-1",
+        StagedProposal(
+            artifact_id="note-uuid-1",
+            intent_event=_make_intent(note_path=str(note_file), action_label=action_label),
+            proposed_at=0.0,
+        ),
+    )
+
+    resp = svc.confirm(ConfirmRequest(
+        proposal_id="prop-1",
+        artifact_id="note-uuid-1",
+        action="confirm",
+        idempotency_key="ikey-b3",
+    ))
+
+    assert resp.status == "blocked"
+    assert "panel.action.blocked" in resp.events_emitted

--- a/tests/panel/test_panel_confirm_idempotency.py
+++ b/tests/panel/test_panel_confirm_idempotency.py
@@ -1,0 +1,101 @@
+"""Panel confirmation idempotency projection tests (issue #1054).
+
+Verifies that duplicate confirm requests with the same idempotency key
+do not produce double vault writes.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from unittest.mock import MagicMock, patch
+
+import app.panel.confirmation as confirm_module
+from app.agents.panel.writeback import stable_action_id
+from app.events.panel import (
+    NoteRef,
+    PanelInfo,
+    PanelIntentAction,
+    PanelIntentEvent,
+    PanelIntentPayload,
+    PanelRuntimeActionResult,
+)
+from app.panel.confirmation import (
+    ConfirmIdempotencyStore,
+    ConfirmRequest,
+    PanelConfirmationService,
+    ProposalStore,
+    StagedProposal,
+)
+
+
+def _make_intent(
+    note_uuid: str = "note-uuid-1",
+    note_path: str | None = None,
+    action_label: str = "tag note",
+) -> PanelIntentEvent:
+    aid = stable_action_id(action_label)
+    return PanelIntentEvent(
+        payload=PanelIntentPayload(
+            note=NoteRef(uuid=note_uuid, path=note_path),
+            panel=PanelInfo(panel_id="panel-1", instruction="do it"),
+            actions=[PanelIntentAction(id=aid, label=action_label, checked=True)],
+        )
+    )
+
+
+def _mock_result(action_label: str = "tag note") -> MagicMock:
+    aid = stable_action_id(action_label)
+    result = MagicMock()
+    result.actions = [
+        PanelRuntimeActionResult(id=aid, label=action_label, checked=True, status="triggered")
+    ]
+    result.emitted_events = [{"event": "panel.intent.executed"}]
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Idempotency: duplicate confirm does not double-write
+# ---------------------------------------------------------------------------
+
+def test_confirm_idempotent_does_not_double_write_receipt(tmp_path: pathlib.Path) -> None:
+    action_label = "tag note"
+    aid = stable_action_id(action_label)
+    note_file = tmp_path / "test.md"
+    note_file.write_text(
+        f"# Note\n- [ ] {action_label} <!--ai:id={aid}-->\n",
+        encoding="utf-8",
+    )
+
+    ps = ProposalStore()
+    ids = ConfirmIdempotencyStore()
+    svc = PanelConfirmationService(ps, ids)
+
+    ps.stage(
+        "prop-1",
+        StagedProposal(
+            artifact_id="note-uuid-1",
+            intent_event=_make_intent(note_path=str(note_file), action_label=action_label),
+            proposed_at=0.0,
+        ),
+    )
+
+    req = ConfirmRequest(
+        proposal_id="prop-1",
+        artifact_id="note-uuid-1",
+        action="confirm",
+        idempotency_key="ikey-idem-1",
+    )
+
+    mock_result = _mock_result(action_label)
+
+    with patch.object(confirm_module, "execute_panel_intent", return_value=mock_result) as mock_fn:
+        resp1 = svc.confirm(req)
+        resp2 = svc.confirm(req)  # duplicate — same idempotency key
+
+    # execute_panel_intent called exactly once
+    assert mock_fn.call_count == 1
+
+    # Both responses are identical (idempotent)
+    assert resp1.status == resp2.status
+    assert resp1.outcome == resp2.outcome
+    assert resp1.idempotency_key == resp2.idempotency_key

--- a/tests/panel/test_panel_confirm_reject.py
+++ b/tests/panel/test_panel_confirm_reject.py
@@ -1,0 +1,90 @@
+"""Panel confirmation rejection projection tests (issue #1054)."""
+
+from __future__ import annotations
+
+import pathlib
+from unittest.mock import patch
+
+import app.panel.confirmation as confirm_module
+from app.agents.panel.writeback import stable_action_id
+from app.events.panel import (
+    NoteRef,
+    PanelInfo,
+    PanelIntentAction,
+    PanelIntentEvent,
+    PanelIntentPayload,
+)
+from app.panel.confirmation import (
+    ConfirmIdempotencyStore,
+    ConfirmRequest,
+    PanelConfirmationService,
+    ProposalStore,
+    StagedProposal,
+)
+
+
+def _make_intent(
+    note_uuid: str = "note-uuid-1",
+    note_path: str | None = None,
+    action_label: str = "delete file",
+) -> PanelIntentEvent:
+    aid = stable_action_id(action_label)
+    return PanelIntentEvent(
+        payload=PanelIntentPayload(
+            note=NoteRef(uuid=note_uuid, path=note_path),
+            panel=PanelInfo(panel_id="panel-1", instruction="do it"),
+            actions=[PanelIntentAction(id=aid, label=action_label, checked=True)],
+        )
+    )
+
+
+def _service() -> tuple[PanelConfirmationService, ProposalStore, ConfirmIdempotencyStore]:
+    ps = ProposalStore()
+    ids = ConfirmIdempotencyStore()
+    return PanelConfirmationService(ps, ids), ps, ids
+
+
+# ---------------------------------------------------------------------------
+# Rejected: checkbox removed, no execution receipt
+# ---------------------------------------------------------------------------
+
+def test_panel_projection_rejected_removes_checkbox_no_execution_receipt(tmp_path: pathlib.Path) -> None:
+    action_label = "delete file"
+    aid = stable_action_id(action_label)
+    note_file = tmp_path / "test.md"
+    note_file.write_text(
+        f"# Note\n- [ ] {action_label} <!--ai:id={aid}-->\n",
+        encoding="utf-8",
+    )
+
+    svc, ps, _ = _service()
+    ps.stage(
+        "prop-1",
+        StagedProposal(
+            artifact_id="note-uuid-1",
+            intent_event=_make_intent(note_path=str(note_file), action_label=action_label),
+            proposed_at=0.0,
+        ),
+    )
+
+    mock_exec = patch.object(confirm_module, "execute_panel_intent")
+    with mock_exec as mock_fn:
+        resp = svc.confirm(ConfirmRequest(
+            proposal_id="prop-1",
+            artifact_id="note-uuid-1",
+            action="reject",
+            idempotency_key="ikey-r1",
+        ))
+
+    # execute_panel_intent must never be called on rejection
+    mock_fn.assert_not_called()
+
+    assert resp.status == "rejected"
+    # No execution receipt
+    assert resp.receipt is None
+
+    content = note_file.read_text(encoding="utf-8")
+    # Checkbox removed
+    assert f"- [ ] {action_label}" not in content
+    # No execution-success marker
+    assert "✅" not in content

--- a/tests/panel/test_panel_durable_projection.py
+++ b/tests/panel/test_panel_durable_projection.py
@@ -1,0 +1,340 @@
+"""Durable vault-visible Panel projection tests (issue #1054).
+
+Tests outcome → vault-state mapping per PANEL_DURABLE_PROJECTION_MAPPING.md.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import app.panel.confirmation as confirm_module
+import app.agents.panel_agent.runtime as runtime_module
+from app.agents.panel.writeback import AI_STATUS_HEADER, stable_action_id, write_receipts
+from app.agents.panel_agent.state import PanelAgentState
+from app.events.panel import (
+    NoteRef,
+    PanelInfo,
+    PanelIntentEvent,
+    PanelIntentPayload,
+    PanelIntentAction,
+    PanelRuntimeActionResult,
+)
+from app.panel.confirmation import (
+    ConfirmIdempotencyStore,
+    ConfirmRequest,
+    PanelConfirmationService,
+    ProposalStore,
+    StagedProposal,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_intent(
+    note_uuid: str = "note-uuid-1",
+    note_path: str | None = None,
+    action_label: str = "send email",
+    action_id: str | None = None,
+) -> PanelIntentEvent:
+    _id = action_id or stable_action_id(action_label)
+    return PanelIntentEvent(
+        payload=PanelIntentPayload(
+            note=NoteRef(uuid=note_uuid, path=note_path),
+            panel=PanelInfo(panel_id="panel-1", instruction="do the thing"),
+            actions=[PanelIntentAction(id=_id, label=action_label, checked=True)],
+        )
+    )
+
+
+def _stage(
+    store: ProposalStore,
+    proposal_id: str = "prop-1",
+    note_uuid: str = "note-uuid-1",
+    note_path: str | None = None,
+    action_label: str = "send email",
+) -> None:
+    store.stage(
+        proposal_id,
+        StagedProposal(
+            artifact_id=note_uuid,
+            intent_event=_make_intent(note_uuid, note_path, action_label),
+            proposed_at=0.0,
+        ),
+    )
+
+
+def _service() -> tuple[PanelConfirmationService, ProposalStore, ConfirmIdempotencyStore]:
+    ps = ProposalStore()
+    ids = ConfirmIdempotencyStore()
+    svc = PanelConfirmationService(ps, ids)
+    return svc, ps, ids
+
+
+def _confirm_request(
+    proposal_id: str = "prop-1",
+    artifact_id: str = "note-uuid-1",
+    action: str = "confirm",
+    ikey: str = "ikey-1",
+) -> ConfirmRequest:
+    return ConfirmRequest(
+        proposal_id=proposal_id,
+        artifact_id=artifact_id,
+        action=action,
+        idempotency_key=ikey,
+    )
+
+
+def _mock_execute_result(
+    status: str = "triggered",
+    action_label: str = "send email",
+    events: list[str] | None = None,
+    inverse_action_id: str | None = None,
+) -> MagicMock:
+    _id = stable_action_id(action_label)
+    result = MagicMock()
+    details: dict = {}
+    if inverse_action_id:
+        details["inverse_action_id"] = inverse_action_id
+    result.actions = [
+        PanelRuntimeActionResult(
+            id=_id,
+            label=action_label,
+            checked=True,
+            status=status,
+            details=details,
+        )
+    ]
+    result.emitted_events = [{"event": e} for e in (events or ["panel.intent.executed", "panel.action.triggered"])]
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Helpers for graph-level mocking (lets _apply_note_writeback run)
+# ---------------------------------------------------------------------------
+
+def _make_graph_state(
+    intent: PanelIntentEvent,
+    action_label: str,
+    status: str = "triggered",
+    note_path: str | None = None,
+) -> PanelAgentState:
+    """Build a minimal PanelAgentState as run_panel_graph would return."""
+    aid = stable_action_id(action_label)
+    action = PanelIntentAction(id=aid, label=action_label, checked=True)
+    result = PanelRuntimeActionResult(id=aid, label=action_label, checked=True, status=status)
+    from app.events.schema import make_outbox_event
+    emitted = [make_outbox_event(event="panel.intent.executed", source="test", payload={})]
+    return PanelAgentState(
+        trace_id="test-trace",
+        note=intent.payload.note,
+        panel=intent.payload.panel,
+        actions=[action],
+        action_results=[result],
+        emitted_events=emitted,
+        executed_action_ids=[aid] if status == "triggered" else [],
+        vault_root=None,
+        intent_event=intent,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Executed: checkbox removal
+# ---------------------------------------------------------------------------
+
+def test_panel_projection_executed_removes_checkbox(tmp_path: pathlib.Path) -> None:
+    action_label = "send email"
+    aid = stable_action_id(action_label)
+    note_file = tmp_path / "test.md"
+    note_file.write_text(
+        f"# Note\n- [ ] {action_label} <!--ai:id={aid}-->\n",
+        encoding="utf-8",
+    )
+
+    svc, ps, _ = _service()
+    intent = _make_intent(note_path=str(note_file), action_label=action_label)
+    ps.stage("prop-1", StagedProposal(artifact_id="note-uuid-1", intent_event=intent, proposed_at=0.0))
+
+    graph_state = _make_graph_state(intent, action_label, note_path=str(note_file))
+    with patch.object(runtime_module, "run_panel_graph", return_value=graph_state), \
+         patch.object(runtime_module, "load_panel_action_catalog", return_value=None), \
+         patch.object(runtime_module, "_write_db_outbox_events"):
+        svc.confirm(_confirm_request())
+
+    content = note_file.read_text(encoding="utf-8")
+    assert f"- [ ] {action_label}" not in content
+
+
+# ---------------------------------------------------------------------------
+# Executed: receipt callout written
+# ---------------------------------------------------------------------------
+
+def test_panel_projection_executed_writes_receipt_callout(tmp_path: pathlib.Path) -> None:
+    action_label = "archive note"
+    aid = stable_action_id(action_label)
+    note_file = tmp_path / "test.md"
+    note_file.write_text(
+        f"# Note\n- [ ] {action_label} <!--ai:id={aid}-->\n",
+        encoding="utf-8",
+    )
+
+    svc, ps, _ = _service()
+    intent = _make_intent(note_path=str(note_file), action_label=action_label)
+    ps.stage("prop-1", StagedProposal(artifact_id="note-uuid-1", intent_event=intent, proposed_at=0.0))
+
+    graph_state = _make_graph_state(intent, action_label, note_path=str(note_file))
+    with patch.object(runtime_module, "run_panel_graph", return_value=graph_state), \
+         patch.object(runtime_module, "load_panel_action_catalog", return_value=None), \
+         patch.object(runtime_module, "_write_db_outbox_events"):
+        svc.confirm(_confirm_request())
+
+    content = note_file.read_text(encoding="utf-8")
+    # The existing writeback writes ✅ receipt via _apply_note_writeback
+    assert "✅" in content or AI_STATUS_HEADER in content
+
+
+# ---------------------------------------------------------------------------
+# Executed: inverse action declared in receipt
+# ---------------------------------------------------------------------------
+
+def test_panel_projection_inverse_action_declared(tmp_path: pathlib.Path) -> None:
+    action_label = "promote note"
+    aid = stable_action_id(action_label)
+    note_file = tmp_path / "test.md"
+    note_file.write_text(
+        f"# Note\n- [ ] {action_label} <!--ai:id={aid}-->\n",
+        encoding="utf-8",
+    )
+
+    svc, ps, _ = _service()
+    _stage(ps, note_path=str(note_file), action_label=action_label)
+
+    mock_result = _mock_execute_result(action_label=action_label, inverse_action_id="demote-note-abc")
+    with patch.object(confirm_module, "execute_panel_intent", return_value=mock_result):
+        resp = svc.confirm(_confirm_request())
+
+    # inverse_action is captured in receipt (may be None if no inverse)
+    assert resp.receipt is not None
+    # When declared, must be non-empty
+    assert resp.receipt.inverse_action == "demote-note-abc"
+
+
+def test_panel_projection_inverse_action_none_when_undeclared(tmp_path: pathlib.Path) -> None:
+    action_label = "tag note"
+    note_file = tmp_path / "test.md"
+    note_file.write_text(f"# Note\n- [ ] {action_label}\n", encoding="utf-8")
+
+    svc, ps, _ = _service()
+    _stage(ps, note_path=str(note_file), action_label=action_label)
+
+    mock_result = _mock_execute_result(action_label=action_label)
+    with patch.object(confirm_module, "execute_panel_intent", return_value=mock_result):
+        resp = svc.confirm(_confirm_request())
+
+    assert resp.receipt is not None
+    assert resp.receipt.inverse_action is None
+
+
+# ---------------------------------------------------------------------------
+# Executed: event emission
+# ---------------------------------------------------------------------------
+
+def test_panel_projection_execution_emits_intent_executed_event(tmp_path: pathlib.Path) -> None:
+    note_file = tmp_path / "test.md"
+    note_file.write_text("# Note\n- [ ] do work\n", encoding="utf-8")
+
+    svc, ps, _ = _service()
+    _stage(ps, note_path=str(note_file))
+
+    mock_result = _mock_execute_result(events=["panel.intent.executed", "panel.action.triggered"])
+    with patch.object(confirm_module, "execute_panel_intent", return_value=mock_result):
+        resp = svc.confirm(_confirm_request())
+
+    assert "panel.intent.executed" in resp.events_emitted
+
+
+# ---------------------------------------------------------------------------
+# Logged: event emission
+# ---------------------------------------------------------------------------
+
+def test_panel_projection_logged_emits_logged_event(tmp_path: pathlib.Path) -> None:
+    action_label = "log this"
+    note_file = tmp_path / "test.md"
+    note_file.write_text(f"# Note\n- [ ] {action_label}\n", encoding="utf-8")
+
+    svc, ps, _ = _service()
+    _stage(ps, note_path=str(note_file), action_label=action_label)
+
+    # All actions logged → logged outcome
+    mock_result = _mock_execute_result(
+        status="logged",
+        action_label=action_label,
+        events=["panel.action.logged"],
+    )
+    with patch.object(confirm_module, "execute_panel_intent", return_value=mock_result):
+        resp = svc.confirm(_confirm_request())
+
+    assert "panel.action.logged" in resp.events_emitted
+
+
+# ---------------------------------------------------------------------------
+# Watcher compatibility: vault state parseable without special-casing
+# ---------------------------------------------------------------------------
+
+def test_panel_projection_watcher_compatible(tmp_path: pathlib.Path) -> None:
+    """Vault state written via confirm path must be parseable by the Panel watcher."""
+    from app.agents.panel.parser import parse_panel
+
+    action_label = "move note"
+    aid = stable_action_id(action_label)
+    # Minimal note with panel block using the standard panel fence format
+    note_content = (
+        "# Note\n"
+        "%% AI panel %%\n"
+        f"- [ ] {action_label} <!--ai:id={aid}-->\n"
+        "%% AI panel end %%\n"
+    )
+    note_file = tmp_path / "watcher_compat.md"
+    note_file.write_text(note_content, encoding="utf-8")
+
+    # Write a receipt directly (simulating executed projection outcome)
+    updated = write_receipts(note_content, [f"✅ {action_label} — success — 2026-05-17T12:00:00Z"])
+    note_file.write_text(updated, encoding="utf-8")
+
+    content = note_file.read_text(encoding="utf-8")
+    # Parser must not raise; the panel block must still be parseable
+    parsed = parse_panel(content)
+    # Receipt block is outside the panel action scope — parser simply ignores it
+    assert parsed is not None
+
+
+# ---------------------------------------------------------------------------
+# Architecture: companion_ui must not write vault directly
+# ---------------------------------------------------------------------------
+
+def test_companion_ui_does_not_write_vault_directly() -> None:
+    import ast
+
+    vault_write_calls = {"write_text", "write_bytes", "open"}
+    companion_ui_root = pathlib.Path(__file__).parents[2] / "companion-ui"
+    if not companion_ui_root.exists():
+        pytest.skip("companion-ui directory not present")
+
+    violations: list[str] = []
+    for py_file in companion_ui_root.rglob("*.py"):
+        try:
+            tree = ast.parse(py_file.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and node.attr in vault_write_calls:
+                violations.append(f"{py_file}:{node.col_offset} uses .{node.attr}")
+
+    assert not violations, (
+        "companion_ui modules must not write vault files directly:\n"
+        + "\n".join(violations)
+    )


### PR DESCRIPTION
Closes #1054
Advances #1022

## Summary

- `app/panel/confirmation.py` — projection writeback for all 4 outcome classes:
  - **executed**: `execute_panel_intent` handles vault writeback (checkbox removal + ✅ receipt via `_apply_note_writeback`); `Receipt.inverse_action` extracted from `action_results.details["inverse_action_id"]`
  - **rejected**: `_write_rejected_projection` removes checkbox + writes ❌ dismissed receipt; no execution receipt written
  - **blocked**: `_write_blocked_projection` preserves checkbox + writes 🚫 blocked receipt to AI status callout; emits `panel.action.blocked` event
  - **logged**: detected from `execute_panel_intent` result (all checked actions `status=logged`); emits `panel.action.logged` if not already emitted
- `app/events/panel.py` — adds `PanelActionBlockedEvent` (`panel.action.blocked`)
- `app/events/types.py` — adds `PANEL_ACTION_TRIGGERED` and `PANEL_ACTION_BLOCKED` constants
- `tests/panel/test_panel_durable_projection.py` — 8 tests (executed writeback, receipt callout, inverse-action, event emission, logged event, watcher compat, architecture guard)
- `tests/panel/test_panel_confirm_blocked.py` — 3 tests (checkbox preserved, blocked receipt, event emitted)
- `tests/panel/test_panel_confirm_reject.py` — 1 test (checkbox removed, no execution receipt, execute_panel_intent not called)
- `tests/panel/test_panel_confirm_idempotency.py` — 1 test (duplicate confirm, single write)

## Validation

```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/panel/test_panel_durable_projection.py   # 8 passed
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/panel/test_panel_confirm_blocked.py       # 3 passed
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/panel/test_panel_confirm_reject.py        # 1 passed
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/panel/test_panel_confirm_idempotency.py   # 1 passed
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/api -m "not pg"                           # 62 passed, 2 deselected
git diff --check                                                                             # clean
```

## Constraints honored

- Runtime is sole vault writer — no vault-write code in companion_ui/ (architecture test passes)
- WriteGuard checked before every confirm; blocked outcome writes receipt without executing
- Idempotency: duplicate confirm returns cached response, execute_panel_intent called once
- `_apply_note_writeback` reused for executed/logged outcomes via `execute_panel_intent`
- `remove_actions_from_markdown` + `write_receipts` primitives reused for rejected/blocked
- No new vault syntax invented; callout format matches existing AI status block convention
- Watcher compatibility: vault state parseable by Panel watcher without special-casing

🤖 Generated with [Claude Code](https://claude.com/claude-code)