### PR TITLE
fix(companion-ui): remove unused imports and dead assignment in visual_shell

### DIFF
--- a/companion-ui/companion-app/companion_ui/panel/visual_shell.py
+++ b/companion-ui/companion-app/companion_ui/panel/visual_shell.py
@@ -17,14 +17,12 @@ Boundary:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from typing import Optional
 
 from companion_ui.panel.render_model import PanelRenderState, render_panel_state
 from companion_ui.panel.proposal_row import (
     ProposalRow,
     ProposalReceipt,
-    ProposalEvidence,
     make_stub_proposal_row,
     make_stub_receipt,
 )
@@ -158,7 +156,7 @@ def build_confirming_view(artifact_id: str) -> PanelShellView:
     )
     session = PanelInteractionSession(artifact_id=artifact_id)
     for p in proposals:
-        s = session.register_proposal(p.proposal_id)
+        session.register_proposal(p.proposal_id)
     # Simulate user confirming prop-001
     session.get("prop-001").confirm()
     return PanelShellView(


### PR DESCRIPTION
- [x] Docs authoring lane

## Summary
Lovability audit (Phase 5) found 4 ruff lint violations in `panel/visual_shell.py`: 3 unused imports (`datetime`, `timezone`, `ProposalEvidence`) and 1 unused local variable (`s`). No logic change.

## Changes
- `companion-ui/companion-app/companion_ui/panel/visual_shell.py`: remove unused imports and dead assignment

## Validation
- `ruff check companion-ui/companion-app/companion_ui/` → `All checks passed!`
- `tests/companion_ui/test_panel_visual_shell.py` → 24/24 passed
- `tests/companion_ui/` full suite → 775/775 passed (pre-change)

---