### PR TITLE
Add Companion UI Playwright runtime harness

### DIFF
--- a/.github/workflows/browser-runtime.yml
+++ b/.github/workflows/browser-runtime.yml
@@ -1,0 +1,43 @@
+name: Companion UI Browser Runtime
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: companion-ui-browser-runtime-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: read-all
+
+jobs:
+  companion-ui-browser-runtime:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true
+    env:
+      PYTHONPATH: ${{ github.workspace }}
+      PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
+      COMPANION_UI_BROWSER_TESTS: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install Python deps
+        run: |
+          python -m pip install -U pip
+          pip install -e ".[dev,browser]"
+
+      - name: Install Playwright Chromium
+        run: |
+          python -m playwright install --with-deps chromium
+
+      - name: Run Companion UI browser-runtime tests
+        run: |
+          pytest -q tests/companion_ui/test_mermaid_browser.py

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -13,6 +13,34 @@ Authority: Canonical testing and validation strategy for the active baseline, in
 - LLM eval (DeepEval/Ragas): opt-in `@pytest.mark.eval` tests for ASK/retrieval quality (see `docs/eval.md`).
 - Property-based ingest invariants: `tests/ingest/test_normalize_properties.py` ensures normalize outputs Core-6 fields robustly.
 
+## Companion UI Browser Runtime Tests
+
+Decision (#1435): Companion UI client-JS runtime behaviour uses Playwright, not Selenium or
+Preview-MCP-only UAT. Browser runtime tests are additive to the existing static
+`tests/companion_ui/*_browser.py` assertions.
+
+Use static Companion UI browser assertions when the contract is server-emitted HTML from
+`render_index_html`: stable selectors, text, data attributes, fallback DOM, and API wiring visible
+in the rendered string. These tests stay fast, run in normal pytest lanes, and do not require
+browser binaries.
+
+Use real browser runtime tests when the contract depends on actual client execution: dynamic
+`import()` loading, DOM mutation after module scripts run, event/click behaviour, async fetch
+handling, browser storage, or layout/runtime APIs. The current harness serves `render_index_html`
+output on `127.0.0.1` and drives Chromium headlessly through Playwright.
+
+Determinism rule: browser tests must not depend on live `esm.sh` or other network resources. The
+browser harness fulfills the pinned Mermaid and CodeMirror module URLs from repo-local ESM stubs and
+blocks unexpected external requests. These stubs prove Companion UI runtime wiring and graceful
+degradation; they are not a new product bundle authority.
+
+Execution:
+- Normal companion UI test runs skip browser-runtime tests unless explicitly enabled.
+- Local opt-in command:
+  `COMPANION_UI_BROWSER_TESTS=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_mermaid_browser.py`
+- CI runs the browser suite in `.github/workflows/browser-runtime.yml` as a separate non-blocking
+  job. The existing smoke gates must not install browser binaries or depend on this job.
+
 ## Layer mapping
 | Layer | Focus | Representative suites | Command |
 | --- | --- | --- | --- |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ dev = [
     "datasets>=2.21.0",
     "hypothesis>=6.108.0",
 ]
+browser = [
+    "playwright>=1.48,<2",
+]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/pytest.ini
+++ b/pytest.ini
@@ -13,5 +13,6 @@ markers =
     panel_llm_e2e: PanelAgent LangGraph LLM decider E2E tests (opt-in; require PANEL_AGENT_LLM_E2E=1 and real LLM)
     eval: LLM/retrieval eval tests (DeepEval/Ragas); opt-in
     e2e: end-to-end Reality-MVP flows over the memory backend
+    browser_runtime: Companion UI real-browser runtime tests; opt-in via COMPANION_UI_BROWSER_TESTS=1
     human_uat: human-need acceptance scenarios; opt-in and non-blocking unless promoted by baseline docs
     watcher_controls: watcher guardrails/backoff/stop-file regression tests

--- a/tests/companion_ui/browser_runtime_harness.py
+++ b/tests/companion_ui/browser_runtime_harness.py
@@ -1,0 +1,128 @@
+"""Thin Playwright harness helpers for Companion UI runtime tests."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from threading import Thread
+from typing import Iterator
+from urllib.parse import urlparse
+
+from companion_ui.workspace.serve_dev_page import render_index_html
+
+
+_VENDOR_DIR = Path(__file__).resolve().parent / "fixtures" / "browser_vendor"
+_ESM_STUBS = {
+    "https://esm.sh/mermaid@10.9.1": _VENDOR_DIR / "mermaid_10_9_1.mjs",
+    "https://esm.sh/codemirror@6.0.1": _VENDOR_DIR / "codemirror_6_0_1.mjs",
+    "https://esm.sh/@codemirror/lang-markdown@6.2.5": _VENDOR_DIR
+    / "codemirror_lang_markdown_6_2_5.mjs",
+    "https://esm.sh/@codemirror/theme-one-dark@6.1.2": _VENDOR_DIR
+    / "codemirror_theme_one_dark_6_1_2.mjs",
+}
+
+
+def companion_workspace_fields(*, body: str) -> dict:
+    """Return the minimal workspace payload consumed by render_index_html."""
+
+    return {
+        "title": "Mermaid Browser Runtime",
+        "note_path": "Notes/mermaid-browser-runtime.md",
+        "artifact_id": "art-browser-runtime-001",
+        "content_hash": "sha256-browser-runtime",
+        "body": body,
+        "guard_writeguard_status": "ok",
+        "guard_canvas_enabled": True,
+        "guard_degraded": False,
+        "guard_workspace_update_available": False,
+        "guard_update_flow_available": False,
+        "runtime_vault_provenance": "resolved",
+        "runtime_vault_name": "BrowserTestVault",
+        "runtime_vault_channel": "test",
+        "panel_state": "idle",
+        "panel_proposal_count": 0,
+        "canvas_session_state": "idle",
+        "canvas_session_persistence": "durable",
+        "panel_proposals": [],
+        "panel_message": "",
+        "find_candidates": [],
+        "reorient_sections": None,
+        "resurface_candidates": [],
+        "governance_receipts": [],
+        "suggestion_state": "idle",
+        "suggestion_composer_enabled": True,
+        "is_production_ui": False,
+        "dev_page_label": "dev/staging",
+        "workspace_loaded_at": None,
+    }
+
+
+@contextmanager
+def serve_rendered_workspace(body: str) -> Iterator[str]:
+    """Serve render_index_html output on localhost for a browser test."""
+
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="Notes/mermaid-browser-runtime.md",
+        fields=companion_workspace_fields(body=body),
+    ).encode("utf-8")
+
+    class _Handler(BaseHTTPRequestHandler):
+        def log_message(self, format: str, *args: object) -> None:
+            return
+
+        def do_GET(self) -> None:
+            parsed = urlparse(self.path)
+            if parsed.path != "/":
+                self.send_response(404)
+                self.end_headers()
+                return
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(html)))
+            self.end_headers()
+            self.wfile.write(html)
+
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}/"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+
+def install_offline_esm_routes(context: object) -> list[str]:
+    """Route browser module imports to repo-local stubs and record leaks."""
+
+    unexpected_external_requests: list[str] = []
+
+    def route_request(route: object) -> None:
+        request = route.request
+        url = request.url
+        parsed = urlparse(url)
+        cache_key = url.split("?", 1)[0]
+        if parsed.scheme == "http" and parsed.hostname == "127.0.0.1":
+            route.continue_()
+            return
+        if cache_key in _ESM_STUBS:
+            route.fulfill(
+                status=200,
+                content_type="text/javascript; charset=utf-8",
+                body=_ESM_STUBS[cache_key].read_text(encoding="utf-8"),
+            )
+            return
+        if parsed.scheme == "https" and parsed.hostname == "fonts.googleapis.com":
+            route.fulfill(status=200, content_type="text/css; charset=utf-8", body="")
+            return
+        if parsed.scheme == "https" and parsed.hostname == "fonts.gstatic.com":
+            route.fulfill(status=200, content_type="font/woff2", body=b"")
+            return
+        unexpected_external_requests.append(url)
+        route.abort()
+
+    context.route("**/*", route_request)
+    return unexpected_external_requests

--- a/tests/companion_ui/fixtures/browser_vendor/codemirror_6_0_1.mjs
+++ b/tests/companion_ui/fixtures/browser_vendor/codemirror_6_0_1.mjs
@@ -1,0 +1,35 @@
+export const basicSetup = [];
+
+function docFromText(text) {
+  return {
+    length: text.length,
+    toString() {
+      return text;
+    }
+  };
+}
+
+export class EditorView {
+  constructor(config) {
+    this.parent = config.parent || null;
+    this.state = {doc: docFromText(String(config.doc || ''))};
+    if (this.parent) {
+      var mount = document.createElement('div');
+      mount.setAttribute('data-testid', 'codemirror-stub');
+      mount.textContent = this.state.doc.toString();
+      this.parent.appendChild(mount);
+      this.mount = mount;
+    }
+  }
+
+  dispatch(update) {
+    if (update && update.changes && typeof update.changes.insert === 'string') {
+      this.state = {doc: docFromText(update.changes.insert)};
+      if (this.mount) {
+        this.mount.textContent = update.changes.insert;
+      }
+    }
+  }
+
+  requestMeasure() {}
+}

--- a/tests/companion_ui/fixtures/browser_vendor/codemirror_lang_markdown_6_2_5.mjs
+++ b/tests/companion_ui/fixtures/browser_vendor/codemirror_lang_markdown_6_2_5.mjs
@@ -1,0 +1,5 @@
+export const markdownLanguage = {};
+
+export function markdown(options) {
+  return {extension: 'markdown', options};
+}

--- a/tests/companion_ui/fixtures/browser_vendor/codemirror_theme_one_dark_6_1_2.mjs
+++ b/tests/companion_ui/fixtures/browser_vendor/codemirror_theme_one_dark_6_1_2.mjs
@@ -1,0 +1,1 @@
+export const oneDark = {extension: 'oneDark'};

--- a/tests/companion_ui/fixtures/browser_vendor/mermaid_10_9_1.mjs
+++ b/tests/companion_ui/fixtures/browser_vendor/mermaid_10_9_1.mjs
@@ -1,0 +1,26 @@
+var initialized = false;
+
+function renderSvg(id) {
+  return '<svg id="' + id + '" xmlns="http://www.w3.org/2000/svg" role="img" ' +
+    'data-testid="stub-mermaid-svg" viewBox="0 0 160 40">' +
+    '<title>Stub Mermaid diagram</title>' +
+    '<rect x="1" y="1" width="158" height="38" fill="none" stroke="currentColor"></rect>' +
+    '<text x="12" y="24">stub mermaid</text>' +
+    '</svg>';
+}
+
+export default {
+  initialize(options) {
+    initialized = true;
+    this.options = options;
+  },
+  async render(id, source) {
+    if (!initialized) {
+      throw new Error('mermaid stub used before initialize');
+    }
+    if (String(source).includes('BROKEN_CLIENT_RENDER')) {
+      throw new Error('stub mermaid render failure');
+    }
+    return {svg: renderSvg(id)};
+  }
+};

--- a/tests/companion_ui/test_mermaid_browser.py
+++ b/tests/companion_ui/test_mermaid_browser.py
@@ -1,0 +1,86 @@
+"""Real-browser Mermaid runtime coverage for the Companion UI workspace."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+if os.environ.get("COMPANION_UI_BROWSER_TESTS") != "1":
+    pytest.skip(
+        "Set COMPANION_UI_BROWSER_TESTS=1 to run Playwright browser-runtime tests.",
+        allow_module_level=True,
+    )
+
+from playwright.sync_api import sync_playwright
+
+from tests.companion_ui.browser_runtime_harness import (
+    install_offline_esm_routes,
+    serve_rendered_workspace,
+)
+
+
+pytestmark = pytest.mark.browser_runtime
+
+
+def test_valid_mermaid_renders_svg() -> None:
+    body = "\n".join(
+        [
+            "Runtime Mermaid fixture.",
+            "",
+            "```mermaid",
+            "graph TD",
+            "    A --> B",
+            "```",
+        ]
+    )
+
+    with serve_rendered_workspace(body) as url, sync_playwright() as playwright:
+        browser = playwright.chromium.launch()
+        try:
+            context = browser.new_context()
+            unexpected_external_requests = install_offline_esm_routes(context)
+            page = context.new_page()
+
+            page.goto(url, wait_until="domcontentloaded")
+            page.locator('[data-testid="vault-mermaid-rendered"] svg').wait_for()
+
+            block = page.locator('[data-testid="vault-mermaid-block"]').first
+            assert block.get_attribute("data-mermaid-state") == "rendered"
+            assert page.locator('[data-testid="stub-mermaid-svg"]').count() == 1
+            assert page.locator('[data-testid="failed-embed"][data-kind="mermaid"]').count() == 0
+            assert unexpected_external_requests == []
+        finally:
+            browser.close()
+
+
+def test_broken_mermaid_uses_failed_embed_partial() -> None:
+    body = "\n".join(
+        [
+            "Runtime Mermaid failure fixture.",
+            "",
+            "```mermaid",
+            "graph TD",
+            "    BROKEN_CLIENT_RENDER",
+            "```",
+        ]
+    )
+
+    with serve_rendered_workspace(body) as url, sync_playwright() as playwright:
+        browser = playwright.chromium.launch()
+        try:
+            context = browser.new_context()
+            unexpected_external_requests = install_offline_esm_routes(context)
+            page = context.new_page()
+
+            page.goto(url, wait_until="domcontentloaded")
+            page.locator('[data-testid="failed-embed"][data-kind="mermaid"]').wait_for()
+
+            failed = page.locator('[data-testid="failed-embed"][data-kind="mermaid"]').first
+            assert failed.get_attribute("data-mermaid-state") == "failed"
+            assert failed.get_attribute("data-diagnostic-code") == "mermaid_render_error"
+            assert page.locator('[data-testid="vault-mermaid-source"]').count() == 1
+            assert page.locator('[data-testid="vault-mermaid-rendered"] svg').count() == 0
+            assert unexpected_external_requests == []
+        finally:
+            browser.close()

--- a/tests/companion_ui/test_mermaid_runtime_injection.py
+++ b/tests/companion_ui/test_mermaid_runtime_injection.py
@@ -1,10 +1,10 @@
 """Mermaid client-runtime injection on the workspace dev page (#1344).
 
 Static/structural coverage for the placeholder + lazy runtime contract. The
-real-browser behaviour (valid source -> SVG; broken source -> failed-embed; the
-bundle network request only when a fence exists) is verified via the Claude
-Preview MCP UAT recorded on the issue; here we pin the server-emitted shape and
-the lazy-load guard so they cannot silently regress.
+real-browser behaviour (valid source -> SVG; broken source -> failed-embed) is
+covered by the opt-in Playwright suite in test_mermaid_browser.py; here we pin
+the server-emitted shape and the lazy-load guard so they cannot silently
+regress.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Fixes #1435

## Summary
Adds an opt-in Playwright browser-runtime harness for Companion UI client-JS behavior. The first real browser coverage serves `render_index_html` on localhost and proves Mermaid runtime behavior: valid Mermaid placeholders become inline SVG, and client-render failures degrade to the existing failed-embed partial.

The browser suite is separate from normal companion UI/static assertions, uses repo-local ESM stubs for the pinned Mermaid/CodeMirror imports, and runs in a non-blocking CI workflow so smoke does not depend on browser binaries.

## Acceptance Criteria Mapping
- AC1 decision recorded: `docs/TESTING.md` records Playwright over Selenium/status quo, repo-local ESM stubs instead of live `esm.sh`, and the non-blocking CI posture.
- AC2 runtime AC proven: `tests/companion_ui/test_mermaid_browser.py` covers valid Mermaid -> inline SVG and broken client render -> `[data-testid="failed-embed"][data-kind="mermaid"]`.
- AC3 deterministic/non-blocking CI: `.github/workflows/browser-runtime.yml` installs Playwright Chromium in a separate `continue-on-error` job; the test harness blocks unexpected external requests and fulfills Mermaid/CodeMirror imports from repo-local stubs.
- AC4 guidance documented: `docs/TESTING.md` explains when to use static `*_browser.py` assertions versus real browser runtime tests.
- Existing static tests are kept and `tests/companion_ui/test_mermaid_runtime_injection.py` now points runtime coverage at the Playwright test instead of Preview-MCP-only UAT.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/python -m pytest -q tests/companion_ui/test_mermaid_runtime_injection.py tests/companion_ui/test_mermaid_block_renderer.py tests/companion_ui/test_mermaid_browser.py` - 11 passed, 1 skipped
- `COMPANION_UI_BROWSER_TESTS=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/python -m pytest -q tests/companion_ui/test_mermaid_browser.py` - 2 passed
- `/Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/python -m ruff check app tests companion-ui/companion-app/companion_ui` - passed
- `python3 scripts/docs_guard.py` - passed
- `git diff --check` and `git diff --cached --check` - passed

## Broad Suite Note
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/python -m pytest -q tests/companion_ui` - 1237 passed, 1 skipped, 2 failed.
- The two failures predate this slice and were also observed before #1435 work:
  - `tests/companion_ui/test_real_note_workspace_dev_server.py::TestRenderIndexHtml::test_renders_runtime_safety_strip_and_identity_pills`
  - `tests/companion_ui/test_resurface_mode_browser.py::test_workspace_resurface_source_link_uses_logical_identifier`
- Follow-up bug filed: #1443.

## Issue Workflow Notes
- Dispatcher unavailable (`db_exists:false`) - used GitHub-label-only claim.
- Source-doc note: `docs/QUALITY.md` is referenced in the external task prompt but is absent in this checkout; this PR updates the live owner doc `docs/TESTING.md`.