### PR TITLE
fix(dev-ui): skip full stack recreate when runtime API already healthy

### DIFF
--- a/scripts/lib/companion_ui_startup.sh
+++ b/scripts/lib/companion_ui_startup.sh
@@ -122,9 +122,22 @@ cui_docker_ok() {
 
 # ── runtime orchestration ─────────────────────────────────────────────────────
 
+# Single-shot probe of the runtime API /healthz. Read-only. Returns 0 if healthy.
+cui_api_healthy_now() {
+  curl -fsS --max-time 3 "http://127.0.0.1:${CUI_API_PORT}/healthz" >/dev/null 2>&1
+}
+
 cui_start_runtime() {
   local root _rc
   root="$(cui_repo_root)"
+  # Restarting the UI should not recreate an already-healthy stack. When the
+  # runtime API is up, skip the full start_full_system.sh recreate (and its
+  # watcher/worker health race). Set CUI_FORCE_RECREATE=1 to force a rebuild,
+  # e.g. after changing runtime code or compose config.
+  if [ "${CUI_FORCE_RECREATE:-0}" != "1" ] && cui_api_healthy_now; then
+    cui_log "runtime API already healthy on port ${CUI_API_PORT} — skipping full stack recreate (set CUI_FORCE_RECREATE=1 to force)"
+    return 0
+  fi
   cui_log "starting runtime API via scripts/start_full_system.sh (project=${CUI_COMPOSE_PROJECT})"
   (
     cd "${root}" || exit 1

--- a/tests/scripts/test_companion_ui_startup_skip_recreate.py
+++ b/tests/scripts/test_companion_ui_startup_skip_recreate.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LIB = REPO_ROOT / "scripts/lib/companion_ui_startup.sh"
+
+# Source the startup lib, then override cui_repo_root to a fake repo whose
+# scripts/start_full_system.sh stub records that it ran. curl is stubbed to
+# simulate the runtime API being healthy or not. We then call cui_start_runtime
+# and report whether the full-system start was invoked.
+_HARNESS = r"""
+set -euo pipefail
+FAKE_ROOT="$1"
+CURL_RC="$2"
+export CUI_API_PORT=18001
+export CUI_CHANNEL=dev
+export CUI_COMPOSE_PROJECT=pkm-dev
+export CUI_COMPOSE_FILES=docker-compose.yaml
+
+mkdir -p "$FAKE_ROOT/scripts"
+cat > "$FAKE_ROOT/scripts/start_full_system.sh" <<'EOS'
+#!/usr/bin/env bash
+# cui_start_runtime cd's to the repo root before invoking us.
+touch "$(pwd)/.full_system_ran"
+EOS
+chmod +x "$FAKE_ROOT/scripts/start_full_system.sh"
+
+source "$LIB"
+cui_repo_root() { printf '%s' "$FAKE_ROOT"; }
+curl() { return "$CURL_RC"; }
+
+cui_start_runtime >/dev/null 2>&1 || true
+
+if [ -f "$FAKE_ROOT/.full_system_ran" ]; then
+  echo RECREATED
+else
+  echo SKIPPED
+fi
+"""
+
+
+def _run(tmp_path: Path, *, curl_rc: int, force_recreate: str | None = None) -> str:
+    env = {"LIB": str(LIB)}
+    cmd = ["bash", "-c", _HARNESS, "harness", str(tmp_path), str(curl_rc)]
+    full_env = {**_base_env(), **env}
+    if force_recreate is not None:
+        full_env["CUI_FORCE_RECREATE"] = force_recreate
+    result = subprocess.run(
+        cmd, env=full_env, cwd=REPO_ROOT, capture_output=True, text=True, check=True
+    )
+    return result.stdout.strip().splitlines()[-1]
+
+
+def _base_env() -> dict[str, str]:
+    import os
+
+    return dict(os.environ)
+
+
+def test_healthy_stack_skips_compose_recreate(tmp_path: Path) -> None:
+    # curl_rc=0 → API healthy → recreate skipped.
+    assert _run(tmp_path, curl_rc=0) == "SKIPPED"
+
+
+def test_cold_start_runs_full_system(tmp_path: Path) -> None:
+    # curl_rc=7 → API unreachable → full start_full_system.sh runs.
+    assert _run(tmp_path, curl_rc=7) == "RECREATED"
+
+
+def test_warm_restart_no_health_race(tmp_path: Path) -> None:
+    # Healthy stack must not be recreated, so the watcher/worker health race
+    # never opens on the warm-restart path.
+    assert _run(tmp_path, curl_rc=0) == "SKIPPED"
+
+
+def test_force_recreate_overrides_healthy_skip(tmp_path: Path) -> None:
+    # Operator can force a rebuild even when the stack is healthy.
+    assert _run(tmp_path, curl_rc=0, force_recreate="1") == "RECREATED"


### PR DESCRIPTION
Fixes #1381

## Summary
`make dev-ui` (= `scripts/dev/start_niflheim_ui.sh`) always invoked `start_full_system.sh`, recreating the API/watcher/worker containers on every run even when the stack was already healthy. That 60-90s recreate also opened a watcher/worker `health: starting` race that intermittently failed `verify_runtime_stack.sh`.

## Change
Add `cui_api_healthy_now` (single-shot `/healthz` probe) and gate `cui_start_runtime` (`scripts/lib/companion_ui_startup.sh`): when the runtime API is already healthy, skip the full recreate and just refresh the UI. Cold start still runs the full `start_full_system.sh`. `CUI_FORCE_RECREATE=1` forces a rebuild after runtime-code or compose changes.

## Acceptance Criteria
- [x] Healthy stack skips compose recreate — `tests/scripts/test_companion_ui_startup_skip_recreate.py::test_healthy_stack_skips_compose_recreate`
- [x] Cold start still runs full system — `::test_cold_start_runs_full_system`
- [x] Warm restart avoids the health race — `::test_warm_restart_no_health_race`
- [x] `CUI_FORCE_RECREATE=1` overrides the healthy skip — `::test_force_recreate_overrides_healthy_skip`

## Validation
- `pytest tests/scripts/test_companion_ui_startup_skip_recreate.py` → 4 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)