### PR TITLE
Fix Companion UI Markdown GFM rendering regression

### DIFF
--- a/companion-ui/companion-app/companion_ui/renderer/callout_renderer.py
+++ b/companion-ui/companion-app/companion_ui/renderer/callout_renderer.py
@@ -71,6 +71,17 @@ class ObsidianCalloutRenderer:
         body_lines: list[str] = []
 
         while index < len(lines):
+            if not lines[index].strip():
+                next_index = _next_nonblank_index(lines, index + 1)
+                if next_index is None:
+                    break
+                next_quoted = _QUOTED_LINE_RE.match(lines[next_index])
+                if not next_quoted or CALLOUT_HEADER_RE.match(lines[next_index]):
+                    break
+                if body_lines:
+                    body_lines.append("")
+                index = next_index
+                continue
             quoted_line = _QUOTED_LINE_RE.match(lines[index])
             if not quoted_line:
                 break
@@ -182,6 +193,15 @@ def _fold_state(marker: str | None) -> str:
     if marker == "+":
         return "expanded"
     return "none"
+
+
+def _next_nonblank_index(lines: list[str], start: int) -> int | None:
+    index = start
+    while index < len(lines):
+        if lines[index].strip():
+            return index
+        index += 1
+    return None
 
 
 def _default_title(callout_type: str) -> str:

--- a/companion-ui/companion-app/companion_ui/renderer/vault_markdown_renderer.py
+++ b/companion-ui/companion-app/companion_ui/renderer/vault_markdown_renderer.py
@@ -249,6 +249,15 @@ def _render_blocks(markdown: str, context: _RenderContext) -> str:
     return "".join(parts)
 
 
