### PR TITLE
Fix static OpenAPI YAML validation selection

### DIFF
--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -114,7 +114,14 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
     ),
     (
         "companion_ui",
-        ("companion-ui/", "app/api/", "api/", "tests/companion_ui/", "tests/api/"),
+        (
+            "companion-ui/",
+            "app/api/",
+            "api/",
+            "tests/companion_ui/",
+            "tests/api/",
+            "tests/architecture/test_openapi_static_contract.py",
+        ),
         (
             "tests/companion_ui",
             "tests/api",

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -119,6 +119,7 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
             "tests/companion_ui",
             "tests/api",
             "tests/architecture/test_openapi_sync.py",
+            "tests/architecture/test_openapi_static_contract.py",
             *E2E_TARGETS["companion_ui"],
         ),
     ),

--- a/tests/architecture/test_openapi_static_contract.py
+++ b/tests/architecture/test_openapi_static_contract.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+OPENAPI_DOCUMENT = Path(__file__).resolve().parents[2] / "api" / "openapi.yaml"
+
+
+def test_static_openapi_yaml_parses() -> None:
+    document = yaml.safe_load(OPENAPI_DOCUMENT.read_text(encoding="utf-8"))
+
+    assert isinstance(document, dict)

--- a/tests/governance/test_select_pr_tests.py
+++ b/tests/governance/test_select_pr_tests.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from scripts.select_pr_tests import select_tests
+
+
+def test_openapi_yaml_change_selects_static_contract_validation() -> None:
+    selection = select_tests(["api/openapi.yaml"])
+
+    assert selection.full_suite is False
+    assert selection.unowned_paths == ()
+    assert "companion_ui" in selection.subsystems
+    assert "tests/architecture/test_openapi_static_contract.py" in selection.targets
+
+
+def test_companion_api_paths_select_api_targets() -> None:
+    selection = select_tests(["companion-ui/companion-app/src/workspace.ts", "tests/api/test_status_api.py"])
+
+    assert "companion_ui" in selection.subsystems
+    assert "tests/companion_ui" in selection.targets
+    assert "tests/api" in selection.targets

--- a/tests/governance/test_select_pr_tests.py
+++ b/tests/governance/test_select_pr_tests.py
@@ -12,6 +12,13 @@ def test_openapi_yaml_change_selects_static_contract_validation() -> None:
     assert "tests/architecture/test_openapi_static_contract.py" in selection.targets
 
 
+def test_static_openapi_contract_test_path_is_owned() -> None:
+    selection = select_tests(["tests/architecture/test_openapi_static_contract.py"])
+
+    assert selection.unowned_paths == ()
+    assert "companion_ui" in selection.subsystems
+
+
 def test_companion_api_paths_select_api_targets() -> None:
     selection = select_tests(["companion-ui/companion-app/src/workspace.ts", "tests/api/test_status_api.py"])
 


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Closes #3563

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): Companion/API contract publication
- Write class: governance/docs/process
- Authority impact: Strengthens the CI test-selection authority for the published static OpenAPI contract.
- Persistence impact: None.
- Derived/rebuildable impact: None.
- Human knowledge impact: None.
- Memory impact: None; Builder System delivery evidence remains separate from runtime/user memory.
- Retrieval/context impact: None.
- Sync/deployment impact: PR validation now executes a focused static OpenAPI YAML parse check when that file changes.
- External boundary impact: Published static OpenAPI contract validation is explicit in PR selection.
- New or changed contract: api/openapi.yaml selects tests/architecture/test_openapi_static_contract.py.
- Owner-doc impact: None; this changes CI enforcement, not shipped API semantics.
- Transition debt impact: Reduces static-contract validation drift.
- Fitness rule impact: Adds an explicit selected test for static YAML validity.
- Boundary risk: Low: Builder System CI selection only; no runtime or API-route behavior changes.

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Routes api/openapi.yaml-only PRs to a focused static YAML parser test.
- Keeps existing companion/API target selection covered without broadening the PR test matrix.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [ ] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [ ] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [x] ruff check app tests
- [x] python3 -m pytest -q tests/scripts/test_select_pr_tests.py tests/governance/test_select_pr_tests.py tests/architecture/test_openapi_static_contract.py -m not-pg (52 passed)
- [x] python3 scripts/select_pr_tests.py --changed-file api/openapi.yaml

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No delivery divergence, operational roadmap movement, or authority crossing beyond the governed issue-backed PR.

## Notes
Dispatcher claim receipt: task_id=github-RasmusTho--agentic-pkm-mvp-issue-3563; lease_id=lease-5109a3d1; evidence=verified-dispatcher-lease. Project Status reconciliation to In Progress was deferred by the repo GraphQL-budget kill switch (91 remaining); Issue/dispatcher truth remains authoritative.