### PR TITLE
Clarify promotion receipt semantics

### DIFF
--- a/docs/CONCEPTS/ONTOLOGY_VOCABULARY.md
+++ b/docs/CONCEPTS/ONTOLOGY_VOCABULARY.md
@@ -163,16 +163,23 @@ They record where the active runtime most clearly compresses multiple ontology l
     term for a human artifact.
 
 - `app/promotion/consumer.py` and `app/services/note_update.py`
-  - `promotion` currently resolves into `review_state` mutation in both vault frontmatter and store
-    payload. A `PROMOTE_DONE` DB outbox event is emitted on success and serves as the current
-    transition record; `payload["promotion"]` in the ObjectStore row provides inline provenance.
+  - `promotion` currently resolves into durable `maturity` / `review_state` mutation in vault
+    frontmatter and into mirror payload updates in the ObjectStore.
+  - A `PROMOTE_DONE` DB outbox event is emitted on success as the execution/result event. It is not
+    the final receipt store.
+  - A separate `PROMOTION_TRANSITION_APPLIED` / `promotion.transition.applied` event is emitted as
+    the current transition-accountability event / interim receipt-supporting record. It carries
+    authority, basis, outcome, and artifact linkage for the applied transition.
+  - `payload["promotion"]` in the ObjectStore row provides inline machine-mirror provenance only.
   - What is missing is a **distinct durable promotion receipt artifact** — separate from the store
-    payload and queryable as an accountability record. Until that is added, the transition record
-    lives only as an outbox event and an embedded payload field.
+    payload and queryable as an accountability record. Until that is added, accountability is
+    recoverable from the transition-accountability event plus supporting operational traces, not
+    from a final durable receipt store.
   - Tracked follow-on: issue #1403. Target state: promotion consumer writes a formal receipt record
     in addition to the store payload mutation. Pre-requisite: receipt store model.
   - This note is an enabling-change annotation, not a current-state claim. Current behavior
-    (PROMOTE_DONE event + payload["promotion"]) is the correct interim implementation.
+    (`PROMOTE_DONE` + `promotion.transition.applied` + `payload["promotion"]`) is the correct
+    interim implementation.
 
 - `app/domain/plan.py` and `app/agents/planner/graph.py`
   - `plan` currently means execution plan much more than human project or commitment structure.

