### PR TITLE
Add explainable CKM maturity assessments

### DIFF
--- a/app/builderops/ckm/assess.py
+++ b/app/builderops/ckm/assess.py
@@ -44,12 +44,12 @@ FORMULAS: dict[str, Formula] = {
     "functional-evidence-balance-v1": Formula(
         "functional-evidence-balance-v1",
         "functional_completeness",
-        "Confidence-weighted supporting functional edges divided by supporting plus weakening edges.",
+        "Realizing source/merged-PR confidence versus declared spec/requirement intent, reduced by weakening evidence.",
     ),
     "test-evidence-balance-v1": Formula(
         "test-evidence-balance-v1",
         "test_completeness",
-        "Confidence-weighted supporting test edges divided by supporting plus weakening edges.",
+        "Confidence-weighted executable test and invariant-registry evidence balance.",
     ),
     "current-doc-evidence-v1": Formula(
         "current-doc-evidence-v1",
@@ -59,7 +59,7 @@ FORMULAS: dict[str, Formula] = {
     "source-and-surface-span-v1": Formula(
         "source-and-surface-span-v1",
         "integration_completeness",
-        "Half credit for source realization and half for a caller/surface or integration edge.",
+        "Half credit for source realization and half for another caller/surface artifact kind, reduced by integration weaknesses.",
     ),
     "operational-evidence-balance-v1": Formula(
         "operational-evidence-balance-v1",
@@ -113,11 +113,6 @@ def _dimension_edges(edges: Sequence[CkmEvidenceEdge], dimension: str) -> tuple[
     return tuple(edge for edge in edges if edge.maturity_dimension == dimension)
 
 
-def _generic_dimension(edges: Sequence[CkmEvidenceEdge], dimension: str) -> DimensionResult:
-    selected = _dimension_edges(edges, dimension)
-    return DimensionResult(score=_edge_balance(selected), edges=selected)
-
-
 def _artifact_payload(artifact: CkmArtifact) -> Mapping[str, object]:
     try:
         value = json.loads(artifact.provenance)
@@ -126,10 +121,75 @@ def _artifact_payload(artifact: CkmArtifact) -> Mapping[str, object]:
     return value if isinstance(value, dict) else {}
 
 
+def _is_merged_pull_request(
+    edge: CkmEvidenceEdge, artifacts: Mapping[str, CkmArtifact]
+) -> bool:
+    return edge.evidence_kind == "pull_request" and bool(
+        _artifact_payload(artifacts[edge.artifact_id]).get("merged_at")
+    )
+
+
+def _functional(edges: Sequence[CkmEvidenceEdge], artifacts: Mapping[str, CkmArtifact]) -> DimensionResult:
+    """Compare realized source/merged-PR evidence with declared intent."""
+
+    relevant_kinds = {"source", "pull_request", "spec", "requirement"}
+    selected = tuple(
+        edge
+        for edge in edges
+        if edge.evidence_kind in relevant_kinds
+        or (
+            edge.maturity_dimension == "functional_completeness"
+            and edge.polarity == "weakens"
+        )
+    )
+    realization = sum(
+        float(edge.confidence)
+        for edge in selected
+        if edge.polarity == "supports"
+        and (
+            edge.evidence_kind == "source"
+            or _is_merged_pull_request(edge, artifacts)
+        )
+    )
+    intent = sum(
+        float(edge.confidence)
+        for edge in selected
+        if edge.polarity == "supports" and edge.evidence_kind in {"spec", "requirement"}
+    )
+    base = min(1.0, realization / max(1.0, intent))
+    weakening = sum(float(edge.confidence) for edge in selected if edge.polarity == "weakens")
+    score = base * (realization / (realization + weakening) if realization + weakening else 0.0)
+    return DimensionResult(score, selected)
+
+
+def _test_completeness(
+    edges: Sequence[CkmEvidenceEdge], artifacts: Mapping[str, CkmArtifact]
+) -> DimensionResult:
+    """Use executable test evidence plus explicit invariant-registry citations."""
+
+    test_kinds = {"test", "coverage", "benchmark", "ci_result"}
+    selected = tuple(
+        edge
+        for edge in edges
+        if edge.maturity_dimension == "test_completeness"
+        and (
+            edge.evidence_kind in test_kinds
+            or edge.source_ref == "docs/testing/invariant-tests.md"
+        )
+    )
+    return DimensionResult(_edge_balance(selected), selected)
+
+
 def _documentation(
     edges: Sequence[CkmEvidenceEdge], artifacts: Mapping[str, CkmArtifact]
 ) -> DimensionResult:
     selected = _dimension_edges(edges, "documentation_quality")
+    selected = tuple(
+        edge
+        for edge in selected
+        if edge.evidence_kind == "doc"
+        and artifacts[edge.artifact_id].artifact_kind == "document"
+    )
     if not selected:
         return DimensionResult(0.0, ())
     current = 0.0
@@ -158,17 +218,22 @@ def _integration(
         edge
         for edge in edges
         if edge.polarity == "supports"
-        and (
-            edge.maturity_dimension == "integration_completeness"
-            or edge.evidence_kind in {"doc", "pull_request"}
-        )
-        and edge not in source_edges
+        and edge.maturity_dimension == "integration_completeness"
+        and edge.evidence_kind != "source"
     )
-    selected = tuple(dict.fromkeys((*source_edges, *surface_edges)))
-    score = (0.5 if source_edges else 0.0) + (0.5 if surface_edges else 0.0)
-    weakening = [edge for edge in selected if edge.polarity == "weakens"]
-    if weakening:
-        score *= _edge_balance(selected)
+    weakening_edges = tuple(
+        edge for edge in edges if edge.maturity_dimension == "integration_completeness" and edge.polarity == "weakens"
+    )
+    selected = tuple(dict.fromkeys((*source_edges, *surface_edges, *weakening_edges)))
+    source_kinds = {artifacts[edge.artifact_id].artifact_kind for edge in source_edges}
+    surface_kinds = {artifacts[edge.artifact_id].artifact_kind for edge in surface_edges}
+    score = (0.5 if source_kinds else 0.0) + (0.5 if surface_kinds - source_kinds else 0.0)
+    supporting_confidence = sum(
+        float(edge.confidence) for edge in selected if edge.polarity == "supports"
+    )
+    weakening_confidence = sum(float(edge.confidence) for edge in weakening_edges)
+    if weakening_confidence:
+        score *= supporting_confidence / (supporting_confidence + weakening_confidence)
     return DimensionResult(score, selected)
 
 
@@ -179,8 +244,12 @@ def _operational(
     selected = tuple(
         edge
         for edge in edges
-        if edge.maturity_dimension == "operational_readiness"
-        or any(keyword in artifacts[edge.artifact_id].source_ref.casefold() for keyword in keywords)
+        if edge.evidence_kind == "doc"
+        and artifacts[edge.artifact_id].artifact_kind == "document"
+        and (
+            edge.maturity_dimension == "operational_readiness"
+            or any(keyword in artifacts[edge.artifact_id].source_ref.casefold() for keyword in keywords)
+        )
     )
     return DimensionResult(_edge_balance(selected), selected)
 
@@ -197,12 +266,14 @@ def _architectural_stability(
         float(edge.confidence)
         for edge in architecture
         if edge.polarity == "supports"
+        and artifacts[edge.artifact_id].artifact_kind != "commit"
     )
     weakening = sum(
         float(edge.confidence)
         for edge in architecture
         if edge.polarity == "weakens"
-    ) + len(churn)
+        and artifacts[edge.artifact_id].artifact_kind != "commit"
+    ) + sum(float(edge.confidence) for edge in churn)
     denominator = stable + weakening
     return DimensionResult(stable / denominator if denominator else 0.0, selected)
 
@@ -214,7 +285,8 @@ def _requirement_coverage(
     realization = tuple(
         edge
         for edge in edges
-        if edge.polarity == "supports" and edge.evidence_kind in {"source", "pull_request"}
+        if edge.polarity == "supports"
+        and (edge.evidence_kind == "source" or _is_merged_pull_request(edge, artifacts))
     )
     verification = tuple(
         edge
@@ -223,11 +295,21 @@ def _requirement_coverage(
         and edge.evidence_kind in {"test", "coverage", "benchmark", "ci_result"}
     )
     selected = tuple(dict.fromkeys((*intent, *realization, *verification)))
-    if not intent:
+    supporting_intent = sum(
+        float(edge.confidence) for edge in intent if edge.polarity == "supports"
+    )
+    if not supporting_intent:
         return DimensionResult(0.0, selected)
-    score = (0.5 if realization else 0.0) + (0.5 if verification else 0.0)
-    if any(edge.polarity == "weakens" for edge in intent):
-        score *= _edge_balance(intent)
+    realization_coverage = min(
+        1.0, sum(float(edge.confidence) for edge in realization) / supporting_intent
+    )
+    verification_coverage = min(
+        1.0, sum(float(edge.confidence) for edge in verification) / supporting_intent
+    )
+    score = min(realization_coverage, verification_coverage)
+    weakening = sum(float(edge.confidence) for edge in intent if edge.polarity == "weakens")
+    if weakening:
+        score *= supporting_intent / (supporting_intent + weakening)
     return DimensionResult(score, selected)
 
 
@@ -235,12 +317,8 @@ _SCORERS: Mapping[
     str,
     Callable[[Sequence[CkmEvidenceEdge], Mapping[str, CkmArtifact]], DimensionResult],
 ] = {
-    "functional_completeness": lambda edges, artifacts: _generic_dimension(
-        edges, "functional_completeness"
-    ),
-    "test_completeness": lambda edges, artifacts: _generic_dimension(
-        edges, "test_completeness"
-    ),
+    "functional_completeness": _functional,
+    "test_completeness": _test_completeness,
     "documentation_quality": _documentation,
     "integration_completeness": _integration,
     "operational_readiness": _operational,
@@ -261,8 +339,11 @@ def compute_aggregate(scores: Mapping[str, float]) -> float:
     )
 
 
-def _fingerprint(edges: Sequence[CkmEvidenceEdge]) -> str:
-    payload = [
+def _fingerprint(
+    edges: Sequence[CkmEvidenceEdge],
+    artifacts: Mapping[str, CkmArtifact],
+) -> str:
+    edge_payload = [
         {
             "id": edge.id,
             "artifact_id": edge.artifact_id,
@@ -275,9 +356,27 @@ def _fingerprint(edges: Sequence[CkmEvidenceEdge]) -> str:
             "lifecycle": edge.lifecycle,
             "model": edge.model,
             "provider": edge.provider,
+            "artifact": {
+                "kind": artifacts[edge.artifact_id].artifact_kind,
+                "source_ref": artifacts[edge.artifact_id].source_ref,
+                "watermark": artifacts[edge.artifact_id].watermark,
+                "provenance": artifacts[edge.artifact_id].provenance,
+            },
         }
         for edge in sorted(edges, key=lambda item: (item.artifact_id, item.basis, item.id))
     ]
+    formula_payload = {
+        formula_id: {
+            "dimension": FORMULAS[formula_id].dimension,
+            "description": FORMULAS[formula_id].description,
+            "weight": FORMULAS[formula_id].weight,
+        }
+        for formula_id in (*_DIMENSION_FORMULA_IDS.values(), AGGREGATE_FORMULA_ID)
+    }
+    payload = {
+        "edges": edge_payload,
+        "formulae": formula_payload,
+    }
     return hashlib.sha256(
         json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
     ).hexdigest()
@@ -306,7 +405,7 @@ def assess_capabilities(store: CkmStore) -> AssessmentRunResult:
     skipped = 0
     for capability in store.list_capabilities():
         edges = store.list_evidence_edges_for_capability(capability.id)
-        fingerprint = _fingerprint(edges)
+        fingerprint = _fingerprint(edges, artifacts)
         latest = store.latest_assessment_for_capability(capability.id)
         if latest is not None and latest.edge_fingerprint == fingerprint:
             skipped += 1

--- a/app/builderops/ckm/assess.py
+++ b/app/builderops/ckm/assess.py
@@ -1,0 +1,346 @@
+"""Transparent, incremental maturity assessment for CKM capabilities.
+
+No score in this module is inferred by an LLM.  ``FORMULAS`` is the
+published/versioned formula table; stored assessments carry the exact formula
+ids and evidence-edge citations needed to reproduce every value.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Callable, Mapping, Sequence
+
+from app.builderops.ckm.models import (
+    MATURITY_DIMENSIONS,
+    CkmArtifact,
+    CkmEvidenceEdge,
+    CkmValidationError,
+)
+from app.builderops.ckm.store import CkmStore
+
+
+@dataclass(frozen=True)
+class Formula:
+    formula_id: str
+    dimension: str
+    description: str
+    weight: float = 1.0
+
+
+_DIMENSION_FORMULA_IDS = {
+    "functional_completeness": "functional-evidence-balance-v1",
+    "test_completeness": "test-evidence-balance-v1",
+    "documentation_quality": "current-doc-evidence-v1",
+    "integration_completeness": "source-and-surface-span-v1",
+    "operational_readiness": "operational-evidence-balance-v1",
+    "architectural_stability": "architecture-vs-churn-v1",
+    "requirement_coverage": "intent-realization-verification-v1",
+}
+AGGREGATE_FORMULA_ID = "aggregate-weighted-min-v1"
+
+FORMULAS: dict[str, Formula] = {
+    "functional-evidence-balance-v1": Formula(
+        "functional-evidence-balance-v1",
+        "functional_completeness",
+        "Confidence-weighted supporting functional edges divided by supporting plus weakening edges.",
+    ),
+    "test-evidence-balance-v1": Formula(
+        "test-evidence-balance-v1",
+        "test_completeness",
+        "Confidence-weighted supporting test edges divided by supporting plus weakening edges.",
+    ),
+    "current-doc-evidence-v1": Formula(
+        "current-doc-evidence-v1",
+        "documentation_quality",
+        "Current State:-bearing supporting documentation divided by all cited documentation evidence.",
+    ),
+    "source-and-surface-span-v1": Formula(
+        "source-and-surface-span-v1",
+        "integration_completeness",
+        "Half credit for source realization and half for a caller/surface or integration edge.",
+    ),
+    "operational-evidence-balance-v1": Formula(
+        "operational-evidence-balance-v1",
+        "operational_readiness",
+        "Confidence-weighted operational/runbook/health evidence balance.",
+    ),
+    "architecture-vs-churn-v1": Formula(
+        "architecture-vs-churn-v1",
+        "architectural_stability",
+        "Supporting architectural evidence divided by that evidence plus linked commit churn.",
+    ),
+    "intent-realization-verification-v1": Formula(
+        "intent-realization-verification-v1",
+        "requirement_coverage",
+        "Intent is covered only to the extent the capability also has realizing and verifying evidence.",
+    ),
+    AGGREGATE_FORMULA_ID: Formula(
+        AGGREGATE_FORMULA_ID,
+        "aggregate",
+        "Minimum of each dimension score multiplied by its published dimension weight.",
+    ),
+    "legacy-pre-ckm07": Formula(
+        "legacy-pre-ckm07",
+        "legacy",
+        "Migration marker for assessment rows created before formula metadata existed.",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class DimensionResult:
+    score: float
+    edges: tuple[CkmEvidenceEdge, ...]
+
+
+@dataclass(frozen=True)
+class AssessmentRunResult:
+    assessed: int
+    skipped: int
+    assessment_ids: tuple[str, ...]
+
+
+def _edge_balance(edges: Sequence[CkmEvidenceEdge]) -> float:
+    supporting = sum(float(edge.confidence) for edge in edges if edge.polarity == "supports")
+    weakening = sum(float(edge.confidence) for edge in edges if edge.polarity == "weakens")
+    denominator = supporting + weakening
+    return 0.0 if denominator == 0 else supporting / denominator
+
+
+def _dimension_edges(edges: Sequence[CkmEvidenceEdge], dimension: str) -> tuple[CkmEvidenceEdge, ...]:
+    return tuple(edge for edge in edges if edge.maturity_dimension == dimension)
+
+
+def _generic_dimension(edges: Sequence[CkmEvidenceEdge], dimension: str) -> DimensionResult:
+    selected = _dimension_edges(edges, dimension)
+    return DimensionResult(score=_edge_balance(selected), edges=selected)
+
+
+def _artifact_payload(artifact: CkmArtifact) -> Mapping[str, object]:
+    try:
+        value = json.loads(artifact.provenance)
+    except json.JSONDecodeError:
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _documentation(
+    edges: Sequence[CkmEvidenceEdge], artifacts: Mapping[str, CkmArtifact]
+) -> DimensionResult:
+    selected = _dimension_edges(edges, "documentation_quality")
+    if not selected:
+        return DimensionResult(0.0, ())
+    current = 0.0
+    total = 0.0
+    for edge in selected:
+        total += float(edge.confidence)
+        summary = str(_artifact_payload(artifacts[edge.artifact_id]).get("payload_summary", ""))
+        if (
+            edge.polarity == "supports"
+            and "State:" in summary
+            and "State: (not declared)" not in summary
+        ):
+            current += float(edge.confidence)
+    return DimensionResult(current / total if total else 0.0, selected)
+
+
+def _integration(
+    edges: Sequence[CkmEvidenceEdge], artifacts: Mapping[str, CkmArtifact]
+) -> DimensionResult:
+    source_edges = tuple(
+        edge
+        for edge in edges
+        if edge.polarity == "supports" and edge.evidence_kind == "source"
+    )
+    surface_edges = tuple(
+        edge
+        for edge in edges
+        if edge.polarity == "supports"
+        and (
+            edge.maturity_dimension == "integration_completeness"
+            or edge.evidence_kind in {"doc", "pull_request"}
+        )
+        and edge not in source_edges
+    )
+    selected = tuple(dict.fromkeys((*source_edges, *surface_edges)))
+    score = (0.5 if source_edges else 0.0) + (0.5 if surface_edges else 0.0)
+    weakening = [edge for edge in selected if edge.polarity == "weakens"]
+    if weakening:
+        score *= _edge_balance(selected)
+    return DimensionResult(score, selected)
+
+
+def _operational(
+    edges: Sequence[CkmEvidenceEdge], artifacts: Mapping[str, CkmArtifact]
+) -> DimensionResult:
+    keywords = ("operat", "runbook", "health", "observab", "deploy")
+    selected = tuple(
+        edge
+        for edge in edges
+        if edge.maturity_dimension == "operational_readiness"
+        or any(keyword in artifacts[edge.artifact_id].source_ref.casefold() for keyword in keywords)
+    )
+    return DimensionResult(_edge_balance(selected), selected)
+
+
+def _architectural_stability(
+    edges: Sequence[CkmEvidenceEdge], artifacts: Mapping[str, CkmArtifact]
+) -> DimensionResult:
+    architecture = tuple(
+        edge for edge in edges if edge.maturity_dimension == "architectural_stability"
+    )
+    churn = tuple(edge for edge in edges if artifacts[edge.artifact_id].artifact_kind == "commit")
+    selected = tuple(dict.fromkeys((*architecture, *churn)))
+    stable = sum(
+        float(edge.confidence)
+        for edge in architecture
+        if edge.polarity == "supports"
+    )
+    weakening = sum(
+        float(edge.confidence)
+        for edge in architecture
+        if edge.polarity == "weakens"
+    ) + len(churn)
+    denominator = stable + weakening
+    return DimensionResult(stable / denominator if denominator else 0.0, selected)
+
+
+def _requirement_coverage(
+    edges: Sequence[CkmEvidenceEdge], artifacts: Mapping[str, CkmArtifact]
+) -> DimensionResult:
+    intent = tuple(edge for edge in edges if edge.evidence_kind in {"requirement", "spec"})
+    realization = tuple(
+        edge
+        for edge in edges
+        if edge.polarity == "supports" and edge.evidence_kind in {"source", "pull_request"}
+    )
+    verification = tuple(
+        edge
+        for edge in edges
+        if edge.polarity == "supports"
+        and edge.evidence_kind in {"test", "coverage", "benchmark", "ci_result"}
+    )
+    selected = tuple(dict.fromkeys((*intent, *realization, *verification)))
+    if not intent:
+        return DimensionResult(0.0, selected)
+    score = (0.5 if realization else 0.0) + (0.5 if verification else 0.0)
+    if any(edge.polarity == "weakens" for edge in intent):
+        score *= _edge_balance(intent)
+    return DimensionResult(score, selected)
+
+
+_SCORERS: Mapping[
+    str,
+    Callable[[Sequence[CkmEvidenceEdge], Mapping[str, CkmArtifact]], DimensionResult],
+] = {
+    "functional_completeness": lambda edges, artifacts: _generic_dimension(
+        edges, "functional_completeness"
+    ),
+    "test_completeness": lambda edges, artifacts: _generic_dimension(
+        edges, "test_completeness"
+    ),
+    "documentation_quality": _documentation,
+    "integration_completeness": _integration,
+    "operational_readiness": _operational,
+    "architectural_stability": _architectural_stability,
+    "requirement_coverage": _requirement_coverage,
+}
+
+
+def compute_aggregate(scores: Mapping[str, float]) -> float:
+    """Published weighted-min aggregate; the seven scores remain primary."""
+
+    missing = set(MATURITY_DIMENSIONS) - set(scores)
+    if missing:
+        raise CkmValidationError(f"aggregate missing dimension score(s): {sorted(missing)}")
+    return min(
+        float(scores[dimension]) * FORMULAS[_DIMENSION_FORMULA_IDS[dimension]].weight
+        for dimension in MATURITY_DIMENSIONS
+    )
+
+
+def _fingerprint(edges: Sequence[CkmEvidenceEdge]) -> str:
+    payload = [
+        {
+            "id": edge.id,
+            "artifact_id": edge.artifact_id,
+            "basis": edge.basis,
+            "kind": edge.evidence_kind,
+            "polarity": edge.polarity,
+            "dimension": edge.maturity_dimension,
+            "confidence": edge.confidence,
+            "method": edge.extraction_method,
+            "lifecycle": edge.lifecycle,
+            "model": edge.model,
+            "provider": edge.provider,
+        }
+        for edge in sorted(edges, key=lambda item: (item.artifact_id, item.basis, item.id))
+    ]
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _citation(edge: CkmEvidenceEdge) -> dict[str, object]:
+    return {
+        "edge_id": edge.id,
+        "artifact_id": edge.artifact_id,
+        "source_ref": edge.source_ref,
+        "evidence_kind": edge.evidence_kind,
+        "polarity": edge.polarity,
+        "lifecycle": edge.lifecycle,
+    }
+
+
+def assess_capabilities(store: CkmStore) -> AssessmentRunResult:
+    """Append assessments only for capabilities whose evidence set changed."""
+
+    store.ensure_schema()
+    watermarks = store.current_watermark_set()
+    if not watermarks:
+        raise CkmValidationError("cannot assess before ingestion records a source watermark")
+    artifacts = {artifact.id: artifact for artifact in store.list_artifacts()}
+    assessed_ids: list[str] = []
+    skipped = 0
+    for capability in store.list_capabilities():
+        edges = store.list_evidence_edges_for_capability(capability.id)
+        fingerprint = _fingerprint(edges)
+        latest = store.latest_assessment_for_capability(capability.id)
+        if latest is not None and latest.edge_fingerprint == fingerprint:
+            skipped += 1
+            continue
+
+        scores: dict[str, float] = {}
+        citations: dict[str, list[dict[str, object]]] = {}
+        candidate_shares: dict[str, float] = {}
+        formula_ids: dict[str, str] = {}
+        for dimension in MATURITY_DIMENSIONS:
+            result = _SCORERS[dimension](edges, artifacts)
+            scores[dimension] = max(0.0, min(1.0, result.score))
+            citations[dimension] = [_citation(edge) for edge in result.edges]
+            supporting = [edge for edge in result.edges if edge.polarity == "supports"]
+            candidates = [edge for edge in supporting if edge.lifecycle == "candidate"]
+            candidate_shares[dimension] = (
+                len(candidates) / len(supporting) if supporting else 0.0
+            )
+            formula_ids[dimension] = _DIMENSION_FORMULA_IDS[dimension]
+        assessment = store.append_assessment(
+            capability_id=capability.id,
+            scores=scores,
+            citations=citations,
+            candidate_shares=candidate_shares,
+            formula_ids=formula_ids,
+            aggregate=compute_aggregate(scores),
+            aggregate_formula_id=AGGREGATE_FORMULA_ID,
+            low_confidence=any(share > 0.5 for share in candidate_shares.values()),
+            edge_fingerprint=fingerprint,
+            watermark_set=watermarks,
+        )
+        assessed_ids.append(assessment.id)
+    return AssessmentRunResult(
+        assessed=len(assessed_ids),
+        skipped=skipped,
+        assessment_ids=tuple(assessed_ids),
+    )

--- a/app/builderops/ckm/assess.py
+++ b/app/builderops/ckm/assess.py
@@ -382,7 +382,9 @@ def _fingerprint(
     ).hexdigest()
 
 
-def _citation(edge: CkmEvidenceEdge) -> dict[str, object]:
+def _citation(edge: CkmEvidenceEdge, artifact: CkmArtifact) -> dict[str, object]:
+    """Freeze the complete evidence input behind one historical score."""
+
     return {
         "edge_id": edge.id,
         "artifact_id": edge.artifact_id,
@@ -390,6 +392,8 @@ def _citation(edge: CkmEvidenceEdge) -> dict[str, object]:
         "evidence_kind": edge.evidence_kind,
         "polarity": edge.polarity,
         "lifecycle": edge.lifecycle,
+        "edge": edge.to_dict(),
+        "artifact": artifact.to_dict(),
     }
 
 
@@ -418,7 +422,9 @@ def assess_capabilities(store: CkmStore) -> AssessmentRunResult:
         for dimension in MATURITY_DIMENSIONS:
             result = _SCORERS[dimension](edges, artifacts)
             scores[dimension] = max(0.0, min(1.0, result.score))
-            citations[dimension] = [_citation(edge) for edge in result.edges]
+            citations[dimension] = [
+                _citation(edge, artifacts[edge.artifact_id]) for edge in result.edges
+            ]
             supporting = [edge for edge in result.edges if edge.polarity == "supports"]
             candidates = [edge for edge in supporting if edge.lifecycle == "candidate"]
             candidate_shares[dimension] = (

--- a/app/builderops/ckm/models.py
+++ b/app/builderops/ckm/models.py
@@ -319,7 +319,12 @@ class CkmAssessment:
     capability_id: str
     scores: Mapping[str, float]
     citations: Mapping[str, list[JsonDict]]
+    candidate_shares: Mapping[str, float]
+    formula_ids: Mapping[str, str]
     aggregate: float
+    aggregate_formula_id: str
+    low_confidence: bool
+    edge_fingerprint: str
     watermark_set: Mapping[str, str]
     valid_from: str
     asserted_at: str
@@ -334,10 +339,18 @@ class CkmAssessment:
             score = self.scores[dimension]
             if not isinstance(score, (int, float)) or not (0.0 <= float(score) <= 1.0):
                 raise CkmValidationError(f"{dimension} score must be a number in [0.0, 1.0]")
-            if dimension not in self.citations or not self.citations[dimension]:
-                raise CkmValidationError(f"{dimension} must cite at least one evidence edge")
+            if dimension not in self.citations:
+                raise CkmValidationError(f"{dimension} must carry a citations list")
+            share = self.candidate_shares.get(dimension)
+            if not isinstance(share, (int, float)) or not (0.0 <= float(share) <= 1.0):
+                raise CkmValidationError(f"{dimension} candidate share must be in [0.0, 1.0]")
+            _require_nonempty_str(self.formula_ids.get(dimension), f"{dimension} formula_id")
         if not isinstance(self.aggregate, (int, float)) or not (0.0 <= float(self.aggregate) <= 1.0):
             raise CkmValidationError("aggregate must be a number in [0.0, 1.0]")
+        _require_nonempty_str(self.aggregate_formula_id, "aggregate_formula_id")
+        if not isinstance(self.low_confidence, bool):
+            raise CkmValidationError("low_confidence must be a boolean")
+        _require_nonempty_str(self.edge_fingerprint, "edge_fingerprint")
         if not self.watermark_set:
             raise CkmValidationError("watermark_set must not be empty")
         _require_nonempty_str(self.valid_from, "valid_from")
@@ -351,6 +364,8 @@ class CkmAssessment:
         *,
         scores: Mapping[str, float],
         citations: Mapping[str, list[JsonDict]],
+        candidate_shares: Mapping[str, float],
+        formula_ids: Mapping[str, str],
         watermark_set: Mapping[str, str],
     ) -> "CkmAssessment":
         return cls(
@@ -358,7 +373,12 @@ class CkmAssessment:
             capability_id=row["capability_id"],
             scores=scores,
             citations=citations,
+            candidate_shares=candidate_shares,
+            formula_ids=formula_ids,
             aggregate=row["aggregate"],
+            aggregate_formula_id=row["aggregate_formula_id"],
+            low_confidence=bool(row["low_confidence"]),
+            edge_fingerprint=row["edge_fingerprint"],
             watermark_set=watermark_set,
             valid_from=row["valid_from"],
             asserted_at=row["asserted_at"],
@@ -370,11 +390,25 @@ class CkmAssessment:
             "capability_id": self.capability_id,
             "scores": dict(self.scores),
             "citations": {k: list(v) for k, v in self.citations.items()},
+            "candidate_shares": dict(self.candidate_shares),
+            "formula_ids": dict(self.formula_ids),
             "aggregate": self.aggregate,
+            "aggregate_formula_id": self.aggregate_formula_id,
+            "low_confidence": self.low_confidence,
+            "edge_fingerprint": self.edge_fingerprint,
             "watermark_set": dict(self.watermark_set),
             "valid_from": self.valid_from,
             "asserted_at": self.asserted_at,
         }
+
+
+@dataclass(frozen=True)
+class CkmAssessmentProjection:
+    """Projection read model with freshness computed from current store state."""
+
+    assessment: CkmAssessment
+    current_watermark_set: Mapping[str, str]
+    stale_relative_to_evidence: bool
 
 
 @dataclass(frozen=True)

--- a/app/builderops/ckm/schema.py
+++ b/app/builderops/ckm/schema.py
@@ -13,12 +13,13 @@ schema level, not only in application code.
 
 from __future__ import annotations
 
-CKM_SCHEMA_VERSION = 3
+CKM_SCHEMA_VERSION = 4
 
 CKM_TABLE_NAMES = (
     "ckm_capability",
     "ckm_artifact",
     "ckm_evidence_edge",
+    "ckm_evidence_edge_history",
     "ckm_assessment",
     "ckm_finding",
     "ckm_watermark",
@@ -85,6 +86,31 @@ CKM_DDL_STATEMENTS = [
     """
     CREATE INDEX IF NOT EXISTS idx_ckm_evidence_edge_artifact
     ON ckm_evidence_edge(artifact_id)
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS ckm_evidence_edge_history (
+        history_id TEXT PRIMARY KEY,
+        edge_id TEXT NOT NULL,
+        artifact_id TEXT NOT NULL,
+        capability_id TEXT NOT NULL,
+        evidence_kind TEXT NOT NULL,
+        polarity TEXT NOT NULL,
+        maturity_dimension TEXT NOT NULL,
+        confidence REAL NOT NULL,
+        extraction_method TEXT NOT NULL,
+        model TEXT,
+        provider TEXT,
+        lifecycle TEXT NOT NULL,
+        source_ref TEXT NOT NULL,
+        basis TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        retired_at TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_ckm_evidence_edge_history_edge
+    ON ckm_evidence_edge_history(edge_id, retired_at)
     """,
     """
     CREATE TABLE IF NOT EXISTS ckm_assessment (

--- a/app/builderops/ckm/schema.py
+++ b/app/builderops/ckm/schema.py
@@ -13,7 +13,7 @@ schema level, not only in application code.
 
 from __future__ import annotations
 
-CKM_SCHEMA_VERSION = 2
+CKM_SCHEMA_VERSION = 3
 
 CKM_TABLE_NAMES = (
     "ckm_capability",
@@ -104,7 +104,12 @@ CKM_DDL_STATEMENTS = [
         architectural_stability_citations TEXT NOT NULL,
         requirement_coverage REAL NOT NULL,
         requirement_coverage_citations TEXT NOT NULL,
+        candidate_shares TEXT NOT NULL,
+        formula_ids TEXT NOT NULL,
         aggregate REAL NOT NULL,
+        aggregate_formula_id TEXT NOT NULL,
+        low_confidence INTEGER NOT NULL CHECK (low_confidence IN (0, 1)),
+        edge_fingerprint TEXT NOT NULL,
         watermark_set TEXT NOT NULL,
         valid_from TEXT NOT NULL,
         asserted_at TEXT NOT NULL

--- a/app/builderops/ckm/semantic.py
+++ b/app/builderops/ckm/semantic.py
@@ -510,6 +510,13 @@ def reapply_confirmation_receipts(store: CkmStore) -> int:
             capability = capabilities[capability.name]
         except (CkmValidationError, KeyError, TypeError, ValueError):
             continue
+        active = store.get_active_evidence_edge_by_id(payload["edge_id"])
+        if active is None and store.has_retired_evidence_edge(payload["edge_id"]):
+            # Explicit retirement in the current derived graph is not a partial
+            # rebuild. Replaying the older confirmation would resurrect evidence
+            # that cleanup intentionally removed. A true rebuild drops both the
+            # active and history tables, so the normal restoration path remains.
+            continue
         edge = store.upsert_evidence_edge(
             artifact_id=artifact.id,
             capability_id=capability.id,

--- a/app/builderops/ckm/semantic.py
+++ b/app/builderops/ckm/semantic.py
@@ -303,7 +303,7 @@ def _canonical_json(value: Any) -> str:
 
 
 def _confirmation_payload(store: CkmStore, edge_id: str) -> tuple[dict[str, Any], str, str]:
-    edge = store.get_evidence_edge_by_id(edge_id)
+    edge = store.get_active_evidence_edge_by_id(edge_id)
     if edge is None:
         raise CkmValidationError(f"evidence edge not found: {edge_id}")
     if edge.extraction_method != "inferred":
@@ -442,7 +442,7 @@ def _validated_confirmation_receipt(
     if not hmac.compare_digest(payload["binding"], expected_binding):
         raise CkmValidationError("confirmation receipt trusted binding is invalid")
 
-    current = store.get_evidence_edge_by_id(edge_id)
+    current = store.get_active_evidence_edge_by_id(edge_id)
     if current is not None:
         expected_payload, _, _ = _confirmation_payload(store, current.id)
         for field, value in expected_payload.items():

--- a/app/builderops/ckm/store.py
+++ b/app/builderops/ckm/store.py
@@ -26,6 +26,7 @@ from app.builderops.ckm.models import (
     MATURITY_DIMENSIONS,
     CkmArtifact,
     CkmAssessment,
+    CkmAssessmentProjection,
     CkmCapability,
     CkmEvidenceEdge,
     CkmFinding,
@@ -87,6 +88,7 @@ class CkmStore:
         self._receipt_store.initialize()
         with self._connect() as conn:
             self._migrate_evidence_edge_basis(conn)
+            self._migrate_assessment_explainability(conn)
             for statement in CKM_DDL_STATEMENTS:
                 conn.execute(statement)
             conn.commit()
@@ -132,6 +134,37 @@ class CkmStore:
             """
         )
         conn.execute("DROP TABLE ckm_evidence_edge_v1")
+
+    @staticmethod
+    def _migrate_assessment_explainability(conn: sqlite3.Connection) -> None:
+        columns = {
+            row["name"] for row in conn.execute("PRAGMA table_info(ckm_assessment)").fetchall()
+        }
+        if not columns:
+            return
+        additions = (
+            ("candidate_shares", "TEXT NOT NULL DEFAULT '{}'"),
+            ("formula_ids", "TEXT NOT NULL DEFAULT '{}'"),
+            (
+                "aggregate_formula_id",
+                "TEXT NOT NULL DEFAULT 'aggregate-weighted-min-v1'",
+            ),
+            ("low_confidence", "INTEGER NOT NULL DEFAULT 0 CHECK (low_confidence IN (0, 1))"),
+            ("edge_fingerprint", "TEXT NOT NULL DEFAULT 'legacy'"),
+        )
+        for name, declaration in additions:
+            if name not in columns:
+                conn.execute(f"ALTER TABLE ckm_assessment ADD COLUMN {name} {declaration}")
+        zero_shares = _dumps({dimension: 0.0 for dimension in MATURITY_DIMENSIONS})
+        legacy_formulas = _dumps({dimension: "legacy-pre-ckm07" for dimension in MATURITY_DIMENSIONS})
+        conn.execute(
+            """
+            UPDATE ckm_assessment
+            SET candidate_shares = CASE WHEN candidate_shares = '{}' THEN ? ELSE candidate_shares END,
+                formula_ids = CASE WHEN formula_ids = '{}' THEN ? ELSE formula_ids END
+            """,
+            (zero_shares, legacy_formulas),
+        )
 
     def rebuild(self) -> dict[str, Any]:
         """Drop and recreate ``ckm_*`` tables only (INV-CKM-4). Emits a receipt."""
@@ -319,6 +352,11 @@ class CkmStore:
                 (source, value, utc_now()),
             )
             conn.commit()
+
+    def current_watermark_set(self) -> dict[str, str]:
+        with self._connect() as conn:
+            rows = conn.execute("SELECT source, value FROM ckm_watermark ORDER BY source").fetchall()
+        return {str(row["source"]): str(row["value"]) for row in rows}
 
     # --- Evidence edge ---------------------------------------------------------
 
@@ -567,6 +605,11 @@ class CkmStore:
             conn.commit()
         return len(stale)
 
+    def delete_evidence_edge(self, edge_id: str) -> None:
+        with self._connect() as conn:
+            conn.execute("DELETE FROM ckm_evidence_edge WHERE id = ?", (edge_id,))
+            conn.commit()
+
     # --- Assessment (append-only, bitemporal) -----------------------------------
 
     def append_assessment(
@@ -575,7 +618,12 @@ class CkmStore:
         capability_id: str,
         scores: Mapping[str, float],
         citations: Mapping[str, list[JsonDict]],
+        candidate_shares: Mapping[str, float] | None = None,
+        formula_ids: Mapping[str, str] | None = None,
         aggregate: float,
+        aggregate_formula_id: str = "legacy-pre-ckm07",
+        low_confidence: bool = False,
+        edge_fingerprint: str = "legacy",
         watermark_set: Mapping[str, str],
         valid_from: str | None = None,
         asserted_at: str | None = None,
@@ -583,11 +631,17 @@ class CkmStore:
         missing = set(MATURITY_DIMENSIONS) - set(scores)
         if missing:
             raise CkmValidationError(f"assessment missing dimension score(s): {sorted(missing)}")
-        missing_citations = [d for d in MATURITY_DIMENSIONS if not citations.get(d)]
+        missing_citations = [d for d in MATURITY_DIMENSIONS if d not in citations]
         if missing_citations:
             raise CkmValidationError(
-                f"assessment dimension(s) missing citations: {sorted(missing_citations)}"
+                f"assessment dimension(s) missing citations list: {sorted(missing_citations)}"
             )
+        resolved_candidate_shares = candidate_shares or {
+            dimension: 0.0 for dimension in MATURITY_DIMENSIONS
+        }
+        resolved_formula_ids = formula_ids or {
+            dimension: "legacy-pre-ckm07" for dimension in MATURITY_DIMENSIONS
+        }
         if not watermark_set:
             raise CkmValidationError("watermark_set must not be empty")
 
@@ -603,8 +657,28 @@ class CkmStore:
             values.append(scores[dimension])
             columns.append(f"{dimension}_citations")
             values.append(_dumps(citations[dimension]))
-        columns += ["aggregate", "watermark_set", "valid_from", "asserted_at"]
-        values += [aggregate, _dumps(watermark_set), resolved_valid_from, resolved_asserted_at]
+        columns += [
+            "candidate_shares",
+            "formula_ids",
+            "aggregate",
+            "aggregate_formula_id",
+            "low_confidence",
+            "edge_fingerprint",
+            "watermark_set",
+            "valid_from",
+            "asserted_at",
+        ]
+        values += [
+            _dumps(resolved_candidate_shares),
+            _dumps(resolved_formula_ids),
+            aggregate,
+            aggregate_formula_id,
+            int(low_confidence),
+            edge_fingerprint,
+            _dumps(watermark_set),
+            resolved_valid_from,
+            resolved_asserted_at,
+        ]
 
         placeholders = ",".join("?" for _ in values)
         column_list = ",".join(columns)
@@ -648,15 +722,35 @@ class CkmStore:
         assessments = self.list_assessments_for_capability(capability_id)
         return assessments[-1] if assessments else None
 
+    def assessment_for_projection(self, capability_id: str) -> CkmAssessmentProjection:
+        """Return the newest assessment plus store-derived freshness (INV-CKM-5)."""
+
+        assessment = self.latest_assessment_for_capability(capability_id)
+        if assessment is None:
+            raise CkmValidationError(f"capability has no assessment: {capability_id}")
+        current = self.current_watermark_set()
+        return CkmAssessmentProjection(
+            assessment=assessment,
+            current_watermark_set=current,
+            stale_relative_to_evidence=dict(assessment.watermark_set) != current,
+        )
+
     @staticmethod
     def _assessment_from_row(row: sqlite3.Row) -> CkmAssessment:
         scores = {dimension: row[dimension] for dimension in MATURITY_DIMENSIONS}
         citations = {
             dimension: _loads(row[f"{dimension}_citations"]) for dimension in MATURITY_DIMENSIONS
         }
+        candidate_shares = _loads(row["candidate_shares"])
+        formula_ids = _loads(row["formula_ids"])
         watermark_set = _loads(row["watermark_set"])
         return CkmAssessment.from_row(
-            dict(row), scores=scores, citations=citations, watermark_set=watermark_set
+            dict(row),
+            scores=scores,
+            citations=citations,
+            candidate_shares=candidate_shares,
+            formula_ids=formula_ids,
+            watermark_set=watermark_set,
         )
 
     # --- Finding -----------------------------------------------------------------

--- a/app/builderops/ckm/store.py
+++ b/app/builderops/ckm/store.py
@@ -612,6 +612,16 @@ class CkmStore:
             ).fetchone()
         return CkmEvidenceEdge.from_row(row) if row is not None else None
 
+    def has_retired_evidence_edge(self, edge_id: str) -> bool:
+        """Return whether the current graph explicitly retired this edge id."""
+
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT 1 FROM ckm_evidence_edge_history WHERE edge_id = ? LIMIT 1",
+                (edge_id,),
+            ).fetchone()
+        return row is not None
+
     def _set_inferred_edge_confirmed(self, edge_id: str) -> CkmEvidenceEdge:
         """Apply a confirmation already authorized by semantic receipt validation.
 

--- a/app/builderops/ckm/store.py
+++ b/app/builderops/ckm/store.py
@@ -457,14 +457,6 @@ class CkmStore:
                 """,
                 (artifact_id, capability_id, resolved_basis),
             ).fetchone()
-            desired_lifecycle = lifecycle
-            if (
-                existing_row is not None
-                and existing_row["extraction_method"] == "inferred"
-                and existing_row["lifecycle"] == "confirmed"
-                and extraction_method == "inferred"
-            ):
-                desired_lifecycle = "confirmed"
             if existing_row is not None:
                 material_fields = (
                     "artifact_id",
@@ -492,8 +484,19 @@ class CkmStore:
                     "source_ref": source_ref,
                     "basis": resolved_basis,
                 }
-                unchanged = all(existing_row[field] == desired[field] for field in material_fields)
-                unchanged = unchanged and existing_row["lifecycle"] == desired_lifecycle
+                material_unchanged = all(
+                    existing_row[field] == desired[field] for field in material_fields
+                )
+                confirmation_preserved = (
+                    material_unchanged
+                    and existing_row["extraction_method"] == "inferred"
+                    and existing_row["lifecycle"] == "confirmed"
+                    and extraction_method == "inferred"
+                    and lifecycle == "candidate"
+                )
+                unchanged = material_unchanged and (
+                    existing_row["lifecycle"] == lifecycle or confirmation_preserved
+                )
                 if unchanged:
                     conn.commit()
                     return CkmEvidenceEdge.from_row(existing_row)
@@ -514,13 +517,7 @@ class CkmStore:
                     extraction_method = excluded.extraction_method,
                     model = excluded.model,
                     provider = excluded.provider,
-                    lifecycle = CASE
-                        WHEN ckm_evidence_edge.extraction_method = 'inferred'
-                         AND ckm_evidence_edge.lifecycle = 'confirmed'
-                         AND excluded.extraction_method = 'inferred'
-                        THEN 'confirmed'
-                        ELSE excluded.lifecycle
-                    END,
+                    lifecycle = excluded.lifecycle,
                     source_ref = excluded.source_ref,
                     updated_at = excluded.updated_at
                 """,

--- a/app/builderops/ckm/store.py
+++ b/app/builderops/ckm/store.py
@@ -147,7 +147,7 @@ class CkmStore:
             ("formula_ids", "TEXT NOT NULL DEFAULT '{}'"),
             (
                 "aggregate_formula_id",
-                "TEXT NOT NULL DEFAULT 'aggregate-weighted-min-v1'",
+                "TEXT NOT NULL DEFAULT 'legacy-pre-ckm07'",
             ),
             ("low_confidence", "INTEGER NOT NULL DEFAULT 0 CHECK (low_confidence IN (0, 1))"),
             ("edge_fingerprint", "TEXT NOT NULL DEFAULT 'legacy'"),

--- a/app/builderops/ckm/store.py
+++ b/app/builderops/ckm/store.py
@@ -328,6 +328,10 @@ class CkmStore:
             ).fetchall()
             stale = [row for row in rows if row["source_ref"] not in source_refs]
             for row in stale:
+                edge_rows = conn.execute(
+                    "SELECT * FROM ckm_evidence_edge WHERE artifact_id = ?", (row["id"],)
+                ).fetchall()
+                self._archive_evidence_edges(conn, edge_rows)
                 conn.execute("DELETE FROM ckm_evidence_edge WHERE artifact_id = ?", (row["id"],))
                 conn.execute("DELETE FROM ckm_artifact WHERE id = ?", (row["id"],))
             conn.commit()
@@ -359,6 +363,44 @@ class CkmStore:
         return {str(row["source"]): str(row["value"]) for row in rows}
 
     # --- Evidence edge ---------------------------------------------------------
+
+    @staticmethod
+    def _archive_evidence_edges(
+        conn: sqlite3.Connection, rows: list[sqlite3.Row]
+    ) -> None:
+        """Preserve superseded edge versions outside the active CEG projection."""
+
+        retired_at = utc_now()
+        for row in rows:
+            conn.execute(
+                """
+                INSERT INTO ckm_evidence_edge_history (
+                    history_id, edge_id, artifact_id, capability_id,
+                    evidence_kind, polarity, maturity_dimension, confidence,
+                    extraction_method, model, provider, lifecycle, source_ref,
+                    basis, created_at, updated_at, retired_at
+                ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                """,
+                (
+                    new_id("edge_history"),
+                    row["id"],
+                    row["artifact_id"],
+                    row["capability_id"],
+                    row["evidence_kind"],
+                    row["polarity"],
+                    row["maturity_dimension"],
+                    row["confidence"],
+                    row["extraction_method"],
+                    row["model"],
+                    row["provider"],
+                    row["lifecycle"],
+                    row["source_ref"],
+                    row["basis"],
+                    row["created_at"],
+                    row["updated_at"],
+                    retired_at,
+                ),
+            )
 
     def upsert_evidence_edge(
         self,
@@ -408,6 +450,54 @@ class CkmStore:
             )
         with self._connect() as conn:
             conn.execute("BEGIN IMMEDIATE")
+            existing_row = conn.execute(
+                """
+                SELECT * FROM ckm_evidence_edge
+                WHERE artifact_id = ? AND capability_id = ? AND basis = ?
+                """,
+                (artifact_id, capability_id, resolved_basis),
+            ).fetchone()
+            desired_lifecycle = lifecycle
+            if (
+                existing_row is not None
+                and existing_row["extraction_method"] == "inferred"
+                and existing_row["lifecycle"] == "confirmed"
+                and extraction_method == "inferred"
+            ):
+                desired_lifecycle = "confirmed"
+            if existing_row is not None:
+                material_fields = (
+                    "artifact_id",
+                    "capability_id",
+                    "evidence_kind",
+                    "polarity",
+                    "maturity_dimension",
+                    "confidence",
+                    "extraction_method",
+                    "model",
+                    "provider",
+                    "source_ref",
+                    "basis",
+                )
+                desired = {
+                    "artifact_id": artifact_id,
+                    "capability_id": capability_id,
+                    "evidence_kind": evidence_kind,
+                    "polarity": polarity,
+                    "maturity_dimension": maturity_dimension,
+                    "confidence": confidence,
+                    "extraction_method": extraction_method,
+                    "model": model,
+                    "provider": provider,
+                    "source_ref": source_ref,
+                    "basis": resolved_basis,
+                }
+                unchanged = all(existing_row[field] == desired[field] for field in material_fields)
+                unchanged = unchanged and existing_row["lifecycle"] == desired_lifecycle
+                if unchanged:
+                    conn.commit()
+                    return CkmEvidenceEdge.from_row(existing_row)
+                self._archive_evidence_edges(conn, [existing_row])
             conn.execute(
                 """
                 INSERT INTO ckm_evidence_edge (
@@ -494,10 +584,31 @@ class CkmStore:
                 ).fetchone()
         return CkmEvidenceEdge.from_row(row) if row is not None else None
 
-    def get_evidence_edge_by_id(self, edge_id: str) -> CkmEvidenceEdge | None:
+    def get_active_evidence_edge_by_id(self, edge_id: str) -> CkmEvidenceEdge | None:
         with self._connect() as conn:
             row = conn.execute(
                 "SELECT * FROM ckm_evidence_edge WHERE id = ?", (edge_id,)
+            ).fetchone()
+        return CkmEvidenceEdge.from_row(row) if row is not None else None
+
+    def get_evidence_edge_by_id(self, edge_id: str) -> CkmEvidenceEdge | None:
+        """Resolve an edge citation from the active graph or retired history."""
+
+        active = self.get_active_evidence_edge_by_id(edge_id)
+        if active is not None:
+            return active
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT edge_id AS id, artifact_id, capability_id,
+                       evidence_kind, polarity, maturity_dimension,
+                       confidence, extraction_method, model, provider,
+                       lifecycle, source_ref, basis, created_at, updated_at
+                FROM ckm_evidence_edge_history
+                WHERE edge_id = ?
+                ORDER BY retired_at DESC LIMIT 1
+                """,
+                (edge_id,),
             ).fetchone()
         return CkmEvidenceEdge.from_row(row) if row is not None else None
 
@@ -508,18 +619,25 @@ class CkmStore:
         receipt-validating confirmation boundary in ``semantic.py``.
         """
 
-        edge = self.get_evidence_edge_by_id(edge_id)
+        edge = self.get_active_evidence_edge_by_id(edge_id)
         if edge is None:
             raise CkmValidationError(f"evidence edge not found: {edge_id}")
         if edge.extraction_method != "inferred":
             raise CkmValidationError("only inferred evidence edges require confirmation")
+        if edge.lifecycle == "confirmed":
+            return edge
         with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM ckm_evidence_edge WHERE id = ?", (edge_id,)
+            ).fetchone()
+            if row is not None:
+                self._archive_evidence_edges(conn, [row])
             conn.execute(
                 "UPDATE ckm_evidence_edge SET lifecycle = 'confirmed', updated_at = ? WHERE id = ?",
                 (utc_now(), edge_id),
             )
             conn.commit()
-        confirmed = self.get_evidence_edge_by_id(edge_id)
+        confirmed = self.get_active_evidence_edge_by_id(edge_id)
         if confirmed is None:  # pragma: no cover - defensive
             raise CkmValidationError(f"confirmed edge disappeared: {edge_id}")
         return confirmed
@@ -594,19 +712,32 @@ class CkmStore:
                 """
             ).fetchall()
             stale = [
-                row["id"]
+                row
                 for row in rows
                 if str(row["basis"]).startswith(owned_basis_prefixes)
                 if (row["artifact_id"], row["capability_id"], row["basis"])
                 not in edge_keys
             ]
-            for edge_id in stale:
-                conn.execute("DELETE FROM ckm_evidence_edge WHERE id = ?", (edge_id,))
+            archived = []
+            for row in stale:
+                archived.append(
+                    conn.execute(
+                        "SELECT * FROM ckm_evidence_edge WHERE id = ?", (row["id"],)
+                    ).fetchone()
+                )
+            self._archive_evidence_edges(conn, [row for row in archived if row is not None])
+            for row in stale:
+                conn.execute("DELETE FROM ckm_evidence_edge WHERE id = ?", (row["id"],))
             conn.commit()
         return len(stale)
 
     def delete_evidence_edge(self, edge_id: str) -> None:
         with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM ckm_evidence_edge WHERE id = ?", (edge_id,)
+            ).fetchone()
+            if row is not None:
+                self._archive_evidence_edges(conn, [row])
             conn.execute("DELETE FROM ckm_evidence_edge WHERE id = ?", (edge_id,))
             conn.commit()
 

--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -26,6 +26,7 @@ from app.builderops.ckm_reevaluation import (
     build_ckm_reevaluation_report,
 )
 from app.builderops.ckm.models import CkmValidationError
+from app.builderops.ckm.assess import assess_capabilities
 from app.builderops.ckm.ingest_github import ingest_github
 from app.builderops.ckm.ingest_repo import ingest_repo
 from app.builderops.ckm.linkers import link_deterministic
@@ -480,6 +481,19 @@ def ckm_confirm_edge(ctx: click.Context, edge_id: str) -> None:
     except (CkmValidationError, sqlite3.Error) as exc:
         raise click.ClickException(f"ckm edge confirmation failed: {exc}") from exc
     click.echo(f"edge {edge_id} confirmed; receipt builderops://receipts/{receipt['id']}")
+
+
+@ckm.command("assess", help="Append explainable maturity assessments for changed capabilities.")
+@click.pass_context
+def ckm_assess(ctx: click.Context) -> None:
+    try:
+        result = assess_capabilities(_ckm_store(ctx))
+    except (CkmValidationError, sqlite3.Error) as exc:
+        raise click.ClickException(f"ckm assessment failed: {exc}") from exc
+    click.echo(
+        f"assessed {result.assessed} capabilities "
+        f"({result.skipped} unchanged, skipped)"
+    )
 
 
 @builderops.group("inquiry", help="Persist and inspect pre-ticket model inquiry artifacts.")

--- a/tests/builderops/ckm/test_assessment_engine.py
+++ b/tests/builderops/ckm/test_assessment_engine.py
@@ -1,19 +1,28 @@
 from __future__ import annotations
 
+import json
+import sqlite3
 from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
 
 from app.builderops.cli import builderops
+from app.builderops.ckm import assess as assess_module
 from app.builderops.ckm.assess import (
     AGGREGATE_FORMULA_ID,
     FORMULAS,
+    Formula,
     assess_capabilities,
     compute_aggregate,
 )
+from app.builderops.ckm.ingest_repo import iter_docs, iter_schemas, iter_source, iter_tests
+from app.builderops.ckm.linkers import link_deterministic
 from app.builderops.ckm.models import MATURITY_DIMENSIONS
+from app.builderops.ckm.seed import seed_capabilities
 from app.builderops.ckm.store import CkmStore
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 @pytest.fixture()
@@ -136,6 +145,51 @@ def test_aggregate_transparent_and_min_capped(store: CkmStore) -> None:
     assert assessment.aggregate_formula_id in FORMULAS
 
 
+@pytest.mark.parametrize(
+    ("dimension", "artifact_kind", "evidence_kind", "source_ref"),
+    (
+        ("functional_completeness", "source_file", "source", "app/missing.py"),
+        ("test_completeness", "test", "test", "tests/test_missing.py"),
+        ("documentation_quality", "document", "doc", "docs/STALE.md"),
+        ("integration_completeness", "issue", "requirement", "github:issue:dormant"),
+        ("operational_readiness", "document", "doc", "docs/OPERATIONS_GAP.md"),
+        ("architectural_stability", "adr", "adr", "docs/adr/ADR-GAP.md"),
+        ("requirement_coverage", "spec", "spec", "docs/MISSING_SPEC.md"),
+    ),
+)
+def test_published_dimension_formula_inputs_and_weakening(
+    store: CkmStore,
+    dimension: str,
+    artifact_kind: str,
+    evidence_kind: str,
+    source_ref: str,
+) -> None:
+    capability = _capability(store)
+    _fully_evidenced(store, capability.id)
+    assess_capabilities(store)
+    baseline = store.latest_assessment_for_capability(capability.id)
+    assert baseline is not None
+    assert baseline.scores[dimension] == 1.0
+
+    weakening = _edge(
+        store,
+        capability.id,
+        source_ref=source_ref,
+        artifact_kind=artifact_kind,
+        evidence_kind=evidence_kind,
+        dimension=dimension,
+        polarity="weakens",
+    )
+    assess_capabilities(store)
+    weakened = store.latest_assessment_for_capability(capability.id)
+
+    assert weakened is not None
+    assert 0.0 < weakened.scores[dimension] < baseline.scores[dimension]
+    assert weakening.id in {
+        citation["edge_id"] for citation in weakened.citations[dimension]
+    }
+
+
 def test_candidate_share_and_low_confidence_flag(store: CkmStore) -> None:
     capability = _capability(store)
     for index, lifecycle in enumerate(("candidate", "candidate", "confirmed"), 1):
@@ -177,6 +231,10 @@ def test_staleness_detectable_from_projection_read_path(store: CkmStore) -> None
     stale = store.assessment_for_projection(capability.id)
     assert stale.assessment.id == first.id
     assert stale.stale_relative_to_evidence is True
+    watermark_only_run = assess_capabilities(store)
+    assert watermark_only_run.assessed == 0
+    assert watermark_only_run.skipped == 1
+    assert store.assessment_for_projection(capability.id).stale_relative_to_evidence is True
 
     _edge(
         store,
@@ -215,6 +273,318 @@ def test_incremental_skip_unchanged(store: CkmStore) -> None:
     assert [item.id for item in store.list_assessments_for_capability(capability.id)] == [
         assessment.id
     ]
+
+
+def test_artifact_or_watermark_change_reassesses(store: CkmStore) -> None:
+    capability = _capability(store)
+    edge = _edge(
+        store,
+        capability.id,
+        source_ref="docs/RETRIEVAL.md",
+        artifact_kind="document",
+        evidence_kind="doc",
+        dimension="documentation_quality",
+    )
+    first = assess_capabilities(store)
+
+    store.upsert_artifact(
+        source_ref="docs/RETRIEVAL.md",
+        artifact_kind="document",
+        source="fixture",
+        watermark="wm:docs-two",
+        provenance=json.dumps({"payload_summary": "State: superseded"}),
+    )
+    store.set_watermark("docs", "docs-two")
+    second = assess_capabilities(store)
+    history = store.list_assessments_for_capability(capability.id)
+
+    assert edge.artifact_id == store.list_artifacts()[0].id
+    assert first.assessed == 1
+    assert second.assessed == 1
+    assert len(history) == 2
+    assert history[0].edge_fingerprint != history[1].edge_fingerprint
+    assert store.assessment_for_projection(capability.id).stale_relative_to_evidence is False
+
+
+def test_formula_version_change_reassesses(store: CkmStore, monkeypatch: pytest.MonkeyPatch) -> None:
+    capability = _capability(store)
+    _fully_evidenced(store, capability.id)
+    first = assess_capabilities(store)
+
+    formula_id = "functional-evidence-balance-v2"
+    monkeypatch.setitem(
+        FORMULAS,
+        formula_id,
+        Formula(
+            formula_id,
+            "functional_completeness",
+            "Fixture version change with the same inputs.",
+        ),
+    )
+    monkeypatch.setitem(
+        assess_module._DIMENSION_FORMULA_IDS,
+        "functional_completeness",
+        formula_id,
+    )
+    second = assess_capabilities(store)
+    history = store.list_assessments_for_capability(capability.id)
+
+    assert first.assessed == 1
+    assert second.assessed == 1
+    assert len(history) == 2
+    assert history[0].edge_fingerprint != history[1].edge_fingerprint
+    assert history[1].formula_ids["functional_completeness"] == formula_id
+
+
+def test_integration_weakening_edge_reduces_score_and_is_cited(store: CkmStore) -> None:
+    capability = _capability(store)
+    _edge(
+        store,
+        capability.id,
+        source_ref="app/retrieval.py",
+        artifact_kind="source_file",
+        evidence_kind="source",
+        dimension="functional_completeness",
+    )
+    _edge(
+        store,
+        capability.id,
+        source_ref="docs/SURFACE.md",
+        artifact_kind="document",
+        evidence_kind="doc",
+        dimension="integration_completeness",
+    )
+    weakening = _edge(
+        store,
+        capability.id,
+        source_ref="github:issue:built-but-dormant",
+        artifact_kind="issue",
+        evidence_kind="requirement",
+        dimension="integration_completeness",
+        polarity="weakens",
+    )
+
+    assess_capabilities(store)
+    assessment = store.latest_assessment_for_capability(capability.id)
+
+    assert assessment is not None
+    assert assessment.scores["integration_completeness"] == pytest.approx(2 / 3)
+    assert weakening.id in {
+        citation["edge_id"] for citation in assessment.citations["integration_completeness"]
+    }
+
+
+def test_functional_completeness_counts_only_merged_pull_requests(store: CkmStore) -> None:
+    capability = _capability(store)
+    _edge(
+        store,
+        capability.id,
+        source_ref="docs/SPEC.md",
+        artifact_kind="spec",
+        evidence_kind="spec",
+        dimension="requirement_coverage",
+    )
+    pull = store.upsert_artifact(
+        source_ref="github:pull:1",
+        artifact_kind="pull_request",
+        source="fixture",
+        watermark="open",
+        provenance=json.dumps({"merged_at": None}),
+    )
+    store.upsert_evidence_edge(
+        artifact_id=pull.id,
+        capability_id=capability.id,
+        evidence_kind="pull_request",
+        polarity="supports",
+        maturity_dimension="functional_completeness",
+        confidence=1.0,
+        extraction_method="deterministic",
+        lifecycle="confirmed",
+        source_ref=pull.source_ref,
+        basis="fixture:pull",
+    )
+
+    assess_capabilities(store)
+    open_assessment = store.latest_assessment_for_capability(capability.id)
+    assert open_assessment is not None
+    assert open_assessment.scores["functional_completeness"] == 0.0
+
+    store.upsert_artifact(
+        source_ref=pull.source_ref,
+        artifact_kind="pull_request",
+        source="fixture",
+        watermark="merged",
+        provenance=json.dumps({"merged_at": "2026-07-14T00:00:00Z"}),
+    )
+    assess_capabilities(store)
+    merged_assessment = store.latest_assessment_for_capability(capability.id)
+    assert merged_assessment is not None
+    assert merged_assessment.scores["functional_completeness"] == 1.0
+
+
+def test_architectural_stability_treats_commits_as_churn_only(store: CkmStore) -> None:
+    capability = _capability(store)
+    _edge(
+        store,
+        capability.id,
+        source_ref="docs/adr/ADR-9000.md",
+        artifact_kind="adr",
+        evidence_kind="adr",
+        dimension="architectural_stability",
+    )
+    assess_capabilities(store)
+    baseline = store.latest_assessment_for_capability(capability.id)
+    assert baseline is not None
+    assert baseline.scores["architectural_stability"] == 1.0
+
+    for index, expected in ((1, 0.5), (2, 1 / 3)):
+        _edge(
+            store,
+            capability.id,
+            source_ref=f"git:commit-{index}",
+            artifact_kind="commit",
+            evidence_kind="commit",
+            dimension="architectural_stability",
+        )
+        assess_capabilities(store)
+        assessment = store.latest_assessment_for_capability(capability.id)
+        assert assessment is not None
+        assert assessment.scores["architectural_stability"] == pytest.approx(expected)
+
+
+def test_schema_v2_assessment_migrates_with_legacy_formula_provenance(tmp_path: Path) -> None:
+    db_path = tmp_path / "builderops.sqlite3"
+    store = CkmStore(db_path)
+    store.ensure_schema()
+    capability = _capability(store)
+    citations = json.dumps([])
+    scores = {dimension: 0.25 for dimension in MATURITY_DIMENSIONS}
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("DROP TABLE ckm_assessment")
+        dimension_columns = ",\n".join(
+            f"{dimension} REAL NOT NULL, {dimension}_citations TEXT NOT NULL"
+            for dimension in MATURITY_DIMENSIONS
+        )
+        conn.execute(
+            f"""
+            CREATE TABLE ckm_assessment (
+                id TEXT PRIMARY KEY,
+                capability_id TEXT NOT NULL REFERENCES ckm_capability(id),
+                {dimension_columns},
+                aggregate REAL NOT NULL,
+                watermark_set TEXT NOT NULL,
+                valid_from TEXT NOT NULL,
+                asserted_at TEXT NOT NULL
+            )
+            """
+        )
+        columns = ["id", "capability_id"]
+        values: list[object] = ["assessment-v2", capability.id]
+        for dimension in MATURITY_DIMENSIONS:
+            columns.extend((dimension, f"{dimension}_citations"))
+            values.extend((scores[dimension], citations))
+        columns.extend(("aggregate", "watermark_set", "valid_from", "asserted_at"))
+        values.extend((0.25, json.dumps({"docs": "one"}), "2026-01-01", "2026-01-01"))
+        conn.execute(
+            f"INSERT INTO ckm_assessment ({','.join(columns)}) VALUES ({','.join('?' for _ in values)})",
+            values,
+        )
+
+    store.ensure_schema()
+    migrated = store.latest_assessment_for_capability(capability.id)
+
+    assert migrated is not None
+    assert migrated.id == "assessment-v2"
+    assert dict(migrated.scores) == scores
+    assert all(migrated.citations[dimension] == [] for dimension in MATURITY_DIMENSIONS)
+    assert migrated.aggregate == 0.25
+    assert set(migrated.formula_ids.values()) == {"legacy-pre-ckm07"}
+    assert migrated.aggregate_formula_id == "legacy-pre-ckm07"
+    assert set(migrated.candidate_shares.values()) == {0.0}
+    assert migrated.low_confidence is False
+    assert migrated.edge_fingerprint == "legacy"
+    assert dict(migrated.watermark_set) == {"docs": "one"}
+    assert migrated.valid_from == "2026-01-01"
+    assert migrated.asserted_at == "2026-01-01"
+
+    store.ensure_schema()
+    assert store.latest_assessment_for_capability(capability.id) == migrated
+
+
+def test_live_retrieval_outscores_planned_context(tmp_path: Path) -> None:
+    store = CkmStore(tmp_path / "builderops.sqlite3")
+    store.ensure_schema()
+    seed_capabilities(store, repo_root=REPO_ROOT)
+    for artifact in (*iter_docs(REPO_ROOT), *iter_tests(REPO_ROOT), *iter_source(REPO_ROOT), *iter_schemas(REPO_ROOT)):
+        store.upsert_artifact(
+            source_ref=artifact.natural_key,
+            artifact_kind=artifact.artifact_kind,
+            source=artifact.source,
+            watermark=artifact.source_watermark,
+            provenance=artifact.provenance,
+        )
+    store.set_watermark("repo", "live-fixture")
+    link_deterministic(store, REPO_ROOT)
+
+    assess_capabilities(store)
+    capabilities = {item.name: item for item in store.list_capabilities()}
+    retrieval = store.latest_assessment_for_capability(capabilities["Retrieval"].id)
+    context = store.latest_assessment_for_capability(capabilities["Context building"].id)
+
+    assert retrieval is not None
+    assert context is not None
+    assert retrieval.scores["functional_completeness"] > context.scores["functional_completeness"]
+    artifacts = {item.id: item for item in store.list_artifacts()}
+    retrieval_sources = {
+        artifacts[citation["artifact_id"]].source_ref
+        for citation in retrieval.citations["functional_completeness"]
+        if artifacts[citation["artifact_id"]].artifact_kind == "source_file"
+    }
+    context_sources = {
+        artifacts[citation["artifact_id"]].source_ref
+        for citation in context.citations["functional_completeness"]
+        if artifacts[citation["artifact_id"]].artifact_kind == "source_file"
+    }
+    assert "app/retrieval/capability.py" in retrieval_sources
+    assert "app/retrieval/capability.py" not in context_sources
+
+
+def test_assessment_has_no_capability_name_or_lifecycle_prior(store: CkmStore) -> None:
+    first = _capability(store, "Retrieval")
+    second = store.upsert_capability(
+        name="Planned neutral twin",
+        definition=first.definition,
+        existence_provenance="fixture:neutral",
+        lifecycle="candidate",
+        boundary_ref=first.boundary_ref,
+    )
+    fixtures = (
+        ("app/shared.py", "source_file", "source", "functional_completeness"),
+        ("tests/test_shared.py", "test", "test", "test_completeness"),
+        ("docs/SHARED.md", "document", "doc", "documentation_quality"),
+        ("docs/SURFACE_SHARED.md", "document", "doc", "integration_completeness"),
+        ("docs/OPERATIONS_SHARED.md", "document", "doc", "operational_readiness"),
+        ("docs/adr/ADR-SHARED.md", "adr", "adr", "architectural_stability"),
+        ("docs/SPEC_SHARED.md", "spec", "spec", "requirement_coverage"),
+    )
+    for capability in (first, second):
+        for source_ref, artifact_kind, evidence_kind, dimension in fixtures:
+            _edge(
+                store,
+                capability.id,
+                source_ref=source_ref,
+                artifact_kind=artifact_kind,
+                evidence_kind=evidence_kind,
+                dimension=dimension,
+                basis=f"fixture:{source_ref}:{dimension}",
+            )
+
+    assess_capabilities(store)
+    first_assessment = store.latest_assessment_for_capability(first.id)
+    second_assessment = store.latest_assessment_for_capability(second.id)
+    assert first_assessment is not None
+    assert second_assessment is not None
+    assert dict(first_assessment.scores) == dict(second_assessment.scores)
 
 
 def test_cli_assess_reports_assessed_and_skipped(tmp_path: Path) -> None:

--- a/tests/builderops/ckm/test_assessment_engine.py
+++ b/tests/builderops/ckm/test_assessment_engine.py
@@ -18,7 +18,11 @@ from app.builderops.ckm.assess import (
 )
 from app.builderops.ckm.ingest_repo import iter_docs, iter_schemas, iter_source, iter_tests
 from app.builderops.ckm.linkers import link_deterministic
-from app.builderops.ckm.models import MATURITY_DIMENSIONS
+from app.builderops.ckm.models import (
+    MATURITY_DIMENSIONS,
+    CkmArtifact,
+    CkmEvidenceEdge,
+)
 from app.builderops.ckm.seed import seed_capabilities
 from app.builderops.ckm.store import CkmStore
 
@@ -121,6 +125,9 @@ def test_every_dimension_cites_evidence(store: CkmStore) -> None:
     for dimension in MATURITY_DIMENSIONS:
         assert isinstance(assessment.citations[dimension], list)
         assert all(citation["edge_id"] in edge_ids for citation in assessment.citations[dimension])
+        for citation in assessment.citations[dimension]:
+            assert CkmEvidenceEdge.from_row(citation["edge"]).validate().id == citation["edge_id"]
+            assert CkmArtifact.from_row(citation["artifact"]).validate().id == citation["artifact_id"]
 
 
 def test_aggregate_transparent_and_min_capped(store: CkmStore) -> None:
@@ -304,6 +311,57 @@ def test_artifact_or_watermark_change_reassesses(store: CkmStore) -> None:
     assert len(history) == 2
     assert history[0].edge_fingerprint != history[1].edge_fingerprint
     assert store.assessment_for_projection(capability.id).stale_relative_to_evidence is False
+
+
+def test_historical_citations_survive_edge_change_and_artifact_cleanup(
+    store: CkmStore,
+) -> None:
+    capability = _capability(store)
+    edge = _edge(
+        store,
+        capability.id,
+        source_ref="app/retrieval.py",
+        artifact_kind="source_file",
+        evidence_kind="source",
+        dimension="functional_completeness",
+    )
+    assess_capabilities(store)
+    first = store.latest_assessment_for_capability(capability.id)
+    assert first is not None
+    first_citation = first.citations["functional_completeness"][0]
+
+    store.upsert_evidence_edge(
+        artifact_id=edge.artifact_id,
+        capability_id=edge.capability_id,
+        evidence_kind=edge.evidence_kind,
+        polarity=edge.polarity,
+        maturity_dimension=edge.maturity_dimension,
+        confidence=0.25,
+        extraction_method=edge.extraction_method,
+        lifecycle=edge.lifecycle,
+        source_ref=edge.source_ref,
+        basis=edge.basis,
+    )
+    assess_capabilities(store)
+    second = store.latest_assessment_for_capability(capability.id)
+    assert second is not None
+    second_citation = second.citations["functional_completeness"][0]
+
+    assert first_citation["edge"]["confidence"] == 1.0
+    assert second_citation["edge"]["confidence"] == 0.25
+    assert first_citation["artifact"]["provenance"] == "{}"
+    assert store.delete_artifacts_not_in("fixture", set()) == 1
+    assess_capabilities(store)
+
+    history = store.list_assessments_for_capability(capability.id)
+    assert len(history) == 3
+    for assessment in history[:2]:
+        citation = assessment.citations["functional_completeness"][0]
+        assert store.get_evidence_edge_by_id(citation["edge_id"]) is not None
+        assert CkmEvidenceEdge.from_row(citation["edge"]).validate()
+        assert CkmArtifact.from_row(citation["artifact"]).validate()
+    assert store.list_evidence_edges() == []
+    assert store.list_artifacts() == []
 
 
 def test_formula_version_change_reassesses(store: CkmStore, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/builderops/ckm/test_assessment_engine.py
+++ b/tests/builderops/ckm/test_assessment_engine.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from app.builderops.cli import builderops
+from app.builderops.ckm.assess import (
+    AGGREGATE_FORMULA_ID,
+    FORMULAS,
+    assess_capabilities,
+    compute_aggregate,
+)
+from app.builderops.ckm.models import MATURITY_DIMENSIONS
+from app.builderops.ckm.store import CkmStore
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> CkmStore:
+    result = CkmStore(tmp_path / "builderops.sqlite3")
+    result.ensure_schema()
+    result.set_watermark("docs", "docs-one")
+    result.set_watermark("source", "source-one")
+    return result
+
+
+def _capability(store: CkmStore, name: str = "Retrieval"):
+    return store.upsert_capability(
+        name=name,
+        definition="Retrieve grounded context.",
+        existence_provenance="seeded:docs/CAPABILITY_CONTRACT_MODEL.md :: Retrieval",
+        lifecycle="confirmed",
+        boundary_ref="RCA",
+    )
+
+
+def _edge(
+    store: CkmStore,
+    capability_id: str,
+    *,
+    source_ref: str,
+    artifact_kind: str,
+    evidence_kind: str,
+    dimension: str,
+    lifecycle: str = "confirmed",
+    polarity: str = "supports",
+    basis: str | None = None,
+):
+    artifact = store.upsert_artifact(
+        source_ref=source_ref,
+        artifact_kind=artifact_kind,
+        source="fixture",
+        watermark=f"wm:{source_ref}",
+        provenance=(
+            '{"payload_summary":"State: current"}'
+            if artifact_kind in {"document", "adr", "spec"}
+            else "{}"
+        ),
+    )
+    return store.upsert_evidence_edge(
+        artifact_id=artifact.id,
+        capability_id=capability_id,
+        evidence_kind=evidence_kind,
+        polarity=polarity,
+        maturity_dimension=dimension,
+        confidence=1.0,
+        extraction_method="deterministic" if lifecycle == "confirmed" else "inferred",
+        lifecycle=lifecycle,
+        source_ref=source_ref,
+        basis=basis or f"fixture:{source_ref}:{dimension}",
+        model=None if lifecycle == "confirmed" else "fixture-model",
+        provider=None if lifecycle == "confirmed" else "fixture-provider",
+    )
+
+
+def _fully_evidenced(store: CkmStore, capability_id: str) -> None:
+    fixtures = (
+        ("app/retrieval.py", "source_file", "source", "functional_completeness"),
+        ("tests/test_retrieval.py", "test", "test", "test_completeness"),
+        ("docs/RETRIEVAL.md", "document", "doc", "documentation_quality"),
+        ("docs/SURFACE.md", "document", "doc", "integration_completeness"),
+        ("docs/OPERATIONS.md", "document", "doc", "operational_readiness"),
+        ("docs/adr/ADR-9000.md", "adr", "adr", "architectural_stability"),
+        ("docs/SPEC.md", "spec", "spec", "requirement_coverage"),
+    )
+    for source_ref, artifact_kind, evidence_kind, dimension in fixtures:
+        _edge(
+            store,
+            capability_id,
+            source_ref=source_ref,
+            artifact_kind=artifact_kind,
+            evidence_kind=evidence_kind,
+            dimension=dimension,
+        )
+
+
+def test_every_dimension_cites_evidence(store: CkmStore) -> None:
+    capability = _capability(store)
+    _fully_evidenced(store, capability.id)
+
+    run = assess_capabilities(store)
+    assessment = store.latest_assessment_for_capability(capability.id)
+
+    assert run.assessed == 1
+    assert assessment is not None
+    assert set(assessment.scores) == set(MATURITY_DIMENSIONS)
+    assert set(assessment.citations) == set(MATURITY_DIMENSIONS)
+    assert set(assessment.formula_ids) == set(MATURITY_DIMENSIONS)
+    assert all(formula_id in FORMULAS for formula_id in assessment.formula_ids.values())
+    edge_ids = {edge.id for edge in store.list_evidence_edges()}
+    for dimension in MATURITY_DIMENSIONS:
+        assert isinstance(assessment.citations[dimension], list)
+        assert all(citation["edge_id"] in edge_ids for citation in assessment.citations[dimension])
+
+
+def test_aggregate_transparent_and_min_capped(store: CkmStore) -> None:
+    capability = _capability(store)
+    _fully_evidenced(store, capability.id)
+    # Remove the sole operational edge so this dimension is transparently starved.
+    operational = next(
+        edge
+        for edge in store.list_evidence_edges()
+        if edge.maturity_dimension == "operational_readiness"
+    )
+    store.delete_evidence_edge(operational.id)
+
+    assess_capabilities(store)
+    assessment = store.latest_assessment_for_capability(capability.id)
+
+    assert assessment is not None
+    assert assessment.scores["operational_readiness"] == 0.0
+    assert assessment.aggregate == compute_aggregate(assessment.scores)
+    assert assessment.aggregate <= assessment.scores["operational_readiness"]
+    assert assessment.aggregate_formula_id == AGGREGATE_FORMULA_ID
+    assert assessment.aggregate_formula_id in FORMULAS
+
+
+def test_candidate_share_and_low_confidence_flag(store: CkmStore) -> None:
+    capability = _capability(store)
+    for index, lifecycle in enumerate(("candidate", "candidate", "confirmed"), 1):
+        _edge(
+            store,
+            capability.id,
+            source_ref=f"tests/test_candidate_{index}.py",
+            artifact_kind="test",
+            evidence_kind="test",
+            dimension="test_completeness",
+            lifecycle=lifecycle,
+        )
+
+    assess_capabilities(store)
+    assessment = store.latest_assessment_for_capability(capability.id)
+
+    assert assessment is not None
+    assert assessment.candidate_shares["test_completeness"] == pytest.approx(2 / 3)
+    assert assessment.low_confidence is True
+
+
+def test_staleness_detectable_from_projection_read_path(store: CkmStore) -> None:
+    capability = _capability(store)
+    _edge(
+        store,
+        capability.id,
+        source_ref="app/retrieval.py",
+        artifact_kind="source_file",
+        evidence_kind="source",
+        dimension="functional_completeness",
+    )
+    first_run = assess_capabilities(store)
+    first = store.latest_assessment_for_capability(capability.id)
+    assert first_run.assessed == 1
+    assert first is not None
+    assert store.assessment_for_projection(capability.id).stale_relative_to_evidence is False
+
+    store.set_watermark("source", "source-two")
+    stale = store.assessment_for_projection(capability.id)
+    assert stale.assessment.id == first.id
+    assert stale.stale_relative_to_evidence is True
+
+    _edge(
+        store,
+        capability.id,
+        source_ref="tests/test_retrieval.py",
+        artifact_kind="test",
+        evidence_kind="test",
+        dimension="test_completeness",
+    )
+    second_run = assess_capabilities(store)
+    history = store.list_assessments_for_capability(capability.id)
+    assert second_run.assessed == 1
+    assert len(history) == 2
+    assert history[0].id == first.id
+    assert store.assessment_for_projection(capability.id).stale_relative_to_evidence is False
+
+
+def test_incremental_skip_unchanged(store: CkmStore) -> None:
+    capability = _capability(store)
+    _edge(
+        store,
+        capability.id,
+        source_ref="app/retrieval.py",
+        artifact_kind="source_file",
+        evidence_kind="source",
+        dimension="functional_completeness",
+    )
+
+    first = assess_capabilities(store)
+    assessment = store.latest_assessment_for_capability(capability.id)
+    second = assess_capabilities(store)
+
+    assert first.assessed == 1
+    assert second.assessed == 0
+    assert second.skipped == 1
+    assert [item.id for item in store.list_assessments_for_capability(capability.id)] == [
+        assessment.id
+    ]
+
+
+def test_cli_assess_reports_assessed_and_skipped(tmp_path: Path) -> None:
+    db_path = tmp_path / "builderops.sqlite3"
+    store = CkmStore(db_path)
+    store.ensure_schema()
+    store.set_watermark("docs", "docs-one")
+    _capability(store)
+
+    runner = CliRunner()
+    first = runner.invoke(builderops, ["--db-path", str(db_path), "ckm", "assess"])
+    second = runner.invoke(builderops, ["--db-path", str(db_path), "ckm", "assess"])
+
+    assert first.exit_code == 0, first.output
+    assert "assessed 1 capabilities (0 unchanged, skipped)" in first.output
+    assert second.exit_code == 0, second.output
+    assert "assessed 0 capabilities (1 unchanged, skipped)" in second.output

--- a/tests/builderops/ckm/test_semantic.py
+++ b/tests/builderops/ckm/test_semantic.py
@@ -433,6 +433,105 @@ def test_retired_confirmed_edge_is_not_resurrected_but_rebuild_restores(
     assert restored[0].lifecycle == "confirmed"
 
 
+@pytest.mark.parametrize(
+    ("field", "changed_value"),
+    (
+        ("confidence", 0.1),
+        ("model", "replacement-model"),
+        ("provider", "replacement-provider"),
+        ("polarity", "weakens"),
+        ("maturity_dimension", "operational_readiness"),
+        ("evidence_kind", "requirement"),
+    ),
+)
+def test_material_change_demotes_confirmed_edge_until_new_receipt(
+    store: CkmStore,
+    field: str,
+    changed_value: object,
+) -> None:
+    capability = _capability(store)
+    artifact = _artifact(store)
+    associate_unlinked_artifacts(
+        store,
+        client=StubAssociator([_proposal(artifact.id, capability.id)]),
+    )
+    original = store.list_evidence_edges()[0]
+    runner = CliRunner()
+    confirmation = runner.invoke(
+        builderops,
+        ["--db-path", str(store.db_path), "ckm", "confirm-edge", original.id],
+    )
+    assert confirmation.exit_code == 0, confirmation.output
+
+    replacement = {
+        "artifact_id": original.artifact_id,
+        "capability_id": original.capability_id,
+        "evidence_kind": original.evidence_kind,
+        "polarity": original.polarity,
+        "maturity_dimension": original.maturity_dimension,
+        "confidence": original.confidence,
+        "extraction_method": original.extraction_method,
+        "lifecycle": "candidate",
+        "source_ref": original.source_ref,
+        "basis": original.basis,
+        "provider": original.provider,
+        "model": original.model,
+    }
+    replacement[field] = changed_value
+    changed = store.upsert_evidence_edge(**replacement)
+
+    assert changed.id == original.id
+    assert changed.lifecycle == "candidate"
+    assert getattr(changed, field) == changed_value
+    assert reapply_confirmation_receipts(store) == 0
+    assert store.get_active_evidence_edge_by_id(original.id).lifecycle == "candidate"
+    assert len(store.list_builderops_receipts("ckm_edge_confirmed")) == 1
+
+    reconfirmation = runner.invoke(
+        builderops,
+        ["--db-path", str(store.db_path), "ckm", "confirm-edge", original.id],
+    )
+    assert reconfirmation.exit_code == 0, reconfirmation.output
+    assert store.get_active_evidence_edge_by_id(original.id).lifecycle == "confirmed"
+    assert len(store.list_builderops_receipts("ckm_edge_confirmed")) == 2
+
+
+def test_new_basis_creates_candidate_without_mutating_confirmed_claim(
+    store: CkmStore,
+) -> None:
+    capability = _capability(store)
+    artifact = _artifact(store)
+    associate_unlinked_artifacts(
+        store,
+        client=StubAssociator([_proposal(artifact.id, capability.id)]),
+    )
+    original = store.list_evidence_edges()[0]
+    confirmation = CliRunner().invoke(
+        builderops,
+        ["--db-path", str(store.db_path), "ckm", "confirm-edge", original.id],
+    )
+    assert confirmation.exit_code == 0, confirmation.output
+
+    replacement = store.upsert_evidence_edge(
+        artifact_id=original.artifact_id,
+        capability_id=original.capability_id,
+        evidence_kind=original.evidence_kind,
+        polarity=original.polarity,
+        maturity_dimension=original.maturity_dimension,
+        confidence=original.confidence,
+        extraction_method=original.extraction_method,
+        lifecycle="candidate",
+        source_ref=original.source_ref,
+        basis="A materially different rationale.",
+        provider=original.provider,
+        model=original.model,
+    )
+
+    assert replacement.id != original.id
+    assert replacement.lifecycle == "candidate"
+    assert store.get_active_evidence_edge_by_id(original.id).lifecycle == "confirmed"
+
+
 @pytest.mark.parametrize("field", ["actor", "confidence", "model", "basis"])
 def test_trusted_confirmation_rejects_tampering_before_and_after_rebuild(
     tmp_path: Path, field: str

--- a/tests/builderops/ckm/test_semantic.py
+++ b/tests/builderops/ckm/test_semantic.py
@@ -376,6 +376,28 @@ def test_confirmation_receipt_survives_rebuild(
     assert restored[0].basis == original.basis
 
 
+def test_retired_inferred_edge_cannot_be_confirmed(store: CkmStore) -> None:
+    capability = _capability(store)
+    artifact = _artifact(store)
+    associate_unlinked_artifacts(
+        store,
+        client=StubAssociator([_proposal(artifact.id, capability.id)]),
+    )
+    edge = store.list_evidence_edges()[0]
+    store.delete_evidence_edge(edge.id)
+
+    result = CliRunner().invoke(
+        builderops,
+        ["--db-path", str(store.db_path), "ckm", "confirm-edge", edge.id],
+    )
+
+    assert result.exit_code != 0
+    assert "evidence edge not found" in result.output
+    assert store.get_active_evidence_edge_by_id(edge.id) is None
+    assert store.get_evidence_edge_by_id(edge.id) is not None
+    assert store.list_builderops_receipts("ckm_edge_confirmed") == []
+
+
 @pytest.mark.parametrize("field", ["actor", "confidence", "model", "basis"])
 def test_trusted_confirmation_rejects_tampering_before_and_after_rebuild(
     tmp_path: Path, field: str

--- a/tests/builderops/ckm/test_semantic.py
+++ b/tests/builderops/ckm/test_semantic.py
@@ -398,6 +398,41 @@ def test_retired_inferred_edge_cannot_be_confirmed(store: CkmStore) -> None:
     assert store.list_builderops_receipts("ckm_edge_confirmed") == []
 
 
+def test_retired_confirmed_edge_is_not_resurrected_but_rebuild_restores(
+    store: CkmStore,
+) -> None:
+    capability = _capability(store)
+    artifact = _artifact(store)
+    associate_unlinked_artifacts(
+        store,
+        client=StubAssociator([_proposal(artifact.id, capability.id)]),
+    )
+    edge = store.list_evidence_edges()[0]
+    confirmation = CliRunner().invoke(
+        builderops,
+        ["--db-path", str(store.db_path), "ckm", "confirm-edge", edge.id],
+    )
+    assert confirmation.exit_code == 0, confirmation.output
+
+    store.delete_evidence_edge(edge.id)
+
+    assert store.has_retired_evidence_edge(edge.id) is True
+    assert reapply_confirmation_receipts(store) == 0
+    assert store.list_evidence_edges() == []
+
+    store.rebuild()
+    rebuilt_capability = _capability(store)
+    rebuilt_artifact = _artifact(store)
+
+    assert store.has_retired_evidence_edge(edge.id) is False
+    assert reapply_confirmation_receipts(store) == 1
+    restored = store.list_evidence_edges()
+    assert len(restored) == 1
+    assert restored[0].artifact_id == rebuilt_artifact.id
+    assert restored[0].capability_id == rebuilt_capability.id
+    assert restored[0].lifecycle == "confirmed"
+
+
 @pytest.mark.parametrize("field", ["actor", "confidence", "model", "basis"])
 def test_trusted_confirmation_rejects_tampering_before_and_after_rebuild(
     tmp_path: Path, field: str

--- a/tests/builderops/ckm/test_store.py
+++ b/tests/builderops/ckm/test_store.py
@@ -76,6 +76,8 @@ def test_upsert_idempotent_and_rebuild(store: CkmStore) -> None:
     edge_second = _upsert_evidence_edge(store, artifact_first.id, first.id)
     assert edge_first.id == edge_second.id
     assert len(store.list_evidence_edges_for_capability(first.id)) == 1
+    with sqlite3.connect(store.db_path) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM ckm_evidence_edge_history").fetchone()[0] == 0
 
     assert store.table_names() == sorted(CKM_TABLE_NAMES)
 


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Closes #3145

## SBS Impact
- Primary subsystem: Builder System (BuilderOps plane)
- Secondary subsystem(s): none
- Write class: derived assessment rows in additive `ckm_*` state
- Authority impact: none; every assessment remains a projection-only analytical judgment
- Persistence impact: rebuildable; schema v3 adds formula, candidate-share, confidence, and edge-fingerprint metadata
- Human knowledge / memory / runtime impact: none
- External boundary impact: none; assessment reads already-ingested CKM evidence only
- New or changed contract: transparent seven-dimension assessment, weighted-min aggregate, freshness read model, and `ckm assess` CLI
- Owner-doc impact: none; parent #3138 owns capability-level promotion after acceptance
- Transition debt impact: no effect
- Fitness rule impact: no effect

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Publish versioned deterministic formulas for all seven maturity dimensions and the weighted-min convenience aggregate.
- Persist per-dimension evidence citations, candidate share, formula ids, low-confidence state, edge fingerprints, and ingestion watermarks on append-only assessments.
- Add projection-read staleness detection, incremental unchanged-edge skipping, and the `ckm assess` CLI.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints and INV-CKM-1..7 were preserved.
- [x] Every Acceptance Criterion's named test passes.
- [x] No Product/Runtime, vault, or GitHub write path was added.

## Validation
- [x] `python -m pytest tests/builderops/ckm/test_assessment_engine.py -q` — 6 passed.
- [x] `python -m pytest tests/builderops/ckm/ -q` — 44 passed.
- [x] `ruff check app tests` — all checks passed.
- [x] `mypy app` — success across 726 source files.
- [x] Live seed → repo ingest → deterministic link → assess — 31 capabilities assessed; stored vectors/citations/formulas/freshness inspected.
- [ ] `python -m pytest -q -m "not pg"` — 8171 passed, 114 skipped, 18 xfailed; two unrelated current-tree failures remain in `test_every_write_note_relative_seam_has_port_coverage` (episode call-site census) and `test_validate_question_note_rejects_bad_created_at_format` (standing-questions timestamp validation). Current-head CI is required before merge.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: this bounded implementation produced no delivery divergence or operational material beyond the governing Issue/PR receipts.

## Coordination
- Dispatcher unavailable (`dispatcher_db_uninitialized`) — canonical pickup wrapper used GitHub-label-only fallback; claim receipt: issue comment 4967115146.