### PR TITLE
feat(companion-ui): parse vault Markdown for renderer

### DIFF
--- a/companion-ui/companion-app/companion_ui/renderer/__init__.py
+++ b/companion-ui/companion-app/companion_ui/renderer/__init__.py
@@ -1,0 +1,31 @@
+"""Renderer-safe Markdown parsing models for Companion UI."""
+
+from companion_ui.renderer.models import (
+    AssetRef,
+    AssetResolution,
+    BlockIdRef,
+    EmbedRef,
+    HeadingRef,
+    LinkResolution,
+    MarkdownDiagnostic,
+    ObsidianCommentRef,
+    SourceRange,
+    VaultMarkdownDocument,
+    WikiLinkRef,
+)
+from companion_ui.renderer.vault_markdown_parser import parse_vault_markdown
+
+__all__ = [
+    "AssetRef",
+    "AssetResolution",
+    "BlockIdRef",
+    "EmbedRef",
+    "HeadingRef",
+    "LinkResolution",
+    "MarkdownDiagnostic",
+    "ObsidianCommentRef",
+    "SourceRange",
+    "VaultMarkdownDocument",
+    "WikiLinkRef",
+    "parse_vault_markdown",
+]

--- a/companion-ui/companion-app/companion_ui/renderer/models.py
+++ b/companion-ui/companion-app/companion_ui/renderer/models.py
@@ -1,0 +1,123 @@
+"""Renderer-safe document model for Obsidian-compatible vault Markdown.
+
+These dataclasses are intentionally inert: they describe parsed source text for
+later resolver/renderer phases and do not perform navigation, file access, or
+vault writes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+
+DiagnosticSeverity = Literal["info", "warning", "error"]
+EmbedKind = Literal["image", "note", "pdf", "audio", "video", "canvas", "unknown"]
+LinkResolutionKind = Literal["resolved", "missing", "ambiguous"]
+AssetResolutionKind = Literal["allowed", "missing", "blocked", "unsupported"]
+
+
+@dataclass(frozen=True)
+class SourceRange:
+    """Character range in the original raw Markdown string."""
+
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class MarkdownDiagnostic:
+    severity: DiagnosticSeverity
+    code: str
+    message: str
+    source_range: SourceRange | None = None
+
+
+@dataclass(frozen=True)
+class HeadingRef:
+    level: int
+    text: str
+    anchor: str
+    source_range: SourceRange | None = None
+
+
+@dataclass(frozen=True)
+class BlockIdRef:
+    block_id: str
+    anchor: str
+    source_range: SourceRange | None = None
+
+
+@dataclass(frozen=True)
+class WikiLinkRef:
+    raw: str
+    target: str
+    alias: str | None = None
+    heading: str | None = None
+    block_id: str | None = None
+    local_only: bool = False
+    source_range: SourceRange | None = None
+
+
+@dataclass(frozen=True)
+class EmbedRef:
+    raw: str
+    target: str
+    kind: EmbedKind
+    width: int | None = None
+    height: int | None = None
+    heading: str | None = None
+    block_id: str | None = None
+    fragment: str | None = None
+    source_range: SourceRange | None = None
+
+
+@dataclass(frozen=True)
+class AssetRef:
+    raw: str
+    target: str
+    alt: str | None = None
+    source_range: SourceRange | None = None
+
+
+@dataclass(frozen=True)
+class ObsidianCommentRef:
+    raw: str
+    text: str
+    suppress_in_reading_view: bool = True
+    source_range: SourceRange | None = None
+
+
+@dataclass(frozen=True)
+class LinkResolution:
+    kind: LinkResolutionKind
+    display_text: str
+    note_path: str | None = None
+    heading: str | None = None
+    block_id: str | None = None
+    reason: str | None = None
+    candidates: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class AssetResolution:
+    kind: AssetResolutionKind
+    display_name: str
+    src: str | None = None
+    width: int | None = None
+    height: int | None = None
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class VaultMarkdownDocument:
+    raw_markdown: str
+    frontmatter: str | None
+    body_markdown: str
+    diagnostics: list[MarkdownDiagnostic] = field(default_factory=list)
+    headings: list[HeadingRef] = field(default_factory=list)
+    block_ids: list[BlockIdRef] = field(default_factory=list)
+    wikilinks: list[WikiLinkRef] = field(default_factory=list)
+    embeds: list[EmbedRef] = field(default_factory=list)
+    asset_refs: list[AssetRef] = field(default_factory=list)
+    comments: list[ObsidianCommentRef] = field(default_factory=list)

--- a/companion-ui/companion-app/companion_ui/renderer/vault_markdown_parser.py
+++ b/companion-ui/companion-app/companion_ui/renderer/vault_markdown_parser.py
@@ -23,7 +23,7 @@ from companion_ui.renderer.models import (
 )
 
 
-_FENCE_RE = re.compile(r"^\s*(?:>\s*)*(```|~~~)\s*([A-Za-z0-9_-]+)?")
+_FENCE_RE = re.compile(r"^\s*(?:>\s*)*(`{3,}|~{3,})\s*([A-Za-z0-9_-]+)?")
 _HEADING_RE = re.compile(r"^(#{1,6})[ \t]+(.+?)\s*$")
 _EXPLICIT_ANCHOR_RE = re.compile(r"\s*\{#([A-Za-z0-9_-]+)\}\s*$")
 _BLOCK_ID_RE = re.compile(r"(?<!\S)\^([A-Za-z0-9_-]+)")
@@ -47,13 +47,14 @@ def parse_vault_markdown(raw_markdown: str) -> VaultMarkdownDocument:
         diagnostics.extend(_validate_frontmatter(frontmatter, raw_markdown))
 
     non_fenced_spans = list(_iter_non_fenced_spans(body_markdown, body_offset))
+    reference_spans = list(_iter_comment_suppressed_spans(non_fenced_spans))
     fenced_diagnostics = _detect_diagnostic_only_code_blocks(body_markdown, body_offset)
 
     headings = _extract_headings(body_markdown, body_offset)
-    block_ids = _extract_block_ids(non_fenced_spans)
-    wikilinks = _extract_wikilinks(non_fenced_spans)
-    embeds, embed_diagnostics = _extract_embeds(non_fenced_spans)
-    asset_refs = _extract_asset_refs(non_fenced_spans)
+    block_ids = _extract_block_ids(reference_spans)
+    wikilinks = _extract_wikilinks(reference_spans)
+    embeds, embed_diagnostics = _extract_embeds(reference_spans)
+    asset_refs = _extract_asset_refs(reference_spans)
     comments = _extract_comments(non_fenced_spans)
 
     return VaultMarkdownDocument(
@@ -155,7 +156,7 @@ def _iter_non_fenced_spans(body_markdown: str, body_offset: int) -> Iterator[tup
                 span_start = None
                 in_fence = True
                 fence_marker = fence_match.group(1)
-            elif fence_marker == fence_match.group(1):
+            elif _is_closing_fence(fence_marker, fence_match.group(1)):
                 in_fence = False
                 fence_marker = None
             cursor += len(line)
@@ -169,6 +170,25 @@ def _iter_non_fenced_spans(body_markdown: str, body_offset: int) -> Iterator[tup
 
     if span_parts and span_start is not None:
         yield "".join(span_parts), body_offset + span_start
+
+
+def _iter_comment_suppressed_spans(
+    spans: Iterable[tuple[str, int]],
+) -> Iterator[tuple[str, int]]:
+    for text, source_offset in spans:
+        cursor = 0
+        for match in _COMMENT_RE.finditer(text):
+            if match.start() > cursor:
+                yield text[cursor : match.start()], source_offset + cursor
+            cursor = match.end()
+        if cursor < len(text):
+            yield text[cursor:], source_offset + cursor
+
+
+def _is_closing_fence(open_marker: str | None, candidate: str) -> bool:
+    if not open_marker:
+        return False
+    return candidate[0] == open_marker[0] and len(candidate) >= len(open_marker)
 
 
 def _detect_diagnostic_only_code_blocks(
@@ -202,7 +222,7 @@ def _detect_diagnostic_only_code_blocks(
                         ),
                     )
                 )
-        elif fence_marker == marker:
+        elif _is_closing_fence(fence_marker, marker):
             in_fence = False
             fence_marker = None
         cursor += len(line)
@@ -223,7 +243,7 @@ def _extract_headings(body_markdown: str, body_offset: int) -> list[HeadingRef]:
             if not in_fence:
                 in_fence = True
                 fence_marker = marker
-            elif fence_marker == marker:
+            elif _is_closing_fence(fence_marker, marker):
                 in_fence = False
                 fence_marker = None
             cursor += len(line)

--- a/companion-ui/companion-app/companion_ui/renderer/vault_markdown_parser.py
+++ b/companion-ui/companion-app/companion_ui/renderer/vault_markdown_parser.py
@@ -1,0 +1,509 @@
+"""Parse vault Markdown into renderer-safe references.
+
+The parser is deliberately read-only and text-only. It preserves the raw source
+verbatim, extracts references needed by later renderer/resolver phases, and
+does not resolve links, assets, or paths.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Iterator
+
+from companion_ui.renderer.models import (
+    AssetRef,
+    BlockIdRef,
+    EmbedRef,
+    HeadingRef,
+    MarkdownDiagnostic,
+    ObsidianCommentRef,
+    SourceRange,
+    VaultMarkdownDocument,
+    WikiLinkRef,
+)
+
+
+_FENCE_RE = re.compile(r"^\s*(?:>\s*)*(```|~~~)\s*([A-Za-z0-9_-]+)?")
+_HEADING_RE = re.compile(r"^(#{1,6})[ \t]+(.+?)\s*$")
+_EXPLICIT_ANCHOR_RE = re.compile(r"\s*\{#([A-Za-z0-9_-]+)\}\s*$")
+_BLOCK_ID_RE = re.compile(r"(?<!\S)\^([A-Za-z0-9_-]+)")
+_WIKILINK_RE = re.compile(r"(?<!!)\[\[([^\]\r\n]+?)\]\]")
+_EMBED_RE = re.compile(r"!\[\[([^\]\r\n]+?)\]\]")
+_ASSET_RE = re.compile(r"!\[([^\]\r\n]*)\]\(([^)\r\n]+)\)")
+_COMMENT_RE = re.compile(r"%%(.*?)%%", re.DOTALL)
+
+_IMAGE_EXTENSIONS = {"avif", "bmp", "gif", "jpeg", "jpg", "png", "svg", "webp"}
+_AUDIO_EXTENSIONS = {"aac", "flac", "m4a", "mp3", "ogg", "wav"}
+_VIDEO_EXTENSIONS = {"avi", "m4v", "mkv", "mov", "mp4", "webm"}
+_DIAGNOSTIC_ONLY_EMBED_KINDS = {"note", "pdf", "audio", "video", "canvas"}
+_DIAGNOSTIC_ONLY_CODE_BLOCKS = {"dataview", "dataviewjs", "query"}
+
+
+def parse_vault_markdown(raw_markdown: str) -> VaultMarkdownDocument:
+    """Parse raw Markdown without mutating it or resolving external targets."""
+
+    frontmatter, body_markdown, body_offset, diagnostics = _split_frontmatter(raw_markdown)
+    if frontmatter is not None:
+        diagnostics.extend(_validate_frontmatter(frontmatter, raw_markdown))
+
+    non_fenced_spans = list(_iter_non_fenced_spans(body_markdown, body_offset))
+    fenced_diagnostics = _detect_diagnostic_only_code_blocks(body_markdown, body_offset)
+
+    headings = _extract_headings(body_markdown, body_offset)
+    block_ids = _extract_block_ids(non_fenced_spans)
+    wikilinks = _extract_wikilinks(non_fenced_spans)
+    embeds, embed_diagnostics = _extract_embeds(non_fenced_spans)
+    asset_refs = _extract_asset_refs(non_fenced_spans)
+    comments = _extract_comments(non_fenced_spans)
+
+    return VaultMarkdownDocument(
+        raw_markdown=raw_markdown,
+        frontmatter=frontmatter,
+        body_markdown=body_markdown,
+        diagnostics=[*diagnostics, *embed_diagnostics, *fenced_diagnostics],
+        headings=headings,
+        block_ids=block_ids,
+        wikilinks=wikilinks,
+        embeds=embeds,
+        asset_refs=asset_refs,
+        comments=comments,
+    )
+
+
+def _split_frontmatter(
+    raw_markdown: str,
+) -> tuple[str | None, str, int, list[MarkdownDiagnostic]]:
+    lines = raw_markdown.splitlines(keepends=True)
+    if not lines or lines[0].strip() != "---":
+        return None, raw_markdown, 0, []
+
+    cursor = len(lines[0])
+    for line in lines[1:]:
+        if line.strip() == "---":
+            closing_end = cursor + len(line)
+            frontmatter = raw_markdown[len(lines[0]) : cursor]
+            return frontmatter, raw_markdown[closing_end:], closing_end, []
+        cursor += len(line)
+
+    diagnostic = MarkdownDiagnostic(
+        severity="error",
+        code="frontmatter_unterminated",
+        message="Opening frontmatter delimiter has no closing delimiter.",
+        source_range=SourceRange(0, len(lines[0])),
+    )
+    return None, raw_markdown, 0, [diagnostic]
+
+
+def _validate_frontmatter(frontmatter: str, raw_markdown: str) -> list[MarkdownDiagnostic]:
+    if not _frontmatter_looks_malformed(frontmatter):
+        return []
+    start = raw_markdown.find(frontmatter) if frontmatter else 0
+    if start < 0:
+        start = 0
+    return [
+        MarkdownDiagnostic(
+            severity="warning",
+            code="frontmatter_parse_error",
+            message="Frontmatter could not be parsed as simple YAML.",
+            source_range=SourceRange(start, start + len(frontmatter)),
+        )
+    ]
+
+
+def _frontmatter_looks_malformed(frontmatter: str) -> bool:
+    stack: list[str] = []
+    quote: str | None = None
+    bracket_pairs = {"]": "[", "}": "{"}
+
+    for line in frontmatter.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if not line.startswith((" ", "\t", "-")) and ":" not in line:
+            return True
+        for char in line:
+            if quote:
+                if char == quote:
+                    quote = None
+                continue
+            if char in {"'", '"'}:
+                quote = char
+            elif char in {"[", "{"}:
+                stack.append(char)
+            elif char in bracket_pairs:
+                if not stack or stack[-1] != bracket_pairs[char]:
+                    return True
+                stack.pop()
+
+    return bool(stack or quote)
+
+
+def _iter_non_fenced_spans(body_markdown: str, body_offset: int) -> Iterator[tuple[str, int]]:
+    span_parts: list[str] = []
+    span_start: int | None = None
+    cursor = 0
+    in_fence = False
+    fence_marker: str | None = None
+
+    for line in body_markdown.splitlines(keepends=True):
+        fence_match = _FENCE_RE.match(line)
+        if fence_match:
+            if not in_fence:
+                if span_parts and span_start is not None:
+                    yield "".join(span_parts), body_offset + span_start
+                span_parts = []
+                span_start = None
+                in_fence = True
+                fence_marker = fence_match.group(1)
+            elif fence_marker == fence_match.group(1):
+                in_fence = False
+                fence_marker = None
+            cursor += len(line)
+            continue
+
+        if not in_fence:
+            if span_start is None:
+                span_start = cursor
+            span_parts.append(line)
+        cursor += len(line)
+
+    if span_parts and span_start is not None:
+        yield "".join(span_parts), body_offset + span_start
+
+
+def _detect_diagnostic_only_code_blocks(
+    body_markdown: str,
+    body_offset: int,
+) -> list[MarkdownDiagnostic]:
+    diagnostics: list[MarkdownDiagnostic] = []
+    cursor = 0
+    in_fence = False
+    fence_marker: str | None = None
+
+    for line in body_markdown.splitlines(keepends=True):
+        match = _FENCE_RE.match(line)
+        if not match:
+            cursor += len(line)
+            continue
+
+        marker, language = match.group(1), (match.group(2) or "").lower()
+        if not in_fence:
+            in_fence = True
+            fence_marker = marker
+            if language in _DIAGNOSTIC_ONLY_CODE_BLOCKS:
+                diagnostics.append(
+                    MarkdownDiagnostic(
+                        severity="info",
+                        code="diagnostic_only_code_block",
+                        message=f"Fenced {language} block is parsed for diagnostics only.",
+                        source_range=SourceRange(
+                            body_offset + cursor,
+                            body_offset + cursor + len(line),
+                        ),
+                    )
+                )
+        elif fence_marker == marker:
+            in_fence = False
+            fence_marker = None
+        cursor += len(line)
+
+    return diagnostics
+
+
+def _extract_headings(body_markdown: str, body_offset: int) -> list[HeadingRef]:
+    headings: list[HeadingRef] = []
+    cursor = 0
+    in_fence = False
+    fence_marker: str | None = None
+
+    for line in body_markdown.splitlines(keepends=True):
+        fence_match = _FENCE_RE.match(line)
+        if fence_match:
+            marker = fence_match.group(1)
+            if not in_fence:
+                in_fence = True
+                fence_marker = marker
+            elif fence_marker == marker:
+                in_fence = False
+                fence_marker = None
+            cursor += len(line)
+            continue
+
+        if not in_fence:
+            line_without_newline = line.rstrip("\r\n")
+            match = _HEADING_RE.match(line_without_newline)
+            if match:
+                level = len(match.group(1))
+                text, anchor = _heading_text_and_anchor(match.group(2))
+                headings.append(
+                    HeadingRef(
+                        level=level,
+                        text=text,
+                        anchor=anchor,
+                        source_range=SourceRange(
+                            body_offset + cursor,
+                            body_offset + cursor + len(line_without_newline),
+                        ),
+                    )
+                )
+        cursor += len(line)
+
+    return headings
+
+
+def _heading_text_and_anchor(raw_text: str) -> tuple[str, str]:
+    text = raw_text.strip()
+    explicit_anchor = _EXPLICIT_ANCHOR_RE.search(text)
+    if explicit_anchor:
+        text = text[: explicit_anchor.start()].strip()
+        return text, explicit_anchor.group(1)
+    text = text.strip(" #\t")
+    return text, _slugify_heading(text)
+
+
+def _slugify_heading(text: str) -> str:
+    lowered = text.lower()
+    kept = [char if char.isalnum() else "-" for char in lowered]
+    slug = re.sub(r"-+", "-", "".join(kept)).strip("-")
+    return slug
+
+
+def _extract_block_ids(spans: Iterable[tuple[str, int]]) -> list[BlockIdRef]:
+    refs: list[BlockIdRef] = []
+    for text, source_offset in spans:
+        for match in _BLOCK_ID_RE.finditer(text):
+            block_id = match.group(1)
+            refs.append(
+                BlockIdRef(
+                    block_id=block_id,
+                    anchor=block_id,
+                    source_range=SourceRange(
+                        source_offset + match.start(),
+                        source_offset + match.end(),
+                    ),
+                )
+            )
+    return refs
+
+
+def _extract_wikilinks(spans: Iterable[tuple[str, int]]) -> list[WikiLinkRef]:
+    refs: list[WikiLinkRef] = []
+    for text, source_offset in spans:
+        for match in _WIKILINK_RE.finditer(text):
+            raw = match.group(0)
+            target_text = match.group(1)
+            parsed = _parse_wikilink_target(target_text)
+            refs.append(
+                WikiLinkRef(
+                    raw=raw,
+                    target=parsed["target"],
+                    alias=parsed["alias"],
+                    heading=parsed["heading"],
+                    block_id=parsed["block_id"],
+                    local_only=parsed["local_only"],
+                    source_range=SourceRange(
+                        source_offset + match.start(),
+                        source_offset + match.end(),
+                    ),
+                )
+            )
+    return refs
+
+
+def _parse_wikilink_target(text: str) -> dict[str, str | bool | None]:
+    target_part, alias = _split_once(text, "|")
+    target = target_part
+    heading: str | None = None
+    block_id: str | None = None
+    local_only = False
+
+    if target_part.startswith("#^"):
+        target = ""
+        block_id = target_part[2:]
+        local_only = True
+    elif target_part.startswith("^"):
+        target = ""
+        block_id = target_part[1:]
+        local_only = True
+    elif target_part.startswith("#"):
+        target = ""
+        heading = target_part[1:]
+        local_only = True
+    elif "#^" in target_part:
+        target, block_id = target_part.split("#^", 1)
+    elif "#" in target_part:
+        target, heading = target_part.split("#", 1)
+
+    return {
+        "target": target.strip(),
+        "alias": alias.strip() if alias else None,
+        "heading": heading.strip() if heading else None,
+        "block_id": block_id.strip() if block_id else None,
+        "local_only": local_only,
+    }
+
+
+def _extract_embeds(
+    spans: Iterable[tuple[str, int]],
+) -> tuple[list[EmbedRef], list[MarkdownDiagnostic]]:
+    refs: list[EmbedRef] = []
+    diagnostics: list[MarkdownDiagnostic] = []
+    for text, source_offset in spans:
+        for match in _EMBED_RE.finditer(text):
+            raw = match.group(0)
+            ref = _parse_embed(
+                raw,
+                match.group(1),
+                source_offset + match.start(),
+                source_offset + match.end(),
+            )
+            refs.append(ref)
+            if ref.kind == "unknown":
+                diagnostics.append(
+                    MarkdownDiagnostic(
+                        severity="warning",
+                        code="unknown_embed_type",
+                        message=f"Embed target has an unsupported type: {ref.target}",
+                        source_range=ref.source_range,
+                    )
+                )
+            elif ref.kind in _DIAGNOSTIC_ONLY_EMBED_KINDS:
+                diagnostics.append(
+                    MarkdownDiagnostic(
+                        severity="info",
+                        code="diagnostic_only_embed",
+                        message=f"{ref.kind} embeds are parsed but not rendered by this parser.",
+                        source_range=ref.source_range,
+                    )
+                )
+    return refs, diagnostics
+
+
+def _parse_embed(raw: str, text: str, start: int, end: int) -> EmbedRef:
+    target_with_fragment, size_hint = _split_once(text, "|")
+    target, heading, block_id, fragment = _split_embed_fragment(target_with_fragment)
+    width, height = _parse_size_hint(size_hint)
+    kind = _classify_embed_kind(target)
+    return EmbedRef(
+        raw=raw,
+        target=target.strip(),
+        kind=kind,
+        width=width,
+        height=height,
+        heading=heading,
+        block_id=block_id,
+        fragment=fragment,
+        source_range=SourceRange(start, end),
+    )
+
+
+def _split_embed_fragment(target_text: str) -> tuple[str, str | None, str | None, str | None]:
+    target = target_text
+    heading: str | None = None
+    block_id: str | None = None
+    fragment: str | None = None
+
+    if "#^" in target_text:
+        target, block_id = target_text.split("#^", 1)
+    elif "#" in target_text:
+        target, fragment = target_text.split("#", 1)
+        if not _looks_like_asset_target(target):
+            heading = fragment
+            fragment = None
+
+    return (
+        target.strip(),
+        heading.strip() if heading else None,
+        block_id.strip() if block_id else None,
+        fragment.strip() if fragment else None,
+    )
+
+
+def _parse_size_hint(size_hint: str | None) -> tuple[int | None, int | None]:
+    if not size_hint:
+        return None, None
+    normalized = size_hint.strip().lower()
+    if "x" in normalized:
+        width_text, height_text = normalized.split("x", 1)
+        return _parse_positive_int(width_text), _parse_positive_int(height_text)
+    return _parse_positive_int(normalized), None
+
+
+def _parse_positive_int(text: str) -> int | None:
+    try:
+        value = int(text.strip())
+    except ValueError:
+        return None
+    return value if value > 0 else None
+
+
+def _classify_embed_kind(target: str) -> str:
+    extension = _target_extension(target)
+    if not extension:
+        return "note"
+    if extension in _IMAGE_EXTENSIONS:
+        return "image"
+    if extension == "pdf":
+        return "pdf"
+    if extension in _AUDIO_EXTENSIONS:
+        return "audio"
+    if extension in _VIDEO_EXTENSIONS:
+        return "video"
+    if extension == "canvas":
+        return "canvas"
+    return "unknown"
+
+
+def _looks_like_asset_target(target: str) -> bool:
+    return bool(_target_extension(target))
+
+
+def _target_extension(target: str) -> str:
+    path = target.split("?", 1)[0].split("#", 1)[0].rstrip("/")
+    last_segment = path.rsplit("/", 1)[-1]
+    if "." not in last_segment:
+        return ""
+    return last_segment.rsplit(".", 1)[-1].lower()
+
+
+def _extract_asset_refs(spans: Iterable[tuple[str, int]]) -> list[AssetRef]:
+    refs: list[AssetRef] = []
+    for text, source_offset in spans:
+        for match in _ASSET_RE.finditer(text):
+            refs.append(
+                AssetRef(
+                    raw=match.group(0),
+                    alt=match.group(1),
+                    target=match.group(2).strip(),
+                    source_range=SourceRange(
+                        source_offset + match.start(),
+                        source_offset + match.end(),
+                    ),
+                )
+            )
+    return refs
+
+
+def _extract_comments(spans: Iterable[tuple[str, int]]) -> list[ObsidianCommentRef]:
+    comments: list[ObsidianCommentRef] = []
+    for text, source_offset in spans:
+        for match in _COMMENT_RE.finditer(text):
+            comments.append(
+                ObsidianCommentRef(
+                    raw=match.group(0),
+                    text=match.group(1),
+                    suppress_in_reading_view=True,
+                    source_range=SourceRange(
+                        source_offset + match.start(),
+                        source_offset + match.end(),
+                    ),
+                )
+            )
+    return comments
+
+
+def _split_once(text: str, separator: str) -> tuple[str, str | None]:
+    if separator not in text:
+        return text, None
+    left, right = text.split(separator, 1)
+    return left, right

