### PR TITLE
Bind Canvas session controls

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -85,7 +85,11 @@ class DevPageState:
     shell: Optional[RealNoteWorkspaceShell] = None
     error: Optional[str] = None
     panel_rail_placeholder: str = "Panel / agent rail — placeholder (dev)"
+    canvas_session_id: str | None = None
     canvas_session_state: str = "idle"
+    canvas_user_present: bool = False
+    canvas_can_edit_body: bool = False
+    canvas_recovery_needed: bool = False
     canvas_session_persistence: str = ""
     panel_state: str = "idle"
     panel_proposal_count: int = 0
@@ -178,7 +182,11 @@ class RealNoteWorkspaceDevPage:
         self.state = DevPageState(
             shell=shell,
             panel_rail_placeholder=panel_render.get("label", "Panel ready"),
+            canvas_session_id=canvas.get("session_id"),
             canvas_session_state=canvas.get("session_state") or "idle",
+            canvas_user_present=bool(canvas.get("user_present", False)),
+            canvas_can_edit_body=bool(canvas.get("can_edit_body", False)),
+            canvas_recovery_needed=bool(canvas.get("recovery_needed", False)),
             canvas_session_persistence=canvas.get("session_persistence") or "",
             panel_state=panel_state,
             panel_proposal_count=panel_count,
@@ -189,6 +197,35 @@ class RealNoteWorkspaceDevPage:
             is_loaded=True,
         )
         return self.state
+
+    def open_canvas_session(self, intent: NoteLoadIntent) -> DevPageState:
+        """Open a Canvas session through the runtime, then refresh workspace state."""
+        try:
+            self._http.post(
+                "/api/canvas/sessions",
+                json={"note_path": intent.note_path},
+            )
+        except WorkspaceClientError as exc:
+            self.state = DevPageState(error=str(exc))
+            return self.state
+        return self.load(intent)
+
+    def close_canvas_session(
+        self,
+        *,
+        session_id: str,
+        note_path: str,
+    ) -> DevPageState:
+        """Close a Canvas session through the runtime, then refresh workspace state."""
+        try:
+            self._http.delete(
+                f"/api/canvas/sessions/{session_id}",
+                params={"total_summary": "session closed from Companion UI"},
+            )
+        except WorkspaceClientError as exc:
+            self.state = DevPageState(error=str(exc))
+            return self.state
+        return self.load(NoteLoadIntent(note_path=note_path))
 
     def render_fields(self) -> Optional[dict]:
         """Return a flat dict of renderable fields for the current state.
@@ -205,7 +242,11 @@ class RealNoteWorkspaceDevPage:
             "body": shell.body,
             "content_hash": shell.content_hash,
             "panel_rail": self.state.panel_rail_placeholder,
+            "canvas_session_id": self.state.canvas_session_id,
             "canvas_session_state": self.state.canvas_session_state,
+            "canvas_user_present": self.state.canvas_user_present,
+            "canvas_can_edit_body": self.state.canvas_can_edit_body,
+            "canvas_recovery_needed": self.state.canvas_recovery_needed,
             "canvas_session_persistence": self.state.canvas_session_persistence,
             "panel_state": self.state.panel_state,
             "panel_proposal_count": self.state.panel_proposal_count,

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -82,7 +82,10 @@ def _render_note_section(fields: dict) -> str:
     content_hash = _e(fields.get("content_hash", ""))
     body = _e(fields.get("body", ""))
     panel_rail = _e(fields.get("panel_rail", "Panel / agent rail placeholder"))
+    canvas_session_id = _e(fields.get("canvas_session_id") or "")
     canvas_state = _e(fields.get("canvas_session_state", "idle"))
+    canvas_user_present = bool(fields.get("canvas_user_present", False))
+    canvas_can_edit_body = bool(fields.get("canvas_can_edit_body", False))
     persistence = str(fields.get("canvas_session_persistence", ""))
     panel_render = fields.get("panel_render") or {}
     panel_state = _e(panel_render.get("state") or fields.get("panel_state", "idle"))
@@ -123,6 +126,12 @@ def _render_note_section(fields: dict) -> str:
     proposal_rows_html = _render_panel_proposal_rows(
         fields.get("panel_proposals") or [],
     )
+    canvas_controls_html = _render_canvas_session_controls(
+        note_path=note_path_val,
+        session_id=canvas_session_id,
+        can_edit_body=canvas_can_edit_body,
+        user_present=canvas_user_present,
+    )
 
     return f"""
   <div class="workspace-layout">
@@ -151,6 +160,7 @@ def _render_note_section(fields: dict) -> str:
           <span class="rail-state-label">Canvas</span>
           <span class="rail-state-value">{canvas_state}</span>
         </div>
+        {canvas_controls_html}
         <div class="rail-state-row">
           <span class="rail-state-label">Panel</span>
           <span class="rail-state-value" data-testid="workspace-panel-label">{panel_label}</span>
