### PR TITLE
companion-ui: implement Reorient daily recovery view

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -448,7 +448,20 @@ def _render_find_mode(candidates: list[dict]) -> str:
 
 def _render_reorient_mode(sections: dict[str, list[dict]]) -> str:
     if not any(sections.get(name) for name in sections):
-        return ""
+        return """
+        <section
+          class="reorient-mode"
+          data-testid="reorient-mode"
+          data-affordance-status="read-only"
+          data-capability="reorient">
+          <div class="rail-state-row">
+            <span class="rail-state-label">Reorient</span>
+            <span class="rail-state-value">read-only</span>
+          </div>
+          <div class="reorient-empty" data-testid="reorient-empty-state">
+            Reorient is available, but no orientation payload is available for this note yet.
+          </div>
+        </section>"""
 
     labels = {
         "facts": "Facts",
@@ -458,24 +471,46 @@ def _render_reorient_mode(sections: dict[str, list[dict]]) -> str:
         "recent_deltas": "Recent deltas",
         "open_loops": "Open loops",
     }
+    groups = [
+        ("where-am-i", "Where am I?", ("facts", "inferences")),
+        ("what-changed", "What changed?", ("recent_deltas", "stale_context")),
+        ("what-next", "What next?", ("candidates", "open_loops")),
+    ]
     section_html: list[str] = []
-    for name, label in labels.items():
-        items = sections.get(name) or []
+    for group_id, group_label, section_names in groups:
         rows: list[str] = []
