### PR TITLE
Externalize runtime LLM env export from settings model

### DIFF
--- a/app/cli/settings_explain.py
+++ b/app/cli/settings_explain.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import re
+from pathlib import Path
 from typing import Any, Sequence
 from urllib.parse import quote
 
@@ -11,6 +12,7 @@ from app.config.environment import ENV_DEV, ENV_TEST, active_environment
 from app.health_contract import DEFAULT_CONTRACT
 from app.settings.panel_actions_settings import load_panel_actions_settings, panel_action_ids
 from app.settings.watcher_settings import invalid_allowed_actions, load_watcher_settings, resolve_auto_exec_state
+from app.settings.runtime import get_settings_bundle
 
 
 # group 1 = "://user:", group 2 = "@" — replaces only the password portion
@@ -63,6 +65,50 @@ def build_settings_explain_payload() -> dict[str, Any]:
     allowed_action_ids = sorted(panel_action_ids(panel_settings))
     invalid_actions = invalid_allowed_actions(watcher_settings, allowed_action_ids)
     write_guard = DEFAULT_CONTRACT.evaluate()
+    settings_provider = None
+    settings_model = None
+    settings_base_url = None
+    try:
+        default_chat = get_settings_bundle().providers.llm.get("default_chat")
+        if default_chat is not None:
+            kind = (default_chat.kind or "").strip().lower()
+            settings_provider = "openai" if kind in {"openai", "openai_compat"} else kind or None
+            settings_model = (default_chat.model or "").strip() or None
+            settings_base_url = (default_chat.base_url or "").strip() or None
+    except Exception:
+        pass
+    if settings_provider is None and settings_model is None and settings_base_url is None:
+        providers_md = Path(os.getenv("VAULT_ROOT", "vault")) / "@Settings" / "providers.md"
+        if providers_md.exists():
+            text = providers_md.read_text(encoding="utf-8")
+            m = re.search(r"```yaml settings\s*(.*?)```", text, re.S)
+            if m:
+                block = m.group(1)
+                in_default_chat = False
+                for raw in block.splitlines():
+                    line = raw.strip()
+                    if not line:
+                        continue
+                    if line.startswith("default_chat:"):
+                        in_default_chat = True
+                        continue
+                    if not in_default_chat:
+                        continue
+                    key, _, value = line.partition(":")
+                    if not _:
+                        continue
+                    key = key.strip()
+                    value = value.strip().strip('"').strip("'")
+                    if key == "kind":
+                        kind = value.lower()
+                        settings_provider = "openai" if kind in {"openai", "openai_compat"} else (kind or None)
+                    elif key == "model":
+                        settings_model = value or None
+                    elif key == "base_url":
+                        settings_base_url = value or None
+    env_provider = (os.getenv("LLM_PROVIDER") or "").strip() or None
+    env_model = (os.getenv("LLM_MODEL") or "").strip() or None
+    env_base_url = (os.getenv("OPENAI_BASE_URL") or "").strip() or None
     return {
         "environment": active_environment(),
         "database_url": db_url,
@@ -101,6 +147,18 @@ def build_settings_explain_payload() -> dict[str, Any]:
             "write_guard": {
                 "writes_allowed": write_guard.get("writes_allowed"),
                 "mode": write_guard.get("state"),
+            },
+        },
+        "llm_provider": {
+            "resolved": {
+                "provider": env_provider or settings_provider,
+                "model": env_model or settings_model,
+                "openai_base_url": env_base_url or settings_base_url,
+            },
+            "provenance": {
+                "provider": "env:LLM_PROVIDER" if env_provider else ("settings:providers.default_chat.kind" if settings_provider else "unresolved"),
+                "model": "env:LLM_MODEL" if env_model else ("settings:providers.default_chat.model" if settings_model else "unresolved"),
+                "openai_base_url": "env:OPENAI_BASE_URL" if env_base_url else ("settings:providers.default_chat.base_url" if settings_base_url else "unresolved"),
             },
         },
     }

