### PR TITLE
Add non-canonical Knowledge Compilation runtime artifact contracts (#1534)

### DIFF
--- a/app/knowledge_compilation/__init__.py
+++ b/app/knowledge_compilation/__init__.py
@@ -1,0 +1,37 @@
+"""v6.x Knowledge Compilation and Memory Curation runtime foundation (parent #1533).
+
+Slice #1534 ships the pure runtime artifact contracts only. See
+``app.knowledge_compilation.runtime_artifacts``.
+"""
+
+from app.knowledge_compilation.runtime_artifacts import (
+    AGENT_MEMORY_CLASS,
+    BRIDGE_ARTIFACT_CLASSES,
+    COMPILATION_DRAFT_CLASS,
+    CURATION_CANDIDATE_CLASS,
+    REORIENTATION_PACKET_CLASS,
+    AdmissionState,
+    CompilationDraft,
+    ContextAuthorityLimits,
+    CurationCandidate,
+    GeneratedArtifact,
+    ReorientationPacket,
+    SourceRef,
+    TrustVerb,
+)
+
+__all__ = [
+    "AGENT_MEMORY_CLASS",
+    "BRIDGE_ARTIFACT_CLASSES",
+    "COMPILATION_DRAFT_CLASS",
+    "CURATION_CANDIDATE_CLASS",
+    "REORIENTATION_PACKET_CLASS",
+    "AdmissionState",
+    "CompilationDraft",
+    "ContextAuthorityLimits",
+    "CurationCandidate",
+    "GeneratedArtifact",
+    "ReorientationPacket",
+    "SourceRef",
+    "TrustVerb",
+]

--- a/app/knowledge_compilation/runtime_artifacts.py
+++ b/app/knowledge_compilation/runtime_artifacts.py
@@ -178,6 +178,10 @@ class GeneratedArtifact(BaseModel):
             raise ValueError(
                 f"generated {self.artifact_class} must remain non-canonical"
             )
+        if self.artifact_class == AGENT_MEMORY_CLASS:
+            raise ValueError(
+                f"generated {self.artifact_class} must not claim durable agent-memory class"
+            )
         # Admission requires durable receipt evidence regardless of trust verb: downstream
         # code keys off admission_state, so a self-marked admitted artifact must not be
         # indistinguishable from a reviewed one (RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md;

--- a/app/knowledge_compilation/runtime_artifacts.py
+++ b/app/knowledge_compilation/runtime_artifacts.py
@@ -229,6 +229,13 @@ class ReorientationPacket(GeneratedArtifact):
     """
 
     artifact_class: Literal["reorientation_packet"] = REORIENTATION_PACKET_CLASS
+    # A reorientation packet exists to support re-orientation, so it is orient-capable by
+    # default (CONTEXT_ACTIVATION_SEMANTICS.md: ``may_orient=true`` permits re-orientation;
+    # leaving it false would strip the one permission the packet needs). Write, promote, and
+    # action authority stay disabled and are still refused by the base validator.
+    authority_limits: ContextAuthorityLimits = Field(
+        default_factory=lambda: ContextAuthorityLimits(may_orient=True)
+    )
     summary: Optional[str] = None
     leave_point_ref: Optional[str] = None  # reference only
     memory_handoff_refs: list[str] = Field(default_factory=list)  # reference-only memory ids

--- a/app/knowledge_compilation/runtime_artifacts.py
+++ b/app/knowledge_compilation/runtime_artifacts.py
@@ -27,9 +27,10 @@ write helpers. Storage, API, events, and UI belong to later slices, not here.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Literal, Optional
+from typing import Any, Literal, Optional, Self
 from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -166,6 +167,18 @@ class GeneratedArtifact(BaseModel):
         """Generated artifacts may reference receipts but never *are* receipt authority."""
 
         return False
+
+    def model_copy(
+        self, *, update: Mapping[str, Any] | None = None, deep: bool = False
+    ) -> Self:
+        copied = super().model_copy(update=update, deep=deep)
+        # Pydantic's model_copy(update=...) does not re-run validators, so the immutable-update
+        # path could otherwise bypass the construction invariants (e.g.
+        # update={"canonical": True} or an authority-elevating update). Re-validate the copy —
+        # validating a plain mapping (not a model instance) forces the after-validator to run —
+        # so the frozen guarantees also hold across copies.
+        type(self).model_validate(copied.model_dump())
+        return copied
 
     @model_validator(mode="after")
     def _enforce_noncanonical_suggest_posture(self) -> "GeneratedArtifact":

--- a/app/knowledge_compilation/runtime_artifacts.py
+++ b/app/knowledge_compilation/runtime_artifacts.py
@@ -1,0 +1,235 @@
+"""Pure runtime/domain models for v6.x Knowledge Compilation and Memory Curation.
+
+Child slice #1534 under parent feature #1533. This is the first executable slice: it
+defines the non-canonical, ``SUGGEST``-posture runtime support artifacts —
+``CompilationDraft``, ``CurationCandidate``, and ``ReorientationPacket`` — *before* any
+proposal builders (#1535), reorientation assembly (#1536), admission handoff (#1537), or
+eval/trace harness (#1538) work begins.
+
+Authority posture follows the source contracts:
+
+- ``docs/CONCEPTS/TRUST_SEMANTICS_CONTRACT.md`` — ASSERT / SUGGEST / APPLY. Generated
+  outputs default to SUGGEST and may not self-escalate.
+- ``docs/CONCEPTS/AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT.md`` — generated/inferred material
+  is never canonical and never action-authorizing without accepted review.
+- ``docs/CONTEXTUALIZATION_LAYER/CONTEXT_ACTIVATION_SEMANTICS.md`` — the hidden-authority
+  guard (unreviewed memory, embeddings, retrieval ranking, generated summaries cannot
+  grant authority) and the bridge/assembly-artifact framing for return-to-work supports.
+- ``docs/CONCEPTS/RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md`` — a trace is not a receipt;
+  these artifacts reference receipts by id and never *are* receipt authority.
+- ``docs/plans/V6X_KNOWLEDGE_COMPILATION_AND_MEMORY_CURATION.md`` — Artifact Model /
+  Review and Promotion Posture.
+
+This module is intentionally pure domain code. It must not wire up a database session, an
+object store, a knowledge or vault port, a write guard, an outbox emitter, or filesystem
+write helpers. Storage, API, events, and UI belong to later slices, not here.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Literal, Optional
+from uuid import uuid4
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class TrustVerb(str, Enum):
+    """Trust verbs from ``TRUST_SEMANTICS_CONTRACT.md``.
+
+    Generated artifacts default to ``SUGGEST``. ``ASSERT``/``APPLY`` may only be carried
+    after an explicit human admission decision (#1537); the contract here never
+    self-escalates the verb.
+    """
+
+    SUGGEST = "SUGGEST"
+    ASSERT = "ASSERT"
+    APPLY = "APPLY"
+
+
+class AdmissionState(str, Enum):
+    """Review/admission posture for generated artifacts.
+
+    Generated artifacts start ``PENDING_REVIEW`` and require an explicit admission
+    decision plus receipt posture before any promotion path (handled in #1537). Aligns
+    with the review lifecycle in ``agent_memory.candidate.ReviewState`` without coupling
+    to it.
+    """
+
+    PENDING_REVIEW = "pending_review"
+    ADMITTED = "admitted"
+    REJECTED = "rejected"
+
+
+# Artifact-class tokens. Plain strings to match the house convention
+# (see ``app/agent_memory/candidate.py`` -> ``MemoryCandidate.artifact_class``); typed as
+# ``Literal`` so they can serve as the pinned per-subclass ``artifact_class`` default.
+COMPILATION_DRAFT_CLASS: Literal["compilation_draft"] = "compilation_draft"
+CURATION_CANDIDATE_CLASS: Literal["curation_candidate"] = "curation_candidate"
+REORIENTATION_PACKET_CLASS: Literal["reorientation_packet"] = "reorientation_packet"
+
+# Bridge/assembly support artifacts compose other material for orientation/return-to-work.
+# They are never durable memory, canonical knowledge, or receipt authority.
+BRIDGE_ARTIFACT_CLASSES: frozenset[str] = frozenset({REORIENTATION_PACKET_CLASS})
+
+# Durable agent-memory artifact class (``app/agent_memory/candidate.py``). Generated
+# knowledge-compilation artifacts must never claim this class.
+AGENT_MEMORY_CLASS = "agentic_memory"
+
+
+class SourceRef(BaseModel):
+    """First-class provenance reference for a generated artifact.
+
+    Mirrors the provenance posture of ``agent_memory.candidate`` (``source_refs``) and
+    ``context_bundles.schema`` (``ItemProvenance``/``IncludedItem``). Review posture,
+    retrieval scores, and the deriving mechanism may be *recorded* here, but recording
+    them never grants authority — see ``ContextAuthorityLimits``.
+    """
+
+    artifact_id: str
+    note_path: Optional[str] = None
+    role: Optional[str] = None
+    # Recorded provenance signals — never authoritative on their own:
+    review_state: Optional[str] = None  # e.g. "unreviewed"
+    retrieval_score: Optional[float] = None  # ranking signal
+    derived_by: Optional[str] = None  # e.g. "embedding", "generated_summary"
+
+
+class ContextAuthorityLimits(BaseModel):
+    """Authority-limit flags for a generated artifact.
+
+    Mirrors ``app/context_bundles/schema.py`` -> ``AuthorityFlags``. Generated
+    knowledge-compilation artifacts are inform/orient-only: they may never carry write,
+    promotion, or action-authorization authority. The hidden-authority guard
+    (``CONTEXT_ACTIVATION_SEMANTICS.md``) means unreviewed memory, embeddings, retrieval
+    scores, and generated summaries cannot flip the latter three on.
+    """
+
+    may_inform: bool = True
+    may_orient: bool = False
+    may_propose: bool = False
+    may_promote: bool = False
+    may_write: bool = False
+    may_authorize_action: bool = False
+
+
+class GeneratedArtifact(BaseModel):
+    """Base for non-canonical, ``SUGGEST``-posture generated runtime supports.
+
+    Invariants enforced at construction:
+
+    - at least one ``source_ref`` must be present (no sourceless synthesis);
+    - ``canonical`` stays ``False``;
+    - the trust verb stays ``SUGGEST`` unless the artifact is explicitly ``ADMITTED``;
+    - the artifact can never carry write/promote/action-authorization authority.
+    """
+
+    artifact_class: str
+    artifact_id: str = Field(default_factory=lambda: uuid4().hex)
+    canonical: bool = Field(default=False)
+    trust_verb: TrustVerb = Field(default=TrustVerb.SUGGEST)
+    admission_state: AdmissionState = Field(default=AdmissionState.PENDING_REVIEW)
+    inferred: bool = Field(default=True)
+
+    source_refs: list[SourceRef] = Field(default_factory=list)
+    generated_by: Optional[str] = None
+    # Operational trace id only. A trace is not a receipt
+    # (``RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md``).
+    trace_ref: Optional[str] = None
+
+    authority_limits: ContextAuthorityLimits = Field(default_factory=ContextAuthorityLimits)
+
+    # Receipts are referenced by id only — a generated artifact is never itself a receipt.
+    admission_receipt_ref: Optional[str] = None
+
+    generated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+    @property
+    def is_bridge_artifact(self) -> bool:
+        """True only for bridge/assembly support artifacts (e.g. reorientation packets)."""
+
+        return self.artifact_class in BRIDGE_ARTIFACT_CLASSES
+
+    @property
+    def grants_receipt_authority(self) -> bool:
+        """Generated artifacts may reference receipts but never *are* receipt authority."""
+
+        return False
+
+    @model_validator(mode="after")
+    def _enforce_noncanonical_suggest_posture(self) -> "GeneratedArtifact":
+        if not self.source_refs:
+            raise ValueError(
+                f"{self.artifact_class} requires at least one source_ref "
+                f"(provenance) before construction"
+            )
+        if self.canonical:
+            raise ValueError(
+                f"generated {self.artifact_class} must remain non-canonical"
+            )
+        if (
+            self.trust_verb is not TrustVerb.SUGGEST
+            and self.admission_state is not AdmissionState.ADMITTED
+        ):
+            raise ValueError(
+                f"generated {self.artifact_class} cannot carry trust_verb "
+                f"{self.trust_verb.value} without explicit admission"
+            )
+        limits = self.authority_limits
+        elevated = [
+            name
+            for name, granted in (
+                ("may_write", limits.may_write),
+                ("may_promote", limits.may_promote),
+                ("may_authorize_action", limits.may_authorize_action),
+            )
+            if granted
+        ]
+        if elevated:
+            raise ValueError(
+                f"generated {self.artifact_class} cannot grant hidden authority: "
+                f"{', '.join(elevated)}"
+            )
+        return self
+
+
+class CompilationDraft(GeneratedArtifact):
+    """Generated synthesis candidate, explicitly non-canonical.
+
+    The bounded contract here only fixes the model and posture; building drafts from
+    approved context (preserving source refs and uncertainty) is #1535.
+    """
+
+    artifact_class: Literal["compilation_draft"] = COMPILATION_DRAFT_CLASS
+    title: str
+    body: Optional[str] = None
+    uncertainty_notes: Optional[str] = None
+
+
+class CurationCandidate(GeneratedArtifact):
+    """Proposed retained-material set with source links and rationale, non-canonical.
+
+    Building candidates (preserving rationale and explicit exclusions) is #1535.
+    """
+
+    artifact_class: Literal["curation_candidate"] = CURATION_CANDIDATE_CLASS
+    title: str
+    rationale: Optional[str] = None
+    excluded_refs: list[SourceRef] = Field(default_factory=list)
+
+
+class ReorientationPacket(GeneratedArtifact):
+    """Compact read-only context bundle for return-to-work flows.
+
+    A bridge/assembly support artifact (``CONTEXT_ACTIVATION_SEMANTICS.md``): it composes
+    references for orientation but is **not** agent memory, **not** canonical knowledge,
+    and **not** receipt authority. Memory and receipts are referenced by id only. Read-only
+    assembly of the packet contents is #1536.
+    """
+
+    artifact_class: Literal["reorientation_packet"] = REORIENTATION_PACKET_CLASS
+    summary: Optional[str] = None
+    leave_point_ref: Optional[str] = None  # reference only
+    memory_handoff_refs: list[str] = Field(default_factory=list)  # reference-only memory ids
+    stale_after: Optional[datetime] = None

--- a/app/knowledge_compilation/runtime_artifacts.py
+++ b/app/knowledge_compilation/runtime_artifacts.py
@@ -168,13 +168,19 @@ class GeneratedArtifact(BaseModel):
             raise ValueError(
                 f"generated {self.artifact_class} must remain non-canonical"
             )
-        if (
-            self.trust_verb is not TrustVerb.SUGGEST
-            and self.admission_state is not AdmissionState.ADMITTED
+        if self.trust_verb is not TrustVerb.SUGGEST and (
+            self.admission_state is not AdmissionState.ADMITTED
+            or not self.admission_receipt_ref
         ):
+            # Trust escalation past SUGGEST requires both an explicit ADMITTED decision and a
+            # durable receipt reference (RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md; epic #1533:
+            # "mutation/promotion requires explicit admission plus receipt posture"). Without
+            # the receipt, a self-marked admitted artifact would be indistinguishable from a
+            # reviewed one. The admission handoff that attaches the receipt is slice #1537.
             raise ValueError(
                 f"generated {self.artifact_class} cannot carry trust_verb "
-                f"{self.trust_verb.value} without explicit admission"
+                f"{self.trust_verb.value} without explicit admission and a durable "
+                f"admission_receipt_ref"
             )
         limits = self.authority_limits
         elevated = [

--- a/app/knowledge_compilation/runtime_artifacts.py
+++ b/app/knowledge_compilation/runtime_artifacts.py
@@ -32,7 +32,7 @@ from enum import Enum
 from typing import Literal, Optional
 from uuid import uuid4
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class TrustVerb(str, Enum):
@@ -87,6 +87,8 @@ class SourceRef(BaseModel):
     them never grants authority — see ``ContextAuthorityLimits``.
     """
 
+    model_config = ConfigDict(frozen=True)
+
     artifact_id: str
     note_path: Optional[str] = None
     role: Optional[str] = None
@@ -106,6 +108,8 @@ class ContextAuthorityLimits(BaseModel):
     scores, and generated summaries cannot flip the latter three on.
     """
 
+    model_config = ConfigDict(frozen=True)
+
     may_inform: bool = True
     may_orient: bool = False
     may_propose: bool = False
@@ -123,7 +127,13 @@ class GeneratedArtifact(BaseModel):
     - ``canonical`` stays ``False``;
     - the trust verb stays ``SUGGEST`` unless the artifact is explicitly ``ADMITTED``;
     - the artifact can never carry write/promote/action-authorization authority.
+
+    The model (and its nested authority/provenance models) is frozen so these invariants
+    cannot be bypassed by post-construction mutation; collection fields are tuples so their
+    contents cannot be mutated in place either.
     """
+
+    model_config = ConfigDict(frozen=True)
 
     artifact_class: str
     artifact_id: str = Field(default_factory=lambda: uuid4().hex)
@@ -132,7 +142,7 @@ class GeneratedArtifact(BaseModel):
     admission_state: AdmissionState = Field(default=AdmissionState.PENDING_REVIEW)
     inferred: bool = Field(default=True)
 
-    source_refs: list[SourceRef] = Field(default_factory=list)
+    source_refs: tuple[SourceRef, ...] = Field(default_factory=tuple)
     generated_by: Optional[str] = None
     # Operational trace id only. A trace is not a receipt
     # (``RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md``).
@@ -168,19 +178,25 @@ class GeneratedArtifact(BaseModel):
             raise ValueError(
                 f"generated {self.artifact_class} must remain non-canonical"
             )
-        if self.trust_verb is not TrustVerb.SUGGEST and (
-            self.admission_state is not AdmissionState.ADMITTED
-            or not self.admission_receipt_ref
+        # Admission requires durable receipt evidence regardless of trust verb: downstream
+        # code keys off admission_state, so a self-marked admitted artifact must not be
+        # indistinguishable from a reviewed one (RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md;
+        # epic #1533: "mutation/promotion requires explicit admission plus receipt posture").
+        # The admission handoff that attaches the receipt is slice #1537.
+        if self.admission_state is AdmissionState.ADMITTED and not self.admission_receipt_ref:
+            raise ValueError(
+                f"generated {self.artifact_class} marked admitted requires a durable "
+                f"admission_receipt_ref"
+            )
+        # Trust escalation past SUGGEST additionally requires the explicit ADMITTED decision
+        # (which, by the check above, already carries a receipt).
+        if (
+            self.trust_verb is not TrustVerb.SUGGEST
+            and self.admission_state is not AdmissionState.ADMITTED
         ):
-            # Trust escalation past SUGGEST requires both an explicit ADMITTED decision and a
-            # durable receipt reference (RECEIPT_TRACE_ACCOUNTABILITY_CONTRACT.md; epic #1533:
-            # "mutation/promotion requires explicit admission plus receipt posture"). Without
-            # the receipt, a self-marked admitted artifact would be indistinguishable from a
-            # reviewed one. The admission handoff that attaches the receipt is slice #1537.
             raise ValueError(
                 f"generated {self.artifact_class} cannot carry trust_verb "
-                f"{self.trust_verb.value} without explicit admission and a durable "
-                f"admission_receipt_ref"
+                f"{self.trust_verb.value} without explicit admission"
             )
         limits = self.authority_limits
         elevated = [
@@ -222,7 +238,7 @@ class CurationCandidate(GeneratedArtifact):
     artifact_class: Literal["curation_candidate"] = CURATION_CANDIDATE_CLASS
     title: str
     rationale: Optional[str] = None
-    excluded_refs: list[SourceRef] = Field(default_factory=list)
+    excluded_refs: tuple[SourceRef, ...] = Field(default_factory=tuple)
 
 
 class ReorientationPacket(GeneratedArtifact):
@@ -244,5 +260,5 @@ class ReorientationPacket(GeneratedArtifact):
     )
     summary: Optional[str] = None
     leave_point_ref: Optional[str] = None  # reference only
-    memory_handoff_refs: list[str] = Field(default_factory=list)  # reference-only memory ids
+    memory_handoff_refs: tuple[str, ...] = Field(default_factory=tuple)  # reference-only ids
     stale_after: Optional[datetime] = None

--- a/tests/knowledge_compilation/test_runtime_artifacts.py
+++ b/tests/knowledge_compilation/test_runtime_artifacts.py
@@ -132,6 +132,14 @@ def test_reorientation_packet_is_bridge_artifact_not_memory_or_receipt_authority
     assert draft.authority_limits.may_orient is False
 
 
+def test_generated_artifact_base_cannot_claim_agent_memory_class() -> None:
+    with pytest.raises(ValueError, match="must not claim durable agent-memory class"):
+        runtime_artifacts.GeneratedArtifact(
+            artifact_class=AGENT_MEMORY_CLASS,
+            source_refs=[_source()],
+        )
+
+
 def test_unreviewed_memory_and_rankings_cannot_grant_hidden_authority() -> None:
     # Provenance carrying unreviewed memory, embeddings, retrieval scores, generated summaries.
     hidden_authority_sources = [

--- a/tests/knowledge_compilation/test_runtime_artifacts.py
+++ b/tests/knowledge_compilation/test_runtime_artifacts.py
@@ -245,3 +245,19 @@ def test_artifacts_are_frozen_against_post_construction_authority_mutation() -> 
     assert isinstance(draft.source_refs, tuple)
     assert isinstance(packet.memory_handoff_refs, tuple)
     assert not hasattr(draft.source_refs, "clear")
+
+
+def test_model_copy_update_revalidates_invariants() -> None:
+    draft = CompilationDraft(title="orig", source_refs=[_source()])
+
+    # The immutable-update path must not bypass the construction invariants.
+    with pytest.raises(ValueError, match="non-canonical"):
+        draft.model_copy(update={"canonical": True})
+    with pytest.raises(ValueError, match="hidden authority"):
+        draft.model_copy(update={"authority_limits": ContextAuthorityLimits(may_write=True)})
+
+    # A benign copy still works and stays non-canonical / inform-only.
+    renamed = draft.model_copy(update={"title": "updated"})
+    assert renamed.title == "updated"
+    assert renamed.canonical is False
+    assert renamed.authority_limits.may_write is False

--- a/tests/knowledge_compilation/test_runtime_artifacts.py
+++ b/tests/knowledge_compilation/test_runtime_artifacts.py
@@ -66,8 +66,15 @@ def test_generated_artifacts_default_to_noncanonical_suggest_posture() -> None:
 
 
 def test_non_suggest_trust_requires_admission_and_durable_receipt() -> None:
-    # ADMITTED but without a durable receipt ref → refused: a self-marked admitted artifact
-    # must not be indistinguishable from a reviewed one.
+    # ADMITTED but without a durable receipt ref → refused, even at SUGGEST trust: downstream
+    # code keys off admission_state, so a self-marked admitted artifact must not be
+    # indistinguishable from a reviewed one.
+    with pytest.raises(ValueError, match="durable admission_receipt_ref"):
+        CompilationDraft(
+            title="Admitted at suggest without receipt",
+            source_refs=[_source()],
+            admission_state=AdmissionState.ADMITTED,
+        )
     with pytest.raises(ValueError, match="durable admission_receipt_ref"):
         CompilationDraft(
             title="Admitted without receipt",
@@ -109,7 +116,7 @@ def test_reorientation_packet_is_bridge_artifact_not_memory_or_receipt_authority
     assert packet.grants_receipt_authority is False
 
     # References memory by id only — it does not embed or become memory.
-    assert packet.memory_handoff_refs == ["agentic_memory:cand_123"]
+    assert packet.memory_handoff_refs == ("agentic_memory:cand_123",)
     assert packet.canonical is False
 
     # Orient-capable by default (its whole purpose is re-orientation), while write/promote/
@@ -211,3 +218,22 @@ def test_runtime_artifacts_are_pure_domain_no_db_or_vault_writes() -> None:
     # No DB/vault/outbox/filesystem-write symbols referenced anywhere in the module.
     for symbol in _FORBIDDEN_SYMBOLS:
         assert symbol not in used_names, f"runtime_artifacts must not reference {symbol!r}"
+
+
+def test_artifacts_are_frozen_against_post_construction_authority_mutation() -> None:
+    draft = CompilationDraft(title="frozen", source_refs=[_source()])
+    packet = ReorientationPacket(summary="frozen", source_refs=[_source()])
+
+    # Frozen: post-construction field assignment is rejected, so the construction-time
+    # invariants (non-canonical, no hidden authority, provenance) cannot be bypassed later.
+    with pytest.raises(ValueError):
+        draft.canonical = True
+    with pytest.raises(ValueError):
+        draft.authority_limits.may_write = True
+    with pytest.raises(ValueError):
+        packet.authority_limits.may_authorize_action = True
+
+    # Collection fields are tuples — no in-place mutation API (e.g. .clear()).
+    assert isinstance(draft.source_refs, tuple)
+    assert isinstance(packet.memory_handoff_refs, tuple)
+    assert not hasattr(draft.source_refs, "clear")

--- a/tests/knowledge_compilation/test_runtime_artifacts.py
+++ b/tests/knowledge_compilation/test_runtime_artifacts.py
@@ -89,9 +89,17 @@ def test_reorientation_packet_is_bridge_artifact_not_memory_or_receipt_authority
     assert packet.memory_handoff_refs == ["agentic_memory:cand_123"]
     assert packet.canonical is False
 
-    # Compilation/curation outputs are not bridge artifacts — the classification is meaningful.
+    # Orient-capable by default (its whole purpose is re-orientation), while write/promote/
+    # action authority stay disabled.
+    assert packet.authority_limits.may_orient is True
+    assert packet.authority_limits.may_write is False
+    assert packet.authority_limits.may_promote is False
+    assert packet.authority_limits.may_authorize_action is False
+
+    # Compilation/curation outputs are not bridge artifacts and are not orient-capable.
     draft = CompilationDraft(title="d", source_refs=[_source()])
     assert draft.is_bridge_artifact is False
+    assert draft.authority_limits.may_orient is False
 
 
 def test_unreviewed_memory_and_rankings_cannot_grant_hidden_authority() -> None:

--- a/tests/knowledge_compilation/test_runtime_artifacts.py
+++ b/tests/knowledge_compilation/test_runtime_artifacts.py
@@ -65,6 +65,29 @@ def test_generated_artifacts_default_to_noncanonical_suggest_posture() -> None:
         )
 
 
+def test_non_suggest_trust_requires_admission_and_durable_receipt() -> None:
+    # ADMITTED but without a durable receipt ref → refused: a self-marked admitted artifact
+    # must not be indistinguishable from a reviewed one.
+    with pytest.raises(ValueError, match="durable admission_receipt_ref"):
+        CompilationDraft(
+            title="Admitted without receipt",
+            source_refs=[_source()],
+            trust_verb=TrustVerb.ASSERT,
+            admission_state=AdmissionState.ADMITTED,
+        )
+
+    # ADMITTED plus a durable receipt ref → permitted (models the post-#1537 admitted state).
+    admitted = CompilationDraft(
+        title="Admitted with receipt",
+        source_refs=[_source()],
+        trust_verb=TrustVerb.ASSERT,
+        admission_state=AdmissionState.ADMITTED,
+        admission_receipt_ref="receipt:admission:123",
+    )
+    assert admitted.trust_verb is TrustVerb.ASSERT
+    assert admitted.admission_receipt_ref == "receipt:admission:123"
+
+
 def test_reorientation_packet_is_bridge_artifact_not_memory_or_receipt_authority() -> None:
     packet = ReorientationPacket(
         summary="Resume work on X",

--- a/tests/knowledge_compilation/test_runtime_artifacts.py
+++ b/tests/knowledge_compilation/test_runtime_artifacts.py
@@ -1,0 +1,182 @@
+"""Runtime artifact contract tests for v6.x Knowledge Compilation (#1534, parent #1533).
+
+These cover the bounded slice: pure, non-canonical, SUGGEST-posture runtime support
+models for CompilationDraft, CurationCandidate, and ReorientationPacket — with no
+storage, API, event, or UI wiring and no hidden authority.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+
+import pytest
+
+import app.knowledge_compilation.runtime_artifacts as runtime_artifacts
+from app.knowledge_compilation.runtime_artifacts import (
+    AGENT_MEMORY_CLASS,
+    BRIDGE_ARTIFACT_CLASSES,
+    AdmissionState,
+    CompilationDraft,
+    ContextAuthorityLimits,
+    CurationCandidate,
+    ReorientationPacket,
+    SourceRef,
+    TrustVerb,
+)
+
+
+def _source() -> SourceRef:
+    return SourceRef(
+        artifact_id="note:abc123",
+        note_path="vault://notes/abc.md",
+        role="source",
+    )
+
+
+def test_generated_artifacts_default_to_noncanonical_suggest_posture() -> None:
+    draft = CompilationDraft(title="Synthesis candidate", source_refs=[_source()])
+    candidate = CurationCandidate(title="Retained set", source_refs=[_source()])
+    packet = ReorientationPacket(summary="Return-to-work", source_refs=[_source()])
+
+    for artifact in (draft, candidate, packet):
+        assert artifact.canonical is False
+        assert artifact.trust_verb is TrustVerb.SUGGEST
+        assert artifact.admission_state is AdmissionState.PENDING_REVIEW
+        # Default authority posture is inform-only: never write/promote/act.
+        assert artifact.authority_limits.may_write is False
+        assert artifact.authority_limits.may_promote is False
+        assert artifact.authority_limits.may_authorize_action is False
+
+    # Provenance is mandatory: construction fails without at least one source_ref.
+    with pytest.raises(ValueError, match="requires at least one source_ref"):
+        CompilationDraft(title="No sources")
+
+    # Generated artifacts cannot be marked canonical.
+    with pytest.raises(ValueError, match="non-canonical"):
+        CurationCandidate(title="Tries canonical", source_refs=[_source()], canonical=True)
+
+    # Generated artifacts cannot self-escalate trust without explicit admission.
+    with pytest.raises(ValueError, match="without explicit admission"):
+        CompilationDraft(
+            title="Tries to assert",
+            source_refs=[_source()],
+            trust_verb=TrustVerb.APPLY,
+        )
+
+
+def test_reorientation_packet_is_bridge_artifact_not_memory_or_receipt_authority() -> None:
+    packet = ReorientationPacket(
+        summary="Resume work on X",
+        source_refs=[_source()],
+        memory_handoff_refs=["agentic_memory:cand_123"],
+        admission_receipt_ref="receipt:abc",
+    )
+
+    # Bridge/assembly classification.
+    assert packet.artifact_class == "reorientation_packet"
+    assert packet.artifact_class in BRIDGE_ARTIFACT_CLASSES
+    assert packet.is_bridge_artifact is True
+
+    # Not agent memory.
+    assert packet.artifact_class != AGENT_MEMORY_CLASS
+
+    # Not receipt authority: references receipts by id only, never *is* one.
+    assert isinstance(packet.admission_receipt_ref, str)
+    assert packet.grants_receipt_authority is False
+
+    # References memory by id only — it does not embed or become memory.
+    assert packet.memory_handoff_refs == ["agentic_memory:cand_123"]
+    assert packet.canonical is False
+
+    # Compilation/curation outputs are not bridge artifacts — the classification is meaningful.
+    draft = CompilationDraft(title="d", source_refs=[_source()])
+    assert draft.is_bridge_artifact is False
+
+
+def test_unreviewed_memory_and_rankings_cannot_grant_hidden_authority() -> None:
+    # Provenance carrying unreviewed memory, embeddings, retrieval scores, generated summaries.
+    hidden_authority_sources = [
+        SourceRef(artifact_id="agentic_memory:cand_x", review_state="unreviewed"),
+        SourceRef(artifact_id="embed:chunk_y", derived_by="embedding", retrieval_score=0.99),
+        SourceRef(artifact_id="summary:z", derived_by="generated_summary"),
+    ]
+    draft = CompilationDraft(title="From rankings", source_refs=hidden_authority_sources)
+
+    # High retrieval scores / unreviewed memory / generated summaries never elevate authority.
+    assert draft.authority_limits.may_write is False
+    assert draft.authority_limits.may_promote is False
+    assert draft.authority_limits.may_authorize_action is False
+    assert draft.trust_verb is TrustVerb.SUGGEST
+
+    # Explicitly trying to hand a generated artifact write/action authority is refused.
+    with pytest.raises(ValueError, match="hidden authority"):
+        CompilationDraft(
+            title="Tries to grab write authority",
+            source_refs=hidden_authority_sources,
+            authority_limits=ContextAuthorityLimits(may_write=True),
+        )
+    with pytest.raises(ValueError, match="hidden authority"):
+        ReorientationPacket(
+            summary="Tries to authorize action",
+            source_refs=[_source()],
+            authority_limits=ContextAuthorityLimits(may_authorize_action=True),
+        )
+
+
+_FORBIDDEN_IMPORT_SUBSTRINGS = (
+    "sqlalchemy",
+    "app.db",
+    "app.io",
+    "app.objects",
+    "app.index",
+    "app.outbox",
+    "objectstore",
+    "knowledgeport",
+    "vaultport",
+    "writeguard",
+    "outbox",
+)
+
+# Identifiers that would imply storage/vault/outbox/filesystem write wiring. Checked
+# against actual usage (Name/Attribute/import nodes) via AST, not raw text, so the module
+# may still describe its own constraints in docstrings.
+_FORBIDDEN_SYMBOLS = (
+    "ObjectStore",
+    "KnowledgePort",
+    "VaultPort",
+    "WriteGuard",
+    "Session",
+    "sessionmaker",
+    "open",
+)
+
+
+def test_runtime_artifacts_are_pure_domain_no_db_or_vault_writes() -> None:
+    src = inspect.getsource(runtime_artifacts)
+    tree = ast.parse(src)
+
+    imported_modules: set[str] = set()
+    used_names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.update(alias.name.lower() for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            module = (node.module or "").lower()
+            imported_modules.add(module)
+            for alias in node.names:
+                imported_modules.add(f"{module}.{alias.name}".lower())
+                used_names.add(alias.asname or alias.name)
+        elif isinstance(node, ast.Name):
+            used_names.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            used_names.add(node.attr)
+
+    for forbidden in _FORBIDDEN_IMPORT_SUBSTRINGS:
+        assert not any(forbidden in mod for mod in imported_modules), (
+            f"runtime_artifacts must not import {forbidden!r}; imports={sorted(imported_modules)}"
+        )
+
+    # No DB/vault/outbox/filesystem-write symbols referenced anywhere in the module.
+    for symbol in _FORBIDDEN_SYMBOLS:
+        assert symbol not in used_names, f"runtime_artifacts must not reference {symbol!r}"


### PR DESCRIPTION
Fixes #1534

## Change Lane
- [x] Implementation lane

## Summary
- First executable slice of the v6.x Knowledge Compilation & Memory Curation runtime foundation (parent #1533).
- Adds `app/knowledge_compilation/runtime_artifacts.py`: pure runtime/domain models `CompilationDraft`, `CurationCandidate`, `ReorientationPacket` (shared base `GeneratedArtifact`), plus `TrustVerb`, `AdmissionState`, `SourceRef`, and `ContextAuthorityLimits`.
- Generated artifacts default to `canonical=False`, `trust_verb=SUGGEST`, `admission_state=pending_review`; require ≥1 `source_ref` before construction; refuse `may_write` / `may_promote` / `may_authorize_action`; and cannot self-escalate trust without explicit admission.
- `ReorientationPacket` is modeled as a bridge/assembly artifact (`is_bridge_artifact`), distinct from agent memory and from receipt authority (references receipts/memory by id only).

## Implementation Scope Check
- [x] Change stays within the linked Issue scope (pure contracts; no storage/API/events/UI).
- [x] Constraints followed: non-canonical default, no DB imports, no event changes, no hidden authority.
- [x] Acceptance Criteria satisfied — each maps to a passing test (see Validation).
- [x] No behavior/contract docs required in this slice; owner-doc promotion is deferred to parent (#1533) feature validation per the epic contract.

## Acceptance Criteria → Verify
- Non-canonical / SUGGEST / provenance-required → `tests/knowledge_compilation/test_runtime_artifacts.py::test_generated_artifacts_default_to_noncanonical_suggest_posture`
- Packet is bridge artifact, not memory/receipt authority → `::test_reorientation_packet_is_bridge_artifact_not_memory_or_receipt_authority`
- No hidden authority from memory/embeddings/rankings → `::test_unreviewed_memory_and_rankings_cannot_grant_hidden_authority`
- Pure domain, no DB/Vault/outbox/filesystem-write imports → `::test_runtime_artifacts_are_pure_domain_no_db_or_vault_writes`

## Validation
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/knowledge_compilation/test_runtime_artifacts.py` → **4 passed**
- [x] `ruff check app tests` → **All checks passed!**
- [x] `mypy app/knowledge_compilation` → **Success: no issues found**
- Change is additive only (new package + new tests; no existing module edited), so existing-suite risk is minimal.

## BuilderOps Routing
- Records/projections/receipts: LearningSignal `lrn_20260602204523_13d86428` (workflow_divergence) — publish-pr PR-body templates omit the `## BuilderOps Routing` section that `pr-contract` enforces.
- Reason: The #1534 implementation produced no plan/doc/contract divergence; the single signal recorded is a delivery-workflow gap, captured via capture-learning per the BuilderOps checkpoint.

## Notes
- Dispatcher unavailable (`db_exists: false`) — used GitHub-label-only claim per AGENTS.md fallback.
- Delivered in isolated worktree `agentic-pkm-mvp-1534` off `origin/main`; the in-flight governance branch was untouched.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)