### PR TITLE
fix(companion-ui): resolved wikilinks navigate + workspace link-resolver seam (#1345)

### DIFF
--- a/companion-ui/companion-app/companion_ui/renderer/vault_markdown_renderer.py
+++ b/companion-ui/companion-app/companion_ui/renderer/vault_markdown_renderer.py
@@ -362,6 +362,16 @@ def _render_heading(match: re.Match[str], context: _RenderContext) -> str:
     return f'<h{level} id="{_e(anchor)}">{_render_inline(text, context)}</h{level}>'
 
 
+def _slugify_anchor(text: str) -> str:
+    """Slug used for heading element ids and heading-fragment link hrefs.
+
+    Both sides must agree so that ``[[Note#Heading]]`` navigates to the rendered
+    ``<h_ id="...">`` (#1345).
+    """
+    slug = re.sub(r"-+", "-", "".join(char if char.isalnum() else "-" for char in text.lower()))
+    return slug.strip("-")
+
+
 def _heading_text_and_anchor(raw_text: str) -> tuple[str, str]:
     text = raw_text.strip()
     explicit_anchor = _EXPLICIT_ANCHOR_RE.search(text)
@@ -369,8 +379,7 @@ def _heading_text_and_anchor(raw_text: str) -> tuple[str, str]:
         text = text[: explicit_anchor.start()].strip()
         return text, explicit_anchor.group(1)
     text = text.strip(" #\t")
-    slug = re.sub(r"-+", "-", "".join(char if char.isalnum() else "-" for char in text.lower()))
-    return text, slug.strip("-")
+    return text, _slugify_anchor(text)
 
 
 def _list_kind(line: str) -> str | None:
@@ -548,7 +557,8 @@ def _render_wikilink(raw: str, context: _RenderContext) -> str:
     href = f"?note_path={quote(note_path, safe='')}"
     fragment = _resolution_fragment(resolution)
     if fragment:
-        href = f"{href}#{quote(fragment, safe='')}"
+        # Keep ``^`` literal so block-id links read as ``#^block-id`` (#1345 AC4).
+        href = f"{href}#{quote(fragment, safe='^')}"
     trigger_html = (
         '<a class="vault-wikilink" '
         'data-link-state="resolved" '
@@ -621,11 +631,14 @@ def _render_unresolved_link_partial(
 
 
 def _resolution_fragment(resolution: object) -> str:
-    heading = getattr(resolution, "heading", None)
     block_id = getattr(resolution, "block_id", None)
     if block_id:
         return f"^{block_id}"
-    return str(heading or "")
+    heading = getattr(resolution, "heading", None)
+    if heading:
+        # Match the slugified heading element id so the link scrolls to it.
+        return _slugify_anchor(str(heading))
+    return ""
 
 
 def _render_obsidian_embed(raw: str, context: _RenderContext) -> str:

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -57,6 +57,7 @@ from companion_ui.renderer import (
     render_note_outline,
     render_vault_markdown,
 )
+from companion_ui.renderer.link_resolver import VaultLinkResolver
 from companion_ui.workspace.real_note_workspace_dev_page import (
     NoteLoadIntent,
     RealNoteWorkspaceDevPage,
@@ -774,6 +775,28 @@ def _render_left_context_panel(
     )
 
 
+def _coerce_vault_link_index(value: object) -> dict[str, list[str]]:
+    """Normalize an optional active-vault link index for the link resolver.
+
+    Accepts ``{target: note_path}`` or ``{target: [note_path, ...]}`` and returns
+    a mapping the ``VaultLinkResolver`` accepts. Unknown/None shapes yield an
+    empty index (links stay diagnostic), preserving prior behavior (#1345).
+    """
+    if not isinstance(value, dict):
+        return {}
+    index: dict[str, list[str]] = {}
+    for key, candidates in value.items():
+        if isinstance(candidates, str):
+            paths = [candidates]
+        elif isinstance(candidates, (list, tuple)):
+            paths = [str(path) for path in candidates if path]
+        else:
+            continue
+        if paths:
+            index[str(key)] = paths
+    return index
+
+
 def _render_note_section(fields: dict) -> str:
     """Render the workspace shell from render_fields() output.
 
@@ -799,7 +822,14 @@ def _render_note_section(fields: dict) -> str:
     vault_channel = _e(fields.get("runtime_vault_channel") or "unknown")
     vault_provenance = fields.get("runtime_vault_provenance") or "unresolved"
     raw_body = str(fields.get("body", "") or "")
-    rendered_body = render_vault_markdown(raw_body, note_path=raw_note_path)
+    # #1345 — seed the link resolver with the active-vault link index so
+    # vault-internal wikilinks resolve and navigate. When the index is absent
+    # (current runtime, pending the read-only link-index API) this is an empty
+    # resolver, identical to the prior default — every link stays diagnostic.
+    link_resolver = VaultLinkResolver(_coerce_vault_link_index(fields.get("vault_link_index")))
+    rendered_body = render_vault_markdown(
+        raw_body, note_path=raw_note_path, link_resolver=link_resolver
+    )
     body = rendered_body.html
     outline_html = render_note_outline(rendered_body.document)
     has_headings = bool(tuple(rendered_body.document.headings))

--- a/companion-ui/docs/VAULT_MARKDOWN_RENDERER_CONTRACT.md
+++ b/companion-ui/docs/VAULT_MARKDOWN_RENDERER_CONTRACT.md
@@ -257,6 +257,12 @@ output (HTML via React or equivalent).
 
 - The renderer does not call write endpoints.
 - The renderer does not read vault files directly.
+- A resolved internal link emits `<a class="vault-wikilink" data-link-state="resolved" href="?note_path=…">`.
+  A heading fragment is emitted as the slugified heading anchor (`#some-heading`,
+  matching the rendered `<h_ id>`) so the link scrolls to the heading; a block-id
+  fragment keeps the literal `#^block-id` form. Resolution requires the
+  `VaultLinkResolver` to be seeded with the active-vault link index; with an empty
+  index every link stays diagnostic.
 - The renderer does not emit navigation events as mutations.
 - The renderer does not store resolved content in durable state.
 - Clicking an internal link is a navigation event, not a mutation.

--- a/tests/companion_ui/test_vault_markdown_renderer.py
+++ b/tests/companion_ui/test_vault_markdown_renderer.py
@@ -193,6 +193,69 @@ def test_missing_image_still_uses_partial_alongside_existing_asset() -> None:
     assert "nonexistent-image.png" in rendered.html
 
 
+def _wikilink_resolver() -> VaultLinkResolver:
+    # Stub resolver seeded with a single existing note (#1345). A real workspace
+    # request seeds the same shape from the active-vault link index.
+    return VaultLinkResolver({"Existing Note": "Notes/Existing Note.md"})
+
+
+def test_bare_wikilink_resolves() -> None:
+    # #1345 AC1 — a bare wikilink to an existing note navigates.
+    rendered = render_vault_markdown("[[Existing Note]]", link_resolver=_wikilink_resolver())
+
+    assert 'class="vault-wikilink"' in rendered.html
+    assert 'data-link-state="resolved"' in rendered.html
+    assert 'href="?note_path=Notes%2FExisting%20Note.md"' in rendered.html
+    assert ">Existing Note</a>" in rendered.html
+    assert "vault-wikilink-diagnostic" not in rendered.html
+
+
+def test_aliased_wikilink_resolves() -> None:
+    # #1345 AC2 — aliased link resolves; the alias is the visible text.
+    rendered = render_vault_markdown(
+        "[[Existing Note|display alias]]", link_resolver=_wikilink_resolver()
+    )
+
+    assert 'data-link-state="resolved"' in rendered.html
+    assert 'href="?note_path=Notes%2FExisting%20Note.md"' in rendered.html
+    assert ">display alias</a>" in rendered.html
+
+
+def test_heading_fragment_wikilink_resolves() -> None:
+    # #1345 AC3 — heading-fragment link resolves; href carries the slug anchor
+    # that matches the rendered heading element id so it scrolls into view.
+    rendered = render_vault_markdown(
+        "[[Existing Note#Some Heading]]", link_resolver=_wikilink_resolver()
+    )
+
+    assert 'data-link-state="resolved"' in rendered.html
+    assert "?note_path=Notes%2FExisting%20Note.md#some-heading" in rendered.html
+
+
+def test_block_id_wikilink_resolves() -> None:
+    # #1345 AC4 — block-id link resolves; href keeps the literal ^block-id form.
+    rendered = render_vault_markdown(
+        "[[Existing Note#^block-id]]", link_resolver=_wikilink_resolver()
+    )
+
+    assert 'data-link-state="resolved"' in rendered.html
+    assert "?note_path=Notes%2FExisting%20Note.md#^block-id" in rendered.html
+
+
+def test_unresolved_wikilink_unchanged() -> None:
+    # #1345 AC5 — an unresolved target keeps the post-#1334 diagnostic shape.
+    rendered = render_vault_markdown(
+        "[[Definitely Missing]]", link_resolver=_wikilink_resolver()
+    )
+
+    assert (
+        '<span class="vault-wikilink vault-wikilink-diagnostic" '
+        'data-link-state="missing"'
+    ) in rendered.html
+    assert "Definitely Missing" in rendered.html
+    assert 'data-link-state="resolved"' not in rendered.html
+
+
 def test_unsafe_html_stripped() -> None:
     rendered = render_vault_markdown(_fixture("comments-and-html.md"))
     lowered = rendered.html.lower()

--- a/tests/companion_ui/test_workspace_wikilink_seeding.py
+++ b/tests/companion_ui/test_workspace_wikilink_seeding.py
@@ -1,0 +1,87 @@
+"""Workspace wikilink resolver seeding (#1345).
+
+The renderer resolves vault-internal wikilinks correctly when given a seeded
+``VaultLinkResolver``. These tests pin the workspace render seam: when the
+fields carry an active-vault link index, ``[[Note]]`` renders as a resolved,
+navigable ``vault-wikilink``; when the index is absent (current runtime,
+pending the read-only link-index API), links stay diagnostic — identical to the
+prior default. This is a structural seam test against the rendered HTML.
+"""
+
+from __future__ import annotations
+
+from companion_ui.workspace.serve_dev_page import render_index_html
+
+
+def _fields(*, body: str, vault_link_index: object | None = None) -> dict:
+    base: dict = {
+        "title": "Seed Check",
+        "note_path": "Notes/seed-check.md",
+        "artifact_id": "art-seed-001",
+        "content_hash": "sha256-seed",
+        "body": body,
+        "guard_writeguard_status": "ok",
+        "guard_canvas_enabled": True,
+        "guard_degraded": False,
+        "guard_workspace_update_available": False,
+        "guard_update_flow_available": False,
+        "runtime_vault_provenance": "resolved",
+        "runtime_vault_name": "TestVault",
+        "runtime_vault_channel": "dev",
+        "panel_state": "idle",
+        "panel_proposal_count": 0,
+        "canvas_session_state": "idle",
+        "canvas_session_persistence": "durable",
+        "panel_proposals": [],
+        "panel_message": "",
+        "find_candidates": [],
+        "reorient_sections": None,
+        "resurface_candidates": [],
+        "governance_receipts": [],
+        "suggestion_state": "idle",
+        "suggestion_composer_enabled": True,
+        "is_production_ui": False,
+        "dev_page_label": "dev/staging",
+        "workspace_loaded_at": None,
+    }
+    if vault_link_index is not None:
+        base["vault_link_index"] = vault_link_index
+    return base
+
+
+def _render(**kwargs) -> str:
+    return render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="Notes/seed-check.md",
+        fields=_fields(**kwargs),
+    )
+
+
+def test_seeded_link_index_resolves_internal_wikilink() -> None:
+    html = _render(
+        body="See [[Existing Note]] for details.",
+        vault_link_index={"Existing Note": "Notes/Existing Note.md"},
+    )
+
+    assert 'class="vault-wikilink"' in html
+    assert 'data-link-state="resolved"' in html
+    assert "href=\"?note_path=Notes%2FExisting%20Note.md\"" in html
+
+
+def test_missing_link_index_keeps_diagnostic() -> None:
+    # No vault_link_index -> empty resolver -> diagnostic, unchanged behavior.
+    html = _render(body="See [[Existing Note]] for details.")
+
+    assert 'vault-wikilink-diagnostic' in html
+    assert 'data-link-state="missing"' in html
+    assert 'data-link-state="resolved"' not in html
+
+
+def test_link_index_accepts_list_candidates() -> None:
+    # Single-candidate list resolves; the coercion helper accepts list shape.
+    html = _render(
+        body="[[Existing Note]]",
+        vault_link_index={"Existing Note": ["Notes/Existing Note.md"]},
+    )
+
+    assert 'data-link-state="resolved"' in html


### PR DESCRIPTION
Fixes #1345

## Summary
Delivers the functional/internal-link branch of #1332 AC3: resolved vault-internal wikilinks navigate, unresolved keep the #1334 diagnostic. The renderer already emitted resolved `<a>` links, but (a) heading-fragment hrefs used the **raw** heading instead of the slug that the rendered `<h_ id>` uses (so they didn't scroll), and (b) the workspace render passed **no resolver**, so every link diagnosed. Both fixed.

## Scope
- **Renderer (`vault_markdown_renderer.py`):** shared `_slugify_anchor` now powers both heading element ids and heading-fragment link hrefs → `[[Note#Some Heading]]` emits `…#some-heading` and scrolls to the heading. Block-id links keep the literal `#^block-id` (`quote(safe='^')`). Resolved/alias/diagnostic shapes unchanged.
- **Workspace seam (`serve_dev_page.py`):** `_render_note_section` seeds `VaultLinkResolver(_coerce_vault_link_index(fields.get("vault_link_index")))`. **Absent index = empty resolver = prior behavior** (all diagnostic); populated index resolves + navigates.
- **Tests:** AC1–AC5 named renderer tests in `test_vault_markdown_renderer.py` (`test_bare_wikilink_resolves`, `test_aliased_wikilink_resolves`, `test_heading_fragment_wikilink_resolves`, `test_block_id_wikilink_resolves`, `test_unresolved_wikilink_unchanged`) + new `test_workspace_wikilink_seeding.py` pinning the seam (seeded→resolved, absent→diagnostic, list-candidate shape).
- **Owner doc:** `VAULT_MARKDOWN_RENDERER_CONTRACT.md` — invariant documenting the resolved-link href fragment forms + the seeding requirement.

## Out of scope (and why)
- **End-to-end live resolution** requires a read-only **vault link-index API** to populate `vault_link_index` — the UI must not rglob the vault (`UI_RUNTIME_BOUNDARIES`), and `/vault-browser` is capped/filtered, not a complete index. Creating that endpoint is new API architecture, so it is deferred to a bounded follow-up: **#1431**. This PR ships the renderer contract + the seam so #1431 is a small wiring slice.
- Hover preview (§10-D), rename backfill, cross-vault links, embed transclusion.

## Contract/SoT docs read
`VAULT_MARKDOWN_RENDERER_CONTRACT.md`, `UI_RUNTIME_BOUNDARIES.md`, `vault_markdown_renderer.py`, `link_resolver.py`, `serve_dev_page.py`, `real_note_workspace_dev_page.py`, `app/api/routes/companion.py`.

## Tests run
```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest -q \
  tests/companion_ui/test_vault_markdown_renderer.py tests/companion_ui/test_workspace_wikilink_seeding.py
# 18 passed
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest -q tests/companion_ui \
  -k "vault_markdown or wikilink or link or outline or heading or render"
# 310 passed, 4 failed — all 4 are documented pre-existing baseline failures
#   (companion.py:562 lambda kwarg ×3, drifted runtime-safety-strip testid ×1), unrelated.
.venv/bin/python -m ruff check <touched files>   # All checks passed!
git diff --check                                  # clean
```

## Known residual risks
- Until #1431 wires the link-index API, live wikilinks remain diagnostic (no regression — same as before). The seam + renderer are proven by tests.

## Rollback plan
Revert this commit; the renderer returns to raw heading fragments and the no-resolver workspace render. No runtime/migration impact.