### PR TITLE
fix(ops): route API Docker healthcheck to /healthz instead of /api/status

### DIFF
--- a/config/runtime.defaults.env
+++ b/config/runtime.defaults.env
@@ -24,6 +24,6 @@ WATCHER_STATE_DIR=tmp
 WATCHER_STOP_FILE=/app/tmp/WATCHER_STOP
 WATCHER_MAX_SCANNED_FILES_PER_TICK=500
 INDEX_OUTBOX_PATH=/app/tmp/index-outbox.jsonl
-API_HEALTHCHECK_URL=http://127.0.0.1:8000/api/status
+API_HEALTHCHECK_URL=http://127.0.0.1:8000/healthz
 # v6.0 canvas seam — deliberately gated until canvas feature is stable enough for default-on
 CANVAS_ENABLED=0


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane

## Linked Issue
Fixes #1207

## Summary
- Change `API_HEALTHCHECK_URL` in `config/runtime.defaults.env` from `/api/status` to `/healthz`
- `/healthz` returns `{"ok": true}` with no external state reads — cheap, bounded, always-fast liveness probe
- `/api/status` remains available for diagnostics but no longer controls basic container health

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed. (Docs already correctly describe `/healthz` as liveness and `/api/status` as diagnostics — no doc writeback needed.)
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Validation
- [x] `ruff check app tests` — All checks passed.
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -k "health or status"` — 125 passed, 2 skipped.
- Pre-existing guard failure in `tests/guards/test_no_hardcoded_runtime_defaults.py` (`scripts/export_runtime_env.sh: http://host.docker.internal:11434/v1`) is unrelated to this change and predates it.

**Dispatcher:** Dispatcher available (db_exists: true) — used dispatcher-assisted claim flow.

## Notes
- AC "Dev compose healthcheck remains green when /healthz is healthy" requires live Docker to verify; not verifiable offline. The config change is minimal and correct per inspection.
- The `test_no_hardcoded_runtime_defaults.py` guard has a pre-existing failure on `scripts/export_runtime_env.sh` — tracked separately and not introduced by this PR.