### PR TITLE
fix(companion-ui): move dev/operator chrome out of default workspace (#1418)

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -2914,6 +2914,7 @@ def render_index_html(
     fields: Optional[dict] = None,
     error: str = "",
     production_profile: bool = False,
+    diagnostics: bool = False,
 ) -> str:
     """Render the workspace dev page as a Companion UI visual shell.
 
@@ -3030,6 +3031,15 @@ def render_index_html(
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
+    }}
+    /* #1418 — dev/operator harness chrome is hidden in the default human
+       workspace and only revealed in diagnostics mode (?diagnostics=1). The
+       elements stay in the DOM for operator access + data-* compatibility. */
+    body[data-diagnostics="false"] .topbar,
+    body[data-diagnostics="false"] .dev-controls-disclosure,
+    body[data-diagnostics="false"] .workspace-dev-ribbon,
+    body[data-diagnostics="false"] .dev-chip {{
+      display: none;
     }}
     .dev-chip {{
       display: inline-block;
@@ -5029,7 +5039,7 @@ def render_index_html(
     }}
   </style>
 </head>
-<body>
+<body data-diagnostics="{'true' if diagnostics else 'false'}">
   <div class="topbar">
     <div class="topbar-api">
       <span class="api-label">Server-side runtime</span>
@@ -5343,6 +5353,8 @@ def handle_get(
     note_path = params.get("note_path", [""])[0].strip()
     _filter_keys = ("kind", "zone", "review_state", "trust")
     active_filters = {k: params[k] for k in _filter_keys if params.get(k)}
+    # #1418 — diagnostics/operator chrome is opt-in via an explicit route.
+    diagnostics = params.get("diagnostics", ["0"])[0].strip().lower() in {"1", "true", "yes", "on"}
     fields: Optional[dict] = None
     error = ""
 
@@ -5360,6 +5372,7 @@ def handle_get(
         fields=fields,
         error=error,
         production_profile=production_profile,
+        diagnostics=diagnostics,
     )
 
 

--- a/tests/companion_ui/test_workspace_dev_chrome_gating.py
+++ b/tests/companion_ui/test_workspace_dev_chrome_gating.py
@@ -1,0 +1,141 @@
+"""Dev/operator chrome gated out of the default workspace (#1418).
+
+Applies `ADAPTIVE_WORKSPACE_LAYOUT_HANDOFF.md` §§5.3, 11 and Vault Browser UI
+Requirements R5/R7: the default human workspace must not show dev/operator
+harness chrome (`SERVER-SIDE RUNTIME same-origin bridge`, `dev controls`, raw
+`NOTE_PATH`/`LOAD`, `DEV / not production` banner). Those controls remain
+available behind an explicit diagnostics route (`?diagnostics=1`). Elements stay
+in the DOM (data-* compatibility) but are hidden by default via CSS keyed on
+`body[data-diagnostics="false"]`.
+"""
+
+from __future__ import annotations
+
+import re
+
+from companion_ui.workspace.serve_dev_page import handle_get, render_index_html
+
+
+def _page(*, diagnostics: bool = False) -> str:
+    return render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="",
+        fields=None,
+        diagnostics=diagnostics,
+    )
+
+
+def test_default_workspace_marks_body_non_diagnostics():
+    html = _page()
+    m = re.search(r"<body[^>]*>", html)
+    assert m and 'data-diagnostics="false"' in m.group(0)
+
+
+def test_diagnostics_mode_marks_body_diagnostics():
+    html = _page(diagnostics=True)
+    m = re.search(r"<body[^>]*>", html)
+    assert m and 'data-diagnostics="true"' in m.group(0)
+
+
+def test_default_workspace_hides_dev_chrome_via_css():
+    html = _page()
+    # CSS hides each dev/operator chrome element when not in diagnostics mode.
+    for selector in (
+        r"\.topbar",
+        r"\.dev-controls-disclosure",
+        r"\.workspace-dev-ribbon",
+        r"\.dev-chip",
+    ):
+        rule = re.search(
+            r'body\[data-diagnostics="false"\][^{]*' + selector + r"[^{]*\{([^}]*)\}",
+            html,
+        )
+        assert rule, f"missing default-hide rule for {selector}"
+        assert "display: none" in rule.group(1)
+
+
+def test_dev_chrome_elements_remain_in_dom_for_diagnostics():
+    # The controls are not deleted — diagnostics mode can reveal them.
+    html = _page()
+    assert 'class="topbar"' in html
+    assert 'data-testid="workspace-dev-controls"' in html
+    assert 'id="note_path"' in html  # raw NOTE_PATH input present but hidden
+    assert "same-origin bridge" in html
+
+
+def test_human_header_strip_is_not_gated_by_diagnostics():
+    # The human-facing header (vault/runtime posture) must always be available.
+    fields = _min_fields()
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="Notes/n.md",
+        fields=fields,
+        diagnostics=False,
+    )
+    assert 'data-testid="workspace-vault-chip"' in html
+    # The header strip is not inside the diagnostics-gated chrome.
+    header_idx = html.index('data-testid="workspace-vault-chip"')
+    # The gated topbar appears before the workspace content; ensure the vault
+    # chip is not wrapped by a diagnostics-hidden container class.
+    assert 'class="workspace-diagnostics-chrome"' not in html[header_idx - 400:header_idx]
+
+
+def test_handle_get_threads_diagnostics_query_param():
+    html = handle_get(
+        query_string="diagnostics=1",
+        client=None,  # no note_path → no network
+        api_base_url="http://127.0.0.1:18001",
+    )
+    m = re.search(r"<body[^>]*>", html)
+    assert m and 'data-diagnostics="true"' in m.group(0)
+
+    html2 = handle_get(
+        query_string="",
+        client=None,
+        api_base_url="http://127.0.0.1:18001",
+    )
+    m2 = re.search(r"<body[^>]*>", html2)
+    assert m2 and 'data-diagnostics="false"' in m2.group(0)
+
+
+def _min_fields() -> dict:
+    return {
+        "title": "N",
+        "note_path": "Notes/n.md",
+        "artifact_id": "a",
+        "artifact_kind": "human_note",
+        "artifact_identity_source": "frontmatter.uuid",
+        "artifact_identity_state": "resolved",
+        "artifact_companion_of": None,
+        "artifact_owns_identity": True,
+        "content_hash": "h",
+        "body": "# N\n\nBody.",
+        "panel_rail": "rail",
+        "runtime_environment_label": "dev",
+        "runtime_api_base_url_label": "local-dev",
+        "runtime_trace_id": "t",
+        "runtime_vault_name": "vault/dev",
+        "runtime_vault_channel": "dev",
+        "runtime_vault_provenance": "resolved",
+        "canvas_session_state": "idle",
+        "canvas_session_persistence": "durable",
+        "panel_state": "idle",
+        "panel_proposal_count": 0,
+        "panel_proposals": [],
+        "panel_message": "",
+        "guard_writeguard_status": "ok",
+        "guard_canvas_enabled": True,
+        "guard_degraded": False,
+        "guard_workspace_update_available": True,
+        "guard_update_flow_available": False,
+        "find_candidates": [],
+        "find_payload_available": False,
+        "reorient_sections": {},
+        "resurface_candidates": [],
+        "governance_receipts": [],
+        "suggestion_state": "idle",
+        "suggestion_composer_enabled": True,
+        "is_production_ui": False,
+        "dev_page_label": "dev/staging",
+        "workspace_loaded_at": None,
+    }


### PR DESCRIPTION
Fixes #1418

## Summary
The default human workspace no longer shows dev/operator harness chrome. It's hidden by default and revealed only via an explicit `?diagnostics=1` route. Implements `ADAPTIVE_WORKSPACE_LAYOUT_HANDOFF.md` §§5.3, 11 and Vault Browser UI Requirements R5/R7.

## Source docs read
- `companion-ui/docs/ADAPTIVE_WORKSPACE_LAYOUT_HANDOFF.md` §§5.3, 11; `companion-ui/docs/VAULT_BROWSER_UI_REQUIREMENTS.md` R5/R7; `docs/COGNITIVE_PROSTHESIS_CHARTER.md`; `docs/COMPANION_UI_PRODUCT_SPEC.md`; `docs/HUMAN-FLOWS.md`
- bug-to-issue contract #1418; issue-to-code workflow

## Changes
- `render_index_html` gains a `diagnostics: bool = False` param; `handle_get` parses it from `?diagnostics=1` (`1/true/yes/on`).
- `<body data-diagnostics="...">` plus CSS `body[data-diagnostics="false"] { .topbar, .dev-controls-disclosure, .workspace-dev-ribbon, .dev-chip → display:none }`.
- Elements stay in the DOM (operator access in diagnostics mode + `data-*` test compatibility).
- The human header strip (vault chip, runtime pill, freshness, quick-open, Browse Vault) is unchanged and always visible.
- New `tests/companion_ui/test_workspace_dev_chrome_gating.py` (6 cases).

## Authority / guardrail notes
No runtime authority changes, no hidden writes, no hardcoded IPs/hostnames. Dev functionality is preserved (revealed in diagnostics mode), not deleted. Browse Vault still focuses the canonical left-panel browse mode (#1398) — no duplicate surface. Stable `data-*` anchors preserved.

## Diagnostics access path
`http://<dev-host>:8111/?note_path=...&diagnostics=1` reveals the operator chrome (topbar, dev controls, NOTE_PATH/LOAD). Default (no param) is the clean human workspace.

## Tests run
- `test_workspace_dev_chrome_gating.py` → 6 passed.
- Matrix `test_real_note_workspace_dev_server.py + test_real_note_workspace_visual_shell.py + test_workspace_layout.py + test_vault_browser_single_surface.py` → 135 passed, 1 failed (the pre-existing `test_renders_runtime_safety_strip_and_identity_pills` baseline — a drifted test asserting a non-existent testid).
- Full `tests/companion_ui/` → 1178 passed, 4 failed = the documented pre-existing baseline only; no new regressions.
- `python3 scripts/docs_guard.py` → OK; `git diff --check` → clean; `python3 -m ruff check app tests companion-ui/companion-app/companion_ui` → **All checks passed!**

## Browser UAT (acceptance gate)
Local static render (live vault note), 1280×800, `preview_eval` computed visibility:
- **Default** (`data-diagnostics="false"`): `.topbar`, `.dev-controls-disclosure`, `.dev-chip`, `.workspace-dev-ribbon`, `#note_path` all **not visible** (`display:none`); `workspace-vault-chip` and `workspace-browse-vault` **visible**. Screenshot shows a clean human header with no SERVER-SIDE RUNTIME / dev controls / NOTE_PATH / DEV banner.
- **Diagnostics** (`?diagnostics=1`, `data-diagnostics="true"`): topbar, dev controls, and NOTE_PATH input all **visible** again.

## Known limitations
- Diagnostics access is a query-param route (`?diagnostics=1`); no in-UI toggle button was added to avoid reintroducing chrome. Documented above.
- Dispatcher claim via GitHub-label flow; Codex review rate-limited (did not run) — relying on green CI + documented browser UAT.

---