### PR TITLE
[codex] deliver receipt query and orientation fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,12 @@ lint:
 	$(PYTHON) -m mypy app || true
 
 test:
-	export PYTEST_DISABLE_PLUGIN_AUTOLOAD=1; $(PYTHON) -m pytest -q -c /dev/null
+	@PYTEST_PLUGIN_ARGS=""; \
+	if $(PYTHON) -c "import pytest_asyncio.plugin" >/dev/null 2>&1; then \
+		PYTEST_PLUGIN_ARGS="-p pytest_asyncio.plugin"; \
+	fi; \
+	export PYTEST_DISABLE_PLUGIN_AUTOLOAD=1; \
+	$(PYTHON) -m pytest $$PYTEST_PLUGIN_ARGS -q -c /dev/null --import-mode=importlib
 
 eval:
 	$(PYTHON) -m app.eval.run
@@ -62,19 +67,29 @@ persist-runtime-repairs:
 	@bash scripts/persist_runtime_repairs.sh
 
 smoke:
-	@XDIST_ARGS=""; \
-	if $(PYTHON) -m pytest -p xdist.plugin --help 2>/dev/null | rg -q -- "^-n "; then \
+	@PYTEST_PLUGIN_ARGS=""; \
+	XDIST_ARGS=""; \
+	if $(PYTHON) -c "import xdist.plugin" >/dev/null 2>&1; then \
+		PYTEST_PLUGIN_ARGS="-p xdist.plugin"; \
 		XDIST_ARGS="-n $(SMOKE_WORKERS) --dist=loadfile"; \
 	fi; \
+	if $(PYTHON) -c "import pytest_asyncio.plugin" >/dev/null 2>&1; then \
+		PYTEST_PLUGIN_ARGS="$$PYTEST_PLUGIN_ARGS -p pytest_asyncio.plugin"; \
+	fi; \
 	PYTHONPATH="$(PWD)" PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 STORE_BACKEND=memory \
-	$(PYTHON) -m pytest -p xdist.plugin -q -c /dev/null -k "not slow and not e2e" $$XDIST_ARGS
+	$(PYTHON) -m pytest $$PYTEST_PLUGIN_ARGS -q -c /dev/null --import-mode=importlib -k "not slow and not e2e" $$XDIST_ARGS
 	@if [ "$(SMOKE_E2E_WORKERS)" != "0" ]; then \
+		PYTEST_E2E_PLUGIN_ARGS=""; \
 		XDIST_E2E_ARGS=""; \
-		if $(PYTHON) -m pytest -p xdist.plugin --help 2>/dev/null | rg -q -- "^-n "; then \
+		if $(PYTHON) -c "import xdist.plugin" >/dev/null 2>&1; then \
+			PYTEST_E2E_PLUGIN_ARGS="-p xdist.plugin"; \
 			XDIST_E2E_ARGS="-n $(SMOKE_E2E_WORKERS) --dist=loadfile"; \
 		fi; \
+		if $(PYTHON) -c "import pytest_asyncio.plugin" >/dev/null 2>&1; then \
+			PYTEST_E2E_PLUGIN_ARGS="$$PYTEST_E2E_PLUGIN_ARGS -p pytest_asyncio.plugin"; \
+		fi; \
 		PYTHONPATH="$(PWD)" PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 STORE_BACKEND=memory \
-		$(PYTHON) -m pytest -p xdist.plugin -q -c /dev/null -k "e2e and not slow" $$XDIST_E2E_ARGS ; \
+		$(PYTHON) -m pytest $$PYTEST_E2E_PLUGIN_ARGS -q -c /dev/null --import-mode=importlib -k "e2e and not slow" $$XDIST_E2E_ARGS ; \
 	fi
 
 test-vault-init:

--- a/app/agents/panel_agent/agent.py
+++ b/app/agents/panel_agent/agent.py
@@ -52,6 +52,7 @@ def _map_action(action: ParsedAction, catalog: PanelActionCatalog) -> PanelInten
     action_id = descriptor.id if descriptor else (action.action_id or normalize_label(action.label) or uuid4().hex)
     return PanelIntentAction(
         id=action_id,
+        option_id=action.option_id,
         label=action.label,
         checked=action.checked,
         mapping=mapping,

--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -617,7 +617,17 @@ def _validate_workspace_markdown_note_path(note_path_raw: str) -> str:
 
 
 def _find_workspace_note(vault_root: Path, safe_note_path: str) -> Path | None:
-    """Resolve a validated note path while preserving direct lookup latency."""
+    """Resolve a validated note path while preserving direct lookup latency.
+
+    Workspace reads are restricted to markdown notes. The direct O(1) lookup
+    replaced an earlier ``rglob("*.md")`` scan that was implicitly
+    markdown-only; without this suffix guard a read such as
+    ``note_path=attachments/private.txt`` would surface arbitrary non-note vault
+    content (the GET read path validates with ``_validate_workspace_note_path``,
+    not the ``.md``-enforcing validator used by write endpoints).
+    """
+    if not safe_note_path.endswith(".md"):
+        return None
     root_real = os.path.realpath(vault_root)
     target_real = os.path.realpath(os.path.join(root_real, safe_note_path))
     if not target_real.startswith(root_real + os.sep):

--- a/app/api/routes/companion.py
+++ b/app/api/routes/companion.py
@@ -617,39 +617,10 @@ def _validate_workspace_markdown_note_path(note_path_raw: str) -> str:
 
 
 def _find_workspace_note(vault_root: Path, safe_note_path: str) -> Path | None:
-    root_real = Path(os.path.realpath(vault_root))
-    for candidate in vault_root.rglob("*.md"):
-        if not candidate.is_file():
-            continue
-        if _vault_relative(candidate, vault_root) != safe_note_path:
-            continue
-        candidate_real = Path(os.path.realpath(candidate))
-        try:
-            candidate_real.relative_to(root_real)
-        except ValueError as exc:
-            raise HTTPException(
-                status_code=400,
-                detail={
-                    "error": "path_escape",
-                    "message": "Resolved note path is outside the vault.",
-                },
-            ) from exc
-        return candidate_real
-    return None
-
-
-def _vault_contained_abs_path(vault_root: Path, safe_note_path: str) -> Path:
-    """Resolve a validated relative note path to an absolute path, asserting it
-    stays inside the vault root.
-
-    Defense-in-depth against path traversal and symlink escape on top of
-    ``_validate_workspace_note_path`` (and a sanitizer CodeQL recognizes for the
-    py/path-injection rule): the realpath of the target must be the vault root
-    itself or a descendant of it.
-    """
+    """Resolve a validated note path while preserving direct lookup latency."""
     root_real = os.path.realpath(vault_root)
     target_real = os.path.realpath(os.path.join(root_real, safe_note_path))
-    if target_real != root_real and not target_real.startswith(root_real + os.sep):
+    if not target_real.startswith(root_real + os.sep):
         raise HTTPException(
             status_code=400,
             detail={
@@ -657,6 +628,8 @@ def _vault_contained_abs_path(vault_root: Path, safe_note_path: str) -> Path:
                 "message": "Resolved note path is outside the vault.",
             },
         )
+    if not os.path.isfile(target_real):
+        return None
     return Path(target_real)
 
 

--- a/app/builderops/store.py
+++ b/app/builderops/store.py
@@ -281,6 +281,8 @@ class SqliteBuilderOpsStore:
                 "transition requires lifecycle_state or promotion_status"
             )
         key = _idempotency_key({"idempotency_key": idempotency_key})
+        if key is None:
+            raise BuilderOpsValidationError("idempotency_key must be a non-empty string")
         if not lease_id:
             raise BuilderOpsValidationError("lease_id must not be empty")
         validate_source_refs(source_refs)

--- a/app/events/panel.py
+++ b/app/events/panel.py
@@ -21,6 +21,7 @@ class PanelActionMapping(BaseModel):
 
 class PanelIntentAction(BaseModel):
     id: str
+    option_id: str | None = None
     label: str
     checked: bool
     mapping: PanelActionMapping | None = None

--- a/app/receipts/artifact_receipts.py
+++ b/app/receipts/artifact_receipts.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
-import json
-import os
 from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
 from typing import Any, Iterable
 
-from app.settings.watcher_settings import load_watcher_settings
+from app.receipts.outbox_sources import (
+    first_str,
+    nested,
+    normalize_note_path,
+    read_receipt_source_records,
+    record_event,
+    record_payload,
+)
+from app.receipts.promotion_receipts import query_promotion_receipts
 
 
 @dataclass(frozen=True)
@@ -21,7 +26,6 @@ class ArtifactReceiptTarget:
 _RECEIPT_SUPPORTING_EVENTS = {
     "panel.action.blocked",
     "panel.action.logged",
-    "promotion.transition.applied",
 }
 
 
