### PR TITLE
companion(feature): browse vault notes from workspace UI

### DIFF
--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import heapq
 from pathlib import Path, PurePosixPath
 from uuid import uuid4
 
@@ -100,6 +101,22 @@ class WorkspaceStateResponse(BaseModel):
     panel: PanelState
     suggestions: SuggestionsState
     guards: GuardState
+
+
+class VaultBrowserNoteState(BaseModel):
+    note_path: str
+    title: str
+    zone: str
+
+
+class VaultBrowserStateResponse(BaseModel):
+    notes: list[VaultBrowserNoteState]
+    query: str
+    total_notes: int
+    filtered_notes: int
+    read_only: bool = True
+    vault_identity: VaultIdentityState
+    identity_available: bool
 
 
 def _truthy_env(name: str, default: bool = False) -> bool:
@@ -414,6 +431,143 @@ def _safe_resurface_source_link(candidate_id: str) -> str:
     if candidate_id in {"resurface-pending-promotions", "resurface-new-activity"}:
         return "status.events"
     return "runtime:resurfacing"
+
+
+def _zone_for_path(note_path: str) -> str:
+    parts = PurePosixPath(note_path).parts
+    return parts[0] if parts else "root"
+
+
+def _list_markdown_notes(vault_root: Path) -> list[VaultBrowserNoteState]:
+    notes: list[VaultBrowserNoteState] = []
+    for candidate in vault_root.rglob("*.md"):
+        if not candidate.is_file():
+            continue
+        safe_path = _vault_relative(candidate, vault_root)
+        if safe_path is None:
+            continue
+        body = candidate.read_text(encoding="utf-8")
+        notes.append(
+            VaultBrowserNoteState(
+                note_path=safe_path,
+                title=_browser_title(body, fallback=candidate.stem),
+                zone=_zone_for_path(safe_path),
+            )
+        )
+    notes.sort(key=lambda note: note.note_path)
+    return notes
+
+
+def _safe_vault_browse_max_notes() -> int:
+    raw = os.getenv("VAULT_BROWSE_MAX_NOTES")
+    if raw is None:
+        return 250
+    try:
+        parsed = int(raw.strip())
+    except (TypeError, ValueError):
+        return 250
+    return max(1, min(parsed, 1000))
+
+
+def _select_vault_notes(
+    vault_root: Path,
+    *,
+    query: str,
+    limit: int,
+) -> tuple[list[VaultBrowserNoteState], int, int]:
+    needle = query.strip().lower()
+    total_notes = 0
+    filtered_notes = 0
+    # Keep only the lexicographically-smallest `limit` note paths without
+    # materializing the full sorted collection in memory.
+    selected_heap: list[tuple[str, VaultBrowserNoteState]] = []
+    for candidate in vault_root.rglob("*.md"):
+        if not candidate.is_file():
+            continue
+        safe_path = _vault_relative(candidate, vault_root)
+        if safe_path is None:
+            continue
+        total_notes += 1
+        body = candidate.read_text(encoding="utf-8")
+        title = _browser_title(body, fallback=candidate.stem)
+        if needle and needle not in safe_path.lower() and needle not in title.lower():
+            continue
+        filtered_notes += 1
+        note = VaultBrowserNoteState(
+            note_path=safe_path,
+            title=title,
+            zone=_zone_for_path(safe_path),
+        )
+        key = note.note_path
+        if len(selected_heap) < limit:
+            heapq.heappush(selected_heap, (_invert_lex(key), note))
+        elif _invert_lex(key) > selected_heap[0][0]:
+            heapq.heapreplace(selected_heap, (_invert_lex(key), note))
+
+    selected = sorted((item[1] for item in selected_heap), key=lambda note: note.note_path)
+    return selected, total_notes, filtered_notes
+
+
+def _invert_lex(value: str) -> str:
+    return "".join(chr(0x10FFFF - ord(ch)) for ch in value)
+
+
+def _filter_notes(
+    notes: list[VaultBrowserNoteState],
+    *,
+    query: str,
+) -> list[VaultBrowserNoteState]:
+    if not query:
+        return notes
+    needle = query.strip().lower()
+    if not needle:
+        return notes
+    return [
+        note
+        for note in notes
+        if needle in note.note_path.lower() or needle in note.title.lower()
+    ]
+
+
+def _browser_title(body: str, *, fallback: str) -> str:
+    if body.startswith("---\n"):
+        lines = body.splitlines()
+        for line in lines[1:]:
+            if line.strip() == "---":
+                break
+            key, sep, value = line.partition(":")
+            if sep and key.strip().lower() == "title":
+                parsed = value.strip().strip('"').strip("'")
+                if parsed:
+                    return parsed
+    return _extract_title(body, fallback=fallback)
+
+
+@router.get("/vault-browser", response_model=VaultBrowserStateResponse)
+def read_companion_vault_browser(
+    q: str = Query("", description="Case-insensitive path/title filter"),
+    limit: int = Query(250, ge=1, le=1000),
+) -> VaultBrowserStateResponse:
+    vault_root = resolve_vault_root()
+    effective_limit = min(limit, _safe_vault_browse_max_notes())
+    selected, total_notes, filtered_notes = _select_vault_notes(
+        vault_root,
+        query=q,
+        limit=effective_limit,
+    )
+    identity = _vault_identity_state(vault_root)
+    identity_available = (
+        bool(identity.vault_name.strip()) and identity.channel in {"dev", "test", "prod"}
+    )
+    return VaultBrowserStateResponse(
+        notes=selected,
+        query=q,
+        total_notes=total_notes,
+        filtered_notes=filtered_notes,
+        read_only=True,
+        vault_identity=identity,
+        identity_available=identity_available,
+    )
 
 
 @router.get("/workspace", response_model=WorkspaceStateResponse)

