### PR TITLE
Use cursor-supported REST pull ingestion

### DIFF
--- a/app/builderops/ckm/ingest_github.py
+++ b/app/builderops/ckm/ingest_github.py
@@ -96,19 +96,18 @@ def _gh_fetch(repository: str) -> Callable[[str, str | None], list[dict[str, Any
 
     def fetch(kind: str, since: str | None) -> list[dict[str, Any]]:
         endpoint = f"repos/{repository}/issues?state=all&per_page=100"
-        if kind == "pulls":
-            endpoint = f"repos/{repository}/pulls?state=all&per_page=100"
         if since:
             endpoint = f"{endpoint}&since={since}"
         decoded = request_list(endpoint)
         if kind == "issues":
             return [item for item in decoded if "pull_request" not in item]
-        for item in decoded:
+        pulls = [item for item in decoded if "pull_request" in item]
+        for item in pulls:
             number = item.get("number")
             if isinstance(number, int):
                 files = request_list(f"repos/{repository}/pulls/{number}/files?per_page=100")
                 item["changed_files"] = [str(file["filename"]) for file in files if "filename" in file]
-        return decoded
+        return pulls
 
     return fetch
 

--- a/app/builderops/ckm/ingest_github.py
+++ b/app/builderops/ckm/ingest_github.py
@@ -57,16 +57,20 @@ def normalize_github_payload(payload: Mapping[str, Any], *, artifact_kind: str) 
     if artifact_kind not in {"issue", "pull_request"}:
         raise ValueError(f"unsupported GitHub artifact kind: {artifact_kind}")
     key_kind = "issue" if artifact_kind == "issue" else "pull"
+    pull_request = payload.get("pull_request")
+    merged_at = payload.get("merged_at")
+    if merged_at is None and isinstance(pull_request, Mapping):
+        merged_at = pull_request.get("merged_at")
     provenance = {
         "source_ref": f"github:{key_kind}:{number}",
         "extraction_method": "github_rest",
         "number": number,
         "title": str(payload.get("title", "")),
         "state": str(payload.get("state", "")),
-        "merged_at": payload.get("merged_at"),
+        "merged_at": merged_at,
         "labels": _labels(payload),
         "references": _references(payload),
-        "linked_pull_request": payload.get("pull_request"),
+        "linked_pull_request": pull_request,
         "closing_references": payload.get("closing_issues_references", []),
         "changed_files": payload.get("changed_files", [] if artifact_kind == "pull_request" else None),
         "updated_at": updated_at,

--- a/tests/builderops/ckm/test_ingest_github.py
+++ b/tests/builderops/ckm/test_ingest_github.py
@@ -52,6 +52,18 @@ def test_rest_payload_normalization_with_refs() -> None:
     assert pull_payload["merged_at"] == "2026-07-01T10:00:30Z"
 
 
+def test_pull_issue_payload_preserves_nested_merged_at() -> None:
+    pull = _pull()
+    pull.pop("merged_at")
+    pull["pull_request"] = {"merged_at": "2026-07-01T10:00:30Z"}
+
+    payload = json.loads(
+        normalize_github_payload(pull, artifact_kind="pull_request").provenance
+    )
+
+    assert payload["merged_at"] == "2026-07-01T10:00:30Z"
+
+
 def test_updated_at_cursor_incremental(tmp_path: Path) -> None:
     responses = {"issues": [_issue()], "pulls": [_pull()]}
 

--- a/tests/builderops/ckm/test_ingest_github.py
+++ b/tests/builderops/ckm/test_ingest_github.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from click.testing import CliRunner
 
 from app.builderops.cli import builderops
-from app.builderops.ckm.ingest_github import ingest_github, normalize_github_payload
+from app.builderops.ckm.ingest_github import _gh_fetch, ingest_github, normalize_github_payload
 from app.builderops.ckm.store import CkmStore
 
 
@@ -68,6 +68,32 @@ def test_updated_at_cursor_incremental(tmp_path: Path) -> None:
     updated = ingest_github(store, fetch=fetch)
     assert updated["issues"]["changed"] == 1
     assert len([item for item in store.list_artifacts() if item.source == "github_issues"]) == 1
+
+
+def test_github_pull_fetch_uses_cursor_supported_endpoint(monkeypatch) -> None:
+    calls: list[str] = []
+    pull = {**_pull(), "pull_request": {"url": "https://example.test/pulls/77"}}
+
+    def fake_run(args, **_kwargs):
+        endpoint = args[-1]
+        calls.append(endpoint)
+        if endpoint.startswith("repos/example/repo/issues?"):
+            payload = [[_issue(), pull]]
+        elif endpoint == "repos/example/repo/pulls/77/files?per_page=100":
+            payload = [[{"filename": "app/builderops/ckm/ingest_github.py"}]]
+        else:
+            raise AssertionError(f"unexpected endpoint: {endpoint}")
+        return subprocess.CompletedProcess(args, 0, json.dumps(payload), "")
+
+    monkeypatch.setattr("app.builderops.ckm.ingest_github.subprocess.run", fake_run)
+
+    records = _gh_fetch("example/repo")("pulls", "2026-07-01T10:00:00Z")
+
+    assert records == [{**pull, "changed_files": ["app/builderops/ckm/ingest_github.py"]}]
+    assert calls == [
+        "repos/example/repo/issues?state=all&per_page=100&since=2026-07-01T10:00:00Z",
+        "repos/example/repo/pulls/77/files?per_page=100",
+    ]
 
 
 def test_offline_degrade_preserves_watermark_via_entrypoint(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Closes #3649

## SBS Impact
- Primary subsystem: Builder System (BuilderOps CKM projection)
- Secondary subsystem(s): GitHub REST adapter
- Write class: Derived ingest code and focused tests
- Authority impact: None; CKM remains rebuildable projection-only state.
- Persistence impact: Rebuildable CKM artifacts and cursor watermarks.
- Derived/rebuildable impact: All changed data is rebuildable.
- Human knowledge impact: None.
- Memory impact: None.
- Retrieval/context impact: None at runtime.
- Sync/deployment impact: None.
- External boundary impact: GitHub REST API query semantics and rate limits.
- New or changed contract: Pull incremental selection uses a cursor-supported REST path.
- Owner-doc impact: None; existing BuilderOps documentation remains accurate.
- Transition debt impact: Reduces GitHub ingestion rate-limit risk.
- Fitness rule impact: Focused request-shape regression coverage.
- Boundary risk: Normal; external REST query semantics with rebuildable outputs.

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Select incremental pull records through the REST Issues endpoint, which supports the stored since cursor.
- Hydrate changed-file details only for selected pull-request records.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [ ] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [ ] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [x] pytest -q tests/builderops/ckm/test_ingest_github.py (6 passed)
- [x] ruff check app/builderops/ckm/ingest_github.py tests/builderops/ckm/test_ingest_github.py (passed)
- [x] ruff check app tests companion-ui/companion-app (passed)
- [x] git diff --check (passed)

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: Bounded CKM ingestion repair; the linked Issue and PR hold the delivery record.

## Notes
Dispatcher unavailable (db_exists: false); pickup used the GitHub-label-only fallback receipt.
