### PR TITLE
docs: owner-doc promotion for #1054 — add panel.action.blocked to event inventory

### DIFF
--- a/docs/PANEL_AGENT.md
+++ b/docs/PANEL_AGENT.md
@@ -193,6 +193,7 @@ Architectural reading note:
 - `panel.intent.executed` — payload `{note, panel, actions:[{id,label,checked,status,emitted_events}], executed_action_ids:[...]}` (source `panel_agent` / trigger `runtime`).
 - `panel.action.triggered` — payload `{note, panel_id, action:{id,label}, target_event}` for handled actions.
 - `panel.action.logged` — payload `{note, panel_id, action:{id,label,checked}, reason, mapping?}` for unmapped/unimplemented actions.
+- `panel.action.blocked` — payload `{note, panel_id, action_id, gate, reason, timestamp}` emitted when a confirmed action is blocked at a gate; checkbox is preserved in the working set (intention not acted upon). Delivered by #1057.
 - `promote.intent.created` — payload includes `{note, panel, action, instruction, maturity}` plus `{action_id, intent_source="panel.note", note.path}`; emitted when a checked action has `intent_type: promotion`; downstream consumer uses `note.path` to patch the vault note frontmatter (for example `maturity: evergreen` plus a compatibility-mapped review posture).
 
 ## Wiring configuration


### PR DESCRIPTION
Closes: docs-only, no governing issue required.

## Summary

PR #1057 (closes #1054) shipped `panel.action.blocked` as a new emitted event type. The **Derived runtime events** section in `docs/PANEL_AGENT.md` listed the existing events (`panel.intent.executed`, `panel.action.triggered`, `panel.action.logged`, `promote.intent.created`) but was missing the new entry.

This PR adds the single missing line so the owner doc reflects current shipped behavior.

## Direct Repair

Type: docs
Reason: Owner doc missing new shipped event; wording is unambiguous and no judgment call needed.
Validation: No code changed; docs-only line insertion. Visual diff verified.
Issue required: no — bounded immediate repair

🤖 Generated with [Claude Code](https://claude.com/claude-code)