### PR TITLE
feat(companion-ui): Obsidian-style collapsible folder tree in the Vault Browser (#1425)

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -1679,6 +1679,119 @@ def _render_filter_chips(
     )
 
 
+def _build_vault_tree(notes: list[dict]) -> dict:
+    """Build a nested folder tree from server-provided note paths (#1425).
+
+    Returns ``{"folders": {name: subtree}, "files": [(note, filename, path)]}``.
+    Insertion order is preserved (folders first-seen, files in order).
+    """
+    root: dict = {"folders": {}, "files": []}
+    for note in notes:
+        path = str(note.get("note_path") or "").strip()
+        if not path:
+            continue
+        parts = path.split("/")
+        folders, filename = parts[:-1], parts[-1]
+        node = root
+        for folder in folders:
+            node = node["folders"].setdefault(folder, {"folders": {}, "files": []})
+        node["files"].append((note, filename, path))
+    return root
+
+
+def _render_vault_tree(
+    node: dict,
+    *,
+    note_path: str,
+    active_folder_paths: set[str],
+    base: str,
+) -> str:
+    parts: list[str] = []
+    # Folders first (Obsidian-like), then files at this level.
+    for name, child in node["folders"].items():
+        full = f"{base}/{name}" if base else name
+        is_open = full in active_folder_paths
+        children = _render_vault_tree(
+            child, note_path=note_path, active_folder_paths=active_folder_paths, base=full
+        )
+        parts.append(
+            f'<li class="vault-tree-folder" data-testid="workspace-vault-browser-group" '
+            f'data-folder="{_e(full)}">'
+            f'<details class="vault-tree-folder-details"{" open" if is_open else ""}>'
+            f'<summary class="vault-tree-folder-summary">{_e(name)}</summary>'
+            f'<ul class="vault-tree-children">{children}</ul>'
+            "</details></li>"
+        )
+    for note, filename, path in node["files"]:
+        parts.append(_render_vault_note_row(note, filename, path, note_path))
+    return "".join(parts)
+
+
+def _render_vault_note_row(note: dict, filename: str, path: str, note_path: str) -> str:
+    """Render one clean note row: name only (filename stem); metadata hidden (#1417/#1425)."""
+    title = _e(note.get("title") or filename)
+    stem = filename[:-3] if filename.lower().endswith(".md") else filename
+    zone = _e(note.get("zone") or "root")
+    href = "/?note_path=" + quote(path, safe="/")
+    active = "true" if path == note_path else "false"
+
+    hidden_badge_attrs = ' class="note-badge note-badge--nav-hidden" data-nav-visible="false"'
+    kind_val = note.get("kind")
+    kind_badge = (
+        f'<span{hidden_badge_attrs} '
+        f'data-testid="workspace-vault-browser-note-kind">{_e(str(kind_val))}</span>'
+        if kind_val else ""
+    )
+    review_state_val = note.get("review_state")
+    review_badge = (
+        f'<span{hidden_badge_attrs} '
+        f'data-testid="workspace-vault-browser-note-review-state">{_e(str(review_state_val))}</span>'
+        if review_state_val else ""
+    )
+    trust_val = note.get("trust")
+    trust_badge = (
+        f'<span{hidden_badge_attrs} '
+        f'data-testid="workspace-vault-browser-note-trust">{_e(str(trust_val))}</span>'
+        if trust_val else ""
+    )
+    frontmatter_valid = note.get("frontmatter_valid", True)
+    missing_fields = note.get("missing_required_fields") or []
+    health_badge = ""
+    if not frontmatter_valid or missing_fields:
+        missing_label = ", ".join(missing_fields) if missing_fields else "invalid"
+        health_badge = (
+            f'<span class="note-badge note-badge--health note-badge--health-invalid" '
+            f'data-testid="workspace-vault-browser-note-health" '
+            f'data-missing-fields="{_e(missing_label)}">missing: {_e(missing_label)}</span>'
+        )
+    badges_html = kind_badge + review_badge + trust_badge + health_badge
+
+    kind_safe = _e(str(kind_val)) if kind_val else ""
+    is_companion = kind_val in _COMPANION_KINDS
+    row_extra_class = " vault-browser-row--companion" if is_companion else ""
+    row_kind_attr = f' data-kind="{kind_safe}"' if kind_safe else ""
+    row_companion_attr = ' data-companion="true"' if is_companion else ""
+    nav_hidden = _should_hide_note_by_default(note)
+    row_hidden_attr = " hidden" if nav_hidden else ""
+    row_nav_attr = ' data-nav-visible="false"' if nav_hidden else ""
+
+    # Obsidian-clean row: the visible label is the filename stem (disambiguates
+    # same-titled notes); the frontmatter title is the tooltip. The full path and
+    # raw metadata stay in hidden elements (data-* preserved for tests).
+    return (
+        f'<li class="vault-browser-row{row_extra_class}" '
+        f'data-testid="workspace-vault-browser-note-row" data-active="{active}"'
+        f'{row_kind_attr}{row_companion_attr}{row_nav_attr}{row_hidden_attr}>'
+        f'<a href="{href}" class="vault-browser-row-title" '
+        f'data-testid="workspace-vault-browser-note-link" title="{title}">{_e(stem)}</a>'
+        f'<code class="vault-browser-row-path" data-testid="workspace-vault-browser-note-path" '
+        f'title="{_e(path)}" hidden>{_e(filename)}</code>'
+        f'<span data-testid="workspace-vault-browser-note-zone" '
+        f'class="vault-browser-zone-label">{zone}</span>'
+        f"{badges_html}</li>"
+    )
+
+
 def _render_vault_browser(
     *,
     note_path: str,
@@ -1733,92 +1846,24 @@ def _render_vault_browser(
     # §6 — group rows by folder so the list stays scannable at 40+ artifacts.
     # Insertion order is preserved (dicts are ordered) so any server ordering
     # intent survives; each folder header is emitted once.
-    grouped: dict[str, list[str]] = {}
-    for note in notes:
-        path = str(note.get("note_path") or "").strip()
-        if not path:
-            continue
-        title = _e(note.get("title") or path)
-        zone = _e(note.get("zone") or "root")
-        href = "/?note_path=" + quote(path, safe="/")
-        active = "true" if path == note_path else "false"
-        folder = path.rsplit("/", 1)[0] if "/" in path else "(root)"
-        filename = path.rsplit("/", 1)[-1]
-
-        # Per-note metadata badges: hidden from the nav list by default (daily-use
-        # visibility pass). The inspector panel shows the full metadata. These
-        # elements retain their data-testid for test compatibility but are visually
-        # hidden so the nav list stays calm and navigation-focused.
-        hidden_badge_attrs = ' class="note-badge note-badge--nav-hidden" data-nav-visible="false"'
-        kind_val = note.get("kind")
-        kind_badge = (
-            f'<span{hidden_badge_attrs} '
-            f'data-testid="workspace-vault-browser-note-kind">{_e(str(kind_val))}</span>'
-            if kind_val else ""
-        )
-        review_state_val = note.get("review_state")
-        review_badge = (
-            f'<span{hidden_badge_attrs} '
-            f'data-testid="workspace-vault-browser-note-review-state">{_e(str(review_state_val))}</span>'
-            if review_state_val else ""
-        )
-        trust_val = note.get("trust")
-        trust_badge = (
-            f'<span{hidden_badge_attrs} '
-            f'data-testid="workspace-vault-browser-note-trust">{_e(str(trust_val))}</span>'
-            if trust_val else ""
-        )
-        frontmatter_valid = note.get("frontmatter_valid", True)
-        missing_fields = note.get("missing_required_fields") or []
-        health_badge = ""
-        if not frontmatter_valid or missing_fields:
-            missing_label = ", ".join(missing_fields) if missing_fields else "invalid"
-            health_badge = (
-                f'<span class="note-badge note-badge--health note-badge--health-invalid" '
-                f'data-testid="workspace-vault-browser-note-health" '
-                f'data-missing-fields="{_e(missing_label)}">missing: {_e(missing_label)}</span>'
-            )
-        badges_html = kind_badge + review_badge + trust_badge + health_badge
-
-        kind_safe = _e(str(kind_val)) if kind_val else ""
-        is_companion = kind_val in _COMPANION_KINDS
-        row_extra_class = " vault-browser-row--companion" if is_companion else ""
-        row_kind_attr = f' data-kind="{kind_safe}"' if kind_safe else ""
-        row_companion_attr = ' data-companion="true"' if is_companion else ""
-        nav_hidden = _should_hide_note_by_default(note)
-        row_hidden_attr = " hidden" if nav_hidden else ""
-        row_nav_attr = ' data-nav-visible="false"' if nav_hidden else ""
-
-        # §6.1/§6.3 — title leads; the path is compact (filename only, with the
-        # full absolute path preserved in the title attribute as a details
-        # affordance). Raw metadata stays in the nav-hidden badges above.
-        grouped.setdefault(folder, []).append(
-            f"""
-          <li class="vault-browser-row{row_extra_class}" data-testid="workspace-vault-browser-note-row" data-active="{active}"{row_kind_attr}{row_companion_attr}{row_nav_attr}{row_hidden_attr}>
-            <a href="{href}" class="vault-browser-row-title" data-testid="workspace-vault-browser-note-link">{title}</a>
-            <code class="vault-browser-row-path" data-testid="workspace-vault-browser-note-path" title="{_e(path)}">{_e(filename)}</code>
-            <span data-testid="workspace-vault-browser-note-zone" class="vault-browser-zone-label">{zone}</span>
-            {badges_html}
-          </li>"""
-        )
-
-    list_items: list[str] = []
-    for folder, folder_rows in grouped.items():
-        folder_label = _e(folder)
-        list_items.append(
-            '<li class="vault-browser-group" '
-            'data-testid="workspace-vault-browser-group" '
-            f'data-folder="{folder_label}">'
-            f'<span class="vault-browser-group-label" title="{folder_label}">'
-            f"{folder_label}</span></li>"
-        )
-        list_items.extend(folder_rows)
-
+    # #1425 — render an Obsidian-style nested, collapsible folder tree built from
+    # the server-provided note paths. Folders on the path to the active note are
+    # expanded by default; the rest are collapsed.
+    tree = _build_vault_tree(notes)
+    active_folder_paths: set[str] = set()
+    if note_path and "/" in note_path:
+        acc = ""
+        for seg in note_path.split("/")[:-1]:
+            acc = f"{acc}/{seg}" if acc else seg
+            active_folder_paths.add(acc)
+    tree_html = _render_vault_tree(
+        tree, note_path=note_path, active_folder_paths=active_folder_paths, base=""
+    )
     list_html = (
-        '<ul class="vault-browser-list" data-testid="workspace-vault-browser-list">'
-        + "".join(list_items)
+        '<ul class="vault-browser-list vault-tree" data-testid="workspace-vault-browser-list">'
+        + tree_html
         + "</ul>"
-        if list_items
+        if (tree["folders"] or tree["files"])
         else ""
     )
     read_only_text = "read-only" if read_only else "mutating"
@@ -4997,6 +5042,67 @@ def render_index_html(
       color: var(--fg-1);
     }}
     /* §6 — density: folder group headers + compact, truncating rows. */
+    /* #1425 — Obsidian-style collapsible folder tree. */
+    .vault-tree, .vault-tree ul {{
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }}
+    .vault-tree-children {{
+      padding-left: 14px;
+    }}
+    .vault-tree-folder {{ list-style: none; }}
+    .vault-tree-folder-details > summary {{ list-style: none; }}
+    .vault-tree-folder-details > summary::-webkit-details-marker {{ display: none; }}
+    .vault-tree-folder-summary {{
+      align-items: center;
+      color: var(--fg-2);
+      cursor: pointer;
+      display: flex;
+      font-size: var(--text-sm);
+      gap: 4px;
+      overflow: hidden;
+      padding: 3px 4px;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }}
+    .vault-tree-folder-summary::before {{
+      color: var(--fg-3);
+      content: "\\203A";
+      display: inline-block;
+      flex-shrink: 0;
+      transition: transform 0.12s ease;
+      width: 10px;
+    }}
+    .vault-tree-folder-details[open] > .vault-tree-folder-summary::before {{
+      transform: rotate(90deg);
+    }}
+    .vault-tree-folder-summary:hover {{ color: var(--fg-1); }}
+    /* Tree note rows: name only, indented, with a clear active highlight. */
+    .vault-tree .vault-browser-row {{
+      border-radius: var(--radius-sm);
+      list-style: none;
+      padding: 3px 6px;
+    }}
+    .vault-tree .vault-browser-row:hover {{ background: var(--bg-raised); }}
+    .vault-tree .vault-browser-row[data-active="true"] {{
+      background: var(--bg-raised);
+    }}
+    .vault-tree .vault-browser-row[data-active="true"] > .vault-browser-row-title {{
+      color: var(--fg-1);
+    }}
+    .vault-tree .vault-browser-row-title {{
+      color: var(--fg-2);
+      display: block;
+      overflow: hidden;
+      text-decoration: none;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }}
+    .vault-tree .vault-browser-row-path {{ display: none; }}
+    /* #1425 — de-emphasize browse header chrome; the tree is the surface. */
+    .vault-browser-meta,
+    .vault-browser-state {{ display: none; }}
     .vault-browser-group {{
       list-style: none;
       padding: 8px 4px 2px;

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -5042,27 +5042,43 @@ def render_index_html(
       color: var(--fg-1);
     }}
     /* §6 — density: folder group headers + compact, truncating rows. */
-    /* #1425 — Obsidian-style collapsible folder tree. */
+    /* #1425/#1427 — Obsidian-style collapsible folder tree. The folder summaries
+       and note rows share the exact graphical profile of the Outline list
+       (font-display 13px/18px, 2px left rail, accent for the active item) so the
+       single left panel reads as one consistent family across its modes. */
     .vault-tree, .vault-tree ul {{
       list-style: none;
       margin: 0;
       padding: 0;
     }}
-    .vault-tree-children {{
-      padding-left: 14px;
+    .vault-tree {{
+      display: flex;
+      flex-direction: column;
+      gap: 3px;
     }}
-    .vault-tree-folder {{ list-style: none; }}
+    .vault-tree-children {{
+      display: flex;
+      flex-direction: column;
+      gap: 3px;
+      padding-left: 12px;
+    }}
+    .vault-tree-folder {{ list-style: none; min-width: 0; }}
     .vault-tree-folder-details > summary {{ list-style: none; }}
     .vault-tree-folder-details > summary::-webkit-details-marker {{ display: none; }}
     .vault-tree-folder-summary {{
       align-items: center;
+      border-left: 2px solid transparent;
+      border-radius: var(--radius-sm);
+      box-sizing: border-box;
       color: var(--fg-2);
       cursor: pointer;
       display: flex;
-      font-size: var(--text-sm);
+      font-family: var(--font-display);
+      font-size: 13px;
       gap: 4px;
+      line-height: 18px;
       overflow: hidden;
-      padding: 3px 4px;
+      padding: 5px 6px;
       text-overflow: ellipsis;
       white-space: nowrap;
     }}
@@ -5077,32 +5093,59 @@ def render_index_html(
     .vault-tree-folder-details[open] > .vault-tree-folder-summary::before {{
       transform: rotate(90deg);
     }}
-    .vault-tree-folder-summary:hover {{ color: var(--fg-1); }}
-    /* Tree note rows: name only, indented, with a clear active highlight. */
-    .vault-tree .vault-browser-row {{
-      border-radius: var(--radius-sm);
-      list-style: none;
-      padding: 3px 6px;
-    }}
-    .vault-tree .vault-browser-row:hover {{ background: var(--bg-raised); }}
-    .vault-tree .vault-browser-row[data-active="true"] {{
-      background: var(--bg-raised);
-    }}
-    .vault-tree .vault-browser-row[data-active="true"] > .vault-browser-row-title {{
+    .vault-tree-folder-summary:hover {{
       color: var(--fg-1);
+      outline: 1px solid var(--border-focus);
+      outline-offset: 1px;
+    }}
+    /* Tree note rows mirror .note-outline-link exactly. */
+    .vault-tree .vault-browser-row {{
+      box-sizing: border-box;
+      list-style: none;
+      min-width: 0;
     }}
     .vault-tree .vault-browser-row-title {{
+      border-left: 2px solid transparent;
+      border-radius: var(--radius-sm);
+      box-sizing: border-box;
       color: var(--fg-2);
       display: block;
+      font-family: var(--font-display);
+      font-size: 13px;
+      line-height: 18px;
       overflow: hidden;
+      padding: 5px 6px;
       text-decoration: none;
       text-overflow: ellipsis;
       white-space: nowrap;
     }}
+    .vault-tree .vault-browser-row-title:hover {{
+      color: var(--fg-1);
+      outline: 1px solid var(--border-focus);
+      outline-offset: 1px;
+    }}
+    .vault-tree .vault-browser-row[data-active="true"] > .vault-browser-row-title {{
+      border-left-color: var(--accent);
+      color: var(--accent);
+    }}
     .vault-tree .vault-browser-row-path {{ display: none; }}
-    /* #1425 — de-emphasize browse header chrome; the tree is the surface. */
+    /* #1425 — de-emphasize browse header chrome; the tree is the surface. The
+       "Browse vault notes" toggle matches the Outline heading label. */
     .vault-browser-meta,
     .vault-browser-state {{ display: none; }}
+    .vault-browser > summary[data-testid="workspace-vault-browser-toggle"] {{
+      color: var(--fg-3);
+      cursor: pointer;
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      letter-spacing: 0.08em;
+      list-style: none;
+      margin-bottom: 10px;
+      text-transform: uppercase;
+    }}
+    .vault-browser > summary[data-testid="workspace-vault-browser-toggle"]::-webkit-details-marker {{
+      display: none;
+    }}
     .vault-browser-group {{
       list-style: none;
       padding: 8px 4px 2px;

--- a/tests/companion_ui/test_vault_browser_tree.py
+++ b/tests/companion_ui/test_vault_browser_tree.py
@@ -1,0 +1,134 @@
+"""Obsidian-style collapsible folder tree in the Vault Browser (#1425).
+
+Browse mode renders a nested, collapsible folder tree (like the Obsidian file
+explorer) instead of flat folder groups: folders nest by real path depth and
+collapse, notes render as clean name-only rows indented under their folder, the
+active note's ancestor folders are expanded by default, and the active row is
+highlighted. #1417 (no raw metadata in rows) guarantees still hold.
+"""
+
+from __future__ import annotations
+
+import re
+
+from companion_ui.workspace.serve_dev_page import render_index_html
+
+# Mirrors the live Niflheim vault layout (from /api/companion/vault/notes).
+_NOTES = [
+    {"note_path": "Companion UI UAT.md", "title": "Companion UI UAT", "kind": "note"},
+    {"note_path": "Test.md", "title": "0. **Executive summary**", "kind": "note"},
+    {"note_path": "📥 Inbox/Companion_UI_Markdown_Feature_UAT.md", "title": "Companion UI Markdown Feature UAT", "kind": "note", "review_state": "needs_review"},
+    {"note_path": "📥 Inbox/Namnlös.md", "title": "Companion UI Markdown Feature UAT", "kind": "note"},
+    {"note_path": "📥 Inbox/Test note 2.md", "title": "Test note 2", "kind": "note"},
+    {"note_path": "⚙️ System/vault.layout.md", "title": "Vault Layout Contract", "kind": "note"},
+    {"note_path": "⚙️ System/companions/11111111-1111-4111-8111-111111111111.md", "title": "Companion UI UAT", "kind": "companion_note"},
+]
+
+
+def _fields(*, notes, note_path):
+    return {
+        "title": "N", "note_path": note_path, "artifact_id": "a", "artifact_kind": "note",
+        "artifact_identity_source": "frontmatter.uuid", "artifact_identity_state": "resolved",
+        "artifact_companion_of": None, "artifact_owns_identity": True, "content_hash": "h",
+        "body": "# N\n\nBody.", "panel_rail": "rail", "runtime_environment_label": "dev",
+        "runtime_api_base_url_label": "local-dev", "runtime_trace_id": "t",
+        "runtime_vault_name": "vault/dev", "runtime_vault_channel": "dev", "runtime_vault_provenance": "resolved",
+        "canvas_session_state": "idle", "canvas_session_persistence": "durable",
+        "panel_state": "idle", "panel_proposal_count": 0, "panel_proposals": [], "panel_message": "",
+        "guard_writeguard_status": "ok", "guard_canvas_enabled": True, "guard_degraded": False,
+        "guard_workspace_update_available": True, "guard_update_flow_available": False,
+        "find_candidates": [], "find_payload_available": False, "reorient_sections": {},
+        "resurface_candidates": [], "governance_receipts": [], "suggestion_state": "idle",
+        "suggestion_composer_enabled": True, "is_production_ui": False, "dev_page_label": "dev/staging",
+        "workspace_loaded_at": None,
+        "vault_browser_notes": notes, "vault_browser_query": "",
+        "vault_browser_total_notes": len(notes), "vault_browser_filtered_notes": len(notes),
+        "vault_browser_read_only": True, "vault_browser_identity_available": True,
+        "vault_browser_vault_name": "vault/dev", "vault_browser_vault_channel": "dev",
+    }
+
+
+def _html(*, notes=None, note_path="📥 Inbox/Companion_UI_Markdown_Feature_UAT.md"):
+    notes = _NOTES if notes is None else notes
+    return render_index_html(api_base_url="http://127.0.0.1:18001", note_path=note_path,
+                             fields=_fields(notes=notes, note_path=note_path))
+
+
+def _folder(html, full):
+    """Return the opening markup of the folder node with data-folder == full."""
+    m = re.search(r'<li class="vault-tree-folder"[^>]*data-folder="' + re.escape(full) + r'"[^>]*>', html)
+    return m.group(0) if m else None
+
+
+def test_browse_renders_nested_folder_tree():
+    html = _html()
+    # Folders exist for both System and its nested companions subfolder.
+    assert _folder(html, "⚙️ System")
+    assert _folder(html, "⚙️ System/companions")
+    # The companions folder node is nested *inside* the System folder node.
+    sys_start = html.index('data-folder="⚙️ System"')
+    sys_details = html.index("</details>", sys_start)  # close of the System folder
+    comp_idx = html.index('data-folder="⚙️ System/companions"')
+    assert sys_start < comp_idx < sys_details, "companions must nest inside System"
+
+
+def test_active_note_ancestor_folders_expanded_others_collapsed():
+    html = _html(note_path="📥 Inbox/Test note 2.md")
+    inbox = _folder(html, "📥 Inbox")
+    system = _folder(html, "⚙️ System")
+    assert inbox and system
+    # The active note's folder <details> is open; an unrelated folder is not.
+    inbox_details = re.search(r'data-folder="📥 Inbox"[^>]*>\s*<details([^>]*)>', html)
+    system_details = re.search(r'data-folder="⚙️ System"[^>]*>\s*<details([^>]*)>', html)
+    assert inbox_details and "open" in inbox_details.group(1)
+    assert system_details and "open" not in system_details.group(1)
+
+
+def test_note_rows_show_name_only_no_metadata():
+    html = _html()
+    rows = re.findall(r'<li class="vault-browser-row[^"]*"[^>]*>.*?</li>', html, re.S)
+    assert rows
+    # The active Inbox note row shows the filename stem as its visible link text,
+    # not the (duplicate) frontmatter title, and carries no raw metadata text.
+    active = [r for r in rows if 'data-active="true"' in r][0]
+    link = re.search(r'data-testid="workspace-vault-browser-note-link"[^>]*>([^<]*)</a>', active)
+    assert link and link.group(1) == "Companion_UI_Markdown_Feature_UAT"
+    # Filter-style label text never appears in a row.
+    for leak in ("Kind:", "Zone:", "Review:", "Trust:"):
+        assert leak not in active, f"row leaks {leak!r}"
+    # review_state appears only inside a nav-hidden badge (hidden from row text).
+    if "needs_review" in active:
+        badge = re.search(r'<span([^>]*)>needs_review</span>', active)
+        assert badge and "note-badge--nav-hidden" in badge.group(1)
+    # The path/zone elements carry the path only in a hidden code/attr, never as
+    # visible row label text (the visible label is the stem above).
+    assert "hidden>" in active  # the note-path <code> is hidden
+    assert 'class="vault-browser-zone-label"' in active  # zone span present but display:none
+
+
+def test_active_note_row_is_highlighted():
+    html = _html()
+    rows = re.findall(r'<li class="vault-browser-row[^"]*"[^>]*>.*?</li>', html, re.S)
+    active = [r for r in rows if 'data-active="true"' in r]
+    assert len(active) == 1
+    # A visible active style exists.
+    assert re.search(r'\.vault-browser-row\[data-active="true"\][^{]*\{[^}]*\}', html)
+
+
+def test_folders_are_collapsible_details():
+    html = _html()
+    folder = _folder(html, "📥 Inbox")
+    assert folder
+    # The folder body is a <details>/<summary> (collapsible) with the segment name.
+    block = html[html.index(folder):]
+    summary = re.search(r'<summary class="vault-tree-folder-summary"[^>]*>([^<]*)</summary>', block)
+    assert summary and "Inbox" in summary.group(1)
+
+
+def test_tree_preserves_note_testids_and_density():
+    html = _html()
+    assert 'data-testid="workspace-vault-browser-list"' in html
+    assert 'data-testid="workspace-vault-browser-note-link"' in html
+    assert 'data-testid="workspace-vault-browser-note-row"' in html
+    # Root-level notes (no folder) still render as rows.
+    assert "Companion UI UAT.md" in html or "Companion UI UAT" in html


### PR DESCRIPTION
Fixes #1425

## Summary
Browse mode now renders the Vault Browser as a nested, collapsible **folder tree** like the Obsidian file explorer (owner's UAT reference), instead of flat folder groups. Folders nest by real path depth and collapse; notes are clean name-only rows indented under their folder; the active note's ancestor folders auto-expand and the active row is highlighted.

## Source / reference
- Owner UAT reference: the Obsidian file explorer for the Niflheim vault (nested collapsible folders + emoji + indented name-only notes + active highlight + vault name at foot).
- `companion-ui/docs/VAULT_BROWSER_UI_REQUIREMENTS.md`, `ADAPTIVE_WORKSPACE_LAYOUT_HANDOFF.md` §§4.1, 6; `docs/HUMAN-FLOWS.md`; issue-to-code workflow.

## Changes
- `_build_vault_tree` / `_render_vault_tree`: build + render a nested tree from server-provided note paths (no filesystem reads). Folders → collapsible `<details>` with a rotating chevron and the emoji/segment name; nested folders nest in the DOM (e.g. `⚙️ System > companions`).
- Auto-expand the folders on the path to the active note; collapse the rest.
- `_render_vault_note_row`: clean rows — visible label is the **filename stem** (disambiguates same-titled notes, matching Obsidian), title is the tooltip; path/zone/metadata stay in hidden elements (`data-*` preserved). Root notes render at the bottom.
- Active row highlighted; browse header meta + matches counter de-emphasized (hidden, kept in DOM for tests). Companion/UUID notes keep daily-use hide-by-default (#1361).
- New `tests/companion_ui/test_vault_browser_tree.py` (6 cases).

## Authority / guardrail notes
Non-authoritative shell: tree is built from server-provided paths only — no filesystem reads, no writes, no kind inference. No drag-drop/rename/create/sort. #1417 (no raw metadata in rows), #1398 (one canonical surface), #1399 (browse mode), #1400 (density) and same-origin behaviour all preserved; stable `data-*` testids kept (`note-row/-link/-path`, `-group`, `-list`).

## Tests run
- `test_vault_browser_tree.py` → 6 passed.
- Compat matrix `test_vault_browser.py + test_vault_browser_density.py + test_vault_browser_single_surface.py + test_vault_browser_left_pane.py + test_vault_browser_inspector.py + test_orphan_text_nodes.py` → 70 passed.
- Full `tests/companion_ui/` → 1196 passed, 4 failed = documented pre-existing baseline only; no new regressions.
- `python3 scripts/docs_guard.py` → OK; `git diff --check` → clean; `python3 -m ruff check app tests companion-ui/companion-app/companion_ui` → **All checks passed!**

## Browser UAT (acceptance gate)
Local static render of a representative Niflheim layout, 1280×900, Browse mode, `preview_eval` walk of the rendered tree:

```
▸ ⚙️ System [collapsed]
▸ 💡 Knowledge [collapsed]
▸ 📁 Projects [collapsed]
▸ 📥 Inbox [open]                ← active note's folder auto-expanded
  • Companion_UI_Markdown_Feature_UAT ◀ active   ← indented + highlighted (bg-raised)
  • Namnlös
  • Test note 2
▸ 🔍 Focus [collapsed]
▸ 📒 Reference [collapsed]
• Companion UI UAT               ← root notes at the bottom
• Test
```
- `⚙️ System > companions` nests inside System (`details.contains` = true); companion note hidden by default.
- Active row computed background = `bg-raised`; header meta computed `display:none`.
- **Before**: flat folder-group headers (`(root)`, `📥 Inbox`, `⚙️ System/companions`) with title+filename rows and a matches counter.

## Known limitations
- The artifact inspector still renders below the tree for the selected note (the #1255/#1417-sanctioned metadata home); its label/value spacing is a pre-existing cosmetic quirk, out of scope here.
- Folder order is server/insertion order (not Obsidian's custom configured order).
- Live runtime needs redeploy to reflect this; acceptance evidence is local static-render UAT.
- Dispatcher claim via GitHub-label flow; Codex review rate-limited (did not run).

---