### PR TITLE
Add read-only Knowledge Compilation reorientation packet assembly (#1536)

### DIFF
--- a/app/knowledge_compilation/__init__.py
+++ b/app/knowledge_compilation/__init__.py
@@ -2,7 +2,8 @@
 
 Slice #1534 ships the pure runtime artifact contracts
 (``app.knowledge_compilation.runtime_artifacts``); slice #1535 adds the deterministic
-proposal builders (``app.knowledge_compilation.proposal_builders``).
+proposal builders (``app.knowledge_compilation.proposal_builders``); slice #1536 adds
+read-only reorientation packet assembly (``app.knowledge_compilation.reorientation_packet``).
 """
 
 from app.knowledge_compilation.proposal_builders import (
@@ -25,6 +26,10 @@ from app.knowledge_compilation.runtime_artifacts import (
     SourceRef,
     TrustVerb,
 )
+from app.knowledge_compilation.reorientation_packet import (
+    PacketAssemblyError,
+    assemble_reorientation_packet_from_bundle,
+)
 
 __all__ = [
     "AGENT_MEMORY_CLASS",
@@ -37,10 +42,12 @@ __all__ = [
     "ContextAuthorityLimits",
     "CurationCandidate",
     "GeneratedArtifact",
+    "PacketAssemblyError",
     "ProposalContext",
     "ReorientationPacket",
     "SourceRef",
     "TrustVerb",
+    "assemble_reorientation_packet_from_bundle",
     "build_compilation_draft",
     "build_curation_candidate",
 ]

--- a/app/knowledge_compilation/reorientation_packet.py
+++ b/app/knowledge_compilation/reorientation_packet.py
@@ -86,6 +86,8 @@ def _memory_handoff_refs(
 ) -> tuple[str, ...]:
     if max_memory_handoff_refs < 0:
         raise PacketAssemblyError("max_memory_handoff_refs must be non-negative")
+    if max_memory_handoff_refs == 0:
+        return ()
     refs: list[str] = []
     for item in included:
         role = (item.source_role or "").lower()

--- a/app/knowledge_compilation/reorientation_packet.py
+++ b/app/knowledge_compilation/reorientation_packet.py
@@ -1,0 +1,177 @@
+"""Assemble read-only ReorientationPacket supports from orientation context bundles.
+
+Slice #1536 under parent feature #1533. This module stays pure-domain: it consumes
+already-approved orientation/context-bundle inputs and returns a non-canonical
+``ReorientationPacket`` without storage, API, event emission, or mutation behavior.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from app.context_bundles.schema import ContextBundle, ExcludedItem, IncludedItem
+from app.knowledge_compilation.runtime_artifacts import (
+    AGENT_MEMORY_CLASS,
+    ReorientationPacket,
+    SourceRef,
+)
+from app.orientation.bundle_consumer import build_orientation_frame_from_bundle
+
+
+class PacketAssemblyError(ValueError):
+    """Raised when packet assembly would cross the read-only orientation boundary."""
+
+
+_MUTATION_SOURCE_ROLES = {
+    "action",
+    "apply",
+    "mutation",
+    "mutation_intent",
+    "write",
+    "write_intent",
+    "write_proposal",
+}
+
+
+def _bounded(text: str, limit: int) -> str:
+    if limit < 1:
+        raise PacketAssemblyError("max_summary_chars must be positive")
+    if len(text) <= limit:
+        return text
+    if limit <= 3:
+        return text[:limit]
+    return f"{text[: limit - 3]}..."
+
+
+def _source_ref_from_included(item: IncludedItem) -> SourceRef:
+    provenance = item.provenance
+    return SourceRef(
+        artifact_id=item.artifact_id,
+        note_path=item.path,
+        role=item.source_role or "orientation_context",
+        review_state=item.review_state,
+        retrieval_score=item.retrieval_score,
+        derived_by=provenance.transformed_by if provenance else None,
+    )
+
+
+def _source_ref_from_excluded(item: ExcludedItem) -> SourceRef:
+    provenance = item.provenance
+    return SourceRef(
+        artifact_id=item.artifact_id,
+        role="excluded",
+        review_state=item.review_state,
+        derived_by=provenance.transformed_by if provenance else None,
+    )
+
+
+def _reject_mutation_inputs(bundle: ContextBundle) -> None:
+    for item in bundle.included:
+        role = (item.source_role or "").lower()
+        trust = (item.trust_state or "").upper()
+        if role in _MUTATION_SOURCE_ROLES:
+            raise PacketAssemblyError(
+                f"cannot assemble reorientation packet from mutation-scoped item {item.artifact_id}"
+            )
+        if trust == "APPLY":
+            raise PacketAssemblyError(
+                f"cannot assemble reorientation packet from APPLY-scoped item {item.artifact_id}"
+            )
+
+
+def _memory_handoff_refs(
+    included: list[IncludedItem],
+    *,
+    max_memory_handoff_refs: int,
+) -> tuple[str, ...]:
+    if max_memory_handoff_refs < 0:
+        raise PacketAssemblyError("max_memory_handoff_refs must be non-negative")
+    refs: list[str] = []
+    for item in included:
+        role = (item.source_role or "").lower()
+        if role == "memory_handoff" or item.artifact_id.startswith(f"{AGENT_MEMORY_CLASS}:"):
+            refs.append(item.artifact_id)
+        if len(refs) >= max_memory_handoff_refs:
+            break
+    return tuple(refs)
+
+
+def _summary(
+    bundle: ContextBundle,
+    *,
+    fact_count: int,
+    inference_count: int,
+    candidate_count: int,
+    excluded_count: int,
+    stale: bool,
+    max_summary_chars: int,
+) -> str:
+    text = (
+        f"bundle={bundle.id}; facts={fact_count}; inferences={inference_count}; "
+        f"candidate_refs={candidate_count}; exclusions={excluded_count}; stale={stale}"
+    )
+    return _bounded(text, max_summary_chars)
+
+
+def assemble_reorientation_packet_from_bundle(
+    bundle: ContextBundle,
+    *,
+    trace_ref: str,
+    now: datetime | None = None,
+    leave_point_ref: str | None = None,
+    max_source_refs: int = 12,
+    max_memory_handoff_refs: int = 8,
+    max_summary_chars: int = 240,
+) -> ReorientationPacket:
+    """Create a reference-only packet for return-to-work orientation.
+
+    The existing orientation bundle consumer performs the main authority checks:
+    ``may_orient`` must be true, ``may_write`` must be false, and the bundle must be
+    scoped for ``orient`` use. This assembly layer adds packet-specific refusal of
+    mutation/APPLY inputs, caps copied references, and keeps memory handoff hints as
+    identifiers only.
+    """
+
+    if not trace_ref.strip():
+        raise PacketAssemblyError("trace_ref is required for packet assembly")
+    if max_source_refs < 1:
+        raise PacketAssemblyError("max_source_refs must be positive")
+
+    frame = build_orientation_frame_from_bundle(bundle, now=now)
+    _reject_mutation_inputs(bundle)
+
+    source_refs = tuple(
+        _source_ref_from_included(item) for item in bundle.included[:max_source_refs]
+    )
+    excluded_refs = tuple(_source_ref_from_excluded(item) for item in bundle.excluded)
+    exclusion_reasons = tuple(item.reason for item in bundle.excluded)
+
+    return ReorientationPacket(
+        summary=_summary(
+            bundle,
+            fact_count=len(frame.facts),
+            inference_count=len(frame.inferences),
+            candidate_count=len(frame.candidate_actions),
+            excluded_count=len(frame.exclusions),
+            stale=frame.stale,
+            max_summary_chars=max_summary_chars,
+        ),
+        source_refs=source_refs,
+        trace_ref=trace_ref,
+        generated_by="knowledge_compilation.reorientation_packet",
+        leave_point_ref=leave_point_ref,
+        memory_handoff_refs=_memory_handoff_refs(
+            bundle.included,
+            max_memory_handoff_refs=max_memory_handoff_refs,
+        ),
+        stale_after=bundle.expiry.stale_after,
+        stale_reason=frame.stale_reason,
+        excluded_refs=excluded_refs,
+        exclusion_reasons=exclusion_reasons,
+    )
+
+
+__all__ = [
+    "PacketAssemblyError",
+    "assemble_reorientation_packet_from_bundle",
+]

--- a/app/knowledge_compilation/runtime_artifacts.py
+++ b/app/knowledge_compilation/runtime_artifacts.py
@@ -279,3 +279,6 @@ class ReorientationPacket(GeneratedArtifact):
     leave_point_ref: Optional[str] = None  # reference only
     memory_handoff_refs: tuple[str, ...] = Field(default_factory=tuple)  # reference-only ids
     stale_after: Optional[datetime] = None
+    stale_reason: Optional[str] = None
+    excluded_refs: tuple[SourceRef, ...] = Field(default_factory=tuple)
+    exclusion_reasons: tuple[str, ...] = Field(default_factory=tuple)

--- a/tests/knowledge_compilation/test_reorientation_packet.py
+++ b/tests/knowledge_compilation/test_reorientation_packet.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import ast
+import inspect
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+import app.knowledge_compilation.reorientation_packet as reorientation_packet
+from app.context_bundles.schema import (
+    AuthorityFlags,
+    BundleScope,
+    BundleTrigger,
+    ContextBundle,
+    ExcludedItem,
+    ExpiryPosture,
+    IncludedItem,
+    ItemProvenance,
+)
+from app.knowledge_compilation.reorientation_packet import (
+    PacketAssemblyError,
+    assemble_reorientation_packet_from_bundle,
+)
+from app.knowledge_compilation.runtime_artifacts import (
+    AdmissionState,
+    ReorientationPacket,
+    TrustVerb,
+)
+from app.orientation.bundle_consumer import BundleAuthorityViolation
+
+
+_NOW = datetime(2026, 6, 2, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _bundle(
+    *,
+    included: list[IncludedItem] | None = None,
+    excluded: list[ExcludedItem] | None = None,
+    authority: AuthorityFlags | None = None,
+    expiry: ExpiryPosture | None = None,
+    intended_use: list[str] | None = None,
+) -> ContextBundle:
+    return ContextBundle(
+        id="ctx_return_to_work",
+        created_at=_NOW,
+        trigger=BundleTrigger(type="orientation", source="test"),
+        intended_use=intended_use or ["orient"],
+        scope=BundleScope(project="knowledge-compilation"),
+        included=included or [],
+        excluded=excluded or [],
+        authority=authority or AuthorityFlags(may_orient=True),
+        expiry=expiry or ExpiryPosture(),
+    )
+
+
+def _included(
+    artifact_id: str,
+    *,
+    path: str | None = None,
+    reason: str = "return-to-work source",
+    source_role: str | None = None,
+    trust_state: str | None = "reviewed",
+    review_state: str | None = "confirmed",
+    retrieval_score: float | None = None,
+    provenance: ItemProvenance | None = None,
+) -> IncludedItem:
+    return IncludedItem(
+        artifact_id=artifact_id,
+        path=path,
+        reason=reason,
+        source_role=source_role,
+        trust_state=trust_state,
+        review_state=review_state,
+        retrieval_score=retrieval_score,
+        provenance=provenance or ItemProvenance(origin="vault note"),
+    )
+
+
+def test_reorientation_packet_projects_read_only_orientation_context() -> None:
+    bundle = _bundle(
+        included=[
+            _included("note:one", path="vault://one.md"),
+            _included("note:two", path="vault://two.md", source_role="inference"),
+        ]
+    )
+
+    packet = assemble_reorientation_packet_from_bundle(
+        bundle,
+        trace_ref="trace:return-to-work:1",
+        now=_NOW,
+    )
+
+    assert isinstance(packet, ReorientationPacket)
+    assert packet.is_bridge_artifact is True
+    assert packet.trust_verb is TrustVerb.SUGGEST
+    assert packet.admission_state is AdmissionState.PENDING_REVIEW
+    assert packet.authority_limits.may_orient is True
+    assert packet.authority_limits.may_write is False
+    assert packet.authority_limits.may_promote is False
+    assert packet.authority_limits.may_authorize_action is False
+    assert packet.trace_ref == "trace:return-to-work:1"
+    assert [ref.artifact_id for ref in packet.source_refs] == ["note:one", "note:two"]
+
+
+def test_packet_preserves_trace_staleness_and_caps_content() -> None:
+    stale_after = _NOW - timedelta(minutes=5)
+    included = [
+        _included(
+            f"note:{idx}",
+            path=f"vault://note-{idx}.md",
+            reason="long reason text that should not become unbounded packet body",
+            retrieval_score=0.5,
+        )
+        for idx in range(6)
+    ]
+    excluded = [
+        ExcludedItem(
+            artifact_id="note:excluded",
+            reason="stale source",
+            trust_state="stale",
+            provenance=ItemProvenance(origin="vault note"),
+        )
+    ]
+    bundle = _bundle(
+        included=included,
+        excluded=excluded,
+        expiry=ExpiryPosture(stale_after=stale_after, reason="bundle expired"),
+    )
+
+    packet = assemble_reorientation_packet_from_bundle(
+        bundle,
+        trace_ref="trace:return-to-work:2",
+        now=_NOW,
+        max_source_refs=3,
+        max_summary_chars=96,
+    )
+
+    assert packet.trace_ref == "trace:return-to-work:2"
+    assert packet.stale_after == stale_after
+    assert packet.stale_reason == "bundle expired"
+    assert len(packet.source_refs) == 3
+    assert len(packet.summary or "") <= 96
+    assert "long reason text" not in (packet.summary or "")
+    assert [ref.artifact_id for ref in packet.excluded_refs] == ["note:excluded"]
+    assert packet.exclusion_reasons == ("stale source",)
+
+
+def test_packet_exposes_reference_only_memory_handoff() -> None:
+    bundle = _bundle(
+        included=[
+            _included(
+                "agentic_memory:cand_123",
+                reason="raw candidate content must not be copied into packet",
+                source_role="memory_handoff",
+                trust_state="unreviewed",
+                review_state="pending",
+                provenance=ItemProvenance(origin="orientation intent"),
+            )
+        ]
+    )
+
+    packet = assemble_reorientation_packet_from_bundle(
+        bundle,
+        trace_ref="trace:return-to-work:3",
+        now=_NOW,
+    )
+
+    assert packet.memory_handoff_refs == ("agentic_memory:cand_123",)
+    assert "raw candidate content" not in (packet.summary or "")
+    assert packet.admission_receipt_ref is None
+    assert packet.grants_receipt_authority is False
+    assert packet.authority_limits.may_write is False
+
+
+def test_packet_refuses_mutation_and_storage_paths() -> None:
+    write_bundle = _bundle(
+        included=[_included("note:one")],
+        authority=AuthorityFlags(may_orient=True, may_write=True),
+    )
+    with pytest.raises(BundleAuthorityViolation):
+        assemble_reorientation_packet_from_bundle(
+            write_bundle,
+            trace_ref="trace:return-to-work:4",
+            now=_NOW,
+        )
+
+    mutation_bundle = _bundle(
+        included=[
+            _included(
+                "intent:write",
+                source_role="mutation_intent",
+                trust_state="SUGGEST",
+            )
+        ]
+    )
+    with pytest.raises(PacketAssemblyError, match="mutation"):
+        assemble_reorientation_packet_from_bundle(
+            mutation_bundle,
+            trace_ref="trace:return-to-work:5",
+            now=_NOW,
+        )
+
+    apply_bundle = _bundle(
+        included=[_included("note:apply", trust_state="APPLY")],
+    )
+    with pytest.raises(PacketAssemblyError, match="APPLY"):
+        assemble_reorientation_packet_from_bundle(
+            apply_bundle,
+            trace_ref="trace:return-to-work:6",
+            now=_NOW,
+        )
+
+    src = inspect.getsource(reorientation_packet)
+    tree = ast.parse(src)
+    imported_modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.update(alias.name.lower() for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imported_modules.add((node.module or "").lower())
+
+    forbidden = (
+        "sqlalchemy",
+        "app.db",
+        "app.objects",
+        "app.outbox",
+        "objectstore",
+        "knowledgeport",
+        "vaultport",
+        "writeguard",
+    )
+    assert not any(
+        bad in module for bad in forbidden for module in imported_modules
+    ), sorted(imported_modules)

--- a/tests/knowledge_compilation/test_reorientation_packet.py
+++ b/tests/knowledge_compilation/test_reorientation_packet.py
@@ -171,6 +171,14 @@ def test_packet_exposes_reference_only_memory_handoff() -> None:
     assert packet.grants_receipt_authority is False
     assert packet.authority_limits.may_write is False
 
+    no_handoff_packet = assemble_reorientation_packet_from_bundle(
+        bundle,
+        trace_ref="trace:return-to-work:3",
+        now=_NOW,
+        max_memory_handoff_refs=0,
+    )
+    assert no_handoff_packet.memory_handoff_refs == ()
+
 
 def test_packet_refuses_mutation_and_storage_paths() -> None:
     write_bundle = _bundle(


### PR DESCRIPTION
Fixes #1536

## Summary
- Adds `app/knowledge_compilation/reorientation_packet.py` to assemble reference-only `ReorientationPacket` supports from orientation-scoped `ContextBundle` inputs.
- Preserves trace id, capped source references, exclusions, stale posture, and memory handoff references while keeping packets non-canonical, suggest-only, and read-only.
- Extends the `ReorientationPacket` model with stale/exclusion metadata and exports the assembly API through `app.knowledge_compilation`.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/knowledge_compilation/test_reorientation_packet.py tests/orientation/test_context_bundle_orientation.py` -> 11 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/knowledge_compilation/test_runtime_artifacts.py` -> 8 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/knowledge_compilation tests/orientation/test_context_bundle_orientation.py` -> 23 passed after rebasing on merged #1535
- `git diff --check` -> passed
- `ruff check app tests` -> not run locally; `ruff` is not installed in this shell
- `python3 -m ruff check app tests` -> not run locally; Python environment has no `ruff` module

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded issue-backed implementation; no new BuilderOps operational material, learning divergence, docs freshness finding, roadmap movement, or promotion intent was produced.

## Notes
- Dispatcher unavailable (`python3 -m app.dispatcher status --json` failed because this shell lacks `yaml`) — used the repo-approved GitHub-label-only claim fallback.
- Delivered in isolated worktree `/Users/rasmusthornberg/code/agentic-pkm-mvp-1536` on branch `codex/1536-reorientation-packet-runtime`.
- Rebases cleanly on merged #1535 / PR #1543.