### PR TITLE
feat(companion-ui): render Find mode candidates

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -125,6 +125,7 @@ class DevPageState:
     governance_receipts: list[dict[str, Any]] | None = None
     portrait_sheet: dict[str, Any] | None = None
     keyboard_shortcuts: dict[str, Any] | None = None
+    find_candidates: list[dict[str, Any]] | None = None
     suggestion_cards: list[dict[str, Any]] | None = None
     suggested_insertions: list[dict[str, Any]] | None = None
     guard_writeguard_status: str = "ok"
@@ -184,6 +185,8 @@ class RealNoteWorkspaceDevPage:
         panel = raw.get("panel") or {}
         suggestions = raw.get("suggestions") or {}
         guards = raw.get("guards") or {}
+        runtime = raw.get("runtime") or {}
+        find_payload = raw.get("find") or runtime.get("find") or {}
 
         # The runtime echoes artifact_id only when supplied in the request.
         # Fall back to note_path so note-path-only loads don't fail the shell's
@@ -282,6 +285,7 @@ class RealNoteWorkspaceDevPage:
                 suggestion_cards,
                 rail_state=suggestion_machine.state,
             ),
+            find_candidates=_find_candidates_from_payload(find_payload),
             suggested_insertions=_suggested_insertions_from_payload(suggestions),
             guard_writeguard_status=guards.get("writeguard_status") or "ok",
             guard_canvas_enabled=bool(guards.get("canvas_enabled", True)),
@@ -666,6 +670,7 @@ class RealNoteWorkspaceDevPage:
             "governance_receipts": self.state.governance_receipts or [],
             "portrait_sheet": self.state.portrait_sheet or {},
             "keyboard_shortcuts": self.state.keyboard_shortcuts or {},
+            "find_candidates": self.state.find_candidates or [],
             "suggestion_cards": self.state.suggestion_cards or [],
             "suggested_insertions": self.state.suggested_insertions or [],
             "guard_writeguard_status": self.state.guard_writeguard_status,
@@ -817,6 +822,41 @@ def _shortcut_map_from_cards(
         rail_state=rail_state,
         terminal_state=rail_state in {"applied", "discarded", "blocked"},
     ).to_render_dict()
+
+
+def _find_candidates_from_payload(find_payload: dict[str, Any]) -> list[dict[str, Any]]:
+    raw_candidates = find_payload.get("candidates") or find_payload.get("hits") or []
+    if isinstance(raw_candidates, dict):
+        raw_candidates = [raw_candidates]
+    if not isinstance(raw_candidates, list):
+        return []
+
+    candidates: list[dict[str, Any]] = []
+    for index, raw in enumerate(raw_candidates, start=1):
+        if not isinstance(raw, dict):
+            continue
+        payload = raw.get("payload") if isinstance(raw.get("payload"), dict) else {}
+        citation = raw.get("citation") or raw.get("source_ref") or payload.get("source_ref")
+        scope = raw.get("scope") or payload.get("scope") or find_payload.get("scope")
+        why = (
+            raw.get("why")
+            or raw.get("why_this_source")
+            or raw.get("explanation")
+            or payload.get("why")
+            or "Matched the current Find query."
+        )
+        candidates.append(
+            {
+                "candidate_id": str(raw.get("candidate_id") or raw.get("id") or f"find-{index}"),
+                "title": str(raw.get("title") or raw.get("doc_id") or raw.get("object_id") or "Source"),
+                "snippet": str(raw.get("snippet") or raw.get("text") or ""),
+                "citation": str(citation or "uncited"),
+                "scope": str(scope or "workspace"),
+                "why": str(why),
+                "panel_handoff": bool(raw.get("panel_handoff", True)),
+            }
+        )
+    return candidates
 
 
 def _suggested_insertions_from_payload(suggestions: dict[str, Any]) -> list[dict[str, Any]]:

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -143,6 +143,7 @@ def _render_note_section(fields: dict) -> str:
     governance_receipts_html = _render_governance_receipts(
         fields.get("governance_receipts") or []
     )
+    find_mode_html = _render_find_mode(fields.get("find_candidates") or [])
     suggested_insertions_html = _render_suggested_insertions(
         fields.get("suggested_insertions") or []
     )
@@ -207,6 +208,7 @@ def _render_note_section(fields: dict) -> str:
         {suggestion_cards_html}
         {shortcut_html}
         {governance_receipts_html}
+        {find_mode_html}
         {guard_html}
         {persistence_html}
         {panel_rail}
