### PR TITLE
fix(companion-ui): remove raw metadata leakage from Vault Browser rows (#1417)

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -1657,10 +1657,18 @@ def _render_filter_chips(
             )
     if not chips_html:
         return ""
+    # #1417 — the Kind:/Zone:/Review:/Trust: facets are filtering controls, not a
+    # default reading surface. Keep them (and their wiring) but tuck them behind a
+    # collapsed "Filters" disclosure so they do not dump raw metadata into the
+    # default Browse view.
     return (
+        '<details class="vault-browser-filters-disclosure">'
+        '<summary class="vault-browser-filters-summary" '
+        'data-testid="workspace-vault-browser-filters-toggle">Filters</summary>'
         '<div class="vault-browser-filters" data-testid="workspace-vault-browser-filters">'
         + "".join(chips_html)
         + "</div>"
+        "</details>"
     )
 
 
@@ -3148,7 +3156,13 @@ def render_index_html(
       padding: 2px 10px 4px;
       display: block;
     }}
-    .note-badge--nav-hidden {{ opacity: 0.45; }}
+    /* #1417 — raw kind/review/trust metadata must not show as visible row text.
+       Keep the elements in the DOM (data-* compatibility) but hide them; the
+       inspector/disclosure carries the detail. */
+    .note-badge--nav-hidden {{ display: none; }}
+    /* #1417 — the raw zone value (e.g. 'inbox', '⚙ System') is navigation noise;
+       folder grouping already supplies path context. Hide it from row text. */
+    .vault-browser-zone-label {{ display: none; }}
 
     /* ---- Error state ---- */
     .error-state {{
@@ -4912,6 +4926,46 @@ def render_index_html(
       margin: 0;
       overflow-y: auto;
       padding: 0;
+    }}
+    /* #1417 — Filters tucked behind a collapsed disclosure; chips get light
+       chip chrome so the expanded view reads as controls, not a metadata dump. */
+    .vault-browser-filters-disclosure {{
+      border-bottom: 1px solid var(--border);
+      margin-bottom: 6px;
+      padding-bottom: 6px;
+    }}
+    .vault-browser-filters-summary {{
+      color: var(--fg-3);
+      cursor: pointer;
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      letter-spacing: 0.04em;
+      list-style: none;
+      padding: 2px 2px;
+    }}
+    .vault-browser-filters-summary::-webkit-details-marker {{ display: none; }}
+    .vault-browser-filters {{
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px;
+      padding-top: 6px;
+    }}
+    /* Deterministic collapse: do not rely on UA details behavior so the facets
+       are hidden from the default Browse view in every engine. */
+    .vault-browser-filters-disclosure:not([open]) > .vault-browser-filters {{
+      display: none;
+    }}
+    .filter-chip {{
+      background: var(--bg-raised);
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      color: var(--fg-2);
+      font-size: var(--text-xs);
+      padding: 2px 8px;
+    }}
+    .filter-chip[data-active="true"] {{
+      border-color: var(--border-focus);
+      color: var(--fg-1);
     }}
     /* §6 — density: folder group headers + compact, truncating rows. */
     .vault-browser-group {{

--- a/tests/companion_ui/test_vault_browser_density.py
+++ b/tests/companion_ui/test_vault_browser_density.py
@@ -244,3 +244,73 @@ def test_long_paths_are_truncated_or_moved_to_details():
     assert path_el.group(1).strip() != f"{long_folder}/a-rather-long-note-filename.md"
     # A truncation style exists for the path.
     assert ".vault-browser-row-path" in html
+
+
+# ---------------------------------------------------------------------------
+# #1417 — raw metadata must not leak into visible Browse row text
+# ---------------------------------------------------------------------------
+
+
+def _css_block(html: str, selector_re: str) -> str:
+    m = re.search(r"\n {4}" + selector_re + r"\s*\{(.*?)\}", html, re.S)
+    assert m, f"CSS rule {selector_re!r} not found"
+    return m.group(1)
+
+
+def test_row_metadata_badges_are_hidden_not_dimmed():
+    # The kind/review/trust badges carry note-badge--nav-hidden; that class must
+    # hide them (display:none), not merely dim them (opacity), so raw metadata
+    # like "note"/"needs_review"/"asserted" never shows as visible row text.
+    html = _html()
+    block = _css_block(html, r"\.note-badge--nav-hidden")
+    assert "display: none" in block, "nav-hidden badges must be display:none"
+    assert "opacity:" not in block, "nav-hidden must not merely dim metadata"
+
+
+def test_row_zone_label_not_rendered_as_visible_text():
+    # The raw zone label (e.g. 'inbox', '⚙ System') must not show as primary row
+    # text; folder grouping already supplies path context. Element may remain in
+    # the DOM (for data-* compatibility) but must be hidden.
+    html = _html()
+    assert 'data-testid="workspace-vault-browser-note-zone"' in html  # preserved
+    block = _css_block(html, r"\.vault-browser-zone-label")
+    assert "display: none" in block, "zone label must be hidden from row text"
+
+
+def test_filter_chips_are_collapsed_behind_a_filters_disclosure():
+    # The Kind:/Zone:/Review:/Trust: filter facets must not dump into the default
+    # Browse view; they live behind a collapsed Filters disclosure.
+    html = _html()
+    # The filters region is wrapped in a <details> that is not open by default.
+    m = re.search(
+        r'<details([^>]*)class="[^"]*vault-browser-filters-disclosure[^"]*"[^>]*>(.*?)</details>',
+        html,
+        re.S,
+    )
+    assert m, "filter chips must be inside a vault-browser-filters-disclosure <details>"
+    assert "open" not in m.group(1), "Filters disclosure must be collapsed by default"
+    # The chips (with their wiring) are preserved inside the disclosure.
+    assert 'data-testid="vault-browser-filter-chip"' in m.group(2)
+    assert 'onclick="vbToggleFilter(this)"' in m.group(2)
+    # Human-facing summary label.
+    assert re.search(r"<summary[^>]*>\s*Filters", m.group(2) + m.group(0))
+
+
+def test_no_raw_kind_or_trust_label_in_default_visible_row_area():
+    # Belt-and-braces: the literal "Kind:" / "Trust:" / "Review:" label text only
+    # appears inside the collapsed Filters disclosure, never in a row.
+    note = {
+        "note_path": "📥 Inbox/Companion UI UAT.md",
+        "title": "Companion UI UAT",
+        "zone": "inbox",
+        "kind": "note",
+        "review_state": "needs_review",
+        "trust": "internal",
+    }
+    html = _html(notes=[note], note_path="📥 Inbox/Companion UI UAT.md")
+    row = _rows(html)[0]
+    for leak in ("Kind:", "Zone:", "Review:", "Trust:"):
+        assert leak not in row, f"row leaks raw metadata label {leak!r}"
+    # The concatenated metadata fragment seen in UAT (e.g. 'noteinboxinternal')
+    # must not appear as visible row text — those values live in hidden badges.
+    assert ">note<" not in row or "note-badge--nav-hidden" in row


### PR DESCRIPTION
Fixes #1417

## Summary
Browse Vault rows no longer dump raw metadata as visible text. Kind/review/trust badges are truly hidden, the raw zone label is hidden, and the Kind:/Zone:/Review:/Trust: filter facets are tucked behind a collapsed "Filters" disclosure. Detailed metadata remains in the existing artifact inspector (the sanctioned progressive-disclosure home).

## Source docs read
- `companion-ui/docs/VAULT_BROWSER_UI_REQUIREMENTS.md` (R1/R5/R7), `companion-ui/docs/ADAPTIVE_WORKSPACE_LAYOUT_HANDOFF.md` §6, `docs/COGNITIVE_PROSTHESIS_CHARTER.md`, `docs/COMPANION_UI_PRODUCT_SPEC.md`, `docs/HUMAN-FLOWS.md`
- bug-to-issue contract #1417; issue-to-code workflow

## Changes
- `.note-badge--nav-hidden`: `opacity:0.45` → `display:none` (kind/review/trust badges hidden from row text; elements kept in DOM for `data-*` compatibility).
- `.vault-browser-zone-label`: `display:none` (raw zone value no longer visible; folder grouping supplies path context).
- `_render_filter_chips`: wrapped in a collapsed `<details class="vault-browser-filters-disclosure">` ("Filters" summary) with deterministic collapse CSS (not UA-dependent) and light chip chrome; chip testids + `vbToggleFilter` wiring preserved.
- 4 regression tests added to `tests/companion_ui/test_vault_browser_density.py`.

## Authority / guardrail notes
No graph/timeline/saved views, no change to Vault Browser authority or server-side filtering semantics, no local kind inference, no hidden writes. Stable `data-*` row/chip testids preserved. Detailed metadata is not lost — it moves to the existing inspector (#1255), the issue's endorsed location, not duplicated into another default-visible area.

## Tests run
- `test_vault_browser_density.py` (incl. 4 new) → 10 passed.
- Matrix `test_vault_browser.py + test_vault_browser_single_surface.py + tests/api/test_companion_vault_browser_filters.py + test_orphan_text_nodes.py` → 49 passed.
- Full `tests/companion_ui/` → 1172 passed, 4 failed — the 4 are the documented pre-existing baseline (2× mermaid `app/api/routes/companion.py:562` TypeError, `test_renders_runtime_safety_strip_and_identity_pills`, `test_workspace_resurface_source_link_uses_logical_identifier`), unrelated to this change.
- `python3 scripts/docs_guard.py` → OK; `git diff --check` → clean; `python3 -m ruff check app tests companion-ui/companion-app/companion_ui` → **All checks passed!**

## Browser UAT (acceptance gate)
Local static render of the **real live vault paths** (fetched from the runtime's `/api/companion/vault/notes`) plus the kind/zone/review/trust metadata that produced the leakage, driven in a real browser (1280×800), Browse mode active.

- **Before** (user's live screenshot at `http://10.42.42.10:8111/?note_path=📥 Inbox/Companion_UI_Markdown_Feature_UAT.md`): filter dump "Kind: noteKind: test_note Zone:… Review:… Trust:…" and rows like "Companion UI UAT.md / noteinboxinternal".
- **After** (this PR): `preview_eval` on the rendered list region reports **zero** leak tokens (`Kind:`/`Zone:`/`Review:`/`Trust:`/`needs_review`/`test_note`/`internal`/`noteinbox`); rows render as `title | filename`; folder groups `(root)` / `📥 Inbox` / `⚙️ System` / `⚙️ System/companions`; the Filters disclosure is collapsed by default (chips `offsetParent === null`). Metadata appears only in the bottom inspector for the selected note.

## Known limitations
- The artifact inspector's label/value spacing (e.g. "kindnote") is a pre-existing cosmetic quirk in `_render_artifact_inspector`, out of scope for this row-leakage fix.
- Dispatcher claim used GitHub-label flow (removed `agent:ready`); Codex review is rate-limited and did not run — relying on green CI + documented browser UAT.

---