### PR TITLE
Wire Vault Browser receipt detail toggle

### DIFF
--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -1621,16 +1621,47 @@ def _render_inspector_receipts(note: dict) -> str:
         )
 
     rows: list[str] = []
-    for receipt in receipts:
+    for idx, receipt in enumerate(receipts):
         receipt_id = str(receipt.get("receipt_id") or "")
         state = str(receipt.get("state") or "unknown")
         action_type = str(receipt.get("action_type") or "")
         trace_id = str(receipt.get("trace_id") or "")
+        action_id = str(receipt.get("action_id") or "")
+        artifact_uuid = str(receipt.get("artifact_uuid") or "")
+        requested_by = str(receipt.get("requested_by") or "")
+        approved_by = str(receipt.get("approved_by") or "")
+        status = str(receipt.get("status") or state or "")
+        timestamp = str(receipt.get("timestamp") or "")
         receipt_state = state if state in _RECEIPT_STATES else "unknown"
+        detail_id = f"vault-browser-receipt-detail-{idx}"
+        detail_fields = (
+            ("receipt-id", "receipt_id", receipt_id),
+            ("trace-id", "trace_id", trace_id),
+            ("action-id", "action_id", action_id),
+            ("artifact-uuid", "artifact_uuid", artifact_uuid),
+            ("requested-by", "requested_by", requested_by),
+            ("approved-by", "approved_by", approved_by),
+            ("status", "status", status),
+            ("timestamp", "timestamp", timestamp),
+        )
+        detail_rows = "".join(
+            f'<dt class="receipt-detail-label">{_e(label)}</dt>'
+            f'<dd data-testid="vault-browser-receipt-detail-{_e(testid_suffix)}" '
+            f'class="receipt-detail-value">{_e(value)}</dd>'
+            for testid_suffix, label, value in detail_fields
+        )
         rows.append(
             f'<div class="receipt-row" '
             f'data-testid="vault-browser-receipt-row" '
-            f'data-receipt-state="{_e(receipt_state)}">'
+            f'data-receipt-state="{_e(receipt_state)}" '
+            f'data-detail-id="{_e(detail_id)}" '
+            f'data-expanded="false" '
+            f'aria-expanded="false" '
+            f'role="button" '
+            f'tabindex="0" '
+            f'onclick="vaultBrowserToggleReceiptDetail(this)" '
+            f'onkeydown="if(event.key===\'Enter\'||event.key===\' \')'
+            f'{{event.preventDefault();vaultBrowserToggleReceiptDetail(this);}}">'
             f'<span data-testid="vault-browser-receipt-id" class="receipt-id">{_e(receipt_id)}</span>'
             f'<span data-testid="vault-browser-receipt-state" class="receipt-state">{_e(state)}</span>'
             f'<span data-testid="vault-browser-receipt-action-type" class="receipt-action">{_e(action_type)}</span>'
@@ -1639,6 +1670,14 @@ def _render_inspector_receipts(note: dict) -> str:
                 if trace_id else ""
             )
             + '</div>'
+            f'<dl class="receipt-detail" '
+            f'data-testid="vault-browser-receipt-detail" '
+            f'id="{_e(detail_id)}" '
+            f'hidden '
+            f'aria-hidden="true" '
+            f'data-expanded="false">'
+            f'{detail_rows}'
+            f'</dl>'
         )
     return (
         '<div class="inspector-receipts" '
@@ -5372,6 +5411,37 @@ def render_index_html(
       color: var(--fg-3);
       flex-shrink: 0;
     }}
+    .receipt-row {{
+      cursor: pointer;
+      display: grid;
+      gap: 4px;
+      grid-template-columns: minmax(0, 1fr) auto;
+      padding: 3px 0;
+    }}
+    .receipt-row:focus-visible {{
+      border-radius: var(--radius-sm);
+      outline: 1px solid var(--accent);
+      outline-offset: 2px;
+    }}
+    .receipt-detail {{
+      border-left: 1px solid var(--border);
+      display: grid;
+      gap: 2px 8px;
+      grid-template-columns: max-content minmax(0, 1fr);
+      margin: 2px 0 6px;
+      padding-left: 8px;
+    }}
+    .receipt-detail[hidden] {{ display: none; }}
+    .receipt-detail-label {{
+      color: var(--fg-3);
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+    }}
+    .receipt-detail-value {{
+      margin: 0;
+      min-width: 0;
+      overflow-wrap: anywhere;
+    }}
     /* #1425 — de-emphasize browse header chrome; the tree is the surface. The
        "Browse vault notes" toggle matches the Outline heading label. */
     .vault-browser-meta,
