### PR TITLE
fix(companion-ui): collapse non-actionable right rail states (#1401)

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -912,6 +912,41 @@ def _render_note_section(fields: dict) -> str:
         governance_receipts_count=len(fields.get("governance_receipts") or []),
         suggestion_state=str(fields.get("suggestion_state", "idle") or "idle"),
     )
+
+    # §§8–9 — right rail compaction. The rail stays expanded only when it has
+    # actionable or safety-critical content. Otherwise the idle/unavailable
+    # cards collapse behind one compact posture treatment.
+    _panel_last_response = fields.get("panel_last_response") or {}
+    rail_safety_critical = (
+        writeguard_blocked
+        or recovery_needed
+        or conflict_detected
+        or guard_degraded
+        or vault_unreachable
+    )
+    rail_actionable = bool(
+        rail_safety_critical
+        or proposal_count > 0
+        or bool(panel_proposals)
+        or bool(_panel_last_response)
+        or canvas_session_state_raw not in {"idle", "", "unknown"}
+        or panel_state_raw not in {"idle", "", "unknown"}
+        or bool(panel_message_raw)
+        or len(fields.get("find_candidates") or []) > 0
+        or bool(fields.get("reorient_sections"))
+        or len(fields.get("resurface_candidates") or []) > 0
+        or len(fields.get("governance_receipts") or []) > 0
+        or len(fields.get("suggestion_cards") or []) > 0
+        or str(fields.get("suggestion_state", "idle") or "idle") not in {"idle", "", "unknown"}
+    )
+    rail_posture_token = "active" if rail_actionable else "idle"
+    if rail_safety_critical:
+        rail_posture_copy = "Companion &middot; needs attention"
+    elif rail_actionable:
+        rail_posture_copy = "Companion &middot; active"
+    else:
+        rail_posture_copy = "Companion &middot; idle — no active proposals."
+
     guard_messages: list[str] = []
     if writeguard_status.lower() == "blocked":
         guard_messages.append("WriteGuard blocked")
@@ -1052,6 +1087,52 @@ def _render_note_section(fields: dict) -> str:
         identity_state_label=identity_state,
     )
 
