### PR TITLE
Add renderer error-state partials

### DIFF
--- a/companion-ui/companion-app/companion_ui/renderer/mermaid_renderer.py
+++ b/companion-ui/companion-app/companion_ui/renderer/mermaid_renderer.py
@@ -177,17 +177,8 @@ def _render_error_result(
         code=code,
         message=f"{message} {detail}".strip(),
     )
-    body_html = (
-        '<div class="vault-mermaid-error" '
-        'data-testid="vault-mermaid-error" '
-        f'data-diagnostic-code="{_e(code)}" '
-        'role="alert">'
-        f"{_e(message)}"
-        f'<span class="vault-mermaid-error-detail">{_e(detail)}</span>'
-        "</div>"
-    )
     return MermaidRenderResult(
-        html=_render_figure(source, state="error", body_html=body_html),
+        html=_render_failed_embed_partial(source, code=code),
         diagnostics=(diagnostic,),
     )
 
@@ -209,12 +200,31 @@ def _render_source_details(source: str) -> str:
     return (
         '<details class="vault-mermaid-source" '
         'data-testid="vault-mermaid-source" '
-        "open>"
-        "<summary>Mermaid source</summary>"
+        ">"
+        "<summary>view source</summary>"
         '<pre class="vault-code-block vault-mermaid-source-code" data-language="mermaid">'
         f'<code class="language-mermaid">{_e(source)}</code>'
         "</pre>"
         "</details>"
+    )
+
+
+def _render_failed_embed_partial(source: str, *, code: str) -> str:
+    return (
+        '<figure class="vault-mermaid-block failed-embed failed-embed--mermaid" '
+        'data-testid="failed-embed" '
+        f'data-diagnostic-code="{_e(code)}" '
+        'data-embed-state="failed" '
+        'data-source-preserved="true" '
+        'data-network-policy="blocked">'
+        '<div class="failed-embed-main">'
+        '<span class="failed-embed-tag">MERMAID</span>'
+        '<span class="failed-embed-message">'
+        "Diagram source available &mdash; interactive render unavailable in this view."
+        "</span>"
+        "</div>"
+        f"{_render_source_details(source)}"
+        "</figure>"
     )
 
 

--- a/companion-ui/companion-app/companion_ui/renderer/vault_markdown_renderer.py
+++ b/companion-ui/companion-app/companion_ui/renderer/vault_markdown_renderer.py
@@ -482,17 +482,27 @@ def _render_wikilink(raw: str, context: _RenderContext) -> str:
         link = parse_wikilink(raw)
         resolution = context.link_resolver.resolve(link, note_path=context.note_path)
     except Exception as exc:  # Resolver contract says never throw; guard third-party stubs.
-        return _render_link_diagnostic(raw, "missing", str(exc))
+        return _render_unresolved_link_partial(raw, "missing", title_raw=raw, reason=str(exc))
 
     kind = str(getattr(resolution, "kind", "missing"))
     label = link_display_label(resolution) if kind in {"resolved", "missing", "ambiguous"} else raw
     if kind != "resolved":
-        trigger_html = _render_link_diagnostic(label, kind, getattr(resolution, "reason", None))
+        trigger_html = _render_unresolved_link_partial(
+            label,
+            kind,
+            title_raw=raw,
+            reason=getattr(resolution, "reason", None),
+        )
         return _wrap_link_preview(trigger_html, resolution, context)
 
     note_path = _safe_note_path(str(getattr(resolution, "note_path", "") or ""))
     if not note_path:
-        return _render_link_diagnostic(label, "missing", "Resolved note path was not browser-safe.")
+        return _render_unresolved_link_partial(
+            label,
+            "missing",
+            title_raw=raw,
+            reason="Resolved note path was not browser-safe.",
+        )
 
     href = f"?note_path={quote(note_path, safe='')}"
     fragment = _resolution_fragment(resolution)
@@ -552,11 +562,19 @@ def _render_link_preview_exception(message: str) -> str:
     )
 
 
-def _render_link_diagnostic(label: str, kind: str, reason: str | None) -> str:
-    reason_attr = f' title="{_e(reason)}"' if reason else ""
+def _render_unresolved_link_partial(
+    label: str,
+    kind: str,
+    *,
+    title_raw: str,
+    reason: str | None,
+) -> str:
+    missing_title = f"{title_raw} \u2014 not found in vault"
+    title = missing_title if kind == "missing" else (reason or missing_title)
     return (
         '<span class="vault-wikilink vault-wikilink-diagnostic" '
-        f'data-link-state="{_e(kind)}"{reason_attr}>'
+        f'data-link-state="{_e(kind)}" '
+        f'title="{_e(title)}">'
         f"{_e(label)}</span>"
     )
 
