### PR TITLE
Add cited CKM gap and missing-evidence detection

### DIFF
--- a/app/builderops/ckm/assess.py
+++ b/app/builderops/ckm/assess.py
@@ -339,7 +339,7 @@ def compute_aggregate(scores: Mapping[str, float]) -> float:
     )
 
 
-def _fingerprint(
+def assessment_fingerprint(
     edges: Sequence[CkmEvidenceEdge],
     artifacts: Mapping[str, CkmArtifact],
 ) -> str:
@@ -409,7 +409,7 @@ def assess_capabilities(store: CkmStore) -> AssessmentRunResult:
     skipped = 0
     for capability in store.list_capabilities():
         edges = store.list_evidence_edges_for_capability(capability.id)
-        fingerprint = _fingerprint(edges, artifacts)
+        fingerprint = assessment_fingerprint(edges, artifacts)
         latest = store.latest_assessment_for_capability(capability.id)
         if latest is not None and latest.edge_fingerprint == fingerprint:
             skipped += 1

--- a/app/builderops/ckm/gaps.py
+++ b/app/builderops/ckm/gaps.py
@@ -1,0 +1,374 @@
+"""Deterministic, cited CKM gap and missing-evidence detection."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from app.builderops.ckm.assess import assessment_fingerprint
+from app.builderops.ckm.models import (
+    MATURITY_DIMENSIONS,
+    CkmArtifact,
+    CkmAssessment,
+    CkmCapability,
+    CkmEvidenceEdge,
+    CkmValidationError,
+)
+from app.builderops.ckm.store import CkmStore
+
+
+_DELIVERED_STATE = re.compile(r"\b(delivered|implemented|shipped|live|baseline)\b", re.I)
+_NON_CURRENT_STATE = re.compile(
+    r"\b(not implemented|not yet|planned|target[- ]state|draft|candidate|historical|superseded|advisory)\b",
+    re.I,
+)
+
+
+@dataclass(frozen=True)
+class GapDetectionConfig:
+    floor: float = 0.5
+    healthy_floor: float = 0.75
+    healthy_sibling_count: int = 2
+
+    def validate(self) -> "GapDetectionConfig":
+        if not 0.0 <= self.floor <= 1.0:
+            raise CkmValidationError("gap floor must be between 0 and 1")
+        if not 0.0 <= self.healthy_floor <= 1.0:
+            raise CkmValidationError("healthy sibling floor must be between 0 and 1")
+        if self.healthy_sibling_count < 1:
+            raise CkmValidationError("healthy sibling count must be positive")
+        return self
+
+
+@dataclass(frozen=True)
+class GapDetectionResult:
+    findings: int
+    starved_dimensions: int
+    uncovered_boundaries: int
+    claim_exceeds_evidence: int
+
+
+def _artifact_payload(artifact: CkmArtifact) -> Mapping[str, object]:
+    try:
+        value = json.loads(artifact.provenance)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _artifact_citation(artifact: CkmArtifact, *, role: str) -> dict[str, object]:
+    return {
+        "role": role,
+        "artifact_id": artifact.id,
+        "source_ref": artifact.source_ref,
+        "artifact": artifact.to_dict(),
+    }
+
+
+def _edge_citation(
+    edge: CkmEvidenceEdge,
+    artifact: CkmArtifact,
+    *,
+    role: str,
+) -> dict[str, object]:
+    return {
+        "role": role,
+        "edge_id": edge.id,
+        "artifact_id": artifact.id,
+        "source_ref": edge.source_ref,
+        "edge": edge.to_dict(),
+        "artifact": artifact.to_dict(),
+    }
+
+
+def _dedupe_citations(citations: Sequence[Mapping[str, object]]) -> list[dict[str, object]]:
+    result: list[dict[str, object]] = []
+    seen: set[str] = set()
+    for citation in citations:
+        normalized = dict(citation)
+        key = json.dumps(normalized, sort_keys=True, separators=(",", ":"))
+        if key not in seen:
+            seen.add(key)
+            result.append(normalized)
+    return result
+
+
+def _state_claim(artifact: CkmArtifact) -> str | None:
+    summary = str(_artifact_payload(artifact).get("payload_summary", ""))
+    match = re.search(r"state:\s*(.+)$", summary, flags=re.I)
+    if match is None:
+        return None
+    state = match.group(1).strip()
+    if _NON_CURRENT_STATE.search(state) or not _DELIVERED_STATE.search(state):
+        return None
+    return state
+
+
+def _seed_source_ref(capability: CkmCapability) -> str | None:
+    marker = "seeded:"
+    if not capability.existence_provenance.startswith(marker):
+        return None
+    source = capability.existence_provenance[len(marker) :].split("::", 1)[0].strip()
+    return source or None
+
+
+def _is_merged_pr(edge: CkmEvidenceEdge, artifact: CkmArtifact) -> bool:
+    return (
+        edge.evidence_kind == "pull_request"
+        and artifact.artifact_kind == "pull_request"
+        and bool(_artifact_payload(artifact).get("merged_at"))
+    )
+
+
+def _validate_assessment_snapshot(
+    store: CkmStore,
+    capabilities: Sequence[CkmCapability],
+    artifacts: Mapping[str, CkmArtifact],
+    edges_by_capability: Mapping[str, list[CkmEvidenceEdge]],
+) -> dict[str, CkmAssessment]:
+    current_watermarks = store.current_watermark_set()
+    if not current_watermarks:
+        raise CkmValidationError("cannot detect gaps before ingestion records a watermark")
+    latest: dict[str, CkmAssessment] = {}
+    for capability in capabilities:
+        if capability.lifecycle != "confirmed" or _seed_source_ref(capability) is None:
+            continue
+        assessment = store.latest_assessment_for_capability(capability.id)
+        if assessment is None:
+            raise CkmValidationError(
+                f"cannot detect gaps before assessing seeded capability: {capability.name}"
+            )
+        if dict(assessment.watermark_set) != current_watermarks:
+            raise CkmValidationError(
+                f"assessment is stale relative to evidence for capability: {capability.name}"
+            )
+        current_fingerprint = assessment_fingerprint(
+            edges_by_capability.get(capability.id, []), artifacts
+        )
+        if assessment.edge_fingerprint != current_fingerprint:
+            raise CkmValidationError(
+                f"assessment does not match current evidence for capability: {capability.name}"
+            )
+        latest[capability.id] = assessment
+    return latest
+
+
+def detect_gaps(
+    store: CkmStore,
+    *,
+    config: GapDetectionConfig | None = None,
+) -> GapDetectionResult:
+    """Replace current findings from one coherent assessment/evidence snapshot."""
+
+    resolved = (config or GapDetectionConfig()).validate()
+    store.ensure_schema()
+    capabilities = store.list_capabilities()
+    artifacts = {artifact.id: artifact for artifact in store.list_artifacts()}
+    artifacts_by_ref = {artifact.source_ref: artifact for artifact in artifacts.values()}
+    edges = store.list_evidence_edges()
+    edges_by_capability: dict[str, list[CkmEvidenceEdge]] = {}
+    for edge in edges:
+        edges_by_capability.setdefault(edge.capability_id, []).append(edge)
+    assessments = _validate_assessment_snapshot(
+        store, capabilities, artifacts, edges_by_capability
+    )
+    findings: dict[tuple[str, str, str], dict[str, Any]] = {}
+
+    # Starved dimensions compare one weak score with a genuinely healthy sibling set.
+    for capability in capabilities:
+        assessment = assessments.get(capability.id)
+        if assessment is None:
+            continue
+        scores = assessment.scores
+        for dimension in MATURITY_DIMENSIONS:
+            score = float(scores[dimension])
+            if score >= resolved.floor:
+                continue
+            healthy = sorted(
+                (
+                    sibling
+                    for sibling in MATURITY_DIMENSIONS
+                    if sibling != dimension
+                    and float(scores[sibling]) >= resolved.healthy_floor
+                ),
+                key=lambda sibling: (-float(scores[sibling]), sibling),
+            )
+            if len(healthy) < resolved.healthy_sibling_count:
+                continue
+            strongest = healthy[0]
+            evidence = list(assessment.citations[dimension])
+            if not evidence:
+                evidence = list(assessment.citations[strongest])
+            if not evidence:
+                raise CkmValidationError(
+                    f"healthy assessment lacks cited evidence for capability: {capability.name}"
+                )
+            citations = _dedupe_citations(
+                [
+                    *evidence,
+                    {
+                        "role": "assessment",
+                        "detector": "starved_dimension",
+                        "assessment_id": assessment.id,
+                        "formula_id": assessment.formula_ids[dimension],
+                        "watermark_set": dict(assessment.watermark_set),
+                    },
+                ]
+            )
+            statement = (
+                f"{capability.name}: {dimension.replace('_', ' ')} is {score:.2f}, below "
+                f"the {resolved.floor:.2f} floor, while {strongest.replace('_', ' ')} is "
+                f"{float(scores[strongest]):.2f}; "
+                f"{len(assessment.citations[dimension])} cited evidence item(s) support the weak dimension."
+            )
+            findings[("gap", capability.id, dimension)] = {
+                "kind": "gap",
+                "capability_id": capability.id,
+                "dimension": dimension,
+                "statement": statement,
+                "citations": citations,
+                "detector": "starved_dimension",
+            }
+
+    # Boundary coverage is aggregated across the seeded boundary and all mapped capabilities.
+    boundary_groups: dict[str, list[CkmCapability]] = {}
+    for capability in capabilities:
+        if (
+            capability.lifecycle == "confirmed"
+            and capability.boundary_ref
+            and _seed_source_ref(capability) is not None
+        ):
+            boundary_groups.setdefault(capability.boundary_ref, []).append(capability)
+    for boundary_ref, members in sorted(boundary_groups.items()):
+        member_ids = {member.id for member in members}
+        covered = False
+        for member in members:
+            for edge in edges_by_capability.get(member.id, []):
+                artifact = artifacts[edge.artifact_id]
+                if edge.lifecycle != "confirmed" or edge.polarity != "supports":
+                    continue
+                if edge.evidence_kind == "source" or _is_merged_pr(edge, artifact):
+                    covered = True
+                    break
+            if covered:
+                break
+        if covered:
+            continue
+        anchor = next(
+            (member for member in members if member.id in {item.parent_id for item in members}),
+            min(members, key=lambda item: item.name),
+        )
+        source_ref = _seed_source_ref(anchor)
+        seed_artifact = artifacts_by_ref.get(source_ref or "")
+        if seed_artifact is None:
+            raise CkmValidationError(
+                f"seed source artifact is missing for uncovered boundary: {boundary_ref}"
+            )
+        key = ("gap", anchor.id, "functional_completeness")
+        prior = findings.get(key)
+        citations = [_artifact_citation(seed_artifact, role="seed_artifact")]
+        if prior is not None:
+            citations.extend(prior["citations"])
+        citations.append(
+            {
+                "role": "assessment",
+                "detector": "uncovered_boundary",
+                "boundary_ref": boundary_ref,
+                "mapped_capability_ids": sorted(member_ids),
+            }
+        )
+        findings[key] = {
+            "kind": "gap",
+            "capability_id": anchor.id,
+            "dimension": "functional_completeness",
+            "statement": (
+                f"{anchor.name}: functional completeness has an uncovered {boundary_ref} boundary; "
+                f"{len(members)} mapped capability/capabilities have zero confirmed source or merged-PR evidence."
+            ),
+            "citations": _dedupe_citations(citations),
+            "detector": "uncovered_boundary",
+        }
+
+    # Delivered-state claims are grouped per capability and missing evidence class.
+    claim_groups: dict[tuple[str, str], list[tuple[CkmArtifact, CkmEvidenceEdge, str]]] = {}
+    for edge in edges:
+        artifact = artifacts[edge.artifact_id]
+        if (
+            edge.lifecycle != "confirmed"
+            or edge.polarity != "supports"
+            or artifact.artifact_kind not in {"document", "spec"}
+        ):
+            continue
+        claim = _state_claim(artifact)
+        assessment = assessments.get(edge.capability_id)
+        if claim is None or assessment is None:
+            continue
+        for dimension in ("functional_completeness", "test_completeness"):
+            if float(assessment.scores[dimension]) < resolved.floor:
+                claim_groups.setdefault((edge.capability_id, dimension), []).append(
+                    (artifact, edge, claim)
+                )
+    capability_by_id = {capability.id: capability for capability in capabilities}
+    missing_kinds = {
+        "functional_completeness": ["pull_request", "source"],
+        "test_completeness": ["benchmark", "ci_result", "coverage", "test"],
+    }
+    for (capability_id, dimension), claims in sorted(claim_groups.items()):
+        capability = capability_by_id[capability_id]
+        assessment = assessments[capability_id]
+        evidence_kinds = missing_kinds[dimension]
+        observed = sum(
+            1
+            for edge in edges_by_capability.get(capability_id, [])
+            if edge.lifecycle == "confirmed"
+            and edge.polarity == "supports"
+            and edge.evidence_kind in evidence_kinds
+        )
+        unique_claims = {
+            (artifact.id, edge.id): (artifact, edge, claim)
+            for artifact, edge, claim in claims
+        }
+        citations = [
+            _edge_citation(edge, artifact, role="claiming_artifact")
+            for artifact, edge, _claim in sorted(
+                unique_claims.values(), key=lambda item: (item[0].source_ref, item[1].id)
+            )
+        ]
+        citations.append(
+            {
+                "role": "missing_evidence_class",
+                "dimension": dimension,
+                "evidence_kinds": evidence_kinds,
+                "observed_edge_count": observed,
+            }
+        )
+        source_refs = sorted({artifact.source_ref for artifact, _edge, _claim in claims})
+        findings[("missing_evidence", capability_id, dimension)] = {
+            "kind": "missing_evidence",
+            "capability_id": capability_id,
+            "dimension": dimension,
+            "statement": (
+                f"{capability.name}: {', '.join(source_refs)} claims delivered/live/baseline state, "
+                f"but {dimension.replace('_', ' ')} is {float(assessment.scores[dimension]):.2f}; "
+                f"missing evidence class {', '.join(evidence_kinds)} has {observed} confirmed edge(s)."
+            ),
+            "citations": _dedupe_citations(citations),
+            "detector": "claim_exceeds_evidence",
+        }
+
+    ordered = [findings[key] for key in sorted(findings)]
+    persisted = store.replace_findings(
+        [
+            {field: finding[field] for field in ("kind", "capability_id", "dimension", "statement", "citations")}
+            for finding in ordered
+        ]
+    )
+    detectors = [finding["detector"] for finding in ordered]
+    return GapDetectionResult(
+        findings=len(persisted),
+        starved_dimensions=detectors.count("starved_dimension"),
+        uncovered_boundaries=detectors.count("uncovered_boundary"),
+        claim_exceeds_evidence=detectors.count("claim_exceeds_evidence"),
+    )

--- a/app/builderops/ckm/gaps.py
+++ b/app/builderops/ckm/gaps.py
@@ -21,7 +21,9 @@ from app.builderops.ckm.store import CkmStore
 
 _DELIVERED_STATE = re.compile(r"\b(delivered|implemented|shipped|live|baseline)\b", re.I)
 _NON_CURRENT_STATE = re.compile(
-    r"\b(not implemented|not yet|planned|target[- ]state|draft|candidate|historical|superseded|advisory)\b",
+    r"\b(?:future|planned|target(?:[- ]state)?|draft|candidate|historical|superseded|advisory|not yet|unimplemented)\b"
+    r"|\b(?:does\s+not|doesn't|not|no|never|without)\s+(?:\w+\s+){0,3}"
+    r"(?:delivered|implemented|shipped|live|baseline)\b",
     re.I,
 )
 
@@ -48,6 +50,7 @@ class GapDetectionResult:
     starved_dimensions: int
     uncovered_boundaries: int
     claim_exceeds_evidence: int
+    stale_assessments: int = 0
 
 
 def _artifact_payload(artifact: CkmArtifact) -> Mapping[str, object]:
@@ -122,16 +125,29 @@ def _is_merged_pr(edge: CkmEvidenceEdge, artifact: CkmArtifact) -> bool:
     )
 
 
+def _counts_as_missing_class_evidence(
+    edge: CkmEvidenceEdge,
+    artifact: CkmArtifact,
+    dimension: str,
+) -> bool:
+    if edge.lifecycle != "confirmed" or edge.polarity != "supports":
+        return False
+    if dimension == "functional_completeness":
+        return edge.evidence_kind == "source" or _is_merged_pr(edge, artifact)
+    return edge.evidence_kind in {"benchmark", "ci_result", "coverage", "test"}
+
+
 def _validate_assessment_snapshot(
     store: CkmStore,
     capabilities: Sequence[CkmCapability],
     artifacts: Mapping[str, CkmArtifact],
     edges_by_capability: Mapping[str, list[CkmEvidenceEdge]],
-) -> dict[str, CkmAssessment]:
+) -> tuple[dict[str, CkmAssessment], set[str], dict[str, str]]:
     current_watermarks = store.current_watermark_set()
     if not current_watermarks:
         raise CkmValidationError("cannot detect gaps before ingestion records a watermark")
     latest: dict[str, CkmAssessment] = {}
+    stale_assessments: set[str] = set()
     for capability in capabilities:
         if capability.lifecycle != "confirmed" or _seed_source_ref(capability) is None:
             continue
@@ -141,9 +157,7 @@ def _validate_assessment_snapshot(
                 f"cannot detect gaps before assessing seeded capability: {capability.name}"
             )
         if dict(assessment.watermark_set) != current_watermarks:
-            raise CkmValidationError(
-                f"assessment is stale relative to evidence for capability: {capability.name}"
-            )
+            stale_assessments.add(capability.id)
         current_fingerprint = assessment_fingerprint(
             edges_by_capability.get(capability.id, []), artifacts
         )
@@ -152,7 +166,26 @@ def _validate_assessment_snapshot(
                 f"assessment does not match current evidence for capability: {capability.name}"
             )
         latest[capability.id] = assessment
-    return latest
+    return latest, stale_assessments, current_watermarks
+
+
+def _assessment_citation(
+    assessment: CkmAssessment,
+    *,
+    detector: str,
+    stale: bool,
+    current_watermarks: Mapping[str, str],
+    **details: object,
+) -> dict[str, object]:
+    return {
+        "role": "assessment",
+        "detector": detector,
+        "assessment_id": assessment.id,
+        "assessment_watermark_set": dict(assessment.watermark_set),
+        "current_watermark_set": dict(current_watermarks),
+        "stale_relative_to_global_evidence": stale,
+        **details,
+    }
 
 
 def detect_gaps(
@@ -171,7 +204,7 @@ def detect_gaps(
     edges_by_capability: dict[str, list[CkmEvidenceEdge]] = {}
     for edge in edges:
         edges_by_capability.setdefault(edge.capability_id, []).append(edge)
-    assessments = _validate_assessment_snapshot(
+    assessments, stale_assessments, current_watermarks = _validate_assessment_snapshot(
         store, capabilities, artifacts, edges_by_capability
     )
     findings: dict[tuple[str, str, str], dict[str, Any]] = {}
@@ -208,13 +241,13 @@ def detect_gaps(
             citations = _dedupe_citations(
                 [
                     *evidence,
-                    {
-                        "role": "assessment",
-                        "detector": "starved_dimension",
-                        "assessment_id": assessment.id,
-                        "formula_id": assessment.formula_ids[dimension],
-                        "watermark_set": dict(assessment.watermark_set),
-                    },
+                    _assessment_citation(
+                        assessment,
+                        detector="starved_dimension",
+                        stale=capability.id in stale_assessments,
+                        current_watermarks=current_watermarks,
+                        formula_id=assessment.formula_ids[dimension],
+                    ),
                 ]
             )
             statement = (
@@ -271,13 +304,16 @@ def detect_gaps(
         citations = [_artifact_citation(seed_artifact, role="seed_artifact")]
         if prior is not None:
             citations.extend(prior["citations"])
+        anchor_assessment = assessments[anchor.id]
         citations.append(
-            {
-                "role": "assessment",
-                "detector": "uncovered_boundary",
-                "boundary_ref": boundary_ref,
-                "mapped_capability_ids": sorted(member_ids),
-            }
+            _assessment_citation(
+                anchor_assessment,
+                detector="uncovered_boundary",
+                stale=anchor.id in stale_assessments,
+                current_watermarks=current_watermarks,
+                boundary_ref=boundary_ref,
+                mapped_capability_ids=sorted(member_ids),
+            )
         )
         findings[key] = {
             "kind": "gap",
@@ -322,9 +358,9 @@ def detect_gaps(
         observed = sum(
             1
             for edge in edges_by_capability.get(capability_id, [])
-            if edge.lifecycle == "confirmed"
-            and edge.polarity == "supports"
-            and edge.evidence_kind in evidence_kinds
+            if _counts_as_missing_class_evidence(
+                edge, artifacts[edge.artifact_id], dimension
+            )
         )
         unique_claims = {
             (artifact.id, edge.id): (artifact, edge, claim)
@@ -343,6 +379,15 @@ def detect_gaps(
                 "evidence_kinds": evidence_kinds,
                 "observed_edge_count": observed,
             }
+        )
+        citations.append(
+            _assessment_citation(
+                assessment,
+                detector="claim_exceeds_evidence",
+                stale=capability_id in stale_assessments,
+                current_watermarks=current_watermarks,
+                formula_id=assessment.formula_ids[dimension],
+            )
         )
         source_refs = sorted({artifact.source_ref for artifact, _edge, _claim in claims})
         findings[("missing_evidence", capability_id, dimension)] = {
@@ -371,4 +416,5 @@ def detect_gaps(
         starved_dimensions=detectors.count("starved_dimension"),
         uncovered_boundaries=detectors.count("uncovered_boundary"),
         claim_exceeds_evidence=detectors.count("claim_exceeds_evidence"),
+        stale_assessments=len(stale_assessments),
     )

--- a/app/builderops/ckm/models.py
+++ b/app/builderops/ckm/models.py
@@ -432,6 +432,28 @@ class CkmFinding:
         _require_nonempty_str(self.statement, "statement")
         if not self.citations:
             raise CkmValidationError("citations must not be empty")
+        has_evidence_snapshot = False
+        for citation in self.citations:
+            if not isinstance(citation, Mapping):
+                raise CkmValidationError("finding citations must be mappings")
+            edge_payload = citation.get("edge")
+            artifact_payload = citation.get("artifact")
+            if isinstance(edge_payload, Mapping):
+                edge = CkmEvidenceEdge.from_row(edge_payload).validate()
+                if citation.get("edge_id") not in {None, edge.id}:
+                    raise CkmValidationError("finding citation edge id does not match its snapshot")
+                has_evidence_snapshot = True
+            if isinstance(artifact_payload, Mapping):
+                artifact = CkmArtifact.from_row(artifact_payload).validate()
+                if citation.get("artifact_id") not in {None, artifact.id}:
+                    raise CkmValidationError(
+                        "finding citation artifact id does not match its snapshot"
+                    )
+                has_evidence_snapshot = True
+        if not has_evidence_snapshot:
+            raise CkmValidationError(
+                "finding citations must include an evidence edge or artifact snapshot"
+            )
         _require_nonempty_str(self.created_at, "created_at")
         _require_nonempty_str(self.updated_at, "updated_at")
         return self

--- a/app/builderops/ckm/store.py
+++ b/app/builderops/ckm/store.py
@@ -16,7 +16,7 @@ import json
 import secrets
 import sqlite3
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 from uuid import uuid4
 
 from app.builderops.config import BuilderOpsPaths, load_paths, validate_db_path_outside_vault
@@ -902,10 +902,17 @@ class CkmStore:
         statement: str,
         citations: list[JsonDict],
     ) -> CkmFinding:
-        if not citations:
-            raise CkmValidationError("citations must not be empty")
         now = utc_now()
-        candidate_id = new_id("find")
+        candidate = CkmFinding(
+            id=new_id("find"),
+            kind=kind,
+            capability_id=capability_id,
+            dimension=dimension,
+            statement=statement,
+            citations=citations,
+            created_at=now,
+            updated_at=now,
+        ).validate()
         with self._connect() as conn:
             conn.execute("BEGIN IMMEDIATE")
             conn.execute(
@@ -919,13 +926,102 @@ class CkmStore:
                     citations = excluded.citations,
                     updated_at = excluded.updated_at
                 """,
-                (candidate_id, kind, capability_id, dimension, statement, _dumps(citations), now, now),
+                (
+                    candidate.id,
+                    candidate.kind,
+                    candidate.capability_id,
+                    candidate.dimension,
+                    candidate.statement,
+                    _dumps(candidate.citations),
+                    candidate.created_at,
+                    candidate.updated_at,
+                ),
             )
             conn.commit()
         finding = self.get_finding(kind=kind, capability_id=capability_id, dimension=dimension)
         if finding is None:  # pragma: no cover - defensive
             raise CkmValidationError("finding upsert did not persist")
         return finding
