### PR TITLE
builder: bridge PR and CI evidence into candidates

### DIFF
--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -7,6 +7,10 @@ from typing import Any, Callable
 import click
 
 from app.builderops.config import load_paths
+from app.builderops.evidence_bridge import (
+    EvidenceBridgeError,
+    build_evidence_bridge_report,
+)
 from app.builderops.epic_dispatch import EpicDispatchError, build_dispatch_plan
 from app.builderops.epic_lifecycle_plan import (
     EpicLifecyclePlanError,
@@ -543,6 +547,39 @@ def retrospective_closure_check(
             outcomes=outcomes,
         )
     except RetrospectiveClosureError as exc:
+        raise click.ClickException(str(exc)) from exc
+    _emit(payload, as_json)
+
+
+@builderops.group(
+    "evidence-bridge",
+    help="Classify PR/CI/review evidence into observe-only reevaluation candidates.",
+)
+def evidence_bridge() -> None:
+    """Evidence bridge helpers for continuous reevaluation."""
+
+
+@evidence_bridge.command(
+    "classify",
+    help="Classify delivery evidence without mutating GitHub, Product, or runtime state.",
+)
+@click.option(
+    "--evidence-file",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    required=True,
+    help="JSON object with observed, unknown, and candidate evidence fields.",
+)
+@click.option("--json", "as_json", is_flag=True)
+def evidence_bridge_classify(
+    evidence_file: Path,
+    as_json: bool,
+) -> None:
+    evidence = _load_json_value_file(evidence_file, field="evidence-file")
+    if not isinstance(evidence, dict):
+        raise click.BadParameter("evidence-file must contain a JSON object")
+    try:
+        payload = build_evidence_bridge_report(evidence)
+    except EvidenceBridgeError as exc:
         raise click.ClickException(str(exc)) from exc
     _emit(payload, as_json)
 

--- a/app/builderops/evidence_bridge.py
+++ b/app/builderops/evidence_bridge.py
@@ -1,0 +1,233 @@
+"""Observe-only PR/CI/review evidence bridge helpers."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from app.builderops.models import BuilderOpsValidationError, validate_source_refs
+
+OBSERVED_EVIDENCE_KINDS = frozenset(
+    {
+        "ci_failure",
+        "review_finding",
+        "missing_evidence",
+        "human_exception",
+        "tcd_signal",
+    }
+)
+UNKNOWN_EVIDENCE_KINDS = frozenset(
+    {
+        "unknown_ci_context",
+        "unknown_review_context",
+        "unknown_artifact",
+        "unknown_for_retro",
+    }
+)
+EVIDENCE_BRIDGE_ROUTES = frozenset(
+    {
+        "learning_signal",
+        "issue_candidate",
+        "debt_fitness_candidate",
+        "discard",
+    }
+)
+
+
+class EvidenceBridgeError(BuilderOpsValidationError):
+    """Raised when evidence bridge input is malformed."""
+
+
+def build_evidence_bridge_report(evidence: Mapping[str, Any]) -> dict[str, Any]:
+    """Classify delivery evidence into observe-only reevaluation candidates."""
+
+    if not isinstance(evidence, Mapping):
+        raise EvidenceBridgeError("evidence payload must be an object")
+
+    observed = _normalize_entries(
+        evidence.get("observed", []),
+        field="observed",
+        allowed_kinds=OBSERVED_EVIDENCE_KINDS,
+        require_source_refs=True,
+    )
+    unknown = _normalize_entries(
+        evidence.get("unknown", []),
+        field="unknown",
+        allowed_kinds=UNKNOWN_EVIDENCE_KINDS,
+        require_source_refs=False,
+    )
+    evidence_ids = {item["id"] for item in [*observed, *unknown]}
+    candidate = _normalize_candidates(
+        evidence.get("candidate", evidence.get("candidates", [])),
+        evidence_ids=evidence_ids,
+    )
+
+    return {
+        "observe_only": True,
+        "mutations_performed": False,
+        "mutation_channels": {
+            "git_push": False,
+            "github_label": False,
+            "github_merge": False,
+            "github_project": False,
+            "product_runtime": False,
+        },
+        "observed": observed,
+        "unknown": unknown,
+        "candidate": candidate,
+        "routing_outcomes": sorted(EVIDENCE_BRIDGE_ROUTES),
+        "receipt_body": _receipt_body(observed, unknown, candidate),
+    }
+
+
+def _normalize_entries(
+    value: Any,
+    *,
+    field: str,
+    allowed_kinds: frozenset[str],
+    require_source_refs: bool,
+) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        raise EvidenceBridgeError(f"{field} must be a list")
+    entries: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for index, item in enumerate(value):
+        if not isinstance(item, Mapping):
+            raise EvidenceBridgeError(f"{field}[{index}] must be an object")
+        entry_id = _required_string(item.get("id"), f"{field}[{index}].id")
+        if entry_id in seen_ids:
+            raise EvidenceBridgeError(f"duplicate evidence id: {entry_id}")
+        seen_ids.add(entry_id)
+        kind = _required_string(item.get("kind"), f"{field}[{index}].kind")
+        if kind not in allowed_kinds:
+            raise EvidenceBridgeError(
+                f"{field}[{index}].kind must be one of {sorted(allowed_kinds)}"
+            )
+        summary = _required_string(item.get("summary"), f"{field}[{index}].summary")
+        entry: dict[str, Any] = {"id": entry_id, "kind": kind, "summary": summary}
+        source_refs = item.get("source_refs")
+        if source_refs is not None:
+            entry["source_refs"] = _validated_source_refs(
+                source_refs,
+                f"{field}[{index}].source_refs",
+            )
+        elif require_source_refs:
+            raise EvidenceBridgeError(f"{field}[{index}].source_refs must be provided")
+        if item.get("notes"):
+            entry["notes"] = _required_string(item["notes"], f"{field}[{index}].notes")
+        return_unknown_bucket = item.get("unknown_for_retro")
+        if return_unknown_bucket is not None:
+            entry["unknown_for_retro"] = bool(return_unknown_bucket)
+        entries.append(entry)
+    return entries
+
+
+def _normalize_candidates(
+    value: Any,
+    *,
+    evidence_ids: set[str],
+) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        raise EvidenceBridgeError("candidate must be a list")
+    candidates: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for index, item in enumerate(value):
+        if not isinstance(item, Mapping):
+            raise EvidenceBridgeError(f"candidate[{index}] must be an object")
+        candidate_id = _required_string(item.get("id"), f"candidate[{index}].id")
+        if candidate_id in seen_ids:
+            raise EvidenceBridgeError(f"duplicate candidate id: {candidate_id}")
+        seen_ids.add(candidate_id)
+        route = _required_string(item.get("route"), f"candidate[{index}].route")
+        if route not in EVIDENCE_BRIDGE_ROUTES:
+            raise EvidenceBridgeError(
+                f"candidate[{index}].route must be one of {sorted(EVIDENCE_BRIDGE_ROUTES)}"
+            )
+        source_refs = _validated_source_refs(
+            item.get("source_refs"),
+            f"candidate[{index}].source_refs",
+        )
+        upstream_artifact = _optional_string(
+            item.get("upstream_artifact"),
+            f"candidate[{index}].upstream_artifact",
+        )
+        unknown_for_retro = bool(item.get("unknown_for_retro", False))
+        if not upstream_artifact and not unknown_for_retro:
+            raise EvidenceBridgeError(
+                f"candidate[{index}] requires upstream_artifact or unknown_for_retro"
+            )
+        raw_ids = item.get("evidence_ids")
+        if not isinstance(raw_ids, list) or not raw_ids:
+            raise EvidenceBridgeError(f"candidate[{index}].evidence_ids must be a non-empty list")
+        normalized_ids = [
+            _required_string(value, f"candidate[{index}].evidence_ids[{id_index}]")
+            for id_index, value in enumerate(raw_ids)
+        ]
+        missing_ids = [value for value in normalized_ids if value not in evidence_ids]
+        if missing_ids:
+            raise EvidenceBridgeError(
+                f"candidate[{index}].evidence_ids reference unknown evidence: {missing_ids}"
+            )
+        candidate: dict[str, Any] = {
+            "id": candidate_id,
+            "route": route,
+            "summary": _required_string(item.get("summary"), f"candidate[{index}].summary"),
+            "evidence_ids": normalized_ids,
+            "source_refs": source_refs,
+            "recommendation": _required_string(
+                item.get("recommendation"),
+                f"candidate[{index}].recommendation",
+            ),
+            "unknown_for_retro": unknown_for_retro,
+        }
+        if upstream_artifact:
+            candidate["upstream_artifact"] = upstream_artifact
+        candidates.append(candidate)
+    return candidates
+
+
+def _validated_source_refs(value: Any, field: str) -> list[dict[str, Any]]:
+    try:
+        validate_source_refs(value, field)
+    except BuilderOpsValidationError as exc:
+        raise EvidenceBridgeError(str(exc)) from exc
+    if not isinstance(value, list):  # validate_source_refs guards this.
+        raise EvidenceBridgeError(f"{field} must be a non-empty list")
+    return list(value)
+
+
+def _required_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise EvidenceBridgeError(f"{field} must be a non-empty string")
+    return value.strip()
+
+
+def _optional_string(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    return _required_string(value, field)
+
+
+def _receipt_body(
+    observed: list[dict[str, Any]],
+    unknown: list[dict[str, Any]],
+    candidates: list[dict[str, Any]],
+) -> str:
+    routes = ", ".join(
+        f"{item['id']}={item['route']}"
+        for item in candidates
+    )
+    return (
+        "Evidence bridge observe-only report: "
+        f"observed={len(observed)}, unknown={len(unknown)}, "
+        f"candidate={len(candidates)}"
+        + (f"; routes: {routes}." if routes else ".")
+    )
+
+
+__all__ = [
+    "EVIDENCE_BRIDGE_ROUTES",
+    "EvidenceBridgeError",
+    "OBSERVED_EVIDENCE_KINDS",
+    "UNKNOWN_EVIDENCE_KINDS",
+    "build_evidence_bridge_report",
+]

--- a/docs/development/DELIVERY_FEEDBACK_LOOP.md
+++ b/docs/development/DELIVERY_FEEDBACK_LOOP.md
@@ -170,6 +170,14 @@ actionable item through the same governed destinations as learning: issue, PR, f
 row, `PromotionIntent`, or receipt. CKM output remains projection-only and never becomes product or
 runtime truth by itself.
 
+The observe-only BuilderOps helper `python -m app.builderops builderops evidence-bridge classify`
+bridges PR evidence packs, CI failure context, review findings, missing evidence, and Human
+Exception causes into reevaluation candidates. Its report keeps `observed`, `unknown`, and
+`candidate` fields separate; candidates require `source_refs` plus a named upstream artifact, unless
+they are explicitly held in an `unknown_for_retro` bucket. First rollout is artifact/comment-only:
+the helper does not push, merge, label, update Project state, write Product docs, or change
+Product/Runtime behavior.
+
 ### 4b. Retrospective closure rule
 
 A retrospective or reevaluation pass is not complete until every in-scope signal has one of these

--- a/tests/builderops/test_evidence_bridge.py
+++ b/tests/builderops/test_evidence_bridge.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from app.builderops.__main__ import _root as builderops_standalone_root
+from app.builderops.evidence_bridge import (
+    EvidenceBridgeError,
+    build_evidence_bridge_report,
+)
+
+
+def _ref(ref_type: str = "pull_request", ref: str = "#3281") -> dict[str, str]:
+    return {"ref_type": ref_type, "ref": ref}
+
+
+def _evidence() -> dict[str, object]:
+    return {
+        "observed": [
+            {
+                "id": "obs-ci-repeat",
+                "kind": "ci_failure",
+                "summary": "Architecture CI failed twice on docs guard drift.",
+                "source_refs": [_ref("ci_run", "https://github.test/runs/1")],
+            },
+            {
+                "id": "obs-review-repeat",
+                "kind": "review_finding",
+                "summary": "Review repeatedly asked for source-ref validation.",
+                "source_refs": [_ref("review_thread", "PRRT_1")],
+            },
+            {
+                "id": "obs-missing-evidence",
+                "kind": "missing_evidence",
+                "summary": "Owner-doc receipt was missing from the PR body.",
+                "source_refs": [_ref("pull_request", "#3281")],
+            },
+        ],
+        "unknown": [
+            {
+                "id": "unk-human-exception-cause",
+                "kind": "unknown_for_retro",
+                "summary": "The upstream artifact for a Human Exception cause is unclear.",
+            }
+        ],
+        "candidate": [
+            {
+                "id": "cand-learning",
+                "route": "learning_signal",
+                "summary": "Docs guard drift should be captured for retrospective handling.",
+                "evidence_ids": ["obs-ci-repeat"],
+                "source_refs": [_ref("ci_artifact", "ci-failure-context-3281.json")],
+                "upstream_artifact": ".codex/skills/publish-pr/SKILL.md",
+                "recommendation": "Create a LearningSignal with the CI artifact as source evidence.",
+            },
+            {
+                "id": "cand-issue",
+                "route": "issue_candidate",
+                "summary": "Repeated missing owner-doc receipts need a bounded follow-up issue.",
+                "evidence_ids": ["obs-missing-evidence"],
+                "source_refs": [_ref("pull_request", "#3281")],
+                "upstream_artifact": ".codex/skills/publish-pr/SKILL.md",
+                "recommendation": "Open a governance-lane issue if the pattern repeats.",
+            },
+            {
+                "id": "cand-debt",
+                "route": "debt_fitness_candidate",
+                "summary": "Source-ref validation has become a repeated review finding.",
+                "evidence_ids": ["obs-review-repeat"],
+                "source_refs": [_ref("review_thread", "PRRT_1")],
+                "upstream_artifact": "docs/architecture/SBS_TRANSITION_DEBT.md::D12",
+                "recommendation": "Record the repeated failure mode as transition debt or a fitness rule.",
+            },
+            {
+                "id": "cand-discard",
+                "route": "discard",
+                "summary": "The Human Exception cause has no named upstream artifact yet.",
+                "evidence_ids": ["unk-human-exception-cause"],
+                "source_refs": [_ref("github_issue", "#3263")],
+                "unknown_for_retro": True,
+                "recommendation": "Keep in the unknown-for-retro bucket until a named artifact exists.",
+            },
+        ],
+    }
+
+
+def test_evidence_bridge_distinguishes_observed_unknown_and_candidate() -> None:
+    report = build_evidence_bridge_report(_evidence())
+
+    assert set(["observed", "unknown", "candidate"]).issubset(report)
+    assert report["observed"][0]["id"] == "obs-ci-repeat"
+    assert report["unknown"][0]["id"] == "unk-human-exception-cause"
+    assert report["candidate"][0]["route"] == "learning_signal"
+    assert report["mutations_performed"] is False
+
+
+def test_evidence_bridge_rejects_candidate_without_source_refs_or_artifact() -> None:
+    missing_refs = _evidence()
+    missing_refs["candidate"] = [
+        {
+            "id": "cand-bad",
+            "route": "learning_signal",
+            "summary": "Missing source refs.",
+            "evidence_ids": ["obs-ci-repeat"],
+            "upstream_artifact": ".codex/skills/publish-pr/SKILL.md",
+            "recommendation": "Reject this candidate.",
+        }
+    ]
+
+    with pytest.raises(EvidenceBridgeError, match="source_refs"):
+        build_evidence_bridge_report(missing_refs)
+
+    missing_artifact = _evidence()
+    missing_artifact["candidate"] = [
+        {
+            "id": "cand-bad",
+            "route": "learning_signal",
+            "summary": "Missing upstream artifact.",
+            "evidence_ids": ["obs-ci-repeat"],
+            "source_refs": [_ref()],
+            "recommendation": "Reject this candidate.",
+        }
+    ]
+
+    with pytest.raises(EvidenceBridgeError, match="upstream_artifact"):
+        build_evidence_bridge_report(missing_artifact)
+
+
+def test_evidence_bridge_routes_repeated_patterns_to_supported_outcomes() -> None:
+    report = build_evidence_bridge_report(_evidence())
+
+    routes = {item["route"] for item in report["candidate"]}
+    assert routes == {
+        "learning_signal",
+        "issue_candidate",
+        "debt_fitness_candidate",
+        "discard",
+    }
+    assert "cand-learning=learning_signal" in report["receipt_body"]
+    assert "cand-debt=debt_fitness_candidate" in report["receipt_body"]
+
+
+def test_evidence_bridge_rejects_unknown_evidence_ids() -> None:
+    evidence = _evidence()
+    evidence["candidate"] = [
+        {
+            "id": "cand-bad",
+            "route": "issue_candidate",
+            "summary": "Unknown evidence id.",
+            "evidence_ids": ["obs-missing"],
+            "source_refs": [_ref()],
+            "upstream_artifact": ".codex/skills/issue-to-code/SKILL.md",
+            "recommendation": "Reject this candidate.",
+        }
+    ]
+
+    with pytest.raises(EvidenceBridgeError, match="unknown evidence"):
+        build_evidence_bridge_report(evidence)
+
+
+def test_evidence_bridge_cli_is_observe_only(tmp_path: Path) -> None:
+    evidence_file = tmp_path / "evidence.json"
+    evidence_file.write_text(json.dumps(_evidence()), encoding="utf-8")
+
+    result = CliRunner().invoke(
+        builderops_standalone_root,
+        [
+            "builderops",
+            "evidence-bridge",
+            "classify",
+            "--evidence-file",
+            str(evidence_file),
+            "--json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["observe_only"] is True
+    assert payload["mutations_performed"] is False
+    assert payload["mutation_channels"] == {
+        "git_push": False,
+        "github_label": False,
+        "github_merge": False,
+        "github_project": False,
+        "product_runtime": False,
+    }
+    assert payload["candidate"][0]["id"] == "cand-learning"


### PR DESCRIPTION
## Summary
- add an observe-only BuilderOps evidence bridge for PR/CI/review delivery evidence
- expose `python3 -m app.builderops builderops evidence-bridge classify --evidence-file ... --json`
- document the bridge under continuous reevaluation inputs

## BuilderOps Routing
- Records/projections/receipts: observe-only evidence bridge report artifact from `builderops evidence-bridge classify`; no BuilderOps store writes in this PR.
- Reason: #3263 requires PR/CI/review evidence to be classifiable into learning and reevaluation candidates without mutating GitHub, Product, or Runtime state.
- Issue: #3263
- Parent: #3260
- Route: governance-lane BuilderOps helper and docs update
- Mutations authorized by helper: none; output is artifact/comment-only and observe-only

## SBS Impact
- Builder System only. No Product/Runtime behavior changes.
- CKM authority unchanged; this issue does not implement CKM and does not treat projections as authority.
- Evidence is classified into observed facts, unknowns, and candidate recommendations with source refs and upstream artifacts.

## Owner-Doc Writeback
- Resolved in this PR: `docs/development/DELIVERY_FEEDBACK_LOOP.md` now documents the evidence bridge and observe-only first rollout constraints.
- No runtime/user memory or automatic Product owner-doc writeback.

## Validation
- `pytest -q tests/builderops/test_evidence_bridge.py tests/builderops/test_retrospective_closure.py`
- `ruff check app/builderops/evidence_bridge.py app/builderops/cli.py tests/builderops/test_evidence_bridge.py`
- `mypy app/builderops/evidence_bridge.py`
- `git diff --check`
- `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1 python3 scripts/docs_guard.py`

Closes #3263
