### PR TITLE
feat(companion-ui): read-only real note workspace shell (#1064)

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_shell.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_shell.py
@@ -1,0 +1,128 @@
+"""Read-only real-note workspace shell (#1064).
+
+Renders an actual vault note/artifact payload as received from the
+GET /api/artifacts/note endpoint. Note body is the primary surface;
+a reserved secondary slot holds Panel/agent state without requiring Panel data.
+
+This module does NOT:
+- read or write vault files directly
+- call runtime APIs or Panel confirmation
+- render Canvas body-edit controls or bounded suggestion flow
+- implement mutation controls of any kind
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+# Layout region identifiers (data-testid anchors for rendering layers).
+REGION_NOTE_BODY = "workspace-note-body"       # primary surface
+REGION_NOTE_HEADER = "workspace-note-header"   # title / path / identity strip
+REGION_AGENT_RAIL = "workspace-agent-rail"     # secondary slot: Panel / agent state
+
+
+@dataclass
+class ArtifactNotePayload:
+    """Typed payload received from the runtime note-read endpoint.
+
+    Mirrors the shape of ArtifactNoteResponse from app/api/routes/artifacts.py.
+    The Companion UI consumes this payload; it must not fetch vault files itself.
+    """
+
+    artifact_id: str
+    note_path: str
+    title: str
+    body: str
+    content_hash: str
+
+
+@dataclass
+class RealNoteWorkspaceShell:
+    """Model contract for the read-only real-note workspace shell.
+
+    Layout:
+    - note body is the primary working surface (REGION_NOTE_BODY = "primary")
+    - note header strip carries identity metadata (REGION_NOTE_HEADER = "header")
+    - agent rail is the reserved secondary slot for Panel/agent state
+      (REGION_AGENT_RAIL = "secondary") — may be empty; presence is mandatory
+
+    Mutation controls are not exposed (is_read_only = True, always).
+    """
+
+    payload: ArtifactNotePayload
+    # Optional Panel/agent state to display in the secondary rail slot.
+    agent_rail_state: Optional[str] = field(default=None)
+
+    def __post_init__(self) -> None:
+        if not self.payload.artifact_id:
+            raise ValueError("artifact_id is required in workspace shell payload")
+
+    # ------------------------------------------------------------------
+    # Layout / region contract
+    # ------------------------------------------------------------------
+
+    @property
+    def regions(self) -> dict[str, str]:
+        return {
+            REGION_NOTE_BODY:   "primary",
+            REGION_NOTE_HEADER: "header",
+            REGION_AGENT_RAIL:  "secondary",
+        }
+
+    def region_role(self, region: str) -> str:
+        if region not in self.regions:
+            raise KeyError(f"Unknown workspace layout region: {region!r}")
+        return self.regions[region]
+
+    # ------------------------------------------------------------------
+    # Identity / content accessors
+    # ------------------------------------------------------------------
+
+    @property
+    def artifact_id(self) -> str:
+        return self.payload.artifact_id
+
+    @property
+    def note_path(self) -> str:
+        return self.payload.note_path
+
+    @property
+    def title(self) -> str:
+        return self.payload.title
+
+    @property
+    def body(self) -> str:
+        return self.payload.body
+
+    @property
+    def content_hash(self) -> str:
+        return self.payload.content_hash
+
+    # ------------------------------------------------------------------
+    # Read-only guard
+    # ------------------------------------------------------------------
+
+    @property
+    def is_read_only(self) -> bool:
+        """Workspace shell is always read-only; no mutation controls are rendered."""
+        return True
+
+    @property
+    def mutation_controls(self) -> list:
+        """No mutation controls exposed from this shell."""
+        return []
+
+    # ------------------------------------------------------------------
+    # Agent rail slot
+    # ------------------------------------------------------------------
+
+    @property
+    def has_agent_rail(self) -> bool:
+        """Secondary rail slot is always present (may be empty)."""
+        return True
+
+    @property
+    def agent_rail_is_empty(self) -> bool:
+        return self.agent_rail_state is None

--- a/tests/companion_ui/test_real_note_workspace_shell.py
+++ b/tests/companion_ui/test_real_note_workspace_shell.py
@@ -1,0 +1,133 @@
+"""Tests for real-note read-only workspace shell (#1064).
+
+Verifies that the shell renders a real note payload as the primary surface,
+exposes a secondary agent rail slot, is read-only, and performs no direct
+vault I/O.
+"""
+
+from __future__ import annotations
+
+from companion_ui.workspace.real_note_workspace_shell import (
+    REGION_AGENT_RAIL,
+    REGION_NOTE_BODY,
+    REGION_NOTE_HEADER,
+    ArtifactNotePayload,
+    RealNoteWorkspaceShell,
+)
+
+
+def _payload(
+    artifact_id: str = "note-uuid-1",
+    note_path: str = "/vault/notes/test.md",
+    title: str = "My Test Note",
+    body: str = "# My Test Note\n\nBody content here.",
+    content_hash: str = "abc123def456",
+) -> ArtifactNotePayload:
+    return ArtifactNotePayload(
+        artifact_id=artifact_id,
+        note_path=note_path,
+        title=title,
+        body=body,
+        content_hash=content_hash,
+    )
+
+
+def _shell(**kw) -> RealNoteWorkspaceShell:
+    return RealNoteWorkspaceShell(payload=_payload(**kw))
+
+
+# ---------------------------------------------------------------------------
+# AC 1: shell renders all required fields from real note payload
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_shell_renders_real_note_payload() -> None:
+    shell = _shell(
+        artifact_id="note-uuid-42",
+        note_path="/vault/notes/research.md",
+        title="Research Note",
+        body="# Research Note\n\nDetailed body.",
+        content_hash="deadbeef0000",
+    )
+    assert shell.artifact_id == "note-uuid-42"
+    assert shell.note_path == "/vault/notes/research.md"
+    assert shell.title == "Research Note"
+    assert "Detailed body" in shell.body
+    assert shell.content_hash == "deadbeef0000"
+
+
+# ---------------------------------------------------------------------------
+# AC 2: note body is primary surface; agent rail is secondary
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_shell_preserves_note_body_as_primary_surface() -> None:
+    shell = _shell()
+    assert shell.region_role(REGION_NOTE_BODY) == "primary"
+    # Secondary/header regions are subordinate to the body
+    assert shell.region_role(REGION_NOTE_HEADER) == "header"
+    assert shell.region_role(REGION_AGENT_RAIL) == "secondary"
+
+
+# ---------------------------------------------------------------------------
+# AC 3: secondary agent rail slot is exposed without requiring Panel data
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_shell_exposes_secondary_agent_slot() -> None:
+    shell = _shell()
+    assert shell.has_agent_rail is True
+    # Empty by default — no Panel runtime data required
+    assert shell.agent_rail_is_empty is True
+    assert REGION_AGENT_RAIL in shell.regions
+
+    # Can receive optional agent state
+    shell_with_state = RealNoteWorkspaceShell(
+        payload=_payload(), agent_rail_state="proposals-staged"
+    )
+    assert not shell_with_state.agent_rail_is_empty
+    assert shell_with_state.agent_rail_state == "proposals-staged"
+
+
+# ---------------------------------------------------------------------------
+# AC 4: no mutation controls rendered in read-only shell
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_shell_is_read_only() -> None:
+    shell = _shell()
+    assert shell.is_read_only is True
+    assert shell.mutation_controls == []
+
+
+# ---------------------------------------------------------------------------
+# AC 5: shell has no direct vault I/O
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_shell_has_no_direct_vault_io() -> None:
+    """Architecture guard: workspace shell must not import or call vault I/O."""
+    import ast
+    import pathlib
+
+    vault_io_calls = {"read_text", "read_bytes", "write_text", "write_bytes", "open"}
+    shell_file = (
+        pathlib.Path(__file__).resolve().parents[2]
+        / "companion-ui"
+        / "companion-app"
+        / "companion_ui"
+        / "workspace"
+        / "real_note_workspace_shell.py"
+    )
+    assert shell_file.exists(), f"Shell file not found: {shell_file}"
+
+    tree = ast.parse(shell_file.read_text(encoding="utf-8"))
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and node.attr in vault_io_calls:
+            violations.append(f"line {getattr(node, 'lineno', '?')}: uses .{node.attr}")
+
+    assert not violations, (
+        "real_note_workspace_shell must not perform direct vault I/O:\n"
+        + "\n".join(violations)
+    )


### PR DESCRIPTION
## Summary

- Adds `companion_ui/workspace/real_note_workspace_shell.py` with `ArtifactNotePayload` and `RealNoteWorkspaceShell`
- Shell renders note payload (`artifact_id`, `note_path`, `title`, `body`, `content_hash`) consumed from the #1063 endpoint contract
- `REGION_NOTE_BODY` = primary, `REGION_NOTE_HEADER` = header, `REGION_AGENT_RAIL` = secondary
- Always `is_read_only = True`; `mutation_controls = []`
- Secondary agent rail slot present but empty by default — no Panel runtime data required
- No direct vault reads/writes (architecture guard test passes)

Closes #1064
Depends on #1063 (endpoint contract consumed)

## Classification
- lane: code
- risk: low
- touches_runtime: no (companion-ui only)
- touches_ci_or_skills: no
- closes_issue: yes

## Test plan
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_real_note_workspace_shell.py` → 5 passed
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/` → 564 passed, 0 regressions
- [x] `git diff --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)