### PR TITLE
docs: address review comments — serve_dev_page placeholder and UAT cleanup guard

### DIFF
--- a/companion-ui/docs/REAL_NOTE_WORKSPACE_DEV_PAGE.md
+++ b/companion-ui/docs/REAL_NOTE_WORKSPACE_DEV_PAGE.md
@@ -70,6 +70,14 @@ python -m app.cli status
 
 ## 3. How to Start the Companion UI Dev Page
 
+> **No browser dev server is shipped yet.**
+> `companion_ui.workspace.serve_dev_page` does not exist. The commands below
+> are placeholders showing the intended invocation shape for when the minimal
+> browser dev server is implemented (the next implementation slice per
+> `companion-ui/docs/COMPANION_UI_TARGET_ARCHITECTURE.md` section 6). Until
+> then, run the page model directly from a script or REPL as described in the
+> inline comments below.
+
 The dev page is currently a Python page model (`RealNoteWorkspaceDevPage`).
 To run it as a local HTTP dev server, use a minimal WSGI/ASGI wrapper or
 call the model directly from a script/REPL.
@@ -106,7 +114,7 @@ COMPANION_API_BASE_URL=http://127.0.0.1:18001 HOST=127.0.0.1 PORT=8111 \
 ```bash
 # Explicit bind to all interfaces — only do this for intentional LAN/Tailscale access
 COMPANION_API_BASE_URL=http://<mac-mini-ip>:18001 HOST=0.0.0.0 PORT=8111 \
-  python -m companion_ui.workspace.serve_dev_page
+  python -m companion_ui.workspace.serve_dev_page  # placeholder; adapt to your runner
 ```
 
 Then from another device:
@@ -164,8 +172,13 @@ targets. The runtime owns environment and vault binding.
 
    ```bash
    COMPANION_API_BASE_URL=http://127.0.0.1:<api-port> PORT=<ui-port> \
-     HOST=127.0.0.1 python -m companion_ui.workspace.serve_dev_page
+     HOST=127.0.0.1 python -m companion_ui.workspace.serve_dev_page  # placeholder; adapt to your runner
    ```
+
+   > **Not yet implemented.** `companion_ui.workspace.serve_dev_page` is a
+   > placeholder for the browser dev server (next implementation slice). Until
+   > it ships, run the `RealNoteWorkspaceDevPage` model directly from a
+   > script or REPL.
 
 5. **Set the UI API base URL to the matching runtime API port.**
 

--- a/docs/runbooks/UAT_REAL_NOTE_VERTICAL_SLICE.md
+++ b/docs/runbooks/UAT_REAL_NOTE_VERTICAL_SLICE.md
@@ -106,62 +106,64 @@ uat_note = vault_uat_dir / "test_confirm_session.md"
 uat_note_rel = "_uat_test/test_confirm_session.md"
 uat_note.write_text(f"# UAT Note\n- [ ] {ACTION_LABEL} <!--ai:id={AID}-->\nBody.\n", encoding="utf-8")
 
