### PR TITLE
Fix temporal import-boundary registration

### DIFF
--- a/importlinter.ini
+++ b/importlinter.ini
@@ -39,6 +39,7 @@ source_modules =
     app.source_understanding
     app.knowledge_compilation
     app.calibration
+    app.temporal
     app.planner
     app.orientation
     app.resurfacing


### PR DESCRIPTION
## Summary

- register the newly shipped non-interaction `app.temporal` package in the interaction-protected import contract
- restore the existing package-coverage architecture test and unblock docs-selected CI on current main

## Scope

One configuration-line correction. No temporal runtime behavior, dependency direction, test assertion, or broader layer contract changes.

## Validation

- `pytest -q tests/architecture/test_import_boundary.py` — 8 passed
- docs-selected non-pg `tests/ci tests/docs tests/architecture` slice — 133 passed
- `git diff --check`

## SBS Impact

- Primary: CES; secondary: SIP
- Write class: governance/config
- Owner-doc impact: no owner-doc change implied
- Restores existing interaction-boundary fitness coverage; no runtime authority or persistence impact

## BuilderOps Routing

- Records/projections/receipts: dispatcher task `github-RasmusTho--agentic-pkm-mvp-issue-3613`, PR link, and post-merge delivery receipt
- Reason: bounded upstream CI-regression repair discovered while delivering #3596; no runtime projection or learning record

Closes #3613
