### PR TITLE
companion(feature): support active note body updates

### DIFF
--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -13,7 +13,9 @@ from pydantic import BaseModel, Field
 import app.api.routes.canvas as canvas_module
 import app.panel.confirmation as confirm_module
 from app.api.routes.artifacts import _content_hash, _extract_title
+from app.chat.canvas_writer import _body_contains_frontmatter, _split_frontmatter
 from app.config.paths import resolve_vault_root
+from app.knowledge.write_ops import write_note_from_absolute
 from app.orientation.runtime import build_orientation_frame
 from app.resurfacing.runtime import evaluate_resurfacing_candidates
 from app.services.artifact_identity import resolve_note_artifact_identity
@@ -101,6 +103,22 @@ class WorkspaceStateResponse(BaseModel):
     panel: PanelState
     suggestions: SuggestionsState
     guards: GuardState
+
+
+class WorkspaceBodyUpdateRequest(BaseModel):
+    active_note_path: str
+    target_note_path: str
+    new_body: str
+    content_hash: str | None = None
+
+
+class WorkspaceBodyUpdateResponse(BaseModel):
+    ok: bool
+    state: str
+    note_path: str
+    reason: str | None = None
+    content_hash_before: str
+    content_hash_after: str
 
 
 class VaultBrowserNoteState(BaseModel):
@@ -543,6 +561,25 @@ def _browser_title(body: str, *, fallback: str) -> str:
     return _extract_title(body, fallback=fallback)
 
 
+def _compose_note_with_preserved_frontmatter(*, original_content: str, new_body: str) -> str:
+    if _body_contains_frontmatter(new_body):
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "frontmatter_update_not_allowed",
+                "state": "failure",
+                "message": (
+                    "active-note body update only accepts body content; "
+                    "frontmatter changes require a governed flow"
+                ),
+            },
+        )
+    frontmatter_inner, _ = _split_frontmatter(original_content)
+    if frontmatter_inner is not None:
+        return f"---{frontmatter_inner}\n---\n{new_body}"
+    return new_body if new_body.endswith("\n") else f"{new_body}\n"
+
+
 @router.get("/vault-browser", response_model=VaultBrowserStateResponse)
 def read_companion_vault_browser(
     q: str = Query("", description="Case-insensitive path/title filter"),
@@ -635,6 +672,106 @@ def read_companion_workspace(
             degraded=not canvas_enabled or writeguard_status == "unknown",
             workspace_update=workspace_update,
         ),
+    )
+
+
+@router.post("/workspace/update", response_model=WorkspaceBodyUpdateResponse)
+def update_companion_workspace_note_body(
+    req: WorkspaceBodyUpdateRequest,
+) -> WorkspaceBodyUpdateResponse:
+    safe_active_note_path = _validate_workspace_note_path(req.active_note_path)
+    safe_target_note_path = _validate_workspace_note_path(req.target_note_path)
+    if safe_active_note_path != safe_target_note_path:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": "active_note_scope_mismatch",
+                "state": "blocked",
+                "message": "Body update is scoped to the active note only.",
+                "active_note_path": safe_active_note_path,
+                "target_note_path": safe_target_note_path,
+            },
+        )
+
+    vault_root = resolve_vault_root()
+    note_path = _find_workspace_note(vault_root, safe_active_note_path)
+    if note_path is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "error": "note_not_found",
+                "state": "failure",
+                "message": "No note exists for the requested active note path.",
+                "note_path": safe_active_note_path,
+            },
+        )
+
+    writeguard_status = _writeguard_status()
+    workspace_update = _workspace_update_capability(
+        canvas_enabled=_truthy_env("CANVAS_ENABLED"),
+        writeguard_status=writeguard_status,
+    )
+    if not workspace_update.available:
+        writeguard_blocked = workspace_update.reason == "writeguard_blocked"
+        error = (
+            "writeguard_blocked"
+            if writeguard_blocked
+            else "workspace_update_unavailable"
+        )
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": error,
+                "state": "blocked",
+                "message": (
+                    "WriteGuard blocked active-note body update."
+                    if writeguard_blocked
+                    else "Workspace update capability is disabled for this runtime."
+                ),
+                "reason": workspace_update.reason,
+            },
+        )
+
+    try:
+        DEFAULT_WRITE_GUARD.assert_writes_allowed("companion.workspace.update.active_note_body")
+    except WritesBlockedError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": "writeguard_blocked",
+                "state": "blocked",
+                "message": str(exc),
+                "reason": exc.reason,
+            },
+        ) from exc
+
+    original_content = note_path.read_text(encoding="utf-8")
+    content_hash_before = _content_hash(original_content)
+    if req.content_hash is not None and req.content_hash != content_hash_before:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": "content_hash_mismatch",
+                "state": "failure",
+                "message": "Active note changed since it was loaded; refresh before updating.",
+                "content_hash_before": content_hash_before,
+            },
+        )
+
+    new_content = _compose_note_with_preserved_frontmatter(
+        original_content=original_content,
+        new_body=req.new_body,
+    )
+    write_note_from_absolute(note_path, new_content, vault_root=vault_root)
+    updated_content = note_path.read_text(encoding="utf-8")
+    content_hash_after = _content_hash(updated_content)
+    return WorkspaceBodyUpdateResponse(
+        ok=True,
+        state="success",
+        note_path=safe_active_note_path,
+        reason="active_note_body_updated",
+        content_hash_before=content_hash_before,
+        content_hash_after=content_hash_after,
     )
 
 

