### PR TITLE
companion(runtime): verify dev workspace update configuration

### DIFF
--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -77,10 +77,20 @@ class SuggestionsState(BaseModel):
     pending_receipts: list[dict[str, str]] = Field(default_factory=list)
 
 
+class WorkspaceUpdateCapabilityState(BaseModel):
+    available: bool
+    state: str
+    reason: str
+    scope: str = "active_note_body"
+    governance_actions_enabled: bool = False
+    config_mode: str = "inherited"
+
+
 class GuardState(BaseModel):
     canvas_enabled: bool
     writeguard_status: str
     degraded: bool
+    workspace_update: WorkspaceUpdateCapabilityState
 
 
 class WorkspaceStateResponse(BaseModel):
@@ -261,6 +271,56 @@ def _writeguard_status() -> str:
     return "ok"
 
 
+def _workspace_update_capability(
+    *,
+    canvas_enabled: bool,
+    writeguard_status: str,
+) -> WorkspaceUpdateCapabilityState:
+    raw = os.getenv("COMPANION_WORKSPACE_UPDATE_ENABLED")
+    explicit = raw is not None
+    if explicit:
+        config_enabled = raw.strip().lower() in {"1", "true", "yes", "on"}
+    else:
+        # Backwards-compatible fallback when older clients only reason about Canvas.
+        config_enabled = canvas_enabled
+
+    if not canvas_enabled:
+        return WorkspaceUpdateCapabilityState(
+            available=False,
+            state="disabled",
+            reason="canvas_disabled",
+            config_mode="explicit" if explicit else "inherited",
+        )
+    if not config_enabled:
+        return WorkspaceUpdateCapabilityState(
+            available=False,
+            state="disabled",
+            reason="disabled_by_config" if explicit else "disabled_by_canvas_policy",
+            config_mode="explicit" if explicit else "inherited",
+        )
+    if writeguard_status == "blocked":
+        return WorkspaceUpdateCapabilityState(
+            available=False,
+            state="disabled",
+            reason="writeguard_blocked",
+            config_mode="explicit" if explicit else "inherited",
+        )
+    if writeguard_status == "unknown":
+        return WorkspaceUpdateCapabilityState(
+            available=False,
+            state="degraded",
+            reason="writeguard_unknown",
+            config_mode="explicit" if explicit else "inherited",
+        )
+
+    return WorkspaceUpdateCapabilityState(
+        available=True,
+        state="available",
+        reason="explicit_dev_config" if explicit else "canvas_inherited",
+        config_mode="explicit" if explicit else "inherited",
+    )
+
+
 def _reorient_state() -> dict[str, list[dict[str, str | bool]]]:
     def item(
         label: str,
@@ -386,6 +446,10 @@ def read_companion_workspace(
         body = artifact_path.read_text(encoding="utf-8")
     canvas_enabled = _truthy_env("CANVAS_ENABLED")
     writeguard_status = _writeguard_status()
+    workspace_update = _workspace_update_capability(
+        canvas_enabled=canvas_enabled,
+        writeguard_status=writeguard_status,
+    )
 
     return WorkspaceStateResponse(
         artifact=ArtifactState(
@@ -415,6 +479,7 @@ def read_companion_workspace(
             canvas_enabled=canvas_enabled,
             writeguard_status=writeguard_status,
             degraded=not canvas_enabled or writeguard_status == "unknown",
+            workspace_update=workspace_update,
         ),
     )
 

--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -146,6 +146,12 @@ class DevPageState:
     guard_writeguard_status: str = "ok"
     guard_canvas_enabled: bool = True
     guard_degraded: bool = False
+    guard_workspace_update_available: bool = False
+    guard_workspace_update_state: str = "disabled"
+    guard_workspace_update_reason: str = "not_declared"
+    guard_workspace_update_scope: str = "active_note_body"
+    guard_workspace_update_governance_actions_enabled: bool = False
+    guard_workspace_update_config_mode: str = "inherited"
     is_loaded: bool = False
 
 
@@ -202,6 +208,7 @@ class RealNoteWorkspaceDevPage:
         suggestions = raw.get("suggestions") or {}
         guards = raw.get("guards") or {}
         runtime = raw.get("runtime") or {}
+        workspace_update_guard = guards.get("workspace_update") or {}
         raw_find_payload = raw.get("find")
         runtime_find_payload = runtime.get("find")
         find_payload_available = isinstance(raw_find_payload, dict) or isinstance(
@@ -249,7 +256,28 @@ class RealNoteWorkspaceDevPage:
         state_conflict = session_state in {"paused", "interrupted"}
         conflict_detected = recovery_needed or hash_conflict or state_conflict
         runtime_can_edit_body = bool(canvas.get("can_edit_body", False))
-        can_edit_body = runtime_can_edit_body and (not conflict_detected or recovery_acknowledged)
+        if workspace_update_guard:
+            workspace_update_available = bool(workspace_update_guard.get("available", False))
+            workspace_update_state = str(workspace_update_guard.get("state") or "disabled")
+            workspace_update_reason = str(workspace_update_guard.get("reason") or "not_declared")
+            workspace_update_scope = str(workspace_update_guard.get("scope") or "active_note_body")
+            workspace_update_governance_actions_enabled = bool(
+                workspace_update_guard.get("governance_actions_enabled", False)
+            )
+            workspace_update_config_mode = str(workspace_update_guard.get("config_mode") or "inherited")
+        else:
+            # Compatibility fallback for runtime payloads without explicit workspace_update capability.
+            workspace_update_available = runtime_can_edit_body and bool(guards.get("canvas_enabled", True))
+            workspace_update_state = "legacy_inferred" if workspace_update_available else "disabled"
+            workspace_update_reason = "legacy_payload"
+            workspace_update_scope = "active_note_body"
+            workspace_update_governance_actions_enabled = False
+            workspace_update_config_mode = "inherited"
+        can_edit_body = (
+            runtime_can_edit_body
+            and workspace_update_available
+            and (not conflict_detected or recovery_acknowledged)
+        )
         if content_hash:
             self._last_content_hash_by_note[resolved_note_path] = content_hash
         shell = RealNoteWorkspaceShell(payload=payload, agent_rail_state=None)
@@ -328,6 +356,12 @@ class RealNoteWorkspaceDevPage:
             guard_writeguard_status=guards.get("writeguard_status") or "ok",
             guard_canvas_enabled=bool(guards.get("canvas_enabled", True)),
             guard_degraded=bool(guards.get("degraded", False)),
+            guard_workspace_update_available=workspace_update_available,
+            guard_workspace_update_state=workspace_update_state,
+            guard_workspace_update_reason=workspace_update_reason,
+            guard_workspace_update_scope=workspace_update_scope,
+            guard_workspace_update_governance_actions_enabled=workspace_update_governance_actions_enabled,
+            guard_workspace_update_config_mode=workspace_update_config_mode,
             is_loaded=True,
         )
         return self.state
@@ -755,6 +789,14 @@ class RealNoteWorkspaceDevPage:
             "guard_writeguard_status": self.state.guard_writeguard_status,
             "guard_canvas_enabled": self.state.guard_canvas_enabled,
             "guard_degraded": self.state.guard_degraded,
+            "guard_workspace_update_available": self.state.guard_workspace_update_available,
+            "guard_workspace_update_state": self.state.guard_workspace_update_state,
+            "guard_workspace_update_reason": self.state.guard_workspace_update_reason,
+            "guard_workspace_update_scope": self.state.guard_workspace_update_scope,
+            "guard_workspace_update_governance_actions_enabled": (
+                self.state.guard_workspace_update_governance_actions_enabled
+            ),
+            "guard_workspace_update_config_mode": self.state.guard_workspace_update_config_mode,
             "is_production_ui": self.is_production_ui,
             "dev_page_label": self.dev_page_label,
         }

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -121,6 +121,14 @@ def _render_note_section(fields: dict) -> str:
     writeguard_blocked = writeguard_status.lower() == "blocked"
     canvas_enabled = bool(fields.get("guard_canvas_enabled", True))
     guard_degraded = bool(fields.get("guard_degraded", False))
+    workspace_update_available = bool(fields.get("guard_workspace_update_available", False))
+    workspace_update_state = _e(fields.get("guard_workspace_update_state") or "disabled")
+    workspace_update_reason = _e(fields.get("guard_workspace_update_reason") or "not_declared")
+    workspace_update_scope = _e(fields.get("guard_workspace_update_scope") or "active_note_body")
+    workspace_update_governance_actions_enabled = bool(
+        fields.get("guard_workspace_update_governance_actions_enabled", False)
+    )
+    workspace_update_config_mode = _e(fields.get("guard_workspace_update_config_mode") or "inherited")
     identity_caution_html = ""
     if identity_state_raw.startswith("unresolved"):
         identity_caution_html = (
@@ -163,6 +171,22 @@ def _render_note_section(fields: dict) -> str:
           <span class="safety-label">guard</span>
           <span>{'degraded' if guard_degraded else 'normal'}</span>
         </div>
+        <div class="safety-item" data-testid="workspace-update-flow-state" data-update-state="{workspace_update_state}">
+          <span class="safety-label">workspace update</span>
+          <span>{'available' if workspace_update_available else 'disabled'}</span>
+          <span class="safety-sep">/</span>
+          <span>{workspace_update_scope}</span>
+        </div>
+        <div class="safety-item" data-testid="workspace-update-flow-reason">
+          <span class="safety-label">update reason</span>
+          <span>{workspace_update_reason}</span>
+          <span class="safety-sep">/</span>
+          <span>{workspace_update_config_mode}</span>
+        </div>
+        <div class="safety-item" data-testid="workspace-update-governance-state">
+          <span class="safety-label">governance via update</span>
+          <span>{'enabled' if workspace_update_governance_actions_enabled else 'disabled'}</span>
+        </div>
         <div class="safety-item" data-testid="workspace-runtime-trace-id">
           <span class="safety-label">trace</span>
           <code>{runtime_trace_id or 'unavailable'}</code>
@@ -173,6 +197,8 @@ def _render_note_section(fields: dict) -> str:
         guard_messages.append("WriteGuard blocked")
     if not canvas_enabled:
         guard_messages.append("Canvas disabled")
+    if not workspace_update_available:
+        guard_messages.append("Workspace update disabled")
     guard_html = ""
     if guard_messages:
         guard_html = (
@@ -239,6 +265,8 @@ def _render_note_section(fields: dict) -> str:
         recovery_acknowledged=recovery_acknowledged,
         conflict_detected=conflict_detected,
         canvas_enabled=canvas_enabled,
+        workspace_update_available=workspace_update_available,
+        workspace_update_reason=workspace_update_reason,
         writeguard_blocked=writeguard_blocked,
         session_log_path=session_log_path,
         undo_available=undo_available,
@@ -883,13 +911,15 @@ def _render_canvas_session_controls(
     recovery_acknowledged: bool,
     conflict_detected: bool,
     canvas_enabled: bool,
+    workspace_update_available: bool,
+    workspace_update_reason: str,
     writeguard_blocked: bool,
     session_log_path: str,
     undo_available: bool,
     applied_edit_count: int,
     undone_edit_count: int,
 ) -> str:
-    canvas_blocked = not canvas_enabled or writeguard_blocked
+    canvas_blocked = not canvas_enabled or writeguard_blocked or (not workspace_update_available)
     start_status = "blocked" if not canvas_enabled else "experimental" if not session_id else "unavailable"
     close_status = "blocked" if not canvas_enabled else "experimental" if session_id else "unavailable"
     edit_status = "blocked" if canvas_blocked else "active" if can_edit_body else "unavailable"
@@ -943,12 +973,18 @@ def _render_canvas_session_controls(
             </div>
           </form>"""
     else:
+        unavailable_copy = "Body edit composer unavailable until Canvas has an active editable session."
+        if not workspace_update_available:
+            unavailable_copy = (
+                "Body edit composer disabled by workspace update capability: "
+                f"{workspace_update_reason}."
+            )
         composer_html = """
           <div
             class="canvas-body-edit-unavailable"
             data-testid="workspace-canvas-body-edit-unavailable"
             data-affordance-status="blocked">
-            Body edit composer unavailable until Canvas has an active editable session.
+            """ + unavailable_copy + """
           </div>"""
     recovery_api_path = f"/api/canvas/sessions/{session_id}/recovery/ack" if session_id else ""
     recovery_html = ""

--- a/docs/HUMAN-FLOWS.md
+++ b/docs/HUMAN-FLOWS.md
@@ -912,3 +912,10 @@ document should continue to hold.
 Converse interaction design handoff materials are now available at `companion-ui/design_handoff/2026-05-03-converse/`.
 The handoff reinforces the document-first Converse behavior: vault note remains primary, dialogue operates as a secondary rail/sheet, and suggestion moments are staged for explicit user action.
 That direction is no longer handoff-only: a bounded implementation now exists in `companion-ui/companion-app/` with rail-state geometry, thread/composer states, the staged suggestion moment (apply/discard intents, mirrored proposal identity cues, and dimmed non-focused region), the session-drawer/portrait-sheet interaction slices, a read-only real-note workspace shell, and confirm-response artifact refresh delivered by PRs #745, #746, #750, #762, #1069, and #1070. The supporting runtime path now exposes `GET /api/artifacts/note` for read-only artifact hydration and `POST /api/panel/confirm` for explicit governed panel confirmation.
+
+## Companion Niflheim dev UAT workspace update check
+
+For Niflheim dev UAT, Companion workspace update capability must be visible as runtime-declared state before mutation testing proceeds:
+- the runtime safety strip must declare workspace update availability as `available` or `disabled`
+- disabled state must remain non-mutating in the UI (no active body-update composer)
+- workspace update capability is scoped to active-note body updates and must not authorize governance-bearing actions

--- a/tests/api/test_companion_workspace_api.py
+++ b/tests/api/test_companion_workspace_api.py
@@ -350,6 +350,37 @@ def test_workspace_guards(
     assert guards["writeguard_status"] == "blocked"
 
 
+def test_workspace_update_capability_exposed_for_dev_config(
+    client: TestClient, vault_note: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CANVAS_ENABLED", "1")
+    monkeypatch.setenv("COMPANION_WORKSPACE_UPDATE_ENABLED", "1")
+
+    resp = _workspace(client)
+
+    assert resp.status_code == 200
+    workspace_update = resp.json()["guards"]["workspace_update"]
+    assert workspace_update["available"] is True
+    assert workspace_update["state"] == "available"
+    assert workspace_update["reason"] == "explicit_dev_config"
+    assert workspace_update["scope"] == "active_note_body"
+    assert workspace_update["config_mode"] == "explicit"
+
+
+def test_workspace_update_capability_does_not_enable_governance_actions(
+    client: TestClient, vault_note: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CANVAS_ENABLED", "1")
+    monkeypatch.setenv("COMPANION_WORKSPACE_UPDATE_ENABLED", "1")
+
+    resp = _workspace(client)
+
+    assert resp.status_code == 200
+    workspace_update = resp.json()["guards"]["workspace_update"]
+    assert workspace_update["governance_actions_enabled"] is False
+    assert workspace_update["scope"] == "active_note_body"
+
+
 def test_workspace_note_not_found(
     client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/companion_ui/test_real_note_workspace_dev_page.py
+++ b/tests/companion_ui/test_real_note_workspace_dev_page.py
@@ -62,7 +62,18 @@ def _workspace_response(
         "artifact": artifact or _artifact_response(),
         "canvas": canvas or {"session_state": "idle", "session_persistence": "in_memory"},
         "panel": panel or {"state": "idle", "proposal_count": 0},
-        "guards": guards or {"canvas_enabled": True, "writeguard_status": "ok"},
+        "guards": guards or {
+            "canvas_enabled": True,
+            "writeguard_status": "ok",
+            "workspace_update": {
+                "available": True,
+                "state": "available",
+                "reason": "explicit_dev_config",
+                "scope": "active_note_body",
+                "governance_actions_enabled": False,
+                "config_mode": "explicit",
+            },
+        },
         "runtime": {
             "environment_label": "dev",
             "api_base_url_label": "local-dev",
@@ -443,3 +454,77 @@ def test_render_fields_vault_identity_path_with_spaces() -> None:
     fields = page.render_fields()
     assert fields is not None
     assert fields["runtime_vault_name"] == "Mobile Documents"
+
+
+def test_workspace_renders_update_flow_availability() -> None:
+    page = _loaded_page(
+        response=_workspace_response(
+            guards={
+                "canvas_enabled": True,
+                "writeguard_status": "ok",
+                "workspace_update": {
+                    "available": True,
+                    "state": "available",
+                    "reason": "explicit_dev_config",
+                    "scope": "active_note_body",
+                    "governance_actions_enabled": False,
+                    "config_mode": "explicit",
+                },
+            }
+        )
+    )
+    fields = page.render_fields()
+    assert fields is not None
+    assert fields["guard_workspace_update_available"] is True
+    assert fields["guard_workspace_update_state"] == "available"
+    assert fields["guard_workspace_update_scope"] == "active_note_body"
+
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="notes/research.md",
+        fields=fields,
+    )
+    assert 'data-testid="workspace-update-flow-state"' in html
+    assert 'data-update-state="available"' in html
+    assert 'data-testid="workspace-update-governance-state"' in html
+    assert "governance via update" in html
+
+
+def test_workspace_update_flow_disabled_state_is_non_mutating() -> None:
+    page = _loaded_page(
+        response=_workspace_response(
+            canvas={
+                "session_id": "session-1",
+                "session_state": "active",
+                "user_present": True,
+                "can_edit_body": True,
+                "session_persistence": "in_memory",
+            },
+            guards={
+                "canvas_enabled": True,
+                "writeguard_status": "ok",
+                "workspace_update": {
+                    "available": False,
+                    "state": "disabled",
+                    "reason": "disabled_by_config",
+                    "scope": "active_note_body",
+                    "governance_actions_enabled": False,
+                    "config_mode": "explicit",
+                },
+            },
+        )
+    )
+    fields = page.render_fields()
+    assert fields is not None
+    assert fields["guard_workspace_update_available"] is False
+    assert fields["guard_workspace_update_state"] == "disabled"
+
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="notes/research.md",
+        fields=fields,
+    )
+    assert 'data-testid="workspace-update-flow-state"' in html
+    assert 'data-update-state="disabled"' in html
+    assert 'data-testid="workspace-canvas-body-edit-unavailable"' in html
+    assert 'data-testid="workspace-canvas-body-edit-composer"' not in html


### PR DESCRIPTION
## Summary
- expose explicit runtime-declared `guards.workspace_update` capability state in `GET /api/companion/workspace`
- render workspace update availability/disabled state in Companion dev workspace safety strip
- enforce non-mutating UI behavior when workspace update is disabled (body-edit composer unavailable)
- document Niflheim dev UAT workspace update verification in `docs/HUMAN-FLOWS.md`
- repair stale #1224 Verify test-path drift before implementation (`issue-maintenance-change-control`)

## Skill route
- `agentic-pkm → issue-maintenance-change-control → issue-to-code → publish-pr`

## Contract
Closes #1224

## AC verification
- AC1 (dev runtime exposes explicit workspace update capability)
  - Verify: `tests/api/test_companion_workspace_api.py::test_workspace_update_capability_exposed_for_dev_config`
- AC2 (UI shows available/disabled update flow state)
  - Verify: `tests/companion_ui/test_real_note_workspace_dev_page.py::test_workspace_renders_update_flow_availability`
- AC3 (disabled renders safe non-mutating state)
  - Verify: `tests/companion_ui/test_real_note_workspace_dev_page.py::test_workspace_update_flow_disabled_state_is_non_mutating`
- AC4 (Niflheim UAT flow-state check documented)
  - Verify: `docs/HUMAN-FLOWS.md :: Companion Niflheim dev UAT workspace update check`
- AC5 (update capability does not enable governance actions)
  - Verify: `tests/api/test_companion_workspace_api.py::test_workspace_update_capability_does_not_enable_governance_actions`

## Dispatcher
- Dispatcher unavailable/not used in this run; GitHub-label claim path used.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/api/test_companion_workspace_api.py tests/companion_ui/test_real_note_workspace_dev_page.py`
- `python3 scripts/docs_guard.py`
- `git diff --check`
