### PR TITLE
companion-ui: add production launch profile

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -477,6 +477,7 @@ def render_index_html(
     note_path: str = "",
     fields: Optional[dict] = None,
     error: str = "",
+    production_profile: bool = False,
 ) -> str:
     """Render the workspace dev page as a Companion UI visual shell.
 
@@ -493,16 +494,24 @@ def render_index_html(
         content_section = _render_error_section(error)
     elif fields is not None:
         content_section = _render_note_section(fields)
+    title_suffix = "PROD" if production_profile else "DEV"
+    dev_chip = "" if production_profile else '<span class="dev-chip">DEV / not production</span>'
+    production_static_link = (
+        '<link rel="stylesheet" href="/static/companion-workspace.css">'
+        if production_profile
+        else ""
+    )
 
     return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Companion UI — Real-Note Workspace [DEV]</title>
+  <title>Companion UI — Real-Note Workspace [{title_suffix}]</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;1,400&family=Space+Grotesk:wght@300;400;500;600&display=swap" rel="stylesheet">
+  {production_static_link}
   <style>
     /* Yggdrasil design tokens (subset inlined for offline resilience) */
     :root {{
@@ -1021,7 +1030,7 @@ def render_index_html(
       <span class="api-label">Runtime API</span>
       <span class="api-url" title="{_e(api_base_url)}">{_e(api_base_url)}</span>
     </div>
-    <span class="dev-chip">DEV / not production</span>
+    {dev_chip}
   </div>
   <div class="load-bar">
     <form method="GET" action="/" style="display:flex;align-items:center;gap:8px;width:100%">
@@ -1046,6 +1055,7 @@ def handle_get(
     query_string: str,
     client: WorkspaceHttpClient,
     api_base_url: str,
+    production_profile: bool = False,
 ) -> str:
     """Parse query string, optionally load a note, and return full page HTML.
 
@@ -1069,10 +1079,17 @@ def handle_get(
         note_path=note_path,
         fields=fields,
         error=error,
+        production_profile=production_profile,
     )
 
 
