### PR TITLE
docs(#955): add Governance status sections to pre-governance design handoff READMEs

### DIFF
--- a/companion-ui/design_handoff/2026-05-03-converse/README.md
+++ b/companion-ui/design_handoff/2026-05-03-converse/README.md
@@ -420,6 +420,16 @@ Open `Companion UI Wireframes.html` in a browser and navigate the canvas. Scroll
 
 ---
 
+## Governance status
+
+**Crossing:** A (pre-governance)
+
+This package was archived before the design handoff governance chain was established in [`companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md`](../../../companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md). It is explicitly exempt from retroactive maturity-checklist completion. The maturity checklist (Crossing B) and the associated required files (`implementation-contracts.md`, `authority-boundaries.md`, `open-questions.md`) do not apply to this package retroactively. The package remains a valid exploration archive.
+
+Future work: a Crossing B review may be initiated as a separate task if this package is nominated for promotion to a normalized spec.
+
+---
+
 ## Prompt to paste into Claude Code
 
 Paste this at the start of your Claude Code session:

--- a/companion-ui/design_handoff/2026-05-08-cognitive-temporal/README.md
+++ b/companion-ui/design_handoff/2026-05-08-cognitive-temporal/README.md
@@ -1,0 +1,32 @@
+# Design Handoff — Cognitive-Temporal Modes
+
+**Date:** 2026-05-08
+**Status:** Design handoff v1 · exploration archive
+
+## What this is
+
+A design exploration of cognitive modes and temporal cognition patterns for the Companion UI. Covers orientation, exploration, synthesis, review, and resurfacing modes — and the re-entry mist transitions between them.
+
+Produced using Claude Design session output. Files in this package are HTML prototypes and JSX reference components, not production code.
+
+## Files
+
+- `Cognitive Modes.html` — interactive mode exploration prototype
+- `Re-entry Mist Variants.html` — transition and re-entry state variants
+- `Temporal Cognition.html` — temporal state and cognition patterns
+- `cognitive-primitives.jsx`, `mode-*.jsx`, `temporal-*.jsx`, `reentry-*.jsx` — JSX reference components (design canvas only)
+- `colors_and_type.css` — Yggdrasil design tokens
+
+## Authority status
+
+Visual guidance and exploration only. These files are not architecture authority, runtime truth, or schema declarations. See `companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md` for the full authority boundary definition.
+
+---
+
+## Governance status
+
+**Crossing:** A (pre-governance)
+
+This package was archived before the design handoff governance chain was established in [`companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md`](../../docs/DESIGN_HANDOFF_GOVERNANCE.md). It is explicitly exempt from retroactive maturity-checklist completion. The maturity checklist (Crossing B) and the associated required files (`implementation-contracts.md`, `authority-boundaries.md`, `open-questions.md`) do not apply to this package retroactively. The package remains a valid exploration archive.
+
+Future work: a Crossing B review may be initiated as a separate task if this package is nominated for promotion to a normalized spec.

--- a/companion-ui/design_handoff/2026-05-11-canvas-suggestion-flow/README.md
+++ b/companion-ui/design_handoff/2026-05-11-canvas-suggestion-flow/README.md
@@ -39,6 +39,18 @@ See `Canvas Suggestion Flow.html §13` for the full design-vs-contract split. Hi
 
 See `companion-ui/companion-app/canvas_suggestion_flow.html` for the staged prototype.
 
+## Governance status
+
+**Crossing:** B+ (normalized spec exists)
+
+This package was archived before the design handoff governance chain was established in [`companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md`](../../docs/DESIGN_HANDOFF_GOVERNANCE.md). It is pre-governance for the purposes of retroactive maturity-checklist completion; however, a normalized spec has since been authored and is authoritative:
+
+**Normalized spec:** [`companion-ui/docs/CANVAS_SUGGESTION_FLOW.md`](../../docs/CANVAS_SUGGESTION_FLOW.md)
+
+Because the normalized spec exists, this package is effectively at Crossing B+ — it has cleared the handoff→normalized-spec crossing. Implementation issues derived from this package (#868–#874) reference the normalized spec, not this design archive. Do not modify the implementation issues via this package.
+
+---
+
 ## Related docs
 
 - `companion-ui/docs/OVERLAY_GRAMMAR.md`


### PR DESCRIPTION
## Summary

- Adds a `Governance status` section to `companion-ui/design_handoff/2026-05-03-converse/README.md` naming Crossing A (pre-governance) and linking to `companion-ui/docs/DESIGN_HANDOFF_GOVERNANCE.md`.
- Creates the missing `companion-ui/design_handoff/2026-05-08-cognitive-temporal/README.md` with the same Crossing A (pre-governance) `Governance status` section and a brief package description.
- Adds a `Governance status` section to `companion-ui/design_handoff/2026-05-11-canvas-suggestion-flow/README.md` naming Crossing B+ and citing the normalized spec at `companion-ui/docs/CANVAS_SUGGESTION_FLOW.md`.

## Scope

**docs-only.** No `docs/**` owner-docs changed. No runtime code, no tests, no configuration. Changed files are limited to the three design handoff READMEs named in #955.

## Validation

```
grep -l "Governance status" companion-ui/design_handoff/2026-05-{03,08,11}-*/README.md
# → all three files
git diff --check  # → clean
git diff --name-only origin/main..HEAD  # → exactly the three READMEs
```

Closes #955

🤖 Generated with [Claude Code](https://claude.com/claude-code)