--- a/tests/companion_ui/test_obsidian_compatibility_fixtures.py
+++ b/tests/companion_ui/test_obsidian_compatibility_fixtures.py
@@ -1,0 +1,71 @@
+"""Parser-level smoke coverage across the Obsidian compatibility fixtures."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from companion_ui.renderer import parse_vault_markdown
+
+
+FIXTURE_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "companion-ui"
+    / "companion-app"
+    / "tests"
+    / "fixtures"
+    / "obsidian-renderer"
+)
+
+FIXTURE_NAMES = [
+    "basic.md",
+    "frontmatter-properties.md",
+    "malformed-frontmatter.md",
+    "wikilinks.md",
+    "embeds-images.md",
+    "callouts.md",
+    "mermaid.md",
+    "comments-and-html.md",
+    "missing-links-assets.md",
+    "full-smoke.md",
+]
+
+
+@pytest.mark.parametrize("fixture_name", FIXTURE_NAMES)
+def test_obsidian_fixture_raw_markdown_round_trips(fixture_name: str) -> None:
+    raw_markdown = (FIXTURE_DIR / fixture_name).read_text(encoding="utf-8")
+
+    document = parse_vault_markdown(raw_markdown)
+
+    assert document.raw_markdown == raw_markdown
+    assert isinstance(document.body_markdown, str)
+
+
+def test_full_smoke_fixture_extracts_all_parser_reference_types() -> None:
+    document = parse_vault_markdown((FIXTURE_DIR / "full-smoke.md").read_text(encoding="utf-8"))
+
+    assert document.frontmatter is not None
+    assert len(document.headings) == 3
+    assert len(document.block_ids) == 1
+    assert len(document.wikilinks) == 7
+    assert len(document.embeds) == 3
+    assert len(document.comments) == 1
+    assert {asset.target for asset in document.asset_refs} == set()
+    assert any(diagnostic.code == "diagnostic_only_code_block" for diagnostic in document.diagnostics)
+
+
+def test_missing_links_assets_fixture_keeps_unresolved_targets_unresolved() -> None:
+    document = parse_vault_markdown(
+        (FIXTURE_DIR / "missing-links-assets.md").read_text(encoding="utf-8")
+    )
+
+    assert {link.target for link in document.wikilinks} == {
+        "ZZZ_NONEXISTENT_NOTE_ZZZ",
+        "README",
+    }
+    assert {embed.target for embed in document.embeds} == {
+        "zzz_nonexistent_image_zzz.png",
+        "https://external.example.com/file.png",
+    }
+    assert document.asset_refs[0].target == "zzz_missing.png"

--- a/tests/companion_ui/test_vault_markdown_parser.py
+++ b/tests/companion_ui/test_vault_markdown_parser.py
@@ -114,6 +114,19 @@ def test_comment_extraction() -> None:
     assert document.comments[1].text.strip() == "Multi-word inline comment"
 
 
+def test_comment_bodies_are_not_parsed_as_active_references() -> None:
+    document = parse_vault_markdown(
+        "Visible [[LiveNote]]\n\n"
+        "%% hidden [[DraftOnly]] ![[hidden.png]] ^hidden-block %%\n\n"
+        "After [[AfterNote]]\n"
+    )
+
+    assert [link.target for link in document.wikilinks] == ["LiveNote", "AfterNote"]
+    assert document.embeds == []
+    assert document.block_ids == []
+    assert len(document.comments) == 1
+
+
 def test_malformed_frontmatter_diagnostic() -> None:
     document = parse_vault_markdown(_fixture("malformed-frontmatter.md"))
 
@@ -124,3 +137,18 @@ def test_malformed_frontmatter_diagnostic() -> None:
         and diagnostic.severity in {"warning", "error"}
         for diagnostic in document.diagnostics
     )
+
+
+def test_long_fence_keeps_inner_shorter_fence_literal() -> None:
+    document = parse_vault_markdown(
+        "````markdown\n"
+        "```python\n"
+        "[[NotAnActiveLink]]\n"
+        "![[not-active.png]]\n"
+        "```\n"
+        "````\n\n"
+        "[[ActiveLink]]\n"
+    )
+
+    assert [link.target for link in document.wikilinks] == ["ActiveLink"]
+    assert document.embeds == []

--- a/tests/companion_ui/test_vault_markdown_parser.py
+++ b/tests/companion_ui/test_vault_markdown_parser.py
@@ -1,0 +1,126 @@
+"""Fixture-driven parser coverage for Obsidian-compatible vault Markdown (#1296)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from companion_ui.renderer import parse_vault_markdown
+
+
+FIXTURE_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "companion-ui"
+    / "companion-app"
+    / "tests"
+    / "fixtures"
+    / "obsidian-renderer"
+)
+
+
+def _fixture(name: str) -> str:
+    return (FIXTURE_DIR / name).read_text(encoding="utf-8")
+
+
+def test_raw_markdown_preserved() -> None:
+    raw_markdown = _fixture("full-smoke.md")
+
+    document = parse_vault_markdown(raw_markdown)
+
+    assert document.raw_markdown == raw_markdown
+
+
+def test_frontmatter_extraction() -> None:
+    document = parse_vault_markdown(_fixture("frontmatter-properties.md"))
+
+    assert document.frontmatter is not None
+    assert "title: Frontmatter Fixture" in document.frontmatter
+    assert "tags: [alpha, beta, gamma]" in document.frontmatter
+    assert "aliases: [Alt Name, Another Alias]" in document.frontmatter
+
+
+def test_body_excludes_frontmatter() -> None:
+    document = parse_vault_markdown(_fixture("frontmatter-properties.md"))
+
+    assert document.body_markdown.startswith("\nBody text")
+    assert "title: Frontmatter Fixture" not in document.body_markdown
+    assert "custom_field: some value" not in document.body_markdown
+
+
+def test_heading_extraction() -> None:
+    document = parse_vault_markdown(_fixture("basic.md"))
+
+    assert [(heading.level, heading.text, heading.anchor) for heading in document.headings] == [
+        (1, "Heading 1", "heading-1"),
+        (2, "Heading 2", "custom-anchor"),
+        (3, "Heading 3", "heading-3"),
+    ]
+
+
+def test_block_id_extraction() -> None:
+    document = parse_vault_markdown(_fixture("wikilinks.md"))
+
+    assert [(block.block_id, block.anchor) for block in document.block_ids] == [
+        ("local-block-id", "local-block-id")
+    ]
+
+
+def test_wikilink_extraction() -> None:
+    document = parse_vault_markdown(_fixture("wikilinks.md"))
+
+    links = {link.raw: link for link in document.wikilinks}
+    assert links["[[ExistingNote]]"].target == "ExistingNote"
+    assert links["[[ExistingNote|Display Alias]]"].alias == "Display Alias"
+    assert links["[[ExistingNote#Section Header]]"].heading == "Section Header"
+    assert links["[[ExistingNote#Section Header|Alias]]"].alias == "Alias"
+    assert links["[[ExistingNote#^abc123]]"].block_id == "abc123"
+    assert links["[[#Local Section]]"].local_only is True
+    assert links["[[#Local Section]]"].heading == "Local Section"
+    assert links["[[^local-block-id]]"].local_only is True
+    assert links["[[^local-block-id]]"].block_id == "local-block-id"
+    assert links["[[NonExistentNote12345]]"].target == "NonExistentNote12345"
+    assert links["[[AmbiguousNote]]"].target == "AmbiguousNote"
+    assert len(document.wikilinks) == 9
+
+
+def test_embed_extraction() -> None:
+    document = parse_vault_markdown(_fixture("embeds-images.md"))
+
+    embeds = {embed.raw: embed for embed in document.embeds}
+    assert embeds["![[test-image.png]]"].kind == "image"
+    assert embeds["![[test-image.png|100]]"].width == 100
+    assert embeds["![[test-image.png|100x145]]"].width == 100
+    assert embeds["![[test-image.png|100x145]]"].height == 145
+    assert embeds["![[SomeNote]]"].kind == "note"
+    assert embeds["![[SomeNote#Heading]]"].heading == "Heading"
+    assert embeds["![[SomeNote#^blockid]]"].block_id == "blockid"
+    assert embeds["![[document.pdf]]"].kind == "pdf"
+    assert embeds["![[document.pdf#page=3]]"].fragment == "page=3"
+    assert embeds["![[audio.mp3]]"].kind == "audio"
+    assert embeds["![[video.mp4]]"].kind == "video"
+    assert embeds["![[diagram.canvas]]"].kind == "canvas"
+    assert embeds["![[unknown.xyz]]"].kind == "unknown"
+    assert document.asset_refs[0].raw == "![Alt text](https://example.com/image.png)"
+    assert document.asset_refs[0].alt == "Alt text"
+    assert len(document.embeds) == 12
+
+
+def test_comment_extraction() -> None:
+    document = parse_vault_markdown(_fixture("comments-and-html.md"))
+
+    assert len(document.comments) == 2
+    assert document.comments[0].raw == "%% This comment should be hidden in Reading View. %%"
+    assert document.comments[0].text.strip() == "This comment should be hidden in Reading View."
+    assert document.comments[0].suppress_in_reading_view is True
+    assert document.comments[1].text.strip() == "Multi-word inline comment"
+
+
+def test_malformed_frontmatter_diagnostic() -> None:
+    document = parse_vault_markdown(_fixture("malformed-frontmatter.md"))
+
+    assert document.frontmatter is not None
+    assert document.body_markdown.startswith("\nBody text should still be returned")
+    assert any(
+        diagnostic.code == "frontmatter_parse_error"
+        and diagnostic.severity in {"warning", "error"}
+        for diagnostic in document.diagnostics
+    )


