### PR TITLE
fix(companion-ui): remove duplicate Vault Browser surfaces (#1398)

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -438,7 +438,9 @@ def _render_workspace_header_strip(
         vault_state = "unresolved"
     else:
         vault_state = "ok"
-    browse_target = "#vault-browser-overlay"
+    # §5.2 — Browse Vault routes to the canonical left-pane browse surface, not
+    # the modal overlay (which is a narrow responsive fallback only).
+    browse_target = "#vault-browser-left-pane"
     telemetry_rows = [
         ("workspace-runtime-channel", "runtime_environment_label", "runtime", runtime_environment),
         ("workspace-runtime-channel-api", "runtime_api_base_url_label", "channel", runtime_channel),
@@ -554,7 +556,7 @@ def _render_workspace_header_strip(
           <button class="workspace-quick-open" data-testid="workspace-quick-open" type="button" aria-disabled="true" title="Quick-open is visual only in this slice">
             <kbd>/</kbd><span>⌘K</span>
           </button>
-          <button class="workspace-browse-vault" data-testid="workspace-browse-vault" type="button" onclick="vaultBrowser.open()">Browse vault</button>
+          <button class="workspace-browse-vault" data-testid="workspace-browse-vault" type="button" data-browse-target="vault-browser-pane" onclick="vaultBrowser.focus()">Browse vault</button>
           {dev_ribbon}
         </div>
       </header>"""
@@ -629,7 +631,7 @@ def _render_note_not_found(note_path: str) -> str:
         f"<code>{safe_path}</code>"
         f"<p>No artifact at {safe_path}. The vault may have moved or this link may be stale.</p>"
         f'<div class="not-found-actions">'
-        f'<button type="button" class="not-found-browse" onclick="vaultBrowser.open()">Browse vault</button>'
+        f'<button type="button" class="not-found-browse" data-browse-target="vault-browser-pane" onclick="vaultBrowser.focus()">Browse vault</button>'
         f'<button type="button" class="not-found-last-note" data-testid="workspace-open-last-note">Open last note</button>'
         f"</div>"
         f"</div>"
@@ -956,7 +958,7 @@ def _render_note_section(fields: dict) -> str:
 
     return f"""
   <div class="workspace-layout workspace-layout--three-col">
-    <nav class="vault-browser-left-pane" data-testid="workspace-vault-browser-left-pane" data-region="vault-browser-pane">
+    <nav class="vault-browser-left-pane" id="vault-browser-left-pane" data-testid="workspace-vault-browser-left-pane" data-region="vault-browser-pane" data-browser-role="canonical">
       {vault_browser_html}
     </nav>
     <div class="workspace-main">
@@ -4684,15 +4686,19 @@ def render_index_html(
         <button type="button"
           id="vault-browse-btn"
           data-testid="vault-browse-button"
-          onclick="vaultBrowser.open()">Browse vault</button>
+          data-browse-target="vault-browser-pane"
+          onclick="vaultBrowser.focus()">Browse vault</button>
       </form>
     </div>
   </details>
   {content_section}
 
-  <!-- Vault note browser overlay -->
+  <!-- Vault note browser overlay — narrow responsive fallback only (§5.3).
+       On desktop, Browse Vault focuses the canonical left-pane browse surface
+       instead of opening this modal. -->
   <div class="vault-browser-overlay" id="vault-browser-overlay"
-       data-testid="vault-browser-overlay" role="dialog" aria-modal="true">
+       data-testid="vault-browser-overlay" data-browser-role="responsive-fallback"
+       role="dialog" aria-modal="true">
     <div class="vault-browser-panel">
       <div class="vault-browser-header">
         <span class="vault-browser-title">Browse vault</span>
@@ -4775,6 +4781,23 @@ def render_index_html(
     }}
 
     window.vaultBrowser = {{
+      focus: function() {{
+        // §5.2/§5.3 — on desktop the canonical browser is the left context
+        // pane; focus it in place. Only fall back to the modal overlay on
+        // narrow viewports where the persistent left pane is not available.
+        var leftPane = document.getElementById('vault-browser-left-pane');
+        var hasInlinePane = leftPane &&
+          window.matchMedia('(min-width: 860px)').matches &&
+          window.getComputedStyle(leftPane).display !== 'none';
+        if (hasInlinePane) {{
+          leftPane.setAttribute('data-browse-focused', 'true');
+          leftPane.scrollIntoView({{ block: 'nearest', inline: 'nearest' }});
+          var paneSearch = leftPane.querySelector('input, a, button');
+          if (paneSearch) paneSearch.focus();
+          return;
+        }}
+        vaultBrowser.open();
+      }},
       open: function() {{
         overlay.classList.add('open');
         search.value = '';

--- a/tests/companion_ui/test_vault_browser_single_surface.py
+++ b/tests/companion_ui/test_vault_browser_single_surface.py
@@ -1,0 +1,154 @@
+"""Single canonical Vault Browser surface (#1398).
+
+Applies ``ADAPTIVE_WORKSPACE_LAYOUT_HANDOFF.md`` §5: the normal desktop
+workspace exposes exactly one canonical Vault Browser surface — the left
+context panel in browse mode. Every Browse Vault entrypoint focuses that
+canonical surface rather than opening a competing modal. The modal/sheet
+browser remains only as a narrow responsive fallback (hidden by default),
+and same-origin remote-client behaviour is preserved.
+
+These are SSR markup/contract tests against the rendered dev-page HTML.
+"""
+
+from __future__ import annotations
+
+import re
+
+from companion_ui.workspace.serve_dev_page import render_index_html
+
+
+def _fields(*, note_path: str = "Notes/note.md") -> dict:
+    return {
+        "title": "Note Title",
+        "note_path": note_path,
+        "artifact_id": "art-123",
+        "artifact_kind": "human_note",
+        "artifact_identity_source": "frontmatter.uuid",
+        "artifact_identity_state": "resolved",
+        "artifact_companion_of": None,
+        "artifact_owns_identity": True,
+        "content_hash": "sha256-aaa",
+        "body": "# Note\n\nBody content here.",
+        "panel_rail": "Panel / agent rail placeholder",
+        "runtime_environment_label": "dev",
+        "runtime_api_base_url_label": "local-dev",
+        "runtime_trace_id": "trace-1",
+        "runtime_vault_name": "vault/dev",
+        "runtime_vault_channel": "local-dev",
+        "runtime_vault_provenance": "resolved",
+        "canvas_session_state": "idle",
+        "canvas_session_persistence": "durable",
+        "panel_state": "idle",
+        "panel_proposal_count": 0,
+        "panel_proposals": [],
+        "panel_message": "",
+        "guard_writeguard_status": "ok",
+        "guard_canvas_enabled": True,
+        "guard_degraded": False,
+        "guard_workspace_update_available": True,
+        "guard_update_flow_available": True,
+        "find_candidates": [],
+        "find_payload_available": False,
+        "reorient_sections": {},
+        "resurface_candidates": [],
+        "governance_receipts": [],
+        "suggestion_state": "idle",
+        "suggestion_composer_enabled": True,
+        "is_production_ui": False,
+        "dev_page_label": "dev/staging",
+        "workspace_loaded_at": None,
+    }
+
+
+def _html(**kw) -> str:
+    return render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path=kw.get("note_path", "Notes/note.md"),
+        fields=_fields(**kw),
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC: exactly one default/canonical Vault Browser surface
+# ---------------------------------------------------------------------------
+
+
+def test_only_one_default_vault_browser_surface():
+    html = _html()
+    # Exactly one surface is declared canonical, and it is the left context pane.
+    assert html.count('data-browser-role="canonical"') == 1
+    canonical = re.search(
+        r'<nav[^>]*data-testid="workspace-vault-browser-left-pane"[^>]*>', html
+    )
+    assert canonical and 'data-browser-role="canonical"' in canonical.group(0)
+    # Exactly one canonical browser region (the left context pane) in the
+    # default workspace; the modal overlay is not canonical.
+    assert html.count('data-region="vault-browser-pane"') == 1
+    assert html.count('data-testid="workspace-vault-browser-left-pane"') == 1
+
+
+# ---------------------------------------------------------------------------
+# AC: Browse Vault focuses the left-panel browse surface
+# ---------------------------------------------------------------------------
+
+
+def test_browse_vault_focuses_left_panel_browse_mode():
+    html = _html()
+    btn = re.search(
+        r'<button[^>]*data-testid="workspace-browse-vault"[^>]*>', html
+    )
+    assert btn, "header Browse vault button missing"
+    token = btn.group(0)
+    # The entrypoint routes to the canonical left-pane browse surface...
+    assert 'data-browse-target="vault-browser-pane"' in token
+    # ...by focusing it rather than opening the modal directly.
+    assert "vaultBrowser.focus()" in token
+
+
+# ---------------------------------------------------------------------------
+# AC: desktop browse does not open a duplicate modal
+# ---------------------------------------------------------------------------
+
+
+def test_desktop_browse_does_not_open_duplicate_modal():
+    html = _html()
+    # No browse entrypoint opens the modal directly via an onclick handler;
+    # the modal is reachable only through the responsive fallback branch.
+    assert 'onclick="vaultBrowser.open()"' not in html
+    # The vault identity chip no longer jumps straight to the modal overlay.
+    assert 'href="#vault-browser-overlay"' not in html
+    # The modal overlay is explicitly a narrow responsive fallback, not canonical.
+    overlay = re.search(
+        r'<div[^>]*data-testid="vault-browser-overlay"[^>]*>', html
+    )
+    assert overlay and 'data-browser-role="responsive-fallback"' in overlay.group(0)
+
+
+# ---------------------------------------------------------------------------
+# AC: no duplicate visible browser regions in the default workspace
+# ---------------------------------------------------------------------------
+
+
+def test_no_duplicate_visible_browser_regions_in_default_workspace():
+    html = _html()
+    # Only one canonical left-pane browser region renders by default.
+    assert html.count('data-testid="workspace-vault-browser-left-pane"') == 1
+    # The fallback modal overlay is hidden by default (display:none until .open).
+    m = re.search(r"\n {4}\.vault-browser-overlay\s*\{(.*?)\n {4}\}", html, re.S)
+    assert m, ".vault-browser-overlay rule not found"
+    assert "display: none;" in m.group(1)
+
+
+# ---------------------------------------------------------------------------
+# AC: same-origin remote-safe behaviour preserved
+# ---------------------------------------------------------------------------
+
+
+def test_same_origin_remote_safe_behavior_preserved():
+    html = _html()
+    # Browser-side vault listing uses a same-origin relative path...
+    assert "'/api/companion/vault/notes'" in html
+    # ...with no client-side dependency on a runtime localhost host.
+    assert "127.0.0.1:18001/api/companion/vault/notes" not in html
+    assert "fetch('http://127.0.0.1" not in html
+    assert 'fetch("http://127.0.0.1' not in html


### PR DESCRIPTION
Fixes #1398

## Summary
Consolidates the Vault Browser to one canonical surface — the left context pane in browse mode — and routes every Browse Vault entrypoint to focus it instead of opening a competing modal. Implements `ADAPTIVE_WORKSPACE_LAYOUT_HANDOFF.md` §5.

## Source docs read
- `companion-ui/docs/ADAPTIVE_WORKSPACE_LAYOUT_HANDOFF.md` §5 (§5.1 do-not-render, §5.2 canonical entrypoint, §5.3 modal fallback)
- `companion-ui/docs/VAULT_BROWSER_UI_REQUIREMENTS.md`, `docs/VAULT_BROWSER_CAPABILITY_CONTRACT.md`, `companion-ui/docs/UI_RUNTIME_BOUNDARIES.md`

## Handoff sections applied
§5 (duplicate Vault Browser rules).

## Changes
- Left context pane marked canonical: `id="vault-browser-left-pane"`, `data-browser-role="canonical"`.
- Modal overlay marked narrow responsive fallback: `data-browser-role="responsive-fallback"` (still hidden by default, `display:none`).
- All Browse Vault entrypoints (header `workspace-browse-vault`, vault-identity chip `href` → `#vault-browser-left-pane`, not-found action, dev-controls `vault-browse-button`) now call `vaultBrowser.focus()` with `data-browse-target="vault-browser-pane"` — no entrypoint opens the modal via an onclick handler.
- New responsive-aware `vaultBrowser.focus()`: focuses the canonical left pane in place on desktop (`min-width:860px` and pane visible); only falls back to the modal on narrow viewports.
- New `tests/companion_ui/test_vault_browser_single_surface.py` (5 cases): one canonical surface, browse focuses left-pane browse mode, desktop browse opens no duplicate modal, no duplicate visible browser regions, same-origin remote-safe behaviour preserved.

## Authority / guardrail notes
No new browser capabilities, no graph/timeline/saved views, no change to Vault Browser runtime authority or filtering semantics, no hardcoded hostnames/IPs, no direct vault file access. Same-origin contract preserved (relative `/api/companion/vault/notes`). Stable `data-*` anchors preserved; modal overlay and its testids kept for the responsive fallback.

## Tests run
- `test_vault_browser_single_surface.py` → 5 passed.
- Validation matrix `test_vault_browser_single_surface.py + test_vault_browser.py + test_vault_browser_left_pane.py + tests/api/test_companion_vault_browser_api.py` → 40 passed.
- Full `tests/companion_ui/` → 1148 passed, 4 failed. **All 4 failures are pre-existing on clean `main`** (identical before this PR): `test_renders_runtime_safety_strip_and_identity_pills`, 2× `test_mermaid_block_renderer` (TypeError in `app/api/routes/companion.py:562`), `test_workspace_resurface_source_link_uses_logical_identifier`. None touch this PR's changed lines.
- `python3 scripts/docs_guard.py` → OK
- `git diff --check` → clean
- `python3 -m ruff check app tests companion-ui/companion-app/companion_ui` → 1 error (F541) in the reorient region of `serve_dev_page.py` (~line 1886). **Pre-existing**; not in this PR's changed lines (#1401 area).

## Browser UAT
Deferred to parent (#1395) remote-client UAT; the dev runtime LAN URL is not reachable from this build environment. The desktop-vs-narrow focus/fallback behaviour is JS that warrants real-browser confirmation.

## Known limitations / lifecycle
- Dispatcher unavailable (`db_exists: false`) — GitHub-label-only flow; issues not labeled `agent:ready`.
- Codex code review is rate-limited (usage limits reached) and did not run; relying on green CI + local verification.
- Dev-controls harness button kept inside the existing `dev controls` disclosure; full relocation of dev/operator chrome behind a flag is left to follow-up to keep this PR bounded to duplicate-surface removal.

---