### PR TITLE
refactor(store): migrate cli/domain/watcher callers off app.store.object_store

### DIFF
--- a/app/cli/smoke.py
+++ b/app/cli/smoke.py
@@ -18,7 +18,7 @@ from app.planner.schema import Plan, PlanMetadata, PlanStep, new_plan_id
 from app.planner.tools import MCP_TOOL_DESCRIPTORS
 from app.retrieval.hybrid import get_store, hybrid_search
 from app.settings.validate import validate_settings
-from app.store.object_store import DomainObject, ObjectStore
+from app.objects import DomainObject, ObjectStore
 from app.stores.plan_store import get_plan_store, reset_plan_store
 
 _DEFAULT_VAULT = Path("tmp/vault_smoke")

--- a/app/domain/plan.py
+++ b/app/domain/plan.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Literal, Optional
 from uuid import uuid4
 
-from app.store.object_store import DomainObject
+from app.objects import DomainObject
 
 
 PlanStatus = Literal["planned", "in_progress", "done", "failed"]

--- a/app/orchestrator/executor.py
+++ b/app/orchestrator/executor.py
@@ -20,7 +20,7 @@ AgentHandler = Callable[[AgentRequest], AgentResponse]
 from app.policy.enforce import assert_tool_allowed, is_policy_enforced
 from app.quality import timeout_wrapper
 from app.outbox.events import INDEX_OUTBOX_PATH
-from app.store.object_store import ObjectStore
+from app.objects import ObjectStore
 from app.events.schema import OutboxEvent
 
 from .events import emit_mcp_tool_call_finished, emit_mcp_tool_call_started

--- a/app/watcher/vault_watcher.py
+++ b/app/watcher/vault_watcher.py
@@ -18,7 +18,7 @@ from app.services.companion_note import find_companion_by_content_hash, read_com
 from app.ingest.vault_alpha import run_vault_alpha_ingest_paths
 from app.settings.panel_actions import PanelActionMapping, load_panel_action_mappings
 from app.settings.watcher_settings import load_watcher_settings, resolve_auto_exec_enabled
-from app.store.object_store import ObjectStore
+from app.objects import ObjectStore
 from app.watcher.events import emit_watcher_run_event
 from app.write_guard import DEFAULT_WRITE_GUARD, WritesBlockedError
 from scripts.yaml_roundtrip import load_frontmatter

--- a/tests/cli/test_index_rebuild_cli.py
+++ b/tests/cli/test_index_rebuild_cli.py
@@ -13,7 +13,7 @@ from app.cli import cli
 from app.components.embeddings import get_embedding_client, get_embedding_identity
 from app.db.dsn import resolve_dsn
 from app.store import object_store as legacy_store
-from app.store.object_store import DomainObject, ObjectStore
+from app.objects import DomainObject, ObjectStore
 from app.stores import get_vector_index, reset_store_backends
 
 

--- a/tests/cli/test_panel_cli.py
+++ b/tests/cli/test_panel_cli.py
@@ -9,7 +9,7 @@ from click.testing import CliRunner
 
 from app.cli import cli
 from app.store import object_store as object_store_module
-from app.store.object_store import DomainObject, ObjectStore
+from app.objects import DomainObject, ObjectStore
 
 
 def _seed_panel_note(note_uuid: str, markdown: str) -> None:

--- a/tests/cli/test_panel_orchestrator_cli.py
+++ b/tests/cli/test_panel_orchestrator_cli.py
@@ -16,7 +16,7 @@ from app.events.panel import NoteRef, PanelActionMapping, PanelIntentAction, Pan
 from app.planner.schema import Plan, PlanMetadata, PlanStep
 from app.cli import cli
 from app.store import object_store as object_store_module
-from app.store.object_store import DomainObject, ObjectStore
+from app.objects import DomainObject, ObjectStore
 from app.stores.plan_store import get_plan_store, reset_plan_store
 
 

--- a/tests/cli/test_panel_runtime_cli.py
+++ b/tests/cli/test_panel_runtime_cli.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 from click.testing import CliRunner
 
 from app.cli import cli
-from app.store.object_store import DomainObject, ObjectStore
+from app.objects import DomainObject, ObjectStore
 
 
 def _seed_note(note_uuid: str, markdown: str) -> None:

--- a/tests/cli/test_uat_run_cli.py
+++ b/tests/cli/test_uat_run_cli.py
@@ -5,7 +5,7 @@ from click.testing import CliRunner
 
 from app.cli import cli
 from app.cli.uat import DEFAULT_FOLDER_NAME, DEFAULT_TARGET_SUBDIR
-from app.store.object_store import ObjectStore
+from app.objects import ObjectStore
 from app.store import object_store as object_store_module
 from scripts.yaml_roundtrip import load_frontmatter
 

--- a/tests/runtime/test_worker_ingest_event.py
+++ b/tests/runtime/test_worker_ingest_event.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from app.services.companion_note import read_companion
-from app.store.object_store import ObjectStore
+from app.objects import ObjectStore
 from app.workers import outbox_worker
 from app.events.types import INGEST_VAULT_CHANGED, PANEL_SCAN_REQUESTED
 from scripts.yaml_roundtrip import load_frontmatter

--- a/tests/runtime/test_worker_uuid_heal_retry.py
+++ b/tests/runtime/test_worker_uuid_heal_retry.py
@@ -4,7 +4,7 @@ import errno
 from pathlib import Path
 
 from app.services.note_uuid import ensure_note_uuid as real_ensure_note_uuid
-from app.store.object_store import ObjectStore
+from app.objects import ObjectStore
 from app.workers import outbox_worker
 from scripts.yaml_roundtrip import load_frontmatter
 from tests.runtime.test_worker_ingest_event import _write_layout_note


### PR DESCRIPTION
## Summary
- migrate scoped CLI/domain/orchestrator/watcher imports from `app.store.object_store` to `app.objects`
- migrate associated `tests/cli/**` and `tests/runtime/**` imports to `app.objects`
- preserve behavior; import-boundary-only refactor

## Skill route
- `agentic-pkm → issue-to-code → publish-pr`

## Contract
Closes #1175

## AC verification
- AC1 (scoped modules no deprecated imports)
  - Verify: `rg "from app\.store\.object_store|app\.store\.object_store" app/cli app/domain/plan.py app/orchestrator/executor.py app/watcher/vault_watcher.py` returns no matches
- AC2 (relevant tests pass)
  - Verify: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/cli tests/runtime` passes
- AC3 (no planned package cleanup)
  - Verify: diff excludes `app/sync`, `app/orientation`, `app/resurfacing`

## Dispatcher
- Dispatcher unavailable/not used in this run; GitHub-label claim path used.

## Validation
- `rg "from app\.store\.object_store|app\.store\.object_store" app/cli app/domain/plan.py app/orchestrator/executor.py app/watcher/vault_watcher.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/cli tests/runtime`
