### PR TITLE
feat(companion-ui): add VaultMarkdownRenderer core

### DIFF
--- a/companion-ui/companion-app/companion_ui/renderer/__init__.py
+++ b/companion-ui/companion-app/companion_ui/renderer/__init__.py
@@ -14,6 +14,11 @@ from companion_ui.renderer.models import (
     WikiLinkRef,
 )
 from companion_ui.renderer.vault_markdown_parser import parse_vault_markdown
+from companion_ui.renderer.vault_markdown_renderer import (
+    RenderedVaultMarkdown,
+    VaultMarkdownRenderer,
+    render_vault_markdown,
+)
 
 __all__ = [
     "AssetRef",
@@ -28,4 +33,7 @@ __all__ = [
     "VaultMarkdownDocument",
     "WikiLinkRef",
     "parse_vault_markdown",
+    "RenderedVaultMarkdown",
+    "VaultMarkdownRenderer",
+    "render_vault_markdown",
 ]

--- a/companion-ui/companion-app/companion_ui/renderer/vault_markdown_renderer.py
+++ b/companion-ui/companion-app/companion_ui/renderer/vault_markdown_renderer.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import html
+from html.parser import HTMLParser
 import re
 from typing import Protocol
 from urllib.parse import quote
@@ -27,11 +28,6 @@ from companion_ui.renderer.vault_markdown_parser import parse_vault_markdown
 
 
 _TOKEN_RE = re.compile(r"(`[^`\n]+`|!\[[^\]\n]*\]\([^) \n][^)\n]*\)|!\[\[[^\]\n]+?\]\]|\[\[[^\]\n]+?\]\])")
-_SCRIPT_RE = re.compile(r"<script\b[^>]*>.*?</script\s*>", re.IGNORECASE | re.DOTALL)
-_STYLE_RE = re.compile(r"<style\b[^>]*>.*?</style\s*>", re.IGNORECASE | re.DOTALL)
-_HTML_TAG_RE = re.compile(r"</?[A-Za-z][^>]*>")
-_EVENT_HANDLER_RE = re.compile(r"\s+on[A-Za-z]+\s*=\s*(['\"]).*?\1", re.IGNORECASE | re.DOTALL)
-_JAVASCRIPT_URL_RE = re.compile(r"javascript\s*:", re.IGNORECASE)
 _FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})\s*([A-Za-z0-9_-]+)?\s*$")
 _HEADING_RE = re.compile(r"^(#{1,6})[ \t]+(.+?)\s*$")
 _EXPLICIT_ANCHOR_RE = re.compile(r"\s*\{#([A-Za-z0-9_-]+)\}\s*$")
@@ -63,6 +59,40 @@ class LinkResolverProtocol(Protocol):
 class AssetResolverProtocol(Protocol):
     def resolve(self, *args: object, **kwargs: object) -> object:
         ...