--- a/docs/CONCEPTS/RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md
+++ b/docs/CONCEPTS/RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md
@@ -174,6 +174,15 @@ Current bounded projection note (#1279):
 - when the source is unavailable, the browser must preserve the `unavailable` state rather than
   fabricating receipt rows.
 
+Promotion transition note (#1438):
+- `promote.done` / `PROMOTE_DONE` is an execution-result trace event, not the final durable receipt
+  store;
+- `promotion.transition.applied` / `PROMOTION_TRANSITION_APPLIED` is the current
+  transition-accountability event and interim receipt-supporting record for successful promotion
+  transitions;
+- ObjectStore `payload["promotion"]` inline provenance is mirror provenance, not receipt authority;
+- a formal durable promotion receipt remains blocked on the receipt-store/query model.
+
 ## 6. Minimal accountability rule
 
 For every meaningful system action, the overall system should make it possible to recover:

--- a/docs/CONCEPTS/WORKFLOW_MUTATION_AND_GOVERNANCE_SEMANTICS.md
+++ b/docs/CONCEPTS/WORKFLOW_MUTATION_AND_GOVERNANCE_SEMANTICS.md
@@ -84,15 +84,29 @@ These are the failure modes this contract exists to prevent:
 
 These notes document known gaps between the contracts above and the current runtime, so future implementors know what is target-state vs delivered. They are enabling-change annotations, not contract revisions.
 
-### Promotion path — receipt gap (tracking issue #1403)
+### Promotion path — receipt/accountability gap (tracking issue #1403)
 
-The `app/promotion/consumer.py` + `app/services/note_update.py` path satisfies the "no silent durable write" rule via a `PROMOTE_DONE` DB outbox event on success, and embeds `payload["promotion"]` provenance in the ObjectStore row. However, it does not yet produce a **formal durable promotion receipt** as a distinct, queryable accountability artifact (as specified by §Receipt linkage above and `docs/CONCEPTS/RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md`).
+The `app/promotion/consumer.py` + `app/services/note_update.py` path satisfies the current
+"no silent durable write" rule through separate observable records after a successful governed
+mutation:
 
-Current state: `PROMOTE_DONE` event in DB outbox = the transition record. `payload["promotion"]` = inline provenance.
-Target state: promotion consumer also writes a formal receipt record to a receipt store.
+- `PROMOTE_DONE` is the execution/result event. It records that promotion execution applied and
+  carries the resulting `state`, `maturity`, `review_state`, note identity, and source event.
+- `PROMOTION_TRANSITION_APPLIED` / `promotion.transition.applied` is the current transition
+  accountability event and interim receipt-supporting record. It carries the transition family,
+  target maturity, authority, basis, outcome, and artifact linkage.
+- `payload["promotion"]` in the ObjectStore row is inline operational provenance for the machine
+  mirror, not the durable receipt store.
+
+Current state: `PROMOTE_DONE` + `promotion.transition.applied` + ObjectStore inline provenance are
+the correct interim implementation. They provide execution/result trace, transition-accountability
+audit material, and mirror provenance respectively.
+Target state: promotion consumer also writes a formal, durable, queryable promotion receipt record
+to a receipt store.
 Pre-requisite: receipt store model (not yet built).
 
-Until the receipt store is built, treat `PROMOTE_DONE` + `payload["promotion"]` as the correct interim implementation. Do not add ad hoc receipt workarounds.
+Until the receipt store is built, do not add ad hoc receipt workarounds or treat DB outbox rows or
+ObjectStore inline provenance as the final durable receipt authority.
 
 ## Cross-references
 

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -242,11 +242,22 @@ Examples in the current runtime:
 - `panel.intent.created` = intent-creation layer
 - `promote.intent.created` = transition intent layer
 - `promote.done` / `promote.error` = execution-result layer
-- `promotion.transition.applied` = human-legible transition receipt layer for admitted promotion applies
+- `promotion.transition.applied` = transition-accountability event / interim receipt-supporting
+  record for admitted promotion applies
 
 The event stream is not, by itself, the complete receipt model.
 It is primarily an operational trace surface that may support later receipt or audit construction.
 It is also not identical to the metadata mirror.
+
+Promotion clarification (#1438):
+- `PROMOTE_DONE` records execution/result semantics: which note was updated, which resulting
+  `maturity` / `review_state` applied, and which source event drove execution.
+- `PROMOTION_TRANSITION_APPLIED` records the current transition-accountability semantics:
+  `note_uuid`, `note_path`, `transition_family`, `target_maturity`, `authority`, `basis`,
+  `outcome`, and `artifact_linkage`.
+- DB outbox events and ObjectStore inline provenance support accountability and audit, but they are
+  not the final durable promotion receipt store. Formal durable promotion receipts remain blocked on
+  a receipt-store/query model.
 
 ## References
 

--- a/tests/promotion/test_promotion_receipts.py
+++ b/tests/promotion/test_promotion_receipts.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from app.events.types import PROMOTE_ERROR, PROMOTE_INTENT_CREATED
+from app.events.types import PROMOTE_DONE, PROMOTE_ERROR, PROMOTE_INTENT_CREATED
 from app.promotion.consumer import consume_promotion_intents, reset_promotion_dedup_store
 
 
@@ -51,10 +51,64 @@ def test_applied_promotion_writes_transition_receipt(tmp_path: Path) -> None:
     assert payload["intent_event_id"] == "evt-applied"
     assert payload["trace_id"] == "trace-applied"
     assert payload["note_uuid"] == note_uuid
+    assert payload["note_path"] == str(note_path)
     assert payload["transition_family"] == "promotion"
     assert payload["target_maturity"] == "evergreen"
     assert payload["executor"] == "promotion.consumer"
     assert payload["effect"] == "applied"
+    assert payload["authority"] == {
+        "mode": "governed_execution",
+        "component": "panel_agent.runtime",
+        "executor": "promotion.consumer",
+    }
+    assert payload["basis"] == {
+        "source_event": "evt-applied",
+        "intent_type": "promotion",
+    }
+    assert payload["outcome"] == {
+        "status": "applied",
+        "review_state": "reviewed",
+        "maturity": "evergreen",
+    }
+    assert payload["artifact_linkage"] == {
+        "note_uuid": note_uuid,
+        "note_path": str(note_path),
+    }
+
+
+def test_promote_done_remains_execution_result_separate_from_transition_accountability(
+    tmp_path: Path,
+) -> None:
+    reset_promotion_dedup_store()
+    note_path = tmp_path / "vault" / "N.md"
+    note_uuid = "00000000-0000-0000-0000-000000000104"
+    _write_note(note_path, note_uuid)
+
+    outbox = tmp_path / "outbox.jsonl"
+    event = _intent_event(note_path, note_uuid, event_id="evt-result", trace_id="trace-result")
+    outbox.write_text(json.dumps(event, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    summary = consume_promotion_intents(outbox_path=outbox)
+    assert summary["applied"] == 1
+
+    records = _read_jsonl(outbox)
+    done_events = [r for r in records if r.get("event") == PROMOTE_DONE]
+    transition_events = [r for r in records if r.get("event") == "promotion.transition.applied"]
+    assert len(done_events) == 1
+    assert len(transition_events) == 1
+
+    done_payload = done_events[0]["payload"]
+    assert done_payload == {
+        "note_uuid": note_uuid,
+        "note_path": str(note_path),
+        "state": "evergreen",
+        "maturity": "evergreen",
+        "review_state": "reviewed",
+        "source_event": "evt-result",
+    }
+    assert "authority" not in done_payload
+    assert "basis" not in done_payload
+    assert "artifact_linkage" not in done_payload
 
 
 def test_replayed_promotion_intent_does_not_duplicate_receipt(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #1438

## Summary
Clarifies the current promotion accountability model without adding a receipt store: `PROMOTE_DONE` remains the execution/result event, while `PROMOTION_TRANSITION_APPLIED` is the transition-accountability event and interim receipt-supporting record.

Adds focused promotion tests proving the transition accountability payload is separate from the raw execution result and carries the required authority, basis, outcome, and artifact linkage fields.

## Acceptance Criteria Mapping
- Docs distinguish execution-result event, transition-accountability event, operational trace, audit material, and final receipt store: updated `docs/CONCEPTS/WORKFLOW_MUTATION_AND_GOVERNANCE_SEMANTICS.md`, `docs/EVENTS.md`, `docs/CONCEPTS/RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md`, and `docs/CONCEPTS/ONTOLOGY_VOCABULARY.md`.
- Focused test asserts `PROMOTION_TRANSITION_APPLIED` includes `note_uuid`, `note_path`, `transition_family`, `target_maturity`, `authority`, `basis`, `outcome`, and `artifact_linkage`: `tests/promotion/test_promotion_receipts.py`.
- Focused test asserts `PROMOTE_DONE` remains an execution/result payload separate from transition accountability fields.
- No `review_state` field rename, no frontmatter schema change, and no receipt table/store/model introduced.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/python -m pytest -q tests/promotion/test_promotion_receipts.py` - 4 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/python -m pytest -q tests/promotion tests/events/test_outbox_consumer_contract.py tests/services/test_note_update_promotion.py` - 29 passed
- `/Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/python -m ruff check app tests` - passed
- `python3 scripts/docs_guard.py` - passed
- `git diff --check` - passed

## Broad Check Note
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/python -m pytest -q tests -k "promotion"` reached 79 passed / 1 skipped / 4305 deselected, then failed in `tests/agents/pilot_agent/test_runtime.py::TestRuntimeFeatureFlag::test_feature_flag_promotion` because async tests require an asyncio plugin while plugin autoload is disabled. Classified as test environment/plugin setup, not a #1438 code failure.

## Issue Workflow Notes
- Dispatcher claim status was unavailable (`db_exists:false`), so this was claimed and tracked through GitHub issue labels/project state.