### PR TITLE
feat(companion-runtime): expose resolved vault/channel identity in workspace UI

### DIFF
--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -110,14 +110,14 @@ def _safe_api_label() -> str:
     return (os.getenv("COMPANION_API_BASE_URL_LABEL") or "local-dev").strip() or "local-dev"
 
 
-def _vault_identity_state() -> VaultIdentityState:
+def _vault_identity_state(vault_root: Path) -> VaultIdentityState:
     vault_root_raw = os.getenv("VAULT_ROOT", "").strip()
-    if vault_root_raw:
-        vault_name = Path(vault_root_raw).name or vault_root_raw
-        provenance = "env"
+    resolved_vault_name = vault_root.name or str(vault_root)
+    if not vault_root_raw:
+        provenance = "default"
     else:
-        vault_name = "unresolved"
-        provenance = "unresolved"
+        env_path = Path(vault_root_raw).resolve()
+        provenance = "env" if env_path == vault_root.resolve() else "fallback"
     raw_channel = (
         os.getenv("PKM_ENVIRONMENT")
         or os.getenv("CHANNEL")
@@ -125,7 +125,11 @@ def _vault_identity_state() -> VaultIdentityState:
         or ""
     ).strip().lower()
     channel = raw_channel if raw_channel in {"dev", "test", "prod"} else "unknown"
-    return VaultIdentityState(vault_name=vault_name, channel=channel, provenance=provenance)
+    return VaultIdentityState(
+        vault_name=resolved_vault_name,
+        channel=channel,
+        provenance=provenance,
+    )
 
 
 def _validate_workspace_note_path(note_path_raw: str) -> str:
@@ -400,7 +404,7 @@ def read_companion_workspace(
             environment_label=_safe_environment_label(),
             api_base_url_label=_safe_api_label(),
             trace_id=trace_id,
-            vault_identity=_vault_identity_state(),
+            vault_identity=_vault_identity_state(vault_root),
             reorient=_reorient_state(),
             resurface=_resurface_state(safe_note_path),
         ),

--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -34,10 +34,17 @@ class ArtifactState(BaseModel):
     owns_identity: bool = True
 
 
+class VaultIdentityState(BaseModel):
+    vault_name: str
+    channel: str
+    provenance: str
+
+
 class RuntimeState(BaseModel):
     environment_label: str
     api_base_url_label: str
     trace_id: str
+    vault_identity: VaultIdentityState
     reorient: dict[str, list[dict[str, str | bool]]] = Field(default_factory=dict)
     resurface: dict[str, list[dict[str, str | list[str]]]] = Field(default_factory=dict)
 
@@ -101,6 +108,24 @@ def _safe_environment_label() -> str:
 
 def _safe_api_label() -> str:
     return (os.getenv("COMPANION_API_BASE_URL_LABEL") or "local-dev").strip() or "local-dev"
+
+
+def _vault_identity_state() -> VaultIdentityState:
+    vault_root_raw = os.getenv("VAULT_ROOT", "").strip()
+    if vault_root_raw:
+        vault_name = Path(vault_root_raw).name or vault_root_raw
+        provenance = "env"
+    else:
+        vault_name = "unresolved"
+        provenance = "unresolved"
+    raw_channel = (
+        os.getenv("PKM_ENVIRONMENT")
+        or os.getenv("CHANNEL")
+        or os.getenv("PKM_CHANNEL")
+        or ""
+    ).strip().lower()
+    channel = raw_channel if raw_channel in {"dev", "test", "prod"} else "unknown"
+    return VaultIdentityState(vault_name=vault_name, channel=channel, provenance=provenance)
 
 
 def _validate_workspace_note_path(note_path_raw: str) -> str:
@@ -375,6 +400,7 @@ def read_companion_workspace(
             environment_label=_safe_environment_label(),
             api_base_url_label=_safe_api_label(),
             trace_id=trace_id,
+            vault_identity=_vault_identity_state(),
             reorient=_reorient_state(),
             resurface=_resurface_state(safe_note_path),
         ),

--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -106,6 +106,9 @@ class DevPageState:
     runtime_environment_label: str = "unknown"
     runtime_api_base_url_label: str = "local-dev"
     runtime_trace_id: str = ""
+    runtime_vault_name: str = "unresolved"
+    runtime_vault_channel: str = "unknown"
+    runtime_vault_provenance: str = "unresolved"
     canvas_session_id: str | None = None
     canvas_session_state: str = "idle"
     canvas_user_present: bool = False
