### PR TITLE
feat(vault-browser): visually distinguish companion notes from human notes (#1283)

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -874,10 +874,15 @@ def _render_artifact_inspector(
     receipts_html = _render_inspector_receipts(note)
     posture_html = _render_inspector_review_posture(note)
 
+    is_companion_note = bool(kind_val and "companion" in str(kind_val))
+    inspector_kind_attr = f' data-kind="{_e(str(kind_val))}"' if kind_val else ""
+    inspector_companion_attr = ' data-companion="true"' if is_companion_note else ""
+
     return (
         f'<section class="vault-browser-inspector" '
         f'data-testid="workspace-vault-browser-inspector" '
-        f'data-affordance-status="read-only">'
+        f'data-affordance-status="read-only"'
+        f'{inspector_kind_attr}{inspector_companion_attr}>'
         f'<header class="inspector-header">'
         f'<span data-testid="workspace-vault-browser-inspector-title" '
         f'class="inspector-title">{title}</span>'
@@ -1248,9 +1253,15 @@ def _render_vault_browser(
             )
         badges_html = "".join(badges)
 
+        kind_safe = _e(str(kind_val)) if kind_val else ""
+        is_companion = bool(kind_val and "companion" in str(kind_val))
+        row_extra_class = " vault-browser-row--companion" if is_companion else ""
+        row_kind_attr = f' data-kind="{kind_safe}"' if kind_safe else ""
+        row_companion_attr = ' data-companion="true"' if is_companion else ""
+
         rows.append(
             f"""
-          <li class="vault-browser-row" data-testid="workspace-vault-browser-note-row" data-active="{active}">
+          <li class="vault-browser-row{row_extra_class}" data-testid="workspace-vault-browser-note-row" data-active="{active}"{row_kind_attr}{row_companion_attr}>
             <a href="{href}" data-testid="workspace-vault-browser-note-link">{title}</a>
             <code data-testid="workspace-vault-browser-note-path">{_e(path)}</code>
             <span data-testid="workspace-vault-browser-note-zone">{zone}</span>

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -88,6 +88,13 @@ def _e(value: str) -> str:
     return _html.escape(str(value))
 
 
+# Canonical companion kind values from COMPANION_NOTE_CONTRACT.md.
+# Exact match only — substring checks risk false-positives on arbitrary kind strings
+# (e.g. "non_companion_attachment"). Extend this set as new companion kinds are
+# introduced via the contract, not via loose substring heuristics.
+_COMPANION_KINDS: frozenset[str] = frozenset({"companion_note"})
+
+
 # Maximum characters for any single rail item label / reason / relation field.
 # Prevents operator/agent note body content from leaking into the rail verbatim.
 _RAIL_ITEM_MAX: int = 280
@@ -874,7 +881,7 @@ def _render_artifact_inspector(
     receipts_html = _render_inspector_receipts(note)
     posture_html = _render_inspector_review_posture(note)
 
-    is_companion_note = bool(kind_val and "companion" in str(kind_val))
+    is_companion_note = kind_val in _COMPANION_KINDS
     inspector_kind_attr = f' data-kind="{_e(str(kind_val))}"' if kind_val else ""
     inspector_companion_attr = ' data-companion="true"' if is_companion_note else ""
 
@@ -1254,7 +1261,7 @@ def _render_vault_browser(
         badges_html = "".join(badges)
 
         kind_safe = _e(str(kind_val)) if kind_val else ""
-        is_companion = bool(kind_val and "companion" in str(kind_val))
+        is_companion = kind_val in _COMPANION_KINDS
         row_extra_class = " vault-browser-row--companion" if is_companion else ""
         row_kind_attr = f' data-kind="{kind_safe}"' if kind_safe else ""
         row_companion_attr = ' data-companion="true"' if is_companion else ""

--- a/tests/companion_ui/test_vault_browser.py
+++ b/tests/companion_ui/test_vault_browser.py
@@ -517,6 +517,90 @@ def test_vbtoggle_script_block_present_in_page() -> None:
     assert "url.searchParams" in html
 
 
+# ---- #1283: visually distinguish companion vs human notes ----
+
+
+def test_companion_note_row_has_data_companion_true() -> None:
+    """#1283 AC1: Companion note row carries data-companion="true"."""
+    companion = _note_with_metadata(
+        note_path="notes/companion.md",
+        title="Companion",
+        kind="companion_note",
+        zone="semi_active",
+    )
+    page = _load_page(
+        browser_payload=_vault_browser_payload(notes=[companion], total_notes=1, filtered_notes=1),
+    )
+    fields = page.render_fields()
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="notes/current.md",
+        fields=fields,
+    )
+    assert 'data-companion="true"' in html, (
+        "companion_note row must carry data-companion=\"true\""
+    )
+
+
+def test_companion_note_row_has_data_kind_companion_note() -> None:
+    """#1283 AC1: Companion note row carries data-kind="companion_note"."""
+    companion = _note_with_metadata(
+        note_path="notes/companion.md",
+        kind="companion_note",
+    )
+    page = _load_page(
+        browser_payload=_vault_browser_payload(notes=[companion], total_notes=1, filtered_notes=1),
+    )
+    fields = page.render_fields()
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="notes/current.md",
+        fields=fields,
+    )
+    assert 'data-kind="companion_note"' in html, (
+        "companion_note row must carry data-kind=\"companion_note\""
+    )
+
+
+def test_companion_note_row_carries_companion_css_class() -> None:
+    """#1283 AC1: Companion note row carries vault-browser-row--companion CSS class."""
+    companion = _note_with_metadata(
+        note_path="notes/companion.md",
+        kind="companion_note",
+    )
+    page = _load_page(
+        browser_payload=_vault_browser_payload(notes=[companion], total_notes=1, filtered_notes=1),
+    )
+    fields = page.render_fields()
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="notes/current.md",
+        fields=fields,
+    )
+    assert "vault-browser-row--companion" in html, (
+        "companion_note row must carry vault-browser-row--companion CSS class"
+    )
+
+
+def test_human_note_row_has_no_companion_treatment() -> None:
+    """#1283 AC1 boundary: human_note row does NOT carry companion treatment."""
+    human = _note_with_metadata(
+        note_path="notes/human.md",
+        kind="human_note",
+    )
+    page = _load_page(
+        browser_payload=_vault_browser_payload(notes=[human], total_notes=1, filtered_notes=1),
+    )
+    fields = page.render_fields()
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="notes/current.md",
+        fields=fields,
+    )
+    assert 'data-companion="true"' not in html
+    assert "vault-browser-row--companion" not in html
+
+
 def test_vault_provenance_attribute_is_escaped() -> None:
     payload = _workspace_payload()
     payload["runtime"]["vault_identity"]["provenance"] = 'env" onmouseover="alert(1)'

