### PR TITLE
feat(companion-ui): adaptive left context panel modes (#1399)

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -676,6 +676,93 @@ def _render_body_edit_panel(update_flow_available: bool, note_path: str, raw_bod
 </div>"""
 
 
+_LEFT_PANEL_MODES = ("browse", "outline", "context", "collapsed")
+
+
+def _render_left_context_panel(
+    *,
+    vault_browser_html: str,
+    outline_html: str,
+    has_headings: bool,
+    note_path_val: str,
+    identity_state_label: str,
+) -> str:
+    """Render the single adaptive left context panel (#1399, handoff §4).
+
+    One panel, four modes (browse / outline / context / collapsed); only one
+    mode region is visible at a time. Opening a note prefers ``outline`` when
+    the note has headings, otherwise ``collapsed`` so the panel does not cold
+    open into a noisy browser dump. Mode labels are human-facing; internal mode
+    keys stay in ``data-*`` attributes.
+    """
+
+    default_mode = "outline" if has_headings else "collapsed"
+
+    def _region(mode: str, label_testid: str, inner: str) -> str:
+        hidden = "" if mode == default_mode else " hidden"
+        return (
+            f'<div class="left-panel-mode left-panel-mode--{mode}" '
+            f'data-left-panel-mode-region="{mode}" data-mode="{mode}" '
+            f'data-testid="workspace-left-panel-mode-{mode}" role="tabpanel"'
+            f"{hidden}>{inner}</div>"
+        )
+
+    # §4.3 — context mode is compact, not a metadata dump.
+    context_inner = (
+        '<div class="left-panel-context" data-testid="workspace-left-panel-context">'
+        '<div class="left-panel-context-row">'
+        '<span class="lpc-label">Path</span>'
+        f'<span class="lpc-value">{note_path_val or "—"}</span></div>'
+        '<div class="left-panel-context-row">'
+        '<span class="lpc-label">Identity</span>'
+        f'<span class="lpc-value">{identity_state_label}</span></div>'
+        '<p class="left-panel-context-empty">Nothing needs attention for this note.</p>'
+        "</div>"
+    )
+
+    def _tab(mode: str, label: str) -> str:
+        selected = "true" if mode == default_mode else "false"
+        return (
+            f'<button type="button" class="left-panel-mode-tab" role="tab" '
+            f'data-mode="{mode}" data-testid="workspace-left-panel-tab-{mode}" '
+            f'aria-selected="{selected}" '
+            f"onclick=\"leftPanel.setMode('{mode}')\">{label}</button>"
+        )
+
+    switcher = (
+        '<div class="left-panel-mode-switcher" role="tablist" '
+        'data-testid="workspace-left-panel-mode-switcher">'
+        f"{_tab('browse', 'Browse')}"
+        f"{_tab('outline', 'Outline')}"
+        f"{_tab('context', 'Context')}"
+        '<button type="button" class="left-panel-collapse" '
+        'data-testid="workspace-left-panel-collapse" aria-label="Collapse panel" '
+        "onclick=\"leftPanel.collapse()\">&#10216;</button>"
+        "</div>"
+    )
+
+    reopen_hidden = "" if default_mode == "collapsed" else " hidden"
+    reopen = (
+        '<button type="button" class="left-panel-reopen" '
+        'data-testid="workspace-left-panel-reopen" '
+        f"onclick=\"leftPanel.reopen()\"{reopen_hidden}>Open panel</button>"
+    )
+
+    return (
+        '<nav class="vault-browser-left-pane" id="vault-browser-left-pane" '
+        'data-testid="workspace-vault-browser-left-pane" '
+        'data-region="vault-browser-pane" data-browser-role="canonical" '
+        f'data-left-panel-modes="{" ".join(_LEFT_PANEL_MODES)}" '
+        f'data-left-panel-mode="{default_mode}">'
+        f"{switcher}"
+        f"{_region('browse', 'browse', vault_browser_html)}"
+        f"{_region('outline', 'outline', outline_html)}"
+        f"{_region('context', 'context', context_inner)}"
+        f"{reopen}"
+        "</nav>"
+    )
+
+
 def _render_note_section(fields: dict) -> str:
     """Render the workspace shell from render_fields() output.
 
@@ -704,6 +791,7 @@ def _render_note_section(fields: dict) -> str:
     rendered_body = render_vault_markdown(raw_body, note_path=raw_note_path)
     body = rendered_body.html
     outline_html = render_note_outline(rendered_body.document)
+    has_headings = bool(tuple(rendered_body.document.headings))
     hidden_frontmatter_html, rendered_props = _render_note_frontmatter_region(rendered_body.document)
     panel_rail = _e(fields.get("panel_rail", "Panel / agent rail placeholder"))
     canvas_session_id = _e(fields.get("canvas_session_id") or "")
@@ -956,11 +1044,17 @@ def _render_note_section(fields: dict) -> str:
         )
     )
 
+    left_context_panel_html = _render_left_context_panel(
+        vault_browser_html=vault_browser_html,
+        outline_html=outline_html,
+        has_headings=has_headings,
+        note_path_val=note_path_val,
+        identity_state_label=identity_state,
+    )
+
     return f"""
   <div class="workspace-layout workspace-layout--three-col">
-    <nav class="vault-browser-left-pane" id="vault-browser-left-pane" data-testid="workspace-vault-browser-left-pane" data-region="vault-browser-pane" data-browser-role="canonical">
-      {vault_browser_html}
-    </nav>
+    {left_context_panel_html}
     <div class="workspace-main">
       {workspace_header_strip_html}
       {vault_unreachable_banner_html}
@@ -975,11 +1069,11 @@ def _render_note_section(fields: dict) -> str:
       {hidden_frontmatter_html}
       {note_not_found_html}
       <div
-        class="note-reading-layout"
+        class="note-reading-layout note-reading-layout--single"
         data-testid="workspace-note-reading-layout">
-        {outline_html}
         <button class="workspace-outline-ribbon" data-testid="workspace-outline-ribbon"
-          aria-label="open outline" data-layout-visible="800-1099">☰ outline</button>
+          aria-label="open outline" data-layout-visible="800-1099"
+          onclick="leftPanel.setMode('outline')">☰ outline</button>
         <div class="note-body" data-testid="workspace-note-body" data-region="note-body"
           data-read-only="true">
           <div class="note-body-readonly-indicator"
@@ -3031,6 +3125,95 @@ def render_index_html(
       overflow-y: auto;
       padding: 12px 8px;
     }}
+    /* §4 — single adaptive left context panel: mode switcher + mode regions. */
+    .left-panel-mode-switcher {{
+      align-items: center;
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      flex-shrink: 0;
+      gap: 2px;
+      margin-bottom: 8px;
+      padding-bottom: 6px;
+    }}
+    .left-panel-mode-tab {{
+      background: none;
+      border: none;
+      border-radius: var(--radius-sm);
+      color: var(--fg-3);
+      cursor: pointer;
+      font-family: var(--font-ui);
+      font-size: var(--text-xs);
+      padding: 3px 8px;
+    }}
+    .left-panel-mode-tab[aria-selected="true"] {{
+      background: var(--bg-raised);
+      color: var(--fg-1);
+    }}
+    .left-panel-collapse {{
+      background: none;
+      border: none;
+      color: var(--fg-3);
+      cursor: pointer;
+      margin-left: auto;
+      padding: 3px 6px;
+    }}
+    .left-panel-mode {{
+      display: flex;
+      flex: 1;
+      flex-direction: column;
+      min-height: 0;
+    }}
+    .left-panel-mode[hidden] {{ display: none; }}
+    .left-panel-context-row {{
+      display: flex;
+      gap: 8px;
+      justify-content: space-between;
+      padding: 4px 2px;
+    }}
+    .left-panel-context .lpc-label {{
+      color: var(--fg-3);
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+    }}
+    .left-panel-context .lpc-value {{
+      color: var(--fg-2);
+      font-size: var(--text-xs);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }}
+    .left-panel-context-empty {{
+      color: var(--fg-3);
+      font-size: var(--text-sm);
+      margin-top: 8px;
+    }}
+    .left-panel-reopen {{
+      background: var(--bg-raised);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      color: var(--fg-2);
+      cursor: pointer;
+      font-size: var(--text-xs);
+      padding: 6px 10px;
+    }}
+    .left-panel-reopen[hidden] {{ display: none; }}
+    /* §4 — the outline now lives in the left panel (outline mode), so the
+       central reading layout is a single column. Double-class selector beats
+       the 2-column .note-reading-layout rule from note_outline_css(). */
+    .note-reading-layout.note-reading-layout--single {{
+      grid-template-columns: minmax(0, 1fr);
+    }}
+    /* Collapsed mode maximizes reading: hide switcher + mode regions, keep the
+       reopen affordance, and shrink the panel to a narrow rail. */
+    .vault-browser-left-pane[data-left-panel-mode="collapsed"] {{
+      align-items: center;
+      overflow: visible;
+      padding: 12px 6px;
+    }}
+    .vault-browser-left-pane[data-left-panel-mode="collapsed"] .left-panel-mode-switcher,
+    .vault-browser-left-pane[data-left-panel-mode="collapsed"] .left-panel-mode {{
+      display: none;
+    }}
     .workspace-main {{
       flex: 1;
       min-width: 0;
@@ -4790,6 +4973,8 @@ def render_index_html(
           window.matchMedia('(min-width: 860px)').matches &&
           window.getComputedStyle(leftPane).display !== 'none';
         if (hasInlinePane) {{
+          // §4.1/§5.2 — activate browse mode in the single left context panel.
+          if (window.leftPanel) window.leftPanel.setMode('browse');
           leftPane.setAttribute('data-browse-focused', 'true');
           leftPane.scrollIntoView({{ block: 'nearest', inline: 'nearest' }});
           var paneSearch = leftPane.querySelector('input, a, button');
@@ -4828,6 +5013,51 @@ def render_index_html(
     document.addEventListener('keydown', function(e) {{
       if (e.key === 'Escape') vaultBrowser.close();
     }});
+  }})();
+  </script>
+
+  <script>
+  (function() {{
+    // §4 — single adaptive left context panel controller. Exactly one mode is
+    // visible at a time; collapsed maximizes the reading surface and keeps a
+    // visible reopen affordance that restores the last non-collapsed mode.
+    function nav() {{ return document.getElementById('vault-browser-left-pane'); }}
+
+    window.leftPanel = {{
+      setMode: function(mode) {{
+        var n = nav();
+        if (!n) return;
+        var current = n.getAttribute('data-left-panel-mode');
+        if (current && current !== 'collapsed') {{
+          n.setAttribute('data-left-panel-last-mode', current);
+        }}
+        n.setAttribute('data-left-panel-mode', mode);
+        var regions = n.querySelectorAll('[data-left-panel-mode-region]');
+        Array.prototype.forEach.call(regions, function(r) {{
+          if (mode !== 'collapsed' && r.getAttribute('data-mode') === mode) {{
+            r.removeAttribute('hidden');
+          }} else {{
+            r.setAttribute('hidden', '');
+          }}
+        }});
+        var tabs = n.querySelectorAll('[role="tab"]');
+        Array.prototype.forEach.call(tabs, function(t) {{
+          t.setAttribute('aria-selected',
+            t.getAttribute('data-mode') === mode ? 'true' : 'false');
+        }});
+        var reopen = n.querySelector('[data-testid="workspace-left-panel-reopen"]');
+        if (reopen) {{
+          if (mode === 'collapsed') reopen.removeAttribute('hidden');
+          else reopen.setAttribute('hidden', '');
+        }}
+      }},
+      collapse: function() {{ window.leftPanel.setMode('collapsed'); }},
+      reopen: function() {{
+        var n = nav();
+        var last = (n && n.getAttribute('data-left-panel-last-mode')) || 'browse';
+        window.leftPanel.setMode(last);
+      }}
+    }};
   }})();
   </script>
 

--- a/tests/companion_ui/_orphan_text.py
+++ b/tests/companion_ui/_orphan_text.py
@@ -104,6 +104,17 @@ CONTAINER_TESTIDS: frozenset[str] = frozenset(
         "workspace-outline-sheet-trigger",
         "workspace-panel-sheet-trigger",
         "workspace-sheet-triggers",
+        # Adaptive left context panel modes (§4 / #1399)
+        "workspace-left-panel-mode-switcher",
+        "workspace-left-panel-tab-browse",
+        "workspace-left-panel-tab-outline",
+        "workspace-left-panel-tab-context",
+        "workspace-left-panel-collapse",
+        "workspace-left-panel-reopen",
+        "workspace-left-panel-context",
+        "workspace-left-panel-mode-browse",
+        "workspace-left-panel-mode-outline",
+        "workspace-left-panel-mode-context",
         # Dev controls disclosure (#1361)
         "workspace-dev-controls-toggle",
     }

--- a/tests/companion_ui/test_left_context_panel_modes.py
+++ b/tests/companion_ui/test_left_context_panel_modes.py
@@ -1,0 +1,203 @@
+"""Adaptive left context panel modes (#1399).
+
+Applies ``ADAPTIVE_WORKSPACE_LAYOUT_HANDOFF.md`` §4: the single left context
+panel established by #1397 becomes mode-aware. It supports four modes —
+``browse``, ``outline``, ``context``, ``collapsed`` — and renders only one at a
+time. Opening a note prefers ``outline`` (when the note has headings) or
+``collapsed`` (when it does not), never a cold-start browser dump. The Browse
+Vault action activates ``browse`` mode in the same panel, the outline lives
+inside the same left slot (not a second pane), collapsed mode keeps a visible
+reopen affordance, and mode labels are human-facing.
+
+SSR markup/contract tests against the rendered dev-page HTML.
+"""
+
+from __future__ import annotations
+
+import re
+
+from companion_ui.workspace.serve_dev_page import render_index_html
+
+_WITH_HEADINGS = "# Alpha\n\nText.\n\n## Beta\n\nMore.\n\n### Gamma\n\nEnd."
+_NO_HEADINGS = "Just a paragraph with no headings at all.\n\nAnd another one."
+
+
+def _fields(*, body: str, note_path: str = "Notes/note.md") -> dict:
+    return {
+        "title": "Note Title",
+        "note_path": note_path,
+        "artifact_id": "art-123",
+        "artifact_kind": "human_note",
+        "artifact_identity_source": "frontmatter.uuid",
+        "artifact_identity_state": "resolved",
+        "artifact_companion_of": None,
+        "artifact_owns_identity": True,
+        "content_hash": "sha256-aaa",
+        "body": body,
+        "panel_rail": "Panel / agent rail placeholder",
+        "runtime_environment_label": "dev",
+        "runtime_api_base_url_label": "local-dev",
+        "runtime_trace_id": "trace-1",
+        "runtime_vault_name": "vault/dev",
+        "runtime_vault_channel": "local-dev",
+        "runtime_vault_provenance": "resolved",
+        "canvas_session_state": "idle",
+        "canvas_session_persistence": "durable",
+        "panel_state": "idle",
+        "panel_proposal_count": 0,
+        "panel_proposals": [],
+        "panel_message": "",
+        "guard_writeguard_status": "ok",
+        "guard_canvas_enabled": True,
+        "guard_degraded": False,
+        "guard_workspace_update_available": True,
+        "guard_update_flow_available": True,
+        "find_candidates": [],
+        "find_payload_available": False,
+        "reorient_sections": {},
+        "resurface_candidates": [],
+        "governance_receipts": [],
+        "suggestion_state": "idle",
+        "suggestion_composer_enabled": True,
+        "is_production_ui": False,
+        "dev_page_label": "dev/staging",
+        "workspace_loaded_at": None,
+    }
+
+
+def _html(*, body: str = _WITH_HEADINGS, note_path: str = "Notes/note.md") -> str:
+    return render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path=note_path,
+        fields=_fields(body=body, note_path=note_path),
+    )
+
+
+def _left_nav(html: str) -> str:
+    """Return the left context panel markup.
+
+    The panel is a ``<nav>`` that contains an inner ``<nav class="note-outline">``
+    (the outline), so a naive ``</nav>`` scan would truncate early. The panel
+    always ends immediately before the central ``workspace-main`` region, so we
+    bound on that instead.
+    """
+    start = html.index('<nav class="vault-browser-left-pane"')
+    end = html.index('<div class="workspace-main"', start)
+    return html[start:end]
+
+
+# ---------------------------------------------------------------------------
+# AC: declares supported modes
+# ---------------------------------------------------------------------------
+
+
+def test_left_panel_declares_supported_modes():
+    nav = _left_nav(_html())
+    m = re.search(r'data-left-panel-modes="([^"]*)"', nav)
+    assert m, "left panel must declare its supported modes"
+    modes = set(m.group(1).split())
+    assert modes == {"browse", "outline", "context", "collapsed"}
+
+
+# ---------------------------------------------------------------------------
+# AC: only one mode visible at a time
+# ---------------------------------------------------------------------------
+
+
+def test_only_one_left_panel_mode_visible_at_a_time():
+    nav = _left_nav(_html(body=_WITH_HEADINGS))
+    # Each mode content region is a div carrying data-left-panel-mode-region
+    # (the mode switcher is excluded — it is not a content region).
+    regions = re.findall(
+        r'<div[^>]*data-left-panel-mode-region="[a-z]+"[^>]*>', nav
+    )
+    assert len(regions) >= 2, "expected multiple mode regions in the panel"
+    visible = [r for r in regions if "hidden" not in r]
+    assert len(visible) == 1, f"exactly one mode region must be visible, got {len(visible)}"
+
+
+# ---------------------------------------------------------------------------
+# AC: opening a note defaults to outline/collapsed, not a browser dump
+# ---------------------------------------------------------------------------
+
+
+def test_open_note_defaults_to_outline_or_collapsed_not_browser_dump():
+    # With headings → outline.
+    nav = _left_nav(_html(body=_WITH_HEADINGS))
+    mode = re.search(r'data-left-panel-mode="([a-z]+)"', nav).group(1)
+    assert mode == "outline"
+    # The browse mode region is not the active/visible one.
+    browse = re.search(
+        r'<div[^>]*data-testid="workspace-left-panel-mode-browse"[^>]*>', nav
+    ).group(0)
+    assert "hidden" in browse
+    # Without headings → collapsed (no cold-start outline either).
+    nav2 = _left_nav(_html(body=_NO_HEADINGS))
+    mode2 = re.search(r'data-left-panel-mode="([a-z]+)"', nav2).group(1)
+    assert mode2 == "collapsed"
+
+
+# ---------------------------------------------------------------------------
+# AC: browse action activates browse mode in the single left panel
+# ---------------------------------------------------------------------------
+
+
+def test_browse_action_activates_browse_mode():
+    html = _html()
+    # The Browse Vault entrypoint targets the left panel...
+    assert 'data-browse-target="vault-browser-pane"' in html
+    # ...and the focus handler activates browse mode on the left panel.
+    assert "setMode('browse')" in html or 'data-left-panel-mode' in html
+    # The left-panel controller exposes a browse-mode activation path.
+    assert "leftPanel" in html
+    assert "browse" in _left_nav(html)
+
+
+# ---------------------------------------------------------------------------
+# AC: outline mode uses the same left panel slot (not a second pane)
+# ---------------------------------------------------------------------------
+
+
+def test_outline_mode_uses_same_left_panel_slot():
+    html = _html(body=_WITH_HEADINGS)
+    nav = _left_nav(html)
+    # The outline renders inside the left context panel.
+    assert 'data-testid="note-outline"' in nav
+    # ...and not as a second column inside the central reading layout.
+    reading_start = html.index('data-testid="workspace-note-reading-layout"')
+    reading_end = html.index("</div>", html.index('data-testid="workspace-note-body"'))
+    reading_region = html[reading_start:reading_end]
+    assert 'data-testid="note-outline"' not in reading_region
+
+
+# ---------------------------------------------------------------------------
+# AC: collapsed mode has a reopen affordance
+# ---------------------------------------------------------------------------
+
+
+def test_collapsed_mode_has_reopen_affordance():
+    nav = _left_nav(_html(body=_NO_HEADINGS))
+    assert 'data-left-panel-mode="collapsed"' in nav
+    reopen = re.search(
+        r'<button[^>]*data-testid="workspace-left-panel-reopen"[^>]*>(.*?)</button>',
+        nav,
+        re.S,
+    )
+    assert reopen, "collapsed mode must expose a reopen affordance"
+    assert "hidden" not in reopen.group(0), "reopen affordance must be visible when collapsed"
+
+
+# ---------------------------------------------------------------------------
+# AC: mode labels are human-facing, not debug strings
+# ---------------------------------------------------------------------------
+
+
+def test_mode_labels_are_human_facing():
+    nav = _left_nav(_html())
+    # Human-facing tab labels.
+    assert ">Browse</button>" in nav
+    assert ">Outline</button>" in nav
+    assert ">Context</button>" in nav
+    # Internal mode keys live in data-* attributes, not as visible copy.
+    assert ">browse</button>" not in nav
+    assert ">outline</button>" not in nav


### PR DESCRIPTION
Fixes #1399

## Summary
Makes the single left context panel mode-aware with four mutually-exclusive modes — browse, outline, context, collapsed — so the panel adapts to the current task instead of cold-opening into a noisy browser dump. Implements `ADAPTIVE_WORKSPACE_LAYOUT_HANDOFF.md` §4.

## Source docs read
- `companion-ui/docs/ADAPTIVE_WORKSPACE_LAYOUT_HANDOFF.md` §4 (panel model, §4.1–§4.4)
- `companion-ui/docs/MLP_INTERACTION_DESIGN_HANDOFF.md`, `companion-ui/docs/UI_RUNTIME_BOUNDARIES.md`, `docs/COMPANION_UI_PRODUCT_SPEC.md`

## Handoff sections applied
§4 (left context panel model).

## Changes
- New `_render_left_context_panel()`: a mode switcher with human-facing tab labels (Browse / Outline / Context) + a collapse control, plus one content region per mode. Internal mode keys live only in `data-*` attributes.
- Default-mode policy (§4): a note with headings opens in **outline**; a note without headings opens **collapsed** — never a cold-start browser dump.
- The outline now lives **inside** the left panel (outline mode) and is removed from the central reading layout, which becomes single-column. `.note-reading-layout--single` overrides the 2-column rule from `note_outline_css()` by specificity, so that CSS and `test_note_outline` stay untouched.
- New `leftPanel` JS controller (`setMode`/`collapse`/`reopen`): mutual-exclusive mode visibility, last-non-collapsed-mode memory, and a visible reopen affordance in collapsed mode. `vaultBrowser.focus()` (from #1398) now also activates browse mode. The 800–1099px outline ribbon triggers outline mode.
- Registered the new panel containers in the orphan-text whitelist (`tests/companion_ui/_orphan_text.py`).
- New `tests/companion_ui/test_left_context_panel_modes.py` (7 cases): declared modes, one-visible-at-a-time, outline/collapsed default (not browser dump), browse-action activates browse mode, outline uses the same slot (not a second pane), collapsed reopen affordance, human-facing labels.

## Authority / guardrail notes
No new Vault Browser capabilities, no saved views/graph/timeline, no collapsing of Vault Browser/Outline/Panel/Canvas/Find/Reorient/Resurface semantics, no new runtime writes, no direct vault access, no local override of runtime/WriteGuard state. Pure projection + client-side mode toggling. Stable `data-*` markers preserved; outline renderer output (`render_note_outline`) reused unchanged.

## Tests run
- `test_left_context_panel_modes.py` → 7 passed.
- Suggested validation `test_left_context_panel_modes.py + test_workspace_layout.py + test_note_outline.py + test_vault_browser.py` → 42 passed.
- Adjacency check (`+ test_workspace_responsive.py + test_vault_browser_single_surface.py`) → 62 passed (outline, responsive ribbon/sheet, #1397, #1398 all intact).
- Full `tests/companion_ui/` → 1155 passed, 4 failed. **All 4 failures are the pre-existing baseline on clean `main`** (2× `test_mermaid_block_renderer` TypeError in `app/api/routes/companion.py:562`, `test_renders_runtime_safety_strip_and_identity_pills`, `test_workspace_resurface_source_link_uses_logical_identifier`). The orphan-text and shell-alignment suites pass (new containers whitelisted).
- `python3 scripts/docs_guard.py` → OK
- `git diff --check` → clean
- `python3 -m ruff check app tests companion-ui/companion-app/companion_ui` → 1 error (F541) at `serve_dev_page.py:1961` in the reorient idle section. **Pre-existing** (not my changed lines; #1401 area).

## Browser UAT
Deferred to parent (#1395) remote-client UAT. Mode switching/collapse/reopen are client-side JS that warrant real-browser confirmation (the SSR default-mode render and markup contract are unit-covered here).

## Known limitations / lifecycle
- Dispatcher unavailable (`db_exists: false`) — GitHub-label-only flow; issue not labeled `agent:ready`.
- Codex code review is rate-limited (usage limits reached) and did not run; relying on green CI + local verification.
- At 800–1099px the existing `.note-outline { display:none }` responsive rule still applies to the in-panel outline; the ribbon remains the narrow-viewport outline affordance. Full narrow-viewport mode polish is left to follow-up to keep this PR bounded to the desktop mode model.

---