--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -152,6 +152,9 @@ class DevPageState:
     guard_workspace_update_scope: str = "active_note_body"
     guard_workspace_update_governance_actions_enabled: bool = False
     guard_workspace_update_config_mode: str = "inherited"
+    active_note_body_update_enabled: bool = False
+    active_note_body_update_state: str = "idle"
+    active_note_body_update_message: str = ""
     vault_browser_notes: list[dict[str, Any]] | None = None
     vault_browser_query: str = ""
     vault_browser_total_notes: int = 0
@@ -382,6 +385,7 @@ class RealNoteWorkspaceDevPage:
             guard_workspace_update_scope=workspace_update_scope,
             guard_workspace_update_governance_actions_enabled=workspace_update_governance_actions_enabled,
             guard_workspace_update_config_mode=workspace_update_config_mode,
+            active_note_body_update_enabled=workspace_update_available,
             vault_browser_notes=list(vault_browser.get("notes") or []),
             vault_browser_query=str(vault_browser.get("query") or ""),
             vault_browser_total_notes=int(vault_browser.get("total_notes") or 0),
@@ -526,6 +530,60 @@ class RealNoteWorkspaceDevPage:
         refreshed.suggestion_allowed_transitions = sorted(machine.allowed_transitions())
         refreshed.suggestion_composer_enabled = machine.composer_enabled
         refreshed.suggestion_apply_transition_path = transition_path
+        return refreshed
+
+    def update_active_note_body(self, *, new_body: str) -> DevPageState:
+        """Update the currently loaded note body through the workspace update API."""
+        if self.state.shell is None:
+            self.state.error = "No workspace note is loaded"
+            self.state.is_loaded = False
+            self.state.active_note_body_update_state = "failure"
+            self.state.active_note_body_update_message = "No active note loaded."
+            return self.state
+
+        note_path = self.state.shell.note_path
+        if not self.state.guard_workspace_update_available:
+            self.state.active_note_body_update_state = "blocked"
+            self.state.active_note_body_update_message = (
+                "Workspace update capability is disabled for the active runtime."
+            )
+            return self.state
+
+        try:
+            response = self._http.post(
+                "/api/companion/workspace/update",
+                json={
+                    "active_note_path": note_path,
+                    "target_note_path": note_path,
+                    "new_body": new_body,
+                    "content_hash": self.state.shell.content_hash,
+                },
+            )
+        except WorkspaceClientHTTPError as exc:
+            lowered = exc.detail.lower()
+            is_blocked = exc.status_code in {403, 409} and (
+                "blocked" in lowered
+                or "writeguard" in lowered
+                or "scope" in lowered
+                or "unavailable" in lowered
+            )
+            self.state.active_note_body_update_state = "blocked" if is_blocked else "failure"
+            self.state.active_note_body_update_message = exc.detail
+            self.state.error = str(exc)
+            self.state.is_loaded = False
+            return self.state
+        except WorkspaceClientError as exc:
+            self.state.active_note_body_update_state = "failure"
+            self.state.active_note_body_update_message = str(exc)
+            self.state.error = str(exc)
+            self.state.is_loaded = False
+            return self.state
+
+        refreshed = self.load(NoteLoadIntent(note_path=note_path))
+        refreshed.active_note_body_update_state = "success"
+        refreshed.active_note_body_update_message = (
+            str(response.get("reason") or "active_note_body_updated")
+        )
         return refreshed
 
     def queue_governance_suggestion(
@@ -827,6 +885,9 @@ class RealNoteWorkspaceDevPage:
                 self.state.guard_workspace_update_governance_actions_enabled
             ),
             "guard_workspace_update_config_mode": self.state.guard_workspace_update_config_mode,