+    # §§8–9 — compact posture chip + the detailed rail cards. When the rail is
+    # not actionable, the idle cards collapse behind one details affordance so
+    # the rail stops acting as a permanent status dump.
+    rail_posture_html = (
+        '<div class="rail-posture" data-testid="workspace-rail-posture" '
+        f'data-rail-posture="{rail_posture_token}">{rail_posture_copy}</div>'
+    )
+    rail_cards_inner = f"""
+        <div class="rail-state-row" data-testid="workspace-canvas-state">
+          <span class="rail-state-label">Canvas</span>
+          <span class="rail-state-value" data-canvas-state="{canvas_state}">{canvas_state_copy}</span>
+        </div>
+        {canvas_controls_html}
+        {active_note_body_update_html}
+        <div class="rail-state-row">
+          <span class="rail-state-label">Panel</span>
+          <span class="rail-state-value" data-testid="workspace-panel-label">{panel_label}</span>
+          <span class="rail-state-count" data-testid="workspace-panel-proposal-count">{proposal_text}</span>
+        </div>
+        {panel_message_html}
+        {proposal_rows_html}
+        {panel_response_html}
+        {suggestion_flow_html}
+        {suggestion_cards_html}
+        {shortcut_html}
+        {governance_receipts_html}
+        {find_mode_html}
+        {reorient_mode_html}
+        {resurface_mode_html}
+        {act_mode_html}
+        {guard_html}
+        {persistence_html}
+        {panel_rail}
+        {rail_empty_state_html}"""
+    if rail_actionable:
+        rail_body_html = (
+            f'<div class="rail-placeholder-body">{rail_cards_inner}\n      </div>'
+        )
+    else:
+        rail_body_html = (
+            '<div class="rail-placeholder-body">'
+            '<details class="rail-idle-details" data-testid="workspace-rail-idle-details">'
+            '<summary class="rail-idle-summary">Companion details</summary>'
+            f"{rail_cards_inner}\n      </details></div>"
+        )
+
     return f"""
   <div class="workspace-layout workspace-layout--three-col">
     {left_context_panel_html}
@@ -1103,34 +1184,8 @@ def _render_note_section(fields: dict) -> str:
         <span class="rail-label" data-panel-state="{panel_state}">{'Panel&nbsp;&middot;&nbsp;idle' if panel_state_raw == 'idle' else 'Panel'}</span>
         <span class="rail-badge" data-testid="workspace-panel-state" data-panel-state="{panel_state}">{panel_state_copy}</span>
       </div>
-      <div class="rail-placeholder-body">
-        <div class="rail-state-row" data-testid="workspace-canvas-state">
-          <span class="rail-state-label">Canvas</span>
-          <span class="rail-state-value" data-canvas-state="{canvas_state}">{canvas_state_copy}</span>
-        </div>
-        {canvas_controls_html}
-        {active_note_body_update_html}
-        <div class="rail-state-row">
-          <span class="rail-state-label">Panel</span>
-          <span class="rail-state-value" data-testid="workspace-panel-label">{panel_label}</span>
-          <span class="rail-state-count" data-testid="workspace-panel-proposal-count">{proposal_text}</span>
-        </div>
-        {panel_message_html}
-        {proposal_rows_html}
-        {panel_response_html}
-        {suggestion_flow_html}
-        {suggestion_cards_html}
-        {shortcut_html}
-        {governance_receipts_html}
-        {find_mode_html}
-        {reorient_mode_html}
-        {resurface_mode_html}
-        {act_mode_html}
-        {guard_html}
-        {persistence_html}
-        {panel_rail}
-        {rail_empty_state_html}
-      </div>
+      {rail_posture_html}
+      {rail_body_html}
     </aside>
     <div class="workspace-panel-peek" data-testid="workspace-panel-peek"
       data-layout-visible="1100-1299"
@@ -1978,7 +2033,7 @@ def _render_reorient_mode(sections: dict[str, list[dict]]) -> str:
     has_content = bool(sections) and any(sections.get(name) for name in sections)
     if not has_content:
         # Idle: single line with collapsed recall disclosure (AC3 §8.3)
-        return f"""
+        return """
         <section
           class="reorient-mode panel-section"
           data-testid="reorient-mode"
@@ -4135,6 +4190,26 @@ def render_index_html(
     }}
 
     /* ---- Agent rail ---- */
+    /* §§8–9 — compact posture chip + collapsed idle details. */
+    .rail-posture {{
+      color: var(--fg-2);
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      padding: 6px 10px;
+    }}
+    .rail-posture[data-rail-posture="active"] {{ color: var(--fg-1); }}
+    .rail-idle-details {{
+      border-top: 1px solid var(--border);
+      margin-top: 4px;
+    }}
+    .rail-idle-summary {{
+      color: var(--fg-3);
+      cursor: pointer;
+      font-size: var(--text-xs);
+      list-style: none;
+      padding: 6px 10px;
+    }}
+    .rail-idle-summary::-webkit-details-marker {{ display: none; }}
     .agent-rail {{
       width: 280px;
       flex-shrink: 0;

--- a/tests/companion_ui/test_right_rail_compaction.py
+++ b/tests/companion_ui/test_right_rail_compaction.py
@@ -1,0 +1,194 @@
+"""Right rail compaction for non-actionable states (#1401).
+
+Applies ``ADAPTIVE_WORKSPACE_LAYOUT_HANDOFF.md`` §§8, 9, 11: the right
+companion rail must earn its space. When only non-actionable states exist (no
+proposals, no candidates, Canvas idle/disabled, Find unavailable, Resurface
+degraded, suggestions idle, generic persistence), the rail collapses the noisy
+idle cards into a single compact posture treatment. Actionable and
+safety-critical states — active Panel proposal, Panel receipt/block reason,
+WriteGuard block, Canvas recovery/conflict — keep the rail expanded. Internal
+runtime/test labels must not leak into the default human copy.
+
+SSR markup/contract tests against the rendered dev-page HTML.
+"""
+
+from __future__ import annotations
+
+from companion_ui.workspace.serve_dev_page import render_index_html
+
+_IDLE_TOKENS = (
+    "in_memory",
+    "SUGGESTION idle",
+    "FIND unavailable",
+    "composer enabled",
+    "user not present",
+)
+
+
+def _fields(**overrides) -> dict:
+    base = {
+        "title": "Note Title",
+        "note_path": "Notes/note.md",
+        "artifact_id": "art-123",
+        "artifact_kind": "human_note",
+        "artifact_identity_source": "frontmatter.uuid",
+        "artifact_identity_state": "resolved",
+        "artifact_companion_of": None,
+        "artifact_owns_identity": True,
+        "content_hash": "sha256-aaa",
+        "body": "# Note\n\nBody content here.",
+        "panel_rail": "Panel / agent rail placeholder",
+        "runtime_environment_label": "dev",
+        "runtime_api_base_url_label": "local-dev",
+        "runtime_trace_id": "trace-1",
+        "runtime_vault_name": "vault/dev",
+        "runtime_vault_channel": "local-dev",
+        "runtime_vault_provenance": "resolved",
+        "canvas_session_state": "idle",
+        "canvas_session_persistence": "in_memory",
+        "panel_state": "idle",
+        "panel_proposal_count": 0,
+        "panel_proposals": [],
+        "panel_message": "",
+        "panel_last_response": {},
+        "guard_writeguard_status": "ok",
+        "guard_canvas_enabled": True,
+        "guard_degraded": False,
+        "guard_workspace_update_available": True,
+        "guard_update_flow_available": True,
+        "find_candidates": [],
+        "find_payload_available": False,
+        "reorient_sections": {},
+        "resurface_candidates": [],
+        "governance_receipts": [],
+        "suggestion_state": "idle",
+        "suggestion_composer_enabled": True,
+        "is_production_ui": False,
+        "dev_page_label": "dev/staging",
+        "workspace_loaded_at": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def _html(**overrides) -> str:
+    return render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="Notes/note.md",
+        fields=_fields(**overrides),
+    )
+
+
+def _rail(html: str) -> str:
+    start = html.index('data-testid="workspace-agent-rail"')
+    end = html.index("</aside>", start)
+    return html[start:end]
+
+
+# ---------------------------------------------------------------------------
+# AC: compact non-actionable states
+# ---------------------------------------------------------------------------
+
+
+def test_right_rail_compacts_non_actionable_states():
+    rail = _rail(_html())
+    # A single compact posture treatment is present...
+    assert 'data-testid="workspace-rail-posture"' in rail
+    assert 'data-rail-posture="idle"' in rail
+    # ...and the noisy idle cards are collapsed behind one details affordance.
+    assert 'data-testid="workspace-rail-idle-details"' in rail
+
+
+# ---------------------------------------------------------------------------
+# AC: does not render multiple idle cards
+# ---------------------------------------------------------------------------
+
+
+def test_right_rail_does_not_render_multiple_idle_cards():
+    rail = _rail(_html())
+    posture_idx = rail.index('data-testid="workspace-rail-posture"')
+    details_idx = rail.index('data-testid="workspace-rail-idle-details"')
+    # Exactly one compact posture group is the default visible treatment.
+    assert rail.count('data-testid="workspace-rail-posture"') == 1
+    # The idle canvas/panel cards live inside the collapsed details, not as
+    # separate top-level cards above it.
+    canvas_idx = rail.index('data-testid="workspace-canvas-state"')
+    assert posture_idx < details_idx < canvas_idx
+
+
+# ---------------------------------------------------------------------------
+# AC: active Panel proposal keeps the rail expanded
+# ---------------------------------------------------------------------------
+
+
+def test_active_panel_proposal_keeps_rail_expanded():
+    proposals = [
+        {
+            "proposal_id": "p1",
+            "summary": "Add a link",
+            "action_mode": "confirm_required",
+            "status": "staged",
+        }
+    ]
+    rail = _rail(_html(panel_state="proposals-staged", panel_proposal_count=1, panel_proposals=proposals))
+    # Rail is expanded (no idle compaction) and the proposal is visible.
+    assert 'data-testid="workspace-rail-idle-details"' not in rail
+    assert 'data-rail-posture="active"' in rail
+
+
+# ---------------------------------------------------------------------------
+# AC: receipt / block reason keeps the outcome visible
+# ---------------------------------------------------------------------------
+
+
+def test_panel_receipt_or_block_reason_keeps_outcome_visible():
+    response = {
+        "status": "executed",
+        "receipt": {
+            "receipt_id": "r1",
+            "outcome": "applied",
+            "message": "done",
+            "persistence": "durable",
+        },
+    }
+    rail = _rail(_html(panel_last_response=response))
+    assert 'data-testid="workspace-rail-idle-details"' not in rail
+    assert 'data-testid="workspace-panel-receipt"' in rail
+
+
+# ---------------------------------------------------------------------------
+# AC: WriteGuard block overrides compaction
+# ---------------------------------------------------------------------------
+
+
+def test_writeguard_block_overrides_compaction():
+    rail = _rail(_html(guard_writeguard_status="blocked"))
+    assert 'data-testid="workspace-rail-idle-details"' not in rail
+    assert 'data-testid="workspace-guard-indicator"' in rail
+
+
+# ---------------------------------------------------------------------------
+# AC: Canvas recovery / conflict overrides compaction
+# ---------------------------------------------------------------------------
+
+
+def test_canvas_recovery_overrides_compaction():
+    rail = _rail(_html(canvas_recovery_needed=True))
+    assert 'data-testid="workspace-rail-idle-details"' not in rail
+
+
+# ---------------------------------------------------------------------------
+# AC: internal labels do not leak into the default copy
+# ---------------------------------------------------------------------------
+
+
+def test_internal_labels_do_not_leak_to_default_copy():
+    html = _html()
+    rail = _rail(html)
+    details_idx = rail.index('data-testid="workspace-rail-idle-details"')
+    head = rail[:details_idx]
+    # The default (pre-details) rail copy is the human posture line...
+    assert "Companion" in head
+    # ...and carries no internal/test labels (those live behind the details).
+    for token in _IDLE_TOKENS:
+        assert token not in head, f"internal label {token!r} leaked into default rail copy"


### PR DESCRIPTION
Fixes #1401

## Summary
Makes the right companion rail earn its space: when only non-actionable states exist it collapses the noisy idle cards into one compact posture treatment, while actionable and safety-critical states keep the rail expanded. Implements `ADAPTIVE_WORKSPACE_LAYOUT_HANDOFF.md` §§8, 9, 11.

## Source docs read
- `companion-ui/docs/ADAPTIVE_WORKSPACE_LAYOUT_HANDOFF.md` §§8 (right rail), 9 (state hierarchy), 11 (human-facing copy)
- `companion-ui/docs/PANEL_COMPANION_UI_CONTRACT.md`, `companion-ui/docs/CANVAS_SUGGESTION_FLOW.md`, `companion-ui/docs/UI_RUNTIME_BOUNDARIES.md`

## Handoff sections applied
§§8, 9, 11.

## Changes
- Added a server-side `rail_actionable` computation. The rail expands only for actionable/safety-critical content: active Panel proposal, Panel receipt/block reason (`panel_last_response`), WriteGuard block, Canvas recovery/conflict, active Canvas edit session, actionable Reorient, live find/resurface/governance/suggestion content, or runtime degraded/unavailable.
- When non-actionable: render one compact posture chip (`workspace-rail-posture`, `data-rail-posture="idle"`, "Companion · idle — no active proposals.") and collapse the idle canvas/panel/find/resurface/persistence cards behind a single `<details data-testid="workspace-rail-idle-details">`. All existing `data-*` markers stay in the DOM.
- Safety-critical signals override compaction (posture `needs attention`, rail expanded).
- Internal/test labels (`in_memory`, `SUGGESTION idle`, `FIND unavailable`, …) stay behind the details affordance, out of the default posture copy (§11).
- Fixed a pre-existing F541 (f-string without placeholders) in the reorient idle section — reorient renders in this rail — so the ruff gate is clean.
- New `tests/companion_ui/test_right_rail_compaction.py` (7 cases): compacts non-actionable states, no multiple idle cards, active proposal keeps expanded, receipt/block keeps outcome visible, WriteGuard block overrides, Canvas recovery overrides, internal labels do not leak.

## Authority / guardrail notes
No critical safety state hidden (overrides keep blocked/recovery/degraded expanded). No unavailable action made to look active. No change to Panel/Canvas runtime semantics, no new write paths, no direct vault access. Compaction is presentation-only; diagnostic state moves behind the details affordance rather than being removed. Stable `data-*` markers preserved.

## Tests run
- `test_right_rail_compaction.py` → 7 passed.
- Validation matrix (`test_right_rail_compaction.py` + panel-confirm/canvas-edit/canvas-recovery/find/resurface/reorient browser) → 54 passed, 1 failed. The 1 failure (`test_workspace_resurface_source_link_uses_logical_identifier`) is a **pre-existing baseline** failure (`app/api/routes/companion.py:562` TypeError), unrelated to the rail.
- Full `tests/companion_ui/` → 1168 passed, 4 failed — exactly the pre-existing baseline (2× mermaid, safety-strip, resurface-source-link); no new regressions.
- `python3 scripts/docs_guard.py` → OK
- `git diff --check` → clean
- `python3 -m ruff check app tests companion-ui/companion-app/companion_ui` → **All checks passed!** (the previously pre-existing F541 is now fixed)

## Browser UAT
Deferred to parent (#1395) remote-client UAT (rail compact-vs-expanded across idle and critical states is an explicit handoff §12 UAT item). Dev runtime LAN URL not reachable from this build environment.

## Known limitations / lifecycle
- Dispatcher unavailable (`db_exists: false`) — GitHub-label-only flow; issue not labeled `agent:ready`.
- Codex code review is rate-limited (usage limits reached) and did not run; relying on green CI + local verification.

---