### PR TITLE
companion-ui: clean up Resurface read-only state

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -208,7 +208,10 @@ def _render_note_section(fields: dict) -> str:
     )
     find_mode_html = _render_find_mode(fields.get("find_candidates") or [])
     reorient_mode_html = _render_reorient_mode(fields.get("reorient_sections") or {})
-    resurface_mode_html = _render_resurface_mode(fields.get("resurface_candidates") or [])
+    resurface_mode_html = _render_resurface_mode(
+        fields.get("resurface_candidates") or [],
+        degraded=guard_degraded,
+    )
     act_mode_html = _render_act_mode(
         proposals=fields.get("panel_proposals") or [],
         response=fields.get("panel_last_response") or {},
@@ -546,9 +549,31 @@ def _render_reorient_mode(sections: dict[str, list[dict]]) -> str:
         </section>"""
 
 
-def _render_resurface_mode(candidates: list[dict]) -> str:
+def _render_resurface_mode(candidates: list[dict], *, degraded: bool = False) -> str:
     if not candidates:
-        return ""
+        affordance_status = "unavailable" if degraded else "read-only"
+        state_label = "degraded" if degraded else "empty"
+        state_testid = "resurface-degraded-state" if degraded else "resurface-empty-state"
+        state_copy = (
+            "Resurface is degraded because the runtime reported degraded guard state; "
+            "no candidate payload is actionable here."
+            if degraded
+            else "No Resurface candidates are available for this note. Nothing needs action here."
+        )
+        return f"""
+        <section
+          class="resurface-mode"
+          data-testid="resurface-mode"
+          data-affordance-status="{affordance_status}"
+          data-capability="resurface">
+          <div class="rail-state-row">
+            <span class="rail-state-label">Resurface</span>
+            <span class="rail-state-value">{state_label}</span>
+          </div>
+          <div class="resurface-empty" data-testid="{state_testid}">
+            {state_copy}
+          </div>
+        </section>"""
     rows: list[str] = []
     for candidate in candidates:
         signals = "".join(
@@ -565,8 +590,9 @@ def _render_resurface_mode(candidates: list[dict]) -> str:
                 f'data-intent="resurface.{intent}" '
                 'data-affordance-status="unavailable" '
                 'data-runtime-backed="false" '
+                'data-persistence-backed="false" '
                 'aria-disabled="true" disabled>'
-                f"{label} unavailable</button>"
+                f"{label} unavailable (no persistence)</button>"
             )
             for intent, label in (
                 ("dismiss", "Dismiss"),
@@ -579,8 +605,12 @@ def _render_resurface_mode(candidates: list[dict]) -> str:
           <article
             class="resurface-candidate"
             data-testid="resurface-candidate"
+            data-affordance-status="read-only"
+            data-runtime-backed="true"
             data-candidate-id="{_e(candidate.get("candidate_id", ""))}">
-            <div class="resurface-title">{_e(candidate.get("label", ""))}</div>
+            <div class="resurface-title" data-testid="resurface-candidate-label">
+              {_e(candidate.get("label", ""))}
+            </div>
             <div class="resurface-why" data-testid="resurface-why-now">
               {_e(candidate.get("why_now", ""))}
             </div>

--- a/companion-ui/docs/MLP_CAPABILITY_MATRIX.md
+++ b/companion-ui/docs/MLP_CAPABILITY_MATRIX.md
@@ -90,10 +90,10 @@ Out of scope:
 | Display Panel block reason | `runtime_read`, `render_only`, `receipt_bearing`, `experimental` | Panel confirm response and workspace panel state expose block reason. | Blocked state must remain visible. |
 | Render Reorient sections | `runtime_read`, `render_only`, `experimental` | Workspace API calls orientation runtime and maps facts/inferences/candidates/stale context. | Read-side recovery only. |
 | Reorient Panel handoff | `render_only`, `unavailable`, `experimental` | Shell can render a Panel handoff button from payload marker. | No distinct durable handoff behavior is claimed in current MLP. |
-| Render Resurface candidates | `runtime_read`, `render_only`, `experimental` | Workspace API calls read-only resurfacing runtime and shell renders candidates. | Low-pressure candidate display; no urgency unless payload says so. |
-| Resurface dismiss | `render_only`, `unavailable` | Shell renders a dismiss control; no persistence endpoint is present in current MLP. | Must not look durable until persistence exists. |
-| Resurface snooze | `render_only`, `unavailable` | Shell renders a snooze control; no persistence endpoint is present in current MLP. | Must not look durable until persistence exists. |
-| Resurface pin | `render_only`, `unavailable` | Shell renders a pin control; no persistence endpoint is present in current MLP. | Must not look durable until persistence exists. |
+| Render Resurface candidates | `runtime_read`, `render_only`, `experimental` | Workspace API calls read-only resurfacing runtime and shell renders candidates, empty state, or degraded state. | Low-pressure candidate display; no urgency unless payload says so. |
+| Resurface dismiss | `render_only`, `unavailable` | Shell renders a disabled dismiss control; no persistence endpoint is present in current MLP. | Explicitly marked unavailable and not persistence-backed until persistence exists. |
+| Resurface snooze | `render_only`, `unavailable` | Shell renders a disabled snooze control; no persistence endpoint is present in current MLP. | Explicitly marked unavailable and not persistence-backed until persistence exists. |
+| Resurface pin | `render_only`, `unavailable` | Shell renders a disabled pin control; no persistence endpoint is present in current MLP. | Explicitly marked unavailable and not persistence-backed until persistence exists. |
 | Render Find candidates | `render_only`, `unavailable`, `experimental` | Shell can render candidates if a payload exists, but workspace aggregate does not provide a full Find backend payload today. | Candidate display only; no full search product claim. |
 | Find unavailable state | `render_only`, `unavailable` | Required MLP state for missing backend payload. | Should be explicit rather than silent absence. |
 | Production launch profile | `unavailable`, `experimental` | Dev server documents port/bind defaults; production safety issue #1188 remains open. | Not `production_ready` until #1188 defines and verifies launch safety. |
@@ -108,14 +108,13 @@ Out of scope:
 - Panel confirmation uses `POST /api/panel/confirm`; runtime owns policy, WriteGuard, idempotency, events, receipts, and durable projection.
 - Reorient and Resurface are read-side in the current workspace shell.
 - Find candidate rendering exists as a shell capability, but no full backend Find payload is claimed by this matrix.
-- Resurface dismiss/snooze/pin controls are currently not backed by durable persistence and must be treated as unavailable/read-only.
+- Resurface dismiss/snooze/pin controls are currently not backed by durable persistence and render as unavailable/not persistence-backed.
 
 ## Known MLP gaps
 
 - No capability in this matrix is marked `production_ready`.
 - Vault/channel identity is not yet exposed as a dedicated safe read-only workspace field.
 - Find unavailable and empty states still need explicit UI treatment under #1187.
-- Resurface dismiss/snooze/pin need read-only/unavailable treatment under #1186 unless persistence exists by then.
 - Affordance status markers for all major rail cards/actionable sections are handled by #1179.
 - Real-note shell metadata and runtime/channel identity polish are handled by #1182.
 - Canvas recovery/conflict acknowledgement is currently local/volatile in the shell.

--- a/tests/companion_ui/test_resurface_mode_browser.py
+++ b/tests/companion_ui/test_resurface_mode_browser.py
@@ -67,6 +67,9 @@ def test_why_now_explanation() -> None:
 
     assert 'data-testid="resurface-mode"' in html
     assert 'data-testid="resurface-candidate"' in html
+    assert 'data-testid="resurface-candidate-label"' in html
+    assert 'data-affordance-status="read-only"' in html
+    assert 'data-runtime-backed="true"' in html
     assert 'data-testid="resurface-why-now"' in html
     assert "Derived relevance changed" in html
     assert "should act now" not in html.lower()
@@ -94,9 +97,11 @@ def test_resurface_actions_marked_read_only_or_unavailable_without_persistence()
     assert 'data-testid="resurface-action-pin"' in html
     assert html.count('data-affordance-status="unavailable"') >= 3
     assert html.count('data-runtime-backed="false"') >= 3
+    assert html.count('data-persistence-backed="false"') >= 3
     assert "Dismiss unavailable" in html
     assert "Snooze unavailable" in html
     assert "Pin unavailable" in html
+    assert "no persistence" in html
 
 
 def test_relation_to_active_artifact() -> None:
@@ -155,3 +160,62 @@ def test_workspace_resurface_source_link_uses_logical_identifier(
     candidate = response.runtime.resurface["candidates"][0]
     assert candidate["source_link"] == "status.worker_queue"
     assert "secret" not in str(candidate)
+
+
+class _EmptyResurfaceClient:
+    def __init__(self, *, degraded: bool = False) -> None:
+        self.degraded = degraded
+
+    def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        assert url == "/api/companion/workspace"
+        assert params == {"note_path": "Notes/resurface.md"}
+        return {
+            "artifact": {
+                "artifact_id": "art-1186",
+                "note_path": "Notes/resurface.md",
+                "title": "Resurface Note",
+                "body": "# Resurface Note",
+                "content_hash": "hash-resurface-empty",
+            },
+            "canvas": {"session_state": "idle", "can_edit_body": False},
+            "panel": {"state": "idle", "proposal_count": 0},
+            "guards": {
+                "canvas_enabled": True,
+                "writeguard_status": "ok",
+                "degraded": self.degraded,
+            },
+            "runtime": {"resurface": {"candidates": []}},
+            "suggestions": {},
+        }
+
+
+def _render_empty_resurface(*, degraded: bool = False) -> str:
+    page = RealNoteWorkspaceDevPage(_EmptyResurfaceClient(degraded=degraded))  # type: ignore[arg-type]
+    state = page.load(NoteLoadIntent(note_path="Notes/resurface.md"))
+    assert state.is_loaded is True
+    fields = page.render_fields()
+    assert fields is not None
+    return render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="Notes/resurface.md",
+        fields=fields,
+    )
+
+
+def test_resurface_empty_state_is_visible() -> None:
+    html = _render_empty_resurface()
+
+    assert 'data-testid="resurface-mode"' in html
+    assert 'data-testid="resurface-empty-state"' in html
+    assert 'data-affordance-status="read-only"' in html
+    assert "No Resurface candidates are available" in html
+    assert "Nothing needs action" in html
+
+
+def test_resurface_degraded_state_is_visible() -> None:
+    html = _render_empty_resurface(degraded=True)
+
+    assert 'data-testid="resurface-mode"' in html
+    assert 'data-testid="resurface-degraded-state"' in html
+    assert 'data-affordance-status="unavailable"' in html
+    assert "runtime reported degraded guard state" in html


### PR DESCRIPTION
Fixes #1186

## Summary
- Keep the Resurface rail visible when no candidates exist, with explicit empty and degraded states.
- Mark Resurface candidates as read-only runtime-backed display and dismiss/snooze/pin as unavailable, non-runtime-backed, and not persistence-backed.
- Update the MLP capability matrix to reflect the shipped Resurface read-only treatment.

## Files changed
- `companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py`
- `tests/companion_ui/test_resurface_mode_browser.py`
- `companion-ui/docs/MLP_CAPABILITY_MATRIX.md`

## Authority / guardrail notes
- Resurface remains read-side only.
- No persistence endpoint, action endpoint, API schema, source-of-truth semantics, or direct vault write path was added.
- Dismiss/snooze/pin remain disabled display controls until runtime-backed persistence exists.

## Tests run
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_resurface_mode_browser.py tests/api/test_companion_workspace_api.py` -> `21 passed`
- `/Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/ruff check app tests companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py` -> `All checks passed!`
- `python3 scripts/docs_guard.py` -> `Docs guard: OK`
- `git diff --check` -> clean

## Known limitations
- Resurface persistence for dismiss/snooze/pin remains unavailable by design in this issue.
- Resurface urgency is not inferred locally; the shell only displays runtime-provided candidate context.