### PR TITLE
fix(api): reconstruct artifact path from vault root to resolve CodeQL path-injection

### DIFF
--- a/app/api/routes/artifacts.py
+++ b/app/api/routes/artifacts.py
@@ -54,23 +54,27 @@ def _resolve_and_validate(
             detail={"error": "invalid_path", "note_path": note_path_raw, "reason": "path_traversal"},
         )
 
-    if candidate.is_absolute():
-        resolved = candidate.resolve()
-    else:
-        resolved = (vault_root / candidate).resolve()
-
     vault_resolved = vault_root.resolve()
 
-    # Reject paths that escape the vault root
+    if candidate.is_absolute():
+        candidate_resolved = candidate.resolve()
+    else:
+        candidate_resolved = (vault_root / candidate).resolve()
+
+    # Reject paths that escape the vault root; capture the vault-relative part.
     try:
-        resolved.relative_to(vault_resolved)
+        contained = candidate_resolved.relative_to(vault_resolved)
     except ValueError:
         raise HTTPException(
             status_code=400,
             detail={"error": "invalid_path", "note_path": note_path_raw, "reason": "outside_vault"},
         )
 
-    return resolved
+    # Reconstruct the final path from the trusted vault root so that downstream
+    # file I/O is not tainted by the raw user-supplied value (fixes CodeQL
+    # py/path-injection: the returned path flows from vault_resolved, not from
+    # user input).
+    return vault_resolved / contained
 
 
 @router.get("/note", response_model=ArtifactNoteResponse)


### PR DESCRIPTION
## Direct Repair

Type: code
Reason: CodeQL `py/path-injection` alert #42 flagged that user-supplied `note_path` flowed into file I/O through `candidate.resolve()` without the taint being cleared after the `relative_to` containment check. `_resolve_and_validate` returned the user-derived resolved path; callers then called `.read_text()` on it. The fix reconstructs the returned path from the trusted `vault_resolved` base + the validated `contained` relative part, breaking the taint chain while keeping identical runtime behavior.
Validation: `pytest tests/api/test_artifact_note_read_api.py -v` — 5/5 pass; `ruff check` clean; `mypy` clean
Issue required: no — bounded immediate repair

## Summary

- `_resolve_and_validate` now captures `contained = candidate_resolved.relative_to(vault_resolved)` after the containment check
- Returns `vault_resolved / contained` instead of the user-derived `candidate_resolved`
- No functional change for valid vault paths; all existing tests pass unchanged
- Resolves CodeQL `py/path-injection` (alert #42, `app/api/routes/artifacts.py:58`)