### PR TITLE
docs(governance): add automation maintenance skill (#1496)

### DIFF
--- a/.codex/skills/README.md
+++ b/.codex/skills/README.md
@@ -46,6 +46,8 @@ just to capture operational state that belongs in BuilderOps Vault.
   - convert active docs into bounded backlog Issues
 - `temporal-doc-governance`
   - audit and refresh time-sensitive current-state docs
+- `automation-maintenance`
+  - inspect Codex app automations for this repository, detect redirect/stale `cwds`, use the Codex app automation update tool when available, and report exact pending changes when local automation state cannot be safely updated
 - `publish-pr`
   - publication boundary for branch, commit, push, and PR creation after local work is ready
 - `pr-integration`

--- a/.codex/skills/automation-maintenance/SKILL.md
+++ b/.codex/skills/automation-maintenance/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: automation-maintenance
+description: "Inspect and maintain Codex app automations for this repository, especially cwd drift between the redirect workspace and the canonical repo root."
+---
+
+# Automation Maintenance
+
+Use this governance skill when asked to inspect, repair, or report Codex app automations for this
+repository.
+
+Codex app automation definitions live under `$CODEX_HOME/automations/*/automation.toml` as local
+operational state. They are not repo source truth and must not be committed into this repository.
+
+## Canonical repository cwd
+
+Canonical repo automations for `RasmusTho/agentic-pkm-mvp` must use:
+
+```text
+/Users/rasmusthornberg/code/agentic-pkm-mvp
+```
+
+An automation may use a different `cwds` entry only when its prompt or a repo issue documents a
+specific justified exception. The redirect workspace
+`/Users/rasmusthornberg/Documents/New project` is stale for this repository.
+
+## Inspection workflow
+
+1. Read `AGENTS.md` and this skill.
+2. Inspect local automation definitions:
+   ```bash
+   AUTOMATION_HOME="${CODEX_HOME:-$HOME/.codex}/automations"
+   find "$AUTOMATION_HOME" -maxdepth 2 -name automation.toml -print
+   rg -n "agentic-pkm-mvp|Documents/New project|cwds|prompt|id" "$AUTOMATION_HOME"
+   ```
+3. Identify automations for this repo by `cwds`, prompt text, id, name, or memory references to
+   `RasmusTho/agentic-pkm-mvp` or `agentic-pkm-mvp`.
+4. For each matching automation, classify `cwds`:
+   - `canonical`: every repo cwd points at `/Users/rasmusthornberg/code/agentic-pkm-mvp`
+   - `redirect`: any repo cwd points at `/Users/rasmusthornberg/Documents/New project`
+   - `stale`: any repo cwd points at another old worktree or branch workspace without a documented exception
+   - `uncertain`: the automation appears related to this repo but the intended cwd is not clear
+5. Do not inspect or mutate unrelated automations beyond listing them as skipped.
+
+## Safe update behavior
+
+- Prefer the Codex app automation update tool when it is available in the current environment.
+- Update only the matching automation ids that are in scope.
+- Preserve the existing prompt, schedule, model, status, and environment fields unless the task
+  explicitly asks to change them.
+- Change `cwds` to the canonical repo root only when the automation is clearly for this repo and no
+  justified exception exists.
+- If the update tool is unavailable, blocked, or ambiguous, do not edit `automation.toml` files by
+  hand. Report exact pending changes instead.
+- If durable follow-up is needed, create or update a GitHub Issue with the automation id, current
+  cwd, intended cwd, and blocker. Do not treat local automation state as repo truth.
+
+## Receipt shape
+
+Every run must finish with a concise receipt:
+
+```text
+AUTOMATION MAINTENANCE RECEIPT
+Reviewed: <automation ids or paths>
+Changed: <id: old cwds -> new cwds, or "none">
+Skipped: <unrelated ids and reason>
+Pending: <exact intended changes not applied>
+Residual uncertainty: <unknown ownership, missing tool, permission limits, or "none">
+Follow-up Issue: <#n or "none">
+```
+
+## Capturing learning
+
+**Capturing learning:** if this work reveals a repeatable workflow gap, create a BuilderOps
+`LearningSignal`; use `docs/learning-log.md` only as an explicit compatibility fallback.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,8 @@ Repo-local workflow helpers live under `.codex/skills/`. They do not replace thi
   `.codex/skills/docs-to-issue/SKILL.md`
 - Temporal current-state doc audit / freshness work:
   `.codex/skills/temporal-doc-governance/SKILL.md`
+- Codex app automation cwd drift inspection / maintenance:
+  `.codex/skills/automation-maintenance/SKILL.md`
 - Branch / commit / push / PR publication after local work is ready:
   `.codex/skills/publish-pr/SKILL.md`
 - PR mergeability / CI attachment before verification:


### PR DESCRIPTION
## Change Lane
- [ ] Implementation lane
- [ ] Docs authoring lane
- [x] Governance lane

Docs authoring applies only to docs-only changes in approved docs-authoring surfaces. It must not be used for code, runtime behavior, contracts, shipped reality, or implementation writeback.
Governance lane applies to bounded repository-governance changes such as repo-local skills, PR/issue policy, and lightweight enforcement for docs/governance workflows. It may include repo-meta governance scripts and focused tests, but it must not be used for product/runtime implementation.

## Linked Issue
Closes #1496

## Summary
- Adds `.codex/skills/automation-maintenance/SKILL.md` for inspecting Codex app automations and detecting redirect/stale `cwds`.
- Routes the new skill from `AGENTS.md` and `.codex/skills/README.md`.
- Defines canonical cwd, safe update behavior, fallback reporting behavior, and a required automation-maintenance receipt shape.

## Changed Files
- `AGENTS.md`
- `.codex/skills/README.md`
- `.codex/skills/automation-maintenance/SKILL.md`

## Acceptance Criteria Mapping
- AC1: Skill/workflow doc describes inspecting `$CODEX_HOME/automations/*/automation.toml`, identifying repo automations, and detecting redirect/stale `cwds`.
  - Evidence: `.codex/skills/automation-maintenance/SKILL.md` inspection workflow and `.codex/skills/README.md` skill routing.
- AC2: Guidance says canonical repo automations use `/Users/rasmusthornberg/code/agentic-pkm-mvp` unless a justified exception is documented.
  - Evidence: `.codex/skills/automation-maintenance/SKILL.md :: Canonical repository cwd`.
- AC3: Guidance defines safe update behavior: use the Codex app automation update tool when available; otherwise report exact pending changes and create/fix a GitHub Issue if durable follow-up is needed.
  - Evidence: `.codex/skills/automation-maintenance/SKILL.md :: Safe update behavior`.
- AC4: Guidance includes a receipt shape listing reviewed, changed, skipped, pending, and residual uncertainty.
  - Evidence: `.codex/skills/automation-maintenance/SKILL.md :: Receipt shape`.

## Local Automation Inspection Receipt
Reviewed local operational input only; no local automation files were committed.

```text
AUTOMATION MAINTENANCE RECEIPT
Reviewed: skill-progression-map, daily-bug-scan, weekly-release-notes, temporal-docs-audit, learning-retro-intake, kanban-cleanup-retry
Changed: none
Skipped: kanban-cleanup-retry (not clearly a canonical repo cwd automation from the grep output)
Pending: none from this PR; current grep showed named repo automations using /Users/rasmusthornberg/code/agentic-pkm-mvp
Residual uncertainty: local automation state is personal operational state and may drift outside repo review
Follow-up Issue: none
```

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [x] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [x] This PR only changes approved governance surfaces.
- [x] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [x] No product/runtime implementation or shipped feature behavior changed.

## Dispatcher Claim
- Default dispatcher command failed with `ModuleNotFoundError: No module named 'yaml'`.
- `/opt/homebrew/bin/python3.12 -m app.dispatcher status --json` returned `db_exists: false`.
- Used documented GitHub-label fallback via `scripts/issue_pickup_claim.sh --issue 1496`.

## Validation
Implementation lane:
- [ ] `ruff check app tests`
- [x] No files under `app/` or `tests/` changed; `ruff check app tests` not run.
- [ ] `mypy app`
- [ ] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -m "not pg"`
- [x] Additional targeted checks run as needed

Docs authoring lane:
- [x] Docs/governance checks run as appropriate for the touched surfaces
- [x] Any validation gaps or tooling limitations are stated explicitly

Governance lane:
- [x] Governance checks run as appropriate for the touched surfaces
- [x] Any validation gaps or tooling limitations are stated explicitly

Validation output:
```text
rg -n "automation-maintenance|automations/\*/automation.toml|canonical repo automations|agentic-pkm-mvp" .codex/skills docs/development AGENTS.md
# passed; matches include AGENTS.md, .codex/skills/README.md, and .codex/skills/automation-maintenance/SKILL.md

git diff --check -- .codex/skills docs/development AGENTS.md
# passed; no output

python3 scripts/docs_guard.py
Docs guard: OK

PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest -q tests/architecture/test_agent_skill_entrypoints.py
...                                                                      [100%]
3 passed in 0.04s
```

## Scope Statement
Governance/workflow skill only. No local automation TOML files committed, no product/runtime behavior changes, no mutation of unrelated automations, and no dependency on personal Codex app state as repo truth.