### PR TITLE
Fix residual review-comment guards

### DIFF
--- a/.github/workflows/issue-pr-governance.yml
+++ b/.github/workflows/issue-pr-governance.yml
@@ -92,12 +92,20 @@ jobs:
             // It records the BuilderOps objects/projections/receipts created, or an explicit "none" reason.
             const builderOpsRoutingMatch = body.match(/## BuilderOps Routing[\s\S]*?(?=\n##\s|\n---)|## BuilderOps Routing[\s\S]*/i);
             const builderOpsRoutingSection = builderOpsRoutingMatch ? builderOpsRoutingMatch[0] : "";
+            const hasConcreteBuilderOpsValue = (pattern) => {
+              const match = builderOpsRoutingSection.match(pattern);
+              if (!match) {
+                return false;
+              }
+              const value = match[1].trim();
+              return value.length > 0 && !/^<.*>$/.test(value);
+            };
             const hasBuilderOpsRouting =
               Boolean(builderOpsRoutingSection) &&
-              /(?:^|\n)\s*-\s*Records\/projections\/receipts:\s*\S/i.test(builderOpsRoutingSection) &&
-              /(?:^|\n)\s*-\s*Reason:\s*\S/i.test(builderOpsRoutingSection);
+              hasConcreteBuilderOpsValue(/(?:^|\n)\s*-\s*Records\/projections\/receipts:\s*(.*?)\s*(?:\n|$)/i) &&
+              hasConcreteBuilderOpsValue(/(?:^|\n)\s*-\s*Reason:\s*(.*?)\s*(?:\n|$)/i);
             if (!hasBuilderOpsRouting) {
-              core.setFailed("PR body must include `## BuilderOps Routing` with `Records/projections/receipts:` and `Reason:` lines.");
+              core.setFailed("PR body must include `## BuilderOps Routing` with concrete `Records/projections/receipts:` and `Reason:` lines.");
               return;
             }
             const issueLinkPattern = /(Fixes|Closes|Resolves)\s+#\d+/i;

--- a/app/knowledge_compilation/proposal_builders.py
+++ b/app/knowledge_compilation/proposal_builders.py
@@ -33,6 +33,7 @@ from app.knowledge_compilation.runtime_artifacts import (
 _MACHINE_DERIVATIONS: frozenset[str] = frozenset(
     {"embedding", "generated_summary", "summary", "retrieval", "rerank"}
 )
+_APPROVED_REVIEW_STATES: frozenset[str] = frozenset({"reviewed", "accepted"})
 
 
 class ProposalContext(BaseModel):
@@ -74,9 +75,11 @@ def _reject_hidden_authority(context: ProposalContext) -> None:
             "into a non-canonical proposal"
         )
     for ref in context.source_refs:
-        if (ref.review_state or "").strip().lower() == "unreviewed":
+        review_state = (ref.review_state or "").strip().lower()
+        if review_state and review_state not in _APPROVED_REVIEW_STATES:
             raise ValueError(
-                f"unreviewed source {ref.artifact_id!r} cannot be laundered into a proposal"
+                f"source {ref.artifact_id!r} has non-approved review_state {ref.review_state!r}; "
+                f"only reviewed or accepted sources can be laundered into a proposal"
             )
         if ref.retrieval_score is not None:
             raise ValueError(

--- a/tests/architecture/test_pr_hot_path_governance.py
+++ b/tests/architecture/test_pr_hot_path_governance.py
@@ -130,8 +130,8 @@ _BUILDEROPS_ROUTING_REGEX = _re.compile(
     _re.IGNORECASE,
 )
 _BUILDEROPS_ROUTING_FIELDS = [
-    _re.compile(r"(?:^|\n)\s*-\s*Records/projections/receipts:\s*\S", _re.IGNORECASE),
-    _re.compile(r"(?:^|\n)\s*-\s*Reason:\s*\S", _re.IGNORECASE),
+    _re.compile(r"(?:^|\n)\s*-\s*Records/projections/receipts:\s*(.*?)\s*(?:\n|$)", _re.IGNORECASE),
+    _re.compile(r"(?:^|\n)\s*-\s*Reason:\s*(.*?)\s*(?:\n|$)", _re.IGNORECASE),
 ]
 
 
@@ -150,7 +150,14 @@ def _has_builderops_routing(body: str) -> bool:
     if not m:
         return False
     section = m.group(0)
-    return all(p.search(section) for p in _BUILDEROPS_ROUTING_FIELDS)
+    for pattern in _BUILDEROPS_ROUTING_FIELDS:
+        match = pattern.search(section)
+        if not match:
+            return False
+        value = match.group(1).strip()
+        if not value or _re.fullmatch(r"<.*>", value):
+            return False
+    return True
 
 
 _VALID_DIRECT_REPAIR_FIELDS = (
@@ -210,6 +217,13 @@ def test_builderops_routing_required_fields() -> None:
 
     missing_reason = "## BuilderOps Routing\n- Records/projections/receipts: none"
     assert not _has_builderops_routing(missing_reason), "Expected missing reason line to be rejected"
+
+    template_placeholders = (
+        '## BuilderOps Routing\n'
+        '- Records/projections/receipts: <ids or "none">\n'
+        "- Reason: <why no BuilderOps material was created, or what was routed>"
+    )
+    assert not _has_builderops_routing(template_placeholders), "Expected unchanged template placeholders to be rejected"
 
 
 def test_direct_repair_rejected_when_fields_incomplete() -> None:

--- a/tests/knowledge_compilation/test_proposal_builders.py
+++ b/tests/knowledge_compilation/test_proposal_builders.py
@@ -102,6 +102,15 @@ def test_builders_reject_hidden_authority_context() -> None:
             title="t",
         )
 
+    for review_state in ("queued", "candidate", "rejected"):
+        with pytest.raises(ValueError, match="non-approved review_state"):
+            build_compilation_draft(
+                ProposalContext(
+                    source_refs=(SourceRef(artifact_id=f"m-{review_state}", review_state=review_state),)
+                ),
+                title="t",
+            )
+
     # Retrieval-ranked source presented as approved authority.
     with pytest.raises(ValueError, match="retrieval"):
         build_compilation_draft(


### PR DESCRIPTION
## Direct Repair
Type: code
Reason: Daily review-comment closure audit found two actionable inline review comments that remained unaddressed after their governing PRs/issues were terminal: PR #1543 discussion r3344575115 and PR #1540 discussion r3344253498.
Validation: PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/knowledge_compilation/test_proposal_builders.py tests/architecture/test_pr_hot_path_governance.py; /tmp/codex-ruff-venv/bin/ruff check app tests; git diff --check
Issue required: no

## Summary
- Reject explicit non-approved proposal source review states such as `queued`, `candidate`, and `rejected`; only `reviewed` and `accepted` remain approved when `review_state` is supplied.
- Reject unchanged PR-template BuilderOps Routing placeholders in the governance workflow instead of accepting any non-empty value.

## Review Anchors
- PR #1543: https://github.com/RasmusTho/agentic-pkm-mvp/pull/1543#discussion_r3344575115
- PR #1540: https://github.com/RasmusTho/agentic-pkm-mvp/pull/1540#discussion_r3344253498

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/knowledge_compilation/test_proposal_builders.py tests/architecture/test_pr_hot_path_governance.py` -> 16 passed
- `/tmp/codex-ruff-venv/bin/ruff check app tests` -> All checks passed
- `git diff --check` -> passed

## BuilderOps Routing
- Records/projections/receipts: LearningSignal `lrn_20260603051749_1d0cb650`
- Reason: captured workflow divergence where terminal PRs retained actionable unacknowledged inline review comments.

---