### PR TITLE
ops(companion-ui): define MLP production launch safety

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/serve_production_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_production_page.py
@@ -20,6 +20,10 @@ from companion_ui.workspace.serve_dev_page import (
 
 _PRODUCTION_PORT = 8113
 _PRODUCTION_API_BASE_URL = "http://127.0.0.1:18000"
+_PRODUCTION_SAFETY_WARNING = (
+    "Local-only default. Public internet exposure is not supported; "
+    "this profile does not provide auth, TLS, or a reverse proxy."
+)
 _PRODUCTION_STATIC_ASSETS = {
     "/static/companion-workspace.css": (
         "text/css; charset=utf-8",
@@ -69,6 +73,7 @@ def main() -> None:
     )
     server = HTTPServer((config["host"], config["port"]), handler)
     print("[companion-ui] Production profile", flush=True)
+    print(f"[companion-ui] Safety:     {_PRODUCTION_SAFETY_WARNING}", flush=True)
     print(
         f"[companion-ui] Listening:   http://{config['host']}:{config['port']}/",
         flush=True,

--- a/companion-ui/docs/MLP_PRODUCTION_LAUNCH_SAFETY.md
+++ b/companion-ui/docs/MLP_PRODUCTION_LAUNCH_SAFETY.md
@@ -1,0 +1,124 @@
+---
+name: Companion UI MLP Production Launch Safety
+description: Minimal operator-safe launch profile for the Companion UI MLP production server-rendered shell.
+doc_role: Production launch safety / operator runbook
+authority: Operational guidance subordinate to runtime authority docs, Companion UI contracts, and shipped behavior.
+owner: Companion UI / operations
+last_reviewed: 2026-05-21
+governing_issue: "#1188"
+---
+
+# MLP Production Launch Safety
+
+## Purpose
+
+This document defines the minimal production launch safety pass for the Companion UI MLP under #1177 and #1188.
+
+It documents how to run the current server-rendered Companion UI shell against the production runtime without implying public internet readiness or a full frontend platform.
+
+## Authority and Boundaries
+
+Companion UI remains a shell/host. It is not a fourth authority surface.
+
+The runtime remains authoritative for policy, WriteGuard, idempotency, action handling, events, receipts, and durable projection. The UI never writes vault files directly and never chooses the vault.
+
+Vault / Markdown remains the human-readable canonical surface. The UI must show runtime/channel and guard/degraded state where the workspace payload exposes it.
+
+## Launch Command
+
+From the repository root:
+
+```bash
+cd companion-ui/companion-app
+COMPANION_API_BASE_URL=http://127.0.0.1:18000 HOST=127.0.0.1 PORT=8113 \
+  python -m companion_ui.workspace.serve_production_page
+```
+
+Open:
+
+```text
+http://127.0.0.1:8113/?note_path=<runtime-relative-note-path>
+```
+
+The runtime API must already be running on the configured production API base URL.
+
+## Port Map
+
+| Surface | Dev | Test | Prod |
+|---|---:|---:|---:|
+| Runtime API | 18001 | 18002 | 18000 |
+| Companion UI | 8111 | 8112 | 8113 |
+
+## Bind Address
+
+Default production binding is local-only:
+
+```text
+HOST=127.0.0.1
+```
+
+LAN or Tailscale exposure must be an explicit operator action:
+
+```bash
+HOST=0.0.0.0 PORT=8113 COMPANION_API_BASE_URL=http://<trusted-host>:18000 \
+  python -m companion_ui.workspace.serve_production_page
+```
+
+Use LAN/Tailscale only on trusted personal networks or trusted tailnets. Prefer Tailscale over open LAN when another device needs access.
+
+## No Public Exposure
+
+Do not expose this profile to the public internet.
+
+The current MLP production profile does not provide auth, TLS, reverse proxy hardening, multi-user isolation, or public exposure safety. Public access requires a separate accepted auth/TLS/reverse-proxy contract and implementation.
+
+## Readiness and Health Checks
+
+Before use:
+
+1. Start the production runtime API.
+2. Confirm the runtime health endpoint responds:
+
+```bash
+curl -fsS http://127.0.0.1:18000/health
+```
+
+3. Start Companion UI with the launch command above.
+4. Open a real note through `GET /api/companion/workspace` by loading the UI with a runtime-relative `note_path`.
+5. Confirm the UI visibly shows runtime/channel, WriteGuard state, Canvas enabled/disabled state, guard/degraded state, artifact identity or unresolved fallback, note path, content hash, and receipt/block state when present.
+
+## Stop and Rollback
+
+Stop the Companion UI process with `Ctrl-C` in the terminal that launched it.
+
+Rollback options:
+
+- Return to the previous known-good git checkout or release channel.
+- Restart the runtime API on the previous known-good version.
+- Restart Companion UI using the same local-only bind and API base URL.
+
+The UI does not own durable vault writes, so UI rollback does not require vault migration. Runtime rollback must still respect runtime migration and data-store rules.
+
+## Known Limitations
+
+- Minimal server-rendered shell.
+- No auth, TLS, or reverse proxy by default.
+- No public internet safety.
+- No global inbox.
+- No direct UI vault writes.
+- No UI-side proposal reclassification.
+- Canvas session and proposal visibility may include in-memory or volatile limits where the runtime reports them.
+- Find is candidate/unavailable display, not a full search product.
+- Resurface controls are unavailable unless runtime-backed persistence exists.
+
+## Verification
+
+Issue #1188 verification:
+
+```bash
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q \
+  tests/companion_ui/test_production_launch_profile.py \
+  tests/companion_ui/test_real_note_workspace_dev_server.py
+python3 scripts/docs_guard.py
+git diff --check
+```

--- a/companion-ui/docs/README.md
+++ b/companion-ui/docs/README.md
@@ -5,6 +5,7 @@ Foundational documents for cognitive interaction architecture.
 ## Product architecture and hosting
 - `COMPANION_UI_TARGET_ARCHITECTURE.md` — owner doc for Companion UI target architecture: local-first web app served by Yggdrasil, localhost/LAN/Tailscale access model, runtime API as the only vault access path, vault-boundary rules, current shipped state, browser dev server as the next slice, long-term options (PWA, desktop wrapper), non-goals. Governing issue: #1102.
 - `LOCAL_ACCESS_MODEL.md` — local access posture for Companion UI: localhost default, LAN/Tailscale opt-in, token/session auth option, CSRF posture, dev/production separation, public internet non-goal.
+- `MLP_PRODUCTION_LAUNCH_SAFETY.md` — minimal Companion UI MLP production launch safety runbook: command, port map, localhost default, LAN/Tailscale opt-in, no-public-exposure warning, readiness checks, stop/rollback, and known limitations. Governing issue: #1188.
 
 ## Core set
 - `SYSTEM_OVERVIEW.md`

--- a/tests/companion_ui/test_production_launch_profile.py
+++ b/tests/companion_ui/test_production_launch_profile.py
@@ -10,6 +10,20 @@ def test_production_port(monkeypatch) -> None:
     assert load_config()["port"] == 8113
 
 
+def test_production_default_host_is_local_only(monkeypatch) -> None:
+    monkeypatch.delenv("HOST", raising=False)
+    from companion_ui.workspace.serve_production_page import load_config
+
+    assert load_config()["host"] == "127.0.0.1"
+
+
+def test_production_default_api_points_at_prod_runtime(monkeypatch) -> None:
+    monkeypatch.delenv("COMPANION_API_BASE_URL", raising=False)
+    from companion_ui.workspace.serve_production_page import load_config
+
+    assert load_config()["api_base_url"] == "http://127.0.0.1:18000"
+
+
 def test_no_dev_marker_in_production() -> None:
     from companion_ui.workspace.serve_production_page import render_production_index_html
 
@@ -33,3 +47,58 @@ def test_production_output_links_static_asset() -> None:
     html = render_production_index_html(api_base_url="http://127.0.0.1:18000")
 
     assert 'href="/static/companion-workspace.css"' in html
+
+
+def test_production_safety_warning_is_explicit() -> None:
+    from companion_ui.workspace.serve_production_page import _PRODUCTION_SAFETY_WARNING
+
+    warning = _PRODUCTION_SAFETY_WARNING.lower()
+    assert "local-only" in warning
+    assert "public internet exposure is not supported" in warning
+    assert "auth" in warning
+    assert "tls" in warning
+    assert "reverse proxy" in warning
+
+
+def test_production_shell_shows_runtime_channel_and_guard_state() -> None:
+    from companion_ui.workspace.serve_production_page import render_production_index_html
+
+    html = render_production_index_html(
+        api_base_url="http://127.0.0.1:18000",
+        fields={
+            "title": "Prod Note",
+            "note_path": "Notes/prod.md",
+            "artifact_id": "art-prod",
+            "content_hash": "hash-prod",
+            "body": "# Prod Note",
+            "runtime_environment_label": "prod",
+            "runtime_api_base_url_label": "local-prod",
+            "guard_writeguard_status": "ok",
+            "guard_canvas_enabled": True,
+            "guard_degraded": False,
+        },
+    )
+
+    assert 'data-testid="workspace-runtime-channel"' in html
+    assert "prod" in html
+    assert "local-prod" in html
+    assert 'data-testid="workspace-writeguard-state"' in html
+    assert 'data-testid="workspace-guard-degraded-state"' in html
+
+
+def test_production_launch_safety_doc_covers_operator_requirements() -> None:
+    from pathlib import Path
+
+    doc = Path("companion-ui/docs/MLP_PRODUCTION_LAUNCH_SAFETY.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "python -m companion_ui.workspace.serve_production_page" in doc
+    assert "Runtime API | 18001 | 18002 | 18000" in doc
+    assert "Companion UI | 8111 | 8112 | 8113" in doc
+    assert "HOST=127.0.0.1" in doc
+    assert "Tailscale" in doc
+    assert "Do not expose this profile to the public internet." in doc
+    assert "curl -fsS http://127.0.0.1:18000/health" in doc
+    assert "Ctrl-C" in doc
+    assert "No direct UI vault writes" in doc


### PR DESCRIPTION
Fixes #1188

## Summary
- Add the Companion UI MLP production launch safety runbook with launch command, port map, localhost default, LAN/Tailscale opt-in, readiness checks, stop/rollback, and known limitations.
- Add an explicit production profile safety warning for local-only/default no-public-exposure posture.
- Expand production launch tests for defaults, visible runtime/channel and guard state, and operator documentation coverage.

## Files changed
- `companion-ui/docs/MLP_PRODUCTION_LAUNCH_SAFETY.md`
- `companion-ui/docs/README.md`
- `companion-ui/companion-app/companion_ui/workspace/serve_production_page.py`
- `tests/companion_ui/test_production_launch_profile.py`

## Authority / guardrail notes
- No auth, TLS, reverse proxy, public exposure, new infrastructure, API schema, or runtime authority behavior was added.
- Production profile remains runtime-mediated and local-only by default.
- Companion UI still never writes vault files directly and does not own policy, WriteGuard, events, receipts, or durable projection.

## Tests run
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_production_launch_profile.py tests/companion_ui/test_real_note_workspace_dev_server.py` -> `54 passed`
- `/Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/ruff check app tests companion-ui/companion-app/companion_ui/workspace/serve_production_page.py` -> `All checks passed!`
- `python3 scripts/docs_guard.py` -> `Docs guard: OK`
- `git diff --check` -> clean

## Known limitations
- This is a minimal server-rendered shell launch profile.
- Non-loopback LAN/Tailscale use remains explicit operator opt-in.
- Public internet exposure remains unsupported until separate auth/TLS/reverse-proxy work is scoped and accepted.