### PR TITLE
Wire Vault Browser artifact-scoped find_related

### DIFF
--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import datetime
 import os
 import heapq
+import re
 from pathlib import Path, PurePosixPath
 from uuid import uuid4
 
@@ -215,6 +216,38 @@ class VaultLinkIndexResponse(BaseModel):
     total_notes: int
     truncated: bool = False
     read_only: bool = True
+    vault_identity: VaultIdentityState
+    identity_available: bool
+
+
+class VaultRelatedScopeState(BaseModel):
+    note_path: str
+    artifact_uuid: str | None = None
+
+
+class VaultRelatedSignalState(BaseModel):
+    signal: str
+    value: str
+    weight: int
+    provenance: str
+
+
+class VaultRelatedResultState(BaseModel):
+    note_path: str
+    title: str
+    artifact_uuid: str | None = None
+    kind: str | None = None
+    zone: str | None = None
+    data_mode: str = "read_only"
+    ranking_score: int
+    ranking_signals: list[VaultRelatedSignalState]
+
+
+class VaultRelatedResponse(BaseModel):
+    scope: VaultRelatedScopeState
+    results: list[VaultRelatedResultState]
+    read_only: bool = True
+    data_mode: str = "read_only"
     vault_identity: VaultIdentityState
     identity_available: bool
 
@@ -860,6 +893,303 @@ def _browser_title(body: str, *, fallback: str) -> str:
     return _extract_title(body, fallback=fallback)
 
 
