### PR TITLE
test(companion-ui): R1 regression — frontmatter not visible outside identity chrome

### DIFF
--- a/tests/companion_ui/test_workspace_shell_alignment.py
+++ b/tests/companion_ui/test_workspace_shell_alignment.py
@@ -499,3 +499,61 @@ class TestOperatorPromptDoesNotLeakIntoRail:
         rail = _rail_region(html)
         assert long_why not in rail
         assert "C" * 280 in rail
+
+
+# ---------------------------------------------------------------------------
+# R1 regression — frontmatter must not be user-visible outside identity chrome
+# Issue #1290: UAT confirmed raw YAML was visible adjacent to the note frame.
+# These tests lock in the fix: the workspace-note-frontmatter section is hidden
+# from user view via aria-hidden + display:none; raw YAML stays out of the body.
+# ---------------------------------------------------------------------------
+
+
+def _frontmatter_section_tag(html: str) -> str:
+    """Return the opening <section> tag for the workspace-note-frontmatter element."""
+    m = re.search(
+        r'(<section\b[^>]*data-testid="workspace-note-frontmatter"[^>]*>)',
+        html,
+    )
+    assert m, "workspace-note-frontmatter section not found"
+    return m.group(1)
+
+
+class TestFrontmatterR1NotVisibleOutsideChrome:
+    """R1 regression: raw frontmatter must not be user-visible outside identity chrome (#1290)."""
+
+    def test_frontmatter_section_is_aria_hidden_when_frontmatter_present(self) -> None:
+        """Opening tag must carry aria-hidden=true so assistive tech sees it hidden."""
+        html = _html(body=_FRONTMATTER_BODY)
+        tag = _frontmatter_section_tag(html)
+        assert 'data-frontmatter-present="true"' in tag, (
+            "Expected data-frontmatter-present=true for a body that has frontmatter"
+        )
+        assert 'aria-hidden="true"' in tag, (
+            f"R1 violation: workspace-note-frontmatter must carry aria-hidden=true; got: {tag!r}"
+        )
+
+    def test_frontmatter_section_is_display_none_when_frontmatter_present(self) -> None:
+        """Opening tag must carry display:none so the section is visually hidden."""
+        html = _html(body=_FRONTMATTER_BODY)
+        tag = _frontmatter_section_tag(html)
+        assert "display:none" in tag or "display: none" in tag, (
+            f"R1 violation: workspace-note-frontmatter must carry style=display:none; got: {tag!r}"
+        )
+
+    def test_raw_yaml_keys_absent_from_note_body_region(self) -> None:
+        """R1: raw YAML key:value syntax must not appear in the note-body rendering surface."""
+        html = _html(body=_FRONTMATTER_BODY)
+        body = _body_region(html)
+        for key in ("uuid:", "kind:", "zone:", "tags:"):
+            assert key not in body, (
+                f"R1 violation: raw YAML key '{key}' found in workspace-note-body region"
+            )
+
+    def test_frontmatter_section_absent_from_agent_rail(self) -> None:
+        """The frontmatter section must not be rendered inside the agent rail."""
+        html = _html(body=_FRONTMATTER_BODY)
+        rail = _rail_region(html)
+        assert 'data-testid="workspace-note-frontmatter"' not in rail, (
+            "R1 violation: workspace-note-frontmatter section must not appear in agent rail"
+        )


### PR DESCRIPTION
Fixes #1290

## Summary

Adds regression tests confirming that the workspace-note-frontmatter section is visually hidden (via `aria-hidden` and `display:none`) and that raw YAML keys are absent from both the note-body and agent-rail regions.

The underlying code fix (hiding the section with `aria-hidden="true" style="display:none"`) was already applied in PR #1285. This PR adds the AC3 regression test coverage that was missing, locking the fix in place.

## Acceptance criteria coverage

- **AC1** — raw YAML not visible in the default UI: covered by `test_frontmatter_section_is_display_none_when_frontmatter_present` and `test_raw_yaml_keys_absent_from_note_body_region`.
- **AC2** — if a metadata chrome is shown, it shows human-readable fields (not raw YAML): the implementation uses option (a) — completely hidden — no chrome is shown. Identity metadata is displayed in the note-header from server-provided fields (API response), not from client-side frontmatter parsing.
- **AC3** — regression test in `tests/companion_ui/`: ✅ `TestFrontmatterR1NotVisibleOutsideChrome` (4 tests).
- **AC4** — R0 companion note sourcing: artifact metadata in the header (title, kind, uuid, identity state) comes from `fields.get(...)` — the server-provided API response — not from client-side frontmatter parsing. The server is responsible for sourcing from the companion note when available. This is confirmed by code review of `_render_note_section` in `serve_dev_page.py`.

## Validation

```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg" tests/companion_ui/test_workspace_shell_alignment.py
# 45 passed in 0.28s

PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg" tests/companion_ui/
# 966 passed in 8.53s

python3 -m ruff check companion-ui/companion-app/companion_ui tests/companion_ui/test_workspace_shell_alignment.py
# All checks passed!
```

Dispatcher unavailable (db_exists: false) — used GitHub-label-only claim.