### PR TITLE
spike(companion-ui): add CodeMirror source adapter

### DIFF
--- a/companion-ui/companion-app/companion_ui/spikes/__init__.py
+++ b/companion-ui/companion-app/companion_ui/spikes/__init__.py
@@ -1,0 +1,5 @@
+"""Isolated Companion UI spike modules.
+
+Modules in this package are not production surface wiring. They exist to prove
+adapter contracts and fixture behavior before any governed adoption decision.
+"""

--- a/companion-ui/companion-app/companion_ui/spikes/codemirror_adapter.py
+++ b/companion-ui/companion-app/companion_ui/spikes/codemirror_adapter.py
@@ -1,0 +1,126 @@
+"""CodeMirror 6 source-mode NoteEditorAdapter spike.
+
+This module is deliberately isolated from the production note surface. It
+models the adapter boundary needed for a future browser CodeMirror integration
+while proving that raw Obsidian-flavored Markdown can round-trip without
+normalization, autosave, or direct vault writes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class SelectionRange:
+    """Simple text selection range for the conceptual adapter contract."""
+
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class BodyPatch:
+    """Governed in-memory body patch supplied by Canvas/Panel in future wiring."""
+
+    start: int
+    end: int
+    replacement: str
+    governed: bool = True
+
+
+class CodeMirrorNoteEditorAdapter:
+    """In-memory source-mode adapter for the CodeMirror spike.
+
+    The spike does not instantiate the browser CodeMirror package because this
+    repository has no npm/React frontend module yet. The boundary deliberately
+    mirrors CodeMirror's source document behavior: content is stored as raw
+    text and returned byte-for-byte unless an explicit governed patch is
+    applied.
+    """
+
+    runtime = "codemirror-6-source-mode-spike"
+    production_wired = False
+    autosave_enabled = False
+    recommendation = "defer"
+
+    def __init__(self, markdown: str = "") -> None:
+        self._markdown = str(markdown)
+        self._selection: SelectionRange | None = None
+        self._write_calls: tuple[str, ...] = ()
+
+    @property
+    def write_calls(self) -> tuple[str, ...]:
+        return self._write_calls
+
+    def getMarkdown(self) -> str:
+        """Return raw Markdown exactly as held by the adapter."""
+
+        return self._markdown
+
+    def setMarkdown(self, markdown: str) -> None:
+        """Replace in-memory editor content without normalization or autosave."""
+
+        self._markdown = str(markdown)
+
+    def getSelection(self) -> SelectionRange | None:
+        """Return the current selection range, if one is known."""
+
+        return self._selection
+
+    def setSelection(self, start: int, end: int) -> None:
+        """Test helper matching the conceptual selection state CodeMirror exposes."""
+
+        bounded_start = _clamp(start, 0, len(self._markdown))
+        bounded_end = _clamp(end, bounded_start, len(self._markdown))
+        self._selection = SelectionRange(start=bounded_start, end=bounded_end)
+
+    def applyBodyPatch(self, patch: BodyPatch | Mapping[str, object]) -> None:
+        """Apply a governed in-memory body patch.
+
+        This is intentionally not a persistence operation. Ungoverned patches
+        are rejected because future production wiring must route through the
+        Panel/Canvas governance path.
+        """
+
+        normalized = _coerce_patch(patch)
+        if not normalized.governed:
+            raise ValueError("CodeMirror adapter spike rejects ungoverned body patches")
+
+        start = _clamp(normalized.start, 0, len(self._markdown))
+        end = _clamp(normalized.end, start, len(self._markdown))
+        self._markdown = (
+            self._markdown[:start]
+            + normalized.replacement
+            + self._markdown[end:]
+        )
+        self._selection = SelectionRange(
+            start=start,
+            end=start + len(normalized.replacement),
+        )
+
+    def focusBlock(self, block_id: str) -> bool:
+        """Move selection to an Obsidian block id marker when present."""
+
+        marker = f"^{block_id}"
+        index = self._markdown.find(marker)
+        if index < 0:
+            return False
+        self._selection = SelectionRange(start=index, end=index + len(marker))
+        return True
+
+
+def _coerce_patch(patch: BodyPatch | Mapping[str, object]) -> BodyPatch:
+    if isinstance(patch, BodyPatch):
+        return patch
+    return BodyPatch(
+        start=int(patch.get("start", 0)),
+        end=int(patch.get("end", 0)),
+        replacement=str(patch.get("replacement", "")),
+        governed=bool(patch.get("governed", True)),
+    )
+
+
+def _clamp(value: int, lower: int, upper: int) -> int:
+    return max(lower, min(int(value), upper))

--- a/tests/companion_ui/test_codemirror_adapter.py
+++ b/tests/companion_ui/test_codemirror_adapter.py
@@ -1,0 +1,66 @@
+"""CodeMirror source-mode adapter spike tests (#1305)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from companion_ui.spikes.codemirror_adapter import (
+    BodyPatch,
+    CodeMirrorNoteEditorAdapter,
+    SelectionRange,
+)
+
+
+def test_adapter_interface() -> None:
+    adapter = CodeMirrorNoteEditorAdapter("# Title\n\nBody")
+
+    assert adapter.getMarkdown() == "# Title\n\nBody"
+    adapter.setMarkdown("alpha beta gamma")
+    assert adapter.getMarkdown() == "alpha beta gamma"
+    assert adapter.getSelection() is None
+
+    adapter.setSelection(6, 10)
+    assert adapter.getSelection() == SelectionRange(start=6, end=10)
+
+    adapter.applyBodyPatch(BodyPatch(start=6, end=10, replacement="BETA"))
+    assert adapter.getMarkdown() == "alpha BETA gamma"
+    assert adapter.getSelection() == SelectionRange(start=6, end=10)
+
+    adapter.setMarkdown("Paragraph with ^block-id marker")
+    assert adapter.focusBlock("block-id") is True
+    assert adapter.getSelection() == SelectionRange(start=15, end=24)
+    assert adapter.focusBlock("missing") is False
+
+
+def test_no_autosave_or_write() -> None:
+    adapter = CodeMirrorNoteEditorAdapter("Body")
+
+    assert adapter.autosave_enabled is False
+    assert adapter.production_wired is False
+    assert adapter.write_calls == ()
+
+    with pytest.raises(ValueError, match="ungoverned"):
+        adapter.applyBodyPatch({"start": 0, "end": 0, "replacement": "x", "governed": False})
+
+    source = (
+        Path(__file__).resolve().parents[2]
+        / "companion-ui"
+        / "companion-app"
+        / "companion_ui"
+        / "spikes"
+        / "codemirror_adapter.py"
+    ).read_text(encoding="utf-8")
+    for forbidden_call in (
+        "httpx.",
+        "WorkspaceHttpClient",
+        "fetch(",
+        ".post(",
+        ".put(",
+        ".patch(",
+        ".delete(",
+        "write_text(",
+        "open(",
+    ):
+        assert forbidden_call not in source

