### PR TITLE
fix(dev): bind migrate to app_dev

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,7 @@
 services:
   migrate:
     environment:
+      LLM_PROVIDER: mock
       DATABASE_URL: postgresql+psycopg://app:app@db:5432/app_dev
       DB_DSN: postgresql+psycopg://app:app@db:5432/app_dev
 
@@ -14,10 +15,6 @@ services:
     # and watcher mtime saturation prevents re-population via normal watch ticks.
     volumes:
       - pgdata-dev:/var/lib/postgresql/data
-
-  migrate:
-    environment:
-      LLM_PROVIDER: mock
 
   api:
     ports: !override

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,9 @@
 services:
+  migrate:
+    environment:
+      DATABASE_URL: postgresql+psycopg://app:app@db:5432/app_dev
+      DB_DSN: postgresql+psycopg://app:app@db:5432/app_dev
+
   db:
     environment:
       POSTGRES_DB: app_dev
@@ -22,6 +27,8 @@ services:
       PKM_ENVIRONMENT: dev
       DATABASE_URL: postgresql+psycopg://app:app@db:5432/app_dev
       DB_DSN: postgresql+psycopg://app:app@db:5432/app_dev
+      VAULT_ROOT: ${VAULT_ROOT:-}
+      VAULT_ROOT_DEV: ${VAULT_ROOT_DEV:-}
 
   worker:
     environment:
@@ -29,6 +36,8 @@ services:
       PKM_ENVIRONMENT: dev
       DATABASE_URL: postgresql+psycopg://app:app@db:5432/app_dev
       DB_DSN: postgresql+psycopg://app:app@db:5432/app_dev
+      VAULT_ROOT: ${VAULT_ROOT:-}
+      VAULT_ROOT_DEV: ${VAULT_ROOT_DEV:-}
 
   watcher:
     environment:
@@ -36,6 +45,8 @@ services:
       PKM_ENVIRONMENT: dev
       DATABASE_URL: postgresql+psycopg://app:app@db:5432/app_dev
       DB_DSN: postgresql+psycopg://app:app@db:5432/app_dev
+      VAULT_ROOT: ${VAULT_ROOT:-}
+      VAULT_ROOT_DEV: ${VAULT_ROOT_DEV:-}
 
   heimdal-capture-watch:
     environment:

--- a/tests/deploy/test_dev_channel_compose.py
+++ b/tests/deploy/test_dev_channel_compose.py
@@ -1,0 +1,51 @@
+"""Merged dev-compose regression contract for Issue #3659."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.release_channels.channel_isolation_preflight import _load_compose
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BASE_COMPOSE = REPO_ROOT / "docker-compose.yaml"
+DEV_COMPOSE = REPO_ROOT / "docker-compose.dev.yml"
+DEV_DSN = "postgresql+psycopg://app:app@db:5432/app_dev"
+
+
+def _merged_service_environment(service: str) -> dict[str, str]:
+    """Model Compose's mapping merge for one service environment block."""
+    base_service = _load_compose(BASE_COMPOSE)["services"][service]
+    dev_service = _load_compose(DEV_COMPOSE)["services"][service]
+
+    def environment_mapping(service_config: dict) -> dict[str, str]:
+        environment = service_config.get("environment") or {}
+        if isinstance(environment, dict):
+            return environment
+        return dict(item.split("=", 1) for item in environment)
+
+    return {
+        **environment_mapping(base_service),
+        **environment_mapping(dev_service),
+    }
+
+
+def test_dev_migrate_uses_app_dev_dsn() -> None:
+    """The one-shot migration gate must target the same DB as dev services."""
+    migrate_environment = _merged_service_environment("migrate")
+
+    assert migrate_environment["DATABASE_URL"] == DEV_DSN
+    assert migrate_environment["DB_DSN"] == DEV_DSN
+    assert "/app_dev" in migrate_environment["DATABASE_URL"]
+    assert "/app_dev" in migrate_environment["DB_DSN"]
+
+
+def test_dev_runtime_services_forward_deploy_vault_bindings() -> None:
+    """Vault selection is deploy configuration, never a product-code path."""
+    expected = {
+        "VAULT_ROOT": "${VAULT_ROOT:-}",
+        "VAULT_ROOT_DEV": "${VAULT_ROOT_DEV:-}",
+    }
+
+    for service in ("api", "worker", "watcher"):
+        environment = _merged_service_environment(service)
+        assert {key: environment.get(key) for key in expected} == expected


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Fixes #3659

