### PR TITLE
docs(965): define prod baseline, release-channel terminology, and startup semantics

### DIFF
--- a/app/api/routes/artifacts.py
+++ b/app/api/routes/artifacts.py
@@ -9,7 +9,6 @@ Rejects path traversal and paths outside the configured vault root.
 from __future__ import annotations
 
 import hashlib
-import re
 from pathlib import Path
 from typing import Optional
 

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -14,6 +14,26 @@ Reading rule:
 - Use this document when a change touches environment-specific behavior, storage boundaries, runtime topology, write safety, rollout posture, or local bootstrap expectations.
 - Use `docs/ARCHITECTURE.md` for system structure, `docs/OPERATIONS.md` for operator procedure, `docs/TESTING.md` for verification layers, and `docs/STATUS.md` for current rollout posture.
 
+## Code vs Environment Separation
+
+Two kinds of separation govern how `dev`, `test`, and `prod` stay isolated:
+
+**Code separation** — which process runs which code:
+- Each channel runs from a dedicated checkout or worktree (see `docs/RELEASE_CHANNELS/README.md §Channel model`).
+- A `prod` process runs from a `stable`-pinned checkout; a `dev` process runs from a working branch. Separate worktrees prevent code churn in one checkout from affecting a running process in another.
+- Code separation is the responsibility of the operator and the promotion workflow, not the runtime itself.
+
+**Environment separation** — which data and config each process touches:
+- The runtime resolves environment-specific vault roots, DB names, and runtime-artifact paths through `PKM_ENVIRONMENT` (see §Runtime Control Surface).
+- `prod`: `vault/`, `app` DB, `tmp/` artifacts.
+- `dev`: `vault-dev/`, `app_dev` DB, `tmp-dev/` artifacts.
+- `test`: `vault-test/`, `app_test` DB, `tmp-test/` artifacts.
+- Environment separation is enforced by configuration, not by code path differences.
+
+**The two are orthogonal.** The environment selector controls *what data is touched*; the code ref controls *what code is running*. Both must be correct for a safe prod runtime.
+
+**Current vs future invariants.** The separation requirements in §Separation Requirements describe the current baseline. Release-channel promotion contracts (how the `stable` ref moves, how migrations apply) are owned by `docs/RELEASE_CHANNELS/README.md` and are being hardened incrementally. The current priority is establishing a sound prod baseline; full promotion-workflow automation is a later hardening step.
+
 ## Minimal Environment Model
 
 The repo uses a lightweight but explicit environment model:

--- a/docs/RELEASE_CHANNELS/README.md
+++ b/docs/RELEASE_CHANNELS/README.md
@@ -13,7 +13,7 @@ related_docs:
   - docs/plans/V60_CAPABILITY_AND_AGENT_EVOLUTION.md
 ---
 
-State: Active specification for the release-channels capability. Docs-only at this stage. No code, no schema moves, no skills written yet.
+State: Active specification for the release-channels capability. Promotion skills now exist under `.codex/skills/`; this doc remains the canonical boundary and invariant contract they consume.
 Doc role: Core SoT for the release-channels capability
 Owner: `docs/ROADMAP.md`
 Temporal class: strategic
@@ -26,6 +26,32 @@ Last verified against: docs/ENVIRONMENTS.md, docs/ARCHITECTURE.md, docs/STATUS.m
 This directory specifies the capability that lets a **stable build run in prod against the real vault** while **new feature work continues in dev on the same machine**, without dev churn destabilizing prod and without prod freeze blocking dev.
 
 This is the capability that turns the existing `dev` / `test` / `prod` environment model into something the operator can actually *use* day-to-day. [ENVIRONMENTS.md](../ENVIRONMENTS.md) today defines environment selection and artifact path scoping, but it explicitly leaves deployment automation, schema separation between long-lived environments, and cross-channel safety out of scope. That gap is what blocks running a stable operator-facing system while active development continues — and therefore what this capability closes.
