### PR TITLE
Add Panel checkbox projection runtime

### DIFF
--- a/app/agents/panel/agent.py
+++ b/app/agents/panel/agent.py
@@ -15,11 +15,11 @@ from .intents import PanelIntent, enrich_panel_intents
 from .parser import parse_panel
 from .schema import PanelState
 from .writeback import (
-    ACTION_PATTERN as _ACTION_PATTERN,
     AI_STATUS_HEADER as _AI_STATUS_HEADER,
     EXECUTED_FALLBACK as _EXECUTED_FALLBACK,
     MAX_RECEIPTS as _MAX_RECEIPTS,
     annotate_action_ids as _annotate_action_ids,
+    parse_action_line as _parse_action_line,
     remove_actions_from_markdown as _remove_actions_from_markdown,
     stable_action_id as _stable_action_id,
     write_receipts as _write_receipts,
@@ -109,14 +109,14 @@ def _existing_suggested_action_checks(panel: list[str]) -> tuple[dict[str, bool]
     default_ids = {_stable_action_id(label) for label in _SUGGESTED_ACTIONS}
 
     for raw in panel[start:end]:
-        match = _ACTION_PATTERN.match(raw)
-        if not match:
+        parsed = _parse_action_line(raw)
+        if parsed is None:
             continue
-        checked = (match.group(2) or "").strip().lower() == "x"
-        label = (match.group(3) or "").strip()
+        checked = parsed.checked
+        label = parsed.label.strip()
         if not label:
             continue
-        action_id = (match.group(5) or "").strip() or _stable_action_id(label)
+        action_id = (parsed.action_id or "").strip() or _stable_action_id(label)
 
         existing_by_id[action_id] = checked
         existing_by_label[label] = checked

--- a/app/agents/panel/parser.py
+++ b/app/agents/panel/parser.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import re
 from typing import Iterable, Literal
+
+from app.agents.panel.writeback import parse_action_line
 
 from .schema import PanelAction, PanelLogEntry, PanelState
 
@@ -16,11 +17,6 @@ _LABEL_PREFIXES = {
     "actions": ("actions", "åtgärder"),
     "logs": ("log", "logg"),
 }
-_ACTION_PATTERN = re.compile(
-    r"^- \[( |x|X)\]\s*(.*?)"
-    r"(?:\s*<!--\s*ai:id=([A-Za-z0-9_.-]+)\s*-->)?"
-    r"(?:\s*<!--\s*ai:proposed=([A-Za-z0-9_.-]+)\s*-->)?\s*$"
-)
 
 
 def parse_panel(markdown: str) -> PanelState:
@@ -82,7 +78,7 @@ def _collect_panel_sections_from_lines(lines: Iterable[str]) -> dict[str, list[s
         if stripped.startswith("## ") and _is_non_panel_heading(lowered):
             current = None
             continue
-        if _ACTION_PATTERN.match(stripped):
+        if parse_action_line(stripped):
             sections["actions"].append(raw_line.rstrip())
             continue
         if current:
@@ -91,7 +87,7 @@ def _collect_panel_sections_from_lines(lines: Iterable[str]) -> dict[str, list[s
     if not sections["actions"]:
         for raw_line in lines:
             stripped = raw_line.strip()
-            if _ACTION_PATTERN.match(stripped):
+            if parse_action_line(stripped):
                 sections["actions"].append(raw_line.rstrip())
     return sections
 
@@ -164,20 +160,15 @@ def _is_non_panel_heading(line: str) -> bool:
 
 
 def _line_to_action(line: str) -> PanelAction | None:
-    match = _ACTION_PATTERN.match(line.strip())
-    if not match:
-        return None
-    checked = match.group(1).lower() == "x"
-    text = match.group(2).strip()
-    action_id = match.group(3) or None
-    proposal_pending = match.group(4) is not None
-    if not text:
+    parsed = parse_action_line(line.strip())
+    if parsed is None:
         return None
     return PanelAction(
-        checked=checked,
-        text=text,
-        action_id=action_id,
-        proposal_pending=proposal_pending,
+        checked=parsed.checked,
+        text=parsed.label,
+        action_id=parsed.action_id,
+        option_id=parsed.option_id,
+        proposal_pending=parsed.proposal_marker is not None,
     )
 
 
@@ -201,7 +192,7 @@ def _fallback_instruction(lines: list[str]) -> str:
                 if remainder:
                     return remainder
             continue
-        if _ACTION_PATTERN.match(stripped):
+        if parse_action_line(stripped):
             continue
         if stripped.startswith("## ") and _is_non_panel_heading(stripped.lower()):
             continue

--- a/app/agents/panel/schema.py
+++ b/app/agents/panel/schema.py
@@ -7,6 +7,7 @@ class PanelAction(BaseModel):
     checked: bool = False
     text: str
     action_id: str | None = None
+    option_id: str | None = None
     proposal_pending: bool = False
 
 

--- a/app/agents/panel/writeback.py
+++ b/app/agents/panel/writeback.py
@@ -7,14 +7,17 @@ from __future__ import annotations
 
 import hashlib
 import re
+from dataclasses import dataclass
 from typing import Iterable
+from uuid import uuid4
 
 from app.objects import DomainObject, ObjectStore
 
 ACTION_PATTERN = re.compile(
-    r"^(\s*-\s*\[( |x|X)\]\s*)(.*?)"
-    r"(\s*<!--\s*ai:id=([A-Za-z0-9_.-]+)\s*-->)?"
-    r"(\s*<!--\s*ai:proposed=([A-Za-z0-9_.-]+)\s*-->)?\s*$"
+    r"^(\s*-\s*\[( |x|X)\]\s*)(.*?)\s*$"
+)
+AI_METADATA_PATTERN = re.compile(
+    r"<!--\s*ai:(option_id|id|proposed)=([A-Za-z0-9_.-]+)\s*-->"
 )
 AI_STATUS_HEADER = "> [!info]- AI status"
 MAX_RECEIPTS = 20
@@ -23,10 +26,63 @@ MAX_RECEIPTS = 20
 EXECUTED_FALLBACK: dict[str, set[str]] = {}
 
 
+@dataclass(frozen=True)
+class ParsedActionLine:
+    prefix: str
+    checked: bool
+    label: str
+    action_id: str | None = None
+    option_id: str | None = None
+    proposal_marker: str | None = None
+    metadata_comments: tuple[str, ...] = ()
+
+
 def stable_action_id(text: str) -> str:
     """Deterministic short hash for a checkbox label."""
     digest = hashlib.sha1(text.strip().encode("utf-8")).hexdigest()
     return digest[:8]
+
+
+def new_option_id() -> str:
+    """Generate a durable Panel option identity for newly written proposals."""
+    return f"opt_{uuid4().hex}"
+
+
+def parse_action_line(line: str) -> ParsedActionLine | None:
+    """Parse a Panel checkbox line and strip known AI metadata from the label.
+
+    Supports ``ai:option_id``, ``ai:id``, and ``ai:proposed`` comments in any
+    order. Unknown comments remain part of the rendered/action label.
+    """
+    match = ACTION_PATTERN.match(line)
+    if not match:
+        return None
+    rest = match.group(3) or ""
+    metadata: dict[str, str] = {}
+    comments: list[str] = []
+    for meta_match in AI_METADATA_PATTERN.finditer(rest):
+        key = meta_match.group(1)
+        value = meta_match.group(2)
+        metadata[key] = value
+        comments.append(meta_match.group(0))
+    label = AI_METADATA_PATTERN.sub("", rest).strip()
+    if not label:
+        return None
+    return ParsedActionLine(
+        prefix=match.group(1),
+        checked=(match.group(2) or "").lower() == "x",
+        label=label,
+        action_id=metadata.get("id"),
+        option_id=metadata.get("option_id"),
+        proposal_marker=metadata.get("proposed"),
+        metadata_comments=tuple(comments),
+    )
+
+
+def _format_action_line(parsed: ParsedActionLine, metadata_comments: Iterable[str]) -> str:
+    comments = [comment for comment in metadata_comments if comment]
+    suffix = f" {' '.join(comments)}" if comments else ""
+    return f"{parsed.prefix}{parsed.label}{suffix}"
 
 
 def annotate_action_ids(markdown: str) -> str:
@@ -34,17 +90,16 @@ def annotate_action_ids(markdown: str) -> str:
     lines = markdown.splitlines()
     changed = False
     for idx, line in enumerate(lines):
-        match = ACTION_PATTERN.match(line)
-        if not match:
+        parsed = parse_action_line(line)
+        if parsed is None:
             continue
-        label = (match.group(3) or "").strip()
-        action_id = match.group(5)
-        proposed_marker = match.group(6) or ""
-        if action_id:
+        if parsed.action_id:
             continue
-        action_id = stable_action_id(label)
-        prefix = match.group(1)
-        lines[idx] = f"{prefix}{label} <!--ai:id={action_id}-->{proposed_marker}"
+        action_id = stable_action_id(parsed.label)
+        lines[idx] = _format_action_line(
+            parsed,
+            (f"<!--ai:id={action_id}-->", *parsed.metadata_comments),
+        )
         changed = True
     if not changed:
         return markdown
@@ -106,11 +161,9 @@ def remove_actions_from_markdown(markdown: str, action_ids: set[str]) -> str:
         return markdown
     result: list[str] = []
     for line in markdown.splitlines():
-        match = ACTION_PATTERN.match(line)
-        if match:
-            candidate_id = match.group(5)
-            if candidate_id and candidate_id in action_ids:
-                continue
+        parsed = parse_action_line(line)
+        if parsed and parsed.action_id and parsed.action_id in action_ids:
+            continue
         result.append(line)
     return "\n".join(result)
 
@@ -149,10 +202,14 @@ def upsert_executed_ids(note_id: str, action_ids: Iterable[str]) -> None:
 
 __all__ = [
     "ACTION_PATTERN",
+    "AI_METADATA_PATTERN",
     "AI_STATUS_HEADER",
     "EXECUTED_FALLBACK",
     "MAX_RECEIPTS",
+    "ParsedActionLine",
     "annotate_action_ids",
+    "new_option_id",
+    "parse_action_line",
     "remove_actions_from_markdown",
     "stable_action_id",
     "upsert_executed_ids",

--- a/app/agents/panel_agent/parser.py
+++ b/app/agents/panel_agent/parser.py
@@ -1,22 +1,16 @@
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
 from typing import Iterable, Literal
 
 from app.agents.panel.filters import is_ai_fence
+from app.agents.panel.writeback import parse_action_line
 
 _SECTION_MAP: dict[str, Literal["instruction", "actions", "log"]] = {
     "ai-instruktion": "instruction",
     "ai-åtgärder": "actions",
     "ai-logg": "log",
 }
-_ACTION_PATTERN = re.compile(
-    r"^- \[( |x|X)\]\s*(.*?)"
-    r"(?:\s*<!--\s*ai:id=([A-Za-z0-9_.-]+)\s*-->)?"
-    r"(?:\s*<!--\s*ai:proposed=([A-Za-z0-9_.-]+)\s*-->)?\s*$"
-)
-
 
 @dataclass
 class PanelBlock:
@@ -29,6 +23,7 @@ class ParsedAction:
     label: str
     checked: bool
     action_id: str | None = None
+    option_id: str | None = None
     proposal_pending: bool = False
 
 
@@ -97,20 +92,15 @@ def _match_section(line: str) -> Literal["instruction", "actions", "log"] | None
 
 
 def _parse_action(line: str) -> ParsedAction | None:
-    match = _ACTION_PATTERN.match(line.strip())
-    if not match:
-        return None
-    checked = match.group(1).lower() == "x"
-    label = match.group(2).strip()
-    action_id = match.group(3) or None
-    proposal_pending = match.group(4) is not None
-    if not label:
+    parsed = parse_action_line(line.strip())
+    if parsed is None:
         return None
     return ParsedAction(
-        label=label,
-        checked=checked,
-        action_id=action_id,
-        proposal_pending=proposal_pending,
+        label=parsed.label,
+        checked=parsed.checked,
+        action_id=parsed.action_id,
+        option_id=parsed.option_id,
+        proposal_pending=parsed.proposal_marker is not None,
     )
 
 

--- a/app/agents/panel_agent/runtime.py
+++ b/app/agents/panel_agent/runtime.py
@@ -5,12 +5,13 @@ import logging
 import os
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Callable, Iterable
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from app.agents.panel.writeback import (
     annotate_action_ids,
+    new_option_id,
     remove_actions_from_markdown,
     stable_action_id,
     upsert_executed_ids,
@@ -289,7 +290,12 @@ def _existing_panel_proposal_labels(markdown: str) -> set[str]:
     return {action.text.strip() for action in parsed.actions if action.text.strip()}
 
 
-def _write_proposals_to_panel(markdown: str, proposed_labels: list[tuple[str, str]]) -> str:
+def _write_proposals_to_panel(
+    markdown: str,
+    proposed_labels: list[tuple[str, str]],
+    *,
+    option_id_factory: Callable[[], str] | None = None,
+) -> str:
     """Write proposed (unchecked) actions into the AI-åtgärder section of a panel.
 
     Finds the correct panel block and inserts proposals after existing checkboxes
@@ -327,6 +333,7 @@ def _write_proposals_to_panel(markdown: str, proposed_labels: list[tuple[str, st
         existing_labels = set()
 
     proposal_lines = []
+    make_option_id = option_id_factory or new_option_id
     for action_id, label in proposed_labels:
         label_text = label.strip()
         stable_id = stable_action_id(label_text)
@@ -336,8 +343,9 @@ def _write_proposals_to_panel(markdown: str, proposed_labels: list[tuple[str, st
         # parser can re-surface them as `proposal_pending=True` on subsequent
         # passes. This prevents the LLM from auto-selecting an unchecked
         # proposed line on a later pass and bypassing the human gate (#979).
+        option_id = make_option_id()
         proposal_lines.append(
-            f"- [ ] {label_text} <!--ai:id={stable_id}--> <!--ai:proposed=979-->"
+            f"- [ ] {label_text} <!--ai:option_id={option_id}--> <!--ai:id={stable_id}--> <!--ai:proposed=979-->"
         )
 
     if not proposal_lines:

--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -24,6 +24,10 @@ from app.knowledge.write_ops import write_note_from_absolute
 from app.observability.status_service import OrientationSignals, get_orientation_signals
 from app.orientation.leave_point_cursor import latest_leave_point_projection
 from app.orientation.runtime import build_orientation_frame
+from app.panel.checkbox_projection import (
+    PanelSelectableOption,
+    extract_panel_selectable_options,
+)
 from app.receipts.artifact_receipts import ArtifactReceiptTarget, receipts_for_artifacts
 from app.resurfacing.runtime import evaluate_resurfacing_candidates
 from app.services.artifact_identity import resolve_note_artifact_identity
@@ -107,6 +111,7 @@ class PanelState(BaseModel):
     latest_receipt_outcome: str | None
     blocked_reason: str | None
     no_match_reason: str | None
+    selectable_options: list[PanelSelectableOption] = Field(default_factory=list)
 
 
 class SuggestionsState(BaseModel):
@@ -625,8 +630,13 @@ def _proposal_count_for_artifact(artifact_id: str | None) -> int:
     return sum(1 for proposal in proposals.values() if proposal.artifact_id == artifact_id)
 
 
-def _panel_state(artifact_id: str | None) -> PanelState:
+def _panel_state(
+    artifact_id: str | None,
+    selectable_options: list[PanelSelectableOption] | None = None,
+) -> PanelState:
+    options = list(selectable_options or [])
     proposal_count = _proposal_count_for_artifact(artifact_id)
+    selectable_count = sum(1 for option in options if option.selectable)
     cache = getattr(confirm_module._idempotency_store, "_cache", {})
     relevant = [resp for resp in cache.values() if resp.artifact_id == artifact_id]
     latest = relevant[-1] if relevant else None
@@ -638,7 +648,7 @@ def _panel_state(artifact_id: str | None) -> PanelState:
             blocked_reason = latest.block_reason.message
     if blocked_reason:
         state = "blocked"
-    elif proposal_count:
+    elif proposal_count or selectable_count:
         state = "proposals-staged"
     elif latest_outcome == "success":
         state = "receipt-displayed"
@@ -646,11 +656,12 @@ def _panel_state(artifact_id: str | None) -> PanelState:
         state = "idle"
     return PanelState(
         state=state,
-        proposal_count=proposal_count,
+        proposal_count=proposal_count + selectable_count,
         receipt_count=len(relevant),
         latest_receipt_outcome=latest_outcome,
         blocked_reason=blocked_reason,
         no_match_reason=None,
+        selectable_options=options,
     )
 
 
@@ -1794,6 +1805,16 @@ def read_companion_workspace(
     )
     orientation_signals = get_orientation_signals()
 
+    content_hash = _content_hash(body)
+    selectable_options: list[PanelSelectableOption] = []
+    if identity.artifact_id:
+        selectable_options = extract_panel_selectable_options(
+            body,
+            artifact_id=identity.artifact_id,
+            note_path=safe_note_path,
+            content_hash=content_hash,
+        )
+
     return WorkspaceStateResponse(
         artifact=ArtifactState(
             artifact_id=identity.artifact_id,
@@ -1801,7 +1822,7 @@ def read_companion_workspace(
             note_path=safe_note_path,
             title=_extract_title(body, fallback=artifact_path.stem),
             body=body,
-            content_hash=_content_hash(body),
+            content_hash=content_hash,
             identity_source=identity.identity_source,
             identity_state=identity.identity_state,
             companion_of=identity.companion_of,
@@ -1816,7 +1837,7 @@ def read_companion_workspace(
             resurface=_resurface_state(safe_note_path, signals=orientation_signals),
         ),
         canvas=_canvas_state(safe_note_path, vault_root, canvas_enabled),
-        panel=_panel_state(identity.artifact_id),
+        panel=_panel_state(identity.artifact_id, selectable_options=selectable_options),
         suggestions=SuggestionsState(),
         guards=GuardState(
             canvas_enabled=canvas_enabled,

--- a/app/api/routes/panel.py
+++ b/app/api/routes/panel.py
@@ -1,9 +1,12 @@
-"""Panel confirmation API route.
+"""Panel confirmation API routes.
 
 POST /api/panel/confirm — submits a user's explicit confirm or reject decision
 for a staged Panel proposal. The runtime owns policy evaluation, WriteGuard,
 idempotency, execution, receipts, and event emission. The Companion UI must
 not write vault files directly.
+
+POST /api/panel/checkbox-projection — source-backed read-mode projection of a
+runtime-declared Panel checkbox option to the canonical checked Markdown state.
 """
 
 from __future__ import annotations
@@ -11,6 +14,12 @@ from __future__ import annotations
 from fastapi import APIRouter, HTTPException
 
 import app.panel.confirmation as confirm_module
+import app.panel.checkbox_projection as checkbox_projection_module
+from app.panel.checkbox_projection import (
+    CheckboxProjectionHTTPError,
+    CheckboxProjectionRequest,
+    CheckboxProjectionResponse,
+)
 from app.panel.confirmation import (
     ConfirmRequest,
     ConfirmResponse,
@@ -34,3 +43,16 @@ async def panel_confirm(request: ConfirmRequest) -> ConfirmResponse:
         raise HTTPException(status_code=422, detail=str(exc))
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc))
+
+
+@router.post("/checkbox-projection", response_model=CheckboxProjectionResponse)
+async def panel_checkbox_projection(
+    request: CheckboxProjectionRequest,
+) -> CheckboxProjectionResponse:
+    try:
+        return checkbox_projection_module._service.project(request)
+    except CheckboxProjectionHTTPError as exc:
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail=exc.response.model_dump(mode="json"),
+        ) from exc

--- a/app/panel/checkbox_projection.py
+++ b/app/panel/checkbox_projection.py
@@ -1,0 +1,527 @@
+"""Runtime-mediated projection of Panel checkbox confirmations.
+
+The browser never writes vault Markdown directly. This service validates the
+current note source, projects the canonical ``- [x]`` checkbox state through
+the governed backend writer path, then lets the normal Panel runtime observe
+that checked state.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import threading
+from pathlib import Path, PurePosixPath
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+from app.agents.panel.parser import is_ai_fence, parse_panel
+from app.agents.panel.writeback import parse_action_line, stable_action_id
+from app.agents.panel_agent.execution import refresh_panel_note_object, run_panel_note_execution
+from app.api.routes.artifacts import _content_hash
+from app.config.paths import resolve_vault_root
+from app.knowledge.write_ops import write_note_from_absolute
+from app.services.artifact_identity import resolve_note_artifact_identity
+from app.write_guard import DEFAULT_WRITE_GUARD, WriteGuard, WritesBlockedError
+
+
+ProjectionStatus = Literal[
+    "projected",
+    "already_projected",
+    "queued",
+    "executed",
+    "blocked",
+    "stale",
+    "not_found",
+    "not_selectable",
+    "failed",
+]
+
+_CODE_FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})")
+_CHECKBOX_MARK_RE = re.compile(r"^(\s*-\s*\[)( )(\]\s*.*)$")
+
+
+class SourceRange(BaseModel):
+    start_line: int = Field(ge=0)
+    end_line: int = Field(ge=0, description="Exclusive 0-based end line.")
+
+
+class PanelSelectableOption(BaseModel):
+    artifact_id: str
+    note_path: str
+    panel_id: str
+    option_id: str
+    action_id: str
+    label: str
+    checked: bool
+    proposal_pending: bool
+    source_range: SourceRange
+    source_hash: str
+    content_hash: str
+    selectable: bool
+
+
+class CheckboxProjectionRequest(BaseModel):
+    artifact_id: str = Field(min_length=1)
+    note_path: str = Field(min_length=1)
+    panel_id: str = Field(min_length=1)
+    option_id: str = Field(min_length=1)
+    expected_content_hash: str = Field(min_length=1)
+    expected_source_hash: str = Field(min_length=1)
+    idempotency_key: str = Field(min_length=1)
+
+    @field_validator(
+        "artifact_id",
+        "note_path",
+        "panel_id",
+        "option_id",
+        "expected_content_hash",
+        "expected_source_hash",
+        "idempotency_key",
+        mode="before",
+    )
+    @classmethod
+    def _strip_value(cls, value: object) -> object:
+        return value.strip() if isinstance(value, str) else value
+
+
+class CheckboxProjectionResponse(BaseModel):
+    status: ProjectionStatus
+    artifact_id: str
+    note_path: str
+    panel_id: str
+    option_id: str
+    content_hash_before: str
+    content_hash_after: str
+    receipt: dict | None = None
+    block_reason: str | None = None
+    idempotency_key: str
+
+
+class CheckboxProjectionHTTPError(Exception):
+    def __init__(self, status_code: int, response: CheckboxProjectionResponse) -> None:
+        self.status_code = status_code
+        self.response = response
+        super().__init__(response.status)
+
+
+class CheckboxProjectionIdempotencyStore:
+    def __init__(self) -> None:
+        self._cache: dict[str, CheckboxProjectionResponse] = {}
+
+    def get(self, key: str) -> CheckboxProjectionResponse | None:
+        return self._cache.get(key)
+
+    def set(self, key: str, response: CheckboxProjectionResponse) -> None:
+        self._cache[key] = response
+
+    def clear(self) -> None:
+        self._cache.clear()
+
+
+def _source_line_hash(source_line: str) -> str:
+    return hashlib.sha256(source_line.encode("utf-8")).hexdigest()
+
+
+def _source_line_without_newline(raw_line: str) -> str:
+    return raw_line.rstrip("\r\n")
+
+
+def _valid_note_path(note_path_raw: str) -> str | None:
+    note_path = (note_path_raw or "").split("#", 1)[0]
+    candidate = PurePosixPath(note_path)
+    if (
+        not note_path
+        or note_path.startswith("/")
+        or ".." in candidate.parts
+        or candidate.as_posix() in {"", "."}
+        or not candidate.as_posix().endswith(".md")
+    ):
+        return None
+    return candidate.as_posix()
+
+
+def _vault_contained_abs_path(vault_root: Path, safe_note_path: str) -> Path | None:
+    root_real = os.path.realpath(vault_root)
+    target_real = os.path.realpath(os.path.join(root_real, safe_note_path))
+    if target_real != root_real and not target_real.startswith(root_real + os.sep):
+        return None
+    return Path(target_real)
+
+
+def _section_for_line(line: str) -> Literal["instruction", "actions", "logs"] | None:
+    stripped = line.strip().lower()
+    if stripped.startswith(("## ai-åtgärder", "### ai-åtgärder")):
+        return "actions"
+    if stripped.startswith(("## ai-instruktion", "### ai-instruktion")):
+        return "instruction"
+    if stripped.startswith(("## ai-logg", "### ai-logg")):
+        return "logs"
+    if stripped.startswith(("actions:", "åtgärder:")):
+        return "actions"
+    if stripped.startswith(("instruction:", "instruktion:")):
+        return "instruction"
+    if stripped.startswith(("log:", "logg:")):
+        return "logs"
+    return None
+
+
+def _panel_ranges(markdown: str) -> list[tuple[str, int, int]]:
+    parsed = parse_panel(markdown)
+    ranges: list[tuple[str, int, int]] = []
+    for index, (start, end) in enumerate(parsed.spans, start=1):
+        ranges.append((f"panel-{index}", start, end))
+    return ranges
+
+
+def extract_panel_selectable_options(
+    markdown: str,
+    *,
+    artifact_id: str,
+    note_path: str,
+    content_hash: str | None = None,
+) -> list[PanelSelectableOption]:
+    """Return source-backed Panel checkbox options eligible for UI projection.
+
+    Options without an explicit durable ``ai:option_id`` marker are omitted.
+    Ordinary Markdown tasks, code-block tasks, receipt checkboxes, and tasks
+    outside a valid Panel ``AI-åtgärder`` section are not returned.
+    """
+    lines = markdown.splitlines()
+    current_content_hash = content_hash or _content_hash(markdown)
+    options: list[PanelSelectableOption] = []
+
+    for panel_id, start, end in _panel_ranges(markdown):
+        current_section: Literal["instruction", "actions", "logs"] | None = None
+        code_fence: str | None = None
+        lower_bound = max(0, start)
+        upper_bound = min(len(lines) - 1, end)
+        for line_index in range(lower_bound, upper_bound + 1):
+            raw_line = lines[line_index]
+            if is_ai_fence(raw_line):
+                continue
+            fence = _CODE_FENCE_RE.match(raw_line)
+            if fence:
+                marker = fence.group(1)[0]
+                if code_fence == marker:
+                    code_fence = None
+                elif code_fence is None:
+                    code_fence = marker
+                continue
+            if code_fence is not None:
+                continue
+            section = _section_for_line(raw_line)
+            if section is not None:
+                current_section = section
+                continue
+            if current_section != "actions":
+                continue
+            parsed = parse_action_line(raw_line)
+            if parsed is None or parsed.option_id is None:
+                continue
+            action_id = parsed.action_id or stable_action_id(parsed.label)
+            proposal_pending = parsed.proposal_marker is not None
+            options.append(
+                PanelSelectableOption(
+                    artifact_id=artifact_id,
+                    note_path=note_path,
+                    panel_id=panel_id,
+                    option_id=parsed.option_id,
+                    action_id=action_id,
+                    label=parsed.label,
+                    checked=parsed.checked,
+                    proposal_pending=proposal_pending,
+                    source_range=SourceRange(start_line=line_index, end_line=line_index + 1),
+                    source_hash=_source_line_hash(raw_line),
+                    content_hash=current_content_hash,
+                    selectable=bool(proposal_pending and not parsed.checked),
+                )
+            )
+    return options
+
+
+def _project_checked(markdown: str, *, line_index: int) -> str | None:
+    lines = markdown.splitlines(keepends=True)
+    if line_index < 0 or line_index >= len(lines):
+        return None
+    line = lines[line_index]
+    source_line = _source_line_without_newline(line)
+    newline = line[len(source_line):]
+    match = _CHECKBOX_MARK_RE.match(source_line)
+    if not match:
+        return None
+    lines[line_index] = f"{match.group(1)}x{match.group(3)}{newline}"
+    return "".join(lines)
+
+
+class CheckboxProjectionService:
+    def __init__(
+        self,
+        *,
+        idempotency_store: CheckboxProjectionIdempotencyStore | None = None,
+        write_guard: WriteGuard | None = None,
+    ) -> None:
+        self._idempotency = idempotency_store or CheckboxProjectionIdempotencyStore()
+        self._guard = write_guard or DEFAULT_WRITE_GUARD
+        self._locks: dict[str, threading.Lock] = {}
+        self._locks_guard = threading.Lock()
+
+    def _lock_for_note(self, safe_note_path: str) -> threading.Lock:
+        with self._locks_guard:
+            if safe_note_path not in self._locks:
+                self._locks[safe_note_path] = threading.Lock()
+            return self._locks[safe_note_path]
+
+    def project(self, request: CheckboxProjectionRequest) -> CheckboxProjectionResponse:
+        cached = self._idempotency.get(request.idempotency_key)
+        if cached is not None:
+            return cached
+
+        safe_note_path = _valid_note_path(request.note_path)
+        if safe_note_path is None:
+            response = self._response(
+                request,
+                status="not_selectable",
+                note_path=request.note_path,
+                before="",
+                after="",
+                block_reason="invalid_note_path",
+            )
+            raise CheckboxProjectionHTTPError(422, response)
+
+        lock = self._lock_for_note(safe_note_path)
+        with lock:
+            cached = self._idempotency.get(request.idempotency_key)
+            if cached is not None:
+                return cached
+            return self._project_locked(request, safe_note_path)
+
+    def _project_locked(
+        self,
+        request: CheckboxProjectionRequest,
+        safe_note_path: str,
+    ) -> CheckboxProjectionResponse:
+        vault_root = resolve_vault_root()
+        note_path = _vault_contained_abs_path(vault_root, safe_note_path)
+        if note_path is None or not note_path.is_file():
+            response = self._response(
+                request,
+                status="not_found",
+                note_path=safe_note_path,
+                before="",
+                after="",
+                block_reason="note_not_found",
+            )
+            raise CheckboxProjectionHTTPError(404, response)
+
+        current = note_path.read_text(encoding="utf-8")
+        content_hash_before = _content_hash(current)
+        if content_hash_before != request.expected_content_hash:
+            response = self._response(
+                request,
+                status="stale",
+                note_path=safe_note_path,
+                before=content_hash_before,
+                after=content_hash_before,
+                block_reason="content_hash_mismatch",
+            )
+            raise CheckboxProjectionHTTPError(409, response)
+
+        identity = resolve_note_artifact_identity(
+            artifact_path=note_path,
+            vault_root=vault_root,
+            safe_note_path=safe_note_path,
+            body=current,
+            heal_missing_uuid=False,
+        )
+        if identity.artifact_id != request.artifact_id:
+            response = self._response(
+                request,
+                status="not_found",
+                note_path=safe_note_path,
+                before=content_hash_before,
+                after=content_hash_before,
+                block_reason="artifact_mismatch",
+            )
+            raise CheckboxProjectionHTTPError(404, response)
+
+        options = extract_panel_selectable_options(
+            current,
+            artifact_id=request.artifact_id,
+            note_path=safe_note_path,
+            content_hash=content_hash_before,
+        )
+        matches = [
+            option
+            for option in options
+            if option.panel_id == request.panel_id and option.option_id == request.option_id
+        ]
+        if len(matches) != 1:
+            response = self._response(
+                request,
+                status="not_found",
+                note_path=safe_note_path,
+                before=content_hash_before,
+                after=content_hash_before,
+                block_reason="option_not_found_or_ambiguous",
+            )
+            raise CheckboxProjectionHTTPError(404, response)
+        option = matches[0]
+
+        if option.source_hash != request.expected_source_hash:
+            response = self._response(
+                request,
+                status="stale",
+                note_path=safe_note_path,
+                before=content_hash_before,
+                after=content_hash_before,
+                block_reason="source_hash_mismatch",
+            )
+            raise CheckboxProjectionHTTPError(409, response)
+
+        if option.checked:
+            response = self._response(
+                request,
+                status="already_projected",
+                note_path=safe_note_path,
+                before=content_hash_before,
+                after=content_hash_before,
+            )
+            self._idempotency.set(request.idempotency_key, response)
+            return response
+
+        if not option.selectable:
+            response = self._response(
+                request,
+                status="not_selectable",
+                note_path=safe_note_path,
+                before=content_hash_before,
+                after=content_hash_before,
+                block_reason="option_not_pending_or_selectable",
+            )
+            raise CheckboxProjectionHTTPError(422, response)
+
+        try:
+            self._guard.assert_writes_allowed("panel.checkbox_projection")
+        except WritesBlockedError as exc:
+            response = self._response(
+                request,
+                status="blocked",
+                note_path=safe_note_path,
+                before=content_hash_before,
+                after=content_hash_before,
+                block_reason=str(exc),
+            )
+            self._idempotency.set(request.idempotency_key, response)
+            return response
+
+        projected = _project_checked(current, line_index=option.source_range.start_line)
+        if projected is None:
+            response = self._response(
+                request,
+                status="stale",
+                note_path=safe_note_path,
+                before=content_hash_before,
+                after=content_hash_before,
+                block_reason="source_line_no_longer_projectable",
+            )
+            raise CheckboxProjectionHTTPError(409, response)
+
+        write_note_from_absolute(note_path, projected, vault_root=vault_root)
+        written = note_path.read_text(encoding="utf-8")
+        content_hash_after = _content_hash(written)
+
+        response = self._execute_or_projected(
+            request,
+            note_path=note_path,
+            safe_note_path=safe_note_path,
+            raw_text=written,
+            content_hash_before=content_hash_before,
+            content_hash_after=content_hash_after,
+        )
+        self._idempotency.set(request.idempotency_key, response)
+        return response
+
+    def _execute_or_projected(
+        self,
+        request: CheckboxProjectionRequest,
+        *,
+        note_path: Path,
+        safe_note_path: str,
+        raw_text: str,
+        content_hash_before: str,
+        content_hash_after: str,
+    ) -> CheckboxProjectionResponse:
+        try:
+            refresh_panel_note_object(
+                note_uuid=request.artifact_id,
+                note_path=note_path,
+                raw_text=raw_text,
+                trace_id=request.idempotency_key,
+            )
+            result = run_panel_note_execution(
+                request.artifact_id,
+                trace_id=request.idempotency_key,
+                trigger="companion",
+            )
+        except Exception as exc:
+            return self._response(
+                request,
+                status="failed",
+                note_path=safe_note_path,
+                before=content_hash_before,
+                after=content_hash_after,
+                block_reason=f"runtime_execution_failed:{type(exc).__name__}",
+            )
+
+        status: ProjectionStatus = "executed" if result.runtime_results else "projected"
+        return self._response(
+            request,
+            status=status,
+            note_path=safe_note_path,
+            before=content_hash_before,
+            after=content_hash_after,
+        )
+
+    @staticmethod
+    def _response(
+        request: CheckboxProjectionRequest,
+        *,
+        status: ProjectionStatus,
+        note_path: str,
+        before: str,
+        after: str,
+        block_reason: str | None = None,
+    ) -> CheckboxProjectionResponse:
+        return CheckboxProjectionResponse(
+            status=status,
+            artifact_id=request.artifact_id,
+            note_path=note_path,
+            panel_id=request.panel_id,
+            option_id=request.option_id,
+            content_hash_before=before,
+            content_hash_after=after,
+            receipt=None,
+            block_reason=block_reason,
+            idempotency_key=request.idempotency_key,
+        )
+
+
+_idempotency_store = CheckboxProjectionIdempotencyStore()
+_service = CheckboxProjectionService(idempotency_store=_idempotency_store)
+
+
+__all__ = [
+    "CheckboxProjectionHTTPError",
+    "CheckboxProjectionIdempotencyStore",
+    "CheckboxProjectionRequest",
+    "CheckboxProjectionResponse",
+    "CheckboxProjectionService",
+    "PanelSelectableOption",
+    "SourceRange",
+    "_idempotency_store",
+    "_service",
+    "extract_panel_selectable_options",
+]

--- a/app/panel/checkbox_projection.py
+++ b/app/panel/checkbox_projection.py
@@ -437,6 +437,7 @@ class CheckboxProjectionService:
             request,
             note_path=note_path,
             safe_note_path=safe_note_path,
+            rollback_text=current,
             raw_text=written,
             content_hash_before=content_hash_before,
             content_hash_after=content_hash_after,
@@ -450,6 +451,7 @@ class CheckboxProjectionService:
         *,
         note_path: Path,
         safe_note_path: str,
+        rollback_text: str,
         raw_text: str,
         content_hash_before: str,
         content_hash_after: str,
@@ -467,12 +469,14 @@ class CheckboxProjectionService:
                 trigger="companion",
             )
         except Exception as exc:
+            write_note_from_absolute(note_path, rollback_text, vault_root=resolve_vault_root())
+            rolled_back = note_path.read_text(encoding="utf-8")
             return self._response(
                 request,
                 status="failed",
                 note_path=safe_note_path,
                 before=content_hash_before,
-                after=content_hash_after,
+                after=_content_hash(rolled_back),
                 block_reason=f"runtime_execution_failed:{type(exc).__name__}",
             )
 

--- a/companion-ui/companion-app/companion_ui/renderer/vault_markdown_renderer.py
+++ b/companion-ui/companion-app/companion_ui/renderer/vault_markdown_renderer.py
@@ -42,6 +42,9 @@ _ORDERED_RE = re.compile(r"^\s*\d+[.)]\s+(.*)$")
 _CALLOUT_RE = CALLOUT_HEADER_RE
 _TABLE_SEPARATOR_RE = re.compile(r"^\s*\|?\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|?\s*$")
 _COMMENT_RE = re.compile(r"%%.*?%%", re.DOTALL)
+_AI_METADATA_COMMENT_RE = re.compile(
+    r"<!--\s*ai:(?:option_id|id|proposed)=([A-Za-z0-9_.-]+)\s*-->"
+)
 _DIAGNOSTIC_ONLY_LANGUAGES = {"dataview", "dataviewjs", "query"}
 _BLOCKED_SRC_SCHEMES = ("file:", "javascript:", "data:")
 _ABSOLUTE_PATH_RE = re.compile(r"^(?:/|[A-Za-z]:[\\/])")
@@ -125,6 +128,7 @@ class _RenderContext:
     link_preview: LinkPreviewProtocol | None
     preview_depth: int
     diagnostics: list[MarkdownDiagnostic]
+    panel_options_by_source_line: dict[int, list[dict[str, object]]]
     preview_counter: int = 0
 
 
@@ -150,6 +154,8 @@ class VaultMarkdownRenderer:
         *,
         note_path: str = "",
         preview_depth: int = 0,
+        panel_selectable_options: list[dict[str, object]] | None = None,
+        content_hash: str = "",
     ) -> RenderedVaultMarkdown:
         parsed = parse_vault_markdown(document) if isinstance(document, str) else document
         diagnostics = list(parsed.diagnostics)
@@ -161,9 +167,15 @@ class VaultMarkdownRenderer:
             link_preview=self._link_preview,
             preview_depth=max(0, int(preview_depth)),
             diagnostics=diagnostics,
+            panel_options_by_source_line=_panel_options_by_source_line(
+                panel_selectable_options,
+                content_hash=content_hash,
+            ),
         )
         body_markdown = _strip_obsidian_comments(parsed.body_markdown)
-        body_html = _render_blocks(body_markdown, context)
+        body_offset = max(0, len(parsed.raw_markdown) - len(parsed.body_markdown))
+        body_line_offset = parsed.raw_markdown[:body_offset].count("\n")
+        body_html = _render_blocks(body_markdown, context, line_offset=body_line_offset)
         diagnostics_html = _render_diagnostics(diagnostics)
         rendered_html = (
             '<article class="vault-markdown-rendered" data-renderer="vault-markdown">'
@@ -185,6 +197,8 @@ def render_vault_markdown(
     asset_resolver: AssetResolverProtocol | None = None,
     mermaid_renderer: MermaidBlockRenderer | None = None,
     link_preview: LinkPreviewProtocol | None = None,
+    panel_selectable_options: list[dict[str, object]] | None = None,
+    content_hash: str = "",
 ) -> RenderedVaultMarkdown:
     """Convenience wrapper for one-shot rendering."""
 
@@ -193,10 +207,15 @@ def render_vault_markdown(
         asset_resolver=asset_resolver,
         mermaid_renderer=mermaid_renderer,
         link_preview=link_preview,
-    ).render(raw_markdown, note_path=note_path)
+    ).render(
+        raw_markdown,
+        note_path=note_path,
+        panel_selectable_options=panel_selectable_options,
+        content_hash=content_hash,
+    )
 
 
-def _render_blocks(markdown: str, context: _RenderContext) -> str:
+def _render_blocks(markdown: str, context: _RenderContext, *, line_offset: int = 0) -> str:
     lines = markdown.splitlines()
     parts: list[str] = []
     index = 0
@@ -239,7 +258,7 @@ def _render_blocks(markdown: str, context: _RenderContext) -> str:
             continue
 
         if _list_kind(line) is not None:
-            html_block, index = _render_list_block(lines, index, context)
+            html_block, index = _render_list_block(lines, index, context, line_offset=line_offset)
             parts.append(html_block)
             continue
 
@@ -442,6 +461,8 @@ def _render_list_block(
     lines: list[str],
     start: int,
     context: _RenderContext,
+    *,
+    line_offset: int = 0,
 ) -> tuple[str, int]:
     """Render a (possibly nested) list block, indentation-aware (#1410).
 
@@ -449,7 +470,7 @@ def _render_list_block(
     so nested ordered lists render inside a nested ``<ol>`` (restarting at 1)
     rather than as flattened continuation items.
     """
-    entries: list[tuple[int, str, str | None, str]] = []
+    entries: list[tuple[int, int, str, str | None, str]] = []
     index = start
     base_indent = _list_indent(lines[start])
     base_kind = _list_kind(lines[start])
@@ -470,31 +491,31 @@ def _render_list_block(
         if kind == "task":
             match = _TASK_RE.match(lines[index])
             assert match is not None
-            entries.append((indent, "task", match.group(1).strip() or " ", match.group(2)))
+            entries.append((line_offset + index, indent, "task", match.group(1).strip() or " ", match.group(2)))
         elif kind == "ol":
             match = _ORDERED_RE.match(lines[index])
             assert match is not None
-            entries.append((indent, "ol", None, match.group(1)))
+            entries.append((line_offset + index, indent, "ol", None, match.group(1)))
         else:
             match = _UNORDERED_RE.match(lines[index])
             assert match is not None
-            entries.append((indent, "ul", None, match.group(1)))
+            entries.append((line_offset + index, indent, "ul", None, match.group(1)))
         index += 1
 
-    html, _ = _build_list_html(entries, 0, entries[0][0], context)
+    html, _ = _build_list_html(entries, 0, entries[0][1], context)
     return html, index
 
 
 def _build_list_html(
-    entries: list[tuple[int, str, str | None, str]],
+    entries: list[tuple[int, int, str, str | None, str]],
     pos: int,
     indent: int,
     context: _RenderContext,
 ) -> tuple[str, int]:
-    list_kind = entries[pos][1]
+    list_kind = entries[pos][2]
     items: list[str] = []
-    while pos < len(entries) and entries[pos][0] >= indent:
-        e_indent, e_kind, e_state, e_content = entries[pos]
+    while pos < len(entries) and entries[pos][1] >= indent:
+        e_source_line, e_indent, e_kind, e_state, e_content = entries[pos]
         if e_indent > indent:
             # Deeper than expected without a parent item at this level — attach
             # the nested list to the previous item (or open a bare item).
@@ -506,14 +527,25 @@ def _build_list_html(
             continue
         pos += 1
         nested_html = ""
-        if pos < len(entries) and entries[pos][0] > indent:
-            nested_html, pos = _build_list_html(entries, pos, entries[pos][0], context)
+        if pos < len(entries) and entries[pos][1] > indent:
+            nested_html, pos = _build_list_html(entries, pos, entries[pos][1], context)
         if e_kind == "task":
             checked_attr = " checked" if (e_state or "").lower() == "x" else ""
+            panel_option = _matching_panel_option(
+                context,
+                source_line=e_source_line,
+                state=e_state or " ",
+                content=e_content,
+            )
+            input_attrs = 'type="checkbox"'
+            if panel_option is None:
+                input_attrs += " disabled"
+            else:
+                input_attrs += _panel_checkbox_attrs(panel_option)
             items.append(
                 '<li class="task-list-item" '
                 f'data-task-state="{_e(e_state or " ")}">'
-                f'<input type="checkbox" disabled{checked_attr}> '
+                f'<input {input_attrs}{checked_attr}> '
                 f"{_render_inline(e_content, context)}{nested_html}</li>"
             )
         else:
@@ -522,6 +554,67 @@ def _build_list_html(
     tag = "ol" if list_kind == "ol" else "ul"
     cls = ' class="task-list"' if list_kind == "task" else ""
     return f"<{tag}{cls}>{''.join(items)}</{tag}>", pos
+
+
+def _panel_options_by_source_line(
+    options: list[dict[str, object]] | None,
+    *,
+    content_hash: str,
+) -> dict[int, list[dict[str, object]]]:
+    by_line: dict[int, list[dict[str, object]]] = {}
+    for raw in options or []:
+        if not isinstance(raw, dict):
+            continue
+        if raw.get("selectable") is not True:
+            continue
+        source_range = raw.get("source_range")
+        if not isinstance(source_range, dict):
+            continue
+        try:
+            source_line = int(source_range.get("start_line"))
+        except (TypeError, ValueError):
+            continue
+        normalized = dict(raw)
+        if not normalized.get("content_hash") and content_hash:
+            normalized["content_hash"] = content_hash
+        by_line.setdefault(source_line, []).append(normalized)
+    return by_line
+
+
+def _strip_ai_metadata_comments(text: str) -> str:
+    return _AI_METADATA_COMMENT_RE.sub("", text).strip()
+
+
+def _matching_panel_option(
+    context: _RenderContext,
+    *,
+    source_line: int,
+    state: str,
+    content: str,
+) -> dict[str, object] | None:
+    if (state or "").lower() == "x":
+        return None
+    options = context.panel_options_by_source_line.get(source_line) or []
+    label = _strip_ai_metadata_comments(content)
+    matches = [
+        option
+        for option in options
+        if str(option.get("label") or "").strip() == label
+    ]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _panel_checkbox_attrs(option: dict[str, object]) -> str:
+    attrs = {
+        "data-panel-checkbox": "true",
+        "data-artifact-id": option.get("artifact_id") or "",
+        "data-note-path": option.get("note_path") or "",
+        "data-panel-id": option.get("panel_id") or "",
+        "data-option-id": option.get("option_id") or "",
+        "data-source-hash": option.get("source_hash") or "",
+        "data-content-hash": option.get("content_hash") or "",
+    }
+    return "".join(f' {name}="{_e(value)}"' for name, value in attrs.items())
 
 
 def _render_paragraph(

--- a/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/real_note_workspace_dev_page.py
@@ -129,6 +129,7 @@ class DevPageState:
     panel_proposal_count: int = 0
     panel_render: dict[str, Any] | None = None
     panel_proposals: list[dict[str, Any]] | None = None
+    panel_selectable_options: list[dict[str, Any]] | None = None
     panel_last_response: dict[str, Any] | None = None
     suggestion_state: str = "idle"
     suggestion_dom_alias: str = "idle"
@@ -346,6 +347,11 @@ class RealNoteWorkspaceDevPage:
             panel=panel,
             artifact_id=resolved_artifact_id,
         )
+        panel_selectable_options = [
+            option
+            for option in (panel.get("selectable_options") or [])
+            if isinstance(option, dict)
+        ]
         suggestion_machine = CanvasRailStateMachine(
             _normalise_suggestion_state(suggestions.get("current_suggestion_state"))
         )
@@ -384,6 +390,7 @@ class RealNoteWorkspaceDevPage:
             panel_proposal_count=panel_count,
             panel_render=panel_render,
             panel_proposals=panel_proposals,
+            panel_selectable_options=panel_selectable_options,
             panel_last_response=panel_last_response,
             suggestion_state=suggestion_machine.state,
             suggestion_dom_alias=suggestion_machine.dom_alias,
@@ -885,6 +892,7 @@ class RealNoteWorkspaceDevPage:
             "panel_proposal_count": self.state.panel_proposal_count,
             "panel_render": self.state.panel_render or {},
             "panel_proposals": self.state.panel_proposals or [],
+            "panel_selectable_options": self.state.panel_selectable_options or [],
             "panel_last_response": self.state.panel_last_response or {},
             "suggestion_state": self.state.suggestion_state,
             "suggestion_dom_alias": self.state.suggestion_dom_alias,

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -5001,6 +5001,13 @@ def render_index_html(
       cursor: pointer;
       border-color: var(--accent);
     }}
+    .vault-markdown-rendered .panel-checkbox-feedback {{
+      display: block;
+      margin-top: 4px;
+      color: var(--destructive);
+      font-size: 0.84rem;
+      line-height: 1.25;
+    }}
     .vault-markdown-rendered li.task-list-item > input[type="checkbox"]:checked {{
       background: var(--accent);
       border-color: var(--accent);
@@ -6725,6 +6732,37 @@ def render_index_html(
       var url = '/api/companion/workspace?note_path=' + encodeURIComponent(notePath || '');
       return fetch(url, {{method: 'GET'}}).catch(function() {{ return null; }});
     }}
+    function panelProjectionSucceeded(data) {{
+      return data && ['projected', 'executed', 'already_projected'].indexOf(data.status) !== -1;
+    }}
+    function panelProjectionMessage(data, fallback) {{
+      if (!data) return fallback;
+      if (data.block_reason) return data.block_reason;
+      if (data.status === 'blocked') return 'Panel action blocked by runtime guard.';
+      if (data.status === 'failed') return 'Panel action failed before execution completed.';
+      if (data.status === 'stale') return 'Panel action is stale. Refresh the note and try again.';
+      if (data.status === 'not_found') return 'Panel action is no longer available.';
+      if (data.status === 'not_selectable') return 'Panel action is not selectable.';
+      return fallback;
+    }}
+    function setPanelCheckboxFeedback(target, message) {{
+      var item = target.closest ? target.closest('li.task-list-item') : null;
+      if (!item) return;
+      var feedback = item.querySelector('.panel-checkbox-feedback');
+      if (!feedback) {{
+        feedback = document.createElement('span');
+        feedback.className = 'panel-checkbox-feedback';
+        feedback.setAttribute('role', 'status');
+        item.appendChild(feedback);
+      }}
+      feedback.textContent = message || '';
+    }}
+    function clearPanelCheckboxFeedback(target) {{
+      var item = target.closest ? target.closest('li.task-list-item') : null;
+      if (!item) return;
+      var feedback = item.querySelector('.panel-checkbox-feedback');
+      if (feedback) feedback.remove();
+    }}
     document.addEventListener('click', function(event) {{
       var target = event.target && event.target.closest
         ? event.target.closest('input[data-panel-checkbox="true"]')
@@ -6743,6 +6781,7 @@ def render_index_html(
       }};
       target.setAttribute('data-panel-submitting', 'true');
       target.disabled = true;
+      clearPanelCheckboxFeedback(target);
       fetch('/api/panel/checkbox-projection', {{
         method: 'POST',
         headers: {{'Content-Type': 'application/json'}},
@@ -6752,10 +6791,11 @@ def render_index_html(
           return {{ok: response.ok, status: response.status, data: data}};
         }});
       }}).then(function(result) {{
-        if (!result.ok) {{
+        if (!result.ok || !panelProjectionSucceeded(result.data)) {{
           target.disabled = false;
           target.removeAttribute('data-panel-submitting');
           target.checked = false;
+          setPanelCheckboxFeedback(target, panelProjectionMessage(result.data, 'Panel checkbox projection failed.'));
           try {{ console.error('panel checkbox projection failed', result.status, result.data); }} catch (e) {{}}
           return;
         }}

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -1004,7 +1004,11 @@ def _render_note_section(fields: dict) -> str:
         link_index = _coerce_vault_link_index(raw_link_index)
     link_resolver = VaultLinkResolver(link_index)
     rendered_body = render_vault_markdown(
-        raw_body, note_path=raw_note_path, link_resolver=link_resolver
+        raw_body,
+        note_path=raw_note_path,
+        link_resolver=link_resolver,
+        panel_selectable_options=fields.get("panel_selectable_options") or [],
+        content_hash=content_hash,
     )
     body = rendered_body.html
     # Frontmatter-stripped source for the direct human editor (the save endpoint
@@ -4967,7 +4971,8 @@ def render_index_html(
       border-top: 1px solid var(--border);
       margin: 32px 0;
     }}
-    /* §6.5 — task lists: custom checkboxes; read-only is the truth in v0. */
+    /* §6.5 — task lists: ordinary checkboxes stay read-only; runtime-declared
+       Panel options can request backend checkbox projection. */
     .vault-markdown-rendered ul.task-list {{
       list-style: none;
       padding-left: 4px;
@@ -4991,6 +4996,10 @@ def render_index_html(
       background: transparent;
       cursor: default;
       vertical-align: baseline;
+    }}
+    .vault-markdown-rendered li.task-list-item > input[data-panel-checkbox="true"] {{
+      cursor: pointer;
+      border-color: var(--accent);
     }}
     .vault-markdown-rendered li.task-list-item > input[type="checkbox"]:checked {{
       background: var(--accent);
@@ -6704,6 +6713,65 @@ def render_index_html(
     window.location.href = url.toString();
   }}
   </script>
+  <script>
+  (function() {{
+    function idempotencyKey() {{
+      if (window.crypto && typeof window.crypto.randomUUID === 'function') {{
+        return window.crypto.randomUUID();
+      }}
+      return 'panel-checkbox-' + Date.now() + '-' + Math.random().toString(16).slice(2);
+    }}
+    function refreshWorkspace(notePath) {{
+      var url = '/api/companion/workspace?note_path=' + encodeURIComponent(notePath || '');
+      return fetch(url, {{method: 'GET'}}).catch(function() {{ return null; }});
+    }}
+    document.addEventListener('click', function(event) {{
+      var target = event.target && event.target.closest
+        ? event.target.closest('input[data-panel-checkbox="true"]')
+        : null;
+      if (!target) return;
+      event.preventDefault();
+      if (target.getAttribute('data-panel-submitting') === 'true') return;
+      var payload = {{
+        artifact_id: target.getAttribute('data-artifact-id') || '',
+        note_path: target.getAttribute('data-note-path') || '',
+        panel_id: target.getAttribute('data-panel-id') || '',
+        option_id: target.getAttribute('data-option-id') || '',
+        expected_content_hash: target.getAttribute('data-content-hash') || '',
+        expected_source_hash: target.getAttribute('data-source-hash') || '',
+        idempotency_key: idempotencyKey()
+      }};
+      target.setAttribute('data-panel-submitting', 'true');
+      target.disabled = true;
+      fetch('/api/panel/checkbox-projection', {{
+        method: 'POST',
+        headers: {{'Content-Type': 'application/json'}},
+        body: JSON.stringify(payload)
+      }}).then(function(response) {{
+        return response.json().then(function(data) {{
+          return {{ok: response.ok, status: response.status, data: data}};
+        }});
+      }}).then(function(result) {{
+        if (!result.ok) {{
+          target.disabled = false;
+          target.removeAttribute('data-panel-submitting');
+          target.checked = false;
+          try {{ console.error('panel checkbox projection failed', result.status, result.data); }} catch (e) {{}}
+          return;
+        }}
+        target.checked = true;
+        refreshWorkspace(payload.note_path).finally(function() {{
+          window.location.reload();
+        }});
+      }}).catch(function(error) {{
+        target.disabled = false;
+        target.removeAttribute('data-panel-submitting');
+        target.checked = false;
+        try {{ console.error('panel checkbox projection network error', error); }} catch (e) {{}}
+      }});
+    }});
+  }})();
+  </script>
   {_mermaid_runtime_script()}
   {_note_editor_script()}
 </body>
@@ -6821,6 +6889,19 @@ def make_handler(
                     return
                 self._send_json(200, data)
                 return
+            if parsed.path == "/api/companion/workspace":
+                params = parse_qs(parsed.query)
+                note_param = params.get("note_path", [""])[0]
+                try:
+                    data = self._client.get(
+                        "/api/companion/workspace",
+                        params={"note_path": note_param},
+                    )
+                except WorkspaceClientError as exc:
+                    self._proxy_error(exc)
+                    return
+                self._send_json(200, data)
+                return
             if parsed.path == "/api/companion/vault/notes":
                 params = parse_qs(parsed.query)
                 q = params.get("q", [""])[0]
@@ -6852,6 +6933,7 @@ def make_handler(
             {
                 "/api/companion/workspace/body",
                 "/api/companion/note/save",  # direct human note edit
+                "/api/panel/checkbox-projection",
             }
         )
 

--- a/companion-ui/docs/PANEL_COMPANION_UI_CONTRACT.md
+++ b/companion-ui/docs/PANEL_COMPANION_UI_CONTRACT.md
@@ -31,7 +31,7 @@ This document covers:
 2. Panel render contract (states, rendering concepts, invariants).
 3. Panel confirmation / write-back contract (confirmation semantics, write-back boundary, default approach).
 
-This is a contract/docs-only document. It does not implement runtime behavior, UI components, vault write paths, or confirmation endpoints. Those belong to separate implementation issues.
+This is a contract document. Current implementation status is called out where relevant; future Panel behavior beyond the implemented read-mode checkbox projection slice still belongs to separate implementation issues.
 
 ---
 
@@ -256,7 +256,7 @@ The Companion UI signals confirmation to the runtime (e.g., via a lightweight ca
 
 #### Approach 2: Dedicated runtime endpoint
 
-The Companion UI calls a dedicated runtime endpoint (for example, a revised `POST /api/panel/confirm` or a separate projection endpoint) that accepts a specific source-backed Panel option target, projects the checked checkbox state through the runtime, and then schedules or triggers governed execution with status feedback.
+The Companion UI calls a dedicated runtime endpoint that accepts a specific source-backed Panel option target, projects the checked checkbox state through the runtime, and then schedules or triggers governed execution with status feedback. The implemented read-mode endpoint is `POST /api/panel/checkbox-projection`. The legacy `POST /api/panel/confirm` endpoint remains the staged/transient proposal confirmation path.
 
 **Strengths:**
 - Direct feedback loop: Companion UI can display `confirming → executing → receipt` states immediately.
@@ -265,7 +265,7 @@ The Companion UI calls a dedicated runtime endpoint (for example, a revised `POS
 - Confirmation remains explicit and named in the UI, while durable human-facing confirmation authority remains the vault-visible Panel checkbox state.
 
 **Weaknesses:**
-- Requires a new runtime endpoint (out of scope for this contract; must be a separate implementation issue).
+- Requires the dedicated runtime endpoint boundary to stay source-backed and guarded; it must not collapse into a UI-only approval store.
 - Must still produce a durable vault-visible projection and Obsidian-compatible receipt so the vault surface remains consistent.
 - Adds a new integration boundary that must be governed and tested.
 
@@ -288,13 +288,13 @@ inside the valid Panel `AI-åtgärder` section.
 
 That checked checkbox state is the canonical human-facing confirmation signal. The endpoint request is transport, not approval authority. Companion UI does not create a separate approval model, does not own durable confirmation state, and does not execute a Panel action directly from a browser click.
 
-Current implementation note: the existing `POST /api/panel/confirm` path is a staged proposal confirmation API, not yet the source-backed read-mode checkbox projection contract described here. It does not currently validate current vault Markdown, validate source freshness, and project `- [x]` before execution. A future endpoint revision or separate projection endpoint is required before Companion UI read-mode checkbox clicks can use this contract.
+Current implementation note: `POST /api/panel/checkbox-projection` is the source-backed read-mode projection endpoint. The existing `POST /api/panel/confirm` path is still a staged proposal confirmation API and must not be described as the Markdown checkbox projection path.
 
 **While preserving durable vault-visible projection / Obsidian-compatible semantics:**
 - The runtime endpoint must produce the same durable vault-visible output as the checkbox + watcher flow: a receipt in the AI status callout, executed checkboxes removed from the panel working set, and event stream emissions.
 - Obsidian-compatible panel/checkbox semantics must remain possible. The vault surface must not become dependent on Companion UI being present for panel state to make sense.
 
-**Do NOT implement the endpoint in this contract.** The endpoint is a follow-up implementation issue. The decision recorded here is: prefer the dedicated endpoint approach; require it to produce Obsidian-compatible durable vault-visible projection.
+The endpoint decision recorded here is: use the dedicated source-backed projection endpoint for Companion UI read-mode checkbox clicks, and require it to produce Obsidian-compatible durable vault-visible projection.
 
 ### Same-Turn Execution Constraint
 
@@ -338,7 +338,7 @@ The renderer may continue to display ordinary Markdown task checkboxes as read-o
 The following runtime state and APIs are required for the confirmation write-back path. These are named here as dependencies; their implementation belongs to separate issues.
 
 Required for runtime-mediated checkbox projection:
-- A source-backed projection endpoint or revised confirm endpoint that accepts note/artifact identity, `panel_id`, durable `option_id`, expected content/source freshness hashes, and an idempotency key.
+- The source-backed `POST /api/panel/checkbox-projection` endpoint, accepting note/artifact identity, `panel_id`, durable `option_id`, expected content/source freshness hashes, and an idempotency key.
 - Runtime validation that the target option is still a pending/selectable task checkbox inside a valid Panel `AI-åtgärder` section and not an ordinary task or code-block checkbox.
 - Runtime projection of the checked checkbox state through the governed backend write path before normal Panel execution observes or is triggered from that state.
 - A status/receipt polling or callback mechanism so the UI can display `confirming → executing → receipt` states.
@@ -349,9 +349,8 @@ Required for all approaches:
 - Durable option identity that can be referenced across the projection request.
 - Receipt payload with enough information to render `receipt-displayed` state in the UI.
 
-Open questions deferred to implementation:
-- Exact endpoint path and request/response schema.
-- Whether status feedback is synchronous (polling) or async (webhook/SSE).
+Open questions deferred to follow-up implementation:
+- Whether richer status feedback is synchronous (polling) or async (webhook/SSE).
 - How Companion UI discovers the current Panel state on note open (polling, initial load, or event subscription).
 - How cancellation of a confirming or executing proposal is handled.
 
@@ -368,14 +367,13 @@ This contract is docs-only. The following are **not** decided here:
 - Obsidian plugin implementation.
 - Production-ready Panel component shell.
 
-### Open Questions for Implementation Lane
+### Open Questions for Follow-Up Lanes
 
-1. **Confirm endpoint schema.** What fields does the confirm request carry? What does the response include? How does the UI correlate a confirm request to a receipt?
-2. **Panel state discovery on note open.** How does Companion UI learn the current Panel state for the active note (are there proposals already staged? is there a receipt to display)?
-3. **Clarification-needed state interaction.** When the Panel needs more information from the user, how does the UI surface that without collapsing into a chat interface?
-4. **Proposal row correction UX.** When the user wants to correct a proposal before confirming, what does the edit affordance look like? Does it open an inline editor, a modal, or a freeform instruction field?
-5. **Receipt retention.** How long does the Companion UI keep a receipt visible? Does it persist across note navigations?
-6. **Partial-complete state.** When some proposals in a set are confirmed and others are not, how does the Panel state machine track and display the mixed state?
+1. **Richer status feedback.** Should execution status beyond the projection response be exposed through polling, SSE, or workspace refresh only?
+2. **Clarification-needed state interaction.** When the Panel needs more information from the user, how does the UI surface that without collapsing into a chat interface?
+3. **Proposal row correction UX.** When the user wants to correct a proposal before confirming, what does the edit affordance look like? Does it open an inline editor, a modal, or a freeform instruction field?
+4. **Receipt retention.** How long does the Companion UI keep a receipt visible? Does it persist across note navigations?
+5. **Partial-complete state.** When some proposals in a set are confirmed and others are not, how does the Panel state machine track and display the mixed state?
 
 ---
 
@@ -428,14 +426,15 @@ The following production UI items are not yet implemented and are deferred until
 
 - Production visual component integration (if/when required).
 - Styling and design-system integration.
-- Real data loading from runtime state.
+- Richer execution status/receipt streaming beyond workspace refresh.
 
-### Still-pending runtime/projection work
+### Delivered runtime/projection work
 
-The following items remain pending — spec/contract only, implementation deferred:
+The following read-mode projection foundations are delivered:
 
-- **Panel read-mode checkbox projection endpoint or endpoint revision** — based on `companion-ui/docs/PANEL_CONFIRMATION_API_CONTRACT.md`. Create a bounded implementation issue for a source-backed runtime projection path: request/response schema, current Markdown/source-freshness validation, governed checkbox projection, execution trigger/watcher convergence, and receipt mapping.
-- **Runtime-mediated durable vault-visible projection implementation** — based on `companion-ui/docs/PANEL_DURABLE_PROJECTION_MAPPING.md`. Verify that confirmation via Companion UI produces the same vault-visible receipt and checkbox state as the CLI/watcher flow.
+- **Panel read-mode checkbox projection endpoint** — `POST /api/panel/checkbox-projection` implements source-backed runtime projection for runtime-declared selectable Panel options.
+- **Runtime-declared selectable options in workspace state** — `/api/companion/workspace` exposes `panel.selectable_options` so the renderer does not infer authority from arbitrary task-list DOM.
+- **Companion read-mode checkbox affordance** — ordinary Markdown task checkboxes remain read-only; only runtime-declared Panel options call the projection endpoint.
 
 ---
 

--- a/companion-ui/docs/PANEL_CONFIRMATION_API_CONTRACT.md
+++ b/companion-ui/docs/PANEL_CONFIRMATION_API_CONTRACT.md
@@ -1,6 +1,6 @@
 ---
 name: Panel Confirmation / Checkbox Projection API Contract
-description: API contract for Panel confirmation transport and the future runtime-mediated checkbox projection endpoint — request/response schema, source freshness, idempotency, blocked/receipt semantics, and boundary rules
+description: API contract for Panel confirmation transport and the runtime-mediated checkbox projection endpoint — request/response schema, source freshness, idempotency, blocked/receipt semantics, and boundary rules
 doc_role: API contract / spec
 authority: Binding contract for any implementation or revision of Panel confirmation transport and read-mode checkbox projection. Must not be bypassed or extended without a governing issue.
 owner: v6.0 architecture / Panel runtime implementation lane
@@ -18,12 +18,9 @@ source_contracts:
 
 ## Purpose
 
-Define the API contract boundary for Panel confirmation transport and the future runtime-mediated read-mode checkbox projection path.
+Define the API contract boundary for Panel confirmation transport and the runtime-mediated read-mode checkbox projection path.
 
-This document is **spec/contract only**. It does not implement the endpoint,
-does not add backend routes, and does not change event schemas. The
-implementation belongs to a follow-up issue explicitly scoped to runtime
-endpoint implementation or endpoint revision.
+Current implementation status: `POST /api/panel/checkbox-projection` is the source-backed read-mode projection endpoint. `POST /api/panel/confirm` remains the staged/transient proposal confirmation endpoint and is not the Markdown checkbox projection path.
 
 ---
 
@@ -41,30 +38,17 @@ endpoint implementation or endpoint revision.
 - Same-turn execution of newly generated proposals is NOT allowed unless the
   existing governed runtime explicitly supports it.
 
-Current-state correction: the existing `POST /api/panel/confirm` implementation
-is a staged proposal confirmation endpoint backed by transient proposal identity.
-It does not yet validate current vault Markdown, validate source freshness, and
-project `- [x]` inside the Panel block before execution. Therefore it is
-insufficient for Companion UI read-mode Markdown checkbox projection until a
-future implementation revises it or adds a separate projection endpoint.
-
-This document defines the future projection contract so implementation can be
-scoped in a separate issue without claiming the current endpoint already
-provides this behavior.
+Current-state correction: the existing `POST /api/panel/confirm` implementation is a staged proposal confirmation endpoint backed by transient proposal identity. It does not validate current vault Markdown, validate source freshness, and project `- [x]` inside the Panel block before execution. It remains insufficient for Companion UI read-mode Markdown checkbox projection.
 
 ---
 
 ## Endpoint
 
 ```
-POST /api/panel/confirm
+POST /api/panel/checkbox-projection
 ```
 
-The current route name may be retained for compatibility, but before it can
-serve Companion UI read-mode checkbox clicks it must be revised to behave as a
-runtime-mediated checkbox projection endpoint. A separate endpoint may also be
-introduced if compatibility requires keeping the staged proposal confirmation
-API distinct.
+This endpoint is distinct from `POST /api/panel/confirm` so the staged proposal confirmation API can remain compatibility-stable.
 
 For read-mode checkbox projection, the endpoint request is transport. It is not
 the durable approval authority. The durable human-facing confirmation signal is
@@ -84,7 +68,7 @@ The runtime sequence is:
 
 ---
 
-## Future Read-Mode Projection Request Schema
+## Read-Mode Projection Request Schema
 
 ```json
 {
@@ -93,7 +77,7 @@ The runtime sequence is:
   "panel_id": "<string>",
   "option_id": "<string>",
   "expected_content_hash": "<string>",
-  "expected_source_hash": "<string or null>",
+  "expected_source_hash": "<string>",
   "idempotency_key": "<string>"
 }
 ```
@@ -107,7 +91,7 @@ The runtime sequence is:
 | `panel_id` | string | yes | Runtime-declared identifier for the Panel block that contains the selectable option. |
 | `option_id` | string | yes | Durable identity for the specific selectable Panel option line. Must not be inferred from label text, rendered DOM order, or `ai:proposed`. |
 | `expected_content_hash` | string | yes | Hash of the note content snapshot rendered by Companion UI. Used to reject stale projection requests. |
-| `expected_source_hash` | string or null | yes | Hash of the source line/range for the option when available. Null is allowed only when the runtime-defined projection contract explicitly permits content-level freshness alone. |
+| `expected_source_hash` | string | yes | SHA-256 hash of the current source line for the option in the UI snapshot. |
 | `idempotency_key` | string | yes | Client-generated UUID (v4) or equivalent. Duplicate requests with the same key must return the same projection/execution status without duplicating writes or execution. |
 
 ### Constraints
@@ -120,9 +104,7 @@ The runtime sequence is:
 - The request targets checkbox projection only. Correction/edit/reject flows
   require separate contract text and must not be smuggled into the first
   read-mode checkbox slice.
-- The Companion UI must not call this projection path in the same turn that a
-  proposal was generated unless a future governed runtime contract explicitly
-  allows that path.
+- The request targets only projection of an unchecked pending/selectable option to checked state. It does not implement batch confirmation, uncheck, reject, correction, or multi-select grace semantics.
 
 ### Validation requirements
 
@@ -146,37 +128,32 @@ The runtime must validate:
 
 ```json
 {
-  "option_id":     "<string>",
-  "panel_id":      "<string>",
-  "artifact_id":   "<string>",
-  "status":        "<string — see Status Values>",
-  "outcome":       "<string — see Outcome Values>",
-  "receipt":       {
-    "action_taken":  "<string>",
-    "outcome":       "<string>",
-    "timestamp":     "<ISO 8601>",
-    "message":       "<string or null>",
-    "inverse_action": "<string or null — identifier for the inverse/undo action>"
-  },
-  "idempotency_key": "<string — echoed from request>",
-  "events_emitted":  ["<string>", ...]
+  "status": "projected|already_projected|queued|executed|blocked|stale|not_found|not_selectable|failed",
+  "artifact_id": "<string>",
+  "note_path": "<string>",
+  "panel_id": "<string>",
+  "option_id": "<string>",
+  "content_hash_before": "<string>",
+  "content_hash_after": "<string>",
+  "receipt": null,
+  "block_reason": "<string or null>",
+  "idempotency_key": "<string>"
 }
 ```
 
-### Blocked (HTTP 200 with blocked status, or HTTP 422)
+### Blocked (HTTP 200)
 
 ```json
 {
-  "option_id": "<string>",
-  "panel_id": "<string>",
+  "status": "blocked",
   "artifact_id": "<string>",
-  "status":      "blocked",
-  "outcome":     "blocked",
-  "block_reason": {
-    "gate":    "<string — policy | writeguard | allowlist | capability>",
-    "message": "<string — human-readable reason>",
-    "code":    "<string or null — machine-readable block code>"
-  },
+  "note_path": "<string>",
+  "panel_id": "<string>",
+  "option_id": "<string>",
+  "content_hash_before": "<string>",
+  "content_hash_after": "<string>",
+  "receipt": null,
+  "block_reason": "<human-readable reason>",
   "idempotency_key": "<string>"
 }
 ```
@@ -185,10 +162,18 @@ The runtime must validate:
 
 ```json
 {
-  "error":   "<string — error class>",
-  "message": "<string — human-readable error>",
-  "option_id": "<string or null>",
-  "idempotency_key": "<string or null>"
+  "detail": {
+    "status": "stale|not_found|not_selectable|failed",
+    "artifact_id": "<string>",
+    "note_path": "<string>",
+    "panel_id": "<string>",
+    "option_id": "<string>",
+    "content_hash_before": "<string>",
+    "content_hash_after": "<string>",
+    "receipt": null,
+    "block_reason": "<string or null>",
+    "idempotency_key": "<string>"
+  }
 }
 ```
 
@@ -196,26 +181,25 @@ The runtime must validate:
 
 | Status | Description |
 |---|---|
-| `projecting` | Runtime received the request and is validating/projecting the checked checkbox. |
 | `projected` | The checked checkbox projection was written; execution is pending or has been scheduled. |
-| `executing` | Normal Panel execution is in progress after projection. |
-| `executed` | Execution complete. Receipt is present. |
-| `blocked` | Execution was blocked (policy, WriteGuard, allowlist, capability). |
-| `logged` | Action was logged for review rather than executed (policy outcome). |
+| `already_projected` | The targeted option is already checked in current Markdown. |
+| `queued` | Projection succeeded and normal Panel execution is deferred to watcher/runtime convergence. |
+| `executed` | Normal Panel execution ran after projection. |
+| `blocked` | Projection was blocked by WriteGuard or runtime safety policy before the checkbox was changed. |
 | `stale` | The current note content/source no longer matches the UI snapshot. |
 | `not_found` | The target Panel or option no longer exists or no longer resolves uniquely. |
+| `not_selectable` | The target exists but is not an unchecked pending/selectable option. |
+| `failed` | Projection succeeded but immediate runtime execution failed; the vault-visible checked checkbox remains the convergence signal. |
 
-### Outcome Values
+### HTTP Mapping
 
-| Outcome | Description |
+| HTTP status | Projection status |
 |---|---|
-| `projected` | Checked checkbox state was projected; execution has not completed yet. |
-| `success` | Governed execution completed; vault-visible projection written. |
-| `blocked` | Execution denied at a policy gate. |
-| `logged` | Action logged; deferral projection written. |
-| `partial` | Some sub-actions succeeded, others blocked (if applicable). |
-| `stale` | Projection rejected because the source content changed. |
-| `not_found` | Projection rejected because the Panel option is missing or ambiguous. |
+| `200` | `projected`, `already_projected`, `queued`, `executed`, `blocked`, or `failed` after a successful projection with runtime execution failure |
+| `404` | `not_found` |
+| `409` | `stale` content/source mismatch |
+| `422` | invalid request or `not_selectable` |
+| `500` | unexpected backend failure before a typed projection response can be produced |
 
 ---
 
@@ -226,9 +210,10 @@ The runtime must validate:
 - The runtime must resolve `option_id` against the current Markdown source,
   scoped by `artifact_id`, `note_path`, and `panel_id`.
 - `ai:proposed` is only a pending marker and is not an option identity.
-- Existing `ai:id` must not be treated as durable `option_id` until
-  `docs/PANEL_AGENT.md` explicitly promotes it and defines collision,
-  duplicate-label, and migration semantics.
+- Existing `ai:id` is not durable `option_id`; it remains legacy/current runtime
+  idempotency and removal metadata.
+- Runtime-generated proposals use the explicit durable marker
+  `<!--ai:option_id=opt_...-->`.
 - If the `option_id` is unknown, expired, missing, moved without a validating
   source hash, or ambiguous, the endpoint must return a 4xx or typed response
   with `status: "not_found"` or `status: "stale"` as appropriate.
@@ -280,13 +265,13 @@ as transient errors and must not treat them as confirmed or rejected.
 
 ## Receipt Semantics
 
-A receipt is a durable record of execution outcome. The receipt is:
-
-- Included in the `receipt` field of the HTTP 200 success response.
-- Written to the vault AI-status callout by the runtime as a durable
-  vault-visible projection (see `PANEL_DURABLE_PROJECTION_MAPPING.md`).
-- Not written by Companion UI. The UI renders the receipt from the response;
-  the runtime writes the vault-visible version.
+A receipt is a durable record of execution outcome. For the first read-mode
+checkbox projection slice, the projection response may return `receipt: null`;
+the Companion UI refreshes workspace state after projection instead of treating
+the transport response as a durable receipt store. Durable receipts are written
+to the vault AI-status callout by the normal Panel runtime when execution
+completes (see `PANEL_DURABLE_PROJECTION_MAPPING.md`). Companion UI never
+writes receipts directly.
 
 Receipt fields:
 
@@ -302,8 +287,8 @@ Receipt fields:
 
 ## Durable Vault-Visible Projection Requirement
 
-The future projection implementation must produce a durable vault-visible
-projection equivalent to the CLI/watcher flow:
+The projection implementation must produce a durable vault-visible projection
+equivalent to the CLI/watcher flow:
 
 - The target checkbox is projected as checked (`- [x]`) inside the valid Panel
   `AI-åtgärder` section.
@@ -318,13 +303,14 @@ projection mapping.
 
 ---
 
-## Same-Turn Execution Prohibition
+## Same-Turn Execution Boundary
 
-The projection path must not accept a request for an option that was generated
-in the same Companion UI interaction turn. Same-turn execution of newly
-generated proposals is not allowed by this contract.
+The first implementation slice does not add a Companion-only same-turn approval
+model. Source freshness, pending/selectable status, WriteGuard, and normal
+Panel runtime gates still apply. If stricter same-turn turn-ID enforcement is
+required, it must be added as a separate runtime contract and test slice.
 
-Enforcement mechanism (implementation recommendation):
+Possible future enforcement mechanism:
 - Include a `proposed_at` timestamp or source-generation marker in the option
   payload exposed to Companion UI.
 - Reject requests where the option was generated within the current interaction window.
@@ -360,8 +346,9 @@ proposal/execution model.
 | `panel.action.logged` | Action was logged rather than executed. |
 | `panel.action.blocked` | Execution was blocked at a gate. |
 
-The response's `events_emitted` field must list the event names emitted for
-this confirmation, so the Companion UI can correlate status.
+The current checkbox-projection response does not expose an `events_emitted`
+field. Companion UI refreshes workspace state after the projection response;
+future richer status APIs may expose event names or receipt details.
 
 ---
 
@@ -386,9 +373,9 @@ The Companion UI owns:
 
 ---
 
-## Required Tests Before Implementation
+## Required Coverage
 
-The following tests must exist before or alongside endpoint implementation:
+The implementation must carry focused coverage for:
 
 1. Parser/mapping tests prove only valid Panel `AI-åtgärder` checkboxes are eligible.
 2. Projection endpoint validation tests cover `artifact_id`, `note_path`, `panel_id`, `option_id`, content/source hashes, and pending/selectable status.
@@ -396,11 +383,11 @@ The following tests must exist before or alongside endpoint implementation:
 4. WriteGuard and safe/degraded-mode tests prove projection does not bypass governed write policy.
 5. Idempotency/retry tests cover duplicate browser clicks, retries, already-checked options, and watcher overlap.
 6. Watcher/runtime convergence tests prove Obsidian/plain-text checked checkboxes and Companion UI projection produce the same semantics and receipts.
-7. Companion UI read-mode browser tests prove ordinary task checkboxes stay non-agent controls and only runtime-declared Panel options call the projection endpoint.
+7. Companion UI read-mode tests prove ordinary task checkboxes stay non-agent controls and only runtime-declared Panel options call the projection endpoint.
 
 ---
 
-## Open Questions (Deferred to Implementation)
+## Open Questions (Deferred to Follow-Up)
 
 1. **Status feedback mechanism.** Is confirmation status delivered synchronously
    (single response) or asynchronously (polling endpoint or SSE stream)?
@@ -410,20 +397,16 @@ The following tests must exist before or alongside endpoint implementation:
    or equivalent?
 3. **Partial-complete handling.** If a proposal decomposes into sub-actions and
    some are blocked, how does the response model `partial` outcomes?
-4. **Option identity decision.** Does the runtime promote `ai:id` into durable
-   `option_id` with stronger generation rules, or introduce a new explicit
-   marker such as `<!--ai:option_id=...-->`?
-5. **Authentication.** What auth context does the endpoint require? Is it
+4. **Authentication.** What auth context does the endpoint require? Is it
    session-scoped to the Companion UI session?
 
 ---
 
 ## Governing Boundary Statement
 
-- This document is contract/spec only.
-- The endpoint is not implemented here.
-- No backend routes are added by this document.
-- No event schemas are changed by this document.
+- `POST /api/panel/checkbox-projection` is the read-mode source-backed projection endpoint.
+- `POST /api/panel/confirm` remains the staged/transient proposal confirmation endpoint.
+- No event schemas are changed by this contract.
 - The Companion UI must not write vault files directly under any circumstance.
 - The runtime is the sole writer of vault-visible state.
 - All execution must flow through policy → WriteGuard → idempotency →

--- a/companion-ui/docs/PANEL_DURABLE_PROJECTION_MAPPING.md
+++ b/companion-ui/docs/PANEL_DURABLE_PROJECTION_MAPPING.md
@@ -20,9 +20,10 @@ source_contracts:
 Define the mapping from Panel confirmation/execution outcome to vault-visible
 state.
 
-This document is **spec/contract only**. It does not implement runtime writer
-behavior, vault writes, or watcher behavior. Implementation belongs to a
-follow-up issue explicitly scoped to runtime projection implementation.
+This document is the contract for runtime writer behavior, vault-visible
+projection, and watcher/runtime convergence. The first read-mode checkbox
+projection slice is implemented through `POST /api/panel/checkbox-projection`;
+future projection behavior must preserve the same mapping.
 
 ---
 
@@ -116,9 +117,9 @@ option identity, WriteGuard, safe/degraded policy, and idempotency.
 
 **Companion UI rendering:** `confirming` → `executing` states.
 
-**Writer:** Runtime (via future source-backed projection endpoint or revised
-confirm endpoint). The current staged `POST /api/panel/confirm` implementation
-does not yet provide this source-backed checkbox projection contract.
+**Writer:** Runtime via `POST /api/panel/checkbox-projection`. The staged
+`POST /api/panel/confirm` implementation is not the source-backed checkbox
+projection endpoint.
 
 ---
 
@@ -320,7 +321,7 @@ The two paths must converge on the same vault-visible state.
 ## Race and Idempotency Requirements
 
 - Stale Companion UI content: reject with stale-content status; do not guess by label or rendered DOM position.
-- Watcher overlap: projection and watcher execution must deduplicate through existing Panel idempotency keys and the future durable option identity.
+- Watcher overlap: projection and watcher execution must deduplicate through existing Panel idempotency keys and the durable `ai:option_id` option identity.
 - Browser retries: the same `idempotency_key` returns the same result and must not write or execute twice.
 - Already checked checkbox: treat as idempotent if it targets the same option and source generation; otherwise return current status.
 - Option missing or moved: fail stale/not-found unless durable `option_id` and source hash validate an unambiguous move.
@@ -381,8 +382,9 @@ The following tests must exist before or alongside projection implementation:
    proposed checkbox remains in the working set.
 9. `test_panel_projection_blocked_writes_blocked_receipt` — a blocked receipt
    entry appears in the AI status callout.
-10. `test_panel_projection_rejected_removes_checkbox_no_execution_receipt` —
-   after rejection, the checkbox is removed and no execution receipt is written.
+10. Reject/dismiss-scope only:
+    `test_panel_projection_rejected_removes_checkbox_no_execution_receipt` —
+    after rejection, the checkbox is removed and no execution receipt is written.
 11. `test_panel_projection_watcher_compatible` — the vault state produced by
    the projection path is parseable by the watcher without special-casing.
 12. `test_panel_projection_inverse_action_declared` — executed receipts include

--- a/docs/PANEL_AGENT.md
+++ b/docs/PANEL_AGENT.md
@@ -132,20 +132,22 @@ Companion UI read-mode clicks are an acceleration of this checkbox semantics. Th
 
 Only task checkboxes inside a valid Panel `AI-åtgärder` section are eligible for Panel confirmation. Ordinary Markdown task checkboxes remain ordinary task checkboxes. Checkboxes inside fenced code blocks or other non-Panel regions are not Panel actions.
 
+Current implementation: Companion UI read mode uses `POST /api/panel/checkbox-projection` for runtime-mediated projection of runtime-declared selectable Panel options. The existing staged `POST /api/panel/confirm` endpoint remains the transient staged-proposal confirmation path and is not the source-backed Markdown checkbox projection endpoint.
+
 ### Panel identity vocabulary
 
 - `panel_id`: Runtime identifier for one parsed Panel block within one note/artifact. It scopes proposals and options but does not identify an option by itself.
 - `proposal_id`: Identifier for one proposal-generation event or staged proposal set. It groups options produced together and may be useful for receipts or freshness checks, but it is not by itself the durable identity of an individual selectable checkbox option.
-- `option_id`: Durable identity for one selectable Panel option line in `AI-åtgärder`. This is the identity a Companion UI projection request must target.
+- `option_id`: Durable identity for one selectable Panel option line in `AI-åtgärder`. This is the identity a Companion UI projection request must target. Newly generated runtime proposals use the explicit Markdown marker `<!--ai:option_id=opt_...-->`.
 - `action_id`: Canonical catalog/runtime action identifier, such as `promote.evergreen`. Multiple options may map to the same `action_id` with different labels, parameters, evidence, or source locations.
 - `ai:id`: Existing hidden Markdown marker used by current runtime idempotency/removal paths. Existing implementations may derive it from a label hash. Therefore it MUST NOT be treated as a durable `option_id` until this document explicitly promotes it and defines collision, duplicate-label, and migration semantics.
 - `ai:proposed`: Existing hidden Markdown marker that means the checkbox was system-proposed and is still pending human confirmation. It is not a unique option identity.
 - `source_line` / `source_range`: The source location of the option line in the current note content, using runtime-defined line/range indexing. It is a locator and freshness aid, not authority by itself.
 - `source_hash` / `content_hash`: Hash over the current note content or over the relevant source range, used to reject stale UI projections. The hash proves the UI is acting on the same content snapshot the runtime validates; it is not an identity substitute.
 
-Blocking identity decision: before Companion UI read-mode checkbox confirmation is implemented, the docs MUST decide whether `ai:id` is promoted to durable `option_id` with stronger generation rules, or whether a new explicit option marker such as `<!--ai:option_id=...-->` is introduced. Until then, Companion UI must not infer durable option identity from label text, rendered DOM position, or `ai:proposed`.
+Identity decision: Companion UI read-mode checkbox projection uses a new explicit durable option marker, `<!--ai:option_id=opt_...-->`. Existing `ai:id` is not promoted to durable option identity; it remains legacy/current runtime idempotency and removal metadata. Existing `ai:proposed` remains only a pending/provenance marker.
 
-Recommended decision: introduce a new explicit `option_id` marker and leave `ai:id` as a legacy/current runtime idempotency and removal marker until the runtime is migrated.
+Companion UI must not infer durable option identity from label text, rendered DOM position, or `ai:proposed`. Existing proposal lines without `ai:option_id` remain parseable for legacy runtime behavior, but they are not Companion UI read-mode clickable.
 
 ### Example
 ```markdown

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -43,8 +43,7 @@ Execution:
 
 ## Panel Read-Mode Checkbox Projection Coverage
 
-Future implementation of Companion UI read-mode Panel checkbox confirmation must include focused
-coverage before it can be claimed as supported runtime behavior:
+Companion UI read-mode Panel checkbox confirmation must keep focused coverage for:
 
 - Parser/mapping tests proving only valid `AI-åtgärder` task checkboxes are eligible and code-block/ordinary-task checkboxes are excluded.
 - Projection endpoint validation tests for `note_path`/`artifact_id`, `panel_id`, `option_id`, `content_hash`/`source_hash`, pending/selectable status, and stale-content rejection.
@@ -56,8 +55,9 @@ coverage before it can be claimed as supported runtime behavior:
 - Ordinary Markdown task-list regression tests proving generic rendered task-list DOM never becomes Panel authority.
 - Obsidian/text-editor compatibility tests proving manually changing `- [ ]` to `- [x]` in a valid Panel remains a valid confirmation path.
 
-This coverage is future-facing. It does not claim the existing `POST /api/panel/confirm` path already
-performs source-backed checkbox projection.
+The source-backed read-mode projection endpoint is `POST /api/panel/checkbox-projection`.
+The existing `POST /api/panel/confirm` path remains the staged/transient confirm API and
+must not be treated as Markdown checkbox projection coverage.
 
 ## Layer mapping
 | Layer | Focus | Representative suites | Command |

--- a/tests/agents/panel_agent/test_panel_option_id_writeback.py
+++ b/tests/agents/panel_agent/test_panel_option_id_writeback.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from app.agents.panel.parser import parse_panel
+from app.agents.panel_agent.runtime import _write_proposals_to_panel
+
+
+def _panel() -> str:
+    return (
+        "# Note\n"
+        "%% AI:Start %%\n"
+        "## AI-instruktion\n"
+        "Do something.\n"
+        "## AI-åtgärder\n"
+        "%% AI:End %%\n"
+    )
+
+
+def test_generated_proposal_lines_include_option_id() -> None:
+    updated = _write_proposals_to_panel(
+        _panel(),
+        [("promote.evergreen", "Make this note evergreen")],
+        option_id_factory=lambda: "opt_test_1",
+    )
+
+    assert "<!--ai:option_id=opt_test_1-->" in updated
+    assert "<!--ai:id=" in updated
+    assert "<!--ai:proposed=979-->" in updated
+    parsed = parse_panel(updated)
+    assert parsed.actions[0].option_id == "opt_test_1"
+
+
+def test_rerun_does_not_duplicate_existing_proposal() -> None:
+    first = _write_proposals_to_panel(
+        _panel(),
+        [("promote.evergreen", "Make this note evergreen")],
+        option_id_factory=lambda: "opt_first",
+    )
+    second = _write_proposals_to_panel(
+        first,
+        [("promote.evergreen", "Make this note evergreen")],
+        option_id_factory=lambda: "opt_second",
+    )
+
+    assert second.count("Make this note evergreen") == 1
+    assert "opt_first" in second
+    assert "opt_second" not in second
+
+
+def test_duplicate_labels_get_distinct_option_ids_when_generated() -> None:
+    ids = iter(["opt_a", "opt_b"])
+
+    updated = _write_proposals_to_panel(
+        _panel(),
+        [
+            ("proposal.one", "Duplicate label"),
+            ("proposal.two", "Duplicate label"),
+        ],
+        option_id_factory=lambda: next(ids),
+    )
+
+    assert "<!--ai:option_id=opt_a-->" in updated
+    assert "<!--ai:option_id=opt_b-->" in updated

--- a/tests/agents/panel_agent/test_parser.py
+++ b/tests/agents/panel_agent/test_parser.py
@@ -40,3 +40,23 @@ def test_parse_panel_extracts_instruction_and_actions() -> None:
 
     assert labels == ["Action label 1", "Action label 2", "Action label 3"]
     assert states == [False, True, False]
+
+
+def test_parse_panel_accepts_option_id_metadata_in_any_order() -> None:
+    panel_block = """%% AI:Start %%
+### AI-instruktion
+Gör en sak.
+
+### AI-åtgärder
+- [ ] Action label <!--ai:proposed=979--> <!--ai:option_id=opt_runtime--> <!--ai:id=action.id-->
+%% AI:End %%
+"""
+
+    parsed = parse_panel(panel_block, panel_id="panel-1")
+
+    assert len(parsed.actions) == 1
+    action = parsed.actions[0]
+    assert action.label == "Action label"
+    assert action.option_id == "opt_runtime"
+    assert action.action_id == "action.id"
+    assert action.proposal_pending is True

--- a/tests/agents/test_panel_parser.py
+++ b/tests/agents/test_panel_parser.py
@@ -141,3 +141,39 @@ def test_parse_panel_action_with_ai_id_comment():
     assert action.action_id == "promote.evergreen"
     assert action.checked is True
     assert action.text == "Make this note evergreen"
+
+
+def test_parse_panel_action_with_option_id_and_metadata_any_order():
+    markdown = textwrap.dedent(
+        """
+        ## AI-åtgärder
+        - [ ] Make this note evergreen <!--ai:proposed=979--> <!--ai:option_id=opt_abc--> <!--ai:id=promote.evergreen-->
+        """
+    )
+
+    state = parse_panel(markdown)
+
+    assert len(state.actions) == 1
+    action = state.actions[0]
+    assert action.text == "Make this note evergreen"
+    assert action.option_id == "opt_abc"
+    assert action.action_id == "promote.evergreen"
+    assert action.proposal_pending is True
+
+
+def test_parse_panel_label_strips_known_ai_comments_but_keeps_old_lines_parseable():
+    markdown = textwrap.dedent(
+        """
+        ## AI-åtgärder
+        - [ ] Old proposal <!--ai:id=old-id--> <!--ai:proposed=979-->
+        - [ ] New proposal <!--ai:option_id=opt_new--> <!--ai:proposed=979-->
+        """
+    )
+
+    state = parse_panel(markdown)
+
+    assert [action.text for action in state.actions] == ["Old proposal", "New proposal"]
+    assert state.actions[0].action_id == "old-id"
+    assert state.actions[0].option_id is None
+    assert state.actions[0].proposal_pending is True
+    assert state.actions[1].option_id == "opt_new"

--- a/tests/api/test_companion_workspace_api.py
+++ b/tests/api/test_companion_workspace_api.py
@@ -189,6 +189,39 @@ def test_workspace_panel_state(client: TestClient, vault_note: Path) -> None:
     assert panel["blocked_reason"] is None
 
 
+def test_workspace_panel_state_exposes_source_backed_selectable_options(
+    client: TestClient,
+    vault_note: Path,
+) -> None:
+    vault_note.write_text(
+        "---\n"
+        "uuid: note-uuid-1\n"
+        "---\n\n"
+        "# Test Note\n\n"
+        "- [ ] ordinary task\n\n"
+        "%% AI:Start %%\n"
+        "## AI-instruktion\n"
+        "Do the thing.\n"
+        "## AI-åtgärder\n"
+        "- [ ] Send email <!--ai:option_id=opt_workspace--> <!--ai:id=send.email--> <!--ai:proposed=979-->\n"
+        "%% AI:End %%\n",
+        encoding="utf-8",
+    )
+
+    resp = _workspace(client)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    panel = data["panel"]
+    assert panel["state"] == "proposals-staged"
+    assert panel["proposal_count"] == 1
+    options = panel["selectable_options"]
+    assert len(options) == 1
+    assert options[0]["option_id"] == "opt_workspace"
+    assert options[0]["content_hash"] == data["artifact"]["content_hash"]
+    assert options[0]["selectable"] is True
+
+
 def test_workspace_artifact_id_uses_frontmatter_uuid(client: TestClient, vault_note: Path) -> None:
     resp = _workspace(client)
 

--- a/tests/companion_ui/test_markdown_renderer_lists.py
+++ b/tests/companion_ui/test_markdown_renderer_lists.py
@@ -104,6 +104,78 @@ def test_unchecked_task_remains_unchecked():
     li = re.search(r'<li class="task-list-item"[^>]*>.*?</li>', html, re.S).group(0)
     assert 'data-task-state=" "' in li
     assert "checked" not in li
+    assert "<input type=\"checkbox\" disabled>" in li
+
+
+def test_panel_selectable_option_checkbox_is_clickable_with_projection_attrs():
+    md = "- [ ] Send email <!--ai:option_id=opt_ui--> <!--ai:id=send.email--> <!--ai:proposed=979-->\n"
+    rendered = render_vault_markdown(
+        md,
+        panel_selectable_options=[
+            {
+                "artifact_id": "note-uuid-1",
+                "note_path": "notes/panel.md",
+                "panel_id": "panel-1",
+                "option_id": "opt_ui",
+                "action_id": "send.email",
+                "label": "Send email",
+                "checked": False,
+                "proposal_pending": True,
+                "source_range": {"start_line": 0, "end_line": 1},
+                "source_hash": "source-hash",
+                "content_hash": "content-hash",
+                "selectable": True,
+            }
+        ],
+    )
+
+    li = re.search(r'<li class="task-list-item"[^>]*>.*?</li>', rendered.html, re.S).group(0)
+    assert 'data-panel-checkbox="true"' in li
+    assert 'data-panel-id="panel-1"' in li
+    assert 'data-option-id="opt_ui"' in li
+    assert 'data-source-hash="source-hash"' in li
+    assert 'data-content-hash="content-hash"' in li
+    assert "<input type=\"checkbox\" disabled" not in li
+
+
+def test_renderer_does_not_enable_task_without_runtime_declared_option():
+    md = "- [ ] Send email <!--ai:option_id=opt_ui--> <!--ai:id=send.email--> <!--ai:proposed=979-->\n"
+    html = render_vault_markdown(md, panel_selectable_options=[]).html
+    li = re.search(r'<li class="task-list-item"[^>]*>.*?</li>', html, re.S).group(0)
+
+    assert 'data-panel-checkbox="true"' not in li
+    assert "<input type=\"checkbox\" disabled>" in li
+
+
+def test_panel_checkbox_source_line_matches_full_markdown_with_frontmatter():
+    md = (
+        "---\n"
+        "uuid: note-uuid-1\n"
+        "---\n\n"
+        "# Note\n\n"
+        "- [ ] Send email <!--ai:option_id=opt_ui--> <!--ai:id=send.email--> <!--ai:proposed=979-->\n"
+    )
+    html = render_vault_markdown(
+        md,
+        panel_selectable_options=[
+            {
+                "artifact_id": "note-uuid-1",
+                "note_path": "notes/panel.md",
+                "panel_id": "panel-1",
+                "option_id": "opt_ui",
+                "action_id": "send.email",
+                "label": "Send email",
+                "checked": False,
+                "proposal_pending": True,
+                "source_range": {"start_line": 6, "end_line": 7},
+                "source_hash": "source-hash",
+                "content_hash": "content-hash",
+                "selectable": True,
+            }
+        ],
+    ).html
+
+    assert 'data-panel-checkbox="true"' in html
 
 
 def test_task_list_allows_blank_spacer_lines():

--- a/tests/companion_ui/test_panel_checkbox_projection_read_mode.py
+++ b/tests/companion_ui/test_panel_checkbox_projection_read_mode.py
@@ -66,3 +66,7 @@ def test_read_mode_panel_option_has_projection_affordance_and_ordinary_task_is_d
     assert 'data-source-hash="source-hash"' in html
     assert "/api/panel/checkbox-projection" in html
     assert "/api/companion/workspace?note_path=" in html
+    assert "panelProjectionSucceeded(result.data)" in html
+    assert "'blocked'" in html
+    assert "'failed'" in html
+    assert "panel-checkbox-feedback" in html

--- a/tests/companion_ui/test_panel_checkbox_projection_read_mode.py
+++ b/tests/companion_ui/test_panel_checkbox_projection_read_mode.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from companion_ui.workspace.serve_dev_page import render_index_html
+
+
+def _fields() -> dict:
+    return {
+        "title": "Panel Note",
+        "note_path": "notes/panel.md",
+        "artifact_id": "note-uuid-1",
+        "artifact_kind": "human_note",
+        "artifact_identity_source": "frontmatter.uuid",
+        "artifact_identity_state": "resolved",
+        "artifact_owns_identity": True,
+        "content_hash": "content-hash",
+        "body": (
+            "# Panel Note\n\n"
+            "- [ ] ordinary task\n\n"
+            "%% AI:Start %%\n"
+            "## AI-instruktion\n"
+            "Do the thing.\n"
+            "## AI-åtgärder\n"
+            "- [ ] Send email <!--ai:option_id=opt_ui--> <!--ai:id=send.email--> <!--ai:proposed=979-->\n"
+            "%% AI:End %%\n"
+        ),
+        "panel_state": "proposals-staged",
+        "panel_proposal_count": 1,
+        "panel_selectable_options": [
+            {
+                "artifact_id": "note-uuid-1",
+                "note_path": "notes/panel.md",
+                "panel_id": "panel-1",
+                "option_id": "opt_ui",
+                "action_id": "send.email",
+                "label": "Send email",
+                "checked": False,
+                "proposal_pending": True,
+                "source_range": {"start_line": 8, "end_line": 9},
+                "source_hash": "source-hash",
+                "content_hash": "content-hash",
+                "selectable": True,
+            }
+        ],
+        "guard_writeguard_status": "ok",
+        "guard_canvas_enabled": True,
+        "guard_degraded": False,
+        "is_production_ui": False,
+        "dev_page_label": "dev/staging",
+    }
+
+
+def test_read_mode_panel_option_has_projection_affordance_and_ordinary_task_is_disabled() -> None:
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        note_path="notes/panel.md",
+        fields=_fields(),
+    )
+
+    ordinary_index = html.index("ordinary task")
+    ordinary_input = html.rfind("<input", 0, ordinary_index)
+    assert "disabled" in html[ordinary_input:ordinary_index]
+
+    assert 'data-panel-checkbox="true"' in html
+    assert 'data-panel-id="panel-1"' in html
+    assert 'data-option-id="opt_ui"' in html
+    assert 'data-source-hash="source-hash"' in html
+    assert "/api/panel/checkbox-projection" in html
+    assert "/api/companion/workspace?note_path=" in html

--- a/tests/panel/test_panel_checkbox_projection.py
+++ b/tests/panel/test_panel_checkbox_projection.py
@@ -222,6 +222,38 @@ def test_projection_endpoint_duplicate_idempotency_key_returns_cached_response(
     assert runtime.call_count == 1
 
 
+def test_projection_endpoint_runtime_failure_rolls_back_for_retry(
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    note = _write_note(tmp_path)
+    runtime = MagicMock(side_effect=RuntimeError("transient"))
+    monkeypatch.setattr(projection_module, "run_panel_note_execution", runtime)
+    body = _request_for(note)
+
+    resp = client.post("/api/panel/checkbox-projection", json=body)
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "failed"
+    assert "- [ ] Send email <!--ai:option_id=opt_abc-->" in note.read_text(encoding="utf-8")
+
+    retry_body = _request_for(note)
+    retry_body["idempotency_key"] = "idem-retry"
+    monkeypatch.setattr(
+        projection_module,
+        "run_panel_note_execution",
+        MagicMock(return_value=MagicMock(runtime_results=[object()])),
+    )
+
+    retry = client.post("/api/panel/checkbox-projection", json=retry_body)
+
+    assert retry.status_code == 200
+    assert retry.json()["status"] == "executed"
+    assert "- [x] Send email <!--ai:option_id=opt_abc-->" in note.read_text(encoding="utf-8")
+
+
 def test_projection_endpoint_writeguard_blocked_does_not_project(
     client: TestClient,
     tmp_path: Path,

--- a/tests/panel/test_panel_checkbox_projection.py
+++ b/tests/panel/test_panel_checkbox_projection.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.panel.checkbox_projection as projection_module
+from app.api.app import app
+from app.api.routes.artifacts import _content_hash
+from app.panel.checkbox_projection import extract_panel_selectable_options
+from app.write_guard import DEFAULT_WRITE_GUARD, WriteGuard, WritesBlockedError
+
+
+@pytest.fixture(autouse=True)
+def _clear_projection_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    projection_module._idempotency_store.clear()
+    projection_module._service._guard = DEFAULT_WRITE_GUARD
+    monkeypatch.setenv("PANEL_AGENT_DECIDER", "rule")
+    yield
+    projection_module._idempotency_store.clear()
+    projection_module._service._guard = DEFAULT_WRITE_GUARD
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def _panel_note(*, checked: bool = False, option_id: str = "opt_abc") -> str:
+    mark = "x" if checked else " "
+    return (
+        "---\n"
+        "uuid: note-uuid-1\n"
+        "---\n\n"
+        "# Note\n\n"
+        "- [ ] ordinary task\n\n"
+        "```markdown\n"
+        "- [ ] code task <!--ai:option_id=opt_code--> <!--ai:id=code--> <!--ai:proposed=979-->\n"
+        "```\n\n"
+        "%% AI:Start %%\n"
+        "## AI-instruktion\n"
+        "Do the thing.\n"
+        "## AI-åtgärder\n"
+        f"- [{mark}] Send email <!--ai:option_id={option_id}--> <!--ai:id=send.email--> <!--ai:proposed=979-->\n"
+        "- [ ] Missing identity <!--ai:id=legacy--> <!--ai:proposed=979-->\n"
+        "## AI-logg\n"
+        "- [ ] receipt checkbox <!--ai:option_id=opt_receipt--> <!--ai:id=receipt--> <!--ai:proposed=979-->\n"
+        "%% AI:End %%\n"
+    )
+
+
+def _write_note(tmp_path: Path, content: str | None = None) -> Path:
+    note = tmp_path / "notes" / "panel.md"
+    note.parent.mkdir(parents=True, exist_ok=True)
+    note.write_text(content or _panel_note(), encoding="utf-8")
+    return note
+
+
+def _request_for(note: Path, *, option_id: str = "opt_abc") -> dict:
+    content = note.read_text(encoding="utf-8")
+    option = next(
+        option
+        for option in extract_panel_selectable_options(
+            content,
+            artifact_id="note-uuid-1",
+            note_path="notes/panel.md",
+            content_hash=_content_hash(content),
+        )
+        if option.option_id == option_id
+    )
+    return {
+        "artifact_id": option.artifact_id,
+        "note_path": option.note_path,
+        "panel_id": option.panel_id,
+        "option_id": option.option_id,
+        "expected_content_hash": option.content_hash,
+        "expected_source_hash": option.source_hash,
+        "idempotency_key": "idem-1",
+    }
+
+
+def test_option_extraction_only_returns_panel_actions_with_option_id() -> None:
+    content = _panel_note()
+
+    options = extract_panel_selectable_options(
+        content,
+        artifact_id="note-uuid-1",
+        note_path="notes/panel.md",
+    )
+
+    assert [option.option_id for option in options] == ["opt_abc"]
+    option = options[0]
+    assert option.panel_id == "panel-1"
+    assert option.action_id == "send.email"
+    assert option.label == "Send email"
+    assert option.checked is False
+    assert option.proposal_pending is True
+    assert option.selectable is True
+    source_line = content.splitlines()[option.source_range.start_line]
+    assert option.source_hash == projection_module._source_line_hash(source_line)
+
+
+def test_projection_endpoint_checks_markdown_source_and_projects_checkbox(
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    note = _write_note(tmp_path)
+    runtime_result = MagicMock(runtime_results=[object()])
+    monkeypatch.setattr(projection_module, "run_panel_note_execution", MagicMock(return_value=runtime_result))
+
+    resp = client.post("/api/panel/checkbox-projection", json=_request_for(note))
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "executed"
+    assert data["content_hash_before"] != data["content_hash_after"]
+    updated = note.read_text(encoding="utf-8")
+    assert "- [x] Send email <!--ai:option_id=opt_abc-->" in updated
+    assert "- [ ] ordinary task" in updated
+
+
+def test_projection_endpoint_rejects_stale_content_hash(
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    note = _write_note(tmp_path)
+    body = _request_for(note)
+    body["expected_content_hash"] = "stale"
+
+    resp = client.post("/api/panel/checkbox-projection", json=body)
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["status"] == "stale"
+    assert "- [x] Send email" not in note.read_text(encoding="utf-8")
+
+
+def test_projection_endpoint_rejects_stale_source_hash(
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    note = _write_note(tmp_path)
+    body = _request_for(note)
+    body["expected_source_hash"] = "stale"
+
+    resp = client.post("/api/panel/checkbox-projection", json=body)
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["block_reason"] == "source_hash_mismatch"
+
+
+def test_projection_endpoint_unknown_option_returns_404(
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    note = _write_note(tmp_path)
+    body = _request_for(note)
+    body["option_id"] = "opt_missing"
+
+    resp = client.post("/api/panel/checkbox-projection", json=body)
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"]["status"] == "not_found"
+
+
+def test_projection_endpoint_already_checked_is_idempotent(
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    note = _write_note(tmp_path, _panel_note(checked=True))
+    content = note.read_text(encoding="utf-8")
+    option = extract_panel_selectable_options(
+        content,
+        artifact_id="note-uuid-1",
+        note_path="notes/panel.md",
+        content_hash=_content_hash(content),
+    )[0]
+    body = {
+        "artifact_id": option.artifact_id,
+        "note_path": option.note_path,
+        "panel_id": option.panel_id,
+        "option_id": option.option_id,
+        "expected_content_hash": option.content_hash,
+        "expected_source_hash": option.source_hash,
+        "idempotency_key": "idem-checked",
+    }
+
+    resp = client.post("/api/panel/checkbox-projection", json=body)
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "already_projected"
+
+
+def test_projection_endpoint_duplicate_idempotency_key_returns_cached_response(
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    note = _write_note(tmp_path)
+    runtime = MagicMock(return_value=MagicMock(runtime_results=[object()]))
+    monkeypatch.setattr(projection_module, "run_panel_note_execution", runtime)
+    body = _request_for(note)
+
+    first = client.post("/api/panel/checkbox-projection", json=body)
+    second = client.post("/api/panel/checkbox-projection", json=body)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json() == second.json()
+    assert runtime.call_count == 1
+
+
+def test_projection_endpoint_writeguard_blocked_does_not_project(
+    client: TestClient,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VAULT_ROOT", str(tmp_path))
+    note = _write_note(tmp_path)
+    guard = MagicMock(spec=WriteGuard)
+    guard.assert_writes_allowed.side_effect = WritesBlockedError(
+        "blocked",
+        "guard active",
+        "panel.checkbox_projection",
+    )
+    projection_module._service._guard = guard
+
+    resp = client.post("/api/panel/checkbox-projection", json=_request_for(note))
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "blocked"
+    assert "- [x] Send email" not in note.read_text(encoding="utf-8")


### PR DESCRIPTION
## Direct Repair
Type: code
Reason: Implements the already-merged Panel checkbox projection contract from PR #1478 and addresses the read-mode checkbox projection path without opening a separate backlog issue.
Validation: local focused tests, docs guard, diff whitespace check, and repo-standard ruff gate passed.
Issue required: no

## Summary
Adds the runtime-mediated Panel checkbox projection path for Companion UI read-mode checkboxes, preserving vault-visible Panel checkbox semantics while validating source state and durable option identity.

## Changes
- Adds the checkbox projection runtime and Panel API/workspace wiring.
- Carries durable option identity through Panel parser/writeback/runtime surfaces.
- Updates the Companion Markdown renderer/dev page to expose eligible Panel proposal checkboxes without treating ordinary Markdown tasks as approvals.
- Updates the Panel/Companion contracts and focused test coverage for projection, parser/writeback identity, API workspace shape, and Markdown task-list regressions.
- Handles review feedback by rolling back failed post-projection execution and surfacing non-success projection statuses in the UI.

## Validation
- `git diff --check`
- `python3 scripts/docs_guard.py`
- `/Users/rasmusthornberg/code/agentic-pkm-mvp/.venv/bin/ruff check app tests`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/panel/test_panel_checkbox_projection.py tests/companion_ui/test_panel_checkbox_projection_read_mode.py tests/api/test_companion_workspace_api.py tests/agents/test_panel_parser.py tests/agents/panel_agent/test_parser.py tests/agents/panel_agent/test_panel_option_id_writeback.py tests/companion_ui/test_markdown_renderer_lists.py tests/api/test_panel_confirm_api.py tests/panel/test_panel_durable_projection.py` (75 passed)

---