### PR TITLE
Canonical dev/Niflheim Companion UI startup + doctor (#1358)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fmt lint test eval docs smoke ci-smoke setup-merge-driver hygiene-logs indexer-run transcribe qa cold-boot start verify verify-runtime doctor persist-runtime-repairs install-skills test-vault-init start-test-system test-bootstrap dev-up dev-down dev-start-full prod-up prod-down prod-start-full test-start-full test-up test-down verify-test-channel verify-prod-channel dispatcher-init dispatcher-sync
+.PHONY: fmt lint test eval docs smoke ci-smoke setup-merge-driver hygiene-logs indexer-run transcribe qa cold-boot start verify verify-runtime doctor persist-runtime-repairs install-skills test-vault-init start-test-system test-bootstrap dev-up dev-down dev-start-full prod-up prod-down prod-start-full test-start-full test-up test-down verify-test-channel verify-prod-channel dev-ui dev-ui-doctor dispatcher-init dispatcher-sync
 
 PYTHON ?= $(shell if [ -x .venv/bin/python ]; then printf '%s' .venv/bin/python; elif command -v python3.12 >/dev/null 2>&1; then command -v python3.12; elif command -v python3 >/dev/null 2>&1; then command -v python3; elif command -v python >/dev/null 2>&1; then command -v python; fi)
 TEST_VAULT_ROOT ?= $(PWD)/vault-test
@@ -108,6 +108,15 @@ dev-start-full:
 	PKM_ENVIRONMENT="dev" \
 	START_MODE=runtime \
 	scripts/start_full_system.sh
+
+# Canonical dev/Niflheim Companion UI startup + doctor (Issue #1358).
+# dev-ui orchestrates the dev runtime API and Companion UI dev page against the
+# Niflheim vault in one command. dev-ui-doctor is the read-only diagnostic.
+dev-ui:
+	@bash scripts/dev/start_niflheim_ui.sh
+
+dev-ui-doctor:
+	@bash scripts/dev/dev_ui_doctor.sh
 
 prod-up:
 	@$(COMPOSE_PROD) up -d --build

--- a/companion-ui/docs/REAL_NOTE_WORKSPACE_DEV_PAGE.md
+++ b/companion-ui/docs/REAL_NOTE_WORKSPACE_DEV_PAGE.md
@@ -89,6 +89,42 @@ python -m app.cli status
 
 The browser dev server ships as `companion_ui.workspace.serve_dev_page` (#1103).
 
+### Canonical operator command (recommended)
+
+For dev/Niflheim UAT, one repo-owned command starts the runtime API **and** the
+Companion UI dev page, with guards (Issue #1358):
+
+```bash
+make dev-ui            # start dev runtime + Companion UI against Niflheim
+make dev-ui-doctor     # read-only diagnostic (no services started, no vault writes)
+```
+
+`make dev-ui` (→ `scripts/dev/start_niflheim_ui.sh`):
+
+- requires `.env.dev.local` (gitignored) and fails fast if it is missing;
+- refuses to start if the resolved `VAULT_ROOT` is not Niflheim/Nifelheim;
+- brings up the dev runtime via `scripts/start_full_system.sh`
+  (`PKM_ENVIRONMENT=dev`, project `pkm-dev`) and waits for `/healthz` on `18001`;
+- verifies the API container sees its `/app/vault` mount;
+- replaces only a stale **Companion UI** listener on `8111` — never an unrelated
+  SSH/Colima/Docker process — and starts the dev page;
+- prints the final UAT URL(s) and the API/UI log paths.
+
+LAN/Tailscale UAT is opt-in and explicit:
+
+```bash
+CUI_BIND_LAN=1 make dev-ui                     # bind UI to 0.0.0.0
+CUI_TARGET_NOTE="Some Note.md" make dev-ui     # also verify a note via the API
+```
+
+`make dev-ui-doctor` (→ `scripts/dev/dev_ui_doctor.sh`) is read-only and reports:
+Docker/Colima availability, dev vault resolution (Niflheim), API health, the
+container vault mount, UI-port occupancy (distinguishing a Companion UI listener
+from an unrelated process), UI reachability, an optional target note, and the
+Tailscale IP. Expected output is a labelled `[ok]/[warn]/[FAIL]` checklist.
+
+The manual environment-variable invocations below remain valid for ad hoc use.
+
 ### Environment variables
 
 | Variable               | Default                     | Purpose                                       |

--- a/scripts/dev/dev_ui_doctor.sh
+++ b/scripts/dev/dev_ui_doctor.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Read-only dev/Niflheim Companion UI doctor (Issue #1358).
+#
+# Diagnoses common dev startup failure modes without starting services or
+# mutating runtime/vault state: Docker/Colima availability, dev vault
+# resolution (Niflheim), runtime API health, container vault mount, UI port
+# occupancy, UI reachability, optional target note, and Tailscale IP.
+#
+# Usage:
+#   make dev-ui-doctor
+#   scripts/dev/dev_ui_doctor.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=../lib/companion_ui_startup.sh
+source "${SCRIPT_DIR}/../lib/companion_ui_startup.sh"
+
+CUI_CHANNEL="dev"
+CUI_EXPECTED_VAULT_PATTERN="nife?lheim"
+CUI_EXPECTED_VAULT_LABEL="Niflheim/Nifelheim"
+CUI_API_PORT="18001"
+CUI_UI_PORT="8111"
+CUI_COMPOSE_FILES="docker-compose.yaml:docker-compose.dev.yml"
+CUI_COMPOSE_PROJECT="pkm-dev"
+CUI_SERVE_MODULE="companion_ui.workspace.serve_dev_page"
+export CUI_CHANNEL CUI_EXPECTED_VAULT_PATTERN CUI_EXPECTED_VAULT_LABEL \
+  CUI_API_PORT CUI_UI_PORT CUI_COMPOSE_FILES CUI_COMPOSE_PROJECT CUI_SERVE_MODULE
+
+cui_run_doctor

--- a/scripts/dev/start_niflheim_ui.sh
+++ b/scripts/dev/start_niflheim_ui.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Canonical dev/Niflheim Companion UI startup (Issue #1358).
+#
+# Starts the dev runtime API + Companion UI dev page against the Niflheim vault
+# in one operator command. Refuses to start against the wrong vault, verifies
+# runtime health and the container vault mount, handles a stale UI listener on
+# port 8111 safely, and prints the final UAT URLs and log paths.
+#
+# Usage:
+#   make dev-ui
+#   scripts/dev/start_niflheim_ui.sh
+#
+# Optional environment:
+#   CUI_BIND_LAN=1                 bind the UI to 0.0.0.0 for LAN/Tailscale UAT
+#   CUI_TARGET_NOTE=<rel-path>     verify a note path via /api/companion/workspace
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=../lib/companion_ui_startup.sh
+source "${SCRIPT_DIR}/../lib/companion_ui_startup.sh"
+
+CUI_CHANNEL="dev"
+CUI_EXPECTED_VAULT_PATTERN="nife?lheim"
+CUI_EXPECTED_VAULT_LABEL="Niflheim/Nifelheim"
+CUI_API_PORT="18001"
+CUI_UI_PORT="8111"
+CUI_COMPOSE_FILES="docker-compose.yaml:docker-compose.dev.yml"
+CUI_COMPOSE_PROJECT="pkm-dev"
+CUI_SERVE_MODULE="companion_ui.workspace.serve_dev_page"
+export CUI_CHANNEL CUI_EXPECTED_VAULT_PATTERN CUI_EXPECTED_VAULT_LABEL \
+  CUI_API_PORT CUI_UI_PORT CUI_COMPOSE_FILES CUI_COMPOSE_PROJECT CUI_SERVE_MODULE
+
+cui_run_start

--- a/scripts/lib/companion_ui_startup.sh
+++ b/scripts/lib/companion_ui_startup.sh
@@ -1,0 +1,432 @@
+#!/usr/bin/env bash
+# Shared helpers for the canonical Companion UI operator startup/doctor commands.
+#
+# This library is sourced by the per-channel wrapper scripts
+# (scripts/dev/start_niflheim_ui.sh, scripts/test/start_bifrost_ui.sh,
+# scripts/prod/start_midgard_ui.sh and their *_doctor.sh siblings).
+#
+# It is channel-agnostic: a wrapper sets the CUI_* configuration variables
+# below, then calls cui_run_start or cui_run_doctor. Channel identity, vault
+# guard, ports, compose project, and serve module are all supplied by the
+# wrapper so this library never special-cases a named vault internally.
+#
+# Required CUI_* configuration (set by the wrapper before calling an entry point):
+#   CUI_CHANNEL                 dev|test|prod
+#   CUI_EXPECTED_VAULT_PATTERN  egrep pattern matched against the VAULT_ROOT basename
+#   CUI_EXPECTED_VAULT_LABEL    human label for the expected vault (e.g. "Niflheim/Nifelheim")
+#   CUI_API_PORT                runtime API host port (e.g. 18001)
+#   CUI_UI_PORT                 Companion UI host port (e.g. 8111)
+#   CUI_COMPOSE_FILES           COMPOSE_FILE value for start_full_system.sh
+#   CUI_COMPOSE_PROJECT         COMPOSE_PROJECT_NAME for the channel (e.g. pkm-dev)
+#   CUI_SERVE_MODULE            companion_ui.workspace.serve_dev_page | serve_production_page
+#
+# Optional behaviour flags (default safe):
+#   CUI_BIND_LAN=1              bind the UI to 0.0.0.0 for LAN/Tailscale UAT (default: 127.0.0.1)
+#   CUI_TARGET_NOTE=<rel-path>  optional note path to verify via /api/companion/workspace
+#   CUI_WATCHER_AUTO_EXEC       passthrough to start_full_system.sh (prod wrapper sets 0 by default)
+
+# ── repo + python resolution ────────────────────────────────────────────────
+
+cui_repo_root() {
+  local lib_dir
+  lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+  (cd "${lib_dir}/../.." && pwd)
+}
+
+cui_python_bin() {
+  if [ -n "${CUI_PYTHON:-}" ] && [ -x "${CUI_PYTHON}" ]; then
+    printf '%s\n' "${CUI_PYTHON}"
+    return 0
+  fi
+  local root
+  root="$(cui_repo_root)"
+  if [ -x "${root}/.venv/bin/python" ]; then
+    printf '%s\n' "${root}/.venv/bin/python"
+    return 0
+  fi
+  if command -v python3.12 >/dev/null 2>&1; then command -v python3.12; return 0; fi
+  if command -v python3 >/dev/null 2>&1; then command -v python3; return 0; fi
+  if command -v python >/dev/null 2>&1; then command -v python; return 0; fi
+  return 1
+}
+
+# ── logging ──────────────────────────────────────────────────────────────────
+
+cui_log()  { printf '[companion-ui:%s] %s\n' "${CUI_CHANNEL:-?}" "$*"; }
+cui_warn() { printf '[companion-ui:%s] WARN: %s\n' "${CUI_CHANNEL:-?}" "$*" >&2; }
+cui_err()  { printf '[companion-ui:%s] ERROR: %s\n' "${CUI_CHANNEL:-?}" "$*" >&2; }
+cui_die()  { cui_err "$*"; exit 1; }
+
+cui_lower() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
+
+# ── configuration guard ───────────────────────────────────────────────────────
+
+cui_require_config() {
+  local missing=""
+  local key
+  for key in CUI_CHANNEL CUI_EXPECTED_VAULT_PATTERN CUI_EXPECTED_VAULT_LABEL \
+             CUI_API_PORT CUI_UI_PORT CUI_COMPOSE_FILES CUI_COMPOSE_PROJECT CUI_SERVE_MODULE; do
+    if [ -z "${!key:-}" ]; then
+      missing="${missing} ${key}"
+    fi
+  done
+  if [ -n "${missing}" ]; then
+    cui_die "wrapper did not set required config:${missing}"
+  fi
+}
+
+# ── channel env loading + vault guard ─────────────────────────────────────────
+
+# Loads .env.<channel>.local into the environment. Fails fast if the file is
+# absent. Uses the repo's space-safe Python-based env parser.
+cui_load_channel_env() {
+  local root env_file
+  root="$(cui_repo_root)"
+  env_file=".env.${CUI_CHANNEL}.local"
+  if [ ! -f "${root}/${env_file}" ]; then
+    cui_die "missing ${env_file} in repo root (${root}). Create it with channel config (PKM_ENVIRONMENT=${CUI_CHANNEL}, VAULT_ROOT=...). See .env.example."
+  fi
+  # shellcheck source=/dev/null
+  source "${root}/scripts/lib/load_env_defaults.sh"
+  ( cd "${root}" && load_env_defaults_file "${env_file}" ) >/dev/null 2>&1 || true
+  # load_env_defaults_file runs in a subshell for the parser; re-load into this
+  # shell by re-sourcing in the repo root so exported keys persist.
+  cd "${root}" || cui_die "cannot cd to repo root ${root}"
+  load_env_defaults_file "${env_file}"
+}
+
+# Verifies VAULT_ROOT basename matches the expected channel vault. Read-only.
+cui_guard_vault_name() {
+  local base base_lc
+  if [ -z "${VAULT_ROOT:-}" ]; then
+    cui_die "VAULT_ROOT is not set after loading .env.${CUI_CHANNEL}.local; cannot confirm channel vault."
+  fi
+  base="$(basename "${VAULT_ROOT}")"
+  base_lc="$(cui_lower "${base}")"
+  if printf '%s' "${base_lc}" | grep -Eq "${CUI_EXPECTED_VAULT_PATTERN}"; then
+    cui_log "vault guard OK: resolved vault '${base}' matches expected ${CUI_EXPECTED_VAULT_LABEL}"
+    return 0
+  fi
+  cui_die "vault guard FAILED: resolved vault '${base}' (VAULT_ROOT=${VAULT_ROOT}) does not look like ${CUI_EXPECTED_VAULT_LABEL}. Refusing to start ${CUI_CHANNEL} channel against the wrong vault."
+}
+
+# ── docker / colima ───────────────────────────────────────────────────────────
+
+# Returns 0 if the Docker daemon is reachable.
+cui_docker_ok() {
+  command -v docker >/dev/null 2>&1 || return 1
+  docker info >/dev/null 2>&1 || return 1
+  return 0
+}
+
+# ── runtime orchestration ─────────────────────────────────────────────────────
+
+cui_start_runtime() {
+  local root
+  root="$(cui_repo_root)"
+  cui_log "starting runtime API via scripts/start_full_system.sh (project=${CUI_COMPOSE_PROJECT})"
+  (
+    cd "${root}" || exit 1
+    COMPOSE_FILE="${CUI_COMPOSE_FILES}" \
+    COMPOSE_PROJECT_NAME="${CUI_COMPOSE_PROJECT}" \
+    PKM_ENVIRONMENT="${CUI_CHANNEL}" \
+    START_MODE=runtime \
+    ${CUI_WATCHER_AUTO_EXEC:+WATCHER_AUTO_EXEC="${CUI_WATCHER_AUTO_EXEC}"} \
+    scripts/start_full_system.sh
+  ) || cui_die "runtime startup (start_full_system.sh) failed for ${CUI_CHANNEL}"
+}
+
+# Polls the runtime API /healthz. Read-only. Returns 0 on healthy.
+cui_wait_healthz() {
+  local url attempts i
+  url="http://127.0.0.1:${CUI_API_PORT}/healthz"
+  attempts="${CUI_HEALTH_ATTEMPTS:-30}"
+  i=1
+  while [ "${i}" -le "${attempts}" ]; do
+    if curl -fsS --max-time 3 "${url}" >/dev/null 2>&1; then
+      cui_log "runtime API healthy at ${url}"
+      return 0
+    fi
+    sleep 2
+    i=$((i + 1))
+  done
+  return 1
+}
+
+# Locates the API container for the compose project and lists /app/vault.
+# Read-only. Prints a human summary; returns non-zero if mount is missing.
+cui_verify_vault_mount() {
+  local cid count
+  cid="$(docker ps --filter "label=com.docker.compose.project=${CUI_COMPOSE_PROJECT}" \
+          --filter "name=api" --format '{{.ID}}' 2>/dev/null | head -n1)"
+  if [ -z "${cid}" ]; then
+    cui_warn "no running api container found for project ${CUI_COMPOSE_PROJECT}; cannot confirm /app/vault mount"
+    return 1
+  fi
+  if ! docker exec "${cid}" sh -c 'test -d /app/vault' >/dev/null 2>&1; then
+    cui_warn "api container ${cid} has no /app/vault directory; vault mount is missing/stale"
+    return 1
+  fi
+  count="$(docker exec "${cid}" sh -c 'ls -1 /app/vault 2>/dev/null | wc -l' 2>/dev/null | tr -d '[:space:]')"
+  cui_log "vault mount OK: container ${cid} sees /app/vault (host VAULT_ROOT=${VAULT_ROOT:-unknown}, top-level entries=${count:-0})"
+  return 0
+}
+
+# ── UI port handling ───────────────────────────────────────────────────────────
+
+# Prints PIDs (one per line) listening on the given TCP port.
+cui_port_listener_pids() {
+  local port="$1"
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN -t 2>/dev/null | sort -u
+}
+
+# Returns 0 if the given PID is a Companion UI dev/production server.
+cui_pid_is_companion() {
+  local pid="$1" cmd
+  cmd="$(ps -o command= -p "${pid}" 2>/dev/null || true)"
+  printf '%s' "${cmd}" | grep -Eq 'companion_ui\.workspace\.serve_(dev|production)_page'
+}
+
+# Frees the UI port ONLY if the listener is a Companion UI server. Never touches
+# unrelated processes (SSH, Colima, Docker, etc.) — fails with instructions
+# instead.
+cui_free_ui_port() {
+  local pids pid
+  pids="$(cui_port_listener_pids "${CUI_UI_PORT}")"
+  if [ -z "${pids}" ]; then
+    return 0
+  fi
+  for pid in ${pids}; do
+    if cui_pid_is_companion "${pid}"; then
+      cui_log "replacing stale Companion UI listener on ${CUI_UI_PORT} (pid ${pid})"
+      kill "${pid}" 2>/dev/null || true
+    else
+      cui_die "UI port ${CUI_UI_PORT} is held by a non-Companion process (pid ${pid}: $(ps -o command= -p "${pid}" 2>/dev/null | head -c 120)). Refusing to kill an unrelated process. Free the port manually or choose another UI port."
+    fi
+  done
+  # brief settle so the port is released before bind
+  sleep 1
+}
+
+# ── network helpers (best effort, read-only) ──────────────────────────────────
+
+cui_lan_ip() {
+  local ip
+  ip="$(ipconfig getifaddr en0 2>/dev/null || true)"
+  if [ -z "${ip}" ]; then ip="$(ipconfig getifaddr en1 2>/dev/null || true)"; fi
+  printf '%s' "${ip}"
+}
+
+cui_tailscale_ip() {
+  command -v tailscale >/dev/null 2>&1 || return 0
+  tailscale ip -4 2>/dev/null | head -n1
+}
+
+# ── Companion UI server ────────────────────────────────────────────────────────
+
+cui_start_ui() {
+  local root py app_dir host log_path
+  root="$(cui_repo_root)"
+  app_dir="${root}/companion-ui/companion-app"
+  log_path="${root}/tmp/companion-ui-${CUI_CHANNEL}.log"
+  mkdir -p "${root}/tmp"
+  py="$(cui_python_bin)" || cui_die "no usable python interpreter found for Companion UI server"
+
+  if [ "${CUI_BIND_LAN:-0}" = "1" ]; then
+    host="0.0.0.0"
+    cui_log "binding UI to 0.0.0.0 (LAN/Tailscale UAT explicitly requested)"
+  else
+    host="127.0.0.1"
+  fi
+
+  cui_free_ui_port
+
+  cui_log "starting Companion UI (${CUI_SERVE_MODULE}) on ${host}:${CUI_UI_PORT}"
+  (
+    cd "${app_dir}" || exit 1
+    COMPANION_API_BASE_URL="http://127.0.0.1:${CUI_API_PORT}" \
+    HOST="${host}" \
+    PORT="${CUI_UI_PORT}" \
+    nohup "${py}" -m "${CUI_SERVE_MODULE}" >"${log_path}" 2>&1 &
+    printf '%s' "$!" >"${root}/tmp/companion-ui-${CUI_CHANNEL}.pid"
+  )
+  CUI_UI_LOG_PATH="${log_path}"
+  CUI_UI_HOST="${host}"
+
+  # wait for the UI to accept connections
+  local i=1
+  while [ "${i}" -le 15 ]; do
+    if curl -fsS --max-time 3 "http://127.0.0.1:${CUI_UI_PORT}/" >/dev/null 2>&1; then
+      cui_log "Companion UI responding on 127.0.0.1:${CUI_UI_PORT}"
+      return 0
+    fi
+    sleep 1
+    i=$((i + 1))
+  done
+  cui_warn "Companion UI did not respond on 127.0.0.1:${CUI_UI_PORT} within timeout; check ${log_path}"
+  return 1
+}
+
+# ── target note verification (optional, read-only) ────────────────────────────
+
+cui_verify_target_note() {
+  local note url
+  note="${CUI_TARGET_NOTE:-}"
+  [ -n "${note}" ] || return 0
+  url="http://127.0.0.1:${CUI_API_PORT}/api/companion/workspace?note_path=$(printf '%s' "${note}" | sed 's/ /%20/g')"
+  if curl -fsS --max-time 5 "${url}" >/dev/null 2>&1; then
+    cui_log "target note OK: '${note}' is reachable via /api/companion/workspace"
+    return 0
+  fi
+  cui_warn "target note '${note}' could not be loaded via /api/companion/workspace (note may not exist in the ${CUI_CHANNEL} vault)"
+  return 1
+}
+
+# ── final operator summary ─────────────────────────────────────────────────────
+
+cui_print_summary() {
+  local lan ts query
+  lan="$(cui_lan_ip)"
+  ts="$(cui_tailscale_ip)"
+  query=""
+  if [ -n "${CUI_TARGET_NOTE:-}" ]; then
+    query="?note_path=$(printf '%s' "${CUI_TARGET_NOTE}" | sed 's/ /%20/g')"
+  fi
+  echo ""
+  echo "================ Companion UI (${CUI_CHANNEL}) ready ================"
+  echo "  runtime API : http://127.0.0.1:${CUI_API_PORT}/healthz"
+  echo "  UI (local)  : http://127.0.0.1:${CUI_UI_PORT}/${query}"
+  if [ "${CUI_BIND_LAN:-0}" = "1" ]; then
+    [ -n "${lan}" ] && echo "  UI (LAN)    : http://${lan}:${CUI_UI_PORT}/${query}"
+    [ -n "${ts}" ]  && echo "  UI (Tailscale): http://${ts}:${CUI_UI_PORT}/${query}"
+  else
+    echo "  UI bind     : 127.0.0.1 only (set CUI_BIND_LAN=1 for LAN/Tailscale UAT)"
+  fi
+  echo "  API log     : ${CUI_API_LOG_PATH:-see scripts/start_full_system.sh output / tmp/}"
+  echo "  UI log      : ${CUI_UI_LOG_PATH:-tmp/companion-ui-${CUI_CHANNEL}.log}"
+  echo "===================================================================="
+}
+
+# ── entry points ───────────────────────────────────────────────────────────────
+
+cui_run_start() {
+  cui_require_config
+  cui_log "canonical startup begin"
+  cui_load_channel_env
+  cui_guard_vault_name
+  if ! cui_docker_ok; then
+    cui_die "Docker/Colima is not available. Start Docker Desktop or 'colima start', then retry."
+  fi
+  cui_start_runtime
+  if ! cui_wait_healthz; then
+    cui_die "runtime API never became healthy at http://127.0.0.1:${CUI_API_PORT}/healthz"
+  fi
+  cui_verify_vault_mount || cui_warn "continuing despite vault-mount check warning"
+  cui_start_ui || cui_warn "Companion UI start reported a warning"
+  cui_verify_target_note || true
+  cui_print_summary
+  cui_log "canonical startup complete"
+}
+
+# Read-only diagnostic. Never starts services or mutates vault/runtime state.
+cui_run_doctor() {
+  cui_require_config
+  local rc=0
+  echo "============ Companion UI doctor (${CUI_CHANNEL}) ============"
+
+  # 1. Docker / Colima
+  if cui_docker_ok; then
+    echo "  [ok]   docker/colima reachable"
+  else
+    echo "  [FAIL] docker/colima unavailable (start Docker Desktop or 'colima start')"
+    rc=1
+  fi
+
+  # 2. Channel env file + vault resolution (read-only)
+  local root env_file
+  root="$(cui_repo_root)"
+  env_file=".env.${CUI_CHANNEL}.local"
+  if [ -f "${root}/${env_file}" ]; then
+    echo "  [ok]   ${env_file} present"
+    # shellcheck source=/dev/null
+    source "${root}/scripts/lib/load_env_defaults.sh"
+    ( cd "${root}" && load_env_defaults_file "${env_file}" ) >/dev/null 2>&1 || true
+    cd "${root}" 2>/dev/null && load_env_defaults_file "${env_file}" >/dev/null 2>&1 || true
+    if [ -n "${VAULT_ROOT:-}" ]; then
+      local base base_lc
+      base="$(basename "${VAULT_ROOT}")"
+      base_lc="$(cui_lower "${base}")"
+      if printf '%s' "${base_lc}" | grep -Eq "${CUI_EXPECTED_VAULT_PATTERN}"; then
+        echo "  [ok]   vault resolves to ${CUI_EXPECTED_VAULT_LABEL} ('${base}')"
+      else
+        echo "  [FAIL] vault '${base}' does not match expected ${CUI_EXPECTED_VAULT_LABEL}"
+        rc=1
+      fi
+    else
+      echo "  [FAIL] VAULT_ROOT not set by ${env_file}"
+      rc=1
+    fi
+  else
+    echo "  [FAIL] ${env_file} missing (see .env.example)"
+    rc=1
+  fi
+
+  # 3. API health (read-only)
+  if curl -fsS --max-time 3 "http://127.0.0.1:${CUI_API_PORT}/healthz" >/dev/null 2>&1; then
+    echo "  [ok]   runtime API healthy on :${CUI_API_PORT}"
+  else
+    echo "  [warn] runtime API not healthy on :${CUI_API_PORT} (not started yet?)"
+  fi
+
+  # 4. Vault mount (read-only; only if container running)
+  if cui_docker_ok; then
+    if cui_verify_vault_mount >/dev/null 2>&1; then
+      echo "  [ok]   api container sees /app/vault"
+    else
+      echo "  [warn] api container vault mount missing/stale or container not running"
+    fi
+  fi
+
+  # 5. UI port occupancy (read-only)
+  local pids pid
+  pids="$(cui_port_listener_pids "${CUI_UI_PORT}")"
+  if [ -z "${pids}" ]; then
+    echo "  [ok]   UI port ${CUI_UI_PORT} is free"
+  else
+    for pid in ${pids}; do
+      if cui_pid_is_companion "${pid}"; then
+        echo "  [ok]   UI port ${CUI_UI_PORT} held by Companion UI (pid ${pid}, replaceable)"
+      else
+        echo "  [warn] UI port ${CUI_UI_PORT} held by NON-Companion pid ${pid}: $(ps -o command= -p "${pid}" 2>/dev/null | head -c 80)"
+      fi
+    done
+  fi
+
+  # 6. UI process reachable (read-only)
+  if curl -fsS --max-time 3 "http://127.0.0.1:${CUI_UI_PORT}/" >/dev/null 2>&1; then
+    echo "  [ok]   Companion UI responding on :${CUI_UI_PORT}"
+  else
+    echo "  [info] Companion UI not responding on :${CUI_UI_PORT} (not started yet?)"
+  fi
+
+  # 7. Target note (optional, read-only)
+  if [ -n "${CUI_TARGET_NOTE:-}" ]; then
+    if curl -fsS --max-time 5 "http://127.0.0.1:${CUI_API_PORT}/api/companion/workspace?note_path=$(printf '%s' "${CUI_TARGET_NOTE}" | sed 's/ /%20/g')" >/dev/null 2>&1; then
+      echo "  [ok]   target note '${CUI_TARGET_NOTE}' reachable"
+    else
+      echo "  [warn] target note '${CUI_TARGET_NOTE}' not reachable"
+    fi
+  fi
+
+  # 8. Tailscale IP
+  local ts
+  ts="$(cui_tailscale_ip)"
+  if [ -n "${ts}" ]; then
+    echo "  [ok]   tailscale IP detected: ${ts}"
+  else
+    echo "  [info] no tailscale IP detected (LAN-only or tailscale down)"
+  fi
+
+  echo "============================================================="
+  return "${rc}"
+}

--- a/scripts/lib/companion_ui_startup.sh
+++ b/scripts/lib/companion_ui_startup.sh
@@ -177,7 +177,9 @@ cui_verify_vault_mount() {
 # Prints PIDs (one per line) listening on the given TCP port.
 cui_port_listener_pids() {
   local port="$1"
-  lsof -nP -iTCP:"${port}" -sTCP:LISTEN -t 2>/dev/null | sort -u
+  # `|| true` so an empty result (lsof exit 1) does not abort callers under
+  # `set -o pipefail`.
+  { lsof -nP -iTCP:"${port}" -sTCP:LISTEN -t 2>/dev/null || true; } | sort -u
 }
 
 # Returns 0 if the given PID is a Companion UI dev/production server.
@@ -219,7 +221,7 @@ cui_lan_ip() {
 
 cui_tailscale_ip() {
   command -v tailscale >/dev/null 2>&1 || return 0
-  tailscale ip -4 2>/dev/null | head -n1
+  { tailscale ip -4 2>/dev/null || true; } | head -n1
 }
 
 # ── Companion UI server ────────────────────────────────────────────────────────

--- a/tests/ops/test_companion_ui_startup_targets.py
+++ b/tests/ops/test_companion_ui_startup_targets.py
@@ -1,0 +1,177 @@
+"""
+Static inspection tests for the canonical Companion UI operator startup/doctor
+commands (Issues #1358 / #1359 / #1360).
+
+These mirror tests/ops/test_release_channel_startup_targets.py: they read the
+Makefile and the channel startup scripts directly and assert the canonical
+operator surface, channel binding, vault guard, ports, and safe UI-port
+handling. No Docker, runtime, or real vault required.
+
+Per-channel coverage is added as each sibling issue ships:
+  - dev/Niflheim  : #1358 (this file's dev cases + shared library cases)
+  - test/Bifröst  : #1359
+  - prod/Midgård  : #1360
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MAKEFILE = REPO_ROOT / "Makefile"
+SHARED_LIB = REPO_ROOT / "scripts" / "lib" / "companion_ui_startup.sh"
+DEV_START = REPO_ROOT / "scripts" / "dev" / "start_niflheim_ui.sh"
+DEV_DOCTOR = REPO_ROOT / "scripts" / "dev" / "dev_ui_doctor.sh"
+
+
+def _makefile_target_body(makefile_text: str, target_name: str) -> str | None:
+    pattern = re.compile(
+        rf"^{re.escape(target_name)}\s*:.*?(?=\n\S|\Z)",
+        re.DOTALL | re.MULTILINE,
+    )
+    match = pattern.search(makefile_text)
+    return match.group(0) if match else None
+
+
+def _bash_syntax_ok(path: Path) -> tuple[bool, str]:
+    proc = subprocess.run(
+        ["bash", "-n", str(path)],
+        capture_output=True,
+        text=True,
+    )
+    return proc.returncode == 0, proc.stderr
+
+
+# ── shared library (delivered by #1358, reused by #1359 / #1360) ──────────────
+
+
+def test_shared_library_exists_and_is_valid_bash() -> None:
+    """The channel-agnostic Companion UI startup library must exist and parse.
+
+    Verify: Issue #1358 AC1 —
+      tests/ops/test_companion_ui_startup_targets.py::test_shared_library_exists_and_is_valid_bash
+    """
+    assert SHARED_LIB.is_file(), (
+        "scripts/lib/companion_ui_startup.sh is required as the shared helper "
+        "for the canonical Companion UI startup/doctor commands (Issue #1358)."
+    )
+    ok, err = _bash_syntax_ok(SHARED_LIB)
+    assert ok, f"companion_ui_startup.sh failed `bash -n`:\n{err}"
+
+
+def test_shared_library_refuses_to_kill_unrelated_processes() -> None:
+    """Stale UI-port handling must target only Companion UI listeners.
+
+    Verify: Issue #1358 AC6 —
+      tests/ops/test_companion_ui_startup_targets.py::test_shared_library_refuses_to_kill_unrelated_processes
+    """
+    text = SHARED_LIB.read_text(encoding="utf-8")
+    # The guard identifies Companion UI listeners specifically...
+    assert "serve_(dev|production)_page" in text or "serve_dev_page" in text, (
+        "Shared library must identify Companion UI listeners specifically "
+        "before killing a UI-port holder (Issue #1358 AC6)."
+    )
+    # ...and explicitly refuses to kill a non-Companion holder.
+    assert re.search(r"non-Companion", text), (
+        "Shared library must refuse to kill a non-Companion process holding "
+        "the UI port and fail with instructions instead (Issue #1358 AC6)."
+    )
+
+
+def test_shared_library_doctor_is_read_only() -> None:
+    """The doctor entry point must not start services or mutate state.
+
+    Verify: Issue #1358 AC7 —
+      tests/ops/test_companion_ui_startup_targets.py::test_shared_library_doctor_is_read_only
+    """
+    text = SHARED_LIB.read_text(encoding="utf-8")
+    doctor = re.search(r"cui_run_doctor\(\)\s*\{.*?\n\}", text, re.DOTALL)
+    assert doctor is not None, "cui_run_doctor function not found in shared library."
+    body = doctor.group(0)
+    assert "cui_start_runtime" not in body, (
+        "Doctor must not start the runtime (read-only requirement, Issue #1358 AC7)."
+    )
+    assert "cui_start_ui" not in body, (
+        "Doctor must not start the Companion UI (read-only requirement, Issue #1358 AC7)."
+    )
+
+
+# ── dev / Niflheim (#1358) ────────────────────────────────────────────────────
+
+
+def test_dev_ui_make_targets_exist_and_delegate() -> None:
+    """make dev-ui and make dev-ui-doctor must exist and call the scripts.
+
+    Verify: Issue #1358 AC1 / AC7 —
+      tests/ops/test_companion_ui_startup_targets.py::test_dev_ui_make_targets_exist_and_delegate
+    """
+    text = MAKEFILE.read_text(encoding="utf-8")
+    start = _makefile_target_body(text, "dev-ui")
+    doctor = _makefile_target_body(text, "dev-ui-doctor")
+    assert start is not None, "Makefile is missing the canonical 'dev-ui' target (Issue #1358)."
+    assert doctor is not None, "Makefile is missing the 'dev-ui-doctor' target (Issue #1358)."
+    assert "scripts/dev/start_niflheim_ui.sh" in start, (
+        "'dev-ui' must delegate to scripts/dev/start_niflheim_ui.sh (Issue #1358)."
+    )
+    assert "scripts/dev/dev_ui_doctor.sh" in doctor, (
+        "'dev-ui-doctor' must delegate to scripts/dev/dev_ui_doctor.sh (Issue #1358)."
+    )
+
+
+def test_dev_scripts_exist_and_are_valid_bash() -> None:
+    """The dev startup and doctor scripts must exist and parse.
+
+    Verify: Issue #1358 AC1 / AC7 —
+      tests/ops/test_companion_ui_startup_targets.py::test_dev_scripts_exist_and_are_valid_bash
+    """
+    for path in (DEV_START, DEV_DOCTOR):
+        assert path.is_file(), f"{path.relative_to(REPO_ROOT)} is required (Issue #1358)."
+        ok, err = _bash_syntax_ok(path)
+        assert ok, f"{path.name} failed `bash -n`:\n{err}"
+
+
+def test_dev_start_binds_niflheim_channel_and_ports() -> None:
+    """The dev start script must bind PKM dev channel, Niflheim guard, and ports.
+
+    Verify: Issue #1358 AC2 / AC3 / AC5 —
+      tests/ops/test_companion_ui_startup_targets.py::test_dev_start_binds_niflheim_channel_and_ports
+    """
+    text = DEV_START.read_text(encoding="utf-8")
+    assert re.search(r'CUI_CHANNEL=["\']?dev["\']?', text), "dev start must set CUI_CHANNEL=dev."
+    assert "nife?lheim" in text, (
+        "dev start must guard the resolved vault against Niflheim/Nifelheim (Issue #1358 AC2)."
+    )
+    assert re.search(r'CUI_API_PORT=["\']?18001["\']?', text), "dev API port must be 18001 (AC3)."
+    assert re.search(r'CUI_UI_PORT=["\']?8111["\']?', text), "dev UI port must be 8111 (AC5)."
+    assert "companion_ui.workspace.serve_dev_page" in text, (
+        "dev start must launch the Companion UI dev page module (Issue #1358)."
+    )
+    assert "pkm-dev" in text, "dev start must target the pkm-dev compose project."
+
+
+@pytest.mark.parametrize(
+    "vault_basename,should_match",
+    [
+        ("Niflheim", True),
+        ("Nifelheim", True),
+        ("niflheim", True),
+        ("Midgård", False),
+        ("Bifröst", False),
+        ("PKM - Alpha", False),
+    ],
+)
+def test_dev_vault_guard_pattern(vault_basename: str, should_match: bool) -> None:
+    """The dev vault guard regex must accept Niflheim spellings and reject others.
+
+    Verify: Issue #1358 AC2 —
+      tests/ops/test_companion_ui_startup_targets.py::test_dev_vault_guard_pattern
+    """
+    pattern = re.compile("nife?lheim")
+    matched = bool(pattern.search(vault_basename.lower()))
+    assert matched is should_match, (
+        f"vault guard pattern match for '{vault_basename}' was {matched}, expected {should_match}."
+    )


### PR DESCRIPTION
Fixes #1358

## Summary
Adds one canonical operator command for dev/Niflheim Companion UI UAT: `make dev-ui` orchestrates the dev runtime API + Companion UI dev page, and `make dev-ui-doctor` is a read-only diagnostic. Replaces the ad hoc multi-step startup debugging described in the issue. Introduces the channel-agnostic helper `scripts/lib/companion_ui_startup.sh` that the test (#1359) and prod (#1360) siblings will reuse.

## Pickup note
This issue was not `agent:ready` (its guard asks to confirm the command surface first). The surface was confirmed by the operator for this pass: **Make targets → scripts**, start command **orchestrates runtime + UI**, **one PR per sibling** (#1358 → #1359 → #1360).

## Files
- `scripts/lib/companion_ui_startup.sh` — shared helper: channel env load, vault-name guard, `/healthz` wait, container `/app/vault` mount check, safe UI-port handling, UI launch, read-only doctor.
- `scripts/dev/start_niflheim_ui.sh`, `scripts/dev/dev_ui_doctor.sh` — dev wrappers.
- `Makefile` — `dev-ui`, `dev-ui-doctor` targets (+ `.PHONY`).
- `tests/ops/test_companion_ui_startup_targets.py` — static-inspection verification.
- `companion-ui/docs/REAL_NOTE_WORKSPACE_DEV_PAGE.md` — canonical-command section (AC8).

## Acceptance criteria mapping
- **AC1** canonical start command — `make dev-ui` → `scripts/dev/start_niflheim_ui.sh`. *Verify:* `test_dev_ui_make_targets_exist_and_delegate`, `test_dev_scripts_exist_and_are_valid_bash`.
- **AC2** wrong vault blocked — vault-name guard on resolved `VAULT_ROOT` basename (`nife?lheim`); fails fast if `.env.dev.local` missing. *Verify:* `test_dev_vault_guard_pattern` + manual run below.
- **AC3** runtime health verified — `cui_wait_healthz` polls `http://127.0.0.1:18001/healthz`. *Verify:* `test_dev_start_binds_niflheim_channel_and_ports`.
- **AC4** vault mount verified — `cui_verify_vault_mount` inspects the `pkm-dev` api container's `/app/vault`.
- **AC5** UI on canonical port — UI starts on `8111` via `serve_dev_page`. *Verify:* same port test.
- **AC6** stale UI handled safely — only a Companion UI listener is replaced; a non-Companion holder aborts with instructions. *Verify:* `test_shared_library_refuses_to_kill_unrelated_processes`.
- **AC7** doctor exists, read-only — `make dev-ui-doctor`. *Verify:* `test_shared_library_doctor_is_read_only`.
- **AC8** docs updated — owner doc section added.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/ops` → **109 passed** (12 new).
- `bash -n` on all three scripts → clean.
- `ruff check tests/ops/test_companion_ui_startup_targets.py` → clean.
- `git diff --check` → clean.
- Behavioural smoke (read-only, no Docker/real vault on this host): missing `.env.dev.local` → fails fast; wrong vault (`PKM - Alpha`) → guard rejects; `Niflheim` path → guard passes then stops at Docker check; `dev-ui-doctor` → labelled checklist, correctly flags a non-Companion holder on 8111.
- **Operator-side manual validation** (needs Docker + real `.env.dev.local` with a Niflheim `VAULT_ROOT`): `make dev-ui` end-to-end, `curl http://127.0.0.1:8111/`, `curl http://127.0.0.1:18001/healthz`.

## Risk / rollback
Ops / developer-experience only. No runtime channel semantics, contracts, events, AgentState, frontmatter, or write paths changed; UI still reaches the vault only through the runtime API. Rollback = revert the commit (additive scripts + targets + test + doc section).