### PR TITLE
canvas-ui: render Canvas provenance and undo controls

### DIFF
--- a/app/api/routes/canvas.py
+++ b/app/api/routes/canvas.py
@@ -3,6 +3,7 @@
 POST   /api/canvas/sessions                  — open session, return session_id
 POST   /api/canvas/sessions/{id}/edits       — apply body edit
 POST   /api/canvas/sessions/{id}/governance  — submit governance action
+DELETE /api/canvas/sessions/{id}/edits/last  — undo last body edit
 DELETE /api/canvas/sessions/{id}             — close session
 
 Gated by CANVAS_ENABLED env var (must be "1" or truthy to enable; default off).
@@ -12,14 +13,16 @@ All session state is in-memory for the lifetime of the API process.
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from app.api.routes.artifacts import _content_hash
-from app.chat.canvas_writer import CanvasWriter, GovernanceBearingMutationError
+from app.chat.canvas_writer import CanvasWriter, GovernanceBearingMutationError, _split_frontmatter
 from app.chat.governance_router import GovernanceActionType, GovernanceRouter
 from app.chat.session_log import SessionLog, SessionLogWriter
 from app.config.paths import resolve_vault_root
@@ -28,6 +31,18 @@ router = APIRouter(prefix="/canvas", tags=["canvas"])
 
 # In-memory session registry — process lifetime only.
 _sessions: dict[str, SessionLog] = {}
+
+
+@dataclass(frozen=True)
+class _AppliedBodyEdit:
+    edit_id: str
+    body_before: str
+    body_after: str
+    change_summary: str
+
+
+_edit_history: dict[str, list[_AppliedBodyEdit]] = {}
+_undone_history: dict[str, list[_AppliedBodyEdit]] = {}
 
 
 def _canvas_enabled() -> bool:
@@ -70,6 +85,13 @@ class EditResponse(BaseModel):
     ok: bool
 
 
+class UndoResponse(BaseModel):
+    session_id: str
+    ok: bool
+    undo_id: str
+    original_edit_id: str
+
+
 class GovernanceRequest(BaseModel):
     action_type: str
     payload: dict[str, Any] = {}
@@ -107,6 +129,12 @@ def _validate_note_path(note_path_str: str, vault_root: Path) -> Path:
     return candidate
 
 
+def _note_body(note_path: Path) -> str:
+    content = note_path.read_text(encoding="utf-8")
+    _, body = _split_frontmatter(content)
+    return body
+
+
 @router.post("/sessions", response_model=OpenSessionResponse)
 def open_session(req: OpenSessionRequest) -> OpenSessionResponse:
     _require_canvas()
@@ -118,6 +146,8 @@ def open_session(req: OpenSessionRequest) -> OpenSessionResponse:
     log_writer = SessionLogWriter(vault_root=vault_root)
     session = log_writer.open_session(note_path, req.label)
     _sessions[session.session_id] = session
