### PR TITLE
fix(orientation): filter leave-point cursor scope at DB level (#1465)

### DIFF
--- a/app/orientation/leave_point_cursor.py
+++ b/app/orientation/leave_point_cursor.py
@@ -304,9 +304,11 @@ def latest_leave_point_projection(
                 """
                 SELECT payload
                 FROM leave_point_trace_events
+                WHERE vault_id = ? AND channel = ?
                 ORDER BY captured_at DESC, id DESC
-                LIMIT 100
-                """
+                LIMIT 20
+                """,
+                (vault_id, channel),
             ).fetchall()
     except Exception:
         rows = []

--- a/app/orientation/leave_point_cursor.py
+++ b/app/orientation/leave_point_cursor.py
@@ -306,7 +306,7 @@ def latest_leave_point_projection(
                 FROM leave_point_trace_events
                 WHERE vault_id = ? AND channel = ?
                 ORDER BY captured_at DESC, id DESC
-                LIMIT 20
+                LIMIT 50
                 """,
                 (vault_id, channel),
             ).fetchall()

--- a/docs/adr/ADR-0008-leave-point-cursor.md
+++ b/docs/adr/ADR-0008-leave-point-cursor.md
@@ -1,9 +1,9 @@
-State: Proposed - decision recorded; no runtime behavior is claimed. This ADR gates downstream implementation issue #1455.
+State: Implemented — runtime behavior shipped in PR #1464 (merge commit 3fe0cc29). Scope-filter hardening applied in PR #1465.
 
 # ADR-0008: Leave-Point Cursor as Bounded Operational Trace
 
 **Date:** 2026-05-31
-**Status:** Proposed - decision recorded; docs-only
+**Status:** Implemented — shipped in PR #1464 (merge commit `3fe0cc29`)
 
 ---
 

--- a/tests/api/test_leave_point_cursor.py
+++ b/tests/api/test_leave_point_cursor.py
@@ -388,3 +388,43 @@ def test_cursor_does_not_emit_mutation_intents(
     data = _orientation(client, monkeypatch)
 
     assert data["mutation_intents"] == []
+
+
+def test_scope_filtered_query_finds_valid_cursor_after_many_cross_scope_rows() -> None:
+    # Regression: old code fetched LIMIT 100 globally then filtered in Python,
+    # which hid a valid in-scope cursor when >100 cross-scope rows existed first.
+    vault_root = Path(os.environ["VAULT_ROOT"])
+    _note(vault_root, "notes/cursor.md", "artifact-1")
+
+    base = datetime.now(timezone.utc) - timedelta(hours=1)
+    # Insert 110 cross-scope rows (wrong channel) with timestamps newer than the valid row.
+    for i in range(110):
+        capture_leave_point_cursor(
+            vault_id="vault-test",
+            channel="other-channel",
+            artifact_uuid=f"artifact-cross-{i}",
+            source_kind="artifact_activation",
+            source_ref_id="notes/cursor.md",
+            capture_reason="artifact_focus",
+            trace_id=f"trace-cross-{i}",
+            captured_at=base + timedelta(seconds=i + 1),
+        )
+
+    # Insert the valid in-scope row with the oldest timestamp among all rows.
+    _capture(
+        artifact_uuid="artifact-1",
+        vault_id="vault-test",
+        channel="test",
+        trace_id="trace-valid",
+        captured_at=base,
+    )
+
+    projection = latest_leave_point_projection(
+        vault_id="vault-test",
+        channel="test",
+        vault_root=vault_root,
+    )
+
+    assert projection.status == "present"
+    assert projection.artifact_ref.artifact_uuid == "artifact-1"
+    assert projection.source_ref.trace_id == "trace-valid"


### PR DESCRIPTION
## Summary

- SQL in `latest_leave_point_projection()` now filters `vault_id` and `channel` at DB level (`WHERE vault_id = ? AND channel = ?`), fixing the latent correctness issue where >100 cross-scope rows could hide a valid in-scope cursor from the Python-level filter.
- LIMIT set to 50 (not the original global 100, not the too-low 20): enough to recover past corrupt/expired in-scope rows while keeping I/O bounded.
- Regression test `test_scope_filtered_query_finds_valid_cursor_after_many_cross_scope_rows` inserts 110 cross-scope rows (wrong channel, newer timestamps) before the valid in-scope row and asserts `status == "present"`. Fails on the old behaviour, passes after the fix.
- ADR-0008 status updated from "Proposed — no runtime behavior is claimed" to "Implemented", referencing implementation PR #1464 and merge commit `3fe0cc29`.

## No-op confirmation

- No vault writes, receipt writes, memory writes, or orientation read-path writes added.
- Append-only semantics preserved — no UPDATE, UPSERT, INSERT OR REPLACE, or mutable current-row semantics.
- TTL semantics unchanged. Allowed fields unchanged. Capture semantics unchanged. Cursor architecture unchanged.

## Direct Repair

Type: code
Reason: Post-merge boundary audit of #1455 found `latest_leave_point_projection()` fetched 100 global rows then filtered vault_id/channel in Python — a valid in-scope cursor could be hidden when >100 cross-scope rows preceded it. Bounded single-function correctness fix with regression test; no architecture change.
Validation: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/api/test_leave_point_cursor.py tests/api/test_companion_orientation_api.py` — 28 passed; `ruff check` — clean; `docs_guard.py` — OK.
Issue required: no

## Test plan

- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/api/test_leave_point_cursor.py` — 22 passed
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/api/test_companion_orientation_api.py` — 6 passed
- [x] `ruff check` — All checks passed
- [x] `docs_guard.py` — Docs guard: OK
- [x] `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)