### PR TITLE
Bind suggestion flow state

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -35,6 +35,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Optional
 
+from companion_ui.canvas_suggestion_flow.rail_state_machine import (
+    CanvasRailStateMachine,
+)
 from companion_ui.panel.proposal_row import ProposalEvidence, ProposalRow
 from companion_ui.panel.render_model import PanelRenderState, render_panel_state
 from companion_ui.workspace.real_note_workspace_shell import (
@@ -95,6 +98,10 @@ class DevPageState:
     panel_proposal_count: int = 0
     panel_render: dict[str, Any] | None = None
     panel_proposals: list[dict[str, Any]] | None = None
+    suggestion_state: str = "idle"
+    suggestion_dom_alias: str = "idle"
+    suggestion_allowed_transitions: list[str] | None = None
+    suggestion_composer_enabled: bool = True
     guard_writeguard_status: str = "ok"
     guard_canvas_enabled: bool = True
     is_loaded: bool = False
@@ -146,6 +153,7 @@ class RealNoteWorkspaceDevPage:
         artifact = raw.get("artifact") or {}
         canvas = raw.get("canvas") or {}
         panel = raw.get("panel") or {}
+        suggestions = raw.get("suggestions") or {}
         guards = raw.get("guards") or {}
 
         # The runtime echoes artifact_id only when supplied in the request.
@@ -179,6 +187,9 @@ class RealNoteWorkspaceDevPage:
             panel=panel,
             artifact_id=resolved_artifact_id,
         )
