### PR TITLE
fix(runtime): bound health_contract outbox read; extend UI requirements with R0 two-note model

### DIFF
--- a/app/health_contract.py
+++ b/app/health_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from datetime import timezone, datetime, timedelta
@@ -9,10 +10,63 @@ from typing import Any
 
 from app.config.environment import active_environment
 from app.config.paths import resolve_vault_root
-from app.events.outbox import event_name, latest_trace_story, normalize_timestamp, read_outbox
+from app.events.outbox import default_outbox_path, event_name, latest_trace_story, normalize_timestamp
 from app.index.doctor import diagnose_index
 from app.settings.health_settings import HealthThresholds, load_health_settings
 from app.stores import get_object_store
+
+# Health checks must never load the full outbox into memory; it can grow to hundreds of MB.
+# Bound tail reads to this many bytes — enough to capture recent activity for all checks.
+_HEALTH_TAIL_BYTES = 8 * 1024 * 1024  # 8 MB
+
+
+def _count_outbox_lines(path: Path) -> int:
+    """Count lines in outbox without loading content into memory."""
+    if not path.exists():
+        return 0
+    try:
+        with path.open("rb") as fh:
+            return sum(chunk.count(b"\n") for chunk in iter(lambda: fh.read(1024 * 1024), b""))
+    except Exception:
+        return 0
+
+
+def _read_tail_records(path: Path | None = None) -> list[dict[str, Any]]:
+    """Read at most _HEALTH_TAIL_BYTES from the end of the outbox; return parsed records."""
+    target = (path or default_outbox_path()).expanduser()
+    if not target.exists():
+        return []
+    try:
+        with target.open("rb") as fh:
+            fh.seek(0, os.SEEK_END)
+            size = fh.tell()
+            if size > _HEALTH_TAIL_BYTES:
+                fh.seek(size - _HEALTH_TAIL_BYTES)
+                partial = True
+            else:
+                fh.seek(0)
+                partial = False
+            data = fh.read()
+    except Exception:
+        return []
+    try:
+        lines = data.decode("utf-8", errors="replace").splitlines()
+    except Exception:
+        return []
+    if partial and lines:
+        lines = lines[1:]  # drop potentially truncated first line
+    records: list[dict[str, Any]] = []
+    for ln in lines:
+        ln = ln.strip()
+        if not ln:
+            continue
+        try:
+            obj = json.loads(ln)
+            if isinstance(obj, dict):
+                records.append(obj)
+        except Exception:
+            continue
+    return records
 
 WRITE_BLOCKED_STATES = {"safe_mode", "unhealthy"}
 INCIDENT_STATES = {"degraded", "unhealthy", "safe_mode"}
@@ -117,8 +171,9 @@ class HealthContract:
         now = self.now_fn()
         vault_root = self.vault_root_fn()
         settings_result = load_health_settings(vault_root=vault_root)
-        records = read_outbox()
-        outbox_count = len(records)
+        outbox_path = default_outbox_path()
+        outbox_count = _count_outbox_lines(outbox_path)
+        records = _read_tail_records(outbox_path)
         object_count = self._count_objects()
         latest_ts = self._latest_timestamp(records)
         age = self._compute_age(latest_ts, now)

--- a/companion-ui/docs/VAULT_BROWSER_UI_REQUIREMENTS.md
+++ b/companion-ui/docs/VAULT_BROWSER_UI_REQUIREMENTS.md
@@ -62,9 +62,37 @@ future capability. It is not automatically in scope for the current issue.
 NON-GOAL means forbidden behavior or explicitly out-of-scope behavior. Implementations must not
 smuggle NON-GOAL behavior into adjacent work.
 
+## R0 Two-note rendering model
+
+The system distinguishes two note types that appear together in a loaded workspace view:
+
+- **Main note**: the human-authored vault note. Its body is clean prose. The user reads and
+  edits this content. It is the cognitive anchor of the workspace.
+- **Companion note**: a system-managed note stored in the vault companion directory
+  (`⚙️ System/companions/<uuid>.md` or equivalent). It holds artifact metadata: uuid, kind,
+  trust, review_state, provenance, origin, source_ref, created, updated, and similar fields.
+
+Requirements derived from this model:
+
+- The UI MUST load both the main note and the companion note when a note is opened.
+- The UI MUST render only the main note body as the primary reading surface.
+- Companion note content MUST NOT appear as part of the main reading area.
+- Artifact metadata displayed in the UI (uuid, kind, trust, review posture, provenance) MUST be
+  sourced from the companion note where it is available.
+- When a companion note is absent, the UI MAY fall back to frontmatter fields in the main note,
+  but MUST make it clear that companion metadata is missing.
+- Main notes SHOULD be writable as clean human prose without requiring YAML frontmatter.
+- The companion note is the authoritative metadata store. Main note frontmatter is a legacy/fallback
+  source only.
+- This separation MUST NOT be collapsed. A UI that reads metadata only from main note frontmatter
+  violates this model and must be corrected.
+- Mixing main note body with companion note metadata in the same rendering region is a NON-GOAL.
+
 ## R1 Workspace orientation and body rendering
 
 - Raw YAML/frontmatter MUST NOT render as ordinary body text.