@@ -282,6 +285,9 @@ class RealNoteWorkspaceDevPage:
             runtime_environment_label=runtime.get("environment_label") or "unknown",
             runtime_api_base_url_label=runtime.get("api_base_url_label") or "local-dev",
             runtime_trace_id=runtime.get("trace_id") or "",
+            runtime_vault_name=(runtime.get("vault_identity") or {}).get("vault_name") or "unresolved",
+            runtime_vault_channel=(runtime.get("vault_identity") or {}).get("channel") or "unknown",
+            runtime_vault_provenance=(runtime.get("vault_identity") or {}).get("provenance") or "unresolved",
             canvas_session_id=canvas.get("session_id"),
             canvas_session_state=session_state,
             canvas_user_present=bool(canvas.get("user_present", False)),
@@ -706,6 +712,9 @@ class RealNoteWorkspaceDevPage:
             "runtime_environment_label": self.state.runtime_environment_label,
             "runtime_api_base_url_label": self.state.runtime_api_base_url_label,
             "runtime_trace_id": self.state.runtime_trace_id,
+            "runtime_vault_name": self.state.runtime_vault_name,
+            "runtime_vault_channel": self.state.runtime_vault_channel,
+            "runtime_vault_provenance": self.state.runtime_vault_provenance,
             "canvas_session_id": self.state.canvas_session_id,
             "canvas_session_state": self.state.canvas_session_state,
             "canvas_user_present": self.state.canvas_user_present,

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -95,6 +95,9 @@ def _render_note_section(fields: dict) -> str:
     runtime_environment = _e(_status_label(fields.get("runtime_environment_label")))
     runtime_channel = _e(_status_label(fields.get("runtime_api_base_url_label"), fallback="local-dev"))
     runtime_trace_id = _e(fields.get("runtime_trace_id") or "")
+    vault_name = _e(fields.get("runtime_vault_name") or "unresolved")
+    vault_channel = _e(fields.get("runtime_vault_channel") or "unknown")
+    vault_provenance = fields.get("runtime_vault_provenance") or "unresolved"
     body = _e(fields.get("body", ""))
     panel_rail = _e(fields.get("panel_rail", "Panel / agent rail placeholder"))
     canvas_session_id = _e(fields.get("canvas_session_id") or "")
@@ -142,9 +145,11 @@ def _render_note_section(fields: dict) -> str:
           <span class="safety-sep">/</span>
           <span>{runtime_channel}</span>
         </div>
-        <div class="safety-item" data-testid="workspace-vault-identity">
+        <div class="safety-item" data-testid="workspace-vault-identity" data-vault-provenance="{vault_provenance}">
           <span class="safety-label">vault/channel</span>
-          <span>vault identity unavailable</span>
+          <span>{vault_name}</span>
+          <span class="safety-sep">/</span>
+          <span>{vault_channel}</span>
         </div>
         <div class="safety-item" data-testid="workspace-writeguard-state">
           <span class="safety-label">WriteGuard</span>

