### PR TITLE
feat(companion-ui): integrate suggestion layout and shortcuts

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -36,6 +36,8 @@ from dataclasses import dataclass
 from typing import Any, Optional
 from uuid import uuid4
 
+from companion_ui.canvas_suggestion_flow.keyboard_shortcuts import SuggestionShortcutMap
+from companion_ui.canvas_suggestion_flow.portrait_sheet import PortraitSheet, SheetSnap
 from companion_ui.canvas_suggestion_flow.receipt_strip import ReceiptPill, ReceiptsStrip
 from companion_ui.canvas_suggestion_flow.suggested_insertion import (
     SuggestedInsertion,
@@ -121,6 +123,8 @@ class DevPageState:
     governance_pending_transition_path: list[str] | None = None
     governance_actions: list[dict[str, Any]] | None = None
     governance_receipts: list[dict[str, Any]] | None = None
+    portrait_sheet: dict[str, Any] | None = None
+    keyboard_shortcuts: dict[str, Any] | None = None
     suggestion_cards: list[dict[str, Any]] | None = None
     suggested_insertions: list[dict[str, Any]] | None = None
     guard_writeguard_status: str = "ok"
@@ -242,6 +246,7 @@ class RealNoteWorkspaceDevPage:
         panel_last_response = self.state.panel_last_response
         if panel_last_response and panel_last_response.get("artifact_id") != resolved_artifact_id:
             panel_last_response = None
+        suggestion_cards = _suggestion_cards_from_payload(suggestions)
         self.state = DevPageState(
             shell=shell,
             panel_rail_placeholder=panel_render.get("label", "Panel ready"),
@@ -267,8 +272,16 @@ class RealNoteWorkspaceDevPage:
             suggestion_dom_alias=suggestion_machine.dom_alias,
             suggestion_allowed_transitions=sorted(suggestion_machine.allowed_transitions()),
             suggestion_composer_enabled=suggestion_machine.composer_enabled,
-            suggestion_cards=_suggestion_cards_from_payload(suggestions),
+            suggestion_cards=suggestion_cards,
             governance_actions=_governance_actions_from_payload(suggestions),
+            portrait_sheet=_portrait_sheet_from_cards(
+                suggestion_cards,
+                rail_state=suggestion_machine.state,
+            ),
+            keyboard_shortcuts=_shortcut_map_from_cards(
+                suggestion_cards,
+                rail_state=suggestion_machine.state,
+            ),
             suggested_insertions=_suggested_insertions_from_payload(suggestions),
             guard_writeguard_status=guards.get("writeguard_status") or "ok",
             guard_canvas_enabled=bool(guards.get("canvas_enabled", True)),
@@ -651,6 +664,8 @@ class RealNoteWorkspaceDevPage:
             "governance_pending_transition_path": self.state.governance_pending_transition_path
             or [],
             "governance_receipts": self.state.governance_receipts or [],
+            "portrait_sheet": self.state.portrait_sheet or {},
+            "keyboard_shortcuts": self.state.keyboard_shortcuts or {},
             "suggestion_cards": self.state.suggestion_cards or [],
             "suggested_insertions": self.state.suggested_insertions or [],
             "guard_writeguard_status": self.state.guard_writeguard_status,
@@ -771,6 +786,37 @@ def _governance_actions_from_payload(suggestions: dict[str, Any]) -> list[dict[s
             }
         )
     return actions
+
+
+def _portrait_sheet_from_cards(
+    cards: list[dict[str, Any]],
+    *,
+    rail_state: str,
+) -> dict[str, Any]:
+    suggestion_id = str(cards[0].get("data_suggestion_id") or "suggestion") if cards else "none"
+    sheet = PortraitSheet(
+        suggestion_id=suggestion_id,
+        current_snap=SheetSnap.PEEK if cards else SheetSnap.CLOSED,
+        rail_state=rail_state,
+    )
+    if rail_state in {"staged_body", "staged_governance"}:
+        sheet = sheet.auto_snap_on_proposal()
+    return sheet.to_render_dict()
+
+
+def _shortcut_map_from_cards(
+    cards: list[dict[str, Any]],
+    *,
+    rail_state: str,
+) -> dict[str, Any]:
+    variant = str(cards[0].get("data_variant") or "terminal") if cards else "terminal"
+    if rail_state in {"applied", "discarded"}:
+        variant = "terminal"
+    return SuggestionShortcutMap(
+        variant=variant,
+        rail_state=rail_state,
+        terminal_state=rail_state in {"applied", "discarded", "blocked"},
+    ).to_render_dict()
 
 
 def _suggested_insertions_from_payload(suggestions: dict[str, Any]) -> list[dict[str, Any]]:

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -138,6 +138,8 @@ def _render_note_section(fields: dict) -> str:
     )
     suggestion_flow_html = _render_suggestion_flow_region(fields)
     suggestion_cards_html = _render_suggestion_cards(fields.get("suggestion_cards") or [])
+    portrait_sheet_html = _render_portrait_sheet(fields.get("portrait_sheet") or {})
+    shortcut_html = _render_keyboard_shortcuts(fields.get("keyboard_shortcuts") or {})
     governance_receipts_html = _render_governance_receipts(
         fields.get("governance_receipts") or []
     )
@@ -178,7 +180,11 @@ def _render_note_section(fields: dict) -> str:
         {suggested_insertions_html}
       </div>
     </div>
-    <aside class="agent-rail" data-testid="workspace-agent-rail" data-region="agent-rail">
+    <aside
+      class="agent-rail"
+      data-testid="workspace-agent-rail"
+      data-region="agent-rail"
+      data-layout-desktop="side-rail">
       <div class="rail-header">
         <span class="rail-label">Companion&nbsp;/ Panel</span>
         <span class="rail-badge" data-testid="workspace-panel-state">{panel_state}</span>
@@ -199,12 +205,14 @@ def _render_note_section(fields: dict) -> str:
         {panel_response_html}
         {suggestion_flow_html}
         {suggestion_cards_html}
+        {shortcut_html}
         {governance_receipts_html}
         {guard_html}
         {persistence_html}
         {panel_rail}
       </div>
     </aside>
+    {portrait_sheet_html}
   </div>"""
 
 
@@ -234,6 +242,49 @@ def _render_suggestion_flow_region(fields: dict) -> str:
           </div>
           <div class="suggestion-composer-state">{composer_text}</div>
           <div class="suggestion-transitions">{transition_html}</div>
+        </div>"""
+
+
+def _render_portrait_sheet(sheet: dict) -> str:
+    if not sheet:
+        return ""
+    visible = "true" if sheet.get("is_visible") else "false"
+    return f"""
+    <aside
+      class="portrait-sheet"
+      data-testid="{_e(sheet.get("data_testid", "portrait-sheet"))}"
+      data-layout-portrait="bottom-sheet"
+      data-suggestion-id="{_e(sheet.get("suggestion_id", ""))}"
+      data-rail-state="{_e(sheet.get("rail_state", ""))}"
+      data-current-snap="{_e(sheet.get("current_snap", ""))}"
+      data-height-hint="{_e(sheet.get("height_hint", ""))}"
+      data-auto-snap-target="{_e(sheet.get("auto_snap_target", ""))}"
+      data-forbidden-auto-snap="{_e(sheet.get("forbidden_auto_snap", ""))}"
+      data-touch-target-min-height="{_e(sheet.get("touch_target_min_height", ""))}"
+      data-receipts-strip-position="{_e(sheet.get("receipts_strip_position", ""))}"
+      aria-hidden="{visible == "false"}">
+    </aside>"""
+
+
+def _render_keyboard_shortcuts(shortcuts: dict) -> str:
+    bindings = shortcuts.get("key_bindings") or {}
+    if not bindings:
+        return ""
+    rows = "".join(
+        (
+            '<span class="shortcut-hint" data-testid="workspace-shortcut" '
+            f'data-intent="{_e(intent)}" data-key="{_e(key)}">{_e(key)}</span>'
+        )
+        for intent, key in bindings.items()
+    )
+    return f"""
+        <div
+          class="shortcut-map"
+          data-testid="workspace-shortcut-map"
+          data-variant="{_e(shortcuts.get("variant", ""))}"
+          data-rail-state="{_e(shortcuts.get("rail_state", ""))}"
+          data-ignore-input-focus="true">
+          {rows}
         </div>"""
 
 
@@ -1005,6 +1056,60 @@ def render_index_html(
       font-size: var(--text-xs);
       padding: 4px 7px;
       text-transform: uppercase;
+    }}
+    .shortcut-map {{
+      background: var(--bg-raised);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      padding: 8px 10px;
+    }}
+    .shortcut-hint {{
+      color: var(--fg-2);
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      min-height: 20px;
+    }}
+    .portrait-sheet {{
+      display: none;
+    }}
+    @media (max-width: 899px) {{
+      .workspace-shell {{
+        padding-bottom: 60px;
+      }}
+      .agent-rail {{
+        display: none;
+      }}
+      .portrait-sheet {{
+        background: var(--bg-surface);
+        border-top: 1px solid var(--border);
+        bottom: 0;
+        display: block;
+        left: 0;
+        min-height: 44px;
+        position: fixed;
+        right: 0;
+        z-index: 20;
+      }}
+      .portrait-sheet[data-current-snap="peek"] {{
+        height: 60px;
+      }}
+      .portrait-sheet[data-current-snap="half"] {{
+        height: 50vh;
+      }}
+      .portrait-sheet[data-current-snap="full"] {{
+        height: calc(100vh - 64px);
+      }}
+      .portrait-sheet[data-current-snap="closed"] {{
+        display: none;
+      }}
+    }}
+    @media (min-width: 900px) {{
+      .agent-rail[data-layout-desktop="side-rail"] {{
+        display: flex;
+      }}
     }}
     .panel-proposal-row {{
       background: var(--bg-raised);

--- a/tests/companion_ui/test_suggestion_layout_browser.py
+++ b/tests/companion_ui/test_suggestion_layout_browser.py
@@ -1,0 +1,127 @@
+"""Tests for live workspace suggestion layout and shortcut integration (#1136)."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from companion_ui.workspace.real_note_workspace_dev_page import (
+    NoteLoadIntent,
+    RealNoteWorkspaceDevPage,
+)
+from companion_ui.workspace.serve_dev_page import render_index_html
+
+
+class _FakeClient:
+    def __init__(
+        self,
+        *,
+        suggestion_state: str,
+        variant: str = "body",
+    ) -> None:
+        self.suggestion_state = suggestion_state
+        self.variant = variant
+
+    def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        assert url == "/api/companion/workspace"
+        assert params == {"note_path": "Notes/canvas.md"}
+        return {
+            "artifact": {
+                "artifact_id": "art-1136",
+                "note_path": "Notes/canvas.md",
+                "title": "Canvas Note",
+                "body": "# Canvas Note\n\nBody.",
+                "content_hash": "hash-1",
+            },
+            "canvas": {
+                "session_id": "session-1",
+                "session_state": "active",
+                "user_present": True,
+                "can_edit_body": True,
+                "recovery_needed": False,
+                "session_log_path": ".chats/canvas/session.md",
+                "undo_available": False,
+                "applied_edit_count": 0,
+                "undone_edit_count": 0,
+                "session_persistence": "in_memory",
+            },
+            "panel": {"state": "idle", "proposal_count": 0},
+            "guards": {"canvas_enabled": True, "writeguard_status": "ok"},
+            "runtime": {},
+            "suggestions": {
+                "current_suggestion_state": self.suggestion_state,
+                "proposals": [
+                    {
+                        "suggestion_id": "s-layout",
+                        "server_declared_classification": self.variant,
+                        "title": "Suggestion",
+                        "preview_text": "Preview",
+                        "proposed_text": "# Canvas Note\n\nUpdated.",
+                    }
+                ],
+            },
+        }
+
+
+def _render_workspace(*, suggestion_state: str, variant: str = "body") -> str:
+    page = RealNoteWorkspaceDevPage(
+        _FakeClient(suggestion_state=suggestion_state, variant=variant)  # type: ignore[arg-type]
+    )
+    state = page.load(NoteLoadIntent(note_path="Notes/canvas.md"))
+    assert state.is_loaded is True
+    fields = page.render_fields()
+    assert fields is not None
+    return render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="Notes/canvas.md",
+        fields=fields,
+    )
+
+
+def test_desktop_side_rail() -> None:
+    html = _render_workspace(suggestion_state="staged_body")
+
+    assert 'data-testid="workspace-agent-rail"' in html
+    assert 'data-layout-desktop="side-rail"' in html
+    assert "@media (min-width: 900px)" in html
+
+
+def test_portrait_bottom_sheet() -> None:
+    html = _render_workspace(suggestion_state="staged_body")
+
+    assert 'data-testid="portrait-sheet"' in html
+    assert 'data-layout-portrait="bottom-sheet"' in html
+    assert "@media (max-width: 899px)" in html
+    assert 'data-touch-target-min-height="44px"' in html
+
+
+def test_proposal_arrival_snaps_half() -> None:
+    html = _render_workspace(suggestion_state="staged_governance", variant="governance")
+    sheet = re.search(r'<aside\s+class="portrait-sheet".*?</aside>', html, re.DOTALL)
+
+    assert sheet is not None
+    sheet_html = sheet.group(0)
+    assert 'data-current-snap="half"' in html
+    assert 'data-auto-snap-target="half"' in html
+    assert 'data-forbidden-auto-snap="full"' in html
+    assert 'data-current-snap="full"' not in sheet_html
+
+
+def test_keyboard_shortcuts_staged_only() -> None:
+    staged_body = _render_workspace(suggestion_state="staged_body", variant="body")
+    idle_body = _render_workspace(suggestion_state="idle", variant="body")
+    staged_governance = _render_workspace(
+        suggestion_state="staged_governance",
+        variant="governance",
+    )
+
+    assert 'data-testid="workspace-shortcut-map"' in staged_body
+    assert 'data-intent="suggestion.apply" data-key="A"' in staged_body
+    assert 'data-intent="governance.queue" data-key="Q"' not in staged_body
+    assert 'data-ignore-input-focus="true"' in staged_body
+
+    assert 'data-intent="governance.queue" data-key="Q"' in staged_governance
+    assert 'data-intent="suggestion.apply" data-key="A"' not in staged_governance
+
+    assert 'data-intent="suggestion.apply" data-key="A"' not in idle_body
+    assert 'data-intent="suggestion.discard" data-key="D"' not in idle_body


### PR DESCRIPTION
## Summary
- Expose live portrait sheet and keyboard shortcut render models from the Companion workspace page state.
- Render desktop side-rail and portrait bottom-sheet markers/CSS, including half auto-snap for staged proposals.
- Render staged-state shortcut hints for body and governance suggestions while suppressing mutating shortcuts outside staged states.

## Issues included
- Closes #1136

## Claim workflow
- Claimed #1136 with scripts/issue_pickup_claim.sh and set Project status to In Progress.
- Dispatcher status fallback used because python3 -m app.dispatcher status --json is missing the yaml dependency in this environment.

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_suggestion_layout_browser.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_canvas_portrait_sheet.py tests/companion_ui/test_canvas_suggestion_shortcuts.py tests/companion_ui/test_suggestion_flow_browser.py tests/companion_ui/test_suggestion_card_browser.py tests/companion_ui/test_real_note_workspace_dev_server.py
- /tmp/agentic-pkm-checks-1123/bin/ruff check app tests
- git diff --check