### PR TITLE
chore(governance): enforce BuilderOps routing in workflows

### DIFF
--- a/.codex/skills/README.md
+++ b/.codex/skills/README.md
@@ -30,6 +30,28 @@ Create GitHub Issues from BuilderOps material only when it has become bounded ex
 `Verify:` targets. Open PRs only for repo-governed artifact changes. Do not edit canonical docs
 just to capture operational state that belongs in BuilderOps Vault.
 
+## BuilderOps workflow checkpoints
+
+The routing decision must live in the skills and automation prompts that agents already execute.
+Do not rely on a human remembering where BuilderOps material belongs.
+
+1. **Start checkpoint:** before implementation, maintenance, or audit work becomes durable, classify
+   any raw notes, recovery context, docs freshness state, roadmap movement, learning, or proposed
+   authority crossing. Create the matching BuilderOps record when the material is not already fully
+   represented by a GitHub Issue, PR, or reviewed repo artifact.
+2. **Divergence checkpoint:** whenever a plan, issue, doc, or skill turns out to be wrong while work
+   is active, invoke `capture-learning` immediately and create a `LearningSignal` instead of saving
+   the observation for a later human memory pass.
+3. **Publication checkpoint:** every PR body must state the BuilderOps routing outcome: records
+   created, projections or receipts updated, or `none` with a short reason. A missing routing outcome
+   is missing delivery traceability.
+4. **Closure checkpoint:** before merge or delivery receipt, unresolved adoption, retro, freshness,
+   roadmap, or promotion observations must be represented by a BuilderOps record, a bounded GitHub
+   Issue with `Verify:` targets, or an explicit `none` reason.
+5. **Automation checkpoint:** recurring Codex automations for this repo must read the relevant
+   workflow skill and route high-churn operational material to BuilderOps first. `docs/learning-log.md`
+   is historical/fallback only; generated projections are readable views only.
+
 ## Skill routing
 
 - `agentic-pkm`

--- a/.codex/skills/automation-maintenance/SKILL.md
+++ b/.codex/skills/automation-maintenance/SKILL.md
@@ -54,6 +54,23 @@ specific justified exception. The redirect workspace
 - If durable follow-up is needed, create or update a GitHub Issue with the automation id, current
   cwd, intended cwd, and blocker. Do not treat local automation state as repo truth.
 
+## BuilderOps adoption checks
+
+When maintaining repo automations, also inspect whether recurring prompts route BuilderOps material
+without depending on human memory.
+
+- Automations that inspect delivery learning must read BuilderOps `LearningSignal` records first and
+  use `docs/learning-log.md` only for historical or explicit compatibility fallback entries.
+- Automations that audit docs freshness must create or propose `DocsFreshnessRecord` material for
+  high-churn review state instead of editing `docs/DOCS_INDEX.md` as an operational queue.
+- Automations that inspect roadmap or issue movement must create or propose
+  `RoadmapExecutionItem` material for execution state instead of turning `docs/ROADMAP.md` into a
+  daily status log.
+- Automations that discover cross-surface changes must create or propose `PromotionIntent` material
+  before GitHub Issue, PR, ADR, owner-doc, skill, AGENTS, projection, or discard handling.
+- Automation prompts should cite the repo-local skill they are following and should produce a short
+  BuilderOps routing receipt: records created, projections/receipts updated, or `none` with a reason.
+
 ## Receipt shape
 
 Every run must finish with a concise receipt:

--- a/.codex/skills/issue-to-code/SKILL.md
+++ b/.codex/skills/issue-to-code/SKILL.md
@@ -55,6 +55,28 @@ Hot path:
 Conditional / maintenance path:
 `Issue maintenance -> Agent` and `Publish PR -> PR integration` only when mergeability, CI attachment, or review repair is still needed.
 
