### PR TITLE
Add Knowledge Compilation trace harness (#1538)

### DIFF
--- a/app/knowledge_compilation/__init__.py
+++ b/app/knowledge_compilation/__init__.py
@@ -5,7 +5,8 @@ Slice #1534 ships the pure runtime artifact contracts
 proposal builders (``app.knowledge_compilation.proposal_builders``); slice #1536 adds
 read-only reorientation packet assembly (``app.knowledge_compilation.reorientation_packet``);
 slice #1537 adds the explicit review/admission handoff
-(``app.knowledge_compilation.review_admission``).
+(``app.knowledge_compilation.review_admission``); slice #1538 adds the provider-free
+diagnostic trace harness (``app.knowledge_compilation.trace_harness``).
 """
 
 from app.knowledge_compilation.proposal_builders import (
@@ -27,6 +28,13 @@ from app.knowledge_compilation.runtime_artifacts import (
     ReorientationPacket,
     SourceRef,
     TrustVerb,
+)
+from app.knowledge_compilation.trace_harness import (
+    AdmissionTraceRecord,
+    ArtifactTraceRecord,
+    KnowledgeCompilationTraceError,
+    KnowledgeCompilationTraceReport,
+    evaluate_knowledge_compilation_trace,
 )
 from app.knowledge_compilation.reorientation_packet import (
     PacketAssemblyError,
@@ -56,10 +64,14 @@ __all__ = [
     "AdmissionHandoffError",
     "AdmissionReceiptPosture",
     "AdmissionScope",
+    "AdmissionTraceRecord",
+    "ArtifactTraceRecord",
     "CompilationDraft",
     "ContextAuthorityLimits",
     "CurationCandidate",
     "GeneratedArtifact",
+    "KnowledgeCompilationTraceError",
+    "KnowledgeCompilationTraceReport",
     "PacketAssemblyError",
     "ProposalContext",
     "ReorientationPacket",
@@ -68,6 +80,7 @@ __all__ = [
     "assemble_reorientation_packet_from_bundle",
     "build_compilation_draft",
     "build_curation_candidate",
+    "evaluate_knowledge_compilation_trace",
     "record_admission_decision",
     "route_admitted_memory_to_review_queue",
 ]

--- a/app/knowledge_compilation/trace_harness.py
+++ b/app/knowledge_compilation/trace_harness.py
@@ -1,0 +1,227 @@
+"""Provider-free diagnostic trace harness for Knowledge Compilation runtime slices.
+
+Child slice #1538 under parent feature #1533. The harness inspects generated
+runtime artifacts and admission handoff outcomes, producing diagnostic evidence
+only. It is not a durable receipt, event family, storage backend, provider call,
+or promotion executor.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.knowledge_compilation.review_admission import (
+    AdmissionDecision,
+    AdmissionHandoff,
+)
+from app.knowledge_compilation.runtime_artifacts import (
+    AdmissionState,
+    CompilationDraft,
+    CurationCandidate,
+    GeneratedArtifact,
+    ReorientationPacket,
+    SourceRef,
+    TrustVerb,
+)
+
+
+TraceableArtifact = CompilationDraft | CurationCandidate | ReorientationPacket
+
+
+class KnowledgeCompilationTraceError(Exception):
+    """Raised when trace validation finds missing evidence or authority drift."""
+
+
+class ArtifactTraceRecord(BaseModel):
+    """Diagnostic evidence captured for one generated runtime artifact."""
+
+    model_config = ConfigDict(frozen=True)
+
+    artifact_id: str
+    artifact_class: str
+    trace_ref: Optional[str] = None
+    source_ids: tuple[str, ...] = Field(default_factory=tuple)
+    canonical: bool
+    trust_verb: str
+    admission_state: str
+    admission_receipt_ref: Optional[str] = None
+    may_write: bool = False
+    may_promote: bool = False
+    may_authorize_action: bool = False
+
+
+class AdmissionTraceRecord(BaseModel):
+    """Diagnostic evidence captured for one explicit admission handoff."""
+
+    model_config = ConfigDict(frozen=True)
+
+    artifact_id: str
+    decision: AdmissionDecision
+    scope: str
+    reviewer_ref: str
+    actor_ref: str
+    authority_basis: str
+    receipt_ref: str
+    trace_ref: Optional[str] = None
+    source_ids: tuple[str, ...] = Field(default_factory=tuple)
+
+
+class KnowledgeCompilationTraceReport(BaseModel):
+    """Diagnostic eval report for the runtime-foundation flow."""
+
+    model_config = ConfigDict(frozen=True)
+
+    artifact_records: tuple[ArtifactTraceRecord, ...] = Field(default_factory=tuple)
+    admission_records: tuple[AdmissionTraceRecord, ...] = Field(default_factory=tuple)
+    promotion_path_records: tuple[str, ...] = Field(default_factory=tuple)
+    provider_free: bool = True
+    diagnostic_only: bool = True
+    emits_events: bool = False
+    durable_writes: bool = False
+    is_receipt: bool = False
+
+
+def _value(value: object) -> str:
+    return str(getattr(value, "value", value))
+
+
+def _source_ids(source_refs: tuple[SourceRef, ...]) -> tuple[str, ...]:
+    ids = tuple(ref.artifact_id for ref in source_refs)
+    if not ids:
+        raise KnowledgeCompilationTraceError(
+            "generated artifact trace requires provenance source_refs"
+        )
+    return ids
+
+
+def _validate_artifact_posture(artifact: GeneratedArtifact) -> ArtifactTraceRecord:
+    source_ids = _source_ids(artifact.source_refs)
+    if artifact.canonical:
+        raise KnowledgeCompilationTraceError(
+            f"generated artifact {artifact.artifact_id!r} drifted to canonical posture"
+        )
+
+    trust_verb = _value(artifact.trust_verb)
+    admission_state = _value(artifact.admission_state)
+    if trust_verb == TrustVerb.APPLY.value:
+        raise KnowledgeCompilationTraceError(
+            f"generated artifact {artifact.artifact_id!r} carries direct APPLY authority"
+        )
+    if trust_verb != TrustVerb.SUGGEST.value and admission_state != AdmissionState.ADMITTED.value:
+        raise KnowledgeCompilationTraceError(
+            f"generated artifact {artifact.artifact_id!r} escalated trust without admission"
+        )
+
+    limits = artifact.authority_limits
+    if limits.may_write or limits.may_promote or limits.may_authorize_action:
+        raise KnowledgeCompilationTraceError(
+            f"generated artifact {artifact.artifact_id!r} carries hidden authority"
+        )
+
+    if admission_state == AdmissionState.ADMITTED.value and not artifact.admission_receipt_ref:
+        raise KnowledgeCompilationTraceError(
+            f"generated artifact {artifact.artifact_id!r} is admitted without admission receipt"
+        )
+
+    return ArtifactTraceRecord(
+        artifact_id=artifact.artifact_id,
+        artifact_class=artifact.artifact_class,
+        trace_ref=artifact.trace_ref,
+        source_ids=source_ids,
+        canonical=artifact.canonical,
+        trust_verb=trust_verb,
+        admission_state=admission_state,
+        admission_receipt_ref=artifact.admission_receipt_ref,
+        may_write=limits.may_write,
+        may_promote=limits.may_promote,
+        may_authorize_action=limits.may_authorize_action,
+    )
+
+
+def _validate_handoff(handoff: AdmissionHandoff) -> AdmissionTraceRecord:
+    original = handoff.original_artifact
+    admitted = handoff.admitted_artifact
+    if original.source_refs != admitted.source_refs:
+        raise KnowledgeCompilationTraceError(
+            f"admission handoff for {original.artifact_id!r} changed provenance"
+        )
+    if original.trace_ref != admitted.trace_ref:
+        raise KnowledgeCompilationTraceError(
+            f"admission handoff for {original.artifact_id!r} changed trace identity"
+        )
+    if admitted.canonical:
+        raise KnowledgeCompilationTraceError(
+            f"admission handoff for {original.artifact_id!r} made the artifact canonical"
+        )
+
+    source_ids = _source_ids(admitted.source_refs)
+    record = handoff.decision_record
+    if admitted.admission_receipt_ref != record.receipt_ref:
+        raise KnowledgeCompilationTraceError(
+            f"admission handoff for {original.artifact_id!r} has mismatched receipt"
+        )
+
+    return AdmissionTraceRecord(
+        artifact_id=admitted.artifact_id,
+        decision=record.decision,
+        scope=record.scope.value,
+        reviewer_ref=record.reviewer_ref,
+        actor_ref=record.actor_ref,
+        authority_basis=record.authority_basis,
+        receipt_ref=record.receipt_ref,
+        trace_ref=admitted.trace_ref,
+        source_ids=source_ids,
+    )
+
+
+def _validate_promotion_paths(
+    requested_artifact_ids: tuple[str, ...],
+    *,
+    artifact_records: dict[str, ArtifactTraceRecord],
+    admission_records: dict[str, AdmissionTraceRecord],
+) -> tuple[str, ...]:
+    for artifact_id in requested_artifact_ids:
+        artifact_record = artifact_records.get(artifact_id)
+        admission_record = admission_records.get(artifact_id)
+        if artifact_record is None:
+            raise KnowledgeCompilationTraceError(
+                f"promotion-like path references unknown artifact {artifact_id!r}"
+            )
+        if (
+            artifact_record.admission_state != AdmissionState.ADMITTED.value
+            or not artifact_record.admission_receipt_ref
+            or admission_record is None
+            or admission_record.decision is not AdmissionDecision.ADMIT
+            or admission_record.receipt_ref != artifact_record.admission_receipt_ref
+        ):
+            raise KnowledgeCompilationTraceError(
+                "promotion-like path requires explicit admission receipt posture"
+            )
+    return requested_artifact_ids
+
+
+def evaluate_knowledge_compilation_trace(
+    *,
+    artifacts: Sequence[TraceableArtifact],
+    handoffs: Sequence[AdmissionHandoff] = (),
+    promotion_like_artifact_ids: Sequence[str] = (),
+) -> KnowledgeCompilationTraceReport:
+    """Build a provider-free diagnostic report for generated KC runtime artifacts."""
+
+    artifact_records = tuple(_validate_artifact_posture(artifact) for artifact in artifacts)
+    admission_records = tuple(_validate_handoff(handoff) for handoff in handoffs)
+    artifact_record_map = {record.artifact_id: record for record in artifact_records}
+    admission_record_map = {record.artifact_id: record for record in admission_records}
+    promotion_records = _validate_promotion_paths(
+        tuple(promotion_like_artifact_ids),
+        artifact_records=artifact_record_map,
+        admission_records=admission_record_map,
+    )
+    return KnowledgeCompilationTraceReport(
+        artifact_records=artifact_records,
+        admission_records=admission_records,
+        promotion_path_records=promotion_records,
+    )

--- a/app/knowledge_compilation/trace_harness.py
+++ b/app/knowledge_compilation/trace_harness.py
@@ -144,6 +144,7 @@ def _validate_artifact_posture(artifact: GeneratedArtifact) -> ArtifactTraceReco
 def _validate_handoff(handoff: AdmissionHandoff) -> AdmissionTraceRecord:
     original = handoff.original_artifact
     admitted = handoff.admitted_artifact
+    admitted_record = _validate_artifact_posture(admitted)
     if original.source_refs != admitted.source_refs:
         raise KnowledgeCompilationTraceError(
             f"admission handoff for {original.artifact_id!r} changed provenance"
@@ -152,12 +153,6 @@ def _validate_handoff(handoff: AdmissionHandoff) -> AdmissionTraceRecord:
         raise KnowledgeCompilationTraceError(
             f"admission handoff for {original.artifact_id!r} changed trace identity"
         )
-    if admitted.canonical:
-        raise KnowledgeCompilationTraceError(
-            f"admission handoff for {original.artifact_id!r} made the artifact canonical"
-        )
-
-    source_ids = _source_ids(admitted.source_refs)
     record = handoff.decision_record
     if admitted.admission_receipt_ref != record.receipt_ref:
         raise KnowledgeCompilationTraceError(
@@ -173,7 +168,7 @@ def _validate_handoff(handoff: AdmissionHandoff) -> AdmissionTraceRecord:
         authority_basis=record.authority_basis,
         receipt_ref=record.receipt_ref,
         trace_ref=admitted.trace_ref,
-        source_ids=source_ids,
+        source_ids=admitted_record.source_ids,
     )
 
 

--- a/tests/eval/test_knowledge_compilation_trace_harness.py
+++ b/tests/eval/test_knowledge_compilation_trace_harness.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import ast
+import inspect
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import pytest
+
+import app.knowledge_compilation.trace_harness as trace_harness
+from app.context_bundles.schema import (
+    AuthorityFlags,
+    BundleScope,
+    BundleTrigger,
+    ContextBundle,
+    ExpiryPosture,
+    IncludedItem,
+    ItemProvenance,
+)
+from app.knowledge_compilation.proposal_builders import (
+    ProposalContext,
+    build_compilation_draft,
+    build_curation_candidate,
+)
+from app.knowledge_compilation.reorientation_packet import (
+    assemble_reorientation_packet_from_bundle,
+)
+from app.knowledge_compilation.review_admission import (
+    AdmissionDecision,
+    AdmissionReceiptPosture,
+    AdmissionScope,
+    record_admission_decision,
+)
+from app.knowledge_compilation.runtime_artifacts import (
+    AdmissionState,
+    CompilationDraft,
+    ContextAuthorityLimits,
+    SourceRef,
+)
+from app.knowledge_compilation.trace_harness import (
+    KnowledgeCompilationTraceError,
+    evaluate_knowledge_compilation_trace,
+)
+
+
+_NOW = datetime(2026, 6, 2, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@dataclass(frozen=True)
+class _RuntimeFlow:
+    draft: object
+    candidate: object
+    packet: object
+    handoff: object
+
+
+def _source() -> SourceRef:
+    return SourceRef(artifact_id="note:source", note_path="vault://source.md")
+
+
+def _bundle() -> ContextBundle:
+    return ContextBundle(
+        id="ctx_trace_harness",
+        created_at=_NOW,
+        trigger=BundleTrigger(type="orientation", source="test"),
+        intended_use=["orient"],
+        scope=BundleScope(project="knowledge-compilation"),
+        included=[
+            IncludedItem(
+                artifact_id="note:source",
+                path="vault://source.md",
+                reason="trace harness source",
+                source_role="source",
+                trust_state="reviewed",
+                review_state="confirmed",
+                provenance=ItemProvenance(origin="vault note"),
+            )
+        ],
+        authority=AuthorityFlags(may_orient=True),
+        expiry=ExpiryPosture(),
+    )
+
+
+def _runtime_flow() -> _RuntimeFlow:
+    context = ProposalContext(
+        source_refs=(_source(),),
+        content="compiled observation",
+        rationale="retain the reviewed source",
+        trace_ref="trace:kc:1538",
+        generated_by="knowledge_compiler",
+    )
+    draft = build_compilation_draft(context, title="Compiled observation")
+    candidate = build_curation_candidate(context, title="Retained source set")
+    packet = assemble_reorientation_packet_from_bundle(
+        _bundle(),
+        trace_ref="trace:kc:1538",
+        now=_NOW,
+    )
+    handoff = record_admission_decision(
+        draft,
+        reviewer_ref="reviewer:rasmus",
+        actor_ref="agent:codex",
+        decision=AdmissionDecision.ADMIT,
+        scope=AdmissionScope.MEMORY_REVIEW_QUEUE,
+        authority_basis="reviewed for memory queue only",
+        receipt_ref="receipt:admission:1538",
+        receipt_posture=AdmissionReceiptPosture.DURABLE_RECEIPT_REF,
+    )
+    return _RuntimeFlow(draft=draft, candidate=candidate, packet=packet, handoff=handoff)
+
+
+def _tamper(artifact: CompilationDraft, **updates: object) -> CompilationDraft:
+    values = dict(artifact.__dict__)
+    values.update(updates)
+    return artifact.__class__.model_construct(**values)
+
+
+def test_harness_records_trace_for_each_generated_artifact() -> None:
+    flow = _runtime_flow()
+
+    report = evaluate_knowledge_compilation_trace(
+        artifacts=(flow.draft, flow.candidate, flow.packet),
+        handoffs=(flow.handoff,),
+    )
+
+    assert report.provider_free is True
+    assert report.diagnostic_only is True
+    assert report.is_receipt is False
+    assert [record.artifact_class for record in report.artifact_records] == [
+        "compilation_draft",
+        "curation_candidate",
+        "reorientation_packet",
+    ]
+    assert report.artifact_records[0].trace_ref == "trace:kc:1538"
+    assert report.artifact_records[0].source_ids == ("note:source",)
+    assert report.artifact_records[0].canonical is False
+    assert report.artifact_records[0].trust_verb == "SUGGEST"
+    assert report.admission_records[0].artifact_id == flow.draft.artifact_id
+    assert report.admission_records[0].decision is AdmissionDecision.ADMIT
+    assert report.admission_records[0].receipt_ref == "receipt:admission:1538"
+    assert report.admission_records[0].source_ids == ("note:source",)
+
+
+def test_harness_fails_on_missing_provenance_or_authority_escalation() -> None:
+    draft = _runtime_flow().draft
+
+    missing_provenance = _tamper(draft, source_refs=())
+    with pytest.raises(KnowledgeCompilationTraceError, match="provenance"):
+        evaluate_knowledge_compilation_trace(artifacts=(missing_provenance,))
+
+    canonical_drift = _tamper(draft, canonical=True)
+    with pytest.raises(KnowledgeCompilationTraceError, match="canonical"):
+        evaluate_knowledge_compilation_trace(artifacts=(canonical_drift,))
+
+    elevated_authority = _tamper(
+        draft,
+        authority_limits=ContextAuthorityLimits(may_write=True),
+    )
+    with pytest.raises(KnowledgeCompilationTraceError, match="authority"):
+        evaluate_knowledge_compilation_trace(artifacts=(elevated_authority,))
+
+
+def test_harness_requires_admission_receipt_before_promotion_path() -> None:
+    flow = _runtime_flow()
+
+    with pytest.raises(KnowledgeCompilationTraceError, match="admission receipt"):
+        evaluate_knowledge_compilation_trace(
+            artifacts=(flow.draft,),
+            promotion_like_artifact_ids=(flow.draft.artifact_id,),
+        )
+
+    report = evaluate_knowledge_compilation_trace(
+        artifacts=(flow.handoff.admitted_artifact,),
+        handoffs=(flow.handoff,),
+        promotion_like_artifact_ids=(flow.draft.artifact_id,),
+    )
+
+    assert report.promotion_path_records == (flow.draft.artifact_id,)
+    assert report.artifact_records[0].admission_state == AdmissionState.ADMITTED.value
+    assert report.artifact_records[0].admission_receipt_ref == "receipt:admission:1538"
+
+
+def test_harness_runs_provider_free_without_db_or_vault_mutation() -> None:
+    flow = _runtime_flow()
+
+    report = evaluate_knowledge_compilation_trace(
+        artifacts=(flow.draft, flow.candidate, flow.packet),
+        handoffs=(flow.handoff,),
+    )
+
+    assert report.provider_free is True
+    assert report.diagnostic_only is True
+    assert report.emits_events is False
+    assert report.durable_writes is False
+    assert report.is_receipt is False
+
+    src = inspect.getsource(trace_harness)
+    tree = ast.parse(src)
+    imported_modules: set[str] = set()
+    used_names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.update(alias.name.lower() for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            module = (node.module or "").lower()
+            imported_modules.add(module)
+            for alias in node.names:
+                imported_modules.add(f"{module}.{alias.name}".lower())
+        elif isinstance(node, ast.Name):
+            used_names.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            used_names.add(node.attr)
+
+    forbidden_imports = (
+        "sqlalchemy",
+        "app.db",
+        "app.events",
+        "app.outbox",
+        "app.agent_memory.promotion",
+        "app.llm",
+        "app.vault",
+        "objectstore",
+        "knowledgeport",
+        "vaultport",
+        "writeguard",
+    )
+    for forbidden in forbidden_imports:
+        assert not any(forbidden in module for module in imported_modules), (
+            f"trace_harness must not import {forbidden!r}; "
+            f"imports={sorted(imported_modules)}"
+        )
+    assert "open" not in used_names
+    assert "emit" not in used_names

--- a/tests/eval/test_knowledge_compilation_trace_harness.py
+++ b/tests/eval/test_knowledge_compilation_trace_harness.py
@@ -142,7 +142,8 @@ def test_harness_records_trace_for_each_generated_artifact() -> None:
 
 
 def test_harness_fails_on_missing_provenance_or_authority_escalation() -> None:
-    draft = _runtime_flow().draft
+    flow = _runtime_flow()
+    draft = flow.draft
 
     missing_provenance = _tamper(draft, source_refs=())
     with pytest.raises(KnowledgeCompilationTraceError, match="provenance"):
@@ -158,6 +159,17 @@ def test_harness_fails_on_missing_provenance_or_authority_escalation() -> None:
     )
     with pytest.raises(KnowledgeCompilationTraceError, match="authority"):
         evaluate_knowledge_compilation_trace(artifacts=(elevated_authority,))
+
+    bad_handoff = flow.handoff.__class__.model_construct(
+        original_artifact=flow.handoff.original_artifact,
+        admitted_artifact=_tamper(
+            flow.handoff.admitted_artifact,
+            authority_limits=ContextAuthorityLimits(may_write=True),
+        ),
+        decision_record=flow.handoff.decision_record,
+    )
+    with pytest.raises(KnowledgeCompilationTraceError, match="authority"):
+        evaluate_knowledge_compilation_trace(artifacts=(), handoffs=(bad_handoff,))
 
 
 def test_harness_requires_admission_receipt_before_promotion_path() -> None:


### PR DESCRIPTION
Fixes #1538

## Summary
- add a provider-free diagnostic trace harness for the Knowledge Compilation runtime foundation
- record trace evidence for `CompilationDraft`, `CurationCandidate`, `ReorientationPacket`, and explicit admission handoff outcomes
- fail closed on missing provenance, canonical drift, authority escalation, and promotion-like paths without matching admission receipt posture
- keep harness output diagnostic/eval-only: no provider calls, durable receipts, event emission, storage, vault writes, or promotion execution

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/eval/test_knowledge_compilation_trace_harness.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/eval/test_knowledge_compilation_trace_harness.py tests/knowledge_compilation`
- `git diff --check`
- `ruff check app tests` could not run locally: `ruff: command not found`
- `python3 -m ruff check app tests` could not run locally: `No module named ruff`

## BuilderOps routing
- Records/projections/receipts: none
- Reason: bounded provider-free eval/diagnostic harness; no BuilderOps record/projection/promotion material processed.

## Notes
- Worktree: `/Users/rasmusthornberg/code/agentic-pkm-mvp-1538`
- Branch: `codex/1538-knowledge-compilation-trace-harness`
