### PR TITLE
Update learning retro workflow guardrails

### DIFF
--- a/.codex/skills/README.md
+++ b/.codex/skills/README.md
@@ -43,7 +43,7 @@ Conditional / maintenance path:
 - `capture-learning`
   - micro-skill: append one structured divergence entry to `docs/learning-log.md` when a plan divergence occurs; invoke on divergence, not on normal work
 - `learning-retrospective`
-  - cadence-triggered: read `docs/learning-log.md` since last retro marker, cluster by upstream artifact, propose concrete edits for human review, append retro marker after human response
+  - cadence-triggered: read `docs/learning-log.md` since last retro marker, cluster by upstream artifact, propose concrete edits for human review; when explicitly requested, run autonomous maintenance by applying safe governance fixes, creating Issues for unresolved work, and appending the retro marker after every entry is resolved or tracked
 - `learning-to-issue`
   - convert retrospective learnings (learning-log entries, live PR/CI divergences) into canonical bounded GitHub Issues; also normalizes raw-intake issues created outside the standard contract
 - `promote-to-test`

--- a/.codex/skills/learning-retrospective/SKILL.md
+++ b/.codex/skills/learning-retrospective/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: learning-retrospective
-description: "Read docs/learning-log.md since the last retro marker, cluster signals by upstream artifact, propose concrete edits for human review, then append a retro marker. Does NOT auto-execute edits."
+description: "Read docs/learning-log.md since the last retro marker, cluster signals by upstream artifact, propose concrete edits for human review, or execute explicit autonomous maintenance when requested."
 ---
 
 # Learning Retrospective
 
 Periodic maintenance pass. Reads batched divergence signals logged since the last retrospective and converts them into concrete, actionable edit proposals for upstream artifacts.
 
-**Does NOT execute edits.** All proposals go to human review first.
+Default mode is proposal-only: do not execute edits unless the human explicitly asks the agent to handle the retro, apply safe workflow fixes, or create Issues for unresolved work.
 
 ## Trigger
 
@@ -62,7 +62,18 @@ Output all proposals clearly. State:
 
 Wait for human response (which proposals to accept, which to reject).
 
-### Step 5: Append retro marker
+### Step 5: Autonomous maintenance mode
+
+Use this mode only when the human explicitly asks the agent to handle the retro end to end, improve the workflow, or create Issues for unresolved learnings.
+
+In autonomous maintenance mode:
+- apply only safe governance-lane edits whose upstream artifact is named by the log entry and whose exact repair is clear;
+- verify whether any proposals were already applied by current repo reality before editing again;
+- create canonical GitHub Issues via `learning-to-issue` for unresolved work, storage decisions, or changes that need human authority;
+- do not change product/runtime behavior;
+- do not append the retro marker until every entry since the last marker is either applied, already satisfied by repo reality, or represented by an Issue.
+
+### Step 6: Append retro marker
 
 After human responds (regardless of how many proposals are accepted), append to `docs/learning-log.md`:
 
@@ -72,7 +83,7 @@ After human responds (regardless of how many proposals are accepted), append to 
 
 Where N = accepted proposals, M = total proposals made.
 
-Accepted proposals should be committed as governance-lane PRs — either by the human or a follow-up agent run using the `publish-pr` skill.
+In autonomous maintenance mode, N = entries resolved directly or already satisfied by repo reality; M = entries considered. Accepted proposals should be committed as governance-lane PRs — either by the human or a follow-up agent run using the `publish-pr` skill.
 
 ## Success signal
 
@@ -86,5 +97,5 @@ After each retrospective, at least one upstream artifact should carry a dated ed
 
 1. Log scope (entries read, date range, last retro marker if any)
 2. Clusters formed (upstream artifact → entry count)
-3. Proposals (numbered, concrete, with artifact path and exact edit text)
+3. Proposals or autonomous actions (numbered, concrete, with artifact path and exact edit text or Issue receipt)
 4. Retro marker appended

--- a/.codex/skills/post-merge-owner-doc/SKILL.md
+++ b/.codex/skills/post-merge-owner-doc/SKILL.md
@@ -27,6 +27,8 @@ Then answer: does the diff change something those owner docs currently claim?
 
 The receipt comment always goes on the **closed issue** that the PR fixes. If the PR closed multiple issues, post the receipt on each one. If the PR closed no issues (docs-only lane, governance lane), post the receipt as a **PR comment** instead — the PR is then the auditable artifact.
 
+After posting, verify the receipt exists by reading back the issue or PR comments. A watchdog reminder, stale notification, or planned follow-up is not a `post-merge owner-doc check:` receipt. [owner-doc-receipt-gate]
+
 ## Three outcomes
 
 Classify the claim into one of three lanes: immediate action, queued follow-up, or no change.

--- a/.codex/skills/pr-integration/SKILL.md
+++ b/.codex/skills/pr-integration/SKILL.md
@@ -52,14 +52,18 @@ If any condition fails, stop and use the relevant escalation path.
 ## Hot-Path Execution
 
 - Classify the PR with the hot-path fields from `PR_HOT_PATH.md`.
