### PR TITLE
Bind Panel rail to workspace state

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -33,8 +33,10 @@ This module does NOT:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 
+from companion_ui.panel.proposal_row import ProposalEvidence, ProposalRow
+from companion_ui.panel.render_model import PanelRenderState, render_panel_state
 from companion_ui.workspace.real_note_workspace_shell import (
     ArtifactNotePayload,
     RealNoteWorkspaceShell,
@@ -87,6 +89,8 @@ class DevPageState:
     canvas_session_persistence: str = ""
     panel_state: str = "idle"
     panel_proposal_count: int = 0
+    panel_render: dict[str, Any] | None = None
+    panel_proposals: list[dict[str, Any]] | None = None
     guard_writeguard_status: str = "ok"
     guard_canvas_enabled: bool = True
     is_loaded: bool = False
@@ -158,16 +162,28 @@ class RealNoteWorkspaceDevPage:
         )
         shell = RealNoteWorkspaceShell(payload=payload, agent_rail_state=None)
         panel_count = int(panel.get("proposal_count") or 0)
-        panel_label = panel.get("state") or "idle"
-        if panel_count:
-            panel_label = f"{panel_label} ({panel_count} proposal{'s' if panel_count != 1 else ''})"
+        panel_state = panel.get("state") or "idle"
+        panel_message = _panel_message(panel)
+        render_state = PanelRenderState(
+            artifact_id=resolved_artifact_id,
+            state=panel_state,
+            message=panel_message,
+            proposal_count=panel_count,
+        )
+        panel_render = render_panel_state(render_state)
+        panel_proposals = _proposal_rows_from_panel(
+            panel=panel,
+            artifact_id=resolved_artifact_id,
+        )
         self.state = DevPageState(
             shell=shell,
-            panel_rail_placeholder=f"Panel state: {panel_label}",
+            panel_rail_placeholder=panel_render.get("label", "Panel ready"),
             canvas_session_state=canvas.get("session_state") or "idle",
             canvas_session_persistence=canvas.get("session_persistence") or "",
-            panel_state=panel.get("state") or "idle",
+            panel_state=panel_state,
             panel_proposal_count=panel_count,
+            panel_render=panel_render,
+            panel_proposals=panel_proposals,
             guard_writeguard_status=guards.get("writeguard_status") or "ok",
             guard_canvas_enabled=bool(guards.get("canvas_enabled", True)),
             is_loaded=True,
@@ -193,8 +209,53 @@ class RealNoteWorkspaceDevPage:
             "canvas_session_persistence": self.state.canvas_session_persistence,
             "panel_state": self.state.panel_state,
             "panel_proposal_count": self.state.panel_proposal_count,
+            "panel_render": self.state.panel_render or {},
+            "panel_proposals": self.state.panel_proposals or [],
             "guard_writeguard_status": self.state.guard_writeguard_status,
             "guard_canvas_enabled": self.state.guard_canvas_enabled,
             "is_production_ui": self.is_production_ui,
             "dev_page_label": self.dev_page_label,
         }