--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -152,6 +152,16 @@ class DevPageState:
     guard_workspace_update_scope: str = "active_note_body"
     guard_workspace_update_governance_actions_enabled: bool = False
     guard_workspace_update_config_mode: str = "inherited"
+    vault_browser_notes: list[dict[str, Any]] | None = None
+    vault_browser_query: str = ""
+    vault_browser_total_notes: int = 0
+    vault_browser_filtered_notes: int = 0
+    vault_browser_error: str | None = None
+    vault_browser_read_only: bool = True
+    vault_browser_identity_available: bool = False
+    vault_browser_vault_name: str = "unresolved"
+    vault_browser_vault_channel: str = "unknown"
+    vault_browser_vault_provenance: str = "unresolved"
     is_loaded: bool = False
 
 
@@ -209,6 +219,15 @@ class RealNoteWorkspaceDevPage:
         guards = raw.get("guards") or {}
         runtime = raw.get("runtime") or {}
         workspace_update_guard = guards.get("workspace_update") or {}
+        vault_browser_error: str | None = None
+        try:
+            vault_browser = self._http.get(
+                "/api/companion/vault-browser",
+                params={"q": "", "limit": 250},
+            )
+        except WorkspaceClientError as exc:
+            vault_browser = {}
+            vault_browser_error = str(exc)
         raw_find_payload = raw.get("find")
         runtime_find_payload = runtime.get("find")
         find_payload_available = isinstance(raw_find_payload, dict) or isinstance(
@@ -218,6 +237,7 @@ class RealNoteWorkspaceDevPage:
         find_payload = raw_find_payload or runtime_find_payload or {}
         reorient_payload = raw.get("reorient") or runtime.get("reorient") or {}
         resurface_payload = raw.get("resurface") or runtime.get("resurface") or {}
+        vault_browser_identity = vault_browser.get("vault_identity") or {}
 
         # The runtime echoes artifact_id only when supplied in the request.
         # Fall back to note_path so note-path-only loads don't fail the shell's
@@ -362,6 +382,16 @@ class RealNoteWorkspaceDevPage:
             guard_workspace_update_scope=workspace_update_scope,
             guard_workspace_update_governance_actions_enabled=workspace_update_governance_actions_enabled,
             guard_workspace_update_config_mode=workspace_update_config_mode,
+            vault_browser_notes=list(vault_browser.get("notes") or []),
+            vault_browser_query=str(vault_browser.get("query") or ""),
+            vault_browser_total_notes=int(vault_browser.get("total_notes") or 0),
+            vault_browser_filtered_notes=int(vault_browser.get("filtered_notes") or 0),
+            vault_browser_error=vault_browser_error,
+            vault_browser_read_only=bool(vault_browser.get("read_only", True)),
+            vault_browser_identity_available=bool(vault_browser.get("identity_available", False)),
+            vault_browser_vault_name=str(vault_browser_identity.get("vault_name") or "unresolved"),
+            vault_browser_vault_channel=str(vault_browser_identity.get("channel") or "unknown"),
+            vault_browser_vault_provenance=str(vault_browser_identity.get("provenance") or "unresolved"),
             is_loaded=True,
         )
         return self.state
