### PR TITLE
Add Companion UI workspace integration contracts

### DIFF
--- a/companion-ui/docs/CANVAS_BROWSER_EDITOR_DECISION.md
+++ b/companion-ui/docs/CANVAS_BROWSER_EDITOR_DECISION.md
@@ -1,0 +1,139 @@
+---
+name: Canvas Browser Editor Decision
+description: Decision record for the browser editor primitive and edit delivery model used by Canvas browser integration
+doc_role: Decision record / implementation gate
+authority: Binding decision for Canvas browser editor integration until superseded by a later accepted decision.
+owner: Companion UI / Canvas integration
+last_reviewed: 2026-05-19
+source_contracts:
+  - companion-ui/docs/WORKSPACE_STATE_CONTRACT.md
+  - companion-ui/docs/CANVAS_AGENT_MVP_CONTRACT.md
+  - companion-ui/docs/CANVAS_SUGGESTION_FLOW.md
+  - companion-ui/companion-app/companion_ui/canvas_core/session_state.py
+  - companion-ui/companion-app/companion_ui/canvas_core/undo_stack.py
+  - app/api/routes/canvas.py
+governing_issue: "#1126"
+---
+
+# Canvas Browser Editor Decision
+
+## Decision
+
+Use a native `textarea` as the interim Canvas browser editor primitive.
+
+The browser integration will edit Markdown source directly and submit the full
+note body through the existing Canvas body-edit lane. No CodeMirror,
+ProseMirror, rich-text editor, or rendered-markdown/source split is introduced
+in this slice.
+
+## Rationale
+
+The shipped Canvas API and Canvas Core model are already shaped around direct
+body replacement for the currently open artifact:
+
+- The browser loads the full note body from the workspace aggregate.
+- The Canvas edit path accepts a replacement body (`new_body`) plus a change
+  summary.
+- Canvas Core permits only body edits on the direct co-authoring path.
+- Governance-bearing or ambiguous mutations must route through the escape
+  hatch/Panel path, not through the body editor.
+
+A `textarea` matches that model with the least extra state:
+
+- Markdown source is the canonical editing representation for this interim
+  browser slice.
+- No editor dependency is added before richer UX requirements are proven.
+- Full-body replacement is simple to reason about and test.
+- Replacement with a richer editor remains possible later because this decision
+  does not define a persistent editor document model.
+
+## Rejected Options
+
+| Option | Reason rejected for this slice |
+|---|---|
+| CodeMirror | Reasonable future option, but adds a dependency and editor state model before the first browser integration proves the full-body flow. |
+| ProseMirror | Too much document-model complexity for a Markdown body replacement API. Would require serialization decisions that are not needed now. |
+| Rendered markdown plus source editor toggle | Useful later, but introduces two synchronized views before the edit/conflict path is proven. |
+
+## Edit Delivery
+
+Canvas browser edits use full-body replacement.
+
+The browser flow is:
+
+1. Load `artifact.body` and `artifact.content_hash` from
+   `GET /api/companion/workspace`.
+2. Let the user and assistant edit the Markdown body in the `textarea`.
+3. Before submit, compare the current workspace baseline to the latest known
+   `content_hash` if the implementation has refreshed state.
+4. Submit `new_body` and `change_summary` through the Canvas edit path.
+5. On success, refresh workspace state and replace the local baseline.
+
+The browser integration must not invent a patch/delta protocol in this slice.
+If patch-based edits become necessary, they require a separate API contract
+change before implementation.
+
+### Hash Check Implication
+
+`WORKSPACE_STATE_CONTRACT.md` exposes `artifact.content_hash` as the browser's
+stale-read baseline. Browser implementation must use that value to avoid
+overwriting external changes silently.
+
+If the runtime edit endpoint does not yet accept an explicit content-hash
+precondition, the implementation issue must add that precondition or perform an
+equivalent runtime-side stale-read check before applying the full-body
+replacement. Silent last-write-wins behavior is not acceptable for the browser
+Canvas editor.
+
+## Conflict Behavior
+
+### Content Hash Mismatch
+
+When the browser's baseline hash does not match the runtime's current body
+hash, the submit is stale.
+
+Required behavior:
+
+- Do not submit or apply the replacement body silently.
+- Surface a conflict state in the browser.
+- Offer an explicit refresh/reload path that preserves the user's unsent draft
+  locally until the user decides what to do.
+- Require a new user action before retrying against the refreshed baseline.
+
+### Paused or Interrupted Session
+
+When `canvas.session_state` is `paused` or `interrupted`:
+
+- Body editing is disabled.
+- The browser renders recovery-needed state from
+  `canvas.recovery_needed = true`.
+- Resume/recover must be explicit before body edits can submit.
+
+### External Obsidian Edit
+
+An external Obsidian edit is detected as a content-hash delta between the
+loaded baseline and the current runtime state.
+
+Required behavior is the same as content hash mismatch: no silent overwrite,
+visible conflict state, explicit refresh/retry.
+
+## Undo Granularity
+
+Use last-assistant-edit undo only for the interim browser slice.
+
+This matches the shipped Canvas undo stack, which is session-scoped,
+artifact-scoped, and reverts the most recent assistant-applied body edit when
+the current body still matches the post-edit body. Stack-wide or arbitrary
+multi-step browser undo is out of scope for this decision.
+
+User keystroke undo remains the browser/editor's local responsibility. Canvas
+assistant undo remains the runtime/session responsibility.
+
+## Implementation Gate
+
+Issues #1126-#1129 (Canvas browser integration) are blocked until this
+decision doc is accepted.
+
+Any later move to CodeMirror, ProseMirror, a rendered/source split, streaming
+edits, or patch-based delivery must be recorded in a replacement decision
+before implementation.

