### PR TITLE
Fix ADR-0059 retrieval review residuals

### DIFF
--- a/app/eval/golden.py
+++ b/app/eval/golden.py
@@ -61,6 +61,7 @@ def _snapshot_store(store) -> List[dict]:
             "language": doc.language,
             "source_ref": doc.source_ref,
             "payload": doc.payload,
+            "embedding": doc.embedding,
         }
         for doc in store.all()
     ]

--- a/app/fitness/metrics.py
+++ b/app/fitness/metrics.py
@@ -32,6 +32,7 @@ def _snapshot_store(store: MemoryHybridStore) -> List[dict]:
             "language": doc.language,
             "source_ref": doc.source_ref,
             "payload": doc.payload,
+            "embedding": doc.embedding,
         }
         for doc in store.all()
     ]

--- a/app/retrieval/hook_adapter.py
+++ b/app/retrieval/hook_adapter.py
@@ -36,6 +36,17 @@ def _bm25_dominance_margin(query: str, items: List[Dict[str, Any]]) -> float | N
     min_v = float(np.min(raw))
     max_v = float(np.max(raw))
     if math.isclose(max_v - min_v, 0.0):
+        # Rank-BM25's IDF can collapse to zero for a two-result window even
+        # when one result uniquely contains every query term. Preserve the
+        # same deterministic lexical intent with a bounded coverage fallback;
+        # absent a coverage gap this remains a genuine non-dominant tie.
+        if len(items) == 2:
+            query_terms = set(query_tokens)
+            coverage = np.asarray(
+                [len(query_terms & set(tokens)) / len(query_terms) for tokens in tokenized_docs],
+                dtype=np.float32,
+            )
+            return float(abs(coverage[0] - coverage[1]))
         # Every candidate scores identically -> no dominant top result.
         return 0.0
     norm = (raw - min_v) / (max_v - min_v)

