### PR TITLE
fix(companion-ui): edit composer no longer squeezes the note reading surface (#1416)

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -653,27 +653,38 @@ def _render_body_edit_panel(update_flow_available: bool, note_path: str, raw_bod
             "</span>"
             "</section>"
         )
-    return f"""<div class="body-edit-panel" data-testid="workspace-body-edit-panel"
+    # #1416 — render the dev composer as an opt-in disclosure that is collapsed
+    # by default. In the fixed-height shell (#1397) a sibling that grows with its
+    # content squeezes the note reading surface; a collapsed <details> contributes
+    # only its summary row so the note body keeps its reading height, and the
+    # expanded body is height-bounded with internal scroll (CSS) so it still
+    # cannot consume the reading layout's space. testid markers are preserved.
+    return f"""<details class="body-edit-panel" data-testid="workspace-body-edit-panel"
          data-update-flow="available">
-  <div class="body-edit-header">
+  <summary class="body-edit-summary" data-testid="workspace-body-edit-summary">
     <span class="body-edit-label">Edit note body</span>
-    <span class="body-edit-note">Frontmatter and UUID are preserved. WriteGuard is authoritative.</span>
+    <span class="body-edit-note">Opt-in &middot; keeps the reading surface primary</span>
+  </summary>
+  <div class="body-edit-body">
+    <div class="body-edit-header">
+      <span class="body-edit-note">Frontmatter and UUID are preserved. WriteGuard is authoritative.</span>
+    </div>
+    <div class="body-edit-codemirror" id="body-edit-codemirror"
+         data-testid="workspace-body-edit-textarea"
+         data-note-path="{note_path}"
+         data-raw-body="{_e(raw_body)}"></div>
+    <div class="body-edit-actions">
+      <button class="body-edit-submit"
+              data-testid="workspace-body-edit-submit"
+              onclick="bodyEditor.submit()">Apply update</button>
+      <button class="body-edit-reset"
+              data-testid="workspace-body-edit-reset"
+              onclick="bodyEditor.reset()">Reset</button>
+    </div>
+    <div class="body-edit-status" id="body-edit-status"
+         data-testid="workspace-body-edit-status"></div>
   </div>
-  <div class="body-edit-codemirror" id="body-edit-codemirror"
-       data-testid="workspace-body-edit-textarea"
-       data-note-path="{note_path}"
-       data-raw-body="{_e(raw_body)}"></div>
-  <div class="body-edit-actions">
-    <button class="body-edit-submit"
-            data-testid="workspace-body-edit-submit"
-            onclick="bodyEditor.submit()">Apply update</button>
-    <button class="body-edit-reset"
-            data-testid="workspace-body-edit-reset"
-            onclick="bodyEditor.reset()">Reset</button>
-  </div>
-  <div class="body-edit-status" id="body-edit-status"
-       data-testid="workspace-body-edit-status"></div>
-</div>"""
+</details>"""
 
 
 _LEFT_PANEL_MODES = ("browse", "outline", "context", "collapsed")
@@ -4875,14 +4886,40 @@ def render_index_html(
     .panel-confirm-receipt {{ color: var(--fg-1); }}
     .panel-confirm-blocked {{ color: var(--destructive); }}
     /* Body edit panel */
+    /* #1416 — the composer is shrink-locked and height-bounded so it cannot
+       squeeze the central note reading surface in the fixed-height shell
+       (#1397). Collapsed by default it is just the summary row; expanded it is
+       capped at 42vh and scrolls internally instead of growing the column. */
     .body-edit-panel {{
       border: 1px solid var(--border-strong);
       border-radius: var(--radius-md);
       display: flex;
       flex-direction: column;
+      flex-shrink: 0;
       gap: 8px;
       margin-top: 12px;
+      max-height: 42vh;
+      overflow-y: auto;
       padding: 12px;
+    }}
+    .body-edit-summary {{
+      align-items: baseline;
+      cursor: pointer;
+      display: flex;
+      gap: 10px;
+      list-style-position: inside;
+    }}
+    /* Deterministic collapse — some rendering engines do not apply the UA
+       details:not([open]) rule, so hide the body explicitly when collapsed so
+       the composer contributes only its summary row (#1416). */
+    .body-edit-panel:not([open]) > :not(summary) {{
+      display: none;
+    }}
+    .body-edit-body {{
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      padding-top: 10px;
     }}
     .body-edit-disabled {{
       border-color: var(--border-strong);
@@ -4908,7 +4945,9 @@ def render_index_html(
       background: var(--bg-raised);
       border: 1px solid var(--border-strong);
       border-radius: var(--radius-md);
-      min-height: 200px;
+      max-height: 28vh;
+      min-height: 160px;
+      overflow: auto;
       width: 100%;
     }}
     .body-edit-codemirror .cm-editor {{
@@ -5541,6 +5580,14 @@ def render_index_html(
       extensions: [basicSetup, markdown({{base: markdownLanguage}}), oneDark],
       parent: container,
     }});
+    // #1416 — the composer is a collapsed <details> by default, so CodeMirror
+    // mounts with zero measured size. Re-measure when the user opens it.
+    var panel = container.closest('details.body-edit-panel');
+    if (panel) {{
+      panel.addEventListener('toggle', function() {{
+        if (panel.open && window._cmView) {{ window._cmView.requestMeasure(); }}
+      }});
+    }}
   }}
   </script>
   <script>

--- a/tests/companion_ui/test_workspace_layout.py
+++ b/tests/companion_ui/test_workspace_layout.py
@@ -196,3 +196,57 @@ def test_layout_preserves_single_scroll_ownership_markers():
     assert "overflow-y: auto;" not in content, (
         "note-body-content must not own a second nested scroll"
     )
+
+
+# ---------------------------------------------------------------------------
+# AC (#1416): the dev "Edit note body" composer must not squeeze the reading
+# surface in the fixed-height shell. With guard_update_flow_available the
+# composer renders as an opt-in disclosure (collapsed by default) and is
+# shrink-locked + height-bounded, so the note reading layout stays primary.
+# ---------------------------------------------------------------------------
+
+
+def test_edit_composer_is_collapsed_by_default_so_reading_stays_primary():
+    # _fields() sets guard_update_flow_available=True, so the enabled composer
+    # renders. It must be present but collapsed, contributing only its summary
+    # row, so the note body keeps its reading height (#1416, corrective #4).
+    html = _html()
+    assert 'data-testid="workspace-body-edit-panel"' in html
+    assert 'data-update-flow="available"' in html
+    panel = re.search(
+        r'<details class="body-edit-panel"[^>]*'
+        r'data-testid="workspace-body-edit-panel"[^>]*>',
+        html,
+    )
+    assert panel, "enabled body-edit composer must render as a <details> disclosure"
+    # Collapsed by default: no `open` attribute on the <details> tag.
+    assert not re.search(r"\bopen\b", panel.group(0)), (
+        "edit composer must be collapsed by default (opt-in), not expanded"
+    )
+
+
+def test_edit_composer_does_not_compete_with_reading_layout_for_shell_height():
+    html = _html()
+    # The reading layout remains the single growing primary region.
+    reading = _css_block(html, r"\.note-reading-layout")
+    assert "flex: 1;" in reading
+    assert "min-height: 0;" in reading
+    # The composer is shrink-locked and height-bounded with internal scroll, so
+    # it cannot consume the reading layout's space even when expanded.
+    panel = _css_block(html, r"\.body-edit-panel")
+    assert "flex-shrink: 0;" in panel, "composer must not be squeezed by the shell"
+    assert "max-height" in panel, "composer must be height-bounded"
+    assert "overflow-y: auto;" in panel, "composer must scroll internally when tall"
+
+
+def test_edit_composer_preserves_single_scroll_ownership():
+    # With the composer enabled, the #1397 scroll-ownership contract still holds.
+    html = _html()
+    body = _css_block(html, r"body")
+    assert "height: 100dvh;" in body
+    assert "overflow: hidden;" in body
+    note_body = _css_block(html, r"\.note-body")
+    assert "overflow-y: auto;" in note_body
+    # The composer's internal scroll is a bounded editor surface, not a second
+    # ownership of the page/reading scroll.
+    assert html.count("height: 100dvh;") == 1


### PR DESCRIPTION
Fixes #1416

## Summary
In the fixed-height shell (#1397), the enabled dev **"Edit note body"** composer rendered as a flex sibling of the reading layout that grew with its content and squeezed the rendered note body to ~120px. This change renders the composer as an opt-in `<details>` disclosure that is **collapsed by default** (summary row only) and **shrink-locked + height-bounded** (`flex-shrink:0`, `max-height:42vh`, internal scroll), so the note reading layout stays the primary growing region.

## Scope
- `_render_body_edit_panel` (enabled branch): `<div class="body-edit-panel">` → `<details class="body-edit-panel">` with a `<summary>` ("Edit note body · Opt-in") and a `.body-edit-body` wrapper. All `workspace-body-edit-*` testids preserved; a new `workspace-body-edit-summary` testid added.
- CSS: composer `flex-shrink:0` + `max-height:42vh` + `overflow-y:auto`; deterministic `.body-edit-panel:not([open]) > :not(summary){display:none}` collapse (some engines don't apply UA `details` collapse); CodeMirror container `min-height:160px` + `max-height:28vh`.
- Client JS: re-`requestMeasure()` CodeMirror on disclosure `toggle` (it mounts while collapsed/hidden).
- Tests: 3 new layout-contract tests in `tests/companion_ui/test_workspace_layout.py`.

## Out of scope
- Canvas/Panel runtime semantics, writeguard, new editor capabilities, the broader #1395 corrective. No new write paths or runtime semantics.

## Contract/SoT docs read
- `companion-ui/docs/ADAPTIVE_WORKSPACE_LAYOUT_HANDOFF.md` (§3.3/§7 scroll ownership, §10 collapse-before-shrink, §5.3/§11 dev controls behind disclosure). The fix **conforms to** existing handoff guidance (collapse before shrinking the center; dev/operator harness behind diagnostics chrome), so no contract change → no owner-doc edit required.
- `serve_dev_page.py`, `note_outline.py`, `tests/companion_ui/test_workspace_layout.py`, `_orphan_text.py`.

## Behavior changes
- Enabled composer is collapsed by default and never crushes the reading surface; expanded it is bounded at 42vh and scrolls internally instead of growing the column.

## Tests run
```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest -q \
  tests/companion_ui/test_workspace_layout.py \
  tests/companion_ui/test_orphan_text_nodes.py \
  tests/companion_ui/test_workspace_shell_alignment.py
# 68 passed

PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest -q tests/companion_ui \
  -k "workspace or body_edit or composer or reading or layout or canvas_edit or shell or properties or responsive"
# 396 passed, 2 failed (both pre-existing baseline failures unrelated to this change:
#   test_renders_runtime_safety_strip_and_identity_pills — drifted testid;
#   test_workspace_resurface_source_link_uses_logical_identifier — companion.py:562 lambda kwarg)

.venv/bin/python -m ruff check <touched files>   # All checks passed!
git diff --check                                  # clean
```

## UAT evidence (static render of `render_index_html`, Claude Preview MCP)
Collapsed (default), measured via DOM `getBoundingClientRect`:
- 1280×720: note body **518px** (was 120px), composer 54px summary, `body{overflow:hidden}`, `details.open=false`.
- 1440×900: note body **698px**, composer 54px.

Expanded (explicit opt-in) at 1280×720: panel capped at 42vh (302px) with internal scroll; CodeMirror mounts + measures (`requestMeasure` on toggle); note body 270px and bounded. No console errors at either viewport.

AC1 (note body ≥360px usable + not clipped with composer enabled): met in default state at both viewports. AC2 (#1397 scroll-ownership preserved): `test_workspace_layout.py` green.

## Known residual risks
- Expanded composer reduces the reading column to ~270px at 720px height — this is the explicit opt-in tradeoff sanctioned by the issue (disclosure option), and is bounded (no unbounded growth).

## Rollback plan
Revert this commit; the composer returns to the always-expanded sibling layout. No data/runtime/migration impact.

## Notes
- Dispatcher unavailable in this environment (`python -m app.dispatcher` not runnable) — used GitHub-label-only flow.

---