+## BuilderOps routing checkpoint
+
+Before editing and again before PR handoff, decide whether the work produced BuilderOps material.
+This is a required workflow checkpoint, not an optional memory aid.
+
+- Raw handoff/recovery notes or temporary evidence that should survive the turn -> create an
+  `AgentWorklog`.
+- Plan/doc/skill/issue divergence that names an upstream artifact -> invoke `capture-learning` and
+  create a `LearningSignal` immediately.
+- Docs freshness observations or review queues -> create a `DocsFreshnessRecord`.
+- Roadmap execution movement, active blockers, shipped refs, or issue movement that is operational
+  rather than strategic roadmap truth -> create a `RoadmapExecutionItem`.
+- Material that should cross into GitHub, PR, ADR, owner-doc, skill/AGENTS, generated projection, or
+  discard handling -> create a `PromotionIntent` and leave the authority crossing to the normal
+  reviewed path.
+- Completed projections, transitions, promotions, supersessions, or discards -> create or cite a
+  `BuilderOpsReceipt`.
+
+If no BuilderOps record is needed, record `BuilderOps routing: none` with the reason in the PR
+handoff. Never append to `docs/learning-log.md` except as an explicit compatibility fallback when a
+BuilderOps write is unavailable.
+
 Treat these Issue sections as binding for the governing slice issue:
 
 - `Context`
@@ -303,17 +325,19 @@ When continuing through anchor drift:
    - Treat passing acceptance tests as supporting evidence, not the sole gate for delivered classification.
    - If source specs still say "Not yet implemented" while shipped code exists, route the spec-state writeback through docs/governance repair rather than opening duplicate implementation work.
 4. **Execute Action: Begin Implementation Work** (update labels, Issue Project Status, verify).
-5. Restate the bounded outcome from the Issue.
-6. Read source-anchored docs and owning code paths.
-7. If anchor drift exists, resolve it using the rules above before coding.
-8. **Verify acceptance verifiability**: every Acceptance Criterion must carry a resolvable `Verify:` target. If any AC lacks one, stop implementation and route through `issue-maintenance-change-control` to repair the contract before coding.
-9. **Test-first for behavioral ACs**: for each AC whose `Verify:` names a test, ensure that test exists in the repo and currently fails against the unchanged code path. If the test is missing, write it first from the AC; if it is present but does not fail, either the AC is already satisfied (stop and validate) or the test does not actually exercise the AC (fix the test).
-10. Implement the smallest complete change that turns every behavioral `Verify:` test green without breaking unrelated tests.
-11. **Writeback for non-behavioral ACs**: perform each non-behavioral `Verify:` target in the same change (doc anchor writeback, roadmap wording cleanup, runtime receipt, etc.).
-12. Update owner docs if shipped behavior/contracts changed.
-13. Rewrite roadmap/plan wording if the delivered work was previously listed as pending.
-14. Run `Suggested Validation` plus any obviously necessary focused checks. Confirm every AC's `Verify:` target now resolves green.
-14a. **Branch-Truth Gate — Phase 1: Pre-Commit (mandatory before `git add`/`git commit`)** [branch-truth-gate]
+5. Run the BuilderOps routing checkpoint and create any needed operational record before the context
+   becomes hidden local memory.
+6. Restate the bounded outcome from the Issue.
+7. Read source-anchored docs and owning code paths.
+8. If anchor drift exists, resolve it using the rules above before coding.
+9. **Verify acceptance verifiability**: every Acceptance Criterion must carry a resolvable `Verify:` target. If any AC lacks one, stop implementation and route through `issue-maintenance-change-control` to repair the contract before coding.
+10. **Test-first for behavioral ACs**: for each AC whose `Verify:` names a test, ensure that test exists in the repo and currently fails against the unchanged code path. If the test is missing, write it first from the AC; if it is present but does not fail, either the AC is already satisfied (stop and validate) or the test does not actually exercise the AC (fix the test).
+11. Implement the smallest complete change that turns every behavioral `Verify:` test green without breaking unrelated tests.
+12. **Writeback for non-behavioral ACs**: perform each non-behavioral `Verify:` target in the same change (doc anchor writeback, roadmap wording cleanup, runtime receipt, etc.).
+13. Update owner docs if shipped behavior/contracts changed.
+14. Rewrite roadmap/plan wording if the delivered work was previously listed as pending.
+15. Run `Suggested Validation` plus any obviously necessary focused checks. Confirm every AC's `Verify:` target now resolves green.
+15a. **Branch-Truth Gate — Phase 1: Pre-Commit (mandatory before `git add`/`git commit`)** [branch-truth-gate]
 
     For multi-agent parallel work, a dedicated per-issue worktree (via `git worktree add`) is mandatory for the full issue lifecycle — from initial implementation through every review-fix push. Do NOT commit to an active PR from the shared root worktree.
 
