### PR TITLE
test(companion-ui): add orphan-text-node regression check

### DIFF
--- a/tests/companion_ui/_orphan_text.py
+++ b/tests/companion_ui/_orphan_text.py
@@ -1,0 +1,254 @@
+"""Orphan text-node detector for Companion UI rendered HTML.
+
+Implements the build-time check described in issue #1343 / design §11.1
+closing rule.  A text node is "orphan" when none of its ancestors in the
+document body carry a ``data-testid`` or ``class`` attribute that belongs to
+the whitelist of known design-system containers.
+
+This is a pytest helper — import and call ``assert_no_orphan_text(html)``
+from companion-UI workspace tests.
+"""
+from __future__ import annotations
+
+from html.parser import HTMLParser
+
+# Whitelist of ``data-testid`` values that legitimately host text content.
+# Extend this list when new design-system containers ship.
+CONTAINER_TESTIDS: frozenset[str] = frozenset(
+    {
+        # Header strip (§7.2 / #1336)
+        "workspace-wordmark",
+        "workspace-vault-chip",
+        "workspace-runtime-status",
+        "workspace-runtime-pill",
+        "workspace-runtime-human-label",
+        "workspace-freshness",
+        "workspace-dev-ribbon",
+        "workspace-quick-open",
+        "workspace-browse-vault",
+        "workspace-header-row",
+        # Runtime status popover rows
+        "workspace-runtime-status-popover",
+        "workspace-runtime-channel",
+        "workspace-runtime-channel-api",
+        "workspace-vault-identity",
+        "workspace-vault-channel",
+        "workspace-vault-provenance",
+        "workspace-writeguard-state",
+        "workspace-canvas-enabled-state",
+        "workspace-update-flow-state",
+        "workspace-update-flow-state-detail",
+        "workspace-update-flow-availability",
+        "workspace-update-flow-scope",
+        "workspace-update-flow-reason",
+        "workspace-update-flow-config-mode",
+        "workspace-update-governance-state",
+        "workspace-guard-degraded-state",
+        "workspace-runtime-trace-id",
+        # Legacy primary posture (pre-#1336 baseline on origin/main)
+        "workspace-primary-posture",
+        "workspace-primary-posture-identity",
+        "workspace-primary-posture-trace",
+        # Note header / breadcrumb
+        "workspace-note-header",
+        "workspace-note-breadcrumb",
+        "workspace-breadcrumb",
+        "workspace-note-title",
+        "workspace-properties-disclosure",
+        "workspace-note-frontmatter",
+        # Note body
+        "workspace-note-body",
+        # Outline
+        "note-outline",
+        "note-outline-link",
+        # Panel / agent rail
+        "workspace-agent-rail",
+        "workspace-panel-empty",
+        "workspace-panel-header",
+        "workspace-panel-section",
+        "workspace-reorient-strip",
+        "workspace-reorient-disclosure",
+        "workspace-canvas-session",
+        "workspace-suggestions",
+        "workspace-find-section",
+        "workspace-resurface-section",
+        # Banners
+        "workspace-vault-unreachable-banner",
+        "workspace-session-persistence",
+        "workspace-session-persistence-notice",
+        # Vault browser (left pane + overlay)
+        "vault-browser-overlay",
+        "vault-browser-row",
+        "vault-browser-empty",
+        "vault-browser-header",
+        "vault-browser-search",
+        "vault-browser-path",
+        "vault-browser-section",
+        "workspace-vault-browser-toggle",
+        "workspace-vault-browser-active-identity",
+        "workspace-vault-browser-read-only",
+        "workspace-vault-browser-provenance",
+        "workspace-vault-browser-state-identity-unavailable",
+        "vault-browse-button",
+        # Body edit panel
+        "workspace-body-edit-submit",
+        "workspace-body-edit-reset",
+        # Properties panel
+        "workspace-note-properties",
+        "vault-properties-label",
+        "vault-properties-mode",
+        "vault-property-value",
+        "vault-property-key",
+    }
+)
+
+# Whitelist of CSS class name tokens — any element whose ``class`` attribute
+# contains at least one of these is a legitimate text host.
+CONTAINER_CLASSES: frozenset[str] = frozenset(
+    {
+        "vault-markdown-rendered",
+        "panel-section",
+        "primary-posture",
+        "safety-item",          # legacy runtime-safety-strip rows (pre-#1336)
+        "workspace-runtime-popover-row",
+        "workspace-runtime-popover-key",
+        "workspace-session-persistence",
+        "note-heading",
+        "note-subheading",
+        "note-frontmatter-row",
+        "note-properties",
+        "note-breadcrumb",
+        "receipt-row",
+        "receipt-strip",
+        "governance-receipt",
+        "suggestion-card",
+        "canvas-session-card",
+        "canvas-action-row",
+        "reorient-section",
+        "find-candidate",
+        "resurface-candidate",
+        "panel-proposal-row",
+        "panel-message",
+        # Vault browser
+        "vault-browser-list",
+        "vault-browser-row-label",
+        "vault-browser-action",
+        "vault-browser-path-part",
+        "workspace-vault-browser-meta",
+        "workspace-vault-browser-state-identity-unavailable",
+        # Inspector
+        "inspector-panel",
+        "inspector-row",
+        "inspector-field",
+        "inspector-label",
+        "inspector-value",
+        # Dev-mode chrome (topbar, load-bar) — legitimate in dev/staging profile
+        "topbar",
+        "topbar-api",
+        "api-label",
+        "api-url",
+        "dev-chip",
+        "load-bar",
+        # Body edit panel
+        "body-edit-header",
+        "body-edit-label",
+        "body-edit-note",
+        "body-edit-actions",
+        # Properties panel
+        "vault-properties-header",
+        "vault-properties-list",
+        "vault-property",
+    }
+)
+
+_VOID_TAGS: frozenset[str] = frozenset(
+    {
+        "area", "base", "br", "col", "embed", "hr", "img", "input",
+        "link", "meta", "param", "source", "track", "wbr",
+    }
+)
+
+# Tags whose entire subtree is skipped (not user-facing rendered text)
+_SKIP_SUBTREE_TAGS: frozenset[str] = frozenset({"head", "style", "script"})
+
+
+class _StackWalker(HTMLParser):
+    """SAX-style walker that maintains an ancestor stack and records orphans."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Each frame: {"tag": str, "testid": str, "classes": list[str]}
+        self._stack: list[dict] = []
+        self._skip_depth: int = 0
+        # (text_snippet, path_str)
+        self.orphans: list[tuple[str, str]] = []
+
+    def handle_starttag(self, tag: str, attrs: list) -> None:
+        if self._skip_depth > 0:
+            if tag not in _VOID_TAGS:
+                self._skip_depth += 1
+            return
+        if tag in _SKIP_SUBTREE_TAGS:
+            self._skip_depth += 1
+            return
+        if tag in _VOID_TAGS:
+            return
+        attr_dict = dict(attrs)
+        self._stack.append(
+            {
+                "tag": tag,
+                "testid": attr_dict.get("data-testid", ""),
+                "classes": (attr_dict.get("class") or "").split(),
+            }
+        )
+
+    def handle_endtag(self, tag: str) -> None:
+        if self._skip_depth > 0:
+            self._skip_depth -= 1
+            return
+        if tag in _VOID_TAGS:
+            return
+        # Pop back to (and including) the most recent matching open tag.
+        for i in range(len(self._stack) - 1, -1, -1):
+            if self._stack[i]["tag"] == tag:
+                del self._stack[i:]
+                break
+
+    def handle_data(self, data: str) -> None:
+        if self._skip_depth > 0:
+            return
+        text = data.strip()
+        if not text:
+            return
+        if self._in_safe_container():
+            return
+        path = " > ".join(
+            f"{f['tag']}[{f['testid'] or ','.join(f['classes'][:1])}]"
+            for f in self._stack[-5:]
+        )
+        self.orphans.append((text[:80], path))
+
+    def _in_safe_container(self) -> bool:
+        for frame in self._stack:
+            if frame["testid"] in CONTAINER_TESTIDS:
+                return True
+            for cls in frame["classes"]:
+                if cls in CONTAINER_CLASSES:
+                    return True
+        return False
+
+
+def assert_no_orphan_text(html: str) -> None:
+    """Assert every non-whitespace text node in *html* has a safe container ancestor.
+
+    Raises ``AssertionError`` with the offending text and DOM path on failure.
+    """
+    walker = _StackWalker()
+    walker.feed(html)
+    if walker.orphans:
+        lines = "\n".join(f"  {t!r} at {p}" for t, p in walker.orphans[:5])
+        suffix = f"\n  … and {len(walker.orphans) - 5} more" if len(walker.orphans) > 5 else ""
+        raise AssertionError(
+            f"{len(walker.orphans)} orphan text node(s) — text outside a known design-system container:\n"
+            f"{lines}{suffix}"
+        )

--- a/tests/companion_ui/test_orphan_text_nodes.py
+++ b/tests/companion_ui/test_orphan_text_nodes.py
@@ -1,0 +1,167 @@
+"""Orphan text-node regression tests for Companion UI (#1343).
+
+Implements ACs 1–5 from issue #1343 / design §11.1 closing rule.
+"""
+from __future__ import annotations
+
+import pytest
+from companion_ui.workspace.serve_dev_page import render_index_html
+
+from tests.companion_ui._orphan_text import (
+    CONTAINER_TESTIDS,
+    assert_no_orphan_text,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _fields(**overrides) -> dict:
+    base: dict = {
+        "title": "Orphan Check Note",
+        "note_path": "Notes/orphan-check.md",
+        "artifact_id": "art-orphan-001",
+        "content_hash": "sha256-abc",
+        "guard_writeguard_status": "ok",
+        "guard_canvas_enabled": True,
+        "guard_degraded": False,
+        "guard_workspace_update_available": False,
+        "guard_update_flow_available": True,
+        "runtime_vault_provenance": "resolved",
+        "runtime_vault_name": "TestVault",
+        "runtime_vault_channel": "dev",
+        "panel_state": "idle",
+        "panel_proposal_count": 0,
+        "canvas_session_state": "idle",
+        "canvas_session_persistence": "durable",
+        "panel_proposals": [],
+        "panel_message": "",
+        "find_candidates": [],
+        "reorient_sections": None,
+        "resurface_candidates": [],
+        "governance_receipts": [],
+        "suggestion_state": "idle",
+        "suggestion_composer_enabled": True,
+        "is_production_ui": False,
+        "dev_page_label": "dev/staging",
+        "workspace_loaded_at": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def _render(**overrides) -> str:
+    return render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path=overrides.get("note_path", "Notes/orphan-check.md"),
+        fields=_fields(**overrides),
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC1 — helper detects an orphan text node
+# ---------------------------------------------------------------------------
+
+
+class TestHelperDetectsOrphan:
+    def test_helper_detects_orphan(self) -> None:
+        fragment = "<html><body><div>Bare orphan text here</div></body></html>"
+        with pytest.raises(AssertionError, match="orphan"):
+            assert_no_orphan_text(fragment)
+
+    def test_helper_is_silent_for_safe_containers(self) -> None:
+        fragment = (
+            '<html><body>'
+            '<div data-testid="workspace-note-body"><p>Safe text</p></div>'
+            '</body></html>'
+        )
+        assert_no_orphan_text(fragment)
+
+    def test_helper_ignores_whitespace_only_nodes(self) -> None:
+        fragment = "<html><body><div>   \n\t   </div></body></html>"
+        assert_no_orphan_text(fragment)
+
+    def test_helper_ignores_style_and_script_content(self) -> None:
+        fragment = (
+            "<html><head><style>body { margin: 0; }</style></head>"
+            "<body><script>var x = 1;</script></body></html>"
+        )
+        assert_no_orphan_text(fragment)
+
+
+# ---------------------------------------------------------------------------
+# AC2 — whitelist covers current legitimate surfaces
+# ---------------------------------------------------------------------------
+
+
+class TestWhitelistCoverage:
+    def test_whitelist_covers_current_surfaces(self) -> None:
+        required = {
+            # §7.2 header strip
+            "workspace-wordmark",
+            "workspace-vault-chip",
+            "workspace-runtime-pill",
+            "workspace-freshness",
+            "workspace-dev-ribbon",
+            # breadcrumb
+            "workspace-breadcrumb",
+            # body
+            "workspace-note-body",
+            # runtime popover
+            "workspace-runtime-status-popover",
+            # banner
+            "workspace-vault-unreachable-banner",
+            # outline
+            "note-outline-link",
+        }
+        for token in required:
+            assert token in CONTAINER_TESTIDS, (
+                f"{token!r} missing from CONTAINER_TESTIDS — add it to _orphan_text.py"
+            )
+
+
+# ---------------------------------------------------------------------------
+# AC3 — helper passes on a clean render
+# ---------------------------------------------------------------------------
+
+
+class TestCleanRenderPasses:
+    def test_helper_passes_on_clean_render(self) -> None:
+        html = _render(body="# Test Note\n\nThis is body content.\n\n- item 1\n- item 2")
+        assert_no_orphan_text(html)
+
+    def test_helper_passes_with_heading_content(self) -> None:
+        body = "# Heading\n\n## Sub-heading\n\nBody paragraph.\n\n> Callout text"
+        html = _render(body=body)
+        assert_no_orphan_text(html)
+
+    def test_helper_passes_with_empty_panel(self) -> None:
+        html = _render(panel_state="idle", panel_proposal_count=0)
+        assert_no_orphan_text(html)
+
+
+# ---------------------------------------------------------------------------
+# AC4 — helper catches the §4.5 runtime-leak regression class
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeLeakRegression:
+    def test_helper_catches_runtime_leak_regression(self) -> None:
+        fragment = (
+            '<html><body><div class="workspace-main">'
+            "Degradedvault/dev8f3c7b55433e4126b1cb3a6ae30b430c"
+            "</div></body></html>"
+        )
+        with pytest.raises(AssertionError):
+            assert_no_orphan_text(fragment)
+
+    def test_helper_catches_runtime_string_at_top_level(self) -> None:
+        fragment = (
+            '<html><body><div>'
+            "runtime/trace/8f3c7b55433e4126b1cb3a6ae30b430c"
+            "</div></body></html>"
+        )
+        with pytest.raises(AssertionError):
+            assert_no_orphan_text(fragment)

--- a/tests/companion_ui/test_workspace_shell_alignment.py
+++ b/tests/companion_ui/test_workspace_shell_alignment.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import re
 
 from companion_ui.workspace.serve_dev_page import render_index_html
+from tests.companion_ui._orphan_text import assert_no_orphan_text
 
 
 # ---------------------------------------------------------------------------
@@ -137,6 +138,7 @@ _FRONTMATTER_BODY = (
 class TestFrontmatterStrippedFromBody:
     def test_frontmatter_block_not_in_body_region(self) -> None:
         html = _html(body=_FRONTMATTER_BODY)
+        assert_no_orphan_text(html)  # AC5 opt-in: catch future orphan-text regressions
         body = _body_region(html)
         assert "uuid: 11111111" not in body
         assert "- companion-ui" not in body


### PR DESCRIPTION
## Governing issue

Fixes #1343

## Design authority

Design §11.1 closing rule / §4.5 (orphan text-node regression class) — 2026-05-26 design handoff.

## What changed

**New: `tests/companion_ui/_orphan_text.py`** — `assert_no_orphan_text(html)` helper that walks the rendered DOM and raises when a non-whitespace text node has no ancestor in the design-system container whitelist. Catches the §4.5 regression: raw runtime-state strings rendered outside labeled components.

**New: `tests/companion_ui/test_orphan_text_nodes.py`** — 10 tests covering all 5 ACs: helper detects orphan, whitelist covers current surfaces, passes on clean render, catches runtime-leak regression class.

**Updated: `tests/companion_ui/test_workspace_shell_alignment.py`** — opts into the helper in `test_frontmatter_block_not_in_body_region` (AC5).

## Files changed

- `tests/companion_ui/_orphan_text.py` — new helper
- `tests/companion_ui/test_orphan_text_nodes.py` — new test file
- `tests/companion_ui/test_workspace_shell_alignment.py` — opt-in import + call

## Tests run

```
tests/companion_ui/test_orphan_text_nodes.py        10 passed
tests/companion_ui/test_workspace_shell_alignment.py 55 passed
Full companion_ui suite (ex. infra tests):          959 passed
```

## Dispatcher note

Dispatcher unavailable (`db_exists: false`) — GitHub-label-only claim.