### PR TITLE
fix(companion-ui): clean the Vault Browser tree — collapse inspector dump + subtle hover (#1427)

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -1871,9 +1871,21 @@ def _render_vault_browser(
     calm_provenance = "read-only fallback · filesystem index" if read_only else "filesystem index"
     filters_html = _render_filter_chips(notes, active_filters or {})
     selected_note = next((n for n in notes if str(n.get("note_path") or "").strip() == note_path), None)
-    inspector_html = (
+    # #1427 — keep the inspector out of the default browse view. The tree is the
+    # surface; the inspector metadata/actions sit behind a collapsed disclosure
+    # so the pane reads like a file tree, not a debug dump (fields stay in DOM).
+    _inspector_panel = (
         _render_artifact_inspector(selected_note, vault_name=vault_name, vault_channel=vault_channel)
         if selected_note is not None
+        else ""
+    )
+    inspector_html = (
+        '<details class="vault-browser-inspector-disclosure">'
+        '<summary class="vault-browser-inspector-summary" '
+        'data-testid="workspace-vault-browser-inspector-toggle">Note details</summary>'
+        f"{_inspector_panel}"
+        "</details>"
+        if _inspector_panel
         else ""
     )
     hidden_html = (
@@ -5093,10 +5105,14 @@ def render_index_html(
     .vault-tree-folder-details[open] > .vault-tree-folder-summary::before {{
       transform: rotate(90deg);
     }}
-    .vault-tree-folder-summary:hover {{
+    /* #1427 — subtle full-width background highlight on hover/focus (Obsidian /
+       Claude Code style), not a heavy outline box or browser focus ring. */
+    .vault-tree-folder-details > summary:focus {{ outline: none; }}
+    .vault-tree-folder-summary:hover,
+    .vault-tree-folder-details > summary:focus-visible > .vault-tree-folder-summary,
+    .vault-tree-folder-details > summary:focus-visible {{
+      background: var(--bg-raised);
       color: var(--fg-1);
-      outline: 1px solid var(--border-focus);
-      outline-offset: 1px;
     }}
     /* Tree note rows mirror .note-outline-link exactly. */
     .vault-tree .vault-browser-row {{
@@ -5119,16 +5135,54 @@ def render_index_html(
       text-overflow: ellipsis;
       white-space: nowrap;
     }}
-    .vault-tree .vault-browser-row-title:hover {{
+    .vault-tree .vault-browser-row-title:hover,
+    .vault-tree .vault-browser-row-title:focus-visible {{
+      background: var(--bg-raised);
       color: var(--fg-1);
-      outline: 1px solid var(--border-focus);
-      outline-offset: 1px;
+      outline: none;
+    }}
+    /* Active note: a subtle full-width background block + the Outline accent
+       rail/text, so it reads as the current selection (Obsidian/Claude Code). */
+    .vault-tree .vault-browser-row[data-active="true"] {{
+      background: var(--bg-raised);
+      border-radius: var(--radius-sm);
     }}
     .vault-tree .vault-browser-row[data-active="true"] > .vault-browser-row-title {{
       border-left-color: var(--accent);
       color: var(--accent);
     }}
     .vault-tree .vault-browser-row-path {{ display: none; }}
+    /* #1427 — inspector behind a collapsed disclosure; deterministic collapse. */
+    .vault-browser-inspector-disclosure {{
+      border-top: 1px solid var(--border);
+      margin-top: 8px;
+      padding-top: 6px;
+    }}
+    .vault-browser-inspector-summary {{
+      color: var(--fg-3);
+      cursor: pointer;
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      letter-spacing: 0.06em;
+      list-style: none;
+      padding: 2px 2px;
+      text-transform: uppercase;
+    }}
+    .vault-browser-inspector-summary::-webkit-details-marker {{ display: none; }}
+    .vault-browser-inspector-disclosure:not([open]) > :not(summary) {{
+      display: none;
+    }}
+    /* #1427 — readable label/value spacing in the inspector (was "kindnote"). */
+    .inspector-field {{
+      display: flex;
+      gap: 6px;
+      justify-content: space-between;
+      padding: 2px 0;
+    }}
+    .inspector-field > .inspector-label {{
+      color: var(--fg-3);
+      flex-shrink: 0;
+    }}
     /* #1425 — de-emphasize browse header chrome; the tree is the surface. The
        "Browse vault notes" toggle matches the Outline heading label. */
     .vault-browser-meta,

--- a/tests/companion_ui/test_vault_browser_tree.py
+++ b/tests/companion_ui/test_vault_browser_tree.py
@@ -132,3 +132,50 @@ def test_tree_preserves_note_testids_and_density():
     assert 'data-testid="workspace-vault-browser-note-row"' in html
     # Root-level notes (no folder) still render as rows.
     assert "Companion UI UAT.md" in html or "Companion UI UAT" in html
+
+
+# ---------------------------------------------------------------------------
+# #1427 — clean default browse view (no inspector dump, subtle hover/selection)
+# ---------------------------------------------------------------------------
+
+
+def test_inspector_is_collapsed_behind_a_disclosure_by_default():
+    html = _html()
+    m = re.search(
+        r'<details class="vault-browser-inspector-disclosure"([^>]*)>(.*?)</details>',
+        html, re.S,
+    )
+    assert m, "inspector must sit behind a vault-browser-inspector-disclosure <details>"
+    assert "open" not in m.group(1), "inspector disclosure must be collapsed by default"
+    # The inspector fields are still in the DOM (preserve #1255).
+    assert 'data-testid="workspace-vault-browser-inspector"' in m.group(2)
+    # Deterministic collapse CSS so the dump is hidden in every engine.
+    assert re.search(
+        r'\.vault-browser-inspector-disclosure:not\(\[open\]\)[^{]*\{[^}]*display:\s*none',
+        html,
+    )
+
+
+def test_tree_hover_uses_background_not_outline_box():
+    html = _html()
+    # The tree row hover rule highlights with a background, not an outline box.
+    hover = re.search(
+        r'\.vault-tree \.vault-browser-row-title:hover[^{]*\{([^}]*)\}', html
+    )
+    assert hover, "tree row hover rule missing"
+    assert "background" in hover.group(1)
+    # No heavy outline box (outline:none to drop the focus ring is fine).
+    assert "border-focus" not in hover.group(1)
+    assert "outline: 1px" not in hover.group(1)
+    # The folder summary focus ring is suppressed (no heavy blue box).
+    assert re.search(
+        r'\.vault-tree-folder-details > summary:focus[^{]*\{[^}]*outline:\s*none', html
+    )
+
+
+def test_active_note_has_subtle_background_highlight():
+    html = _html()
+    rule = re.search(
+        r'\.vault-tree \.vault-browser-row\[data-active="true"\]\s*\{([^}]*)\}', html
+    )
+    assert rule and "background" in rule.group(1), "active row needs a background highlight"


### PR DESCRIPTION
Fixes #1427

## Summary
Follow-up to #1425. Live UAT showed the browse pane still reading as a debug dump (always-visible inspector metadata/actions) with a heavy blue outline-box on hover/focus. This makes the default browse view just the clean folder tree — like Obsidian, the Outline mode, and the Claude Code sidebar.

## Changes
- The artifact inspector is collapsed behind a "Note details" disclosure (deterministic `:not([open])` collapse). Default browse surface = the tree only; inspector fields stay in the DOM (preserve #1255).
- Hover/focus uses a subtle full-width `bg-raised` background highlight instead of the `border-focus` outline box + browser focus ring (`summary:focus { outline:none }`).
- The active note gets a subtle background block in addition to the Outline accent rail + accent text.
- Inspector field rows get label/value spacing (`.inspector-field { display:flex; gap:6px }`) so the disclosed inspector is readable (was "kindnote").

## Authority / guardrail notes
Non-authoritative shell; no runtime/write/semantics changes. Preserves #1417 (no raw metadata in rows), #1425 (tree + Outline graphical profile), #1255 (inspector fields in DOM), same-origin behaviour. Stable `data-*` testids kept.

## Tests run
- `test_vault_browser_tree.py` (incl. 3 new) → 9 passed.
- `test_vault_browser_inspector.py + test_vault_browser.py + test_vault_browser_density.py + test_orphan_text_nodes.py` → 57 passed.
- Full `tests/companion_ui/` → 1199 passed, 4 failed = documented pre-existing baseline only; no new regressions.
- `docs_guard` OK; `git diff --check` clean; `ruff` → **All checks passed!**

## Browser UAT (acceptance gate)
Local static render of the Niflheim layout, 1280×900, Browse mode, `preview_eval`:
- **Before** (live UAT screenshot of #1425): below the tree, a dump — `Companion UI UAT.md / kindnote / zoneCompanion UI UAT.md / review stateinbox / trustinternal / uuid11111111… / Open note / Copy path / Find related …` — plus a blue outline box around the focused Inbox folder.
- **After** (this PR): default pane text = `Browse | Outline | Context | BROWSE VAULT NOTES | Filters | ⚙️ System | 💡 Knowledge | 📁 Projects | 📥 Inbox | Companion_UI_Markdown_Feature_UAT | Namnlös | Test note 2 | 🔍 Focus | 📒 Reference | Companion UI UAT | NOTE DETAILS`. Inspector `offsetParent === null` (behind the collapsed "NOTE DETAILS" disclosure); active row background == `--bg-raised`; no outline box.

## Known limitations
- Live runtime needs redeploy to reflect this; acceptance evidence is local static-render UAT.
- Dispatcher claim via GitHub-label flow; Codex review rate-limited (did not run).

---