### PR TITLE
fix(companion-ui): body-edit Save — human error copy, URL-fragment strip, calm read-only (#1447)

### DIFF
--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -377,6 +377,10 @@ def list_vault_notes(
 
 
 def _validate_workspace_note_path(note_path_raw: str) -> str:
+    # Strip any URL fragment / section anchor — the canonical note identity never
+    # includes a "#section" suffix; a leaked anchor must not turn a valid edit
+    # into a confusing 404 (#1447). Obsidian note filenames cannot contain '#'.
+    note_path_raw = (note_path_raw or "").split("#", 1)[0]
     candidate = PurePosixPath(note_path_raw)
     if (
         not note_path_raw

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -886,12 +886,15 @@ def _note_editor_script() -> str:
       save: function () {
         var ta = document.getElementById('note-source-editor');
         if (!ta) { return; }
+        // Strip any URL fragment/anchor from the note identity — the canonical
+        // note path never includes a #section-anchor (#1447).
+        var notePath = (ta.getAttribute('data-note-path') || '').split('#')[0];
         setStatus('', 'Saving\\u2026');
         fetch('/api/companion/note/save', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            note_path: ta.getAttribute('data-note-path'),
+            note_path: notePath,
             new_body: ta.value,
             expected_content_hash: ta.getAttribute('data-content-hash') || null
           })
@@ -904,14 +907,33 @@ def _note_editor_script() -> str:
             return;
           }
           var d = res.data || {};
-          var msg = (d.message || (d.detail && d.detail.message) || ('HTTP ' + res.status));
-          if (res.status === 409) {
-            setStatus('error', 'Could not save \\u2014 the note changed elsewhere or the runtime is busy. Reload and re-apply.');
+          var detail = d.detail || d;
+          var err = detail.error || d.error || '';
+          var rawMsg = detail.message || d.message || '';
+          // Keep the raw machine detail inspectable (console + hover) without
+          // showing raw JSON to the human (#1447).
+          try { console.error('note save failed', res.status, d); } catch (e) {}
+          var human;
+          if (res.status === 404 && /not\\s*found/i.test(rawMsg) && err !== 'note_not_found') {
+            human = 'Saving is not available on this runtime yet \\u2014 it needs the latest build (restart the runtime API).';
+          } else if (err === 'note_not_found' || res.status === 404) {
+            human = 'Note not found for: ' + notePath + '. Reload the note and try again.';
+          } else if (err === 'content_hash_mismatch') {
+            human = 'This note changed elsewhere since you opened it. Reload and re-apply your edit.';
+          } else if (err === 'runtime_write_blocked') {
+            human = 'The runtime has writes blocked right now (degraded state). Try again shortly.';
+          } else if (err === 'path_escape' || err === 'invalid_note_path' || err === 'not_a_note_file') {
+            human = 'That note path is not valid for editing.';
+          } else if (err === 'frontmatter_in_body') {
+            human = 'The body must not contain a frontmatter block (it is preserved automatically).';
           } else {
-            setStatus('error', 'Save failed: ' + msg);
+            human = 'Save failed (HTTP ' + res.status + '). See the browser console for details.';
           }
+          var s = document.querySelector('.note-edit-status');
+          if (s && rawMsg) { s.setAttribute('title', rawMsg); }
+          setStatus('error', human);
         }).catch(function (e) {
-          setStatus('error', 'Network error: ' + (e && e.message ? e.message : e));
+          setStatus('error', 'Network error \\u2014 the runtime may be unreachable. ' + (e && e.message ? e.message : ''));
         });
       }
     };
@@ -1095,7 +1117,10 @@ def _render_note_section(fields: dict) -> str:
         if vault_unreachable
         else ""
     )
