### PR TITLE
Fix WriteGuard enforcement for append writes

### DIFF
--- a/app/knowledge/write_ops.py
+++ b/app/knowledge/write_ops.py
@@ -120,7 +120,18 @@ def append_note_relative(
     content: str,
     *,
     vault_root: Path | str,
+    action: str = KNOWLEDGE_WRITE_ACTION,
+    write_guard: "WriteGuard | None" = None,
 ) -> WriteReceipt:
+    # Guard-at-seam (#3129): append-only writes share the same production
+    # boundary as relative overwrites. Assert before resolving the port so an
+    # unhealthy/safe-mode runtime cannot mutate the vault through append.
+    # The lazy import preserves the circular-import avoidance used by the
+    # sibling write seams above.
+    from app.write_guard import DEFAULT_WRITE_GUARD
+
+    guard = write_guard or DEFAULT_WRITE_GUARD
+    guard.assert_writes_allowed(action)
     resolved_root = Path(vault_root).expanduser().resolve()
     locator = make_note_locator(note_rel_path)
     port = resolve_knowledge_port(vault_root=resolved_root, settings=_local_fs_settings())

--- a/docs/testing/invariant-tests.md
+++ b/docs/testing/invariant-tests.md
@@ -815,14 +815,20 @@ captured here with the structurally-enforced part marked `schema_enforced` and t
   asserts `WriteGuard` before writing.
 - **Protected principle:** a single write-health gate governs all vault mutation; no seam is exempt.
 - **Affected boundaries:** WSP.
-- **Required fixture / data:** `app/knowledge/write_ops.py:71,110-127`.
+- **Required fixture / data:** `app/knowledge/write_ops.py::write_note_relative`,
+  `app/knowledge/write_ops.py::append_note_relative`, and controlled healthy/safe-mode `WriteGuard`
+  states.
 - **Expected failure mode:** `append_note_relative` writes to the vault while the runtime is in an
   unhealthy/safe-mode state, because it is not asserted like its `write_note_relative` sibling.
-- **Current enforcement:** `gate`; violated today at `append_note_relative` (`write_ops.py:118-127`) —
-  enforceable now, independent of the stale-detection mechanism above. Fix tracked as T3.
-- **Eventual test path:** `tests/invariants/test_vault_multiwriter.py::test_write_guard_asserted_at_every_write_seam`.
+- **Current enforcement:** `gate` + `runtime_test` — both relative write seams assert `WriteGuard`
+  before resolving the knowledge port. `append_note_relative` rejects a safe-mode guard before any
+  port resolution and permits a healthy guarded append; this enforcement is independent of the
+  stale-detection mechanism above.
+- **Runtime test path:**
+  `tests/knowledge/test_write_ops.py::test_append_note_relative_rejects_unhealthy_write_guard`,
+  `tests/knowledge/test_write_ops.py::test_append_note_relative_allows_healthy_write_guard`.
 - **Related docs / contracts / ADRs:** ADR-0055; `docs/audits/YGGDRASIL_ECOSYSTEM_2026-07-06.md` §2/§7 (INV-VW2).
-- **Related issues:** #3114, #3020.
+- **Related issues:** #3129, #3114, #3020.
 
 ### icloud_conflict_artifacts_never_silently_ingested
 
@@ -883,7 +889,7 @@ captured here with the structurally-enforced part marked `schema_enforced` and t
 | expansion_requires_activation_record | #9 | GOV | static + runtime | `tests/invariants/test_expansion_invariants.py`, `tests/activation/test_expansion_gate_records.py` |
 | curation_citations_resolve | #3,#9 | GOV/RCA | static + runtime | `tests/invariants/test_curation_invariants.py`, `tests/curation/test_contradiction_citations_resolve.py` |
 | stale_write_rejected_for_rewritten_notes (INV-VW1) | vault canonical + fail-loud | WSP/HKA | gate (target) | `tests/invariants/test_vault_multiwriter.py` (future) |
