### PR TITLE
fix(companion-ui): scale Vault Browser list to folders and 40+ artifacts (#1400)

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -1660,7 +1660,10 @@ def _render_vault_browser(
     # but excluded from the visible nav list (#1361).
     hidden_count = sum(1 for n in notes if _should_hide_note_by_default(n))
 
-    rows: list[str] = []
+    # §6 — group rows by folder so the list stays scannable at 40+ artifacts.
+    # Insertion order is preserved (dicts are ordered) so any server ordering
+    # intent survives; each folder header is emitted once.
+    grouped: dict[str, list[str]] = {}
     for note in notes:
         path = str(note.get("note_path") or "").strip()
         if not path:
@@ -1669,6 +1672,8 @@ def _render_vault_browser(
         zone = _e(note.get("zone") or "root")
         href = "/?note_path=" + quote(path, safe="/")
         active = "true" if path == note_path else "false"
+        folder = path.rsplit("/", 1)[0] if "/" in path else "(root)"
+        filename = path.rsplit("/", 1)[-1]
 
         # Per-note metadata badges: hidden from the nav list by default (daily-use
         # visibility pass). The inspector panel shows the full metadata. These
@@ -1714,21 +1719,36 @@ def _render_vault_browser(
         row_hidden_attr = " hidden" if nav_hidden else ""
         row_nav_attr = ' data-nav-visible="false"' if nav_hidden else ""
 
-        rows.append(
+        # §6.1/§6.3 — title leads; the path is compact (filename only, with the
+        # full absolute path preserved in the title attribute as a details
+        # affordance). Raw metadata stays in the nav-hidden badges above.
+        grouped.setdefault(folder, []).append(
             f"""
           <li class="vault-browser-row{row_extra_class}" data-testid="workspace-vault-browser-note-row" data-active="{active}"{row_kind_attr}{row_companion_attr}{row_nav_attr}{row_hidden_attr}>
-            <a href="{href}" data-testid="workspace-vault-browser-note-link">{title}</a>
-            <code data-testid="workspace-vault-browser-note-path">{_e(path)}</code>
+            <a href="{href}" class="vault-browser-row-title" data-testid="workspace-vault-browser-note-link">{title}</a>
+            <code class="vault-browser-row-path" data-testid="workspace-vault-browser-note-path" title="{_e(path)}">{_e(filename)}</code>
             <span data-testid="workspace-vault-browser-note-zone" class="vault-browser-zone-label">{zone}</span>
             {badges_html}
           </li>"""
         )
 
+    list_items: list[str] = []
+    for folder, folder_rows in grouped.items():
+        folder_label = _e(folder)
+        list_items.append(
+            '<li class="vault-browser-group" '
+            'data-testid="workspace-vault-browser-group" '
+            f'data-folder="{folder_label}">'
+            f'<span class="vault-browser-group-label" title="{folder_label}">'
+            f"{folder_label}</span></li>"
+        )
+        list_items.extend(folder_rows)
+
     list_html = (
         '<ul class="vault-browser-list" data-testid="workspace-vault-browser-list">'
-        + "".join(rows)
+        + "".join(list_items)
         + "</ul>"
-        if rows
+        if list_items
         else ""
     )
     read_only_text = "read-only" if read_only else "mutating"
@@ -4817,6 +4837,41 @@ def render_index_html(
       margin: 0;
       overflow-y: auto;
       padding: 0;
+    }}
+    /* §6 — density: folder group headers + compact, truncating rows. */
+    .vault-browser-group {{
+      list-style: none;
+      padding: 8px 4px 2px;
+      position: sticky;
+      top: 0;
+      background: var(--bg-surface);
+      z-index: 1;
+    }}
+    .vault-browser-group-label {{
+      color: var(--fg-3);
+      display: block;
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      letter-spacing: 0.04em;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }}
+    .vault-browser-row-title {{
+      display: block;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }}
+    .vault-browser-row-path {{
+      color: var(--fg-3);
+      direction: rtl;
+      display: block;
+      font-size: var(--text-xs);
+      overflow: hidden;
+      text-align: left;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }}
     .vault-browser-item {{
       border-bottom: 1px solid var(--border);

--- a/tests/companion_ui/_orphan_text.py
+++ b/tests/companion_ui/_orphan_text.py
@@ -90,6 +90,8 @@ CONTAINER_TESTIDS: frozenset[str] = frozenset(
         "workspace-vault-browser-provenance",
         "workspace-vault-browser-state-identity-unavailable",
         "vault-browse-button",
+        # Vault browser density: folder group headers (§6 / #1400)
+        "workspace-vault-browser-group",
         # Body edit panel
         "workspace-body-edit-submit",
         "workspace-body-edit-reset",

--- a/tests/companion_ui/test_vault_browser_density.py
+++ b/tests/companion_ui/test_vault_browser_density.py
@@ -1,0 +1,246 @@
+"""Vault Browser density and 40+ artifact scale (#1400).
+
+Applies ``ADAPTIVE_WORKSPACE_LAYOUT_HANDOFF.md`` §6: the browse list must stay
+scannable at 40+ artifacts across nested directories. Rows lead with the
+title and a compact folder/path context, the list scrolls inside the left
+panel without clamping the note pane, raw metadata stays out of primary row
+text, companion notes are distinguishable without noisy badges, and long paths
+are truncated / moved to a details affordance.
+
+SSR markup/contract tests against the rendered dev-page HTML.
+"""
+
+from __future__ import annotations
+
+import re
+
+from companion_ui.workspace.serve_dev_page import render_index_html
+
+
+def _dense_notes(count: int = 42) -> list[dict]:
+    folders = [
+        "projects/alpha",
+        "projects/beta/sub",
+        "research/papers",
+        "research/notes/2026",
+        "daily/2026/05",
+        "reference",
+    ]
+    notes = []
+    for i in range(count):
+        folder = folders[i % len(folders)]
+        path = f"{folder}/note-{i:02d}.md"
+        notes.append(
+            {
+                "note_path": path,
+                "title": f"Artifact {i:02d} title",
+                "zone": folder.split("/")[0],
+                "kind": "human_note",
+            }
+        )
+    return notes
+
+
+def _fields(*, notes: list[dict], note_path: str = "projects/alpha/note-00.md") -> dict:
+    return {
+        "title": "Note Title",
+        "note_path": note_path,
+        "artifact_id": "art-123",
+        "artifact_kind": "human_note",
+        "artifact_identity_source": "frontmatter.uuid",
+        "artifact_identity_state": "resolved",
+        "artifact_companion_of": None,
+        "artifact_owns_identity": True,
+        "content_hash": "sha256-aaa",
+        "body": "# Note\n\nBody content here.",
+        "panel_rail": "Panel / agent rail placeholder",
+        "runtime_environment_label": "dev",
+        "runtime_api_base_url_label": "local-dev",
+        "runtime_trace_id": "trace-1",
+        "runtime_vault_name": "vault/dev",
+        "runtime_vault_channel": "local-dev",
+        "runtime_vault_provenance": "resolved",
+        "canvas_session_state": "idle",
+        "canvas_session_persistence": "durable",
+        "panel_state": "idle",
+        "panel_proposal_count": 0,
+        "panel_proposals": [],
+        "panel_message": "",
+        "guard_writeguard_status": "ok",
+        "guard_canvas_enabled": True,
+        "guard_degraded": False,
+        "guard_workspace_update_available": True,
+        "guard_update_flow_available": True,
+        "find_candidates": [],
+        "find_payload_available": False,
+        "reorient_sections": {},
+        "resurface_candidates": [],
+        "governance_receipts": [],
+        "suggestion_state": "idle",
+        "suggestion_composer_enabled": True,
+        "is_production_ui": False,
+        "dev_page_label": "dev/staging",
+        "workspace_loaded_at": None,
+        # Vault browser payload
+        "vault_browser_notes": notes,
+        "vault_browser_query": "",
+        "vault_browser_total_notes": len(notes),
+        "vault_browser_filtered_notes": len(notes),
+        "vault_browser_read_only": True,
+        "vault_browser_identity_available": True,
+        "vault_browser_vault_name": "vault/dev",
+        "vault_browser_vault_channel": "dev",
+    }
+
+
+def _html(*, notes: list[dict] | None = None, note_path: str = "projects/alpha/note-00.md") -> str:
+    notes = _dense_notes() if notes is None else notes
+    return render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path=note_path,
+        fields=_fields(notes=notes, note_path=note_path),
+    )
+
+
+def _rows(html: str) -> list[str]:
+    return re.findall(
+        r'<li class="vault-browser-row[^"]*"[^>]*>.*?</li>', html, re.S
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC: 40+ artifacts with nested folders
+# ---------------------------------------------------------------------------
+
+
+def test_vault_browser_handles_40_artifacts_with_nested_folders():
+    html = _html()
+    rows = _rows(html)
+    assert len(rows) >= 40, f"expected >=40 rows, got {len(rows)}"
+    # Folder grouping renders a header per distinct folder; nested paths appear
+    # in the group folder markers.
+    groups = re.findall(r'data-testid="workspace-vault-browser-group"[^>]*data-folder="([^"]*)"', html)
+    assert groups, "expected folder group headers"
+    assert any("/" in g for g in groups), "expected nested folder group headers"
+    assert "projects/beta/sub" in groups
+
+
+# ---------------------------------------------------------------------------
+# AC: list scrolls inside the left panel, note pane stays visible
+# ---------------------------------------------------------------------------
+
+
+def test_browser_list_scrolls_inside_left_panel():
+    html = _html()
+    m = re.search(r"\n {4}\.vault-browser-list\s*\{(.*?)\n {4}\}", html, re.S)
+    assert m, ".vault-browser-list rule not found"
+    assert "overflow-y: auto;" in m.group(1)
+    # The note pane is not clamped away by the dense list.
+    assert 'data-testid="workspace-note-body"' in html
+    assert 'data-region="note-body"' in html
+
+
+# ---------------------------------------------------------------------------
+# AC: rows prioritize title and folder
+# ---------------------------------------------------------------------------
+
+
+def test_browser_rows_prioritize_title_and_folder():
+    html = _html()
+    rows = _rows(html)
+    assert rows
+    row = rows[0]
+    # Title (note-link) is the primary, first content of the row.
+    link_idx = row.index('data-testid="workspace-vault-browser-note-link"')
+    path_idx = row.index('data-testid="workspace-vault-browser-note-path"')
+    assert link_idx < path_idx, "title must precede the path in the row"
+    # Folder hierarchy is conveyed by group headers.
+    assert 'data-testid="workspace-vault-browser-group"' in html
+
+
+# ---------------------------------------------------------------------------
+# AC: rows do not dump raw metadata as primary text
+# ---------------------------------------------------------------------------
+
+
+def test_browser_rows_do_not_dump_raw_metadata():
+    note = {
+        "note_path": "projects/alpha/secret.md",
+        "title": "Secret Artifact",
+        "zone": "projects",
+        "kind": "human_note",
+        "review_state": "needs_review",
+        "trust": "asserted",
+    }
+    html = _html(notes=[note], note_path="projects/alpha/secret.md")
+    row = _rows(html)[0]
+    # review_state / trust are present only as nav-hidden metadata badges, never
+    # as bare primary row text.
+    for badge_testid, value in (
+        ("workspace-vault-browser-note-review-state", "needs_review"),
+        ("workspace-vault-browser-note-trust", "asserted"),
+    ):
+        badge = re.search(
+            rf'<span[^>]*data-testid="{badge_testid}"[^>]*>([^<]*)</span>', row
+        )
+        assert badge, f"{badge_testid} badge missing"
+        # the badge carrying the raw value is flagged nav-hidden
+        full = re.search(
+            rf'<span([^>]*)data-testid="{badge_testid}"', row
+        ).group(1)
+        assert "note-badge--nav-hidden" in full, f"{value} must be in a nav-hidden badge"
+
+
+# ---------------------------------------------------------------------------
+# AC: companion notes distinguishable without noisy badges
+# ---------------------------------------------------------------------------
+
+
+def test_companion_notes_are_distinguishable_without_noisy_badges():
+    note = {
+        "note_path": "projects/alpha/Note.companion.md",
+        "title": "Companion sidecar",
+        "zone": "projects",
+        "kind": "companion_note",
+    }
+    html = _html(notes=[note], note_path="projects/alpha/Note.companion.md")
+    rows = _rows(html)
+    assert rows
+    row = rows[0]
+    # Distinguished structurally...
+    assert "vault-browser-row--companion" in row
+    assert 'data-companion="true"' in row
+    # ...without a noisy visible kind badge (the kind marker stays nav-hidden).
+    kind = re.search(r'<span([^>]*)data-testid="workspace-vault-browser-note-kind"', row)
+    assert kind and "note-badge--nav-hidden" in kind.group(1)
+
+
+# ---------------------------------------------------------------------------
+# AC: long paths truncated or moved to details
+# ---------------------------------------------------------------------------
+
+
+def test_long_paths_are_truncated_or_moved_to_details():
+    long_folder = "projects/very/deeply/nested/area/with/many/segments"
+    note = {
+        "note_path": f"{long_folder}/a-rather-long-note-filename.md",
+        "title": "Deep note",
+        "zone": "projects",
+        "kind": "human_note",
+    }
+    html = _html(notes=[note], note_path=f"{long_folder}/a-rather-long-note-filename.md")
+    row = _rows(html)[0]
+    path_el = re.search(
+        r'<code[^>]*data-testid="workspace-vault-browser-note-path"[^>]*>([^<]*)</code>',
+        row,
+    )
+    assert path_el, "note-path element missing"
+    # Full absolute path is preserved in a details affordance (title attribute),
+    # while the visible text is compact (not the whole nested path).
+    open_tag = re.search(
+        r'<code[^>]*data-testid="workspace-vault-browser-note-path"[^>]*>', row
+    ).group(0)
+    assert f'title="{long_folder}/a-rather-long-note-filename.md"' in open_tag
+    assert path_el.group(1).strip() != f"{long_folder}/a-rather-long-note-filename.md"
+    # A truncation style exists for the path.
+    assert ".vault-browser-row-path" in html


### PR DESCRIPTION
Fixes #1400

## Summary
Makes the Vault Browser list scannable at realistic density (40+ artifacts, nested folders): folder grouping, title-first rows, compact path with full path behind a details affordance, and in-panel scroll. Implements `ADAPTIVE_WORKSPACE_LAYOUT_HANDOFF.md` §6.

## Source docs read
- `companion-ui/docs/ADAPTIVE_WORKSPACE_LAYOUT_HANDOFF.md` §6 (row layout, grouping, metadata visibility)
- `companion-ui/docs/VAULT_BROWSER_UI_REQUIREMENTS.md`, `docs/VAULT_BROWSER_CAPABILITY_CONTRACT.md`, `docs/CONCEPTS/COMPANION_NOTE_CONTRACT.md`

## Handoff sections applied
§6 (Vault Browser density and scale).

## Changes
- Rows are grouped by folder; each folder renders a sticky `vault-browser-group` header once.
- Row primary text leads with the title; the path is compact (filename only) with the full absolute path in the `title` attribute (details affordance).
- Truncation styles for title (`vault-browser-row-title`), path (`vault-browser-row-path`, middle-truncation via rtl), and group label; list keeps `overflow-y:auto` so the central note pane is unaffected.
- Raw metadata (kind/review_state/trust) remains in the existing nav-hidden badges; companion notes keep `vault-browser-row--companion` + `data-companion` without a noisy visible badge.
- Whitelisted the folder group header in `tests/companion_ui/_orphan_text.py`.
- New `tests/companion_ui/test_vault_browser_density.py` (6 cases): 40+ artifacts with nested folders, in-panel scroll + note pane intact, title/folder priority, no raw-metadata dump, companion distinguishable without noisy badges, long paths truncated/moved to details.

## Authority / guardrail notes
No graph/timeline/saved views/relation browsing, no change to Vault Browser authority or filtering semantics, no hidden writes, no local kind inference (kind comes from server-supplied fields), no DB-over-vault authority. Stable `data-*` row testids preserved (note-row/link/path/zone/kind/review-state/trust). Server-side filtering and same-origin behaviour untouched.

## Tests run
- `test_vault_browser_density.py` → 6 passed.
- Validation matrix `test_vault_browser_density.py + test_vault_browser.py + tests/api/test_companion_vault_browser_filters.py` → 40 passed.
- Full `tests/companion_ui/` → 1161 passed, 4 failed. **All 4 failures are the pre-existing baseline on clean `main`** (2× `test_mermaid_block_renderer` TypeError `app/api/routes/companion.py:562`, `test_renders_runtime_safety_strip_and_identity_pills`, `test_workspace_resurface_source_link_uses_logical_identifier`); none touch this PR's changed lines.
- `python3 scripts/docs_guard.py` → OK
- `git diff --check` → clean
- `python3 -m ruff check app tests companion-ui/companion-app/companion_ui` → 1 error (F541) at `serve_dev_page.py:1981` in the reorient idle section. **Pre-existing**; not my changed lines (#1401 area).

## Browser UAT
Deferred to parent (#1395) remote-client UAT (the 40+ files/nested-folder scenario and in-panel scroll are explicit UAT items in handoff §12). Dev runtime LAN URL not reachable from this build environment.

## Known limitations / lifecycle
- Dispatcher unavailable (`db_exists: false`) — GitHub-label-only flow; issue not labeled `agent:ready`.
- Codex code review is rate-limited (usage limits reached) and did not run; relying on green CI + local verification.
- Folder ordering follows server note order (insertion order); explicit alphabetical/zone sorting is out of scope for this density pass.

---