### PR TITLE
fix(companion-ui): collapse right rail for non-actionable disabled/degraded states (#1419)

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -917,13 +917,20 @@ def _render_note_section(fields: dict) -> str:
     # actionable or safety-critical content. Otherwise the idle/unavailable
     # cards collapse behind one compact posture treatment.
     _panel_last_response = fields.get("panel_last_response") or {}
+    # #1419 — only genuinely safety-affecting state is "critical". Generic
+    # guard_degraded (e.g. Canvas disabled) and vault_unreachable are passive
+    # capability/availability states: the former is non-actionable, the latter
+    # already has its own prominent unreachable banner. They must not force the
+    # rail open or read as "needs attention".
     rail_safety_critical = (
         writeguard_blocked
         or recovery_needed
         or conflict_detected
-        or guard_degraded
-        or vault_unreachable
     )
+    # Reorient counts as actionable only when it carries real items (an
+    # orientation step), not when it is the idle/empty recall payload (#1419).
+    _reorient = fields.get("reorient_sections") or {}
+    reorient_actionable = any(_reorient.get(name) for name in _reorient)
     rail_actionable = bool(
         rail_safety_critical
         or proposal_count > 0
@@ -933,7 +940,7 @@ def _render_note_section(fields: dict) -> str:
         or panel_state_raw not in {"idle", "", "unknown"}
         or bool(panel_message_raw)
         or len(fields.get("find_candidates") or []) > 0
-        or bool(fields.get("reorient_sections"))
+        or reorient_actionable
         or len(fields.get("resurface_candidates") or []) > 0
         or len(fields.get("governance_receipts") or []) > 0
         or len(fields.get("suggestion_cards") or []) > 0
@@ -4225,6 +4232,11 @@ def render_index_html(
     .rail-idle-details {{
       border-top: 1px solid var(--border);
       margin-top: 4px;
+    }}
+    /* #1419 — deterministic collapse: hide the non-actionable cards when the
+       details is closed, independent of UA details behavior. */
+    .rail-idle-details:not([open]) > :not(summary) {{
+      display: none;
     }}
     .rail-idle-summary {{
       color: var(--fg-3);

--- a/tests/companion_ui/test_right_rail_compaction.py
+++ b/tests/companion_ui/test_right_rail_compaction.py
@@ -192,3 +192,56 @@ def test_internal_labels_do_not_leak_to_default_copy():
     # ...and carries no internal/test labels (those live behind the details).
     for token in _IDLE_TOKENS:
         assert token not in head, f"internal label {token!r} leaked into default rail copy"
+
+
+# ---------------------------------------------------------------------------
+# #1419 — degraded/disabled-only state must NOT expand the rail
+# ---------------------------------------------------------------------------
+
+
+def test_rail_compacts_for_degraded_disabled_only_state():
+    # Matches the user UAT screenshot: runtime degraded + Canvas disabled +
+    # workspace update disabled + Find unavailable + Resurface degraded +
+    # Suggestions idle + idle Reorient + no proposals/recovery/block.
+    rail = _rail(_html(
+        guard_degraded=True,
+        guard_canvas_enabled=False,
+        guard_workspace_update_available=False,
+        find_payload_available=False,
+        reorient_sections={"open_loops": []},  # idle reorient (no items)
+        resurface_candidates=[],
+        suggestion_state="idle",
+        panel_state="idle",
+        panel_proposal_count=0,
+    ))
+    # None of those are actionable → compact posture, not "needs attention".
+    assert 'data-rail-posture="idle"' in rail
+    assert "needs attention" not in rail
+    # The disabled/degraded cards collapse behind the single details treatment.
+    assert 'data-testid="workspace-rail-idle-details"' in rail
+
+
+def test_generic_guard_degraded_alone_is_not_actionable():
+    rail = _rail(_html(guard_degraded=True))
+    assert 'data-rail-posture="idle"' in rail
+    assert 'data-testid="workspace-rail-idle-details"' in rail
+
+
+def test_idle_reorient_payload_does_not_expand_rail():
+    # An empty-section reorient dict must not force the rail open.
+    rail = _rail(_html(reorient_sections={"open_loops": [], "facts": []}))
+    assert 'data-rail-posture="idle"' in rail
+    assert 'data-testid="workspace-rail-idle-details"' in rail
+
+
+def test_actionable_reorient_with_items_still_expands_rail():
+    # A reorient payload with real items is an actionable orientation step.
+    rail = _rail(_html(reorient_sections={"open_loops": [{"text": "Close loop X", "source_path": "n.md"}]}))
+    assert 'data-testid="workspace-rail-idle-details"' not in rail
+
+
+def test_writeguard_block_still_expands_despite_compaction_fix():
+    # Safety-critical write block must remain visible (regression guard).
+    rail = _rail(_html(guard_writeguard_status="blocked", guard_degraded=True))
+    assert 'data-testid="workspace-rail-idle-details"' not in rail
+    assert 'data-testid="workspace-guard-indicator"' in rail


### PR DESCRIPTION
Fixes #1419

## Summary
The right rail no longer expands (or reads "needs attention") when it contains only non-actionable disabled/degraded/idle state. Post-merge UAT regression of #1401. Implements `ADAPTIVE_WORKSPACE_LAYOUT_HANDOFF.md` §§8–9 and Vault Browser UI Requirements R5/R8.

## Source docs read
- `ADAPTIVE_WORKSPACE_LAYOUT_HANDOFF.md` §§8–9; `VAULT_BROWSER_UI_REQUIREMENTS.md` R5/R8; `PANEL_COMPANION_UI_CONTRACT.md`; `CANVAS_SUGGESTION_FLOW.md`; `docs/HUMAN-FLOWS.md`
- bug-to-issue contract #1419; issue-to-code workflow

## Root cause
`rail_safety_critical` (added in #1401) included `guard_degraded` and `vault_unreachable`, so the live "canvas off Degraded" runtime state forced `rail_actionable = True` → posture "needs attention" + the full card stack. `rail_actionable` also counted `bool(reorient_sections)`, which is true even for an empty `{"open_loops": []}` idle payload.

## Changes
- `rail_safety_critical` = WriteGuard block OR Canvas recovery OR Canvas conflict only. `guard_degraded` is non-actionable (passive capability state); `vault_unreachable` already has its own banner.
- Reorient counts as actionable only when it carries real items (`any(sections.get(n) for n in sections)`), not for the idle/empty recall payload.
- Deterministic collapse CSS `.rail-idle-details:not([open]) > :not(summary){display:none}` so the non-actionable cards are hidden in every engine.
- 5 regression tests added to `tests/companion_ui/test_right_rail_compaction.py`.

## Authority / guardrail notes
No critical safety state hidden — WriteGuard block, Canvas recovery/conflict, active edit session, active proposal/receipt, and real find/resurface/reorient content all still expand the rail (regression-tested). No Panel/Canvas/Find/Reorient/Resurface runtime semantics changed; no write paths. Stable `data-*` markers preserved.

## Tests run
- `test_right_rail_compaction.py` (incl. 5 new) → 12 passed.
- Matrix `panel_confirm/canvas_edit/canvas_recovery/find/resurface/reorient browser` → 47 passed, 1 failed (the pre-existing `test_workspace_resurface_source_link_uses_logical_identifier` baseline, `app/api/routes/companion.py:562` TypeError).
- Full `tests/companion_ui/` → 1183 passed, 4 failed = the documented pre-existing baseline only; no new regressions.
- `python3 scripts/docs_guard.py` → OK; `git diff --check` → clean; `python3 -m ruff check app tests companion-ui/companion-app/companion_ui` → **All checks passed!**

## Browser UAT (acceptance gate)
Local static render reproducing the user's scenario (`guard_degraded` + Canvas disabled + workspace update disabled + Find unavailable + Resurface degraded + Suggestions idle + idle Reorient + no proposals/recovery/block), 1280×800, Chromium-class preview:
- **Before** (user's live screenshot): posture "Companion · needs attention" with stacked Canvas/Panel/Suggestions/Find/Resurface cards + red "Canvas disabled / Workspace update disabled".
- **After** (this PR): `preview_eval` reports posture `idle`; default rail text = `PANEL · IDLE | No active Panel proposal | Companion · idle — no active proposals. | Companion details`; **0** non-actionable cards visible (collapsed behind the details).
- Regression: WriteGuard-blocked fixture still keeps the rail expanded with the guard indicator visible.

## Known limitations
- Dispatcher claim via GitHub-label flow; Codex review rate-limited (did not run) — relying on green CI + documented browser UAT.

---