### PR TITLE
panel-ui: complete Act receipt MLP

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -55,6 +55,7 @@ from companion_ui.workspace.real_note_workspace_shell import (
 )
 from companion_ui.workspace.workspace_http_client import (
     WorkspaceClientError,
+    WorkspaceClientHTTPError,
     WorkspaceHttpClient,
 )
 
@@ -648,6 +649,24 @@ class RealNoteWorkspaceDevPage:
                 "/api/panel/confirm",
                 json=request_payload,
             )
+        except WorkspaceClientHTTPError as exc:
+            if exc.status_code == 422 and "same-turn" in exc.detail.lower():
+                self.state.panel_last_response = {
+                    "proposal_id": proposal_id,
+                    "artifact_id": artifact_id,
+                    "status": "blocked",
+                    "outcome": "blocked",
+                    "block_reason": {
+                        "gate": "same-turn",
+                        "message": (
+                            "Same-turn confirmation is not allowed. "
+                            "The proposal must be confirmed in a later interaction."
+                        ),
+                    },
+                }
+                return self.state
+            self.state = DevPageState(error=str(exc))
+            return self.state
         except WorkspaceClientError as exc:
             self.state = DevPageState(error=str(exc))
             return self.state

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -934,12 +934,16 @@ def _render_panel_proposal_rows(
             for label in ("confirm", "correct", "reject")
             if affordances.get(label) and proposal_available
         ]