+    _edit_history[session.session_id] = []
+    _undone_history[session.session_id] = []
     return OpenSessionResponse(
         session_id=session.session_id,
         note_path=str(session.note_path),
@@ -135,6 +165,7 @@ def apply_edit(session_id: str, req: EditRequest) -> EditResponse:
         current_hash = _content_hash(session.note_path.read_text(encoding="utf-8"))
         if current_hash != req.content_hash:
             raise HTTPException(status_code=409, detail="content_hash mismatch")
+    body_before = _note_body(session.note_path)
     vault_root = _get_vault_root()
     log_writer = SessionLogWriter(vault_root=vault_root)
     writer = CanvasWriter(vault_root=vault_root, log_writer=log_writer)
@@ -142,7 +173,61 @@ def apply_edit(session_id: str, req: EditRequest) -> EditResponse:
         writer.apply_edit(session, req.new_body, req.change_summary)
     except GovernanceBearingMutationError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
+    body_after = _note_body(session.note_path)
+    _edit_history.setdefault(session_id, []).append(
+        _AppliedBodyEdit(
+            edit_id=str(uuid4()),
+            body_before=body_before,
+            body_after=body_after,
+            change_summary=req.change_summary,
+        )
+    )
     return EditResponse(session_id=session_id, ok=True)
+
+
+@router.delete("/sessions/{session_id}/edits/last", response_model=UndoResponse)
+def undo_last_edit(session_id: str) -> UndoResponse:
+    _require_canvas()
+    session = _sessions.get(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail=f"Session {session_id!r} not found")
+
+    edits = _edit_history.setdefault(session_id, [])
+    if not edits:
+        raise HTTPException(status_code=409, detail="No undoable Canvas body edit")
+
+    latest = edits[-1]
+    current_body = _note_body(session.note_path)
+    if current_body != latest.body_after:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Cannot undo last Canvas body edit: note body has diverged since "
+                "the assistant edit was applied"
+            ),
+        )
+
+    vault_root = _get_vault_root()
+    log_writer = SessionLogWriter(vault_root=vault_root)
+    writer = CanvasWriter(vault_root=vault_root, log_writer=log_writer)
+    undo_id = str(uuid4())
+    try:
+        writer.apply_edit(
+            session,
+            latest.body_before,
+            f"[undo:{undo_id}] reverted edit:{latest.edit_id}",
+        )
+    except GovernanceBearingMutationError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    edits.pop()
+    _undone_history.setdefault(session_id, []).append(latest)
+    return UndoResponse(
+        session_id=session_id,
+        ok=True,
+        undo_id=undo_id,
+        original_edit_id=latest.edit_id,
+    )
 
 
 @router.post("/sessions/{session_id}/governance", response_model=GovernanceResponse)
@@ -175,6 +260,8 @@ def close_session(session_id: str, total_summary: str = "session closed") -> Clo
     session = _sessions.pop(session_id, None)
     if session is None:
         raise HTTPException(status_code=404, detail=f"Session {session_id!r} not found")
+    _edit_history.pop(session_id, None)
+    _undone_history.pop(session_id, None)
     vault_root = _get_vault_root()
     log_writer = SessionLogWriter(vault_root=vault_root)
     log_writer.close_session(session, total_summary)

--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -40,6 +40,9 @@ class CanvasState(BaseModel):
     can_edit_body: bool
     recovery_needed: bool
     session_log_path: str | None
+    undo_available: bool = False
+    applied_edit_count: int = 0
+    undone_edit_count: int = 0
     session_persistence: str = "in_memory"
 
 
@@ -167,6 +170,8 @@ def _canvas_state(safe_note_path: str, vault_root: Path, canvas_enabled: bool) -
         )
 
     log_path = _vault_relative(Path(session.log_path), vault_root)
+    applied_edits = getattr(canvas_module, "_edit_history", {}).get(session.session_id, [])
+    undone_edits = getattr(canvas_module, "_undone_history", {}).get(session.session_id, [])
     return CanvasState(
         session_id=session.session_id,
         session_state="active",
@@ -174,6 +179,9 @@ def _canvas_state(safe_note_path: str, vault_root: Path, canvas_enabled: bool) -
         can_edit_body=canvas_enabled,
         recovery_needed=False,
         session_log_path=log_path,
+        undo_available=bool(applied_edits),
+        applied_edit_count=len(applied_edits),
+        undone_edit_count=len(undone_edits),
     )
 
 

--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -93,6 +93,10 @@ class DevPageState:
     canvas_user_present: bool = False
     canvas_can_edit_body: bool = False
     canvas_recovery_needed: bool = False
+    canvas_session_log_path: str | None = None
+    canvas_undo_available: bool = False
+    canvas_applied_edit_count: int = 0
+    canvas_undone_edit_count: int = 0
     canvas_session_persistence: str = ""
     panel_state: str = "idle"
     panel_proposal_count: int = 0
@@ -198,6 +202,10 @@ class RealNoteWorkspaceDevPage:
             canvas_user_present=bool(canvas.get("user_present", False)),
             canvas_can_edit_body=bool(canvas.get("can_edit_body", False)),
             canvas_recovery_needed=bool(canvas.get("recovery_needed", False)),
+            canvas_session_log_path=canvas.get("session_log_path"),
+            canvas_undo_available=bool(canvas.get("undo_available", False)),
+            canvas_applied_edit_count=int(canvas.get("applied_edit_count") or 0),
+            canvas_undone_edit_count=int(canvas.get("undone_edit_count") or 0),
             canvas_session_persistence=canvas.get("session_persistence") or "",
             panel_state=panel_state,
             panel_proposal_count=panel_count,
