### PR TITLE
Add dispatcher Signboard projection

### DIFF
--- a/app/dispatcher/cli.py
+++ b/app/dispatcher/cli.py
@@ -35,7 +35,8 @@ from app.dispatcher.sync_github import (
 
 REQUIRED_COMMANDS = frozenset([
     "init", "queue", "next", "show", "claim",
-    "heartbeat", "release", "update", "block", "complete", "events", "pull",
+    "heartbeat", "release", "update", "move", "block", "complete", "events", "pull",
+    "export-signboard",
 ])
 
 
@@ -215,6 +216,22 @@ def _cmd_update(args: argparse.Namespace, store: SqliteStore) -> int:
         return _emit_error(str(exc), args.json)
 
 
+def _cmd_move(args: argparse.Namespace, store: SqliteStore) -> int:
+    from app.dispatcher.services import move_task
+    try:
+        task = move_task(
+            store,
+            task_id=args.task_id,
+            status=args.status,
+            note=args.note,
+            actor=args.agent,
+        )
+        _emit({"ok": True, "task": _compact_task(task)}, args.json)
+        return 0
+    except ValueError as exc:
+        return _emit_error(str(exc), args.json)
+
+
 def _cmd_block(args: argparse.Namespace, store: SqliteStore) -> int:
     try:
         task = queue_module.block(
@@ -310,6 +327,16 @@ def _cmd_pull(args: argparse.Namespace, store: SqliteStore) -> int:
         return _emit_error(f"pull failed: {exc}", args.json)
 
 
+def _cmd_export_signboard(args: argparse.Namespace, store: SqliteStore) -> int:
+    from pathlib import Path
+
+    from app.dispatcher.signboard import export_signboard
+
+    result = export_signboard(store, Path(args.path))
+    _emit({"ok": True, **result}, args.json)
+    return 0
+
+
 # ---------------------------------------------------------------------------
 # Parser
 # ---------------------------------------------------------------------------
@@ -324,12 +351,14 @@ _COMMAND_MAP = {
     "heartbeat": _cmd_heartbeat,
     "release": _cmd_release,
     "update": _cmd_update,
+    "move": _cmd_move,
     "block": _cmd_block,
     "complete": _cmd_complete,
     "events": _cmd_events,
     "link-pr": _cmd_link_pr,
     "status": _cmd_status,
     "pull": _cmd_pull,
+    "export-signboard": _cmd_export_signboard,
 }
 
 
@@ -385,6 +414,13 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--agent", default="cli")
     p.add_argument("--json", action="store_true")
 
+    p = sub.add_parser("move", help="Move a task to a lifecycle status")
+    p.add_argument("task_id")
+    p.add_argument("--status", required=True)
+    p.add_argument("--note", default=None)
+    p.add_argument("--agent", default="cli")
+    p.add_argument("--json", action="store_true")
+
     p = sub.add_parser("block", help="Mark task as blocked")
     p.add_argument("task_id")
     p.add_argument("--reason", required=True)
@@ -411,6 +447,10 @@ def build_parser() -> argparse.ArgumentParser:
 
     p = sub.add_parser("pull", help="Pull open agent:ready issues from GitHub")
     p.add_argument("--repo", required=True, help="GitHub repo (owner/repo)")
+    p.add_argument("--json", action="store_true")
+
+    p = sub.add_parser("export-signboard", help="Export dispatcher queue as a Signboard Markdown board")
+    p.add_argument("path", help="Directory to write kanban columns into")
     p.add_argument("--json", action="store_true")
 
     return parser

--- a/app/dispatcher/services.py
+++ b/app/dispatcher/services.py
@@ -9,6 +9,7 @@ import uuid
 from datetime import datetime, timezone
 
 from app.dispatcher.models import EventRecord, TaskRecord
+from app.dispatcher.signboard import canonical_status
 from app.dispatcher.store import SqliteStore
 
 
@@ -60,6 +61,45 @@ def update_task(
     return task
 
 
+def move_task(
+    store: SqliteStore,
+    task_id: str,
+    status: str,
+    actor: str,
+    note: str | None = None,
+) -> TaskRecord:
+    """Move a task to a lifecycle status. Emits task.moved event."""
+    task = store.get_task(task_id)
+    if task is None:
+        raise ValueError(f"Task {task_id} not found")
+
+    next_status = canonical_status(status)
+    previous_status = task.status
+    task.status = next_status
+    if next_status != "blocked":
+        task.blocked_reason = None
+    task.updated_at = _utc_now()
+    store.upsert_task(task)
+
+    payload: dict = {
+        "from_status": previous_status,
+        "to_status": next_status,
+    }
+    if note is not None:
+        payload["note"] = note
+
+    store.append_event(EventRecord(
+        event_id=_make_event_id(),
+        timestamp=_utc_now(),
+        task_id=task_id,
+        event_type="task.moved",
+        actor=actor,
+        payload=payload,
+    ))
+
+    return task
+
+
 def link_pr(
     store: SqliteStore,
     task_id: str,
@@ -85,5 +125,4 @@ def link_pr(
     ))
 
     return task
-
 

--- a/app/dispatcher/services.py
+++ b/app/dispatcher/services.py
@@ -74,6 +74,11 @@ def move_task(
         raise ValueError(f"Task {task_id} not found")
 
     next_status = canonical_status(status)
+    if next_status == "completed" and task.lease_id is not None:
+        raise ValueError(
+            f"Cannot move task {task_id} to completed while lease {task.lease_id} is active; "
+            "use complete instead"
+        )
     previous_status = task.status
     task.status = next_status
     if next_status != "blocked":
@@ -125,4 +130,3 @@ def link_pr(
     ))
 
     return task
-

--- a/app/dispatcher/signboard.py
+++ b/app/dispatcher/signboard.py
@@ -25,11 +25,16 @@ STATUS_COLUMNS: dict[str, str] = {
     "done": "Done",
 }
 
+VALID_STATUSES = frozenset(STATUS_COLUMNS.keys()) - {"done"}
+
 
 def canonical_status(status: str) -> str:
     normalized = status.strip().lower().replace(" ", "_").replace("-", "_")
     if normalized == "done":
         return "completed"
+    if normalized not in VALID_STATUSES:
+        allowed = ", ".join(sorted(VALID_STATUSES | {"done"}))
+        raise ValueError(f"Unknown dispatcher status {status!r}; expected one of: {allowed}")
     return normalized
 
 
@@ -54,12 +59,20 @@ def export_signboard(store: SqliteStore, board_root: Path) -> dict[str, Any]:
     written: list[str] = []
     for task in tasks:
         filename = _task_filename(task)
+        target_column = column_for_status(task.status)
+        target = root / target_column / filename
+        for column in sorted(set(STATUS_COLUMNS.values())):
+            for candidate in (root / column).glob(f"{task.task_id}--*.md"):
+                if candidate == target:
+                    continue
+                if _is_generated_card(candidate):
+                    candidate.unlink()
+
         for column in sorted(set(STATUS_COLUMNS.values())):
             candidate = root / column / filename
-            if candidate.exists() and column != column_for_status(task.status):
+            if candidate.exists() and column != target_column:
                 candidate.unlink()
 
-        target = root / column_for_status(task.status) / filename
         target.write_text(_render_task(task), encoding="utf-8")
         written.append(str(target))
 
@@ -75,6 +88,16 @@ def _task_filename(task: TaskRecord) -> str:
     title = re.sub(r"[^A-Za-z0-9._-]+", "-", task.title.strip()).strip("-")
     title = title[:72].strip("-") or "task"
     return f"{task.task_id}--{title}.md"
+
+
+def _is_generated_card(path: Path) -> bool:
+    try:
+        return "generated_by: dispatcher.signboard" in path.read_text(
+            encoding="utf-8",
+            errors="ignore",
+        )
+    except OSError:
+        return False
 
 
 def _yaml_scalar(value: Any) -> str:

--- a/app/dispatcher/signboard.py
+++ b/app/dispatcher/signboard.py
@@ -1,0 +1,142 @@
+"""Signboard Markdown projection for dispatcher tasks.
+
+The dispatcher remains the operational source of truth. This module writes a
+one-way Markdown projection that lightweight kanban tools can render from disk.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from app.dispatcher.models import TaskRecord
+from app.dispatcher.store import SqliteStore
+
+
+STATUS_COLUMNS: dict[str, str] = {
+    "backlog": "Backlog",
+    "ready": "Ready",
+    "claimed": "In Progress",
+    "in_progress": "In Progress",
+    "review": "Review",
+    "blocked": "Blocked",
+    "completed": "Done",
+    "done": "Done",
+}
+
+
+def canonical_status(status: str) -> str:
+    normalized = status.strip().lower().replace(" ", "_").replace("-", "_")
+    if normalized == "done":
+        return "completed"
+    return normalized
+
+
+def column_for_status(status: str) -> str:
+    normalized = canonical_status(status)
+    return STATUS_COLUMNS.get(normalized, "Backlog")
+
+
+def export_signboard(store: SqliteStore, board_root: Path) -> dict[str, Any]:
+    """Write dispatcher tasks as Markdown files grouped by kanban column.
+
+    The exporter only removes prior generated files for task IDs that still
+    exist in dispatcher. It leaves unrelated human notes alone.
+    """
+
+    root = Path(board_root).expanduser()
+    root.mkdir(parents=True, exist_ok=True)
+    for column in sorted(set(STATUS_COLUMNS.values())):
+        (root / column).mkdir(parents=True, exist_ok=True)
+
+    tasks = store.list_tasks()
+    written: list[str] = []
+    for task in tasks:
+        filename = _task_filename(task)
+        for column in sorted(set(STATUS_COLUMNS.values())):
+            candidate = root / column / filename
+            if candidate.exists() and column != column_for_status(task.status):
+                candidate.unlink()
+
+        target = root / column_for_status(task.status) / filename
+        target.write_text(_render_task(task), encoding="utf-8")
+        written.append(str(target))
+
+    return {
+        "root": str(root),
+        "count": len(tasks),
+        "columns": sorted(set(STATUS_COLUMNS.values())),
+        "written": written,
+    }
+
+
+def _task_filename(task: TaskRecord) -> str:
+    title = re.sub(r"[^A-Za-z0-9._-]+", "-", task.title.strip()).strip("-")
+    title = title[:72].strip("-") or "task"
+    return f"{task.task_id}--{title}.md"
+
+
+def _yaml_scalar(value: Any) -> str:
+    if value is None:
+        return '""'
+    text = str(value).replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{text}"'
+
+
+def _yaml_list(values: list[str]) -> str:
+    if not values:
+        return "[]"
+    return "[" + ", ".join(_yaml_scalar(v) for v in values) + "]"
+
+
+def _render_task(task: TaskRecord) -> str:
+    source_refs = list(task.source_anchor_refs or [])
+    github_url = ""
+    labels: list[str] = []
+    if task.sync_state:
+        github_url = str(task.sync_state.get("url") or "")
+        raw_labels = task.sync_state.get("labels") or []
+        if isinstance(raw_labels, list):
+            labels = [str(label) for label in raw_labels]
+
+    frontmatter = [
+        "---",
+        "generated_by: dispatcher.signboard",
+        f"id: {_yaml_scalar(task.task_id)}",
+        f"issue_number: {task.issue_number}",
+        f"title: {_yaml_scalar(task.title)}",
+        f"status: {_yaml_scalar(canonical_status(task.status))}",
+        f"column: {_yaml_scalar(column_for_status(task.status))}",
+        f"priority: {_yaml_scalar(task.priority)}",
+        f"claimed_by: {_yaml_scalar(task.claimed_by)}",
+        f"linked_pr: {_yaml_scalar(task.linked_pr)}",
+        f"blocked_reason: {_yaml_scalar(task.blocked_reason)}",
+        f"github_url: {_yaml_scalar(github_url)}",
+        f"labels: {_yaml_list(labels)}",
+        f"source_anchor_refs: {_yaml_list(source_refs)}",
+        f"updated_at: {_yaml_scalar(task.updated_at)}",
+        "---",
+        "",
+    ]
+
+    body = [
+        f"# {task.title}",
+        "",
+        f"- Task: `{task.task_id}`",
+        f"- Issue: `#{task.issue_number}`",
+        f"- Status: `{canonical_status(task.status)}`",
+        f"- Priority: `{task.priority}`",
+    ]
+    if task.claimed_by:
+        body.append(f"- Claimed by: `{task.claimed_by}`")
+    if task.linked_pr:
+        body.append(f"- PR: `#{task.linked_pr}`")
+    if task.blocked_reason:
+        body.append(f"- Blocked: {task.blocked_reason}")
+    if github_url:
+        body.append(f"- GitHub: {github_url}")
+    if source_refs:
+        body.append(f"- Source anchors: {', '.join(source_refs)}")
+    body.extend(["", "## Notes", "", "## Receipts", ""])
+    return "\n".join(frontmatter + body)

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -249,16 +249,22 @@ Observable signals:
 
 ## Optional Future Projections
 
-The following are described as **optional projections only** and are not part of the dispatcher hot path:
+The following are described as **optional projections only** and are not part of the dispatcher hot path.
+The dispatcher SQLite store is the Builder System control plane for active queue, lease, heartbeat,
+and lifecycle status. Projection surfaces render or repair that state; they do not replace it.
 
 | Target | Type | Status |
 | --- | --- | --- |
-| GitHub Projects board | Optional read projection | Not in dispatcher hot path (see Source-of-Truth Boundaries) |
+| Signboard Markdown board | Local generated projection | Implemented via `python -m app.dispatcher export-signboard <path>` |
+| GitHub Projects board | Deprecated optional projection | Not in dispatcher hot path (see Source-of-Truth Boundaries) |
 | Plane / Vikunja / Baserow | Optional external board | Not implemented — future scope only |
-| Local Markdown/JSON dashboard | Optional local projection | Not implemented — future scope only |
+| Local Markdown/JSON dashboard | Optional local projection | Signboard export is the current Markdown projection |
 | CLI sync-status command | Optional surface | Expressible via `get_sync_meta` in a future `disp sync-status` command |
 
 External boards and GitHub Projects are projections only and must not become required for core queue/lease/claim behavior.
+Agents must use dispatcher commands for work selection and mutation. Signboard files are generated
+for human kanban inspection and should not be treated as authoritative input unless a future
+two-way projection command explicitly validates and imports them.
 
 ## Operational Deployment
 
@@ -307,6 +313,47 @@ GitHub Project v2 / GraphQL reconciliation stays out of dispatcher `next`, `clai
 and `complete`. Low-frequency/batched projection repair is exposed separately through
 `scripts/reconcile_builderops_project_status.sh`, which delegates to the existing project
 reconciliation helper.
+
+### Signboard projection
+
+The dispatcher can export the active Builder Ops queue into a Signboard-compatible Markdown board:
+
+```bash
+python -m app.dispatcher export-signboard ~/BuilderOpsVault/agent-delivery --json
+```
+
+The exporter writes one Markdown file per dispatcher task under status columns:
+
+```text
+Backlog/
+Ready/
+In Progress/
+Review/
+Blocked/
+Done/
+```
+
+Canonical dispatcher statuses are mapped as follows:
+
+| Dispatcher status | Signboard column |
+| --- | --- |
+| `backlog` | `Backlog` |
+| `ready` | `Ready` |
+| `claimed`, `in_progress` | `In Progress` |
+| `review` | `Review` |
+| `blocked` | `Blocked` |
+| `completed`, `done` | `Done` |
+
+Manual lifecycle changes should use dispatcher commands, for example:
+
+```bash
+python -m app.dispatcher move github-issue-123 --status review --agent codex --json
+python -m app.dispatcher block github-issue-123 --reason "waiting for owner decision" --agent claude --json
+python -m app.dispatcher export-signboard ~/BuilderOpsVault/agent-delivery --json
+```
+
+The generated Markdown frontmatter is projection state only. Do not patch generated Signboard cards
+as the source of a claim, heartbeat, or lifecycle transition.
 
 ### Epic-runner lifecycle planning
 

--- a/tests/dispatcher/test_cli.py
+++ b/tests/dispatcher/test_cli.py
@@ -309,6 +309,60 @@ def test_update_clears_blocked_reason_on_non_blocked_status(tmp_env, store):
     assert next_data["task"]["task_id"] == ready.task_id
 
 
+def test_move_command_sets_lifecycle_status_and_emits_event(tmp_env, store):
+    from tests.dispatcher.helpers import seed_tasks
+    tasks = seed_tasks(store)
+    ready = next(t for t in tasks if t.status == "ready")
+
+    code, data = _run(
+        ["move", ready.task_id, "--status", "Review", "--agent", "codex", "--json"],
+    )
+    assert code == 0
+    assert data["ok"] is True
+    assert data["task"]["status"] == "review"
+
+    events_code, events_data = _run(["events", "--tail", "20", "--json"])
+    assert events_code == 0
+    moved = [e for e in events_data["events"] if e["event_type"] == "task.moved"]
+    assert moved
+    assert moved[-1]["payload"]["from_status"] == "ready"
+    assert moved[-1]["payload"]["to_status"] == "review"
+
+
+def test_move_done_normalizes_to_completed(tmp_env, store):
+    from tests.dispatcher.helpers import seed_tasks
+    tasks = seed_tasks(store)
+    ready = next(t for t in tasks if t.status == "ready")
+
+    code, data = _run(
+        ["move", ready.task_id, "--status", "Done", "--agent", "codex", "--json"],
+    )
+    assert code == 0
+    assert data["task"]["status"] == "completed"
+
+
+def test_export_signboard_writes_markdown_columns(tmp_env, store, tmp_path: Path):
+    from tests.dispatcher.helpers import seed_tasks
+    tasks = seed_tasks(store)
+    ready = next(t for t in tasks if t.status == "ready")
+    _run(["move", ready.task_id, "--status", "Review", "--agent", "codex", "--json"])
+
+    board = tmp_path / "BuilderOpsVault" / "agent-delivery"
+    code, data = _run(["export-signboard", str(board), "--json"])
+    assert code == 0
+    assert data["ok"] is True
+    assert data["count"] == len(tasks)
+    assert (board / "Backlog").is_dir()
+    assert (board / "Review").is_dir()
+
+    review_cards = list((board / "Review").glob(f"{ready.task_id}--*.md"))
+    assert len(review_cards) == 1
+    content = review_cards[0].read_text(encoding="utf-8")
+    assert "generated_by: dispatcher.signboard" in content
+    assert 'status: "review"' in content
+    assert f"issue_number: {ready.issue_number}" in content
+
+
 def test_status_command(tmp_env):
     _run(["init", "--json"])
     code, data = _run(["status", "--json"])

--- a/tests/dispatcher/test_cli.py
+++ b/tests/dispatcher/test_cli.py
@@ -341,6 +341,39 @@ def test_move_done_normalizes_to_completed(tmp_env, store):
     assert data["task"]["status"] == "completed"
 
 
+def test_move_rejects_unknown_status(tmp_env, store):
+    from tests.dispatcher.helpers import seed_tasks
+    tasks = seed_tasks(store)
+    ready = next(t for t in tasks if t.status == "ready")
+
+    code, data = _run(
+        ["move", ready.task_id, "--status", "revieew", "--agent", "codex", "--json"],
+    )
+    assert code == 1
+    assert data["ok"] is False
+    assert "Unknown dispatcher status" in data["error"]
+
+
+def test_move_completed_rejects_active_lease(tmp_env, store):
+    from tests.dispatcher.helpers import seed_tasks
+    tasks = seed_tasks(store)
+    ready = next(t for t in tasks if t.status == "ready")
+    _run(["claim", ready.task_id, "--agent", "codex", "--json"])
+
+    code, data = _run(
+        ["move", ready.task_id, "--status", "completed", "--agent", "codex", "--json"],
+    )
+    assert code == 1
+    assert data["ok"] is False
+    assert "use complete instead" in data["error"]
+
+    stored = store.get_task(ready.task_id)
+    assert stored is not None
+    assert stored.status == "claimed"
+    assert stored.lease_id is not None
+    assert stored.claimed_by == "codex"
+
+
 def test_export_signboard_writes_markdown_columns(tmp_env, store, tmp_path: Path):
     from tests.dispatcher.helpers import seed_tasks
     tasks = seed_tasks(store)
@@ -361,6 +394,31 @@ def test_export_signboard_writes_markdown_columns(tmp_env, store, tmp_path: Path
     assert "generated_by: dispatcher.signboard" in content
     assert 'status: "review"' in content
     assert f"issue_number: {ready.issue_number}" in content
+
+
+def test_export_signboard_removes_stale_generated_card_after_title_change(
+    tmp_env,
+    store,
+    tmp_path: Path,
+):
+    from tests.dispatcher.helpers import seed_tasks
+    tasks = seed_tasks(store)
+    ready = next(t for t in tasks if t.status == "ready")
+    board = tmp_path / "BuilderOpsVault" / "agent-delivery"
+
+    code, data = _run(["export-signboard", str(board), "--json"])
+    assert code == 0
+    first_cards = list(board.glob(f"**/{ready.task_id}--*.md"))
+    assert len(first_cards) == 1
+
+    ready.title = "Test: renamed feature A"
+    store.upsert_task(ready)
+    code, data = _run(["export-signboard", str(board), "--json"])
+    assert code == 0
+
+    cards = list(board.glob(f"**/{ready.task_id}--*.md"))
+    assert len(cards) == 1
+    assert "renamed-feature-A" in cards[0].name
 
 
 def test_status_command(tmp_env):


### PR DESCRIPTION
## Direct Repair
Type: code
Reason: Move active Builder Ops lifecycle control away from GitHub Project v2/GraphQL and make dispatcher the agent-facing source of operational truth, with Signboard as a generated human board projection.
Validation: `pytest tests/dispatcher -q` (122 passed); `python3 -m compileall -q app/dispatcher`.
Issue required: no

Scope: Add dispatcher lifecycle move support, one-way Signboard Markdown export, dispatcher tests, and dispatcher documentation. No product/runtime behavior changes.

## Change Lane
- [ ] Implementation lane
- [ ] Docs authoring lane
- [x] Governance lane

## Linked Issue
Fixes #

Required for implementation lane. Leave blank for docs authoring lane.
Leave blank for governance lane when the PR stays within approved governance surfaces.

## SBS Impact
- Primary subsystem: Builder System
- Secondary subsystem(s): Dispatcher, Builder Ops workflow projection
- Write class: repo governance/workflow code and docs
- Authority impact: dispatcher SQLite is clarified as active Builder Ops control plane; Signboard/GitHub Project are projection surfaces
- Persistence impact: dispatcher DB remains operational state; generated Signboard Markdown is rebuildable projection
- Derived/rebuildable impact: Signboard board files are derived from dispatcher tasks
- Human knowledge impact: documents Codex/Claude workflow boundary for generated boards
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: agents can export local Signboard board without GraphQL/API project calls
- External boundary impact: reduces reliance on GitHub Project v2/GraphQL in hot path
- New or changed contract: `python -m app.dispatcher move`; `python -m app.dispatcher export-signboard <path>`
- Owner-doc impact: owner doc updated in this PR (`docs/AGENT_ISSUE_DISPATCHER.md`)
- Transition debt impact: GitHub Project v2 remains as deprecated optional projection until fully removed from older docs/scripts
- Fitness rule impact: dispatcher tests cover move/export behavior
- Boundary risk: Signboard cards are explicitly one-way generated projection, not authoritative input

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Adds dispatcher `move` command for explicit lifecycle transitions.
- Adds `export-signboard` to generate a Markdown kanban board from dispatcher state.
- Documents dispatcher as Builder Ops control plane and Signboard/GitHub Project as projections.

## Implementation Scope Check
- [x] Change stays within the Direct Repair scope.
- [x] Constraints from the Direct Repair scope were followed.
- [x] Direct Repair validation is satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [x] This PR only changes approved governance surfaces.
- [x] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [x] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [ ] `ruff check app tests`
- [x] If files under `app/` or `tests/` changed, lint output from `ruff check app tests` is included below or a tooling limitation is stated.
- [ ] `mypy app`
- [ ] `pytest -q -m "not pg"`
- [x] Additional targeted checks run as needed

Docs authoring lane:
- [ ] Docs/governance checks run as appropriate for the touched surfaces
- [x] Any validation gaps or tooling limitations are stated explicitly

Governance lane:
- [x] Governance checks run as appropriate for the touched surfaces
- [x] Any validation gaps or tooling limitations are stated explicitly

Validation run:
- `pytest tests/dispatcher -q` -> 122 passed
- `python3 -m compileall -q app/dispatcher` -> passed

Validation gaps:
- Full repo test suite, `ruff`, and `mypy` were not run; this is a focused Builder System dispatcher/governance change.

## BuilderOps Routing
- Records/projections/receipts: dispatcher Signboard projection introduced; no external BuilderOps record created.
- Reason: this PR itself updates the Builder Ops dispatcher contract and generated projection path.

## Notes
- Signboard export is intentionally one-way. Agents must continue mutating dispatcher state via CLI commands, not by editing generated Markdown cards.

