### PR TITLE
companion-ui: improve real-note MLP workspace shell

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -97,6 +97,14 @@ class DevPageState:
     shell: Optional[RealNoteWorkspaceShell] = None
     error: Optional[str] = None
     panel_rail_placeholder: str = "Panel / agent rail — placeholder (dev)"
+    artifact_kind: str = "human_note"
+    artifact_identity_source: str = "unknown"
+    artifact_identity_state: str = "unknown"
+    artifact_companion_of: str | None = None
+    artifact_owns_identity: bool = True
+    runtime_environment_label: str = "unknown"
+    runtime_api_base_url_label: str = "local-dev"
+    runtime_trace_id: str = ""
     canvas_session_id: str | None = None
     canvas_session_state: str = "idle"
     canvas_user_present: bool = False
@@ -132,6 +140,7 @@ class DevPageState:
     suggested_insertions: list[dict[str, Any]] | None = None
     guard_writeguard_status: str = "ok"
     guard_canvas_enabled: bool = True
+    guard_degraded: bool = False
     is_loaded: bool = False
 
 
@@ -257,6 +266,14 @@ class RealNoteWorkspaceDevPage:
         self.state = DevPageState(
             shell=shell,
             panel_rail_placeholder=panel_render.get("label", "Panel ready"),
+            artifact_kind=artifact.get("artifact_kind") or "human_note",
+            artifact_identity_source=artifact.get("identity_source") or "unknown",
+            artifact_identity_state=artifact.get("identity_state") or "unknown",
+            artifact_companion_of=artifact.get("companion_of"),
+            artifact_owns_identity=bool(artifact.get("owns_identity", True)),
+            runtime_environment_label=runtime.get("environment_label") or "unknown",
+            runtime_api_base_url_label=runtime.get("api_base_url_label") or "local-dev",
+            runtime_trace_id=runtime.get("trace_id") or "",
             canvas_session_id=canvas.get("session_id"),
             canvas_session_state=session_state,
             canvas_user_present=bool(canvas.get("user_present", False)),
@@ -295,6 +312,7 @@ class RealNoteWorkspaceDevPage:
             suggested_insertions=_suggested_insertions_from_payload(suggestions),
             guard_writeguard_status=guards.get("writeguard_status") or "ok",
             guard_canvas_enabled=bool(guards.get("canvas_enabled", True)),
+            guard_degraded=bool(guards.get("degraded", False)),
             is_loaded=True,
         )
         return self.state
@@ -648,6 +666,14 @@ class RealNoteWorkspaceDevPage:
             "body": shell.body,
             "content_hash": shell.content_hash,
             "panel_rail": self.state.panel_rail_placeholder,
+            "artifact_kind": self.state.artifact_kind,
+            "artifact_identity_source": self.state.artifact_identity_source,
+            "artifact_identity_state": self.state.artifact_identity_state,
+            "artifact_companion_of": self.state.artifact_companion_of,
+            "artifact_owns_identity": self.state.artifact_owns_identity,
+            "runtime_environment_label": self.state.runtime_environment_label,
+            "runtime_api_base_url_label": self.state.runtime_api_base_url_label,
+            "runtime_trace_id": self.state.runtime_trace_id,
             "canvas_session_id": self.state.canvas_session_id,
             "canvas_session_state": self.state.canvas_session_state,
             "canvas_user_present": self.state.canvas_user_present,
@@ -683,6 +709,7 @@ class RealNoteWorkspaceDevPage:
             "suggested_insertions": self.state.suggested_insertions or [],
             "guard_writeguard_status": self.state.guard_writeguard_status,
             "guard_canvas_enabled": self.state.guard_canvas_enabled,
+            "guard_degraded": self.state.guard_degraded,
             "is_production_ui": self.is_production_ui,
             "dev_page_label": self.dev_page_label,
         }

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -34,6 +34,7 @@ LAN/Tailscale (explicit operator action required — not the default):
 """
 
 import html as _html
+import json
 import os
 import sys
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -69,6 +70,11 @@ def _e(value: str) -> str:
     return _html.escape(str(value))
 
 
+def _status_label(value: object, *, fallback: str = "unknown") -> str:
+    text = str(value or "").strip()
+    return text if text else fallback
+
+
 def _render_note_section(fields: dict) -> str:
     """Render the workspace shell from render_fields() output.
 