+            "active_note_body_update_enabled": self.state.active_note_body_update_enabled,
+            "active_note_body_update_state": self.state.active_note_body_update_state,
+            "active_note_body_update_message": self.state.active_note_body_update_message,
             "vault_browser_notes": self.state.vault_browser_notes or [],
             "vault_browser_query": self.state.vault_browser_query,
             "vault_browser_total_notes": self.state.vault_browser_total_notes,

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -129,6 +129,11 @@ def _render_note_section(fields: dict) -> str:
         fields.get("guard_workspace_update_governance_actions_enabled", False)
     )
     workspace_update_config_mode = _e(fields.get("guard_workspace_update_config_mode") or "inherited")
+    active_note_body_update_enabled = bool(
+        fields.get("active_note_body_update_enabled", workspace_update_available)
+    )
+    active_note_body_update_state = _e(fields.get("active_note_body_update_state") or "idle")
+    active_note_body_update_message = _e(fields.get("active_note_body_update_message") or "")
     identity_caution_html = ""
     if identity_state_raw.startswith("unresolved"):
         identity_caution_html = (
@@ -286,6 +291,14 @@ def _render_note_section(fields: dict) -> str:
         applied_edit_count=applied_edit_count,
         undone_edit_count=undone_edit_count,
     )
+    active_note_body_update_html = _render_active_note_body_update_flow(
+        note_path=note_path_val,
+        content_hash=content_hash,
+        enabled=active_note_body_update_enabled,
+        state=active_note_body_update_state,
+        message=active_note_body_update_message,
+        reason=workspace_update_reason,
+    )
 
     return f"""
   <div class="workspace-layout">
@@ -340,6 +353,7 @@ def _render_note_section(fields: dict) -> str:
           <span class="rail-state-value">{canvas_state}</span>
         </div>
         {canvas_controls_html}
+        {active_note_body_update_html}
         <div class="rail-state-row">
           <span class="rail-state-label">Panel</span>
           <span class="rail-state-value" data-testid="workspace-panel-label">{panel_label}</span>
@@ -364,6 +378,74 @@ def _render_note_section(fields: dict) -> str:
     </aside>
     {portrait_sheet_html}
   </div>"""
