### PR TITLE
companion-ui: clear trusted hash bypass after refresh failure

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -166,6 +166,7 @@ class RealNoteWorkspaceDevPage:
         try:
             raw = self._http.get("/api/companion/workspace", params=params)
         except WorkspaceClientError as exc:
+            self._trusted_hash_refresh_notes.discard(intent.note_path)
             self.state = DevPageState(error=str(exc))
             return self.state
 

--- a/tests/companion_ui/test_canvas_recovery_browser.py
+++ b/tests/companion_ui/test_canvas_recovery_browser.py
@@ -9,6 +9,7 @@ from companion_ui.workspace.real_note_workspace_dev_page import (
     RealNoteWorkspaceDevPage,
 )
 from companion_ui.workspace.serve_dev_page import render_index_html
+from companion_ui.workspace.workspace_http_client import WorkspaceClientNetworkError
 
 
 class _FakeClient:
@@ -19,7 +20,10 @@ class _FakeClient:
 
     def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
         self.get_calls.append((url, params))
-        return self.payloads.pop(0)
+        payload = self.payloads.pop(0)
+        if isinstance(payload, Exception):
+            raise payload
+        return payload
 
     def post(self, url: str, *, json: dict[str, Any]) -> dict[str, Any]:
         self.post_calls.append((url, json))
@@ -174,4 +178,27 @@ def test_recovery_ack_resets_for_new_conflict_cycle() -> None:
 
     assert state.canvas_conflict_detected is True
     assert state.canvas_recovery_acknowledged is False
+    assert state.canvas_can_edit_body is False
+
+
+def test_failed_post_edit_refresh_clears_trusted_hash_bypass() -> None:
+    client = _FakeClient([
+        _workspace_payload(content_hash="hash-1"),
+        WorkspaceClientNetworkError("refresh failed"),
+        _workspace_payload(content_hash="hash-2", recovery_needed=False),
+    ])
+    page = _load_page(client)
+
+    failed_refresh = page.apply_canvas_edit(
+        session_id="session-1",
+        note_path="Notes/canvas.md",
+        new_body="Updated.",
+        change_summary="edit before failed refresh",
+        content_hash="hash-1",
+    )
+    assert failed_refresh.is_loaded is False
+
+    state = page.load(NoteLoadIntent(note_path="Notes/canvas.md"))
+
+    assert state.canvas_conflict_detected is True
     assert state.canvas_can_edit_body is False


### PR DESCRIPTION
## Summary
- clear the trusted hash-refresh bypass when a workspace reload fails
- add a regression test covering failed post-edit refresh followed by hash drift

## Direct Repair
Type: code
Reason: Follow-up for the unresolved inline review on #1158 about stale trusted hash bypass state after failed post-edit refresh.
Validation: targeted Canvas recovery pytest, ruff, and git diff --check listed below.
Issue required: no

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_canvas_recovery_browser.py` - 6 passed
- `/tmp/agentic-pkm-checks-1123/bin/ruff check companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py tests/companion_ui/test_canvas_recovery_browser.py` - passed
- `git diff --check` - passed