-    read_only_pill_html = _render_read_only_pill() if not canvas_enabled else ""
+    # Direct human editing is always available, so "Canvas off" no longer means
+    # the note is read-only — the misleading read-only pill is suppressed (#1447).
+    # A genuine write-blocked state surfaces with explicit copy at save time.
+    read_only_pill_html = ""
     note_not_found_html = _render_note_not_found(raw_note_path) if note_not_found else ""
     rail_empty_state_html = _render_rail_empty_state(
         panel_proposal_count=proposal_count,
@@ -1360,10 +1385,10 @@ def _render_note_section(fields: dict) -> str:
           aria-label="open outline" data-layout-visible="800-1099"
           onclick="leftPanel.setMode('outline')">☰ outline</button>
         <div class="note-body" data-testid="workspace-note-body" data-region="note-body"
-          data-read-only="true">
+          data-read-only="false">
           <div class="note-body-readonly-indicator"
             data-testid="workspace-note-body-readonly-indicator"
-            data-read-only="true">read-only</div>
+            data-read-only="false" hidden>read-only</div>
           <div class="note-body-readonly-reason"
             data-testid="workspace-note-body-readonly-reason"
             aria-live="polite"

--- a/companion-ui/docs/COMPANION_UI_DAILY_USE_VISIBILITY_CONTRACT.md
+++ b/companion-ui/docs/COMPANION_UI_DAILY_USE_VISIBILITY_CONTRACT.md
@@ -112,13 +112,18 @@ debugging and test assertions.
 
 ## Section D — Read-only body affordance
 
-### Rule: Note body always carries read-only indicator
+### Rule: Note body is editable; read-only chrome is calmed (#1447)
 
-The note body div (`data-testid="workspace-note-body"`) carries `data-read-only="true"`.
-
-A calm, low-noise read-only indicator (`data-testid="workspace-note-body-readonly-indicator"`)
-is always rendered in the note body area when the body is read-only. It uses small monospace
-uppercase text styled with `color: var(--fg-3)`.
+Direct human editing is always available via the note's Read/Edit editor
+(independent of Canvas/the update flow), so the note body is **not** read-only
+merely because Canvas is off. The note body div
+(`data-testid="workspace-note-body"`) carries `data-read-only="false"`, the
+read-only indicator (`data-testid="workspace-note-body-readonly-indicator"`) is
+present for inspectability but rendered `hidden`, and the "Canvas off" read-only
+pill (`data-testid="workspace-read-only-pill"`) is **suppressed** — it
+contradicted the always-available editor and read as unsolicited read-only
+nagging. A genuine write-blocked state (runtime degraded/health) surfaces with
+explicit, human-readable copy at **save time**, not as ambient read-only chrome.
 
 ### Rule: Inline reason with Why? link on focus/click
 

--- a/tests/api/test_companion_note_save_api.py
+++ b/tests/api/test_companion_note_save_api.py
@@ -99,6 +99,25 @@ def test_matching_content_hash_saves(tmp_path: Path, monkeypatch) -> None:
     assert "v2" in note.read_text(encoding="utf-8")
 
 
+def test_url_fragment_in_note_path_normalized_to_canonical_note(tmp_path: Path, monkeypatch) -> None:
+    # #1447 — a leaked URL section anchor (#...) must not turn a valid edit into a
+    # 404; the fragment is stripped and the canonical note is written.
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+    _clear_gates(monkeypatch)
+    note = tmp_path / "Inbox" / "Note.md"
+    _write_note(note, frontmatter="title: N", body="old\n")
+
+    client = TestClient(app)
+    resp = client.post(
+        "/api/companion/note/save",
+        json={"note_path": "Inbox/Note.md#14-3-long-section-c", "new_body": "# Saved\n"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["note_path"] == "Inbox/Note.md"
+    assert "# Saved" in note.read_text(encoding="utf-8")
+
+
 def test_missing_note_is_404(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
     monkeypatch.setenv("PKM_ENVIRONMENT", "dev")

--- a/tests/companion_ui/test_direct_note_editor.py
+++ b/tests/companion_ui/test_direct_note_editor.py
@@ -101,6 +101,31 @@ def test_no_edit_disabled_nag() -> None:
     assert "Editing is not enabled in this workspace" not in html
 
 
+def test_editor_strips_url_fragment_from_note_path() -> None:
+    # #1447 — the save call strips any #section anchor from the note identity.
+    html = _render()
+    assert ".split('#')[0]" in html
+
+
+def test_editor_shows_human_error_copy_not_raw_json() -> None:
+    # #1447 — failures map to human-readable copy; raw JSON is not surfaced and
+    # the runtime-route-missing (deploy skew) case gets specific guidance.
+    html = _render()
+    assert "needs the latest build" in html  # route-missing / deploy-skew case
+    assert "Note not found for: " in html
+    assert "writes blocked" in html
+    assert "console.error('note save failed'" in html  # raw detail kept inspectable
+    # The old behaviour ('Save failed: ' + raw JSON message) is gone.
+    assert "'Save failed: ' + msg" not in html
+
+
+def test_no_canvas_off_readonly_pill() -> None:
+    # #1447 — editing is always available, so the misleading read-only pill is
+    # suppressed (canvas disabled no longer implies read-only).
+    html = _render(canvas_enabled=False)
+    assert 'data-testid="workspace-read-only-pill"' not in html
+
+
 def test_page_server_proxies_note_save() -> None:
     # The page server must proxy the human-save path to the runtime (same-origin).
     from companion_ui.workspace import serve_dev_page as mod

--- a/tests/companion_ui/test_workspace_daily_use_visibility.py
+++ b/tests/companion_ui/test_workspace_daily_use_visibility.py
@@ -310,13 +310,16 @@ class TestReadOnlyBodyAffordance:
         assert 'data-testid="workspace-note-body-readonly-indicator"' in html
 
     def test_readonly_indicator_on_note_body(self) -> None:
+        # Direct human editing is always available, so the note body is no longer
+        # read-only just because Canvas is off (#1447). The attribute is present
+        # for inspectability but now reflects the editable state.
         html = _html()
         note_body_m = re.search(
             r'data-testid="workspace-note-body"[^>]*data-read-only="([^"]*)"',
             html,
         )
         assert note_body_m, "workspace-note-body must carry data-read-only attribute"
-        assert note_body_m.group(1) == "true"
+        assert note_body_m.group(1) == "false"
 
     def test_readonly_reason_element_present(self) -> None:
         html = _html()

--- a/tests/companion_ui/test_workspace_read_only_pill.py
+++ b/tests/companion_ui/test_workspace_read_only_pill.py
@@ -44,12 +44,14 @@ def _render(**overrides) -> str:
 
 
 class TestReadOnlyPill:
-    def test_pill_visible_when_canvas_disabled(self) -> None:
+    def test_no_readonly_pill_when_canvas_disabled(self) -> None:
+        # #1447 — direct human editing is always available, so Canvas being off no
+        # longer means the note is read-only. The misleading "Canvas off" read-only
+        # pill is suppressed; a genuine write-blocked state surfaces at save time.
         html = _render(guard_canvas_enabled=False)
-        assert 'data-testid="workspace-read-only-pill"' in html
-        m = re.search(r'data-testid="workspace-read-only-pill"[^>]*title="([^"]+)"', html)
-        assert m, "read-only pill missing title attribute"
-        assert re.search(r"Canvas off", m.group(1)), f"title does not mention Canvas off: {m.group(1)!r}"
+        assert 'data-testid="workspace-read-only-pill"' not in html
+        # The editor is offered instead.
+        assert 'data-testid="workspace-note-edit-toggle"' in html
 
     def test_pill_absent_when_canvas_enabled(self) -> None:
         html = _render(guard_canvas_enabled=True)


### PR DESCRIPTION
Fixes #1447

## Root cause
The UAT failure (`Save failed: {"detail":"Not Found"}`) is **deploy skew**: the page server was redeployed with the editor + proxy, but the runtime API (`:18001`) wasn't restarted with the freshly-merged `/note/save` route — so the proxy forwarded to a route the runtime doesn't have → FastAPI's default `{"detail":"Not Found"}`. I confirmed this against the live runtime (a missing-path POST to `:18001/api/companion/note/save` returns the same default 404; the route is unmounted there). **Immediate unblock: restart the runtime API on the latest build.**

Beyond the deploy trigger, #1447 flagged real robustness gaps, all fixed here.

## Changes
- **Editor `save()` (serve_dev_page.py):**
  - Strips any URL `#section-anchor` from the note identity before saving (the canonical path never carries a fragment).
  - Maps failures to **human-readable copy** instead of raw JSON: route-missing/deploy-skew → *"Saving is not available on this runtime yet — it needs the latest build (restart the runtime API)"*; plus `note_not_found`, `content_hash_mismatch`, `runtime_write_blocked`, path/validation, frontmatter. Raw machine detail stays inspectable via `console.error` + the status `title` attribute.
- **Backend `_validate_workspace_note_path` (companion.py):** strips a leaked `#fragment` so a valid edit never becomes a confusing 404 (Obsidian filenames can't contain `#`). Verified: `POST` with `Inbox/Note.md#14-3-long-section-c` writes the canonical `Inbox/Note.md`.
- **Calm read-only (the contradicting badges):** direct editing is always available, so the misleading "Canvas off" read-only **pill is suppressed** and the note body reports `data-read-only="false"` (indicator kept in DOM, hidden). A genuine write-blocked state surfaces with explicit copy at save time.

## On the "UI state gating" AC
#1447 asks "UI should not show active Save when writes are disabled." Resolution: per the owner's explicit direction, **human editing is intentionally always available** (decoupled from Canvas/writeguard in #1445). So Save stays active by design — the fix is clean, explicit error handling (above), not hiding the editor. Documented in the daily-use visibility contract.

## Tests
- API: `tests/api/test_companion_note_save_api.py::test_url_fragment_in_note_path_normalized_to_canonical_note` (+ existing round-trip/conflict/404).
- UI: `tests/companion_ui/test_direct_note_editor.py` — fragment strip, human error copy (no raw JSON, deploy-skew guidance, raw detail inspectable), no read-only pill.
- Read-only: updated `test_workspace_read_only_pill.py` + `test_workspace_daily_use_visibility.py` to the editable contract.
- `pytest -q tests/companion_ui` → 1247 passed, 1 skipped, 2 failed (both documented pre-existing baseline failures). ruff (touched) + the new API/UI tests green.

## Out of scope
The deploy/restart itself (operator action). The Canvas/AI-mediated edit flow is untouched.

## Docs
`COMPANION_UI_DAILY_USE_VISIBILITY_CONTRACT.md` — read-only chrome rule updated for the always-editable note body.

## Rollback
Revert this commit; error copy returns to raw JSON and the read-only pill returns. No migration impact.