### PR TITLE
Fix follow-up review repairs: embed model resolution, vault note lookup, test isolation, UI ordering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ tmp/index-outbox.jsonl
 tmp/index.jsonl
 runtime/settings/
 runtime/dispatcher/
+runtime/orientation/
 verification_report.md
 
 # Local hygiene artifacts

--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -584,10 +584,19 @@ def _validate_workspace_markdown_note_path(note_path_raw: str) -> str:
 
 
 def _find_workspace_note(vault_root: Path, safe_note_path: str) -> Path | None:
-    candidate_real = _vault_contained_abs_path(vault_root, safe_note_path)
-    if not candidate_real.is_file():
+    root_real = os.path.realpath(vault_root)
+    target_real = os.path.realpath(os.path.join(root_real, safe_note_path))
+    if target_real != root_real and not target_real.startswith(root_real + os.sep):
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "path_escape",
+                "message": "Resolved note path is outside the vault.",
+            },
+        )
+    if not os.path.isfile(target_real):
         return None
-    return candidate_real
+    return Path(target_real)
 
 
 def _vault_contained_abs_path(vault_root: Path, safe_note_path: str) -> Path:

--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -585,24 +585,20 @@ def _validate_workspace_markdown_note_path(note_path_raw: str) -> str:
 
 def _find_workspace_note(vault_root: Path, safe_note_path: str) -> Path | None:
     root_real = Path(os.path.realpath(vault_root))
-    for candidate in vault_root.rglob("*.md"):
-        if not candidate.is_file():
-            continue
-        if _vault_relative(candidate, vault_root) != safe_note_path:
-            continue
-        candidate_real = Path(os.path.realpath(candidate))
-        try:
-            candidate_real.relative_to(root_real)
-        except ValueError as exc:
-            raise HTTPException(
-                status_code=400,
-                detail={
-                    "error": "path_escape",
-                    "message": "Resolved note path is outside the vault.",
-                },
-            ) from exc
-        return candidate_real
-    return None
+    candidate_real = Path(os.path.realpath(os.path.join(root_real, safe_note_path)))
+    try:
+        candidate_real.relative_to(root_real)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "path_escape",
+                "message": "Resolved note path is outside the vault.",
+            },
+        ) from exc
+    if not candidate_real.is_file():
+        return None
+    return candidate_real
 
 
 def _vault_contained_abs_path(vault_root: Path, safe_note_path: str) -> Path:

--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -584,19 +584,25 @@ def _validate_workspace_markdown_note_path(note_path_raw: str) -> str:
 
 
 def _find_workspace_note(vault_root: Path, safe_note_path: str) -> Path | None:
-    root_real = os.path.realpath(vault_root)
-    target_real = os.path.realpath(os.path.join(root_real, safe_note_path))
-    if target_real != root_real and not target_real.startswith(root_real + os.sep):
-        raise HTTPException(
-            status_code=400,
-            detail={
-                "error": "path_escape",
-                "message": "Resolved note path is outside the vault.",
-            },
-        )
-    if not os.path.isfile(target_real):
-        return None
-    return Path(target_real)
+    root_real = Path(os.path.realpath(vault_root))
+    for candidate in vault_root.rglob("*.md"):
+        if not candidate.is_file():
+            continue
+        if _vault_relative(candidate, vault_root) != safe_note_path:
+            continue
+        candidate_real = Path(os.path.realpath(candidate))
+        try:
+            candidate_real.relative_to(root_real)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": "path_escape",
+                    "message": "Resolved note path is outside the vault.",
+                },
+            ) from exc
+        return candidate_real
+    return None
 
 
 def _vault_contained_abs_path(vault_root: Path, safe_note_path: str) -> Path:

--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -584,18 +584,7 @@ def _validate_workspace_markdown_note_path(note_path_raw: str) -> str:
 
 
 def _find_workspace_note(vault_root: Path, safe_note_path: str) -> Path | None:
-    root_real = Path(os.path.realpath(vault_root))
-    candidate_real = Path(os.path.realpath(os.path.join(root_real, safe_note_path)))
-    try:
-        candidate_real.relative_to(root_real)
-    except ValueError as exc:
-        raise HTTPException(
-            status_code=400,
-            detail={
-                "error": "path_escape",
-                "message": "Resolved note path is outside the vault.",
-            },
-        ) from exc
+    candidate_real = _vault_contained_abs_path(vault_root, safe_note_path)
     if not candidate_real.is_file():
         return None
     return candidate_real

--- a/app/components/embeddings.py
+++ b/app/components/embeddings.py
@@ -119,12 +119,12 @@ def _resolve_embedding_provider_name(value: str | None) -> str:
 
 
 def _resolve_embedding_model(provider: str, override_model: str | None, configured_model: str | None = None) -> str:
+    if provider == "mock":
+        return _MOCK_EMBED_MODEL
     if override_model:
         return override_model
     if configured_model:
         return configured_model
-    if provider == "mock":
-        return _MOCK_EMBED_MODEL
     env_model = _normalize_name(os.getenv("EMBED_MODEL")) or _normalize_name(os.getenv("OLLAMA_EMBED_MODEL"))
     if env_model:
         return env_model

--- a/app/components/embeddings/legacy.py
+++ b/app/components/embeddings/legacy.py
@@ -134,12 +134,12 @@ def _resolve_embedding_provider_name(value: str | None) -> str:
 
 
 def _resolve_embedding_model(provider: str, override_model: str | None, configured_model: str | None = None) -> str:
+    if provider == "mock":
+        return _MOCK_EMBED_MODEL
     if override_model:
         return override_model
     if configured_model:
         return configured_model
-    if provider == "mock":
-        return _MOCK_EMBED_MODEL
     env_model = _normalize_name(os.getenv("EMBED_MODEL")) or _normalize_name(os.getenv("OLLAMA_EMBED_MODEL"))
     if env_model:
         return env_model

--- a/app/components/llm/router.py
+++ b/app/components/llm/router.py
@@ -198,6 +198,8 @@ class LLMRouter:
             override_model = target.model or target_model
         if override_model is None and routing is not None:
             override_model = routing.default_embed_model
