### PR TITLE
builder: decommission GitHub Projects as agent pickup gate

### DIFF
--- a/.codex/skills/README.md
+++ b/.codex/skills/README.md
@@ -14,7 +14,7 @@ boundary and artifact map in `docs/architecture/SBS_OPERATING_MODEL.md`.
 ## Workflow map
 
 Hot path:
-`Docs -> Issue -> Project -> Agent -> issue-to-code fast claim -> Publish PR -> CI -> Verification -> Merge -> Project/doc closure -> Owner Doc`
+`Docs -> Issue -> Dispatcher/GitHub claim -> Agent -> issue-to-code -> Publish PR -> CI -> Verification -> Merge -> closure -> Owner Doc`
 
 Conditional / maintenance path:
 `Issue maintenance -> Agent` for stale or false backlog state, and `Publish PR -> pr-integration` only when readiness/repair work is still needed before verification.
@@ -66,7 +66,7 @@ Do not rely on a human remembering where BuilderOps material belongs.
 Shared contracts: `.codex/skills/_shared/` holds the canonical contract files that skills reference
 instead of carrying inline copies — `ISSUE_CONTRACT.md` (Issue section list + `Verify:` rule),
 `LABEL_TAXONOMY.md` (canonical labels + `lane:governance` exception), `LIFECYCLE_TRUTH_MATRIX.md`
-(required Project Status per Issue/PR state), `BRANCH_TRUTH_GATE.md` (publication workspace gate),
+(optional legacy Project projection per Issue/PR state), `BRANCH_TRUTH_GATE.md` (publication workspace gate),
 `PROJECT_STATUS_OPERATIONS.md` (Project GraphQL operations), and `CI_WAIT_CONTRACT.md` (how to wait
 on CI checks — and the optional `--codex` verdict path — via REST without draining the shared API budget). A reference like
 `_shared/<FILE>.md :: <section>` resolves there. `_shared/` is not a skill directory.

--- a/.codex/skills/_shared/LABEL_TAXONOMY.md
+++ b/.codex/skills/_shared/LABEL_TAXONOMY.md
@@ -15,15 +15,15 @@ own copies.
 | `prio:high` | blocks other work or has active regression |
 | `prio:med` | normal delivery priority |
 | `prio:low` | nice-to-have, no urgency |
-| `agent:ready` | bounded, testable, unblocked — safe for agent execution; use only with `Status=Ready` |
+| `agent:ready` | bounded, testable, unblocked, and strictly validated — safe for agent pickup without requiring Project Status |
 | `agent:blocked` | dependency unresolved, including parent validation hubs waiting on child slices |
 | `agent:needs-human` | requires a named human decision, tradeoff, missing input, or authority question |
 
 Rules:
 
 - Every new implementation Issue leaves creation with exactly one truthful agent-state label.
-- `agent:blocked` and `agent:needs-human` belong on non-active work, normally with
-  `Status=Backlog`.
+- `agent:blocked` and `agent:needs-human` belong on non-active work. A Project may mirror them as
+  `Backlog`, but that projection does not control pickup.
 - Closed or delivered Issues must not retain any `agent:*` label.
 
 ## Governance-lane exception

--- a/.codex/skills/_shared/LIFECYCLE_TRUTH_MATRIX.md
+++ b/.codex/skills/_shared/LIFECYCLE_TRUTH_MATRIX.md
@@ -2,9 +2,11 @@ State: Shared skill contract. Canonical lifecycle truth matrix for Issues and PR
 
 # Lifecycle Truth Matrix
 
-Single source for the required Project Status of every Issue and PR content state. Every other
-cell is drift and must be corrected. Skills reference this file instead of carrying their own
-copies; `issue-maintenance-change-control` owns the reconciliation procedure that applies it.
+Single source for the optional legacy Project projection of Issue and PR content state. Project
+presence or Status never gates issue readiness, pickup, or claim. Review, merge, closure, and
+optional projection-repair behavior remain owned by their downstream skills. Skills reference this
+file instead of carrying their own copies; `issue-maintenance-change-control` owns optional
+reconciliation.
 
 ## Allowed Project statuses
 
@@ -12,7 +14,7 @@ copies; `issue-maintenance-change-control` owns the reconciliation procedure tha
 
 ## Matrix
 
-| Content | Content state | Required Project Status |
+| Content | Content state | Projected Status |
 |---------|---------------|-------------------------|
 | Issue | CLOSED | `Done` |
 | Issue | OPEN + `agent:ready` | `Ready` |
@@ -34,7 +36,7 @@ PR card in `Review` as drift.
 
 ## Binding rules
 
-- `agent:ready ↔ Status=Ready` is a post-condition, not just a declarative rule: an open
-  `agent:ready` Issue in any other status means the queue is lying about what is pickable.
+- `agent:ready` is the pickup qualifier after strict validation. `Status=Ready` is its preferred
+  legacy board projection, not a precondition or collision guard.
 - GitHub Issue state, agent labels, linked PR state, and merge/delivery reality outrank Project
   state when they disagree; correct the projection to match the harder truth.

--- a/.codex/skills/backlog-reconciliation-drift-audit/SKILL.md
+++ b/.codex/skills/backlog-reconciliation-drift-audit/SKILL.md
@@ -90,11 +90,10 @@ For each drift case, recommend one concrete corrective action only:
 - Roadmap should remain forward-looking.
 - Status may note delivery, but lasting truth belongs in the owner doc.
 - GitHub remains the canonical backlog-state surface.
-- Treat Project `Status` as the primary lifecycle signal; run Project reads/mutations per
-  `.codex/skills/_shared/PROJECT_STATUS_OPERATIONS.md`.
+- Treat Project `Status` as an optional legacy projection; run its reads/mutations only when the
+  audit explicitly includes Project repair.
 - Treat `agent:ready` and other agent-state labels per `.codex/skills/_shared/LABEL_TAXONOMY.md` as
-  the canonical label semantics; `agent:ready` is the pickup qualifier for `Status=Ready`, not a
-  substitute for `In Progress`, `Review`, or `Done`.
+  the canonical label semantics; `agent:ready` is the pickup qualifier after strict validation.
 - For Issue and PR cards, follow `.codex/skills/_shared/LIFECYCLE_TRUTH_MATRIX.md` as the single
   source for required Project Status. Skills reference this file instead of carrying their own copy;
   do not restate its rows here — an open non-draft PR legitimately projects to `Review` via the