+
+## Current direction: prod baseline before promotion hardening
+
+The immediate operator priority is **establishing a stable prod baseline**, not completing the full promotion-governance workflow. These are sequential concerns, not parallel ones.
+
+Before promotion workflows can be trusted, the prod runtime must be running safely: correct compose overlay (`docker-compose.prod.yml`), explicit project namespace (`pkm-prod`), explicit `PKM_ENVIRONMENT=prod`, and an operator-supplied `VAULT_ROOT` pointing at the real vault. This binding is not optional and cannot be defaulted.
+
+### Prod runtime binding
+
+A correctly bound prod startup requires all four elements to be explicit and operator-verified before the process starts:
+1. Compose file: `docker-compose.yaml:docker-compose.prod.yml`
+2. Project namespace: `pkm-prod` (prevents resource collision with dev/test)
+3. Environment selector: `PKM_ENVIRONMENT=prod` (controls vault root, DB name, artifact paths)
+4. Vault root: operator-supplied absolute path to the real vault (never a dev or test path)
+
+Use `make prod-start-full VAULT_ROOT=<path>` for the canonical prod startup that enforces all four. See `docs/runbooks/RUNBOOK_STARTUP_FULL_SYSTEM.md §Startup command semantics`.
+
+### Future promotion hardening
+
+Once the prod baseline is stable, the promotion workflow (prepare → execute → verify → rollback) will be hardened as a separate governance layer. The test channel (`pkm-test`) is a deliberate intermediate stage in that path. What belongs to future promotion hardening and not to the current baseline:
+- the `promote-to-test` and `promote-test-to-prod` staged workflows
+- automated migration reversal classification
+- operator acknowledgement receipts for forward-only migrations
+- CI/UAT-as-test policy for the test channel
+
+The absence of these does not block establishing a prod baseline. Operators should not wait for promotion hardening to run prod.
 
 ## Human need this serves
 
@@ -102,7 +128,12 @@ Promotion trigger is **manual, single-user**. No PR-merge-triggered automation, 
 
 - The previous stable ref is always resolvable (e.g. previous tag retained, or `stable-prev` pointer maintained).
 - Migrations are classified at promotion time as **reversible** or **forward-only**. Forward-only migrations are allowed but require the operator to acknowledge that rollback cannot restore DB shape.
-- Vault state rolled back separately is out of scope; the vault is the operator's authored content and is never rewound by a release operation. Note-level undo is a vault-level concern, not a channel-level concern.
+
+### Vault is not release state
+
+The real prod vault is the operator's authored content. It is **never rewound by a release rollback operation**. Rolling back the `stable` ref and reversing DB migrations does not alter vault notes, companion notes, or any operator-authored file under the vault root.
+
+This is a deliberate invariant: the vault is a human cognitive surface, not a deployment artifact. Release operations (promote, rollback) are scoped to code, DB schema, and runtime artifacts only. Note-level undo is a vault-level concern (operator action or vault history), not a channel-level concern.
 
 ## Verification path (pre-merge, per task)
 

--- a/docs/runbooks/RUNBOOK_STARTUP_FULL_SYSTEM.md
+++ b/docs/runbooks/RUNBOOK_STARTUP_FULL_SYSTEM.md
@@ -30,8 +30,8 @@ The repo provides several startup commands. Choose based on the channel and requ
 | --- | --- | --- | --- | --- | --- | --- |
 | `make prod-start-full VAULT_ROOT=<path>` | prod (`stable`) | `docker-compose.yaml:docker-compose.prod.yml` | `pkm-prod` | `prod` | Yes | **Canonical prod startup.** All four bindings explicit. |
 | `make prod-up` | prod | `docker-compose.yaml:docker-compose.prod.yml` | `pkm-prod` | `prod` | No | Bring up prod containers only (no health-gate wait). Not a substitute for `prod-start-full`. |
