### PR TITLE
feat(runtime-api): expose read-only artifact note endpoint (#1063)

### DIFF
--- a/app/api/app.py
+++ b/app/api/app.py
@@ -78,6 +78,11 @@ try:
 except ImportError:
     panel_router = None
 
+try:
+    from app.api.routes.artifacts import router as artifacts_router
+except ImportError:
+    artifacts_router = None
+
 static_dir = Path(__file__).resolve().parent.parent / "web" / "static"
 logger = logging.getLogger(__name__)
 
@@ -177,6 +182,8 @@ def _create_app() -> FastAPI:
         application.include_router(canvas_router, prefix="/api")
     if panel_router is not None:
         application.include_router(panel_router, prefix="/api")
+    if artifacts_router is not None:
+        application.include_router(artifacts_router, prefix="/api")
     return application
 
 

--- a/app/api/routes/artifacts.py
+++ b/app/api/routes/artifacts.py
@@ -1,0 +1,101 @@
+"""Read-only artifact note endpoint.
+
+GET /api/artifacts/note?note_path=<path>[&artifact_id=<id>]
+
+Returns a vault note's metadata and body without mutating it.
+Rejects path traversal and paths outside the configured vault root.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
+
+from app.config.paths import resolve_vault_root
+
+router = APIRouter(prefix="/artifacts", tags=["artifacts"])
+
+
+class ArtifactNoteResponse(BaseModel):
+    artifact_id: str
+    note_path: str
+    title: str
+    body: str
+    content_hash: str
+
+
+def _extract_title(body: str, fallback: str) -> str:
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("# "):
+            return stripped[2:].strip()
+    return fallback
+
+
+def _content_hash(text: str) -> str:
+    return hashlib.sha1(text.encode("utf-8")).hexdigest()[:16]
+
+
+def _resolve_and_validate(
+    note_path_raw: str,
+    vault_root: Path,
+) -> Path:
+    """Resolve note path and reject traversal or outside-vault paths."""
+    candidate = Path(note_path_raw)
+
+    # Reject explicit traversal components before any resolution
+    if ".." in candidate.parts:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "invalid_path", "note_path": note_path_raw, "reason": "path_traversal"},
+        )
+
+    if candidate.is_absolute():
+        resolved = candidate
+    else:
+        resolved = (vault_root / candidate).resolve()
+
+    vault_resolved = vault_root.resolve()
+
+    # Reject paths that escape the vault root
+    try:
+        resolved.relative_to(vault_resolved)
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "invalid_path", "note_path": note_path_raw, "reason": "outside_vault"},
+        )
+
+    return resolved
+
+
+@router.get("/note", response_model=ArtifactNoteResponse)
+def read_artifact_note(
+    note_path: str = Query(..., description="Vault-relative or absolute path to the note"),
+    artifact_id: Optional[str] = Query(None, description="Artifact UUID; echoed back in response"),
+) -> ArtifactNoteResponse:
+    vault_root = resolve_vault_root()
+
+    resolved = _resolve_and_validate(note_path, vault_root)
+
+    if not resolved.exists() or not resolved.is_file():
+        raise HTTPException(
+            status_code=404,
+            detail={"error": "note_not_found", "note_path": note_path},
+        )
+
+    body = resolved.read_text(encoding="utf-8")
+    title = _extract_title(body, fallback=resolved.stem)
+
+    return ArtifactNoteResponse(
+        artifact_id=artifact_id or "",
+        note_path=str(resolved),
+        title=title,
+        body=body,
+        content_hash=_content_hash(body),
+    )

--- a/tests/api/test_artifact_note_read_api.py
+++ b/tests/api/test_artifact_note_read_api.py
@@ -1,0 +1,140 @@
+"""Read-only artifact note endpoint acceptance tests (no Postgres required).
+
+All behavioral ACs from issue #1063, run against the API TestClient with
+tmp_path vault files.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import pathlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.app import app
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture()
+def vault_note(tmp_path: pathlib.Path, monkeypatch) -> pathlib.Path:
+    """Create a minimal vault note in tmp_path and set VAULT_ROOT."""
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    note = tmp_path / "notes" / "test_artifact.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text(
+        "# My Test Note\n\nSome body text.\n\n- [ ] action item\n",
+        encoding="utf-8",
+    )
+    return note
+
+
+# ---------------------------------------------------------------------------
+# AC 1: endpoint returns real note payload
+# ---------------------------------------------------------------------------
+
+
+def test_read_artifact_note_returns_body_payload(
+    client: TestClient, vault_note: pathlib.Path, tmp_path: pathlib.Path
+) -> None:
+    resp = client.get(
+        "/api/artifacts/note",
+        params={"note_path": str(vault_note), "artifact_id": "note-uuid-test-1"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["artifact_id"] == "note-uuid-test-1"
+    assert data["note_path"] == str(vault_note)
+    assert data["title"] == "My Test Note"
+    assert "Some body text" in data["body"]
+    assert data["content_hash"]  # non-empty version marker
+    # content_hash must be deterministic
+    expected_hash = hashlib.sha1(vault_note.read_bytes()).hexdigest()[:16]
+    assert data["content_hash"] == expected_hash
+
+
+# ---------------------------------------------------------------------------
+# AC 2: missing note returns typed error
+# ---------------------------------------------------------------------------
+
+
+def test_read_artifact_note_missing_returns_typed_error(
+    client: TestClient, tmp_path: pathlib.Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    missing = tmp_path / "does_not_exist.md"
+    resp = client.get("/api/artifacts/note", params={"note_path": str(missing)})
+    assert resp.status_code == 404
+    detail = resp.json()["detail"]
+    assert detail["error"] == "note_not_found"
+    assert "note_path" in detail
+
+
+# ---------------------------------------------------------------------------
+# AC 3: path traversal is rejected
+# ---------------------------------------------------------------------------
+
+
+def test_read_artifact_note_rejects_path_traversal(
+    client: TestClient, tmp_path: pathlib.Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    traversal = "../etc/passwd"
+    resp = client.get("/api/artifacts/note", params={"note_path": traversal})
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert detail["error"] == "invalid_path"
+    assert detail["reason"] == "path_traversal"
+
+
+# ---------------------------------------------------------------------------
+# AC 4: endpoint does not mutate the note file
+# ---------------------------------------------------------------------------
+
+
+def test_read_artifact_note_does_not_mutate_file(
+    client: TestClient, vault_note: pathlib.Path
+) -> None:
+    original = vault_note.read_text(encoding="utf-8")
+    client.get("/api/artifacts/note", params={"note_path": str(vault_note)})
+    assert vault_note.read_text(encoding="utf-8") == original
+
+
+# ---------------------------------------------------------------------------
+# AC 5: Companion UI does not read vault files directly
+# ---------------------------------------------------------------------------
+
+
+def test_companion_ui_does_not_read_vault_directly() -> None:
+    """Architecture guard: no vault-read/write code in companion_ui/ modules."""
+    import ast
+    import pathlib
+
+    vault_io_calls = {"read_text", "read_bytes", "write_text", "write_bytes", "open"}
+    companion_ui_root = pathlib.Path(__file__).parents[2] / "companion-ui"
+    if not companion_ui_root.exists():
+        pytest.skip("companion-ui directory not present")
+
+    violations: list[str] = []
+    for py_file in companion_ui_root.rglob("*.py"):
+        try:
+            tree = ast.parse(py_file.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and node.attr in vault_io_calls:
+                violations.append(f"{py_file}:{node.col_offset} uses .{node.attr}")
+
+    assert not violations, (
+        "companion_ui modules must not access vault files directly:\n"
+        + "\n".join(violations)
+    )


### PR DESCRIPTION
## Summary

- Adds `GET /api/artifacts/note?note_path=<path>[&artifact_id=<id>]`
- Returns `artifact_id`, `note_path`, `title`, `body`, `content_hash`
- Rejects `..` path traversal with `400 invalid_path/path_traversal`
- Rejects outside-vault absolute paths with `400 invalid_path/outside_vault`
- Returns typed `404 note_not_found` for missing files
- Read-only; no vault mutations
- Companion UI must call this endpoint, not read files directly (architecture guard test included)

Closes #1063

## Endpoint
`GET /api/artifacts/note`

## Classification
- lane: code
- risk: low
- touches_runtime: yes (new route registered in app.py)
- touches_ci_or_skills: no
- closes_issue: yes

## Test plan
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/api/test_artifact_note_read_api.py` → 5 passed
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/api -m "not pg"` → 67 passed, 0 regressions
- [x] `git diff --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)