### PR TITLE
Add deterministic Knowledge Compilation proposal builders (#1535)

### DIFF
--- a/app/knowledge_compilation/__init__.py
+++ b/app/knowledge_compilation/__init__.py
@@ -1,9 +1,15 @@
 """v6.x Knowledge Compilation and Memory Curation runtime foundation (parent #1533).
 
-Slice #1534 ships the pure runtime artifact contracts only. See
-``app.knowledge_compilation.runtime_artifacts``.
+Slice #1534 ships the pure runtime artifact contracts
+(``app.knowledge_compilation.runtime_artifacts``); slice #1535 adds the deterministic
+proposal builders (``app.knowledge_compilation.proposal_builders``).
 """
 
+from app.knowledge_compilation.proposal_builders import (
+    ProposalContext,
+    build_compilation_draft,
+    build_curation_candidate,
+)
 from app.knowledge_compilation.runtime_artifacts import (
     AGENT_MEMORY_CLASS,
     BRIDGE_ARTIFACT_CLASSES,
@@ -31,7 +37,10 @@ __all__ = [
     "ContextAuthorityLimits",
     "CurationCandidate",
     "GeneratedArtifact",
+    "ProposalContext",
     "ReorientationPacket",
     "SourceRef",
     "TrustVerb",
+    "build_compilation_draft",
+    "build_curation_candidate",
 ]

--- a/app/knowledge_compilation/proposal_builders.py
+++ b/app/knowledge_compilation/proposal_builders.py
@@ -1,0 +1,126 @@
+"""Deterministic, provider-free proposal builders for v6.x Knowledge Compilation.
+
+Child slice #1535 under parent feature #1533. Builds ``CompilationDraft`` and
+``CurationCandidate`` proposals (the runtime contracts from #1534) out of explicitly
+supplied, *approved* context — preserving provenance, uncertainty, exclusions, rationale,
+trust posture, and trace ids, and refusing to launder hidden authority from unreviewed
+memory, embeddings, retrieval ranking, generated summaries, stale inputs, or
+write-authorizing bundles.
+
+Authority posture follows ``docs/CONCEPTS/TRUST_SEMANTICS_CONTRACT.md`` (SUGGEST / no
+laundering) and ``docs/CONTEXTUALIZATION_LAYER/CONTEXT_ACTIVATION_SEMANTICS.md`` (activation
+rights / hidden-authority guard).
+
+This module is pure, deterministic domain code: no LLM/provider call, no events, no vault
+writes, no database/object-store/port writes, no API/UI wiring.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.knowledge_compilation.runtime_artifacts import (
+    CompilationDraft,
+    ContextAuthorityLimits,
+    CurationCandidate,
+    SourceRef,
+)
+
+# ``derived_by`` values that mark machine-derived material which must not be laundered into a
+# proposal's authority (it is a ranking/synthesis signal, not approved human authority).
+_MACHINE_DERIVATIONS: frozenset[str] = frozenset(
+    {"embedding", "generated_summary", "summary", "retrieval", "rerank"}
+)
+
+
+class ProposalContext(BaseModel):
+    """Explicitly supplied, approved context for deterministic proposal building.
+
+    The context is the builder's only input — there is no provider call or retrieval inside
+    the builder. ``authority_limits`` records the posture of the supplying bundle; a
+    write/promote/action-authorizing bundle is refused rather than laundered into a proposal.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    source_refs: tuple[SourceRef, ...] = Field(default_factory=tuple)
+    authority_limits: ContextAuthorityLimits = Field(default_factory=ContextAuthorityLimits)
+    stale: bool = False
+    content: Optional[str] = None
+    uncertainty_notes: Optional[str] = None
+    rationale: Optional[str] = None
+    excluded_refs: tuple[SourceRef, ...] = Field(default_factory=tuple)
+    generated_by: Optional[str] = None
+    trace_ref: Optional[str] = None
+
+
+def _reject_hidden_authority(context: ProposalContext) -> None:
+    """Refuse context that would launder hidden authority into a generated proposal.
+
+    Raises ``ValueError`` rather than silently degrading the input, so a builder never turns
+    unreviewed/ranked/derived/stale/write-authorizing material into proposal authority.
+    """
+
+    if not context.source_refs:
+        raise ValueError("proposal context requires provenance: at least one source_ref")
+    if context.stale:
+        raise ValueError("proposal context is stale; refusing to build a proposal from stale input")
+    limits = context.authority_limits
+    if limits.may_write or limits.may_promote or limits.may_authorize_action:
+        raise ValueError(
+            "proposal context is write-authorizing; refusing to launder action authority "
+            "into a non-canonical proposal"
+        )
+    for ref in context.source_refs:
+        if (ref.review_state or "").strip().lower() == "unreviewed":
+            raise ValueError(
+                f"unreviewed source {ref.artifact_id!r} cannot be laundered into a proposal"
+            )
+        if ref.retrieval_score is not None:
+            raise ValueError(
+                f"retrieval-ranked source {ref.artifact_id!r} is a ranking signal, not approved "
+                f"authority"
+            )
+        if (ref.derived_by or "").strip().lower() in _MACHINE_DERIVATIONS:
+            raise ValueError(
+                f"machine-derived source {ref.artifact_id!r} ({ref.derived_by}) is not approved "
+                f"authority"
+            )
+
+
+def build_compilation_draft(context: ProposalContext, *, title: str) -> CompilationDraft:
+    """Build a non-canonical ``CompilationDraft`` from approved context.
+
+    Preserves source refs, body content, uncertainty posture, and trace id. The output's
+    non-canonical / SUGGEST / pending-review posture is guaranteed by the #1534 contract.
+    """
+
+    _reject_hidden_authority(context)
+    return CompilationDraft(
+        title=title,
+        source_refs=context.source_refs,
+        body=context.content,
+        uncertainty_notes=context.uncertainty_notes,
+        generated_by=context.generated_by,
+        trace_ref=context.trace_ref,
+    )
+
+
+def build_curation_candidate(context: ProposalContext, *, title: str) -> CurationCandidate:
+    """Build a non-canonical ``CurationCandidate`` from approved context.
+
+    Preserves retained-material rationale, source links, and the excluded refs (which carry
+    their exclusion reason on the ref), without dropping or downgrading provenance.
+    """
+
+    _reject_hidden_authority(context)
+    return CurationCandidate(
+        title=title,
+        source_refs=context.source_refs,
+        rationale=context.rationale,
+        excluded_refs=context.excluded_refs,
+        generated_by=context.generated_by,
+        trace_ref=context.trace_ref,
+    )

--- a/tests/knowledge_compilation/test_proposal_builders.py
+++ b/tests/knowledge_compilation/test_proposal_builders.py
@@ -1,0 +1,172 @@
+"""Proposal-builder tests for v6.x Knowledge Compilation (#1535, parent #1533).
+
+Deterministic, provider-free builders that turn explicitly supplied, approved context into
+non-canonical CompilationDraft / CurationCandidate proposals — without laundering hidden
+authority and without storage/API/event/UI wiring.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+
+import pytest
+
+import app.knowledge_compilation.proposal_builders as proposal_builders
+from app.knowledge_compilation.proposal_builders import (
+    ProposalContext,
+    build_compilation_draft,
+    build_curation_candidate,
+)
+from app.knowledge_compilation.runtime_artifacts import (
+    AdmissionState,
+    CompilationDraft,
+    ContextAuthorityLimits,
+    CurationCandidate,
+    SourceRef,
+    TrustVerb,
+)
+
+
+def _clean_source() -> SourceRef:
+    return SourceRef(artifact_id="note:x", note_path="vault://x.md", role="source")
+
+
+def test_compilation_draft_preserves_source_refs_and_uncertainty() -> None:
+    src = _clean_source()
+    ctx = ProposalContext(
+        source_refs=(src,),
+        content="synthesis body",
+        uncertainty_notes="two sources disagree on the date",
+        trace_ref="trace:abc",
+        generated_by="compiler",
+    )
+    draft = build_compilation_draft(ctx, title="Draft A")
+
+    assert isinstance(draft, CompilationDraft)
+    assert draft.source_refs == (src,)
+    assert draft.body == "synthesis body"
+    assert draft.uncertainty_notes == "two sources disagree on the date"
+    assert draft.trace_ref == "trace:abc"
+    assert draft.generated_by == "compiler"
+    # Non-canonical, suggest-only posture preserved from the #1534 contract.
+    assert draft.canonical is False
+    assert draft.trust_verb is TrustVerb.SUGGEST
+    assert draft.admission_state is AdmissionState.PENDING_REVIEW
+
+
+def test_curation_candidate_preserves_rationale_and_exclusions() -> None:
+    kept = SourceRef(artifact_id="note:keep", role="retained")
+    excluded = SourceRef(artifact_id="note:old", role="excluded: superseded by note:keep")
+    ctx = ProposalContext(
+        source_refs=(kept,),
+        rationale="retain the primary; the newer source supersedes the older draft",
+        excluded_refs=(excluded,),
+    )
+    candidate = build_curation_candidate(ctx, title="Curation A")
+
+    assert isinstance(candidate, CurationCandidate)
+    assert candidate.source_refs == (kept,)
+    assert candidate.rationale == "retain the primary; the newer source supersedes the older draft"
+    # Excluded source links and their reasons (carried on the ref) are preserved, not dropped.
+    assert candidate.excluded_refs == (excluded,)
+    assert candidate.canonical is False
+    assert candidate.trust_verb is TrustVerb.SUGGEST
+
+
+def test_builders_reject_hidden_authority_context() -> None:
+    clean = _clean_source()
+
+    # Unprovenanced context.
+    with pytest.raises(ValueError, match="provenance"):
+        build_compilation_draft(ProposalContext(source_refs=()), title="t")
+
+    # Stale inputs.
+    with pytest.raises(ValueError, match="stale"):
+        build_compilation_draft(ProposalContext(source_refs=(clean,), stale=True), title="t")
+
+    # Write-authorizing context bundle.
+    with pytest.raises(ValueError, match="write-authorizing"):
+        build_curation_candidate(
+            ProposalContext(
+                source_refs=(clean,),
+                authority_limits=ContextAuthorityLimits(may_write=True),
+            ),
+            title="t",
+        )
+
+    # Unreviewed memory laundering.
+    with pytest.raises(ValueError, match="unreviewed"):
+        build_compilation_draft(
+            ProposalContext(source_refs=(SourceRef(artifact_id="m", review_state="unreviewed"),)),
+            title="t",
+        )
+
+    # Retrieval-ranked source presented as approved authority.
+    with pytest.raises(ValueError, match="retrieval"):
+        build_compilation_draft(
+            ProposalContext(source_refs=(SourceRef(artifact_id="r", retrieval_score=0.92),)),
+            title="t",
+        )
+
+    # Machine-derived (embedding / generated summary) source.
+    with pytest.raises(ValueError, match="machine-derived"):
+        build_curation_candidate(
+            ProposalContext(source_refs=(SourceRef(artifact_id="s", derived_by="generated_summary"),)),
+            title="t",
+        )
+
+
+_FORBIDDEN_IMPORT_SUBSTRINGS = (
+    "sqlalchemy",
+    "app.db",
+    "app.io",
+    "app.objects",
+    "app.index",
+    "app.outbox",
+    "app.events",
+    "objectstore",
+    "knowledgeport",
+    "vaultport",
+    "writeguard",
+    "outbox",
+)
+
+_FORBIDDEN_SYMBOLS = (
+    "ObjectStore",
+    "KnowledgePort",
+    "VaultPort",
+    "WriteGuard",
+    "Session",
+    "sessionmaker",
+    "emit",
+    "open",
+)
+
+
+def test_builders_do_not_emit_events_write_vault_or_import_db() -> None:
+    src = inspect.getsource(proposal_builders)
+    tree = ast.parse(src)
+
+    imported_modules: set[str] = set()
+    used_names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.update(alias.name.lower() for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            module = (node.module or "").lower()
+            imported_modules.add(module)
+            for alias in node.names:
+                imported_modules.add(f"{module}.{alias.name}".lower())
+                used_names.add(alias.asname or alias.name)
+        elif isinstance(node, ast.Name):
+            used_names.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            used_names.add(node.attr)
+
+    for forbidden in _FORBIDDEN_IMPORT_SUBSTRINGS:
+        assert not any(forbidden in mod for mod in imported_modules), (
+            f"proposal_builders must not import {forbidden!r}; imports={sorted(imported_modules)}"
+        )
+    for symbol in _FORBIDDEN_SYMBOLS:
+        assert symbol not in used_names, f"proposal_builders must not reference {symbol!r}"


### PR DESCRIPTION
Fixes #1535

## Change Lane
- [x] Implementation lane

## Summary
- Slice #1535 under parent #1533: deterministic, provider-free proposal builders on top of the #1534 contracts.
- Adds `app/knowledge_compilation/proposal_builders.py`: `ProposalContext` input model plus `build_compilation_draft` and `build_curation_candidate`.
- Builders preserve source refs, body/uncertainty, rationale, excluded refs (with their reasons), trust posture, and trace ids; outputs stay non-canonical / SUGGEST / pending-review via the #1534 model.
- `_reject_hidden_authority` refuses unprovenanced, stale, unreviewed, retrieval-ranked, machine-derived, or write-authorizing context rather than laundering it into a proposal.

## Implementation Scope Check
- [x] Within Issue scope (builders only; artifact models unchanged from #1534).
- [x] Constraints followed: non-canonical outputs, no provider/LLM, no events, no DB/vault writes, no API/UI.
- [x] Acceptance Criteria satisfied — each maps to a passing test.

## Acceptance Criteria → Verify
- Draft preserves source refs + uncertainty → `tests/knowledge_compilation/test_proposal_builders.py::test_compilation_draft_preserves_source_refs_and_uncertainty`
- Candidate preserves rationale + exclusions → `::test_curation_candidate_preserves_rationale_and_exclusions`
- Reject hidden-authority context → `::test_builders_reject_hidden_authority_context`
- No events/vault/DB/port writes (pure) → `::test_builders_do_not_emit_events_write_vault_or_import_db`

## Validation
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/knowledge_compilation/test_proposal_builders.py tests/knowledge_compilation/test_runtime_artifacts.py` → **12 passed**
- [x] `ruff check app tests` → **All checks passed!**
- [x] `mypy app/knowledge_compilation` → **Success**

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded slice delivered as specified; no plan/doc/contract divergence (the publish-pr template gap was already captured as LearningSignal lrn_20260602204523_13d86428 under #1534).

## Notes
- Dispatcher unavailable (`db_exists: false`) — GitHub-label claim. Delivered in isolated worktree `agentic-pkm-mvp-1535` off `origin/main` (incl. merged #1534).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)