--- a/tests/companion_ui/test_vault_browser_inspector.py
+++ b/tests/companion_ui/test_vault_browser_inspector.py
@@ -282,3 +282,59 @@ def test_inspector_has_no_edit_controls() -> None:
     assert 'data-intent="write' not in inspector_html
     assert 'data-intent="edit' not in inspector_html
     assert "data-affordance-status=\"active\"" not in inspector_html
+
+
+# ---- #1283: companion note visual distinction in inspector ----
+
+
+def test_inspector_companion_note_carries_data_companion_true() -> None:
+    """#1283 AC2: Inspector panel for companion_note carries data-companion="true"."""
+    note = _browser_note(
+        note_path="notes/current.md",
+        kind="companion_note",
+    )
+    _, _, html = _load_page(
+        browser_payload=_vault_browser_payload(notes=[note]),
+    )
+    inspector_start = html.find('data-testid="workspace-vault-browser-inspector"')
+    assert inspector_start != -1
+    # Extract just the opening section tag
+    inspector_tag_end = html.find(">", inspector_start) + 1
+    inspector_tag = html[inspector_start:inspector_tag_end]
+    assert 'data-companion="true"' in inspector_tag, (
+        f"companion_note inspector must carry data-companion=\"true\"; got: {inspector_tag!r}"
+    )
+
+
+def test_inspector_companion_note_carries_data_kind() -> None:
+    """#1283 AC2: Inspector panel for companion_note carries data-kind="companion_note"."""
+    note = _browser_note(
+        note_path="notes/current.md",
+        kind="companion_note",
+    )
+    _, _, html = _load_page(
+        browser_payload=_vault_browser_payload(notes=[note]),
+    )
+    inspector_start = html.find('data-testid="workspace-vault-browser-inspector"')
+    assert inspector_start != -1
+    inspector_tag_end = html.find(">", inspector_start) + 1
+    inspector_tag = html[inspector_start:inspector_tag_end]
+    assert 'data-kind="companion_note"' in inspector_tag, (
+        f"companion_note inspector must carry data-kind=\"companion_note\"; got: {inspector_tag!r}"
+    )
+
+
+def test_inspector_human_note_has_no_companion_attribute() -> None:
+    """#1283 AC2 boundary: Inspector panel for human_note does NOT carry data-companion="true"."""
+    note = _browser_note(
+        note_path="notes/current.md",
+        kind="human_note",
+    )
+    _, _, html = _load_page(
+        browser_payload=_vault_browser_payload(notes=[note]),
+    )
+    inspector_start = html.find('data-testid="workspace-vault-browser-inspector"')
+    assert inspector_start != -1
+    inspector_tag_end = html.find(">", inspector_start) + 1
+    inspector_tag = html[inspector_start:inspector_tag_end]
+    assert 'data-companion="true"' not in inspector_tag


### PR DESCRIPTION
Fixes #1283

## Summary

Adds explicit visual treatment for `companion_note` kind entries in both the vault browser list and artifact inspector, driven entirely by the server-declared `kind` field.

**Browser list rows:**
- Every row now carries `data-kind="{kind}"` derived from the server payload
- `companion_note` rows gain `data-companion="true"` and the CSS class `vault-browser-row--companion`
- `human_note` rows carry no companion treatment

**Artifact inspector:**
- The `<section>` element gains `data-kind="{kind}"` and `data-companion="true"` for companion artifacts
- No new API field; uses existing `kind` from the normalized server payload (#1253)

## Changes

- `companion-ui/.../serve_dev_page.py`: 10 lines in row rendering loop + 4 lines in inspector section builder
- `tests/companion_ui/test_vault_browser.py`: 4 new tests (row attributes, CSS class, human boundary)
- `tests/companion_ui/test_vault_browser_inspector.py`: 3 new tests (inspector data-companion, data-kind, human boundary)

## Test plan

- [x] 31 tests pass (24 pre-existing + 7 new)
- [x] `ruff check` passes on changed files
- [x] All existing `data-testid` and `data-kind` badge attributes preserved

## Requirements affected

- Vault Browser capability contract §4.1 — VaultArtifact `kind` field now surfaced on row/inspector elements
- No new API field; treatment derived from existing `kind` value

🤖 Generated with [Claude Code](https://claude.ai/claude-code)