### PR TITLE
feat(companion-ui): direct human note editor — edit your own notes, no Canvas/writeguard ceremony, native spellcheck

### DIFF
--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -413,6 +413,28 @@ def _find_workspace_note(vault_root: Path, safe_note_path: str) -> Path | None:
     return candidate if candidate.is_file() else None
 
 
+def _vault_contained_abs_path(vault_root: Path, safe_note_path: str) -> Path:
+    """Resolve a validated relative note path to an absolute path, asserting it
+    stays inside the vault root.
+
+    Defense-in-depth against path traversal and symlink escape on top of
+    ``_validate_workspace_note_path`` (and a sanitizer CodeQL recognizes for the
+    py/path-injection rule): the realpath of the target must be the vault root
+    itself or a descendant of it.
+    """
+    root_real = os.path.realpath(vault_root)
+    target_real = os.path.realpath(os.path.join(root_real, safe_note_path))
+    if target_real != root_real and not target_real.startswith(root_real + os.sep):
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "path_escape",
+                "message": "Resolved note path is outside the vault.",
+            },
+        )
+    return Path(target_real)
+
+
 def _vault_relative(path: Path, vault_root: Path) -> str | None:
     try:
         return path.relative_to(vault_root).as_posix()
@@ -1653,12 +1675,14 @@ def save_note_body(req: NoteSaveRequest) -> NoteSaveResponse:
 
     safe_note_path = _validate_workspace_markdown_note_path(req.note_path)
     vault_root = resolve_vault_root()
-    note_path = _find_workspace_note(vault_root, safe_note_path)
-    if note_path is None:
+    if _find_workspace_note(vault_root, safe_note_path) is None:
         raise HTTPException(
             status_code=404,
             detail={"error": "note_not_found", "message": "No note exists for the requested note_path"},
         )
+    # Defense-in-depth: resolve to an absolute path proven to be inside the vault
+    # before any filesystem read/write.
+    note_path = _vault_contained_abs_path(vault_root, safe_note_path)
 
     if _body_contains_frontmatter(req.new_body):
         raise HTTPException(

--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -1603,4 +1603,97 @@ def update_workspace_body(req: BodyUpdateRequest) -> BodyUpdateResponse:
     )
 
 
+class NoteSaveRequest(BaseModel):
+    note_path: str
+    new_body: str
+    # Optional optimistic-concurrency token: the content_hash the editor loaded
+    # with. When provided and stale, the save is refused so a concurrent change
+    # is not clobbered. Omit to force-save.
+    expected_content_hash: str | None = None
+
+
+class NoteSaveResponse(BaseModel):
+    status: str
+    note_path: str
+    content_hash: str
+
+
+@router.post("/note/save", response_model=NoteSaveResponse)
+def save_note_body(req: NoteSaveRequest) -> NoteSaveResponse:
+    """Human-initiated direct edit of the active note body.
+
+    This is a first-class human operation over the user's own vault. It is
+    intentionally **not** gated by ``CANVAS_ENABLED`` or
+    ``WORKSPACE_UPDATE_FLOW_ENABLED`` (those govern AI/Canvas-mediated writes,
+    not the human typing in their own note) and does not route through the
+    Canvas-session/active-note-body-update state machine.
+
+    The only retained guard is the runtime-health write block — pure data-safety
+    that refuses writes while the runtime is in a broken/degraded state — which
+    never trips in normal operation. Frontmatter is preserved verbatim; the body
+    must not carry its own frontmatter block.
+    """
+    try:
+        DEFAULT_WRITE_GUARD.assert_writes_allowed("companion.note.human_edit")
+    except WritesBlockedError as exc:
+        # 409: transient runtime-health state, not a permission denial.
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": "runtime_write_blocked",
+                "message": str(exc),
+                "state": exc.state,
+            },
+        ) from exc
+    except Exception:
+        # The health snapshot could not even be evaluated (e.g. a minimally
+        # configured vault). The human-edit path fails open — this courtesy
+        # data-safety net must never block the user from editing their own note.
+        pass
+
+    safe_note_path = _validate_workspace_markdown_note_path(req.note_path)
+    vault_root = resolve_vault_root()
+    note_path = _find_workspace_note(vault_root, safe_note_path)
+    if note_path is None:
+        raise HTTPException(
+            status_code=404,
+            detail={"error": "note_not_found", "message": "No note exists for the requested note_path"},
+        )
+
+    if _body_contains_frontmatter(req.new_body):
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "frontmatter_in_body",
+                "message": "new_body must not contain a frontmatter block; frontmatter is preserved automatically",
+            },
+        )
+
+    current = note_path.read_text(encoding="utf-8")
+    if req.expected_content_hash and _content_hash(current) != req.expected_content_hash:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": "content_hash_mismatch",
+                "message": "The note changed since you opened it. Reload to pick up the latest, then re-apply your edit.",
+                "content_hash": _content_hash(current),
+            },
+        )
+
+    frontmatter_inner, _ = _split_frontmatter(current)
+    if frontmatter_inner is not None:
+        new_content = f"---{frontmatter_inner}\n---\n{req.new_body}"
+    else:
+        new_content = req.new_body if req.new_body.endswith("\n") else req.new_body + "\n"
+
+    write_note_from_absolute(note_path, new_content, vault_root=vault_root)
+
+    written = note_path.read_text(encoding="utf-8")
+    return NoteSaveResponse(
+        status="ok",
+        note_path=safe_note_path,
+        content_hash=_content_hash(written),
+    )
+
+
 __all__ = ["router"]

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -641,19 +641,12 @@ def _render_note_not_found(note_path: str) -> str:
 
 def _render_body_edit_panel(update_flow_available: bool, note_path: str, raw_body: str = "") -> str:
     if not update_flow_available:
-        return (
-            '<section class="body-edit-panel body-edit-disabled workspace-action-absent" '
-            'data-testid="workspace-action-absent" '
-            'data-action="body-edit" '
-            'data-reason="update_flow_disabled" '
-            'data-update-flow="disabled">'
-            '<span class="absent-label" data-testid="workspace-body-edit-panel">'
-            "&#9998; Read only</span>"
-            '<span class="absent-reason">'
-            "This note is open for reading. Editing is not enabled in this workspace."
-            "</span>"
-            "</section>"
-        )
+        # Direct human editing is always available via the note's own Read/Edit
+        # editor (independent of the Canvas/update flow), so the old "Editing is
+        # not enabled in this workspace" absence card is no longer shown — it
+        # contradicted the always-available editor and read as unsolicited
+        # read-only nagging. The Canvas-mediated composer below is dev-only.
+        return ""
     # #1416 — render the dev composer as an opt-in disclosure that is collapsed
     # by default. In the fixed-height shell (#1397) a sibling that grows with its
     # content squeezes the note reading surface; a collapsed <details> contributes
@@ -846,6 +839,86 @@ def _mermaid_runtime_script() -> str:
   </script>"""
 
 
+def _note_editor_script() -> str:
+    """Direct human note editor: Read <-> Edit toggle over a plain textarea.
+
+    Edit mode swaps the rendered body for the raw source in a native
+    ``<textarea spellcheck>`` (OS-grade spellcheck — far better than any JS
+    editor and impossible inside CodeMirror). Save POSTs to the same-origin
+    ``/api/companion/note/save`` proxy (frontmatter preserved server-side, no
+    Canvas/writeguard ceremony) and reloads to pick up the re-rendered note.
+    Returned as a plain string so JS braces are not double-escaped by the page
+    template.
+    """
+    return """
+  <script>
+  (function () {
+    function el(sel) { return document.querySelector(sel); }
+    function setStatus(cls, text) {
+      var s = el('.note-edit-status');
+      if (s) { s.className = 'note-edit-status' + (cls ? ' ' + cls : ''); s.textContent = text || ''; }
+    }
+    window.noteEditor = {
+      start: function () {
+        var ta = document.getElementById('note-source-editor');
+        if (!ta) { return; }
+        var content = el('.note-body-content');
+        var actions = el('[data-testid="workspace-note-edit-actions"]');
+        var toggle = el('.note-edit-toggle');
+        if (content) { content.hidden = true; }
+        ta.hidden = false;
+        if (actions) { actions.hidden = false; }
+        if (toggle) { toggle.hidden = true; }
+        setStatus('', '');
+        ta.focus();
+      },
+      cancel: function () {
+        var ta = document.getElementById('note-source-editor');
+        var content = el('.note-body-content');
+        var actions = el('[data-testid="workspace-note-edit-actions"]');
+        var toggle = el('.note-edit-toggle');
+        if (ta) { ta.hidden = true; ta.value = ta.defaultValue; }
+        if (content) { content.hidden = false; }
+        if (actions) { actions.hidden = true; }
+        if (toggle) { toggle.hidden = false; }
+        setStatus('', '');
+      },
+      save: function () {
+        var ta = document.getElementById('note-source-editor');
+        if (!ta) { return; }
+        setStatus('', 'Saving\\u2026');
+        fetch('/api/companion/note/save', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            note_path: ta.getAttribute('data-note-path'),
+            new_body: ta.value,
+            expected_content_hash: ta.getAttribute('data-content-hash') || null
+          })
+        }).then(function (r) {
+          return r.json().then(function (d) { return { ok: r.ok, status: r.status, data: d }; });
+        }).then(function (res) {
+          if (res.ok) {
+            setStatus('ok', 'Saved. Reloading\\u2026');
+            window.location.reload();
+            return;
+          }
+          var d = res.data || {};
+          var msg = (d.message || (d.detail && d.detail.message) || ('HTTP ' + res.status));
+          if (res.status === 409) {
+            setStatus('error', 'Could not save \\u2014 the note changed elsewhere or the runtime is busy. Reload and re-apply.');
+          } else {
+            setStatus('error', 'Save failed: ' + msg);
+          }
+        }).catch(function (e) {
+          setStatus('error', 'Network error: ' + (e && e.message ? e.message : e));
+        });
+      }
+    };
+  })();
+  </script>"""
+
+
 def _coerce_vault_link_index(value: object) -> dict[str, list[str]]:
     """Normalize an optional active-vault link index for the link resolver.
 
