### PR TITLE
companion-ui: implement Find unavailable and candidate states

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -135,6 +135,7 @@ class DevPageState:
     portrait_sheet: dict[str, Any] | None = None
     keyboard_shortcuts: dict[str, Any] | None = None
     find_candidates: list[dict[str, Any]] | None = None
+    find_payload_available: bool = False
     reorient_sections: dict[str, list[dict[str, Any]]] | None = None
     resurface_candidates: list[dict[str, Any]] | None = None
     suggestion_cards: list[dict[str, Any]] | None = None
@@ -198,7 +199,13 @@ class RealNoteWorkspaceDevPage:
         suggestions = raw.get("suggestions") or {}
         guards = raw.get("guards") or {}
         runtime = raw.get("runtime") or {}
-        find_payload = raw.get("find") or runtime.get("find") or {}
+        raw_find_payload = raw.get("find")
+        runtime_find_payload = runtime.get("find")
+        find_payload_available = isinstance(raw_find_payload, dict) or isinstance(
+            runtime_find_payload,
+            dict,
+        )
+        find_payload = raw_find_payload or runtime_find_payload or {}
         reorient_payload = raw.get("reorient") or runtime.get("reorient") or {}
         resurface_payload = raw.get("resurface") or runtime.get("resurface") or {}
 
@@ -308,6 +315,7 @@ class RealNoteWorkspaceDevPage:
                 rail_state=suggestion_machine.state,
             ),
             find_candidates=_find_candidates_from_payload(find_payload),
+            find_payload_available=find_payload_available,
             reorient_sections=_reorient_sections_from_payload(reorient_payload),
             resurface_candidates=_resurface_candidates_from_payload(resurface_payload),
             suggested_insertions=_suggested_insertions_from_payload(suggestions),
@@ -727,6 +735,7 @@ class RealNoteWorkspaceDevPage:
             "portrait_sheet": self.state.portrait_sheet or {},
             "keyboard_shortcuts": self.state.keyboard_shortcuts or {},
             "find_candidates": self.state.find_candidates or [],
+            "find_payload_available": self.state.find_payload_available,
             "reorient_sections": self.state.reorient_sections or {},
             "resurface_candidates": self.state.resurface_candidates or [],
             "suggestion_cards": self.state.suggestion_cards or [],
