### PR TITLE
docs(companion-ui): add Obsidian compatibility matrix and renderer contract

### DIFF
--- a/companion-ui/docs/OBSIDIAN_COMPATIBILITY_MATRIX.md
+++ b/companion-ui/docs/OBSIDIAN_COMPATIBILITY_MATRIX.md
@@ -1,0 +1,341 @@
+---
+name: Obsidian Compatibility Matrix
+description: Source-of-truth matrix for Obsidian compatibility in Companion UI's note surface — phases, mutation risk, and explicit non-goals
+doc_role: Compatibility specification
+authority: SoT for Obsidian syntax compatibility decisions in Companion UI. Binding on all Companion UI renderer and editor implementation work.
+owner: Companion UI / note surface
+temporal_class: strategic
+review_cadence: event-driven
+last_reviewed: 2026-05-25
+last_verified_against: |
+  companion-ui/docs/VAULT_MARKDOWN_RENDERER_CONTRACT.md,
+  companion-ui/docs/COMPANION_UI_TARGET_ARCHITECTURE.md,
+  companion-ui/docs/UI_RUNTIME_BOUNDARIES.md,
+  companion-ui/docs/PANEL_COMPANION_UI_CONTRACT.md,
+  companion-ui/docs/CANVAS_SUGGESTION_FLOW.md,
+  docs/COMPANION_UI_PRODUCT_SPEC.md,
+  docs/ARCHITECTURE.md,
+  docs/DESIGN_PRINCIPLES.md
+---
+
+# Obsidian Compatibility Matrix
+
+## 1. Purpose and Scope
+
+This document is the source-of-truth matrix for Obsidian compatibility in the Companion UI
+note surface.
+
+It defines:
+
+- the compatibility target (Reading View-like, not Live Preview parity),
+- the architectural posture governing how far Companion UI follows Obsidian conventions,
+- a feature-by-feature matrix with phase, mutation risk, and test-fixture requirement,
+- explicit non-goals and stop conditions.
+
+This document is not an implementation spec. Implementation details live in
+`companion-ui/docs/VAULT_MARKDOWN_RENDERER_CONTRACT.md` and the bounded GitHub issues created
+from this matrix.
+
+---
+
+## 2. Architectural Posture
+
+**Obsidian remains the primary interaction surface for now.**
+
+Companion UI is a cognitive prosthesis — a surface for reading, orienting, resuming, reviewing,
+safely staging suggestions, inspecting provenance, and collaborating with agents around Markdown
+notes. It is not an Obsidian replacement, not an Obsidian clone, and not a general-purpose
+Markdown editor.
+
+The note rendering surface in Companion UI must:
+
+- reduce cognitive load by preserving Obsidian-familiar note semantics;
+- render the note body consistently with how Obsidian presents it in Reading View;
+- never become a hidden source of semantic authority over note content;
+- never allow renderer or editor choices to bypass Panel, Canvas suggestion flow,
+  GovernanceRouter, WriteGuard, receipts, or session-log provenance.
+
+**Markdown files are the durable human source of truth.** DB/index/store projections are
+rebuildable mirrors. The renderer is not semantic authority.
+
+**Companion UI does not directly write vault files.** All mutations must route through the
+governed runtime execution path (policy, WriteGuard, idempotency, deterministic note-writer,
+receipt).
+
+---
+
+## 3. Compatibility Target
+
+**Target: Obsidian Reading View-like behavior for a safe subset of Obsidian syntax.**
+
+This means:
+
+- The rendered output of a vault note in Companion UI should look and feel like Obsidian
+  Reading View for supported constructs.
+- Unsupported constructs render as diagnostics, placeholders, or source blocks — not silent
+  failures.
+- Plugin-dependent behavior is outside scope.
+- Live Preview parity is explicitly out of scope.
+- Full Obsidian clone is explicitly out of scope.
+
+---
+
+## 4. Explicit Non-Goals
+
+The following are not targets for this workstream:
+
+- Full Obsidian clone or visual pixel-parity.
+- Obsidian Live Preview parity (rich WYSIWYG over raw Markdown).
+- Plugin execution or plugin CSS compatibility.
+- Dataview execution.
+- Editable transclusion.
+- Automatic link rename mutation.
+- Task checkbox toggling until a governed write contract exists.
+- Frontmatter editing until a governance route through Panel/governance exists.
+- Custom CSS snippet compatibility.
+- Cross-vault global search execution within the renderer.
+- PDF viewer (unless already available as a safe viewer).
+- Audio/video players (unless already available).
+- Canvas diagram editing.
+
+Companion UI does not claim to replace Obsidian. Both surfaces co-exist; Companion UI must
+minimize friction for users who use Obsidian daily.
+
+---
+
+## 5. Compatibility Matrix
+
+Legend:
+
+- **Phase**: `Adopt now` | `Adopt soon` | `Spike` | `Diagnostic only` | `Inspiration only` | `Reject/defer`
+- **Mutation risk**: `None (read-only)` | `Low (UI state only)` | `Governed (requires write contract)`
+- **Fixture required**: `Yes` | `No`
+
+### 5.1 CommonMark / Base Markdown
+
+| Feature | Syntax example | Companion UI target | Phase | Mutation risk | Fixture required | Notes |
+|---|---|---|---|---|---|---|
+| Headings | `# H1` … `###### H6` | Render as heading elements with anchor IDs | Adopt now | None | Yes | Heading IDs needed for outline/link fragments |
+| Paragraphs | Plain text blocks | Render as `<p>` | Adopt now | None | Yes | |
+| Ordered lists | `1. item` | Render as `<ol>` | Adopt now | None | Yes | |
+| Unordered lists | `- item` / `* item` | Render as `<ul>` | Adopt now | None | Yes | |
+| Nested lists | Indented lists | Render nested | Adopt now | None | Yes | |
+| Blockquotes | `> text` | Render as `<blockquote>` | Adopt now | None | Yes | Obsidian callouts override the bare blockquote for `[!type]` blocks |
+| Horizontal rules | `---` / `***` | Render as `<hr>` | Adopt now | None | No | |
+| Inline emphasis | `*em*` / `**strong**` / `***bold-em***` | Render appropriately | Adopt now | None | Yes | |
+| Inline code | `` `code` `` | Render as `<code>` | Adopt now | None | Yes | |
+| Fenced code blocks | ` ```lang\ncode\n``` ` | Render with language class; syntax-highlight where safe | Adopt now | None | Yes | See CodeBlockRenderer; Mermaid is a special fenced block case |
+| Syntax highlighting | Language-tagged fenced blocks | Highlight via safe client-side library | Adopt now | None | Yes | Must not execute code |
+
+### 5.2 GFM Extensions
+
+| Feature | Syntax example | Companion UI target | Phase | Mutation risk | Fixture required | Notes |
+|---|---|---|---|---|---|---|
+| GFM tables | `\| A \| B \|` | Render as table | Adopt now | None | Yes | remark-gfm |
+| GFM task lists | `- [ ] item` / `- [x] item` | Render as visual checkbox; no toggle | Adopt now | Governed (toggling deferred) | Yes | Toggling is mutation; defer until governed write contract exists |
+| Nonstandard task checkbox states | `- [/] item` / `- [-] item` etc. | Render as styled read-only checkbox | Adopt now | Governed | Yes | Visual representation only; do not normalize the symbol |
+| GFM strikethrough | `~~text~~` | Render as `<s>` | Adopt now | None | Yes | |
+| GFM autolinks | `https://...` | Render as external link | Adopt now | None | No | |
+| GFM footnotes | `[^1]` | Render if remark-gfm supports it | Adopt soon | None | No | Low priority |
+
+### 5.3 Standard Markdown Links and Images
+
+| Feature | Syntax example | Companion UI target | Phase | Mutation risk | Fixture required | Notes |
+|---|---|---|---|---|---|---|
+| Ordinary Markdown links | `[text](url)` | Render as link; external URLs open externally | Adopt now | None | Yes | Internal relative paths route through link resolver |
+| Ordinary Markdown images | `![alt](path)` | Render through VaultAssetResolver | Adopt now | None | Yes | Must not use file:// directly |
+
+### 5.4 Obsidian Wikilinks
+
+| Feature | Syntax example | Companion UI target | Phase | Mutation risk | Fixture required | Notes |
+|---|---|---|---|---|---|---|
+| Basic wikilink | `[[Note]]` | Parse and render as internal navigation link | Adopt now | None | Yes | |
+| Wikilink with alias | `[[Note\|Alias]]` | Render Alias as display text | Adopt now | None | Yes | |
+| Heading link | `[[Note#Heading]]` | Parse target + heading fragment | Adopt now | None | Yes | |
+| Local heading link | `[[#Heading]]` | Scroll/focus within current document | Adopt now | None | Yes | |
+| Nested heading link | `[[Note#H2#H3]]` if supported | Parse where possible; diagnostic otherwise | Adopt soon | None | No | Obsidian support is limited |
+| Block link | `[[Note#^block-id]]` | Parse; render as link to anchor or diagnostic | Adopt now | None | Yes | Block ID anchors may not exist in rendered HTML |
+| Local block link | `[[^local-block]]` | Same as block link scoped to current doc | Adopt now | None | Yes | |
+| Wikilink with heading alias | `[[Note#Heading\|Alias]]` | Parse; render Alias | Adopt now | None | Yes | |
+| Missing note link | Link to non-existent note | Render as visible missing-link diagnostic | Adopt now | None | Yes | Do not auto-create the note |
+| Ambiguous note link | Link matches multiple notes | Render as ambiguous-link diagnostic | Adopt now | None | Yes | Do not resolve silently |
+| Link rename mutation | Auto-update `[[Old]]` → `[[New]]` | Reject/defer | Reject/defer | Governed | No | Out of scope |
+
+### 5.5 Obsidian Embeds
+
+| Feature | Syntax example | Companion UI target | Phase | Mutation risk | Fixture required | Notes |
+|---|---|---|---|---|---|---|
+| Image embed | `![[image.png]]` | Render through VaultAssetResolver | Adopt now | None | Yes | |
+| Image embed with width | `![[image.png\|100]]` | Parse width; apply to rendered image | Adopt now | None | Yes | |
+| Image embed with width×height | `![[image.png\|100x145]]` | Parse both dimensions | Adopt now | None | Yes | |
+| Note embed | `![[Some Note]]` | Diagnostic placeholder (render-only later) | Diagnostic only → Adopt soon | None | Yes | Full transclusion is complex; start with placeholder |
+| Heading embed | `![[Note#Heading]]` | Diagnostic placeholder initially | Diagnostic only | None | Yes | |
+| Block embed | `![[Note#^block-id]]` | Diagnostic placeholder initially | Diagnostic only | None | Yes | |
+| PDF embed | `![[document.pdf]]` | Diagnostic placeholder unless safe viewer exists | Diagnostic only | None | Yes | |
+| PDF embed with page | `![[document.pdf#page=3]]` | Parse page hint; show in placeholder | Diagnostic only | None | No | |
+| Audio embed | `![[audio.mp3]]` | Diagnostic placeholder | Diagnostic only | None | No | |
+| Video embed | `![[video.mp4]]` | Diagnostic placeholder | Diagnostic only | None | No | |
+| Canvas embed | `![[diagram.canvas]]` | Diagnostic placeholder | Diagnostic only | None | Yes | |
+| List embed | `![[Note^list-block]]` | Diagnostic placeholder | Diagnostic only | None | No | |
+| Search embed | `![[query/...]]` | Diagnostic placeholder; do not execute query | Diagnostic only | None | No | Search execution is out of scope |
+| Editable transclusion | In-place editing of embedded note | Reject/defer | Reject/defer | Governed | No | Cross-note mutation; out of scope |
+
+### 5.6 Obsidian Callouts
+
+| Feature | Syntax example | Companion UI target | Phase | Mutation risk | Fixture required | Notes |
+|---|---|---|---|---|---|---|
+| Basic callout | `> [!note]` | Render with type styling | Adopt now | None | Yes | |
+| Callout with custom title | `> [!warning] My Title` | Render title text | Adopt now | None | Yes | |
+| Foldable callout (collapsed) | `> [!tip]-` | Render collapsed; expand on click | Adopt now | Low (UI state) | Yes | Fold state is UI-local; no mutation |
+| Foldable callout (expanded) | `> [!tip]+` | Render expanded by default | Adopt now | Low (UI state) | Yes | |
+| Nested callouts | Callout inside callout | Render nested | Adopt now | None | Yes | |
+| Callout with title only (no body) | `> [!note] Title only` | Render as title-only callout | Adopt now | None | Yes | |
+| Unsupported/custom callout type | `> [!custom]` | Default to note-like visual treatment | Adopt now | None | Yes | Do not error |
+| Markdown inside callout | `> [!note]\n> **bold** [[link]]` | Render nested Markdown/wikilinks | Adopt now | None | Yes | |
+| Wikilinks/embeds inside callout | `> [!tip]\n> ![[img.png]]` | Render via same resolver pipeline | Adopt now | None | Yes | |
+
+### 5.7 Properties / Frontmatter
+
+| Feature | Syntax example | Companion UI target | Phase | Mutation risk | Fixture required | Notes |
+|---|---|---|---|---|---|---|
+| YAML frontmatter | `---\ntitle: X\n---` | Render in read-only properties surface | Adopt now | None | Yes | Do not render as body text |
+| Tags property | `tags: [foo, bar]` | Render as read-only tag chips | Adopt now | None | Yes | |
+| Aliases property | `aliases: [Alt Name]` | Render as read-only values | Adopt now | None | Yes | |
+| Malformed frontmatter | Invalid YAML | Show diagnostic, render body anyway | Adopt now | None | Yes | |
+| Frontmatter editing | UI-side edit of properties | Reject/defer | Reject/defer | Governed | No | Requires governance route through Panel/governance |
+
+### 5.8 Comments
+
+| Feature | Syntax example | Companion UI target | Phase | Mutation risk | Fixture required | Notes |
+|---|---|---|---|---|---|---|
+| Obsidian comments | `%% comment %%` | Hidden in Reading View; available in source/inspect mode | Adopt soon | None | Yes | Comments must be parsed and stripped from rendered output |
+
+### 5.9 Diagrams
+
+| Feature | Syntax example | Companion UI target | Phase | Mutation risk | Fixture required | Notes |
+|---|---|---|---|---|---|---|
+| Mermaid fenced blocks | ` ```mermaid\n...\n``` ` | Render via controlled Mermaid component | Adopt now | None | Yes | Render-only; no interactive editing |
+| MathJax / LaTeX | `$$...$$` / `$...$` | Render if safe schema can be defined | Adopt soon | None | No | Safety schema must be explicit before adoption |
+
+### 5.10 HTML
+
+| Feature | Syntax example | Companion UI target | Phase | Mutation risk | Fixture required | Notes |
+|---|---|---|---|---|---|---|
+| Inline HTML | `<span style="...">` | Sanitized or disabled via rehype-sanitize | Adopt now | None | Yes | Raw HTML must be sanitized; script execution forbidden |
+| Unsafe HTML / script tags | `<script>...` | Strip/sanitize; never execute | Adopt now | None | Yes | |
+| Remote images via HTML | `<img src="https://...">` | Block by default or require explicit policy | Adopt now | None | Yes | Remote image policy must be explicit and test-covered |
+
+### 5.11 Plugins and Extended Syntax
+
+| Feature | Syntax example | Companion UI target | Phase | Mutation risk | Fixture required | Notes |
+|---|---|---|---|---|---|---|
+| Dataview blocks | ` ```dataview\nTABLE...\n``` ` | Diagnostic placeholder; never execute | Diagnostic only | None | Yes | Do not execute Dataview queries |
+| Other plugin code blocks | ` ```plugin-name\n...\n``` ` | Diagnostic placeholder | Diagnostic only | None | No | |
+| Full plugin runtime | Any Obsidian plugin behavior | Reject/defer | Reject/defer | N/A | No | Out of scope |
+
+### 5.12 Navigation and Orientation Affordances
+
+| Feature | Companion UI target | Phase | Mutation risk | Fixture required | Notes |
+|---|---|---|---|---|---|
+| Note outline (heading navigation) | Read-only heading outline panel | Adopt soon | None | No | Must not mutate document |
+| Hover/page preview | Read-only popover for internal links | Adopt soon | None | No | Bounded read-only rendering only; no unbounded recursion |
+| Read-only backlinks | List of inbound links to current note | Adopt soon | None | No | Read from API; no in-renderer link scanning |
+| Local graph | Visual graph of note relations | Inspiration only | None | No | Complex; deferred |
+| Command palette | UI command dispatch | Inspiration only | N/A | No | Complex; deferred |
+| Plugin compatibility | CSS/behavior from Obsidian plugins | Reject/defer | N/A | No | Out of scope |
+
+---
+
+## 6. Mutation / Governance Boundary
+
+The following affordances are **read-only in Companion UI**:
+
+- Note content rendering.
+- Properties/frontmatter display.
+- Wikilink/embed display.
+- Callout expand/collapse (local UI state only).
+- Outline navigation (scroll/focus; no rename).
+- Hover preview (read rendering only).
+- Backlinks display (read from API).
+
+The following affordances **require a governed write contract** before they may be implemented:
+
+- Task checkbox toggling.
+- Frontmatter/property editing.
+- Note creation from missing links.
+- Automatic link rename/update.
+- Inline note embed editing (transclusion editing).
+- AI suggestion application (must route through Canvas body-edit lane or governance queue).
+
+**No renderer implementation may bypass Panel, Canvas suggestion flow, GovernanceRouter,
+WriteGuard, receipts, or session-log provenance.**
+
+Editor adoption must not introduce write paths that are not governed by the existing contracts.
+Milkdown, MDXEditor, CodeMirror, or any other rich editor must be adopted only after proving:
+
+1. Obsidian-flavored Markdown round-trip preservation without silent mutation.
+2. Frontmatter preservation.
+3. Wikilink, embed, callout, comment, and Mermaid block preservation.
+4. Write interception compatible with existing governance pipeline.
+
+---
+
+## 7. Phasing
+
+### Phase 1 — Adopt now
+
+Core note reading surface: basic Markdown, GFM, wikilinks, internal links, image embeds,
+image sizing, callouts, Mermaid render-only, properties/frontmatter split, unsafe HTML
+sanitization, unsupported syntax diagnostics.
+
+Implementation target: VaultMarkdownRenderer wired to main note area. Parser, link resolver,
+asset resolver, and sanitization boundaries in place. Fixture suite covers all Adopt-now rows.
+
+### Phase 2 — Adopt soon
+
+Note outline, hover/link preview, read-only backlinks, read-only properties panel, MathJax
+(if safe schema defined), comments hidden in reading view but available in inspect/source mode.
+
+### Phase 3 — Spike
+
+Source-mode editor adapter (CodeMirror); rich editor spike (Milkdown, MDXEditor) against
+Obsidian compatibility fixtures.
+
+### Phase 4 — Diagnostic only → later adoption
+
+Note embeds (full transclusion), heading/block embeds, PDF/audio/video/canvas/search embeds.
+Upgrade from diagnostic to adopted when a safe implementation path is confirmed and governed.
+
+### Phase 5 — Reject/defer
+
+Plugin runtime, Dataview execution, editable transclusion, automatic link rename mutation,
+frontmatter editing without governance route, full Live Preview parity, full Obsidian clone.
+
+---
+
+## 8. Stop Conditions
+
+- If a renderer or editor choice would allow bypassing Panel, Canvas suggestion flow,
+  GovernanceRouter, WriteGuard, receipts, or session-log provenance: **stop, do not proceed**.
+- If a renderer or editor choice requires changing stored Markdown semantics: **stop**.
+- If a feature marked Adopt now requires arbitrary file-system access from the browser:
+  **stop and split the asset-resolution boundary into a separate governed issue**.
+- If plugin-execution behavior is required for a feature: **stop and mark Reject/defer**.
+- If a rich editor (Milkdown, MDXEditor) cannot preserve Obsidian-flavored Markdown in a
+  round-trip test: **reject or defer the editor choice until the round-trip is proven**.
+- If MathJax safety schema cannot be defined without allowing script execution: **stay at
+  Diagnostic only until the schema is defined**.
+
+---
+
+## 9. Source Anchors and Related Docs
+
+- `companion-ui/docs/VAULT_MARKDOWN_RENDERER_CONTRACT.md` — renderer contract and component boundaries
+- `companion-ui/docs/COMPANION_UI_TARGET_ARCHITECTURE.md` — hosting and vault-boundary rules
+- `companion-ui/docs/UI_RUNTIME_BOUNDARIES.md` — cognitive boundary constraints
+- `companion-ui/docs/PANEL_COMPANION_UI_CONTRACT.md` — Panel write-back boundary
+- `companion-ui/docs/CANVAS_SUGGESTION_FLOW.md` — Canvas suggestion flow governance
+- `docs/COMPANION_UI_PRODUCT_SPEC.md` — product mode model and non-goals
+- `docs/DESIGN_PRINCIPLES.md` — boundary-first design and explicit mutation authority
+- `docs/ARCHITECTURE.md` — current runtime architecture
+- `docs/FRONTMATTER.md` — frontmatter rules and ownership

