### PR TITLE
Update issue-set dispatch claim guidance

### DIFF
--- a/.codex/skills/deliver-issue-set/SKILL.md
+++ b/.codex/skills/deliver-issue-set/SKILL.md
@@ -71,6 +71,7 @@ Delivery rules:
 - Do not claim the whole epic or entire Kanban pool up front.
 - Do not claim more issues than there are ready sub-agent execution slots.
 - Never make speculative claims. Every claimed issue must have an owner agent, worktree/branch plan, validation plan, and expected return receipt.
+- Claim each selected issue before dispatching implementation work. A coordinator may hand work to a sub-agent only after the issue is claimed through `issue-to-code` / `scripts/issue_pickup_claim.sh`, Project Status is `In Progress`, `agent:ready` is removed, and a claim receipt comment names the coordinator session, assignee/sub-agent, worktree/branch plan, and expected return receipt.
 - For each issue, follow `issue-to-code` from claim through implementation and local validation.
 - Use `publish-pr` for branch, commit, push, and PR creation/update.
 - Use `pr-integration` only when the PR needs readiness or repair before verification.
@@ -89,6 +90,11 @@ Parallel claim is allowed only when all are true:
 - the expected token savings or quality gain is explicit, for example isolating unrelated subsystems, avoiding repeated context reload, or letting independent validation run concurrently
 
 If any parallel worker stalls, fails claim, loses branch/worktree truth, or discovers contract drift, release or reclassify that issue before claiming replacements.
+
+If a sub-agent starts pickup and finds an existing claim receipt or lifecycle claim that does not match
+the dispatching coordinator, it must stop and report the collision instead of implementing. Do not
+rationalize a foreign claim as belonging to the current dispatch; the coordinator must reconcile,
+release, or choose a different issue before work continues.
 
 Delivery mode is complete only when every in-scope issue is either:
 


### PR DESCRIPTION
- [x] Governance lane

## Summary
Update `deliver-issue-set` guidance so coordinators claim each selected issue before dispatching sub-agent implementation work.

## Changes
- Require coordinator claim-before-dispatch through `issue-to-code` / `scripts/issue_pickup_claim.sh`.
- Require claim receipt comments to name coordinator session, assignee/sub-agent, worktree/branch plan, and expected return receipt.
- Require sub-agents to stop and report when an existing lifecycle claim or claim receipt belongs to another coordinator.

## Validation
- `python3 scripts/lint_skills_consistency.py` (pass, zero output)
- `scripts/agent_workspace_preflight.sh --expected-branch codex/learning-retro-deliver-claims --expected-worktree /Users/rasmusthornberg/.codex/worktrees/learning-retro-deliver-claims --allow-dirty` before commit and before push (pass; local main stale ref advisory only, branch/worktree OK)

## BuilderOps Routing
- Records/projections/receipts: `lrn_20260609221307_70cb369a`, `receipt_20260614053126_a2f53cfc`, `receipt_20260614055617_ceaa29fc`, `receipt_20260614055722_00a8d009`, `tmp/builderops-learning-retro/learning-summary.md`
- Reason: Publishes the governance-lane direct fix selected by the learning-retrospective automation; records duplicate PR #1988 supersession by #1989.

---