### PR TITLE
feat(companion-ui): queue governance suggestions through Panel

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -36,6 +36,7 @@ from dataclasses import dataclass
 from typing import Any, Optional
 from uuid import uuid4
 
+from companion_ui.canvas_suggestion_flow.receipt_strip import ReceiptPill, ReceiptsStrip
 from companion_ui.canvas_suggestion_flow.suggested_insertion import (
     SuggestedInsertion,
 )
@@ -117,6 +118,9 @@ class DevPageState:
     suggestion_allowed_transitions: list[str] | None = None
     suggestion_composer_enabled: bool = True
     suggestion_apply_transition_path: list[str] | None = None
+    governance_pending_transition_path: list[str] | None = None
+    governance_actions: list[dict[str, Any]] | None = None
+    governance_receipts: list[dict[str, Any]] | None = None
     suggestion_cards: list[dict[str, Any]] | None = None
     suggested_insertions: list[dict[str, Any]] | None = None
     guard_writeguard_status: str = "ok"
@@ -264,6 +268,7 @@ class RealNoteWorkspaceDevPage:
             suggestion_allowed_transitions=sorted(suggestion_machine.allowed_transitions()),
             suggestion_composer_enabled=suggestion_machine.composer_enabled,
             suggestion_cards=_suggestion_cards_from_payload(suggestions),
+            governance_actions=_governance_actions_from_payload(suggestions),
             suggested_insertions=_suggested_insertions_from_payload(suggestions),
             guard_writeguard_status=guards.get("writeguard_status") or "ok",
             guard_canvas_enabled=bool(guards.get("canvas_enabled", True)),
@@ -396,6 +401,91 @@ class RealNoteWorkspaceDevPage:
         refreshed.suggestion_allowed_transitions = sorted(machine.allowed_transitions())
         refreshed.suggestion_composer_enabled = machine.composer_enabled
         refreshed.suggestion_apply_transition_path = transition_path
+        return refreshed
+
+    def queue_governance_suggestion(
+        self,
+        *,
+        suggestion_id: str,
+        session_id: str,
+        note_path: str,
+    ) -> DevPageState:
+        """Queue a staged governance suggestion through the Canvas Panel pipeline."""
+        if self.state.shell is None:
+            self.state.error = "No workspace note is loaded"
+            self.state.is_loaded = False
+            return self.state
+        if self.state.suggestion_state != "staged_governance":
+            self.state.error = "Governance queue requires staged_governance state"
+            self.state.is_loaded = False
+            return self.state
+
+        action = next(
+            (
+                item
+                for item in (self.state.governance_actions or [])
+                if item.get("suggestion_id") == suggestion_id
+            ),
+            None,
+        )
+        if action is None:
+            self.state.error = f"Unknown governance suggestion: {suggestion_id}"
+            self.state.is_loaded = False
+            return self.state
+
+        machine = CanvasRailStateMachine(self.state.suggestion_state)
+        transition_path = [machine.state]
+        machine.transition("governance_pending")
+        transition_path.append(machine.state)
+
+        try:
+            response = self._http.post(
+                f"/api/canvas/sessions/{session_id}/governance",
+                json={
+                    "action_type": action["action_type"],
+                    "payload": action["payload"],
+                },
+            )
+        except WorkspaceClientError as exc:
+            machine.transition("staged_governance", error=str(exc))
+            self.state.suggestion_state = machine.state
+            self.state.suggestion_dom_alias = machine.dom_alias
+            self.state.suggestion_allowed_transitions = sorted(machine.allowed_transitions())
+            self.state.suggestion_composer_enabled = machine.composer_enabled
+            self.state.governance_pending_transition_path = transition_path + [machine.state]
+            self.state.error = str(exc)
+            self.state.is_loaded = False
+            return self.state
+
+        receipt = ReceiptPill(
+            receipt_id=str(response.get("intent_id") or ""),
+            suggestion_id=suggestion_id,
+            artifact_id=str(response.get("artifact_id") or self.state.shell.artifact_id),
+            outcome="queued",
+            label=f"queued · {response.get('intent_id')} · {action['action_type']}",
+            display_timestamp="queued",
+            message=action.get("summary"),
+        ).to_render_dict()
+
+        refreshed = self.load(NoteLoadIntent(note_path=note_path))
+        refreshed.suggestion_state = machine.state
+        refreshed.suggestion_dom_alias = machine.dom_alias
+        refreshed.suggestion_allowed_transitions = sorted(machine.allowed_transitions())
+        refreshed.suggestion_composer_enabled = machine.composer_enabled
+        refreshed.governance_pending_transition_path = transition_path
+        refreshed.governance_receipts = ReceiptsStrip(
+            pills=[
+                ReceiptPill(
+                    receipt_id=receipt["data_receipt_id"],
+                    suggestion_id=receipt["data_suggestion_id"],
+                    artifact_id=receipt["data_artifact_id"],
+                    outcome=receipt["data_status"],
+                    label=receipt["label"],
+                    display_timestamp=receipt["display_timestamp"],
+                    message=receipt.get("message"),
+                )
+            ]
+        ).to_render_dict()["non_terminal_pills"]
         return refreshed
 
     def acknowledge_canvas_recovery(self, *, note_path: str) -> DevPageState:
@@ -558,6 +648,9 @@ class RealNoteWorkspaceDevPage:
             "suggestion_composer_enabled": self.state.suggestion_composer_enabled,
             "suggestion_apply_transition_path": self.state.suggestion_apply_transition_path
             or [],
+            "governance_pending_transition_path": self.state.governance_pending_transition_path
+            or [],
+            "governance_receipts": self.state.governance_receipts or [],
             "suggestion_cards": self.state.suggestion_cards or [],
             "suggested_insertions": self.state.suggested_insertions or [],
             "guard_writeguard_status": self.state.guard_writeguard_status,
@@ -652,6 +745,32 @@ def _suggestion_cards_from_payload(suggestions: dict[str, Any]) -> list[dict[str
         )
         cards.append(card.as_render_dict())
     return cards
+
+
+def _governance_actions_from_payload(suggestions: dict[str, Any]) -> list[dict[str, Any]]:
+    actions: list[dict[str, Any]] = []
+    fallback_classification = suggestions.get("server_declared_classification")
+    for index, raw in enumerate(_suggestion_payloads(suggestions), start=1):
+        variant = raw.get("server_declared_classification") or fallback_classification
+        if variant != "governance":
+            continue
+        suggestion_id = str(raw.get("suggestion_id") or f"suggestion-{index}")
+        payload = raw.get("payload")
+        if not isinstance(payload, dict):
+            payload = {
+                "suggestion_id": suggestion_id,
+                "title": raw.get("title"),
+                "summary": raw.get("summary") or raw.get("preview_text"),
+            }
+        actions.append(
+            {
+                "suggestion_id": suggestion_id,
+                "action_type": str(raw.get("action_type") or "frontmatter_update"),
+                "payload": payload,
+                "summary": raw.get("summary") or raw.get("preview_text"),
+            }
+        )
+    return actions
 
 
 def _suggested_insertions_from_payload(suggestions: dict[str, Any]) -> list[dict[str, Any]]:

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -138,6 +138,9 @@ def _render_note_section(fields: dict) -> str:
     )
     suggestion_flow_html = _render_suggestion_flow_region(fields)
     suggestion_cards_html = _render_suggestion_cards(fields.get("suggestion_cards") or [])
+    governance_receipts_html = _render_governance_receipts(
+        fields.get("governance_receipts") or []
+    )
     suggested_insertions_html = _render_suggested_insertions(
         fields.get("suggested_insertions") or []
     )
@@ -196,6 +199,7 @@ def _render_note_section(fields: dict) -> str:
         {panel_response_html}
         {suggestion_flow_html}
         {suggestion_cards_html}
+        {governance_receipts_html}
         {guard_html}
         {persistence_html}
         {panel_rail}