## SBS Impact
- Primary subsystem: Product/Runtime System — dev deployment boundary.
- Secondary subsystem(s): Builder System — merged-Compose regression contract.
- Write class: deploy/environment configuration and regression test.
- Authority impact: deploy/environment bindings remain the authority; product code is untouched.
- Persistence impact: none.
- Derived/rebuildable impact: dev database/runtime artifacts remain rebuildable.
- Human knowledge impact: none.
- Memory impact: none.
- Retrieval/context impact: none.
- Sync/deployment impact: dev migration and long-lived services receive consistent `app_dev` and operator-selected vault bindings.
- External boundary impact: dev Compose environment and configured host mounts only.
- New or changed contract: merged dev Compose binds migrate to `app_dev`; API/worker/watcher forward the deploy-provided vault bindings.
- Owner-doc impact: none; this restores the documented current environment model.
- Transition debt impact: reduces dev-channel drift.
- Fitness rule impact: strengthened by `tests/deploy/test_dev_channel_compose.py`.
- Boundary risk: dev only; no image publication and no test/prod/stable mutation.

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Bind the one-shot dev migration service to the in-container `app_dev` DSNs.
- Forward the deploy-provided vault variables to API, worker, and watcher.
- Guard the merged Compose contract with focused regression tests.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] All Acceptance Criteria are satisfied, including actual dev runtime verification.
- [x] Docs were reviewed; no current-state owner-doc claim changed.
- [x] No tracked backlog item is represented as shipped before merge.

## Validation
- [x] `pytest -q tests/deploy/test_dev_channel_compose.py tests/deploy/test_dev_llm_provider_compose.py tests/ops/test_compose_override.py tests/ops/test_heimdal_capture_watch_compose.py` — 12 passed.
- [x] `ruff check app tests` — passed.
- [x] `mypy app` — 745 source files passed.
- [x] Actual dev deploy/UAT with image `b0a814e7d1a70c2c009ab1d2780f81d84715f6bf`: browser smoke passed, `/readyz` returned running/empty, required API health was true, migrate exited 0 on `app_dev`, and Niflheim/capture/key probes passed without exposing sensitive values.
- [x] UAT-tested SHA `875a4b5ac6a4c93ef7eecb2a7e4cf3f691659432` and current head `895eae0d` contain identical blobs for both PR files; intervening main changes are docs, the dev image pin, and CI selector repair.
- [ ] Full non-PG local run was invalidated by host `ENOSPC` after 4,952 passes; current-head GitHub CI is the authoritative broad-suite gate.

## BuilderOps Routing
- Records/projections/receipts: `runtime/builderops/epic-runs/settings-3156-dev-compose-20260716.json`, `lrn_20260715223214_54c04175`, `lrn_20260715224559_c6521767`.
- Reason: the epic run state tracks the serial dependency/CI chain; learning signals record two corrected shell-probe evidence hazards encountered during actual runtime verification.

## Notes
- The configured Niflheim vault currently contains no `@Settings/*.md`; health therefore truthfully reports `no_vault/defaults`. The already-merged #3159 runtime receipt covers the same delivered Settings line through valid, invalid/last-valid, and restored settings states.
- No temporary settings were written during this UAT. No capture content was read, moved, deleted, or archived.
- No image was published and no test/prod/stable channel was changed.
