### PR TITLE
fix(panel-agent): use stable_action_id hash for executed action filtering

### DIFF
--- a/app/agents/panel_agent/runtime.py
+++ b/app/agents/panel_agent/runtime.py
@@ -128,7 +128,14 @@ def execute_panel_intent(
         executed_ids = set(payload.get("executed_action_ids") or [])
 
     original_action_count = len(list(intent_event.payload.actions))
-    actions = [action for action in intent_event.payload.actions if action.id not in executed_ids]
+    # Filter executed actions by comparing against stable_action_id hash (same hash
+    # used for persisting executed_ids). action.id (e.g. "proposal.next_actions") is
+    # distinct from the persisted hash of action.label.
+    from app.agents.panel.writeback import stable_action_id
+    actions = [
+        action for action in intent_event.payload.actions
+        if stable_action_id(action.label) not in executed_ids
+    ]
     converged_rerun = bool(executed_ids) and original_action_count > 0 and not actions
     payload = intent_event.payload.model_copy(update={"actions": list(actions)})
     intent_event = intent_event.model_copy(update={"payload": payload})


### PR DESCRIPTION
The runtime was comparing action.id strings against stored executed_ids (SHA1 hashes). This mismatch meant executed actions were never filtered out on reruns, causing no-match events to be emitted incorrectly. Fixed by using stable_action_id(action.label) for filtering to match the hash scheme used when persisting executed IDs. Closes #1201.