### PR TITLE
chore(builderops): ignore local runtime store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ tmp/index-outbox.jsonl
 *.jsonl
 tmp/index.jsonl
 runtime/settings/
+runtime/builderops/
 runtime/dispatcher/
 runtime/orientation/
 verification_report.md

--- a/docs/builderops/BUILDEROPS_VAULT_STORE.md
+++ b/docs/builderops/BUILDEROPS_VAULT_STORE.md
@@ -85,8 +85,8 @@ Override mechanisms:
 - API/tool callers may set `builderops_db_path` through tool settings or `BUILDEROPS_DB_PATH`
   through the environment; see `docs/builderops/BUILDEROPS_VAULT_BOUNDARY.md`.
 
-The default path is repo-local runtime state. It is not `$CODEX_HOME`, not local hidden memory, and
-not a reviewed docs surface.
+The default path is repo-local runtime state and is ignored by Git via `runtime/builderops/`. It is
+not `$CODEX_HOME`, not local hidden memory, not repo authority, and not a reviewed docs surface.
 
 ## CLI
 


### PR DESCRIPTION
## Direct Repair
Type: governance
Reason: BuilderOps creates repo-local SQLite runtime state under runtime/builderops; without an ignore rule it appears as untracked repo work and confuses authority boundaries.
Validation: git diff --check; python3 scripts/docs_guard.py; git status --short --ignored=matching runtime .gitignore docs/builderops/BUILDEROPS_VAULT_STORE.md
Issue required: no - bounded local-state hygiene repair

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: This PR only marks the existing BuilderOps runtime store path as ignored local operational state and documents the boundary; no BuilderOps material was processed.

## Summary
- Ignore `runtime/builderops/` alongside other repo-local runtime state directories.
- Clarify that the default BuilderOps SQLite path is git-ignored runtime state, not repo authority.

## Validation
- git diff --check
- python3 scripts/docs_guard.py -> Docs guard: OK
- git status --short --ignored=matching runtime .gitignore docs/builderops/BUILDEROPS_VAULT_STORE.md -> `runtime/builderops/` and `runtime/orientation/` show as ignored, not untracked