### PR TITLE
feat(companion-ui): read-only vault link-index API — wikilinks resolve end-to-end (#1431)

### DIFF
--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -181,6 +181,24 @@ class VaultBrowserStateResponse(BaseModel):
     active_filters: dict[str, list[str]] = Field(default_factory=dict)
 
 
+class VaultLinkIndexResponse(BaseModel):
+    """Complete, read-only listing of active-vault note paths for link resolution.
+
+    The Companion UI seeds its ``VaultLinkResolver`` from ``note_paths`` so that
+    vault-internal wikilinks resolve and navigate (#1431). Unlike the vault
+    browser, this is **not** paginated/filtered — it is the full link index. The
+    resolver expands each path into its lookup keys (full path, stem path, name,
+    stem); the server returns the raw paths so the UI never reads the filesystem.
+    """
+
+    note_paths: list[str]
+    total_notes: int
+    truncated: bool = False
+    read_only: bool = True
+    vault_identity: VaultIdentityState
+    identity_available: bool
+
+
 def _truthy_env(name: str, default: bool = False) -> bool:
     raw = os.getenv(name)
     if raw is None:
@@ -856,6 +874,62 @@ def read_companion_vault_browser(
         vault_identity=identity,
         identity_available=identity_available,
         active_filters=active_filters,
+    )
+
+
+def _safe_vault_link_index_max() -> int:
+    raw = os.getenv("VAULT_LINK_INDEX_MAX")
+    if raw is None:
+        return 5000
+    try:
+        return max(1, int(raw))
+    except (TypeError, ValueError):
+        return 5000
+
+
+def _collect_vault_note_paths(vault_root: Path, *, limit: int) -> tuple[list[str], bool]:
+    """Enumerate every non-hidden Markdown note path under the vault (read-only).
+
+    Returns (sorted_paths, truncated). No file content is read and nothing is
+    written; only paths are collected for link resolution (#1431).
+    """
+    paths: list[str] = []
+    truncated = False
+    for candidate in vault_root.rglob("*.md"):
+        if not candidate.is_file():
+            continue
+        safe_path = _vault_relative(candidate, vault_root)
+        if safe_path is None or _is_hidden_browser_path(safe_path):
+            continue
+        paths.append(safe_path)
+        if len(paths) >= limit:
+            truncated = True
+            break
+    paths.sort()
+    return paths, truncated
+
+
+@router.get("/vault-link-index", response_model=VaultLinkIndexResponse)
+def read_companion_vault_link_index() -> VaultLinkIndexResponse:
+    # #1431 — complete read-only note-path listing so the Companion UI can seed
+    # VaultLinkResolver and resolve vault-internal wikilinks end-to-end. Mirrors
+    # the vault browser's read-only posture (no mutation, no write path); the UI
+    # must not read the filesystem directly (UI_RUNTIME_BOUNDARIES).
+    vault_root = resolve_vault_root()
+    note_paths, truncated = _collect_vault_note_paths(
+        vault_root, limit=_safe_vault_link_index_max()
+    )
+    identity = _vault_identity_state(vault_root)
+    identity_available = (
+        bool(identity.vault_name.strip()) and identity.channel in {"dev", "test", "prod"}
+    )
+    return VaultLinkIndexResponse(
+        note_paths=note_paths,
+        total_notes=len(note_paths),
+        truncated=truncated,
+        read_only=True,
+        vault_identity=identity,
+        identity_available=identity_available,
     )
 
 

--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -160,6 +160,7 @@ class DevPageState:
     active_note_body_update_state: str = "idle"
     active_note_body_update_message: str = ""
     vault_browser_notes: list[dict[str, Any]] | None = None
+    vault_link_index: list[str] | None = None
     vault_browser_query: str = ""
     vault_browser_total_notes: int = 0
     vault_browser_filtered_notes: int = 0
@@ -241,6 +242,23 @@ class RealNoteWorkspaceDevPage:
                 vault_browser_error = str(exc)
         else:
             vault_browser = {}
+        # #1431 — fetch the complete vault link index so wikilinks resolve
+        # end-to-end. This is a best-effort, non-critical enrichment: any failure
+        # (client error, missing endpoint on an older runtime, malformed payload)
+        # must degrade to an empty index — links stay diagnostic (prior
+        # behaviour) and the note still renders. The UI never reads the vault
+        # filesystem; it only consumes the runtime API payload.
+        vault_link_index: list[str] = []
+        if isinstance(self._http, WorkspaceHttpClient):
+            try:
+                link_index_payload = self._http.get(
+                    "/api/companion/vault-link-index", params={}
+                )
+                vault_link_index = [
+                    str(path) for path in (link_index_payload.get("note_paths") or []) if path
+                ]
+            except Exception:
+                vault_link_index = []
         raw_find_payload = raw.get("find")
         runtime_find_payload = runtime.get("find")
         find_payload_available = isinstance(raw_find_payload, dict) or isinstance(
@@ -398,6 +416,7 @@ class RealNoteWorkspaceDevPage:
             guard_workspace_update_config_mode=workspace_update_config_mode,
             active_note_body_update_enabled=workspace_update_available,
             vault_browser_notes=list(vault_browser.get("notes") or []),
+            vault_link_index=vault_link_index,
             vault_browser_query=str(vault_browser.get("query") or ""),
             vault_browser_total_notes=int(vault_browser.get("total_notes") or 0),
             vault_browser_filtered_notes=int(vault_browser.get("filtered_notes") or 0),
@@ -900,6 +919,7 @@ class RealNoteWorkspaceDevPage:
             "active_note_body_update_state": self.state.active_note_body_update_state,
             "active_note_body_update_message": self.state.active_note_body_update_message,
             "vault_browser_notes": self.state.vault_browser_notes or [],
+            "vault_link_index": self.state.vault_link_index or [],
             "vault_browser_query": self.state.vault_browser_query,
             "vault_browser_total_notes": self.state.vault_browser_total_notes,
             "vault_browser_filtered_notes": self.state.vault_browser_filtered_notes,

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -893,11 +893,20 @@ def _render_note_section(fields: dict) -> str:
     vault_channel = _e(fields.get("runtime_vault_channel") or "unknown")
     vault_provenance = fields.get("runtime_vault_provenance") or "unresolved"
     raw_body = str(fields.get("body", "") or "")
-    # #1345 — seed the link resolver with the active-vault link index so
-    # vault-internal wikilinks resolve and navigate. When the index is absent
-    # (current runtime, pending the read-only link-index API) this is an empty
-    # resolver, identical to the prior default — every link stays diagnostic.
-    link_resolver = VaultLinkResolver(_coerce_vault_link_index(fields.get("vault_link_index")))
+    # #1345/#1431 — seed the link resolver with the active-vault link index so
+    # vault-internal wikilinks resolve and navigate. The index arrives either as
+    # the read-only link-index API's note-path list (#1431) — the resolver
+    # expands each path into its lookup keys — or as a pre-built {target: paths}
+    # mapping. Absent index → empty resolver, identical to the prior default
+    # (every link stays diagnostic).
+    raw_link_index = fields.get("vault_link_index")
+    if isinstance(raw_link_index, (list, tuple)):
+        link_index: list[str] | dict[str, list[str]] = [
+            str(path) for path in raw_link_index if path
+        ]
+    else:
+        link_index = _coerce_vault_link_index(raw_link_index)
+    link_resolver = VaultLinkResolver(link_index)
     rendered_body = render_vault_markdown(
         raw_body, note_path=raw_note_path, link_resolver=link_resolver
     )

--- a/companion-ui/docs/VAULT_MARKDOWN_RENDERER_CONTRACT.md
+++ b/companion-ui/docs/VAULT_MARKDOWN_RENDERER_CONTRACT.md
@@ -262,7 +262,11 @@ output (HTML via React or equivalent).
   matching the rendered `<h_ id>`) so the link scrolls to the heading; a block-id
   fragment keeps the literal `#^block-id` form. Resolution requires the
   `VaultLinkResolver` to be seeded with the active-vault link index; with an empty
-  index every link stays diagnostic.
+  index every link stays diagnostic. The workspace seeds that index from the
+  read-only `GET /api/companion/vault-link-index` endpoint (#1431) — a complete
+  note-path listing the resolver expands into lookup keys; the UI never reads the
+  vault filesystem, and a failed/absent fetch degrades to the empty (diagnostic)
+  index.
 - The renderer does not emit navigation events as mutations.
 - The renderer does not store resolved content in durable state.
 - Clicking an internal link is a navigation event, not a mutation.

--- a/tests/api/test_vault_link_index_endpoint.py
+++ b/tests/api/test_vault_link_index_endpoint.py
@@ -1,0 +1,89 @@
+"""Read-only vault link-index API contract tests (#1431).
+
+`GET /api/companion/vault-link-index` returns the complete active-vault note-path
+listing so the Companion UI can seed `VaultLinkResolver` and resolve
+vault-internal wikilinks end-to-end. Invariants (per
+`docs/VAULT_BROWSER_CAPABILITY_CONTRACT.md` §6 read-only posture and
+`companion-ui/docs/UI_RUNTIME_BOUNDARIES.md`):
+
+- complete (not paginated/filtered) note-path enumeration
+- hidden / dot-prefixed folder exclusion
+- read-only: no mutation, no write path, no file content read
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app.api.app import app
+
+
+def _write_note(path: Path, *, title: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"---\ntitle: {title}\n---\n\nBody.\n", encoding="utf-8")
+
+
+def test_returns_complete_index(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+    _write_note(tmp_path / "notes" / "Existing Note.md", title="Existing Note")
+    _write_note(tmp_path / "projects" / "Roadmap.md", title="Roadmap")
+    _write_note(tmp_path / "Daily" / "2026-01-01.md", title="Daily")
+    # excluded: non-markdown and dot-prefixed folder
+    (tmp_path / "notes" / "ignore.txt").write_text("nope", encoding="utf-8")
+    _write_note(tmp_path / ".obsidian" / "workspace.md", title="Hidden")
+
+    client = TestClient(app)
+    resp = client.get("/api/companion/vault-link-index")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["read_only"] is True
+    assert data["identity_available"] is True
+    assert data["vault_identity"]["channel"] == "dev"
+    paths = set(data["note_paths"])
+    # Complete: every non-hidden markdown note is present (full vault, not capped).
+    assert paths == {
+        "notes/Existing Note.md",
+        "projects/Roadmap.md",
+        "Daily/2026-01-01.md",
+    }
+    assert data["total_notes"] == 3
+    assert data["truncated"] is False
+    # Hidden + non-markdown excluded.
+    assert not any(".obsidian" in p for p in paths)
+    assert not any(p.endswith(".txt") for p in paths)
+
+
+def test_endpoint_is_read_only_and_never_writes(tmp_path: Path, monkeypatch) -> None:
+    # AC4 — the endpoint mutates nothing: the vault is byte-identical after the
+    # call and the response declares read_only.
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+    note = tmp_path / "notes" / "Existing Note.md"
+    _write_note(note, title="Existing Note")
+    before = {p: p.read_bytes() for p in tmp_path.rglob("*") if p.is_file()}
+
+    client = TestClient(app)
+    resp = client.get("/api/companion/vault-link-index")
+
+    assert resp.status_code == 200
+    assert resp.json()["read_only"] is True
+    after = {p: p.read_bytes() for p in tmp_path.rglob("*") if p.is_file()}
+    assert after == before, "link-index endpoint must not create or modify files"
+
+
+def test_index_respects_truncation_cap(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+    monkeypatch.setenv("VAULT_LINK_INDEX_MAX", "2")
+    for i in range(5):
+        _write_note(tmp_path / "notes" / f"Note {i}.md", title=f"Note {i}")
+
+    client = TestClient(app)
+    data = client.get("/api/companion/vault-link-index").json()
+
+    assert len(data["note_paths"]) == 2
+    assert data["truncated"] is True

--- a/tests/companion_ui/test_vault_link_index_seeding.py
+++ b/tests/companion_ui/test_vault_link_index_seeding.py
@@ -1,0 +1,113 @@
+"""UI seeding of the vault link index from the runtime API (#1431).
+
+`RealNoteWorkspaceDevPage.load` fetches `GET /api/companion/vault-link-index`
+and exposes the note-path list as `fields["vault_link_index"]`, which
+`serve_dev_page` feeds into the `VaultLinkResolver` so wikilinks resolve
+end-to-end. A failed/absent fetch degrades to an empty index (links stay
+diagnostic), and the UI never reads the vault filesystem directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from companion_ui.workspace.real_note_workspace_dev_page import NoteLoadIntent, RealNoteWorkspaceDevPage
+from companion_ui.workspace.workspace_http_client import WorkspaceClientNetworkError, WorkspaceHttpClient
+
+
+def _workspace_payload() -> dict[str, Any]:
+    return {
+        "artifact": {
+            "artifact_id": "note-uuid-link-1",
+            "artifact_kind": "human_note",
+            "note_path": "notes/current.md",
+            "title": "Current",
+            "body": "See [[Existing Note]].",
+            "content_hash": "hash-current",
+            "identity_source": "frontmatter.uuid",
+            "identity_state": "resolved",
+            "companion_of": None,
+            "owns_identity": True,
+        },
+        "canvas": {"session_state": "idle", "session_persistence": "in_memory"},
+        "panel": {"state": "idle", "proposal_count": 0},
+        "guards": {"canvas_enabled": True, "writeguard_status": "ok"},
+        "runtime": {
+            "environment_label": "dev",
+            "api_base_url_label": "local-dev",
+            "trace_id": "trace-link-index",
+            "vault_identity": {"vault_name": "Niflheim", "channel": "dev", "provenance": "env"},
+        },
+        "suggestions": {},
+    }
+
+
+def _vault_browser_payload() -> dict[str, Any]:
+    return {
+        "notes": [{"note_path": "notes/current.md", "title": "Current", "zone": "notes"}],
+        "query": "",
+        "total_notes": 1,
+        "filtered_notes": 1,
+        "read_only": True,
+        "vault_identity": {"vault_name": "Niflheim", "channel": "dev", "provenance": "env"},
+        "identity_available": True,
+    }
+
+
+def _link_index_payload() -> dict[str, Any]:
+    return {
+        "note_paths": ["notes/current.md", "Notes/Existing Note.md", "Archive/Other.md"],
+        "total_notes": 3,
+        "truncated": False,
+        "read_only": True,
+        "vault_identity": {"vault_name": "Niflheim", "channel": "dev", "provenance": "env"},
+        "identity_available": True,
+    }
+
+
+def _mock_get_response(payload: dict[str, Any]) -> MagicMock:
+    mock = MagicMock()
+    mock.status_code = 200
+    mock.json.return_value = payload
+    return mock
+
+
+def _load_page(*, link_index_error: bool = False) -> RealNoteWorkspaceDevPage:
+    def _side_effect(url: str, *, params: dict[str, Any], timeout: float):
+        if url.endswith("/api/companion/workspace"):
+            return _mock_get_response(_workspace_payload())
+        if url.endswith("/api/companion/vault-browser"):
+            return _mock_get_response(_vault_browser_payload())
+        if url.endswith("/api/companion/vault-link-index"):
+            if link_index_error:
+                raise WorkspaceClientNetworkError("link index unavailable")
+            return _mock_get_response(_link_index_payload())
+        raise AssertionError(f"Unexpected URL: {url}")
+
+    with patch("httpx.get", side_effect=_side_effect):
+        client = WorkspaceHttpClient(base_url="http://localhost:18001")
+        page = RealNoteWorkspaceDevPage(client)
+        page.load(NoteLoadIntent(note_path="notes/current.md"))
+    return page
+
+
+def test_render_fields_populates_vault_link_index_from_endpoint() -> None:
+    # AC2 — the page seeds fields["vault_link_index"] from the link-index API.
+    page = _load_page()
+    fields = page.render_fields()
+    assert fields is not None
+    assert fields["vault_link_index"] == [
+        "notes/current.md",
+        "Notes/Existing Note.md",
+        "Archive/Other.md",
+    ]
+
+
+def test_link_index_fetch_failure_degrades_to_empty() -> None:
+    # A failed link-index fetch must not break note load; index is empty.
+    page = _load_page(link_index_error=True)
+    fields = page.render_fields()
+    assert fields is not None
+    assert fields["vault_link_index"] == []
+    assert fields["body"]  # the note still loaded and rendered

--- a/tests/companion_ui/test_workspace_wikilink_seeding.py
+++ b/tests/companion_ui/test_workspace_wikilink_seeding.py
@@ -85,3 +85,18 @@ def test_link_index_accepts_list_candidates() -> None:
     )
 
     assert 'data-link-state="resolved"' in html
+
+
+def test_link_index_note_path_list_resolves_end_to_end() -> None:
+    # #1431 AC3 — the read-only link-index API returns a note-path list; the
+    # resolver expands each path into its lookup keys so a bare wikilink to an
+    # existing note resolves and navigates end-to-end.
+    html = _render(
+        body="See [[Existing Note]] and [[Missing One]].",
+        vault_link_index=["Notes/Existing Note.md", "Archive/Other.md"],
+    )
+
+    assert 'data-link-state="resolved"' in html
+    assert "href=\"?note_path=Notes%2FExisting%20Note.md\"" in html
+    # The unknown target still degrades to the diagnostic.
+    assert 'data-link-state="missing"' in html


### PR DESCRIPTION
Fixes #1431

## Summary
Completes the #1345 follow-up: vault-internal wikilinks now **resolve and navigate end-to-end** in the live workspace instead of all rendering as diagnostics. #1345 shipped the renderer contract + the resolver seam but nothing populated the index; this adds the read-only API that fills it, respecting `UI_RUNTIME_BOUNDARIES` (the UI never reads the vault filesystem).

## Scope
- **App (`app/api/routes/companion.py`):** new `GET /api/companion/vault-link-index` + `VaultLinkIndexResponse`. Complete (not paginated/filtered) note-path enumeration via `rglob("*.md")`, hidden/dot-folder exclusion (`_is_hidden_browser_path`), `VAULT_LINK_INDEX_MAX` cap (default 5000) with a `truncated` flag. Read-only — mirrors the vault-browser posture; no file content read, no write path.
- **UI (`real_note_workspace_dev_page.py`):** `load()` fetches the endpoint and exposes `fields["vault_link_index"]` (the note-path list). Best-effort enrichment — **any** failure (client error, missing endpoint on an older runtime, malformed payload) degrades to an empty index so the note still renders.
- **Seam (`serve_dev_page.py`):** `_render_note_section` now accepts the note-path **list** (the resolver expands each path into its lookup keys: full path / stem path / name / stem) as well as the pre-built `{target: paths}` mapping from #1345. Empty/absent → diagnostic, unchanged.
- **Tests:** `tests/api/test_vault_link_index_endpoint.py` (complete index, hidden exclusion, **read-only/no-write**, truncation cap); `tests/companion_ui/test_vault_link_index_seeding.py` (render_fields seeds from endpoint; failure degrades to empty); extended `test_workspace_wikilink_seeding.py` (note-path list resolves end-to-end, unknown stays diagnostic).
- **Owner doc:** `VAULT_MARKDOWN_RENDERER_CONTRACT.md` — the resolution invariant now names the endpoint as the index source.

## ACs
- **AC1** complete index → `test_returns_complete_index`. **AC2** UI seeds from endpoint → `test_render_fields_populates_vault_link_index_from_endpoint`. **AC3** end-to-end resolved link → `test_link_index_note_path_list_resolves_end_to_end`. **AC4** read-only / never writes → `test_endpoint_is_read_only_and_never_writes` + UI boundary tests green.

## Out of scope
Backlinks/relation graph, rename backfill, cross-vault links, caching/invalidation (noted as a perf follow-up if large-vault latency shows). The semantic Find (#1282) is a separate, contract-distinct surface.

## Compatibility note
`load()` now issues a third runtime GET. The fetch degrades on any error, so `_FakeClient`-based tests (which skip the `WorkspaceHttpClient` path) and strict-mock tests are unaffected after the graceful-degradation change; the full `tests/companion_ui` suite is green except the 2 documented pre-existing baseline failures.

## Tests run
```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest -q \
  tests/api/test_vault_link_index_endpoint.py tests/companion_ui/test_vault_link_index_seeding.py \
  tests/companion_ui/test_workspace_wikilink_seeding.py   # 9 passed
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest -q tests/companion_ui tests/api/test_companion_vault_browser_api.py tests/api/test_vault_link_index_endpoint.py
  # 1237 passed, 2 failed (both documented pre-existing baseline failures)
ruff check app tests   # All checks passed!
mypy app               # Success: no issues found in 454 source files
git diff --check       # clean
```

## Known residual risks
- Per-request full vault `rglob` for ≤5000 notes; fine for v0, capped + `truncated`. Caching is a noted follow-up.
- Live Niflheim observation (clicking a resolved link navigates) remains an owner walk — the build env can't reach the runtime.

## Rollback plan
Revert this commit; the endpoint and seeding are removed and wikilinks return to diagnostic-only (the #1345 renderer contract is unaffected). No migration impact.