### PR TITLE
canvas-ui: render Canvas recovery conflict state

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -92,7 +92,10 @@ class DevPageState:
     canvas_session_state: str = "idle"
     canvas_user_present: bool = False
     canvas_can_edit_body: bool = False
+    canvas_runtime_can_edit_body: bool = False
     canvas_recovery_needed: bool = False
+    canvas_recovery_acknowledged: bool = False
+    canvas_conflict_detected: bool = False
     canvas_session_log_path: str | None = None
     canvas_undo_available: bool = False
     canvas_applied_edit_count: int = 0
@@ -138,6 +141,8 @@ class RealNoteWorkspaceDevPage:
     def __init__(self, http_client: WorkspaceHttpClient) -> None:
         self._http = http_client
         self.state: DevPageState = DevPageState()
+        self._last_content_hash_by_note: dict[str, str] = {}
+        self._acknowledged_recovery_notes: set[str] = set()
 
     def load(self, intent: NoteLoadIntent) -> DevPageState:
         """Load a note via the runtime API.
@@ -176,6 +181,23 @@ class RealNoteWorkspaceDevPage:
             body=artifact.get("body", ""),
             content_hash=artifact.get("content_hash", ""),
         )
+        content_hash = payload.content_hash
+        previous_hash = self._last_content_hash_by_note.get(resolved_note_path)
+        session_state = canvas.get("session_state") or "idle"
+        recovery_needed = bool(canvas.get("recovery_needed", False))
+        recovery_acknowledged = resolved_note_path in self._acknowledged_recovery_notes
+        hash_conflict = (
+            recovery_needed
+            and previous_hash is not None
+            and bool(content_hash)
+            and previous_hash != content_hash
+        )
+        state_conflict = session_state in {"paused", "interrupted"}
+        conflict_detected = recovery_needed or hash_conflict or state_conflict
+        runtime_can_edit_body = bool(canvas.get("can_edit_body", False))
+        can_edit_body = runtime_can_edit_body and (not conflict_detected or recovery_acknowledged)
+        if content_hash:
+            self._last_content_hash_by_note[resolved_note_path] = content_hash
         shell = RealNoteWorkspaceShell(payload=payload, agent_rail_state=None)
         panel_count = int(panel.get("proposal_count") or 0)
         panel_state = panel.get("state") or "idle"
@@ -198,10 +220,13 @@ class RealNoteWorkspaceDevPage:
             shell=shell,
             panel_rail_placeholder=panel_render.get("label", "Panel ready"),
             canvas_session_id=canvas.get("session_id"),
-            canvas_session_state=canvas.get("session_state") or "idle",
+            canvas_session_state=session_state,
             canvas_user_present=bool(canvas.get("user_present", False)),
-            canvas_can_edit_body=bool(canvas.get("can_edit_body", False)),
-            canvas_recovery_needed=bool(canvas.get("recovery_needed", False)),
+            canvas_runtime_can_edit_body=runtime_can_edit_body,
+            canvas_can_edit_body=can_edit_body,
+            canvas_recovery_needed=recovery_needed,
+            canvas_recovery_acknowledged=recovery_acknowledged,
+            canvas_conflict_detected=conflict_detected,
             canvas_session_log_path=canvas.get("session_log_path"),
             canvas_undo_available=bool(canvas.get("undo_available", False)),
             canvas_applied_edit_count=int(canvas.get("applied_edit_count") or 0),
@@ -278,6 +303,15 @@ class RealNoteWorkspaceDevPage:
             return self.state
         return self.load(NoteLoadIntent(note_path=note_path))
 
+    def acknowledge_canvas_recovery(self, *, note_path: str) -> DevPageState:
+        """Acknowledge recovery/conflict state before body edits resume."""
+        self._acknowledged_recovery_notes.add(note_path)
+        if self.state.shell is not None and self.state.shell.note_path == note_path:
+            self.state.canvas_recovery_acknowledged = True
+            self.state.canvas_conflict_detected = False
+            self.state.canvas_can_edit_body = self.state.canvas_runtime_can_edit_body
+        return self.state
+
     def undo_last_canvas_edit(
         self,
         *,
@@ -316,6 +350,8 @@ class RealNoteWorkspaceDevPage:
             "canvas_user_present": self.state.canvas_user_present,
             "canvas_can_edit_body": self.state.canvas_can_edit_body,
             "canvas_recovery_needed": self.state.canvas_recovery_needed,
+            "canvas_recovery_acknowledged": self.state.canvas_recovery_acknowledged,
+            "canvas_conflict_detected": self.state.canvas_conflict_detected,
             "canvas_session_log_path": self.state.canvas_session_log_path,
             "canvas_undo_available": self.state.canvas_undo_available,
             "canvas_applied_edit_count": self.state.canvas_applied_edit_count,

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -86,6 +86,9 @@ def _render_note_section(fields: dict) -> str:
     canvas_state = _e(fields.get("canvas_session_state", "idle"))
     canvas_user_present = bool(fields.get("canvas_user_present", False))
     canvas_can_edit_body = bool(fields.get("canvas_can_edit_body", False))
+    recovery_needed = bool(fields.get("canvas_recovery_needed", False))
+    recovery_acknowledged = bool(fields.get("canvas_recovery_acknowledged", False))
+    conflict_detected = bool(fields.get("canvas_conflict_detected", False))
     session_log_path = _e(fields.get("canvas_session_log_path") or "")
     undo_available = bool(fields.get("canvas_undo_available", False))
     applied_edit_count = int(fields.get("canvas_applied_edit_count", 0) or 0)
@@ -134,9 +137,13 @@ def _render_note_section(fields: dict) -> str:
     canvas_controls_html = _render_canvas_session_controls(
         note_path=note_path_val,
         session_id=canvas_session_id,
+        session_state=canvas_state,
         can_edit_body=canvas_can_edit_body,
         user_present=canvas_user_present,
         content_hash=content_hash,
+        recovery_needed=recovery_needed,
+        recovery_acknowledged=recovery_acknowledged,
+        conflict_detected=conflict_detected,
         session_log_path=session_log_path,
         undo_available=undo_available,
         applied_edit_count=applied_edit_count,
@@ -220,9 +227,13 @@ def _render_canvas_session_controls(
     *,
     note_path: str,
     session_id: str,
+    session_state: str,
     can_edit_body: bool,
     user_present: bool,
     content_hash: str,
+    recovery_needed: bool,
+    recovery_acknowledged: bool,
+    conflict_detected: bool,
     session_log_path: str,
     undo_available: bool,
     applied_edit_count: int,
@@ -236,6 +247,22 @@ def _render_canvas_session_controls(
     undo_api_path = f"/api/canvas/sessions/{session_id}/edits/last" if session_id else ""
     present_text = "user present" if user_present else "user not present"
     log_text = session_log_path or "no session log"
+    recovery_api_path = f"/api/canvas/sessions/{session_id}/recovery/ack" if session_id else ""
+    recovery_html = ""
+    if conflict_detected:
+        recovery_state = "acknowledged" if recovery_acknowledged else "needs acknowledgement"
+        recovery_reason = "recovery needed" if recovery_needed else "paused/interrupted"
+        recovery_html = f"""
+          <div class="canvas-recovery-conflict" data-testid="workspace-canvas-recovery-conflict">
+            <span data-testid="workspace-canvas-conflict-session-state">{session_state}</span>
+            <span>{recovery_reason}</span>
+            <span data-testid="workspace-canvas-recovery-state">{recovery_state}</span>
+            <button
+              type="button"
+              data-testid="workspace-canvas-recovery-ack"
+              data-api-method="LOCAL"
+              data-api-path="{recovery_api_path}">Acknowledge</button>
+          </div>"""
     return f"""
         <div class="canvas-controls" data-testid="workspace-canvas-session-controls">
           <button
