### PR TITLE
Fix make dev-ui / test-ui / prod-ui aborting when start_full_system.sh exits non-zero

### DIFF
--- a/scripts/lib/companion_ui_startup.sh
+++ b/scripts/lib/companion_ui_startup.sh
@@ -123,7 +123,7 @@ cui_docker_ok() {
 # ── runtime orchestration ─────────────────────────────────────────────────────
 
 cui_start_runtime() {
-  local root
+  local root _rc
   root="$(cui_repo_root)"
   cui_log "starting runtime API via scripts/start_full_system.sh (project=${CUI_COMPOSE_PROJECT})"
   (
@@ -134,7 +134,14 @@ cui_start_runtime() {
     START_MODE=runtime \
     ${CUI_WATCHER_AUTO_EXEC:+WATCHER_AUTO_EXEC="${CUI_WATCHER_AUTO_EXEC}"} \
     scripts/start_full_system.sh
-  ) || cui_die "runtime startup (start_full_system.sh) failed for ${CUI_CHANNEL}"
+  ) || {
+    _rc=$?
+    # start_full_system.sh can exit non-zero even when the stack came up
+    # (e.g. its final Python health-check step exits 1 while all containers
+    # are actually healthy). Treat this as a warning and let cui_wait_healthz
+    # be the authoritative health gate instead of aborting here.
+    cui_warn "start_full_system.sh exited non-zero (rc=${_rc}) — checking API health to confirm stack state"
+  }
 }
 
 # Polls the runtime API /healthz. Read-only. Returns 0 on healthy.


### PR DESCRIPTION
## Direct Repair

Type: code
Reason: `cui_start_runtime` called `cui_die` on any non-zero exit from `start_full_system.sh`, aborting `make dev-ui` before the Companion UI was ever started — even when all containers were up and the API was healthy. Root cause confirmed on the Mac mini: `start_full_system.sh`'s final Python health-check step (`→ Checking API health...`) exits 1 despite a healthy stack (LangChain deprecation warnings + timing). The fix demotes the non-zero exit to a warning and lets `cui_wait_healthz` — which polls `/healthz` directly via `curl` — be the authoritative gate.
Validation: `bash -n scripts/lib/companion_ui_startup.sh` clean; 34 ops tests pass; confirmed by live run on the Mac mini (both first and second invocations of `make dev-ui` now complete successfully).
Issue required: no

## Summary

One-line change in `scripts/lib/companion_ui_startup.sh`: replace `|| cui_die` with `|| { warn + continue }` in `cui_start_runtime`. The real health gate is `cui_wait_healthz` (polls `http://127.0.0.1:<port>/healthz` up to 30 times) which immediately follows and will abort with a clear message if the API genuinely didn't come up.

## Validation

- `bash -n scripts/lib/companion_ui_startup.sh` → clean
- `pytest -q tests/ops/test_companion_ui_startup_targets.py` → 34 passed
- Live: `make dev-ui` on Mac mini now reaches the Companion UI start step and completes