@@ -330,7 +354,7 @@ When continuing through anchor drift:
 
     Branch name must match. Do not check the remote PR head SHA here — a new local commit will advance HEAD past the remote ref before push.
 
-14b. **Branch-Truth Gate — Phase 2: Pre-Push (mandatory before `git push`)** [branch-truth-gate]
+15b. **Branch-Truth Gate — Phase 2: Pre-Push (mandatory before `git push`)** [branch-truth-gate]
 
     ```bash
     EXPECTED_BRANCH="<PR head branch name>"
@@ -345,12 +369,12 @@ When continuing through anchor drift:
 
     If branch name fails at pre-push: stop, switch to the correct worktree, and re-run both phases.
 
-15. Run `.codex/skills/publish-pr/SKILL.md` to create or update the implementation PR linked to the governing Issue unless a concrete blocker or explicit user instruction prevents it.
-16. For a normal PR, hand off to `docs/development/PR_HOT_PATH.md` through `pr-integration` only as needed.
-17. If any hot-path trigger applies, read `docs/development/PR_ESCALATION_PATHS.md` and use the relevant escalation procedure.
-18. **Execute Action: Request Review** only when review is explicitly requested.
-19. If the slice merges and this is not the final child slice, keep the parent issue open for later acceptance.
-20. If this is the final child slice, route post-merge parent closure through `docs/development/PARENT_ISSUE_CLOSURE.md`.
+16. Run `.codex/skills/publish-pr/SKILL.md` to create or update the implementation PR linked to the governing Issue unless a concrete blocker or explicit user instruction prevents it.
+17. For a normal PR, hand off to `docs/development/PR_HOT_PATH.md` through `pr-integration` only as needed.
+18. If any hot-path trigger applies, read `docs/development/PR_ESCALATION_PATHS.md` and use the relevant escalation procedure.
+19. **Execute Action: Request Review** only when review is explicitly requested.
+20. If the slice merges and this is not the final child slice, keep the parent issue open for later acceptance.
+21. If this is the final child slice, route post-merge parent closure through `docs/development/PARENT_ISSUE_CLOSURE.md`.
 
 ## PR handoff requirements
 
@@ -362,6 +386,7 @@ Before handing off to `publish-pr`, confirm:
 - acceptance criteria are satisfied
 - docs were updated in the same change when needed
 - owner docs and roadmap/plan wording were updated when the work became shipped reality
+- BuilderOps routing is represented by records/projections/receipts or by a short `none` reason
 - the next step is the short PR hot path unless an escalation trigger exists
 
 

--- a/.codex/skills/post-merge-owner-doc/SKILL.md
+++ b/.codex/skills/post-merge-owner-doc/SKILL.md
@@ -53,6 +53,12 @@ Add one comment on the closed issue, verbatim: `post-merge owner-doc check: no o
 
 That comment is the receipt. If it is missing on a closed implementation issue, this skill did not run.
 
+If the merge implies no owner-doc change but reveals future adoption, workflow learning, docs
+freshness, roadmap execution, or promotion material, route that material to BuilderOps first:
+`LearningSignal`, `DocsFreshnessRecord`, `RoadmapExecutionItem`, `PromotionIntent`, or
+`BuilderOpsReceipt` as applicable. Create a GitHub Issue only when the material is bounded executable
+work with `Verify:` targets.
+
 ## Judgment rules
 
 - **Trust the diff, not metadata.** Do not rely on labels, PR-body tokens, or issue classification as primary signal. Read the code/doc change itself.

