### PR TITLE
feat(companion-ui): connect Panel confirm response to artifact refresh (#1065)

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/confirm_session.py
+++ b/companion-ui/companion-app/companion_ui/workspace/confirm_session.py
@@ -1,0 +1,148 @@
+"""Panel confirm → artifact refresh session model (#1065).
+
+Connects the Companion UI layer to the Panel confirm API and the artifact
+read endpoint. The UI remains a pure API consumer — no vault file access.
+
+Contracts consumed:
+- POST /api/panel/confirm  (panel confirmation endpoint, #1053)
+- GET  /api/artifacts/note (read-only artifact endpoint, #1063)
+
+This module does NOT:
+- read or write vault files directly
+- implement proposal generation or staging UI
+- add Canvas bounded suggestions or body-edit
+- make real HTTP calls (requires an injected http_client)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional, Protocol
+
+
+# ---------------------------------------------------------------------------
+# HTTP client protocol — injected so tests can use stubs
+# ---------------------------------------------------------------------------
+
+
+class HttpClient(Protocol):
+    def post(self, url: str, *, json: dict[str, Any]) -> dict[str, Any]:
+        ...
+
+    def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Response / payload types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ConfirmOutcome:
+    """Typed result from POST /api/panel/confirm."""
+
+    status: str           # "executed" | "blocked" | "rejected" | "logged"
+    proposal_id: str
+    artifact_id: str
+    receipt: Optional[dict[str, Any]] = None
+    block_reason: Optional[dict[str, Any]] = None
+    events_emitted: list[str] = field(default_factory=list)
+
+    @property
+    def is_executed(self) -> bool:
+        return self.status == "executed"
+
+    @property
+    def is_blocked(self) -> bool:
+        return self.status == "blocked"
+
+    @property
+    def is_rejected(self) -> bool:
+        return self.status == "rejected"
+
+    @property
+    def block_gate(self) -> Optional[str]:
+        if self.block_reason:
+            return self.block_reason.get("gate")
+        return None
+
+
+@dataclass
+class ArtifactPayload:
+    """Note payload received from GET /api/artifacts/note."""
+
+    artifact_id: str
+    note_path: str
+    title: str
+    body: str
+    content_hash: str
+
+
+# ---------------------------------------------------------------------------
+# Workspace confirm session
+# ---------------------------------------------------------------------------
+
+
+class WorkspaceConfirmSession:
+    """Companion UI session model for Panel confirm → artifact refresh flow.
+
+    Call confirm() to:
+    1. POST to /api/panel/confirm with the staged proposal
+    2. Record the typed result
+    3. Reload the artifact note payload via GET /api/artifacts/note
+
+    After confirm(), inspect last_result and current_payload.
+    """
+
+    def __init__(self, http_client: HttpClient) -> None:
+        self._http = http_client
+        self.last_result: Optional[ConfirmOutcome] = None
+        self.current_payload: Optional[ArtifactPayload] = None
+
+    def confirm(
+        self,
+        *,
+        proposal_id: str,
+        artifact_id: str,
+        note_path: str,
+        action: str,
+        idempotency_key: str,
+    ) -> ConfirmOutcome:
+        """Submit Panel confirm request and refresh artifact payload."""
+        raw = self._http.post(
+            "/api/panel/confirm",
+            json={
+                "proposal_id": proposal_id,
+                "artifact_id": artifact_id,
+                "action": action,
+                "idempotency_key": idempotency_key,
+            },
+        )
+        result = ConfirmOutcome(
+            status=raw.get("status", ""),
+            proposal_id=raw.get("proposal_id", proposal_id),
+            artifact_id=raw.get("artifact_id", artifact_id),
+            receipt=raw.get("receipt"),
+            block_reason=raw.get("block_reason"),
+            events_emitted=raw.get("events_emitted") or [],
+        )
+        self.last_result = result
+
+        # Always reload artifact payload after any confirm response
+        self._refresh_artifact(note_path=note_path, artifact_id=artifact_id)
+
+        return result
+
+    def _refresh_artifact(self, *, note_path: str, artifact_id: str) -> None:
+        raw = self._http.get(
+            "/api/artifacts/note",
+            params={"note_path": note_path, "artifact_id": artifact_id},
+        )
+        self.current_payload = ArtifactPayload(
+            artifact_id=raw.get("artifact_id", artifact_id),
+            note_path=raw.get("note_path", note_path),
+            title=raw.get("title", ""),
+            body=raw.get("body", ""),
+            content_hash=raw.get("content_hash", ""),
+        )

--- a/tests/companion_ui/test_panel_confirm_artifact_refresh.py
+++ b/tests/companion_ui/test_panel_confirm_artifact_refresh.py
@@ -1,0 +1,223 @@
+"""Tests: Panel confirm response → artifact refresh (#1065).
+
+Verifies that the workspace session model submits confirm requests, displays
+typed results, and reloads the artifact payload through the read endpoint
+contract — without direct vault file access.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from companion_ui.workspace.confirm_session import (
+    ArtifactPayload,
+    ConfirmOutcome,
+    WorkspaceConfirmSession,
+)
+
+
+# ---------------------------------------------------------------------------
+# Stub HTTP client
+# ---------------------------------------------------------------------------
+
+_EXECUTED_CONFIRM_RESPONSE: dict[str, Any] = {
+    "proposal_id": "prop-1",
+    "artifact_id": "note-uuid-1",
+    "status": "executed",
+    "outcome": "success",
+    "receipt": {"action_taken": "confirm", "outcome": "success", "timestamp": "2026-01-01T00:00:00Z"},
+    "block_reason": None,
+    "idempotency_key": "idem-1",
+    "events_emitted": ["panel.intent.executed"],
+}
+
+_BLOCKED_CONFIRM_RESPONSE: dict[str, Any] = {
+    "proposal_id": "prop-1",
+    "artifact_id": "note-uuid-1",
+    "status": "blocked",
+    "outcome": "blocked",
+    "receipt": None,
+    "block_reason": {"gate": "writeguard", "message": "blocked in test"},
+    "idempotency_key": "idem-1",
+    "events_emitted": ["panel.action.blocked"],
+}
+
+_REJECTED_CONFIRM_RESPONSE: dict[str, Any] = {
+    "proposal_id": "prop-1",
+    "artifact_id": "note-uuid-1",
+    "status": "rejected",
+    "outcome": "rejected",
+    "receipt": None,
+    "block_reason": None,
+    "idempotency_key": "idem-1",
+    "events_emitted": [],
+}
+
+_REFRESHED_ARTIFACT_RESPONSE: dict[str, Any] = {
+    "artifact_id": "note-uuid-1",
+    "note_path": "/vault/notes/test.md",
+    "title": "Test Note",
+    "body": "# Test Note\n\nUpdated body after confirm.",
+    "content_hash": "refreshed00",
+}
+
+
+class _StubHttpClient:
+    """Stub HTTP client for testing WorkspaceConfirmSession."""
+
+    def __init__(
+        self,
+        confirm_response: dict[str, Any],
+        artifact_response: dict[str, Any] = _REFRESHED_ARTIFACT_RESPONSE,
+    ) -> None:
+        self._confirm = confirm_response
+        self._artifact = artifact_response
+        self.confirm_calls: list[dict] = []
+        self.artifact_calls: list[dict] = []
+
+    def post(self, url: str, *, json: dict[str, Any]) -> dict[str, Any]:
+        self.confirm_calls.append({"url": url, "json": json})
+        return dict(self._confirm)
+
+    def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        self.artifact_calls.append({"url": url, "params": params})
+        return dict(self._artifact)
+
+
+def _confirm_kwargs(**overrides) -> dict:
+    base = {
+        "proposal_id": "prop-1",
+        "artifact_id": "note-uuid-1",
+        "note_path": "/vault/notes/test.md",
+        "action": "confirm",
+        "idempotency_key": "idem-1",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# AC 1: UI sends confirm request, records/displays executed result
+# ---------------------------------------------------------------------------
+
+
+def test_panel_confirm_displays_executed_result() -> None:
+    http = _StubHttpClient(confirm_response=_EXECUTED_CONFIRM_RESPONSE)
+    session = WorkspaceConfirmSession(http)
+
+    result = session.confirm(**_confirm_kwargs(action="confirm"))
+
+    assert result.status == "executed"
+    assert result.is_executed is True
+    assert result.receipt is not None
+    assert result.receipt["outcome"] == "success"
+    assert result.receipt["action_taken"] == "confirm"
+    assert session.last_result is result
+
+    # Confirm was submitted to the right endpoint
+    assert len(http.confirm_calls) == 1
+    call = http.confirm_calls[0]
+    assert call["url"] == "/api/panel/confirm"
+    assert call["json"]["action"] == "confirm"
+
+
+# ---------------------------------------------------------------------------
+# AC 2: guarded (blocked) result displayed with reason, no local mutation
+# ---------------------------------------------------------------------------
+
+
+def test_panel_confirm_displays_guarded_result() -> None:
+    http = _StubHttpClient(confirm_response=_BLOCKED_CONFIRM_RESPONSE)
+    session = WorkspaceConfirmSession(http)
+
+    result = session.confirm(**_confirm_kwargs(action="confirm"))
+
+    assert result.status == "blocked"
+    assert result.is_blocked is True
+    assert result.block_reason is not None
+    assert result.block_reason["gate"] == "writeguard"
+    assert result.receipt is None
+    # No mutation assumed — shell still loads refreshed payload from API
+    assert session.current_payload is not None
+
+
+# ---------------------------------------------------------------------------
+# AC 3: reject result displayed as non-execution
+# ---------------------------------------------------------------------------
+
+
+def test_panel_confirm_displays_rejected_result() -> None:
+    http = _StubHttpClient(confirm_response=_REJECTED_CONFIRM_RESPONSE)
+    session = WorkspaceConfirmSession(http)
+
+    result = session.confirm(**_confirm_kwargs(action="reject"))
+
+    assert result.status == "rejected"
+    assert result.is_rejected is True
+    assert result.receipt is None
+    assert result.block_reason is None
+    # Confirmed call was a reject action
+    assert http.confirm_calls[0]["json"]["action"] == "reject"
+
+
+# ---------------------------------------------------------------------------
+# AC 4: artifact payload reloaded after response via read endpoint contract
+# ---------------------------------------------------------------------------
+
+
+def test_panel_confirm_refreshes_artifact_payload_after_response() -> None:
+    http = _StubHttpClient(
+        confirm_response=_EXECUTED_CONFIRM_RESPONSE,
+        artifact_response=_REFRESHED_ARTIFACT_RESPONSE,
+    )
+    session = WorkspaceConfirmSession(http)
+
+    assert session.current_payload is None
+
+    session.confirm(**_confirm_kwargs(action="confirm"))
+
+    # Payload is refreshed after every confirm response (regardless of outcome)
+    assert session.current_payload is not None
+    assert isinstance(session.current_payload, ArtifactPayload)
+    assert session.current_payload.content_hash == "refreshed00"
+    assert session.current_payload.artifact_id == "note-uuid-1"
+
+    # Artifact endpoint was called exactly once
+    assert len(http.artifact_calls) == 1
+    art_call = http.artifact_calls[0]
+    assert art_call["url"] == "/api/artifacts/note"
+    assert art_call["params"]["note_path"] == "/vault/notes/test.md"
+    assert art_call["params"]["artifact_id"] == "note-uuid-1"
+
+
+# ---------------------------------------------------------------------------
+# AC 5: Companion UI session has no direct vault file access
+# ---------------------------------------------------------------------------
+
+
+def test_panel_confirm_ui_has_no_direct_vault_file_access() -> None:
+    """Architecture guard: confirm_session must not access vault files directly."""
+    import ast
+    import pathlib
+
+    vault_io_calls = {"read_text", "read_bytes", "write_text", "write_bytes", "open"}
+    session_file = (
+        pathlib.Path(__file__).resolve().parents[2]
+        / "companion-ui"
+        / "companion-app"
+        / "companion_ui"
+        / "workspace"
+        / "confirm_session.py"
+    )
+    assert session_file.exists(), f"confirm_session.py not found: {session_file}"
+
+    tree = ast.parse(session_file.read_text(encoding="utf-8"))
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and node.attr in vault_io_calls:
+            violations.append(f"line {getattr(node, 'lineno', '?')}: uses .{node.attr}")
+
+    assert not violations, (
+        "confirm_session must not access vault files directly:\n"
+        + "\n".join(violations)
+    )


### PR DESCRIPTION
## Summary

- Adds `companion_ui/workspace/confirm_session.py` with `WorkspaceConfirmSession`
- Session submits `POST /api/panel/confirm` via injected `HttpClient` protocol, records typed `ConfirmOutcome`
- After any confirm response (executed/blocked/rejected), reloads artifact payload via `GET /api/artifacts/note`
- `ConfirmOutcome` carries `status`, `receipt`, `block_reason`, `events_emitted`
- No direct vault file access; architecture guard test passes
- No proposal generation, Canvas body-edit, or bounded suggestion flow

Closes #1065
Depends on #1063 (`GET /api/artifacts/note`) and #1064 (workspace shell)

## Classification
- lane: code
- risk: low
- touches_runtime: no (companion-ui only)
- touches_ci_or_skills: no
- closes_issue: yes

## Test plan
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_panel_confirm_artifact_refresh.py` → 5 passed
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/` → 569 passed, 0 regressions
- [x] `git diff --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)