### PR TITLE
canvas-ui: bind suggestion payload cards

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -35,9 +35,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Optional
 
+from companion_ui.canvas_suggestion_flow.suggested_insertion import (
+    SuggestedInsertion,
+)
 from companion_ui.canvas_suggestion_flow.rail_state_machine import (
     CanvasRailStateMachine,
 )
+from companion_ui.canvas_suggestion_flow.suggestion_card import SuggestionCard
 from companion_ui.panel.proposal_row import ProposalEvidence, ProposalRow
 from companion_ui.panel.render_model import PanelRenderState, render_panel_state
 from companion_ui.workspace.real_note_workspace_shell import (
@@ -109,6 +113,8 @@ class DevPageState:
     suggestion_dom_alias: str = "idle"
     suggestion_allowed_transitions: list[str] | None = None
     suggestion_composer_enabled: bool = True
+    suggestion_cards: list[dict[str, Any]] | None = None
+    suggested_insertions: list[dict[str, Any]] | None = None
     guard_writeguard_status: str = "ok"
     guard_canvas_enabled: bool = True
     is_loaded: bool = False
@@ -240,6 +246,8 @@ class RealNoteWorkspaceDevPage:
             suggestion_dom_alias=suggestion_machine.dom_alias,
             suggestion_allowed_transitions=sorted(suggestion_machine.allowed_transitions()),
             suggestion_composer_enabled=suggestion_machine.composer_enabled,
+            suggestion_cards=_suggestion_cards_from_payload(suggestions),
+            suggested_insertions=_suggested_insertions_from_payload(suggestions),
             guard_writeguard_status=guards.get("writeguard_status") or "ok",
             guard_canvas_enabled=bool(guards.get("canvas_enabled", True)),
             is_loaded=True,
@@ -365,6 +373,8 @@ class RealNoteWorkspaceDevPage:
             "suggestion_dom_alias": self.state.suggestion_dom_alias,
             "suggestion_allowed_transitions": self.state.suggestion_allowed_transitions or [],
             "suggestion_composer_enabled": self.state.suggestion_composer_enabled,
+            "suggestion_cards": self.state.suggestion_cards or [],
+            "suggested_insertions": self.state.suggested_insertions or [],
             "guard_writeguard_status": self.state.guard_writeguard_status,
             "guard_canvas_enabled": self.state.guard_canvas_enabled,
             "is_production_ui": self.is_production_ui,
@@ -413,3 +423,48 @@ def _proposal_affordance_set(raw: Any) -> set[str]:
     if isinstance(raw, list):
         return set(raw)
     return {"confirm", "correct", "reject"}
+
+
+def _suggestion_payloads(suggestions: dict[str, Any]) -> list[dict[str, Any]]:
+    raw = suggestions.get("proposals") or suggestions.get("proposal")
+    if raw is None and suggestions.get("server_declared_classification"):
+        raw = suggestions
+    if isinstance(raw, dict):
+        return [raw]
+    if isinstance(raw, list):
+        return [item for item in raw if isinstance(item, dict)]
+    return []
+
+
+def _suggestion_cards_from_payload(suggestions: dict[str, Any]) -> list[dict[str, Any]]:
+    cards: list[dict[str, Any]] = []
+    fallback_classification = suggestions.get("server_declared_classification")
+    for index, raw in enumerate(_suggestion_payloads(suggestions), start=1):
+        variant = raw.get("server_declared_classification") or fallback_classification
+        if variant not in {"body", "governance", "blocked"}:
+            variant = "blocked"
+        card = SuggestionCard(
+            suggestion_id=str(raw.get("suggestion_id") or f"suggestion-{index}"),
+            variant=variant,
+            title=str(raw.get("title") or raw.get("summary") or "Suggestion"),
+            preview_text=str(raw.get("preview_text") or raw.get("proposed_text") or ""),
+            denial_reason=raw.get("denial_reason") or "Suggestion is blocked.",
+        )
+        cards.append(card.as_render_dict())
+    return cards
+
+
+def _suggested_insertions_from_payload(suggestions: dict[str, Any]) -> list[dict[str, Any]]:
+    insertions: list[dict[str, Any]] = []
+    fallback_classification = suggestions.get("server_declared_classification")
+    for index, raw in enumerate(_suggestion_payloads(suggestions), start=1):
+        variant = raw.get("server_declared_classification") or fallback_classification
+        if variant != "body":
+            continue
+        insertion = SuggestedInsertion(
+            suggestion_id=str(raw.get("suggestion_id") or f"suggestion-{index}"),
+            anchor_description=str(raw.get("anchor_description") or "current note body"),
+            proposed_text=str(raw.get("proposed_text") or raw.get("preview_text") or ""),
+        )
+        insertions.append(insertion.as_render_dict())
+    return insertions

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -134,6 +134,10 @@ def _render_note_section(fields: dict) -> str:
         fields.get("panel_proposals") or [],
     )
     suggestion_flow_html = _render_suggestion_flow_region(fields)