--- a/app/retrieval/hybrid.py
+++ b/app/retrieval/hybrid.py
@@ -352,7 +352,8 @@ def rebuild_from_durable_index(*, force: bool = False) -> int:
     first time scores are computed (fail-safe, logged, never a crash).
 
     ADR-0059 step 3 (mixed-identity observability, #3406): each row's
-    recorded ``provider``/``model`` is compared against the active primary
+    recorded full embedding identity (``provider``, ``model``, ``dim``, and
+    ``normalize``) is compared against the active primary
     embedding identity (resolved the same way the write path resolves its
     default — ``get_embedding_identity()``, see ``app/stores/pg.py``). Rows
     that diverge are CTI-2 reconcilable fallback writes; they are counted
@@ -376,16 +377,23 @@ def rebuild_from_durable_index(*, force: bool = False) -> int:
     docs: list[dict] = []
     missing_embeddings = 0
     mixed_identity_count = 0
-    mixed_identity_tuples: set[tuple[Any, Any]] = set()
+    mixed_identity_tuples: set[tuple[Any, Any, Any, Any]] = set()
     for row in index.all_rows():
-        row_provider = row.get("provider")
-        row_model = row.get("model")
-        if (row_provider or row_model) and (row_provider, row_model) != (
+        row_identity = (
+            row.get("provider"),
+            row.get("model"),
+            row.get("dim"),
+            row.get("normalize"),
+        )
+        active_identity_tuple = (
             active_identity.provider,
             active_identity.model,
-        ):
+            active_identity.dim,
+            active_identity.normalize,
+        )
+        if any(value is not None for value in row_identity) and row_identity != active_identity_tuple:
             mixed_identity_count += 1
-            mixed_identity_tuples.add((row_provider, row_model))
+            mixed_identity_tuples.add(row_identity)
         payload = row.get("payload") or {}
         text = _row_text(payload)
         if not text:
@@ -613,13 +621,18 @@ def _weighted_rrf_combined(
     """
     weights = tuning.rrf_signal_weights
     rrf_k = tuning.rrf_k
-    bm25_rank = _rrf_ranks(bm25_raw)
-    emb_rank = _rrf_ranks(emb_raw)
-    overlap_rank = _rrf_ranks(overlap_bonus)
+    def _contribution(raw_scores: np.ndarray, weight: float) -> np.ndarray:
+        # An all-zero list is absence of signal, not a tied ranking. Assigning
+        # sequential ranks would inject store order into RRF and can outweigh
+        # actual dense evidence (#3432).
+        if not np.any(np.asarray(raw_scores, dtype=np.float32)):
+            return np.zeros(len(raw_scores), dtype=np.float32)
+        return weight / (rrf_k + _rrf_ranks(raw_scores))
+
     rrf_scores = (
-        weights.lexical / (rrf_k + bm25_rank)
-        + weights.dense / (rrf_k + emb_rank)
-        + _RRF_OVERLAP_WEIGHT / (rrf_k + overlap_rank)
+        _contribution(bm25_raw, weights.lexical)
+        + _contribution(emb_raw, weights.dense)
+        + _contribution(overlap_bonus, _RRF_OVERLAP_WEIGHT)
     ).astype(np.float32)
     return _normalize(rrf_scores)
 

--- a/app/retrieval/tuning.py
+++ b/app/retrieval/tuning.py
@@ -65,10 +65,10 @@ def reset_retrieval_tuning_cache() -> None:
 
 
 def _base_tuning() -> RetrievalTuning:
-    try:
-        return get_settings_bundle().retrieval_tuning
-    except Exception:
-        return RetrievalTuning()
+    # The runtime settings bundle is the authoritative typed configuration
+    # surface. Do not downgrade a malformed runtime file to defaults here:
+    # callers of the actual retrieval resolver must fail just as startup does.
+    return get_settings_bundle().retrieval_tuning
 
 
 def _parse_int(raw: str, *, env_key: str) -> int:

--- a/app/settings/runtime.py
+++ b/app/settings/runtime.py
@@ -49,12 +49,32 @@ def _read_yaml(path: Path) -> Dict[str, Any]:
     return data
 
 
+def _read_typed_mapping_yaml(path: Path, *, setting_name: str) -> Dict[str, Any]:
+    """Load a mapping-backed typed settings file without shape fallback.
+
+    A present file with a list/scalar is malformed configuration, not an empty
+    override.  Retrieval tuning uses this stricter boundary because ranking
+    strategy defaults must never be selected by silently discarding operator
+    input (#3432).
+    """
+    if not path.exists():
+        return {}
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise ValueError(f"{setting_name} must be a YAML mapping")
+    return data
+
+
 def _build_bundle() -> SettingsBundle:
     global_yaml = _read_yaml(RUNTIME / "global.yaml")
     providers_yaml = _read_yaml(RUNTIME / "providers.yaml")
     llm_routing_yaml = _read_yaml(RUNTIME / "llm_routing.yaml")
     embeddings_yaml = _read_yaml(RUNTIME / "embeddings.yaml")
-    retrieval_tuning_yaml = _read_yaml(RUNTIME / "retrieval_tuning.yaml")
+    retrieval_tuning_yaml = _read_typed_mapping_yaml(
+        RUNTIME / "retrieval_tuning.yaml", setting_name="retrieval_tuning.yaml"
+    )
     instance_yaml = _read_yaml(RUNTIME / "instance.yaml")
     yggdrasil_yaml = _read_yaml(RUNTIME / "yggdrasil.yaml")
     agents_dir = RUNTIME / "agents"

--- a/app/settings/runtime.py
+++ b/app/settings/runtime.py
@@ -74,12 +74,10 @@ def _build_bundle() -> SettingsBundle:
             embedding_profiles = EmbeddingProfiles(**embeddings_yaml)
         except Exception:
             embedding_profiles = EmbeddingProfiles()
-    retrieval_tuning = RetrievalTuning()
-    if retrieval_tuning_yaml:
-        try:
-            retrieval_tuning = RetrievalTuning(**retrieval_tuning_yaml)
-        except Exception:
-            retrieval_tuning = RetrievalTuning()
+    # Retrieval ranking configuration is typed runtime authority.  Unlike
+    # optional legacy settings, invalid values must stop startup rather than
+    # silently serving the default ranking strategy (#3432).
+    retrieval_tuning = RetrievalTuning(**retrieval_tuning_yaml)
     yggdrasil_paths = None
     if yggdrasil_yaml:
         try:

--- a/app/stores/memory.py
+++ b/app/stores/memory.py
@@ -249,6 +249,8 @@ class MemoryVectorIndex(VectorIndex):
                 "embedding": list(entry.embedding or []),
                 "model": entry.model,
                 "provider": entry.identity.provider if entry.identity else None,
+                "dim": entry.identity.dim if entry.identity else None,
+                "normalize": entry.identity.normalize if entry.identity else None,
             }
             for entry in sorted(self._entries.values(), key=lambda e: e.seq)
         ]

--- a/app/stores/pg.py
+++ b/app/stores/pg.py
@@ -691,7 +691,7 @@ class PgVectorIndex(VectorIndex):
             with conn.cursor() as cur:
                 cur.execute(
                     """
-                    SELECT object_id, kind, source_ref, payload, embedding, model, provider
+                    SELECT object_id, kind, source_ref, payload, embedding, model, provider, dim, normalize
                     FROM store_vector_index
                     ORDER BY updated_at
                     """
@@ -706,6 +706,8 @@ class PgVectorIndex(VectorIndex):
                 "embedding": coerce_floats(row["embedding"] or []),
                 "model": row["model"],
                 "provider": row["provider"],
+                "dim": row["dim"],
+                "normalize": row["normalize"],
             }
             for row in rows
         ]

--- a/tests/retrieval/test_conditional_rerank.py
+++ b/tests/retrieval/test_conditional_rerank.py
@@ -112,3 +112,24 @@ def test_containment_enforced_when_conditional_rerank_runs(monkeypatch: pytest.M
     )
     with pytest.raises(AssertionError, match="rerank introduced doc_ids"):
         scoped_hybrid_search("alpha beta gamma", k=5)
+
+
+def test_conditional_gate_two_result_unique_match_does_not_collapse(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rank-BM25 has a zero-IDF degeneracy on a two-document candidate set;
+    the exact lexical result must still be protected from reranking."""
+    monkeypatch.setenv("RETRIEVAL_RERANK", "conditional")
+    reset_retrieval_tuning_cache()
+    calls: list[list[dict]] = []
+    monkeypatch.setattr(
+        "app.retrieval.hook_adapter.apply_optional_rerank",
+        lambda _query, items: calls.append(list(items)) or list(reversed(items)),
+    )
+    items = [
+        {"id": "exact", "text": "alpha beta exact document", "score": 0.9},
+        {"id": "other", "text": "unrelated gardening note", "score": 0.5},
+    ]
+
+    assert maybe_rerank("alpha beta", items) == items
+    assert calls == []

--- a/tests/retrieval/test_hybrid_stored_vectors.py
+++ b/tests/retrieval/test_hybrid_stored_vectors.py
@@ -21,6 +21,8 @@ import pytest
 
 from app.components.retrieval import embed_docs
 from app.retrieval import hybrid
+from app.eval import golden
+from app.fitness import metrics
 from app.stores import get_vector_index, reset_store_backends
 
 _SEED_TEXTS = [
@@ -200,3 +202,26 @@ def test_dim_mismatched_preloaded_vector_fails_loud() -> None:
     )
     with pytest.raises(ValueError, match="embedding dim mismatch"):
         store.bm25_scores(["alpha"])
+
+
+def test_snapshot_restore_preserves_cached_embeddings() -> None:
+    """Eval/fitness corpus swaps must not turn a warm stored-vector cache into
+    a lazy-embedding corpus when restoring it."""
+    store = hybrid.get_store()
+    docs = [
+        {
+            "doc_id": "stored-vector",
+            "text": "cached vector survives eval fixture replacement",
+            "embedding": [0.25, 0.5, 0.75],
+        }
+    ]
+    store.set_documents(docs)
+
+    golden_snapshot = golden._snapshot_store(store)  # noqa: SLF001 - regression seam
+    fitness_snapshot = metrics._snapshot_store(store)  # noqa: SLF001 - regression seam
+    store.set_documents([])
+    golden._restore_store(store, golden_snapshot)  # noqa: SLF001 - regression seam
+    assert store.all()[0].embedding == [0.25, 0.5, 0.75]
+    store.set_documents([])
+    metrics._restore_store(store, fitness_snapshot)  # noqa: SLF001 - regression seam
+    assert store.all()[0].embedding == [0.25, 0.5, 0.75]

--- a/tests/retrieval/test_mixed_identity_observability.py
+++ b/tests/retrieval/test_mixed_identity_observability.py
@@ -140,3 +140,28 @@ def test_active_primary_identity_resolution_matches_write_path() -> None:
     identity = get_embedding_identity()
     assert identity.provider
     assert identity.model
+
+
+def test_mixed_identity_count_uses_full_identity_tuple(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Same provider/model but changed dimension or normalization is still
+    an identity drift and must be counted in rebuild observability."""
+    _seed_durable_index()
+    idx = get_vector_index()
+    real_all_rows = idx.all_rows
+    active = get_embedding_identity()
+
+    def _patched_all_rows():
+        rows = real_all_rows()
+        rows[0].update({"provider": active.provider, "model": active.model, "dim": active.dim + 1, "normalize": active.normalize})
+        rows[1].update({"provider": active.provider, "model": active.model, "dim": active.dim, "normalize": not active.normalize})
+        return rows
+
+    monkeypatch.setattr(idx, "all_rows", _patched_all_rows)
+    caplog.set_level(logging.INFO, logger="app.retrieval.hybrid")
+    hybrid.rebuild_from_durable_index(force=True)
+    message = next(r.getMessage() for r in caplog.records if "mixed_identity_count" in r.getMessage())
+    assert "mixed_identity_count=2" in message
+    assert str(active.dim + 1) in message
+    assert str(not active.normalize) in message

--- a/tests/retrieval/test_retrieval_tuning_config.py
+++ b/tests/retrieval/test_retrieval_tuning_config.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import math
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -30,6 +31,7 @@ from app.retrieval.tuning import (
     get_retrieval_tuning,
     reset_retrieval_tuning_cache,
 )
+from app.settings import runtime
 
 pytestmark = pytest.mark.not_pg
 
@@ -230,3 +232,21 @@ def test_reserved_strategies_resolve_and_stay_non_default(monkeypatch: pytest.Mo
     tuning = get_retrieval_tuning()
     assert tuning.fusion == "linear"
     assert tuning.rerank == "off"
+
+
+def test_invalid_runtime_tuning_yaml_fails_loud(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A typed runtime file is configuration authority, not an optional hint.
+
+    This proves the startup path itself rejects invalid YAML instead of quietly
+    constructing default retrieval tuning and serving an unintended strategy.
+    """
+    runtime_root = tmp_path / "runtime"
+    runtime_root.mkdir()
+    (runtime_root / "retrieval_tuning.yaml").write_text("fusion: not-a-strategy\n", encoding="utf-8")
+    monkeypatch.setattr(runtime, "RUNTIME", runtime_root)
+    monkeypatch.setattr(runtime, "_CURRENT", None)
+
+    with pytest.raises(Exception, match="fusion"):
+        runtime.get_settings_bundle()

--- a/tests/retrieval/test_retrieval_tuning_config.py
+++ b/tests/retrieval/test_retrieval_tuning_config.py
@@ -234,8 +234,15 @@ def test_reserved_strategies_resolve_and_stay_non_default(monkeypatch: pytest.Mo
     assert tuning.rerank == "off"
 
 
+@pytest.mark.parametrize(
+    "raw_yaml",
+    [
+        "fusion: not-a-strategy\n",
+        "- rrf\n",
+    ],
+)
 def test_invalid_runtime_tuning_yaml_fails_loud(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, raw_yaml: str
 ) -> None:
     """A typed runtime file is configuration authority, not an optional hint.
 
@@ -244,7 +251,7 @@ def test_invalid_runtime_tuning_yaml_fails_loud(
     """
     runtime_root = tmp_path / "runtime"
     runtime_root.mkdir()
-    (runtime_root / "retrieval_tuning.yaml").write_text("fusion: not-a-strategy\n", encoding="utf-8")
+    (runtime_root / "retrieval_tuning.yaml").write_text(raw_yaml, encoding="utf-8")
     monkeypatch.setattr(runtime, "RUNTIME", runtime_root)
     monkeypatch.setattr(runtime, "_CURRENT", None)
 
@@ -252,5 +259,5 @@ def test_invalid_runtime_tuning_yaml_fails_loud(
     # constructor: a resolver-level fallback would otherwise still serve
     # defaults despite the invalid typed YAML.
     reset_retrieval_tuning_cache()
-    with pytest.raises(Exception, match="fusion"):
+    with pytest.raises(Exception):
         get_retrieval_tuning()

--- a/tests/retrieval/test_retrieval_tuning_config.py
+++ b/tests/retrieval/test_retrieval_tuning_config.py
@@ -248,5 +248,9 @@ def test_invalid_runtime_tuning_yaml_fails_loud(
     monkeypatch.setattr(runtime, "RUNTIME", runtime_root)
     monkeypatch.setattr(runtime, "_CURRENT", None)
 
+    # Exercise the retrieval hot-path resolver rather than only the bundle
+    # constructor: a resolver-level fallback would otherwise still serve
+    # defaults despite the invalid typed YAML.
+    reset_retrieval_tuning_cache()
     with pytest.raises(Exception, match="fusion"):
-        runtime.get_settings_bundle()
+        get_retrieval_tuning()

--- a/tests/retrieval/test_rrf_fusion.py
+++ b/tests/retrieval/test_rrf_fusion.py
@@ -151,3 +151,22 @@ def test_rrf_top1_in_every_signal_wins_by_construction() -> None:
 
     combined = hybrid._weighted_rrf_combined(bm25, emb, overlap, _Tuning())  # noqa: SLF001
     assert int(np.argmax(combined)) == 0
+
+
+def test_rrf_no_signal_lists_do_not_inject_store_order() -> None:
+    """All-zero lexical/overlap lists carry no rank evidence, so their tied
+    store order must not outweigh the dense signal."""
+    bm25 = np.zeros(2, dtype=np.float32)
+    overlap = np.zeros(2, dtype=np.float32)
+    emb = np.array([0.1, 0.9], dtype=np.float32)
+
+    class _Weights:
+        lexical = 1.0
+        dense = 0.8
+
+    class _Tuning:
+        rrf_signal_weights = _Weights()
+        rrf_k = 60
+
+    combined = hybrid._weighted_rrf_combined(bm25, emb, overlap, _Tuning())  # noqa: SLF001
+    assert int(np.argmax(combined)) == 1


### PR DESCRIPTION
Fixes #3432

## Summary
- Make invalid typed retrieval tuning YAML fail at settings load and the actual retrieval resolver, including malformed non-mapping YAML; preserve cached embeddings through eval/fitness snapshots; carry full embedding identity through rebuild observability.
- Prevent no-signal RRF lists from injecting store order and retain the conditional lexical protection for two-result exact-match searches.

## Fail-loud proof
The original five AC regression proofs failed before their fixes and pass after them. Two review repairs further closed fail-open paths in the actual resolver:
- With the old resolver catch-all fallback restored, invalid mapping YAML made `get_retrieval_tuning()` serve defaults; it now raises.
- With the previous generic YAML loader, a present list (`- rrf`) was coerced to `{}` and the resolver served defaults; the new retrieval-specific mapping loader rejects it. Both mapping and raw-shape cases pass through the real resolver.

## Validation
- PASS: `pytest -q tests/retrieval/test_retrieval_tuning_config.py tests/retrieval/test_hybrid_stored_vectors.py tests/retrieval/test_rrf_fusion.py tests/retrieval/test_conditional_rerank.py tests/retrieval/test_mixed_identity_observability.py` (26 passed)
- PASS: `ruff check app tests`
- BLOCKED by unrelated baseline/environment: `pytest -q -m "not pg"` (7699 passed; 7 unrelated failures: missing cryptography/click, optional Whisper, and existing browse expectation)
- BLOCKED by environment: `RUN_INTEGRATED_RUNTIME_UAT=1 pytest -q -m uat_integrated_runtime` (11 passed; Docker executable absent for the container-only receipt test)
- `mypy app` remains the existing unrelated 22-error baseline (#3306).

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: the governing issue and coordinator claim receipt already carry the bounded delivery state; no new BuilderOps operational material was produced.