+_WIKILINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
+
+
+def _normalize_relation_token(value: str) -> str:
+    token = str(value or "").strip()
+    if "|" in token:
+        token = token.split("|", 1)[0]
+    if "#" in token:
+        token = token.split("#", 1)[0]
+    token = token.strip()
+    if token.endswith(".md"):
+        token = token[:-3]
+    return token.lower()
+
+
+def _wikilink_targets(body: str) -> set[str]:
+    targets: set[str] = set()
+    for match in _WIKILINK_RE.finditer(body):
+        token = _normalize_relation_token(match.group(1))
+        if token:
+            targets.add(token)
+    return targets
+
+
+def _coerce_relation_tags(raw: object) -> set[str]:
+    if raw is None:
+        return set()
+    values: list[object]
+    if isinstance(raw, list):
+        values = raw
+    elif isinstance(raw, tuple | set):
+        values = list(raw)
+    elif isinstance(raw, str):
+        stripped = raw.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            values = [part.strip().strip('"').strip("'") for part in stripped[1:-1].split(",")]
+        elif "," in stripped:
+            values = [part.strip() for part in stripped.split(",")]
+        else:
+            values = [stripped]
+    else:
+        values = [raw]
+    return {
+        str(value).strip().lstrip("#").lower()
+        for value in values
+        if str(value).strip()
+    }
+
+
+def _frontmatter_dict(body: str) -> dict:
+    fm_inner, _ = _split_frontmatter(body)
+    if fm_inner is None:
+        return {}
+    try:
+        raw = yaml.safe_load(fm_inner) or {}
+    except Exception:
+        return {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def _collect_relation_notes(vault_root: Path) -> list[dict[str, object]]:
+    notes: list[dict[str, object]] = []
+    if not vault_root.exists():
+        return notes
+    for candidate in vault_root.rglob("*.md"):
+        if not candidate.is_file():
+            continue
+        safe_path = _vault_relative(candidate, vault_root)
+        if safe_path is None or _is_hidden_browser_path(safe_path):
+            continue
+        try:
+            body = candidate.read_text(encoding="utf-8")
+        except Exception:
+            continue
+        path_zone = _zone_for_path(safe_path)
+        metadata = _parse_note_artifact_metadata(body, path_derived_zone=path_zone)
+        frontmatter = _frontmatter_dict(body)
+        tags = _coerce_relation_tags(frontmatter.get("tags") or frontmatter.get("tag"))
+        title = _browser_title(body, fallback=candidate.stem)
+        notes.append(
+            {
+                "note_path": safe_path,
+                "title": title,
+                "artifact_uuid": metadata["uuid"],
+                "kind": metadata["kind"],
+                "zone": metadata["zone"],
+                "source_ref": metadata["source_ref"],
+                "tags": tags,
+                "wikilink_targets": _wikilink_targets(body),
+            }
+        )
+    return notes
+
+
+def _relation_link_keys(note: dict[str, object]) -> set[str]:
+    note_path = str(note.get("note_path") or "")
+    title = str(note.get("title") or "")
+    uuid = str(note.get("artifact_uuid") or "")
+    path = PurePosixPath(note_path)
+    candidates = {
+        note_path,
+        note_path.removesuffix(".md"),
+        path.name,
+        path.name.removesuffix(".md"),
+        title,
+        uuid,
+    }
+    return {
+        _normalize_relation_token(value)
+        for value in candidates
+        if str(value).strip()
+    }
+
+
+def _resolve_related_scope(
+    notes: list[dict[str, object]],
+    *,
+    note_path: str | None,
+    artifact_uuid: str | None,
+) -> dict[str, object]:
+    target: dict[str, object] | None = None
+    if note_path:
+        target = next((note for note in notes if note.get("note_path") == note_path), None)
+        if target is None:
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "error": "artifact_not_found",
+                    "message": "No vault note exists for the requested note_path.",
+                    "note_path": note_path,
+                },
+            )
+    if artifact_uuid:
+        uuid_match = next(
+            (note for note in notes if note.get("artifact_uuid") == artifact_uuid),
+            None,
+        )
+        if uuid_match is None:
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "error": "artifact_not_found",
+                    "message": "No vault note exists for the requested artifact_uuid.",
+                    "artifact_uuid": artifact_uuid,
+                },
+            )
+        if target is not None and target.get("note_path") != uuid_match.get("note_path"):
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error": "artifact_scope_mismatch",
+                    "message": "note_path and artifact_uuid identify different artifacts.",
+                    "note_path": note_path,
+                    "artifact_uuid": artifact_uuid,
+                },
+            )
+        target = uuid_match
+    if target is None:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "artifact_scope_required",
+                "message": "Provide note_path and/or artifact_uuid for artifact-scoped Find.",
+            },
+        )
+    return target
+
+
+def _signal(signal: str, value: str, *, weight: int, provenance: str) -> dict[str, object]:
+    return {
+        "signal": signal,
+        "value": value,
+        "weight": weight,
+        "provenance": provenance,
+    }
+
+
+def _related_signals(
+    target: dict[str, object],
+    candidate: dict[str, object],
+) -> list[dict[str, object]]:
+    target_path = str(target.get("note_path") or "")
+    candidate_path = str(candidate.get("note_path") or "")
+    target_keys = _relation_link_keys(target)
+    candidate_keys = _relation_link_keys(candidate)
+    target_links = target.get("wikilink_targets") or set()
+    candidate_links = candidate.get("wikilink_targets") or set()
+    target_tags = target.get("tags") or set()
+    candidate_tags = candidate.get("tags") or set()
+    signals: list[dict[str, object]] = []
+
+    if isinstance(target_links, set) and target_links.intersection(candidate_keys):
+        signals.append(
+            _signal(
+                "wikilink_outlink",
+                candidate_path,
+                weight=100,
+                provenance=f"{target_path} wikilinks to candidate",
+            )
+        )
+    if isinstance(candidate_links, set) and candidate_links.intersection(target_keys):
+        signals.append(
+            _signal(
+                "wikilink_backlink",
+                target_path,
+                weight=100,
+                provenance=f"{candidate_path} wikilinks to scope artifact",
+            )
+        )
+    if isinstance(target_tags, set) and isinstance(candidate_tags, set):
+        for tag in sorted(target_tags.intersection(candidate_tags)):
+            signals.append(
+                _signal(
+                    "shared_tag",
+                    tag,
+                    weight=30,
+                    provenance="frontmatter.tags",
+                )
+            )
+    target_source = str(target.get("source_ref") or "")
+    candidate_source = str(candidate.get("source_ref") or "")
+    target_uuid = str(target.get("artifact_uuid") or "")
+    candidate_uuid = str(candidate.get("artifact_uuid") or "")
+    if candidate_source and candidate_source in {target_path, target_uuid}:
+        signals.append(
+            _signal(
+                "source_ref_points_to_scope",
+                candidate_source,
+                weight=80,
+                provenance=f"{candidate_path} frontmatter.source_ref",
+            )
+        )
+    if target_source and target_source in {candidate_path, candidate_uuid}:
+        signals.append(
+            _signal(
+                "scope_source_ref_points_to_candidate",
+                target_source,
+                weight=80,
+                provenance=f"{target_path} frontmatter.source_ref",
+            )
+        )
+    if target_source and candidate_source and target_source == candidate_source:
+        signals.append(
+            _signal(
+                "shared_source_ref",
+                target_source,
+                weight=60,
+                provenance="frontmatter.source_ref",
+            )
+        )
+    target_zone = str(target.get("zone") or "")
+    candidate_zone = str(candidate.get("zone") or "")
+    if target_zone and candidate_zone and target_zone == candidate_zone:
+        signals.append(
+            _signal(
+                "shared_zone",
+                target_zone,
+                weight=10,
+                provenance="frontmatter.zone/path zone",
+            )
+        )
+    return signals
+
+
+def _rank_related_notes(
+    target: dict[str, object],
+    notes: list[dict[str, object]],
+    *,
+    limit: int,
+) -> list[VaultRelatedResultState]:
+    results: list[VaultRelatedResultState] = []
+    target_path = target.get("note_path")
+    for candidate in notes:
+        if candidate.get("note_path") == target_path:
+            continue
+        signals = _related_signals(target, candidate)
+        if not signals:
+            continue
+        ranking_score = sum(int(signal["weight"]) for signal in signals)
+        results.append(
+            VaultRelatedResultState(
+                note_path=str(candidate.get("note_path") or ""),
+                title=str(candidate.get("title") or ""),
+                artifact_uuid=_str_or_none(candidate.get("artifact_uuid")),
+                kind=_str_or_none(candidate.get("kind")),
+                zone=_str_or_none(candidate.get("zone")),
+                ranking_score=ranking_score,
+                ranking_signals=[
+                    VaultRelatedSignalState.model_validate(signal)
+                    for signal in signals
+                ],
+            )
+        )
+    results.sort(key=lambda result: (-result.ranking_score, result.note_path))
+    return results[:limit]
+
+
 def _compose_note_with_preserved_frontmatter(*, original_content: str, new_body: str) -> str:
     if _body_contains_frontmatter(new_body):
         raise HTTPException(
@@ -979,6 +1309,64 @@ def read_companion_vault_link_index() -> VaultLinkIndexResponse:
         total_notes=len(note_paths),
         truncated=truncated,
         read_only=True,
+        vault_identity=identity,
+        identity_available=identity_available,
+    )
+
+
+@router.get("/vault-related", response_model=VaultRelatedResponse)
+def read_companion_vault_related(
+    note_path: str | None = Query(
+        default=None,
+        description="Vault-relative markdown note path to use as the Find scope.",
+    ),
+    artifact_uuid: str | None = Query(
+        default=None,
+        description="Artifact UUID to use as the Find scope.",
+    ),
+    limit: int = Query(10, ge=1, le=50),
+) -> VaultRelatedResponse:
+    """Return deterministic, read-only related artifacts for one vault artifact.
+
+    This intentionally does not reuse ``/search`` because that route is text /
+    embedding search. Vault Browser ``find_related`` requires artifact scope and
+    surfaced ranking/provenance signals so Browse and Find remain separate.
+    """
+    if note_path is None and artifact_uuid is None:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "artifact_scope_required",
+                "message": "Provide note_path and/or artifact_uuid for artifact-scoped Find.",
+            },
+        )
+    safe_note_path = (
+        _validate_workspace_markdown_note_path(note_path)
+        if note_path is not None
+        else None
+    )
+    safe_artifact_uuid = artifact_uuid.strip() if artifact_uuid else None
+    vault_root = resolve_vault_root()
+    notes = _collect_relation_notes(vault_root)
+    target = _resolve_related_scope(
+        notes,
+        note_path=safe_note_path,
+        artifact_uuid=safe_artifact_uuid,
+    )
+    identity = _vault_identity_state(vault_root)
+    identity_available = (
+        bool(identity.vault_name.strip()) and identity.channel in {"dev", "test", "prod"}
+    )
+    target_note_path = str(target.get("note_path") or "")
+    target_uuid = _str_or_none(target.get("artifact_uuid"))
+    return VaultRelatedResponse(
+        scope=VaultRelatedScopeState(
+            note_path=target_note_path,
+            artifact_uuid=target_uuid,
+        ),
+        results=_rank_related_notes(target, notes, limit=limit),
+        read_only=True,
+        data_mode="read_only",
         vault_identity=identity,
         identity_available=identity_available,
     )

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -1690,6 +1690,54 @@ def _render_inspector_receipts(note: dict) -> str:
     )
 
 
