### PR TITLE
Preserve locked worktrees during cleanup

### DIFF
--- a/scripts/git_hygiene.py
+++ b/scripts/git_hygiene.py
@@ -762,6 +762,23 @@ def janitor_apply(
         pr_states=pr_states,
     )
 
+    preservation_receipts = plan.get("preservation_receipts", [])
+    if preservation_receipts:
+        return {
+            **plan,
+            "mode": "apply",
+            "destructive_actions": actions,
+            "errors": [
+                {
+                    "artifact": "worktree",
+                    "action": "preserve",
+                    "reason": "preservation_evidence_present",
+                    "preservation_receipts": preservation_receipts,
+                }
+            ],
+            "ok": False,
+        }
+
     apply_git(["worktree", "prune"], {"artifact": "worktree", "action": "prune_metadata"})
     reclaimable = plan.get("reclaimable_worktrees", plan["candidates"]["worktrees"])
     for worktree in reclaimable:

--- a/scripts/git_hygiene.py
+++ b/scripts/git_hygiene.py
@@ -393,6 +393,7 @@ def _worktree_reclaim_reason(
     protected_branches: set[str],
     pr_states: dict[str, dict[str, Any]] | None,
     cwd: Path,
+    locked: bool = False,
 ) -> tuple[str | None, str | None]:
     """Decide whether a present worktree is safe to reclaim.
 
@@ -416,6 +417,11 @@ def _worktree_reclaim_reason(
         return "root_worktree", None
     if branch in protected_branches:
         return "protected_branch", None
+    # `git worktree list --porcelain` exposes a `locked` record for worktrees
+    # guarded by another tool or session.  A lock is positive preservation
+    # evidence, not stale metadata: never make it a removal candidate.
+    if locked:
+        return "locked_worktree", None
     if f"worktree:{path}" in active_resources or _branch_has_active_lease(
         branch, active_resources
     ):
@@ -518,6 +524,37 @@ def _lease_resources(active_leases: list[dict[str, Any]], now: float | None = No
     }
 
 
+PRESERVATION_REASONS = {
+    "active_lease",
+    "dirty_worktree",
+    "locked_worktree",
+    "unknown_merge_state",
+    "worktree_state_unavailable",
+}
+
+
+def _preservation_receipt(item: dict[str, Any]) -> dict[str, Any] | None:
+    """Return an operator-readable receipt for non-destructive holds."""
+    reason = item.get("reason")
+    if item.get("artifact") != "worktree" or reason not in PRESERVATION_REASONS:
+        return None
+    next_action = {
+        "active_lease": "wait for the owning agent to release or supersede its lease",
+        "dirty_worktree": "preserve local drift; inspect or commit it before any cleanup",
+        "locked_worktree": "preserve the lock; verify the owning session before any cleanup",
+        "unknown_merge_state": "verify merge and ownership state before any cleanup",
+        "worktree_state_unavailable": "restore or inspect the worktree; do not infer abandonment",
+    }[reason]
+    return {
+        "artifact": "worktree",
+        "path": item["path"],
+        "branch": item.get("branch", ""),
+        "reason": reason,
+        "action": "preserve",
+        "next_action": next_action,
+    }
+
+
 def build_janitor_plan(
     cwd: Path,
     *,
@@ -537,6 +574,7 @@ def build_janitor_plan(
     checked_out = _checked_out_branches(worktrees)
 
     skipped: list[dict[str, Any]] = []
+    preservation_receipts: list[dict[str, Any]] = []
     local_branches = []
     for branch in _local_branches(cwd):
         reason = _local_branch_skip_reason(
@@ -579,9 +617,14 @@ def build_janitor_plan(
             protected_branches=protected,
             pr_states=pr_states,
             cwd=cwd,
+            locked="locked" in worktree,
         )
         if reason:
-            skipped.append({"artifact": "worktree", "path": path, "branch": branch, "reason": reason})
+            item = {"artifact": "worktree", "path": path, "branch": branch, "reason": reason}
+            skipped.append(item)
+            receipt = _preservation_receipt(item)
+            if receipt:
+                preservation_receipts.append(receipt)
             continue
         reclaimable_worktrees.append(
             {"path": path, "branch": branch, "merge_proof": merge_proof}
@@ -646,6 +689,7 @@ def build_janitor_plan(
         "skipped": skipped,
         "prune_candidates": prune_candidates,
         "active_leases_respected": sorted(active_resources),
+        "preservation_receipts": preservation_receipts,
     }
 
 

--- a/tests/ops/test_git_hygiene.py
+++ b/tests/ops/test_git_hygiene.py
@@ -523,6 +523,51 @@ def test_janitor_plan_skips_dirty_worktree(tmp_path, monkeypatch) -> None:
         item["artifact"] == "worktree" and item["reason"] == "dirty_worktree"
         for item in report["skipped"]
     )
+    assert report["preservation_receipts"] == [
+        {
+            "artifact": "worktree",
+            "path": str(dirty_worktree),
+            "branch": "codex/dirty",
+            "reason": "dirty_worktree",
+            "action": "preserve",
+            "next_action": "preserve local drift; inspect or commit it before any cleanup",
+        }
+    ]
+
+
+def test_janitor_plan_skips_locked_worktree(tmp_path, monkeypatch) -> None:
+    locked_worktree = tmp_path / "locked"
+    locked_worktree.mkdir()
+
+    def fake_run_git(args: list[str], _cwd: Path) -> str:
+        if args == ["branch", "--show-current"]:
+            return "main"
+        if args == ["rev-parse", "--show-toplevel"]:
+            return str(tmp_path)
+        if args == ["worktree", "list", "--porcelain"]:
+            return (
+                f"worktree {tmp_path}\nHEAD abc\nbranch refs/heads/main\n\n"
+                f"worktree {locked_worktree}\nHEAD def\nbranch refs/heads/codex/locked\nlocked active Claude session\n\n"
+            )
+        if args == ["for-each-ref", "--format=%(refname:short)", "refs/heads"]:
+            return "main\ncodex/locked"
+        if args == ["for-each-ref", "--format=%(refname:short)", "refs/remotes/origin"]:
+            return ""
+        if args in (["stash", "list", "--date=unix"], ["worktree", "prune", "--dry-run"], ["remote", "prune", "origin", "--dry-run"]):
+            return ""
+        raise AssertionError(f"unexpected git command: {args}")
+
+    monkeypatch.setattr(git_hygiene, "run_git", fake_run_git)
+    monkeypatch.setattr(git_hygiene, "_is_ancestor", lambda *_args: True)
+    monkeypatch.setattr(git_hygiene, "_worktree_dirty", lambda _path: False)
+
+    report = git_hygiene.build_janitor_plan(
+        tmp_path, pr_states={"codex/locked": {"state": "MERGED"}}
+    )
+
+    assert report["reclaimable_worktrees"] == []
+    assert report["preservation_receipts"][0]["reason"] == "locked_worktree"
+    assert report["preservation_receipts"][0]["action"] == "preserve"
 
 
 def test_janitor_plan_remote_merged_branch_is_delete_candidate(
@@ -967,6 +1012,10 @@ def test_reclaimable_skips_dirty_lease_open_pr_and_root_with_reasons(
     assert reasons[str(dirty_wt)] == "dirty_worktree"
     assert reasons[str(leased_wt)] == "active_lease"
     assert reasons[str(openpr_wt)] == "open_or_draft_pr"
+    assert any(
+        item["path"] == str(leased_wt) and item["reason"] == "active_lease"
+        for item in report["preservation_receipts"]
+    )
     # None of the skipped worktrees leaked into reclaimable.
     reclaim_paths = {item["path"] for item in report["reclaimable_worktrees"]}
     assert reclaim_paths.isdisjoint(

--- a/tests/ops/test_git_hygiene.py
+++ b/tests/ops/test_git_hygiene.py
@@ -1154,6 +1154,53 @@ def test_janitor_apply_skips_branch_delete_when_worktree_remove_fails(
     assert ["branch", "-d", "deliver/foo"] not in commands
 
 
+def test_janitor_apply_preserves_worktrees_when_receipts_exist(tmp_path, monkeypatch) -> None:
+    commands: list[list[str]] = []
+
+    def fake_run_git_result(args: list[str], _cwd: Path):
+        commands.append(args)
+        return subprocess.CompletedProcess(["git", *args], 0, "", "")
+
+    monkeypatch.setattr(git_hygiene, "run_git_result", fake_run_git_result)
+    monkeypatch.setattr(
+        git_hygiene,
+        "build_janitor_plan",
+        lambda *args, **kwargs: {
+            "mode": "report",
+            "remote_policy": "merged-and-closed-with-rescue",
+            "destructive_actions": [],
+            "candidates": {
+                "local_branches": [{"branch": "merged-branch"}],
+                "worktrees": [],
+                "remote_branches": [{"branch": "merged-remote"}],
+                "remote_branches_requiring_rescue": [],
+                "old_stashes": [{"ref": "stash@{0}"}],
+            },
+            "reclaimable_worktrees": [{"path": str(tmp_path / "safe"), "branch": "safe"}],
+            "orphaned_worktrees": [],
+            "skipped": [],
+            "prune_candidates": {"worktree": [], "remote": []},
+            "active_leases_respected": [],
+            "preservation_receipts": [
+                {
+                    "artifact": "worktree",
+                    "path": str(tmp_path / "locked"),
+                    "branch": "locked",
+                    "reason": "locked_worktree",
+                    "action": "preserve",
+                    "next_action": "preserve the lock; verify the owning session before any cleanup",
+                }
+            ],
+        },
+    )
+
+    report = git_hygiene.janitor_apply(tmp_path, pr_states={})
+
+    assert report["ok"] is False
+    assert report["errors"][0]["reason"] == "preservation_evidence_present"
+    assert commands == [["fetch", "--prune", "origin"]]
+
+
 def test_janitor_apply_worktree_reclaim_is_idempotent(tmp_path) -> None:
     """AC3 idempotency: a second apply over an already-reclaimed worktree is a
     no-op (nothing left to remove)."""


### PR DESCRIPTION
## Change Lane
- [ ] Implementation lane
- [x] Governance lane

Closes #3576

## Summary
- Treat Git worktree locks as preservation evidence during hygiene planning.
- Emit structured preservation receipts for locked, dirty, leased, unavailable, and indeterminate worktrees.
- The daily cleanup automation now blocks destructive apply whenever preservation receipts exist.

## SBS Impact
Builder System recovery and workspace-safety change only. GitHub remains delivery authority; hygiene reports are derived local evidence.

## Validation
- `pytest -q tests/ops/test_git_hygiene.py` — 38 passed.
- `ruff check scripts/git_hygiene.py tests/ops/test_git_hygiene.py` — passed.
- `git diff --check` — passed.
- Live report confirmed locked Claude worktrees emit preservation receipts and are absent from reclaimable worktrees.

## BuilderOps Routing
- Records/projections/receipts: none.
- Reason: the governing issue and GitHub claim receipt capture this bounded recovery fix; no separate BuilderOps record is needed.