### PR TITLE
feat(vault-browser): wire filter chip clicks to server-side reload (#1280)

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -77,6 +77,8 @@ class NoteLoadIntent:
     """Represents the operator's intent to load a specific note by path.
 
     note_path is forwarded to the runtime API as a query parameter.
+    active_filters carries optional vault browser filter dimensions (kind,
+    zone, review_state, trust) forwarded as multi-value query params.
     The UI does not resolve vault paths or access vault files directly.
     The runtime API is bound to an environment; it determines which vault
     is read.
@@ -84,6 +86,7 @@ class NoteLoadIntent:
 
     note_path: str
     artifact_id: Optional[str] = None
+    active_filters: dict[str, list[str]] = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
@@ -227,9 +230,11 @@ class RealNoteWorkspaceDevPage:
         vault_browser_error: str | None = None
         if isinstance(self._http, WorkspaceHttpClient):
             try:
+                browser_params: dict[str, Any] = {"q": "", "limit": 250}
+                browser_params.update(intent.active_filters)
                 vault_browser = self._http.get(
                     "/api/companion/vault-browser",
-                    params={"q": "", "limit": 250},
+                    params=browser_params,
                 )
             except WorkspaceClientError as exc:
                 vault_browser = {}

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -1113,15 +1113,25 @@ def _render_filter_chips(
         if not values:
             continue
         active_set = set(active_filters.get(field, []))
+        multi_active = len(active_set) > 1
         for val in sorted(values):
             is_active = val in active_set
+            deselect_span = (
+                '<span class="filter-chip-remove" aria-label="remove filter" data-testid="filter-chip-remove">×</span>'
+                if is_active and multi_active
+                else ""
+            )
             chips_html.append(
                 f'<span class="filter-chip" '
                 f'data-testid="vault-browser-filter-chip" '
                 f'data-key="{_e(field)}" '
                 f'data-value="{_e(val)}" '
-                f'data-active="{"true" if is_active else "false"}">'
-                f'{_e(label)}: {_e(val)}</span>'
+                f'data-active="{"true" if is_active else "false"}" '
+                f'onclick="vbToggleFilter(this)" '
+                f'style="cursor:pointer">'
+                f'{_e(label)}: {_e(val)}'
+                f'{deselect_span}'
+                f'</span>'
             )
     if not chips_html:
         return ""
@@ -3417,6 +3427,19 @@ def render_index_html(
     }};
   }})();
   </script>
+  <script>
+  function vbToggleFilter(el) {{
+    var key = el.dataset.key;
+    var val = el.dataset.value;
+    var url = new URL(window.location.href);
+    var params = url.searchParams;
+    var existing = params.getAll(key);
+    params.delete(key);
+    if (existing.indexOf(val) === -1) {{ params.append(key, val); }}
+    existing.filter(function(v) {{ return v !== val; }}).forEach(function(v) {{ params.append(key, v); }});
+    window.location.href = url.toString();
+  }}
+  </script>
 </body>
 </html>"""
 
@@ -3434,12 +3457,14 @@ def handle_get(
     """
     params = parse_qs(query_string)
     note_path = params.get("note_path", [""])[0].strip()
+    _filter_keys = ("kind", "zone", "review_state", "trust")
+    active_filters = {k: params[k] for k in _filter_keys if params.get(k)}
     fields: Optional[dict] = None
     error = ""
 
     if note_path:
         page = RealNoteWorkspaceDevPage(client)
-        state = page.load(NoteLoadIntent(note_path=note_path))
+        state = page.load(NoteLoadIntent(note_path=note_path, active_filters=active_filters))
         if state.is_loaded:
             fields = page.render_fields()
         else:

--- a/tests/companion_ui/test_vault_browser.py
+++ b/tests/companion_ui/test_vault_browser.py
@@ -396,6 +396,127 @@ def test_vault_browser_inactive_filter_chip_has_data_active_false() -> None:
     assert 'data-active="false"' in html
 
 
+# ---- #1280: wire filter chip clicks to server-side reload ----
+
+
+def test_filter_chips_carry_onclick_wiring() -> None:
+    """#1280 AC1+AC2: Every filter chip carries onclick=vbToggleFilter(this) for toggle interaction."""
+    page = _load_page(
+        browser_payload=_vault_browser_payload_with_filters(),
+    )
+    fields = page.render_fields()
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="notes/current.md",
+        fields=fields,
+    )
+    assert 'onclick="vbToggleFilter(this)"' in html
+
+
+def test_filter_chips_carry_cursor_pointer_style() -> None:
+    """#1280 AC1: Filter chips are visually afforded as clickable."""
+    page = _load_page(
+        browser_payload=_vault_browser_payload_with_filters(),
+    )
+    fields = page.render_fields()
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="notes/current.md",
+        fields=fields,
+    )
+    assert 'style="cursor:pointer"' in html
+
+
+def test_multi_value_active_chips_show_deselect_affordance() -> None:
+    """#1280 AC3: When 2+ values active for a dimension, active chips show a deselect affordance."""
+    page = _load_page(
+        browser_payload=_vault_browser_payload_with_filters(
+            active_filters={"kind": ["human_note", "companion_note"]},
+        ),
+    )
+    fields = page.render_fields()
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="notes/current.md",
+        fields=fields,
+    )
+    assert 'data-testid="filter-chip-remove"' in html
+
+
+def test_single_active_chip_no_deselect_affordance() -> None:
+    """#1280 AC3 boundary: single active value → no deselect affordance (no ambiguity)."""
+    page = _load_page(
+        browser_payload=_vault_browser_payload_with_filters(
+            active_filters={"kind": ["human_note"]},
+        ),
+    )
+    fields = page.render_fields()
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="notes/current.md",
+        fields=fields,
+    )
+    assert 'data-testid="filter-chip-remove"' not in html
+
+
+def test_handle_get_passes_filter_params_to_vault_browser_api() -> None:
+    """#1280 AC4: URL filter params are forwarded to the vault browser API call."""
+    from unittest.mock import MagicMock, patch
+
+    from companion_ui.workspace.serve_dev_page import handle_get
+    from companion_ui.workspace.workspace_http_client import WorkspaceHttpClient
+
+    captured: dict = {}
+
+    workspace_mock = MagicMock()
+    workspace_mock.status_code = 200
+    workspace_mock.json.return_value = _workspace_payload()
+
+    browser_mock = MagicMock()
+    browser_mock.status_code = 200
+    browser_mock.json.return_value = _vault_browser_payload_with_filters(
+        active_filters={"kind": ["human_note"]},
+    )
+
+    def _side_effect(url: str, *, params: dict, timeout: float):
+        if url.endswith("/api/companion/workspace"):
+            return workspace_mock
+        if url.endswith("/api/companion/vault-browser"):
+            captured["params"] = dict(params)
+            return browser_mock
+        raise AssertionError(f"Unexpected URL: {url}")
+
+    with patch("httpx.get", side_effect=_side_effect):
+        client = WorkspaceHttpClient(base_url="http://localhost:18001")
+        handle_get(
+            query_string="note_path=notes/current.md&kind=human_note",
+            client=client,
+            api_base_url="http://127.0.0.1:18001",
+        )
+
+    assert "kind" in captured.get("params", {}), (
+        "Filter param 'kind' must be forwarded to vault-browser API"
+    )
+    assert captured["params"]["kind"] == ["human_note"], (
+        f"Filter value must be ['human_note']; got: {captured['params']['kind']!r}"
+    )
+
+
+def test_vbtoggle_script_block_present_in_page() -> None:
+    """#1280: vbToggleFilter JS function is embedded in page output."""
+    page = _load_page(
+        browser_payload=_vault_browser_payload_with_filters(),
+    )
+    fields = page.render_fields()
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="notes/current.md",
+        fields=fields,
+    )
+    assert "vbToggleFilter" in html
+    assert "url.searchParams" in html
+
+
 def test_vault_provenance_attribute_is_escaped() -> None:
     payload = _workspace_payload()
     payload["runtime"]["vault_identity"]["provenance"] = 'env" onmouseover="alert(1)'