@@ -80,6 +86,15 @@ def _render_note_section(fields: dict) -> str:
     note_path_val = _e(fields.get("note_path", ""))
     artifact_id = _e(fields.get("artifact_id", ""))
     content_hash = _e(fields.get("content_hash", ""))
+    artifact_kind = _e(_status_label(fields.get("artifact_kind"), fallback="human_note"))
+    identity_source = _e(_status_label(fields.get("artifact_identity_source")))
+    identity_state_raw = _status_label(fields.get("artifact_identity_state"))
+    identity_state = _e(identity_state_raw)
+    companion_of = _e(fields.get("artifact_companion_of") or "")
+    owns_identity = bool(fields.get("artifact_owns_identity", True))
+    runtime_environment = _e(_status_label(fields.get("runtime_environment_label")))
+    runtime_channel = _e(_status_label(fields.get("runtime_api_base_url_label"), fallback="local-dev"))
+    runtime_trace_id = _e(fields.get("runtime_trace_id") or "")
     body = _e(fields.get("body", ""))
     panel_rail = _e(fields.get("panel_rail", "Panel / agent rail placeholder"))
     canvas_session_id = _e(fields.get("canvas_session_id") or "")
@@ -102,6 +117,52 @@ def _render_note_section(fields: dict) -> str:
     writeguard_status = _e(fields.get("guard_writeguard_status", "ok"))
     writeguard_blocked = writeguard_status.lower() == "blocked"
     canvas_enabled = bool(fields.get("guard_canvas_enabled", True))
+    guard_degraded = bool(fields.get("guard_degraded", False))
+    identity_caution_html = ""
+    if identity_state_raw.startswith("unresolved"):
+        identity_caution_html = (
+            '<div class="identity-caution" data-testid="workspace-artifact-identity-caution">'
+            "Artifact identity unresolved; runtime may block governed actions until identity is resolved."
+            "</div>"
+        )
+    companion_html = (
+        f'<span class="identity-meta" data-testid="workspace-companion-of">companion of {companion_of}</span>'
+        if companion_of
+        else ""
+    )
+    safety_strip_html = f"""
+      <section
+        class="runtime-safety-strip"
+        data-testid="workspace-runtime-safety-strip"
+        data-affordance-status="read-only"
+        data-runtime-backed="true">
+        <div class="safety-item" data-testid="workspace-runtime-channel">
+          <span class="safety-label">runtime</span>
+          <span>{runtime_environment}</span>
+          <span class="safety-sep">/</span>
+          <span>{runtime_channel}</span>
+        </div>
+        <div class="safety-item" data-testid="workspace-vault-identity">
+          <span class="safety-label">vault/channel</span>
+          <span>vault identity unavailable</span>
+        </div>
+        <div class="safety-item" data-testid="workspace-writeguard-state">
+          <span class="safety-label">WriteGuard</span>
+          <span>{writeguard_status}</span>
+        </div>
+        <div class="safety-item" data-testid="workspace-canvas-enabled-state">
+          <span class="safety-label">Canvas</span>
+          <span>{'enabled' if canvas_enabled else 'disabled'}</span>
+        </div>
+        <div class="safety-item" data-testid="workspace-guard-degraded-state">
+          <span class="safety-label">guard</span>
+          <span>{'degraded' if guard_degraded else 'normal'}</span>
+        </div>
+        <div class="safety-item" data-testid="workspace-runtime-trace-id">
+          <span class="safety-label">trace</span>
+          <code>{runtime_trace_id or 'unavailable'}</code>
+        </div>
+      </section>"""
     guard_messages: list[str] = []
     if writeguard_status.lower() == "blocked":
         guard_messages.append("WriteGuard blocked")
