### PR TITLE
fix(companion-ui): resolve review debt in workspace update and vault browser

### DIFF
--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -289,6 +289,19 @@ def _validate_workspace_note_path(note_path_raw: str) -> str:
     return candidate.as_posix()
 
 
+def _validate_workspace_markdown_note_path(note_path_raw: str) -> str:
+    safe_note_path = _validate_workspace_note_path(note_path_raw)
+    if not safe_note_path.endswith(".md"):
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "not_a_note_file",
+                "message": "Body updates are restricted to markdown note files (.md)",
+            },
+        )
+    return safe_note_path
+
+
 def _find_workspace_note(vault_root: Path, safe_note_path: str) -> Path | None:
     for candidate in vault_root.rglob("*"):
         if not candidate.is_file():
@@ -589,14 +602,15 @@ def _parse_note_artifact_metadata(body: str, *, path_derived_zone: str) -> dict:
         parse_error = True
 
     uuid_val = fm.get("uuid")
-    missing = [f for f in _ARTIFACT_REQUIRED_FIELDS if not fm.get(f)]
+    normalized_uuid = _str_or_none(uuid_val)
+    missing = ["uuid"] if normalized_uuid is None else []
     frontmatter_valid = not parse_error and not missing
 
     fm_zone = fm.get("zone")
     zone = str(fm_zone).strip() if fm_zone else path_derived_zone
 
     return {
-        "uuid": str(uuid_val).strip() if uuid_val else None,
+        "uuid": normalized_uuid,
         "kind": _str_or_none(fm.get("kind")),
         "zone": zone,
         "review_state": _str_or_none(fm.get("review_state")),
@@ -908,8 +922,8 @@ def read_companion_workspace(
 def update_companion_workspace_note_body(
     req: WorkspaceBodyUpdateRequest,
 ) -> WorkspaceBodyUpdateResponse:
-    safe_active_note_path = _validate_workspace_note_path(req.active_note_path)
-    safe_target_note_path = _validate_workspace_note_path(req.target_note_path)
+    safe_active_note_path = _validate_workspace_markdown_note_path(req.active_note_path)
+    safe_target_note_path = _validate_workspace_markdown_note_path(req.target_note_path)
     if safe_active_note_path != safe_target_note_path:
         raise HTTPException(
             status_code=409,
@@ -1030,15 +1044,7 @@ def update_workspace_body(req: BodyUpdateRequest) -> BodyUpdateResponse:
             detail={"error": "writes_blocked", "message": str(exc)},
         ) from exc
 
-    safe_note_path = _validate_workspace_note_path(req.note_path)
-    if not safe_note_path.endswith(".md"):
-        raise HTTPException(
-            status_code=422,
-            detail={
-                "error": "not_a_note_file",
-                "message": "Body updates are restricted to markdown note files (.md)",
-            },
-        )
+    safe_note_path = _validate_workspace_markdown_note_path(req.note_path)
     vault_root = resolve_vault_root()
     note_path = _find_workspace_note(vault_root, safe_note_path)
     if note_path is None:

--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -574,13 +574,11 @@ class RealNoteWorkspaceDevPage:
             self.state.active_note_body_update_state = "blocked" if is_blocked else "failure"
             self.state.active_note_body_update_message = exc.detail
             self.state.error = str(exc)
-            self.state.is_loaded = False
             return self.state
         except WorkspaceClientError as exc:
             self.state.active_note_body_update_state = "failure"
             self.state.active_note_body_update_message = str(exc)
             self.state.error = str(exc)
-            self.state.is_loaded = False
             return self.state
 
         refreshed = self.load(NoteLoadIntent(note_path=note_path))

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -40,6 +40,7 @@ import sys
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Optional
 from urllib.parse import parse_qs, quote, urlparse
+import yaml
 
 from companion_ui.workspace.real_note_workspace_dev_page import (
     NoteLoadIntent,
@@ -99,6 +100,12 @@ def _split_frontmatter(body: str) -> tuple[list[str], str]:
     if end_idx is None:
         return [], body
     fm_lines = lines[1:end_idx]
+    try:
+        parsed = yaml.safe_load("\n".join(fm_lines))
+    except Exception:
+        return [], body
+    if parsed is not None and not isinstance(parsed, dict):
+        return [], body
     remaining = "\n".join(lines[end_idx + 1:])
     return fm_lines, remaining
 
@@ -200,6 +207,7 @@ def _render_primary_posture(
 def _render_rail_empty_state(
     *,
     panel_proposal_count: int,
+    panel_proposals: list[dict] | None,
     canvas_session_state: str,
     panel_state: str,
     panel_message: str,
@@ -217,6 +225,7 @@ def _render_rail_empty_state(
     """
     active = (
         panel_proposal_count > 0
+        or bool(panel_proposals)
         or canvas_session_state not in {"idle", "", "unknown"}
         or panel_state not in {"idle", "", "unknown"}
         or bool(panel_message)
@@ -323,6 +332,7 @@ def _render_note_section(fields: dict) -> str:
     panel_message_raw = str(panel_render.get("message") or "")
     panel_message = _e(panel_message_raw)
     proposal_count = int(fields.get("panel_proposal_count", 0) or 0)
+    panel_proposals = fields.get("panel_proposals") or []
     writeguard_status = _e(fields.get("guard_writeguard_status", "ok"))
     writeguard_blocked = writeguard_status.lower() == "blocked"
     canvas_enabled = bool(fields.get("guard_canvas_enabled", True))
@@ -373,6 +383,7 @@ def _render_note_section(fields: dict) -> str:
     )
     rail_empty_state_html = _render_rail_empty_state(
         panel_proposal_count=proposal_count,
+        panel_proposals=panel_proposals,
         canvas_session_state=canvas_session_state_raw,
         panel_state=panel_state_raw,
         panel_message=panel_message_raw,
@@ -394,7 +405,7 @@ def _render_note_section(fields: dict) -> str:
           <span class="safety-sep">/</span>
           <span>{runtime_channel}</span>
         </div>
-        <div class="safety-item" data-testid="workspace-vault-identity" data-vault-provenance="{vault_provenance}">
+        <div class="safety-item" data-testid="workspace-vault-identity" data-vault-provenance="{_e(vault_provenance)}">
           <span class="safety-label">vault/channel</span>
           <span>{vault_name}</span>
           <span class="safety-sep">/</span>

--- a/docs/HUMAN-FLOWS.md
+++ b/docs/HUMAN-FLOWS.md
@@ -915,7 +915,7 @@ That direction is no longer handoff-only: a bounded implementation now exists in
 
 ## Vault Browser as orientation surface
 
-The Companion UI vault browser is the human-first navigation and orientation surface over the vault for the reorient/find/return-to-context flows. Its long-term capability contract — concepts (`VaultArtifact`, `VaultView`, `VaultQuery`, `VaultRelation`, `VaultActivity`, `VaultHealth`, `VaultAction`, `VaultProposal`, `VaultReceipt`), action-mode boundary, MLP-versus-future scope, and non-goals — is owned by `docs/VAULT_BROWSER_CAPABILITY_CONTRACT.md`. Current shipped behavior is bounded as `Vault Browser MLP v0`: read-only Markdown enumeration with deterministic title/path filtering, active-vault identity, empty/error/identity-unavailable states, and note selection into the Companion workspace. The browser is a projection layer; the vault and Markdown/frontmatter remain the human control surface.
+The Companion UI vault browser is the human-first navigation and orientation surface over the vault for the reorient/find/return-to-context flows. Its long-term capability contract — concepts (`VaultArtifact`, `VaultView`, `VaultQuery`, `VaultRelation`, `VaultActivity`, `VaultHealth`, `VaultAction`, `VaultProposal`, `VaultReceipt`), action-mode boundary, MLP-versus-future scope, and non-goals — is owned by `docs/VAULT_BROWSER_CAPABILITY_CONTRACT.md`. Current shipped behavior is bounded as `Vault Browser MLP v0`: read-only Markdown enumeration with deterministic title/path filtering, active-vault identity, empty/error/identity-unavailable states, and note selection into the Companion workspace. When a browse cap applies, the retained subset is deterministic: lexicographically smallest matching note paths are preserved. The browser is a projection layer; the vault and Markdown/frontmatter remain the human control surface.
 
 ## Companion Niflheim dev UAT workspace update check
 
@@ -929,6 +929,8 @@ For Niflheim dev UAT, Companion workspace update capability must be visible as r
 For Niflheim dev UAT, active-note body updates in Companion workspace must stay bounded and guarded:
 - entering the active-note body update flow must be explicit and note-local
 - update attempts must be scoped to the active note path only
+- target paths must resolve to Markdown note files (`.md`) before any write occurs
 - successful updates must preserve frontmatter and UUID while changing body content
 - blocked updates must show a clear guard reason (for example WriteGuard or capability disabled)
 - failed updates must show a clear failure state distinct from blocked
+- blocked/failed update attempts must preserve loaded workspace context so the note and status surfaces remain visible

--- a/tests/api/test_companion_vault_browser_api.py
+++ b/tests/api/test_companion_vault_browser_api.py
@@ -111,3 +111,14 @@ def test_vault_browser_is_read_only(
     assert get_resp.json()["read_only"] is True
     assert post_resp.status_code == 405
     assert note_path.read_text(encoding="utf-8") == before
+
+
+def test_vault_browser_cap_preserves_lexicographic_subset(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+    monkeypatch.setenv("VAULT_BROWSE_MAX_NOTES", "2")
+    _write_note(tmp_path / "z" / "late.md", title="Late")
+    _write_note(tmp_path / "a" / "first.md", title="First")
+    _write_note(tmp_path / "m" / "middle.md", title="Middle")
+    data = TestClient(app).get("/api/companion/vault-browser").json()
+    assert [n["note_path"] for n in data["notes"]] == ["a/first.md", "m/middle.md"]

--- a/tests/api/test_companion_vault_browser_metadata.py
+++ b/tests/api/test_companion_vault_browser_metadata.py
@@ -123,6 +123,21 @@ class TestReadModelReturnsExpectedFieldsForHealthyNote:
 
 
 class TestInvalidFrontmatterSurfacesHealthState:
+    def test_blank_uuid_is_invalid_after_normalization(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+        monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+        _write_note(
+            tmp_path / "notes" / "blank-uuid.md",
+            "---\nuuid: '   '\ntitle: Blank UUID\n---\n\nBody.\n",
+        )
+        resp = TestClient(app).get("/api/companion/vault-browser")
+        note = resp.json()["notes"][0]
+        assert note["uuid"] is None
+        assert note["frontmatter_valid"] is False
+        assert "uuid" in note["missing_required_fields"]
+
     def test_no_frontmatter_surfaces_missing_uuid(
         self, tmp_path: Path, monkeypatch
     ) -> None:

--- a/tests/api/test_companion_workspace_body_update.py
+++ b/tests/api/test_companion_workspace_body_update.py
@@ -95,6 +95,15 @@ def test_body_update_preserves_frontmatter(
     assert "---" in content
 
 
+def test_body_update_preserves_frontmatter_and_uuid(
+    client: TestClient, vault_note: Path
+) -> None:
+    _patch_body(client, "notes/note.md", "# Test Note\n\nReplaced body.\n")
+    content = vault_note.read_text(encoding="utf-8")
+    assert "uuid: note-uuid-1" in content
+    assert "title: Test Note" in content
+
+
 def test_body_update_preserves_uuid(
     client: TestClient, vault_note: Path
 ) -> None:
@@ -213,6 +222,19 @@ def test_body_update_yaml_file_rejected(
     resp = _patch_body(client, "_system/settings.yaml", "injected: true\n")
     assert resp.status_code == 422
     assert resp.json()["detail"]["error"] == "not_a_note_file"
+
+
+def test_body_update_rejects_non_markdown_targets(
+    client: TestClient, vault: Path
+) -> None:
+    target = vault / "_system" / "settings.yaml"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    before = "key: value\n"
+    target.write_text(before, encoding="utf-8")
+    resp = _patch_body(client, "_system/settings.yaml", "injected: true\n")
+    assert resp.status_code == 422
+    assert resp.json()["detail"]["error"] == "not_a_note_file"
+    assert target.read_text(encoding="utf-8") == before
 
 
 def test_body_update_json_file_rejected(

--- a/tests/api/test_companion_workspace_update_api.py
+++ b/tests/api/test_companion_workspace_update_api.py
@@ -118,6 +118,31 @@ def test_body_update_preserves_frontmatter_and_uuid(
     assert "Initial active body." not in updated
 
 
+def test_workspace_update_rejects_non_markdown_targets(
+    client: TestClient,
+    workspace_notes: dict[str, Path],
+    tmp_path: Path,
+) -> None:
+    active = workspace_notes["active"]
+    other_yaml = tmp_path / "notes" / "other.yaml"
+    other_yaml.write_text("foo: bar\n", encoding="utf-8")
+    workspace = _workspace(client, "notes/active.md")
+    content_hash = workspace["artifact"]["content_hash"]
+    before = active.read_text(encoding="utf-8")
+    resp = client.post(
+        "/api/companion/workspace/update",
+        json={
+            "active_note_path": "notes/active.md",
+            "target_note_path": "notes/other.yaml",
+            "new_body": "# Active\n\nAttempted write.\n",
+            "content_hash": content_hash,
+        },
+    )
+    assert resp.status_code == 422
+    assert resp.json()["detail"]["error"] == "not_a_note_file"
+    assert active.read_text(encoding="utf-8") == before
+
+
 def test_body_update_respects_write_guard(
     client: TestClient,
     workspace_notes: dict[str, Path],

--- a/tests/companion_ui/test_active_note_body_update.py
+++ b/tests/companion_ui/test_active_note_body_update.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 from companion_ui.workspace.real_note_workspace_dev_page import NoteLoadIntent, RealNoteWorkspaceDevPage
 from companion_ui.workspace.serve_dev_page import render_index_html
-from companion_ui.workspace.workspace_http_client import WorkspaceHttpClient
+from companion_ui.workspace.workspace_http_client import WorkspaceClientNetworkError, WorkspaceHttpClient
 
 
 def _workspace_payload(note_path: str = "notes/current.md", title: str = "Current") -> dict[str, Any]:
@@ -135,3 +135,21 @@ def test_body_update_renders_success_blocked_and_failure_states() -> None:
         fields=fields,
     )
     assert 'data-testid="workspace-active-note-body-update-state-failure"' in failure_html
+
+
+def test_blocked_body_update_preserves_loaded_state_and_renders_blocked_status() -> None:
+    page = _load_page()
+    page.state.guard_workspace_update_available = False
+    state = page.update_active_note_body(new_body="# Body\n\nBlocked")
+    assert state.is_loaded is True
+    assert state.shell is not None
+    assert state.active_note_body_update_state == "blocked"
+
+
+def test_failed_body_update_preserves_loaded_state_and_renders_failure_status() -> None:
+    page = _load_page()
+    with patch.object(page._http, "post", side_effect=WorkspaceClientNetworkError("network timeout")):
+        state = page.update_active_note_body(new_body="# Body\n\nFail")
+    assert state.is_loaded is True
+    assert state.shell is not None
+    assert state.active_note_body_update_state == "failure"

--- a/tests/companion_ui/test_vault_browser.py
+++ b/tests/companion_ui/test_vault_browser.py
@@ -394,3 +394,17 @@ def test_vault_browser_inactive_filter_chip_has_data_active_false() -> None:
 
     # Without active filters, all chips should have data-active="false"
     assert 'data-active="false"' in html
+
+
+def test_vault_provenance_attribute_is_escaped() -> None:
+    payload = _workspace_payload()
+    payload["runtime"]["vault_identity"]["provenance"] = 'env" onmouseover="alert(1)'
+    page = _load_page(workspace_payload=payload)
+    fields = page.render_fields()
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="notes/current.md",
+        fields=fields,
+    )
+    assert 'data-vault-provenance="env&quot; onmouseover=&quot;alert(1)"' in html
+    assert 'data-vault-provenance="env" onmouseover=' not in html

--- a/tests/companion_ui/test_workspace_shell_alignment.py
+++ b/tests/companion_ui/test_workspace_shell_alignment.py
@@ -373,3 +373,20 @@ class TestRailEmptyState:
         html = _html(canvas_session_state="composing")
         rail = _rail_region(html)
         assert 'data-testid="workspace-rail-empty-state"' not in rail
+
+def test_delimiter_shaped_body_without_frontmatter_is_not_stripped() -> None:
+    body = "---\nThis is prose, not yaml: [\n---\n\nParagraph stays.\n"
+    html = _html(body=body)
+    note_body = _body_region(html)
+    assert "This is prose, not yaml" in note_body
+    assert "Paragraph stays." in note_body
+
+
+def test_rail_empty_state_uses_rendered_panel_proposals_not_stale_count() -> None:
+    html = _html(
+        panel_state="idle",
+        panel_proposal_count=0,
+        panel_proposals=[{"proposal_id": "p1", "status": "pending", "summary": "queued"}],
+    )
+    rail = _rail_region(html)
+    assert 'data-testid="workspace-rail-empty-state"' not in rail


### PR DESCRIPTION
Fixes #1268
Fixes #1269

## Summary
Stabilizes Companion UI review-debt surfaces by hardening workspace body-update path validation and repairing active Vault Browser/workspace-shell correctness regressions.

## Skill Route
- `AGENTS.md`
- `.codex/skills/agentic-pkm/SKILL.md`
- `.codex/skills/issue-to-code/SKILL.md`
- `.codex/skills/publish-pr/SKILL.md`
- `.codex/skills/verification-and-closure/SKILL.md`

## Dispatcher / Claim Note
- Dispatcher status check was unavailable in this shell (`python3 -m app.dispatcher status --json` failed with `ModuleNotFoundError: No module named 'yaml'`).
- Used GitHub-label claim flow (`scripts/issue_pickup_claim.sh --issue 1268` and `--issue 1269`), which removed `agent:ready` before local edits.
- Explicitly reconciled Project Status for both issues to `In Progress` via `scripts/reconcile_project_status.py`.

## AC Mapping
### Issue #1268
- `POST /api/companion/workspace/body` rejects non-markdown paths before write.
  - Verify: `tests/api/test_companion_workspace_body_update.py::test_body_update_rejects_non_markdown_targets`
- `POST /api/companion/workspace/update` rejects non-markdown paths.
  - Verify: `tests/api/test_companion_workspace_update_api.py::test_workspace_update_rejects_non_markdown_targets`
- Frontmatter + UUID preserved for valid markdown updates.
  - Verify: `tests/api/test_companion_workspace_body_update.py::test_body_update_preserves_frontmatter_and_uuid`
  - Verify: `tests/api/test_companion_workspace_update_api.py::test_body_update_preserves_frontmatter_and_uuid`
- Blocked updates preserve loaded workspace state and render blocked status.
  - Verify: `tests/companion_ui/test_active_note_body_update.py::test_blocked_body_update_preserves_loaded_state_and_renders_blocked_status`
- Failed/network updates preserve loaded workspace state and render failure status.
  - Verify: `tests/companion_ui/test_active_note_body_update.py::test_failed_body_update_preserves_loaded_state_and_renders_failure_status`

### Issue #1269
- Whitespace-only UUID normalized before required-field validation.
  - Verify: `tests/api/test_companion_vault_browser_metadata.py::test_blank_uuid_is_invalid_after_normalization`
- Delimiter-shaped prose not stripped unless leading block is valid frontmatter.
  - Verify: `tests/companion_ui/test_workspace_shell_alignment.py::test_delimiter_shaped_body_without_frontmatter_is_not_stripped`
- Rail empty-state checks rendered proposals, not only stale count.
  - Verify: `tests/companion_ui/test_workspace_shell_alignment.py::test_rail_empty_state_uses_rendered_panel_proposals_not_stale_count`
- Vault-browser cap keeps lexicographically smallest deterministic subset.
  - Verify: `tests/api/test_companion_vault_browser_api.py::test_vault_browser_cap_preserves_lexicographic_subset`
- `vault_provenance` escaped in HTML attribute context.
  - Verify: `tests/companion_ui/test_vault_browser.py::test_vault_provenance_attribute_is_escaped`

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/api/test_companion_workspace_body_update.py tests/api/test_companion_workspace_update_api.py tests/companion_ui/test_active_note_body_update.py tests/api/test_companion_vault_browser_api.py tests/api/test_companion_vault_browser_metadata.py tests/companion_ui/test_vault_browser.py tests/companion_ui/test_workspace_shell_alignment.py`
  - Result: `89 passed`
- `.venv/bin/ruff check app tests`
  - Result: `All checks passed!`
- `.venv/bin/python scripts/docs_guard.py`
  - Result: `Docs guard: OK`
- `git diff --check`
  - Result: no whitespace/conflict marker issues

## Scope Boundaries
Included:
- Companion workspace body update path guard/validation hardening
- Companion UI blocked/failure update-state preservation
- Vault Browser metadata normalization, deterministic cap behavior, and rendering safety fixes

Out of scope (not implemented):
- Inspector model/features
- VaultAction model
- Agent receipts
- Semantic retrieval / graph
- New governance write behavior
- Any write-path expansion beyond existing update endpoints

## Docs Writeback
No owner-doc writeback required for this slice; runtime/UI contract remained within existing declared surfaces and this PR repairs correctness regressions only.

## Secondary Check #1270
Inspected only for dependency relevance; intentionally deferred. Companion UI paths in this slice do not depend on the artifact read route under #1270, so it should remain a separate security pass.

## Residual Risks
- `serve_dev_page._split_frontmatter` now uses YAML parse validation to distinguish prose-vs-frontmatter blocks; future performance regressions from very large synthetic leading blocks are possible but low risk for current dev-page usage.
