### PR TITLE
fix(companion-ui): fix Markdown list rendering against Obsidian reference (#1410)

### DIFF
--- a/companion-ui/companion-app/companion_ui/renderer/vault_markdown_renderer.py
+++ b/companion-ui/companion-app/companion_ui/renderer/vault_markdown_renderer.py
@@ -238,18 +238,8 @@ def _render_blocks(markdown: str, context: _RenderContext) -> str:
             index += 1
             continue
 
-        if _TASK_RE.match(line):
-            html_block, index = _render_task_list(lines, index, context)
-            parts.append(html_block)
-            continue
-
-        if _UNORDERED_RE.match(line):
-            html_block, index = _render_list(lines, index, context, ordered=False)
-            parts.append(html_block)
-            continue
-
-        if _ORDERED_RE.match(line):
-            html_block, index = _render_list(lines, index, context, ordered=True)
+        if _list_kind(line) is not None:
+            html_block, index = _render_list_block(lines, index, context)
             parts.append(html_block)
             continue
 
@@ -383,48 +373,99 @@ def _heading_text_and_anchor(raw_text: str) -> tuple[str, str]:
     return text, slug.strip("-")
 
 
-def _render_task_list(
+def _list_kind(line: str) -> str | None:
+    """Classify a line as a list item: 'task', 'ol', 'ul', or None.
+
+    Task items (``- [ ]``) are a special case of unordered items and must be
+    checked first.
+    """
+    if _TASK_RE.match(line):
+        return "task"
+    if _ORDERED_RE.match(line):
+        return "ol"
+    if _UNORDERED_RE.match(line):
+        return "ul"
+    return None
+
+
+def _list_indent(line: str) -> int:
+    expanded = line.expandtabs(4)
+    return len(expanded) - len(expanded.lstrip(" "))
+
+
+def _render_list_block(
     lines: list[str],
     start: int,
     context: _RenderContext,
 ) -> tuple[str, int]:
-    items: list[str] = []
+    """Render a (possibly nested) list block, indentation-aware (#1410).
+
+    Collects consecutive list lines and rebuilds the nesting from their indent
+    so nested ordered lists render inside a nested ``<ol>`` (restarting at 1)
+    rather than as flattened continuation items.
+    """
+    entries: list[tuple[int, str, str | None, str]] = []
     index = start
     while index < len(lines):
-        match = _TASK_RE.match(lines[index])
-        if not match:
+        kind = _list_kind(lines[index])
+        if kind is None:
             break
-        state = match.group(1).strip() or " "
-        checked = state.lower() == "x"
-        checked_attr = " checked" if checked else ""
-        items.append(
-            '<li class="task-list-item" '
-            f'data-task-state="{_e(state)}">'
-            f'<input type="checkbox" disabled{checked_attr}> '
-            f"{_render_inline(match.group(2), context)}</li>"
-        )
+        indent = _list_indent(lines[index])
+        if kind == "task":
+            match = _TASK_RE.match(lines[index])
+            assert match is not None
+            entries.append((indent, "task", match.group(1).strip() or " ", match.group(2)))
+        elif kind == "ol":
+            match = _ORDERED_RE.match(lines[index])
+            assert match is not None
+            entries.append((indent, "ol", None, match.group(1)))
+        else:
+            match = _UNORDERED_RE.match(lines[index])
+            assert match is not None
+            entries.append((indent, "ul", None, match.group(1)))
         index += 1
-    return f'<ul class="task-list">{"".join(items)}</ul>', index
+
+    html, _ = _build_list_html(entries, 0, entries[0][0], context)
+    return html, index
 
 
-def _render_list(
-    lines: list[str],
-    start: int,
+def _build_list_html(
+    entries: list[tuple[int, str, str | None, str]],
+    pos: int,
+    indent: int,
     context: _RenderContext,
-    *,
-    ordered: bool,
 ) -> tuple[str, int]:
-    pattern = _ORDERED_RE if ordered else _UNORDERED_RE
+    list_kind = entries[pos][1]
     items: list[str] = []
-    index = start
-    while index < len(lines):
-        match = pattern.match(lines[index])
-        if not match or _TASK_RE.match(lines[index]):
-            break
-        items.append(f"<li>{_render_inline(match.group(1), context)}</li>")
-        index += 1
-    tag = "ol" if ordered else "ul"
-    return f"<{tag}>{''.join(items)}</{tag}>", index
+    while pos < len(entries) and entries[pos][0] >= indent:
+        e_indent, e_kind, e_state, e_content = entries[pos]
+        if e_indent > indent:
+            # Deeper than expected without a parent item at this level — attach
+            # the nested list to the previous item (or open a bare item).
+            nested_html, pos = _build_list_html(entries, pos, e_indent, context)
+            if items:
+                items[-1] = items[-1][: -len("</li>")] + nested_html + "</li>"
+            else:
+                items.append(f"<li>{nested_html}</li>")
+            continue
+        pos += 1
+        nested_html = ""
+        if pos < len(entries) and entries[pos][0] > indent:
+            nested_html, pos = _build_list_html(entries, pos, entries[pos][0], context)
+        if e_kind == "task":
+            checked_attr = " checked" if (e_state or "").lower() == "x" else ""
+            items.append(
+                '<li class="task-list-item" '
+                f'data-task-state="{_e(e_state or " ")}">'
+                f'<input type="checkbox" disabled{checked_attr}> '
+                f"{_render_inline(e_content, context)}{nested_html}</li>"
+            )
+        else:
+            items.append(f"<li>{_render_inline(e_content, context)}{nested_html}</li>")
+
+    tag = "ol" if list_kind == "ol" else "ul"
+    cls = ' class="task-list"' if list_kind == "task" else ""
+    return f"<{tag}{cls}>{''.join(items)}</{tag}>", pos
 
 
 def _render_paragraph(

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -3987,19 +3987,26 @@ def render_index_html(
       vertical-align: baseline;
     }}
     .vault-markdown-rendered li.task-list-item > input[type="checkbox"]:checked {{
-      background: var(--accent-dim);
+      background: var(--accent);
       border-color: var(--accent);
     }}
     .vault-markdown-rendered li.task-list-item > input[type="checkbox"]:checked::after {{
       content: "";
       position: absolute;
-      left: 3px;
-      top: 0px;
+      left: 4px;
+      top: 1px;
       width: 4px;
       height: 8px;
       border: solid var(--bg-base);
-      border-width: 0 1.5px 1.5px 0;
+      border-width: 0 2px 2px 0;
       transform: rotate(45deg);
+    }}
+    /* #1410 — completed tasks get Obsidian-style completed treatment so the
+       checked state is unambiguous beyond the checkbox alone. */
+    .vault-markdown-rendered li.task-list-item[data-task-state="x"],
+    .vault-markdown-rendered li.task-list-item[data-task-state="X"] {{
+      color: var(--fg-3);
+      text-decoration: line-through;
     }}
     {note_outline_css()}
     .vault-callout {{

--- a/tests/companion_ui/test_markdown_renderer_lists.py
+++ b/tests/companion_ui/test_markdown_renderer_lists.py
@@ -1,0 +1,103 @@
+"""Markdown list rendering against Obsidian reference (#1410).
+
+Covers the UAT note sections 3.1 (bulleted), 3.2 (numbered), 3.3 (task list):
+- nested bulleted lists indent under their parent bullet;
+- nested ordered lists render in a nested <ol> (restarting at 1), not as
+  continued top-level items 4/5;
+- checked task items render with an unambiguous checked state + completed
+  treatment; unchecked tasks stay unchecked;
+- bold and inline code inside list/task items still render.
+"""
+
+from __future__ import annotations
+
+import re
+
+from companion_ui.renderer.vault_markdown_renderer import render_vault_markdown
+from companion_ui.workspace.serve_dev_page import render_index_html
+
+
+def _html(md: str) -> str:
+    return render_vault_markdown(md).html
+
+
+# ---------------------------------------------------------------------------
+# 3.1 — nested bulleted lists
+# ---------------------------------------------------------------------------
+
+
+def test_nested_bulleted_lists_indent_under_parent():
+    md = "- Item A\n- Item B\n    - Nested bullet B\n- Item C\n"
+    html = _html(md)
+    # The nested bullet lives in a <ul> nested inside the Item B <li>, not as a
+    # flat sibling.
+    assert re.search(r"<li>Item B<ul><li>Nested bullet B</li></ul></li>", html), html
+    # The flat-list bug (nested item as a sibling) must be gone.
+    assert "<li>Nested bullet B</li><li>Item C</li>" not in html
+
+
+# ---------------------------------------------------------------------------
+# 3.2 — nested ordered lists restart numbering
+# ---------------------------------------------------------------------------
+
+
+def test_nested_ordered_lists_render_nested_ol():
+    md = (
+        "1. First numbered item\n"
+        "2. Second numbered item\n"
+        "3. Third numbered item\n"
+        "    1. Nested numbered item\n"
+        "    2. Another nested numbered item\n"
+    )
+    html = _html(md)
+    # Nested ordered items belong to a nested <ol> inside the third <li> so the
+    # browser restarts numbering at 1 — they are NOT emitted as items 4/5.
+    assert re.search(
+        r"<li>Third numbered item<ol><li>Nested numbered item</li>"
+        r"<li>Another nested numbered item</li></ol></li>",
+        html,
+    ), html
+    # Exactly two <ol> open tags (outer + nested).
+    assert html.count("<ol>") == 2
+
+
+# ---------------------------------------------------------------------------
+# 3.3 — task list checked/unchecked
+# ---------------------------------------------------------------------------
+
+
+def test_checked_task_has_unambiguous_checked_state():
+    html = _html("- [x] Completed task\n")
+    li = re.search(r'<li class="task-list-item"[^>]*>.*?</li>', html, re.S).group(0)
+    assert 'data-task-state="x"' in li
+    assert "<input type=\"checkbox\" disabled checked>" in li or "checked>" in li
+
+
+def test_unchecked_task_remains_unchecked():
+    html = _html("- [ ] Open task\n")
+    li = re.search(r'<li class="task-list-item"[^>]*>.*?</li>', html, re.S).group(0)
+    assert 'data-task-state=" "' in li
+    assert "checked" not in li
+
+
+def test_checked_task_has_completed_styling_hook_in_page_css():
+    # The page provides a completed (strikethrough/muted) treatment keyed on the
+    # checked task state, comparable to Obsidian.
+    page = render_index_html(api_base_url="http://127.0.0.1:18001", note_path="")
+    m = re.search(
+        r'li\.task-list-item\[data-task-state="x"\][^{]*\{([^}]*)\}', page
+    )
+    assert m, "missing completed-task CSS rule for data-task-state=x"
+    assert "line-through" in m.group(1)
+
+
+def test_bold_and_inline_code_in_list_items():
+    html = _html("- **bold item** with `code`\n")
+    assert "<strong>bold item</strong>" in html
+    assert "<code>code</code>" in html
+
+
+def test_bold_and_inline_code_in_task_items():
+    html = _html("- [ ] task with **bold** and `code`\n")
+    assert "<strong>bold</strong>" in html
+    assert "<code>code</code>" in html


### PR DESCRIPTION
Fixes #1410

## Summary
Markdown list rendering now matches Obsidian-compatible behaviour for the UAT note sections 3.1–3.3: nested bullets indent under their parent, nested ordered lists render in a nested `<ol>` (restarting at 1 — not as items 4/5), and checked tasks get a clear checked state + completed treatment.

## Source docs read
- `docs/TESTING.md`, `docs/QUALITY.md`, `docs/AI_DEVELOPMENT.md`
- existing renderer tests (`test_vault_markdown_renderer.py`), `vault_markdown_renderer.py`
- bug-to-issue contract #1410; issue-to-code workflow

## Root cause
`_render_list` / `_render_task_list` matched `^\s*` but ignored indentation, flattening every matching line into one `<ol>`/`<ul>`. Nested ordered items therefore continued the parent numbering (4, 5).

## Changes
- New indentation-aware `_render_list_block` + recursive `_build_list_html` (with `_list_kind` / `_list_indent` helpers) reconstruct nesting from each line's indent (tabs expanded to 4). Nested ordered → nested `<ol>` inside the parent `<li>`; nested bullets → nested `<ul>`. Task items keep `class="task-list"` and `data-task-state`.
- Completed-task styling in the page CSS: `li.task-list-item[data-task-state="x"]` → `line-through` + muted; brighter checked checkbox fill + higher-contrast tick.
- New `tests/companion_ui/test_markdown_renderer_lists.py` (7 cases): nested bullets, nested ordered restart, checked/unchecked state, completed CSS hook, bold + inline code in list and task items.

## Authority / guardrail notes
Renderer-only correctness fix; no editor replacement, no note-content changes, no runtime/API behaviour. Headings/callouts/code/Mermaid/links/properties rendering paths untouched (existing `test_vault_markdown_renderer.py` still green). Deterministic + test-covered.

## Tests run
- `test_markdown_renderer_lists.py` → 7 passed; `test_vault_markdown_renderer.py` → 7 passed.
- Full `tests/companion_ui/` → 1190 passed, 4 failed = documented pre-existing baseline only (2× mermaid, safety-strip, resurface-source-link); no new regressions.
- `python3 scripts/docs_guard.py` → OK; `git diff --check` → clean; `python3 -m ruff check app tests companion-ui/companion-app/companion_ui` → **All checks passed!**

## Browser UAT (acceptance gate)
Local static render of UAT sections 3.1–3.3, 1280×900, `preview_eval` on the rendered note body:
- **3.1**: nested `<ul>` exists (`ul li ul`) — "Nested bullet A/B" indent under "Second bullet".
- **3.2**: `totalOls = 2`; the nested `<ol>` is a child of the third `<li>` and contains `["Nested numbered item", "Another nested numbered item"]` — restarts at 1/2 instead of continuing 4/5.
- **3.3**: checked task computes `text-decoration: line-through`, checkbox `checked === true`; unchecked tasks stay unchecked.
- **Before** (user's live screenshot): §3.2 nested items rendered as `4. Nested numbered item`, `5. Another nested numbered item` (flattened).

## Known limitations
- Loose lists (blank lines between items) are rendered as separate tight lists; the UAT constructs are tight lists. Out of scope for this fix.
- Dispatcher claim via GitHub-label flow; Codex review rate-limited (did not run) — relying on green CI + documented browser UAT.

---