### PR TITLE
fix(review-debt): repair agent-memory authority/recall semantics and artifact note-read CodeQL debt

### DIFF
--- a/app/agent_memory/authority_guard.py
+++ b/app/agent_memory/authority_guard.py
@@ -60,6 +60,8 @@ def evaluate_memory_authority(
         posture_markers.append("contradicted")
     if candidate.contradiction_state is ContradictionState.REVISED:
         posture_markers.append("revised")
+    if candidate.contradiction_state is ContradictionState.REJECTED:
+        posture_markers.append("rejected")
     if candidate.review_state is ReviewState.REJECTED or promoted.outcome is ReviewState.REJECTED:
         posture_markers.append("rejected")
 
@@ -71,6 +73,8 @@ def evaluate_memory_authority(
         blocked.append("inferred_memory_not_mutation_authoritative")
     if promoted.outcome in {ReviewState.REVISED, ReviewState.REJECTED}:
         blocked.append("non_current_memory_lifecycle_state")
+    if candidate.contradiction_state in {ContradictionState.CONTRADICTED, ContradictionState.REJECTED}:
+        blocked.append("contradiction_state_blocks_mutation_authority")
     if conflicts_with_human_truth:
         blocked.append("human_authored_truth_precedence")
 

--- a/app/agent_memory/recall_explanation.py
+++ b/app/agent_memory/recall_explanation.py
@@ -91,6 +91,11 @@ def _authority_limits(promoted: PromotedMemory, use_right: RecallUseRight) -> li
 
     return limits
 
+def _effective_review_state(promoted: PromotedMemory) -> ReviewState:
+    if promoted.outcome is ReviewState.ACCEPTED:
+        return ReviewState.ACCEPTED
+    return promoted.candidate.review_state
+
 
 def build_recall_explanation(
     promoted: PromotedMemory,
@@ -112,8 +117,10 @@ def build_recall_explanation(
     authority source, and receipt reference.
     """
 
+    effective_review_state = _effective_review_state(promoted)
+
     if use_right is RecallUseRight.INSTRUCTIONAL:
-        if promoted.candidate.review_state is not ReviewState.ACCEPTED:
+        if effective_review_state is not ReviewState.ACCEPTED:
             raise ValueError(
                 "instructional recall requires review_state=accepted"
             )
@@ -121,13 +128,13 @@ def build_recall_explanation(
             raise ValueError("instructional recall requires a behavioral_claim")
 
     if use_right is RecallUseRight.ACTION_AUTHORIZING:
-        if promoted.candidate.review_state is not ReviewState.ACCEPTED:
+        if effective_review_state is not ReviewState.ACCEPTED:
             raise ValueError(
                 "action_authorizing recall requires review_state=accepted"
             )
-        if not action_scope or not authority_source or not receipt_reference:
+        if not behavioral_claim or not action_scope or not authority_source or not receipt_reference:
             raise ValueError(
-                "action_authorizing recall requires action_scope, authority_source, and receipt_reference"
+                "action_authorizing recall requires behavioral_claim, action_scope, authority_source, and receipt_reference"
             )
 
     return RecallExplanation(
@@ -138,7 +145,7 @@ def build_recall_explanation(
         memory_type=promoted.candidate.memory_type.value,
         use_right=use_right,
         lifecycle_state=_lifecycle_state(promoted),
-        review_state=promoted.candidate.review_state,
+        review_state=effective_review_state,
         activation_reason=activation_reason,
         why_now=why_now,
         bundle_reference=bundle_reference,

--- a/tests/agent_memory/test_memory_authority_guard.py
+++ b/tests/agent_memory/test_memory_authority_guard.py
@@ -109,3 +109,29 @@ def test_memory_supports_suggestion_without_escalating_to_mutation_authority() -
     assert decision.allow_suggestion is True
     assert decision.allow_mutation is False
     assert decision.authority_level is MemoryAuthorityLevel.SUGGESTION_ONLY
+
+
+def test_contradicted_memory_cannot_authorize_mutation_writeback() -> None:
+    promoted = _promoted(
+        review_state=ReviewState.ACCEPTED,
+        inferred=False,
+        contradiction_state=ContradictionState.CONTRADICTED,
+    )
+    decision = evaluate_memory_authority(
+        promoted,
+        use_right=RecallUseRight.ACTION_AUTHORIZING,
+        requested_action_scope="active_note_body_update",
+    )
+    assert decision.allow_mutation is False
+    assert "contradiction_state_blocks_mutation_authority" in decision.blocked_reasons
+
+
+def test_rejected_contradiction_state_requires_posture_visibility() -> None:
+    promoted = _promoted(
+        review_state=ReviewState.ACCEPTED,
+        inferred=False,
+        contradiction_state=ContradictionState.REJECTED,
+    )
+    decision = evaluate_memory_authority(promoted, use_right=RecallUseRight.ACTIVATABLE)
+    assert decision.posture_visibility_required is True
+    assert "rejected" in decision.posture_markers

--- a/tests/agent_memory/test_memory_recall_explanation.py
+++ b/tests/agent_memory/test_memory_recall_explanation.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+import pytest
+
 from app.agent_memory.candidate import MemoryCandidate, MemoryType, ReviewState
 from app.agent_memory.promotion import PromotedMemory
 from app.agent_memory.recall_explanation import (
@@ -110,3 +112,29 @@ def test_recall_explanation_preserves_authority_limits() -> None:
     assert "does_not_authorize_writeback" in explanation.authority_limits
     assert "requires_accepted_review_state_for_instructional_use" in explanation.authority_limits
     assert "inferred_memory_requires_review_visibility" in explanation.authority_limits
+
+
+def test_instructional_recall_accepts_promoted_accepted_memory() -> None:
+    promoted = _make_promoted_memory(outcome=ReviewState.ACCEPTED, review_state=ReviewState.UNREVIEWED)
+    explanation = build_recall_explanation(
+        promoted,
+        use_right=RecallUseRight.INSTRUCTIONAL,
+        activation_reason=ActivationReason.AUTHORITY_SIGNAL,
+        why_now="Accepted promotion should govern instructional authority posture.",
+        behavioral_claim="Keep release notes compact and factual.",
+    )
+    assert explanation.review_state is ReviewState.ACCEPTED
+
+
+def test_action_authorizing_recall_requires_behavioral_claim() -> None:
+    promoted = _make_promoted_memory(outcome=ReviewState.ACCEPTED, review_state=ReviewState.ACCEPTED)
+    with pytest.raises(ValueError, match="behavioral_claim"):
+        build_recall_explanation(
+            promoted,
+            use_right=RecallUseRight.ACTION_AUTHORIZING,
+            activation_reason=ActivationReason.AUTHORITY_SIGNAL,
+            why_now="Attempting authority escalation without instructional rationale.",
+            action_scope="active_note_body_update",
+            authority_source="review_receipt",
+            receipt_reference="receipt://authority-001",
+        )

--- a/tests/api/test_artifact_note_read_api.py
+++ b/tests/api/test_artifact_note_read_api.py
@@ -155,3 +155,51 @@ def test_companion_ui_does_not_read_vault_directly() -> None:
         "companion_ui modules must not access vault files directly:\n"
         + "\n".join(violations)
     )
+
+
+def test_read_artifact_note_rejects_path_traversal_escape(
+    client: TestClient, tmp_path: pathlib.Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    resp = client.get("/api/artifacts/note", params={"note_path": "../outside.md"})
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert detail["error"] == "invalid_path"
+    assert detail["reason"] in {"path_traversal", "outside_vault"}
+
+
+def test_read_artifact_note_rejects_symlink_escape(
+    client: TestClient, tmp_path: pathlib.Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    outside = tmp_path.parent / "outside-target.md"
+    outside.write_text("outside", encoding="utf-8")
+    link = tmp_path / "notes" / "escape.md"
+    link.parent.mkdir(parents=True, exist_ok=True)
+    link.symlink_to(outside)
+
+    resp = client.get("/api/artifacts/note", params={"note_path": "notes/escape.md"})
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert detail["error"] == "invalid_path"
+    assert detail["reason"] == "outside_vault"
+
+
+def test_read_artifact_note_uses_trusted_vault_relative_path(
+    client: TestClient, tmp_path: pathlib.Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    note = tmp_path / "notes" / "trusted.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text("# Trusted\n\nok\n", encoding="utf-8")
+    capture: dict[str, str] = {}
+    original = pathlib.Path.read_text
+
+    def _capture_read_text(self: pathlib.Path, *args, **kwargs) -> str:  # type: ignore[no-untyped-def]
+        capture["path"] = str(self.resolve())
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "read_text", _capture_read_text)
+    resp = client.get("/api/artifacts/note", params={"note_path": "notes/trusted.md"})
+    assert resp.status_code == 200
+    assert capture["path"] == str(note.resolve())


### PR DESCRIPTION
Fixes #1267
Fixes #1270

## Skill route
AGENTS.md -> .codex/skills/agentic-pkm/SKILL.md -> .codex/skills/issue-to-code/SKILL.md -> .codex/skills/publish-pr/SKILL.md -> .codex/skills/verification-and-closure/SKILL.md

## Dispatcher/GitHub-label claim note
Dispatcher unavailable in this environment (python import dependency error: missing yaml when running app.dispatcher), so GitHub-label-only claim path was used via scripts/issue_pickup_claim.sh for #1267 and #1270.

## Summary
- #1267: repaired recall/authority semantics for accepted-promoted memories and tightened action-authorizing rationale requirements.
- #1270: verified artifact note-read path sanitizer shape and added focused regression tests to close active CodeQL review debt.

## AC mapping
- #1267 accepted/promoted memory recognized for instructional recall
  - Verify: tests/agent_memory/test_memory_recall_explanation.py::test_instructional_recall_accepts_promoted_accepted_memory
- #1267 action-authorizing recall requires behavioral_claim + authority fields
  - Verify: tests/agent_memory/test_memory_recall_explanation.py::test_action_authorizing_recall_requires_behavioral_claim
- #1267 contradicted memory cannot authorize mutation/writeback
  - Verify: tests/agent_memory/test_memory_authority_guard.py::test_contradicted_memory_cannot_authorize_mutation_writeback
- #1267 rejected contradiction posture visibility required
  - Verify: tests/agent_memory/test_memory_authority_guard.py::test_rejected_contradiction_state_requires_posture_visibility
- #1270 absolute paths rejected
  - Verify: tests/api/test_artifact_note_read_api.py::test_read_artifact_note_rejects_absolute_path
- #1270 traversal escape rejected
  - Verify: tests/api/test_artifact_note_read_api.py::test_read_artifact_note_rejects_path_traversal_escape
- #1270 symlink escape rejected
  - Verify: tests/api/test_artifact_note_read_api.py::test_read_artifact_note_rejects_symlink_escape
- #1270 trusted vault-relative resolved path used for file I/O
  - Verify: tests/api/test_artifact_note_read_api.py::test_read_artifact_note_uses_trusted_vault_relative_path

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/agent_memory/test_memory_recall_explanation.py tests/agent_memory/test_memory_authority_guard.py tests/api/test_artifact_note_read_api.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/agent_memory/
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/api/test_artifact_note_read_api.py
- python3 scripts/docs_guard.py
- git diff --check
- ruff check app tests (tooling limitation in this shell: no ruff module installed)

## Scope boundaries
In scope:
- Agent Memory recall/authority semantics in app/agent_memory and matching tests
- Artifact note-read CodeQL debt verification and regression tests in tests/api/test_artifact_note_read_api.py

Out of scope:
- Companion body-update routes (#1268)
- New memory lifecycle states
- Broad artifact API refactors

## Docs writeback statement
No owner-doc writeback required; shipped runtime contract behavior is repaired within existing documented boundaries.

## Residual risk
Low. Main residual is environment lint tooling availability in this shell.