### PR TITLE
fix(docs): correct panel.action.blocked payload fields in PANEL_AGENT.md

### DIFF
--- a/docs/PANEL_AGENT.md
+++ b/docs/PANEL_AGENT.md
@@ -193,7 +193,7 @@ Architectural reading note:
 - `panel.intent.executed` — payload `{note, panel, actions:[{id,label,checked,status,emitted_events}], executed_action_ids:[...]}` (source `panel_agent` / trigger `runtime`).
 - `panel.action.triggered` — payload `{note, panel_id, action:{id,label}, target_event}` for handled actions.
 - `panel.action.logged` — payload `{note, panel_id, action:{id,label,checked}, reason, mapping?}` for unmapped/unimplemented actions.
-- `panel.action.blocked` — payload `{note, panel_id, action_id, gate, reason, timestamp}` emitted when a confirmed action is blocked at a gate; checkbox is preserved in the working set (intention not acted upon). Delivered by #1057.
+- `panel.action.blocked` — payload `{note_uuid, note_path, gate, reason, proposal_id}` (timestamp on outbox envelope) emitted when a confirmed action is blocked at a gate; checkbox is preserved in the working set (intention not acted upon). Delivered by #1057.
 - `promote.intent.created` — payload includes `{note, panel, action, instruction, maturity}` plus `{action_id, intent_source="panel.note", note.path}`; emitted when a checked action has `intent_type: promotion`; downstream consumer uses `note.path` to patch the vault note frontmatter (for example `maturity: evergreen` plus a compatibility-mapped review posture).
 
 ## Wiring configuration


### PR DESCRIPTION
## Direct Repair

**Type:** docs
**Reason:** Review comment on #1058 identified that the documented payload for `panel.action.blocked` did not match the actual emitted fields. Doc said `{note, panel_id, action_id, gate, reason, timestamp}`; shipped code (`app/panel/confirmation.py`) emits `{note_uuid, note_path, gate, reason, proposal_id}` with timestamp on the outbox event envelope.
**Validation:** `git diff --check` clean; doc field names verified against `_emit_projection_event` call site in `confirmation.py`.
**Issue required:** no

Addresses review comment on [#1058](https://github.com/RasmusTho/agentic-pkm-mvp/pull/1058).

🤖 Generated with [Claude Code](https://claude.com/claude-code)