@@ -42,11 +46,11 @@ def receipts_for_artifacts(
     if not target_list:
         return {}
 
-    records = _read_receipt_source_records(outbox_path=outbox_path)
+    records = read_receipt_source_records(outbox_path=outbox_path)
     if records is None:
         return None
 
-    path_targets = {_normalize_note_path(target.note_path, vault_root=vault_root): target for target in target_list}
+    path_targets = {normalize_note_path(target.note_path, vault_root=vault_root): target for target in target_list}
     uuid_targets = {
         str(target.artifact_uuid).strip(): target
         for target in target_list
@@ -76,102 +80,26 @@ def receipts_for_artifacts(
             result[note_path].append(dict(receipt))
             seen[note_path].add(receipt_id)
 
+    promotion_projection = query_promotion_receipts(vault_root=vault_root, records=records)
+    for row in promotion_projection.rows:
+        receipt = row.to_artifact_receipt()
+        promotion_matched: set[str] = set()
+        if row.artifact_uuid and row.artifact_uuid in uuid_targets:
+            promotion_matched.add(uuid_targets[row.artifact_uuid].note_path)
+        if row.artifact_path and row.artifact_path in path_targets:
+            promotion_matched.add(path_targets[row.artifact_path].note_path)
+        if not promotion_matched:
+            continue
+        receipt_id = str(receipt.get("receipt_id") or "")
+        for note_path in promotion_matched:
+            if receipt_id in seen[note_path]:
+                continue
+            result[note_path].append(dict(receipt))
+            seen[note_path].add(receipt_id)
+
     for rows in result.values():
         rows.sort(key=lambda row: str(row.get("timestamp") or ""))
     return result
-
-
-def _read_receipt_source_records(*, outbox_path: Path | None) -> list[dict[str, Any]] | None:
-    source_available = False
-    records: list[dict[str, Any]] = []
-
-    db_records = _read_db_outbox_records()
-    if db_records is not None:
-        source_available = True
-        records.extend(db_records)
-
-    jsonl_records = _read_jsonl_outbox_records(outbox_path=outbox_path)
-    if jsonl_records is not None:
-        source_available = True
-        records.extend(jsonl_records)
-
-    return records if source_available else None
-
-
-def _read_db_outbox_records() -> list[dict[str, Any]] | None:
-    if not _db_outbox_configured():
-        return None
-    try:
-        from app.services import outbox as outbox_service
-
-        conn = outbox_service._open_conn()
-    except Exception:
-        return None
-    try:
-        cur = conn.cursor()
-        cur.execute("select id, topic, payload, created_at from outbox order by created_at asc")
-        rows = cur.fetchall() or []
-    except Exception:
-        return None
-    finally:
-        try:
-            conn.close()
-        except Exception:
-            pass
-
-    records: list[dict[str, Any]] = []
-    for row in rows:
-        if isinstance(row, dict):
-            row_id = row.get("id")
-            topic = row.get("topic")
-            payload = row.get("payload")
-            created_at = row.get("created_at")
-        else:
-            row_id, topic, payload, created_at = row
-        record = _coerce_record(payload)
-        record.setdefault("event", topic)
-        record.setdefault("event_type", topic)
-        record.setdefault("event_id", str(row_id) if row_id is not None else "")
-        if created_at is not None:
-            record.setdefault("created_at", _coerce_timestamp(created_at))
-            record.setdefault("timestamp", _coerce_timestamp(created_at))
-        records.append(record)
-    return records
-
-
-def _db_outbox_configured() -> bool:
-    backend = (os.getenv("STORE_BACKEND") or "").strip().lower()
-    return backend == "pg" or bool(os.getenv("DATABASE_URL") or os.getenv("DB_DSN"))
-
-
-def _read_jsonl_outbox_records(*, outbox_path: Path | None) -> list[dict[str, Any]] | None:
-    resolved = _resolve_jsonl_outbox_path(outbox_path)
-    if resolved is None or not resolved.exists() or not resolved.is_file():
-        return None
-    records: list[dict[str, Any]] = []
-    for line in resolved.read_text(encoding="utf-8").splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            parsed = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if isinstance(parsed, dict):
-            records.append(parsed)
-    return records
-
-
-def _resolve_jsonl_outbox_path(outbox_path: Path | None) -> Path | None:
-    if outbox_path is not None:
-        return Path(outbox_path).expanduser()
-    env_path = (os.getenv("INDEX_OUTBOX_PATH") or "").strip()
-    if env_path:
-        return Path(env_path).expanduser()
-    try:
-        return load_watcher_settings().paths.index_outbox
-    except Exception:
-        return None
 
 
 def _project_receipt_record(
@@ -179,23 +107,23 @@ def _project_receipt_record(
     *,
     vault_root: Path,
 ) -> tuple[dict[str, str | None], str | None, str | None] | None:
-    event = _record_event(record)
+    event = record_event(record)
     if event not in _RECEIPT_SUPPORTING_EVENTS:
         return None
-    payload = _record_payload(record)
-    artifact_uuid = _first_str(
+    payload = record_payload(record)
+    artifact_uuid = first_str(
         payload.get("artifact_uuid"),
         payload.get("note_uuid"),
-        _nested(payload, "note", "uuid"),
-        _nested(payload, "artifact_linkage", "note_uuid"),
+        nested(payload, "note", "uuid"),
+        nested(payload, "artifact_linkage", "note_uuid"),
     )
-    artifact_path = _normalize_note_path(
-        _first_str(
+    artifact_path = normalize_note_path(
+        first_str(
             payload.get("artifact_path"),
             payload.get("note_path"),
             payload.get("path"),
-            _nested(payload, "note", "path"),
-            _nested(payload, "artifact_linkage", "note_path"),
+            nested(payload, "note", "path"),
+            nested(payload, "artifact_linkage", "note_path"),
         ),
         vault_root=vault_root,
     )
@@ -203,16 +131,16 @@ def _project_receipt_record(
         return None
 
     status, state = _status_and_state(event, payload)
-    trace_id = _first_str(record.get("trace_id"), payload.get("trace_id"))
-    action_id = _first_str(
+    trace_id = first_str(record.get("trace_id"), payload.get("trace_id"))
+    action_id = first_str(
         payload.get("action_id"),
         payload.get("intent_event_id"),
         payload.get("source_event"),
-        _nested(payload, "action", "id"),
+        nested(payload, "action", "id"),
         event,
     )
-    timestamp = _first_str(record.get("timestamp"), record.get("created_at")) or ""
-    receipt_id = _first_str(payload.get("receipt_id"), record.get("event_id"))
+    timestamp = first_str(record.get("timestamp"), record.get("created_at")) or ""
+    receipt_id = first_str(payload.get("receipt_id"), record.get("event_id"))
     if not receipt_id:
         receipt_id = f"{event}:{trace_id or 'no-trace'}:{artifact_uuid or artifact_path}:{timestamp}"
 
@@ -225,7 +153,7 @@ def _project_receipt_record(
         "artifact_path": artifact_path,
         "path": artifact_path,
         "requested_by": _requested_by(record, payload),
-        "approved_by": _first_str(payload.get("approved_by"), _nested(payload, "authority", "approved_by")),
+        "approved_by": first_str(payload.get("approved_by"), nested(payload, "authority", "approved_by")),
         "status": status,
         "timestamp": timestamp,
         "state": state,
@@ -233,71 +161,13 @@ def _project_receipt_record(
     return receipt, artifact_uuid, artifact_path
 
 
-def _coerce_record(value: Any) -> dict[str, Any]:
-    if isinstance(value, dict):
-        return dict(value)
-    if isinstance(value, str):
-        try:
-            parsed = json.loads(value)
-        except json.JSONDecodeError:
-            return {}
-        return dict(parsed) if isinstance(parsed, dict) else {}
-    return {}
-
-
-def _record_event(record: dict[str, Any]) -> str:
-    return str(record.get("event") or record.get("event_type") or record.get("topic") or "").strip()
-
-
-def _record_payload(record: dict[str, Any]) -> dict[str, Any]:
-    payload = record.get("payload")
-    if isinstance(payload, str):
-        try:
-            payload = json.loads(payload)
-        except json.JSONDecodeError:
-            return {}
-    return dict(payload) if isinstance(payload, dict) else {}
-
-
-def _nested(data: dict[str, Any], *path: str) -> Any:
-    current: Any = data
-    for part in path:
-        if not isinstance(current, dict):
-            return None
-        current = current.get(part)
-    return current
-
-
-def _first_str(*values: Any) -> str | None:
-    for value in values:
-        if value is None:
-            continue
-        text = str(value).strip()
-        if text:
-            return text
-    return None
-
-
-def _normalize_note_path(value: str | None, *, vault_root: Path) -> str | None:
-    text = (value or "").strip()
-    if not text:
-        return None
-    path = Path(text).expanduser()
-    if path.is_absolute():
-        try:
-            return path.relative_to(vault_root).as_posix()
-        except ValueError:
-            return path.as_posix()
-    return path.as_posix().removeprefix("./")
-
-
 def _status_and_state(event: str, payload: dict[str, Any]) -> tuple[str, str]:
     if event == "panel.action.blocked":
         return "blocked", "blocked"
     if event == "panel.action.logged":
-        return _first_str(payload.get("status"), payload.get("outcome"), "logged") or "logged", "applied"
-    raw = _first_str(
-        _nested(payload, "outcome", "status"),
+        return first_str(payload.get("status"), payload.get("outcome"), "logged") or "logged", "applied"
+    raw = first_str(
+        nested(payload, "outcome", "status"),
         payload.get("status"),
         payload.get("effect"),
         "applied",
@@ -314,18 +184,12 @@ def _status_and_state(event: str, payload: dict[str, Any]) -> tuple[str, str]:
 
 
 def _requested_by(record: dict[str, Any], payload: dict[str, Any]) -> str | None:
-    return _first_str(
+    return first_str(
         payload.get("requested_by"),
-        _nested(payload, "authority", "requested_by"),
-        _nested(payload, "authority", "component"),
+        nested(payload, "authority", "requested_by"),
+        nested(payload, "authority", "component"),
         record.get("source"),
     )
-
-
-def _coerce_timestamp(value: Any) -> str:
-    if isinstance(value, datetime):
-        return value.isoformat().replace("+00:00", "Z")
-    return str(value)
 
 
 __all__ = ["ArtifactReceiptTarget", "receipts_for_artifacts"]

--- a/app/receipts/outbox_sources.py
+++ b/app/receipts/outbox_sources.py
@@ -1,0 +1,185 @@
+"""Shared readers for receipt-supporting outbox records."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from app.settings.watcher_settings import load_watcher_settings
+
+
+def read_receipt_source_records(*, outbox_path: Path | None = None) -> list[dict[str, Any]] | None:
+    """Read receipt-supporting source records from configured durable/audit sources.
+
+    ``None`` means no source is available. An empty list means a source is
+    connected and contains no readable records.
+    """
+
+    source_available = False
+    records: list[dict[str, Any]] = []
+
+    db_records = _read_db_outbox_records()
+    if db_records is not None:
+        source_available = True
+        records.extend(db_records)
+
+    jsonl_records = _read_jsonl_outbox_records(outbox_path=outbox_path)
+    if jsonl_records is not None:
+        source_available = True
+        records.extend(jsonl_records)
+
+    return records if source_available else None
+
+
+def record_event(record: dict[str, Any]) -> str:
+    return str(record.get("event") or record.get("event_type") or record.get("topic") or "").strip()
+
+
+def record_payload(record: dict[str, Any]) -> dict[str, Any]:
+    payload = record.get("payload")
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except json.JSONDecodeError:
+            return {}
+    return dict(payload) if isinstance(payload, dict) else {}
+
+
+def first_str(*values: Any) -> str | None:
+    for value in values:
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None
+
+
+def nested(data: dict[str, Any], *path: str) -> Any:
+    current: Any = data
+    for part in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(part)
+    return current
+
+
+def normalize_note_path(value: str | None, *, vault_root: Path) -> str | None:
+    text = (value or "").strip()
+    if not text:
+        return None
+    path = Path(text).expanduser()
+    if path.is_absolute():
+        try:
+            return path.relative_to(vault_root).as_posix()
+        except ValueError:
+            return path.as_posix()
+    return path.as_posix().removeprefix("./")
+
+
+def coerce_timestamp(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat().replace("+00:00", "Z")
+    return str(value)
+
+
+def _read_db_outbox_records() -> list[dict[str, Any]] | None:
+    if not _db_outbox_configured():
+        return None
+    try:
+        from app.services import outbox as outbox_service
+
+        conn = outbox_service._open_conn()
+    except Exception:
+        return None
+    try:
+        cur = conn.cursor()
+        cur.execute("select id, topic, payload, created_at from outbox order by created_at asc")
+        rows = cur.fetchall() or []
+    except Exception:
+        return None
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+    records: list[dict[str, Any]] = []
+    for row in rows:
+        if isinstance(row, dict):
+            row_id = row.get("id")
+            topic = row.get("topic")
+            payload = row.get("payload")
+            created_at = row.get("created_at")
+        else:
+            row_id, topic, payload, created_at = row
+        record = _coerce_record(payload)
+        record.setdefault("event", topic)
+        record.setdefault("event_type", topic)
+        record.setdefault("event_id", str(row_id) if row_id is not None else "")
+        if created_at is not None:
+            record.setdefault("created_at", coerce_timestamp(created_at))
+            record.setdefault("timestamp", coerce_timestamp(created_at))
+        records.append(record)
+    return records
+
+
+def _db_outbox_configured() -> bool:
+    backend = (os.getenv("STORE_BACKEND") or "").strip().lower()
+    return backend == "pg" or bool(os.getenv("DATABASE_URL") or os.getenv("DB_DSN"))
+
+
+def _read_jsonl_outbox_records(*, outbox_path: Path | None) -> list[dict[str, Any]] | None:
+    resolved = _resolve_jsonl_outbox_path(outbox_path)
+    if resolved is None or not resolved.exists() or not resolved.is_file():
+        return None
+    records: list[dict[str, Any]] = []
+    for line in resolved.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            records.append(parsed)
+    return records
+
+
+def _resolve_jsonl_outbox_path(outbox_path: Path | None) -> Path | None:
+    if outbox_path is not None:
+        return Path(outbox_path).expanduser()
+    env_path = (os.getenv("INDEX_OUTBOX_PATH") or "").strip()
+    if env_path:
+        return Path(env_path).expanduser()
+    try:
+        return load_watcher_settings().paths.index_outbox
+    except Exception:
+        return None
+
+
+def _coerce_record(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return dict(value)
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        return dict(parsed) if isinstance(parsed, dict) else {}
+    return {}
+
+
+__all__ = [
+    "coerce_timestamp",
+    "first_str",
+    "nested",
+    "normalize_note_path",
+    "read_receipt_source_records",
+    "record_event",
+    "record_payload",
+]

--- a/app/receipts/promotion_receipts.py
+++ b/app/receipts/promotion_receipts.py
@@ -1,0 +1,244 @@
+"""Typed read-only promotion receipt query projection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+from app.events.types import PROMOTION_TRANSITION_APPLIED
+from app.receipts.outbox_sources import (
+    first_str,
+    nested,
+    normalize_note_path,
+    read_receipt_source_records,
+    record_event,
+    record_payload,
+)
+
+
+@dataclass(frozen=True)
+class PromotionReceiptQuery:
+    artifact_uuid: str | None = None
+    artifact_path: str | None = None
+    receipt_or_source_event_id: str | None = None
+    trace_id: str | None = None
+    transition_family: str | None = None
+    target_maturity: str | None = None
+    outcome_status: str | None = None
+
+
+@dataclass(frozen=True)
+class PromotionReceiptRow:
+    receipt_id: str
+    source_event_id: str | None
+    trace_id: str | None
+    timestamp: str
+    artifact_uuid: str | None
+    artifact_path: str | None
+    transition_family: str | None
+    target_maturity: str | None
+    review_state: str | None
+    maturity: str | None
+    authority: dict[str, Any]
+    basis: dict[str, Any]
+    outcome: dict[str, Any]
+    artifact_linkage: dict[str, Any]
+    executor: str | None
+    source: str | None
+    triggering_intent_event_id: str | None
+
+    @property
+    def outcome_status(self) -> str | None:
+        return first_str(self.outcome.get("status"))
+
+    def to_artifact_receipt(self) -> dict[str, str | None]:
+        status = self.outcome_status or "applied"
+        state = status if status in {"applied", "queued", "blocked", "rejected", "failed"} else "applied"
+        return {
+            "receipt_id": self.receipt_id,
+            "trace_id": self.trace_id,
+            "action_id": self.triggering_intent_event_id or self.source_event_id,
+            "action_type": PROMOTION_TRANSITION_APPLIED,
+            "artifact_uuid": self.artifact_uuid,
+            "artifact_path": self.artifact_path,
+            "path": self.artifact_path,
+            "requested_by": first_str(
+                self.authority.get("requested_by"),
+                self.authority.get("component"),
+                self.source,
+            ),
+            "approved_by": first_str(self.authority.get("approved_by")),
+            "status": status,
+            "timestamp": self.timestamp,
+            "state": state,
+        }
+
+
+@dataclass(frozen=True)
+class PromotionReceiptQueryResult:
+    source_available: bool
+    rows: tuple[PromotionReceiptRow, ...] = ()
+    non_authoritative_records: tuple[dict[str, str | None], ...] = field(default_factory=tuple)
+
+
+def query_promotion_receipts(
+    query: PromotionReceiptQuery | None = None,
+    *,
+    vault_root: Path,
+    outbox_path: Path | None = None,
+    records: Iterable[dict[str, Any]] | None = None,
+) -> PromotionReceiptQueryResult:
+    """Return typed promotion receipt rows derived from authoritative records.
+
+    The v1 authority source is ``promotion.transition.applied``. Other records,
+    including ``promote.done``, are intentionally ignored.
+    """
+
+    source_records = list(records) if records is not None else read_receipt_source_records(outbox_path=outbox_path)
+    if source_records is None:
+        return PromotionReceiptQueryResult(source_available=False)
+
+    filters = query or PromotionReceiptQuery()
+    rows: list[PromotionReceiptRow] = []
+    non_authoritative: list[dict[str, str | None]] = []
+    for record in source_records:
+        event = record_event(record)
+        if event != PROMOTION_TRANSITION_APPLIED:
+            continue
+        row, reason = _project_transition_applied(record, vault_root=vault_root)
+        if row is None:
+            non_authoritative.append({
+                "event_id": first_str(record.get("event_id")),
+                "trace_id": first_str(record.get("trace_id")),
+                "reason": reason,
+            })
+            continue
+        if _matches(row, filters):
+            rows.append(row)
+
+    rows.sort(key=lambda row: row.timestamp)
+    return PromotionReceiptQueryResult(
+        source_available=True,
+        rows=tuple(rows),
+        non_authoritative_records=tuple(non_authoritative),
+    )
+
+
+def _project_transition_applied(
+    record: dict[str, Any],
+    *,
+    vault_root: Path,
+) -> tuple[PromotionReceiptRow | None, str]:
+    payload = record_payload(record)
+    authority = payload.get("authority")
+    basis = payload.get("basis")
+    outcome = payload.get("outcome")
+    artifact_linkage = payload.get("artifact_linkage")
+    if not isinstance(authority, dict):
+        return None, "missing_authority"
+    if not isinstance(basis, dict):
+        return None, "missing_basis"
+    if not isinstance(outcome, dict):
+        return None, "missing_outcome"
+    if not isinstance(artifact_linkage, dict):
+        return None, "missing_artifact_linkage"
+
+    artifact_uuid = first_str(
+        payload.get("artifact_uuid"),
+        payload.get("note_uuid"),
+        nested(payload, "note", "uuid"),
+        artifact_linkage.get("artifact_uuid"),
+        artifact_linkage.get("note_uuid"),
+    )
+    artifact_path = normalize_note_path(
+        first_str(
+            payload.get("artifact_path"),
+            payload.get("note_path"),
+            payload.get("path"),
+            nested(payload, "note", "path"),
+            artifact_linkage.get("artifact_path"),
+            artifact_linkage.get("note_path"),
+        ),
+        vault_root=vault_root,
+    )
+    if not artifact_uuid and not artifact_path:
+        return None, "missing_artifact_identity"
+
+    receipt_id = first_str(payload.get("receipt_id"), record.get("event_id"))
+    if not receipt_id:
+        return None, "missing_receipt_or_event_id"
+    timestamp = first_str(record.get("timestamp"), record.get("created_at"))
+    if not timestamp:
+        return None, "missing_timestamp"
+
+    source_event_id = first_str(
+        payload.get("source_event"),
+        payload.get("intent_event_id"),
+        basis.get("source_event"),
+        record.get("event_id"),
+    )
+    trace_id = first_str(record.get("trace_id"), payload.get("trace_id"))
+    target_maturity = first_str(payload.get("target_maturity"), outcome.get("maturity"))
+    triggering_intent = first_str(payload.get("intent_event_id"), basis.get("source_event"))
+    return (
+        PromotionReceiptRow(
+            receipt_id=receipt_id,
+            source_event_id=source_event_id,
+            trace_id=trace_id,
+            timestamp=timestamp,
+            artifact_uuid=artifact_uuid,
+            artifact_path=artifact_path,
+            transition_family=first_str(payload.get("transition_family"), "promotion"),
+            target_maturity=target_maturity,
+            review_state=first_str(outcome.get("review_state")),
+            maturity=first_str(outcome.get("maturity")),
+            authority=dict(authority),
+            basis=dict(basis),
+            outcome=dict(outcome),
+            artifact_linkage=dict(artifact_linkage),
+            executor=first_str(payload.get("executor"), authority.get("executor")),
+            source=_record_source(record),
+            triggering_intent_event_id=triggering_intent,
+        ),
+        "",
+    )
+
+
+def _record_source(record: dict[str, Any]) -> str | None:
+    source = record.get("source")
+    if isinstance(source, dict):
+        return first_str(source.get("component"), source.get("name"), source.get("trigger"))
+    return first_str(source)
+
+
+def _matches(row: PromotionReceiptRow, query: PromotionReceiptQuery) -> bool:
+    if query.artifact_uuid and query.artifact_uuid != row.artifact_uuid:
+        return False
+    if query.artifact_path and query.artifact_path != row.artifact_path:
+        return False
+    if query.receipt_or_source_event_id:
+        values = {
+            row.receipt_id,
+            row.source_event_id,
+            row.triggering_intent_event_id,
+        }
+        if query.receipt_or_source_event_id not in values:
+            return False
+    if query.trace_id and query.trace_id != row.trace_id:
+        return False
+    if query.transition_family and query.transition_family != row.transition_family:
+        return False
+    if query.target_maturity and query.target_maturity != row.target_maturity:
+        return False
+    if query.outcome_status and query.outcome_status != row.outcome_status:
+        return False
+    return True
+
+
+__all__ = [
+    "PromotionReceiptQuery",
+    "PromotionReceiptQueryResult",
+    "PromotionReceiptRow",
+    "query_promotion_receipts",
+]

--- a/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
+++ b/companion-ui/companion-app/companion_ui/workspace/serve_dev_page.py
@@ -72,6 +72,7 @@ from companion_ui.workspace.workspace_http_client import (
 _DEFAULT_HOST = "127.0.0.1"
 _DEFAULT_PORT = 8111
 _DEFAULT_API_BASE_URL = "http://127.0.0.1:18001"
+_TRUTHY_ENV = {"1", "true", "yes", "on"}
 
 
 def load_config() -> dict:
@@ -85,6 +86,10 @@ def load_config() -> dict:
         "port": int(os.environ.get("PORT", str(_DEFAULT_PORT))),
         "api_base_url": os.environ.get("COMPANION_API_BASE_URL", _DEFAULT_API_BASE_URL),
     }
+
+
+def orientation_ambient_refresh_enabled() -> bool:
+    return os.environ.get("COMPANION_ORIENTATION_AMBIENT_REFRESH", "").strip().lower() in _TRUTHY_ENV
 
 
 def _e(value: str) -> str:
@@ -3771,6 +3776,7 @@ def _render_orientation_index_html(
     orientation: dict,
     production_profile: bool,
     diagnostics: bool,
+    ambient_refresh_enabled: bool = False,
 ) -> str:
     scope = _orientation_dict(orientation.get("scope"))
     meta = _orientation_dict(orientation.get("meta"))
@@ -3780,6 +3786,9 @@ def _render_orientation_index_html(
     title_suffix = "PROD" if production_profile else "DEV"
     dev_chip = "" if production_profile else '<span class="dev-chip">DEV / not production</span>'
     freshness = _orientation_str(meta.get("freshness"), "unknown")
+    stale_after = _orientation_str(meta.get("stale_after"))
+    as_of = _orientation_str(meta.get("as_of"))
+    trace_id = _orientation_str(meta.get("trace_id"), "unknown")
     runtime_posture = _orientation_str(guards.get("runtime_posture"), "unknown")
     reason_html = "".join(
         f'<span class="orientation-reason">{_e(reason)}</span>' for reason in reasons
@@ -3795,6 +3804,23 @@ def _render_orientation_index_html(
         if degraded
         else ""
     )
+    refresh_mode = "foreground_pull" if ambient_refresh_enabled else "manual"
+    refresh_state = "degraded" if degraded else ("scheduled" if ambient_refresh_enabled and stale_after else "manual_refresh")
+    refresh_copy = (
+        "Foreground refresh scheduled from server freshness metadata."
+        if ambient_refresh_enabled and stale_after and not degraded
+        else "Manual refresh"
+    )
+    refresh_html = f"""
+        <section class="orientation-refresh"
+          data-testid="workspace-orientation-ambient-refresh"
+          data-refresh-mode="{_e(refresh_mode)}"
+          data-refresh-state="{_e(refresh_state)}"
+          data-read-only="true">
+          <span>{_e(refresh_copy)}</span>
+          <a href="/" data-testid="workspace-orientation-manual-refresh">Refresh</a>
+        </section>"""
+    ambient_script = _orientation_ambient_refresh_script() if ambient_refresh_enabled else ""
     return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -4016,6 +4042,21 @@ def _render_orientation_index_html(
       padding: 12px 16px;
     }}
     .orientation-degraded strong {{ color: var(--destructive); }}
+    .orientation-refresh {{
+      align-items: center;
+      background: var(--bg-surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      color: var(--fg-2);
+      display: flex;
+      font-family: var(--font-mono);
+      font-size: 12px;
+      gap: 10px;
+      justify-content: space-between;
+      padding: 10px 12px;
+    }}
+    .orientation-refresh a {{ color: var(--cyan); text-decoration: none; }}
+    .orientation-refresh a:hover {{ text-decoration: underline; }}
     @media (max-width: 860px) {{
       .orientation-grid {{ grid-template-columns: 1fr; }}
       .orientation-governance-grid {{ grid-template-columns: 1fr; }}
@@ -4045,7 +4086,12 @@ def _render_orientation_index_html(
   <main class="orientation-shell" data-testid="workspace-reentry-orientation"
     data-read-only="true"
     data-contract-version="{_e(_orientation_str(meta.get("contract_version"), "unknown"))}"
-    data-freshness="{_e(freshness)}">
+    data-freshness="{_e(freshness)}"
+    data-as-of="{_e(as_of)}"
+    data-stale-after="{_e(stale_after)}"
+    data-trace-id="{_e(trace_id)}"
+    data-degraded="{str(degraded).lower()}"
+    data-ambient-refresh="{'enabled' if ambient_refresh_enabled else 'disabled'}">
     <header class="orientation-header">
       <div class="orientation-eyebrow">Workspace orientation</div>
       <h1 class="orientation-heading">Re-entry snapshot</h1>
@@ -4053,10 +4099,11 @@ def _render_orientation_index_html(
         <span>vault: {_e(_orientation_str(scope.get("vault_id"), "unknown"))}</span>
         <span>channel: {_e(_orientation_str(scope.get("channel"), "unknown"))}</span>
         <span>freshness: {_e(freshness)}</span>
-        <span>as of: {_e(_orientation_str(meta.get("as_of"), "unknown"))}</span>
-        <span>trace: {_e(_orientation_str(meta.get("trace_id"), "unknown"))}</span>
+        <span>as of: {_e(as_of or "unknown")}</span>
+        <span>trace: {_e(trace_id)}</span>
       </div>
     </header>
+    {refresh_html}
     {degraded_html}
     <div class="orientation-grid">
       <div class="orientation-column">
@@ -4070,8 +4117,76 @@ def _render_orientation_index_html(
       </div>
     </div>
   </main>
+  {ambient_script}
 </body>
 </html>"""
+
+
+def _orientation_ambient_refresh_script() -> str:
+    return """
+  <script>
+  (function() {
+    var shell = document.querySelector('[data-testid="workspace-reentry-orientation"]');
+    var status = document.querySelector('[data-testid="workspace-orientation-ambient-refresh"]');
+    if (!shell || shell.dataset.ambientRefresh !== 'enabled') return;
+    var timer = null;
+    function setState(state) {
+      shell.dataset.refreshState = state;
+      if (status) status.dataset.refreshState = state;
+    }
+    function parseDue(raw) {
+      var due = Date.parse(raw || '');
+      return Number.isFinite(due) ? due : null;
+    }
+    function foreground() {
+      return !document.hidden && document.visibilityState !== 'hidden';
+    }
+    function schedule(raw) {
+      if (timer) window.clearTimeout(timer);
+      var due = parseDue(raw || shell.dataset.staleAfter);
+      if (due === null) {
+        setState('manual_refresh');
+        return;
+      }
+      var delay = Math.max(0, due - Date.now());
+      setState(delay > 0 ? 'scheduled' : 'stale');
+      timer = window.setTimeout(refreshIfForeground, delay);
+    }
+    function applyMetadata(data) {
+      var meta = data && data.meta ? data.meta : {};
+      shell.dataset.freshness = meta.freshness || 'unknown';
+      shell.dataset.asOf = meta.as_of || '';
+      shell.dataset.staleAfter = meta.stale_after || '';
+      shell.dataset.traceId = meta.trace_id || '';
+      var degraded = !!(meta.degraded_reasons && meta.degraded_reasons.length);
+      shell.dataset.degraded = degraded ? 'true' : 'false';
+      setState(degraded || shell.dataset.freshness === 'partial' ? 'degraded' : 'fresh');
+      schedule(shell.dataset.staleAfter);
+    }
+    function refreshIfForeground() {
+      if (!foreground()) return;
+      setState('refreshing');
+      fetch('/api/companion/orientation', {method: 'GET'})
+        .then(function(response) {
+          if (!response.ok) throw new Error('orientation refresh failed');
+          return response.json();
+        })
+        .then(applyMetadata)
+        .catch(function() {
+          setState('manual_refresh');
+        });
+    }
+    function refreshWhenStale() {
+      var due = parseDue(shell.dataset.staleAfter);
+      if (due !== null && Date.now() >= due) refreshIfForeground();
+    }
+    document.addEventListener('visibilitychange', function() {
+      if (foreground()) refreshWhenStale();
+    });
+    window.addEventListener('focus', refreshWhenStale);
+    schedule(shell.dataset.staleAfter);
+  }());
+  </script>"""
 
 
 def render_index_html(
@@ -4083,6 +4198,7 @@ def render_index_html(
     orientation: Optional[dict] = None,
     production_profile: bool = False,
     diagnostics: bool = False,
+    ambient_refresh_enabled: bool = False,
 ) -> str:
     """Render the workspace dev page as a Companion UI visual shell.
 
@@ -4101,6 +4217,7 @@ def render_index_html(
             orientation=orientation,
             production_profile=production_profile,
             diagnostics=diagnostics,
+            ambient_refresh_enabled=ambient_refresh_enabled,
         )
 
     content_section = ""
@@ -7181,6 +7298,7 @@ def handle_get(
         orientation=orientation,
         production_profile=production_profile,
         diagnostics=diagnostics,
+        ambient_refresh_enabled=orientation_ambient_refresh_enabled(),
     )
 
 

--- a/companion-ui/docs/WORKSPACE_ORIENTATION_CONTRACT.md
+++ b/companion-ui/docs/WORKSPACE_ORIENTATION_CONTRACT.md
@@ -646,9 +646,12 @@ fresh snapshot.
   operational trace cursor admitted by ADR-0008.
 - MemoryCandidate intents are Phase 3 handoff hints only; they do not create,
   enqueue, review, promote, reject, revise, or store memory.
-- No push, streaming, SSE, WebSocket, notification, or ambient resurfacing
-  transport in the current implementation. Future foreground, client-initiated
-  ambient refresh eligibility is governed by ADR-0011 and remains unimplemented.
+- No push, streaming, SSE, WebSocket, notification, or server-initiated ambient
+  resurfacing transport in the current implementation. The Companion UI re-entry
+  surface may opt into the ADR-0011 foreground ambient refresh slice with
+  `COMPANION_ORIENTATION_AMBIENT_REFRESH=1`; that refresh is client-initiated,
+  read-only, default-off, and based only on server-declared `meta.freshness` /
+  `meta.stale_after` metadata.
 - No multi-agent semantics in the current implementation. Future multi-agent
   read eligibility is governed by ADR-0012 and remains unimplemented.
 - No raw vault absolute paths.
@@ -666,10 +669,12 @@ Implementing `GET /api/companion/orientation` must follow this contract and must
 not imply changes to the artifact-scoped workspace endpoint. The current
 implementation is limited to the read-only orientation shape in this contract.
 Leave-point cursor projection is governed by ADR-0008. MemoryCandidate intent
-emission is governed by ADR-0009. Push, ambient resurfacing transport, and
-multi-agent semantics remain out of scope. ADR-0011 permits only a future
-bounded, default-off, client-initiated foreground ambient refresh child; it does
-not authorize server push, SSE, WebSocket, notifications, or background wakeups.
+emission is governed by ADR-0009. Push transport and multi-agent semantics
+remain out of scope. ADR-0011 permits only the bounded, default-off,
+client-initiated foreground ambient refresh implemented behind
+`COMPANION_ORIENTATION_AMBIENT_REFRESH=1`; it does not authorize server push,
+SSE, WebSocket, notifications, background wakeups, badges, counters, banners,
+or urgency feeds.
 ADR-0012 permits only a future bounded same-projection read path for agent
 consumers; it does not authorize shared mutable workspace state, A2A routing,
 or orchestration semantics.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 pytest==9.0.3
+pytest-asyncio==1.4.0
 httpx==0.27.2
 pytest-cov==5.0.0
 pytest-timeout==2.3.1

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -180,7 +180,7 @@ Emitted when an AI panel is parsed for a note and actions are mapped.
 Payload highlights:
 - `note.uuid` (required), plus optional `note.path` / `note.origin`
 - `panel.panel_id`, `panel.instruction`, optional `panel.raw_block`
-- `actions[]`: `id`, `label`, `checked`, optional `mapping` (`intent_type`, `downstream_event`, `params`)
+- `actions[]`: `id`, optional `option_id`, `label`, `checked`, optional `mapping` (`intent_type`, `downstream_event`, `params`)
 
 ### `panel.intent.executed`
 

--- a/docs/PANEL_AGENT.md
+++ b/docs/PANEL_AGENT.md
@@ -208,6 +208,7 @@ Architectural reading note:
     "actions": [
       {
         "id": "promote.evergreen",
+        "option_id": "opt_example",
         "label": "Gör denna anteckning evergreen",
         "checked": true,
         "mapping": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0",
+    "pytest-asyncio>=1.4,<2",
     "pytest-xdist>=3.6",
     "ruff>=0.5",
     "mypy>=1.9",

--- a/requirements-smoke.txt
+++ b/requirements-smoke.txt
@@ -3,6 +3,7 @@ SQLAlchemy>=2,<3
 httpx
 jsonschema
 pytest
+pytest-asyncio==1.4.0
 click>=8,<9
 watchfiles>=1.0,<2
 requests>=2.0,<3

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,7 @@ pydantic==2.12.0
 pydantic-settings==2.6.1
 pydantic_core==2.41.1
 pytest==9.0.3
+pytest-asyncio==1.4.0
 pytest-cov==5.0.0
 python-dotenv>=1.2.2
 PyYAML==6.0.3

--- a/scripts/validate_source_anchors.py
+++ b/scripts/validate_source_anchors.py
@@ -19,20 +19,23 @@ from typing import Optional, Tuple, List
 
 def extract_source_anchors_section(body: str) -> Optional[str]:
     """Extract the Source Anchors section from issue body."""
-    pattern = r'### Source Anchors\s*\n(.*?)(?=\n### |\Z)'
-    match = re.search(pattern, body, re.DOTALL)
+    pattern = r'^#{2,6}\s+Source Anchors\s*\n(.*?)(?=\n#{2,6}\s+|\Z)'
+    match = re.search(pattern, body, re.DOTALL | re.MULTILINE)
     return match.group(1).strip() if match else None
 
 
-def parse_anchors(section: str) -> List[Tuple[str, str]]:
+def parse_anchors(section: str) -> List[Tuple[str, str | None]]:
     """
     Parse anchor entries from the Source Anchors section.
 
     Expected format:
     - `docs/ROADMAP.md :: ORCHV2-TDD`
     - `docs/STATUS.md :: SETTINGS-PROVENANCE`
+    - `docs/PANEL_AGENT.md` :: accepted decision
+    - #1234 / PR #1235
 
-    Returns list of (doc_path, anchor_id) tuples.
+    Returns list of (doc_path, anchor_id) tuples for markdown references.
+    GitHub issue/PR references are represented as ("#1234", None).
     """
     anchors = []
     lines = section.split('\n')
@@ -42,15 +45,30 @@ def parse_anchors(section: str) -> List[Tuple[str, str]]:
         if not line or line.startswith('#'):
             continue
 
-        # Extract from format: - `docs/PATH.md :: ANCHOR-ID`
-        # or: docs/PATH.md :: ANCHOR-ID
-        # Anchor ID can contain alphanumerics, spaces, hyphens, underscores
-        match = re.search(r'`?([^`]+\.md)\s*::\s*([^`\n]+?)\s*`?$', line)
+        if re.search(r'(?:^|\s)(?:#\d+|PR\s+#\d+|pull request\s+#\d+)(?:\b|$)', line, re.IGNORECASE):
+            anchors.append((line, None))
+            continue
+
+        # Extract from formats:
+        # - `docs/PATH.md :: ANCHOR-ID`
+        # - `docs/PATH.md` :: descriptive locator
+        # - docs/PATH.md
+        match = re.search(r'`?([^`\s]+\.md)`?(?:\s*::\s*([^`\n]+?)\s*)?`?$', line)
         if match:
             doc_path, anchor_id = match.groups()
-            anchors.append((doc_path.strip(), anchor_id.strip()))
+            anchors.append((doc_path.strip(), anchor_id.strip() if anchor_id else None))
 
     return anchors
+
+
+def _is_github_ref(ref: str) -> bool:
+    return bool(re.search(r'(?:^|\s)(?:#\d+|PR\s+#\d+|pull request\s+#\d+)(?:\b|$)', ref, re.IGNORECASE))
+
+
+def _looks_like_stable_anchor(anchor_id: str | None) -> bool:
+    if not anchor_id:
+        return False
+    return bool(re.fullmatch(r'[A-Z0-9][A-Z0-9_-]{2,}', anchor_id.strip()))
 
 
 def find_anchor_in_doc(doc_path: str, anchor_id: str) -> bool:
@@ -103,7 +121,7 @@ def validate_issue_body(body: str) -> Tuple[bool, List[str]]:
     # Check for Source Anchors section
     section = extract_source_anchors_section(body)
     if not section:
-        errors.append("Issue is missing required `### Source Anchors` section")
+        errors.append("Issue is missing required `Source Anchors` section")
         return False, errors
 
     # Parse anchors
@@ -114,6 +132,8 @@ def validate_issue_body(body: str) -> Tuple[bool, List[str]]:
 
     # Validate each anchor
     for doc_path, anchor_id in anchors:
+        if _is_github_ref(doc_path):
+            continue
         if not doc_path.endswith('.md'):
             errors.append(f"Invalid anchor path: '{doc_path}' must be a markdown file (.md)")
             continue
@@ -123,7 +143,7 @@ def validate_issue_body(body: str) -> Tuple[bool, List[str]]:
             errors.append(f"Anchor file not found: {doc_path}")
             continue
 
-        if not find_anchor_in_doc(doc_path, anchor_id):
+        if _looks_like_stable_anchor(anchor_id) and not find_anchor_in_doc(doc_path, anchor_id or ""):
             errors.append(f"Anchor not found in {doc_path}: {anchor_id}")
 
     return len(errors) == 0, errors

--- a/tests/agents/panel_agent/test_panel_planner_pipeline.py
+++ b/tests/agents/panel_agent/test_panel_planner_pipeline.py
@@ -167,6 +167,36 @@ def test_execute_panel_intent_direct_does_not_create_plan(tmp_path: Path, monkey
     assert store.list_by_event(events[0].event_id) == []
 
 
+def test_panel_intent_event_preserves_parsed_option_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    note_uuid = str(uuid4())
+    outbox_path = tmp_path / "index-outbox.jsonl"
+    settings_path = _settings_file(tmp_path)
+    markdown = """%% AI:Start %%
+## AI-instruktion
+Please process this panel.
+## AI-åtgärder
+- [x] Gör denna anteckning evergreen <!--ai:option_id=opt_1493--> <!--ai:id=promote.evergreen-->
+%% AI:End %%
+"""
+    _seed_note(note_uuid, markdown)
+
+    monkeypatch.setenv("PANEL_ACTIONS_PATH", str(settings_path))
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    monkeypatch.setattr("app.agents.panel_agent.agent.INDEX_OUTBOX_PATH", outbox_path, raising=False)
+
+    events = run_panel_intent_for_note(note_uuid, trace_id="trace-panel-option-id")
+
+    assert len(events) == 1
+    actions = events[0].payload.actions
+    assert len(actions) == 1
+    assert actions[0].id == "promote.evergreen"
+    assert actions[0].option_id == "opt_1493"
+    records = _read_outbox(outbox_path)
+    assert records[0]["payload"]["actions"][0]["option_id"] == "opt_1493"
+
+
 def test_execute_panel_intent_planner_creates_plan(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     note_uuid = str(uuid4())
     outbox_path = tmp_path / "index-outbox.jsonl"

--- a/tests/api/test_companion_vault_browser_api.py
+++ b/tests/api/test_companion_vault_browser_api.py
@@ -351,10 +351,12 @@ def test_vault_browser_includes_receipts_from_outbox_projection(
                 "timestamp": "2026-05-30T12:00:00Z",
                 "payload": {
                     "intent_event_id": "intent-1279",
+                    "source_event": "intent-1279",
                     "note_uuid": note_uuid,
                     "note_path": "notes/receipt.md",
-                    "outcome": {"status": "applied"},
                     "authority": {"component": "panel_agent.runtime"},
+                    "basis": {"source_event": "intent-1279", "intent_type": "promotion"},
+                    "outcome": {"status": "applied"},
                     "artifact_linkage": {
                         "note_uuid": note_uuid,
                         "note_path": "notes/receipt.md",

--- a/tests/companion_ui/test_orientation_ambient_refresh.py
+++ b/tests/companion_ui/test_orientation_ambient_refresh.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from typing import Any
+
+from companion_ui.workspace.serve_dev_page import handle_get, render_index_html
+
+
+class _OrientationClient:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+        self.get_calls: list[tuple[str, dict[str, Any]]] = []
+        self.post_calls: list[tuple[str, dict[str, Any]]] = []
+        self.delete_calls: list[tuple[str, dict[str, Any] | None]] = []
+
+    def get(self, url: str, *, params: dict[str, Any]) -> dict[str, Any]:
+        self.get_calls.append((url, params))
+        if url != "/api/companion/orientation":
+            raise AssertionError(f"unexpected GET from orientation surface: {url}")
+        return self.payload
+
+    def post(self, url: str, *, json: dict[str, Any]) -> dict[str, Any]:
+        self.post_calls.append((url, json))
+        raise AssertionError(f"unexpected POST from orientation surface: {url}")
+
+    def delete(self, url: str, *, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        self.delete_calls.append((url, params))
+        raise AssertionError(f"unexpected DELETE from orientation surface: {url}")
+
+
+def _source_ref(label: str = "orientation signals") -> dict[str, str]:
+    return {
+        "kind": "runtime_signal",
+        "ref": "orientation.signals",
+        "label": label,
+    }
+
+
+def _artifact_ref(note_path: str = "Notes/resume.md") -> dict[str, str]:
+    return {
+        "artifact_uuid": "art-resume",
+        "logical_ref": note_path,
+        "title": "Resume plan",
+    }
+
+
+def _orientation_payload(*, degraded: bool = False) -> dict[str, Any]:
+    reasons = ["resurfacing_source_unavailable"] if degraded else []
+    return {
+        "scope": {
+            "kind": "workspace",
+            "vault_id": "dev-vault",
+            "channel": "dev",
+        },
+        "meta": {
+            "contract_version": "workspace_orientation.v1",
+            "as_of": "2026-05-31T12:00:00Z",
+            "trace_id": "trace-orientation-ambient",
+            "freshness": "partial" if degraded else "fresh",
+            "stale_after": "2026-05-31T12:05:00Z",
+            "degraded_reasons": reasons,
+            "caps": {
+                "open_loops": 8,
+                "notable_changes": 8,
+                "resurface_candidates": 5,
+                "mutation_intents": 0,
+                "source_refs_per_item": 3,
+            },
+        },
+        "leave_point": {
+            "status": "present",
+            "artifact_ref": _artifact_ref(),
+            "captured_at": "2026-05-31T11:45:00Z",
+            "authority_role": "operational_trace_pointer",
+            "source_ref": {"kind": "artifact_activation", "trace_id": "trace-leave"},
+        },
+        "open_loops": [],
+        "notable_changes": [],
+        "resurface": {
+            "candidates": [
+                {
+                    "id": "candidate-1",
+                    "label": "Check runtime API PR",
+                    "why_now": "Relevant because API contract just landed.",
+                    "signal_labels": ["recent_change=orientation"],
+                    "artifact_ref": _artifact_ref("Notes/resurface.md"),
+                    "authority_role": "derived",
+                    "source_ref": _source_ref("resurfacing signal"),
+                }
+            ]
+        },
+        "governance": {
+            "pending_proposal_count": 0,
+            "pending_receipt_count": 0,
+            "latest_receipt_outcome": None,
+            "authority_role": "derived",
+            "source_ref": _source_ref("governance summary"),
+        },
+        "guards": {
+            "read_only": True,
+            "runtime_posture": "degraded" if degraded else "healthy",
+            "degraded": degraded,
+            "reasons": reasons,
+            "authority_role": "derived",
+            "source_ref": _source_ref("minimal status posture"),
+        },
+        "mutation_intents": [],
+    }
+
+
+def test_ambient_refresh_disabled_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("COMPANION_ORIENTATION_AMBIENT_REFRESH", raising=False)
+    client = _OrientationClient(_orientation_payload())
+
+    html = handle_get(
+        query_string="",
+        client=client,  # type: ignore[arg-type]
+        api_base_url="http://127.0.0.1:18001",
+    )
+
+    assert client.get_calls == [("/api/companion/orientation", {})]
+    assert 'data-testid="workspace-reentry-orientation"' in html
+    assert 'data-ambient-refresh="disabled"' in html
+    assert 'data-refresh-mode="manual"' in html
+    assert "fetch('/api/companion/orientation'" not in html
+
+
+def test_ambient_refresh_uses_foreground_pull_after_staleness(monkeypatch) -> None:
+    monkeypatch.setenv("COMPANION_ORIENTATION_AMBIENT_REFRESH", "1")
+    client = _OrientationClient(_orientation_payload())
+
+    html = handle_get(
+        query_string="",
+        client=client,  # type: ignore[arg-type]
+        api_base_url="http://127.0.0.1:18001",
+    )
+
+    assert client.get_calls == [("/api/companion/orientation", {})]
+    assert 'data-ambient-refresh="enabled"' in html
+    assert 'data-stale-after="2026-05-31T12:05:00Z"' in html
+    assert 'data-refresh-mode="foreground_pull"' in html
+    assert "fetch('/api/companion/orientation', {method: 'GET'})" in html
+    assert "window.setTimeout(refreshIfForeground, delay)" in html
+    assert "document.addEventListener('visibilitychange'" in html
+    assert "window.addEventListener('focus', refreshWhenStale)" in html
+    assert "EventSource" not in html
+    assert "WebSocket" not in html
+
+
+def test_ambient_refresh_preserves_degraded_and_stale_states() -> None:
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        orientation=_orientation_payload(degraded=True),
+        ambient_refresh_enabled=True,
+    )
+
+    assert 'data-testid="workspace-orientation-degraded"' in html
+    assert 'data-freshness="partial"' in html
+    assert 'data-degraded="true"' in html
+    assert 'data-refresh-state="degraded"' in html
+    assert 'data-testid="workspace-orientation-manual-refresh"' in html
+    assert "resurfacing_source_unavailable" in html
+
+
+def test_ambient_refresh_renders_no_notification_ui() -> None:
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        orientation=_orientation_payload(),
+        ambient_refresh_enabled=True,
+    )
+
+    forbidden = [
+        "Notification",
+        "EventSource",
+        "WebSocket",
+        "setInterval",
+        "data-testid=\"orientation-notification\"",
+        "data-testid=\"orientation-badge\"",
+        "data-testid=\"orientation-modal\"",
+        "data-testid=\"orientation-banner\"",
+        "urgency",
+    ]
+    for token in forbidden:
+        assert token not in html
+
+
+def test_ambient_refresh_has_no_write_or_action_execution_path() -> None:
+    html = render_index_html(
+        api_base_url="http://127.0.0.1:18001",
+        orientation=_orientation_payload(),
+        ambient_refresh_enabled=True,
+    )
+
+    assert "method: 'POST'" not in html
+    assert 'data-api-method="POST"' not in html
+    assert "/api/panel/confirm" not in html
+    assert "/api/companion/workspace/body" not in html
+    assert "resurface.dismiss" not in html
+    assert "resurface.snooze" not in html
+    assert "resurface.pin" not in html

--- a/tests/companion_ui/test_workspace_note_selection_latency.py
+++ b/tests/companion_ui/test_workspace_note_selection_latency.py
@@ -12,6 +12,9 @@ from __future__ import annotations
 import time
 from pathlib import Path
 
+import pytest
+from fastapi import HTTPException
+
 
 def _write_note(directory: Path, relative: str, content: str) -> Path:
     path = directory / relative
@@ -40,6 +43,25 @@ class TestFindWorkspaceNoteDirectLookup:
 
         result = _find_workspace_note(tmp_path, "Notes/missing.md")
         assert result is None
+
+    def test_rejects_symlink_escape(self, tmp_path: Path) -> None:
+        from app.api.routes.companion import _find_workspace_note
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        outside = tmp_path / "outside.md"
+        outside.write_text("# Outside\n", encoding="utf-8")
+        link = vault / "linked.md"
+        try:
+            link.symlink_to(outside)
+        except OSError as exc:
+            pytest.skip(f"symlink unavailable: {exc}")
+
+        with pytest.raises(HTTPException) as exc_info:
+            _find_workspace_note(vault, "linked.md")
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail["error"] == "path_escape"
 
     def test_lookup_is_sub_millisecond_with_many_vault_files(self, tmp_path: Path) -> None:
         from app.api.routes.companion import _find_workspace_note

--- a/tests/companion_ui/test_workspace_note_selection_latency.py
+++ b/tests/companion_ui/test_workspace_note_selection_latency.py
@@ -44,6 +44,17 @@ class TestFindWorkspaceNoteDirectLookup:
         result = _find_workspace_note(tmp_path, "Notes/missing.md")
         assert result is None
 
+    def test_rejects_non_markdown_note(self, tmp_path: Path) -> None:
+        # Workspace reads must stay restricted to markdown notes. The direct
+        # lookup replaced an rglob("*.md") scan that was implicitly md-only;
+        # without a suffix guard a request such as attachments/private.txt would
+        # surface arbitrary non-note vault content.
+        from app.api.routes.companion import _find_workspace_note
+
+        _write_note(tmp_path, "attachments/private.txt", "secret content")
+        result = _find_workspace_note(tmp_path, "attachments/private.txt")
+        assert result is None
+
     def test_rejects_symlink_escape(self, tmp_path: Path) -> None:
         from app.api.routes.companion import _find_workspace_note
 

--- a/tests/events/test_event_envelope_versioning.py
+++ b/tests/events/test_event_envelope_versioning.py
@@ -84,6 +84,20 @@ def _panel_record() -> dict[str, object]:
     ).model_dump(mode="json")
 
 
+def test_panel_intent_action_option_id_is_optional_and_serialized() -> None:
+    legacy = PanelIntentAction(id="promote.evergreen", label="Promote", checked=True)
+    assert legacy.option_id is None
+    assert legacy.model_dump(mode="json")["option_id"] is None
+
+    with_option = PanelIntentAction(
+        id="promote.evergreen",
+        option_id="opt_1493",
+        label="Promote",
+        checked=True,
+    )
+    assert with_option.model_dump(mode="json")["option_id"] == "opt_1493"
+
+
 def _outbox_record(event_name: str, *, source: str, trace_id: str, payload: dict[str, object]) -> dict[str, object]:
     return make_outbox_event(event_name, source=source, trace_id=trace_id, payload=payload).model_dump(mode="json")
 

--- a/tests/ops/test_makefile_smoke.py
+++ b/tests/ops/test_makefile_smoke.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _makefile_target_block(makefile: str, target: str, next_target: str) -> str:
+    return makefile.split(f"{target}:", maxsplit=1)[1].split(
+        f"\n{next_target}:", maxsplit=1
+    )[0]
+
+
+def test_make_test_loads_pytest_asyncio_when_available() -> None:
+    makefile = Path("Makefile").read_text(encoding="utf-8")
+    test_block = _makefile_target_block(makefile, "test", "eval")
+
+    assert '$(PYTHON) -c "import pytest_asyncio.plugin"' in test_block
+    assert "-p pytest_asyncio.plugin" in test_block
+    assert "--import-mode=importlib" in test_block
+
+
+def test_make_smoke_loads_xdist_only_when_available() -> None:
+    makefile = Path("Makefile").read_text(encoding="utf-8")
+    smoke_block = _makefile_target_block(makefile, "smoke", "test-vault-init")
+
+    assert '$(PYTHON) -c "import xdist.plugin"' in smoke_block
+    assert "PYTEST_PLUGIN_ARGS" in smoke_block
+    assert "$(PYTHON) -m pytest $$PYTEST_PLUGIN_ARGS" in smoke_block
+    assert "$(PYTHON) -m pytest -p xdist.plugin" not in smoke_block
+
+
+def test_make_smoke_loads_pytest_asyncio_when_available() -> None:
+    makefile = Path("Makefile").read_text(encoding="utf-8")
+    smoke_block = _makefile_target_block(makefile, "smoke", "test-vault-init")
+
+    assert '$(PYTHON) -c "import pytest_asyncio.plugin"' in smoke_block
+    assert "-p pytest_asyncio.plugin" in smoke_block
+    assert "PYTEST_E2E_PLUGIN_ARGS=\"$$PYTEST_E2E_PLUGIN_ARGS -p pytest_asyncio.plugin\"" in smoke_block
+
+
+def test_make_smoke_preserves_importlib_mode_without_pytest_ini() -> None:
+    makefile = Path("Makefile").read_text(encoding="utf-8")
+    smoke_block = _makefile_target_block(makefile, "smoke", "test-vault-init")
+
+    assert "-c /dev/null" in smoke_block
+    assert "--import-mode=importlib" in smoke_block

--- a/tests/receipts/test_promotion_receipt_query.py
+++ b/tests/receipts/test_promotion_receipt_query.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.events.types import PROMOTE_DONE, PROMOTION_TRANSITION_APPLIED
+from app.receipts.promotion_receipts import PromotionReceiptQuery, query_promotion_receipts
+
+
+def _write_jsonl(path: Path, *records: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(json.dumps(record, ensure_ascii=False) for record in records) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _transition_record(
+    *,
+    event_id: str = "evt-receipt-1",
+    trace_id: str = "trace-1",
+    timestamp: str = "2026-05-30T12:00:00Z",
+    note_uuid: str = "00000000-0000-0000-0000-000000001403",
+    note_path: str = "notes/receipt.md",
+    intent_event_id: str = "intent-1",
+    family: str = "promotion",
+    target_maturity: str = "evergreen",
+    status: str = "applied",
+    review_state: str = "reviewed",
+    maturity: str = "evergreen",
+) -> dict:
+    return {
+        "event": PROMOTION_TRANSITION_APPLIED,
+        "event_id": event_id,
+        "trace_id": trace_id,
+        "source": "promotion.consumer",
+        "timestamp": timestamp,
+        "payload": {
+            "intent_event_id": intent_event_id,
+            "source_event": intent_event_id,
+            "trace_id": trace_id,
+            "note_uuid": note_uuid,
+            "note_path": note_path,
+            "transition_family": family,
+            "target_maturity": target_maturity,
+            "executor": "promotion.consumer",
+            "authority": {
+                "mode": "governed_execution",
+                "component": "panel_agent.runtime",
+                "executor": "promotion.consumer",
+            },
+            "basis": {
+                "source_event": intent_event_id,
+                "intent_type": "promotion",
+            },
+            "outcome": {
+                "status": status,
+                "review_state": review_state,
+                "maturity": maturity,
+            },
+            "artifact_linkage": {
+                "note_uuid": note_uuid,
+                "note_path": note_path,
+            },
+        },
+    }
+
+
+def test_query_projects_transition_applied_records(tmp_path: Path) -> None:
+    outbox = tmp_path / "outbox.jsonl"
+    _write_jsonl(
+        outbox,
+        {
+            "event": PROMOTE_DONE,
+            "event_id": "evt-done",
+            "trace_id": "trace-done",
+            "timestamp": "2026-05-30T11:00:00Z",
+            "payload": {"note_uuid": "ignored", "review_state": "reviewed"},
+        },
+        _transition_record(),
+    )
+
+    result = query_promotion_receipts(vault_root=tmp_path, outbox_path=outbox)
+
+    assert result.source_available is True
+    assert result.non_authoritative_records == ()
+    assert len(result.rows) == 1
+    row = result.rows[0]
+    assert row.receipt_id == "evt-receipt-1"
+    assert row.source_event_id == "intent-1"
+    assert row.trace_id == "trace-1"
+    assert row.timestamp == "2026-05-30T12:00:00Z"
+    assert row.artifact_uuid == "00000000-0000-0000-0000-000000001403"
+    assert row.artifact_path == "notes/receipt.md"
+    assert row.transition_family == "promotion"
+    assert row.target_maturity == "evergreen"
+    assert row.review_state == "reviewed"
+    assert row.maturity == "evergreen"
+    assert row.authority["component"] == "panel_agent.runtime"
+    assert row.basis["source_event"] == "intent-1"
+    assert row.outcome["status"] == "applied"
+    assert row.artifact_linkage["note_path"] == "notes/receipt.md"
+    assert row.executor == "promotion.consumer"
+    assert row.source == "promotion.consumer"
+    assert row.triggering_intent_event_id == "intent-1"
+
+
+def test_query_filters_and_orders_promotion_receipts(tmp_path: Path) -> None:
+    outbox = tmp_path / "outbox.jsonl"
+    first_uuid = "00000000-0000-0000-0000-000000001401"
+    second_uuid = "00000000-0000-0000-0000-000000001402"
+    _write_jsonl(
+        outbox,
+        _transition_record(
+            event_id="evt-late",
+            trace_id="trace-late",
+            timestamp="2026-05-30T12:10:00Z",
+            note_uuid=second_uuid,
+            note_path="notes/later.md",
+            intent_event_id="intent-late",
+            target_maturity="seedling",
+            status="failed",
+            review_state="draft",
+            maturity="seedling",
+        ),
+        _transition_record(
+            event_id="evt-early",
+            trace_id="trace-early",
+            timestamp="2026-05-30T12:00:00Z",
+            note_uuid=first_uuid,
+            note_path="notes/early.md",
+            intent_event_id="intent-early",
+        ),
+    )
+
+    all_rows = query_promotion_receipts(vault_root=tmp_path, outbox_path=outbox).rows
+    assert [row.receipt_id for row in all_rows] == ["evt-early", "evt-late"]
+
+    queries = [
+        PromotionReceiptQuery(artifact_uuid=first_uuid),
+        PromotionReceiptQuery(artifact_path="notes/early.md"),
+        PromotionReceiptQuery(receipt_or_source_event_id="evt-early"),
+        PromotionReceiptQuery(receipt_or_source_event_id="intent-early"),
+        PromotionReceiptQuery(trace_id="trace-early"),
+        PromotionReceiptQuery(target_maturity="evergreen"),
+        PromotionReceiptQuery(outcome_status="applied"),
+    ]
+    for query in queries:
+        result = query_promotion_receipts(query, vault_root=tmp_path, outbox_path=outbox)
+        assert [row.receipt_id for row in result.rows] == ["evt-early"]
+
+    by_family = query_promotion_receipts(
+        PromotionReceiptQuery(transition_family="promotion"),
+        vault_root=tmp_path,
+        outbox_path=outbox,
+    )
+    assert [row.receipt_id for row in by_family.rows] == ["evt-early", "evt-late"]
+
+    failed = query_promotion_receipts(
+        PromotionReceiptQuery(outcome_status="failed"),
+        vault_root=tmp_path,
+        outbox_path=outbox,
+    )
+    assert [row.receipt_id for row in failed.rows] == ["evt-late"]
+
+
+def test_query_distinguishes_unavailable_empty_and_non_authoritative_sources(
+    tmp_path: Path,
+) -> None:
+    missing = query_promotion_receipts(
+        vault_root=tmp_path,
+        outbox_path=tmp_path / "missing.jsonl",
+    )
+    assert missing.source_available is False
+    assert missing.rows == ()
+    assert missing.non_authoritative_records == ()
+
+    empty_outbox = tmp_path / "empty.jsonl"
+    empty_outbox.write_text("", encoding="utf-8")
+    empty = query_promotion_receipts(vault_root=tmp_path, outbox_path=empty_outbox)
+    assert empty.source_available is True
+    assert empty.rows == ()
+    assert empty.non_authoritative_records == ()
+
+    non_authoritative_outbox = tmp_path / "non-authoritative.jsonl"
+    _write_jsonl(
+        non_authoritative_outbox,
+        {
+            "event": PROMOTION_TRANSITION_APPLIED,
+            "event_id": "evt-no-authority",
+            "trace_id": "trace-no-authority",
+            "timestamp": "2026-05-30T12:00:00Z",
+            "payload": {
+                "note_uuid": "00000000-0000-0000-0000-000000001404",
+                "note_path": "notes/non-authoritative.md",
+                "outcome": {"status": "applied"},
+                "artifact_linkage": {"note_path": "notes/non-authoritative.md"},
+            },
+        },
+        {
+            "event": PROMOTE_DONE,
+            "event_id": "evt-done-only",
+            "trace_id": "trace-done-only",
+            "timestamp": "2026-05-30T12:01:00Z",
+            "payload": {
+                "note_uuid": "00000000-0000-0000-0000-000000001405",
+                "note_path": "notes/done.md",
+                "promotion": {"review_state": "reviewed"},
+            },
+        },
+    )
+    non_authoritative = query_promotion_receipts(
+        vault_root=tmp_path,
+        outbox_path=non_authoritative_outbox,
+    )
+    assert non_authoritative.source_available is True
+    assert non_authoritative.rows == ()
+    assert non_authoritative.non_authoritative_records == (
+        {
+            "event_id": "evt-no-authority",
+            "trace_id": "trace-no-authority",
+            "reason": "missing_authority",
+        },
+    )

--- a/tests/scripts/test_validate_source_anchors.py
+++ b/tests/scripts/test_validate_source_anchors.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.validate_source_anchors import validate_issue_body
+
+
+def test_validate_source_anchors_accepts_required_issue_section_shape() -> None:
+    ok, errors = validate_issue_body(
+        """
+## Context
+Test.
+
+## Source Anchors
+- #1403 :: prior issue
+- `docs/CONCEPTS/RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md` :: Promotion receipt query model decision (#1489)
+"""
+    )
+
+    assert ok is True
+    assert errors == []
+
+
+def test_validate_source_anchors_accepts_explicit_existing_stable_anchor(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "ROADMAP.md").write_text("## Delivery PA2-FREEFORM\n", encoding="utf-8")
+
+    ok, errors = validate_issue_body(
+        """
+## Source Anchors
+- `docs/ROADMAP.md :: PA2-FREEFORM`
+"""
+    )
+
+    assert ok is True
+    assert errors == []
+
+
+def test_validate_source_anchors_rejects_missing_section() -> None:
+    ok, errors = validate_issue_body("## Context\nNo anchors.\n")
+
+    assert ok is False
+    assert errors == ["Issue is missing required `Source Anchors` section"]
+
+
+def test_validate_source_anchors_rejects_missing_doc_path(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    ok, errors = validate_issue_body(
+        """
+## Source Anchors
+- `docs/MISSING.md` :: MISSING-ANCHOR
+"""
+    )
+
+    assert ok is False
+    assert errors == ["Anchor file not found: docs/MISSING.md"]
+
+
+def test_validate_source_anchors_rejects_missing_explicit_stable_anchor(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "ROADMAP.md").write_text("## Different Anchor\n", encoding="utf-8")
+
+    ok, errors = validate_issue_body(
+        """
+## Source Anchors
+- `docs/ROADMAP.md :: PA2-FREEFORM`
+"""
+    )
+
+    assert ok is False
+    assert errors == ["Anchor not found in docs/ROADMAP.md: PA2-FREEFORM"]


### PR DESCRIPTION
## Summary

- Fixes #1403 by adding a typed read-only promotion receipt query projection over `promotion.transition.applied`, with Vault Browser receipt compatibility preserved.
- Fixes #1458 by adding default-off foreground orientation ambient refresh behind `COMPANION_ORIENTATION_AMBIENT_REFRESH=1`, with no push/SSE/WebSocket/notification/write path.
- Fixes #1493 by carrying optional `option_id` through `panel.intent.created` action payloads.
- Repairs local validation/harness issues: conditional pytest plugin loading, explicit `pytest-asyncio`, direct workspace note lookup, BuilderOps mypy narrowing, and Source Anchors validator compatibility.
- Partially addresses #1474 through issue-maintenance scoping: no safe artifact-scoped agent-memory posture source/API exists yet, so the issue was relabeled `agent:blocked` with a scoping receipt.

## Validation

- `ruff check app tests companion-ui/companion-app scripts/validate_source_anchors.py`
- `mypy app`
- `python -m app.cli settings-validate --json`
- Focused regression bundle: `189 passed`
- `make smoke`: `4471 passed, 38 skipped, 44 deselected`
- `git diff --check`
- Live Source Anchors validation passed for #1403, #1450, #1458, #1473, #1474, #1491, #1493.
- Live `agent:ready` queue is empty after claiming/fixing/blocking the remaining ready issues.

## Notes

- Project v2 status reconciliation was not applied because GraphQL quota was exhausted. Issue labels/comments were updated via REST/`gh` where needed.
- Unrelated local workspace changes were intentionally excluded from this PR: `AGENTS.md`, `.codex/skills/README.md`, and `.codex/skills/epic-ready-issue-planning/SKILL.md`.


## BuilderOps Routing

- Records/projections/receipts: LearningSignal `lrn_20260602205344_35434fc6` (workflow_divergence)
- Reason: Code delivery plus a review-feedback security repair (workspace reads restricted to `.md` notes). A `LearningSignal` was captured for the underlying divergence: the #1289 note-lookup latency rewrite dropped the implicit `.md` restriction, shipping a P2 path-disclosure regression caught only at review. Upstream artifact named: `app/api/routes/companion.py::_find_workspace_note` (lookup rewrites must preserve note-type restriction; guard + regression test added here). Excluded local workspace changes (`AGENTS.md`, `.codex/skills/README.md`) are tracked separately and out of scope.

