### PR TITLE
ci: fix manifest platform verification for multi-arch push images

### DIFF
--- a/.github/workflows/app-image-build.yml
+++ b/.github/workflows/app-image-build.yml
@@ -92,10 +92,15 @@ jobs:
         run: |
           set -euo pipefail
           image="${{ steps.build-identity.outputs.image }}"
-          inspect_output="$(docker buildx imagetools inspect "${image}")"
-          echo "${inspect_output}"
+          manifest_platforms="$(docker buildx imagetools inspect "${image}" | awk '
+            $1 == "Platform:" {
+              print $2
+            }
+          ' | sort -u)"
+          echo "Discovered manifest platforms:"
+          echo "${manifest_platforms}"
           for required_platform in linux/amd64 linux/arm64; do
-            if ! echo "${inspect_output}" | grep -q "Platform: ${required_platform}"; then
+            if ! echo "${manifest_platforms}" | grep -qx "${required_platform}"; then
               echo "missing required platform in image manifest: ${required_platform}"
               exit 1
             fi

--- a/.github/workflows/app-image-build.yml
+++ b/.github/workflows/app-image-build.yml
@@ -36,6 +36,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
       - name: Login to GHCR
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
@@ -44,19 +49,35 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build app image
+      - name: Build app image (PR validation)
+        if: github.event_name == 'pull_request'
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile
           load: true
           push: false
+          platforms: linux/amd64
           tags: ${{ steps.build-identity.outputs.image }}
           build-args: |
             VCS_REF=${{ env.VCS_REF }}
             BUILT_AT=${{ env.BUILT_AT }}
 
+      - name: Build and push app image (main multi-arch)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.build-identity.outputs.image }}
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            VCS_REF=${{ env.VCS_REF }}
+            BUILT_AT=${{ env.BUILT_AT }}
+
       - name: Verify image runtime version
+        if: github.event_name == 'pull_request'
         shell: bash
         run: |
           set -euo pipefail
@@ -65,9 +86,22 @@ jobs:
             "${{ steps.build-identity.outputs.image }}" \
             -c 'from app.version import get_runtime_version; import os; version = get_runtime_version(); assert version["git_sha"] == os.environ["VCS_REF"], version; assert version["built_at"] == os.environ["BUILT_AT"], version'
 
-      - name: Push app image to GHCR
+      - name: Verify pushed app image runtime version and platforms
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         shell: bash
         run: |
           set -euo pipefail
-          docker push "${{ steps.build-identity.outputs.image }}"
+          image="${{ steps.build-identity.outputs.image }}"
+          inspect_output="$(docker buildx imagetools inspect "${image}")"
+          echo "${inspect_output}"
+          for required_platform in linux/amd64 linux/arm64; do
+            if ! echo "${inspect_output}" | grep -q "Platform: ${required_platform}"; then
+              echo "missing required platform in image manifest: ${required_platform}"
+              exit 1
+            fi
+          done
+          docker run --rm \
+            --platform linux/amd64 \
+            --entrypoint python \
+            "${image}" \
+            -c 'from app.version import get_runtime_version; import os; version = get_runtime_version(); assert version["git_sha"] == os.environ["VCS_REF"], version; assert version["built_at"] == os.environ["BUILT_AT"], version'

--- a/tests/deploy/test_ci_image_build.py
+++ b/tests/deploy/test_ci_image_build.py
@@ -52,6 +52,8 @@ def test_built_image_version_reports_build_sha(monkeypatch) -> None:
     assert "if: github.event_name == 'pull_request'" in workflow
     assert "if: github.event_name == 'push' && github.ref == 'refs/heads/main'" in workflow
     assert "docker buildx imagetools inspect" in workflow
+    assert "manifest_platforms=\"" in workflow
+    assert "awk '" in workflow
     assert "--platform linux/amd64" in workflow
 
     monkeypatch.setenv("VCS_REF", "0123456789abcdef0123456789abcdef01234567")