--- a/.codex/skills/publish-pr/SKILL.md
+++ b/.codex/skills/publish-pr/SKILL.md
@@ -40,6 +40,8 @@ turn validated local changes into a truthful branch, commit, pushed head, and PR
 - Do not publish unrelated local changes.
 - For implementation lane PRs, the body must include `Fixes #<id>`, `Closes #<id>`, or `Resolves #<id>`.
 - For docs-authoring or governance lane PRs, leave the linked Issue blank unless a governing Issue actually exists.
+- Every PR body must include a `## BuilderOps Routing` section that names relevant BuilderOps
+  records/projections/receipts or states `none` with a short reason.
 - Default to opening an open PR.
 - Use `--draft` only with an explicit reason that the PR is not yet ready for review or still needs integration/repair.
 - Publication does not move work to `Done`.
@@ -163,6 +165,10 @@ Fixes #<ISSUE_NUMBER>
 ## Validation
 <What validation actually ran>
 
+## BuilderOps Routing
+- Records/projections/receipts: <ids or "none">
+- Reason: <why no BuilderOps material was created, or what was routed>
+
 ---
 EOF
 )"
@@ -183,6 +189,10 @@ gh pr create \
 
 ## Validation
 <Docs validation that ran>
+
+## BuilderOps Routing
+- Records/projections/receipts: <ids or "none">
+- Reason: <why no BuilderOps material was created, or what was routed>
 
 ---
 EOF
@@ -205,6 +215,10 @@ gh pr create \
 ## Validation
 <Governance validation that ran>
 
+## BuilderOps Routing
+- Records/projections/receipts: <ids or "none">
+- Reason: <why no BuilderOps material was created, or what was routed>
+
 ---
 EOF
 )"
@@ -225,6 +239,8 @@ Pre-push PR-body contract gate:
   - governance lane: `- [x] Governance lane`
   - direct repair: a complete `## Direct Repair` block with `Type:`, `Reason:`, `Validation:`, and `Issue required: no`
 - If none is present, stop and repair the PR body before publication.
+- Verify the body includes `## BuilderOps Routing`. If no BuilderOps object was created, the
+  section must still explain why the work did not produce operational BuilderOps material.
 
 Direct Repair block placement: prefer placing the `## Direct Repair` block as the first section of the PR body (before `## Summary`). The governance check accepts the block in any position — first, middle, or last — but first placement is preferred for reviewer clarity.
 

--- a/.codex/skills/verification-and-closure/SKILL.md
+++ b/.codex/skills/verification-and-closure/SKILL.md
@@ -53,6 +53,9 @@ Test/check failures must be classified, not dismissed as merely "out of scope" w
 - Verify owner-doc writeback if shipped behavior or contracts changed and acceptance is complete
 - Verify roadmap or plan wording was cleaned up if the item is now delivered
 - Verify no duplicate `planned` and `shipped` statements remain active at once
+- Verify the PR body includes a BuilderOps routing outcome, and that unresolved learning, docs
+  freshness, roadmap execution, promotion, projection, or receipt material is represented by a
+  BuilderOps record, a bounded GitHub Issue, or an explicit `none` reason
 - Verify project lifecycle state still makes sense
 - Verify closed terminal PR cards do not remain blank in the Project
 - Verify review-feedback repairs are present on the target base branch before treating them as closed; a side branch or intermediate PR is not enough unless the fixing commit is reachable from the final merge target. [base-branch-truth]
@@ -125,6 +128,24 @@ When all prerequisites are met:
 - `Review` is reserved for the review handoff state
 - if project/PR automation already projected `Done`, verify that state rather than writing it again
 - only apply the fallback `Done` mutation when the item still needs terminal projection