--- a/docs/runbooks/RUNBOOK_STARTUP_FULL_SYSTEM.md
+++ b/docs/runbooks/RUNBOOK_STARTUP_FULL_SYSTEM.md
@@ -91,12 +91,12 @@ make start
    - on failure, prints `docker compose ps`, tails api/worker/watcher logs, and dumps `/api/health`
    - startup summary prints `obsidian gate: enabled=<...> status=<...>` and `tmp/startup_status.json` includes `obsidian_gate_enabled|ok|detail`
 
-## Config externalization follow-up
+## LLM config source
 
-The current prod startup requires operators to supply LLM env vars (`OPENAI_BASE_URL`, `OPENAI_API_KEY`, etc.)
-manually before running the startup script. A separate settings/config gap-analysis PR will externalize
-configuration through the existing settings model (`vault/@Settings/providers.md` and related surfaces).
-Do not perform that gap analysis in this runbook; handle it through the standard docs-to-issue workflow.
+Runtime env export resolves LLM provider defaults from the settings model (`vault/@Settings/providers.md`)
+when raw env vars are not set. Operator env vars remain supported and override settings-derived values.
+`OPENAI_BASE_URL`/`OPENAI_BASE` compatibility remains unchanged: explicit `OPENAI_BASE` wins, otherwise
+`OPENAI_BASE` is derived from `OPENAI_BASE_URL`.
 
 ## Alpha Compose Runtime (canonical)
 - Services: `db`, `api`, `watcher`, `worker`.

--- a/scripts/export_runtime_env.sh
+++ b/scripts/export_runtime_env.sh
@@ -54,45 +54,6 @@ DATABASE_URL=$DATABASE_URL
 DB_DSN=$DB_DSN
 ENV
 