--- a/companion-ui/docs/COMPANION_UI_TARGET_ARCHITECTURE.md
+++ b/companion-ui/docs/COMPANION_UI_TARGET_ARCHITECTURE.md
@@ -118,6 +118,9 @@ Rules:
 - Work-computer access is deferred unless already safely reachable through the operator's approved
   Tailscale/network setup.
 
+The detailed localhost/LAN/Tailscale/token/CSRF posture is defined in
+`companion-ui/docs/LOCAL_ACCESS_MODEL.md`.
+
 ---
 
 ## 5. Current Shipped State
@@ -146,6 +149,14 @@ and `docs/STATUS.md` for current sequencing.
 
 For operational detail on the shipped dev server, see
 `companion-ui/docs/REAL_NOTE_WORKSPACE_DEV_PAGE.md`.
+
+The next browser integration contracts are:
+
+- `companion-ui/docs/WORKSPACE_STATE_CONTRACT.md` — read-side workspace aggregate for artifact,
+  Canvas, Panel, suggestion, and guard state.
+- `companion-ui/docs/CANVAS_BROWSER_EDITOR_DECISION.md` — interim Canvas browser editor primitive
+  and full-body edit delivery decision.
+- `companion-ui/docs/PANEL_STATE_DISCOVERY_DELTA.md` — Panel browser discovery gap analysis.
 
 ---
 
@@ -220,6 +231,10 @@ The following must not happen under this architecture:
 |---|---|
 | `companion-ui/docs/UI_RUNTIME_BOUNDARIES.md` | Cognitive boundary and integration boundary rules; upstream of this doc |
 | `companion-ui/docs/REAL_NOTE_WORKSPACE_DEV_PAGE.md` | Operational detail for the dev page: ports, env vars, UAT steps |
+| `companion-ui/docs/WORKSPACE_STATE_CONTRACT.md` | Read-side aggregate contract for browser workspace state |
+| `companion-ui/docs/LOCAL_ACCESS_MODEL.md` | Localhost, LAN, Tailscale, token, and CSRF access posture |
+| `companion-ui/docs/CANVAS_BROWSER_EDITOR_DECISION.md` | Canvas browser editor primitive and edit delivery decision |
+| `companion-ui/docs/PANEL_STATE_DISCOVERY_DELTA.md` | Panel discovery delta against the workspace aggregate |
 | `companion-ui/docs/PANEL_COMPANION_UI_CONTRACT.md` | Panel surface contract; vault write-back boundary rules |
 | `companion-ui/docs/CANVAS_AGENT_MVP_CONTRACT.md` | Canvas surface contract; in-session authority model |
 | `docs/COMPANION_UI_PRODUCT_SPEC.md` | Product mode model (Find/Reorient/Resurface/Act); upstream authority |

