### PR TITLE
fix(companion-ui): body-edit wiring acceptance + unsaved-edit signal (#1346)

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -1370,6 +1370,22 @@ def _render_active_note_body_update_flow(
             + "</div>"
         )
 
+    # #1346 AC5 — visible unsaved-edit signal. Rendered hidden by default and
+    # revealed when the editor has uncommitted content (client `oninput`), or
+    # shown immediately when the page model reports the `staged` state. It is an
+    # unsaved indicator only — it submits no write and does not alter writeguard.
+    staged_hidden = "" if safe_state == "staged" else " hidden"
+    staged_message = safe_message if (safe_state == "staged" and safe_message) else "Unsaved edit — commit to save."
+    staged_html = (
+        '<div class="active-note-body-update-staged" '
+        'data-testid="workspace-active-note-body-update-state-staged"'
+        f"{staged_hidden}>{staged_message}</div>"
+    )
+    reveal_staged = (
+        "var s=this.closest('.active-note-body-update-flow')"
+        ".querySelector('[data-testid=\\'workspace-active-note-body-update-state-staged\\']');"
+        "if(s){s.hidden=this.value.length===0;}"
+    )
     return f"""
         <section
           class="active-note-body-update-flow"
@@ -1379,6 +1395,7 @@ def _render_active_note_body_update_flow(
           <textarea
             id="active_note_body_update_input"
             data-testid="workspace-active-note-body-update-input"
+            oninput="{reveal_staged}"
             aria-label="Active note body update input"></textarea>
           <button
             type="button"
@@ -1387,6 +1404,7 @@ def _render_active_note_body_update_flow(
             data-api-path="/api/companion/workspace/update"
             data-note-path="{_e(note_path)}"
             data-content-hash="{_e(content_hash)}">Update body</button>
+          {staged_html}
           {status_html}
         </section>"""
 

--- a/companion-ui/design_handoff/2026-05-26-companion-ui-design-review/HUMAN_UAT_RESULTS.md
+++ b/companion-ui/design_handoff/2026-05-26-companion-ui-design-review/HUMAN_UAT_RESULTS.md
@@ -32,7 +32,7 @@ features under test. It was loaded through the runtime API and observed in the b
 | Mermaid diagrams | **PASS (automated + Preview UAT) / live UAT pending** | Valid fences render to inline SVG via a sandboxed client runtime; invalid fences degrade to the #1340 failed-embed partial (no Mermaid "bomb" error graphic). See the "2026-05-30 — Mermaid functional rendering (#1344)" section. Live Niflheim re-observation handed to the owner. |
 | Images | **PASS (automated) / live UAT pending** | Real-image rendering now proven via a committed license-clean fixture (`Attachments/uat_real_image.png`) and renderer tests; missing-image placeholder (#1340) unchanged. See the "2026-05-30 — image rendering fixture (#1347)" section below. Live Niflheim re-observation handed to the owner. |
 | Internal / wiki links | **FAIL** | Wikilinks (`[[Note Name]]`) do not resolve and do not navigate. Rendered as raw text or as a non-functional link. |
-| Body edit (note mutation) | **FAIL** | No body edit functionality is wired to the browser UI. Attempting to edit the note body produces no visible effect. The Canvas body-edit API exists in the backend but is not connected. |
+| Body edit (note mutation) | **PASS (automated) / live enabled-Canvas UAT pending** | The `active_note_body_update` flow is wired through `POST /api/companion/workspace/update` with writeguard: disabled→no write, commit→success+re-render, writeguard reject→blocked state, unsaved→staged signal, Panel proposals stay staged. See the "2026-05-30 — body-edit wiring (#1346)" section. Live enabled-Canvas walk handed to the owner (Niflheim keeps Canvas disabled). |
 
 ---
 
@@ -228,3 +228,37 @@ For the live Niflheim UAT (`http://10.42.42.10:8111`), add to
 malformed edges) and record the two fixture line numbers. Expected: the valid
 fence renders as a diagram; the broken fence shows the failed-embed dashed
 container with `view source`, and no error graphic leaks into the page.
+
+---
+
+## 2026-05-30 — body-edit wiring (#1346, supersedes the "Body edit FAIL" row; #1332 AC4)
+
+Note body editing is wired through the runtime `active_note_body_update` flow
+(`POST /api/companion/workspace/update`) with writeguard, Panel/Canvas
+separation, and staged-proposal preservation. The audit found the commit /
+writeguard / re-render machinery already implemented in
+`RealNoteWorkspaceDevPage.update_active_note_body`; this issue added the unsaved
+("staged") signal and the named acceptance coverage.
+
+### Automated acceptance (`tests/companion_ui/test_active_note_body_update.py`)
+
+| AC | Behaviour | Test |
+|---|---|---|
+| AC1 | Update capability disabled → no write, `blocked` state | `test_no_writes_when_canvas_disabled` |
+| AC2 | Explicit commit → `POST /workspace/update`, reload, `success` | `test_commit_round_trip` |
+| AC3 | Writeguard reject (403/blocked) → `blocked` state DOM, no silent loss | `test_writeguard_rejection_surfaces_failure_state` |
+| AC4 | Panel proposal stays staged; no auto-apply without explicit Apply | `test_proposal_does_not_auto_apply` |
+| AC5 | Uncommitted edit → visible `…-state-staged` signal + `oninput` reveal | `test_unsaved_edit_signal_visible` |
+| AC6 | After commit the body re-renders via `render_vault_markdown` (heading → `<h2>`) | `test_body_rerenders_with_renderer_after_commit` |
+
+### Live-runtime follow-up (owner)
+
+The live Niflheim runtime keeps Canvas disabled, so the **enabled-Canvas** human
+walk runs against a dev runtime with `CANVAS_ENABLED=1` /
+`guard_workspace_update_available=true`:
+1. With Canvas disabled: the body is read-only (#1341 pill); editing writes nothing.
+2. With Canvas enabled: type in the body → the unsaved/staged signal appears; the
+   explicit `Update body` commit succeeds and the body re-renders (headings,
+   callouts, links apply).
+3. Inject a Panel proposal: it stays staged (Apply / Discard / Defer) and never
+   becomes body text without explicit Apply.

--- a/companion-ui/docs/COMPANION_UI_DAILY_USE_VISIBILITY_CONTRACT.md
+++ b/companion-ui/docs/COMPANION_UI_DAILY_USE_VISIBILITY_CONTRACT.md
@@ -63,6 +63,16 @@ When `active_note_body_update_enabled=false` (defaults to `guard_workspace_updat
 the blocked state element (`data-testid="workspace-active-note-body-update-state-blocked"`) is
 rendered with `hidden`. The outer section carries `data-flow-state="disabled"` for automation.
 
+### Rule: Active-note-body-update unsaved-edit signal (#1346)
+
+When the update flow is enabled, the unsaved-edit signal
+(`data-testid="workspace-active-note-body-update-state-staged"`) is always present in DOM and
+rendered `hidden` by default. It is revealed when the editor has uncommitted content — on
+client `oninput` while typing, or immediately when the page model reports
+`active_note_body_update_state="staged"`. It is an unsaved indicator only: it submits no write
+and does not bypass writeguard. The actual commit remains the explicit `Update body` action
+through `POST /api/companion/workspace/update`.
+
 ---
 
 ## Section C — Vault browser: filtering and calm provenance

--- a/tests/companion_ui/test_active_note_body_update.py
+++ b/tests/companion_ui/test_active_note_body_update.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+import re
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 from companion_ui.workspace.real_note_workspace_dev_page import NoteLoadIntent, RealNoteWorkspaceDevPage
 from companion_ui.workspace.serve_dev_page import render_index_html
-from companion_ui.workspace.workspace_http_client import WorkspaceClientNetworkError, WorkspaceHttpClient
+from companion_ui.workspace.workspace_http_client import (
+    WorkspaceClientHTTPError,
+    WorkspaceClientNetworkError,
+    WorkspaceHttpClient,
+)
 
 
 def _workspace_payload(note_path: str = "notes/current.md", title: str = "Current") -> dict[str, Any]:
@@ -153,3 +158,144 @@ def test_failed_body_update_preserves_loaded_state_and_renders_failure_status() 
     assert state.is_loaded is True
     assert state.shell is not None
     assert state.active_note_body_update_state == "failure"
+
+
+# ---------------------------------------------------------------------------
+# #1346 acceptance: body-edit wiring through active_note_body_update
+# (Canvas commit, writeguard, staged-proposal preservation; #1332 AC4 blocker).
+# The live enabled-Canvas human UAT runs against a dev runtime with Canvas
+# enabled; the live Niflheim runtime keeps Canvas disabled, so that walk is
+# handed to the owner. These pin the automated acceptance.
+# ---------------------------------------------------------------------------
+
+
+def _render(page: RealNoteWorkspaceDevPage) -> str:
+    fields = page.render_fields()
+    assert fields is not None
+    return render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="notes/current.md",
+        fields=fields,
+    )
+
+
+def test_no_writes_when_canvas_disabled() -> None:
+    # AC1 — when the runtime update capability is unavailable (Canvas disabled),
+    # the body update attempts no write and the flow reports the blocked state.
+    page = _load_page()
+    page.state.guard_workspace_update_available = False
+    with patch.object(page._http, "post") as mock_post:
+        state = page.update_active_note_body(new_body="# Body\n\nMust not write")
+    mock_post.assert_not_called()
+    assert state.active_note_body_update_state == "blocked"
+
+
+def test_commit_round_trip() -> None:
+    # AC2 — with the update capability available, an explicit commit posts to the
+    # runtime update endpoint, reloads, and surfaces the success state.
+    updated = _workspace_payload()
+    updated["artifact"]["body"] = "# Body\n\n## Committed Heading\n\nDone."
+    updated["artifact"]["content_hash"] = "hash-after"
+    page = _load_page()
+
+    def _get(url: str, *, params, timeout):
+        if url.endswith("/api/companion/workspace"):
+            return _mock_get_response(updated)
+        if url.endswith("/api/companion/vault-browser"):
+            return _mock_get_response(_vault_browser_payload())
+        raise AssertionError(url)
+
+    with patch("httpx.get", side_effect=_get), patch.object(
+        page._http, "post", return_value={"reason": "active_note_body_updated"}
+    ) as mock_post:
+        state = page.update_active_note_body(new_body="# Body\n\n## Committed Heading\n\nDone.")
+
+    assert mock_post.call_args[0][0] == "/api/companion/workspace/update"
+    payload = mock_post.call_args.kwargs["json"]
+    assert payload["active_note_path"] == "notes/current.md"
+    assert payload["new_body"].endswith("Done.")
+    assert state.active_note_body_update_state == "success"
+
+
+def test_writeguard_rejection_surfaces_failure_state() -> None:
+    # AC3 — a writeguard rejection surfaces as the blocked state in the flow DOM;
+    # no silent loss, no infinite spinner.
+    page = _load_page()
+    with patch.object(
+        page._http,
+        "post",
+        side_effect=WorkspaceClientHTTPError(403, "writeguard blocked: scope not allowed"),
+    ):
+        state = page.update_active_note_body(new_body="# Body\n\nBlocked")
+    assert state.active_note_body_update_state == "blocked"
+    assert "writeguard" in state.active_note_body_update_message.lower()
+    html = _render(page)
+    assert 'data-testid="workspace-active-note-body-update-state-blocked"' in html
+
+
+def test_unsaved_edit_signal_visible() -> None:
+    # AC5 — an uncommitted edit (staged state) renders a visible unsaved signal,
+    # and the input carries the client reveal hook for real typing.
+    page = _load_page()
+    fields = page.render_fields()
+    assert fields is not None
+    fields["active_note_body_update_state"] = "staged"
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="notes/current.md",
+        fields=fields,
+    )
+    match = re.search(
+        r'<div class="active-note-body-update-staged"[^>]*'
+        r'data-testid="workspace-active-note-body-update-state-staged"([^>]*)>',
+        html,
+    )
+    assert match, "staged unsaved-edit signal must be present"
+    assert "hidden" not in match.group(1), "staged signal must be visible when staged"
+    # The input reveals the signal on uncommitted typing.
+    assert "oninput=" in html
+    assert "workspace-active-note-body-update-state-staged" in html
+
+
+def test_body_rerenders_with_renderer_after_commit() -> None:
+    # AC6 — after a successful commit the body re-renders through the Markdown
+    # renderer (not raw text): a heading in the new body becomes an <h2>.
+    updated = _workspace_payload()
+    updated["artifact"]["body"] = "# Body\n\n## Committed Heading\n\nRendered."
+    page = _load_page()
+
+    def _get(url: str, *, params, timeout):
+        if url.endswith("/api/companion/workspace"):
+            return _mock_get_response(updated)
+        if url.endswith("/api/companion/vault-browser"):
+            return _mock_get_response(_vault_browser_payload())
+        raise AssertionError(url)
+
+    with patch("httpx.get", side_effect=_get), patch.object(
+        page._http, "post", return_value={"reason": "active_note_body_updated"}
+    ):
+        page.update_active_note_body(new_body="# Body\n\n## Committed Heading\n\nRendered.")
+
+    html = _render(page)
+    assert 'class="vault-markdown-rendered"' in html
+    assert '<h2 id="committed-heading">Committed Heading</h2>' in html
+
+
+def test_proposal_does_not_auto_apply() -> None:
+    # AC4 — a Panel proposal carrying suggested body text does not become document
+    # state on its own: loading/rendering a staged proposal posts no Canvas edit.
+    payload = _workspace_payload()
+    payload["panel"] = {"state": "proposals-staged", "proposal_count": 1}
+    page = _load_page(workspace_payload=payload)
+    with patch.object(page._http, "post") as mock_post:
+        html = _render(page)
+    mock_post.assert_not_called()
+    assert page.state.panel_proposal_count == 1
+    # An explicit apply still requires the staged_body state machine, never an
+    # automatic commit (guard in apply_body_suggestion).
+    page.state.suggestion_state = "idle"
+    result = page.apply_body_suggestion(
+        suggestion_id="sugg-1", session_id="session-1", note_path="notes/current.md"
+    )
+    assert "staged_body" in (result.error or "")
+    assert 'data-testid="workspace-active-note-body-update-flow"' in html


### PR DESCRIPTION
Fixes #1346

## Summary
Delivers the body-edit branch of #1332 (AC4 blocker): note body editing wires through the runtime `active_note_body_update` flow with writeguard, Panel/Canvas separation, and staged-proposal preservation.

## Audit finding
The commit / writeguard / re-render machinery **already existed** in `RealNoteWorkspaceDevPage.update_active_note_body` (`POST /api/companion/workspace/update`): disabled→no write/`blocked`; 403/409 writeguard→`blocked`; other errors→`failure`; success→reload→re-render via `render_vault_markdown`. Panel proposals are gated behind `staged_body` in `apply_body_suggestion`. The **one genuine gap** was a visible unsaved-edit signal.

## Scope
- **AC5 signal (additive UI only):** `_render_active_note_body_update_flow` now renders a `workspace-active-note-body-update-state-staged` element — `hidden` by default, revealed on uncommitted typing (`oninput`) or when the page model reports `active_note_body_update_state="staged"`. It submits no write and does not touch writeguard.
- **6 named acceptance tests** in `tests/companion_ui/test_active_note_body_update.py`: `test_no_writes_when_canvas_disabled` (AC1), `test_commit_round_trip` (AC2), `test_writeguard_rejection_surfaces_failure_state` (AC3), `test_proposal_does_not_auto_apply` (AC4), `test_unsaved_edit_signal_visible` (AC5), `test_body_rerenders_with_renderer_after_commit` (AC6).
- **Docs:** `COMPANION_UI_DAILY_USE_VISIBILITY_CONTRACT.md` rule for the staged signal; `HUMAN_UAT_RESULTS.md` Body-edit row + section.

## Out of scope (and constraints honored)
- No writeguard / Canvas / Panel / AgentState semantics changed — the write still goes through the existing writeguard-mediated endpoint. No autosave, no CodeMirror replacement, no WYSIWYG, no diff preview. AI proposals never become document state without explicit Apply.

## Contract/SoT docs read
`CANVAS_AGENT_MVP_CONTRACT.md`, `PANEL_COMPANION_UI_CONTRACT.md`, `UI_RUNTIME_BOUNDARIES.md`, `WORKSPACE_STATE_CONTRACT.md`, `COMPANION_UI_DAILY_USE_VISIBILITY_CONTRACT.md`; `real_note_workspace_dev_page.py`, `serve_dev_page.py`, `app/api/routes/companion.py`.

## Tests run
```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest -q tests/companion_ui/test_active_note_body_update.py   # 10 passed
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest -q tests/companion_ui \
  -k "active_note_body_update or canvas or body_edit or panel_section or daily_use"   # 360 passed
.venv/bin/python -m ruff check <touched files>   # All checks passed!
git diff --check                                  # clean
```

## Known residual risks
- The **live enabled-Canvas** human walk can't run on Niflheim (Canvas disabled there); handed to the owner with a dev-runtime checklist in `HUMAN_UAT_RESULTS.md`. The automated acceptance covers the contract.

## Rollback plan
Revert this commit; the staged signal and tests are removed, the commit path is unchanged. No runtime/migration impact.

## Note
Removed the stale `agent:blocked` label — the block was "live Canvas UAT impossible on Niflheim", not the implementation; the automated acceptance is delivered and the live walk is an owner handoff.