### PR TITLE
feat(agent-memory): implement memory authority guard (#1083)

### DIFF
--- a/app/agent_memory/authority_guard.py
+++ b/app/agent_memory/authority_guard.py
@@ -1,0 +1,196 @@
+"""Memory authority guard (AGENT-MEMORY-05).
+
+Implements the authority boundary that prevents unreviewed, inferred, or
+contradicted memory from authorizing writeback or overriding human-authored
+knowledge, as specified in
+``docs/AGENT_MEMORY/PREVENT_UNREVIEWED_MEMORY_AUTHORITY.md``.
+
+Key invariants (all categorical — not configurable, not softened by confidence):
+
+- Unreviewed and rejected memory cannot authorize writeback or governed apply
+  flows. ``candidate`` and ``unreviewed`` review states never reach
+  ``activatable``, ``instructional``, or ``action_authorizing`` use rights.
+- Human-authored artifacts (``human_knowledge``, ``human_authored``,
+  ``human_note``) remain stronger authority than recalled memory regardless
+  of acceptance state.
+- Stale, contradicted, or inferred unreviewed memory must surface its posture
+  before reuse; silent consumption raises ``AuthorityGuardError``.
+- A suggestion path exists (``SUGGESTIVE`` use right is allowed for unreviewed
+  memory) but must not be escalated to ``INSTRUCTIONAL`` or
+  ``ACTION_AUTHORIZING`` without review.
+
+This module imports ``UseRight`` from ``recall_explanation`` (AGENT-MEMORY-04)
+as the shared use-right vocabulary. It ships no storage backend, activation
+engine, or recall surface.
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+from app.agent_memory.candidate import (
+    ActivationPolicy,
+    ContradictionState,
+    MemoryCandidate,
+    ReviewState,
+)
+from app.agent_memory.promotion import PromotedMemory
+from app.agent_memory.recall_explanation import UseRight
+from app.agent_memory.review_queue import ReviewEntry, ReviewStatus
+
+__all__ = [
+    "AuthorityGuardError",
+    "assert_writeback_authorized",
+    "assert_does_not_override_human_truth",
+    "assert_posture_visible",
+    "assert_suggestion_only",
+]
+
+
+class AuthorityGuardError(Exception):
+    """Raised when a memory authority check fails categorically."""
+
+
+_HUMAN_AUTHORED_CLASSES = frozenset({"human_knowledge", "human_authored", "human_note"})
+
+_BLOCKED_ACTIVATION_POLICIES = frozenset(
+    {ActivationPolicy.REVIEW_QUEUE_ONLY, ActivationPolicy.BLOCKED}
+)
+
+_UNESCALATABLE_REVIEW_STATES = frozenset({ReviewState.UNREVIEWED, ReviewState.REVIEWED})
+
+_POSTURE_REQUIRED_CONTRADICTION_STATES = frozenset(
+    {ContradictionState.CONTRADICTED, ContradictionState.REVISED}
+)
+
+
+def _extract_candidate(memory: Union[PromotedMemory, ReviewEntry]) -> MemoryCandidate:
+    return memory.candidate
+
+
+# ---------------------------------------------------------------------------
+# Public guard functions
+# ---------------------------------------------------------------------------
+
+
+def assert_writeback_authorized(memory: Union[PromotedMemory, ReviewEntry]) -> None:
+    """Raise AuthorityGuardError if memory cannot authorize writeback.
+
+    Blocked states:
+    - ReviewEntry with PENDING status (unreviewed candidate)
+    - PromotedMemory with REJECTED or REVISED outcome
+    - candidate.review_state is UNREVIEWED or REVIEWED (not yet accepted)
+    - candidate.activation_policy is REVIEW_QUEUE_ONLY or BLOCKED
+
+    The only state that passes: PromotedMemory with outcome=ACCEPTED and
+    candidate.review_state=ACCEPTED.
+
+    This guard is categorical. Confidence score, frequency, or proximity to
+    sources do not override it.
+    """
+    candidate = _extract_candidate(memory)
+
+    if isinstance(memory, ReviewEntry):
+        if memory.status is ReviewStatus.PENDING:
+            raise AuthorityGuardError(
+                f"unreviewed candidate {candidate.candidate_id!r} cannot authorize "
+                "writeback; candidate must be reviewed and accepted first"
+            )
+
+    if isinstance(memory, PromotedMemory):
+        if memory.outcome in (ReviewState.REJECTED, ReviewState.REVISED):
+            raise AuthorityGuardError(
+                f"memory with outcome={memory.outcome!r} cannot authorize writeback; "
+                "only ACCEPTED outcome grants write authority"
+            )
+
+    if candidate.review_state in (ReviewState.UNREVIEWED, ReviewState.REVIEWED):
+        raise AuthorityGuardError(
+            f"memory with review_state={candidate.review_state!r} cannot authorize "
+            "writeback; review_state must be ACCEPTED"
+        )
+
+    if candidate.activation_policy in _BLOCKED_ACTIVATION_POLICIES:
+        raise AuthorityGuardError(
+            f"memory with activation_policy={candidate.activation_policy!r} cannot "
+            "authorize writeback; policy restricts activation to review surface only"
+        )
+
+
+def assert_does_not_override_human_truth(
+    memory: Union[PromotedMemory, ReviewEntry],
+    *,
+    target_artifact_class: str,
+) -> None:
+    """Raise AuthorityGuardError if memory would override a human-authored artifact.
+
+    Human-authored artifact classes (``human_knowledge``, ``human_authored``,
+    ``human_note``) are always stronger authority than recalled memory,
+    regardless of the memory's review or acceptance state. This applies even
+    to fully promoted memory.
+    """
+    if target_artifact_class in _HUMAN_AUTHORED_CLASSES:
+        candidate = _extract_candidate(memory)
+        raise AuthorityGuardError(
+            f"memory {candidate.candidate_id!r} cannot override human-authored artifact "
+            f"of class {target_artifact_class!r}; human-authored knowledge remains "
+            "stronger authority than recalled memory regardless of acceptance state"
+        )
+
+
+def assert_posture_visible(memory: Union[PromotedMemory, ReviewEntry]) -> None:
+    """Raise AuthorityGuardError if memory posture must be surfaced before reuse.
+
+    Raises for:
+    - candidate.contradiction_state is CONTRADICTED or REVISED (stale/contradicted)
+    - candidate.inferred is True AND candidate.review_state is UNREVIEWED
+
+    Passes for:
+    - Accepted memory (inferred or not) — review makes the posture explicit
+    - Clear, non-contradicted, non-inferred-unreviewed memory
+
+    Silent consumption of stale, contradicted, or inferred unreviewed memory
+    is not allowed; the caller must have a surface that makes posture visible
+    before reaching a recall or reuse point.
+    """
+    candidate = _extract_candidate(memory)
+
+    if candidate.contradiction_state in _POSTURE_REQUIRED_CONTRADICTION_STATES:
+        raise AuthorityGuardError(
+            f"memory {candidate.candidate_id!r} has contradiction_state="
+            f"{candidate.contradiction_state!r} and must surface its posture before "
+            "reuse; silent consumption of contradicted or stale memory is not allowed"
+        )
+
+    if candidate.inferred and candidate.review_state is ReviewState.UNREVIEWED:
+        raise AuthorityGuardError(
+            f"inferred unreviewed memory {candidate.candidate_id!r} must surface its "
+            "posture before reuse; callers must make the inferred/unreviewed status "
+            "visible rather than consuming it silently"
+        )
+
+
+def assert_suggestion_only(
+    memory: Union[PromotedMemory, ReviewEntry],
+    *,
+    proposed_use_right: UseRight,
+) -> None:
+    """Raise AuthorityGuardError if proposed_use_right exceeds SUGGESTIVE for
+    unreviewed or not-yet-accepted memory.
+
+    Unreviewed (UNREVIEWED) and in-review-but-not-accepted (REVIEWED) candidates
+    may only be used with SUGGESTIVE use right. Any escalation to INFORMATIONAL,
+    INSTRUCTIONAL, or ACTION_AUTHORIZING raises.
+
+    Accepted memory is not restricted by this guard — a separate escalation
+    check (build_recall_explanation) governs ACTION_AUTHORIZING requirements.
+    """
+    candidate = _extract_candidate(memory)
+
+    if candidate.review_state in _UNESCALATABLE_REVIEW_STATES:
+        if proposed_use_right is not UseRight.SUGGESTIVE:
+            raise AuthorityGuardError(
+                f"memory with review_state={candidate.review_state!r} may only be used "
+                f"with use_right={UseRight.SUGGESTIVE!r}; escalation to "
+                f"{proposed_use_right!r} requires review_state=accepted"
+            )

--- a/tests/agent_memory/test_memory_authority_guard.py
+++ b/tests/agent_memory/test_memory_authority_guard.py
@@ -1,0 +1,271 @@
+"""Tests for memory authority guard (AGENT-MEMORY-05).
+
+Verifies the four Acceptance Criteria from Issue #1083:
+
+1. test_unreviewed_memory_cannot_authorize_writeback
+2. test_memory_cannot_override_human_authored_truth
+3. test_memory_authority_guard_requires_posture_visibility
+4. test_memory_supports_suggestion_without_escalating_to_mutation_authority
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.agent_memory.authority_guard import (
+    AuthorityGuardError,
+    assert_does_not_override_human_truth,
+    assert_posture_visible,
+    assert_suggestion_only,
+    assert_writeback_authorized,
+)
+from app.agent_memory.candidate import (
+    ActivationPolicy,
+    ContradictionState,
+    MemoryCandidate,
+    MemoryType,
+    ReviewState,
+)
+from app.agent_memory.promotion import PromotedMemory
+from app.agent_memory.recall_explanation import UseRight
+from app.agent_memory.review_queue import ReviewEntry, ReviewStatus
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _candidate(
+    *,
+    title: str = "User prefers concise answers",
+    memory_type: MemoryType = MemoryType.PREFERENCE_MEMORY,
+    inferred: bool = True,
+    source_refs: list[str] | None = None,
+    review_state: ReviewState = ReviewState.UNREVIEWED,
+    activation_policy: ActivationPolicy | None = None,
+    contradiction_state: ContradictionState = ContradictionState.CLEAR,
+    contradiction_notes: str | None = None,
+) -> MemoryCandidate:
+    if activation_policy is None:
+        if review_state is ReviewState.UNREVIEWED:
+            activation_policy = ActivationPolicy.REVIEW_QUEUE_ONLY
+        else:
+            activation_policy = ActivationPolicy.EXPLICIT_OR_CONTEXTUAL
+    return MemoryCandidate(
+        title=title,
+        memory_type=memory_type,
+        inferred=inferred,
+        source_refs=source_refs or ["session:2026-05-21T09:00:00Z"],
+        derived_from="conversation:abc123",
+        generated_by="companion_agent",
+        review_state=review_state,
+        activation_policy=activation_policy,
+        contradiction_state=contradiction_state,
+        contradiction_notes=contradiction_notes,
+    )
+
+
+def _promoted_memory(
+    *,
+    candidate: MemoryCandidate | None = None,
+    outcome: ReviewState = ReviewState.ACCEPTED,
+    decided_by: str = "reviewer:rasmus",
+    decision_notes: str | None = None,
+    revision_of: str | None = None,
+) -> PromotedMemory:
+    c = candidate or _candidate(
+        review_state=ReviewState.ACCEPTED,
+        inferred=False,
+    )
+    return PromotedMemory(
+        outcome=outcome,
+        candidate=c,
+        decided_by=decided_by,
+        decided_at=datetime.now(timezone.utc),
+        decision_notes=decision_notes,
+        revision_of=revision_of,
+    )
+
+
+def _review_entry(
+    *,
+    candidate: MemoryCandidate | None = None,
+    status: ReviewStatus = ReviewStatus.PENDING,
+) -> ReviewEntry:
+    c = candidate or _candidate()
+    return ReviewEntry(candidate=c, status=status)
+
+
+# ---------------------------------------------------------------------------
+# AC 1: Unreviewed memory cannot authorize writeback or governed apply flows
+# ---------------------------------------------------------------------------
+
+
+def test_unreviewed_memory_cannot_authorize_writeback() -> None:
+    # ReviewEntry (PENDING/unreviewed) → blocked
+    entry = _review_entry()
+    with pytest.raises(AuthorityGuardError):
+        assert_writeback_authorized(entry)
+
+    # PromotedMemory with REJECTED outcome → blocked
+    rejected_candidate = _candidate(review_state=ReviewState.REJECTED)
+    rejected = _promoted_memory(candidate=rejected_candidate, outcome=ReviewState.REJECTED)
+    with pytest.raises(AuthorityGuardError):
+        assert_writeback_authorized(rejected)
+
+    # PromotedMemory with REVISED outcome → blocked (authority moves to revised successor)
+    revised_candidate = _candidate(review_state=ReviewState.REVISED)
+    revised = _promoted_memory(candidate=revised_candidate, outcome=ReviewState.REVISED)
+    with pytest.raises(AuthorityGuardError):
+        assert_writeback_authorized(revised)
+
+    # REVIEW_QUEUE_ONLY activation policy → blocked even if review_state is something else
+    blocked_policy_candidate = _candidate(
+        review_state=ReviewState.UNREVIEWED,
+        activation_policy=ActivationPolicy.BLOCKED,
+    )
+    blocked_entry = _review_entry(candidate=blocked_policy_candidate)
+    with pytest.raises(AuthorityGuardError):
+        assert_writeback_authorized(blocked_entry)
+
+    # PromotedMemory with ACCEPTED outcome + accepted candidate → passes
+    accepted_candidate = _candidate(
+        review_state=ReviewState.ACCEPTED,
+        inferred=False,
+        activation_policy=ActivationPolicy.EXPLICIT_OR_CONTEXTUAL,
+    )
+    promoted = _promoted_memory(candidate=accepted_candidate, outcome=ReviewState.ACCEPTED)
+    assert_writeback_authorized(promoted)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# AC 2: Memory cannot override human-authored truth regardless of acceptance state
+# ---------------------------------------------------------------------------
+
+
+def test_memory_cannot_override_human_authored_truth() -> None:
+    # Even a fully accepted, promoted memory cannot override human-authored artifacts
+    accepted_candidate = _candidate(
+        review_state=ReviewState.ACCEPTED,
+        inferred=False,
+        activation_policy=ActivationPolicy.EXPLICIT_OR_CONTEXTUAL,
+    )
+    promoted = _promoted_memory(candidate=accepted_candidate, outcome=ReviewState.ACCEPTED)
+
+    for human_class in ("human_knowledge", "human_authored", "human_note"):
+        with pytest.raises(AuthorityGuardError):
+            assert_does_not_override_human_truth(
+                promoted, target_artifact_class=human_class
+            )
+
+    # Non-human-authored target artifact classes are not blocked
+    assert_does_not_override_human_truth(
+        promoted, target_artifact_class="agentic_memory"
+    )  # must not raise
+
+    assert_does_not_override_human_truth(
+        promoted, target_artifact_class="project_context"
+    )  # must not raise
+
+    # Even unreviewed memory is blocked from overriding human truth
+    entry = _review_entry()
+    with pytest.raises(AuthorityGuardError):
+        assert_does_not_override_human_truth(entry, target_artifact_class="human_knowledge")
+
+    with pytest.raises(AuthorityGuardError):
+        assert_does_not_override_human_truth(entry, target_artifact_class="human_authored")
+
+
+# ---------------------------------------------------------------------------
+# AC 3: Stale, contradicted, or inferred memory must surface posture before reuse
+# ---------------------------------------------------------------------------
+
+
+def test_memory_authority_guard_requires_posture_visibility() -> None:
+    # Contradicted candidate → posture must be surfaced before reuse
+    contradicted_candidate = _candidate(
+        contradiction_state=ContradictionState.CONTRADICTED,
+        contradiction_notes="Later sessions contradict this.",
+    )
+    entry = _review_entry(candidate=contradicted_candidate)
+    with pytest.raises(AuthorityGuardError):
+        assert_posture_visible(entry)
+
+    # REVISED contradiction_state → same rule
+    revised_candidate = _candidate(
+        contradiction_state=ContradictionState.REVISED,
+        contradiction_notes="This was superseded by a correction.",
+    )
+    with pytest.raises(AuthorityGuardError):
+        assert_posture_visible(_review_entry(candidate=revised_candidate))
+
+    # Inferred + unreviewed → must surface posture
+    inferred_unreviewed = _candidate(inferred=True, review_state=ReviewState.UNREVIEWED)
+    with pytest.raises(AuthorityGuardError):
+        assert_posture_visible(_review_entry(candidate=inferred_unreviewed))
+
+    # Inferred but accepted (review makes posture visible) → passes
+    accepted_inferred = _candidate(
+        inferred=True,
+        review_state=ReviewState.ACCEPTED,
+        activation_policy=ActivationPolicy.EXPLICIT_OR_CONTEXTUAL,
+    )
+    promoted = _promoted_memory(candidate=accepted_inferred, outcome=ReviewState.ACCEPTED)
+    assert_posture_visible(promoted)  # must not raise
+
+    # Non-inferred, non-contradicted, clear state → passes
+    clear_candidate = _candidate(
+        inferred=False,
+        review_state=ReviewState.ACCEPTED,
+        contradiction_state=ContradictionState.CLEAR,
+        activation_policy=ActivationPolicy.EXPLICIT_OR_CONTEXTUAL,
+    )
+    clear_promoted = _promoted_memory(candidate=clear_candidate, outcome=ReviewState.ACCEPTED)
+    assert_posture_visible(clear_promoted)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# AC 4: Implementation distinguishes memory-supported suggestion from
+#        memory-authorized mutation
+# ---------------------------------------------------------------------------
+
+
+def test_memory_supports_suggestion_without_escalating_to_mutation_authority() -> None:
+    unreviewed = _candidate(review_state=ReviewState.UNREVIEWED)
+    entry = _review_entry(candidate=unreviewed)
+
+    # Suggestion path (SUGGESTIVE) is allowed for unreviewed memory
+    assert_suggestion_only(entry, proposed_use_right=UseRight.SUGGESTIVE)  # must not raise
+
+    # Escalation to stronger use rights is blocked
+    with pytest.raises(AuthorityGuardError):
+        assert_suggestion_only(entry, proposed_use_right=UseRight.INFORMATIONAL)
+
+    with pytest.raises(AuthorityGuardError):
+        assert_suggestion_only(entry, proposed_use_right=UseRight.INSTRUCTIONAL)
+
+    with pytest.raises(AuthorityGuardError):
+        assert_suggestion_only(entry, proposed_use_right=UseRight.ACTION_AUTHORIZING)
+
+    # Accepted memory can use INSTRUCTIONAL without tripping the suggestion-only guard
+    accepted_candidate = _candidate(
+        review_state=ReviewState.ACCEPTED,
+        inferred=False,
+        activation_policy=ActivationPolicy.EXPLICIT_OR_CONTEXTUAL,
+    )
+    promoted = _promoted_memory(candidate=accepted_candidate, outcome=ReviewState.ACCEPTED)
+    assert_suggestion_only(promoted, proposed_use_right=UseRight.INSTRUCTIONAL)  # must not raise
+    assert_suggestion_only(promoted, proposed_use_right=UseRight.SUGGESTIVE)  # also fine
+
+    # REVIEWED (not yet accepted) state → only SUGGESTIVE allowed
+    reviewed_candidate = _candidate(
+        review_state=ReviewState.REVIEWED,
+        activation_policy=ActivationPolicy.EXPLICIT_OR_CONTEXTUAL,
+    )
+    reviewed_entry = _review_entry(candidate=reviewed_candidate)
+    assert_suggestion_only(reviewed_entry, proposed_use_right=UseRight.SUGGESTIVE)
+    with pytest.raises(AuthorityGuardError):
+        assert_suggestion_only(reviewed_entry, proposed_use_right=UseRight.INSTRUCTIONAL)


### PR DESCRIPTION
## Summary

- Adds `app/agent_memory/authority_guard.py` with four categorical guard functions and `AuthorityGuardError`
- Adds `tests/agent_memory/test_memory_authority_guard.py` with all four AC tests from issue #1083
- Guards enforce the safety invariant from `CONTEXT_ACTIVATION_SEMANTICS.md` §7.1: unreviewed memory must not become hidden authority
- `assert_writeback_authorized` — blocks unreviewed, rejected, and revised memory; only `ACCEPTED` `PromotedMemory` passes
- `assert_does_not_override_human_truth` — blocks all memory from overriding `human_knowledge`, `human_authored`, `human_note` targets regardless of acceptance state
- `assert_posture_visible` — requires posture surfacing for contradicted, stale, or inferred-unreviewed memory before consumption
- `assert_suggestion_only` — allows `SUGGESTIVE` use right for unreviewed memory but blocks escalation to `INFORMATIONAL`, `INSTRUCTIONAL`, or `ACTION_AUTHORIZING`
- All guards are categorical — no confidence score, frequency, or proximity value can override them

## Dependencies

Builds on `recall_explanation.py` (PR #1243, issue #1082) — imports `UseRight` enum.

## Test plan

- [x] `pytest tests/agent_memory/test_memory_authority_guard.py -v` — 4 tests, all pass
- [x] `pytest tests/agent_memory/ -v` — 35 tests, no regressions (includes all prior slices)
- [x] `mypy app/agent_memory/authority_guard.py` — no issues
- [x] `ruff check` — no issues

## Source Anchors

- `docs/AGENT_MEMORY/PREVENT_UNREVIEWED_MEMORY_AUTHORITY.md :: Acceptance Criteria`
- `docs/CONTEXTUALIZATION_LAYER/CONTEXT_ACTIVATION_SEMANTICS.md :: §7.1 The core rule`
- `docs/CONCEPTS/AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT.md :: Authority rules`

Fixes #1083

🤖 Generated with [Claude Code](https://claude.com/claude-code)