--- a/companion-ui/docs/LOCAL_ACCESS_MODEL.md
+++ b/companion-ui/docs/LOCAL_ACCESS_MODEL.md
@@ -1,0 +1,141 @@
+---
+name: Companion UI Local Access Model
+description: Localhost, LAN, Tailscale, token, and CSRF posture for Companion UI access
+doc_role: Access model / security posture
+authority: Binding docs-first access model for Companion UI browser dev/staging and future production hardening.
+owner: Companion UI / product architecture
+last_reviewed: 2026-05-19
+source_contracts:
+  - companion-ui/docs/COMPANION_UI_TARGET_ARCHITECTURE.md
+  - companion-ui/docs/REAL_NOTE_WORKSPACE_DEV_PAGE.md
+  - docs/ENVIRONMENTS.md
+governing_issue: "#1125"
+---
+
+# Local Access Model
+
+## Purpose
+
+Define the local auth and trusted-device access model for Companion UI before
+production hardening or broader LAN/Tailscale use is implemented.
+
+This document is docs-first. It does not implement auth, TLS, reverse proxying,
+token issuance, or session cookies.
+
+## Localhost Default
+
+Default localhost posture: bind to `127.0.0.1` and require no auth for
+loopback-only dev access.
+
+Rules:
+
+- The Companion UI dev server binds to `127.0.0.1` by default.
+- The runtime API used by the dev page is expected to be local by default.
+- No token, cookie, or login is required for loopback-only local development.
+- This default is acceptable only while the service is not reachable from other
+  devices.
+
+Rationale:
+
+- Loopback-only access keeps the threat model local to the operator's machine.
+- The current dev server is explicitly not a production UI.
+- Adding auth before the first local workflow is proven would create more
+  operational complexity without changing the default network exposure.
+
+## LAN and Tailscale
+
+LAN or Tailscale access is opt-in.
+
+Rules:
+
+- Binding to `0.0.0.0`, a LAN IP, or a Tailscale IP must be an explicit
+  operator action.
+- The operator is responsible for deciding that the LAN or Tailnet is trusted
+  enough for the current dev/staging posture.
+- Public internet exposure is not supported.
+- Work-computer or workplace-network access is deferred unless it is already
+  allowed by the operator's approved network policy.
+
+Minimum posture for LAN/Tailscale dev use:
+
+- Use only trusted devices.
+- Keep the service off the public internet.
+- Prefer Tailscale over open LAN when accessing from another personal device.
+- Treat LAN/Tailscale mode as dev/staging, not production.
+
+Future production posture for non-loopback access should add token/session
+auth before treating the surface as supported beyond trusted-device personal
+use.
+
+## Token or Session Auth Option
+
+When Companion UI moves beyond loopback-only dev usage, the minimal auth option
+is an operator-issued bearer token or local session secret.
+
+Expected shape:
+
+- The runtime generates or reads a local secret from operator configuration.
+- The browser/dev page sends the token on API calls using an authorization
+  header or same-site session cookie.
+- The token is scoped to the local Companion UI surface.
+- The token does not grant shell access, vault path access, or direct file I/O.
+- The token is revocable by rotating the local secret.
+
+This document does not choose a final implementation mechanism. It only states
+that non-loopback supported access should not rely on network trust alone once
+the workspace aggregate and mutation-capable browser flows mature.
+
+## CSRF
+
+Loopback-only dev posture has a narrower CSRF threat model but is not immune to
+browser-origin mistakes.
+
+Rules for the current local model:
+
+- Mutating runtime endpoints must not rely on browser UI state as authority.
+- Mutating requests should use JSON APIs and explicit methods, not GET.
+- If cookie-based auth is introduced, CSRF protection becomes mandatory for
+  mutating endpoints.
+- If bearer-token auth is introduced, tokens must not be exposed in URLs.
+- CORS should remain restrictive by default. Do not allow arbitrary origins for
+  mutation-capable endpoints.
+
+For the current read-only dev page:
+
+- `GET /api/companion/workspace` is read-side only.
+- `POST /api/panel/confirm` and Canvas edit endpoints remain explicit mutation
+  boundaries and must keep runtime-side policy, WriteGuard, idempotency, and
+  receipt checks.
+
+## Dev and Production Profile Separation
+
+| Concern | Dev/staging profile | Future production profile |
+|---|---|---|
+| Bind address | `127.0.0.1` default; `0.0.0.0` only by explicit operator action | Localhost-first; non-loopback only with hardening |
+| Auth | None for loopback-only | Token/session auth for supported non-loopback access |
+| TLS | Not required for loopback-only dev | Required for public or reverse-proxied exposure; public exposure is not currently supported |
+| Reverse proxy | Out of scope | Future hardening option |
+| Public internet | Not supported | Not supported until a separate auth/TLS/reverse-proxy contract is accepted |
+| Multi-user | Not supported | Non-goal unless a later product decision changes scope |
+
+## non-goals
+
+- public internet exposure.
+- Multi-user support.
+- Enterprise auth.
+- OAuth/SAML/SSO.
+- Browser direct vault filesystem access.
+- Treating network-level trust as production-grade auth.
+- Implementing auth hardening in this docs-first issue.
+
+## Implementation Trigger
+
+Auth hardening implementation must not start until this document is accepted.
+
+In particular, implementation of token/session auth, CSRF middleware,
+reverse-proxy behavior, or production access hardening must be scoped in a
+separate implementation issue after the workspace aggregate endpoint is
+delivered.
+
+Issue #1133, or any equivalent auth-hardening issue, must treat this document
+as the access-model source of truth.

