### PR TITLE
feat(companion-ui): replace body-edit textarea with CodeMirror 6 source editor

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -3556,7 +3556,12 @@ def render_index_html(
         var statusEl = document.getElementById('body-edit-status');
         if (!container || !statusEl) return;
         var notePath = container.getAttribute('data-note-path');
-        var newBody = window._cmView ? window._cmView.state.doc.toString() : '';
+        if (!window._cmView) {{
+          statusEl.className = 'body-edit-status error';
+          statusEl.textContent = 'Editor not ready. Wait for the page to finish loading.';
+          return;
+        }}
+        var newBody = window._cmView.state.doc.toString();
         statusEl.className = 'body-edit-status';
         statusEl.textContent = 'Submitting…';
         fetch('/api/companion/workspace/body', {{

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -287,7 +287,7 @@ def _render_rail_empty_state(
     )
 
 
-def _render_body_edit_panel(update_flow_available: bool, note_path: str) -> str:
+def _render_body_edit_panel(update_flow_available: bool, note_path: str, raw_body: str = "") -> str:
     if not update_flow_available:
         return (
             '<section class="body-edit-panel body-edit-disabled workspace-action-absent" '
@@ -308,10 +308,10 @@ def _render_body_edit_panel(update_flow_available: bool, note_path: str) -> str:
     <span class="body-edit-label">Edit note body</span>
     <span class="body-edit-note">Frontmatter and UUID are preserved. WriteGuard is authoritative.</span>
   </div>
-  <textarea class="body-edit-textarea" id="body-edit-textarea"
-            data-testid="workspace-body-edit-textarea"
-            rows="10" placeholder="Enter new note body…"
-            data-note-path="{note_path}"></textarea>
+  <div class="body-edit-codemirror" id="body-edit-codemirror"
+       data-testid="workspace-body-edit-textarea"
+       data-note-path="{note_path}"
+       data-raw-body="{_e(raw_body)}"></div>
   <div class="body-edit-actions">
     <button class="body-edit-submit"
             data-testid="workspace-body-edit-submit"
@@ -668,7 +668,7 @@ def _render_note_section(fields: dict) -> str:
           {suggested_insertions_html}
         </div>
       </div>
-      {_render_body_edit_panel(update_flow_available, note_path_val)}
+      {_render_body_edit_panel(update_flow_available, note_path_val, raw_body)}
     </div>
     <aside
       class="agent-rail"
@@ -3267,17 +3267,19 @@ def render_index_html(
     .body-edit-header {{ display: flex; flex-direction: column; gap: 2px; }}
     .body-edit-label {{ color: var(--fg-1); font-family: var(--font-ui); font-size: var(--text-sm); font-weight: 600; }}
     .body-edit-note {{ color: var(--fg-3); font-family: var(--font-mono); font-size: var(--text-xs); }}
-    .body-edit-textarea {{
+    .body-edit-codemirror {{
       background: var(--bg-raised);
       border: 1px solid var(--border-strong);
       border-radius: var(--radius-md);
-      color: var(--fg-1);
-      font-family: var(--font-mono);
-      font-size: var(--text-sm);
-      padding: 8px;
-      resize: vertical;
+      min-height: 200px;
       width: 100%;
     }}
+    .body-edit-codemirror .cm-editor {{
+      border-radius: var(--radius-md);
+      font-family: var(--font-mono);
+      font-size: var(--text-sm);
+    }}
+    .body-edit-codemirror .cm-focused {{ outline: 1px solid var(--border-focus); }}
     .body-edit-actions {{ display: flex; gap: 8px; }}
     .body-edit-submit {{
       background: var(--bg-raised);
@@ -3550,11 +3552,11 @@ def render_index_html(
   (function() {{
     window.bodyEditor = {{
       submit: function() {{
-        var ta = document.getElementById('body-edit-textarea');
+        var container = document.getElementById('body-edit-codemirror');
         var statusEl = document.getElementById('body-edit-status');
-        if (!ta || !statusEl) return;
-        var notePath = ta.getAttribute('data-note-path');
-        var newBody = ta.value;
+        if (!container || !statusEl) return;
+        var notePath = container.getAttribute('data-note-path');
+        var newBody = window._cmView ? window._cmView.state.doc.toString() : '';
         statusEl.className = 'body-edit-status';
         statusEl.textContent = 'Submitting…';
         fetch('/api/companion/workspace/body', {{
@@ -3580,13 +3582,32 @@ def render_index_html(
         }});
       }},
       reset: function() {{
-        var ta = document.getElementById('body-edit-textarea');
+        var container = document.getElementById('body-edit-codemirror');
         var statusEl = document.getElementById('body-edit-status');
-        if (ta) ta.value = '';
+        if (window._cmView && container) {{
+          var orig = container.getAttribute('data-raw-body') || '';
+          window._cmView.dispatch({{
+            changes: {{from: 0, to: window._cmView.state.doc.length, insert: orig}}
+          }});
+        }}
         if (statusEl) {{ statusEl.className = 'body-edit-status'; statusEl.textContent = ''; }}
       }}
     }};
   }})();
+  </script>
+  <script type="module">
+  import {{EditorView, basicSetup}} from 'https://esm.sh/codemirror@6.0.1';
+  import {{markdown, markdownLanguage}} from 'https://esm.sh/@codemirror/lang-markdown@6.2.5';
+  import {{oneDark}} from 'https://esm.sh/@codemirror/theme-one-dark@6.1.2';
+  var container = document.getElementById('body-edit-codemirror');
+  if (container) {{
+    var rawBody = container.dataset.rawBody || '';
+    window._cmView = new EditorView({{
+      doc: rawBody,
+      extensions: [basicSetup, markdown({{base: markdownLanguage}}), oneDark],
+      parent: container,
+    }});
+  }}
   </script>
   <script>
   function vbToggleFilter(el) {{

--- a/companion-ui/docs/COMPANION_UI_TARGET_ARCHITECTURE.md
+++ b/companion-ui/docs/COMPANION_UI_TARGET_ARCHITECTURE.md
@@ -125,7 +125,7 @@ The detailed localhost/LAN/Tailscale/token/CSRF posture is defined in
 
 ## 5. Current Shipped State
 
-As of 2026-05-26 (after PR #1101, PR #1108, PR #1119, and the Obsidian renderer parser/resolver slices merged):
+As of 2026-05-26 (after PR #1101, PR #1108, PR #1119, the Obsidian renderer/editor epic #1293–#1306, and the CodeMirror source editor #1329):
 
 | Component | State |
 |---|---|
@@ -134,7 +134,15 @@ As of 2026-05-26 (after PR #1101, PR #1108, PR #1119, and the Obsidian renderer 
 | Browser dev server | Shipped — `companion_ui/workspace/serve_dev_page.py` (#1103 / PR #1108) |
 | Real-note workspace visual shell (first alignment pass) | Shipped — Yggdrasil tokens, note body primary, companion rail placeholder (#1119). Dev/staging only. |
 | Obsidian-compatible Markdown parser and resolvers | Shipped — `companion_ui/renderer/` parser, link resolver, and asset resolver provide read-only parsing/resolution boundaries (#1296, #1297, #1298). |
-| Vault Markdown renderer core | Shipped — Python server-side read-only renderer wired into the Python-served note body. The implementation does not add a React/TypeScript frontend stack; unsafe HTML is stripped/escaped, wikilinks/assets route through resolver boundaries, and callout/Mermaid/properties upgrades remain in follow-up renderer slices (#1299). |
+| Vault Markdown renderer core | Shipped — Python server-side read-only renderer wired into the Python-served note body (#1299). Unsafe HTML stripped/escaped; wikilinks/assets route through resolver boundaries. |
+| Obsidian callout renderer | Shipped — `companion_ui/renderer/callout_renderer.py`; type styling, fold state, nested Markdown (#1300 / PR #1313). |
+| Mermaid safe renderer | Shipped — `companion_ui/renderer/mermaid_renderer.py`; source preserved, no JS execution, no external network (#1301 / PR #1315). |
+| Properties/frontmatter renderer | Shipped — `companion_ui/renderer/properties_renderer.py`; read-only YAML display, tag chips, aliases, malformed diagnostics (#1302 / PR #1314). |
+| Note outline navigation | Shipped — `companion_ui/renderer/note_outline.py`; heading navigation, desktop side panel, no rename (#1303 / PR #1316). |
+| Link preview | Shipped — `companion_ui/renderer/link_preview.py`; bounded hover preview, read-only, no write path (#1304 / PR #1325). |
+| CodeMirror 6 source editor (body-edit panel) | Shipped for dev surface — `serve_dev_page.py` body-edit panel replaces the plain textarea with a CodeMirror 6 editor loaded via ESM CDN (`esm.sh`), pre-populated with raw Markdown. Write path unchanged (`POST /api/companion/workspace/body`). No autosave. No production bundling yet (#1329). |
+| CodeMirror 6 adapter spike | Spike only — `companion_ui/spikes/codemirror_adapter.py`; adapter contract proven, raw-text round-trip across all Obsidian fixtures (#1305 / PR #1326). Decision: defer full production adoption until npm/browser frontend module exists. |
+| Milkdown / MDXEditor rich-editor spikes | Spike only — test-only adapters in `tests/companion_ui/rich_editor_spike_adapters.py` (#1306 / PR #1327). Decision: defer both until real browser runtime round-trip is proven. |
 | Canvas Core models and session API | Shipped — `companion_ui/canvas_core/`, `app/api/routes/canvas.py` behind `CANVAS_ENABLED` |
 | Canvas Suggestion Flow models | Shipped — `companion_ui/canvas_suggestion_flow/` (browser integration pending) |
 | Panel models and confirmation service | Shipped — `companion_ui/panel/`, `app/panel/confirmation.py`, `POST /api/panel/confirm` |

--- a/tests/companion_ui/test_real_note_workspace_dev_server.py
+++ b/tests/companion_ui/test_real_note_workspace_dev_server.py
@@ -930,6 +930,14 @@ class TestBodyEditPanelRendering:
         assert "window._cmView.state.doc.toString()" in html
         assert "ta.value" not in html
 
+    def test_submit_guards_against_uninitialized_editor(self) -> None:
+        html = self._html(update_flow_available=True)
+        # submit() must bail out early (not post) when _cmView is not ready
+        assert "if (!window._cmView)" in html
+        assert "Editor not ready" in html
+        # the fallback empty-string path must not exist
+        assert "_cmView ? window._cmView.state.doc.toString() : ''" not in html
+
     def test_codemirror_absent_when_flow_disabled(self) -> None:
         html = self._html(update_flow_available=False)
         assert 'id="body-edit-codemirror"' not in html

--- a/tests/companion_ui/test_real_note_workspace_dev_server.py
+++ b/tests/companion_ui/test_real_note_workspace_dev_server.py
@@ -903,3 +903,33 @@ class TestBodyEditPanelRendering:
             fields=self._fields(update_flow_available=True, note_path="Inbox/Todo.md"),
         )
         assert 'data-note-path="Inbox/Todo.md"' in html
+
+    def test_codemirror_container_present_when_flow_available(self) -> None:
+        html = self._html(update_flow_available=True)
+        assert 'id="body-edit-codemirror"' in html
+        assert 'class="body-edit-codemirror"' in html
+
+    def test_codemirror_raw_body_in_data_attribute(self) -> None:
+        from companion_ui.workspace.serve_dev_page import render_index_html
+        html = render_index_html(
+            api_base_url="http://127.0.0.1:18001",
+            fields={**self._fields(update_flow_available=True), "body": "# Hello\n\nWorld"},
+        )
+        assert "data-raw-body=" in html
+        assert "# Hello" in html
+
+    def test_codemirror_esm_loader_present(self) -> None:
+        html = self._html(update_flow_available=True)
+        assert 'type="module"' in html
+        assert "esm.sh/codemirror" in html
+        assert "_cmView" in html
+
+    def test_body_editor_reads_from_cmview_not_textarea_value(self) -> None:
+        html = self._html(update_flow_available=True)
+        assert "window._cmView" in html
+        assert "window._cmView.state.doc.toString()" in html
+        assert "ta.value" not in html
+
+    def test_codemirror_absent_when_flow_disabled(self) -> None:
+        html = self._html(update_flow_available=False)
+        assert 'id="body-edit-codemirror"' not in html


### PR DESCRIPTION
## Summary

- Replaces the plain `<textarea>` in the dev surface body-edit panel with a CodeMirror 6 `EditorView` mounted into a container div
- CodeMirror 6 is loaded via `<script type="module">` from esm.sh CDN — no build step, no npm required for the dev surface
- Raw Markdown is pre-populated via `data-raw-body` on the container; the ESM loader script reads it on mount
- `bodyEditor.submit()` reads `window._cmView.state.doc.toString()` instead of `ta.value`; `bodyEditor.reset()` dispatches a full-replace change to restore the original
- Write path (`POST /api/companion/workspace/body`) unchanged; no autosave; explicit "Apply update" button only
- Governance (WriteGuard, governed write path) is fully preserved

## Closes

Fixes #1329

## Validation

**Tests (12/12 `TestBodyEditPanelRendering` pass; 1032 broader tests pass):**
- `test_codemirror_container_present_when_flow_available` — container div and class present
- `test_codemirror_raw_body_in_data_attribute` — raw Markdown is HTML-escaped into `data-raw-body`
- `test_codemirror_esm_loader_present` — `type="module"`, `esm.sh/codemirror`, `_cmView` present
- `test_body_editor_reads_from_cmview_not_textarea_value` — `window._cmView.state.doc.toString()` used; no `ta.value`
- `test_codemirror_absent_when_flow_disabled` — container absent when update_flow_available=False
- Existing tests (note-path in data attribute, testid selectors) continue to pass unchanged

**Pre-existing failure (not caused by this PR):**
`test_workspace_resurface_source_link_uses_logical_identifier` — `TypeError: unexpected keyword argument 'signals'` — reproduced on unmodified origin/main; not introduced here.

**CI note:** `ruff check` unavailable locally (ruff not installed in this environment). GitHub Actions CI will run it.

**Dispatcher note:** Dispatcher unavailable locally (missing `yaml` dep). GitHub-label fallback used at issue creation.

## Doc writeback

`companion-ui/docs/COMPANION_UI_TARGET_ARCHITECTURE.md` §5 "Current Shipped State" updated:
- All renderer components from epic #1293–#1306 marked shipped with PR references
- CodeMirror 6 source editor row added as "Shipped for dev surface"
- CodeMirror adapter spike and Milkdown/MDXEditor spikes marked "Spike only" with defer decisions

## Atlas UAT after dev deploy

1. Start dev server: `COMPANION_API_BASE_URL=http://127.0.0.1:18001 python -m companion_ui.workspace.serve_dev_page`
2. Open `http://127.0.0.1:8111` — note body renders in read-only renderer
3. Scroll to "Edit note body" panel — CodeMirror editor appears (not a plain textarea), with syntax highlighting and oneDark theme
4. Edit the Markdown content in the editor
5. Click "Apply update" — status shows `Updated. hash=…`
6. Reload page — edited content appears in the rendered note body
7. Click "Reset" — editor content restored to the pre-edit raw body; status cleared
8. With `update_flow_available=False` (no write permission): editor panel shows "Read only" text only; no CodeMirror editor mounted

🤖 Generated with [Claude Code](https://claude.com/claude-code)