### PR TITLE
Normalize vault browser metadata timestamps

### DIFF
--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -1027,8 +1027,8 @@ def _parse_note_artifact_metadata(body: str, *, path_derived_zone: str) -> dict:
         "trust": _str_or_none(fm.get("trust")),
         "origin": _str_or_none(fm.get("origin")),
         "source_ref": _str_or_none(fm.get("source_ref")),
-        "created": _str_or_none(fm.get("created")),
-        "updated": _str_or_none(fm.get("updated")),
+        "created": _timestamp_str_or_none(fm.get("created")),
+        "updated": _timestamp_str_or_none(fm.get("updated")),
         "frontmatter_valid": frontmatter_valid,
         "missing_required_fields": missing if not parse_error else list(_ARTIFACT_REQUIRED_FIELDS),
     }
@@ -1041,6 +1041,38 @@ def _str_or_none(val: object) -> str | None:
         return val.isoformat()
     s = str(val).strip()
     return s if s else None
+
+
+def _timestamp_str_or_none(val: object) -> str | None:
+    if val is None:
+        return None
+    if isinstance(val, datetime.datetime):
+        return _format_timestamp_datetime(val)
+    if isinstance(val, datetime.date):
+        return val.isoformat()
+    s = str(val).strip()
+    if not s:
+        return None
+    return _normalize_timestamp_string(s)
+
+
+def _normalize_timestamp_string(value: str) -> str:
+    if not any(separator in value for separator in ("T", "t", " ")):
+        return value
+    parse_value = f"{value[:-1]}+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.datetime.fromisoformat(parse_value)
+    except ValueError:
+        return value
+    return _format_timestamp_datetime(parsed)
+
+
+def _format_timestamp_datetime(value: datetime.datetime) -> str:
+    if value.tzinfo is None or value.utcoffset() is None:
+        return value.isoformat()
+    utc_value = value.astimezone(datetime.timezone.utc)
+    iso_value = utc_value.isoformat()
+    return f"{iso_value[:-6]}Z" if iso_value.endswith("+00:00") else iso_value
 
 
 def _zone_for_path(note_path: str) -> str:

--- a/docs/VAULT_BROWSER_CAPABILITY_CONTRACT.md
+++ b/docs/VAULT_BROWSER_CAPABILITY_CONTRACT.md
@@ -82,7 +82,7 @@ Required conceptual fields:
 - `trust` — trust tier (`assert` / `suggest` / `apply` per `docs/CONCEPTS/TRUST_SEMANTICS_CONTRACT.md`)
 - `origin` — provenance class (human-authored, agent-proposed, imported, mirrored)
 - `source_ref` — pointer to the canonical source artifact when applicable (`docs/CONCEPTS/ARTIFACT_PROJECTION_AND_SOURCE_CONTRACT.md`)
-- `created`, `updated` — ISO-8601 timestamps
+- `created`, `updated` — ISO-8601 timestamps; UTC timestamp values emitted by the browser API are normalized to `Z`
 
 The artifact's authoritative state is in Markdown/frontmatter where it exists. The browser may carry projection fields beyond this list, but every projection must be reconstructible from vault + governed mirrors.
 