--- a/tests/api/test_companion_workspace_vault_identity.py
+++ b/tests/api/test_companion_workspace_vault_identity.py
@@ -1,0 +1,151 @@
+"""Tests for vault/channel identity in the companion workspace API response.
+
+Covers:
+- vault_identity field present in runtime response
+- vault_name derived from last path component of VAULT_ROOT
+- channel read from PKM_ENVIRONMENT, CHANNEL, PKM_CHANNEL (in that order)
+- provenance="env" when VAULT_ROOT is set, "unresolved" when absent
+- vault paths containing spaces (iCloud Mobile Documents)
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.api.routes.canvas as canvas_module
+import app.panel.confirmation as confirm_module
+from app.api.app import app
+
+
+@pytest.fixture(autouse=True)
+def _clear_runtime_state() -> None:
+    canvas_module._sessions.clear()
+    canvas_module._edit_history.clear()
+    canvas_module._undone_history.clear()
+    confirm_module._proposal_store.clear()
+    confirm_module._idempotency_store.clear()
+    yield
+    canvas_module._sessions.clear()
+    canvas_module._edit_history.clear()
+    canvas_module._undone_history.clear()
+    confirm_module._proposal_store.clear()
+    confirm_module._idempotency_store.clear()
+
+
+@pytest.fixture()
+def vault_note(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    monkeypatch.delenv("CANVAS_ENABLED", raising=False)
+    note = tmp_path / "notes" / "note.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text(
+        "---\nuuid: note-uuid-1\n---\n\n# Test Note\n\nBody text.\n",
+        encoding="utf-8",
+    )
+    return note
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def _workspace(client: TestClient, note_path: str = "notes/note.md"):
+    return client.get("/api/companion/workspace", params={"note_path": note_path})
+
+
+def test_vault_identity_present_in_runtime(
+    client: TestClient, vault_note: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+    resp = _workspace(client)
+    assert resp.status_code == 200
+    runtime = resp.json()["runtime"]
+    assert "vault_identity" in runtime
+
+
+def test_vault_name_derived_from_vault_root_basename(
+    client: TestClient, vault_note: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("PKM_ENVIRONMENT", raising=False)
+    # tmp_path basename is used as vault_name
+    resp = _workspace(client)
+    assert resp.status_code == 200
+    identity = resp.json()["runtime"]["vault_identity"]
+    assert identity["vault_name"] == tmp_path.name
+
+
+def test_vault_channel_from_pkm_environment(
+    client: TestClient, vault_note: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+    monkeypatch.delenv("CHANNEL", raising=False)
+    monkeypatch.delenv("PKM_CHANNEL", raising=False)
+    resp = _workspace(client)
+    assert resp.status_code == 200
+    assert resp.json()["runtime"]["vault_identity"]["channel"] == "dev"
+
+
+def test_vault_channel_from_channel_env(
+    client: TestClient, vault_note: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("PKM_ENVIRONMENT", raising=False)
+    monkeypatch.setenv("CHANNEL", "dev")
+    monkeypatch.delenv("PKM_CHANNEL", raising=False)
+    resp = _workspace(client)
+    assert resp.status_code == 200
+    assert resp.json()["runtime"]["vault_identity"]["channel"] == "dev"
+
+
+def test_vault_channel_from_pkm_channel_env(
+    client: TestClient, vault_note: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("PKM_ENVIRONMENT", raising=False)
+    monkeypatch.delenv("CHANNEL", raising=False)
+    monkeypatch.setenv("PKM_CHANNEL", "test")
+    resp = _workspace(client)
+    assert resp.status_code == 200
+    assert resp.json()["runtime"]["vault_identity"]["channel"] == "test"
+
+
+def test_vault_provenance_env_when_vault_root_set(
+    client: TestClient, vault_note: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    resp = _workspace(client)
+    assert resp.status_code == 200
+    identity = resp.json()["runtime"]["vault_identity"]
+    assert identity["provenance"] == "env"
+
+
+def test_vault_provenance_unresolved_when_vault_root_absent(
+    client: TestClient, vault_note: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("VAULT_ROOT", raising=False)
+    resp = _workspace(client)
+    # May 404 if vault root is unresolvable, but identity should reflect it
+    if resp.status_code == 200:
+        identity = resp.json()["runtime"]["vault_identity"]
+        assert identity["provenance"] == "unresolved"
+
+
+def test_vault_name_safe_for_path_with_spaces(
+    client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault_dir = tmp_path / "Mobile Documents" / "iCloud~md~obsidian" / "Documents" / "Niflheim"
+    vault_dir.mkdir(parents=True)
+    note = vault_dir / "notes" / "note.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text(
+        "---\nuuid: nifl-uuid-1\n---\n\n# Note\n\nBody.\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("VAULT_ROOT", str(vault_dir))
+    monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+    monkeypatch.delenv("CANVAS_ENABLED", raising=False)
+    resp = _workspace(client)
+    assert resp.status_code == 200
+    identity = resp.json()["runtime"]["vault_identity"]
+    assert identity["vault_name"] == "Niflheim"
+    assert identity["provenance"] == "env"

--- a/tests/api/test_companion_workspace_vault_identity.py
+++ b/tests/api/test_companion_workspace_vault_identity.py
@@ -4,7 +4,8 @@ Covers:
 - vault_identity field present in runtime response
 - vault_name derived from last path component of VAULT_ROOT
 - channel read from PKM_ENVIRONMENT, CHANNEL, PKM_CHANNEL (in that order)
-- provenance="env" when VAULT_ROOT is set, "unresolved" when absent
+- provenance="env" when VAULT_ROOT is set and used, "default" when absent
+- provenance="fallback" when VAULT_ROOT is invalid and runtime falls back
 - vault paths containing spaces (iCloud Mobile Documents)
 """
 from __future__ import annotations
