### PR TITLE
docs: add Layer-7 and relation-taxonomy authoring checklists

### DIFF
--- a/companion-ui/docs/SEMANTIC_PROJECTION_ALIGNMENT.md
+++ b/companion-ui/docs/SEMANTIC_PROJECTION_ALIGNMENT.md
@@ -88,3 +88,12 @@ This document is verified by the existence of:
 - **mutation semantics** distinguishing direct body edits, governance-bearing mutations, metadata edits, relation edits, proposal applications, and receipt generation;
 - **authority boundaries** stating no UI-owned truth, no implicit escalation, server-side classification, and governance routing ownership; and
 - a **contract alignment findings** table mapping each Companion UI contract to these rules and confirming consistency.
+
+## Contract authoring checklist
+
+Use this checklist when authoring a new Companion UI contract or extending an existing one. A contract must satisfy all four rules before it is considered aligned with Layer 7.
+
+- [ ] **Layer mapped.** The contract is mapped to a specific layer in `docs/SEMANTIC_SYSTEM_ARCHITECTURE.md`. State the layer explicitly (e.g., "Layer 7 — UI projection") in the contract's Authority/Role section.
+- [ ] **Durability posture stated.** The contract declares whether its state is runtime-only, durable, or a projection. Runtime-only state must not become a durable artifact without an explicit governed path. Acceptable values: `runtime` (discardable), `projection` (rebuildable/read-only), `durable` (must route through write-guard and receipts).
+- [ ] **Write authority stated.** The contract states that the UI does not own vault I/O, does not reclassify actions locally, and that any durable write routes through the server-side governance path (WriteGuard, receipts, outbox). UI-only stores must not hold meaning-bearing artifacts.
+- [ ] **Runtime boundary flagged.** Any new hidden or implicit state is checked against `docs/CONCEPTS/RUNTIME_VS_DURABLE_STATE_BOUNDARY.md`. State that should be discardable must not persist. State that must survive restart must use the governed write path.

--- a/docs/CONCEPTS/RELATION_TAXONOMY.md
+++ b/docs/CONCEPTS/RELATION_TAXONOMY.md
@@ -118,3 +118,12 @@ This document is verified by the existence of:
 - a **canonical relation table** covering at least `links_to`, `companion_for`, `has_companion`, `derived_from`, `source_ref`, `supports`, `conflicts_with`, `supersedes`, `part_of`, `task_for`, `proposal_for`, `decision_about`, `contextualizes` (plus `sphere_membership`), each with authorship, authority, governance, rebuildability, persistence, retrieval, and projection semantics;
 - explicit **inferred-vs-authoritative** and **provenance-relation** rules ensuring no hidden semantics inside generic links; and
 - alignment of provenance-sensitive relations with the provenance/source contract and the authority matrix.
+
+## Relation authoring checklist
+
+Use this checklist when defining a new relation type or adding a new relation to the store or frontmatter. A new relation definition must state all four items.
+
+- [ ] **Type declared.** The relation type is one of: `explicit` (human-authored and authority-bearing), `inferred` (machine-derived, non-authoritative until confirmed), or `provenance` (tracks origin, dependency, or transformation — must remain visible as provenance, never collapsed into a plain navigational link). State the type explicitly in the relation definition.
+- [ ] **Inferred/confirmed flag.** If the relation is `inferred`, declare whether it carries an `inferred` flag in the store and how confirmation promotes it to `explicit`. An inferred relation must never be rendered as a confirmed edge without a confirm/dismiss affordance.
+- [ ] **Provenance visibility.** If the relation is a provenance relation (`derived_from`, `source_ref`, `supports`, `conflicts_with`, or any relation tracking origin/dependency/transformation), the definition states that it must be rendered as visible provenance — never as a plain "see also" link. The fact/inference/stale distinction must be preserved at the UI layer (owner: `companion-ui/docs/SEMANTIC_PROJECTION_ALIGNMENT.md`).
+- [ ] **Generic link semantics.** If the relation is generic (i.e., carries no specific semantic beyond "these two things are related"), state this explicitly. Generic links carry no hidden semantics; do not rely on a generic link to carry a typed semantic that should be a distinct relation.


### PR DESCRIPTION
## Summary

- Appends a **"Contract authoring checklist"** section to `companion-ui/docs/SEMANTIC_PROJECTION_ALIGNMENT.md` — four Layer-7 checks any new Companion UI contract must satisfy (layer mapped, durability posture, write authority, runtime boundary)
- Appends a **"Relation authoring checklist"** section to `docs/CONCEPTS/RELATION_TAXONOMY.md` — four taxonomy checks any new relation definition must satisfy (type declared, inferred/confirmed flag, provenance visibility, generic link semantics)

Docs-only change per the docs-authoring lane. No code changes. No gates or enforcement machinery — checklists only.

## Validation

- `python3 scripts/docs_guard.py` → OK
- `git diff --check` → clean
- `grep -n "Contract authoring checklist" companion-ui/docs/SEMANTIC_PROJECTION_ALIGNMENT.md` → line 92
- `grep -n "Relation authoring checklist" docs/CONCEPTS/RELATION_TAXONOMY.md` → line 122

## Closes

Closes #1405

## Source

Audit recommendation 4 from `docs/SEMANTIC_DRIFT_AUDIT.md` (epic #1363 follow-on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)