@@ -797,6 +827,16 @@ class RealNoteWorkspaceDevPage:
                 self.state.guard_workspace_update_governance_actions_enabled
             ),
             "guard_workspace_update_config_mode": self.state.guard_workspace_update_config_mode,
+            "vault_browser_notes": self.state.vault_browser_notes or [],
+            "vault_browser_query": self.state.vault_browser_query,
+            "vault_browser_total_notes": self.state.vault_browser_total_notes,
+            "vault_browser_filtered_notes": self.state.vault_browser_filtered_notes,
+            "vault_browser_error": self.state.vault_browser_error,
+            "vault_browser_read_only": self.state.vault_browser_read_only,
+            "vault_browser_identity_available": self.state.vault_browser_identity_available,
+            "vault_browser_vault_name": self.state.vault_browser_vault_name,
+            "vault_browser_vault_channel": self.state.vault_browser_vault_channel,
+            "vault_browser_vault_provenance": self.state.vault_browser_vault_provenance,
             "is_production_ui": self.is_production_ui,
             "dev_page_label": self.dev_page_label,
         }

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -39,7 +39,7 @@ import os
 import sys
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Optional
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, quote, urlparse
 
 from companion_ui.workspace.real_note_workspace_dev_page import (
     NoteLoadIntent,
@@ -251,6 +251,19 @@ def _render_note_section(fields: dict) -> str:
         response=fields.get("panel_last_response") or {},
         writeguard_blocked=writeguard_blocked,
     )
+    vault_browser_html = _render_vault_browser(
+        note_path=fields.get("note_path") or "",
+        notes=fields.get("vault_browser_notes") or [],
+        query=str(fields.get("vault_browser_query") or ""),
+        total_notes=int(fields.get("vault_browser_total_notes") or 0),
+        filtered_notes=int(fields.get("vault_browser_filtered_notes") or 0),
+        error=fields.get("vault_browser_error"),
+        read_only=bool(fields.get("vault_browser_read_only", True)),
+        identity_available=bool(fields.get("vault_browser_identity_available", False)),
+        vault_name=str(fields.get("vault_browser_vault_name") or "unresolved"),
+        vault_channel=str(fields.get("vault_browser_vault_channel") or "unknown"),
+        vault_provenance=str(fields.get("vault_browser_vault_provenance") or "unresolved"),
+    )
     suggested_insertions_html = _render_suggested_insertions(
         fields.get("suggested_insertions") or []
     )
@@ -343,6 +356,7 @@ def _render_note_section(fields: dict) -> str:
         {reorient_mode_html}
         {resurface_mode_html}
         {act_mode_html}
+        {vault_browser_html}
         {guard_html}
         {persistence_html}
         {panel_rail}
