### PR TITLE
panel-ui: wire correction flow

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -392,6 +392,34 @@ class RealNoteWorkspaceDevPage:
             action="reject",
         )
 
+    def correct_panel_proposal(
+        self,
+        *,
+        proposal_id: str,
+        artifact_id: str,
+        note_path: str,
+        corrected_action_id: str | None = None,
+        corrected_parameters: dict[str, Any] | None = None,
+    ) -> DevPageState:
+        """Submit a corrected staged Panel proposal, then refresh workspace state."""
+        if corrected_action_id is None and corrected_parameters is None:
+            self.state.error = (
+                "Panel correction requires corrected_action_id or corrected_parameters"
+            )
+            self.state.is_loaded = False
+            return self.state
+        return self._submit_panel_decision(
+            proposal_id=proposal_id,
+            artifact_id=artifact_id,
+            note_path=note_path,
+            action="confirm",
+            correction={
+                "enabled": True,
+                "corrected_action_id": corrected_action_id,
+                "corrected_parameters": corrected_parameters,
+            },
+        )
+
     def _submit_panel_decision(
         self,
         *,
@@ -399,16 +427,20 @@ class RealNoteWorkspaceDevPage:
         artifact_id: str,
         note_path: str,
         action: str,
+        correction: dict[str, Any] | None = None,
     ) -> DevPageState:
+        request_payload: dict[str, Any] = {
+            "proposal_id": proposal_id,
+            "artifact_id": artifact_id,
+            "action": action,
+            "idempotency_key": str(uuid4()),
+        }
+        if correction is not None:
+            request_payload["correction"] = correction
         try:
             response = self._http.post(
                 "/api/panel/confirm",
-                json={
-                    "proposal_id": proposal_id,
-                    "artifact_id": artifact_id,
-                    "action": action,
-                    "idempotency_key": str(uuid4()),
-                },
+                json=request_payload,
             )
         except WorkspaceClientError as exc:
             self.state = DevPageState(error=str(exc))

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -392,7 +392,7 @@ def _render_panel_proposal_rows(proposals: list[dict]) -> str:
         affordances = proposal.get("affordances") or {}
         enabled_affordances = [
             label
-            for label in ("confirm", "reject")
+            for label in ("confirm", "correct", "reject")
             if affordances.get(label)
         ]
         buttons = "".join(
@@ -435,9 +435,16 @@ def _render_panel_confirm_response(response: dict) -> str:
     block_reason = response.get("block_reason") or {}
     receipt_html = ""
     if status in {"executed", "logged"} and receipt:
+        corrected_badge = ""
+        if receipt.get("message") == "corrected":
+            corrected_badge = (
+                '<span class="panel-confirm-corrected" '
+                'data-testid="workspace-panel-corrected-receipt">corrected</span>'
+            )
         receipt_html = (
             '<div class="panel-confirm-receipt" data-testid="workspace-panel-receipt">'
             + _e(receipt.get("message") or receipt.get("outcome") or status)
+            + corrected_badge
             + "</div>"
         )
     blocked_html = ""

--- a/tests/companion_ui/test_panel_correction_browser.py
+++ b/tests/companion_ui/test_panel_correction_browser.py
@@ -1,0 +1,153 @@
+"""Tests for Panel correction browser wiring (#1139)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from companion_ui.workspace.real_note_workspace_dev_page import (
+    NoteLoadIntent,
+    RealNoteWorkspaceDevPage,
+)
+from companion_ui.workspace.serve_dev_page import render_index_html
+
+
+class _FakeClient:
+    def __init__(
+        self,
+        payloads: list[dict[str, Any]],
+        *,
+        post_response: dict[str, Any] | None = None,
+    ) -> None:
+        self.payloads = payloads
+        self.post_response = post_response or {
+            "proposal_id": "proposal-1",
+            "artifact_id": "art-1139",
+            "status": "executed",
+            "outcome": "success",
+            "receipt": {"message": "corrected", "outcome": "success"},
+            "idempotency_key": "server-key",
+        }
+        self.get_calls: list[tuple[str, dict[str, Any]]] = []
+        self.post_calls: list[tuple[str, dict[str, Any]]] = []
+
+    def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        self.get_calls.append((url, params))
+        return self.payloads.pop(0)
+
+    def post(self, url: str, *, json: dict[str, Any]) -> dict[str, Any]:
+        self.post_calls.append((url, json))
+        return self.post_response
+
+
+def _workspace_payload() -> dict[str, Any]:
+    return {
+        "artifact": {
+            "artifact_id": "art-1139",
+            "note_path": "Notes/panel.md",
+            "title": "Panel Note",
+            "body": "# Panel Note\n\nBody.",
+            "content_hash": "hash-1",
+        },
+        "canvas": {
+            "session_id": None,
+            "session_state": None,
+            "user_present": False,
+            "can_edit_body": False,
+            "recovery_needed": False,
+            "session_log_path": None,
+            "undo_available": False,
+            "applied_edit_count": 0,
+            "undone_edit_count": 0,
+            "session_persistence": "in_memory",
+        },
+        "panel": {
+            "state": "proposals-staged",
+            "proposal_count": 1,
+            "proposals": [
+                {
+                    "proposal_id": "proposal-1",
+                    "artifact_id": "art-1139",
+                    "description": "Update status",
+                    "status": "staged",
+                    "affordances": {"confirm": True, "correct": True, "reject": True},
+                }
+            ],
+        },
+        "guards": {"canvas_enabled": True, "writeguard_status": "ok"},
+        "runtime": {},
+        "suggestions": {},
+    }
+
+
+def _loaded_page(client: _FakeClient) -> RealNoteWorkspaceDevPage:
+    page = RealNoteWorkspaceDevPage(client)  # type: ignore[arg-type]
+    state = page.load(NoteLoadIntent(note_path="Notes/panel.md"))
+    assert state.is_loaded is True
+    return page
+
+
+def _html(page: RealNoteWorkspaceDevPage) -> str:
+    fields = page.render_fields()
+    assert fields is not None
+    return render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="Notes/panel.md",
+        fields=fields,
+    )
+
+
+def test_correction_calls_api() -> None:
+    client = _FakeClient([_workspace_payload(), _workspace_payload()])
+    page = _loaded_page(client)
+
+    page.correct_panel_proposal(
+        proposal_id="proposal-1",
+        artifact_id="art-1139",
+        note_path="Notes/panel.md",
+        corrected_action_id="proposal-1",
+        corrected_parameters={"value": "evergreen"},
+    )
+
+    assert client.post_calls[0][0] == "/api/panel/confirm"
+    payload = client.post_calls[0][1]
+    assert payload["proposal_id"] == "proposal-1"
+    assert payload["artifact_id"] == "art-1139"
+    assert payload["action"] == "confirm"
+    assert payload["idempotency_key"]
+    assert payload["correction"] == {
+        "enabled": True,
+        "corrected_action_id": "proposal-1",
+        "corrected_parameters": {"value": "evergreen"},
+    }
+
+
+def test_corrected_receipt_marked() -> None:
+    client = _FakeClient([_workspace_payload(), _workspace_payload()])
+    page = _loaded_page(client)
+    page.correct_panel_proposal(
+        proposal_id="proposal-1",
+        artifact_id="art-1139",
+        note_path="Notes/panel.md",
+        corrected_action_id="proposal-1",
+        corrected_parameters={"value": "evergreen"},
+    )
+
+    html = _html(page)
+
+    assert 'data-testid="workspace-panel-corrected-receipt"' in html
+    assert "corrected" in html
+
+
+def test_invalid_correction_rejected() -> None:
+    client = _FakeClient([_workspace_payload()])
+    page = _loaded_page(client)
+
+    state = page.correct_panel_proposal(
+        proposal_id="proposal-1",
+        artifact_id="art-1139",
+        note_path="Notes/panel.md",
+    )
+
+    assert state.is_loaded is False
+    assert "requires corrected_action_id or corrected_parameters" in (state.error or "")
+    assert client.post_calls == []


### PR DESCRIPTION
Fixes #1139

## Summary
- add a Panel correction submit path that posts `correction.enabled=true` to `/api/panel/confirm`
- render the existing correct affordance in Panel proposal rows and mark corrected receipts distinctly
- add browser/page-model regression coverage for correction submit, corrected receipt display, and invalid correction rejection

## Dispatcher
- Dispatcher unavailable: `python3 -m app.dispatcher status --json` failed during app import with `ModuleNotFoundError: No module named 'yaml'`; used GitHub-label claim via `scripts/issue_pickup_claim.sh --issue 1139` and manually set Project status to In Progress.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_panel_correction_browser.py` - 3 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_panel_confirm_browser.py tests/companion_ui/test_panel_rail_browser.py tests/companion_ui/test_panel_interactions.py` - 42 passed
- after #1145 merged: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_panel_confirm_browser.py tests/companion_ui/test_panel_rail_browser.py tests/companion_ui/test_panel_interactions.py tests/panel/test_panel_confirm_correction.py` - 51 passed
- `/tmp/agentic-pkm-checks-1123/bin/ruff check companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py tests/companion_ui/test_panel_correction_browser.py` - passed
- `/tmp/agentic-pkm-checks-1123/bin/ruff check app tests` - passed
- `git diff --check` / `git diff --check origin/main...HEAD` - passed
