### PR TITLE
Add CKM GitHub artifact ingestion

### DIFF
--- a/app/builderops/ckm/ingest_github.py
+++ b/app/builderops/ckm/ingest_github.py
@@ -118,7 +118,7 @@ def _ingest_kind(
     fetch: Callable[[str, str | None], Sequence[Mapping[str, Any]]],
     fetch_kind: str,
     artifact_kind: str,
-) -> dict[str, int | str]:
+) -> tuple[dict[str, int | str], str, str | None, str | None]:
     watermark_key = "github_issues" if artifact_kind == "issue" else "github_pull_requests"
     previous = store.get_watermark(watermark_key)
     records = [normalize_github_payload(item, artifact_kind=artifact_kind) for item in fetch(fetch_kind, previous)]
@@ -137,9 +137,12 @@ def _ingest_kind(
             changed += 1
         if newest is None or record.source_watermark > newest:
             newest = record.source_watermark
-    if newest is not None and newest != previous:
-        store.set_watermark(watermark_key, newest)
-    return {"artifacts": len(records), "changed": changed, "watermark": newest or "(none)"}
+    return (
+        {"artifacts": len(records), "changed": changed, "watermark": newest or "(none)"},
+        watermark_key,
+        previous,
+        newest,
+    )
 
 
 def ingest_github(
@@ -152,10 +155,20 @@ def ingest_github(
     store.ensure_schema()
     try:
         fetch = fetch or _gh_fetch(repository)
-        issues = _ingest_kind(store, fetch=fetch, fetch_kind="issues", artifact_kind="issue")
-        pulls = _ingest_kind(store, fetch=fetch, fetch_kind="pulls", artifact_kind="pull_request")
+        issues, issues_key, issues_previous, issues_newest = _ingest_kind(
+            store, fetch=fetch, fetch_kind="issues", artifact_kind="issue"
+        )
+        pulls, pulls_key, pulls_previous, pulls_newest = _ingest_kind(
+            store, fetch=fetch, fetch_kind="pulls", artifact_kind="pull_request"
+        )
     except FileNotFoundError:
         return {"status": "skipped (gh unavailable)"}
     except subprocess.CalledProcessError as exc:
         return {"status": "skipped (gh unavailable or rate-limited)", "detail": str(exc)}
+    for key, previous, newest in (
+        (issues_key, issues_previous, issues_newest),
+        (pulls_key, pulls_previous, pulls_newest),
+    ):
+        if newest is not None and newest != previous:
+            store.set_watermark(key, newest)
     return {"status": "ok", "issues": issues, "pull_requests": pulls}

--- a/app/builderops/ckm/ingest_github.py
+++ b/app/builderops/ckm/ingest_github.py
@@ -1,0 +1,161 @@
+"""REST-backed GitHub artifact ingestion for CKM-04.
+
+This adapter only reads GitHub delivery artifacts through ``gh api`` and
+writes normalized, rebuildable rows to the CKM BuilderOps store.  A missing or
+temporarily unavailable CLI is an honest skip: no source watermark advances.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Sequence
+
+from app.builderops.ckm.store import CkmStore
+
+DEFAULT_REPOSITORY = "RasmusTho/agentic-pkm-mvp"
+_DOC_REF_RE = re.compile(r"\bdocs/[A-Za-z0-9_./-]+\.md\b")
+_ISSUE_REF_RE = re.compile(r"(?<![\w/])#\d+\b")
+
+
+@dataclass(frozen=True)
+class GithubArtifact:
+    natural_key: str
+    artifact_kind: str
+    payload_summary: str
+    provenance: str
+    source: str
+    source_watermark: str
+
+
+def _labels(payload: Mapping[str, Any]) -> list[str]:
+    values = payload.get("labels", [])
+    return sorted(
+        item["name"] if isinstance(item, Mapping) and isinstance(item.get("name"), str) else str(item)
+        for item in values if isinstance(item, (str, Mapping))
+    )
+
+
+def _references(payload: Mapping[str, Any]) -> list[str]:
+    text = "\n".join(str(payload.get(key, "")) for key in ("body", "title"))
+    refs = {*_DOC_REF_RE.findall(text), *_ISSUE_REF_RE.findall(text)}
+    for key in ("closing_issues_references", "closed_by_pull_requests_references"):
+        for item in payload.get(key, []) or []:
+            if isinstance(item, Mapping) and isinstance(item.get("number"), int):
+                refs.add(f"#{item['number']}")
+    return sorted(refs)
+
+
+def normalize_github_payload(payload: Mapping[str, Any], *, artifact_kind: str) -> GithubArtifact:
+    """Turn one REST object into a typed, provenance-bearing CKM artifact."""
+    number = payload.get("number")
+    updated_at = payload.get("updated_at")
+    if not isinstance(number, int) or not isinstance(updated_at, str) or not updated_at:
+        raise ValueError("GitHub artifact requires integer number and updated_at")
+    if artifact_kind not in {"issue", "pull_request"}:
+        raise ValueError(f"unsupported GitHub artifact kind: {artifact_kind}")
+    key_kind = "issue" if artifact_kind == "issue" else "pull"
+    provenance = {
+        "source_ref": f"github:{key_kind}:{number}",
+        "extraction_method": "github_rest",
+        "number": number,
+        "title": str(payload.get("title", "")),
+        "state": str(payload.get("state", "")),
+        "labels": _labels(payload),
+        "references": _references(payload),
+        "linked_pull_request": payload.get("pull_request"),
+        "closing_references": payload.get("closing_issues_references", []),
+        "changed_files": payload.get("changed_files", [] if artifact_kind == "pull_request" else None),
+        "updated_at": updated_at,
+    }
+    return GithubArtifact(
+        natural_key=f"github:{key_kind}:{number}",
+        artifact_kind=artifact_kind,
+        payload_summary=f"#{number} {provenance['title']} ({provenance['state']})",
+        provenance=json.dumps(provenance, sort_keys=True),
+        source="github_issues" if artifact_kind == "issue" else "github_pull_requests",
+        source_watermark=updated_at,
+    )
+
+
+def _gh_fetch(repository: str) -> Callable[[str, str | None], list[dict[str, Any]]]:
+    def request_list(endpoint: str) -> list[dict[str, Any]]:
+        completed = subprocess.run(
+            ["gh", "api", "--paginate", "--slurp", endpoint],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        pages = json.loads(completed.stdout)
+        if not isinstance(pages, list) or not all(isinstance(page, list) for page in pages):
+            raise ValueError("GitHub REST endpoint returned non-list pages")
+        return [item for page in pages for item in page if isinstance(item, dict)]
+
+    def fetch(kind: str, since: str | None) -> list[dict[str, Any]]:
+        endpoint = f"repos/{repository}/issues?state=all&per_page=100"
+        if kind == "pulls":
+            endpoint = f"repos/{repository}/pulls?state=all&per_page=100"
+        if since:
+            endpoint = f"{endpoint}&since={since}"
+        decoded = request_list(endpoint)
+        if kind == "issues":
+            return [item for item in decoded if "pull_request" not in item]
+        for item in decoded:
+            number = item.get("number")
+            if isinstance(number, int):
+                files = request_list(f"repos/{repository}/pulls/{number}/files?per_page=100")
+                item["changed_files"] = [str(file["filename"]) for file in files if "filename" in file]
+        return decoded
+
+    return fetch
+
+
+def _ingest_kind(
+    store: CkmStore,
+    *,
+    fetch: Callable[[str, str | None], Sequence[Mapping[str, Any]]],
+    fetch_kind: str,
+    artifact_kind: str,
+) -> dict[str, int | str]:
+    watermark_key = "github_issues" if artifact_kind == "issue" else "github_pull_requests"
+    previous = store.get_watermark(watermark_key)
+    records = [normalize_github_payload(item, artifact_kind=artifact_kind) for item in fetch(fetch_kind, previous)]
+    changed = 0
+    newest = previous
+    for record in records:
+        existing = store.get_artifact_by_source_ref(record.natural_key)
+        if existing is None or existing.watermark != record.source_watermark:
+            store.upsert_artifact(
+                source_ref=record.natural_key,
+                artifact_kind=record.artifact_kind,
+                source=record.source,
+                watermark=record.source_watermark,
+                provenance=record.provenance,
+            )
+            changed += 1
+        if newest is None or record.source_watermark > newest:
+            newest = record.source_watermark
+    if newest is not None and newest != previous:
+        store.set_watermark(watermark_key, newest)
+    return {"artifacts": len(records), "changed": changed, "watermark": newest or "(none)"}
+
+
+def ingest_github(
+    store: CkmStore,
+    *,
+    repository: str = DEFAULT_REPOSITORY,
+    fetch: Callable[[str, str | None], Sequence[Mapping[str, Any]]] | None = None,
+) -> dict[str, Any]:
+    """Ingest Issues and pull requests, or return an honest unavailable skip."""
+    store.ensure_schema()
+    try:
+        fetch = fetch or _gh_fetch(repository)
+        issues = _ingest_kind(store, fetch=fetch, fetch_kind="issues", artifact_kind="issue")
+        pulls = _ingest_kind(store, fetch=fetch, fetch_kind="pulls", artifact_kind="pull_request")
+    except FileNotFoundError:
+        return {"status": "skipped (gh unavailable)"}
+    except subprocess.CalledProcessError as exc:
+        return {"status": "skipped (gh unavailable or rate-limited)", "detail": str(exc)}
+    return {"status": "ok", "issues": issues, "pull_requests": pulls}

--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -26,6 +26,7 @@ from app.builderops.ckm_reevaluation import (
     build_ckm_reevaluation_report,
 )
 from app.builderops.ckm.models import CkmValidationError
+from app.builderops.ckm.ingest_github import ingest_github
 from app.builderops.ckm.ingest_repo import ingest_repo
 from app.builderops.ckm.seed import SeedManifestError, seed_capabilities
 from app.builderops.ckm.store import CkmStore
@@ -384,18 +385,36 @@ def ckm_seed(ctx: click.Context) -> None:
     click.echo(f"seeded {result['seeded']} capabilities, {result['changed']} changed")
 
 
-@ckm.command("ingest", help="Ingest deterministic local repository artifacts into the CEG.")
-@click.option("--source", type=click.Choice(["repo"]), required=True)
+@ckm.command("ingest", help="Ingest repository and GitHub delivery artifacts into the CEG.")
+@click.option("--source", type=click.Choice(["repo", "github", "all"]), required=True)
 @click.option("--repo-root", type=click.Path(file_okay=False, path_type=Path), default=Path.cwd)
 @click.option("--git-limit", type=click.IntRange(1, 5000), default=500, show_default=True)
 @click.pass_context
 def ckm_ingest(ctx: click.Context, source: str, repo_root: Path, git_limit: int) -> None:
-    del source  # Reserved for the sibling source adapters documented by the CKM spec.
     try:
-        result = ingest_repo(_ckm_store(ctx), repo_root, git_limit=git_limit)
+        store = _ckm_store(ctx)
+        result: dict[str, Any] = {}
+        if source in {"repo", "all"}:
+            result["repo"] = ingest_repo(store, repo_root, git_limit=git_limit)
+        if source in {"github", "all"}:
+            result["github"] = ingest_github(store)
     except (OSError, ValueError, sqlite3.Error, subprocess.CalledProcessError) as exc:
-        raise click.ClickException(f"ckm repo ingestion failed: {exc}") from exc
-    segments = [f"{name}: {data['artifacts']} artifacts (+{data['changed']})" for name, data in result.items()]
+        raise click.ClickException(f"ckm ingestion failed: {exc}") from exc
+    if source == "github" and result["github"]["status"] != "ok":
+        click.echo(result["github"]["status"])
+        return
+    segments: list[str] = []
+    for name, data in result.get("repo", {}).items():
+        segments.append(f"{name}: {data['artifacts']} artifacts (+{data['changed']})")
+    github = result.get("github")
+    if github:
+        if github["status"] != "ok":
+            segments.append(github["status"])
+        else:
+            segments.extend(
+                f"github {name}: {data['artifacts']} artifacts (+{data['changed']})"
+                for name, data in (("issues", github["issues"]), ("pull_requests", github["pull_requests"]))
+            )
     click.echo("; ".join(segments))
 
 

--- a/tests/builderops/ckm/test_ingest_github.py
+++ b/tests/builderops/ckm/test_ingest_github.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
 from click.testing import CliRunner
@@ -83,6 +84,19 @@ def test_offline_degrade_preserves_watermark_via_entrypoint(tmp_path: Path, monk
     invocation = runner.invoke(builderops, ["--db-path", str(db_path), "ckm", "ingest", "--source", "github"])
     assert invocation.exit_code == 0
     assert "skipped (gh unavailable)" in invocation.output
+
+
+def test_partial_fetch_failure_never_advances_either_watermark(tmp_path: Path) -> None:
+    def partly_unavailable(kind: str, since: str | None) -> list[dict[str, object]]:
+        if kind == "issues":
+            return [_issue()]
+        raise subprocess.CalledProcessError(1, ["gh", "api"])
+
+    result = ingest_github(_store(tmp_path), fetch=partly_unavailable)
+    assert result["status"] == "skipped (gh unavailable or rate-limited)"
+    store = _store(tmp_path)
+    assert store.get_watermark("github_issues") is None
+    assert store.get_watermark("github_pull_requests") is None
 
 
 def test_rest_only_no_graphql() -> None:

--- a/tests/builderops/ckm/test_ingest_github.py
+++ b/tests/builderops/ckm/test_ingest_github.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from app.builderops.cli import builderops
+from app.builderops.ckm.ingest_github import ingest_github, normalize_github_payload
+from app.builderops.ckm.store import CkmStore
+
+
+def _store(tmp_path: Path) -> CkmStore:
+    return CkmStore(tmp_path / "state" / "builderops.sqlite3")
+
+
+def _issue(updated_at: str = "2026-07-01T10:00:00Z") -> dict[str, object]:
+    return {
+        "number": 42,
+        "title": "Document CKM #3138",
+        "state": "open",
+        "updated_at": updated_at,
+        "labels": [{"name": "type:task"}],
+        "body": "See docs/CAPABILITY_KNOWLEDGE_MODEL/README.md and #3138.",
+    }
+
+
+def _pull(updated_at: str = "2026-07-01T10:01:00Z") -> dict[str, object]:
+    return {
+        "number": 77,
+        "title": "Add CKM adapter",
+        "state": "closed",
+        "updated_at": updated_at,
+        "body": "Fixes #42; see docs/CAPABILITY_KNOWLEDGE_MODEL/GITHUB_ARTIFACT_INGESTION.md",
+        "changed_files": ["app/builderops/ckm/ingest_github.py"],
+    }
+
+
+def test_rest_payload_normalization_with_refs() -> None:
+    record = normalize_github_payload(_issue(), artifact_kind="issue")
+    payload = json.loads(record.provenance)
+    assert record.natural_key == "github:issue:42"
+    assert record.artifact_kind == "issue"
+    assert payload["references"] == ["#3138", "docs/CAPABILITY_KNOWLEDGE_MODEL/README.md"]
+    assert payload["labels"] == ["type:task"]
+
+
+def test_updated_at_cursor_incremental(tmp_path: Path) -> None:
+    responses = {"issues": [_issue()], "pulls": [_pull()]}
+
+    def fetch(kind: str, since: str | None) -> list[dict[str, object]]:
+        return responses[kind]
+
+    store = _store(tmp_path)
+    first = ingest_github(store, fetch=fetch)
+    assert first["issues"]["changed"] == 1
+    assert first["pull_requests"]["changed"] == 1
+    assert ingest_github(store, fetch=fetch)["issues"]["changed"] == 0
+
+    responses["issues"] = [_issue("2026-07-02T10:00:00Z")]
+    updated = ingest_github(store, fetch=fetch)
+    assert updated["issues"]["changed"] == 1
+    assert len([item for item in store.list_artifacts() if item.source == "github_issues"]) == 1
+
+
+def test_offline_degrade_preserves_watermark_via_entrypoint(tmp_path: Path, monkeypatch) -> None:
+    store = _store(tmp_path)
+    store.ensure_schema()
+    store.set_watermark("github_issues", "2026-07-01T00:00:00Z")
+
+    def unavailable(kind: str, since: str | None) -> list[dict[str, object]]:
+        raise FileNotFoundError("gh")
+
+    result = ingest_github(store, fetch=unavailable)
+    assert result["status"] == "skipped (gh unavailable)"
+    assert store.get_watermark("github_issues") == "2026-07-01T00:00:00Z"
+
+    monkeypatch.setattr("app.builderops.cli.ingest_github", lambda *_args, **_kwargs: result)
+    db_path = tmp_path / "cli.sqlite3"
+    cli_store = CkmStore(db_path)
+    cli_store.ensure_schema()
+    runner = CliRunner()
+    invocation = runner.invoke(builderops, ["--db-path", str(db_path), "ckm", "ingest", "--source", "github"])
+    assert invocation.exit_code == 0
+    assert "skipped (gh unavailable)" in invocation.output
+
+
+def test_rest_only_no_graphql() -> None:
+    module = Path(__file__).parents[3] / "app/builderops/ckm/ingest_github.py"
+    assert "graphql" not in module.read_text(encoding="utf-8").lower()


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Closes #3142

## SBS Impact
- Primary subsystem: Builder System (BuilderOps plane)
- Secondary subsystem(s): none
- Write class: derived CKM state only
- Authority impact: none; projection-only
- Persistence impact: rebuildable additive CKM tables
- Derived/rebuildable impact: all CKM artifacts are derived and rebuildable
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none at runtime
- Sync/deployment impact: none
- External boundary impact: GitHub REST reads only
- New or changed contract: CKM GitHub ingestion adapter
- Owner-doc impact: none; capability acceptance owns promotion
- Transition debt impact: no effect
- Fitness rule impact: no effect
- Boundary risk: low; read-only external API adapter with offline skip

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Add REST-only GitHub artifact ingestion to the CKM with typed issue and pull-request provenance, incremental watermarks, and an honest offline/rate-limit skip.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [ ] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [ ] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [x] python -m pytest tests/builderops/ckm/test_ingest_github.py -q (4 passed); ruff check app tests (passed); pytest -q -m "not pg" (passed); live temporary-store CLI smoke run twice

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No BuilderOps operational record was produced; the CKM store rows are the issue-scoped derived output.

## Notes
None.