--- a/companion-ui/docs/PANEL_STATE_DISCOVERY_DELTA.md
+++ b/companion-ui/docs/PANEL_STATE_DISCOVERY_DELTA.md
@@ -1,0 +1,108 @@
+---
+name: Panel State Discovery Delta
+description: Gap analysis for Panel browser state discovery against the workspace aggregate contract
+doc_role: Gap analysis / implementation gate
+authority: Binding delta for whether Panel browser integration needs a separate discovery contract.
+owner: Companion UI / Panel integration
+last_reviewed: 2026-05-19
+source_contracts:
+  - companion-ui/docs/PANEL_COMPANION_UI_CONTRACT.md
+  - companion-ui/docs/PANEL_CONFIRMATION_API_CONTRACT.md
+  - companion-ui/docs/PANEL_DURABLE_PROJECTION_MAPPING.md
+  - companion-ui/docs/WORKSPACE_STATE_CONTRACT.md
+governing_issue: "#1127"
+---
+
+# Panel State Discovery Delta
+
+## Sufficiency Statement
+
+The workspace aggregate is sufficient for the current Panel browser discovery
+slice. No separate Panel state discovery endpoint is needed.
+
+`GET /api/companion/workspace` is the read-side browser discovery mechanism for
+artifact-local Panel state. `POST /api/panel/confirm` remains the write-side
+confirmation path.
+
+## Existing Contract Coverage
+
+| Question | Answer |
+|---|---|
+| How does the browser discover staged proposals on cold load? | It reads `panel.state` and `panel.proposal_count` from `GET /api/companion/workspace?note_path=...`. If `panel.state = "proposals-staged"` and `proposal_count > 0`, the browser renders the Panel proposal affordance for that artifact. |
+| How does the browser discover receipts for a given note? | It reads `panel.receipt_count` and renders receipt posture according to `panel.state`, especially `receipt-displayed`, `blocked`, `logged`, and `partial-complete` states. The durable vault-visible receipt mapping remains governed by `PANEL_DURABLE_PROJECTION_MAPPING.md`. |
+| Is polling, SSE, or explicit refresh the right model? | Explicit refresh and load-time aggregation are sufficient for the current slice. Polling or SSE is not required until there is a concrete live-update UX issue. |
+| What does blocked/no-match state look like? | `panel.state = "blocked"` carries `blocked_reason`; `panel.state = "no-match"` carries `no_match_reason`. Both are defined by `WORKSPACE_STATE_CONTRACT.md` and rendered as visible Panel states, not silent failures. |
+
+## Cold Load Discovery
+
+When a note is opened, the browser calls:
+
+```http
+GET /api/companion/workspace?note_path=<relative_path>
+```
+
+The browser uses only the `panel` slice for Panel discovery:
+
+```json
+{
+  "panel": {
+    "state": "proposals-staged",
+    "proposal_count": 2,
+    "receipt_count": 0,
+    "blocked_reason": null,
+    "no_match_reason": null
+  }
+}
+```
+
+Rules:
+
+- The browser does not scan vault text for Panel checkboxes.
+- The browser does not re-run Panel cognition on cold load.
+- The browser does not infer proposal classes locally.
+- The browser renders server-declared Panel state for the active artifact only.
+
+## Receipt Discovery
+
+Receipt discovery is aggregate-level for this slice:
+
+- `receipt_count` tells the browser whether there are current receipt/outcome
+  items relevant to the active artifact.
+- `panel.state = "receipt-displayed"` tells the browser the primary render
+  state.
+- Blocked/logged/partial outcomes remain governed by
+  `PANEL_CONFIRMATION_API_CONTRACT.md` and
+  `PANEL_DURABLE_PROJECTION_MAPPING.md`.
+
+This delta does not introduce a new receipt list schema. If the browser later
+needs full receipt rows on cold load, that is an additive extension to
+`WORKSPACE_STATE_CONTRACT.md`, not a separate discovery endpoint.
+
+## Update Model
+
+The current update model is explicit refresh:
+
+- Initial note open calls the workspace aggregate.
+- After `POST /api/panel/confirm`, the browser refreshes workspace state.
+- Manual refresh or note navigation refreshes workspace state.
+
+Polling and SSE are out of scope for this delta. They can be introduced later
+only if the product requires live Panel updates while the user remains on the
+same note.
+
+## Additive Gaps
+
+No additive fields are required for the current Panel browser integration
+slice.
+
+Future additive fields may be justified if implementation needs:
+
+- full proposal row summaries on cold load,
+- full receipt row summaries on cold load,
+- proposal validity/expiry windows,
+- live update cursors,
+- or per-proposal blocked reasons.
+
+Those additions should extend the `panel` slice in
+`WORKSPACE_STATE_CONTRACT.md` rather than creating a second Panel discovery
+contract.

--- a/companion-ui/docs/PANEL_STATE_DISCOVERY_DELTA.md
+++ b/companion-ui/docs/PANEL_STATE_DISCOVERY_DELTA.md
@@ -29,7 +29,7 @@ confirmation path.
 | Question | Answer |
 |---|---|
 | How does the browser discover staged proposals on cold load? | It reads `panel.state` and `panel.proposal_count` from `GET /api/companion/workspace?note_path=...`. If `panel.state = "proposals-staged"` and `proposal_count > 0`, the browser renders the Panel proposal affordance for that artifact. |
-| How does the browser discover receipts for a given note? | It reads `panel.receipt_count` and renders receipt posture according to `panel.state`, especially `receipt-displayed`, `blocked`, `logged`, and `partial-complete` states. The durable vault-visible receipt mapping remains governed by `PANEL_DURABLE_PROJECTION_MAPPING.md`. |
+| How does the browser discover receipts for a given note? | It reads `panel.receipt_count` and `panel.latest_receipt_outcome`. `panel.state` tells the browser whether a receipt should be displayed; `latest_receipt_outcome` distinguishes success, blocked, logged/deferred, partial, and rejected outcomes. The durable vault-visible receipt mapping remains governed by `PANEL_DURABLE_PROJECTION_MAPPING.md`. |
 | Is polling, SSE, or explicit refresh the right model? | Explicit refresh and load-time aggregation are sufficient for the current slice. Polling or SSE is not required until there is a concrete live-update UX issue. |
 | What does blocked/no-match state look like? | `panel.state = "blocked"` carries `blocked_reason`; `panel.state = "no-match"` carries `no_match_reason`. Both are defined by `WORKSPACE_STATE_CONTRACT.md` and rendered as visible Panel states, not silent failures. |
 