@@ -123,7 +122,7 @@ On a plan divergence (you did something unexpected, or discovered an earlier art
 Receipt format:
 
 - backlog receipt:
-  `BACKLOG RECEIPT: Issue #123 created or updated, labeled ..., Project Status=Ready|Backlog|...`
+  `BACKLOG RECEIPT: Issue #123 created or updated, labeled ...; optional Project repair: <status|none>`
 - delivery receipt:
   `DELIVERY RECEIPT: Issue #123 delivered by PR #456. Merge commit: <sha>. CI: passed. Docs updated: yes/no. Owner doc updated: <path>. Project Status: Done.`
 - closure receipt:

--- a/.codex/skills/bug-to-issue/SKILL.md
+++ b/.codex/skills/bug-to-issue/SKILL.md
@@ -36,11 +36,9 @@ This is the hot-path defect intake lane, not the cold-path maintenance lane.
    - Add one priority: `prio:high`, `prio:med`, or `prio:low` based on impact.
    - Add `agent:ready` only if the scope is bounded, testable, and unblocked.
    - Otherwise add `agent:needs-human` or `agent:blocked`.
-5. Project:
-   - Run the add-item / Set Project Status operations from `.codex/skills/_shared/PROJECT_STATUS_OPERATIONS.md`.
-   - Add the new Issue to Project `Agent Delivery Control Plane`.
-   - Set Status to match the agent-state label: `agent:ready` → `Ready`; otherwise (`agent:blocked`, `agent:needs-human`) → `Backlog`.
-6. Output receipt: issue number, labels set, Project Status set, and whether it was created or updated.
+5. Optional Project projection:
+   - Project add/status operations are cold-path repair only; do not require ProjectV2 for Issue creation or `agent:ready`.
+6. Output receipt: issue number, labels set, and whether it was created or updated.
 
 ## Heuristics for `agent:ready`
 

--- a/.codex/skills/deliver-issue-set/SKILL.md
+++ b/.codex/skills/deliver-issue-set/SKILL.md
@@ -44,7 +44,7 @@ Allowed:
 - classify issue readiness
 - repair issue contracts when the owner docs make the intended contract unambiguous
 - create bounded issues through `docs-to-issue` or `feature-breakdown` when source docs already support the work
-- correct labels and Project Status for readiness truth
+- correct authoritative labels for readiness truth; Project repair is optional cold-path projection maintenance
 - produce implementation order, parallelization plan, and verification ledger
 
 Forbidden in planning / readiness mode:
@@ -58,7 +58,7 @@ Forbidden in planning / readiness mode:
 - merge PRs
 - close delivered issues except as an explicit maintenance correction after following `issue-maintenance-change-control`
 
-All GitHub label, Issue body, Project Status, and issue-creation mutations must be executed with explicit `gh` or GraphQL commands, verified, and reported with receipts.
+All GitHub label, Issue body, and issue-creation mutations must be executed with explicit `gh` commands, verified, and reported with receipts. Optional Project projection repair stays outside the pickup/dispatch hot path.
 
 ### Delivery Mode
 
@@ -124,7 +124,7 @@ Delivery rules:
 - Do not claim more issues than there are ready sub-agent execution slots.
 - Never make speculative claims. Every claimed issue must have an owner agent, worktree/branch plan, validation plan, and expected return receipt.
 - Before dispatching any issue or batch, reconcile the candidate set against current `origin/main` and live GitHub state. Re-read the issue body/state, linked PRs, and existing claim receipts on the current branch tip so already-delivered, superseded, closed, merged, or otherwise stale work is dropped before a slice is assigned. A dispatch plan built from stale local context or pre-merge assumptions is non-authoritative; if `origin/main`, the issue, or a linked PR disagrees with the earlier plan, current repo/GitHub truth wins and the coordinator must recompute the pickup target before dispatch.
-- Confirm each selected issue is claimable before dispatching: `Status=Ready`, labeled `agent:ready`, and carrying no conflicting prior claim. Do not pre-transition status or remove `agent:ready` from the coordinator before dispatch — `issue-to-code` selects only `Ready` + `agent:ready` issues, so pre-claiming would force a compliant sub-agent to reject the assignment. If the dispatcher is unavailable, use GitHub-label-only claim fallback and coordinate from the live issue/project state; there is no dispatcher lease to reconcile. The fast-claim handshake (`Ready -> In Progress` + remove `agent:ready` via `scripts/issue_pickup_claim.sh`) is performed by the sub-agent as the first step of its own `issue-to-code` pickup. An issue counts as dispatched only once that pickup has acquired the lease and recorded a claim receipt comment naming the coordinator session, assignee/sub-agent, worktree/branch plan, and expected return receipt.
+- Confirm each selected issue is claimable before dispatching: labeled `agent:ready` after strict contract validation and carrying no conflicting prior claim. Project Status is not a dispatch precondition. Do not remove `agent:ready` from the coordinator before dispatch; the sub-agent performs the fast claim through `scripts/issue_pickup_claim.sh`. If the dispatcher is unavailable, use GitHub-label-only fallback and coordinate from live Issue/PR state. An issue counts as dispatched only once pickup has acquired the available claim signal and recorded a claim receipt naming the coordinator session, assignee/sub-agent, worktree/branch plan, and expected return receipt.
 - For each issue, follow `issue-to-code` from claim through implementation and local validation.
 - Use `publish-pr` for branch, commit, push, and PR creation/update.
 - Use `pr-integration` only when the PR needs readiness or repair before verification.
@@ -136,7 +136,7 @@ Delivery rules:
 
 Parallel claim is allowed only when all are true:
 
-- each issue is independently `Status=Ready` and labeled `agent:ready`
+- each issue is independently contract-valid and labeled `agent:ready`
 - each issue has concrete `Verify:` targets and source authority
 - dependency order allows parallel work
 - likely touched files, migrations, schemas, release channels, and owner-doc writebacks do not create uncontrolled conflicts
@@ -154,7 +154,7 @@ issue state, linked PR state, and claim/release/superseded receipts. A non-match
 real collision only when it is the latest live lease and has not been released or superseded — i.e.
 the Issue is currently `In Progress` / not `agent:ready`, and no later release/superseded receipt or
 re-Ready transition has reclaimed it. Stale receipts from a prior, already-released or superseded lease
-on a re-Readied Issue (the Issue is back to `Ready` + `agent:ready` with no live foreign lease) do not
+on a re-opened pickup (the Issue is labeled `agent:ready` again with no live foreign lease) do not
 block valid pickup; treat them as historical and proceed. When the latest lease is a genuine foreign
 claim, stop and report the collision instead of implementing. If the dispatcher is unavailable, resolve
 collision checks against the live issue/project state and explicit lease signal; when live evidence
@@ -186,7 +186,7 @@ For a Kanban / Project request:
 
 - Resolve the Project, view, lane, or status filter before execution.
 - If the user says "all issues on Kanban" without a narrower lane, inspect the shared Project state and define the in-scope set explicitly before mutating anything.
-- Treat `Ready` plus `agent:ready` issues as executable pickup candidates.
+- Treat strictly validated `agent:ready` issues as executable pickup candidates; Project Status may be inspected as a projection but does not gate pickup.
 - Treat `Backlog`, `agent:blocked`, and `agent:needs-human` as non-active until readiness repair proves otherwise.
 - Do not mark blocked or unclear items as delivered just to clear the board.
 

--- a/.codex/skills/docs-to-issue/SKILL.md
+++ b/.codex/skills/docs-to-issue/SKILL.md
@@ -102,25 +102,24 @@ Skill-specific rule: if an AC cannot carry a resolvable `Verify:` target, the AC
   - `docs/STATUS.md :: SETTINGS-PROVENANCE`
 - Prefer stable anchor IDs over prose fragments.
 
-## Project rules
+## Pickup label and optional Project projection rules
 
-Run the add-item / Set Project Status operations from `.codex/skills/_shared/PROJECT_STATUS_OPERATIONS.md`.
+Project add/status operations from `.codex/skills/_shared/PROJECT_STATUS_OPERATIONS.md` are optional
+cold-path projection repair. They do not gate Issue creation or `agent:ready`.
 
-- Add each new Issue to Project `Agent Delivery Control Plane`.
-- Set Status appropriately:
-  - `Ready` only if bounded, testable, unblocked, and safe for agent execution
-  - every Acceptance Criterion must carry a resolvable `Verify:` target before `Status=Ready`
-  - immediately before applying `agent:ready` or `Status=Ready`, run strict readiness validation
+- Set the agent label appropriately:
+  - `agent:ready` only if bounded, testable, unblocked, and safe for agent execution
+  - every Acceptance Criterion must carry a resolvable `Verify:` target before `agent:ready`
+  - immediately before applying `agent:ready`, run strict readiness validation
     on the exact body file:
     ```bash
     python3 scripts/validate_issue_readiness.py --body-file <body-file> --label agent:ready
     ```
     Do not use `--observe-only` for a Ready mutation. If validation fails, do not apply
-    `agent:ready` or `Status=Ready`.
-  - otherwise `Backlog`
+    `agent:ready`.
+  - otherwise use `agent:blocked` or `agent:needs-human` according to the actual blocker
 - Every new implementation Issue should leave creation with exactly one truthful agent-state label.
-- Use `agent:ready` only with `Status=Ready`.
-- Use `agent:blocked` or `agent:needs-human` only for non-active work, normally with `Status=Backlog`.
+- Use `agent:blocked` or `agent:needs-human` only for non-active work.
 - Use `agent:blocked` for dependency waiting, including parent issues waiting on child slices; use `agent:needs-human` only for a named human decision, tradeoff, missing input, or authority question.
 - Do not leave delivered or closed work with any `agent:*` label.
 
@@ -139,7 +138,7 @@ On a plan divergence (you did something unexpected, or discovered an earlier art
 For each created Issue, include:
 
 - backlog receipt:
-  `BACKLOG RECEIPT: Issue #123 created, labeled ..., added to Project "Agent Delivery Control Plane", Status=Ready|Backlog.`
+  `BACKLOG RECEIPT: Issue #123 created, labeled ...; optional Project repair: <status|none>.`
 - delivery receipt template:
   `DELIVERY RECEIPT: Issue #123 delivered by PR #456. Merge commit: <sha>. CI: passed. Docs updated: yes/no. Owner doc updated: <path>. Project Status: Done.`
 

--- a/.codex/skills/feature-breakdown/SKILL.md
+++ b/.codex/skills/feature-breakdown/SKILL.md
@@ -201,9 +201,9 @@ By contrast, additive work on a single surface that mirrors an existing pattern 
    - If the GitHub parent issue later closes, update the local `PARENT_FEATURE_ISSUE.md` again so it no longer reads as an unfiled or active draft.
    - When closing, also update the capability `README.md` so it no longer reads as an active pre-delivery lane and so any now-satisfied acceptance checklist truthfully reflects the delivered docs/spec state.
 9. Create or update GitHub issues from the task specifications, in dependency order.
-10. Keep labels and Project status truthful:
-    - parent feature issue normally starts as `Backlog` plus `agent:blocked`
-    - ready tasks use `Status=Ready` plus `agent:ready`
+10. Keep authoritative labels truthful; Project status is optional projection:
+    - parent feature issue normally starts with `agent:blocked`
+    - ready tasks use `agent:ready` after strict validation
     - blocked tasks use `agent:blocked`
     - decision-dependent tasks use `agent:needs-human` only when a named human decision, tradeoff, missing input, or authority question is still open
 11. Emit one clear breakdown receipt showing the parent feature issue, implementation tasks, evidence surface, and execution order.
@@ -292,6 +292,6 @@ On a plan divergence (you did something unexpected, or discovered an earlier art
 When creating issues, include:
 
 - `FEATURE RECEIPT: Issue #123 created or updated as the parent feature issue.`
-- `TASK RECEIPT: Issue #124 created from LOCAL_TEST_BOOTSTRAP/RESET_RUNTIME_STATE, Status=Ready, label=agent:ready.`
+- `TASK RECEIPT: Issue #124 created from LOCAL_TEST_BOOTSTRAP/RESET_RUNTIME_STATE, label=agent:ready; optional Project repair: none.`
 
 If no parent feature issue is needed, say so explicitly and explain why the work should remain a single bounded issue instead.

--- a/.codex/skills/issue-maintenance-change-control/SKILL.md
+++ b/.codex/skills/issue-maintenance-change-control/SKILL.md
@@ -7,7 +7,7 @@ description: "Keep GitHub Issues, PRs, labels, and Project state truthful when b
 
 You are an Issue maintenance and lifecycle-correction agent for a repo-first, docs-as-code software system.
 
-⚠️ **CRITICAL: All corrections (labels, Project Status, Issue edits, duplicates, PR reconciliation) must be executed using explicit commands (`gh issue edit`, `gh issue close`, `gh api graphql`). Do not describe corrections—execute them and verify they succeeded. Track all executed changes in the output receipt.**
+⚠️ **CRITICAL: All authoritative corrections (labels, Issue edits, duplicates, PR reconciliation) must be executed using explicit commands and verified. Project repair is optional cold-path projection maintenance and must not gate Issue readiness or pickup.**
 
 Your job is to keep GitHub Issues, Pull Requests, labels, and Project state truthful when backlog state drifts from implementation reality.
 That includes PR lifecycle truth, not only Issue lifecycle truth.
@@ -59,13 +59,13 @@ conditional path (`Issue maintenance -> Agent`), not the hot path.
 - Preserve traceability through `Source Anchors`.
 - Prefer batched maintenance actions for repeated drift patterns; reserve single-item churn for cases where the items genuinely differ.
 - Delivered, repo-verifiable parent scope should not stay open only for future adoption or retro observation.
-- Before adding or preserving `agent:ready`, or before setting Project Status to `Ready`, run strict
+- Before adding or preserving `agent:ready`, run strict
   executable-contract validation on the exact Issue body:
   ```bash
   python3 scripts/validate_issue_readiness.py --body-file <body-file> --label agent:ready
   ```
   Do not use `--observe-only` for a Ready mutation. If validation fails, remove or avoid
-  `agent:ready` and do not set Project Status `Ready`.
+  `agent:ready`.
 
 ## Canonical lifecycle expectations
 
@@ -78,7 +78,7 @@ conditional path (`Issue maintenance -> Agent`), not the hot path.
 
 ### Lifecycle truth matrix
 
-The canonical matrix lives at `.codex/skills/_shared/LIFECYCLE_TRUTH_MATRIX.md` — Project Status must match content state for both Issues and PRs; every other cell is drift and must be corrected. This skill owns the reconciliation procedure that applies it; the matrix itself (including the review-requested `Review` semantics settled by #1806) is defined once in the shared file.
+The canonical optional projection matrix lives at `.codex/skills/_shared/LIFECYCLE_TRUTH_MATRIX.md`. This skill owns Project reconciliation when a maintenance run explicitly includes that projection.
 
 ### Drift patterns that must be flagged explicitly
 
@@ -86,7 +86,7 @@ These are the high-frequency drift patterns that are easy to miss. A maintenance
 
 - **Merged/closed PRs stuck in `Review` or `In Progress`** — stale handoff state on terminal work. "Terminal status on terminal work" is as common as blank PR cards and must be checked alongside them.
 - **Closed Issues stuck in `Review` or `In Progress`** — the Issue is Done; non-terminal status on closed Issues is drift, not a pending handoff.
-- **Open `agent:ready` Issues not in `Ready`** — the queue is lying about what is pickable. The `agent:ready ↔ Status=Ready` binding is a post-condition, not just a declarative rule.
+- **Open `agent:ready` Issues with invalid contracts or active foreign claims** — the queue is lying about what is pickable regardless of Project Status.
 - **PRs with no Project Status (blank / not in Project)** — the board cannot reflect lifecycle if the PR isn't represented at all. Open and closed PRs both need Project entries.
 - **Open non-draft PRs stuck in `In Progress`** — the PR is ready for Project review tracking but the board still shows active implementation. Draft PRs remain `In Progress`; opened/reopened non-draft PRs and PRs marked ready for review belong in `Review` (see the lifecycle truth matrix and Project PR automation).
 
@@ -105,7 +105,7 @@ If any of the above is missing or unclear, first try to resolve it from the SoT 
 
 ## Checks to perform
 
-1. **Project-state audit:** bucket every Project item by (`content.state`, `Status`) and list every cell that violates the lifecycle truth matrix. This is the authoritative drift set for the run; nothing below may proceed on the assumption the board is clean until this audit is produced.
+1. **Optional Project-state audit:** only when Project repair is explicitly in scope, bucket Project items by (`content.state`, `Status`). This projection audit must not precede or gate authoritative Issue/PR corrections.
 2. Compare Issue `Scope`, `Source Anchors`, `Acceptance Criteria`, and `Source Docs` to current docs.
 3. Compare the Issue to open, merged, and closed PRs and repo reality.
 4. Check whether the Issue is too large, stale, partially shipped, or blocked.
@@ -225,8 +225,8 @@ Child slice issues may become `agent:ready` only when their executable contract 
 
 1. **If contract lives in an open spec PR:** keep the child issue non-active (`agent:blocked` or `agent:needs-human`) until the spec merges or the issue is rewritten with required local contract sections
 
-2. **If contract is concrete and merged:** can label as `agent:ready` with `Status=Ready` only after
-   strict readiness validation exits 0
+2. **If contract is concrete and merged:** can label as `agent:ready` only after strict readiness
+   validation exits 0; optional Project repair may mirror it as `Ready` afterward
 3. **Child issues should form an execution chain**: each delivered child should post a validation receipt to the parent issue, and the final child must include a parent-closure handoff or create/link an explicit parent-closure issue before the parent is closed.
 
 ## Quick Reference: Maintenance State Corrections
@@ -238,7 +238,7 @@ Child slice issues may become `agent:ready` only when their executable contract 
 | Delivered but open | Execute Delivered Open | +agent:needs-human | Backlog | Comment explaining next step |
 | Parent feature | Keep non-active | +agent:blocked | Backlog | Validation hub, waiting on child chain |
 | Child with spec in PR | Keep non-active | +agent:blocked | Backlog | Wait for spec merge |
-| Child with concrete contract | Can label ready | +agent:ready | Ready | Only when merged, clear, and strict readiness validation passes |
+| Child with concrete contract | Can label ready | +agent:ready | Optional projection: Ready | Only when merged, clear, and strict readiness validation passes |
 
 ## When splitting
 
@@ -290,7 +290,9 @@ Use this when the user asks for a maintenance run across everything not done.
 1. Resolve repo:
    - If repo not given, ask for `owner/repo`.
    - If user says they are the owner, resolve the username via `gh api user --jq .login` or infer it from `git remote` (prefer the GitHub app account resolver when available, but do not depend on it).
-2. **Pre-flight Project-state audit.** Before any label edits or helper scripts, query every Project item and bucket it by (`content.state`, `Status`). Flag every cell that violates the lifecycle truth matrix. This audit is independent of any reconciliation helper and must be executed directly via GraphQL:
+2. **Optional Project-state audit.** Run this only when Project repair is explicitly requested, and
+   only after authoritative Issue/PR reads. It never gates label edits or pickup. If in scope, query
+   Project items and bucket them by (`content.state`, `Status`):
 
    ```bash
    gh api graphql -f projectId="$PROJECT_ID" -f query='
@@ -363,7 +365,7 @@ Use this when the user asks for a maintenance run across everything not done.
      - Keep or set `agent:needs-human` for boundary moves without explicit direction or module paths.
      - Keep or set `agent:blocked` when external dependencies are stated.
    
-   - **Execute Project state reconciliation** for each open issue only after labels are corrected and
+   - **Optionally execute Project state reconciliation** only when projection repair is in scope and after labels are corrected and
      strict validation has passed for any `Ready` target: run the Set Project Status mutation from
      `.codex/skills/_shared/PROJECT_STATUS_OPERATIONS.md` — validated `agent:ready` → `Ready`
      option ID; `agent:blocked` or `agent:needs-human` → `Backlog` option ID.
@@ -415,7 +417,7 @@ Use this when the user asks for a maintenance run across everything not done.
    - state that Issue/PR truth remains authoritative until Project reconciliation can resume
 
 10. **Post-condition verification.** After all corrections, re-run the step 2 audit query and verify zero drift cells remain. Specifically check:
-    - Every `agent:ready` open Issue is in `Status=Ready`
+    - Every `agent:ready` open Issue has a strictly valid contract; when optional Project repair is in scope, its preferred projection is `Status=Ready`
     - Every `agent:blocked` / `agent:needs-human` open Issue is in `Status=Backlog`
     - Every closed Issue is in `Status=Done`
     - Every merged / closed PR is in `Status=Done`

--- a/.codex/skills/issue-to-code/SKILL.md
+++ b/.codex/skills/issue-to-code/SKILL.md
@@ -7,7 +7,7 @@ description: "Implement a bounded GitHub slice issue as the canonical task contr
 
 You are a builder agent implementing GitHub backlog work in a repo-first, docs-as-code software system.
 
-⚠️ **CRITICAL: All lifecycle state changes (labels, Project Status) must be executed using explicit commands (`gh issue edit`, `gh api graphql`, `gh pr edit`). Do not describe these changes—execute them and verify they succeeded before continuing.**
+⚠️ **CRITICAL: All authoritative lifecycle state changes (Issue labels, comments, and closure) must be executed using explicit commands and verified. Project Status is optional legacy projection repair and is never a pickup precondition.**
 
 Your governing rule:
 Only execute bounded implementation work from a GitHub Issue that is the canonical task contract.
@@ -73,7 +73,7 @@ Apply `docs/development/AGENT_OPERATING_PROTOCOL.md` for the full classification
 ## Canonical workflow
 
 Hot path:
-`Docs -> Feature issue -> Slice issue -> Agent -> Fast claim (Ready -> In Progress + remove agent:ready) -> Publish PR -> PR integration (conditional readiness/repair) -> CI -> Slice verification -> Merge -> Feature validation -> Acceptance -> Owner Doc`
+`Docs -> Feature issue -> Slice issue -> Agent -> Fast claim (dispatcher lease or label removal + claimant receipt) -> Publish PR -> PR integration (conditional readiness/repair) -> CI -> Slice verification -> Merge -> Feature validation -> Acceptance -> Owner Doc`
 
 Conditional / maintenance path:
 `Issue maintenance -> Agent` and `Publish PR -> PR integration` only when mergeability, CI attachment, or review repair is still needed.
@@ -91,20 +91,20 @@ BuilderOps write is unavailable.
 
 Treat every canonical Issue contract section (`.codex/skills/_shared/ISSUE_CONTRACT.md`) as binding for the governing slice issue.
 
-## GitHub and Project rules
+## GitHub and optional Project projection rules
 
 - GitHub Issue is the canonical implementation task contract.
-- GitHub Project `Agent Delivery Control Plane` is the canonical lifecycle state machine.
-- The agent is responsible for keeping Project status truthful while it works.
-- Do not leave actively worked Issues in `Ready`.
+- GitHub Project `Agent Delivery Control Plane` is an optional legacy lifecycle projection.
+- Project repair is a cold-path maintenance concern and is not part of selection or claim.
+- Do not leave actively worked Issues labeled `agent:ready`.
 - Do not leave blocked Issues in `In Progress`.
 - Do not use `Review` only because a PR exists; keep work `In Progress` until review handoff is explicit.
-- Treat `Ready -> In Progress` plus removal of `agent:ready` as the fast claim/lease handshake.
-- Keep that claim minimal and compatible with multi-agent environments: one active lease per Issue, with the label/status transition as the shared signal.
+- Treat dispatcher lease acquisition plus removal of `agent:ready` as the fast claim handshake.
+- In GitHub-label-only fallback, removal of `agent:ready` plus a durable claim-receipt comment naming agent, session, branch, and worktree is the shared one-owner signal.
 
 Allowed labels: the canonical taxonomy in `.codex/skills/_shared/LABEL_TAXONOMY.md`.
 
-Allowed Project statuses: per `.codex/skills/_shared/LIFECYCLE_TRUTH_MATRIX.md` (`Backlog`, `Ready`, `In Progress`, `Review`, `Done`).
+Legacy Project projection statuses remain documented in `.codex/skills/_shared/LIFECYCLE_TRUTH_MATRIX.md`; they do not gate selection or claim.
 
 For complex or resumed claim/review handoff state, a caller may first generate a local dry-run plan:
 `python3 -m app.builderops builderops epic-run-state lifecycle-plan --transition <claim|review> --issue-file <file> [--pr-file <file>] --json`.
@@ -115,7 +115,7 @@ handoff changes still follow the explicit commands in this skill.
 ## Issue selection rule before implementation
 
 - Work from bounded slice issues, not from parent feature issues that still require decomposition or post-merge validation.
-- Work only from GitHub Issues that are both `Status=Ready` and labeled `agent:ready`.
+- Work only from GitHub Issues labeled `agent:ready` after strict issue-contract validation. Project Status is not a pickup precondition.
 - Among ready issues, pick one of the highest available priority:
   - `prio:high` before `prio:med` before `prio:low`
 - If several candidate issues share the same priority, use engineering judgment and prefer:
@@ -183,9 +183,7 @@ whether pickup used dispatcher-backed coordination or GitHub-label-only fallback
 
 #### GitHub-Based Claim (Fallback or Non-Dispatcher Flow)
 
-1. **Ensure Issue is in Project** (if missing, add it first): run the resolve-item query from `.codex/skills/_shared/PROJECT_STATUS_OPERATIONS.md`; an empty `projectItems` list means add-to-Project first.
-
-2. **Fast-claim the Issue via mandatory preflight wrapper:**
+1. **Fast-claim the Issue via mandatory preflight wrapper:**
    ```bash
    scripts/issue_pickup_claim.sh --issue <N>
    ```
@@ -193,12 +191,18 @@ whether pickup used dispatcher-backed coordination or GitHub-label-only fallback
    `fallback_reason=<reason|none>` in its pickup receipt. Preserve that receipt in the PR body or
    claim comment when the issue uses dispatcher coordination or fallback.
 
-3. **Set Issue Project Status to In Progress:** run the Set Project Status mutation from `.codex/skills/_shared/PROJECT_STATUS_OPERATIONS.md` with the `In Progress` option ID.
-
-4. **Verify:**
+2. **For label-only fallback, post the durable claimant receipt immediately:**
    ```bash
-   gh issue view #<N> --json labels,projectItems
+   gh issue comment <N> --body "Claim receipt: agent=<agent-id> session=<session-id> branch=<branch> worktree=<worktree> coordination_mode=github-label-only-fallback fallback_reason=<reason>"
    ```
+
+3. **Verify the authoritative claim signal and claimant receipt:**
+   ```bash
+   gh issue view #<N> --json labels,state
+   gh api repos/:owner/:repo/issues/<N>/comments --jq '.[-1].body'
+   ```
+
+Project reconciliation, when desired, is a separate cold-path projection repair. Do not query or mutate ProjectV2 in this claim path.
 
 ### Action: Issue is Blocked (Mid-Implementation)
 

--- a/.codex/skills/learning-to-issue/SKILL.md
+++ b/.codex/skills/learning-to-issue/SKILL.md
@@ -69,13 +69,13 @@ If an AC cannot carry a resolvable `Verify:` target, refine or split before mark
 
 ## Allowed labels (canonical only)
 
-Use the canonical taxonomy from `.codex/skills/_shared/LABEL_TAXONOMY.md`, including its governance-lane exception: governance-lane learning issues add `lane:governance` in addition to the canonical delivery label set so Project filtering and verification routing stay aligned with `AGENTS.md` and `docs/development/DELIVERY_FEEDBACK_LOOP.md`.
+Use the canonical taxonomy from `.codex/skills/_shared/LABEL_TAXONOMY.md`, including its governance-lane exception: governance-lane learning issues add `lane:governance` in addition to the canonical delivery label set so verification routing stays aligned with `AGENTS.md` and `docs/development/DELIVERY_FEEDBACK_LOOP.md`.
 
 ## Creating the issue
 
 Choose the label set based on readiness before running `gh issue create`:
 
-**Bounded, testable, and unblocked -> `agent:ready`, Status=Ready:**
+**Bounded, testable, and unblocked -> `agent:ready`:**
 ```bash
 python3 scripts/validate_issue_readiness.py --body-file <body-file> --label agent:ready
 gh issue create \
@@ -83,37 +83,35 @@ gh issue create \
   --title "<type>: <bounded outcome>" \
   --label "type:task,prio:med,agent:ready" \
   --body "..."
-# Then set Project Status=Ready
 ```
 For governance-lane learning issues, also add `--label "lane:governance"` so the issue is visible in the governance lane filter and keeps the relaxed governance verification path.
 
-**Dependency unresolved -> `agent:blocked`, Status=Backlog:**
+**Dependency unresolved -> `agent:blocked`:**
 ```bash
 gh issue create \
   --repo <owner/repo> \
   --title "<type>: <bounded outcome>" \
   --label "type:task,prio:med,agent:blocked" \
   --body "..."
-# Then set Project Status=Backlog
 ```
 
-**Requires human decision -> `agent:needs-human`, Status=Backlog:**
+**Requires human decision -> `agent:needs-human`:**
 ```bash
 gh issue create \
   --repo <owner/repo> \
   --title "<type>: <bounded outcome>" \
   --label "type:task,prio:med,agent:needs-human" \
   --body "..."
-# Then set Project Status=Backlog
 ```
 
-Do not apply `agent:ready` or set Project Status `Ready` unless strict validation exits 0. Never use
-`--observe-only` for a Ready mutation. Every AC must have a resolvable `Verify:` target and no
+Do not apply `agent:ready` unless strict validation exits 0. Never use
+`--observe-only` for a ready-label mutation. Every AC must have a resolvable `Verify:` target and no
 dependency may block execution.
 
 **Issue body (all cases):** use the body template from `.codex/skills/_shared/ISSUE_CONTRACT.md`, with the learning-specific requirements above (`## Context` links the source record; `## Applies learning` filled, e.g. `Applies learning from \`BuilderOps LearningSignal <id>\``).
 
-Run the add-item / Set Project Status operations from `.codex/skills/_shared/PROJECT_STATUS_OPERATIONS.md`. After creation, add to Project `Agent Delivery Control Plane` and verify Status matches the chosen readiness state.
+Project add/status operations are optional cold-path projection repair. Do not invoke GraphQL or
+ProjectV2 as part of Issue readiness or creation.
 
 ## Raw-intake normalization path
 
@@ -159,7 +157,7 @@ Signs a raw-intake issue needs normalization:
 
 **Backlog receipt (new issue):**
 ```
-BACKLOG RECEIPT: Issue #N created - "<title>", labeled type:task/prio:med/agent:ready, added to Project "Agent Delivery Control Plane", Status=Ready. Source: BuilderOps LearningSignal <id>, BuilderOps PromotionIntent <id>, or docs/learning-log.md :: YYYY-MM-DD compatibility entry.
+BACKLOG RECEIPT: Issue #N created - "<title>", labeled type:task/prio:med/agent:ready. Source: BuilderOps LearningSignal <id>, BuilderOps PromotionIntent <id>, or docs/learning-log.md :: YYYY-MM-DD compatibility entry.
 ```
 
 **Normalization receipt (existing issue updated):**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ Repo-local workflow helpers live under `.codex/skills/`. They do not replace thi
 
 For GitHub implementation work, loading `.codex/skills/issue-to-code/SKILL.md` is mandatory before coding.
 That skill owns the pickup rule:
-when active work begins, move the governing Issue/Project state to `In Progress` and remove `agent:ready` before local edits so another agent does not pick up the same task.
+when active work begins, acquire the dispatcher claim when available and remove `agent:ready` before local edits so another agent does not pick up the same task. GitHub Project Status is an optional projection, not a pickup dependency.
 
 Execution discipline:
 
@@ -177,7 +177,7 @@ Many agents run against this repo at once. C_coordination, C_delay, and C_rework
 - **Dedicated worktree by default.** Any concurrent implementation or publication runs in its own `git worktree`, never the shared root worktree. Do not edit, commit, or push from the shared root checkout while other agents may be active. The publish/claim boundary (`scripts/agent_workspace_preflight.sh`) enforces this by default and refuses the shared root worktree — set `PKM_ALLOW_SHARED_ROOT=1` for deliberate solo work in the root.
 - **Never switch the shared root worktree's branch out from under a concurrent agent.** Branch switches happen in your own worktree. The shared-root HEAD thrash is a real, recurring loss — uncommitted work rides an unexpected checkout.
 - **Branch-truth before write.** Capture `EXPECTED_BRANCH` / `EXPECTED_WORKTREE` at branch creation and run the branch-truth gate before commit and before push (`_shared/BRANCH_TRUTH_GATE.md`). Proportionality never relaxes this.
-- **Smallest shared lease, then local.** Claim the issue/lane with the minimal shared handshake (`Ready -> In Progress`, remove `agent:ready`), then keep execution local and deterministic. One active lease per issue.
+- **Smallest shared lease, then local.** Claim the issue/lane with the minimal shared handshake (dispatcher lease when available; otherwise remove `agent:ready` and post a claimant receipt), then keep execution local and deterministic. One active lease per issue.
 - **Right-size fan-out.** Parallelize only independent issues with isolated worktrees, explicit return receipts, and an explicit token/quality rationale. Over-fanning raises C_coordination faster than it cuts C_delay — when in doubt, fewer agents.
 - **Reconcile races on evidence, do not redo.** On a claim or delivery collision, the latest unreleased lease governs; verify on `origin/main` and close your duplicate rather than re-implementing.
 - **Shared-budget awareness.** The GitHub API budget (5,000/hr) is shared across every concurrent agent, and GraphQL exhausts first. A tool call's real cost is its *marginal cost to all agents*, not to your task — so never busy-wait on a shared budget, prefer the transport that spares the scarce bucket (REST `gh api` over GraphQL `gh pr`/`gh issue`/`gh repo`; `git push --delete` over the API for branch ops), and read the free `gh api rate_limit` endpoint before assuming exhaustion. The same rule covers any pooled resource (CI runners, the embedding/Ollama queue). For waiting on CI checks (and the optional `--codex` verdict path, inactive as the default gate) specifically, follow `_shared/CI_WAIT_CONTRACT.md` — a tight `gh pr checks` loop drains the shared GraphQL bucket to zero and stalls every other agent.
@@ -310,7 +310,7 @@ For implementation work, GitHub Issues are the canonical task contract.
 
 Builder-agent rules:
 
-- Only pick work from a GitHub Issue that is both `Status=Ready` and labeled `agent:ready`.
+- Only pick work from a GitHub Issue carrying a strictly valid `agent:ready` label; strict contract validation must pass before the label is applied.
 - Read the full Issue before editing.
 - Treat `Context`, `Scope`, `Source Anchors`, `Constraints`, `Acceptance Criteria`, `Out of Scope`, `Suggested Validation`, and `Source Docs` as binding.
 - Every `Acceptance Criterion` must declare its verification inline with a `Verify:` marker: a concrete test pointer (`tests/...::test_name`) for behavioral criteria, or a concrete non-test target (doc writeback path plus anchor, runtime receipt, roadmap diff) for non-behavioral criteria. ACs without a resolvable `Verify:` target are not executable and the Issue must not be `agent:ready`.
@@ -320,9 +320,9 @@ Builder-agent rules:
 - Do not expand scope beyond the Issue without updating the task contract first.
 - Do not create new backlog work in GitHub without stable `Source Anchors` that point to the most local governing doc items.
 - Prefer stable anchor IDs over prose fragments when the source doc is likely to produce multiple Issues over time.
-- Treat GitHub Issues as the canonical backlog receipt. GitHub Project is the shared operating board when available; inline doc markers such as `Tracked by: #...` are secondary convenience notes only.
-- Prefer Issues plus truthful agent labels and linked PR state as harder authority than Project state if they drift.
-- Use Project `Status` as the pickup and coordination projection. `agent:ready` is only the pickup qualifier for `Status=Ready`; blocked labels belong on non-active work, and closed issues must not retain `agent:*` labels.
+- Treat GitHub Issues as the canonical backlog receipt. GitHub Project is an optional legacy projection when available; inline doc markers such as `Tracked by: #...` are secondary convenience notes only.
+- Prefer Issues plus truthful agent labels, linked PR state, and CI as harder authority than Project state if they drift.
+- Use `agent:ready` as the external pickup qualifier without requiring GitHub Project Status. The dispatcher claim is the collision guard when available; blocked labels belong on non-active work, and closed issues must not retain `agent:*` labels.
 - When a PR delivers a tracked backlog item, update the owner doc to describe shipped reality and rewrite roadmap/plan wording so it no longer reads as pending work.
 - Prefer GitHub REST endpoints for routine issue/label/PR operations; use GraphQL when REST does not express the required operation.
 - When GraphQL is required, resolve stable identifiers once per run and reuse cached values instead of repeating lookup queries.

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -40,12 +40,14 @@ The dispatcher is an operational coordination layer, not a lifecycle replacement
 | Surface | Role in MVP | Authority |
 | --- | --- | --- |
 | GitHub Issues / PRs / CI | Durable delivery lifecycle and merge truth | Hard authority |
-| Local Dispatcher state | Fast operational coordination (queue, claims, leases, heartbeats, local progress) | Operational authority only |
-| GitHub Project / external boards | Human-facing projection | Optional projection, not hot path |
+| Dispatcher SQLite | Volatile operational coordination (queue, claims, leases, heartbeats, local progress) | Operational authority only |
+| external BuilderOps Vault | Durable BuilderOps Markdown artifacts; never SQLite or live claims | BuilderOps artifact authority |
+| GitHub Project / Signboard / external boards | Human-facing views | Optional projection, not hot path |
 
 Normative boundary:
 - GitHub remains the durable development source of truth.
-- Dispatcher owns local operational multi-agent coordination state.
+- Dispatcher SQLite owns volatile operational multi-agent coordination state.
+- The external BuilderOps Vault stores durable Markdown artifacts while SQLite and active claims stay local to the dispatcher host.
 - External boards (including GitHub Projects) are optional projections and must not be required in the agent hot path.
 
 ## Non-Goals (MVP)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -716,9 +716,11 @@ Development control model:
 
 - Docs define intent, contracts, and owner boundaries.
 - GitHub Issues are the canonical task contract for implementation work.
-- GitHub Project v2 is the delivery state machine.
-- Local Agent Issue Dispatcher is the active operational coordination primitive for claim ordering,
-  leases, heartbeats, and completion; GitHub Issue/PR truth still outranks dispatcher state.
+- GitHub Project v2 is an optional legacy projection, not a pickup gate.
+- Dispatcher SQLite is the active volatile coordination primitive for claim ordering, leases,
+  heartbeats, and completion; GitHub Issues / PRs / CI remain durable delivery truth.
+- The external BuilderOps Vault stores durable BuilderOps Markdown artifacts. It does not contain
+  dispatcher SQLite or active claims.
 - Coding agents are the execution layer that implement bounded Issues.
 - Pull requests are the implementation artifact.
 - CI/test workflows are the validation loop.
@@ -726,7 +728,7 @@ Development control model:
 
 Canonical delivery sequence:
 
-`Docs -> Issue -> Project -> Agent -> PR -> CI -> Feedback`
+`Docs -> Issue -> Dispatcher claim -> Agent -> PR -> CI -> Feedback`
 
 Required Issue contract:
 
@@ -748,7 +750,7 @@ Required label ontology:
 - priority: `prio:high`, `prio:med`, `prio:low`
 - agent qualifiers: `agent:ready`, `agent:blocked`, `agent:needs-human`
 
-Required Project state machine:
+Optional legacy Project projection states:
 
 - `Backlog -> Ready -> In Progress -> Review -> Done`
 
@@ -758,12 +760,12 @@ Optional Project field:
 
 Guardrails for builder agents:
 
-- Project `Status` is the primary lifecycle signal.
-- `agent:ready` qualifies an Issue for pickup only when `Status=Ready`.
+- A strictly validated `agent:ready` label is the external pickup qualifier.
+- Project Status is a rebuildable projection and does not gate pickup.
 - `In Progress` covers active implementation and open PR work before explicit review handoff.
 - `Review` begins only when review handoff is explicit, normally after review is requested.
 - Closed or delivered work must not retain `agent:*` labels.
-- Agents only pick Issues with `Status=Ready` and label `agent:ready`.
+- Agents only pick Issues with a strictly validated `agent:ready` label and no conflicting dispatcher claim.
 - Agents must stay within the linked Issue scope.
 - Agents must respect the linked Issue constraints.
 - Agents must satisfy the linked Issue acceptance criteria before claiming completion.

--- a/docs/development/BUILDER_SYSTEM_PROCESS_MAP.md
+++ b/docs/development/BUILDER_SYSTEM_PROCESS_MAP.md
@@ -19,8 +19,8 @@ The Builder System has these layers:
 
 1. Intent layer: human intent enters through docs, issues, tasks, explicit decisions, and strategic constraints. Observed authority: `PROJECT_KERNEL`, charter, docs, and GitHub issue contracts route intent; `AGENTS.md` names the owner as the authority for irreversible and strategic calls [AGENTS.md:161-169], [docs/DOCS_INDEX.md:48-90].
 2. Docs-as-code/spec authority layer: docs are primary Builder System authority, not background. `docs/DOCS_INDEX.md` is the stable role/routing map and says to read Core SoT docs before references, and plans/historical docs as context only [docs/DOCS_INDEX.md:1-17].
-3. Contract layer: GitHub issues, PR templates, shared skill contracts, labels, Project states, `Verify:` markers, and SBS impact blocks define executable work [`.codex/skills/_shared/ISSUE_CONTRACT.md`:12-72], [`.github/ISSUE_TEMPLATE/task.yml`:73-109].
-4. Dispatch/routing layer: dispatcher queue/leases, labels, Project status, skill routing, model/reasoning policy, and worktree isolation select work and prevent collisions [docs/AGENT_ISSUE_DISPATCHER.md:132-180], [AGENTS.md:171-182].
+3. Contract layer: GitHub issues, PR templates, shared skill contracts, labels, `Verify:` markers, and SBS impact blocks define executable work [`.codex/skills/_shared/ISSUE_CONTRACT.md`:12-72], [`.github/ISSUE_TEMPLATE/task.yml`:73-109].
+4. Dispatch/routing layer: dispatcher queue/leases, labels, skill routing, model/reasoning policy, and worktree isolation select work and prevent collisions; Project status is projection evidence only [docs/AGENT_ISSUE_DISPATCHER.md:132-180], [AGENTS.md:171-182].
 5. Execution layer: skills, agents, scripts, local worktrees, implementation PRs, and publication boundaries perform work [`.codex/skills/README.md`:144-164], [`.codex/skills/publish-pr/SKILL.md`:53-159].
 6. Verification/evidence layer: local validation, CI, REST-only check waiting, local review gate, delivery receipts, Project reconciliation, and owner-doc receipts prove work [`.codex/skills/verification-and-closure/SKILL.md`:46-77], [`.codex/skills/_shared/CI_WAIT_CONTRACT.md`:22-82].
 7. Closure/spec-feedback layer: merge, issue closure, dispatcher completion, parent validation receipts, post-merge owner-doc decisions, and roadmap/spec state updates close work truthfully [`.codex/skills/verification-and-closure/SKILL.md`:194-208], [docs/development/PARENT_ISSUE_CLOSURE.md:13-49].
@@ -68,7 +68,7 @@ Read-only GitHub evidence used:
 | issue contract | implemented | `.codex/skills/_shared/ISSUE_CONTRACT.md`, `.github/ISSUE_TEMPLATE/task.yml` | Executable backlog shape | Source docs | Issue body with `Verify:` markers | Issue creation/edit | [`.codex/skills/_shared/ISSUE_CONTRACT.md`:12-72], [`.github/ISSUE_TEMPLATE/task.yml`:73-109] |
 | issue template | implemented | `.github/ISSUE_TEMPLATE/task.yml` | Form enforcement for task contracts | Human/agent issue creation | Structured issue fields | GitHub issue form | [`.github/ISSUE_TEMPLATE/task.yml`:1-141] |
 | issue readiness validator | partially_implemented | `issue-pr-governance.yml`, `validate_source_anchors.py`, skills | Enforce sections and source anchors for ready/blocked issues | Issue body/labels | Failed checks or valid issue | GitHub Action read/write labels only for cleanup | [`.github/workflows/issue-pr-governance.yml`:40-78] |
-| issue queue | partially_implemented | GitHub labels/Project, dispatcher SQLite | Expose ready work | `agent:ready`, Status=Ready, dispatcher pull | Queue entries | GitHub labels/Project; dispatcher store | [`.github/github-governance.yml`:28-31], [docs/AGENT_ISSUE_DISPATCHER.md:132-180] |
+| issue queue | partially_implemented | GitHub labels, dispatcher SQLite | Expose ready work | strictly validated `agent:ready`, dispatcher pull | Queue entries | GitHub labels; dispatcher store | [docs/AGENT_ISSUE_DISPATCHER.md:132-180] |
 | dispatcher | implemented | `app/dispatcher/**`, `docs/AGENT_ISSUE_DISPATCHER.md`, Makefile targets | Queue, claim, lease, heartbeat, completion | GitHub `agent:ready` issues | Local tasks/leases/events | Local dispatcher DB only | [docs/AGENT_ISSUE_DISPATCHER.md:21-36], [Makefile:356-361], [app/dispatcher/cli.py:31-32] |
 | model router | implicit | `AGENTS.md` TCD policy, `.codex/agents/*.toml` | Choose model/reasoning by risk | Task risk/TCD | Model/effort choice | Agent/session config | [AGENTS.md:112-157], [`.codex/agents/slice-implementer.toml`:1-20] |
 | skill router | partially_implemented | `AGENTS.md`, `.codex/skills/README.md` | Route work to workflow skill | Task class | Skill path | Agent behavior | [AGENTS.md:18-68], [`.codex/skills/README.md`:64-128] |
@@ -161,7 +161,7 @@ flowchart TD
 | feature breakdown | Capability too large | Agent | Owner/spec docs | feature-breakdown | feature-breakdown | gh/docs | Spec dir, parent/child issues | PR + GitHub | task specs with ACs | parent vs child | validation hub | blocked parent | target acceptance ambiguity | [`.codex/skills/feature-breakdown/SKILL.md`:25-47], [`.codex/skills/feature-breakdown/SKILL.md`:107-129] |
 | issue intake | Issue opened/edited/labeled | GitHub Action + agent | Issue body | issue template, governance | docs-to-issue/learning-to-issue | `issue-pr-governance.yml` | Checked issue | Issue labels/comments | section/source checks | label/status | maintenance | failed governance check | missing human input | [`.github/workflows/issue-pr-governance.yml`:3-78] |
 | issue validation | Before coding | Agent | Issue | `AGENT_OPERATING_PROTOCOL`, issue contract | issue-to-code | source-anchor validation | pass/block | labels/Project | all `Verify:` targets | source truth sufficient? | issue maintenance | `agent:blocked` or `needs-human` | authority unclear | [`.codex/skills/issue-to-code/SKILL.md`:19-72] |
-| readiness classification | Queue eligibility | Agent + GitHub state | labels/Project | label taxonomy, lifecycle matrix | issue-maintenance | Project ops | Ready/Backlog | labels/Project | `agent:ready` + Status=Ready | agent-ready? | drift repair | no pickup | named decision | [`.codex/skills/_shared/LABEL_TAXONOMY.md`:8-37], [`.codex/skills/_shared/LIFECYCLE_TRUTH_MATRIX.md`:13-40] |
+| readiness classification | Queue eligibility | Agent + GitHub state | labels | label taxonomy, issue contract | issue-maintenance | readiness validator | ready/non-active | labels | strictly valid `agent:ready` | agent-ready? | drift repair | no pickup | named decision | [`.codex/skills/_shared/LABEL_TAXONOMY.md`], [`.codex/skills/_shared/ISSUE_CONTRACT.md`] |
 | dispatcher / queue selection | Work pickup | Agent + dispatcher | Ready tasks | dispatcher contract | issue-to-code | `python -m app.dispatcher next/claim` | Lease/task | dispatcher DB + GitHub label | lease acquired | priority and fit | release/reclaim | fallback to GitHub-label-only | dispatcher unavailable plus unsafe fallback | [docs/AGENT_ISSUE_DISPATCHER.md:165-180] |
 | model routing | Before work | Agent | risk/TCD | `AGENTS.md` TCD | relevant skill | none | model/effort choice | session only | review outcome | under/over-model? | learning | escalate capability | >10 min human steering or repeated failures | [AGENTS.md:112-157] |
 | skill routing | Task start | Agent | task class | `AGENTS.md`, skills README | matching skill | none | loaded skill | none | skill instructions | narrowest skill | learning | wrong skill -> repair | unclear route | [AGENTS.md:18-68], [`.codex/skills/README.md`:64-128] |
@@ -190,15 +190,20 @@ flowchart TD
 
 Observed: the repo has an actual dispatcher implementation and a documented operational deployment. It is not merely a label convention. The dispatcher has SQLite task/lease/event storage, a CLI, GitHub pull-sync, queue/claim/heartbeat/complete commands, tests, and Makefile targets [docs/AGENT_ISSUE_DISPATCHER.md:21-36], [app/dispatcher/cli.py:31-32], [Makefile:356-361], [tests/dispatcher/test_agent_loop.py:1-30].
 
+Authority roles are intentionally split: GitHub Issues / PRs / CI are durable delivery truth;
+Dispatcher SQLite owns volatile queue, claim, lease, and heartbeat coordination; the external
+BuilderOps Vault owns durable BuilderOps Markdown artifacts but no SQLite or live claims; and
+GitHub Project plus Signboard remain rebuildable projection surfaces.
+
 Mechanism classification:
 
 | Mechanism | Classification | Current behavior | Evidence |
 | --- | --- | --- | --- |
-| how work becomes eligible | deterministic + agentic | Issue must be `agent:ready` and Status=Ready; issue must satisfy contract and `Verify:` targets | [`.codex/skills/issue-to-code/SKILL.md`:109-124], [docs/development/DEV_WORKFLOW.md:216-255] |
-| how work is queued | deterministic + partial | Dispatcher pull reads open `agent:ready` issues; GitHub Project Agent Queue also exists | [docs/AGENT_ISSUE_DISPATCHER.md:199-215], [`.github/github-governance.yml`:46-50] |
+| how work becomes eligible | deterministic + agentic | Issue must carry a strictly validated `agent:ready` label and satisfy its contract and `Verify:` targets; Project Status does not gate pickup | [`.codex/skills/issue-to-code/SKILL.md`], [docs/development/DEV_WORKFLOW.md] |
+| how work is queued | deterministic + partial | Dispatcher SQLite pulls open `agent:ready` issues and owns volatile queue/lease state; the external BuilderOps Vault stores durable artifacts | [docs/AGENT_ISSUE_DISPATCHER.md] |
 | how an agent selects an issue | agentic | Priority order plus engineering judgment; dispatcher `next` returns ready tasks but no full lane scheduler | [`.codex/skills/issue-to-code/SKILL.md`:109-124], [docs/AGENT_ISSUE_DISPATCHER.md:168-170] |
-| labels affect readiness | deterministic | `agent:ready` only with Status=Ready; `agent:blocked` and `needs-human` with Backlog | [`.codex/skills/_shared/LABEL_TAXONOMY.md`:8-37] |
-| Project status affects routing | deterministic + best-effort | Status=Ready qualifies pickup; Project is projection and may drift | [docs/development/GITHUB_GOVERNANCE_SETUP.md:52-87] |
+| labels affect readiness | deterministic | `agent:ready` is the external pickup qualifier after strict validation; `agent:blocked` and `needs-human` are non-active | [`.codex/skills/_shared/LABEL_TAXONOMY.md`] |
+| Project status affects routing | none | Project is an optional legacy projection and is not consulted by dispatcher sync or pickup | [docs/AGENT_ISSUE_DISPATCHER.md :: Source-of-Truth Boundaries] |
 | work is claimed | deterministic | Dispatcher lease then GitHub label removal; fallback GitHub-label-only | [`.codex/skills/issue-to-code/SKILL.md`:133-175] |
 | branch/worktree allocation | partially deterministic | Dedicated worktree required by policy; preflight detects shared root/drift; no central allocator | [AGENTS.md:171-182], [`.codex/skills/_shared/BRANCH_TRUTH_GATE.md`:9-77] |
 | model choice | agentic | TCD policy and adapter defaults; no deterministic router service | [AGENTS.md:112-157], [`.codex/agents/issue-set-coordinator.toml`:1-21] |
@@ -213,7 +218,7 @@ Mechanism classification:
 flowchart TD
   Issue["GitHub Issue"] --> Shape{"Contract + Verify valid?"}
   Shape -->|no| Repair["issue maintenance / docs repair"]
-  Shape -->|yes| Ready{"agent:ready + Status=Ready?"}
+  Shape -->|yes| Ready{"strictly valid agent:ready?"}
   Ready -->|no| Backlog["Backlog / blocked / needs-human"]
   Ready -->|yes| Pull["dispatcher pull"]
   Pull --> Queue["dispatcher ready queue"]
@@ -221,7 +226,7 @@ flowchart TD
   Next --> Preflight["workspace preflight"]
   Preflight -->|fail| Block["block/release"]
   Preflight -->|pass| Lease["claim lease TTL"]
-  Lease --> Label["remove agent:ready + Status In Progress"]
+  Lease --> Label["remove agent:ready"]
   Label --> Work["implementation"]
   Work --> Heartbeat["heartbeat while active"]
   Work --> PR["publish PR"]
@@ -242,7 +247,7 @@ stateDiagram-v2
   NeedsRepair --> IssueDrafted
   IssueDrafted --> NeedsHuman: authority/intent missing
   NeedsHuman --> IssueDrafted: decision supplied
-  IssueDrafted --> AgentReady: agent:ready + Status Ready
+  IssueDrafted --> AgentReady: strict validation + agent:ready
   AgentReady --> Claimed: dispatcher/GitHub claim
   Claimed --> InImplementation
   InImplementation --> PRPublished
@@ -358,7 +363,7 @@ stateDiagram-v2
 | Is source truth sufficient? | `DOCS_INDEX` + operating protocol | partial | yes | if unclear | source anchors/docs | proceed/repair | target-state treated as shipped | [docs/DOCS_INDEX.md:80-90], [docs/development/AGENT_OPERATING_PROTOCOL.md:73-83] |
 | Is this current-state or target-state? | doc role headers/index | partial | yes | if ambiguous | doc role | classification | false current claim | [docs/DOCS_INDEX.md:11-17], [docs/architecture/SBS_OPERATING_MODEL.md:28-34] |
 | Is an issue executable? | issue contract + `Verify:` | partial | yes | no | ACs/body | ready/repair | untestable AC | [`.codex/skills/_shared/ISSUE_CONTRACT.md`:53-72] |
-| Is issue agent-ready? | labels + Project status | yes | yes | no | labels/status | queue eligible | drift | [`.codex/skills/_shared/LIFECYCLE_TRUTH_MATRIX.md`:13-40] |
+| Is issue agent-ready? | strict issue validation + label | yes | yes | no | body/labels | queue eligible | malformed issue labeled ready | [`.codex/skills/_shared/ISSUE_CONTRACT.md`], [`.codex/skills/_shared/LABEL_TAXONOMY.md`] |
 | Product/Runtime, Builder, or boundary? | SBS classification | partial | yes | if unclear | touched surface | SBS impact | wrong authority | [docs/architecture/SBS_OPERATING_MODEL.md:95-118] |
 | Risk level? | TCD + PR hot path | partial | yes | no | lane/touched surface | low/normal/high | under-modeling | [AGENTS.md:142-157], [docs/development/PR_HOT_PATH.md:12-25] |
 | Docs-only/code/runtime/governance/release/Mimer/BuilderOps? | lane and skill routing | partial | yes | no | files/scope | lane | wrong lane | [docs/development/DEV_WORKFLOW.md:107-169], [`.codex/skills/README.md`:130-164] |
@@ -381,7 +386,7 @@ stateDiagram-v2
 flowchart TD
   MalformedIssue["Malformed issue"] --> Maintenance["issue-maintenance-change-control"]
   Maintenance --> RepairContract["repair sections / Verify / labels"]
-  RepairContract --> Ready["agent:ready + Status Ready"]
+  RepairContract --> Ready["strict validation + agent:ready"]
 ```
 
 Issue readiness repair loop: triggered by malformed issue, stale anchors, missing `Verify:`, or drift; actor is agent/maintenance skill; no max retry is defined; state is GitHub issue body/labels/Project; escalates to `agent:needs-human` when authority or input is missing [docs/development/AGENT_OPERATING_PROTOCOL.md:73-83], [`.codex/skills/README.md`:168-178].
@@ -658,7 +663,7 @@ flowchart TD
 
 ```mermaid
 flowchart TD
-  ReadyIssue["agent:ready + Status Ready"] --> PullSync["dispatcher pull"]
+  ReadyIssue["strictly valid agent:ready"] --> PullSync["dispatcher pull"]
   PullSync --> Queue["ready queue"]
   Queue --> Next["next eligible"]
   Next --> Preflight["worktree preflight"]

--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -192,7 +192,7 @@ State model for lane-based delivery:
 - Issue state supports claim and bounded execution truth: `Ready`, `In Progress`, `Blocked`, `Done`.
 - PR/Project-item state supports review/integration projection: `Review`, `In Progress`, `Blocked`, `Done`.
 - Keep issue and PR state separate in multi-slice lanes where several implementation issues can feed the same lane PR.
-- `issue-to-code` owns fast issue claim (`Ready` -> `In Progress` and remove `agent:ready`) to prevent double-pick.
+- `issue-to-code` owns fast issue claim (dispatcher lease when available; otherwise remove `agent:ready` and post a claimant receipt) to prevent double-pick.
   - Claim must run through `scripts/issue_pickup_claim.sh --issue <N>` so workspace preflight is enforced before label mutation.
 - Open PR is the default publication mode. Draft PR is opt-in and requires an explicit reason.
 - `Review` is the agent-review gate before verification, not a generic waiting state.
@@ -203,7 +203,7 @@ State model for lane-based delivery:
 Execution rule:
 
 - do not start non-trivial implementation without a governing Issue
-- prefer Issues with `Status=Ready` and label `agent:ready`
+- select Issues with a strictly validated `agent:ready` label; Project Status is not a pickup gate
 - use the linked Issue as the bounded source of truth for scope and acceptance
 - implementation PRs should usually link the governing slice / child issue
 - do not implement directly from a feature / capability issue when the work is clearly multi-slice
@@ -216,8 +216,8 @@ Optional repo-local Codex skills may assist with either lane from `.codex/skills
 Lifecycle truth rule:
 
 - GitHub Issue state and linked PR/merge state are the harder lifecycle authority.
-- Project `Status` is the preferred projection of that lifecycle for pickup and board visibility.
-- `agent:ready` qualifies an Issue for pickup only when `Status=Ready`.
+- Project `Status` is an optional legacy projection for board visibility.
+- `agent:ready` qualifies an Issue for pickup after strict contract validation; dispatcher claim state prevents active collisions when available.
 - `In Progress` covers active implementation, including draft PRs and open PRs before explicit review handoff.
 - `Review` begins only when the PR becomes the explicit review handoff artifact, normally after review is requested.
 - closed or delivered work must not retain `agent:*` labels.

--- a/docs/development/GITHUB_GOVERNANCE_SETUP.md
+++ b/docs/development/GITHUB_GOVERNANCE_SETUP.md
@@ -44,13 +44,13 @@ Status meanings:
 - `Done`: merged or otherwise fully delivered work; the Issue is closed and no `agent:*` labels remain
 
 Agent-label meanings:
-- `agent:ready`: queue-eligible work; use only with `Status=Ready`
+- `agent:ready`: strictly validated queue-eligible work; Project Status is not a pickup precondition
 - `agent:blocked`: blocked by dependency waiting, including parent validation hubs waiting on child slices; normally pair with a non-active status such as `Backlog`
 - `agent:needs-human`: blocked on a named human decision, tradeoff, missing input, or authority question; normally pair with a non-active status such as `Backlog`
 - open implementation Issues should normally carry exactly one truthful agent-state label
 
 Interpretation rule:
-- GitHub Project `Status` is the preferred operational projection of lifecycle state, not the hardest source of truth.
+- GitHub Project `Status` is an optional legacy projection of lifecycle state, not a pickup gate or source of truth.
 - GitHub Issue state, agent labels, linked PR state, and merge/delivery reality outrank Project state when they disagree.
 - Agent labels qualify pickup or blocker state; they do not replace Issue/PR lifecycle truth.
 
@@ -117,7 +117,7 @@ cleanup is not automatic in v1.
 - Docs-authoring PRs may omit an Issue reference only when they are explicitly classified as docs authoring and remain limited to approved docs-authoring surfaces.
 - Governance-lane PRs may omit an Issue reference only when they are explicitly classified as governance lane and remain limited to approved governance surfaces.
 - Agents only pick Issues labeled `agent:ready`.
-- Agents only pick Issues when `Status=Ready` and the Issue is labeled `agent:ready`.
+- Agents only pick strictly validated Issues labeled `agent:ready` and acquire the dispatcher claim when available.
 - Issue claim (`Ready` -> `In Progress` plus `agent:ready` removal) remains a synchronous skill action, not PR automation.
 - Agents must stay within Issue scope, constraints, and acceptance criteria.
 - Blank/free-form Issues are disabled at repo level.

--- a/docs/development/GOVERNANCE_PROPORTIONALITY.md
+++ b/docs/development/GOVERNANCE_PROPORTIONALITY.md
@@ -8,7 +8,7 @@ Temporal class: durable
 
 This repository is intentionally single-operator. Every gate, receipt, and report section is paid for twice: once by an agent burning context to produce it, once by one human reading it. The governing goal is cost-effectiveness — keep the safety properties (fail-closed promotion, truthful lifecycle state, delivery traceability) while cutting per-change overhead for low-risk work.
 
-Proportionality applies to *reporting and PR-body machinery*. It never applies to lifecycle truth: labels and Project Status must stay truthful at every tier — the board must never lie.
+Proportionality applies to *reporting and PR-body machinery*. It never applies to authoritative lifecycle truth: Issue labels, Issue/PR state, CI, and merge evidence must stay truthful at every tier. Project Status is optional projection repair.
 
 ## Risk tiers
 
@@ -23,7 +23,7 @@ Three tiers. When in doubt, classify up. A PR that mixes tiers takes the highest
 **Required machinery:**
 
 - lane classifier in the PR body (the checkbox above)
-- truthful lifecycle state (labels, Project Status) — mandatory at every tier
+- truthful authoritative lifecycle state (labels, Issue/PR state, CI) — mandatory at every tier
 - `## BuilderOps Routing` may be omitted entirely when nothing was routed: **absence means "none"**. A present-but-unfilled section (template placeholders) still fails CI — claiming the section means filling it.
 - output format: a short human summary (2–4 sentences) plus a receipt line; no multi-section report
 - validation: lightweight docs/governance checks appropriate to the touched surfaces; no full code/test smoke by default
@@ -48,7 +48,7 @@ Three tiers. When in doubt, classify up. A PR that mixes tiers takes the highest
 
 ## What proportionality never relaxes
 
-- Lifecycle truth: labels and Project Status stay accurate at every tier.
+- Lifecycle truth: labels and Issue/PR state stay accurate at every tier; Project projection repair is optional and cold-path.
 - The fail-closed release-channel promotion chain.
 - `Verify:` targets on issue-backed acceptance criteria.
 - Branch-truth gates at the publication boundary.

--- a/tests/dispatcher/test_sync_github.py
+++ b/tests/dispatcher/test_sync_github.py
@@ -168,6 +168,34 @@ def test_normalize_github_issue_string_labels() -> None:
     assert task.status == "ready"
 
 
+def test_agent_ready_issue_pickable_without_project_status(tmp_store: SqliteStore) -> None:
+    """ProjectV2 fields are neither required nor consulted for queue eligibility."""
+    payload = {
+        "number": 201,
+        "title": "Label-only ready task",
+        "state": "open",
+        "labels": [{"name": "agent:ready"}, {"name": "prio:high"}],
+        "createdAt": "2026-07-09T00:00:00Z",
+        "updatedAt": "2026-07-09T01:00:00Z",
+        "body": VALID_READY_BODY,
+    }
+
+    source = _mock_source([payload], open_issues=[payload])
+    adapter = PullSyncAdapter(store=tmp_store, source=source)
+
+    upserted = adapter.pull("RasmusTho/agentic-pkm-mvp")
+
+    assert [task.issue_number for task in upserted] == [201]
+    stored = tmp_store.get_task("github-issue-201")
+    assert stored is not None
+    assert stored.status == "ready"
+    assert {call[0] for call in source.method_calls} == {
+        "list_issues",
+        "list_open_issues",
+        "get_rate_limit",
+    }
+
+
 # ---------------------------------------------------------------------------
 # AC: Sync state records metadata
 # ---------------------------------------------------------------------------

--- a/tests/governance/test_project_pickup_deprecation.py
+++ b/tests/governance/test_project_pickup_deprecation.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(relative: str) -> str:
+    return (REPO_ROOT / relative).read_text(encoding="utf-8")
+
+
+def test_active_pickup_contract_is_label_only() -> None:
+    agents = _read("AGENTS.md")
+    issue_to_code = _read(".codex/skills/issue-to-code/SKILL.md")
+    deliver_issue_set = _read(".codex/skills/deliver-issue-set/SKILL.md")
+    dev_workflow = _read("docs/development/DEV_WORKFLOW.md")
+    labels = _read(".codex/skills/_shared/LABEL_TAXONOMY.md")
+
+    assert "strictly valid `agent:ready`" in agents
+    assert "without requiring GitHub Project Status" in agents
+    assert "Work only from GitHub Issues labeled `agent:ready`" in issue_to_code
+    assert "Project Status is not a pickup precondition" in issue_to_code
+    assert "Project Status is not a dispatch precondition" in deliver_issue_set
+    assert "Project Status is not a pickup gate" in dev_workflow
+    assert "without requiring Project Status" in labels
+    assert "label removal + claimant receipt" in issue_to_code
+
+    canonical_pickup_contracts = (
+        agents,
+        issue_to_code,
+        deliver_issue_set,
+        dev_workflow,
+        _read(".codex/skills/README.md"),
+        _read("docs/development/BUILDER_SYSTEM_PROCESS_MAP.md"),
+    )
+    forbidden_gates = (
+        "Issue -> Project -> Agent",
+        "both `Status=Ready` and labeled `agent:ready`",
+        "`agent:ready` + Status=Ready",
+        "Status=Ready qualifies pickup",
+    )
+    for contract in canonical_pickup_contracts:
+        for phrase in forbidden_gates:
+            assert phrase not in contract
+
+
+def test_ready_producers_do_not_require_project_status() -> None:
+    producers = (
+        _read(".codex/skills/docs-to-issue/SKILL.md"),
+        _read(".codex/skills/feature-breakdown/SKILL.md"),
+        _read(".codex/skills/learning-to-issue/SKILL.md"),
+        _read(".codex/skills/bug-to-issue/SKILL.md"),
+        _read(".codex/skills/issue-maintenance-change-control/SKILL.md"),
+    )
+
+    for contract in producers:
+        assert "Use `agent:ready` only with `Status=Ready`" not in contract
+        assert "can label as `agent:ready` with `Status=Ready` only" not in contract
+        assert "project" in contract.lower()
+        assert "optional" in contract.lower()
+
+
+def test_builderops_authority_roles_are_explicit() -> None:
+    dispatcher = _read("docs/AGENT_ISSUE_DISPATCHER.md")
+    architecture = _read("docs/ARCHITECTURE.md")
+    process_map = _read("docs/development/BUILDER_SYSTEM_PROCESS_MAP.md")
+
+    for text in (dispatcher, architecture, process_map):
+        assert "GitHub Issues / PRs / CI" in text
+        assert "Dispatcher SQLite" in text
+        assert "external BuilderOps Vault" in text
+        assert "Project" in text
+        assert "projection" in text
+    assert "GitHub Project v2 is the delivery state machine" not in architecture
+    assert "Status=Ready qualifies pickup" not in process_map
+    assert "labels, Project states, `Verify:` markers" not in process_map
+    assert "labels, Project status, skill routing" not in process_map
+
+
+def test_external_vault_excludes_volatile_coordination_state() -> None:
+    contract = _read(
+        "docs/BUILDEROPS_MODEL_INQUIRY/EXTERNAL_BUILDEROPS_VAULT_CONFIGURATION.md"
+    )
+
+    assert "shared Markdown artifacts" in contract
+    assert "local-only claims root" in contract
+    assert "without creating SQLite files or live leases inside it" in contract

--- a/tests/ops/test_builderops_project_reconciliation.py
+++ b/tests/ops/test_builderops_project_reconciliation.py
@@ -8,7 +8,7 @@ from app.dispatcher import cli as dispatcher_cli
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
-def test_project_reconciliation_is_separate_from_dispatcher_claim_path() -> None:
+def test_project_reconciliation_is_not_pickup_gate() -> None:
     hook = REPO_ROOT / "scripts" / "reconcile_builderops_project_status.sh"
     hook_text = hook.read_text(encoding="utf-8")
     dispatcher_text = (REPO_ROOT / "app" / "dispatcher" / "cli.py").read_text(encoding="utf-8")


### PR DESCRIPTION
## Change Lane
- [ ] Implementation lane
- [ ] Docs authoring lane
- [x] Governance lane

## Linked Issue
Fixes #3294

## SBS Impact
- Primary subsystem: Builder System
- Secondary subsystem(s): dispatcher, issue lifecycle, BuilderOps Vault
- Write class: governance/tooling
- Authority impact: `agent:ready` plus strict validation becomes the external pickup qualifier; ProjectV2 is optional projection
- Persistence impact: dispatcher SQLite remains volatile coordination; the external BuilderOps Vault remains durable artifact storage
- Derived/rebuildable impact: GitHub Project and Signboard remain projections
- Human knowledge impact: removes routine Project repair from agent pickup
- Memory impact: unaffected
- Retrieval/context impact: reduces pickup context and GraphQL dependency
- Sync/deployment impact: no Product/Runtime deployment change
- External boundary impact: removes ProjectV2/GraphQL from readiness, intake, and pickup hot paths
- New or changed contract: label-only pickup with dispatcher claim; claim-comment fallback when dispatcher is unavailable
- Owner-doc impact: owner docs updated in this PR
- Transition debt impact: reduces D12 workflow inconsistency and Project hot-path debt
- Fitness rule impact: adds focused governance and dispatcher regression tests
- Boundary risk: low; Builder System governance only

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Removes GitHub Project Status as an agent readiness/pickup prerequisite across canonical skills and issue producers.
- Makes the source-of-truth split explicit: GitHub Issues/PRs/CI for delivery truth, dispatcher SQLite for volatile coordination, external BuilderOps Vault for durable artifacts, and Project/Signboard for projections.
- Defines a durable claimant comment for the dispatcher-unavailable fallback and preserves cold-path Project repair.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [x] This PR only changes approved governance surfaces.
- [x] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [x] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [x] `ruff check app tests`
- [x] If files under `app/` or `tests/` changed, lint output from `ruff check app tests` is included below or a tooling limitation is stated.
- [ ] `mypy app`
- [ ] `pytest -q -m "not pg"`
- [x] Additional targeted checks run as needed

Docs authoring lane:
- [x] Docs/governance checks run as appropriate for the touched surfaces
- [x] Any validation gaps or tooling limitations are stated explicitly

Governance lane:
- [x] Governance checks run as appropriate for the touched surfaces
- [x] Any validation gaps or tooling limitations are stated explicitly

Validation run:
- `pytest -q tests/dispatcher/test_sync_github.py tests/ops/test_builderops_project_reconciliation.py tests/governance/test_project_pickup_deprecation.py` — 42 passed
- `pytest -q tests/governance tests/architecture --maxfail=1` — 174 passed, 2 third-party deprecation warnings
- `ruff check app tests` — passed
- `python3 scripts/docs_guard.py` — passed
- `python3 scripts/lint_skills_consistency.py` — passed
- `git diff --check` — passed

Validation gaps:
- Full non-Postgres suite and mypy were not run because this is a governance-only contract change with no product/runtime module changes.

## BuilderOps Routing
- Records/projections/receipts: GitHub issue #3294 claim receipt and independent review receipts
- Reason: the divergence was promoted directly into the governing Issue contract and this PR; no additional BuilderOps record is needed.

## Notes
- Independent review completed clean after two repair rounds.
- Residual risk: label-only fallback uses label removal then a claim-comment write; a crash between them can leave ownerless claimed state. Dispatcher-backed claims remain the normal path.
