### PR TITLE
feat(companion-ui): add read-only link previews

### DIFF
--- a/companion-ui/companion-app/companion_ui/renderer/__init__.py
+++ b/companion-ui/companion-app/companion_ui/renderer/__init__.py
@@ -24,6 +24,11 @@ from companion_ui.renderer.mermaid_renderer import (
     MermaidRenderError,
     MermaidRenderResult,
 )
+from companion_ui.renderer.link_preview import (
+    LinkPreview,
+    RenderedLinkPreview,
+    link_preview_css,
+)
 from companion_ui.renderer.vault_markdown_parser import parse_vault_markdown
 from companion_ui.renderer.note_outline import (
     note_outline_css,
@@ -43,6 +48,7 @@ __all__ = [
     "EmbedRef",
     "HeadingRef",
     "LinkResolution",
+    "LinkPreview",
     "MarkdownDiagnostic",
     "MermaidBlockRenderer",
     "MermaidRenderError",
@@ -51,10 +57,12 @@ __all__ = [
     "PropertiesRenderer",
     "PropertyField",
     "RenderedProperties",
+    "RenderedLinkPreview",
     "SourceRange",
     "VaultMarkdownDocument",
     "WikiLinkRef",
     "parse_frontmatter_fields",
+    "link_preview_css",
     "parse_vault_markdown",
     "note_outline_css",
     "note_outline_script",

--- a/companion-ui/companion-app/companion_ui/renderer/link_preview.py
+++ b/companion-ui/companion-app/companion_ui/renderer/link_preview.py
@@ -1,0 +1,258 @@
+"""Read-only hover/focus previews for internal vault links.
+
+Preview content is supplied by the caller as vault-relative note bodies. This
+renderer never reads vault files, never calls HTTP clients, and never exposes
+filesystem paths.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import html
+import re
+
+from companion_ui.renderer.asset_resolver import VaultAssetResolver
+from companion_ui.renderer.link_resolver import VaultLinkResolver
+from companion_ui.renderer.mermaid_renderer import MermaidBlockRenderer
+from companion_ui.renderer.models import MarkdownDiagnostic
+
+
+_ABSOLUTE_PATH_RE = re.compile(r"^(?:/|[A-Za-z]:[\\/])")
+_DEFAULT_MAX_DEPTH = 1
+_DEFAULT_MAX_SOURCE_CHARS = 4_000
+
+
+@dataclass(frozen=True)
+class RenderedLinkPreview:
+    """HTML and diagnostics for one internal-link preview popover."""
+
+    html: str
+    diagnostics: tuple[MarkdownDiagnostic, ...] = ()
+    write_calls: tuple[str, ...] = ()
+
+
+class LinkPreview:
+    """Render bounded, sanitized previews for already-resolved internal links."""
+
+    def __init__(
+        self,
+        note_sources: Mapping[str, str] | None = None,
+        *,
+        link_resolver: object | None = None,
+        asset_resolver: object | None = None,
+        mermaid_renderer: MermaidBlockRenderer | None = None,
+        max_depth: int = _DEFAULT_MAX_DEPTH,
+        max_source_chars: int = _DEFAULT_MAX_SOURCE_CHARS,
+    ) -> None:
+        self._note_sources = {
+            _safe_note_path(path): body
+            for path, body in dict(note_sources or {}).items()
+            if _safe_note_path(path)
+        }
+        self._link_resolver = link_resolver or VaultLinkResolver({})
+        self._asset_resolver = asset_resolver or VaultAssetResolver({})
+        self._mermaid_renderer = mermaid_renderer or MermaidBlockRenderer()
+        self._max_depth = max(0, int(max_depth))
+        self._max_source_chars = max(1, int(max_source_chars))
+
+    def render(
+        self,
+        resolution: object,
+        *,
+        note_path: str = "",
+        depth: int = 0,
+    ) -> RenderedLinkPreview:
+        """Render one preview without mutating vault or renderer state."""
+
+        _ = note_path
+        state = str(getattr(resolution, "kind", "missing") or "missing")
+        display_text = str(getattr(resolution, "display_text", "") or "link")
+
+        if depth >= self._max_depth:
+            return _diagnostic_preview(
+                state="depth-limited",
+                title=display_text,
+                message="Preview depth limit reached.",
+            )
+
+        if state == "missing":
+            reason = str(getattr(resolution, "reason", "") or "missing link")
+            return _diagnostic_preview(
+                state="missing",
+                title=display_text,
+                message="Preview unavailable: missing link.",
+                detail=reason,
+            )
+        if state == "ambiguous":
+            candidates = tuple(
+                str(candidate)
+                for candidate in getattr(resolution, "candidates", ()) or ()
+            )
+            return _diagnostic_preview(
+                state="ambiguous",
+                title=display_text,
+                message="Preview unavailable: ambiguous link.",
+                detail=", ".join(candidates) if candidates else "Multiple targets match this link.",
+            )
+        if state != "resolved":
+            return _diagnostic_preview(
+                state="missing",
+                title=display_text,
+                message="Preview unavailable: unresolved link.",
+            )
+
+        target_path = _safe_note_path(str(getattr(resolution, "note_path", "") or ""))
+        if not target_path:
+            return _diagnostic_preview(
+                state="missing",
+                title=display_text,
+                message="Preview unavailable: unsafe target path.",
+            )
+
+        source = self._note_sources.get(target_path)
+        if source is None:
+            return _diagnostic_preview(
+                state="missing",
+                title=display_text,
+                message="Preview unavailable: target content was not supplied.",
+            )
+
+        diagnostics: list[MarkdownDiagnostic] = []
+        if len(source) > self._max_source_chars:
+            source = source[: self._max_source_chars]
+            diagnostics.append(
+                MarkdownDiagnostic(
+                    severity="info",
+                    code="link_preview_truncated",
+                    message="Preview source was truncated to the configured size limit.",
+                )
+            )
+
+        from companion_ui.renderer.vault_markdown_renderer import VaultMarkdownRenderer
+
+        rendered = VaultMarkdownRenderer(
+            link_resolver=self._link_resolver,
+            asset_resolver=self._asset_resolver,
+            mermaid_renderer=self._mermaid_renderer,
+            link_preview=self,
+        ).render(source, note_path=target_path, preview_depth=depth + 1)
+        diagnostics.extend(rendered.diagnostics)
+        diagnostic_html = _preview_diagnostics(diagnostics)
+        return RenderedLinkPreview(
+            html=(
+                '<section class="link-preview-card" '
+                'data-preview-state="resolved" '
+                'data-readonly="true">'
+                f'<div class="link-preview-title">{_e(display_text)}</div>'
+                f"{diagnostic_html}{rendered.html}"
+                "</section>"
+            ),
+            diagnostics=tuple(diagnostics),
+        )
+
+
+def link_preview_css() -> str:
+    """CSS for CSS-only hover/focus preview popovers."""
+
+    return """
+    .vault-link-preview-host {
+      display: inline-block;
+      position: relative;
+    }
+    .vault-link-preview-host:focus {
+      outline: 2px solid var(--cyan);
+      outline-offset: 2px;
+    }
+    .link-preview-popover {
+      background: rgba(7,11,18,0.96);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      box-shadow: 0 18px 48px rgba(0,0,0,0.35);
+      color: var(--fg-1);
+      display: none;
+      font-family: var(--font-ui);
+      left: 0;
+      max-height: min(420px, 70vh);
+      max-width: min(520px, 88vw);
+      min-width: 280px;
+      overflow: auto;
+      padding: 14px;
+      position: absolute;
+      top: calc(100% + 8px);
+      width: max-content;
+      z-index: 30;
+    }
+    .vault-link-preview-host:hover .link-preview-popover,
+    .vault-link-preview-host:focus-within .link-preview-popover,
+    .vault-link-preview-host:focus .link-preview-popover {
+      display: block;
+    }
+    .link-preview-card {
+      display: block;
+    }
+    .link-preview-title {
+      color: var(--fg-3);
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      letter-spacing: 0.08em;
+      margin-bottom: 8px;
+      text-transform: uppercase;
+    }
+    .link-preview-diagnostic,
+    .link-preview-diagnostics {
+      background: rgba(212,168,67,0.12);
+      border: 1px solid rgba(212,168,67,0.35);
+      border-radius: var(--radius-sm);
+      color: var(--accent);
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      margin: 0;
+      padding: 8px 10px;
+    }
+    """
+
+
+def _diagnostic_preview(
+    *,
+    state: str,
+    title: str,
+    message: str,
+    detail: str = "",
+) -> RenderedLinkPreview:
+    detail_html = f'<div class="link-preview-detail">{_e(detail)}</div>' if detail else ""
+    return RenderedLinkPreview(
+        html=(
+            '<section class="link-preview-card link-preview-diagnostic" '
+            f'data-preview-state="{_e(state)}" '
+            'data-readonly="true">'
+            f'<div class="link-preview-title">{_e(title)}</div>'
+            f'<div class="link-preview-message">{_e(message)}</div>'
+            f"{detail_html}"
+            "</section>"
+        )
+    )
+
+
+def _preview_diagnostics(diagnostics: list[MarkdownDiagnostic]) -> str:
+    if not diagnostics:
+        return ""
+    items = "".join(
+        '<li class="link-preview-diagnostic-item" '
+        f'data-diagnostic-code="{_e(diagnostic.code)}" '
+        f'data-diagnostic-severity="{_e(diagnostic.severity)}">'
+        f"{_e(diagnostic.message)}</li>"
+        for diagnostic in diagnostics
+    )
+    return f'<ul class="link-preview-diagnostics">{items}</ul>'
+
+
+def _safe_note_path(note_path: str) -> str:
+    normalized = str(note_path or "").strip().replace("\\", "/").removeprefix("./")
+    if not normalized or _ABSOLUTE_PATH_RE.match(normalized):
+        return ""
+    return normalized
+
+
+def _e(value: object) -> str:
+    return html.escape(str(value), quote=True)

--- a/companion-ui/companion-app/companion_ui/renderer/vault_markdown_renderer.py
+++ b/companion-ui/companion-app/companion_ui/renderer/vault_markdown_renderer.py
@@ -67,6 +67,11 @@ class AssetResolverProtocol(Protocol):
         ...
 
 
+class LinkPreviewProtocol(Protocol):
+    def render(self, resolution: object, *, note_path: str = "", depth: int = 0) -> object:
+        ...
+
+
 class _RawHtmlStripper(HTMLParser):
     """Strip raw HTML tags and suppress script/style contents."""
 
@@ -117,7 +122,10 @@ class _RenderContext:
     link_resolver: LinkResolverProtocol
     asset_resolver: AssetResolverProtocol
     mermaid_renderer: MermaidBlockRenderer
+    link_preview: LinkPreviewProtocol | None
+    preview_depth: int
     diagnostics: list[MarkdownDiagnostic]
+    preview_counter: int = 0
 
 
 class VaultMarkdownRenderer:
@@ -129,16 +137,19 @@ class VaultMarkdownRenderer:
         link_resolver: LinkResolverProtocol | None = None,
         asset_resolver: AssetResolverProtocol | None = None,
         mermaid_renderer: MermaidBlockRenderer | None = None,
+        link_preview: LinkPreviewProtocol | None = None,
     ) -> None:
         self._link_resolver = link_resolver or VaultLinkResolver({})
         self._asset_resolver = asset_resolver or VaultAssetResolver({})
         self._mermaid_renderer = mermaid_renderer or MermaidBlockRenderer()
+        self._link_preview = link_preview
 
     def render(
         self,
         document: VaultMarkdownDocument | str,
         *,
         note_path: str = "",
+        preview_depth: int = 0,
     ) -> RenderedVaultMarkdown:
         parsed = parse_vault_markdown(document) if isinstance(document, str) else document
         diagnostics = list(parsed.diagnostics)
@@ -147,6 +158,8 @@ class VaultMarkdownRenderer:
             link_resolver=self._link_resolver,
             asset_resolver=self._asset_resolver,
             mermaid_renderer=self._mermaid_renderer,
+            link_preview=self._link_preview,
+            preview_depth=max(0, int(preview_depth)),
             diagnostics=diagnostics,
         )
         body_markdown = _strip_obsidian_comments(parsed.body_markdown)
@@ -171,6 +184,7 @@ def render_vault_markdown(
     link_resolver: LinkResolverProtocol | None = None,
     asset_resolver: AssetResolverProtocol | None = None,
     mermaid_renderer: MermaidBlockRenderer | None = None,
+    link_preview: LinkPreviewProtocol | None = None,
 ) -> RenderedVaultMarkdown:
     """Convenience wrapper for one-shot rendering."""
 
@@ -178,6 +192,7 @@ def render_vault_markdown(
         link_resolver=link_resolver,
         asset_resolver=asset_resolver,
         mermaid_renderer=mermaid_renderer,
+        link_preview=link_preview,
     ).render(raw_markdown, note_path=note_path)
 
 
@@ -472,7 +487,8 @@ def _render_wikilink(raw: str, context: _RenderContext) -> str:
     kind = str(getattr(resolution, "kind", "missing"))
     label = link_display_label(resolution) if kind in {"resolved", "missing", "ambiguous"} else raw
     if kind != "resolved":
-        return _render_link_diagnostic(label, kind, getattr(resolution, "reason", None))
+        trigger_html = _render_link_diagnostic(label, kind, getattr(resolution, "reason", None))
+        return _wrap_link_preview(trigger_html, resolution, context)
 
     note_path = _safe_note_path(str(getattr(resolution, "note_path", "") or ""))
     if not note_path:
@@ -482,11 +498,57 @@ def _render_wikilink(raw: str, context: _RenderContext) -> str:
     fragment = _resolution_fragment(resolution)
     if fragment:
         href = f"{href}#{quote(fragment, safe='')}"
-    return (
+    trigger_html = (
         '<a class="vault-wikilink" '
         'data-link-state="resolved" '
         f'data-note-path="{_e(note_path)}" '
         f'href="{_e(href)}">{_e(str(getattr(resolution, "display_text", label)))}</a>'
+    )
+    return _wrap_link_preview(trigger_html, resolution, context)
+
+
+def _wrap_link_preview(trigger_html: str, resolution: object, context: _RenderContext) -> str:
+    if context.link_preview is None:
+        return trigger_html
+
+    context.preview_counter += 1
+    preview_id = (
+        f"link-preview-{context.preview_counter}"
+        if context.preview_depth == 0
+        else f"link-preview-{context.preview_depth + 1}-{context.preview_counter}"
+    )
+    try:
+        preview = context.link_preview.render(
+            resolution,
+            note_path=context.note_path,
+            depth=context.preview_depth,
+        )
+        preview_html = str(getattr(preview, "html", "") or "")
+    except Exception as exc:  # Preview must never crash the note surface.
+        preview_html = _render_link_preview_exception(str(exc))
+
+    if not preview_html:
+        return trigger_html
+    return (
+        '<span class="vault-link-preview-host" '
+        'data-testid="link-preview" '
+        f'data-preview-depth="{context.preview_depth}" '
+        'tabindex="0" '
+        f'aria-describedby="{_e(preview_id)}">'
+        f"{trigger_html}"
+        f'<span id="{_e(preview_id)}" class="link-preview-popover" role="tooltip">'
+        f"{preview_html}</span>"
+        "</span>"
+    )
+
+
+def _render_link_preview_exception(message: str) -> str:
+    return (
+        '<section class="link-preview-card link-preview-diagnostic" '
+        'data-preview-state="missing" data-readonly="true">'
+        '<div class="link-preview-title">Preview unavailable</div>'
+        f'<div class="link-preview-message">{_e(message)}</div>'
+        "</section>"
     )
 
 

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -48,6 +48,7 @@ from urllib.parse import parse_qs, quote, urlparse
 from companion_ui.renderer import (
     PropertiesRenderer,
     VaultMarkdownDocument,
+    link_preview_css,
     note_outline_css,
     note_outline_script,
     parse_vault_markdown,
@@ -2776,6 +2777,7 @@ def render_index_html(
     .vault-callout-body > :last-child {{
       margin-bottom: 0;
     }}
+    {link_preview_css()}
     .vault-wikilink {{
       color: var(--cyan);
       text-decoration: none;

--- a/tests/companion_ui/test_link_preview.py
+++ b/tests/companion_ui/test_link_preview.py
@@ -1,0 +1,131 @@
+"""Read-only internal-link preview coverage for Companion UI (#1304)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from companion_ui.renderer import LinkPreview, render_vault_markdown
+from companion_ui.renderer.link_resolver import VaultLinkResolver
+
+
+def _resolver() -> VaultLinkResolver:
+    return VaultLinkResolver(
+        {
+            "ExistingNote": "Notes/ExistingNote.md",
+            "UnsafeNote": "Notes/UnsafeNote.md",
+            "RecursiveNote": "Notes/RecursiveNote.md",
+            "AmbiguousNote": ("A/AmbiguousNote.md", "B/AmbiguousNote.md"),
+        }
+    )
+
+
+def _preview(*, max_depth: int = 1) -> LinkPreview:
+    return LinkPreview(
+        {
+            "Notes/ExistingNote.md": "# Existing Note\n\nPreview body with **bold** text.",
+            "Notes/UnsafeNote.md": "# Unsafe\n\n<script>alert('xss')</script>\n\nSafe text.",
+            "Notes/RecursiveNote.md": "# Recursive\n\nNested [[ExistingNote]].",
+        },
+        link_resolver=_resolver(),
+        max_depth=max_depth,
+    )
+
+
+def _render(markdown: str, *, max_depth: int = 1) -> str:
+    return render_vault_markdown(
+        markdown,
+        note_path="Notes/current.md",
+        link_resolver=_resolver(),
+        link_preview=_preview(max_depth=max_depth),
+    ).html
+
+
+def test_hover_shows_preview() -> None:
+    html = _render("See [[ExistingNote]].")
+
+    assert 'data-testid="link-preview"' in html
+    assert 'class="link-preview-popover"' in html
+    assert 'data-preview-state="resolved"' in html
+    assert '<h1 id="existing-note">Existing Note</h1>' in html
+    assert "Preview body with <strong>bold</strong> text." in html
+
+
+def test_preview_read_only() -> None:
+    html = _render("See [[ExistingNote]].")
+
+    assert 'data-readonly="true"' in html
+    assert "<textarea" not in html
+    assert "<button" not in html
+    assert "contenteditable" not in html.lower()
+    assert "POST" not in html
+    assert "PUT" not in html
+    assert "PATCH" not in html
+    assert "DELETE" not in html
+
+
+def test_preview_sanitization() -> None:
+    html = _render("See [[UnsafeNote]].")
+    lowered = html.lower()
+
+    assert 'data-preview-state="resolved"' in html
+    assert "Safe text." in html
+    assert "<script" not in lowered
+    assert "alert(" not in lowered
+    assert "javascript:" not in lowered
+
+
+def test_depth_limit() -> None:
+    html = _render("See [[RecursiveNote]].", max_depth=1)
+
+    assert 'data-preview-state="resolved"' in html
+    assert 'data-preview-state="depth-limited"' in html
+    assert html.count('data-preview-state="resolved"') == 1
+    assert "Preview depth limit reached." in html
+
+
+def test_missing_link_preview() -> None:
+    html = _render("Missing [[MissingNote]].")
+
+    assert 'data-link-state="missing"' in html
+    assert 'data-preview-state="missing"' in html
+    assert "Preview unavailable: missing link." in html
+
+
+def test_keyboard_accessible() -> None:
+    html = _render("See [[ExistingNote]].")
+
+    assert 'tabindex="0"' in html
+    assert 'aria-describedby="link-preview-1"' in html
+    assert 'id="link-preview-1"' in html
+    assert 'role="tooltip"' in html
+
+
+def test_no_write_calls() -> None:
+    rendered = render_vault_markdown(
+        "See [[ExistingNote]].",
+        note_path="Notes/current.md",
+        link_resolver=_resolver(),
+        link_preview=_preview(),
+    )
+
+    assert rendered.write_calls == ()
+    assert rendered.html
+
+    source = (
+        Path(__file__).resolve().parents[2]
+        / "companion-ui"
+        / "companion-app"
+        / "companion_ui"
+        / "renderer"
+        / "link_preview.py"
+    ).read_text(encoding="utf-8")
+    for forbidden_call in (
+        "httpx.",
+        "WorkspaceHttpClient",
+        "fetch(",
+        ".post(",
+        ".put(",
+        ".patch(",
+        ".delete(",
+    ):
+        assert forbidden_call not in source


### PR DESCRIPTION
Closes #1304

## Summary
- Add a read-only `LinkPreview` renderer for internal links with caller-supplied note bodies, explicit depth and source-size limits, and missing/ambiguous diagnostics.
- Thread optional link previews through `VaultMarkdownRenderer` so hover/focus popovers use the same sanitized renderer subset as the main note surface.
- Add CSS-only popover chrome to the Companion UI note surface; no vault file reads, write endpoints, or editable controls are introduced.

## Validation
- `pytest tests/companion_ui/test_link_preview.py -q` — 7 passed
- `pytest tests/companion_ui/test_link_preview.py tests/companion_ui/test_vault_markdown_renderer.py tests/companion_ui/test_obsidian_compatibility_fixtures.py tests/companion_ui/test_vault_link_resolver.py tests/companion_ui/test_obsidian_link_parser.py tests/companion_ui/test_workspace_shell_alignment.py tests/companion_ui/test_real_note_workspace_dev_server.py -q && git diff --check` — 157 passed; whitespace check passed
- `ruff check app tests` not run locally: `ruff` is not installed (`command not found`; `python3 -m ruff` reported `No module named ruff`).

## Coordination Notes
- Dispatcher unavailable: `python3 -m app.dispatcher status --json` failed because local dependency `yaml` is missing; used GitHub-label fallback claim.
