### PR TITLE
fix(companion): vault identity as a hot-reloadable setting (instance.vault.name)

### DIFF
--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -206,7 +206,48 @@ def _safe_api_label() -> str:
     return (os.getenv("COMPANION_API_BASE_URL_LABEL") or "local-dev").strip() or "local-dev"
 
 
+def _configured_vault_name() -> str | None:
+    """Return the operator-configured vault name from settings, if any.
+
+    Vault identity is a first-class, hot-reloadable setting
+    (``instance.vault.name``). Reading it here means a renamed or switched vault
+    takes effect on the next request with no restart, and it is the seam where
+    future multi-vault selection will resolve the active vault.
+    """
+    try:
+        from app.settings.runtime import get_settings_bundle
+
+        bundle = get_settings_bundle()
+    except Exception:
+        return None
+    vault = getattr(getattr(bundle, "instance", None), "vault", None)
+    name = getattr(vault, "name", None)
+    if isinstance(name, str) and name.strip():
+        return name.strip()
+    return None
+
+
 def _vault_identity_state(vault_root: Path) -> VaultIdentityState:
+    raw_channel = (
+        os.getenv("PKM_ENVIRONMENT")
+        or os.getenv("CHANNEL")
+        or os.getenv("PKM_CHANNEL")
+        or ""
+    ).strip().lower()
+    channel = raw_channel if raw_channel in {"dev", "test", "prod"} else "unknown"
+
+    # A configured vault name is authoritative. It survives the container's
+    # host-VAULT_ROOT-vs-/app/vault path divergence that previously mislabeled a
+    # correctly-mounted vault as `fallback`/`vault`.
+    configured_name = _configured_vault_name()
+    if configured_name:
+        return VaultIdentityState(
+            vault_name=configured_name,
+            channel=channel,
+            provenance="settings",
+        )
+
+    # No configured name: infer identity from the VAULT_ROOT path as before.
     vault_root_raw = os.getenv("VAULT_ROOT", "").strip()
     vault_name = vault_root.name or str(vault_root)
     if not vault_root_raw:
@@ -217,13 +258,6 @@ def _vault_identity_state(vault_root: Path) -> VaultIdentityState:
             provenance = "env" if env_path == vault_root.resolve() else "fallback"
         except Exception:
             provenance = "fallback"
