### PR TITLE
Make note-UUID allocation single-purpose (#3622)

### DIFF
--- a/app/services/note_uuid.py
+++ b/app/services/note_uuid.py
@@ -9,6 +9,19 @@ from app.write_guard import DEFAULT_WRITE_GUARD
 from scripts.yaml_roundtrip import dump_frontmatter, load_frontmatter
 
 
+def _new_note_uuid() -> str:
+    """Allocate a fresh note-identity UUID.
+
+    This is the single, single-purpose allocation seam for a *note's* identity
+    (#3622). Infrastructure UUIDs generated elsewhere on the write path — e.g.
+    the knowledge adapter's ``.rewrite-swap`` staging name and the
+    ``concurrent-save-*`` conflict-artifact writer identity — are a separate
+    concern and are deliberately not routed through here, so a test that counts
+    note-identity allocations by patching this seam is not confounded by them.
+    """
+    return str(uuid.uuid4())
+
+
 def ensure_note_uuid(path: Path, *, vault_root: Path | str, preferred_uuid: str | None = None) -> str:
     resolved = Path(path).resolve()
     root = Path(vault_root).expanduser().resolve()
@@ -21,7 +34,7 @@ def ensure_note_uuid(path: Path, *, vault_root: Path | str, preferred_uuid: str 
 
     candidate = str(preferred_uuid or "").strip()
     if not candidate:
-        candidate = str(uuid.uuid4())
+        candidate = _new_note_uuid()
     frontmatter["uuid"] = candidate
     DEFAULT_WRITE_GUARD.assert_writes_allowed("ensure uuid")
     write_note_from_absolute(

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -356,10 +356,16 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
             "app/agents/panel/",
             "app/promotion/",
             "app/panel/",
+            # The note-update service is the panel-driven note-body write path
+            # (handle_panel_update / upsert_executed_ids); its regression suite
+            # is tests/services/test_note_update_service.py.
+            "app/services/note_update.py",
+            "app/services/note_uuid.py",
             "tests/agents/panel_agent/",
             "tests/agents/test_panel",
             "tests/promotion/",
             "tests/panel/",
+            "tests/services/test_note_update_service.py",
             "tests/e2e/test_panel_to_promotion_consume.py",
             "tests/e2e/test_panel_watcher_e2e.py",
             "tests/e2e/test_promotion_intent_to_index.py",
@@ -376,6 +382,7 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
             "tests/agents/test_panel_pipeline_integration.py",
             "tests/agents/test_panel_receipts.py",
             "tests/agents/test_panel_writeback_guard.py",
+            "tests/services/test_note_update_service.py",
             "tests/promotion",
             "tests/panel",
             *E2E_TARGETS["promotion_panel"],

--- a/tests/services/test_note_update_service.py
+++ b/tests/services/test_note_update_service.py
@@ -156,11 +156,16 @@ def test_process_note_update_adds_uuid_without_frontmatter(
     generated = uuid.UUID("00000000-0000-0000-0000-00000000A001")
     calls: list[str] = []
 
-    def fake_uuid4() -> uuid.UUID:
+    def fake_new_note_uuid() -> str:
+        # Count only note-identity allocations. Patching the single-purpose
+        # seam (not the global ``uuid.uuid4``) keeps this assertion immune to
+        # the write adapter's infrastructure UUIDs (``.rewrite-swap`` staging
+        # name, ``concurrent-save-*`` conflict-artifact identity), which are a
+        # separate concern and must not be conflated with note identity (#3622).
         calls.append("called")
-        return generated
+        return str(generated)
 
-    monkeypatch.setattr("app.services.note_uuid.uuid.uuid4", fake_uuid4)
+    monkeypatch.setattr("app.services.note_uuid._new_note_uuid", fake_new_note_uuid)
     monkeypatch.setattr("app.settings.panel_actions.load_panel_action_mappings", lambda: _mapping())
     note_path = tmp_path / "note.md"
     note_path.write_text("Just content\n", encoding="utf-8")


### PR DESCRIPTION
Fixes #3622

## Summary
`test_process_note_update_adds_uuid_without_frontmatter` counted UUID allocations by patching the shared global `app.services.note_uuid.uuid.uuid4`, so it also caught the knowledge FS adapter's intended atomic-write infrastructure UUIDs and saw three calls. Note-identity allocation now goes through a single-purpose `_new_note_uuid()` seam, and the counting test patches that seam — asserting exactly one note UUID allocation without conflating unrelated adapter infra UUIDs.

## Premise refinement
The issue framed the two extra calls as "unintended UUID allocations in the note-update path." They are in fact **intended** infra UUIDs in the knowledge FS write adapter (`adapters.py:211` `.rewrite-swap` staging name; `adapters.py:115` `concurrent-save-*` conflict-artifact identity), from the #3570 VMW-01 optimistic-concurrency rewrite-swap. Removing them would weaken write atomicity (out of scope), so the fix makes the note-UUID seam single-purpose rather than deleting adapter UUIDs. Captured as BuilderOps LearningSignal `lrn_20260713222131_bd1cf0bd`.

## Validation
- `pytest -q tests/services/test_note_update_service.py -m "not pg"` — 8 passed (AC1 exactly-one note UUID; AC2 idempotent reprocess preserves UUID).
- Root-caused via stack instrumentation: call #1 `note_uuid.py:24` (note identity), #2 `adapters.py:211`, #3 `adapters.py:115` (adapter infra).
- `ruff check app/services/note_uuid.py tests/services/test_note_update_service.py` — clean.

## BuilderOps Routing
- Records/projections/receipts: LearningSignal `lrn_20260713222131_bd1cf0bd`
- Reason: issue premise diverged from repo reality (adapter infra UUIDs vs note-identity allocation); routed per capture-learning.