### PR TITLE
builder: integrate deliver-issue-set with epic run-state

### DIFF
--- a/.codex/skills/deliver-issue-set/SKILL.md
+++ b/.codex/skills/deliver-issue-set/SKILL.md
@@ -68,6 +68,28 @@ Delivery mode may claim, implement, publish, verify, merge, and close issues onl
 
 Delivery rules:
 
+- Use epic run-state v0 as coordination evidence for any delivery-mode epic or parent-feature run
+  that spans planning plus at least one child issue. The helper surface is:
+  `python3 -m app.builderops builderops epic-run-state record --epic-issue-number <N> --run-id <safe-id>`.
+  Use `--root <tmpdir>` in tests; otherwise the default path is
+  `runtime/builderops/epic-runs/<run_id>.json`.
+- Record only evidence supplied by current GitHub/repo/PR/CI facts or by the current runner
+  decision: child queue, issue/PR/branch/worktree mapping, validation status, review findings,
+  reusable constraints, follow-ups, stop conditions, dispatcher status snapshots, compact receipts,
+  and last verified head SHA. Do not infer lifecycle, Project, label, merge, closure, or product
+  truth from the state file.
+- Treat run-state as discardable local coordination state, never authority. If it is missing or
+  deleted, rebuild it from live GitHub/repo evidence where practical and continue from that evidence;
+  if the authoritative evidence is ambiguous, stop under the normal Human Exception / issue
+  maintenance rules instead of trusting stale local state.
+- Use `--dry-run --json` before any new run-state write path or when auditing a run. Dry-run output
+  must not perform GitHub writes; it only previews the deterministic state that would be written.
+- Repeated `record` calls are the resume path. They must be idempotent for child queue, reusable
+  constraints, review findings, follow-ups, and compact receipts; duplicated local state is a runner
+  bug to repair before dispatching more work.
+- Dispatcher status in run-state is snapshot-only. Recording `{"db_exists": false}` or similar does
+  not start, stop, claim, heartbeat, release, or complete dispatcher work. Keep dispatcher behavior
+  governed by the existing dispatcher flow until a separate child issue changes it.
 - Default to delivering one issue at a time.
 - You may claim multiple issues only when you are immediately assigning them to active sub-agents with isolated worktrees and the parallelization is rational from both token-budget and quality perspectives.
 - Before selecting or dispatching work, classify each candidate as Product/Runtime System,

--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -7,6 +7,15 @@ from typing import Any, Callable
 import click
 
 from app.builderops.config import load_paths