+
+
+def _panel_message(panel: dict[str, Any]) -> str | None:
+    state = panel.get("state") or "idle"
+    if state == "blocked":
+        return panel.get("blocked_reason") or panel.get("message")
+    if state == "no-match":
+        return panel.get("no_match_reason") or panel.get("message")
+    return panel.get("message")
+
+
+def _proposal_rows_from_panel(
+    *,
+    panel: dict[str, Any],
+    artifact_id: str,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for raw in panel.get("proposals") or []:
+        evidence_raw = raw.get("evidence") or {}
+        evidence = ProposalEvidence(
+            trigger_summary=evidence_raw.get("trigger_summary", ""),
+            action_class=evidence_raw.get("action_class", ""),
+            cognition_route=evidence_raw.get("cognition_route", ""),
+        )
+        affordances = _proposal_affordance_set(raw.get("affordances"))
+        row = ProposalRow(
+            proposal_id=raw.get("proposal_id", ""),
+            artifact_id=raw.get("artifact_id") or artifact_id,
+            description=raw.get("description", ""),
+            evidence=evidence,
+            available_affordances=affordances,
+            status=raw.get("status", "staged"),
+        )
+        rows.append(row.as_render_dict())
+    return rows
+
+
+def _proposal_affordance_set(raw: Any) -> set[str]:
+    if isinstance(raw, dict):
+        return {name for name, enabled in raw.items() if enabled}
+    if isinstance(raw, list):
+        return set(raw)
+    return {"confirm", "correct", "reject"}

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -84,7 +84,10 @@ def _render_note_section(fields: dict) -> str:
     panel_rail = _e(fields.get("panel_rail", "Panel / agent rail placeholder"))
     canvas_state = _e(fields.get("canvas_session_state", "idle"))
     persistence = str(fields.get("canvas_session_persistence", ""))
-    panel_state = _e(fields.get("panel_state", "idle"))
+    panel_render = fields.get("panel_render") or {}
+    panel_state = _e(panel_render.get("state") or fields.get("panel_state", "idle"))
+    panel_label = _e(panel_render.get("label") or panel_rail)
+    panel_message = _e(panel_render.get("message") or "")
     proposal_count = int(fields.get("panel_proposal_count", 0) or 0)
     writeguard_status = _e(fields.get("guard_writeguard_status", "ok"))
     canvas_enabled = bool(fields.get("guard_canvas_enabled", True))
@@ -110,6 +113,16 @@ def _render_note_section(fields: dict) -> str:
             "</div>"
         )
     proposal_text = f"{proposal_count} proposal{'s' if proposal_count != 1 else ''}"
+    panel_message_html = ""
+    if panel_message:
+        panel_message_html = (
+            '<div class="panel-message" data-testid="workspace-panel-message">'
+            + panel_message
+            + "</div>"
+        )
+    proposal_rows_html = _render_panel_proposal_rows(
+        fields.get("panel_proposals") or [],
+    )
 
     return f"""
   <div class="workspace-layout">
@@ -140,15 +153,51 @@ def _render_note_section(fields: dict) -> str:
         </div>
         <div class="rail-state-row">
           <span class="rail-state-label">Panel</span>
-          <span class="rail-state-value">{panel_state}</span>
+          <span class="rail-state-value" data-testid="workspace-panel-label">{panel_label}</span>
           <span class="rail-state-count" data-testid="workspace-panel-proposal-count">{proposal_text}</span>
         </div>
+        {panel_message_html}
+        {proposal_rows_html}
         {guard_html}
         {persistence_html}
         {panel_rail}
       </div>
     </aside>
   </div>"""
+
+
+def _render_panel_proposal_rows(proposals: list[dict]) -> str:
+    if not proposals:
+        return ""
+
+    rows: list[str] = []
+    for proposal in proposals:
+        evidence = proposal.get("evidence") or {}
+        affordances = proposal.get("affordances") or {}
+        enabled_affordances = [
+            label
+            for label in ("confirm", "correct", "reject")
+            if affordances.get(label)
+        ]
+        rows.append(
+            f"""
+        <div class="panel-proposal-row" data-testid="workspace-panel-proposal-row">
+          <div class="panel-proposal-title">{_e(proposal.get("description", ""))}</div>
+          <div class="panel-proposal-meta">
+            <span>{_e(proposal.get("proposal_id", ""))}</span>
+            <span>{_e(proposal.get("status", ""))}</span>
+          </div>
+          <div class="panel-proposal-evidence" data-testid="workspace-panel-evidence">
+            <span>{_e(evidence.get("trigger_summary", ""))}</span>
+            <span>{_e(evidence.get("action_class", ""))}</span>
+            <span>{_e(evidence.get("cognition_route", ""))}</span>
+          </div>
+          <div class="panel-proposal-affordances">
+            {_e(" / ".join(enabled_affordances))}
+          </div>
+        </div>"""
+        )
+    return "\n".join(rows)
 
 
 def _render_error_section(error: str) -> str:
@@ -507,6 +556,35 @@ def render_index_html(
       background: var(--bg-raised);
       border: 1px solid var(--border);
       color: var(--fg-2);
+    }}
+    .panel-message {{
+      border-left: 2px solid var(--accent);
+      color: var(--fg-2);
+      font-size: var(--text-sm);
+      padding-left: 10px;
+    }}
+    .panel-proposal-row {{
+      background: var(--bg-raised);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      color: var(--fg-2);
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      padding: 10px;
+    }}
+    .panel-proposal-title {{
+      color: var(--fg-1);
+      font-size: var(--text-sm);
+      font-style: normal;
+    }}
+    .panel-proposal-meta, .panel-proposal-evidence, .panel-proposal-affordances {{
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      font-style: normal;
     }}
   </style>
 </head>

--- a/tests/companion_ui/test_panel_rail_browser.py
+++ b/tests/companion_ui/test_panel_rail_browser.py
@@ -1,0 +1,133 @@
+"""Tests for live Panel state binding in the Companion workspace rail (#1137)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from companion_ui.panel.render_model import PANEL_STATES_REQUIRED
+from companion_ui.workspace.real_note_workspace_dev_page import (
+    NoteLoadIntent,
+    RealNoteWorkspaceDevPage,
+)
+from companion_ui.workspace.serve_dev_page import render_index_html
+
+
+class _FakeClient:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append((url, params))
+        return self.payload
+
+
+def _workspace_payload(panel: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "artifact": {
+            "artifact_id": "art-1137",
+            "note_path": "Notes/panel.md",
+            "title": "Panel Note",
+            "body": "# Panel Note\n\nBody.",
+            "content_hash": "sha256-panel",
+        },
+        "canvas": {"session_state": "idle", "session_persistence": "in_memory"},
+        "panel": panel,
+        "guards": {"canvas_enabled": True, "writeguard_status": "ok"},
+        "runtime": {},
+        "suggestions": {},
+    }
+
+
+def _html_for_panel(panel: dict[str, Any]) -> str:
+    client = _FakeClient(_workspace_payload(panel))
+    page = RealNoteWorkspaceDevPage(client)  # type: ignore[arg-type]
+    state = page.load(NoteLoadIntent(note_path="Notes/panel.md"))
+    assert state.is_loaded is True
+    assert client.calls == [
+        ("/api/companion/workspace", {"note_path": "Notes/panel.md"}),
+    ]
+    fields = page.render_fields()
+    assert fields is not None
+    return render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="Notes/panel.md",
+        fields=fields,
+    )
+
+
+def test_all_panel_states_render() -> None:
+    for state in sorted(PANEL_STATES_REQUIRED):
+        panel: dict[str, Any] = {"state": state, "proposal_count": 0}
+        if state == "proposals-staged":
+            panel["proposal_count"] = 1
+        if state == "blocked":
+            panel["blocked_reason"] = "WriteGuard blocked this action."
+        if state == "no-match":
+            panel["no_match_reason"] = "No actionable proposals were found."
+
+        html = _html_for_panel(panel)
+
+        assert 'data-testid="workspace-panel-state"' in html
+        assert state in html
+        assert 'data-testid="workspace-panel-label"' in html
+
+
+def test_proposal_rows_rendered() -> None:
+    html = _html_for_panel({
+        "state": "proposals-staged",
+        "proposal_count": 2,
+        "proposals": [
+            {
+                "proposal_id": "prop-1",
+                "description": "Move note to Projects",
+                "status": "staged",
+                "evidence": {
+                    "trigger_summary": "Project tag detected",
+                    "action_class": "lifecycle.move",
+                    "cognition_route": "rule",
+                },
+                "affordances": {"confirm": True, "correct": True, "reject": True},
+            },
+            {
+                "proposal_id": "prop-2",
+                "description": "Add follow-up reminder",
+                "status": "staged",
+                "evidence": {
+                    "trigger_summary": "Contains commitment language",
+                    "action_class": "followup.create",
+                    "cognition_route": "freeform",
+                },
+                "affordances": ["confirm", "reject"],
+            },
+        ],
+    })
+
+    assert html.count('data-testid="workspace-panel-proposal-row"') == 2
+    assert "Move note to Projects" in html
+    assert "Add follow-up reminder" in html
+    assert "Project tag detected" in html
+    assert "lifecycle.move" in html
+    assert "freeform" in html
+
+
+def test_blocked_reason_visible() -> None:
+    html = _html_for_panel({
+        "state": "blocked",
+        "proposal_count": 0,
+        "blocked_reason": "WriteGuard blocked execution in dev.",
+    })
+
+    assert 'data-testid="workspace-panel-message"' in html
+    assert "WriteGuard blocked execution in dev." in html
+
+
+def test_no_match_reason_visible() -> None:
+    html = _html_for_panel({
+        "state": "no-match",
+        "proposal_count": 0,
+        "no_match_reason": "Panel found no matching catalog action.",
+    })
+
+    assert 'data-testid="workspace-panel-message"' in html
+    assert "Panel found no matching catalog action." in html

--- a/tests/companion_ui/test_real_note_workspace_dev_page.py
+++ b/tests/companion_ui/test_real_note_workspace_dev_page.py
@@ -150,7 +150,7 @@ def test_loads_from_workspace_aggregate() -> None:
     page = _loaded_page(response=_workspace_response(
         artifact=_artifact_response(title="Aggregate Note"),
         canvas={"session_state": "active", "session_persistence": "in_memory"},
-        panel={"state": "proposal_staged", "proposal_count": 2},
+        panel={"state": "proposals-staged", "proposal_count": 2},
         guards={"canvas_enabled": False, "writeguard_status": "blocked"},
     ))
 
@@ -159,7 +159,7 @@ def test_loads_from_workspace_aggregate() -> None:
     assert fields["title"] == "Aggregate Note"
     assert fields["canvas_session_state"] == "active"
     assert fields["canvas_session_persistence"] == "in_memory"
-    assert fields["panel_state"] == "proposal_staged"
+    assert fields["panel_state"] == "proposals-staged"
     assert fields["panel_proposal_count"] == 2
     assert fields["guard_writeguard_status"] == "blocked"
     assert fields["guard_canvas_enabled"] is False


### PR DESCRIPTION
## Summary
- Binds the Companion rail to server-declared Panel state via the workspace aggregate.
- Uses `PanelRenderState` and `ProposalRow` to normalize Panel labels, messages, proposal rows, evidence, and affordances.
- Adds browser rail coverage for all required Panel states, proposal rows, blocked reason, and no-match reason.

## Issues
- Closes #1137

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_panel_rail_browser.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_panel_rail_browser.py tests/companion_ui/test_real_note_workspace_dev_page.py tests/companion_ui/test_real_note_workspace_visual_shell.py tests/companion_ui/test_real_note_workspace_dev_server.py tests/companion_ui/test_panel_visual_shell.py tests/companion_ui/test_panel_render_model.py tests/companion_ui/test_panel_proposal_row.py`
- `/tmp/agentic-pkm-checks-1123/bin/ruff check companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py tests/companion_ui/test_panel_rail_browser.py tests/companion_ui/test_real_note_workspace_dev_page.py`
- `git diff --check`

## Notes
- Backend aggregate schema was not expanded in this slice. The rail consumes optional `panel.proposals` rows when present and still renders current real aggregate fields (`panel.state`, counts, blocked/no-match reasons) without extra backend scope.