### PR TITLE
companion-ui: implement active-artifact Reorient mode

### DIFF
--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -13,6 +13,7 @@ import app.api.routes.canvas as canvas_module
 import app.panel.confirmation as confirm_module
 from app.api.routes.artifacts import _content_hash, _extract_title
 from app.config.paths import resolve_vault_root
+from app.orientation.runtime import build_orientation_frame
 from app.services.artifact_identity import resolve_note_artifact_identity
 from app.write_guard import DEFAULT_WRITE_GUARD, WritesBlockedError
 
@@ -36,6 +37,7 @@ class RuntimeState(BaseModel):
     environment_label: str
     api_base_url_label: str
     trace_id: str
+    reorient: dict[str, list[dict[str, str | bool]]] = Field(default_factory=dict)
 
 
 class CanvasState(BaseModel):
@@ -228,6 +230,56 @@ def _writeguard_status() -> str:
     return "ok"
 
 
+def _reorient_state() -> dict[str, list[dict[str, str | bool]]]:
+    frame = build_orientation_frame()
+
+    def item(
+        label: str,
+        *,
+        source_link: str = "runtime:orientation",
+        panel_handoff: bool = False,
+    ) -> dict[str, str | bool]:
+        return {
+            "label": label,
+            "source_link": source_link,
+            "panel_handoff": panel_handoff,
+        }
+
+    open_loops = [
+        item(loop, panel_handoff=not loop.startswith("No unresolved"))
+        for loop in frame.explanation.open_items
+    ]
+    candidates = [
+        item(intent, panel_handoff=True)
+        for intent in frame.mutation_intents
+    ]
+    if not candidates:
+        candidates = [
+            item(
+                "No direct action candidate is staged by the orientation runtime.",
+                panel_handoff=False,
+            )
+        ]
+    return {
+        "facts": [
+            item(frame.explanation.leave_point),
+        ],
+        "inferences": [
+            item(frame.frame),
+        ],
+        "candidates": candidates,
+        "stale_context": [
+            item(
+                "No stale context marker is present in the current orientation runtime snapshot.",
+            )
+        ],
+        "recent_deltas": [
+            item(frame.explanation.notable_change),
+        ],
+        "open_loops": open_loops,
+    }
+
+
 @router.get("/workspace", response_model=WorkspaceStateResponse)
 def read_companion_workspace(
     note_path: str = Query(..., description="Runtime-relative note path"),
@@ -276,6 +328,7 @@ def read_companion_workspace(
             environment_label=_safe_environment_label(),
             api_base_url_label=_safe_api_label(),
             trace_id=trace_id,
+            reorient=_reorient_state(),
         ),
         canvas=_canvas_state(safe_note_path, vault_root, canvas_enabled),
         panel=_panel_state(identity.artifact_id),

--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -231,8 +231,6 @@ def _writeguard_status() -> str:
 
 
 def _reorient_state() -> dict[str, list[dict[str, str | bool]]]:
-    frame = build_orientation_frame()
-
     def item(
         label: str,
         *,
@@ -243,6 +241,23 @@ def _reorient_state() -> dict[str, list[dict[str, str | bool]]]:
             "label": label,
             "source_link": source_link,
             "panel_handoff": panel_handoff,
+        }
+
+    try:
+        frame = build_orientation_frame()
+    except Exception:
+        return {
+            "facts": [],
+            "inferences": [],
+            "candidates": [],
+            "stale_context": [
+                item(
+                    "Orientation runtime unavailable; Reorient metadata is degraded.",
+                    source_link="runtime:orientation#unavailable",
+                )
+            ],
+            "recent_deltas": [],
+            "open_loops": [],
         }
 
     open_loops = [

--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -126,6 +126,7 @@ class DevPageState:
     portrait_sheet: dict[str, Any] | None = None
     keyboard_shortcuts: dict[str, Any] | None = None
     find_candidates: list[dict[str, Any]] | None = None
+    reorient_sections: dict[str, list[dict[str, Any]]] | None = None
     suggestion_cards: list[dict[str, Any]] | None = None
     suggested_insertions: list[dict[str, Any]] | None = None
     guard_writeguard_status: str = "ok"
@@ -187,6 +188,7 @@ class RealNoteWorkspaceDevPage:
         guards = raw.get("guards") or {}
         runtime = raw.get("runtime") or {}
         find_payload = raw.get("find") or runtime.get("find") or {}
+        reorient_payload = raw.get("reorient") or runtime.get("reorient") or {}
 
         # The runtime echoes artifact_id only when supplied in the request.
         # Fall back to note_path so note-path-only loads don't fail the shell's
@@ -286,6 +288,7 @@ class RealNoteWorkspaceDevPage:
                 rail_state=suggestion_machine.state,
             ),
             find_candidates=_find_candidates_from_payload(find_payload),
+            reorient_sections=_reorient_sections_from_payload(reorient_payload),
             suggested_insertions=_suggested_insertions_from_payload(suggestions),
             guard_writeguard_status=guards.get("writeguard_status") or "ok",
             guard_canvas_enabled=bool(guards.get("canvas_enabled", True)),
@@ -671,6 +674,7 @@ class RealNoteWorkspaceDevPage:
             "portrait_sheet": self.state.portrait_sheet or {},
             "keyboard_shortcuts": self.state.keyboard_shortcuts or {},
             "find_candidates": self.state.find_candidates or [],
+            "reorient_sections": self.state.reorient_sections or {},
             "suggestion_cards": self.state.suggestion_cards or [],
             "suggested_insertions": self.state.suggested_insertions or [],
             "guard_writeguard_status": self.state.guard_writeguard_status,
@@ -748,6 +752,39 @@ def _suggestion_payloads(suggestions: dict[str, Any]) -> list[dict[str, Any]]:
         return [item for item in raw if isinstance(item, dict)]
     return []
 
+
+def _reorient_sections_from_payload(
+    reorient: dict[str, Any],
+) -> dict[str, list[dict[str, Any]]]:
+    sections: dict[str, list[dict[str, Any]]] = {}
+    for section in (
+        "facts",
+        "inferences",
+        "candidates",
+        "stale_context",
+        "recent_deltas",
+        "open_loops",
+    ):
+        raw_items = reorient.get(section) or []
+        items: list[dict[str, Any]] = []
+        for index, raw in enumerate(raw_items, start=1):
+            if isinstance(raw, str):
+                raw = {"label": raw}
+            if not isinstance(raw, dict):
+                continue
+            label = str(raw.get("label") or raw.get("text") or "").strip()
+            if not label:
+                continue
+            items.append(
+                {
+                    "item_id": str(raw.get("item_id") or f"{section}-{index}"),
+                    "label": label,
+                    "source_link": str(raw.get("source_link") or raw.get("source") or ""),
+                    "panel_handoff": bool(raw.get("panel_handoff", False)),
+                }
+            )
+        sections[section] = items
+    return sections
 
 def _suggestion_cards_from_payload(suggestions: dict[str, Any]) -> list[dict[str, Any]]:
     cards: list[dict[str, Any]] = []

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -144,6 +144,7 @@ def _render_note_section(fields: dict) -> str:
         fields.get("governance_receipts") or []
     )
     find_mode_html = _render_find_mode(fields.get("find_candidates") or [])
