### PR TITLE
Fix companion UI test contract drift

### DIFF
--- a/tests/companion_ui/test_real_note_workspace_dev_server.py
+++ b/tests/companion_ui/test_real_note_workspace_dev_server.py
@@ -381,7 +381,7 @@ class TestRenderIndexHtml:
             fields=fields,
         )
 
-        assert 'data-testid="workspace-runtime-safety-strip"' in html
+        assert 'data-testid="workspace-primary-posture"' in html
         assert 'data-testid="workspace-runtime-channel"' in html
         assert "dev" in html
         assert "local-dev" in html

--- a/tests/companion_ui/test_resurface_mode_browser.py
+++ b/tests/companion_ui/test_resurface_mode_browser.py
@@ -139,7 +139,7 @@ def test_workspace_resurface_source_link_uses_logical_identifier(
     monkeypatch.setattr(
         companion,
         "evaluate_resurfacing_candidates",
-        lambda: ResurfacingEvaluation(
+        lambda *, signals=None: ResurfacingEvaluation(
             generated_at="2026-05-21T00:00:00Z",
             status_summary="resurfacing_candidates=1",
             candidates=[

--- a/tests/companion_ui/test_workspace_dev_chrome_gating.py
+++ b/tests/companion_ui/test_workspace_dev_chrome_gating.py
@@ -16,6 +16,13 @@ import re
 from companion_ui.workspace.serve_dev_page import handle_get, render_index_html
 
 
+class _OrientationClient:
+    def get(self, url: str, *, params: dict) -> dict:
+        assert url == "/api/companion/orientation"
+        assert params == {}
+        return {}
+
+
 def _page(*, diagnostics: bool = False) -> str:
     return render_index_html(
         api_base_url="http://127.0.0.1:18001",
@@ -81,9 +88,10 @@ def test_human_header_strip_is_not_gated_by_diagnostics():
 
 
 def test_handle_get_threads_diagnostics_query_param():
+    client = _OrientationClient()
     html = handle_get(
         query_string="diagnostics=1",
-        client=None,  # no note_path → no network
+        client=client,
         api_base_url="http://127.0.0.1:18001",
     )
     m = re.search(r"<body[^>]*>", html)
@@ -91,7 +99,7 @@ def test_handle_get_threads_diagnostics_query_param():
 
     html2 = handle_get(
         query_string="",
-        client=None,
+        client=client,
         api_base_url="http://127.0.0.1:18001",
     )
     m2 = re.search(r"<body[^>]*>", html2)


### PR DESCRIPTION
Fixes #1443

## Summary
Restore the Companion UI pytest lane by aligning stale tests with current workspace contracts. The runtime safety assertion now targets the shipped primary-posture surface, the resurface monkeypatch accepts the current `signals=` call shape, and the diagnostics chrome test uses a fake orientation client because no-note workspace loads now fetch re-entry orientation.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui/test_real_note_workspace_dev_server.py::TestRenderIndexHtml::test_renders_runtime_safety_strip_and_identity_pills tests/companion_ui/test_resurface_mode_browser.py::test_workspace_resurface_source_link_uses_logical_identifier` — 2 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/companion_ui` — 1260 passed, 1 skipped
- `/Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/ruff check app tests companion-ui/companion-app/companion_ui` — passed
- `python3 scripts/docs_guard.py` — Docs guard: OK
- `git diff --check` — passed

## Workflow Notes
- Dispatcher unavailable: `python3 -m app.dispatcher status --json` failed because the local Python environment is missing `yaml`; used GitHub-label fallback claim.
- Project status update unavailable during pickup: GraphQL quota was exhausted until 2026-05-31 23:19:22 CEST; `agent:ready` was removed via REST and verified.