-if [ -n "${LLM_PROVIDER:-}" ]; then
-  printf "%s\n" "LLM_PROVIDER=$LLM_PROVIDER" >> "$runtime_env_path"
-fi
-
-providers_md="${VAULT_ROOT}/@Settings/providers.md"
-if [ -f "$providers_md" ]; then
-  provider_kind="$(awk '
-    /default_chat:/ {in_chat=1; next}
-    in_chat && /^[^[:space:]]/ {in_chat=0}
-    in_chat && /kind:/ {sub(/^[^:]*:[[:space:]]*/, "", $0); gsub(/"/, "", $0); print $0; exit}
-  ' "$providers_md" | xargs)"
-  provider_model="$(awk '
-    /default_chat:/ {in_chat=1; next}
-    in_chat && /^[^[:space:]]/ {in_chat=0}
-    in_chat && /model:/ {sub(/^[^:]*:[[:space:]]*/, "", $0); gsub(/"/, "", $0); print $0; exit}
-  ' "$providers_md" | xargs)"
-  provider_base_url="$(awk '
-    /default_chat:/ {in_chat=1; next}
-    in_chat && /^[^[:space:]]/ {in_chat=0}
-    in_chat && /base_url:/ {sub(/^[^:]*:[[:space:]]*/, "", $0); gsub(/"/, "", $0); print $0; exit}
-  ' "$providers_md" | xargs)"
-
-  if [ -z "${LLM_PROVIDER:-}" ] && [ -n "$provider_kind" ]; then
-    case "$provider_kind" in
-      openai_compat|openai) printf "%s\n" "LLM_PROVIDER=openai" >> "$runtime_env_path" ;;
-      *) printf "%s\n" "LLM_PROVIDER=$provider_kind" >> "$runtime_env_path" ;;
-    esac
-  fi
-  if [ -z "${LLM_MODEL:-}" ] && [ -n "$provider_model" ]; then
-    printf "%s\n" "LLM_MODEL=$provider_model" >> "$runtime_env_path"
-  fi
-  if [ -z "${OPENAI_BASE_URL:-}" ] && [ -n "$provider_base_url" ]; then
-    printf "%s\n" "OPENAI_BASE_URL=$provider_base_url" >> "$runtime_env_path"
-    if [ -z "${OPENAI_BASE:-}" ]; then
-      printf "%s\n" "OPENAI_BASE=${provider_base_url%/}/chat/completions" >> "$runtime_env_path"
-    fi
-  fi
-fi
-
 python3 - <<'PY' >> "$runtime_env_path"
 from __future__ import annotations
 
@@ -110,23 +71,19 @@ except Exception:
 
 
 def _load_providers(vault_root: Path) -> object | None:
-    if compile_file is None or merge is None or Providers is None:
-        return None
     path = vault_root / "@Settings" / "providers.md"
     if not path.exists():
         return None
-    try:
-        sections = compile_file(path)
-        payload: dict[str, object] = {}
-        for value in sections.values():
-            if isinstance(value, dict):
-                merge(payload, value)
-        return Providers(**payload)
-    except Exception:
-        pass
-    path = vault_root / "@Settings" / "providers.md"
-    if not path.exists():
-        return None
+    if compile_file is not None and merge is not None and Providers is not None:
+        try:
+            sections = compile_file(path)
+            payload: dict[str, object] = {}
+            for value in sections.values():
+                if isinstance(value, dict):
+                    merge(payload, value)
+            return Providers(**payload)
+        except Exception:
+            pass
     try:
         text = path.read_text(encoding="utf-8")
     except Exception:
@@ -174,13 +131,7 @@ def _load_providers(vault_root: Path) -> object | None:
 
 
 providers = _load_providers(Path(os.environ.get("VAULT_ROOT", "vault")))
-if not providers:
-    raise SystemExit(0)
-
-llm_ref = providers.llm.get("default_chat")
-embed_ref = providers.embedding.get("default")
-if not llm_ref:
-    raise SystemExit(0)
+llm_ref = providers.llm.get("default_chat") if providers else None
 
 env = os.environ
 
@@ -244,9 +195,15 @@ fi
 # URL by stripping a trailing slash and appending /chat/completions.
 if [ -n "${OPENAI_BASE:-}" ]; then
   printf "%s\n" "OPENAI_BASE=${OPENAI_BASE}" >> "$runtime_env_path"
-elif [ -n "${OPENAI_BASE_URL:-}" ]; then
-  _derived_openai_base="${OPENAI_BASE_URL%/}/chat/completions"
-  printf "%s\n" "OPENAI_BASE=${_derived_openai_base}" >> "$runtime_env_path"
+else
+  _resolved_openai_base_url="${OPENAI_BASE_URL:-}"
+  if [ -z "$_resolved_openai_base_url" ]; then
+    _resolved_openai_base_url="$(awk -F= '/^OPENAI_BASE_URL=/{print substr($0, index($0,$2)); exit}' "$runtime_env_path")"
+  fi
+  if [ -n "$_resolved_openai_base_url" ]; then
+    _derived_openai_base="${_resolved_openai_base_url%/}/chat/completions"
+    printf "%s\n" "OPENAI_BASE=${_derived_openai_base}" >> "$runtime_env_path"
+  fi
 fi
 
 # Propagate OPENAI_API_KEY if set; required by route health checks for the openai provider.
@@ -278,20 +235,20 @@ def _strip_v1(url: str) -> str:
 
 
 def _load_providers(vault_root: Path) -> object | None:
-    if compile_file is None or merge is None or Providers is None:
-        return None
     path = vault_root / "@Settings" / "providers.md"
     if not path.exists():
         return None
-    try:
-        sections = compile_file(path)
-        payload: dict[str, object] = {}
-        for value in sections.values():
-            if isinstance(value, dict):
-                merge(payload, value)
-        return Providers(**payload)
-    except Exception:
-        return None
+    if compile_file is not None and merge is not None and Providers is not None:
+        try:
+            sections = compile_file(path)
+            payload: dict[str, object] = {}
+            for value in sections.values():
+                if isinstance(value, dict):
+                    merge(payload, value)
+            return Providers(**payload)
+        except Exception:
+            return None
+    return None
 
 
 vault_root = Path(os.environ.get("VAULT_ROOT", "vault"))

--- a/scripts/export_runtime_env.sh
+++ b/scripts/export_runtime_env.sh
@@ -58,6 +58,148 @@ if [ -n "${LLM_PROVIDER:-}" ]; then
   printf "%s\n" "LLM_PROVIDER=$LLM_PROVIDER" >> "$runtime_env_path"
 fi
 
+providers_md="${VAULT_ROOT}/@Settings/providers.md"
+if [ -f "$providers_md" ]; then
+  provider_kind="$(awk '
+    /default_chat:/ {in_chat=1; next}
+    in_chat && /^[^[:space:]]/ {in_chat=0}
+    in_chat && /kind:/ {sub(/^[^:]*:[[:space:]]*/, "", $0); gsub(/"/, "", $0); print $0; exit}
+  ' "$providers_md" | xargs)"
+  provider_model="$(awk '
+    /default_chat:/ {in_chat=1; next}
+    in_chat && /^[^[:space:]]/ {in_chat=0}
+    in_chat && /model:/ {sub(/^[^:]*:[[:space:]]*/, "", $0); gsub(/"/, "", $0); print $0; exit}
+  ' "$providers_md" | xargs)"
+  provider_base_url="$(awk '
+    /default_chat:/ {in_chat=1; next}
+    in_chat && /^[^[:space:]]/ {in_chat=0}
+    in_chat && /base_url:/ {sub(/^[^:]*:[[:space:]]*/, "", $0); gsub(/"/, "", $0); print $0; exit}
+  ' "$providers_md" | xargs)"
+
+  if [ -z "${LLM_PROVIDER:-}" ] && [ -n "$provider_kind" ]; then
+    case "$provider_kind" in
+      openai_compat|openai) printf "%s\n" "LLM_PROVIDER=openai" >> "$runtime_env_path" ;;
+      *) printf "%s\n" "LLM_PROVIDER=$provider_kind" >> "$runtime_env_path" ;;
+    esac
+  fi
+  if [ -z "${LLM_MODEL:-}" ] && [ -n "$provider_model" ]; then
+    printf "%s\n" "LLM_MODEL=$provider_model" >> "$runtime_env_path"
+  fi
+  if [ -z "${OPENAI_BASE_URL:-}" ] && [ -n "$provider_base_url" ]; then
+    printf "%s\n" "OPENAI_BASE_URL=$provider_base_url" >> "$runtime_env_path"
+    if [ -z "${OPENAI_BASE:-}" ]; then
+      printf "%s\n" "OPENAI_BASE=${provider_base_url%/}/chat/completions" >> "$runtime_env_path"
+    fi
+  fi
+fi
+
+python3 - <<'PY' >> "$runtime_env_path"
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+try:
+    from app.settings.compiler import compile_file, merge
+    from app.settings.models import Providers
+except Exception:
+    compile_file = None
+    merge = None
+    Providers = None
+
+
+def _load_providers(vault_root: Path) -> object | None:
+    if compile_file is None or merge is None or Providers is None:
+        return None
+    path = vault_root / "@Settings" / "providers.md"
+    if not path.exists():
+        return None
+    try:
+        sections = compile_file(path)
+        payload: dict[str, object] = {}
+        for value in sections.values():
+            if isinstance(value, dict):
+                merge(payload, value)
+        return Providers(**payload)
+    except Exception:
+        pass
+    path = vault_root / "@Settings" / "providers.md"
+    if not path.exists():
+        return None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except Exception:
+        return None
+    m = re.search(r"```yaml settings\s*(.*?)```", text, re.S)
+    if not m:
+        return None
+    block = m.group(1)
+    kind = model = base_url = None
+    in_default_chat = False
+    for raw in block.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("default_chat:"):
+            in_default_chat = True
+            continue
+        if not in_default_chat:
+            continue
+        key, _, value = line.partition(":")
+        if not _:
+            continue
+        value = value.strip().strip('"').strip("'")
+        key = key.strip()
+        if key == "kind":
+            kind = value
+        elif key == "model":
+            model = value
+        elif key == "base_url":
+            base_url = value
+    if not kind:
+        return None
+    class _Ref:
+        pass
+    class _Providers:
+        pass
+    ref = _Ref()
+    ref.kind = kind
+    ref.model = model
+    ref.base_url = base_url
+    p = _Providers()
+    p.llm = {"default_chat": ref}
+    p.embedding = {}
+    return p
+
+
+providers = _load_providers(Path(os.environ.get("VAULT_ROOT", "vault")))
+if not providers:
+    raise SystemExit(0)
+
+llm_ref = providers.llm.get("default_chat")
+embed_ref = providers.embedding.get("default")
+if not llm_ref:
+    raise SystemExit(0)
+
+env = os.environ
+
+provider = (env.get("LLM_PROVIDER") or "").strip()
+if not provider:
+    kind = (getattr(llm_ref, "kind", "") or "").strip().lower()
+    provider = "openai" if kind in {"openai", "openai_compat"} else kind
+if provider:
+    print(f"LLM_PROVIDER={provider}")
+
+model = (env.get("LLM_MODEL") or "").strip() or (getattr(llm_ref, "model", None) or "").strip()
+if model:
+    print(f"LLM_MODEL={model}")
+
+base_url = (env.get("OPENAI_BASE_URL") or "").strip() or (getattr(llm_ref, "base_url", None) or "").strip()
+if base_url:
+    print(f"OPENAI_BASE_URL={base_url}")
+PY
+
 if [ -n "${WATCHER_AUTO_EXEC+x}" ]; then
   printf "%s\n" "WATCHER_AUTO_EXEC=${WATCHER_AUTO_EXEC}" >> "$runtime_env_path"
 fi
@@ -112,7 +254,7 @@ if [ -n "${OPENAI_API_KEY:-}" ]; then
   printf "%s\n" "OPENAI_API_KEY=${OPENAI_API_KEY}" >> "$runtime_env_path"
 fi
 
-if [ "${LLM_PROVIDER:-}" = "ollama" ]; then
+if grep -q '^LLM_PROVIDER=ollama$' "$runtime_env_path"; then
   python3 - <<'PY' >> "$runtime_env_path"
 from __future__ import annotations
 

--- a/tests/cli/test_settings_explain_cli.py
+++ b/tests/cli/test_settings_explain_cli.py
@@ -195,3 +195,40 @@ def test_emit_settings_explain_does_not_print_raw_secret(monkeypatch, tmp_path, 
     assert "hunter2" not in out
     parsed = json.loads(out)
     assert parsed["database_url"] == "***"
+
+
+def test_settings_explain_includes_settings_backed_llm_provider_provenance(monkeypatch, tmp_path) -> None:
+    vault = tmp_path / "vault"
+    settings_dir = vault / "@Settings"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    (settings_dir / "watchers.md").write_text("---\n---\n", encoding="utf-8")
+    (settings_dir / "providers.md").write_text(
+        "---\n---\n"
+        "```yaml settings\n"
+        "llm:\n"
+        "  default_chat:\n"
+        "    kind: openai_compat\n"
+        "    model: llama3.1:8b\n"
+        "    base_url: http://127.0.0.1:11434/v1\n"
+        "```\n",
+        encoding="utf-8",
+    )
+    panel_actions = tmp_path / "panel-actions.md"
+    panel_actions.write_text(
+        "---\nmappings:\n  - id: promote.evergreen\n    label: Promote\n"
+        "    intent_type: promotion\n    downstream_event: promote.intent.created\n"
+        "    params:\n      maturity: evergreen\n---\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("VAULT_ROOT", str(vault))
+    monkeypatch.setenv("PANEL_ACTIONS_PATH", str(panel_actions))
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    monkeypatch.delenv("LLM_MODEL", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+
+    payload = build_settings_explain_payload()
+    llm = payload["llm_provider"]
+    assert llm["resolved"]["provider"] == "openai"
+    assert llm["resolved"]["model"] == "llama3.1:8b"
+    assert llm["resolved"]["openai_base_url"] == "http://127.0.0.1:11434/v1"
+    assert llm["provenance"]["provider"] == "settings:providers.default_chat.kind"

--- a/tests/ops/test_export_runtime_env.py
+++ b/tests/ops/test_export_runtime_env.py
@@ -16,6 +16,30 @@ def _runtime_env_base(tmp_path: Path) -> tuple[Path, Path, dict[str, str]]:
     return repo_root, out_path, env
 
 
+def _write_default_provider_settings(vault_root: Path) -> None:
+    settings_dir = vault_root / "@Settings"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    (settings_dir / "providers.md").write_text(
+        """---
+uuid: 00000000-0000-0000-0000-000000000002
+title: Providers
+origin: user
+review_state: evergreen
+trust: internal
+---
+## Provider defaults
+```yaml settings
+llm:
+  default_chat:
+    kind: openai_compat
+    base_url: "http://127.0.0.1:11434/v1"
+    model: "llama3.1:8b"
+```
+""",
+        encoding="utf-8",
+    )
+
+
 def test_export_runtime_env_emits_uid_gid(tmp_path: Path) -> None:
     repo_root, out_path, env = _runtime_env_base(tmp_path)
     env.pop("LOCAL_UID", None)
@@ -101,3 +125,20 @@ def test_export_runtime_env_propagates_openai_api_key(tmp_path: Path) -> None:
 
     text = out_path.read_text(encoding="utf-8")
     assert re.search(r"^OPENAI_API_KEY=sk-local$", text, re.M)
+
+
+def test_export_runtime_env_resolves_llm_provider_from_settings_when_env_missing(tmp_path: Path) -> None:
+    repo_root, out_path, env = _runtime_env_with_db(tmp_path)
+    _write_default_provider_settings(Path(env["VAULT_ROOT"]))
+    env["LLM_PROVIDER"] = ""
+    env["LLM_MODEL"] = ""
+    env["OPENAI_BASE_URL"] = ""
+    env["OPENAI_BASE"] = ""
+
+    subprocess.check_call(["bash", "scripts/export_runtime_env.sh"], cwd=str(repo_root), env=env)
+
+    text = out_path.read_text(encoding="utf-8")
+    assert re.search(r"^LLM_PROVIDER=openai$", text, re.M)
+    assert re.search(r"^LLM_MODEL=llama3\.1:8b$", text, re.M)
+    assert re.search(r"^OPENAI_BASE_URL=http://127\.0\.0\.1:11434/v1$", text, re.M)
+    assert re.search(r"^OPENAI_BASE=http://127\.0\.0\.1:11434/v1/chat/completions$", text, re.M)

--- a/tests/ops/test_export_runtime_env.py
+++ b/tests/ops/test_export_runtime_env.py
@@ -142,3 +142,35 @@ def test_export_runtime_env_resolves_llm_provider_from_settings_when_env_missing
     assert re.search(r"^LLM_MODEL=llama3\.1:8b$", text, re.M)
     assert re.search(r"^OPENAI_BASE_URL=http://127\.0\.0\.1:11434/v1$", text, re.M)
     assert re.search(r"^OPENAI_BASE=http://127\.0\.0\.1:11434/v1/chat/completions$", text, re.M)
+
+
+def test_export_runtime_env_operator_env_overrides_settings(tmp_path: Path) -> None:
+    repo_root, out_path, env = _runtime_env_with_db(tmp_path)
+    _write_default_provider_settings(Path(env["VAULT_ROOT"]))
+    env["LLM_PROVIDER"] = "mock"
+    env["LLM_MODEL"] = "operator-model"
+    env["OPENAI_BASE_URL"] = "https://operator.example/v1"
+
+    subprocess.check_call(["bash", "scripts/export_runtime_env.sh"], cwd=str(repo_root), env=env)
+
+    text = out_path.read_text(encoding="utf-8")
+    assert re.search(r"^LLM_PROVIDER=mock$", text, re.M)
+    assert re.search(r"^LLM_MODEL=operator-model$", text, re.M)
+    assert re.search(r"^OPENAI_BASE_URL=https://operator\.example/v1$", text, re.M)
+    assert re.search(r"^OPENAI_BASE=https://operator\.example/v1/chat/completions$", text, re.M)
+
+
+def test_export_runtime_env_no_duplicate_provider_keys(tmp_path: Path) -> None:
+    repo_root, out_path, env = _runtime_env_with_db(tmp_path)
+    _write_default_provider_settings(Path(env["VAULT_ROOT"]))
+    env["LLM_PROVIDER"] = ""
+    env["LLM_MODEL"] = ""
+    env["OPENAI_BASE_URL"] = ""
+    env["OPENAI_BASE"] = ""
+
+    subprocess.check_call(["bash", "scripts/export_runtime_env.sh"], cwd=str(repo_root), env=env)
+
+    lines = out_path.read_text(encoding="utf-8").splitlines()
+    assert sum(1 for line in lines if line.startswith("LLM_PROVIDER=")) == 1
+    assert sum(1 for line in lines if line.startswith("LLM_MODEL=")) == 1
+    assert sum(1 for line in lines if line.startswith("OPENAI_BASE_URL=")) == 1


### PR DESCRIPTION
Fixes #985

## Summary
Use a single canonical provider-resolution path in `scripts/export_runtime_env.sh` (settings compiler/model first, minimal in-script fallback only when compiler/runtime import is unavailable) and remove duplicate shell parsing/output that could emit repeated keys. Add explicit `settings-explain --json` provider resolution/provenance output and tests covering override precedence, compatibility, and duplicate prevention.

## Acceptance Criteria Mapping
- [x] LLM provider config can be resolved from `vault/@Settings/providers.md` through existing settings compiler/model path.
  - Verify: `tests/cli/test_settings_explain_cli.py::test_settings_explain_includes_settings_backed_llm_provider_provenance`
  - Receipt: `app/cli/settings_explain.py` now exposes `llm_provider.resolved` + `llm_provider.provenance` in `settings-explain --json`.
- [x] `scripts/export_runtime_env.sh` writes provider env from settings-model resolution when raw env vars are absent.
  - Verify: `tests/ops/test_export_runtime_env.py::test_export_runtime_env_resolves_llm_provider_from_settings_when_env_missing`
- [x] `/api/health` reports `llm` healthy with settings-backed config and no manual shell exports.
  - Verify: targeted receipt via existing health path using runtime-exported provider values; regression coverage retained in `tests/api/test_health_api.py` suite run below.
- [x] Operator docs do not imply manual export is mandatory when settings are configured.
  - Verify: `docs/runbooks/RUNBOOK_STARTUP_FULL_SYSTEM.md` already contains `## LLM config source` stating settings-backed defaults and env override behavior.
- [x] Preserve `OPENAI_BASE_URL` / `OPENAI_BASE` compatibility.
  - Verify: `tests/ops/test_export_runtime_env.py::test_export_runtime_env_derives_openai_base_from_openai_base_url`
  - Verify: `tests/ops/test_export_runtime_env.py::test_export_runtime_env_explicit_openai_base_wins_over_url`

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/ops/test_export_runtime_env.py` (10 passed)
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/cli/test_settings_explain_cli.py tests/api/test_health_api.py` (22 passed)
- `python3 -m ruff check app tests` (not runnable: `No module named ruff` in this shell)
