### PR TITLE
Canonical test/Bifröst Companion UI startup + doctor (#1359)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fmt lint test eval docs smoke ci-smoke setup-merge-driver hygiene-logs indexer-run transcribe qa cold-boot start verify verify-runtime doctor persist-runtime-repairs install-skills test-vault-init start-test-system test-bootstrap dev-up dev-down dev-start-full prod-up prod-down prod-start-full test-start-full test-up test-down verify-test-channel verify-prod-channel dev-ui dev-ui-doctor dispatcher-init dispatcher-sync
+.PHONY: fmt lint test eval docs smoke ci-smoke setup-merge-driver hygiene-logs indexer-run transcribe qa cold-boot start verify verify-runtime doctor persist-runtime-repairs install-skills test-vault-init start-test-system test-bootstrap dev-up dev-down dev-start-full prod-up prod-down prod-start-full test-start-full test-up test-down verify-test-channel verify-prod-channel dev-ui dev-ui-doctor test-ui test-ui-doctor dispatcher-init dispatcher-sync
 
 PYTHON ?= $(shell if [ -x .venv/bin/python ]; then printf '%s' .venv/bin/python; elif command -v python3.12 >/dev/null 2>&1; then command -v python3.12; elif command -v python3 >/dev/null 2>&1; then command -v python3; elif command -v python >/dev/null 2>&1; then command -v python; fi)
 TEST_VAULT_ROOT ?= $(PWD)/vault-test
@@ -117,6 +117,15 @@ dev-ui:
 
 dev-ui-doctor:
 	@bash scripts/dev/dev_ui_doctor.sh
+
+# Canonical test/Bifröst Companion UI startup + doctor (Issue #1359).
+# Same pattern as dev-ui, bound to the test channel (PKM_ENVIRONMENT=test,
+# pkm-test, app_test, API 18002, UI 8112) with channel separation preserved.
+test-ui:
+	@bash scripts/test/start_bifrost_ui.sh
+
+test-ui-doctor:
+	@bash scripts/test/test_ui_doctor.sh
 
 prod-up:
 	@$(COMPOSE_PROD) up -d --build

--- a/companion-ui/docs/REAL_NOTE_WORKSPACE_DEV_PAGE.md
+++ b/companion-ui/docs/REAL_NOTE_WORKSPACE_DEV_PAGE.md
@@ -123,6 +123,20 @@ container vault mount, UI-port occupancy (distinguishing a Companion UI listener
 from an unrelated process), UI reachability, an optional target note, and the
 Tailscale IP. Expected output is a labelled `[ok]/[warn]/[FAIL]` checklist.
 
+For test/Bifröst UAT/smoke verification, the same pattern is bound to the test
+channel (Issue #1359):
+
+```bash
+make test-ui           # start test runtime + Companion UI against Bifröst
+make test-ui-doctor     # read-only test-channel diagnostic
+```
+
+`make test-ui` (→ `scripts/test/start_bifrost_ui.sh`) uses
+`PKM_ENVIRONMENT=test`, requires `.env.test.local`, refuses to start unless the
+resolved vault is Bifröst/Bifrost, and reports its channel identity
+(`PKM_ENVIRONMENT=test`, project `pkm-test`, DB `app_test`, API `18002`, UI
+`8112`) so the test channel is never confused with dev or prod.
+
 The manual environment-variable invocations below remain valid for ad hoc use.
 
 ### Environment variables

--- a/scripts/lib/companion_ui_startup.sh
+++ b/scripts/lib/companion_ui_startup.sh
@@ -24,6 +24,7 @@
 #   CUI_BIND_LAN=1              bind the UI to 0.0.0.0 for LAN/Tailscale UAT (default: 127.0.0.1)
 #   CUI_TARGET_NOTE=<rel-path>  optional note path to verify via /api/companion/workspace
 #   CUI_WATCHER_AUTO_EXEC       passthrough to start_full_system.sh (prod wrapper sets 0 by default)
+#   CUI_DB_LABEL                expected channel DB name to report (e.g. app_dev/app_test/app)
 
 # ── repo + python resolution ────────────────────────────────────────────────
 
@@ -296,6 +297,7 @@ cui_print_summary() {
   fi
   echo ""
   echo "================ Companion UI (${CUI_CHANNEL}) ready ================"
+  echo "  channel     : PKM_ENVIRONMENT=${CUI_CHANNEL}  project=${CUI_COMPOSE_PROJECT}  db=${CUI_DB_LABEL:-derived}"
   echo "  runtime API : http://127.0.0.1:${CUI_API_PORT}/healthz"
   echo "  UI (local)  : http://127.0.0.1:${CUI_UI_PORT}/${query}"
   if [ "${CUI_BIND_LAN:-0}" = "1" ]; then
@@ -335,6 +337,7 @@ cui_run_doctor() {
   cui_require_config
   local rc=0
   echo "============ Companion UI doctor (${CUI_CHANNEL}) ============"
+  echo "  channel: PKM_ENVIRONMENT=${CUI_CHANNEL}  project=${CUI_COMPOSE_PROJECT}  db=${CUI_DB_LABEL:-derived}"
 
   # 1. Docker / Colima
   if cui_docker_ok; then

--- a/scripts/test/start_bifrost_ui.sh
+++ b/scripts/test/start_bifrost_ui.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Canonical test/Bifröst Companion UI startup (Issue #1359).
+#
+# Starts the test runtime API + Companion UI against the Bifröst vault in one
+# operator command, using the same shared pattern as dev/Niflheim (#1358) while
+# preserving test-channel separation (PKM_ENVIRONMENT=test, app_test DB,
+# pkm-test compose project, API 18002, UI 8112).
+#
+# Usage:
+#   make test-ui
+#   scripts/test/start_bifrost_ui.sh
+#
+# Optional environment:
+#   CUI_BIND_LAN=1                 bind the UI to 0.0.0.0 for LAN/Tailscale UAT
+#   CUI_TARGET_NOTE=<rel-path>     verify a note path via /api/companion/workspace
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=../lib/companion_ui_startup.sh
+source "${SCRIPT_DIR}/../lib/companion_ui_startup.sh"
+
+CUI_CHANNEL="test"
+CUI_EXPECTED_VAULT_PATTERN="bifr(ö|o)st"
+CUI_EXPECTED_VAULT_LABEL="Bifröst/Bifrost"
+CUI_API_PORT="18002"
+CUI_UI_PORT="8112"
+CUI_COMPOSE_FILES="docker-compose.yaml:docker-compose.test.yml"
+CUI_COMPOSE_PROJECT="pkm-test"
+CUI_SERVE_MODULE="companion_ui.workspace.serve_dev_page"
+CUI_DB_LABEL="app_test"
+export CUI_CHANNEL CUI_EXPECTED_VAULT_PATTERN CUI_EXPECTED_VAULT_LABEL \
+  CUI_API_PORT CUI_UI_PORT CUI_COMPOSE_FILES CUI_COMPOSE_PROJECT CUI_SERVE_MODULE CUI_DB_LABEL
+
+cui_run_start

--- a/scripts/test/test_ui_doctor.sh
+++ b/scripts/test/test_ui_doctor.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Read-only test/Bifröst Companion UI doctor (Issue #1359).
+#
+# Diagnoses common test-channel startup failure modes without starting services
+# or mutating runtime/vault state: Docker/Colima availability, test vault
+# resolution (Bifröst), runtime API health on 18002, container vault mount, UI
+# port 8112 occupancy, UI reachability, optional target note, and Tailscale IP.
+# Reports channel identity (PKM_ENVIRONMENT=test, pkm-test, app_test) so test is
+# clearly distinguished from dev/prod.
+#
+# Usage:
+#   make test-ui-doctor
+#   scripts/test/test_ui_doctor.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=../lib/companion_ui_startup.sh
+source "${SCRIPT_DIR}/../lib/companion_ui_startup.sh"
+
+CUI_CHANNEL="test"
+CUI_EXPECTED_VAULT_PATTERN="bifr(ö|o)st"
+CUI_EXPECTED_VAULT_LABEL="Bifröst/Bifrost"
+CUI_API_PORT="18002"
+CUI_UI_PORT="8112"
+CUI_COMPOSE_FILES="docker-compose.yaml:docker-compose.test.yml"
+CUI_COMPOSE_PROJECT="pkm-test"
+CUI_SERVE_MODULE="companion_ui.workspace.serve_dev_page"
+CUI_DB_LABEL="app_test"
+export CUI_CHANNEL CUI_EXPECTED_VAULT_PATTERN CUI_EXPECTED_VAULT_LABEL \
+  CUI_API_PORT CUI_UI_PORT CUI_COMPOSE_FILES CUI_COMPOSE_PROJECT CUI_SERVE_MODULE CUI_DB_LABEL
+
+cui_run_doctor

--- a/tests/ops/test_companion_ui_startup_targets.py
+++ b/tests/ops/test_companion_ui_startup_targets.py
@@ -26,6 +26,8 @@ MAKEFILE = REPO_ROOT / "Makefile"
 SHARED_LIB = REPO_ROOT / "scripts" / "lib" / "companion_ui_startup.sh"
 DEV_START = REPO_ROOT / "scripts" / "dev" / "start_niflheim_ui.sh"
 DEV_DOCTOR = REPO_ROOT / "scripts" / "dev" / "dev_ui_doctor.sh"
+TEST_START = REPO_ROOT / "scripts" / "test" / "start_bifrost_ui.sh"
+TEST_DOCTOR = REPO_ROOT / "scripts" / "test" / "test_ui_doctor.sh"
 
 
 def _makefile_target_body(makefile_text: str, target_name: str) -> str | None:
@@ -175,3 +177,91 @@ def test_dev_vault_guard_pattern(vault_basename: str, should_match: bool) -> Non
     assert matched is should_match, (
         f"vault guard pattern match for '{vault_basename}' was {matched}, expected {should_match}."
     )
+
+
+# ── test / Bifröst (#1359) ────────────────────────────────────────────────────
+
+
+def test_test_ui_make_targets_exist_and_delegate() -> None:
+    """make test-ui and make test-ui-doctor must exist and call the scripts.
+
+    Verify: Issue #1359 AC1 / AC5 —
+      tests/ops/test_companion_ui_startup_targets.py::test_test_ui_make_targets_exist_and_delegate
+    """
+    text = MAKEFILE.read_text(encoding="utf-8")
+    start = _makefile_target_body(text, "test-ui")
+    doctor = _makefile_target_body(text, "test-ui-doctor")
+    assert start is not None, "Makefile is missing the canonical 'test-ui' target (Issue #1359)."
+    assert doctor is not None, "Makefile is missing the 'test-ui-doctor' target (Issue #1359)."
+    assert "scripts/test/start_bifrost_ui.sh" in start, (
+        "'test-ui' must delegate to scripts/test/start_bifrost_ui.sh (Issue #1359)."
+    )
+    assert "scripts/test/test_ui_doctor.sh" in doctor, (
+        "'test-ui-doctor' must delegate to scripts/test/test_ui_doctor.sh (Issue #1359)."
+    )
+
+
+def test_test_scripts_exist_and_are_valid_bash() -> None:
+    """The test startup and doctor scripts must exist and parse.
+
+    Verify: Issue #1359 AC1 / AC5 —
+      tests/ops/test_companion_ui_startup_targets.py::test_test_scripts_exist_and_are_valid_bash
+    """
+    for path in (TEST_START, TEST_DOCTOR):
+        assert path.is_file(), f"{path.relative_to(REPO_ROOT)} is required (Issue #1359)."
+        ok, err = _bash_syntax_ok(path)
+        assert ok, f"{path.name} failed `bash -n`:\n{err}"
+
+
+def test_test_start_binds_bifrost_channel_and_ports() -> None:
+    """The test start script must bind the test channel, Bifröst guard, and ports.
+
+    Verify: Issue #1359 AC2 / AC3 / AC4 —
+      tests/ops/test_companion_ui_startup_targets.py::test_test_start_binds_bifrost_channel_and_ports
+    """
+    text = TEST_START.read_text(encoding="utf-8")
+    assert re.search(r'CUI_CHANNEL=["\']?test["\']?', text), "test start must set CUI_CHANNEL=test."
+    assert "bifr" in text, (
+        "test start must guard the resolved vault against Bifröst/Bifrost (Issue #1359 AC2)."
+    )
+    assert re.search(r'CUI_API_PORT=["\']?18002["\']?', text), "test API port must be 18002."
+    assert re.search(r'CUI_UI_PORT=["\']?8112["\']?', text), "test UI port must be 8112."
+    assert "pkm-test" in text, "test start must target the pkm-test compose project (AC3)."
+    assert "app_test" in text, "test start must report the app_test channel DB (AC3)."
+
+
+@pytest.mark.parametrize(
+    "vault_basename,should_match",
+    [
+        ("Bifröst", True),
+        ("Bifrost", True),
+        ("bifröst", True),
+        ("Niflheim", False),
+        ("Midgård", False),
+        ("vault-test", False),
+    ],
+)
+def test_test_vault_guard_pattern(vault_basename: str, should_match: bool) -> None:
+    """The test vault guard regex must accept Bifröst spellings and reject others.
+
+    Verify: Issue #1359 AC2 —
+      tests/ops/test_companion_ui_startup_targets.py::test_test_vault_guard_pattern
+    """
+    pattern = re.compile("bifr(ö|o)st")
+    matched = bool(pattern.search(vault_basename.lower()))
+    assert matched is should_match, (
+        f"vault guard pattern match for '{vault_basename}' was {matched}, expected {should_match}."
+    )
+
+
+def test_channel_scripts_use_distinct_ports_and_projects() -> None:
+    """Dev and test channels must not share UI/API ports or compose projects.
+
+    Verify: Issue #1359 AC3 (channel separation) —
+      tests/ops/test_companion_ui_startup_targets.py::test_channel_scripts_use_distinct_ports_and_projects
+    """
+    dev = DEV_START.read_text(encoding="utf-8")
+    test = TEST_START.read_text(encoding="utf-8")
+    assert "8111" in dev and "8112" in test, "dev/test UI ports must differ (8111 vs 8112)."
+    assert "18001" in dev and "18002" in test, "dev/test API ports must differ (18001 vs 18002)."
+    assert "pkm-dev" in dev and "pkm-test" in test, "dev/test compose projects must differ."


### PR DESCRIPTION
Fixes #1359

> Replaces #1375, which GitHub auto-closed when the stacked base branch (#1358) was deleted on merge. Rebased onto `main`; diff is test-channel only.

## Summary
Extends the canonical Companion UI operator-command pattern to the test channel: `make test-ui` orchestrates the test runtime API + Companion UI against Bifröst, `make test-ui-doctor` is the read-only diagnostic. Channel separation is explicit and reported.

## Files
- `scripts/test/start_bifrost_ui.sh`, `scripts/test/test_ui_doctor.sh`
- `scripts/lib/companion_ui_startup.sh` — channel-identity reporting line (PKM_ENVIRONMENT / project / DB) for AC3
- `Makefile` — `test-ui`, `test-ui-doctor`
- `tests/ops/test_companion_ui_startup_targets.py` — test-channel + cross-channel distinctness cases
- `companion-ui/docs/REAL_NOTE_WORKSPACE_DEV_PAGE.md` — test command documented next to dev (AC6)

## Acceptance criteria
- AC1 `make test-ui` — `test_test_ui_make_targets_exist_and_delegate`, `test_test_scripts_exist_and_are_valid_bash`
- AC2 Bifröst guard — `test_test_vault_guard_pattern`
- AC3 channel separation (PKM_ENVIRONMENT=test/pkm-test/app_test, distinct ports) — `test_test_start_binds_bifrost_channel_and_ports`, `test_channel_scripts_use_distinct_ports_and_projects`
- AC4 health+mount (18002 / pkm-test)
- AC5 read-only doctor — `test_shared_library_doctor_is_read_only`
- AC6 docs

## Validation
`pytest -q tests/ops/test_companion_ui_startup_targets.py` → 22 passed; `bash -n` clean; read-only smoke (Niflheim rejected, Bifröst accepted). Live UAT operator-side (Docker + real `.env.test.local`).

## Risk / rollback
Ops / developer-experience only; no runtime/contract/event/write-path changes. Rollback = revert.