### PR TITLE
feat(agent-memory): promote, reject, and revise memory lifecycle (#1081)

### DIFF
--- a/app/agent_memory/promotion.py
+++ b/app/agent_memory/promotion.py
@@ -1,0 +1,192 @@
+"""Memory promotion, rejection, and revision lifecycle (AGENT-MEMORY-03).
+
+Implements explicit post-review lifecycle decisions as specified in
+``docs/AGENT_MEMORY/PROMOTE_REJECT_AND_REVISE_MEMORY.md``.
+
+Key invariants:
+
+- Promotion preserves provenance and review context, not merely a final value.
+- Rejection is a visible lifecycle outcome that retains the candidate and its
+  rejection receipt; it is not silent deletion.
+- Revision is a correction path that references the prior candidate; earlier
+  evidence is never silently overwritten.
+- Promotion into ``semantic_memory`` requires stricter review evidence than
+  simple episodic retention (i.e. an explicit asserted source reference or a
+  non-inferred candidate).
+
+This module ships no storage backend, activation engine, or recall surface.
+Those are owned by later slices.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+from uuid import uuid4
+
+from pydantic import BaseModel, Field
+
+from app.agent_memory.candidate import MemoryCandidate, MemoryType, ReviewState
+from app.agent_memory.review_queue import (
+    ReviewDecision,
+    ReviewEntry,
+    ReviewStatus,
+)
+
+
+class PromotionError(Exception):
+    """Raised when a promotion lifecycle operation violates an explicit invariant."""
+
+
+class PromotedMemory(BaseModel):
+    """A memory candidate that has completed the review lifecycle.
+
+    Promotion copies the full review entry so that provenance, source references,
+    and the review decision receipt are preserved alongside the promoted content.
+    The artifact is immutable once created; it is a record, not a cursor.
+    """
+
+    promotion_id: str = Field(default_factory=lambda: uuid4().hex)
+    outcome: ReviewState  # ACCEPTED, REJECTED, or REVISED
+    candidate: MemoryCandidate  # full candidate — provenance preserved
+    decided_by: str
+    decided_at: datetime
+    decision_notes: Optional[str] = None
+    # For REVISED outcome: ID of the prior candidate this replaces
+    revision_of: Optional[str] = None
+    promoted_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SEMANTIC_TYPES = {MemoryType.SEMANTIC_MEMORY}
+
+# Episodic memory types that can be promoted with standard review evidence
+_EPISODIC_TYPES = {
+    MemoryType.EPISODIC_MEMORY,
+    MemoryType.WORKING_CONTEXT,
+    MemoryType.PROSPECTIVE_MEMORY,
+    MemoryType.PROCEDURAL_MEMORY,
+    MemoryType.PREFERENCE_MEMORY,
+    MemoryType.POLICY_MEMORY,
+}
+
+
+def _require_decided(entry: ReviewEntry, expected: ReviewDecision) -> None:
+    if entry.status is ReviewStatus.PENDING:
+        raise PromotionError(
+            f"candidate {entry.candidate_id!r} has not been reviewed yet"
+        )
+    if entry.decision is not expected:
+        raise PromotionError(
+            f"candidate {entry.candidate_id!r} has decision "
+            f"{entry.decision!r}, expected {expected!r}"
+        )
+
+
+def _require_asserted_promote_fields(entry: ReviewEntry) -> None:
+    """Semantic promotion requires stricter review evidence.
+
+    Per the Issue constraint:
+    "Semantic promotion (to ``semantic_memory``) requires stricter review evidence
+    than episodic retention."
+
+    Stricter evidence means the candidate must carry at least one source reference
+    *and* must not be flagged as a pure inference (inferred=False), OR it must
+    carry an explicit asserted source reference.  We implement the minimum viable
+    rule: the candidate must either be non-inferred OR have more than one source
+    reference demonstrating cross-session evidence.
+    """
+    candidate = entry.candidate
+    has_multi_source = len(candidate.source_refs) > 1
+    is_asserted = not candidate.inferred
+    if not (is_asserted or has_multi_source):
+        raise PromotionError(
+            f"semantic promotion of {entry.candidate_id!r} requires the candidate to "
+            "be non-inferred (asserted) or carry multiple source references as stricter "
+            "review evidence; inferred single-source candidates may only be retained as "
+            "episodic memory"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def promote(entry: ReviewEntry) -> PromotedMemory:
+    """Promote a reviewed candidate to durable memory.
+
+    Requires ``ReviewDecision.PROMOTE`` to have been recorded on *entry*.
+    Enforces stricter evidence requirements for ``semantic_memory`` targets.
+
+    Returns a :class:`PromotedMemory` with ``outcome=ReviewState.ACCEPTED``
+    and the full review provenance embedded.
+    """
+    _require_decided(entry, ReviewDecision.PROMOTE)
+
+    if entry.candidate.memory_type in _SEMANTIC_TYPES:
+        _require_asserted_promote_fields(entry)
+
+    return PromotedMemory(
+        outcome=ReviewState.ACCEPTED,
+        candidate=entry.candidate,
+        decided_by=entry.decided_by,  # type: ignore[arg-type]
+        decided_at=entry.decided_at,  # type: ignore[arg-type]
+        decision_notes=entry.decision_notes,
+    )
+
+
+def reject(entry: ReviewEntry) -> PromotedMemory:
+    """Record a visible rejection outcome for a reviewed candidate.
+
+    The candidate artifact is *retained* with ``outcome=ReviewState.REJECTED``
+    so the rejection reason and provenance remain inspectable. Rejection is a
+    lifecycle state, not deletion.
+
+    Requires ``ReviewDecision.REJECT`` to have been recorded on *entry*.
+    """
+    _require_decided(entry, ReviewDecision.REJECT)
+
+    return PromotedMemory(
+        outcome=ReviewState.REJECTED,
+        candidate=entry.candidate,
+        decided_by=entry.decided_by,  # type: ignore[arg-type]
+        decided_at=entry.decided_at,  # type: ignore[arg-type]
+        decision_notes=entry.decision_notes,
+    )
+
+
+def revise(original_entry: ReviewEntry, revised_entry: ReviewEntry) -> PromotedMemory:
+    """Record a revision that corrects an earlier candidate.
+
+    The *original_entry* must carry ``ReviewDecision.REVISE``.
+    The *revised_entry* is the new pending candidate that replaced it —
+    it may be PENDING (awaiting its own decision) or already PROMOTED.
+
+    Returns a :class:`PromotedMemory` for the original entry with
+    ``outcome=ReviewState.REVISED`` and ``revision_of`` pointing at the
+    original candidate ID.  The revised entry's ``revision_of`` must reference
+    the original candidate so the chain of evidence is preserved.
+
+    Earlier evidence in the original candidate is never overwritten; it remains
+    accessible via the returned artifact's ``candidate`` field.
+    """
+    _require_decided(original_entry, ReviewDecision.REVISE)
+
+    if revised_entry.revision_of != original_entry.candidate_id:
+        raise PromotionError(
+            f"revised entry {revised_entry.candidate_id!r} does not reference "
+            f"original candidate {original_entry.candidate_id!r} via revision_of"
+        )
+
+    return PromotedMemory(
+        outcome=ReviewState.REVISED,
+        candidate=original_entry.candidate,
+        decided_by=original_entry.decided_by,  # type: ignore[arg-type]
+        decided_at=original_entry.decided_at,  # type: ignore[arg-type]
+        decision_notes=original_entry.decision_notes,
+        revision_of=revised_entry.candidate_id,
+    )

--- a/docs/AGENT_MEMORY/PROMOTE_REJECT_AND_REVISE_MEMORY.md
+++ b/docs/AGENT_MEMORY/PROMOTE_REJECT_AND_REVISE_MEMORY.md
@@ -27,12 +27,16 @@ This task defines the implementation contract for post-review memory decisions. 
 
 ## Concretely
 
-A later implementation should be able to:
+`app/agent_memory/promotion.py` implements the post-review lifecycle decisions:
 
-- promote a reviewed candidate into a more durable memory class,
-- reject a candidate without erasing the evidence trail,
-- revise a candidate when the content or classification was partly right but incomplete,
-- and preserve enough history to explain why the state changed.
+- `promote(entry)` — promotes a reviewed candidate, producing a `PromotedMemory` with
+  `outcome=ACCEPTED` and full provenance embedded.
+- `reject(entry)` — records a visible rejection, producing a `PromotedMemory` with
+  `outcome=REJECTED`; the candidate is retained, not deleted.
+- `revise(original_entry, revised_entry)` — records a correction, producing a `PromotedMemory`
+  with `outcome=REVISED`; earlier evidence is preserved and the correction chain is traceable.
+- `PromotedMemory` — the immutable receipt type that preserves provenance and review context
+  across all three outcomes.
 
 ## Why This Matters
 
@@ -42,13 +46,13 @@ memory can drift into opaque state and rejected memory can disappear without exp
 
 ## Acceptance Criteria
 
-- [ ] Promotion is specified as preserving provenance and review context rather than copying only a
+- [x] Promotion is specified as preserving provenance and review context rather than copying only a
   final memory value. Verify: `tests/agent_memory/test_memory_promotion.py::test_promoted_memory_preserves_provenance`
-- [ ] Rejection is specified as a visible lifecycle outcome rather than silent deletion of the
+- [x] Rejection is specified as a visible lifecycle outcome rather than silent deletion of the
   candidate. Verify: `tests/agent_memory/test_memory_promotion.py::test_rejected_memory_preserves_review_receipt`
-- [ ] Revision is specified as a correction path that can narrow or reclassify a candidate without
+- [x] Revision is specified as a correction path that can narrow or reclassify a candidate without
   erasing earlier evidence. Verify: `tests/agent_memory/test_memory_promotion.py::test_revised_memory_preserves_prior_context`
-- [ ] Promotion into stronger knowledge posture is stricter than simple episodic retention. Verify: `tests/agent_memory/test_memory_promotion.py::test_semantic_promotion_requires_stricter_review_than_episodic_retention`
+- [x] Promotion into stronger knowledge posture is stricter than simple episodic retention. Verify: `tests/agent_memory/test_memory_promotion.py::test_semantic_promotion_requires_stricter_review_than_episodic_retention`
 
 ## How to Verify (Pre-Merge)
 
@@ -71,5 +75,4 @@ memory can drift into opaque state and rejected memory can disappear without exp
 
 ## Related GitHub Issues
 
-Not created in this PR. When filed later, use this task spec as the child implementation issue
-contract for promotion, rejection, and revision flows.
+Implemented by #1081.

--- a/tests/agent_memory/test_memory_promotion.py
+++ b/tests/agent_memory/test_memory_promotion.py
@@ -1,0 +1,348 @@
+"""Tests for memory promotion, rejection, and revision lifecycle (AGENT-MEMORY-03).
+
+Verifies the four Acceptance Criteria from Issue #1081:
+
+1. test_promoted_memory_preserves_provenance
+2. test_rejected_memory_preserves_review_receipt
+3. test_revised_memory_preserves_prior_context
+4. test_semantic_promotion_requires_stricter_review_than_episodic_retention
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.agent_memory.candidate import (
+    ContradictionState,
+    MemoryCandidate,
+    MemoryType,
+    ReviewState,
+)
+from app.agent_memory.promotion import PromotedMemory, PromotionError, promote, reject, revise
+from app.agent_memory.review_queue import (
+    MemoryCandidateReviewQueue,
+    ReviewDecision,
+    ReviewStatus,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _candidate(
+    *,
+    title: str = "Observed user preference",
+    memory_type: MemoryType = MemoryType.PREFERENCE_MEMORY,
+    inferred: bool = True,
+    content: str = "User answered tersely in two consecutive sessions.",
+    source_refs: list[str] | None = None,
+) -> MemoryCandidate:
+    return MemoryCandidate(
+        title=title,
+        memory_type=memory_type,
+        inferred=inferred,
+        content=content,
+        source_refs=source_refs or ["session:2026-05-21T09:00:00Z"],
+        derived_from="conversation:abc123",
+        generated_by="companion_agent",
+    )
+
+
+def _promoted_entry(
+    queue: MemoryCandidateReviewQueue,
+    candidate: MemoryCandidate,
+    *,
+    decided_by: str = "reviewer:rasmus",
+    notes: str | None = None,
+) -> object:
+    queue.enqueue(candidate)
+    return queue.decide(
+        candidate.candidate_id,
+        ReviewDecision.PROMOTE,
+        decided_by=decided_by,
+        notes=notes,
+    )
+
+
+def _rejected_entry(
+    queue: MemoryCandidateReviewQueue,
+    candidate: MemoryCandidate,
+    *,
+    decided_by: str = "reviewer:rasmus",
+    notes: str | None = "Not a stable observation.",
+) -> object:
+    queue.enqueue(candidate)
+    return queue.decide(
+        candidate.candidate_id,
+        ReviewDecision.REJECT,
+        decided_by=decided_by,
+        notes=notes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC 1 — Promotion preserves provenance and review context
+# ---------------------------------------------------------------------------
+
+
+def test_promoted_memory_preserves_provenance() -> None:
+    """Promotion must preserve provenance and review context, not only the final value.
+
+    AC: "Promotion preserves provenance and review context, not only the final memory value."
+    Verify: tests/agent_memory/test_memory_promotion.py::test_promoted_memory_preserves_provenance
+    """
+    queue = MemoryCandidateReviewQueue()
+    candidate = _candidate(
+        title="User prefers concise technical answers",
+        memory_type=MemoryType.PREFERENCE_MEMORY,
+        inferred=True,
+        source_refs=["session:2026-05-21T09:00:00Z"],
+    )
+
+    entry = _promoted_entry(
+        queue,
+        candidate,
+        decided_by="reviewer:rasmus",
+        notes="Confirmed in three consecutive sessions.",
+    )
+
+    result: PromotedMemory = promote(entry)
+
+    # Outcome is ACCEPTED — not merely "reviewed"
+    assert result.outcome is ReviewState.ACCEPTED
+
+    # The full candidate is preserved — provenance fields survive promotion
+    assert result.candidate.candidate_id == candidate.candidate_id
+    assert result.candidate.title == candidate.title
+    assert result.candidate.source_refs == ["session:2026-05-21T09:00:00Z"]
+    assert result.candidate.derived_from == "conversation:abc123"
+    assert result.candidate.generated_by == "companion_agent"
+
+    # The review receipt fields are preserved alongside the promoted content
+    assert result.decided_by == "reviewer:rasmus"
+    assert result.decided_at is not None
+    assert result.decision_notes == "Confirmed in three consecutive sessions."
+
+    # The promotion receipt itself carries a unique ID
+    assert result.promotion_id is not None
+    assert result.promoted_at is not None
+
+
+# ---------------------------------------------------------------------------
+# AC 2 — Rejection preserves the review receipt (visible outcome, not deletion)
+# ---------------------------------------------------------------------------
+
+
+def test_rejected_memory_preserves_review_receipt() -> None:
+    """Rejection must be a visible lifecycle outcome that preserves the review receipt.
+
+    AC: "Rejection is a visible lifecycle outcome that preserves the review receipt."
+    Verify: tests/agent_memory/test_memory_promotion.py::test_rejected_memory_preserves_review_receipt
+    """
+    queue = MemoryCandidateReviewQueue()
+    candidate = _candidate(
+        title="Spurious one-off observation",
+        memory_type=MemoryType.EPISODIC_MEMORY,
+        inferred=True,
+    )
+
+    entry = _rejected_entry(
+        queue,
+        candidate,
+        decided_by="reviewer:rasmus",
+        notes="Single session; not representative of a stable pattern.",
+    )
+
+    result: PromotedMemory = reject(entry)
+
+    # Outcome is REJECTED — a distinct, inspectable lifecycle state
+    assert result.outcome is ReviewState.REJECTED
+
+    # The candidate artifact is retained — rejection is NOT deletion
+    assert result.candidate.candidate_id == candidate.candidate_id
+    assert result.candidate.title == "Spurious one-off observation"
+    assert result.candidate.source_refs == ["session:2026-05-21T09:00:00Z"]
+
+    # The review receipt is preserved: who rejected it, when, and why
+    assert result.decided_by == "reviewer:rasmus"
+    assert result.decided_at is not None
+    assert result.decision_notes == "Single session; not representative of a stable pattern."
+
+    # The rejection receipt has its own ID and timestamp
+    assert result.promotion_id is not None
+    assert result.promoted_at is not None
+
+    # The rejection entry remains visible in the queue (not deleted)
+    queue_entry = queue.get(candidate.candidate_id)
+    assert queue_entry.status is ReviewStatus.REJECTED
+    assert queue_entry.decision_notes is not None
+
+    # A rejected candidate must not become recallable working-context memory
+    assert queue.recallable_for_working_context() == []
+
+    # reject() raises PromotionError if the entry has a non-REJECT decision
+    promote_candidate = _candidate(title="Different candidate")
+    promoted_entry = _promoted_entry(queue, promote_candidate)
+    with pytest.raises(PromotionError):
+        reject(promoted_entry)
+
+
+# ---------------------------------------------------------------------------
+# AC 3 — Revision preserves earlier evidence (correction without erasure)
+# ---------------------------------------------------------------------------
+
+
+def test_revised_memory_preserves_prior_context() -> None:
+    """Revision must preserve earlier evidence; it is a correction path, not erasure.
+
+    AC: "Revision is a correction path that preserves earlier evidence."
+    Verify: tests/agent_memory/test_memory_promotion.py::test_revised_memory_preserves_prior_context
+    """
+    queue = MemoryCandidateReviewQueue()
+    original = _candidate(
+        title="User prefers terse responses",
+        memory_type=MemoryType.PREFERENCE_MEMORY,
+        inferred=True,
+        content="Single session showing short replies.",
+        source_refs=["session:2026-05-20T09:00:00Z"],
+    )
+
+    revision_candidate = MemoryCandidate(
+        title="Revised: user prefers detail on technical topics",
+        memory_type=MemoryType.PREFERENCE_MEMORY,
+        inferred=True,
+        content="Multiple sessions show preference for detail in technical questions.",
+        source_refs=["session:2026-05-21T09:00:00Z"],
+        derived_from="conversation:def456",
+        generated_by="companion_agent",
+        contradiction_state=ContradictionState.CONTRADICTED,
+        correction_of=original.candidate_id,
+        contradiction_notes="Later sessions contradict the initial single-session observation.",
+    )
+
+    queue.enqueue(original)
+    revised_queue_entry = queue.decide(
+        original.candidate_id,
+        ReviewDecision.REVISE,
+        decided_by="reviewer:rasmus",
+        notes="Narrowed to technical-topic preference based on multi-session pattern.",
+        revision=revision_candidate,
+    )
+
+    # The revised candidate enters the queue as a new pending entry
+    revised_entry = queue.get(revision_candidate.candidate_id)
+    assert revised_entry.status is ReviewStatus.PENDING
+    assert revised_entry.revision_of == original.candidate_id
+
+    result: PromotedMemory = revise(revised_queue_entry, revised_entry)
+
+    # Outcome is REVISED — a distinct lifecycle state from ACCEPTED or REJECTED
+    assert result.outcome is ReviewState.REVISED
+
+    # The original candidate's evidence is preserved in the artifact
+    assert result.candidate.candidate_id == original.candidate_id
+    assert result.candidate.title == "User prefers terse responses"
+    assert result.candidate.source_refs == ["session:2026-05-20T09:00:00Z"]
+    assert result.candidate.content == "Single session showing short replies."
+
+    # The review receipt is preserved: reviewer, timestamp, notes
+    assert result.decided_by == "reviewer:rasmus"
+    assert result.decided_at is not None
+    assert result.decision_notes is not None
+
+    # The revision_of field links forward to the revised successor,
+    # so the correction chain is traceable
+    assert result.revision_of == revision_candidate.candidate_id
+
+    # The original queue entry shows REVISED status — evidence is not deleted
+    original_queue_entry = queue.get(original.candidate_id)
+    assert original_queue_entry.status is ReviewStatus.REVISED
+
+    # revise() raises PromotionError if revised_entry does not link to the original
+    unrelated = _candidate(title="Unrelated candidate")
+    queue.enqueue(unrelated)
+    # Manually produce an entry with wrong revision_of by using a non-revision candidate
+    # (revision_of=None does not match original.candidate_id)
+    from app.agent_memory.review_queue import ReviewEntry, ReviewStatus as RS
+    wrong_link_entry = ReviewEntry(
+        candidate=unrelated,
+        status=RS.PENDING,
+        revision_of=None,  # does not reference original
+    )
+    with pytest.raises(PromotionError):
+        revise(revised_queue_entry, wrong_link_entry)
+
+
+# ---------------------------------------------------------------------------
+# AC 4 — Semantic promotion requires stricter review than episodic retention
+# ---------------------------------------------------------------------------
+
+
+def test_semantic_promotion_requires_stricter_review_than_episodic_retention() -> None:
+    """Semantic promotion (semantic_memory) requires stricter review evidence.
+
+    AC: "Promotion into stronger knowledge posture (semantic) requires stricter review
+    than episodic retention."
+    Verify: tests/agent_memory/test_memory_promotion.py::
+             test_semantic_promotion_requires_stricter_review_than_episodic_retention
+    """
+    queue = MemoryCandidateReviewQueue()
+
+    # --- Episodic promotion: inferred + single source is allowed ---
+    episodic_candidate = _candidate(
+        title="User episodic event",
+        memory_type=MemoryType.EPISODIC_MEMORY,
+        inferred=True,
+        source_refs=["session:2026-05-21T09:00:00Z"],
+    )
+    episodic_entry = _promoted_entry(queue, episodic_candidate)
+    episodic_result = promote(episodic_entry)
+    assert episodic_result.outcome is ReviewState.ACCEPTED
+
+    # --- Semantic promotion: inferred + single source is NOT sufficient ---
+    weak_semantic_candidate = _candidate(
+        title="Agent-inferred semantic claim with one source",
+        memory_type=MemoryType.SEMANTIC_MEMORY,
+        inferred=True,  # inferred, only one source reference
+        source_refs=["session:2026-05-21T09:00:00Z"],
+    )
+    weak_entry = _promoted_entry(queue, weak_semantic_candidate)
+    with pytest.raises(PromotionError, match="stricter review evidence"):
+        promote(weak_entry)
+
+    # --- Semantic promotion: asserted (non-inferred) is allowed ---
+    asserted_semantic_candidate = _candidate(
+        title="Human-asserted semantic fact",
+        memory_type=MemoryType.SEMANTIC_MEMORY,
+        inferred=False,  # explicitly asserted by a reviewer
+        source_refs=["note:explicit-knowledge.md"],
+    )
+    asserted_entry = _promoted_entry(queue, asserted_semantic_candidate)
+    asserted_result = promote(asserted_entry)
+    assert asserted_result.outcome is ReviewState.ACCEPTED
+
+    # --- Semantic promotion: inferred but multi-source is allowed ---
+    multi_source_semantic_candidate = _candidate(
+        title="Agent-inferred semantic claim with multi-session evidence",
+        memory_type=MemoryType.SEMANTIC_MEMORY,
+        inferred=True,
+        source_refs=[
+            "session:2026-05-19T09:00:00Z",
+            "session:2026-05-20T09:00:00Z",
+        ],
+    )
+    multi_source_entry = _promoted_entry(queue, multi_source_semantic_candidate)
+    multi_source_result = promote(multi_source_entry)
+    assert multi_source_result.outcome is ReviewState.ACCEPTED
+
+    # --- promote() raises PromotionError for candidates with non-PROMOTE decision ---
+    reject_semantic_candidate = _candidate(
+        title="Rejected semantic candidate",
+        memory_type=MemoryType.SEMANTIC_MEMORY,
+        inferred=False,
+    )
+    reject_entry = _rejected_entry(queue, reject_semantic_candidate)
+    with pytest.raises(PromotionError):
+        promote(reject_entry)


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Fixes #1081

## Summary
- Adds `app/agent_memory/promotion.py` with `PromotedMemory`, `promote()`, `reject()`, and `revise()` implementing the post-review memory lifecycle (AGENT-MEMORY-03).
- Adds `tests/agent_memory/test_memory_promotion.py` with all four AC tests passing.
- Updates `docs/AGENT_MEMORY/PROMOTE_REJECT_AND_REVISE_MEMORY.md` to reflect shipped reality (checked ACs, updated Concretely section, updated Related GitHub Issues).

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Validation
Implementation lane:
- [x] `ruff check app tests` — All checks passed!
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/agent_memory/test_memory_promotion.py` — 4 passed
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/agent_memory/` — 12 passed

```
$ ruff check app tests
All checks passed!

$ PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/agent_memory/test_memory_promotion.py
....
4 passed in 1.72s

$ PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/agent_memory/
............
12 passed in 0.56s
```

## Dispatcher
Dispatcher available (db_exists: true). Claimed task `github-issue-1081` with lease `lease-e6bafbe3`. GitHub-label claim via `scripts/issue_pickup_claim.sh --issue 1081 --skip-preflight`.

## Notes
- `PromotedMemory` is an immutable receipt (Pydantic BaseModel) — no storage backend; storage semantics remain out of scope for this slice.
- Semantic-memory stricter-evidence rule: candidate must be non-inferred (asserted) OR carry multiple source references. Single-source inferred candidates are rejected with a clear `PromotionError`.
- `promote()`, `reject()`, and `revise()` all raise `PromotionError` if the `ReviewEntry` does not carry the expected `ReviewDecision`, enforcing the one-way lifecycle boundary.