+
+
+class _RawHtmlStripper(HTMLParser):
+    """Strip raw HTML tags and suppress script/style contents."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.parts: list[str] = []
+        self._suppressed_tag_stack: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        _ = attrs
+        if tag.lower() in {"script", "style"}:
+            self._suppressed_tag_stack.append(tag.lower())
+
+    def handle_endtag(self, tag: str) -> None:
+        lowered = tag.lower()
+        if lowered in {"script", "style"} and lowered in self._suppressed_tag_stack:
+            self._suppressed_tag_stack.remove(lowered)
+
+    def handle_data(self, data: str) -> None:
+        if not self._suppressed_tag_stack:
+            self.parts.append(data)
+
+    def handle_entityref(self, name: str) -> None:
+        if not self._suppressed_tag_stack:
+            self.parts.append(f"&{name};")
+
+    def handle_charref(self, name: str) -> None:
+        if not self._suppressed_tag_stack:
+            self.parts.append(f"&#{name};")
+
+    def text(self) -> str:
+        return "".join(self.parts)
 
 
 @dataclass(frozen=True)
@@ -589,11 +619,10 @@ def _strip_obsidian_comments(text: str) -> str:
 
 
 def _strip_raw_html(text: str) -> str:
-    clean = _SCRIPT_RE.sub("", text)
-    clean = _STYLE_RE.sub("", clean)
-    clean = _EVENT_HANDLER_RE.sub("", clean)
-    clean = _JAVASCRIPT_URL_RE.sub("", clean)
-    return _HTML_TAG_RE.sub("", clean)
+    stripper = _RawHtmlStripper()
+    stripper.feed(text)
+    stripper.close()
+    return stripper.text()
 
 
 def _safe_note_path(note_path: str) -> str:

--- a/companion-ui/companion-app/companion_ui/renderer/vault_markdown_renderer.py
+++ b/companion-ui/companion-app/companion_ui/renderer/vault_markdown_renderer.py
@@ -1,0 +1,619 @@
+"""Server-side Vault Markdown renderer for the Companion UI note surface.
+
+The renderer is deliberately read-only. It consumes parser output plus injected
+link/asset resolvers, returns sanitized HTML, and never reads vault files or
+calls write endpoints.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import html
+import re
+from typing import Protocol
+from urllib.parse import quote
+
+from companion_ui.renderer.asset_resolver import VaultAssetResolver
+from companion_ui.renderer.link_resolver import (
+    VaultLinkResolver,
+    link_display_label,
+    parse_wikilink,
+)
+from companion_ui.renderer.models import (
+    MarkdownDiagnostic,
+    VaultMarkdownDocument,
+)
+from companion_ui.renderer.vault_markdown_parser import parse_vault_markdown
+
+
+_TOKEN_RE = re.compile(r"(`[^`\n]+`|!\[[^\]\n]*\]\([^) \n][^)\n]*\)|!\[\[[^\]\n]+?\]\]|\[\[[^\]\n]+?\]\])")
+_SCRIPT_RE = re.compile(r"<script\b[^>]*>.*?</script\s*>", re.IGNORECASE | re.DOTALL)
+_STYLE_RE = re.compile(r"<style\b[^>]*>.*?</style\s*>", re.IGNORECASE | re.DOTALL)
+_HTML_TAG_RE = re.compile(r"</?[A-Za-z][^>]*>")
+_EVENT_HANDLER_RE = re.compile(r"\s+on[A-Za-z]+\s*=\s*(['\"]).*?\1", re.IGNORECASE | re.DOTALL)
+_JAVASCRIPT_URL_RE = re.compile(r"javascript\s*:", re.IGNORECASE)
+_FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})\s*([A-Za-z0-9_-]+)?\s*$")
+_HEADING_RE = re.compile(r"^(#{1,6})[ \t]+(.+?)\s*$")
+_EXPLICIT_ANCHOR_RE = re.compile(r"\s*\{#([A-Za-z0-9_-]+)\}\s*$")
+_TASK_RE = re.compile(r"^\s*[-*+]\s+\[([^\]])\]\s+(.*)$")
+_UNORDERED_RE = re.compile(r"^\s*[-*+]\s+(.*)$")
+_ORDERED_RE = re.compile(r"^\s*\d+[.)]\s+(.*)$")
+_CALLOUT_RE = re.compile(r"^\s*>\s*\[!([A-Za-z0-9_-]+)\]([+-])?(?:\s+(.*))?\s*$")
+_TABLE_SEPARATOR_RE = re.compile(r"^\s*\|?\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|?\s*$")
+_COMMENT_RE = re.compile(r"%%.*?%%", re.DOTALL)
+_DIAGNOSTIC_ONLY_LANGUAGES = {"dataview", "dataviewjs", "query"}
+_BLOCKED_SRC_SCHEMES = ("file:", "javascript:", "data:")
+_ABSOLUTE_PATH_RE = re.compile(r"^(?:/|[A-Za-z]:[\\/])")
+_WINDOWS_ABSOLUTE_PATH_RE = re.compile(r"^[A-Za-z]:[\\/]")
+_LOCAL_PATH_PREFIXES = (
+    "/Users/",
+    "/home/",
+    "/private/",
+    "/tmp/",
+    "/var/",
+    "/Volumes/",
+)
+
+
+class LinkResolverProtocol(Protocol):
+    def resolve(self, *args: object, **kwargs: object) -> object:
+        ...
+
+
+class AssetResolverProtocol(Protocol):
+    def resolve(self, *args: object, **kwargs: object) -> object:
+        ...
+
+
+@dataclass(frozen=True)
+class RenderedVaultMarkdown:
+    """Browser-safe render result for one vault Markdown document."""
+
+    html: str
+    document: VaultMarkdownDocument
+    diagnostics: tuple[MarkdownDiagnostic, ...]
+    write_calls: tuple[str, ...] = ()
+
+
+@dataclass
+class _RenderContext:
+    note_path: str
+    link_resolver: LinkResolverProtocol
+    asset_resolver: AssetResolverProtocol
+    diagnostics: list[MarkdownDiagnostic]
+
+
+class VaultMarkdownRenderer:
+    """Render parsed vault Markdown to sanitized, read-only HTML."""
+
+    def __init__(
+        self,
+        *,
+        link_resolver: LinkResolverProtocol | None = None,
+        asset_resolver: AssetResolverProtocol | None = None,
+    ) -> None:
+        self._link_resolver = link_resolver or VaultLinkResolver({})
+        self._asset_resolver = asset_resolver or VaultAssetResolver({})
+
+    def render(
+        self,
+        document: VaultMarkdownDocument | str,
+        *,
+        note_path: str = "",
+    ) -> RenderedVaultMarkdown:
+        parsed = parse_vault_markdown(document) if isinstance(document, str) else document
+        diagnostics = list(parsed.diagnostics)
+        context = _RenderContext(
+            note_path=_safe_note_path(note_path),
+            link_resolver=self._link_resolver,
+            asset_resolver=self._asset_resolver,
+            diagnostics=diagnostics,
+        )
+        body_markdown = _strip_obsidian_comments(parsed.body_markdown)
+        body_html = _render_blocks(body_markdown, context)
+        diagnostics_html = _render_diagnostics(diagnostics)
+        rendered_html = (
+            '<article class="vault-markdown-rendered" data-renderer="vault-markdown">'
+            f"{diagnostics_html}{body_html}"
+            "</article>"
+        )
+        return RenderedVaultMarkdown(
+            html=rendered_html,
+            document=parsed,
+            diagnostics=tuple(diagnostics),
+        )
+
+
+def render_vault_markdown(
+    raw_markdown: VaultMarkdownDocument | str,
+    *,
+    note_path: str = "",
+    link_resolver: LinkResolverProtocol | None = None,
+    asset_resolver: AssetResolverProtocol | None = None,
+) -> RenderedVaultMarkdown:
+    """Convenience wrapper for one-shot rendering."""
+
+    return VaultMarkdownRenderer(
+        link_resolver=link_resolver,
+        asset_resolver=asset_resolver,
+    ).render(raw_markdown, note_path=note_path)
+
+
+def _render_blocks(markdown: str, context: _RenderContext) -> str:
+    lines = markdown.splitlines()
+    parts: list[str] = []
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if not line.strip():
+            index += 1
+            continue
+
+        fence = _FENCE_RE.match(line)
+        if fence:
+            html_block, index = _render_fenced_code(lines, index, fence, context)
+            parts.append(html_block)
+            continue
+
+        if _CALLOUT_RE.match(line):
+            html_block, index = _render_callout_stub(lines, index, context)
+            parts.append(html_block)
+            continue
+
+        if line.lstrip().startswith(">"):
+            html_block, index = _render_blockquote(lines, index, context)
+            parts.append(html_block)
+            continue
+
+        if _is_table_start(lines, index):
+            html_block, index = _render_table(lines, index, context)
+            parts.append(html_block)
+            continue
+
+        heading = _HEADING_RE.match(line)
+        if heading:
+            parts.append(_render_heading(heading, context))
+            index += 1
+            continue
+
+        if _is_thematic_break(line):
+            parts.append("<hr>")
+            index += 1
+            continue
+
+        if _TASK_RE.match(line):
+            html_block, index = _render_task_list(lines, index, context)
+            parts.append(html_block)
+            continue
+
+        if _UNORDERED_RE.match(line):
+            html_block, index = _render_list(lines, index, context, ordered=False)
+            parts.append(html_block)
+            continue
+
+        if _ORDERED_RE.match(line):
+            html_block, index = _render_list(lines, index, context, ordered=True)
+            parts.append(html_block)
+            continue
+
+        html_block, index = _render_paragraph(lines, index, context)
+        parts.append(html_block)
+
+    return "".join(parts)
+
+
+def _render_fenced_code(
+    lines: list[str],
+    start: int,
+    fence: re.Match[str],
+    context: _RenderContext,
+) -> tuple[str, int]:
+    marker = fence.group(1)
+    language = (fence.group(2) or "").lower()
+    code_lines: list[str] = []
+    index = start + 1
+    while index < len(lines):
+        close = _FENCE_RE.match(lines[index])
+        if close and close.group(1).startswith(marker[0]) and len(close.group(1)) >= len(marker):
+            index += 1
+            break
+        code_lines.append(lines[index])
+        index += 1
+
+    code = "\n".join(code_lines)
+    if language in _DIAGNOSTIC_ONLY_LANGUAGES:
+        context.diagnostics.append(
+            MarkdownDiagnostic(
+                severity="info",
+                code="unsupported_plugin_block",
+                message=f"Fenced {language} block is diagnostic-only and was not executed.",
+            )
+        )
+        return (
+            _render_unsupported_diagnostic(
+                code="unsupported_plugin_block",
+                message=f"{language} block not executed.",
+            )
+            + _render_code_block(code, language),
+            index,
+        )
+    return _render_code_block(code, language), index
+
+
+def _render_code_block(code: str, language: str) -> str:
+    language_attr = f' data-language="{_e(language)}"' if language else ""
+    class_attr = f' class="language-{_e(language)}"' if language else ""
+    return (
+        f"<pre class=\"vault-code-block\"{language_attr}>"
+        f"<code{class_attr}>{_e(code)}</code>"
+        "</pre>"
+    )
+
+
+def _render_callout_stub(
+    lines: list[str],
+    start: int,
+    context: _RenderContext,
+) -> tuple[str, int]:
+    first_line = lines[start]
+    match = _CALLOUT_RE.match(first_line)
+    callout_type = (match.group(1) if match else "callout").lower()
+    index = start + 1
+    while index < len(lines) and (not lines[index].strip() or lines[index].lstrip().startswith(">")):
+        index += 1
+    context.diagnostics.append(
+        MarkdownDiagnostic(
+            severity="info",
+            code="unsupported_callout",
+            message=f"Callout rendering for {callout_type!r} is pending a dedicated renderer.",
+        )
+    )
+    return (
+        _render_unsupported_diagnostic(
+            code="unsupported_callout",
+            message=f"Callout rendering pending: {callout_type}",
+        ),
+        index,
+    )
+
+
+def _render_blockquote(
+    lines: list[str],
+    start: int,
+    context: _RenderContext,
+) -> tuple[str, int]:
+    quote_lines: list[str] = []
+    index = start
+    while index < len(lines) and lines[index].lstrip().startswith(">"):
+        quote_lines.append(lines[index].lstrip()[1:].lstrip())
+        index += 1
+    content = "<br>".join(_render_inline(line, context) for line in quote_lines)
+    return f"<blockquote>{content}</blockquote>", index
+
+
+def _render_table(
+    lines: list[str],
+    start: int,
+    context: _RenderContext,
+) -> tuple[str, int]:
+    table_lines: list[str] = []
+    index = start
+    while index < len(lines) and "|" in lines[index] and lines[index].strip():
+        table_lines.append(lines[index])
+        index += 1
+
+    rows = [_split_table_row(line) for line in table_lines]
+    header = rows[0]
+    body_rows = rows[2:]
+    head_html = "".join(f"<th>{_render_inline(cell, context)}</th>" for cell in header)
+    body_html = "".join(
+        "<tr>" + "".join(f"<td>{_render_inline(cell, context)}</td>" for cell in row) + "</tr>"
+        for row in body_rows
+    )
+    return f"<table><thead><tr>{head_html}</tr></thead><tbody>{body_html}</tbody></table>", index
+
+
+def _split_table_row(line: str) -> list[str]:
+    stripped = line.strip().strip("|")
+    return [cell.strip() for cell in stripped.split("|")]
+
+
+def _render_heading(match: re.Match[str], context: _RenderContext) -> str:
+    level = len(match.group(1))
+    text, anchor = _heading_text_and_anchor(match.group(2))
+    return f'<h{level} id="{_e(anchor)}">{_render_inline(text, context)}</h{level}>'
+
+
+def _heading_text_and_anchor(raw_text: str) -> tuple[str, str]:
+    text = raw_text.strip()
+    explicit_anchor = _EXPLICIT_ANCHOR_RE.search(text)
+    if explicit_anchor:
+        text = text[: explicit_anchor.start()].strip()
+        return text, explicit_anchor.group(1)
+    text = text.strip(" #\t")
+    slug = re.sub(r"-+", "-", "".join(char if char.isalnum() else "-" for char in text.lower()))
+    return text, slug.strip("-")
+
+
+def _render_task_list(
+    lines: list[str],
+    start: int,
+    context: _RenderContext,
+) -> tuple[str, int]:
+    items: list[str] = []
+    index = start
+    while index < len(lines):
+        match = _TASK_RE.match(lines[index])
+        if not match:
+            break
+        state = match.group(1).strip() or " "
+        checked = state.lower() == "x"
+        checked_attr = " checked" if checked else ""
+        items.append(
+            '<li class="task-list-item" '
+            f'data-task-state="{_e(state)}">'
+            f'<input type="checkbox" disabled{checked_attr}> '
+            f"{_render_inline(match.group(2), context)}</li>"
+        )
+        index += 1
+    return f'<ul class="task-list">{"".join(items)}</ul>', index
+
+
+def _render_list(
+    lines: list[str],
+    start: int,
+    context: _RenderContext,
+    *,
+    ordered: bool,
+) -> tuple[str, int]:
+    pattern = _ORDERED_RE if ordered else _UNORDERED_RE
+    items: list[str] = []
+    index = start
+    while index < len(lines):
+        match = pattern.match(lines[index])
+        if not match or _TASK_RE.match(lines[index]):
+            break
+        items.append(f"<li>{_render_inline(match.group(1), context)}</li>")
+        index += 1
+    tag = "ol" if ordered else "ul"
+    return f"<{tag}>{''.join(items)}</{tag}>", index
+
+
+def _render_paragraph(
+    lines: list[str],
+    start: int,
+    context: _RenderContext,
+) -> tuple[str, int]:
+    paragraph_lines: list[str] = []
+    index = start
+    while index < len(lines):
+        line = lines[index]
+        if not line.strip():
+            break
+        if paragraph_lines and _is_block_start(lines, index):
+            break
+        paragraph_lines.append(line.strip())
+        index += 1
+    text = " ".join(paragraph_lines)
+    return f"<p>{_render_inline(text, context)}</p>", index
+
+
+def _render_inline(text: str, context: _RenderContext) -> str:
+    parts: list[str] = []
+    cursor = 0
+    for match in _TOKEN_RE.finditer(text):
+        if match.start() > cursor:
+            parts.append(_render_text_segment(text[cursor : match.start()]))
+        token = match.group(0)
+        if token.startswith("`") and token.endswith("`"):
+            parts.append(f"<code>{_e(token[1:-1])}</code>")
+        elif token.startswith("![["):
+            parts.append(_render_obsidian_embed(token, context))
+        elif token.startswith("!["):
+            parts.append(_render_markdown_image(token, context))
+        elif token.startswith("[["):
+            parts.append(_render_wikilink(token, context))
+        cursor = match.end()
+    if cursor < len(text):
+        parts.append(_render_text_segment(text[cursor:]))
+    return "".join(parts)
+
+
+def _render_text_segment(text: str) -> str:
+    clean = _strip_raw_html(text)
+    escaped = _e(clean)
+    escaped = re.sub(r"\*\*\*(.+?)\*\*\*", r"<strong><em>\1</em></strong>", escaped)
+    escaped = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", escaped)
+    escaped = re.sub(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)", r"<em>\1</em>", escaped)
+    escaped = re.sub(r"~~(.+?)~~", r"<del>\1</del>", escaped)
+    return escaped
+
+
+def _render_wikilink(raw: str, context: _RenderContext) -> str:
+    try:
+        link = parse_wikilink(raw)
+        resolution = context.link_resolver.resolve(link, note_path=context.note_path)
+    except Exception as exc:  # Resolver contract says never throw; guard third-party stubs.
+        return _render_link_diagnostic(raw, "missing", str(exc))
+
+    kind = str(getattr(resolution, "kind", "missing"))
+    label = link_display_label(resolution) if kind in {"resolved", "missing", "ambiguous"} else raw
+    if kind != "resolved":
+        return _render_link_diagnostic(label, kind, getattr(resolution, "reason", None))
+
+    note_path = _safe_note_path(str(getattr(resolution, "note_path", "") or ""))
+    if not note_path:
+        return _render_link_diagnostic(label, "missing", "Resolved note path was not browser-safe.")
+
+    href = f"?note_path={quote(note_path, safe='')}"
+    fragment = _resolution_fragment(resolution)
+    if fragment:
+        href = f"{href}#{quote(fragment, safe='')}"
+    return (
+        '<a class="vault-wikilink" '
+        'data-link-state="resolved" '
+        f'data-note-path="{_e(note_path)}" '
+        f'href="{_e(href)}">{_e(str(getattr(resolution, "display_text", label)))}</a>'
+    )
+
+
+def _render_link_diagnostic(label: str, kind: str, reason: str | None) -> str:
+    reason_attr = f' title="{_e(reason)}"' if reason else ""
+    return (
+        '<span class="vault-wikilink vault-wikilink-diagnostic" '
+        f'data-link-state="{_e(kind)}"{reason_attr}>'
+        f"{_e(label)}</span>"
+    )
+
+
+def _resolution_fragment(resolution: object) -> str:
+    heading = getattr(resolution, "heading", None)
+    block_id = getattr(resolution, "block_id", None)
+    if block_id:
+        return f"^{block_id}"
+    return str(heading or "")
+
+
+def _render_obsidian_embed(raw: str, context: _RenderContext) -> str:
+    return _render_asset(raw, context, kind="obsidian-embed", alt=None)
+
+
+def _render_markdown_image(raw: str, context: _RenderContext) -> str:
+    match = re.match(r"!\[([^\]\n]*)\]\(([^)\n]+)\)", raw)
+    if not match:
+        return _e(raw)
+    return _render_asset(match.group(2).strip(), context, kind="markdown-image", alt=match.group(1))
+
+
+def _render_asset(
+    raw_target: str,
+    context: _RenderContext,
+    *,
+    kind: str,
+    alt: str | None,
+) -> str:
+    try:
+        resolution = context.asset_resolver.resolve(
+            {
+                "notePath": context.note_path,
+                "rawTarget": raw_target,
+                "kind": kind,
+            }
+        )
+    except Exception as exc:  # Resolver contract says never throw; guard third-party stubs.
+        return _render_asset_diagnostic(raw_target, "missing", str(exc))
+
+    state = str(getattr(resolution, "kind", "missing"))
+    display_name = str(getattr(resolution, "display_name", None) or getattr(resolution, "displayName", "") or raw_target)
+    if state != "allowed":
+        return _render_asset_diagnostic(
+            display_name,
+            state,
+            str(getattr(resolution, "reason", "") or ""),
+        )
+
+    src = str(getattr(resolution, "src", "") or "")
+    if not _is_browser_safe_src(src):
+        return _render_asset_diagnostic(display_name, "blocked", "Resolved image source was not browser-safe.")
+
+    width = getattr(resolution, "width", None)
+    height = getattr(resolution, "height", None)
+    width_attr = f' width="{int(width)}"' if isinstance(width, int) else ""
+    height_attr = f' height="{int(height)}"' if isinstance(height, int) else ""
+    alt_text = alt if alt is not None else display_name
+    return (
+        '<img class="vault-image" data-asset-state="allowed" '
+        f'src="{_e(src)}" alt="{_e(alt_text)}"{width_attr}{height_attr}>'
+    )
+
+
+def _render_asset_diagnostic(label: str, state: str, reason: str) -> str:
+    reason_attr = f' title="{_e(reason)}"' if reason else ""
+    return (
+        '<span class="vault-asset-diagnostic" '
+        f'data-asset-state="{_e(state)}"{reason_attr}>'
+        f"{_e(label)} ({_e(state)} asset)</span>"
+    )
+
+
+def _render_diagnostics(diagnostics: list[MarkdownDiagnostic]) -> str:
+    if not diagnostics:
+        return ""
+    items = "".join(
+        '<li class="vault-diagnostic" '
+        f'data-diagnostic-code="{_e(diagnostic.code)}" '
+        f'data-diagnostic-severity="{_e(diagnostic.severity)}">'
+        f"{_e(diagnostic.message)}</li>"
+        for diagnostic in diagnostics
+    )
+    return f'<aside class="vault-diagnostics" aria-label="Markdown diagnostics"><ul>{items}</ul></aside>'
+
+
+def _render_unsupported_diagnostic(*, code: str, message: str) -> str:
+    return (
+        '<div class="unsupported-block-diagnostic" '
+        f'data-diagnostic-code="{_e(code)}">{_e(message)}</div>'
+    )
+
+
+def _is_table_start(lines: list[str], index: int) -> bool:
+    return (
+        index + 1 < len(lines)
+        and "|" in lines[index]
+        and bool(_TABLE_SEPARATOR_RE.match(lines[index + 1]))
+    )
+
+
+def _is_thematic_break(line: str) -> bool:
+    stripped = line.strip()
+    return stripped in {"---", "***", "___"}
+
+
+def _is_block_start(lines: list[str], index: int) -> bool:
+    line = lines[index]
+    return bool(
+        _FENCE_RE.match(line)
+        or _HEADING_RE.match(line)
+        or _CALLOUT_RE.match(line)
+        or line.lstrip().startswith(">")
+        or _TASK_RE.match(line)
+        or _UNORDERED_RE.match(line)
+        or _ORDERED_RE.match(line)
+        or _is_thematic_break(line)
+        or _is_table_start(lines, index)
+    )
+
+
+def _strip_obsidian_comments(text: str) -> str:
+    return _COMMENT_RE.sub("", text)
+
+
+def _strip_raw_html(text: str) -> str:
+    clean = _SCRIPT_RE.sub("", text)
+    clean = _STYLE_RE.sub("", clean)
+    clean = _EVENT_HANDLER_RE.sub("", clean)
+    clean = _JAVASCRIPT_URL_RE.sub("", clean)
+    return _HTML_TAG_RE.sub("", clean)
+
+
+def _safe_note_path(note_path: str) -> str:
+    normalized = str(note_path or "").strip().replace("\\", "/").removeprefix("./")
+    if not normalized or _ABSOLUTE_PATH_RE.match(normalized):
+        return ""
+    return normalized
+
+
+def _is_browser_safe_src(src: str) -> bool:
+    normalized = str(src or "").strip()
+    lowered = normalized.lower()
+    if not normalized or lowered.startswith(_BLOCKED_SRC_SCHEMES):
+        return False
+    if _WINDOWS_ABSOLUTE_PATH_RE.match(normalized):
+        return False
+    if normalized.startswith("/") and not normalized.startswith("/api/"):
+        return False
+    return not normalized.startswith(_LOCAL_PATH_PREFIXES)
+
+
+def _e(value: object) -> str:
+    return html.escape(str(value), quote=True)

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -40,8 +40,8 @@ import sys
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Optional
 from urllib.parse import parse_qs, quote, urlparse