+
+    def replace_findings(self, findings: Sequence[Mapping[str, Any]]) -> list[CkmFinding]:
+        """Atomically reconcile the disposable current finding projection."""
+
+        now = utc_now()
+        candidates: dict[tuple[str, str, str], CkmFinding] = {}
+        for raw in findings:
+            raw_citations = raw.get("citations", [])
+            if not isinstance(raw_citations, list):
+                raise CkmValidationError("finding citations must be a list")
+            candidate = CkmFinding(
+                id=new_id("find"),
+                kind=str(raw.get("kind", "")),
+                capability_id=str(raw.get("capability_id", "")),
+                dimension=str(raw.get("dimension", "")),
+                statement=str(raw.get("statement", "")),
+                citations=list(raw_citations),
+                created_at=now,
+                updated_at=now,
+            ).validate()
+            key = (candidate.kind, candidate.capability_id, candidate.dimension)
+            if key in candidates:
+                raise CkmValidationError(f"duplicate finding natural key: {key}")
+            candidates[key] = candidate
+
+        with self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            existing_rows = conn.execute("SELECT * FROM ckm_finding").fetchall()
+            existing = {
+                (row["kind"], row["capability_id"], row["dimension"]): row
+                for row in existing_rows
+            }
+            for kind, capability_id, dimension in set(existing) - set(candidates):
+                conn.execute(
+                    """
+                    DELETE FROM ckm_finding
+                    WHERE kind = ? AND capability_id = ? AND dimension = ?
+                    """,
+                    (kind, capability_id, dimension),
+                )
+            for key, candidate in sorted(candidates.items()):
+                row = existing.get(key)
+                citations_json = _dumps(candidate.citations)
+                if row is None:
+                    conn.execute(
+                        """
+                        INSERT INTO ckm_finding (
+                            id, kind, capability_id, dimension, statement,
+                            citations, created_at, updated_at
+                        ) VALUES (?,?,?,?,?,?,?,?)
+                        """,
+                        (
+                            candidate.id,
+                            candidate.kind,
+                            candidate.capability_id,
+                            candidate.dimension,
+                            candidate.statement,
+                            citations_json,
+                            candidate.created_at,
+                            candidate.updated_at,
+                        ),
+                    )
+                elif row["statement"] != candidate.statement or row["citations"] != citations_json:
+                    conn.execute(
+                        """
+                        UPDATE ckm_finding
+                        SET statement = ?, citations = ?, updated_at = ?
+                        WHERE kind = ? AND capability_id = ? AND dimension = ?
+                        """,
+                        (
+                            candidate.statement,
+                            citations_json,
+                            now,
+                            candidate.kind,
+                            candidate.capability_id,
+                            candidate.dimension,
+                        ),
+                    )
+            conn.commit()
+        return self.list_findings()
 
     def get_finding(self, *, kind: str, capability_id: str, dimension: str) -> CkmFinding | None:
         with self._connect() as conn:
@@ -945,5 +1041,15 @@ class CkmStore:
             rows = conn.execute(
                 "SELECT * FROM ckm_finding WHERE capability_id = ? ORDER BY created_at",
                 (capability_id,),
+            ).fetchall()
+        return [CkmFinding.from_row(row, citations=_loads(row["citations"])) for row in rows]
+
+    def list_findings(self) -> list[CkmFinding]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT * FROM ckm_finding
+                ORDER BY kind, capability_id, dimension
+                """
             ).fetchall()
         return [CkmFinding.from_row(row, citations=_loads(row["citations"])) for row in rows]

--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -25,8 +25,9 @@ from app.builderops.ckm_reevaluation import (
     CkmReevaluationError,
     build_ckm_reevaluation_report,
 )
-from app.builderops.ckm.models import CkmValidationError
+from app.builderops.ckm.models import MATURITY_DIMENSIONS, CkmValidationError
 from app.builderops.ckm.assess import assess_capabilities
+from app.builderops.ckm.gaps import GapDetectionConfig, detect_gaps
 from app.builderops.ckm.ingest_github import ingest_github
 from app.builderops.ckm.ingest_repo import ingest_repo
 from app.builderops.ckm.linkers import link_deterministic
@@ -493,6 +494,46 @@ def ckm_assess(ctx: click.Context) -> None:
     click.echo(
         f"assessed {result.assessed} capabilities "
         f"({result.skipped} unchanged, skipped)"
+    )
+
+
+@ckm.command("gaps", help="Regenerate cited CKM gap and missing-evidence findings.")
+@click.option("--floor", type=click.FloatRange(0.0, 1.0), default=0.5, show_default=True)
+@click.option(
+    "--healthy-floor",
+    type=click.FloatRange(0.0, 1.0),
+    default=0.75,
+    show_default=True,
+)
+@click.option(
+    "--healthy-sibling-count",
+    type=click.IntRange(1, len(MATURITY_DIMENSIONS) - 1),
+    default=2,
+    show_default=True,
+)
+@click.pass_context
+def ckm_gaps(
+    ctx: click.Context,
+    floor: float,
+    healthy_floor: float,
+    healthy_sibling_count: int,
+) -> None:
+    try:
+        result = detect_gaps(
+            _ckm_store(ctx),
+            config=GapDetectionConfig(
+                floor=floor,
+                healthy_floor=healthy_floor,
+                healthy_sibling_count=healthy_sibling_count,
+            ),
+        )
+    except (CkmValidationError, sqlite3.Error) as exc:
+        raise click.ClickException(f"ckm gap detection failed: {exc}") from exc
+    click.echo(
+        f"{result.findings} findings: "
+        f"{result.starved_dimensions} starved-dimension, "
+        f"{result.uncovered_boundaries} uncovered-boundary, "
+        f"{result.claim_exceeds_evidence} claim-exceeds-evidence"
     )
 
 

--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -535,6 +535,12 @@ def ckm_gaps(
         f"{result.uncovered_boundaries} uncovered-boundary, "
         f"{result.claim_exceeds_evidence} claim-exceeds-evidence"
     )
+    if result.stale_assessments:
+        click.echo(
+            f"warning: {result.stale_assessments} assessment(s) are stale relative to the "
+            "global evidence watermark but remain current for their unchanged evidence fingerprint",
+            err=True,
+        )
 
 
 @builderops.group("inquiry", help="Persist and inspect pre-ticket model inquiry artifacts.")

--- a/tests/builderops/ckm/test_gap_detection.py
+++ b/tests/builderops/ckm/test_gap_detection.py
@@ -7,7 +7,7 @@ import pytest
 from click.testing import CliRunner
 
 from app.builderops.cli import builderops
-from app.builderops.ckm.assess import assessment_fingerprint
+from app.builderops.ckm.assess import assess_capabilities, assessment_fingerprint
 from app.builderops.ckm.gaps import GapDetectionConfig, detect_gaps
 from app.builderops.ckm.models import MATURITY_DIMENSIONS, CkmValidationError
 from app.builderops.ckm.store import CkmStore
@@ -455,3 +455,104 @@ def test_stale_assessment_leaves_existing_findings_untouched(store: CkmStore) ->
         detect_gaps(store)
 
     assert [finding.to_dict() for finding in store.list_findings()] == before
+
+
+@pytest.mark.parametrize(
+    "state",
+    (
+        "not live",
+        "not shipped",
+        "future baseline target",
+        "does not claim shipped runtime behavior",
+    ),
+)
+def test_negative_or_future_state_does_not_claim_delivery(
+    store: CkmStore,
+    state: str,
+) -> None:
+    capability = _capability(store, "Explicit non-claim")
+    artifact, edge = _edge(
+        store,
+        capability.id,
+        source_ref="docs/NON_CLAIM.md",
+        artifact_kind="document",
+        evidence_kind="doc",
+        dimension="documentation_quality",
+        payload_summary=f"Explicit non-claim — State: {state}",
+    )
+    citations = {dimension: [] for dimension in MATURITY_DIMENSIONS}
+    citations["documentation_quality"] = [_citation(artifact, edge)]
+    _assessment(
+        store,
+        capability.id,
+        _score_map(0.1),
+        citations,
+        asserted_at="2026-07-14T11:04:00Z",
+    )
+
+    result = detect_gaps(store)
+
+    assert result.claim_exceeds_evidence == 0
+
+
+def test_open_pr_does_not_satisfy_missing_functional_evidence(store: CkmStore) -> None:
+    capability = _capability(store, "Open PR claim")
+    claim_artifact, claim_edge = _edge(
+        store,
+        capability.id,
+        source_ref="docs/OPEN_PR_CLAIM.md",
+        artifact_kind="document",
+        evidence_kind="doc",
+        dimension="documentation_quality",
+        payload_summary="Open PR claim — State: delivered",
+    )
+    _edge(
+        store,
+        capability.id,
+        source_ref="github:pull_request:9999",
+        artifact_kind="pull_request",
+        evidence_kind="pull_request",
+        dimension="functional_completeness",
+        payload_summary="Open PR",
+    )
+    citations = {dimension: [] for dimension in MATURITY_DIMENSIONS}
+    citations["documentation_quality"] = [_citation(claim_artifact, claim_edge)]
+    _assessment(
+        store,
+        capability.id,
+        _score_map(0.1, functional_completeness=0.2, test_completeness=0.9),
+        citations,
+        asserted_at="2026-07-14T11:05:00Z",
+    )
+
+    detect_gaps(store)
+    tension = next(finding for finding in store.list_findings() if finding.kind == "missing_evidence")
+    missing_class = next(
+        citation
+        for citation in tension.citations
+        if citation.get("role") == "missing_evidence_class"
+    )
+
+    assert missing_class["observed_edge_count"] == 0
+
+
+def test_watermark_only_lag_is_recoverable_and_explicit(store: CkmStore) -> None:
+    _three_family_fixture(store)
+    first = detect_gaps(store)
+    store.set_watermark("fixture", "two")
+
+    assessment_run = assess_capabilities(store)
+    second = detect_gaps(store)
+
+    assert assessment_run.assessed == 0
+    assert assessment_run.skipped == 3
+    assert first.findings == second.findings == 3
+    assert second.stale_assessments == 3
+    assert all(
+        any(
+            citation.get("role") == "assessment"
+            and citation.get("stale_relative_to_global_evidence") is True
+            for citation in finding.citations
+        )
+        for finding in store.list_findings()
+    )

--- a/tests/builderops/ckm/test_gap_detection.py
+++ b/tests/builderops/ckm/test_gap_detection.py
@@ -1,0 +1,457 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from app.builderops.cli import builderops
+from app.builderops.ckm.assess import assessment_fingerprint
+from app.builderops.ckm.gaps import GapDetectionConfig, detect_gaps
+from app.builderops.ckm.models import MATURITY_DIMENSIONS, CkmValidationError
+from app.builderops.ckm.store import CkmStore
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> CkmStore:
+    result = CkmStore(tmp_path / "builderops.sqlite3")
+    result.ensure_schema()
+    result.set_watermark("fixture", "one")
+    return result
+
+
+def _capability(
+    store: CkmStore,
+    name: str,
+    *,
+    boundary_ref: str | None = None,
+    seed_ref: str | None = None,
+    parent_id: str | None = None,
+):
+    source_ref = seed_ref or f"docs/{name.replace(' ', '_').upper()}.md"
+    store.upsert_artifact(
+        source_ref=source_ref,
+        artifact_kind="document",
+        source="fixture",
+        watermark=f"wm:{source_ref}",
+        provenance=json.dumps(
+            {
+                "source_ref": source_ref,
+                "payload_summary": "Seed taxonomy — State: baseline",
+            },
+            sort_keys=True,
+        ),
+    )
+    return store.upsert_capability(
+        name=name,
+        definition=f"Fixture capability {name}.",
+        existence_provenance=f"seeded:{source_ref} :: fixture",
+        lifecycle="confirmed",
+        boundary_ref=boundary_ref,
+        parent_id=parent_id,
+    )
+
+
+def _edge(
+    store: CkmStore,
+    capability_id: str,
+    *,
+    source_ref: str,
+    artifact_kind: str,
+    evidence_kind: str,
+    dimension: str,
+    payload_summary: str = "State: current",
+):
+    artifact = store.upsert_artifact(
+        source_ref=source_ref,
+        artifact_kind=artifact_kind,
+        source="fixture",
+        watermark=f"wm:{source_ref}",
+        provenance=json.dumps(
+            {"source_ref": source_ref, "payload_summary": payload_summary},
+            sort_keys=True,
+        ),
+    )
+    edge = store.upsert_evidence_edge(
+        artifact_id=artifact.id,
+        capability_id=capability_id,
+        evidence_kind=evidence_kind,
+        polarity="supports",
+        maturity_dimension=dimension,
+        confidence=1.0,
+        extraction_method="deterministic",
+        lifecycle="confirmed",
+        source_ref=source_ref,
+        basis=f"fixture:{source_ref}:{dimension}",
+    )
+    return artifact, edge
+
+
+def _citation(artifact, edge) -> dict[str, object]:
+    return {
+        "edge_id": edge.id,
+        "artifact_id": artifact.id,
+        "source_ref": artifact.source_ref,
+        "edge": edge.to_dict(),
+        "artifact": artifact.to_dict(),
+    }
+
+
+def _assessment(
+    store: CkmStore,
+    capability_id: str,
+    scores: dict[str, float],
+    citations: dict[str, list[dict[str, object]]],
+    *,
+    asserted_at: str,
+) -> None:
+    artifacts = {artifact.id: artifact for artifact in store.list_artifacts()}
+    edges = store.list_evidence_edges_for_capability(capability_id)
+    store.append_assessment(
+        capability_id=capability_id,
+        scores=scores,
+        citations=citations,
+        aggregate=min(scores.values()),
+        watermark_set={"fixture": "one"},
+        edge_fingerprint=assessment_fingerprint(edges, artifacts),
+        asserted_at=asserted_at,
+        valid_from=asserted_at,
+    )
+
+
+def _score_map(default: float, **overrides: float) -> dict[str, float]:
+    scores = {dimension: default for dimension in MATURITY_DIMENSIONS}
+    scores.update(overrides)
+    return scores
+
+
+def _semantic_findings(store: CkmStore) -> list[tuple[object, ...]]:
+    return [
+        (
+            finding.id,
+            finding.kind,
+            finding.capability_id,
+            finding.dimension,
+            finding.statement,
+            finding.citations,
+        )
+        for finding in store.list_findings()
+    ]
+
+
+def _three_family_fixture(store: CkmStore) -> dict[str, object]:
+    starved = _capability(store, "Starved capability", boundary_ref=None)
+    source_artifact, source_edge = _edge(
+        store,
+        starved.id,
+        source_ref="app/starved.py",
+        artifact_kind="source_file",
+        evidence_kind="source",
+        dimension="functional_completeness",
+    )
+    test_artifact, test_edge = _edge(
+        store,
+        starved.id,
+        source_ref="tests/test_starved.py",
+        artifact_kind="test",
+        evidence_kind="test",
+        dimension="test_completeness",
+    )
+    starved_citations = {dimension: [] for dimension in MATURITY_DIMENSIONS}
+    starved_citations["functional_completeness"] = [_citation(source_artifact, source_edge)]
+    starved_citations["test_completeness"] = [_citation(test_artifact, test_edge)]
+    _assessment(
+        store,
+        starved.id,
+        _score_map(0.9, test_completeness=0.2),
+        starved_citations,
+        asserted_at="2026-07-14T10:00:00Z",
+    )
+
+    uncovered = _capability(
+        store,
+        "Uncovered boundary",
+        boundary_ref="VOID",
+        seed_ref="docs/SYSTEM_BREAKDOWN_STRUCTURE.md",
+    )
+    _assessment(
+        store,
+        uncovered.id,
+        _score_map(0.0),
+        {dimension: [] for dimension in MATURITY_DIMENSIONS},
+        asserted_at="2026-07-14T10:00:01Z",
+    )
+
+    tension = _capability(store, "Claiming capability", boundary_ref=None)
+    claim_artifact, claim_edge = _edge(
+        store,
+        tension.id,
+        source_ref="docs/CLAIMING_CAPABILITY.md",
+        artifact_kind="document",
+        evidence_kind="doc",
+        dimension="documentation_quality",
+        payload_summary="Claiming capability — State: delivered",
+    )
+    tension_citations = {dimension: [] for dimension in MATURITY_DIMENSIONS}
+    tension_citations["documentation_quality"] = [_citation(claim_artifact, claim_edge)]
+    _assessment(
+        store,
+        tension.id,
+        _score_map(
+            0.1,
+            functional_completeness=0.2,
+            test_completeness=0.9,
+        ),
+        tension_citations,
+        asserted_at="2026-07-14T10:00:02Z",
+    )
+    return {
+        "starved": starved,
+        "uncovered": uncovered,
+        "tension": tension,
+        "claim_artifact": claim_artifact,
+    }
+
+
+def test_findings_name_capability_dimension_and_citation(store: CkmStore) -> None:
+    capability = _capability(store, "Enforced finding")
+    artifact = store.get_artifact_by_source_ref("docs/ENFORCED_FINDING.md")
+    assert artifact is not None
+
+    with pytest.raises(CkmValidationError, match="citation"):
+        store.upsert_finding(
+            kind="gap",
+            capability_id=capability.id,
+            dimension="test_completeness",
+            statement="Concrete missing-test statement.",
+            citations=[],
+        )
+    with pytest.raises(CkmValidationError, match="evidence edge or artifact"):
+        store.upsert_finding(
+            kind="gap",
+            capability_id=capability.id,
+            dimension="test_completeness",
+            statement="Concrete missing-test statement.",
+            citations=[{"role": "missing_evidence_class", "dimension": "test_completeness"}],
+        )
+
+    finding = store.upsert_finding(
+        kind="gap",
+        capability_id=capability.id,
+        dimension="test_completeness",
+        statement="Enforced finding has no executable test evidence.",
+        citations=[
+            {
+                "role": "seed_artifact",
+                "artifact_id": artifact.id,
+                "source_ref": artifact.source_ref,
+                "artifact": artifact.to_dict(),
+            }
+        ],
+    )
+
+    assert finding.capability_id == capability.id
+    assert finding.dimension == "test_completeness"
+    assert finding.statement.startswith("Enforced finding")
+    assert finding.citations[0]["artifact_id"] == artifact.id
+
+
+def test_three_detector_families_on_fixture(store: CkmStore) -> None:
+    fixture = _three_family_fixture(store)
+
+    result = detect_gaps(
+        store,
+        config=GapDetectionConfig(floor=0.5, healthy_floor=0.75, healthy_sibling_count=2),
+    )
+    findings = store.list_findings()
+
+    assert result.starved_dimensions == 1
+    assert result.uncovered_boundaries == 1
+    assert result.claim_exceeds_evidence == 1
+    assert len(findings) == 3
+    assert {
+        (finding.kind, finding.capability_id)
+        for finding in findings
+    } == {
+        ("gap", fixture["starved"].id),
+        ("gap", fixture["uncovered"].id),
+        ("missing_evidence", fixture["tension"].id),
+    }
+
+
+def test_tension_cites_claim_and_missing_class(store: CkmStore) -> None:
+    fixture = _three_family_fixture(store)
+
+    detect_gaps(store)
+    tension = next(finding for finding in store.list_findings() if finding.kind == "missing_evidence")
+
+    claim_citation = next(
+        citation for citation in tension.citations if citation.get("role") == "claiming_artifact"
+    )
+    missing_class = next(
+        citation
+        for citation in tension.citations
+        if citation.get("role") == "missing_evidence_class"
+    )
+    assert claim_citation["artifact_id"] == fixture["claim_artifact"].id
+    assert claim_citation["artifact"]["source_ref"] == "docs/CLAIMING_CAPABILITY.md"
+    assert missing_class == {
+        "role": "missing_evidence_class",
+        "dimension": "functional_completeness",
+        "evidence_kinds": ["pull_request", "source"],
+        "observed_edge_count": 0,
+    }
+    assert "docs/CLAIMING_CAPABILITY.md" in tension.statement
+    assert "functional completeness" in tension.statement
+
+
+def test_regeneration_deterministic(store: CkmStore) -> None:
+    _three_family_fixture(store)
+    config = GapDetectionConfig(floor=0.5, healthy_floor=0.75, healthy_sibling_count=2)
+
+    first_result = detect_gaps(store, config=config)
+    first = _semantic_findings(store)
+    second_result = detect_gaps(store, config=config)
+    second = _semantic_findings(store)
+
+    assert first_result == second_result
+    assert first == second
+
+    cli = CliRunner().invoke(
+        builderops,
+        ["--db-path", str(store.db_path), "ckm", "gaps"],
+    )
+    assert cli.exit_code == 0
+    assert cli.output.strip() == (
+        "3 findings: 1 starved-dimension, 1 uncovered-boundary, "
+        "1 claim-exceeds-evidence"
+    )
+
+
+def test_planned_state_does_not_claim_delivery(store: CkmStore) -> None:
+    capability = _capability(store, "Planned capability")
+    artifact, edge = _edge(
+        store,
+        capability.id,
+        source_ref="docs/PLANNED.md",
+        artifact_kind="document",
+        evidence_kind="doc",
+        dimension="documentation_quality",
+        payload_summary="Planned capability — State: target-state / planned",
+    )
+    citations = {dimension: [] for dimension in MATURITY_DIMENSIONS}
+    citations["documentation_quality"] = [_citation(artifact, edge)]
+    _assessment(
+        store,
+        capability.id,
+        _score_map(0.1),
+        citations,
+        asserted_at="2026-07-14T11:00:00Z",
+    )
+
+    result = detect_gaps(store)
+
+    assert result.findings == 0
+    assert store.list_findings() == []
+
+
+def test_candidate_source_does_not_cover_boundary(store: CkmStore) -> None:
+    capability = _capability(
+        store,
+        "Candidate-only boundary",
+        boundary_ref="CAND",
+        seed_ref="docs/SYSTEM_BREAKDOWN_STRUCTURE.md",
+    )
+    artifact = store.upsert_artifact(
+        source_ref="app/candidate.py",
+        artifact_kind="source_file",
+        source="fixture",
+        watermark="wm:candidate",
+        provenance='{"source_ref":"app/candidate.py"}',
+    )
+    store.upsert_evidence_edge(
+        artifact_id=artifact.id,
+        capability_id=capability.id,
+        evidence_kind="source",
+        polarity="supports",
+        maturity_dimension="functional_completeness",
+        confidence=0.8,
+        extraction_method="inferred",
+        lifecycle="candidate",
+        source_ref=artifact.source_ref,
+        basis="fixture:candidate-source",
+        model="fixture-model",
+        provider="fixture-provider",
+    )
+    _assessment(
+        store,
+        capability.id,
+        _score_map(0.0),
+        {dimension: [] for dimension in MATURITY_DIMENSIONS},
+        asserted_at="2026-07-14T11:01:00Z",
+    )
+
+    result = detect_gaps(store)
+
+    assert result.uncovered_boundaries == 1
+    assert store.list_findings()[0].capability_id == capability.id
+
+
+def test_confirmed_child_source_covers_whole_boundary(store: CkmStore) -> None:
+    parent = _capability(
+        store,
+        "Covered boundary",
+        boundary_ref="COV",
+        seed_ref="docs/SYSTEM_BREAKDOWN_STRUCTURE.md",
+    )
+    child = _capability(
+        store,
+        "Covered child",
+        boundary_ref="COV",
+        parent_id=parent.id,
+    )
+    artifact, edge = _edge(
+        store,
+        child.id,
+        source_ref="app/covered.py",
+        artifact_kind="source_file",
+        evidence_kind="source",
+        dimension="functional_completeness",
+    )
+    for capability in (parent, child):
+        citations = {dimension: [] for dimension in MATURITY_DIMENSIONS}
+        if capability.id == child.id:
+            citations["functional_completeness"] = [_citation(artifact, edge)]
+        _assessment(
+            store,
+            capability.id,
+            _score_map(0.0),
+            citations,
+            asserted_at=f"2026-07-14T11:02:0{int(capability.id == child.id)}Z",
+        )
+
+    result = detect_gaps(store)
+
+    assert result.uncovered_boundaries == 0
+    assert store.list_findings() == []
+
+
+def test_stale_assessment_leaves_existing_findings_untouched(store: CkmStore) -> None:
+    _three_family_fixture(store)
+    detect_gaps(store)
+    before = [finding.to_dict() for finding in store.list_findings()]
+    artifact = store.get_artifact_by_source_ref("app/starved.py")
+    assert artifact is not None
+    store.upsert_artifact(
+        source_ref=artifact.source_ref,
+        artifact_kind=artifact.artifact_kind,
+        source=artifact.source,
+        watermark="wm:changed",
+        provenance=artifact.provenance,
+    )
+
+    with pytest.raises(CkmValidationError, match="does not match current evidence"):
+        detect_gaps(store)
+
+    assert [finding.to_dict() for finding in store.list_findings()] == before


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Closes #3146
Parent validation hub: #3138

## Summary
- Add deterministic starved-dimension, uncovered-boundary, and claim-exceeds-evidence detectors over current CKM assessments and evidence.
- Persist only concrete capability+dimension findings with frozen edge/artifact citations through one atomic current-projection reconcile.
- Fail closed before mutation when seeded capability assessments are missing or fingerprint-stale; global watermark-only lag remains usable only for an unchanged evidence fingerprint and is marked explicitly in findings/CLI.
- Add `python -m app.builderops ckm gaps` with configurable floor thresholds.

## SBS Impact
- Primary subsystem: Builder System (BuilderOps CKM plane)
- Write class: derived/additive `ckm_finding` projection only
- Authority impact: none; no Product, runtime, vault, or GitHub writes from CKM code
- Persistence: rebuildable/disposable findings over rebuildable CKM state

## Acceptance Evidence
- `tests/builderops/ckm/test_gap_detection.py`: 14 passed, including all four issue-named AC tests plus stale-state, watermark-recovery, negative/future-State, open-PR, candidate-boundary, and child-boundary regressions.
- Full CKM suite: 106 passed.
- `ruff check app tests`: passed.
- `mypy app` on the pre-main-integration head: 728 source files passed. Current main then introduced one unrelated Heimdal type error; reproduced on clean `origin/main` and filed as #3671.
- Full `pytest -q -m "not pg"`: 8229 passed, 114 skipped, 85 deselected, 18 xfailed; two unrelated failures reproduced on clean `origin/main` (write-note-relative census and standing-question timestamp format validation).
- Fresh live repo-only pipeline: seed 31 capabilities; ingest/link/assess completed; gaps produced 58 cited findings (48 starved, 10 uncovered boundary, 0 claim-exceeds-evidence); prior false claims from explicitly non-shipped docs were eliminated.
- `git diff --check`: passed.

## Dispatcher / Workspace
- Dispatcher-backed claim: task `github-RasmusTho--agentic-pkm-mvp-issue-3146`, lease `lease-40c271fb`, agent `codex-ckm3138-delivery`.
- Isolated worktree: `/Users/rasmus/workspace/agentic-pkm-mvp-3146`.

## Owner-Doc Writeback
No child-local owner-doc change. The active CKM specification already defines this slice; parent #3138 owns capability acceptance and owner-doc promotion after CKM-10.

## TCD
```yaml
tcd_plan:
  task_summary: Deterministic cited CKM gap generation over current assessments
  assumptions: Existing finding natural key and two public finding kinds remain authoritative
  complexity: medium
  risk: high
  verification_difficulty: moderate
  human_review_burden: medium
  defect_blast_radius: medium
  budget_pressure: low
  recommended_capability:
    workflow_or_skill: issue-to-code
    model_family: gpt-5.6-terra
    reasoning_effort: high
    tools: focused pytest, live temporary CKM rebuild, Ruff, mypy, independent review
    github_context_required: true
  cheapest_acceptable_path: Pure detectors plus atomic store reconciliation and focused regressions
  escalation_triggers: Citation-history breakage, stale-state mutation, or boundary/claim false positives
  deescalation_triggers: Detector rules remain isolated and synthetic/live fixtures pass
  review_gate: Independent review emphasizing citations, stale-state behavior, and one-run regeneration
```

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The bounded GitHub issue and PR are the canonical delivery records; CKM findings created during validation used a disposable temporary database and no BuilderOps Vault operational record was needed.