+    suggestion_cards_html = _render_suggestion_cards(fields.get("suggestion_cards") or [])
+    suggested_insertions_html = _render_suggested_insertions(
+        fields.get("suggested_insertions") or []
+    )
     canvas_controls_html = _render_canvas_session_controls(
         note_path=note_path_val,
         session_id=canvas_session_id,
@@ -165,6 +169,7 @@ def _render_note_section(fields: dict) -> str:
       </header>
       <div class="note-body" data-testid="workspace-note-body" data-region="note-body">
         <pre class="note-body-content">{body}</pre>
+        {suggested_insertions_html}
       </div>
     </div>
     <aside class="agent-rail" data-testid="workspace-agent-rail" data-region="agent-rail">
@@ -186,6 +191,7 @@ def _render_note_section(fields: dict) -> str:
         {panel_message_html}
         {proposal_rows_html}
         {suggestion_flow_html}
+        {suggestion_cards_html}
         {guard_html}
         {persistence_html}
         {panel_rail}
@@ -221,6 +227,80 @@ def _render_suggestion_flow_region(fields: dict) -> str:
           <div class="suggestion-composer-state">{composer_text}</div>
           <div class="suggestion-transitions">{transition_html}</div>
         </div>"""
+
+
+def _render_suggestion_cards(cards: list[dict]) -> str:
+    rows: list[str] = []
+    for card in cards:
+        intents = card.get("available_intents") or []
+        actions = "".join(
+            (
+                '<button type="button" class="suggestion-action" '
+                f'data-intent="{_e(intent)}">{_e(_suggestion_action_label(intent))}</button>'
+            )
+            for intent in intents
+        )
+        role = f' role="{_e(card.get("aria_role"))}"' if card.get("aria_role") else ""
+        notice = ""
+        if card.get("classification_notice"):
+            notice = (
+                '<div class="suggestion-card-notice" '
+                'data-testid="suggestion-card-classification">'
+                + _e(card.get("classification_notice"))
+                + "</div>"
+            )
+        denial = ""
+        if card.get("denial_reason"):
+            denial = (
+                '<div class="suggestion-card-denial" data-testid="suggestion-card-denial">'
+                + _e(card.get("denial_reason"))
+                + "</div>"
+            )
+        rows.append(
+            f"""
+        <div
+          class="suggestion-card"
+          data-testid="suggestion-card"
+          data-variant="{_e(card.get("data_variant", ""))}"
+          data-suggestion-id="{_e(card.get("data_suggestion_id", ""))}"{role}>
+          <div class="suggestion-card-title">{_e(card.get("title", ""))}</div>
+          <div class="suggestion-card-preview">{_e(card.get("preview_text", ""))}</div>
+          {notice}
+          {denial}
+          <div class="suggestion-card-actions">{actions}</div>
+        </div>"""
+        )
+    return "\n".join(rows)
+
+
+def _suggestion_action_label(intent: str) -> str:
+    return {
+        "suggestion.apply": "Apply",
+        "suggestion.discard": "Discard",
+        "suggestion.inspect": "Inspect",
+        "governance.queue": "Queue",
+        "blocked.acknowledge": "Acknowledge",
+    }.get(intent, intent)
+
+
+def _render_suggested_insertions(insertions: list[dict]) -> str:
+    rows: list[str] = []
+    for insertion in insertions:
+        if not insertion.get("is_visible", True):
+            continue
+        rows.append(
+            f"""
+        <ins
+          class="suggested-insertion"
+          data-testid="suggested-insertion-block"
+          data-suggestion-id="{_e(insertion.get("data_suggestion_id", ""))}"
+          data-state="{_e(insertion.get("data_state", ""))}"
+          aria-label="{_e(insertion.get("aria_label", ""))}">
+          <span class="suggested-insertion-label">{_e(insertion.get("label", ""))}</span>
+          <span class="suggested-insertion-text">{_e(insertion.get("proposed_text", ""))}</span>
+        </ins>"""
+        )
+    return "\n".join(rows)
 
 
 def _render_canvas_session_controls(
@@ -610,6 +690,27 @@ def render_index_html(
       white-space: pre-wrap;
       word-break: break-word;
     }}
+    .suggested-insertion {{
+      background: rgba(212,168,67,0.08);
+      border-left: 3px solid var(--accent);
+      color: var(--fg-1);
+      display: block;
+      font-family: var(--font-mono);
+      font-size: var(--text-sm);
+      margin-top: 12px;
+      padding: 10px 12px;
+      text-decoration: none;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }}
+    .suggested-insertion-label {{
+      color: var(--accent);
+      display: block;
+      font-size: var(--text-xs);
+      letter-spacing: 0.06em;
+      margin-bottom: 4px;
+      text-transform: uppercase;
+    }}
 
     /* ---- Agent rail ---- */
     .agent-rail {{
@@ -778,6 +879,42 @@ def render_index_html(
       display: flex;
       flex-wrap: wrap;
       gap: 6px;
+    }}
+    .suggestion-card {{
+      background: var(--bg-raised);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      color: var(--fg-2);
+      display: flex;
+      flex-direction: column;
+      gap: 7px;
+      padding: 10px;
+    }}
+    .suggestion-card[data-variant="blocked"] {{
+      border-color: rgba(255,61,61,0.3);
+    }}
+    .suggestion-card-title {{
+      color: var(--fg-1);
+      font-size: var(--text-sm);
+    }}
+    .suggestion-card-preview, .suggestion-card-notice, .suggestion-card-denial {{
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+    }}
+    .suggestion-card-actions {{
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+    }}
+    .suggestion-action {{
+      background: var(--bg-surface);
+      border: 1px solid var(--border-strong);
+      border-radius: var(--radius-md);
+      color: var(--fg-1);
+      font-family: var(--font-ui);
+      font-size: var(--text-xs);
+      padding: 4px 7px;
+      text-transform: uppercase;
     }}
     .panel-proposal-row {{
       background: var(--bg-raised);

--- a/tests/companion_ui/test_suggestion_card_browser.py
+++ b/tests/companion_ui/test_suggestion_card_browser.py
@@ -1,0 +1,138 @@
+"""Tests for runtime suggestion payload cards in the workspace shell (#1133)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from companion_ui.workspace.real_note_workspace_dev_page import (
+    NoteLoadIntent,
+    RealNoteWorkspaceDevPage,
+)
+from companion_ui.workspace.serve_dev_page import render_index_html
+
+
+class _FakeClient:
+    def __init__(self, suggestions: dict[str, Any]) -> None:
+        self.suggestions = suggestions
+
+    def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "artifact": {
+                "artifact_id": "art-1133",
+                "note_path": "Notes/canvas.md",
+                "title": "Canvas Note",
+                "body": "# Canvas Note\n\nBody.",
+                "content_hash": "hash-1",
+            },
+            "canvas": {
+                "session_id": "session-1",
+                "session_state": "active",
+                "user_present": True,
+                "can_edit_body": True,
+                "recovery_needed": False,
+                "session_log_path": ".chats/canvas/session.md",
+                "undo_available": False,
+                "applied_edit_count": 0,
+                "undone_edit_count": 0,
+                "session_persistence": "in_memory",
+            },
+            "panel": {"state": "idle", "proposal_count": 0},
+            "guards": {"canvas_enabled": True, "writeguard_status": "ok"},
+            "runtime": {},
+            "suggestions": self.suggestions,
+        }
+
+
+def _html_for_suggestions(suggestions: dict[str, Any]) -> str:
+    page = RealNoteWorkspaceDevPage(_FakeClient(suggestions))  # type: ignore[arg-type]
+    state = page.load(NoteLoadIntent(note_path="Notes/canvas.md"))
+    assert state.is_loaded is True
+    fields = page.render_fields()
+    assert fields is not None
+    return render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="Notes/canvas.md",
+        fields=fields,
+    )
+
+
+def test_body_proposal_renders_card_and_insertion() -> None:
+    html = _html_for_suggestions(
+        {
+            "proposals": [
+                {
+                    "suggestion_id": "s-body",
+                    "server_declared_classification": "body",
+                    "title": "Add bridge paragraph",
+                    "preview_text": "Bridge preview",
+                    "anchor_description": "after intro",
+                    "proposed_text": "Bridge text.",
+                }
+            ]
+        }
+    )
+
+    assert 'data-testid="suggestion-card"' in html
+    assert 'data-variant="body"' in html
+    assert 'data-intent="suggestion.apply"' in html
+    assert 'data-testid="suggested-insertion-block"' in html
+    assert 'data-suggestion-id="s-body"' in html
+    assert "Bridge text." in html
+
+
+def test_governance_proposal_no_apply_action() -> None:
+    html = _html_for_suggestions(
+        {
+            "proposals": [
+                {
+                    "suggestion_id": "s-gov",
+                    "server_declared_classification": "governance",
+                    "title": "Move note",
+                    "preview_text": "lifecycle.move",
+                }
+            ]
+        }
+    )
+
+    assert 'data-variant="governance"' in html
+    assert 'data-intent="governance.queue"' in html
+    assert 'data-intent="suggestion.apply"' not in html
+    assert 'data-testid="suggested-insertion-block"' not in html
+
+
+def test_blocked_proposal_renders_blocked_variant() -> None:
+    html = _html_for_suggestions(
+        {
+            "proposals": [
+                {
+                    "suggestion_id": "s-blocked",
+                    "server_declared_classification": "blocked",
+                    "title": "Edit blocked",
+                    "preview_text": "blocked",
+                    "denial_reason": "Canvas disabled.",
+                }
+            ]
+        }
+    )
+
+    assert 'data-variant="blocked"' in html
+    assert 'role="alert"' in html
+    assert 'data-intent="blocked.acknowledge"' in html
+    assert "Canvas disabled." in html
+
+
+def test_no_reclassification_controls() -> None:
+    html = _html_for_suggestions(
+        {
+            "server_declared_classification": "governance",
+            "proposal": {
+                "suggestion_id": "s-owned",
+                "title": "Queue lifecycle update",
+                "preview_text": "frontmatter update",
+            },
+        }
+    )
+
+    lowered = html.lower()
+    assert "reclassify" not in lowered
+    assert "classification-control" not in lowered


### PR DESCRIPTION
## Summary
- bind `workspace.suggestions` runtime proposal payloads to shipped `SuggestionCard` variants without UI-side reclassification controls
- render body proposals with `SuggestedInsertion` inline previews and body-only Apply actions
- render governance and blocked proposal variants with the correct non-Apply actions and blocked alert state

Closes #1133

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_suggestion_card_browser.py` — 4 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_suggestion_card_browser.py tests/companion_ui/test_suggestion_card.py tests/companion_ui/test_suggested_insertion.py tests/companion_ui/test_suggestion_flow_browser.py tests/companion_ui/test_real_note_workspace_dev_page.py tests/companion_ui/test_real_note_workspace_visual_shell.py tests/companion_ui/test_real_note_workspace_dev_server.py` — 180 passed
- `/tmp/agentic-pkm-checks-1123/bin/ruff check companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py tests/companion_ui/test_suggestion_card_browser.py` — passed
- `git diff --check` — passed

## Workflow Notes
- Dispatcher unavailable (`ModuleNotFoundError: No module named 'yaml'` from `python3 -m app.dispatcher status --json`) — used mandatory pickup wrapper / GitHub label claim.
