### PR TITLE
Add deterministic CKM evidence linkers

### DIFF
--- a/app/builderops/ckm/ingest_github.py
+++ b/app/builderops/ckm/ingest_github.py
@@ -63,6 +63,7 @@ def normalize_github_payload(payload: Mapping[str, Any], *, artifact_kind: str) 
         "number": number,
         "title": str(payload.get("title", "")),
         "state": str(payload.get("state", "")),
+        "merged_at": payload.get("merged_at"),
         "labels": _labels(payload),
         "references": _references(payload),
         "linked_pull_request": payload.get("pull_request"),

--- a/app/builderops/ckm/ingest_repo.py
+++ b/app/builderops/ckm/ingest_repo.py
@@ -158,6 +158,19 @@ def iter_source(root: Path) -> Iterable[RepoArtifact]:
         )
 
 
+def iter_schemas(root: Path) -> Iterable[RepoArtifact]:
+    for path in sorted((root / "schemas").glob("**/*.json")):
+        content = path.read_bytes()
+        yield _file_artifact(
+            root,
+            path,
+            content=content,
+            kind="document",
+            summary=f"JSON schema: {_relative(root, path)}",
+            source="repo_schemas",
+        )
+
+
 def _git(root: Path, *args: str) -> str:
     return subprocess.run(
         ["git", "-C", str(root), *args], check=True, text=True, capture_output=True
@@ -242,6 +255,7 @@ def ingest_repo(store: CkmStore, root: Path, *, git_limit: int = 500) -> dict[st
         "docs": _ingest_tree(store, "docs", iter_docs(root)),
         "tests": _ingest_tree(store, "tests", iter_tests(root)),
         "source": _ingest_tree(store, "source", iter_source(root)),
+        "schemas": _ingest_tree(store, "schemas", iter_schemas(root)),
     }
     previous_head = store.get_watermark("git")
     # Bind both traversal and the persisted watermark to one immutable snapshot.

--- a/app/builderops/ckm/linkers.py
+++ b/app/builderops/ckm/linkers.py
@@ -21,6 +21,7 @@ _PARENT_RE = re.compile(r"^parent_capability:\s*(.+?)\s*$", re.MULTILINE)
 _LINKER_BASIS_PREFIXES = (
     "matrix:",
     "spec-directory:",
+    "spec-source:",
     "adr-reference:",
     "test-code:",
     "github-spec-ref:",
@@ -70,9 +71,10 @@ def _emit(
     rule: str,
     detail: str,
     desired_edges: set[tuple[str, str, str]],
+    maturity_dimension: str | None = None,
 ) -> int:
     evidence_kind = _kind(artifact)
-    dimension = _dimension(artifact)
+    dimension = maturity_dimension or _dimension(artifact)
     basis = f"{rule}:{detail}"
     desired_edges.add((artifact.id, capability.id, basis))
     existing = store.get_evidence_edge(
@@ -157,7 +159,8 @@ def _spec_links(
         path = root / artifact.source_ref
         if not path.is_file():
             continue
-        match = _PARENT_RE.search(path.read_text(encoding="utf-8"))
+        text = path.read_text(encoding="utf-8")
+        match = _PARENT_RE.search(text)
         if not match:
             continue
         parent = match.group(1).strip().strip('"\'').casefold()
@@ -171,6 +174,18 @@ def _spec_links(
                 detail=artifact.source_ref,
                 desired_edges=desired_edges,
             )
+            for source_ref in sorted(set(_PATH_RE.findall(text))):
+                normalized = source_ref.replace("../", "")
+                source = artifacts.get(normalized)
+                if source is not None and source.artifact_kind == "source_file":
+                    changed += _emit(
+                        store,
+                        source,
+                        capability,
+                        rule="spec-source",
+                        detail=artifact.source_ref,
+                        desired_edges=desired_edges,
+                    )
     return changed
 
 
@@ -245,7 +260,7 @@ def _test_links(
             source = artifacts.get(source_ref)
             if source is None:
                 continue
-            capability_ids = artifact_edges.get(source.id, set()) or artifact_edges.get(test.id, set())
+            capability_ids = artifact_edges.get(source.id, set())
             for capability_id in sorted(capability_ids):
                 capability = capabilities.get(capability_id)
                 if capability:
@@ -278,9 +293,29 @@ def _github_links(
     for artifact in artifacts.values():
         if artifact.artifact_kind not in {"issue", "pull_request"}:
             continue
-        references = _provenance(artifact).get("references", [])
+        provenance = _provenance(artifact)
+        references = provenance.get("references", [])
         if not isinstance(references, list):
             continue
+        labels = provenance.get("labels", [])
+        is_closed_task = (
+            artifact.artifact_kind == "issue"
+            and provenance.get("state") == "closed"
+            and isinstance(labels, list)
+            and "type:task" in labels
+        )
+        is_merged_pr = (
+            artifact.artifact_kind == "pull_request"
+            and isinstance(provenance.get("merged_at"), str)
+            and bool(provenance["merged_at"])
+        )
+        dimension = (
+            "requirement_coverage"
+            if is_closed_task
+            else "functional_completeness"
+            if is_merged_pr
+            else "integration_completeness"
+        )
         emitted: set[str] = set()
         for reference in (str(value) for value in references):
             for spec_path, capability in spec_capabilities.items():
@@ -292,6 +327,7 @@ def _github_links(
                         rule="github-spec-ref",
                         detail=reference,
                         desired_edges=desired_edges,
+                        maturity_dimension=dimension,
                     )
                     emitted.add(capability.id)
         for capability in capabilities:
@@ -306,6 +342,7 @@ def _github_links(
                     rule="github-ref",
                     detail=seed_path,
                     desired_edges=desired_edges,
+                    maturity_dimension=dimension,
                 )
     return changed
 

--- a/app/builderops/ckm/linkers.py
+++ b/app/builderops/ckm/linkers.py
@@ -84,6 +84,19 @@ def _emit(
         maturity_dimension=dimension,
         basis=basis,
     )
+    if (
+        existing is not None
+        and existing.evidence_kind == evidence_kind
+        and existing.polarity == "supports"
+        and existing.maturity_dimension == dimension
+        and existing.confidence == 1.0
+        and existing.extraction_method == "deterministic"
+        and existing.lifecycle == "confirmed"
+        and existing.source_ref == artifact.source_ref
+        and existing.model is None
+        and existing.provider is None
+    ):
+        return 0
     store.upsert_evidence_edge(
         artifact_id=artifact.id,
         capability_id=capability.id,
@@ -241,7 +254,12 @@ def _test_links(
     changed = 0
     artifact_edges: dict[str, set[str]] = {}
     for edge in store.list_evidence_edges():
-        artifact_edges.setdefault(edge.artifact_id, set()).add(edge.capability_id)
+        if (
+            edge.extraction_method == "deterministic"
+            and edge.lifecycle == "confirmed"
+            and edge.basis.startswith(("seed-source:", "spec-source:"))
+        ):
+            artifact_edges.setdefault(edge.artifact_id, set()).add(edge.capability_id)
     capabilities = {capability.id: capability for capability in store.list_capabilities()}
     for test in artifacts.values():
         if test.artifact_kind != "test":
@@ -288,7 +306,14 @@ def _github_links(
     for edge in store.list_evidence_edges():
         linked_artifact = artifact_by_id.get(edge.artifact_id)
         linked_capability = capability_by_id.get(edge.capability_id)
-        if linked_artifact and linked_capability and linked_artifact.artifact_kind == "spec":
+        if (
+            linked_artifact
+            and linked_capability
+            and linked_artifact.artifact_kind == "spec"
+            and edge.extraction_method == "deterministic"
+            and edge.lifecycle == "confirmed"
+            and edge.basis.startswith("spec-directory:")
+        ):
             spec_capabilities[linked_artifact.source_ref] = linked_capability
     for artifact in artifacts.values():
         if artifact.artifact_kind not in {"issue", "pull_request"}:

--- a/app/builderops/ckm/linkers.py
+++ b/app/builderops/ckm/linkers.py
@@ -15,8 +15,17 @@ from app.builderops.ckm.store import CkmStore
 _PATH_RE = re.compile(r"(?:\.\./)*(?:app|docs|tests|schemas)/[A-Za-z0-9_./-]+(?:\.md|\.py|\.json)?")
 _LINK_RE = re.compile(r"\]\(([^)#]+(?:\.md|\.py|\.json))\)")
 _ISSUE_RE = re.compile(r"(?<![\w/])#(\d+)\b")
+_ADR_RE = re.compile(r"\bADR-(\d{4})\b")
 _BOUNDARY_RE = re.compile(r"\b(HIX|WSP|HKA|SIP|GOV|EBF|PDM|DRI|RCA|MEM|CAO|EXE|SFC|OEF|CES)\b")
 _PARENT_RE = re.compile(r"^parent_capability:\s*(.+?)\s*$", re.MULTILINE)
+_LINKER_BASIS_PREFIXES = (
+    "matrix:",
+    "spec-directory:",
+    "adr-reference:",
+    "test-code:",
+    "github-spec-ref:",
+    "github-ref:",
+)
 
 
 def _provenance(artifact: CkmArtifact) -> dict[str, object]:
@@ -53,13 +62,6 @@ def _dimension(artifact: CkmArtifact) -> str:
     }.get(artifact.artifact_kind, "functional_completeness")
 
 
-def _basis(rule: str, artifact: CkmArtifact, detail: str) -> str:
-    return json.dumps(
-        {"artifact_source_ref": artifact.source_ref, "basis": f"{rule}:{detail}"},
-        sort_keys=True,
-    )
-
-
 def _emit(
     store: CkmStore,
     artifact: CkmArtifact,
@@ -67,14 +69,18 @@ def _emit(
     *,
     rule: str,
     detail: str,
+    desired_edges: set[tuple[str, str, str]],
 ) -> int:
     evidence_kind = _kind(artifact)
     dimension = _dimension(artifact)
+    basis = f"{rule}:{detail}"
+    desired_edges.add((artifact.id, capability.id, basis))
     existing = store.get_evidence_edge(
         artifact_id=artifact.id,
         capability_id=capability.id,
         evidence_kind=evidence_kind,
         maturity_dimension=dimension,
+        basis=basis,
     )
     store.upsert_evidence_edge(
         artifact_id=artifact.id,
@@ -85,7 +91,8 @@ def _emit(
         confidence=1.0,
         extraction_method="deterministic",
         lifecycle="confirmed",
-        source_ref=_basis(rule, artifact, detail),
+        source_ref=artifact.source_ref,
+        basis=basis,
     )
     return int(existing is None)
 
@@ -94,7 +101,8 @@ def _matrix_links(
     store: CkmStore,
     root: Path,
     artifacts: dict[str, CkmArtifact],
-    boundaries: dict[str, CkmCapability],
+    boundaries: dict[str, list[CkmCapability]],
+    desired_edges: set[tuple[str, str, str]],
 ) -> int:
     path = root / "docs/architecture/traceability-matrix.md"
     if not path.is_file():
@@ -103,19 +111,33 @@ def _matrix_links(
     for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
         if not line.startswith("|") or not re.match(r"^\|\s*\d+\s*\|", line):
             continue
-        row_capabilities = [boundaries[key] for key in sorted(set(_BOUNDARY_RE.findall(line))) if key in boundaries]
+        row_capabilities = [
+            capability
+            for key in sorted(set(_BOUNDARY_RE.findall(line)))
+            for capability in boundaries.get(key, [])
+        ]
         refs = {match.replace("../", "") for match in _PATH_RE.findall(line)}
         for target in _LINK_RE.findall(line):
             normalized = posixpath.normpath(posixpath.join("docs/architecture", target))
             if not normalized.startswith("../"):
                 refs.add(normalized)
         refs.update(f"github:issue:{number}" for number in _ISSUE_RE.findall(line))
+        for number in _ADR_RE.findall(line):
+            prefix = f"docs/adr/ADR-{number}"
+            refs.update(ref for ref in artifacts if ref.startswith(prefix))
         for ref in sorted(refs):
             artifact = artifacts.get(ref)
             if artifact is None:
                 continue
             for capability in row_capabilities:
-                changed += _emit(store, artifact, capability, rule="matrix", detail=f"row:{line_number}")
+                changed += _emit(
+                    store,
+                    artifact,
+                    capability,
+                    rule="matrix",
+                    detail=f"row:{line_number}",
+                    desired_edges=desired_edges,
+                )
     return changed
 
 
@@ -124,6 +146,7 @@ def _spec_links(
     root: Path,
     artifacts: dict[str, CkmArtifact],
     capabilities: list[CkmCapability],
+    desired_edges: set[tuple[str, str, str]],
 ) -> int:
     by_name = {capability.name.casefold(): capability for capability in capabilities}
     by_slug = {capability.name.casefold().replace(" ", "-"): capability for capability in capabilities}
@@ -140,7 +163,14 @@ def _spec_links(
         parent = match.group(1).strip().strip('"\'').casefold()
         capability = by_name.get(parent) or by_slug.get(parent.replace(" ", "-"))
         if capability:
-            changed += _emit(store, artifact, capability, rule="spec-directory", detail=artifact.source_ref)
+            changed += _emit(
+                store,
+                artifact,
+                capability,
+                rule="spec-directory",
+                detail=artifact.source_ref,
+                desired_edges=desired_edges,
+            )
     return changed
 
 
@@ -149,6 +179,7 @@ def _adr_links(
     root: Path,
     artifacts: dict[str, CkmArtifact],
     capabilities: list[CkmCapability],
+    desired_edges: set[tuple[str, str, str]],
 ) -> int:
     changed = 0
     for artifact in artifacts.values():
@@ -161,7 +192,14 @@ def _adr_links(
         for capability in capabilities:
             seed_path = _seed_path(capability)
             if seed_path and seed_path in text:
-                changed += _emit(store, artifact, capability, rule="adr-reference", detail=seed_path)
+                changed += _emit(
+                    store,
+                    artifact,
+                    capability,
+                    rule="adr-reference",
+                    detail=seed_path,
+                    desired_edges=desired_edges,
+                )
     return changed
 
 
@@ -179,9 +217,16 @@ def _imported_modules(path: Path) -> set[str]:
     return modules
 
 
-def _test_links(store: CkmStore, root: Path, artifacts: dict[str, CkmArtifact]) -> int:
+def _test_links(
+    store: CkmStore,
+    root: Path,
+    artifacts: dict[str, CkmArtifact],
+    desired_edges: set[tuple[str, str, str]],
+) -> int:
     changed = 0
-    source_edges = {edge.artifact_id: edge.capability_id for edge in store.list_evidence_edges()}
+    artifact_edges: dict[str, set[str]] = {}
+    for edge in store.list_evidence_edges():
+        artifact_edges.setdefault(edge.artifact_id, set()).add(edge.capability_id)
     capabilities = {capability.id: capability for capability in store.list_capabilities()}
     for test in artifacts.values():
         if test.artifact_kind != "test":
@@ -196,13 +241,22 @@ def _test_links(store: CkmStore, root: Path, artifacts: dict[str, CkmArtifact]) 
         for module in _imported_modules(root / relative):
             if module.startswith("app."):
                 candidates.add(module.replace(".", "/") + ".py")
-        for source_ref in candidates:
+        for source_ref in sorted(candidates):
             source = artifacts.get(source_ref)
-            if source is None or source.id not in source_edges:
+            if source is None:
                 continue
-            capability = capabilities.get(source_edges[source.id])
-            if capability:
-                changed += _emit(store, test, capability, rule="test-code", detail=source_ref)
+            capability_ids = artifact_edges.get(source.id, set()) or artifact_edges.get(test.id, set())
+            for capability_id in sorted(capability_ids):
+                capability = capabilities.get(capability_id)
+                if capability:
+                    changed += _emit(
+                        store,
+                        test,
+                        capability,
+                        rule="test-code",
+                        detail=source_ref,
+                        desired_edges=desired_edges,
+                    )
     return changed
 
 
@@ -210,6 +264,7 @@ def _github_links(
     store: CkmStore,
     artifacts: dict[str, CkmArtifact],
     capabilities: list[CkmCapability],
+    desired_edges: set[tuple[str, str, str]],
 ) -> int:
     changed = 0
     spec_capabilities: dict[str, CkmCapability] = {}
@@ -236,6 +291,7 @@ def _github_links(
                         capability,
                         rule="github-spec-ref",
                         detail=reference,
+                        desired_edges=desired_edges,
                     )
                     emitted.add(capability.id)
         for capability in capabilities:
@@ -243,7 +299,14 @@ def _github_links(
             if capability.id not in emitted and seed_path and any(
                 str(ref).startswith(seed_path) for ref in references
             ):
-                changed += _emit(store, artifact, capability, rule="github-ref", detail=seed_path)
+                changed += _emit(
+                    store,
+                    artifact,
+                    capability,
+                    rule="github-ref",
+                    detail=seed_path,
+                    desired_edges=desired_edges,
+                )
     return changed
 
 
@@ -253,14 +316,21 @@ def link_deterministic(store: CkmStore, root: Path) -> dict[str, int | str]:
     root = root.resolve()
     artifacts = {artifact.source_ref: artifact for artifact in store.list_artifacts()}
     capabilities = store.list_capabilities()
-    boundaries = {capability.boundary_ref: capability for capability in capabilities if capability.boundary_ref}
+    boundaries: dict[str, list[CkmCapability]] = {}
+    for capability in capabilities:
+        if capability.boundary_ref:
+            boundaries.setdefault(capability.boundary_ref, []).append(capability)
+    desired_edges: set[tuple[str, str, str]] = set()
     results = {
-        "matrix": _matrix_links(store, root, artifacts, boundaries),
-        "spec": _spec_links(store, root, artifacts, capabilities),
-        "adr": _adr_links(store, root, artifacts, capabilities),
-        "test_code": _test_links(store, root, artifacts),
-        "github_ref": _github_links(store, artifacts, capabilities),
+        "matrix": _matrix_links(store, root, artifacts, boundaries, desired_edges),
+        "spec": _spec_links(store, root, artifacts, capabilities, desired_edges),
+        "adr": _adr_links(store, root, artifacts, capabilities, desired_edges),
+        "test_code": _test_links(store, root, artifacts, desired_edges),
+        "github_ref": _github_links(store, artifacts, capabilities, desired_edges),
     }
+    results["removed"] = store.delete_deterministic_edges_not_in(
+        desired_edges, owned_basis_prefixes=_LINKER_BASIS_PREFIXES
+    )
     linked_ids = {edge.artifact_id for edge in store.list_evidence_edges()}
     results["unlinked_artifacts"] = sum(artifact.id not in linked_ids for artifact in artifacts.values())
     watermark = hashlib.sha256(

--- a/app/builderops/ckm/linkers.py
+++ b/app/builderops/ckm/linkers.py
@@ -1,0 +1,270 @@
+"""Deterministic evidence linkers for the Capability Evidence Graph."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+import posixpath
+import re
+from pathlib import Path
+
+from app.builderops.ckm.models import CkmArtifact, CkmCapability
+from app.builderops.ckm.store import CkmStore
+
+_PATH_RE = re.compile(r"(?:\.\./)*(?:app|docs|tests|schemas)/[A-Za-z0-9_./-]+(?:\.md|\.py|\.json)?")
+_LINK_RE = re.compile(r"\]\(([^)#]+(?:\.md|\.py|\.json))\)")
+_ISSUE_RE = re.compile(r"(?<![\w/])#(\d+)\b")
+_BOUNDARY_RE = re.compile(r"\b(HIX|WSP|HKA|SIP|GOV|EBF|PDM|DRI|RCA|MEM|CAO|EXE|SFC|OEF|CES)\b")
+_PARENT_RE = re.compile(r"^parent_capability:\s*(.+?)\s*$", re.MULTILINE)
+
+
+def _provenance(artifact: CkmArtifact) -> dict[str, object]:
+    try:
+        value = json.loads(artifact.provenance)
+    except json.JSONDecodeError:
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _seed_path(capability: CkmCapability) -> str | None:
+    marker = "seeded:"
+    if not capability.existence_provenance.startswith(marker):
+        return None
+    return capability.existence_provenance[len(marker) :].split("::", 1)[0].strip()
+
+
+def _kind(artifact: CkmArtifact) -> str:
+    return {
+        "document": "doc",
+        "source_file": "source",
+        "issue": "requirement",
+    }.get(artifact.artifact_kind, artifact.artifact_kind)
+
+
+def _dimension(artifact: CkmArtifact) -> str:
+    return {
+        "test": "test_completeness",
+        "pull_request": "functional_completeness",
+        "issue": "requirement_coverage",
+        "adr": "architectural_stability",
+        "spec": "requirement_coverage",
+        "document": "documentation_quality",
+    }.get(artifact.artifact_kind, "functional_completeness")
+
+
+def _basis(rule: str, artifact: CkmArtifact, detail: str) -> str:
+    return json.dumps(
+        {"artifact_source_ref": artifact.source_ref, "basis": f"{rule}:{detail}"},
+        sort_keys=True,
+    )
+
+
+def _emit(
+    store: CkmStore,
+    artifact: CkmArtifact,
+    capability: CkmCapability,
+    *,
+    rule: str,
+    detail: str,
+) -> int:
+    evidence_kind = _kind(artifact)
+    dimension = _dimension(artifact)
+    existing = store.get_evidence_edge(
+        artifact_id=artifact.id,
+        capability_id=capability.id,
+        evidence_kind=evidence_kind,
+        maturity_dimension=dimension,
+    )
+    store.upsert_evidence_edge(
+        artifact_id=artifact.id,
+        capability_id=capability.id,
+        evidence_kind=evidence_kind,
+        polarity="supports",
+        maturity_dimension=dimension,
+        confidence=1.0,
+        extraction_method="deterministic",
+        lifecycle="confirmed",
+        source_ref=_basis(rule, artifact, detail),
+    )
+    return int(existing is None)
+
+
+def _matrix_links(
+    store: CkmStore,
+    root: Path,
+    artifacts: dict[str, CkmArtifact],
+    boundaries: dict[str, CkmCapability],
+) -> int:
+    path = root / "docs/architecture/traceability-matrix.md"
+    if not path.is_file():
+        return 0
+    changed = 0
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not line.startswith("|") or not re.match(r"^\|\s*\d+\s*\|", line):
+            continue
+        row_capabilities = [boundaries[key] for key in sorted(set(_BOUNDARY_RE.findall(line))) if key in boundaries]
+        refs = {match.replace("../", "") for match in _PATH_RE.findall(line)}
+        for target in _LINK_RE.findall(line):
+            normalized = posixpath.normpath(posixpath.join("docs/architecture", target))
+            if not normalized.startswith("../"):
+                refs.add(normalized)
+        refs.update(f"github:issue:{number}" for number in _ISSUE_RE.findall(line))
+        for ref in sorted(refs):
+            artifact = artifacts.get(ref)
+            if artifact is None:
+                continue
+            for capability in row_capabilities:
+                changed += _emit(store, artifact, capability, rule="matrix", detail=f"row:{line_number}")
+    return changed
+
+
+def _spec_links(
+    store: CkmStore,
+    root: Path,
+    artifacts: dict[str, CkmArtifact],
+    capabilities: list[CkmCapability],
+) -> int:
+    by_name = {capability.name.casefold(): capability for capability in capabilities}
+    by_slug = {capability.name.casefold().replace(" ", "-"): capability for capability in capabilities}
+    changed = 0
+    for artifact in artifacts.values():
+        if artifact.artifact_kind != "spec":
+            continue
+        path = root / artifact.source_ref
+        if not path.is_file():
+            continue
+        match = _PARENT_RE.search(path.read_text(encoding="utf-8"))
+        if not match:
+            continue
+        parent = match.group(1).strip().strip('"\'').casefold()
+        capability = by_name.get(parent) or by_slug.get(parent.replace(" ", "-"))
+        if capability:
+            changed += _emit(store, artifact, capability, rule="spec-directory", detail=artifact.source_ref)
+    return changed
+
+
+def _adr_links(
+    store: CkmStore,
+    root: Path,
+    artifacts: dict[str, CkmArtifact],
+    capabilities: list[CkmCapability],
+) -> int:
+    changed = 0
+    for artifact in artifacts.values():
+        if artifact.artifact_kind != "adr":
+            continue
+        path = root / artifact.source_ref
+        if not path.is_file():
+            continue
+        text = path.read_text(encoding="utf-8")
+        for capability in capabilities:
+            seed_path = _seed_path(capability)
+            if seed_path and seed_path in text:
+                changed += _emit(store, artifact, capability, rule="adr-reference", detail=seed_path)
+    return changed
+
+
+def _imported_modules(path: Path) -> set[str]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return set()
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def _test_links(store: CkmStore, root: Path, artifacts: dict[str, CkmArtifact]) -> int:
+    changed = 0
+    source_edges = {edge.artifact_id: edge.capability_id for edge in store.list_evidence_edges()}
+    capabilities = {capability.id: capability for capability in store.list_capabilities()}
+    for test in artifacts.values():
+        if test.artifact_kind != "test":
+            continue
+        candidates: set[str] = set()
+        relative = test.source_ref
+        if relative.startswith("tests/"):
+            tail = relative.removeprefix("tests/")
+            name = Path(tail).name
+            mirrored = str(Path("app") / Path(tail).parent / name.removeprefix("test_"))
+            candidates.add(mirrored)
+        for module in _imported_modules(root / relative):
+            if module.startswith("app."):
+                candidates.add(module.replace(".", "/") + ".py")
+        for source_ref in candidates:
+            source = artifacts.get(source_ref)
+            if source is None or source.id not in source_edges:
+                continue
+            capability = capabilities.get(source_edges[source.id])
+            if capability:
+                changed += _emit(store, test, capability, rule="test-code", detail=source_ref)
+    return changed
+
+
+def _github_links(
+    store: CkmStore,
+    artifacts: dict[str, CkmArtifact],
+    capabilities: list[CkmCapability],
+) -> int:
+    changed = 0
+    spec_capabilities: dict[str, CkmCapability] = {}
+    capability_by_id = {capability.id: capability for capability in capabilities}
+    artifact_by_id = {artifact.id: artifact for artifact in artifacts.values()}
+    for edge in store.list_evidence_edges():
+        linked_artifact = artifact_by_id.get(edge.artifact_id)
+        linked_capability = capability_by_id.get(edge.capability_id)
+        if linked_artifact and linked_capability and linked_artifact.artifact_kind == "spec":
+            spec_capabilities[linked_artifact.source_ref] = linked_capability
+    for artifact in artifacts.values():
+        if artifact.artifact_kind not in {"issue", "pull_request"}:
+            continue
+        references = _provenance(artifact).get("references", [])
+        if not isinstance(references, list):
+            continue
+        emitted: set[str] = set()
+        for reference in (str(value) for value in references):
+            for spec_path, capability in spec_capabilities.items():
+                if reference == spec_path or reference.startswith(str(Path(spec_path).parent) + "/"):
+                    changed += _emit(
+                        store,
+                        artifact,
+                        capability,
+                        rule="github-spec-ref",
+                        detail=reference,
+                    )
+                    emitted.add(capability.id)
+        for capability in capabilities:
+            seed_path = _seed_path(capability)
+            if capability.id not in emitted and seed_path and any(
+                str(ref).startswith(seed_path) for ref in references
+            ):
+                changed += _emit(store, artifact, capability, rule="github-ref", detail=seed_path)
+    return changed
+
+
+def link_deterministic(store: CkmStore, root: Path) -> dict[str, int | str]:
+    """Run every mechanical linker and report the honest unlinked backlog."""
+    store.ensure_schema()
+    root = root.resolve()
+    artifacts = {artifact.source_ref: artifact for artifact in store.list_artifacts()}
+    capabilities = store.list_capabilities()
+    boundaries = {capability.boundary_ref: capability for capability in capabilities if capability.boundary_ref}
+    results = {
+        "matrix": _matrix_links(store, root, artifacts, boundaries),
+        "spec": _spec_links(store, root, artifacts, capabilities),
+        "adr": _adr_links(store, root, artifacts, capabilities),
+        "test_code": _test_links(store, root, artifacts),
+        "github_ref": _github_links(store, artifacts, capabilities),
+    }
+    linked_ids = {edge.artifact_id for edge in store.list_evidence_edges()}
+    results["unlinked_artifacts"] = sum(artifact.id not in linked_ids for artifact in artifacts.values())
+    watermark = hashlib.sha256(
+        "\n".join(f"{item.source_ref}:{item.watermark}" for item in sorted(artifacts.values(), key=lambda value: value.source_ref)).encode()
+    ).hexdigest()
+    store.set_watermark("deterministic_linkers", watermark)
+    return {**results, "watermark": watermark}

--- a/app/builderops/ckm/linkers.py
+++ b/app/builderops/ckm/linkers.py
@@ -37,11 +37,53 @@ def _provenance(artifact: CkmArtifact) -> dict[str, object]:
     return value if isinstance(value, dict) else {}
 
 
-def _seed_path(capability: CkmCapability) -> str | None:
+def _seed_source(capability: CkmCapability) -> tuple[str, str | None] | None:
     marker = "seeded:"
     if not capability.existence_provenance.startswith(marker):
         return None
-    return capability.existence_provenance[len(marker) :].split("::", 1)[0].strip()
+    source = capability.existence_provenance[len(marker) :]
+    path, separator, anchor = source.partition("::")
+    normalized_path = path.strip()
+    if not normalized_path:
+        return None
+    normalized_anchor = anchor.strip() if separator and anchor.strip() else None
+    return normalized_path, normalized_anchor
+
+
+def _seed_path(capability: CkmCapability) -> str | None:
+    source = _seed_source(capability)
+    return source[0] if source is not None else None
+
+
+def _contains_phrase(text: str, phrase: str, *, case_sensitive: bool = False) -> bool:
+    flags = 0 if case_sensitive else re.IGNORECASE
+    return bool(re.search(rf"(?<![\w-]){re.escape(phrase)}(?![\w-])", text, flags))
+
+
+def _adr_disambiguator(
+    text: str,
+    capability: CkmCapability,
+    *,
+    anchor_occurrences: dict[str, int],
+) -> str | None:
+    """Return capability-specific evidence for an ADR sharing a seed document.
+
+    A document path alone cannot identify one capability when multiple seed rows
+    cite it. Prefer the human-readable capability name, then the SBS boundary
+    code, then an anchor only when that anchor uniquely identifies a seed row
+    within the shared document.
+    """
+    if _contains_phrase(text, capability.name):
+        return f"name:{capability.name}"
+    if capability.boundary_ref and _contains_phrase(
+        text, capability.boundary_ref, case_sensitive=True
+    ):
+        return f"boundary:{capability.boundary_ref}"
+    source = _seed_source(capability)
+    anchor = source[1] if source is not None else None
+    if anchor and anchor_occurrences.get(anchor.casefold()) == 1 and _contains_phrase(text, anchor):
+        return f"anchor:{anchor}"
+    return None
 
 
 def _kind(artifact: CkmArtifact) -> str:
@@ -210,6 +252,11 @@ def _adr_links(
     desired_edges: set[tuple[str, str, str]],
 ) -> int:
     changed = 0
+    capabilities_by_seed_path: dict[str, list[CkmCapability]] = {}
+    for capability in capabilities:
+        seed_path = _seed_path(capability)
+        if seed_path:
+            capabilities_by_seed_path.setdefault(seed_path, []).append(capability)
     for artifact in artifacts.values():
         if artifact.artifact_kind != "adr":
             continue
@@ -217,15 +264,34 @@ def _adr_links(
         if not path.is_file():
             continue
         text = path.read_text(encoding="utf-8")
-        for capability in capabilities:
-            seed_path = _seed_path(capability)
-            if seed_path and seed_path in text:
+        for seed_path, candidates in capabilities_by_seed_path.items():
+            if seed_path not in text:
+                continue
+            anchors = [
+                source[1].casefold()
+                for capability in candidates
+                if (source := _seed_source(capability)) is not None and source[1] is not None
+            ]
+            anchor_occurrences = {anchor: anchors.count(anchor) for anchor in set(anchors)}
+            for capability in candidates:
+                disambiguator = None
+                if len(candidates) > 1:
+                    disambiguator = _adr_disambiguator(
+                        text,
+                        capability,
+                        anchor_occurrences=anchor_occurrences,
+                    )
+                    if disambiguator is None:
+                        continue
+                detail = seed_path
+                if disambiguator is not None:
+                    detail = f"{seed_path}|selector:{disambiguator}"
                 changed += _emit(
                     store,
                     artifact,
                     capability,
                     rule="adr-reference",
-                    detail=seed_path,
+                    detail=detail,
                     desired_edges=desired_edges,
                 )
     return changed

--- a/app/builderops/ckm/models.py
+++ b/app/builderops/ckm/models.py
@@ -242,6 +242,7 @@ class CkmEvidenceEdge:
     extraction_method: str
     lifecycle: str
     source_ref: str
+    basis: str
     created_at: str
     updated_at: str
     model: str | None = None
@@ -261,6 +262,7 @@ class CkmEvidenceEdge:
         if self.extraction_method == "inferred" and not (self.model and self.provider):
             raise CkmValidationError("inferred evidence edges require model and provider")
         _require_nonempty_str(self.source_ref, "source_ref")
+        _require_nonempty_str(self.basis, "basis")
         _require_nonempty_str(self.created_at, "created_at")
         _require_nonempty_str(self.updated_at, "updated_at")
         return self
@@ -280,6 +282,7 @@ class CkmEvidenceEdge:
             provider=row["provider"],
             lifecycle=row["lifecycle"],
             source_ref=row["source_ref"],
+            basis=row["basis"],
             created_at=row["created_at"],
             updated_at=row["updated_at"],
         )
@@ -298,6 +301,7 @@ class CkmEvidenceEdge:
             "provider": self.provider,
             "lifecycle": self.lifecycle,
             "source_ref": self.source_ref,
+            "basis": self.basis,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
         }

--- a/app/builderops/ckm/schema.py
+++ b/app/builderops/ckm/schema.py
@@ -13,7 +13,7 @@ schema level, not only in application code.
 
 from __future__ import annotations
 
-CKM_SCHEMA_VERSION = 1
+CKM_SCHEMA_VERSION = 2
 
 CKM_TABLE_NAMES = (
     "ckm_capability",
@@ -72,9 +72,10 @@ CKM_DDL_STATEMENTS = [
         provider TEXT,
         lifecycle TEXT NOT NULL CHECK (lifecycle IN ('candidate', 'confirmed')),
         source_ref TEXT NOT NULL,
+        basis TEXT NOT NULL,
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL,
-        UNIQUE (artifact_id, capability_id, evidence_kind, maturity_dimension)
+        UNIQUE (artifact_id, capability_id, basis)
     )
     """,
     """

--- a/app/builderops/ckm/store.py
+++ b/app/builderops/ckm/store.py
@@ -85,6 +85,7 @@ class CkmStore:
         # exists first: receipt writes below depend on it.
         self._receipt_store.initialize()
         with self._connect() as conn:
+            self._migrate_evidence_edge_basis(conn)
             for statement in CKM_DDL_STATEMENTS:
                 conn.execute(statement)
             conn.commit()
@@ -96,6 +97,39 @@ class CkmStore:
         if prior_receipts:
             return prior_receipts[-1]
         return self._emit_schema_receipt(event_type="ckm_schema_ensured", action="ensure_schema")
+
+    @staticmethod
+    def _migrate_evidence_edge_basis(conn: sqlite3.Connection) -> None:
+        columns = conn.execute("PRAGMA table_info(ckm_evidence_edge)").fetchall()
+        if not columns or any(row["name"] == "basis" for row in columns):
+            return
+        conn.execute("ALTER TABLE ckm_evidence_edge RENAME TO ckm_evidence_edge_v1")
+        edge_ddl = next(
+            statement for statement in CKM_DDL_STATEMENTS
+            if "CREATE TABLE IF NOT EXISTS ckm_evidence_edge" in statement
+        )
+        conn.execute(edge_ddl)
+        conn.execute(
+            """
+            INSERT INTO ckm_evidence_edge (
+                id, artifact_id, capability_id, evidence_kind, polarity,
+                maturity_dimension, confidence, extraction_method, model,
+                provider, lifecycle, source_ref, basis, created_at, updated_at
+            )
+            SELECT id, artifact_id, capability_id, evidence_kind, polarity,
+                   maturity_dimension, confidence, extraction_method, model,
+                   provider, lifecycle,
+                   CASE WHEN json_valid(source_ref)
+                        THEN COALESCE(json_extract(source_ref, '$.artifact_source_ref'), source_ref)
+                        ELSE source_ref END,
+                   CASE WHEN json_valid(source_ref)
+                        THEN COALESCE(json_extract(source_ref, '$.basis'), source_ref)
+                        ELSE source_ref END,
+                   created_at, updated_at
+            FROM ckm_evidence_edge_v1
+            """
+        )
+        conn.execute("DROP TABLE ckm_evidence_edge_v1")
 
     def rebuild(self) -> dict[str, Any]:
         """Drop and recreate ``ckm_*`` tables only (INV-CKM-4). Emits a receipt."""
@@ -298,11 +332,13 @@ class CkmStore:
         extraction_method: str,
         lifecycle: str,
         source_ref: str,
+        basis: str | None = None,
         model: str | None = None,
         provider: str | None = None,
     ) -> CkmEvidenceEdge:
         now = utc_now()
         candidate_id = new_id("edge")
+        resolved_basis = basis or source_ref
         with self._connect() as conn:
             conn.execute("BEGIN IMMEDIATE")
             conn.execute(
@@ -310,9 +346,9 @@ class CkmStore:
                 INSERT INTO ckm_evidence_edge (
                     id, artifact_id, capability_id, evidence_kind, polarity,
                     maturity_dimension, confidence, extraction_method, model,
-                    provider, lifecycle, source_ref, created_at, updated_at
-                ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
-                ON CONFLICT(artifact_id, capability_id, evidence_kind, maturity_dimension)
+                    provider, lifecycle, source_ref, basis, created_at, updated_at
+                ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                ON CONFLICT(artifact_id, capability_id, basis)
                 DO UPDATE SET
                     polarity = excluded.polarity,
                     confidence = excluded.confidence,
@@ -336,6 +372,7 @@ class CkmStore:
                     provider,
                     lifecycle,
                     source_ref,
+                    resolved_basis,
                     now,
                     now,
                 ),
@@ -346,6 +383,7 @@ class CkmStore:
             capability_id=capability_id,
             evidence_kind=evidence_kind,
             maturity_dimension=maturity_dimension,
+            basis=resolved_basis,
         )
         if edge is None:  # pragma: no cover - defensive
             raise CkmValidationError("evidence edge upsert did not persist")
@@ -358,16 +396,27 @@ class CkmStore:
         capability_id: str,
         evidence_kind: str,
         maturity_dimension: str,
+        basis: str | None = None,
     ) -> CkmEvidenceEdge | None:
         with self._connect() as conn:
-            row = conn.execute(
-                """
-                SELECT * FROM ckm_evidence_edge
-                WHERE artifact_id = ? AND capability_id = ?
-                  AND evidence_kind = ? AND maturity_dimension = ?
-                """,
-                (artifact_id, capability_id, evidence_kind, maturity_dimension),
-            ).fetchone()
+            if basis is None:
+                row = conn.execute(
+                    """
+                    SELECT * FROM ckm_evidence_edge
+                    WHERE artifact_id = ? AND capability_id = ?
+                      AND evidence_kind = ? AND maturity_dimension = ?
+                    ORDER BY basis LIMIT 1
+                    """,
+                    (artifact_id, capability_id, evidence_kind, maturity_dimension),
+                ).fetchone()
+            else:
+                row = conn.execute(
+                    """
+                    SELECT * FROM ckm_evidence_edge
+                    WHERE artifact_id = ? AND capability_id = ? AND basis = ?
+                    """,
+                    (artifact_id, capability_id, basis),
+                ).fetchone()
         return CkmEvidenceEdge.from_row(row) if row is not None else None
 
     def list_evidence_edges_for_capability(self, capability_id: str) -> list[CkmEvidenceEdge]:
@@ -384,6 +433,32 @@ class CkmStore:
                 "SELECT * FROM ckm_evidence_edge ORDER BY artifact_id, capability_id"
             ).fetchall()
         return [CkmEvidenceEdge.from_row(row) for row in rows]
+
+    def delete_deterministic_edges_not_in(
+        self,
+        edge_keys: set[tuple[str, str, str]],
+        *,
+        owned_basis_prefixes: tuple[str, ...],
+    ) -> int:
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT id, artifact_id, capability_id, basis
+                FROM ckm_evidence_edge
+                WHERE extraction_method = 'deterministic'
+                """
+            ).fetchall()
+            stale = [
+                row["id"]
+                for row in rows
+                if str(row["basis"]).startswith(owned_basis_prefixes)
+                if (row["artifact_id"], row["capability_id"], row["basis"])
+                not in edge_keys
+            ]
+            for edge_id in stale:
+                conn.execute("DELETE FROM ckm_evidence_edge WHERE id = ?", (edge_id,))
+            conn.commit()
+        return len(stale)
 
     # --- Assessment (append-only, bitemporal) -----------------------------------
 

--- a/app/builderops/ckm/store.py
+++ b/app/builderops/ckm/store.py
@@ -378,6 +378,13 @@ class CkmStore:
             ).fetchall()
         return [CkmEvidenceEdge.from_row(row) for row in rows]
 
+    def list_evidence_edges(self) -> list[CkmEvidenceEdge]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM ckm_evidence_edge ORDER BY artifact_id, capability_id"
+            ).fetchall()
+        return [CkmEvidenceEdge.from_row(row) for row in rows]
+
     # --- Assessment (append-only, bitemporal) -----------------------------------
 
     def append_assessment(

--- a/app/builderops/ckm/store.py
+++ b/app/builderops/ckm/store.py
@@ -122,9 +122,10 @@ class CkmStore:
                    CASE WHEN json_valid(source_ref)
                         THEN COALESCE(json_extract(source_ref, '$.artifact_source_ref'), source_ref)
                         ELSE source_ref END,
-                   CASE WHEN json_valid(source_ref)
-                        THEN COALESCE(json_extract(source_ref, '$.basis'), source_ref)
-                        ELSE source_ref END,
+                   (CASE WHEN json_valid(source_ref)
+                         THEN COALESCE(json_extract(source_ref, '$.basis'), source_ref)
+                         ELSE 'legacy:' || source_ref END)
+                   || ':legacy:' || evidence_kind || ':' || maturity_dimension,
                    created_at, updated_at
             FROM ckm_evidence_edge_v1
             """
@@ -350,7 +351,9 @@ class CkmStore:
                 ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
                 ON CONFLICT(artifact_id, capability_id, basis)
                 DO UPDATE SET
+                    evidence_kind = excluded.evidence_kind,
                     polarity = excluded.polarity,
+                    maturity_dimension = excluded.maturity_dimension,
                     confidence = excluded.confidence,
                     extraction_method = excluded.extraction_method,
                     model = excluded.model,

--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -28,6 +28,7 @@ from app.builderops.ckm_reevaluation import (
 from app.builderops.ckm.models import CkmValidationError
 from app.builderops.ckm.ingest_github import ingest_github
 from app.builderops.ckm.ingest_repo import ingest_repo
+from app.builderops.ckm.linkers import link_deterministic
 from app.builderops.ckm.seed import SeedManifestError, seed_capabilities
 from app.builderops.ckm.store import CkmStore
 from app.builderops.config import BuilderOpsPaths, load_paths
@@ -416,6 +417,22 @@ def ckm_ingest(ctx: click.Context, source: str, repo_root: Path, git_limit: int)
                 for name, data in (("issues", github["issues"]), ("pull_requests", github["pull_requests"]))
             )
     click.echo("; ".join(segments))
+
+
+@ckm.command("link", help="Create confirmed deterministic CKM evidence edges.")
+@click.option("--repo-root", type=click.Path(file_okay=False, path_type=Path), default=Path.cwd)
+@click.pass_context
+def ckm_link(ctx: click.Context, repo_root: Path) -> None:
+    try:
+        result = link_deterministic(_ckm_store(ctx), repo_root)
+    except (OSError, ValueError, sqlite3.Error) as exc:
+        raise click.ClickException(f"ckm linking failed: {exc}") from exc
+    click.echo(
+        "; ".join(
+            [f"{name}: {result[name]} new" for name in ("matrix", "spec", "adr", "test_code", "github_ref")]
+            + [f"unlinked artifacts: {result['unlinked_artifacts']}"]
+        )
+    )
 
 
 @builderops.group("inquiry", help="Persist and inspect pre-ticket model inquiry artifacts.")

--- a/docs/CAPABILITY_KNOWLEDGE_MODEL/REPO_ARTIFACT_INGESTION.md
+++ b/docs/CAPABILITY_KNOWLEDGE_MODEL/REPO_ARTIFACT_INGESTION.md
@@ -1,6 +1,6 @@
 ---
 name: Repo Artifact Ingestion
-description: Deterministic local adapters that normalize docs, ADRs, spec directories, tests, and git history into CKM artifact records with watermarks
+description: Deterministic local adapters that normalize docs, ADRs, spec directories, tests, schemas, source, and git history into CKM artifact records with watermarks
 task_id: CKM-03
 source_anchor: docs/research/DEVELOPMENT_KNOWLEDGE_MODEL.md :: 5.14 Data Sources
 parent_capability: Capability Knowledge Model
@@ -21,15 +21,16 @@ Turn the repository's local artifact surfaces into normalized `ckm_artifact` rec
   - **docs adapter** — walks `docs/**/*.md`; `artifact_kind` from location/header (`adr` for `docs/adr/`, `spec` for spec directories with task frontmatter, `doc` otherwise); captures the `State:` header line and title as the payload summary.
   - **test adapter** — walks `tests/**/test_*.py`; records module path + test names (AST-level listing, no execution).
   - **source adapter** — walks `app/**/*.py`; records module path + top-level docstring first line.
+  - **schema adapter** — walks `schemas/**/*.json`; records each JSON schema as a provenance-bearing document artifact so deterministic matrix citations have a resolvable producer.
   - **git adapter** — `git log` over a bounded window (configurable, default: since last watermark) yielding commit records (sha, subject, changed paths).
-- Watermarking per source (`docs`, `tests`, `source`, `git`): stores the last-ingested state (HEAD sha for git; content hash set for tree walks) in a `ckm_watermark` helper table; re-runs ingest only what changed (INV-CKM-5, INV-CKM-7).
+- Watermarking per source (`docs`, `tests`, `source`, `schemas`, `git`): stores the last-ingested state (HEAD sha for git; content hash set for tree walks) in a `ckm_watermark` helper table; re-runs ingest only what changed (INV-CKM-5, INV-CKM-7).
 - CLI: `python -m app.builderops ckm ingest --source repo`.
 
 ## Concretely
 
 ```bash
 python -m app.builderops ckm ingest --source repo
-# → "docs: 412 artifacts (+3), tests: 388 (+1), source: 290 (0), git: 5210 commits (+17); watermark advanced to <sha>"
+# → "docs: 412 artifacts (+3), tests: 388 (+1), source: 290 (0), schemas: 27 (0), git: 5210 commits (+17)"
 ```
 
 ## Why This Matters
@@ -38,7 +39,7 @@ Everything downstream is only as honest as ingestion: a missed artifact class sh
 
 ## Acceptance Criteria
 
-- [ ] All four adapters produce records with non-null natural keys, kinds, and provenance, over a fixture tree.
+- [ ] All five tree adapters plus git produce records with non-null natural keys, kinds, and provenance over a fixture tree, including JSON schemas required by the traceability matrix.
   - Verify: `tests/builderops/ckm/test_ingest_repo.py::test_adapters_yield_typed_provenanced_records`
 - [ ] Re-ingestion over an unchanged tree inserts zero new rows; touching one doc re-ingests exactly that artifact and advances the watermark.
   - Verify: `tests/builderops/ckm/test_ingest_repo.py::test_incremental_watermark_semantics`

--- a/tests/builderops/ckm/test_ingest_github.py
+++ b/tests/builderops/ckm/test_ingest_github.py
@@ -31,6 +31,7 @@ def _pull(updated_at: str = "2026-07-01T10:01:00Z") -> dict[str, object]:
         "number": 77,
         "title": "Add CKM adapter",
         "state": "closed",
+        "merged_at": "2026-07-01T10:00:30Z",
         "updated_at": updated_at,
         "body": "Fixes #42; see docs/CAPABILITY_KNOWLEDGE_MODEL/GITHUB_ARTIFACT_INGESTION.md",
         "changed_files": ["app/builderops/ckm/ingest_github.py"],
@@ -44,6 +45,11 @@ def test_rest_payload_normalization_with_refs() -> None:
     assert record.artifact_kind == "issue"
     assert payload["references"] == ["#3138", "docs/CAPABILITY_KNOWLEDGE_MODEL/README.md"]
     assert payload["labels"] == ["type:task"]
+
+    pull_payload = json.loads(
+        normalize_github_payload(_pull(), artifact_kind="pull_request").provenance
+    )
+    assert pull_payload["merged_at"] == "2026-07-01T10:00:30Z"
 
 
 def test_updated_at_cursor_incremental(tmp_path: Path) -> None:

--- a/tests/builderops/ckm/test_ingest_repo.py
+++ b/tests/builderops/ckm/test_ingest_repo.py
@@ -9,6 +9,7 @@ from app.builderops.ckm.ingest_repo import (
     ingest_repo,
     iter_docs,
     iter_git,
+    iter_schemas,
     iter_source,
     iter_tests,
 )
@@ -28,6 +29,7 @@ def _repo(tmp_path: Path) -> Path:
     _write(tmp_path / "docs/guide.md", "State: Draft\n\n# A guide\n")
     _write(tmp_path / "tests/unit/test_example.py", "def test_one():\n    pass\n")
     _write(tmp_path / "app/example.py", '\"\"\"Example module.\"\"\"\n')
+    _write(tmp_path / "schemas/example.schema.json", '{"type":"object"}\n')
     subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
     subprocess.run(["git", "-C", str(tmp_path), "add", "."], check=True)
     subprocess.run(
@@ -43,10 +45,17 @@ def _store(tmp_path: Path) -> CkmStore:
 
 def test_adapters_yield_typed_provenanced_records(tmp_path: Path) -> None:
     root = _repo(tmp_path / "repo")
-    artifacts = [*iter_docs(root), *iter_tests(root), *iter_source(root), *iter_git(root, None)]
+    artifacts = [
+        *iter_docs(root),
+        *iter_tests(root),
+        *iter_source(root),
+        *iter_schemas(root),
+        *iter_git(root, None),
+    ]
     assert artifacts
     assert {artifact.artifact_kind for artifact in artifacts} >= {"adr", "spec", "document", "test", "source_file", "commit"}
     assert all(artifact.natural_key and artifact.provenance and artifact.payload_summary for artifact in artifacts)
+    assert next(item for item in artifacts if item.natural_key == "schemas/example.schema.json").artifact_kind == "document"
 
 
 def test_incremental_watermark_semantics(tmp_path: Path) -> None:
@@ -54,6 +63,7 @@ def test_incremental_watermark_semantics(tmp_path: Path) -> None:
     store = _store(tmp_path)
     first = ingest_repo(store, root)
     assert first["docs"]["changed"] == 3
+    assert first["schemas"]["changed"] == 1
     with store._connect() as conn:
         rows_before = {
             table: conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]

--- a/tests/builderops/ckm/test_linkers.py
+++ b/tests/builderops/ckm/test_linkers.py
@@ -38,7 +38,7 @@ def test_matrix_rows_become_edges_on_live_matrix(tmp_path: Path) -> None:
     result = link_deterministic(store, REPO_ROOT)
     matrix_edges = [
         edge for edge in store.list_evidence_edges()
-        if json.loads(edge.source_ref)["basis"].startswith("matrix:")
+        if edge.basis.startswith("matrix:")
     ]
     assert result["matrix"] > 0
     assert matrix_edges
@@ -46,6 +46,14 @@ def test_matrix_rows_become_edges_on_live_matrix(tmp_path: Path) -> None:
     assert {
         capability_by_id[edge.capability_id].boundary_ref for edge in matrix_edges
     } >= {"RCA", "GOV", "SIP"}
+    rca_ids = {
+        capability.id
+        for capability in capability_by_id.values()
+        if capability.boundary_ref == "RCA"
+    }
+    assert rca_ids <= {edge.capability_id for edge in matrix_edges}
+    artifact_by_id = {item.id: item for item in store.list_artifacts()}
+    assert any(artifact_by_id[edge.artifact_id].artifact_kind == "adr" for edge in matrix_edges)
 
 
 def test_edges_carry_method_lifecycle_basis(tmp_path: Path) -> None:
@@ -56,18 +64,121 @@ def test_edges_carry_method_lifecycle_basis(tmp_path: Path) -> None:
     assert edges
     assert all(edge.extraction_method == "deterministic" for edge in edges)
     assert all(edge.lifecycle == "confirmed" for edge in edges)
-    assert all(json.loads(edge.source_ref)["basis"] for edge in edges)
+    assert all(edge.basis for edge in edges)
 
 
 def test_link_idempotent_incremental(tmp_path: Path) -> None:
     store = _store(tmp_path)
     _ingest_docs(store)
     first = link_deterministic(store, REPO_ROOT)
-    first_count = len(store.list_evidence_edges())
+    first_edges = {
+        (edge.artifact_id, edge.capability_id, edge.basis): edge.id
+        for edge in store.list_evidence_edges()
+    }
+    sample = next(iter(store.list_evidence_edges()))
+    store.upsert_evidence_edge(
+        artifact_id=sample.artifact_id,
+        capability_id=sample.capability_id,
+        evidence_kind=sample.evidence_kind,
+        polarity="supports",
+        maturity_dimension=sample.maturity_dimension,
+        confidence=1.0,
+        extraction_method="deterministic",
+        lifecycle="confirmed",
+        source_ref=sample.source_ref,
+        basis="matrix:removed-source-reference",
+    )
     second = link_deterministic(store, REPO_ROOT)
     assert first["matrix"] > 0
     assert sum(second[name] for name in ("matrix", "spec", "adr", "test_code", "github_ref")) == 0
-    assert len(store.list_evidence_edges()) == first_count
+    assert second["removed"] == 1
+    assert {
+        (edge.artifact_id, edge.capability_id, edge.basis): edge.id
+        for edge in store.list_evidence_edges()
+    } == first_edges
+    capability = next(
+        item for item in store.list_capabilities() if item.existence_provenance.startswith("seeded:")
+    )
+    seed_path = capability.existence_provenance.removeprefix("seeded:").split("::", 1)[0].strip()
+    store.upsert_artifact(
+        source_ref="github:issue:incremental",
+        artifact_kind="issue",
+        source="fixture",
+        watermark="new",
+        provenance=json.dumps({"references": [seed_path]}),
+    )
+    incremental = link_deterministic(store, REPO_ROOT)
+    assert incremental["github_ref"] == 1
+    assert sum(
+        incremental[name] for name in ("matrix", "spec", "adr", "test_code")
+    ) == 0
+
+
+def test_spec_test_code_and_github_linker_families(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    (root / "app").mkdir(parents=True)
+    (root / "tests").mkdir()
+    (root / "docs/CAP").mkdir(parents=True)
+    (root / "app/foo.py").write_text("def value() -> int:\n    return 1\n", encoding="utf-8")
+    (root / "tests/test_foo.py").write_text(
+        "from app.foo import value\n\ndef test_value():\n    assert value() == 1\n",
+        encoding="utf-8",
+    )
+    (root / "docs/CAP/TASK.md").write_text(
+        '---\nparent_capability: "Example Capability"\n---\n', encoding="utf-8"
+    )
+    store = CkmStore(tmp_path / "builderops.sqlite3")
+    store.ensure_schema()
+    capability = store.upsert_capability(
+        name="Example Capability",
+        definition="Fixture capability",
+        existence_provenance="seeded:docs/owner.md :: example",
+        lifecycle="confirmed",
+    )
+
+    def artifact(source_ref: str, kind: str, references: list[str] | None = None):
+        return store.upsert_artifact(
+            source_ref=source_ref,
+            artifact_kind=kind,
+            source="fixture",
+            watermark="one",
+            provenance=json.dumps({"source_ref": source_ref, "references": references or []}),
+        )
+
+    source = artifact("app/foo.py", "source_file")
+    test = artifact("tests/test_foo.py", "test")
+    spec = artifact("docs/CAP/TASK.md", "spec")
+    issue = artifact("github:issue:1", "issue", ["docs/CAP/TASK.md"])
+    pull_request = artifact("github:pull_request:2", "pull_request", ["docs/owner.md"])
+    store.upsert_evidence_edge(
+        artifact_id=source.id,
+        capability_id=capability.id,
+        evidence_kind="source",
+        polarity="supports",
+        maturity_dimension="functional_completeness",
+        confidence=1.0,
+        extraction_method="deterministic",
+        lifecycle="confirmed",
+        source_ref=source.source_ref,
+        basis="fixture:source-capability",
+    )
+
+    result = link_deterministic(store, root)
+    edges = store.list_evidence_edges()
+    by_artifact = {item.id: item for item in (test, spec, issue, pull_request)}
+    linked = {
+        (by_artifact[edge.artifact_id].source_ref, edge.basis)
+        for edge in edges
+        if edge.artifact_id in by_artifact
+    }
+    assert result["spec"] == 1
+    assert result["test_code"] == 1
+    assert result["github_ref"] == 2
+    assert ("tests/test_foo.py", "test-code:app/foo.py") in linked
+    assert ("docs/CAP/TASK.md", "spec-directory:docs/CAP/TASK.md") in linked
+    assert ("github:issue:1", "github-spec-ref:docs/CAP/TASK.md") in linked
+    assert ("github:pull_request:2", "github-ref:docs/owner.md") in linked
+    assert any(edge.basis == "fixture:source-capability" for edge in edges)
 
 
 def test_unlinked_backlog_reported(tmp_path: Path) -> None:

--- a/tests/builderops/ckm/test_linkers.py
+++ b/tests/builderops/ckm/test_linkers.py
@@ -124,6 +124,109 @@ def test_edges_carry_method_lifecycle_basis(tmp_path: Path) -> None:
     assert all(edge.basis for edge in edges)
 
 
+def test_adr_shared_seed_path_requires_capability_specific_selector(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    adr_path = root / "docs/adr/ADR-9000-shared-seed.md"
+    adr_path.parent.mkdir(parents=True)
+    adr_path.write_text(
+        "# ADR-9000\n\nSee docs/shared-owner.md for the taxonomy.\n",
+        encoding="utf-8",
+    )
+    store = CkmStore(tmp_path / "builderops.sqlite3")
+    store.ensure_schema()
+    capabilities = {
+        name: store.upsert_capability(
+            name=name,
+            definition="Fixture capability",
+            existence_provenance="seeded:docs/shared-owner.md :: Shared taxonomy",
+            boundary_ref=boundary,
+        )
+        for name, boundary in (
+            ("Human Authority Kernel", None),
+            ("Retrieval & Context Assembly", "RCA"),
+            ("Machine Memory & Learning", "MEM"),
+        )
+    }
+    adr = store.upsert_artifact(
+        source_ref="docs/adr/ADR-9000-shared-seed.md",
+        artifact_kind="adr",
+        source="repo_docs",
+        watermark="one",
+        provenance='{"source_ref":"docs/adr/ADR-9000-shared-seed.md"}',
+    )
+
+    path_only = link_deterministic(store, root)
+
+    assert path_only["adr"] == 0
+    assert not [edge for edge in store.list_evidence_edges() if edge.artifact_id == adr.id]
+
+    adr_path.write_text(
+        "# ADR-9000\n\nSee docs/shared-owner.md. This decision covers RCA and "
+        "the Human Authority Kernel.\n",
+        encoding="utf-8",
+    )
+    selected = link_deterministic(store, root)
+    adr_edges = [
+        edge for edge in store.list_evidence_edges() if edge.artifact_id == adr.id
+    ]
+
+    assert selected["adr"] == 2
+    assert {edge.capability_id for edge in adr_edges} == {
+        capabilities["Human Authority Kernel"].id,
+        capabilities["Retrieval & Context Assembly"].id,
+    }
+    assert {edge.basis for edge in adr_edges} == {
+        "adr-reference:docs/shared-owner.md|selector:name:Human Authority Kernel",
+        "adr-reference:docs/shared-owner.md|selector:boundary:RCA",
+    }
+
+
+def test_live_adr_shared_seed_associations_name_their_selector(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _ingest_docs(store)
+
+    link_deterministic(store, REPO_ROOT)
+
+    artifacts = {artifact.id: artifact for artifact in store.list_artifacts()}
+    capabilities = {capability.id: capability for capability in store.list_capabilities()}
+    shared_edges = [
+        edge
+        for edge in store.list_evidence_edges()
+        if edge.basis.startswith(
+            "adr-reference:docs/SYSTEM_BREAKDOWN_STRUCTURE.md|selector:"
+        )
+    ]
+    assert shared_edges
+    assert not any(
+        artifacts[edge.artifact_id].source_ref
+        in {
+            "docs/adr/ADR-0015-authority-first-target-sbs.md",
+            "docs/adr/ADR-0016-contract-first-module-lazy-sbs.md",
+        }
+        for edge in shared_edges
+    )
+    for edge in shared_edges:
+        artifact = artifacts[edge.artifact_id]
+        capability = capabilities[edge.capability_id]
+        text = (REPO_ROOT / artifact.source_ref).read_text(encoding="utf-8")
+        selector = edge.basis.split("|selector:", 1)[1]
+        selector_kind, selector_value = selector.split(":", 1)
+        if selector_kind == "boundary":
+            assert capability.boundary_ref == selector_value
+            assert re.search(
+                rf"(?<![A-Z0-9]){re.escape(selector_value)}(?![A-Z0-9])", text
+            )
+        else:
+            assert selector_kind in {"name", "anchor"}
+            assert re.search(re.escape(selector_value), text, re.IGNORECASE)
+    assert any(
+        artifacts[edge.artifact_id].source_ref
+        == "docs/adr/ADR-0020-sfc-single-node-upgrade-path.md"
+        and capabilities[edge.capability_id].boundary_ref == "SFC"
+        for edge in shared_edges
+    )
+
+
 def test_link_idempotent_incremental(tmp_path: Path) -> None:
     store = _store(tmp_path)
     _ingest_docs(store)

--- a/tests/builderops/ckm/test_linkers.py
+++ b/tests/builderops/ckm/test_linkers.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from app.builderops.cli import builderops
+from app.builderops.ckm.ingest_repo import iter_docs
+from app.builderops.ckm.linkers import link_deterministic
+from app.builderops.ckm.seed import seed_capabilities
+from app.builderops.ckm.store import CkmStore
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _store(tmp_path: Path) -> CkmStore:
+    store = CkmStore(tmp_path / "builderops.sqlite3")
+    store.ensure_schema()
+    seed_capabilities(store, repo_root=REPO_ROOT)
+    return store
+
+
+def _ingest_docs(store: CkmStore) -> None:
+    for artifact in iter_docs(REPO_ROOT):
+        store.upsert_artifact(
+            source_ref=artifact.natural_key,
+            artifact_kind=artifact.artifact_kind,
+            source=artifact.source,
+            watermark=artifact.source_watermark,
+            provenance=artifact.provenance,
+        )
+
+
+def test_matrix_rows_become_edges_on_live_matrix(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _ingest_docs(store)
+    result = link_deterministic(store, REPO_ROOT)
+    matrix_edges = [
+        edge for edge in store.list_evidence_edges()
+        if json.loads(edge.source_ref)["basis"].startswith("matrix:")
+    ]
+    assert result["matrix"] > 0
+    assert matrix_edges
+    capability_by_id = {item.id: item for item in store.list_capabilities()}
+    assert {
+        capability_by_id[edge.capability_id].boundary_ref for edge in matrix_edges
+    } >= {"RCA", "GOV", "SIP"}
+
+
+def test_edges_carry_method_lifecycle_basis(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _ingest_docs(store)
+    link_deterministic(store, REPO_ROOT)
+    edges = store.list_evidence_edges()
+    assert edges
+    assert all(edge.extraction_method == "deterministic" for edge in edges)
+    assert all(edge.lifecycle == "confirmed" for edge in edges)
+    assert all(json.loads(edge.source_ref)["basis"] for edge in edges)
+
+
+def test_link_idempotent_incremental(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _ingest_docs(store)
+    first = link_deterministic(store, REPO_ROOT)
+    first_count = len(store.list_evidence_edges())
+    second = link_deterministic(store, REPO_ROOT)
+    assert first["matrix"] > 0
+    assert sum(second[name] for name in ("matrix", "spec", "adr", "test_code", "github_ref")) == 0
+    assert len(store.list_evidence_edges()) == first_count
+
+
+def test_unlinked_backlog_reported(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.upsert_artifact(
+        source_ref="docs/unlinked.md",
+        artifact_kind="document",
+        source="repo_docs",
+        watermark="one",
+        provenance='{"source_ref":"docs/unlinked.md"}',
+    )
+    result = link_deterministic(store, REPO_ROOT)
+    assert result["unlinked_artifacts"] == 1
+
+    runner = CliRunner()
+    invocation = runner.invoke(
+        builderops,
+        ["--db-path", str(store.db_path), "ckm", "link", "--repo-root", str(REPO_ROOT)],
+    )
+    assert invocation.exit_code == 0
+    assert "unlinked artifacts: 1" in invocation.output

--- a/tests/builderops/ckm/test_linkers.py
+++ b/tests/builderops/ckm/test_linkers.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import json
+import posixpath
+import re
 from pathlib import Path
 
 from click.testing import CliRunner
 
 from app.builderops.cli import builderops
-from app.builderops.ckm.ingest_repo import iter_docs
+from app.builderops.ckm.ingest_repo import iter_docs, iter_schemas, iter_tests
 from app.builderops.ckm.linkers import link_deterministic
 from app.builderops.ckm.seed import seed_capabilities
 from app.builderops.ckm.store import CkmStore
@@ -35,6 +37,30 @@ def _ingest_docs(store: CkmStore) -> None:
 def test_matrix_rows_become_edges_on_live_matrix(tmp_path: Path) -> None:
     store = _store(tmp_path)
     _ingest_docs(store)
+    for artifact in (*iter_tests(REPO_ROOT), *iter_schemas(REPO_ROOT)):
+        store.upsert_artifact(
+            source_ref=artifact.natural_key,
+            artifact_kind=artifact.artifact_kind,
+            source=artifact.source,
+            watermark=artifact.source_watermark,
+            provenance=artifact.provenance,
+        )
+    matrix_path = REPO_ROOT / "docs/architecture/traceability-matrix.md"
+    matrix_lines = matrix_path.read_text(encoding="utf-8").splitlines()
+    issue_numbers = {
+        number
+        for line in matrix_lines
+        if re.match(r"^\|\s*\d+\s*\|", line)
+        for number in re.findall(r"(?<![\w/])#(\d+)\b", line)
+    }
+    for number in issue_numbers:
+        store.upsert_artifact(
+            source_ref=f"github:issue:{number}",
+            artifact_kind="issue",
+            source="fixture",
+            watermark="one",
+            provenance=json.dumps({"references": []}),
+        )
     result = link_deterministic(store, REPO_ROOT)
     matrix_edges = [
         edge for edge in store.list_evidence_edges()
@@ -54,6 +80,37 @@ def test_matrix_rows_become_edges_on_live_matrix(tmp_path: Path) -> None:
     assert rca_ids <= {edge.capability_id for edge in matrix_edges}
     artifact_by_id = {item.id: item for item in store.list_artifacts()}
     assert any(artifact_by_id[edge.artifact_id].artifact_kind == "adr" for edge in matrix_edges)
+    edge_keys = {
+        (artifact_by_id[edge.artifact_id].source_ref, edge.capability_id, edge.basis)
+        for edge in matrix_edges
+    }
+    artifacts = {item.source_ref for item in artifact_by_id.values()}
+    capabilities_by_boundary: dict[str, set[str]] = {}
+    for capability in capability_by_id.values():
+        if capability.boundary_ref:
+            capabilities_by_boundary.setdefault(capability.boundary_ref, set()).add(capability.id)
+    for line_number, line in enumerate(matrix_lines, 1):
+        if not re.match(r"^\|\s*\d+\s*\|", line):
+            continue
+        boundaries = set(re.findall(r"\b(?:HIX|WSP|HKA|SIP|GOV|EBF|PDM|DRI|RCA|MEM|CAO|EXE|SFC|OEF|CES)\b", line))
+        references = {
+            match.replace("../", "")
+            for match in re.findall(
+                r"(?:\.\./)*(?:app|docs|tests|schemas)/[A-Za-z0-9_./-]+(?:\.md|\.py|\.json)?",
+                line,
+            )
+        }
+        references.update(
+            posixpath.normpath(posixpath.join("docs/architecture", target))
+            for target in re.findall(r"\]\(([^)#]+(?:\.md|\.py|\.json))\)", line)
+        )
+        references.update(f"github:issue:{number}" for number in re.findall(r"(?<![\w/])#(\d+)\b", line))
+        for number in re.findall(r"\bADR-(\d{4})\b", line):
+            references.update(ref for ref in artifacts if ref.startswith(f"docs/adr/ADR-{number}"))
+        for reference in references & artifacts:
+            for boundary in boundaries:
+                for capability_id in capabilities_by_boundary.get(boundary, set()):
+                    assert (reference, capability_id, f"matrix:row:{line_number}") in edge_keys
 
 
 def test_edges_carry_method_lifecycle_basis(tmp_path: Path) -> None:
@@ -125,60 +182,83 @@ def test_spec_test_code_and_github_linker_families(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     (root / "docs/CAP/TASK.md").write_text(
-        '---\nparent_capability: "Example Capability"\n---\n', encoding="utf-8"
+        '---\nparent_capability: "Example Capability"\n---\n\nImplementation: app/foo.py\n',
+        encoding="utf-8",
     )
     store = CkmStore(tmp_path / "builderops.sqlite3")
     store.ensure_schema()
-    capability = store.upsert_capability(
+    store.upsert_capability(
         name="Example Capability",
         definition="Fixture capability",
         existence_provenance="seeded:docs/owner.md :: example",
         lifecycle="confirmed",
     )
 
-    def artifact(source_ref: str, kind: str, references: list[str] | None = None):
+    def artifact(
+        source_ref: str,
+        kind: str,
+        references: list[str] | None = None,
+        **provenance: object,
+    ):
         return store.upsert_artifact(
             source_ref=source_ref,
             artifact_kind=kind,
             source="fixture",
             watermark="one",
-            provenance=json.dumps({"source_ref": source_ref, "references": references or []}),
+            provenance=json.dumps({
+                "source_ref": source_ref,
+                "references": references or [],
+                **provenance,
+            }),
         )
 
     source = artifact("app/foo.py", "source_file")
     test = artifact("tests/test_foo.py", "test")
     spec = artifact("docs/CAP/TASK.md", "spec")
-    issue = artifact("github:issue:1", "issue", ["docs/CAP/TASK.md"])
-    pull_request = artifact("github:pull_request:2", "pull_request", ["docs/owner.md"])
-    store.upsert_evidence_edge(
-        artifact_id=source.id,
-        capability_id=capability.id,
-        evidence_kind="source",
-        polarity="supports",
-        maturity_dimension="functional_completeness",
-        confidence=1.0,
-        extraction_method="deterministic",
-        lifecycle="confirmed",
-        source_ref=source.source_ref,
-        basis="fixture:source-capability",
+    issue = artifact(
+        "github:issue:1", "issue", ["docs/CAP/TASK.md"], state="open", labels=[]
+    )
+    pull_request = artifact(
+        "github:pull:2", "pull_request", ["docs/owner.md"], state="open", merged_at=None
+    )
+    closed_task = artifact(
+        "github:issue:3",
+        "issue",
+        ["docs/owner.md"],
+        state="closed",
+        labels=["type:task"],
+    )
+    merged_pr = artifact(
+        "github:pull:4",
+        "pull_request",
+        ["docs/owner.md"],
+        state="closed",
+        merged_at="2026-07-01T00:00:00Z",
     )
 
     result = link_deterministic(store, root)
     edges = store.list_evidence_edges()
-    by_artifact = {item.id: item for item in (test, spec, issue, pull_request)}
+    by_artifact = {
+        item.id: item for item in (source, test, spec, issue, pull_request, closed_task, merged_pr)
+    }
     linked = {
         (by_artifact[edge.artifact_id].source_ref, edge.basis)
         for edge in edges
         if edge.artifact_id in by_artifact
     }
-    assert result["spec"] == 1
+    assert result["spec"] == 2
     assert result["test_code"] == 1
-    assert result["github_ref"] == 2
+    assert result["github_ref"] == 4
+    assert ("app/foo.py", "spec-source:docs/CAP/TASK.md") in linked
     assert ("tests/test_foo.py", "test-code:app/foo.py") in linked
     assert ("docs/CAP/TASK.md", "spec-directory:docs/CAP/TASK.md") in linked
     assert ("github:issue:1", "github-spec-ref:docs/CAP/TASK.md") in linked
-    assert ("github:pull_request:2", "github-ref:docs/owner.md") in linked
-    assert any(edge.basis == "fixture:source-capability" for edge in edges)
+    assert ("github:pull:2", "github-ref:docs/owner.md") in linked
+    dimensions = {by_artifact[edge.artifact_id].source_ref: edge.maturity_dimension for edge in edges if edge.artifact_id in by_artifact and edge.basis.startswith("github")}
+    assert dimensions["github:issue:1"] == "integration_completeness"
+    assert dimensions["github:pull:2"] == "integration_completeness"
+    assert dimensions["github:issue:3"] == "requirement_coverage"
+    assert dimensions["github:pull:4"] == "functional_completeness"
 
 
 def test_unlinked_backlog_reported(tmp_path: Path) -> None:

--- a/tests/builderops/ckm/test_linkers.py
+++ b/tests/builderops/ckm/test_linkers.py
@@ -260,6 +260,79 @@ def test_spec_test_code_and_github_linker_families(tmp_path: Path) -> None:
     assert dimensions["github:issue:3"] == "requirement_coverage"
     assert dimensions["github:pull:4"] == "functional_completeness"
 
+    artifact(
+        "github:issue:1",
+        "issue",
+        ["docs/CAP/TASK.md"],
+        state="closed",
+        labels=["type:task"],
+    )
+    artifact(
+        "github:pull:2",
+        "pull_request",
+        ["docs/owner.md"],
+        state="closed",
+        merged_at="2026-07-02T00:00:00Z",
+    )
+    transition = link_deterministic(store, root)
+    transitioned = {
+        by_artifact[edge.artifact_id].source_ref: edge.maturity_dimension
+        for edge in store.list_evidence_edges()
+        if edge.artifact_id in {issue.id, pull_request.id}
+        and edge.basis.startswith("github")
+    }
+    assert transition["github_ref"] == 0
+    assert transitioned["github:issue:1"] == "requirement_coverage"
+    assert transitioned["github:pull:2"] == "functional_completeness"
+
+
+def test_candidate_inference_never_promotes_to_confirmed_test_edge(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    (root / "app").mkdir(parents=True)
+    (root / "tests").mkdir()
+    (root / "app/foo.py").write_text("def value() -> int:\n    return 1\n", encoding="utf-8")
+    (root / "tests/test_foo.py").write_text("from app.foo import value\n", encoding="utf-8")
+    store = CkmStore(tmp_path / "builderops.sqlite3")
+    store.ensure_schema()
+    capability = store.upsert_capability(
+        name="Inferred Capability",
+        definition="Fixture",
+        existence_provenance="seeded:docs/owner.md :: inferred",
+    )
+    source = store.upsert_artifact(
+        source_ref="app/foo.py",
+        artifact_kind="source_file",
+        source="fixture",
+        watermark="one",
+        provenance='{"source_ref":"app/foo.py"}',
+    )
+    store.upsert_artifact(
+        source_ref="tests/test_foo.py",
+        artifact_kind="test",
+        source="fixture",
+        watermark="one",
+        provenance='{"source_ref":"tests/test_foo.py"}',
+    )
+    store.upsert_evidence_edge(
+        artifact_id=source.id,
+        capability_id=capability.id,
+        evidence_kind="source",
+        polarity="supports",
+        maturity_dimension="functional_completeness",
+        confidence=0.5,
+        extraction_method="inferred",
+        lifecycle="candidate",
+        source_ref=source.source_ref,
+        basis="inferred:fixture",
+        model="fixture-model",
+        provider="fixture-provider",
+    )
+
+    result = link_deterministic(store, root)
+
+    assert result["test_code"] == 0
+    assert not any(edge.basis.startswith("test-code:") for edge in store.list_evidence_edges())
+
 
 def test_unlinked_backlog_reported(tmp_path: Path) -> None:
     store = _store(tmp_path)

--- a/tests/builderops/ckm/test_store.py
+++ b/tests/builderops/ckm/test_store.py
@@ -86,6 +86,60 @@ def test_upsert_idempotent_and_rebuild(store: CkmStore) -> None:
     assert store.list_artifacts() == []
 
 
+def test_schema_migrates_edge_basis_without_losing_rows(tmp_path: Path) -> None:
+    store = CkmStore(tmp_path / "builderops.sqlite3")
+    store.ensure_schema()
+    capability = _upsert_capability(store)
+    artifact = _upsert_artifact(store)
+    with sqlite3.connect(store.db_path) as conn:
+        conn.execute("DROP TABLE ckm_evidence_edge")
+        conn.execute(
+            """
+            CREATE TABLE ckm_evidence_edge (
+                id TEXT PRIMARY KEY,
+                artifact_id TEXT NOT NULL REFERENCES ckm_artifact(id),
+                capability_id TEXT NOT NULL REFERENCES ckm_capability(id),
+                evidence_kind TEXT NOT NULL,
+                polarity TEXT NOT NULL,
+                maturity_dimension TEXT NOT NULL,
+                confidence REAL NOT NULL,
+                extraction_method TEXT NOT NULL,
+                model TEXT,
+                provider TEXT,
+                lifecycle TEXT NOT NULL,
+                source_ref TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                UNIQUE (artifact_id, capability_id, evidence_kind, maturity_dimension)
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO ckm_evidence_edge VALUES
+            (?, ?, ?, 'adr', 'supports', 'requirement_coverage', 0.9,
+             'deterministic', NULL, NULL, 'confirmed', ?, 't', 't')
+            """,
+            ("edge_legacy", artifact.id, capability.id, artifact.source_ref),
+        )
+        conn.commit()
+
+    store.ensure_schema()
+
+    edges = store.list_evidence_edges()
+    assert len(edges) == 1
+    assert edges[0].id == "edge_legacy"
+    assert edges[0].basis == artifact.source_ref
+    with sqlite3.connect(store.db_path) as conn:
+        indexes = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'ckm_evidence_edge'"
+            )
+        }
+    assert {"idx_ckm_evidence_edge_capability", "idx_ckm_evidence_edge_artifact"} <= indexes
+
+
 # --- AC: provenance-bearing NOT NULL columns ---------------------------------
 
 

--- a/tests/builderops/ckm/test_store.py
+++ b/tests/builderops/ckm/test_store.py
@@ -122,14 +122,22 @@ def test_schema_migrates_edge_basis_without_losing_rows(tmp_path: Path) -> None:
             """,
             ("edge_legacy", artifact.id, capability.id, artifact.source_ref),
         )
+        conn.execute(
+            """
+            INSERT INTO ckm_evidence_edge VALUES
+            (?, ?, ?, 'doc', 'supports', 'documentation_quality', 0.8,
+             'deterministic', NULL, NULL, 'confirmed', ?, 't', 't')
+            """,
+            ("edge_legacy_second", artifact.id, capability.id, artifact.source_ref),
+        )
         conn.commit()
 
     store.ensure_schema()
 
     edges = store.list_evidence_edges()
-    assert len(edges) == 1
-    assert edges[0].id == "edge_legacy"
-    assert edges[0].basis == artifact.source_ref
+    assert {edge.id for edge in edges} == {"edge_legacy", "edge_legacy_second"}
+    assert len({edge.basis for edge in edges}) == 2
+    assert all(edge.source_ref == artifact.source_ref for edge in edges)
     with sqlite3.connect(store.db_path) as conn:
         indexes = {
             row[0]


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Closes #3143

## SBS Impact
- Primary subsystem: Builder System (BuilderOps plane)
- Write class: derived CKM evidence edges only
- Authority impact: none; projection-only confirmed mechanical edges
- Persistence impact: rebuildable additive CKM tables; schema v2 migrates the edge natural key without row loss
- Human knowledge / memory / runtime impact: none
- External boundary impact: none; consumes already-ingested artifacts
- New or changed contract: deterministic CKM linker stage and CLI command
- Owner-doc impact: repo ingestion spec updated for the schema producer
- Boundary risk: low; read-only repo inputs and derived BuilderOps writes

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Add deterministic CKM evidence linkers for matrix, spec, ADR, test/code, and GitHub references.
- Preserve all boundary-mapped capabilities, use artifact+capability+basis identity, prune only stale linker-owned edges, and expose the unlinked backlog.
- Fail closed on ambiguous shared ADR seed sources and record the capability-specific selector in provenance.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Repo ingestion owner spec updated for schema artifacts required by matrix citations.

## Validation
- [x] Full CKM suite: 38 passed.
- [x] `ruff check app tests`.
- [x] `mypy app/builderops/ckm app/builderops/cli.py`.
- [x] Live seed → full repo ingest → link twice: matrix/schema/test-code evidence produced; second run zero new; no unsupported test-code edges.
- [x] Live shared-SBS ADR audit: 18 edges across five ADRs; every selector occurs in source text; path-only ADR-0015/0016 remain unlinked.
- [x] Current-head GitHub CI at `738c9a479cbf0b079c2c0434e38f6b9e4fc063f9`: all required checks green; merge state clean.
- [x] Mandatory final independent review gate: accept, low residual risk.

## Review convergence receipt
- Standard repair 1: rejected; fixed boundary multiplicity, ADR citations, basis identity, stale reconciliation, and linker-family coverage.
- Standard repair 2: rejected; fixed source-backed test-code, GitHub state hints, schema producer, and exhaustive matrix verification.
- Escalated repair 1: rejected; fixed lifecycle transitions, multi-edge v1 migration, and inferred-candidate promotion.
- Escalated repair 2 (fresh high-reasoning context): accepted after fail-closed shared ADR seed disambiguation.
- Final round count: 4 fixes, each independently re-reviewed; final verdict clean.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: CKM edges and watermark are issue-scoped derived outputs.

## Notes
Dispatcher unavailable (`db_exists: false`) — used GitHub-label-only claim.