@@ -911,6 +984,9 @@ def _render_note_section(fields: dict) -> str:
         raw_body, note_path=raw_note_path, link_resolver=link_resolver
     )
     body = rendered_body.html
+    # Frontmatter-stripped source for the direct human editor (the save endpoint
+    # preserves frontmatter and rejects a frontmatter block in the body).
+    editor_body = str(getattr(rendered_body.document, "body_markdown", "") or "")
     outline_html = render_note_outline(rendered_body.document)
     has_headings = bool(tuple(rendered_body.document.headings))
     hidden_frontmatter_html, rendered_props = _render_note_frontmatter_region(rendered_body.document)
@@ -1297,7 +1373,29 @@ def _render_note_section(fields: dict) -> str:
               data-testid="workspace-note-body-readonly-why">Why?</a>
           </div>
           {read_only_pill_html}
-          <div class="note-body-content">{body}</div>
+          <div class="note-edit-bar" data-testid="workspace-note-edit-bar">
+            <button type="button" class="note-edit-toggle"
+              data-testid="workspace-note-edit-toggle"
+              onclick="noteEditor.start()">&#9998;&#160;Edit</button>
+            <div class="note-edit-actions" data-testid="workspace-note-edit-actions" hidden>
+              <button type="button" class="note-edit-save"
+                data-testid="workspace-note-edit-save"
+                onclick="noteEditor.save()">Save</button>
+              <button type="button" class="note-edit-cancel"
+                data-testid="workspace-note-edit-cancel"
+                onclick="noteEditor.cancel()">Cancel</button>
+              <span class="note-edit-status" data-testid="workspace-note-edit-status"
+                aria-live="polite"></span>
+            </div>
+          </div>
+          <div class="note-body-content" data-testid="workspace-note-rendered">{body}</div>
+          <textarea class="note-source-editor" id="note-source-editor"
+            data-testid="workspace-note-source-editor"
+            spellcheck="true" autocapitalize="sentences" autocorrect="on"
+            autocomplete="off" wrap="soft"
+            aria-label="Edit note source"
+            data-note-path="{note_path_val}" data-content-hash="{content_hash}"
+            hidden>{_e(editor_body)}</textarea>
           {suggested_insertions_html}
         </div>
       </div>
@@ -4098,6 +4196,55 @@ def render_index_html(
       overflow-y: auto;
       padding: 24px 24px 96px;
     }}
