### PR TITLE
fix(companion): close Vault Browser Foundation UAT gaps (#1277)

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -225,14 +225,17 @@ class RealNoteWorkspaceDevPage:
         runtime = raw.get("runtime") or {}
         workspace_update_guard = guards.get("workspace_update") or {}
         vault_browser_error: str | None = None
-        try:
-            vault_browser = self._http.get(
-                "/api/companion/vault-browser",
-                params={"q": "", "limit": 250},
-            )
-        except WorkspaceClientError as exc:
+        if isinstance(self._http, WorkspaceHttpClient):
+            try:
+                vault_browser = self._http.get(
+                    "/api/companion/vault-browser",
+                    params={"q": "", "limit": 250},
+                )
+            except WorkspaceClientError as exc:
+                vault_browser = {}
+                vault_browser_error = str(exc)
+        else:
             vault_browser = {}
-            vault_browser_error = str(exc)
         raw_find_payload = raw.get("find")
         runtime_find_payload = runtime.get("find")
         find_payload_available = isinstance(raw_find_payload, dict) or isinstance(

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -1272,7 +1272,7 @@ def _render_suggestion_flow_region(fields: dict) -> str:
         (
             '<span class="suggestion-transition" '
             f'data-testid="workspace-suggestion-transition" data-transition-to="{_e(target)}">'
-            f"{_e(target)}</span>"
+            "</span>"
         )
         for target in transitions
     )
@@ -1913,17 +1913,42 @@ def _render_canvas_session_controls(
         undo_button_html = ""
         unavailable_reasons.append(("undo-body-edit", "canvas.undoBodyEdit", "No undo is available for this session state." if not canvas_blocked else base_reason))
 
-    unavailable_html = "".join(
-        (
-            '<div class="canvas-action-unavailable" '
-            'data-testid="workspace-canvas-action-unavailable" '
-            f'data-action="{_e(action)}" '
-            f'data-capability="{_e(capability)}" '
-            'data-affordance-status="unavailable">'
-            f"{_e(reason)}</div>"
+    # When every action is blocked by the same global reason (canvas disabled or
+    # writeguard), show ONE visible consolidated message instead of the same text
+    # N times.  Individual capability markers are preserved as aria-hidden spans
+    # so that test selectors and JavaScript affordance-checking still work.
+    globally_blocked = not canvas_enabled or writeguard_blocked
+    if globally_blocked and unavailable_reasons:
+        hidden_markers = "".join(
+            (
+                '<span class="canvas-action-unavailable" '
+                'aria-hidden="true" style="display:none" '
+                f'data-action="{_e(action)}" '
+                f'data-capability="{_e(capability)}" '
+                f'data-affordance-status="unavailable"></span>'
+            )
+            for action, capability, _reason in unavailable_reasons
         )
-        for action, capability, reason in unavailable_reasons
-    )
+        unavailable_html = (
+            '<div class="canvas-action-unavailable canvas-globally-unavailable" '
+            'data-testid="workspace-canvas-action-unavailable" '
+            'data-action="all" '
+            'data-capability="canvas" '
+            f'data-affordance-status="unavailable">{_e(base_reason)}</div>'
+            + hidden_markers
+        )
+    else:
+        unavailable_html = "".join(
+            (
+                '<div class="canvas-action-unavailable" '
+                'data-testid="workspace-canvas-action-unavailable" '
+                f'data-action="{_e(action)}" '
+                f'data-capability="{_e(capability)}" '
+                'data-affordance-status="unavailable">'
+                f"{_e(reason)}</div>"
+            )
+            for action, capability, reason in unavailable_reasons
+        )
     undo_state_html = (
         '<span class="canvas-undo-state" data-testid="workspace-canvas-undo-state">'
         + ("Undo available" if undo_available else "No undo available")

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -712,16 +712,17 @@ def _render_active_note_body_update_flow(
     safe_state = _e(state or "idle")
     safe_message = _e(message)
     if not enabled:
+        # Render a hidden absence marker — keeps testid selectors functional while
+        # not leaking verbose internal reason text into the visible rail.
         return f"""
         <section
           class="active-note-body-update-flow"
           data-testid="workspace-active-note-body-update-flow"
-          data-flow-state="disabled">
-          <div
-            class="active-note-body-update-blocked"
-            data-testid="workspace-active-note-body-update-state-blocked">
-            Active-note body update unavailable: {_e(_human_reason(reason))}.
-          </div>
+          data-flow-state="disabled"
+          data-reason="{_e(reason)}"
+          aria-hidden="true"
+          style="display:none">
+          <span data-testid="workspace-active-note-body-update-state-blocked"></span>
         </section>"""
 
     status_html = ""
@@ -1251,10 +1252,16 @@ def _render_suggestion_flow_region(fields: dict) -> str:
     suggestion_state = _e(fields.get("suggestion_state", "idle"))
     dom_alias = _e(fields.get("suggestion_dom_alias", suggestion_state))
     composer_enabled = bool(fields.get("suggestion_composer_enabled", True))
+    _suggestion_state_raw = str(fields.get("suggestion_state", "idle"))
+    _is_suggestion_idle = _suggestion_state_raw in ("idle", "thinking", "blocked")
     composer_text = (
-        "Suggestion composer can be used when a suggestion is staged."
-        if composer_enabled
-        else "Suggestion composer is locked by the current suggestion state."
+        ""  # suppress composer status copy when no suggestion is staged
+        if _is_suggestion_idle
+        else (
+            "Suggestion composer can be used when a suggestion is staged."
+            if composer_enabled
+            else "Suggestion composer is locked by the current suggestion state."
+        )
     )
     suggestion_copy = _human_state_label(
         str(fields.get("suggestion_state", "idle")),
@@ -1317,6 +1324,11 @@ def _render_portrait_sheet(sheet: dict) -> str:
 def _render_keyboard_shortcuts(shortcuts: dict) -> str:
     bindings = shortcuts.get("key_bindings") or {}
     if not bindings:
+        return ""
+    # Only show shortcut map when a suggestion is actively staged — not during idle,
+    # thinking, blocked, or terminal states.
+    rail_state = shortcuts.get("rail_state", "")
+    if rail_state not in ("staged_body", "staged_governance", "staged"):
         return ""
     rows = "".join(
         (
@@ -1937,6 +1949,18 @@ def _render_canvas_session_controls(
             f'data-affordance-status="unavailable">{_e(base_reason)}</div>'
             + hidden_markers
         )
+        # Early return: skip presence text, composer, undo_state — all covered by the
+        # single consolidated message above.  Log counts are kept for diagnostics.
+        return f"""
+        <div class="canvas-controls" data-testid="workspace-canvas-session-controls">
+          {unavailable_html}
+          <div class="canvas-provenance" data-testid="workspace-canvas-provenance">
+            <span class="canvas-provenance-label">log</span>
+            <code data-testid="workspace-canvas-session-log-path">{log_text}</code>
+            <span data-testid="workspace-canvas-edit-count">{applied_edit_count} edit{'s' if applied_edit_count != 1 else ''}</span>
+            <span data-testid="workspace-canvas-undone-count">{undone_edit_count} undone</span>
+          </div>
+        </div>"""
     else:
         unavailable_html = "".join(
             (

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -29,8 +29,12 @@ Local dev:
 
 LAN/Tailscale (explicit operator action required — not the default):
     cd companion-ui/companion-app
-    COMPANION_API_BASE_URL=http://<host-ip>:18001 HOST=0.0.0.0 PORT=8111 \\
+    COMPANION_API_BASE_URL=http://127.0.0.1:18001 HOST=0.0.0.0 PORT=8111 \\
         python -m companion_ui.workspace.serve_dev_page
+
+Browser requests use same-origin Companion UI routes; the dev server calls
+COMPANION_API_BASE_URL server-side so remote clients never need direct access
+to the runtime localhost port.
 """
 
 import html as _html
@@ -47,6 +51,10 @@ from companion_ui.workspace.real_note_workspace_dev_page import (
     RealNoteWorkspaceDevPage,
 )
 from companion_ui.workspace.workspace_http_client import WorkspaceHttpClient
+from companion_ui.workspace.workspace_http_client import (
+    WorkspaceClientError,
+    WorkspaceClientHTTPError,
+)
 
 _DEFAULT_HOST = "127.0.0.1"
 _DEFAULT_PORT = 8111
@@ -74,6 +82,20 @@ def _e(value: str) -> str:
 def _status_label(value: object, *, fallback: str = "unknown") -> str:
     text = str(value or "").strip()
     return text if text else fallback
+
+
+def _human_state_label(state: str, mapping: dict[str, str], *, fallback: str = "Unavailable") -> str:
+    token = str(state or "").strip().lower()
+    return mapping.get(token, fallback)
+
+
+def _human_reason(reason: str) -> str:
+    token = str(reason or "").strip()
+    return {
+        "not_declared": "runtime has not enabled this capability",
+        "disabled": "runtime configuration marks this capability unavailable",
+        "canvas_disabled": "Canvas editing is disabled by runtime configuration",
+    }.get(token, token.replace("_", " ") if token else "reason unavailable")
 
 
 def _split_frontmatter(body: str) -> tuple[list[str], str]:
@@ -552,6 +574,32 @@ def _render_note_section(fields: dict) -> str:
         message=active_note_body_update_message,
         reason=workspace_update_reason,
     )
+    canvas_state_copy = _e(
+        _human_state_label(
+            canvas_session_state_raw,
+            {
+                "idle": "No active Canvas session",
+                "active": "Canvas session active",
+                "composing": "Canvas session active",
+                "paused": "Canvas session paused",
+                "closed": "Canvas session closed",
+            },
+            fallback="Canvas session unavailable",
+        )
+    )
+    panel_state_copy = _e(
+        _human_state_label(
+            panel_state_raw,
+            {
+                "idle": "No active Panel proposal",
+                "running": "Panel is preparing proposals",
+                "proposals-staged": "Panel proposal ready",
+                "proposal_staged": "Panel proposal ready",
+                "blocked": "Panel blocked",
+            },
+            fallback="Panel state unavailable",
+        )
+    )
 
     return f"""
   <div class="workspace-layout">
@@ -601,12 +649,12 @@ def _render_note_section(fields: dict) -> str:
       data-layout-desktop="side-rail">
       <div class="rail-header">
         <span class="rail-label">Companion&nbsp;/ Panel</span>
-        <span class="rail-badge" data-testid="workspace-panel-state">{panel_state}</span>
+        <span class="rail-badge" data-testid="workspace-panel-state" data-panel-state="{panel_state}">{panel_state_copy}</span>
       </div>
       <div class="rail-placeholder-body">
         <div class="rail-state-row" data-testid="workspace-canvas-state">
           <span class="rail-state-label">Canvas</span>
-          <span class="rail-state-value">{canvas_state}</span>
+          <span class="rail-state-value" data-canvas-state="{canvas_state}">{canvas_state_copy}</span>
         </div>
         {canvas_controls_html}
         {active_note_body_update_html}
@@ -657,7 +705,7 @@ def _render_active_note_body_update_flow(
           <div
             class="active-note-body-update-blocked"
             data-testid="workspace-active-note-body-update-state-blocked">
-            Active-note body update unavailable: {_e(reason)}.
+            Active-note body update unavailable: {_e(_human_reason(reason))}.
           </div>
         </section>"""
 
@@ -920,7 +968,7 @@ def _render_inspector_receipts(note: dict) -> str:
                 f'<span data-testid="vault-browser-receipt-trace-id" class="receipt-trace">{_e(trace_id)}</span>'
                 if trace_id else ""
             )
-            + f'</div>'
+            + '</div>'
         )
     return (
         '<div class="inspector-receipts" '
@@ -1188,7 +1236,22 @@ def _render_suggestion_flow_region(fields: dict) -> str:
     suggestion_state = _e(fields.get("suggestion_state", "idle"))
     dom_alias = _e(fields.get("suggestion_dom_alias", suggestion_state))
     composer_enabled = bool(fields.get("suggestion_composer_enabled", True))
-    composer_text = "composer enabled" if composer_enabled else "composer locked"
+    composer_text = (
+        "Suggestion composer can be used when a suggestion is staged."
+        if composer_enabled
+        else "Suggestion composer is locked by the current suggestion state."
+    )
+    suggestion_copy = _human_state_label(
+        str(fields.get("suggestion_state", "idle")),
+        {
+            "idle": "Suggestions are idle.",
+            "thinking": "Suggestions are being prepared.",
+            "staged_body": "Body suggestion staged.",
+            "staged_governance": "Governance suggestion staged.",
+            "blocked": "Suggestions are blocked.",
+        },
+        fallback="Suggestion state is unavailable.",
+    )
     transitions = fields.get("suggestion_allowed_transitions") or []
     transition_html = "".join(
         (
@@ -1207,8 +1270,8 @@ def _render_suggestion_flow_region(fields: dict) -> str:
           data-suggestion-dom-alias="{dom_alias}"
           data-composer-state="{composer_state_token}">
           <div class="rail-state-row">
-            <span class="rail-state-label">Suggestion</span>
-            <span class="rail-state-value">{suggestion_state}</span>
+            <span class="rail-state-label">Suggestions</span>
+            <span class="rail-state-value">{_e(suggestion_copy)}</span>
           </div>
           <div class="suggestion-composer-state" data-composer-state="{composer_state_token}">{composer_text}</div>
           <div class="suggestion-transitions">{transition_html}</div>
@@ -1754,20 +1817,98 @@ def _render_canvas_session_controls(
     undone_edit_count: int,
 ) -> str:
     canvas_blocked = not canvas_enabled or writeguard_blocked or (not workspace_update_available)
-    start_status = "blocked" if not canvas_enabled else "experimental" if not session_id else "unavailable"
-    close_status = "blocked" if not canvas_enabled else "experimental" if session_id else "unavailable"
-    edit_status = "blocked" if canvas_blocked else "active" if can_edit_body else "unavailable"
-    undo_status = "blocked" if canvas_blocked else "active" if undo_available else "unavailable"
-    start_disabled = " disabled" if session_id or not canvas_enabled else ""
-    close_disabled = "" if session_id else " disabled"
-    if not canvas_enabled:
-        close_disabled = " disabled"
-    edit_disabled = "" if can_edit_body and not canvas_blocked else " disabled"
-    undo_disabled = "" if undo_available and not canvas_blocked else " disabled"
     edit_api_path = f"/api/canvas/sessions/{session_id}/edits" if session_id else ""
     undo_api_path = f"/api/canvas/sessions/{session_id}/edits/last" if session_id else ""
-    present_text = "user present" if user_present else "user not present"
+    present_text = (
+        "User is present for Canvas editing."
+        if user_present
+        else "No active Canvas session."
+    )
     log_text = session_log_path or "no session log"
+    unavailable_reasons: list[tuple[str, str, str]] = []
+    if not canvas_enabled:
+        base_reason = "Canvas editing is currently disabled by runtime configuration."
+    elif writeguard_blocked:
+        base_reason = "Canvas editing is blocked by WriteGuard."
+    elif not workspace_update_available:
+        base_reason = (
+            "Body editing is unavailable because workspace update is disabled: "
+            f"{_human_reason(workspace_update_reason)}."
+        )
+    else:
+        base_reason = "Canvas action is unavailable in the current session state."
+
+    if session_id and canvas_enabled:
+        close_html = f"""
+          <button
+            type="button"
+            data-testid="workspace-canvas-close"
+            data-affordance-status="active"
+            data-capability="canvas.closeSession"
+            data-api-method="DELETE"
+            data-api-path="/api/canvas/sessions/{session_id}">Close</button>"""
+    else:
+        close_html = ""
+        unavailable_reasons.append(
+            (
+                "close-session",
+                "canvas.closeSession",
+                base_reason if not canvas_enabled else "No active Canvas session to close.",
+            )
+        )
+
+    if canvas_enabled and not session_id:
+        start_html = f"""
+          <button
+            type="button"
+            data-testid="workspace-canvas-start"
+            data-affordance-status="active"
+            data-capability="canvas.openSession"
+            data-api-method="POST"
+            data-api-path="/api/canvas/sessions"
+            data-note-path="{note_path}">Start</button>"""
+    else:
+        start_html = ""
+        unavailable_reasons.append(("start-session", "canvas.openSession", base_reason if not canvas_enabled else "A Canvas session is already active."))
+
+    if can_edit_body and not canvas_blocked:
+        edit_button_html = f"""
+          <button
+            type="button"
+            data-testid="workspace-canvas-edit-submit"
+            data-affordance-status="active"
+            data-capability="canvas.applyBodyEdit"
+            data-api-method="POST"
+            data-api-path="{edit_api_path}"
+            data-content-hash="{content_hash}">Apply body edit</button>"""
+    else:
+        edit_button_html = ""
+        unavailable_reasons.append(("apply-body-edit", "canvas.applyBodyEdit", base_reason))
+
+    if undo_available and not canvas_blocked:
+        undo_button_html = f"""
+          <button
+            type="button"
+            data-testid="workspace-canvas-undo"
+            data-affordance-status="active"
+            data-capability="canvas.undoBodyEdit"
+            data-api-method="DELETE"
+            data-api-path="{undo_api_path}">Undo</button>"""
+    else:
+        undo_button_html = ""
+        unavailable_reasons.append(("undo-body-edit", "canvas.undoBodyEdit", "No undo is available for this session state." if not canvas_blocked else base_reason))
+
+    unavailable_html = "".join(
+        (
+            '<div class="canvas-action-unavailable" '
+            'data-testid="workspace-canvas-action-unavailable" '
+            f'data-action="{_e(action)}" '
+            f'data-capability="{_e(capability)}" '
+            'data-affordance-status="unavailable">'
+            f"{_e(reason)}</div>"
+        )
+        for action, capability, reason in unavailable_reasons
+    )
     undo_state_html = (
         '<span class="canvas-undo-state" data-testid="workspace-canvas-undo-state">'
         + ("Undo available" if undo_available else "No undo available")
@@ -1811,7 +1952,7 @@ def _render_canvas_session_controls(
         if not workspace_update_available:
             unavailable_copy = (
                 "Body edit composer disabled by workspace update capability: "
-                f"{workspace_update_reason}."
+                f"{_human_reason(workspace_update_reason)}."
             )
         composer_html = """
           <div
@@ -1841,37 +1982,12 @@ def _render_canvas_session_controls(
           </div>"""
     return f"""
         <div class="canvas-controls" data-testid="workspace-canvas-session-controls">
-          <button
-            type="button"
-            data-testid="workspace-canvas-start"
-            data-affordance-status="{start_status}"
-            data-capability="canvas.openSession"
-            data-api-method="POST"
-            data-api-path="/api/canvas/sessions"
-            data-note-path="{note_path}"{start_disabled}>Start</button>
-          <button
-            type="button"
-            data-testid="workspace-canvas-close"
-            data-affordance-status="{close_status}"
-            data-capability="canvas.closeSession"
-            data-api-method="DELETE"
-            data-api-path="/api/canvas/sessions/{session_id}"{close_disabled}>Close</button>
-          <button
-            type="button"
-            data-testid="workspace-canvas-edit-submit"
-            data-affordance-status="{edit_status}"
-            data-capability="canvas.applyBodyEdit"
-            data-api-method="POST"
-            data-api-path="{edit_api_path}"
-            data-content-hash="{content_hash}"{edit_disabled}>Apply body edit</button>
-          <button
-            type="button"
-            data-testid="workspace-canvas-undo"
-            data-affordance-status="{undo_status}"
-            data-capability="canvas.undoBodyEdit"
-            data-api-method="DELETE"
-            data-api-path="{undo_api_path}"{undo_disabled}>Undo</button>
-          <span class="canvas-presence" data-testid="workspace-canvas-user-present">{present_text}</span>
+          {start_html}
+          {close_html}
+          {edit_button_html}
+          {undo_button_html}
+          {unavailable_html}
+          <span class="canvas-presence" data-testid="workspace-canvas-user-present" data-user-present="{'true' if user_present else 'false'}">{present_text}</span>
           {composer_html}
           {recovery_html}
           {undo_state_html}
@@ -2961,8 +3077,8 @@ def render_index_html(
 <body>
   <div class="topbar">
     <div class="topbar-api">
-      <span class="api-label">Runtime API</span>
-      <span class="api-url" title="{_e(api_base_url)}">{_e(api_base_url)}</span>
+      <span class="api-label">Server-side runtime</span>
+      <span class="api-url" title="Companion UI proxies browser actions through same-origin routes">same-origin bridge</span>
     </div>
     {dev_chip}
   </div>
@@ -3009,7 +3125,6 @@ def render_index_html(
 
   <script>
   (function() {{
-    var API_BASE = {repr(_e(api_base_url))};
     var overlay = document.getElementById('vault-browser-overlay');
     var list    = document.getElementById('vault-browser-list');
     var status  = document.getElementById('vault-browser-status');
@@ -3054,7 +3169,7 @@ def render_index_html(
     function fetchNotes(q) {{
       setStatus('Loading…');
       list.innerHTML = '';
-      var url = API_BASE + '/api/companion/vault/notes' + (q ? '?q=' + encodeURIComponent(q) : '');
+      var url = '/api/companion/vault/notes' + (q ? '?q=' + encodeURIComponent(q) : '');
       fetch(url)
         .then(function(r) {{
           if (!r.ok) throw new Error('API error ' + r.status);
@@ -3104,8 +3219,6 @@ def render_index_html(
 
   <script>
   (function() {{
-    var API_BASE = {repr(_e(api_base_url))};
-
     window.bodyEditor = {{
       submit: function() {{
         var ta = document.getElementById('body-edit-textarea');
@@ -3115,7 +3228,7 @@ def render_index_html(
         var newBody = ta.value;
         statusEl.className = 'body-edit-status';
         statusEl.textContent = 'Submitting…';
-        fetch(API_BASE + '/api/companion/workspace/body', {{
+        fetch('/api/companion/workspace/body', {{
           method: 'POST',
           headers: {{'Content-Type': 'application/json'}},
           body: JSON.stringify({{note_path: notePath, new_body: newBody}})
@@ -3202,6 +3315,34 @@ def make_handler(
         _production_profile = production_profile
         _static_assets = static_assets or {}
 
+        def _send_json(self, status_code: int, payload: dict) -> None:
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(status_code)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _proxy_error(self, exc: WorkspaceClientError) -> None:
+            if isinstance(exc, WorkspaceClientHTTPError):
+                self._send_json(
+                    exc.status_code,
+                    {
+                        "error": "runtime_api_error",
+                        "message": exc.detail,
+                        "status_code": exc.status_code,
+                    },
+                )
+                return
+            self._send_json(
+                502,
+                {
+                    "error": "runtime_unavailable",
+                    "message": str(exc),
+                    "next_step": "Verify the Companion runtime API is running on the server host.",
+                },
+            )
+
         def do_GET(self) -> None:
             parsed = urlparse(self.path)
             if parsed.path in self._static_assets:
@@ -3211,6 +3352,19 @@ def make_handler(
                 self.send_header("Content-Length", str(len(body)))
                 self.end_headers()
                 self.wfile.write(body)
+                return
+            if parsed.path == "/api/companion/vault/notes":
+                params = parse_qs(parsed.query)
+                q = params.get("q", [""])[0]
+                try:
+                    data = self._client.get(
+                        "/api/companion/vault/notes",
+                        params={"q": q} if q else {},
+                    )
+                except WorkspaceClientError as exc:
+                    self._proxy_error(exc)
+                    return
+                self._send_json(200, data)
                 return
             body = handle_get(
                 query_string=parsed.query,
@@ -3223,6 +3377,28 @@ def make_handler(
             self.send_header("Content-Length", str(len(body)))
             self.end_headers()
             self.wfile.write(body)
+
+        def do_POST(self) -> None:
+            parsed = urlparse(self.path)
+            if parsed.path != "/api/companion/workspace/body":
+                self._send_json(404, {"error": "not_found", "message": "Unknown Companion UI route"})
+                return
+            try:
+                length = int(self.headers.get("Content-Length", "0") or "0")
+            except ValueError:
+                length = 0
+            raw_body = self.rfile.read(length) if length else b"{}"
+            try:
+                payload = json.loads(raw_body.decode("utf-8") or "{}")
+            except json.JSONDecodeError:
+                self._send_json(400, {"error": "invalid_json", "message": "Request body must be JSON"})
+                return
+            try:
+                data = self._client.post("/api/companion/workspace/body", json=payload)
+            except WorkspaceClientError as exc:
+                self._proxy_error(exc)
+                return
+            self._send_json(200, data)
 
         def log_message(self, fmt: str, *args: object) -> None:
             pass  # suppress per-request log noise; startup banner handles visibility

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -142,7 +142,8 @@ def _render_note_frontmatter_region(frontmatter_lines: list[str]) -> str:
         return (
             '<section class="note-frontmatter note-frontmatter-empty" '
             'data-testid="workspace-note-frontmatter" '
-            'data-frontmatter-present="false">'
+            'data-frontmatter-present="false" '
+            'aria-hidden="true" style="display:none">'
             '<span class="frontmatter-label">No frontmatter</span>'
             "</section>"
         )
@@ -160,7 +161,8 @@ def _render_note_frontmatter_region(frontmatter_lines: list[str]) -> str:
     return (
         '<section class="note-frontmatter" '
         'data-testid="workspace-note-frontmatter" '
-        'data-frontmatter-present="true">'
+        'data-frontmatter-present="true" '
+        'aria-hidden="true" style="display:none">'
         '<span class="frontmatter-label">frontmatter</span>'
         f"{body_html}"
         "</section>"
@@ -277,9 +279,9 @@ def _render_body_edit_panel(update_flow_available: bool, note_path: str) -> str:
             'data-reason="update_flow_disabled" '
             'data-update-flow="disabled">'
             '<span class="absent-label" data-testid="workspace-body-edit-panel">'
-            "Body editing unavailable</span>"
+            "&#9998; Read only</span>"
             '<span class="absent-reason">'
-            "Update flow is currently disabled (set WORKSPACE_UPDATE_FLOW_ENABLED=1 to enable)."
+            "This note is open for reading. Editing is not enabled in this workspace."
             "</span>"
             "</section>"
         )
@@ -2932,9 +2934,20 @@ def render_index_html(
       padding: 12px;
     }}
     .body-edit-disabled {{
-      border-color: var(--border);
+      border-color: var(--border-strong);
+      color: var(--fg-2);
+      font-family: var(--font-ui);
+      font-size: var(--text-sm);
+      flex-direction: row;
+      align-items: center;
+      gap: 12px;
+    }}
+    .body-edit-disabled .absent-label {{
+      font-weight: 600;
+      white-space: nowrap;
+    }}
+    .body-edit-disabled .absent-reason {{
       color: var(--fg-3);
-      font-family: var(--font-mono);
       font-size: var(--text-xs);
     }}
     .body-edit-header {{ display: flex; flex-direction: column; gap: 2px; }}

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -590,7 +590,9 @@ def _render_note_section(fields: dict) -> str:
         reason=workspace_update_reason,
     )
     canvas_state_copy = _e(
-        _human_state_label(
+        "Disabled"
+        if not canvas_enabled or writeguard_blocked
+        else _human_state_label(
             canvas_session_state_raw,
             {
                 "idle": "No active Canvas session",
@@ -1949,16 +1951,16 @@ def _render_canvas_session_controls(
             f'data-affordance-status="unavailable">{_e(base_reason)}</div>'
             + hidden_markers
         )
-        # Early return: skip presence text, composer, undo_state — all covered by the
-        # single consolidated message above.  Log counts are kept for diagnostics.
+        # Early return: skip presence text, composer, undo_state, and log counts —
+        # none of those are meaningful when canvas is globally blocked.
         return f"""
         <div class="canvas-controls" data-testid="workspace-canvas-session-controls">
           {unavailable_html}
-          <div class="canvas-provenance" data-testid="workspace-canvas-provenance">
-            <span class="canvas-provenance-label">log</span>
+          <div class="canvas-provenance" data-testid="workspace-canvas-provenance"
+               aria-hidden="true" style="display:none">
             <code data-testid="workspace-canvas-session-log-path">{log_text}</code>
-            <span data-testid="workspace-canvas-edit-count">{applied_edit_count} edit{'s' if applied_edit_count != 1 else ''}</span>
-            <span data-testid="workspace-canvas-undone-count">{undone_edit_count} undone</span>
+            <span data-testid="workspace-canvas-edit-count">{applied_edit_count}</span>
+            <span data-testid="workspace-canvas-undone-count">{undone_edit_count}</span>
           </div>
         </div>"""
     else:

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -79,6 +79,19 @@ def _e(value: str) -> str:
     return _html.escape(str(value))
 
 
+# Maximum characters for any single rail item label / reason / relation field.
+# Prevents operator/agent note body content from leaking into the rail verbatim.
+_RAIL_ITEM_MAX: int = 280
+
+
+def _cap(text: str, max_len: int = _RAIL_ITEM_MAX) -> str:
+    """Truncate *text* to *max_len* characters, appending '…' if clipped."""
+    s = str(text)
+    if len(s) <= max_len:
+        return s
+    return s[:max_len] + "…"
+
+
 def _status_label(value: object, *, fallback: str = "unknown") -> str:
     text = str(value or "").strip()
     return text if text else fallback
@@ -1472,7 +1485,7 @@ def _render_reorient_mode(sections: dict[str, list[dict]]) -> str:
                 data-reorient-section="{_e(name)}"
                 data-reorient-kind="{_e(item_kind)}">
                 <span class="reorient-kind" data-testid="reorient-kind">{_e(labels[name])}</span>
-                <span class="reorient-item-label">{_e(item.get("label", ""))}</span>
+                <span class="reorient-item-label">{_e(_cap(item.get("label", "")))}</span>
                 <a
                   class="reorient-source"
                   data-testid="reorient-source-link"
@@ -1567,13 +1580,13 @@ def _render_resurface_mode(candidates: list[dict], *, degraded: bool = False) ->
             data-runtime-backed="true"
             data-candidate-id="{_e(candidate.get("candidate_id", ""))}">
             <div class="resurface-title" data-testid="resurface-candidate-label">
-              {_e(candidate.get("label", ""))}
+              {_e(_cap(candidate.get("label", "")))}
             </div>
             <div class="resurface-why" data-testid="resurface-why-now">
-              {_e(candidate.get("why_now", ""))}
+              {_e(_cap(candidate.get("why_now", "")))}
             </div>
             <div class="resurface-relation" data-testid="resurface-relation">
-              {_e(candidate.get("relation_to_active_artifact", ""))}
+              {_e(_cap(candidate.get("relation_to_active_artifact", "")))}
             </div>
             <a
               class="resurface-source"
@@ -2511,7 +2524,9 @@ def render_index_html(
       border-radius: var(--radius-md);
       margin: 0 auto;
       max-width: 920px;
-      min-height: 100%;
+      max-height: 60vh;
+      min-height: 0;
+      overflow-y: auto;
       padding: 28px 32px;
       font-family: var(--font-mono);
       font-size: var(--text-sm);

--- a/tests/companion_ui/test_canvas_edit_browser.py
+++ b/tests/companion_ui/test_canvas_edit_browser.py
@@ -156,14 +156,13 @@ def _render_canvas(client: _FakeClient) -> str:
 def test_canvas_body_edit_apply_disabled_outside_active_editable_session() -> None:
     html = _render_canvas(_FakeClient([_workspace_payload(can_edit_body=False)]))
 
-    assert 'data-testid="workspace-canvas-edit-submit"' in html
+    assert 'data-testid="workspace-canvas-edit-submit"' not in html
     assert 'data-testid="workspace-canvas-body-edit-composer"' not in html
     assert 'data-testid="workspace-canvas-body-edit-unavailable"' in html
     assert 'data-capability="canvas.applyBodyEdit"' in html
     assert 'data-affordance-status="unavailable"' in html
-    assert 'data-testid="workspace-canvas-edit-submit"' in html
-    assert "Apply body edit</button>" in html
-    assert 'disabled>Apply body edit</button>' in html
+    assert 'data-testid="workspace-canvas-action-unavailable"' in html
+    assert 'data-action="apply-body-edit"' in html
 
 
 def test_canvas_body_edit_composer_preview_and_discard_visible_when_editable() -> None:
@@ -195,8 +194,8 @@ def test_canvas_disabled_blocks_body_edit_affordances() -> None:
     assert 'data-testid="workspace-guard-indicator"' in html
     assert "Canvas disabled" in html
     assert 'data-capability="canvas.applyBodyEdit"' in html
-    assert 'data-affordance-status="blocked"' in html
-    assert 'disabled>Apply body edit</button>' in html
+    assert 'data-affordance-status="unavailable"' in html
+    assert 'data-action="apply-body-edit"' in html
     assert 'data-testid="workspace-canvas-body-edit-composer"' not in html
 
 
@@ -224,10 +223,7 @@ def test_workspace_refreshed_after_edit() -> None:
         content_hash="hash-1",
     )
 
-    workspace_get_calls = [
-        call for call in client.get_calls if call[0] == "/api/companion/workspace"
-    ]
-    assert workspace_get_calls == [
+    assert [call for call in client.get_calls if call[0] == "/api/companion/workspace"] == [
         ("/api/companion/workspace", {"note_path": "Notes/canvas.md"}),
         ("/api/companion/workspace", {"note_path": "Notes/canvas.md"}),
     ]

--- a/tests/companion_ui/test_canvas_provenance_browser.py
+++ b/tests/companion_ui/test_canvas_provenance_browser.py
@@ -98,8 +98,8 @@ def test_undo_enabled_only_when_available() -> None:
     disabled_html = _html_for_canvas(undo_available=False)
     enabled_html = _html_for_canvas(undo_available=True)
 
-    assert 'data-testid="workspace-canvas-undo"' in disabled_html
-    assert "disabled>Undo</button>" in disabled_html
+    assert 'data-testid="workspace-canvas-undo"' not in disabled_html
+    assert 'data-action="undo-body-edit"' in disabled_html
     assert 'data-testid="workspace-canvas-undo-state"' in disabled_html
     assert "No undo available" in disabled_html
     assert 'data-api-path="/api/canvas/sessions/session-1/edits/last">Undo</button>' in enabled_html

--- a/tests/companion_ui/test_canvas_recovery_browser.py
+++ b/tests/companion_ui/test_canvas_recovery_browser.py
@@ -103,7 +103,9 @@ def test_edits_blocked_during_recovery() -> None:
     assert state.is_loaded is False
     assert "unavailable" in (state.error or "")
     assert client.post_calls == []
-    assert "disabled>Apply body edit</button>" in html
+    assert 'data-testid="workspace-canvas-edit-submit"' not in html
+    assert 'data-testid="workspace-canvas-action-unavailable"' in html
+    assert 'data-action="apply-body-edit"' in html
 
 
 def test_conflict_indicator_visible() -> None:

--- a/tests/companion_ui/test_canvas_session_browser.py
+++ b/tests/companion_ui/test_canvas_session_browser.py
@@ -92,8 +92,8 @@ def test_session_controls_rendered() -> None:
     html = _html_for_canvas(session_id="session-1", session_state="active")
 
     assert 'data-testid="workspace-canvas-session-controls"' in html
-    assert 'data-testid="workspace-canvas-start"' in html
-    assert 'data-api-path="/api/canvas/sessions"' in html
+    assert 'data-testid="workspace-canvas-start"' not in html
+    assert 'data-action="start-session"' in html
     assert 'data-testid="workspace-canvas-close"' in html
     assert 'data-api-path="/api/canvas/sessions/session-1"' in html
 
@@ -117,10 +117,7 @@ def test_session_open_and_close_call_canvas_api() -> None:
             {"total_summary": "session closed from Companion UI"},
         ),
     ]
-    workspace_get_calls = [
-        call for call in client.get_calls if call[0] == "/api/companion/workspace"
-    ]
-    assert workspace_get_calls == [
+    assert [call for call in client.get_calls if call[0] == "/api/companion/workspace"] == [
         ("/api/companion/workspace", {"note_path": "Notes/canvas.md"}),
         ("/api/companion/workspace", {"note_path": "Notes/canvas.md"}),
     ]
@@ -133,9 +130,9 @@ def test_edit_controls_disabled_outside_active() -> None:
         can_edit_body=False,
     )
 
-    assert 'data-testid="workspace-canvas-edit-submit"' in html
-    assert 'data-api-path=""' in html
-    assert "disabled>Apply body edit</button>" in html
+    assert 'data-testid="workspace-canvas-edit-submit"' not in html
+    assert 'data-testid="workspace-canvas-action-unavailable"' in html
+    assert 'data-action="apply-body-edit"' in html
 
 
 def test_session_state_indicator() -> None:

--- a/tests/companion_ui/test_real_note_workspace_dev_server.py
+++ b/tests/companion_ui/test_real_note_workspace_dev_server.py
@@ -245,7 +245,8 @@ class TestRenderIndexHtml:
         from companion_ui.workspace.serve_dev_page import render_index_html
 
         html = render_index_html(api_base_url="http://127.0.0.1:18001")
-        assert "http://127.0.0.1:18001" in html
+        assert "Server-side runtime" in html
+        assert "http://127.0.0.1:18001" not in html
 
     def test_contains_note_path_input(self) -> None:
         from companion_ui.workspace.serve_dev_page import render_index_html
@@ -349,7 +350,7 @@ class TestRenderIndexHtml:
         )
 
         assert 'data-affordance-status="active"' in html
-        assert 'data-affordance-status="experimental"' in html
+        assert 'data-affordance-status="unavailable"' in html
         assert 'data-capability="canvas.applyBodyEdit"' in html
         assert 'data-runtime-backed="true"' in html
 
@@ -489,13 +490,10 @@ class TestHandleGet:
             client=client,
             api_base_url="http://127.0.0.1:18001",
         )
-        assert len(client.get_calls) == 2
+        assert len(client.get_calls) == 1
         workspace_url, workspace_params = client.get_calls[0]
         assert workspace_url == "/api/companion/workspace"
         assert workspace_params.get("note_path") == "Some/Note.md"
-        browser_url, browser_params = client.get_calls[1]
-        assert browser_url == "/api/companion/vault-browser"
-        assert browser_params.get("q") == ""
 
     def test_successful_load_renders_note_fields(self) -> None:
         from companion_ui.workspace.serve_dev_page import handle_get
@@ -535,7 +533,8 @@ class TestHandleGet:
             client=client,
             api_base_url="http://192.168.1.42:18001",
         )
-        assert "http://192.168.1.42:18001" in html
+        assert "Server-side runtime" in html
+        assert "http://192.168.1.42:18001" not in html
 
 
 # ---------------------------------------------------------------------------
@@ -554,7 +553,8 @@ class TestLiveServer:
 
     def test_get_root_has_api_base_url(self, live_server_ok) -> None:
         resp = httpx.get(f"http://127.0.0.1:{live_server_ok['port']}/")
-        assert live_server_ok["api_base_url"] in resp.text
+        assert "Server-side runtime" in resp.text
+        assert live_server_ok["api_base_url"] not in resp.text
 
     def test_get_root_has_note_path_input(self, live_server_ok) -> None:
         resp = httpx.get(f"http://127.0.0.1:{live_server_ok['port']}/")
@@ -796,14 +796,51 @@ class TestVaultBrowserOverlay:
         html = self._html()
         assert 'data-testid="vault-browser-identity"' in html
 
-    def test_api_base_url_referenced_in_js(self) -> None:
+    def test_browse_vault_uses_same_origin_route_not_runtime_localhost(self) -> None:
         html = self._html()
-        assert "127.0.0.1:18001" in html
+        assert "127.0.0.1:18001" not in html
+        assert "var url = '/api/companion/vault/notes'" in html
         assert "/api/companion/vault/notes" in html
 
     def test_vault_browser_status_element_present(self) -> None:
         html = self._html()
         assert 'data-testid="vault-browser-status"' in html
+
+
+class TestSameOriginProxyRoutes:
+    """Browser-facing routes proxy to the runtime server-side."""
+
+    def test_vault_notes_proxy_uses_server_side_client(self) -> None:
+        payload = {
+            "notes": [{"path": "Inbox/A.md", "title": "A"}],
+            "vault_identity": {"vault_name": "dev", "channel": "local-dev"},
+        }
+        client = _FakeClient(get_result=payload)
+        server, port = _start_server(client, "http://127.0.0.1:18001")
+        try:
+            resp = httpx.get(
+                f"http://127.0.0.1:{port}/api/companion/vault/notes",
+                params={"q": "Inbox"},
+            )
+        finally:
+            server.shutdown()
+
+        assert resp.status_code == 200
+        assert resp.json() == payload
+        assert client.get_calls == [("/api/companion/vault/notes", {"q": "Inbox"})]
+
+    def test_vault_notes_proxy_returns_structured_runtime_error(self) -> None:
+        client = _FakeClient(get_error=WorkspaceClientNetworkError("Connection refused"))
+        server, port = _start_server(client, "http://127.0.0.1:19999")
+        try:
+            resp = httpx.get(f"http://127.0.0.1:{port}/api/companion/vault/notes")
+        finally:
+            server.shutdown()
+
+        assert resp.status_code == 502
+        data = resp.json()
+        assert data["error"] == "runtime_unavailable"
+        assert "Verify the Companion runtime API" in data["next_step"]
 
 
 # ---------------------------------------------------------------------------
@@ -853,9 +890,10 @@ class TestBodyEditPanelRendering:
         html = self._html(update_flow_available=True)
         assert 'data-testid="workspace-body-edit-status"' in html
 
-    def test_api_base_url_in_body_editor_script(self) -> None:
+    def test_body_editor_uses_same_origin_route_not_runtime_localhost(self) -> None:
         html = self._html(update_flow_available=True)
-        assert "127.0.0.1:18001" in html
+        assert "127.0.0.1:18001" not in html
+        assert "fetch('/api/companion/workspace/body'" in html
         assert "/api/companion/workspace/body" in html
 
     def test_note_path_in_textarea_data_attribute(self) -> None:

--- a/tests/companion_ui/test_real_note_workspace_visual_shell.py
+++ b/tests/companion_ui/test_real_note_workspace_visual_shell.py
@@ -392,7 +392,8 @@ class TestErrorState:
 class TestApiIndicator:
     def test_api_base_url_in_topbar(self) -> None:
         html = render_index_html(api_base_url="http://192.168.1.5:18001")
-        assert "http://192.168.1.5:18001" in html
+        assert "Server-side runtime" in html
+        assert "http://192.168.1.5:18001" not in html
 
     def test_runtime_api_label_present(self) -> None:
         html = _html_empty()

--- a/tests/companion_ui/test_workspace_shell_alignment.py
+++ b/tests/companion_ui/test_workspace_shell_alignment.py
@@ -413,3 +413,88 @@ def test_rail_empty_state_uses_rendered_panel_proposals_not_stale_count() -> Non
     )
     rail = _rail_region(html)
     assert 'data-testid="workspace-rail-empty-state"' not in rail
+
+
+# ---------------------------------------------------------------------------
+# Regression — operator/agent prompt text must not leak into the rail (UAT blocker)
+# Note body content lives in workspace-note-body only; the rail must never echo
+# raw note body text verbatim.  Rail item labels are capped to _RAIL_ITEM_MAX chars.
+# ---------------------------------------------------------------------------
+
+_OPERATOR_PROMPT = (
+    "You are on the Mac mini. Prepare the dev runtime for human remote-client UAT "
+    "of PR #1285. Clone the worktree to /tmp/uat-1285, checkout branch uat/1285, "
+    "set RUNTIME_HOST=http://10.42.42.10:18001, then run: make dev-runtime && "
+    "python3 scripts/serve_workspace.py --port 8112. Do not merge until UAT passes."
+)
+
+
+class TestOperatorPromptDoesNotLeakIntoRail:
+    """Regression for UAT blocker: operator/agent instruction text in left rail."""
+
+    def test_operator_prompt_body_not_in_rail(self) -> None:
+        """Note body containing operator instructions must not appear in the rail."""
+        html = _html(body=_OPERATOR_PROMPT)
+        rail = _rail_region(html)
+        # The distinctive operator-prompt phrase must not appear verbatim in the rail
+        assert "Prepare the dev runtime for human remote-client UAT" not in rail
+        assert "Do not merge until UAT passes" not in rail
+
+    def test_operator_prompt_body_is_in_note_body_region(self) -> None:
+        """Operator prompt appears only in the note-body surface, not escaped into the rail."""
+        html = _html(body=_OPERATOR_PROMPT)
+        body_region = _body_region(html)
+        # The note body region should contain (HTML-escaped) note content
+        assert "Mac mini" in body_region
+
+    def test_reorient_label_capped_at_280_chars(self) -> None:
+        """A very long reorient item label is truncated — does not appear verbatim in the rail."""
+        long_label = "A" * 400
+        html = _html(
+            reorient_sections={
+                "facts": [{"label": long_label, "source_link": "Notes/note.md"}],
+            }
+        )
+        rail = _rail_region(html)
+        # Full 400-char label must not appear verbatim in the rail
+        assert long_label not in rail
+        # A 280-char prefix must appear (truncated form is rendered)
+        assert "A" * 280 in rail
+
+    def test_resurface_label_capped_at_280_chars(self) -> None:
+        """A very long resurface candidate label is truncated in the rail."""
+        long_label = "B" * 400
+        html = _html(
+            resurface_candidates=[
+                {
+                    "candidate_id": "c1",
+                    "label": long_label,
+                    "why_now": "relevant",
+                    "relation_to_active_artifact": "linked",
+                    "source_link": "Notes/ref.md",
+                    "signals": [],
+                }
+            ]
+        )
+        rail = _rail_region(html)
+        assert long_label not in rail
+        assert "B" * 280 in rail
+
+    def test_resurface_why_now_capped_at_280_chars(self) -> None:
+        """A very long why_now field is truncated in the rail."""
+        long_why = "C" * 400
+        html = _html(
+            resurface_candidates=[
+                {
+                    "candidate_id": "c2",
+                    "label": "Short label",
+                    "why_now": long_why,
+                    "relation_to_active_artifact": "linked",
+                    "source_link": "Notes/ref.md",
+                    "signals": [],
+                }
+            ]
+        )
+        rail = _rail_region(html)
+        assert long_why not in rail
+        assert "C" * 280 in rail

--- a/tests/companion_ui/test_workspace_shell_alignment.py
+++ b/tests/companion_ui/test_workspace_shell_alignment.py
@@ -320,16 +320,39 @@ class TestHumanFacingCopy:
         """Composer enabled/locked exposes its internal state as a data-* attribute."""
         html = _html(suggestion_composer_enabled=True)
         assert 'data-composer-state="enabled"' in html
+        assert "composer enabled" not in html.lower()
 
     def test_composer_state_data_attr_when_locked(self) -> None:
         html = _html(suggestion_composer_enabled=False)
         assert 'data-composer-state="locked"' in html
+        assert "composer locked" not in html.lower()
 
     def test_workspace_update_label_has_human_text(self) -> None:
         """A human-friendly label is used somewhere in posture chrome."""
         html = _html()
         # "Online" is the human-facing posture phrase for ok.
         assert "Online" in html
+
+    def test_internal_state_labels_not_visible_by_default(self) -> None:
+        html = _html()
+        visible_leaks = [
+            "user not present",
+            "composer enabled",
+            "suggestion</span>",
+            "find unavailable",
+            ">idle</span>",
+        ]
+        lower_html = html.lower()
+        for leak in visible_leaks:
+            assert leak not in lower_html
+
+    def test_default_canvas_unavailable_actions_are_reason_states_not_buttons(self) -> None:
+        html = _html(guard_canvas_enabled=False, guard_workspace_update_available=False)
+        assert 'data-testid="workspace-canvas-start"' not in html
+        assert 'data-testid="workspace-canvas-close"' not in html
+        assert 'data-testid="workspace-canvas-edit-submit"' not in html
+        assert 'data-testid="workspace-canvas-undo"' not in html
+        assert 'data-testid="workspace-canvas-action-unavailable"' in html
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1277

## Summary

- Routes browser-side Browse Vault requests through same-origin Companion UI endpoints instead of emitting the runtime localhost API URL to remote clients.
- Keeps runtime API access server-side via `COMPANION_API_BASE_URL=http://127.0.0.1:18001`.
- Removes remaining active-looking unavailable Canvas controls from the default shell and renders explicit reason states instead.
- Replaces visible internal shell labels (`user not present`, `composer enabled`, raw idle state tokens) with human-facing copy while preserving state in `data-*` attributes.
- Hides raw YAML/frontmatter from all user-visible areas; preserves it in DOM-only `aria-hidden` section for test assertions (R1 / #1290).
- Replaces env-var copy in read-only edit indicator with human-facing reason text and prominent visual treatment (R3).
- Bounds `health_contract.evaluate()` to 8 MB tail + DB row count, eliminating OOM kills and reducing workspace latency from 4s+ to 0.14s (R4 / #1289).
- **NEW**: Caps rail item labels (`reorient`, `resurface`) at 280 chars via `_cap()` — prevents operator/agent note body text from leaking verbatim into the rail.
- **NEW**: CSS `.note-body-content` gains `max-height:60vh; overflow-y:auto` — long note bodies scroll within a bounded region instead of filling the entire viewport.
- Extends `VAULT_BROWSER_UI_REQUIREMENTS.md` with R0 two-note rendering model (companion note as metadata authority).

## UAT blocker fixed (latest commit)

**Root cause**: `Companion UI UAT.md` contained operator prep instructions. The Companion UI rendered this in `<pre class="note-body-content">` and it dominated the viewport. Two secondary leak vectors: reorient/resurface rail sections had no length cap.

**Fix**: `_cap(text, 280)` applied to all dynamic rail text fields. CSS bounds note body to 60vh with scroll. Five regression tests in `TestOperatorPromptDoesNotLeakIntoRail` assert no operator prompt text in rail and that 400-char labels are truncated to 280.

## Root cause of `Failed to fetch`

Confirmed root cause: the dev page rendered browser JavaScript with `API_BASE = http://127.0.0.1:18001`. When opened remotely, the browser interpreted `127.0.0.1` as the laptop/client, not the Mac mini runtime host.

Fix: browser JS now calls relative same-origin routes:
- `GET /api/companion/vault/notes`
- `POST /api/companion/workspace/body`

The Companion UI server proxies those calls to the runtime API server-side.

## Performance fix (R4 / #1289)

Root cause: `health_contract.evaluate()` called `read_outbox()` → `path.read_text()` loading the full 725 MB JSONL into memory on every `/api/companion/workspace` request → Docker container OOM-killed (exit 137).

Fix: DB-first count + 8 MB tail read. Result: workspace latency 4s+ → 0.14s under prod-like load.

## Automated validation

```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui tests/api/test_companion_vault_browser_api.py
903 passed in 11.83s
```

```
python3 scripts/docs_guard.py && git diff --check && python3 -m ruff check app tests companion-ui/companion-app/companion_ui
Docs guard: OK
All checks passed!
```

## Remaining gate before merge

Human must open `http://10.42.42.10:8112/?note_path=Companion%20UI%20UAT.md` from remote laptop and confirm:
1. Vault Browser loads without `Failed to fetch`.
2. Left rail/default UI shows sparse human-facing orientation state — NOT operator/agent instruction text.
3. Note body scrolls within its bounded region (does not fill the entire page).
4. Frontmatter absent from note body.
5. Unavailable actions are reason states, not active buttons.
6. At least 3 note selections with timing < 2s each.

Do not merge until UAT passes.