### PR TITLE
feat: add read-only ASK provenance shadow (#3546)

### DIFF
--- a/app/agent_memory/ask_provenance_manifest.py
+++ b/app/agent_memory/ask_provenance_manifest.py
@@ -12,6 +12,7 @@ import hmac
 import json
 import logging
 import os
+import re
 import tempfile
 import threading
 import time
@@ -36,6 +37,7 @@ _JANITOR_LOCK = threading.Lock()
 _CAPTURE_QUEUE: Queue[dict[str, Any]] = Queue(maxsize=64)
 _CAPTURE_WORKER_LOCK = threading.Lock()
 _CAPTURE_WORKER_STARTED = False
+_DIGEST_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 
 
 @dataclass(frozen=True)
@@ -108,7 +110,7 @@ def _validate_identity_record(record: Any, *, value_field: str) -> None:
         if (
             set(record) != {"status", value_field}
             or not isinstance(record.get(value_field), str)
-            or not record[value_field]
+            or not _DIGEST_PATTERN.fullmatch(record[value_field])
         ):
             raise ValueError("available identity requires a non-empty value")
         return
@@ -137,9 +139,14 @@ def _validate_manifest(manifest: Mapping[str, Any]) -> None:
     }
     if set(manifest) != required or manifest.get("schema") != SCHEMA:
         raise ValueError("invalid ASK provenance manifest shape")
-    for field in ("manifest_id", "captured_at", "expires_at", "answer_hash", "query_hash"):
+    for field in ("manifest_id", "captured_at", "expires_at"):
         if not isinstance(manifest.get(field), str) or not manifest[field]:
             raise ValueError(f"invalid manifest field: {field}")
+    for field in ("answer_hash", "query_hash"):
+        if not isinstance(manifest.get(field), str) or not _DIGEST_PATTERN.fullmatch(
+            manifest[field]
+        ):
+            raise ValueError(f"invalid manifest digest: {field}")
     captured_at = datetime.fromisoformat(manifest["captured_at"].replace("Z", "+00:00"))
     expires_at = datetime.fromisoformat(manifest["expires_at"].replace("Z", "+00:00"))
     if captured_at.utcoffset() is None or expires_at.utcoffset() is None:
@@ -163,14 +170,18 @@ def _validate_manifest(manifest: Mapping[str, Any]) -> None:
     principal_reason = authorization["principal_unavailable_reason"]
     if (principal_hash is None) == (principal_reason is None):
         raise ValueError("principal identity must be available xor unavailable")
-    if principal_hash is not None and (not isinstance(principal_hash, str) or not principal_hash):
+    if principal_hash is not None and (
+        not isinstance(principal_hash, str) or not _DIGEST_PATTERN.fullmatch(principal_hash)
+    ):
         raise ValueError("invalid principal hash")
     if principal_reason is not None and (
         not isinstance(principal_reason, str) or not principal_reason
     ):
         raise ValueError("invalid principal unavailable reason")
     for field in ("authorization_context_hash", "policy_hash"):
