### PR TITLE
Render Obsidian callouts in Companion UI

### DIFF
--- a/companion-ui/companion-app/companion_ui/renderer/callout_renderer.py
+++ b/companion-ui/companion-app/companion_ui/renderer/callout_renderer.py
@@ -1,0 +1,214 @@
+"""Obsidian callout rendering for the Companion UI note surface."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import html
+import re
+
+
+CALLOUT_HEADER_RE = re.compile(
+    r"^\s*>\s*\[!([A-Za-z0-9_-]+)\]([+-])?(?:\s+(.*))?\s*$"
+)
+_QUOTED_LINE_RE = re.compile(r"^\s*>\s?(.*)$")
+
+_CALLOUT_TYPE_ALIASES = {
+    "abstract": "abstract",
+    "summary": "abstract",
+    "tldr": "abstract",
+    "info": "info",
+    "todo": "todo",
+    "tip": "tip",
+    "hint": "tip",
+    "important": "tip",
+    "success": "success",
+    "check": "success",
+    "done": "success",
+    "question": "question",
+    "help": "question",
+    "faq": "question",
+    "warning": "warning",
+    "caution": "warning",
+    "attention": "warning",
+    "failure": "failure",
+    "fail": "failure",
+    "missing": "failure",
+    "danger": "danger",
+    "error": "danger",
+    "bug": "bug",
+    "example": "example",
+    "quote": "quote",
+    "cite": "quote",
+    "note": "note",
+}
+
+
+@dataclass(frozen=True)
+class ObsidianCallout:
+    """Parsed Obsidian callout block."""
+
+    callout_type: str
+    visual_type: str
+    title: str
+    fold_state: str
+    body_markdown: str
+    supported: bool
+
+
+class ObsidianCalloutRenderer:
+    """Render Obsidian `> [!type]` callouts without mutating Markdown."""
+
+    def parse(self, lines: list[str], start: int) -> tuple[ObsidianCallout, int]:
+        match = CALLOUT_HEADER_RE.match(lines[start])
+        if not match:
+            raise ValueError("line is not an Obsidian callout header")
+
+        callout_type = match.group(1).lower()
+        fold_marker = match.group(2)
+        explicit_title = (match.group(3) or "").strip()
+        index = start + 1
+        body_lines: list[str] = []
+
+        while index < len(lines):
+            quoted_line = _QUOTED_LINE_RE.match(lines[index])
+            if not quoted_line:
+                break
+            body_lines.append(quoted_line.group(1))
+            index += 1
+
+        visual_type = _CALLOUT_TYPE_ALIASES.get(callout_type, "note")
+        body_markdown = "\n".join(body_lines).strip("\n")
+
+        return (
+            ObsidianCallout(
+                callout_type=callout_type,
+                visual_type=visual_type,
+                title=explicit_title or _default_title(callout_type),
+                fold_state=_fold_state(fold_marker),
+                body_markdown=body_markdown,
+                supported=callout_type in _CALLOUT_TYPE_ALIASES,
+            ),
+            index,
+        )
+
+    def render_from_lines(
+        self,
+        lines: list[str],
+        start: int,
+        *,
+        render_body: Callable[[str], str],
+        render_title: Callable[[str], str] | None = None,
+    ) -> tuple[str, int]:
+        callout, index = self.parse(lines, start)
+        return (
+            self.render(
+                callout,
+                render_body=render_body,
+                render_title=render_title,
+            ),
+            index,
+        )
+
+    def render(
+        self,
+        callout: ObsidianCallout,
+        *,
+        render_body: Callable[[str], str],
+        render_title: Callable[[str], str] | None = None,
+    ) -> str:
+        body_html = render_body(callout.body_markdown) if callout.body_markdown else ""
+        title_html = (
+            render_title(callout.title) if render_title is not None else html.escape(callout.title)
+        )
+        classes = " ".join(
+            [
+                "vault-callout",
+                f"vault-callout--{_class_token(callout.visual_type)}",
+                f"vault-callout-source--{_class_token(callout.callout_type)}",
+            ]
+        )
+        attrs = (
+            f'class="{classes}" '
+            f'data-callout-type="{_e(callout.callout_type)}" '
+            f'data-callout-visual-type="{_e(callout.visual_type)}" '
+            f'data-callout-supported="{str(callout.supported).lower()}"'
+        )
+        title = (
+            '<span class="vault-callout-title">'
+            f"{title_html}"
+            "</span>"
+        )
+        icon = (
+            '<span class="vault-callout-icon" aria-hidden="true">'
+            f"{_e(_icon_label(callout.visual_type))}"
+            "</span>"
+        )
+        body = (
+            '<div class="vault-callout-body">'
+            f"{body_html}"
+            "</div>"
+            if body_html
+            else ""
+        )
+
+        if callout.fold_state != "none":
+            open_attr = " open" if callout.fold_state == "expanded" else ""
+            return (
+                f"<details {attrs} "
+                f'data-callout-fold="{_e(callout.fold_state)}"{open_attr}>'
+                f'<summary class="vault-callout-header">{icon}{title}</summary>'
+                f"{body}"
+                "</details>"
+            )
+
+        return (
+            f"<section {attrs}>"
+            f'<div class="vault-callout-header">{icon}{title}</div>'
+            f"{body}"
+            "</section>"
+        )
+
+
+def is_obsidian_callout_start(line: str) -> bool:
+    """Return true when a Markdown line begins an Obsidian callout block."""
+
+    return bool(CALLOUT_HEADER_RE.match(line))
+
+
+def _fold_state(marker: str | None) -> str:
+    if marker == "-":
+        return "collapsed"
+    if marker == "+":
+        return "expanded"
+    return "none"
+
+
+def _default_title(callout_type: str) -> str:
+    return callout_type.replace("-", " ").replace("_", " ").title()
+
+
+def _class_token(value: str) -> str:
+    return re.sub(r"[^a-z0-9-]+", "-", value.lower()).strip("-") or "note"
+
+
+def _icon_label(visual_type: str) -> str:
+    return {
+        "abstract": "A",
+        "bug": "B",
+        "danger": "!",
+        "example": "E",
+        "failure": "X",
+        "info": "i",
+        "note": "N",
+        "question": "?",
+        "quote": '"',
+        "success": "+",
+        "tip": "*",
+        "todo": "T",
+        "warning": "!",
+    }.get(visual_type, "N")
+
+
+def _e(value: str) -> str:
+    return html.escape(value, quote=True)

--- a/companion-ui/companion-app/companion_ui/renderer/vault_markdown_renderer.py
+++ b/companion-ui/companion-app/companion_ui/renderer/vault_markdown_renderer.py
@@ -15,6 +15,10 @@ from typing import Protocol
 from urllib.parse import quote
 
 from companion_ui.renderer.asset_resolver import VaultAssetResolver
+from companion_ui.renderer.callout_renderer import (
+    CALLOUT_HEADER_RE,
+    ObsidianCalloutRenderer,
+)
 from companion_ui.renderer.link_resolver import (
     VaultLinkResolver,
     link_display_label,
@@ -34,7 +38,7 @@ _EXPLICIT_ANCHOR_RE = re.compile(r"\s*\{#([A-Za-z0-9_-]+)\}\s*$")
 _TASK_RE = re.compile(r"^\s*[-*+]\s+\[([^\]])\]\s+(.*)$")
 _UNORDERED_RE = re.compile(r"^\s*[-*+]\s+(.*)$")
 _ORDERED_RE = re.compile(r"^\s*\d+[.)]\s+(.*)$")
-_CALLOUT_RE = re.compile(r"^\s*>\s*\[!([A-Za-z0-9_-]+)\]([+-])?(?:\s+(.*))?\s*$")
+_CALLOUT_RE = CALLOUT_HEADER_RE
 _TABLE_SEPARATOR_RE = re.compile(r"^\s*\|?\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|?\s*$")
 _COMMENT_RE = re.compile(r"%%.*?%%", re.DOTALL)
 _DIAGNOSTIC_ONLY_LANGUAGES = {"dataview", "dataviewjs", "query"}
@@ -49,6 +53,7 @@ _LOCAL_PATH_PREFIXES = (
     "/var/",
     "/Volumes/",
 )
+_CALLOUT_RENDERER = ObsidianCalloutRenderer()
 
 
 class LinkResolverProtocol(Protocol):
@@ -186,7 +191,7 @@ def _render_blocks(markdown: str, context: _RenderContext) -> str:
             continue
 
         if _CALLOUT_RE.match(line):
-            html_block, index = _render_callout_stub(lines, index, context)
+            html_block, index = _render_callout(lines, index, context)
             parts.append(html_block)
             continue
 
@@ -280,30 +285,16 @@ def _render_code_block(code: str, language: str) -> str:
     )
 
 
-def _render_callout_stub(
+def _render_callout(
     lines: list[str],
     start: int,
     context: _RenderContext,
 ) -> tuple[str, int]:
-    first_line = lines[start]
-    match = _CALLOUT_RE.match(first_line)
-    callout_type = (match.group(1) if match else "callout").lower()
-    index = start + 1
-    while index < len(lines) and (not lines[index].strip() or lines[index].lstrip().startswith(">")):
-        index += 1
-    context.diagnostics.append(
-        MarkdownDiagnostic(
-            severity="info",
-            code="unsupported_callout",
-            message=f"Callout rendering for {callout_type!r} is pending a dedicated renderer.",
-        )
-    )
-    return (
-        _render_unsupported_diagnostic(
-            code="unsupported_callout",
-            message=f"Callout rendering pending: {callout_type}",
-        ),
-        index,
+    return _CALLOUT_RENDERER.render_from_lines(
+        lines,
+        start,
+        render_body=lambda body_markdown: _render_blocks(body_markdown, context),
+        render_title=lambda title: _render_inline(title, context),
     )
 
 

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -2428,6 +2428,61 @@ def render_index_html(
       overflow-x: auto;
       padding: 14px;
     }}
+    .vault-callout {{
+      --callout-rgb: 0, 212, 232;
+      --callout-color: rgb(var(--callout-rgb));
+      background: rgba(var(--callout-rgb), 0.08);
+      border: 1px solid rgba(var(--callout-rgb), 0.25);
+      border-left: 4px solid var(--callout-color);
+      border-radius: var(--radius-md);
+      margin: 0 0 16px;
+      padding: 12px 14px;
+    }}
+    .vault-callout--warning {{ --callout-rgb: 212, 168, 67; }}
+    .vault-callout--danger,
+    .vault-callout--failure,
+    .vault-callout--bug {{ --callout-rgb: 255, 61, 61; }}
+    .vault-callout--success,
+    .vault-callout--tip {{ --callout-rgb: 98, 208, 123; }}
+    .vault-callout--question,
+    .vault-callout--example {{ --callout-rgb: 74, 158, 255; }}
+    .vault-callout--quote {{ --callout-rgb: 122, 154, 184; }}
+    .vault-callout-header {{
+      align-items: center;
+      color: var(--callout-color);
+      display: flex;
+      font-family: var(--font-ui);
+      font-size: var(--text-sm);
+      font-weight: 600;
+      gap: 8px;
+      line-height: 1.35;
+    }}
+    .vault-callout > summary.vault-callout-header {{
+      cursor: pointer;
+      list-style: none;
+    }}
+    .vault-callout > summary.vault-callout-header::-webkit-details-marker {{
+      display: none;
+    }}
+    .vault-callout-icon {{
+      align-items: center;
+      border: 1px solid rgba(var(--callout-rgb), 0.4);
+      border-radius: 999px;
+      display: inline-flex;
+      flex: 0 0 auto;
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      height: 20px;
+      justify-content: center;
+      line-height: 1;
+      width: 20px;
+    }}
+    .vault-callout-body {{
+      margin-top: 10px;
+    }}
+    .vault-callout-body > :last-child {{
+      margin-bottom: 0;
+    }}
     .vault-wikilink {{
       color: var(--cyan);
       text-decoration: none;

--- a/tests/companion_ui/test_obsidian_callout_renderer.py
+++ b/tests/companion_ui/test_obsidian_callout_renderer.py
@@ -1,0 +1,159 @@
+"""Obsidian callout rendering coverage for the Companion UI note surface."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from companion_ui.renderer import render_vault_markdown
+from companion_ui.renderer.link_resolver import VaultLinkResolver
+
+
+FIXTURE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "companion-ui"
+    / "companion-app"
+    / "tests"
+    / "fixtures"
+    / "obsidian-renderer"
+    / "callouts.md"
+)
+
+
+def _fixture() -> str:
+    return FIXTURE_PATH.read_text(encoding="utf-8")
+
+
+def _render_fixture(raw_markdown: str | None = None) -> str:
+    rendered = render_vault_markdown(
+        _fixture() if raw_markdown is None else raw_markdown,
+        note_path="Notes/current.md",
+        link_resolver=VaultLinkResolver({"WikiLink": "Notes/WikiLink.md"}),
+    )
+    assert rendered.write_calls == ()
+    return rendered.html
+
+
+def test_basic_callout() -> None:
+    html = _render_fixture()
+
+    assert 'data-callout-type="note"' in html
+    assert 'class="vault-callout vault-callout--note vault-callout-source--note"' in html
+    assert '<span class="vault-callout-title">Note</span>' in html
+    assert "Basic note callout body." in html
+
+
+def test_custom_title() -> None:
+    html = _render_fixture()
+
+    assert 'data-callout-type="warning"' in html
+    assert 'data-callout-visual-type="warning"' in html
+    assert '<span class="vault-callout-title">Custom Title Here</span>' in html
+    assert "Warning with custom title." in html
+
+
+def test_foldable_collapsed() -> None:
+    html = _render_fixture()
+
+    assert re.search(
+        r"<details [^>]*data-callout-type=\"tip\"[^>]*data-callout-fold=\"collapsed\"",
+        html,
+    )
+    assert not re.search(
+        r"<details [^>]*data-callout-type=\"tip\"[^>]*open",
+        html,
+    )
+    assert "Foldable callout collapsed by default." in html
+
+
+def test_foldable_expanded() -> None:
+    html = _render_fixture()
+
+    assert re.search(
+        r"<details [^>]*data-callout-type=\"faq\"[^>]*data-callout-fold=\"expanded\"[^>]*open",
+        html,
+    )
+    assert 'data-callout-visual-type="question"' in html
+    assert "Foldable callout expanded by default." in html
+
+
+def test_title_only() -> None:
+    raw_markdown = _fixture().replace(
+        "> [!abstract]\n> Title-only callout - no body line",
+        "> [!abstract] Title-only callout - no body line",
+    )
+    html = _render_fixture(raw_markdown)
+
+    assert 'data-callout-type="abstract"' in html
+    assert '<span class="vault-callout-title">Title-only callout - no body line</span>' in html
+    assert "vault-callout-body" not in _callout_fragment(html, "abstract")
+
+
+def test_nested_callout() -> None:
+    html = _render_fixture()
+
+    assert re.search(
+        r'data-callout-type="info".*data-callout-type="note".*'
+        r"Nested callout inside outer callout\.",
+        html,
+        re.DOTALL,
+    )
+
+
+def test_unsupported_type_fallback() -> None:
+    html = _render_fixture()
+
+    fragment = _callout_fragment(html, "custom-type")
+    assert 'data-callout-type="custom-type"' in fragment
+    assert 'data-callout-visual-type="note"' in fragment
+    assert 'data-callout-supported="false"' in fragment
+    assert "vault-callout--note" in fragment
+    assert "Unsupported/custom type should default to note-like treatment." in fragment
+    assert "unsupported_callout" not in html
+
+
+def test_fold_no_mutation() -> None:
+    rendered = render_vault_markdown(_fixture(), note_path="Notes/current.md")
+    source_paths = [
+        Path(__file__).resolve().parents[2]
+        / "companion-ui"
+        / "companion-app"
+        / "companion_ui"
+        / "renderer"
+        / "callout_renderer.py",
+        Path(__file__).resolve().parents[2]
+        / "companion-ui"
+        / "companion-app"
+        / "companion_ui"
+        / "renderer"
+        / "vault_markdown_renderer.py",
+    ]
+    source_text = "\n".join(path.read_text(encoding="utf-8") for path in source_paths)
+
+    assert rendered.write_calls == ()
+    assert "<details" in rendered.html
+    for forbidden in ("fetch(", "httpx.", ".post(", ".put(", ".patch(", ".delete("):
+        assert forbidden not in source_text
+
+
+def test_callouts_fixture() -> None:
+    html = _render_fixture()
+
+    assert html
+    assert html.count('data-callout-type="') == 8
+    assert "<strong>bold</strong>" in html
+    assert 'class="vault-wikilink" data-link-state="resolved"' in html
+    assert "Notes/WikiLink.md" in html
+    assert "unsupported_callout" not in html
+
+
+def _callout_fragment(html: str, callout_type: str) -> str:
+    data_start = html.index(f'data-callout-type="{callout_type}"')
+    section_start = html.rfind("<section", 0, data_start)
+    details_start = html.rfind("<details", 0, data_start)
+    start = max(section_start, details_start)
+    next_section = html.find("<section", data_start + 1)
+    next_details = html.find("<details", data_start + 1)
+    candidates = [index for index in (next_section, next_details) if index != -1]
+    end = min(candidates) if candidates else len(html)
+    return html[start:end]


### PR DESCRIPTION
Closes #1300

## Summary
- Add `ObsidianCalloutRenderer` for Obsidian `> [!type]` callouts, including custom titles, native local fold state, nested Markdown body rendering, and note-like fallback for custom types.
- Replace the #1299 unsupported-callout diagnostic path in `VaultMarkdownRenderer` with the dedicated callout renderer.
- Add callout-only note-surface CSS and focused fixture-backed tests.

## Coordination
- Dispatcher unavailable: `python3 -m app.dispatcher status --json` failed because the local environment is missing `yaml`; used GitHub-label fallback claim via `scripts/issue_pickup_claim.sh --issue 1300`.

## Validation
- `pytest tests/companion_ui/test_obsidian_callout_renderer.py`
- `pytest tests/companion_ui/test_vault_markdown_renderer.py`
- `pytest tests/companion_ui/test_obsidian_compatibility_fixtures.py`
- `pytest tests/companion_ui/test_real_note_workspace_dev_page.py tests/companion_ui/test_real_note_workspace_dev_server.py`
- `git diff --check`
- `ruff check app tests` not run: local `ruff` executable is not installed (`RUFF_NOT_FOUND`).