@@ -596,16 +614,31 @@ def _render_asset(
             }
         )
     except Exception as exc:  # Resolver contract says never throw; guard third-party stubs.
-        return _render_asset_diagnostic(raw_target, "missing", str(exc))
+        return _render_missing_image_partial(
+            display_name=raw_target,
+            target=raw_target,
+            state="missing",
+            reason=str(exc),
+            alt=alt,
+        )
 
     state = str(getattr(resolution, "kind", "missing"))
-    display_name = str(getattr(resolution, "display_name", None) or getattr(resolution, "displayName", "") or raw_target)
+    display_name = str(
+        getattr(resolution, "display_name", None)
+        or getattr(resolution, "displayName", "")
+        or raw_target
+    )
     if state != "allowed":
-        return _render_asset_diagnostic(
-            display_name,
-            state,
-            str(getattr(resolution, "reason", "") or ""),
-        )
+        reason = str(getattr(resolution, "reason", "") or "")
+        if state == "missing":
+            return _render_missing_image_partial(
+                display_name=display_name,
+                target=raw_target,
+                state=state,
+                reason=reason,
+                alt=alt,
+            )
+        return _render_asset_diagnostic(display_name, state, reason)
 
     src = str(getattr(resolution, "src", "") or "")
     if not _is_browser_safe_src(src):
@@ -619,6 +652,35 @@ def _render_asset(
     return (
         '<img class="vault-image" data-asset-state="allowed" '
         f'src="{_e(src)}" alt="{_e(alt_text)}"{width_attr}{height_attr}>'
+    )
+
+
+def _render_missing_image_partial(
+    *,
+    display_name: str,
+    target: str,
+    state: str,
+    reason: str,
+    alt: str | None,
+) -> str:
+    title_attr = f' title="{_e(reason)}"' if reason else ""
+    alt_html = (
+        f'<figcaption class="missing-image-alt">{_e(alt)}</figcaption>'
+        if alt
+        else ""
+    )
+    return (
+        '<figure class="vault-asset-diagnostic missing-image" '
+        'data-testid="missing-image" '
+        f'data-asset-state="{_e(state)}"{title_attr}>'
+        '<div class="missing-image-box">'
+        '<span class="missing-image-icon" aria-hidden="true"></span>'
+        '<span class="missing-image-caption">'
+        f"<code>{_e(display_name)}</code> &mdash; not found at <code>{_e(target)}</code>"
+        "</span>"
+        "</div>"
+        f"{alt_html}"
+        "</figure>"
     )
 
 

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -2993,6 +2993,106 @@ def render_index_html(
       display: inline;
       cursor: help;
     }}