-    raw_channel = (
-        os.getenv("PKM_ENVIRONMENT")
-        or os.getenv("CHANNEL")
-        or os.getenv("PKM_CHANNEL")
-        or ""
-    ).strip().lower()
-    channel = raw_channel if raw_channel in {"dev", "test", "prod"} else "unknown"
     return VaultIdentityState(
         vault_name=vault_name,
         channel=channel,

--- a/app/settings/models.py
+++ b/app/settings/models.py
@@ -255,6 +255,26 @@ class YggdrasilPaths(BaseModel):
     heimdall_root: Optional[Path] = None
 
 
+class VaultSettings(BaseModel):
+    name: Optional[str] = Field(
+        default=None,
+        description=(
+            "Human-facing vault name shown in the Companion UI and used as the "
+            "vault's runtime identity. When unset, the runtime infers it from the "
+            "VAULT_ROOT path basename. Authoritative and hot-reloadable: changing "
+            "it does not require a restart."
+        ),
+    )
+    purpose: Optional[str] = Field(
+        default=None,
+        description=(
+            "Reserved for multi-vault routing (e.g. 'personal', 'work', 'research'). "
+            "Not yet wired to vault selection; present so a single-vault config can "
+            "evolve into plural vaults without a schema break."
+        ),
+    )
+
+
 class InstanceSettings(BaseModel):
     id: str = Field(
         default="home",
@@ -267,6 +287,10 @@ class InstanceSettings(BaseModel):
     environment: Literal["dev", "prod", "test"] = Field(
         default="prod",
         description="Runtime environment; 'prod' is production-safe default, 'dev' enables development features.",
+    )
+    vault: VaultSettings = Field(
+        default_factory=VaultSettings,
+        description="Active vault identity. Hot-reloadable; the seam for future multi-vault support.",
     )
 
 

--- a/tests/api/test_companion_workspace_vault_identity.py
+++ b/tests/api/test_companion_workspace_vault_identity.py
@@ -155,6 +155,70 @@ def test_vault_provenance_fallback_when_vault_root_invalid(
     assert identity["provenance"] == "fallback"
 
 
+def _configure_runtime_vault(monkeypatch, tmp_path, name):
+    """Point the settings runtime at a temp instance.yaml carrying vault.name."""
+    from app.settings import runtime as settings_runtime
+
+    runtime_dir = tmp_path / "runtime_settings"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    (runtime_dir / "global.yaml").write_text("{}\n", encoding="utf-8")
+    (runtime_dir / "providers.yaml").write_text("{}\n", encoding="utf-8")
+    (runtime_dir / "instance.yaml").write_text(
+        f"vault:\n  name: {name}\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(settings_runtime, "RUNTIME", runtime_dir)
+    monkeypatch.setattr(settings_runtime, "_SUBSCRIBERS", [])
+    monkeypatch.setattr(settings_runtime, "_CURRENT", None)
+    return runtime_dir
+
+
+def test_mounted_vault_reports_truthful_identity(
+    client: TestClient, vault_note: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A configured vault name is authoritative: provenance="settings", real name.
+    _configure_runtime_vault(monkeypatch, tmp_path, "Niflheim")
+    resp = _workspace(client)
+    assert resp.status_code == 200
+    identity = resp.json()["runtime"]["vault_identity"]
+    assert identity["vault_name"] == "Niflheim"
+    assert identity["provenance"] == "settings"
+
+
+def test_configured_vault_name_survives_container_path_divergence(
+    client: TestClient, vault_note: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The container bug: host VAULT_ROOT does not exist in-container (would infer
+    # `fallback`/`vault`). A configured name overrides that and stays truthful.
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path / "host-only" / "Niflheim"))
+    _configure_runtime_vault(monkeypatch, tmp_path, "Niflheim")
+    resp = _workspace(client, note_path="notes/note.md")
+    assert resp.status_code == 200
+    identity = resp.json()["runtime"]["vault_identity"]
+    assert identity["vault_name"] == "Niflheim"
+    assert identity["provenance"] == "settings"
+
+
+def test_configured_vault_name_hot_reloads_without_restart(
+    client: TestClient, vault_note: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.settings import runtime as settings_runtime
+
+    runtime_dir = _configure_runtime_vault(monkeypatch, tmp_path, "Niflheim")
+    assert (
+        _workspace(client).json()["runtime"]["vault_identity"]["vault_name"]
+        == "Niflheim"
+    )
+    # Rename on disk + reload (no process restart) → next request reflects it.
+    (runtime_dir / "instance.yaml").write_text(
+        "vault:\n  name: Midgard\n", encoding="utf-8"
+    )
+    settings_runtime.reload_settings_bundle(notify=False)
+    assert (
+        _workspace(client).json()["runtime"]["vault_identity"]["vault_name"]
+        == "Midgard"
+    )
+
+
 def test_vault_name_safe_for_path_with_spaces(
     client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/settings/test_instance_settings.py
+++ b/tests/settings/test_instance_settings.py
@@ -42,3 +42,49 @@ def test_instance_loaded_from_runtime_file(tmp_path, monkeypatch):
 
     assert bundle.instance.id == "laptop"
     assert bundle.instance.role == "satellite"
+
+
+def test_vault_settings_default_when_unset(tmp_path, monkeypatch):
+    runtime_dir = tmp_path / "runtime/settings"
+    _write_yaml(runtime_dir / "global.yaml", {})
+    _write_yaml(runtime_dir / "providers.yaml", {})
+    _reset_runtime(monkeypatch, runtime_dir)
+
+    bundle = runtime.reload_settings_bundle(notify=False)
+
+    assert bundle.instance.vault.name is None
+    assert bundle.instance.vault.purpose is None
+
+
+def test_vault_name_loaded_from_runtime_file(tmp_path, monkeypatch):
+    runtime_dir = tmp_path / "runtime/settings"
+    _write_yaml(runtime_dir / "global.yaml", {})
+    _write_yaml(runtime_dir / "providers.yaml", {})
+    _write_yaml(
+        runtime_dir / "instance.yaml",
+        {"id": "laptop", "vault": {"name": "Niflheim", "purpose": "personal"}},
+    )
+    _reset_runtime(monkeypatch, runtime_dir)
+
+    bundle = runtime.reload_settings_bundle(notify=False)
+
+    assert bundle.instance.vault.name == "Niflheim"
+    assert bundle.instance.vault.purpose == "personal"
+
+
+def test_vault_name_hot_reloads_without_restart(tmp_path, monkeypatch):
+    runtime_dir = tmp_path / "runtime/settings"
+    _write_yaml(runtime_dir / "global.yaml", {})
+    _write_yaml(runtime_dir / "providers.yaml", {})
+    instance_path = runtime_dir / "instance.yaml"
+    _write_yaml(instance_path, {"vault": {"name": "Niflheim"}})
+    _reset_runtime(monkeypatch, runtime_dir)
+
+    first = runtime.reload_settings_bundle(notify=False)
+    assert first.instance.vault.name == "Niflheim"
+
+    # Operator renames/switches the vault on disk; a reload (the same path the
+    # hot-reload watcher drives) picks it up with no process restart.
+    _write_yaml(instance_path, {"vault": {"name": "Midgard"}})
+    second = runtime.reload_settings_bundle(notify=False)
+    assert second.instance.vault.name == "Midgard"


### PR DESCRIPTION
Fixes #1382

## Summary
The Companion UI reported `provenance: fallback` / `vault_name: vault` for a **correctly-mounted** vault. Root cause (per the issue): the containerized runtime inherits the *host* `VAULT_ROOT`, which doesn't exist in-container, so `resolve_vault_root()` lands on the correct `/app/vault` mount — but `_vault_identity_state` then compared host-path vs resolved-path and reported `fallback`, discarding the real vault name.

Per the multi-vault intent (vault identity should be a system setting, changeable without restart, and able to grow to plural vaults), the fix makes vault identity a **first-class setting** rather than a path heuristic.

## Change
- **`app/settings/models.py`** — new `VaultSettings` (`name` + reserved `purpose`) added to `InstanceSettings`. Defaults to `None`, so absent config is fully backward-compatible.
- **`app/api/routes/companion.py`** — `_vault_identity_state` reads `instance.vault.name` first (`provenance="settings"`), surviving the container host-vs-mount path divergence. Falls back to the prior path inference (`env`/`fallback`/`default`) when no name is configured.

The settings bundle is already hot-reloadable (`reload_settings_bundle`, hot-reload watcher), so renaming/switching the vault takes effect on the next request with **no restart**. `instance.yaml` is operator-maintained (not compiler-managed), so this is the right surface.

### Multi-vault seam
`VaultSettings.purpose` is reserved now so a single-vault config evolves into plural vaults without a schema break; plural-vault selection will resolve the active vault from settings in this same function.

## Acceptance Criteria
- [x] A correctly-mounted vault reports its real name + non-fallback provenance — `tests/api/test_companion_workspace_vault_identity.py::test_mounted_vault_reports_truthful_identity`
- [x] Configured name survives the container path divergence — `::test_configured_vault_name_survives_container_path_divergence`
- [x] Name change applies without restart (hot reload) — `::test_configured_vault_name_hot_reloads_without_restart`
- [x] Genuinely missing/unconfigured vault still reports `fallback`/`default` (existing contract retained) — `::test_vault_provenance_fallback_when_vault_root_invalid`, `::test_vault_provenance_default_when_vault_root_absent`
- [x] Settings model: vault name loads + hot-reloads — `tests/settings/test_instance_settings.py::test_vault_name_loaded_from_runtime_file`, `::test_vault_name_hot_reloads_without_restart`

## Validation
- `pytest tests/settings/test_instance_settings.py tests/api/test_companion_workspace_vault_identity.py` → 17 passed
- `pytest tests/settings/ tests/api/` → 269 passed, 2 skipped (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)