@@ -49,6 +49,7 @@ The browser uses only the `panel` slice for Panel discovery:
     "state": "proposals-staged",
     "proposal_count": 2,
     "receipt_count": 0,
+    "latest_receipt_outcome": null,
     "blocked_reason": null,
     "no_match_reason": null
   }
@@ -70,13 +71,17 @@ Receipt discovery is aggregate-level for this slice:
   items relevant to the active artifact.
 - `panel.state = "receipt-displayed"` tells the browser the primary render
   state.
+- `latest_receipt_outcome` tells the browser what happened: `success`,
+  `blocked`, `logged`, `partial`, or `rejected`.
 - Blocked/logged/partial outcomes remain governed by
   `PANEL_CONFIRMATION_API_CONTRACT.md` and
   `PANEL_DURABLE_PROJECTION_MAPPING.md`.
 
 This delta does not introduce a new receipt list schema. If the browser later
 needs full receipt rows on cold load, that is an additive extension to
-`WORKSPACE_STATE_CONTRACT.md`, not a separate discovery endpoint.
+`WORKSPACE_STATE_CONTRACT.md`, not a separate discovery endpoint. Until then,
+`latest_receipt_outcome` is the required field that prevents the browser from
+misrepresenting a logged/deferred or blocked receipt as a successful execution.
 
 ## Update Model
 

--- a/companion-ui/docs/README.md
+++ b/companion-ui/docs/README.md
@@ -4,6 +4,7 @@ Foundational documents for cognitive interaction architecture.
 
 ## Product architecture and hosting
 - `COMPANION_UI_TARGET_ARCHITECTURE.md` — owner doc for Companion UI target architecture: local-first web app served by Yggdrasil, localhost/LAN/Tailscale access model, runtime API as the only vault access path, vault-boundary rules, current shipped state, browser dev server as the next slice, long-term options (PWA, desktop wrapper), non-goals. Governing issue: #1102.
+- `LOCAL_ACCESS_MODEL.md` — local access posture for Companion UI: localhost default, LAN/Tailscale opt-in, token/session auth option, CSRF posture, dev/production separation, public internet non-goal.
 
 ## Core set
 - `SYSTEM_OVERVIEW.md`
@@ -17,6 +18,9 @@ Foundational documents for cognitive interaction architecture.
 - `DESIGN_BRIEF.md` (preserved source brief)
 
 ## Surface contracts and feature implementation specs
+- `WORKSPACE_STATE_CONTRACT.md` — read-side aggregate contract for `GET /api/companion/workspace`, combining artifact, runtime, Canvas, Panel, suggestion, and guard state without creating a new authority surface. Governing issue: #1122.
+- `CANVAS_BROWSER_EDITOR_DECISION.md` — decision record choosing `textarea` as the interim Canvas browser editor primitive and preserving full-body replacement semantics. Governing issue: #1126.
+- `PANEL_STATE_DISCOVERY_DELTA.md` — Panel browser discovery gap analysis; confirms the workspace aggregate is sufficient for the current slice. Governing issue: #1127.
 - `CANVAS_AGENT_MVP_CONTRACT.md` — normalized Canvas Agent MVP surface contract: co-authoring posture, session lifecycle, user-present authority, direct in-place editing, undo/rollback, `.chats/` provenance, governance-bearing escape hatch, distinction from Panel and from Canvas bounded suggestion flow. Governing issue: #1021.
 - `CANVAS_SUGGESTION_FLOW.md` — normalized implementation spec for the Canvas Suggestion Flow: state machine, component inventory, intent vocabulary, backend mapping, invariants. Derived from design handoff `companion-ui/design_handoff/2026-05-11-canvas-suggestion-flow/`. Implementation contracts for #868–#874.
 

--- a/companion-ui/docs/WORKSPACE_STATE_CONTRACT.md
+++ b/companion-ui/docs/WORKSPACE_STATE_CONTRACT.md
@@ -89,6 +89,7 @@ Panel state, receipts, or write-guard state.
     "state": "idle | running | proposals-staged | confirming | executing | receipt-displayed | no-match | blocked | clarification-needed | plan-staged | capability-needed | partial-complete",
     "proposal_count": 0,
     "receipt_count": 0,
+    "latest_receipt_outcome": "success | blocked | logged | partial | rejected | null",
     "blocked_reason": null,
     "no_match_reason": null
   },
@@ -173,6 +174,7 @@ refresh.
 | `state` | One of the Panel render states defined in `PANEL_COMPANION_UI_CONTRACT.md`. |
 | `proposal_count` | Count of currently staged artifact-local proposals for this note. |
 | `receipt_count` | Count of current receipt/outcome items relevant to this note. |