@@ -270,6 +278,24 @@ class RealNoteWorkspaceDevPage:
             return self.state
         return self.load(NoteLoadIntent(note_path=note_path))
 
+    def undo_last_canvas_edit(
+        self,
+        *,
+        session_id: str,
+        note_path: str,
+    ) -> DevPageState:
+        """Undo the most recent Canvas body edit, then refresh workspace state."""
+        if not self.state.canvas_undo_available:
+            self.state.error = "No undoable Canvas body edit is available"
+            self.state.is_loaded = False
+            return self.state
+        try:
+            self._http.delete(f"/api/canvas/sessions/{session_id}/edits/last")
+        except WorkspaceClientError as exc:
+            self.state = DevPageState(error=str(exc))
+            return self.state
+        return self.load(NoteLoadIntent(note_path=note_path))
+
     def render_fields(self) -> Optional[dict]:
         """Return a flat dict of renderable fields for the current state.
 
@@ -290,6 +316,10 @@ class RealNoteWorkspaceDevPage:
             "canvas_user_present": self.state.canvas_user_present,
             "canvas_can_edit_body": self.state.canvas_can_edit_body,
             "canvas_recovery_needed": self.state.canvas_recovery_needed,
+            "canvas_session_log_path": self.state.canvas_session_log_path,
+            "canvas_undo_available": self.state.canvas_undo_available,
+            "canvas_applied_edit_count": self.state.canvas_applied_edit_count,
+            "canvas_undone_edit_count": self.state.canvas_undone_edit_count,
             "canvas_session_persistence": self.state.canvas_session_persistence,
             "panel_state": self.state.panel_state,
             "panel_proposal_count": self.state.panel_proposal_count,

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -86,6 +86,10 @@ def _render_note_section(fields: dict) -> str:
     canvas_state = _e(fields.get("canvas_session_state", "idle"))
     canvas_user_present = bool(fields.get("canvas_user_present", False))
     canvas_can_edit_body = bool(fields.get("canvas_can_edit_body", False))
+    session_log_path = _e(fields.get("canvas_session_log_path") or "")
+    undo_available = bool(fields.get("canvas_undo_available", False))
+    applied_edit_count = int(fields.get("canvas_applied_edit_count", 0) or 0)
+    undone_edit_count = int(fields.get("canvas_undone_edit_count", 0) or 0)
     persistence = str(fields.get("canvas_session_persistence", ""))
     panel_render = fields.get("panel_render") or {}
     panel_state = _e(panel_render.get("state") or fields.get("panel_state", "idle"))
@@ -133,6 +137,10 @@ def _render_note_section(fields: dict) -> str:
         can_edit_body=canvas_can_edit_body,
         user_present=canvas_user_present,
         content_hash=content_hash,
+        session_log_path=session_log_path,
+        undo_available=undo_available,
+        applied_edit_count=applied_edit_count,
+        undone_edit_count=undone_edit_count,
     )
 
     return f"""
@@ -215,12 +223,19 @@ def _render_canvas_session_controls(
     can_edit_body: bool,
     user_present: bool,
     content_hash: str,
+    session_log_path: str,
+    undo_available: bool,
+    applied_edit_count: int,
+    undone_edit_count: int,
 ) -> str:
     start_disabled = " disabled" if session_id else ""
     close_disabled = "" if session_id else " disabled"
     edit_disabled = "" if can_edit_body else " disabled"
+    undo_disabled = "" if undo_available else " disabled"
     edit_api_path = f"/api/canvas/sessions/{session_id}/edits" if session_id else ""
+    undo_api_path = f"/api/canvas/sessions/{session_id}/edits/last" if session_id else ""
     present_text = "user present" if user_present else "user not present"
