### PR TITLE
docs(builderops): update agent workflows for BuilderOps Vault (#1509)

### DIFF
--- a/.codex/skills/README.md
+++ b/.codex/skills/README.md
@@ -14,6 +14,22 @@ Hot path:
 Conditional / maintenance path:
 `Issue maintenance -> Agent` for stale or false backlog state, and `Publish PR -> pr-integration` only when readiness/repair work is still needed before verification.
 
+## BuilderOps Vault routing
+
+BuilderOps Vault is the operational plane for the building system. BuilderOps records are not
+product/runtime truth unless explicitly promoted through the appropriate authority path.
+
+- Raw builder-agent working notes, handoffs, recovery notes, and temporary evidence -> `AgentWorklog`
+- Delivery divergences that name an upstream artifact -> `LearningSignal`
+- High-churn docs freshness observations or review queues -> `DocsFreshnessRecord`
+- Roadmap execution movement, active issue movement, blockers, or shipped refs -> `RoadmapExecutionItem`
+- Requests to cross into GitHub Issue, PR/branch proposal, ADR/decision doc, owner-doc or skill/AGENTS writeback, generated projection, or discard handling -> `PromotionIntent`
+- State transitions, retrospective completions, projections, promotions, supersessions, and discards -> `BuilderOpsReceipt`
+
+Create GitHub Issues from BuilderOps material only when it has become bounded executable work with
+`Verify:` targets. Open PRs only for repo-governed artifact changes. Do not edit canonical docs
+just to capture operational state that belongs in BuilderOps Vault.
+
 ## Skill routing
 
 - `agentic-pkm`

--- a/.codex/skills/docs-to-issue/SKILL.md
+++ b/.codex/skills/docs-to-issue/SKILL.md
@@ -31,6 +31,12 @@ Use maintenance skills instead of this lane when the work is a repair, audit, or
 
 - GitHub Issues are the canonical backlog task contract.
 - GitHub Project is the canonical backlog state machine.
+- A BuilderOps `PromotionIntent` can propose a GitHub Issue, but Issue creation is the explicit
+  promotion into the GitHub task-contract surface. Preserve the `PromotionIntent` or receipt link
+  in `Source Anchors` or `Applies learning (optional)` when present.
+- Create a PR from BuilderOps material only when the promoted target is a repo-governed artifact
+  change. A `PromotionIntent` by itself does not mutate code, tests, docs, ADRs, skills, or
+  `AGENTS.md`.
 - Inline doc markers such as `Tracked by: #123` and `Backlog: #123` are secondary convenience notes only.
 - New backlog work must use stable `Source Anchors`.
 - Do not create duplicate Issues.

--- a/.codex/skills/feature-breakdown/SKILL.md
+++ b/.codex/skills/feature-breakdown/SKILL.md
@@ -133,7 +133,7 @@ AC verifiability rule for task specs:
 - Keep implementation tasks independently mergeable. If a task cannot be verified on its own, the breakdown is still too coarse.
 - If the execution order cannot be explained as one flat ordered list, the capability boundary is still too large or needs a plan before breaking down.
 - One task specification can map to many GitHub issues. The spec is the source of truth, not the issue.
-- Parent issues are validation hubs during delivery. After child delivery and repo-verifiable acceptance, close the parent and split future observation into a follow-up issue or learning-log item.
+- Parent issues are validation hubs during delivery. After child delivery and repo-verifiable acceptance, close the parent and split future observation into a BuilderOps `LearningSignal`, `PromotionIntent`, discard/supersession receipt, or a follow-up GitHub Issue when it is executable work.
 
 ## When to trigger
 

--- a/.codex/skills/issue-maintenance-change-control/SKILL.md
+++ b/.codex/skills/issue-maintenance-change-control/SKILL.md
@@ -233,7 +233,7 @@ Parent feature issues are validation hubs, not direct pickup issues. Unless expl
    ```
 
 2. **Use them to track child slice delivery** in comments and body updates, including validation receipts posted by each delivered child
-3. **When the parent is fully repo-verifiable and only future observation remains, close it and move that observation to a follow-up issue or learning-log item**
+3. **When the parent is fully repo-verifiable and only future observation remains, close it and move that observation to a BuilderOps `LearningSignal`, `PromotionIntent`, discard/supersession receipt, or a follow-up GitHub Issue when it is executable work**
 
 ### Child Slice Issues
 

--- a/.codex/skills/learning-to-issue/SKILL.md
+++ b/.codex/skills/learning-to-issue/SKILL.md
@@ -13,6 +13,8 @@ This is the maintenance-learning intake lane. It is distinct from `docs-to-issue
 
 Invoke when:
 - A BuilderOps `LearningSignal` names a concrete upstream artifact and the repair is bounded enough for the backlog.
+- A BuilderOps `PromotionIntent` targets `github_issue` and the promoted material is bounded,
+  executable work with resolvable `Verify:` targets.
 - A historical `docs/learning-log.md` compatibility entry names a concrete upstream artifact and has not yet been represented by a `LearningSignal`.
 - `learning-retrospective` proposes a concrete edit and the edit requires implementation work (not just a doc change).
 - During `pr-integration` or `verification-and-closure`, a live divergence was observed that needs a tracking issue rather than an inline fix.
@@ -50,7 +52,7 @@ Every issue created by this skill must use the same contract as `docs-to-issue`:
 
 **Required sections (in order):**
 
-- `## Context` - background from the LearningSignal, historical learning-log compatibility entry, or observed divergence; link the source record, entry, or PR
+- `## Context` - background from the LearningSignal, PromotionIntent, historical learning-log compatibility entry, or observed divergence; link the source record, entry, or PR
 - `## Scope` - what changes, what files/artifacts are touched
 - `## Source Anchors` - the named upstream artifact(s) that absorb the fix; use the most local actionable item
 - `## Constraints` - what must not change; what approaches are excluded
@@ -124,7 +126,7 @@ Do not apply `agent:ready` unless every AC has a resolvable `Verify:` target and
 **Issue body template (all cases):**
 ```
 ## Context
-<1-2 sentences from the LearningSignal, historical learning-log compatibility entry, or observed divergence. Link the source: `BuilderOps LearningSignal <id>`, `docs/learning-log.md :: YYYY-MM-DD entry`, or `PR #N`>
+<1-2 sentences from the LearningSignal, PromotionIntent, historical learning-log compatibility entry, or observed divergence. Link the source: `BuilderOps LearningSignal <id>`, `BuilderOps PromotionIntent <id>`, `docs/learning-log.md :: YYYY-MM-DD entry`, or `PR #N`>
 
 ## Scope
 <What changes. Name files and artifacts.>
@@ -149,7 +151,7 @@ Do not apply `agent:ready` unless every AC has a resolvable `Verify:` target and
 - `<path>`
 
 ## Applies learning (optional)
-Applies learning from `BuilderOps LearningSignal <id>` or `docs/learning-log.md :: YYYY-MM-DD - <compatibility entry title>`.
+Applies learning from `BuilderOps LearningSignal <id>`, `BuilderOps PromotionIntent <id>`, or `docs/learning-log.md :: YYYY-MM-DD - <compatibility entry title>`.
 ```
 
 After creation, add to Project `Agent Delivery Control Plane` and verify Status matches the chosen readiness state.
@@ -196,7 +198,7 @@ Signs a raw-intake issue needs normalization:
 
 **Backlog receipt (new issue):**
 ```
-BACKLOG RECEIPT: Issue #N created - "<title>", labeled type:task/prio:med/agent:ready, added to Project "Agent Delivery Control Plane", Status=Ready. Source: BuilderOps LearningSignal <id> or docs/learning-log.md :: YYYY-MM-DD compatibility entry.
+BACKLOG RECEIPT: Issue #N created - "<title>", labeled type:task/prio:med/agent:ready, added to Project "Agent Delivery Control Plane", Status=Ready. Source: BuilderOps LearningSignal <id>, BuilderOps PromotionIntent <id>, or docs/learning-log.md :: YYYY-MM-DD compatibility entry.
 ```
 
 **Normalization receipt (existing issue updated):**

--- a/.codex/skills/temporal-doc-governance/SKILL.md
+++ b/.codex/skills/temporal-doc-governance/SKILL.md
@@ -11,12 +11,25 @@ This is a periodic maintenance pass, not a hot-path delivery step.
 Typical targets:
 
 - `docs/STATUS.md`
-- `docs/ROADMAP.md`
-- `docs/DOCS_INDEX.md`
+- `docs/ROADMAP.md` for strategic sequencing authority, not daily execution movement
+- `docs/DOCS_INDEX.md` for stable doc roles and reading order, not freshness queue state
 - rollout, track, runbook, and current-state docs
 - any doc that can drift because code, issues, runtime posture, or operational state changed
 
 Use it to repair temporal drift, not to add one-off backlog intake or implementation chatter.
+
+## BuilderOps routing
+
+Write BuilderOps records instead of editing repo docs when the finding is operational state:
+
+- docs freshness posture, stale reasons, evidence, or next review owner -> `DocsFreshnessRecord`
+- roadmap execution movement, active issues, blockers, shipped refs, or next execution decision -> `RoadmapExecutionItem`
+- a proposed doc/index/roadmap writeback -> `PromotionIntent`
+- completion, discard, supersession, or projection evidence -> `BuilderOpsReceipt`
+
+Generated BuilderOps projections are review views, not authority. `docs/DOCS_INDEX.md` remains the
+stable document role/routing authority, and `docs/ROADMAP.md` remains the strategic sequencing
+authority. Do not rewrite either file solely to capture high-churn operational state.
 
 ## First context to load
 
@@ -64,8 +77,11 @@ Use these classes:
 ## Update rules
 
 - Prefer correcting current-state claims over rewriting large sections.
-- Keep `ROADMAP` forward-looking; move delivered truth into the owner/current-state doc.
+- Keep `ROADMAP` forward-looking; move delivered truth into the owner/current-state doc and move
+  daily execution movement into `RoadmapExecutionItem`.
 - Keep `STATUS` explicitly operational; remove roadmap-like language when reality is already shipped or no longer active.
+- Keep `DOCS_INDEX` focused on stable document roles, authority, and reading order; move review
+  queue/freshness state into `DocsFreshnessRecord`.
 - Batch repeated temporal corrections where the same claim appears across multiple docs, and avoid splitting one drift class into many micro-edits unless the surfaces truly diverge.
 - If a claim cannot be verified, mark the uncertainty instead of presenting it as current truth.
 - Update `Last reviewed` whenever the doc is intentionally checked.
@@ -89,4 +105,4 @@ When updating, also report:
 
 ## Capturing learning
 
-**Capturing learning:** if during this work you notice a divergence from plan — you did something you did not expect to do, or discovered an earlier artifact was wrong — invoke `capture-learning` before continuing. Do not batch to end of task; context is freshest now. Only log if you can name an upstream artifact that could absorb the fix.
+**Capturing learning:** if during this work you notice a divergence from plan — you did something you did not expect to do, or discovered an earlier artifact was wrong — invoke `capture-learning` before continuing. Create a BuilderOps `LearningSignal`; use `docs/learning-log.md` only as an explicit compatibility fallback. Do not batch to end of task; context is freshest now. Only log if you can name an upstream artifact that could absorb the fix.

--- a/.codex/skills/verification-and-closure/SKILL.md
+++ b/.codex/skills/verification-and-closure/SKILL.md
@@ -133,7 +133,7 @@ Use [`docs/development/PARENT_ISSUE_CLOSURE.md`](../../../docs/development/PAREN
 - if a slice issue is fully delivered, merge the PR and deliver the Issue
 - if the parent feature still needs validation, keep it open and record the child validation receipt on the parent issue
 - if the parent feature is the final child slice or an explicit closure task, close the parent after repo-verifiable acceptance is satisfied and the parent-closure handoff or explicit parent-closure issue is resolved
-- future adoption or retro work should move to a follow-up Issue or learning-log item, not block delivered repo-verifiable scope
+- future adoption or retro work should move to a BuilderOps `LearningSignal`, `PromotionIntent`, discard/supersession receipt, or a follow-up GitHub Issue when it is executable work; it should not block delivered repo-verifiable scope
 
 ## Dependent Issue Unblocking
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,9 +37,9 @@ Repo-local workflow helpers live under `.codex/skills/`. They do not replace thi
   `.codex/skills/pr-integration/SKILL.md`
 - Delivery verification and feedback-loop closure:
   `.codex/skills/verification-and-closure/SKILL.md`
-- Log a divergence from plan during delivery:
+- Capture a BuilderOps learning signal for a divergence from plan:
   `.codex/skills/capture-learning/SKILL.md`
-- Retrospective over divergence log to improve upstream artifacts:
+- Retrospective over BuilderOps learning signals to improve upstream artifacts:
   `.codex/skills/learning-retrospective/SKILL.md`
 - Promote a reviewed commit from dev to stable prod (produce plan):
   `.codex/skills/prepare-promotion/SKILL.md`
@@ -68,6 +68,15 @@ Workflow state model:
 - `Review` is the agent-review phase before verification; it is not a human-waiting synonym.
 - PR/project `Done` should be projected by automation where possible; skills should only fallback-correct when projection drifts.
 - `pr-integration` is a conditional repair/readiness step, not a mandatory hop after every publish.
+
+BuilderOps Vault workflow boundary:
+
+- BuilderOps Vault governs builder-operations material only. It does not change product/runtime truth, repo owner docs, code, tests, ADRs, or runtime contracts unless material is explicitly promoted through the normal GitHub/PR/repo authority path.
+- Use BuilderOps records instead of direct repo-doc edits for operational state: `AgentWorklog` for raw builder-agent work notes, `LearningSignal` for delivery divergences, `DocsFreshnessRecord` for high-churn docs freshness state, `RoadmapExecutionItem` for roadmap execution movement, `PromotionIntent` for staged cross-surface proposals, and `BuilderOpsReceipt` for transitions, projections, promotions, supersessions, or discards.
+- GitHub Issues remain the executable task-contract surface. Create or update an Issue when BuilderOps material becomes bounded implementation, governance, docs, or follow-up work that needs backlog ownership and `Verify:` targets.
+- Open a PR only when repo-governed artifacts must change: code, tests, authoritative docs, ADRs, `.codex/skills/**`, `AGENTS.md`, or generated projections committed to the repo. A BuilderOps record alone is not a repo change.
+- Use `PromotionIntent` before crossing authority classes. Promotion targets include GitHub Issue, PR/branch proposal, ADR/decision doc proposal, owner-doc or skill/AGENTS writeback proposal, generated projection, or discard receipt. Promotion is a reviewed boundary crossing, not automatic synchronization.
+- Generated BuilderOps projections are repo-readable views, not source of truth. If a projection is stale, regenerate or reconcile from BuilderOps Vault; do not hand-edit the projection as authority.
 
 ## Change classification
 

--- a/docs/development/DELIVERY_FEEDBACK_LOOP.md
+++ b/docs/development/DELIVERY_FEEDBACK_LOOP.md
@@ -6,7 +6,7 @@ Temporal class: operational
 Review cadence: per retrospective
 Source of truth: BuilderOps Vault LearningSignal records for operational learning; this document defines workflow
 Last reviewed: 2026-06-01
-Last verified against: issue #1506, docs/learning-log.md, docs/builderops/BUILDEROPS_VAULT_OBJECT_MODEL.md, docs/builderops/BUILDEROPS_VAULT_PROJECTIONS.md, .codex/skills/capture-learning/SKILL.md, .codex/skills/learning-retrospective/SKILL.md
+Last verified against: issues #1506/#1509, docs/learning-log.md, docs/builderops/BUILDEROPS_VAULT_OBJECT_MODEL.md, docs/builderops/BUILDEROPS_VAULT_PROJECTIONS.md, .codex/skills/capture-learning/SKILL.md, .codex/skills/learning-retrospective/SKILL.md
 
 # Delivery Feedback Loop
 
@@ -34,6 +34,35 @@ Docs -> Feature -> Slice -> Agent -> PR -> CI -> Verification -> Merge
                AGENTS.md · skill prompts · slice template
                task-contract template · owner-doc conventions
 ```
+
+## BuilderOps operating-plane boundary
+
+BuilderOps records are operational builder-system material. They are not product/runtime truth and
+do not change repo authority unless they are explicitly promoted through GitHub Issues, PRs, ADR or
+owner-doc proposals, generated projections, or discard receipts.
+
+### raw-agent-worklog-boundary
+
+Raw builder-agent work notes belong in BuilderOps Vault as `AgentWorklog` records by default.
+They do not belong in reviewed repo docs, `$CODEX_HOME`, or repo-local ignored state as the durable
+default. Local scratch may exist only as transient execution state.
+
+Promotion path:
+
+```text
+AgentWorklog
+  -> LearningSignal, when the note contains durable workflow learning
+  -> PromotionIntent, when the note should cross into GitHub, PR, ADR, owner-doc, skill, AGENTS, generated projection, or discard handling
+  -> BuilderOpsReceipt, when the note is processed, superseded, projected, promoted, or discarded
+```
+
+Create or update a GitHub Issue only when the promoted material becomes bounded executable work
+with `Verify:` targets. Open a PR only when repo-governed artifacts need to change. Direct edits to
+repo docs are not the capture path for raw working notes, docs freshness queues, roadmap execution
+movement, or unresolved learning.
+
+This section is the raw-worklog storage decision for #1495: BuilderOps Vault is the durable
+operational surface, and explicit promotion is the only path into GitHub/repo authority.
 
 ## Components
 

--- a/docs/development/PARENT_ISSUE_CLOSURE.md
+++ b/docs/development/PARENT_ISSUE_CLOSURE.md
@@ -17,7 +17,9 @@ Close the parent issue when all of the following are true:
 1. All child or slice issues are closed or terminal.
 2. Repo-verifiable parent acceptance criteria are satisfied.
 3. The closure receipt links the child issues, PRs, validation receipts, and the parent-closure handoff or explicit parent-closure issue.
-4. Future adoption, retro notes, or observation work has moved to a follow-up issue or learning-log item.
+4. Future adoption, retro notes, or observation work has moved to the right BuilderOps surface:
+   `LearningSignal` for operational learning, `PromotionIntent` for boundary-crossing proposals,
+   `BuilderOpsReceipt` for discard/supersession, or a follow-up GitHub Issue when it is executable work.
 
 ## Boundary Rules
 
@@ -38,10 +40,10 @@ The closure receipt should name:
 - the validation receipts posted by each delivered child
 - the evidence proving repo-verifiable acceptance
 - the parent-closure handoff or explicit parent-closure issue when the final child delivered the closure
-- any follow-up issue that will hold future adoption or retro work
+- any follow-up issue or BuilderOps record that will hold future adoption or retro work
 
 Minimal receipt shape:
 
 ```text
-PARENT CLOSURE RECEIPT: parent #<n> closed after child issues #<a>, #<b>. Evidence: <links>. Validation receipts: <links>. Parent-closure handoff: <link to issue or receipt>. Follow-up: #<m> or learning-log item.
+PARENT CLOSURE RECEIPT: parent #<n> closed after child issues #<a>, #<b>. Evidence: <links>. Validation receipts: <links>. Parent-closure handoff: <link to issue or receipt>. Follow-up: #<m>, BuilderOps LearningSignal/PromotionIntent, or discard receipt.
 ```

--- a/docs/development/PR_HOT_PATH.md
+++ b/docs/development/PR_HOT_PATH.md
@@ -52,8 +52,8 @@ Default rule:
 
 These are follow-up tasks, not default PR blockers:
 
-- learning-log retro
-- future adoption observation
+- BuilderOps learning retrospective over `LearningSignal` records
+- future adoption observation captured as `LearningSignal`, `PromotionIntent`, or a follow-up Issue
 - owner-doc reflection
 - full dependency scan
 - board or project polish


### PR DESCRIPTION
## Change Lane
- [ ] Implementation lane
- [ ] Docs authoring lane
- [x] Governance lane

Docs authoring applies only to docs-only changes in approved docs-authoring surfaces. It must not be used for code, runtime behavior, contracts, shipped reality, or implementation writeback.
Governance lane applies to bounded repository-governance changes such as repo-local skills, PR/issue policy, and lightweight enforcement for docs/governance workflows. It may include repo-meta governance scripts and focused tests, but it must not be used for product/runtime implementation.

## Linked Issue
Closes #1509
Parent: #1498
Dependencies delivered: #1499, #1501, #1502, #1503, #1504, #1505, #1506, #1507, #1508

## Summary
- Adds BuilderOps Vault workflow routing to `AGENTS.md`, `.codex/skills/README.md`, and delivery feedback docs so raw worklogs, learning signals, docs freshness, roadmap execution, promotion intents, and receipts go to the correct BuilderOps object types.
- Defines `PromotionIntent` handling for GitHub Issue and PR promotion without making BuilderOps records product/runtime truth.
- Replaces stale future-observation guidance that pointed to learning-log items with BuilderOps records or bounded follow-up GitHub Issues.

## Changed Files
- `AGENTS.md`
- `docs/development/DELIVERY_FEEDBACK_LOOP.md`
- `docs/development/PARENT_ISSUE_CLOSURE.md`
- `docs/development/PR_HOT_PATH.md`
- `.codex/skills/README.md`
- `.codex/skills/docs-to-issue/SKILL.md`
- `.codex/skills/feature-breakdown/SKILL.md`
- `.codex/skills/issue-maintenance-change-control/SKILL.md`
- `.codex/skills/learning-to-issue/SKILL.md`
- `.codex/skills/temporal-doc-governance/SKILL.md`
- `.codex/skills/verification-and-closure/SKILL.md`

## Acceptance Criteria Mapping
- AC1: Skills/governance docs state when agents should write BuilderOps records instead of editing repo docs.
  - Evidence: `AGENTS.md`, `.codex/skills/README.md`, `.codex/skills/temporal-doc-governance/SKILL.md`, and `docs/development/DELIVERY_FEEDBACK_LOOP.md` now route operational state to `AgentWorklog`, `LearningSignal`, `DocsFreshnessRecord`, `RoadmapExecutionItem`, `PromotionIntent`, and `BuilderOpsReceipt`.
- AC2: Guidance states BuilderOps records are not product truth unless promoted.
  - Evidence: `AGENTS.md` and `docs/development/DELIVERY_FEEDBACK_LOOP.md` explicitly state BuilderOps records do not change product/runtime or repo authority unless explicitly promoted.
- AC3: Guidance defines when to create GitHub Issues/PRs from BuilderOps `PromotionIntent`.
  - Evidence: `AGENTS.md`, `.codex/skills/README.md`, `.codex/skills/docs-to-issue/SKILL.md`, and `.codex/skills/learning-to-issue/SKILL.md` define Issue/PR promotion rules.
- AC4: #1495 can be closed or explicitly superseded after writeback.
  - Evidence: `docs/development/DELIVERY_FEEDBACK_LOOP.md :: raw-agent-worklog-boundary` names BuilderOps Vault `AgentWorklog` as the durable raw-worklog surface. I will add a supersession/closure comment to #1495 after this PR merges.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [x] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [x] This PR only changes approved governance surfaces.
- [x] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [x] No product/runtime implementation or shipped feature behavior changed.

## Dispatcher Claim
- Default dispatcher command failed with `ModuleNotFoundError: No module named 'yaml'`.
- `/opt/homebrew/bin/python3.12 -m app.dispatcher status --json` returned `db_exists: false`.
- Used documented GitHub-label fallback via `scripts/issue_pickup_claim.sh --issue 1509`.

## Validation
Implementation lane:
- [ ] `ruff check app tests`
- [x] No files under `app/` or `tests/` changed; `ruff check app tests` not run.
- [ ] `mypy app`
- [ ] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg"`
- [ ] Additional targeted checks run as needed

Docs authoring lane:
- [x] Docs/governance checks run as appropriate for the touched surfaces
- [x] Any validation gaps or tooling limitations are stated explicitly

Governance lane:
- [x] Governance checks run as appropriate for the touched surfaces
- [x] Any validation gaps or tooling limitations are stated explicitly

Validation output:
```text
rg -n "BuilderOps|AgentWorklog|LearningSignal|PromotionIntent|raw worklog" AGENTS.md docs/development .codex/skills
# passed; matches present in AGENTS.md, docs/development, and repo-local skills

rg -n "PromotionIntent|GitHub Issue|PR|pull request|repo-governed" AGENTS.md docs/development .codex/skills/README.md .codex/skills/docs-to-issue/SKILL.md .codex/skills/learning-to-issue/SKILL.md
# passed; Issue/PR promotion guidance present

rg -n "learning-log item|learning-log retro" AGENTS.md docs/development .codex/skills
# no matches

git diff --check -- AGENTS.md docs/development .codex/skills
# passed; no output

python3 scripts/docs_guard.py
Docs guard: OK
```

## Scope Statement
Minimal workflow/skills update only. No store/API/MCP/projection/promotion-gateway implementation, no product/runtime behavior changes, no direct BuilderOps data migration, and no silent authority transfer.

## Notes
- Follow-up closure: after merge, comment on and close/supersede #1495 using the new `raw-agent-worklog-boundary` writeback.
- Known unrelated issue remains: the default local dispatcher Python environment lacks `yaml`; this PR records the fallback but does not change dispatcher dependencies.