### PR TITLE
Add fail-loud Signboard validation lint

### DIFF
--- a/app/dispatcher/cli.py
+++ b/app/dispatcher/cli.py
@@ -36,7 +36,7 @@ from app.dispatcher.sync_github import (
 REQUIRED_COMMANDS = frozenset([
     "init", "queue", "next", "show", "claim",
     "heartbeat", "release", "update", "move", "block", "complete", "events", "pull",
-    "export-signboard",
+    "export-signboard", "signboard-validate",
 ])
 
 
@@ -413,6 +413,31 @@ def _cmd_export_signboard(args: argparse.Namespace, store: SqliteStore) -> int:
     return 0
 
 
+def _cmd_signboard_validate(args: argparse.Namespace, store: SqliteStore) -> int:
+    from pathlib import Path
+
+    from app.dispatcher.signboard import (
+        NoActiveVaultError,
+        default_signboard_root,
+        validate_signboard,
+    )
+
+    if args.path:
+        target_path = Path(args.path)
+    else:
+        try:
+            target_path = default_signboard_root()
+        except NoActiveVaultError as exc:
+            return _emit_error(str(exc), args.json)
+
+    result = validate_signboard(store, target_path)
+    if result["findings"]:
+        _emit_payload({"ok": False, **result}, args.json, 1)
+        return 1
+    _emit({"ok": True, **result}, args.json)
+    return 0
+
+
 # ---------------------------------------------------------------------------
 # Parser
 # ---------------------------------------------------------------------------
@@ -435,6 +460,7 @@ _COMMAND_MAP = {
     "status": _cmd_status,
     "pull": _cmd_pull,
     "export-signboard": _cmd_export_signboard,
+    "signboard-validate": _cmd_signboard_validate,
 }
 
 
@@ -540,6 +566,21 @@ def build_parser() -> argparse.ArgumentParser:
             "Directory to write kanban columns into. Optional: defaults to "
             "BuilderOpsVault/agent-delivery inside the active vault "
             "(active-vault-selection mechanism); no path needs to be typed."
+        ),
+    )
+    p.add_argument("--json", action="store_true")
+
+    p = sub.add_parser(
+        "signboard-validate",
+        help="Validate generated Signboard cards without changing the board or dispatcher store",
+    )
+    p.add_argument(
+        "path",
+        nargs="?",
+        default=None,
+        help=(
+            "Directory containing Signboard columns. Optional: defaults to "
+            "BuilderOpsVault/agent-delivery inside the active vault."
         ),
     )
     p.add_argument("--json", action="store_true")

--- a/app/dispatcher/signboard.py
+++ b/app/dispatcher/signboard.py
@@ -10,6 +10,8 @@ import re
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 from app.dispatcher.models import TaskRecord
 from app.dispatcher.store import SqliteStore
 from app.vault.manager import get_vault_manager
@@ -24,6 +26,7 @@ DEFAULT_SIGNBOARD_SUBPATH = Path("BuilderOpsVault") / "agent-delivery"
 
 _NOTES_HEADING = "## Notes"
 _RECEIPTS_HEADING = "## Receipts"
+_GENERATED_FILENAME_RE = re.compile(r".+--.+\.md$")
 
 
 class NoActiveVaultError(RuntimeError):
@@ -139,6 +142,120 @@ def export_signboard(store: SqliteStore, board_root: Path) -> dict[str, Any]:
         "columns": sorted(set(STATUS_COLUMNS.values())),
         "written": written,
     }