+from app.builderops.epic_run_state import (
+    EpicRunStateError,
+    apply_epic_run_update,
+    create_epic_run_state,
+    epic_run_state_path,
+    load_epic_run_state,
+    new_epic_run_state,
+    update_epic_run_state,
+)
 from app.builderops.models import BuilderOpsValidationError, normalize_actor
 from app.builderops.promotion_gateway import BuilderOpsPromotionGateway
 from app.builderops.projections import (
@@ -26,6 +35,25 @@ def _parse_json_object(value: str | None, *, field: str) -> dict[str, Any]:
     if not isinstance(parsed, dict):
         raise click.BadParameter(f"{field} must be a JSON object")
     return parsed
+
+
+def _load_json_object_file(path: Path | None, *, field: str) -> dict[str, Any]:
+    if path is None:
+        return {}
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise click.BadParameter(f"{field} must contain a JSON object") from exc
+    if not isinstance(parsed, dict):
+        raise click.BadParameter(f"{field} must contain a JSON object")
+    return parsed
+
+
+def _merge_json_objects(*objects: dict[str, Any]) -> dict[str, Any]:
+    merged: dict[str, Any] = {}
+    for item in objects:
+        merged.update(item)
+    return merged
 
 
 def _parse_ref(value: str) -> dict[str, Any]:
@@ -74,6 +102,21 @@ def _emit_projection_results(payload: list[dict[str, Any]], as_json: bool) -> No
         click.echo(
             f"{item['projection_type']}\t{item['record_count']}\t{item['path']}"
         )
+
+
+def _epic_run_state_payload(
+    *,
+    dry_run: bool,
+    path: Path,
+    state: dict[str, Any],
+    state_exists: bool,
+) -> dict[str, Any]:
+    return {
+        "dry_run": dry_run,
+        "path": str(path),
+        "state": state,
+        "state_exists": state_exists,
+    }
 
 
 def _store(ctx: click.Context) -> SqliteBuilderOpsStore:
@@ -424,6 +467,108 @@ def create_roadmap_execution_item(
     if idempotency_key:
         payload["idempotency_key"] = idempotency_key
     _handle_create(ctx, _store(ctx).create_roadmap_execution_item, payload, as_json)
+
+
+@builderops.group("epic-run-state", help="Record local deliver-issue-set epic run state.")
+def epic_run_state() -> None:
+    """Local coordination evidence for deliver-issue-set runs."""
+
+
+@epic_run_state.command(
+    "record",
+    help="Create or update an epic run-state file from explicit local evidence.",
+)
+@click.option("--epic-issue-number", required=True, type=int)
+@click.option("--run-id", required=True)
+@click.option(
+    "--root",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Override epic run-state root. Defaults to runtime/builderops/epic-runs.",
+)
+@click.option("--update-json", default="{}", help="JSON object with run-state update fields.")
+@click.option(
+    "--update-file",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="Path to a JSON object with run-state update fields.",
+)
+@click.option("--dry-run", is_flag=True, help="Preview the state without writing a file.")
+@click.option("--json", "as_json", is_flag=True)
+def record_epic_run_state(
+    epic_issue_number: int,
+    run_id: str,
+    root: Path | None,
+    update_json: str,
+    update_file: Path | None,
+    dry_run: bool,
+    as_json: bool,
+) -> None:
+    updates = _merge_json_objects(
+        _load_json_object_file(update_file, field="update-file"),
+        _parse_json_object(update_json, field="update-json"),
+    )
+    try:
+        path = epic_run_state_path(run_id, root=root)
+        state_exists = path.exists()
+        if dry_run:
+            if state_exists:
+                base_state = load_epic_run_state(run_id, root=root)
+                if base_state["epic_issue_number"] != epic_issue_number:
+                    raise EpicRunStateError(
+                        f"run_id {run_id!r} already belongs to epic "
+                        f"{base_state['epic_issue_number']}"
+                    )
+            else:
+                base_state = new_epic_run_state(epic_issue_number, run_id)
+            state = apply_epic_run_update(base_state, **updates)
+        elif state_exists:
+            existing_state = load_epic_run_state(run_id, root=root)
+            if existing_state["epic_issue_number"] != epic_issue_number:
+                raise EpicRunStateError(
+                    f"run_id {run_id!r} already belongs to epic "
+                    f"{existing_state['epic_issue_number']}"
+                )
+            state = (
+                update_epic_run_state(run_id, root=root, **updates)
+                if updates
+                else existing_state
+            )
+        else:
+            state = create_epic_run_state(
+                epic_issue_number,
+                run_id,
+                root=root,
+                **updates,
+            )
+    except EpicRunStateError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    _emit(
+        _epic_run_state_payload(
+            dry_run=dry_run,
+            path=path,
+            state=state,
+            state_exists=state_exists,
+        ),
+        as_json,
+    )
+
+
+@epic_run_state.command("show", help="Read an existing epic run-state file.")
+@click.argument("run_id")
+@click.option(
+    "--root",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Override epic run-state root. Defaults to runtime/builderops/epic-runs.",
+)
+@click.option("--json", "as_json", is_flag=True)
+def show_epic_run_state(run_id: str, root: Path | None, as_json: bool) -> None:
+    try:
+        _emit(load_epic_run_state(run_id, root=root), as_json)
+    except (EpicRunStateError, FileNotFoundError) as exc:
+        raise click.ClickException(str(exc)) from exc
 
 
 @builderops.command("acquire-lease", help="Acquire or renew a BuilderOps record lease.")

--- a/tests/builderops/test_epic_run_state.py
+++ b/tests/builderops/test_epic_run_state.py
@@ -7,7 +7,9 @@ import json
 from pathlib import Path
 
 import pytest
+from click.testing import CliRunner
 
+from app.builderops.__main__ import _root as builderops_standalone_root
 from app.builderops.epic_run_state import (
     DEFAULT_EPIC_RUNS_DIR,
     EpicRunStateError,
@@ -21,6 +23,14 @@ from app.builderops.epic_run_state import (
     serialize_epic_run_state,
     update_epic_run_state,
 )
+
+
+def _run_builderops(args: list[str]):
+    return CliRunner().invoke(
+        builderops_standalone_root,
+        ["builderops", *args],
+        catch_exceptions=False,
+    )
 
 
 def test_create_load_update_round_trip_uses_temp_runtime(tmp_path: Path) -> None:
@@ -259,3 +269,184 @@ def test_apply_update_rejects_unknown_fields() -> None:
 
     with pytest.raises(EpicRunStateError, match="unknown run-state update"):
         apply_epic_run_update(state, run_id="other-run")
+
+
+def test_cli_dry_run_previews_state_without_writing(tmp_path: Path) -> None:
+    result = _run_builderops(
+        [
+            "epic-run-state",
+            "record",
+            "--epic-issue-number",
+            "3229",
+            "--run-id",
+            "run-dry",
+            "--root",
+            str(tmp_path),
+            "--update-json",
+            json.dumps(
+                {
+                    "child_queue": [
+                        {"issue_number": 3247, "state": "queued"},
+                    ],
+                    "dispatcher_status": {"db_exists": False},
+                }
+            ),
+            "--dry-run",
+            "--json",
+        ]
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["dry_run"] is True
+    assert payload["state_exists"] is False
+    assert payload["state"]["child_queue"] == [
+        {"issue_number": 3247, "state": "queued"}
+    ]
+    assert payload["state"]["dispatcher_status"] == {"db_exists": False}
+    assert not epic_run_state_path("run-dry", root=tmp_path).exists()
+
+
+def test_cli_record_resume_is_idempotent_for_epic_runner_fields(
+    tmp_path: Path,
+) -> None:
+    update = {
+        "child_queue": [{"issue_number": 3247, "state": "queued"}],
+        "issue_mappings": {
+            "3247": {
+                "branch": "codex/3247-deliver-issue-set-run-state",
+                "pr_number": 3250,
+                "worktree": "/tmp/wt-3247",
+            }
+        },
+        "validation_status": {"3247": {"pytest": "passed"}},
+        "review_findings": [{"id": "finding-3247", "status": "resolved"}],
+        "reusable_constraints": [
+            {"id": "state-not-authority", "text": "state is evidence only"}
+        ],
+        "follow_ups": [{"id": "follow-up-3247", "summary": "wire dispatcher later"}],
+        "stop_conditions": [
+            {"id": "no-github-dry-run-writes", "summary": "dry-run is local only"}
+        ],
+        "dispatcher_status": {"db_exists": False},
+        "compact_receipts": [{"id": "receipt-3247", "summary": "state recorded"}],
+        "last_verified_head_sha": "abc1234",
+    }
+    args = [
+        "epic-run-state",
+        "record",
+        "--epic-issue-number",
+        "3229",
+        "--run-id",
+        "run-resume",
+        "--root",
+        str(tmp_path),
+        "--update-json",
+        json.dumps(update),
+        "--json",
+    ]
+
+    first = _run_builderops(args)
+    second = _run_builderops(args)
+
+    assert first.exit_code == 0, first.output
+    assert second.exit_code == 0, second.output
+    first_payload = json.loads(first.output)
+    second_payload = json.loads(second.output)
+    assert first_payload["state"] == second_payload["state"]
+    state = second_payload["state"]
+    assert len(state["child_queue"]) == 1
+    assert len(state["review_findings"]) == 1
+    assert len(state["reusable_constraints"]) == 1
+    assert len(state["follow_ups"]) == 1
+    assert len(state["compact_receipts"]) == 1
+    assert state["issue_mappings"]["3247"]["pr_number"] == 3250
+    assert state["validation_status"]["3247"] == {"pytest": "passed"}
+    assert state["stop_conditions"] == update["stop_conditions"]
+    assert state["last_verified_head_sha"] == "abc1234"
+
+    shown = _run_builderops(
+        [
+            "epic-run-state",
+            "show",
+            "run-resume",
+            "--root",
+            str(tmp_path),
+            "--json",
+        ]
+    )
+    assert shown.exit_code == 0, shown.output
+    assert json.loads(shown.output) == state
+
+
+def test_cli_recreates_deleted_state_from_supplied_evidence(tmp_path: Path) -> None:
+    update = {
+        "child_queue": [{"issue_number": 3247, "state": "queued"}],
+        "reusable_constraints": [
+            {
+                "id": "rebuildable",
+                "text": "missing local state must be rebuilt from explicit evidence",
+            }
+        ],
+    }
+    args = [
+        "epic-run-state",
+        "record",
+        "--epic-issue-number",
+        "3229",
+        "--run-id",
+        "run-recreate",
+        "--root",
+        str(tmp_path),
+        "--update-json",
+        json.dumps(update),
+        "--json",
+    ]
+
+    created = _run_builderops(args)
+    assert created.exit_code == 0, created.output
+    epic_run_state_path("run-recreate", root=tmp_path).unlink()
+
+    recreated = _run_builderops(args)
+
+    assert recreated.exit_code == 0, recreated.output
+    state = json.loads(recreated.output)["state"]
+    assert state["epic_issue_number"] == 3229
+    assert state["child_queue"] == update["child_queue"]
+    assert state["reusable_constraints"] == update["reusable_constraints"]
+
+
+def test_cli_rejects_epic_mismatch_before_writing(tmp_path: Path) -> None:
+    create_epic_run_state(
+        3229,
+        "run-owned-by-3229",
+        root=tmp_path,
+        child_queue=[{"issue_number": 3247, "state": "queued"}],
+    )
+
+    result = _run_builderops(
+        [
+            "epic-run-state",
+            "record",
+            "--epic-issue-number",
+            "3230",
+            "--run-id",
+            "run-owned-by-3229",
+            "--root",
+            str(tmp_path),
+            "--update-json",
+            json.dumps(
+                {
+                    "child_queue": [
+                        {"issue_number": 9999, "state": "should-not-write"}
+                    ]
+                }
+            ),
+            "--json",
+        ]
+    )
+
+    assert result.exit_code != 0
+    assert "already belongs to epic 3229" in result.output
+    state = load_epic_run_state("run-owned-by-3229", root=tmp_path)
+    assert state["child_queue"] == [{"issue_number": 3247, "state": "queued"}]


### PR DESCRIPTION
Fixes #3247

Parent: #3229

## Summary
- Add `builderops epic-run-state record/show` so deliver-issue-set can create, update, dry-run, and resume local epic run-state from explicit evidence.
- Update the deliver-issue-set contract to treat run-state as discardable coordination evidence, not authority, and keep dispatcher/lifecycle/sub-agent behavior unchanged.

## Validation
- pytest -q tests/builderops/test_epic_run_state.py tests/builderops/test_builderops_cli_automation.py
- python3 -m py_compile app/builderops/epic_run_state.py app/builderops/cli.py
- ruff check app tests companion-ui/companion-app
- python3 scripts/lint_skills_consistency.py
- git diff --check
- manual non-mutating dry-run and resume/idempotency sanity checks

## Dispatcher / lifecycle note
Dispatcher unavailable locally (`db_exists: false`) so GitHub-label-only claim fallback was used. This PR does not modify dispatcher, lifecycle, Project, label, merge, closure, or sub-agent behavior.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: #3247 and this PR provide the durable delivery evidence; no separate BuilderOps record was needed.