@@ -286,6 +288,46 @@ def _render_keyboard_shortcuts(shortcuts: dict) -> str:
           data-ignore-input-focus="true">
           {rows}
         </div>"""
+
+
+def _render_find_mode(candidates: list[dict]) -> str:
+    if not candidates:
+        return ""
+    rows: list[str] = []
+    for candidate in candidates:
+        handoff = ""
+        if candidate.get("panel_handoff", True):
+            handoff = (
+                '<button type="button" class="find-panel-handoff" '
+                'data-testid="find-panel-handoff" data-intent="find.panelHandoff">'
+                "Panel</button>"
+            )
+        rows.append(
+            f"""
+        <article
+          class="find-candidate"
+          data-testid="find-candidate"
+          data-candidate-id="{_e(candidate.get("candidate_id", ""))}">
+          <div class="find-candidate-title">{_e(candidate.get("title", ""))}</div>
+          <div class="find-candidate-snippet">{_e(candidate.get("snippet", ""))}</div>
+          <div class="find-candidate-meta">
+            <span data-testid="find-candidate-citation">{_e(candidate.get("citation", ""))}</span>
+            <span data-testid="find-candidate-scope">{_e(candidate.get("scope", ""))}</span>
+          </div>
+          <div class="find-candidate-why" data-testid="find-candidate-why">
+            {_e(candidate.get("why", ""))}
+          </div>
+          {handoff}
+        </article>"""
+        )
+    return f"""
+        <section class="find-mode" data-testid="find-mode">
+          <div class="rail-state-row">
+            <span class="rail-state-label">Find</span>
+            <span class="rail-state-value">{len(candidates)} candidates</span>
+          </div>
+          {"".join(rows)}
+        </section>"""
 
 
 def _render_suggestion_cards(cards: list[dict]) -> str:
@@ -1074,6 +1116,39 @@ def render_index_html(
     }}
     .portrait-sheet {{
       display: none;
+    }}
+    .find-mode, .find-candidate {{
+      background: var(--bg-raised);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      color: var(--fg-2);
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      padding: 10px;
+    }}
+    .find-candidate-title {{
+      color: var(--fg-1);
+      font-size: var(--text-sm);
+    }}
+    .find-candidate-snippet, .find-candidate-why, .find-candidate-meta {{
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+    }}
+    .find-candidate-meta {{
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }}
+    .find-panel-handoff {{
+      align-self: flex-start;
+      background: var(--bg-surface);
+      border: 1px solid var(--border-strong);
+      border-radius: var(--radius-md);
+      color: var(--fg-1);
+      font-size: var(--text-xs);
+      padding: 4px 7px;
+      text-transform: uppercase;
     }}
     @media (max-width: 899px) {{
       .workspace-shell {{

--- a/tests/companion_ui/test_find_mode_browser.py
+++ b/tests/companion_ui/test_find_mode_browser.py
@@ -1,0 +1,85 @@
+"""Tests for Find mode rendering in the Companion workspace shell (#1140)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from companion_ui.workspace.real_note_workspace_dev_page import (
+    NoteLoadIntent,
+    RealNoteWorkspaceDevPage,
+)
+from companion_ui.workspace.serve_dev_page import render_index_html
+
+
+class _FakeClient:
+    def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        assert url == "/api/companion/workspace"
+        assert params == {"note_path": "Notes/find.md"}
+        return {
+            "artifact": {
+                "artifact_id": "art-1140",
+                "note_path": "Notes/find.md",
+                "title": "Find Note",
+                "body": "# Find Note",
+                "content_hash": "hash-find",
+            },
+            "canvas": {"session_state": "idle", "can_edit_body": False},
+            "panel": {"state": "idle", "proposal_count": 0},
+            "guards": {"canvas_enabled": True, "writeguard_status": "ok"},
+            "runtime": {
+                "find": {
+                    "scope": "active-project",
+                    "candidates": [
+                        {
+                            "candidate_id": "cand-1",
+                            "title": "Project brief",
+                            "snippet": "Relevant source excerpt.",
+                            "citation": "Notes/project-brief.md#L12",
+                            "scope": "project",
+                            "why": "Matched the active artifact title and project tag.",
+                            "panel_handoff": True,
+                        }
+                    ],
+                }
+            },
+            "suggestions": {},
+        }
+
+
+def _render_find() -> str:
+    page = RealNoteWorkspaceDevPage(_FakeClient())  # type: ignore[arg-type]
+    state = page.load(NoteLoadIntent(note_path="Notes/find.md"))
+    assert state.is_loaded is True
+    fields = page.render_fields()
+    assert fields is not None
+    return render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="Notes/find.md",
+        fields=fields,
+    )
+
+
+def test_candidates_with_explanations() -> None:
+    html = _render_find()
+
+    assert 'data-testid="find-mode"' in html
+    assert 'data-testid="find-candidate"' in html
+    assert "Project brief" in html
+    assert 'data-testid="find-candidate-why"' in html
+    assert "Matched the active artifact title and project tag." in html
+
+
+def test_candidate_citation_and_scope() -> None:
+    html = _render_find()
+
+    assert 'data-testid="find-candidate-citation"' in html
+    assert "Notes/project-brief.md#L12" in html
+    assert 'data-testid="find-candidate-scope"' in html
+    assert "project" in html
+
+
+def test_panel_handoff() -> None:
+    html = _render_find()
+
+    assert 'data-testid="find-panel-handoff"' in html
+    assert 'data-intent="find.panelHandoff"' in html


### PR DESCRIPTION
## Summary
- Normalize read-only Find mode candidates from workspace payload data (find or runtime.find).
- Render candidate source, snippet, citation, scope, and why-this-source explanation in the Companion rail.
- Add Panel handoff affordance for actionable candidates without adding retrieval mutations or backend calls.

## Issues included
- Closes #1140

## Claim workflow
- Verified blockers #1124 and #1137 are closed and Project Done.
- Claimed #1140 with scripts/issue_pickup_claim.sh and set Project status to In Progress.
- Dispatcher status fallback used because python3 -m app.dispatcher status --json is missing the yaml dependency in this environment.

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_find_mode_browser.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_real_note_workspace_dev_server.py tests/companion_ui/test_panel_rail_browser.py tests/companion_ui/test_suggestion_layout_browser.py
- /tmp/agentic-pkm-checks-1123/bin/ruff check app tests
- git diff --check