### PR TITLE
Potential fix for code scanning alert no. 20: Information exposure through an exception

### DIFF
--- a/app/settings/panel_actions.py
+++ b/app/settings/panel_actions.py
@@ -132,8 +132,8 @@ def get_panel_actions_diagnostics(root: Optional[Path] = None) -> Dict[str, Any]
         if resolved.exists():
             try:
                 mappings = load_panel_action_mappings(resolved)
-            except Exception as exc:
-                _set_last_error(f"{exc.__class__.__name__}: {exc}")
+            except Exception:
+                _set_last_error("mapping load failed")
                 mappings = {}
         else:
             _set_last_error(f"missing: {resolved}")


### PR DESCRIPTION
## Direct Repair
Type: code
Reason: Bounded security hardening fix to stop returning raw exception text in panel-action diagnostics for CodeQL alert 20.
Validation: CI checks on this PR (`smoke`, `smoke-docker`, `settings`, `CodeQL`) plus targeted runtime behavior in existing diagnostics path.
Issue required: no — bounded immediate repair

## Summary
Potential fix for [https://github.com/RasmusTho/agentic-pkm-mvp/security/code-scanning/20](https://github.com/RasmusTho/agentic-pkm-mvp/security/code-scanning/20)

The safest fix is to **stop returning raw exception text in API diagnostics**, while still preserving debuggability server-side.

Best single approach with minimal behavior change:
1. In `app/settings/panel_actions.py`, when `load_panel_action_mappings` fails, store/log a **generic error code/message** instead of interpolating `exc`.
2. Keep returning `last_panel_mapping_load_error` in the diagnostics payload, but ensure it is sanitized (for example `"mapping load failed"`).
3. Optionally log full exception server-side (not required for the CodeQL sink fix, and not necessary if you want minimal edits).

Concretely, edit the `except Exception as exc:` block in `get_panel_actions_diagnostics` to avoid using `exc` in `_set_last_error(...)`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
