### PR TITLE
decision(builderops): define authority and promotion boundary (#1499)

### DIFF
--- a/docs/DOCS_INDEX.md
+++ b/docs/DOCS_INDEX.md
@@ -414,6 +414,7 @@ These directories are docs-only specification authority for v6.0 capability boun
 | docs/adr/0005-per-loop.md | ADR PER loop | Partially outdated | 2026-02-05 | Historical rationale for shared PER base; v5.5 uses mixed loop/graph implementations; delta noted. |
 | docs/adr/ADR-0006-deepagents-harness.md | ADR DeepAgents harness | Proposed | 2026-03-25 | Evaluation memo for DeepAgents as outer agent harness; decision pending pilot. |
 | docs/adr/ADR-0008-leave-point-cursor.md | ADR leave-point cursor | Proposed | 2026-05-31 | Decides that the Workspace Orientation leave-point cursor is admissible only as a bounded append-only operational trace pointer, not memory, durable workspace state, session truth, receipt, workflow resume command, UI-owned state, or vault artifact. |
+| docs/adr/ADR-0010-builderops-vault-authority-boundary.md | ADR BuilderOps Vault authority boundary | Accepted (docs/governance decision) | 2026-06-01 | Defines BuilderOps Vault as the operating plane for builder-agent work while preserving the repo as product/runtime truth authority; names BuilderOps surfaces, non-authority boundaries, projection boundaries, explicit promotion targets, and the raw worklog boundary from #1495. Docs-only; no runtime/store/CLI/schema/API/MCP/promotion-gateway behavior is implemented. |
 | docs/adrs/ADR-00xx-promotion-agent.md | ADR promotion agent | Partially outdated | 2026-02-05 | Historical lifecycle intent; current baseline uses DB outbox + idempotent promotion consumer; delta noted. |
 
 ## Legacy and Archive

--- a/docs/adr/ADR-0010-builderops-vault-authority-boundary.md
+++ b/docs/adr/ADR-0010-builderops-vault-authority-boundary.md
@@ -1,0 +1,221 @@
+State: Accepted - docs/governance decision for BuilderOps Vault authority. No runtime, store, CLI, schema, API, MCP, or promotion-gateway behavior is implemented.
+
+# ADR-0010: BuilderOps Vault Authority and Promotion Boundary
+
+**Date:** 2026-06-01
+**Status:** Accepted - docs/governance decision for #1499
+
+---
+
+## Context
+
+BuilderOps Vault needs an authority decision before any BuilderOps Vault implementation begins. The
+vault is intended to become the shared operating plane for builder-agent work, but that operating
+plane must not blur into product/runtime truth or silently rewrite repository authority.
+
+The active missing package is now the BuilderOps operating plane. The earlier Contextualization
+Layer package is not the active gap for this issue: #1093 through #1098 are completed docs/spec
+deliveries, and this ADR must not frame BuilderOps Vault as filling that completed package.
+
+#1495 raised the related raw agent worklog boundary: raw builder-agent work notes need a default
+home that does not pollute reviewed repo docs, `$CODEX_HOME`, or local-only ignored state. This ADR
+reconciles that boundary at the authority level. It does not implement storage or migrate any
+learning-log, roadmap, or docs freshness state.
+
+## Decision
+
+BuilderOps governs the building system.
+Repo governs product/runtime truth.
+GitHub Issues and skills are BuilderOps surfaces.
+Promotion across authority classes is explicit.
+No silent authority transfer.
+
+BuilderOps Vault is the BuilderOps operating plane. It may guide work, queue proposals, record
+signals, and generate projections. It may not silently change code, tests, runtime contracts,
+product ADRs, canonical architecture docs, current-state owner docs, or any other product/runtime
+truth surface.
+
+GitHub Issues remain the current executable task-contract surface. Repo-local skills under
+`.codex/skills/**` and `AGENTS.md` are BuilderOps-governance artifacts stored in the repo as
+bootstrap/executable copies until a future BuilderOps-to-repo export/promotion pipeline exists.
+
+## Authority model
+
+### A. BuilderOps domain
+
+BuilderOps governs the building system.
+
+BuilderOps Vault owns, or will own once implemented, builder-agent worklogs, learning signals,
+roadmap execution state, docs freshness state, maintenance queues, promotion intents, and
+builder-operation receipts.
+
+BuilderOps may guide work, queue proposals, record signals, and generate projections. Those objects
+are operating-plane material unless explicitly promoted across an authority boundary.
+
+### B. Product/runtime domain
+
+Repo governs product/runtime truth.
+
+The repository remains the authority surface for code, tests, product/runtime contracts, ADRs,
+canonical architecture docs, and current-state owner docs.
+
+Product/runtime truth changes only through normal repo authority gates. BuilderOps does not bypass
+tests, PR review, ADR/doc ownership, contract-governance requirements, or the product/runtime owner
+docs that define shipped reality.
+
+### C. Projection/mirror domain
+
+The projection/mirror domain includes generated views, exported summaries, dashboards, GitHub
+Project views, external board/tool projections, and generated repo/dashboard views.
+
+Projections are not authority by default. Generated projections must identify themselves as
+projections. Projection drift does not change source authority.
+
+## BuilderOps surfaces
+
+The following are BuilderOps surfaces even when stored in GitHub or in the repository:
+
+- GitHub Issues
+- `.codex/skills/**`
+- `AGENTS.md`
+
+GitHub Issues are BuilderOps artifacts and remain the current executable task-contract surface for
+implementation work. They are not product/runtime semantic truth.
+
+Repo-local skills under `.codex/skills/**` are BuilderOps-governance artifacts stored in the repo as
+bootstrap/executable copies. They sequence and operationalize builder-agent workflow, but they do
+not become product/runtime contracts merely because they live in the repository.
+
+`AGENTS.md` is a BuilderOps-governance surface while stored in the repo. It is the canonical
+builder-agent instruction entrypoint, not runtime/system-agent architecture.
+
+Changes to `.codex/skills/**` and `AGENTS.md` still require repo PR until a future
+BuilderOps-to-repo export/promotion pipeline exists. Storage in the repo is a bootstrap/executable
+mechanic, not an authority-class collapse.
+
+## Product/runtime non-authority boundary
+
+BuilderOps may propose, queue, route, and record.
+
+BuilderOps may not silently change code, tests, runtime contracts, product ADRs, canonical
+architecture docs, or current-state owner docs.
+
+No product/runtime contract changes without the repo authority gate.
+
+If BuilderOps evidence implies a product/runtime change, the output is a proposal, issue, PR,
+ADR/decision doc, or owner-doc writeback proposal. It is not silent truth mutation.
+
+## Projection/mirror boundary
+
+Generated views and dashboards are projections.
+
+External tool boards are projections unless the governing repo docs say otherwise.
+
+Projections must preserve provenance back to their source authority.
+
+Projection updates do not imply authority transfer.
+
+Projection drift is corrected by reconciling with the authoritative source, not by treating the
+projection as truth.
+
+## Promotion targets
+
+Allowed promotion targets are:
+
+- GitHub Issue
+- PR
+- ADR/decision doc
+- owner-doc writeback proposal
+- generated projection
+- discard receipt
+
+Promotion mapping:
+
+- BuilderOps operational signal -> GitHub Issue
+- BuilderOps decision -> skill/AGENTS proposal
+- BuilderOps task -> PR
+- BuilderOps finding -> owner-doc writeback proposal
+- BuilderOps projection -> generated repo/dashboard view
+- BuilderOps obsolete/invalid signal -> discard receipt
+
+A skill/AGENTS proposal is not self-applying. It crosses into repo authority through an explicit
+PR, and when appropriate through an owner-doc writeback proposal or ADR/decision doc.
+
+Promotion is an explicit boundary crossing, not automatic synchronization.
+
+## Raw worklog boundary
+
+This section reconciles #1495 at the authority level.
+
+Raw agent worklogs belong in BuilderOps Vault by default.
+
+Raw agent worklogs do not belong in reviewed repo docs by default.
+
+Raw agent worklogs do not belong in `$CODEX_HOME` by default.
+
+Raw agent worklogs do not belong in local-only ignored state by default, except as transient
+execution scratch/state.
+
+Raw worklogs may later be promoted into GitHub Issues, owner-doc writeback proposals, learning
+summaries, ADR/decision docs, generated projections, or discard receipts through explicit
+promotion.
+
+Raw worklog existence is not itself product/runtime truth.
+
+Until BuilderOps Vault storage exists, #1499 does not authorize a new permanent raw-worklog storage
+mechanic. `docs/learning-log.md`, where still used, remains a promoted learning-summary surface, not
+the default raw worklog store. Storage mechanics and migrations belong to #1500 and later issues.
+
+## Consequences
+
+BuilderOps Vault can become the shared operating plane for builder-agent work.
+
+GitHub Issues remain the current executable task-contract surface for now.
+
+Repo-local skills and `AGENTS.md` remain repo-stored bootstrap/executable copies for now.
+
+A future BuilderOps-to-repo export/promotion pipeline can change storage mechanics later, but not
+through #1499.
+
+Product/runtime contracts remain protected by normal repo gates.
+
+Generated projections must be labeled as projections.
+
+## Out of scope for #1499
+
+#1499 does not implement:
+
+- BuilderOps store
+- BuilderOps object schemas
+- CLI
+- API or MCP boundary
+- promotion gateway
+- migrations
+- moving `.codex/skills/**` out of the repo
+- replacing GitHub Issues as the current executable task-contract surface
+- changing product/runtime contracts
+- changing code, tests, or runtime behavior
+- migrating learning-log, docs freshness, or roadmap execution state
+
+These belong to #1500 and later issues unless the issue contract is updated.
+
+## Validation
+
+Acceptance criteria are discoverable with:
+
+```bash
+rg -n "BuilderOps governs the building system|GitHub Issues and skills are BuilderOps surfaces|Promotion targets|Raw worklog boundary" docs .codex AGENTS.md
+git diff --check docs .codex AGENTS.md
+python3 scripts/docs_guard.py
+```
+
+## References
+
+- #1498 - epic(builderops): create shared BuilderOps Vault operating plane
+- #1499 - decision(builderops): define BuilderOps Vault authority and promotion boundary
+- #1495 - type:task: decide raw agent worklog persistence boundary
+- `docs/CONCEPTS/RUNTIME_VS_DURABLE_STATE_BOUNDARY.md`
+- `docs/development/DELIVERY_FEEDBACK_LOOP.md`
+- `docs/DOCS_INDEX.md`
+- `docs/ROADMAP.md`
+- `AGENTS.md`

--- a/docs/adr/ADR-0010-builderops-vault-authority-boundary.md
+++ b/docs/adr/ADR-0010-builderops-vault-authority-boundary.md
@@ -125,7 +125,7 @@ Allowed promotion targets are:
 - GitHub Issue
 - PR
 - ADR/decision doc
-- owner-doc writeback proposal
+- owner-doc writeback proposal, including skill/AGENTS proposal for BuilderOps-governance surfaces
 - generated projection
 - discard receipt
 

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -14,5 +14,6 @@ State: Index (historical). ADRs are design records and may be partially outdated
 - [ADR 0007: Workspace State Contract — artifact-scoped vs note-independent scope split (proposed)](./ADR-0007-workspace-state-contract-scope-split.md)
 - [ADR 0008: Leave-point cursor as bounded operational trace (proposed)](./ADR-0008-leave-point-cursor.md)
 - [ADR 0009: Orientation MemoryCandidate intent threshold and trace semantics (accepted, implemented by #1457)](./ADR-0009-orientation-memory-candidate-intent.md)
+- [ADR 0010: BuilderOps Vault authority and promotion boundary (accepted, docs/governance)](./ADR-0010-builderops-vault-authority-boundary.md)
 - [ADR: Agentminne v1](./ADR-00X-agent-memory-v1.md)
 - [ADR: Agentminne v4.2](./ADR-00X-agent-memory-v42.md)


### PR DESCRIPTION
Closes #1499
Parent: #1498
Related: #1495

## Change Lane
- [ ] Implementation lane
- [ ] Docs authoring lane
- [x] Governance lane

## Summary
- Added ADR-0010 defining BuilderOps Vault authority, non-authority, projection, promotion, and raw worklog boundaries.
- Indexed the new ADR in `docs/adr/INDEX.md` and `docs/DOCS_INDEX.md`.

## Changed files
- `docs/adr/ADR-0010-builderops-vault-authority-boundary.md`
- `docs/adr/INDEX.md`
- `docs/DOCS_INDEX.md`

## Acceptance criteria mapping
- Decision doc/ADR exists with canonical phrasing: satisfied by `docs/adr/ADR-0010-builderops-vault-authority-boundary.md` Decision section.
- Allowed promotion targets explicitly named: satisfied by `## Promotion targets`.
- #1495 raw worklog boundary reconciled: satisfied by `## Raw worklog boundary`.
- GitHub Issues, `.codex/skills/**`, and `AGENTS.md` named as BuilderOps surfaces: satisfied by `## BuilderOps surfaces`.

## Validation commands and outputs

`rg -n "BuilderOps governs the building system|GitHub Issues and skills are BuilderOps surfaces|Promotion targets|Raw worklog boundary" docs .codex AGENTS.md`

```text
docs/adr/ADR-0010-builderops-vault-authority-boundary.md:27:BuilderOps governs the building system.
docs/adr/ADR-0010-builderops-vault-authority-boundary.md:29:GitHub Issues and skills are BuilderOps surfaces.
docs/adr/ADR-0010-builderops-vault-authority-boundary.md:46:BuilderOps governs the building system.
docs/adr/ADR-0010-builderops-vault-authority-boundary.md:121:## Promotion targets
docs/adr/ADR-0010-builderops-vault-authority-boundary.md:146:## Raw worklog boundary
docs/adr/ADR-0010-builderops-vault-authority-boundary.md:207:rg -n "BuilderOps governs the building system|GitHub Issues and skills are BuilderOps surfaces|Promotion targets|Raw worklog boundary" docs .codex AGENTS.md
```

`git diff --check docs .codex AGENTS.md`

```text
(no output)
```

`git diff --check HEAD~1..HEAD -- docs .codex AGENTS.md`

```text
(no output)
```

`python3 scripts/docs_guard.py`

```text
Docs guard: OK
```

## Scope statements
- Docs/decision only.
- No runtime/store/CLI/schema/API/MCP/promotion-gateway implementation.
- No product/runtime authority changed.
- Contextualization Layer package #1093-#1098 is completed and not the active missing package for this issue.

## Dispatcher/claim fallback
- Dispatcher unavailable: `python3 -m app.dispatcher status --json` failed locally with `ModuleNotFoundError: No module named 'yaml'` before dispatcher status could be read.
- Used GitHub-label-only claim fallback: removed `agent:needs-human`, briefly set #1499 to `agent:ready`/`Ready` after the owner decision was supplied, claimed with `scripts/issue_pickup_claim.sh --issue 1499`, and set #1499 to `In Progress`.