### PR TITLE
Wire Canvas body edit apply

### DIFF
--- a/app/api/routes/canvas.py
+++ b/app/api/routes/canvas.py
@@ -18,6 +18,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
+from app.api.routes.artifacts import _content_hash
 from app.chat.canvas_writer import CanvasWriter, GovernanceBearingMutationError
 from app.chat.governance_router import GovernanceActionType, GovernanceRouter
 from app.chat.session_log import SessionLog, SessionLogWriter
@@ -61,6 +62,7 @@ class OpenSessionResponse(BaseModel):
 class EditRequest(BaseModel):
     new_body: str
     change_summary: str
+    content_hash: str | None = None
 
 
 class EditResponse(BaseModel):
@@ -129,6 +131,10 @@ def apply_edit(session_id: str, req: EditRequest) -> EditResponse:
     session = _sessions.get(session_id)
     if session is None:
         raise HTTPException(status_code=404, detail=f"Session {session_id!r} not found")
+    if req.content_hash is not None:
+        current_hash = _content_hash(session.note_path.read_text(encoding="utf-8"))
+        if current_hash != req.content_hash:
+            raise HTTPException(status_code=409, detail="content_hash mismatch")
     vault_root = _get_vault_root()
     log_writer = SessionLogWriter(vault_root=vault_root)
     writer = CanvasWriter(vault_root=vault_root, log_writer=log_writer)

--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -227,6 +227,34 @@ class RealNoteWorkspaceDevPage:
             return self.state
         return self.load(NoteLoadIntent(note_path=note_path))
 
+    def apply_canvas_edit(
+        self,
+        *,
+        session_id: str,
+        note_path: str,
+        new_body: str,
+        change_summary: str,
+        content_hash: str,
+    ) -> DevPageState:
+        """Apply a body-safe Canvas edit, then refresh workspace state."""
+        if not self.state.canvas_can_edit_body:
+            self.state.error = "Canvas body edit unavailable outside an active editable session"
+            self.state.is_loaded = False
+            return self.state
+        try:
+            self._http.post(
+                f"/api/canvas/sessions/{session_id}/edits",
+                json={
+                    "new_body": new_body,
+                    "change_summary": change_summary,
+                    "content_hash": content_hash,
+                },
+            )
+        except WorkspaceClientError as exc:
+            self.state = DevPageState(error=str(exc))
+            return self.state
+        return self.load(NoteLoadIntent(note_path=note_path))
+
     def render_fields(self) -> Optional[dict]:
         """Return a flat dict of renderable fields for the current state.
 

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -131,6 +131,7 @@ def _render_note_section(fields: dict) -> str:
         session_id=canvas_session_id,
         can_edit_body=canvas_can_edit_body,
         user_present=canvas_user_present,
+        content_hash=content_hash,
     )
 
     return f"""
@@ -182,10 +183,12 @@ def _render_canvas_session_controls(
     session_id: str,
     can_edit_body: bool,
     user_present: bool,
+    content_hash: str,
 ) -> str:
     start_disabled = " disabled" if session_id else ""
     close_disabled = "" if session_id else " disabled"
     edit_disabled = "" if can_edit_body else " disabled"
+    edit_api_path = f"/api/canvas/sessions/{session_id}/edits" if session_id else ""
     present_text = "user present" if user_present else "user not present"
     return f"""
         <div class="canvas-controls" data-testid="workspace-canvas-session-controls">
@@ -202,7 +205,10 @@ def _render_canvas_session_controls(
             data-api-path="/api/canvas/sessions/{session_id}"{close_disabled}>Close</button>
           <button
             type="button"
-            data-testid="workspace-canvas-edit-submit"{edit_disabled}>Apply body edit</button>
+            data-testid="workspace-canvas-edit-submit"
+            data-api-method="POST"
+            data-api-path="{edit_api_path}"
+            data-content-hash="{content_hash}"{edit_disabled}>Apply body edit</button>
           <span class="canvas-presence" data-testid="workspace-canvas-user-present">{present_text}</span>
         </div>"""
 

--- a/tests/api/test_canvas_api.py
+++ b/tests/api/test_canvas_api.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 
 import app.api.routes.canvas as canvas_module
 from app.api.app import app
+from app.api.routes.artifacts import _content_hash
 
 
 @pytest.fixture(autouse=True)