+- Raw YAML/frontmatter MUST NOT render in any user-visible area outside the bounded
+  identity/metadata chrome — including areas adjacent to, above, or below the body frame.
 - Human-readable body content MUST be visually distinct from metadata.
 - Frontmatter-derived metadata MUST remain visible in bounded identity/metadata chrome where
   available.
@@ -74,6 +102,8 @@ smuggle NON-GOAL behavior into adjacent work.
   leaking raw implementation detail.
 - The note body remains the human cognitive anchor. Metadata chrome supports orientation; it must
   not compete with the body as prose.
+- Frontmatter that leaks outside the note body frame but is still user-visible is an R1 violation,
+  even if it is not rendered inline with the body text.
 
 ## R2 Vault Browser layout
 
@@ -106,6 +136,8 @@ smuggle NON-GOAL behavior into adjacent work.
 - Normal dev-runtime note selection SHOULD complete within 2 seconds for ordinary notes.
 - UAT for note selection SHOULD include at least three repeated selections and timings.
 - Slow or unreliable selection MUST be treated as a blocker or explicit performance follow-up.
+- UAT 2026-05-25 observed ~5s note selection latency on dev runtime. This is a documented blocker;
+  root cause investigation is required before this requirement can be marked satisfied.
 - Selection MUST NOT rely on client-side access to Mac mini localhost APIs when the UI is opened
   remotely.
 - Remote-client UAT matters when the user-visible behavior depends on a browser running on a
@@ -257,3 +289,9 @@ The Vault Browser / Workspace UI is not:
 - If issue ACs and this document conflict, stop and run `issue-maintenance-change-control`.
 - Do not use this document to silently expand an issue. Convert MAY / FUTURE requirements into
   bounded issues through the repo workflow before implementation.
+- The two-note rendering model (R0) applies to all Vault Browser / Workspace UI implementation
+  issues. Implementation must not skip companion note loading, must not mix companion metadata
+  into the main note body frame, and must not render main note frontmatter in any user-visible
+  region.
+- Note selection performance (R4) is a documented blocker as of UAT 2026-05-25. Any PR claiming
+  browse/open flow completion must resolve or explicitly defer this with a follow-up issue.


### PR DESCRIPTION
## Summary

- Fixes OOM crash on every `/api/companion/workspace` request caused by `health_contract.evaluate()` reading the full 725 MB `index-outbox.jsonl` into memory
- Extends `companion-ui/docs/VAULT_BROWSER_UI_REQUIREMENTS.md` with R0 (two-note rendering model), R1 clarification, R4 UAT blocker note

Surfaced during UAT for #1277 / PR #1285 on 2026-05-25.

## Runtime OOM fix — `app/health_contract.py`

### Root cause

`DEFAULT_WRITE_GUARD` calls `DEFAULT_CONTRACT.evaluate()` on every request that checks write permission, including `GET /api/companion/workspace`. `evaluate()` called `read_outbox()` which reads the entire outbox via `path.read_text()`. The outbox has grown to 725 MB. Every workspace request OOM-killed the container (exit code 137).

The same class of bug was fixed for `/api/status` in commit `3e93b617` (bounded `_iter_tail_lines` in `status_service.py`), but `health_contract.evaluate()` was not updated at that time.

### Fix

Replaced `read_outbox()` in `evaluate()` with two bounded helpers:

- `_count_outbox_lines(path)` — streams the file in 1 MB chunks counting `\n` bytes; never loads content into memory
- `_read_tail_records(path)` — reads at most 8 MB from the end of the file (same cap as `_STATUS_TAIL_BYTES` in `status_service.py`); drops the potentially-partial first line

`outbox_count` now comes from `_count_outbox_lines()` (accurate total without loading content).
`records` passed to `_latest_timestamp`, `_events_status`, `_count_errors` comes from `_read_tail_records()` (recent records only, sufficient for all three).

Health state machine semantics are preserved: the state machine already holds in-memory transition state; it only needs recent timestamps and error counts from the tail.

### Validation

```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/ -k "health_contract or write_guard or writeguard"
35 passed (2 pre-existing failures unrelated to this change)
python3 -m ruff check app/health_contract.py
All checks passed!
```

Live: container stayed healthy through repeated `/api/companion/workspace` calls after restart.

## Docs update — `companion-ui/docs/VAULT_BROWSER_UI_REQUIREMENTS.md`

### R0 Two-note rendering model (new section)

Codifies the product architecture requirement from UAT 2026-05-25:

- Main note = human-authored prose, rendered clean with no frontmatter
- Companion note = system metadata store (uuid, kind, trust, review_state, provenance)
- UI MUST load both; MUST render only the main note body to the user
- Metadata displayed in UI chrome MUST be sourced from companion note where available
- Main note frontmatter is a legacy/fallback source only
- Mixing companion metadata into the main note body frame is a NON-GOAL

### R1 clarification

Added explicit requirement that frontmatter leaking outside the note body frame but still visible to the user is also an R1 violation — not only inline body rendering.

### R4 UAT observation

Documented ~5s note selection latency observed in UAT 2026-05-25 as a recorded blocker.

## Related

- UAT receipt: https://github.com/RasmusTho/agentic-pkm-mvp/pull/1285#issuecomment-4535652550
- #1289 — note selection latency blocker
- #1290 — frontmatter renders outside note frame
- #1277 / PR #1285 — remains draft pending resolution of blockers