### PR TITLE
Fix lifecycle claim planner Project gate

### DIFF
--- a/app/builderops/epic_lifecycle_plan.py
+++ b/app/builderops/epic_lifecycle_plan.py
@@ -150,11 +150,9 @@ def _plan_claim(
     labels = set(issue["labels"])
     if "agent:ready" not in labels:
         plan["blocked_reasons"].append("missing-agent-ready-label")
-    if issue["project_status"] != "Ready":
-        plan["blocked_reasons"].append("project-status-not-ready")
     if plan["blocked_reasons"]:
         plan["authority_notes"].append(
-            "Claim planning only proposes mutations for open Ready issues with agent:ready."
+            "Claim planning only proposes mutations for open issues with agent:ready."
         )
         return
 

--- a/tests/builderops/test_epic_lifecycle_plan.py
+++ b/tests/builderops/test_epic_lifecycle_plan.py
@@ -75,6 +75,31 @@ def test_claim_plan_separates_required_reads_and_projection_writes() -> None:
     assert plan["summary"]["no_mutations_performed"] is True
 
 
+def test_claim_plan_allows_missing_optional_project_status() -> None:
+    plan = build_lifecycle_transition_plan(
+        transition="claim",
+        issue=_issue(project_status=None),
+        repo="RasmusTho/agentic-pkm-mvp",
+    )
+
+    assert plan["blocked_reasons"] == []
+    assert [
+        item["action"] for item in plan["proposed_writes"]["issue_project_status"]
+    ] == ["add_to_project", "set_status"]
+    assert plan["proposed_writes"]["issue_project_status"][-1]["value"] == "In Progress"
+
+
+def test_claim_plan_treats_stale_project_status_as_projection_drift() -> None:
+    plan = build_lifecycle_transition_plan(
+        transition="claim",
+        issue=_issue(project_status="Backlog"),
+        repo="RasmusTho/agentic-pkm-mvp",
+    )
+
+    assert plan["blocked_reasons"] == []
+    assert plan["proposed_writes"]["issue_project_status"][0]["value"] == "In Progress"
+
+
 def test_claim_plan_blocks_non_ready_issue_without_writes() -> None:
     plan = build_lifecycle_transition_plan(
         transition="claim",
@@ -83,10 +108,7 @@ def test_claim_plan_blocks_non_ready_issue_without_writes() -> None:
         repo="RasmusTho/agentic-pkm-mvp",
     )
 
-    assert plan["blocked_reasons"] == [
-        "missing-agent-ready-label",
-        "project-status-not-ready",
-    ]
+    assert plan["blocked_reasons"] == ["missing-agent-ready-label"]
     assert plan["proposed_writes"]["issue_labels"] == []
     assert plan["proposed_writes"]["issue_project_status"] == []
 


### PR DESCRIPTION
Fixes #3610

## Summary
- Keep an open `agent:ready` issue claimable when its optional GitHub Project status is absent or stale.
- Preserve deterministic projection-repair suggestions and add regressions for both projection states.

## Validation
- `pytest -q tests/builderops/test_epic_lifecycle_plan.py` — 10 passed
- `ruff check app tests` — passed
- `git diff --check` — passed

## BuilderOps Routing
- Records/projections/receipts: none; existing LearningSignal `lrn_20260713160658_e9835bd8` is the issue's source evidence.
- Reason: this bounded fix resolves the recorded contract drift directly; no new divergence was discovered.

---