### PR TITLE
Add leave-point trace cursor

### DIFF
--- a/app/api/routes/canvas.py
+++ b/app/api/routes/canvas.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 from uuid import uuid4
 
 from fastapi import APIRouter, HTTPException
@@ -27,6 +27,7 @@ from app.chat.canvas_writer import CanvasWriter, GovernanceBearingMutationError,
 from app.chat.governance_router import GovernanceActionType, GovernanceRouter
 from app.chat.session_log import SessionLog, SessionLogWriter
 from app.config.paths import resolve_vault_root
+from app.orientation.leave_point_cursor import capture_leave_point_cursor
 from app.panel.canvas_pipeline import CanvasPanelPipeline
 from app.panel.confirmation import _proposal_store as _panel_proposal_store
 
@@ -139,6 +140,61 @@ def _note_body(note_path: Path) -> str:
     return body
 
 
+def _runtime_channel() -> str:
+    raw = (
+        os.getenv("PKM_ENVIRONMENT")
+        or os.getenv("CHANNEL")
+        or os.getenv("PKM_CHANNEL")
+        or ""
+    ).strip().lower()
+    return raw if raw in {"dev", "test", "prod"} else "unknown"
+
+
+def _runtime_vault_id(vault_root: Path) -> str:
+    try:
+        from app.settings.runtime import get_settings_bundle
+
+        bundle = get_settings_bundle()
+        configured = getattr(getattr(getattr(bundle, "instance", None), "vault", None), "name", None)
+        if isinstance(configured, str) and configured.strip():
+            return configured.strip()
+    except Exception:
+        pass
+    return vault_root.name or "default"
+
+
+def _capture_leave_point_for_session(
+    session: SessionLog,
+    *,
+    source_kind: Literal["artifact_activation", "canvas_session", "session_end"],
+    capture_reason: Literal["artifact_focus", "artifact_interaction", "session_end"],
+) -> None:
+    vault_root = _get_vault_root()
+    try:
+        safe_note_path = str(session.note_path.relative_to(vault_root))
+        identity = resolve_note_artifact_identity(
+            artifact_path=session.note_path,
+            vault_root=vault_root,
+            safe_note_path=safe_note_path,
+            body=session.note_path.read_text(encoding="utf-8"),
+            heal_missing_uuid=False,
+        )
+        if identity.artifact_id is None:
+            return
+        capture_leave_point_cursor(
+            vault_id=_runtime_vault_id(vault_root),
+            channel=_runtime_channel(),
+            artifact_uuid=identity.artifact_id,
+            source_kind=source_kind,
+            source_ref_id=safe_note_path,
+            capture_reason=capture_reason,
+            last_session_id=session.session_id,
+            content_hash_at_capture=_content_hash(session.note_path.read_text(encoding="utf-8")),
+        )
+    except Exception:
+        return
+
+
 @router.post("/sessions", response_model=OpenSessionResponse)
 def open_session(req: OpenSessionRequest) -> OpenSessionResponse:
     _require_canvas()
@@ -152,6 +208,11 @@ def open_session(req: OpenSessionRequest) -> OpenSessionResponse:
     _sessions[session.session_id] = session
     _edit_history[session.session_id] = []
     _undone_history[session.session_id] = []
+    _capture_leave_point_for_session(
+        session,
+        source_kind="artifact_activation",
+        capture_reason="artifact_focus",
+    )
     return OpenSessionResponse(
         session_id=session.session_id,
         note_path=str(session.note_path),
@@ -185,6 +246,11 @@ def apply_edit(session_id: str, req: EditRequest) -> EditResponse:
             body_after=body_after,
             change_summary=req.change_summary,
         )
+    )
+    _capture_leave_point_for_session(
+        session,
+        source_kind="canvas_session",
+        capture_reason="artifact_interaction",
     )
     return EditResponse(session_id=session_id, ok=True)
 
@@ -280,6 +346,11 @@ def close_session(session_id: str, total_summary: str = "session closed") -> Clo
     vault_root = _get_vault_root()
     log_writer = SessionLogWriter(vault_root=vault_root)
     log_writer.close_session(session, total_summary)
+    _capture_leave_point_for_session(
+        session,
+        source_kind="session_end",
+        capture_reason="session_end",
+    )
     return CloseResponse(session_id=session_id, log_path=str(session.log_path))
 
 

--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -22,6 +22,7 @@ from app.chat.canvas_writer import _body_contains_frontmatter, _split_frontmatte
 from app.config.paths import resolve_vault_root
 from app.knowledge.write_ops import write_note_from_absolute
 from app.observability.status_service import OrientationSignals, get_orientation_signals
+from app.orientation.leave_point_cursor import latest_leave_point_projection
 from app.orientation.runtime import build_orientation_frame
 from app.receipts.artifact_receipts import ArtifactReceiptTarget, receipts_for_artifacts
 from app.resurfacing.runtime import evaluate_resurfacing_candidates
@@ -180,19 +181,23 @@ class WorkspaceOrientationSourceRef(BaseModel):
 
 
 class WorkspaceOrientationArtifactRef(BaseModel):
