### PR TITLE
Fix verification dispatch candidate directory

### DIFF
--- a/.github/workflows/verification-dispatch-request.yml
+++ b/.github/workflows/verification-dispatch-request.yml
@@ -70,6 +70,7 @@ jobs:
         id: resolve
         if: steps.inspect.outputs.run_head_sha != ''
         run: |
+          mkdir -p verification-dispatch
           test -f verification-dispatch/pr-candidates.json || printf '[]\n' \
             > verification-dispatch/pr-candidates.json
           python3 - <<'PY'

--- a/tests/governance/test_verification_dispatch_workflow.py
+++ b/tests/governance/test_verification_dispatch_workflow.py
@@ -35,6 +35,20 @@ def test_successful_current_head_emits_dispatch_artifact() -> None:
     assert "github.event.workflow_run.head_sha" in text
 
 
+def test_resolve_step_creates_candidate_directory_before_fallback_write() -> None:
+    text = _workflow_text()
+    resolve_step = text.split("- name: Resolve triggering PR", 1)[1].split(
+        "- name: Fetch current PR and linked issue", 1
+    )[0]
+
+    mkdir_offset = resolve_step.index("mkdir -p verification-dispatch")
+    fallback_offset = resolve_step.index(
+        "test -f verification-dispatch/pr-candidates.json"
+    )
+
+    assert mkdir_offset < fallback_offset
+
+
 def test_workflow_is_artifact_only_and_least_privilege() -> None:
     text = _workflow_text()
     lowered = text.lower()


### PR DESCRIPTION
## Summary
- create the verification-dispatch directory before the resolve-step fallback redirects into pr-candidates.json
- add a workflow-order regression for the exact production failure from Actions run 29270626198
- preserve the artifact-only, least-privilege request contract unchanged

Fixes #3618

## Verification
- red before fix: test_resolve_step_creates_candidate_directory_before_fallback_write failed because mkdir was absent
- pytest -q tests/governance/test_verification_dispatch_workflow.py: 5 passed
- pytest -q tests/governance/test_verification_dispatch_request.py tests/governance/test_verification_dispatch_workflow.py tests/scripts/test_public_seam_lint.py: 26 passed
- python3 -m ruff check tests/governance/test_verification_dispatch_workflow.py: passed
- git diff --check: passed

## BuilderOps Routing
- Records/projections/receipts: GitHub Actions run 29270626198; issue #3618; post-merge verification-dispatch workflow receipt pending.
- Reason: bounded production bug repair for a deterministic filesystem-order failure; no owner-doc change or model escalation implied.
- TCD: deterministic local repair; no capability escalation required.
- Owner-doc: none implied.