-def make_handler(*, client: WorkspaceHttpClient, api_base_url: str) -> type:
+def make_handler(
+    *,
+    client: WorkspaceHttpClient,
+    api_base_url: str,
+    production_profile: bool = False,
+    static_assets: dict[str, tuple[str, bytes]] | None = None,
+) -> type:
     """Return a configured BaseHTTPRequestHandler subclass.
 
     The returned class closes over client and api_base_url as class attributes
@@ -1082,13 +1099,24 @@ def make_handler(*, client: WorkspaceHttpClient, api_base_url: str) -> type:
     class _Handler(BaseHTTPRequestHandler):
         _client = client
         _api_base_url = api_base_url
+        _production_profile = production_profile
+        _static_assets = static_assets or {}
 
         def do_GET(self) -> None:
             parsed = urlparse(self.path)
+            if parsed.path in self._static_assets:
+                content_type, body = self._static_assets[parsed.path]
+                self.send_response(200)
+                self.send_header("Content-Type", content_type)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
             body = handle_get(
                 query_string=parsed.query,
                 client=self._client,
                 api_base_url=self._api_base_url,
+                production_profile=self._production_profile,
             ).encode("utf-8")
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")

--- a/companion-ui/companion-app/companion_ui/workspace/serve_production_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_production_page.py
@@ -1,0 +1,85 @@
+"""Production launch profile for the Companion real-note workspace.
+
+This profile is separate from the dev/staging server. It keeps the same
+runtime-mediated workspace boundary but uses production defaults and omits
+dev/staging markers from rendered output.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from http.server import HTTPServer
+
+from companion_ui.workspace.serve_dev_page import (
+    _DEFAULT_HOST,
+    WorkspaceHttpClient,
+    make_handler,
+    render_index_html,
+)
+
+_PRODUCTION_PORT = 8113
+_PRODUCTION_API_BASE_URL = "http://127.0.0.1:18000"
+_PRODUCTION_STATIC_ASSETS = {
+    "/static/companion-workspace.css": (
+        "text/css; charset=utf-8",
+        b":root{color-scheme:dark;} body{min-height:100vh;}\n",
+    )
+}
+
+
+def load_config() -> dict:
+    """Load production profile config from environment variables."""
+    return {
+        "host": os.environ.get("HOST", _DEFAULT_HOST),
+        "port": int(os.environ.get("PORT", str(_PRODUCTION_PORT))),
+        "api_base_url": os.environ.get(
+            "COMPANION_API_BASE_URL",
+            _PRODUCTION_API_BASE_URL,
+        ),
+    }
+
+
+def render_production_index_html(
+    *,
+    api_base_url: str,
+    note_path: str = "",
+    fields: dict | None = None,
+    error: str = "",
+) -> str:
+    """Render the workspace shell with production-profile chrome."""
+    return render_index_html(
+        api_base_url=api_base_url,
+        note_path=note_path,
+        fields=fields,
+        error=error,
+        production_profile=True,
+    )
+
+
+def main() -> None:
+    """Entry point: read production config, bind server, serve until stopped."""
+    config = load_config()
+    client = WorkspaceHttpClient(base_url=config["api_base_url"])
+    handler = make_handler(
+        client=client,
+        api_base_url=config["api_base_url"],
+        production_profile=True,
+        static_assets=_PRODUCTION_STATIC_ASSETS,
+    )
+    server = HTTPServer((config["host"], config["port"]), handler)
+    print("[companion-ui] Production profile", flush=True)
+    print(
+        f"[companion-ui] Listening:   http://{config['host']}:{config['port']}/",
+        flush=True,
+    )
+    print(f"[companion-ui] Runtime API: {config['api_base_url']}", flush=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        server.server_close()
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/companion-ui/docs/REAL_NOTE_WORKSPACE_DEV_PAGE.md
+++ b/companion-ui/docs/REAL_NOTE_WORKSPACE_DEV_PAGE.md
@@ -138,7 +138,37 @@ http://<host-lan-or-tailnet-ip>:8111/?note_path=<valid-dev-note-path>
 
 ---
 
-## 4. Environment-Bound Vault Access Model
+## 4. Production Launch Profile
+
+The production launch profile is separate from the dev/staging server. It keeps
+the same runtime-mediated workspace boundary, defaults to the production runtime
+API port, links production-profile static assets under `/static/`, and omits
+dev/staging markers from rendered output. It does not add auth, TLS, reverse
+proxying, public internet exposure, or direct vault access.
+
+```bash
+cd companion-ui/companion-app
+COMPANION_API_BASE_URL=http://127.0.0.1:18000 HOST=127.0.0.1 PORT=8113 \
+  python -m companion_ui.workspace.serve_production_page
+```
+
+Then open:
+
+```
+http://127.0.0.1:8113/?note_path=<valid-prod-note-path>
+```
+
+Production profile defaults:
+
+| Variable | Default | Purpose |
+|---|---:|---|
+| `COMPANION_API_BASE_URL` | `http://127.0.0.1:18000` | Production runtime API target |
+| `HOST` | `127.0.0.1` | Localhost-first bind address |
+| `PORT` | `8113` | Companion UI production profile port |
+
+---
+
+## 5. Environment-Bound Vault Access Model
 
 > The Companion UI dev page reads from whichever vault is bound to the
 > configured runtime API. It does not know or choose the vault directly.
@@ -159,7 +189,7 @@ targets. The runtime owns environment and vault binding.
 
 ---
 
-## 5. Manual UAT Against Environment-Bound Vaults
+## 6. Manual UAT Against Environment-Bound Vaults
 
 ### Verification steps
 
@@ -221,7 +251,7 @@ targets. The runtime owns environment and vault binding.
 
 ---
 
-## 6. Local Network / Tailscale Access
+## 7. Local Network / Tailscale Access
 
 ### Home network (LAN) access
 
@@ -271,7 +301,7 @@ targets. The runtime owns environment and vault binding.
 
 ---
 
-## 7. Safety Rules
+## 8. Safety Rules
 
 The following safety rules apply unconditionally to the dev/staging page:
 

--- a/tests/companion_ui/test_production_launch_profile.py
+++ b/tests/companion_ui/test_production_launch_profile.py
@@ -1,0 +1,35 @@
+"""Tests for Companion UI production launch profile (#1144)."""
+
+from __future__ import annotations
+
+
+def test_production_port(monkeypatch) -> None:
+    monkeypatch.delenv("PORT", raising=False)
+    from companion_ui.workspace.serve_production_page import load_config
+
+    assert load_config()["port"] == 8113
+
+
+def test_no_dev_marker_in_production() -> None:
+    from companion_ui.workspace.serve_production_page import render_production_index_html
+
+    html = render_production_index_html(api_base_url="http://127.0.0.1:18000")
+
+    assert "DEV / not production" not in html
+    assert "dev/staging" not in html.lower()
+    assert "not production" not in html.lower()
+
+
+def test_runtime_target_configurable(monkeypatch) -> None:
+    monkeypatch.setenv("COMPANION_API_BASE_URL", "http://127.0.0.1:18042")
+    from companion_ui.workspace.serve_production_page import load_config
+
+    assert load_config()["api_base_url"] == "http://127.0.0.1:18042"
+
+
+def test_production_output_links_static_asset() -> None:
+    from companion_ui.workspace.serve_production_page import render_production_index_html
+
+    html = render_production_index_html(api_base_url="http://127.0.0.1:18000")
+
+    assert 'href="/static/companion-workspace.css"' in html


### PR DESCRIPTION
Fixes #1144

## Summary
- add a separate `companion_ui.workspace.serve_production_page` launch profile with production defaults: UI port 8113 and runtime API `http://127.0.0.1:18000`
- keep dev server behavior unchanged while allowing production rendering to omit dev/staging markers
- add production-profile static asset serving and document the production launch command

## Dispatcher
- Dispatcher unavailable: `python3 -m app.dispatcher status --json` failed during app import with `ModuleNotFoundError: No module named 'yaml'`; used GitHub-label claim via `scripts/issue_pickup_claim.sh --issue 1144` and manually set Project status to In Progress.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_production_launch_profile.py` - 4 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_real_note_workspace_dev_server.py` - 42 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_production_launch_profile.py tests/companion_ui/test_real_note_workspace_dev_server.py` - 46 passed
- `/tmp/agentic-pkm-checks-1123/bin/ruff check app tests` - passed
- `python3 scripts/docs_guard.py` - Docs guard: OK
- `git diff --check` - passed
