### PR TITLE
[#1179] Mark Companion UI MLP affordance statuses

### DIFF
--- a/companion-ui/companion-app/companion_ui/panel/proposal_row.py
+++ b/companion-ui/companion-app/companion_ui/panel/proposal_row.py
@@ -24,6 +24,8 @@ PROPOSAL_STATUS_VALUES: set[str] = {
     "corrected",
     "rejected",
     "blocked",
+    "expired",
+    "unknown",
 }
 
 # Valid receipt outcome values.

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -100,6 +100,7 @@ def _render_note_section(fields: dict) -> str:
     panel_message = _e(panel_render.get("message") or "")
     proposal_count = int(fields.get("panel_proposal_count", 0) or 0)
     writeguard_status = _e(fields.get("guard_writeguard_status", "ok"))
+    writeguard_blocked = writeguard_status.lower() == "blocked"
     canvas_enabled = bool(fields.get("guard_canvas_enabled", True))
     guard_messages: list[str] = []
     if writeguard_status.lower() == "blocked":
@@ -132,6 +133,7 @@ def _render_note_section(fields: dict) -> str:
         )
     proposal_rows_html = _render_panel_proposal_rows(
         fields.get("panel_proposals") or [],
+        writeguard_blocked=writeguard_blocked,
     )
     panel_response_html = _render_panel_confirm_response(
         fields.get("panel_last_response") or {},
@@ -149,6 +151,7 @@ def _render_note_section(fields: dict) -> str:
     act_mode_html = _render_act_mode(
         proposals=fields.get("panel_proposals") or [],
         response=fields.get("panel_last_response") or {},
+        writeguard_blocked=writeguard_blocked,
     )
     suggested_insertions_html = _render_suggested_insertions(
         fields.get("suggested_insertions") or []
@@ -163,6 +166,8 @@ def _render_note_section(fields: dict) -> str:
         recovery_needed=recovery_needed,
         recovery_acknowledged=recovery_acknowledged,
         conflict_detected=conflict_detected,
+        canvas_enabled=canvas_enabled,
+        writeguard_blocked=writeguard_blocked,
         session_log_path=session_log_path,
         undo_available=undo_available,
         applied_edit_count=applied_edit_count,
@@ -301,15 +306,32 @@ def _render_keyboard_shortcuts(shortcuts: dict) -> str:
 
 def _render_find_mode(candidates: list[dict]) -> str:
     if not candidates:
-        return ""
+        return """
+        <section
+          class="find-mode"
+          data-testid="find-mode"
+          data-affordance-status="unavailable"
+          data-capability="find">
+          <div class="rail-state-row">
+            <span class="rail-state-label">Find</span>
+            <span class="rail-state-value">unavailable</span>
+          </div>
+          <div class="find-unavailable" data-testid="find-unavailable-state">
+            Find is unavailable because no backend candidate payload is available yet.
+          </div>
+        </section>"""
     rows: list[str] = []
     for candidate in candidates:
         handoff = ""
         if candidate.get("panel_handoff", True):
             handoff = (
                 '<button type="button" class="find-panel-handoff" '
-                'data-testid="find-panel-handoff" data-intent="find.panelHandoff">'
-                "Panel</button>"
+                'data-testid="find-panel-handoff" '
+                'data-intent="find.panelHandoff" '
+                'data-affordance-status="unavailable" '
+                'data-runtime-backed="false" '
+                'aria-disabled="true" disabled>'
+                "Panel unavailable</button>"
             )
         rows.append(
             f"""
@@ -330,7 +352,11 @@ def _render_find_mode(candidates: list[dict]) -> str:
         </article>"""
         )
     return f"""
-        <section class="find-mode" data-testid="find-mode">
+        <section
+          class="find-mode"
+          data-testid="find-mode"
+          data-affordance-status="read-only"
+          data-capability="find">
           <div class="rail-state-row">
             <span class="rail-state-label">Find</span>
             <span class="rail-state-value">{len(candidates)} candidates</span>
@@ -361,7 +387,10 @@ def _render_reorient_mode(sections: dict[str, list[dict]]) -> str:
                 handoff = (
                     '<button type="button" class="reorient-panel-handoff" '
                     'data-testid="reorient-panel-handoff" '
-                    'data-intent="reorient.panelHandoff">Panel</button>'
+                    'data-intent="reorient.panelHandoff" '
+                    'data-affordance-status="unavailable" '
+                    'data-runtime-backed="false" '
+                    'aria-disabled="true" disabled>Panel unavailable</button>'
                 )
             rows.append(
                 f"""
@@ -413,7 +442,11 @@ def _render_resurface_mode(candidates: list[dict]) -> str:
             (
                 '<button type="button" class="resurface-action" '
                 f'data-testid="resurface-action-{intent}" '
-                f'data-intent="resurface.{intent}">{label}</button>'
+                f'data-intent="resurface.{intent}" '
+                'data-affordance-status="unavailable" '
+                'data-runtime-backed="false" '
+                'aria-disabled="true" disabled>'
+                f"{label} unavailable</button>"
             )
             for intent, label in (
                 ("dismiss", "Dismiss"),
@@ -446,7 +479,11 @@ def _render_resurface_mode(candidates: list[dict]) -> str:
           </article>"""
         )
     return f"""
-        <section class="resurface-mode" data-testid="resurface-mode">
+        <section
+          class="resurface-mode"
+          data-testid="resurface-mode"
+          data-affordance-status="read-only"
+          data-capability="resurface">
           <div class="rail-state-row">
             <span class="rail-state-label">Resurface</span>
             <span class="rail-state-value">low-pressure</span>
@@ -455,7 +492,12 @@ def _render_resurface_mode(candidates: list[dict]) -> str:
         </section>"""
 
 
-def _render_act_mode(*, proposals: list[dict], response: dict) -> str:
+def _render_act_mode(
+    *,
+    proposals: list[dict],
+    response: dict,
+    writeguard_blocked: bool,
+) -> str:
     if not proposals and not response:
         return ""
 
@@ -465,6 +507,9 @@ def _render_act_mode(*, proposals: list[dict], response: dict) -> str:
         proposal_id = _e(proposal.get("proposal_id", ""))
         artifact_id = _e(proposal.get("artifact_id", ""))
         affordances = proposal.get("affordances") or {}
+        proposal_status = str(proposal.get("status") or "staged")
+        proposal_available = proposal_status == "staged" and not writeguard_blocked
+        proposal_affordance_status = "active" if proposal_available else "blocked" if writeguard_blocked else "unavailable"
         actions = "".join(
             (
                 '<button type="button" class="act-panel-action" '
@@ -472,19 +517,28 @@ def _render_act_mode(*, proposals: list[dict], response: dict) -> str:
                 f'data-panel-action="{_e(label)}" '
                 'data-api-method="POST" '
                 'data-api-path="/api/panel/confirm" '
+                f'data-affordance-status="{proposal_affordance_status}" '
                 f'data-proposal-id="{proposal_id}" '
                 f'data-artifact-id="{artifact_id}" '
                 'data-writeguard-bypass="false">'
                 f"{_e(label)}</button>"
             )
             for label in ("confirm", "correct", "reject")
-            if affordances.get(label, True)
+            if affordances.get(label, True) and proposal_available
         )
+        if not proposal_available:
+            actions = (
+                '<span class="act-panel-unavailable" '
+                'data-testid="act-panel-unavailable" '
+                f'data-affordance-status="{proposal_affordance_status}">'
+                f"{_e(proposal_status)} proposal unavailable</span>"
+            )
         proposal_rows.append(
             f"""
           <article
             class="act-proposal"
             data-testid="act-proposal-review"
+            data-affordance-status="{proposal_affordance_status}"
             data-proposal-id="{proposal_id}"
             data-artifact-id="{artifact_id}">
             <div class="act-proposal-title">{_e(proposal.get("description", ""))}</div>
@@ -524,6 +578,7 @@ def _render_act_mode(*, proposals: list[dict], response: dict) -> str:
           class="act-mode"
           data-testid="act-mode"
           data-authority-surface="panel"
+          data-affordance-status="{'blocked' if writeguard_blocked else 'active'}"
           data-writeguard-bypass="false">
           <div class="rail-state-row">
             <span class="rail-state-label">Act</span>
@@ -646,15 +701,24 @@ def _render_canvas_session_controls(
     recovery_needed: bool,
     recovery_acknowledged: bool,
     conflict_detected: bool,
+    canvas_enabled: bool,
+    writeguard_blocked: bool,
     session_log_path: str,
     undo_available: bool,
     applied_edit_count: int,
     undone_edit_count: int,
 ) -> str:
-    start_disabled = " disabled" if session_id else ""
+    canvas_blocked = not canvas_enabled or writeguard_blocked
+    start_status = "blocked" if not canvas_enabled else "experimental" if not session_id else "unavailable"
+    close_status = "blocked" if not canvas_enabled else "experimental" if session_id else "unavailable"
+    edit_status = "blocked" if canvas_blocked else "active" if can_edit_body else "unavailable"
+    undo_status = "blocked" if canvas_blocked else "active" if undo_available else "unavailable"
+    start_disabled = " disabled" if session_id or not canvas_enabled else ""
     close_disabled = "" if session_id else " disabled"
-    edit_disabled = "" if can_edit_body else " disabled"
-    undo_disabled = "" if undo_available else " disabled"
+    if not canvas_enabled:
+        close_disabled = " disabled"
+    edit_disabled = "" if can_edit_body and not canvas_blocked else " disabled"
+    undo_disabled = "" if undo_available and not canvas_blocked else " disabled"
     edit_api_path = f"/api/canvas/sessions/{session_id}/edits" if session_id else ""
     undo_api_path = f"/api/canvas/sessions/{session_id}/edits/last" if session_id else ""
     present_text = "user present" if user_present else "user not present"
@@ -680,23 +744,31 @@ def _render_canvas_session_controls(
           <button
             type="button"
             data-testid="workspace-canvas-start"
+            data-affordance-status="{start_status}"
+            data-capability="canvas.openSession"
             data-api-method="POST"
             data-api-path="/api/canvas/sessions"
             data-note-path="{note_path}"{start_disabled}>Start</button>
           <button
             type="button"
             data-testid="workspace-canvas-close"
+            data-affordance-status="{close_status}"
+            data-capability="canvas.closeSession"
             data-api-method="DELETE"
             data-api-path="/api/canvas/sessions/{session_id}"{close_disabled}>Close</button>
           <button
             type="button"
             data-testid="workspace-canvas-edit-submit"
+            data-affordance-status="{edit_status}"
+            data-capability="canvas.applyBodyEdit"
             data-api-method="POST"
             data-api-path="{edit_api_path}"
             data-content-hash="{content_hash}"{edit_disabled}>Apply body edit</button>
           <button
             type="button"
             data-testid="workspace-canvas-undo"
+            data-affordance-status="{undo_status}"
+            data-capability="canvas.undoBodyEdit"
             data-api-method="DELETE"
             data-api-path="{undo_api_path}"{undo_disabled}>Undo</button>
           <span class="canvas-presence" data-testid="workspace-canvas-user-present">{present_text}</span>
@@ -710,7 +782,11 @@ def _render_canvas_session_controls(
         </div>"""
 
 
-def _render_panel_proposal_rows(proposals: list[dict]) -> str:
+def _render_panel_proposal_rows(
+    proposals: list[dict],
+    *,
+    writeguard_blocked: bool,
+) -> str:
     if not proposals:
         return ""
 
@@ -718,25 +794,40 @@ def _render_panel_proposal_rows(proposals: list[dict]) -> str:
     for proposal in proposals:
         evidence = proposal.get("evidence") or {}
         affordances = proposal.get("affordances") or {}
+        proposal_status = str(proposal.get("status") or "staged")
+        proposal_available = proposal_status == "staged" and not writeguard_blocked
+        affordance_status = "active" if proposal_available else "blocked" if writeguard_blocked else "unavailable"
         enabled_affordances = [
             label
             for label in ("confirm", "correct", "reject")
-            if affordances.get(label)
+            if affordances.get(label) and proposal_available
         ]
         buttons = "".join(
             (
                 '<button type="button" class="panel-proposal-action" '
                 'data-testid="workspace-panel-action" '
                 f'data-panel-action="{_e(label)}" '
+                f'data-affordance-status="{affordance_status}" '
+                'data-runtime-backed="true" '
                 'data-api-method="POST" '
                 'data-api-path="/api/panel/confirm">'
                 f"{_e(label)}</button>"
             )
             for label in enabled_affordances
         )
+        if not proposal_available:
+            buttons = (
+                '<span class="panel-proposal-unavailable" '
+                'data-testid="workspace-panel-proposal-unavailable" '
+                f'data-affordance-status="{affordance_status}">'
+                f"{_e(proposal_status)} proposal unavailable</span>"
+            )
         rows.append(
             f"""
-        <div class="panel-proposal-row" data-testid="workspace-panel-proposal-row">
+        <div
+          class="panel-proposal-row"
+          data-testid="workspace-panel-proposal-row"
+          data-affordance-status="{affordance_status}">
           <div class="panel-proposal-title">{_e(proposal.get("description", ""))}</div>
           <div class="panel-proposal-meta">
             <span>{_e(proposal.get("proposal_id", ""))}</span>

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -508,7 +508,7 @@ def _render_act_mode(
         artifact_id = _e(proposal.get("artifact_id", ""))
         affordances = proposal.get("affordances") or {}
         proposal_status = str(proposal.get("status") or "staged")
-        proposal_available = proposal_status == "staged" and not writeguard_blocked
+        proposal_available = proposal_status in {"staged", "corrected"} and not writeguard_blocked
         proposal_affordance_status = "active" if proposal_available else "blocked" if writeguard_blocked else "unavailable"
         actions = "".join(
             (
@@ -795,7 +795,7 @@ def _render_panel_proposal_rows(
         evidence = proposal.get("evidence") or {}
         affordances = proposal.get("affordances") or {}
         proposal_status = str(proposal.get("status") or "staged")
-        proposal_available = proposal_status == "staged" and not writeguard_blocked
+        proposal_available = proposal_status in {"staged", "corrected"} and not writeguard_blocked
         affordance_status = "active" if proposal_available else "blocked" if writeguard_blocked else "unavailable"
         enabled_affordances = [
             label

--- a/tests/companion_ui/test_canvas_edit_browser.py
+++ b/tests/companion_ui/test_canvas_edit_browser.py
@@ -8,6 +8,7 @@ from companion_ui.workspace.real_note_workspace_dev_page import (
     NoteLoadIntent,
     RealNoteWorkspaceDevPage,
 )
+from companion_ui.workspace.serve_dev_page import render_index_html
 from companion_ui.workspace.workspace_http_client import WorkspaceClientHTTPError
 
 
@@ -39,6 +40,8 @@ def _workspace_payload(
     body: str = "# Canvas Note\n\nBody.",
     content_hash: str = "hash-1",
     can_edit_body: bool = True,
+    canvas_enabled: bool = True,
+    writeguard_status: str = "ok",
 ) -> dict[str, Any]:
     return {
         "artifact": {
@@ -58,7 +61,7 @@ def _workspace_payload(
             "session_persistence": "in_memory",
         },
         "panel": {"state": "idle", "proposal_count": 0},
-        "guards": {"canvas_enabled": True, "writeguard_status": "ok"},
+        "guards": {"canvas_enabled": canvas_enabled, "writeguard_status": writeguard_status},
         "runtime": {},
         "suggestions": {},
     }
@@ -113,6 +116,47 @@ def test_edit_disabled_outside_active_session() -> None:
     assert state.is_loaded is False
     assert "unavailable" in (state.error or "")
     assert client.post_calls == []
+
+
+def _render_canvas(client: _FakeClient) -> str:
+    page = _loaded_page(client)
+    fields = page.render_fields()
+    assert fields is not None
+    return render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="Notes/canvas.md",
+        fields=fields,
+    )
+
+
+def test_canvas_body_edit_apply_disabled_outside_active_editable_session() -> None:
+    html = _render_canvas(_FakeClient([_workspace_payload(can_edit_body=False)]))
+
+    assert 'data-testid="workspace-canvas-edit-submit"' in html
+    assert 'data-capability="canvas.applyBodyEdit"' in html
+    assert 'data-affordance-status="unavailable"' in html
+    assert 'data-testid="workspace-canvas-edit-submit"' in html
+    assert "Apply body edit</button>" in html
+    assert 'disabled>Apply body edit</button>' in html
+
+
+def test_canvas_in_memory_session_volatility_visible() -> None:
+    html = _render_canvas(_FakeClient([_workspace_payload(can_edit_body=True)]))
+
+    assert 'data-testid="workspace-session-persistence"' in html
+    assert "Session persistence: in_memory" in html
+
+
+def test_canvas_disabled_blocks_body_edit_affordances() -> None:
+    html = _render_canvas(
+        _FakeClient([_workspace_payload(can_edit_body=True, canvas_enabled=False)])
+    )
+
+    assert 'data-testid="workspace-guard-indicator"' in html
+    assert "Canvas disabled" in html
+    assert 'data-capability="canvas.applyBodyEdit"' in html
+    assert 'data-affordance-status="blocked"' in html
+    assert 'disabled>Apply body edit</button>' in html
 
 
 def test_workspace_refreshed_after_edit() -> None:

--- a/tests/companion_ui/test_find_mode_browser.py
+++ b/tests/companion_ui/test_find_mode_browser.py
@@ -83,3 +83,45 @@ def test_panel_handoff() -> None:
 
     assert 'data-testid="find-panel-handoff"' in html
     assert 'data-intent="find.panelHandoff"' in html
+    assert 'data-affordance-status="unavailable"' in html
+    assert 'data-runtime-backed="false"' in html
+    assert "Panel unavailable" in html
+
+
+class _NoFindPayloadClient:
+    def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        assert url == "/api/companion/workspace"
+        assert params == {"note_path": "Notes/find.md"}
+        return {
+            "artifact": {
+                "artifact_id": "art-1140",
+                "note_path": "Notes/find.md",
+                "title": "Find Note",
+                "body": "# Find Note",
+                "content_hash": "hash-find",
+            },
+            "canvas": {"session_state": "idle", "can_edit_body": False},
+            "panel": {"state": "idle", "proposal_count": 0},
+            "guards": {"canvas_enabled": True, "writeguard_status": "ok"},
+            "runtime": {},
+            "suggestions": {},
+        }
+
+
+def test_find_unavailable_state_renders_without_backend_payload() -> None:
+    page = RealNoteWorkspaceDevPage(_NoFindPayloadClient())  # type: ignore[arg-type]
+    state = page.load(NoteLoadIntent(note_path="Notes/find.md"))
+    assert state.is_loaded is True
+    fields = page.render_fields()
+    assert fields is not None
+
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="Notes/find.md",
+        fields=fields,
+    )
+
+    assert 'data-testid="find-mode"' in html
+    assert 'data-testid="find-unavailable-state"' in html
+    assert 'data-affordance-status="unavailable"' in html
+    assert "Find is unavailable" in html

--- a/tests/companion_ui/test_panel_confirm_browser.py
+++ b/tests/companion_ui/test_panel_confirm_browser.py
@@ -39,7 +39,11 @@ class _FakeClient:
         return self.post_response
 
 
-def _workspace_payload() -> dict[str, Any]:
+def _workspace_payload(
+    *,
+    proposal_status: str = "staged",
+    writeguard_status: str = "ok",
+) -> dict[str, Any]:
     return {
         "artifact": {
             "artifact_id": "art-1138",
@@ -68,12 +72,12 @@ def _workspace_payload() -> dict[str, Any]:
                     "proposal_id": "proposal-1",
                     "artifact_id": "art-1138",
                     "description": "Do the thing",
-                    "status": "staged",
-                    "affordances": {"confirm": True, "reject": True},
+                    "status": proposal_status,
+                    "affordances": {"confirm": True, "correct": True, "reject": True},
                 }
             ],
         },
-        "guards": {"canvas_enabled": True, "writeguard_status": "ok"},
+        "guards": {"canvas_enabled": True, "writeguard_status": writeguard_status},
         "runtime": {},
         "suggestions": {},
     }
@@ -214,3 +218,37 @@ def test_panel_response_cleared_when_switching_notes() -> None:
     state = page.load(NoteLoadIntent(note_path="Notes/b.md"))
 
     assert state.panel_last_response is None
+
+
+def test_panel_actions_active_only_for_staged_proposal() -> None:
+    html = _html(_loaded_page(_FakeClient([_workspace_payload()])))
+
+    assert 'data-testid="workspace-panel-proposal-row"' in html
+    assert 'data-affordance-status="active"' in html
+    assert 'data-panel-action="confirm"' in html
+    assert 'data-panel-action="correct"' in html
+    assert 'data-panel-action="reject"' in html
+    assert 'data-runtime-backed="true"' in html
+
+
+def test_unknown_or_expired_panel_proposal_state_is_unavailable() -> None:
+    html = _html(
+        _loaded_page(_FakeClient([_workspace_payload(proposal_status="expired")]))
+    )
+
+    assert 'data-testid="workspace-panel-proposal-unavailable"' in html
+    assert 'data-affordance-status="unavailable"' in html
+    assert "expired proposal unavailable" in html
+    assert 'data-panel-action="confirm"' not in html
+
+
+def test_writeguard_blocked_panel_actions_are_marked_blocked() -> None:
+    html = _html(
+        _loaded_page(_FakeClient([_workspace_payload(writeguard_status="blocked")]))
+    )
+
+    assert 'data-testid="workspace-guard-indicator"' in html
+    assert "WriteGuard blocked" in html
+    assert 'data-testid="workspace-panel-proposal-unavailable"' in html
+    assert 'data-affordance-status="blocked"' in html
+    assert 'data-panel-action="confirm"' not in html

--- a/tests/companion_ui/test_panel_confirm_browser.py
+++ b/tests/companion_ui/test_panel_confirm_browser.py
@@ -242,6 +242,19 @@ def test_unknown_or_expired_panel_proposal_state_is_unavailable() -> None:
     assert 'data-panel-action="confirm"' not in html
 
 
+def test_corrected_panel_proposal_remains_confirmable_and_rejectable() -> None:
+    html = _html(
+        _loaded_page(_FakeClient([_workspace_payload(proposal_status="corrected")]))
+    )
+
+    assert 'data-testid="workspace-panel-proposal-row"' in html
+    assert 'data-affordance-status="active"' in html
+    assert 'data-panel-action="confirm"' in html
+    assert 'data-panel-action="reject"' in html
+    assert 'data-panel-action="correct"' not in html
+    assert 'data-testid="workspace-panel-proposal-unavailable"' not in html
+
+
 def test_writeguard_blocked_panel_actions_are_marked_blocked() -> None:
     html = _html(
         _loaded_page(_FakeClient([_workspace_payload(writeguard_status="blocked")]))

--- a/tests/companion_ui/test_real_note_workspace_dev_page.py
+++ b/tests/companion_ui/test_real_note_workspace_dev_page.py
@@ -21,6 +21,7 @@ from companion_ui.workspace.real_note_workspace_dev_page import (
     NoteLoadIntent,
     RealNoteWorkspaceDevPage,
 )
+from companion_ui.workspace.serve_dev_page import render_index_html
 from companion_ui.workspace.real_note_workspace_shell import (
     REGION_AGENT_RAIL,
     REGION_NOTE_BODY,
@@ -166,6 +167,47 @@ def test_loads_from_workspace_aggregate() -> None:
     assert fields["artifact_id"] == "note-uuid-42"
     assert "Detailed body" in fields["body"]
     assert fields["content_hash"] == "deadbeef0042"
+
+
+def test_writeguard_blocked_marks_mutating_affordances_blocked() -> None:
+    page = _loaded_page(response=_workspace_response(
+        artifact=_artifact_response(title="Guarded Note"),
+        canvas={
+            "session_id": "session-1",
+            "session_state": "active",
+            "user_present": True,
+            "can_edit_body": True,
+            "session_persistence": "in_memory",
+        },
+        panel={
+            "state": "proposals-staged",
+            "proposal_count": 1,
+            "proposals": [
+                {
+                    "proposal_id": "proposal-1",
+                    "artifact_id": "note-uuid-42",
+                    "description": "Apply guarded change",
+                    "status": "staged",
+                    "affordances": {"confirm": True, "correct": True, "reject": True},
+                }
+            ],
+        },
+        guards={"canvas_enabled": True, "writeguard_status": "blocked"},
+    ))
+    fields = page.render_fields()
+    assert fields is not None
+
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="notes/research.md",
+        fields=fields,
+    )
+
+    assert 'data-testid="workspace-guard-indicator"' in html
+    assert "WriteGuard blocked" in html
+    assert 'data-capability="canvas.applyBodyEdit"' in html
+    assert 'data-affordance-status="blocked"' in html
+    assert 'data-testid="workspace-panel-proposal-unavailable"' in html
 
 
 # ---------------------------------------------------------------------------

--- a/tests/companion_ui/test_real_note_workspace_dev_server.py
+++ b/tests/companion_ui/test_real_note_workspace_dev_server.py
@@ -299,6 +299,48 @@ class TestRenderIndexHtml:
         )
         assert "rail" in html.lower() or "panel" in html.lower()
 
+    def test_workspace_renders_affordance_status_markers(self) -> None:
+        from companion_ui.workspace.serve_dev_page import render_index_html
+
+        fields = {
+            "title": "T",
+            "note_path": "N.md",
+            "artifact_id": "a",
+            "content_hash": "h",
+            "body": "b",
+            "panel_rail": "Panel / agent rail placeholder",
+            "canvas_session_id": "session-1",
+            "canvas_session_state": "active",
+            "canvas_can_edit_body": True,
+            "canvas_user_present": True,
+            "canvas_session_persistence": "in_memory",
+            "panel_state": "proposals-staged",
+            "panel_proposal_count": 1,
+            "panel_render": {"state": "proposals-staged", "label": "Proposal staged"},
+            "panel_proposals": [
+                {
+                    "proposal_id": "proposal-1",
+                    "artifact_id": "a",
+                    "description": "Do thing",
+                    "status": "staged",
+                    "affordances": {"confirm": True, "correct": True, "reject": True},
+                }
+            ],
+            "guard_canvas_enabled": True,
+            "guard_writeguard_status": "ok",
+            "is_production_ui": False,
+            "dev_page_label": "dev/staging",
+        }
+        html = render_index_html(
+            api_base_url="http://127.0.0.1:18001",
+            fields=fields,
+        )
+
+        assert 'data-affordance-status="active"' in html
+        assert 'data-affordance-status="experimental"' in html
+        assert 'data-capability="canvas.applyBodyEdit"' in html
+        assert 'data-runtime-backed="true"' in html
+
     def test_error_state_is_visible(self) -> None:
         from companion_ui.workspace.serve_dev_page import render_index_html
 

--- a/tests/companion_ui/test_resurface_mode_browser.py
+++ b/tests/companion_ui/test_resurface_mode_browser.py
@@ -84,6 +84,21 @@ def test_dismiss_snooze_pin() -> None:
     assert 'data-intent="resurface.pin"' in html
 
 
+def test_resurface_actions_marked_read_only_or_unavailable_without_persistence() -> None:
+    html = _render_resurface()
+
+    assert 'data-testid="resurface-mode"' in html
+    assert 'data-affordance-status="read-only"' in html
+    assert 'data-testid="resurface-action-dismiss"' in html
+    assert 'data-testid="resurface-action-snooze"' in html
+    assert 'data-testid="resurface-action-pin"' in html
+    assert html.count('data-affordance-status="unavailable"') >= 3
+    assert html.count('data-runtime-backed="false"') >= 3
+    assert "Dismiss unavailable" in html
+    assert "Snooze unavailable" in html
+    assert "Pin unavailable" in html
+
+
 def test_relation_to_active_artifact() -> None:
     html = _render_resurface()
 


### PR DESCRIPTION
Fixes #1179

## Summary

Add honest affordance status treatment to the current server-rendered Companion UI shell.

The PR marks read-only/unavailable/blocked/experimental affordances with stable `data-affordance-status` markers, disables controls that are not currently backed by runtime/persistence, and keeps runtime-backed Canvas and Panel actions actionable only in the states where they are valid.

## Files changed

- `companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py`
- `companion-ui/companion-app/companion_ui/panel/proposal_row.py`
- `tests/companion_ui/test_real_note_workspace_dev_page.py`
- `tests/companion_ui/test_real_note_workspace_dev_server.py`
- `tests/companion_ui/test_resurface_mode_browser.py`
- `tests/companion_ui/test_find_mode_browser.py`
- `tests/companion_ui/test_panel_confirm_browser.py`
- `tests/companion_ui/test_canvas_edit_browser.py`

## Authority / guardrail notes

- No direct vault writes from Companion UI were added.
- No new runtime endpoints, event contracts, or authority semantics were added.
- UI still renders server-declared classifications; it does not reclassify proposals locally.
- Panel and Canvas semantics remain separate.
- Resurface dismiss/snooze/pin and Find/Reorient Panel handoffs are explicitly unavailable/read-only where no backing behavior exists.

## Tests run

```bash
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_real_note_workspace_dev_page.py tests/companion_ui/test_real_note_workspace_dev_server.py tests/companion_ui/test_resurface_mode_browser.py tests/companion_ui/test_find_mode_browser.py tests/companion_ui/test_panel_confirm_browser.py tests/companion_ui/test_canvas_edit_browser.py
/Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/ruff check app tests
python3 scripts/docs_guard.py
git diff --check
```

Results:

- targeted pytest: `78 passed`
- ruff: `All checks passed!`
- docs guard: `Docs guard: OK`
- `git diff --check`: clean

## Workflow notes

- Dispatcher unavailable: `python3 -m app.dispatcher status --json` failed earlier in this workstream with `ModuleNotFoundError: No module named 'yaml'`; used GitHub-label-only claim through `scripts/issue_pickup_claim.sh --issue 1179`.
- Issue contract maintenance was applied before implementation: #1179 was updated with required sections and inline `Verify:` markers, and Project status was corrected from `Backlog` to `Ready` before claim.

## Known limitations

- This is the affordance honesty pass only; it does not implement durable Resurface persistence, a full Find backend, or production launch safety.
- The Companion UI surface remains the current server-rendered shell.
