### PR TITLE
audit: close deployment and promotion guard review findings

### DIFF
--- a/.codex/skills/execute-promotion/SKILL.md
+++ b/.codex/skills/execute-promotion/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: execute-promotion
-description: "Execute a reviewed promotion plan: in checkout mode move the stable ref, apply migrations, and restart from the updated checkout; in pinned-image mode run scripts/deploy_channel.sh for the authorized SHA. Requires a complete, operator-acknowledged promotion plan from prepare-promotion."
+description: "Execute a reviewed promotion plan: in checkout mode move the stable ref, apply migrations, and restart from the updated checkout; in pinned-image mode run scripts/deploy_channel.sh deploy for the authorized SHA. Requires a complete, operator-acknowledged promotion plan from prepare-promotion."
 ---
 
 # Execute Promotion
@@ -31,6 +31,10 @@ receipt itself as runtime memory or Product truth.
 
 ## Stable-branch protection and PR-based advancement
 
+This section applies to checkout / gated-`stable` execution only. Pinned-image mode does not advance
+`stable`; it uses the ADR-0040-authorized SHA and `scripts/deploy_channel.sh deploy` after the
+deployment-model switch below resolves to pinned-image.
+
 `origin/stable` is a **protected branch** (`enforce_admins: true`; required status checks: `smoke`, `smoke-docker`, `pr-contract`; PR required). Direct pushes and refs-API updates to `stable` are rejected by GitHub.
 
 Every stable-ref advancement therefore proceeds through a **governed PR targeting `stable`**, not a direct push or annotated-tag force-push:
@@ -43,6 +47,9 @@ Every stable-ref advancement therefore proceeds through a **governed PR targetin
 Never introduce a direct protected-branch ref mutation as the normal promotion path.
 
 ## Ancestry preflight (fail-closed)
+
+This preflight is checkout / gated-`stable` only. Pinned-image mode does not fail on dormant
+`origin/stable` ancestry while ADR-0040 authorizes prod from the current promotion ref.
 
 Before any stable-ref movement, verify that the current `stable` is an ancestor of the promotion candidate:
 
@@ -80,7 +87,7 @@ Before any physical deploy step, resolve the target channel's deployment model:
   authority for which SHA may be promoted, then execute the physical deploy through:
 
   ```bash
-  scripts/deploy_channel.sh prod <authorized-sha> --ack-forward-only
+  scripts/deploy_channel.sh deploy prod <authorized-sha> --ack-forward-only
   ```
 
   The script owns the pin bump, migration gate, API/worker/watcher/heimdal-capture-watch/gateway
@@ -111,7 +118,7 @@ Before any physical deploy step, resolve the target channel's deployment model:
 **Pinned-image model (post-cutover):**
 
 11. Confirms the plan names the authorized SHA and that the matching image tag is available.
-12. Runs `scripts/deploy_channel.sh prod <authorized-sha>` with the required forward-only migration acknowledgment flag when the plan contains acknowledged forward-only migrations. This script is the only physical deploy step in pinned-image mode.
+12. Runs `scripts/deploy_channel.sh deploy prod <authorized-sha>` with the required forward-only migration acknowledgment flag when the plan contains acknowledged forward-only migrations. This script is the only physical deploy step in pinned-image mode.
 13. Reads and records the deploy receipt at `ops/deployments/prod-latest.json`, including the deployed SHA and health/smoke outcome.
 
 14. Appends the promotion execution receipt to the plan file: timestamp, operator, deployment model, merged PR URL or deploy receipt path, which ref/SHA was authorized, which migrations applied, and process recreate/restart confirmation.
@@ -120,10 +127,19 @@ Before any physical deploy step, resolve the target channel's deployment model:
 ## Pre-conditions
 
 - A complete promotion plan produced by `prepare-promotion` exists and all operator acknowledgments are ticked.
-- `git merge-base --is-ancestor origin/stable <candidate-sha>` passes (ancestry preflight; see above).
 - The prod Postgres container is running (`make prod-up` healthy).
+- The active deployment model has been resolved before execution.
+
+**Checkout model only:**
+
+- `git merge-base --is-ancestor origin/stable <candidate-sha>` passes (ancestry preflight; see above).
 - The prod checkout (separate worktree, per `docs/RELEASE_CHANNELS/DEFINE_CONCURRENCY_RULE.md`) is available.
 - `origin/stable` resolves to the current prod commit.
