### PR TITLE
companion-ui: address review comments

### DIFF
--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -172,6 +172,7 @@ def _canvas_state(safe_note_path: str, vault_root: Path, canvas_enabled: bool) -
     log_path = _vault_relative(Path(session.log_path), vault_root)
     applied_edits = getattr(canvas_module, "_edit_history", {}).get(session.session_id, [])
     undone_edits = getattr(canvas_module, "_undone_history", {}).get(session.session_id, [])
+    undo_available = _undo_available_for_session(session=session, applied_edits=applied_edits)
     return CanvasState(
         session_id=session.session_id,
         session_state="active",
@@ -179,10 +180,21 @@ def _canvas_state(safe_note_path: str, vault_root: Path, canvas_enabled: bool) -
         can_edit_body=canvas_enabled,
         recovery_needed=False,
         session_log_path=log_path,
-        undo_available=bool(applied_edits),
+        undo_available=undo_available,
         applied_edit_count=len(applied_edits),
         undone_edit_count=len(undone_edits),
     )
+
+
+def _undo_available_for_session(*, session: object, applied_edits: list[object]) -> bool:
+    if not applied_edits:
+        return False
+    latest = applied_edits[-1]
+    try:
+        current_body = canvas_module._note_body(Path(session.note_path))
+    except Exception:
+        return False
+    return current_body == getattr(latest, "body_after", None)
 
 
 def _proposal_count_for_artifact(artifact_id: str) -> int:

--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -41,6 +41,7 @@ from companion_ui.canvas_suggestion_flow.suggested_insertion import (
 )
 from companion_ui.canvas_suggestion_flow.rail_state_machine import (
     CanvasRailStateMachine,
+    RAIL_STATES,
 )
 from companion_ui.canvas_suggestion_flow.suggestion_card import SuggestionCard
 from companion_ui.panel.proposal_row import ProposalEvidence, ProposalRow
@@ -150,7 +151,8 @@ class RealNoteWorkspaceDevPage:
         self._http = http_client
         self.state: DevPageState = DevPageState()
         self._last_content_hash_by_note: dict[str, str] = {}
