### PR TITLE
chore(lint): remove four ruff F401 unused-import errors

### DIFF
--- a/app/api/routes/artifacts.py
+++ b/app/api/routes/artifacts.py
@@ -9,7 +9,6 @@ Rejects path traversal and paths outside the configured vault root.
 from __future__ import annotations
 
 import hashlib
-import re
 from pathlib import Path
 from typing import Optional
 

--- a/tests/companion_ui/test_panel_confirm_artifact_refresh.py
+++ b/tests/companion_ui/test_panel_confirm_artifact_refresh.py
@@ -11,7 +11,6 @@ from typing import Any
 
 from companion_ui.workspace.confirm_session import (
     ArtifactPayload,
-    ConfirmOutcome,
     WorkspaceConfirmSession,
 )
 

--- a/tests/integration/test_panel_confirm_integration.py
+++ b/tests/integration/test_panel_confirm_integration.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import pathlib
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
@@ -227,7 +227,6 @@ def test_panel_confirm_integration_blocked_vault_and_receipt(
     mock_guard.assert_writes_allowed.side_effect = WritesBlockedError(
         "blocked", "write guard active in UAT", "panel.confirm"
     )
-    from app.write_guard import DEFAULT_WRITE_GUARD
     original_guard = confirm_module._service._guard
     confirm_module._service._guard = mock_guard
 


### PR DESCRIPTION
## Direct Repair

- **Type:** lint cleanup (small, bounded). No behavioral change, no docs change.
- **Validation:** `ruff check app tests` passes locally (was 4 F401 errors, now 0).

## Summary

`CI Smoke / smoke` has been failing on `main` for at least the last three runs because of four ruff F401 unused-import errors. None of the removed names are referenced in their files:

- `app/api/routes/artifacts.py` — `import re` (no `re.` usage anywhere in the module)
- `tests/companion_ui/test_panel_confirm_artifact_refresh.py` — `ConfirmOutcome` (only appears on its own import line)
- `tests/integration/test_panel_confirm_integration.py` — `patch` from `unittest.mock` (only appears on the import line)
- `tests/integration/test_panel_confirm_integration.py` — inner `from app.write_guard import DEFAULT_WRITE_GUARD` (imported inside `test_panel_confirm_integration_blocked_vault_and_receipt` but never referenced)

Each removal was verified with `grep` before applying. `ruff check app tests --fix` produced the diff; running `ruff check app tests` afterwards reports `All checks passed!`.

This unblocks the `smoke` lint job for downstream PRs (including docs-only PRs like [#1086](https://github.com/RasmusTho/agentic-pkm-mvp/pull/1086) whose `mergeStateStatus` was UNSTABLE only because of this pre-existing failure).

## Test plan

- [ ] `CI Smoke / smoke` (Lint (ruff)) goes green
- [ ] `pytest` smoke jobs remain green (the removed test imports are unused, so test behavior is unchanged)