--- a/companion-ui/docs/README.md
+++ b/companion-ui/docs/README.md
@@ -18,9 +18,12 @@ Foundational documents for cognitive interaction architecture.
 - `FUTURE_RESEARCH.md`
 - `DESIGN_BRIEF.md` (preserved source brief)
 
+## Obsidian-compatible note surface
+- `OBSIDIAN_COMPATIBILITY_MATRIX.md` — source-of-truth matrix for Obsidian syntax compatibility in Companion UI: compatibility target (Reading View-like), feature-by-feature phase assignments (adopt now / adopt soon / spike / diagnostic only / reject/defer), mutation/governance boundary, stop conditions. Workstream: Companion UI Obsidian-Compatible Note Surface.
+- `VAULT_MARKDOWN_RENDERER_CONTRACT.md` — contract for read-only Companion UI rendering of vault Markdown: document model (VaultMarkdownDocument, WikiLinkRef, EmbedRef, etc.), parser/renderer/resolver responsibilities, component boundaries (VaultMarkdownRenderer, ObsidianCalloutRenderer, MermaidBlockRenderer, etc.), security model, governance boundary, test contract, editor-adapter boundary. Workstream: Companion UI Obsidian-Compatible Note Surface.
+
 ## Surface contracts and feature implementation specs
 - `WORKSPACE_STATE_CONTRACT.md` — read-side aggregate contract for `GET /api/companion/workspace`, combining artifact, runtime, Canvas, Panel, suggestion, and guard state without creating a new authority surface. Governing issue: #1122.