--- a/tests/deploy/test_ci_image_build.py
+++ b/tests/deploy/test_ci_image_build.py
@@ -20,6 +20,7 @@ def test_ci_builds_sha_tagged_image() -> None:
     assert "  push:" in workflow
     assert "  pull_request:" in workflow
     assert "    paths:" not in workflow
+    assert "uses: docker/setup-qemu-action@v3" in workflow
     assert 'vcs_ref="${GITHUB_SHA}"' in workflow
     assert 'owner="${GITHUB_REPOSITORY_OWNER,,}"' in workflow
     assert 'image="ghcr.io/${owner}/pkm-app:${vcs_ref}"' in workflow
@@ -27,6 +28,10 @@ def test_ci_builds_sha_tagged_image() -> None:
     assert "context: ." in workflow
     assert "file: Dockerfile" in workflow
     assert "tags: ${{ steps.build-identity.outputs.image }}" in workflow
+    assert "if: github.event_name == 'pull_request'" in workflow
+    assert "platforms: linux/amd64" in workflow
+    assert "platforms: linux/amd64,linux/arm64" in workflow
+    assert "load: true" in workflow
     assert "push: false" in workflow
 
 
@@ -44,6 +49,10 @@ def test_built_image_version_reports_build_sha(monkeypatch) -> None:
     assert "get_runtime_version" in workflow
     assert 'version["git_sha"] == os.environ["VCS_REF"]' in workflow
     assert 'version["built_at"] == os.environ["BUILT_AT"]' in workflow
+    assert "if: github.event_name == 'pull_request'" in workflow
+    assert "if: github.event_name == 'push' && github.ref == 'refs/heads/main'" in workflow
+    assert "docker buildx imagetools inspect" in workflow
+    assert "--platform linux/amd64" in workflow
 
     monkeypatch.setenv("VCS_REF", "0123456789abcdef0123456789abcdef01234567")
     monkeypatch.setenv("BUILT_AT", "2026-06-30T00:00:00Z")
@@ -57,7 +66,9 @@ def test_single_image_artifact_per_commit() -> None:
     workflow = _workflow_text()
 
     assert "strategy:" not in workflow
-    assert workflow.count("uses: docker/build-push-action@") == 1
+    assert workflow.count("uses: docker/build-push-action@") == 2
+    assert workflow.count("if: github.event_name == 'pull_request'") == 2
+    assert workflow.count("if: github.event_name == 'push' && github.ref == 'refs/heads/main'") >= 2
     assert "matrix:" not in workflow
     assert "CHANNEL" not in workflow
     assert "ENVIRONMENT" not in workflow

--- a/tests/deploy/test_ghcr_push_and_pin.py
+++ b/tests/deploy/test_ghcr_push_and_pin.py
@@ -23,9 +23,11 @@ def test_ci_pushes_sha_tag_to_ghcr() -> None:
     assert "uses: docker/login-action@v3" in workflow
     assert "registry: ghcr.io" in workflow
     assert 'image="ghcr.io/${owner}/pkm-app:${vcs_ref}"' in workflow
-    assert 'docker push "${{ steps.build-identity.outputs.image }}"' in workflow
+    assert 'push: true' in workflow
     assert "if: github.event_name == 'push' && github.ref == 'refs/heads/main'" in workflow
-    assert "push: false" in workflow
+    assert "platforms: linux/amd64,linux/arm64" in workflow
+    assert "load: true" in workflow
+    assert "docker buildx imagetools inspect" in workflow
 
 
 def test_per_channel_pin_files_present() -> None:


### PR DESCRIPTION
## Summary
- Fix main branch manifest-platform verification in .github/workflows/app-image-build.yml to parse platform list deterministically.
- Keep verification strict on required linux/amd64 and linux/arm64 while ignoring unknown/unknown entries from buildx output.
- Extend workflow test coverage in tests/deploy/test_ci_image_build.py for new parsing command usage.

## Validation
- python3 -m pytest tests/deploy/test_ci_image_build.py tests/deploy/test_ghcr_push_and_pin.py

Closes #3124