### PR TITLE
Add fenced CKM semantic evidence association

### DIFF
--- a/app/builderops/ckm/semantic.py
+++ b/app/builderops/ckm/semantic.py
@@ -301,7 +301,85 @@ def _confirmation_payload(store: CkmStore, edge_id: str) -> tuple[dict[str, Any]
     return payload, artifact.source_ref, capability.name
 
 
-def confirm_edge(store: CkmStore, edge_id: str) -> dict[str, Any]:
+def _validated_confirmation_receipt(
+    store: CkmStore,
+    receipt: dict[str, Any],
+    *,
+    expected_edge_id: str | None = None,
+) -> tuple[dict[str, Any], CkmArtifact, CkmCapability]:
+    """Validate that a durable receipt authorizes exactly one edge promotion."""
+
+    if receipt.get("object_type") != "BuilderOpsReceipt":
+        raise CkmValidationError("confirmation record must be a BuilderOpsReceipt")
+    if receipt.get("event_type") != "ckm_edge_confirmed":
+        raise CkmValidationError("confirmation receipt has an invalid event type")
+    if receipt.get("action") != "confirm_edge":
+        raise CkmValidationError("confirmation receipt has an invalid action")
+    actor = receipt.get("actor")
+    if not isinstance(actor, dict) or actor.get("actor_type") != "human":
+        raise CkmValidationError("confirmation receipt requires a human actor")
+    if not isinstance(actor.get("id"), str) or not actor["id"].strip():
+        raise CkmValidationError("confirmation receipt requires a named human actor")
+    try:
+        payload = json.loads(receipt["receipt_body"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise CkmValidationError("confirmation receipt body must be valid JSON") from exc
+    if not isinstance(payload, dict):
+        raise CkmValidationError("confirmation receipt body must be an object")
+
+    edge_id = payload.get("id")
+    if not isinstance(edge_id, str) or not edge_id:
+        raise CkmValidationError("confirmation receipt payload requires an edge id")
+    if expected_edge_id is not None and edge_id != expected_edge_id:
+        raise CkmValidationError("confirmation receipt does not bind the requested edge")
+    if receipt.get("source_refs") != [
+        {"ref_type": "ckm_evidence_edge", "ref": edge_id}
+    ]:
+        raise CkmValidationError("confirmation receipt source does not bind its payload edge")
+    if payload.get("extraction_method") != "inferred" or payload.get("lifecycle") != "confirmed":
+        raise CkmValidationError("confirmation receipt must promote one inferred edge")
+    for field in ("basis", "provider", "model", "artifact_source_ref", "capability_name"):
+        value = payload.get(field)
+        if not isinstance(value, str) or not value.strip():
+            raise CkmValidationError(
+                f"confirmation receipt payload requires non-empty {field}"
+            )
+    if payload.get("source_ref") != payload["artifact_source_ref"]:
+        raise CkmValidationError("confirmation payload artifact source binding is inconsistent")
+
+    artifact = next(
+        (item for item in store.list_artifacts() if item.source_ref == payload["artifact_source_ref"]),
+        None,
+    )
+    capability = next(
+        (item for item in store.list_capabilities() if item.name == payload["capability_name"]),
+        None,
+    )
+    if artifact is None or capability is None:
+        raise CkmValidationError("confirmation receipt target is absent from the current graph")
+    expected_targets = [
+        {"ref_type": "repo_artifact", "ref": artifact.source_ref},
+        {"ref_type": "ckm_capability", "ref": capability.name},
+    ]
+    if receipt.get("target_refs") != expected_targets:
+        raise CkmValidationError("confirmation receipt targets do not bind its payload")
+
+    current = store.get_evidence_edge_by_id(edge_id)
+    if current is not None:
+        expected_payload = {
+            **asdict(current),
+            "lifecycle": "confirmed",
+            "artifact_source_ref": artifact.source_ref,
+            "capability_name": capability.name,
+        }
+        if payload != expected_payload:
+            raise CkmValidationError("confirmation receipt payload does not match its source edge")
+    return payload, artifact, capability
+
+
+def _confirm_edge_from_cli(store: CkmStore, edge_id: str) -> dict[str, Any]:
+    """Execute the human-operated CLI confirmation boundary."""
+
     payload, artifact_ref, capability_name = _confirmation_payload(store, edge_id)
     payload["lifecycle"] = "confirmed"
     receipt = store.append_builderops_receipt(
@@ -322,7 +400,8 @@ def confirm_edge(store: CkmStore, edge_id: str) -> dict[str, Any]:
     )
     # Receipt first: if the derived-row update fails, the durable confirmation
     # intent still exists and the normal rebuild/reapply path can restore it.
-    store.confirm_inferred_edge(edge_id)
+    _validated_confirmation_receipt(store, receipt, expected_edge_id=edge_id)
+    store._set_inferred_edge_confirmed(edge_id)
     return receipt
 
 
@@ -332,10 +411,12 @@ def reapply_confirmation_receipts(store: CkmStore) -> int:
     capabilities = {item.name: item for item in store.list_capabilities()}
     for receipt in store.list_builderops_receipts("ckm_edge_confirmed"):
         try:
-            payload = json.loads(receipt["receipt_body"])
-            artifact = artifacts[payload["artifact_source_ref"]]
-            capability = capabilities[payload["capability_name"]]
-        except (KeyError, TypeError, ValueError):
+            payload, artifact, capability = _validated_confirmation_receipt(store, receipt)
+            # The lookup maps make the rebuild dependency explicit and reject
+            # receipts whose targets do not belong to this rebuilt graph.
+            artifact = artifacts[artifact.source_ref]
+            capability = capabilities[capability.name]
+        except (CkmValidationError, KeyError, TypeError, ValueError):
             continue
         edge = store.upsert_evidence_edge(
             artifact_id=artifact.id,
@@ -351,7 +432,7 @@ def reapply_confirmation_receipts(store: CkmStore) -> int:
             provider=payload["provider"],
             model=payload["model"],
         )
-        if store.confirm_inferred_edge(edge.id).lifecycle == "confirmed":
+        if store._set_inferred_edge_confirmed(edge.id).lifecycle == "confirmed":
             restored += 1
     return restored
 
@@ -363,6 +444,5 @@ __all__ = [
     "SemanticBatch",
     "SemanticProposal",
     "associate_unlinked_artifacts",
-    "confirm_edge",
     "reapply_confirmation_receipts",
 ]

--- a/app/builderops/ckm/semantic.py
+++ b/app/builderops/ckm/semantic.py
@@ -1,0 +1,368 @@
+"""Fenced semantic association for otherwise-unlinked CKM artifacts.
+
+This is the MVP's only inferred evidence writer.  It deliberately keeps the
+provider seam injectable, validates structured output, discards low-confidence
+proposals, and writes every accepted edge as an inferred candidate.  Explicit
+confirmation is represented by a BuilderOps receipt so it survives rebuilding
+the derived ``ckm_*`` tables.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from hashlib import sha256
+import json
+from typing import Any, Callable, Protocol, Sequence
+
+from app.builderops.ckm.models import (
+    EVIDENCE_KINDS,
+    MATURITY_DIMENSIONS,
+    CkmArtifact,
+    CkmCapability,
+    CkmValidationError,
+    utc_now,
+)
+from app.builderops.ckm.store import CkmStore
+from app.components.llm.constrained import register_schema, validate_payload
+from app.components.llm.fabric import LLMTaskIntent, get_chat_client
+
+SEMANTIC_SCHEMA_REF = "builderops.ckm.semantic-association.v1"
+SEMANTIC_ASSOCIATION_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "required": ["proposals"],
+    "additionalProperties": False,
+    "properties": {
+        "proposals": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "artifact_id",
+                    "capability_id",
+                    "evidence_kind",
+                    "maturity_dimension",
+                    "confidence",
+                    "rationale",
+                ],
+                "additionalProperties": False,
+                "properties": {
+                    "artifact_id": {"type": "string", "minLength": 1},
+                    "capability_id": {"type": "string", "minLength": 1},
+                    "evidence_kind": {"type": "string", "minLength": 1},
+                    "maturity_dimension": {"type": "string", "minLength": 1},
+                    "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+                    "rationale": {"type": "string", "minLength": 1},
+                },
+            },
+        }
+    },
+}
+register_schema(SEMANTIC_SCHEMA_REF, SEMANTIC_ASSOCIATION_SCHEMA)
+
+
+class SemanticAssociationError(RuntimeError):
+    """The semantic stage ran but its response was not usable."""
+
+
+class SemanticProviderUnavailable(SemanticAssociationError):
+    """No configured provider could execute the bounded association call."""
+
+
+@dataclass(frozen=True)
+class SemanticProposal:
+    artifact_id: str
+    capability_id: str
+    evidence_kind: str
+    maturity_dimension: str
+    confidence: float
+    rationale: str
+
+
+@dataclass(frozen=True)
+class SemanticBatch:
+    provider: str
+    model: str
+    proposals: list[SemanticProposal]
+
+
+@dataclass(frozen=True)
+class SemanticAssociationResult:
+    status: str
+    proposed: int
+    discarded: int
+    no_match: int
+    provider: str | None
+    model: str | None
+
+
+class SemanticAssociator(Protocol):
+    provider: str
+    model: str
+
+    def propose(
+        self,
+        *,
+        artifacts: Sequence[CkmArtifact],
+        capabilities: Sequence[CkmCapability],
+    ) -> SemanticBatch: ...
+
+
+class FabricSemanticAssociator:
+    """Production adapter over the repo's existing routed chat fabric."""
+
+    def __init__(self) -> None:
+        try:
+            self._client = get_chat_client(
+                LLMTaskIntent(
+                    # Semantic association is a bounded classification task;
+                    # this route is the configured cheap-model tier.
+                    task_kind="classify",
+                    complexity_hint="low",
+                    budget="low",
+                    json_schema_required=True,
+                )
+            )
+        except Exception as exc:  # route/config failures are the unavailable path
+            raise SemanticProviderUnavailable(str(exc)) from exc
+        self.provider = self._client.route.provider
+        self.model = self._client.route.model
+        if self.provider == "mock":
+            raise SemanticProviderUnavailable("mock route is not a semantic association provider")
+
+    def propose(
+        self,
+        *,
+        artifacts: Sequence[CkmArtifact],
+        capabilities: Sequence[CkmCapability],
+    ) -> SemanticBatch:
+        user = json.dumps(
+            {
+                "artifacts": [
+                    {
+                        "id": item.id,
+                        "source_ref": item.source_ref,
+                        "artifact_kind": item.artifact_kind,
+                        "provenance": item.provenance[:1000],
+                    }
+                    for item in artifacts
+                ],
+                "capabilities": [
+                    {"id": item.id, "name": item.name, "definition": item.definition}
+                    for item in capabilities
+                ],
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+        try:
+            raw = self._client.chat(
+                SEMANTIC_SCHEMA_REF,
+                {
+                    "system": (
+                        "Associate only artifacts that clearly evidence an existing capability. "
+                        "Return no proposal for uncertainty; never invent capabilities."
+                    ),
+                    "user": user,
+                },
+                kind="ckm_associate",
+                max_tokens=3000,
+                response_format=SEMANTIC_ASSOCIATION_SCHEMA,
+            )
+        except Exception as exc:
+            raise SemanticProviderUnavailable(str(exc)) from exc
+        try:
+            payload = validate_payload(SEMANTIC_SCHEMA_REF, json.loads(raw))
+            proposals = [SemanticProposal(**item) for item in payload["proposals"]]
+        except (TypeError, ValueError, KeyError) as exc:
+            raise SemanticAssociationError(f"invalid semantic association response: {exc}") from exc
+        return SemanticBatch(provider=self.provider, model=self.model, proposals=proposals)
+
+
+def _unlinked_artifacts(store: CkmStore, limit: int) -> list[CkmArtifact]:
+    linked_ids = {edge.artifact_id for edge in store.list_evidence_edges()}
+    return [item for item in store.list_artifacts() if item.id not in linked_ids][:limit]
+
+
+def associate_unlinked_artifacts(
+    store: CkmStore,
+    *,
+    limit: int = 200,
+    confidence_floor: float = 0.6,
+    client: SemanticAssociator | None = None,
+    client_factory: Callable[[], SemanticAssociator | None] = FabricSemanticAssociator,
+) -> SemanticAssociationResult:
+    if limit <= 0:
+        raise ValueError("limit must be positive")
+    if not 0 <= confidence_floor <= 1:
+        raise ValueError("confidence_floor must be in [0, 1]")
+    store.ensure_schema()
+    artifacts = _unlinked_artifacts(store, limit)
+    if not artifacts:
+        return SemanticAssociationResult("ok", 0, 0, 0, None, None)
+    capabilities = store.list_capabilities()
+    if not capabilities:
+        return SemanticAssociationResult("ok", 0, 0, len(artifacts), None, None)
+    if client is None:
+        try:
+            client = client_factory()
+        except SemanticProviderUnavailable:
+            client = None
+    if client is None:
+        return SemanticAssociationResult(
+            "skipped (llm unavailable)", 0, 0, len(artifacts), None, None
+        )
+    try:
+        batch = client.propose(artifacts=artifacts, capabilities=capabilities)
+    except SemanticProviderUnavailable:
+        return SemanticAssociationResult(
+            "skipped (llm unavailable)", 0, 0, len(artifacts), client.provider, client.model
+        )
+
+    artifact_by_id = {item.id: item for item in artifacts}
+    capability_ids = {item.id for item in capabilities}
+    for proposal in batch.proposals:
+        if proposal.artifact_id not in artifact_by_id:
+            raise SemanticAssociationError(
+                f"proposal references artifact outside the bounded batch: {proposal.artifact_id}"
+            )
+        if proposal.capability_id not in capability_ids:
+            raise SemanticAssociationError(
+                f"proposal references unknown capability: {proposal.capability_id}"
+            )
+        if proposal.evidence_kind not in EVIDENCE_KINDS:
+            raise SemanticAssociationError(
+                f"proposal has invalid evidence kind: {proposal.evidence_kind}"
+            )
+        if proposal.maturity_dimension not in MATURITY_DIMENSIONS:
+            raise SemanticAssociationError(
+                f"proposal has invalid maturity dimension: {proposal.maturity_dimension}"
+            )
+        if not 0 <= proposal.confidence <= 1:
+            raise SemanticAssociationError("proposal confidence must be in [0, 1]")
+        if not proposal.rationale.strip():
+            raise SemanticAssociationError("proposal rationale must not be empty")
+
+    proposed = 0
+    discarded = 0
+    matched_artifacts: set[str] = set()
+    for proposal in batch.proposals:
+        artifact = artifact_by_id.get(proposal.artifact_id)
+        if artifact is None:  # pragma: no cover - guarded above
+            raise SemanticAssociationError("validated artifact disappeared")
+        matched_artifacts.add(proposal.artifact_id)
+        if proposal.confidence < confidence_floor:
+            discarded += 1
+            continue
+        before = len(store.list_evidence_edges())
+        store.upsert_evidence_edge(
+            artifact_id=proposal.artifact_id,
+            capability_id=proposal.capability_id,
+            evidence_kind=proposal.evidence_kind,
+            polarity="supports",
+            maturity_dimension=proposal.maturity_dimension,
+            confidence=proposal.confidence,
+            extraction_method="inferred",
+            lifecycle="candidate",
+            source_ref=artifact.source_ref,
+            basis=proposal.rationale,
+            provider=batch.provider,
+            model=batch.model,
+        )
+        proposed += int(len(store.list_evidence_edges()) > before)
+
+    watermark = sha256(
+        "\n".join(sorted(item.watermark for item in artifacts)).encode("utf-8")
+    ).hexdigest()
+    store.set_watermark("semantic_association", f"batch:{watermark}")
+    return SemanticAssociationResult(
+        status="ok",
+        proposed=proposed,
+        discarded=discarded,
+        no_match=len({item.id for item in artifacts} - matched_artifacts),
+        provider=batch.provider,
+        model=batch.model,
+    )
+
+
+def _confirmation_payload(store: CkmStore, edge_id: str) -> tuple[dict[str, Any], str, str]:
+    edge = store.get_evidence_edge_by_id(edge_id)
+    if edge is None:
+        raise CkmValidationError(f"evidence edge not found: {edge_id}")
+    if edge.extraction_method != "inferred":
+        raise CkmValidationError("only inferred evidence edges require confirmation")
+    artifact = next(item for item in store.list_artifacts() if item.id == edge.artifact_id)
+    capability = store.get_capability(edge.capability_id)
+    if capability is None:  # pragma: no cover - foreign keys make this defensive
+        raise CkmValidationError(f"capability not found: {edge.capability_id}")
+    payload = asdict(edge)
+    payload["artifact_source_ref"] = artifact.source_ref
+    payload["capability_name"] = capability.name
+    return payload, artifact.source_ref, capability.name
+
+
+def confirm_edge(store: CkmStore, edge_id: str) -> dict[str, Any]:
+    payload, artifact_ref, capability_name = _confirmation_payload(store, edge_id)
+    payload["lifecycle"] = "confirmed"
+    receipt = store.append_builderops_receipt(
+        source_refs=[{"ref_type": "ckm_evidence_edge", "ref": edge_id}],
+        summary=f"Confirmed inferred CKM edge for {capability_name}",
+        event_type="ckm_edge_confirmed",
+        actor={"actor_type": "human", "id": "operator"},
+        occurred_at=utc_now(),
+        target_refs=[
+            {"ref_type": "repo_artifact", "ref": artifact_ref},
+            {"ref_type": "ckm_capability", "ref": capability_name},
+        ],
+        action="confirm_edge",
+        receipt_body=json.dumps(payload, ensure_ascii=False, sort_keys=True),
+        idempotency_key=(
+            f"ckm-confirm:{artifact_ref}:{capability_name}:{payload['basis']}"
+        ),
+    )
+    # Receipt first: if the derived-row update fails, the durable confirmation
+    # intent still exists and the normal rebuild/reapply path can restore it.
+    store.confirm_inferred_edge(edge_id)
+    return receipt
+
+
+def reapply_confirmation_receipts(store: CkmStore) -> int:
+    restored = 0
+    artifacts = {item.source_ref: item for item in store.list_artifacts()}
+    capabilities = {item.name: item for item in store.list_capabilities()}
+    for receipt in store.list_builderops_receipts("ckm_edge_confirmed"):
+        try:
+            payload = json.loads(receipt["receipt_body"])
+            artifact = artifacts[payload["artifact_source_ref"]]
+            capability = capabilities[payload["capability_name"]]
+        except (KeyError, TypeError, ValueError):
+            continue
+        edge = store.upsert_evidence_edge(
+            artifact_id=artifact.id,
+            capability_id=capability.id,
+            evidence_kind=payload["evidence_kind"],
+            polarity=payload["polarity"],
+            maturity_dimension=payload["maturity_dimension"],
+            confidence=payload["confidence"],
+            extraction_method="inferred",
+            lifecycle="candidate",
+            source_ref=artifact.source_ref,
+            basis=payload["basis"],
+            provider=payload["provider"],
+            model=payload["model"],
+        )
+        if store.confirm_inferred_edge(edge.id).lifecycle == "confirmed":
+            restored += 1
+    return restored
+
+
+__all__ = [
+    "FabricSemanticAssociator",
+    "SemanticAssociationError",
+    "SemanticAssociationResult",
+    "SemanticBatch",
+    "SemanticProposal",
+    "associate_unlinked_artifacts",
+    "confirm_edge",
+    "reapply_confirmation_receipts",
+]

--- a/app/builderops/ckm/semantic.py
+++ b/app/builderops/ckm/semantic.py
@@ -9,8 +9,9 @@ the derived ``ckm_*`` tables.
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from hashlib import sha256
+import hmac
 import json
 from typing import Any, Callable, Protocol, Sequence
 
@@ -23,7 +24,11 @@ from app.builderops.ckm.models import (
     utc_now,
 )
 from app.builderops.ckm.store import CkmStore
-from app.components.llm.constrained import register_schema, validate_payload
+from app.components.llm.constrained import (
+    ConstrainedCompletionError,
+    register_schema,
+    validate_payload,
+)
 from app.components.llm.fabric import LLMTaskIntent, get_chat_client
 
 SEMANTIC_SCHEMA_REF = "builderops.ckm.semantic-association.v1"
@@ -169,11 +174,19 @@ class FabricSemanticAssociator:
                 max_tokens=3000,
                 response_format=SEMANTIC_ASSOCIATION_SCHEMA,
             )
+        except ConstrainedCompletionError as exc:
+            raise SemanticAssociationError(
+                f"invalid semantic association response: {exc}"
+            ) from exc
         except Exception as exc:
             raise SemanticProviderUnavailable(str(exc)) from exc
         try:
             payload = validate_payload(SEMANTIC_SCHEMA_REF, json.loads(raw))
             proposals = [SemanticProposal(**item) for item in payload["proposals"]]
+        except ConstrainedCompletionError as exc:
+            raise SemanticAssociationError(
+                f"invalid semantic association response: {exc}"
+            ) from exc
         except (TypeError, ValueError, KeyError) as exc:
             raise SemanticAssociationError(f"invalid semantic association response: {exc}") from exc
         return SemanticBatch(provider=self.provider, model=self.model, proposals=proposals)
@@ -285,6 +298,10 @@ def associate_unlinked_artifacts(
     )
 
 
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
 def _confirmation_payload(store: CkmStore, edge_id: str) -> tuple[dict[str, Any], str, str]:
     edge = store.get_evidence_edge_by_id(edge_id)
     if edge is None:
@@ -295,10 +312,52 @@ def _confirmation_payload(store: CkmStore, edge_id: str) -> tuple[dict[str, Any]
     capability = store.get_capability(edge.capability_id)
     if capability is None:  # pragma: no cover - foreign keys make this defensive
         raise CkmValidationError(f"capability not found: {edge.capability_id}")
-    payload = asdict(edge)
-    payload["artifact_source_ref"] = artifact.source_ref
-    payload["capability_name"] = capability.name
+    payload = {
+        "edge_id": edge.id,
+        "artifact_source_ref": artifact.source_ref,
+        "capability_name": capability.name,
+        "evidence_kind": edge.evidence_kind,
+        "polarity": edge.polarity,
+        "maturity_dimension": edge.maturity_dimension,
+        "confidence": edge.confidence,
+        "extraction_method": edge.extraction_method,
+        "lifecycle": "confirmed",
+        "source_ref": edge.source_ref,
+        "basis": edge.basis,
+        "provider": edge.provider,
+        "model": edge.model,
+    }
+    stable_claim = {key: value for key, value in payload.items() if key != "edge_id"}
+    payload["confirmation_key"] = sha256(
+        _canonical_json(stable_claim).encode("utf-8")
+    ).hexdigest()
     return payload, artifact.source_ref, capability.name
+
+
+def _binding_document(receipt: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
+    unsigned_payload = {key: value for key, value in payload.items() if key != "binding"}
+    return {
+        "object_type": "BuilderOpsReceipt",
+        "event_type": receipt.get("event_type"),
+        "action": receipt.get("action"),
+        "actor": receipt.get("actor"),
+        "source_refs": receipt.get("source_refs"),
+        "target_refs": receipt.get("target_refs"),
+        "payload": unsigned_payload,
+    }
+
+
+def _sign_confirmation(
+    store: CkmStore, envelope: dict[str, Any], payload: dict[str, Any]
+) -> str:
+    key = store._confirmation_signing_key(create=True)
+    if key is None:  # pragma: no cover - create=True guarantees a key
+        raise CkmValidationError("CKM confirmation signing key is unavailable")
+    return hmac.new(
+        key,
+        _canonical_json(_binding_document(envelope, payload)).encode("utf-8"),
+        sha256,
+    ).hexdigest()
 
 
 def _validated_confirmation_receipt(
@@ -327,7 +386,7 @@ def _validated_confirmation_receipt(
     if not isinstance(payload, dict):
         raise CkmValidationError("confirmation receipt body must be an object")
 
-    edge_id = payload.get("id")
+    edge_id = payload.get("edge_id")
     if not isinstance(edge_id, str) or not edge_id:
         raise CkmValidationError("confirmation receipt payload requires an edge id")
     if expected_edge_id is not None and edge_id != expected_edge_id:
@@ -338,7 +397,15 @@ def _validated_confirmation_receipt(
         raise CkmValidationError("confirmation receipt source does not bind its payload edge")
     if payload.get("extraction_method") != "inferred" or payload.get("lifecycle") != "confirmed":
         raise CkmValidationError("confirmation receipt must promote one inferred edge")
-    for field in ("basis", "provider", "model", "artifact_source_ref", "capability_name"):
+    for field in (
+        "basis",
+        "provider",
+        "model",
+        "artifact_source_ref",
+        "capability_name",
+        "confirmation_key",
+        "binding",
+    ):
         value = payload.get(field)
         if not isinstance(value, str) or not value.strip():
             raise CkmValidationError(
@@ -364,15 +431,26 @@ def _validated_confirmation_receipt(
     if receipt.get("target_refs") != expected_targets:
         raise CkmValidationError("confirmation receipt targets do not bind its payload")
 
+    key = store._confirmation_signing_key()
+    if key is None:
+        raise CkmValidationError("confirmation receipt has no trusted signing key")
+    expected_binding = hmac.new(
+        key,
+        _canonical_json(_binding_document(receipt, payload)).encode("utf-8"),
+        sha256,
+    ).hexdigest()
+    if not hmac.compare_digest(payload["binding"], expected_binding):
+        raise CkmValidationError("confirmation receipt trusted binding is invalid")
+
     current = store.get_evidence_edge_by_id(edge_id)
     if current is not None:
-        expected_payload = {
-            **asdict(current),
-            "lifecycle": "confirmed",
-            "artifact_source_ref": artifact.source_ref,
-            "capability_name": capability.name,
-        }
-        if payload != expected_payload:
+        expected_payload, _, _ = _confirmation_payload(store, current.id)
+        for field, value in expected_payload.items():
+            if field != "binding" and payload.get(field) != value:
+                raise CkmValidationError(
+                    "confirmation receipt payload does not match its source edge"
+                )
+        if payload.get("confirmation_key") != expected_payload["confirmation_key"]:
             raise CkmValidationError("confirmation receipt payload does not match its source edge")
     return payload, artifact, capability
 
@@ -381,22 +459,36 @@ def _confirm_edge_from_cli(store: CkmStore, edge_id: str) -> dict[str, Any]:
     """Execute the human-operated CLI confirmation boundary."""
 
     payload, artifact_ref, capability_name = _confirmation_payload(store, edge_id)
-    payload["lifecycle"] = "confirmed"
-    receipt = store.append_builderops_receipt(
-        source_refs=[{"ref_type": "ckm_evidence_edge", "ref": edge_id}],
-        summary=f"Confirmed inferred CKM edge for {capability_name}",
-        event_type="ckm_edge_confirmed",
-        actor={"actor_type": "human", "id": "operator"},
-        occurred_at=utc_now(),
-        target_refs=[
+    for existing in store.list_builderops_receipts("ckm_edge_confirmed"):
+        try:
+            existing_payload, _, _ = _validated_confirmation_receipt(store, existing)
+        except CkmValidationError:
+            continue
+        if existing_payload["confirmation_key"] == payload["confirmation_key"]:
+            store._set_inferred_edge_confirmed(edge_id)
+            return existing
+
+    envelope = {
+        "event_type": "ckm_edge_confirmed",
+        "action": "confirm_edge",
+        "actor": {"actor_type": "human", "id": "operator"},
+        "source_refs": [{"ref_type": "ckm_evidence_edge", "ref": edge_id}],
+        "target_refs": [
             {"ref_type": "repo_artifact", "ref": artifact_ref},
             {"ref_type": "ckm_capability", "ref": capability_name},
         ],
-        action="confirm_edge",
+    }
+    payload["binding"] = _sign_confirmation(store, envelope, payload)
+    receipt = store.append_builderops_receipt(
+        source_refs=envelope["source_refs"],
+        summary=f"Confirmed inferred CKM edge for {capability_name}",
+        event_type=envelope["event_type"],
+        actor=envelope["actor"],
+        occurred_at=utc_now(),
+        target_refs=envelope["target_refs"],
+        action=envelope["action"],
         receipt_body=json.dumps(payload, ensure_ascii=False, sort_keys=True),
-        idempotency_key=(
-            f"ckm-confirm:{artifact_ref}:{capability_name}:{payload['basis']}"
-        ),
+        idempotency_key=f"ckm-confirm:{payload['confirmation_key']}",
     )
     # Receipt first: if the derived-row update fails, the durable confirmation
     # intent still exists and the normal rebuild/reapply path can restore it.

--- a/app/builderops/ckm/store.py
+++ b/app/builderops/ckm/store.py
@@ -339,6 +339,12 @@ class CkmStore:
     ) -> CkmEvidenceEdge:
         now = utc_now()
         candidate_id = new_id("edge")
+        if extraction_method == "inferred" and (
+            basis is None or not isinstance(basis, str) or not basis.strip()
+        ):
+            raise CkmValidationError(
+                "inferred evidence edges require an explicit non-empty rationale as basis"
+            )
         resolved_basis = basis or source_ref
         candidate = CkmEvidenceEdge(
             id=candidate_id,
@@ -456,7 +462,13 @@ class CkmStore:
             ).fetchone()
         return CkmEvidenceEdge.from_row(row) if row is not None else None
 
-    def confirm_inferred_edge(self, edge_id: str) -> CkmEvidenceEdge:
+    def _set_inferred_edge_confirmed(self, edge_id: str) -> CkmEvidenceEdge:
+        """Apply a confirmation already authorized by semantic receipt validation.
+
+        This is intentionally private: callers must use the receipt-producing and
+        receipt-validating confirmation boundary in ``semantic.py``.
+        """
+
         edge = self.get_evidence_edge_by_id(edge_id)
         if edge is None:
             raise CkmValidationError(f"evidence edge not found: {edge_id}")

--- a/app/builderops/ckm/store.py
+++ b/app/builderops/ckm/store.py
@@ -13,6 +13,7 @@ never invents its own receipt/authority path.
 from __future__ import annotations
 
 import json
+import secrets
 import sqlite3
 from pathlib import Path
 from typing import Any, Mapping
@@ -493,6 +494,37 @@ class CkmStore:
 
     def append_builderops_receipt(self, **fields: Any) -> JsonDict:
         return self._receipt_store.append_receipt(**fields)
+
+    def _confirmation_signing_key(self, *, create: bool = False) -> bytes | None:
+        """Return the local CKM confirmation key, creating it only at the CLI boundary.
+
+        The key lives in BuilderOps metadata, outside the rebuildable ``ckm_*``
+        projection.  Receipt replay may read it but never creates it: an
+        unsigned, self-asserted receipt therefore cannot bootstrap its own
+        authority after a rebuild.
+        """
+
+        key_name = "ckm_confirmation_signing_key_v1"
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT value FROM builderops_meta WHERE key = ?", (key_name,)
+            ).fetchone()
+            if row is None and create:
+                value = secrets.token_hex(32)
+                conn.execute(
+                    "INSERT INTO builderops_meta (key, value) VALUES (?, ?)",
+                    (key_name, value),
+                )
+                conn.commit()
+                return bytes.fromhex(value)
+            conn.commit()
+        if row is None:
+            return None
+        try:
+            return bytes.fromhex(str(row["value"]))
+        except ValueError as exc:  # fail closed on damaged trusted metadata
+            raise CkmValidationError("CKM confirmation signing key is invalid") from exc
 
     def list_evidence_edges_for_capability(self, capability_id: str) -> list[CkmEvidenceEdge]:
         with self._connect() as conn:

--- a/app/builderops/ckm/store.py
+++ b/app/builderops/ckm/store.py
@@ -340,6 +340,27 @@ class CkmStore:
         now = utc_now()
         candidate_id = new_id("edge")
         resolved_basis = basis or source_ref
+        candidate = CkmEvidenceEdge(
+            id=candidate_id,
+            artifact_id=artifact_id,
+            capability_id=capability_id,
+            evidence_kind=evidence_kind,
+            polarity=polarity,
+            maturity_dimension=maturity_dimension,
+            confidence=confidence,
+            extraction_method=extraction_method,
+            model=model,
+            provider=provider,
+            lifecycle=lifecycle,
+            source_ref=source_ref,
+            basis=resolved_basis,
+            created_at=now,
+            updated_at=now,
+        ).validate()
+        if candidate.extraction_method == "inferred" and candidate.lifecycle != "candidate":
+            raise CkmValidationError(
+                "inferred evidence edges must enter as candidate; use a confirmation receipt"
+            )
         with self._connect() as conn:
             conn.execute("BEGIN IMMEDIATE")
             conn.execute(
@@ -358,7 +379,13 @@ class CkmStore:
                     extraction_method = excluded.extraction_method,
                     model = excluded.model,
                     provider = excluded.provider,
-                    lifecycle = excluded.lifecycle,
+                    lifecycle = CASE
+                        WHEN ckm_evidence_edge.extraction_method = 'inferred'
+                         AND ckm_evidence_edge.lifecycle = 'confirmed'
+                         AND excluded.extraction_method = 'inferred'
+                        THEN 'confirmed'
+                        ELSE excluded.lifecycle
+                    END,
                     source_ref = excluded.source_ref,
                     updated_at = excluded.updated_at
                 """,
@@ -421,6 +448,39 @@ class CkmStore:
                     (artifact_id, capability_id, basis),
                 ).fetchone()
         return CkmEvidenceEdge.from_row(row) if row is not None else None
+
+    def get_evidence_edge_by_id(self, edge_id: str) -> CkmEvidenceEdge | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM ckm_evidence_edge WHERE id = ?", (edge_id,)
+            ).fetchone()
+        return CkmEvidenceEdge.from_row(row) if row is not None else None
+
+    def confirm_inferred_edge(self, edge_id: str) -> CkmEvidenceEdge:
+        edge = self.get_evidence_edge_by_id(edge_id)
+        if edge is None:
+            raise CkmValidationError(f"evidence edge not found: {edge_id}")
+        if edge.extraction_method != "inferred":
+            raise CkmValidationError("only inferred evidence edges require confirmation")
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE ckm_evidence_edge SET lifecycle = 'confirmed', updated_at = ? WHERE id = ?",
+                (utc_now(), edge_id),
+            )
+            conn.commit()
+        confirmed = self.get_evidence_edge_by_id(edge_id)
+        if confirmed is None:  # pragma: no cover - defensive
+            raise CkmValidationError(f"confirmed edge disappeared: {edge_id}")
+        return confirmed
+
+    def list_builderops_receipts(self, event_type: str | None = None) -> list[JsonDict]:
+        receipts = self._receipt_store.list_records("BuilderOpsReceipt")
+        if event_type is None:
+            return receipts
+        return [receipt for receipt in receipts if receipt.get("event_type") == event_type]
+
+    def append_builderops_receipt(self, **fields: Any) -> JsonDict:
+        return self._receipt_store.append_receipt(**fields)
 
     def list_evidence_edges_for_capability(self, capability_id: str) -> list[CkmEvidenceEdge]:
         with self._connect() as conn:

--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -31,8 +31,8 @@ from app.builderops.ckm.ingest_repo import ingest_repo
 from app.builderops.ckm.linkers import link_deterministic
 from app.builderops.ckm.semantic import (
     SemanticAssociationError,
+    _confirm_edge_from_cli,
     associate_unlinked_artifacts,
-    confirm_edge,
     reapply_confirmation_receipts,
 )
 from app.builderops.ckm.seed import SeedManifestError, seed_capabilities
@@ -476,7 +476,7 @@ def ckm_associate(ctx: click.Context, limit: int, confidence_floor: float) -> No
 @click.pass_context
 def ckm_confirm_edge(ctx: click.Context, edge_id: str) -> None:
     try:
-        receipt = confirm_edge(_ckm_store(ctx), edge_id)
+        receipt = _confirm_edge_from_cli(_ckm_store(ctx), edge_id)
     except (CkmValidationError, sqlite3.Error) as exc:
         raise click.ClickException(f"ckm edge confirmation failed: {exc}") from exc
     click.echo(f"edge {edge_id} confirmed; receipt builderops://receipts/{receipt['id']}")

--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -29,6 +29,12 @@ from app.builderops.ckm.models import CkmValidationError
 from app.builderops.ckm.ingest_github import ingest_github
 from app.builderops.ckm.ingest_repo import ingest_repo
 from app.builderops.ckm.linkers import link_deterministic
+from app.builderops.ckm.semantic import (
+    SemanticAssociationError,
+    associate_unlinked_artifacts,
+    confirm_edge,
+    reapply_confirmation_receipts,
+)
 from app.builderops.ckm.seed import SeedManifestError, seed_capabilities
 from app.builderops.ckm.store import CkmStore
 from app.builderops.config import BuilderOpsPaths, load_paths
@@ -424,15 +430,56 @@ def ckm_ingest(ctx: click.Context, source: str, repo_root: Path, git_limit: int)
 @click.pass_context
 def ckm_link(ctx: click.Context, repo_root: Path) -> None:
     try:
-        result = link_deterministic(_ckm_store(ctx), repo_root)
+        store = _ckm_store(ctx)
+        result = link_deterministic(store, repo_root)
+        confirmations_reapplied = reapply_confirmation_receipts(store)
     except (OSError, ValueError, sqlite3.Error) as exc:
         raise click.ClickException(f"ckm linking failed: {exc}") from exc
     click.echo(
         "; ".join(
             [f"{name}: {result[name]} new" for name in ("matrix", "spec", "adr", "test_code", "github_ref")]
-            + [f"unlinked artifacts: {result['unlinked_artifacts']}"]
+            + [
+                f"confirmations reapplied: {confirmations_reapplied}",
+                f"unlinked artifacts: {result['unlinked_artifacts']}",
+            ]
         )
     )
+
+
+@ckm.command("associate", help="Propose fenced inferred edges for unlinked CKM artifacts.")
+@click.option("--limit", type=click.IntRange(1, 1000), default=200, show_default=True)
+@click.option(
+    "--confidence-floor", type=click.FloatRange(0.0, 1.0), default=0.6, show_default=True
+)
+@click.pass_context
+def ckm_associate(ctx: click.Context, limit: int, confidence_floor: float) -> None:
+    try:
+        result = associate_unlinked_artifacts(
+            _ckm_store(ctx), limit=limit, confidence_floor=confidence_floor
+        )
+    except (SemanticAssociationError, CkmValidationError, sqlite3.Error) as exc:
+        raise click.ClickException(f"ckm semantic association failed: {exc}") from exc
+    if result.status != "ok":
+        click.echo(result.status)
+        return
+    provider_model = (
+        f"; model={result.provider}:{result.model}" if result.provider and result.model else ""
+    )
+    click.echo(
+        f"proposed {result.proposed} candidate edges; discarded {result.discarded} below floor; "
+        f"{result.no_match} no-match{provider_model}"
+    )
+
+
+@ckm.command("confirm-edge", help="Confirm one inferred candidate edge with a durable receipt.")
+@click.argument("edge_id")
+@click.pass_context
+def ckm_confirm_edge(ctx: click.Context, edge_id: str) -> None:
+    try:
+        receipt = confirm_edge(_ckm_store(ctx), edge_id)
+    except (CkmValidationError, sqlite3.Error) as exc:
+        raise click.ClickException(f"ckm edge confirmation failed: {exc}") from exc
+    click.echo(f"edge {edge_id} confirmed; receipt builderops://receipts/{receipt['id']}")
 
 
 @builderops.group("inquiry", help="Persist and inspect pre-ticket model inquiry artifacts.")

--- a/tests/builderops/ckm/test_semantic.py
+++ b/tests/builderops/ckm/test_semantic.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import asdict
+import json
 from pathlib import Path
 
 import pytest
@@ -86,6 +88,23 @@ def test_inferred_edges_fenced_via_store_write_path(store: CkmStore) -> None:
     assert (edge.provider, edge.model) == ("stub-provider", "stub-model")
     assert edge.basis == "The artifact explicitly explains the retrieval capability."
 
+    for rationale in (None, "", "   "):
+        with pytest.raises(CkmValidationError, match="explicit non-empty rationale"):
+            store.upsert_evidence_edge(
+                artifact_id=artifact.id,
+                capability_id=capability.id,
+                evidence_kind="doc",
+                polarity="supports",
+                maturity_dimension="documentation_quality",
+                confidence=0.9,
+                extraction_method="inferred",
+                lifecycle="candidate",
+                source_ref=artifact.source_ref,
+                basis=rationale,
+                provider="stub-provider",
+                model="stub-model",
+            )
+
     with pytest.raises(CkmValidationError, match="inferred evidence edges must enter as candidate"):
         store.upsert_evidence_edge(
             artifact_id=artifact.id,
@@ -101,6 +120,78 @@ def test_inferred_edges_fenced_via_store_write_path(store: CkmStore) -> None:
             provider="stub-provider",
             model="stub-model",
         )
+
+
+def _append_confirmation_receipt(
+    store: CkmStore,
+    *,
+    edge,
+    artifact_ref: str,
+    capability_name: str,
+    variant: str,
+) -> None:
+    payload = {
+        **asdict(edge),
+        "lifecycle": "confirmed",
+        "artifact_source_ref": artifact_ref,
+        "capability_name": capability_name,
+    }
+    actor = {"actor_type": "human", "id": "operator"}
+    action = "confirm_edge"
+    event_type = "ckm_edge_confirmed"
+    target_refs = [
+        {"ref_type": "repo_artifact", "ref": artifact_ref},
+        {"ref_type": "ckm_capability", "ref": capability_name},
+    ]
+    if variant == "non-human":
+        actor = {"actor_type": "agent", "id": "forger"}
+    elif variant == "wrong-event":
+        event_type = "ckm_edge_observed"
+    elif variant == "wrong-action":
+        action = "observe_edge"
+    elif variant == "wrong-target":
+        target_refs[0] = {"ref_type": "repo_artifact", "ref": "docs/other.md"}
+    elif variant == "forged-payload":
+        payload["confidence"] = 0.01
+    store.append_builderops_receipt(
+        source_refs=[{"ref_type": "ckm_evidence_edge", "ref": edge.id}],
+        summary="Attempted confirmation",
+        event_type=event_type,
+        actor=actor,
+        occurred_at=edge.updated_at,
+        target_refs=target_refs,
+        action=action,
+        receipt_body=json.dumps(payload, ensure_ascii=False, sort_keys=True),
+        idempotency_key=f"test-confirm-{variant}",
+    )
+
+
+@pytest.mark.parametrize(
+    "variant",
+    ["non-human", "wrong-event", "wrong-action", "wrong-target", "forged-payload"],
+)
+def test_confirmation_rejects_invalid_or_forged_receipts(
+    tmp_path: Path, variant: str
+) -> None:
+    store = CkmStore(tmp_path / f"{variant}.sqlite3")
+    store.ensure_schema()
+    capability = _capability(store)
+    artifact = _artifact(store)
+    associate_unlinked_artifacts(
+        store,
+        client=StubAssociator([_proposal(artifact.id, capability.id)]),
+    )
+    edge = store.list_evidence_edges()[0]
+    _append_confirmation_receipt(
+        store,
+        edge=edge,
+        artifact_ref=artifact.source_ref,
+        capability_name=capability.name,
+        variant=variant,
+    )
+
+    assert reapply_confirmation_receipts(store) == 0
+    assert store.get_evidence_edge_by_id(edge.id).lifecycle == "candidate"
 
 
 def test_confidence_floor_discards(store: CkmStore) -> None:
@@ -165,6 +256,10 @@ def test_confirmation_receipt_survives_rebuild(store: CkmStore) -> None:
         client=StubAssociator([_proposal(artifact.id, capability.id)]),
     )
     original = store.list_evidence_edges()[0]
+
+    # There is no public lifecycle mutation bypass; promotion must traverse a
+    # human receipt that is validated against the edge and both targets.
+    assert not hasattr(store, "confirm_inferred_edge")
 
     runner = CliRunner()
     confirmation = runner.invoke(

--- a/tests/builderops/ckm/test_semantic.py
+++ b/tests/builderops/ckm/test_semantic.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from app.builderops.cli import builderops
+from app.builderops.ckm.models import CkmValidationError
+from app.builderops.ckm.semantic import (
+    SemanticAssociationError,
+    SemanticAssociationResult,
+    SemanticBatch,
+    SemanticProposal,
+    associate_unlinked_artifacts,
+    reapply_confirmation_receipts,
+)
+from app.builderops.ckm.store import CkmStore
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> CkmStore:
+    value = CkmStore(tmp_path / "builderops.sqlite3")
+    value.ensure_schema()
+    return value
+
+
+def _capability(store: CkmStore):
+    return store.upsert_capability(
+        name="Retrieval",
+        definition="Retrieve relevant material with provenance.",
+        existence_provenance="seeded:docs/CAPABILITY_CONTRACT_MODEL.md :: Retrieval",
+        lifecycle="confirmed",
+    )
+
+
+def _artifact(store: CkmStore):
+    return store.upsert_artifact(
+        source_ref="docs/retrieval-notes.md",
+        artifact_kind="document",
+        source="repo_docs",
+        watermark="commit:abc",
+        provenance='{"source_ref":"docs/retrieval-notes.md"}',
+    )
+
+
+class StubAssociator:
+    provider = "stub-provider"
+    model = "stub-model"
+
+    def __init__(self, proposals: list[SemanticProposal]) -> None:
+        self._proposals = proposals
+
+    def propose(self, *, artifacts, capabilities) -> SemanticBatch:
+        return SemanticBatch(
+            provider=self.provider,
+            model=self.model,
+            proposals=self._proposals,
+        )
+
+
+def _proposal(artifact_id: str, capability_id: str, *, confidence: float = 0.9):
+    return SemanticProposal(
+        artifact_id=artifact_id,
+        capability_id=capability_id,
+        evidence_kind="doc",
+        maturity_dimension="documentation_quality",
+        confidence=confidence,
+        rationale="The artifact explicitly explains the retrieval capability.",
+    )
+
+
+def test_inferred_edges_fenced_via_store_write_path(store: CkmStore) -> None:
+    capability = _capability(store)
+    artifact = _artifact(store)
+
+    result = associate_unlinked_artifacts(
+        store,
+        client=StubAssociator([_proposal(artifact.id, capability.id)]),
+    )
+
+    assert result.proposed == 1
+    edge = store.list_evidence_edges()[0]
+    assert edge.extraction_method == "inferred"
+    assert edge.lifecycle == "candidate"
+    assert (edge.provider, edge.model) == ("stub-provider", "stub-model")
+    assert edge.basis == "The artifact explicitly explains the retrieval capability."
+
+    with pytest.raises(CkmValidationError, match="inferred evidence edges must enter as candidate"):
+        store.upsert_evidence_edge(
+            artifact_id=artifact.id,
+            capability_id=capability.id,
+            evidence_kind="doc",
+            polarity="supports",
+            maturity_dimension="documentation_quality",
+            confidence=0.9,
+            extraction_method="inferred",
+            lifecycle="confirmed",
+            source_ref=artifact.source_ref,
+            basis="An invalid direct confirmation.",
+            provider="stub-provider",
+            model="stub-model",
+        )
+
+
+def test_confidence_floor_discards(store: CkmStore) -> None:
+    capability = _capability(store)
+    artifact = _artifact(store)
+
+    result = associate_unlinked_artifacts(
+        store,
+        client=StubAssociator([_proposal(artifact.id, capability.id, confidence=0.59)]),
+        confidence_floor=0.6,
+    )
+
+    assert result == SemanticAssociationResult(
+        status="ok",
+        proposed=0,
+        discarded=1,
+        no_match=0,
+        provider="stub-provider",
+        model="stub-model",
+    )
+    assert store.list_evidence_edges() == []
+
+
+def test_unknown_proposal_target_fails_without_writes(store: CkmStore) -> None:
+    capability = _capability(store)
+    artifact = _artifact(store)
+    proposal = _proposal(artifact.id, capability.id)
+    invalid = SemanticProposal(
+        artifact_id="art_outside_bounded_batch",
+        capability_id=proposal.capability_id,
+        evidence_kind=proposal.evidence_kind,
+        maturity_dimension=proposal.maturity_dimension,
+        confidence=proposal.confidence,
+        rationale=proposal.rationale,
+    )
+
+    with pytest.raises(SemanticAssociationError, match="outside the bounded batch"):
+        associate_unlinked_artifacts(store, client=StubAssociator([invalid]))
+
+    assert store.list_evidence_edges() == []
+    assert store.get_watermark("semantic_association") is None
+
+
+def test_llm_unavailable_skips_cleanly(store: CkmStore) -> None:
+    _capability(store)
+    _artifact(store)
+    store.set_watermark("semantic_association", "prior")
+
+    result = associate_unlinked_artifacts(store, client=None, client_factory=lambda: None)
+
+    assert result.status == "skipped (llm unavailable)"
+    assert result.proposed == 0
+    assert store.list_evidence_edges() == []
+    assert store.get_watermark("semantic_association") == "prior"
+
+
+def test_confirmation_receipt_survives_rebuild(store: CkmStore) -> None:
+    capability = _capability(store)
+    artifact = _artifact(store)
+    associate_unlinked_artifacts(
+        store,
+        client=StubAssociator([_proposal(artifact.id, capability.id)]),
+    )
+    original = store.list_evidence_edges()[0]
+
+    runner = CliRunner()
+    confirmation = runner.invoke(
+        builderops,
+        ["--db-path", str(store.db_path), "ckm", "confirm-edge", original.id],
+    )
+    assert confirmation.exit_code == 0, confirmation.output
+    assert f"edge {original.id} confirmed; receipt builderops://receipts/" in confirmation.output
+    receipt = store.list_builderops_receipts("ckm_edge_confirmed")[0]
+    assert store.get_evidence_edge_by_id(original.id).lifecycle == "confirmed"
+    assert receipt["event_type"] == "ckm_edge_confirmed"
+
+    # An idempotent association pass must not demote a human-confirmed edge.
+    store.upsert_evidence_edge(
+        artifact_id=artifact.id,
+        capability_id=capability.id,
+        evidence_kind=original.evidence_kind,
+        polarity=original.polarity,
+        maturity_dimension=original.maturity_dimension,
+        confidence=original.confidence,
+        extraction_method="inferred",
+        lifecycle="candidate",
+        source_ref=original.source_ref,
+        basis=original.basis,
+        provider=original.provider,
+        model=original.model,
+    )
+    assert store.get_evidence_edge_by_id(original.id).lifecycle == "confirmed"
+
+    store.rebuild()
+    rebuilt_capability = _capability(store)
+    rebuilt_artifact = _artifact(store)
+    assert reapply_confirmation_receipts(store) == 1
+
+    restored = store.list_evidence_edges()
+    assert len(restored) == 1
+    assert restored[0].artifact_id == rebuilt_artifact.id
+    assert restored[0].capability_id == rebuilt_capability.id
+    assert restored[0].lifecycle == "confirmed"
+    assert restored[0].basis == original.basis

--- a/tests/builderops/ckm/test_semantic.py
+++ b/tests/builderops/ckm/test_semantic.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from dataclasses import asdict
 import json
 from pathlib import Path
+import sqlite3
 
 import pytest
 from click.testing import CliRunner
@@ -10,6 +10,7 @@ from click.testing import CliRunner
 from app.builderops.cli import builderops
 from app.builderops.ckm.models import CkmValidationError
 from app.builderops.ckm.semantic import (
+    FabricSemanticAssociator,
     SemanticAssociationError,
     SemanticAssociationResult,
     SemanticBatch,
@@ -18,6 +19,7 @@ from app.builderops.ckm.semantic import (
     reapply_confirmation_receipts,
 )
 from app.builderops.ckm.store import CkmStore
+from app.components.llm.constrained import ConstrainedCompletionError
 
 
 @pytest.fixture()
@@ -131,10 +133,23 @@ def _append_confirmation_receipt(
     variant: str,
 ) -> None:
     payload = {
-        **asdict(edge),
+        "edge_id": edge.id,
         "lifecycle": "confirmed",
         "artifact_source_ref": artifact_ref,
         "capability_name": capability_name,
+        "evidence_kind": edge.evidence_kind,
+        "polarity": edge.polarity,
+        "maturity_dimension": edge.maturity_dimension,
+        "confidence": edge.confidence,
+        "extraction_method": edge.extraction_method,
+        "source_ref": edge.source_ref,
+        "basis": edge.basis,
+        "provider": edge.provider,
+        "model": edge.model,
+        "confirmation_key": "a" * 64,
+        # A structurally plausible value is still not trusted without the
+        # secret binding created by the human-operated confirmation boundary.
+        "binding": "b" * 64,
     }
     actor = {"actor_type": "human", "id": "operator"}
     action = "confirm_edge"
@@ -168,7 +183,14 @@ def _append_confirmation_receipt(
 
 @pytest.mark.parametrize(
     "variant",
-    ["non-human", "wrong-event", "wrong-action", "wrong-target", "forged-payload"],
+    [
+        "self-asserted",
+        "non-human",
+        "wrong-event",
+        "wrong-action",
+        "wrong-target",
+        "forged-payload",
+    ],
 )
 def test_confirmation_rejects_invalid_or_forged_receipts(
     tmp_path: Path, variant: str
@@ -192,6 +214,44 @@ def test_confirmation_rejects_invalid_or_forged_receipts(
 
     assert reapply_confirmation_receipts(store) == 0
     assert store.get_evidence_edge_by_id(edge.id).lifecycle == "candidate"
+
+    # Absence of the source edge after rebuild must not turn a structurally
+    # valid human self-assertion into authority.
+    store.rebuild()
+    _capability(store)
+    _artifact(store)
+    assert reapply_confirmation_receipts(store) == 0
+    assert store.list_evidence_edges() == []
+
+
+class _FabricClient:
+    def __init__(self, *, response: str | None = None, error: Exception | None = None) -> None:
+        self.response = response
+        self.error = error
+
+    def chat(self, *args, **kwargs) -> str:
+        if self.error is not None:
+            raise self.error
+        assert self.response is not None
+        return self.response
+
+
+@pytest.mark.parametrize("failure", ["schema", "constrained"])
+def test_fabric_adapter_maps_structured_output_failures(failure: str) -> None:
+    associator = object.__new__(FabricSemanticAssociator)
+    associator.provider = "stub-provider"
+    associator.model = "stub-model"
+    if failure == "schema":
+        associator._client = _FabricClient(response='{"proposals": [{"artifact_id": "x"}]}')
+    else:
+        associator._client = _FabricClient(
+            error=ConstrainedCompletionError(
+                schema_ref="test", reason="schema violation"
+            )
+        )
+
+    with pytest.raises(SemanticAssociationError, match="invalid semantic association response"):
+        associator.propose(artifacts=[], capabilities=[])
 
 
 def test_confidence_floor_discards(store: CkmStore) -> None:
@@ -248,7 +308,9 @@ def test_llm_unavailable_skips_cleanly(store: CkmStore) -> None:
     assert store.get_watermark("semantic_association") == "prior"
 
 
-def test_confirmation_receipt_survives_rebuild(store: CkmStore) -> None:
+def test_confirmation_receipt_survives_rebuild(
+    store: CkmStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
     capability = _capability(store)
     artifact = _artifact(store)
     associate_unlinked_artifacts(
@@ -271,6 +333,18 @@ def test_confirmation_receipt_survives_rebuild(store: CkmStore) -> None:
     receipt = store.list_builderops_receipts("ckm_edge_confirmed")[0]
     assert store.get_evidence_edge_by_id(original.id).lifecycle == "confirmed"
     assert receipt["event_type"] == "ckm_edge_confirmed"
+
+    # The stable semantic confirmation key makes a delayed retry idempotent;
+    # changing wall-clock timestamps cannot conflict with the prior request.
+    monkeypatch.setattr(
+        "app.builderops.ckm.semantic.utc_now", lambda: "2099-01-01T00:00:00Z"
+    )
+    repeated = runner.invoke(
+        builderops,
+        ["--db-path", str(store.db_path), "ckm", "confirm-edge", original.id],
+    )
+    assert repeated.exit_code == 0, repeated.output
+    assert len(store.list_builderops_receipts("ckm_edge_confirmed")) == 1
 
     # An idempotent association pass must not demote a human-confirmed edge.
     store.upsert_evidence_edge(
@@ -300,3 +374,45 @@ def test_confirmation_receipt_survives_rebuild(store: CkmStore) -> None:
     assert restored[0].capability_id == rebuilt_capability.id
     assert restored[0].lifecycle == "confirmed"
     assert restored[0].basis == original.basis
+
+
+@pytest.mark.parametrize("field", ["actor", "confidence", "model", "basis"])
+def test_trusted_confirmation_rejects_tampering_before_and_after_rebuild(
+    tmp_path: Path, field: str
+) -> None:
+    store = CkmStore(tmp_path / f"tamper-{field}.sqlite3")
+    store.ensure_schema()
+    capability = _capability(store)
+    artifact = _artifact(store)
+    associate_unlinked_artifacts(
+        store,
+        client=StubAssociator([_proposal(artifact.id, capability.id)]),
+    )
+    edge = store.list_evidence_edges()[0]
+    runner = CliRunner()
+    confirmation = runner.invoke(
+        builderops,
+        ["--db-path", str(store.db_path), "ckm", "confirm-edge", edge.id],
+    )
+    assert confirmation.exit_code == 0, confirmation.output
+    receipt = store.list_builderops_receipts("ckm_edge_confirmed")[0]
+
+    if field == "actor":
+        receipt["actor"] = {"actor_type": "human", "id": "different-human"}
+    else:
+        body = json.loads(receipt["receipt_body"])
+        body[field] = 0.01 if field == "confidence" else f"altered-{field}"
+        receipt["receipt_body"] = json.dumps(body, ensure_ascii=False, sort_keys=True)
+    with sqlite3.connect(store.db_path) as conn:
+        conn.execute(
+            "UPDATE builderops_records SET payload = ? WHERE id = ?",
+            (json.dumps(receipt, ensure_ascii=False, sort_keys=True), receipt["id"]),
+        )
+        conn.commit()
+
+    assert reapply_confirmation_receipts(store) == 0
+    store.rebuild()
+    _capability(store)
+    _artifact(store)
+    assert reapply_confirmation_receipts(store) == 0
+    assert store.list_evidence_edges() == []


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Fixes #3144

## SBS Impact
- Primary subsystem: Builder System (BuilderOps plane)
- Secondary subsystem(s): none
- Write class: derived CKM analytical state plus BuilderOps confirmation receipt
- Authority impact: none; inferred edges remain candidates until explicit confirmation
- Persistence impact: rebuildable CKM rows; durable confirmation intent lives in the existing BuilderOps receipt substrate
- Derived/rebuildable impact: semantic edges rebuild from source artifacts and confirmation receipts re-apply after rebuild
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none at runtime
- Sync/deployment impact: none
- External boundary impact: routed LLM classification call with schema validation and skip-on-unavailable fallback
- New or changed contract: implements the existing CKM-06 specification; no Product/Runtime contract change
- Owner-doc impact: none; CKM owner-doc promotion remains at parent acceptance #3138
- Transition debt impact: no effect
- Fitness rule impact: no effect
- Boundary risk: inference is confidence-floored, provenance-bearing, candidate-only, and cannot write Product/Runtime or GitHub state

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Add bounded semantic association for CKM artifacts left unlinked by deterministic rules, using the configured cheap classification route and strict structured-output validation.
- Fence accepted edges as inferred candidates with provider/model/rationale provenance, discard sub-floor proposals, and preserve explicit confirmation through durable BuilderOps receipts across CKM rebuilds.
- Add `ckm associate` and `ckm confirm-edge`; deterministic linking re-applies prior confirmation receipts.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed. (No contract text changed; existing CKM-06 spec remains authoritative.)
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality. (Slice-only delivery; parent #3138 owns capability acceptance/promotion.)

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [ ] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [ ] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [x] `ruff check app tests`
- [x] If files under `app/` or `tests/` changed, lint output from `ruff check app tests` is included below or a tooling limitation is stated.
- [x] `mypy app`
- [ ] `pytest -q -m "not pg"`
- [x] Additional targeted checks run as needed

Evidence:
- `ruff check app tests companion-ui/companion-app` → `All checks passed!`
- `mypy app` → `Success: no issues found in 726 source files`
- `python -m pytest tests/builderops/ckm/test_semantic.py -q` → `5 passed`
- `python -m pytest tests/builderops/ckm -q` → `43 passed`
- Full `not pg` → `8169 passed, 114 skipped, 18 xfailed`; two unrelated failures reproduced unchanged on clean `origin/main`: `tests/properties/test_guard_at_seam.py::test_every_write_note_relative_seam_has_port_coverage` and `tests/standing_questions/test_question_store.py::test_validate_question_note_rejects_bad_created_at_format`. Current-head CI is required.
- Live bounded flow in a temporary store: seed 31 capabilities; ingest live repo; deterministic link; `ckm associate --limit 20` → `skipped (llm unavailable)`, exit 0, zero inferred edges, semantic watermark untouched. No provider was configured, so five-proposal visual inspection could not be performed.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: no delivery divergence or high-churn operational material required a BuilderOps record; runtime confirmation receipts are the implemented CKM behavior, not a delivery record.

## Notes
- Dispatcher unavailable for claim (`unsupported dispatcher schema_version: 3` / `dispatcher_db_uninitialized`); used the canonical GitHub-label-only fallback and durable pickup receipt on #3144.
- Owner-doc resolution: no owner-doc change implied for this child slice; promotion remains governed by #3138 acceptance.

## Review Repair Attempt 1
- Head: `1f0a0513693c4469d128387cbfd13e3e38d5b760`
- Required explicit non-empty rationale for every inferred write; omitted and blank values now fail at the production store boundary.
- Removed the public direct lifecycle mutation path; CLI confirmation and replay now validate a durable human receipt against event, action, source edge, complete payload, artifact target, and capability target before promotion.
- Regression coverage: omission/blank rationale, absent public bypass, non-human actor, wrong event/action/target, and forged payload.
- Validation: `ruff check app tests` (passed); `mypy app` (passed, 726 files); semantic suite (10 passed); CKM suite (48 passed); full `not pg` (8175 passed, 114 skipped, 18 xfailed; two unchanged baseline failures already documented above).

## Review Repair Attempt 2
- Head: `0f5bad5fd676d08cd86e2f9a8666e9ecaf4840a5`
- Durable confirmation receipts now carry an HMAC trust binding rooted in BuilderOps metadata outside rebuildable `ckm_*` state. Replay fails closed without that trusted key and rejects changes to actor, confidence, model, basis, targets, action, or edge claim before and after rebuild.
- Confirmation idempotency now uses a stable semantic claim key and reuses the original trusted receipt across delayed retries instead of including mutable timestamps in a conflicting request.
- Provider `ConstrainedCompletionError` and schema-validation failures now surface as `SemanticAssociationError`; provider transport/config unavailability retains the named skip path.
- Regression coverage: self-asserted human receipt before/after rebuild, trusted receipt tampering before/after rebuild, schema/constrained adapter failures, and delayed repeated confirmation.
- Validation: semantic suite 17 passed; CKM suite 55 passed; `ruff check app tests companion-ui/companion-app` passed; `mypy app` passed (726 files); full `not pg` reached 100% with only the same two unrelated baseline failures documented above. Fresh independent review is required before merge.