+    .failed-embed {{
+      align-items: flex-start;
+      background: var(--bg-surface);
+      border: 1px dashed var(--border-strong);
+      border-radius: 2px;
+      display: flex;
+      gap: 16px;
+      justify-content: space-between;
+      margin: 0 0 16px;
+      padding: 14px 16px;
+    }}
+    .failed-embed-main {{
+      align-items: baseline;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      min-width: 0;
+    }}
+    .failed-embed-tag {{
+      color: var(--amber);
+      font-family: var(--font-mono);
+      font-size: 11px;
+      letter-spacing: 0;
+      line-height: 1;
+    }}
+    .failed-embed-message {{
+      color: var(--fg-2);
+      font-size: var(--text-sm);
+    }}
+    .failed-embed .vault-mermaid-source {{
+      flex: 0 0 auto;
+      margin: 0;
+    }}
+    .failed-embed .vault-mermaid-source > summary {{
+      color: var(--accent);
+      cursor: pointer;
+      font-size: var(--text-sm);
+      list-style: none;
+    }}
+    .failed-embed .vault-mermaid-source > summary::-webkit-details-marker {{
+      display: none;
+    }}
+    .failed-embed .vault-mermaid-source[open] {{
+      flex-basis: 100%;
+    }}
+    .failed-embed .vault-mermaid-source-code {{
+      margin: 12px 0 0;
+    }}
+    .vault-asset-diagnostic.missing-image {{
+      background: transparent;
+      border: 0;
+      color: var(--fg-2);
+      display: block;
+      font-family: inherit;
+      margin: 0 0 16px;
+      padding: 0;
+    }}
+    .missing-image-box {{
+      align-items: center;
+      background: var(--bg-surface);
+      border: 1px dashed var(--border-strong);
+      border-radius: 4px;
+      box-sizing: border-box;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      height: 120px;
+      justify-content: center;
+      max-width: 100%;
+      width: 100%;
+    }}
+    .missing-image-icon {{
+      border: 1px solid var(--fg-3);
+      border-radius: 2px;
+      box-sizing: border-box;
+      height: 20px;
+      position: relative;
+      width: 20px;
+    }}
+    .missing-image-icon::after {{
+      border-bottom: 1px solid var(--fg-3);
+      border-left: 1px solid var(--fg-3);
+      bottom: 4px;
+      content: "";
+      height: 6px;
+      left: 4px;
+      position: absolute;
+      transform: rotate(-45deg);
+      width: 10px;
+    }}
+    .missing-image-caption {{
+      color: var(--fg-2);
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+    }}
+    .missing-image-alt {{
+      color: var(--fg-2);
+      font-size: var(--text-sm);
+      margin-top: 6px;
+    }}
     .vault-asset-diagnostic,
     .unsupported-block-diagnostic,
     .vault-diagnostics {{

--- a/tests/companion_ui/test_failed_embed_partial.py
+++ b/tests/companion_ui/test_failed_embed_partial.py
@@ -1,0 +1,43 @@
+"""Renderer degraded-state coverage for failed embed partials."""
+
+from __future__ import annotations
+
+from companion_ui.renderer import render_vault_markdown
+
+
+def test_failed_mermaid_renders_dashed_container() -> None:
+    rendered = render_vault_markdown(
+        "\n".join(
+            [
+                "```mermaid",
+                "this is not a supported mermaid diagram",
+                "```",
+            ]
+        )
+    )
+
+    assert 'data-testid="failed-embed"' in rendered.html
+    assert "failed-embed--mermaid" in rendered.html
+    assert "<details" in rendered.html
+    assert "view source" in rendered.html
+    assert "this is not a supported mermaid diagram" in rendered.html
+
+
+def test_body_continues_after_failure() -> None:
+    rendered = render_vault_markdown(
+        "\n".join(
+            [
+                "Before the failed embed.",
+                "",
+                "```mermaid",
+                "this is not a supported mermaid diagram",
+                "```",
+                "",
+                "After the failed embed.",
+            ]
+        )
+    )
+
+    assert "<p>Before the failed embed.</p>" in rendered.html
+    assert 'data-testid="failed-embed"' in rendered.html
+    assert "<p>After the failed embed.</p>" in rendered.html

--- a/tests/companion_ui/test_missing_image_partial.py
+++ b/tests/companion_ui/test_missing_image_partial.py
@@ -1,0 +1,17 @@
+"""Renderer degraded-state coverage for missing image partials."""
+
+from __future__ import annotations
+
+from companion_ui.renderer import render_vault_markdown
+
+
+def test_missing_image_dashed_rectangle() -> None:
+    rendered = render_vault_markdown("![alt text](attachments/missing.png)")
+
+    assert 'data-testid="missing-image"' in rendered.html
+    assert 'data-asset-state="missing"' in rendered.html
+    assert (
+        "<code>missing.png</code> &mdash; "
+        "not found at <code>attachments/missing.png</code>"
+    ) in rendered.html
+    assert '<figcaption class="missing-image-alt">alt text</figcaption>' in rendered.html

--- a/tests/companion_ui/test_vault_markdown_renderer.py
+++ b/tests/companion_ui/test_vault_markdown_renderer.py
@@ -111,6 +111,15 @@ def test_internal_links() -> None:
     assert "Notes/ExistingNote.md" in rendered.html
 
 
+def test_unresolved_link_partial_emits_title_attr() -> None:
+    rendered = render_vault_markdown("[[Missing Note]]", link_resolver=_link_resolver())
+
+    assert (
+        '<span class="vault-wikilink vault-wikilink-diagnostic" '
+        'data-link-state="missing" title="[[Missing Note]] — not found in vault">'
+    ) in rendered.html
+
+
 def test_image_rendering() -> None:
     rendered = render_vault_markdown(
         _fixture("embeds-images.md"),


### PR DESCRIPTION
Fixes #1340

## Summary
- Adds renderer-side degraded-state partial shapes for failed Mermaid embeds, missing images, and unresolved wikilinks while preserving existing diagnostic class hooks.
- Adds focused companion-ui tests for the #1340 acceptance criteria and posts the UAT fixture receipt on the issue.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui -k "embed or missing_image or unresolved or markdown_renderer"` → 30 passed, 1016 deselected
- `git diff --check` → passed
- `git diff --cached --check` → passed before commit
- `ruff check app tests` could not run: `zsh:1: command not found: ruff`
- `python3 -m ruff check app tests` could not run: `/opt/homebrew/opt/python@3.14/bin/python3.14: No module named ruff`

## Coordination
- Dispatcher fallback was not used because the coordinator pre-claimed this issue via the `issue_pickup_claim` wrapper / GitHub label signal before this work began.
- UAT fixture receipt comment: https://github.com/RasmusTho/agentic-pkm-mvp/issues/1340#issuecomment-4551723263

## Known Limitations
- This is visual/degraded-state only; functional Mermaid rendering, wikilink resolution, and real image resolution remain out of scope for their sibling issues.