-| write_guard_asserted_at_every_write_seam (INV-VW2) | vault canonical + fail-loud | WSP | gate — violated today | `tests/invariants/test_vault_multiwriter.py` (future) |
+| write_guard_asserted_at_every_write_seam (INV-VW2) | vault canonical + fail-loud | WSP | gate + runtime | `tests/knowledge/test_write_ops.py::test_append_note_relative_rejects_unhealthy_write_guard`, `tests/knowledge/test_write_ops.py::test_append_note_relative_allows_healthy_write_guard` |
 | icloud_conflict_artifacts_never_silently_ingested (INV-VW3) | vault canonical + fail-loud | SIP/WSP | doctor (target) | `tests/invariants/test_vault_multiwriter.py` (future) |
 
 ## Heimdal invariants (HEIM-1..14) — sibling registry

--- a/tests/knowledge/test_write_ops.py
+++ b/tests/knowledge/test_write_ops.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from app.knowledge import write_ops
 from app.knowledge.contracts import WriteReceipt
 from app.knowledge.settings import KnowledgeAdapter, KnowledgeSettings
+from app.write_guard import WriteGuard, WritesBlockedError
 
 
 def test_default_vault_root_for_path_uses_filesystem_anchor(tmp_path: Path) -> None:
@@ -132,6 +135,46 @@ def test_append_note_relative_uses_port_append(monkeypatch, tmp_path: Path) -> N
     assert captured["path"] == "Inbox/log.md"
     assert captured["vault"] == "Vault"
     assert captured["content"] == "line\n"
+
+
+def test_append_note_relative_rejects_unhealthy_write_guard(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        write_ops,
+        "resolve_knowledge_port",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("port should not resolve")),
+    )
+    guard = WriteGuard(lambda: {"state": "safe_mode", "reason": "test-induced block"})
+
+    with pytest.raises(WritesBlockedError):
+        write_ops.append_note_relative(
+            "Inbox/log.md",
+            "line\n",
+            vault_root=tmp_path,
+            write_guard=guard,
+        )
+
+
+def test_append_note_relative_allows_healthy_write_guard(monkeypatch, tmp_path: Path) -> None:
+    captured: dict[str, object] = {}
+
+    class FakePort:
+        def append_note(self, locator, content):  # type: ignore[no-untyped-def]
+            captured["path"] = locator.path
+            captured["content"] = content
+            return WriteReceipt(operation="append_note", locator=locator, adapter="fake")
+
+    monkeypatch.setattr(write_ops, "resolve_knowledge_port", lambda **_kwargs: FakePort())
+    guard = WriteGuard(lambda: {"state": "healthy", "reason": None})
+
+    receipt = write_ops.append_note_relative(
+        "Inbox/log.md",
+        "line\n",
+        vault_root=tmp_path,
+        write_guard=guard,
+    )
+
+    assert receipt.operation == "append_note"
+    assert captured == {"path": "Inbox/log.md", "content": "line\n"}
 
 
 def test_advanced_uri_from_vault_path_inside_root(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #3129

## Summary
- Assert `WriteGuard` at the `append_note_relative` production seam before resolving the port.
- Add regression coverage for blocked safe-mode writes and healthy append writes.
- Update the INV-VW2 registry and coverage map to reflect the delivered gate and its production-path tests.

## Validation
- `pytest -q tests/knowledge/test_write_ops.py::test_append_note_relative_rejects_unhealthy_write_guard tests/knowledge/test_write_ops.py::test_append_note_relative_allows_healthy_write_guard`
- `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1 python3 scripts/docs_guard.py` (the bounded guard repair has no temporal-doc impact)
- `ruff check app tests`
- `pytest -q -m "not pg"`
- `RUN_INTEGRATED_RUNTIME_UAT=1 pytest -q -m uat_integrated_runtime`
- `mypy app`

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded runtime correctness repair; GitHub issue, dispatcher claim, commit, and PR provide the delivery trace.