+def _render_vault_related_results(results: list[dict]) -> str:
+    if not results:
+        return (
+            '<div class="vault-related-results" '
+            'data-testid="vault-browser-find-related-results" '
+            'data-mode="read_only" '
+            'data-state="idle"></div>'
+        )
+    rows: list[str] = []
+    for result in results:
+        signals = result.get("ranking_signals") or result.get("signals") or []
+        signal_html = "".join(
+            (
+                '<span class="vault-related-signal" '
+                'data-testid="vault-browser-find-related-signal" '
+                f'data-signal="{_e(str(signal.get("signal") or ""))}" '
+                f'data-weight="{_e(str(signal.get("weight") or ""))}" '
+                f'data-provenance="{_e(str(signal.get("provenance") or ""))}">'
+                f'{_e(str(signal.get("signal") or ""))}: {_e(str(signal.get("value") or ""))}'
+                '</span>'
+            )
+            for signal in signals
+            if isinstance(signal, dict)
+        )
+        rows.append(
+            f'<article class="vault-related-result" '
+            f'data-testid="vault-browser-find-related-result" '
+            f'data-mode="{_e(str(result.get("data_mode") or "read_only"))}" '
+            f'data-note-path="{_e(str(result.get("note_path") or ""))}" '
+            f'data-ranking-score="{_e(str(result.get("ranking_score") or 0))}">'
+            f'<span class="vault-related-title">{_e(str(result.get("title") or "Related artifact"))}</span>'
+            f'<code class="vault-related-path">{_e(str(result.get("note_path") or ""))}</code>'
+            f'<span class="vault-related-score" '
+            f'data-testid="vault-browser-find-related-score">'
+            f'{_e(str(result.get("ranking_score") or 0))}</span>'
+            f'<span class="vault-related-signals">{signal_html}</span>'
+            f'</article>'
+        )
+    return (
+        '<div class="vault-related-results" '
+        'data-testid="vault-browser-find-related-results" '
+        'data-mode="read_only" '
+        'data-state="ready">'
+        + "".join(rows)
+        + '</div>'
+    )
+
+
 def _render_vault_actions(note: dict) -> str:
     """Render the VaultAction display model for the selected browser artifact.
 
@@ -1706,6 +1754,7 @@ def _render_vault_actions(note: dict) -> str:
     this slice. No new write path is opened without guard/receipt semantics.
     """
     note_path = str(note.get("note_path") or "").strip()