+    log_text = session_log_path or "no session log"
     return f"""
         <div class="canvas-controls" data-testid="workspace-canvas-session-controls">
           <button
@@ -240,7 +255,18 @@ def _render_canvas_session_controls(
             data-api-method="POST"
             data-api-path="{edit_api_path}"
             data-content-hash="{content_hash}"{edit_disabled}>Apply body edit</button>
+          <button
+            type="button"
+            data-testid="workspace-canvas-undo"
+            data-api-method="DELETE"
+            data-api-path="{undo_api_path}"{undo_disabled}>Undo</button>
           <span class="canvas-presence" data-testid="workspace-canvas-user-present">{present_text}</span>
+          <div class="canvas-provenance" data-testid="workspace-canvas-provenance">
+            <span class="canvas-provenance-label">log</span>
+            <code data-testid="workspace-canvas-session-log-path">{log_text}</code>
+            <span data-testid="workspace-canvas-edit-count">{applied_edit_count} edit{'s' if applied_edit_count != 1 else ''}</span>
+            <span data-testid="workspace-canvas-undone-count">{undone_edit_count} undone</span>
+          </div>
         </div>"""
 
 
@@ -667,6 +693,25 @@ def render_index_html(
       font-family: var(--font-mono);
       font-size: var(--text-xs);
       grid-column: 1 / -1;
+    }}
+    .canvas-provenance {{
+      color: var(--fg-3);
+      display: flex;
+      flex-direction: column;
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      gap: 2px;
+      grid-column: 1 / -1;
+      min-width: 0;
+    }}
+    .canvas-provenance code {{
+      color: var(--fg-2);
+      overflow-wrap: anywhere;
+    }}
+    .canvas-provenance-label {{
+      color: var(--fg-3);
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
     }}
     .suggestion-flow {{
       background: var(--bg-raised);

--- a/tests/api/test_canvas_api.py
+++ b/tests/api/test_canvas_api.py
@@ -15,8 +15,12 @@ from app.api.routes.artifacts import _content_hash
 @pytest.fixture(autouse=True)
 def _clear_sessions():
     canvas_module._sessions.clear()
+    canvas_module._edit_history.clear()
+    canvas_module._undone_history.clear()
     yield
     canvas_module._sessions.clear()
+    canvas_module._edit_history.clear()
+    canvas_module._undone_history.clear()
 
 
 @pytest.fixture()
@@ -62,6 +66,55 @@ def test_edit_updates_vault_file(client: TestClient, vault: Path) -> None:
     assert edit_resp.json()["ok"] is True
     note = vault / "note.md"
     assert "Updated body." in note.read_text(encoding="utf-8")
+
+
+def test_undo_last_edit_reverts_body_and_preserves_log(client: TestClient, vault: Path) -> None:
+    open_resp = client.post(
+        "/api/canvas/sessions", json={"note_path": "note.md", "label": "undo-test"}
+    )
+    session_id = open_resp.json()["session_id"]
+    log_path = Path(open_resp.json()["log_path"])
+
+    edit_resp = client.post(
+        f"/api/canvas/sessions/{session_id}/edits",
+        json={
+            "new_body": "Updated body.",
+            "change_summary": "rewrote",
+            "content_hash": _content_hash((vault / "note.md").read_text(encoding="utf-8")),
+        },
+    )
+    assert edit_resp.status_code == 200
+
+    undo_resp = client.delete(f"/api/canvas/sessions/{session_id}/edits/last")
+
+    assert undo_resp.status_code == 200
+    assert undo_resp.json()["ok"] is True
+    assert "Original body." in (vault / "note.md").read_text(encoding="utf-8")
+    log_content = log_path.read_text(encoding="utf-8")
+    assert "rewrote" in log_content
+    assert "[undo:" in log_content
+    assert "reverted edit:" in log_content
+
+
+def test_undo_rejects_diverged_body(client: TestClient, vault: Path) -> None:
+    open_resp = client.post(
+        "/api/canvas/sessions", json={"note_path": "note.md", "label": "undo-conflict"}
+    )
+    session_id = open_resp.json()["session_id"]
+    client.post(
+        f"/api/canvas/sessions/{session_id}/edits",
+        json={
+            "new_body": "Updated body.",
+            "change_summary": "rewrote",
+            "content_hash": _content_hash((vault / "note.md").read_text(encoding="utf-8")),
+        },
+    )
+    (vault / "note.md").write_text("# Hello\n\nManual user change.\n", encoding="utf-8")
+
+    undo_resp = client.delete(f"/api/canvas/sessions/{session_id}/edits/last")
+
+    assert undo_resp.status_code == 409
+    assert "Manual user change." in (vault / "note.md").read_text(encoding="utf-8")
 
 
 def test_edit_rejects_stale_content_hash(client: TestClient, vault: Path) -> None:

--- a/tests/api/test_companion_workspace_api.py
+++ b/tests/api/test_companion_workspace_api.py
@@ -21,10 +21,14 @@ from app.write_guard import DEFAULT_WRITE_GUARD, WriteGuard, WritesBlockedError
 @pytest.fixture(autouse=True)
 def _clear_runtime_state() -> None:
     canvas_module._sessions.clear()
+    canvas_module._edit_history.clear()
+    canvas_module._undone_history.clear()
     confirm_module._proposal_store.clear()
     confirm_module._idempotency_store.clear()
     yield
     canvas_module._sessions.clear()
+    canvas_module._edit_history.clear()
+    canvas_module._undone_history.clear()
     confirm_module._proposal_store.clear()
     confirm_module._idempotency_store.clear()
     companion_module.DEFAULT_WRITE_GUARD.snapshot_fn = DEFAULT_WRITE_GUARD.snapshot_fn
@@ -97,6 +101,9 @@ def test_workspace_canvas_state_no_session(client: TestClient, vault_note: Path)
     assert canvas["session_id"] is None
     assert canvas["session_state"] is None
     assert canvas["session_persistence"] == "in_memory"
+    assert canvas["undo_available"] is False
+    assert canvas["applied_edit_count"] == 0
+    assert canvas["undone_edit_count"] == 0
 
 
 def test_workspace_canvas_state_with_open_session(
@@ -112,6 +119,15 @@ def test_workspace_canvas_state_with_open_session(
         note_path=vault_note,
         label="test",
     )
+    canvas_module._edit_history["session-1"] = [
+        canvas_module._AppliedBodyEdit(
+            edit_id="edit-1",
+            body_before="Body text.\n",
+            body_after="Updated body.\n",
+            change_summary="updated",
+        )
+    ]
+    canvas_module._undone_history["session-1"] = []
 
     resp = _workspace(client)
 
@@ -120,6 +136,9 @@ def test_workspace_canvas_state_with_open_session(
     assert canvas["session_id"] == "session-1"
     assert canvas["session_state"] == "active"
     assert canvas["session_log_path"] == ".chats/note/session.md"
+    assert canvas["undo_available"] is True
+    assert canvas["applied_edit_count"] == 1
+    assert canvas["undone_edit_count"] == 0
     assert canvas["session_persistence"] == "in_memory"
 
 

--- a/tests/companion_ui/test_canvas_provenance_browser.py
+++ b/tests/companion_ui/test_canvas_provenance_browser.py
@@ -1,0 +1,127 @@
+"""Tests for Canvas provenance and undo controls in the workspace shell (#1130)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from companion_ui.workspace.real_note_workspace_dev_page import (
+    NoteLoadIntent,
+    RealNoteWorkspaceDevPage,
+)
+from companion_ui.workspace.serve_dev_page import render_index_html
+
+
+class _FakeClient:
+    def __init__(self, payloads: list[dict[str, Any]]) -> None:
+        self.payloads = payloads
+        self.get_calls: list[tuple[str, dict[str, Any]]] = []
+        self.delete_calls: list[tuple[str, dict[str, Any] | None]] = []
+
+    def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        self.get_calls.append((url, params))
+        return self.payloads.pop(0)
+
+    def delete(
+        self,
+        url: str,
+        *,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        self.delete_calls.append((url, params))
+        return {"session_id": "session-1", "ok": True}
+
+
+def _workspace_payload(
+    *,
+    body: str = "# Canvas Note\n\nBody.",
+    session_log_path: str | None = ".chats/canvas/session.md",
+    undo_available: bool = False,
+    applied_edit_count: int = 0,
+    undone_edit_count: int = 0,
+) -> dict[str, Any]:
+    return {
+        "artifact": {
+            "artifact_id": "art-1130",
+            "note_path": "Notes/canvas.md",
+            "title": "Canvas Note",
+            "body": body,
+            "content_hash": "hash-1",
+        },
+        "canvas": {
+            "session_id": "session-1",
+            "session_state": "active",
+            "user_present": True,
+            "can_edit_body": True,
+            "recovery_needed": False,
+            "session_log_path": session_log_path,
+            "undo_available": undo_available,
+            "applied_edit_count": applied_edit_count,
+            "undone_edit_count": undone_edit_count,
+            "session_persistence": "in_memory",
+        },
+        "panel": {"state": "idle", "proposal_count": 0},
+        "guards": {"canvas_enabled": True, "writeguard_status": "ok"},
+        "runtime": {},
+        "suggestions": {},
+    }
+
+
+def _html_for_canvas(**canvas_overrides: Any) -> str:
+    client = _FakeClient([_workspace_payload(**canvas_overrides)])
+    page = RealNoteWorkspaceDevPage(client)  # type: ignore[arg-type]
+    state = page.load(NoteLoadIntent(note_path="Notes/canvas.md"))
+    assert state.is_loaded is True
+    fields = page.render_fields()
+    assert fields is not None
+    return render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="Notes/canvas.md",
+        fields=fields,
+    )
+
+
+def test_session_log_path_visible() -> None:
+    html = _html_for_canvas(session_log_path=".chats/canvas/session.md")
+
+    assert 'data-testid="workspace-canvas-provenance"' in html
+    assert 'data-testid="workspace-canvas-session-log-path"' in html
+    assert ".chats/canvas/session.md" in html
+
+
+def test_undo_enabled_only_when_available() -> None:
+    disabled_html = _html_for_canvas(undo_available=False)
+    enabled_html = _html_for_canvas(undo_available=True)
+
+    assert 'data-testid="workspace-canvas-undo"' in disabled_html
+    assert "disabled>Undo</button>" in disabled_html
+    assert 'data-api-path="/api/canvas/sessions/session-1/edits/last">Undo</button>' in enabled_html
+
+
+def test_provenance_preserved_after_undo() -> None:
+    client = _FakeClient(
+        [
+            _workspace_payload(undo_available=True, applied_edit_count=1),
+            _workspace_payload(
+                body="# Canvas Note\n\nOriginal.",
+                undo_available=False,
+                applied_edit_count=0,
+                undone_edit_count=1,
+            ),
+        ]
+    )
+    page = RealNoteWorkspaceDevPage(client)  # type: ignore[arg-type]
+    page.load(NoteLoadIntent(note_path="Notes/canvas.md"))
+
+    state = page.undo_last_canvas_edit(
+        session_id="session-1",
+        note_path="Notes/canvas.md",
+    )
+
+    assert state.is_loaded is True
+    assert client.delete_calls == [
+        ("/api/canvas/sessions/session-1/edits/last", None),
+    ]
+    fields = page.render_fields()
+    assert fields is not None
+    assert fields["canvas_session_log_path"] == ".chats/canvas/session.md"
+    assert fields["canvas_undone_edit_count"] == 1


### PR DESCRIPTION
## Summary
- add explicit `DELETE /api/canvas/sessions/{session_id}/edits/last` for last body-edit undo with divergence conflict protection
- expose Canvas session log path, undo availability, applied edit count, and undone edit count through the Companion workspace aggregate
- render the provenance/undo controls in the workspace rail and refresh state after undo

Closes #1130

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_canvas_provenance_browser.py` — 3 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/api/test_canvas_api.py tests/api/test_companion_workspace_api.py` — 15 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_canvas_provenance_browser.py tests/companion_ui/test_canvas_edit_browser.py tests/companion_ui/test_canvas_session_browser.py tests/companion_ui/test_real_note_workspace_dev_page.py tests/companion_ui/test_real_note_workspace_visual_shell.py tests/companion_ui/test_real_note_workspace_dev_server.py` — 106 passed
- `/tmp/agentic-pkm-checks-1123/bin/ruff check app/api/routes/canvas.py app/api/routes/companion.py companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py tests/api/test_canvas_api.py tests/api/test_companion_workspace_api.py tests/companion_ui/test_canvas_provenance_browser.py` — passed
- `git diff --check` — passed

## Workflow Notes
- Dispatcher unavailable (`ModuleNotFoundError: No module named 'yaml'` from `python3 -m app.dispatcher status --json`) — used mandatory pickup wrapper / GitHub label claim.
