### PR TITLE
Split PR CI by subsystem SoI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
       # the full `tests` job, which autoloads plugins. See issue #2036.
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -40,6 +42,17 @@ jobs:
         run: |
           set -o pipefail
           pytest -q -m "not pg" tests/eval/test_classification_golden.py
+      - name: Fetch PR base ref
+        shell: bash
+        run: git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+      - name: Select subsystem-scoped pytest targets
+        id: select-tests
+        shell: bash
+        run: |
+          python scripts/select_pr_tests.py \
+            --base-ref "origin/${{ github.base_ref }}" \
+            --head-ref HEAD \
+            --github-output "$GITHUB_OUTPUT"
       - name: Run not-pg unit tests
         shell: bash
         timeout-minutes: 22
@@ -56,7 +69,9 @@ jobs:
           PYTEST_ADDOPTS: "--timeout=120 --timeout-method=thread"
         run: |
           set -o pipefail
-          pytest -q -m "not pg" | tee pytest-not-pg.log
+          echo "Selected subsystems: ${{ steps.select-tests.outputs.subsystems }}"
+          echo "Selection reason: ${{ steps.select-tests.outputs.reason }}"
+          pytest ${{ steps.select-tests.outputs.pytest_args }} | tee pytest-not-pg.log
       - name: Upload test logs
         if: always()
         uses: actions/upload-artifact@v4

--- a/docs/development/TEST_STRATEGY_HOT_PATH.md
+++ b/docs/development/TEST_STRATEGY_HOT_PATH.md
@@ -20,6 +20,8 @@ The goal is to keep docs-only and governance/skill PRs cheap while preserving di
 - The broad runtime smoke workflows live in `.github/workflows/smoke.yml` and `.github/workflows/ci-smoke.yaml`.
 - Governance PR contract checks live in `.github/workflows/issue-pr-governance.yml`.
 - The hot-path and direct-repair invariants are covered by `tests/architecture/test_pr_hot_path_governance.py`.
+- PR unit CI uses `scripts/select_pr_tests.py` to map changed files to subsystem-scoped pytest targets. Shared CI/test config, migrations, dependencies, or unknown surfaces fall back to the full `pytest -q -m "not pg"` suite.
+- E2E tests under `tests/e2e/` are selected by owned file targets, not by the whole directory, for subsystem-scoped PR CI. New unowned e2e files fall back to the full not-pg suite until assigned to a subsystem.
 
 ## Check Levels
 
@@ -63,7 +65,7 @@ The goal is to keep docs-only and governance/skill PRs cheap while preserving di
 
 - Run level 1.
 - Run level 2 if the change affects skills or agent entrypoints.
-- Run level 4 for the touched runtime surface.
+- Run level 4 for the touched runtime surface. In PR CI, the touched System of Interest is selected from changed paths and mapped to focused pytest targets; cross-subsystem and unknown changes use the full not-pg fallback.
 - Run level 5 only when the touched runtime surface is the thing smoke is meant to prove.
 - Use level 6 for promotion or release validation.
 
@@ -76,7 +78,9 @@ The goal is to keep docs-only and governance/skill PRs cheap while preserving di
 - Docs-only PRs should not run full runtime smoke by default.
 - Governance/skill PRs should run cheap skill coherence and workflow invariant tests before any broader smoke.
 - Runtime PRs should run focused tests first and add smoke only when the runtime surface is actually touched.
+- Subsystem-scoped CI must be conservative: workflow/test configuration, dependency files, migrations, shared fixtures, and unmapped runtime paths choose the full not-pg suite rather than silently skipping risk.
+- E2E coverage must be split by subsystem-owned files. A subsystem target may include only the e2e flows it owns or shares; `tests/e2e` as a whole is reserved for full fallback, nightly, or explicit manual verification.
+- Slow or flaky test classes should be marked and routed to nightly/manual workflows unless the changed subsystem explicitly owns their risk.
 - Direct repair PRs are classified by the surfaces they touch, not by whether they carry a governing issue.
 - Failing required checks must be classified, not ignored as out-of-scope.
 - A required check that is stale, missing, or unrelated to the current head SHA is a blocking classification problem, not a silent pass.
