### PR TITLE
governance: continue delivery past reparable blockers

### DIFF
--- a/.codex/skills/deliver-issue-set/SKILL.md
+++ b/.codex/skills/deliver-issue-set/SKILL.md
@@ -132,7 +132,7 @@ Delivery rules:
 - When coordinating autonomous delivery, do not treat an unprotected branch or absent required-status-check rule as permission to skip the process gate. `verification-and-closure` still owns the current CI/checks plus local-review-gate prerequisites before merge.
 - A coordinator waits on many PRs at once — the worst case for the shared API budget. Poll per `_shared/CI_WAIT_CONTRACT.md` (REST check-runs only, ≥60–120s backoff, `scripts/await_pr_checks.sh`); never run concurrent `gh pr checks` loops, which drain the shared GraphQL bucket to zero and stall every sub-agent.
 - After every delivered issue, re-read the parent feature issue / Project state and recompute the next pickup target.
-- Stop instead of forcing delivery when an issue is blocked, malformed, stale, already delivered, missing `Verify:` targets, missing authority, or needs human input.
+- Stop forcing the current issue when it is blocked, malformed, stale, already delivered, missing `Verify:` targets, missing authority, or needs human input. Apply the [no-progress final gate](#no-progress-final-gate) before treating that stop as a delivery conclusion.
 
 Parallel claim is allowed only when all are true:
 
@@ -163,9 +163,40 @@ conflicts, the coordinator must reconcile, release, or choose a different issue 
 Delivery mode is complete only when every in-scope issue is either:
 
 - delivered and verified through `verification-and-closure`, or
-- explicitly classified as non-executable with a maintenance receipt, blocker reason, and next action
+- explicitly classified as non-executable only after the no-progress final gate establishes that no small, source-authorized remediation can be created, repaired, claimed, or continued; the maintenance receipt must name the blocker, next action, and verified human-authority need when one remains
 
 Do not report the whole epic or Kanban scope as delivered while blocked or non-executable issues are silently left behind.
+
+### No-progress final gate
+
+This gate applies whenever Delivery Mode encounters a blocker. It prevents a delivery agent from
+ending a turn with a blocker report while the delivery loop still has a small, evidence-backed next
+move.
+
+Before a final delivery update, determine from the current issue, owner docs, Source Anchors, and
+live repository/GitHub state whether a small, source-authorized remediation can be created, repaired,
+claimed, or continued. Typical examples include a malformed configuration issue, an omitted channel
+binding, or a validation precondition whose owning source already identifies the intended repair.
+
+If such remediation exists, the agent must not conclude delivery with the blocker report. It must:
+
+1. repair an existing Issue contract through `issue-maintenance-change-control`, or create a bounded
+   remediation Issue through `docs-to-issue` or `feature-breakdown`, as the source authority requires;
+2. make the Issue strict before pickup: bounded Scope, resolving Source Anchors, complete constraints,
+   and an Acceptance Criterion with a concrete `Verify:` target for every claimed outcome;
+3. select it as the next pickup, claim it through `issue-to-code` when it is ready, or continue the
+   already-claimed remediation; and
+4. resume the Delivery Procedure from the resulting next pickup.
+
+Escalate through `owner-decision-brief` only when the evidence verifies that a human authority,
+choice, credential, or external action is genuinely required. Record that authority need and the
+evidence in the maintenance receipt. A blocked slice may pause while that decision is pending, but a
+plain “reported the blocker” update is not delivery completion.
+
+The only valid final states for a reparable blocker are an active/next claimed remediation, a strict
+ready Issue with an explicit next pickup owner when a claim cannot yet run, or a verified
+human-authority stop. Do not use this gate to invent scope: if source authority cannot support a
+bounded remediation, record that fact and follow the normal maintenance or Human Exception route.
 
 ## Scope Resolution
 

--- a/.codex/skills/deliver-issue-set/SKILL.md
+++ b/.codex/skills/deliver-issue-set/SKILL.md
@@ -178,6 +178,13 @@ live repository/GitHub state whether a small, source-authorized remediation can 
 claimed, or continued. Typical examples include a malformed configuration issue, an omitted channel
 binding, or a validation precondition whose owning source already identifies the intended repair.
 
+For any vault-binding remediation, run `owner-decision-brief :: Local vault-binding preflight` before
+creating, repairing, claiming, or continuing that remediation — even when no owner question is yet
+needed. A vault-binding repair may proceed only when that preflight independently establishes its
+channel-owned source and either confirms all-writer isolation or proves that the bounded repair will
+restore one missing/divergent writer binding to that already-proven source; otherwise it is a
+verified authority stop, not a repair candidate.
+
 If such remediation exists, the agent must not conclude delivery with the blocker report. It must:
 
 1. repair an existing Issue contract through `issue-maintenance-change-control`, or create a bounded
@@ -192,6 +199,10 @@ Escalate through `owner-decision-brief` only when the evidence verifies that a h
 choice, credential, or external action is genuinely required. Record that authority need and the
 evidence in the maintenance receipt. A blocked slice may pause while that decision is pending, but a
 plain “reported the blocker” update is not delivery completion.
+
+For vault-binding or startup/configuration investigations, all Issue, PR, BuilderOps, and maintenance
+receipt evidence must be redacted: record variable names plus boolean/path-class results only. Never
+record raw paths, vault names, environment values, DSNs, secrets, or raw startup/Compose output.
 
 The only valid final states for a reparable blocker are an active/next claimed remediation, a strict
 ready Issue with an explicit next pickup owner when a claim cannot yet run, or a verified

--- a/.codex/skills/owner-decision-brief/SKILL.md
+++ b/.codex/skills/owner-decision-brief/SKILL.md
@@ -60,6 +60,11 @@ This preflight is inspection-only unless the governing issue or source authority
 resulting bounded repair. It does not authorize a real-vault write, a deployment, or disclosure of
 environment-file contents.
 
+This redaction discipline applies to every preflight outcome, including a repair that can continue:
+Issue, PR, BuilderOps, and maintenance receipts may contain only variable names and redacted
+boolean/path-class results. They must never contain raw paths, vault names, environment values, DSNs,
+secrets, or raw startup/Compose output.
+
 ## Step 1 — The filter: is this discretionary decision the owner's at all?
 
 Before writing anything owner-facing, test the decision against the escalation gate of

--- a/.codex/skills/owner-decision-brief/SKILL.md
+++ b/.codex/skills/owner-decision-brief/SKILL.md
@@ -29,6 +29,30 @@ Two failure modes motivate this skill, and it must close both:
 2. **Escalations in project jargon.** When a decision *is* the owner's, it arrives wrapped
    in internal terminology, so he must first decode the question before he can decide.
 
+## Local vault-binding preflight
+
+When the apparent blocker is a missing local vault binding, mount, or path, complete this preflight
+before adding `agent:needs-human` or asking the owner. A missing binding is often a reparable
+channel-bootstrap/configuration problem, not an owner decision.
+
+1. Inspect the deploy environment files selected for the target channel and identify the variables
+   that supply the vault source and target. Check presence and resolved path shape only; never copy
+   secret values into chat, Issues, PRs, or receipts.
+2. Inspect the effective Compose file and overlays for the target service, including the resolved
+   mount/bind source and container target. Confirm that the deploy environment and Compose wiring
+   agree.
+3. Check the configured source path and the standard local Obsidian locations, including
+   `~/Library/Mobile Documents/iCloud~md~obsidian/Documents` and `~/Documents/Obsidian`, then the
+   intended vault subdirectory. Confirm that a candidate is readable, not merely present.
+4. If these checks expose a source-authorized, reversible repair, create or repair the bounded Issue
+   and continue delivery; do not ask the owner for confirmation. If the source is absent or several
+   legitimate vaults remain and the owner must choose one, retain the command/path evidence in the
+   durable record and proceed to Step 1.
+
+This preflight is inspection-only unless the governing issue or source authority already permits the
+resulting bounded repair. It does not authorize a real-vault write, a deployment, or disclosure of
+environment-file contents.
+
 ## Step 1 — The filter: is this discretionary decision the owner's at all?
 
 Before writing anything owner-facing, test the decision against the escalation gate of

--- a/.codex/skills/owner-decision-brief/SKILL.md
+++ b/.codex/skills/owner-decision-brief/SKILL.md
@@ -36,24 +36,25 @@ before adding `agent:needs-human` or asking the owner. A missing binding is ofte
 channel-bootstrap/configuration problem, not an owner decision.
 
 1. Inspect the deploy environment files selected for the target channel and identify the variables
-   that supply the vault source and target. Check presence and resolved path shape only; never copy
-   secret values into chat, Issues, PRs, or receipts.
-2. Inspect only the target service's mount/bind fields in the effective Compose file and overlays.
-   Use source inspection or a redacted, non-interpolating view; never render or retain the full
-   effective configuration, environment values, or unrelated service fields. Confirm that the deploy
-   environment and Compose wiring agree.
+   that supply the vault source and target. Use a non-emitting parser or check that returns only
+   presence/path-class results; do not `cat`, source, echo, or otherwise print the file or its values.
+2. Run the same non-emitting, structured check across every write-capable service and watcher binding
+   for the target channel, not just the first failing service. It must exclude ambient/plain vault
+   selectors and confirm that deploy environment and Compose wiring resolve to the same channel-owned
+   source. Never run raw Compose config, doctor, startup, environment, or directory-listing commands
+   during this preflight: those outputs can expose private paths, vault names, or secrets.
 3. Check the configured source path and the standard local Obsidian locations, including
    `~/Library/Mobile Documents/iCloud~md~obsidian/Documents` and `~/Documents/Obsidian`, then the
-   intended vault subdirectory. Confirm that a candidate is readable, not merely present; use this
-   only as diagnostic evidence, never as a channel-binding selection.
-4. Only when the target channel's deploy environment, Compose wiring, or canonical bootstrap/doctor
-   output already identifies a channel-owned source may the agent create or repair the resulting
-   bounded, reversible configuration Issue and continue delivery. A generic iCloud/Obsidian discovery
-   must never be used to create or rewrite a dev/test/prod binding. If the channel-owned source is
-   absent, or several legitimate vaults remain and the owner must choose one, retain the command/path
-   outcome only as redacted boolean/path-class evidence (for example, `channel source: absent` or
-   `configured path: unreadable`), never as full commands, raw environment values, vault names, or
-   absolute private paths; then proceed to Step 1.
+   intended vault subdirectory. Test only the exact candidate path silently, without enumerating its
+   contents. Use the result only as diagnostic evidence, never as a channel-binding selection.
+4. Create or repair a bounded, reversible configuration Issue only when the non-emitting check
+   independently proves a channel-owned canonical source and matching bindings for every
+   write-capable service, or proves that the bounded repair will restore a single missing/divergent
+   binding to that already-proven source. A generic iCloud/Obsidian discovery must never be used to
+   create or rewrite a dev/test/prod binding. If channel ownership or matching bindings cannot be
+   independently established, do not repair the binding: retain only redacted boolean/path-class
+   evidence (for example, `channel source: absent` or `configured path: unreadable`) and proceed to
+   Step 1.
 
 This preflight is inspection-only unless the governing issue or source authority already permits the
 resulting bounded repair. It does not authorize a real-vault write, a deployment, or disclosure of

--- a/.codex/skills/owner-decision-brief/SKILL.md
+++ b/.codex/skills/owner-decision-brief/SKILL.md
@@ -38,16 +38,22 @@ channel-bootstrap/configuration problem, not an owner decision.
 1. Inspect the deploy environment files selected for the target channel and identify the variables
    that supply the vault source and target. Check presence and resolved path shape only; never copy
    secret values into chat, Issues, PRs, or receipts.
-2. Inspect the effective Compose file and overlays for the target service, including the resolved
-   mount/bind source and container target. Confirm that the deploy environment and Compose wiring
-   agree.
+2. Inspect only the target service's mount/bind fields in the effective Compose file and overlays.
+   Use source inspection or a redacted, non-interpolating view; never render or retain the full
+   effective configuration, environment values, or unrelated service fields. Confirm that the deploy
+   environment and Compose wiring agree.
 3. Check the configured source path and the standard local Obsidian locations, including
    `~/Library/Mobile Documents/iCloud~md~obsidian/Documents` and `~/Documents/Obsidian`, then the
-   intended vault subdirectory. Confirm that a candidate is readable, not merely present.
-4. If these checks expose a source-authorized, reversible repair, create or repair the bounded Issue
-   and continue delivery; do not ask the owner for confirmation. If the source is absent or several
-   legitimate vaults remain and the owner must choose one, retain the command/path evidence in the
-   durable record and proceed to Step 1.
+   intended vault subdirectory. Confirm that a candidate is readable, not merely present; use this
+   only as diagnostic evidence, never as a channel-binding selection.
+4. Only when the target channel's deploy environment, Compose wiring, or canonical bootstrap/doctor
+   output already identifies a channel-owned source may the agent create or repair the resulting
+   bounded, reversible configuration Issue and continue delivery. A generic iCloud/Obsidian discovery
+   must never be used to create or rewrite a dev/test/prod binding. If the channel-owned source is
+   absent, or several legitimate vaults remain and the owner must choose one, retain the command/path
+   outcome only as redacted boolean/path-class evidence (for example, `channel source: absent` or
+   `configured path: unreadable`), never as full commands, raw environment values, vault names, or
+   absolute private paths; then proceed to Step 1.
 
 This preflight is inspection-only unless the governing issue or source authority already permits the
 resulting bounded repair. It does not authorize a real-vault write, a deployment, or disclosure of

--- a/.codex/skills/verification-and-closure/SKILL.md
+++ b/.codex/skills/verification-and-closure/SKILL.md
@@ -43,6 +43,25 @@ Test/check failures must be classified, not dismissed as merely "out of scope" w
 - merge state if already merged
 - current `origin/main` / target-base reachability for any resumed, chained, or review-repair work
 
+## Pre-API startup failure classification
+
+When a validation attempt fails before the API starts accepting requests (for example, before the
+service listens, reports ready, or can answer its first API health check), classify the failure first
+as **channel-bootstrap/configuration work**, not as a verified feature failure. Preserve the concrete
+startup evidence and determine whether the failure is in deploy environment selection, Compose
+wiring, mounts, channel binding, or another bootstrap prerequisite.
+
+- Do not mark the feature acceptance criterion failed, delivered, or impossible solely from a
+  pre-API startup failure. Its feature proof is still unverified.
+- If the startup evidence implicates the changed feature path after bootstrap/configuration is known
+  good, reclassify it as a feature failure and repair it through the governing Issue.
+- If a small, source-authorized bootstrap/configuration remediation exists, route it through
+  `deliver-issue-set :: No-progress final gate`: create or repair a strict Issue with `Verify:`
+  targets, claim or continue that next pickup, and resume delivery. Do not end with a blocker report.
+- Escalate only when the bootstrap evidence establishes a genuine human-authority need; otherwise use
+  the existing issue-maintenance and delivery paths. This classification does not authorize deploy,
+  image, pin, or runtime changes by itself.
+
 ## Validation Rules
 
 - Compare code and docs to the governing issue's `Scope`, `Source Anchors`, `Constraints`, `Acceptance Criteria`, and `Suggested Validation`

--- a/.codex/skills/verification-and-closure/SKILL.md
+++ b/.codex/skills/verification-and-closure/SKILL.md
@@ -47,9 +47,11 @@ Test/check failures must be classified, not dismissed as merely "out of scope" w
 
 When a validation attempt fails before the API starts accepting requests (for example, before the
 service listens, reports ready, or can answer its first API health check), classify the failure first
-as **channel-bootstrap/configuration work**, not as a verified feature failure. Preserve the concrete
-startup evidence and determine whether the failure is in deploy environment selection, Compose
-wiring, mounts, channel binding, or another bootstrap prerequisite.
+as **channel-bootstrap/configuration work**, not as a verified feature failure. Preserve a concrete,
+redacted startup classification and determine whether the failure is in deploy environment
+selection, Compose wiring, mounts, channel binding, or another bootstrap prerequisite. Evidence in
+Issues, PRs, BuilderOps, and receipts may name variables and boolean/path-class results only; never
+include raw paths, vault names, environment values, DSNs, secrets, or raw startup/Compose output.
 
 - Do not mark the feature acceptance criterion failed, delivered, or impossible solely from a
   pre-API startup failure. Its feature proof is still unverified.
@@ -58,6 +60,8 @@ wiring, mounts, channel binding, or another bootstrap prerequisite.
 - If a small, source-authorized bootstrap/configuration remediation exists, route it through
   `deliver-issue-set :: No-progress final gate`: create or repair a strict Issue with `Verify:`
   targets, claim or continue that next pickup, and resume delivery. Do not end with a blocker report.
+- For a vault-binding remediation, require `owner-decision-brief :: Local vault-binding preflight`
+  before creating, repairing, claiming, or continuing the Issue, even when no owner ask follows.
 - Escalate only when the bootstrap evidence establishes a genuine human-authority need; otherwise use
   the existing issue-maintenance and delivery paths. This classification does not authorize deploy,
   image, pin, or runtime changes by itself.


### PR DESCRIPTION
- [x] Governance lane

## Summary
Strengthens delivery-agent recovery rules so reparable environment and Compose blockers become bounded follow-up work instead of a terminal blocker report.

## Changes
- Adds the Delivery Mode no-progress final gate.
- Requires a safe, channel-scoped local vault-binding preflight before any vault-binding remediation or owner escalation.
- Requires non-emitting, redacted evidence across every write-capable service before any channel-binding repair.
- Classifies pre-API startup failures as channel-bootstrap/configuration work.
- Does not change runtime, images, pins, deploy configuration, or channel state.

## Validation
- `python3 scripts/docs_guard.py`
- `python3 scripts/lint_skills_consistency.py`
- `pytest -q tests/governance/test_skills_consistency_lint.py tests/architecture/test_agent_skill_entrypoints.py tests/architecture/test_pr_hot_path_governance.py tests/governance/test_issue_pr_governance.py` (39 passed)
- `python3 scripts/review_before_ci_gate.py --lane governance --review-gate-complete ...`

## BuilderOps Routing
- Records/projections/receipts: `lrn_20260714122951_018f0e2a`, `lrn_20260714123015_c9b20fe0`, `lrn_20260714123438_e1f17a48`, `lrn_20260714123838_facb4cc9`
- Reason: Independent review found concrete vault-binding safety divergences; this PR repairs the named upstream skill contracts.