+
+
+def _render_active_note_body_update_flow(
+    *,
+    note_path: str,
+    content_hash: str,
+    enabled: bool,
+    state: str,
+    message: str,
+    reason: str,
+) -> str:
+    safe_state = _e(state or "idle")
+    safe_message = _e(message)
+    if not enabled:
+        return f"""
+        <section
+          class="active-note-body-update-flow"
+          data-testid="workspace-active-note-body-update-flow"
+          data-flow-state="disabled">
+          <div
+            class="active-note-body-update-blocked"
+            data-testid="workspace-active-note-body-update-state-blocked">
+            Active-note body update unavailable: {_e(reason)}.
+          </div>
+        </section>"""
+
+    status_html = ""
+    if safe_state == "success":
+        status_html = (
+            '<div class="active-note-body-update-success" '
+            'data-testid="workspace-active-note-body-update-state-success">'
+            + (safe_message or "Body update saved.")
+            + "</div>"
+        )
+    elif safe_state == "blocked":
+        status_html = (
+            '<div class="active-note-body-update-blocked" '
+            'data-testid="workspace-active-note-body-update-state-blocked">'
+            + (safe_message or "Body update blocked by runtime guard.")
+            + "</div>"
+        )
+    elif safe_state == "failure":
+        status_html = (
+            '<div class="active-note-body-update-failure" '
+            'data-testid="workspace-active-note-body-update-state-failure">'
+            + (safe_message or "Body update failed.")
+            + "</div>"
+        )
+
+    return f"""
+        <section
+          class="active-note-body-update-flow"
+          data-testid="workspace-active-note-body-update-flow"
+          data-flow-state="enabled">
+          <label for="active_note_body_update_input">Active note body update</label>
+          <textarea
+            id="active_note_body_update_input"
+            data-testid="workspace-active-note-body-update-input"
+            aria-label="Active note body update input"></textarea>
+          <button
+            type="button"
+            data-testid="workspace-active-note-body-update-submit"
+            data-api-method="POST"
+            data-api-path="/api/companion/workspace/update"
+            data-note-path="{_e(note_path)}"
+            data-content-hash="{_e(content_hash)}">Update body</button>
+          {status_html}
+        </section>"""
 
 
 def _render_vault_browser(

--- a/docs/HUMAN-FLOWS.md
+++ b/docs/HUMAN-FLOWS.md
@@ -919,3 +919,12 @@ For Niflheim dev UAT, Companion workspace update capability must be visible as r
 - the runtime safety strip must declare workspace update availability as `available` or `disabled`
 - disabled state must remain non-mutating in the UI (no active body-update composer)
 - workspace update capability is scoped to active-note body updates and must not authorize governance-bearing actions
+
+## Companion Niflheim dev UAT active note body update check
+
+For Niflheim dev UAT, active-note body updates in Companion workspace must stay bounded and guarded:
+- entering the active-note body update flow must be explicit and note-local
+- update attempts must be scoped to the active note path only
+- successful updates must preserve frontmatter and UUID while changing body content
+- blocked updates must show a clear guard reason (for example WriteGuard or capability disabled)
+- failed updates must show a clear failure state distinct from blocked

--- a/tests/api/test_companion_workspace_update_api.py
+++ b/tests/api/test_companion_workspace_update_api.py
@@ -1,0 +1,151 @@
+"""Companion workspace active-note body update API tests (#1226)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.api.routes.companion as companion_module
+from app.api.app import app
+from app.write_guard import DEFAULT_WRITE_GUARD, WriteGuard, WritesBlockedError
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _reset_guard_snapshot() -> None:
+    yield
+    companion_module.DEFAULT_WRITE_GUARD.snapshot_fn = DEFAULT_WRITE_GUARD.snapshot_fn
+
+
+@pytest.fixture()
+def workspace_notes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Path]:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    monkeypatch.setenv("CANVAS_ENABLED", "1")
+    monkeypatch.setenv("COMPANION_WORKSPACE_UPDATE_ENABLED", "1")
+
+    active = tmp_path / "notes" / "active.md"
+    active.parent.mkdir(parents=True, exist_ok=True)
+    active.write_text(
+        "---\n"
+        "uuid: active-uuid-1\n"
+        "title: Active\n"
+        "---\n\n"
+        "# Active\n\n"
+        "Initial active body.\n",
+        encoding="utf-8",
+    )
+
+    other = tmp_path / "notes" / "other.md"
+    other.write_text(
+        "---\n"
+        "uuid: other-uuid-1\n"
+        "---\n\n"
+        "# Other\n\n"
+        "Other note body.\n",
+        encoding="utf-8",
+    )
+
+    return {"active": active, "other": other}
+
+
+def _workspace(client: TestClient, note_path: str) -> dict:
+    resp = client.get("/api/companion/workspace", params={"note_path": note_path})
+    assert resp.status_code == 200
+    return resp.json()
+
+
+def test_body_update_is_scoped_to_active_note(
+    client: TestClient,
+    workspace_notes: dict[str, Path],
+) -> None:
+    workspace = _workspace(client, "notes/active.md")
+    content_hash = workspace["artifact"]["content_hash"]
+
+    resp = client.post(
+        "/api/companion/workspace/update",
+        json={
+            "active_note_path": "notes/active.md",
+            "target_note_path": "notes/other.md",
+            "new_body": "# Should not apply\n\nNope.\n",
+            "content_hash": content_hash,
+        },
+    )
+
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert detail["error"] == "active_note_scope_mismatch"
+    assert detail["state"] == "blocked"
+    assert "active note only" in detail["message"].lower()
+
+    assert "Initial active body." in workspace_notes["active"].read_text(encoding="utf-8")
+    assert "Other note body." in workspace_notes["other"].read_text(encoding="utf-8")
+
+
+def test_body_update_preserves_frontmatter_and_uuid(
+    client: TestClient,
+    workspace_notes: dict[str, Path],
+) -> None:
+    workspace = _workspace(client, "notes/active.md")
+    content_hash = workspace["artifact"]["content_hash"]
+
+    resp = client.post(
+        "/api/companion/workspace/update",
+        json={
+            "active_note_path": "notes/active.md",
+            "target_note_path": "notes/active.md",
+            "new_body": "# Active\n\nUpdated body from Companion workspace.\n",
+            "content_hash": content_hash,
+        },
+    )
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["ok"] is True
+    assert payload["state"] == "success"
+    assert payload["note_path"] == "notes/active.md"
+
+    updated = workspace_notes["active"].read_text(encoding="utf-8")
+    assert "uuid: active-uuid-1" in updated
+    assert "title: Active" in updated
+    assert "Updated body from Companion workspace." in updated
+    assert "Initial active body." not in updated
+
+
+def test_body_update_respects_write_guard(
+    client: TestClient,
+    workspace_notes: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = _workspace(client, "notes/active.md")
+    content_hash = workspace["artifact"]["content_hash"]
+    mock_guard = MagicMock(spec=WriteGuard)
+    mock_guard.assert_writes_allowed.side_effect = WritesBlockedError(
+        "blocked",
+        "write guard active",
+        "companion.workspace.update.active_note_body",
+    )
+    monkeypatch.setattr(companion_module, "DEFAULT_WRITE_GUARD", mock_guard)
+
+    resp = client.post(
+        "/api/companion/workspace/update",
+        json={
+            "active_note_path": "notes/active.md",
+            "target_note_path": "notes/active.md",
+            "new_body": "# Active\n\nBlocked edit.\n",
+            "content_hash": content_hash,
+        },
+    )
+
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert detail["error"] == "writeguard_blocked"
+    assert detail["state"] == "blocked"
+    assert "blocked" in detail["message"].lower()
+    assert "Initial active body." in workspace_notes["active"].read_text(encoding="utf-8")

--- a/tests/companion_ui/test_active_note_body_update.py
+++ b/tests/companion_ui/test_active_note_body_update.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from companion_ui.workspace.real_note_workspace_dev_page import NoteLoadIntent, RealNoteWorkspaceDevPage
+from companion_ui.workspace.serve_dev_page import render_index_html
+from companion_ui.workspace.workspace_http_client import WorkspaceHttpClient
+
+
+def _workspace_payload(note_path: str = "notes/current.md", title: str = "Current") -> dict[str, Any]:
+    return {
+        "artifact": {
+            "artifact_id": "note-uuid-update-1",
+            "artifact_kind": "human_note",
+            "note_path": note_path,
+            "title": title,
+            "body": "# Body\n\nInitial text.\n",
+            "content_hash": "hash-current",
+            "identity_source": "frontmatter.uuid",
+            "identity_state": "resolved",
+            "companion_of": None,
+            "owns_identity": True,
+        },
+        "canvas": {"session_state": "idle", "session_persistence": "in_memory"},
+        "panel": {"state": "idle", "proposal_count": 0},
+        "guards": {
+            "canvas_enabled": True,
+            "writeguard_status": "ok",
+            "workspace_update": {
+                "available": True,
+                "state": "available",
+                "reason": "explicit_dev_config",
+                "scope": "active_note_body",
+                "governance_actions_enabled": False,
+                "config_mode": "explicit",
+            },
+        },
+        "runtime": {
+            "environment_label": "dev",
+            "api_base_url_label": "local-dev",
+            "trace_id": "trace-active-note-update",
+            "vault_identity": {"vault_name": "Niflheim", "channel": "dev", "provenance": "env"},
+        },
+        "suggestions": {},
+    }
+
+
+def _vault_browser_payload() -> dict[str, Any]:
+    return {
+        "notes": [
+            {
+                "note_path": "notes/current.md",
+                "title": "Current",
+                "zone": "notes",
+            }
+        ],
+        "query": "",
+        "total_notes": 1,
+        "filtered_notes": 1,
+        "read_only": True,
+        "vault_identity": {"vault_name": "Niflheim", "channel": "dev", "provenance": "env"},
+        "identity_available": True,
+    }
+
+
+def _mock_get_response(payload: dict[str, Any]) -> MagicMock:
+    mock = MagicMock()
+    mock.status_code = 200
+    mock.json.return_value = payload
+    return mock
+
+
+def _load_page(*, workspace_payload: dict[str, Any] | None = None) -> RealNoteWorkspaceDevPage:
+    workspace = _mock_get_response(workspace_payload or _workspace_payload())
+    browser = _mock_get_response(_vault_browser_payload())
+
+    def _side_effect(url: str, *, params: dict[str, Any], timeout: float):
+        if url.endswith("/api/companion/workspace"):
+            return workspace
+        if url.endswith("/api/companion/vault-browser"):
+            return browser
+        raise AssertionError(f"Unexpected URL: {url}")
+
+    with patch("httpx.get", side_effect=_side_effect):
+        client = WorkspaceHttpClient(base_url="http://localhost:18001")
+        page = RealNoteWorkspaceDevPage(client)
+        page.load(NoteLoadIntent(note_path="notes/current.md"))
+    return page
+
+
+def test_user_can_enter_active_note_body_update_flow() -> None:
+    page = _load_page()
+    fields = page.render_fields()
+    assert fields is not None
+
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="notes/current.md",
+        fields=fields,
+    )
+    assert 'data-testid="workspace-active-note-body-update-flow"' in html
+    assert 'data-testid="workspace-active-note-body-update-input"' in html
+    assert 'data-testid="workspace-active-note-body-update-submit"' in html
+
+
+def test_body_update_renders_success_blocked_and_failure_states() -> None:
+    page = _load_page()
+    fields = page.render_fields()
+    assert fields is not None
+
+    fields["active_note_body_update_state"] = "success"
+    fields["active_note_body_update_message"] = "active_note_body_updated"
+    success_html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="notes/current.md",
+        fields=fields,
+    )
+    assert 'data-testid="workspace-active-note-body-update-state-success"' in success_html
+
+    fields["active_note_body_update_state"] = "blocked"
+    fields["active_note_body_update_message"] = "writeguard blocked"
+    blocked_html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="notes/current.md",
+        fields=fields,
+    )
+    assert 'data-testid="workspace-active-note-body-update-state-blocked"' in blocked_html
+
+    fields["active_note_body_update_state"] = "failure"
+    fields["active_note_body_update_message"] = "network timeout"
+    failure_html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="notes/current.md",
+        fields=fields,
+    )
+    assert 'data-testid="workspace-active-note-body-update-state-failure"' in failure_html

--- a/tests/companion_ui/test_real_note_workspace_dev_page.py
+++ b/tests/companion_ui/test_real_note_workspace_dev_page.py
@@ -127,10 +127,11 @@ def test_dev_page_exposes_note_path_load_intent() -> None:
         state = page.load(NoteLoadIntent(note_path="Notes/test.md"))
 
     assert state.is_loaded is True
-    call_args = mock_get.call_args
-    assert call_args.args[0] == "http://localhost:18001/api/companion/workspace"
-    assert "note_path" in call_args.kwargs["params"]
-    assert call_args.kwargs["params"]["note_path"] == "Notes/test.md"
+    assert len(mock_get.call_args_list) >= 1
+    workspace_call = mock_get.call_args_list[0]
+    assert workspace_call.args[0] == "http://localhost:18001/api/companion/workspace"
+    assert "note_path" in workspace_call.kwargs["params"]
+    assert workspace_call.kwargs["params"]["note_path"] == "Notes/test.md"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1226

## Summary
- add `POST /api/companion/workspace/update` for active-note body updates through runtime-only write path
- enforce active-note scope checks, workspace capability guard, writeguard blocking, and hash-based stale-write detection
- preserve note frontmatter/UUID while updating body content and return explicit success/blocked/failure update states
- add Companion UI active-note body update flow rendering with explicit success/blocked/failure state surfaces
- update Niflheim dev UAT flow docs for active-note body update verification

## Skill route
- `agentic-pkm → issue-to-code → publish-pr`

## Contract
Fixes #1226

## AC verification
- AC1 (enter active-note body update flow)
  - Verify: `tests/companion_ui/test_active_note_body_update.py::test_user_can_enter_active_note_body_update_flow`
- AC2 (scoped to active note only)
  - Verify: `tests/api/test_companion_workspace_update_api.py::test_body_update_is_scoped_to_active_note`
- AC3 (frontmatter/UUID preserved)
  - Verify: `tests/api/test_companion_workspace_update_api.py::test_body_update_preserves_frontmatter_and_uuid`
- AC4 (WriteGuard authoritative)
  - Verify: `tests/api/test_companion_workspace_update_api.py::test_body_update_respects_write_guard`
- AC5 (UI success/blocked/failure states)
  - Verify: `tests/companion_ui/test_active_note_body_update.py::test_body_update_renders_success_blocked_and_failure_states`
- AC6 (Niflheim dev UAT writeback)
  - Verify: `docs/HUMAN-FLOWS.md :: Companion Niflheim dev UAT active note body update check`

## Dispatcher
- Dispatcher unavailable/not used in this run; GitHub-label claim path used.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/api/test_companion_workspace_update_api.py tests/companion_ui/test_active_note_body_update.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/api/test_companion_workspace_api.py tests/companion_ui/test_real_note_workspace_dev_page.py`
- `python3 scripts/docs_guard.py`
- `git diff --check`
- `ruff check app tests` could not run in this environment (`ruff` not on PATH and `python3 -m ruff` unavailable).