+    artifact_uuid = str(note.get("uuid") or "").strip()
 
     def _action(
         testid: str,
@@ -1721,6 +1770,10 @@ def _render_vault_actions(note: dict) -> str:
         requires_confirmation: bool = False,
         data_href: str = "",
         data_path: str = "",
+        data_api_method: str = "",
+        data_api_path: str = "",
+        data_note_path: str = "",
+        data_artifact_uuid: str = "",
         onclick: str = "",
     ) -> str:
         blocked_attr = (
@@ -1737,6 +1790,14 @@ def _render_vault_actions(note: dict) -> str:
         confirm_attr = ' data-requires-confirmation="true"' if requires_confirmation else ""
         href_attr = f' data-href="{_e(data_href)}"' if data_href else ""
         path_attr = f' data-path="{_e(data_path)}"' if data_path else ""
+        api_method_attr = f' data-api-method="{_e(data_api_method)}"' if data_api_method else ""
+        api_path_attr = f' data-api-path="{_e(data_api_path)}"' if data_api_path else ""
+        note_path_attr = f' data-note-path="{_e(data_note_path)}"' if data_note_path else ""
+        artifact_uuid_attr = (
+            f' data-artifact-uuid="{_e(data_artifact_uuid)}"'
+            if data_artifact_uuid
+            else ""
+        )
         onclick_attr = f' onclick="{_e(onclick)}"' if onclick else ""
         return (
             f'<div class="vault-action" '
@@ -1749,6 +1810,10 @@ def _render_vault_actions(note: dict) -> str:
             f"{confirm_attr}"
             f"{href_attr}"
             f"{path_attr}"
+            f"{api_method_attr}"
+            f"{api_path_attr}"
+            f"{note_path_attr}"
+            f"{artifact_uuid_attr}"
             f'{onclick_attr}>'
             f'<span class="vault-action-label">{_e(label)}</span>'
             f"</div>"
@@ -1776,8 +1841,16 @@ def _render_vault_actions(note: dict) -> str:
             "vault-action-find-related",
             "Find related (read-only)",
             "read_only",
-            disabled=True,
-            disabled_reason="Find not connected for this artifact.",
+            affordance="available" if note_path or artifact_uuid else "unavailable",
+            disabled=not (note_path or artifact_uuid),
+            disabled_reason=(
+                "" if note_path or artifact_uuid else "Artifact scope unavailable for Find."
+            ),
+            data_api_method="GET" if note_path or artifact_uuid else "",
+            data_api_path="/api/companion/vault-related" if note_path or artifact_uuid else "",
+            data_note_path=note_path,
+            data_artifact_uuid=artifact_uuid,
+            onclick="vaultBrowserFindRelated(this)" if note_path or artifact_uuid else "",
         ),
         _action(
             "vault-action-queue-review",
@@ -1794,6 +1867,7 @@ def _render_vault_actions(note: dict) -> str:
         'data-testid="workspace-vault-browser-inspector-actions">'
         + "".join(actions)
         + "</div>"
+        + _render_vault_related_results(list(note.get("related_results") or []))
     )
 
 
@@ -5442,6 +5516,34 @@ def render_index_html(
       min-width: 0;
       overflow-wrap: anywhere;
     }}
+    .vault-related-results {{
+      display: grid;
+      gap: 6px;
+      margin-top: 6px;
+    }}
+    .vault-related-result {{
+      border-left: 1px solid var(--border);
+      display: grid;
+      gap: 2px;
+      padding-left: 8px;
+    }}
+    .vault-related-title {{
+      color: var(--fg-1);
+      font-weight: 600;
+    }}
+    .vault-related-path,
+    .vault-related-score,
+    .vault-related-signal {{
+      color: var(--fg-3);
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      overflow-wrap: anywhere;
+    }}
+    .vault-related-signals {{
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px;
+    }}
     /* #1425 — de-emphasize browse header chrome; the tree is the surface. The
        "Browse vault notes" toggle matches the Outline heading label. */
     .vault-browser-meta,
