### PR TITLE
Document model inquiry host-auth boundary

### DIFF
--- a/.codex/skills/start-model-inquiry/SKILL.md
+++ b/.codex/skills/start-model-inquiry/SKILL.md
@@ -62,6 +62,12 @@ The configured remote host owns the existing Claude and Codex subscription sessi
 and durable inquiry artifacts. `Tailscale_macmini` is an operator-configured SSH host alias, and
 the remote launcher is host-specific operator configuration outside Git.
 
+On the configured host, the Fable command may be mediated by a host-local, GUI-session proxy so a
+non-interactive SSH launch does not need direct login-keychain access. This is an internal remote-host
+authentication path, not a desktop-skill capability: do not configure it, read or copy its credentials
+or certificates, invoke it directly, or substitute a different provider path. If that host path is
+unavailable, preserve the established ambiguous-launcher failure handling below.
+
 The configured remote launcher owns the high-reasoning profile and extended per-role deadline for
 both independent roles. Do not lower or override that profile from the desktop skill, and do not
 move its model or adapter configuration into the local workspace.
@@ -88,6 +94,7 @@ move its model or adapter configuration into the local workspace.
 
 - Do not run local BuilderOps, Python, Codex, or Claude commands for this inquiry.
 - Do not install dependencies, run vault-init, configure adapters, or use API keys.
+- Do not configure, inspect, copy, or print remote-host proxy credentials, certificates, or endpoints.
 - Do not create a GitHub Issue; use the separate promotion path after a ready receipt exists.
 - Do not automate another desktop app or copy turns between apps.
 - Do not write inquiry artifacts to Companion UI or a human knowledge vault.

--- a/claude-skills/start-model-inquiry/SKILL.md
+++ b/claude-skills/start-model-inquiry/SKILL.md
@@ -63,6 +63,12 @@ The configured remote host owns the existing Claude and Codex subscription sessi
 and durable inquiry artifacts. `Tailscale_macmini` is an operator-configured SSH host alias, and
 the remote launcher is host-specific operator configuration outside Git.
 
+On the configured host, the Fable command may be mediated by a host-local, GUI-session proxy so a
+non-interactive SSH launch does not need direct login-keychain access. This is an internal remote-host
+authentication path, not a desktop-skill capability: do not configure it, read or copy its credentials
+or certificates, invoke it directly, or substitute a different provider path. If that host path is
+unavailable, preserve the established ambiguous-launcher failure handling below.
+
 The configured remote launcher owns the high-reasoning profile and extended per-role deadline for
 both independent roles. Do not lower or override that profile from the desktop skill, and do not
 move its model or adapter configuration into the local workspace.
@@ -89,6 +95,7 @@ move its model or adapter configuration into the local workspace.
 
 - Do not run local BuilderOps, Python, Codex, or Claude commands for this inquiry.
 - Do not install dependencies, run vault-init, configure adapters, or use API keys.
+- Do not configure, inspect, copy, or print remote-host proxy credentials, certificates, or endpoints.
 - Do not create a GitHub Issue; use the separate promotion path after a ready receipt exists.
 - Do not automate clicks, keystrokes, windows, tabs, or another desktop app.
 - Do not write model transcripts to Companion UI or a human knowledge vault.

--- a/docs/BUILDEROPS_MODEL_INQUIRY/DESKTOP_SKILL_LAUNCHERS.md
+++ b/docs/BUILDEROPS_MODEL_INQUIRY/DESKTOP_SKILL_LAUNCHERS.md
@@ -33,7 +33,10 @@ profile is versioned with the BuilderOps command. That profile gives both roles 
 effort and a bounded extended deadline. Neither skill rebuilds that environment, configures
 providers, or reimplements orchestration in prompt prose.
 
-The operator machine needs the `Tailscale_macmini` SSH alias. A failed copy or SSH command, empty
+The operator machine needs the `Tailscale_macmini` SSH alias. The remote host may internally mediate
+the Fable command through a GUI-session proxy so the SSH child does not directly depend on login-keychain
+access. That authentication path is host-specific operator configuration outside Git; desktop skill
+packages neither configure it nor access its credentials, certificates, or endpoint. A failed copy or SSH command, empty
 stdout, malformed JSON, or absent response field fails loudly: report the error and stop. Do not
 retry, inspect the vault for a substitute response, or fall back to an in-chat inquiry.
 


### PR DESCRIPTION
## Direct Repair
Type: governance
Reason: Bounded clarification of the host-local authentication boundary in the paired Codex and Claude model-inquiry skills.
Validation: python3 scripts/lint_skills_consistency.py; pytest -q tests/governance/test_start_model_inquiry_skill.py; python3 scripts/docs_guard.py; git diff --check origin/main...HEAD
Issue required: no

## Change Lane
- [ ] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue


## SBS Impact
- Primary subsystem: Builder System
- Secondary subsystem(s): Model-inquiry skill guidance, desktop launcher documentation
- Write class: governance/documentation
- Authority impact: no change; host authentication remains outside the repository and is owned by the configured host
- Persistence impact: none; no credential or runtime state is added to the repository
- Derived/rebuildable impact: unaffected
- Human knowledge impact: agents receive an explicit safe boundary for host-local authentication mediation
- Memory impact: unaffected
- Retrieval/context impact: improves skill guidance for remote desktop inquiry execution
- Sync/deployment impact: repository governance publication only
- External boundary impact: documents the boundary without exposing or configuring any host endpoint, certificate, or credential
- New or changed contract: skills must treat configured host auth mediation as internal and must not inspect, copy, or configure its secrets or endpoint
- Owner-doc impact: docs/BUILDEROPS_MODEL_INQUIRY/DESKTOP_SKILL_LAUNCHERS.md updated
- Transition debt impact: reduces repeated host-auth troubleshooting and unsafe credential handling by agents
- Fitness rule impact: existing skill consistency and targeted governance tests remain applicable
- Boundary risk: low; documentation-only change with no runtime behavior change

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Document the safe host-local authentication boundary used when desktop model inquiries invoke the configured remote host.

## Implementation Scope Check
- [ ] Change stays within the linked Issue scope.
- [ ] Constraints from the linked Issue were followed.
- [ ] Acceptance Criteria from the linked Issue are satisfied.
- [ ] Docs were updated in the same change when behavior/contracts changed.
- [ ] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [ ] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [ ] No product/runtime implementation or shipped feature behavior changed.

## Validation
Direct repair:
- [x] python3 scripts/lint_skills_consistency.py; pytest -q tests/governance/test_start_model_inquiry_skill.py; python3 scripts/docs_guard.py; git diff --check origin/main...HEAD

## BuilderOps Routing
- Records/projections/receipts: lrn_20260714144705_6118559e
- Reason: Captures the desktop-skill host-auth-boundary divergence and its correction.

## Notes
No host endpoint, certificate, credential, or proxy configuration is committed.