### PR TITLE
fix(quality-wave): suppress no-match annotation on rerun/rebuild with only unchecked actions

### DIFF
--- a/app/agents/panel_agent/graph.py
+++ b/app/agents/panel_agent/graph.py
@@ -461,9 +461,13 @@ def _apply_actions(state: PanelAgentState, *, selected_ids: set[str] | None, rea
     # Only emit no-match when there was real input AND a cognition decision was
     # made this pass (freeform LLM returned empty, or checked-but-unmapped). A
     # rule-mode passthrough with empty actions is not a no-match.
+    # Unchecked actions in actions_to_process are not user-triggered input;
+    # they are panel suggestions that the user hasn't acted on yet. Only
+    # count them as "had input" when at least one is checked — i.e., the
+    # user explicitly requested something this pass (#1201).
     cognition_decided = bool(state.cognition_decision_made)
     had_input = (
-        bool(actions_to_process)
+        any(a.checked for a in actions_to_process)
         or (bool(instruction_text) and cognition_decided)
     ) and not converged_rerun
     if had_input and not produced_any and not proposed_ids_now:


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane

## Linked Issue
Fixes #1201

## Summary
- Change `had_input` guard in `_apply_actions` from `bool(actions_to_process)` to `any(a.checked for a in actions_to_process)`
- The root cause: after the first run removes executed `[x]` checkboxes, reruns and cold rebuilds found only unchecked `[ ]` remnants; `had_input=True` + `produced_any=False` wrongly emitted "Inga åtgärder matchade" annotations
- Unchecked actions are panel suggestions awaiting user input, not user-triggered input that should produce a no-match signal
- The instruction-path leg (`bool(instruction_text) and cognition_decided`) is unchanged: freeform LLM no-match still surfaces correctly

## Root cause analysis
`RuleCognitionBackend.select_actions()` always returns `None`, so `cognition_decided` is always `False` in rule mode. The only signal making `had_input=True` was `bool(actions_to_process)` — which is True for unchecked-only remnants. On cold rebuild the ObjectStore is empty (`executed_ids={}`), so the `converged_rerun` guard doesn't fire either.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed. (No doc update needed; no-match semantics were not changed for user-checked input.)
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Validation
- [x] `ruff check app tests` — All checks passed.
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/quality_wave/test_registry_chain.py::test_registry_chain_contract_and_rerun_idempotence tests/quality_wave/test_registry_chain.py::test_registry_cold_rebuild_recreates_final_state_from_seed_data` — **2 passed** (both previously failing).
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/quality_wave/` — **177 passed, 6 skipped**.
- [x] Broader suite `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/ -m "not pg"` — 3436 passed, 81 skipped. Two pre-existing failures: `tests/guards/test_no_hardcoded_runtime_defaults.py` (export_runtime_env.sh, unrelated) and `tests/agents/panel_agent/test_proposal_only_outputs.py::test_proposal_outputs_remain_bounded` (cognition_metadata key, also pre-existing on main).

**Dispatcher:** Dispatcher available — used dispatcher-assisted claim flow.

## Notes
- The pre-existing `test_proposal_outputs_remain_bounded` failure (`cognition_metadata` key in logged event payload) is unrelated and predates this PR.