@@ -374,6 +374,8 @@ For future implementation issues, this contract requires:
 The currently shipped Companion UI vault browser (from #1225 / PR #1239 and follow-ups) is the canonical realization of `Vault Browser MLP v0` as defined in §6. Alignment work for that baseline is tracked under #1252. Subsequent slices that introduce metadata, inspector, governed action, or receipt behavior extend this contract without weakening §6 or §8.
 
 **#1253 (normalized metadata read model):** The vault browser API response now includes normalized artifact metadata per note: `uuid`, `kind`, `zone` (frontmatter-preferred, path-derived fallback), `review_state`, `trust`, `origin`, `source_ref`, `created`, `updated`, `frontmatter_valid`, and `missing_required_fields`. Frontmatter is parsed server-side; clients never receive raw YAML. Missing or invalid frontmatter surfaces as explicit health state (`frontmatter_valid: false`), not a crash. Basic metadata badges (`kind`, `review_state`, `trust`) and health warnings render in the browser list view when present. This is an enabling change for §4.1 (`VaultArtifact` fields) without introducing filters (§4.3), inspector (§4.4+), or actions (§4.7) — those remain in subsequent slices.
+
+**#1469 (metadata timestamp serialization):** The vault browser metadata read model now normalizes `created` and `updated` timestamp output server-side. YAML-parsed datetime values and quoted ISO strings that carry UTC as `Z` or `+00:00` are accepted without client parsing and emitted in the browser API payload with UTC normalized to `Z`. Plain date values remain date strings, invalid timestamp strings are preserved as existing string metadata rather than rejected, malformed YAML/frontmatter health behavior remains unchanged, and vault frontmatter is not rewritten on read.
 
 **#1254 (deterministic metadata filters and badges):** The vault browser API now accepts deterministic server-side filter query params: `kind`, `zone`, `review_state`, `trust` (each multi-value, e.g. `?kind=human_note&kind=companion_note`). Active filters are returned in `active_filters` and composed with the existing `q` text search (AND semantics). Notes with a missing field value for an active filter are excluded. Filter chips are rendered in the Companion UI with `data-testid="vault-browser-filter-chip"`, `data-key`, `data-value`, `data-active` attributes. No opaque ranking or hidden heuristics. This enables §4.3 (`VaultQuery`) filter dimensions without introducing inspector, actions, or receipts.
 

--- a/tests/api/test_companion_vault_browser_api.py
+++ b/tests/api/test_companion_vault_browser_api.py
@@ -215,6 +215,62 @@ def test_vault_browser_pagination_is_read_only(tmp_path: Path, monkeypatch) -> N
     assert second.read_text(encoding="utf-8") == before[second]
 
 
+def test_vault_browser_datetime_frontmatter_serializes_stably(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+    note_path = tmp_path / "notes" / "timestamped.md"
+    note_path.parent.mkdir(parents=True, exist_ok=True)
+    note_path.write_text(
+        "---\n"
+        "title: Timestamped\n"
+        "uuid: timestamped-uuid\n"
+        "created: 2026-01-01T00:00:00Z\n"
+        "updated: 2026-01-02T03:04:05+00:00\n"
+        "---\n\n"
+        "Body.\n",
+        encoding="utf-8",
+    )
+
+    resp = TestClient(app).get("/api/companion/vault-browser")
+
+    assert resp.status_code == 200
+    note = next(note for note in resp.json()["notes"] if note["note_path"] == "notes/timestamped.md")
+    assert note["created"] == "2026-01-01T00:00:00Z"
+    assert note["updated"] == "2026-01-02T03:04:05Z"
+
+
+def test_vault_browser_accepts_iso_timestamp_variants(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+    note_path = tmp_path / "notes" / "timestamp-strings.md"
+    note_path.parent.mkdir(parents=True, exist_ok=True)
+    note_path.write_text(
+        "---\n"
+        "title: Timestamp Strings\n"
+        "uuid: timestamp-strings-uuid\n"
+        'created: "2026-01-01T00:00:00Z"\n'
+        'updated: "2026-01-02T03:04:05+00:00"\n'
+        "---\n\n"
+        "Body.\n",
+        encoding="utf-8",
+    )
+
+    resp = TestClient(app).get("/api/companion/vault-browser")
+
+    assert resp.status_code == 200
+    note = next(
+        note for note in resp.json()["notes"] if note["note_path"] == "notes/timestamp-strings.md"
+    )
+    assert note["created"] == "2026-01-01T00:00:00Z"
+    assert note["updated"] == "2026-01-02T03:04:05Z"
+
+
 def test_vault_browser_includes_receipts_from_outbox_projection(
     tmp_path: Path,
     monkeypatch,

--- a/tests/companion_ui/test_vault_browser_inspector.py
+++ b/tests/companion_ui/test_vault_browser_inspector.py
@@ -227,6 +227,21 @@ def test_inspector_renders_metadata_section_fields() -> None:
     assert 'data-testid="workspace-vault-browser-inspector-trust"' in html
 
 
+def test_inspector_renders_normalized_timestamp_fields() -> None:
+    """#1469: Inspector renders normalized timestamp strings from the server payload."""
+    note = _browser_note(
+        created="2026-01-01T00:00:00Z",
+        updated="2026-01-02T03:04:05Z",
+    )
+    browser = _vault_browser_payload(notes=[note])
+    _, _, html = _load_page(note_path="notes/current.md", browser_payload=browser)
+
+    assert 'data-testid="workspace-vault-browser-inspector-created"' in html
+    assert 'data-testid="workspace-vault-browser-inspector-updated"' in html
+    assert "2026-01-01T00:00:00Z" in html
+    assert "2026-01-02T03:04:05Z" in html
+
+
 # ---- AC3: health state visible and not hidden ----
 
 


### PR DESCRIPTION
Fixes #1469

## Summary
Normalize Vault Browser `created` and `updated` metadata timestamps server-side so YAML-parsed UTC datetimes and quoted ISO UTC strings emit stable `Z` payload values without writing back to vault frontmatter.

## Acceptance Criteria
- YAML-parsed datetime frontmatter values emit stable API timestamp strings normalized to `Z`.
- Quoted ISO timestamp strings using `Z` and `+00:00` remain accepted and normalize without crashing.
- The Companion UI inspector renders timestamp strings from the normalized server payload without YAML/date parsing.
- `docs/VAULT_BROWSER_CAPABILITY_CONTRACT.md` records the timestamp output posture in §4.1 and shipped behavior in §11.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/python -m pytest -q tests/api/test_companion_vault_browser_api.py tests/companion_ui/test_vault_browser_inspector.py` — 31 passed
- `/Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/python -m ruff check app tests companion-ui/companion-app/companion_ui` — passed
- `python3 scripts/docs_guard.py` — OK
- `git diff --check` — passed

## Workflow Notes
- Dispatcher fallback: `/Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/python -m app.dispatcher status --json` reported `db_exists=false`, so claim used `scripts/issue_pickup_claim.sh --issue 1469 --repo RasmusTho/agentic-pkm-mvp`; Project status was set to `In Progress` via `scripts/reconcile_project_status.py`.