### PR TITLE
companion(workspace): align workspace shell with Vault Browser orientation contract (#1260)

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -75,14 +75,182 @@ def _status_label(value: object, *, fallback: str = "unknown") -> str:
     return text if text else fallback
 
 
+def _split_frontmatter(body: str) -> tuple[list[str], str]:
+    """Split a YAML frontmatter prefix off ``body``.
+
+    Returns ``(frontmatter_lines, remaining_body)``. If the body does not begin
+    with a ``---``/``---`` fenced YAML block, returns ``([], body)`` unchanged.
+
+    Frontmatter is treated as opaque text for rendering — keys are surfaced as
+    chrome but not parsed into a typed model here. The runtime owns parsing for
+    contract purposes (#1253); this helper only ensures the body region does
+    not display the frontmatter as prose.
+    """
+    if not body.startswith("---"):
+        return [], body
+    lines = body.split("\n")
+    if not lines or lines[0].strip() != "---":
+        return [], body
+    end_idx: int | None = None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            end_idx = i
+            break
+    if end_idx is None:
+        return [], body
+    fm_lines = lines[1:end_idx]
+    remaining = "\n".join(lines[end_idx + 1:])
+    return fm_lines, remaining
+
+
+def _render_note_frontmatter_region(frontmatter_lines: list[str]) -> str:
+    """Render frontmatter as bounded metadata chrome separate from the body.
+
+    AC1 / AC2 (#1260): the body region must not display YAML frontmatter as
+    prose; frontmatter-derived metadata remains visible in dedicated chrome.
+    """
+    if not frontmatter_lines:
+        return (
+            '<section class="note-frontmatter note-frontmatter-empty" '
+            'data-testid="workspace-note-frontmatter" '
+            'data-frontmatter-present="false">'
+            '<span class="frontmatter-label">No frontmatter</span>'
+            "</section>"
+        )
+    rows: list[str] = []
+    for line in frontmatter_lines:
+        stripped = line.rstrip()
+        if not stripped:
+            continue
+        rows.append(
+            '<div class="frontmatter-line">'
+            f'<code>{_e(stripped)}</code>'
+            "</div>"
+        )
+    body_html = "".join(rows) or '<span class="frontmatter-label">(empty frontmatter)</span>'
+    return (
+        '<section class="note-frontmatter" '
+        'data-testid="workspace-note-frontmatter" '
+        'data-frontmatter-present="true">'
+        '<span class="frontmatter-label">frontmatter</span>'
+        f"{body_html}"
+        "</section>"
+    )
+
+
+def _compute_primary_posture(
+    *,
+    writeguard_blocked: bool,
+    vault_unresolved: bool,
+    canvas_enabled: bool,
+    workspace_update_available: bool,
+    guard_degraded: bool,
+) -> tuple[str, str]:
+    """Resolve a single primary posture token + human-facing label.
+
+    Order of precedence (most severe wins):
+        blocked > unavailable > degraded > ok
+
+    AC3 / AC4 (#1260): consolidate competing safety/status rows into one
+    primary posture surface; degraded/blocked/unavailable visibly distinct
+    from ok.
+    """
+    if writeguard_blocked:
+        return "blocked", "Blocked"
+    if vault_unresolved:
+        return "unavailable", "Unavailable"
+    if guard_degraded or not canvas_enabled or not workspace_update_available:
+        return "degraded", "Degraded"
+    return "ok", "Online"
+
+
+def _render_primary_posture(
+    *,
+    posture: str,
+    label: str,
+    vault_name: str,
+    vault_channel: str,
+    runtime_trace_id: str,
+) -> str:
+    """Render the single primary posture surface above the detailed safety strip.
+
+    AC3 (#1260): one primary posture region; AC4: distinct tone class per
+    posture state; AC6: human-readable label, internal token in ``data-*``.
+    """
+    trace = runtime_trace_id or "unavailable"
+    return (
+        f'<section class="primary-posture posture-tone-{posture}" '
+        f'data-testid="workspace-primary-posture" '
+        f'data-posture="{posture}">'
+        f'<span class="primary-posture-label">{_e(label)}</span>'
+        f'<span class="primary-posture-identity" '
+        'data-testid="workspace-primary-posture-identity">'
+        f'<span class="primary-posture-vault">{_e(vault_name)}</span>'
+        f'<span class="primary-posture-sep">/</span>'
+        f'<span class="primary-posture-channel">{_e(vault_channel)}</span>'
+        "</span>"
+        '<span class="primary-posture-trace" '
+        'data-testid="workspace-primary-posture-trace">'
+        f"<code>{_e(trace)}</code>"
+        "</span>"
+        "</section>"
+    )
+
+
+def _render_rail_empty_state(
+    *,
+    panel_proposal_count: int,
+    canvas_session_state: str,
+    panel_state: str,
+    panel_message: str,
+    find_candidates_count: int,
+    reorient_present: bool,
+    resurface_count: int,
+    governance_receipts_count: int,
+    suggestion_state: str,
+) -> str:
+    """Render a single no-active-session card when the rail is fully idle.
+
+    AC7 (#1260): empty/inactive rail cards collapse to a single clear
+    no-active-session/unavailable state. Individual section placeholders may
+    still render; this card is the consolidated signal that nothing is active.
+    """
+    active = (
+        panel_proposal_count > 0
+        or canvas_session_state not in {"idle", "", "unknown"}
+        or panel_state not in {"idle", "", "unknown"}
+        or bool(panel_message)
+        or find_candidates_count > 0
+        or reorient_present
+        or resurface_count > 0
+        or governance_receipts_count > 0
+        or suggestion_state not in {"idle", "", "unknown"}
+    )
+    if active:
+        return ""
+    return (
+        '<div class="rail-empty-state" '
+        'data-testid="workspace-rail-empty-state" '
+        'data-rail-state="empty">'
+        "No active session. Nothing pending in Panel, Canvas, or governance."
+        "</div>"
+    )
+
+
 def _render_body_edit_panel(update_flow_available: bool, note_path: str) -> str:
     if not update_flow_available:
         return (
-            '<div class="body-edit-panel body-edit-disabled" '
-            'data-testid="workspace-body-edit-panel" data-update-flow="disabled">'
-            '<span class="body-edit-label">Update flow disabled '
-            '(set WORKSPACE_UPDATE_FLOW_ENABLED=1 to enable)</span>'
-            "</div>"
+            '<section class="body-edit-panel body-edit-disabled workspace-action-absent" '
+            'data-testid="workspace-action-absent" '
+            'data-action="body-edit" '
+            'data-reason="update_flow_disabled" '
+            'data-update-flow="disabled">'
+            '<span class="absent-label" data-testid="workspace-body-edit-panel">'
+            "Body editing unavailable</span>"
+            '<span class="absent-reason">'
+            "Update flow is currently disabled (set WORKSPACE_UPDATE_FLOW_ENABLED=1 to enable)."
+            "</span>"
+            "</section>"
         )
     return f"""<div class="body-edit-panel" data-testid="workspace-body-edit-panel"
          data-update-flow="available">
@@ -130,7 +298,10 @@ def _render_note_section(fields: dict) -> str:
     vault_name = _e(fields.get("runtime_vault_name") or "unresolved")
     vault_channel = _e(fields.get("runtime_vault_channel") or "unknown")
     vault_provenance = fields.get("runtime_vault_provenance") or "unresolved"
-    body = _e(fields.get("body", ""))
+    raw_body = str(fields.get("body", "") or "")
+    frontmatter_lines, stripped_body = _split_frontmatter(raw_body)
+    body = _e(stripped_body)
+    note_frontmatter_html = _render_note_frontmatter_region(frontmatter_lines)
     panel_rail = _e(fields.get("panel_rail", "Panel / agent rail placeholder"))
     canvas_session_id = _e(fields.get("canvas_session_id") or "")
     canvas_state = _e(fields.get("canvas_session_state", "idle"))
@@ -145,9 +316,12 @@ def _render_note_section(fields: dict) -> str:
     undone_edit_count = int(fields.get("canvas_undone_edit_count", 0) or 0)
     persistence = str(fields.get("canvas_session_persistence", ""))
     panel_render = fields.get("panel_render") or {}
-    panel_state = _e(panel_render.get("state") or fields.get("panel_state", "idle"))
+    panel_state_raw = str(panel_render.get("state") or fields.get("panel_state", "idle"))
+    panel_state = _e(panel_state_raw)
+    canvas_session_state_raw = str(fields.get("canvas_session_state", "idle") or "idle")
     panel_label = _e(panel_render.get("label") or panel_rail)
-    panel_message = _e(panel_render.get("message") or "")
+    panel_message_raw = str(panel_render.get("message") or "")
+    panel_message = _e(panel_message_raw)
     proposal_count = int(fields.get("panel_proposal_count", 0) or 0)
     writeguard_status = _e(fields.get("guard_writeguard_status", "ok"))
     writeguard_blocked = writeguard_status.lower() == "blocked"
@@ -178,6 +352,35 @@ def _render_note_section(fields: dict) -> str:
         f'<span class="identity-meta" data-testid="workspace-companion-of">companion of {companion_of}</span>'
         if companion_of
         else ""
+    )
+    vault_unresolved = (
+        str(vault_provenance).lower() == "unresolved"
+        or str(fields.get("runtime_vault_name") or "").lower() == "unresolved"
+    )
+    posture_token, posture_label = _compute_primary_posture(
+        writeguard_blocked=writeguard_blocked,
+        vault_unresolved=vault_unresolved,
+        canvas_enabled=canvas_enabled,
+        workspace_update_available=workspace_update_available,
+        guard_degraded=guard_degraded,
+    )
+    primary_posture_html = _render_primary_posture(
+        posture=posture_token,
+        label=posture_label,
+        vault_name=str(fields.get("runtime_vault_name") or "unresolved"),
+        vault_channel=str(fields.get("runtime_vault_channel") or "unknown"),
+        runtime_trace_id=str(fields.get("runtime_trace_id") or ""),
+    )
+    rail_empty_state_html = _render_rail_empty_state(
+        panel_proposal_count=proposal_count,
+        canvas_session_state=canvas_session_state_raw,
+        panel_state=panel_state_raw,
+        panel_message=panel_message_raw,
+        find_candidates_count=len(fields.get("find_candidates") or []),
+        reorient_present=bool(fields.get("reorient_sections")),
+        resurface_count=len(fields.get("resurface_candidates") or []),
+        governance_receipts_count=len(fields.get("governance_receipts") or []),
+        suggestion_state=str(fields.get("suggestion_state", "idle") or "idle"),
     )
     safety_strip_html = f"""
       <section
@@ -341,6 +544,7 @@ def _render_note_section(fields: dict) -> str:
     return f"""
   <div class="workspace-layout">
     <div class="workspace-main">
+      {primary_posture_html}
       {safety_strip_html}
       <header
         class="note-header active-note-header"
@@ -371,6 +575,7 @@ def _render_note_section(fields: dict) -> str:
         </div>
         {identity_caution_html}
       </header>
+      {note_frontmatter_html}
       <div class="note-body" data-testid="workspace-note-body" data-region="note-body">
         <pre class="note-body-content">{body}</pre>
         {suggested_insertions_html}
@@ -413,6 +618,7 @@ def _render_note_section(fields: dict) -> str:
         {guard_html}
         {persistence_html}
         {panel_rail}
+        {rail_empty_state_html}
       </div>
     </aside>
     {portrait_sheet_html}
@@ -586,17 +792,19 @@ def _render_suggestion_flow_region(fields: dict) -> str:
         )
         for target in transitions
     )
+    composer_state_token = "enabled" if composer_enabled else "locked"
     return f"""
         <div
           class="suggestion-flow"
           data-testid="workspace-suggestion-flow"
           data-suggestion-state="{suggestion_state}"
-          data-suggestion-dom-alias="{dom_alias}">
+          data-suggestion-dom-alias="{dom_alias}"
+          data-composer-state="{composer_state_token}">
           <div class="rail-state-row">
             <span class="rail-state-label">Suggestion</span>
             <span class="rail-state-value">{suggestion_state}</span>
           </div>
-          <div class="suggestion-composer-state">{composer_text}</div>
+          <div class="suggestion-composer-state" data-composer-state="{composer_state_token}">{composer_text}</div>
           <div class="suggestion-transitions">{transition_html}</div>
         </div>"""
 

--- a/tests/companion_ui/test_workspace_shell_alignment.py
+++ b/tests/companion_ui/test_workspace_shell_alignment.py
@@ -1,0 +1,375 @@
+"""Tests for the workspace shell alignment with the Vault Browser orientation contract (#1260).
+
+Eight acceptance criteria from the issue are covered:
+
+AC1 — workspace body rendering does not display YAML frontmatter as normal body.
+AC2 — frontmatter-derived identity/metadata remains visible.
+AC3 — safety/status presentation consolidated into one primary posture surface.
+AC4 — degraded/blocked/unavailable visibly distinct from ok/available.
+AC5 — unavailable actions render as absence/reason states or clearly non-actionable controls.
+AC6 — human-facing copy replaces internal runtime/test labels; internal state lives in data-*.
+AC7 — empty/inactive rail cards collapse to a single no-active-session/unavailable state.
+
+AC8 (existing MLP v0 tests still pass) is verified by the existing test files
+``test_vault_browser.py`` and ``test_companion_vault_browser_api.py``.
+"""
+
+from __future__ import annotations
+
+import re
+
+from companion_ui.workspace.serve_dev_page import render_index_html
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture
+# ---------------------------------------------------------------------------
+
+
+def _fields(
+    *,
+    body: str = "# Note\n\nBody content here.",
+    title: str = "Note Title",
+    note_path: str = "Notes/note.md",
+    artifact_id: str = "art-123",
+    content_hash: str = "sha256-aaa",
+    guard_writeguard_status: str = "ok",
+    guard_canvas_enabled: bool = True,
+    guard_degraded: bool = False,
+    guard_workspace_update_available: bool = True,
+    guard_update_flow_available: bool = True,
+    runtime_vault_provenance: str = "resolved",
+    runtime_vault_name: str = "vault/dev",
+    runtime_vault_channel: str = "local-dev",
+    panel_state: str = "idle",
+    panel_proposal_count: int = 0,
+    canvas_session_state: str = "idle",
+    canvas_session_persistence: str = "durable",
+    panel_proposals: list | None = None,
+    panel_message: str = "",
+    find_candidates: list | None = None,
+    reorient_sections: dict | None = None,
+    resurface_candidates: list | None = None,
+    governance_receipts: list | None = None,
+    suggestion_state: str = "idle",
+    suggestion_composer_enabled: bool = True,
+) -> dict:
+    return {
+        "title": title,
+        "note_path": note_path,
+        "artifact_id": artifact_id,
+        "artifact_kind": "human_note",
+        "artifact_identity_source": "frontmatter.uuid",
+        "artifact_identity_state": "resolved",
+        "artifact_companion_of": None,
+        "artifact_owns_identity": True,
+        "content_hash": content_hash,
+        "body": body,
+        "panel_rail": "Panel / agent rail placeholder",
+        "runtime_environment_label": "dev",
+        "runtime_api_base_url_label": "local-dev",
+        "runtime_trace_id": "trace-1",
+        "runtime_vault_name": runtime_vault_name,
+        "runtime_vault_channel": runtime_vault_channel,
+        "runtime_vault_provenance": runtime_vault_provenance,
+        "canvas_session_state": canvas_session_state,
+        "canvas_session_persistence": canvas_session_persistence,
+        "panel_state": panel_state,
+        "panel_proposal_count": panel_proposal_count,
+        "panel_proposals": panel_proposals or [],
+        "panel_message": panel_message,
+        "guard_writeguard_status": guard_writeguard_status,
+        "guard_canvas_enabled": guard_canvas_enabled,
+        "guard_degraded": guard_degraded,
+        "guard_workspace_update_available": guard_workspace_update_available,
+        "guard_update_flow_available": guard_update_flow_available,
+        "find_candidates": find_candidates or [],
+        "find_payload_available": False,
+        "reorient_sections": reorient_sections or {},
+        "resurface_candidates": resurface_candidates or [],
+        "governance_receipts": governance_receipts or [],
+        "suggestion_state": suggestion_state,
+        "suggestion_composer_enabled": suggestion_composer_enabled,
+        "is_production_ui": False,
+        "dev_page_label": "dev/staging",
+    }
+
+
+def _html(**kw) -> str:
+    return render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path=kw.get("note_path", "Notes/note.md"),
+        fields=_fields(**kw),
+    )
+
+
+def _body_region(html: str) -> str:
+    m = re.search(r'data-testid="workspace-note-body".*?</div>', html, re.DOTALL)
+    assert m, "workspace-note-body region not found"
+    return m.group()
+
+
+def _rail_region(html: str) -> str:
+    m = re.search(r'data-testid="workspace-agent-rail".*?</aside>', html, re.DOTALL)
+    assert m, "workspace-agent-rail region not found"
+    return m.group()
+
+
+# ---------------------------------------------------------------------------
+# AC1 — frontmatter not rendered as note body
+# ---------------------------------------------------------------------------
+
+
+_FRONTMATTER_BODY = (
+    "---\n"
+    "uuid: 11111111-2222-3333-4444-555555555555\n"
+    "kind: human_note\n"
+    "zone: active\n"
+    "tags:\n"
+    "  - companion-ui\n"
+    "---\n"
+    "# Heading\n"
+    "\n"
+    "Body paragraph here.\n"
+)
+
+
+class TestFrontmatterStrippedFromBody:
+    def test_frontmatter_block_not_in_body_region(self) -> None:
+        html = _html(body=_FRONTMATTER_BODY)
+        body = _body_region(html)
+        assert "uuid: 11111111" not in body
+        assert "- companion-ui" not in body
+
+    def test_body_content_remains_in_body_region(self) -> None:
+        html = _html(body=_FRONTMATTER_BODY)
+        body = _body_region(html)
+        assert "Body paragraph here." in body
+        assert "# Heading" in body
+
+    def test_body_without_frontmatter_unchanged(self) -> None:
+        body_only = "# Plain note\n\nNo frontmatter."
+        html = _html(body=body_only)
+        body = _body_region(html)
+        assert "# Plain note" in body
+        assert "No frontmatter." in body
+
+    def test_frontmatter_region_present_when_frontmatter_exists(self) -> None:
+        html = _html(body=_FRONTMATTER_BODY)
+        assert 'data-testid="workspace-note-frontmatter"' in html
+        assert 'data-frontmatter-present="true"' in html
+
+    def test_frontmatter_region_marked_absent_when_no_frontmatter(self) -> None:
+        html = _html(body="# Plain\nbody only")
+        assert 'data-frontmatter-present="false"' in html
+
+    def test_frontmatter_keys_surfaced_in_frontmatter_region(self) -> None:
+        html = _html(body=_FRONTMATTER_BODY)
+        m = re.search(
+            r'data-testid="workspace-note-frontmatter".*?</section>',
+            html,
+            re.DOTALL,
+        )
+        assert m, "workspace-note-frontmatter region not found"
+        region = m.group()
+        assert "uuid" in region
+        assert "kind" in region
+
+
+# ---------------------------------------------------------------------------
+# AC2 — identity/metadata visible in bounded chrome
+# ---------------------------------------------------------------------------
+
+
+class TestIdentityChromePersists:
+    def test_artifact_identity_pill_present_with_frontmatter_body(self) -> None:
+        html = _html(body=_FRONTMATTER_BODY, artifact_id="art-xyz")
+        assert 'data-testid="workspace-artifact-identity-pill"' in html
+        assert "art-xyz" in html
+
+    def test_content_hash_pill_present_with_frontmatter_body(self) -> None:
+        html = _html(body=_FRONTMATTER_BODY, content_hash="sha256-zzz")
+        assert 'data-testid="workspace-content-hash-pill"' in html
+        assert "sha256-zzz" in html
+
+    def test_path_visible(self) -> None:
+        html = _html(body=_FRONTMATTER_BODY, note_path="Inbox/foo.md")
+        assert "Inbox/foo.md" in html
+
+
+# ---------------------------------------------------------------------------
+# AC3 — primary posture surface
+# ---------------------------------------------------------------------------
+
+
+class TestPrimaryPostureSurface:
+    def test_primary_posture_present(self) -> None:
+        html = _html()
+        assert 'data-testid="workspace-primary-posture"' in html
+
+    def test_primary_posture_ok_when_no_problems(self) -> None:
+        html = _html()
+        assert re.search(r'data-testid="workspace-primary-posture"[^>]*data-posture="ok"', html)
+
+    def test_primary_posture_blocked_when_writeguard_blocked(self) -> None:
+        html = _html(guard_writeguard_status="blocked")
+        assert re.search(
+            r'data-testid="workspace-primary-posture"[^>]*data-posture="blocked"', html
+        )
+
+    def test_primary_posture_degraded_when_guard_degraded(self) -> None:
+        html = _html(guard_degraded=True)
+        assert re.search(
+            r'data-testid="workspace-primary-posture"[^>]*data-posture="degraded"', html
+        )
+
+    def test_primary_posture_unavailable_when_vault_unresolved(self) -> None:
+        html = _html(runtime_vault_provenance="unresolved")
+        assert re.search(
+            r'data-testid="workspace-primary-posture"[^>]*data-posture="unavailable"', html
+        )
+
+    def test_primary_posture_blocked_overrides_degraded(self) -> None:
+        html = _html(guard_writeguard_status="blocked", guard_degraded=True)
+        assert re.search(
+            r'data-testid="workspace-primary-posture"[^>]*data-posture="blocked"', html
+        )
+
+    def test_primary_posture_has_human_label(self) -> None:
+        html = _html()
+        m = re.search(
+            r'data-testid="workspace-primary-posture".*?</section>',
+            html,
+            re.DOTALL,
+        )
+        assert m
+        region = m.group()
+        assert "Online" in region or "Ok" in region or "Ready" in region
+
+
+# ---------------------------------------------------------------------------
+# AC4 — visibly distinct posture tones
+# ---------------------------------------------------------------------------
+
+
+class TestDistinctPostureTones:
+    def test_ok_tone_class(self) -> None:
+        html = _html()
+        assert 'class="primary-posture posture-tone-ok"' in html or \
+            'posture-tone-ok' in html
+
+    def test_degraded_tone_class(self) -> None:
+        html = _html(guard_degraded=True)
+        assert "posture-tone-degraded" in html
+
+    def test_blocked_tone_class(self) -> None:
+        html = _html(guard_writeguard_status="blocked")
+        assert "posture-tone-blocked" in html
+
+    def test_unavailable_tone_class(self) -> None:
+        html = _html(runtime_vault_provenance="unresolved")
+        assert "posture-tone-unavailable" in html
+
+
+# ---------------------------------------------------------------------------
+# AC5 — absence states for unavailable actions
+# ---------------------------------------------------------------------------
+
+
+class TestAbsenceForUnavailableActions:
+    def test_body_edit_absence_card_when_update_flow_disabled(self) -> None:
+        html = _html(guard_update_flow_available=False)
+        assert 'data-testid="workspace-action-absent"' in html
+        assert 'data-action="body-edit"' in html
+
+    def test_body_edit_absence_carries_reason(self) -> None:
+        html = _html(guard_update_flow_available=False)
+        m = re.search(
+            r'data-testid="workspace-action-absent"[^>]*data-action="body-edit".*?</section>',
+            html,
+            re.DOTALL,
+        )
+        assert m
+        # absence card must say why
+        assert "unavailable" in m.group().lower() or "disabled" in m.group().lower()
+
+    def test_no_actionable_submit_button_when_update_flow_disabled(self) -> None:
+        html = _html(guard_update_flow_available=False)
+        # No clickable Apply update button when the flow is unavailable.
+        assert 'data-testid="workspace-body-edit-submit"' not in html
+
+    def test_active_note_body_update_absence_when_disabled(self) -> None:
+        html = _html(guard_workspace_update_available=False)
+        # Existing testid already differentiates the disabled card; just confirm
+        # the absence is still rendered (regression guard).
+        assert 'data-testid="workspace-active-note-body-update-state-blocked"' in html
+
+
+# ---------------------------------------------------------------------------
+# AC6 — human-facing copy with data-* internal state
+# ---------------------------------------------------------------------------
+
+
+class TestHumanFacingCopy:
+    def test_primary_posture_has_data_posture_attr(self) -> None:
+        """Internal posture token lives in data-* so tests don't depend on copy."""
+        html = _html()
+        assert 'data-posture="ok"' in html
+
+    def test_composer_state_data_attr_present(self) -> None:
+        """Composer enabled/locked exposes its internal state as a data-* attribute."""
+        html = _html(suggestion_composer_enabled=True)
+        assert 'data-composer-state="enabled"' in html
+
+    def test_composer_state_data_attr_when_locked(self) -> None:
+        html = _html(suggestion_composer_enabled=False)
+        assert 'data-composer-state="locked"' in html
+
+    def test_workspace_update_label_has_human_text(self) -> None:
+        """A human-friendly label is used somewhere in posture chrome."""
+        html = _html()
+        # "Online" is the human-facing posture phrase for ok.
+        assert "Online" in html
+
+
+# ---------------------------------------------------------------------------
+# AC7 — rail empty state
+# ---------------------------------------------------------------------------
+
+
+class TestRailEmptyState:
+    def test_rail_empty_state_present_when_fully_idle(self) -> None:
+        html = _html()
+        rail = _rail_region(html)
+        assert 'data-testid="workspace-rail-empty-state"' in rail
+
+    def test_rail_empty_state_carries_human_copy(self) -> None:
+        html = _html()
+        m = re.search(
+            r'data-testid="workspace-rail-empty-state".*?</div>',
+            html,
+            re.DOTALL,
+        )
+        assert m
+        text = m.group().lower()
+        assert "no active session" in text or "no active panel" in text or "nothing active" in text
+
+    def test_rail_empty_state_absent_when_proposals_present(self) -> None:
+        html = _html(
+            panel_proposals=[
+                {
+                    "proposal_id": "p1",
+                    "summary": "do thing",
+                    "status": "pending",
+                }
+            ],
+            panel_proposal_count=1,
+            panel_state="proposal_staged",
+        )
+        rail = _rail_region(html)
+        assert 'data-testid="workspace-rail-empty-state"' not in rail
+
+    def test_rail_empty_state_absent_when_canvas_active(self) -> None:
+        html = _html(canvas_session_state="composing")
+        rail = _rail_region(html)
+        assert 'data-testid="workspace-rail-empty-state"' not in rail


### PR DESCRIPTION
Closes #1260

## Skill route

`agentic-pkm` repo context → `issue-to-code` (TDD: tests first, minimal implementation, refactor) → `publish-pr` → `verification-and-closure` after CI/merge.

## Summary

Aligns the Companion workspace shell with the Vault Browser orientation contract so that the browser opens notes into a human-first surface rather than a UAT/dev diagnostic dump. Addresses C1–C7 from the landed Claude Design handoff (#1259, PR #1262) for the surfaces the browser inherits — without implementing any of #1253–#1257.

This is the prerequisite gating step before #1255 (artifact inspector), #1256 (VaultAction model), and #1257 (receipts/review posture). The locked sequencing in [IMPLEMENTATION_SEQUENCE.md](companion-ui/design_handoff/2026-05-24-vault-browser-foundation/IMPLEMENTATION_SEQUENCE.md) names this issue explicitly as that prerequisite.

## Scope boundaries

- Server-side rendering only (`serve_dev_page.py`). No new API endpoints, no schema changes, no event contracts.
- No runtime behavior changes outside the rendered HTML.
- Does NOT implement: #1253 metadata read model, #1254 filters/badges, #1255 inspector, #1256 VaultAction, #1257 receipts/review posture.
- Preserves all existing `data-testid` and visible copy that other tests depend on; new behavior is additive.

## Files changed

```
companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py | +218 -10
tests/companion_ui/test_workspace_shell_alignment.py               | +375 (new)
```

## AC mapping

| AC | Implementation | Verify (test) |
|---|---|---|
| AC1 — Workspace body rendering does not display YAML frontmatter as normal body content. | `_split_frontmatter()` strips leading `---…---` YAML; `<pre>` body region renders the stripped remainder. | `TestFrontmatterStrippedFromBody::test_frontmatter_block_not_in_body_region`, `test_body_content_remains_in_body_region`, `test_body_without_frontmatter_unchanged` |
| AC2 — Frontmatter-derived identity/metadata remains visible. | `workspace-note-frontmatter` section (separate from body region); existing `workspace-artifact-identity-pill` / `workspace-content-hash-pill` chrome untouched. | `TestFrontmatterStrippedFromBody::test_frontmatter_region_present_when_frontmatter_exists`, `TestIdentityChromePersists::*` |
| AC3 — Safety/status consolidated into one primary posture surface. | `_compute_primary_posture()` + `_render_primary_posture()` render a single `workspace-primary-posture` section above the detailed strip. Precedence: blocked > unavailable > degraded > ok. | `TestPrimaryPostureSurface::*` (6 tests covering ok/blocked/degraded/unavailable, override order, human label) |
| AC4 — Degraded/blocked/unavailable visibly distinct from ok. | `posture-tone-{ok|degraded|blocked|unavailable}` CSS class + `data-posture` attribute on the posture section. | `TestDistinctPostureTones::test_*_tone_class` (4 tests) |
| AC5 — Unavailable actions render as absence/reason states. | Disabled `_render_body_edit_panel` returns `<section workspace-action-absent data-action=body-edit data-reason=update_flow_disabled>` with absent-label + reason copy. No actionable submit button is rendered. Legacy `workspace-body-edit-panel` testid preserved as a child element for backward compat. | `TestAbsenceForUnavailableActions::*` (4 tests) + preserved `TestBodyEditPanelRendering` in `test_real_note_workspace_dev_server.py` |
| AC6 — Human-facing copy; internal state in `data-*`. | Posture exposes `data-posture` token + human label ("Online" / "Degraded" / "Blocked" / "Unavailable"). Composer enabled/locked exposes `data-composer-state` on `workspace-suggestion-flow`. | `TestHumanFacingCopy::*` (4 tests) |
| AC7 — Empty/inactive rail cards collapse to a no-active-session state. | `_render_rail_empty_state()` renders a single `workspace-rail-empty-state` card at the rail bottom when proposals=0, canvas idle, panel idle, no message, find/reorient/resurface/governance empty, suggestion idle. | `TestRailEmptyState::*` (3 tests) |
| AC8 — Existing browser MLP v0 tests still pass. | No removed testids; no changed visible copy used in existing assertions. | `tests/companion_ui/test_vault_browser.py` + `tests/api/test_companion_vault_browser_api.py` (both pass) |

## Validation

```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q \\
  tests/companion_ui/test_workspace_shell_alignment.py \\
  tests/companion_ui/test_real_note_workspace_visual_shell.py \\
  tests/companion_ui/test_real_note_workspace_dev_page.py \\
  tests/companion_ui/test_real_note_workspace_dev_server.py \\
  tests/companion_ui/test_vault_browser.py \\
  tests/api/test_companion_vault_browser_api.py \\
  tests/companion_ui/test_active_note_body_update.py \\
  tests/companion_ui/test_production_launch_profile.py
→ 184 passed
```

```
python3 scripts/docs_guard.py        → OK
git diff --check                     → clean
python3 -m ruff check (touched files) → All checks passed
```

Wider companion_ui suite (informational): 805 passed, 79 failed. **All 79 failures are pre-existing on `main`** (mock HTTP clients in test files like `test_resurface_mode_browser.py`, `test_suggestion_flow_browser.py`, etc. only allow `/api/companion/workspace` while the page now also fetches `/api/companion/vault-browser` — unrelated to this PR). Verified by running the same tests on `main` before any changes: identical 79 failures.

## Docs updated

No owner-doc writeback required:
- The companion-app workspace shell does not have a dedicated specification doc; its contract is governed by the existing test suite (now extended by `test_workspace_shell_alignment.py`).
- The capability contract (`docs/VAULT_BROWSER_CAPABILITY_CONTRACT.md`) is unchanged — the workspace shell is not part of that contract surface; it is the host the browser opens notes into.
- The non-authoritative Claude Design handoff (`companion-ui/design_handoff/2026-05-24-vault-browser-foundation/`) already names this work; no rewrite needed.

## Runtime / API / UI behavior statement

No runtime, API, or event-contract behavior changes. Server-side rendered HTML structure is extended additively. No WriteGuard, governance, or receipt boundary is touched. No hidden writes introduced; no DB/store made authoritative.

## Residual risks / follow-ups

- Posture precedence (blocked > unavailable > degraded > ok) is encoded in code; if a future operator requires a different ranking it must route through `issue-maintenance-change-control`.
- The frontmatter parser is intentionally text-only (`_split_frontmatter` returns raw lines). Structured frontmatter parsing into a normalized read model is the work of #1253, not this PR.
- The disabled-body-edit absence card now exposes `workspace-action-absent` as the canonical testid; the legacy `workspace-body-edit-panel` testid remains for backward compat. Future tests should prefer the new testid.
- Rail-empty placeholder coexists with existing per-section empty placeholders (find/reorient/resurface render their own empty/unavailable cards even when present). Future cleanup of those per-section placeholders is a separate concern.
- 79 pre-existing test failures (mock-client issues) remain on `main` and are not addressed here — would be a separate fix-it issue.

## Confirmation: no out-of-scope future design work

No metadata read model, no filters, no inspector, no VaultAction model, no receipts. Diff is strictly server-side rendering changes within the existing `serve_dev_page.py` module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)