+| `latest_receipt_outcome` | Server-declared outcome for the most recent relevant receipt: `success`, `blocked`, `logged`, `partial`, `rejected`, or `null` when no receipt is available. The UI must use this field, not `state`, to distinguish successful execution from logged/deferred or blocked outcomes on cold load. |
 | `blocked_reason` | Human-readable reason when `state = "blocked"`, else `null`. |
 | `no_match_reason` | Human-readable reason when `state = "no-match"`, else `null`. |
 
@@ -278,6 +280,7 @@ showing unavailable actions.
     "state": "blocked",
     "proposal_count": 0,
     "receipt_count": 0,
+    "latest_receipt_outcome": "blocked",
     "blocked_reason": "WriteGuard blocked the requested operation",
     "no_match_reason": null
   },

--- a/companion-ui/docs/WORKSPACE_STATE_CONTRACT.md
+++ b/companion-ui/docs/WORKSPACE_STATE_CONTRACT.md
@@ -1,0 +1,327 @@
+---
+name: Companion UI Workspace State Contract
+description: Read-side aggregate contract for the Companion UI browser workspace state endpoint
+doc_role: API contract / spec
+authority: Binding read-side contract for `GET /api/companion/workspace` and downstream Canvas/Panel browser integration.
+owner: Companion UI / product architecture
+last_reviewed: 2026-05-19
+source_contracts:
+  - companion-ui/docs/COMPANION_UI_TARGET_ARCHITECTURE.md
+  - companion-ui/docs/UI_RUNTIME_BOUNDARIES.md
+  - companion-ui/docs/PANEL_COMPANION_UI_CONTRACT.md
+  - companion-ui/docs/PANEL_CONFIRMATION_API_CONTRACT.md
+  - companion-ui/docs/CANVAS_AGENT_MVP_CONTRACT.md
+  - companion-ui/docs/CANVAS_SUGGESTION_FLOW.md
+governing_issue: "#1122"
+---
+
+# Workspace State Contract
+
+## Purpose
+
+Define the read-side aggregate endpoint the browser workspace uses to load one
+coordinated view of the active artifact and its Companion UI runtime state.
+
+This contract exists because `GET /api/artifacts/note` only reads the artifact
+body and note metadata. The browser also needs Canvas session posture, Panel
+proposal posture, suggestion posture, and guard status before Canvas/Panel
+browser integration can proceed.
+
+This document is a contract only. It does not implement the endpoint.
+
+## Endpoint
+
+```http
+GET /api/companion/workspace?note_path=<relative_path>
+```
+
+The endpoint is read-only. It may aggregate runtime state from existing
+endpoints or services, but it must not mutate vault files, session state,
+Panel state, receipts, or write-guard state.
+
+### Request Parameters
+
+| Field | Required | Description |
+|---|---:|---|
+| `note_path` | yes | Runtime-relative note path for the artifact to load. Absolute vault filesystem paths are not accepted from browser callers. |
+
+## Authority Rules
+
+- The endpoint is a read-side UI aggregate. It is not a source of semantic,
+  governance, or mutation authority.
+- The UI must not infer body/governance classification from this payload.
+  Classification is server-declared and belongs to the runtime.
+- The UI must not infer Panel action classes, capability classes, or governance
+  categories locally.
+- The payload must not expose raw vault filesystem paths to the browser.
+- Runtime environment selection, vault binding, policy, WriteGuard, execution,
+  and receipt production remain owned by the backend runtime.
+- If an aggregate field is unavailable, the response must surface that as
+  `guards.degraded = true` with a reason-bearing blocked/error field rather
+  than letting the UI guess.
+
+## Success Payload
+
+```json
+{
+  "artifact": {
+    "artifact_id": "string",
+    "note_path": "string",
+    "title": "string",
+    "body": "string",
+    "content_hash": "string"
+  },
+  "runtime": {
+    "environment_label": "dev | test | prod | unknown",
+    "api_base_url_label": "string",
+    "trace_id": "string"
+  },
+  "canvas": {
+    "session_id": "string | null",
+    "session_state": "start | active | paused | interrupted | closed | null",
+    "user_present": true,
+    "can_edit_body": true,
+    "recovery_needed": false,
+    "session_log_path": "string | null",
+    "session_persistence": "in_memory | durable"
+  },
+  "panel": {
+    "state": "idle | running | proposals-staged | confirming | executing | receipt-displayed | no-match | blocked | clarification-needed | plan-staged | capability-needed | partial-complete",
+    "proposal_count": 0,
+    "receipt_count": 0,
+    "blocked_reason": null,
+    "no_match_reason": null
+  },
+  "suggestions": {
+    "current_suggestion_state": null,
+    "server_declared_classification": null,
+    "pending_receipts": []
+  },
+  "guards": {
+    "canvas_enabled": false,
+    "writeguard_status": "ok | blocked | unknown",
+    "degraded": false
+  }
+}
+```
+
+## Field Rules
+
+### `artifact`
+
+`artifact` is the note body and note identity needed to render the active
+workspace.
+
+| Field | Rule |
+|---|---|
+| `artifact_id` | Stable artifact identifier when available. Empty string is allowed only for legacy/read-only note loads where the runtime cannot resolve an ID. |
+| `note_path` | Browser-safe runtime-relative path or opaque note reference. It must not be an absolute vault path. |
+| `title` | Display title extracted or supplied by the runtime. |
+| `body` | Current note body at the time of aggregation. |
+| `content_hash` | Hash of the body returned in this payload. Browser edit flows must use it as the stale-read baseline before full-body replacement. |
+
+### `runtime`
+
+`runtime` gives the browser safe operational labels for the currently attached
+runtime.
+
+| Field | Rule |
+|---|---|
+| `environment_label` | Safe label only. It must not include vault root paths. |
+| `api_base_url_label` | Safe display label such as `local-dev`, `local-test`, `local-prod`, or an operator-provided alias. It must not expose filesystem paths or secrets. |
+| `trace_id` | Correlation ID for this aggregate read. |
+
+### `canvas`
+
+`canvas` describes the active Canvas session posture for the artifact.
+
+| Field | Rule |
+|---|---|
+| `session_id` | Current session ID if one is open for this artifact, else `null`. |
+| `session_state` | Canvas session lifecycle state from the Canvas Core contract, or `null` when no session exists. |
+| `user_present` | Whether user-present body co-authoring authority is currently available. |
+| `can_edit_body` | True only when Canvas is enabled, a session is active, user presence is established, and the active mutation class is body-only. |
+| `recovery_needed` | True for paused/interrupted recoverable sessions. |
+| `session_log_path` | Browser-safe vault-relative `.chats/...` provenance path when available. It must not be an absolute vault filesystem path. |
+| `session_persistence` | Typed capability field: `in_memory` or `durable`. |
+
+#### Durability Posture
+
+For the current browser dev/server integration slice,
+`session_persistence: "in_memory"` is explicitly accepted.
+
+Meaning:
+
+- Canvas sessions survive only for the lifetime of the API process.
+- A process restart loses the in-memory session registry.
+- The note body remains durable through the normal note write path.
+- Session logs that have already been written remain durable provenance, but
+  the open session registry itself is not durable.
+
+This is accepted because the current slice is a local dev/staging integration
+path and the shipped Canvas API keeps session state in memory. A future durable
+session registry is a separate implementation decision and must not be implied
+by this contract.
+
+### `panel`
+
+`panel` is the canonical Panel state slice for browser cold load and explicit
+refresh.
+
+| Field | Rule |
+|---|---|
+| `state` | One of the Panel render states defined in `PANEL_COMPANION_UI_CONTRACT.md`. |
+| `proposal_count` | Count of currently staged artifact-local proposals for this note. |
+| `receipt_count` | Count of current receipt/outcome items relevant to this note. |
+| `blocked_reason` | Human-readable reason when `state = "blocked"`, else `null`. |
+| `no_match_reason` | Human-readable reason when `state = "no-match"`, else `null`. |
+
+The workspace aggregate is the read-side discovery mechanism for Panel browser
+state. A separate Panel discovery endpoint must not be introduced unless this
+aggregate proves insufficient in a later accepted delta.
+
+### `suggestions`
+
+`suggestions` describes the Canvas bounded suggestion flow posture when a
+suggestion is currently staged or pending.
+
+| Field | Rule |
+|---|---|
+| `current_suggestion_state` | Canonical state from `CANVAS_SUGGESTION_FLOW.md`, or `null`. |
+| `server_declared_classification` | Server-declared classification such as `body` or `governance`, or `null`. The UI must not compute this locally. |
+| `pending_receipts` | Pending governance receipt summaries for queued suggestions. Empty when none. |
+
+### `guards`
+
+`guards` lets the browser render safe blocked/degraded states without making
+policy decisions itself.
+
+| Field | Rule |
+|---|---|
+| `canvas_enabled` | Server-side Canvas feature flag value. |
+| `writeguard_status` | Runtime-reported guard posture: `ok`, `blocked`, or `unknown`. |
+| `degraded` | True when the aggregate is partial or a sub-surface could not be evaluated. |
+
+## error payloads
+
+The endpoint returns typed error payloads for request-level failures.
+
+### Invalid Path
+
+```json
+{
+  "error": "invalid_note_path",
+  "message": "note_path must be a relative runtime note path",
+  "trace_id": "string"
+}
+```
+
+Use HTTP 400 or 422.
+
+### Note Not Found
+
+```json
+{
+  "error": "note_not_found",
+  "message": "No note exists for the requested note_path",
+  "note_path": "string",
+  "trace_id": "string"
+}
+```
+
+Use HTTP 404.
+
+### Runtime Unavailable
+
+```json
+{
+  "error": "runtime_unavailable",
+  "message": "The runtime aggregate source could not be reached",
+  "trace_id": "string"
+}
+```
+
+Use HTTP 503.
+
+## Blocked and Degraded Payloads
+
+Surface-level blocks should usually return HTTP 200 with a complete aggregate
+and reason-bearing blocked fields. This lets the browser render the note while
+showing unavailable actions.
+
+### Canvas Disabled
+
+```json
+{
+  "canvas": {
+    "session_id": null,
+    "session_state": null,
+    "user_present": false,
+    "can_edit_body": false,
+    "recovery_needed": false,
+    "session_log_path": null,
+    "session_persistence": "in_memory"
+  },
+  "guards": {
+    "canvas_enabled": false,
+    "writeguard_status": "unknown",
+    "degraded": false
+  }
+}
+```
+
+### WriteGuard Blocked
+
+```json
+{
+  "panel": {
+    "state": "blocked",
+    "proposal_count": 0,
+    "receipt_count": 0,
+    "blocked_reason": "WriteGuard blocked the requested operation",
+    "no_match_reason": null
+  },
+  "guards": {
+    "canvas_enabled": true,
+    "writeguard_status": "blocked",
+    "degraded": false
+  }
+}
+```
+
+### Partial Aggregate
+
+```json
+{
+  "guards": {
+    "canvas_enabled": true,
+    "writeguard_status": "unknown",
+    "degraded": true
+  }
+}
+```
+
+A partial aggregate must include a specific reason-bearing field in the surface
+that failed to resolve. The UI must not silently substitute local defaults.
+
+## existing endpoints
+
+This endpoint complements existing API surfaces. It must not duplicate their
+write authority.
+
+| Existing endpoint | Relationship |
+|---|---|
+| `GET /api/artifacts/note` | Artifact read source. The aggregate may reuse it, but must normalize browser-facing `note_path` so raw vault filesystem paths are not exposed. |
+| `POST /api/canvas/sessions` | Existing Canvas session lifecycle write path. The aggregate reports current state; it does not open sessions. |
+| `POST /api/canvas/sessions/{id}/edits` | Existing Canvas body edit path. The aggregate provides the body and content hash baseline for browser edit flows; it does not apply edits. |
+| `DELETE /api/canvas/sessions/{id}` | Existing Canvas session close path. The aggregate reports state; it does not close sessions. |
+| `POST /api/panel/confirm` | Existing Panel confirmation write path. The aggregate reports staged/receipt posture; confirmation remains explicit and runtime-mediated. |
+
+## Implementation Gate
+
+Implementing `GET /api/companion/workspace` must follow this contract before
+Canvas browser editing or Panel browser discovery issues proceed.
+
+The Panel slice in this document is the canonical source for Panel browser
+state discovery. `PANEL_STATE_DISCOVERY_DELTA.md` may only confirm sufficiency
+or define additive gaps.


