### PR TITLE
Fix production Ollama transport

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,18 +2,32 @@
 # `docker compose down` (even without -v) cannot destroy prod data.
 # Usage: docker compose -f docker-compose.yaml -f docker-compose.prod.yml -p pkm-prod up -d
 services:
+  # Production uses the project-local Ollama service over the Compose network.
+  # Do not publish 11434: the mac mini may also have a host Ollama listener,
+  # and api/worker must not depend on host.docker.internal routing.
+  ollama:
+    ports: !override []
+
   api:
     environment:
       API_HEALTHCHECK_URL: http://host.docker.internal:18000/readyz
       PKM_ENVIRONMENT: prod
       DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://app:app@db:5432/app}
       DB_DSN: ${DB_DSN:-postgresql+psycopg://app:app@db:5432/app}
+      OLLAMA_BASE_URL: http://ollama:11434
+    depends_on:
+      ollama:
+        condition: service_healthy
 
   worker:
     environment:
       PKM_ENVIRONMENT: prod
       DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://app:app@db:5432/app}
       DB_DSN: ${DB_DSN:-postgresql+psycopg://app:app@db:5432/app}
+      OLLAMA_BASE_URL: http://ollama:11434
+    depends_on:
+      ollama:
+        condition: service_healthy
 
   watcher:
     environment:

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -270,6 +270,31 @@ Environment separation MUST be explicit across the following surfaces.
 
 **Operational consequence**: production incidents, unsafe drift, or blocked write conditions should route through health/write-guard/operator workflows rather than ad hoc override behavior.
 
+<a id="prod-ollama-topology"></a>
+
+### Production Ollama topology
+
+Production's API and worker use the `ollama` service in the `pkm-prod` Compose project at
+`http://ollama:11434`. The production overlay starts that service before API/worker readiness and
+does **not** publish port `11434` to the macOS host. This avoids relying on
+`host.docker.internal` and prevents a collision with any host-local Ollama process.
+
+The provider cache is the project-scoped `pkm-prod_ollama` volume inherited from the base Compose
+file. It is persistent across normal recreate/redeploy operations, but Compose never downloads a
+model implicitly. Before enabling Ollama-backed work, the operator must confirm that this cache
+contains the configured models — currently `nomic-embed-text:latest` (768 dimensions) and the
+configured chat model — without changing the existing embedding provider/model/dimension identity.
+
+The Mac mini's shared Colima budget remains 4 GB. A sidecar restores transport; it does not make
+the co-resident embedding and chat models fit more memory. Keep embedding work serial and do not
+start a rebuild or download models as part of a transport-only redeploy. Inspect model/cache disk
+usage and the running container memory before any later rebuild.
+
+To roll back this topology, redeploy the previous committed production revision (where the
+production API/worker point at the prior provider route) using the same `pkm-prod` project. The
+named cache volume is preserved; do not remove it unless an operator intentionally accepts losing
+the cached models.
+
 ## Runtime Control Surface
 
 The runtime provides explicit environment selection through a documented control surface with a clear priority hierarchy for `dev`, `prod`, and `test`.

--- a/docs/architecture/inv-ef1-register.json
+++ b/docs/architecture/inv-ef1-register.json
@@ -1878,6 +1878,20 @@
       "issue": "#2892"
     },
     {
+      "artifact": "docker-compose.prod.yml",
+      "category": "iii",
+      "why_load_bearing": "Production Compose documents the operator-bound host capacity constraint needed to avoid an unsafe Ollama topology.",
+      "disposition": "stay",
+      "issue": "#3462"
+    },
+    {
+      "artifact": "docs/ENVIRONMENTS.md",
+      "category": "iii",
+      "why_load_bearing": "The production topology runbook documents the operator-bound Mac mini capacity constraint needed for a safe redeploy.",
+      "disposition": "stay",
+      "issue": "#3462"
+    },
+    {
       "artifact": "vault/_system/events/ingest.log.jsonl",
       "category": "ii",
       "why_load_bearing": "Existing repository artifact retains an operator-bound reference pending its scoped migration review.",

--- a/tests/ops/test_container_healthcheck_targets.py
+++ b/tests/ops/test_container_healthcheck_targets.py
@@ -9,6 +9,7 @@ import yaml
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+_PROD_OLLAMA_BASE_URL = "http://ollama:11434"
 
 
 class _ComposeLoader(yaml.SafeLoader):
@@ -58,3 +59,22 @@ def test_no_container_healthcheck_targets_api_health() -> None:
                 f"{compose_path.name}:{service_name} healthcheck must use /healthz or /readyz, "
                 "not /api/health"
             )
+
+
+def test_prod_api_and_worker_use_the_internal_ollama_service() -> None:
+    """Prod must start and address its Compose-local Ollama provider (#3462)."""
+    prod_compose = yaml.load(
+        (REPO_ROOT / "docker-compose.prod.yml").read_text(encoding="utf-8"),
+        Loader=_ComposeLoader,
+    ) or {}
+    services = prod_compose.get("services") or {}
+
+    ollama = services.get("ollama") or {}
+    assert ollama.get("ports") == [], "prod must not publish Ollama's host port"
+
+    for service_name in ("api", "worker"):
+        service = services.get(service_name) or {}
+        environment = service.get("environment") or {}
+        assert environment.get("OLLAMA_BASE_URL") == _PROD_OLLAMA_BASE_URL
+        assert "host.docker.internal" not in environment["OLLAMA_BASE_URL"]
+        assert (service.get("depends_on") or {}).get("ollama") == {"condition": "service_healthy"}


### PR DESCRIPTION
Fixes #3462

## Summary
- Production API and worker use the Compose-local Ollama service at http://ollama:11434.
- The production overlay health-gates API and worker on Ollama and leaves port 11434 unpublished.
- No production deploy, model download, re-embedding, or index rebuild was performed.

## Validation
- Targeted container, CLI, API, and release-channel tests passed.
- Public seam lint, ruff, and diff check passed.
- All PR CI checks are green.

## Rollback
Redeploy the preceding committed production revision with the same pkm-prod Compose project. Preserve the Ollama cache volume unless an operator deliberately chooses to discard cached models.

## Operator gate
Production deploy and runtime health evidence remain operator-owned and are tracked by the linked post-merge follow-up.

## BuilderOps Routing
- Records/projections/receipts: none.
- Reason: bounded code and owner-document delivery; the remaining runtime receipt is explicit post-merge operator work.
