### PR TITLE
Use Projects-scoped token for project status automation

### DIFF
--- a/.github/workflows/project-pr-opened.yml
+++ b/.github/workflows/project-pr-opened.yml
@@ -17,7 +17,10 @@ jobs:
       - name: Project PR state projection
         # Draft PRs stay In Progress; non-draft PRs move to Review.
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN cannot write to a user-owned ProjectV2 board; a PAT/App
+          # token with Projects read/write is required. Falls back to the default
+          # token (graceful no-op) when PROJECT_TOKEN is unset.
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           python3 scripts/project_status.py \
             --repo "${{ github.repository }}" \

--- a/.github/workflows/project-pr-stage-change.yml
+++ b/.github/workflows/project-pr-stage-change.yml
@@ -17,7 +17,10 @@ jobs:
       - name: Project PR stage projection
         # Stage-change events are deterministic: ready -> Review, draft -> In Progress.
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN cannot write to a user-owned ProjectV2 board; a PAT/App
+          # token with Projects read/write is required. Falls back to the default
+          # token (graceful no-op) when PROJECT_TOKEN is unset.
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           python3 scripts/project_status.py \
             --repo "${{ github.repository }}" \

--- a/.github/workflows/project-status-reconcile.yml
+++ b/.github/workflows/project-status-reconcile.yml
@@ -21,7 +21,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Reconcile issue project status
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN cannot write to a user-owned ProjectV2 board; a PAT/App
+          # token with Projects read/write is required. Falls back to the default
+          # token (graceful no-op) when PROJECT_TOKEN is unset.
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           python3 scripts/reconcile_project_status.py \
             --repo "${{ github.repository }}" \
@@ -34,7 +37,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Reconcile existing project items
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN cannot write to a user-owned ProjectV2 board; a PAT/App
+          # token with Projects read/write is required. Falls back to the default
+          # token (graceful no-op) when PROJECT_TOKEN is unset.
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           python3 scripts/reconcile_project_status.py \
             --repo "${{ github.repository }}" \


### PR DESCRIPTION
- [x] Governance lane

## Summary
The three project-status workflows authenticated with `secrets.GITHUB_TOKEN`, which cannot read or write a **user-owned** ProjectV2 board. Every scheduled/event run hit the graceful "project board is unavailable to current credentials" no-op in `reconcile_project_status.py` and exited 0 (green), so merged PR cards never advanced to `Done` and the board silently drifted (31 stale cards found in the 2026-05-28 audit).

The reconcile logic is already correct (`desired_pr_status` maps merged PRs → `Done`); only the credential was wrong.

## Changes
Point project automation at `secrets.PROJECT_TOKEN`, falling back to `GITHUB_TOKEN` so the graceful no-op is preserved when the secret is unset:
- `.github/workflows/project-pr-opened.yml`
- `.github/workflows/project-pr-stage-change.yml`
- `.github/workflows/project-status-reconcile.yml` (both jobs)

## Operator action required
This is inert until the secret exists. Create a fine-grained PAT with **Projects: Read and write** (and Issues/Pull requests: Read) for this repo, then add it as repo secret `PROJECT_TOKEN`. Trigger `Project Status Reconcile` via `workflow_dispatch` to confirm it writes (log should show `scan complete: N change(s)` instead of the "unavailable" skip).

## Validation
Root cause confirmed from the live scheduled-scan run log:
\`\`\`
skip project reconciliation for project scan: project board is unavailable to current credentials
detail: Project "Agent Delivery Control Plane" not found for owner "RasmusTho"
\`\`\`
YAML token-reference change only; no script logic changed. Behavior verified safe in both states (secret present → writes; absent → existing no-op).

---