### PR TITLE
fix(dev): contain malformed panel UUID worker events

### DIFF
--- a/app/workers/outbox_worker.py
+++ b/app/workers/outbox_worker.py
@@ -97,6 +97,7 @@ _PANEL_LATENCY_SUMMARY_DEDUP = EventDedupStore()
 
 # Dead-letter reason for a dispatch-time schema violation (KERNEL-08, #2770).
 SCHEMA_VIOLATION_REASON = "schema_violation"
+INVALID_NOTE_UUID_REASON = "invalid_note_uuid"
 
 
 class SchemaViolationDispatchError(RuntimeError):
@@ -113,6 +114,19 @@ class SchemaViolationDispatchError(RuntimeError):
     def __init__(self, violation: TopicSchemaViolation) -> None:
         super().__init__(str(violation))
         self.violation = violation
+
+
+class InvalidPanelNoteUUIDDispatchError(ValueError):
+    """A stored panel-note UUID is malformed and cannot be dispatched safely.
+
+    This is deliberately distinct from a transient handler error. The source note
+    and its queued event are durable evidence, but retrying the same immutable
+    malformed UUID only crash-loops the worker. The consume loop dead-letters
+    this one row immediately and continues with later events.
+    """
+
+    def __init__(self, value: str) -> None:
+        super().__init__(f"invalid panel note uuid: {value}")
 
 
 def _resolve_instance_id() -> str:
@@ -331,6 +345,23 @@ def run_once(
     event_id = _event_id_from_message(message)
     try:
         _dispatch_topic(topic, payload, trace_id=trace_id, message=message, event_id=event_id)
+    except InvalidPanelNoteUUIDDispatchError as uuid_exc:
+        logger.warning(
+            "worker dead-lettered malformed panel note uuid topic=%s id=%s",
+            topic,
+            message.get("id"),
+        )
+        _dead_letter_outbox_message(
+            topic,
+            payload,
+            message_id=str(message.get("id") or ""),
+            reason=INVALID_NOTE_UUID_REASON,
+            attempts=0,
+            trace_id=None if trace_id == "-" else trace_id,
+            error=str(uuid_exc),
+        )
+        ack_outbox(message["id"])
+        return WorkerTickResult(state="processed", processed=1)
     except SchemaViolationDispatchError as schema_exc:
         # Immediate dead-letter (KERNEL-08, #2770): see the matching branch in
         # run()'s consume loop for the invariant (never transient, no retry budget).
@@ -1254,6 +1285,11 @@ def handle_panel_scan_requested(
         logger.info("panel scan skipped (missing uuid) note_path=%s", note_path)
         return WorkerPanelSummary(emitted=0, deferred=True)
 
+    try:
+        UUID(note_uuid)
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise InvalidPanelNoteUUIDDispatchError(note_uuid) from exc
+
     refresh_panel_note_object(
         note_uuid=note_uuid,
         note_path=note_path,
@@ -1641,6 +1677,24 @@ def run(
                             message=message,
                             event_id=event_id,
                         )
+                    except InvalidPanelNoteUUIDDispatchError as uuid_exc:
+                        errors_total += 1
+                        logger.warning(
+                            "worker dead-lettered malformed panel note uuid topic=%s id=%s",
+                            topic,
+                            message.get("id"),
+                        )
+                        _dead_letter_outbox_message(
+                            topic,
+                            payload,
+                            message_id=str(message.get("id") or ""),
+                            reason=INVALID_NOTE_UUID_REASON,
+                            attempts=0,
+                            trace_id=None if trace_id == "-" else trace_id,
+                            error=str(uuid_exc),
+                        )
+                        ack_outbox(message["id"])
+                        continue
                     except SchemaViolationDispatchError as schema_exc:
                         # Immediate dead-letter (KERNEL-08, #2770): a registered-schema
                         # violation is never transient and never worth a retry budget —

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -331,6 +331,25 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
         ("tests/events", "tests/receipts", "tests/contracts"),
     ),
     (
+        # The outbox worker is the production consumer for event delivery, but
+        # it sits outside app/events/. Keep its poison-row and heartbeat
+        # regressions owned so CI runs them rather than fail-closing as
+        # unowned before pytest starts.
+        "outbox_worker",
+        (
+            "app/workers/outbox_worker.py",
+            "tests/workers/",
+            "tests/worker/",
+            "tests/services/test_outbox_idempotency.py",
+        ),
+        (
+            "tests/workers",
+            "tests/worker",
+            "tests/services/test_outbox_idempotency.py",
+            "tests/events",
+        ),
+    ),
+    (
         "heimdal_mimer",
         (
             "app/heimdal/",

--- a/tests/scripts/test_select_pr_tests.py
+++ b/tests/scripts/test_select_pr_tests.py
@@ -240,6 +240,22 @@ def test_store_ingest_change_selects_its_owned_contract_tests() -> None:
     assert "tests/architecture" in selection.targets
 
 
+def test_outbox_worker_change_selects_worker_regressions() -> None:
+    """Outbox-worker changes must reach pytest, not fail as unowned in CI."""
+    selection = select_tests(
+        ["app/workers/outbox_worker.py", "tests/workers/test_outbox_worker.py"]
+    )
+
+    assert selection.full_suite is False
+    assert selection.subsystems == ("outbox_worker",)
+    assert selection.unowned_paths == ()
+    assert "tests/workers" in selection.targets
+    assert "tests/worker" in selection.targets
+    assert "tests/services/test_outbox_idempotency.py" in selection.targets
+    assert "tests/events" in selection.targets
+    assert "tests/workers/test_outbox_worker.py" in selection.targets
+
+
 def test_heimdal_capture_adapter_change_has_a_ci_owner() -> None:
     selection = select_tests(["app/heimdal/capture_adapter.py", "tests/heimdal/test_capture_adapter.py"])
 

--- a/tests/workers/test_outbox_worker.py
+++ b/tests/workers/test_outbox_worker.py
@@ -18,6 +18,7 @@ These tests lock in two guarantees for #2407:
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -257,6 +258,72 @@ def test_schema_violation_dead_letters_at_dispatch(monkeypatch: pytest.MonkeyPat
     assert dead_letters[0]["reason"] == "schema_violation"
     assert dead_letters[0]["message_id"] == "row-schema-violation"
     assert acked == ["row-schema-violation"]
+
+
+def test_run_dead_letters_malformed_panel_note_uuid_without_worker_exit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A malformed stored panel UUID is poison for one row, not the worker.
+
+    Exercise the production ``run()`` consume path rather than the UUID helper
+    in isolation: the worker must keep running long enough to write a heartbeat
+    after it has recorded and acknowledged the malformed event.
+    """
+    vault = tmp_path / "selected-vault"
+    note = vault / "Inbox" / "malformed-panel.md"
+    note.parent.mkdir(parents=True)
+    source = "---\ntitle: Broken panel\nuuid: not-a-uuid\n---\n\n- [ ] Keep this source unchanged\n"
+    note.write_text(source, encoding="utf-8")
+    monkeypatch.setenv("VAULT_ROOT", str(vault))
+    monkeypatch.delenv("WATCHER_VAULT_PATH", raising=False)
+    audit_path = tmp_path / "audit.jsonl"
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(audit_path))
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_DSN", raising=False)
+
+    message = {
+        "id": "row-panel-bad-uuid",
+        "topic": outbox_worker.PANEL_SCAN_REQUESTED,
+        "payload": {
+            "vault_path": str(note),
+            "relative_path": "Inbox/malformed-panel.md",
+            "trace_id": "trace-panel-bad-uuid",
+        },
+    }
+    polled = False
+
+    def poll_once():
+        nonlocal polled
+        if polled:
+            return None
+        polled = True
+        return message
+
+    monkeypatch.setattr(outbox_worker, "poll_outbox_one", poll_once)
+    monkeypatch.setattr(outbox_worker, "bootstrap", lambda: None)
+    monkeypatch.setenv("WORKER_HEARTBEAT_INTERVAL", "0")
+
+    acked: list[str] = []
+    monkeypatch.setattr(outbox_worker, "ack_outbox", lambda mid: acked.append(str(mid)))
+    heartbeats: list[dict[str, object]] = []
+    monkeypatch.setattr(outbox_worker, "write_worker_heartbeat", lambda **kwargs: heartbeats.append(kwargs))
+
+    outbox_worker.run(interval=0.0, heartbeat_interval=0, log_heartbeat_interval=None, stop_after_ticks=2)
+
+    assert acked == ["row-panel-bad-uuid"]
+    receipt = json.loads(audit_path.read_text(encoding="utf-8"))
+    assert receipt["event"] == outbox_worker.OUTBOX_EVENT_DEAD_LETTERED
+    assert receipt["payload"] == {
+        "original_topic": outbox_worker.PANEL_SCAN_REQUESTED,
+        "original_event_id": "",
+        "outbox_id": "row-panel-bad-uuid",
+        "reason": "invalid_note_uuid",
+        "attempts": 0,
+        "error": "invalid panel note uuid: not-a-uuid",
+    }
+    assert heartbeats and heartbeats[-1]["processed_total"] == 1
+    assert note.read_text(encoding="utf-8") == source
 
 
 def test_schema_violation_on_grandfathered_row_is_log_only_never_dead_lettered(


### PR DESCRIPTION
Fixes #3665

## Summary

- Classify malformed stored UUIDs in `panel.scan.requested` as event-local permanent failures before the object-store/panel path.
- Immediately preserve the existing `outbox.event.dead_lettered` audit receipt and acknowledge the poison row, so the worker continues to heartbeat instead of crash-looping.
- Add production-loop regression coverage for receipt fields, ack, continued heartbeat, and byte-unchanged source note.
- Give the outbox-worker surface a CI test-selector owner so its regression reaches pytest instead of failing pre-pytest as unowned.

## Validation

- `pytest -q tests/workers/test_outbox_worker.py tests/workers/test_outbox_worker_consumes_ingest.py tests/worker/test_embedding_request_poison.py` — 17 passed.
- `ruff check app tests` — passed.
- `mypy app` — passed.
- `git diff --check` — passed.
- `pytest -q tests/scripts/test_select_pr_tests.py::test_outbox_worker_change_selects_worker_regressions` — passed.
- `python scripts/select_pr_tests.py --changed-file app/workers/outbox_worker.py --changed-file tests/workers/test_outbox_worker.py` — selects `outbox_worker` with worker, outbox-idempotency, and event contract coverage; exit 0.
- `pytest -q -m "not pg"` was started locally, but the workspace runner cut the run before an exit receipt; CI is the authoritative pending full-suite evidence.

## Remaining gate / draft reason

The issue's runtime AC remains intentionally pending: after this branch is integrated, isolated dev UAT must process the existing malformed `app_dev` row and record a fresh worker heartbeat plus `/api/health.required_ok=true` on #3159 and #3517. This PR does not edit or delete any dev outbox data.

## BuilderOps Routing

- Records/projections/receipts: `runtime/builderops/epic-runs/settings-3156-dev-uat-20260714.json`; `lrn_20260714122432_fe966fb6`; #3665 receipt `4969471991`.
- Reason: no new BuilderOps record; the delivery divergence and parent-receipt route are already represented by #3665 and the Settings Spine epic run.

---