+
+
+def validate_signboard(store: SqliteStore, board_root: Path) -> dict[str, Any]:
+    """Return read-only findings for generated Signboard cards.
+
+    Signboard is a derived projection. This intentionally never repairs cards
+    or updates the dispatcher store; ``export-signboard`` remains the repair
+    operation after a failing validation run.
+    """
+    root = Path(board_root).expanduser()
+    tasks = {
+        task.task_id: task
+        for task in store.list_tasks()
+        if task.status != "_meta"
+    }
+    findings: list[dict[str, str]] = []
+    cards_by_task: dict[str, list[str]] = {}
+
+    for path in sorted(root.rglob("*.md")) if root.is_dir() else []:
+        relative_path = str(path.relative_to(root))
+        text = _read_card_text(path)
+        if text is None:
+            if _GENERATED_FILENAME_RE.fullmatch(path.name):
+                findings.append({
+                    "kind": "unreadable_generated_card_candidate",
+                    "path": relative_path,
+                    "detail": "generated filename candidate could not be read",
+                })
+            continue
+        if not _is_generated_card_text(text):
+            continue
+
+        frontmatter = _parse_generated_frontmatter(text)
+        if frontmatter is None:
+            findings.append({
+                "kind": "malformed_generated_card",
+                "path": relative_path,
+                "detail": "generated card frontmatter is missing or invalid",
+            })
+            continue
+
+        task_id = frontmatter["id"]
+        status = frontmatter["status"]
+        expected_column = column_for_status(status)
+        actual_column = path.parent.name
+        cards_by_task.setdefault(task_id, []).append(relative_path)
+        if actual_column != expected_column or frontmatter["column"] != expected_column:
+            findings.append({
+                "kind": "column_status_mismatch",
+                "path": relative_path,
+                "detail": (
+                    f"status {status!r} belongs in {expected_column!r}; "
+                    f"card column is {actual_column!r} and frontmatter column is "
+                    f"{frontmatter['column']!r}"
+                ),
+            })
+
+        task = tasks.get(task_id)
+        if task is None:
+            findings.append({
+                "kind": "stale_card",
+                "path": relative_path,
+                "detail": f"task {task_id!r} is absent from the dispatcher store",
+            })
+        elif actual_column != column_for_status(task.status):
+            findings.append({
+                "kind": "stale_card",
+                "path": relative_path,
+                "detail": (
+                    f"task {task_id!r} now belongs in "
+                    f"{column_for_status(task.status)!r}"
+                ),
+            })
+
+    for task_id, paths in cards_by_task.items():
+        if len(paths) > 1:
+            findings.append({
+                "kind": "duplicate_card",
+                "path": ", ".join(paths),
+                "detail": f"task {task_id!r} has {len(paths)} generated cards",
+            })
+
+    return {"root": str(root), "count": len(tasks), "findings": findings}
+
+
+def _parse_generated_frontmatter(text: str) -> dict[str, str] | None:
+    """Parse the minimal generated-card schema without accepting loose YAML."""
+    if not text.startswith("---\n"):
+        return None
+    try:
+        _, raw_frontmatter, _ = text.split("---\n", 2)
+        data = yaml.safe_load(raw_frontmatter)
+    except (ValueError, yaml.YAMLError):
+        return None
+    if not isinstance(data, dict):
+        return None
+
+    task_id = data.get("id")
+    issue_number = data.get("issue_number")
+    status = data.get("status")
+    column = data.get("column")
+    if not isinstance(task_id, str) or not task_id.strip():
+        return None
+    if not isinstance(issue_number, int) or isinstance(issue_number, bool):
+        return None
+    if not isinstance(status, str) or not status.strip():
+        return None
+    if not isinstance(column, str) or not column.strip():
+        return None
+    try:
+        canonical = canonical_status(status)
+    except ValueError:
+        return None
+    return {"id": task_id, "status": canonical, "column": column}
 
 
 def _task_filename(task: TaskRecord) -> str:

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -427,6 +427,13 @@ python -m app.dispatcher export-signboard --json
 The generated Markdown frontmatter is projection state only. Do not patch generated Signboard cards
 as the source of a claim, heartbeat, or lifecycle transition.
 
+Run `python -m app.dispatcher signboard-validate [path] --json` to lint the generated board without
+changing either the board or dispatcher store. As with `export-signboard`, the path is optional and
+defaults to the active vault's `BuilderOpsVault/agent-delivery` root. Validation exits nonzero for
+malformed generated cards, duplicate generated cards, column/status drift, cards stale against the
+dispatcher store, and unreadable generated-filename candidates; run `export-signboard` to repair
+valid generated-card drift. Human-authored files are outside this lint's jurisdiction.
+
 Each generated card carries a `## Notes` section the human may hand-edit directly in the vault.
 Re-running `export-signboard` refreshes the generated frontmatter and body but splices any existing
 `## Notes` content back in unchanged — it never blind-overwrites human-authored notes. The exporter

--- a/tests/dispatcher/test_signboard.py
+++ b/tests/dispatcher/test_signboard.py
@@ -20,6 +20,7 @@ from app.dispatcher.signboard import (
     NoActiveVaultError,
     default_signboard_root,
     export_signboard,
+    validate_signboard,
 )
 from app.dispatcher.config import load_paths
 from app.dispatcher.events import JsonlEventWriter
@@ -351,3 +352,124 @@ def test_exported_card_carries_its_source_repo(tmp_env, store, tmp_path: Path) -
     content = card.read_text(encoding="utf-8")
     assert 'repo: "RasmusTho/bifrost"' in content
     assert "- Repo: `RasmusTho/bifrost`" in content
