### PR TITLE
companion-ui: implement governed Resurface mode

### DIFF
--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -302,7 +302,7 @@ def _resurface_state(safe_note_path: str) -> dict[str, list[dict[str, str | list
     candidates: list[dict[str, str | list[str]]] = []
     for candidate in evaluation.candidates:
         signals = candidate.why_now.signals
-        source_link = signals[0].source if signals else "runtime:resurfacing"
+        source_link = _safe_resurface_source_link(candidate.candidate_id)
         signal_labels = [f"{signal.name}={signal.value}" for signal in signals]
         candidates.append(
             {
@@ -317,6 +317,14 @@ def _resurface_state(safe_note_path: str) -> dict[str, list[dict[str, str | list
             }
         )
     return {"candidates": candidates}
+
+
+def _safe_resurface_source_link(candidate_id: str) -> str:
+    if candidate_id == "resurface-worker-queue":
+        return "status.worker_queue"
+    if candidate_id in {"resurface-pending-promotions", "resurface-new-activity"}:
+        return "status.events"
+    return "runtime:resurfacing"
 
 
 @router.get("/workspace", response_model=WorkspaceStateResponse)

--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -14,6 +14,7 @@ import app.panel.confirmation as confirm_module
 from app.api.routes.artifacts import _content_hash, _extract_title
 from app.config.paths import resolve_vault_root
 from app.orientation.runtime import build_orientation_frame
+from app.resurfacing.runtime import evaluate_resurfacing_candidates
 from app.services.artifact_identity import resolve_note_artifact_identity
 from app.write_guard import DEFAULT_WRITE_GUARD, WritesBlockedError
 
@@ -38,6 +39,7 @@ class RuntimeState(BaseModel):
     api_base_url_label: str
     trace_id: str
     reorient: dict[str, list[dict[str, str | bool]]] = Field(default_factory=dict)
+    resurface: dict[str, list[dict[str, str | list[str]]]] = Field(default_factory=dict)
 
 
 class CanvasState(BaseModel):
@@ -295,6 +297,28 @@ def _reorient_state() -> dict[str, list[dict[str, str | bool]]]:
     }
 
 
+def _resurface_state(safe_note_path: str) -> dict[str, list[dict[str, str | list[str]]]]:
+    evaluation = evaluate_resurfacing_candidates()
+    candidates: list[dict[str, str | list[str]]] = []
+    for candidate in evaluation.candidates:
+        signals = candidate.why_now.signals
+        source_link = signals[0].source if signals else "runtime:resurfacing"
+        signal_labels = [f"{signal.name}={signal.value}" for signal in signals]
+        candidates.append(
+            {
+                "candidate_id": candidate.candidate_id,
+                "label": candidate.label,
+                "why_now": candidate.why_now.explanation,
+                "relation_to_active_artifact": (
+                    f"Runtime resurfacing signal evaluated while {safe_note_path} is active."
+                ),
+                "source_link": source_link,
+                "signal_labels": signal_labels,
+            }
+        )
+    return {"candidates": candidates}
+
+
 @router.get("/workspace", response_model=WorkspaceStateResponse)
 def read_companion_workspace(
     note_path: str = Query(..., description="Runtime-relative note path"),
@@ -344,6 +368,7 @@ def read_companion_workspace(
             api_base_url_label=_safe_api_label(),
             trace_id=trace_id,
             reorient=_reorient_state(),
+            resurface=_resurface_state(safe_note_path),
         ),
         canvas=_canvas_state(safe_note_path, vault_root, canvas_enabled),
         panel=_panel_state(identity.artifact_id),

--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -127,6 +127,7 @@ class DevPageState:
     keyboard_shortcuts: dict[str, Any] | None = None
     find_candidates: list[dict[str, Any]] | None = None
     reorient_sections: dict[str, list[dict[str, Any]]] | None = None
+    resurface_candidates: list[dict[str, Any]] | None = None
     suggestion_cards: list[dict[str, Any]] | None = None
     suggested_insertions: list[dict[str, Any]] | None = None
     guard_writeguard_status: str = "ok"
@@ -189,6 +190,7 @@ class RealNoteWorkspaceDevPage:
         runtime = raw.get("runtime") or {}
         find_payload = raw.get("find") or runtime.get("find") or {}
         reorient_payload = raw.get("reorient") or runtime.get("reorient") or {}
+        resurface_payload = raw.get("resurface") or runtime.get("resurface") or {}
 
         # The runtime echoes artifact_id only when supplied in the request.
         # Fall back to note_path so note-path-only loads don't fail the shell's
@@ -289,6 +291,7 @@ class RealNoteWorkspaceDevPage:
             ),
             find_candidates=_find_candidates_from_payload(find_payload),
             reorient_sections=_reorient_sections_from_payload(reorient_payload),
+            resurface_candidates=_resurface_candidates_from_payload(resurface_payload),
             suggested_insertions=_suggested_insertions_from_payload(suggestions),
             guard_writeguard_status=guards.get("writeguard_status") or "ok",
             guard_canvas_enabled=bool(guards.get("canvas_enabled", True)),
@@ -675,6 +678,7 @@ class RealNoteWorkspaceDevPage:
             "keyboard_shortcuts": self.state.keyboard_shortcuts or {},
             "find_candidates": self.state.find_candidates or [],
             "reorient_sections": self.state.reorient_sections or {},
+            "resurface_candidates": self.state.resurface_candidates or [],
             "suggestion_cards": self.state.suggestion_cards or [],
             "suggested_insertions": self.state.suggested_insertions or [],
             "guard_writeguard_status": self.state.guard_writeguard_status,
@@ -785,6 +789,42 @@ def _reorient_sections_from_payload(
             )
         sections[section] = items
     return sections
+
+
+def _resurface_candidates_from_payload(resurface: dict[str, Any]) -> list[dict[str, Any]]:
+    raw_candidates = resurface.get("candidates") or []
+    if isinstance(raw_candidates, dict):
+        raw_candidates = [raw_candidates]
+    if not isinstance(raw_candidates, list):
+        return []
+
+    candidates: list[dict[str, Any]] = []
+    for index, raw in enumerate(raw_candidates, start=1):
+        if not isinstance(raw, dict):
+            continue
+        why_now = str(raw.get("why_now") or raw.get("why") or "").strip()
+        relation = str(
+            raw.get("relation_to_active_artifact") or raw.get("relation") or ""
+        ).strip()
+        source_link = str(raw.get("source_link") or raw.get("source") or "").strip()
+        if not why_now or not relation or not source_link:
+            continue
+        signal_labels = raw.get("signal_labels") or raw.get("signals") or []
+        if not isinstance(signal_labels, list):
+            signal_labels = [str(signal_labels)]
+        candidates.append(
+            {
+                "candidate_id": str(
+                    raw.get("candidate_id") or raw.get("id") or f"resurface-{index}"
+                ),
+                "label": str(raw.get("label") or raw.get("title") or "Resurfacing candidate"),
+                "why_now": why_now,
+                "relation_to_active_artifact": relation,
+                "source_link": source_link,
+                "signal_labels": [str(label) for label in signal_labels],
+            }
+        )
+    return candidates
 
 def _suggestion_cards_from_payload(suggestions: dict[str, Any]) -> list[dict[str, Any]]:
     cards: list[dict[str, Any]] = []

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -145,6 +145,7 @@ def _render_note_section(fields: dict) -> str:
     )
     find_mode_html = _render_find_mode(fields.get("find_candidates") or [])
     reorient_mode_html = _render_reorient_mode(fields.get("reorient_sections") or {})
+    resurface_mode_html = _render_resurface_mode(fields.get("resurface_candidates") or [])
     suggested_insertions_html = _render_suggested_insertions(
         fields.get("suggested_insertions") or []
     )
@@ -211,6 +212,7 @@ def _render_note_section(fields: dict) -> str:
         {governance_receipts_html}
         {find_mode_html}
         {reorient_mode_html}
+        {resurface_mode_html}
         {guard_html}
         {persistence_html}
         {panel_rail}
@@ -387,6 +389,64 @@ def _render_reorient_mode(sections: dict[str, list[dict]]) -> str:
             <span class="rail-state-value">read-only</span>
           </div>
           {"".join(section_html)}
+        </section>"""
+
+
+def _render_resurface_mode(candidates: list[dict]) -> str:
+    if not candidates:
+        return ""
+    rows: list[str] = []
+    for candidate in candidates:
+        signals = "".join(
+            (
+                '<span class="resurface-signal" data-testid="resurface-signal">'
+                f"{_e(signal)}</span>"
+            )
+            for signal in candidate.get("signal_labels", [])
+        )
+        actions = "".join(
+            (
+                '<button type="button" class="resurface-action" '
+                f'data-testid="resurface-action-{intent}" '
+                f'data-intent="resurface.{intent}">{label}</button>'
+            )
+            for intent, label in (
+                ("dismiss", "Dismiss"),
+                ("snooze", "Snooze"),
+                ("pin", "Pin"),
+            )
+        )
+        rows.append(
+            f"""
+          <article
+            class="resurface-candidate"
+            data-testid="resurface-candidate"
+            data-candidate-id="{_e(candidate.get("candidate_id", ""))}">
+            <div class="resurface-title">{_e(candidate.get("label", ""))}</div>
+            <div class="resurface-why" data-testid="resurface-why-now">
+              {_e(candidate.get("why_now", ""))}
+            </div>
+            <div class="resurface-relation" data-testid="resurface-relation">
+              {_e(candidate.get("relation_to_active_artifact", ""))}
+            </div>
+            <a
+              class="resurface-source"
+              data-testid="resurface-source-link"
+              href="#"
+              data-source-link="{_e(candidate.get("source_link", ""))}">
+              {_e(candidate.get("source_link", ""))}
+            </a>
+            <div class="resurface-signals">{signals}</div>
+            <div class="resurface-actions">{actions}</div>
+          </article>"""
+        )
+    return f"""
+        <section class="resurface-mode" data-testid="resurface-mode">
+          <div class="rail-state-row">
+            <span class="rail-state-label">Resurface</span>
+            <span class="rail-state-value">low-pressure</span>
+          </div>
+          {"".join(rows)}
         </section>"""
 
 

--- a/companion-ui/docs/COMPANION_UI_TARGET_ARCHITECTURE.md
+++ b/companion-ui/docs/COMPANION_UI_TARGET_ARCHITECTURE.md
@@ -138,8 +138,8 @@ As of 2026-05-19 (after PR #1101, PR #1108, PR #1119 merged):
 | Panel models and confirmation service | Shipped — `companion_ui/panel/`, `app/panel/confirmation.py`, `POST /api/panel/confirm` |
 | Canvas governance pipeline (stub replaced) | Shipped — `app/panel/canvas_pipeline.py`, wired into `app/api/routes/canvas.py` |
 | Panel correction path | Shipped — `app/panel/confirmation.py` (correction.enabled=true now supported) |
-| Product modes | Partially shipped — Find and Reorient render in the dev/staging workspace shell; Resurface and Act remain pending |
-| Production Companion UI | **Not yet shipped** — production hardening and remaining product modes are next |
+| Product modes | Partially shipped — Find, Reorient, and Resurface render in the dev/staging workspace shell; Act remains pending |
+| Production Companion UI | **Not yet shipped** — production hardening and remaining Act mode are next |
 | Auth / TLS / reverse proxy for Companion UI | **Not yet shipped** — deferred until workspace state endpoint ships |
 | PWA packaging | **Not yet shipped** |
 | Native app wrapper (Tauri, Electron, etc.) | **Not yet shipped** |
@@ -161,7 +161,7 @@ Summary of next work:
 6. Bind browser shell to workspace state endpoint
 7. Docs: decide editor integration for shipped Canvas API (gate: after #3)
 8. Canvas/Panel/Suggestion Flow browser integration (wire existing models, not rebuild)
-9. Remaining product modes (Resurface/Act) on top of wired surfaces
+9. Remaining product mode (Act) on top of wired surfaces
 
 All future Companion UI implementation must be preceded by a bounded GitHub issue.
 Docs-first where contracts are undecided. Agents must rescope to integration if they discover

--- a/companion-ui/docs/WORKSPACE_STATE_CONTRACT.md
+++ b/companion-ui/docs/WORKSPACE_STATE_CONTRACT.md
@@ -87,6 +87,9 @@ Panel state, receipts, or write-guard state.
       "stale_context": [],
       "recent_deltas": [],
       "open_loops": []
+    },
+    "resurface": {
+      "candidates": []
     }
   },
   "canvas": {
@@ -157,6 +160,7 @@ runtime.
 | `api_base_url_label` | Safe display label such as `local-dev`, `local-test`, `local-prod`, or an operator-provided alias. It must not expose filesystem paths or secrets. |
 | `trace_id` | Correlation ID for this aggregate read. |
 | `reorient` | Read-only Reorient-mode projection derived from the orientation runtime. Items are grouped as facts, inferences, candidates, stale context, recent deltas, and open loops. Each item must carry a source link; actionable items may expose a Panel handoff hint, but the workspace aggregate does not execute or mutate from Reorient mode. |
+| `resurface` | Read-only Resurface-mode projection derived from the resurfacing runtime. Candidates carry a grounded why-now explanation, relation to the active artifact, source link, and signal labels. Dismiss, snooze, and pin are UI affordances only in this slice; the aggregate does not persist those decisions or upgrade similarity into urgency. |
 
 ### `canvas`
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -371,7 +371,7 @@ All six task specs are complete and closed; promotion and rollback skills are au
 - First visual alignment pass delivered (#1119): Yggdrasil design tokens, note body as primary surface, companion rail placeholder, dev/staging marker. This is a dev/staging shell, not a production Companion UI contract.
 - Existing model/runtime foundations confirmed shipped and not to be rebuilt: Canvas Core models and session API (`canvas_core/`, `app/api/routes/canvas.py`), Panel models and confirmation service (`panel/`, `app/panel/confirmation.py`), Canvas Suggestion Flow models (`canvas_suggestion_flow/`), `GET /api/artifacts/note` artifact read endpoint. Remaining Companion UI work is browser wiring, read-side state discovery, stub replacement, and production shell hardening.
 - Governance stub replaced: `_StubPipeline` in `app/api/routes/canvas.py` wired to real `CanvasPanelPipeline` that stages proposals in `ProposalStore`; Panel correction path in `PanelConfirmationService` implemented.
-- Product mode integration has begun in the dev/staging workspace shell: Find renders source candidates with explanation and Panel handoff, and Reorient renders read-only orientation sections from the orientation runtime with source links and Panel handoff hints. Resurface and Act remain pending.
+- Product mode integration has begun in the dev/staging workspace shell: Find renders source candidates with explanation and Panel handoff; Reorient renders read-only orientation sections from the orientation runtime with source links and Panel handoff hints; and Resurface renders low-pressure why-now candidates from the resurfacing runtime with dismiss, snooze, and pin affordances. Act remains pending.
 - **Issue-first policy**: all future Companion UI implementation changes must be governed by a bounded GitHub issue before implementation begins. Docs-first where contracts are undecided. Any issue that discovers a shipped model must be rescoped as integration work, not reimplementation.
 - Next implementation sequence (immediate queue — items 7–8 shipped above; items 3–6 and 9–10 are the active forward line):
   1. `docs(companion-ui)`: define post-dev-server implementation roadmap
@@ -385,4 +385,4 @@ All six task specs are complete and closed; promotion and rollback skills are au
   9. `docs(canvas-ui)`: decide browser editor integration for shipped Canvas API (blocked on #3)
   10. `docs(panel-ui)`: define missing Panel state discovery delta — scoped as gap analysis against existing `PANEL_COMPANION_UI_CONTRACT.md`; not a new contract from scratch
   - Items 3–6 and items 9–10 are sequential; items in each group can run in parallel where independent.
-  - Then: remaining product modes (Resurface/Act) on top of the wired browser surfaces.
+  - Then: remaining Act mode on top of the wired browser surfaces.

--- a/tests/companion_ui/test_resurface_mode_browser.py
+++ b/tests/companion_ui/test_resurface_mode_browser.py
@@ -1,0 +1,93 @@
+"""Tests for Resurface mode rendering in the Companion workspace shell (#1142)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from companion_ui.workspace.real_note_workspace_dev_page import (
+    NoteLoadIntent,
+    RealNoteWorkspaceDevPage,
+)
+from companion_ui.workspace.serve_dev_page import render_index_html
+
+
+class _FakeClient:
+    def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        assert url == "/api/companion/workspace"
+        assert params == {"note_path": "Notes/resurface.md"}
+        return {
+            "artifact": {
+                "artifact_id": "art-1142",
+                "note_path": "Notes/resurface.md",
+                "title": "Resurface Note",
+                "body": "# Resurface Note",
+                "content_hash": "hash-resurface",
+            },
+            "canvas": {"session_state": "idle", "can_edit_body": False},
+            "panel": {"state": "idle", "proposal_count": 0},
+            "guards": {"canvas_enabled": True, "writeguard_status": "ok"},
+            "runtime": {
+                "resurface": {
+                    "candidates": [
+                        {
+                            "candidate_id": "resurface-1",
+                            "label": "Queued runtime work remains unresolved",
+                            "why_now": (
+                                "Derived relevance changed because the worker queue "
+                                "has unresolved pending items."
+                            ),
+                            "relation_to_active_artifact": (
+                                "Evaluated while Notes/resurface.md is active."
+                            ),
+                            "source_link": "status.worker_queue",
+                            "signal_labels": ["worker_queue_pending=2"],
+                        }
+                    ]
+                }
+            },
+            "suggestions": {},
+        }
+
+
+def _render_resurface() -> str:
+    page = RealNoteWorkspaceDevPage(_FakeClient())  # type: ignore[arg-type]
+    state = page.load(NoteLoadIntent(note_path="Notes/resurface.md"))
+    assert state.is_loaded is True
+    fields = page.render_fields()
+    assert fields is not None
+    return render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="Notes/resurface.md",
+        fields=fields,
+    )
+
+
+def test_why_now_explanation() -> None:
+    html = _render_resurface()
+
+    assert 'data-testid="resurface-mode"' in html
+    assert 'data-testid="resurface-candidate"' in html
+    assert 'data-testid="resurface-why-now"' in html
+    assert "Derived relevance changed" in html
+    assert "should act now" not in html.lower()
+    assert "urgent" not in html.lower()
+
+
+def test_dismiss_snooze_pin() -> None:
+    html = _render_resurface()
+
+    assert 'data-testid="resurface-action-dismiss"' in html
+    assert 'data-testid="resurface-action-snooze"' in html
+    assert 'data-testid="resurface-action-pin"' in html
+    assert 'data-intent="resurface.dismiss"' in html
+    assert 'data-intent="resurface.snooze"' in html
+    assert 'data-intent="resurface.pin"' in html
+
+
+def test_relation_to_active_artifact() -> None:
+    html = _render_resurface()
+
+    assert 'data-testid="resurface-relation"' in html
+    assert "Evaluated while Notes/resurface.md is active." in html
+    assert 'data-testid="resurface-source-link"' in html
+    assert "status.worker_queue" in html

--- a/tests/companion_ui/test_resurface_mode_browser.py
+++ b/tests/companion_ui/test_resurface_mode_browser.py
@@ -91,3 +91,52 @@ def test_relation_to_active_artifact() -> None:
     assert "Evaluated while Notes/resurface.md is active." in html
     assert 'data-testid="resurface-source-link"' in html
     assert "status.worker_queue" in html
+
+
+def test_workspace_resurface_source_link_uses_logical_identifier(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from app.api.routes import companion
+    from app.resurfacing.runtime import (
+        ResurfacingCandidate,
+        ResurfacingEvaluation,
+        ResurfacingSignal,
+        ResurfacingWhyNow,
+    )
+
+    note = tmp_path / "Notes" / "resurface.md"
+    note.parent.mkdir()
+    note.write_text("---\nuuid: note-1142\n---\n# Resurface Note\n", encoding="utf-8")
+
+    monkeypatch.setattr(companion, "resolve_vault_root", lambda: tmp_path)
+    monkeypatch.setattr(
+        companion,
+        "evaluate_resurfacing_candidates",
+        lambda: ResurfacingEvaluation(
+            generated_at="2026-05-21T00:00:00Z",
+            status_summary="resurfacing_candidates=1",
+            candidates=[
+                ResurfacingCandidate(
+                    candidate_id="resurface-worker-queue",
+                    label="Queued runtime work remains unresolved",
+                    why_now=ResurfacingWhyNow(
+                        explanation="Worker queue has unresolved pending items.",
+                        signals=[
+                            ResurfacingSignal(
+                                name="worker_queue_pending",
+                                value=2,
+                                source="postgresql://user:secret@example/app",
+                            )
+                        ],
+                    ),
+                )
+            ],
+        ),
+    )
+
+    response = companion.read_companion_workspace(note_path="Notes/resurface.md")
+
+    candidate = response.runtime.resurface["candidates"][0]
+    assert candidate["source_link"] == "status.worker_queue"
+    assert "secret" not in str(candidate)


### PR DESCRIPTION
Fixes #1142

## Summary
- Adds a read-only `runtime.resurface` projection to the Companion workspace aggregate, derived from `app/resurfacing/runtime.py`.
- Renders Resurface candidates in the dev/staging workspace shell with why-now explanation, relation to the active artifact, source link, and signal labels.
- Adds distinct dismiss, snooze, and pin UI affordances without persisting action state or inflating urgency.

## Stacking
- Stacked on #1168 / `codex/companion-reorient-mode` because both slices extend the same workspace aggregate and browser render path.
- Merge order: #1168 first, then this PR.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_resurface_mode_browser.py` — 3 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_resurface_mode_browser.py tests/companion_ui/test_reorient_mode_browser.py tests/companion_ui/test_find_mode_browser.py tests/companion_ui/test_real_note_workspace_dev_page.py tests/api/test_companion_workspace_api.py` — 31 passed
- `python3 -m py_compile app/api/routes/companion.py companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py` — passed
- `python3 scripts/docs_guard.py` — Docs guard: OK
- `git diff --check` — passed
- `ruff check app tests` — not run: `ruff` is not installed on PATH and `python3 -m ruff` reports `No module named ruff`
- `mypy app` — not run: `python3 -m mypy` reports `No module named mypy`

## Workflow Notes
- Dispatcher unavailable in this environment because `python3 -m app.dispatcher status --json` fails on missing local dependency `yaml`; used GitHub-label claim path via `scripts/issue_pickup_claim.sh --issue 1142`.
- Branch publication used dedicated worktree `/Users/rasmusthornberg/code/agentic-pkm-mvp-resurface`.