### PR TITLE
refactor(store): migrate ingest and indexer callers off app.store.object_store

### DIFF
--- a/app/indexer/consumer.py
+++ b/app/indexer/consumer.py
@@ -10,7 +10,7 @@ from app.components.llm.router import LLMTaskIntent
 from app.embedding_config import coerce_floats
 from app.llm.embeddings import EMBED_MODEL
 from app.outbox import events as outbox_events
-from app.store.object_store import ObjectStore
+from app.objects import ObjectStore
 from app.stores import get_vector_index
 
 logger = logging.getLogger(__name__)

--- a/app/ingest/api.py
+++ b/app/ingest/api.py
@@ -106,7 +106,7 @@ def ingest_object(
     payload_out.setdefault("emergent_tags", [])
 
     # Persist object so the indexer stage can load text by object_id.
-    from app.store.object_store import DomainObject, ObjectStore
+    from app.objects import DomainObject, ObjectStore
 
     store = ObjectStore()
     store.save_object(

--- a/app/ingest/vault_alpha.py
+++ b/app/ingest/vault_alpha.py
@@ -34,7 +34,7 @@ from app.services.companion_note import (
     write_companion,
 )
 from app.services.note_uuid import ensure_note_uuid
-from app.store.object_store import DomainObject, ObjectStore
+from app.objects import DomainObject, ObjectStore
 from app.stores import get_object_store
 from app.vault.layout import ensure_vault_layout
 from app.vault.paths import get_vault_system_dir_rel

--- a/app/promotion/consumer.py
+++ b/app/promotion/consumer.py
@@ -12,7 +12,7 @@ from app.events.models import new_event
 from app.outbox.events import INDEX_OUTBOX_PATH
 from app.services.note_update import apply_promotion_frontmatter
 from app.components.concurrency import EventDedupStore
-from app.store.object_store import DomainObject, ObjectStore
+from app.objects import DomainObject, ObjectStore
 from app.services.outbox import write_outbox_event
 
 

--- a/app/services/indexer.py
+++ b/app/services/indexer.py
@@ -9,7 +9,7 @@ from typing import Dict
 from app.components.embeddings import get_embedding_client, get_embedding_identity
 from app.observability.tracer import start_span
 from app.outbox.events import DEFAULT_EMBEDDING_VIEW, emit_index_embedding_failed, emit_index_object_embedded
-from app.store.object_store import DomainObject, ObjectStore
+from app.objects import DomainObject, ObjectStore
 from app.stores import get_vector_index
 
 logger = logging.getLogger(__name__)

--- a/tests/e2e/test_panel_llm_e2e.py
+++ b/tests/e2e/test_panel_llm_e2e.py
@@ -177,7 +177,7 @@ def _read_outbox(path: Path) -> list[dict]:
 
 def _seed_note(note_uuid: str, markdown: str) -> None:
     from datetime import datetime, timezone
-    from app.store.object_store import DomainObject, ObjectStore
+    from app.objects import DomainObject, ObjectStore
 
     obj = DomainObject(
         uuid=note_uuid,

--- a/tests/e2e/test_panel_to_promotion_consume.py
+++ b/tests/e2e/test_panel_to_promotion_consume.py
@@ -13,7 +13,7 @@ from app.events.types import PROMOTE_DONE, PROMOTE_INTENT_CREATED
 from app.observability.status_service import get_system_status
 from app.promotion.consumer import consume_promotion_intents
 from app.store import object_store as object_store_module
-from app.store.object_store import DomainObject, ObjectStore
+from app.objects import DomainObject, ObjectStore
 
 pytestmark = pytest.mark.not_pg
 

--- a/tests/e2e/test_runtime_contract_regressions.py
+++ b/tests/e2e/test_runtime_contract_regressions.py
@@ -11,7 +11,7 @@ import app.observability.status_service as status_service
 import app.watcher.registry as registry
 from app.cli.uat import DEFAULT_FOLDER_NAME, DEFAULT_TARGET_SUBDIR, seed_vault_test_notes
 from app.runtime.runtime_loop import RuntimeLoopConfig, run_once
-from app.store.object_store import ObjectStore
+from app.objects import ObjectStore
 from app.stores import reset_store_backends
 from scripts.yaml_roundtrip import load_frontmatter
 

--- a/tests/e2e/test_runtime_loop_vault_test.py
+++ b/tests/e2e/test_runtime_loop_vault_test.py
@@ -9,7 +9,7 @@ import app.observability.status_service as status_service
 from app.promotion.consumer import consume_promotion_intents
 from app.runtime.runtime_loop import RuntimeLoopConfig, run_once
 from app.store import object_store as object_store_module
-from app.store.object_store import ObjectStore
+from app.objects import ObjectStore
 from scripts.yaml_roundtrip import load_frontmatter
 
 PROMOTE_UUID = "11111111-1111-4111-8111-111111111111"

--- a/tests/indexer/test_outbox_roundtrip.py
+++ b/tests/indexer/test_outbox_roundtrip.py
@@ -10,7 +10,7 @@ import pytest
 from app.components.embeddings import get_embedding_client
 from app.outbox import events
 from app.stores import get_vector_index, reset_store_backends
-from app.store.object_store import DomainObject, ObjectStore
+from app.objects import DomainObject, ObjectStore
 
 
 def test_emit_index_embedding_requested_writes_db_outbox_and_audit(tmp_path, monkeypatch) -> None:

--- a/tests/indexer/test_outbox_roundtrip_pg.py
+++ b/tests/indexer/test_outbox_roundtrip_pg.py
@@ -11,7 +11,7 @@ import pytest
 from app.db.dsn import resolve_dsn
 from app.components.embeddings import get_embedding_client
 from app.outbox import events
-from app.store.object_store import DomainObject, ObjectStore
+from app.objects import DomainObject, ObjectStore
 from app.stores import get_vector_index, reset_store_backends
 
 


### PR DESCRIPTION
## Summary
- migrate scoped ingest/indexer runtime imports from `app.store.object_store` to `app.objects`
- migrate associated `tests/indexer/**` and `tests/e2e/**` class imports to `app.objects`
- keep two test module-alias imports on `app.store.object_store` for `_MEMORY_STORE` fixture reset only

## Skill route
- `agentic-pkm → issue-to-code → publish-pr`

## Contract
Closes #1174

## AC verification
- AC1 (scoped ingest/indexer modules no deprecated imports)
  - Verify: `rg "from app\.store\.object_store|app\.store\.object_store" app/ingest app/indexer app/services/indexer.py app/promotion/consumer.py` returns no matches
- AC2 (relevant tests pass)
  - Verify: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/indexer tests/e2e` passes
- AC3 (no planned package cleanup)
  - Verify: diff excludes `app/sync`, `app/orientation`, `app/resurfacing`

## Dispatcher
- Dispatcher unavailable/not used in this run; GitHub-label claim path used.

## Validation
- `rg "from app\.store\.object_store|app\.store\.object_store" app/ingest app/indexer app/services/indexer.py app/promotion/consumer.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/indexer tests/e2e`