### PR DESCRIPTION
## Change Lane
- [ ] Implementation lane
- [x] Docs authoring lane
- [ ] Governance lane

Docs authoring applies only to docs-only changes in approved docs-authoring surfaces. It must not be used for code, runtime behavior, contracts, shipped reality, or implementation writeback.
Governance lane applies to bounded repository-governance changes such as repo-local skills, PR/issue policy, and lightweight enforcement for docs/governance workflows. It may include repo-meta governance scripts and focused tests, but it must not be used for product/runtime implementation.

## Linked Issue
Fixes #1122
Fixes #1125
Fixes #1126
Fixes #1127

Required for implementation lane. Leave blank for docs authoring lane.
Leave blank for governance lane when the PR stays within approved governance surfaces.

## Summary
- Adds the read-side Companion UI workspace aggregate contract for artifact, Canvas, Panel, suggestions, and guard state.
- Records the Canvas browser editor decision (`textarea` interim), Panel discovery delta, and local access model before browser integration proceeds.

## Implementation Scope Check
- [ ] Change stays within the linked Issue scope.
- [ ] Constraints from the linked Issue were followed.
- [ ] Acceptance Criteria from the linked Issue are satisfied.
- [ ] Docs were updated in the same change when behavior/contracts changed.
- [ ] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [x] This PR only changes approved docs-authoring surfaces.
- [x] No code, runtime behavior, contracts, or shipped reality changed.
- [x] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [ ] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [ ] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [ ] `ruff check app tests`
- [ ] `mypy app`
- [ ] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg"`
- [ ] Additional targeted checks run as needed

Docs authoring lane:
- [x] `git diff --check`
- [x] `python3 scripts/docs_guard.py`
- [x] Issue-specific grep checks for workspace state, Canvas editor, Panel discovery, and local access docs
- [x] `scripts/validate_source_anchors.py` not run; it requires an issue body input and is not a standalone docs-file validator

Governance lane:
- [ ] Governance checks run as appropriate for the touched surfaces
- [ ] Any validation gaps or tooling limitations are stated explicitly

## Notes
- `session_persistence: "in_memory"` is explicitly accepted for the current dev/staging browser slice.
- Canvas browser editing is intentionally scoped to a native `textarea` interim primitive with full-body replacement and hash-conflict requirements.
- Panel browser discovery is satisfied by the workspace aggregate for the current slice; no separate Panel discovery endpoint is introduced.
- Review fix aa87a68 adds `panel.latest_receipt_outcome` so cold-load receipt discovery cannot misrepresent logged/deferred or blocked outcomes as successful execution.
