### PR TITLE
perf(companion-ui): fix note selection latency — O(1) vault lookup + deduplicated orientation signals (#1289)

### DIFF
--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -19,6 +19,7 @@ from app.api.routes.artifacts import _content_hash, _extract_title
 from app.chat.canvas_writer import _body_contains_frontmatter, _split_frontmatter
 from app.config.paths import resolve_vault_root
 from app.knowledge.write_ops import write_note_from_absolute
+from app.observability.status_service import OrientationSignals, get_orientation_signals
 from app.orientation.runtime import build_orientation_frame
 from app.resurfacing.runtime import evaluate_resurfacing_candidates
 from app.services.artifact_identity import resolve_note_artifact_identity
@@ -303,12 +304,8 @@ def _validate_workspace_markdown_note_path(note_path_raw: str) -> str:
 
 
 def _find_workspace_note(vault_root: Path, safe_note_path: str) -> Path | None:
-    for candidate in vault_root.rglob("*"):
-        if not candidate.is_file():
-            continue
-        if _vault_relative(candidate, vault_root) == safe_note_path:
-            return candidate
-    return None
+    candidate = vault_root / safe_note_path
+    return candidate if candidate.is_file() else None
 
 
 def _vault_relative(path: Path, vault_root: Path) -> str | None:
@@ -462,7 +459,7 @@ def _workspace_update_capability(
     )
 
 
-def _reorient_state() -> dict[str, list[dict[str, str | bool]]]:
+def _reorient_state(signals: OrientationSignals | None = None) -> dict[str, list[dict[str, str | bool]]]:
     def item(
         label: str,
         *,
@@ -476,7 +473,7 @@ def _reorient_state() -> dict[str, list[dict[str, str | bool]]]:
         }
 
     try:
-        frame = build_orientation_frame()
+        frame = build_orientation_frame(signals=signals)
     except Exception:
         return {
             "facts": [],
@@ -527,8 +524,8 @@ def _reorient_state() -> dict[str, list[dict[str, str | bool]]]:
     }
 
 
-def _resurface_state(safe_note_path: str) -> dict[str, list[dict[str, str | list[str]]]]:
-    evaluation = evaluate_resurfacing_candidates()
+def _resurface_state(safe_note_path: str, signals: OrientationSignals | None = None) -> dict[str, list[dict[str, str | list[str]]]]:
+    evaluation = evaluate_resurfacing_candidates(signals=signals)
     candidates: list[dict[str, str | list[str]]] = []
     for candidate in evaluation.candidates:
         signals = candidate.why_now.signals
@@ -883,6 +880,7 @@ def read_companion_workspace(
         canvas_enabled=canvas_enabled,
         writeguard_status=writeguard_status,
     )
+    orientation_signals = get_orientation_signals()
 
     return WorkspaceStateResponse(
         artifact=ArtifactState(
@@ -902,8 +900,8 @@ def read_companion_workspace(
             api_base_url_label=_safe_api_label(),
             trace_id=trace_id,
             vault_identity=_vault_identity_state(vault_root),
-            reorient=_reorient_state(),
-            resurface=_resurface_state(safe_note_path),
+            reorient=_reorient_state(signals=orientation_signals),
+            resurface=_resurface_state(safe_note_path, signals=orientation_signals),
         ),
         canvas=_canvas_state(safe_note_path, vault_root, canvas_enabled),
         panel=_panel_state(identity.artifact_id),

--- a/app/orientation/runtime.py
+++ b/app/orientation/runtime.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
-from app.observability.status_service import get_orientation_signals
+from app.observability.status_service import OrientationSignals, get_orientation_signals
 
 
 class OrientationExplanation(BaseModel):
@@ -36,8 +36,9 @@ def pass_through_context_dimensions(record: dict[str, object]) -> dict[str, obje
     }
 
 
-def build_orientation_frame() -> OrientationFrame:
-    signals = get_orientation_signals()
+def build_orientation_frame(signals: OrientationSignals | None = None) -> OrientationFrame:
+    if signals is None:
+        signals = get_orientation_signals()
     events = signals.events
     ingestion = signals.ingestion
     queue = signals.worker_queue

--- a/app/resurfacing/runtime.py
+++ b/app/resurfacing/runtime.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 
 from pydantic import BaseModel, Field
 
-from app.observability.status_service import get_orientation_signals
+from app.observability.status_service import OrientationSignals, get_orientation_signals
 
 
 class ResurfacingSignal(BaseModel):
@@ -37,13 +37,13 @@ def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
-def evaluate_resurfacing_candidates() -> ResurfacingEvaluation:
+def evaluate_resurfacing_candidates(signals: OrientationSignals | None = None) -> ResurfacingEvaluation:
     """Produce resurfacing candidates from derived relevance-change runtime signals.
 
     This seam is intentionally query-independent and read-only.
     """
 
-    orientation = get_orientation_signals()
+    orientation = signals if signals is not None else get_orientation_signals()
     events = orientation.events
     ingestion = orientation.ingestion
     queue = orientation.worker_queue

--- a/tests/companion_ui/test_workspace_note_selection_latency.py
+++ b/tests/companion_ui/test_workspace_note_selection_latency.py
@@ -1,0 +1,111 @@
+"""Regression tests for note selection latency fix (#1289).
+
+Verifies:
+- _find_workspace_note uses direct path lookup instead of vault-wide rglob.
+- get_orientation_signals is called exactly once per workspace request.
+
+R4: note selection MUST complete within 2s for ordinary notes on dev runtime.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+
+def _write_note(directory: Path, relative: str, content: str) -> Path:
+    path = directory / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# _find_workspace_note: O(1) path lookup, not O(N) rglob
+# ---------------------------------------------------------------------------
+
+
+class TestFindWorkspaceNoteDirectLookup:
+    """_find_workspace_note must resolve by direct path, not vault-wide scan."""
+
+    def test_returns_path_for_existing_note(self, tmp_path: Path) -> None:
+        from app.api.routes.companion import _find_workspace_note
+
+        note = _write_note(tmp_path, "Notes/my.md", "# My Note")
+        result = _find_workspace_note(tmp_path, "Notes/my.md")
+        assert result == note
+
+    def test_returns_none_for_missing_note(self, tmp_path: Path) -> None:
+        from app.api.routes.companion import _find_workspace_note
+
+        result = _find_workspace_note(tmp_path, "Notes/missing.md")
+        assert result is None
+
+    def test_lookup_is_sub_millisecond_with_many_vault_files(self, tmp_path: Path) -> None:
+        from app.api.routes.companion import _find_workspace_note
+
+        deep = tmp_path / "Deep"
+        deep.mkdir()
+        for i in range(500):
+            (deep / f"note_{i}.md").write_text(f"# Note {i}")
+
+        _write_note(tmp_path, "Notes/target.md", "# Target")
+
+        elapsed = []
+        for _ in range(5):
+            start = time.perf_counter()
+            result = _find_workspace_note(tmp_path, "Notes/target.md")
+            elapsed.append(time.perf_counter() - start)
+            assert result is not None
+
+        avg_ms = sum(elapsed) / len(elapsed) * 1000
+        assert avg_ms < 10, (
+            f"_find_workspace_note averaged {avg_ms:.2f}ms across 5 runs — "
+            "suggests O(N) rglob is still in use (O(1) direct lookup should be <1ms)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# get_orientation_signals: called exactly once per workspace request
+# ---------------------------------------------------------------------------
+
+
+class TestOrientationSignalsComputedOnce:
+    """Orientation signals must be computed once per workspace request, not twice."""
+
+    def test_orientation_signals_called_once_per_request(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        from app.api.routes import companion as companion_module
+        from app.observability import status_service
+        from app.observability.status_service import OrientationSignals
+        from app.observability.status_model import (
+            EventCounters,
+            IngestionStatus,
+            WorkerQueueStatus,
+        )
+
+        _write_note(tmp_path, "Notes/x.md", "---\nuuid: test-uuid-x\n---\n# X\n")
+
+        call_count = 0
+
+        def _stub_signals() -> OrientationSignals:
+            nonlocal call_count
+            call_count += 1
+            return OrientationSignals(
+                events=EventCounters(),
+                ingestion=IngestionStatus(),
+                worker_queue=WorkerQueueStatus(mode="none"),
+            )
+
+        monkeypatch.setattr(status_service, "get_orientation_signals", _stub_signals)
+        monkeypatch.setattr(companion_module, "get_orientation_signals", _stub_signals)
+        monkeypatch.setattr(companion_module, "resolve_vault_root", lambda: tmp_path)
+
+        companion_module.read_companion_workspace(note_path="Notes/x.md")
+
+        assert call_count == 1, (
+            f"get_orientation_signals called {call_count} times — "
+            "expected exactly 1 (shared across build_orientation_frame and "
+            "evaluate_resurfacing_candidates)"
+        )


### PR DESCRIPTION
Fixes #1289

## Summary

Fixes ~5s note selection latency (R4 blocker). Root cause was two compounding issues on the `read_companion_workspace` hot path.

## Root cause timing breakdown

| Contributor | Before | After | Method |
|---|---|---|---|
| `_find_workspace_note` — `vault_root.rglob("*")` scan | O(N) full vault walk on every selection | O(1) single `is_file()` check | Direct `vault_root / safe_note_path` |
| `get_orientation_signals()` called twice | 2× 8 MB tail-read of 725 MB outbox + JSON parse | 1× | Shared `signals` argument |

`_find_workspace_note` was walking every file in the vault using `rglob("*")` on each note selection. With a large vault (thousands of Markdown files) this alone accounts for several seconds. `safe_note_path` is already the vault-relative path, so the correct approach is a direct construction with no scanning needed.

`get_orientation_signals()` was called independently by `build_orientation_frame()` and `evaluate_resurfacing_candidates()` — both called from the same workspace request. Each call reads 8 MB from the end of the 725 MB outbox file. The fix passes pre-computed signals to both functions.

`health_contract.evaluate()` is **not** on the hot path — `_get_write_guard_status()` reads the cached state machine state only.

## Changes

- `app/api/routes/companion.py`: Replace `rglob("*")` with `vault_root / safe_note_path`; import and compute `get_orientation_signals()` once; thread signals into `_reorient_state()` and `_resurface_state()`.
- `app/orientation/runtime.py`: Add `signals: OrientationSignals | None = None` to `build_orientation_frame()`.
- `app/resurfacing/runtime.py`: Add `signals: OrientationSignals | None = None` to `evaluate_resurfacing_candidates()`.
- `tests/companion_ui/test_workspace_note_selection_latency.py`: New regression tests asserting O(1) lookup and single orientation-signals call.

## Test plan

- [x] `test_workspace_note_selection_latency.py` — 4 tests, all green
- [x] `_find_workspace_note` with 500 vault files: sub-10ms (0.02ms measured)
- [x] `get_orientation_signals` called exactly once per workspace request (monkeypatched call counter)
- [x] Full test suite: 3933+ passed, no new failures introduced (70 pre-existing failures on baseline, 69 after changes)
- [x] Ruff lint: all checks passed

## UAT receipt (R4)

Runtime not available for live timing (dev runtime on Mac mini, `http://10.42.42.10:8112`). Fix is architecturally sound: the O(N) rglob is confirmed eliminated by the sub-millisecond test. The remaining I/O (single `get_orientation_signals` + single `is_file` stat) is bounded and predictable.

If live UAT timing is needed before merge, three selections should be timed against the updated branch on the Mac mini runtime.

## Requirements affected

- R4: Note selection latency ≤2s — primary fix
- R4 AC1: Root cause identified and documented ✓
- R4 AC3: No regression to OOM fix — `health_contract.evaluate()` confirmed not on hot path ✓

🤖 Generated with [Claude Code](https://claude.ai/claude-code)