@@ -177,15 +238,35 @@ def _render_note_section(fields: dict) -> str:
     return f"""
   <div class="workspace-layout">
     <div class="workspace-main">
-      <header class="note-header" data-testid="workspace-note-header" data-region="note-header">
+      {safety_strip_html}
+      <header
+        class="note-header active-note-header"
+        data-testid="workspace-note-header"
+        data-region="note-header">
         <h1 class="note-title">{title}</h1>
         <div class="note-provenance">
           <span class="prov-item"><span class="prov-label">path</span><code>{note_path_val}</code></span>
           <span class="prov-sep">&middot;</span>
-          <span class="prov-item"><span class="prov-label">artifact</span><code>{artifact_id}</code></span>
+          <span
+            class="prov-item artifact-identity-pill"
+            data-testid="workspace-artifact-identity-pill"
+            data-identity-state="{identity_state}"
+            data-identity-source="{identity_source}"
+            data-artifact-kind="{artifact_kind}"
+            data-owns-identity="{'true' if owns_identity else 'false'}">
+            <span class="prov-label">artifact</span><code>{artifact_id or 'unresolved'}</code>
+            <span class="identity-meta">{identity_state}</span>
+            <span class="identity-meta">{identity_source}</span>
+            {companion_html}
+          </span>
           <span class="prov-sep">&middot;</span>
-          <span class="prov-item"><span class="prov-label">hash</span><code>{content_hash}</code></span>
+          <span
+            class="prov-item content-hash-pill"
+            data-testid="workspace-content-hash-pill">
+            <span class="prov-label">hash</span><code>{content_hash or 'unavailable'}</code>
+          </span>
         </div>
+        {identity_caution_html}
       </header>
       <div class="note-body" data-testid="workspace-note-body" data-region="note-body">
         <pre class="note-body-content">{body}</pre>
@@ -881,11 +962,48 @@ def _render_panel_confirm_response(response: dict) -> str:
         </div>"""
 
 
+def _error_detail(error: str) -> dict:
+    if not error.startswith("HTTP "):
+        return {}
+    _, _, maybe_json = error.partition(": ")
+    if not maybe_json:
+        return {}
+    try:
+        payload = json.loads(maybe_json)
+    except json.JSONDecodeError:
+        return {}
+    detail = payload.get("detail")
+    return detail if isinstance(detail, dict) else {}
+
+
 def _render_error_section(error: str) -> str:
     """Render a visible error state using Yggdrasil destructive tokens."""
+    detail = _error_detail(error)
+    error_kind = str(detail.get("error") or "")
+    if error_kind == "note_not_found":
+        note_path = _e(detail.get("note_path") or "")
+        message = _e(detail.get("message") or "No note exists for the requested note_path")
+        return f"""
+  <div class="error-state note-not-found-state" data-testid="workspace-note-not-found-state">
+    <span class="error-label">Note not found</span>
+    <span class="error-message">
+      <code>{note_path}</code> — {message}. Check the runtime-relative path and load again.
+    </span>
+  </div>"""
+    runtime_unavailable = any(
+        marker in error.lower()
+        for marker in ("connection refused", "timed out", "timeout", "network")
+    )
+    runtime_label = "Runtime unavailable" if runtime_unavailable else "API Error"
+    runtime_marker = (
+        '<span data-testid="workspace-runtime-unavailable-state"></span>'
+        if runtime_unavailable
+        else ""
+    )
     return f"""
-  <div class="error-state" data-testid="workspace-error-state">
-    <span class="error-label">API Error</span>
+  <div class="error-state" data-testid="workspace-error-state" data-error-kind="{'runtime-unavailable' if runtime_unavailable else 'api-error'}">
+    <span class="error-label">{runtime_label}</span>
+    {runtime_marker}
     <span class="error-message"><code>{_e(error)}</code></span>
   </div>"""
 
@@ -1096,6 +1214,11 @@ def render_index_html(
     }}
     .error-message {{ color: var(--fg-2); }}
     .error-message code {{ background: none; border: none; padding: 0; color: var(--fg-1); }}