-confirm_module._proposal_store.clear()
-confirm_module._idempotency_store.clear()
-confirm_module._proposal_store.stage(
-    PROPOSAL_ID,
-    StagedProposal(
-        artifact_id=ARTIFACT_ID,
-        intent_event=PanelIntentEvent(payload=PanelIntentPayload(
-            note=NoteRef(uuid=ARTIFACT_ID, path=str(uat_note.resolve())),
-            panel=PanelInfo(panel_id=PROPOSAL_ID, instruction="UAT"),
-            actions=[PanelIntentAction(id=AID, label=ACTION_LABEL, checked=True)],
-        )),
-        proposed_at=0.0,
-    ),
-)
-
-def _fake_graph(state, **kwargs):
-    result = PanelRuntimeActionResult(id=AID, label=ACTION_LABEL, checked=True, status="triggered")
-    emitted = [make_outbox_event(event="panel.intent.executed", source="test", payload={})]
-    return PanelAgentState(
-        trace_id="uat-trace", note=state.note, panel=state.panel,
-        actions=state.actions, action_results=[result],
-        emitted_events=emitted, executed_action_ids=[AID],
-        vault_root=None, intent_event=state.intent_event,
+try:
+    confirm_module._proposal_store.clear()
+    confirm_module._idempotency_store.clear()
+    confirm_module._proposal_store.stage(
+        PROPOSAL_ID,
+        StagedProposal(
+            artifact_id=ARTIFACT_ID,
+            intent_event=PanelIntentEvent(payload=PanelIntentPayload(
+                note=NoteRef(uuid=ARTIFACT_ID, path=str(uat_note.resolve())),
+                panel=PanelInfo(panel_id=PROPOSAL_ID, instruction="UAT"),
+                actions=[PanelIntentAction(id=AID, label=ACTION_LABEL, checked=True)],
+            )),
+            proposed_at=0.0,
+        ),
     )
 
-class RealApiStub:
-    def post(self, url, *, json):
-        return client.post(url, json=json).json()
-    def get(self, url, *, params):
-        return client.get(url, params=params).json()
+    def _fake_graph(state, **kwargs):
+        result = PanelRuntimeActionResult(id=AID, label=ACTION_LABEL, checked=True, status="triggered")
+        emitted = [make_outbox_event(event="panel.intent.executed", source="test", payload={})]
+        return PanelAgentState(
+            trace_id="uat-trace", note=state.note, panel=state.panel,
+            actions=state.actions, action_results=[result],
+            emitted_events=emitted, executed_action_ids=[AID],
+            vault_root=None, intent_event=state.intent_event,
+        )
 
-with patch.object(runtime_module, "run_panel_graph", _fake_graph), \
-     patch.object(runtime_module, "load_panel_action_catalog", lambda: None), \
-     patch.object(runtime_module, "_write_db_outbox_events", lambda _: None):
+    class RealApiStub:
+        def post(self, url, *, json):
+            return client.post(url, json=json).json()
+        def get(self, url, *, params):
+            return client.get(url, params=params).json()
 
-    session = WorkspaceConfirmSession(http_client=RealApiStub())
-    outcome = session.confirm(
-        proposal_id=PROPOSAL_ID, artifact_id=ARTIFACT_ID,
-        note_path=uat_note_rel, action="confirm",
-        idempotency_key="idem-uat-real-001",
-    )
+    with patch.object(runtime_module, "run_panel_graph", _fake_graph), \
+         patch.object(runtime_module, "load_panel_action_catalog", lambda: None), \
+         patch.object(runtime_module, "_write_db_outbox_events", lambda _: None):
 
-assert outcome.status == "executed"
-print(f"CHECK 3 WorkspaceConfirmSession.confirm PASS  status={outcome.status}")
+        session = WorkspaceConfirmSession(http_client=RealApiStub())
+        outcome = session.confirm(
+            proposal_id=PROPOSAL_ID, artifact_id=ARTIFACT_ID,
+            note_path=uat_note_rel, action="confirm",
+            idempotency_key="idem-uat-real-001",
+        )
 
-# Refresh must reflect the post-confirm state of the same note that was confirmed.
-assert session.current_payload is not None
-assert session.current_payload.body == uat_note.read_text(encoding="utf-8")
-print(f"CHECK 4 Artifact refresh after confirm  PASS")
+    assert outcome.status == "executed"
+    print(f"CHECK 3 WorkspaceConfirmSession.confirm PASS  status={outcome.status}")
 
-vault_content = uat_note.read_text(encoding="utf-8")
-assert f"- [ ] {ACTION_LABEL}" not in vault_content
-assert AI_STATUS_HEADER in vault_content and "✅" in vault_content
-print(f"CHECK 5 Vault state after confirm        PASS")
+    # Refresh must reflect the post-confirm state of the same note that was confirmed.
+    assert session.current_payload is not None
+    assert session.current_payload.body == uat_note.read_text(encoding="utf-8")
+    print(f"CHECK 4 Artifact refresh after confirm  PASS")
 
-shutil.rmtree(vault_uat_dir, ignore_errors=True)
+    vault_content = uat_note.read_text(encoding="utf-8")
+    assert f"- [ ] {ACTION_LABEL}" not in vault_content
+    assert AI_STATUS_HEADER in vault_content and "✅" in vault_content
+    print(f"CHECK 5 Vault state after confirm        PASS")
+
+finally:
+    shutil.rmtree(vault_uat_dir, ignore_errors=True)
 
 print("\n  UAT RESULT:  ALL 5 CHECKS PASSED  ✅")
 PYEOF

--- a/docs/runbooks/UAT_REAL_NOTE_VERTICAL_SLICE.md
+++ b/docs/runbooks/UAT_REAL_NOTE_VERTICAL_SLICE.md
@@ -99,7 +99,6 @@ AID = stable_action_id(ACTION_LABEL)
 
 # UAT note lives inside the vault so the GET endpoint can serve it, and both
 # the confirm writeback and the artifact refresh operate on the same file.
-import shutil
 vault_uat_dir = vault / "_uat_test"
 vault_uat_dir.mkdir(exist_ok=True)
 uat_note = vault_uat_dir / "test_confirm_session.md"
@@ -163,7 +162,13 @@ try:
     print(f"CHECK 5 Vault state after confirm        PASS")
 
 finally:
-    shutil.rmtree(vault_uat_dir, ignore_errors=True)
+    # Remove only the file this run created, not the entire _uat_test directory.
+    # The operator may have pre-existing files under _uat_test; rmtree would wipe them.
+    uat_note.unlink(missing_ok=True)
+    try:
+        vault_uat_dir.rmdir()  # succeeds only if the directory is now empty
+    except OSError:
+        pass
 
 print("\n  UAT RESULT:  ALL 5 CHECKS PASSED  ✅")
 PYEOF


### PR DESCRIPTION
## Direct Repair

Type: docs
Reason: Two P2 inline comments from Codex review of PR #1104 flagged pre-existing issues in files that were not changed by that PR. Addressing them now as a bounded direct repair.
Validation: \`git diff --check\` clean; \`PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/architecture\` — 54 passed (all green, including the previously-failing docs-index test which is now fixed on main).
Issue required: no — bounded direct repair; governing issues #1105 and #1106 were filed for traceability.

## Summary

- **`companion-ui/docs/REAL_NOTE_WORKSPACE_DEV_PAGE.md`**: Added a section-3 notice that \`companion_ui.workspace.serve_dev_page\` does not exist yet and the commands are placeholders. Added \`# placeholder; adapt to your runner\` to the LAN/Tailscale startup command and a "Not yet implemented" callout to the UAT section 5 step 4 command. All three invocation sites now consistently communicate placeholder status.
- **`docs/runbooks/UAT_REAL_NOTE_VERTICAL_SLICE.md`**: Wrapped the mutation and assertion block (after \`uat_note.write_text\`) in \`try/finally\` so \`shutil.rmtree(vault_uat_dir)\` runs unconditionally even when an assertion fails mid-run, preventing test residue from being left in the operator's real vault.

## Changed files

| File | Change |
|---|---|
| `companion-ui/docs/REAL_NOTE_WORKSPACE_DEV_PAGE.md` | Section 3 notice + 2 inline placeholder comments + UAT step 4 callout |
| `docs/runbooks/UAT_REAL_NOTE_VERTICAL_SLICE.md` | try/finally guard around mutation/assertion block |

## Validation performed

```
git diff --check
→ no output (clean)

PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/architecture
→ 54 passed (all green)
```

The previously-failing `test_all_docs_are_listed_in_docs_index` test (caused by `UAT_REAL_NOTE_VERTICAL_SLICE.md` not being in `DOCS_INDEX.md`) now passes — that was fixed in main before this PR; confirmed on this branch.

Closes #1105
Closes #1106