### PR TITLE
Update lint guidance for code PRs

### DIFF
--- a/.codex/skills/issue-to-code/SKILL.md
+++ b/.codex/skills/issue-to-code/SKILL.md
@@ -257,6 +257,8 @@ Only move to Review when the PR is the **explicit review handoff artifact** (nor
 - Preserve architecture boundaries and event/outbox compatibility where relevant.
 - Update docs in the same change if behavior, contracts, or architecture change.
 - If the work turns a roadmap/plan item into shipped reality, update the owner doc and rewrite roadmap/plan wording so it no longer reads as pending.
+- For any PR that changes files under `app/` or `tests/`, run the repo-standard lint gate, currently `ruff check app tests`, before merge and include the lint output or explicit tooling limitation in the PR body.
+- Keep docs-only validation lightweight: docs-only PRs should run appropriate docs/governance checks, not the full code/test smoke by default.
 - Do not collapse parent feature validation and owner-doc promotion into one slice PR by default.
 - Use `Fixes #<issue>` in the PR.
 - Default to publishing a branch and PR in the same turn once implementation and validation are complete.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,6 +36,7 @@ Leave blank for governance lane when the PR stays within approved governance sur
 ## Validation
 Implementation lane:
 - [ ] `ruff check app tests`
+- [ ] If files under `app/` or `tests/` changed, lint output from `ruff check app tests` is included below or a tooling limitation is stated.
 - [ ] `mypy app`
 - [ ] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg"`
 - [ ] Additional targeted checks run as needed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,7 @@ Builder-agent rules:
 - Treat `Context`, `Scope`, `Source Anchors`, `Constraints`, `Acceptance Criteria`, `Out of Scope`, `Suggested Validation`, and `Source Docs` as binding.
 - Every `Acceptance Criterion` must declare its verification inline with a `Verify:` marker: a concrete test pointer (`tests/...::test_name`) for behavioral criteria, or a concrete non-test target (doc writeback path plus anchor, runtime receipt, roadmap diff) for non-behavioral criteria. ACs without a resolvable `Verify:` target are not executable and the Issue must not be `agent:ready`.
 - Link the PR back to the governing Issue using `Fixes #<id>`, `Closes #<id>`, or `Resolves #<id>`.
+- If a PR changes files under `app/` or `tests/`, run `ruff check app tests` before merge and include the lint output or tooling limitation in the PR body. Docs-only PRs can keep validation lightweight and should not run full smoke by default unless the touched surface requires it.
 - Do not treat chat-only requests as canonical implementation tasks when an Issue is expected.
 - Do not expand scope beyond the Issue without updating the task contract first.
 - Do not create new backlog work in GitHub without stable `Source Anchors` that point to the most local governing doc items.

--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -73,6 +73,9 @@ Run narrower or broader suites when the touched area requires it.
 
 Enforcement note:
 - The command list above is a required pre-merge gate, not advisory.
+- Any PR that changes files under `app/` or `tests/` must run the repo-standard lint gate, currently `ruff check app tests`, before merge.
+- Docs-only PRs can keep validation lightweight and should not run full smoke by default unless their touched surface requires it.
+- When `app/` or `tests/` changed, include the `ruff check app tests` output or an explicit tooling limitation in the PR body.
 - If CI is not currently blocking these checks, treat merge as blocked until either:
   - the checks pass locally and evidence is attached to the PR, or
   - blocking CI coverage is added for the missing check and enabled.


### PR DESCRIPTION
Fixes #1100

## Summary
- Clarifies that PRs touching `app/` or `tests/` must run `ruff check app tests` before merge.
- Updates workflow guidance and the PR template so lint output is included when code/test files changed, while docs-only validation remains lightweight.

## Validation
- `git diff --check`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/architecture` -> 54 passed
- `ruff check app tests` not run because this PR changes only governance/docs workflow files, not `app/` or `tests/`.

## Notes
- Dispatcher unavailable: `python3 -m app.dispatcher status --json` failed because the local Python environment is missing `yaml`; used GitHub-label-only claim.