-        for item in items:
-            handoff = ""
-            if item.get("panel_handoff"):
-                handoff = (
-                    '<button type="button" class="reorient-panel-handoff" '
-                    'data-testid="reorient-panel-handoff" '
-                    'data-intent="reorient.panelHandoff" '
-                    'data-affordance-status="unavailable" '
-                    'data-runtime-backed="false" '
-                    'aria-disabled="true" disabled>Panel unavailable</button>'
-                )
-            rows.append(
-                f"""
-              <li class="reorient-item" data-testid="reorient-item">
+        for name in section_names:
+            items = sections.get(name) or []
+            if not items:
+                continue
+            item_kind = {
+                "facts": "fact",
+                "inferences": "inference",
+                "candidates": "candidate",
+                "stale_context": "stale-caution",
+                "recent_deltas": "recent-delta",
+                "open_loops": "open-loop",
+            }[name]
+            for item in items:
+                handoff = ""
+                if item.get("panel_handoff"):
+                    handoff = (
+                        '<button type="button" class="reorient-panel-handoff" '
+                        'data-testid="reorient-panel-handoff" '
+                        'data-intent="reorient.panelHandoff" '
+                        'data-affordance-status="read-only" '
+                        'data-runtime-backed="false" '
+                        'aria-disabled="true" disabled>'
+                        "Panel handoff candidate</button>"
+                    )
+                rows.append(
+                    f"""
+              <li
+                class="reorient-item"
+                data-testid="reorient-item"
+                data-reorient-section="{_e(name)}"
+                data-reorient-kind="{_e(item_kind)}">
+                <span class="reorient-kind" data-testid="reorient-kind">{_e(labels[name])}</span>
                 <span class="reorient-item-label">{_e(item.get("label", ""))}</span>
                 <a
                   class="reorient-source"
@@ -486,19 +521,23 @@ def _render_reorient_mode(sections: dict[str, list[dict]]) -> str:
                 </a>
                 {handoff}
               </li>"""
-            )
+                )
         section_html.append(
             f"""
             <section
               class="reorient-section"
               data-testid="reorient-section"
-              data-reorient-section="{_e(name)}">
-              <div class="reorient-section-title">{_e(label)}</div>
+              data-reorient-group="{_e(group_id)}">
+              <div class="reorient-section-title">{_e(group_label)}</div>
               <ul class="reorient-list">{"".join(rows)}</ul>
             </section>"""
         )
     return f"""
-        <section class="reorient-mode" data-testid="reorient-mode">
+        <section
+          class="reorient-mode"
+          data-testid="reorient-mode"
+          data-affordance-status="read-only"
+          data-capability="reorient">
           <div class="rail-state-row">
             <span class="rail-state-label">Reorient</span>
             <span class="rail-state-value">read-only</span>

--- a/tests/companion_ui/test_reorient_mode_browser.py
+++ b/tests/companion_ui/test_reorient_mode_browser.py
@@ -89,6 +89,14 @@ def test_orientation_fields_rendered() -> None:
     html = _render_reorient()
 
     assert 'data-testid="reorient-mode"' in html
+    assert 'data-affordance-status="read-only"' in html
+    assert 'data-capability="reorient"' in html
+    assert 'data-reorient-group="where-am-i"' in html
+    assert 'data-reorient-group="what-changed"' in html
+    assert 'data-reorient-group="what-next"' in html
+    assert "Where am I?" in html
+    assert "What changed?" in html
+    assert "What next?" in html
     assert 'data-reorient-section="facts"' in html
     assert 'data-reorient-section="inferences"' in html
     assert 'data-reorient-section="candidates"' in html
@@ -97,6 +105,19 @@ def test_orientation_fields_rendered() -> None:
     assert 'data-reorient-section="open_loops"' in html
     assert "Last leave-point came from runtime activity." in html
     assert "One promotion intent remains open." in html
+
+
+def test_reorient_kinds_distinguish_facts_inferences_candidates_and_stale_context() -> None:
+    html = _render_reorient()
+
+    assert 'data-reorient-kind="fact"' in html
+    assert 'data-reorient-kind="inference"' in html
+    assert 'data-reorient-kind="candidate"' in html
+    assert 'data-reorient-kind="stale-caution"' in html
+    assert 'data-reorient-kind="recent-delta"' in html
+    assert 'data-reorient-kind="open-loop"' in html
+    assert "Stale context" in html
+    assert "Candidates" in html
 
 
 def test_source_links_present() -> None:
@@ -112,6 +133,30 @@ def test_panel_handoff() -> None:
 
     assert 'data-testid="reorient-panel-handoff"' in html
     assert 'data-intent="reorient.panelHandoff"' in html
+    assert 'data-affordance-status="read-only"' in html
+    assert 'data-runtime-backed="false"' in html
+    assert "Panel handoff candidate" in html
+
+
+def test_reorient_empty_state_visible() -> None:
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="Notes/reorient.md",
+        fields={
+            "title": "Reorient Note",
+            "note_path": "Notes/reorient.md",
+            "artifact_id": "art-1141",
+            "content_hash": "hash-reorient",
+            "body": "# Reorient Note",
+            "panel_rail": "Panel ready",
+            "reorient_sections": {},
+            "guard_canvas_enabled": True,
+            "guard_writeguard_status": "ok",
+        },
+    )
+
+    assert 'data-testid="reorient-empty-state"' in html
+    assert "no orientation payload is available" in html
 
 
 def test_workspace_reorient_failure_degrades_without_blocking_note_load(


### PR DESCRIPTION
Fixes #1185

## Summary

Implement the Reorient daily recovery view in the current server-rendered Companion workspace shell.

The PR maps existing runtime Reorient sections into three read-only recovery groups: `Where am I?`, `What changed?`, and `What next?`. It preserves facts, inferences, candidates, stale context, recent deltas, and open-loop distinctions through stable markers, keeps Panel handoff as read-only candidate display, and renders an explicit empty/degraded state when no orientation payload is available.

## Files changed

- `companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py`
- `tests/companion_ui/test_reorient_mode_browser.py`

## Authority / guardrail notes

- Reorient remains read-side only.
- No direct mutation, confirmation, or vault write behavior was added.
- Panel handoff remains non-runtime-backed/read-only unless a separate runtime staging path exists.
- Stale context is rendered as caution metadata, not an error.
- Candidates and open loops are displayed as candidates/open loops, not confirmed actions.

## Tests run

```bash
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_reorient_mode_browser.py tests/api/test_companion_workspace_api.py
/Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/ruff check app tests companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
python3 scripts/docs_guard.py
git diff --check
```

Results:

- targeted pytest: `20 passed`
- ruff: `All checks passed!`
- docs guard: `Docs guard: OK`
- `git diff --check`: clean

## Workflow notes

- Issue contract maintenance was applied before implementation: #1185 was updated with inline `Verify:` markers, and Project status was corrected from `Backlog` to `Ready` before claim.

## Known limitations

- This slice does not add a runtime staging endpoint for Reorient Panel handoff.
- Reorient remains a read-side recovery view, not an execution surface.