### PR DESCRIPTION
Closes #1296

## Summary
- Adds `companion_ui.renderer` dataclasses for the renderer-safe Markdown document model.
- Implements `parse_vault_markdown(raw_markdown: str)` for raw source preservation, frontmatter/body splitting, headings, block IDs, wikilinks, embeds, standard image asset refs, Obsidian comments, and parser diagnostics.
- Keeps the parser read-only: no link or asset resolution, no rendering, no vault file access, and no write endpoints.

## Module Path Decision
- Parser/model code lives under `companion-ui/companion-app/companion_ui/renderer/`.
- Tests import through the existing `tests/companion_ui/conftest.py` path insertion for `companion-ui/companion-app`.

## Lifecycle
- Dispatcher unavailable: `dispatcher status --json` was not installed, and `python3 -m app.dispatcher status --json` failed with `ModuleNotFoundError: No module named 'yaml'`.
- Used GitHub-label fallback via `scripts/issue_pickup_claim.sh --issue 1296` and manually verified Project status as `In Progress`.

## Validation
- `pytest tests/companion_ui/test_vault_markdown_parser.py -q` -> 11 passed
- `pytest tests/companion_ui/test_obsidian_compatibility_fixtures.py -q` -> 12 passed
- `git diff --check` -> passed
- `git diff --check origin/main...HEAD` -> passed
- `ruff check app tests` -> not run; local shell has no `ruff` command
- `python3 -m ruff check app tests` -> not run; local Python reports `No module named ruff`