+def _next_nonblank_index(lines: list[str], start: int) -> int | None:
+    index = start
+    while index < len(lines):
+        if lines[index].strip():
+            return index
+        index += 1
+    return None
+
+
 def _render_fenced_code(
     lines: list[str],
     start: int,
@@ -335,8 +344,21 @@ def _render_table(
     context: _RenderContext,
 ) -> tuple[str, int]:
     table_lines: list[str] = []
+    expected_columns = len(_split_table_row(lines[start]))
     index = start
-    while index < len(lines) and "|" in lines[index] and lines[index].strip():
+    while index < len(lines):
+        if not lines[index].strip():
+            next_index = _next_nonblank_index(lines, index + 1)
+            if next_index is None or not _is_table_row(
+                lines[next_index],
+                expected_columns=expected_columns,
+                require_outer_pipes=True,
+            ):
+                break
+            index = next_index
+            continue
+        if not _is_table_row(lines[index], expected_columns=expected_columns):
+            break
         table_lines.append(lines[index])
         index += 1
 
@@ -354,6 +376,20 @@ def _render_table(
 def _split_table_row(line: str) -> list[str]:
     stripped = line.strip().strip("|")
     return [cell.strip() for cell in stripped.split("|")]
+
+
+def _is_table_row(
+    line: str,
+    *,
+    expected_columns: int,
+    require_outer_pipes: bool = False,
+) -> bool:
+    stripped = line.strip()
+    if "|" not in stripped:
+        return False
+    if require_outer_pipes and not (stripped.startswith("|") and stripped.endswith("|")):
+        return False
+    return len(_split_table_row(stripped)) == expected_columns
 
 
 def _render_heading(match: re.Match[str], context: _RenderContext) -> str:
@@ -415,7 +451,18 @@ def _render_list_block(
     """
     entries: list[tuple[int, str, str | None, str]] = []
     index = start
+    base_indent = _list_indent(lines[start])
+    base_kind = _list_kind(lines[start])
     while index < len(lines):
+        if not lines[index].strip():
+            next_index = _next_nonblank_index(lines, index + 1)
+            next_kind = _list_kind(lines[next_index]) if next_index is not None else None
+            if next_index is None or next_kind is None:
+                break
+            if _list_indent(lines[next_index]) == base_indent and next_kind != base_kind:
+                break
+            index = next_index
+            continue
         kind = _list_kind(lines[index])
         if kind is None:
             break
@@ -768,10 +815,11 @@ def _render_unsupported_diagnostic(*, code: str, message: str) -> str:
 
 
 def _is_table_start(lines: list[str], index: int) -> bool:
-    return (
-        index + 1 < len(lines)
+    separator_index = _next_nonblank_index(lines, index + 1)
+    return bool(
+        separator_index is not None
         and "|" in lines[index]
-        and bool(_TABLE_SEPARATOR_RE.match(lines[index + 1]))
+        and bool(_TABLE_SEPARATOR_RE.match(lines[separator_index]))
     )
 
 

--- a/tests/companion_ui/test_markdown_renderer_lists.py
+++ b/tests/companion_ui/test_markdown_renderer_lists.py
@@ -36,6 +36,14 @@ def test_nested_bulleted_lists_indent_under_parent():
     assert "<li>Nested bullet B</li><li>Item C</li>" not in html
 
 
+def test_nested_bulleted_lists_allow_blank_spacer_lines():
+    md = "- Item A\n\n- Item B\n\n    - Nested bullet B\n\n- Item C\n"
+    html = _html(md)
+
+    assert re.search(r"<li>Item B<ul><li>Nested bullet B</li></ul></li>", html), html
+    assert html.count("<ul>") == 2
+
+
 # ---------------------------------------------------------------------------
 # 3.2 — nested ordered lists restart numbering
 # ---------------------------------------------------------------------------
@@ -61,6 +69,24 @@ def test_nested_ordered_lists_render_nested_ol():
     assert html.count("<ol>") == 2
 
 
+def test_nested_ordered_lists_allow_blank_spacer_lines():
+    md = (
+        "1. First numbered item\n\n"
+        "2. Second numbered item\n\n"
+        "3. Third numbered item\n\n"
+        "    1. Nested numbered item\n\n"
+        "    2. Another nested numbered item\n"
+    )
+    html = _html(md)
+
+    assert re.search(
+        r"<li>Third numbered item<ol><li>Nested numbered item</li>"
+        r"<li>Another nested numbered item</li></ol></li>",
+        html,
+    ), html
+    assert html.count("<ol>") == 2
+
+
 # ---------------------------------------------------------------------------
 # 3.3 — task list checked/unchecked
 # ---------------------------------------------------------------------------
@@ -78,6 +104,19 @@ def test_unchecked_task_remains_unchecked():
     li = re.search(r'<li class="task-list-item"[^>]*>.*?</li>', html, re.S).group(0)
     assert 'data-task-state=" "' in li
     assert "checked" not in li
+
+
+def test_task_list_allows_blank_spacer_lines():
+    html = _html("- [ ] Open task\n\n- [x] Completed task\n")
+
+    assert html.count('<ul class="task-list">') == 1
+    assert html.count('class="task-list-item"') == 2
+
+
+def test_blank_separated_mixed_list_types_keep_marker_semantics():
+    html = _html("- bullet\n\n1. ordered\n")
+
+    assert re.search(r"<ul><li>bullet</li></ul><ol><li>ordered</li></ol>", html), html
 
 
 def test_checked_task_has_completed_styling_hook_in_page_css():

--- a/tests/companion_ui/test_obsidian_callout_renderer.py
+++ b/tests/companion_ui/test_obsidian_callout_renderer.py
@@ -43,6 +43,15 @@ def test_basic_callout() -> None:
     assert "Basic note callout body." in html
 
 
+def test_callout_allows_blank_spacer_between_header_and_body() -> None:
+    html = _render_fixture("> [!note]\n\n> Body stays inside the callout.\n")
+
+    fragment = _callout_fragment(html, "note")
+    assert '<div class="vault-callout-body">' in fragment
+    assert "Body stays inside the callout." in fragment
+    assert "<blockquote>Body stays inside" not in html
+
+
 def test_custom_title() -> None:
     html = _render_fixture()
 

--- a/tests/companion_ui/test_vault_markdown_renderer.py
+++ b/tests/companion_ui/test_vault_markdown_renderer.py
@@ -86,6 +86,44 @@ def test_basic_fixtures() -> None:
     assert 'data-language="python"' in basic.html
 
 
+def test_gfm_table_allows_blank_spacer_lines_between_rows() -> None:
+    rendered = render_vault_markdown(
+        "\n".join(
+            [
+                "| Feature | Input syntax | Expected rendering |",
+                "",
+                "|---|---|---|",
+                "",
+                "| Bold | `**text**` | **text** |",
+                "",
+                "| Inline code | `` `code` `` | `code` |",
+            ]
+        )
+    )
+
+    assert "<table>" in rendered.html
+    assert "<th>Feature</th>" in rendered.html
+    assert "<td>Bold</td>" in rendered.html
+    assert "<p>| Feature |" not in rendered.html
+
+
+def test_gfm_table_does_not_capture_pipe_paragraph_after_blank_line() -> None:
+    rendered = render_vault_markdown(
+        "\n".join(
+            [
+                "| A | B |",
+                "|---|---|",
+                "| left | right |",
+                "",
+                "This paragraph has A | B text.",
+            ]
+        )
+    )
+
+    assert rendered.html.count("<tr>") == 2
+    assert "<p>This paragraph has A | B text.</p>" in rendered.html
+
+
 def test_frontmatter_excluded_from_body() -> None:
     rendered = render_vault_markdown(_fixture("frontmatter-properties.md"))
 


### PR DESCRIPTION
## Direct Repair
Type: code
Reason: Bounded regression repair for Companion UI Markdown rendering where blank spacer lines in UAT-shaped Markdown broke GFM tables, nested/task lists, and Obsidian callout grouping.
Validation: focused renderer/parser/editor tests, full Companion UI suite classification, CI checks on PR head, and UAT-shaped render evidence.
Issue required: no — bounded immediate repair from browser UAT regression report

## Summary
Fixes the Companion UI Markdown renderer regression where blank spacer lines in UAT-shaped Markdown caused GFM tables, loose/nested lists, task lists, and Obsidian callout bodies to split into raw or visually detached blocks.

This keeps the existing server-side renderer path: runtime API payload -> parse_vault_markdown -> render_vault_markdown. No direct vault filesystem access or note-path special casing is introduced.

## Root Cause
The running UAT page was using the expected `serve_dev_page.py` renderer path, but the UAT note body includes blank spacer lines between table rows, list items, and callout header/body lines. The renderer treated those blank lines as hard block terminators, so table rows became paragraphs, list items became separate top-level lists, and callout bodies fell through to standalone blockquotes.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_vault_markdown_renderer.py::test_gfm_table_allows_blank_spacer_lines_between_rows tests/companion_ui/test_vault_markdown_renderer.py::test_gfm_table_does_not_capture_pipe_paragraph_after_blank_line tests/companion_ui/test_markdown_renderer_lists.py::test_nested_bulleted_lists_allow_blank_spacer_lines tests/companion_ui/test_markdown_renderer_lists.py::test_nested_ordered_lists_allow_blank_spacer_lines tests/companion_ui/test_markdown_renderer_lists.py::test_task_list_allows_blank_spacer_lines tests/companion_ui/test_markdown_renderer_lists.py::test_blank_separated_mixed_list_types_keep_marker_semantics tests/companion_ui/test_obsidian_callout_renderer.py::test_callout_allows_blank_spacer_between_header_and_body -m 'not pg'` — 7 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_vault_markdown_renderer.py tests/companion_ui/test_markdown_renderer_lists.py tests/companion_ui/test_obsidian_callout_renderer.py tests/companion_ui/test_missing_image_partial.py tests/companion_ui/test_failed_embed_partial.py tests/companion_ui/test_vault_markdown_parser.py tests/companion_ui/test_obsidian_compatibility_fixtures.py tests/companion_ui/test_mermaid_block_renderer.py tests/companion_ui/test_properties_renderer.py tests/companion_ui/test_editor_roundtrip.py tests/companion_ui/test_codemirror_adapter.py tests/companion_ui/test_active_note_body_update.py -m 'not pg'` — 105 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui -m 'not pg'` — 1252 passed, 1 skipped, 2 failed; the two failures match the pre-existing unrelated failures documented in `docs/STATUS.md` (`workspace-runtime-safety-strip` testid drift and `signals` kwarg monkeypatch)
- `git diff --check` — passed
- `ruff` unavailable in this local Python environment (`command not found`; `python3 -m ruff` and Python 3.12 module lookup both report no module named ruff)

## Browser/UAT Evidence
I fetched the live UAT page at `http://10.42.42.10:8111/?note_path=📥%20Inbox/Namnlös.md`, extracted the note source from the page, and rendered it through the fixed local renderer. Evidence after the fix:

- `table_count: 2`
- `raw_table_paragraph: False`
- `task_list_count: 1`
- `task_item_count: 4`
- `callout_body_count: 6`
- `callout_blockquote_split: False`
- `missing_image_count: 2`
- `frontmatter_leaked: False`

No governing GitHub issue was provided in the chat request, so this PR is not linked with a `Fixes #...` footer.