### PR TITLE
fix(guards): rephrase OPENAI_BASE example to satisfy hardcoded runtime defaults guard (#1200)

### DIFF
--- a/scripts/export_runtime_env.sh
+++ b/scripts/export_runtime_env.sh
@@ -95,8 +95,8 @@ if [ -n "$scope_glob_raw" ]; then
   printf "%s\n" "WATCHER_SCOPE_GLOB=$scope_glob_raw" >> "$runtime_env_path"
 fi
 
-# OPENAI_BASE is the full chat-completions URL used directly by the adapter and health checks
-# (e.g. http://host.docker.internal:11434/v1/chat/completions).
+# OPENAI_BASE is the full chat-completions URL used directly by the adapter and health checks.
+# See `.env.example` and `config/runtime.defaults.env` for canonical example values.
 # If the operator set it explicitly, write it as-is.
 # Otherwise, if OPENAI_BASE_URL is set (OpenAI-compatible base), derive the chat-completions
 # URL by stripping a trailing slash and appending /chat/completions.


### PR DESCRIPTION
Fixes #1200

## Summary

`scripts/export_runtime_env.sh` line 99 carried an inline example URL `http://host.docker.internal:11434/v1/chat/completions` inside a comment. The `no_hardcoded_runtime_defaults` guard regex matches `http://host\.docker\.internal:11434/v1` and flagged this file even though the literal lived only in documentation prose. Rephrase the comment to point operators at the canonical example sources (`.env.example`, `config/runtime.defaults.env`) instead of inlining the URL. No runtime behavior change.

## Validation

```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/guards/test_no_hardcoded_runtime_defaults.py::test_no_hardcoded_runtime_defaults
# => 1 passed in 0.21s

PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/guards/
# => 7 passed in 1.80s

bash -n scripts/export_runtime_env.sh
# => syntax OK
```

## Lint

No files under `app/` or `tests/` changed; `ruff check app tests` not required for this PR per AGENTS.md.

## Dispatcher

Dispatcher unavailable (`db_exists: false`) — used GitHub-label-only claim via `scripts/issue_pickup_claim.sh --issue 1200`.

---