@@ -261,6 +288,7 @@ def _render_canvas_session_controls(
             data-api-method="DELETE"
             data-api-path="{undo_api_path}"{undo_disabled}>Undo</button>
           <span class="canvas-presence" data-testid="workspace-canvas-user-present">{present_text}</span>
+          {recovery_html}
           <div class="canvas-provenance" data-testid="workspace-canvas-provenance">
             <span class="canvas-provenance-label">log</span>
             <code data-testid="workspace-canvas-session-log-path">{log_text}</code>
@@ -693,6 +721,25 @@ def render_index_html(
       font-family: var(--font-mono);
       font-size: var(--text-xs);
       grid-column: 1 / -1;
+    }}
+    .canvas-recovery-conflict {{
+      background: var(--destructive-muted);
+      border: 1px solid rgba(255,61,61,0.3);
+      border-radius: var(--radius-md);
+      color: var(--destructive);
+      display: flex;
+      flex-direction: column;
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      gap: 5px;
+      grid-column: 1 / -1;
+      padding: 8px 10px;
+    }}
+    .canvas-recovery-conflict button {{
+      background: var(--bg-raised);
+      border: 1px solid rgba(255,61,61,0.35);
+      color: var(--fg-1);
+      width: 100%;
     }}
     .canvas-provenance {{
       color: var(--fg-3);

--- a/tests/companion_ui/test_canvas_recovery_browser.py
+++ b/tests/companion_ui/test_canvas_recovery_browser.py
@@ -1,0 +1,150 @@
+"""Tests for Canvas recovery and conflict display in the workspace shell (#1131)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from companion_ui.workspace.real_note_workspace_dev_page import (
+    NoteLoadIntent,
+    RealNoteWorkspaceDevPage,
+)
+from companion_ui.workspace.serve_dev_page import render_index_html
+
+
+class _FakeClient:
+    def __init__(self, payloads: list[dict[str, Any]]) -> None:
+        self.payloads = payloads
+        self.get_calls: list[tuple[str, dict[str, Any]]] = []
+        self.post_calls: list[tuple[str, dict[str, Any]]] = []
+
+    def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        self.get_calls.append((url, params))
+        return self.payloads.pop(0)
+
+    def post(self, url: str, *, json: dict[str, Any]) -> dict[str, Any]:
+        self.post_calls.append((url, json))
+        return {"session_id": "session-1", "ok": True}
+
+
+def _workspace_payload(
+    *,
+    content_hash: str = "hash-1",
+    session_state: str = "active",
+    recovery_needed: bool = False,
+    can_edit_body: bool = True,
+) -> dict[str, Any]:
+    return {
+        "artifact": {
+            "artifact_id": "art-1131",
+            "note_path": "Notes/canvas.md",
+            "title": "Canvas Note",
+            "body": "# Canvas Note\n\nBody.",
+            "content_hash": content_hash,
+        },
+        "canvas": {
+            "session_id": "session-1",
+            "session_state": session_state,
+            "user_present": True,
+            "can_edit_body": can_edit_body,
+            "recovery_needed": recovery_needed,
+            "session_log_path": ".chats/canvas/session.md",
+            "undo_available": False,
+            "applied_edit_count": 0,
+            "undone_edit_count": 0,
+            "session_persistence": "in_memory",
+        },
+        "panel": {"state": "idle", "proposal_count": 0},
+        "guards": {"canvas_enabled": True, "writeguard_status": "ok"},
+        "runtime": {},
+        "suggestions": {},
+    }
+
+
+def _load_page(client: _FakeClient) -> RealNoteWorkspaceDevPage:
+    page = RealNoteWorkspaceDevPage(client)  # type: ignore[arg-type]
+    state = page.load(NoteLoadIntent(note_path="Notes/canvas.md"))
+    assert state.is_loaded is True
+    return page
+
+
+def _html(page: RealNoteWorkspaceDevPage) -> str:
+    fields = page.render_fields()
+    assert fields is not None
+    return render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="Notes/canvas.md",
+        fields=fields,
+    )
+
+
+def test_edits_blocked_during_recovery() -> None:
+    client = _FakeClient([_workspace_payload(recovery_needed=True)])
+    page = _load_page(client)
+    html = _html(page)
+
+    state = page.apply_canvas_edit(
+        session_id="session-1",
+        note_path="Notes/canvas.md",
+        new_body="Updated.",
+        change_summary="edit during recovery",
+        content_hash="hash-1",
+    )
+
+    assert state.is_loaded is False
+    assert "unavailable" in (state.error or "")
+    assert client.post_calls == []
+    assert "disabled>Apply body edit</button>" in html
+
+
+def test_conflict_indicator_visible() -> None:
+    for session_state in ("paused", "interrupted"):
+        client = _FakeClient([
+            _workspace_payload(session_state=session_state, recovery_needed=True)
+        ])
+        page = _load_page(client)
+        html = _html(page)
+
+        assert 'data-testid="workspace-canvas-recovery-conflict"' in html
+        assert session_state in html
+        assert 'data-testid="workspace-canvas-recovery-ack"' in html
+
+
+def test_edits_resume_after_recovery_ack() -> None:
+    client = _FakeClient([
+        _workspace_payload(content_hash="hash-1"),
+        _workspace_payload(content_hash="hash-2", recovery_needed=True),
+        _workspace_payload(content_hash="hash-3", recovery_needed=False),
+    ])
+    page = _load_page(client)
+    page.load(NoteLoadIntent(note_path="Notes/canvas.md"))
+
+    state_before_ack = page.apply_canvas_edit(
+        session_id="session-1",
+        note_path="Notes/canvas.md",
+        new_body="Updated.",
+        change_summary="blocked before ack",
+        content_hash="hash-2",
+    )
+    assert state_before_ack.is_loaded is False
+    assert client.post_calls == []
+
+    page.acknowledge_canvas_recovery(note_path="Notes/canvas.md")
+    state_after_ack = page.apply_canvas_edit(
+        session_id="session-1",
+        note_path="Notes/canvas.md",
+        new_body="Updated.",
+        change_summary="allowed after ack",
+        content_hash="hash-2",
+    )
+
+    assert state_after_ack.is_loaded is True
+    assert client.post_calls == [
+        (
+            "/api/canvas/sessions/session-1/edits",
+            {
+                "new_body": "Updated.",
+                "change_summary": "allowed after ack",
+                "content_hash": "hash-2",
+            },
+        ),
+    ]


### PR DESCRIPTION
## Summary
- detect Canvas recovery/conflict state from workspace aggregate paused/interrupted/recovery flags and local content-hash drift
- block body-edit submit while recovery is pending, then allow edits after explicit local acknowledgement
- render recovery conflict state and acknowledgement control in the workspace rail

Closes #1131

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_canvas_recovery_browser.py` — 3 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_canvas_recovery_browser.py tests/companion_ui/test_canvas_session_browser.py tests/companion_ui/test_canvas_edit_browser.py tests/companion_ui/test_canvas_provenance_browser.py tests/companion_ui/test_real_note_workspace_dev_page.py tests/companion_ui/test_real_note_workspace_visual_shell.py tests/companion_ui/test_real_note_workspace_dev_server.py` — 109 passed
- `/tmp/agentic-pkm-checks-1123/bin/ruff check companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py tests/companion_ui/test_canvas_recovery_browser.py` — passed
- `git diff --check` — passed

## Workflow Notes
- Dispatcher unavailable (`ModuleNotFoundError: No module named 'yaml'` from `python3 -m app.dispatcher status --json`) — used mandatory pickup wrapper / GitHub label claim.