+        suggestion_machine = CanvasRailStateMachine(
+            suggestions.get("current_suggestion_state") or "idle"
+        )
         self.state = DevPageState(
             shell=shell,
             panel_rail_placeholder=panel_render.get("label", "Panel ready"),
@@ -192,6 +203,10 @@ class RealNoteWorkspaceDevPage:
             panel_proposal_count=panel_count,
             panel_render=panel_render,
             panel_proposals=panel_proposals,
+            suggestion_state=suggestion_machine.state,
+            suggestion_dom_alias=suggestion_machine.dom_alias,
+            suggestion_allowed_transitions=sorted(suggestion_machine.allowed_transitions()),
+            suggestion_composer_enabled=suggestion_machine.composer_enabled,
             guard_writeguard_status=guards.get("writeguard_status") or "ok",
             guard_canvas_enabled=bool(guards.get("canvas_enabled", True)),
             is_loaded=True,
@@ -280,6 +295,10 @@ class RealNoteWorkspaceDevPage:
             "panel_proposal_count": self.state.panel_proposal_count,
             "panel_render": self.state.panel_render or {},
             "panel_proposals": self.state.panel_proposals or [],
+            "suggestion_state": self.state.suggestion_state,
+            "suggestion_dom_alias": self.state.suggestion_dom_alias,
+            "suggestion_allowed_transitions": self.state.suggestion_allowed_transitions or [],
+            "suggestion_composer_enabled": self.state.suggestion_composer_enabled,
             "guard_writeguard_status": self.state.guard_writeguard_status,
             "guard_canvas_enabled": self.state.guard_canvas_enabled,
             "is_production_ui": self.is_production_ui,

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -126,6 +126,7 @@ def _render_note_section(fields: dict) -> str:
     proposal_rows_html = _render_panel_proposal_rows(
         fields.get("panel_proposals") or [],
     )
+    suggestion_flow_html = _render_suggestion_flow_region(fields)
     canvas_controls_html = _render_canvas_session_controls(
         note_path=note_path_val,
         session_id=canvas_session_id,
@@ -169,12 +170,42 @@ def _render_note_section(fields: dict) -> str:
         </div>
         {panel_message_html}
         {proposal_rows_html}
+        {suggestion_flow_html}
         {guard_html}
         {persistence_html}
         {panel_rail}
       </div>
     </aside>
   </div>"""
+
+
+def _render_suggestion_flow_region(fields: dict) -> str:
+    suggestion_state = _e(fields.get("suggestion_state", "idle"))
+    dom_alias = _e(fields.get("suggestion_dom_alias", suggestion_state))
+    composer_enabled = bool(fields.get("suggestion_composer_enabled", True))
+    composer_text = "composer enabled" if composer_enabled else "composer locked"
+    transitions = fields.get("suggestion_allowed_transitions") or []
+    transition_html = "".join(
+        (
+            '<span class="suggestion-transition" '
+            f'data-testid="workspace-suggestion-transition" data-transition-to="{_e(target)}">'
+            f"{_e(target)}</span>"
+        )
+        for target in transitions
+    )
+    return f"""
+        <div
+          class="suggestion-flow"
+          data-testid="workspace-suggestion-flow"
+          data-suggestion-state="{suggestion_state}"
+          data-suggestion-dom-alias="{dom_alias}">
+          <div class="rail-state-row">
+            <span class="rail-state-label">Suggestion</span>
+            <span class="rail-state-value">{suggestion_state}</span>
+          </div>
+          <div class="suggestion-composer-state">{composer_text}</div>
+          <div class="suggestion-transitions">{transition_html}</div>
+        </div>"""
 
 
 def _render_canvas_session_controls(
@@ -636,6 +667,25 @@ def render_index_html(
       font-family: var(--font-mono);
       font-size: var(--text-xs);
       grid-column: 1 / -1;
+    }}
+    .suggestion-flow {{
+      background: var(--bg-raised);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      padding: 10px;
+    }}
+    .suggestion-composer-state, .suggestion-transition {{
+      color: var(--fg-2);
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+    }}
+    .suggestion-transitions {{
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
     }}
     .panel-proposal-row {{
       background: var(--bg-raised);

--- a/tests/companion_ui/test_suggestion_flow_browser.py
+++ b/tests/companion_ui/test_suggestion_flow_browser.py
@@ -1,0 +1,92 @@
+"""Tests for browser binding to the Canvas suggestion-flow state machine (#1132)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from companion_ui.canvas_suggestion_flow.rail_state_machine import (
+    CanvasRailStateMachine,
+    RAIL_STATES,
+)
+from companion_ui.workspace.real_note_workspace_dev_page import (
+    NoteLoadIntent,
+    RealNoteWorkspaceDevPage,
+)
+from companion_ui.workspace.serve_dev_page import render_index_html
+
+
+class _FakeClient:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+
+    def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        assert url == "/api/companion/workspace"
+        assert params == {"note_path": "Notes/suggestion.md"}
+        return self.payload
+
+
+def _workspace_payload(state: str) -> dict[str, Any]:
+    return {
+        "artifact": {
+            "artifact_id": "art-1132",
+            "note_path": "Notes/suggestion.md",
+            "title": "Suggestion Note",
+            "body": "# Suggestion Note\n\nBody.",
+            "content_hash": "sha256-suggestion",
+        },
+        "canvas": {
+            "session_id": "session-1",
+            "session_state": "active",
+            "user_present": True,
+            "can_edit_body": True,
+            "recovery_needed": False,
+            "session_log_path": None,
+            "session_persistence": "in_memory",
+        },
+        "panel": {"state": "idle", "proposal_count": 0},
+        "suggestions": {"current_suggestion_state": state},
+        "guards": {"canvas_enabled": True, "writeguard_status": "ok"},
+        "runtime": {},
+    }
+
+
+def _html_for_state(state: str) -> str:
+    page = RealNoteWorkspaceDevPage(_FakeClient(_workspace_payload(state)))  # type: ignore[arg-type]
+    loaded = page.load(NoteLoadIntent(note_path="Notes/suggestion.md"))
+    assert loaded.is_loaded is True
+    fields = page.render_fields()
+    assert fields is not None
+    return render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="Notes/suggestion.md",
+        fields=fields,
+    )
+
+
+def test_all_states_render() -> None:
+    for state in sorted(RAIL_STATES):
+        html = _html_for_state(state)
+        machine = CanvasRailStateMachine(state)
+
+        assert 'data-testid="workspace-suggestion-flow"' in html
+        assert f'data-suggestion-state="{state}"' in html
+        assert f'data-suggestion-dom-alias="{machine.dom_alias}"' in html
+        assert state in html
+
+
+def test_illegal_transitions_blocked() -> None:
+    state = "staged_governance"
+    html = _html_for_state(state)
+    allowed = CanvasRailStateMachine(state).allowed_transitions()
+
+    assert 'data-transition-to="governance_pending"' in html
+    assert 'data-transition-to="discarded"' in html
+    assert 'data-transition-to="apply_pending"' not in html
+    assert "apply_pending" not in allowed
+
+
+def test_suggestion_state_attribute() -> None:
+    html = _html_for_state("staged_body")
+
+    assert 'data-testid="workspace-suggestion-flow"' in html
+    assert 'data-suggestion-state="staged_body"' in html


### PR DESCRIPTION
## Summary
- Binds the workspace rail to the shipped Canvas suggestion-flow state machine.
- Renders canonical suggestion state, DOM alias, composer lock state, and model-allowed transition hints.
- Adds `data-suggestion-state` on the suggestion rail region for browser targeting.

## Issues
- Closes #1132

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_suggestion_flow_browser.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_suggestion_flow_browser.py tests/companion_ui/test_canvas_rail_state_machine.py tests/companion_ui/test_real_note_workspace_dev_page.py tests/companion_ui/test_real_note_workspace_visual_shell.py tests/companion_ui/test_real_note_workspace_dev_server.py tests/companion_ui/test_canvas_session_browser.py tests/companion_ui/test_canvas_edit_browser.py`
- `/tmp/agentic-pkm-checks-1123/bin/ruff check companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py tests/companion_ui/test_suggestion_flow_browser.py`
- `git diff --check`

## Notes
- This only renders server-declared suggestion state. SuggestionCard/SuggestedInsertion payload binding remains #1133.