### PR TITLE
docs(uat): record task-list + code-block retest verdicts (#1348)

### DIFF
--- a/companion-ui/design_handoff/2026-05-26-companion-ui-design-review/HUMAN_UAT_RESULTS.md
+++ b/companion-ui/design_handoff/2026-05-26-companion-ui-design-review/HUMAN_UAT_RESULTS.md
@@ -123,3 +123,28 @@ Design should specify what both the successful and missing states should look li
 | Task list retest needed | Test coverage gap — design should specify correct rendering |
 | Code block retest needed | Test coverage gap — design should specify correct rendering |
 | Image asset missing | Test fixture gap — design should specify both states |
+
+---
+
+## 2026-05-30 retest — task lists & code blocks (#1348)
+
+Retested against `origin/main` after #1410 (Markdown list rendering) merged. Observed via local static render of the UAT note sections driven in a real browser at 1280×900 (the live runtime had not yet been redeployed with #1410).
+
+### Task list retest — **PASS**
+
+The renderer now produces correctly nested lists and unambiguous task states:
+
+- Unchecked tasks render an empty checkbox with `data-task-state=" "`.
+- Checked tasks render a filled accent checkbox with a check tick **and** an Obsidian-style completed treatment (`text-decoration: line-through`, muted color) keyed on `data-task-state="x"`.
+- Bold and inline code inside task items render (`<strong>`, `<code>`).
+- Nested ordered/unordered list items now indent under their parent (nested `<ol>` restarts numbering at 1 instead of continuing 4/5).
+
+Evidence: `getComputedStyle` on the checked item reported `text-decoration-line: line-through` with `checkbox.checked === true`; the nested ordered list rendered as a nested `<ol>` inside the parent `<li>`. Covered by `tests/companion_ui/test_markdown_renderer_lists.py`. Supersedes the earlier "Task list retest needed" gap.
+
+### Code block retest — **PASS (functional)**
+
+Fenced code blocks render as `<pre class="vault-code-block" data-language="…"><code class="language-…">`, both with a language hint (python/json/ts observed in the live note) and without one (plain block). Monospace, contained horizontal scroll, visible language attribute. Supersedes the earlier "Fenced code blocks AMBIGUOUS" row.
+
+### Syntax highlighting decision
+
+**Not required for current acceptance.** Code blocks are a faithful, readable monospace surface with a language label; token-level syntax highlighting is a reading-comfort enhancement, not a correctness requirement for the cognitive-workspace MLP. No follow-up issue filed; revisit only if a future spec mandates highlighted code.


### PR DESCRIPTION
Fixes #1348

- [x] Docs authoring lane (issue-backed)

## Summary
Records the 2026-05-30 retest of the UAT note's task lists and fenced code blocks in `HUMAN_UAT_RESULTS.md`, after #1410 fixed Markdown list rendering. Both areas now PASS, and the syntax-highlighting decision is recorded.

## Changes
- New dated section in `companion-ui/design_handoff/2026-05-26-companion-ui-design-review/HUMAN_UAT_RESULTS.md`:
  - **Task list retest — PASS**: nested lists indent correctly; checked items show a filled checkbox + Obsidian-style completed treatment (`line-through`); bold/inline code render. (Evidence: browser `getComputedStyle` + `tests/companion_ui/test_markdown_renderer_lists.py`.)
  - **Code block retest — PASS (functional)**: `<pre class="vault-code-block" data-language>` with and without a language hint.
  - **Syntax highlighting decision**: not required for current acceptance; no follow-up filed.

## ACs
- AC1 (task list retest with evidence) ✓ — recorded.
- AC2 (verdict on #1332) ✓ — comment posted on #1332.
- AC3 (code block retest with evidence) ✓ — recorded.
- AC4 (syntax highlighting decision) ✓ — recorded (no, with rationale).
- AC5 (code-block verdict on #1332) ✓ — comment posted on #1332.

## Validation
`python3 scripts/docs_guard.py` → OK; `git diff --check` → clean. Docs-only change.

## Notes
Retest was done via local static render of the merged renderer (live runtime not yet redeployed with #1410). Codex review rate-limited; relying on docs_guard + the underlying #1410 test coverage.

---