### PR TITLE
fix(startup): prevent dev compose collisions with prod stack

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,11 +2,11 @@ services:
   db:
     environment:
       POSTGRES_DB: app_dev
-    ports:
+    ports: !override
       - "15433:5432"
 
   api:
-    ports:
+    ports: !override
       - "18001:8000"
     environment:
       PKM_ENVIRONMENT: dev

--- a/scripts/start_full_system.sh
+++ b/scripts/start_full_system.sh
@@ -592,12 +592,39 @@ if [ -z "${START_WORKER:-}" ]; then
     START_WORKER=0
   fi
 fi
+resolve_channel_defaults() {
+  local raw_env normalized_env
+  raw_env="${PKM_ENVIRONMENT:-${ENVIRONMENT:-}}"
+  normalized_env="$(printf "%s" "$raw_env" | tr '[:upper:]' '[:lower:]' | xargs)"
+  case "$normalized_env" in
+    dev)
+      COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.yaml:docker-compose.dev.yml}"
+      COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-pkm-dev}"
+      API_BASE_URL="${API_BASE_URL:-http://127.0.0.1:18001}"
+      ;;
+    test)
+      COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.yaml:docker-compose.test.yml}"
+      COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-pkm-test}"
+      API_BASE_URL="${API_BASE_URL:-http://127.0.0.1:18002}"
+      ;;
+    prod|"")
+      COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.yaml:docker-compose.prod.yml}"
+      COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-pkm-prod}"
+      API_BASE_URL="${API_BASE_URL:-http://127.0.0.1:18000}"
+      ;;
+    *)
+      API_BASE_URL="${API_BASE_URL:-http://127.0.0.1:18000}"
+      ;;
+  esac
+  export COMPOSE_FILE COMPOSE_PROJECT_NAME API_BASE_URL
+}
+
 START_FLIGHT_RECORDER="${START_FLIGHT_RECORDER:-1}"
 FLIGHT_RECORDER_INTERVAL="${FLIGHT_RECORDER_INTERVAL:-5}"
 FLIGHT_RECORDER_DURATION="${FLIGHT_RECORDER_DURATION:-0}"
 VERIFY_ACTIVE="${VERIFY_ACTIVE:-0}"
 ALLOW_LEGACY_VAULT="${ALLOW_LEGACY_VAULT:-0}"
-API_BASE_URL="${API_BASE_URL:-http://127.0.0.1:18000}"
+resolve_channel_defaults
 API_BASE_URL="${API_BASE_URL%/}"
 HEALTH_ENDPOINT="${HEALTH_ENDPOINT:-$API_BASE_URL/healthz}"
 HEALTH_MAX_ATTEMPTS="${HEALTH_MAX_ATTEMPTS:-12}"
@@ -741,8 +768,71 @@ run_docker_compose() {
   fi
 }
 
+check_compose_port_conflicts() {
+  local config_json
+  if ! config_json=$(run_docker_compose config --format json 2>/dev/null); then
+    return 0
+  fi
+  CONFIG_JSON="$config_json" python - <<'PY'
+import json
+import os
+import re
+import subprocess
+import sys
+
+project = os.environ.get("COMPOSE_PROJECT_NAME", "<default>")
+environment = os.environ.get("PKM_ENVIRONMENT") or os.environ.get("ENVIRONMENT") or "prod(default)"
+
+try:
+    config = json.loads(os.environ["CONFIG_JSON"])
+except Exception:
+    sys.exit(0)
+
+ps = subprocess.run(
+    ["docker", "ps", "--format", "{{.Names}}\t{{.Ports}}"],
+    capture_output=True,
+    text=True,
+    check=False,
+)
+running = []
+for line in ps.stdout.splitlines():
+    parts = line.split("\t", 1)
+    if len(parts) == 2:
+        running.append((parts[0], parts[1]))
+
+collisions = []
+for service_name, service in (config.get("services") or {}).items():
+    for port in service.get("ports") or []:
+        published = str(port.get("published") or "").strip()
+        if not published:
+            continue
+        pattern = re.compile(rf"(^|[^\d]){re.escape(published)}->")
+        for container_name, ports in running:
+            if container_name.startswith(f"{project}-"):
+                continue
+            if pattern.search(ports):
+                collisions.append((service_name, published, container_name))
+                break
+
+if collisions:
+    print("ERROR: Port preflight failed before compose up.", file=sys.stderr)
+    print(f"Target environment={environment}, compose project={project}", file=sys.stderr)
+    for service_name, published, owner in collisions:
+        print(
+            f"  service '{service_name}' needs host port {published}, already used by '{owner}'",
+            file=sys.stderr,
+        )
+    print("Safe next actions:", file=sys.stderr)
+    print("  - Start with the canonical env-specific target (prod/test/dev).", file=sys.stderr)
+    print("  - If owner is stale same-environment stack, stop only that project.", file=sys.stderr)
+    print("  - Do not blindly stop unrelated prod/test containers.", file=sys.stderr)
+    sys.exit(19)
+PY
+}
+
 run_preflight
 start_startup_watchdog "$STARTUP_TIMEOUT_SECONDS"
