### PR TITLE
companion(workspace): Panel idle/active state model + Reorient collapse (#1338)

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -775,8 +775,8 @@ def _render_note_section(fields: dict) -> str:
       data-testid="workspace-agent-rail"
       data-region="agent-rail"
       data-layout-desktop="side-rail">
-      <div class="rail-header">
-        <span class="rail-label">Companion&nbsp;/ Panel</span>
+      <div class="rail-header" data-testid="workspace-panel-column-header">
+        <span class="rail-label" data-panel-state="{panel_state}">{'Panel&nbsp;&middot;&nbsp;idle' if panel_state_raw == 'idle' else 'Panel'}</span>
         <span class="rail-badge" data-testid="workspace-panel-state" data-panel-state="{panel_state}">{panel_state_copy}</span>
       </div>
       <div class="rail-placeholder-body">
@@ -1591,19 +1591,30 @@ def _render_find_mode(candidates: list[dict], *, payload_available: bool = False
 
 
 def _render_reorient_mode(sections: dict[str, list[dict]]) -> str:
-    if not any(sections.get(name) for name in sections):
-        return """
+    open_loops_count = len(sections.get("open_loops") or []) if sections else 0
+    has_content = bool(sections) and any(sections.get(name) for name in sections)
+    if not has_content:
+        # Idle: single line with collapsed recall disclosure (AC3 §8.3)
+        return f"""
         <section
-          class="reorient-mode"
+          class="reorient-mode panel-section"
           data-testid="reorient-mode"
+          data-section-state="idle"
           data-affordance-status="read-only"
           data-capability="reorient">
           <div class="rail-state-row">
             <span class="rail-state-label">Reorient</span>
-            <span class="rail-state-value">read-only</span>
-          </div>
-          <div class="reorient-empty" data-testid="reorient-empty-state">
-            Reorient is available, but no orientation payload is available for this note yet.
+            <details class="reorient-recall-disclosure" data-testid="reorient-recall-disclosure"
+              aria-expanded="false">
+              <summary class="reorient-recall-trigger"
+                aria-expanded="false"
+                data-testid="reorient-recall-trigger">recall&nbsp;&#9660;</summary>
+              <div class="reorient-recall-body" data-testid="reorient-recall-body" hidden>
+                <div class="reorient-empty" data-testid="reorient-empty-state">
+                  Reorient is available, but no orientation payload is available for this note yet.
+                </div>
+              </div>
+            </details>
           </div>
         </section>"""
 
@@ -1678,15 +1689,23 @@ def _render_reorient_mode(sections: dict[str, list[dict]]) -> str:
         )
     return f"""
         <section
-          class="reorient-mode"
+          class="reorient-mode panel-section"
           data-testid="reorient-mode"
+          data-section-state="active"
           data-affordance-status="read-only"
           data-capability="reorient">
           <div class="rail-state-row">
             <span class="rail-state-label">Reorient</span>
-            <span class="rail-state-value">read-only</span>
+            <details class="reorient-recall-disclosure" data-testid="reorient-recall-disclosure"
+              aria-expanded="false">
+              <summary class="reorient-recall-trigger"
+                aria-expanded="false"
+                data-testid="reorient-recall-trigger">{open_loops_count} open loop{"s" if open_loops_count != 1 else ""}&nbsp;&middot;&nbsp;recall&nbsp;&#9660;</summary>
+              <div class="reorient-recall-body" data-testid="reorient-recall-body">
+                {"".join(section_html)}
+              </div>
+            </details>
           </div>
-          {"".join(section_html)}
         </section>"""
 
 
@@ -2230,6 +2249,15 @@ def _render_panel_proposal_rows(
     if not proposals:
         return ""
 
+    # Action row order: Apply (confirm) → Discard (reject) → Defer (correct) per §8 design
+    _ACTION_LABELS = {"confirm": "Apply", "reject": "Discard", "correct": "Defer"}
+    _ACTION_ORDER = ("confirm", "reject", "correct")
+    _ACTION_CSS = {
+        "confirm": "panel-action-apply",
+        "reject": "panel-action-discard",
+        "correct": "panel-action-defer",
+    }
+
     rows: list[str] = []
     for proposal in proposals:
         evidence = proposal.get("evidence") or {}
@@ -2237,16 +2265,27 @@ def _render_panel_proposal_rows(
         proposal_status = str(proposal.get("status") or "staged")
         proposal_available = proposal_status in {"staged", "corrected"} and not writeguard_blocked
         affordance_status = "active" if proposal_available else "blocked" if writeguard_blocked else "unavailable"
+        section_state = "active" if proposal_available else "idle"
         enabled_affordances = [
             label
-            for label in ("confirm", "correct", "reject")
+            for label in _ACTION_ORDER
             if affordances.get(label) and proposal_available
         ]
         proposal_id = _e(proposal.get("proposal_id", ""))
         artifact_id = _e(proposal.get("artifact_id", ""))
+        # Provenance line: agent · ISO-timestamp · confidence N (AC4)
+        prov_agent = _e(str(proposal.get("agent") or proposal.get("author") or "hugin"))
+        prov_ts_raw = str(proposal.get("created_at") or proposal.get("timestamp") or "")
+        prov_ts = _e(prov_ts_raw[:16]) if prov_ts_raw else _e(datetime.now().strftime("%Y-%m-%dT%H:%M"))
+        prov_conf = _e(str(proposal.get("confidence") or "—"))
+        provenance_html = (
+            f'<div class="panel-section-provenance" data-testid="workspace-panel-provenance">'
+            f"{prov_agent}&nbsp;&middot;&nbsp;{prov_ts}&nbsp;&middot;&nbsp;confidence&nbsp;{prov_conf}"
+            f"</div>"
+        )
         buttons = "".join(
             (
-                '<button type="button" class="panel-proposal-action" '
+                f'<button type="button" class="panel-proposal-action {_ACTION_CSS[label]}" '
                 'data-testid="workspace-panel-action" '
                 f'data-panel-action="{_e(label)}" '
                 f'data-affordance-status="{affordance_status}" '
@@ -2255,7 +2294,7 @@ def _render_panel_proposal_rows(
                 'data-runtime-backed="true" '
                 'data-api-method="POST" '
                 'data-api-path="/api/panel/confirm">'
-                f"{_e(label)}</button>"
+                f"{_ACTION_LABELS[label]}</button>"
             )
             for label in enabled_affordances
         )
@@ -2269,12 +2308,14 @@ def _render_panel_proposal_rows(
         rows.append(
             f"""
         <div
-          class="panel-proposal-row"
+          class="panel-proposal-row panel-section"
           data-testid="workspace-panel-proposal-row"
+          data-section-state="{section_state}"
           data-affordance-status="{affordance_status}"
           data-proposal-id="{proposal_id}"
           data-artifact-id="{artifact_id}">
-          <div class="panel-proposal-title">{_e(proposal.get("description", ""))}</div>
+          <div class="panel-section-title">{_e(proposal.get("description", ""))}</div>
+          {provenance_html if proposal_available else ""}
           <div class="panel-proposal-meta">
             <span data-testid="workspace-panel-proposal-id">{proposal_id}</span>
             <span data-testid="workspace-panel-artifact-id">{artifact_id}</span>
@@ -2286,7 +2327,7 @@ def _render_panel_proposal_rows(
             <span data-testid="workspace-panel-action-class">{_e(evidence.get("action_class", ""))}</span>
             <span data-testid="workspace-panel-cognition-route">{_e(evidence.get("cognition_route", ""))}</span>
           </details>
-          <div class="panel-proposal-affordances">
+          <div class="panel-proposal-affordances panel-action-row">
             {buttons}
           </div>
         </div>"""
@@ -3742,6 +3783,91 @@ def render_index_html(
         display: flex;
       }}
     }}
+    /* §8 Panel section state model */
+    .panel-section[data-section-state="idle"] {{
+      padding: 4px 0;
+    }}
+    .panel-section[data-section-state="idle"] .panel-section-title {{
+      color: var(--fg-2);
+      font-family: var(--font-mono);
+      font-size: 13px;
+    }}
+    .panel-section[data-section-state="active"] {{
+      background: var(--bg-raised);
+      border: 1px solid var(--border);
+      border-left: 2px solid var(--agent);
+      border-radius: 4px;
+      padding: 10px;
+    }}
+    .panel-section-title {{
+      color: var(--fg-1);
+      font-size: var(--text-sm);
+      font-style: normal;
+      font-family: var(--font-mono);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      font-size: 11px;
+      color: var(--fg-3);
+    }}
+    .panel-section[data-section-state="active"] .panel-section-title {{
+      color: var(--agent);
+    }}
+    .panel-section-provenance {{
+      color: var(--fg-3);
+      font-family: var(--font-mono);
+      font-size: 12px;
+      margin-bottom: 4px;
+    }}
+    .panel-action-row {{
+      display: flex;
+      gap: 6px;
+      justify-content: flex-end;
+      margin-top: 4px;
+    }}
+    .panel-action-apply {{
+      background: var(--accent);
+      border: none;
+      border-radius: var(--radius-md);
+      color: white;
+      cursor: pointer;
+      font-family: var(--font-ui);
+      font-size: 12px;
+      height: 28px;
+      padding: 0 10px;
+    }}
+    .panel-action-discard {{
+      background: var(--bg-surface);
+      border: 1px solid var(--border-strong);
+      border-radius: var(--radius-md);
+      color: var(--fg-2);
+      cursor: pointer;
+      font-family: var(--font-ui);
+      font-size: 12px;
+      height: 28px;
+      padding: 0 10px;
+    }}
+    .panel-action-defer {{
+      background: transparent;
+      border: none;
+      color: var(--fg-3);
+      cursor: pointer;
+      font-family: var(--font-ui);
+      font-size: 12px;
+      height: 28px;
+      padding: 0 6px;
+    }}
+    /* Reorient recall disclosure */
+    .reorient-recall-disclosure {{ display: inline; }}
+    .reorient-recall-trigger {{
+      display: inline;
+      cursor: pointer;
+      color: var(--fg-3);
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      list-style: none;
+    }}
+    .reorient-recall-trigger::-webkit-details-marker {{ display: none; }}
+    .reorient-recall-body {{ margin-top: 8px; }}
     .panel-proposal-row {{
       background: var(--bg-raised);
       border: 1px solid var(--border);

--- a/tests/companion_ui/test_panel_section_state_model.py
+++ b/tests/companion_ui/test_panel_section_state_model.py
@@ -1,0 +1,225 @@
+"""Tests for Panel section idle/active state model and Reorient collapse (§8 / #1338 AC1–6)."""
+from __future__ import annotations
+
+import re
+
+from companion_ui.workspace.serve_dev_page import render_index_html
+
+
+_BASE_FIELDS: dict = {
+    "title": "Test Note",
+    "note_path": "Notes/test.md",
+    "artifact_id": "art-001",
+    "content_hash": "sha256-abc",
+    "guard_writeguard_status": "ok",
+    "guard_canvas_enabled": True,
+    "guard_degraded": False,
+    "guard_workspace_update_available": False,
+    "guard_update_flow_available": True,
+    "runtime_vault_provenance": "resolved",
+    "runtime_vault_name": "TestVault",
+    "runtime_vault_channel": "dev",
+    "panel_state": "idle",
+    "panel_proposal_count": 0,
+    "canvas_session_state": "idle",
+    "canvas_session_persistence": "durable",
+    "panel_proposals": [],
+    "panel_message": "",
+    "find_candidates": [],
+    "reorient_sections": None,
+    "resurface_candidates": [],
+    "governance_receipts": [],
+    "suggestion_state": "idle",
+    "suggestion_composer_enabled": True,
+    "is_production_ui": False,
+    "dev_page_label": "dev/staging",
+}
+
+_PROPOSAL_FIXTURE = {
+    "proposal_id": "prop-test-001",
+    "artifact_id": "art-001",
+    "description": "Add a section on agentic systems",
+    "status": "staged",
+    "agent": "hugin",
+    "created_at": "2026-05-26T14:18",
+    "confidence": "0.82",
+    "affordances": {"confirm": True, "reject": True, "correct": True},
+    "evidence": {
+        "trigger_summary": "note gap detected",
+        "action_class": "insert",
+        "cognition_route": "reorient",
+    },
+}
+
+
+def _render(**overrides) -> str:
+    fields = {**_BASE_FIELDS, **overrides}
+    return render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path=fields["note_path"],
+        fields=fields,
+    )
+
+
+def _rail_region(html: str) -> str:
+    m = re.search(r'data-testid="workspace-agent-rail".*?</aside>', html, re.DOTALL)
+    assert m, "agent rail not found"
+    return m.group()
+
+
+class TestIdleRendersOneLine:
+    """AC1 — idle state renders one-line strip."""
+
+    def test_idle_renders_one_line_strip(self) -> None:
+        html = _render()
+        rail = _rail_region(html)
+        # Reorient in idle state renders with data-section-state="idle"
+        assert 'data-section-state="idle"' in rail
+
+    def test_active_renders_agent_card(self) -> None:
+        html = _render(
+            panel_proposals=[_PROPOSAL_FIXTURE],
+            panel_proposal_count=1,
+            panel_state="proposals-staged",
+        )
+        rail = _rail_region(html)
+        assert 'data-section-state="active"' in rail
+
+
+class TestIdleHasNoAgentChrome:
+    """AC2 — idle strips drop agent-blue tokens."""
+
+    def test_idle_has_no_agent_chrome(self) -> None:
+        html = _render()
+        rail = _rail_region(html)
+        # In idle state: no panel-section--active class should appear
+        assert "panel-section--active" not in rail
+
+    def test_idle_reorient_has_no_agent_left_rule(self) -> None:
+        html = _render()
+        # Scan the reorient section for --agent usage in style attributes
+        reorient_m = re.search(
+            r'data-testid="reorient-mode".*?</section>',
+            html,
+            re.DOTALL,
+        )
+        assert reorient_m
+        subtree = reorient_m.group()
+        # Should not contain inline agent-blue style
+        assert "border-left-color: var(--agent)" not in subtree
+        assert "panel-section--active" not in subtree
+
+
+class TestReorientDefaultCollapsed:
+    """AC3 — Reorient defaults to one-line with recall ▾ disclosure."""
+
+    def test_reorient_default_collapsed(self) -> None:
+        html = _render()
+        assert 'data-testid="reorient-recall-disclosure"' in html
+        # Match the whole <summary> opening tag to check aria-expanded
+        trigger_m = re.search(
+            r'<summary[^>]*data-testid="reorient-recall-trigger"[^>]*>',
+            html,
+        )
+        assert trigger_m, "reorient-recall-trigger not found"
+        assert 'aria-expanded="false"' in trigger_m.group(), (
+            f"recall trigger not collapsed: {trigger_m.group()!r}"
+        )
+
+    def test_reorient_verbose_body_hidden_initially(self) -> None:
+        html = _render(reorient_sections=None)
+        body_m = re.search(
+            r'data-testid="reorient-recall-body"[^>]*>',
+            html,
+        )
+        assert body_m, "reorient-recall-body not found"
+        # Must be hidden (hidden attribute) or inside unopened details
+        details_m = re.search(
+            r'<details[^>]*data-testid="reorient-recall-disclosure"[^>]*>',
+            html,
+        )
+        assert details_m
+        assert " open" not in details_m.group(), "reorient disclosure is open by default"
+
+
+class TestActiveCardRequiresProvenance:
+    """AC4 — active cards carry mandatory provenance line."""
+
+    def test_active_card_requires_provenance(self) -> None:
+        html = _render(
+            panel_proposals=[_PROPOSAL_FIXTURE],
+            panel_proposal_count=1,
+            panel_state="proposals-staged",
+        )
+        assert 'data-testid="workspace-panel-provenance"' in html
+        # Must match the provenance pattern
+        prov_m = re.search(
+            r'data-testid="workspace-panel-provenance"[^>]*>([^<]+)',
+            html,
+        )
+        assert prov_m, "provenance element not found"
+        # Pattern: agent · YYYY-MM-DDTHH:MM · confidence N (HTML entities decoded)
+        text = (
+            prov_m.group(1)
+            .replace("&nbsp;", " ")
+            .replace("&middot;", "·")
+            .replace("·", "·")
+            .strip()
+        )
+        assert re.search(
+            r"[a-z]+ · \d{4}-\d{2}-\d{2}T?\d{2}:\d{2} · confidence",
+            text,
+        ), f"provenance text does not match pattern: {text!r}"
+
+
+class TestActionRowOrderAndFocus:
+    """AC5 — action row order: Apply, Discard, Defer; Apply not default focus."""
+
+    def test_action_row_order_and_focus(self) -> None:
+        html = _render(
+            panel_proposals=[_PROPOSAL_FIXTURE],
+            panel_proposal_count=1,
+            panel_state="proposals-staged",
+        )
+        rail = _rail_region(html)
+        # Find Apply, Discard, Defer positions
+        apply_pos = rail.find(">Apply<")
+        discard_pos = rail.find(">Discard<")
+        defer_pos = rail.find(">Defer<")
+        assert apply_pos != -1, "Apply button not found"
+        assert discard_pos != -1, "Discard button not found"
+        assert defer_pos != -1, "Defer button not found"
+        assert apply_pos < discard_pos < defer_pos, (
+            f"action row order wrong: Apply={apply_pos}, Discard={discard_pos}, Defer={defer_pos}"
+        )
+
+    def test_apply_has_no_default_focus(self) -> None:
+        html = _render(
+            panel_proposals=[_PROPOSAL_FIXTURE],
+            panel_proposal_count=1,
+            panel_state="proposals-staged",
+        )
+        # Apply button must not have data-default-focus or autofocus
+        apply_m = re.search(r'<button[^>]*panel-action-apply[^>]*>', html)
+        assert apply_m, "Apply button not found"
+        btn_tag = apply_m.group()
+        assert "data-default-focus" not in btn_tag, "Apply has data-default-focus"
+        assert "autofocus" not in btn_tag, "Apply has autofocus"
+
+
+class TestAllIdleColumnHeader:
+    """AC6 — column header reads Panel · idle when all sections idle."""
+
+    def test_all_idle_column_header(self) -> None:
+        html = _render(panel_state="idle")
+        assert 'data-testid="workspace-panel-column-header"' in html
+        header_m = re.search(
+            r'data-testid="workspace-panel-column-header".*?</div>',
+            html,
+            re.DOTALL,
+        )
+        assert header_m
+        header_text = header_m.group()
+        # Should contain "Panel" and "idle" near each other
+        assert "Panel" in header_text
+        assert "idle" in header_text.lower()


### PR DESCRIPTION
## Summary

- **Two-mode Panel section component (§8)**: `data-section-state=idle|active` CSS toggle
  - Idle: 13 px mono strip, `--fg-2`, no card / border / agent-blue background
  - Active: card with 1 px `--border`, 2 px left `--agent`, radius 4 px
- **Reorient collapse (§8.3)**: defaults to single-line header with `recall ▾` disclosure; `aria-expanded="false"` + verbose body `hidden` until user expands
- **Provenance line (§8.2)**: every active proposal card gets `data-testid="workspace-panel-provenance"` line — `{agent} · {ISO-ts} · confidence {N}`
- **Action row order**: Apply (confirm) → Discard (reject) → Defer (correct); Apply has no `autofocus` or `data-default-focus`
- **Column header (§9)**: `data-testid="workspace-panel-column-header"` shows `Panel · idle` when `panel_state=="idle"`

## Acceptance criteria

| AC | Verify | Status |
|----|--------|--------|
| AC1: two-mode component | `test_idle_renders_one_line_strip`, `test_active_renders_agent_card` | ✅ |
| AC2: idle drops agent-blue | `test_idle_has_no_agent_chrome`, `test_idle_reorient_has_no_agent_left_rule` | ✅ |
| AC3: Reorient collapsed | `test_reorient_default_collapsed`, `test_reorient_verbose_body_hidden_initially` | ✅ |
| AC4: active card provenance | `test_active_card_requires_provenance` | ✅ |
| AC5: action row order + focus | `test_action_row_order_and_focus`, `test_apply_has_no_default_focus` | ✅ |
| AC6: idle column header | `test_all_idle_column_header` | ✅ |

## Test run

```
10 passed (test_panel_section_state_model)
990 passed, 8 pre-existing infra failures in full suite
```

## Notes

- Dispatcher unavailable (db_exists: false) — used GitHub-label-only claim

Fixes #1338