### PR TITLE
docs(governance): define promotion receipt query model (#1489)

### DIFF
--- a/docs/CONCEPTS/ONTOLOGY_VOCABULARY.md
+++ b/docs/CONCEPTS/ONTOLOGY_VOCABULARY.md
@@ -171,12 +171,16 @@ They record where the active runtime most clearly compresses multiple ontology l
     the current transition-accountability event / interim receipt-supporting record. It carries
     authority, basis, outcome, and artifact linkage for the applied transition.
   - `payload["promotion"]` in the ObjectStore row provides inline machine-mirror provenance only.
-  - What is missing is a **distinct durable promotion receipt artifact** — separate from the store
-    payload and queryable as an accountability record. Until that is added, accountability is
-    recoverable from the transition-accountability event plus supporting operational traces, not
-    from a final durable receipt store.
-  - Tracked follow-on: issue #1403. Target state: promotion consumer writes a formal receipt record
-    in addition to the store payload mutation. Pre-requisite: receipt store model.
+  - Decision #1489 defines the v1 formal promotion receipt model as a typed, read-only query view
+    over durable receipt-supporting audit records. For successful promotion applies,
+    `promotion.transition.applied` is the transition-accountability source for that view.
+  - The final durable/queryable receipt authority for v1 consumers is the receipt query contract:
+    artifact UUID/path, receipt or source event id, trace id, timestamp, transition family, target
+    maturity, resulting `review_state` / `maturity`, authority, basis, outcome, artifact linkage,
+    executor/source, and triggering intent/source event.
+  - A dedicated physical receipt store remains deferred. #1403 should be rewritten or split around
+    this query model before changing promotion receipt behavior; #1474 may only consume a read-only,
+    source-limited projection that keeps agent-memory posture non-authoritative.
   - This note is an enabling-change annotation, not a current-state claim. Current behavior
     (`PROMOTE_DONE` + `promotion.transition.applied` + `payload["promotion"]`) is the correct
     interim implementation.

--- a/docs/CONCEPTS/RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md
+++ b/docs/CONCEPTS/RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md
@@ -181,7 +181,40 @@ Promotion transition note (#1438):
   transition-accountability event and interim receipt-supporting record for successful promotion
   transitions;
 - ObjectStore `payload["promotion"]` inline provenance is mirror provenance, not receipt authority;
-- a formal durable promotion receipt remains blocked on the receipt-store/query model.
+- the formal promotion receipt query model is defined below.
+
+Promotion receipt query model decision (#1489):
+- The v1 formal promotion receipt model is a typed, read-only query/projection over durable
+  receipt-supporting audit records, not a new write table in the first slice. The source authority
+  for successful promotion applies is the durable `promotion.transition.applied` event record when
+  it carries authority, basis, outcome, artifact linkage, event identity, trace identity, and
+  timestamp.
+- Consumers must use a stable receipt query/projection contract rather than direct ad hoc scans of
+  DB outbox rows or JSONL diagnostics. The current per-artifact browser projection may remain an
+  implementation of that read model while preserving the honest `unavailable` state when no
+  receipt-supporting source is available.
+- The four surfaces have separate authority roles:
+  - `PROMOTE_DONE` is the execution/result trace: it records that promotion execution completed and
+    which durable `maturity` / `review_state` result was applied.
+  - `PROMOTION_TRANSITION_APPLIED` is the transition-accountability audit source and v1
+    receipt-supporting authority for the queryable promotion receipt view.
+  - ObjectStore `payload["promotion"]` is machine-mirror inline provenance and latest mirror
+    posture; it may support display or reconstruction but must not authorize a change or satisfy
+    receipt authority by itself.
+  - The final durable/queryable receipt authority for v1 consumers is the typed promotion receipt
+    read model derived from receipt-supporting audit records. A later implementation may materialize
+    that model into a dedicated physical store, but consumers depend on the query contract rather
+    than the storage shape.
+- Minimum read/query surface: artifact UUID and path; receipt id or source event id; trace id;
+  timestamp; transition family; target maturity; resulting `review_state` / `maturity`; authority;
+  basis; outcome; artifact linkage; executor/source; and the triggering intent/source event. The
+  query surface must support lookup by artifact UUID/path, receipt or event id, trace id,
+  transition family, target maturity, and outcome status, ordered by timestamp.
+- Follow-up posture: #1403 should be rewritten or split into a bounded implementation issue that
+  wires promotion receipt writes/read queries to this model without changing frontmatter field
+  names. #1474 may proceed only against a read-only, source-limited posture/receipt projection that
+  uses this query contract and preserves non-authoritative agent-memory labeling; UI implementation
+  remains blocked if that source/API is unavailable.
 
 Orientation MemoryCandidate intent note (#1456):
 - `GET /api/companion/orientation` may emit a bounded MemoryCandidate
@@ -214,7 +247,7 @@ But the existence of traces alone does not satisfy the rule.
 ## 7. Non-goals
 
 This document does not yet define:
-- a final receipt storage model,
+- a final physical receipt storage model,
 - a final trace schema,
 - exact event payload redesigns,
 - or exact UI surfaces for accountability.

--- a/docs/CONCEPTS/WORKFLOW_MUTATION_AND_GOVERNANCE_SEMANTICS.md
+++ b/docs/CONCEPTS/WORKFLOW_MUTATION_AND_GOVERNANCE_SEMANTICS.md
@@ -5,8 +5,8 @@ Owner: Workflow mutation and governance semantics
 Temporal class: strategic
 Review cadence: event-driven
 Source of truth: mixed
-Last reviewed: 2026-05-29
-Last verified against: docs/SEMANTIC_SYSTEM_ARCHITECTURE.md, docs/SEMANTIC_AUTHORITY_MATRIX.md, docs/CONCEPTS/TRUST_SEMANTICS_CONTRACT.md, docs/CONCEPTS/RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md, docs/CONCEPTS/RELATION_TAXONOMY.md, docs/CONCEPTS/RUNTIME_VS_DURABLE_STATE_BOUNDARY.md, docs/PANEL_AGENT.md, docs/FRONTMATTER.md, docs/CANVAS_CHAT_SURFACE/README.md, docs/INTERACTION_SURFACES_AND_AUTHORITY/README.md, companion-ui/docs/SEMANTIC_PROJECTION_ALIGNMENT.md, epic #1363, issue #1371.
+Last reviewed: 2026-06-02
+Last verified against: docs/SEMANTIC_SYSTEM_ARCHITECTURE.md, docs/SEMANTIC_AUTHORITY_MATRIX.md, docs/CONCEPTS/TRUST_SEMANTICS_CONTRACT.md, docs/CONCEPTS/RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md, docs/CONCEPTS/RELATION_TAXONOMY.md, docs/CONCEPTS/RUNTIME_VS_DURABLE_STATE_BOUNDARY.md, docs/PANEL_AGENT.md, docs/FRONTMATTER.md, docs/CANVAS_CHAT_SURFACE/README.md, docs/INTERACTION_SURFACES_AND_AUTHORITY/README.md, companion-ui/docs/SEMANTIC_PROJECTION_ALIGNMENT.md, epic #1363, issue #1371, issue #1489.
 
 # Workflow Mutation and Governance Semantics
 
@@ -98,15 +98,23 @@ mutation:
 - `payload["promotion"]` in the ObjectStore row is inline operational provenance for the machine
   mirror, not the durable receipt store.
 
-Current state: `PROMOTE_DONE` + `promotion.transition.applied` + ObjectStore inline provenance are
-the correct interim implementation. They provide execution/result trace, transition-accountability
-audit material, and mirror provenance respectively.
-Target state: promotion consumer also writes a formal, durable, queryable promotion receipt record
-to a receipt store.
-Pre-requisite: receipt store model (not yet built).
+Decision (#1489): the v1 formal receipt/query model is a typed, read-only promotion receipt view
+over durable receipt-supporting audit records. For successful promotion applies,
+`promotion.transition.applied` is the transition-accountability source for that view, while
+`PROMOTE_DONE` remains execution/result trace and ObjectStore `payload["promotion"]` remains
+machine-mirror provenance. The final durable/queryable receipt authority for v1 consumers is the
+query contract, not ObjectStore inline metadata and not arbitrary raw event scans.
 
-Until the receipt store is built, do not add ad hoc receipt workarounds or treat DB outbox rows or
-ObjectStore inline provenance as the final durable receipt authority.
+Minimum downstream query surface: artifact UUID/path, receipt or source event id, trace id,
+timestamp, transition family, target maturity, resulting `review_state` / `maturity`, authority,
+basis, outcome, artifact linkage, executor/source, and triggering intent/source event. Consumers
+must handle source-unavailable as an honest unavailable state rather than fabricating receipts.
+
+Follow-up posture: #1403 should be rewritten or split around this query model before implementing
+promotion receipt behavior. #1474 may only consume a read-only, source-limited projection backed by
+this model and must keep agent-memory posture non-authoritative unless a later owner contract
+explicitly changes that authority. A dedicated physical receipt store is deferred until a later
+bounded issue proves the query-over-audit-records model is insufficient.
 
 ## Cross-references
 

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -255,9 +255,13 @@ Promotion clarification (#1438):
 - `PROMOTION_TRANSITION_APPLIED` records the current transition-accountability semantics:
   `note_uuid`, `note_path`, `transition_family`, `target_maturity`, `authority`, `basis`,
   `outcome`, and `artifact_linkage`.
-- DB outbox events and ObjectStore inline provenance support accountability and audit, but they are
-  not the final durable promotion receipt store. Formal durable promotion receipts remain blocked on
-  a receipt-store/query model.
+- Receipt query decision (#1489): the v1 formal promotion receipt model is a typed, read-only
+  query/projection over durable receipt-supporting audit records. For successful promotion applies,
+  `PROMOTION_TRANSITION_APPLIED` is the receipt-supporting audit source for that query model.
+- `PROMOTE_DONE` remains execution/result trace, ObjectStore `payload["promotion"]` remains
+  machine-mirror provenance, and neither surface is the final durable/queryable receipt authority.
+  Consumers that need promotion receipt posture must use the stable receipt query/projection
+  contract instead of treating arbitrary outbox scans or ObjectStore inline metadata as authority.
 
 ## References
 

--- a/docs/VAULT_BROWSER_CAPABILITY_CONTRACT.md
+++ b/docs/VAULT_BROWSER_CAPABILITY_CONTRACT.md
@@ -242,13 +242,14 @@ Required fields:
 
 Receipts are surfaced read-only in the browser. The browser does not author receipts; receipts come from governed execution (`docs/CONCEPTS/RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md`, `docs/EVENTS.md`).
 
-Current bounded implementation note (#1279): until a final durable receipt store/query model exists,
-the Vault Browser may populate per-artifact receipt rows from an explicit read-only projection over
-governed outbox/event records that already carry receipt/accountability semantics, such as
-`promotion.transition.applied`, `panel.action.logged`, and `panel.action.blocked`. This projection is
-not a parallel receipt authority and must remain batch-oriented over the notes returned by a browser
-load. If no outbox/event receipt source is available, the per-note `receipts` key is omitted so the
-inspector renders `data-receipt-state="unavailable"` honestly.
+Current bounded implementation note (#1279, refined by #1489): the Vault Browser may populate
+per-artifact receipt rows from an explicit read-only projection over governed outbox/event records
+that already carry receipt/accountability semantics, such as `promotion.transition.applied`,
+`panel.action.logged`, and `panel.action.blocked`. This projection is the current implementation of
+the v1 receipt query model for browser consumers, not a parallel receipt authority, not an arbitrary
+event scan, and not an ObjectStore-derived authority surface. It must remain batch-oriented over the
+notes returned by a browser load. If no outbox/event receipt source is available, the per-note
+`receipts` key is omitted so the inspector renders `data-receipt-state="unavailable"` honestly.
 
 Current UI detail implementation note (#1284): receipt rows may expand/collapse locally in the
 inspector to reveal read-only receipt details. The expanded detail displays available VaultReceipt


### PR DESCRIPTION
Closes #1489

## Summary
- Defines the #1489 v1 promotion receipt/query model as a typed, read-only query/projection over durable receipt-supporting audit records.
- Distinguishes `PROMOTE_DONE`, `PROMOTION_TRANSITION_APPLIED`, ObjectStore `payload["promotion"]`, and the final durable/queryable receipt authority.
- Records downstream posture for #1403 and #1474 and refines the Vault Browser receipt projection note.

## Changed files
- `docs/CONCEPTS/RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md`
- `docs/CONCEPTS/WORKFLOW_MUTATION_AND_GOVERNANCE_SEMANTICS.md`
- `docs/CONCEPTS/ONTOLOGY_VOCABULARY.md`
- `docs/EVENTS.md`
- `docs/VAULT_BROWSER_CAPABILITY_CONTRACT.md`

## Acceptance criteria mapping
- Owner docs record chosen model: receipt and workflow contracts name the #1489 v1 typed read/query model.
- Four surfaces distinguished: receipt, workflow, ontology, and event docs name execution/result event, transition-accountability event, ObjectStore inline provenance, and final durable/queryable receipt authority.
- Minimum query/read surface: receipt, workflow, and ontology docs list required fields and lookup posture.
- Follow-up handling: docs explicitly state #1403 should be rewritten/split around this model and #1474 may only proceed against a read-only source-limited projection, remaining blocked if the source/API is unavailable.
- Validation: docs guard and whitespace checks passed.

## Validation
- `python3 scripts/docs_guard.py` -> Docs guard: OK
- `git diff --check` -> pass
- `rg -n 'Promotion receipt query model decision \(#1489\)|Decision \(#1489\)|Receipt query decision \(#1489\)|#1403|#1474|PROMOTE_DONE|PROMOTION_TRANSITION_APPLIED|ObjectStore|final durable/queryable receipt authority' docs/CONCEPTS/RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md docs/CONCEPTS/WORKFLOW_MUTATION_AND_GOVERNANCE_SEMANTICS.md docs/CONCEPTS/ONTOLOGY_VOCABULARY.md docs/EVENTS.md docs/VAULT_BROWSER_CAPABILITY_CONTRACT.md` -> expected matches present

Unit tests run: 0. This PR is a docs/scoping decision only and changes no Python/runtime code.

## Scope statement
Docs-only decision/scoping slice. No new receipt store, no receipt writes, no API implementation, no Vault Browser UI implementation, no frontmatter schema changes, and no product/runtime authority mutation.

## Claim note
Local dispatcher status is still blocked by the existing `ModuleNotFoundError: No module named 'yaml'`; claim used the documented GitHub/project fallback.

## Known follow-ups
- #1403 should be rewritten or split into a bounded implementation issue around this query model before promotion receipt behavior changes.
- #1474 may consume only a read-only, source-limited posture/receipt projection using this model and must keep agent-memory posture non-authoritative.
- Dedicated physical receipt-store materialization remains deferred until a later bounded issue proves query-over-audit-records is insufficient.
