### PR TITLE
feat(companion-ui): add real-note workspace browser dev server (#1103)

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/__init__.py
+++ b/companion-ui/companion-app/companion_ui/workspace/__init__.py
@@ -1,0 +1,10 @@
+"""Companion UI workspace module — real-note workspace dev page and HTTP client.
+
+Provides:
+- WorkspaceHttpClient: transport layer to the runtime API.
+- RealNoteWorkspaceDevPage: in-memory page model for the real-note workspace.
+- serve_dev_page: minimal browser dev server (run with python -m companion_ui.workspace.serve_dev_page).
+
+The workspace module never reads vault files directly.
+Vault binding is owned by the runtime environment, not by Companion UI.
+"""

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -1,0 +1,316 @@
+"""Minimal browser dev server for the real-note workspace page (#1103).
+
+DEV/STAGING ONLY — not for production use.
+
+Does not implement auth, TLS, reverse proxy, or public exposure.
+Calls the configured runtime API through WorkspaceHttpClient
+(GET /api/artifacts/note). Does not read vault files directly.
+Vault binding is determined by the runtime environment, not by this server.
+
+Environment variables:
+    HOST                   Bind address         (default: 127.0.0.1)
+    PORT                   Bind port            (default: 8111)
+    COMPANION_API_BASE_URL Runtime API base URL (default: http://127.0.0.1:18001)
+
+Runtime API port map (docs/ENVIRONMENTS.md):
+    prod → 18000
+    dev  → 18001
+    test → 18002
+
+Companion UI dev server port map:
+    dev  → 8111
+    test → 8112
+    prod → 8113
+
+Local dev:
+    cd companion-ui/companion-app
+    COMPANION_API_BASE_URL=http://127.0.0.1:18001 HOST=127.0.0.1 PORT=8111 \\
+        python -m companion_ui.workspace.serve_dev_page
+
+LAN/Tailscale (explicit operator action required — not the default):
+    cd companion-ui/companion-app
+    COMPANION_API_BASE_URL=http://<host-ip>:18001 HOST=0.0.0.0 PORT=8111 \\
+        python -m companion_ui.workspace.serve_dev_page
+"""
+
+import html as _html
+import os
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Optional
+from urllib.parse import parse_qs, urlparse
+
+from companion_ui.workspace.real_note_workspace_dev_page import (
+    NoteLoadIntent,
+    RealNoteWorkspaceDevPage,
+)
+from companion_ui.workspace.workspace_http_client import WorkspaceHttpClient
+
+_DEFAULT_HOST = "127.0.0.1"
+_DEFAULT_PORT = 8111
+_DEFAULT_API_BASE_URL = "http://127.0.0.1:18001"
+
+
+def load_config() -> dict:
+    """Load server configuration from environment variables.
+
+    Returns a dict with keys: host, port, api_base_url.
+    Defaults: HOST=127.0.0.1, PORT=8111, COMPANION_API_BASE_URL=http://127.0.0.1:18001.
+    """
+    return {
+        "host": os.environ.get("HOST", _DEFAULT_HOST),
+        "port": int(os.environ.get("PORT", str(_DEFAULT_PORT))),
+        "api_base_url": os.environ.get("COMPANION_API_BASE_URL", _DEFAULT_API_BASE_URL),
+    }
+
+
+def _e(value: str) -> str:
+    """HTML-escape a string for safe inline output."""
+    return _html.escape(str(value))
+
+
+def _render_note_section(fields: dict) -> str:
+    """Render the note view table and body preview from render_fields() output."""
+    return f"""
+  <div class="note-view">
+    <table>
+      <tr><th>Title</th><td>{_e(fields.get("title", ""))}</td></tr>
+      <tr><th>Note path</th><td><code>{_e(fields.get("note_path", ""))}</code></td></tr>
+      <tr><th>Artifact ID</th><td><code>{_e(fields.get("artifact_id", ""))}</code></td></tr>
+      <tr><th>Content hash</th><td><code>{_e(fields.get("content_hash", ""))}</code></td></tr>
+    </table>
+    <h3>Body</h3>
+    <pre class="body-preview">{_e(fields.get("body", ""))}</pre>
+  </div>
+  <div class="rail-placeholder">
+    [{_e(fields.get("panel_rail", "Panel / agent rail placeholder"))}]
+  </div>"""
+
+
+def _render_error_section(error: str) -> str:
+    """Render a visible error state section."""
+    return f"""
+  <div class="error">
+    <strong>Error loading note</strong><br>
+    <code>{_e(error)}</code>
+  </div>"""
+
+
+def render_index_html(
+    *,
+    api_base_url: str,
+    note_path: str = "",
+    fields: Optional[dict] = None,
+    error: str = "",
+) -> str:
+    """Render the workspace dev page as plain HTML.
+
+    Pure function — no network calls, no file I/O.
+    All user-supplied values are HTML-escaped.
+    """
+    content_section = ""
+    if error:
+        content_section = _render_error_section(error)
+    elif fields is not None:
+        content_section = _render_note_section(fields)
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Companion UI — Real-Note Workspace [DEV]</title>
+  <style>
+    body {{
+      font-family: monospace;
+      max-width: 960px;
+      margin: 2rem auto;
+      padding: 0 1rem;
+      color: #222;
+    }}
+    .dev-banner {{
+      background: #ffcc00;
+      border: 2px solid #cc8800;
+      padding: 0.5rem 1rem;
+      margin-bottom: 1.5rem;
+      font-weight: bold;
+    }}
+    .api-target {{
+      background: #eef2ff;
+      border: 1px solid #aab;
+      padding: 0.5rem 1rem;
+      margin-bottom: 1.5rem;
+      font-size: 0.95em;
+    }}
+    .load-form {{
+      margin-bottom: 1.5rem;
+    }}
+    .load-form input[type=text] {{
+      width: 55%;
+      padding: 0.35rem 0.5rem;
+      font-family: monospace;
+      font-size: 1em;
+    }}
+    .load-form button {{
+      padding: 0.35rem 1.2rem;
+      margin-left: 0.5rem;
+      cursor: pointer;
+    }}
+    .error {{
+      background: #fff0f0;
+      border: 2px solid #c00;
+      padding: 0.75rem 1rem;
+      margin: 1rem 0;
+      color: #800;
+    }}
+    .note-view table {{
+      border-collapse: collapse;
+      width: 100%;
+      margin-bottom: 1rem;
+    }}
+    .note-view th,
+    .note-view td {{
+      border: 1px solid #ccc;
+      padding: 0.4rem 0.75rem;
+      text-align: left;
+      vertical-align: top;
+    }}
+    .note-view th {{
+      width: 160px;
+      background: #f4f4f4;
+    }}
+    pre.body-preview {{
+      background: #f8f8f8;
+      border: 1px solid #ddd;
+      padding: 1rem;
+      white-space: pre-wrap;
+      word-break: break-word;
+      max-height: 420px;
+      overflow-y: auto;
+      margin: 0;
+    }}
+    .rail-placeholder {{
+      background: #f0f0f0;
+      border: 1px dashed #999;
+      padding: 1rem;
+      margin-top: 1.25rem;
+      color: #666;
+      font-style: italic;
+    }}
+  </style>
+</head>
+<body>
+  <div class="dev-banner">[DEV/STAGING ONLY — not for production use]</div>
+  <h1>Companion UI — Real-Note Workspace</h1>
+  <div class="api-target">
+    <strong>Runtime API:</strong> <code>{_e(api_base_url)}</code>
+  </div>
+  <div class="load-form">
+    <form method="GET" action="/">
+      <label for="note_path"><strong>Note path:</strong></label><br>
+      <input
+        type="text"
+        id="note_path"
+        name="note_path"
+        value="{_e(note_path)}"
+        placeholder="Some/Note.md"
+        autocomplete="off">
+      <button type="submit">Load</button>
+    </form>
+  </div>
+  {content_section}
+</body>
+</html>"""
+
+
+def handle_get(
+    *,
+    query_string: str,
+    client: WorkspaceHttpClient,
+    api_base_url: str,
+) -> str:
+    """Parse query string, optionally load a note, and return full page HTML.
+
+    Pure except for the WorkspaceHttpClient network call when note_path is present.
+    """
+    params = parse_qs(query_string)
+    note_path = params.get("note_path", [""])[0].strip()
+    fields: Optional[dict] = None
+    error = ""
+
+    if note_path:
+        page = RealNoteWorkspaceDevPage(client)
+        state = page.load(NoteLoadIntent(note_path=note_path))
+        if state.is_loaded:
+            fields = page.render_fields()
+        else:
+            error = state.error or "Unknown error"
+
+    return render_index_html(
+        api_base_url=api_base_url,
+        note_path=note_path,
+        fields=fields,
+        error=error,
+    )
+
+
+def make_handler(*, client: WorkspaceHttpClient, api_base_url: str) -> type:
+    """Return a configured BaseHTTPRequestHandler subclass.
+
+    The returned class closes over client and api_base_url as class attributes
+    so each request instance can reach them without global state.
+    """
+
+    class _Handler(BaseHTTPRequestHandler):
+        _client = client
+        _api_base_url = api_base_url
+
+        def do_GET(self) -> None:
+            parsed = urlparse(self.path)
+            body = handle_get(
+                query_string=parsed.query,
+                client=self._client,
+                api_base_url=self._api_base_url,
+            ).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, fmt: str, *args: object) -> None:
+            pass  # suppress per-request log noise; startup banner handles visibility
+
+    return _Handler
+
+
+def main() -> None:
+    """Entry point: read env config, bind server, serve until KeyboardInterrupt."""
+    config = load_config()
+    client = WorkspaceHttpClient(base_url=config["api_base_url"])
+    handler = make_handler(client=client, api_base_url=config["api_base_url"])
+    server = HTTPServer((config["host"], config["port"]), handler)
+    print(
+        "[companion-ui] DEV/STAGING ONLY — real-note workspace dev server",
+        flush=True,
+    )
+    print(
+        f"[companion-ui] Listening:    http://{config['host']}:{config['port']}/",
+        flush=True,
+    )
+    print(
+        f"[companion-ui] Runtime API:  {config['api_base_url']}",
+        flush=True,
+    )
+    print(
+        "[companion-ui] Stop with Ctrl-C",
+        flush=True,
+    )
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        server.server_close()
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/companion-ui/docs/REAL_NOTE_WORKSPACE_DEV_PAGE.md
+++ b/companion-ui/docs/REAL_NOTE_WORKSPACE_DEV_PAGE.md
@@ -70,17 +70,7 @@ python -m app.cli status
 
 ## 3. How to Start the Companion UI Dev Page
 
-> **No browser dev server is shipped yet.**
-> `companion_ui.workspace.serve_dev_page` does not exist. The commands below
-> are placeholders showing the intended invocation shape for when the minimal
-> browser dev server is implemented (the next implementation slice per
-> `companion-ui/docs/COMPANION_UI_TARGET_ARCHITECTURE.md` section 6). Until
-> then, run the page model directly from a script or REPL as described in the
-> inline comments below.
-
-The dev page is currently a Python page model (`RealNoteWorkspaceDevPage`).
-To run it as a local HTTP dev server, use a minimal WSGI/ASGI wrapper or
-call the model directly from a script/REPL.
+The browser dev server ships as `companion_ui.workspace.serve_dev_page` (#1103).
 
 ### Environment variables
 
@@ -90,10 +80,7 @@ call the model directly from a script/REPL.
 | `HOST`                 | `127.0.0.1`                 | Bind address for the dev server               |
 | `PORT`                 | `8111` (dev), `8112` (test), `8113` (prod) | Dev server listen port        |
 
-### Suggested Companion UI dev page ports
-
-Since there are no canonical Companion UI server ports in the repo yet, the
-following convention is suggested:
+### Companion UI dev page ports
 
 | Environment | Companion UI dev page port |
 |-------------|---------------------------|
@@ -104,23 +91,32 @@ following convention is suggested:
 ### Local-only startup (default)
 
 ```bash
-# dev page pointing at dev runtime
+cd companion-ui/companion-app
 COMPANION_API_BASE_URL=http://127.0.0.1:18001 HOST=127.0.0.1 PORT=8111 \
-  python -m companion_ui.workspace.serve_dev_page  # placeholder; adapt to your runner
+  python -m companion_ui.workspace.serve_dev_page
+```
+
+Then open:
+
+```
+http://127.0.0.1:8111/?note_path=<valid-dev-note-path>
 ```
 
 ### Explicit LAN/Tailscale startup
 
+Only use this when intentionally enabling LAN or Tailscale access.
+`HOST=0.0.0.0` must be explicit. Do not expose publicly.
+
 ```bash
-# Explicit bind to all interfaces — only do this for intentional LAN/Tailscale access
-COMPANION_API_BASE_URL=http://<mac-mini-ip>:18001 HOST=0.0.0.0 PORT=8111 \
-  python -m companion_ui.workspace.serve_dev_page  # placeholder; adapt to your runner
+cd companion-ui/companion-app
+COMPANION_API_BASE_URL=http://<host-lan-or-tailnet-ip>:18001 HOST=0.0.0.0 PORT=8111 \
+  python -m companion_ui.workspace.serve_dev_page
 ```
 
-Then from another device:
+Then from a trusted device on the same LAN or Tailnet:
 
 ```
-http://<mac-mini-lan-or-tailnet-ip>:8111/
+http://<host-lan-or-tailnet-ip>:8111/?note_path=<valid-dev-note-path>
 ```
 
 ---
@@ -171,14 +167,10 @@ targets. The runtime owns environment and vault binding.
 4. **Start the matching Companion UI dev/staging page on the matching port.**
 
    ```bash
+   cd companion-ui/companion-app
    COMPANION_API_BASE_URL=http://127.0.0.1:<api-port> PORT=<ui-port> \
-     HOST=127.0.0.1 python -m companion_ui.workspace.serve_dev_page  # placeholder; adapt to your runner
+     HOST=127.0.0.1 python -m companion_ui.workspace.serve_dev_page
    ```
-
-   > **Not yet implemented.** `companion_ui.workspace.serve_dev_page` is a
-   > placeholder for the browser dev server (next implementation slice). Until
-   > it ships, run the `RealNoteWorkspaceDevPage` model directly from a
-   > script or REPL.
 
 5. **Set the UI API base URL to the matching runtime API port.**
 

--- a/tests/companion_ui/test_real_note_workspace_dev_server.py
+++ b/tests/companion_ui/test_real_note_workspace_dev_server.py
@@ -1,0 +1,519 @@
+"""Tests for the real-note workspace browser dev server (#1103).
+
+Verifies:
+- Module exists and can be imported.
+- Default config uses HOST=127.0.0.1, PORT=8111, COMPANION_API_BASE_URL=http://127.0.0.1:18001.
+- Env overrides for host/port/API base URL are respected.
+- render_index_html produces dev/staging marker.
+- render_index_html includes configured API base URL.
+- render_index_html includes note_path input.
+- render_index_html renders note fields (title/path/artifact/body/hash) from render_fields() dict.
+- render_index_html renders visible error state.
+- render_index_html includes Panel/agent rail placeholder when note is present.
+- handle_get calls the page/client path and renders title/path/artifact/body/hash on success.
+- handle_get renders error state on WorkspaceClientError.
+- Full HTTP round-trip: GET / returns HTML with dev marker.
+- Full HTTP round-trip: GET /?note_path=... renders note fields.
+- Full HTTP round-trip: error state is visible.
+- No direct vault file access in serve_dev_page module.
+- No named vaults are used as code configuration values.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import threading
+from http.server import HTTPServer
+from typing import Any, Optional
+
+import httpx
+import pytest
+
+from companion_ui.workspace.workspace_http_client import WorkspaceClientNetworkError
+
+
+# ---------------------------------------------------------------------------
+# Fake HTTP client that matches the WorkspaceHttpClient.get / .post protocol
+# ---------------------------------------------------------------------------
+
+
+class _FakeClient:
+    """Fake HTTP client — no network calls. Implements get/post protocol."""
+
+    def __init__(
+        self,
+        *,
+        get_result: Optional[dict] = None,
+        get_error: Optional[Exception] = None,
+    ) -> None:
+        self._get_result = get_result
+        self._get_error = get_error
+        self.get_calls: list[tuple[str, dict]] = []
+
+    def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        self.get_calls.append((url, params))
+        if self._get_error is not None:
+            raise self._get_error
+        return self._get_result or {}
+
+    def post(self, url: str, *, json: dict[str, Any]) -> dict[str, Any]:
+        return {}
+
+
+def _note_payload(
+    note_path: str = "Some/Note.md",
+    title: str = "Some Note",
+    artifact_id: str = "art-123",
+    content_hash: str = "sha256-deadbeef",
+    body: str = "This is the note body.",
+) -> dict:
+    return {
+        "note_path": note_path,
+        "title": title,
+        "artifact_id": artifact_id,
+        "content_hash": content_hash,
+        "body": body,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Live HTTP server fixtures
+# ---------------------------------------------------------------------------
+
+
+def _start_server(client: _FakeClient, api_base_url: str) -> tuple[HTTPServer, int]:
+    from companion_ui.workspace.serve_dev_page import make_handler
+
+    handler = make_handler(client=client, api_base_url=api_base_url)
+    server = HTTPServer(("127.0.0.1", 0), handler)  # port 0 = OS-assigned
+    port = server.server_address[1]
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    return server, port
+
+
+@pytest.fixture
+def live_server_ok():
+    """Live server with a fake client that returns a note successfully."""
+    payload = _note_payload()
+    client = _FakeClient(get_result=payload)
+    server, port = _start_server(client, "http://127.0.0.1:18001")
+    yield {
+        "port": port,
+        "client": client,
+        "payload": payload,
+        "api_base_url": "http://127.0.0.1:18001",
+    }
+    server.shutdown()
+
+
+@pytest.fixture
+def live_server_error():
+    """Live server with a fake client that always raises a network error."""
+    client = _FakeClient(
+        get_error=WorkspaceClientNetworkError("Connection refused"),
+    )
+    server, port = _start_server(client, "http://127.0.0.1:19999")
+    yield {"port": port, "client": client, "api_base_url": "http://127.0.0.1:19999"}
+    server.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Import / module-level tests
+# ---------------------------------------------------------------------------
+
+
+class TestModuleImport:
+    def test_module_importable(self) -> None:
+        import companion_ui.workspace.serve_dev_page  # noqa: F401
+
+    def test_load_config_importable(self) -> None:
+        from companion_ui.workspace.serve_dev_page import load_config
+
+        assert callable(load_config)
+
+    def test_render_index_html_importable(self) -> None:
+        from companion_ui.workspace.serve_dev_page import render_index_html
+
+        assert callable(render_index_html)
+
+    def test_handle_get_importable(self) -> None:
+        from companion_ui.workspace.serve_dev_page import handle_get
+
+        assert callable(handle_get)
+
+    def test_make_handler_importable(self) -> None:
+        from companion_ui.workspace.serve_dev_page import make_handler
+
+        assert callable(make_handler)
+
+    def test_main_importable(self) -> None:
+        from companion_ui.workspace.serve_dev_page import main
+
+        assert callable(main)
+
+
+# ---------------------------------------------------------------------------
+# Default config and env override tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoadConfig:
+    def test_default_host(self, monkeypatch) -> None:
+        monkeypatch.delenv("HOST", raising=False)
+        from companion_ui.workspace.serve_dev_page import load_config
+
+        assert load_config()["host"] == "127.0.0.1"
+
+    def test_default_port(self, monkeypatch) -> None:
+        monkeypatch.delenv("PORT", raising=False)
+        from companion_ui.workspace.serve_dev_page import load_config
+
+        assert load_config()["port"] == 8111
+
+    def test_default_api_base_url(self, monkeypatch) -> None:
+        monkeypatch.delenv("COMPANION_API_BASE_URL", raising=False)
+        from companion_ui.workspace.serve_dev_page import load_config
+
+        assert load_config()["api_base_url"] == "http://127.0.0.1:18001"
+
+    def test_host_override(self, monkeypatch) -> None:
+        monkeypatch.setenv("HOST", "0.0.0.0")
+        from companion_ui.workspace.serve_dev_page import load_config
+
+        assert load_config()["host"] == "0.0.0.0"
+
+    def test_port_override(self, monkeypatch) -> None:
+        monkeypatch.setenv("PORT", "8112")
+        from companion_ui.workspace.serve_dev_page import load_config
+
+        assert load_config()["port"] == 8112
+
+    def test_api_base_url_override(self, monkeypatch) -> None:
+        monkeypatch.setenv("COMPANION_API_BASE_URL", "http://192.168.1.10:18001")
+        from companion_ui.workspace.serve_dev_page import load_config
+
+        assert load_config()["api_base_url"] == "http://192.168.1.10:18001"
+
+    def test_all_overrides_together(self, monkeypatch) -> None:
+        monkeypatch.setenv("HOST", "0.0.0.0")
+        monkeypatch.setenv("PORT", "8113")
+        monkeypatch.setenv("COMPANION_API_BASE_URL", "http://127.0.0.1:18000")
+        from companion_ui.workspace.serve_dev_page import load_config
+
+        cfg = load_config()
+        assert cfg == {
+            "host": "0.0.0.0",
+            "port": 8113,
+            "api_base_url": "http://127.0.0.1:18000",
+        }
+
+
+# ---------------------------------------------------------------------------
+# render_index_html — pure function tests
+# ---------------------------------------------------------------------------
+
+
+class TestRenderIndexHtml:
+    def test_contains_dev_staging_marker(self) -> None:
+        from companion_ui.workspace.serve_dev_page import render_index_html
+
+        html = render_index_html(api_base_url="http://127.0.0.1:18001")
+        assert "DEV" in html or "STAGING" in html
+
+    def test_contains_api_base_url(self) -> None:
+        from companion_ui.workspace.serve_dev_page import render_index_html
+
+        html = render_index_html(api_base_url="http://127.0.0.1:18001")
+        assert "http://127.0.0.1:18001" in html
+
+    def test_contains_note_path_input(self) -> None:
+        from companion_ui.workspace.serve_dev_page import render_index_html
+
+        html = render_index_html(api_base_url="http://127.0.0.1:18001")
+        assert 'name="note_path"' in html
+
+    def test_contains_load_button(self) -> None:
+        from companion_ui.workspace.serve_dev_page import render_index_html
+
+        html = render_index_html(api_base_url="http://127.0.0.1:18001")
+        assert "<button" in html
+
+    def test_note_path_value_populated_in_input(self) -> None:
+        from companion_ui.workspace.serve_dev_page import render_index_html
+
+        html = render_index_html(
+            api_base_url="http://127.0.0.1:18001",
+            note_path="Inbox/Todo.md",
+        )
+        assert "Inbox/Todo.md" in html
+
+    def test_renders_fields_from_dict(self) -> None:
+        from companion_ui.workspace.serve_dev_page import render_index_html
+
+        fields = {
+            "title": "Some Note",
+            "note_path": "Some/Note.md",
+            "artifact_id": "art-123",
+            "content_hash": "sha256-deadbeef",
+            "body": "This is the note body.",
+            "panel_rail": "Panel / agent rail placeholder",
+            "is_production_ui": False,
+            "dev_page_label": "dev/staging",
+        }
+        html = render_index_html(
+            api_base_url="http://127.0.0.1:18001",
+            note_path="Some/Note.md",
+            fields=fields,
+        )
+        assert "Some Note" in html
+        assert "Some/Note.md" in html
+        assert "art-123" in html
+        assert "sha256-deadbeef" in html
+        assert "This is the note body." in html
+
+    def test_renders_rail_placeholder_when_fields_present(self) -> None:
+        from companion_ui.workspace.serve_dev_page import render_index_html
+
+        fields = {
+            "title": "T",
+            "note_path": "N.md",
+            "artifact_id": "a",
+            "content_hash": "h",
+            "body": "b",
+            "panel_rail": "Panel / agent rail placeholder",
+            "is_production_ui": False,
+            "dev_page_label": "dev/staging",
+        }
+        html = render_index_html(
+            api_base_url="http://127.0.0.1:18001",
+            fields=fields,
+        )
+        assert "rail" in html.lower() or "panel" in html.lower()
+
+    def test_error_state_is_visible(self) -> None:
+        from companion_ui.workspace.serve_dev_page import render_index_html
+
+        html = render_index_html(
+            api_base_url="http://127.0.0.1:19999",
+            note_path="Some/Note.md",
+            error="Connection refused",
+        )
+        assert "error" in html.lower() or "Error" in html
+        assert "Connection refused" in html
+
+    def test_note_content_not_shown_when_only_error(self) -> None:
+        from companion_ui.workspace.serve_dev_page import render_index_html
+
+        html = render_index_html(
+            api_base_url="http://127.0.0.1:19999",
+            error="Connection refused",
+        )
+        assert "Artifact ID" not in html
+
+    def test_html_escaping_in_note_path(self) -> None:
+        from companion_ui.workspace.serve_dev_page import render_index_html
+
+        html = render_index_html(
+            api_base_url="http://127.0.0.1:18001",
+            note_path='<script>alert("xss")</script>',
+        )
+        assert "<script>" not in html
+        assert "&lt;script&gt;" in html
+
+    def test_html_escaping_in_error(self) -> None:
+        from companion_ui.workspace.serve_dev_page import render_index_html
+
+        html = render_index_html(
+            api_base_url="http://127.0.0.1:18001",
+            error="<b>bad</b>",
+        )
+        assert "<b>bad</b>" not in html
+        assert "&lt;b&gt;" in html
+
+    def test_valid_html_doctype(self) -> None:
+        from companion_ui.workspace.serve_dev_page import render_index_html
+
+        html = render_index_html(api_base_url="http://127.0.0.1:18001")
+        assert html.strip().startswith("<!DOCTYPE html>")
+
+
+# ---------------------------------------------------------------------------
+# handle_get — unit tests with fake client
+# ---------------------------------------------------------------------------
+
+
+class TestHandleGet:
+    def test_empty_query_renders_index_no_note(self) -> None:
+        from companion_ui.workspace.serve_dev_page import handle_get
+
+        client = _FakeClient()
+        html = handle_get(
+            query_string="",
+            client=client,
+            api_base_url="http://127.0.0.1:18001",
+        )
+        assert "DEV" in html or "STAGING" in html
+        assert client.get_calls == []
+
+    def test_note_path_param_triggers_api_call(self) -> None:
+        from companion_ui.workspace.serve_dev_page import handle_get
+
+        client = _FakeClient(get_result=_note_payload())
+        handle_get(
+            query_string="note_path=Some%2FNote.md",
+            client=client,
+            api_base_url="http://127.0.0.1:18001",
+        )
+        assert len(client.get_calls) == 1
+        url, params = client.get_calls[0]
+        assert url == "/api/artifacts/note"
+        assert params.get("note_path") == "Some/Note.md"
+
+    def test_successful_load_renders_note_fields(self) -> None:
+        from companion_ui.workspace.serve_dev_page import handle_get
+
+        payload = _note_payload()
+        client = _FakeClient(get_result=payload)
+        html = handle_get(
+            query_string="note_path=Some%2FNote.md",
+            client=client,
+            api_base_url="http://127.0.0.1:18001",
+        )
+        assert "Some Note" in html
+        assert "art-123" in html
+        assert "sha256-deadbeef" in html
+        assert "This is the note body." in html
+
+    def test_client_error_renders_error_state(self) -> None:
+        from companion_ui.workspace.serve_dev_page import handle_get
+
+        client = _FakeClient(
+            get_error=WorkspaceClientNetworkError("Connection refused"),
+        )
+        html = handle_get(
+            query_string="note_path=Some%2FNote.md",
+            client=client,
+            api_base_url="http://127.0.0.1:19999",
+        )
+        assert "Connection refused" in html
+        assert "error" in html.lower() or "Error" in html
+
+    def test_api_base_url_shown_in_output(self) -> None:
+        from companion_ui.workspace.serve_dev_page import handle_get
+
+        client = _FakeClient()
+        html = handle_get(
+            query_string="",
+            client=client,
+            api_base_url="http://192.168.1.42:18001",
+        )
+        assert "http://192.168.1.42:18001" in html
+
+
+# ---------------------------------------------------------------------------
+# Full HTTP round-trip tests
+# ---------------------------------------------------------------------------
+
+
+class TestLiveServer:
+    def test_get_root_returns_200(self, live_server_ok) -> None:
+        resp = httpx.get(f"http://127.0.0.1:{live_server_ok['port']}/")
+        assert resp.status_code == 200
+
+    def test_get_root_has_dev_marker(self, live_server_ok) -> None:
+        resp = httpx.get(f"http://127.0.0.1:{live_server_ok['port']}/")
+        assert "DEV" in resp.text or "STAGING" in resp.text
+
+    def test_get_root_has_api_base_url(self, live_server_ok) -> None:
+        resp = httpx.get(f"http://127.0.0.1:{live_server_ok['port']}/")
+        assert live_server_ok["api_base_url"] in resp.text
+
+    def test_get_root_has_note_path_input(self, live_server_ok) -> None:
+        resp = httpx.get(f"http://127.0.0.1:{live_server_ok['port']}/")
+        assert "note_path" in resp.text
+
+    def test_get_with_note_path_renders_note(self, live_server_ok) -> None:
+        resp = httpx.get(
+            f"http://127.0.0.1:{live_server_ok['port']}/",
+            params={"note_path": "Some/Note.md"},
+        )
+        body = resp.text
+        assert "Some Note" in body
+        assert "art-123" in body
+        assert "sha256-deadbeef" in body
+        assert "This is the note body." in body
+
+    def test_get_content_type_is_html(self, live_server_ok) -> None:
+        resp = httpx.get(f"http://127.0.0.1:{live_server_ok['port']}/")
+        assert "text/html" in resp.headers.get("content-type", "")
+
+    def test_error_state_rendered_on_client_failure(self, live_server_error) -> None:
+        resp = httpx.get(
+            f"http://127.0.0.1:{live_server_error['port']}/",
+            params={"note_path": "Missing/Note.md"},
+        )
+        assert resp.status_code == 200
+        assert "error" in resp.text.lower() or "Error" in resp.text
+        assert "Connection refused" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Boundary / safety checks
+# ---------------------------------------------------------------------------
+
+
+class TestDevServerBoundaries:
+    def test_no_direct_vault_file_access_in_module(self) -> None:
+        """Architecture guard: serve_dev_page must not access vault files directly."""
+        vault_io_calls = {"read_text", "read_bytes", "write_text", "write_bytes"}
+        srv_file = (
+            pathlib.Path(__file__).resolve().parents[2]
+            / "companion-ui"
+            / "companion-app"
+            / "companion_ui"
+            / "workspace"
+            / "serve_dev_page.py"
+        )
+        assert srv_file.exists()
+        tree = ast.parse(srv_file.read_text(encoding="utf-8"))
+        violations = [
+            f"line {node.lineno}: .{node.attr}"
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Attribute) and node.attr in vault_io_calls
+        ]
+        assert not violations, f"Unexpected vault I/O calls: {violations}"
+
+    def test_no_named_vaults_as_config_values(self) -> None:
+        import companion_ui.workspace.serve_dev_page as mod
+
+        src = pathlib.Path(mod.__file__).read_text(encoding="utf-8")
+        # Vault names must not appear as code configuration values.
+        # They are allowed only in documentation and comments (ASCII subset).
+        tree = ast.parse(src)
+        vault_names = {"Nifelheim", "Bifrost", "Midgard"}
+        string_violations = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                for name in vault_names:
+                    if name in node.value:
+                        string_violations.append(
+                            f"line {node.lineno}: string literal contains {name!r}"
+                        )
+        assert not string_violations, f"Named vault found in code string: {string_violations}"
+
+    def test_default_bind_is_local_only(self) -> None:
+        from companion_ui.workspace.serve_dev_page import _DEFAULT_HOST
+
+        assert _DEFAULT_HOST == "127.0.0.1"
+
+    def test_default_port_is_8111(self) -> None:
+        from companion_ui.workspace.serve_dev_page import _DEFAULT_PORT
+
+        assert _DEFAULT_PORT == 8111
+
+    def test_default_api_base_url_points_at_dev_runtime(self) -> None:
+        from companion_ui.workspace.serve_dev_page import _DEFAULT_API_BASE_URL
+
+        assert _DEFAULT_API_BASE_URL == "http://127.0.0.1:18001"


### PR DESCRIPTION
## Summary

- Adds the browser dev server `companion_ui.workspace.serve_dev_page` (#1103).
- Uses the `WorkspaceHttpClient` and `RealNoteWorkspaceDevPage` models delivered by #1101 (already on main).
- Updates `companion-ui/docs/REAL_NOTE_WORKSPACE_DEV_PAGE.md` to replace placeholder commands with real ones.
- Addresses Codex review comment: endpoint is now `/api/artifacts/note` via `WorkspaceHttpClient.get()`, not `/workspace/note`.

Closes #1103

## Dependency note — #1102 / PR #1104

Issue #1102 is delivered and closed. The post-merge owner-doc loop for PR #1104 was not confirmed as completed or explicitly deferred at the time of this PR. No #1102 docs were altered beyond the placeholder-to-real-command update required by this issue.

## Changed files (vs main)

| File | Role |
|------|------|
| `companion-ui/companion-app/companion_ui/workspace/__init__.py` | Package docstring (was empty) |
| `companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py` | Browser dev server — main deliverable |
| `companion-ui/docs/REAL_NOTE_WORKSPACE_DEV_PAGE.md` | Replace placeholder commands with real commands |
| `tests/companion_ui/test_real_note_workspace_dev_server.py` | Dev server tests |

## Validation commands and output

```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/
# → 623 passed

ruff check companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py \
  tests/companion_ui/test_real_note_workspace_dev_server.py
# → All checks passed!

git diff --check
# → (no output)
```

## Exact start commands

### Local dev

```bash
cd companion-ui/companion-app
COMPANION_API_BASE_URL=http://127.0.0.1:18001 HOST=127.0.0.1 PORT=8111 \
  python -m companion_ui.workspace.serve_dev_page
```

Open: `http://127.0.0.1:8111/?note_path=<valid-dev-note-path>`

### LAN/Tailscale (explicit operator action required)

```bash
cd companion-ui/companion-app
COMPANION_API_BASE_URL=http://<host-lan-or-tailnet-ip>:18001 HOST=0.0.0.0 PORT=8111 \
  python -m companion_ui.workspace.serve_dev_page
```

Open from trusted device: `http://<host-lan-or-tailnet-ip>:8111/?note_path=<valid-dev-note-path>`

## Manual UAT notes

Not performed (no runtime API available at PR time). Automated tests use fake HTTP clients that implement the `WorkspaceHttpClient` `get`/`post` protocol and a local `HTTPServer` bound to port 0.

## Boundary statement

This PR adds a minimal browser-accessible dev/staging server for the existing real-note workspace page model. The server calls the configured runtime API through the Companion UI HTTP client (`GET /api/artifacts/note`) and does not read vault files directly. It does not choose Midgård, Nifelheim, Bifröst, or any other vault. Environment/vault binding remains owned by the runtime. The server binds local-only by default; LAN/Tailscale access requires explicit operator configuration. This PR does not implement production UI, auth, TLS, reverse proxy, public exposure, native apps, PWA behavior, Canvas editing, or proposal generation.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)