+        if override_model is None:
+            override_model = _default_embed_model()
         identity = resolve_embedding_identity(
             profile=profile,
             override_model=override_model,
@@ -206,7 +208,7 @@ class LLMRouter:
         return (
             LLMRoute(
                 provider=identity.provider,
-                model=identity.model,
+                model=override_model or identity.model,
                 mode="embeddings",
                 reason=reason,
                 degraded=degraded,

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -1745,9 +1745,9 @@ def _render_artifact_inspector(
         f'{vault_identity_html}'
         f'</div>'
         f'{posture_html}'
+        f'{receipts_html}'
         f'{actions_html}'
         f'{links_html}'
-        f'{receipts_html}'
         f'</section>'
     )
 

--- a/scripts/reset_to_zero.sh
+++ b/scripts/reset_to_zero.sh
@@ -66,8 +66,21 @@ for pattern in "${patterns[@]}"; do
   done
 done
 
+durable_deleted=()
+if [ "${#deleted[@]}" -gt 0 ]; then
+  for entry in "${deleted[@]}"; do
+    case "$entry" in
+      tmp/index-outbox.jsonl|tmp/index-outbox.*.jsonl|tmp/WATCHER_STOP*|tmp/worker_heartbeat.json|tmp/watcher_heartbeat.json|tmp/watcher_state.json|tmp/watcher_state.*.json|tmp/watcher_states|tmp/health_incidents.jsonl|tmp/worker_heartbeat.*|tmp/runtime.env|tmp/startup_status.json|tmp/latest_watcher_tick_log|tmp-test/index-outbox.jsonl|tmp-test/index-outbox.*.jsonl|tmp-test/WATCHER_STOP*|tmp-test/worker_heartbeat.json|tmp-test/watcher_heartbeat.json|tmp-test/watcher_state.json|tmp-test/watcher_state.*.json|tmp-test/watcher_states|tmp-test/health_incidents.jsonl|tmp-test/worker_heartbeat.*|tmp-test/runtime.env|tmp-test/startup_status.json|tmp-test/latest_watcher_tick_log)
+        ;;
+      *)
+        durable_deleted+=("$entry")
+        ;;
+    esac
+  done
+fi
+
 echo "Identified runtime artifacts to delete:"
-if [ "${#deleted[@]}" -eq 0 ]; then
+if [ "${#durable_deleted[@]}" -eq 0 ]; then
   echo "  (none found)"
 else
   for entry in "${deleted[@]}"; do
@@ -94,7 +107,11 @@ else
       rm -f "$entry"
     fi
   done
-  echo "Removed runtime artifacts."
+  if [ "${#durable_deleted[@]}" -eq 0 ]; then
+    echo "No runtime artifacts existed."
+  else
+    echo "Removed runtime artifacts."
+  fi
 fi
 
 cat <<SUMMARY

--- a/tests/api/test_companion_workspace_vault_identity.py
+++ b/tests/api/test_companion_workspace_vault_identity.py
@@ -121,8 +121,9 @@ def test_vault_provenance_env_when_vault_root_set(
 
 
 def test_vault_provenance_default_when_vault_root_absent(
-    client: TestClient, vault_note: Path, monkeypatch: pytest.MonkeyPatch
+    client: TestClient, vault_note: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("VAULT_ROOT", raising=False)
     default_vault = Path("vault").resolve()
     default_note = default_vault / "notes" / "note.md"
@@ -140,6 +141,7 @@ def test_vault_provenance_default_when_vault_root_absent(
 def test_vault_provenance_fallback_when_vault_root_invalid(
     client: TestClient, vault_note: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("VAULT_ROOT", str(tmp_path / "missing-vault"))
     fallback_vault = Path("vault").resolve()
     fallback_note = fallback_vault / "notes" / "note.md"
@@ -189,6 +191,13 @@ def test_configured_vault_name_survives_container_path_divergence(
 ) -> None:
     # The container bug: host VAULT_ROOT does not exist in-container (would infer
     # `fallback`/`vault`). A configured name overrides that and stays truthful.
+    monkeypatch.chdir(tmp_path)
+    fallback_note = tmp_path / "vault" / "notes" / "note.md"
+    fallback_note.parent.mkdir(parents=True, exist_ok=True)
+    fallback_note.write_text(
+        "---\nuuid: fallback-uuid-1\n---\n\n# Fallback Note\n\nBody.\n",
+        encoding="utf-8",
+    )
     monkeypatch.setenv("VAULT_ROOT", str(tmp_path / "host-only" / "Niflheim"))
     _configure_runtime_vault(monkeypatch, tmp_path, "Niflheim")
     resp = _workspace(client, note_path="notes/note.md")


### PR DESCRIPTION
## Direct Repair
Type: code
Reason: Addresses post-merge drift and unresolved review feedback from recent merged PR sweep (#1490). Fixes embed model resolution priority, vault note lookup efficiency, test directory isolation, artifact inspector render ordering, and reset script durable/ephemeral distinction.
Validation: `git diff --check`; `python3 scripts/docs_guard.py`; `ruff check` on all touched Python files; `pytest tests/api/test_companion_workspace_vault_identity.py` (12 passed).
Issue required: no

## Summary
Bounded direct-repair addressing follow-up review issues across embed model routing, vault note path lookup, Companion UI render ordering, test isolation, and reset script accuracy.

## Changes
- Prioritize mock provider early-return in `_resolve_embedding_model` (embeddings.py + legacy.py)
- Add `_default_embed_model()` fallback and use `override_model` directly in `LLMRouter.route_embeddings` result
- Simplify `_find_workspace_note` from rglob scan to direct `realpath` construction
- Add `monkeypatch.chdir(tmp_path)` in three vault provenance tests for directory isolation
- Move `receipts_html` before `actions_html` in artifact inspector section render
- Improve `reset_to_zero.sh` to track durable vs ephemeral deleted artifacts separately
- Add `runtime/orientation/` to .gitignore

## Validation
- `git diff --check` (clean)
- `python3 scripts/docs_guard.py` (OK)
- `ruff check` on all touched Python files (all checks passed)
- `pytest tests/api/test_companion_workspace_vault_identity.py` (12 passed)

---