@@ -350,6 +364,91 @@ def _render_note_section(fields: dict) -> str:
     </aside>
     {portrait_sheet_html}
   </div>"""
+
+
+def _render_vault_browser(
+    *,
+    note_path: str,
+    notes: list[dict],
+    query: str,
+    total_notes: int,
+    filtered_notes: int,
+    error: object,
+    read_only: bool,
+    identity_available: bool,
+    vault_name: str,
+    vault_channel: str,
+    vault_provenance: str,
+) -> str:
+    query_text = _e(query or "")
+    identity_label = f"{vault_name}/{vault_channel}"
+    identity_html = (
+        f'<span data-testid="workspace-vault-browser-active-identity">{_e(identity_label)}</span>'
+    )
+    if error:
+        state_html = (
+            '<div class="vault-browser-state" data-testid="workspace-vault-browser-state-error">'
+            + _e(str(error))
+            + "</div>"
+        )
+    elif not identity_available:
+        state_html = (
+            '<div class="vault-browser-state" '
+            'data-testid="workspace-vault-browser-state-identity-unavailable">'
+            "Vault identity unavailable; browsing context is unresolved."
+            "</div>"
+        )
+    elif filtered_notes == 0:
+        state_html = (
+            '<div class="vault-browser-state" data-testid="workspace-vault-browser-state-empty">'
+            "No notes matched the current filter."
+            "</div>"
+        )
+    else:
+        state_html = (
+            '<div class="vault-browser-state" data-testid="workspace-vault-browser-state-ready">'
+            f"{filtered_notes} matches from {total_notes} markdown notes."
+            "</div>"
+        )
+
+    rows: list[str] = []
+    for note in notes:
+        path = str(note.get("note_path") or "").strip()
+        if not path:
+            continue
+        title = _e(note.get("title") or path)
+        zone = _e(note.get("zone") or "root")
+        href = "/?note_path=" + quote(path, safe="/")
+        active = "true" if path == note_path else "false"
+        rows.append(
+            f"""
+          <li class="vault-browser-row" data-testid="workspace-vault-browser-note-row" data-active="{active}">
+            <a href="{href}" data-testid="workspace-vault-browser-note-link">{title}</a>
+            <code data-testid="workspace-vault-browser-note-path">{_e(path)}</code>
+            <span data-testid="workspace-vault-browser-note-zone">{zone}</span>
+          </li>"""
+        )
+
+    list_html = (
+        '<ul class="vault-browser-list" data-testid="workspace-vault-browser-list">'
+        + "".join(rows)
+        + "</ul>"
+        if rows
+        else ""
+    )
+    read_only_text = "read-only" if read_only else "mutating"
+    return f"""
+        <details class="vault-browser" data-testid="workspace-vault-browser" open>
+          <summary data-testid="workspace-vault-browser-toggle">Browse vault notes</summary>
+          <div class="vault-browser-meta" data-testid="workspace-vault-browser-meta">
+            {identity_html}
+            <span data-testid="workspace-vault-browser-read-only">{read_only_text}</span>
+            <span data-testid="workspace-vault-browser-query">{query_text}</span>
+            <span data-testid="workspace-vault-browser-provenance">{_e(vault_provenance)}</span>
+          </div>
+          {state_html}
+          {list_html}
+        </details>"""
 
 
 def _render_suggestion_flow_region(fields: dict) -> str:

--- a/tests/api/test_companion_vault_browser_api.py
+++ b/tests/api/test_companion_vault_browser_api.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app.api.app import app
+
+
+def _write_note(path: Path, *, title: str, body: str = "Body.\n") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"---\ntitle: {title}\n---\n\n{body}", encoding="utf-8")
+
+
+def test_vault_browser_lists_markdown_notes_for_active_dev_vault(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+    _write_note(tmp_path / "notes" / "Companion UI UAT.md", title="Companion UI UAT")
+    _write_note(tmp_path / "projects" / "Roadmap.md", title="Roadmap")
+    (tmp_path / "notes" / "ignore.txt").write_text("nope", encoding="utf-8")
+
+    client = TestClient(app)
+    resp = client.get("/api/companion/vault-browser")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["read_only"] is True
+    assert data["identity_available"] is True
+    assert data["vault_identity"]["channel"] == "dev"
+    paths = [note["note_path"] for note in data["notes"]]
+    assert "notes/Companion UI UAT.md" in paths
+    assert "projects/Roadmap.md" in paths
+    assert all(path.endswith(".md") for path in paths)
+
+
+def test_vault_browser_filters_by_title_or_path(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+    _write_note(tmp_path / "notes" / "Companion UI UAT.md", title="Companion UI UAT")
+    _write_note(tmp_path / "logs" / "journal.md", title="Daily Journal")
+    _write_note(tmp_path / "projects" / "plan.md", title="Project Plan")
+
+    client = TestClient(app)
+    by_title = client.get("/api/companion/vault-browser", params={"q": "journal"}).json()
+    by_path = client.get("/api/companion/vault-browser", params={"q": "projects"}).json()
+
+    assert by_title["filtered_notes"] == 1
+    assert by_title["notes"][0]["title"] == "Daily Journal"
+    assert by_path["filtered_notes"] == 1
+    assert by_path["notes"][0]["note_path"] == "projects/plan.md"
+
+
+def test_vault_browser_is_read_only(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+    note_path = tmp_path / "notes" / "immutable.md"
+    _write_note(note_path, title="Immutable", body="Original.\n")
+    before = note_path.read_text(encoding="utf-8")
+
+    client = TestClient(app)
+    get_resp = client.get("/api/companion/vault-browser")
+    post_resp = client.post("/api/companion/vault-browser", json={"note_path": "notes/immutable.md"})
+
+    assert get_resp.status_code == 200
+    assert get_resp.json()["read_only"] is True
+    assert post_resp.status_code == 405
+    assert note_path.read_text(encoding="utf-8") == before

--- a/tests/companion_ui/test_vault_browser.py
+++ b/tests/companion_ui/test_vault_browser.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from companion_ui.workspace.real_note_workspace_dev_page import NoteLoadIntent, RealNoteWorkspaceDevPage
+from companion_ui.workspace.serve_dev_page import render_index_html
+from companion_ui.workspace.workspace_http_client import WorkspaceClientNetworkError, WorkspaceHttpClient
+
+
+def _workspace_payload(note_path: str = "notes/current.md", title: str = "Current") -> dict[str, Any]:
+    return {
+        "artifact": {
+            "artifact_id": "note-uuid-1",
+            "artifact_kind": "human_note",
+            "note_path": note_path,
+            "title": title,
+            "body": "# Body\n",
+            "content_hash": "abc",
+            "identity_source": "frontmatter.uuid",
+            "identity_state": "resolved",
+            "companion_of": None,
+            "owns_identity": True,
+        },
+        "canvas": {"session_state": "idle", "session_persistence": "in_memory"},
+        "panel": {"state": "idle", "proposal_count": 0},
+        "guards": {
+            "canvas_enabled": True,
+            "writeguard_status": "ok",
+            "workspace_update": {
+                "available": True,
+                "state": "available",
+                "reason": "explicit_dev_config",
+                "scope": "active_note_body",
+                "governance_actions_enabled": False,
+                "config_mode": "explicit",
+            },
+        },
+        "runtime": {
+            "environment_label": "dev",
+            "api_base_url_label": "local-dev",
+            "trace_id": "trace-vault-browser",
+            "vault_identity": {"vault_name": "Niflheim", "channel": "dev", "provenance": "env"},
+        },
+        "suggestions": {},
+    }
+
+
+def _vault_browser_payload(
+    *,
+    notes: list[dict[str, str]] | None = None,
+    query: str = "",
+    total_notes: int = 1,
+    filtered_notes: int = 1,
+    identity_available: bool = True,
+) -> dict[str, Any]:
+    return {
+        "notes": notes
+        or [
+            {
+                "note_path": "notes/Companion UI UAT.md",
+                "title": "Companion UI UAT",
+                "zone": "notes",
+            }
+        ],
+        "query": query,
+        "total_notes": total_notes,
+        "filtered_notes": filtered_notes,
+        "read_only": True,
+        "vault_identity": {"vault_name": "Niflheim", "channel": "dev", "provenance": "env"},
+        "identity_available": identity_available,
+    }
+
+
+def _mock_get_response(payload: dict[str, Any]) -> MagicMock:
+    mock = MagicMock()
+    mock.status_code = 200
+    mock.json.return_value = payload
+    return mock
+
+
+def _load_page(
+    *,
+    workspace_payload: dict[str, Any] | None = None,
+    browser_payload: dict[str, Any] | None = None,
+    browser_error: Exception | None = None,
+    note_path: str = "notes/current.md",
+) -> RealNoteWorkspaceDevPage:
+    workspace = _mock_get_response(workspace_payload or _workspace_payload(note_path=note_path))
+    browser = _mock_get_response(browser_payload or _vault_browser_payload())
+
+    def _side_effect(url: str, *, params: dict[str, Any], timeout: float):
+        if url.endswith("/api/companion/workspace"):
+            return workspace
+        if url.endswith("/api/companion/vault-browser"):
+            if browser_error is not None:
+                raise browser_error
+            return browser
+        raise AssertionError(f"Unexpected URL: {url}")
+
+    with patch("httpx.get", side_effect=_side_effect):
+        client = WorkspaceHttpClient(base_url="http://localhost:18001")
+        page = RealNoteWorkspaceDevPage(client)
+        page.load(NoteLoadIntent(note_path=note_path))
+    return page
+
+
+def test_workspace_can_open_vault_browser() -> None:
+    page = _load_page()
+    fields = page.render_fields()
+    assert fields is not None
+
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="notes/current.md",
+        fields=fields,
+    )
+    assert 'data-testid="workspace-vault-browser"' in html
+    assert 'data-testid="workspace-vault-browser-toggle"' in html
+    assert 'data-testid="workspace-vault-browser-list"' in html
+    assert 'data-testid="workspace-vault-browser-note-link"' in html
+
+
+def test_selecting_note_loads_workspace_note() -> None:
+    page = _load_page(
+        workspace_payload=_workspace_payload(note_path="notes/Companion UI UAT.md", title="Companion UI UAT"),
+        note_path="notes/Companion UI UAT.md",
+    )
+    fields = page.render_fields()
+    assert fields is not None
+
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="notes/Companion UI UAT.md",
+        fields=fields,
+    )
+    assert fields["note_path"] == "notes/Companion UI UAT.md"
+    assert "Companion UI UAT" in html
+    assert "/?note_path=notes/Companion%20UI%20UAT.md" in html
+
+
+def test_vault_browser_renders_active_vault_identity() -> None:
+    page = _load_page()
+    fields = page.render_fields()
+    assert fields is not None
+
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="notes/current.md",
+        fields=fields,
+    )
+    assert 'data-testid="workspace-vault-browser-active-identity"' in html
+    assert "Niflheim/dev" in html
+
+
+def test_vault_browser_distinguishes_empty_error_and_identity_states() -> None:
+    empty_page = _load_page(
+        browser_payload=_vault_browser_payload(notes=[], total_notes=2, filtered_notes=0),
+    )
+    empty_fields = empty_page.render_fields()
+    assert empty_fields is not None
+    empty_html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="notes/current.md",
+        fields=empty_fields,
+    )
+    assert 'data-testid="workspace-vault-browser-state-empty"' in empty_html
+
+    error_page = _load_page(browser_error=WorkspaceClientNetworkError("connection refused"))
+    error_fields = error_page.render_fields()
+    assert error_fields is not None
+    error_html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="notes/current.md",
+        fields=error_fields,
+    )
+    assert 'data-testid="workspace-vault-browser-state-error"' in error_html
+
+    identity_page = _load_page(
+        browser_payload=_vault_browser_payload(identity_available=False),
+    )
+    identity_fields = identity_page.render_fields()
+    assert identity_fields is not None
+    identity_html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="notes/current.md",
+        fields=identity_fields,
+    )
+    assert 'data-testid="workspace-vault-browser-state-identity-unavailable"' in identity_html


### PR DESCRIPTION
## Summary
- add `GET /api/companion/vault-browser` read-only API for markdown note enumeration in active vault/channel
- add deterministic title/path filtering and explicit vault/channel identity payload
- render a read-only vault browser section in Companion workspace UI, including identity, ready/empty/error/identity-unavailable states
- render note-selection links that load selected notes without manual URL editing

## Skill route
- `agentic-pkm → issue-to-code → publish-pr`

## Contract
Closes #1225

## AC verification
- AC1 (open vault browser in Companion UI)
  - Verify: `tests/companion_ui/test_vault_browser.py::test_workspace_can_open_vault_browser`
- AC2 (list markdown notes from active dev vault)
  - Verify: `tests/api/test_companion_vault_browser_api.py::test_vault_browser_lists_markdown_notes_for_active_dev_vault`
- AC3 (filter by title/path)
  - Verify: `tests/api/test_companion_vault_browser_api.py::test_vault_browser_filters_by_title_or_path`
- AC4 (selecting note loads workspace note)
  - Verify: `tests/companion_ui/test_vault_browser.py::test_selecting_note_loads_workspace_note`
- AC5 (render active vault/channel identity)
  - Verify: `tests/companion_ui/test_vault_browser.py::test_vault_browser_renders_active_vault_identity`
- AC6 (browser is read-only)
  - Verify: `tests/api/test_companion_vault_browser_api.py::test_vault_browser_is_read_only`
- AC7 (distinguish empty/error/identity-unavailable states)
  - Verify: `tests/companion_ui/test_vault_browser.py::test_vault_browser_distinguishes_empty_error_and_identity_states`

## Dispatcher
- Dispatcher unavailable/not used in this run; GitHub-label claim path used.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/api/test_companion_vault_browser_api.py tests/companion_ui/test_vault_browser.py`
- `python3 scripts/docs_guard.py`
- `git diff --check`