+    .note-not-found-state {{
+      background: rgba(212,168,67,0.08);
+      border-color: rgba(212,168,67,0.35);
+    }}
+    .note-not-found-state .error-label {{ color: var(--accent); }}
 
     /* ---- Workspace layout ---- */
     .workspace-layout {{
@@ -1111,6 +1234,40 @@ def render_index_html(
       flex-direction: column;
       overflow: hidden;
     }}
+    .runtime-safety-strip {{
+      align-items: center;
+      background: rgba(17,26,46,0.65);
+      border-bottom: 1px solid var(--border);
+      color: var(--fg-2);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px 12px;
+      padding: 8px 24px;
+    }}
+    .safety-item {{
+      align-items: baseline;
+      display: inline-flex;
+      gap: 5px;
+      min-width: 0;
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+    }}
+    .safety-label {{
+      color: var(--fg-3);
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }}
+    .safety-item code {{
+      background: none;
+      border: none;
+      color: var(--fg-2);
+      max-width: 18ch;
+      overflow: hidden;
+      padding: 0;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }}
+    .safety-sep {{ color: var(--border-strong); }}
 
     /* ---- Note header ---- */
     .note-header {{
@@ -1136,6 +1293,29 @@ def render_index_html(
       color: var(--fg-3);
     }}
     .prov-item {{ display: inline-flex; align-items: baseline; gap: 4px; }}
+    .artifact-identity-pill, .content-hash-pill {{
+      background: var(--bg-raised);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      padding: 2px 6px;
+    }}
+    .artifact-identity-pill[data-identity-state^="unresolved"] {{
+      border-color: rgba(212,168,67,0.35);
+    }}
+    .identity-meta {{
+      color: var(--fg-3);
+      font-size: var(--text-xs);
+    }}
+    .identity-caution {{
+      background: rgba(212,168,67,0.08);
+      border: 1px solid rgba(212,168,67,0.35);
+      border-radius: var(--radius-md);
+      color: var(--accent);
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      margin-top: 10px;
+      padding: 8px 10px;
+    }}
     .prov-label {{
       letter-spacing: 0.06em;
       text-transform: uppercase;
@@ -1160,11 +1340,14 @@ def render_index_html(
       background: var(--bg-raised);
       border: 1px solid var(--border);
       border-radius: var(--radius-md);
-      padding: 20px;
+      margin: 0 auto;
+      max-width: 920px;
+      min-height: 100%;
+      padding: 28px 32px;
       font-family: var(--font-mono);
       font-size: var(--text-sm);
       color: var(--fg-1);
-      line-height: 1.65;
+      line-height: 1.75;
       white-space: pre-wrap;
       word-break: break-word;
     }}

--- a/tests/companion_ui/test_real_note_workspace_dev_page.py
+++ b/tests/companion_ui/test_real_note_workspace_dev_page.py
@@ -37,10 +37,15 @@ from companion_ui.workspace.workspace_http_client import WorkspaceHttpClient
 def _artifact_response(**overrides: Any) -> dict[str, Any]:
     base: dict[str, Any] = {
         "artifact_id": "note-uuid-42",
+        "artifact_kind": "human_note",
         "note_path": "/vault/notes/research.md",
         "title": "Research Note",
         "body": "# Research Note\n\nDetailed body.",
         "content_hash": "deadbeef0042",
+        "identity_source": "frontmatter.uuid",
+        "identity_state": "resolved",
+        "companion_of": None,
+        "owns_identity": True,
     }
     base.update(overrides)
     return base
@@ -58,7 +63,11 @@ def _workspace_response(
         "canvas": canvas or {"session_state": "idle", "session_persistence": "in_memory"},
         "panel": panel or {"state": "idle", "proposal_count": 0},
         "guards": guards or {"canvas_enabled": True, "writeguard_status": "ok"},
-        "runtime": {},
+        "runtime": {
+            "environment_label": "dev",
+            "api_base_url_label": "local-dev",
+            "trace_id": "trace-42",
+        },
         "suggestions": {},
     }
 
@@ -167,6 +176,35 @@ def test_loads_from_workspace_aggregate() -> None:
     assert fields["artifact_id"] == "note-uuid-42"
     assert "Detailed body" in fields["body"]
     assert fields["content_hash"] == "deadbeef0042"
+    assert fields["artifact_identity_source"] == "frontmatter.uuid"
+    assert fields["artifact_identity_state"] == "resolved"
+    assert fields["runtime_environment_label"] == "dev"
+    assert fields["runtime_api_base_url_label"] == "local-dev"
+    assert fields["runtime_trace_id"] == "trace-42"
+
+
+def test_artifact_identity_states_render_from_workspace_payload() -> None:
+    page = _loaded_page(response=_workspace_response(artifact=_artifact_response(
+        artifact_id=None,
+        note_path="notes/blocked.md",
+        title="Blocked Note",
+        identity_source="missing",
+        identity_state="unresolved_missing_uuid",
+    )))
+    fields = page.render_fields()
+    assert fields is not None
+
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="notes/blocked.md",
+        fields=fields,
+    )
+
+    assert 'data-testid="workspace-artifact-identity-pill"' in html
+    assert 'data-identity-state="unresolved_missing_uuid"' in html
+    assert 'data-identity-source="missing"' in html
+    assert 'data-testid="workspace-artifact-identity-caution"' in html
+    assert "Artifact identity unresolved" in html
 
 
 def test_writeguard_blocked_marks_mutating_affordances_blocked() -> None:

--- a/tests/companion_ui/test_real_note_workspace_dev_server.py
+++ b/tests/companion_ui/test_real_note_workspace_dev_server.py
@@ -30,7 +30,10 @@ from typing import Any, Optional
 import httpx
 import pytest
 
-from companion_ui.workspace.workspace_http_client import WorkspaceClientNetworkError
+from companion_ui.workspace.workspace_http_client import (
+    WorkspaceClientHTTPError,
+    WorkspaceClientNetworkError,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -73,13 +76,22 @@ def _note_payload(
             "note_path": note_path,
             "title": title,
             "artifact_id": artifact_id,
+            "artifact_kind": "human_note",
             "content_hash": content_hash,
             "body": body,
+            "identity_source": "frontmatter.uuid",
+            "identity_state": "resolved",
+            "companion_of": None,
+            "owns_identity": True,
         },
         "canvas": {"session_state": "idle", "session_persistence": "in_memory"},
         "panel": {"state": "idle", "proposal_count": 0},
         "guards": {"canvas_enabled": True, "writeguard_status": "ok"},
-        "runtime": {},
+        "runtime": {
+            "environment_label": "dev",
+            "api_base_url_label": "local-dev",
+            "trace_id": "trace-server-1",
+        },
         "suggestions": {},
     }
 
@@ -341,6 +353,47 @@ class TestRenderIndexHtml:
         assert 'data-capability="canvas.applyBodyEdit"' in html
         assert 'data-runtime-backed="true"' in html
 
+    def test_renders_runtime_safety_strip_and_identity_pills(self) -> None:
+        from companion_ui.workspace.serve_dev_page import render_index_html
+
+        fields = {
+            "title": "Some Note",
+            "note_path": "Some/Note.md",
+            "artifact_id": "art-123",
+            "artifact_kind": "human_note",
+            "artifact_identity_source": "frontmatter.uuid",
+            "artifact_identity_state": "resolved",
+            "content_hash": "sha256-deadbeef",
+            "body": "This is the note body.",
+            "panel_rail": "Panel / agent rail placeholder",
+            "runtime_environment_label": "dev",
+            "runtime_api_base_url_label": "local-dev",
+            "runtime_trace_id": "trace-123",
+            "guard_canvas_enabled": False,
+            "guard_writeguard_status": "blocked",
+            "guard_degraded": True,
+            "is_production_ui": False,
+            "dev_page_label": "dev/staging",
+        }
+        html = render_index_html(
+            api_base_url="http://127.0.0.1:18001",
+            fields=fields,
+        )
+
+        assert 'data-testid="workspace-runtime-safety-strip"' in html
+        assert 'data-testid="workspace-runtime-channel"' in html
+        assert "dev" in html
+        assert "local-dev" in html
+        assert 'data-testid="workspace-vault-identity"' in html
+        assert "vault identity unavailable" in html
+        assert 'data-testid="workspace-writeguard-state"' in html
+        assert "blocked" in html
+        assert 'data-testid="workspace-canvas-enabled-state"' in html
+        assert "disabled" in html
+        assert 'data-testid="workspace-artifact-identity-pill"' in html
+        assert 'data-identity-state="resolved"' in html
+        assert 'data-testid="workspace-content-hash-pill"' in html
+
     def test_error_state_is_visible(self) -> None:
         from companion_ui.workspace.serve_dev_page import render_index_html
 
@@ -351,6 +404,25 @@ class TestRenderIndexHtml:
         )
         assert "error" in html.lower() or "Error" in html
         assert "Connection refused" in html
+
+    def test_note_not_found_renders_distinct_state(self) -> None:
+        from companion_ui.workspace.serve_dev_page import handle_get
+
+        client = _FakeClient(
+            get_error=WorkspaceClientHTTPError(
+                404,
+                '{"detail":{"error":"note_not_found","message":"No note exists for the requested note_path","note_path":"Missing/Note.md","trace_id":"trace-missing"}}',
+            ),
+        )
+        html = handle_get(
+            query_string="note_path=Missing%2FNote.md",
+            client=client,
+            api_base_url="http://127.0.0.1:18001",
+        )
+
+        assert 'data-testid="workspace-note-not-found-state"' in html
+        assert "Note not found" in html
+        assert "Missing/Note.md" in html
 
     def test_note_content_not_shown_when_only_error(self) -> None:
         from companion_ui.workspace.serve_dev_page import render_index_html

--- a/tests/companion_ui/test_real_note_workspace_visual_shell.py
+++ b/tests/companion_ui/test_real_note_workspace_visual_shell.py
@@ -41,20 +41,35 @@ def _fields(
     panel_proposal_count: int = 0,
     guard_writeguard_status: str = "ok",
     guard_canvas_enabled: bool = True,
+    guard_degraded: bool = False,
+    artifact_identity_source: str = "frontmatter.uuid",
+    artifact_identity_state: str = "resolved",
+    runtime_environment_label: str = "dev",
+    runtime_api_base_url_label: str = "local-dev",
+    runtime_trace_id: str = "trace-visual-1",
 ) -> dict:
     return {
         "title": title,
         "note_path": note_path,
         "artifact_id": artifact_id,
+        "artifact_kind": "human_note",
+        "artifact_identity_source": artifact_identity_source,
+        "artifact_identity_state": artifact_identity_state,
+        "artifact_companion_of": None,
+        "artifact_owns_identity": True,
         "content_hash": content_hash,
         "body": body,
         "panel_rail": panel_rail,
+        "runtime_environment_label": runtime_environment_label,
+        "runtime_api_base_url_label": runtime_api_base_url_label,
+        "runtime_trace_id": runtime_trace_id,
         "canvas_session_state": canvas_session_state,
         "canvas_session_persistence": canvas_session_persistence,
         "panel_state": panel_state,
         "panel_proposal_count": panel_proposal_count,
         "guard_writeguard_status": guard_writeguard_status,
         "guard_canvas_enabled": guard_canvas_enabled,
+        "guard_degraded": guard_degraded,
         "is_production_ui": False,
         "dev_page_label": "dev/staging",
     }
@@ -155,6 +170,27 @@ class TestNoteHeader:
     def test_content_hash_in_provenance(self) -> None:
         html = _html_with_note(content_hash="sha256-aabbcc")
         assert "sha256-aabbcc" in html
+
+    def test_artifact_identity_pill_present(self) -> None:
+        html = _html_with_note(
+            artifact_identity_source="uuid_healing",
+            artifact_identity_state="healed",
+        )
+        assert 'data-testid="workspace-artifact-identity-pill"' in html
+        assert 'data-identity-source="uuid_healing"' in html
+        assert 'data-identity-state="healed"' in html
+
+    def test_content_hash_pill_present(self) -> None:
+        html = _html_with_note(content_hash="sha256-aabbcc")
+        assert 'data-testid="workspace-content-hash-pill"' in html
+
+    def test_unresolved_identity_caution_visible(self) -> None:
+        html = _html_with_note(
+            artifact_identity_source="missing",
+            artifact_identity_state="unresolved_missing_uuid",
+        )
+        assert 'data-testid="workspace-artifact-identity-caution"' in html
+        assert "Artifact identity unresolved" in html
 
     def test_provenance_labels_are_lowercase(self) -> None:
         """Provenance labels must use subdued lowercase (path, artifact, hash)."""
@@ -261,6 +297,30 @@ class TestAgentRail:
         html = _html_with_note(canvas_session_persistence="in_memory")
         assert 'data-testid="workspace-session-persistence"' in html
         assert "Session persistence: in_memory" in html
+
+
+class TestRuntimeSafetyStrip:
+    def test_runtime_safety_strip_present(self) -> None:
+        html = _html_with_note()
+        assert 'data-testid="workspace-runtime-safety-strip"' in html
+        assert 'data-testid="workspace-runtime-channel"' in html
+        assert 'data-testid="workspace-writeguard-state"' in html
+        assert 'data-testid="workspace-canvas-enabled-state"' in html
+
+    def test_runtime_channel_and_vault_fallback_visible(self) -> None:
+        html = _html_with_note(
+            runtime_environment_label="dev",
+            runtime_api_base_url_label="local-dev",
+        )
+        assert "dev" in html
+        assert "local-dev" in html
+        assert 'data-testid="workspace-vault-identity"' in html
+        assert "vault identity unavailable" in html
+
+    def test_guard_degraded_state_visible(self) -> None:
+        html = _html_with_note(guard_degraded=True, guard_canvas_enabled=False)
+        assert 'data-testid="workspace-guard-degraded-state"' in html
+        assert "degraded" in html
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1182

## Summary

Improve the current server-rendered real-note Companion workspace shell as the MLP entrypoint.

The PR surfaces runtime-provided artifact identity/source/state, runtime/channel labels, guard degradation, WriteGuard and Canvas state, a visible vault/channel unavailable fallback, identity caution copy, and distinct runtime-unavailable / note-not-found error states. It also improves note body readability while preserving the existing shell.

## Files changed

- `companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py`
- `companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py`
- `tests/companion_ui/test_real_note_workspace_dev_page.py`
- `tests/companion_ui/test_real_note_workspace_dev_server.py`
- `tests/companion_ui/test_real_note_workspace_visual_shell.py`

## Authority / guardrail notes

- No direct vault reads or writes were added to Companion UI.
- The workspace still loads through `GET /api/companion/workspace`.
- No new runtime endpoints, API schemas, event contracts, or authority semantics were added.
- The UI renders runtime-provided identity/guard/runtime fields and explicitly shows `vault identity unavailable` because the current API does not expose named vault/channel identity.
- Panel and Canvas semantics remain separate.

## Tests run

```bash
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_real_note_workspace_dev_page.py tests/companion_ui/test_real_note_workspace_dev_server.py tests/companion_ui/test_real_note_workspace_visual_shell.py tests/api/test_companion_workspace_api.py
/Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/ruff check app tests
/Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/ruff check companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py tests/companion_ui/test_real_note_workspace_dev_page.py tests/companion_ui/test_real_note_workspace_dev_server.py tests/companion_ui/test_real_note_workspace_visual_shell.py
python3 scripts/docs_guard.py
git diff --check
```

Results:

- targeted pytest: `119 passed`
- ruff `app tests`: `All checks passed!`
- ruff touched files: `All checks passed!`
- docs guard: `Docs guard: OK`
- `git diff --check`: clean

## Workflow notes

- Issue contract maintenance was applied before implementation: #1182 was updated with inline `Verify:` markers, and Project status was corrected from `Backlog` to `Ready` before claim.
- A broader lint run over all of `companion-ui/companion-app` surfaces pre-existing unused-code findings in untouched `companion_ui/panel/visual_shell.py`; touched workspace files pass targeted lint.

## Known limitations

- This slice does not expose new vault/channel identity from runtime; the UI renders an explicit unavailable fallback.
- This slice does not implement #1183 Canvas body-edit MLP or #1184 Panel receipt MLP.
- The Companion UI remains the current server-rendered shell.