-- `VAULT_BROWSER_UI_REQUIREMENTS.md` — Companion UI requirements for Vault Browser / Workspace behavior derived from user UAT feedback and the Claude Design Vault Browser Foundation handoff; downstream Vault Browser / Workspace UI implementation issues must read it before coding. It is constrained by `docs/VAULT_BROWSER_CAPABILITY_CONTRACT.md` and other SoT docs.
 - `CANVAS_BROWSER_EDITOR_DECISION.md` — decision record choosing `textarea` as the interim Canvas browser editor primitive and preserving full-body replacement semantics. Governing issue: #1126.
 - `PANEL_STATE_DISCOVERY_DELTA.md` — Panel browser discovery gap analysis; confirms the workspace aggregate is sufficient for the current slice. Governing issue: #1127.
 - `CANVAS_AGENT_MVP_CONTRACT.md` — normalized Canvas Agent MVP surface contract: co-authoring posture, session lifecycle, user-present authority, direct in-place editing, undo/rollback, `.chats/` provenance, governance-bearing escape hatch, distinction from Panel and from Canvas bounded suggestion flow. Governing issue: #1021.

--- a/companion-ui/docs/VAULT_MARKDOWN_RENDERER_CONTRACT.md
+++ b/companion-ui/docs/VAULT_MARKDOWN_RENDERER_CONTRACT.md
@@ -1,0 +1,531 @@
+---
+name: Vault Markdown Renderer Contract
+description: Contract for read-only Companion UI rendering of vault Markdown using Obsidian-compatible semantics — parser, resolver, component, security, and governance boundaries
+doc_role: Implementation contract
+authority: SoT for Companion UI vault Markdown rendering. Binding on all renderer, parser, link resolver, asset resolver, and editor-adapter implementation work.
+owner: Companion UI / note surface
+temporal_class: strategic
+review_cadence: event-driven
+last_reviewed: 2026-05-25
+last_verified_against: |
+  companion-ui/docs/OBSIDIAN_COMPATIBILITY_MATRIX.md,
+  companion-ui/docs/COMPANION_UI_TARGET_ARCHITECTURE.md,
+  companion-ui/docs/UI_RUNTIME_BOUNDARIES.md,
+  companion-ui/docs/PANEL_COMPANION_UI_CONTRACT.md,
+  companion-ui/docs/CANVAS_SUGGESTION_FLOW.md,
+  docs/COMPANION_UI_PRODUCT_SPEC.md,
+  docs/DESIGN_PRINCIPLES.md,
+  docs/ARCHITECTURE.md
+---
+
+# Vault Markdown Renderer Contract
+
+## 1. Purpose
+
+Define the contract for read-only Companion UI rendering of vault Markdown using
+Obsidian-compatible semantics.
+
+This document governs:
+
+- the document model produced by the parser,
+- the responsibilities of the renderer, link resolver, and asset resolver,
+- the security model for browser-side rendering,
+- the governance boundary separating rendering from mutation,
+- the test contract for fixture-driven verification,
+- stop conditions for renderer and editor-adapter work.
+
+This document does not implement any component. Implementation belongs to bounded GitHub
+issues sourced from this contract and from
+`companion-ui/docs/OBSIDIAN_COMPATIBILITY_MATRIX.md`.
+
+---
+
+## 2. Non-Goals
+
+The following are explicitly outside this contract:
+
+- Full Obsidian clone or visual pixel-parity.
+- Obsidian Live Preview parity.
+- Plugin execution or plugin CSS compatibility.
+- Dataview execution.
+- Any renderer-side vault file writes.
+- Editor selection or rich-editor adoption.
+- In-place editing, autosave, or task checkbox toggling.
+- Frontmatter editing.
+- Editable transclusion or automatic link rename mutation.
+- Remote file loading outside the API boundary.
+- Production UI styling or design-token application.
+
+---
+
+## 3. Architecture
+
+The renderer sits between the runtime API and the browser note surface.
+
+```
+Runtime API
+  └── GET /api/companion/workspace (artifact.raw_markdown)
+        │
+        ▼
+  [parseVaultMarkdown]
+        │  produces VaultMarkdownDocument
+        ▼
+  [VaultMarkdownRenderer]  ←── VaultLinkResolver (from API)
+        │                  ←── VaultAssetResolver (from API)
+        │
+        ▼
+  Browser note surface (read-only)
+```
+
+Key invariants:
+
+- **Vault files are never accessed directly.** All content comes through the runtime API.
+- **Vault paths are never exposed in the browser.** The renderer works with API-provided content
+  and resolver responses.
+- **The renderer is stateless with respect to vault state.** It does not cache, merge, or
+  infer note content.
+- **The renderer does not call write endpoints.** Rendering is a read-only operation.
+- **Resolver calls are the only side effects allowed during render.**
+
+---
+
+## 4. Data Model
+
+The following types define the conceptual data model. Implementations may use equivalent
+representations in the target language (TypeScript, Python, etc.).
+
+### VaultMarkdownDocument
+
+```typescript
+type VaultMarkdownDocument = {
+  rawMarkdown: string
+  frontmatter: string | null        // raw YAML frontmatter string or null
+  bodyMarkdown: string              // markdown body after frontmatter extraction
+  diagnostics: MarkdownDiagnostic[]
+  headings: HeadingRef[]
+  blockIds: BlockIdRef[]
+  wikilinks: WikiLinkRef[]
+  embeds: EmbedRef[]
+  assetRefs: AssetRef[]
+}
+```
+
+### MarkdownDiagnostic
+
+```typescript
+type MarkdownDiagnostic = {
+  severity: "info" | "warning" | "error"
+  code: string                      // stable diagnostic code for testing
+  message: string
+  sourceRange?: SourceRange         // optional: character range in rawMarkdown
+}
+```
+
+### HeadingRef
+
+```typescript
+type HeadingRef = {
+  level: 1 | 2 | 3 | 4 | 5 | 6
+  text: string
+  anchor: string                    // slug for in-page linking
+  sourceRange?: SourceRange
+}
+```
+
+### BlockIdRef
+
+```typescript
+type BlockIdRef = {
+  blockId: string                   // the ^block-id string
+  anchor: string                    // resolved anchor in rendered HTML
+  sourceRange?: SourceRange
+}
+```
+
+### WikiLinkRef
+
+```typescript
+type WikiLinkRef = {
+  raw: string                       // the full [[...]] text
+  target: string                    // note target (may include extension)
+  alias?: string                    // display text if alias present
+  heading?: string                  // heading fragment if present
+  blockId?: string                  // block ID fragment if present
+  localOnly?: boolean               // true for [[#heading]] and [[^block-id]]
+}
+```
+
+### EmbedRef
+
+```typescript
+type EmbedRef = {
+  raw: string                       // the full ![[...]] text
+  target: string                    // embed target
+  kind: "image" | "note" | "pdf" | "audio" | "video" | "canvas" | "unknown"
+  width?: number                    // parsed from |100 or |100x145
+  height?: number                   // parsed from |100x145
+  heading?: string                  // heading fragment for note embeds
+  blockId?: string                  // block ID fragment for block embeds
+}
+```
+
+### AssetRef
+
+```typescript
+type AssetRef = {
+  raw: string                       // the original markdown image syntax
+  target: string                    // image path or URL
+  alt?: string
+}
+```
+
+### LinkResolution
+
+```typescript
+type LinkResolution =
+  | { kind: "resolved"; notePath: string; displayText: string; heading?: string; blockId?: string }
+  | { kind: "missing"; displayText: string; reason: string }
+  | { kind: "ambiguous"; displayText: string; candidates: string[] }
+```
+
+### AssetResolution
+
+```typescript
+type AssetResolution =
+  | { kind: "allowed"; src: string; displayName: string; width?: number; height?: number }
+  | { kind: "missing"; displayName: string; reason: string }
+  | { kind: "blocked"; displayName: string; reason: string }
+  | { kind: "unsupported"; displayName: string; reason: string }
+```
+
+---
+
+## 5. Parser Responsibilities
+
+`parseVaultMarkdown(rawMarkdown: string): VaultMarkdownDocument`
+
+The parser:
+
+- **Preserves** `rawMarkdown` without modification.
+- **Extracts frontmatter** (YAML between opening and closing `---` delimiters) into
+  `frontmatter`; sets it to `null` if absent.
+- **Produces `bodyMarkdown`** as the portion of `rawMarkdown` after frontmatter extraction,
+  without any semantic change to the text.
+- **Extracts `headings`** with level, text, and anchor slug.
+- **Extracts `blockIds`** — Obsidian block ID markers (`^block-id`) with their anchors.
+- **Extracts `wikilinks`** — all `[[...]]` patterns including aliases, heading fragments,
+  block ID fragments, and local-only variants.
+- **Extracts `embeds`** — all `![[...]]` patterns with classification, size hints, and
+  sub-target fragments.
+- **Extracts `assetRefs`** — standard Markdown image syntax `![alt](path)`.
+- **Extracts Obsidian comments** — `%% ... %%` patterns; these are suppressed in rendered
+  output but may be available in source/inspect mode.
+- **Emits `diagnostics`** for malformed frontmatter (parse error), unrecognized embed types,
+  and syntax that falls into the Diagnostic-only phase.
+- **Does not mutate** source text.
+- **Does not resolve** links or assets (that is the resolver's job).
+- **Does not render** anything (that is the renderer's job).
+
+---
+
+## 6. Renderer Responsibilities
+
+`VaultMarkdownRenderer` takes a `VaultMarkdownDocument` and produces browser-safe rendered
+output (HTML via React or equivalent).
+
+### Required sub-renderers
+
+| Component | Responsibility |
+|---|---|
+| `PropertiesRenderer` | Render frontmatter as read-only structured metadata surface |
+| `InternalLinkRenderer` | Render wikilinks using `VaultLinkResolver`; display resolved/missing/ambiguous states |
+| `ObsidianEmbedRenderer` | Render embeds using `VaultAssetResolver`; dispatch by `kind` |
+| `VaultImageRenderer` | Render image embeds and standard Markdown images via `VaultAssetResolver` |
+| `ObsidianCalloutRenderer` | Detect and render `> [!type]` callouts; local fold state; nested callouts |
+| `MermaidBlockRenderer` | Render fenced `mermaid` blocks via controlled Mermaid component with error boundary |
+| `CodeBlockRenderer` | Render fenced code blocks with syntax highlighting; must not execute code |
+| `UnsupportedBlockDiagnostic` | Render a visible diagnostic for Dataview, plugin blocks, and unsupported constructs |
+
+### Future sub-renderers (do not implement now)
+
+| Component | Purpose |
+|---|---|
+| `NoteOutline` | Read-only outline from `headings` |
+| `LinkPreview` | Hover/focus preview popover for internal links |
+
+### Renderer invariants
+
+- The renderer does not call write endpoints.
+- The renderer does not read vault files directly.
+- The renderer does not emit navigation events as mutations.
+- The renderer does not store resolved content in durable state.
+- Clicking an internal link is a navigation event, not a mutation.
+- Expanding or folding a callout is local UI state, not a mutation.
+- Rendering frontmatter/properties is read-only.
+- Toggling task checkboxes is out of scope until a governed write contract exists.
+- Unsupported constructs render as `UnsupportedBlockDiagnostic`, not as silent gaps.
+
+---
+
+## 7. Resolver Responsibilities
+
+### VaultLinkResolver
+
+```typescript
+interface VaultLinkResolver {
+  resolve(params: {
+    notePath: string       // path of the note being rendered
+    rawTarget: string      // wikilink target string
+    heading?: string
+    blockId?: string
+    alias?: string
+  }): LinkResolution
+}
+```
+
+The resolver:
+
+- Returns `resolved`, `missing`, or `ambiguous` — never throws or returns undefined.
+- Does not create missing notes.
+- Does not rename or update links.
+- Does not cache results across note loads (caching is an implementation concern, not a contract).
+
+The `resolved` variant provides the `notePath` needed for navigation intent emission.
+Navigation intent must be emitted by the renderer, not executed as a mutation.
+
+### VaultAssetResolver
+
+```typescript
+interface VaultAssetResolver {
+  resolve(params: {
+    notePath: string
+    rawTarget: string
+    kind: "markdown-image" | "obsidian-embed"
+  }): AssetResolution
+}
+```
+
+The resolver:
+
+- Returns `allowed`, `missing`, `blocked`, or `unsupported` — never throws.
+- Does not read vault files directly.
+- Does not expose vault filesystem paths to the browser.
+- `blocked` is used when the asset policy forbids the request (e.g., unsupported embed type
+  in the current phase, or remote image blocked by policy).
+- `unsupported` is used for embed kinds in the Diagnostic-only phase.
+
+---
+
+## 8. Security Model
+
+### Hard rules
+
+1. **No direct local file access.** The renderer and resolvers must not use
+   `file://`, `fs.readFileSync`, or equivalent to read vault content.
+2. **No vault path exposure.** Vault filesystem paths must never appear in browser-side
+   HTML, scripts, or network requests.
+3. **All local assets through VaultAssetResolver.** Local images and embeds must be
+   resolved through the resolver, which proxies through the runtime API.
+4. **All internal navigation through VaultLinkResolver.** Internal links must not be
+   resolved directly to vault paths in the browser.
+5. **Raw HTML sanitized or disabled.** rehype-sanitize (or equivalent) must be applied
+   after all plugin transformations. Sanitization schema must be explicit and tested.
+6. **Script execution forbidden.** `<script>` tags, `javascript:` URLs, and inline
+   event handlers must be stripped by sanitization.
+7. **Mermaid render-only with error boundary.** Mermaid must be rendered in a controlled
+   component with a safe configuration (no external network calls, no file access). Mermaid
+   rendering failures must be caught and displayed as diagnostics, not propagate as crashes.
+8. **Dataview and plugin code must not execute.** Fenced blocks with plugin names render as
+   `UnsupportedBlockDiagnostic` or `CodeBlockRenderer` without execution.
+9. **Remote image policy must be explicit and test-covered.** The default policy must block
+   remote images or require explicit opt-in. The policy must be enforced by `VaultAssetResolver`
+   or the sanitization layer, not left to browser default.
+10. **Renderer must not call write endpoints.** No `POST`, `PUT`, `PATCH`, or `DELETE` calls
+    may originate from renderer code.
+
+### Recommended library stack
+
+For React-based implementation:
+
+- `react-markdown` — rendering base (CommonMark + custom component hooks)
+- `remark-gfm` — GFM tables, task lists, strikethrough, autolinks, footnotes
+- `rehype-sanitize` — strict post-transform HTML sanitization with project schema
+- Custom components for wikilinks, callouts, Mermaid, embeds, properties, diagnostics
+
+The sanitization schema must explicitly allow only the tags and attributes required by the
+renderer. It must not use the default permissive schema without review.
+
+---
+
+## 9. Governance Boundary
+
+The following table summarizes what the renderer may and may not do:
+
+| Action | Allowed | Notes |
+|---|---|---|
+| Display note content | Yes | Read-only |
+| Display frontmatter/properties | Yes | Read-only surface |
+| Display resolved wikilinks | Yes | Link text and styling |
+| Display missing/ambiguous link diagnostics | Yes | Required |
+| Emit navigation intent on link click | Yes | Navigation only; not mutation |
+| Expand/collapse callout | Yes | Local UI state only |
+| Display outline | Yes (phase 2) | Scroll/focus; not mutation |
+| Display hover preview | Yes (phase 2) | Read-only rendering |
+| Display read-only backlinks | Yes (phase 2) | From API; not renderer-computed |
+| Toggle task checkboxes | No | Requires governed write contract |
+| Edit frontmatter/properties | No | Requires governance route |
+| Create missing notes from links | No | Mutation; out of scope |
+| Rename/update links | No | Mutation; out of scope |
+| Edit embedded notes | No | Cross-note mutation; out of scope |
+| Apply AI suggestions via renderer | No | Must use Canvas body-edit lane or governance queue |
+| Execute Dataview queries | No | Out of scope |
+| Execute plugin code | No | Out of scope |
+| Write vault files directly | No | API boundary rule |
+| Autosave rendered state | No | Renderer is stateless |
+
+**AI suggestions applied through the renderer are not allowed.** Suggestion application must
+route through the Canvas body-edit lane or the governance queue lane, not through in-place
+renderer editing.
+
+---
+
+## 10. Test Contract
+
+All renderer, parser, resolver, and sub-component implementations must be covered by
+fixture-based tests.
+
+### Fixture location
+
+Fixtures live under:
+
+```
+companion-ui/companion-app/tests/fixtures/obsidian-renderer/
+```
+
+If no fixture convention exists at implementation time, create the directory at this path
+and document the choice in the implementing issue.
+
+### Required fixture files
+
+| File | Covers |
+|---|---|
+| `basic.md` | CommonMark headings, paragraphs, lists, blockquotes, emphasis, code |
+| `frontmatter-properties.md` | YAML frontmatter, tags, aliases, malformed YAML |
+| `wikilinks.md` | All wikilink variants: basic, alias, heading, block, local, missing, ambiguous |
+| `embeds-images.md` | Image embeds, size hints, standard images, unsupported embed types |
+| `callouts.md` | Basic, custom title, foldable +/−, nested, title-only, unsupported type |
+| `mermaid.md` | Valid Mermaid, invalid Mermaid, Mermaid inside callout |
+| `comments-and-html.md` | Obsidian comments `%% %%`, safe inline HTML, unsafe HTML/script |
+| `missing-links-assets.md` | Missing note links, missing images, ambiguous links, blocked assets |
+| `full-smoke.md` | All feature categories combined in a realistic note |
+
+### Fixture content requirements
+
+Every fixture file must include at minimum:
+
+- YAML frontmatter with at least `title`, `tags`, and `aliases`.
+- A representative sample of the constructs in its category.
+- At least one unsafe, missing, or unsupported case where applicable.
+- No executable code, no real vault paths, no real user data.
+
+The `full-smoke.md` fixture must include all of:
+
+- Frontmatter with tags and aliases.
+- H1–H3 headings.
+- GFM table.
+- GFM task list (standard and nonstandard states).
+- Wikilinks: basic, alias, heading, block, local heading, local block, missing.
+- Image embed: basic, width hint, width×height hint.
+- Callout: basic, custom title, foldable, nested.
+- Fenced Mermaid block.
+- Fenced code block with language.
+- Obsidian comment `%% hidden %%`.
+- Unsafe HTML `<script>` tag.
+- Dataview fenced block.
+
+### Test coverage targets
+
+- Parser: every WikiLinkRef variant, every EmbedRef variant, frontmatter extraction,
+  comment extraction, block ID extraction, diagnostics for malformed input.
+- Link resolver: resolved, missing, ambiguous paths.
+- Asset resolver: allowed, missing, blocked, unsupported paths.
+- Renderer: every fixture file passes without crash; unsafe HTML is stripped; diagnostics
+  appear for unsupported constructs; write endpoints are not called.
+- Security: script tags stripped, `file://` URLs blocked, remote images follow policy.
+
+---
+
+## 11. Stop Conditions
+
+- If renderer implementation would call a write endpoint: **stop**.
+- If resolver implementation would read vault files directly: **stop**.
+- If sanitization schema would allow `<script>` or `javascript:` : **stop**.
+- If Mermaid renderer cannot be configured without external network calls: **use
+  placeholder/diagnostic instead**.
+- If any editor adapter (CodeMirror, Milkdown, MDXEditor) cannot guarantee no autosave or
+  direct vault write: **reject the adapter**.
+- If a rich editor cannot prove Obsidian-flavored Markdown round-trip in fixture tests:
+  **defer the editor until round-trip is proven**.
+- If frontmatter editing is requested before a governance route exists: **stop and create a
+  governed issue**.
+- If task checkbox toggling is requested before a governed write contract exists: **stop**.
+
+---
+
+## 12. Future Editor-Adapter Boundary
+
+When a rich editor (CodeMirror, Milkdown, MDXEditor, or equivalent) is considered:
+
+### Required pre-conditions before adoption
+
+1. Obsidian-flavored Markdown round-trip passes all fixture tests without silent mutation.
+2. Frontmatter preservation proven in fixture tests.
+3. Wikilink, embed, callout, Obsidian comment, and Mermaid block preservation proven.
+4. MDX/JSX disabled or safely sandboxed if using MDXEditor.
+5. No autosave or direct vault write without explicit user action.
+6. Write interception is compatible with Panel/Canvas/GovernanceRouter/WriteGuard contracts.
+
+### NoteEditorAdapter conceptual interface
+
+Any editor adoption must implement or conform to a `NoteEditorAdapter` contract:
+
+```typescript
+interface NoteEditorAdapter {
+  getMarkdown(): string               // current editor Markdown content
+  setMarkdown(markdown: string): void // set content programmatically
+  getSelection(): SelectionRange | null
+  applyBodyPatch(patch: BodyPatch): void  // governed patch from Canvas/Panel
+  focusBlock?(blockId: string): void  // optional; focus a specific block
+}
+```
+
+Rules for any editor adapter:
+
+- `getMarkdown()` must return raw Markdown without mutation.
+- `setMarkdown()` must accept Obsidian-flavored Markdown without normalizing it.
+- `applyBodyPatch()` must be the only write path; it must route through the governance
+  pipeline, not bypass it.
+- No autosave or background write behavior is permitted.
+- The adapter must not expose vault paths in its internal state or API surface.
+
+### Spike posture
+
+Editor adoption follows a spike → fixture roundtrip → governed wire-up sequence.
+No editor adapter may be promoted to production until the spike produces a
+documented recommendation (adopt, defer, or reject) and the round-trip fixture test passes.
+
+---
+
+## 13. Relationship to Other Docs
+
+| Document | Relationship |
+|---|---|
+| `companion-ui/docs/OBSIDIAN_COMPATIBILITY_MATRIX.md` | Feature-by-feature phase assignments; upstream of this contract |
+| `companion-ui/docs/COMPANION_UI_TARGET_ARCHITECTURE.md` | Hosting, vault-boundary, and API-only access rules |
+| `companion-ui/docs/UI_RUNTIME_BOUNDARIES.md` | Cognitive boundary constraints |
+| `companion-ui/docs/PANEL_COMPANION_UI_CONTRACT.md` | Panel write-back boundary; governs suggestion application path |
+| `companion-ui/docs/CANVAS_SUGGESTION_FLOW.md` | Canvas body-edit lane; the governed path for AI suggestion application |
+| `docs/COMPANION_UI_PRODUCT_SPEC.md` | Product mode model; Companion UI non-goals |
+| `docs/DESIGN_PRINCIPLES.md` | Explicit mutation authority and boundary-first design |
+| `docs/FRONTMATTER.md` | Frontmatter rules and write contract |
+| `docs/ARCHITECTURE.md` | Current runtime architecture |


### PR DESCRIPTION
## Change Lane
- [ ] Implementation lane
- [x] Docs authoring lane
- [ ] Governance lane

Lane: Docs authoring lane

## Linked Issue
Closes #1293
Closes #1294

## Summary
- Adds the Obsidian compatibility matrix for the Companion UI note surface.
- Adds the Vault Markdown renderer contract and links both docs from the Companion UI docs index.

## Docs Authoring Check
- [x] This PR only changes approved docs-authoring surfaces.
- [x] No code, runtime behavior, or shipped reality changed.
- [x] This PR prepares authoritative documentation for later bounded implementation issues.

## Validation
Docs authoring lane:
- [x] `python3 scripts/docs_guard.py` -> passed
- [x] `git diff --check` -> passed

## Workflow Notes
- Dispatcher unavailable (`python3 -m app.dispatcher status --json` failed: missing `yaml` dependency), so I used GitHub-label-only claim for #1293 and #1294.