+
+## BuilderOps Closure Checkpoint
+
+Before merging or writing the delivery receipt, resolve BuilderOps routing:
+
+- `LearningSignal` exists for any workflow divergence noticed during delivery, or the PR receipt
+  states no divergence was found.
+- `DocsFreshnessRecord` exists for high-churn docs freshness findings that should not become
+  direct `DOCS_INDEX` edits.
+- `RoadmapExecutionItem` exists for operational roadmap movement that should not become strategic
+  `ROADMAP.md` truth.
+- `PromotionIntent` exists for any proposed authority crossing that is not already represented by
+  a GitHub Issue, PR, ADR, or owner-doc change.
+- `BuilderOpsReceipt` exists or is cited when the work processed BuilderOps records, generated
+  projections, promoted material, superseded material, or discarded material.
+
+If none apply, the delivery receipt may state `BuilderOps routing: none` with the reason. Do not use
+`docs/learning-log.md` as the primary closure surface.
 
 ## Parent Issue Closure
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -49,5 +49,9 @@ Governance lane:
 - [ ] Governance checks run as appropriate for the touched surfaces
 - [ ] Any validation gaps or tooling limitations are stated explicitly
 
+## BuilderOps Routing
+- Records/projections/receipts: <ids or "none">
+- Reason: <why no BuilderOps material was created, or what was routed>
+
 ## Notes
 - State any residual risks, follow-ups, or assumptions.

--- a/.github/workflows/issue-pr-governance.yml
+++ b/.github/workflows/issue-pr-governance.yml
@@ -88,6 +88,18 @@ jobs:
               pull_number: context.payload.pull_request.number,
             });
             const body = pullRequest.body || "";