-import yaml
 
+from companion_ui.renderer import parse_vault_markdown, render_vault_markdown
 from companion_ui.workspace.real_note_workspace_dev_page import (
     NoteLoadIntent,
     RealNoteWorkspaceDevPage,
@@ -77,37 +77,15 @@ def _status_label(value: object, *, fallback: str = "unknown") -> str:
 
 
 def _split_frontmatter(body: str) -> tuple[list[str], str]:
-    """Split a YAML frontmatter prefix off ``body``.
+    """Split a frontmatter prefix off ``body`` using the renderer parser.
 
     Returns ``(frontmatter_lines, remaining_body)``. If the body does not begin
-    with a ``---``/``---`` fenced YAML block, returns ``([], body)`` unchanged.
-
-    Frontmatter is treated as opaque text for rendering — keys are surfaced as
-    chrome but not parsed into a typed model here. The runtime owns parsing for
-    contract purposes (#1253); this helper only ensures the body region does
-    not display the frontmatter as prose.
+    with a ``---``/``---`` fenced block, returns ``([], body)`` unchanged.
     """
-    if not body.startswith("---"):
+    document = parse_vault_markdown(body)
+    if document.frontmatter is None:
         return [], body
-    lines = body.split("\n")
-    if not lines or lines[0].strip() != "---":
-        return [], body
-    end_idx: int | None = None
-    for i in range(1, len(lines)):
-        if lines[i].strip() == "---":
-            end_idx = i
-            break
-    if end_idx is None:
-        return [], body
-    fm_lines = lines[1:end_idx]
-    try:
-        parsed = yaml.safe_load("\n".join(fm_lines))
-    except Exception:
-        return [], body
-    if parsed is not None and not isinstance(parsed, dict):
-        return [], body
-    remaining = "\n".join(lines[end_idx + 1:])
-    return fm_lines, remaining
+    return document.frontmatter.splitlines(), document.body_markdown
 
 
 def _render_note_frontmatter_region(frontmatter_lines: list[str]) -> str:
@@ -292,7 +270,8 @@ def _render_note_section(fields: dict) -> str:
     Canvas/Panel integration.
     """
     title = _e(fields.get("title", ""))
-    note_path_val = _e(fields.get("note_path", ""))
+    raw_note_path = str(fields.get("note_path", "") or "")
+    note_path_val = _e(raw_note_path)
     artifact_id = _e(fields.get("artifact_id", ""))
     content_hash = _e(fields.get("content_hash", ""))
     artifact_kind = _e(_status_label(fields.get("artifact_kind"), fallback="human_note"))
@@ -308,8 +287,13 @@ def _render_note_section(fields: dict) -> str:
     vault_channel = _e(fields.get("runtime_vault_channel") or "unknown")
     vault_provenance = fields.get("runtime_vault_provenance") or "unresolved"
     raw_body = str(fields.get("body", "") or "")
-    frontmatter_lines, stripped_body = _split_frontmatter(raw_body)
-    body = _e(stripped_body)
+    rendered_body = render_vault_markdown(raw_body, note_path=raw_note_path)
+    frontmatter_lines = (
+        rendered_body.document.frontmatter.splitlines()
+        if rendered_body.document.frontmatter is not None
+        else []
+    )
+    body = rendered_body.html
     note_frontmatter_html = _render_note_frontmatter_region(frontmatter_lines)
     panel_rail = _e(fields.get("panel_rail", "Panel / agent rail placeholder"))
     canvas_session_id = _e(fields.get("canvas_session_id") or "")
@@ -589,7 +573,7 @@ def _render_note_section(fields: dict) -> str:
       </header>
       {note_frontmatter_html}
       <div class="note-body" data-testid="workspace-note-body" data-region="note-body">
-        <pre class="note-body-content">{body}</pre>
+        <div class="note-body-content">{body}</div>
         {suggested_insertions_html}
       </div>
       {_render_body_edit_panel(update_flow_available, note_path_val)}
@@ -2395,12 +2379,82 @@ def render_index_html(
       max-width: 920px;
       min-height: 100%;
       padding: 28px 32px;
-      font-family: var(--font-mono);
-      font-size: var(--text-sm);
+      font-family: var(--font-ui);
+      font-size: var(--text-base);
       color: var(--fg-1);
       line-height: 1.75;
-      white-space: pre-wrap;
       word-break: break-word;
+    }}
+    .vault-markdown-rendered h1,
+    .vault-markdown-rendered h2,
+    .vault-markdown-rendered h3 {{
+      color: var(--fg-0);
+      line-height: 1.2;
+      margin: 0 0 14px;
+    }}
+    .vault-markdown-rendered h1 {{ font-size: clamp(2rem, 4vw, 3rem); }}
+    .vault-markdown-rendered h2 {{ font-size: 1.6rem; margin-top: 28px; }}
+    .vault-markdown-rendered h3 {{ font-size: 1.25rem; margin-top: 22px; }}
+    .vault-markdown-rendered p,
+    .vault-markdown-rendered ul,
+    .vault-markdown-rendered ol,
+    .vault-markdown-rendered blockquote,
+    .vault-markdown-rendered table,
+    .vault-markdown-rendered pre {{
+      margin: 0 0 16px;
+    }}
+    .vault-markdown-rendered table {{
+      border-collapse: collapse;
+      width: 100%;
+    }}
+    .vault-markdown-rendered th,
+    .vault-markdown-rendered td {{
+      border: 1px solid var(--border);
+      padding: 8px 10px;
+      text-align: left;
+    }}
+    .vault-markdown-rendered th {{
+      background: rgba(255,255,255,0.05);
+      color: var(--fg-0);
+    }}
+    .vault-markdown-rendered code,
+    .vault-markdown-rendered pre {{
+      font-family: var(--font-mono);
+    }}
+    .vault-markdown-rendered pre {{
+      background: rgba(0,0,0,0.25);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      overflow-x: auto;
+      padding: 14px;
+    }}
+    .vault-wikilink {{
+      color: var(--cyan);
+      text-decoration: none;
+    }}
+    .vault-wikilink-diagnostic,
+    .vault-asset-diagnostic,
+    .unsupported-block-diagnostic,
+    .vault-diagnostics {{
+      background: rgba(212,168,67,0.12);
+      border: 1px solid rgba(212,168,67,0.35);
+      border-radius: var(--radius-sm);
+      color: var(--accent);
+      display: inline-block;
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      padding: 4px 7px;
+    }}
+    .unsupported-block-diagnostic,
+    .vault-diagnostics {{
+      display: block;
+      margin: 0 0 16px;
+    }}
+    .vault-image {{
+      border-radius: var(--radius-sm);
+      display: block;
+      height: auto;
+      max-width: 100%;
     }}
     .suggested-insertion {{
       background: rgba(212,168,67,0.08);

--- a/companion-ui/docs/COMPANION_UI_TARGET_ARCHITECTURE.md
+++ b/companion-ui/docs/COMPANION_UI_TARGET_ARCHITECTURE.md
@@ -125,7 +125,7 @@ The detailed localhost/LAN/Tailscale/token/CSRF posture is defined in
 
 ## 5. Current Shipped State
 
-As of 2026-05-19 (after PR #1101, PR #1108, PR #1119 merged):
+As of 2026-05-26 (after PR #1101, PR #1108, PR #1119, and the Obsidian renderer parser/resolver slices merged):
 
 | Component | State |
 |---|---|
@@ -133,6 +133,8 @@ As of 2026-05-19 (after PR #1101, PR #1108, PR #1119 merged):
 | Real-note workspace dev page model | Shipped — `companion_ui/workspace/real_note_workspace_dev_page.py` (#1072 / PR #1101) |
 | Browser dev server | Shipped — `companion_ui/workspace/serve_dev_page.py` (#1103 / PR #1108) |
 | Real-note workspace visual shell (first alignment pass) | Shipped — Yggdrasil tokens, note body primary, companion rail placeholder (#1119). Dev/staging only. |
+| Obsidian-compatible Markdown parser and resolvers | Shipped — `companion_ui/renderer/` parser, link resolver, and asset resolver provide read-only parsing/resolution boundaries (#1296, #1297, #1298). |
+| Vault Markdown renderer core | Shipped — Python server-side read-only renderer wired into the Python-served note body. The implementation does not add a React/TypeScript frontend stack; unsafe HTML is stripped/escaped, wikilinks/assets route through resolver boundaries, and callout/Mermaid/properties upgrades remain in follow-up renderer slices (#1299). |
 | Canvas Core models and session API | Shipped — `companion_ui/canvas_core/`, `app/api/routes/canvas.py` behind `CANVAS_ENABLED` |
 | Canvas Suggestion Flow models | Shipped — `companion_ui/canvas_suggestion_flow/` (browser integration pending) |
 | Panel models and confirmation service | Shipped — `companion_ui/panel/`, `app/panel/confirmation.py`, `POST /api/panel/confirm` |

--- a/tests/companion_ui/test_obsidian_compatibility_fixtures.py
+++ b/tests/companion_ui/test_obsidian_compatibility_fixtures.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from companion_ui.renderer import parse_vault_markdown
+from companion_ui.renderer import parse_vault_markdown, render_vault_markdown
 
 
 FIXTURE_DIR = (
@@ -40,6 +40,16 @@ def test_obsidian_fixture_raw_markdown_round_trips(fixture_name: str) -> None:
 
     assert document.raw_markdown == raw_markdown
     assert isinstance(document.body_markdown, str)
+
+
+@pytest.mark.parametrize("fixture_name", FIXTURE_NAMES)
+def test_obsidian_fixture_renders_without_crash(fixture_name: str) -> None:
+    raw_markdown = (FIXTURE_DIR / fixture_name).read_text(encoding="utf-8")
+
+    rendered = render_vault_markdown(raw_markdown, note_path="Notes/current.md")
+
+    assert rendered.html
+    assert 'class="vault-markdown-rendered"' in rendered.html
 
 
 def test_full_smoke_fixture_extracts_all_parser_reference_types() -> None:

--- a/tests/companion_ui/test_real_note_workspace_visual_shell.py
+++ b/tests/companion_ui/test_real_note_workspace_visual_shell.py
@@ -239,7 +239,8 @@ class TestNoteBody:
             re.DOTALL,
         )
         assert body_region, "workspace-note-body region missing"
-        assert "<pre" in body_region.group(), "body content must be in a pre inside the body region"
+        assert 'class="vault-markdown-rendered"' in body_region.group()
+        assert '<h1 id="test">Test</h1>' in body_region.group()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/companion_ui/test_vault_markdown_renderer.py
+++ b/tests/companion_ui/test_vault_markdown_renderer.py
@@ -1,0 +1,163 @@
+"""VaultMarkdownRenderer integration coverage for the Obsidian note surface."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from companion_ui.renderer import render_vault_markdown
+from companion_ui.renderer.asset_resolver import VaultAssetResolver
+from companion_ui.renderer.link_resolver import VaultLinkResolver
+
+
+FIXTURE_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "companion-ui"
+    / "companion-app"
+    / "tests"
+    / "fixtures"
+    / "obsidian-renderer"
+)
+
+FIXTURE_NAMES = [
+    "basic.md",
+    "frontmatter-properties.md",
+    "malformed-frontmatter.md",
+    "wikilinks.md",
+    "embeds-images.md",
+    "callouts.md",
+    "mermaid.md",
+    "comments-and-html.md",
+    "missing-links-assets.md",
+    "full-smoke.md",
+]
+
+
+def _fixture(name: str) -> str:
+    return (FIXTURE_DIR / name).read_text(encoding="utf-8")
+
+
+def _link_resolver() -> VaultLinkResolver:
+    return VaultLinkResolver(
+        {
+            "ExistingNote": "Notes/ExistingNote.md",
+            "AmbiguousNote": [
+                "Notes/AmbiguousNote.md",
+                "Archive/AmbiguousNote.md",
+            ],
+            "README": [
+                "README.md",
+                "docs/README.md",
+            ],
+        }
+    )
+
+
+def _asset_resolver() -> VaultAssetResolver:
+    return VaultAssetResolver(
+        {
+            "test-image.png": "/api/companion/vault-assets/test-image.png",
+        }
+    )
+
+
+def test_basic_fixtures() -> None:
+    for fixture_name in FIXTURE_NAMES:
+        rendered = render_vault_markdown(
+            _fixture(fixture_name),
+            note_path="Notes/current.md",
+            link_resolver=_link_resolver(),
+            asset_resolver=_asset_resolver(),
+        )
+
+        assert rendered.html
+        assert 'class="vault-markdown-rendered"' in rendered.html
+        assert "file://" not in rendered.html
+        assert "javascript:" not in rendered.html.lower()
+
+    basic = render_vault_markdown(_fixture("basic.md"))
+    assert '<h1 id="heading-1">Heading 1</h1>' in basic.html
+    assert '<h2 id="custom-anchor">Heading 2</h2>' in basic.html
+    assert "<strong>bold</strong>" in basic.html
+    assert "<em>italic</em>" in basic.html
+    assert "<del>strikethrough</del>" in basic.html
+    assert "<table>" in basic.html
+    assert 'class="task-list"' in basic.html
+    assert 'data-task-state="/"' in basic.html
+    assert 'data-language="python"' in basic.html
+
+
+def test_frontmatter_excluded_from_body() -> None:
+    rendered = render_vault_markdown(_fixture("frontmatter-properties.md"))
+
+    assert "Body text that must NOT include" in rendered.html
+    assert "custom_field" not in rendered.html
+    assert "aliases:" not in rendered.html
+    assert rendered.document.frontmatter is not None
+
+
+def test_internal_links() -> None:
+    rendered = render_vault_markdown(
+        _fixture("wikilinks.md"),
+        note_path="Notes/current.md",
+        link_resolver=_link_resolver(),
+    )
+
+    assert 'data-link-state="resolved"' in rendered.html
+    assert 'data-link-state="missing"' in rendered.html
+    assert 'data-link-state="ambiguous"' in rendered.html
+    assert "Display Alias" in rendered.html
+    assert "NonExistentNote12345" in rendered.html
+    assert "ambiguous link" in rendered.html
+    assert "Notes/ExistingNote.md" in rendered.html
+
+
+def test_image_rendering() -> None:
+    rendered = render_vault_markdown(
+        _fixture("embeds-images.md"),
+        asset_resolver=_asset_resolver(),
+    )
+
+    assert '<img class="vault-image"' in rendered.html
+    assert 'src="/api/companion/vault-assets/test-image.png"' in rendered.html
+    assert 'width="100"' in rendered.html
+    assert 'height="145"' in rendered.html
+    assert 'data-asset-state="blocked"' in rendered.html
+    assert 'data-asset-state="unsupported"' in rendered.html
+    assert "file://" not in rendered.html
+
+
+def test_unsafe_html_stripped() -> None:
+    rendered = render_vault_markdown(_fixture("comments-and-html.md"))
+    lowered = rendered.html.lower()
+
+    assert "<script" not in lowered
+    assert "onerror" not in lowered
+    assert "alert(" not in lowered
+    assert "This comment should be hidden" not in rendered.html
+    assert "styled text" in rendered.html
+
+
+def test_no_write_calls() -> None:
+    rendered = render_vault_markdown(
+        "A [[ExistingNote]] and ![[test-image.png]]",
+        note_path="Notes/current.md",
+        link_resolver=_link_resolver(),
+        asset_resolver=_asset_resolver(),
+    )
+
+    assert rendered.write_calls == ()
+    assert "POST" not in rendered.html
+    assert "PUT" not in rendered.html
+    assert "PATCH" not in rendered.html
+    assert "DELETE" not in rendered.html
+
+    renderer_source = (
+        Path(__file__).resolve().parents[2]
+        / "companion-ui"
+        / "companion-app"
+        / "companion_ui"
+        / "renderer"
+        / "vault_markdown_renderer.py"
+    ).read_text(encoding="utf-8")
+    for forbidden_call in ("httpx.", "WorkspaceHttpClient", ".post(", ".put(", ".patch(", ".delete("):
+        assert forbidden_call not in renderer_source

--- a/tests/companion_ui/test_workspace_shell_alignment.py
+++ b/tests/companion_ui/test_workspace_shell_alignment.py
@@ -145,13 +145,13 @@ class TestFrontmatterStrippedFromBody:
         html = _html(body=_FRONTMATTER_BODY)
         body = _body_region(html)
         assert "Body paragraph here." in body
-        assert "# Heading" in body
+        assert '<h1 id="heading">Heading</h1>' in body
 
     def test_body_without_frontmatter_unchanged(self) -> None:
         body_only = "# Plain note\n\nNo frontmatter."
         html = _html(body=body_only)
         body = _body_region(html)
-        assert "# Plain note" in body
+        assert '<h1 id="plain-note">Plain note</h1>' in body
         assert "No frontmatter." in body
 
     def test_frontmatter_region_present_when_frontmatter_exists(self) -> None:
@@ -374,11 +374,12 @@ class TestRailEmptyState:
         rail = _rail_region(html)
         assert 'data-testid="workspace-rail-empty-state"' not in rail
 
-def test_delimiter_shaped_body_without_frontmatter_is_not_stripped() -> None:
+def test_malformed_frontmatter_is_omitted_from_body_with_diagnostic() -> None:
     body = "---\nThis is prose, not yaml: [\n---\n\nParagraph stays.\n"
     html = _html(body=body)
     note_body = _body_region(html)
-    assert "This is prose, not yaml" in note_body
+    assert "This is prose, not yaml" not in note_body
+    assert "frontmatter_parse_error" in note_body
     assert "Paragraph stays." in note_body
 
 


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Closes #1299

## Summary
- Adds a Python server-side `VaultMarkdownRenderer` that renders parsed vault Markdown into sanitized read-only HTML.
- Wires the renderer into the Python-served Companion UI note body, replacing the raw `<pre>` body surface.
- Updates the Companion UI target architecture to record the Phase 4 frontend-stack decision.

## Architecture Decision
- Decision: Option B, Python server-side rendering.
- Rationale: the current Companion UI is Python http.server + HTML with no npm/React build surface. Adding React/TypeScript now would add frontend infrastructure before the core read-surface contract needs it.
- Sanitization approach: raw HTML is disabled/stripped before rendering; `<script>`, `<style>`, inline event handlers, `javascript:`, `file:`, and `data:` sources are blocked; local assets render only through `VaultAssetResolver`; internal links render only through `VaultLinkResolver`.
- Follow-up posture: callouts render as unsupported diagnostics, Mermaid renders as inert fenced code, and frontmatter/properties remain body-omitted/read-only until the dedicated follow-up issues upgrade those sub-renderers.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [ ] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [ ] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [ ] `ruff check app tests`
- [x] If files under `app/` or `tests/` changed, lint output from `ruff check app tests` is included below or a tooling limitation is stated.
- [ ] `mypy app`
- [ ] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg"`
- [x] Additional targeted checks run as needed

Validation run:
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/companion_ui/test_vault_markdown_renderer.py` -> passed (6 tests)
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/companion_ui/test_obsidian_compatibility_fixtures.py` -> passed (22 tests)
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/companion_ui/test_panel_interactions.py tests/companion_ui/test_suggestion_flow_browser.py` -> passed (36 tests)
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/companion_ui -q` -> passed (953 tests)
- `python3 scripts/docs_guard.py` -> passed
- `git diff --check` -> passed

Tooling limitations:
- Dispatcher unavailable: `ModuleNotFoundError: No module named 'yaml'`; used GitHub-label-only claim fallback.
- Local lint unavailable: `ruff check app tests` returned `zsh:1: command not found: ruff`; `python3 -m ruff check app tests` returned `No module named ruff`.
- The stale issue Verify target `tests/companion_ui/test_canvas_suggestion_flow.py` is absent in the repo; issue #1299 was corrected to require the existing `test_panel_interactions.py`, and `test_suggestion_flow_browser.py` was run as extra nearby suggestion-flow coverage.

## Notes
- Renderer is intentionally read-only and exposes no task checkbox mutation, frontmatter editing, Dataview execution, or write endpoint path.
- No React/TypeScript module structure was added in this slice.
