### PR TITLE
Bind Companion shell to workspace aggregate

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/confirm_session.py
+++ b/companion-ui/companion-app/companion_ui/workspace/confirm_session.py
@@ -1,11 +1,11 @@
-"""Panel confirm → artifact refresh session model (#1065).
+"""Panel confirm -> artifact refresh session model (#1065).
 
 Connects the Companion UI layer to the Panel confirm API and the artifact
-read endpoint. The UI remains a pure API consumer — no vault file access.
+read endpoint. The UI remains a pure API consumer - no vault file access.
 
 Contracts consumed:
 - POST /api/panel/confirm  (panel confirmation endpoint, #1053)
-- GET  /api/artifacts/note (read-only artifact endpoint, #1063)
+- GET  /api/companion/workspace (read-side workspace aggregate, #1123)
 
 This module does NOT:
 - read or write vault files directly
@@ -70,7 +70,7 @@ class ConfirmOutcome:
 
 @dataclass
 class ArtifactPayload:
-    """Note payload received from GET /api/artifacts/note."""
+    """Note payload received from the workspace aggregate artifact block."""
 
     artifact_id: str
     note_path: str
@@ -85,12 +85,12 @@ class ArtifactPayload:
 
 
 class WorkspaceConfirmSession:
-    """Companion UI session model for Panel confirm → artifact refresh flow.
+    """Companion UI session model for Panel confirm -> artifact refresh flow.
 
     Call confirm() to:
     1. POST to /api/panel/confirm with the staged proposal
     2. Record the typed result
-    3. Reload the artifact note payload via GET /api/artifacts/note
+    3. Reload the artifact note payload via GET /api/companion/workspace
 
     After confirm(), inspect last_result and current_payload.
     """
@@ -136,13 +136,14 @@ class WorkspaceConfirmSession:
 
     def _refresh_artifact(self, *, note_path: str, artifact_id: str) -> None:
         raw = self._http.get(
-            "/api/artifacts/note",
-            params={"note_path": note_path, "artifact_id": artifact_id},
+            "/api/companion/workspace",
+            params={"note_path": note_path},
         )
+        artifact = raw.get("artifact") or {}
         self.current_payload = ArtifactPayload(
-            artifact_id=raw.get("artifact_id", artifact_id),
-            note_path=raw.get("note_path", note_path),
-            title=raw.get("title", ""),
-            body=raw.get("body", ""),
-            content_hash=raw.get("content_hash", ""),
+            artifact_id=artifact.get("artifact_id", artifact_id),
+            note_path=artifact.get("note_path", note_path),
+            title=artifact.get("title", ""),
+            body=artifact.get("body", ""),
+            content_hash=artifact.get("content_hash", ""),
         )

--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -4,7 +4,7 @@ DEV/STAGING ONLY — this is not a production UI contract.
 
 Provides a thin page model that:
 - accepts a NoteLoadIntent (note_path) from the user
-- loads GET /api/artifacts/note via the live HTTP client
+- loads GET /api/companion/workspace via the live HTTP client
 - renders the payload through the read-only workspace shell
 - exposes a secondary Panel/agent rail placeholder
 
@@ -83,6 +83,12 @@ class DevPageState:
     shell: Optional[RealNoteWorkspaceShell] = None
     error: Optional[str] = None
     panel_rail_placeholder: str = "Panel / agent rail — placeholder (dev)"
+    canvas_session_state: str = "idle"
+    canvas_session_persistence: str = ""
+    panel_state: str = "idle"
+    panel_proposal_count: int = 0
+    guard_writeguard_status: str = "ok"
+    guard_canvas_enabled: bool = True
     is_loaded: bool = False
 
 
@@ -117,38 +123,55 @@ class RealNoteWorkspaceDevPage:
     def load(self, intent: NoteLoadIntent) -> DevPageState:
         """Load a note via the runtime API.
 
-        Calls GET /api/artifacts/note through the injected client.
+        Calls GET /api/companion/workspace through the injected client.
         The runtime API determines which vault is read; the page does
         not choose or inspect vault files.
         """
         params: dict = {"note_path": intent.note_path}
-        if intent.artifact_id:
-            params["artifact_id"] = intent.artifact_id
 
         try:
-            raw = self._http.get("/api/artifacts/note", params=params)
+            raw = self._http.get("/api/companion/workspace", params=params)
         except WorkspaceClientError as exc:
             self.state = DevPageState(error=str(exc))
             return self.state
 
+        artifact = raw.get("artifact") or {}
+        canvas = raw.get("canvas") or {}
+        panel = raw.get("panel") or {}
+        guards = raw.get("guards") or {}
+
         # The runtime echoes artifact_id only when supplied in the request.
         # Fall back to note_path so note-path-only loads don't fail the shell's
         # non-empty artifact_id invariant.
-        resolved_note_path = raw.get("note_path") or intent.note_path
+        resolved_note_path = artifact.get("note_path") or intent.note_path
         resolved_artifact_id = (
-            raw.get("artifact_id")
+            artifact.get("artifact_id")
             or intent.artifact_id
             or resolved_note_path
         )
         payload = ArtifactNotePayload(
             artifact_id=resolved_artifact_id,
             note_path=resolved_note_path,
-            title=raw.get("title", ""),
-            body=raw.get("body", ""),
-            content_hash=raw.get("content_hash", ""),
+            title=artifact.get("title", ""),
+            body=artifact.get("body", ""),
+            content_hash=artifact.get("content_hash", ""),
         )
         shell = RealNoteWorkspaceShell(payload=payload, agent_rail_state=None)
-        self.state = DevPageState(shell=shell, is_loaded=True)
+        panel_count = int(panel.get("proposal_count") or 0)
+        panel_label = panel.get("state") or "idle"
+        if panel_count:
+            panel_label = f"{panel_label} ({panel_count} proposal{'s' if panel_count != 1 else ''})"
+        self.state = DevPageState(
+            shell=shell,
+            panel_rail_placeholder=f"Panel state: {panel_label}",
+            canvas_session_state=canvas.get("session_state") or "idle",
+            canvas_session_persistence=canvas.get("session_persistence") or "",
+            panel_state=panel.get("state") or "idle",
+            panel_proposal_count=panel_count,
+            guard_writeguard_status=guards.get("writeguard_status") or "ok",
+            guard_canvas_enabled=bool(guards.get("canvas_enabled", True)),
+            is_loaded=True,
+        )
         return self.state
 
     def render_fields(self) -> Optional[dict]:
@@ -166,6 +189,12 @@ class RealNoteWorkspaceDevPage:
             "body": shell.body,
             "content_hash": shell.content_hash,
             "panel_rail": self.state.panel_rail_placeholder,
+            "canvas_session_state": self.state.canvas_session_state,
+            "canvas_session_persistence": self.state.canvas_session_persistence,
+            "panel_state": self.state.panel_state,
+            "panel_proposal_count": self.state.panel_proposal_count,
+            "guard_writeguard_status": self.state.guard_writeguard_status,
+            "guard_canvas_enabled": self.state.guard_canvas_enabled,
             "is_production_ui": self.is_production_ui,
             "dev_page_label": self.dev_page_label,
         }

--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_shell.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_shell.py
@@ -1,7 +1,7 @@
 """Read-only real-note workspace shell (#1064).
 
 Renders an actual vault note/artifact payload as received from the
-GET /api/artifacts/note endpoint. Note body is the primary surface;
+workspace aggregate artifact block. Note body is the primary surface;
 a reserved secondary slot holds Panel/agent state without requiring Panel data.
 
 This module does NOT:

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -4,7 +4,7 @@ DEV/STAGING ONLY — not for production use.
 
 Does not implement auth, TLS, reverse proxy, or public exposure.
 Calls the configured runtime API through WorkspaceHttpClient
-(GET /api/artifacts/note). Does not read vault files directly.
+(GET /api/companion/workspace). Does not read vault files directly.
 Vault binding is determined by the runtime environment, not by this server.
 
 Environment variables:
@@ -82,6 +82,34 @@ def _render_note_section(fields: dict) -> str:
     content_hash = _e(fields.get("content_hash", ""))
     body = _e(fields.get("body", ""))
     panel_rail = _e(fields.get("panel_rail", "Panel / agent rail placeholder"))
+    canvas_state = _e(fields.get("canvas_session_state", "idle"))
+    persistence = str(fields.get("canvas_session_persistence", ""))
+    panel_state = _e(fields.get("panel_state", "idle"))
+    proposal_count = int(fields.get("panel_proposal_count", 0) or 0)
+    writeguard_status = _e(fields.get("guard_writeguard_status", "ok"))
+    canvas_enabled = bool(fields.get("guard_canvas_enabled", True))
+    guard_messages: list[str] = []
+    if writeguard_status.lower() == "blocked":
+        guard_messages.append("WriteGuard blocked")
+    if not canvas_enabled:
+        guard_messages.append("Canvas disabled")
+    guard_html = ""
+    if guard_messages:
+        guard_html = (
+            '<div class="rail-alert rail-alert-blocked" '
+            'data-testid="workspace-guard-indicator">'
+            + _e(" / ".join(guard_messages))
+            + "</div>"
+        )
+    persistence_html = ""
+    if persistence == "in_memory":
+        persistence_html = (
+            '<div class="rail-alert rail-alert-muted" '
+            'data-testid="workspace-session-persistence">'
+            "Session persistence: in_memory"
+            "</div>"
+        )
+    proposal_text = f"{proposal_count} proposal{'s' if proposal_count != 1 else ''}"
 
     return f"""
   <div class="workspace-layout">
@@ -103,9 +131,20 @@ def _render_note_section(fields: dict) -> str:
     <aside class="agent-rail" data-testid="workspace-agent-rail" data-region="agent-rail">
       <div class="rail-header">
         <span class="rail-label">Companion&nbsp;/ Panel</span>
-        <span class="rail-badge">idle</span>
+        <span class="rail-badge" data-testid="workspace-panel-state">{panel_state}</span>
       </div>
       <div class="rail-placeholder-body">
+        <div class="rail-state-row" data-testid="workspace-canvas-state">
+          <span class="rail-state-label">Canvas</span>
+          <span class="rail-state-value">{canvas_state}</span>
+        </div>
+        <div class="rail-state-row">
+          <span class="rail-state-label">Panel</span>
+          <span class="rail-state-value">{panel_state}</span>
+          <span class="rail-state-count" data-testid="workspace-panel-proposal-count">{proposal_text}</span>
+        </div>
+        {guard_html}
+        {persistence_html}
         {panel_rail}
       </div>
     </aside>
@@ -431,7 +470,43 @@ def render_index_html(
       padding: 16px;
       font-size: var(--text-sm);
       color: var(--fg-3);
-      font-style: italic;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }}
+    .rail-state-row {{
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      font-style: normal;
+    }}
+    .rail-state-label {{
+      color: var(--fg-3);
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }}
+    .rail-state-value, .rail-state-count {{
+      color: var(--fg-2);
+    }}
+    .rail-alert {{
+      border-radius: var(--radius-md);
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      font-style: normal;
+      padding: 8px 10px;
+    }}
+    .rail-alert-blocked {{
+      background: var(--destructive-muted);
+      border: 1px solid rgba(255,61,61,0.3);
+      color: var(--destructive);
+    }}
+    .rail-alert-muted {{
+      background: var(--bg-raised);
+      border: 1px solid var(--border);
+      color: var(--fg-2);
     }}
   </style>
 </head>

--- a/companion-ui/companion-app/companion_ui/workspace/workspace_http_client.py
+++ b/companion-ui/companion-app/companion_ui/workspace/workspace_http_client.py
@@ -2,7 +2,7 @@
 
 Concrete adapter implementing the HttpClient protocol consumed by
 WorkspaceConfirmSession. Uses httpx to call:
-  GET  /api/artifacts/note
+  GET  /api/companion/workspace
   POST /api/panel/confirm
 
 The base URL is configurable so the same client works against dev,

--- a/companion-ui/docs/REAL_NOTE_WORKSPACE_DEV_PAGE.md
+++ b/companion-ui/docs/REAL_NOTE_WORKSPACE_DEV_PAGE.md
@@ -205,8 +205,8 @@ targets. The runtime owns environment and vault binding.
 
 8. **Verify no mutation occurs during simple load.**
 
-   A `GET /api/artifacts/note` request is read-only. Confirm no vault files
-   are modified during a load-only operation.
+   A `GET /api/companion/workspace` request is read-only. Confirm no vault
+   files are modified during a load-only operation.
 
 ### Example environment mappings
 
@@ -277,8 +277,8 @@ The following safety rules apply unconditionally to the dev/staging page:
 
 - **Do not use real dev/test/prod vaults as automated test fixtures.** Automated
   tests must use fake clients, fixtures, or `tmp_path`.
-- **Default UAT remains read-only note loading.** A `GET /api/artifacts/note`
-  call does not mutate vault files.
+- **Default UAT remains read-only workspace loading.** A
+  `GET /api/companion/workspace` call does not mutate vault files.
 - **Confirm/reject/writeback testing against any real environment vault must be
   explicitly operator-gated** and use a disposable test note. It is not part of
   this PR's scope.

--- a/tests/companion_ui/test_panel_confirm_artifact_refresh.py
+++ b/tests/companion_ui/test_panel_confirm_artifact_refresh.py
@@ -52,12 +52,19 @@ _REJECTED_CONFIRM_RESPONSE: dict[str, Any] = {
     "events_emitted": [],
 }
 
-_REFRESHED_ARTIFACT_RESPONSE: dict[str, Any] = {
+_REFRESHED_ARTIFACT: dict[str, Any] = {
     "artifact_id": "note-uuid-1",
-    "note_path": "/vault/notes/test.md",
+    "note_path": "notes/test.md",
     "title": "Test Note",
     "body": "# Test Note\n\nUpdated body after confirm.",
     "content_hash": "refreshed00",
+}
+
+_REFRESHED_WORKSPACE_RESPONSE: dict[str, Any] = {
+    "artifact": _REFRESHED_ARTIFACT,
+    "canvas": {"session_state": "idle", "session_persistence": "in_memory"},
+    "panel": {"state": "idle", "proposal_count": 0},
+    "guards": {"canvas_enabled": True, "writeguard_status": "ok"},
 }
 
 
@@ -67,7 +74,7 @@ class _StubHttpClient:
     def __init__(
         self,
         confirm_response: dict[str, Any],
-        artifact_response: dict[str, Any] = _REFRESHED_ARTIFACT_RESPONSE,
+        artifact_response: dict[str, Any] = _REFRESHED_WORKSPACE_RESPONSE,
     ) -> None:
         self._confirm = confirm_response
         self._artifact = artifact_response
@@ -87,7 +94,7 @@ def _confirm_kwargs(**overrides) -> dict:
     base = {
         "proposal_id": "prop-1",
         "artifact_id": "note-uuid-1",
-        "note_path": "/vault/notes/test.md",
+        "note_path": "notes/test.md",
         "action": "confirm",
         "idempotency_key": "idem-1",
     }
@@ -167,7 +174,7 @@ def test_panel_confirm_displays_rejected_result() -> None:
 def test_panel_confirm_refreshes_artifact_payload_after_response() -> None:
     http = _StubHttpClient(
         confirm_response=_EXECUTED_CONFIRM_RESPONSE,
-        artifact_response=_REFRESHED_ARTIFACT_RESPONSE,
+        artifact_response=_REFRESHED_WORKSPACE_RESPONSE,
     )
     session = WorkspaceConfirmSession(http)
 
@@ -184,9 +191,9 @@ def test_panel_confirm_refreshes_artifact_payload_after_response() -> None:
     # Artifact endpoint was called exactly once
     assert len(http.artifact_calls) == 1
     art_call = http.artifact_calls[0]
-    assert art_call["url"] == "/api/artifacts/note"
-    assert art_call["params"]["note_path"] == "/vault/notes/test.md"
-    assert art_call["params"]["artifact_id"] == "note-uuid-1"
+    assert art_call["url"] == "/api/companion/workspace"
+    assert art_call["params"]["note_path"] == "notes/test.md"
+    assert "artifact_id" not in art_call["params"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/companion_ui/test_real_note_workspace_dev_page.py
+++ b/tests/companion_ui/test_real_note_workspace_dev_page.py
@@ -45,6 +45,23 @@ def _artifact_response(**overrides: Any) -> dict[str, Any]:
     return base
 
 
+def _workspace_response(
+    *,
+    artifact: dict[str, Any] | None = None,
+    canvas: dict[str, Any] | None = None,
+    panel: dict[str, Any] | None = None,
+    guards: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "artifact": artifact or _artifact_response(),
+        "canvas": canvas or {"session_state": "idle", "session_persistence": "in_memory"},
+        "panel": panel or {"state": "idle", "proposal_count": 0},
+        "guards": guards or {"canvas_enabled": True, "writeguard_status": "ok"},
+        "runtime": {},
+        "suggestions": {},
+    }
+
+
 def _mock_get_response(payload: dict) -> MagicMock:
     m = MagicMock()
     m.status_code = 200
@@ -56,7 +73,7 @@ def _loaded_page(
     note_path: str = "notes/research.md",
     response: dict | None = None,
 ) -> RealNoteWorkspaceDevPage:
-    resp = response or _artifact_response()
+    resp = response or _workspace_response()
     mock_resp = _mock_get_response(resp)
     with patch("httpx.get", return_value=mock_resp):
         client = WorkspaceHttpClient(base_url="http://localhost:18001")
@@ -82,7 +99,7 @@ def test_dev_page_exposes_note_path_load_intent() -> None:
     assert intent_with_id.artifact_id == "uuid-1"
 
     # Dev page calls the runtime API with note_path from the intent
-    mock_resp = _mock_get_response(_artifact_response())
+    mock_resp = _mock_get_response(_workspace_response())
     with patch("httpx.get", return_value=mock_resp) as mock_get:
         client = WorkspaceHttpClient(base_url="http://localhost:18001")
         page = RealNoteWorkspaceDevPage(client)
@@ -90,6 +107,7 @@ def test_dev_page_exposes_note_path_load_intent() -> None:
 
     assert state.is_loaded is True
     call_args = mock_get.call_args
+    assert call_args.args[0] == "http://localhost:18001/api/companion/workspace"
     assert "note_path" in call_args.kwargs["params"]
     assert call_args.kwargs["params"]["note_path"] == "Notes/test.md"
 
@@ -101,13 +119,13 @@ def test_dev_page_exposes_note_path_load_intent() -> None:
 
 def test_dev_page_renders_real_note_payload() -> None:
     """Dev page renders title, path, artifact_id, body, and content marker."""
-    page = _loaded_page(response=_artifact_response(
+    page = _loaded_page(response=_workspace_response(artifact=_artifact_response(
         artifact_id="note-uuid-42",
-        note_path="/vault/notes/research.md",
+        note_path="notes/research.md",
         title="Research Note",
         body="# Research Note\n\nDetailed body.",
         content_hash="deadbeef0042",
-    ))
+    )))
 
     assert page.state.is_loaded is True
     assert page.state.shell is not None
@@ -115,7 +133,7 @@ def test_dev_page_renders_real_note_payload() -> None:
     # All required fields present
     shell = page.state.shell
     assert shell.title == "Research Note"
-    assert shell.note_path == "/vault/notes/research.md"
+    assert shell.note_path == "notes/research.md"
     assert shell.artifact_id == "note-uuid-42"
     assert "Detailed body" in shell.body
     assert shell.content_hash == "deadbeef0042"
@@ -124,7 +142,27 @@ def test_dev_page_renders_real_note_payload() -> None:
     fields = page.render_fields()
     assert fields is not None
     assert fields["title"] == "Research Note"
-    assert fields["note_path"] == "/vault/notes/research.md"
+    assert fields["note_path"] == "notes/research.md"
+
+
+def test_loads_from_workspace_aggregate() -> None:
+    """Dev page reads artifact, Canvas, Panel, and guard fields from the workspace aggregate."""
+    page = _loaded_page(response=_workspace_response(
+        artifact=_artifact_response(title="Aggregate Note"),
+        canvas={"session_state": "active", "session_persistence": "in_memory"},
+        panel={"state": "proposal_staged", "proposal_count": 2},
+        guards={"canvas_enabled": False, "writeguard_status": "blocked"},
+    ))
+
+    fields = page.render_fields()
+    assert fields is not None
+    assert fields["title"] == "Aggregate Note"
+    assert fields["canvas_session_state"] == "active"
+    assert fields["canvas_session_persistence"] == "in_memory"
+    assert fields["panel_state"] == "proposal_staged"
+    assert fields["panel_proposal_count"] == 2
+    assert fields["guard_writeguard_status"] == "blocked"
+    assert fields["guard_canvas_enabled"] is False
     assert fields["artifact_id"] == "note-uuid-42"
     assert "Detailed body" in fields["body"]
     assert fields["content_hash"] == "deadbeef0042"
@@ -185,7 +223,7 @@ def test_dev_page_is_marked_non_production() -> None:
     assert "dev" in page_label_lower or "staging" in page_label_lower
 
     # render_fields exposes is_production_ui=False after load
-    mock_resp = _mock_get_response(_artifact_response())
+    mock_resp = _mock_get_response(_workspace_response())
     with patch("httpx.get", return_value=mock_resp):
         page.load(NoteLoadIntent(note_path="notes/test.md"))
 
@@ -257,22 +295,22 @@ def test_dev_page_note_path_only_load_succeeds_without_artifact_id() -> None:
     must not raise. It should fall back to note_path as the artifact identifier
     so the workspace shell's non-empty artifact_id invariant is satisfied."""
     # Simulate the runtime behaviour: artifact_id echoed as "" when not supplied
-    response_without_artifact_id = {
+    response_without_artifact_id = _workspace_response(artifact={
         "artifact_id": "",
-        "note_path": "/vault/notes/test.md",
+        "note_path": "notes/test.md",
         "title": "Test Note",
         "body": "# Test Note\n\nBody.",
         "content_hash": "abc000",
-    }
+    })
     mock_resp = _mock_get_response(response_without_artifact_id)
 
     with patch("httpx.get", return_value=mock_resp):
         client = WorkspaceHttpClient(base_url="http://localhost:18001")
         page = RealNoteWorkspaceDevPage(client)
-        state = page.load(NoteLoadIntent(note_path="/vault/notes/test.md"))
+        state = page.load(NoteLoadIntent(note_path="notes/test.md"))
 
     assert state.is_loaded is True, f"Expected load to succeed; error: {state.error}"
     assert state.shell is not None
     # Artifact ID falls back to note_path when API returns empty
-    assert state.shell.artifact_id == "/vault/notes/test.md"
+    assert state.shell.artifact_id == "notes/test.md"
     assert state.shell.title == "Test Note"

--- a/tests/companion_ui/test_real_note_workspace_dev_server.py
+++ b/tests/companion_ui/test_real_note_workspace_dev_server.py
@@ -69,11 +69,18 @@ def _note_payload(
     body: str = "This is the note body.",
 ) -> dict:
     return {
-        "note_path": note_path,
-        "title": title,
-        "artifact_id": artifact_id,
-        "content_hash": content_hash,
-        "body": body,
+        "artifact": {
+            "note_path": note_path,
+            "title": title,
+            "artifact_id": artifact_id,
+            "content_hash": content_hash,
+            "body": body,
+        },
+        "canvas": {"session_state": "idle", "session_persistence": "in_memory"},
+        "panel": {"state": "idle", "proposal_count": 0},
+        "guards": {"canvas_enabled": True, "writeguard_status": "ok"},
+        "runtime": {},
+        "suggestions": {},
     }
 
 
@@ -368,7 +375,7 @@ class TestHandleGet:
         )
         assert len(client.get_calls) == 1
         url, params = client.get_calls[0]
-        assert url == "/api/artifacts/note"
+        assert url == "/api/companion/workspace"
         assert params.get("note_path") == "Some/Note.md"
 
     def test_successful_load_renders_note_fields(self) -> None:

--- a/tests/companion_ui/test_real_note_workspace_visual_shell.py
+++ b/tests/companion_ui/test_real_note_workspace_visual_shell.py
@@ -35,6 +35,12 @@ def _fields(
     content_hash: str = "sha256-feedcafe",
     body: str = "# Research Note\n\nContent goes here.",
     panel_rail: str = "Panel / agent rail placeholder",
+    canvas_session_state: str = "idle",
+    canvas_session_persistence: str = "in_memory",
+    panel_state: str = "idle",
+    panel_proposal_count: int = 0,
+    guard_writeguard_status: str = "ok",
+    guard_canvas_enabled: bool = True,
 ) -> dict:
     return {
         "title": title,
@@ -43,6 +49,12 @@ def _fields(
         "content_hash": content_hash,
         "body": body,
         "panel_rail": panel_rail,
+        "canvas_session_state": canvas_session_state,
+        "canvas_session_persistence": canvas_session_persistence,
+        "panel_state": panel_state,
+        "panel_proposal_count": panel_proposal_count,
+        "guard_writeguard_status": guard_writeguard_status,
+        "guard_canvas_enabled": guard_canvas_enabled,
         "is_production_ui": False,
         "dev_page_label": "dev/staging",
     }
@@ -223,6 +235,32 @@ class TestAgentRail:
         """Rail must carry an idle state badge for future Panel state wiring."""
         html = _html_with_note()
         assert "idle" in html
+
+    def test_canvas_state_indicator(self) -> None:
+        html = _html_with_note(canvas_session_state="paused")
+        assert 'data-testid="workspace-canvas-state"' in html
+        assert "Canvas" in html
+        assert "paused" in html
+
+    def test_panel_state_indicator(self) -> None:
+        html = _html_with_note(panel_state="proposal_staged", panel_proposal_count=2)
+        assert 'data-testid="workspace-panel-state"' in html
+        assert "proposal_staged" in html
+        assert "2 proposals" in html
+
+    def test_guard_blocked_indicator(self) -> None:
+        html = _html_with_note(
+            guard_writeguard_status="blocked",
+            guard_canvas_enabled=False,
+        )
+        assert 'data-testid="workspace-guard-indicator"' in html
+        assert "WriteGuard blocked" in html
+        assert "Canvas disabled" in html
+
+    def test_in_memory_session_persistence_notice(self) -> None:
+        html = _html_with_note(canvas_session_persistence="in_memory")
+        assert 'data-testid="workspace-session-persistence"' in html
+        assert "Session persistence: in_memory" in html
 
 
 # ---------------------------------------------------------------------------

--- a/tests/companion_ui/test_workspace_http_client.py
+++ b/tests/companion_ui/test_workspace_http_client.py
@@ -1,7 +1,7 @@
 """Tests: live workspace HTTP client (#1071).
 
 Verifies that WorkspaceHttpClient:
-- fetches artifact note payloads from a configured base URL
+- fetches workspace aggregate payloads from a configured base URL
 - submits Panel confirm requests to the correct endpoint
 - maps executed/blocked/rejected/logged outcomes into WorkspaceConfirmSession shape
 - surfaces HTTP/API failures as typed client errors, not silent empty states
@@ -59,32 +59,39 @@ _REFRESHED_ARTIFACT: dict[str, Any] = {
     "content_hash": "refreshed00",
 }
 
+_REFRESHED_WORKSPACE: dict[str, Any] = {
+    "artifact": _REFRESHED_ARTIFACT,
+    "canvas": {"session_state": "idle", "session_persistence": "in_memory"},
+    "panel": {"state": "idle", "proposal_count": 0},
+    "guards": {"canvas_enabled": True, "writeguard_status": "ok"},
+}
+
 
 # ---------------------------------------------------------------------------
 # AC 1: client fetches artifact note payload from configured base URL
 # ---------------------------------------------------------------------------
 
 
-def test_workspace_http_client_fetches_artifact_note() -> None:
-    """Client calls GET /api/artifacts/note at the configured base URL."""
-    mock_resp = _mock_response(200, _SAMPLE_ARTIFACT)
+def test_workspace_http_client_fetches_workspace_aggregate() -> None:
+    """Client calls GET /api/companion/workspace at the configured base URL."""
+    mock_resp = _mock_response(200, {"artifact": _SAMPLE_ARTIFACT})
 
     with patch("httpx.get", return_value=mock_resp) as mock_get:
         client = WorkspaceHttpClient(base_url="http://localhost:18001")
         result = client.get(
-            "/api/artifacts/note",
+            "/api/companion/workspace",
             params={"note_path": "/vault/notes/test.md"},
         )
 
     mock_get.assert_called_once()
     call_args = mock_get.call_args
-    assert call_args.args[0] == "http://localhost:18001/api/artifacts/note"
+    assert call_args.args[0] == "http://localhost:18001/api/companion/workspace"
     assert call_args.kwargs["params"]["note_path"] == "/vault/notes/test.md"
 
-    assert result["artifact_id"] == "note-uuid-1"
-    assert result["title"] == "Test Note"
-    assert result["content_hash"] == "abc123def456"
-    assert "Body content" in result["body"]
+    assert result["artifact"]["artifact_id"] == "note-uuid-1"
+    assert result["artifact"]["title"] == "Test Note"
+    assert result["artifact"]["content_hash"] == "abc123def456"
+    assert "Body content" in result["artifact"]["body"]
 
 
 # ---------------------------------------------------------------------------
@@ -177,7 +184,7 @@ def test_workspace_http_client_maps_panel_confirm_outcomes() -> None:
             **extra,
         }
         confirm_mock = _mock_response(200, confirm_payload)
-        artifact_mock = _mock_response(200, _REFRESHED_ARTIFACT)
+        artifact_mock = _mock_response(200, _REFRESHED_WORKSPACE)
 
         with patch("httpx.post", return_value=confirm_mock), \
              patch("httpx.get", return_value=artifact_mock):
@@ -220,14 +227,14 @@ def test_workspace_http_client_surfaces_typed_errors() -> None:
     with patch("httpx.get", return_value=_mock_response(404, '{"error":"note_not_found"}')):
         client = WorkspaceHttpClient(base_url="http://localhost:18001")
         with pytest.raises(WorkspaceClientHTTPError) as exc_info:
-            client.get("/api/artifacts/note", params={"note_path": "missing.md"})
+            client.get("/api/companion/workspace", params={"note_path": "missing.md"})
         assert exc_info.value.status_code == 404
 
     # 500 → WorkspaceClientHTTPError with status_code
     with patch("httpx.get", return_value=_mock_response(500, "Internal Server Error")):
         client = WorkspaceHttpClient(base_url="http://localhost:18001")
         with pytest.raises(WorkspaceClientHTTPError) as exc_info:
-            client.get("/api/artifacts/note", params={"note_path": "error.md"})
+            client.get("/api/companion/workspace", params={"note_path": "error.md"})
         assert exc_info.value.status_code == 500
 
     # 422 on confirm → WorkspaceClientHTTPError
@@ -241,13 +248,13 @@ def test_workspace_http_client_surfaces_typed_errors() -> None:
     with patch("httpx.get", side_effect=_httpx.ConnectError("connection refused")):
         client = WorkspaceHttpClient(base_url="http://localhost:18001")
         with pytest.raises(WorkspaceClientNetworkError):
-            client.get("/api/artifacts/note", params={"note_path": "test.md"})
+            client.get("/api/companion/workspace", params={"note_path": "test.md"})
 
     # Timeout → WorkspaceClientNetworkError
     with patch("httpx.get", side_effect=_httpx.TimeoutException("timed out")):
         client = WorkspaceHttpClient(base_url="http://localhost:18001")
         with pytest.raises(WorkspaceClientNetworkError):
-            client.get("/api/artifacts/note", params={"note_path": "slow.md"})
+            client.get("/api/companion/workspace", params={"note_path": "slow.md"})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replaces the real-note dev shell note load with `GET /api/companion/workspace`.
- Renders aggregate Canvas, Panel, guard, and in-memory persistence indicators in the Companion rail.
- Migrates confirm refresh and workspace docs away from the old separate note-read endpoint.

## Issues
- Closes #1124

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_real_note_workspace_dev_page.py::test_loads_from_workspace_aggregate tests/companion_ui/test_real_note_workspace_visual_shell.py::TestAgentRail::test_canvas_state_indicator tests/companion_ui/test_real_note_workspace_visual_shell.py::TestAgentRail::test_panel_state_indicator tests/companion_ui/test_real_note_workspace_visual_shell.py::TestAgentRail::test_guard_blocked_indicator`
- `grep -r "api/artifacts/note" companion-ui/companion-app/companion_ui/workspace/` (no matches; exit 1)
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_real_note_workspace_dev_page.py tests/companion_ui/test_real_note_workspace_visual_shell.py tests/companion_ui/test_real_note_workspace_dev_server.py tests/companion_ui/test_panel_confirm_artifact_refresh.py tests/companion_ui/test_workspace_http_client.py`
- `/tmp/agentic-pkm-checks-1123/bin/ruff check companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py companion-ui/companion-app/companion_ui/workspace/confirm_session.py companion-ui/companion-app/companion_ui/workspace/workspace_http_client.py companion-ui/companion-app/companion_ui/workspace/real_note_workspace_shell.py tests/companion_ui/test_real_note_workspace_dev_page.py tests/companion_ui/test_real_note_workspace_visual_shell.py tests/companion_ui/test_real_note_workspace_dev_server.py tests/companion_ui/test_panel_confirm_artifact_refresh.py tests/companion_ui/test_workspace_http_client.py`
- `git diff --check`
- `python3 scripts/docs_guard.py`

## Notes
- Dispatcher status check was unavailable in this local Python due missing `yaml`; issue pickup used the GitHub label fallback and Project status was set to In Progress before implementation.