-

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+import argparse
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ALWAYS_TARGETS = (
+    "tests/ci",
+    "tests/governance/test_branch_guardrail_packet.py",
+    "tests/ops/test_ci_workflow.py",
+    "tests/scripts/test_select_pr_tests.py",
+)
+
+FULL_SUITE_REASONS = (
+    "shared CI/test/runtime configuration changed",
+    "database migration or schema surface changed",
+    "no subsystem mapping matched",
+)
+
+FULL_SUITE_EXACT = {
+    "conftest.py",
+    "pytest.ini",
+    "pyproject.toml",
+    "requirements.txt",
+    "dev-requirements.txt",
+    "docker-compose.test.yml",
+    ".github/workflows/ci.yml",
+    "scripts/select_pr_tests.py",
+}
+
+FULL_SUITE_PREFIXES = (
+    ".github/workflows/",
+    "alembic/",
+    "tests/conftest.py",
+    "app/db/",
+    "app/testing/",
+)
+
+DOCS_TARGETS = (
+    "tests/docs",
+    "tests/architecture",
+    "tests/governance",
+)
+
+GOVERNANCE_TARGETS = (
+    "tests/governance",
+    "tests/scripts",
+    "tests/ops/test_ci_workflow.py",
+)
+
+E2E_TARGETS = {
+    "companion_ui": (
+        "tests/e2e/test_panel_to_promotion_consume.py",
+        "tests/e2e/test_panel_watcher_e2e.py",
+    ),
+    "watcher_sync": (
+        "tests/e2e/test_runtime_loop_vault_test.py",
+        "tests/e2e/test_watcher_registry_e2e.py",
+        "tests/e2e/test_panel_watcher_e2e.py",
+    ),
+    "orchestration": (
+        "tests/e2e/test_pipe_graph.py",
+        "tests/e2e/test_runtime_contract_regressions.py",
+    ),
+    "memory_retrieval": (
+        "tests/e2e/test_index_rules_e2e.py",
+        "tests/e2e/test_promotion_intent_to_index.py",
+        "tests/e2e/test_reality_mvp_pipeline.py",
+    ),
+    "llm_eval": (
+        "tests/e2e/test_llm_routing_e2e.py",
+        "tests/e2e/test_panel_llm_e2e.py",
+    ),
+    "promotion_panel": (
+        "tests/e2e/test_panel_to_promotion_consume.py",
+        "tests/e2e/test_panel_watcher_e2e.py",
+        "tests/e2e/test_promotion_intent_to_index.py",
+        "tests/e2e/test_panel_llm_e2e.py",
+    ),
+    "ops_deploy": (
+        "tests/e2e/test_operator_workflows.py",
+        "tests/e2e/test_human_need_uat.py",
+    ),
+}
+
+E2E_OWNER_BY_FILE = {
+    target: subsystem for subsystem, targets in E2E_TARGETS.items() for target in targets
+}
+
+SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
+    (
+        "settings",
+        ("app/settings/", "docs/settings/", "tests/settings/", "tests/config/"),
+        ("tests/settings", "tests/config"),
+    ),
+    (
+        "vault",
+        ("app/vault/", "tests/vault/", "tests/knowledge/", "docs/VAULT", "docs/builderops/BUILDEROPS_VAULT"),
+        ("tests/vault", "tests/knowledge", "tests/ports"),
+    ),
+    (
+        "companion_ui",
+        ("companion-ui/", "app/api/", "tests/companion_ui/", "tests/api/"),
+        ("tests/companion_ui", "tests/api", *E2E_TARGETS["companion_ui"]),
+    ),
+    (
+        "watcher_sync",
+        (
+            "app/watcher/",
+            "app/sync/",
+            "scripts/run_live_watcher.sh",
+            "tests/watcher/",
+            "tests/sync/",
+            "tests/e2e/test_runtime_loop_vault_test.py",
+            "tests/e2e/test_watcher_registry_e2e.py",
+            "tests/e2e/test_panel_watcher_e2e.py",
+        ),
+        ("tests/watcher", "tests/sync", *E2E_TARGETS["watcher_sync"]),
+    ),
+    (
+        "orchestration",
+        (
+            "app/orchestrator/",
+            "app/orchestration/",
+            "tests/orchestrator/",
+            "tests/orchestration/",
+            "tests/e2e/test_pipe_graph.py",
+            "tests/e2e/test_runtime_contract_regressions.py",
+        ),
+        ("tests/orchestrator", "tests/orchestration", *E2E_TARGETS["orchestration"]),
+    ),
+    (
+        "memory_retrieval",
+        (
+            "app/memory/",
+            "app/retrieval/",
+            "app/index/",
+            "tests/agent_memory/",
+            "tests/retrieval/",
+            "tests/indexer/",
+            "tests/e2e/test_index_rules_e2e.py",
+            "tests/e2e/test_promotion_intent_to_index.py",
+            "tests/e2e/test_reality_mvp_pipeline.py",
+        ),
+        ("tests/agent_memory", "tests/retrieval", "tests/indexer", "tests/search", *E2E_TARGETS["memory_retrieval"]),
+    ),
+    (
+        "llm_eval",
+        (
+            "app/llm/",
+            "app/eval/",
+            "docs/eval/",
+            "tests/llm/",
+            "tests/eval/",
+            "tests/evals/",
+            "tests/e2e/test_llm_routing_e2e.py",
+            "tests/e2e/test_panel_llm_e2e.py",
+        ),
+        ("tests/llm", "tests/eval", "tests/evals", *E2E_TARGETS["llm_eval"]),
+    ),
+    (
+        "events_receipts",
+        ("app/events/", "app/receipts/", "docs/contracts/events/", "tests/events/", "tests/receipts/"),
+        ("tests/events", "tests/receipts", "tests/contracts"),
+    ),
+    (
+        "promotion_panel",
+        (
+            "app/promotion/",
+            "app/panel/",
+            "tests/promotion/",
+            "tests/panel/",
+            "tests/e2e/test_panel_to_promotion_consume.py",
+            "tests/e2e/test_panel_watcher_e2e.py",
+            "tests/e2e/test_promotion_intent_to_index.py",
+            "tests/e2e/test_panel_llm_e2e.py",
+        ),
+        ("tests/promotion", "tests/panel", *E2E_TARGETS["promotion_panel"]),
+    ),
+    (
+        "ops_deploy",
+        ("scripts/", "ops/", "tests/ops/", "tests/scripts/", "tests/deploy/"),
+        ("tests/ops", "tests/scripts", "tests/deploy"),
+    ),
+)
+
+
+@dataclass(frozen=True)
+class Selection:
+    full_suite: bool
+    subsystems: tuple[str, ...]
+    targets: tuple[str, ...]
+    reason: str
+
+    @property
+    def pytest_args(self) -> str:
+        if self.full_suite:
+            return '-q -m "not pg"'
+        return " ".join(("-q", '-m "not pg"', *self.targets))
+
+
+def _normalize(path: str) -> str:
+    normalized = path.strip().replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
+
+
+def _dedupe(items: list[str]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in items:
+        if item and item not in seen:
+            seen.add(item)
+            result.append(item)
+    return tuple(result)
+
+
+def _is_full_suite_file(path: str) -> bool:
+    return path in FULL_SUITE_EXACT or any(path.startswith(prefix) for prefix in FULL_SUITE_PREFIXES)
+
+
+def _is_docs_only(paths: tuple[str, ...]) -> bool:
+    return bool(paths) and all(path.startswith("docs/") or path in {"README.md", "AGENTS.md"} for path in paths)
+
+
+def _is_governance_only(paths: tuple[str, ...]) -> bool:
+    governance_prefixes = (".github/", "docs/development/", "AGENTS.md", ".codex/")
+    return bool(paths) and all(path.startswith(governance_prefixes) for path in paths)
+
+
+def select_tests(changed_files: list[str]) -> Selection:
+    paths = tuple(path for path in (_normalize(item) for item in changed_files) if path)
+    if not paths:
+        return Selection(True, (), (), "no changed files were provided")
+
+    if any(_is_full_suite_file(path) for path in paths):
+        return Selection(True, (), (), FULL_SUITE_REASONS[0])
+
+    if any(path.startswith("tests/e2e/") and path not in E2E_OWNER_BY_FILE for path in paths):
+        return Selection(True, (), (), "unowned e2e test changed")
+
+    if any(path.startswith("alembic/") or path.startswith("tests/migrations/") for path in paths):
+        return Selection(True, (), (), FULL_SUITE_REASONS[1])
+
+    targets = list(ALWAYS_TARGETS)
+    subsystems: list[str] = []
+
+    if _is_docs_only(paths):
+        return Selection(False, ("docs",), _dedupe([*targets, *DOCS_TARGETS]), "docs-only PR")
+
+    if _is_governance_only(paths):
+        return Selection(False, ("governance",), _dedupe([*targets, *GOVERNANCE_TARGETS]), "governance-only PR")
+
+    for name, prefixes, subsystem_targets in SUBSYSTEMS:
+        if any(path.startswith(prefix) for path in paths for prefix in prefixes):
+            subsystems.append(name)
+            targets.extend(subsystem_targets)
+
+    if not subsystems:
+        return Selection(True, (), (), FULL_SUITE_REASONS[2])
+
+    return Selection(False, _dedupe(subsystems), _dedupe(targets), "matched subsystem SoI")
+
+
+def changed_files_from_git(base_ref: str, head_ref: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "diff", "--name-only", f"{base_ref}...{head_ref}"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def _write_github_output(path: str, selection: Selection) -> None:
+    output = Path(path)
+    with output.open("a", encoding="utf-8") as handle:
+        handle.write(f"full_suite={'true' if selection.full_suite else 'false'}\n")
+        handle.write(f"subsystems={','.join(selection.subsystems) or 'all'}\n")
+        handle.write(f"pytest_args={selection.pytest_args}\n")
+        handle.write(f"reason={selection.reason}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Select PR pytest targets from changed subsystem files.")
+    parser.add_argument("--changed-file", action="append", default=[], help="Changed file path. Repeatable.")
+    parser.add_argument("--base-ref", default="", help="Base git ref for diff selection.")
+    parser.add_argument("--head-ref", default="HEAD", help="Head git ref for diff selection.")
+    parser.add_argument("--github-output", default="", help="Optional GITHUB_OUTPUT path.")
+    args = parser.parse_args()
+
+    changed = args.changed_file
+    if not changed and args.base_ref:
+        changed = changed_files_from_git(args.base_ref, args.head_ref)
+
+    selection = select_tests(changed)
+    print(f"full_suite={'true' if selection.full_suite else 'false'}")
+    print(f"subsystems={','.join(selection.subsystems) or 'all'}")
+    print(f"pytest_args={selection.pytest_args}")
+    print(f"reason={selection.reason}")
+
+    if args.github_output:
+        _write_github_output(args.github_output, selection)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ops/test_ci_workflow.py
+++ b/tests/ops/test_ci_workflow.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def _workflow_text() -> str:
+    return CI_WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_pr_ci_selects_subsystem_scoped_pytest_targets() -> None:
+    workflow = _workflow_text()
+
+    assert "Select subsystem-scoped pytest targets" in workflow
+    assert "scripts/select_pr_tests.py" in workflow
+    assert "steps.select-tests.outputs.pytest_args" in workflow
+    assert 'pytest ${{ steps.select-tests.outputs.pytest_args }} | tee pytest-not-pg.log' in workflow
+
+
+def test_pr_ci_fetches_base_ref_before_diff_selection() -> None:
+    workflow = _workflow_text()
+
+    assert "fetch-depth: 0" in workflow
+    assert 'git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"' in workflow

--- a/tests/scripts/test_select_pr_tests.py
+++ b/tests/scripts/test_select_pr_tests.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.select_pr_tests import select_tests
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_companion_ui_change_selects_companion_and_api_targets() -> None:
+    selection = select_tests(["companion-ui/companion-app/src/workspace.ts", "tests/api/test_status_api.py"])
+
+    assert selection.full_suite is False
+    assert "companion_ui" in selection.subsystems
+    assert "tests/companion_ui" in selection.targets
+    assert "tests/api" in selection.targets
+    assert "tests/e2e/test_panel_to_promotion_consume.py" in selection.targets
+    assert "tests/e2e" not in selection.targets
+    assert selection.pytest_args.startswith('-q -m "not pg"')
+
+
+def test_shared_ci_change_falls_back_to_full_not_pg_suite() -> None:
+    selection = select_tests([".github/workflows/ci.yml"])
+
+    assert selection.full_suite is True
+    assert selection.targets == ()
+    assert selection.pytest_args == '-q -m "not pg"'
+    assert "configuration" in selection.reason
+
+
+def test_docs_only_change_keeps_pr_ci_governance_scoped() -> None:
+    selection = select_tests(["docs/development/TEST_STRATEGY_HOT_PATH.md"])
+
+    assert selection.full_suite is False
+    assert selection.subsystems == ("docs",)
+    assert "tests/docs" in selection.targets
+    assert "tests/governance" in selection.targets
+
+
+def test_unknown_runtime_surface_uses_safe_full_suite_fallback() -> None:
+    selection = select_tests(["app/new_surface/example.py"])
+
+    assert selection.full_suite is True
+    assert "no subsystem mapping" in selection.reason
+
+
+def test_watcher_change_selects_only_watcher_owned_e2e_files() -> None:
+    selection = select_tests(["app/watcher/registry.py"])
+
+    assert selection.full_suite is False
+    assert selection.subsystems == ("watcher_sync",)
+    assert "tests/watcher" in selection.targets
+    assert "tests/e2e/test_runtime_loop_vault_test.py" in selection.targets
+    assert "tests/e2e/test_watcher_registry_e2e.py" in selection.targets
+    assert "tests/e2e/test_panel_watcher_e2e.py" in selection.targets
+    assert "tests/e2e/test_reality_mvp_pipeline.py" not in selection.targets
+    assert "tests/e2e" not in selection.targets
+
+
+def test_shared_panel_watcher_e2e_file_selects_both_owning_subsystems() -> None:
+    selection = select_tests(["tests/e2e/test_panel_watcher_e2e.py"])
+
+    assert selection.full_suite is False
+    assert selection.subsystems == ("watcher_sync", "promotion_panel")
+    assert "tests/watcher" in selection.targets
+    assert "tests/promotion" in selection.targets
+    assert selection.targets.count("tests/e2e/test_panel_watcher_e2e.py") == 1
+
+
+def test_unowned_e2e_file_uses_full_suite_fallback() -> None:
+    selection = select_tests(["tests/e2e/test_new_cross_system_flow.py"])
+
+    assert selection.full_suite is True
+    assert "unowned e2e" in selection.reason
+
+
+def test_cli_writes_github_output(tmp_path: Path) -> None:
+    output = tmp_path / "github-output.txt"
+
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/select_pr_tests.py",
+            "--changed-file",
+            "app/settings/runtime.py",
+            "--github-output",
+            str(output),
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+    )
+
+    text = output.read_text(encoding="utf-8")
+    assert "full_suite=false" in text
+    assert "subsystems=settings" in text
+    assert 'pytest_args=-q -m "not pg"' in text
+    assert "tests/settings" in text


### PR DESCRIPTION
## Change Lane
- [ ] Implementation lane
- [ ] Docs authoring lane
- [x] Governance lane

## Linked Issue
Fixes #

## SBS Impact
Classify Product/Runtime System, Builder System, or boundary work per `docs/architecture/SBS_OPERATING_MODEL.md` §3, then fill SBS impact per §4; use "none"/"unaffected" explicitly rather than leaving a field blank.
- Primary subsystem: Builder System / CI governance
- Secondary subsystem(s): test strategy, PR hot path
- Write class: governance/CI workflow only
- Authority impact: no product/runtime authority change
- Persistence impact: unaffected
- Derived/rebuildable impact: unaffected
- Human knowledge impact: unaffected
- Memory impact: unaffected
- Retrieval/context impact: unaffected
- Sync/deployment impact: PR CI selection behavior changed
- External boundary impact: GitHub Actions PR CI only
- New or changed contract: PR unit CI selects subsystem-scoped pytest targets with conservative full-suite fallback
- Owner-doc impact: `docs/development/TEST_STRATEGY_HOT_PATH.md` updated
- Transition debt impact: subsystem mapping should be tuned from observed CI runs
- Fitness rule impact: existing fitness gates unchanged
- Boundary risk: low; unmapped/shared surfaces fall back to full not-pg suite

## Owner-Doc Writeback
Resolve to exactly one (`docs/architecture/SBS_OPERATING_MODEL.md` §9). A comment or "to update later" note is not an acceptable resolution.
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Add `scripts/select_pr_tests.py` to map changed files to subsystem-scoped pytest targets for PR CI.
- Split `tests/e2e` selection by subsystem-owned files instead of treating the whole e2e directory as one PR target.
- Wire `.github/workflows/ci.yml` to use selector output for the PR not-pg test job.
- Document the conservative fallback and e2e ownership policy in the hot-path test strategy.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [x] This PR only changes approved governance surfaces.
- [x] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [x] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [ ] `ruff check app tests`
- [x] If files under `app/` or `tests/` changed, lint output from `ruff check app tests` is included below or a tooling limitation is stated.
- [ ] `mypy app`
- [ ] `pytest -q -m "not pg"`
- [x] Additional targeted checks run as needed

Docs authoring lane:
- [ ] Docs/governance checks run as appropriate for the touched surfaces
- [x] Any validation gaps or tooling limitations are stated explicitly

Governance lane:
- [x] Governance checks run as appropriate for the touched surfaces
- [x] Any validation gaps or tooling limitations are stated explicitly

Validation run locally:
- `python3 -m py_compile scripts/select_pr_tests.py`
- `pytest -q tests/scripts/test_select_pr_tests.py tests/ops/test_ci_workflow.py`
- `ruff check scripts/select_pr_tests.py tests/scripts/test_select_pr_tests.py tests/ops/test_ci_workflow.py`

Validation gap:
- Full PR CI must run on GitHub because this PR changes the CI workflow itself. The selector intentionally falls back to full `pytest -q -m "not pg"` for this PR because `.github/workflows/ci.yml` changed.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: direct repo governance/CI workflow change requested by owner; no BuilderOps material created.

## Notes
- Residual risk: initial subsystem map is conservative but should be tuned from observed CI runs.
- New unowned `tests/e2e/test_*.py` files fall back to the full not-pg suite until assigned to a subsystem owner.


## Direct Repair
Type: governance
Reason: Owner requested a bounded CI governance repair to split PR test selection by subsystem SoI and stop unrelated e2e tests from dominating every PR.
Validation: `python3 -m py_compile scripts/select_pr_tests.py`; `pytest -q tests/scripts/test_select_pr_tests.py tests/ops/test_ci_workflow.py`; `ruff check scripts/select_pr_tests.py tests/scripts/test_select_pr_tests.py tests/ops/test_ci_workflow.py`
Issue required: no
