### PR TITLE
fix(lint): remove unused imports introduced by #1070

### DIFF
--- a/app/api/routes/artifacts.py
+++ b/app/api/routes/artifacts.py
@@ -9,7 +9,6 @@ Rejects path traversal and paths outside the configured vault root.
 from __future__ import annotations
 
 import hashlib
-import re
 from pathlib import Path
 from typing import Optional
 

--- a/tests/companion_ui/test_panel_confirm_artifact_refresh.py
+++ b/tests/companion_ui/test_panel_confirm_artifact_refresh.py
@@ -11,7 +11,6 @@ from typing import Any
 
 from companion_ui.workspace.confirm_session import (
     ArtifactPayload,
-    ConfirmOutcome,
     WorkspaceConfirmSession,
 )
 

--- a/tests/integration/test_panel_confirm_integration.py
+++ b/tests/integration/test_panel_confirm_integration.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import pathlib
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
@@ -227,7 +227,6 @@ def test_panel_confirm_integration_blocked_vault_and_receipt(
     mock_guard.assert_writes_allowed.side_effect = WritesBlockedError(
         "blocked", "write guard active in UAT", "panel.confirm"
     )
-    from app.write_guard import DEFAULT_WRITE_GUARD
     original_guard = confirm_module._service._guard
     confirm_module._service._guard = mock_guard
 


### PR DESCRIPTION
## Direct Repair

Type: code
Reason: PR #1070 introduced 4 unused imports that break the CI Smoke / Lint (ruff) check on every subsequent PR. This repair removes them to restore CI green.
Validation: `ruff check app/api/routes/artifacts.py tests/companion_ui/test_panel_confirm_artifact_refresh.py tests/integration/test_panel_confirm_integration.py` — All checks passed.
Issue required: no — bounded immediate repair

## Changes

- `app/api/routes/artifacts.py` — remove unused `import re`
- `tests/companion_ui/test_panel_confirm_artifact_refresh.py` — remove unused `ConfirmOutcome` import
- `tests/integration/test_panel_confirm_integration.py` — remove unused `patch` and `DEFAULT_WRITE_GUARD` imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)