+check_compose_port_conflicts
 
 llm_provider="${LLM_PROVIDER:-}"
 llm_provider=$(printf "%s" "$llm_provider" | tr '[:upper:]' '[:lower:]')

--- a/scripts/start_full_system.sh
+++ b/scripts/start_full_system.sh
@@ -769,11 +769,12 @@ run_docker_compose() {
 }
 
 check_compose_port_conflicts() {
+  local target_services=("$@")
   local config_json
   if ! config_json=$(run_docker_compose config --format json 2>/dev/null); then
     return 0
   fi
-  CONFIG_JSON="$config_json" python - <<'PY'
+  CONFIG_JSON="$config_json" TARGET_SERVICES="${target_services[*]:-}" python - <<'PY'
 import json
 import os
 import re
@@ -787,6 +788,12 @@ try:
     config = json.loads(os.environ["CONFIG_JSON"])
 except Exception:
     sys.exit(0)
+
+target_services_raw = (os.environ.get("TARGET_SERVICES") or "").strip()
+if target_services_raw:
+    target_services = set(target_services_raw.split())
+else:
+    target_services = set()
 
 ps = subprocess.run(
     ["docker", "ps", "--format", "{{.Names}}\t{{.Ports}}"],
@@ -802,6 +809,8 @@ for line in ps.stdout.splitlines():
 
 collisions = []
 for service_name, service in (config.get("services") or {}).items():
+    if target_services and service_name not in target_services:
+        continue
     for port in service.get("ports") or []:
         published = str(port.get("published") or "").strip()
         if not published:
@@ -832,7 +841,6 @@ PY
 
 run_preflight
 start_startup_watchdog "$STARTUP_TIMEOUT_SECONDS"
-check_compose_port_conflicts
 
 llm_provider="${LLM_PROVIDER:-}"
 llm_provider=$(printf "%s" "$llm_provider" | tr '[:upper:]' '[:lower:]')
@@ -840,6 +848,17 @@ llm_requires_ollama=0
 if [ "$llm_provider" = "ollama" ]; then
   llm_requires_ollama=1
 fi
+preflight_services=(db api)
+if [ "$START_WORKER" -eq 1 ]; then
+  preflight_services+=(worker)
+fi
+if [ "$START_WATCHERS" -eq 1 ]; then
+  preflight_services+=(watcher)
+fi
+if [ "${AUTO_BOOTSTRAP:-0}" -eq 1 ] && [ "$llm_requires_ollama" -eq 1 ]; then
+  preflight_services+=(ollama)
+fi
+check_compose_port_conflicts "${preflight_services[@]}"
 
 alpha_rebuild="${ALPHA_REBUILD:-0}"
 alpha_rebuild_pull="${ALPHA_REBUILD_PULL:-0}"

--- a/tests/ops/test_compose_override.py
+++ b/tests/ops/test_compose_override.py
@@ -38,3 +38,13 @@ def test_test_compose_uses_prod_runtime_selector_for_test_channel() -> None:
     services = (compose.get("services") or {})
     assert ((services.get("db") or {}).get("ports") or []) == ["15434:5432"]
     assert ((services.get("api") or {}).get("ports") or []) == ["18002:8000"]
+
+
+def test_dev_compose_overrides_base_ports_for_parallel_stack() -> None:
+    raw = Path("docker-compose.dev.yml").read_text(encoding="utf-8")
+    assert "ports: !override" in raw, "dev overlay must use !override to replace base published ports"
+
+    compose = yaml.load(raw, Loader=_ComposeLoader)
+    services = (compose.get("services") or {})
+    assert ((services.get("db") or {}).get("ports") or []) == ["15433:5432"]
+    assert ((services.get("api") or {}).get("ports") or []) == ["18001:8000"]


### PR DESCRIPTION
## Summary

- Fixes direct `scripts/start_full_system.sh` startup so `PKM_ENVIRONMENT=dev|test|prod` selects environment-specific Compose defaults when `COMPOSE_FILE` / `COMPOSE_PROJECT_NAME` are not explicitly set.
- Adds a preflight port-conflict diagnostic before `compose up` to fail fast with owner-container details and safe next actions.
- Preserves existing explicit override behavior: if caller sets `COMPOSE_FILE`/`COMPOSE_PROJECT_NAME`/`API_BASE_URL`, those still win.

## Diagnosis

Manual startup command:

```bash
PKM_ENVIRONMENT=dev scripts/start_full_system.sh
```

failed with:

```text
Bind for 0.0.0.0:15432 failed: port is already allocated
ERROR: compose_up failed for db/api
```

Observed state on host:

- `docker ps` showed running prod stack containers including:
  - `pkm-prod-db-1` bound to `0.0.0.0:15432->5432`
  - `pkm-prod-api-1` bound to `0.0.0.0:18000->8000`
- `docker compose ls` showed `pkm-prod` running.
- failing container name was `workspace-db-1`, indicating direct script invocation used default/generic Compose project context rather than environment-specific project naming.

Root cause:

- `PKM_ENVIRONMENT=dev` influenced runtime environment semantics (vault/artifact/DB logical naming), but direct script invocation did not automatically select dev compose overlay/project/host ports.
- Without explicit `COMPOSE_FILE` and project name, startup used base/default compose settings that map DB to host `15432`, colliding with active prod.

Classification:

- Conflict owner: existing **prod** stack (`pkm-prod-db-1`) on `15432`.
- Type: startup-path isolation gap in direct script invocation (not Companion UI behavior, not vault binding bug).

## Changed files

- `scripts/start_full_system.sh`

## What changed

1. Environment-aware Compose defaults for direct script path:

- `PKM_ENVIRONMENT=dev` =>
  - `COMPOSE_FILE=docker-compose.yaml:docker-compose.dev.yml`
  - `COMPOSE_PROJECT_NAME=pkm-dev`
  - default `API_BASE_URL=http://127.0.0.1:18001`
- `PKM_ENVIRONMENT=test` =>
  - `COMPOSE_FILE=docker-compose.yaml:docker-compose.test.yml`
  - `COMPOSE_PROJECT_NAME=pkm-test`
  - default `API_BASE_URL=http://127.0.0.1:18002`
- `PKM_ENVIRONMENT=prod` (or unset/default) =>
  - `COMPOSE_FILE=docker-compose.yaml:docker-compose.prod.yml`
  - `COMPOSE_PROJECT_NAME=pkm-prod`
  - default `API_BASE_URL=http://127.0.0.1:18000`

2. Preflight conflict guard:

- Computes effective compose config (`docker compose config --format json`).
- Checks published host ports against currently running containers.
- If conflict with a different compose project is found, fails before `compose up` with a clear message:
  - target environment/project
  - conflicting service/port
  - owning container
  - safe next actions
- Does **not** stop containers automatically.

## Validation

```bash
bash -n scripts/start_full_system.sh
# OK

PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/ops/test_release_channel_isolation.py
# 4 passed

PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/ops/test_release_channel_startup_targets.py
# 3 passed

git diff --check
# clean
```

## Constraints confirmation

- No prod/test containers are stopped automatically.
- Companion UI remains unchanged and still uses runtime API only.
- No direct vault reads or vault-name hardcoding added.

## Relation to release-channel issues

- Addresses the startup isolation symptom in the direct script path and aligns with release-channel isolation intent from #964/#967/#968.
- Does not redesign release-channel architecture; this is a bounded startup-path fix.


## Direct Repair
Type: code
Reason: Runtime startup isolation regression fix discovered during manual UAT; bounded to startup script behavior and diagnostics.
Validation: `bash -n scripts/start_full_system.sh`; `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/ops/test_release_channel_isolation.py tests/ops/test_release_channel_startup_targets.py`
Issue required: no