@@ -965,6 +974,7 @@ def _find_candidates_from_payload(find_payload: dict[str, Any]) -> list[dict[str
             continue
         payload = raw.get("payload") if isinstance(raw.get("payload"), dict) else {}
         citation = raw.get("citation") or raw.get("source_ref") or payload.get("source_ref")
+        citation_missing = not bool(str(citation or "").strip())
         scope = raw.get("scope") or payload.get("scope") or find_payload.get("scope")
         why = (
             raw.get("why")
@@ -979,9 +989,13 @@ def _find_candidates_from_payload(find_payload: dict[str, Any]) -> list[dict[str
                 "title": str(raw.get("title") or raw.get("doc_id") or raw.get("object_id") or "Source"),
                 "snippet": str(raw.get("snippet") or raw.get("text") or ""),
                 "citation": str(citation or "uncited"),
+                "citation_missing": citation_missing,
                 "scope": str(scope or "workspace"),
                 "why": str(why),
                 "panel_handoff": bool(raw.get("panel_handoff", True)),
+                "panel_handoff_status": str(
+                    raw.get("panel_handoff_status") or "unavailable"
+                ),
             }
         )
     return candidates

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -206,7 +206,10 @@ def _render_note_section(fields: dict) -> str:
     governance_receipts_html = _render_governance_receipts(
         fields.get("governance_receipts") or []
     )
-    find_mode_html = _render_find_mode(fields.get("find_candidates") or [])
+    find_mode_html = _render_find_mode(
+        fields.get("find_candidates") or [],
+        payload_available=bool(fields.get("find_payload_available", False)),
+    )
     reorient_mode_html = _render_reorient_mode(fields.get("reorient_sections") or {})
     resurface_mode_html = _render_resurface_mode(
         fields.get("resurface_candidates") or [],
@@ -388,45 +391,68 @@ def _render_keyboard_shortcuts(shortcuts: dict) -> str:
         </div>"""
 
 
-def _render_find_mode(candidates: list[dict]) -> str:
+def _render_find_mode(candidates: list[dict], *, payload_available: bool = False) -> str:
     if not candidates:
+        state_value = "empty" if payload_available else "unavailable"
+        affordance_status = "read-only" if payload_available else "unavailable"
+        testid = "find-empty-state" if payload_available else "find-unavailable-state"
+        copy = (
+            "Find returned no candidates for this note. This is an empty read-side result, not an action."
+            if payload_available
+            else "Find is unavailable because no backend candidate payload is available yet."
+        )
         return """
         <section
           class="find-mode"
           data-testid="find-mode"
-          data-affordance-status="unavailable"
+          data-affordance-status="{affordance_status}"
           data-capability="find">
           <div class="rail-state-row">
             <span class="rail-state-label">Find</span>
-            <span class="rail-state-value">unavailable</span>
+            <span class="rail-state-value">{state_value}</span>
           </div>
-          <div class="find-unavailable" data-testid="find-unavailable-state">
-            Find is unavailable because no backend candidate payload is available yet.
+          <div class="find-unavailable" data-testid="{testid}">
+            {copy}
           </div>
-        </section>"""
+        </section>""".format(
+            affordance_status=affordance_status,
+            state_value=state_value,
+            testid=testid,
+            copy=copy,
+        )
     rows: list[str] = []
     for candidate in candidates:
         handoff = ""
+        handoff_status = str(candidate.get("panel_handoff_status") or "unavailable")
+        if handoff_status not in {"read-only", "staged", "actionable", "unavailable"}:
+            handoff_status = "unavailable"
         if candidate.get("panel_handoff", True):
             handoff = (
                 '<button type="button" class="find-panel-handoff" '
                 'data-testid="find-panel-handoff" '
                 'data-intent="find.panelHandoff" '
-                'data-affordance-status="unavailable" '
+                f'data-affordance-status="{_e(handoff_status)}" '
                 'data-runtime-backed="false" '
                 'aria-disabled="true" disabled>'
-                "Panel unavailable</button>"
+                f"Panel {handoff_status}</button>"
             )
+        citation_state = "missing" if candidate.get("citation_missing") else "available"
         rows.append(
             f"""
         <article
           class="find-candidate"
           data-testid="find-candidate"
+          data-affordance-status="read-only"
+          data-runtime-backed="true"
           data-candidate-id="{_e(candidate.get("candidate_id", ""))}">
           <div class="find-candidate-title">{_e(candidate.get("title", ""))}</div>
           <div class="find-candidate-snippet">{_e(candidate.get("snippet", ""))}</div>
           <div class="find-candidate-meta">
-            <span data-testid="find-candidate-citation">{_e(candidate.get("citation", ""))}</span>
+            <span
+              data-testid="find-candidate-citation"
+              data-citation-state="{_e(citation_state)}">
+              {_e(candidate.get("citation", ""))}
+            </span>
             <span data-testid="find-candidate-scope">{_e(candidate.get("scope", ""))}</span>
           </div>
           <div class="find-candidate-why" data-testid="find-candidate-why">

--- a/companion-ui/docs/MLP_CAPABILITY_MATRIX.md
+++ b/companion-ui/docs/MLP_CAPABILITY_MATRIX.md
@@ -94,8 +94,8 @@ Out of scope:
 | Resurface dismiss | `render_only`, `unavailable` | Shell renders a disabled dismiss control; no persistence endpoint is present in current MLP. | Explicitly marked unavailable and not persistence-backed until persistence exists. |
 | Resurface snooze | `render_only`, `unavailable` | Shell renders a disabled snooze control; no persistence endpoint is present in current MLP. | Explicitly marked unavailable and not persistence-backed until persistence exists. |
 | Resurface pin | `render_only`, `unavailable` | Shell renders a disabled pin control; no persistence endpoint is present in current MLP. | Explicitly marked unavailable and not persistence-backed until persistence exists. |
-| Render Find candidates | `render_only`, `unavailable`, `experimental` | Shell can render candidates if a payload exists, but workspace aggregate does not provide a full Find backend payload today. | Candidate display only; no full search product claim. |
-| Find unavailable state | `render_only`, `unavailable` | Required MLP state for missing backend payload. | Should be explicit rather than silent absence. |
+| Render Find candidates | `runtime_read`, `render_only`, `experimental` | Shell renders runtime-provided Find candidates, including citation/source marker, scope, why-this-source, missing-citation marker, and empty result state. | Candidate display only; no full search product or memory-promotion claim. |
+| Find unavailable state | `render_only`, `unavailable` | Shell renders unavailable when no backend candidate payload is present. | Distinct from empty results when a payload exists with zero candidates. |
 | Production launch profile | `unavailable`, `experimental` | Dev server documents port/bind defaults; production safety issue #1188 remains open. | Not `production_ready` until #1188 defines and verifies launch safety. |
 
 ## Current implementation notes
@@ -107,14 +107,13 @@ Out of scope:
 - Canvas governance suggestions queue/stage Panel proposals; they do not execute governance mutations from Canvas.
 - Panel confirmation uses `POST /api/panel/confirm`; runtime owns policy, WriteGuard, idempotency, events, receipts, and durable projection.
 - Reorient and Resurface are read-side in the current workspace shell.
-- Find candidate rendering exists as a shell capability, but no full backend Find payload is claimed by this matrix.
+- Find candidate rendering exists as a shell capability for runtime-provided payloads, but no full backend Find/search product is claimed by this matrix.
 - Resurface dismiss/snooze/pin controls are currently not backed by durable persistence and render as unavailable/not persistence-backed.
 
 ## Known MLP gaps
 
 - No capability in this matrix is marked `production_ready`.
 - Vault/channel identity is not yet exposed as a dedicated safe read-only workspace field.
-- Find unavailable and empty states still need explicit UI treatment under #1187.
 - Affordance status markers for all major rail cards/actionable sections are handled by #1179.
 - Real-note shell metadata and runtime/channel identity polish are handled by #1182.
 - Canvas recovery/conflict acknowledgement is currently local/volatile in the shell.

--- a/tests/companion_ui/test_find_mode_browser.py
+++ b/tests/companion_ui/test_find_mode_browser.py
@@ -64,6 +64,8 @@ def test_candidates_with_explanations() -> None:
 
     assert 'data-testid="find-mode"' in html
     assert 'data-testid="find-candidate"' in html
+    assert 'data-affordance-status="read-only"' in html
+    assert 'data-runtime-backed="true"' in html
     assert "Project brief" in html
     assert 'data-testid="find-candidate-why"' in html
     assert "Matched the active artifact title and project tag." in html
@@ -73,6 +75,7 @@ def test_candidate_citation_and_scope() -> None:
     html = _render_find()
 
     assert 'data-testid="find-candidate-citation"' in html
+    assert 'data-citation-state="available"' in html
     assert "Notes/project-brief.md#L12" in html
     assert 'data-testid="find-candidate-scope"' in html
     assert "project" in html
@@ -125,3 +128,96 @@ def test_find_unavailable_state_renders_without_backend_payload() -> None:
     assert 'data-testid="find-unavailable-state"' in html
     assert 'data-affordance-status="unavailable"' in html
     assert "Find is unavailable" in html
+
+
+class _EmptyFindPayloadClient:
+    def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        assert url == "/api/companion/workspace"
+        assert params == {"note_path": "Notes/find.md"}
+        return {
+            "artifact": {
+                "artifact_id": "art-1187-empty",
+                "note_path": "Notes/find.md",
+                "title": "Find Note",
+                "body": "# Find Note",
+                "content_hash": "hash-find-empty",
+            },
+            "canvas": {"session_state": "idle", "can_edit_body": False},
+            "panel": {"state": "idle", "proposal_count": 0},
+            "guards": {"canvas_enabled": True, "writeguard_status": "ok"},
+            "runtime": {"find": {"scope": "active-project", "candidates": []}},
+            "suggestions": {},
+        }
+
+
+def test_find_empty_state_distinct_from_unavailable() -> None:
+    page = RealNoteWorkspaceDevPage(_EmptyFindPayloadClient())  # type: ignore[arg-type]
+    state = page.load(NoteLoadIntent(note_path="Notes/find.md"))
+    assert state.is_loaded is True
+    fields = page.render_fields()
+    assert fields is not None
+
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="Notes/find.md",
+        fields=fields,
+    )
+
+    assert 'data-testid="find-mode"' in html
+    assert 'data-testid="find-empty-state"' in html
+    assert 'data-testid="find-unavailable-state"' not in html
+    assert 'data-affordance-status="read-only"' in html
+    assert "Find returned no candidates" in html
+
+
+class _MissingCitationFindClient:
+    def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        assert url == "/api/companion/workspace"
+        assert params == {"note_path": "Notes/find.md"}
+        return {
+            "artifact": {
+                "artifact_id": "art-1187-uncited",
+                "note_path": "Notes/find.md",
+                "title": "Find Note",
+                "body": "# Find Note",
+                "content_hash": "hash-find-uncited",
+            },
+            "canvas": {"session_state": "idle", "can_edit_body": False},
+            "panel": {"state": "idle", "proposal_count": 0},
+            "guards": {"canvas_enabled": True, "writeguard_status": "ok"},
+            "runtime": {
+                "find": {
+                    "scope": "active-project",
+                    "candidates": [
+                        {
+                            "candidate_id": "uncited-1",
+                            "title": "Uncited source",
+                            "snippet": "Relevant but uncited.",
+                            "why_this_source": "Runtime supplied a candidate without a citation.",
+                            "panel_handoff_status": "read-only",
+                        }
+                    ],
+                }
+            },
+            "suggestions": {},
+        }
+
+
+def test_find_missing_citation_is_marked_clearly() -> None:
+    page = RealNoteWorkspaceDevPage(_MissingCitationFindClient())  # type: ignore[arg-type]
+    state = page.load(NoteLoadIntent(note_path="Notes/find.md"))
+    assert state.is_loaded is True
+    fields = page.render_fields()
+    assert fields is not None
+
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="Notes/find.md",
+        fields=fields,
+    )
+
+    assert 'data-testid="find-candidate-citation"' in html
+    assert 'data-citation-state="missing"' in html
+    assert "uncited" in html
+    assert 'data-affordance-status="read-only"' in html
+    assert "Panel read-only" in html


### PR DESCRIPTION
Fixes #1187

## Summary
- Distinguish missing Find backend payload from an empty Find payload in the workspace shell.
- Render Find candidates with read-only/runtime-backed markers, citation state, scope, why-this-source, and honest Panel handoff status.
- Mark missing citations explicitly and update the capability matrix for the shipped Find read-side behavior.

## Files changed
- `companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py`
- `companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py`
- `tests/companion_ui/test_find_mode_browser.py`
- `companion-ui/docs/MLP_CAPABILITY_MATRIX.md`

## Authority / guardrail notes
- Find remains read-side candidate display.
- No search endpoint, memory promotion flow, durable knowledge promotion, API schema change, or direct vault write path was added.
- Panel handoff is display/status only unless a future runtime-backed contract provides an action path.

## Tests run
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_find_mode_browser.py tests/api/test_companion_workspace_api.py` -> `20 passed`
- `/Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/ruff check app tests companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py` -> `All checks passed!`
- `python3 scripts/docs_guard.py` -> `Docs guard: OK`
- `git diff --check` -> clean

## Known limitations
- This does not build a full retrieval/search product.
- Candidate handoff to Panel remains non-executing display/status in the current MLP.