### PR TITLE
Fix non-pg test suite failures

### DIFF
--- a/app/health_contract.py
+++ b/app/health_contract.py
@@ -20,13 +20,38 @@ from app.stores import get_object_store
 _HEALTH_TAIL_BYTES = 8 * 1024 * 1024  # 8 MB
 
 
+def _count_outbox_lines_db() -> int | None:
+    """Count total outbox rows via DB when STORE_BACKEND=pg. Returns None on any error."""
+    backend = (os.getenv("STORE_BACKEND") or "memory").strip().lower()
+    if backend != "pg":
+        return None
+    try:
+        from app.services.outbox import count_outbox_events
+
+        return count_outbox_events()
+    except Exception:
+        return None
+
+
 def _count_outbox_lines(path: Path) -> int:
-    """Count lines in outbox without loading content into memory."""
+    """Count outbox records: DB when available, else streaming file line count."""
+    db_count = _count_outbox_lines_db()
+    if db_count is not None:
+        return db_count
     if not path.exists():
         return 0
     try:
+        count = 0
+        saw_bytes = False
+        last_byte = b""
         with path.open("rb") as fh:
-            return sum(chunk.count(b"\n") for chunk in iter(lambda: fh.read(1024 * 1024), b""))
+            for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+                saw_bytes = True
+                count += chunk.count(b"\n")
+                last_byte = chunk[-1:]
+        if saw_bytes and last_byte != b"\n":
+            count += 1
+        return count
     except Exception:
         return 0
 

--- a/app/orientation/runtime.py
+++ b/app/orientation/runtime.py
@@ -27,7 +27,8 @@ def _iso(dt: datetime | None) -> str:
 
 
 def pass_through_context_dimensions(record: dict[str, object]) -> dict[str, object]:
-    payload = dict(record.get("context_dimensions") or {})
+    raw_payload = record.get("context_dimensions")
+    payload = raw_payload if isinstance(raw_payload, dict) else {}
     return {
         "scope": payload.get("scope"),
         "sphere_memberships": list(payload.get("sphere_memberships") or []),

--- a/app/resurfacing/bundle_consumer.py
+++ b/app/resurfacing/bundle_consumer.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, ValidationInfo, field_validator
 
 from app.context_bundles.schema import (
     ContextBundle,
@@ -39,7 +39,7 @@ class WhyNowSignal(BaseModel):
 
     @field_validator("rationale", "signal_name")
     @classmethod
-    def _must_be_non_blank(cls, v: str, info) -> str:
+    def _must_be_non_blank(cls, v: str, info: ValidationInfo) -> str:
         if not v or not v.strip():
             raise ValueError(
                 f"{info.field_name} must be a non-empty string — "

--- a/app/services/outbox.py
+++ b/app/services/outbox.py
@@ -222,6 +222,28 @@ def write_outbox_event(
             conn.close()
 
 
+def count_outbox_events(conn: Any = None) -> int | None:
+    """Return the total DB outbox row count, or None when the DB is unavailable."""
+    try:
+        conn, close = _use_conn(conn)
+    except Exception:
+        return None
+    try:
+        cur = _exec(conn, "select count(*) from outbox")
+        if hasattr(cur, "fetchone"):
+            row = cur.fetchone()
+            return int(row[0]) if row else 0
+        return None
+    except Exception:
+        return None
+    finally:
+        if close:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+
 def insert_object_and_outbox(
     payload: Dict[str, Any],
     topic: str,

--- a/app/vault/actions.py
+++ b/app/vault/actions.py
@@ -60,7 +60,7 @@ from pathlib import Path
 from typing import Optional
 
 from app.vault.layout import VaultLayout
-from app.write_guard import DEFAULT_WRITE_GUARD, WritesBlockedError
+from app.write_guard import DEFAULT_WRITE_GUARD, WriteGuard, WritesBlockedError
 
 logger = logging.getLogger(__name__)
 
@@ -183,7 +183,7 @@ def move_note_to_zone(
     actor: str,
     intent_id: Optional[str] = None,
     trace_id: Optional[str] = None,
-    write_guard=None,
+    write_guard: WriteGuard | None = None,
 ) -> MoveResult:
     """Move a Markdown note from one vault zone to another.
 

--- a/scripts/export_runtime_env.sh
+++ b/scripts/export_runtime_env.sh
@@ -4,6 +4,13 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
+operator_openai_base="${OPENAI_BASE:-}"
+operator_openai_base_url="${OPENAI_BASE_URL:-}"
+export PKM_EXPORT_OPERATOR_OLLAMA_BASE_URL="${OLLAMA_BASE_URL:-}"
+export PKM_EXPORT_OPERATOR_OLLAMA_URL="${OLLAMA_URL:-}"
+export PKM_EXPORT_OPERATOR_OLLAMA_HOST="${OLLAMA_HOST:-}"
+export PKM_EXPORT_OPERATOR_OPENAI_BASE_URL="${OPENAI_BASE_URL:-}"
+
 source "scripts/lib/load_env_defaults.sh"
 load_env_defaults_file ".env"
 load_env_defaults_file "config/runtime.defaults.env"
@@ -193,14 +200,19 @@ fi
 # If the operator set it explicitly, write it as-is.
 # Otherwise, if OPENAI_BASE_URL is set (OpenAI-compatible base), derive the chat-completions
 # URL by stripping a trailing slash and appending /chat/completions.
-if [ -n "${OPENAI_BASE:-}" ]; then
+if [ -n "$operator_openai_base" ]; then
   printf "%s\n" "OPENAI_BASE=${OPENAI_BASE}" >> "$runtime_env_path"
 else
   _resolved_openai_base_url="${OPENAI_BASE_URL:-}"
   if [ -z "$_resolved_openai_base_url" ]; then
     _resolved_openai_base_url="$(awk -F= '/^OPENAI_BASE_URL=/{print substr($0, index($0,$2)); exit}' "$runtime_env_path")"
   fi
-  if [ -n "$_resolved_openai_base_url" ]; then
+  if [ -n "$_resolved_openai_base_url" ] && { [ -n "$operator_openai_base_url" ] || [ -z "${OPENAI_BASE:-}" ]; }; then
+    _derived_openai_base="${_resolved_openai_base_url%/}/chat/completions"
+    printf "%s\n" "OPENAI_BASE=${_derived_openai_base}" >> "$runtime_env_path"
+  elif [ -n "${OPENAI_BASE:-}" ]; then
+    printf "%s\n" "OPENAI_BASE=${OPENAI_BASE}" >> "$runtime_env_path"
+  elif [ -n "$_resolved_openai_base_url" ]; then
     _derived_openai_base="${_resolved_openai_base_url%/}/chat/completions"
     printf "%s\n" "OPENAI_BASE=${_derived_openai_base}" >> "$runtime_env_path"
   fi
@@ -256,8 +268,17 @@ providers = _load_providers(vault_root)
 llm_ref = providers.llm.get("default_chat") if providers else None
 embed_ref = providers.embedding.get("default") if providers else None
 
+def _operator_env(name: str) -> str | None:
+    value = (os.getenv(f"PKM_EXPORT_OPERATOR_{name}") or "").strip()
+    return value or None
+
+
 base_url = (
-    os.getenv("OLLAMA_BASE_URL")
+    _operator_env("OLLAMA_BASE_URL")
+    or _operator_env("OLLAMA_URL")
+    or _operator_env("OLLAMA_HOST")
+    or _operator_env("OPENAI_BASE_URL")
+    or os.getenv("OLLAMA_BASE_URL")
     or os.getenv("OLLAMA_URL")
     or os.getenv("OLLAMA_HOST")
     or os.getenv("OPENAI_BASE_URL")

--- a/scripts/reset_to_zero.sh
+++ b/scripts/reset_to_zero.sh
@@ -43,15 +43,6 @@ patterns=(
   "tmp-test/latest_watcher_tick_log"
 )
 
-deleted=()
-for pattern in "${patterns[@]}"; do
-  for target in $pattern; do
-    if [ -e "$target" ] || [ -L "$target" ]; then
-      deleted+=("$target")
-    fi
-  done
-done
-
 echo "Stopping docker compose (down -v --remove-orphans)"
 if command -v docker &> /dev/null; then
   if docker compose down -v --remove-orphans 2>&1; then
@@ -65,6 +56,15 @@ if command -v docker &> /dev/null; then
 else
   echo "  (docker not available, skipping)"
 fi
+
+deleted=()
+for pattern in "${patterns[@]}"; do
+  for target in $pattern; do
+    if [ -e "$target" ] || [ -L "$target" ]; then
+      deleted+=("$target")
+    fi
+  done
+done
 
 echo "Identified runtime artifacts to delete:"
 if [ "${#deleted[@]}" -eq 0 ]; then

--- a/tests/companion_ui/test_act_mode_browser.py
+++ b/tests/companion_ui/test_act_mode_browser.py
@@ -9,6 +9,10 @@ from companion_ui.workspace.real_note_workspace_dev_page import (
     RealNoteWorkspaceDevPage,
 )
 from companion_ui.workspace.serve_dev_page import render_index_html
+from tests.companion_ui.vault_browser_test_helpers import (
+    default_vault_browser_payload,
+    is_vault_browser_get,
+)
 
 
 class _FakeClient:
@@ -16,6 +20,8 @@ class _FakeClient:
         self._receipt = receipt
 
     def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        if is_vault_browser_get(url):
+            return default_vault_browser_payload()
         assert url == "/api/companion/workspace"
         assert params == {"note_path": "Notes/act.md"}
         panel: dict[str, Any] = {

--- a/tests/companion_ui/test_canvas_edit_browser.py
+++ b/tests/companion_ui/test_canvas_edit_browser.py
@@ -9,6 +9,10 @@ from companion_ui.workspace.real_note_workspace_dev_page import (
     RealNoteWorkspaceDevPage,
 )
 from companion_ui.workspace.serve_dev_page import render_index_html
+from tests.companion_ui.vault_browser_test_helpers import (
+    default_vault_browser_payload,
+    is_vault_browser_get,
+)
 from companion_ui.workspace.workspace_http_client import WorkspaceClientHTTPError
 
 
@@ -26,6 +30,8 @@ class _FakeClient:
 
     def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
         self.get_calls.append((url, params))
+        if is_vault_browser_get(url):
+            return default_vault_browser_payload()
         return self.payloads.pop(0)
 
     def post(self, url: str, *, json: dict[str, Any]) -> dict[str, Any]:
@@ -218,7 +224,10 @@ def test_workspace_refreshed_after_edit() -> None:
         content_hash="hash-1",
     )
 
-    assert client.get_calls == [
+    workspace_get_calls = [
+        call for call in client.get_calls if call[0] == "/api/companion/workspace"
+    ]
+    assert workspace_get_calls == [
         ("/api/companion/workspace", {"note_path": "Notes/canvas.md"}),
         ("/api/companion/workspace", {"note_path": "Notes/canvas.md"}),
     ]

--- a/tests/companion_ui/test_canvas_provenance_browser.py
+++ b/tests/companion_ui/test_canvas_provenance_browser.py
@@ -9,6 +9,10 @@ from companion_ui.workspace.real_note_workspace_dev_page import (
     RealNoteWorkspaceDevPage,
 )
 from companion_ui.workspace.serve_dev_page import render_index_html
+from tests.companion_ui.vault_browser_test_helpers import (
+    default_vault_browser_payload,
+    is_vault_browser_get,
+)
 
 
 class _FakeClient:
@@ -19,6 +23,8 @@ class _FakeClient:
 
     def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
         self.get_calls.append((url, params))
+        if is_vault_browser_get(url):
+            return default_vault_browser_payload()
         return self.payloads.pop(0)
 
     def delete(

--- a/tests/companion_ui/test_canvas_recovery_browser.py
+++ b/tests/companion_ui/test_canvas_recovery_browser.py
@@ -9,6 +9,10 @@ from companion_ui.workspace.real_note_workspace_dev_page import (
     RealNoteWorkspaceDevPage,
 )
 from companion_ui.workspace.serve_dev_page import render_index_html
+from tests.companion_ui.vault_browser_test_helpers import (
+    default_vault_browser_payload,
+    is_vault_browser_get,
+)
 from companion_ui.workspace.workspace_http_client import WorkspaceClientNetworkError
 
 
@@ -20,6 +24,8 @@ class _FakeClient:
 
     def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
         self.get_calls.append((url, params))
+        if is_vault_browser_get(url):
+            return default_vault_browser_payload()
         payload = self.payloads.pop(0)
         if isinstance(payload, Exception):
             raise payload

--- a/tests/companion_ui/test_canvas_session_browser.py
+++ b/tests/companion_ui/test_canvas_session_browser.py
@@ -9,6 +9,10 @@ from companion_ui.workspace.real_note_workspace_dev_page import (
     RealNoteWorkspaceDevPage,
 )
 from companion_ui.workspace.serve_dev_page import render_index_html
+from tests.companion_ui.vault_browser_test_helpers import (
+    default_vault_browser_payload,
+    is_vault_browser_get,
+)
 
 
 class _FakeClient:
@@ -20,6 +24,8 @@ class _FakeClient:
 
     def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
         self.get_calls.append((url, params))
+        if is_vault_browser_get(url):
+            return default_vault_browser_payload()
         return self.payloads.pop(0)
 
     def post(self, url: str, *, json: dict[str, Any]) -> dict[str, Any]:
@@ -111,7 +117,10 @@ def test_session_open_and_close_call_canvas_api() -> None:
             {"total_summary": "session closed from Companion UI"},
         ),
     ]
-    assert client.get_calls == [
+    workspace_get_calls = [
+        call for call in client.get_calls if call[0] == "/api/companion/workspace"
+    ]
+    assert workspace_get_calls == [
         ("/api/companion/workspace", {"note_path": "Notes/canvas.md"}),
         ("/api/companion/workspace", {"note_path": "Notes/canvas.md"}),
     ]

--- a/tests/companion_ui/test_find_mode_browser.py
+++ b/tests/companion_ui/test_find_mode_browser.py
@@ -9,10 +9,16 @@ from companion_ui.workspace.real_note_workspace_dev_page import (
     RealNoteWorkspaceDevPage,
 )
 from companion_ui.workspace.serve_dev_page import render_index_html
+from tests.companion_ui.vault_browser_test_helpers import (
+    default_vault_browser_payload,
+    is_vault_browser_get,
+)
 
 
 class _FakeClient:
     def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        if is_vault_browser_get(url):
+            return default_vault_browser_payload()
         assert url == "/api/companion/workspace"
         assert params == {"note_path": "Notes/find.md"}
         return {
@@ -93,6 +99,8 @@ def test_panel_handoff() -> None:
 
 class _NoFindPayloadClient:
     def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        if is_vault_browser_get(url):
+            return default_vault_browser_payload()
         assert url == "/api/companion/workspace"
         assert params == {"note_path": "Notes/find.md"}
         return {
@@ -132,6 +140,8 @@ def test_find_unavailable_state_renders_without_backend_payload() -> None:
 
 class _EmptyFindPayloadClient:
     def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        if is_vault_browser_get(url):
+            return default_vault_browser_payload()
         assert url == "/api/companion/workspace"
         assert params == {"note_path": "Notes/find.md"}
         return {
@@ -172,6 +182,8 @@ def test_find_empty_state_distinct_from_unavailable() -> None:
 
 class _MissingCitationFindClient:
     def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        if is_vault_browser_get(url):
+            return default_vault_browser_payload()
         assert url == "/api/companion/workspace"
         assert params == {"note_path": "Notes/find.md"}
         return {

--- a/tests/companion_ui/test_governance_queue_browser.py
+++ b/tests/companion_ui/test_governance_queue_browser.py
@@ -9,6 +9,10 @@ from companion_ui.workspace.real_note_workspace_dev_page import (
     RealNoteWorkspaceDevPage,
 )
 from companion_ui.workspace.serve_dev_page import render_index_html
+from tests.companion_ui.vault_browser_test_helpers import (
+    default_vault_browser_payload,
+    is_vault_browser_get,
+)
 
 
 class _FakeClient:
@@ -19,6 +23,8 @@ class _FakeClient:
 
     def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
         self.get_calls.append((url, params))
+        if is_vault_browser_get(url):
+            return default_vault_browser_payload()
         return self.payloads.pop(0)
 
     def post(self, url: str, *, json: dict[str, Any]) -> dict[str, Any]:

--- a/tests/companion_ui/test_panel_confirm_browser.py
+++ b/tests/companion_ui/test_panel_confirm_browser.py
@@ -9,6 +9,10 @@ from companion_ui.workspace.real_note_workspace_dev_page import (
     RealNoteWorkspaceDevPage,
 )
 from companion_ui.workspace.serve_dev_page import render_index_html
+from tests.companion_ui.vault_browser_test_helpers import (
+    default_vault_browser_payload,
+    is_vault_browser_get,
+)
 from companion_ui.workspace.workspace_http_client import WorkspaceClientHTTPError
 
 
@@ -37,6 +41,8 @@ class _FakeClient:
 
     def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
         self.get_calls.append((url, params))
+        if is_vault_browser_get(url):
+            return default_vault_browser_payload()
         return self.payloads.pop(0)
 
     def post(self, url: str, *, json: dict[str, Any]) -> dict[str, Any]:
@@ -167,7 +173,10 @@ def test_workspace_refreshed_after_confirm() -> None:
         note_path="Notes/panel.md",
     )
 
-    assert client.get_calls == [
+    workspace_get_calls = [
+        call for call in client.get_calls if call[0] == "/api/companion/workspace"
+    ]
+    assert workspace_get_calls == [
         ("/api/companion/workspace", {"note_path": "Notes/panel.md"}),
         ("/api/companion/workspace", {"note_path": "Notes/panel.md"}),
     ]

--- a/tests/companion_ui/test_panel_correction_browser.py
+++ b/tests/companion_ui/test_panel_correction_browser.py
@@ -9,6 +9,10 @@ from companion_ui.workspace.real_note_workspace_dev_page import (
     RealNoteWorkspaceDevPage,
 )
 from companion_ui.workspace.serve_dev_page import render_index_html
+from tests.companion_ui.vault_browser_test_helpers import (
+    default_vault_browser_payload,
+    is_vault_browser_get,
+)
 
 
 class _FakeClient:
@@ -32,6 +36,8 @@ class _FakeClient:
 
     def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
         self.get_calls.append((url, params))
+        if is_vault_browser_get(url):
+            return default_vault_browser_payload()
         return self.payloads.pop(0)
 
     def post(self, url: str, *, json: dict[str, Any]) -> dict[str, Any]:

--- a/tests/companion_ui/test_panel_rail_browser.py
+++ b/tests/companion_ui/test_panel_rail_browser.py
@@ -10,6 +10,10 @@ from companion_ui.workspace.real_note_workspace_dev_page import (
     RealNoteWorkspaceDevPage,
 )
 from companion_ui.workspace.serve_dev_page import render_index_html
+from tests.companion_ui.vault_browser_test_helpers import (
+    default_vault_browser_payload,
+    is_vault_browser_get,
+)
 
 
 class _FakeClient:
@@ -19,6 +23,8 @@ class _FakeClient:
 
     def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
         self.calls.append((url, params))
+        if is_vault_browser_get(url):
+            return default_vault_browser_payload()
         return self.payload
 
 
@@ -44,7 +50,10 @@ def _html_for_panel(panel: dict[str, Any]) -> str:
     page = RealNoteWorkspaceDevPage(client)  # type: ignore[arg-type]
     state = page.load(NoteLoadIntent(note_path="Notes/panel.md"))
     assert state.is_loaded is True
-    assert client.calls == [
+    workspace_get_calls = [
+        call for call in client.calls if call[0] == "/api/companion/workspace"
+    ]
+    assert workspace_get_calls == [
         ("/api/companion/workspace", {"note_path": "Notes/panel.md"}),
     ]
     fields = page.render_fields()

--- a/tests/companion_ui/test_reorient_mode_browser.py
+++ b/tests/companion_ui/test_reorient_mode_browser.py
@@ -9,10 +9,16 @@ from companion_ui.workspace.real_note_workspace_dev_page import (
     RealNoteWorkspaceDevPage,
 )
 from companion_ui.workspace.serve_dev_page import render_index_html
+from tests.companion_ui.vault_browser_test_helpers import (
+    default_vault_browser_payload,
+    is_vault_browser_get,
+)
 
 
 class _FakeClient:
     def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        if is_vault_browser_get(url):
+            return default_vault_browser_payload()
         assert url == "/api/companion/workspace"
         assert params == {"note_path": "Notes/reorient.md"}
         return {

--- a/tests/companion_ui/test_resurface_mode_browser.py
+++ b/tests/companion_ui/test_resurface_mode_browser.py
@@ -9,10 +9,16 @@ from companion_ui.workspace.real_note_workspace_dev_page import (
     RealNoteWorkspaceDevPage,
 )
 from companion_ui.workspace.serve_dev_page import render_index_html
+from tests.companion_ui.vault_browser_test_helpers import (
+    default_vault_browser_payload,
+    is_vault_browser_get,
+)
 
 
 class _FakeClient:
     def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        if is_vault_browser_get(url):
+            return default_vault_browser_payload()
         assert url == "/api/companion/workspace"
         assert params == {"note_path": "Notes/resurface.md"}
         return {
@@ -167,6 +173,8 @@ class _EmptyResurfaceClient:
         self.degraded = degraded
 
     def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        if is_vault_browser_get(url):
+            return default_vault_browser_payload()
         assert url == "/api/companion/workspace"
         assert params == {"note_path": "Notes/resurface.md"}
         return {

--- a/tests/companion_ui/test_suggestion_apply_browser.py
+++ b/tests/companion_ui/test_suggestion_apply_browser.py
@@ -8,6 +8,10 @@ from companion_ui.workspace.real_note_workspace_dev_page import (
     NoteLoadIntent,
     RealNoteWorkspaceDevPage,
 )
+from tests.companion_ui.vault_browser_test_helpers import (
+    default_vault_browser_payload,
+    is_vault_browser_get,
+)
 
 
 class _FakeClient:
@@ -18,6 +22,8 @@ class _FakeClient:
 
     def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
         self.get_calls.append((url, params))
+        if is_vault_browser_get(url):
+            return default_vault_browser_payload()
         return self.payloads.pop(0)
 
     def post(self, url: str, *, json: dict[str, Any]) -> dict[str, Any]:
@@ -104,7 +110,10 @@ def test_body_apply_calls_canvas_api() -> None:
             },
         ),
     ]
-    assert client.get_calls == [
+    workspace_get_calls = [
+        call for call in client.get_calls if call[0] == "/api/companion/workspace"
+    ]
+    assert workspace_get_calls == [
         ("/api/companion/workspace", {"note_path": "Notes/canvas.md"}),
         ("/api/companion/workspace", {"note_path": "Notes/canvas.md"}),
     ]

--- a/tests/companion_ui/test_suggestion_flow_browser.py
+++ b/tests/companion_ui/test_suggestion_flow_browser.py
@@ -13,6 +13,10 @@ from companion_ui.workspace.real_note_workspace_dev_page import (
     RealNoteWorkspaceDevPage,
 )
 from companion_ui.workspace.serve_dev_page import render_index_html
+from tests.companion_ui.vault_browser_test_helpers import (
+    default_vault_browser_payload,
+    is_vault_browser_get,
+)
 
 
 class _FakeClient:
@@ -20,6 +24,8 @@ class _FakeClient:
         self.payload = payload
 
     def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        if is_vault_browser_get(url):
+            return default_vault_browser_payload()
         assert url == "/api/companion/workspace"
         assert params == {"note_path": "Notes/suggestion.md"}
         return self.payload

--- a/tests/companion_ui/test_suggestion_layout_browser.py
+++ b/tests/companion_ui/test_suggestion_layout_browser.py
@@ -10,6 +10,10 @@ from companion_ui.workspace.real_note_workspace_dev_page import (
     RealNoteWorkspaceDevPage,
 )
 from companion_ui.workspace.serve_dev_page import render_index_html
+from tests.companion_ui.vault_browser_test_helpers import (
+    default_vault_browser_payload,
+    is_vault_browser_get,
+)
 
 
 class _FakeClient:
@@ -23,6 +27,8 @@ class _FakeClient:
         self.variant = variant
 
     def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        if is_vault_browser_get(url):
+            return default_vault_browser_payload()
         assert url == "/api/companion/workspace"
         assert params == {"note_path": "Notes/canvas.md"}
         return {

--- a/tests/companion_ui/vault_browser_test_helpers.py
+++ b/tests/companion_ui/vault_browser_test_helpers.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def default_vault_browser_payload() -> dict[str, Any]:
+    return {
+        "notes": [],
+        "query": "",
+        "total_notes": 0,
+        "filtered_notes": 0,
+        "read_only": True,
+        "vault_identity": {
+            "vault_name": "Niflheim",
+            "channel": "dev",
+            "provenance": "test",
+        },
+        "identity_available": True,
+        "active_filters": {},
+    }
+
+
+def is_vault_browser_get(url: str) -> bool:
+    return url == "/api/companion/vault-browser" or url.endswith(
+        "/api/companion/vault-browser"
+    )


### PR DESCRIPTION
## Direct Repair
Type: code
Reason: User requested repairing the failing unit/non-PG test suite directly; no governing GitHub Issue was provided, and the repair is bounded to restoring existing test and validation contracts.
Validation: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg"`, `ruff check app tests`, `mypy app`, `python -m app.cli settings-validate --json`
Issue required: no

## Summary
- Update Companion UI browser test doubles to account for the read-only Vault Browser request made during workspace loads.
- Align health/outbox counting, runtime env export precedence, reset-to-zero idempotence, and minor typing issues with existing contracts so the standard validation set passes.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg"` — 3868 passed, 97 skipped, 9 deselected
- `ruff check app tests` — passed
- `mypy app` — passed
- `python -m app.cli settings-validate --json` — `ok: true`

---