-- Verify branch/worktree/current-SHA sanity before any commit or push.
+- Verify branch/worktree/current-SHA sanity before any commit or push. The active worktree must be the PR worktree, the branch name must match the PR head branch before commit/push, and local `HEAD`, tracked remote branch, and PR head SHA must agree before trusting CI attachment or merge readiness. [branch-truth-gate]
 - Run only the relevant checks for the lane and risk.
 - Triage review feedback into blocking, cheap fix, out-of-scope, or incorrect/not-applicable.
+- For review-feedback repairs, verify the fixing commit is reachable from the target base branch before declaring the repair complete. If the repair addresses an earlier review thread, reply with the fixing PR or merge commit and resolve the original thread. [base-branch-truth] [review-thread-closure]
+- On resume or recovery, re-check the current branch, `origin/main`, relevant merged PRs, and expected implementation files before continuing publication, integration, or reimplementation. [post-resume-current-state-gate]
 - Write the minimal delivery receipt before handoff.
 - A governing issue is required for normal planned workflow; a bounded direct repair PR may proceed without one if the PR body includes a complete `Direct Repair` block.
 - Do not require a separate governance/docs lane checkbox when the `Direct Repair` block already states `Type` and `Validation`.
 - Missing issue traceability is an escalation trigger only when the PR is neither issue-backed nor a valid direct repair PR.
 - If CI fails, review blocks, branch drifts, or the PR is large or mixed-scope, stop and read `PR_ESCALATION_PATHS.md`.
+- If CI reports an unavailable pytest flag such as `-n`/`--dist`, check for `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` and require an explicit `-p <plugin_name>` load before adding or changing dependencies. [plugin-load-guard]
+- After a review-fix push where GitHub's merge ref may differ from branch HEAD, fetch `refs/pull/<PR>/merge`, inspect touched symbols in that tree, and run at least one targeted test against the merge-ref worktree before declaring `ready-for-verification`. [merge-ref-validation]
 
 ## Escalation References
 

--- a/.codex/skills/verification-and-closure/SKILL.md
+++ b/.codex/skills/verification-and-closure/SKILL.md
@@ -39,6 +39,7 @@ Test/check failures must be classified, not dismissed as merely "out of scope" w
 - roadmap / status / plan docs
 - CI results
 - merge state if already merged
+- current `origin/main` / target-base reachability for any resumed, chained, or review-repair work
 
 ## Validation Rules
 
@@ -54,6 +55,9 @@ Test/check failures must be classified, not dismissed as merely "out of scope" w
 - Verify no duplicate `planned` and `shipped` statements remain active at once
 - Verify project lifecycle state still makes sense
 - Verify closed terminal PR cards do not remain blank in the Project
+- Verify review-feedback repairs are present on the target base branch before treating them as closed; a side branch or intermediate PR is not enough unless the fixing commit is reachable from the final merge target. [base-branch-truth]
+- If the work addresses earlier review feedback, reply to and resolve the original review thread with the fixing PR or merge commit before final closure. [review-thread-closure]
+- On resume or recovery, re-check branch, `origin/main`, relevant merged PRs, and expected implementation files before continuing publication, reimplementation, or closure. [post-resume-current-state-gate]
 - If the work is a slice under a larger feature, keep post-merge validation evidence on the parent issue
 - If post-merge validation advanced but acceptance is still pending, record the new evidence on the parent issue body or comments
 - If work is incomplete, do not close the loop falsely; create a bounded follow-up Issue instead
@@ -84,6 +88,7 @@ Prerequisites for merge:
 - current SHA truth is intact
 - required checks are green on the current head SHA
 - no unresolved blocking review comments remain
+- no addressed review thread remains unresolved without a reply naming the fixing PR or merge commit
 - no scope drift remains
 - the PR fits one of the two verification modes above
 - if issue-backed, all acceptance criteria from the governing Issue are satisfied and every AC's `Verify:` target resolves green on the current head SHA
@@ -102,7 +107,7 @@ When all prerequisites are met:
 8. if issue-backed, for each spec file named in the Issue's `Source Anchors`, restore any stale `State: Not yet implemented` line to `State: Implemented. Delivered by PR #<PR> (issue #<N>, <YYYY-MM-DD>).`
 9. verify final state
 10. if issue-backed, invoke `post-merge-owner-doc` on the merged PR
-11. assert the receipt exists before emitting a delivery receipt
+11. assert the `post-merge owner-doc check:` receipt exists before emitting a delivery receipt; watchdog reminders or pending reminders are not closure receipts. For direct-repair, docs-lane, or governance-lane PRs with no closing issue, verify the receipt on the PR comment thread. [owner-doc-receipt-gate]
 12. if direct repair, write a direct repair delivery receipt instead of issue-closure state changes
 
 ## When Not to Merge

--- a/.codex/skills/verification-and-closure/SKILL.md
+++ b/.codex/skills/verification-and-closure/SKILL.md
@@ -106,7 +106,7 @@ When all prerequisites are met:
 7. if issue-backed, set Issue and PR Project Status to `Done` if automation has not already projected it
 8. if issue-backed, for each spec file named in the Issue's `Source Anchors`, restore any stale `State: Not yet implemented` line to `State: Implemented. Delivered by PR #<PR> (issue #<N>, <YYYY-MM-DD>).`
 9. verify final state