+
+**Pinned-image model only:**
+
+- The plan names the ADR-0040-authorized SHA for the current promotion ref.
+- The matching pinned image tag is available to `scripts/deploy_channel.sh deploy`.
 
 ## Operator steps
 

--- a/app/release_channels/cutover_readiness.py
+++ b/app/release_channels/cutover_readiness.py
@@ -118,6 +118,7 @@ class _MigrationDelta:
     pending: tuple[MigrationInfo, ...] = ()
     forward_only: tuple[MigrationInfo, ...] = ()
     head_revision: str | None = None
+    unreachable_detail: str | None = None
 
 
 def _default_runner(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
@@ -459,34 +460,65 @@ def _head_revision(migrations: Mapping[str, MigrationInfo]) -> str | None:
     return heads[-1] if heads else None
 
 
-def _path_from_revision_to_head(
+def _ancestor_revisions(
     migrations: Mapping[str, MigrationInfo],
-    *,
     current: str | None,
-    db_revision: str | None,
-    seen: frozenset[str] = frozenset(),
-) -> list[MigrationInfo] | None:
+    *,
+    visiting: frozenset[str] = frozenset(),
+) -> frozenset[str] | None:
     if current is None:
-        return [] if db_revision is None else None
-    if current == db_revision:
-        return []
-    if current in seen:
+        return frozenset()
+    if current in visiting:
         return None
     info = migrations.get(current)
     if info is None:
         return None
 
-    next_seen = seen | {current}
+    ancestors = {current}
+    next_visiting = visiting | {current}
     for parent in info.down_revisions or (None,):
-        parent_path = _path_from_revision_to_head(
+        parent_ancestors = _ancestor_revisions(
             migrations,
-            current=parent,
-            db_revision=db_revision,
-            seen=next_seen,
+            parent,
+            visiting=next_visiting,
         )
-        if parent_path is not None:
-            return [*parent_path, info]
-    return None
+        if parent_ancestors is None:
+            return None
+        ancestors.update(parent_ancestors)
+    return frozenset(ancestors)
+
+
+def _postorder_to_revision(
+    migrations: Mapping[str, MigrationInfo],
+    current: str | None,
+) -> list[MigrationInfo] | None:
+    ordered: list[MigrationInfo] = []
+    emitted: set[str] = set()
+    visiting: set[str] = set()
+
+    def visit(revision: str | None) -> bool:
+        if revision is None:
+            return True
+        if revision in emitted:
+            return True
+        if revision in visiting:
+            return False
+        info = migrations.get(revision)
+        if info is None:
+            return False
+
+        visiting.add(revision)
+        for parent in info.down_revisions or (None,):
+            if not visit(parent):
+                return False
+        visiting.remove(revision)
+        emitted.add(revision)
+        ordered.append(info)
+        return True
+
+    if not visit(current):
+        return None
+    return ordered
 
 
 def _pending_migration_delta(migrations_dir: Path, db_revision: str | None) -> _MigrationDelta:
@@ -495,19 +527,38 @@ def _pending_migration_delta(migrations_dir: Path, db_revision: str | None) -> _
     if head is None:
         return _MigrationDelta(head_revision=None)
 
-    pending = _path_from_revision_to_head(
-        migrations,
-        current=head,
-        db_revision=db_revision,
+    head_ancestors = _ancestor_revisions(migrations, head)
+    ordered_to_head = _postorder_to_revision(migrations, head)
+    if head_ancestors is None or ordered_to_head is None:
+        return _MigrationDelta(
+            head_revision=head,
+            unreachable_detail="migration graph is incomplete or cyclic",
+        )
+    if db_revision not in head_ancestors:
+        return _MigrationDelta(
+            head_revision=head,
+            unreachable_detail=(
+                f"DB revision {db_revision} is not reachable from selected Alembic head {head}"
+            ),
+        )
+
+    db_ancestors = _ancestor_revisions(migrations, db_revision)
+    if db_ancestors is None:
+        return _MigrationDelta(
+            head_revision=head,
+            unreachable_detail="migration graph is incomplete or cyclic",
+        )
+
+    pending_revisions = head_ancestors - db_ancestors
+    pending = tuple(
+        info for info in ordered_to_head if info.revision in pending_revisions
     )
-    if pending is None:
-        pending = []
 
     forward_only = [
         info for info in pending if classify_migration(info.path).classification == FORWARD_ONLY
     ]
     return _MigrationDelta(
-        pending=tuple(pending),
+        pending=pending,
         forward_only=tuple(forward_only),
         head_revision=head,
     )
@@ -545,6 +596,11 @@ def _check_migration_state(
         delta = _pending_migration_delta(root / "app" / "alembic" / "versions", db_revision)
     except MigrationMarkerError as exc:
         return ReadinessCheck("migration-state", False, str(exc)), _MigrationDelta()
+    if delta.unreachable_detail is not None:
+        return (
+            ReadinessCheck("migration-state", False, delta.unreachable_detail),
+            delta,
+        )
     if not delta.pending:
         return (
             ReadinessCheck(

--- a/app/release_channels/fleet_model_fitness.py
+++ b/app/release_channels/fleet_model_fitness.py
@@ -247,8 +247,14 @@ def check_fleet_model_fitness(
         for service in ALL_SERVICES
     )
     app_services = tuple(service for service in services if service.service in APP_CODE_SERVICES)
+    app_bind_services = tuple(service for service in app_services if service.has_app_bind_mount)
     bind_services = tuple(service for service in services if service.has_app_bind_mount)
-    model = "checkout" if bind_services else "pinned-image"
+    if not bind_services:
+        model = "pinned-image"
+    elif len(app_bind_services) == len(APP_CODE_SERVICES):
+        model = "checkout"
+    else:
+        model = "mixed"
 
     # The observed deployment model is physical: a live /app bind mount means
     # checkout/hot-reload, even when the image tag happens to equal the pin.
@@ -263,6 +269,12 @@ def check_fleet_model_fitness(
         )
 
     violations: list[str] = []
+    if model == "mixed":
+        names = ", ".join(service.service for service in bind_services)
+        violations.append(
+            f"mixed pinned/checkout fleet for channel '{channel}': live /app "
+            f"bind-mount(s) on {names}"
+        )
     if model == "checkout" and require_pinned:
         names = ", ".join(service.service for service in bind_services)
         violations.append(

--- a/tests/deploy/test_cutover_readiness.py
+++ b/tests/deploy/test_cutover_readiness.py
@@ -239,9 +239,7 @@ def test_pending_forward_only_migrations_listed_and_gated(tmp_path: Path) -> Non
     assert "002_forward_only.py" in result.summary()
 
 
-def test_merge_revision_down_revision_tuple_does_not_leave_old_base_as_head(
-    tmp_path: Path,
-) -> None:
+def test_merge_revision_walks_all_parent_paths(tmp_path: Path) -> None:
     _write_base_fixture(tmp_path)
     versions = tmp_path / "app" / "alembic" / "versions"
     for child in versions.iterdir():
@@ -279,12 +277,90 @@ def test_merge_revision_down_revision_tuple_does_not_leave_old_base_as_head(
         "prod",
         TARGET_SHA,
         root=tmp_path,
-        db_revision="head",
+        db_revision="left",
         runner=_runner,
     )
 
     assert result.ok, result.summary()
+    assert result.pending_migrations == ("right_base.py", "merge.py", "head.py")
+
+
+def test_merge_revision_lists_shared_pending_parent_once(tmp_path: Path) -> None:
+    _write_base_fixture(tmp_path)
+    versions = tmp_path / "app" / "alembic" / "versions"
+    for child in versions.iterdir():
+        child.unlink()
+    _write_migration(
+        tmp_path,
+        filename="001_base.py",
+        revision="001",
+        down_revision=None,
+        reversibility="reversible",
+    )
+    _write_migration(
+        tmp_path,
+        filename="002_shared.py",
+        revision="002",
+        down_revision="001",
+        reversibility="reversible",
+    )
+    _write_migration(
+        tmp_path,
+        filename="left.py",
+        revision="left",
+        down_revision="002",
+        reversibility="reversible",
+    )
+    _write_migration(
+        tmp_path,
+        filename="right.py",
+        revision="right",
+        down_revision="002",
+        reversibility="reversible",
+    )
+    _write_migration(
+        tmp_path,
+        filename="merge.py",
+        revision="merge",
+        down_revision=("left", "right"),
+        reversibility="reversible",
+    )
+
+    result = check_cutover_readiness(
+        "prod",
+        TARGET_SHA,
+        root=tmp_path,
+        db_revision="001",
+        runner=_runner,
+    )
+
+    assert result.ok, result.summary()
+    assert result.pending_migrations == ("002_shared.py", "left.py", "right.py", "merge.py")
+
+
+def test_unreachable_db_revision_fails_migration_state(tmp_path: Path) -> None:
+    _write_base_fixture(tmp_path)
+    _write_migration(
+        tmp_path,
+        filename="002_reversible.py",
+        revision="002",
+        down_revision="001",
+        reversibility="reversible",
+    )
+
+    result = check_cutover_readiness(
+        "prod",
+        TARGET_SHA,
+        root=tmp_path,
+        db_revision="stale_branch",
+        runner=_runner,
+    )
+
+    assert not result.ok
     assert result.pending_migrations == ()
+    summary = result.summary()
+    assert "migration-state" in summary
+    assert "not reachable from selected Alembic head" in summary
 
 
 def test_missing_migration_marker_fails_without_raising(tmp_path: Path) -> None:

--- a/tests/deploy/test_fleet_model_fitness.py
+++ b/tests/deploy/test_fleet_model_fitness.py
@@ -105,7 +105,7 @@ def test_bind_mount_in_pinned_mode_fails_naming_service(tmp_path: Path) -> None:
         http_get_json=_http_runner(),
     )
 
-    assert result.model == "checkout"
+    assert result.model == "mixed"
     assert result.expected_model == "pinned-image"
     assert not result.ok
     assert any("api" in violation and "/app" in violation for violation in result.violations)
@@ -170,7 +170,7 @@ def test_checkout_model_reports_without_failing(tmp_path: Path) -> None:
     assert result.to_receipt()["model"] == "checkout"
 
 
-def test_bind_mount_with_pin_reports_checkout_without_failing(tmp_path: Path) -> None:
+def test_mixed_pinned_checkout_fleet_fails(tmp_path: Path) -> None:
     root = _root_with_pin(tmp_path)
     inspections = _all_services(api={"app_bind": True})
 
@@ -181,9 +181,12 @@ def test_bind_mount_with_pin_reports_checkout_without_failing(tmp_path: Path) ->
         http_get_json=_http_runner(),
     )
 
-    assert result.ok
-    assert result.model == "checkout"
-    assert result.to_receipt()["ok"] is True
+    assert not result.ok
+    assert result.model == "mixed"
+    assert result.to_receipt()["ok"] is False
+    joined = "\n".join(result.violations)
+    assert "mixed pinned/checkout fleet" in joined
+    assert "api" in joined
 
 
 def test_mixed_fleet_cannot_greenlight_pinned_deploy_receipt(tmp_path: Path) -> None:
@@ -202,31 +205,32 @@ def test_mixed_fleet_cannot_greenlight_pinned_deploy_receipt(tmp_path: Path) -> 
     )
 
     receipt = result.to_receipt()
-    assert result.model == "checkout"
+    assert result.model == "mixed"
     assert not result.ok
     assert receipt["ok"] is False
-    assert receipt["model"] == "checkout"
+    assert receipt["model"] == "mixed"
     assert receipt["expected_model"] == "pinned-image"
     joined = "\n".join(result.violations)
-    assert "expected pinned-image model" in joined
+    assert "mixed pinned/checkout fleet" in joined
     assert "worker-drift" in joined
 
 
-def test_gateway_bind_mount_fails_when_pinned_required(tmp_path: Path) -> None:
+def test_gateway_app_bind_mount_is_rejected(tmp_path: Path) -> None:
     root = _root_with_pin(tmp_path)
     inspections = _all_services(**{"companion-ui": {"app_bind": True}})
 
     result = check_fleet_model_fitness(
         "prod",
         root=root,
-        require_pinned=True,
         docker_runner=_docker_runner(inspections),
         http_get_json=_http_runner(),
     )
 
     receipt = result.to_receipt()
     assert not result.ok
+    assert result.model == "mixed"
     assert receipt["ok"] is False
     joined = "\n".join(result.violations)
+    assert "mixed pinned/checkout fleet" in joined
     assert "companion-ui" in joined
     assert "/app" in joined


### PR DESCRIPTION
Closes #3241
Parent: #3236

## Summary

Fleet-model fitness:
- Rejects mixed pinned/checkout fleets instead of treating any `/app` bind mount as an informational checkout result.
- Includes the managed gateway in `/app` bind-mount drift evidence, so `companion-ui` bind mounts fail the guard instead of being ignored.

Cutover readiness:
- Replaces the single-parent Alembic path walk with ancestor-set delta logic so merge-parent paths are all considered.
- Fails `migration-state` loudly when the DB revision is not reachable from the selected Alembic head.
- Fixed an independent local-review finding by de-duplicating shared pending ancestors in merge graphs and adding regression coverage.

Promotion skill docs:
- Corrects pinned-image examples to `scripts/deploy_channel.sh deploy prod <authorized-sha>`.
- Scopes `stable` branch advancement, ancestry preflight, and checkout requirements to checkout / gated-`stable` mode rather than ADR-0040 pinned-image mode.

## Files changed

- `.codex/skills/execute-promotion/SKILL.md`
- `app/release_channels/fleet_model_fitness.py`
- `app/release_channels/cutover_readiness.py`
- `tests/deploy/test_fleet_model_fitness.py`
- `tests/deploy/test_cutover_readiness.py`

## Validation

- `python3 -m pytest tests/deploy/test_fleet_model_fitness.py tests/deploy/test_cutover_readiness.py` — PASS (`17 passed`).
- `ruff check app/release_channels/fleet_model_fitness.py app/release_channels/cutover_readiness.py tests/deploy` — PASS.
- `python3 scripts/lint_skills_consistency.py` — PASS.
- `git diff --check` — PASS.
- Required focused regressions — PASS as part of the full pytest run:
  - `tests/deploy/test_fleet_model_fitness.py::test_mixed_pinned_checkout_fleet_fails`
  - `tests/deploy/test_fleet_model_fitness.py::test_gateway_app_bind_mount_is_rejected`
  - `tests/deploy/test_cutover_readiness.py::test_merge_revision_walks_all_parent_paths`
  - `tests/deploy/test_cutover_readiness.py::test_unreachable_db_revision_fails_migration_state`
- Note: local `python` is not installed in this shell, so the requested pytest command was run as `python3 -m pytest ...` with the same test targets.
- Independent local review gate — initially found duplicate shared merge ancestors; fixed in this PR with `test_merge_revision_lists_shared_pending_parent_once`; final validation above passed after the fix.

## Source-anchor review threads closed

- `https://github.com/RasmusTho/agentic-pkm-mvp/pull/3207#discussion_r3546118327` — mixed pinned/checkout fleets now fail instead of reporting checkout OK.
- `https://github.com/RasmusTho/agentic-pkm-mvp/pull/3207#discussion_r3546118336` — `companion-ui` gateway `/app` bind mounts now participate in bind-mount drift failures.
- `https://github.com/RasmusTho/agentic-pkm-mvp/pull/3208#discussion_r3546295412` — cutover readiness now walks all merge-parent ancestry before declaring migration readiness.
- `https://github.com/RasmusTho/agentic-pkm-mvp/pull/3208#discussion_r3546295417` — unreachable DB revisions now fail `migration-state` instead of producing an empty pending set.
- `https://github.com/RasmusTho/agentic-pkm-mvp/pull/3206#discussion_r3546031481` — pinned-image deploy examples include the required `deploy` subcommand.
- `https://github.com/RasmusTho/agentic-pkm-mvp/pull/3206#discussion_r3546031488` — stable/checkout gates are scoped away from ADR-0040 pinned-image promotion mode.

## Already-fixed evidence

No listed #3241 finding was already fixed on current `main`; all six assigned findings required this PR. Existing adjacent tests covered some pinned-mode failures, but the exact assigned mixed-fleet, gateway bind-mount, all-merge-parent, and unreachable-DB revision contracts were not fully closed before this patch.

## Guardrail confirmation

No promotions, deploys, live channel changes, branch-protection changes, auto-merge changes, required-check changes, governance artifact tooling changes, runtime API docs changes, BuilderOps run-state changes, unrelated Product/Runtime changes, or broad governance rewrites were made.

## BuilderOps Routing

- Records/projections/receipts: issue #3241 claim receipt and this PR validation evidence.
- Reason: no BuilderOps runtime records or projections were created; this is a bounded governance/deployment guard repair.