@@ -51,12 +52,35 @@ def test_edit_updates_vault_file(client: TestClient, vault: Path) -> None:
 
     edit_resp = client.post(
         f"/api/canvas/sessions/{session_id}/edits",
-        json={"new_body": "Updated body.", "change_summary": "rewrote"},
+        json={
+            "new_body": "Updated body.",
+            "change_summary": "rewrote",
+            "content_hash": _content_hash((vault / "note.md").read_text(encoding="utf-8")),
+        },
     )
     assert edit_resp.status_code == 200
     assert edit_resp.json()["ok"] is True
     note = vault / "note.md"
     assert "Updated body." in note.read_text(encoding="utf-8")
+
+
+def test_edit_rejects_stale_content_hash(client: TestClient, vault: Path) -> None:
+    open_resp = client.post(
+        "/api/canvas/sessions", json={"note_path": "note.md", "label": "stale-test"}
+    )
+    session_id = open_resp.json()["session_id"]
+
+    edit_resp = client.post(
+        f"/api/canvas/sessions/{session_id}/edits",
+        json={
+            "new_body": "Updated body.",
+            "change_summary": "rewrote",
+            "content_hash": "stale-hash",
+        },
+    )
+
+    assert edit_resp.status_code == 409
+    assert "Original body." in (vault / "note.md").read_text(encoding="utf-8")
 
 
 def test_close_session_writes_log(client: TestClient, vault: Path) -> None:

--- a/tests/companion_ui/test_canvas_edit_browser.py
+++ b/tests/companion_ui/test_canvas_edit_browser.py
@@ -1,0 +1,157 @@
+"""Tests for Canvas direct body-edit apply in the workspace shell (#1129)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from companion_ui.workspace.real_note_workspace_dev_page import (
+    NoteLoadIntent,
+    RealNoteWorkspaceDevPage,
+)
+from companion_ui.workspace.workspace_http_client import WorkspaceClientHTTPError
+
+
+class _FakeClient:
+    def __init__(
+        self,
+        payloads: list[dict[str, Any]],
+        *,
+        post_error: Exception | None = None,
+    ) -> None:
+        self.payloads = payloads
+        self.post_error = post_error
+        self.get_calls: list[tuple[str, dict[str, Any]]] = []
+        self.post_calls: list[tuple[str, dict[str, Any]]] = []
+
+    def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        self.get_calls.append((url, params))
+        return self.payloads.pop(0)
+
+    def post(self, url: str, *, json: dict[str, Any]) -> dict[str, Any]:
+        self.post_calls.append((url, json))
+        if self.post_error is not None:
+            raise self.post_error
+        return {"session_id": "session-1", "ok": True}
+
+
+def _workspace_payload(
+    *,
+    body: str = "# Canvas Note\n\nBody.",
+    content_hash: str = "hash-1",
+    can_edit_body: bool = True,
+) -> dict[str, Any]:
+    return {
+        "artifact": {
+            "artifact_id": "art-1129",
+            "note_path": "Notes/canvas.md",
+            "title": "Canvas Note",
+            "body": body,
+            "content_hash": content_hash,
+        },
+        "canvas": {
+            "session_id": "session-1",
+            "session_state": "active" if can_edit_body else "idle",
+            "user_present": can_edit_body,
+            "can_edit_body": can_edit_body,
+            "recovery_needed": False,
+            "session_log_path": None,
+            "session_persistence": "in_memory",
+        },
+        "panel": {"state": "idle", "proposal_count": 0},
+        "guards": {"canvas_enabled": True, "writeguard_status": "ok"},
+        "runtime": {},
+        "suggestions": {},
+    }
+
+
+def _loaded_page(client: _FakeClient) -> RealNoteWorkspaceDevPage:
+    page = RealNoteWorkspaceDevPage(client)  # type: ignore[arg-type]
+    page.load(NoteLoadIntent(note_path="Notes/canvas.md"))
+    return page
+
+
+def test_edit_submit_calls_api() -> None:
+    client = _FakeClient([
+        _workspace_payload(content_hash="hash-1"),
+        _workspace_payload(body="# Canvas Note\n\nUpdated.", content_hash="hash-2"),
+    ])
+    page = _loaded_page(client)
+
+    state = page.apply_canvas_edit(
+        session_id="session-1",
+        note_path="Notes/canvas.md",
+        new_body="# Canvas Note\n\nUpdated.",
+        change_summary="rewrote body",
+        content_hash="hash-1",
+    )
+
+    assert state.is_loaded is True
+    assert client.post_calls == [
+        (
+            "/api/canvas/sessions/session-1/edits",
+            {
+                "new_body": "# Canvas Note\n\nUpdated.",
+                "change_summary": "rewrote body",
+                "content_hash": "hash-1",
+            },
+        ),
+    ]
+
+
+def test_edit_disabled_outside_active_session() -> None:
+    client = _FakeClient([_workspace_payload(can_edit_body=False)])
+    page = _loaded_page(client)
+
+    state = page.apply_canvas_edit(
+        session_id="session-1",
+        note_path="Notes/canvas.md",
+        new_body="Updated.",
+        change_summary="rewrote body",
+        content_hash="hash-1",
+    )
+
+    assert state.is_loaded is False
+    assert "unavailable" in (state.error or "")
+    assert client.post_calls == []
+
+
+def test_workspace_refreshed_after_edit() -> None:
+    client = _FakeClient([
+        _workspace_payload(content_hash="hash-1"),
+        _workspace_payload(content_hash="hash-2"),
+    ])
+    page = _loaded_page(client)
+
+    page.apply_canvas_edit(
+        session_id="session-1",
+        note_path="Notes/canvas.md",
+        new_body="Updated.",
+        change_summary="rewrote body",
+        content_hash="hash-1",
+    )
+
+    assert client.get_calls == [
+        ("/api/companion/workspace", {"note_path": "Notes/canvas.md"}),
+        ("/api/companion/workspace", {"note_path": "Notes/canvas.md"}),
+    ]
+
+
+def test_edit_error_state_visible() -> None:
+    client = _FakeClient(
+        [_workspace_payload(content_hash="hash-1")],
+        post_error=WorkspaceClientHTTPError(409, "content_hash mismatch"),
+    )
+    page = _loaded_page(client)
+
+    state = page.apply_canvas_edit(
+        session_id="session-1",
+        note_path="Notes/canvas.md",
+        new_body="Updated.",
+        change_summary="rewrote body",
+        content_hash="hash-1",
+    )
+
+    assert state.is_loaded is False
+    assert state.error is not None
+    assert "409" in state.error
+    assert "content_hash mismatch" in state.error

--- a/tests/companion_ui/test_canvas_session_browser.py
+++ b/tests/companion_ui/test_canvas_session_browser.py
@@ -124,7 +124,9 @@ def test_edit_controls_disabled_outside_active() -> None:
         can_edit_body=False,
     )
 
-    assert 'data-testid="workspace-canvas-edit-submit" disabled' in html
+    assert 'data-testid="workspace-canvas-edit-submit"' in html
+    assert 'data-api-path=""' in html
+    assert "disabled>Apply body edit</button>" in html
 
 
 def test_session_state_indicator() -> None:


### PR DESCRIPTION
## Summary
- Wires browser-side Canvas body edit apply to `POST /api/canvas/sessions/{id}/edits` and refreshes workspace state after success.
- Sends the workspace `artifact.content_hash` as an optimistic stale-read precondition.
- Adds a narrow runtime `content_hash` check to reject stale browser edits with HTTP 409.
- Surfaces edit errors in the page state and keeps edit submission disabled outside active editable sessions.

## Issues
- Closes #1129

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_canvas_edit_browser.py tests/api/test_canvas_api.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_canvas_edit_browser.py tests/companion_ui/test_canvas_session_browser.py tests/companion_ui/test_real_note_workspace_dev_page.py tests/companion_ui/test_real_note_workspace_visual_shell.py tests/companion_ui/test_real_note_workspace_dev_server.py tests/companion_ui/test_workspace_http_client.py tests/api/test_canvas_api.py tests/api/test_companion_workspace_api.py`
- `/tmp/agentic-pkm-checks-1123/bin/ruff check app/api/routes/canvas.py companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py tests/api/test_canvas_api.py tests/companion_ui/test_canvas_edit_browser.py tests/companion_ui/test_canvas_session_browser.py`
- `git diff --check`

## Notes
- Governance-bearing edits remain out of scope and still route through the existing Canvas writer guard.