### PR TITLE
Restore clean mypy app baseline (#3621)

### DIFF
--- a/app/agent_memory/ask_provenance_manifest.py
+++ b/app/agent_memory/ask_provenance_manifest.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from queue import Full, Queue
-from typing import Any, Mapping, Sequence
+from typing import Any, Iterator, Mapping, Sequence
 from uuid import uuid4
 
 import fcntl
@@ -212,7 +212,7 @@ def _validate_manifest(manifest: Mapping[str, Any]) -> None:
 
 
 @contextmanager
-def _exclusive_manifest_lock(path: Path):
+def _exclusive_manifest_lock(path: Path) -> Iterator[None]:
     """Serialize read/retain/replace across threads and worker processes."""
 
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/app/builderops/ckm/models.py
+++ b/app/builderops/ckm/models.py
@@ -341,7 +341,14 @@ class CkmAssessment:
         return self
 
     @classmethod
-    def from_row(cls, row: Mapping[str, Any], *, scores, citations, watermark_set) -> "CkmAssessment":
+    def from_row(
+        cls,
+        row: Mapping[str, Any],
+        *,
+        scores: Mapping[str, float],
+        citations: Mapping[str, list[JsonDict]],
+        watermark_set: Mapping[str, str],
+    ) -> "CkmAssessment":
         return cls(
             id=row["id"],
             capability_id=row["capability_id"],

--- a/app/builderops/ckm/store.py
+++ b/app/builderops/ckm/store.py
@@ -466,7 +466,9 @@ class CkmStore:
             dimension: _loads(row[f"{dimension}_citations"]) for dimension in MATURITY_DIMENSIONS
         }
         watermark_set = _loads(row["watermark_set"])
-        return CkmAssessment.from_row(row, scores=scores, citations=citations, watermark_set=watermark_set)
+        return CkmAssessment.from_row(
+            dict(row), scores=scores, citations=citations, watermark_set=watermark_set
+        )
 
     # --- Finding -----------------------------------------------------------------
 

--- a/app/builderops/model_inquiry_adapters.py
+++ b/app/builderops/model_inquiry_adapters.py
@@ -12,7 +12,7 @@ import time
 from dataclasses import dataclass
 from typing import Any, Mapping, Protocol
 
-import requests
+import requests  # type: ignore[import-untyped]  # third-party lib ships no type stubs
 
 from app.builderops.model_inquiry_contract import canonical_hash, canonical_json
 from app.builderops.models import BuilderOpsValidationError

--- a/app/heimdal/screen_capture.py
+++ b/app/heimdal/screen_capture.py
@@ -46,10 +46,11 @@ def ingest_screen_bundle(bundle: Mapping[str, Any], *, key: bytes | None = None)
     if shape not in {RAW_CAPTURE_BUNDLE, DERIVED_OBSERVATION}:
         raise ValueError("bundle_shape must be raw_capture_bundle or derived_observation")
     derived_payload = bundle.get("derived_observation")
-    if shape == DERIVED_OBSERVATION and not isinstance(derived_payload, Mapping):
-        raise ValueError("derived_observation bundles require a derived_observation mapping")
-    if shape == DERIVED_OBSERVATION and derived_payload.get("modality") != "screen":
-        raise ValueError("derived_observation modality must be screen")
+    if shape == DERIVED_OBSERVATION:
+        if not isinstance(derived_payload, Mapping):
+            raise ValueError("derived_observation bundles require a derived_observation mapping")
+        if derived_payload.get("modality") != "screen":
+            raise ValueError("derived_observation modality must be screen")
     sensor_data = bundle.get("sensor")
     if not isinstance(sensor_data, Mapping):
         raise ValueError("screen bundle requires sensor {adapter, version, machine}")
@@ -91,6 +92,7 @@ def ingest_screen_bundle(bundle: Mapping[str, Any], *, key: bytes | None = None)
         # The declared on-device path is still admitted through the same
         # guards, then handed directly to the canonical validated publish
         # seam.  It is not a second raw-store or observation writer.
+        assert isinstance(derived_payload, Mapping)  # guaranteed by the shape guard above
         payload = dict(derived_payload)
         provenance = dict(payload.get("provenance") or {})
         provenance.setdefault("content_identity", identity)


### PR DESCRIPTION
Fixes #3621

## Summary
Repairs the type errors that fail `python3 -m mypy app`, behavior-preserving and local to each reported boundary. `mypy app` now reports **no issues in 723 source files**.

## Fixes
- `app/builderops/ckm/models.py` — annotate `CkmAssessment.from_row`'s `scores`/`citations`/`watermark_set` params (were unannotated → `no-untyped-def`).
- `app/builderops/ckm/store.py` — pass `dict(row)` (not `sqlite3.Row`) to `from_row` (`arg-type`).
- `app/agent_memory/ask_provenance_manifest.py` — add `-> Iterator[None]` on the `_exclusive_manifest_lock` contextmanager.
- `app/builderops/model_inquiry_adapters.py` — `# type: ignore[import-untyped]` on the un-stubbed `requests` import.
- `app/heimdal/screen_capture.py` — narrow the optional `derived_observation` payload (nested `isinstance` guard + assert) before `.get()`/`dict()` (two `union-attr`/`arg-type`).

## Drift note
The issue was filed against `7eb3afa2`; on current `origin/main` the `app/dispatcher/control_plane.py` error is already fixed and a new `app/builderops/model_inquiry_adapters.py` un-stubbed-`requests` error appeared. Still six errors / five files; the goal (`mypy app` clean) is unchanged. Fixed the current actual set.

## Validation
- `python3 -m mypy app` — **Success: no issues found in 723 source files** (was 6 errors).
- `ruff check` on all five changed files — clean.
- Focused subsystem tests (ckm store/seed/ingest, model_inquiry suite, ask-provenance) green; one heimdal endpoint test fails **only** on the missing local `python-multipart` dep (identical on unmodified `origin/main`; installed in CI).

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded behavior-preserving type-baseline repair; no plan divergence or authority crossing.