### PR TITLE
Render Mermaid fences safely in Companion UI

### DIFF
--- a/companion-ui/companion-app/companion_ui/renderer/__init__.py
+++ b/companion-ui/companion-app/companion_ui/renderer/__init__.py
@@ -13,6 +13,11 @@ from companion_ui.renderer.models import (
     VaultMarkdownDocument,
     WikiLinkRef,
 )
+from companion_ui.renderer.mermaid_renderer import (
+    MermaidBlockRenderer,
+    MermaidRenderError,
+    MermaidRenderResult,
+)
 from companion_ui.renderer.vault_markdown_parser import parse_vault_markdown
 from companion_ui.renderer.vault_markdown_renderer import (
     RenderedVaultMarkdown,
@@ -28,6 +33,9 @@ __all__ = [
     "HeadingRef",
     "LinkResolution",
     "MarkdownDiagnostic",
+    "MermaidBlockRenderer",
+    "MermaidRenderError",
+    "MermaidRenderResult",
     "ObsidianCommentRef",
     "SourceRange",
     "VaultMarkdownDocument",

--- a/companion-ui/companion-app/companion_ui/renderer/mermaid_renderer.py
+++ b/companion-ui/companion-app/companion_ui/renderer/mermaid_renderer.py
@@ -1,0 +1,222 @@
+"""Safe Mermaid fenced-block rendering for the Companion UI note surface.
+
+The current Python server-side UI has no sandboxed Mermaid runtime. Until a
+safe client component can be configured and tested, Mermaid blocks render as an
+inert diagram shell with preserved source instead of executing Mermaid code.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import html
+import re
+
+from companion_ui.renderer.models import MarkdownDiagnostic
+
+
+_MERMAID_START_RE = re.compile(
+    r"^(?:"
+    r"graph(?:\s+(?:TB|TD|BT|RL|LR))?|"
+    r"flowchart(?:\s+(?:TB|TD|BT|RL|LR))?|"
+    r"sequenceDiagram|"
+    r"classDiagram(?:-v2)?|"
+    r"stateDiagram(?:-v2)?|"
+    r"erDiagram|"
+    r"journey|"
+    r"gantt|"
+    r"pie(?:\s+showData)?|"
+    r"mindmap|"
+    r"timeline|"
+    r"quadrantChart|"
+    r"requirementDiagram|"
+    r"gitGraph|"
+    r"C4Context|C4Container|C4Component|C4Dynamic"
+    r")\b",
+    re.IGNORECASE,
+)
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+_INLINE_CONFIG_RE = re.compile(r"%%\{\s*(?:init|initialize)\s*:", re.IGNORECASE)
+_MERMAID_LINK_RE = re.compile(r"(?im)^\s*(?:click|href)\s+")
+_EXTERNAL_TARGET_RE = re.compile(r"(?i)(?:https?:)?//|file:|javascript:|data:")
+_UNSAFE_COMPONENT_RE = re.compile(
+    r"(?is)"
+    r"<\s*(?:script|iframe|object|embed|link|meta|img)\b|"
+    r"\son[a-z]+\s*=|"
+    r"(?:href|src)\s*=\s*['\"]?\s*(?:https?:|//|file:|javascript:|data:)"
+)
+
+
+@dataclass(frozen=True)
+class MermaidRenderResult:
+    """HTML plus diagnostics emitted while rendering a Mermaid fenced block."""
+
+    html: str
+    diagnostics: tuple[MarkdownDiagnostic, ...] = ()
+
+
+class MermaidRenderError(RuntimeError):
+    """Raised when the controlled Mermaid component fails its safety boundary."""
+
+
+class MermaidBlockRenderer:
+    """Render Mermaid fences without script execution or external resource access."""
+
+    def render(self, source: str) -> MermaidRenderResult:
+        """Render Mermaid source into controlled HTML.
+
+        All exceptions from validation or the component boundary are converted
+        into diagnostic HTML so the note surface cannot crash.
+        """
+
+        normalized_source = _normalize_source(source)
+        try:
+            invalid_reason = _invalid_mermaid_reason(normalized_source)
+            if invalid_reason:
+                return _render_error_result(
+                    normalized_source,
+                    code="invalid_mermaid",
+                    message="Mermaid diagram could not be rendered.",
+                    detail=invalid_reason,
+                )
+
+            component_html = self._render_component(normalized_source)
+            if not component_html:
+                raise MermaidRenderError("Mermaid component returned no content.")
+            if _UNSAFE_COMPONENT_RE.search(component_html):
+                raise MermaidRenderError("Mermaid component returned unsafe markup.")
+
+            diagnostics = _link_policy_diagnostics(normalized_source)
+            return MermaidRenderResult(
+                html=_render_figure(
+                    normalized_source,
+                    state="source-fallback",
+                    body_html=component_html,
+                ),
+                diagnostics=diagnostics,
+            )
+        except Exception as exc:
+            return _render_error_result(
+                normalized_source,
+                code="mermaid_render_error",
+                message="Mermaid rendering failed and was contained.",
+                detail=str(exc),
+            )
+
+    def _render_component(self, source: str) -> str:
+        return _render_source_fallback_component(source)
+
+
+def _normalize_source(source: str) -> str:
+    return str(source or "").replace("\r\n", "\n").replace("\r", "\n").strip("\n")
+
+
+def _invalid_mermaid_reason(source: str) -> str | None:
+    if not source.strip():
+        return "Mermaid diagram source is empty."
+    if _CONTROL_CHAR_RE.search(source):
+        return "Mermaid diagram source contains unsupported control characters."
+    if _INLINE_CONFIG_RE.search(source):
+        return "Inline Mermaid configuration directives are disabled by policy."
+
+    first_line = _first_meaningful_line(source)
+    if not first_line or not _MERMAID_START_RE.match(first_line):
+        return "Mermaid diagram source does not start with a supported diagram type."
+    return None
+
+
+def _first_meaningful_line(source: str) -> str:
+    for line in source.split("\n"):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("%%"):
+            continue
+        return stripped
+    return ""
+
+
+def _link_policy_diagnostics(source: str) -> tuple[MarkdownDiagnostic, ...]:
+    if not (_MERMAID_LINK_RE.search(source) or _EXTERNAL_TARGET_RE.search(source)):
+        return ()
+    return (
+        MarkdownDiagnostic(
+            severity="warning",
+            code="mermaid_link_policy",
+            message=(
+                "Mermaid link directives are rendered as inert source and do not "
+                "bypass Companion UI link policy."
+            ),
+        ),
+    )
+
+
+def _render_source_fallback_component(source: str) -> str:
+    _ = source
+    return (
+        '<div class="vault-mermaid-diagram" '
+        'data-testid="vault-mermaid-diagram" '
+        'data-mermaid-render-mode="source-fallback" '
+        'role="img" '
+        'aria-label="Mermaid diagram source preview">'
+        '<div class="vault-mermaid-diagnostic" '
+        'data-diagnostic-code="mermaid_source_fallback">'
+        "Mermaid source is displayed because safe client-side Mermaid rendering "
+        "is not configured in this server-rendered UI."
+        "</div>"
+        "</div>"
+    )
+
+
+def _render_error_result(
+    source: str,
+    *,
+    code: str,
+    message: str,
+    detail: str,
+) -> MermaidRenderResult:
+    diagnostic = MarkdownDiagnostic(
+        severity="error",
+        code=code,
+        message=f"{message} {detail}".strip(),
+    )
+    body_html = (
+        '<div class="vault-mermaid-error" '
+        'data-testid="vault-mermaid-error" '
+        f'data-diagnostic-code="{_e(code)}" '
+        'role="alert">'
+        f"{_e(message)}"
+        f'<span class="vault-mermaid-error-detail">{_e(detail)}</span>'
+        "</div>"
+    )
+    return MermaidRenderResult(
+        html=_render_figure(source, state="error", body_html=body_html),
+        diagnostics=(diagnostic,),
+    )
+
+
+def _render_figure(source: str, *, state: str, body_html: str) -> str:
+    return (
+        '<figure class="vault-mermaid-block" '
+        'data-testid="vault-mermaid-block" '
+        f'data-mermaid-state="{_e(state)}" '
+        'data-source-preserved="true" '
+        'data-network-policy="blocked">'
+        f"{body_html}"
+        f"{_render_source_details(source)}"
+        "</figure>"
+    )
+
+
+def _render_source_details(source: str) -> str:
+    return (
+        '<details class="vault-mermaid-source" '
+        'data-testid="vault-mermaid-source" '
+        "open>"
+        "<summary>Mermaid source</summary>"
+        '<pre class="vault-code-block vault-mermaid-source-code" data-language="mermaid">'
+        f'<code class="language-mermaid">{_e(source)}</code>'
+        "</pre>"
+        "</details>"
+    )
+
+
+def _e(value: object) -> str:
+    return html.escape(str(value), quote=True)

--- a/companion-ui/companion-app/companion_ui/renderer/vault_markdown_renderer.py
+++ b/companion-ui/companion-app/companion_ui/renderer/vault_markdown_renderer.py
@@ -20,6 +20,7 @@ from companion_ui.renderer.link_resolver import (
     link_display_label,
     parse_wikilink,
 )
+from companion_ui.renderer.mermaid_renderer import MermaidBlockRenderer
 from companion_ui.renderer.models import (
     MarkdownDiagnostic,
     VaultMarkdownDocument,
@@ -110,6 +111,7 @@ class _RenderContext:
     note_path: str
     link_resolver: LinkResolverProtocol
     asset_resolver: AssetResolverProtocol
+    mermaid_renderer: MermaidBlockRenderer
     diagnostics: list[MarkdownDiagnostic]
 
 
@@ -121,9 +123,11 @@ class VaultMarkdownRenderer:
         *,
         link_resolver: LinkResolverProtocol | None = None,
         asset_resolver: AssetResolverProtocol | None = None,
+        mermaid_renderer: MermaidBlockRenderer | None = None,
     ) -> None:
         self._link_resolver = link_resolver or VaultLinkResolver({})
         self._asset_resolver = asset_resolver or VaultAssetResolver({})
+        self._mermaid_renderer = mermaid_renderer or MermaidBlockRenderer()
 
     def render(
         self,
@@ -137,6 +141,7 @@ class VaultMarkdownRenderer:
             note_path=_safe_note_path(note_path),
             link_resolver=self._link_resolver,
             asset_resolver=self._asset_resolver,
+            mermaid_renderer=self._mermaid_renderer,
             diagnostics=diagnostics,
         )
         body_markdown = _strip_obsidian_comments(parsed.body_markdown)
@@ -160,12 +165,14 @@ def render_vault_markdown(
     note_path: str = "",
     link_resolver: LinkResolverProtocol | None = None,
     asset_resolver: AssetResolverProtocol | None = None,
+    mermaid_renderer: MermaidBlockRenderer | None = None,
 ) -> RenderedVaultMarkdown:
     """Convenience wrapper for one-shot rendering."""
 
     return VaultMarkdownRenderer(
         link_resolver=link_resolver,
         asset_resolver=asset_resolver,
+        mermaid_renderer=mermaid_renderer,
     ).render(raw_markdown, note_path=note_path)
 
 
@@ -251,6 +258,11 @@ def _render_fenced_code(
         index += 1
 
     code = "\n".join(code_lines)
+    if language == "mermaid":
+        rendered_mermaid = context.mermaid_renderer.render(code)
+        context.diagnostics.extend(rendered_mermaid.diagnostics)
+        return rendered_mermaid.html, index
+
     if language in _DIAGNOSTIC_ONLY_LANGUAGES:
         context.diagnostics.append(
             MarkdownDiagnostic(

--- a/tests/companion_ui/test_mermaid_block_renderer.py
+++ b/tests/companion_ui/test_mermaid_block_renderer.py
@@ -1,0 +1,103 @@
+"""Mermaid fenced-block rendering coverage for the Companion UI note surface."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from companion_ui.renderer import render_vault_markdown
+from companion_ui.renderer.mermaid_renderer import MermaidBlockRenderer
+
+
+FIXTURE_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "companion-ui"
+    / "companion-app"
+    / "tests"
+    / "fixtures"
+    / "obsidian-renderer"
+)
+MERMAID_SOURCE = """graph TD
+    A[Start] --> B{Is it?}
+    B -- Yes --> C[OK]
+"""
+
+
+def _render_mermaid(source: str):
+    return render_vault_markdown(f"```mermaid\n{source}\n```")
+
+
+def test_valid_diagram() -> None:
+    rendered = _render_mermaid(MERMAID_SOURCE)
+
+    assert 'data-testid="vault-mermaid-block"' in rendered.html
+    assert 'data-testid="vault-mermaid-diagram"' in rendered.html
+    assert 'data-mermaid-state="source-fallback"' in rendered.html
+    assert 'data-mermaid-render-mode="source-fallback"' in rendered.html
+    assert "graph TD" in rendered.html
+    assert not [diagnostic for diagnostic in rendered.diagnostics if diagnostic.severity == "error"]
+
+
+def test_invalid_diagram_error_ui() -> None:
+    rendered = _render_mermaid("this is not valid mermaid syntax @@@")
+
+    assert 'data-testid="vault-mermaid-error"' in rendered.html
+    assert 'data-mermaid-state="error"' in rendered.html
+    assert 'data-diagnostic-code="invalid_mermaid"' in rendered.html
+    assert "this is not valid mermaid syntax @@@" in rendered.html
+    assert any(diagnostic.code == "invalid_mermaid" for diagnostic in rendered.diagnostics)
+
+
+def test_error_boundary() -> None:
+    class FailingMermaidRenderer(MermaidBlockRenderer):
+        def _render_component(self, source: str) -> str:
+            _ = source
+            raise RuntimeError("component exploded")
+
+    renderer = FailingMermaidRenderer()
+    rendered = renderer.render(MERMAID_SOURCE)
+
+    assert 'data-testid="vault-mermaid-error"' in rendered.html
+    assert 'data-mermaid-state="error"' in rendered.html
+    assert 'data-diagnostic-code="mermaid_render_error"' in rendered.html
+    assert any(diagnostic.code == "mermaid_render_error" for diagnostic in rendered.diagnostics)
+
+
+def test_source_preserved() -> None:
+    source = 'flowchart LR\n    A["<unsafe>"] --> B["done"]'
+    rendered = _render_mermaid(source)
+
+    assert 'data-testid="vault-mermaid-source"' in rendered.html
+    assert 'data-source-preserved="true"' in rendered.html
+    assert "flowchart LR" in rendered.html
+    assert "A[&quot;&lt;unsafe&gt;&quot;] --&gt; B" in rendered.html
+    assert "<unsafe>" not in rendered.html
+
+
+def test_no_external_network() -> None:
+    source = 'flowchart LR\n    A --> B\n    click A "https://example.com" "external"'
+    rendered = _render_mermaid(source)
+    module_source = (
+        Path(__file__).resolve().parents[2]
+        / "companion-ui"
+        / "companion-app"
+        / "companion_ui"
+        / "renderer"
+        / "mermaid_renderer.py"
+    ).read_text(encoding="utf-8")
+
+    assert "<script" not in rendered.html.lower()
+    assert "<a " not in rendered.html.lower()
+    assert "href=" not in rendered.html.lower()
+    assert "src=" not in rendered.html.lower()
+    assert any(diagnostic.code == "mermaid_link_policy" for diagnostic in rendered.diagnostics)
+    for forbidden in ("httpx", "requests", "urlopen", "fetch(", "XMLHttpRequest", "subprocess"):
+        assert forbidden not in module_source
+
+
+def test_mermaid_fixture() -> None:
+    rendered = render_vault_markdown((FIXTURE_DIR / "mermaid.md").read_text(encoding="utf-8"))
+
+    assert rendered.html
+    assert 'data-testid="vault-mermaid-diagram"' in rendered.html
+    assert 'data-diagnostic-code="invalid_mermaid"' in rendered.html
+    assert not any(diagnostic.code == "mermaid_render_error" for diagnostic in rendered.diagnostics)


### PR DESCRIPTION
Closes #1301

## Summary
- Adds `MermaidBlockRenderer` for fenced `mermaid` blocks and wires only that fenced-code path through `VaultMarkdownRenderer`.
- Renders Mermaid as a controlled, source-preserving diagram shell with invalid/error diagnostics instead of executing Mermaid in the Python server-rendered UI.
- Adds focused coverage for valid blocks, invalid input, error-boundary containment, source preservation, external-link/network safety, and the merged Mermaid fixture.

## Mermaid safety decision
Safe client-side Mermaid configuration is not currently enforceable in the Python server-side Companion UI frontend: there is no sandboxed Mermaid runtime or controlled client component in this surface. Per the issue stop condition, this PR uses the safe fallback path: Mermaid source is escaped, preserved, and displayed in an inert diagram shell with diagnostic markers; no Mermaid code is executed and no external resources are loaded.

## Coordination
- Dispatcher unavailable: `python3 -m app.dispatcher status --json` failed before CLI startup because local dependency `yaml` is not installed; used the documented GitHub-label fallback claim.
- Issue #1301 was claimed with `scripts/issue_pickup_claim.sh --issue 1301` and Project status set to `In Progress`.

## Validation
- `pytest tests/companion_ui/test_mermaid_block_renderer.py` — 6 passed
- `pytest tests/companion_ui/test_vault_markdown_renderer.py tests/companion_ui/test_obsidian_compatibility_fixtures.py` — 28 passed
- `git diff --check` — passed
- `ruff check app tests` — not run; local `ruff` executable is not available