+            // BuilderOps routing is mandatory delivery traceability for all PRs.
+            // It records the BuilderOps objects/projections/receipts created, or an explicit "none" reason.
+            const builderOpsRoutingMatch = body.match(/## BuilderOps Routing[\s\S]*?(?=\n##\s|\n---)|## BuilderOps Routing[\s\S]*/i);
+            const builderOpsRoutingSection = builderOpsRoutingMatch ? builderOpsRoutingMatch[0] : "";
+            const hasBuilderOpsRouting =
+              Boolean(builderOpsRoutingSection) &&
+              /(?:^|\n)\s*-\s*Records\/projections\/receipts:\s*\S/i.test(builderOpsRoutingSection) &&
+              /(?:^|\n)\s*-\s*Reason:\s*\S/i.test(builderOpsRoutingSection);
+            if (!hasBuilderOpsRouting) {
+              core.setFailed("PR body must include `## BuilderOps Routing` with `Records/projections/receipts:` and `Reason:` lines.");
+              return;
+            }
             const issueLinkPattern = /(Fixes|Closes|Resolves)\s+#\d+/i;
             if (issueLinkPattern.test(body)) {
               return;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ BuilderOps Vault workflow boundary:
 - Open a PR only when repo-governed artifacts must change: code, tests, authoritative docs, ADRs, `.codex/skills/**`, `AGENTS.md`, or generated projections committed to the repo. A BuilderOps record alone is not a repo change.
 - Use `PromotionIntent` before crossing authority classes. Promotion targets include GitHub Issue, PR/branch proposal, ADR/decision doc proposal, owner-doc or skill/AGENTS writeback proposal, generated projection, or discard receipt. Promotion is a reviewed boundary crossing, not automatic synchronization.
 - Generated BuilderOps projections are repo-readable views, not source of truth. If a projection is stale, regenerate or reconcile from BuilderOps Vault; do not hand-edit the projection as authority.
+- Repo-local workflow skills and Codex app automation prompts must carry BuilderOps routing checks directly. Do not rely on a human remembering where learning logs, docs freshness notes, roadmap movement, or worklog material should go.
 
 ## Change classification
 

--- a/docs/development/DELIVERY_FEEDBACK_LOOP.md
+++ b/docs/development/DELIVERY_FEEDBACK_LOOP.md
@@ -170,6 +170,21 @@ Every skill in `.codex/skills/` carries this addendum:
 
 > **Capturing learning:** if during this work you notice a divergence from plan — you did something you didn't expect to do, or discovered an earlier artifact was wrong — invoke `capture-learning` before continuing. Capture a BuilderOps `LearningSignal`; use `docs/learning-log.md` only as an explicit compatibility fallback. Do not batch to end of task; context is freshest now. Only capture if you can name an upstream artifact that could absorb the fix.
 
+## Workflow and automation enforcement
+
+BuilderOps adoption is enforced at workflow boundaries, not by human recall.
+
+- `issue-to-code` runs a BuilderOps routing checkpoint before implementation context becomes hidden
+  local memory and again before PR handoff.
+- `publish-pr` requires a `BuilderOps Routing` section in every PR body.
+- `verification-and-closure` verifies that unresolved BuilderOps material is represented by a
+  BuilderOps record, a bounded GitHub Issue, or an explicit `none` reason before merge.
+- `automation-maintenance` audits recurring Codex app prompts for BuilderOps-first routing.
+- Learning-retro automations must read `LearningSignal` records and generated learning projections
+  first, using `docs/learning-log.md` only for historical or explicit compatibility fallback entries.
+- Temporal-doc automations must route high-churn docs freshness and roadmap execution state to
+  `DocsFreshnessRecord` and `RoadmapExecutionItem` records before considering repo-doc writeback.
+
 ## What this is not
 
 - Not a metrics dashboard

--- a/docs/development/PR_HOT_PATH.md
+++ b/docs/development/PR_HOT_PATH.md
@@ -46,6 +46,7 @@ Default rule:
 
 4. Minimal delivery receipt
 - record PR number, issue number(s), current head SHA, lane, risk, checks run, review classification, and next handoff
+- record BuilderOps routing: records/projections/receipts created, or `none` with a short reason
 - include enough traceability to prove the current delivery state without replaying the full procedure
 
 ## Default Non-Blockers
@@ -90,11 +91,17 @@ Reason: <one or two sentences>
 Validation: <checks run>
 Issue required: no — bounded immediate repair
 
-This block is the contract for bounded direct repair PRs.
+## BuilderOps Routing
 
-- If this block is present and complete, no governing issue is required.
-- If this block is present and complete, no separate lane checkbox is required.
-- The merge receipt may reference this block instead of restating it.
+- Records/projections/receipts: <ids or "none">
+- Reason: <why no BuilderOps material was created, or what was routed>
+
+The `Direct Repair` block is the contract for bounded direct repair PRs. The `BuilderOps Routing`
+section is mandatory delivery traceability, not a second lane classifier.
+
+- If the `Direct Repair` block is present and complete, no governing issue is required.
+- If the `Direct Repair` block is present and complete, no separate lane checkbox is required.
+- The merge receipt may reference the `Direct Repair` block instead of restating it.
 - If the repair expands beyond bounded scope, create or link an issue.
 
 Placement: prefer placing the `## Direct Repair` block first in the PR body (before `## Summary`) so it is immediately visible to reviewers. The governance check accepts the block in any position — first, middle, or last — regardless of whether a trailing newline follows.

--- a/tests/architecture/test_pr_hot_path_governance.py
+++ b/tests/architecture/test_pr_hot_path_governance.py
@@ -27,8 +27,11 @@ def test_hot_path_doc_defers_escalation_and_names_direct_repair_contract() -> No
         "## Direct Repair",
         "Type: docs | governance | code",
         "Validation: <checks run>",
+        "## BuilderOps Routing",
+        "Records/projections/receipts:",
         "Direct repair PRs are allowed without a governing issue when the change is bounded, immediate, and the PR body contains a complete Direct Repair block.",
-        "If this block is present and complete, no separate lane checkbox is required.",
+        "The `Direct Repair` block is the contract for bounded direct repair PRs. The `BuilderOps Routing`",
+        "If the `Direct Repair` block is present and complete, no separate lane checkbox is required.",
         "failing required tests or checks must be classified before merge",
         "delivery traceability must be preserved through either an issue-backed PR or a direct repair block",
     ):
@@ -76,6 +79,9 @@ def test_issue_pr_governance_accepts_direct_repair_block_without_lane_checkbox()
 
     for fragment in (
         "const directRepairSectionMatch = body.match(/## Direct Repair",
+        "const builderOpsRoutingMatch = body.match(/## BuilderOps Routing",
+        "const hasBuilderOpsRouting =",
+        "PR body must include `## BuilderOps Routing`",
         "const isDirectRepair =",
         "if (isDirectRepair) {",
         "includes a complete `Direct Repair` block",
@@ -88,7 +94,21 @@ def test_issue_pr_governance_accepts_direct_repair_block_without_lane_checkbox()
     assert text.index("const directRepairSectionMatch = body.match(/## Direct Repair") < text.index(
         "const docsAuthoringPattern ="
     )
+    assert text.index("const builderOpsRoutingMatch = body.match(/## BuilderOps Routing") < text.index(
+        "const issueLinkPattern ="
+    )
     assert text.index("if (isDirectRepair) {") < text.index("const docsAuthoringPattern =")
+
+
+def test_pr_template_includes_builderops_routing_receipt() -> None:
+    text = _read(".github/pull_request_template.md")
+
+    for fragment in (
+        "## BuilderOps Routing",
+        "Records/projections/receipts:",
+        "Reason:",
+    ):
+        assert fragment in text, fragment
 
 
 import re as _re
@@ -105,6 +125,14 @@ _DIRECT_REPAIR_REGEX = _re.compile(
     r"## Direct Repair[\s\S]*?(?=\n##\s|\n---)|## Direct Repair[\s\S]*",
     _re.IGNORECASE,
 )
+_BUILDEROPS_ROUTING_REGEX = _re.compile(
+    r"## BuilderOps Routing[\s\S]*?(?=\n##\s|\n---)|## BuilderOps Routing[\s\S]*",
+    _re.IGNORECASE,
+)
+_BUILDEROPS_ROUTING_FIELDS = [
+    _re.compile(r"(?:^|\n)\s*-\s*Records/projections/receipts:\s*\S", _re.IGNORECASE),
+    _re.compile(r"(?:^|\n)\s*-\s*Reason:\s*\S", _re.IGNORECASE),
+]
 
 
 def _is_direct_repair(body: str) -> bool:
@@ -116,23 +144,48 @@ def _is_direct_repair(body: str) -> bool:
     return all(p.search(section) for p in _REQUIRED_FIELDS_PATTERNS)
 
 
+def _has_builderops_routing(body: str) -> bool:
+    """Python port of the JavaScript `hasBuilderOpsRouting` logic."""
+    m = _BUILDEROPS_ROUTING_REGEX.search(body)
+    if not m:
+        return False
+    section = m.group(0)
+    return all(p.search(section) for p in _BUILDEROPS_ROUTING_FIELDS)
+
+
 _VALID_DIRECT_REPAIR_FIELDS = (
     "Type: governance\nReason: bounded fix\nValidation: git diff --check\nIssue required: no"
+)
+
+_VALID_BUILDEROPS_ROUTING = (
+    "## BuilderOps Routing\n"
+    "- Records/projections/receipts: none\n"
+    "- Reason: no operational BuilderOps material produced"
 )
 
 
 def test_direct_repair_accepted_when_block_is_first_section() -> None:
     """AC1: Direct Repair block followed by another section."""
-    body = f"## Direct Repair\n{_VALID_DIRECT_REPAIR_FIELDS}\n\n## Summary\nSome summary here."
+    body = (
+        f"## Direct Repair\n{_VALID_DIRECT_REPAIR_FIELDS}\n\n"
+        f"{_VALID_BUILDEROPS_ROUTING}\n\n"
+        "## Summary\nSome summary here."
+    )
     assert _is_direct_repair(body), "Expected direct repair to be accepted when block is first"
+    assert _has_builderops_routing(body), "Expected BuilderOps routing to be accepted"
 
 
 def test_direct_repair_accepted_when_block_is_last_section_no_trailing_newline() -> None:
     """AC2: Direct Repair block at end with no trailing newline (GitHub strips trailing whitespace)."""
-    body = f"## Summary\nSome summary here.\n\n## Direct Repair\n{_VALID_DIRECT_REPAIR_FIELDS}"
+    body = (
+        "## Summary\nSome summary here.\n\n"
+        f"{_VALID_BUILDEROPS_ROUTING}\n\n"
+        f"## Direct Repair\n{_VALID_DIRECT_REPAIR_FIELDS}"
+    )
     # No trailing newline — this was the failing case before the regex fix
     assert not body.endswith("\n"), "Fixture must have no trailing newline to reproduce the bug"
     assert _is_direct_repair(body), "Expected direct repair to be accepted when block is last with no trailing newline"
+    assert _has_builderops_routing(body), "Expected BuilderOps routing to be accepted"
 
 
 def test_direct_repair_accepted_when_block_is_middle_section() -> None:
@@ -140,9 +193,23 @@ def test_direct_repair_accepted_when_block_is_middle_section() -> None:
     body = (
         "## Summary\nSome summary.\n\n"
         f"## Direct Repair\n{_VALID_DIRECT_REPAIR_FIELDS}\n\n"
+        f"{_VALID_BUILDEROPS_ROUTING}\n\n"
         "## Runtime behavior\nNo change."
     )
     assert _is_direct_repair(body), "Expected direct repair to be accepted when block is in the middle"
+    assert _has_builderops_routing(body), "Expected BuilderOps routing to be accepted"
+
+
+def test_builderops_routing_required_fields() -> None:
+    """PR contract requires an explicit BuilderOps routing receipt."""
+    valid_body = f"Fixes #123\n\n{_VALID_BUILDEROPS_ROUTING}"
+    assert _has_builderops_routing(valid_body), "Expected BuilderOps routing section to be accepted"
+
+    missing_records = "## BuilderOps Routing\n- Reason: no operational BuilderOps material produced"
+    assert not _has_builderops_routing(missing_records), "Expected missing records line to be rejected"
+
+    missing_reason = "## BuilderOps Routing\n- Records/projections/receipts: none"
+    assert not _has_builderops_routing(missing_reason), "Expected missing reason line to be rejected"
 
 
 def test_direct_repair_rejected_when_fields_incomplete() -> None:


### PR DESCRIPTION
## Direct Repair
Type: governance
Reason: BuilderOps routing must be enforced by workflow and PR boundaries so agents and automations do not rely on human memory.
Validation: git diff --check; python3 scripts/docs_guard.py; PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/architecture/test_pr_hot_path_governance.py
Issue required: no - bounded immediate governance repair

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: This PR changes repo-governed workflow policy, PR contract enforcement, and local automation prompts; no BuilderOps record was needed because no operational BuilderOps material was processed or migrated.

## Summary
- Adds BuilderOps routing checkpoints to repo-local workflow skills and delivery docs.
- Adds deterministic PR governance enforcement requiring a BuilderOps Routing receipt in every PR body, plus PR-template support and focused architecture tests.
- Updates Codex app automations outside the repo via the app automation tool so recurring runs use BuilderOps-first routing.

## Scope
- Governance/workflow only.
- No product/runtime behavior changes.
- No BuilderOps store/API/promotion implementation changes.
- No migration of learning-log, DOCS_INDEX, or roadmap content.

## Automation Updates Applied
- learning-retro-intake: BuilderOps LearningSignal/projection first, learning-log fallback only.
- temporal-docs-audit: docs freshness and roadmap execution route to BuilderOps records before repo-doc writeback.
- daily-review-comment-closure-audit: workflow divergence and review residue route to BuilderOps records or bounded Issues.
- daily-bug-scan: process divergences route to LearningSignal/PromotionIntent; concrete bugs still route to Issue/PR.
- skill-progression-map, weekly-release-notes, and kanban-cleanup-retry: BuilderOps routing receipts added.

## Validation
- git diff --check
- python3 scripts/docs_guard.py -> Docs guard: OK
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/architecture/test_pr_hot_path_governance.py -> 12 passed