### PR TITLE
Add CKM Markdown projections and query CLI

### DIFF
--- a/app/builderops/ckm/projections.py
+++ b/app/builderops/ckm/projections.py
@@ -10,6 +10,7 @@ from typing import Iterable, Mapping, Sequence
 from app.builderops.ckm.models import (
     MATURITY_DIMENSIONS,
     CkmAssessmentProjection,
+    CkmArtifact,
     CkmCapability,
     CkmEvidenceEdge,
     CkmFinding,
@@ -264,16 +265,28 @@ def _render_gaps(store: CkmStore) -> list[str]:
     return lines
 
 
-def _refs_for_kind(edges: Sequence[CkmEvidenceEdge], kinds: set[str]) -> str:
+def _refs_for_kind(
+    edges: Sequence[CkmEvidenceEdge],
+    artifacts: Mapping[str, CkmArtifact],
+    *,
+    evidence_kinds: set[str],
+    artifact_kinds: set[str] | None = None,
+    excluded_artifact_kinds: set[str] | None = None,
+) -> str:
+    included_artifact_kinds = artifact_kinds or set()
+    excluded = excluded_artifact_kinds or set()
     values = [
         f"{edge.source_ref} ({edge.lifecycle})"
         for edge in edges
-        if edge.evidence_kind in kinds
+        if artifacts[edge.artifact_id].artifact_kind not in excluded
+        if edge.evidence_kind in evidence_kinds
+        or artifacts[edge.artifact_id].artifact_kind in included_artifact_kinds
     ]
     return ", ".join(sorted(set(values))) or "—"
 
 
 def _render_traceability_matrix(store: CkmStore) -> list[str]:
+    artifacts = {item.id: item for item in store.list_artifacts()}
     lines = [
         "# Generated CKM Traceability Matrix",
         "",
@@ -289,13 +302,34 @@ def _render_traceability_matrix(store: CkmStore) -> list[str]:
             str(index),
             f"{capability.name} ({capability.lifecycle})",
             capability.existence_provenance,
-            _refs_for_kind(edges, {"adr"}),
+            _refs_for_kind(
+                edges,
+                artifacts,
+                evidence_kinds={"adr"},
+                artifact_kinds={"adr"},
+            ),
             capability.name,
             "candidate evidence distinguished from confirmed evidence",
             capability.boundary_ref or "—",
-            _refs_for_kind(edges, {"spec", "requirement", "design_doc"}),
-            _refs_for_kind(edges, {"test", "coverage", "benchmark", "ci_result"}),
-            _refs_for_kind(edges, {"issue", "pull_request", "commit", "source"}),
+            _refs_for_kind(
+                edges,
+                artifacts,
+                evidence_kinds={"spec", "requirement", "design_doc"},
+                artifact_kinds={"spec", "requirement"},
+                excluded_artifact_kinds={"issue"},
+            ),
+            _refs_for_kind(
+                edges,
+                artifacts,
+                evidence_kinds={"test", "coverage", "benchmark", "ci_result"},
+                artifact_kinds={"test", "coverage", "benchmark", "ci_result"},
+            ),
+            _refs_for_kind(
+                edges,
+                artifacts,
+                evidence_kinds={"pull_request", "commit", "source"},
+                artifact_kinds={"issue", "pull_request", "commit", "source_file"},
+            ),
         )
         lines.append("| " + " | ".join(_markdown(value) for value in row) + " |")
     return lines

--- a/app/builderops/ckm/projections.py
+++ b/app/builderops/ckm/projections.py
@@ -16,6 +16,7 @@ from app.builderops.ckm.models import (
     CkmValidationError,
     utc_now,
 )
+from app.builderops.ckm.seed import SeedManifestError, load_manifest
 from app.builderops.ckm.store import CkmStore
 
 
@@ -93,7 +94,29 @@ def _slug(value: str) -> str:
 
 def _capability_by_slug(store: CkmStore, slug: str) -> CkmCapability:
     normalized = _slug(slug)
-    matches = [item for item in store.list_capabilities() if _slug(item.name) == normalized]
+    try:
+        manifest = load_manifest()
+    except SeedManifestError as exc:
+        raise CkmValidationError(f"cannot resolve capability slugs: {exc}") from exc
+    manifest_by_slug = {_slug(entry.slug): entry for entry in manifest}
+    manifest_entry = manifest_by_slug.get(normalized)
+    if manifest_entry is not None:
+        capability = store.get_capability_by_name(manifest_entry.name)
+        if capability is None:
+            raise CkmValidationError(
+                f"seeded capability is missing for manifest slug: {slug}"
+            )
+        return capability
+
+    # Manifest slugs are the stable query contract for seeded capabilities.
+    # Name-derived slugs exist only as a deterministic fallback for inferred
+    # capabilities that are not represented in the reviewed seed manifest.
+    seeded_names = {entry.name for entry in manifest}
+    matches = [
+        item
+        for item in store.list_capabilities()
+        if item.name not in seeded_names and _slug(item.name) == normalized
+    ]
     if not matches:
         raise CkmValidationError(f"unknown capability slug: {slug}")
     if len(matches) > 1:

--- a/app/builderops/ckm/projections.py
+++ b/app/builderops/ckm/projections.py
@@ -1,0 +1,379 @@
+"""Non-authoritative Markdown projections over the Capability Evidence Graph."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+from app.builderops.ckm.models import (
+    MATURITY_DIMENSIONS,
+    CkmAssessmentProjection,
+    CkmCapability,
+    CkmEvidenceEdge,
+    CkmFinding,
+    CkmValidationError,
+    utc_now,
+)
+from app.builderops.ckm.store import CkmStore
+
+
+TRACEABILITY_COLUMNS = (
+    "#",
+    "Principle / finding",
+    "Canonical doc",
+    "ADR",
+    "Ontology concepts",
+    "Semantic distinctions",
+    "Control boundaries",
+    "Contract / schema",
+    "Required tests / evals",
+    "Implementation issues",
+)
+
+PROJECTION_FILENAMES = {
+    "ckm-capability-map": "ckm-capability-map.md",
+    "ckm-maturity": "ckm-maturity.md",
+    "ckm-gaps": "ckm-gaps.md",
+    "ckm-traceability-matrix": "ckm-traceability-matrix.md",
+}
+
+
+@dataclass(frozen=True)
+class CkmProjectionResult:
+    projection_type: str
+    path: Path
+    generated_at: str
+
+
+def _markdown(value: object) -> str:
+    return str(value).replace("|", "\\|").replace("\n", " ").strip()
+
+
+def _watermark_text(watermarks: Mapping[str, str]) -> str:
+    if not watermarks:
+        return "none"
+    return ", ".join(f"{key}={value}" for key, value in sorted(watermarks.items()))
+
+
+def _header(
+    projection_type: str,
+    *,
+    generated_at: str,
+    watermarks: Mapping[str, str],
+) -> list[str]:
+    return [
+        "State: Generated projection",
+        "Authority: non-authoritative BuilderOps CKM projection",
+        "Source of truth: CKM evidence store; this file is not source of truth.",
+        f"Generated at: {generated_at}",
+        f"Projection type: {projection_type}",
+        f"Watermarks: {_watermark_text(watermarks)}",
+        "Evidence lifecycle: confirmed and candidate evidence are shown separately.",
+        "Do not edit: regenerate from the CKM store.",
+        "",
+    ]
+
+
+def _edge_counts(edges: Iterable[CkmEvidenceEdge]) -> tuple[int, int]:
+    confirmed = 0
+    candidate = 0
+    for edge in edges:
+        if edge.lifecycle == "candidate":
+            candidate += 1
+        else:
+            confirmed += 1
+    return confirmed, candidate
+
+
+def _slug(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", value.casefold()).strip("-")
+
+
+def _capability_by_slug(store: CkmStore, slug: str) -> CkmCapability:
+    normalized = _slug(slug)
+    matches = [item for item in store.list_capabilities() if _slug(item.name) == normalized]
+    if not matches:
+        raise CkmValidationError(f"unknown capability slug: {slug}")
+    if len(matches) > 1:
+        raise CkmValidationError(f"ambiguous capability slug: {slug}")
+    return matches[0]
+
+
+def _forest_order(capabilities: Sequence[CkmCapability]) -> list[tuple[int, CkmCapability]]:
+    by_parent: dict[str | None, list[CkmCapability]] = {}
+    known_ids = {item.id for item in capabilities}
+    for item in capabilities:
+        parent = item.parent_id if item.parent_id in known_ids else None
+        by_parent.setdefault(parent, []).append(item)
+    for children in by_parent.values():
+        children.sort(key=lambda item: (item.name.casefold(), item.id))
+
+    ordered: list[tuple[int, CkmCapability]] = []
+    visited: set[str] = set()
+
+    def visit(item: CkmCapability, depth: int) -> None:
+        if item.id in visited:
+            return
+        visited.add(item.id)
+        ordered.append((depth, item))
+        for child in by_parent.get(item.id, []):
+            visit(child, depth + 1)
+
+    for root in by_parent.get(None, []):
+        visit(root, 0)
+    # A damaged or mid-migration store must not make capabilities disappear
+    # from an observability surface. Render cycles/orphans as additional roots.
+    for item in sorted(capabilities, key=lambda value: (value.name.casefold(), value.id)):
+        visit(item, 0)
+    return ordered
+
+
+def _render_capability_map(store: CkmStore) -> list[str]:
+    capabilities = store.list_capabilities()
+    all_edges = store.list_evidence_edges()
+    edges_by_capability: dict[str, list[CkmEvidenceEdge]] = {}
+    linked_artifacts: set[str] = set()
+    for edge in all_edges:
+        edges_by_capability.setdefault(edge.capability_id, []).append(edge)
+        linked_artifacts.add(edge.artifact_id)
+    unlinked = sum(artifact.id not in linked_artifacts for artifact in store.list_artifacts())
+    lines = [
+        "# CKM Capability Map",
+        "",
+        f"Unlinked artifacts: **{unlinked}**",
+        "",
+        "| Capability | Lifecycle | Boundary | Confirmed evidence | Candidate evidence |",
+        "| --- | --- | --- | ---: | ---: |",
+    ]
+    for depth, capability in _forest_order(capabilities):
+        confirmed, candidate = _edge_counts(edges_by_capability.get(capability.id, []))
+        name = f"{'↳ ' * depth}{capability.name}"
+        lines.append(
+            f"| {_markdown(name)} | {capability.lifecycle} | "
+            f"{_markdown(capability.boundary_ref or '—')} | {confirmed} | {candidate} |"
+        )
+    return lines
+
+
+def _assessment_or_none(store: CkmStore, capability_id: str) -> CkmAssessmentProjection | None:
+    if store.latest_assessment_for_capability(capability_id) is None:
+        return None
+    return store.assessment_for_projection(capability_id)
+
+
+def _render_maturity(store: CkmStore) -> list[str]:
+    lines = ["# CKM Maturity", ""]
+    for capability in store.list_capabilities():
+        edges = store.list_evidence_edges_for_capability(capability.id)
+        confirmed, candidate = _edge_counts(edges)
+        projection = _assessment_or_none(store, capability.id)
+        lines.extend([f"## {_markdown(capability.name)}", ""])
+        lines.append(
+            f"Evidence: **{confirmed} confirmed / {candidate} candidate**. "
+            f"Lifecycle: **{capability.lifecycle}**."
+        )
+        if projection is None:
+            lines.extend(["Assessment: **missing**.", ""])
+            continue
+        assessment = projection.assessment
+        freshness = "STALE relative to evidence" if projection.stale_relative_to_evidence else "current"
+        confidence = "LOW CONFIDENCE" if assessment.low_confidence else "normal confidence"
+        lines.extend([
+            f"Assessment: **{freshness}**; **{confidence}**; "
+            f"aggregate convenience score **{assessment.aggregate:.3f}** "
+            f"(`{assessment.aggregate_formula_id}`).",
+            "",
+            "| Dimension | Score | Citations | Candidate share | Formula |",
+            "| --- | ---: | ---: | ---: | --- |",
+        ])
+        for dimension in MATURITY_DIMENSIONS:
+            lines.append(
+                f"| {dimension} | {assessment.scores[dimension]:.3f} | "
+                f"{len(assessment.citations[dimension])} | "
+                f"{assessment.candidate_shares[dimension]:.1%} | "
+                f"{_markdown(assessment.formula_ids[dimension])} |"
+            )
+        lines.append("")
+    return lines
+
+
+def _citation_text(citation: Mapping[str, object]) -> str:
+    lifecycle = citation.get("lifecycle")
+    edge = citation.get("edge")
+    if lifecycle is None and isinstance(edge, Mapping):
+        lifecycle = edge.get("lifecycle")
+    source_ref = citation.get("source_ref")
+    artifact = citation.get("artifact")
+    if source_ref is None and isinstance(artifact, Mapping):
+        source_ref = artifact.get("source_ref")
+    role = citation.get("role")
+    parts = [str(source_ref or citation.get("missing_evidence_class") or "snapshot")]
+    if lifecycle in {"candidate", "confirmed"}:
+        parts.append(str(lifecycle))
+    elif role:
+        parts.append(str(role))
+    return " — ".join(parts)
+
+
+def _render_gaps(store: CkmStore) -> list[str]:
+    capabilities = {item.id: item for item in store.list_capabilities()}
+    grouped: dict[str, list[CkmFinding]] = {"gap": [], "missing_evidence": []}
+    for finding in store.list_findings():
+        grouped.setdefault(finding.kind, []).append(finding)
+    lines = ["# CKM Gaps and Missing Evidence", ""]
+    for kind in ("gap", "missing_evidence"):
+        lines.extend([f"## {kind.replace('_', ' ').title()}", ""])
+        findings = grouped.get(kind, [])
+        if not findings:
+            lines.extend(["No current findings.", ""])
+            continue
+        for finding in findings:
+            capability = capabilities.get(finding.capability_id)
+            name = capability.name if capability else finding.capability_id
+            lines.append(
+                f"- **{_markdown(name)} / {finding.dimension}:** {_markdown(finding.statement)}"
+            )
+            for citation in finding.citations:
+                lines.append(f"  - Citation: {_markdown(_citation_text(citation))}")
+        lines.append("")
+    return lines
+
+
+def _refs_for_kind(edges: Sequence[CkmEvidenceEdge], kinds: set[str]) -> str:
+    values = [
+        f"{edge.source_ref} ({edge.lifecycle})"
+        for edge in edges
+        if edge.evidence_kind in kinds
+    ]
+    return ", ".join(sorted(set(values))) or "—"
+
+
+def _render_traceability_matrix(store: CkmStore) -> list[str]:
+    lines = [
+        "# Generated CKM Traceability Matrix",
+        "",
+        "This projection is for side-by-side comparison with the canonical, hand-authored matrix.",
+        "It never edits `docs/architecture/traceability-matrix.md`.",
+        "",
+        "| " + " | ".join(TRACEABILITY_COLUMNS) + " |",
+        "| " + " | ".join("---" for _ in TRACEABILITY_COLUMNS) + " |",
+    ]
+    for index, capability in enumerate(store.list_capabilities(), start=1):
+        edges = store.list_evidence_edges_for_capability(capability.id)
+        row = (
+            str(index),
+            f"{capability.name} ({capability.lifecycle})",
+            capability.existence_provenance,
+            _refs_for_kind(edges, {"adr"}),
+            capability.name,
+            "candidate evidence distinguished from confirmed evidence",
+            capability.boundary_ref or "—",
+            _refs_for_kind(edges, {"spec", "requirement", "design_doc"}),
+            _refs_for_kind(edges, {"test", "coverage", "benchmark", "ci_result"}),
+            _refs_for_kind(edges, {"issue", "pull_request", "commit", "source"}),
+        )
+        lines.append("| " + " | ".join(_markdown(value) for value in row) + " |")
+    return lines
+
+
+def render_projection(
+    store: CkmStore,
+    projection_type: str,
+    *,
+    generated_at: str | None = None,
+) -> str:
+    normalized = projection_type.strip().lower().replace("_", "-")
+    if normalized not in PROJECTION_FILENAMES:
+        allowed = ", ".join(sorted(PROJECTION_FILENAMES))
+        raise CkmValidationError(f"unsupported CKM projection type: {projection_type}; allowed: {allowed}")
+    store.ensure_schema()
+    timestamp = generated_at or utc_now()
+    body = {
+        "ckm-capability-map": _render_capability_map,
+        "ckm-maturity": _render_maturity,
+        "ckm-gaps": _render_gaps,
+        "ckm-traceability-matrix": _render_traceability_matrix,
+    }[normalized](store)
+    return "\n".join(
+        _header(normalized, generated_at=timestamp, watermarks=store.current_watermark_set())
+        + body
+        + [""]
+    )
+
+
+def write_projection(
+    store: CkmStore,
+    projection_type: str,
+    output_dir: Path,
+    *,
+    generated_at: str | None = None,
+) -> CkmProjectionResult:
+    normalized = projection_type.strip().lower().replace("_", "-")
+    filename = PROJECTION_FILENAMES.get(normalized)
+    if filename is None:
+        allowed = ", ".join(sorted(PROJECTION_FILENAMES))
+        raise CkmValidationError(f"unsupported CKM projection type: {projection_type}; allowed: {allowed}")
+    timestamp = generated_at or utc_now()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / filename
+    canonical = Path("docs/architecture/traceability-matrix.md").resolve()
+    if path.resolve() == canonical:
+        raise CkmValidationError("refusing to overwrite the canonical traceability matrix")
+    path.write_text(render_projection(store, normalized, generated_at=timestamp), encoding="utf-8")
+    return CkmProjectionResult(normalized, path, timestamp)
+
+
+def render_capability_show(
+    store: CkmStore,
+    capability_slug: str,
+    *,
+    generated_at: str | None = None,
+) -> str:
+    store.ensure_schema()
+    capability = _capability_by_slug(store, capability_slug)
+    timestamp = generated_at or utc_now()
+    edges = store.list_evidence_edges_for_capability(capability.id)
+    confirmed, candidate = _edge_counts(edges)
+    lines = _header(
+        "ckm-show",
+        generated_at=timestamp,
+        watermarks=store.current_watermark_set(),
+    )
+    lines.extend([
+        f"# {_markdown(capability.name)}",
+        "",
+        f"Lifecycle: **{capability.lifecycle}**. Boundary: **{_markdown(capability.boundary_ref or '—')}**.",
+        f"Evidence: **{confirmed} confirmed / {candidate} candidate**.",
+        "",
+    ])
+    projection = _assessment_or_none(store, capability.id)
+    if projection is None:
+        lines.extend(["Assessment: **missing**.", ""])
+    else:
+        assessment = projection.assessment
+        freshness = "STALE relative to evidence" if projection.stale_relative_to_evidence else "current"
+        lines.extend([
+            f"Assessment: **{freshness}**; aggregate convenience score **{assessment.aggregate:.3f}**.",
+            "",
+            "| Dimension | Score | Citations | Candidate share |",
+            "| --- | ---: | ---: | ---: |",
+        ])
+        for dimension in MATURITY_DIMENSIONS:
+            lines.append(
+                f"| {dimension} | {assessment.scores[dimension]:.3f} | "
+                f"{len(assessment.citations[dimension])} | "
+                f"{assessment.candidate_shares[dimension]:.1%} |"
+            )
+        lines.append("")
+    lines.extend(["## Evidence", ""])
+    if not edges:
+        lines.append("No linked evidence.")
+    for edge in sorted(edges, key=lambda item: (item.lifecycle, item.source_ref, item.id)):
+        lines.append(
+            f"- **{edge.lifecycle}** `{_markdown(edge.evidence_kind)}` "
+            f"[{_markdown(edge.maturity_dimension)}] {_markdown(edge.source_ref)} — "
+            f"basis: {_markdown(edge.basis)}"
+        )
+    return "\n".join(lines + [""])

--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -31,6 +31,11 @@ from app.builderops.ckm.gaps import GapDetectionConfig, detect_gaps
 from app.builderops.ckm.ingest_github import ingest_github
 from app.builderops.ckm.ingest_repo import ingest_repo
 from app.builderops.ckm.linkers import link_deterministic
+from app.builderops.ckm.projections import (
+    PROJECTION_FILENAMES as CKM_PROJECTION_FILENAMES,
+    render_capability_show,
+    write_projection as write_ckm_projection,
+)
 from app.builderops.ckm.semantic import (
     SemanticAssociationError,
     _confirm_edge_from_cli,
@@ -541,6 +546,39 @@ def ckm_gaps(
             "global evidence watermark but remain current for their unchanged evidence fingerprint",
             err=True,
         )
+
+
+@ckm.command("show", help="Render one capability as a non-authoritative CKM projection.")
+@click.argument("capability_slug")
+@click.pass_context
+def ckm_show(ctx: click.Context, capability_slug: str) -> None:
+    try:
+        output = render_capability_show(_ckm_store(ctx), capability_slug)
+    except (CkmValidationError, sqlite3.Error) as exc:
+        raise click.ClickException(f"ckm show failed: {exc}") from exc
+    click.echo(output, nl=False)
+
+
+@ckm.command("project", help="Write one non-authoritative CKM Markdown projection.")
+@click.option(
+    "--type",
+    "projection_type",
+    type=click.Choice(sorted(CKM_PROJECTION_FILENAMES)),
+    required=True,
+)
+@click.option(
+    "--out",
+    "output_dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    required=True,
+)
+@click.pass_context
+def ckm_project(ctx: click.Context, projection_type: str, output_dir: Path) -> None:
+    try:
+        result = write_ckm_projection(_ckm_store(ctx), projection_type, output_dir)
+    except (CkmValidationError, OSError, sqlite3.Error) as exc:
+        raise click.ClickException(f"ckm projection failed: {exc}") from exc
+    click.echo(f"{result.projection_type}\t{result.path}")
 
 
 @builderops.group("inquiry", help="Persist and inspect pre-ticket model inquiry artifacts.")

--- a/tests/builderops/ckm/test_projections.py
+++ b/tests/builderops/ckm/test_projections.py
@@ -72,6 +72,25 @@ def populated_store(tmp_path: Path) -> CkmStore:
         model="fixture-model",
         provider="fixture-provider",
     )
+    issue_artifact = store.upsert_artifact(
+        source_ref="github:issue:42",
+        artifact_kind="issue",
+        source="github",
+        watermark="2026-07-14T12:00:00Z",
+        provenance='{"number":42,"state":"closed"}',
+    )
+    store.upsert_evidence_edge(
+        artifact_id=issue_artifact.id,
+        capability_id=capability.id,
+        evidence_kind="requirement",
+        polarity="supports",
+        maturity_dimension="requirement_coverage",
+        confidence=1.0,
+        extraction_method="deterministic",
+        lifecycle="confirmed",
+        source_ref=issue_artifact.source_ref,
+        basis="fixture:implementation-issue",
+    )
     store.upsert_artifact(
         source_ref="docs/unlinked.md",
         artifact_kind="document",
@@ -140,10 +159,10 @@ def test_candidate_confirmed_distinction_rendered(populated_store: CkmStore) -> 
     maturity = render_projection(populated_store, "ckm-maturity")
     shown = render_capability_show(populated_store, "retrieval")
 
-    assert "| Retrieval | confirmed | RCA | 1 | 1 |" in capability_map
-    assert "Evidence: **1 confirmed / 1 candidate**" in maturity
+    assert "| Retrieval | confirmed | RCA | 2 | 1 |" in capability_map
+    assert "Evidence: **2 confirmed / 1 candidate**" in maturity
     assert "Candidate share" in maturity
-    assert "Evidence: **1 confirmed / 1 candidate**" in shown
+    assert "Evidence: **2 confirmed / 1 candidate**" in shown
     assert "**candidate** `doc`" in shown
     assert "**confirmed** `source`" in shown
     assert "basis: semantic:retrieval-doc" in shown
@@ -173,6 +192,14 @@ def test_generated_matrix_shape_and_never_overwrites_canonical(
     assert canonical_columns == TRACEABILITY_COLUMNS == generated_columns
     assert result.path == tmp_path / "generated" / "ckm-traceability-matrix.md"
     assert canonical.read_bytes() == before
+    retrieval_row = next(
+        line
+        for line in result.path.read_text(encoding="utf-8").splitlines()
+        if "| Retrieval (confirmed) |" in line
+    )
+    cells = [part.strip() for part in retrieval_row.strip("|").split("|")]
+    assert "github:issue:42 (confirmed)" not in cells[7]
+    assert "github:issue:42 (confirmed)" in cells[9]
 
 
 def test_cli_project_and_show(populated_store: CkmStore, tmp_path: Path) -> None:

--- a/tests/builderops/ckm/test_projections.py
+++ b/tests/builderops/ckm/test_projections.py
@@ -14,6 +14,7 @@ from app.builderops.ckm.projections import (
     render_projection,
     write_projection,
 )
+from app.builderops.ckm.seed import seed_capabilities
 from app.builderops.ckm.store import CkmStore
 
 
@@ -200,3 +201,23 @@ def test_cli_project_and_show(populated_store: CkmStore, tmp_path: Path) -> None
     assert shown.exit_code == 0, shown.output
     assert "Projection type: ckm-show" in shown.output
     assert "basis: fixture:confirmed-source" in shown.output
+
+
+def test_show_resolves_manifest_slug_and_inferred_fallback(tmp_path: Path) -> None:
+    store = CkmStore(tmp_path / "slug-query.sqlite3")
+    store.ensure_schema()
+    seed_capabilities(store)
+    store.upsert_capability(
+        name="Novel Inferred Capability",
+        definition="A candidate capability outside the reviewed seed manifest.",
+        existence_provenance="inferred:fixture",
+        lifecycle="candidate",
+    )
+
+    boundary = render_capability_show(store, "rca")
+    inferred = render_capability_show(store, "novel-inferred-capability")
+
+    assert "# Retrieval & Context Assembly" in boundary
+    assert "Boundary: **RCA**" in boundary
+    assert "# Novel Inferred Capability" in inferred
+    assert "Lifecycle: **candidate**" in inferred

--- a/tests/builderops/ckm/test_projections.py
+++ b/tests/builderops/ckm/test_projections.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from app.builderops.cli import builderops
+from app.builderops.ckm.assess import assess_capabilities
+from app.builderops.ckm.projections import (
+    PROJECTION_FILENAMES,
+    TRACEABILITY_COLUMNS,
+    render_capability_show,
+    render_projection,
+    write_projection,
+)
+from app.builderops.ckm.store import CkmStore
+
+
+@pytest.fixture()
+def populated_store(tmp_path: Path) -> CkmStore:
+    store = CkmStore(tmp_path / "builderops.sqlite3")
+    store.ensure_schema()
+    store.set_watermark("github", "2026-07-14T12:00:00Z")
+    store.set_watermark("repo", "abc123")
+    capability = store.upsert_capability(
+        name="Retrieval",
+        definition="Retrieve grounded context.",
+        existence_provenance="seeded:docs/CAPABILITY_CONTRACT_MODEL.md :: Retrieval",
+        lifecycle="confirmed",
+        boundary_ref="RCA",
+    )
+
+    confirmed_artifact = store.upsert_artifact(
+        source_ref="app/retrieval/capability.py",
+        artifact_kind="source_file",
+        source="repo",
+        watermark="abc123",
+        provenance='{"source_ref":"app/retrieval/capability.py"}',
+    )
+    confirmed_edge = store.upsert_evidence_edge(
+        artifact_id=confirmed_artifact.id,
+        capability_id=capability.id,
+        evidence_kind="source",
+        polarity="supports",
+        maturity_dimension="functional_completeness",
+        confidence=1.0,
+        extraction_method="deterministic",
+        lifecycle="confirmed",
+        source_ref=confirmed_artifact.source_ref,
+        basis="fixture:confirmed-source",
+    )
+    candidate_artifact = store.upsert_artifact(
+        source_ref="docs/drafts/retrieval-notes.md",
+        artifact_kind="document",
+        source="repo",
+        watermark="abc123",
+        provenance='{"source_ref":"docs/drafts/retrieval-notes.md"}',
+    )
+    store.upsert_evidence_edge(
+        artifact_id=candidate_artifact.id,
+        capability_id=capability.id,
+        evidence_kind="doc",
+        polarity="supports",
+        maturity_dimension="documentation_quality",
+        confidence=0.8,
+        extraction_method="inferred",
+        lifecycle="candidate",
+        source_ref=candidate_artifact.source_ref,
+        basis="semantic:retrieval-doc",
+        model="fixture-model",
+        provider="fixture-provider",
+    )
+    store.upsert_artifact(
+        source_ref="docs/unlinked.md",
+        artifact_kind="document",
+        source="repo",
+        watermark="abc123",
+        provenance='{"source_ref":"docs/unlinked.md"}',
+    )
+    assess_capabilities(store)
+    store.upsert_finding(
+        kind="gap",
+        capability_id=capability.id,
+        dimension="test_completeness",
+        statement="Retrieval lacks confirmed test evidence.",
+        citations=[
+            {
+                "edge_id": confirmed_edge.id,
+                "artifact_id": confirmed_artifact.id,
+                "source_ref": confirmed_artifact.source_ref,
+                "lifecycle": confirmed_edge.lifecycle,
+                "edge": confirmed_edge.to_dict(),
+                "artifact": confirmed_artifact.to_dict(),
+            }
+        ],
+    )
+    return store
+
+
+def test_all_egress_self_identifies_with_watermark(populated_store: CkmStore) -> None:
+    for projection_type in PROJECTION_FILENAMES:
+        rendered = render_projection(
+            populated_store,
+            projection_type,
+            generated_at="2026-07-14T12:30:00Z",
+        )
+        opening = rendered.splitlines()[:8]
+        assert opening[0] == "State: Generated projection"
+        assert "non-authoritative BuilderOps CKM projection" in opening[1]
+        assert "Generated at: 2026-07-14T12:30:00Z" in opening
+        assert f"Projection type: {projection_type}" in opening
+        assert "Watermarks: github=2026-07-14T12:00:00Z, repo=abc123" in opening
+
+    shown = render_capability_show(
+        populated_store,
+        "retrieval",
+        generated_at="2026-07-14T12:30:00Z",
+    )
+    assert shown.startswith("State: Generated projection\n")
+    assert "Projection type: ckm-show" in shown
+    assert "Watermarks: github=2026-07-14T12:00:00Z, repo=abc123" in shown
+
+
+def test_stale_assessment_flagged_in_render(populated_store: CkmStore) -> None:
+    current = render_projection(populated_store, "ckm-maturity")
+    assert "Assessment: **current**" in current
+
+    populated_store.set_watermark("repo", "def456")
+
+    stale = render_projection(populated_store, "ckm-maturity")
+    shown = render_capability_show(populated_store, "retrieval")
+    assert "STALE relative to evidence" in stale
+    assert "STALE relative to evidence" in shown
+
+
+def test_candidate_confirmed_distinction_rendered(populated_store: CkmStore) -> None:
+    capability_map = render_projection(populated_store, "ckm-capability-map")
+    maturity = render_projection(populated_store, "ckm-maturity")
+    shown = render_capability_show(populated_store, "retrieval")
+
+    assert "| Retrieval | confirmed | RCA | 1 | 1 |" in capability_map
+    assert "Evidence: **1 confirmed / 1 candidate**" in maturity
+    assert "Candidate share" in maturity
+    assert "Evidence: **1 confirmed / 1 candidate**" in shown
+    assert "**candidate** `doc`" in shown
+    assert "**confirmed** `source`" in shown
+    assert "basis: semantic:retrieval-doc" in shown
+
+
+def test_generated_matrix_shape_and_never_overwrites_canonical(
+    populated_store: CkmStore,
+    tmp_path: Path,
+) -> None:
+    canonical = Path("docs/architecture/traceability-matrix.md")
+    before = canonical.read_bytes()
+    canonical_header = next(
+        line
+        for line in canonical.read_text(encoding="utf-8").splitlines()
+        if line.startswith("| # | Principle / finding |")
+    )
+    canonical_columns = tuple(part.strip() for part in canonical_header.strip("|").split("|"))
+
+    result = write_projection(populated_store, "ckm-traceability-matrix", tmp_path / "generated")
+    generated_header = next(
+        line
+        for line in result.path.read_text(encoding="utf-8").splitlines()
+        if line.startswith("| # | Principle / finding |")
+    )
+    generated_columns = tuple(part.strip() for part in generated_header.strip("|").split("|"))
+
+    assert canonical_columns == TRACEABILITY_COLUMNS == generated_columns
+    assert result.path == tmp_path / "generated" / "ckm-traceability-matrix.md"
+    assert canonical.read_bytes() == before
+
+
+def test_cli_project_and_show(populated_store: CkmStore, tmp_path: Path) -> None:
+    output_dir = tmp_path / "projections"
+    runner = CliRunner()
+    project = runner.invoke(
+        builderops,
+        [
+            "--db-path",
+            str(populated_store.db_path),
+            "ckm",
+            "project",
+            "--type",
+            "ckm-capability-map",
+            "--out",
+            str(output_dir),
+        ],
+    )
+    shown = runner.invoke(
+        builderops,
+        ["--db-path", str(populated_store.db_path), "ckm", "show", "retrieval"],
+    )
+
+    assert project.exit_code == 0, project.output
+    assert output_dir.joinpath("ckm-capability-map.md").is_file()
+    assert shown.exit_code == 0, shown.output
+    assert "Projection type: ckm-show" in shown.output
+    assert "basis: fixture:confirmed-source" in shown.output


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Closes #3147
Parent validation hub: #3138

## Summary
- Add four watermarked, non-authoritative CKM Markdown projections: capability map, maturity, cited gaps, and a traceability matrix with the canonical column shape.
- Add `python -m app.builderops ckm show <capability-slug>` with stable manifest-slug resolution, an explicit inferred-capability fallback, maturity, freshness, citations, evidence lifecycle, and basis strings.
- Add `python -m app.builderops ckm project --type <type> --out <dir>` with fixed projection-only filenames.
- Keep candidate and confirmed evidence visibly separate and surface assessment staleness through the real projection read path.

## SBS Impact
- Primary subsystem: Builder System (BuilderOps CKM plane)
- Write class: derived projection files under an explicitly selected output directory
- Authority impact: none; every egress self-identifies as non-authoritative
- Persistence: rebuildable/disposable Markdown over rebuildable CKM state
- Product/runtime/GitHub writes from CKM code: none

## Acceptance Evidence
- `tests/builderops/ckm/test_projections.py`: 6 passed, including all four issue-named AC tests and CLI coverage.
- Full CKM suite: 112 passed.
- `ruff check app tests`: passed.
- `mypy app/builderops/ckm app/builderops/cli.py`: 13 source files passed.
- Full `pytest -q -m "not pg"`: 8250 passed, 114 skipped, 85 deselected, 18 xfailed; the same two unrelated baseline failures previously reproduced on clean `origin/main` remained (write-note-relative census and standing-question timestamp format validation).
- Fresh live full pipeline against repo + GitHub: 31 seeded capabilities; 826 docs, 1176 tests, 730 source files, 27 schemas, 3229 commits, 1682 issues, and 1990 PRs ingested; 50 cited findings; all four files plus `ckm show retrieval` rendered and visually inspected.
- Live projections exposed 9212 unlinked artifacts, preserved the canonical matrix file, carried the same current watermark set, and rendered confirmed/candidate counts.
- Review repair validated canonical boundary queries against the live store: `show rca` resolved Retrieval & Context Assembly and `show hix` resolved Human Interaction & Intent.
- Inline-review repair validated traceability routing by both artifact and evidence kind: live Retrieval issue refs appear in Implementation issues and not Contract/schema.
- `git diff --check`: passed.

## Dispatcher / Workspace
- Dispatcher task import was missing after a successful pull, so pickup used the governed GitHub-label-only fallback with reason `dispatcher_task_missing_after_pull`; claimant receipt: issue comment 4970247646.
- Isolated worktree: `/Users/rasmus/workspace/agentic-pkm-mvp-3147`.

## Owner-Doc Writeback
No child-local owner-doc change. The active CKM specification already defines this slice; parent #3138 owns capability acceptance and owner-doc promotion after CKM-10.

## TCD
```yaml
tcd_plan:
  task_summary: Watermarked CKM Markdown projections and CLI query surface
  assumptions: Existing CKM store read models and BuilderOps projection metadata contract remain authoritative
  complexity: medium
  risk: medium
  verification_difficulty: moderate
  human_review_burden: low
  defect_blast_radius: low
  budget_pressure: low
  recommended_capability:
    workflow_or_skill: issue-to-code
    model_family: gpt-5.6-terra
    reasoning_effort: high
    tools: focused pytest, full CKM suite, Ruff, mypy, full not-pg suite, live CKM rebuild, independent review
    github_context_required: true
  cheapest_acceptable_path: One pure projection module plus thin Click commands and contract-focused tests
  escalation_triggers: Canonical overwrite risk, hidden authority promotion, stale assessment omission, or candidate/confirmed collapse
  deescalation_triggers: Pure read/render path remains isolated and all fixture/live outputs agree
  review_gate: Independent exact-head review emphasizing metadata, path safety, lifecycle honesty, and stale rendering
```

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The bounded GitHub issue and PR are the canonical delivery records; live CKM validation used a disposable temporary database and output directory.