-10. if issue-backed, invoke `post-merge-owner-doc` on the merged PR
+10. invoke `post-merge-owner-doc` on the merged PR. For issue-backed PRs, the receipt belongs on the closed issue; for direct-repair, docs-lane, or governance-lane PRs with no closing issue, the receipt belongs on the PR comment thread.
 11. assert the `post-merge owner-doc check:` receipt exists before emitting a delivery receipt; watchdog reminders or pending reminders are not closure receipts. For direct-repair, docs-lane, or governance-lane PRs with no closing issue, verify the receipt on the PR comment thread. [owner-doc-receipt-gate]
 12. if direct repair, write a direct repair delivery receipt instead of issue-closure state changes
 

--- a/docs/development/DELIVERY_FEEDBACK_LOOP.md
+++ b/docs/development/DELIVERY_FEEDBACK_LOOP.md
@@ -68,12 +68,14 @@ This lets the retrospective skill scope its next read to entries since the last 
 
 Cadence-triggered (manual, or roughly every 10 deliveries). Reads `docs/learning-log.md` since the last retro marker.
 
-**What it does:**
+**What it does by default:**
 1. Clusters signals by upstream artifact.
 2. Proposes **concrete edits** (diffs or specific line additions) to those artifacts — not vague recommendations.
 3. Does NOT execute edits. Outputs proposals for human review.
 4. Accepted proposals are committed as ordinary governance-lane PRs.
 5. Appends a retro marker to the log.
+
+When the human explicitly asks the agent to handle the retro end to end, the retrospective may run in autonomous maintenance mode: verify which entries are already satisfied by current repo reality, apply safe governance-lane edits for clearly named artifacts, create GitHub Issues for unresolved or decision-bearing work, and append the retro marker only after every entry since the last marker is either applied, already satisfied, or represented by an Issue.
 
 **Success signal for the retrospective itself:** upstream artifacts carry dated edits traceable to log entries. If AGENTS.md and skill prompts are static while the log grows, the retrospective step is broken.
 

--- a/docs/development/PR_HOT_PATH.md
+++ b/docs/development/PR_HOT_PATH.md
@@ -38,6 +38,7 @@ Default rule:
 - failing checks must be classified before merge
 
 3. Review feedback triage
+- after CI is green and current, fetch existing review comments before any handoff or merge recommendation; do not park the PR as "awaiting human review" until posted comments are classified
 - blocking regression risk -> fix before merge
 - valid non-blocking improvement -> fix if cheap, otherwise file a follow-up
 - out-of-scope -> short response; follow-up only if useful

--- a/docs/learning-log.md
+++ b/docs/learning-log.md
@@ -145,3 +145,10 @@ Resolution note (2026-05-06): verified `app/orchestrator/v2_runtime.py` now cont
 **Source:** human / verification-and-closure
 **Diverged:** The recovery plan assumed the Panel checkbox projection implementation still needed to be published from the current checkout, but current `main` already contained the merged implementation via PR #1486 and the active root checkout had switched back to `main`.
 **Upstream artifact:** `.codex/skills/pr-integration/SKILL.md` + `.codex/skills/verification-and-closure/SKILL.md` — add an explicit post-resume/current-state gate to re-check branch, `origin/main`, merged PRs, and expected implementation files before continuing publication or reimplementation work.
+
+## 2026-06-01 — learning retro (redirected workspace patch path)
+**Source:** learning-retrospective
+**Diverged:** The startup rule said to switch context to the canonical repo root, but a file-edit patch attempt still resolved relative paths against `/Users/rasmusthornberg/Documents/New project` until the repo-root patch command was run from the canonical cwd.
+**Upstream artifact:** `/Users/rasmusthornberg/Documents/New project/AGENTS.md` — make the workspace redirect rule explicit about verifying file-edit tool path resolution before trusting a patch.
+
+--- retro 2026-06-01: applied 11/11 proposals ---


### PR DESCRIPTION
- [x] Governance lane

## Summary
Run the learning-log retrospective through the current repo state and update the repo-local workflow skills so the same classes of drift are caught earlier.

## Changes
- Adds explicit autonomous-maintenance mode for `learning-retrospective` when the user asks the agent to handle retro work end to end.
- Reinstates concrete `pr-integration` guards for branch truth, plugin-load failures, merge-ref validation, review-thread closure, base-branch reachability, and post-resume current-state checks.
- Tightens `verification-and-closure` and `post-merge-owner-doc` around review-thread closure and receipt verification.
- Appends the 2026-06-01 retro marker to `docs/learning-log.md` after applying the current 11 learning proposals.

## Validation
- `git diff --check`
- `python3 scripts/docs_guard.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/architecture/test_agent_skill_entrypoints.py tests/architecture/test_pr_hot_path_governance.py`

## Follow-ups
- #1495 decides where raw/noncanonical agent worklog material should live.
- #1496 adds a repo-owned Codex automation maintenance path for local automation cwd drift.

---