### PR TITLE
panel-ui: wire confirm and reject actions

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any, Optional
+from uuid import uuid4
 
 from companion_ui.canvas_suggestion_flow.suggested_insertion import (
     SuggestedInsertion,
@@ -109,6 +110,7 @@ class DevPageState:
     panel_proposal_count: int = 0
     panel_render: dict[str, Any] | None = None
     panel_proposals: list[dict[str, Any]] | None = None
+    panel_last_response: dict[str, Any] | None = None
     suggestion_state: str = "idle"
     suggestion_dom_alias: str = "idle"
     suggestion_allowed_transitions: list[str] | None = None
@@ -242,6 +244,7 @@ class RealNoteWorkspaceDevPage:
             panel_proposal_count=panel_count,
             panel_render=panel_render,
             panel_proposals=panel_proposals,
+            panel_last_response=self.state.panel_last_response,
             suggestion_state=suggestion_machine.state,
             suggestion_dom_alias=suggestion_machine.dom_alias,
             suggestion_allowed_transitions=sorted(suggestion_machine.allowed_transitions()),
@@ -338,6 +341,62 @@ class RealNoteWorkspaceDevPage:
             return self.state
         return self.load(NoteLoadIntent(note_path=note_path))
 
+    def confirm_panel_proposal(
+        self,
+        *,
+        proposal_id: str,
+        artifact_id: str,
+        note_path: str,
+    ) -> DevPageState:
+        """Confirm a staged Panel proposal, then refresh workspace state."""
+        return self._submit_panel_decision(
+            proposal_id=proposal_id,
+            artifact_id=artifact_id,
+            note_path=note_path,
+            action="confirm",
+        )
+
+    def reject_panel_proposal(
+        self,
+        *,
+        proposal_id: str,
+        artifact_id: str,
+        note_path: str,
+    ) -> DevPageState:
+        """Reject a staged Panel proposal, then refresh workspace state."""
+        return self._submit_panel_decision(
+            proposal_id=proposal_id,
+            artifact_id=artifact_id,
+            note_path=note_path,
+            action="reject",
+        )
+
+    def _submit_panel_decision(
+        self,
+        *,
+        proposal_id: str,
+        artifact_id: str,
+        note_path: str,
+        action: str,
+    ) -> DevPageState:
+        try:
+            response = self._http.post(
+                "/api/panel/confirm",
+                json={
+                    "proposal_id": proposal_id,
+                    "artifact_id": artifact_id,
+                    "action": action,
+                    "idempotency_key": str(uuid4()),
+                },
+            )
+        except WorkspaceClientError as exc:
+            self.state = DevPageState(error=str(exc))
+            return self.state
+        self.state.panel_last_response = response
+        refreshed = self.load(NoteLoadIntent(note_path=note_path, artifact_id=artifact_id))
+        refreshed.panel_last_response = response
+        return refreshed
+
     def render_fields(self) -> Optional[dict]:
         """Return a flat dict of renderable fields for the current state.
 
@@ -369,6 +428,7 @@ class RealNoteWorkspaceDevPage:
             "panel_proposal_count": self.state.panel_proposal_count,
             "panel_render": self.state.panel_render or {},
             "panel_proposals": self.state.panel_proposals or [],
+            "panel_last_response": self.state.panel_last_response or {},
             "suggestion_state": self.state.suggestion_state,
             "suggestion_dom_alias": self.state.suggestion_dom_alias,
             "suggestion_allowed_transitions": self.state.suggestion_allowed_transitions or [],

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -133,6 +133,9 @@ def _render_note_section(fields: dict) -> str:
     proposal_rows_html = _render_panel_proposal_rows(
         fields.get("panel_proposals") or [],
     )
+    panel_response_html = _render_panel_confirm_response(
+        fields.get("panel_last_response") or {},
+    )
     suggestion_flow_html = _render_suggestion_flow_region(fields)
     suggestion_cards_html = _render_suggestion_cards(fields.get("suggestion_cards") or [])
     suggested_insertions_html = _render_suggested_insertions(
@@ -190,6 +193,7 @@ def _render_note_section(fields: dict) -> str:
         </div>
         {panel_message_html}
         {proposal_rows_html}
+        {panel_response_html}
         {suggestion_flow_html}
         {suggestion_cards_html}
         {guard_html}
@@ -388,9 +392,20 @@ def _render_panel_proposal_rows(proposals: list[dict]) -> str:
         affordances = proposal.get("affordances") or {}
         enabled_affordances = [
             label
-            for label in ("confirm", "correct", "reject")
+            for label in ("confirm", "reject")
             if affordances.get(label)
         ]
+        buttons = "".join(
+            (
+                '<button type="button" class="panel-proposal-action" '
+                'data-testid="workspace-panel-action" '
+                f'data-panel-action="{_e(label)}" '
+                'data-api-method="POST" '
+                'data-api-path="/api/panel/confirm">'
+                f"{_e(label)}</button>"
+            )
+            for label in enabled_affordances
+        )
         rows.append(
             f"""
         <div class="panel-proposal-row" data-testid="workspace-panel-proposal-row">
@@ -405,11 +420,39 @@ def _render_panel_proposal_rows(proposals: list[dict]) -> str:
             <span>{_e(evidence.get("cognition_route", ""))}</span>
           </div>
           <div class="panel-proposal-affordances">
-            {_e(" / ".join(enabled_affordances))}
+            {buttons}
           </div>
         </div>"""
         )
     return "\n".join(rows)
+
+
+def _render_panel_confirm_response(response: dict) -> str:
+    if not response:
+        return ""
+    status = _e(response.get("status", ""))
+    receipt = response.get("receipt") or {}
+    block_reason = response.get("block_reason") or {}
+    receipt_html = ""
+    if status in {"executed", "logged"} and receipt:
+        receipt_html = (
+            '<div class="panel-confirm-receipt" data-testid="workspace-panel-receipt">'
+            + _e(receipt.get("message") or receipt.get("outcome") or status)
+            + "</div>"
+        )
+    blocked_html = ""
+    if status == "blocked" and block_reason:
+        blocked_html = (
+            '<div class="panel-confirm-blocked" data-testid="workspace-panel-blocked-reason">'
+            + _e(block_reason.get("message") or "")
+            + "</div>"
+        )
+    return f"""
+        <div class="panel-confirm-response" data-testid="workspace-panel-confirm-response">
+          <span data-testid="workspace-panel-confirm-status">{status}</span>
+          {receipt_html}
+          {blocked_html}
+        </div>"""
 
 
 def _render_error_section(error: str) -> str:
@@ -939,6 +982,30 @@ def render_index_html(
       font-size: var(--text-xs);
       font-style: normal;
     }}
+    .panel-proposal-action {{
+      background: var(--bg-surface);
+      border: 1px solid var(--border-strong);
+      border-radius: var(--radius-md);
+      color: var(--fg-1);
+      font-family: var(--font-ui);
+      font-size: var(--text-xs);
+      padding: 4px 7px;
+      text-transform: uppercase;
+    }}
+    .panel-confirm-response {{
+      background: var(--bg-raised);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      color: var(--fg-2);
+      display: flex;
+      flex-direction: column;
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      gap: 5px;
+      padding: 10px;
+    }}
+    .panel-confirm-receipt {{ color: var(--fg-1); }}
+    .panel-confirm-blocked {{ color: var(--destructive); }}
   </style>
 </head>
 <body>

--- a/tests/companion_ui/test_panel_confirm_browser.py
+++ b/tests/companion_ui/test_panel_confirm_browser.py
@@ -1,0 +1,183 @@
+"""Tests for Panel confirm/reject browser wiring (#1138)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from companion_ui.workspace.real_note_workspace_dev_page import (
+    NoteLoadIntent,
+    RealNoteWorkspaceDevPage,
+)
+from companion_ui.workspace.serve_dev_page import render_index_html
+
+
+class _FakeClient:
+    def __init__(
+        self,
+        payloads: list[dict[str, Any]],
+        *,
+        post_response: dict[str, Any] | None = None,
+    ) -> None:
+        self.payloads = payloads
+        self.post_response = post_response or {
+            "proposal_id": "proposal-1",
+            "artifact_id": "art-1138",
+            "status": "executed",
+            "outcome": "success",
+            "receipt": {"message": "Done", "outcome": "success"},
+            "idempotency_key": "server-key",
+        }
+        self.get_calls: list[tuple[str, dict[str, Any]]] = []
+        self.post_calls: list[tuple[str, dict[str, Any]]] = []
+
+    def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        self.get_calls.append((url, params))
+        return self.payloads.pop(0)
+
+    def post(self, url: str, *, json: dict[str, Any]) -> dict[str, Any]:
+        self.post_calls.append((url, json))
+        return self.post_response
+
+
+def _workspace_payload() -> dict[str, Any]:
+    return {
+        "artifact": {
+            "artifact_id": "art-1138",
+            "note_path": "Notes/panel.md",
+            "title": "Panel Note",
+            "body": "# Panel Note\n\nBody.",
+            "content_hash": "hash-1",
+        },
+        "canvas": {
+            "session_id": None,
+            "session_state": None,
+            "user_present": False,
+            "can_edit_body": False,
+            "recovery_needed": False,
+            "session_log_path": None,
+            "undo_available": False,
+            "applied_edit_count": 0,
+            "undone_edit_count": 0,
+            "session_persistence": "in_memory",
+        },
+        "panel": {
+            "state": "proposals-staged",
+            "proposal_count": 1,
+            "proposals": [
+                {
+                    "proposal_id": "proposal-1",
+                    "artifact_id": "art-1138",
+                    "description": "Do the thing",
+                    "status": "staged",
+                    "affordances": {"confirm": True, "reject": True},
+                }
+            ],
+        },
+        "guards": {"canvas_enabled": True, "writeguard_status": "ok"},
+        "runtime": {},
+        "suggestions": {},
+    }
+
+
+def _loaded_page(client: _FakeClient) -> RealNoteWorkspaceDevPage:
+    page = RealNoteWorkspaceDevPage(client)  # type: ignore[arg-type]
+    state = page.load(NoteLoadIntent(note_path="Notes/panel.md"))
+    assert state.is_loaded is True
+    return page
+
+
+def _html(page: RealNoteWorkspaceDevPage) -> str:
+    fields = page.render_fields()
+    assert fields is not None
+    return render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="Notes/panel.md",
+        fields=fields,
+    )
+
+
+def test_confirm_calls_api() -> None:
+    client = _FakeClient([_workspace_payload(), _workspace_payload()])
+    page = _loaded_page(client)
+
+    page.confirm_panel_proposal(
+        proposal_id="proposal-1",
+        artifact_id="art-1138",
+        note_path="Notes/panel.md",
+    )
+
+    assert client.post_calls[0][0] == "/api/panel/confirm"
+    payload = client.post_calls[0][1]
+    assert payload["proposal_id"] == "proposal-1"
+    assert payload["artifact_id"] == "art-1138"
+    assert payload["action"] == "confirm"
+    assert payload["idempotency_key"]
+
+
+def test_reject_calls_api() -> None:
+    client = _FakeClient([_workspace_payload(), _workspace_payload()])
+    page = _loaded_page(client)
+
+    page.reject_panel_proposal(
+        proposal_id="proposal-1",
+        artifact_id="art-1138",
+        note_path="Notes/panel.md",
+    )
+
+    assert client.post_calls[0][1]["action"] == "reject"
+
+
+def test_workspace_refreshed_after_confirm() -> None:
+    client = _FakeClient([_workspace_payload(), _workspace_payload()])
+    page = _loaded_page(client)
+
+    page.confirm_panel_proposal(
+        proposal_id="proposal-1",
+        artifact_id="art-1138",
+        note_path="Notes/panel.md",
+    )
+
+    assert client.get_calls == [
+        ("/api/companion/workspace", {"note_path": "Notes/panel.md"}),
+        ("/api/companion/workspace", {"note_path": "Notes/panel.md"}),
+    ]
+
+
+def test_receipt_rendered_after_executed() -> None:
+    client = _FakeClient([_workspace_payload(), _workspace_payload()])
+    page = _loaded_page(client)
+    page.confirm_panel_proposal(
+        proposal_id="proposal-1",
+        artifact_id="art-1138",
+        note_path="Notes/panel.md",
+    )
+
+    html = _html(page)
+
+    assert 'data-testid="workspace-panel-receipt"' in html
+    assert "Done" in html
+
+
+def test_blocked_reason_rendered() -> None:
+    client = _FakeClient(
+        [_workspace_payload(), _workspace_payload()],
+        post_response={
+            "proposal_id": "proposal-1",
+            "artifact_id": "art-1138",
+            "status": "blocked",
+            "outcome": "blocked",
+            "block_reason": {"gate": "writeguard", "message": "Writes blocked"},
+            "idempotency_key": "server-key",
+        },
+    )
+    page = _loaded_page(client)
+    page.confirm_panel_proposal(
+        proposal_id="proposal-1",
+        artifact_id="art-1138",
+        note_path="Notes/panel.md",
+    )
+
+    html = _html(page)
+
+    assert 'data-testid="workspace-panel-blocked-reason"' in html
+    assert "Writes blocked" in html


### PR DESCRIPTION
## Summary
- add browser methods for Panel confirm and reject that call `POST /api/panel/confirm` with fresh UUID idempotency keys
- render confirm/reject proposal actions in the companion rail
- preserve the Panel confirm response through workspace refresh and render executed receipts or blocked reasons

Closes #1138

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_panel_confirm_browser.py` — 5 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_panel_confirm_browser.py tests/companion_ui/test_panel_rail_browser.py tests/companion_ui/test_real_note_workspace_dev_page.py tests/companion_ui/test_real_note_workspace_visual_shell.py tests/companion_ui/test_real_note_workspace_dev_server.py` — 103 passed
- `/tmp/agentic-pkm-checks-1123/bin/ruff check companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py tests/companion_ui/test_panel_confirm_browser.py` — passed
- `git diff --check` — passed

## Workflow Notes
- Dispatcher unavailable (`ModuleNotFoundError: No module named 'yaml'` from `python3 -m app.dispatcher status --json`) — used mandatory pickup wrapper / GitHub label claim.