@@ -275,6 +279,33 @@ def _render_suggestion_cards(cards: list[dict]) -> str:
         </div>"""
         )
     return "\n".join(rows)
+
+
+def _render_governance_receipts(receipts: list[dict]) -> str:
+    rows: list[str] = []
+    for receipt in receipts:
+        rows.append(
+            f"""
+        <button
+          type="button"
+          class="receipt-pill"
+          data-testid="{_e(receipt.get("data_testid", "receipt-pill"))}"
+          data-receipt-id="{_e(receipt.get("data_receipt_id", ""))}"
+          data-suggestion-id="{_e(receipt.get("data_suggestion_id", ""))}"
+          data-artifact-id="{_e(receipt.get("data_artifact_id", ""))}"
+          data-status="{_e(receipt.get("data_status", ""))}"
+          data-intent="{_e(receipt.get("data_intent", "governance.openReceipt"))}"
+          aria-label="{_e(receipt.get("aria_label", ""))}">
+          <span class="receipt-pill-label">{_e(receipt.get("label", ""))}</span>
+          <span class="receipt-pill-time">{_e(receipt.get("display_timestamp", ""))}</span>
+        </button>"""
+        )
+    if not rows:
+        return ""
+    return f"""
+        <div class="receipts-strip" data-testid="receipts-strip" aria-live="polite">
+          {"".join(rows)}
+        </div>"""
 
 
 def _suggestion_action_label(intent: str) -> str:

--- a/tests/companion_ui/test_governance_queue_browser.py
+++ b/tests/companion_ui/test_governance_queue_browser.py
@@ -1,0 +1,151 @@
+"""Tests for governance suggestion queue wiring in the workspace shell (#1135)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from companion_ui.workspace.real_note_workspace_dev_page import (
+    NoteLoadIntent,
+    RealNoteWorkspaceDevPage,
+)
+from companion_ui.workspace.serve_dev_page import render_index_html
+
+
+class _FakeClient:
+    def __init__(self, payloads: list[dict[str, Any]]) -> None:
+        self.payloads = payloads
+        self.get_calls: list[tuple[str, dict[str, Any]]] = []
+        self.post_calls: list[tuple[str, dict[str, Any]]] = []
+
+    def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        self.get_calls.append((url, params))
+        return self.payloads.pop(0)
+
+    def post(self, url: str, *, json: dict[str, Any]) -> dict[str, Any]:
+        self.post_calls.append((url, json))
+        return {
+            "intent_id": "intent-1135",
+            "session_id": "session-1",
+            "artifact_id": "Notes/canvas.md",
+        }
+
+
+def _workspace_payload(*, suggestion_state: str = "staged_governance") -> dict[str, Any]:
+    return {
+        "artifact": {
+            "artifact_id": "art-1135",
+            "note_path": "Notes/canvas.md",
+            "title": "Canvas Note",
+            "body": "# Canvas Note\n\nBody.",
+            "content_hash": "hash-1",
+        },
+        "canvas": {
+            "session_id": "session-1",
+            "session_state": "active",
+            "user_present": True,
+            "can_edit_body": True,
+            "recovery_needed": False,
+            "session_log_path": ".chats/canvas/session.md",
+            "undo_available": False,
+            "applied_edit_count": 0,
+            "undone_edit_count": 0,
+            "session_persistence": "in_memory",
+        },
+        "panel": {"state": "idle", "proposal_count": 0},
+        "guards": {"canvas_enabled": True, "writeguard_status": "ok"},
+        "runtime": {},
+        "suggestions": {
+            "current_suggestion_state": suggestion_state,
+            "proposals": [
+                {
+                    "suggestion_id": "s-gov",
+                    "server_declared_classification": "governance",
+                    "title": "Move note",
+                    "summary": "Queue lifecycle update",
+                    "preview_text": "lifecycle.move",
+                    "action_type": "note_lifecycle",
+                    "payload": {"target": "Projects/Active"},
+                }
+            ],
+        },
+    }
+
+
+def _loaded_page(client: _FakeClient) -> RealNoteWorkspaceDevPage:
+    page = RealNoteWorkspaceDevPage(client)  # type: ignore[arg-type]
+    page.load(NoteLoadIntent(note_path="Notes/canvas.md"))
+    return page
+
+
+def test_governance_queue_calls_api() -> None:
+    client = _FakeClient([
+        _workspace_payload(),
+        _workspace_payload(suggestion_state="governance_pending"),
+    ])
+    page = _loaded_page(client)
+
+    state = page.queue_governance_suggestion(
+        suggestion_id="s-gov",
+        session_id="session-1",
+        note_path="Notes/canvas.md",
+    )
+
+    assert state.is_loaded is True
+    assert client.post_calls == [
+        (
+            "/api/canvas/sessions/session-1/governance",
+            {
+                "action_type": "note_lifecycle",
+                "payload": {"target": "Projects/Active"},
+            },
+        ),
+    ]
+    assert all(url != "/api/canvas/sessions/session-1/edits" for url, _ in client.post_calls)
+
+
+def test_governance_pending_state_transition() -> None:
+    client = _FakeClient([
+        _workspace_payload(),
+        _workspace_payload(suggestion_state="governance_pending"),
+    ])
+    page = _loaded_page(client)
+
+    state = page.queue_governance_suggestion(
+        suggestion_id="s-gov",
+        session_id="session-1",
+        note_path="Notes/canvas.md",
+    )
+
+    fields = page.render_fields()
+    assert state.suggestion_state == "governance_pending"
+    assert fields is not None
+    assert fields["governance_pending_transition_path"] == [
+        "staged_governance",
+        "governance_pending",
+    ]
+
+
+def test_receipt_pill_rendered() -> None:
+    client = _FakeClient([
+        _workspace_payload(),
+        _workspace_payload(suggestion_state="governance_pending"),
+    ])
+    page = _loaded_page(client)
+
+    state = page.queue_governance_suggestion(
+        suggestion_id="s-gov",
+        session_id="session-1",
+        note_path="Notes/canvas.md",
+    )
+
+    fields = page.render_fields()
+    assert state.governance_receipts is not None
+    assert fields is not None
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="Notes/canvas.md",
+        fields=fields,
+    )
+    assert 'data-testid="receipt-pill"' in html
+    assert 'data-receipt-id="intent-1135"' in html
+    assert 'data-intent="governance.openReceipt"' in html


### PR DESCRIPTION
## Summary
- Wire staged governance suggestions to POST /api/canvas/sessions/{id}/governance from the Companion workspace page model.
- Drive and expose the staged_governance -> governance_pending transition path.
- Render the returned intent_id as a ReceiptPill/receipts strip entry with governance.openReceipt intent.

## Issues included
- Closes #1135

## Claim workflow
- Claimed #1135 with scripts/issue_pickup_claim.sh and set Project status to In Progress.
- Dispatcher status fallback used because python3 -m app.dispatcher status --json is missing the yaml dependency in this environment.

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_governance_queue_browser.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_suggestion_card_browser.py tests/companion_ui/test_suggestion_flow_browser.py tests/companion_ui/test_canvas_rail_state_machine.py tests/companion_ui/test_receipt_strip.py
- /tmp/agentic-pkm-checks-1123/bin/ruff check app tests
- git diff --check