### PR TITLE
Fix artifact identity resolution

### DIFF
--- a/app/api/routes/canvas.py
+++ b/app/api/routes/canvas.py
@@ -22,6 +22,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from app.api.routes.artifacts import _content_hash
+from app.services.artifact_identity import resolve_note_artifact_identity
 from app.chat.canvas_writer import CanvasWriter, GovernanceBearingMutationError, _split_frontmatter
 from app.chat.governance_router import GovernanceActionType, GovernanceRouter
 from app.chat.session_log import SessionLog, SessionLogWriter
@@ -245,8 +246,20 @@ def governance_action(session_id: str, req: GovernanceRequest) -> GovernanceResp
         raise HTTPException(status_code=422, detail=f"Unknown action_type: {req.action_type!r}")
     vault_root = _get_vault_root()
     log_writer = SessionLogWriter(vault_root=vault_root)
-    artifact_id = str(session.note_path.relative_to(vault_root))
-    pipeline = CanvasPanelPipeline(proposal_store=_panel_proposal_store, artifact_id=artifact_id)
+    safe_note_path = str(session.note_path.relative_to(vault_root))
+    identity = resolve_note_artifact_identity(
+        artifact_path=session.note_path,
+        vault_root=vault_root,
+        safe_note_path=safe_note_path,
+    )
+    if identity.artifact_id is None:
+        raise HTTPException(status_code=409, detail="artifact identity unresolved")
+    artifact_id = identity.artifact_id
+    pipeline = CanvasPanelPipeline(
+        proposal_store=_panel_proposal_store,
+        artifact_id=artifact_id,
+        note_path=safe_note_path,
+    )
     gov = GovernanceRouter(panel_pipeline=pipeline, session_log_writer=log_writer)
     pending = gov.request_governance_action(session, action_type, req.payload)
     return GovernanceResponse(

--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -8,23 +8,28 @@ from uuid import uuid4
 
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
-import yaml
 
 import app.api.routes.canvas as canvas_module
 import app.panel.confirmation as confirm_module
 from app.api.routes.artifacts import _content_hash, _extract_title
 from app.config.paths import resolve_vault_root
+from app.services.artifact_identity import resolve_note_artifact_identity
 from app.write_guard import DEFAULT_WRITE_GUARD, WritesBlockedError
 
 router = APIRouter(prefix="/companion", tags=["companion"])
 
 
 class ArtifactState(BaseModel):
-    artifact_id: str
+    artifact_id: str | None
+    artifact_kind: str = "human_note"
     note_path: str
     title: str
     body: str
     content_hash: str
+    identity_source: str = "unknown"
+    identity_state: str = "unknown"
+    companion_of: str | None = None
+    owns_identity: bool = True
 
 
 class RuntimeState(BaseModel):
@@ -122,26 +127,6 @@ def _find_workspace_note(vault_root: Path, safe_note_path: str) -> Path | None:
     return None
 
 
-def _frontmatter_artifact_id(body: str) -> str | None:
-    if not body.startswith("---\n"):
-        return None
-    _, remainder = body.split("---\n", 1)
-    if "\n---" not in remainder:
-        return None
-    frontmatter_raw, _ = remainder.split("\n---", 1)
-    try:
-        loaded = yaml.safe_load(frontmatter_raw) or {}
-    except yaml.YAMLError:
-        return None
-    if not isinstance(loaded, dict):
-        return None
-    value = loaded.get("uuid") or loaded.get("id")
-    if value is None:
-        return None
-    artifact_id = str(value).strip()
-    return artifact_id or None
-
-
 def _vault_relative(path: Path, vault_root: Path) -> str | None:
     try:
         return path.relative_to(vault_root).as_posix()
@@ -197,12 +182,14 @@ def _undo_available_for_session(*, session: object, applied_edits: list[object])
     return current_body == getattr(latest, "body_after", None)
 
 
-def _proposal_count_for_artifact(artifact_id: str) -> int:
+def _proposal_count_for_artifact(artifact_id: str | None) -> int:
+    if artifact_id is None:
+        return 0
     proposals = getattr(confirm_module._proposal_store, "_proposals", {})
     return sum(1 for proposal in proposals.values() if proposal.artifact_id == artifact_id)
 
 
-def _panel_state(artifact_id: str) -> PanelState:
+def _panel_state(artifact_id: str | None) -> PanelState:
     proposal_count = _proposal_count_for_artifact(artifact_id)
     cache = getattr(confirm_module._idempotency_store, "_cache", {})
     relevant = [resp for resp in cache.values() if resp.artifact_id == artifact_id]
@@ -261,17 +248,29 @@ def read_companion_workspace(
         )
 
     body = artifact_path.read_text(encoding="utf-8")
-    artifact_id = _frontmatter_artifact_id(body) or _content_hash(safe_note_path)
+    identity = resolve_note_artifact_identity(
+        artifact_path=artifact_path,
+        vault_root=vault_root,
+        safe_note_path=safe_note_path,
+        body=body,
+    )
+    if identity.identity_state == "healed":
+        body = artifact_path.read_text(encoding="utf-8")
     canvas_enabled = _truthy_env("CANVAS_ENABLED")
     writeguard_status = _writeguard_status()
 
     return WorkspaceStateResponse(
         artifact=ArtifactState(
-            artifact_id=artifact_id,
+            artifact_id=identity.artifact_id,
+            artifact_kind=identity.artifact_kind,
             note_path=safe_note_path,
             title=_extract_title(body, fallback=artifact_path.stem),
             body=body,
             content_hash=_content_hash(body),
+            identity_source=identity.identity_source,
+            identity_state=identity.identity_state,
+            companion_of=identity.companion_of,
+            owns_identity=identity.owns_identity,
         ),
         runtime=RuntimeState(
             environment_label=_safe_environment_label(),
@@ -279,7 +278,7 @@ def read_companion_workspace(
             trace_id=trace_id,
         ),
         canvas=_canvas_state(safe_note_path, vault_root, canvas_enabled),
-        panel=_panel_state(artifact_id),
+        panel=_panel_state(identity.artifact_id),
         suggestions=SuggestionsState(),
         guards=GuardState(
             canvas_enabled=canvas_enabled,

--- a/app/panel/canvas_pipeline.py
+++ b/app/panel/canvas_pipeline.py
@@ -7,8 +7,8 @@ so the Companion UI can later confirm or reject it via POST /api/panel/confirm.
 
 from __future__ import annotations
 
-import uuid
 from typing import Any
+from uuid import uuid4
 
 from app.events.panel import (
     NoteRef,
@@ -21,14 +21,6 @@ from app.events.panel import (
 )
 from app.panel.confirmation import ProposalStore, StagedProposal
 
-# Stable namespace for deterministic note UUIDs derived from note paths.
-_CANVAS_NS = uuid.UUID("6ba7b814-9dad-11d1-80b4-00c04fd430c8")
-
-
-def _note_uuid_from_path(note_path: str) -> str:
-    return str(uuid.uuid5(_CANVAS_NS, note_path))
-
-
 class CanvasPanelPipeline:
     """Route a canvas governance intent into the Panel ProposalStore.
 
@@ -40,9 +32,10 @@ class CanvasPanelPipeline:
     with artifact_id equal to the note_path relative to vault_root.
     """
 
-    def __init__(self, proposal_store: ProposalStore, artifact_id: str) -> None:
+    def __init__(self, proposal_store: ProposalStore, artifact_id: str, note_path: str) -> None:
         self._store = proposal_store
         self._artifact_id = artifact_id
+        self._note_path = note_path
 
     def submit_intent(
         self,
@@ -50,13 +43,13 @@ class CanvasPanelPipeline:
         payload: dict[str, Any],
         session_id: str,
     ) -> str:
-        proposal_id = uuid.uuid4().hex
+        proposal_id = uuid4().hex
         intent_event = PanelIntentEvent(
             source=PanelEventSource(component="canvas", trigger="governance"),
             payload=PanelIntentPayload(
                 note=NoteRef(
-                    uuid=_note_uuid_from_path(self._artifact_id),
-                    path=self._artifact_id,
+                    uuid=self._artifact_id,
+                    path=self._note_path,
                     origin=f"canvas/{session_id}",
                 ),
                 panel=PanelInfo(

--- a/app/services/artifact_identity.py
+++ b/app/services/artifact_identity.py
@@ -1,0 +1,122 @@
+"""Runtime artifact identity resolution for active note workspace surfaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+from app.services.companion_note import companion_path
+from app.services.note_uuid import ensure_note_uuid
+from app.write_guard import WritesBlockedError
+from scripts.yaml_roundtrip import load_frontmatter
+
+
+@dataclass(frozen=True)
+class ArtifactIdentity:
+    artifact_id: str | None
+    artifact_kind: str
+    note_path: str
+    identity_source: str
+    identity_state: str
+    companion_of: str | None = None
+    owns_identity: bool = True
+
+
+def resolve_note_artifact_identity(
+    *,
+    artifact_path: Path,
+    vault_root: Path,
+    safe_note_path: str,
+    body: str | None = None,
+    heal_missing_uuid: bool = True,
+) -> ArtifactIdentity:
+    """Resolve active workspace identity without path/hash fallbacks."""
+    companion_identity = _companion_identity(vault_root=vault_root, safe_note_path=safe_note_path)
+    if companion_identity is not None:
+        return companion_identity
+
+    frontmatter = _frontmatter(body if body is not None else artifact_path.read_text(encoding="utf-8"))
+    frontmatter_uuid = str(frontmatter.get("uuid") or "").strip()
+    if frontmatter_uuid:
+        return ArtifactIdentity(
+            artifact_id=frontmatter_uuid,
+            artifact_kind="human_note",
+            note_path=safe_note_path,
+            identity_source="frontmatter.uuid",
+            identity_state="resolved",
+        )
+
+    legacy_id = str(frontmatter.get("id") or "").strip()
+    if legacy_id:
+        return ArtifactIdentity(
+            artifact_id=legacy_id,
+            artifact_kind="human_note",
+            note_path=safe_note_path,
+            identity_source="frontmatter.id",
+            identity_state="legacy_resolved",
+        )
+
+    if heal_missing_uuid:
+        try:
+            healed_uuid = ensure_note_uuid(artifact_path)
+        except (OSError, ValueError, WritesBlockedError):
+            healed_uuid = ""
+        if healed_uuid:
+            return ArtifactIdentity(
+                artifact_id=healed_uuid,
+                artifact_kind="human_note",
+                note_path=safe_note_path,
+                identity_source="uuid_healing",
+                identity_state="healed",
+            )
+
+    return ArtifactIdentity(
+        artifact_id=None,
+        artifact_kind="human_note",
+        note_path=safe_note_path,
+        identity_source="missing",
+        identity_state="unresolved_missing_uuid",
+    )
+
+
+def _frontmatter(markdown: str) -> dict:
+    frontmatter, _ = load_frontmatter(markdown)
+    return frontmatter if isinstance(frontmatter, dict) else {}
+
+
+def _companion_identity(*, vault_root: Path, safe_note_path: str) -> ArtifactIdentity | None:
+    candidate = PurePosixPath(safe_note_path)
+    parts = candidate.parts
+    if len(parts) < 3 or parts[-1].endswith(".md") is False:
+        return None
+
+    parent = PurePosixPath(*parts[:-1]).as_posix()
+    companion_dirs = {
+        companion_path("__placeholder__", vault_root).parent.as_posix(),
+        PurePosixPath("_system/companions").as_posix(),
+    }
+    if parent not in companion_dirs:
+        return None
+
+    note_uuid = Path(parts[-1]).stem.strip()
+    if not note_uuid:
+        return ArtifactIdentity(
+            artifact_id=None,
+            artifact_kind="companion_note",
+            note_path=safe_note_path,
+            identity_source="companion_path",
+            identity_state="unresolved_missing_companion_uuid",
+            owns_identity=False,
+        )
+    return ArtifactIdentity(
+        artifact_id=f"companion:{note_uuid}",
+        artifact_kind="companion_note",
+        note_path=safe_note_path,
+        identity_source="companion_path",
+        identity_state="companion_of_resolved",
+        companion_of=note_uuid,
+        owns_identity=False,
+    )
+
+
+__all__ = ["ArtifactIdentity", "resolve_note_artifact_identity"]

--- a/companion-ui/docs/WORKSPACE_STATE_CONTRACT.md
+++ b/companion-ui/docs/WORKSPACE_STATE_CONTRACT.md
@@ -65,11 +65,16 @@ Panel state, receipts, or write-guard state.
 ```json
 {
   "artifact": {
-    "artifact_id": "string",
+    "artifact_id": "string | null",
+    "artifact_kind": "human_note | companion_note",
     "note_path": "string",
     "title": "string",
     "body": "string",
-    "content_hash": "string"
+    "content_hash": "string",
+    "identity_source": "frontmatter.uuid | frontmatter.id | uuid_healing | companion_path | missing",
+    "identity_state": "resolved | legacy_resolved | healed | unresolved_missing_uuid | companion_of_resolved",
+    "companion_of": "string | null",
+    "owns_identity": true
   },
   "runtime": {
     "environment_label": "dev | test | prod | unknown",
@@ -115,11 +120,23 @@ workspace.
 
 | Field | Rule |
 |---|---|
-| `artifact_id` | Stable artifact identifier when available. Empty string is allowed only for legacy/read-only note loads where the runtime cannot resolve an ID. |
+| `artifact_id` | Stable artifact identifier when available. For normal human vault notes this is the frontmatter `uuid` or a UUID written by the approved healing path. `null` means identity is explicitly unresolved. Path strings and content hashes must not be used as fallback artifact IDs. |
+| `artifact_kind` | `human_note` for normal vault notes; `companion_note` for system-plane companion continuity artifacts. |
 | `note_path` | Browser-safe runtime-relative path or opaque note reference. It must not be an absolute vault path. |
 | `title` | Display title extracted or supplied by the runtime. |
 | `body` | Current note body at the time of aggregation. |
 | `content_hash` | Hash of the body returned in this payload. Browser edit flows must use it as the stale-read baseline before full-body replacement. |
+| `identity_source` | Source of the resolved or unresolved identity decision. |
+| `identity_state` | Server-declared identity state. Missing UUID notes that cannot be healed must surface an unresolved state rather than a path/hash fallback. |
+| `companion_of` | Main note UUID when the loaded artifact is a companion note; otherwise `null`. |
+| `owns_identity` | `true` when the loaded artifact owns human-note identity; `false` for companion notes and other system-plane continuity records. |
+
+Canvas-origin governance proposals and Panel proposal lookup must use the same
+resolved `artifact_id` as this workspace aggregate for the same human note.
+Companion notes may be represented as companion state, but their path or content
+hash must not be treated as human-note artifact identity. Attachment manifest
+entries remain locators/version markers in this contract, not independent
+artifact UUIDs.
 
 ### `runtime`
 

--- a/docs/CONCEPTS/ARTIFACT_MODEL_AND_LIFECYCLES.md
+++ b/docs/CONCEPTS/ARTIFACT_MODEL_AND_LIFECYCLES.md
@@ -34,6 +34,35 @@ When the system must determine the canonical UUID for a note, it follows this pr
 
 Steps 1–3 are automatic. Steps 4–5 are logged and flagged. Step 6 is never automatic — it surfaces as a diagnostic. Step 7 is always safe: new identity, no data loss.
 
+## Runtime Identity Field Rules
+
+`artifact_id` is the canonical runtime field for a resolved human vault-note
+identity. For normal human-authored vault notes, `artifact_id` must resolve to
+the note's frontmatter `uuid`; when an eligible note is missing `uuid`, the
+runtime should use the approved UUID assignment/healing path before returning
+active workspace state.
+
+Paths and hashes are not artifact identity:
+
+- `note_path` and `source_ref` are locators. They may move and must not be used
+  as `artifact_id`.
+- `content_hash` is a version/staleness marker. It may detect body drift and
+  support repair scenarios, but it must not be used as `artifact_id`.
+- `session_id`, `proposal_id`, and DB `objects.id` are runtime-local handles or
+  projection identifiers. They do not define the semantic identity of the human
+  vault note.
+
+Companion notes are system-plane continuity artifacts tied to the main vault
+note UUID. A companion note does not own an independent human-artifact identity,
+and its path or content hash must not become `artifact_id`. Runtime surfaces
+that need to refer to a companion note may expose a clearly typed companion
+state or a namespaced derived handle such as `companion:<note_uuid>`, but that
+handle is not a new UUID rule for all artifacts.
+
+Attachments, images, recordings, and other embedded files remain locator
+entries in the companion attachment manifest in this baseline. This document
+does not define independent attachment UUIDs.
+
 ## Healing Scenarios and Authority Matrix
 
 ### Scenario A: Normal ingest (no prior companion)

--- a/docs/CORE_CONTRACT.md
+++ b/docs/CORE_CONTRACT.md
@@ -74,11 +74,18 @@ these six semantic coordinates must remain stable.
 - Writing-surface human notes remain the primary human contract surface for vault-based work; they express intent and meaning.
 - For vault notes, `uuid` in frontmatter plus the companion note form the primary file-based
   identity anchors used for rebuild and repair.
+- Runtime fields must preserve the distinction between identity, locators, and version markers:
+  `artifact_id` resolves to the human vault-note `uuid` when identity is available; `note_path`
+  and `source_ref` are locators; `content_hash` is a version/staleness marker; DB row ids,
+  proposal ids, and session ids are runtime handles.
 - Watcher ingest writes `uuid` to source note frontmatter only. Other Core-6 fields (`origin`,
   `source_ref`, `trust`, `review_state`) are projected into the companion note and object store —
   they are implicit/derived for the source note, not written to its frontmatter. A uuid-only
   source note frontmatter after ingest is the correct expected runtime outcome (issue #976).
 - External/retained artifacts may also project Core-6 without becoming vault notes.
+- This contract does not currently grant independent UUID identity to every embedded image,
+  recording, PDF, or attachment. Attachment manifests record locators and hashes unless a later
+  architecture update defines a broader artifact-identity contract.
 - The DB/system plane is a normalized mirror or projection of the contract, not the source of truth for human meaning.
 - Policy-selected axes may extend the artifact view, but they do not become part of Core-6 unless this document changes.
 - Runtime/storage terms such as `object`, `store_objects`, or payload-specific shapes may represent Core-6, but they do not define its meaning.

--- a/tests/api/test_canvas_api.py
+++ b/tests/api/test_canvas_api.py
@@ -27,7 +27,7 @@ def _clear_sessions():
 @pytest.fixture()
 def vault(tmp_path: Path) -> Path:
     note = tmp_path / "note.md"
-    note.write_text("# Hello\n\nOriginal body.\n", encoding="utf-8")
+    note.write_text("---\nuuid: note-uuid-canvas\n---\n\n# Hello\n\nOriginal body.\n", encoding="utf-8")
     return tmp_path
 
 
@@ -192,7 +192,30 @@ def test_governance_action_stages_panel_proposal(client: TestClient, vault: Path
     staged = confirm_module._proposal_store.get(intent_id)
     assert staged is not None
     assert staged.artifact_id == artifact_id
+    assert artifact_id == "note-uuid-canvas"
+    assert staged.intent_event.payload.note.uuid == "note-uuid-canvas"
+    assert staged.intent_event.payload.note.path == "note.md"
     assert staged.intent_event.payload.actions[0].mapping.params["field"] == "maturity"
+
+
+def test_canvas_governance_proposal_uses_workspace_artifact_uuid(client: TestClient, vault: Path) -> None:
+    confirm_module._proposal_store.clear()
+    open_resp = client.post(
+        "/api/canvas/sessions", json={"note_path": "note.md", "label": "gov-identity-test"}
+    )
+    session_id = open_resp.json()["session_id"]
+
+    gov_resp = client.post(
+        f"/api/canvas/sessions/{session_id}/governance",
+        json={"action_type": "frontmatter_update", "payload": {"field": "maturity", "value": "evergreen"}},
+    )
+
+    assert gov_resp.status_code == 200
+    artifact_id = gov_resp.json()["artifact_id"]
+    assert artifact_id == "note-uuid-canvas"
+    staged = confirm_module._proposal_store.get(gov_resp.json()["intent_id"])
+    assert staged is not None
+    assert staged.artifact_id == artifact_id
 
 
 def test_canvas_disabled_returns_403(monkeypatch, vault: Path) -> None:

--- a/tests/api/test_companion_workspace_api.py
+++ b/tests/api/test_companion_workspace_api.py
@@ -91,6 +91,9 @@ def test_workspace_returns_artifact_payload(client: TestClient, vault_note: Path
     assert "Body text." in data["artifact"]["body"]
     assert data["artifact"]["content_hash"]
     assert data["artifact"]["artifact_id"] == "note-uuid-1"
+    assert data["artifact"]["artifact_kind"] == "human_note"
+    assert data["artifact"]["identity_source"] == "frontmatter.uuid"
+    assert data["artifact"]["identity_state"] == "resolved"
 
 
 def test_workspace_canvas_state_no_session(client: TestClient, vault_note: Path) -> None:
@@ -184,6 +187,149 @@ def test_workspace_panel_state(client: TestClient, vault_note: Path) -> None:
     assert panel["proposal_count"] == 1
     assert panel["receipt_count"] == 0
     assert panel["blocked_reason"] is None
+
+
+def test_workspace_artifact_id_uses_frontmatter_uuid(client: TestClient, vault_note: Path) -> None:
+    resp = _workspace(client)
+
+    assert resp.status_code == 200
+    artifact = resp.json()["artifact"]
+    assert artifact["artifact_id"] == "note-uuid-1"
+    assert artifact["identity_source"] == "frontmatter.uuid"
+    assert artifact["identity_state"] == "resolved"
+
+
+def test_workspace_missing_uuid_heals_eligible_note_without_hash_identity(
+    client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    note = tmp_path / "notes" / "uuidless.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text("---\ntitle: UUIDless\n---\n\n# UUIDless\n\nBody.\n", encoding="utf-8")
+
+    resp = _workspace(client, "notes/uuidless.md")
+
+    assert resp.status_code == 200
+    artifact = resp.json()["artifact"]
+    assert artifact["artifact_id"]
+    assert artifact["artifact_id"] != companion_module._content_hash("notes/uuidless.md")
+    assert artifact["identity_source"] == "uuid_healing"
+    assert artifact["identity_state"] == "healed"
+    assert f"uuid: {artifact['artifact_id']}" in note.read_text(encoding="utf-8")
+
+
+def test_workspace_missing_uuid_unresolved_state_has_no_hash_artifact_id(
+    client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    note = tmp_path / "notes" / "blocked.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text("# Blocked\n\nBody.\n", encoding="utf-8")
+
+    def _blocked(_path: Path) -> str:
+        raise WritesBlockedError("blocked", "write guard active", "ensure uuid")
+
+    monkeypatch.setattr(companion_module, "ensure_note_uuid", _blocked, raising=False)
+    monkeypatch.setattr("app.services.artifact_identity.ensure_note_uuid", _blocked)
+
+    resp = _workspace(client, "notes/blocked.md")
+
+    assert resp.status_code == 200
+    artifact = resp.json()["artifact"]
+    assert artifact["artifact_id"] is None
+    assert artifact["identity_source"] == "missing"
+    assert artifact["identity_state"] == "unresolved_missing_uuid"
+    assert artifact["artifact_id"] != companion_module._content_hash("notes/blocked.md")
+
+
+def test_workspace_companion_note_has_no_path_hash_identity(
+    client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    note_uuid = "note-uuid-1"
+    companion = tmp_path / "⚙️ System" / "companions" / f"{note_uuid}.md"
+    companion.parent.mkdir(parents=True, exist_ok=True)
+    companion.write_text(
+        "---\n"
+        f"uuid: {note_uuid}\n"
+        "source_ref: notes/note.md\n"
+        "content_hash: abc123\n"
+        "---\n",
+        encoding="utf-8",
+    )
+
+    resp = _workspace(client, f"⚙️ System/companions/{note_uuid}.md")
+
+    assert resp.status_code == 200
+    artifact = resp.json()["artifact"]
+    assert artifact["artifact_id"] == f"companion:{note_uuid}"
+    assert artifact["artifact_kind"] == "companion_note"
+    assert artifact["identity_source"] == "companion_path"
+    assert artifact["identity_state"] == "companion_of_resolved"
+    assert artifact["companion_of"] == note_uuid
+    assert artifact["owns_identity"] is False
+
+
+def test_workspace_legacy_companion_note_has_companion_identity(
+    client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    note_uuid = "legacy-note-uuid-1"
+    companion = tmp_path / "_system" / "companions" / f"{note_uuid}.md"
+    companion.parent.mkdir(parents=True, exist_ok=True)
+    companion.write_text(
+        "---\n"
+        f"uuid: {note_uuid}\n"
+        "source_ref: notes/note.md\n"
+        "content_hash: abc123\n"
+        "---\n",
+        encoding="utf-8",
+    )
+
+    resp = _workspace(client, f"_system/companions/{note_uuid}.md")
+
+    assert resp.status_code == 200
+    artifact = resp.json()["artifact"]
+    assert artifact["artifact_id"] == f"companion:{note_uuid}"
+    assert artifact["artifact_kind"] == "companion_note"
+    assert artifact["identity_source"] == "companion_path"
+    assert artifact["identity_state"] == "companion_of_resolved"
+    assert artifact["companion_of"] == note_uuid
+    assert artifact["owns_identity"] is False
+
+
+def test_workspace_panel_counts_canvas_origin_proposals_by_uuid(
+    client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    monkeypatch.setenv("CANVAS_ENABLED", "1")
+    note = tmp_path / "notes" / "canvas.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text(
+        "---\nuuid: note-uuid-canvas-workspace\n---\n\n# Canvas\n\nBody.\n",
+        encoding="utf-8",
+    )
+
+    open_resp = client.post(
+        "/api/canvas/sessions",
+        json={"note_path": "notes/canvas.md", "label": "workspace-panel-count"},
+    )
+    session_id = open_resp.json()["session_id"]
+    gov_resp = client.post(
+        f"/api/canvas/sessions/{session_id}/governance",
+        json={"action_type": "frontmatter_update", "payload": {"field": "maturity", "value": "evergreen"}},
+    )
+
+    assert gov_resp.status_code == 200
+    assert gov_resp.json()["artifact_id"] == "note-uuid-canvas-workspace"
+
+    resp = _workspace(client, "notes/canvas.md")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["artifact"]["artifact_id"] == "note-uuid-canvas-workspace"
+    assert data["panel"]["state"] == "proposals-staged"
+    assert data["panel"]["proposal_count"] == 1
 
 
 def test_workspace_guards(


### PR DESCRIPTION
Fixes #1160

## Summary
- Adds a shared runtime artifact identity resolver for active Companion workspace and Canvas/Panel proposal flows.
- Resolves human-note artifact identity from frontmatter UUID, heals eligible UUID-less notes through the approved UUID write path, and surfaces explicit unresolved identity instead of path/hash fallbacks.
- Documents that paths/content hashes are locators/version markers, companion notes are system-plane continuity artifacts, and attachment/image/recording UUID identity remains out of scope.
- Addresses review feedback by recognizing both layout-aware companion paths and legacy `_system/companions` paths as companion notes.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/api/test_companion_workspace_api.py tests/api/test_canvas_api.py tests/api/test_panel_confirm_api.py tests/panel tests/companion_ui` -> 796 passed
- `python3 -m py_compile app/services/artifact_identity.py app/api/routes/companion.py app/api/routes/canvas.py app/panel/canvas_pipeline.py` -> passed
- `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1 python3 scripts/docs_guard.py` -> OK
- `git diff --check` -> clean

## Tooling limitations / baseline notes
- Dispatcher unavailable locally because `python3 -m app.dispatcher status --json` failed with `ModuleNotFoundError: No module named 'yaml'`; used documented GitHub-label-only claim fallback.
- `ruff` unavailable: `ruff` command not found and `python3 -m ruff` reports no module named `ruff`.
- `mypy` unavailable: `mypy` command not found and `python3 -m mypy` reports no module named `mypy`.
- Broader `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg"` currently has 4 failures outside this change path: `tests/agents/panel_agent/test_proposal_only_outputs.py::test_proposal_outputs_remain_bounded`, `tests/guards/test_no_hardcoded_runtime_defaults.py::test_no_hardcoded_runtime_defaults`, and two `tests/quality_wave/test_registry_chain.py` snapshot comparison tests.