### PR TITLE
fix(embeddings): canonicalize ollama model tag so dev-ui health gate stops false-mismatching

### DIFF
--- a/app/components/embeddings/legacy.py
+++ b/app/components/embeddings/legacy.py
@@ -41,6 +41,14 @@ class EmbeddingIdentity:
     dim: int
     normalize: bool = True
 
+    def __post_init__(self) -> None:
+        # Ollama treats an untagged model name as its `:latest` tag. Persisting the
+        # canonical form keeps index identity stable regardless of which side wrote
+        # it, so a `nomic-embed-text` index does not spuriously mismatch the
+        # `nomic-embed-text:latest` health expectation (and vice-versa).
+        if self.provider == "ollama" and self.model and ":" not in self.model:
+            object.__setattr__(self, "model", f"{self.model}:latest")
+
 
 @lru_cache(maxsize=1)
 def _deterministic_embeddings_module():

--- a/tests/stores/test_embedding_identity_tag_equivalence.py
+++ b/tests/stores/test_embedding_identity_tag_equivalence.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+
+from app.components.embeddings import EmbeddingIdentity
+from app.stores import pg
+
+
+def test_implicit_latest_tag_matches_explicit() -> None:
+    bare = EmbeddingIdentity(provider="ollama", model="nomic-embed-text", dim=768)
+    tagged = EmbeddingIdentity(provider="ollama", model="nomic-embed-text:latest", dim=768)
+    assert bare.model == "nomic-embed-text:latest"
+    assert bare == tagged
+
+
+def test_distinct_model_still_mismatches() -> None:
+    a = EmbeddingIdentity(provider="ollama", model="nomic-embed-text", dim=768)
+    b = EmbeddingIdentity(provider="ollama", model="mxbai-embed-large", dim=768)
+    assert a != b
+
+
+def test_non_ollama_provider_tag_untouched() -> None:
+    ident = EmbeddingIdentity(provider="openai", model="text-embedding-3-small", dim=1536)
+    assert ident.model == "text-embedding-3-small"
+
+
+class _FakeCursor:
+    def __init__(self, stored_json: str | None) -> None:
+        self._stored_json = stored_json
+        self.executed: list[tuple[str, object]] = []
+
+    def execute(self, sql: str, params: object = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> dict[str, str] | None:
+        if self._stored_json is None:
+            return None
+        return {"identity_json": self._stored_json}
+
+
+def test_rebuild_then_health_consistent() -> None:
+    # Index built with the bare ollama tag; health resolves the explicit `:latest`.
+    stored_json = json.dumps(
+        {"provider": "ollama", "model": "nomic-embed-text", "dim": 768, "normalize": True}
+    )
+    cur = _FakeCursor(stored_json)
+    requested = EmbeddingIdentity(provider="ollama", model="nomic-embed-text:latest", dim=768)
+    resolved = pg._ensure_index_identity(cur, requested, allow_create=False)
+    assert resolved.model == "nomic-embed-text:latest"


### PR DESCRIPTION
Fixes #1380

## Summary
`make dev-ui` was blocked because `app.cli health --json` returned `ok: false` on an embedding-index identity mismatch: the index stored `nomic-embed-text` while health expected `nomic-embed-text:latest`. Ollama treats those as the same model, but the identity check compared raw strings (`app/stores/pg.py:143`). `index rebuild` re-wrote the short tag, so the mismatch never self-healed.

## Change
Canonicalize the tag in `EmbeddingIdentity.__post_init__` (`app/components/embeddings/legacy.py`): for the `ollama` provider, an untagged model gains the explicit `:latest`. Because this runs on every construction — including when the stored identity is loaded from the DB — the existing index now matches **without a rebuild**, and new writes persist the canonical form.

Safety: a genuinely different stored model still mismatches (only the implicit-vs-explicit `:latest` on the *same* model is treated as equal). Non-ollama providers (e.g. openai) are untouched.

## Acceptance Criteria
- [x] Implicit `:latest` matches explicit for the same model — `tests/stores/test_embedding_identity_tag_equivalence.py::test_implicit_latest_tag_matches_explicit`
- [x] A distinct model still mismatches — `::test_distinct_model_still_mismatches`
- [x] Stored bare tag + health explicit tag is consistent (self-heal) — `::test_rebuild_then_health_consistent`
- [x] Non-ollama provider tag untouched — `::test_non_ollama_provider_tag_untouched`

## Validation
- `pytest tests/stores/test_embedding_identity_tag_equivalence.py` → 4 passed
- `pytest tests/stores/ tests/cli/test_index_rebuild_cli.py` → 37 passed, 12 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)