@@ -119,15 +120,39 @@ def test_vault_provenance_env_when_vault_root_set(
     assert identity["provenance"] == "env"
 
 
-def test_vault_provenance_unresolved_when_vault_root_absent(
+def test_vault_provenance_default_when_vault_root_absent(
     client: TestClient, vault_note: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.delenv("VAULT_ROOT", raising=False)
+    default_vault = Path("vault").resolve()
+    default_note = default_vault / "notes" / "note.md"
+    default_note.parent.mkdir(parents=True, exist_ok=True)
+    default_note.write_text(
+        "---\nuuid: default-uuid-1\n---\n\n# Default Note\n\nBody.\n",
+        encoding="utf-8",
+    )
     resp = _workspace(client)
-    # May 404 if vault root is unresolvable, but identity should reflect it
-    if resp.status_code == 200:
-        identity = resp.json()["runtime"]["vault_identity"]
-        assert identity["provenance"] == "unresolved"
+    assert resp.status_code == 200
+    identity = resp.json()["runtime"]["vault_identity"]
+    assert identity["provenance"] == "default"
+
+
+def test_vault_provenance_fallback_when_vault_root_invalid(
+    client: TestClient, vault_note: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path / "missing-vault"))
+    fallback_vault = Path("vault").resolve()
+    fallback_note = fallback_vault / "notes" / "note.md"
+    fallback_note.parent.mkdir(parents=True, exist_ok=True)
+    fallback_note.write_text(
+        "---\nuuid: fallback-uuid-1\n---\n\n# Fallback Note\n\nBody.\n",
+        encoding="utf-8",
+    )
+    resp = _workspace(client)
+    assert resp.status_code == 200
+    identity = resp.json()["runtime"]["vault_identity"]
+    assert identity["vault_name"] == "vault"
+    assert identity["provenance"] == "fallback"
 
 
 def test_vault_name_safe_for_path_with_spaces(

--- a/tests/companion_ui/test_real_note_workspace_dev_page.py
+++ b/tests/companion_ui/test_real_note_workspace_dev_page.py
@@ -394,3 +394,52 @@ def test_dev_page_note_path_only_load_succeeds_without_artifact_id() -> None:
     # Artifact ID falls back to note_path when API returns empty
     assert state.shell.artifact_id == "notes/test.md"
     assert state.shell.title == "Test Note"
+
+
+# ---------------------------------------------------------------------------
+# Vault identity fields in render_fields()
+# ---------------------------------------------------------------------------
+
+
+def _workspace_response_with_vault_identity(
+    vault_name: str = "Niflheim",
+    channel: str = "dev",
+    provenance: str = "env",
+) -> dict:
+    base = _workspace_response()
+    base["runtime"]["vault_identity"] = {
+        "vault_name": vault_name,
+        "channel": channel,
+        "provenance": provenance,
+    }
+    return base
+
+
+def test_render_fields_includes_vault_identity() -> None:
+    page = _loaded_page(response=_workspace_response_with_vault_identity())
+    fields = page.render_fields()
+    assert fields is not None
+    assert fields["runtime_vault_name"] == "Niflheim"
+    assert fields["runtime_vault_channel"] == "dev"
+    assert fields["runtime_vault_provenance"] == "env"
+
+
+def test_render_fields_vault_identity_defaults_when_absent() -> None:
+    """Existing API responses without vault_identity must not break render_fields."""
+    page = _loaded_page(response=_workspace_response())  # no vault_identity in runtime
+    fields = page.render_fields()
+    assert fields is not None
+    assert fields["runtime_vault_name"] == "unresolved"
+    assert fields["runtime_vault_channel"] == "unknown"
+    assert fields["runtime_vault_provenance"] == "unresolved"
+
+
+def test_render_fields_vault_identity_path_with_spaces() -> None:
+    page = _loaded_page(response=_workspace_response_with_vault_identity(
+        vault_name="Mobile Documents",
+        channel="dev",
+        provenance="env",
+    ))
+    fields = page.render_fields()
+    assert fields is not None
+    assert fields["runtime_vault_name"] == "Mobile Documents"

--- a/tests/companion_ui/test_real_note_workspace_dev_server.py
+++ b/tests/companion_ui/test_real_note_workspace_dev_server.py
@@ -385,7 +385,7 @@ class TestRenderIndexHtml:
         assert "dev" in html
         assert "local-dev" in html
         assert 'data-testid="workspace-vault-identity"' in html
-        assert "vault identity unavailable" in html
+        assert "unresolved" in html
         assert 'data-testid="workspace-writeguard-state"' in html
         assert "blocked" in html
         assert 'data-testid="workspace-canvas-enabled-state"' in html
@@ -638,3 +638,83 @@ class TestDevServerBoundaries:
         from companion_ui.workspace.serve_dev_page import _DEFAULT_API_BASE_URL
 
         assert _DEFAULT_API_BASE_URL == "http://127.0.0.1:18001"
+
+
+# ---------------------------------------------------------------------------
+# Vault identity rendering in safety strip
+# ---------------------------------------------------------------------------
+
+
+class TestVaultIdentityRendering:
+    """Safety-strip vault/channel item renders resolved vault name and channel."""
+
+    def _fields_with_vault_identity(
+        self,
+        vault_name: str = "Niflheim",
+        vault_channel: str = "dev",
+        vault_provenance: str = "env",
+    ) -> dict:
+        return {
+            "title": "T",
+            "note_path": "N.md",
+            "artifact_id": "a",
+            "content_hash": "h",
+            "body": "b",
+            "panel_rail": "Panel rail",
+            "runtime_vault_name": vault_name,
+            "runtime_vault_channel": vault_channel,
+            "runtime_vault_provenance": vault_provenance,
+        }
+
+    def test_vault_name_rendered_in_safety_strip(self) -> None:
+        from companion_ui.workspace.serve_dev_page import render_index_html
+
+        html = render_index_html(
+            api_base_url="http://127.0.0.1:18001",
+            fields=self._fields_with_vault_identity(vault_name="Niflheim"),
+        )
+        assert 'data-testid="workspace-vault-identity"' in html
+        assert "Niflheim" in html
+
+    def test_vault_channel_rendered_in_safety_strip(self) -> None:
+        from companion_ui.workspace.serve_dev_page import render_index_html
+
+        html = render_index_html(
+            api_base_url="http://127.0.0.1:18001",
+            fields=self._fields_with_vault_identity(vault_channel="dev"),
+        )
+        assert 'data-testid="workspace-vault-identity"' in html
+        assert ">dev<" in html
+
+    def test_vault_provenance_in_data_attribute(self) -> None:
+        from companion_ui.workspace.serve_dev_page import render_index_html
+
+        html = render_index_html(
+            api_base_url="http://127.0.0.1:18001",
+            fields=self._fields_with_vault_identity(vault_provenance="env"),
+        )
+        assert 'data-vault-provenance="env"' in html
+
+    def test_unresolved_vault_renders_without_crash(self) -> None:
+        from companion_ui.workspace.serve_dev_page import render_index_html
+
+        html = render_index_html(
+            api_base_url="http://127.0.0.1:18001",
+            fields=self._fields_with_vault_identity(
+                vault_name="unresolved",
+                vault_channel="unknown",
+                vault_provenance="unresolved",
+            ),
+        )
+        assert 'data-testid="workspace-vault-identity"' in html
+        assert "unresolved" in html
+
+    def test_vault_name_with_spaces_rendered_safely(self) -> None:
+        from companion_ui.workspace.serve_dev_page import render_index_html
+
+        html = render_index_html(
+            api_base_url="http://127.0.0.1:18001",
+            fields=self._fields_with_vault_identity(vault_name="Mobile Documents"),
+        )
+        assert "Mobile Documents" in html
+        assert 'data-testid="workspace-vault-identity"' in html

--- a/tests/companion_ui/test_real_note_workspace_visual_shell.py
+++ b/tests/companion_ui/test_real_note_workspace_visual_shell.py
@@ -315,7 +315,7 @@ class TestRuntimeSafetyStrip:
         assert "dev" in html
         assert "local-dev" in html
         assert 'data-testid="workspace-vault-identity"' in html
-        assert "vault identity unavailable" in html
+        assert "unresolved" in html
 
     def test_guard_degraded_state_visible(self) -> None:
         html = _html_with_note(guard_degraded=True, guard_canvas_enabled=False)


### PR DESCRIPTION
## Summary
- Adds `VaultIdentityState` (vault_name, channel, provenance) to `RuntimeState` in the companion workspace API
- `vault_name` is derived from the last path component of `VAULT_ROOT` — handles iCloud paths with spaces safely
- `channel` is resolved from `PKM_ENVIRONMENT` → `CHANNEL` → `PKM_CHANNEL` in priority order
- Wires vault identity through `DevPageState` and `render_fields()` in the companion UI layer
- Replaces the hardcoded "vault identity unavailable" safety-strip item with the resolved vault name and channel (e.g. "Niflheim / dev")
- `data-vault-provenance` attribute on the safety item indicates whether identity was resolved from env or is still unresolved

## Test plan
- [x] 8 new API tests in `tests/api/test_companion_workspace_vault_identity.py` — vault_name, channel, provenance, spaces in path
- [x] 3 new dev page render_fields tests — vault identity fields present, defaults when API omits vault_identity
- [x] 5 new safety-strip rendering tests — vault name, channel, provenance attribute, unresolved case, spaces
- [x] Updated 2 existing tests that asserted old "vault identity unavailable" text
- [x] 85 companion-workspace tests all pass; broader suite 3549 passed (pre-existing Ollama URL failure unrelated)

Fixes #1223

🤖 Generated with [Claude Code](https://claude.com/claude-code)