### PR TITLE
fix(governance): reconcile non-draft PRs to review (#1485)

### DIFF
--- a/.github/github-governance.yml
+++ b/.github/github-governance.yml
@@ -52,7 +52,13 @@ project:
       set_status: Backlog
     - event: issue_reopened_or_relabeled
       reconcile_status_from_issue_state_and_agent_label: true
-    - event: pr_opened
+    - event: pr_opened_non_draft
+      set_status: Review
+    - event: pr_opened_draft
+      set_status: In Progress
+    - event: pr_ready_for_review
+      set_status: Review
+    - event: pr_converted_to_draft
       set_status: In Progress
     - event: pr_review_requested
       set_status: Review
@@ -65,8 +71,8 @@ project:
   interpretation:
     status_is_projection_of_issue_and_pr_truth: true
     ready_requires_agent_ready: true
-    in_progress_covers_open_pr_before_review_handoff: true
-    review_requires_explicit_review_handoff: true
+    in_progress_covers_draft_or_rework_prs: true
+    review_covers_open_non_draft_prs: true
     done_requires_closed_issue_or_terminal_pr_card: true
     project_may_drift_when_platform_access_is_limited: true
 shared_operational_state:

--- a/scripts/reconcile_project_status.py
+++ b/scripts/reconcile_project_status.py
@@ -168,7 +168,7 @@ def desired_pr_status(pr: dict[str, Any], explicit_status: str | None) -> str | 
     if pr.get("mergedAt"):
         return "Done"
     if pr.get("state") == "OPEN":
-        return "In Progress"
+        return "In Progress" if pr.get("isDraft") else "Review"
     if pr.get("state") == "CLOSED":
         # Closed PR cards are terminal Project artifacts and must not remain blank.
         return "Done"

--- a/tests/ops/test_project_status_reconcile.py
+++ b/tests/ops/test_project_status_reconcile.py
@@ -6,6 +6,7 @@ import pytest
 from scripts import reconcile_project_status
 from scripts.reconcile_project_status import (
     desired_pr_status,
+    get_pr,
     list_project_items,
     load_governance_project_name,
     reconcile_issue,
@@ -13,8 +14,18 @@ from scripts.reconcile_project_status import (
 )
 
 
-def test_desired_pr_status_open_pr_is_in_progress() -> None:
-    assert desired_pr_status({"state": "OPEN", "mergedAt": None}, None) == "In Progress"
+def test_desired_pr_status_open_non_draft_pr_is_review() -> None:
+    assert (
+        desired_pr_status({"state": "OPEN", "isDraft": False, "mergedAt": None}, None)
+        == "Review"
+    )
+
+
+def test_desired_pr_status_open_draft_pr_is_in_progress() -> None:
+    assert (
+        desired_pr_status({"state": "OPEN", "isDraft": True, "mergedAt": None}, None)
+        == "In Progress"
+    )
 
 
 def test_desired_pr_status_closed_unmerged_pr_is_done() -> None:
@@ -26,6 +37,38 @@ def test_desired_pr_status_explicit_status_wins() -> None:
         desired_pr_status({"state": "CLOSED", "mergedAt": None}, "Review")
         == "Review"
     )
+
+
+def test_get_pr_fetches_draft_state(monkeypatch) -> None:
+    commands = []
+
+    def fake_run_gh(*args: str) -> str:
+        commands.append(args)
+        return reconcile_project_status.json.dumps(
+            {
+                "number": 1484,
+                "state": "OPEN",
+                "isDraft": False,
+                "mergedAt": None,
+                "url": "https://github.com/RasmusTho/agentic-pkm-mvp/pull/1484",
+                "title": "Example PR",
+            }
+        )
+
+    monkeypatch.setattr(reconcile_project_status, "run_gh", fake_run_gh)
+
+    assert get_pr("RasmusTho/agentic-pkm-mvp", 1484)["isDraft"] is False
+    assert commands == [
+        (
+            "pr",
+            "view",
+            "1484",
+            "--repo",
+            "RasmusTho/agentic-pkm-mvp",
+            "--json",
+            "number,state,isDraft,mergedAt,url,title",
+        )
+    ]
 
 
 def test_load_governance_project_name_reads_file(tmp_path, monkeypatch) -> None:
@@ -162,7 +205,7 @@ def test_reconcile_pr_does_not_add_item_found_after_initial_limit(
         {
             "id": "item-501",
             "content": {"type": "PullRequest", "number": 501},
-            "status": "In Progress",
+            "status": "Review",
         },
     ]
     add_calls = []
@@ -191,6 +234,7 @@ def test_reconcile_pr_does_not_add_item_found_after_initial_limit(
         lambda _repo, _number: {
             "number": 501,
             "state": "OPEN",
+            "isDraft": False,
             "mergedAt": None,
             "url": "https://github.com/RasmusTho/agentic-pkm-mvp/pull/501",
         },
@@ -207,11 +251,11 @@ def test_reconcile_pr_does_not_add_item_found_after_initial_limit(
     )
 
     assert (
-        reconcile_pr(args, "RasmusTho", {"number": 1}, "field", {"In Progress": "opt"})
+        reconcile_pr(args, "RasmusTho", {"number": 1}, "field", {"Review": "opt"})
         == 0
     )
     assert add_calls == []
-    assert "pr #501: already In Progress" in capsys.readouterr().out
+    assert "pr #501: already Review" in capsys.readouterr().out
 
 
 def test_reconcile_issue_stops_when_project_listing_fails_before_mutation(


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

Docs authoring applies only to docs-only changes in approved docs-authoring surfaces. It must not be used for code, runtime behavior, contracts, shipped reality, or implementation writeback.
Governance lane applies to bounded repository-governance changes such as repo-local skills, PR/issue policy, and lightweight enforcement for docs/governance workflows. It may include repo-meta governance scripts and focused tests, but it must not be used for product/runtime implementation.

## Linked Issue
Fixes #1485

## Summary
- Updates `scripts/reconcile_project_status.py::desired_pr_status` so open non-draft PRs derive `Review` and open draft PRs derive `In Progress`.
- Adds focused unit coverage for draft/non-draft PR status, the `get_pr` `isDraft` query shape, and existing terminal/override behavior.
- Aligns `.github/github-governance.yml` with the same PR projection contract after automated review found the machine-readable contract was stale.

## Changed Files
- `scripts/reconcile_project_status.py`
- `tests/ops/test_project_status_reconcile.py`
- `.github/github-governance.yml`

## Acceptance Criteria Mapping
- AC1: Open non-draft PRs derive `Review`.
  - Verify: `tests/ops/test_project_status_reconcile.py::test_desired_pr_status_open_non_draft_pr_is_review`.
- AC2: Open draft PRs derive `In Progress`.
  - Verify: `tests/ops/test_project_status_reconcile.py::test_desired_pr_status_open_draft_pr_is_in_progress`.
- AC3: `get_pr` fetches enough data for draft/non-draft distinction.
  - Verify: `tests/ops/test_project_status_reconcile.py::test_get_pr_fetches_draft_state` asserts the `gh pr view --json` field set includes `isDraft`.
- AC4: Merged/closed terminal PR behavior remains `Done`, and explicit `--status` override still wins.
  - Verify: existing tests `test_desired_pr_status_closed_unmerged_pr_is_done` and `test_desired_pr_status_explicit_status_wins` still pass.

## Review Feedback
- Addressed automated review comment on `.github/github-governance.yml` by updating the machine-readable contract: non-draft opened PRs -> `Review`, draft opened PRs -> `In Progress`, ready-for-review -> `Review`, converted-to-draft -> `In Progress`.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [x] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [x] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [x] No product/runtime implementation or shipped feature behavior changed.

## Dispatcher Claim
- Default dispatcher command failed with `ModuleNotFoundError: No module named 'yaml'`.
- `/opt/homebrew/bin/python3.12 -m app.dispatcher status --json` returned `db_exists: false`.
- Used documented GitHub-label fallback via `scripts/issue_pickup_claim.sh --issue 1485`.

## Validation
Implementation lane:
- [x] `ruff check app tests`
- [x] If files under `app/` or `tests/` changed, lint output from `ruff check app tests` is included below or a tooling limitation is stated.
- [ ] `mypy app`
- [ ] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg"`
- [x] Additional targeted checks run as needed

Docs authoring lane:
- [ ] Docs/governance checks run as appropriate for the touched surfaces
- [x] Any validation gaps or tooling limitations are stated explicitly

Governance lane:
- [x] Governance checks run as appropriate for the touched surfaces
- [x] Any validation gaps or tooling limitations are stated explicitly

Validation output:
```text
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest -q tests/ops/test_project_status_reconcile.py
............                                                             [100%]
12 passed in 0.06s

.venv/bin/python -m ruff check scripts/reconcile_project_status.py tests/ops/test_project_status_reconcile.py
All checks passed!

git diff --check -- scripts/reconcile_project_status.py tests/ops/test_project_status_reconcile.py .github/github-governance.yml
# passed; no output

.venv/bin/python -m ruff check app tests
All checks passed!
```

## Scope Statement
Focused governance helper bug fix and matching machine-readable governance contract alignment only. No Issue status derivation changes, no Project option changes, no new Project automation, and no product/runtime behavior changes.

## Notes
- Human-readable governance docs already stated the desired PR projection rule; `.github/github-governance.yml` is now aligned with those docs.