-        if not isinstance(authorization[field], str) or not authorization[field]:
+        if not isinstance(authorization[field], str) or not _DIGEST_PATTERN.fullmatch(
+            authorization[field]
+        ):
             raise ValueError(f"invalid authorization field: {field}")
     for position, item in enumerate(manifest["ordered_evidence"]):
         if not isinstance(item, Mapping) or set(item) != {
@@ -181,6 +192,10 @@ def _validate_manifest(manifest: Mapping[str, Any]) -> None:
             raise ValueError("invalid ordered evidence")
         if item.get("position") != position:
             raise ValueError("evidence order is not canonical")
+        if not isinstance(item.get("source_id_hash"), str) or not _DIGEST_PATTERN.fullmatch(
+            item["source_id_hash"]
+        ):
+            raise ValueError("invalid evidence source hash")
         source_hash = item.get("canonical_source_hash")
         _validate_identity_record(source_hash, value_field="value")
     identities = manifest.get("identities")

--- a/app/agent_memory/ask_provenance_manifest.py
+++ b/app/agent_memory/ask_provenance_manifest.py
@@ -1,0 +1,386 @@
+"""Local, read-only shadow manifests for grounded ASK executions.
+
+The capture seam is deliberately downstream of ASK synthesis and never feeds
+the response path.  Records contain hashes and observed identities only; an
+unobserved identity is explicit and makes comparison fail closed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+import tempfile
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+from uuid import uuid4
+
+logger = logging.getLogger(__name__)
+
+SCHEMA = "ask_provenance_manifest.v1"
+DEFAULT_PATH = Path("runtime/agent_memory/ask_provenance_manifests.jsonl")
+DEFAULT_RETENTION_DAYS = 14
+DEFAULT_LATENCY_BUDGET_MS = 10
+DEFAULT_MAX_RECORDS = 256
+
+
+@dataclass(frozen=True)
+class AuthorizationSnapshot:
+    """The current, actual read context used to capture or compare a run."""
+
+    scope_id: str
+    principal_id: str
+    authorization_context: Mapping[str, Any]
+    policy: Mapping[str, Any]
+    authorized_source_ids: tuple[str, ...] = ()
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _sha256(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _privacy_hash(value: str, key: bytes) -> str:
+    return hmac.new(key, value.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def _normalize_scope(value: str) -> str:
+    return " ".join(value.strip().split()).casefold() or "scope:unscoped"
+
+
+def _identity(value: Any, *, unavailable_reason: str) -> dict[str, str]:
+    if value is None or value == "" or value == {}:
+        return {"status": "unavailable", "reason": unavailable_reason}
+    return {"status": "available", "value_hash": _sha256(_canonical_json(value))}
+
+
+def _source_hash(value: Any) -> dict[str, str]:
+    if not isinstance(value, str) or not value.strip():
+        return {"status": "unavailable", "reason": "canonical_source_hash_not_observed"}
+    return {"status": "available", "value": value.strip()}
+
+
+def _privacy_key(explicit: bytes | None) -> bytes | None:
+    if explicit:
+        return explicit
+    configured = os.getenv("ASK_PROVENANCE_PRIVACY_KEY", "").encode("utf-8")
+    return configured or None
+
+
+def _manifest_path(explicit: Path | None) -> Path:
+    configured = os.getenv("ASK_PROVENANCE_MANIFEST_PATH")
+    return explicit or (Path(configured).expanduser() if configured else DEFAULT_PATH)
+
+
+def _validate_manifest(manifest: Mapping[str, Any]) -> None:
+    required = {
+        "schema",
+        "manifest_id",
+        "captured_at",
+        "expires_at",
+        "answer_hash",
+        "query_hash",
+        "authorization",
+        "ordered_evidence",
+        "identities",
+    }
+    if set(manifest) != required or manifest.get("schema") != SCHEMA:
+        raise ValueError("invalid ASK provenance manifest shape")
+    if not isinstance(manifest.get("ordered_evidence"), list):
+        raise ValueError("ordered_evidence must be a list")
+    authorization = manifest.get("authorization")
+    if not isinstance(authorization, Mapping) or set(authorization) != {
+        "scope_id",
+        "principal_hash",
+        "authorization_context_hash",
+        "policy_hash",
+    }:
+        raise ValueError("invalid authorization snapshot")
+    for position, item in enumerate(manifest["ordered_evidence"]):
+        if not isinstance(item, Mapping) or set(item) != {
+            "position",
+            "source_id_hash",
+            "canonical_source_hash",
+        }:
+            raise ValueError("invalid ordered evidence")
+        if item.get("position") != position:
+            raise ValueError("evidence order is not canonical")
+        source_hash = item.get("canonical_source_hash")
+        if not isinstance(source_hash, Mapping) or source_hash.get("status") not in {
+            "available",
+            "unavailable",
+        }:
+            raise ValueError("invalid canonical source hash")
+    identities = manifest.get("identities")
+    if not isinstance(identities, Mapping) or set(identities) != {
+        "canonical_index",
+        "synthesis",
+    }:
+        raise ValueError("invalid identity set")
+    encoded = _canonical_json(manifest)
+    if "raw_text" in encoded or "source_ref" in encoded or "credential" in encoded:
+        raise ValueError("forbidden raw field in ASK provenance manifest")
+
+
+def _append_manifest(
+    path: Path, manifest: Mapping[str, Any], *, max_records: int = DEFAULT_MAX_RECORDS
+) -> None:
+    # A configured vault/index destination would violate the local shadow-state
+    # boundary.  The default and supported override are runtime-state paths.
+    if any(part.casefold() in {"vault", "index"} for part in path.parts):
+        raise ValueError("ASK provenance manifests cannot be stored in vault/index paths")
+    _validate_manifest(manifest)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing = (
+        [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+        if path.exists()
+        else []
+    )
+    for record in existing:
+        _validate_manifest(record)
+    captured_at = datetime.fromisoformat(str(manifest["captured_at"]).replace("Z", "+00:00"))
+    retained = [
+        record
+        for record in existing
+        if datetime.fromisoformat(record["expires_at"].replace("Z", "+00:00")) > captured_at
+    ]
+    keep_count = max(0, max_records - 1)
+    retained_tail = retained[-keep_count:] if keep_count else []
+    records = [*retained_tail, manifest]
+    # Publish the complete append atomically. A disk/process failure before
+    # replace leaves the previous valid log untouched, never a partial record.
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write("".join(_canonical_json(record) + "\n" for record in records))
+            handle.flush()
+            os.fsync(handle.fileno())
+        temporary.chmod(0o600)
+        temporary.replace(path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def capture_ask_provenance(
+    *,
+    answer: str,
+    query: str,
+    evidence: Sequence[Mapping[str, Any]],
+    authorization: AuthorizationSnapshot,
+    retrieval_identity: Any = None,
+    synthesis_identity: Any = None,
+    path: Path | None = None,
+    privacy_key: bytes | None = None,
+    retention_days: int = DEFAULT_RETENTION_DAYS,
+    latency_budget_ms: int = DEFAULT_LATENCY_BUDGET_MS,
+    clock: Callable[[], float] = time.monotonic,
+    now: datetime | None = None,
+) -> dict[str, Any] | None:
+    """Best-effort capture; every failure is isolated from the ASK result."""
+
+    started = clock()
+    try:
+        key = _privacy_key(privacy_key)
+        if key is None:
+            raise ValueError("privacy key unavailable")
+        captured_at = now or datetime.now(timezone.utc)
+        ordered_evidence = []
+        for position, item in enumerate(evidence):
+            source_id = str(item.get("source_id") or "").strip()
+            if not source_id:
+                raise ValueError("evidence source identity unavailable")
+            ordered_evidence.append(
+                {
+                    "position": position,
+                    "source_id_hash": _privacy_hash(source_id, key),
+                    "canonical_source_hash": _source_hash(item.get("canonical_source_hash")),
+                }
+            )
+        manifest: dict[str, Any] = {
+            "schema": SCHEMA,
+            "manifest_id": f"ask-prov:{uuid4().hex}",
+            "captured_at": captured_at.isoformat().replace("+00:00", "Z"),
+            "expires_at": (captured_at + timedelta(days=max(1, retention_days)))
+            .isoformat()
+            .replace("+00:00", "Z"),
+            "answer_hash": _sha256(answer),
+            "query_hash": _privacy_hash(query, key),
+            "authorization": {
+                "scope_id": _normalize_scope(authorization.scope_id),
+                "principal_hash": _privacy_hash(authorization.principal_id, key),
+                "authorization_context_hash": _sha256(
+                    _canonical_json(authorization.authorization_context)
+                ),
+                "policy_hash": _sha256(_canonical_json(authorization.policy)),
+            },
+            "ordered_evidence": ordered_evidence,
+            "identities": {
+                "canonical_index": _identity(
+                    retrieval_identity,
+                    unavailable_reason="canonical_index_identity_not_observed",
+                ),
+                "synthesis": _identity(
+                    synthesis_identity,
+                    unavailable_reason="synthesis_identity_not_observed",
+                ),
+            },
+        }
+        _validate_manifest(manifest)
+        if (clock() - started) * 1000 > max(0, latency_budget_ms):
+            raise TimeoutError("ASK provenance capture latency budget exceeded")
+        _append_manifest(_manifest_path(path), manifest)
+        return manifest
+    except Exception as exc:
+        logger.warning("ask.provenance capture skipped: %s", type(exc).__name__)
+        return None
+
+
+def _status_value(record: Mapping[str, Any]) -> str | None:
+    return (
+        str(record.get("value") or record.get("value_hash") or "")
+        if record.get("status") == "available"
+        else None
+    )
+
+
+def compare_manifests(
+    left: Mapping[str, Any],
+    right: Mapping[str, Any],
+    *,
+    current_authorization: AuthorizationSnapshot,
+    privacy_key: bytes | None = None,
+) -> dict[str, Any]:
+    """Compare under current authorization, returning no side-specific detail."""
+
+    key = _privacy_key(privacy_key)
+    if key is None:
+        return {"classification": "indeterminate", "reason": "privacy_key_unavailable"}
+    try:
+        _validate_manifest(left)
+        _validate_manifest(right)
+    except (TypeError, ValueError):
+        return {"classification": "indeterminate", "reason": "manifest_invalid"}
+
+    current = {
+        "scope_id": _normalize_scope(current_authorization.scope_id),
+        "principal_hash": _privacy_hash(current_authorization.principal_id, key),
+        "authorization_context_hash": _sha256(
+            _canonical_json(current_authorization.authorization_context)
+        ),
+        "policy_hash": _sha256(_canonical_json(current_authorization.policy)),
+    }
+    axes: list[str] = []
+    axis_fields = (
+        ("scope", "scope_id"),
+        ("principal", "principal_hash"),
+        ("authorization_context", "authorization_context_hash"),
+        ("policy", "policy_hash"),
+    )
+    for axis, field in axis_fields:
+        if (
+            left["authorization"].get(field) != right["authorization"].get(field)
+            or left["authorization"].get(field) != current[field]
+        ):
+            axes.append(axis)
+
+    authorized = {
+        _privacy_hash(source_id, key) for source_id in current_authorization.authorized_source_ids
+    }
+    referenced = {
+        str(item.get("source_id_hash") or "")
+        for manifest in (left, right)
+        for item in manifest["ordered_evidence"]
+    }
+    if not referenced.issubset(authorized):
+        axes.append("authorization")
+    if axes:
+        return {"classification": "scope_mismatch", "mismatch_axes": axes}
+
+    left_index = _status_value(left["identities"]["canonical_index"])
+    right_index = _status_value(right["identities"]["canonical_index"])
+    if left_index is None or right_index is None:
+        return {"classification": "indeterminate", "reason": "canonical_index_identity_unavailable"}
+
+    left_evidence = left["ordered_evidence"]
+    right_evidence = right["ordered_evidence"]
+    if [item["source_id_hash"] for item in left_evidence] != [
+        item["source_id_hash"] for item in right_evidence
+    ]:
+        return {"classification": "indeterminate", "reason": "admitted_evidence_changed"}
+    left_hashes = [_status_value(item["canonical_source_hash"]) for item in left_evidence]
+    right_hashes = [_status_value(item["canonical_source_hash"]) for item in right_evidence]
+    if any(value is None for value in (*left_hashes, *right_hashes)):
+        return {"classification": "indeterminate", "reason": "canonical_source_hash_unavailable"}
+    if left_hashes != right_hashes:
+        return {"classification": "source_drift"}
+    if left_index != right_index:
+        return {"classification": "index_drift"}
+
+    left_synthesis = _status_value(left["identities"]["synthesis"])
+    right_synthesis = _status_value(right["identities"]["synthesis"])
+    if left_synthesis is None or right_synthesis is None:
+        return {"classification": "indeterminate", "reason": "synthesis_identity_unavailable"}
+    if left_synthesis != right_synthesis or left["answer_hash"] != right["answer_hash"]:
+        return {
+            "classification": "indeterminate",
+            "reason": "unsupported_answer_or_synthesis_drift",
+        }
+    return {"classification": "reproducible"}
+
+
+def prune_expired_manifests(path: Path, *, now: str | datetime | None = None) -> int:
+    """Deterministically remove expired local records without any sync path."""
+
+    if not path.exists():
+        return 0
+    instant = (
+        datetime.fromisoformat(now.replace("Z", "+00:00"))
+        if isinstance(now, str)
+        else (now or datetime.now(timezone.utc))
+    )
+    records = [
+        json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()
+    ]
+    for record in records:
+        _validate_manifest(record)
+    kept = [
+        record
+        for record in records
+        if datetime.fromisoformat(record["expires_at"].replace("Z", "+00:00")) > instant
+    ]
+    removed = len(records) - len(kept)
+    if removed:
+        temporary = path.with_suffix(path.suffix + ".tmp")
+        temporary.write_text(
+            "".join(_canonical_json(record) + "\n" for record in kept), encoding="utf-8"
+        )
+        temporary.chmod(0o600)
+        temporary.replace(path)
+    return removed
+
+
+def shadow_capture_enabled() -> bool:
+    return os.getenv("ASK_PROVENANCE_MANIFEST_ENABLED", "").strip().casefold() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+__all__ = [
+    "AuthorizationSnapshot",
+    "capture_ask_provenance",
+    "compare_manifests",
+    "prune_expired_manifests",
+    "shadow_capture_enabled",
+]

--- a/app/agent_memory/ask_provenance_manifest.py
+++ b/app/agent_memory/ask_provenance_manifest.py
@@ -19,6 +19,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from queue import Full, Queue
 from typing import Any, Mapping, Sequence
 from uuid import uuid4
 
@@ -32,6 +33,9 @@ DEFAULT_RETENTION_DAYS = 14
 DEFAULT_MAX_RECORDS = 256
 _JANITOR_PATHS: set[Path] = set()
 _JANITOR_LOCK = threading.Lock()
+_CAPTURE_QUEUE: Queue[dict[str, Any]] = Queue(maxsize=64)
+_CAPTURE_WORKER_LOCK = threading.Lock()
+_CAPTURE_WORKER_STARTED = False
 
 
 @dataclass(frozen=True)
@@ -85,11 +89,11 @@ def _manifest_path(explicit: Path | None) -> Path:
     path = explicit or (Path(configured).expanduser() if configured else DEFAULT_PATH)
     resolved = path.expanduser().resolve(strict=False)
     if explicit is None:
-        runtime_root = (
-            Path(os.getenv("ASK_PROVENANCE_RUNTIME_ROOT", str(DEFAULT_PATH.parent)))
-            .expanduser()
-            .resolve(strict=False)
-        )
+        lexical_root = (Path.cwd() / DEFAULT_PATH.parent).absolute()
+        for candidate in (lexical_root, lexical_root.parent):
+            if candidate.is_symlink():
+                raise ValueError("ASK provenance runtime root cannot be a symlink")
+        runtime_root = lexical_root.resolve(strict=False)
         if not resolved.is_relative_to(runtime_root):
             raise ValueError("ASK provenance path escapes its dedicated runtime root")
     elif "runtime" not in {part.casefold() for part in resolved.parts}:
@@ -138,6 +142,8 @@ def _validate_manifest(manifest: Mapping[str, Any]) -> None:
             raise ValueError(f"invalid manifest field: {field}")
     captured_at = datetime.fromisoformat(manifest["captured_at"].replace("Z", "+00:00"))
     expires_at = datetime.fromisoformat(manifest["expires_at"].replace("Z", "+00:00"))
+    if captured_at.utcoffset() is None or expires_at.utcoffset() is None:
+        raise ValueError("manifest timestamps must be timezone-aware")
     if expires_at <= captured_at:
         raise ValueError("manifest expiry must follow capture")
     if not isinstance(manifest.get("ordered_evidence"), list):
@@ -338,10 +344,33 @@ def schedule_ask_provenance_capture(**capture_kwargs: Any) -> None:
         logger.warning("ask.provenance scheduling skipped: %s", type(exc).__name__)
         return
     capture_kwargs["path"] = path
+    _ensure_capture_worker()
+    try:
+        _CAPTURE_QUEUE.put_nowait(capture_kwargs)
+    except Full:
+        logger.warning("ask.provenance capture skipped: bounded_queue_full")
+
+
+def _ensure_capture_worker() -> None:
+    """Start the single bounded capture worker once per process."""
+
+    global _CAPTURE_WORKER_STARTED
+    with _CAPTURE_WORKER_LOCK:
+        if _CAPTURE_WORKER_STARTED:
+            return
+        _CAPTURE_WORKER_STARTED = True
+
+    def consume() -> None:
+        while True:
+            capture_kwargs = _CAPTURE_QUEUE.get()
+            try:
+                capture_ask_provenance(**capture_kwargs)
+            finally:
+                _CAPTURE_QUEUE.task_done()
+
     threading.Thread(
-        target=capture_ask_provenance,
-        kwargs=capture_kwargs,
-        name="ask-provenance-capture",
+        target=consume,
+        name="ask-provenance-capture-worker",
         daemon=True,
     ).start()
 
@@ -368,6 +397,20 @@ def _ensure_retention_janitor(path: Path) -> None:
         name="ask-provenance-retention",
         daemon=True,
     ).start()
+
+
+def start_ask_provenance_runtime() -> None:
+    """Initialize pruning and bounded workers from application lifespan."""
+
+    if not shadow_capture_enabled():
+        return
+    try:
+        path = _manifest_path(None)
+        prune_expired_manifests(path)
+        _ensure_retention_janitor(path)
+        _ensure_capture_worker()
+    except Exception as exc:
+        logger.warning("ask.provenance runtime init skipped: %s", type(exc).__name__)
 
 
 def _status_value(record: Mapping[str, Any]) -> str | None:
@@ -398,6 +441,8 @@ def compare_manifests(
         return {"classification": "indeterminate", "reason": "manifest_invalid"}
 
     instant = now or datetime.now(timezone.utc)
+    if instant.utcoffset() is None:
+        return {"classification": "indeterminate", "reason": "comparison_time_invalid"}
     if any(
         datetime.fromisoformat(manifest["expires_at"].replace("Z", "+00:00")) <= instant
         for manifest in (left, right)
@@ -445,6 +490,8 @@ def compare_manifests(
         axes.append("authorization")
     if axes:
         return {"classification": "scope_mismatch", "mismatch_axes": axes}
+    if left["query_hash"] != right["query_hash"]:
+        return {"classification": "indeterminate", "reason": "query_changed"}
 
     left_index = _status_value(left["identities"]["canonical_index"])
     right_index = _status_value(right["identities"]["canonical_index"])
@@ -529,4 +576,5 @@ __all__ = [
     "prune_expired_manifests",
     "schedule_ask_provenance_capture",
     "shadow_capture_enabled",
+    "start_ask_provenance_runtime",
 ]

--- a/app/agent_memory/ask_provenance_manifest.py
+++ b/app/agent_memory/ask_provenance_manifest.py
@@ -13,20 +13,25 @@ import json
 import logging
 import os
 import tempfile
+import threading
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Callable, Mapping, Sequence
+from typing import Any, Mapping, Sequence
 from uuid import uuid4
+
+import fcntl
 
 logger = logging.getLogger(__name__)
 
 SCHEMA = "ask_provenance_manifest.v1"
 DEFAULT_PATH = Path("runtime/agent_memory/ask_provenance_manifests.jsonl")
 DEFAULT_RETENTION_DAYS = 14
-DEFAULT_LATENCY_BUDGET_MS = 10
 DEFAULT_MAX_RECORDS = 256
+_JANITOR_PATHS: set[Path] = set()
+_JANITOR_LOCK = threading.Lock()
 
 
 @dataclass(frozen=True)
@@ -34,7 +39,7 @@ class AuthorizationSnapshot:
     """The current, actual read context used to capture or compare a run."""
 
     scope_id: str
-    principal_id: str
+    principal_id: str | None
     authorization_context: Mapping[str, Any]
     policy: Mapping[str, Any]
     authorized_source_ids: tuple[str, ...] = ()
@@ -77,7 +82,41 @@ def _privacy_key(explicit: bytes | None) -> bytes | None:
 
 def _manifest_path(explicit: Path | None) -> Path:
     configured = os.getenv("ASK_PROVENANCE_MANIFEST_PATH")
-    return explicit or (Path(configured).expanduser() if configured else DEFAULT_PATH)
+    path = explicit or (Path(configured).expanduser() if configured else DEFAULT_PATH)
+    resolved = path.expanduser().resolve(strict=False)
+    if explicit is None:
+        runtime_root = (
+            Path(os.getenv("ASK_PROVENANCE_RUNTIME_ROOT", str(DEFAULT_PATH.parent)))
+            .expanduser()
+            .resolve(strict=False)
+        )
+        if not resolved.is_relative_to(runtime_root):
+            raise ValueError("ASK provenance path escapes its dedicated runtime root")
+    elif "runtime" not in {part.casefold() for part in resolved.parts}:
+        raise ValueError("explicit ASK provenance path must remain under a runtime directory")
+    return resolved
+
+
+def _validate_identity_record(record: Any, *, value_field: str) -> None:
+    if not isinstance(record, Mapping):
+        raise ValueError("identity record must be an object")
+    if record.get("status") == "available":
+        if (
+            set(record) != {"status", value_field}
+            or not isinstance(record.get(value_field), str)
+            or not record[value_field]
+        ):
+            raise ValueError("available identity requires a non-empty value")
+        return
+    if record.get("status") == "unavailable":
+        if (
+            set(record) != {"status", "reason"}
+            or not isinstance(record.get("reason"), str)
+            or not record["reason"]
+        ):
+            raise ValueError("unavailable identity requires a reason")
+        return
+    raise ValueError("identity status must be available or unavailable")
 
 
 def _validate_manifest(manifest: Mapping[str, Any]) -> None:
@@ -94,16 +133,39 @@ def _validate_manifest(manifest: Mapping[str, Any]) -> None:
     }
     if set(manifest) != required or manifest.get("schema") != SCHEMA:
         raise ValueError("invalid ASK provenance manifest shape")
+    for field in ("manifest_id", "captured_at", "expires_at", "answer_hash", "query_hash"):
+        if not isinstance(manifest.get(field), str) or not manifest[field]:
+            raise ValueError(f"invalid manifest field: {field}")
+    captured_at = datetime.fromisoformat(manifest["captured_at"].replace("Z", "+00:00"))
+    expires_at = datetime.fromisoformat(manifest["expires_at"].replace("Z", "+00:00"))
+    if expires_at <= captured_at:
+        raise ValueError("manifest expiry must follow capture")
     if not isinstance(manifest.get("ordered_evidence"), list):
         raise ValueError("ordered_evidence must be a list")
     authorization = manifest.get("authorization")
     if not isinstance(authorization, Mapping) or set(authorization) != {
         "scope_id",
         "principal_hash",
+        "principal_unavailable_reason",
         "authorization_context_hash",
         "policy_hash",
     }:
         raise ValueError("invalid authorization snapshot")
+    if not isinstance(authorization["scope_id"], str) or not authorization["scope_id"]:
+        raise ValueError("scope identity unavailable")
+    principal_hash = authorization["principal_hash"]
+    principal_reason = authorization["principal_unavailable_reason"]
+    if (principal_hash is None) == (principal_reason is None):
+        raise ValueError("principal identity must be available xor unavailable")
+    if principal_hash is not None and (not isinstance(principal_hash, str) or not principal_hash):
+        raise ValueError("invalid principal hash")
+    if principal_reason is not None and (
+        not isinstance(principal_reason, str) or not principal_reason
+    ):
+        raise ValueError("invalid principal unavailable reason")
+    for field in ("authorization_context_hash", "policy_hash"):
+        if not isinstance(authorization[field], str) or not authorization[field]:
+            raise ValueError(f"invalid authorization field: {field}")
     for position, item in enumerate(manifest["ordered_evidence"]):
         if not isinstance(item, Mapping) or set(item) != {
             "position",
@@ -114,20 +176,33 @@ def _validate_manifest(manifest: Mapping[str, Any]) -> None:
         if item.get("position") != position:
             raise ValueError("evidence order is not canonical")
         source_hash = item.get("canonical_source_hash")
-        if not isinstance(source_hash, Mapping) or source_hash.get("status") not in {
-            "available",
-            "unavailable",
-        }:
-            raise ValueError("invalid canonical source hash")
+        _validate_identity_record(source_hash, value_field="value")
     identities = manifest.get("identities")
     if not isinstance(identities, Mapping) or set(identities) != {
         "canonical_index",
         "synthesis",
     }:
         raise ValueError("invalid identity set")
+    _validate_identity_record(identities["canonical_index"], value_field="value_hash")
+    _validate_identity_record(identities["synthesis"], value_field="value_hash")
     encoded = _canonical_json(manifest)
     if "raw_text" in encoded or "source_ref" in encoded or "credential" in encoded:
         raise ValueError("forbidden raw field in ASK provenance manifest")
+
+
+@contextmanager
+def _exclusive_manifest_lock(path: Path):
+    """Serialize read/retain/replace across threads and worker processes."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    with lock_path.open("a+", encoding="utf-8") as lock_handle:
+        lock_path.chmod(0o600)
+        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
 
 
 def _append_manifest(
@@ -138,36 +213,39 @@ def _append_manifest(
     if any(part.casefold() in {"vault", "index"} for part in path.parts):
         raise ValueError("ASK provenance manifests cannot be stored in vault/index paths")
     _validate_manifest(manifest)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    existing = (
-        [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
-        if path.exists()
-        else []
-    )
-    for record in existing:
-        _validate_manifest(record)
-    captured_at = datetime.fromisoformat(str(manifest["captured_at"]).replace("Z", "+00:00"))
-    retained = [
-        record
-        for record in existing
-        if datetime.fromisoformat(record["expires_at"].replace("Z", "+00:00")) > captured_at
-    ]
-    keep_count = max(0, max_records - 1)
-    retained_tail = retained[-keep_count:] if keep_count else []
-    records = [*retained_tail, manifest]
-    # Publish the complete append atomically. A disk/process failure before
-    # replace leaves the previous valid log untouched, never a partial record.
-    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
-    temporary = Path(temporary_name)
-    try:
-        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
-            handle.write("".join(_canonical_json(record) + "\n" for record in records))
-            handle.flush()
-            os.fsync(handle.fileno())
-        temporary.chmod(0o600)
-        temporary.replace(path)
-    finally:
-        temporary.unlink(missing_ok=True)
+    with _exclusive_manifest_lock(path):
+        existing = (
+            [
+                json.loads(line)
+                for line in path.read_text(encoding="utf-8").splitlines()
+                if line.strip()
+            ]
+            if path.exists()
+            else []
+        )
+        for record in existing:
+            _validate_manifest(record)
+        captured_at = datetime.fromisoformat(str(manifest["captured_at"]).replace("Z", "+00:00"))
+        retained = [
+            record
+            for record in existing
+            if datetime.fromisoformat(record["expires_at"].replace("Z", "+00:00")) > captured_at
+        ]
+        keep_count = max(0, max_records - 1)
+        retained_tail = retained[-keep_count:] if keep_count else []
+        records = [*retained_tail, manifest]
+        # Publish the complete append atomically while the sidecar lock is held.
+        descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+        temporary = Path(temporary_name)
+        try:
+            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                handle.write("".join(_canonical_json(record) + "\n" for record in records))
+                handle.flush()
+                os.fsync(handle.fileno())
+            temporary.chmod(0o600)
+            temporary.replace(path)
+        finally:
+            temporary.unlink(missing_ok=True)
 
 
 def capture_ask_provenance(
@@ -181,13 +259,10 @@ def capture_ask_provenance(
     path: Path | None = None,
     privacy_key: bytes | None = None,
     retention_days: int = DEFAULT_RETENTION_DAYS,
-    latency_budget_ms: int = DEFAULT_LATENCY_BUDGET_MS,
-    clock: Callable[[], float] = time.monotonic,
     now: datetime | None = None,
 ) -> dict[str, Any] | None:
     """Best-effort capture; every failure is isolated from the ASK result."""
 
-    started = clock()
     try:
         key = _privacy_key(privacy_key)
         if key is None:
@@ -212,11 +287,18 @@ def capture_ask_provenance(
             "expires_at": (captured_at + timedelta(days=max(1, retention_days)))
             .isoformat()
             .replace("+00:00", "Z"),
-            "answer_hash": _sha256(answer),
+            "answer_hash": _privacy_hash(answer, key),
             "query_hash": _privacy_hash(query, key),
             "authorization": {
                 "scope_id": _normalize_scope(authorization.scope_id),
-                "principal_hash": _privacy_hash(authorization.principal_id, key),
+                "principal_hash": (
+                    _privacy_hash(authorization.principal_id, key)
+                    if authorization.principal_id
+                    else None
+                ),
+                "principal_unavailable_reason": (
+                    None if authorization.principal_id else "caller_principal_not_observed"
+                ),
                 "authorization_context_hash": _sha256(
                     _canonical_json(authorization.authorization_context)
                 ),
@@ -235,13 +317,57 @@ def capture_ask_provenance(
             },
         }
         _validate_manifest(manifest)
-        if (clock() - started) * 1000 > max(0, latency_budget_ms):
-            raise TimeoutError("ASK provenance capture latency budget exceeded")
         _append_manifest(_manifest_path(path), manifest)
         return manifest
     except Exception as exc:
         logger.warning("ask.provenance capture skipped: %s", type(exc).__name__)
         return None
+
+
+def schedule_ask_provenance_capture(**capture_kwargs: Any) -> None:
+    """Detach local storage I/O from ASK's response-critical path.
+
+    The daemon worker owns capture/storage failure isolation. Callers receive
+    no manifest-derived state and never wait on locking, retention, or fsync.
+    """
+
+    try:
+        path = _manifest_path(capture_kwargs.get("path"))
+        _ensure_retention_janitor(path)
+    except Exception as exc:
+        logger.warning("ask.provenance scheduling skipped: %s", type(exc).__name__)
+        return
+    capture_kwargs["path"] = path
+    threading.Thread(
+        target=capture_ask_provenance,
+        kwargs=capture_kwargs,
+        name="ask-provenance-capture",
+        daemon=True,
+    ).start()
+
+
+def _ensure_retention_janitor(path: Path) -> None:
+    """Start one daemon janitor per local manifest file."""
+
+    with _JANITOR_LOCK:
+        if path in _JANITOR_PATHS:
+            return
+        _JANITOR_PATHS.add(path)
+
+    def maintain() -> None:
+        interval = max(60, int(os.getenv("ASK_PROVENANCE_RETENTION_SWEEP_SECONDS", "3600")))
+        while True:
+            time.sleep(interval)
+            try:
+                prune_expired_manifests(path)
+            except Exception as exc:
+                logger.warning("ask.provenance retention sweep skipped: %s", type(exc).__name__)
+
+    threading.Thread(
+        target=maintain,
+        name="ask-provenance-retention",
+        daemon=True,
+    ).start()
 
 
 def _status_value(record: Mapping[str, Any]) -> str | None:
@@ -258,6 +384,7 @@ def compare_manifests(
     *,
     current_authorization: AuthorizationSnapshot,
     privacy_key: bytes | None = None,
+    now: datetime | None = None,
 ) -> dict[str, Any]:
     """Compare under current authorization, returning no side-specific detail."""
 
@@ -270,9 +397,23 @@ def compare_manifests(
     except (TypeError, ValueError):
         return {"classification": "indeterminate", "reason": "manifest_invalid"}
 
+    instant = now or datetime.now(timezone.utc)
+    if any(
+        datetime.fromisoformat(manifest["expires_at"].replace("Z", "+00:00")) <= instant
+        for manifest in (left, right)
+    ):
+        return {"classification": "indeterminate", "reason": "manifest_expired"}
+    current_principal = current_authorization.principal_id
+    if (
+        left["authorization"]["principal_hash"] is None
+        or right["authorization"]["principal_hash"] is None
+        or not current_principal
+    ):
+        return {"classification": "indeterminate", "reason": "principal_identity_unavailable"}
+
     current = {
         "scope_id": _normalize_scope(current_authorization.scope_id),
-        "principal_hash": _privacy_hash(current_authorization.principal_id, key),
+        "principal_hash": _privacy_hash(current_principal, key),
         "authorization_context_hash": _sha256(
             _canonical_json(current_authorization.authorization_context)
         ),
@@ -340,32 +481,36 @@ def compare_manifests(
 def prune_expired_manifests(path: Path, *, now: str | datetime | None = None) -> int:
     """Deterministically remove expired local records without any sync path."""
 
-    if not path.exists():
-        return 0
-    instant = (
-        datetime.fromisoformat(now.replace("Z", "+00:00"))
-        if isinstance(now, str)
-        else (now or datetime.now(timezone.utc))
-    )
-    records = [
-        json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()
-    ]
-    for record in records:
-        _validate_manifest(record)
-    kept = [
-        record
-        for record in records
-        if datetime.fromisoformat(record["expires_at"].replace("Z", "+00:00")) > instant
-    ]
-    removed = len(records) - len(kept)
-    if removed:
-        temporary = path.with_suffix(path.suffix + ".tmp")
-        temporary.write_text(
-            "".join(_canonical_json(record) + "\n" for record in kept), encoding="utf-8"
+    with _exclusive_manifest_lock(path):
+        if not path.exists():
+            return 0
+        instant = (
+            datetime.fromisoformat(now.replace("Z", "+00:00"))
+            if isinstance(now, str)
+            else (now or datetime.now(timezone.utc))
         )
-        temporary.chmod(0o600)
-        temporary.replace(path)
-    return removed
+        records = [
+            json.loads(line)
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        for record in records:
+            _validate_manifest(record)
+        kept = [
+            record
+            for record in records
+            if datetime.fromisoformat(record["expires_at"].replace("Z", "+00:00")) > instant
+        ]
+        removed = len(records) - len(kept)
+        if removed:
+            temporary = path.with_suffix(path.suffix + ".tmp")
+            temporary.write_text(
+                "".join(_canonical_json(record) + "\n" for record in kept),
+                encoding="utf-8",
+            )
+            temporary.chmod(0o600)
+            temporary.replace(path)
+        return removed
 
 
 def shadow_capture_enabled() -> bool:
@@ -382,5 +527,6 @@ __all__ = [
     "capture_ask_provenance",
     "compare_manifests",
     "prune_expired_manifests",
+    "schedule_ask_provenance_capture",
     "shadow_capture_enabled",
 ]

--- a/app/agents/ask/graph.py
+++ b/app/agents/ask/graph.py
@@ -22,7 +22,7 @@ from app.agent_memory.recall_explanation import (
 from app.agent_memory.recall_retrieval import RecallCandidate, retrieve_relevant_promoted
 from app.agent_memory.ask_provenance_manifest import (
     AuthorizationSnapshot,
-    capture_ask_provenance,
+    schedule_ask_provenance_capture,
     shadow_capture_enabled,
 )
 from app.agents.ask.state import AgentState, RetrievedHit
@@ -306,10 +306,18 @@ def _capture_provenance_shadow(
     evidence: list[dict[str, Any]] = []
     for source_id in admitted_source_ids:
         hit = hits.get(source_id)
+        provenance = hit.payload.get("provenance") if hit else None
+        canonical_source_hash = (
+            provenance.get("content_hash")
+            if isinstance(provenance, dict)
+            and provenance.get("chunk_policy_version")
+            and provenance.get("pipeline_version")
+            else None
+        )
         evidence.append(
             {
                 "source_id": source_id,
-                "canonical_source_hash": (hit.payload.get("content_hash") if hit else None),
+                "canonical_source_hash": canonical_source_hash,
             }
         )
     policy = {
@@ -319,16 +327,18 @@ def _capture_provenance_shadow(
     }
     authorization_context = {
         "access_mode": envelope.get("access_mode"),
-        "active_workspace_id": envelope.get("active_workspace_id"),
         "allowed_capabilities": envelope.get("allowed_capabilities") or [],
     }
-    capture_ask_provenance(
+    schedule_ask_provenance_capture(
         answer=state.answer,
         query=state.query,
         evidence=evidence,
         authorization=AuthorizationSnapshot(
             scope_id=str(envelope.get("active_scope_id") or "scope:unscoped"),
-            principal_id=str(envelope.get("principal_id") or "principal:unknown"),
+            # The current ASK route has no authenticated caller principal seam.
+            # Record that identity unavailable rather than hashing its historical
+            # placeholder ("principal:ask") as if it were authorization truth.
+            principal_id=None,
             authorization_context=authorization_context,
             policy=policy,
             authorized_source_ids=tuple(admitted_source_ids),

--- a/app/agents/ask/graph.py
+++ b/app/agents/ask/graph.py
@@ -20,6 +20,11 @@ from app.agent_memory.recall_explanation import (
     render_recall_footer,
 )
 from app.agent_memory.recall_retrieval import RecallCandidate, retrieve_relevant_promoted
+from app.agent_memory.ask_provenance_manifest import (
+    AuthorizationSnapshot,
+    capture_ask_provenance,
+    shadow_capture_enabled,
+)
 from app.agents.ask.state import AgentState, RetrievedHit
 from app.agents.ask.utils import build_ask_context, get_ask_settings, llm_answer, score_hit
 from app.config.environment import active_environment
@@ -65,6 +70,7 @@ def _retrieve_node(state: AgentState, *, k: int, ask_settings) -> AgentState:
         ask_score = score_hit(hit)
         enriched.append(_to_retrieved_hit(hit, ask_score=ask_score))
     state.hits = enriched
+    state.retrieval_metadata = dict(getattr(response, "metadata", {}) or {})
     # Content-free scope denials ride the state separately from hits (KERNEL-10): they are
     # scope-level, so later rerank/truncation of hits must never drop them. getattr keeps
     # compatibility with test fakes that return a hits-only response.
@@ -77,7 +83,9 @@ def _rerank_node(state: AgentState, *, ask_settings) -> AgentState:
         return state
     reranker = get_reranker()
     # Order by ask_score first (if present); otherwise use reranker
-    sorted_hits = sorted(state.hits, key=lambda h: (h.ask_score if h.ask_score is not None else 0.0), reverse=True)
+    sorted_hits = sorted(
+        state.hits, key=lambda h: h.ask_score if h.ask_score is not None else 0.0, reverse=True
+    )
 
     class _RRItem:
         def __init__(self, id: str, text: str):
@@ -284,6 +292,52 @@ def _synthesis_source_paths(state: AgentState) -> dict[str, str]:
     return paths
 
 
+def _capture_provenance_shadow(
+    state: AgentState,
+    *,
+    envelope: dict[str, Any],
+    admitted_source_ids: Iterable[str],
+) -> None:
+    """Best-effort post-answer capture with no return path into ASK."""
+
+    if not shadow_capture_enabled() or state.answer is None:
+        return
+    hits = {hit.object_id: hit for hit in state.hits}
+    evidence: list[dict[str, Any]] = []
+    for source_id in admitted_source_ids:
+        hit = hits.get(source_id)
+        evidence.append(
+            {
+                "source_id": source_id,
+                "canonical_source_hash": (hit.payload.get("content_hash") if hit else None),
+            }
+        )
+    policy = {
+        "citation_policy": envelope.get("citation_policy") or {},
+        "mutation_policy": envelope.get("mutation_policy") or {},
+        "execution_policy": envelope.get("execution_policy") or {},
+    }
+    authorization_context = {
+        "access_mode": envelope.get("access_mode"),
+        "active_workspace_id": envelope.get("active_workspace_id"),
+        "allowed_capabilities": envelope.get("allowed_capabilities") or [],
+    }
+    capture_ask_provenance(
+        answer=state.answer,
+        query=state.query,
+        evidence=evidence,
+        authorization=AuthorizationSnapshot(
+            scope_id=str(envelope.get("active_scope_id") or "scope:unscoped"),
+            principal_id=str(envelope.get("principal_id") or "principal:unknown"),
+            authorization_context=authorization_context,
+            policy=policy,
+            authorized_source_ids=tuple(admitted_source_ids),
+        ),
+        retrieval_identity=state.retrieval_metadata.get("canonical_index_identity"),
+        synthesis_identity=state.llm_route,
+    )
+
+
 def _answer_node(state: AgentState, *, ask_settings) -> AgentState:
     if not state.hits and not state.recalled:
         # Preserve the fallback only when neither retrieval nor recall produced context.
@@ -293,7 +347,9 @@ def _answer_node(state: AgentState, *, ask_settings) -> AgentState:
     if state.hits:
         # Default answer: snippet/text of top hit
         top = state.hits[0]
-        fallback = (top.snippet or top.payload.get("text") or top.payload.get("raw_text") or "").strip()
+        fallback = (
+            top.snippet or top.payload.get("text") or top.payload.get("raw_text") or ""
+        ).strip()
     else:
         # Recall-only path: retrieval was empty but guarded recall found supporting memory.
         fallback = _recall_only_fallback(state)
@@ -357,13 +413,20 @@ def _answer_node(state: AgentState, *, ask_settings) -> AgentState:
     # the recall receipt — outside the answer prose, never shown when recall is empty.
     footer = render_recall_footer(state.recalled or [])
     state.answer = f"{answer_text}\n\n{footer}" if footer else answer_text
+    _capture_provenance_shadow(
+        state,
+        envelope=envelope,
+        admitted_source_ids=decision.admitted_artifact_ids,
+    )
     return state
 
 
 def build_ask_graph(ask_settings=None):
     ask_settings = ask_settings or get_ask_settings()
     graph = StateGraph(AgentState)
-    graph.add_node("retrieve", lambda s: _retrieve_node(s, k=TOP_K_INITIAL, ask_settings=ask_settings))
+    graph.add_node(
+        "retrieve", lambda s: _retrieve_node(s, k=TOP_K_INITIAL, ask_settings=ask_settings)
+    )
     graph.add_node("rerank", lambda s: _rerank_node(s, ask_settings=ask_settings))
     graph.add_node("recall", lambda s: _recall_node(s, ask_settings=ask_settings))
     graph.add_node("answer", lambda s: _answer_node(s, ask_settings=ask_settings))

--- a/app/agents/ask/state.py
+++ b/app/agents/ask/state.py
@@ -34,6 +34,9 @@ class AgentState(RuntimeStateModel):
     trace_id: Optional[str] = None
     query: str
     hits: List[RetrievedHit] = Field(default_factory=list)
+    # Authoritative metadata observed on the retrieval response. Shadow
+    # experiments may inspect it, but it never feeds ranking or answer text.
+    retrieval_metadata: dict[str, Any] = Field(default_factory=dict)
     # Content-free scope denials from the retrieval prefilter (KERNEL-10), as plain dicts
     # (ScopeDenial.to_dict()) so they survive the langgraph state round-trip. Scope-level, not
     # per-hit: reranking/truncating hits must never drop them. Carried to the ContextEnvelope

--- a/app/api/app.py
+++ b/app/api/app.py
@@ -207,6 +207,9 @@ def _warm_retrieval_cache() -> None:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    from app.agent_memory.ask_provenance_manifest import start_ask_provenance_runtime
+
+    start_ask_provenance_runtime()
     await _run_index_preflight()
     _log_v6_seam_status()
     _warm_retrieval_cache()

--- a/docs/ASK_PROVENANCE_MANIFEST/README.md
+++ b/docs/ASK_PROVENANCE_MANIFEST/README.md
@@ -27,11 +27,12 @@ requires a local `ASK_PROVENANCE_PRIVACY_KEY`. Records default to restricted
 and are capped at 256 entries. The answer, query, principal, source ids, and
 observed execution identities are hashed; correlation hashes use the local
 privacy key. `ASK_PROVENANCE_MANIFEST_PATH` may relocate the file only within
-the dedicated `ASK_PROVENANCE_RUNTIME_ROOT` (default:
-`runtime/agent_memory`); resolved/symlink escapes are rejected. Capture is
-post-answer and dispatched to a daemon worker, so locking, retention, and
-fsync never block the ASK response. A per-path hourly janitor enforces expiry
-even when no later ASK occurs.
+the fixed repo-local `runtime/agent_memory` root; root/path symlinks and escapes
+are rejected. Capture is post-answer and dispatched through a bounded queue to
+one daemon worker, so locking, retention, and fsync never block the ASK
+response or create unbounded worker threads. Application startup immediately
+prunes expired records and starts a per-path hourly janitor, so expiry remains
+enforced even when no later ASK occurs.
 
 ## Cross-task invariants / interaction safety
 

--- a/docs/ASK_PROVENANCE_MANIFEST/README.md
+++ b/docs/ASK_PROVENANCE_MANIFEST/README.md
@@ -24,9 +24,14 @@ Manifest capture occurs after normal authorization, retrieval, ranking, and answ
 Runtime capture is enabled only with `ASK_PROVENANCE_MANIFEST_ENABLED=1` and
 requires a local `ASK_PROVENANCE_PRIVACY_KEY`. Records default to restricted
 `runtime/agent_memory/ask_provenance_manifests.jsonl`, expire after 14 days,
-and are capped at 256 entries. `ASK_PROVENANCE_MANIFEST_PATH` may relocate that
-local runtime file, but vault and index destinations are rejected. Capture is
-post-answer, bounded, and best-effort: its failure never changes the ASK result.
+and are capped at 256 entries. The answer, query, principal, source ids, and
+observed execution identities are hashed; correlation hashes use the local
+privacy key. `ASK_PROVENANCE_MANIFEST_PATH` may relocate the file only within
+the dedicated `ASK_PROVENANCE_RUNTIME_ROOT` (default:
+`runtime/agent_memory`); resolved/symlink escapes are rejected. Capture is
+post-answer and dispatched to a daemon worker, so locking, retention, and
+fsync never block the ASK response. A per-path hourly janitor enforces expiry
+even when no later ASK occurs.
 
 ## Cross-task invariants / interaction safety
 

--- a/docs/ASK_PROVENANCE_MANIFEST/README.md
+++ b/docs/ASK_PROVENANCE_MANIFEST/README.md
@@ -1,4 +1,4 @@
-State: Specification directory (parent feature issue #3545; first child #3546; no shipped behavior is claimed).
+State: The first executable slice is implemented behind a disabled-by-default local flag; no user-facing Lens is shipped.
 Doc role: Feature specification
 Authority: Defines the ASK provenance-manifest experiment. Subordinate to current retrieval and authorization owner docs for runtime truth.
 Owner: Architecture / retrieval
@@ -19,7 +19,14 @@ Manifest capture occurs after normal authorization, retrieval, ranking, and answ
 
 | Task | Purpose | Status |
 | --- | --- | --- |
-| [CAPTURE_AND_COMPARE_ASK_PROVENANCE.md](CAPTURE_AND_COMPARE_ASK_PROVENANCE.md) | Capture local immutable manifests and safely compare two executions at the identity granularity actually available. | First executable slice |
+| [CAPTURE_AND_COMPARE_ASK_PROVENANCE.md](CAPTURE_AND_COMPARE_ASK_PROVENANCE.md) | Capture local immutable manifests and safely compare two executions at the identity granularity actually available. | Implemented behind disabled-by-default flag (#3546) |
+
+Runtime capture is enabled only with `ASK_PROVENANCE_MANIFEST_ENABLED=1` and
+requires a local `ASK_PROVENANCE_PRIVACY_KEY`. Records default to restricted
+`runtime/agent_memory/ask_provenance_manifests.jsonl`, expire after 14 days,
+and are capped at 256 entries. `ASK_PROVENANCE_MANIFEST_PATH` may relocate that
+local runtime file, but vault and index destinations are rejected. Capture is
+post-answer, bounded, and best-effort: its failure never changes the ASK result.
 
 ## Cross-task invariants / interaction safety
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -5,8 +5,8 @@ Owner: Runtime / operator playbook
 Temporal class: operational
 Review cadence: event-driven
 Source of truth: mixed
-Last reviewed: 2026-07-08
-Last verified against: docs/STATUS.md, docs/ARCHITECTURE.md, docs/ROADMAP.md, docs/HEALTH.md, docs/INFRASTRUCTURE.md, docs/ENVIRONMENTS.md, docs/OBSERVABILITY.md, docs/CONTEXTUAL_RELEVANCE_ENGINE/README.md, app/relevance/now_surface.py, tests/relevance/test_vault_native_moments.py, Makefile, scripts/verify_runtime_stack.sh, merged PRs #1948/#1977/#2115/#2119/#2127/#2128/#2129/#2131/#2135/#2140/#2142, and current repo state at 8e19a275 on 2026-07-08
+Last reviewed: 2026-07-13
+Last verified against: docs/STATUS.md, docs/ARCHITECTURE.md, docs/ROADMAP.md, docs/HEALTH.md, docs/INFRASTRUCTURE.md, docs/ENVIRONMENTS.md, docs/OBSERVABILITY.md, docs/ASK_PROVENANCE_MANIFEST/README.md, docs/CONTEXTUAL_RELEVANCE_ENGINE/README.md, app/agent_memory/ask_provenance_manifest.py, app/relevance/now_surface.py, tests/agent_memory/test_ask_provenance_manifest.py, tests/relevance/test_vault_native_moments.py, Makefile, scripts/verify_runtime_stack.sh, merged PRs #1948/#1977/#2115/#2119/#2127/#2128/#2129/#2131/#2135/#2140/#2142, and current repo state on 2026-07-13
 # Operations Playbook
 
 Use this document as the operator-facing starting point for runtime operations.
@@ -112,6 +112,23 @@ Use `docs/runbooks/UAT_PANEL_WATCHER.md` for the detailed walkthrough and `docs/
 When the issue is startup topology or Compose wiring, switch to `docs/INFRASTRUCTURE.md`.
 When the issue is signal interpretation, switch to `docs/OBSERVABILITY.md`.
 When the issue is health semantics or degraded-state rules, switch to `docs/HEALTH.md`.
+
+## ASK provenance shadow operations
+
+The ASK provenance manifest is an opt-in read-side experiment, not a canonical
+audit store. It is disabled unless `ASK_PROVENANCE_MANIFEST_ENABLED=1` and a
+local `ASK_PROVENANCE_PRIVACY_KEY` is present. Its JSONL file must remain below
+`ASK_PROVENANCE_RUNTIME_ROOT` (default `runtime/agent_memory`); resolved path or
+symlink escapes fail closed, so do not point the root into a vault or index
+surface.
+
+Enabled capture is dispatched after the answer to a daemon worker. File locks,
+atomic replacement, retention, and fsync therefore do not extend ASK response
+latency. Records expire after 14 days, are capped at 256 entries, and an hourly
+per-path janitor removes expired records even if no later ASK occurs. An
+expired, malformed, inaccessible, or identity-incomplete record is not
+comparable and must yield `indeterminate`. Capture/janitor failure is logged
+locally and never changes the ASK response or authorizes a write.
 
 ## Watcher Operations
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -118,14 +118,15 @@ When the issue is health semantics or degraded-state rules, switch to `docs/HEAL
 The ASK provenance manifest is an opt-in read-side experiment, not a canonical
 audit store. It is disabled unless `ASK_PROVENANCE_MANIFEST_ENABLED=1` and a
 local `ASK_PROVENANCE_PRIVACY_KEY` is present. Its JSONL file must remain below
-`ASK_PROVENANCE_RUNTIME_ROOT` (default `runtime/agent_memory`); resolved path or
-symlink escapes fail closed, so do not point the root into a vault or index
+the fixed repo-local `runtime/agent_memory` root; resolved path/root symlinks
+and escapes fail closed, so it cannot be relocated into a vault or index
 surface.
 
-Enabled capture is dispatched after the answer to a daemon worker. File locks,
-atomic replacement, retention, and fsync therefore do not extend ASK response
-latency. Records expire after 14 days, are capped at 256 entries, and an hourly
-per-path janitor removes expired records even if no later ASK occurs. An
+Enabled capture is dispatched after the answer through a bounded queue to one
+daemon worker. File locks, atomic replacement, retention, and fsync therefore
+do not extend ASK response latency or create unbounded worker threads. Records
+expire after 14 days, are capped at 256 entries, and startup pruning plus an
+hourly per-path janitor removes expired records even if no later ASK occurs. An
 expired, malformed, inaccessible, or identity-incomplete record is not
 comparable and must yield `indeterminate`. Capture/janitor failure is logged
 locally and never changes the ASK response or authorizes a write.

--- a/tests/agent_memory/test_ask_provenance_manifest.py
+++ b/tests/agent_memory/test_ask_provenance_manifest.py
@@ -16,6 +16,9 @@ from app.agent_memory.ask_provenance_manifest import (
     start_ask_provenance_runtime,
 )
 
+SOURCE_HASH_A = "a" * 64
+SOURCE_HASH_B = "b" * 64
+
 
 def _snapshot(*, scope: str = "work", principal: str = "owner") -> AuthorizationSnapshot:
     return AuthorizationSnapshot(
@@ -28,7 +31,7 @@ def _snapshot(*, scope: str = "work", principal: str = "owner") -> Authorization
 
 
 def _capture(
-    path: Path, *, source_hash: str = "hash-a", index_identity: str | None = "index-a"
+    path: Path, *, source_hash: str = SOURCE_HASH_A, index_identity: str | None = "index-a"
 ) -> dict:
     if "runtime" not in {part.casefold() for part in path.parts}:
         path = path.parent / "runtime" / path.name
@@ -72,7 +75,7 @@ def test_shadow_capture_preserves_ask_response_and_side_effects(
                     source_ref="vault/private.md",
                     payload={
                         "provenance": {
-                            "content_hash": "hash-a",
+                            "content_hash": SOURCE_HASH_A,
                             "chunk_policy_version": "chunk-v1",
                             "pipeline_version": "pipeline-v1",
                         },
@@ -120,7 +123,7 @@ def test_shadow_capture_preserves_ask_response_and_side_effects(
         record = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
         assert record["ordered_evidence"][0]["canonical_source_hash"] == {
             "status": "available",
-            "value": "hash-a",
+            "value": SOURCE_HASH_A,
         }
         assert record["authorization"]["principal_hash"] is None
         assert (
@@ -153,8 +156,8 @@ def test_manifest_is_minimal_and_privacy_safe(tmp_path: Path) -> None:
 
 
 def test_comparison_classifies_only_supported_drift(tmp_path: Path) -> None:
-    left = _capture(tmp_path / "left.jsonl", source_hash="hash-a")
-    right = _capture(tmp_path / "right.jsonl", source_hash="hash-b")
+    left = _capture(tmp_path / "left.jsonl", source_hash=SOURCE_HASH_A)
+    right = _capture(tmp_path / "right.jsonl", source_hash=SOURCE_HASH_B)
     comparison = compare_manifests(
         left, right, current_authorization=_snapshot(), privacy_key=b"test-only-key"
     )
@@ -179,7 +182,7 @@ def test_comparison_classifies_only_supported_drift(tmp_path: Path) -> None:
     ) == {"classification": "indeterminate", "reason": "manifest_invalid"}
 
     changed_query = json.loads(json.dumps(left))
-    changed_query["query_hash"] = "different-keyed-query-hash"
+    changed_query["query_hash"] = "c" * 64
     assert compare_manifests(
         changed_query,
         left,
@@ -196,6 +199,30 @@ def test_comparison_classifies_only_supported_drift(tmp_path: Path) -> None:
         current_authorization=_snapshot(),
         privacy_key=b"test-only-key",
     ) == {"classification": "indeterminate", "reason": "manifest_invalid"}
+
+    malformed_digest_paths = (
+        ("answer_hash",),
+        ("query_hash",),
+        ("authorization", "principal_hash"),
+        ("authorization", "authorization_context_hash"),
+        ("authorization", "policy_hash"),
+        ("ordered_evidence", 0, "source_id_hash"),
+        ("ordered_evidence", 0, "canonical_source_hash", "value"),
+        ("identities", "canonical_index", "value_hash"),
+        ("identities", "synthesis", "value_hash"),
+    )
+    for field_path in malformed_digest_paths:
+        malformed_digest = json.loads(json.dumps(left))
+        target = malformed_digest
+        for part in field_path[:-1]:
+            target = target[part]
+        target[field_path[-1]] = "x"
+        assert compare_manifests(
+            malformed_digest,
+            left,
+            current_authorization=_snapshot(),
+            privacy_key=b"test-only-key",
+        ) == {"classification": "indeterminate", "reason": "manifest_invalid"}
 
 
 def test_scope_mismatch_redacts_evidence_details(tmp_path: Path) -> None:

--- a/tests/agent_memory/test_ask_provenance_manifest.py
+++ b/tests/agent_memory/test_ask_provenance_manifest.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import hashlib
 import json
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from app.agent_memory.ask_provenance_manifest import (
@@ -8,6 +12,7 @@ from app.agent_memory.ask_provenance_manifest import (
     capture_ask_provenance,
     compare_manifests,
     prune_expired_manifests,
+    schedule_ask_provenance_capture,
 )
 
 
@@ -24,6 +29,8 @@ def _snapshot(*, scope: str = "work", principal: str = "owner") -> Authorization
 def _capture(
     path: Path, *, source_hash: str = "hash-a", index_identity: str | None = "index-a"
 ) -> dict:
+    if "runtime" not in {part.casefold() for part in path.parts}:
+        path = path.parent / "runtime" / path.name
     manifest = capture_ask_provenance(
         answer="Grounded answer",
         query="private question",
@@ -62,7 +69,14 @@ def test_shadow_capture_preserves_ask_response_and_side_effects(
                     score=1.0,
                     snippet="literal",
                     source_ref="vault/private.md",
-                    payload={"content_hash": "hash-a", "domain": "work"},
+                    payload={
+                        "provenance": {
+                            "content_hash": "hash-a",
+                            "chunk_policy_version": "chunk-v1",
+                            "pipeline_version": "pipeline-v1",
+                        },
+                        "domain": "work",
+                    },
                 )
             ],
         )
@@ -81,6 +95,7 @@ def test_shadow_capture_preserves_ask_response_and_side_effects(
         str(tmp_path / "runtime" / "activation" / "ask_synthesis_receipts.jsonl"),
     )
     path = tmp_path / "runtime" / "ask_provenance.jsonl"
+    monkeypatch.setenv("ASK_PROVENANCE_RUNTIME_ROOT", str(tmp_path / "runtime"))
     monkeypatch.setenv("ASK_PROVENANCE_MANIFEST_PATH", str(path))
     monkeypatch.setattr("app.api.routes.ask._ensure_hybrid_store_loaded", lambda: None)
     ask_module._HYBRID_WARMED = True
@@ -98,7 +113,20 @@ def test_shadow_capture_preserves_ask_response_and_side_effects(
         assert enabled.json()["answer"] == disabled.json()["answer"] == "same answer"
         assert enabled.json()["sources"] == disabled.json()["sources"]
         assert enabled.json()["synthesis_source_ids"] == disabled.json()["synthesis_source_ids"]
+        deadline = time.monotonic() + 1
+        while not path.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
         assert path.exists()
+        record = json.loads(path.read_text(encoding="utf-8").splitlines()[0])
+        assert record["ordered_evidence"][0]["canonical_source_hash"] == {
+            "status": "available",
+            "value": "hash-a",
+        }
+        assert record["authorization"]["principal_hash"] is None
+        assert (
+            record["authorization"]["principal_unavailable_reason"]
+            == "caller_principal_not_observed"
+        )
         assert not (tmp_path / "vault").exists()
         assert not (tmp_path / "index").exists()
     finally:
@@ -112,6 +140,7 @@ def test_manifest_is_minimal_and_privacy_safe(tmp_path: Path) -> None:
 
     assert manifest["schema"] == "ask_provenance_manifest.v1"
     assert manifest["answer_hash"]
+    assert manifest["answer_hash"] != hashlib.sha256(b"Grounded answer").hexdigest()
     assert manifest["query_hash"]
     assert manifest["authorization"]["scope_id"] == "work"
     assert [item["position"] for item in manifest["ordered_evidence"]] == [0]
@@ -139,6 +168,15 @@ def test_comparison_classifies_only_supported_drift(tmp_path: Path) -> None:
         "classification": "indeterminate",
         "reason": "canonical_index_identity_unavailable",
     }
+
+    malformed = json.loads(json.dumps(left))
+    malformed["identities"]["canonical_index"] = {"status": "available"}
+    assert compare_manifests(
+        malformed,
+        left,
+        current_authorization=_snapshot(),
+        privacy_key=b"test-only-key",
+    ) == {"classification": "indeterminate", "reason": "manifest_invalid"}
 
 
 def test_scope_mismatch_redacts_evidence_details(tmp_path: Path) -> None:
@@ -197,7 +235,7 @@ def test_scope_mismatch_redacts_evidence_details(tmp_path: Path) -> None:
 def test_capture_failure_isolated_from_ask(tmp_path: Path, monkeypatch) -> None:
     from app.agent_memory import ask_provenance_manifest as module
 
-    path = tmp_path / "manifest.jsonl"
+    path = tmp_path / "runtime" / "manifest.jsonl"
     monkeypatch.setattr(
         module, "_append_manifest", lambda *_a, **_k: (_ for _ in ()).throw(OSError("disk full"))
     )
@@ -217,6 +255,7 @@ def test_manifest_retention_is_local_and_bounded(tmp_path: Path) -> None:
     path = tmp_path / "runtime" / "manifests.jsonl"
     expired = _capture(path)
     fresh = _capture(path)
+    expired["captured_at"] = "2019-01-01T00:00:00Z"
     expired["expires_at"] = "2020-01-01T00:00:00Z"
     fresh["expires_at"] = "2030-01-01T00:00:00Z"
     path.write_text(
@@ -228,18 +267,83 @@ def test_manifest_retention_is_local_and_bounded(tmp_path: Path) -> None:
     assert records == [fresh]
     assert not (tmp_path / "vault").exists()
 
+    expired_for_comparison = json.loads(json.dumps(fresh))
+    expired_for_comparison["captured_at"] = "2019-01-01T00:00:00Z"
+    expired_for_comparison["expires_at"] = "2020-01-01T00:00:00Z"
+    assert compare_manifests(
+        expired_for_comparison,
+        fresh,
+        current_authorization=_snapshot(),
+        privacy_key=b"test-only-key",
+    ) == {"classification": "indeterminate", "reason": "manifest_expired"}
 
-def test_shadow_capture_respects_latency_budget(tmp_path: Path) -> None:
-    ticks = iter((0.0, 0.050))
+
+def test_manifest_path_rejects_runtime_symlink_escape(tmp_path: Path) -> None:
+    outside = tmp_path / "Yggdrasil"
+    outside.mkdir()
+    runtime_link = tmp_path / "runtime"
+    runtime_link.symlink_to(outside, target_is_directory=True)
+
     result = capture_ask_provenance(
         answer="answer",
         query="q",
         evidence=[],
         authorization=_snapshot(),
-        path=tmp_path / "manifest.jsonl",
+        path=runtime_link / "manifest.jsonl",
         privacy_key=b"test-only-key",
-        latency_budget_ms=10,
-        clock=lambda: next(ticks),
     )
+
     assert result is None
-    assert not (tmp_path / "manifest.jsonl").exists()
+    assert not (outside / "manifest.jsonl").exists()
+
+
+def test_shadow_capture_respects_latency_budget(tmp_path: Path, monkeypatch) -> None:
+    from app.agent_memory import ask_provenance_manifest as module
+
+    entered = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+
+    def slow_append(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        entered.set()
+        release.wait(timeout=1)
+        finished.set()
+
+    monkeypatch.setattr(module, "_append_manifest", slow_append)
+    started = time.monotonic()
+    schedule_ask_provenance_capture(
+        answer="answer",
+        query="q",
+        evidence=[],
+        authorization=_snapshot(),
+        path=tmp_path / "runtime" / "manifest.jsonl",
+        privacy_key=b"test-only-key",
+    )
+    elapsed = time.monotonic() - started
+
+    assert entered.wait(timeout=1)
+    assert elapsed < 0.1
+    release.set()
+    assert finished.wait(timeout=1)
+
+
+def test_concurrent_capture_does_not_drop_records(tmp_path: Path) -> None:
+    path = tmp_path / "runtime" / "manifests.jsonl"
+
+    def capture(position: int) -> None:
+        result = capture_ask_provenance(
+            answer=f"answer-{position}",
+            query="q",
+            evidence=[],
+            authorization=_snapshot(),
+            path=path,
+            privacy_key=b"test-only-key",
+        )
+        assert result is not None
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        list(executor.map(capture, range(16)))
+
+    records = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+    assert len(records) == 16
+    assert len({record["manifest_id"] for record in records}) == 16

--- a/tests/agent_memory/test_ask_provenance_manifest.py
+++ b/tests/agent_memory/test_ask_provenance_manifest.py
@@ -13,6 +13,7 @@ from app.agent_memory.ask_provenance_manifest import (
     compare_manifests,
     prune_expired_manifests,
     schedule_ask_provenance_capture,
+    start_ask_provenance_runtime,
 )
 
 
@@ -94,8 +95,7 @@ def test_shadow_capture_preserves_ask_response_and_side_effects(
         "ASK_SYNTHESIS_RECEIPTS_PATH",
         str(tmp_path / "runtime" / "activation" / "ask_synthesis_receipts.jsonl"),
     )
-    path = tmp_path / "runtime" / "ask_provenance.jsonl"
-    monkeypatch.setenv("ASK_PROVENANCE_RUNTIME_ROOT", str(tmp_path / "runtime"))
+    path = tmp_path / "runtime" / "agent_memory" / "ask_provenance.jsonl"
     monkeypatch.setenv("ASK_PROVENANCE_MANIFEST_PATH", str(path))
     monkeypatch.setattr("app.api.routes.ask._ensure_hybrid_store_loaded", lambda: None)
     ask_module._HYBRID_WARMED = True
@@ -173,6 +173,25 @@ def test_comparison_classifies_only_supported_drift(tmp_path: Path) -> None:
     malformed["identities"]["canonical_index"] = {"status": "available"}
     assert compare_manifests(
         malformed,
+        left,
+        current_authorization=_snapshot(),
+        privacy_key=b"test-only-key",
+    ) == {"classification": "indeterminate", "reason": "manifest_invalid"}
+
+    changed_query = json.loads(json.dumps(left))
+    changed_query["query_hash"] = "different-keyed-query-hash"
+    assert compare_manifests(
+        changed_query,
+        left,
+        current_authorization=_snapshot(),
+        privacy_key=b"test-only-key",
+    ) == {"classification": "indeterminate", "reason": "query_changed"}
+
+    naive_time = json.loads(json.dumps(left))
+    naive_time["captured_at"] = "2026-01-01T00:00:00"
+    naive_time["expires_at"] = "2026-01-02T00:00:00"
+    assert compare_manifests(
+        naive_time,
         left,
         current_authorization=_snapshot(),
         privacy_key=b"test-only-key",
@@ -278,23 +297,42 @@ def test_manifest_retention_is_local_and_bounded(tmp_path: Path) -> None:
     ) == {"classification": "indeterminate", "reason": "manifest_expired"}
 
 
-def test_manifest_path_rejects_runtime_symlink_escape(tmp_path: Path) -> None:
+def test_manifest_path_rejects_runtime_symlink_escape(tmp_path: Path, monkeypatch) -> None:
     outside = tmp_path / "Yggdrasil"
     outside.mkdir()
     runtime_link = tmp_path / "runtime"
     runtime_link.symlink_to(outside, target_is_directory=True)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(
+        "ASK_PROVENANCE_MANIFEST_PATH",
+        str(runtime_link / "agent_memory" / "manifest.jsonl"),
+    )
 
     result = capture_ask_provenance(
         answer="answer",
         query="q",
         evidence=[],
         authorization=_snapshot(),
-        path=runtime_link / "manifest.jsonl",
         privacy_key=b"test-only-key",
     )
 
     assert result is None
-    assert not (outside / "manifest.jsonl").exists()
+    assert not (outside / "agent_memory" / "manifest.jsonl").exists()
+
+
+def test_runtime_startup_prunes_without_ask(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("ASK_PROVENANCE_MANIFEST_ENABLED", "1")
+    monkeypatch.setenv("ASK_PROVENANCE_PRIVACY_KEY", "test-only-key")
+    path = tmp_path / "runtime" / "agent_memory" / "ask_provenance_manifests.jsonl"
+    expired = _capture(path)
+    expired["captured_at"] = "2019-01-01T00:00:00Z"
+    expired["expires_at"] = "2020-01-01T00:00:00Z"
+    path.write_text(json.dumps(expired) + "\n", encoding="utf-8")
+
+    start_ask_provenance_runtime()
+
+    assert path.read_text(encoding="utf-8") == ""
 
 
 def test_shadow_capture_respects_latency_budget(tmp_path: Path, monkeypatch) -> None:
@@ -323,6 +361,16 @@ def test_shadow_capture_respects_latency_budget(tmp_path: Path, monkeypatch) -> 
 
     assert entered.wait(timeout=1)
     assert elapsed < 0.1
+    assert (
+        len(
+            [
+                thread
+                for thread in threading.enumerate()
+                if thread.name == "ask-provenance-capture-worker"
+            ]
+        )
+        == 1
+    )
     release.set()
     assert finished.wait(timeout=1)
 

--- a/tests/agent_memory/test_ask_provenance_manifest.py
+++ b/tests/agent_memory/test_ask_provenance_manifest.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.agent_memory.ask_provenance_manifest import (
+    AuthorizationSnapshot,
+    capture_ask_provenance,
+    compare_manifests,
+    prune_expired_manifests,
+)
+
+
+def _snapshot(*, scope: str = "work", principal: str = "owner") -> AuthorizationSnapshot:
+    return AuthorizationSnapshot(
+        scope_id=scope,
+        principal_id=principal,
+        authorization_context={"access_mode": "bounded_context_only"},
+        policy={"citation_required": True, "mutation_allowed": False},
+        authorized_source_ids=("source-1",),
+    )
+
+
+def _capture(
+    path: Path, *, source_hash: str = "hash-a", index_identity: str | None = "index-a"
+) -> dict:
+    manifest = capture_ask_provenance(
+        answer="Grounded answer",
+        query="private question",
+        evidence=[{"source_id": "source-1", "canonical_source_hash": source_hash}],
+        authorization=_snapshot(),
+        retrieval_identity=index_identity,
+        synthesis_identity={"provider": "mock", "model": "mock-1"},
+        path=path,
+        privacy_key=b"test-only-key",
+    )
+    assert manifest is not None
+    return manifest
+
+
+def test_shadow_capture_preserves_ask_response_and_side_effects(
+    tmp_path: Path, monkeypatch
+) -> None:
+    from fastapi.testclient import TestClient
+
+    from app.agents.ask import graph as ask_graph
+    from app.api.app import app
+    from app.api.routes import ask as ask_module
+    from app.retrieval.capability import RetrievalHit, RetrievalResponse
+    from app.retrieval.hybrid import get_store
+
+    def fake_retrieve(request):  # type: ignore[no-untyped-def]
+        return RetrievalResponse(
+            query=request.query,
+            trace_id="trace",
+            metadata={"canonical_index_identity": "index-a"},
+            hits=[
+                RetrievalHit(
+                    object_id="source-1",
+                    doc_id="source-1",
+                    text="literal",
+                    score=1.0,
+                    snippet="literal",
+                    source_ref="vault/private.md",
+                    payload={"content_hash": "hash-a", "domain": "work"},
+                )
+            ],
+        )
+
+    monkeypatch.setattr(ask_graph, "retrieve", fake_retrieve)
+    monkeypatch.setattr(ask_graph, "retrieve_relevant_promoted", lambda *_a, **_k: [])
+    monkeypatch.setattr(
+        ask_graph,
+        "llm_answer",
+        lambda *_a, **_k: ("same answer", {"provider": "mock", "model": "mock-1"}),
+    )
+    monkeypatch.setenv("ASK_PROVENANCE_PRIVACY_KEY", "test-only-key")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(
+        "ASK_SYNTHESIS_RECEIPTS_PATH",
+        str(tmp_path / "runtime" / "activation" / "ask_synthesis_receipts.jsonl"),
+    )
+    path = tmp_path / "runtime" / "ask_provenance.jsonl"
+    monkeypatch.setenv("ASK_PROVENANCE_MANIFEST_PATH", str(path))
+    monkeypatch.setattr("app.api.routes.ask._ensure_hybrid_store_loaded", lambda: None)
+    ask_module._HYBRID_WARMED = True
+    client = TestClient(app)
+
+    try:
+        monkeypatch.delenv("ASK_PROVENANCE_MANIFEST_ENABLED", raising=False)
+        disabled = client.post("/api/ask", json={"question": "private question"})
+        assert not path.exists()
+
+        monkeypatch.setenv("ASK_PROVENANCE_MANIFEST_ENABLED", "1")
+        enabled = client.post("/api/ask", json={"question": "private question"})
+
+        assert enabled.status_code == disabled.status_code == 200
+        assert enabled.json()["answer"] == disabled.json()["answer"] == "same answer"
+        assert enabled.json()["sources"] == disabled.json()["sources"]
+        assert enabled.json()["synthesis_source_ids"] == disabled.json()["synthesis_source_ids"]
+        assert path.exists()
+        assert not (tmp_path / "vault").exists()
+        assert not (tmp_path / "index").exists()
+    finally:
+        ask_module._HYBRID_WARMED = False
+        get_store().set_documents([])
+
+
+def test_manifest_is_minimal_and_privacy_safe(tmp_path: Path) -> None:
+    manifest = _capture(tmp_path / "runtime" / "manifests.jsonl")
+    encoded = json.dumps(manifest, sort_keys=True)
+
+    assert manifest["schema"] == "ask_provenance_manifest.v1"
+    assert manifest["answer_hash"]
+    assert manifest["query_hash"]
+    assert manifest["authorization"]["scope_id"] == "work"
+    assert [item["position"] for item in manifest["ordered_evidence"]] == [0]
+    assert manifest["ordered_evidence"][0]["canonical_source_hash"]["status"] == "available"
+    assert manifest["identities"]["canonical_index"]["status"] == "available"
+    for forbidden in ("Grounded answer", "private question", "vault/private.md", "owner"):
+        assert forbidden not in encoded
+    assert "answer" not in manifest
+    assert "query" not in manifest
+
+
+def test_comparison_classifies_only_supported_drift(tmp_path: Path) -> None:
+    left = _capture(tmp_path / "left.jsonl", source_hash="hash-a")
+    right = _capture(tmp_path / "right.jsonl", source_hash="hash-b")
+    comparison = compare_manifests(
+        left, right, current_authorization=_snapshot(), privacy_key=b"test-only-key"
+    )
+    assert comparison == {"classification": "source_drift"}
+
+    right["identities"]["canonical_index"] = {"status": "unavailable", "reason": "not_observed"}
+    comparison = compare_manifests(
+        left, right, current_authorization=_snapshot(), privacy_key=b"test-only-key"
+    )
+    assert comparison == {
+        "classification": "indeterminate",
+        "reason": "canonical_index_identity_unavailable",
+    }
+
+
+def test_scope_mismatch_redacts_evidence_details(tmp_path: Path) -> None:
+    left = _capture(tmp_path / "left.jsonl")
+    right = _capture(tmp_path / "right.jsonl")
+    comparison = compare_manifests(
+        left,
+        right,
+        current_authorization=_snapshot(scope="personal"),
+        privacy_key=b"test-only-key",
+    )
+
+    assert comparison["classification"] == "scope_mismatch"
+    assert comparison["mismatch_axes"] == ["scope"]
+    assert "evidence" not in json.dumps(comparison)
+    assert "source-1" not in json.dumps(comparison)
+
+    mismatch_snapshots = (
+        AuthorizationSnapshot(
+            "work",
+            "someone-else",
+            {"access_mode": "bounded_context_only"},
+            {"citation_required": True, "mutation_allowed": False},
+            ("source-1",),
+        ),
+        AuthorizationSnapshot(
+            "work",
+            "owner",
+            {"access_mode": "different"},
+            {"citation_required": True, "mutation_allowed": False},
+            ("source-1",),
+        ),
+        AuthorizationSnapshot(
+            "work",
+            "owner",
+            {"access_mode": "bounded_context_only"},
+            {"citation_required": False, "mutation_allowed": False},
+            ("source-1",),
+        ),
+        AuthorizationSnapshot(
+            "work",
+            "owner",
+            {"access_mode": "bounded_context_only"},
+            {"citation_required": True, "mutation_allowed": False},
+            (),
+        ),
+    )
+    expected_axes = ("principal", "authorization_context", "policy", "authorization")
+    for snapshot, expected_axis in zip(mismatch_snapshots, expected_axes):
+        redacted = compare_manifests(
+            left, right, current_authorization=snapshot, privacy_key=b"test-only-key"
+        )
+        assert redacted == {"classification": "scope_mismatch", "mismatch_axes": [expected_axis]}
+
+
+def test_capture_failure_isolated_from_ask(tmp_path: Path, monkeypatch) -> None:
+    from app.agent_memory import ask_provenance_manifest as module
+
+    path = tmp_path / "manifest.jsonl"
+    monkeypatch.setattr(
+        module, "_append_manifest", lambda *_a, **_k: (_ for _ in ()).throw(OSError("disk full"))
+    )
+    result = capture_ask_provenance(
+        answer="still succeeds",
+        query="q",
+        evidence=[],
+        authorization=_snapshot(),
+        path=path,
+        privacy_key=b"test-only-key",
+    )
+    assert result is None
+    assert not path.exists()
+
+
+def test_manifest_retention_is_local_and_bounded(tmp_path: Path) -> None:
+    path = tmp_path / "runtime" / "manifests.jsonl"
+    expired = _capture(path)
+    fresh = _capture(path)
+    expired["expires_at"] = "2020-01-01T00:00:00Z"
+    fresh["expires_at"] = "2030-01-01T00:00:00Z"
+    path.write_text(
+        "\n".join(json.dumps(item) for item in (expired, fresh)) + "\n", encoding="utf-8"
+    )
+
+    assert prune_expired_manifests(path, now="2029-01-01T00:00:00Z") == 1
+    records = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+    assert records == [fresh]
+    assert not (tmp_path / "vault").exists()
+
+
+def test_shadow_capture_respects_latency_budget(tmp_path: Path) -> None:
+    ticks = iter((0.0, 0.050))
+    result = capture_ask_provenance(
+        answer="answer",
+        query="q",
+        evidence=[],
+        authorization=_snapshot(),
+        path=tmp_path / "manifest.jsonl",
+        privacy_key=b"test-only-key",
+        latency_budget_ms=10,
+        clock=lambda: next(ticks),
+    )
+    assert result is None
+    assert not (tmp_path / "manifest.jsonl").exists()


### PR DESCRIPTION
Fixes #3546

## Summary
- add disabled-by-default, local-only ask_provenance_manifest.v1 shadow capture after ASK synthesis
- record privacy-safe keyed answer/query/principal and ordered evidence identities with explicit unavailable reasons
- add current-authorization comparator with redacted mismatch results and strict fail-closed validation
- isolate capture from response latency and enforce locked atomic storage, runtime-root confinement, expiry janitor and bounded local retention

## Validation
- focused issue and regression ledger: 32 passed
- selected memory/retrieval SoI: 221 passed, 7 deselected
- ruff check
- python3 scripts/docs_guard.py

## Safety / SBS
Capture is post-answer, read-only, disabled by default, and isolated from ASK success. Missing source/index/synthesis/principal identity produces indeterminate; scope, principal, authorization-context, policy, or current-access mismatch returns content-free mismatch metadata. No raw query, answer, body, excerpt, source path, or credential is stored. The current ASK route has no authenticated caller seam, so its manifest records principal identity unavailable instead of fabricating the legacy principal:ask placeholder.

## Owner docs
Updated docs/ASK_PROVENANCE_MANIFEST/README.md and docs/OPERATIONS.md with the shipped flag, runtime-root storage boundary, background capture, locking, retention janitor, and failure posture.

## BuilderOps Routing
- Records/projections/receipts: dispatcher task github-RasmusTho--agentic-pkm-mvp-issue-3546; verified lease lease-c43ed40c; PR #3593
- Reason: preserve issue-to-code delivery traceability for the claimed implementation lane
- Coordination: dispatcher-backed
- Task: github-RasmusTho--agentic-pkm-mvp-issue-3546
- Lease: lease-c43ed40c
- Holder: codex
- Evidence: verified-dispatcher-lease
- Session: cognitive-experiments-set-20260713