### PR TITLE
feat(companion-ui): apply body suggestions via Canvas edits

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -116,6 +116,7 @@ class DevPageState:
     suggestion_dom_alias: str = "idle"
     suggestion_allowed_transitions: list[str] | None = None
     suggestion_composer_enabled: bool = True
+    suggestion_apply_transition_path: list[str] | None = None
     suggestion_cards: list[dict[str, Any]] | None = None
     suggested_insertions: list[dict[str, Any]] | None = None
     guard_writeguard_status: str = "ok"
@@ -328,6 +329,75 @@ class RealNoteWorkspaceDevPage:
         self._trusted_hash_refresh_notes.add(note_path)
         return self.load(NoteLoadIntent(note_path=note_path))
 
+    def apply_body_suggestion(
+        self,
+        *,
+        suggestion_id: str,
+        session_id: str,
+        note_path: str,
+    ) -> DevPageState:
+        """Apply a staged body suggestion through the Canvas edit API."""
+        if self.state.shell is None:
+            self.state.error = "No workspace note is loaded"
+            self.state.is_loaded = False
+            return self.state
+        if self.state.suggestion_state != "staged_body":
+            self.state.error = "Body suggestion apply requires staged_body state"
+            self.state.is_loaded = False
+            return self.state
+
+        insertion = next(
+            (
+                item
+                for item in (self.state.suggested_insertions or [])
+                if item.get("data_suggestion_id") == suggestion_id
+            ),
+            None,
+        )
+        if insertion is None:
+            self.state.error = f"Unknown body suggestion: {suggestion_id}"
+            self.state.is_loaded = False
+            return self.state
+
+        machine = CanvasRailStateMachine(self.state.suggestion_state)
+        transition_path = [machine.state]
+        machine.transition("apply_pending")
+        transition_path.append(machine.state)
+
+        try:
+            self._http.post(
+                f"/api/canvas/sessions/{session_id}/edits",
+                json={
+                    "new_body": str(insertion.get("proposed_text") or ""),
+                    "change_summary": f"Applied body suggestion {suggestion_id}",
+                    "content_hash": self.state.shell.content_hash,
+                },
+            )
+        except WorkspaceClientError as exc:
+            machine.transition("staged_body", error=str(exc))
+            self.state.suggestion_state = machine.state
+            self.state.suggestion_dom_alias = machine.dom_alias
+            self.state.suggestion_allowed_transitions = sorted(machine.allowed_transitions())
+            self.state.suggestion_composer_enabled = machine.composer_enabled
+            self.state.suggestion_apply_transition_path = transition_path + [machine.state]
+            self.state.error = str(exc)
+            self.state.is_loaded = False
+            return self.state
+
+        machine.transition("applied")
+        transition_path.append(machine.state)
+        machine.transition("idle")
+        transition_path.append(machine.state)
+
+        self._trusted_hash_refresh_notes.add(note_path)
+        refreshed = self.load(NoteLoadIntent(note_path=note_path))
+        refreshed.suggestion_state = machine.state
+        refreshed.suggestion_dom_alias = machine.dom_alias
+        refreshed.suggestion_allowed_transitions = sorted(machine.allowed_transitions())
+        refreshed.suggestion_composer_enabled = machine.composer_enabled
+        refreshed.suggestion_apply_transition_path = transition_path
+        return refreshed
+
     def acknowledge_canvas_recovery(self, *, note_path: str) -> DevPageState:
         """Acknowledge recovery/conflict state before body edits resume."""
         if self.state.shell is not None and self.state.shell.note_path == note_path:
@@ -486,6 +556,8 @@ class RealNoteWorkspaceDevPage:
             "suggestion_dom_alias": self.state.suggestion_dom_alias,
             "suggestion_allowed_transitions": self.state.suggestion_allowed_transitions or [],
             "suggestion_composer_enabled": self.state.suggestion_composer_enabled,
+            "suggestion_apply_transition_path": self.state.suggestion_apply_transition_path
+            or [],
             "suggestion_cards": self.state.suggestion_cards or [],
             "suggested_insertions": self.state.suggested_insertions or [],
             "guard_writeguard_status": self.state.guard_writeguard_status,