@@ -5741,6 +5811,19 @@ def render_index_html(
   }}
   </script>
   <script>
+  function vaultBrowserToggleReceiptDetail(row) {{
+    if (!row || !row.getAttribute) return;
+    var detailId = row.getAttribute('data-detail-id');
+    var detail = detailId ? document.getElementById(detailId) : null;
+    if (!detail) return;
+    var expanded = row.getAttribute('aria-expanded') === 'true';
+    row.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+    row.setAttribute('data-expanded', expanded ? 'false' : 'true');
+    detail.hidden = expanded;
+    detail.setAttribute('aria-hidden', expanded ? 'true' : 'false');
+    detail.setAttribute('data-expanded', expanded ? 'false' : 'true');
+  }}
+
   function vbToggleFilter(el) {{
     var key = el.dataset.key;
     var val = el.dataset.value;

--- a/docs/VAULT_BROWSER_CAPABILITY_CONTRACT.md
+++ b/docs/VAULT_BROWSER_CAPABILITY_CONTRACT.md
@@ -245,6 +245,10 @@ not a parallel receipt authority and must remain batch-oriented over the notes r
 load. If no outbox/event receipt source is available, the per-note `receipts` key is omitted so the
 inspector renders `data-receipt-state="unavailable"` honestly.
 
+Current UI detail implementation note (#1284): receipt rows may expand/collapse locally in the
+inspector to reveal read-only receipt details. The expanded detail displays available VaultReceipt
+fields and must not contain action buttons, forms, authoring controls, or server mutation hooks.
+
 ## 5. Capability boundaries
 
 The Vault Browser must keep the following capabilities **separate**:
@@ -370,6 +374,8 @@ The currently shipped Companion UI vault browser (from #1225 / PR #1239 and foll
 **#1257 (agent receipts and review posture):** The artifact inspector renders a receipt/posture section (`data-testid="workspace-vault-browser-inspector-receipts"`). Receipt state is determined from the note payload's `receipts` field: absent key → `data-receipt-state="unavailable"` (source not connected, honest placeholder); empty list → `data-receipt-state="no_receipts"` (source connected, none found); non-empty → renders each receipt row with `data-testid="vault-browser-receipt-row"`, `data-receipt-state`, `data-testid="vault-browser-receipt-id"`, and `data-testid="vault-browser-receipt-trace-id"` kept separate from artifact identity. Review posture (`data-testid="workspace-vault-browser-inspector-review-posture"`) surfaces `review_state` and `trust` from the normalized metadata with `data-review-authority="non_authoritative"` — unreviewed/inferred memory is explicitly labeled and does not become action-authorizing. No mutation controls rendered. Supported receipt states: `queued`, `applied`, `blocked`, `rejected`, `failed`. Before #1279, the API did not populate receipts and therefore rendered `unavailable` honestly.
 
 **#1279 (per-artifact receipt source):** The vault browser API now includes a per-note `receipts` field when a receipt-supporting outbox/event source is available. The field is populated by a read-only batch projection over existing governed records keyed by artifact UUID and/or vault-relative path; it does not create a receipt table, author receipts, or introduce a browser write path. Current projected rows carry `receipt_id`, `trace_id`, `action_id`, `action_type`, `artifact_uuid`, `artifact_path`/`path`, `requested_by`, `approved_by`, `status`, `timestamp`, and UI-compatible `state`. Missing source remains the absent-key `unavailable` state; a connected source with no matches returns an empty list (`no_receipts`).
+
+**#1284 (receipt row expand detail):** The artifact inspector receipt rows are now UI-only expandable rows. Clicking a row toggles a collapsed detail region (`data-testid="vault-browser-receipt-detail"`) that displays the available VaultReceipt fields: `receipt_id`, `trace_id`, `action_id`, `artifact_uuid`, `requested_by`, `approved_by`, `status`, and `timestamp`. The detail region is read-only and contains no `<button>`, `<form>`, server mutation hook, or receipt-authoring affordance.
 
 **#1280 (wire interactive filter chip clicks):** Delivered by PR #1322 (2026-05-26). Filter chips now carry `onclick="vbToggleFilter(this)"` and `style="cursor:pointer"` — clicking an inactive chip appends its `data-key`/`data-value` to the URL query string and reloads; clicking an active chip removes it. When multiple values are active for the same dimension, each chip renders a deselect affordance (`data-testid="filter-chip-remove"` `×` span); a single active chip shows no affordance. The `handle_get` handler parses `kind`, `zone`, `review_state`, `trust` from the query string and forwards them to the vault-browser API, making active filter state bookmarkable. Server remains the authoritative filter processor; no client-side filtering is introduced. Extends §4.3 (`VaultQuery`) interactive capability without altering filter semantics.
 

--- a/tests/companion_ui/test_vault_browser_receipts.py
+++ b/tests/companion_ui/test_vault_browser_receipts.py
@@ -101,16 +101,26 @@ def _receipt(
     receipt_id: str = "rcpt-001",
     state: str = "queued",
     action_type: str = "frontmatter_update",
+    action_id: str = "action-001",
     artifact_path: str = "notes/current.md",
     artifact_uuid: str | None = "note-uuid-abc",
+    requested_by: str = "agent:codex",
+    approved_by: str = "human:rasmus",
+    status: str = "ok",
+    timestamp: str = "2026-05-30T21:00:00Z",
     trace_id: str | None = "trace-001",
 ) -> dict[str, Any]:
     return {
         "receipt_id": receipt_id,
         "state": state,
         "action_type": action_type,
+        "action_id": action_id,
         "artifact_path": artifact_path,
         "artifact_uuid": artifact_uuid,
+        "requested_by": requested_by,
+        "approved_by": approved_by,
+        "status": status,
+        "timestamp": timestamp,
         "trace_id": trace_id,
     }
 
@@ -171,6 +181,16 @@ def _inspector_html(html: str) -> str:
         return ""
     end = html.find("</section>", start)
     return html[start:end + len("</section>")] if end != -1 else html[start:]
+
+
+def _receipt_detail_html(html: str) -> str:
+    marker = 'data-testid="vault-browser-receipt-detail"'
+    marker_start = html.find(marker)
+    if marker_start == -1:
+        return ""
+    start = html.rfind("<dl", 0, marker_start)
+    end = html.find("</dl>", marker_start)
+    return html[start : end + len("</dl>")] if start != -1 and end != -1 else ""
 
 
 # ---- AC1: receipt/posture section renders ----
@@ -270,6 +290,80 @@ def test_receipt_trace_id_rendered_separately() -> None:
     html = _inspector_html(_load_html(browser_payload=_vault_browser_payload(notes=[note])))
     assert 'data-testid="vault-browser-receipt-trace-id"' in html
     assert "trace-xyz" in html
+
+
+def test_receipt_row_exposes_collapsed_detail_toggle() -> None:
+    """#1284: receipt row expands a deterministic read-only detail region."""
+    note = _browser_note(receipts=[_receipt(receipt_id="rcpt-detail-001")])
+    html = _inspector_html(_load_html(browser_payload=_vault_browser_payload(notes=[note])))
+    detail = _receipt_detail_html(html)
+
+    assert 'onclick="vaultBrowserToggleReceiptDetail(this)"' in html
+    assert 'data-detail-id="vault-browser-receipt-detail-0"' in html
+    assert 'aria-expanded="false"' in html
+    assert 'data-testid="vault-browser-receipt-detail"' in detail
+    assert 'id="vault-browser-receipt-detail-0"' in detail
+    assert "hidden" in detail
+    assert 'aria-hidden="true"' in detail
+    assert 'data-expanded="false"' in detail
+
+
+def test_receipt_detail_displays_available_receipt_fields() -> None:
+    """#1284: expanded receipt detail exposes VaultReceipt fields."""
+    note = _browser_note(
+        receipts=[
+            _receipt(
+                receipt_id="rcpt-detail-002",
+                trace_id="trace-detail-002",
+                action_id="action-detail-002",
+                artifact_uuid="note-uuid-detail",
+                requested_by="agent:test",
+                approved_by="human:test",
+                status="ok",
+                timestamp="2026-05-30T22:00:00Z",
+            )
+        ]
+    )
+    html = _inspector_html(_load_html(browser_payload=_vault_browser_payload(notes=[note])))
+    detail = _receipt_detail_html(html)
+
+    assert 'data-testid="vault-browser-receipt-detail-receipt-id"' in detail
+    assert "rcpt-detail-002" in detail
+    assert 'data-testid="vault-browser-receipt-detail-trace-id"' in detail
+    assert "trace-detail-002" in detail
+    assert 'data-testid="vault-browser-receipt-detail-action-id"' in detail
+    assert "action-detail-002" in detail
+    assert 'data-testid="vault-browser-receipt-detail-artifact-uuid"' in detail
+    assert "note-uuid-detail" in detail
+    assert 'data-testid="vault-browser-receipt-detail-requested-by"' in detail
+    assert "agent:test" in detail
+    assert 'data-testid="vault-browser-receipt-detail-approved-by"' in detail
+    assert "human:test" in detail
+    assert 'data-testid="vault-browser-receipt-detail-status"' in detail
+    assert "ok" in detail
+    assert 'data-testid="vault-browser-receipt-detail-timestamp"' in detail
+    assert "2026-05-30T22:00:00Z" in detail
+
+
+def test_receipt_detail_contains_no_buttons_or_forms() -> None:
+    """#1284: detail section is read-only and contains no action controls."""
+    note = _browser_note(receipts=[_receipt()])
+    html = _inspector_html(_load_html(browser_payload=_vault_browser_payload(notes=[note])))
+    detail = _receipt_detail_html(html)
+
+    assert "<button" not in detail
+    assert "<form" not in detail
+
+
+def test_receipt_detail_toggle_function_collapses_deterministically() -> None:
+    """#1284: second click collapses via the same deterministic toggler."""
+    note = _browser_note(receipts=[_receipt()])
+    html = _load_html(browser_payload=_vault_browser_payload(notes=[note]))
+
+    assert "function vaultBrowserToggleReceiptDetail(row)" in html
+    assert "var expanded = row.getAttribute('aria-expanded') === 'true';" in html
+    assert "detail.hidden = expanded;" in html
+    assert "row.setAttribute('aria-expanded', expanded ? 'false' : 'true');" in html
 
 
 # ---- AC5: unreviewed memory visible but not action-authorizing ----


### PR DESCRIPTION
Fixes #1284

## Summary
Adds a UI-only expand/collapse detail region for Vault Browser receipt rows after #1279 supplied live receipt data. The detail exposes available VaultReceipt fields without adding any server mutation path, receipt authoring control, form, or action button.

## Acceptance Criteria Mapping
- Clicking a receipt row is wired to `vaultBrowserToggleReceiptDetail(this)` and toggles `aria-expanded`, `data-expanded`, `hidden`, and `aria-hidden` on the associated `data-testid="vault-browser-receipt-detail"` region.
- Detail rows render `receipt_id`, `trace_id`, `action_id`, `artifact_uuid`, `requested_by`, `approved_by`, `status`, and `timestamp` with stable `data-testid` attributes.
- The receipt detail region contains no `<button>` or `<form>` markup and no server mutation hook.
- Existing unavailable/no-receipts states remain unchanged.
- `docs/VAULT_BROWSER_CAPABILITY_CONTRACT.md` documents the read-only UI detail boundary.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/python -m pytest -q tests/companion_ui/test_vault_browser_receipts.py` -> 17 passed
- `/Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/python -m ruff check app tests companion-ui/companion-app/companion_ui` -> All checks passed
- `python3 scripts/docs_guard.py` -> Docs guard: OK
- `git diff --check` -> passed

## Workflow Notes
- #1279 has landed and closed; this PR depends on that live receipt row API shape.
- Dispatcher claim status was unavailable in the local worktree (`db_exists:false`), so issue claiming/project state was handled through GitHub labels/project fields.