### PR TITLE
docs: annotate promotion path receipt gap in owner docs

### DIFF
--- a/docs/CONCEPTS/ONTOLOGY_VOCABULARY.md
+++ b/docs/CONCEPTS/ONTOLOGY_VOCABULARY.md
@@ -164,8 +164,15 @@ They record where the active runtime most clearly compresses multiple ontology l
 
 - `app/promotion/consumer.py` and `app/services/note_update.py`
   - `promotion` currently resolves into `review_state` mutation in both vault frontmatter and store
-    payload.
-  - This is a strong sign that runtime naming and ontology naming are still misaligned here.
+    payload. A `PROMOTE_DONE` DB outbox event is emitted on success and serves as the current
+    transition record; `payload["promotion"]` in the ObjectStore row provides inline provenance.
+  - What is missing is a **distinct durable promotion receipt artifact** — separate from the store
+    payload and queryable as an accountability record. Until that is added, the transition record
+    lives only as an outbox event and an embedded payload field.
+  - Tracked follow-on: issue #1403. Target state: promotion consumer writes a formal receipt record
+    in addition to the store payload mutation. Pre-requisite: receipt store model.
+  - This note is an enabling-change annotation, not a current-state claim. Current behavior
+    (PROMOTE_DONE event + payload["promotion"]) is the correct interim implementation.
 
 - `app/domain/plan.py` and `app/agents/planner/graph.py`
   - `plan` currently means execution plan much more than human project or commitment structure.

--- a/docs/CONCEPTS/WORKFLOW_MUTATION_AND_GOVERNANCE_SEMANTICS.md
+++ b/docs/CONCEPTS/WORKFLOW_MUTATION_AND_GOVERNANCE_SEMANTICS.md
@@ -80,6 +80,20 @@ These are the failure modes this contract exists to prevent:
 3. **Hidden durable writes.** No durable change to the human surface occurs without a receipt. There is no silent write path.
 4. **UI/runtime bypasses around governance.** The Companion UI and runtime layers route mutations to governance; they do not classify or authorize their own durable writes (owner: `companion-ui/docs/SEMANTIC_PROJECTION_ALIGNMENT.md`). Runtime state never becomes durable except through a governed mutation.
 
+## Runtime seam notes
+
+These notes document known gaps between the contracts above and the current runtime, so future implementors know what is target-state vs delivered. They are enabling-change annotations, not contract revisions.
+
+### Promotion path — receipt gap (tracking issue #1403)
+
+The `app/promotion/consumer.py` + `app/services/note_update.py` path satisfies the "no silent durable write" rule via a `PROMOTE_DONE` DB outbox event on success, and embeds `payload["promotion"]` provenance in the ObjectStore row. However, it does not yet produce a **formal durable promotion receipt** as a distinct, queryable accountability artifact (as specified by §Receipt linkage above and `docs/CONCEPTS/RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md`).
+
+Current state: `PROMOTE_DONE` event in DB outbox = the transition record. `payload["promotion"]` = inline provenance.
+Target state: promotion consumer also writes a formal receipt record to a receipt store.
+Pre-requisite: receipt store model (not yet built).
+
+Until the receipt store is built, treat `PROMOTE_DONE` + `payload["promotion"]` as the correct interim implementation. Do not add ad hoc receipt workarounds.
+
 ## Cross-references
 
 - Parent semantic map (Layer 4) and artifact-flow topology: `docs/SEMANTIC_SYSTEM_ARCHITECTURE.md`.


### PR DESCRIPTION
## Change Lane
- [ ] Implementation lane
- [x] Docs authoring lane
- [ ] Governance lane

## Linked Issue
<!-- Docs authoring lane — no issue required -->

## Summary
- Adds enabling-change annotations to `docs/CONCEPTS/ONTOLOGY_VOCABULARY.md` runtime seam notes: clarifies that `PROMOTE_DONE` event + `payload["promotion"]` IS the current transition record; the missing piece is a formal durable receipt artifact
- Adds "Runtime seam notes" section to `docs/CONCEPTS/WORKFLOW_MUTATION_AND_GOVERNANCE_SEMANTICS.md` so readers see interim vs target state without cross-referencing ONTOLOGY_VOCABULARY

## Docs Authoring Check
- [x] This PR only changes approved docs-authoring surfaces.
- [x] No code, runtime behavior, contracts, or shipped reality changed.
- [x] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Validation
- `python3 scripts/docs_guard.py` → OK
- `git diff --check` → clean

## Context
Scoping pass for issue #1403 determined the promotion→receipt receipt gap is a multi-slice feature. Issue #1403 stays open (`agent:needs-human`). This PR delivers the docs-only annotation; code work deferred for human prioritization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)