--- a/tests/companion_ui/test_editor_roundtrip.py
+++ b/tests/companion_ui/test_editor_roundtrip.py
@@ -1,0 +1,52 @@
+"""Editor adapter fixture round-trip tests for Obsidian compatibility spikes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from companion_ui.spikes.codemirror_adapter import CodeMirrorNoteEditorAdapter
+
+
+FIXTURE_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "companion-ui"
+    / "companion-app"
+    / "tests"
+    / "fixtures"
+    / "obsidian-renderer"
+)
+
+
+def _fixtures() -> list[Path]:
+    return sorted(FIXTURE_DIR.glob("*.md"))
+
+
+def test_codemirror_roundtrip() -> None:
+    assert _fixtures(), "Expected obsidian-renderer fixtures"
+
+    for fixture_path in _fixtures():
+        raw_markdown = fixture_path.read_text(encoding="utf-8")
+        adapter = CodeMirrorNoteEditorAdapter()
+
+        adapter.setMarkdown(raw_markdown)
+
+        assert adapter.getMarkdown() == raw_markdown, fixture_path.name
+
+
+def test_obsidian_syntax_preserved() -> None:
+    raw_markdown = (FIXTURE_DIR / "full-smoke.md").read_text(encoding="utf-8")
+    adapter = CodeMirrorNoteEditorAdapter(raw_markdown)
+    round_tripped = adapter.getMarkdown()
+
+    for token in (
+        "[[ExistingNote|Display Alias]]",
+        "![[test-image.png|100x145]]",
+        "> [!warning] Custom Title",
+        "```mermaid",
+        "%% hidden %%",
+        "```dataview",
+        "<script>alert('xss')</script>",
+        "---\n",
+    ):
+        assert token in round_tripped
+    assert round_tripped == raw_markdown


### PR DESCRIPTION
Closes #1305

## Summary
- Add an isolated `companion_ui.spikes.codemirror_adapter` module that models the `NoteEditorAdapter` boundary for a future CodeMirror 6 source-mode integration.
- Prove exact raw Markdown round-trip preservation across all current Obsidian renderer fixtures, including malformed frontmatter, wikilinks, embeds, callouts, Mermaid, comments, unsafe HTML, and Dataview fences.
- Keep the spike out of the production note surface; no autosave, direct vault write, or browser runtime wiring is introduced.

## Recommendation: defer
CodeMirror source mode remains the preferred candidate for a future governed source editor, but production adoption should defer until a browser frontend module exists and can instantiate CodeMirror 6 directly under the Panel/Canvas governance path. This spike proves the adapter contract and raw-text preservation semantics, not a shipped editor UI.

Allowed decision shape for the spike: Recommendation: adopt | defer | reject. Current decision: defer.

## Validation
- `pytest tests/companion_ui/test_codemirror_adapter.py tests/companion_ui/test_editor_roundtrip.py -q && git diff --check` — 4 passed; whitespace check passed
- `grep -r "CodeMirror" companion-ui/companion-app/companion_ui/ | grep -v '/spikes/' | grep -v __pycache__ | wc -l` — 0
- `ruff check app tests` not run locally: `ruff` is not installed (`command not found`; `python3 -m ruff` reported `No module named ruff`).

## CI Notes
- GitHub checks were triggered but failed before repository code executed.
- Setup failures observed: `actions/github-script`, `dorny/paths-filter`, and `github/codeql-action` archive downloads failed from `codeload.github.com`; `project-pr-status` failed during `actions/checkout` with `403 Your account is suspended`.
- Failed workflow runs were rerun once; reruns failed at the same setup/download boundary, not in project tests or implementation code.

## Coordination Notes
- Dispatcher unavailable: `python3 -m app.dispatcher status --json` failed because local dependency `yaml` is missing; used GitHub-label fallback claim.