+        proposal_id = _e(proposal.get("proposal_id", ""))
+        artifact_id = _e(proposal.get("artifact_id", ""))
         buttons = "".join(
             (
                 '<button type="button" class="panel-proposal-action" '
                 'data-testid="workspace-panel-action" '
                 f'data-panel-action="{_e(label)}" '
                 f'data-affordance-status="{affordance_status}" '
+                f'data-proposal-id="{proposal_id}" '
+                f'data-artifact-id="{artifact_id}" '
                 'data-runtime-backed="true" '
                 'data-api-method="POST" '
                 'data-api-path="/api/panel/confirm">'
@@ -959,17 +963,21 @@ def _render_panel_proposal_rows(
         <div
           class="panel-proposal-row"
           data-testid="workspace-panel-proposal-row"
-          data-affordance-status="{affordance_status}">
+          data-affordance-status="{affordance_status}"
+          data-proposal-id="{proposal_id}"
+          data-artifact-id="{artifact_id}">
           <div class="panel-proposal-title">{_e(proposal.get("description", ""))}</div>
           <div class="panel-proposal-meta">
-            <span>{_e(proposal.get("proposal_id", ""))}</span>
+            <span data-testid="workspace-panel-proposal-id">{proposal_id}</span>
+            <span data-testid="workspace-panel-artifact-id">{artifact_id}</span>
             <span>{_e(proposal.get("status", ""))}</span>
           </div>
-          <div class="panel-proposal-evidence" data-testid="workspace-panel-evidence">
-            <span>{_e(evidence.get("trigger_summary", ""))}</span>
-            <span>{_e(evidence.get("action_class", ""))}</span>
-            <span>{_e(evidence.get("cognition_route", ""))}</span>
-          </div>
+          <details class="panel-proposal-evidence" data-testid="workspace-panel-evidence" open>
+            <summary data-testid="workspace-panel-evidence-disclosure">Evidence</summary>
+            <span data-testid="workspace-panel-trigger-summary">{_e(evidence.get("trigger_summary", ""))}</span>
+            <span data-testid="workspace-panel-action-class">{_e(evidence.get("action_class", ""))}</span>
+            <span data-testid="workspace-panel-cognition-route">{_e(evidence.get("cognition_route", ""))}</span>
+          </details>
           <div class="panel-proposal-affordances">
             {buttons}
           </div>
@@ -987,24 +995,46 @@ def _render_panel_confirm_response(response: dict) -> str:
     receipt_html = ""
     if status in {"executed", "logged"} and receipt:
         corrected_badge = ""
-        if receipt.get("message") == "corrected":
+        if receipt.get("message") == "corrected" or receipt.get("corrected") or response.get("corrected"):
             corrected_badge = (
                 '<span class="panel-confirm-corrected" '
                 'data-testid="workspace-panel-corrected-receipt">corrected</span>'
             )
-        receipt_html = (
-            '<div class="panel-confirm-receipt" data-testid="workspace-panel-receipt">'
-            + _e(receipt.get("message") or receipt.get("outcome") or status)
-            + corrected_badge
-            + "</div>"
-        )
+        inverse_html = ""
+        inverse_action = receipt.get("inverse_action") or receipt.get("inverse_action_id")
+        if inverse_action:
+            inverse_html = (
+                '<div class="panel-confirm-inverse" '
+                'data-testid="workspace-panel-inverse-action" '
+                'data-affordance-status="read-only" '
+                'data-runtime-backed="false">'
+                + _e(inverse_action)
+                + "</div>"
+            )
+        receipt_html = f"""
+          <div
+            class="panel-confirm-receipt"
+            data-testid="workspace-panel-receipt"
+            data-receipt-persistence="durable-runtime-projection">
+            <span data-testid="workspace-panel-receipt-outcome">{_e(receipt.get("outcome") or response.get("outcome") or status)}</span>
+            <span data-testid="workspace-panel-receipt-message">{_e(receipt.get("message") or receipt.get("action_taken") or status)}</span>
+            <span data-testid="workspace-panel-receipt-timestamp">{_e(receipt.get("timestamp") or response.get("timestamp") or "timestamp unavailable")}</span>
+            {corrected_badge}
+            {inverse_html}
+          </div>"""
     blocked_html = ""
     if status == "blocked" and block_reason:
-        blocked_html = (
-            '<div class="panel-confirm-blocked" data-testid="workspace-panel-blocked-reason">'
-            + _e(block_reason.get("message") or "")
-            + "</div>"
-        )
+        message = str(block_reason.get("message") or "")
+        if block_reason.get("gate") == "same-turn" or "same-turn" in message.lower():
+            message = (
+                "Same-turn confirmation is not allowed. "
+                "The proposal must be confirmed in a later interaction."
+            )
+        blocked_html = f"""
+          <div class="panel-confirm-blocked" data-testid="workspace-panel-blocked-reason">
+            <span data-testid="workspace-panel-block-gate">{_e(block_reason.get("gate") or "unknown")}</span>
+            <span data-testid="workspace-panel-block-message">{_e(message)}</span>
+          </div>"""
     return f"""
         <div class="panel-confirm-response" data-testid="workspace-panel-confirm-response">
           <span data-testid="workspace-panel-confirm-status">{status}</span>

--- a/tests/companion_ui/test_panel_confirm_browser.py
+++ b/tests/companion_ui/test_panel_confirm_browser.py
@@ -9,6 +9,7 @@ from companion_ui.workspace.real_note_workspace_dev_page import (
     RealNoteWorkspaceDevPage,
 )
 from companion_ui.workspace.serve_dev_page import render_index_html
+from companion_ui.workspace.workspace_http_client import WorkspaceClientHTTPError
 
 
 class _FakeClient:
@@ -16,7 +17,7 @@ class _FakeClient:
         self,
         payloads: list[dict[str, Any]],
         *,
-        post_response: dict[str, Any] | None = None,
+        post_response: dict[str, Any] | Exception | None = None,
     ) -> None:
         self.payloads = payloads
         self.post_response = post_response or {
@@ -24,7 +25,11 @@ class _FakeClient:
             "artifact_id": "art-1138",
             "status": "executed",
             "outcome": "success",
-            "receipt": {"message": "Done", "outcome": "success"},
+            "receipt": {
+                "message": "Done",
+                "outcome": "success",
+                "timestamp": "2026-05-21T19:00:00Z",
+            },
             "idempotency_key": "server-key",
         }
         self.get_calls: list[tuple[str, dict[str, Any]]] = []
@@ -36,6 +41,8 @@ class _FakeClient:
 
     def post(self, url: str, *, json: dict[str, Any]) -> dict[str, Any]:
         self.post_calls.append((url, json))
+        if isinstance(self.post_response, Exception):
+            raise self.post_response
         return self.post_response
 
 
@@ -73,6 +80,11 @@ def _workspace_payload(
                     "artifact_id": "art-1138",
                     "description": "Do the thing",
                     "status": proposal_status,
+                    "evidence": {
+                        "trigger_summary": "Trigger summary",
+                        "action_class": "bounded.panel_action",
+                        "cognition_route": "rule",
+                    },
                     "affordances": {"confirm": True, "correct": True, "reject": True},
                 }
             ],
@@ -173,7 +185,13 @@ def test_receipt_rendered_after_executed() -> None:
     html = _html(page)
 
     assert 'data-testid="workspace-panel-receipt"' in html
+    assert 'data-receipt-persistence="durable-runtime-projection"' in html
+    assert 'data-testid="workspace-panel-receipt-outcome"' in html
+    assert 'data-testid="workspace-panel-receipt-message"' in html
+    assert 'data-testid="workspace-panel-receipt-timestamp"' in html
+    assert "success" in html
     assert "Done" in html
+    assert "2026-05-21T19:00:00Z" in html
 
 
 def test_blocked_reason_rendered() -> None:
@@ -198,7 +216,33 @@ def test_blocked_reason_rendered() -> None:
     html = _html(page)
 
     assert 'data-testid="workspace-panel-blocked-reason"' in html
+    assert 'data-testid="workspace-panel-block-gate"' in html
+    assert "writeguard" in html
     assert "Writes blocked" in html
+
+
+def test_same_turn_blocked_copy_rendered_without_page_error() -> None:
+    client = _FakeClient(
+        [_workspace_payload()],
+        post_response=WorkspaceClientHTTPError(422, "same-turn confirmation denied"),
+    )
+    page = _loaded_page(client)
+    state = page.confirm_panel_proposal(
+        proposal_id="proposal-1",
+        artifact_id="art-1138",
+        note_path="Notes/panel.md",
+    )
+
+    html = _html(page)
+
+    assert state.is_loaded is True
+    assert state.error is None
+    assert 'data-testid="workspace-panel-blocked-reason"' in html
+    assert "same-turn" in html
+    assert (
+        "Same-turn confirmation is not allowed. "
+        "The proposal must be confirmed in a later interaction."
+    ) in html
 
 
 def test_panel_response_cleared_when_switching_notes() -> None:
@@ -224,11 +268,60 @@ def test_panel_actions_active_only_for_staged_proposal() -> None:
     html = _html(_loaded_page(_FakeClient([_workspace_payload()])))
 
     assert 'data-testid="workspace-panel-proposal-row"' in html
+    assert 'data-proposal-id="proposal-1"' in html
+    assert 'data-artifact-id="art-1138"' in html
+    assert 'data-testid="workspace-panel-proposal-id"' in html
+    assert 'data-testid="workspace-panel-artifact-id"' in html
     assert 'data-affordance-status="active"' in html
     assert 'data-panel-action="confirm"' in html
     assert 'data-panel-action="correct"' in html
     assert 'data-panel-action="reject"' in html
     assert 'data-runtime-backed="true"' in html
+
+
+def test_panel_evidence_disclosure_contains_route_fields() -> None:
+    html = _html(_loaded_page(_FakeClient([_workspace_payload()])))
+
+    assert 'data-testid="workspace-panel-evidence"' in html
+    assert 'data-testid="workspace-panel-evidence-disclosure"' in html
+    assert 'data-testid="workspace-panel-trigger-summary"' in html
+    assert 'data-testid="workspace-panel-action-class"' in html
+    assert 'data-testid="workspace-panel-cognition-route"' in html
+    assert "Trigger summary" in html
+    assert "bounded.panel_action" in html
+    assert "rule" in html
+
+
+def test_inverse_action_is_display_only_when_declared() -> None:
+    client = _FakeClient(
+        [_workspace_payload(), _workspace_payload()],
+        post_response={
+            "proposal_id": "proposal-1",
+            "artifact_id": "art-1138",
+            "status": "executed",
+            "outcome": "success",
+            "receipt": {
+                "message": "Done",
+                "outcome": "success",
+                "inverse_action": "undo-panel-action-1",
+            },
+            "idempotency_key": "server-key",
+        },
+    )
+    page = _loaded_page(client)
+    page.confirm_panel_proposal(
+        proposal_id="proposal-1",
+        artifact_id="art-1138",
+        note_path="Notes/panel.md",
+    )
+
+    html = _html(page)
+
+    assert 'data-testid="workspace-panel-inverse-action"' in html
+    assert 'data-affordance-status="read-only"' in html
+    assert 'data-runtime-backed="false"' in html
+    assert "undo-panel-action-1" in html
+    assert 'data-panel-action="inverse"' not in html
 
 
 def test_unknown_or_expired_panel_proposal_state_is_unavailable() -> None:

--- a/tests/companion_ui/test_panel_correction_browser.py
+++ b/tests/companion_ui/test_panel_correction_browser.py
@@ -138,6 +138,33 @@ def test_corrected_receipt_marked() -> None:
     assert "corrected" in html
 
 
+def test_corrected_response_signal_marked() -> None:
+    client = _FakeClient(
+        [_workspace_payload(), _workspace_payload()],
+        post_response={
+            "proposal_id": "proposal-1",
+            "artifact_id": "art-1139",
+            "status": "executed",
+            "outcome": "success",
+            "corrected": True,
+            "receipt": {"message": "Done", "outcome": "success"},
+            "idempotency_key": "server-key",
+        },
+    )
+    page = _loaded_page(client)
+    page.correct_panel_proposal(
+        proposal_id="proposal-1",
+        artifact_id="art-1139",
+        note_path="Notes/panel.md",
+        corrected_action_id="proposal-1",
+        corrected_parameters={"value": "evergreen"},
+    )
+
+    html = _html(page)
+
+    assert 'data-testid="workspace-panel-corrected-receipt"' in html
+
+
 def test_invalid_correction_rejected() -> None:
     client = _FakeClient([_workspace_payload()])
     page = _loaded_page(client)


### PR DESCRIPTION
Fixes #1184

## Summary

Complete the Panel / Act receipt MLP shell around the existing governed `POST /api/panel/confirm` path.

The PR adds stable proposal/artifact identifiers to proposal cards and controls, evidence disclosure markers, richer receipt and block cards, exact same-turn blocked copy, corrected response markers, and display-only inverse action rendering when the runtime declares one.

## Files changed

- `companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py`
- `companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py`
- `tests/companion_ui/test_panel_confirm_browser.py`
- `tests/companion_ui/test_panel_correction_browser.py`

## Authority / guardrail notes

- Panel decisions still route through `POST /api/panel/confirm`.
- Runtime still owns policy, WriteGuard, idempotency, action handling, events, receipts, and durable projection.
- No direct vault reads or writes were added to Companion UI.
- No UI-side proposal classification or auto-confirm path was added.
- Same-turn confirmation is rendered as a blocked Panel outcome, not a successful path.
- Runtime-declared inverse action is display-only; no direct UI shortcut applies it.
- Panel and Canvas semantics remain separate.

## Tests run

```bash
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_panel_confirm_browser.py tests/companion_ui/test_panel_correction_browser.py tests/companion_ui/test_panel_rail_browser.py tests/api/test_panel_confirm_api.py tests/panel
/Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/ruff check app tests companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
python3 scripts/docs_guard.py
git diff --check
```

Results:

- targeted pytest: `68 passed`
- ruff: `All checks passed!`
- docs guard: `Docs guard: OK`
- `git diff --check`: clean

## Workflow notes

- Issue contract maintenance was applied before implementation: #1184 was updated with inline `Verify:` markers, and Project status was corrected from `Backlog` to `Ready` before claim.

## Known limitations

- This slice does not implement new Panel runtime semantics or API schemas.
- The UI remains the current server-rendered shell.
- Inverse action rendering is informational only for this MLP.