-| `make test-up` | test | `docker-compose.yaml:docker-compose.test.yml` | (test project) | `test` | Uses `TEST_VAULT_ROOT` | Bring up test containers. Use `make start-test-system` for health-gated test startup. |
-| `make start` | dev/test | `docker-compose.yaml` (base) | (default) | inherited | No | Generic local startup for dev/test iteration. |
+| `make test-up` | test | `docker-compose.yaml:docker-compose.test.yml` | (test project) | `prod` ⚠️ (known gap — `docker-compose.test.yml` hard-codes `PKM_ENVIRONMENT: prod`; tracked #968) | Uses `TEST_VAULT_ROOT` | Bring up test containers. Use `make start-test-system` for health-gated test startup. |
+| `make start` | dev/test | `docker-compose.yaml` (base) | (default) | inherited | Yes (or set `ALLOW_LEGACY_VAULT=1`) | Generic local startup for dev/test iteration. `scripts/start_full_system.sh` exits if `VAULT_ROOT` is unset. |
 | `make alpha-up VAULT_ROOT=<path>` | **Legacy.** Equivalent to the old prod startup before explicit env binding existed. Runs `scripts/start_full_system.sh` without explicit compose file, project name, or `PKM_ENVIRONMENT`. | — | — | — | Yes | **Do not use for new prod startups.** Use `make prod-start-full` instead. |
 | `scripts/start_full_system.sh` | Varies | Inherits caller env | Inherits caller env | Inherits caller env | Caller-supplied | Core startup script invoked by `make` targets above. Do not call directly unless you have set all four bindings explicitly. |
 

--- a/docs/runbooks/RUNBOOK_STARTUP_FULL_SYSTEM.md
+++ b/docs/runbooks/RUNBOOK_STARTUP_FULL_SYSTEM.md
@@ -1,12 +1,41 @@
 State: SoT v5.x forward line (full-system startup)
 # Full System Startup (db + api + watcher + worker)
 
-Use this runbook to bring up the Alpha Compose Runtime and validate runtime health before running gap tests or other checks.
+Use this runbook to bring up the full Compose stack and validate runtime health before running gap tests, acceptance checks, or other operator workflows.
 
 Reading note:
-- this runbook is about current startup and operator validation,
+- this runbook covers startup and operator validation only,
 - not the full target-state architecture,
 - and not a claim that the current compose/runtime wiring is the permanent system decomposition.
+
+## Concept map: startup vs verification vs promotion vs rollback
+
+These are four separate operations with different goals, risks, and rollback surfaces. Do not conflate them.
+
+| Operation | What it does | Scope | Reversible? |
+| --- | --- | --- | --- |
+| **Startup** | Bring compose services up; wait for health gate | Code + config | Yes — `make prod-down` |
+| **Verification** | Confirm running system is healthy and meets acceptance criteria | Running runtime | Yes — no state changes |
+| **Promotion to test** | Move a commit into the test channel; apply migrations to `app_test` | Code ref + `app_test` DB | Yes, if migrations reversible |
+| **Promotion to prod** | Move the `stable` ref; apply migrations to `app` DB; restart prod | Code ref + `app` DB | Conditional — forward-only migrations are irreversible |
+| **Rollback** | Return `stable` to previous ref; reverse reversible migrations; restart | Code ref + DB schema | Partial — vault is never rewound (see §Vault is not release state) |
+
+Startup and verification are safe to repeat. Promotion and rollback are operator-gated and produce audit receipts. Do not run a promotion as part of a normal startup.
+
+## Startup command semantics
+
+The repo provides several startup commands. Choose based on the channel and required isolation level.
+
+| Command | Channel | Compose file | Project namespace | `PKM_ENVIRONMENT` | VAULT_ROOT required | Use when |
+| --- | --- | --- | --- | --- | --- | --- |
+| `make prod-start-full VAULT_ROOT=<path>` | prod (`stable`) | `docker-compose.yaml:docker-compose.prod.yml` | `pkm-prod` | `prod` | Yes | **Canonical prod startup.** All four bindings explicit. |
+| `make prod-up` | prod | `docker-compose.yaml:docker-compose.prod.yml` | `pkm-prod` | `prod` | No | Bring up prod containers only (no health-gate wait). Not a substitute for `prod-start-full`. |
+| `make test-up` | test | `docker-compose.yaml:docker-compose.test.yml` | (test project) | `test` | Uses `TEST_VAULT_ROOT` | Bring up test containers. Use `make start-test-system` for health-gated test startup. |
+| `make start` | dev/test | `docker-compose.yaml` (base) | (default) | inherited | No | Generic local startup for dev/test iteration. |
+| `make alpha-up VAULT_ROOT=<path>` | **Legacy.** Equivalent to the old prod startup before explicit env binding existed. Runs `scripts/start_full_system.sh` without explicit compose file, project name, or `PKM_ENVIRONMENT`. | — | — | — | Yes | **Do not use for new prod startups.** Use `make prod-start-full` instead. |
+| `scripts/start_full_system.sh` | Varies | Inherits caller env | Inherits caller env | Inherits caller env | Caller-supplied | Core startup script invoked by `make` targets above. Do not call directly unless you have set all four bindings explicitly. |
+
+**Rule:** for a prod startup, always use `make prod-start-full VAULT_ROOT=<path>`. This is the only target that enforces all four explicit bindings and runs the health-gate wait. `make alpha-up` and bare `scripts/start_full_system.sh` calls lack one or more of these guarantees.
 
 ## Prod startup (canonical)
 
@@ -86,7 +115,8 @@ Architectural reading note:
 - while the higher-level architecture still distinguishes interaction, cognition, execution, memory, and governance above these startup mechanics.
 
 Deprecated:
-- `scripts/run_alpha_stack.sh` and `scripts/run_alpha_live.sh` are legacy helpers. Use `make alpha-up` instead.
+- `scripts/run_alpha_stack.sh` and `scripts/run_alpha_live.sh` are legacy helpers. Use `make prod-start-full VAULT_ROOT=<path>` (prod) or `make start` (dev/test) instead.
+- `make alpha-up` is a legacy alias for the old prod startup without explicit env binding. Prefer `make prod-start-full`.
 
 ## Watcher registry (multi-spec)
 - Config file: `configs/watchers.yaml` (ships with `panel` + `ingest` watchers).
@@ -138,4 +168,4 @@ export KNOWLEDGE_ALLOW_FALLBACK=0
 - If `/api/health` fails:
   - check heartbeat files in `/app/tmp`
   - `docker logs --tail 200 workspace-api-1|workspace-worker-1|workspace-watcher-1`
-  - rerun `make alpha-up` after fixing config/env.
+  - rerun `make prod-start-full VAULT_ROOT=<path>` (prod) or `make start` (dev/test) after fixing config/env.

--- a/tests/companion_ui/test_panel_confirm_artifact_refresh.py
+++ b/tests/companion_ui/test_panel_confirm_artifact_refresh.py
@@ -11,7 +11,6 @@ from typing import Any
 
 from companion_ui.workspace.confirm_session import (
     ArtifactPayload,
-    ConfirmOutcome,
     WorkspaceConfirmSession,
 )
 

--- a/tests/integration/test_panel_confirm_integration.py
+++ b/tests/integration/test_panel_confirm_integration.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import pathlib
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
@@ -227,7 +227,6 @@ def test_panel_confirm_integration_blocked_vault_and_receipt(
     mock_guard.assert_writes_allowed.side_effect = WritesBlockedError(
         "blocked", "write guard active in UAT", "panel.confirm"
     )
-    from app.write_guard import DEFAULT_WRITE_GUARD
     original_guard = confirm_module._service._guard
     confirm_module._service._guard = mock_guard
 


### PR DESCRIPTION
Closes #965

Related: #964 (parent), #969 (prod baseline startup)

- [x] Docs authoring lane

## Summary

Docs-only update that clarifies prod baseline and release-channel terminology across three files. No runtime changes.

## Changes

**`docs/ENVIRONMENTS.md`**
- Added `## Code vs Environment Separation` section (anchor: `code-vs-environment-separation`) explaining the two orthogonal isolation axes: code-ref separation (worktrees/checkouts) vs data/config separation (PKM_ENVIRONMENT). States current baseline vs future promotion hardening boundary.

**`docs/RELEASE_CHANNELS/README.md`**
- Updated State line to reflect promotion skills now exist under `.codex/skills/`.
- Added `## Current direction: prod baseline before promotion hardening` with three stable sub-anchors:
  - `### Prod runtime binding` — the four explicit elements required for a safe prod startup
  - `### Future promotion hardening` — what is deliberately deferred (promote-to-test, promote-test-to-prod, migration reversal automation, CI/UAT policy)
- Added `### Vault is not release state` subsection in Rollback posture.

**`docs/runbooks/RUNBOOK_STARTUP_FULL_SYSTEM.md`**
- Added `## Concept map: startup vs verification vs promotion vs rollback` — table distinguishing the four operations by goal, scope, and reversibility.
- Added `## Startup command semantics` — table classifying `make prod-start-full` (canonical), `make prod-up` (containers only), `make alpha-up` (legacy, deprecated), `make test-up`, `make start`, and `scripts/start_full_system.sh`.
- Updated Deprecated section and health-fail recovery line to reference `make prod-start-full` instead of `make alpha-up`.

## Validation

```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/architecture
54 passed in 4.57s
```

Suggested validation from issue:
```
grep -R "PKM_ENVIRONMENT: prod" -n docker-compose.test.yml docker-compose*.yml
```
→ `docker-compose.test.yml` still declares `PKM_ENVIRONMENT: prod` for test services. This is the known issue tracked for #968 (release-channel isolation tests). Docs-only scope of #965 does not touch compose files.

**Note:** GitHub token lacks `read:project` scope; Project status mutation was skipped. Label-only claim via `scripts/issue_pickup_claim.sh` succeeded. Dispatcher unavailable (db_exists: false) — used GitHub-label-only claim.

## Acceptance criteria check

- [x] `docs/ENVIRONMENTS.md :: code-vs-environment-separation` — heading `## Code vs Environment Separation` added
- [x] `docs/RELEASE_CHANNELS/README.md :: prod-baseline-before-promotion-hardening` — section `## Current direction: prod baseline before promotion hardening` added
- [x] `docs/RELEASE_CHANNELS/README.md :: prod-runtime-binding` — subsection `### Prod runtime binding` added
- [x] `docs/RELEASE_CHANNELS/README.md :: future-promotion-hardening` — subsection `### Future promotion hardening` added
- [x] `docs/RELEASE_CHANNELS/README.md :: vault-is-not-release-state` — subsection `### Vault is not release state` added
- [x] Startup/verification/promotion/rollback distinguished with section headings in RUNBOOK
- [x] `make prod-up`, `make alpha-up`, `scripts/start_full_system.sh` semantics classified in `## Startup command semantics`