### PR TITLE
feat(agent-memory): add memory candidate review queue (#1080)

### DIFF
--- a/app/agent_memory/review_queue.py
+++ b/app/agent_memory/review_queue.py
@@ -1,0 +1,210 @@
+"""Memory candidate review queue (AGENT-MEMORY-02).
+
+Pure-domain review surface that holds :class:`MemoryCandidate` entries until a
+reviewer records an explicit decision (promote, reject, or revise). Implements
+the boundary required by
+``docs/AGENT_MEMORY/ADD_MEMORY_CANDIDATE_REVIEW_QUEUE.md`` and the
+hidden-authority guard in
+``docs/CONTEXTUALIZATION_LAYER/CONTEXT_ACTIVATION_SEMANTICS.md`` §7: unreviewed
+candidates are never authorized for working-context recall.
+
+This module deliberately ships no storage backend, API surface, prompt wiring,
+or activation engine. Promotion storage semantics, recall explanation
+rendering, and write-authority enforcement are owned by later slices
+(#1081, #1082, #1083).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.agent_memory.candidate import MemoryCandidate, MemoryType
+
+
+class ReviewDecision(str, Enum):
+    PROMOTE = "promote"
+    REJECT = "reject"
+    REVISE = "revise"
+
+
+class ReviewStatus(str, Enum):
+    PENDING = "pending"
+    PROMOTED = "promoted"
+    REJECTED = "rejected"
+    REVISED = "revised"
+
+
+class ReviewQueueError(Exception):
+    """Raised when a review queue operation violates an explicit invariant."""
+
+
+class ReviewEntry(BaseModel):
+    """A candidate's review-surface projection.
+
+    ``status``, ``decision``, ``decided_by``, and ``decided_at`` reflect the
+    explicit review decision recorded for the underlying candidate. The
+    embedded :class:`MemoryCandidate` is the source of provenance and proposed
+    memory class — those fields are surfaced via read-only properties so that
+    the review surface preserves them without duplicating the candidate shape.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    candidate: MemoryCandidate
+    status: ReviewStatus = Field(default=ReviewStatus.PENDING)
+    decision: Optional[ReviewDecision] = None
+    decided_by: Optional[str] = None
+    decided_at: Optional[datetime] = None
+    decision_notes: Optional[str] = None
+    revision_of: Optional[str] = None
+
+    @property
+    def candidate_id(self) -> str:
+        return self.candidate.candidate_id
+
+    @property
+    def title(self) -> str:
+        return self.candidate.title
+
+    @property
+    def content(self) -> Optional[str]:
+        return self.candidate.content
+
+    @property
+    def source_refs(self) -> list[str]:
+        return list(self.candidate.source_refs)
+
+    @property
+    def derived_from(self) -> Optional[str]:
+        return self.candidate.derived_from
+
+    @property
+    def generated_by(self) -> Optional[str]:
+        return self.candidate.generated_by
+
+    @property
+    def proposed_memory_type(self) -> MemoryType:
+        return self.candidate.memory_type
+
+    @property
+    def inferred(self) -> bool:
+        return self.candidate.inferred
+
+    @property
+    def review_posture(self) -> str:
+        if self.status is not ReviewStatus.PENDING:
+            return "decided"
+        return "inferred" if self.candidate.inferred else "asserted"
+
+
+_DECISION_TO_STATUS: dict[ReviewDecision, ReviewStatus] = {
+    ReviewDecision.PROMOTE: ReviewStatus.PROMOTED,
+    ReviewDecision.REJECT: ReviewStatus.REJECTED,
+    ReviewDecision.REVISE: ReviewStatus.REVISED,
+}
+
+
+class MemoryCandidateReviewQueue:
+    """In-memory review queue for memory candidates awaiting decision."""
+
+    def __init__(self) -> None:
+        self._entries: dict[str, ReviewEntry] = {}
+
+    def enqueue(self, candidate: MemoryCandidate) -> ReviewEntry:
+        if candidate.candidate_id in self._entries:
+            raise ReviewQueueError(
+                f"candidate already in queue: {candidate.candidate_id}"
+            )
+        entry = ReviewEntry(candidate=candidate)
+        self._entries[candidate.candidate_id] = entry
+        return entry
+
+    def get(self, candidate_id: str) -> ReviewEntry:
+        try:
+            return self._entries[candidate_id]
+        except KeyError as exc:
+            raise ReviewQueueError(f"no candidate in queue: {candidate_id}") from exc
+
+    def pending(self) -> list[ReviewEntry]:
+        return [e for e in self._entries.values() if e.status is ReviewStatus.PENDING]
+
+    def decided(self) -> list[ReviewEntry]:
+        return [e for e in self._entries.values() if e.status is not ReviewStatus.PENDING]
+
+    def decide(
+        self,
+        candidate_id: str,
+        decision: ReviewDecision,
+        *,
+        decided_by: str,
+        notes: Optional[str] = None,
+        revision: Optional[MemoryCandidate] = None,
+    ) -> ReviewEntry:
+        """Record an explicit review decision for ``candidate_id``.
+
+        ``decided_by`` is required: a review decision must name its reviewer
+        (human ID, policy identifier, or system reviewer ID). Empty values are
+        refused because they collapse the human-decision boundary the queue
+        exists to enforce.
+
+        ``ReviewDecision.REVISE`` requires a revised :class:`MemoryCandidate`
+        which is enqueued as a new pending entry whose ``revision_of`` points
+        back to the original candidate. The original entry transitions to
+        ``REVISED`` so its evidence remains inspectable.
+        """
+
+        if not decided_by:
+            raise ReviewQueueError(
+                "decided_by is required to record a review decision"
+            )
+
+        entry = self.get(candidate_id)
+        if entry.status is not ReviewStatus.PENDING:
+            raise ReviewQueueError(
+                f"candidate already decided: {candidate_id}"
+            )
+
+        if decision is ReviewDecision.REVISE:
+            if revision is None:
+                raise ReviewQueueError(
+                    "revise requires a revised MemoryCandidate payload"
+                )
+            if revision.candidate_id in self._entries:
+                raise ReviewQueueError(
+                    f"revision candidate id already in queue: {revision.candidate_id}"
+                )
+            revision_entry = ReviewEntry(
+                candidate=revision,
+                status=ReviewStatus.PENDING,
+                revision_of=candidate_id,
+            )
+            self._entries[revision.candidate_id] = revision_entry
+
+        updated = entry.model_copy(
+            update={
+                "status": _DECISION_TO_STATUS[decision],
+                "decision": decision,
+                "decided_by": decided_by,
+                "decided_at": datetime.now(timezone.utc),
+                "decision_notes": notes,
+            }
+        )
+        self._entries[candidate_id] = updated
+        return updated
+
+    def recallable_for_working_context(self) -> list[ReviewEntry]:
+        """Entries authorized for working-context recall.
+
+        Per the hidden-authority guard in
+        ``docs/CONTEXTUALIZATION_LAYER/CONTEXT_ACTIVATION_SEMANTICS.md`` §7,
+        only entries with an explicit PROMOTE decision are authorized for
+        agent working-context recall by this surface. Unreviewed and rejected
+        entries are excluded; revised entries hand authority to the revised
+        successor, which must itself be reviewed.
+        """
+
+        return [e for e in self._entries.values() if e.status is ReviewStatus.PROMOTED]

--- a/app/agent_memory/review_queue.py
+++ b/app/agent_memory/review_queue.py
@@ -33,6 +33,9 @@ class ReviewDecision(str, Enum):
 
 class ReviewStatus(str, Enum):
     PENDING = "pending"
+    # PROMOTED means the review queue recorded a promote decision for this candidate.
+    # It does not mean a durable promoted memory artifact has been created —
+    # durable promotion semantics and storage are owned by #1081.
     PROMOTED = "promoted"
     REJECTED = "rejected"
     REVISED = "revised"
@@ -147,9 +150,9 @@ class MemoryCandidateReviewQueue:
         """Record an explicit review decision for ``candidate_id``.
 
         ``decided_by`` is required: a review decision must name its reviewer
-        (human ID, policy identifier, or system reviewer ID). Empty values are
-        refused because they collapse the human-decision boundary the queue
-        exists to enforce.
+        (human ID, policy identifier, or system reviewer ID). Empty or
+        whitespace-only values are refused because they collapse the
+        human-decision boundary the queue exists to enforce.
 
         ``ReviewDecision.REVISE`` requires a revised :class:`MemoryCandidate`
         which is enqueued as a new pending entry whose ``revision_of`` points
@@ -157,7 +160,7 @@ class MemoryCandidateReviewQueue:
         ``REVISED`` so its evidence remains inspectable.
         """
 
-        if not decided_by:
+        if not decided_by.strip():
             raise ReviewQueueError(
                 "decided_by is required to record a review decision"
             )

--- a/tests/agent_memory/test_memory_candidate_review_queue.py
+++ b/tests/agent_memory/test_memory_candidate_review_queue.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import pytest
+
+from app.agent_memory.candidate import (
+    ContradictionState,
+    MemoryCandidate,
+    MemoryType,
+    ReviewState,
+)
+from app.agent_memory.review_queue import (
+    MemoryCandidateReviewQueue,
+    ReviewDecision,
+    ReviewQueueError,
+    ReviewStatus,
+)
+
+
+def _candidate(
+    *,
+    title: str = "Observed user preference",
+    memory_type: MemoryType = MemoryType.PREFERENCE_MEMORY,
+    inferred: bool = True,
+    content: str = "User answered tersely in two consecutive sessions.",
+) -> MemoryCandidate:
+    return MemoryCandidate(
+        title=title,
+        memory_type=memory_type,
+        inferred=inferred,
+        content=content,
+        source_refs=["session:2026-05-21T09:00:00Z"],
+        derived_from="conversation:abc123",
+        generated_by="companion_agent",
+    )
+
+
+def test_review_queue_requires_human_decision() -> None:
+    queue = MemoryCandidateReviewQueue()
+    candidate = _candidate()
+
+    entry = queue.enqueue(candidate)
+
+    assert entry.status is ReviewStatus.PENDING
+    assert entry.decision is None
+    assert entry.decided_by is None
+    assert entry.decided_at is None
+    assert entry.candidate.review_state is ReviewState.UNREVIEWED
+
+    pending = queue.pending()
+    assert [e.candidate_id for e in pending] == [candidate.candidate_id]
+    assert queue.decided() == []
+
+    # An entry is only promoted when a reviewer makes an explicit decision.
+    # Calling decide(..., decided_by="") is not a real decision and must be refused.
+    with pytest.raises(ReviewQueueError):
+        queue.decide(candidate.candidate_id, ReviewDecision.PROMOTE, decided_by="")
+
+    # Without a recorded decision the queue continues to treat the candidate as pending.
+    assert queue.get(candidate.candidate_id).status is ReviewStatus.PENDING
+
+    decided = queue.decide(
+        candidate.candidate_id,
+        ReviewDecision.PROMOTE,
+        decided_by="reviewer:rasmus",
+        notes="Confirmed in latest session.",
+    )
+
+    assert decided.status is ReviewStatus.PROMOTED
+    assert decided.decision is ReviewDecision.PROMOTE
+    assert decided.decided_by == "reviewer:rasmus"
+    assert decided.decided_at is not None
+
+    # A decided entry cannot be silently re-decided.
+    with pytest.raises(ReviewQueueError):
+        queue.decide(
+            candidate.candidate_id,
+            ReviewDecision.REJECT,
+            decided_by="reviewer:rasmus",
+        )
+
+
+def test_review_queue_exposes_candidate_provenance_and_class() -> None:
+    queue = MemoryCandidateReviewQueue()
+    candidate = _candidate(
+        title="Proposed semantic fact about user domain",
+        memory_type=MemoryType.SEMANTIC_MEMORY,
+        inferred=True,
+        content="User works in clinical genomics tooling.",
+    )
+
+    entry = queue.enqueue(candidate)
+
+    assert entry.title == "Proposed semantic fact about user domain"
+    assert entry.content == "User works in clinical genomics tooling."
+    assert entry.proposed_memory_type is MemoryType.SEMANTIC_MEMORY
+    assert entry.source_refs == ["session:2026-05-21T09:00:00Z"]
+    assert entry.derived_from == "conversation:abc123"
+    assert entry.generated_by == "companion_agent"
+    # Inferred-vs-reviewed posture must remain visible during review.
+    assert entry.inferred is True
+    assert entry.review_posture == "inferred"
+    # Proposed class must not be presented as a promoted/authoritative class.
+    assert entry.candidate.review_state is ReviewState.UNREVIEWED
+    assert entry.status is ReviewStatus.PENDING
+
+    asserted_candidate = MemoryCandidate(
+        title="User explicitly stated preference",
+        memory_type=MemoryType.PREFERENCE_MEMORY,
+        source_refs=["note:explicit-preference.md"],
+        derived_from="vault:notes/preferences.md",
+        generated_by="human",
+        inferred=False,
+    )
+    asserted_entry = queue.enqueue(asserted_candidate)
+    assert asserted_entry.inferred is False
+    assert asserted_entry.review_posture == "asserted"
+
+
+def test_review_queue_supports_promote_reject_and_revise() -> None:
+    queue = MemoryCandidateReviewQueue()
+
+    promote_c = _candidate(title="Promote me")
+    reject_c = _candidate(title="Reject me")
+    revise_c = _candidate(title="Revise me", content="Single-session bias.")
+
+    queue.enqueue(promote_c)
+    queue.enqueue(reject_c)
+    queue.enqueue(revise_c)
+
+    promoted = queue.decide(
+        promote_c.candidate_id,
+        ReviewDecision.PROMOTE,
+        decided_by="reviewer:rasmus",
+    )
+    rejected = queue.decide(
+        reject_c.candidate_id,
+        ReviewDecision.REJECT,
+        decided_by="reviewer:rasmus",
+        notes="Observation was a one-off; not a stable preference.",
+    )
+
+    revision_candidate = MemoryCandidate(
+        title="Revised: user prefers detailed responses on technical topics",
+        memory_type=MemoryType.PREFERENCE_MEMORY,
+        source_refs=["session:2026-05-21T10:00:00Z"],
+        derived_from="conversation:def456",
+        generated_by="companion_agent",
+        inferred=True,
+        contradiction_state=ContradictionState.CONTRADICTED,
+        correction_of=revise_c.candidate_id,
+        contradiction_notes="Later sessions contradict the original observation.",
+    )
+    revised = queue.decide(
+        revise_c.candidate_id,
+        ReviewDecision.REVISE,
+        decided_by="reviewer:rasmus",
+        notes="Narrowed to technical-topic preference.",
+        revision=revision_candidate,
+    )
+
+    assert promoted.status is ReviewStatus.PROMOTED
+    assert rejected.status is ReviewStatus.REJECTED
+    assert revised.status is ReviewStatus.REVISED
+    assert {promoted.decision, rejected.decision, revised.decision} == {
+        ReviewDecision.PROMOTE,
+        ReviewDecision.REJECT,
+        ReviewDecision.REVISE,
+    }
+
+    # Rejection is preserved with reason; it is not silent deletion.
+    assert rejected.decision_notes is not None
+    assert queue.get(reject_c.candidate_id).status is ReviewStatus.REJECTED
+
+    # Revision preserves prior evidence: original entry is still recoverable as REVISED,
+    # and the revised candidate enters the queue as a new pending entry that references
+    # the prior candidate.
+    revised_entry = queue.get(revision_candidate.candidate_id)
+    assert revised_entry.status is ReviewStatus.PENDING
+    assert revised_entry.revision_of == revise_c.candidate_id
+    assert revised_entry.candidate.correction_of == revise_c.candidate_id
+
+    # Revise requires an explicit revised candidate; calling without one is refused.
+    other = _candidate(title="No revision payload")
+    queue.enqueue(other)
+    with pytest.raises(ReviewQueueError):
+        queue.decide(
+            other.candidate_id,
+            ReviewDecision.REVISE,
+            decided_by="reviewer:rasmus",
+        )
+
+
+def test_review_queue_does_not_authorize_unreviewed_recall() -> None:
+    queue = MemoryCandidateReviewQueue()
+    unreviewed = _candidate(title="Unreviewed observation")
+    to_reject = _candidate(title="Rejected observation")
+    to_promote = _candidate(title="Confirmed preference", inferred=False)
+
+    queue.enqueue(unreviewed)
+    queue.enqueue(to_reject)
+    queue.enqueue(to_promote)
+
+    # Before any review, no candidate is recallable as authoritative working-context memory.
+    assert queue.recallable_for_working_context() == []
+
+    queue.decide(
+        to_reject.candidate_id,
+        ReviewDecision.REJECT,
+        decided_by="reviewer:rasmus",
+        notes="Not a real preference.",
+    )
+
+    # A rejected candidate must never become recallable working-context memory.
+    recallable_after_reject = queue.recallable_for_working_context()
+    assert recallable_after_reject == []
+
+    queue.decide(
+        to_promote.candidate_id,
+        ReviewDecision.PROMOTE,
+        decided_by="reviewer:rasmus",
+    )
+
+    recallable_after_promote = queue.recallable_for_working_context()
+    assert [e.candidate_id for e in recallable_after_promote] == [to_promote.candidate_id]
+
+    # The unreviewed candidate, even with high apparent confidence, must remain excluded
+    # from working-context recall until an explicit decision is recorded.
+    assert all(
+        e.candidate_id != unreviewed.candidate_id
+        for e in recallable_after_promote
+    )

--- a/tests/agent_memory/test_memory_candidate_review_queue.py
+++ b/tests/agent_memory/test_memory_candidate_review_queue.py
@@ -51,9 +51,12 @@ def test_review_queue_requires_human_decision() -> None:
     assert queue.decided() == []
 
     # An entry is only promoted when a reviewer makes an explicit decision.
-    # Calling decide(..., decided_by="") is not a real decision and must be refused.
+    # Empty and whitespace-only decided_by values are not real decisions and must be refused.
     with pytest.raises(ReviewQueueError):
         queue.decide(candidate.candidate_id, ReviewDecision.PROMOTE, decided_by="")
+
+    with pytest.raises(ReviewQueueError):
+        queue.decide(candidate.candidate_id, ReviewDecision.PROMOTE, decided_by="   ")
 
     # Without a recorded decision the queue continues to treat the candidate as pending.
     assert queue.get(candidate.candidate_id).status is ReviewStatus.PENDING


### PR DESCRIPTION
Fixes #1080

Parent feature: #900 (referenced as parent context only; not closed by this slice).
Baseline: #1079 / PR #1112 (MemoryCandidate model) inspected and reused.

## Summary

Adds the bounded review surface specified in [docs/AGENT_MEMORY/ADD_MEMORY_CANDIDATE_REVIEW_QUEUE.md](docs/AGENT_MEMORY/ADD_MEMORY_CANDIDATE_REVIEW_QUEUE.md) (AGENT-MEMORY-02). `MemoryCandidateReviewQueue` holds `MemoryCandidate` entries until a reviewer records an explicit promote, reject, or revise decision. Unreviewed candidates are not authorized for working-context recall by this surface.

## Source docs read

- [docs/AGENT_MEMORY/ADD_MEMORY_CANDIDATE_REVIEW_QUEUE.md](docs/AGENT_MEMORY/ADD_MEMORY_CANDIDATE_REVIEW_QUEUE.md)
- [docs/AGENT_MEMORY/DEFINE_MEMORY_CANDIDATE_MODEL.md](docs/AGENT_MEMORY/DEFINE_MEMORY_CANDIDATE_MODEL.md)
- [docs/CONCEPTS/AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT.md](docs/CONCEPTS/AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT.md) — Review and promotion rules; authority rules; lifecycle stages
- [docs/CONTEXTUALIZATION_LAYER/CONTEXT_ACTIVATION_SEMANTICS.md](docs/CONTEXTUALIZATION_LAYER/CONTEXT_ACTIVATION_SEMANTICS.md) §7 — Reviewed vs unreviewed memory (hidden-authority guard)
- [docs/CONTEXTUALIZATION_LAYER/ARTIFACT_LIFECYCLE_MODEL.md](docs/CONTEXTUALIZATION_LAYER/ARTIFACT_LIFECYCLE_MODEL.md) §5.2 — Agentic memory artifacts

## Review comments inspected

PR #1112 inline review comment on `scripts/start_full_system.sh` flagged a `prod|""` branch that silently reinterpreted unset environment state as explicit prod intent (separation already landed in 67a121c). Applied as a general boundary lesson here: the review queue does not invent reviewer identity, does not treat the absence of a decision as a tacit decision, and does not let a candidate's own `review_state` field (which is independently settable on the `MemoryCandidate`) bypass the queue's explicit decide() call. `decide(..., decided_by="")` is refused; pending entries are excluded from `recallable_for_working_context()`; a rejected entry preserves its reason and is never silently re-decided.

## Semantic decisions

- `MemoryCandidateReviewQueue` is a pure-domain object. No storage, API surface, prompt builder, retrieval client, or watcher.
- `ReviewEntry` is frozen and surfaces candidate provenance/class through read-only properties; the embedded `MemoryCandidate` remains the single source of provenance shape (no duplication of #1079).
- Three explicit `ReviewDecision` values (`promote`, `reject`, `revise`) map to three distinct `ReviewStatus` outcomes; double-decision is refused.
- Revise enqueues the revised `MemoryCandidate` as a new pending entry whose `revision_of` references the original. The original transitions to `REVISED` rather than being silently deleted (preserves evidence and provenance per the contract).
- `recallable_for_working_context()` returns only `PROMOTED` entries. This implements the categorical guard from [docs/CONTEXTUALIZATION_LAYER/CONTEXT_ACTIVATION_SEMANTICS.md](docs/CONTEXTUALIZATION_LAYER/CONTEXT_ACTIVATION_SEMANTICS.md) §7.1 ("an unreviewed agentic memory artifact must not become hidden authority") at the review-surface level. It does not claim or alter runtime activation enforcement.
- `artifact_class`, `artifact_type`, `memory_type`, lifecycle state, authority, and provenance remain distinct (not collapsed).

## What was intentionally not implemented

- Storage backend for review entries (Stores/Components layer; later slice).
- Promotion storage and promotion receipts (#1081).
- Recall explanation surfaces (#1082).
- Write-authority / unreviewed-authority enforcement at the recall boundary outside this surface (#1083).
- Companion-note-aware candidate surfacing (#1085).
- Artifact-metadata compatibility with the Contextualization Layer (#1084).
- Any UI rendering, prompt wiring, event emission, or runtime activation.

## Validation

```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/agent_memory/test_memory_candidate_review_queue.py
# 4 passed

PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/agent_memory
# 8 passed (4 new + 4 from #1079)

ruff check app/agent_memory tests/agent_memory   # all checks passed
mypy app/agent_memory                            # success, no issues
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/architecture   # 54 passed
```

Broader `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg"` run completes with 3421 passing. Four failures pre-exist on this baseline and are unrelated to agent memory:

- `tests/agents/panel_agent/test_proposal_only_outputs.py::test_proposal_outputs_remain_bounded`
- `tests/guards/test_no_hardcoded_runtime_defaults.py::test_no_hardcoded_runtime_defaults`
- `tests/quality_wave/test_registry_chain.py::test_registry_chain_contract_and_rerun_idempotence`
- `tests/quality_wave/test_registry_chain.py::test_registry_cold_rebuild_recreates_final_state_from_seed_data`

Each AC `Verify:` target resolves green:

- `test_review_queue_requires_human_decision` ✔
- `test_review_queue_exposes_candidate_provenance_and_class` ✔
- `test_review_queue_supports_promote_reject_and_revise` ✔
- `test_review_queue_does_not_authorize_unreviewed_recall` ✔

## Runtime support posture

This PR ships **model and review-surface behavior only**. It does not claim shipped runtime agent memory: no durable storage, no live recall path, no prompt-builder wiring, no watcher tick, no activation engine. The hidden-authority guard implemented here is a domain-level invariant of the review surface, not a runtime enforcement claim. Statements in `docs/AGENT_MEMORY/*` remain spec-level for everything beyond the candidate model (#1079) and this review surface (#1080).

## Docs writeback

Not needed for this slice. `docs/AGENT_MEMORY/ADD_MEMORY_CANDIDATE_REVIEW_QUEUE.md` is the source-of-truth contract for the review-queue spec; this PR implements that spec without changing it. The doc-level `Implemented by` writeback will land alongside the parent-feature closure path per [docs/development/PARENT_ISSUE_CLOSURE.md](docs/development/PARENT_ISSUE_CLOSURE.md), not in this slice.

## Dispatcher status

Dispatcher unavailable (`python -m app.dispatcher status --json` returned `db_exists: false`). Used GitHub-label-only claim via `scripts/issue_pickup_claim.sh --issue 1080`; `agent:ready` removed before edits per [AGENTS.md](AGENTS.md) fallback path.

---