+    /* ---- Direct human note editor (Read <-> Edit) ---- */
+    .note-edit-bar {{
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      max-width: 68ch;
+      margin: 0 auto 8px;
+      padding: 0 32px;
+    }}
+    .note-edit-toggle, .note-edit-save, .note-edit-cancel {{
+      background: var(--bg-raised);
+      border: 1px solid var(--border-strong);
+      border-radius: var(--radius-md);
+      color: var(--fg-1);
+      cursor: pointer;
+      font-family: var(--font-ui);
+      font-size: var(--text-sm);
+      padding: 4px 12px;
+    }}
+    .note-edit-toggle:hover, .note-edit-save:hover, .note-edit-cancel:hover {{
+      border-color: var(--accent);
+    }}
+    .note-edit-save {{
+      background: color-mix(in srgb, var(--accent) 18%, var(--bg-raised));
+      font-weight: 600;
+    }}
+    .note-edit-actions {{ display: flex; align-items: center; gap: 8px; }}
+    .note-edit-status {{ color: var(--fg-3); font-family: var(--font-mono); font-size: var(--text-xs); }}
+    .note-edit-status.ok {{ color: var(--cyan); }}
+    .note-edit-status.error {{ color: var(--destructive); }}
+    .note-source-editor {{
+      background: var(--bg-base);
+      border: 1px solid var(--border-strong);
+      border-radius: var(--radius-md);
+      box-sizing: border-box;
+      color: var(--fg-1);
+      display: block;
+      font-family: var(--font-mono);
+      font-size: var(--text-sm);
+      line-height: 1.6;
+      margin: 0 auto;
+      max-width: 68ch;
+      min-height: 60vh;
+      padding: 24px 32px;
+      resize: vertical;
+      width: 100%;
+    }}
+    .note-source-editor[hidden] {{ display: none; }}
+    .note-source-editor:focus {{ outline: 1px solid var(--border-focus); }}
     /* Design review §6.1 — body column is a reading surface, not a card.
        Background matches the page; no inset border; line-length capped at 68ch.
        §3.3/§7 — the reading column does not own a second nested scroll and is
@@ -6008,6 +6155,7 @@ def render_index_html(
   }}
   </script>
   {_mermaid_runtime_script()}
+  {_note_editor_script()}
 </body>
 </html>"""
 
@@ -6132,9 +6280,18 @@ def make_handler(
             self.end_headers()
             self.wfile.write(body)
 
+        # POST paths the page server proxies through to the runtime API
+        # (same-origin model; the browser never talks to the runtime directly).
+        _POST_PROXY_PATHS = frozenset(
+            {
+                "/api/companion/workspace/body",
+                "/api/companion/note/save",  # direct human note edit
+            }
+        )
+
         def do_POST(self) -> None:
             parsed = urlparse(self.path)
-            if parsed.path != "/api/companion/workspace/body":
+            if parsed.path not in self._POST_PROXY_PATHS:
                 self._send_json(404, {"error": "not_found", "message": "Unknown Companion UI route"})
                 return
             try:
@@ -6148,7 +6305,7 @@ def make_handler(
                 self._send_json(400, {"error": "invalid_json", "message": "Request body must be JSON"})
                 return
             try:
-                data = self._client.post("/api/companion/workspace/body", json=payload)
+                data = self._client.post(parsed.path, json=payload)
             except WorkspaceClientError as exc:
                 self._proxy_error(exc)
                 return

--- a/tests/api/test_companion_note_save_api.py
+++ b/tests/api/test_companion_note_save_api.py
@@ -1,0 +1,112 @@
+"""Direct human note-save API contract tests.
+
+`POST /api/companion/note/save` is the human-initiated direct edit path. Unlike
+the Canvas-mediated update flow, it is **not** gated by ``CANVAS_ENABLED`` or
+``WORKSPACE_UPDATE_FLOW_ENABLED`` — a human editing their own vault note should
+not require agent-governance ceremony. Frontmatter is preserved; the only
+retained guard is the runtime-health write block (fail-open when health cannot
+be evaluated).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from app.api.app import app
+
+
+def _write_note(path: Path, *, frontmatter: str, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"---\n{frontmatter}\n---\n{body}", encoding="utf-8")
+
+
+def _clear_gates(monkeypatch) -> None:
+    # Prove the save works with NONE of the agent-ceremony gates set.
+    monkeypatch.delenv("CANVAS_ENABLED", raising=False)
+    monkeypatch.delenv("WORKSPACE_UPDATE_FLOW_ENABLED", raising=False)
+
+
+def test_human_save_round_trip_without_canvas_or_flow_env(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+    _clear_gates(monkeypatch)
+    note = tmp_path / "notes" / "My Note.md"
+    _write_note(note, frontmatter="title: My Note\nuuid: abc-123", body="Original body.\n")
+
+    client = TestClient(app)
+    resp = client.post(
+        "/api/companion/note/save",
+        json={"note_path": "notes/My Note.md", "new_body": "# Rewritten\n\nNew text by the human.\n"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "ok"
+    written = note.read_text(encoding="utf-8")
+    # Frontmatter preserved verbatim; body replaced.
+    assert written.startswith("---\ntitle: My Note\nuuid: abc-123\n---")
+    assert "New text by the human." in written
+    assert "Original body." not in written
+
+
+def test_frontmatter_in_body_rejected(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+    _clear_gates(monkeypatch)
+    _write_note(tmp_path / "n.md", frontmatter="title: N", body="b\n")
+
+    client = TestClient(app)
+    resp = client.post(
+        "/api/companion/note/save",
+        json={"note_path": "n.md", "new_body": "---\ntitle: hijack\n---\nbad\n"},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["error"] == "frontmatter_in_body"
+
+
+def test_stale_content_hash_conflicts(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+    _clear_gates(monkeypatch)
+    _write_note(tmp_path / "n.md", frontmatter="title: N", body="b\n")
+
+    client = TestClient(app)
+    resp = client.post(
+        "/api/companion/note/save",
+        json={"note_path": "n.md", "new_body": "x\n", "expected_content_hash": "stale"},
+    )
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["error"] == "content_hash_mismatch"
+
+
+def test_matching_content_hash_saves(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+    _clear_gates(monkeypatch)
+    note = tmp_path / "n.md"
+    _write_note(note, frontmatter="title: N", body="b\n")
+
+    client = TestClient(app)
+    # First save returns the current hash; reuse it as the expected token.
+    first = client.post("/api/companion/note/save", json={"note_path": "n.md", "new_body": "v1\n"})
+    h = first.json()["content_hash"]
+    second = client.post(
+        "/api/companion/note/save",
+        json={"note_path": "n.md", "new_body": "v2\n", "expected_content_hash": h},
+    )
+    assert second.status_code == 200
+    assert "v2" in note.read_text(encoding="utf-8")
+
+
+def test_missing_note_is_404(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+    _clear_gates(monkeypatch)
+
+    client = TestClient(app)
+    resp = client.post(
+        "/api/companion/note/save",
+        json={"note_path": "nope/missing.md", "new_body": "x\n"},
+    )
+    assert resp.status_code == 404

--- a/tests/companion_ui/test_direct_note_editor.py
+++ b/tests/companion_ui/test_direct_note_editor.py
@@ -1,0 +1,111 @@
+"""Direct human note editor UI (Read <-> Edit, native spellcheck).
+
+The note carries an always-available plain-textarea editor, independent of the
+Canvas/update flow. Edit mode swaps the rendered body for the raw (frontmatter-
+stripped) source in a ``<textarea spellcheck>`` (OS-grade spellcheck), and Save
+POSTs to the same-origin ``/api/companion/note/save`` proxy.
+"""
+
+from __future__ import annotations
+
+from companion_ui.workspace.serve_dev_page import render_index_html
+
+
+def _fields(*, body: str, canvas_enabled: bool, content_hash: str = "hash-1") -> dict:
+    return {
+        "title": "Editor Note",
+        "note_path": "notes/editor.md",
+        "artifact_id": "art-ed-1",
+        "content_hash": content_hash,
+        "body": body,
+        "guard_writeguard_status": "ok",
+        "guard_canvas_enabled": canvas_enabled,
+        "guard_degraded": not canvas_enabled,
+        "guard_workspace_update_available": canvas_enabled,
+        "guard_update_flow_available": canvas_enabled,
+        "runtime_vault_provenance": "resolved",
+        "runtime_vault_name": "V",
+        "runtime_vault_channel": "dev",
+        "panel_state": "idle",
+        "panel_proposal_count": 0,
+        "canvas_session_state": "idle",
+        "canvas_session_persistence": "durable",
+        "panel_proposals": [],
+        "panel_message": "",
+        "find_candidates": [],
+        "reorient_sections": None,
+        "resurface_candidates": [],
+        "governance_receipts": [],
+        "suggestion_state": "idle",
+        "suggestion_composer_enabled": True,
+        "is_production_ui": False,
+        "dev_page_label": "dev",
+        "workspace_loaded_at": None,
+    }
+
+
+def _render(*, body: str = "---\ntitle: T\nuuid: u\n---\n# Head\n\nBody text.\n", canvas_enabled: bool = False, **kw) -> str:
+    return render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="notes/editor.md",
+        fields=_fields(body=body, canvas_enabled=canvas_enabled, **kw),
+    )
+
+
+def test_editor_present_when_canvas_disabled() -> None:
+    # The whole point: editing works even with Canvas off (no ceremony).
+    html = _render(canvas_enabled=False)
+    assert 'data-testid="workspace-note-source-editor"' in html
+    assert 'data-testid="workspace-note-edit-toggle"' in html
+    assert 'data-testid="workspace-note-edit-save"' in html
+    assert 'data-testid="workspace-note-edit-cancel"' in html
+
+
+def test_editor_present_when_canvas_enabled() -> None:
+    html = _render(canvas_enabled=True)
+    assert 'data-testid="workspace-note-source-editor"' in html
+
+
+def test_editor_has_native_spellcheck() -> None:
+    html = _render()
+    # Native browser/OS spellcheck — the state-of-the-art path (impossible in CM).
+    assert 'spellcheck="true"' in html
+    assert 'autocapitalize="sentences"' in html
+    assert 'autocorrect="on"' in html
+
+
+def test_editor_carries_frontmatter_stripped_source_and_hash() -> None:
+    html = _render(
+        body="---\ntitle: T\nuuid: secret-uuid\n---\n# Head\n\nBody text.\n",
+        content_hash="hash-xyz",
+    )
+    editor = html.split('data-testid="workspace-note-source-editor"', 1)[1].split("</textarea>", 1)[0]
+    # The editor shows the body, never the frontmatter (save preserves it).
+    assert "# Head" in editor
+    assert "Body text." in editor
+    assert "secret-uuid" not in editor
+    assert "title: T" not in editor
+    # Optimistic-concurrency token + target path for the save call.
+    assert 'data-content-hash="hash-xyz"' in editor
+    assert 'data-note-path="notes/editor.md"' in editor
+
+
+def test_editor_js_saves_to_note_save_endpoint() -> None:
+    html = _render()
+    assert "window.noteEditor" in html
+    assert "/api/companion/note/save" in html
+
+
+def test_no_edit_disabled_nag() -> None:
+    html = _render(canvas_enabled=False)
+    assert "Editing is not enabled in this workspace" not in html
+
+
+def test_page_server_proxies_note_save() -> None:
+    # The page server must proxy the human-save path to the runtime (same-origin).
+    from companion_ui.workspace import serve_dev_page as mod
+
+    source = (mod.__file__)
+    text = open(source, encoding="utf-8").read()
+    assert '"/api/companion/note/save"' in text
+    assert "_POST_PROXY_PATHS" in text

--- a/tests/companion_ui/test_real_note_workspace_dev_server.py
+++ b/tests/companion_ui/test_real_note_workspace_dev_server.py
@@ -749,10 +749,15 @@ class TestUpdateFlowStateRendering:
     def test_update_flow_item_present(self) -> None:
         assert 'data-testid="workspace-update-flow-state"' in self._html()
 
-    def test_update_flow_shows_disabled_by_default(self) -> None:
+    def test_update_flow_disabled_still_allows_direct_editing(self) -> None:
+        # When the Canvas-mediated update flow is off, the old "Editing is not
+        # enabled in this workspace" absence card is no longer shown — direct
+        # human editing is always available via the note's own Read/Edit editor.
         html = self._html(update_flow_available=False)
-        assert 'data-update-flow="disabled"' in html
-        assert ">disabled<" in html
+        assert 'data-update-flow="disabled"' not in html
+        assert "Editing is not enabled in this workspace" not in html
+        assert 'data-testid="workspace-note-source-editor"' in html
+        assert 'data-testid="workspace-note-edit-toggle"' in html
 
     def test_update_flow_shows_available_when_true(self) -> None:
         html = self._html(update_flow_available=True)
@@ -873,10 +878,12 @@ class TestBodyEditPanelRendering:
         assert 'data-testid="workspace-body-edit-panel"' in html
         assert 'data-update-flow="available"' in html
 
-    def test_edit_panel_disabled_state_when_flow_off(self) -> None:
+    def test_no_canvas_composer_nag_when_flow_off(self) -> None:
+        # The Canvas-mediated composer's "edit disabled" absence card is gone;
+        # direct editing is available instead (see TestUpdateFlowStateRendering).
         html = self._html(update_flow_available=False)
-        assert 'data-testid="workspace-body-edit-panel"' in html
-        assert 'data-update-flow="disabled"' in html
+        assert 'data-update-flow="disabled"' not in html
+        assert 'data-testid="workspace-note-source-editor"' in html
 
     def test_textarea_present_when_flow_available(self) -> None:
         html = self._html(update_flow_available=True)
@@ -926,9 +933,12 @@ class TestBodyEditPanelRendering:
 
     def test_body_editor_reads_from_cmview_not_textarea_value(self) -> None:
         html = self._html(update_flow_available=True)
+        # The Canvas CodeMirror composer reads from the live _cmView, not a
+        # textarea. (The separate direct human editor legitimately reads its own
+        # plain <textarea>.value — that is the noteEditor, not bodyEditor.)
         assert "window._cmView" in html
         assert "window._cmView.state.doc.toString()" in html
-        assert "ta.value" not in html
+        assert "var newBody = window._cmView.state.doc.toString();" in html
 
     def test_submit_guards_against_uninitialized_editor(self) -> None:
         html = self._html(update_flow_available=True)

--- a/tests/companion_ui/test_workspace_properties_disclosure.py
+++ b/tests/companion_ui/test_workspace_properties_disclosure.py
@@ -163,6 +163,14 @@ class TestNoFactRestatement:
         # Strip style/script
         stripped = _re.sub(r"<style[^>]*>.*?</style[^>]*>", "", html_outside_details, flags=_re.DOTALL | _re.IGNORECASE)
         stripped = _re.sub(r"<script[^>]*>.*?</script[^>]*>", "", stripped, flags=_re.DOTALL | _re.IGNORECASE)
+        # Strip the direct editor's textarea: its data-content-hash is a machine
+        # optimistic-concurrency token, not human-visible fact restatement.
+        stripped = _re.sub(
+            r'<textarea[^>]*data-testid="workspace-note-source-editor".*?</textarea>',
+            "",
+            stripped,
+            flags=_re.DOTALL,
+        )
         # These unique values should NOT appear outside the disclosure
         assert "art-unique-xzy" not in stripped, "artifact_id leaked outside disclosure"
         assert "sha256-unique-abc" not in stripped, "content_hash leaked outside disclosure"

--- a/tests/companion_ui/test_workspace_shell_alignment.py
+++ b/tests/companion_ui/test_workspace_shell_alignment.py
@@ -392,21 +392,23 @@ class TestDistinctPostureTones:
 
 
 class TestAbsenceForUnavailableActions:
-    def test_body_edit_absence_card_when_update_flow_disabled(self) -> None:
+    def test_direct_editor_available_when_canvas_update_flow_disabled(self) -> None:
+        # The Canvas-mediated body-edit composer is gated by the update flow, but
+        # direct human editing is always available — so there is no "Editing is
+        # not enabled in this workspace" absence card / nag anymore.
         html = _html(guard_update_flow_available=False)
-        assert 'data-testid="workspace-action-absent"' in html
-        assert 'data-action="body-edit"' in html
+        assert "Editing is not enabled in this workspace" not in html
+        assert 'data-testid="workspace-note-source-editor"' in html
+        assert 'data-testid="workspace-note-edit-toggle"' in html
 
-    def test_body_edit_absence_carries_reason(self) -> None:
+    def test_no_canvas_body_edit_absence_nag(self) -> None:
         html = _html(guard_update_flow_available=False)
-        m = re.search(
-            r'data-testid="workspace-action-absent"[^>]*data-action="body-edit".*?</section>',
+        # The old body-edit absence card (workspace-action-absent / body-edit) is
+        # removed; it contradicted the always-available direct editor.
+        assert not re.search(
+            r'data-testid="workspace-action-absent"[^>]*data-action="body-edit"',
             html,
-            re.DOTALL,
         )
-        assert m
-        # absence card must say why
-        assert "unavailable" in m.group().lower() or "disabled" in m.group().lower()
 
     def test_no_actionable_submit_button_when_update_flow_disabled(self) -> None:
         html = _html(guard_update_flow_available=False)


### PR DESCRIPTION
Fixes #1446

## Why

Editing a note in the Companion UI was impossible without agent-invented ceremony: `CANVAS_ENABLED` to even *render* an editor, `WORKSPACE_UPDATE_FLOW_ENABLED` on the endpoint, and a Canvas-session / `active_note_body_update` state machine — plus an unsolicited "Editing is not enabled in this workspace" read-only nag. The owner never asked for that gating; it made the UI unusable for plain editing. This adds a **first-class direct editor for the human**: open a note, type, save, with state-of-the-art spellcheck.

## What

**Backend — `POST /api/companion/note/save`** (`app/api/routes/companion.py`)
- Writes the note body straight to the vault: frontmatter preserved, path-validated, optional `expected_content_hash` optimistic concurrency.
- **Not gated** by `CANVAS_ENABLED` or `WORKSPACE_UPDATE_FLOW_ENABLED` — a human editing their own vault doesn't route through agent governance.
- Keeps only the runtime-health write guard, and it **fails open** when health can't be evaluated (courtesy data-safety, never a permission gate). The owner said writeguard is "reasonable in some context" — this keeps it for the genuine broken-runtime case only.
- The page server proxies the save same-origin (`_POST_PROXY_PATHS`), so the browser never talks to the runtime directly.

**UI — always-available Read ⇄ Edit** (`serve_dev_page.py`)
- Every note shows an `✎ Edit` toggle, independent of Canvas. Edit mode swaps the rendered body for the raw **frontmatter-stripped** source in a plain `<textarea spellcheck="true" autocapitalize autocorrect>`.
- **Native OS-grade spellcheck** — the state of the art for in-browser editing, and impossible inside CodeMirror (it disables native spellcheck). Aligns with the owner's "ok to turn off MD render": read = rendered, edit = source, both kept.
- Save → proxy → reload (re-renders). The contradictory "Editing is not enabled" absence card is removed; the Canvas-mediated dev composer still renders when its flow is enabled.

## Scope / out of scope
- **In:** direct human edit path, native spellcheck, removal of the edit-disabled nag, tests.
- **Out (tracked follow-up):** calming the small "Canvas off" read-only pill (left as-is here to avoid touching the read-only-pill / daily-use contracts in the same change); the Canvas/AI-mediated edit flow is untouched.

## Owner-directed governance note
This intentionally **reverses agent-imposed gating** on *human* editing. The autonomous-agent write paths (writeguard, Canvas, Panel proposals) are unchanged — only the human's direct edit of their own note is decoupled. This is the owner's explicit, repeated direction.

## Tests
```
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest -q \
  tests/companion_ui tests/api/test_companion_note_save_api.py \
  tests/api/test_companion_vault_browser_api.py tests/api/test_companion_vault_related_api.py \
  tests/api/test_vault_link_index_endpoint.py
# 1263 passed, 2 failed (both documented pre-existing baseline failures, unrelated)
ruff check app tests   # All checks passed!
mypy app               # Success: no issues found in 455 source files
git diff --check       # clean
```
New: `tests/api/test_companion_note_save_api.py` (round-trip with no canvas/flow env, frontmatter preserved, content-hash conflict, frontmatter-in-body 400, 404); `tests/companion_ui/test_direct_note_editor.py` (editor present canvas on/off, native spellcheck attrs, frontmatter-stripped source + hash, save endpoint, no nag, proxy allowlist). Updated the dev-server/shell/properties tests that encoded the old gated behavior.

## UAT evidence (Claude Preview MCP, Canvas off, 1280×800)
DOM-verified: `✎ Edit` toggle visible, **no "Editing is not enabled" nag**; clicking Edit reveals the `spellcheck="true"` textarea (source starts at `# Editor UAT`, frontmatter `uuid` stripped), Save/Cancel appear, rendered body hides. Backend round-trip verified via API tests (save with zero canvas/flow env → file written, frontmatter intact).

## Rebase note
Rebased onto current `main`, which gained the receipt / find_related / receipt-detail work (#1279/#1282/#1284) while this was in progress; both coexist green (no overlap — they touched the models/endpoints region, this touches the note-body editor + a new endpoint).

## Deploy note
After deploy, **no `CANVAS_ENABLED` needed** — the editor works regardless. That's the point.

## Rollback
Revert this commit; editing returns to the Canvas-gated composer. No migration impact.