--- a/tests/companion_ui/test_suggestion_apply_browser.py
+++ b/tests/companion_ui/test_suggestion_apply_browser.py
@@ -1,0 +1,155 @@
+"""Tests for body suggestion apply wiring in the workspace shell (#1134)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from companion_ui.workspace.real_note_workspace_dev_page import (
+    NoteLoadIntent,
+    RealNoteWorkspaceDevPage,
+)
+
+
+class _FakeClient:
+    def __init__(self, payloads: list[dict[str, Any]]) -> None:
+        self.payloads = payloads
+        self.get_calls: list[tuple[str, dict[str, Any]]] = []
+        self.post_calls: list[tuple[str, dict[str, Any]]] = []
+
+    def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        self.get_calls.append((url, params))
+        return self.payloads.pop(0)
+
+    def post(self, url: str, *, json: dict[str, Any]) -> dict[str, Any]:
+        self.post_calls.append((url, json))
+        return {"session_id": "session-1", "ok": True}
+
+
+def _workspace_payload(
+    *,
+    body: str = "# Canvas Note\n\nBody.",
+    content_hash: str = "hash-1",
+    suggestion_state: str = "staged_body",
+) -> dict[str, Any]:
+    return {
+        "artifact": {
+            "artifact_id": "art-1134",
+            "note_path": "Notes/canvas.md",
+            "title": "Canvas Note",
+            "body": body,
+            "content_hash": content_hash,
+        },
+        "canvas": {
+            "session_id": "session-1",
+            "session_state": "active",
+            "user_present": True,
+            "can_edit_body": True,
+            "recovery_needed": False,
+            "session_log_path": ".chats/canvas/session.md",
+            "undo_available": False,
+            "applied_edit_count": 1 if content_hash == "hash-2" else 0,
+            "undone_edit_count": 0,
+            "session_persistence": "in_memory",
+        },
+        "panel": {"state": "idle", "proposal_count": 0},
+        "guards": {"canvas_enabled": True, "writeguard_status": "ok"},
+        "runtime": {},
+        "suggestions": {
+            "current_suggestion_state": suggestion_state,
+            "proposals": [
+                {
+                    "suggestion_id": "s-body",
+                    "server_declared_classification": "body",
+                    "title": "Add bridge paragraph",
+                    "preview_text": "Bridge preview",
+                    "anchor_description": "after intro",
+                    "proposed_text": "# Canvas Note\n\nBody.\n\nBridge text.",
+                }
+            ],
+        },
+    }
+
+
+def _loaded_page(client: _FakeClient) -> RealNoteWorkspaceDevPage:
+    page = RealNoteWorkspaceDevPage(client)  # type: ignore[arg-type]
+    page.load(NoteLoadIntent(note_path="Notes/canvas.md"))
+    return page
+
+
+def test_body_apply_calls_canvas_api() -> None:
+    client = _FakeClient([
+        _workspace_payload(content_hash="hash-1"),
+        _workspace_payload(
+            body="# Canvas Note\n\nBody.\n\nBridge text.",
+            content_hash="hash-2",
+            suggestion_state="idle",
+        ),
+    ])
+    page = _loaded_page(client)
+
+    state = page.apply_body_suggestion(
+        suggestion_id="s-body",
+        session_id="session-1",
+        note_path="Notes/canvas.md",
+    )
+
+    assert state.is_loaded is True
+    assert client.post_calls == [
+        (
+            "/api/canvas/sessions/session-1/edits",
+            {
+                "new_body": "# Canvas Note\n\nBody.\n\nBridge text.",
+                "change_summary": "Applied body suggestion s-body",
+                "content_hash": "hash-1",
+            },
+        ),
+    ]
+    assert client.get_calls == [
+        ("/api/companion/workspace", {"note_path": "Notes/canvas.md"}),
+        ("/api/companion/workspace", {"note_path": "Notes/canvas.md"}),
+    ]
+
+
+def test_body_apply_state_transition() -> None:
+    client = _FakeClient([
+        _workspace_payload(content_hash="hash-1"),
+        _workspace_payload(content_hash="hash-2", suggestion_state="idle"),
+    ])
+    page = _loaded_page(client)
+
+    state = page.apply_body_suggestion(
+        suggestion_id="s-body",
+        session_id="session-1",
+        note_path="Notes/canvas.md",
+    )
+
+    fields = page.render_fields()
+    assert state.suggestion_state == "idle"
+    assert fields is not None
+    assert fields["suggestion_apply_transition_path"] == [
+        "staged_body",
+        "apply_pending",
+        "applied",
+        "idle",
+    ]
+    assert fields["suggestion_composer_enabled"] is True
+
+
+def test_no_panel_receipt_for_body_edit() -> None:
+    client = _FakeClient([
+        _workspace_payload(content_hash="hash-1"),
+        _workspace_payload(content_hash="hash-2", suggestion_state="idle"),
+    ])
+    page = _loaded_page(client)
+
+    state = page.apply_body_suggestion(
+        suggestion_id="s-body",
+        session_id="session-1",
+        note_path="Notes/canvas.md",
+    )
+
+    fields = page.render_fields()
+    assert state.panel_last_response is None
+    assert fields is not None
+    assert fields["panel_last_response"] == {}
+    assert all(url != "/api/panel/confirm" for url, _payload in client.post_calls)


### PR DESCRIPTION
## Summary
- Wire staged body suggestions to POST /api/canvas/sessions/{id}/edits from the Companion workspace page model.
- Drive and expose the staged_body -> apply_pending -> applied -> idle transition path after successful apply.
- Preserve the no-Panel-receipt body edit lane and refresh the workspace aggregate after apply.

## Issues included
- Closes #1134

## Claim workflow
- Claimed #1134 with scripts/issue_pickup_claim.sh and set Project status to In Progress.
- Dispatcher status fallback used because python3 -m app.dispatcher status --json is missing the yaml dependency in this environment.

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_suggestion_apply_browser.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_canvas_edit_browser.py tests/companion_ui/test_suggestion_card_browser.py tests/companion_ui/test_suggestion_flow_browser.py tests/companion_ui/test_canvas_rail_state_machine.py
- /tmp/agentic-pkm-checks-1123/bin/ruff check app tests
- git diff --check