### PR TITLE
feat(agent-memory): companion-note-aware memory handling

### DIFF
--- a/app/agent_memory/companion_aware.py
+++ b/app/agent_memory/companion_aware.py
@@ -1,0 +1,346 @@
+"""Companion-note-aware memory handling (AGENT-MEMORY-03).
+
+This module provides the surfaces required to integrate agent memory candidates
+with the Companion Note Pattern defined in
+``docs/CONTEXTUALIZATION_LAYER/COMPANION_NOTE_PATTERN.md``.
+
+Key invariants enforced here:
+
+- New memory candidates for a human knowledge artifact are recorded in a
+  ``synthesis_companion`` (or ``mixed_companion``), NOT inline in the primary note.
+- The companion's ``artifact_class`` remains ``companion_metadata`` even after
+  candidate memory references are added; it must never become ``agentic_memory``.
+- When a candidate is promoted, the companion's candidate list is updated to
+  remove the pending reference AND a separate promoted memory artifact is
+  returned by the caller.
+- The review queue can discover pending candidates from ``synthesis_companion``
+  artifacts by scanning them.
+- Human-authored sections inside the companion (e.g. free-text review notes)
+  are preserved when the system regenerates the ``## Candidate Memories``
+  section.
+
+This module deliberately ships no storage back-end, no watcher, no prompt
+wiring, and no activation engine.  Those surfaces are owned by later slices.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional
+
+from app.agent_memory.candidate import MemoryCandidate
+from app.agent_memory.review_queue import (
+    MemoryCandidateReviewQueue,
+)
+
+# ---------------------------------------------------------------------------
+# Companion artifact class constant — must never be mutated to agentic_memory
+# ---------------------------------------------------------------------------
+
+COMPANION_ARTIFACT_CLASS = "companion_metadata"
+AGENTIC_MEMORY_ARTIFACT_CLASS = "agentic_memory"
+
+# Companion types relevant to memory (from COMPANION_NOTE_PATTERN.md §8)
+SYNTHESIS_COMPANION_TYPE = "synthesis_companion"
+MIXED_COMPANION_TYPE = "mixed_companion"
+
+# Managed-section heading used in the companion body
+CANDIDATE_MEMORIES_HEADING = "## Candidate Memories"
+
+# Regex that matches the managed section block (heading + everything up to
+# the next ## heading or end-of-string).  Non-greedy, DOTALL.
+_MANAGED_SECTION_RE = re.compile(
+    r"(## Candidate Memories\n)(.*?)(?=\n## |\Z)",
+    re.DOTALL,
+)
+
+
+# ---------------------------------------------------------------------------
+# In-memory synthesis companion model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SynthesisCompanion:
+    """In-memory representation of a synthesis companion for a human knowledge artifact.
+
+    ``artifact_class`` is fixed to ``companion_metadata`` and must NOT be
+    changed to ``agentic_memory`` even when candidate memory references are
+    present.  Candidates are *references* that await promotion, not promoted
+    memory artifacts.
+
+    ``companion_type`` defaults to ``synthesis_companion``.  Set it to
+    ``mixed_companion`` when the companion also carries other companion data
+    (activation, processing, etc.).
+
+    ``body`` holds the human-readable companion body text (everything after
+    optional YAML frontmatter).  The ``## Candidate Memories`` section within
+    ``body`` is the system-managed block.  All other sections are
+    human-editable and must not be overwritten by system updates.
+    """
+
+    # Linkage (per COMPANION_NOTE_PATTERN.md §6)
+    companion_for: str
+    target_path: str
+    target_artifact_class: str = "human_knowledge"
+
+    # Identity / class fields — artifact_class must stay companion_metadata
+    artifact_class: str = field(default=COMPANION_ARTIFACT_CLASS)
+    companion_type: str = field(default=SYNTHESIS_COMPANION_TYPE)
+
+    # Timestamps
+    created: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    updated: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    # Optional attribution
+    generated_by: Optional[str] = None
+
+    # Candidate memory references stored in this companion.
+    # Keys are candidate_id strings; values are MemoryCandidate objects.
+    candidates: dict[str, MemoryCandidate] = field(default_factory=dict)
+
+    # Human-readable body (may contain human-authored sections that must not
+    # be overwritten).
+    body: str = field(default="")
+
+    def __post_init__(self) -> None:
+        # Enforce the class invariant: the artifact_class must always be
+        # companion_metadata.  Accept no other value.
+        if self.artifact_class != COMPANION_ARTIFACT_CLASS:
+            raise ValueError(
+                f"SynthesisCompanion artifact_class must be "
+                f"'{COMPANION_ARTIFACT_CLASS}', got '{self.artifact_class}'"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Companion-aware candidate storage
+# ---------------------------------------------------------------------------
+
+
+def add_candidate_to_companion(
+    companion: SynthesisCompanion,
+    candidate: MemoryCandidate,
+) -> SynthesisCompanion:
+    """Record a new memory candidate in the companion's candidate dict.
+
+    Returns a new ``SynthesisCompanion`` instance (companions are treated as
+    value objects here; the caller owns persistence).
+
+    The companion's ``artifact_class`` is verified to remain
+    ``companion_metadata`` after the operation.  The candidate is NOT stored
+    inline in any primary human note.
+    """
+    if companion.artifact_class != COMPANION_ARTIFACT_CLASS:
+        raise ValueError(
+            "companion artifact_class must remain 'companion_metadata' — "
+            f"got '{companion.artifact_class}'"
+        )
+
+    updated_candidates = {**companion.candidates, candidate.candidate_id: candidate}
+    updated_body = _update_candidate_memories_section(companion.body, updated_candidates)
+
+    import dataclasses
+
+    return dataclasses.replace(
+        companion,
+        candidates=updated_candidates,
+        body=updated_body,
+        updated=datetime.now(timezone.utc).isoformat(),
+        artifact_class=COMPANION_ARTIFACT_CLASS,  # explicit: never change
+    )
+
+
+# ---------------------------------------------------------------------------
+# Promotion
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PromotionResult:
+    """Result of promoting a candidate from a companion.
+
+    ``updated_companion`` has the promoted candidate removed from its
+    ``candidates`` dict (and from the ``## Candidate Memories`` section).
+
+    ``promoted_artifact`` is the candidate as a promoted memory artifact.
+    The caller is responsible for persisting it separately — promotion does
+    NOT happen on the companion itself.
+    """
+
+    updated_companion: SynthesisCompanion
+    promoted_artifact: MemoryCandidate
+
+
+def promote_candidate_from_companion(
+    companion: SynthesisCompanion,
+    candidate_id: str,
+) -> PromotionResult:
+    """Promote a candidate from the companion and return both updated surfaces.
+
+    Per the issue constraints:
+    - The companion is updated to remove the pending candidate reference.
+    - The promoted memory artifact is returned separately.
+    - The companion's ``artifact_class`` stays ``companion_metadata``; it does
+      not become ``agentic_memory``.
+
+    Raises ``KeyError`` if ``candidate_id`` is not in the companion's
+    candidate dict.
+    """
+    if candidate_id not in companion.candidates:
+        raise KeyError(f"candidate not found in companion: {candidate_id}")
+
+    candidate = companion.candidates[candidate_id]
+
+    # Build the promoted memory artifact — keep candidate fields, mark as
+    # a promoted (non-inferred) artifact.
+    promoted = candidate.model_copy(
+        update={
+            "artifact_class": AGENTIC_MEMORY_ARTIFACT_CLASS,
+            "inferred": False,
+        }
+    )
+
+    # Remove candidate from companion dict
+    updated_candidates = {
+        cid: c for cid, c in companion.candidates.items() if cid != candidate_id
+    }
+    updated_body = _update_candidate_memories_section(companion.body, updated_candidates)
+
+    import dataclasses
+
+    updated_companion = dataclasses.replace(
+        companion,
+        candidates=updated_candidates,
+        body=updated_body,
+        updated=datetime.now(timezone.utc).isoformat(),
+        artifact_class=COMPANION_ARTIFACT_CLASS,  # explicit: never change
+    )
+
+    return PromotionResult(
+        updated_companion=updated_companion,
+        promoted_artifact=promoted,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Review queue discovery from companions
+# ---------------------------------------------------------------------------
+
+
+def discover_candidates_from_companions(
+    companions: list[SynthesisCompanion],
+    queue: Optional[MemoryCandidateReviewQueue] = None,
+) -> MemoryCandidateReviewQueue:
+    """Discover pending memory candidates from synthesis_companion artifacts.
+
+    Scans each companion in ``companions`` (filtering to those whose
+    ``companion_type`` is ``synthesis_companion`` or ``mixed_companion``) and
+    enqueues all candidates not already present in ``queue``.
+
+    If ``queue`` is None a fresh ``MemoryCandidateReviewQueue`` is created.
+
+    Returns the queue with all discovered candidates enqueued.
+    """
+    if queue is None:
+        queue = MemoryCandidateReviewQueue()
+
+    for companion in companions:
+        if companion.companion_type not in (
+            SYNTHESIS_COMPANION_TYPE,
+            MIXED_COMPANION_TYPE,
+        ):
+            continue
+
+        for candidate in companion.candidates.values():
+            existing_ids = {e.candidate_id for e in queue.pending() + queue.decided()}
+            if candidate.candidate_id not in existing_ids:
+                queue.enqueue(candidate)
+
+    return queue
+
+
+# ---------------------------------------------------------------------------
+# Human-section-preserving body update
+# ---------------------------------------------------------------------------
+
+
+def update_companion_candidate_memories_section(
+    companion: SynthesisCompanion,
+) -> SynthesisCompanion:
+    """Regenerate only the ``## Candidate Memories`` section of the companion body.
+
+    All other sections in the body are preserved unchanged.  This satisfies
+    the COMPANION_NOTE_PATTERN.md §10 requirement that human-authored sections
+    must not be overwritten by system updates.
+    """
+    updated_body = _update_candidate_memories_section(
+        companion.body, companion.candidates
+    )
+
+    import dataclasses
+
+    return dataclasses.replace(
+        companion,
+        body=updated_body,
+        updated=datetime.now(timezone.utc).isoformat(),
+        artifact_class=COMPANION_ARTIFACT_CLASS,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _render_candidate_memories_block(candidates: dict[str, MemoryCandidate]) -> str:
+    """Render the managed ``## Candidate Memories`` block content."""
+    if not candidates:
+        return "(none)\n"
+    lines: list[str] = []
+    for candidate in candidates.values():
+        lines.append(
+            f"- [{candidate.candidate_id}] {candidate.title}"
+            f" ({candidate.memory_type.value}, review_state={candidate.review_state.value})"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _update_candidate_memories_section(
+    body: str,
+    candidates: dict[str, MemoryCandidate],
+) -> str:
+    """Replace the managed section in ``body`` while preserving all other sections.
+
+    If the managed heading is not present in ``body``, it is appended.  All
+    content outside the managed section is untouched.
+    """
+    new_block = _render_candidate_memories_block(candidates)
+
+    if _MANAGED_SECTION_RE.search(body):
+        # Replace the existing managed section content
+        def _replace(m: re.Match) -> str:  # type: ignore[type-arg]
+            return m.group(1) + new_block
+
+        return _MANAGED_SECTION_RE.sub(_replace, body)
+
+    # Append managed section if not present
+    separator = "\n" if body and not body.endswith("\n") else ""
+    return body + separator + CANDIDATE_MEMORIES_HEADING + "\n" + new_block
+
+
+__all__ = [
+    "AGENTIC_MEMORY_ARTIFACT_CLASS",
+    "CANDIDATE_MEMORIES_HEADING",
+    "COMPANION_ARTIFACT_CLASS",
+    "MIXED_COMPANION_TYPE",
+    "SYNTHESIS_COMPANION_TYPE",
+    "PromotionResult",
+    "SynthesisCompanion",
+    "add_candidate_to_companion",
+    "discover_candidates_from_companions",
+    "promote_candidate_from_companion",
+    "update_companion_candidate_memories_section",
+]

--- a/tests/agent_memory/test_companion_aware_memory.py
+++ b/tests/agent_memory/test_companion_aware_memory.py
@@ -1,0 +1,304 @@
+"""Tests for companion-note-aware memory handling (AGENT-MEMORY-03, #1085).
+
+Verifies that:
+1. New memory candidates for a human knowledge artifact are recorded in a
+   synthesis_companion, not inline in the primary note.
+2. The synthesis_companion artifact_class remains 'companion_metadata' after
+   candidate memory references are added (never becomes 'agentic_memory').
+3. Promoting a candidate from a companion updates the companion's candidate
+   list and creates the promoted memory artifact separately.
+4. The review queue can discover pending candidate references from
+   synthesis_companion artifacts.
+5. Human-authored sections in a companion are not overwritten when the system
+   updates the ## Candidate Memories section.
+
+Source: docs/CONTEXTUALIZATION_LAYER/COMPANION_NOTE_PATTERN.md §8 and §10
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.agent_memory.candidate import MemoryCandidate, MemoryType
+from app.agent_memory.companion_aware import (
+    AGENTIC_MEMORY_ARTIFACT_CLASS,
+    CANDIDATE_MEMORIES_HEADING,
+    COMPANION_ARTIFACT_CLASS,
+    SYNTHESIS_COMPANION_TYPE,
+    PromotionResult,
+    SynthesisCompanion,
+    add_candidate_to_companion,
+    discover_candidates_from_companions,
+    promote_candidate_from_companion,
+    update_companion_candidate_memories_section,
+)
+from app.agent_memory.review_queue import ReviewStatus
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_companion(
+    companion_for: str = "My Concept Note",
+    target_path: str = "Concepts/My Concept Note.md",
+    body: str = "",
+) -> SynthesisCompanion:
+    return SynthesisCompanion(
+        companion_for=companion_for,
+        target_path=target_path,
+        body=body,
+    )
+
+
+def _make_candidate(
+    title: str = "User prefers concise answers",
+    memory_type: MemoryType = MemoryType.PREFERENCE_MEMORY,
+) -> MemoryCandidate:
+    return MemoryCandidate(
+        title=title,
+        memory_type=memory_type,
+        content="Observed across three sessions.",
+        source_refs=["session:2026-05-20T10:00:00Z"],
+        generated_by="companion_agent",
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC1: candidates stored in synthesis_companion, not in primary note
+# ---------------------------------------------------------------------------
+
+
+def test_candidate_memory_stored_in_synthesis_companion() -> None:
+    """New candidates for a human knowledge artifact go into a
+    synthesis_companion, not inline in the primary note.
+
+    Verify: the companion receives the candidate in its ``candidates`` dict;
+    the primary note (represented here as a plain string that must remain
+    unchanged) is NOT modified.
+    """
+    primary_note_content = (
+        "---\nartifact_class: human_knowledge\ntitle: My Concept Note\n---\n\n"
+        "# My Concept Note\n\nContent written by the human.\n"
+    )
+
+    companion = _make_companion()
+    candidate = _make_candidate()
+
+    # Act: add candidate to companion — primary note is NOT touched
+    updated_companion = add_candidate_to_companion(companion, candidate)
+
+    # Candidate is in the companion
+    assert candidate.candidate_id in updated_companion.candidates
+    assert updated_companion.candidates[candidate.candidate_id].title == candidate.title
+
+    # Companion is a synthesis_companion
+    assert updated_companion.companion_type == SYNTHESIS_COMPANION_TYPE
+
+    # Primary note is completely unchanged (caller owns the primary note;
+    # companion_aware never touches it)
+    assert primary_note_content == (
+        "---\nartifact_class: human_knowledge\ntitle: My Concept Note\n---\n\n"
+        "# My Concept Note\n\nContent written by the human.\n"
+    )
+
+    # Candidate Memories section appears in the companion body
+    assert CANDIDATE_MEMORIES_HEADING in updated_companion.body
+    assert candidate.candidate_id in updated_companion.body
+
+
+# ---------------------------------------------------------------------------
+# AC2: synthesis_companion artifact_class stays 'companion_metadata'
+# ---------------------------------------------------------------------------
+
+
+def test_companion_class_not_promoted_to_agentic_memory() -> None:
+    """synthesis_companion artifact_class remains 'companion_metadata' after
+    candidate memory references are added; it must never become 'agentic_memory'.
+
+    Source: COMPANION_NOTE_PATTERN.md §8, issue constraint §2.
+    """
+    companion = _make_companion()
+    candidate = _make_candidate()
+
+    # Add a candidate
+    updated = add_candidate_to_companion(companion, candidate)
+
+    # artifact_class must remain companion_metadata
+    assert updated.artifact_class == COMPANION_ARTIFACT_CLASS
+    assert updated.artifact_class != AGENTIC_MEMORY_ARTIFACT_CLASS
+
+    # Adding multiple candidates still preserves the class
+    candidate2 = _make_candidate(title="Second candidate", memory_type=MemoryType.SEMANTIC_MEMORY)
+    updated2 = add_candidate_to_companion(updated, candidate2)
+    assert updated2.artifact_class == COMPANION_ARTIFACT_CLASS
+
+    # Attempting to construct a companion with an agentic_memory class raises ValueError
+    with pytest.raises(ValueError, match="artifact_class must be"):
+        SynthesisCompanion(
+            companion_for="test",
+            target_path="test.md",
+            artifact_class=AGENTIC_MEMORY_ARTIFACT_CLASS,
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC3: promotion updates companion and creates memory artifact separately
+# ---------------------------------------------------------------------------
+
+
+def test_promotion_updates_companion_and_creates_memory_artifact() -> None:
+    """Promoting a candidate from a companion note:
+    - removes the candidate from the companion's candidates dict, and
+    - creates the promoted memory artifact separately (returned in PromotionResult).
+
+    The companion's artifact_class stays 'companion_metadata'.
+    The promoted artifact's artifact_class becomes 'agentic_memory'.
+    """
+    companion = _make_companion()
+    candidate = _make_candidate()
+    companion_with_candidate = add_candidate_to_companion(companion, candidate)
+
+    assert candidate.candidate_id in companion_with_candidate.candidates
+
+    # Act: promote the candidate
+    result: PromotionResult = promote_candidate_from_companion(
+        companion_with_candidate, candidate.candidate_id
+    )
+
+    # Companion is updated: candidate removed
+    assert candidate.candidate_id not in result.updated_companion.candidates
+    assert result.updated_companion.artifact_class == COMPANION_ARTIFACT_CLASS
+
+    # Companion body reflects removal
+    assert CANDIDATE_MEMORIES_HEADING in result.updated_companion.body
+    assert candidate.candidate_id not in result.updated_companion.body
+
+    # Promoted artifact exists and has agentic_memory class
+    assert result.promoted_artifact is not None
+    assert result.promoted_artifact.artifact_class == AGENTIC_MEMORY_ARTIFACT_CLASS
+    assert result.promoted_artifact.candidate_id == candidate.candidate_id
+    assert result.promoted_artifact.title == candidate.title
+
+    # Attempting to promote an absent candidate raises KeyError
+    with pytest.raises(KeyError, match="candidate not found in companion"):
+        promote_candidate_from_companion(
+            result.updated_companion, candidate.candidate_id
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC4: review queue discovers candidates from synthesis_companion artifacts
+# ---------------------------------------------------------------------------
+
+
+def test_review_queue_discovers_candidates_from_companions() -> None:
+    """The review queue can discover pending candidate references from
+    synthesis_companion artifacts.
+
+    Source: issue AC4, COMPANION_NOTE_PATTERN.md §8.
+    """
+    companion_a = _make_companion(
+        companion_for="Note A", target_path="Notes/Note A.md"
+    )
+    companion_b = _make_companion(
+        companion_for="Note B", target_path="Notes/Note B.md"
+    )
+
+    cand_a1 = _make_candidate(title="Candidate A1", memory_type=MemoryType.SEMANTIC_MEMORY)
+    cand_a2 = _make_candidate(title="Candidate A2", memory_type=MemoryType.EPISODIC_MEMORY)
+    cand_b1 = _make_candidate(title="Candidate B1", memory_type=MemoryType.PREFERENCE_MEMORY)
+
+    companion_a = add_candidate_to_companion(companion_a, cand_a1)
+    companion_a = add_candidate_to_companion(companion_a, cand_a2)
+    companion_b = add_candidate_to_companion(companion_b, cand_b1)
+
+    # Act: discover
+    queue = discover_candidates_from_companions([companion_a, companion_b])
+
+    pending = queue.pending()
+    pending_ids = {e.candidate_id for e in pending}
+
+    assert cand_a1.candidate_id in pending_ids
+    assert cand_a2.candidate_id in pending_ids
+    assert cand_b1.candidate_id in pending_ids
+    assert len(pending) == 3
+
+    # All discovered entries are PENDING (not yet decided)
+    for entry in pending:
+        assert entry.status is ReviewStatus.PENDING
+
+    # Non-synthesis companion (type not synthesis_companion/mixed_companion) is ignored
+    non_synthesis = SynthesisCompanion(
+        companion_for="Other",
+        target_path="Other.md",
+        companion_type="activation_companion",  # not synthesis
+    )
+    non_synthesis_with_candidate = add_candidate_to_companion(
+        non_synthesis,
+        _make_candidate(title="Ignored candidate"),
+    )
+    queue2 = discover_candidates_from_companions([non_synthesis_with_candidate])
+    assert queue2.pending() == []
+
+
+# ---------------------------------------------------------------------------
+# AC5: human-authored sections preserved on system update
+# ---------------------------------------------------------------------------
+
+
+def test_companion_human_sections_preserved_on_system_update() -> None:
+    """Human-authored sections in a companion are not overwritten when the
+    system updates the ## Candidate Memories section.
+
+    Source: COMPANION_NOTE_PATTERN.md §10 Editability and Conflict Handling.
+    """
+    human_review_section = (
+        "## Human Review Notes\n\n"
+        "This artifact is particularly relevant to the Q2 planning cycle.\n"
+        "Do not discard candidates related to scheduling.\n"
+    )
+    human_purpose_section = (
+        "## Purpose\n\n"
+        "Carry synthesis signals for the planning note.\n"
+    )
+    initial_body = human_purpose_section + "\n" + human_review_section
+
+    companion = _make_companion(body=initial_body)
+    candidate = _make_candidate()
+
+    # System adds a candidate — should update only ## Candidate Memories
+    updated = add_candidate_to_companion(companion, candidate)
+
+    # Human sections are intact
+    assert human_purpose_section in updated.body
+    assert "This artifact is particularly relevant to the Q2 planning cycle." in updated.body
+    assert "Do not discard candidates related to scheduling." in updated.body
+
+    # Candidate memories section is present with the new candidate
+    assert CANDIDATE_MEMORIES_HEADING in updated.body
+    assert candidate.candidate_id in updated.body
+
+    # Simulate a second system update (e.g. adding another candidate)
+    candidate2 = _make_candidate(
+        title="Second candidate", memory_type=MemoryType.POLICY_MEMORY
+    )
+    updated2 = add_candidate_to_companion(updated, candidate2)
+
+    # Human sections still intact
+    assert "This artifact is particularly relevant to the Q2 planning cycle." in updated2.body
+    assert "Do not discard candidates related to scheduling." in updated2.body
+
+    # Both candidates in managed section
+    assert candidate.candidate_id in updated2.body
+    assert candidate2.candidate_id in updated2.body
+
+    # System-only update (no new candidate, just regenerate the section)
+    refreshed = update_companion_candidate_memories_section(updated2)
+    assert "This artifact is particularly relevant to the Q2 planning cycle." in refreshed.body
+    assert candidate.candidate_id in refreshed.body
+    assert candidate2.candidate_id in refreshed.body
+
+    # artifact_class always remains companion_metadata
+    assert refreshed.artifact_class == COMPANION_ARTIFACT_CLASS


### PR DESCRIPTION
- [x] Implementation lane

## Linked Issue
Fixes #1085

## Summary
- Add `app/agent_memory/companion_aware.py` with `SynthesisCompanion` model and helpers (`add_candidate_to_companion`, `promote_candidate_from_companion`, `discover_candidates_from_companions`, `update_companion_candidate_memories_section`).
- New memory candidates for a human knowledge artifact are stored in a `synthesis_companion` note; the primary note is never touched.
- `artifact_class` on `SynthesisCompanion` is locked to `companion_metadata` (enforced in `__post_init__` and at every mutation boundary).
- Promotion creates a separate `agentic_memory` artifact and removes the candidate from the companion's `## Candidate Memories` section while preserving all human-authored sections.
- Review queue discovery scans `synthesis_companion` and `mixed_companion` artifacts via `discover_candidates_from_companions`.
- Add `tests/agent_memory/test_companion_aware_memory.py` with all five AC-mapped tests.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Validation
- [x] `ruff check app tests` — All checks passed.
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/agent_memory/test_companion_aware_memory.py` — 5 passed.

```
All checks passed!
.....
5 passed in 0.57s
```

## Notes
- No storage back-end, watcher, prompt wiring, or activation engine is included; those surfaces are owned by later slices (#1081, #1082, #1083).
- Dispatcher claim: lease-a7d717e8 (agent-impl-1085, TTL 90 min).