+    reorient_mode_html = _render_reorient_mode(fields.get("reorient_sections") or {})
     suggested_insertions_html = _render_suggested_insertions(
         fields.get("suggested_insertions") or []
     )
@@ -209,6 +210,7 @@ def _render_note_section(fields: dict) -> str:
         {shortcut_html}
         {governance_receipts_html}
         {find_mode_html}
+        {reorient_mode_html}
         {guard_html}
         {persistence_html}
         {panel_rail}
@@ -327,6 +329,64 @@ def _render_find_mode(candidates: list[dict]) -> str:
             <span class="rail-state-value">{len(candidates)} candidates</span>
           </div>
           {"".join(rows)}
+        </section>"""
+
+
+def _render_reorient_mode(sections: dict[str, list[dict]]) -> str:
+    if not any(sections.get(name) for name in sections):
+        return ""
+
+    labels = {
+        "facts": "Facts",
+        "inferences": "Inferences",
+        "candidates": "Candidates",
+        "stale_context": "Stale context",
+        "recent_deltas": "Recent deltas",
+        "open_loops": "Open loops",
+    }
+    section_html: list[str] = []
+    for name, label in labels.items():
+        items = sections.get(name) or []
+        rows: list[str] = []
+        for item in items:
+            handoff = ""
+            if item.get("panel_handoff"):
+                handoff = (
+                    '<button type="button" class="reorient-panel-handoff" '
+                    'data-testid="reorient-panel-handoff" '
+                    'data-intent="reorient.panelHandoff">Panel</button>'
+                )
+            rows.append(
+                f"""
+              <li class="reorient-item" data-testid="reorient-item">
+                <span class="reorient-item-label">{_e(item.get("label", ""))}</span>
+                <a
+                  class="reorient-source"
+                  data-testid="reorient-source-link"
+                  href="#"
+                  data-source-link="{_e(item.get("source_link", ""))}">
+                  {_e(item.get("source_link", ""))}
+                </a>
+                {handoff}
+              </li>"""
+            )
+        section_html.append(
+            f"""
+            <section
+              class="reorient-section"
+              data-testid="reorient-section"
+              data-reorient-section="{_e(name)}">
+              <div class="reorient-section-title">{_e(label)}</div>
+              <ul class="reorient-list">{"".join(rows)}</ul>
+            </section>"""
+        )
+    return f"""
+        <section class="reorient-mode" data-testid="reorient-mode">
+          <div class="rail-state-row">
+            <span class="rail-state-label">Reorient</span>
+            <span class="rail-state-value">read-only</span>
+          </div>
+          {"".join(section_html)}
         </section>"""
 
 

--- a/companion-ui/docs/COMPANION_UI_TARGET_ARCHITECTURE.md
+++ b/companion-ui/docs/COMPANION_UI_TARGET_ARCHITECTURE.md
@@ -138,7 +138,8 @@ As of 2026-05-19 (after PR #1101, PR #1108, PR #1119 merged):
 | Panel models and confirmation service | Shipped — `companion_ui/panel/`, `app/panel/confirmation.py`, `POST /api/panel/confirm` |
 | Canvas governance pipeline (stub replaced) | Shipped — `app/panel/canvas_pipeline.py`, wired into `app/api/routes/canvas.py` |
 | Panel correction path | Shipped — `app/panel/confirmation.py` (correction.enabled=true now supported) |
-| Production Companion UI | **Not yet shipped** — browser wiring, workspace state API, product modes are next |
+| Product modes | Partially shipped — Find and Reorient render in the dev/staging workspace shell; Resurface and Act remain pending |
+| Production Companion UI | **Not yet shipped** — production hardening and remaining product modes are next |
 | Auth / TLS / reverse proxy for Companion UI | **Not yet shipped** — deferred until workspace state endpoint ships |
 | PWA packaging | **Not yet shipped** |
 | Native app wrapper (Tauri, Electron, etc.) | **Not yet shipped** |
@@ -160,7 +161,7 @@ Summary of next work:
 6. Bind browser shell to workspace state endpoint
 7. Docs: decide editor integration for shipped Canvas API (gate: after #3)
 8. Canvas/Panel/Suggestion Flow browser integration (wire existing models, not rebuild)
-9. Product modes (Find/Reorient/Resurface/Act) on top of wired surfaces
+9. Remaining product modes (Resurface/Act) on top of wired surfaces
 
 All future Companion UI implementation must be preceded by a bounded GitHub issue.
 Docs-first where contracts are undecided. Agents must rescope to integration if they discover

--- a/companion-ui/docs/WORKSPACE_STATE_CONTRACT.md
+++ b/companion-ui/docs/WORKSPACE_STATE_CONTRACT.md
@@ -79,7 +79,15 @@ Panel state, receipts, or write-guard state.
   "runtime": {
     "environment_label": "dev | test | prod | unknown",
     "api_base_url_label": "string",
-    "trace_id": "string"
+    "trace_id": "string",
+    "reorient": {
+      "facts": [],
+      "inferences": [],
+      "candidates": [],
+      "stale_context": [],
+      "recent_deltas": [],
+      "open_loops": []
+    }
   },
   "canvas": {
     "session_id": "string | null",
@@ -148,6 +156,7 @@ runtime.
 | `environment_label` | Safe label only. It must not include vault root paths. |
 | `api_base_url_label` | Safe display label such as `local-dev`, `local-test`, `local-prod`, or an operator-provided alias. It must not expose filesystem paths or secrets. |
 | `trace_id` | Correlation ID for this aggregate read. |
+| `reorient` | Read-only Reorient-mode projection derived from the orientation runtime. Items are grouped as facts, inferences, candidates, stale context, recent deltas, and open loops. Each item must carry a source link; actionable items may expose a Panel handoff hint, but the workspace aggregate does not execute or mutate from Reorient mode. |
 
 ### `canvas`
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -371,6 +371,7 @@ All six task specs are complete and closed; promotion and rollback skills are au
 - First visual alignment pass delivered (#1119): Yggdrasil design tokens, note body as primary surface, companion rail placeholder, dev/staging marker. This is a dev/staging shell, not a production Companion UI contract.
 - Existing model/runtime foundations confirmed shipped and not to be rebuilt: Canvas Core models and session API (`canvas_core/`, `app/api/routes/canvas.py`), Panel models and confirmation service (`panel/`, `app/panel/confirmation.py`), Canvas Suggestion Flow models (`canvas_suggestion_flow/`), `GET /api/artifacts/note` artifact read endpoint. Remaining Companion UI work is browser wiring, read-side state discovery, stub replacement, and production shell hardening.
 - Governance stub replaced: `_StubPipeline` in `app/api/routes/canvas.py` wired to real `CanvasPanelPipeline` that stages proposals in `ProposalStore`; Panel correction path in `PanelConfirmationService` implemented.
+- Product mode integration has begun in the dev/staging workspace shell: Find renders source candidates with explanation and Panel handoff, and Reorient renders read-only orientation sections from the orientation runtime with source links and Panel handoff hints. Resurface and Act remain pending.
 - **Issue-first policy**: all future Companion UI implementation changes must be governed by a bounded GitHub issue before implementation begins. Docs-first where contracts are undecided. Any issue that discovers a shipped model must be rescoped as integration work, not reimplementation.
 - Next implementation sequence (immediate queue — items 7–8 shipped above; items 3–6 and 9–10 are the active forward line):
   1. `docs(companion-ui)`: define post-dev-server implementation roadmap
@@ -384,4 +385,4 @@ All six task specs are complete and closed; promotion and rollback skills are au
   9. `docs(canvas-ui)`: decide browser editor integration for shipped Canvas API (blocked on #3)
   10. `docs(panel-ui)`: define missing Panel state discovery delta — scoped as gap analysis against existing `PANEL_COMPANION_UI_CONTRACT.md`; not a new contract from scratch
   - Items 3–6 and items 9–10 are sequential; items in each group can run in parallel where independent.
-  - Then: Canvas browser integration (wire existing models), suggestion-flow browser integration, Panel browser data-binding, product modes (Find/Reorient/Resurface/Act).
+  - Then: remaining product modes (Resurface/Act) on top of the wired browser surfaces.

--- a/tests/companion_ui/test_reorient_mode_browser.py
+++ b/tests/companion_ui/test_reorient_mode_browser.py
@@ -1,0 +1,114 @@
+"""Tests for Reorient mode rendering in the Companion workspace shell (#1141)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from companion_ui.workspace.real_note_workspace_dev_page import (
+    NoteLoadIntent,
+    RealNoteWorkspaceDevPage,
+)
+from companion_ui.workspace.serve_dev_page import render_index_html
+
+
+class _FakeClient:
+    def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        assert url == "/api/companion/workspace"
+        assert params == {"note_path": "Notes/reorient.md"}
+        return {
+            "artifact": {
+                "artifact_id": "art-1141",
+                "note_path": "Notes/reorient.md",
+                "title": "Reorient Note",
+                "body": "# Reorient Note",
+                "content_hash": "hash-reorient",
+            },
+            "canvas": {"session_state": "idle", "can_edit_body": False},
+            "panel": {"state": "idle", "proposal_count": 0},
+            "guards": {"canvas_enabled": True, "writeguard_status": "ok"},
+            "runtime": {
+                "reorient": {
+                    "facts": [
+                        {
+                            "label": "Last leave-point came from runtime activity.",
+                            "source_link": "runtime:orientation#leave-point",
+                        }
+                    ],
+                    "inferences": [
+                        {
+                            "label": "The active note is likely mid-review.",
+                            "source_link": "runtime:orientation#frame",
+                        }
+                    ],
+                    "candidates": [
+                        {
+                            "label": "Review the next unresolved loop.",
+                            "source_link": "runtime:orientation#candidate",
+                            "panel_handoff": True,
+                        }
+                    ],
+                    "stale_context": [
+                        {
+                            "label": "A prior counter snapshot may be stale.",
+                            "source_link": "runtime:orientation#stale",
+                        }
+                    ],
+                    "recent_deltas": [
+                        {
+                            "label": "Ingest counters changed since the last snapshot.",
+                            "source_link": "runtime:orientation#deltas",
+                        }
+                    ],
+                    "open_loops": [
+                        {
+                            "label": "One promotion intent remains open.",
+                            "source_link": "runtime:orientation#open-loops",
+                            "panel_handoff": True,
+                        }
+                    ],
+                }
+            },
+            "suggestions": {},
+        }
+
+
+def _render_reorient() -> str:
+    page = RealNoteWorkspaceDevPage(_FakeClient())  # type: ignore[arg-type]
+    state = page.load(NoteLoadIntent(note_path="Notes/reorient.md"))
+    assert state.is_loaded is True
+    fields = page.render_fields()
+    assert fields is not None
+    return render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="Notes/reorient.md",
+        fields=fields,
+    )
+
+
+def test_orientation_fields_rendered() -> None:
+    html = _render_reorient()
+
+    assert 'data-testid="reorient-mode"' in html
+    assert 'data-reorient-section="facts"' in html
+    assert 'data-reorient-section="inferences"' in html
+    assert 'data-reorient-section="candidates"' in html
+    assert 'data-reorient-section="stale_context"' in html
+    assert 'data-reorient-section="recent_deltas"' in html
+    assert 'data-reorient-section="open_loops"' in html
+    assert "Last leave-point came from runtime activity." in html
+    assert "One promotion intent remains open." in html
+
+
+def test_source_links_present() -> None:
+    html = _render_reorient()
+
+    assert html.count('data-testid="reorient-source-link"') == 6
+    assert "runtime:orientation#leave-point" in html
+    assert "runtime:orientation#open-loops" in html
+
+
+def test_panel_handoff() -> None:
+    html = _render_reorient()
+
+    assert 'data-testid="reorient-panel-handoff"' in html
+    assert 'data-intent="reorient.panelHandoff"' in html