@@ -164,6 +174,37 @@ def _render_note_section(fields: dict) -> str:
       </div>
     </aside>
   </div>"""
+
+
+def _render_canvas_session_controls(
+    *,
+    note_path: str,
+    session_id: str,
+    can_edit_body: bool,
+    user_present: bool,
+) -> str:
+    start_disabled = " disabled" if session_id else ""
+    close_disabled = "" if session_id else " disabled"
+    edit_disabled = "" if can_edit_body else " disabled"
+    present_text = "user present" if user_present else "user not present"
+    return f"""
+        <div class="canvas-controls" data-testid="workspace-canvas-session-controls">
+          <button
+            type="button"
+            data-testid="workspace-canvas-start"
+            data-api-method="POST"
+            data-api-path="/api/canvas/sessions"
+            data-note-path="{note_path}"{start_disabled}>Start</button>
+          <button
+            type="button"
+            data-testid="workspace-canvas-close"
+            data-api-method="DELETE"
+            data-api-path="/api/canvas/sessions/{session_id}"{close_disabled}>Close</button>
+          <button
+            type="button"
+            data-testid="workspace-canvas-edit-submit"{edit_disabled}>Apply body edit</button>
+          <span class="canvas-presence" data-testid="workspace-canvas-user-present">{present_text}</span>
+        </div>"""
 
 
 def _render_panel_proposal_rows(proposals: list[dict]) -> str:
@@ -562,6 +603,33 @@ def render_index_html(
       color: var(--fg-2);
       font-size: var(--text-sm);
       padding-left: 10px;
+    }}
+    .canvas-controls {{
+      display: grid;
+      gap: 6px;
+      grid-template-columns: 1fr 1fr;
+    }}
+    .canvas-controls button {{
+      background: var(--bg-raised);
+      border: 1px solid var(--border-strong);
+      border-radius: var(--radius-md);
+      color: var(--fg-1);
+      font-family: var(--font-ui);
+      font-size: var(--text-xs);
+      letter-spacing: 0.04em;
+      padding: 5px 8px;
+      text-transform: uppercase;
+    }}
+    .canvas-controls button:disabled {{
+      color: var(--fg-3);
+      cursor: not-allowed;
+      opacity: 0.55;
+    }}
+    .canvas-presence {{
+      color: var(--fg-3);
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      grid-column: 1 / -1;
     }}
     .panel-proposal-row {{
       background: var(--bg-raised);

--- a/companion-ui/companion-app/companion_ui/workspace/workspace_http_client.py
+++ b/companion-ui/companion-app/companion_ui/workspace/workspace_http_client.py
@@ -3,7 +3,9 @@
 Concrete adapter implementing the HttpClient protocol consumed by
 WorkspaceConfirmSession. Uses httpx to call:
   GET  /api/companion/workspace
+  POST /api/canvas/sessions
   POST /api/panel/confirm
+  DELETE /api/canvas/sessions/{id}
 
 The base URL is configurable so the same client works against dev,
 test, or prod runtime instances. The runtime environment determines
@@ -91,6 +93,17 @@ class WorkspaceHttpClient:
         full_url = self._base_url + url
         try:
             resp = httpx.post(full_url, json=json, timeout=self._timeout)
+        except httpx.RequestError as exc:
+            raise WorkspaceClientNetworkError(str(exc)) from exc
+        if resp.status_code >= 400:
+            raise WorkspaceClientHTTPError(resp.status_code, resp.text)
+        return resp.json()
+
+    def delete(self, url: str, *, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        """DELETE request to the runtime API. Raises WorkspaceClientError on failure."""
+        full_url = self._base_url + url
+        try:
+            resp = httpx.delete(full_url, params=params, timeout=self._timeout)
         except httpx.RequestError as exc:
             raise WorkspaceClientNetworkError(str(exc)) from exc
         if resp.status_code >= 400:

--- a/tests/companion_ui/test_canvas_session_browser.py
+++ b/tests/companion_ui/test_canvas_session_browser.py
@@ -1,0 +1,141 @@
+"""Tests for Canvas session browser controls in the workspace shell (#1128)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from companion_ui.workspace.real_note_workspace_dev_page import (
+    NoteLoadIntent,
+    RealNoteWorkspaceDevPage,
+)
+from companion_ui.workspace.serve_dev_page import render_index_html
+
+
+class _FakeClient:
+    def __init__(self, payloads: list[dict[str, Any]]) -> None:
+        self.payloads = payloads
+        self.get_calls: list[tuple[str, dict[str, Any]]] = []
+        self.post_calls: list[tuple[str, dict[str, Any]]] = []
+        self.delete_calls: list[tuple[str, dict[str, Any] | None]] = []
+
+    def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        self.get_calls.append((url, params))
+        return self.payloads.pop(0)
+
+    def post(self, url: str, *, json: dict[str, Any]) -> dict[str, Any]:
+        self.post_calls.append((url, json))
+        return {"session_id": "session-1"}
+
+    def delete(
+        self,
+        url: str,
+        *,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        self.delete_calls.append((url, params))
+        return {"session_id": "session-1"}
+
+
+def _workspace_payload(
+    *,
+    session_id: str | None = None,
+    session_state: str | None = None,
+    user_present: bool = False,
+    can_edit_body: bool = False,
+    session_persistence: str = "in_memory",
+) -> dict[str, Any]:
+    return {
+        "artifact": {
+            "artifact_id": "art-1128",
+            "note_path": "Notes/canvas.md",
+            "title": "Canvas Note",
+            "body": "# Canvas Note\n\nBody.",
+            "content_hash": "sha256-canvas",
+        },
+        "canvas": {
+            "session_id": session_id,
+            "session_state": session_state,
+            "user_present": user_present,
+            "can_edit_body": can_edit_body,
+            "recovery_needed": session_state == "paused",
+            "session_log_path": None,
+            "session_persistence": session_persistence,
+        },
+        "panel": {"state": "idle", "proposal_count": 0},
+        "guards": {"canvas_enabled": True, "writeguard_status": "ok"},
+        "runtime": {},
+        "suggestions": {},
+    }
+
+
+def _html_for_canvas(**canvas_overrides: Any) -> str:
+    client = _FakeClient([_workspace_payload(**canvas_overrides)])
+    page = RealNoteWorkspaceDevPage(client)  # type: ignore[arg-type]
+    state = page.load(NoteLoadIntent(note_path="Notes/canvas.md"))
+    assert state.is_loaded is True
+    fields = page.render_fields()
+    assert fields is not None
+    return render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="Notes/canvas.md",
+        fields=fields,
+    )
+
+
+def test_session_controls_rendered() -> None:
+    html = _html_for_canvas(session_id="session-1", session_state="active")
+
+    assert 'data-testid="workspace-canvas-session-controls"' in html
+    assert 'data-testid="workspace-canvas-start"' in html
+    assert 'data-api-path="/api/canvas/sessions"' in html
+    assert 'data-testid="workspace-canvas-close"' in html
+    assert 'data-api-path="/api/canvas/sessions/session-1"' in html
+
+
+def test_session_open_and_close_call_canvas_api() -> None:
+    client = _FakeClient([
+        _workspace_payload(session_id="session-1", session_state="active"),
+        _workspace_payload(session_id=None, session_state="closed"),
+    ])
+    page = RealNoteWorkspaceDevPage(client)  # type: ignore[arg-type]
+
+    page.open_canvas_session(NoteLoadIntent(note_path="Notes/canvas.md"))
+    page.close_canvas_session(session_id="session-1", note_path="Notes/canvas.md")
+
+    assert client.post_calls == [
+        ("/api/canvas/sessions", {"note_path": "Notes/canvas.md"}),
+    ]
+    assert client.delete_calls == [
+        (
+            "/api/canvas/sessions/session-1",
+            {"total_summary": "session closed from Companion UI"},
+        ),
+    ]
+    assert client.get_calls == [
+        ("/api/companion/workspace", {"note_path": "Notes/canvas.md"}),
+        ("/api/companion/workspace", {"note_path": "Notes/canvas.md"}),
+    ]
+
+
+def test_edit_controls_disabled_outside_active() -> None:
+    html = _html_for_canvas(
+        session_id=None,
+        session_state="idle",
+        can_edit_body=False,
+    )
+
+    assert 'data-testid="workspace-canvas-edit-submit" disabled' in html
+
+
+def test_session_state_indicator() -> None:
+    for state in ("active", "paused", "closed"):
+        html = _html_for_canvas(session_id="session-1", session_state=state)
+        assert 'data-testid="workspace-canvas-state"' in html
+        assert state in html
+
+
+def test_in_memory_persistence_notice() -> None:
+    html = _html_for_canvas(session_persistence="in_memory")
+
+    assert 'data-testid="workspace-session-persistence"' in html
+    assert "Session persistence: in_memory" in html


### PR DESCRIPTION
## Summary
- Adds Canvas start/close controls to the Companion workspace rail from aggregate Canvas state.
- Wires browser-side session open/close helpers to existing Canvas session endpoints and refreshes workspace state after responses.
- Renders user-present state, active/paused/closed indicators, disabled edit affordance outside active editable sessions, and the in-memory session notice.

## Issues
- Closes #1128

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_canvas_session_browser.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_canvas_session_browser.py tests/companion_ui/test_real_note_workspace_dev_page.py tests/companion_ui/test_real_note_workspace_visual_shell.py tests/companion_ui/test_real_note_workspace_dev_server.py tests/companion_ui/test_workspace_http_client.py tests/companion_ui/test_panel_rail_browser.py`
- `/tmp/agentic-pkm-checks-1123/bin/ruff check companion-ui/companion-app/companion_ui/workspace/workspace_http_client.py companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py tests/companion_ui/test_canvas_session_browser.py`
- `git diff --check`

## Notes
- This slice only adds lifecycle controls and disabled edit affordance display. Direct body-edit apply remains #1129.