### PR TITLE
Canonical prod/Midgård Companion UI startup + doctor with guardrails (#1360)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fmt lint test eval docs smoke ci-smoke setup-merge-driver hygiene-logs indexer-run transcribe qa cold-boot start verify verify-runtime doctor persist-runtime-repairs install-skills test-vault-init start-test-system test-bootstrap dev-up dev-down dev-start-full prod-up prod-down prod-start-full test-start-full test-up test-down verify-test-channel verify-prod-channel dev-ui dev-ui-doctor test-ui test-ui-doctor dispatcher-init dispatcher-sync
+.PHONY: fmt lint test eval docs smoke ci-smoke setup-merge-driver hygiene-logs indexer-run transcribe qa cold-boot start verify verify-runtime doctor persist-runtime-repairs install-skills test-vault-init start-test-system test-bootstrap dev-up dev-down dev-start-full prod-up prod-down prod-start-full test-start-full test-up test-down verify-test-channel verify-prod-channel dev-ui dev-ui-doctor test-ui test-ui-doctor prod-ui prod-ui-doctor dispatcher-init dispatcher-sync
 
 PYTHON ?= $(shell if [ -x .venv/bin/python ]; then printf '%s' .venv/bin/python; elif command -v python3.12 >/dev/null 2>&1; then command -v python3.12; elif command -v python3 >/dev/null 2>&1; then command -v python3; elif command -v python >/dev/null 2>&1; then command -v python; fi)
 TEST_VAULT_ROOT ?= $(PWD)/vault-test
@@ -126,6 +126,16 @@ test-ui:
 
 test-ui-doctor:
 	@bash scripts/test/test_ui_doctor.sh
+
+# Canonical prod/Midgård Companion UI startup + doctor with guardrails (Issue #1360).
+# prod-ui defaults to a safe verification posture (watchers/workers NOT auto-started);
+# write/automation-capable startup requires PROD_UI_ENABLE_AUTOMATION=1.
+# prod-ui-doctor is the read-only diagnostic (incl. automation-flag safety check).
+prod-ui:
+	@bash scripts/prod/start_midgard_ui.sh
+
+prod-ui-doctor:
+	@bash scripts/prod/prod_ui_doctor.sh
 
 prod-up:
 	@$(COMPOSE_PROD) up -d --build

--- a/companion-ui/docs/REAL_NOTE_WORKSPACE_DEV_PAGE.md
+++ b/companion-ui/docs/REAL_NOTE_WORKSPACE_DEV_PAGE.md
@@ -190,6 +190,36 @@ http://<host-lan-or-tailnet-ip>:8111/?note_path=<valid-dev-note-path>
 
 ## 4. Production Launch Profile
 
+### Canonical operator command (recommended) — prod/Midgård
+
+For prod/Midgård, one guarded operator command starts/verifies the prod runtime
+API + Companion UI production page (Issue #1360):
+
+```bash
+make prod-ui                               # SAFE verification posture (default)
+PROD_UI_ENABLE_AUTOMATION=1 make prod-ui    # write/automation-capable (explicit)
+make prod-ui-doctor                         # read-only prod diagnostic
+```
+
+> **Production safety.** `make prod-ui` (→ `scripts/prod/start_midgard_ui.sh`)
+> defaults to a **safe verification posture**: watchers/workers are **not**
+> auto-started (`WATCHER_AUTO_EXEC=0`). Write-capable / automation-capable
+> startup runs **only** when the operator explicitly acknowledges it via
+> `PROD_UI_ENABLE_AUTOMATION=1`. The command refuses to start unless the
+> resolved vault is Midgård/Midgard, reports prod channel identity
+> (`PKM_ENVIRONMENT=prod`, project `pkm-prod`, DB `app`, API `18000`, UI
+> `8113`), uses the production page module, and never kills unrelated
+> SSH/Colima/Docker processes when freeing the UI port.
+
+`make prod-ui-doctor` (→ `scripts/prod/prod_ui_doctor.sh`) is read-only and adds
+a prod-specific check that surfaces unexpectedly-enabled automation/write flags
+(`PROD_UI_ENABLE_AUTOMATION`, `WATCHER_AUTO_EXEC`).
+
+This command does **not** change promotion/rollback semantics or the `stable`
+release pointer — see `docs/RELEASE_CHANNELS/README.md` for promotion/rollback.
+
+The manual production-profile invocation below remains valid for ad hoc use.
+
 The production launch profile is separate from the dev/staging server. It keeps
 the same runtime-mediated workspace boundary, defaults to the production runtime
 API port, links production-profile static assets under `/static/`, and omits

--- a/scripts/lib/companion_ui_startup.sh
+++ b/scripts/lib/companion_ui_startup.sh
@@ -432,6 +432,11 @@ cui_run_doctor() {
     echo "  [info] no tailscale IP detected (LAN-only or tailscale down)"
   fi
 
+  # 9. Channel-specific extra checks (e.g. prod automation-flag safety).
+  if declare -f cui_extra_doctor >/dev/null 2>&1; then
+    cui_extra_doctor || rc=1
+  fi
+
   echo "============================================================="
   return "${rc}"
 }

--- a/scripts/prod/prod_ui_doctor.sh
+++ b/scripts/prod/prod_ui_doctor.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Read-only prod/Midgård Companion UI doctor with production guardrails
+# (Issue #1360).
+#
+# Diagnoses prod-channel startup failure modes without starting services or
+# mutating runtime/vault state: Docker/Colima availability, prod vault
+# resolution (Midgård), runtime API health on 18000, container vault mount, UI
+# port 8113 occupancy, UI reachability, optional target note, Tailscale IP, and
+# a prod-specific check for unexpectedly-enabled automation/write flags.
+#
+# Usage:
+#   make prod-ui-doctor
+#   scripts/prod/prod_ui_doctor.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=../lib/companion_ui_startup.sh
+source "${SCRIPT_DIR}/../lib/companion_ui_startup.sh"
+
+CUI_CHANNEL="prod"
+CUI_EXPECTED_VAULT_PATTERN="midg(å|a)rd"
+CUI_EXPECTED_VAULT_LABEL="Midgård/Midgard"
+CUI_API_PORT="18000"
+CUI_UI_PORT="8113"
+CUI_COMPOSE_FILES="docker-compose.yaml:docker-compose.prod.yml"
+CUI_COMPOSE_PROJECT="pkm-prod"
+CUI_SERVE_MODULE="companion_ui.workspace.serve_production_page"
+CUI_DB_LABEL="app"
+export CUI_CHANNEL CUI_EXPECTED_VAULT_PATTERN CUI_EXPECTED_VAULT_LABEL \
+  CUI_API_PORT CUI_UI_PORT CUI_COMPOSE_FILES CUI_COMPOSE_PROJECT CUI_SERVE_MODULE CUI_DB_LABEL
+
+# Prod-specific read-only check: surface automation/write-capable flags so the
+# operator can see whether a prod start would run mutation-capable services.
+cui_extra_doctor() {
+  local rc=0
+  if [ "${PROD_UI_ENABLE_AUTOMATION:-0}" = "1" ] || [ "${WATCHER_AUTO_EXEC:-}" = "1" ]; then
+    echo "  [warn] automation/write-capable flags are ENABLED in this environment"
+    echo "         (PROD_UI_ENABLE_AUTOMATION=${PROD_UI_ENABLE_AUTOMATION:-unset}, WATCHER_AUTO_EXEC=${WATCHER_AUTO_EXEC:-unset})."
+    echo "         A prod start here would run mutation-capable services. Confirm this is intended."
+    rc=1
+  else
+    echo "  [ok]   no unexpected automation/write flags enabled (safe verification posture)"
+  fi
+  return "${rc}"
+}
+
+cui_run_doctor

--- a/scripts/prod/start_midgard_ui.sh
+++ b/scripts/prod/start_midgard_ui.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Canonical prod/Midgård Companion UI startup with production guardrails
+# (Issue #1360).
+#
+# Starts/verifies the prod runtime API + Companion UI production page against
+# the Midgård vault, using the same shared pattern as dev (#1358) and test
+# (#1359) but with stricter production safety:
+#
+#   - refuses to start unless the resolved vault is Midgård/Midgard;
+#   - DEFAULTS to a safe verification posture — watchers/workers are NOT
+#     auto-started (WATCHER_AUTO_EXEC=0);
+#   - write-capable / automation-capable startup requires EXPLICIT operator
+#     acknowledgement via PROD_UI_ENABLE_AUTOMATION=1;
+#   - clearly reports prod channel identity and the active posture.
+#
+# This command does not change promotion/rollback semantics or the stable
+# release pointer. See docs/RELEASE_CHANNELS/README.md for promotion/rollback.
+#
+# Usage:
+#   make prod-ui                              # safe verification posture
+#   PROD_UI_ENABLE_AUTOMATION=1 make prod-ui   # explicit write/automation-capable
+#   scripts/prod/start_midgard_ui.sh
+#
+# Optional environment:
+#   CUI_BIND_LAN=1                 bind the UI to 0.0.0.0 (LAN/Tailscale) — explicit only
+#   CUI_TARGET_NOTE=<rel-path>     verify a note path via /api/companion/workspace
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=../lib/companion_ui_startup.sh
+source "${SCRIPT_DIR}/../lib/companion_ui_startup.sh"
+
+CUI_CHANNEL="prod"
+CUI_EXPECTED_VAULT_PATTERN="midg(å|a)rd"
+CUI_EXPECTED_VAULT_LABEL="Midgård/Midgard"
+CUI_API_PORT="18000"
+CUI_UI_PORT="8113"
+CUI_COMPOSE_FILES="docker-compose.yaml:docker-compose.prod.yml"
+CUI_COMPOSE_PROJECT="pkm-prod"
+CUI_SERVE_MODULE="companion_ui.workspace.serve_production_page"
+CUI_DB_LABEL="app"
+
+# Production guardrail: safest posture by default. Automation/write-capable
+# services (watcher auto-exec) are started ONLY on explicit acknowledgement.
+if [ "${PROD_UI_ENABLE_AUTOMATION:-0}" = "1" ]; then
+  CUI_WATCHER_AUTO_EXEC="1"
+  echo "[companion-ui:prod] *** WRITE/AUTOMATION-CAPABLE MODE ENABLED ***"
+  echo "[companion-ui:prod] operator acknowledged via PROD_UI_ENABLE_AUTOMATION=1; watcher auto-exec ON."
+else
+  CUI_WATCHER_AUTO_EXEC="0"
+  echo "[companion-ui:prod] SAFE VERIFICATION POSTURE: watchers/workers NOT auto-started (watcher auto-exec OFF)."
+  echo "[companion-ui:prod] to enable write/automation-capable services, re-run with PROD_UI_ENABLE_AUTOMATION=1."
+fi
+
+export CUI_CHANNEL CUI_EXPECTED_VAULT_PATTERN CUI_EXPECTED_VAULT_LABEL \
+  CUI_API_PORT CUI_UI_PORT CUI_COMPOSE_FILES CUI_COMPOSE_PROJECT CUI_SERVE_MODULE \
+  CUI_DB_LABEL CUI_WATCHER_AUTO_EXEC
+
+cui_run_start

--- a/tests/ops/test_companion_ui_startup_targets.py
+++ b/tests/ops/test_companion_ui_startup_targets.py
@@ -28,6 +28,8 @@ DEV_START = REPO_ROOT / "scripts" / "dev" / "start_niflheim_ui.sh"
 DEV_DOCTOR = REPO_ROOT / "scripts" / "dev" / "dev_ui_doctor.sh"
 TEST_START = REPO_ROOT / "scripts" / "test" / "start_bifrost_ui.sh"
 TEST_DOCTOR = REPO_ROOT / "scripts" / "test" / "test_ui_doctor.sh"
+PROD_START = REPO_ROOT / "scripts" / "prod" / "start_midgard_ui.sh"
+PROD_DOCTOR = REPO_ROOT / "scripts" / "prod" / "prod_ui_doctor.sh"
 
 
 def _makefile_target_body(makefile_text: str, target_name: str) -> str | None:
@@ -265,3 +267,123 @@ def test_channel_scripts_use_distinct_ports_and_projects() -> None:
     assert "8111" in dev and "8112" in test, "dev/test UI ports must differ (8111 vs 8112)."
     assert "18001" in dev and "18002" in test, "dev/test API ports must differ (18001 vs 18002)."
     assert "pkm-dev" in dev and "pkm-test" in test, "dev/test compose projects must differ."
+
+
+# ── prod / Midgård (#1360) ────────────────────────────────────────────────────
+
+
+def test_prod_ui_make_targets_exist_and_delegate() -> None:
+    """make prod-ui and make prod-ui-doctor must exist and call the scripts.
+
+    Verify: Issue #1360 AC1 / AC6 —
+      tests/ops/test_companion_ui_startup_targets.py::test_prod_ui_make_targets_exist_and_delegate
+    """
+    text = MAKEFILE.read_text(encoding="utf-8")
+    start = _makefile_target_body(text, "prod-ui")
+    doctor = _makefile_target_body(text, "prod-ui-doctor")
+    assert start is not None, "Makefile is missing the canonical 'prod-ui' target (Issue #1360)."
+    assert doctor is not None, "Makefile is missing the 'prod-ui-doctor' target (Issue #1360)."
+    assert "scripts/prod/start_midgard_ui.sh" in start, (
+        "'prod-ui' must delegate to scripts/prod/start_midgard_ui.sh (Issue #1360)."
+    )
+    assert "scripts/prod/prod_ui_doctor.sh" in doctor, (
+        "'prod-ui-doctor' must delegate to scripts/prod/prod_ui_doctor.sh (Issue #1360)."
+    )
+
+
+def test_prod_scripts_exist_and_are_valid_bash() -> None:
+    """The prod startup and doctor scripts must exist and parse.
+
+    Verify: Issue #1360 AC1 / AC6 —
+      tests/ops/test_companion_ui_startup_targets.py::test_prod_scripts_exist_and_are_valid_bash
+    """
+    for path in (PROD_START, PROD_DOCTOR):
+        assert path.is_file(), f"{path.relative_to(REPO_ROOT)} is required (Issue #1360)."
+        ok, err = _bash_syntax_ok(path)
+        assert ok, f"{path.name} failed `bash -n`:\n{err}"
+
+
+def test_prod_start_binds_midgard_channel_and_ports() -> None:
+    """The prod start script must bind the prod channel, Midgård guard, and ports.
+
+    Verify: Issue #1360 AC2 / AC4 / AC5 —
+      tests/ops/test_companion_ui_startup_targets.py::test_prod_start_binds_midgard_channel_and_ports
+    """
+    text = PROD_START.read_text(encoding="utf-8")
+    assert re.search(r'CUI_CHANNEL=["\']?prod["\']?', text), "prod start must set CUI_CHANNEL=prod."
+    assert "midg" in text, (
+        "prod start must guard the resolved vault against Midgård/Midgard (Issue #1360 AC2)."
+    )
+    assert re.search(r'CUI_API_PORT=["\']?18000["\']?', text), "prod API port must be 18000."
+    assert re.search(r'CUI_UI_PORT=["\']?8113["\']?', text), "prod UI port must be 8113."
+    assert "pkm-prod" in text, "prod start must target the pkm-prod compose project (AC4)."
+    assert "serve_production_page" in text, (
+        "prod start must launch the Companion UI production page module (Issue #1360)."
+    )
+
+
+def test_prod_defaults_to_safe_posture_and_gates_automation() -> None:
+    """Prod must default to a safe posture and gate write/automation on an
+    explicit operator acknowledgement.
+
+    Verify: Issue #1360 AC3 —
+      tests/ops/test_companion_ui_startup_targets.py::test_prod_defaults_to_safe_posture_and_gates_automation
+    """
+    text = PROD_START.read_text(encoding="utf-8")
+    assert "PROD_UI_ENABLE_AUTOMATION" in text, (
+        "prod start must require an explicit acknowledgement flag for write/automation "
+        "modes (Issue #1360 AC3)."
+    )
+    # Default branch must turn watcher auto-exec OFF.
+    assert re.search(r'CUI_WATCHER_AUTO_EXEC=["\']?0["\']?', text), (
+        "prod start must default WATCHER_AUTO_EXEC to 0 (safe posture, Issue #1360 AC3)."
+    )
+
+
+def test_prod_doctor_checks_automation_flags() -> None:
+    """The prod doctor must surface unexpectedly-enabled automation/write flags.
+
+    Verify: Issue #1360 AC6 —
+      tests/ops/test_companion_ui_startup_targets.py::test_prod_doctor_checks_automation_flags
+    """
+    text = PROD_DOCTOR.read_text(encoding="utf-8")
+    assert "cui_extra_doctor" in text, "prod doctor must define the extra automation-flag check (AC6)."
+    assert "PROD_UI_ENABLE_AUTOMATION" in text and "WATCHER_AUTO_EXEC" in text, (
+        "prod doctor must inspect automation/write flags (Issue #1360 AC6)."
+    )
+
+
+@pytest.mark.parametrize(
+    "vault_basename,should_match",
+    [
+        ("Midgård", True),
+        ("Midgard", True),
+        ("midgård", True),
+        ("Niflheim", False),
+        ("Bifröst", False),
+        ("vault", False),
+    ],
+)
+def test_prod_vault_guard_pattern(vault_basename: str, should_match: bool) -> None:
+    """The prod vault guard regex must accept Midgård spellings and reject others.
+
+    Verify: Issue #1360 AC2 —
+      tests/ops/test_companion_ui_startup_targets.py::test_prod_vault_guard_pattern
+    """
+    pattern = re.compile("midg(å|a)rd")
+    matched = bool(pattern.search(vault_basename.lower()))
+    assert matched is should_match, (
+        f"vault guard pattern match for '{vault_basename}' was {matched}, expected {should_match}."
+    )
+
+
+def test_prod_uses_distinct_ports_from_dev_and_test() -> None:
+    """Prod must not share UI/API ports or compose project with dev/test.
+
+    Verify: Issue #1360 AC4 (channel separation) —
+      tests/ops/test_companion_ui_startup_targets.py::test_prod_uses_distinct_ports_from_dev_and_test
+    """
+    prod = PROD_START.read_text(encoding="utf-8")
+    assert "8113" in prod and "18000" in prod and "pkm-prod" in prod
+    for token in ("8111", "8112", "18001", "18002", "pkm-dev", "pkm-test"):
+        assert token not in prod, f"prod start must not reference dev/test token '{token}'."


### PR DESCRIPTION
Fixes #1360

> **Stacked on #1375 (#1359) → #1374 (#1358).** Base branch is `issue/1359-companion-ui-test-startup`. GitHub retargets to `main` as the stack merges in order. Review the prod-channel diff only.

## Summary
Extends the canonical Companion UI operator-command pattern to prod/Midgård with production guardrails: `make prod-ui` defaults to a safe verification posture (watchers/workers NOT auto-started) and only enables write/automation-capable services on explicit `PROD_UI_ENABLE_AUTOMATION=1`. `make prod-ui-doctor` is read-only and surfaces unexpectedly-enabled automation flags.

## Files
- `scripts/prod/start_midgard_ui.sh`, `scripts/prod/prod_ui_doctor.sh` — prod wrappers.
- `scripts/lib/companion_ui_startup.sh` — optional `cui_extra_doctor` hook for channel-specific checks.
- `Makefile` — `prod-ui`, `prod-ui-doctor`.
- `tests/ops/test_companion_ui_startup_targets.py` — prod cases incl. safe-posture/automation-gate and port distinctness.
- `companion-ui/docs/REAL_NOTE_WORKSPACE_DEV_PAGE.md` — §4 canonical prod command + safety warning (AC7).

## Acceptance criteria mapping
- **AC1** canonical prod command — `make prod-ui`. *Verify:* `test_prod_ui_make_targets_exist_and_delegate`, `test_prod_scripts_exist_and_are_valid_bash`.
- **AC2** wrong vault blocked — Midgård/Midgard guard. *Verify:* `test_prod_vault_guard_pattern` + manual smoke (Niflheim rejected, Midgård accepted).
- **AC3** production guardrails explicit — safe posture default (WATCHER_AUTO_EXEC=0); write/automation requires `PROD_UI_ENABLE_AUTOMATION=1`; posture is announced. *Verify:* `test_prod_defaults_to_safe_posture_and_gates_automation`.
- **AC4** channel separation — reports `PKM_ENVIRONMENT=prod`, `pkm-prod`, `app`; distinct ports. *Verify:* `test_prod_start_binds_midgard_channel_and_ports`, `test_prod_uses_distinct_ports_from_dev_and_test`.
- **AC5** health + mount — `cui_wait_healthz` (18000) + `cui_verify_vault_mount` (pkm-prod).
- **AC6** doctor exists, read-only + automation-flag check. *Verify:* `test_prod_doctor_checks_automation_flags`, `test_shared_library_doctor_is_read_only`.
- **AC7** docs updated with prod safety warning.

## Out-of-scope honoured
No promotion/rollback semantics, no `stable` pointer movement, no compose-file changes, no silent automation. See `docs/RELEASE_CHANNELS/README.md`.

## Validation
- `pytest -q tests/ops/test_companion_ui_startup_targets.py` → **34 passed**.
- `bash -n` on all scripts → clean. `ruff` + `git diff --check` → clean.
- Read-only smoke: safe-posture banner by default; wrong vault rejected; Midgård accepted (then stops at Docker check); doctor flags `WATCHER_AUTO_EXEC=1` as a warn.
- **Operator-side manual** (Docker + real `.env.prod.local` with a Midgård `VAULT_ROOT`): `make prod-ui-doctor`, then `make prod-ui`.

## Risk / rollback
Ops / developer-experience. Rollback = revert the commit.