### PR TITLE
Add Knowledge Compilation admission handoff (#1537)

### DIFF
--- a/app/knowledge_compilation/__init__.py
+++ b/app/knowledge_compilation/__init__.py
@@ -3,7 +3,9 @@
 Slice #1534 ships the pure runtime artifact contracts
 (``app.knowledge_compilation.runtime_artifacts``); slice #1535 adds the deterministic
 proposal builders (``app.knowledge_compilation.proposal_builders``); slice #1536 adds
-read-only reorientation packet assembly (``app.knowledge_compilation.reorientation_packet``).
+read-only reorientation packet assembly (``app.knowledge_compilation.reorientation_packet``);
+slice #1537 adds the explicit review/admission handoff
+(``app.knowledge_compilation.review_admission``).
 """
 
 from app.knowledge_compilation.proposal_builders import (
@@ -30,6 +32,16 @@ from app.knowledge_compilation.reorientation_packet import (
     PacketAssemblyError,
     assemble_reorientation_packet_from_bundle,
 )
+from app.knowledge_compilation.review_admission import (
+    AdmissionDecision,
+    AdmissionDecisionRecord,
+    AdmissionHandoff,
+    AdmissionHandoffError,
+    AdmissionReceiptPosture,
+    AdmissionScope,
+    record_admission_decision,
+    route_admitted_memory_to_review_queue,
+)
 
 __all__ = [
     "AGENT_MEMORY_CLASS",
@@ -38,6 +50,12 @@ __all__ = [
     "CURATION_CANDIDATE_CLASS",
     "REORIENTATION_PACKET_CLASS",
     "AdmissionState",
+    "AdmissionDecision",
+    "AdmissionDecisionRecord",
+    "AdmissionHandoff",
+    "AdmissionHandoffError",
+    "AdmissionReceiptPosture",
+    "AdmissionScope",
     "CompilationDraft",
     "ContextAuthorityLimits",
     "CurationCandidate",
@@ -50,4 +68,6 @@ __all__ = [
     "assemble_reorientation_packet_from_bundle",
     "build_compilation_draft",
     "build_curation_candidate",
+    "record_admission_decision",
+    "route_admitted_memory_to_review_queue",
 ]

--- a/app/knowledge_compilation/review_admission.py
+++ b/app/knowledge_compilation/review_admission.py
@@ -1,0 +1,221 @@
+"""Pure admission handoff for generated Knowledge Compilation artifacts.
+
+Child slice #1537 under parent feature #1533. This module records an explicit
+review/admission decision for generated runtime artifacts and can hand admitted,
+memory-like material to the existing in-memory review queue. It does not promote,
+store, emit, write, or mutate durable memory.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.agent_memory.candidate import MemoryCandidate, MemoryType
+from app.agent_memory.review_queue import MemoryCandidateReviewQueue, ReviewEntry
+from app.knowledge_compilation.runtime_artifacts import (
+    AdmissionState,
+    CompilationDraft,
+    ContextAuthorityLimits,
+    CurationCandidate,
+    GeneratedArtifact,
+    ReorientationPacket,
+    SourceRef,
+    TrustVerb,
+)
+
+
+AdmissibleArtifact = CompilationDraft | CurationCandidate | ReorientationPacket
+
+
+class AdmissionHandoffError(Exception):
+    """Raised when an admission handoff would bypass the explicit review boundary."""
+
+
+class AdmissionDecision(str, Enum):
+    ADMIT = "admit"
+    REJECT = "reject"
+    REVISE = "revise"
+
+
+class AdmissionScope(str, Enum):
+    COMPILATION_REVIEW = "compilation_review"
+    CURATION_REVIEW = "curation_review"
+    MEMORY_REVIEW_QUEUE = "memory_review_queue"
+    ORIENTATION_ONLY = "orientation_only"
+
+
+class AdmissionReceiptPosture(str, Enum):
+    DURABLE_RECEIPT_REF = "durable_receipt_ref"
+
+
+class AdmissionDecisionRecord(BaseModel):
+    """Explicit admission decision and receipt posture for a generated artifact."""
+
+    model_config = ConfigDict(frozen=True)
+
+    reviewer_ref: str
+    actor_ref: str
+    decision: AdmissionDecision
+    scope: AdmissionScope
+    authority_basis: str
+    receipt_ref: str
+    receipt_posture: AdmissionReceiptPosture
+    decision_notes: Optional[str] = None
+    decided_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+    @model_validator(mode="after")
+    def _require_explicit_fields(self) -> "AdmissionDecisionRecord":
+        for field_name in ("reviewer_ref", "actor_ref", "authority_basis", "receipt_ref"):
+            value = getattr(self, field_name)
+            if not value.strip():
+                raise ValueError(f"{field_name} is required for admission handoff")
+        return self
+
+
+class AdmissionHandoff(BaseModel):
+    """Immutable handoff result preserving generated origin and decision evidence."""
+
+    model_config = ConfigDict(frozen=True)
+
+    original_artifact: AdmissibleArtifact
+    admitted_artifact: AdmissibleArtifact
+    decision_record: AdmissionDecisionRecord
+
+    @property
+    def can_promote_directly(self) -> bool:
+        """Admission only opens a downstream review path; it never executes promotion."""
+
+        return False
+
+
+_DECISION_TO_ARTIFACT_STATE: dict[AdmissionDecision, AdmissionState] = {
+    AdmissionDecision.ADMIT: AdmissionState.ADMITTED,
+    AdmissionDecision.REJECT: AdmissionState.REJECTED,
+    AdmissionDecision.REVISE: AdmissionState.REVISION_REQUESTED,
+}
+
+
+def _reject_direct_authority(artifact: GeneratedArtifact) -> None:
+    if artifact.trust_verb is TrustVerb.APPLY:
+        raise AdmissionHandoffError(
+            "admission handoff cannot accept direct APPLY posture; APPLY is an execution "
+            "verb, not a review/admission boundary"
+        )
+    limits: ContextAuthorityLimits = artifact.authority_limits
+    elevated = [
+        name
+        for name, granted in (
+            ("may_write", limits.may_write),
+            ("may_promote", limits.may_promote),
+            ("may_authorize_action", limits.may_authorize_action),
+        )
+        if granted
+    ]
+    if elevated:
+        raise AdmissionHandoffError(
+            "admission handoff cannot carry direct write/action authority: "
+            + ", ".join(elevated)
+        )
+
+
+def record_admission_decision(
+    artifact: AdmissibleArtifact,
+    *,
+    reviewer_ref: str,
+    actor_ref: str,
+    decision: AdmissionDecision,
+    scope: AdmissionScope,
+    authority_basis: str,
+    receipt_ref: str,
+    receipt_posture: AdmissionReceiptPosture,
+    decision_notes: Optional[str] = None,
+) -> AdmissionHandoff:
+    """Record an explicit admission decision for a generated artifact.
+
+    The returned artifact copy carries the decision posture and durable receipt
+    reference, but remains non-canonical and does not gain write/action authority.
+    """
+
+    _reject_direct_authority(artifact)
+    record = AdmissionDecisionRecord(
+        reviewer_ref=reviewer_ref,
+        actor_ref=actor_ref,
+        decision=decision,
+        scope=scope,
+        authority_basis=authority_basis,
+        receipt_ref=receipt_ref,
+        receipt_posture=receipt_posture,
+        decision_notes=decision_notes,
+    )
+    decided_artifact = artifact.model_copy(
+        update={
+            "admission_state": _DECISION_TO_ARTIFACT_STATE[record.decision],
+            "admission_receipt_ref": record.receipt_ref,
+        }
+    )
+    return AdmissionHandoff(
+        original_artifact=artifact,
+        admitted_artifact=decided_artifact,
+        decision_record=record,
+    )
+
+
+def _source_ids(source_refs: tuple[SourceRef, ...]) -> list[str]:
+    return [ref.artifact_id for ref in source_refs]
+
+
+def _artifact_title(artifact: AdmissibleArtifact) -> str:
+    return getattr(artifact, "title", artifact.artifact_id)
+
+
+def _artifact_content(artifact: AdmissibleArtifact) -> Optional[str]:
+    for field_name in ("body", "rationale", "summary"):
+        value = getattr(artifact, field_name, None)
+        if value:
+            return value
+    return None
+
+
+def route_admitted_memory_to_review_queue(
+    handoff: AdmissionHandoff,
+    queue: MemoryCandidateReviewQueue,
+    *,
+    memory_type: MemoryType,
+    title: Optional[str] = None,
+    content: Optional[str] = None,
+) -> ReviewEntry:
+    """Enqueue admitted memory-like material for existing review-queue semantics.
+
+    This is a handoff only: the returned entry is pending review, not durable memory.
+    """
+
+    record = handoff.decision_record
+    if record.decision is not AdmissionDecision.ADMIT:
+        raise AdmissionHandoffError("only admitted artifacts can enter the memory review queue")
+    if record.scope is not AdmissionScope.MEMORY_REVIEW_QUEUE:
+        raise AdmissionHandoffError(
+            "memory handoff requires admission scope memory_review_queue"
+        )
+    artifact = handoff.admitted_artifact
+    if (
+        artifact.admission_state is not AdmissionState.ADMITTED
+        or artifact.admission_receipt_ref != record.receipt_ref
+    ):
+        raise AdmissionHandoffError(
+            "memory handoff requires an admitted artifact with matching receipt reference"
+        )
+
+    candidate = MemoryCandidate(
+        title=title or _artifact_title(artifact),
+        memory_type=memory_type,
+        source_refs=_source_ids(artifact.source_refs),
+        derived_from=artifact.artifact_id,
+        generated_by=artifact.generated_by,
+        content=content if content is not None else _artifact_content(artifact),
+        inferred=artifact.inferred,
+    )
+    return queue.enqueue(candidate)

--- a/app/knowledge_compilation/runtime_artifacts.py
+++ b/app/knowledge_compilation/runtime_artifacts.py
@@ -61,6 +61,7 @@ class AdmissionState(str, Enum):
     PENDING_REVIEW = "pending_review"
     ADMITTED = "admitted"
     REJECTED = "rejected"
+    REVISION_REQUESTED = "revision_requested"
 
 
 # Artifact-class tokens. Plain strings to match the house convention

--- a/tests/knowledge_compilation/test_review_admission_handoff.py
+++ b/tests/knowledge_compilation/test_review_admission_handoff.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import ast
+import inspect
+
+import pytest
+from pydantic import ValidationError
+
+import app.knowledge_compilation.review_admission as review_admission
+from app.agent_memory.candidate import MemoryType, ReviewState
+from app.agent_memory.review_queue import MemoryCandidateReviewQueue, ReviewStatus
+from app.knowledge_compilation.proposal_builders import ProposalContext, build_compilation_draft
+from app.knowledge_compilation.review_admission import (
+    AdmissionDecision,
+    AdmissionHandoffError,
+    AdmissionReceiptPosture,
+    AdmissionScope,
+    record_admission_decision,
+    route_admitted_memory_to_review_queue,
+)
+from app.knowledge_compilation.runtime_artifacts import (
+    AdmissionState,
+    CompilationDraft,
+    ContextAuthorityLimits,
+    SourceRef,
+    TrustVerb,
+)
+
+
+def _source() -> SourceRef:
+    return SourceRef(artifact_id="note:source", note_path="vault://source.md")
+
+
+def _draft() -> CompilationDraft:
+    return build_compilation_draft(
+        ProposalContext(
+            source_refs=(_source(),),
+            content="Candidate memory-like observation.",
+            uncertainty_notes="single source",
+            trace_ref="trace:kc:1537",
+            generated_by="knowledge_compiler",
+        ),
+        title="Draft observation",
+    )
+
+
+def test_admission_requires_explicit_reviewer_decision_and_receipt_posture() -> None:
+    draft = _draft()
+
+    handoff = record_admission_decision(
+        draft,
+        reviewer_ref="reviewer:rasmus",
+        actor_ref="agent:codex",
+        decision=AdmissionDecision.ADMIT,
+        scope=AdmissionScope.MEMORY_REVIEW_QUEUE,
+        authority_basis="human review of proposed memory candidate",
+        receipt_ref="receipt:admission:1537",
+        receipt_posture=AdmissionReceiptPosture.DURABLE_RECEIPT_REF,
+    )
+
+    assert handoff.decision_record.reviewer_ref == "reviewer:rasmus"
+    assert handoff.decision_record.actor_ref == "agent:codex"
+    assert handoff.decision_record.decision is AdmissionDecision.ADMIT
+    assert handoff.decision_record.scope is AdmissionScope.MEMORY_REVIEW_QUEUE
+    assert handoff.decision_record.authority_basis == (
+        "human review of proposed memory candidate"
+    )
+    assert handoff.decision_record.receipt_ref == "receipt:admission:1537"
+    assert handoff.decision_record.receipt_posture is (
+        AdmissionReceiptPosture.DURABLE_RECEIPT_REF
+    )
+    assert handoff.admitted_artifact.admission_state is AdmissionState.ADMITTED
+    assert handoff.admitted_artifact.admission_receipt_ref == "receipt:admission:1537"
+    assert handoff.admitted_artifact.canonical is False
+    assert handoff.can_promote_directly is False
+
+    required = {
+        "reviewer_ref": "",
+        "actor_ref": "",
+        "authority_basis": "",
+        "receipt_ref": "",
+    }
+    for field, value in required.items():
+        kwargs = {
+            "reviewer_ref": "reviewer:rasmus",
+            "actor_ref": "agent:codex",
+            "decision": AdmissionDecision.ADMIT,
+            "scope": AdmissionScope.MEMORY_REVIEW_QUEUE,
+            "authority_basis": "human review",
+            "receipt_ref": "receipt:admission:1537",
+            "receipt_posture": AdmissionReceiptPosture.DURABLE_RECEIPT_REF,
+        }
+        kwargs[field] = value
+        with pytest.raises(ValidationError):
+            record_admission_decision(draft, **kwargs)
+
+
+def test_handoff_routes_to_review_queue_without_promoting() -> None:
+    handoff = record_admission_decision(
+        _draft(),
+        reviewer_ref="reviewer:rasmus",
+        actor_ref="agent:codex",
+        decision=AdmissionDecision.ADMIT,
+        scope=AdmissionScope.MEMORY_REVIEW_QUEUE,
+        authority_basis="reviewed for memory queue only",
+        receipt_ref="receipt:admission:queue",
+        receipt_posture=AdmissionReceiptPosture.DURABLE_RECEIPT_REF,
+    )
+    queue = MemoryCandidateReviewQueue()
+
+    entry = route_admitted_memory_to_review_queue(
+        handoff,
+        queue,
+        memory_type=MemoryType.EPISODIC_MEMORY,
+    )
+
+    assert entry.status is ReviewStatus.PENDING
+    assert entry.decision is None
+    assert entry.candidate.review_state is ReviewState.UNREVIEWED
+    assert entry.candidate.activation_policy.value == "review_queue_only"
+    assert entry.candidate.title == "Draft observation"
+    assert entry.candidate.content == "Candidate memory-like observation."
+    assert entry.candidate.derived_from == handoff.admitted_artifact.artifact_id
+    assert entry.candidate.generated_by == "knowledge_compiler"
+    assert entry.candidate.source_refs == ["note:source"]
+    assert queue.pending() == [entry]
+    assert queue.recallable_for_working_context() == []
+
+
+def test_admission_outcomes_preserve_provenance_and_origin() -> None:
+    draft = _draft()
+    outcomes = (
+        (AdmissionDecision.ADMIT, AdmissionState.ADMITTED),
+        (AdmissionDecision.REJECT, AdmissionState.REJECTED),
+        (AdmissionDecision.REVISE, AdmissionState.REVISION_REQUESTED),
+    )
+
+    for decision, expected_state in outcomes:
+        handoff = record_admission_decision(
+            draft,
+            reviewer_ref="reviewer:rasmus",
+            actor_ref="agent:codex",
+            decision=decision,
+            scope=AdmissionScope.COMPILATION_REVIEW,
+            authority_basis=f"{decision.value} after explicit review",
+            receipt_ref=f"receipt:admission:{decision.value}",
+            receipt_posture=AdmissionReceiptPosture.DURABLE_RECEIPT_REF,
+            decision_notes=f"{decision.value} notes",
+        )
+
+        assert handoff.admitted_artifact.admission_state is expected_state
+        assert handoff.admitted_artifact.source_refs == draft.source_refs
+        assert handoff.admitted_artifact.trace_ref == "trace:kc:1537"
+        assert handoff.admitted_artifact.generated_by == "knowledge_compiler"
+        assert handoff.admitted_artifact.artifact_class == "compilation_draft"
+        assert handoff.admitted_artifact.canonical is False
+        assert handoff.original_artifact == draft
+        assert handoff.decision_record.decision is decision
+        assert handoff.decision_record.decision_notes == f"{decision.value} notes"
+
+
+def test_direct_apply_or_promotion_without_receipt_is_rejected() -> None:
+    draft = _draft()
+
+    apply_artifact = CompilationDraft(
+        title="Direct apply",
+        source_refs=(_source(),),
+        trust_verb=TrustVerb.APPLY,
+        admission_state=AdmissionState.ADMITTED,
+        admission_receipt_ref="receipt:already",
+    )
+    with pytest.raises(AdmissionHandoffError, match="APPLY"):
+        record_admission_decision(
+            apply_artifact,
+            reviewer_ref="reviewer:rasmus",
+            actor_ref="agent:codex",
+            decision=AdmissionDecision.ADMIT,
+            scope=AdmissionScope.MEMORY_REVIEW_QUEUE,
+            authority_basis="would bypass admission",
+            receipt_ref="receipt:admission:apply",
+            receipt_posture=AdmissionReceiptPosture.DURABLE_RECEIPT_REF,
+        )
+
+    with pytest.raises(ValidationError):
+        record_admission_decision(
+            draft,
+            reviewer_ref="reviewer:rasmus",
+            actor_ref="agent:codex",
+            decision=AdmissionDecision.ADMIT,
+            scope="vault_write",
+            authority_basis="write directly to vault",
+            receipt_ref="receipt:admission:vault",
+            receipt_posture=AdmissionReceiptPosture.DURABLE_RECEIPT_REF,
+        )
+
+    with pytest.raises(ValidationError):
+        record_admission_decision(
+            draft,
+            reviewer_ref="reviewer:rasmus",
+            actor_ref="agent:codex",
+            decision=AdmissionDecision.ADMIT,
+            scope=AdmissionScope.MEMORY_REVIEW_QUEUE,
+            authority_basis="missing durable receipt",
+            receipt_ref="",
+            receipt_posture=AdmissionReceiptPosture.DURABLE_RECEIPT_REF,
+        )
+
+    with pytest.raises(ValueError, match="hidden authority"):
+        CompilationDraft(
+            title="Promote directly",
+            source_refs=(_source(),),
+            authority_limits=ContextAuthorityLimits(may_promote=True),
+        )
+
+    src = inspect.getsource(review_admission)
+    tree = ast.parse(src)
+    imported_modules: set[str] = set()
+    used_names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.update(alias.name.lower() for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            module = (node.module or "").lower()
+            imported_modules.add(module)
+            for alias in node.names:
+                imported_modules.add(f"{module}.{alias.name}".lower())
+        elif isinstance(node, ast.Name):
+            used_names.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            used_names.add(node.attr)
+
+    forbidden_imports = (
+        "sqlalchemy",
+        "app.db",
+        "app.objects",
+        "app.outbox",
+        "app.events",
+        "app.agent_memory.promotion",
+        "objectstore",
+        "knowledgeport",
+        "vaultport",
+        "writeguard",
+    )
+    for forbidden in forbidden_imports:
+        assert not any(forbidden in module for module in imported_modules), (
+            f"review_admission must not import {forbidden!r}; "
+            f"imports={sorted(imported_modules)}"
+        )
+    assert "promote" not in used_names


### PR DESCRIPTION
Fixes #1537

## Summary
- add a pure `review_admission` handoff module for generated Knowledge Compilation artifacts
- require explicit reviewer, actor, decision, scope, authority basis, and durable receipt reference before admission posture is attached
- route admitted memory-like material to the existing `MemoryCandidateReviewQueue` as pending review entries, without promotion, storage, events, API, or vault writes
- preserve provenance, trace identity, non-canonical origin, and explicit admit/reject/revise outcomes

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/knowledge_compilation/test_review_admission_handoff.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/knowledge_compilation/test_review_admission_handoff.py tests/agent_memory/test_memory_candidate_review_queue.py tests/agent_memory/test_memory_promotion.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/knowledge_compilation`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/agent_memory`
- `git diff --check`
- `ruff check app tests` could not run locally: `ruff: command not found`
- `python3 -m ruff check app tests` could not run locally: `No module named ruff`

## BuilderOps routing
- Records/projections/receipts: none
- Reason: bounded runtime-domain handoff slice; no BuilderOps record/projection/promotion material processed.

## Notes
- Worktree: `/Users/rasmusthornberg/code/agentic-pkm-mvp-1537`
- Branch: `codex/1537-review-admission-handoff`