-    artifact_id: str | None = None
-    note_path: str | None = None
+    artifact_uuid: str | None = None
+    logical_ref: str | None = None
     title: str | None = None
 
 
+class WorkspaceOrientationLeavePointSourceRef(BaseModel):
+    kind: str | None = None
+    trace_id: str | None = None
+
+
 class WorkspaceOrientationLeavePoint(BaseModel):
-    kind: Literal["derived_only"] = "derived_only"
-    artifact_ref: WorkspaceOrientationArtifactRef | None = None
-    label: str | None = None
-    last_interaction_at: str | None = None
+    status: Literal["absent", "present", "stale", "artifact_missing", "degraded"] = "absent"
+    artifact_ref: WorkspaceOrientationArtifactRef = Field(default_factory=WorkspaceOrientationArtifactRef)
+    captured_at: str | None = None
     last_session_id: str | None = None
-    authority_role: str = "derived"
-    source_ref: WorkspaceOrientationSourceRef
+    authority_role: Literal["operational_trace_pointer", "derived_runtime_projection"] = "derived_runtime_projection"
+    source_ref: WorkspaceOrientationLeavePointSourceRef = Field(default_factory=WorkspaceOrientationLeavePointSourceRef)
 
 
 class WorkspaceOrientationOpenLoop(BaseModel):
@@ -200,7 +205,7 @@ class WorkspaceOrientationOpenLoop(BaseModel):
     label: str
     status: str
     handoff_hint: str
-    artifact_ref: WorkspaceOrientationArtifactRef | None = None
+    artifact_ref: dict[str, str | None] | None = None
     authority_role: str = "derived"
     source_ref: WorkspaceOrientationSourceRef
 
@@ -210,7 +215,7 @@ class WorkspaceOrientationNotableChange(BaseModel):
     label: str
     summary: str
     changed_at: str | None = None
-    artifact_ref: WorkspaceOrientationArtifactRef | None = None
+    artifact_ref: dict[str, str | None] | None = None
     authority_role: str = "derived"
     source_ref: WorkspaceOrientationSourceRef
 
@@ -220,7 +225,7 @@ class WorkspaceOrientationResurfaceCandidate(BaseModel):
     label: str
     why_now: str
     signal_labels: list[str] = Field(default_factory=list)
-    artifact_ref: WorkspaceOrientationArtifactRef | None = None
+    artifact_ref: dict[str, str | None] | None = None
     authority_role: str = "derived"
     source_ref: WorkspaceOrientationSourceRef
 
@@ -822,15 +827,28 @@ def _orientation_leave_point(
     signals: OrientationSignals,
     *,
     frame_label: str | None,
+    identity: VaultIdentityState,
 ) -> WorkspaceOrientationLeavePoint:
+    projection = latest_leave_point_projection(
+        vault_id=identity.vault_name,
+        channel=identity.channel,
+        vault_root=resolve_vault_root(),
+        derived_label=frame_label,
+        derived_at=_orientation_iso(signals.ingestion.last_run_at),
+    )
     return WorkspaceOrientationLeavePoint(
-        label=frame_label,
-        last_interaction_at=_orientation_iso(signals.ingestion.last_run_at),
-        last_session_id=None,
-        source_ref=_orientation_source_ref(
-            "runtime_signal",
-            "orientation.signals",
-            "orientation signals",
+        status=projection.status,
+        artifact_ref=WorkspaceOrientationArtifactRef(
+            artifact_uuid=projection.artifact_ref.artifact_uuid,
+            logical_ref=projection.artifact_ref.logical_ref,
+            title=projection.artifact_ref.title,
+        ),
+        captured_at=projection.captured_at,
+        last_session_id=projection.last_session_id,
+        authority_role=projection.authority_role,
+        source_ref=WorkspaceOrientationLeavePointSourceRef(
+            kind=projection.source_ref.kind,
+            trace_id=projection.source_ref.trace_id,
         ),
     )
 
@@ -1678,6 +1696,7 @@ def read_companion_orientation() -> WorkspaceOrientationResponse:
         leave_point = _orientation_leave_point(
             orientation_signals,
             frame_label=frame.explanation.leave_point,
+            identity=identity,
         )
         open_loops = _orientation_open_loops(frame.explanation.open_items)
         notable_changes = _orientation_notable_changes(

--- a/app/orientation/leave_point_cursor.py
+++ b/app/orientation/leave_point_cursor.py
@@ -1,0 +1,401 @@
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any, Literal
+from uuid import uuid4
+
+import yaml
+
+from app.api.routes.artifacts import _content_hash, _extract_title
+from app.chat.canvas_writer import _split_frontmatter
+
+LEAVE_POINT_EVENT_TYPE = "workspace.leave_point.captured.v1"
+LEAVE_POINT_CURSOR_VERSION = 1
+DEFAULT_TTL = timedelta(hours=72)
+MAX_TTL = timedelta(days=7)
+
+ALLOWED_SOURCE_KINDS = {"artifact_activation", "canvas_session", "session_end"}
+ALLOWED_CAPTURE_REASONS = {"artifact_focus", "artifact_interaction", "session_end"}
+ALLOWED_CURSOR_FIELDS = {
+    "cursor_version",
+    "event_type",
+    "vault_id",
+    "channel",
+    "artifact_uuid",
+    "captured_at",
+    "expires_at",
+    "last_session_id",
+    "trace_id",
+    "source_ref",
+    "content_hash_at_capture",
+    "capture_reason",
+}
+ALLOWED_SOURCE_REF_FIELDS = {"kind", "ref_id"}
+
+
+@dataclass(frozen=True)
+class LeavePointArtifactRef:
+    artifact_uuid: str | None
+    logical_ref: str | None
+    title: str | None
+
+
+@dataclass(frozen=True)
+class LeavePointSourceRef:
+    kind: str | None
+    trace_id: str | None
+
+
+@dataclass(frozen=True)
+class LeavePointProjection:
+    status: Literal["absent", "present", "stale", "artifact_missing", "degraded"]
+    artifact_ref: LeavePointArtifactRef
+    captured_at: str | None
+    last_session_id: str | None
+    authority_role: Literal["operational_trace_pointer", "derived_runtime_projection"]
+    source_ref: LeavePointSourceRef
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_iso(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    raw = value.strip()
+    try:
+        if raw.endswith("Z"):
+            raw = raw[:-1] + "+00:00"
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _db_path() -> Path:
+    configured = os.getenv("LEAVE_POINT_TRACE_DB")
+    if configured:
+        return Path(configured).expanduser()
+    return Path(os.getenv("RUNTIME_TRACE_DIR", "runtime/orientation")).expanduser() / "leave_point_trace.sqlite3"
+
+
+def _connect() -> sqlite3.Connection:
+    path = _db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS leave_point_trace_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_type TEXT NOT NULL,
+            vault_id TEXT NOT NULL,
+            channel TEXT NOT NULL,
+            artifact_uuid TEXT NOT NULL,
+            captured_at TEXT NOT NULL,
+            trace_id TEXT NOT NULL,
+            payload TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_leave_point_trace_scope
+        ON leave_point_trace_events(vault_id, channel, captured_at, id)
+        """
+    )
+    conn.commit()
+    return conn
+
+
+def _safe_str(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _safe_ref_id(value: str) -> str:
+    candidate = PurePosixPath(value)
+    if not value or value.startswith("/") or ".." in candidate.parts:
+        raise ValueError("source_ref.ref_id must not be an absolute or escaping path")
+    return candidate.as_posix()
+
+
+def _frontmatter(body: str) -> dict[str, Any]:
+    frontmatter, _ = _split_frontmatter(body)
+    if frontmatter is None:
+        return {}
+    try:
+        parsed = yaml.safe_load(frontmatter) or {}
+    except Exception:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _artifact_metadata(path: Path, vault_root: Path) -> tuple[str | None, str, str, str]:
+    body = path.read_text(encoding="utf-8")
+    frontmatter = _frontmatter(body)
+    artifact_uuid = _safe_str(frontmatter.get("uuid") or frontmatter.get("id"))
+    logical_ref = path.relative_to(vault_root).as_posix()
+    title = _extract_title(body, fallback=path.stem)
+    return artifact_uuid, logical_ref, title, _content_hash(body)
+
+
+def find_artifact_by_uuid(vault_root: Path, artifact_uuid: str) -> tuple[str, str, str] | None:
+    if not vault_root.exists():
+        return None
+    for path in vault_root.rglob("*.md"):
+        if not path.is_file():
+            continue
+        try:
+            resolved_uuid, logical_ref, title, content_hash = _artifact_metadata(path, vault_root)
+        except Exception:
+            continue
+        if resolved_uuid == artifact_uuid:
+            return logical_ref, title, content_hash
+    return None
+
+
+def capture_leave_point_cursor(
+    *,
+    vault_id: str,
+    channel: str,
+    artifact_uuid: str,
+    source_kind: Literal["artifact_activation", "canvas_session", "session_end"],
+    source_ref_id: str,
+    capture_reason: Literal["artifact_focus", "artifact_interaction", "session_end"],
+    last_session_id: str | None = None,
+    trace_id: str | None = None,
+    content_hash_at_capture: str | None = None,
+    captured_at: datetime | None = None,
+    ttl: timedelta = DEFAULT_TTL,
+) -> dict[str, Any]:
+    if source_kind not in ALLOWED_SOURCE_KINDS:
+        raise ValueError("invalid leave-point source kind")
+    if capture_reason not in ALLOWED_CAPTURE_REASONS:
+        raise ValueError("invalid leave-point capture reason")
+    artifact_uuid = _safe_str(artifact_uuid) or ""
+    vault_id = _safe_str(vault_id) or ""
+    channel = _safe_str(channel) or ""
+    resolved_trace_id = _safe_str(trace_id) or uuid4().hex
+    if not artifact_uuid or not vault_id or not channel or not resolved_trace_id:
+        raise ValueError("vault_id, channel, artifact_uuid, and trace_id are required")
+    if ttl <= timedelta(0) or ttl > MAX_TTL:
+        raise ValueError("leave-point cursor TTL must be positive and at most 7 days")
+
+    captured = captured_at or _now()
+    event = {
+        "cursor_version": LEAVE_POINT_CURSOR_VERSION,
+        "event_type": LEAVE_POINT_EVENT_TYPE,
+        "vault_id": vault_id,
+        "channel": channel,
+        "artifact_uuid": artifact_uuid,
+        "captured_at": _iso(captured),
+        "expires_at": _iso(captured + ttl),
+        "last_session_id": _safe_str(last_session_id),
+        "trace_id": resolved_trace_id,
+        "source_ref": {
+            "kind": source_kind,
+            "ref_id": _safe_ref_id(source_ref_id),
+        },
+        "content_hash_at_capture": _safe_str(content_hash_at_capture),
+        "capture_reason": capture_reason,
+    }
+    with _connect() as conn:
+        conn.execute(
+            """
+            INSERT INTO leave_point_trace_events (
+                event_type, vault_id, channel, artifact_uuid, captured_at, trace_id, payload
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                LEAVE_POINT_EVENT_TYPE,
+                vault_id,
+                channel,
+                artifact_uuid,
+                event["captured_at"],
+                resolved_trace_id,
+                json.dumps(event, sort_keys=True, separators=(",", ":")),
+            ),
+        )
+        conn.commit()
+    return event
+
+
+def _valid_cursor_event(payload: Any, *, vault_id: str, channel: str, now: datetime) -> dict[str, Any] | None:
+    if not isinstance(payload, dict):
+        return None
+    if set(payload) - ALLOWED_CURSOR_FIELDS:
+        return None
+    source_ref = payload.get("source_ref")
+    if not isinstance(source_ref, dict) or set(source_ref) - ALLOWED_SOURCE_REF_FIELDS:
+        return None
+    if payload.get("cursor_version") != LEAVE_POINT_CURSOR_VERSION:
+        return None
+    if payload.get("event_type") != LEAVE_POINT_EVENT_TYPE:
+        return None
+    if payload.get("vault_id") != vault_id or payload.get("channel") != channel:
+        return None
+    if not _safe_str(payload.get("artifact_uuid")) or not _safe_str(payload.get("trace_id")):
+        return None
+    if source_ref.get("kind") not in ALLOWED_SOURCE_KINDS or not _safe_str(source_ref.get("ref_id")):
+        return None
+    if payload.get("capture_reason") not in ALLOWED_CAPTURE_REASONS:
+        return None
+    captured_at = _parse_iso(payload.get("captured_at"))
+    expires_at = _parse_iso(payload.get("expires_at"))
+    if captured_at is None or expires_at is None or expires_at <= now:
+        return None
+    if expires_at - captured_at > MAX_TTL:
+        return None
+    return payload
+
+
+def _projection(
+    *,
+    status: Literal["absent", "present", "stale", "artifact_missing", "degraded"],
+    artifact_uuid: str | None = None,
+    logical_ref: str | None = None,
+    title: str | None = None,
+    captured_at: str | None = None,
+    last_session_id: str | None = None,
+    authority_role: Literal["operational_trace_pointer", "derived_runtime_projection"],
+    source_kind: str | None = None,
+    trace_id: str | None = None,
+) -> LeavePointProjection:
+    return LeavePointProjection(
+        status=status,
+        artifact_ref=LeavePointArtifactRef(
+            artifact_uuid=artifact_uuid,
+            logical_ref=logical_ref,
+            title=title,
+        ),
+        captured_at=captured_at,
+        last_session_id=last_session_id,
+        authority_role=authority_role,
+        source_ref=LeavePointSourceRef(kind=source_kind, trace_id=trace_id),
+    )
+
+
+def latest_leave_point_projection(
+    *,
+    vault_id: str,
+    channel: str,
+    vault_root: Path,
+    derived_label: str | None = None,
+    derived_at: str | None = None,
+) -> LeavePointProjection:
+    try:
+        with _connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT payload
+                FROM leave_point_trace_events
+                ORDER BY captured_at DESC, id DESC
+                LIMIT 100
+                """
+            ).fetchall()
+    except Exception:
+        rows = []
+
+    now = _now()
+    for row in rows:
+        try:
+            payload = json.loads(row["payload"])
+        except Exception:
+            continue
+        event = _valid_cursor_event(payload, vault_id=vault_id, channel=channel, now=now)
+        if event is None:
+            continue
+        artifact_uuid = str(event["artifact_uuid"])
+        source_ref = event["source_ref"]
+        artifact = find_artifact_by_uuid(vault_root, artifact_uuid)
+        if artifact is None:
+            return _projection(
+                status="artifact_missing",
+                artifact_uuid=artifact_uuid,
+                captured_at=event["captured_at"],
+                last_session_id=event.get("last_session_id"),
+                authority_role="operational_trace_pointer",
+                source_kind=source_ref.get("kind"),
+                trace_id=event.get("trace_id"),
+            )
+        logical_ref, title, current_hash = artifact
+        captured_hash = event.get("content_hash_at_capture")
+        if captured_hash and captured_hash != current_hash:
+            return _projection(
+                status="stale",
+                artifact_uuid=artifact_uuid,
+                logical_ref=logical_ref,
+                title=title,
+                captured_at=event["captured_at"],
+                last_session_id=event.get("last_session_id"),
+                authority_role="operational_trace_pointer",
+                source_kind=source_ref.get("kind"),
+                trace_id=event.get("trace_id"),
+            )
+        return _projection(
+            status="present",
+            artifact_uuid=artifact_uuid,
+            logical_ref=logical_ref,
+            title=title,
+            captured_at=event["captured_at"],
+            last_session_id=event.get("last_session_id"),
+            authority_role="operational_trace_pointer",
+            source_kind=source_ref.get("kind"),
+            trace_id=event.get("trace_id"),
+        )
+
+    return _projection(
+        status="absent",
+        title=derived_label,
+        captured_at=derived_at,
+        authority_role="derived_runtime_projection",
+        source_kind=None,
+        trace_id=None,
+    )
+
+
+def append_raw_leave_point_trace(payload: str) -> None:
+    with _connect() as conn:
+        conn.execute(
+            """
+            INSERT INTO leave_point_trace_events (
+                event_type, vault_id, channel, artifact_uuid, captured_at, trace_id, payload
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("corrupt", "unknown", "unknown", "unknown", _iso(_now()), "corrupt", payload),
+        )
+        conn.commit()
+
+
+def clear_leave_point_trace() -> None:
+    path = _db_path()
+    if path.exists():
+        path.unlink()
+
+
+__all__ = [
+    "ALLOWED_CURSOR_FIELDS",
+    "ALLOWED_SOURCE_REF_FIELDS",
+    "DEFAULT_TTL",
+    "LEAVE_POINT_EVENT_TYPE",
+    "LeavePointProjection",
+    "append_raw_leave_point_trace",
+    "capture_leave_point_cursor",
+    "clear_leave_point_trace",
+    "latest_leave_point_projection",
+]

--- a/companion-ui/docs/WORKSPACE_ORIENTATION_CONTRACT.md
+++ b/companion-ui/docs/WORKSPACE_ORIENTATION_CONTRACT.md
@@ -13,8 +13,8 @@ source_contracts:
   - docs/CONCEPTS/RUNTIME_VS_DURABLE_STATE_BOUNDARY.md
   - docs/CONCEPTS/RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md
   - docs/CONCEPTS/SALIENCE_AND_ATTENTIONAL_RELEVANCE_CONTRACT.md
-governing_issue: "#1451; #1454"
-implementation_state: implemented_phase_1; phase_2_cursor_decision_recorded
+governing_issue: "#1451; #1454; #1455"
+implementation_state: implemented_phase_2_cursor
 ---
 
 # Workspace Orientation Contract
@@ -31,10 +31,10 @@ Workspace Orientation Snapshot at `GET /api/companion/orientation`, which
 answers "where am I in the system, what is open, what changed, and what can I
 safely resume?"
 
-This document is the contract for the Phase 1 runtime endpoint and Companion UI
-re-entry consumption. ADR-0008 adds the Phase 2 leave-point cursor projection
-rules for downstream implementation. Both shipped surfaces remain read-only
-projections.
+This document is the contract for the runtime endpoint and Companion UI
+re-entry consumption. Phase 2 implements ADR-0008's leave-point cursor
+projection rules as an append-only operational trace pointer. Both shipped
+surfaces remain read-only projections.
 
 ## Scope
 

--- a/tests/api/test_companion_orientation_api.py
+++ b/tests/api/test_companion_orientation_api.py
@@ -15,6 +15,7 @@ import app.panel.confirmation as confirm_module
 from app.api.app import app
 from app.observability.status_model import EventCounters, IngestionStatus, WorkerQueueStatus
 from app.observability.status_service import OrientationSignals
+from app.orientation.leave_point_cursor import clear_leave_point_trace
 from app.resurfacing.runtime import (
     ResurfacingCandidate,
     ResurfacingEvaluation,
@@ -27,11 +28,15 @@ from app.resurfacing.runtime import (
 def _clear_runtime_state(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
     monkeypatch.setenv("PKM_CHANNEL", "test")
+    monkeypatch.setenv("LEAVE_POINT_TRACE_DB", str(tmp_path / "runtime" / "leave-point.sqlite3"))
+    monkeypatch.setattr(companion_module, "_configured_vault_name", lambda: "vault-test")
+    clear_leave_point_trace()
     canvas_module._sessions.clear()
     canvas_module._edit_history.clear()
     canvas_module._undone_history.clear()
     confirm_module._proposal_store.clear()
     confirm_module._idempotency_store.clear()
+    clear_leave_point_trace()
     yield
     canvas_module._sessions.clear()
     canvas_module._edit_history.clear()
@@ -117,7 +122,8 @@ def test_orientation_snapshot_without_note(
     assert data["scope"]["kind"] == "workspace"
     assert data["scope"]["channel"] == "test"
     assert data["meta"]["contract_version"] == "workspace_orientation.v1"
-    assert data["leave_point"]["kind"] == "derived_only"
+    assert data["leave_point"]["status"] == "absent"
+    assert data["leave_point"]["authority_role"] == "derived_runtime_projection"
     assert data["mutation_intents"] == []
     assert "artifact" not in data
     assert "body" not in data
@@ -179,8 +185,10 @@ def test_items_carry_provenance(
 
     assert resp.status_code == 200
     data = resp.json()
+    assert data["leave_point"]["authority_role"]
+    assert "kind" in data["leave_point"]["source_ref"]
+    assert "trace_id" in data["leave_point"]["source_ref"]
     items = [
-        data["leave_point"],
         *data["open_loops"],
         *data["notable_changes"],
         *data["resurface"]["candidates"],

--- a/tests/api/test_leave_point_cursor.py
+++ b/tests/api/test_leave_point_cursor.py
@@ -1,0 +1,390 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.api.routes.canvas as canvas_module
+import app.api.routes.companion as companion_module
+import app.memory.store as memory_store
+import app.panel.confirmation as confirm_module
+from app.api.app import app
+from app.observability.status_model import EventCounters, IngestionStatus, WorkerQueueStatus
+from app.observability.status_service import OrientationSignals
+from app.orientation import leave_point_cursor as cursor_module
+from app.orientation.leave_point_cursor import (
+    ALLOWED_CURSOR_FIELDS,
+    ALLOWED_SOURCE_REF_FIELDS,
+    append_raw_leave_point_trace,
+    capture_leave_point_cursor,
+    clear_leave_point_trace,
+    latest_leave_point_projection,
+)
+from app.services import outbox as outbox_service
+
+
+@pytest.fixture(autouse=True)
+def _runtime(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir()
+    monkeypatch.setenv("VAULT_ROOT", str(vault_root))
+    monkeypatch.setenv("PKM_CHANNEL", "test")
+    monkeypatch.setenv("LEAVE_POINT_TRACE_DB", str(tmp_path / "runtime" / "leave-point.sqlite3"))
+    monkeypatch.setattr(companion_module, "_configured_vault_name", lambda: "vault-test")
+    canvas_module._sessions.clear()
+    canvas_module._edit_history.clear()
+    canvas_module._undone_history.clear()
+    confirm_module._proposal_store.clear()
+    confirm_module._idempotency_store.clear()
+    clear_leave_point_trace()
+    yield
+    clear_leave_point_trace()
+    canvas_module._sessions.clear()
+    canvas_module._edit_history.clear()
+    canvas_module._undone_history.clear()
+    confirm_module._proposal_store.clear()
+    confirm_module._idempotency_store.clear()
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def _signals() -> OrientationSignals:
+    now = datetime(2026, 5, 31, 12, 0, tzinfo=timezone.utc)
+    return OrientationSignals(
+        events=EventCounters(
+            watcher_runs_total=1,
+            watcher_runs_24h=0,
+            panel_runs_total=0,
+            panel_runs_24h=0,
+            promote_created_total=0,
+            promote_created_24h=0,
+            promotion_executed_total=0,
+            promotion_executed_24h=0,
+            source_path="/tmp/status-events",
+        ),
+        ingestion=IngestionStatus(
+            last_run_at=now,
+            last_run_ok=True,
+            total_scanned=1,
+            total_ingested=1,
+        ),
+        worker_queue=WorkerQueueStatus(
+            mode="memory",
+            pending=0,
+            processed_total=0,
+            source_path="/tmp/worker",
+        ),
+    )
+
+
+def _note(vault_root: Path, rel: str, uuid: str, title: str = "Cursor Note") -> Path:
+    path = vault_root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"---\nuuid: {uuid}\ntitle: {title}\n---\n# {title}\n\nBody text.\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _capture(
+    *,
+    artifact_uuid: str = "artifact-1",
+    vault_id: str = "vault-test",
+    channel: str = "test",
+    trace_id: str = "trace-1",
+    captured_at: datetime | None = None,
+    content_hash_at_capture: str | None = None,
+) -> dict:
+    return capture_leave_point_cursor(
+        vault_id=vault_id,
+        channel=channel,
+        artifact_uuid=artifact_uuid,
+        source_kind="artifact_activation",
+        source_ref_id="notes/cursor.md",
+        capture_reason="artifact_focus",
+        last_session_id="session-1",
+        trace_id=trace_id,
+        captured_at=captured_at,
+        content_hash_at_capture=content_hash_at_capture,
+    )
+
+
+def _orientation(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> dict:
+    monkeypatch.setattr(companion_module, "get_orientation_signals", lambda: _signals())
+    resp = client.get("/api/companion/orientation")
+    assert resp.status_code == 200
+    return resp.json()
+
+
+def test_cursor_survives_restart_reference_only(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    vault_root = Path(os.environ["VAULT_ROOT"])
+    _note(vault_root, "notes/cursor.md", "artifact-1")
+
+    event = _capture()
+    projection = latest_leave_point_projection(vault_id="vault-test", channel="test", vault_root=vault_root)
+
+    assert projection.status == "present"
+    assert projection.artifact_ref.artifact_uuid == "artifact-1"
+    assert projection.artifact_ref.logical_ref == "notes/cursor.md"
+    assert event["last_session_id"] == "session-1"
+
+
+def test_cursor_loss_degrades_to_fresh_orientation(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    data = _orientation(client, monkeypatch)
+
+    assert data["leave_point"]["status"] == "absent"
+    assert data["leave_point"]["authority_role"] == "derived_runtime_projection"
+    assert data["meta"]["freshness"] == "fresh"
+
+
+def test_cursor_contains_references_only() -> None:
+    event = _capture()
+    forbidden = {
+        "body",
+        "summary",
+        "diff",
+        "embedding",
+        "working_set",
+        "open_tabs",
+        "selection",
+        "scroll_position",
+        "raw_chat_history",
+        "memory_candidate",
+        "receipt",
+        "writeguard",
+        "absolute_path",
+        "orientation_summary",
+        "resurfacing_candidates",
+    }
+
+    assert set(event) == ALLOWED_CURSOR_FIELDS
+    assert set(event["source_ref"]) == ALLOWED_SOURCE_REF_FIELDS
+    assert not forbidden.intersection(event)
+    assert all("/Users/" not in json.dumps(value) for value in event.values())
+
+
+def test_cursor_is_reference_only() -> None:
+    test_cursor_contains_references_only()
+
+
+def test_orientation_uses_cursor_with_fallback(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault_root = Path(os.environ["VAULT_ROOT"])
+    _note(vault_root, "notes/cursor.md", "artifact-1")
+    _capture(trace_id="trace-cursor")
+
+    with_cursor = _orientation(client, monkeypatch)
+    clear_leave_point_trace()
+    without_cursor = _orientation(client, monkeypatch)
+
+    assert with_cursor["leave_point"]["status"] == "present"
+    assert with_cursor["leave_point"]["authority_role"] == "operational_trace_pointer"
+    assert with_cursor["leave_point"]["source_ref"] == {
+        "kind": "artifact_activation",
+        "trace_id": "trace-cursor",
+    }
+    assert without_cursor["leave_point"]["status"] == "absent"
+    assert without_cursor["leave_point"]["authority_role"] == "derived_runtime_projection"
+
+
+def test_cursor_loss_degrades_gracefully(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    test_cursor_loss_degrades_to_fresh_orientation(client, monkeypatch)
+
+
+def test_stale_cursor_marked_stale_not_used_as_fact(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault_root = Path(os.environ["VAULT_ROOT"])
+    note = _note(vault_root, "notes/cursor.md", "artifact-1")
+    old_hash = companion_module._content_hash(note.read_text(encoding="utf-8"))
+    _capture(content_hash_at_capture=old_hash)
+    note.write_text(note.read_text(encoding="utf-8") + "\nChanged.\n", encoding="utf-8")
+
+    data = _orientation(client, monkeypatch)
+
+    assert data["leave_point"]["status"] == "stale"
+    assert data["leave_point"]["artifact_ref"]["artifact_uuid"] == "artifact-1"
+
+
+def test_deleted_artifact_produces_degraded_leave_point(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault_root = Path(os.environ["VAULT_ROOT"])
+    note = _note(vault_root, "notes/cursor.md", "artifact-1")
+    _capture()
+    note.unlink()
+
+    data = _orientation(client, monkeypatch)
+
+    assert data["leave_point"]["status"] == "artifact_missing"
+    assert data["leave_point"]["artifact_ref"]["artifact_uuid"] == "artifact-1"
+    assert data["leave_point"]["artifact_ref"]["logical_ref"] is None
+
+
+def test_cross_channel_cursor_ignored(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    vault_root = Path(os.environ["VAULT_ROOT"])
+    _note(vault_root, "notes/cursor.md", "artifact-1")
+    _capture(channel="dev")
+
+    data = _orientation(client, monkeypatch)
+
+    assert data["leave_point"]["status"] == "absent"
+
+
+def test_cross_vault_cursor_ignored(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    vault_root = Path(os.environ["VAULT_ROOT"])
+    _note(vault_root, "notes/cursor.md", "artifact-1")
+    _capture(vault_id="other-vault")
+
+    data = _orientation(client, monkeypatch)
+
+    assert data["leave_point"]["status"] == "absent"
+
+
+def test_cursor_hash_mismatch_degrades_not_overrides(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_stale_cursor_marked_stale_not_used_as_fact(client, monkeypatch)
+
+
+def test_orientation_read_does_not_write_cursor(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_cursor = MagicMock(side_effect=AssertionError("GET orientation must not write cursor"))
+    monkeypatch.setattr(cursor_module, "capture_leave_point_cursor", write_cursor)
+
+    data = _orientation(client, monkeypatch)
+
+    assert data["mutation_intents"] == []
+    assert write_cursor.call_count == 0
+
+
+def test_no_vault_write_for_cursor_capture(tmp_path: Path) -> None:
+    _capture()
+    assert list(tmp_path.rglob("*.md")) == []
+
+
+def test_no_receipt_write_for_cursor_capture(monkeypatch: pytest.MonkeyPatch) -> None:
+    write_outbox = MagicMock(side_effect=AssertionError("cursor capture must not write receipts/outbox"))
+    monkeypatch.setattr(outbox_service, "write_outbox_event", write_outbox)
+
+    _capture()
+
+    assert write_outbox.call_count == 0
+
+
+def test_no_memory_write_for_cursor_capture(monkeypatch: pytest.MonkeyPatch) -> None:
+    remember = MagicMock(side_effect=AssertionError("cursor capture must not write memory"))
+    monkeypatch.setattr(memory_store, "remember", remember)
+
+    _capture()
+
+    assert remember.call_count == 0
+
+
+def test_cursor_rejects_absolute_note_path() -> None:
+    with pytest.raises(ValueError):
+        capture_leave_point_cursor(
+            vault_id="vault-test",
+            channel="test",
+            artifact_uuid="artifact-1",
+            source_kind="artifact_activation",
+            source_ref_id="/Users/rasmus/vault/notes/cursor.md",
+            capture_reason="artifact_focus",
+            trace_id="trace-1",
+        )
+
+
+def test_latest_valid_cursor_wins_concurrent_sessions(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault_root = Path(os.environ["VAULT_ROOT"])
+    _note(vault_root, "notes/one.md", "artifact-1", title="One")
+    _note(vault_root, "notes/two.md", "artifact-2", title="Two")
+    base = datetime(2026, 5, 31, 12, 0, tzinfo=timezone.utc)
+    _capture(artifact_uuid="artifact-1", trace_id="trace-old", captured_at=base)
+    _capture(artifact_uuid="artifact-2", trace_id="trace-new", captured_at=base + timedelta(seconds=1))
+
+    data = _orientation(client, monkeypatch)
+
+    assert data["leave_point"]["status"] == "present"
+    assert data["leave_point"]["artifact_ref"]["artifact_uuid"] == "artifact-2"
+    assert data["leave_point"]["source_ref"]["trace_id"] == "trace-new"
+
+
+def test_corrupt_cursor_ignored_and_next_valid_cursor_used(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault_root = Path(os.environ["VAULT_ROOT"])
+    _note(vault_root, "notes/cursor.md", "artifact-1")
+    _capture(trace_id="trace-valid")
+    append_raw_leave_point_trace("{not-json")
+
+    data = _orientation(client, monkeypatch)
+
+    assert data["leave_point"]["status"] == "present"
+    assert data["leave_point"]["source_ref"]["trace_id"] == "trace-valid"
+
+
+def test_missing_trace_id_rejected_or_ignored(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault_root = Path(os.environ["VAULT_ROOT"])
+    _note(vault_root, "notes/cursor.md", "artifact-1")
+    event = _capture(trace_id="trace-valid")
+    bad = dict(event)
+    bad.pop("trace_id")
+    append_raw_leave_point_trace(json.dumps(bad))
+
+    data = _orientation(client, monkeypatch)
+
+    assert data["leave_point"]["status"] == "present"
+    assert data["leave_point"]["source_ref"]["trace_id"] == "trace-valid"
+
+
+def test_missing_source_ref_rejected_or_ignored(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault_root = Path(os.environ["VAULT_ROOT"])
+    _note(vault_root, "notes/cursor.md", "artifact-1")
+    event = _capture(trace_id="trace-valid")
+    bad = dict(event)
+    bad.pop("source_ref")
+    append_raw_leave_point_trace(json.dumps(bad))
+
+    data = _orientation(client, monkeypatch)
+
+    assert data["leave_point"]["status"] == "present"
+    assert data["leave_point"]["source_ref"]["trace_id"] == "trace-valid"
+
+
+def test_cursor_does_not_emit_mutation_intents(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault_root = Path(os.environ["VAULT_ROOT"])
+    _note(vault_root, "notes/cursor.md", "artifact-1")
+    _capture()
+
+    data = _orientation(client, monkeypatch)
+
+    assert data["mutation_intents"] == []


### PR DESCRIPTION
Fixes #1455

## Summary
- Implements ADR-0008 leave-point cursor as an append-only runtime trace pointer, with strict reference-only schema and 72h default / 7d max TTL.
- Captures only on existing Canvas activation, interaction, and session-end write paths; `GET /api/companion/orientation` remains read-only and projects only the latest admissible cursor.
- Loss, expiry, corrupt rows, cross-vault/channel rows, missing artifacts, and hash mismatches degrade safely to absent/stale/artifact_missing handling without making orientation incorrect.

## Boundary Assertions
- No vault writes for cursor capture.
- No receipt writes for cursor capture.
- No memory writes for cursor capture.
- Orientation read remains read-only and does not write the cursor.
- Cursor loss degrades to fresh derived orientation.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/api/test_leave_point_cursor.py` — 21 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/api/test_companion_orientation_api.py` — 6 passed
- `/tmp/codex-ruff-1455/bin/ruff check app tests` — All checks passed
- `python3 scripts/docs_guard.py` — Docs guard: OK
- `git diff --check` — passed

## Coordination
- Dispatcher unavailable via `python3 -m app.dispatcher status --json` because the system Python environment lacked `yaml`; used GitHub-label-only claim and set Project status to In Progress.