+
+
+# ---------------------------------------------------------------------------
+# #3439: read-only Signboard validation
+# ---------------------------------------------------------------------------
+
+
+def test_validate_clean_board_passes(tmp_env, store, tmp_path: Path) -> None:
+    tasks = seed_tasks(store)
+    board = tmp_path / "board"
+
+    export_signboard(store, board)
+
+    result = validate_signboard(store, board)
+
+    assert result["count"] == len(tasks)
+    assert result["findings"] == []
+
+
+def test_validate_detects_duplicate_cards(tmp_env, store, tmp_path: Path) -> None:
+    ready = next(task for task in seed_tasks(store) if task.status == "ready")
+    board = tmp_path / "board"
+    export_signboard(store, board)
+    card = next((board / "Ready").glob(f"{ready.task_id}--*.md"))
+    duplicate = board / "Done" / card.name
+    duplicate.write_text(card.read_text(encoding="utf-8"), encoding="utf-8")
+
+    result = validate_signboard(store, board)
+
+    assert any(finding["kind"] == "duplicate_card" for finding in result["findings"])
+
+
+def test_validate_detects_column_status_mismatch(tmp_env, store, tmp_path: Path) -> None:
+    ready = next(task for task in seed_tasks(store) if task.status == "ready")
+    board = tmp_path / "board"
+    export_signboard(store, board)
+    card = next((board / "Ready").glob(f"{ready.task_id}--*.md"))
+    wrong = board / "Done" / card.name
+    wrong.write_text(card.read_text(encoding="utf-8"), encoding="utf-8")
+    card.unlink()
+
+    result = validate_signboard(store, board)
+
+    assert any(finding["kind"] == "column_status_mismatch" for finding in result["findings"])
+
+
+def test_validate_detects_stale_card_for_missing_task(tmp_env, store, tmp_path: Path) -> None:
+    ready = next(task for task in seed_tasks(store) if task.status == "ready")
+    board = tmp_path / "board"
+    export_signboard(store, board)
+    card = next((board / "Ready").glob(f"{ready.task_id}--*.md"))
+    content = card.read_text(encoding="utf-8").replace(f'id: "{ready.task_id}"', 'id: "gone"')
+    card.write_text(content, encoding="utf-8")
+
+    result = validate_signboard(store, board)
+
+    assert any(finding["kind"] == "stale_card" for finding in result["findings"])
+
+
+def test_validate_detects_malformed_generated_card(tmp_env, store, tmp_path: Path) -> None:
+    seed_tasks(store)
+    board = tmp_path / "board"
+    malformed = board / "Ready" / "task-bad--broken.md"
+    malformed.parent.mkdir(parents=True)
+    malformed.write_text("---\ngenerated_by: dispatcher.signboard\nid: [\n---\n", encoding="utf-8")
+
+    result = validate_signboard(store, board)
+
+    assert any(finding["kind"] == "malformed_generated_card" for finding in result["findings"])
+
+
+def test_validate_reports_unreadable_card_without_mutation(
+    tmp_env, store, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seed_tasks(store)
+    board = tmp_path / "board"
+    candidate = board / "Ready" / "task-unreadable--candidate.md"
+    candidate.parent.mkdir(parents=True)
+    candidate.write_text("not read", encoding="utf-8")
+    original_read_text = Path.read_text
+
+    def unreadable_read_text(path: Path, *args, **kwargs):
+        if path == candidate:
+            raise OSError("permission denied")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", unreadable_read_text)
+
+    result = validate_signboard(store, board)
+
+    assert any(finding["kind"] == "unreadable_generated_card_candidate" for finding in result["findings"])
+    assert candidate.exists()
+
+
+def test_validate_ignores_human_authored_files(tmp_env, store, tmp_path: Path) -> None:
+    seed_tasks(store)
+    board = tmp_path / "board"
+    human = board / "Ready" / "task-human--notes.md"
+    human.parent.mkdir(parents=True)
+    human.write_text("# Human notes\n", encoding="utf-8")
+
+    result = validate_signboard(store, board)
+
+    assert result["findings"] == []
+
+
+def test_cli_signboard_validate_fails_loud_on_findings(
+    tmp_env, store, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from app.dispatcher.cli import main
+
+    seed_tasks(store)
+    board = tmp_path / "board"
+    broken = board / "Ready" / "task-bad--broken.md"
+    broken.parent.mkdir(parents=True)
+    broken.write_text("---\ngenerated_by: dispatcher.signboard\nid: [\n---\n", encoding="utf-8")
+
+    exit_code = main(["signboard-validate", str(board), "--json"])
+
+    assert exit_code == 1
+    assert '"ok": false' in capsys.readouterr().out


### PR DESCRIPTION
Fixes #3439

## Summary
Adds a read-only `signboard-validate` dispatcher verb that reports malformed, duplicate, stale, mismatched, and unreadable generated-card candidates without modifying the board or dispatcher store.

## Validation
- `pytest -q tests/dispatcher/test_signboard.py tests/dispatcher/test_cli.py`
- `ruff check app tests`
- `python3 scripts/docs_guard.py`
- `git diff --check`

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: This bounded Builder System code/doc slice did not create a durable BuilderOps operational record; the GitHub issue, dispatcher lease, and PR are the delivery receipts.