### PR TITLE
Add zero-write contradiction triage adapter

### DIFF
--- a/app/curation/contradiction_triage.py
+++ b/app/curation/contradiction_triage.py
@@ -134,7 +134,9 @@ def run_contradiction_triage(
             continue
         admitted.append(projected)
 
-    if admitted:
+    if admitted and (excluded or report.suppressed_by_cross_scope_denial):
+        diagnostic = "partial_findings"
+    elif admitted:
         diagnostic = "ok"
     elif excluded or report.suppressed_by_cross_scope_denial:
         diagnostic = "finding_excluded"

--- a/app/curation/contradiction_triage.py
+++ b/app/curation/contradiction_triage.py
@@ -1,0 +1,157 @@
+"""Scope-safe, zero-write read adapter for contradiction findings.
+
+The adapter deliberately calls the delivered contradiction harness with
+``materialize=False``.  It exposes only findings whose two citation handles
+resolve in the caller's current admission scope; excluded details and scan
+exceptions are collapsed to content-free diagnostics.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Callable
+
+from app.curation.contradiction import (
+    ContradictionPassConfig,
+    ContradictionPassReport,
+    run_contradiction_pass,
+)
+from app.curation.findings import CurationFinding, FindingClass
+
+
+class ContradictionTriageScanStatus(str, Enum):
+    SUCCESS = "success"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class AdmittedContradictionCitation:
+    """The minimal result of resolving one citation under current admission."""
+
+    handle: str
+    scope: str
+
+
+@dataclass(frozen=True)
+class ContradictionTriageAdmission:
+    """Caller-owned current scope and citation-resolution boundary."""
+
+    current_scope: str
+    resolve_citation: Callable[[str], AdmittedContradictionCitation | None]
+
+
+@dataclass(frozen=True)
+class ContradictionTriageFinding:
+    """Narrow projection of fields already emitted by the sanctioned harness."""
+
+    finding_id: str
+    observed: str
+    citation_handles: tuple[str, str]
+    interpretation: str
+
+
+@dataclass(frozen=True)
+class ContradictionTriageResult:
+    status: ContradictionTriageScanStatus
+    findings: tuple[ContradictionTriageFinding, ...]
+    diagnostic: str
+
+
+ContradictionHarness = Callable[..., ContradictionPassReport]
+
+
+def _admit_finding(
+    finding: CurationFinding,
+    admission: ContradictionTriageAdmission,
+) -> ContradictionTriageFinding | None:
+    if finding.finding_class is not FindingClass.CONTRADICTION_CLAIM_CONFLICT:
+        return None
+    if not admission.current_scope or len(finding.evidence) != 2:
+        return None
+
+    handles = tuple(finding.evidence)
+    if len(set(handles)) != 2:
+        return None
+
+    for handle in handles:
+        try:
+            resolved = admission.resolve_citation(handle)
+        except Exception:
+            return None
+        if (
+            resolved is None
+            or resolved.handle != handle
+            or resolved.scope != admission.current_scope
+        ):
+            return None
+
+    return ContradictionTriageFinding(
+        finding_id=finding.finding_id,
+        observed=finding.observed,
+        citation_handles=(handles[0], handles[1]),
+        interpretation=finding.span,
+    )
+
+
+def run_contradiction_triage(
+    *,
+    vault_root: Path,
+    queries: list[str],
+    admission: ContradictionTriageAdmission,
+    outbox_path: Path,
+    config: ContradictionPassConfig | None = None,
+    harness: ContradictionHarness | None = None,
+) -> ContradictionTriageResult:
+    """Read findings through the existing harness without materializing them."""
+
+    runner = harness or run_contradiction_pass
+    try:
+        report = runner(
+            vault_root=vault_root,
+            queries=queries,
+            config=config,
+            outbox_path=outbox_path,
+            materialize=False,
+        )
+    except Exception:
+        return ContradictionTriageResult(
+            status=ContradictionTriageScanStatus.FAILED,
+            findings=(),
+            diagnostic="scan_failed",
+        )
+
+    admitted: list[ContradictionTriageFinding] = []
+    seen_ids: set[str] = set()
+    excluded = False
+    for finding in report.findings:
+        if finding.finding_id in seen_ids:
+            continue
+        seen_ids.add(finding.finding_id)
+        projected = _admit_finding(finding, admission)
+        if projected is None:
+            excluded = True
+            continue
+        admitted.append(projected)
+
+    if admitted:
+        diagnostic = "ok"
+    elif excluded or report.suppressed_by_cross_scope_denial:
+        diagnostic = "finding_excluded"
+    else:
+        diagnostic = "no_findings"
+    return ContradictionTriageResult(
+        status=ContradictionTriageScanStatus.SUCCESS,
+        findings=tuple(admitted),
+        diagnostic=diagnostic,
+    )
+
+
+__all__ = [
+    "AdmittedContradictionCitation",
+    "ContradictionTriageAdmission",
+    "ContradictionTriageFinding",
+    "ContradictionTriageResult",
+    "ContradictionTriageScanStatus",
+    "run_contradiction_triage",
+]

--- a/docs/CONTRADICTION_TRIAGE_BENCH/README.md
+++ b/docs/CONTRADICTION_TRIAGE_BENCH/README.md
@@ -1,4 +1,4 @@
-State: Specification directory (parent feature issue #3543; first child #3544; no shipped behavior is claimed).
+State: First read-only adapter slice implemented by issue #3544; parent #3543 remains the validation hub.
 Doc role: Feature specification
 Authority: Defines the future read-only contradiction-triage surface. Subordinate to `docs/MIMER_CAPABILITY_HARDENING/GRADUATED_CURATION.md` for the shipped contradiction-pass harness and to `docs/CONCEPTS/CONTEXT_ADMISSIBILITY_CONTRACT.md` for scope admission.
 Owner: Product / architecture
@@ -12,6 +12,15 @@ Contradiction Triage Bench makes a consequential tension from the existing curat
 ## Current foundation and boundary
 
 The contradiction-pass harness from G2-4 is delivered: it produces scope-aware findings with two resolvable citations and retains the semantic-curation propose-only guard. This capability does **not** replace that harness, its panel-proposal materialization, or its declined-proposal ledger.
+
+The supported Bench read boundary is
+`app.curation.contradiction_triage::run_contradiction_triage`. It invokes the
+sanctioned `app.curation.contradiction::run_contradiction_pass` path with
+`materialize=False` and projects only the existing finding id, verbatim
+observed claims, two citation handles, and interpretation. Citation handles
+must resolve through the caller-supplied current-scope admission boundary;
+otherwise the whole logical finding is excluded with a content-free
+diagnostic. `success/no_findings` remains distinct from `failed/scan_failed`.
 
 The Bench is a supporting read path for the existing note/Panel confirmation model, not a parallel review UI. It must never infer a truth verdict, edit either source, create a receipt, or introduce a Bench-specific disposition. A later durable dismissal or superseding-decision flow requires its own authority, lifecycle, privacy, concurrency, and recovery contract.
 

--- a/docs/CONTRADICTION_TRIAGE_BENCH/README.md
+++ b/docs/CONTRADICTION_TRIAGE_BENCH/README.md
@@ -21,6 +21,8 @@ observed claims, two citation handles, and interpretation. Citation handles
 must resolve through the caller-supplied current-scope admission boundary;
 otherwise the whole logical finding is excluded with a content-free
 diagnostic. `success/no_findings` remains distinct from `failed/scan_failed`.
+Mixed admitted and excluded results retain a content-free `partial_findings`
+diagnostic so a consumer cannot mistake an incomplete scan for a complete one.
 
 The Bench is a supporting read path for the existing note/Panel confirmation model, not a parallel review UI. It must never infer a truth verdict, edit either source, create a receipt, or introduce a Bench-specific disposition. A later durable dismissal or superseding-decision flow requires its own authority, lifecycle, privacy, concurrency, and recovery contract.
 

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -172,6 +172,15 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
         ("tests/relevance",),
     ),
     (
+        "curation",
+        (
+            "app/curation/",
+            "tests/curation/",
+            "docs/CONTRADICTION_TRIAGE_BENCH/",
+        ),
+        ("tests/curation", "tests/invariants"),
+    ),
+    (
         "heimdal",
         ("app/heimdal/", "tests/heimdal/", "docs/HEIMDAL/", "docs/HEIMDAL_CAPTURE_CLIENT/"),
         ("tests/heimdal",),

--- a/tests/curation/test_contradiction_triage_adapter.py
+++ b/tests/curation/test_contradiction_triage_adapter.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.curation.contradiction import ContradictionPassReport
+from app.curation.contradiction_triage import (
+    AdmittedContradictionCitation,
+    ContradictionTriageAdmission,
+    ContradictionTriageScanStatus,
+    run_contradiction_triage,
+)
+from app.curation.findings import CurationFinding, FindingClass
+
+
+def _finding(*, finding_id: str = "finding-1") -> CurationFinding:
+    finding = CurationFinding.create(
+        note_uuid="uuid-a",
+        finding_class=FindingClass.CONTRADICTION_CLAIM_CONFLICT,
+        span="Agent interpretation: tension only; no truth verdict.",
+        observed="Claim A (a.md): Alpha.\nClaim B (b.md): Beta.",
+        proposed="existing panel proposal",
+        evidence=("a.md", "b.md"),
+    )
+    return CurationFinding(
+        finding_id=finding_id,
+        note_uuid=finding.note_uuid,
+        finding_class=finding.finding_class,
+        track=finding.track,
+        span=finding.span,
+        observed=finding.observed,
+        proposed=finding.proposed,
+        evidence=finding.evidence,
+        language_verdict=finding.language_verdict,
+        reversal=finding.reversal,
+    )
+
+
+def _report(*findings: CurationFinding) -> ContradictionPassReport:
+    return ContradictionPassReport(
+        findings=tuple(findings),
+        pairs_considered=1,
+        suppressed_by_decline=0,
+        suppressed_by_cap=0,
+        suppressed_by_cross_scope_denial=0,
+    )
+
+
+def _admission(
+    resolved: dict[str, AdmittedContradictionCitation],
+    *,
+    current_scope: str = "work",
+) -> ContradictionTriageAdmission:
+    return ContradictionTriageAdmission(
+        current_scope=current_scope,
+        resolve_citation=lambda handle: resolved.get(handle),
+    )
+
+
+def test_adapter_requires_two_resolvable_current_scope_citations(tmp_path: Path) -> None:
+    finding = _finding()
+    admission = _admission(
+        {
+            "a.md": AdmittedContradictionCitation(handle="a.md", scope="work"),
+            "b.md": AdmittedContradictionCitation(handle="b.md", scope="work"),
+        }
+    )
+
+    result = run_contradiction_triage(
+        vault_root=tmp_path,
+        queries=["conflict"],
+        admission=admission,
+        outbox_path=tmp_path / "outbox.jsonl",
+        harness=lambda **_: _report(finding, finding),
+    )
+
+    assert result.status is ContradictionTriageScanStatus.SUCCESS
+    assert len(result.findings) == 1
+    assert result.findings[0].citation_handles == ("a.md", "b.md")
+    assert result.findings[0].observed == finding.observed
+
+
+def test_adapter_fails_closed_without_cross_scope_disclosure(tmp_path: Path) -> None:
+    finding = _finding()
+    admission = _admission(
+        {
+            "a.md": AdmittedContradictionCitation(handle="a.md", scope="work"),
+            "b.md": AdmittedContradictionCitation(handle="b.md", scope="personal"),
+        }
+    )
+
+    result = run_contradiction_triage(
+        vault_root=tmp_path,
+        queries=["conflict"],
+        admission=admission,
+        outbox_path=tmp_path / "outbox.jsonl",
+        harness=lambda **_: _report(finding),
+    )
+
+    assert result.status is ContradictionTriageScanStatus.SUCCESS
+    assert result.findings == ()
+    assert result.diagnostic == "finding_excluded"
+    rendered = repr(result)
+    assert "personal" not in rendered
+    assert "b.md" not in rendered
+    assert "Beta" not in rendered
+
+
+def test_adapter_is_zero_write_at_production_call_site(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.curation import contradiction_triage as adapter_module
+
+    calls: list[dict[str, object]] = []
+
+    def production_harness(**kwargs: object) -> ContradictionPassReport:
+        calls.append(kwargs)
+        return _report()
+
+    monkeypatch.setattr(adapter_module, "run_contradiction_pass", production_harness)
+    outbox = tmp_path / "outbox.jsonl"
+    before = set(tmp_path.rglob("*"))
+
+    result = run_contradiction_triage(
+        vault_root=tmp_path,
+        queries=["none"],
+        admission=_admission({}),
+        outbox_path=outbox,
+    )
+
+    assert result.status is ContradictionTriageScanStatus.SUCCESS
+    assert len(calls) == 1
+    assert calls[0]["materialize"] is False
+    assert set(tmp_path.rglob("*")) == before
+    assert not outbox.exists()
+
+
+def test_adapter_distinguishes_failure_from_no_findings(tmp_path: Path) -> None:
+    empty = run_contradiction_triage(
+        vault_root=tmp_path,
+        queries=["none"],
+        admission=_admission({}),
+        outbox_path=tmp_path / "outbox.jsonl",
+        harness=lambda **_: _report(),
+    )
+
+    def fail(**_: object) -> ContradictionPassReport:
+        raise RuntimeError("private source details")
+
+    failed = run_contradiction_triage(
+        vault_root=tmp_path,
+        queries=["none"],
+        admission=_admission({}),
+        outbox_path=tmp_path / "outbox.jsonl",
+        harness=fail,
+    )
+
+    assert empty.status is ContradictionTriageScanStatus.SUCCESS
+    assert empty.diagnostic == "no_findings"
+    assert failed.status is ContradictionTriageScanStatus.FAILED
+    assert failed.diagnostic == "scan_failed"
+    assert "private source details" not in repr(failed)

--- a/tests/curation/test_contradiction_triage_adapter.py
+++ b/tests/curation/test_contradiction_triage_adapter.py
@@ -107,6 +107,42 @@ def test_adapter_fails_closed_without_cross_scope_disclosure(tmp_path: Path) -> 
     assert "Beta" not in rendered
 
 
+def test_adapter_preserves_partial_posture_when_another_finding_is_excluded(
+    tmp_path: Path,
+) -> None:
+    admitted = _finding(finding_id="admitted")
+    excluded = CurationFinding(
+        finding_id="excluded",
+        note_uuid=admitted.note_uuid,
+        finding_class=admitted.finding_class,
+        track=admitted.track,
+        span=admitted.span,
+        observed=admitted.observed,
+        proposed=admitted.proposed,
+        evidence=("a.md", "denied.md"),
+        language_verdict=admitted.language_verdict,
+        reversal=admitted.reversal,
+    )
+    admission = _admission(
+        {
+            "a.md": AdmittedContradictionCitation(handle="a.md", scope="work"),
+            "b.md": AdmittedContradictionCitation(handle="b.md", scope="work"),
+        }
+    )
+
+    result = run_contradiction_triage(
+        vault_root=tmp_path,
+        queries=["conflict"],
+        admission=admission,
+        outbox_path=tmp_path / "outbox.jsonl",
+        harness=lambda **_: _report(admitted, excluded),
+    )
+
+    assert [finding.finding_id for finding in result.findings] == ["admitted"]
+    assert result.diagnostic == "partial_findings"
+    assert "denied.md" not in repr(result)
+
+
 def test_adapter_is_zero_write_at_production_call_site(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/scripts/test_select_pr_tests.py
+++ b/tests/scripts/test_select_pr_tests.py
@@ -172,6 +172,22 @@ def test_relevance_runtime_and_regression_changes_select_relevance_coverage() ->
     assert not selection.unowned_paths
 
 
+def test_curation_adapter_change_selects_curation_coverage() -> None:
+    selection = select_tests(
+        [
+            "app/curation/contradiction_triage.py",
+            "tests/curation/test_contradiction_triage_adapter.py",
+            "docs/CONTRADICTION_TRIAGE_BENCH/README.md",
+        ]
+    )
+
+    assert selection.full_suite is False
+    assert selection.subsystems == ("curation",)
+    assert selection.unowned_paths == ()
+    assert "tests/curation" in selection.targets
+    assert "tests/invariants" in selection.targets
+
+
 def test_journaling_change_has_a_ci_owner() -> None:
     selection = select_tests(
         ["app/journaling/day_context.py", "tests/journaling/test_assemble_day_context.py"]


### PR DESCRIPTION
Fixes #3544

## Summary
- add a typed read adapter over the delivered contradiction harness using `materialize=False`
- require two citation handles to resolve in the caller's current scope and fail closed with content-free diagnostics
- preserve the existing note/Panel proposal path without vault, outbox, receipt, or suppression writes
- register curation paths with subsystem-owned CI selection so the production, test, and owner-doc surfaces fail closed into the intended coverage

## Validation
- `pytest -q tests/scripts/test_select_pr_tests.py tests/curation/test_contradiction_triage_adapter.py tests/curation/test_contradiction_citations_resolve.py tests/curation/test_semantic_never_autowrites.py` (64 passed after rebase)
- `pytest -q tests/invariants/test_curation_invariants.py -k 'citations_resolve or semantic_curation_never_autowrites'` (1 passed)
- `ruff check app tests companion-ui/companion-app scripts/select_pr_tests.py` (passed)
- `python3 scripts/select_pr_tests.py ...` (curation/ops_deploy owned targets; no unowned paths)

## SBS Impact
Product/Runtime Curation + Retrieval admission. Read-only derived output only; no human-knowledge, memory, persistence, sync, or write authority is added. Citation and scope failures remain fail-closed.

## Owner-doc writeback
Updated `docs/CONTRADICTION_TRIAGE_BENCH/README.md :: Current foundation and boundary` with the supported adapter and diagnostic contract.

## BuilderOps Routing
- Records/projections/receipts: local epic run-state `cognitive-experiments-3543-20260713`; LearningSignal `lrn_20260713135209_cdd84ba6`
- Reason: the CI selector initially had no curation owner; the PR now repairs `scripts/select_pr_tests.py :: SUBSYSTEMS` and records the workflow divergence