-        self._acknowledged_recovery_notes: set[str] = set()
+        self._acknowledged_recovery_tokens: set[tuple[str, str, str, str]] = set()
+        self._trusted_hash_refresh_notes: set[str] = set()
 
     def load(self, intent: NoteLoadIntent) -> DevPageState:
         """Load a note via the runtime API.
@@ -193,13 +195,20 @@ class RealNoteWorkspaceDevPage:
         previous_hash = self._last_content_hash_by_note.get(resolved_note_path)
         session_state = canvas.get("session_state") or "idle"
         recovery_needed = bool(canvas.get("recovery_needed", False))
-        recovery_acknowledged = resolved_note_path in self._acknowledged_recovery_notes
+        recovery_token = _recovery_token(
+            note_path=resolved_note_path,
+            session_id=canvas.get("session_id"),
+            session_state=session_state,
+            content_hash=content_hash,
+        )
+        recovery_acknowledged = recovery_token in self._acknowledged_recovery_tokens
         hash_conflict = (
-            recovery_needed
-            and previous_hash is not None
+            previous_hash is not None
             and bool(content_hash)
             and previous_hash != content_hash
+            and resolved_note_path not in self._trusted_hash_refresh_notes
         )
+        self._trusted_hash_refresh_notes.discard(resolved_note_path)
         state_conflict = session_state in {"paused", "interrupted"}
         conflict_detected = recovery_needed or hash_conflict or state_conflict
         runtime_can_edit_body = bool(canvas.get("can_edit_body", False))
@@ -222,8 +231,11 @@ class RealNoteWorkspaceDevPage:
             artifact_id=resolved_artifact_id,
         )
         suggestion_machine = CanvasRailStateMachine(
-            suggestions.get("current_suggestion_state") or "idle"
+            _normalise_suggestion_state(suggestions.get("current_suggestion_state"))
         )
+        panel_last_response = self.state.panel_last_response
+        if panel_last_response and panel_last_response.get("artifact_id") != resolved_artifact_id:
+            panel_last_response = None
         self.state = DevPageState(
             shell=shell,
             panel_rail_placeholder=panel_render.get("label", "Panel ready"),
@@ -244,7 +256,7 @@ class RealNoteWorkspaceDevPage:
             panel_proposal_count=panel_count,
             panel_render=panel_render,
             panel_proposals=panel_proposals,
-            panel_last_response=self.state.panel_last_response,
+            panel_last_response=panel_last_response,
             suggestion_state=suggestion_machine.state,
             suggestion_dom_alias=suggestion_machine.dom_alias,
             suggestion_allowed_transitions=sorted(suggestion_machine.allowed_transitions()),
@@ -312,12 +324,20 @@ class RealNoteWorkspaceDevPage:
         except WorkspaceClientError as exc:
             self.state = DevPageState(error=str(exc))
             return self.state
+        self._trusted_hash_refresh_notes.add(note_path)
         return self.load(NoteLoadIntent(note_path=note_path))
 
     def acknowledge_canvas_recovery(self, *, note_path: str) -> DevPageState:
         """Acknowledge recovery/conflict state before body edits resume."""
-        self._acknowledged_recovery_notes.add(note_path)
         if self.state.shell is not None and self.state.shell.note_path == note_path:
+            self._acknowledged_recovery_tokens.add(
+                _recovery_token(
+                    note_path=note_path,
+                    session_id=self.state.canvas_session_id,
+                    session_state=self.state.canvas_session_state,
+                    content_hash=self.state.shell.content_hash,
+                )
+            )
             self.state.canvas_recovery_acknowledged = True
             self.state.canvas_conflict_detected = False
             self.state.canvas_can_edit_body = self.state.canvas_runtime_can_edit_body
@@ -485,6 +505,21 @@ def _proposal_affordance_set(raw: Any) -> set[str]:
     return {"confirm", "correct", "reject"}
 
 
+def _normalise_suggestion_state(raw_state: Any) -> str:
+    state = str(raw_state or "idle")
+    return state if state in RAIL_STATES else "idle"
+
+
+def _recovery_token(
+    *,
+    note_path: str,
+    session_id: Any,
+    session_state: str,
+    content_hash: str,
+) -> tuple[str, str, str, str]:
+    return (note_path, str(session_id or ""), session_state, content_hash)
+
+
 def _suggestion_payloads(suggestions: dict[str, Any]) -> list[dict[str, Any]]:
     raw = suggestions.get("proposals") or suggestions.get("proposal")
     if raw is None and suggestions.get("server_declared_classification"):
@@ -521,10 +556,13 @@ def _suggested_insertions_from_payload(suggestions: dict[str, Any]) -> list[dict
         variant = raw.get("server_declared_classification") or fallback_classification
         if variant != "body":
             continue
+        proposed_text = str(raw.get("proposed_text") or raw.get("preview_text") or "")
+        if not proposed_text:
+            continue
         insertion = SuggestedInsertion(
             suggestion_id=str(raw.get("suggestion_id") or f"suggestion-{index}"),
             anchor_description=str(raw.get("anchor_description") or "current note body"),
-            proposed_text=str(raw.get("proposed_text") or raw.get("preview_text") or ""),
+            proposed_text=proposed_text,
         )
         insertions.append(insertion.as_render_dict())
     return insertions

--- a/tests/api/test_companion_workspace_api.py
+++ b/tests/api/test_companion_workspace_api.py
@@ -123,7 +123,7 @@ def test_workspace_canvas_state_with_open_session(
         canvas_module._AppliedBodyEdit(
             edit_id="edit-1",
             body_before="Body text.\n",
-            body_after="Updated body.\n",
+            body_after=canvas_module._note_body(vault_note),
             change_summary="updated",
         )
     ]
@@ -140,6 +140,36 @@ def test_workspace_canvas_state_with_open_session(
     assert canvas["applied_edit_count"] == 1
     assert canvas["undone_edit_count"] == 0
     assert canvas["session_persistence"] == "in_memory"
+
+
+def test_workspace_undo_unavailable_when_note_body_diverged(
+    client: TestClient, vault_note: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CANVAS_ENABLED", "1")
+    log_path = tmp_path / ".chats" / "note" / "session.md"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text("session", encoding="utf-8")
+    canvas_module._sessions["session-1"] = SessionLog(
+        log_path=log_path,
+        session_id="session-1",
+        note_path=vault_note,
+        label="test",
+    )
+    canvas_module._edit_history["session-1"] = [
+        canvas_module._AppliedBodyEdit(
+            edit_id="edit-1",
+            body_before="Body text.\n",
+            body_after="Updated body.\n",
+            change_summary="updated",
+        )
+    ]
+
+    resp = _workspace(client)
+
+    assert resp.status_code == 200
+    canvas = resp.json()["canvas"]
+    assert canvas["applied_edit_count"] == 1
+    assert canvas["undo_available"] is False
 
 
 def test_workspace_panel_state(client: TestClient, vault_note: Path) -> None:

--- a/tests/companion_ui/test_canvas_recovery_browser.py
+++ b/tests/companion_ui/test_canvas_recovery_browser.py
@@ -148,3 +148,30 @@ def test_edits_resume_after_recovery_ack() -> None:
             },
         ),
     ]
+
+
+def test_hash_drift_blocks_without_recovery_flag() -> None:
+    client = _FakeClient([
+        _workspace_payload(content_hash="hash-1"),
+        _workspace_payload(content_hash="hash-2", recovery_needed=False),
+    ])
+    page = _load_page(client)
+    state = page.load(NoteLoadIntent(note_path="Notes/canvas.md"))
+
+    assert state.canvas_conflict_detected is True
+    assert state.canvas_can_edit_body is False
+
+
+def test_recovery_ack_resets_for_new_conflict_cycle() -> None:
+    client = _FakeClient([
+        _workspace_payload(content_hash="hash-1", recovery_needed=True),
+        _workspace_payload(content_hash="hash-2", recovery_needed=True),
+    ])
+    page = _load_page(client)
+    page.acknowledge_canvas_recovery(note_path="Notes/canvas.md")
+
+    state = page.load(NoteLoadIntent(note_path="Notes/canvas.md"))
+
+    assert state.canvas_conflict_detected is True
+    assert state.canvas_recovery_acknowledged is False
+    assert state.canvas_can_edit_body is False

--- a/tests/companion_ui/test_panel_confirm_browser.py
+++ b/tests/companion_ui/test_panel_confirm_browser.py
@@ -79,6 +79,20 @@ def _workspace_payload() -> dict[str, Any]:
     }
 
 
+def _workspace_payload_for_note(
+    *,
+    artifact_id: str,
+    note_path: str,
+) -> dict[str, Any]:
+    payload = _workspace_payload()
+    payload["artifact"] = {
+        **payload["artifact"],
+        "artifact_id": artifact_id,
+        "note_path": note_path,
+    }
+    return payload
+
+
 def _loaded_page(client: _FakeClient) -> RealNoteWorkspaceDevPage:
     page = RealNoteWorkspaceDevPage(client)  # type: ignore[arg-type]
     state = page.load(NoteLoadIntent(note_path="Notes/panel.md"))
@@ -181,3 +195,22 @@ def test_blocked_reason_rendered() -> None:
 
     assert 'data-testid="workspace-panel-blocked-reason"' in html
     assert "Writes blocked" in html
+
+
+def test_panel_response_cleared_when_switching_notes() -> None:
+    client = _FakeClient([
+        _workspace_payload_for_note(artifact_id="art-1138-a", note_path="Notes/a.md"),
+        _workspace_payload_for_note(artifact_id="art-1138-a", note_path="Notes/a.md"),
+        _workspace_payload_for_note(artifact_id="art-1138-b", note_path="Notes/b.md"),
+    ])
+    page = RealNoteWorkspaceDevPage(client)  # type: ignore[arg-type]
+    page.load(NoteLoadIntent(note_path="Notes/a.md"))
+    page.confirm_panel_proposal(
+        proposal_id="proposal-1",
+        artifact_id="art-1138-a",
+        note_path="Notes/a.md",
+    )
+
+    state = page.load(NoteLoadIntent(note_path="Notes/b.md"))
+
+    assert state.panel_last_response is None

--- a/tests/companion_ui/test_suggestion_card_browser.py
+++ b/tests/companion_ui/test_suggestion_card_browser.py
@@ -136,3 +136,21 @@ def test_no_reclassification_controls() -> None:
     lowered = html.lower()
     assert "reclassify" not in lowered
     assert "classification-control" not in lowered
+
+
+def test_body_proposal_without_text_skips_insertion() -> None:
+    html = _html_for_suggestions(
+        {
+            "proposals": [
+                {
+                    "suggestion_id": "s-empty",
+                    "server_declared_classification": "body",
+                    "title": "Metadata-only body proposal",
+                }
+            ]
+        }
+    )
+
+    assert 'data-testid="suggestion-card"' in html
+    assert 'data-variant="body"' in html
+    assert 'data-testid="suggested-insertion-block"' not in html

--- a/tests/companion_ui/test_suggestion_flow_browser.py
+++ b/tests/companion_ui/test_suggestion_flow_browser.py
@@ -90,3 +90,10 @@ def test_suggestion_state_attribute() -> None:
 
     assert 'data-testid="workspace-suggestion-flow"' in html
     assert 'data-suggestion-state="staged_body"' in html
+
+
+def test_unknown_suggestion_state_falls_back_to_idle() -> None:
+    html = _html_for_state("future_runtime_state")
+
+    assert 'data-testid="workspace-suggestion-flow"' in html
+    assert 'data-suggestion-state="idle"' in html


### PR DESCRIPTION
## Summary
- address unresolved inline Codex review threads from #1152, #1154, #1155, #1156, and #1157
- guard unknown suggestion states, empty body insertion payloads, stale undo availability, repeated recovery acknowledgements, hash drift, and cross-note panel response carryover
- add regression coverage for each reviewed failure mode

Follow-up for inline review comments on #1152, #1154, #1155, #1156, and #1157.

## Direct Repair
Type: code
Reason: Follow-up for unresolved inline review comments on already-merged Companion UI PRs #1152, #1154, #1155, #1156, and #1157; no new product scope.
Validation: targeted pytest suites, broader regression suites, ruff, and git diff --check listed below.
Issue required: no

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/api/test_companion_workspace_api.py tests/companion_ui/test_suggestion_flow_browser.py tests/companion_ui/test_canvas_recovery_browser.py tests/companion_ui/test_suggestion_card_browser.py tests/companion_ui/test_panel_confirm_browser.py` - 28 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_canvas_edit_browser.py tests/companion_ui/test_canvas_session_browser.py tests/companion_ui/test_canvas_provenance_browser.py tests/companion_ui/test_real_note_workspace_dev_page.py tests/companion_ui/test_real_note_workspace_visual_shell.py tests/companion_ui/test_real_note_workspace_dev_server.py tests/api/test_canvas_api.py` - 114 passed
- `/tmp/agentic-pkm-checks-1123/bin/ruff check app/api/routes/companion.py companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py tests/api/test_companion_workspace_api.py tests/companion_ui/test_suggestion_flow_browser.py tests/companion_ui/test_canvas_recovery_browser.py tests/companion_ui/test_suggestion_card_browser.py tests/companion_ui/test_panel_confirm_browser.py` - passed
- `git diff --check` - passed