### PR DESCRIPTION
Fixes #1280

## Summary

- **`NoteLoadIntent.active_filters`**: new `dict[str, list[str]]` field — carries `kind`/`zone`/`review_state`/`trust` filter dimensions from the query string to the vault browser API as multi-value params.
- **`handle_get`**: parses the 4 filter keys from the query string and populates `active_filters` on `NoteLoadIntent`. URL params are the source of truth — bookmarkable, server-authoritative.
- **`_render_filter_chips`**: adds `onclick="vbToggleFilter(this)"` + `style="cursor:pointer"` on every chip. When 2+ values are active for the same dimension, each active chip gains a `×`-remove affordance (`data-testid="filter-chip-remove"`).
- **`render_index_html`**: embeds `vbToggleFilter()` — toggles filter by adding/removing URL param and navigating. No opaque client-side state; no new framework.

## Changes

- `companion-ui/.../real_note_workspace_dev_page.py`: add `active_filters` field to `NoteLoadIntent`; build `browser_params` from intent and pass to vault-browser API
- `companion-ui/.../serve_dev_page.py`: filter param parsing in `handle_get`; onclick + deselect affordance in `_render_filter_chips`; `vbToggleFilter` JS block in `render_index_html`
- `tests/companion_ui/test_vault_browser.py`: 6 new tests for all ACs

## Test plan

- [x] 30 vault browser tests pass (24 pre-existing + 6 new)
- [x] `ruff check` passes on changed files
- [x] No new write path; server remains authoritative filter processor

## Requirements affected

- Vault Browser capability contract §4.3 — VaultQuery filter dimensions now interactive
- URL params reflect active filter state (bookmarkable)
- No opaque ranking; no client-side filtering

🤖 Generated with [Claude Code](https://claude.ai/claude-code)