--- a/tests/companion_ui/test_reorient_mode_browser.py
+++ b/tests/companion_ui/test_reorient_mode_browser.py
@@ -112,3 +112,28 @@ def test_panel_handoff() -> None:
 
     assert 'data-testid="reorient-panel-handoff"' in html
     assert 'data-intent="reorient.panelHandoff"' in html
+
+
+def test_workspace_reorient_failure_degrades_without_blocking_note_load(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from app.api.routes import companion
+
+    note = tmp_path / "Notes" / "reorient.md"
+    note.parent.mkdir()
+    note.write_text("---\nuuid: note-1141\n---\n# Reorient Note\n", encoding="utf-8")
+
+    monkeypatch.setattr(companion, "resolve_vault_root", lambda: tmp_path)
+
+    def fail_orientation() -> None:
+        raise RuntimeError("orientation unavailable")
+
+    monkeypatch.setattr(companion, "build_orientation_frame", fail_orientation)
+
+    response = companion.read_companion_workspace(note_path="Notes/reorient.md")
+
+    assert response.artifact.artifact_id == "note-1141"
+    assert response.runtime.reorient["stale_context"][0]["source_link"] == (
+        "runtime:orientation#unavailable"
+    )


### PR DESCRIPTION
Fixes #1141

## Summary
- Adds a read-only `runtime.reorient` projection to the Companion workspace aggregate, derived from `app/orientation/runtime.py`.
- Renders Reorient sections in the dev/staging workspace shell: facts, inferences, candidates, stale context, recent deltas, and open loops, each with source links and Panel handoff hints for actionable items.
- Updates Companion UI workspace/current-state docs so Find/Reorient are recorded as partially shipped dev/staging product-mode integration while Resurface/Act remain pending.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_reorient_mode_browser.py` — 3 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_reorient_mode_browser.py tests/companion_ui/test_find_mode_browser.py tests/companion_ui/test_real_note_workspace_dev_page.py tests/api/test_companion_workspace_api.py` — 28 passed
- `python3 -m py_compile app/api/routes/companion.py companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py` — passed
- `python3 scripts/docs_guard.py` — Docs guard: OK
- `git diff --check` — passed
- `ruff check app tests` — not run: `ruff` is not installed on PATH and `python3 -m ruff` reports `No module named ruff`
- `mypy app` — not run: `python3 -m mypy` reports `No module named mypy`

## Workflow Notes
- Dispatcher unavailable: `python3 -m app.dispatcher status --json` failed because local Python dependencies are missing `yaml`; used GitHub-label claim path via `scripts/issue_pickup_claim.sh --issue 1141`.
- Branch publication used dedicated worktree `/Users/rasmusthornberg/code/agentic-pkm-mvp-reorient`.