@@ -5822,6 +5924,75 @@ def render_index_html(
     detail.hidden = expanded;
     detail.setAttribute('aria-hidden', expanded ? 'true' : 'false');
     detail.setAttribute('data-expanded', expanded ? 'false' : 'true');
+  }}
+
+  function vaultBrowserEscape(value) {{
+    return String(value == null ? '' : value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }}
+
+  function renderVaultBrowserFindRelatedResults(data) {{
+    var container = document.querySelector('[data-testid="vault-browser-find-related-results"]');
+    if (!container) return;
+    var results = data && Array.isArray(data.results) ? data.results : [];
+    container.setAttribute('data-mode', 'read_only');
+    container.setAttribute('data-state', results.length ? 'ready' : 'empty');
+    if (!results.length) {{
+      container.innerHTML = '<span class="vault-related-empty">No related artifacts found.</span>';
+      return;
+    }}
+    container.innerHTML = results.map(function(result) {{
+      var signals = Array.isArray(result.ranking_signals) ? result.ranking_signals : [];
+      var signalHtml = signals.map(function(signal) {{
+        return '<span class="vault-related-signal" ' +
+          'data-testid="vault-browser-find-related-signal" ' +
+          'data-signal="' + vaultBrowserEscape(signal.signal) + '" ' +
+          'data-weight="' + vaultBrowserEscape(signal.weight) + '" ' +
+          'data-provenance="' + vaultBrowserEscape(signal.provenance) + '">' +
+          vaultBrowserEscape(signal.signal) + ': ' + vaultBrowserEscape(signal.value) +
+          '</span>';
+      }}).join('');
+      return '<article class="vault-related-result" ' +
+        'data-testid="vault-browser-find-related-result" ' +
+        'data-mode="read_only" ' +
+        'data-note-path="' + vaultBrowserEscape(result.note_path) + '" ' +
+        'data-ranking-score="' + vaultBrowserEscape(result.ranking_score || 0) + '">' +
+        '<span class="vault-related-title">' + vaultBrowserEscape(result.title || 'Related artifact') + '</span>' +
+        '<code class="vault-related-path">' + vaultBrowserEscape(result.note_path || '') + '</code>' +
+        '<span class="vault-related-score" data-testid="vault-browser-find-related-score">' +
+        vaultBrowserEscape(result.ranking_score || 0) + '</span>' +
+        '<span class="vault-related-signals">' + signalHtml + '</span>' +
+        '</article>';
+    }}).join('');
+  }}
+
+  function vaultBrowserFindRelated(action) {{
+    if (!action || !action.dataset) return;
+    var params = new URLSearchParams();
+    if (action.dataset.notePath) params.set('note_path', action.dataset.notePath);
+    if (action.dataset.artifactUuid) params.set('artifact_uuid', action.dataset.artifactUuid);
+    if (!params.toString()) return;
+    var endpoint = action.dataset.apiPath || '/api/companion/vault-related';
+    var url = endpoint + '?' + params.toString();
+    fetch(url, {{method: 'GET'}})
+      .then(function(response) {{
+        if (!response.ok) throw new Error('Find request failed: ' + response.status);
+        return response.json();
+      }})
+      .then(function(data) {{
+        renderVaultBrowserFindRelatedResults(data);
+      }})
+      .catch(function(error) {{
+        var container = document.querySelector('[data-testid="vault-browser-find-related-results"]');
+        if (!container) return;
+        container.setAttribute('data-mode', 'read_only');
+        container.setAttribute('data-state', 'error');
+        container.textContent = error.message;
+      }});
   }}
 
   function vbToggleFilter(el) {{

--- a/docs/VAULT_BROWSER_CAPABILITY_CONTRACT.md
+++ b/docs/VAULT_BROWSER_CAPABILITY_CONTRACT.md
@@ -120,6 +120,11 @@ Supported filter dimensions (capability map; subset shipped per MLP):
 
 Ranking, when used, must be **explicit and observable**: the browser must be able to show which signals contributed to a result's position. Implicit semantic ranking without surfaced signals is out of scope. Deterministic filters (text, path, title) are preferred and required as the default.
 
+Artifact-scoped Find may rank related artifacts only when the response surfaces the contributing
+signals and their weights/provenance. Current deterministic signals include vault wikilinks,
+frontmatter tags, frontmatter/source references, and shared zone; these are not semantic/vector
+neighborhoods.
+
 ### 4.4 VaultRelation
 
 A relation between two artifacts.
@@ -188,7 +193,7 @@ Required fields per action:
 
 Required action modes (boundary contract):
 
-- `read_only` — no state change anywhere (open, peek, copy path)
+- `read_only` — no state change anywhere (open, peek, copy path, find related)
 - `ui_only` — local Companion UI state only (toggle panel, expand row, change view)
 - `bounded_system_write` — governed system-side state change with a receipt (mark indexed, queue for review)
 - `governance_write` — change that crosses an authority boundary (alter review posture, alter trust, promote a relation, change lifecycle state) and must be routed through governed execution
@@ -254,6 +259,7 @@ fields and must not contain action buttons, forms, authoring controls, or server
 The Vault Browser must keep the following capabilities **separate**:
 
 - **Browsing** — enumerating, filtering, ranking, and visually presenting artifacts.
+- **Find** — artifact-scoped related-artifact lookup with visible ranking/provenance signals.
 - **Retrieval** — answering a content/context question with ranked evidence (`docs/RETRIEVAL.md`).
 - **Orientation** — surfacing "what is this, why does it matter, where did it come from, what state is it in" for a specific artifact.
 - **Resurfacing** — bringing forgotten or dormant material back into attention under policy (`docs/CONCEPTS/SALIENCE_AND_ATTENTIONAL_RELEVANCE_CONTRACT.md`, `companion-ui/docs/RESURFACING_HEURISTICS.md`).
@@ -262,6 +268,12 @@ The Vault Browser must keep the following capabilities **separate**:
 - **Agent proposals** — surfaced via `VaultProposal`, never auto-applied.
 
 A Vault Browser implementation may compose with these capabilities, but must not collapse them into a single action.
+
+Current Find implementation note (#1282): `find_related` calls the read-only
+`GET /api/companion/vault-related` endpoint with `note_path` and/or `artifact_uuid` scope.
+The endpoint is separate from `/search`, which remains text/vector search. Results carry
+`data_mode="read_only"`, `ranking_score`, and `ranking_signals` with signal, value, weight, and
+provenance so ordering is inspectable.
 
 ## 6. MLP v0 boundary
 
@@ -376,6 +388,8 @@ The currently shipped Companion UI vault browser (from #1225 / PR #1239 and foll
 **#1279 (per-artifact receipt source):** The vault browser API now includes a per-note `receipts` field when a receipt-supporting outbox/event source is available. The field is populated by a read-only batch projection over existing governed records keyed by artifact UUID and/or vault-relative path; it does not create a receipt table, author receipts, or introduce a browser write path. Current projected rows carry `receipt_id`, `trace_id`, `action_id`, `action_type`, `artifact_uuid`, `artifact_path`/`path`, `requested_by`, `approved_by`, `status`, `timestamp`, and UI-compatible `state`. Missing source remains the absent-key `unavailable` state; a connected source with no matches returns an empty list (`no_receipts`).
 
 **#1284 (receipt row expand detail):** The artifact inspector receipt rows are now UI-only expandable rows. Clicking a row toggles a collapsed detail region (`data-testid="vault-browser-receipt-detail"`) that displays the available VaultReceipt fields: `receipt_id`, `trace_id`, `action_id`, `artifact_uuid`, `requested_by`, `approved_by`, `status`, and `timestamp`. The detail region is read-only and contains no `<button>`, `<form>`, server mutation hook, or receipt-authoring affordance.
+
+**#1282 (artifact-scoped find_related):** The `find_related` VaultAction is now wired as a read-only artifact-scoped Find action, separate from Browse and from `/search` text/vector search. The UI action carries `data-mode="read_only"`, `data-api-method="GET"`, `data-api-path="/api/companion/vault-related"`, and the selected artifact scope (`data-note-path`, `data-artifact-uuid`). The endpoint accepts `note_path` and/or `artifact_uuid`, returns `read_only: true` / `data_mode: "read_only"`, and ranks related artifacts using surfaced deterministic signals such as wikilink outlinks/backlinks, shared frontmatter tags, source references, and shared zone. No write path, receipt authoring path, or hidden semantic ranking is introduced.
 
 **#1280 (wire interactive filter chip clicks):** Delivered by PR #1322 (2026-05-26). Filter chips now carry `onclick="vbToggleFilter(this)"` and `style="cursor:pointer"` — clicking an inactive chip appends its `data-key`/`data-value` to the URL query string and reloads; clicking an active chip removes it. When multiple values are active for the same dimension, each chip renders a deselect affordance (`data-testid="filter-chip-remove"` `×` span); a single active chip shows no affordance. The `handle_get` handler parses `kind`, `zone`, `review_state`, `trust` from the query string and forwards them to the vault-browser API, making active filter state bookmarkable. Server remains the authoritative filter processor; no client-side filtering is introduced. Extends §4.3 (`VaultQuery`) interactive capability without altering filter semantics.
 

--- a/tests/api/test_companion_vault_related_api.py
+++ b/tests/api/test_companion_vault_related_api.py
@@ -1,0 +1,175 @@
+"""Read-only artifact-scoped Find API for Vault Browser find_related (#1282)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app.api.app import app
+
+
+def _write_note(
+    path: Path,
+    *,
+    title: str,
+    uuid: str,
+    tags: list[str] | None = None,
+    zone: str = "notes",
+    source_ref: str | None = None,
+    body: str = "Body.\n",
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tag_lines = "".join(f"  - {tag}\n" for tag in tags or [])
+    source_ref_line = f"source_ref: {source_ref}\n" if source_ref else ""
+    path.write_text(
+        (
+            "---\n"
+            f"title: {title}\n"
+            f"uuid: {uuid}\n"
+            "kind: human_note\n"
+            f"zone: {zone}\n"
+            f"{source_ref_line}"
+            "tags:\n"
+            f"{tag_lines}"
+            "---\n\n"
+            f"{body}"
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_vault_related_returns_read_only_artifact_scoped_signals(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+    target_uuid = "00000000-0000-0000-0000-000000001282"
+    related_uuid = "00000000-0000-0000-0000-000000001283"
+    tag_only_uuid = "00000000-0000-0000-0000-000000001284"
+    _write_note(
+        tmp_path / "notes" / "current.md",
+        title="Current",
+        uuid=target_uuid,
+        tags=["alpha", "pkm"],
+        body="See [[Related Target]] for context.\n",
+    )
+    _write_note(
+        tmp_path / "notes" / "related.md",
+        title="Related Target",
+        uuid=related_uuid,
+        tags=["alpha"],
+        body="Backlink to [[Current]].\n",
+    )
+    _write_note(
+        tmp_path / "notes" / "tag-only.md",
+        title="Tag Only",
+        uuid=tag_only_uuid,
+        tags=["pkm"],
+        body="Shares only a tag.\n",
+    )
+    _write_note(
+        tmp_path / "other" / "unrelated.md",
+        title="Unrelated",
+        uuid="00000000-0000-0000-0000-000000001285",
+        tags=["other"],
+        zone="other",
+        body="No relation.\n",
+    )
+
+    resp = TestClient(app).get(
+        "/api/companion/vault-related",
+        params={"note_path": "notes/current.md"},
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["read_only"] is True
+    assert data["data_mode"] == "read_only"
+    assert data["scope"] == {
+        "note_path": "notes/current.md",
+        "artifact_uuid": target_uuid,
+    }
+    paths = [result["note_path"] for result in data["results"]]
+    assert paths[:2] == ["notes/related.md", "notes/tag-only.md"]
+    assert "other/unrelated.md" not in paths
+    scores = [result["ranking_score"] for result in data["results"]]
+    assert scores == sorted(scores, reverse=True)
+
+    related = data["results"][0]
+    assert related["data_mode"] == "read_only"
+    assert related["artifact_uuid"] == related_uuid
+    signals = related["ranking_signals"]
+    assert {signal["signal"] for signal in signals} >= {
+        "wikilink_outlink",
+        "wikilink_backlink",
+        "shared_tag",
+    }
+    for signal in signals:
+        assert set(signal) == {"signal", "value", "weight", "provenance"}
+        assert signal["weight"] > 0
+        assert signal["provenance"]
+
+
+def test_vault_related_accepts_artifact_uuid_scope(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+    target_uuid = "00000000-0000-0000-0000-000000001286"
+    _write_note(
+        tmp_path / "notes" / "current.md",
+        title="Current",
+        uuid=target_uuid,
+        tags=["alpha"],
+    )
+    _write_note(
+        tmp_path / "notes" / "related.md",
+        title="Related",
+        uuid="00000000-0000-0000-0000-000000001287",
+        tags=["alpha"],
+    )
+
+    resp = TestClient(app).get(
+        "/api/companion/vault-related",
+        params={"artifact_uuid": target_uuid},
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["scope"]["note_path"] == "notes/current.md"
+    assert data["scope"]["artifact_uuid"] == target_uuid
+    assert data["results"][0]["note_path"] == "notes/related.md"
+
+
+def test_vault_related_requires_artifact_scope(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+
+    resp = TestClient(app).get("/api/companion/vault-related")
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["error"] == "artifact_scope_required"
+
+
+def test_vault_related_is_read_only(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+    note_path = tmp_path / "notes" / "current.md"
+    _write_note(
+        note_path,
+        title="Current",
+        uuid="00000000-0000-0000-0000-000000001288",
+        tags=["alpha"],
+    )
+    before = note_path.read_text(encoding="utf-8")
+
+    resp = TestClient(app).post(
+        "/api/companion/vault-related",
+        json={"note_path": "notes/current.md"},
+    )
+
+    assert resp.status_code == 405
+    assert note_path.read_text(encoding="utf-8") == before

--- a/tests/companion_ui/test_vault_browser_vault_action.py
+++ b/tests/companion_ui/test_vault_browser_vault_action.py
@@ -76,8 +76,9 @@ def _browser_note(
     kind: str | None = "human_note",
     zone: str = "notes",
     frontmatter_valid: bool = True,
+    related_results: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
-    return {
+    note = {
         "note_path": note_path,
         "title": title,
         "uuid": uuid,
@@ -92,6 +93,9 @@ def _browser_note(
         "frontmatter_valid": frontmatter_valid,
         "missing_required_fields": [],
     }
+    if related_results is not None:
+        note["related_results"] = related_results
+    return note
 
 
 def _vault_browser_payload(notes: list[dict[str, Any]] | None = None) -> dict[str, Any]:
@@ -294,6 +298,83 @@ def test_copy_path_carries_note_path_in_data_path() -> None:
     assert 'data-path="notes/current.md"' in tag, (
         f"copy_path must carry data-path with the note path; got: {tag!r}"
     )
+
+
+# ---- AC for #1282: find_related wired to read-only artifact-scoped Find ----
+
+
+def test_find_related_affordance_available_with_artifact_scope() -> None:
+    """#1282 AC: find_related is available when the selected artifact has scope."""
+    note = _browser_note(note_path="notes/current.md", uuid="uuid-1282")
+    html = _inspector_html(_load_html(browser_payload=_vault_browser_payload(notes=[note])))
+    tag = _action_tag(html, "vault-action-find-related")
+
+    assert 'data-mode="read_only"' in tag
+    assert 'data-affordance-status="available"' in tag
+    assert 'data-api-method="GET"' in tag
+    assert 'data-api-path="/api/companion/vault-related"' in tag
+    assert 'data-note-path="notes/current.md"' in tag
+    assert 'data-artifact-uuid="uuid-1282"' in tag
+    assert 'onclick="vaultBrowserFindRelated(this)"' in tag
+    assert "Find not connected" not in tag
+    assert "data-disabled" not in tag
+
+
+def test_find_related_results_region_is_read_only() -> None:
+    """#1282 AC: inspector exposes a read-only result region for related artifacts."""
+    html = _inspector_html(_load_html())
+
+    assert 'data-testid="vault-browser-find-related-results"' in html
+    assert 'data-mode="read_only"' in html
+    assert 'data-state="idle"' in html
+
+
+def test_find_related_result_rows_expose_ranking_signals() -> None:
+    """#1282 AC: rendered related rows surface ranking/provenance signals."""
+    note = _browser_note(
+        related_results=[
+            {
+                "note_path": "notes/related.md",
+                "title": "Related",
+                "data_mode": "read_only",
+                "ranking_score": 130,
+                "ranking_signals": [
+                    {
+                        "signal": "shared_tag",
+                        "value": "alpha",
+                        "weight": 30,
+                        "provenance": "frontmatter.tags",
+                    },
+                    {
+                        "signal": "wikilink_backlink",
+                        "value": "notes/current.md",
+                        "weight": 100,
+                        "provenance": "notes/related.md wikilinks to scope artifact",
+                    },
+                ],
+            }
+        ]
+    )
+    html = _inspector_html(_load_html(browser_payload=_vault_browser_payload(notes=[note])))
+
+    assert 'data-testid="vault-browser-find-related-result"' in html
+    assert 'data-mode="read_only"' in html
+    assert 'data-ranking-score="130"' in html
+    assert 'data-testid="vault-browser-find-related-signal"' in html
+    assert 'data-signal="shared_tag"' in html
+    assert 'data-weight="30"' in html
+    assert 'data-provenance="frontmatter.tags"' in html
+
+
+def test_find_related_js_calls_read_only_endpoint() -> None:
+    """#1282 AC: click handler calls the scoped endpoint with GET, not mutation."""
+    html = _load_html()
+
+    assert "function vaultBrowserFindRelated(action)" in html
+    assert "params.set('note_path', action.dataset.notePath);" in html
+    assert "params.set('artifact_uuid', action.dataset.artifactUuid);" in html
+    assert "fetch(url, {method: 'GET'})" in html
+    assert "renderVaultBrowserFindRelatedResults(data);" in html
 
 
 # ---- AC6: body update flow remains separate ----


### PR DESCRIPTION
Fixes #1282

## Summary
Adds a dedicated read-only artifact-scoped Find endpoint at `GET /api/companion/vault-related` and wires the Vault Browser `find_related` action to call it with note path and/or artifact UUID scope. Results stay separate from Browse and from `/search` text/vector search, and every ranked result exposes deterministic ranking/provenance signals.

## Acceptance Criteria Mapping
- Clicking `find_related` is wired as a read-only GET action via `data-api-method="GET"`, `data-api-path="/api/companion/vault-related"`, `data-note-path`, `data-artifact-uuid`, and `onclick="vaultBrowserFindRelated(this)"`.
- The endpoint accepts `note_path` and/or `artifact_uuid` scope and returns `read_only: true`, `data_mode: "read_only"`, `scope`, and `results`.
- Result rows render in the inspector result region with `data-mode="read_only"`, `data-ranking-score`, and visible `ranking_signals` carrying signal, value, weight, and provenance.
- `find_related` no longer renders the old "Find not connected" disabled state when artifact scope is available.
- No write path is introduced; non-GET calls to the endpoint are rejected by routing.
- `docs/VAULT_BROWSER_CAPABILITY_CONTRACT.md` documents the Find/Browse/search separation and the surfaced-signal ranking contract.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/python -m pytest -q tests/companion_ui/test_vault_browser_vault_action.py` -> 18 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/python -m pytest -q tests/api` -> 195 passed, 2 skipped
- `/Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/python -m ruff check app tests` -> All checks passed
- `python3 scripts/docs_guard.py` -> Docs guard: OK
- `git diff --check` -> passed

## Additional Check
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/python -m pytest -q tests/companion_ui` currently has 2 unrelated existing failures outside this slice:
  - `tests/companion_ui/test_real_note_workspace_dev_server.py::TestRenderIndexHtml::test_renders_runtime_safety_strip_and_identity_pills`
  - `tests/companion_ui/test_resurface_mode_browser.py::test_workspace_resurface_source_link_uses_logical_identifier`

## Workflow Notes
- The existing `app/api/routes/search.py` was inspected and left unchanged because it is query-text/vector search, not artifact-scoped Find with surfaced deterministic signals.
- Dispatcher unavailable (`db_exists:false`) — used GitHub-label-only claim.