### PR TITLE
companion(workspace): breadcrumb + properties disclosure replaces chip strip (#1337)

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -174,18 +174,108 @@ def _render_hidden_frontmatter_marker(document: VaultMarkdownDocument) -> str:
     )
 
 
-def _render_note_frontmatter_region(document: VaultMarkdownDocument) -> str:
-    """Render frontmatter as bounded read-only metadata chrome.
+def _render_note_frontmatter_region(document: VaultMarkdownDocument):  # type: ignore[return]
+    """Return (hidden_marker_html, rendered_properties).
 
     AC1 / AC2 (#1260): the body region must not display YAML frontmatter as
     prose; frontmatter-derived metadata remains visible in dedicated chrome.
+    #1337: the visible properties are wrapped in a breadcrumb disclosure; the
+    hidden marker is kept in-place for downstream selectors.
     """
     hidden_marker = _render_hidden_frontmatter_marker(document)
-    properties_html = PropertiesRenderer(
+    rendered_props = PropertiesRenderer(
         test_id="workspace-note-properties",
         include_empty=False,
-    ).render(document).html
-    return hidden_marker + properties_html
+    ).render(document)
+    return hidden_marker, rendered_props
+
+
+def _render_workspace_breadcrumb(
+    *,
+    note_path: str,
+    artifact_id: str,
+    content_hash: str,
+    identity_state: str,
+    identity_source: str,
+    artifact_kind: str,
+    owns_identity: bool,
+    companion_html: str,
+    rendered_props,
+) -> str:
+    """Breadcrumb line under the note title with a properties ▾ disclosure.
+
+    §7.3 / #1337: replaces the chip strip (path · artifact · hash) with a
+    single breadcrumb line; artifact id and hash move inside the disclosure.
+    """
+    # Path segments — keep raw slashes as separators for readability
+    path_segments = note_path.replace("&amp;", "&").split("/")
+    path_html = " / ".join(_e(p) for p in path_segments if p)
+
+    # Pull up to 2 inline meta items from frontmatter (kind + review_state)
+    _META_KEYS = ("kind", "review", "review_state")
+    meta_items: list[str] = []
+    for field in (rendered_props.fields or ()):
+        if field.key in _META_KEYS and field.values:
+            label = _e(field.key)
+            val = _e(", ".join(field.values[:2]))
+            meta_items.append(
+                f'<span class="breadcrumb-meta-item">{label}&nbsp;{val}</span>'
+            )
+        if len(meta_items) >= 2:
+            break
+
+    meta_html = "".join(
+        f'<span class="breadcrumb-sep">&middot;</span>{item}' for item in meta_items
+    )
+
+    # Artifact/hash chips move inside the disclosure
+    artifact_chip = ""
+    if artifact_id:
+        artifact_chip = (
+            f'<span class="prov-item artifact-identity-pill"'
+            f' data-testid="workspace-artifact-identity-pill"'
+            f' data-identity-state="{identity_state}"'
+            f' data-identity-source="{identity_source}"'
+            f' data-artifact-kind="{artifact_kind}"'
+            f' data-owns-identity="{"true" if owns_identity else "false"}">'
+            f'<span class="prov-label">artifact</span>'
+            f"<code>{artifact_id}</code>"
+            f'<span class="identity-meta">{identity_state}</span>'
+            f'<span class="identity-meta">{identity_source}</span>'
+            f"{companion_html}"
+            f"</span>"
+        )
+    hash_chip = ""
+    if content_hash:
+        hash_chip = (
+            f'<span class="prov-item content-hash-pill"'
+            f' data-testid="workspace-content-hash-pill">'
+            f'<span class="prov-label">hash</span>'
+            f"<code>{content_hash}</code>"
+            f"</span>"
+        )
+    identity_chips_html = ""
+    if artifact_chip or hash_chip:
+        identity_chips_html = (
+            f'<div class="breadcrumb-identity-chips">{artifact_chip}{hash_chip}</div>'
+        )
+
+    raw_path = note_path.replace("&amp;", "&")
+    return (
+        f'<div class="workspace-breadcrumb" data-testid="workspace-breadcrumb" data-note-path="{_e(raw_path)}">'
+        f'<span class="breadcrumb-path">{path_html}</span>'
+        f"{meta_html}"
+        f'<details class="workspace-properties-disclosure"'
+        f' data-testid="workspace-properties-disclosure"'
+        f" aria-expanded=\"false\">"
+        f'<summary class="breadcrumb-disclosure-trigger">properties&nbsp;&#9660;</summary>'
+        f'<div class="properties-disclosure-body">'
+        f"{identity_chips_html}"
+        f"{rendered_props.html}"
+        f"</div>"
+        f"</details>"
+        f"</div>"
+    )
 
 
 def _compute_primary_posture(
@@ -493,7 +583,7 @@ def _render_note_section(fields: dict) -> str:
     rendered_body = render_vault_markdown(raw_body, note_path=raw_note_path)
     body = rendered_body.html
     outline_html = render_note_outline(rendered_body.document)
-    note_frontmatter_html = _render_note_frontmatter_region(rendered_body.document)
+    hidden_frontmatter_html, rendered_props = _render_note_frontmatter_region(rendered_body.document)
     panel_rail = _e(fields.get("panel_rail", "Panel / agent rail placeholder"))
     canvas_session_id = _e(fields.get("canvas_session_id") or "")
     canvas_state = _e(fields.get("canvas_session_state", "idle"))
@@ -577,6 +667,17 @@ def _render_note_section(fields: dict) -> str:
         workspace_update_scope=workspace_update_scope,
         workspace_update_governance_actions_enabled=workspace_update_governance_actions_enabled,
         workspace_update_config_mode=workspace_update_config_mode,
+    )
+    breadcrumb_html = _render_workspace_breadcrumb(
+        note_path=note_path_val,
+        artifact_id=artifact_id,
+        content_hash=content_hash,
+        identity_state=identity_state,
+        identity_source=identity_source,
+        artifact_kind=artifact_kind,
+        owns_identity=owns_identity,
+        companion_html=companion_html,
+        rendered_props=rendered_props,
     )
     rail_empty_state_html = _render_rail_empty_state(
         panel_proposal_count=proposal_count,
@@ -734,31 +835,10 @@ def _render_note_section(fields: dict) -> str:
         data-testid="workspace-note-header"
         data-region="note-header">
         <h1 class="note-title">{title}</h1>
-        <div class="note-provenance">
-          <span class="prov-item"><span class="prov-label">path</span><code>{note_path_val}</code></span>
-          <span class="prov-sep">&middot;</span>
-          <span
-            class="prov-item artifact-identity-pill"
-            data-testid="workspace-artifact-identity-pill"
-            data-identity-state="{identity_state}"
-            data-identity-source="{identity_source}"
-            data-artifact-kind="{artifact_kind}"
-            data-owns-identity="{'true' if owns_identity else 'false'}">
-            <span class="prov-label">artifact</span><code>{artifact_id or 'unresolved'}</code>
-            <span class="identity-meta">{identity_state}</span>
-            <span class="identity-meta">{identity_source}</span>
-            {companion_html}
-          </span>
-          <span class="prov-sep">&middot;</span>
-          <span
-            class="prov-item content-hash-pill"
-            data-testid="workspace-content-hash-pill">
-            <span class="prov-label">hash</span><code>{content_hash or 'unavailable'}</code>
-          </span>
-        </div>
+        {breadcrumb_html}
         {identity_caution_html}
       </header>
-      {note_frontmatter_html}
+      {hidden_frontmatter_html}
       <div
         class="note-reading-layout"
         data-testid="workspace-note-reading-layout">
@@ -2850,6 +2930,50 @@ def render_index_html(
       line-height: 1.2;
       color: var(--fg-1);
       margin-bottom: 8px;
+    }}
+    .workspace-breadcrumb {{
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 4px 6px;
+      font-family: var(--font-mono);
+      font-size: 12px;
+      color: var(--fg-3);
+      margin-top: 4px;
+      margin-bottom: 6px;
+    }}
+    .breadcrumb-path {{ color: var(--fg-3); }}
+    .breadcrumb-sep {{ color: var(--border-strong); }}
+    .breadcrumb-meta-item {{ color: var(--fg-3); }}
+    .workspace-properties-disclosure {{ display: contents; }}
+    .workspace-properties-disclosure summary {{
+      display: inline;
+      cursor: pointer;
+      color: var(--fg-3);
+      list-style: none;
+      font-family: var(--font-mono);
+      font-size: 12px;
+    }}
+    .workspace-properties-disclosure summary::-webkit-details-marker {{ display: none; }}
+    .workspace-properties-disclosure[open] summary {{ color: var(--fg-2); }}
+    .properties-disclosure-body {{
+      position: absolute;
+      z-index: 20;
+      background: var(--bg-surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-md);
+      padding: 12px 14px;
+      min-width: 280px;
+      max-width: 480px;
+      box-shadow: 0 2px 12px rgba(0,0,0,0.18);
+    }}
+    .breadcrumb-identity-chips {{
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px 8px;
+      margin-bottom: 8px;
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
     }}
     .note-provenance {{
       display: flex;

--- a/tests/companion_ui/test_real_note_workspace_visual_shell.py
+++ b/tests/companion_ui/test_real_note_workspace_visual_shell.py
@@ -155,13 +155,8 @@ class TestNoteHeader:
 
     def test_note_path_in_provenance(self) -> None:
         html = _html_with_note(note_path="Projects/Alpha.md")
-        header_match = re.search(
-            r'data-testid="workspace-note-header".*?</header>',
-            html,
-            re.DOTALL,
-        )
-        assert header_match
-        assert "Projects/Alpha.md" in header_match.group()
+        # Path is in the breadcrumb's data-note-path attribute (§7.3 / #1337)
+        assert 'data-note-path="Projects/Alpha.md"' in html
 
     def test_artifact_id_in_provenance(self) -> None:
         html = _html_with_note(artifact_id="art-xyz-999")

--- a/tests/companion_ui/test_workspace_properties_disclosure.py
+++ b/tests/companion_ui/test_workspace_properties_disclosure.py
@@ -140,8 +140,8 @@ class TestArtifactAndHashInsideDisclosure:
         outside = html.replace(disc_m.group(), "")
         # Strip style/script blocks before checking
         import re as _re
-        outside = _re.sub(r"<style[^>]*>.*?</style>", "", outside, flags=_re.DOTALL)
-        outside = _re.sub(r"<script[^>]*>.*?</script>", "", outside, flags=_re.DOTALL)
+        outside = _re.sub(r"<style[^>]*>.*?</style>", "", outside, flags=_re.DOTALL | _re.IGNORECASE)
+        outside = _re.sub(r"<script[^>]*>.*?</script>", "", outside, flags=_re.DOTALL | _re.IGNORECASE)
         assert "art-unique-7777" not in outside, (
             "artifact_id appears outside the disclosure (restatement violation)"
         )
@@ -161,8 +161,8 @@ class TestNoFactRestatement:
             flags=_re.DOTALL,
         )
         # Strip style/script
-        stripped = _re.sub(r"<style[^>]*>.*?</style>", "", html_outside_details, flags=_re.DOTALL)
-        stripped = _re.sub(r"<script[^>]*>.*?</script>", "", stripped, flags=_re.DOTALL)
+        stripped = _re.sub(r"<style[^>]*>.*?</style>", "", html_outside_details, flags=_re.DOTALL | _re.IGNORECASE)
+        stripped = _re.sub(r"<script[^>]*>.*?</script>", "", stripped, flags=_re.DOTALL | _re.IGNORECASE)
         # These unique values should NOT appear outside the disclosure
         assert "art-unique-xzy" not in stripped, "artifact_id leaked outside disclosure"
         assert "sha256-unique-abc" not in stripped, "content_hash leaked outside disclosure"

--- a/tests/companion_ui/test_workspace_properties_disclosure.py
+++ b/tests/companion_ui/test_workspace_properties_disclosure.py
@@ -140,8 +140,8 @@ class TestArtifactAndHashInsideDisclosure:
         outside = html.replace(disc_m.group(), "")
         # Strip style/script blocks before checking
         import re as _re
-        outside = _re.sub(r"<style[^>]*>.*?</style\s*>", "", outside, flags=_re.DOTALL | _re.IGNORECASE)
-        outside = _re.sub(r"<script[^>]*>.*?</script\s*>", "", outside, flags=_re.DOTALL | _re.IGNORECASE)
+        outside = _re.sub(r"<style[^>]*>.*?</style[^>]*>", "", outside, flags=_re.DOTALL | _re.IGNORECASE)
+        outside = _re.sub(r"<script[^>]*>.*?</script[^>]*>", "", outside, flags=_re.DOTALL | _re.IGNORECASE)
         assert "art-unique-7777" not in outside, (
             "artifact_id appears outside the disclosure (restatement violation)"
         )
@@ -161,8 +161,8 @@ class TestNoFactRestatement:
             flags=_re.DOTALL,
         )
         # Strip style/script
-        stripped = _re.sub(r"<style[^>]*>.*?</style\s*>", "", html_outside_details, flags=_re.DOTALL | _re.IGNORECASE)
-        stripped = _re.sub(r"<script[^>]*>.*?</script\s*>", "", stripped, flags=_re.DOTALL | _re.IGNORECASE)
+        stripped = _re.sub(r"<style[^>]*>.*?</style[^>]*>", "", html_outside_details, flags=_re.DOTALL | _re.IGNORECASE)
+        stripped = _re.sub(r"<script[^>]*>.*?</script[^>]*>", "", stripped, flags=_re.DOTALL | _re.IGNORECASE)
         # These unique values should NOT appear outside the disclosure
         assert "art-unique-xzy" not in stripped, "artifact_id leaked outside disclosure"
         assert "sha256-unique-abc" not in stripped, "content_hash leaked outside disclosure"

--- a/tests/companion_ui/test_workspace_properties_disclosure.py
+++ b/tests/companion_ui/test_workspace_properties_disclosure.py
@@ -140,8 +140,8 @@ class TestArtifactAndHashInsideDisclosure:
         outside = html.replace(disc_m.group(), "")
         # Strip style/script blocks before checking
         import re as _re
-        outside = _re.sub(r"<style[^>]*>.*?</style>", "", outside, flags=_re.DOTALL | _re.IGNORECASE)
-        outside = _re.sub(r"<script[^>]*>.*?</script>", "", outside, flags=_re.DOTALL | _re.IGNORECASE)
+        outside = _re.sub(r"<style[^>]*>.*?</style\s*>", "", outside, flags=_re.DOTALL | _re.IGNORECASE)
+        outside = _re.sub(r"<script[^>]*>.*?</script\s*>", "", outside, flags=_re.DOTALL | _re.IGNORECASE)
         assert "art-unique-7777" not in outside, (
             "artifact_id appears outside the disclosure (restatement violation)"
         )
@@ -161,8 +161,8 @@ class TestNoFactRestatement:
             flags=_re.DOTALL,
         )
         # Strip style/script
-        stripped = _re.sub(r"<style[^>]*>.*?</style>", "", html_outside_details, flags=_re.DOTALL | _re.IGNORECASE)
-        stripped = _re.sub(r"<script[^>]*>.*?</script>", "", stripped, flags=_re.DOTALL | _re.IGNORECASE)
+        stripped = _re.sub(r"<style[^>]*>.*?</style\s*>", "", html_outside_details, flags=_re.DOTALL | _re.IGNORECASE)
+        stripped = _re.sub(r"<script[^>]*>.*?</script\s*>", "", stripped, flags=_re.DOTALL | _re.IGNORECASE)
         # These unique values should NOT appear outside the disclosure
         assert "art-unique-xzy" not in stripped, "artifact_id leaked outside disclosure"
         assert "sha256-unique-abc" not in stripped, "content_hash leaked outside disclosure"

--- a/tests/companion_ui/test_workspace_properties_disclosure.py
+++ b/tests/companion_ui/test_workspace_properties_disclosure.py
@@ -1,0 +1,190 @@
+"""Tests for breadcrumb + properties disclosure (§7.3 / #1337 AC1–5)."""
+from __future__ import annotations
+
+import re
+
+from companion_ui.workspace.serve_dev_page import render_index_html
+
+
+_FRONTMATTER_BODY = """\
+---
+kind: test_note
+review: needs_review
+uuid: 550e8400-e29b-41d4-a716-446655440000
+trust: high
+tags:
+  - research
+  - agentic
+---
+
+# Test note body
+"""
+
+_FIELDS_BASE: dict = {
+    "title": "Test Note",
+    "note_path": "Inbox/Test Note.md",
+    "artifact_id": "art-12345-uuid",
+    "content_hash": "sha256-deadbeef",
+    "guard_writeguard_status": "ok",
+    "guard_canvas_enabled": True,
+    "guard_degraded": False,
+    "guard_workspace_update_available": False,
+    "guard_update_flow_available": True,
+    "runtime_vault_provenance": "resolved",
+    "runtime_vault_name": "TestVault",
+    "runtime_vault_channel": "dev",
+    "panel_state": "idle",
+    "panel_proposal_count": 0,
+    "canvas_session_state": "idle",
+    "canvas_session_persistence": "durable",
+    "panel_proposals": [],
+    "panel_message": "",
+    "find_candidates": [],
+    "reorient_sections": None,
+    "resurface_candidates": [],
+    "governance_receipts": [],
+    "suggestion_state": "idle",
+    "suggestion_composer_enabled": True,
+    "is_production_ui": False,
+    "dev_page_label": "dev/staging",
+}
+
+
+def _render(**overrides) -> str:
+    fields = {**_FIELDS_BASE, **overrides}
+    return render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path=fields["note_path"],
+        fields=fields,
+    )
+
+
+class TestBreadcrumbReplacesChips:
+    """AC1 — breadcrumb replaces the chip strip."""
+
+    def test_breadcrumb_present(self) -> None:
+        html = _render()
+        assert 'data-testid="workspace-breadcrumb"' in html
+
+    def test_breadcrumb_contains_path(self) -> None:
+        html = _render(note_path="Inbox/Test Note.md")
+        assert 'data-note-path="Inbox/Test Note.md"' in html
+
+    def test_old_chip_row_absent(self) -> None:
+        html = _render()
+        # The standalone note-provenance chip strip no longer exists as a
+        # top-level note-header sibling; chips live inside the disclosure.
+        assert 'class="note-provenance"' not in html
+
+    def test_breadcrumb_path_segments_rendered(self) -> None:
+        html = _render(note_path="Projects/Alpha/Note.md")
+        # Breadcrumb renders path parts separated by " / "
+        assert "Projects" in html
+        assert "Alpha" in html
+        assert "Note.md" in html
+
+
+class TestPropertiesDefaultCollapsed:
+    """AC2 — disclosure default state is collapsed."""
+
+    def test_default_collapsed(self) -> None:
+        html = _render()
+        m = re.search(r'data-testid="workspace-properties-disclosure"[^>]*', html)
+        assert m, "workspace-properties-disclosure not found"
+        assert 'aria-expanded="false"' in m.group(), (
+            f"disclosure is not aria-expanded=false: {m.group()!r}"
+        )
+
+    def test_details_has_no_open_attribute(self) -> None:
+        html = _render()
+        m = re.search(
+            r'<details[^>]*data-testid="workspace-properties-disclosure"[^>]*>',
+            html,
+        )
+        assert m, "properties disclosure <details> not found"
+        assert " open" not in m.group(), "disclosure is open by default"
+
+
+class TestArtifactAndHashInsideDisclosure:
+    """AC3 — artifact id and content hash live inside the disclosure only."""
+
+    def test_artifact_inside_disclosure(self) -> None:
+        html = _render(artifact_id="art-99999")
+        disc_m = re.search(
+            r'data-testid="workspace-properties-disclosure".*?</details>',
+            html,
+            re.DOTALL,
+        )
+        assert disc_m, "workspace-properties-disclosure not found"
+        assert "art-99999" in disc_m.group(), "artifact_id not inside disclosure"
+
+    def test_hash_inside_disclosure(self) -> None:
+        html = _render(content_hash="sha256-cafecafe")
+        disc_m = re.search(
+            r'data-testid="workspace-properties-disclosure".*?</details>',
+            html,
+            re.DOTALL,
+        )
+        assert disc_m, "workspace-properties-disclosure not found"
+        assert "sha256-cafecafe" in disc_m.group(), "content_hash not inside disclosure"
+
+    def test_artifact_only_in_disclosure(self) -> None:
+        """artifact_id must not appear outside the disclosure (no restatement)."""
+        html = _render(artifact_id="art-unique-7777")
+        disc_m = re.search(
+            r'data-testid="workspace-properties-disclosure".*?</details>',
+            html,
+            re.DOTALL,
+        )
+        assert disc_m
+        outside = html.replace(disc_m.group(), "")
+        # Strip style/script blocks before checking
+        import re as _re
+        outside = _re.sub(r"<style[^>]*>.*?</style>", "", outside, flags=_re.DOTALL)
+        outside = _re.sub(r"<script[^>]*>.*?</script>", "", outside, flags=_re.DOTALL)
+        assert "art-unique-7777" not in outside, (
+            "artifact_id appears outside the disclosure (restatement violation)"
+        )
+
+
+class TestNoFactRestatement:
+    """AC4 — each fact appears in at most one visible DOM region."""
+
+    def test_no_fact_restatement_for_key_fields(self) -> None:
+        html = _render(body=_FRONTMATTER_BODY, artifact_id="art-unique-xzy", content_hash="sha256-unique-abc")
+        import re as _re
+        # Exclude the closed details subtree (not visible on default render)
+        html_outside_details = _re.sub(
+            r'<details[^>]*data-testid="workspace-properties-disclosure".*?</details>',
+            "",
+            html,
+            flags=_re.DOTALL,
+        )
+        # Strip style/script
+        stripped = _re.sub(r"<style[^>]*>.*?</style>", "", html_outside_details, flags=_re.DOTALL)
+        stripped = _re.sub(r"<script[^>]*>.*?</script>", "", stripped, flags=_re.DOTALL)
+        # These unique values should NOT appear outside the disclosure
+        assert "art-unique-xzy" not in stripped, "artifact_id leaked outside disclosure"
+        assert "sha256-unique-abc" not in stripped, "content_hash leaked outside disclosure"
+
+
+class TestRendererContractPreserved:
+    """AC5 — Markdown renderer contract unchanged."""
+
+    def test_properties_renderer_html_inside_disclosure(self) -> None:
+        html = _render(body=_FRONTMATTER_BODY)
+        assert 'data-testid="workspace-note-properties"' in html
+
+    def test_all_frontmatter_keys_still_surfaced(self) -> None:
+        html = _render(body=_FRONTMATTER_BODY)
+        disc_m = re.search(
+            r'data-testid="workspace-properties-disclosure".*?</details>',
+            html,
+            re.DOTALL,
+        )
+        assert disc_m
+        disc_html = disc_m.group()
+        assert "kind" in disc_html
+        assert "review" in disc_html
+        assert "trust" in disc_html
+        assert "tags" in disc_html


### PR DESCRIPTION
## Summary

- **Breadcrumb line (§7.3)**: replaces the path/artifact/hash chip strip with a single `workspace-breadcrumb` line under the note title; path is rendered as `Part1 / Part2 / file.md`; `data-note-path` attribute carries the raw machine-readable path
- **Properties disclosure**: wraps the PropertiesRenderer output in `<details data-testid="workspace-properties-disclosure" aria-expanded="false">` — default collapsed, keyboard-accessible via Enter/Space on the `<summary>` trigger
- **No restatement**: artifact id and content hash pills move inside the disclosure (AC3 / §5 UAT-B-03); they no longer appear in the header chip strip
- Up to 2 frontmatter meta items (`kind`, `review_state`) shown inline in the breadcrumb line when present

## Acceptance criteria

| AC | Verify | Status |
|----|--------|--------|
| AC1: breadcrumb replaces chips | `test_breadcrumb_present`, `test_old_chip_row_absent` | ✅ |
| AC2: default collapsed | `test_default_collapsed`, `test_details_has_no_open_attribute` | ✅ |
| AC3: artifact/hash inside disclosure | `test_artifact_inside_disclosure`, `test_hash_inside_disclosure`, `test_artifact_only_in_disclosure` | ✅ |
| AC4: no fact restatement | `test_no_fact_restatement_for_key_fields` | ✅ |
| AC5: renderer contract preserved | `test_properties_renderer_html_inside_disclosure`, `test_all_frontmatter_keys_still_surfaced` | ✅ |

## Test run

```
12 passed (test_workspace_properties_disclosure)
992 passed, 8 pre-existing infra failures in full suite
```

## Notes

- `test_note_path_in_provenance` updated to check `data-note-path="..."` attribute instead of raw path inside header (format changed from `<code>path</code>` to breadcrumb segments)
- Dispatcher unavailable (db_exists: false) — used GitHub-label-only claim

Fixes #1337