### PR TITLE
CKM-10: add self-contained development overview

### DIFF
--- a/app/builderops/ckm/overview_html.py
+++ b/app/builderops/ckm/overview_html.py
@@ -1,0 +1,270 @@
+"""Self-contained, non-authoritative HTML overview for the CKM."""
+
+from __future__ import annotations
+
+from html import escape
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from app.builderops.ckm.models import (
+    MATURITY_DIMENSIONS,
+    CkmCapability,
+    CkmEvidenceEdge,
+    CkmFinding,
+    utc_now,
+)
+from app.builderops.ckm.store import CkmStore
+
+
+def _e(value: object) -> str:
+    return escape(str(value), quote=True)
+
+
+def _watermarks(values: Mapping[str, str]) -> str:
+    if not values:
+        return "none"
+    return ", ".join(f"{_e(key)}={_e(value)}" for key, value in sorted(values.items()))
+
+
+def _forest(capabilities: Sequence[CkmCapability]) -> list[tuple[int, CkmCapability]]:
+    known = {item.id for item in capabilities}
+    children: dict[str | None, list[CkmCapability]] = {}
+    for item in capabilities:
+        parent = item.parent_id if item.parent_id in known else None
+        children.setdefault(parent, []).append(item)
+    for values in children.values():
+        values.sort(key=lambda item: (item.name.casefold(), item.id))
+    result: list[tuple[int, CkmCapability]] = []
+    visited: set[str] = set()
+
+    def visit(item: CkmCapability, depth: int) -> None:
+        if item.id in visited:
+            return
+        visited.add(item.id)
+        result.append((depth, item))
+        for child in children.get(item.id, []):
+            visit(child, depth + 1)
+
+    for root in children.get(None, []):
+        visit(root, 0)
+    for item in sorted(capabilities, key=lambda value: (value.name.casefold(), value.id)):
+        visit(item, 0)
+    return result
+
+
+def _band(aggregate: float | None) -> str:
+    if aggregate is None:
+        return "unknown"
+    if aggregate < 0.4:
+        return "critical"
+    if aggregate < 0.7:
+        return "watch"
+    return "healthy"
+
+
+def _edge_counts(edges: Sequence[CkmEvidenceEdge]) -> tuple[int, int]:
+    return (
+        sum(edge.lifecycle == "confirmed" for edge in edges),
+        sum(edge.lifecycle == "candidate" for edge in edges),
+    )
+
+
+def _citation_source(citation: Mapping[str, object]) -> str:
+    source_ref = citation.get("source_ref")
+    artifact = citation.get("artifact")
+    if source_ref is None and isinstance(artifact, Mapping):
+        source_ref = artifact.get("source_ref")
+    lifecycle = citation.get("lifecycle")
+    edge = citation.get("edge")
+    if lifecycle is None and isinstance(edge, Mapping):
+        lifecycle = edge.get("lifecycle")
+    suffix = f" · {lifecycle}" if lifecycle in {"candidate", "confirmed"} else ""
+    return f"{source_ref or 'evidence snapshot'}{suffix}"
+
+
+def _dimension_markup(
+    dimension: str,
+    score: float,
+    citations: Sequence[Mapping[str, object]],
+    candidate_share: float,
+) -> str:
+    percent = max(0.0, min(100.0, score * 100.0))
+    citation_items = "".join(
+        f"<li>{_e(_citation_source(citation))}</li>" for citation in citations
+    ) or "<li>No selected citations.</li>"
+    return f"""
+      <section class="dimension" data-dimension="{_e(dimension)}">
+        <div class="dimension-label"><span>{_e(dimension.replace('_', ' '))}</span><strong>{score:.2f}</strong></div>
+        <div class="dimension-track" role="progressbar" aria-label="{_e(dimension)}" aria-valuemin="0" aria-valuemax="1" aria-valuenow="{score:.3f}">
+          <span class="dimension-bar" style="width:{percent:.1f}%"></span>
+        </div>
+        <small>{len(citations)} citation(s) · candidate share {candidate_share:.1%}</small>
+        <details class="citations"><summary>Citations</summary><ul>{citation_items}</ul></details>
+      </section>"""
+
+
+def _evidence_markup(edges: Sequence[CkmEvidenceEdge]) -> str:
+    if not edges:
+        return '<p class="empty">No linked evidence.</p>'
+    items = []
+    for edge in sorted(edges, key=lambda item: (item.lifecycle, item.source_ref, item.id)):
+        items.append(
+            f"""<li class="evidence evidence-{_e(edge.lifecycle)}">
+              <span class="badge">{_e(edge.lifecycle)}</span>
+              <code>{_e(edge.evidence_kind)}</code> · {_e(edge.source_ref)}
+              <div class="basis">Basis: {_e(edge.basis)}</div>
+            </li>"""
+        )
+    return f"<ul class=\"evidence-list\">{''.join(items)}</ul>"
+
+
+def _finding_markup(findings: Sequence[CkmFinding]) -> str:
+    if not findings:
+        return '<p class="empty">No current findings.</p>'
+    return "<ul class=\"finding-list\">" + "".join(
+        f"<li><span class=\"badge\">{_e(item.kind)}</span> "
+        f"<strong>{_e(item.dimension.replace('_', ' '))}</strong>: {_e(item.statement)} "
+        f"<small>({len(item.citations)} citation(s))</small></li>"
+        for item in findings
+    ) + "</ul>"
+
+
+def _capability_markup(
+    store: CkmStore,
+    capability: CkmCapability,
+    *,
+    depth: int,
+) -> str:
+    edges = store.list_evidence_edges_for_capability(capability.id)
+    findings = store.list_findings_for_capability(capability.id)
+    confirmed, candidate = _edge_counts(edges)
+    assessment = store.latest_assessment_for_capability(capability.id)
+    projection = store.assessment_for_projection(capability.id) if assessment else None
+    aggregate = float(assessment.aggregate) if assessment else None
+    band = _band(aggregate)
+    flags: list[str] = []
+    if projection and projection.stale_relative_to_evidence:
+        flags.append('<span class="flag flag-stale">STALE relative to evidence</span>')
+    if assessment and assessment.low_confidence:
+        flags.append('<span class="flag flag-low">LOW CONFIDENCE</span>')
+    max_candidate_share = max(assessment.candidate_shares.values()) if assessment else 0.0
+    flags.append(
+        f'<span class="flag flag-candidate">candidate share {max_candidate_share:.1%}</span>'
+    )
+    dimensions = ""
+    if assessment:
+        dimensions = "".join(
+            _dimension_markup(
+                dimension,
+                float(assessment.scores[dimension]),
+                assessment.citations[dimension],
+                float(assessment.candidate_shares[dimension]),
+            )
+            for dimension in MATURITY_DIMENSIONS
+        )
+    else:
+        dimensions = '<p class="empty">Assessment missing.</p>'
+    aggregate_text = f"{aggregate:.2f}" if aggregate is not None else "not assessed"
+    return f"""
+    <article class="capability band-{band}" data-capability-id="{_e(capability.id)}" data-aggregate-band="{band}" style="--depth:{depth}">
+      <details>
+        <summary>
+          <span class="tree-name">{_e(capability.name)}</span>
+          <span class="aggregate">{_e(aggregate_text)}</span>
+          <span class="lifecycle">{_e(capability.lifecycle)}</span>
+        </summary>
+        <div class="capability-body">
+          <p>{_e(capability.definition)}</p>
+          <p>Boundary: <strong>{_e(capability.boundary_ref or '—')}</strong> · Evidence: <strong>{confirmed} confirmed / {candidate} candidate</strong></p>
+          <div class="flags">{''.join(flags)}</div>
+          <div class="dimensions">{dimensions}</div>
+          <details class="drilldown"><summary>Evidence and basis</summary>{_evidence_markup(edges)}</details>
+          <details class="drilldown"><summary>Findings</summary>{_finding_markup(findings)}</details>
+        </div>
+      </details>
+    </article>"""
+
+
+def render_overview_html(
+    store: CkmStore,
+    *,
+    generated_at: str | None = None,
+) -> str:
+    """Render one self-contained CKM projection without mutating the store."""
+
+    timestamp = generated_at or utc_now()
+    capabilities = store.list_capabilities()
+    capability_by_id = {item.id: item for item in capabilities}
+    all_findings = store.list_findings()
+    cards = "".join(
+        _capability_markup(store, capability, depth=depth)
+        for depth, capability in _forest(capabilities)
+    ) or '<p class="empty">No capabilities in the CKM store.</p>'
+    gap_items = "".join(
+        f"<li><span class=\"badge\">{_e(item.kind)}</span> "
+        f"<strong>{_e(capability_by_id[item.capability_id].name if item.capability_id in capability_by_id else item.capability_id)}</strong> · "
+        f"{_e(item.dimension.replace('_', ' '))}: {_e(item.statement)}</li>"
+        for item in all_findings
+    ) or "<li>No current findings.</li>"
+    watermark_text = _watermarks(store.current_watermark_set())
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>CKM Development Overview</title>
+  <style>
+    :root {{ color-scheme: light dark; --bg:#0b1020; --panel:#141b2d; --text:#eef2ff; --muted:#a9b4ca; --line:#33405d; --critical:#ef4444; --watch:#f59e0b; --healthy:#22c55e; --unknown:#64748b; }}
+    * {{ box-sizing:border-box; }}
+    body {{ margin:0; background:var(--bg); color:var(--text); font:15px/1.5 ui-sans-serif,system-ui,sans-serif; }}
+    main, footer {{ width:min(1180px,calc(100% - 32px)); margin:0 auto; }}
+    header {{ padding:38px 0 20px; }} h1,h2 {{ margin:.2em 0; }} .subtitle,.empty,small {{ color:var(--muted); }}
+    .legend,.flags {{ display:flex; gap:8px; flex-wrap:wrap; margin:10px 0; }}
+    .legend span,.flag,.badge,.lifecycle,.aggregate {{ border:1px solid var(--line); border-radius:999px; padding:2px 8px; font-size:12px; }}
+    .capability {{ margin:8px 0 8px calc(var(--depth) * 22px); border:1px solid var(--line); border-left:5px solid var(--unknown); border-radius:10px; background:var(--panel); }}
+    .band-critical {{ border-left-color:var(--critical); }} .band-watch {{ border-left-color:var(--watch); }} .band-healthy {{ border-left-color:var(--healthy); }}
+    summary {{ cursor:pointer; }} .capability > details > summary {{ display:flex; gap:10px; align-items:center; padding:12px 14px; }}
+    .tree-name {{ flex:1; font-weight:700; }} .capability-body {{ border-top:1px solid var(--line); padding:14px; }}
+    .dimensions {{ display:grid; grid-template-columns:repeat(auto-fit,minmax(230px,1fr)); gap:10px; margin:14px 0; }}
+    .dimension {{ border:1px solid var(--line); border-radius:8px; padding:10px; }} .dimension-label {{ display:flex; justify-content:space-between; gap:8px; }}
+    .dimension-track {{ height:8px; margin:7px 0; border-radius:8px; background:#25304a; overflow:hidden; }} .dimension-bar {{ display:block; height:100%; background:#60a5fa; }}
+    .flag-stale,.flag-low {{ border-color:var(--watch); color:#fbbf24; }} .flag-candidate {{ border-color:#60a5fa; }}
+    .drilldown,.citations {{ margin-top:10px; }} .evidence-list,.finding-list {{ padding-left:20px; }} .evidence-list li,.finding-list li {{ margin:7px 0; }} .basis {{ color:var(--muted); margin-left:8px; }}
+    .gaps-panel {{ margin:24px 0; padding:16px; border:1px solid var(--line); border-radius:10px; background:var(--panel); }}
+    footer {{ margin-top:28px; padding:18px 0 36px; border-top:1px solid var(--line); color:var(--muted); overflow-wrap:anywhere; }}
+    @media (max-width:650px) {{ .capability {{ margin-left:calc(var(--depth) * 8px); }} .capability > details > summary {{ align-items:flex-start; flex-wrap:wrap; }} }}
+  </style>
+</head>
+<body>
+  <main>
+    <header><h1>Development Overview</h1><p class="subtitle">Capability Knowledge Model maturity heatmap and cited drill-down.</p></header>
+    <section aria-labelledby="map-heading">
+      <h2 id="map-heading">Capability map</h2>
+      <div class="legend"><span>healthy ≥ 0.70</span><span>watch 0.40–0.69</span><span>critical &lt; 0.40</span><span>unknown</span></div>
+      <div class="capability-tree">{cards}</div>
+    </section>
+    <section class="gaps-panel" aria-labelledby="gaps-heading"><h2 id="gaps-heading">Current gaps</h2><ul>{gap_items}</ul></section>
+  </main>
+  <footer class="projection-footer">
+    <strong>Generated projection (BuilderOps CKM). Not source of truth.</strong><br>
+    Generated: {_e(timestamp)}<br>
+    Watermarks: {watermark_text}<br>
+    Candidate and confirmed evidence remain distinct. Regenerate from the CKM store; do not edit this file as authority.
+  </footer>
+</body>
+</html>
+"""
+
+
+def write_overview_html(
+    store: CkmStore,
+    output_path: Path,
+    *,
+    generated_at: str | None = None,
+) -> Path:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        render_overview_html(store, generated_at=generated_at),
+        encoding="utf-8",
+    )
+    return output_path

--- a/app/builderops/ckm/overview_html.py
+++ b/app/builderops/ckm/overview_html.py
@@ -103,6 +103,30 @@ def _dimension_markup(
       </section>"""
 
 
+def _mini_dimensions_markup(scores: Mapping[str, float] | None) -> str:
+    """Render the seven maturity dimensions in the always-visible card summary."""
+
+    bars = []
+    for dimension in MATURITY_DIMENSIONS:
+        score = float(scores[dimension]) if scores is not None else None
+        percent = max(0.0, min(100.0, score * 100.0)) if score is not None else 0.0
+        label = (
+            f"{dimension.replace('_', ' ')}: {score:.2f}"
+            if score is not None
+            else f"{dimension.replace('_', ' ')}: not assessed"
+        )
+        bars.append(
+            f'<span class="mini-dimension{" mini-unknown" if score is None else ""}" '
+            f'title="{_e(label)}" aria-label="{_e(label)}" '
+            f'style="--score:{percent:.1f}%"></span>'
+        )
+    return (
+        '<span class="mini-dimensions" aria-label="Seven-dimension maturity">'
+        + "".join(bars)
+        + "</span>"
+    )
+
+
 def _evidence_markup(edges: Sequence[CkmEvidenceEdge]) -> str:
     if not edges:
         return '<p class="empty">No linked evidence.</p>'
@@ -147,10 +171,13 @@ def _capability_markup(
         flags.append('<span class="flag flag-stale">STALE relative to evidence</span>')
     if assessment and assessment.low_confidence:
         flags.append('<span class="flag flag-low">LOW CONFIDENCE</span>')
-    max_candidate_share = max(assessment.candidate_shares.values()) if assessment else 0.0
-    flags.append(
-        f'<span class="flag flag-candidate">candidate share {max_candidate_share:.1%}</span>'
-    )
+    if assessment:
+        max_candidate_share = max(assessment.candidate_shares.values())
+        flags.append(
+            f'<span class="flag flag-candidate">candidate share {max_candidate_share:.1%}</span>'
+        )
+    else:
+        flags.append('<span class="flag flag-candidate">candidate share unavailable</span>')
     dimensions = ""
     if assessment:
         dimensions = "".join(
@@ -170,6 +197,7 @@ def _capability_markup(
       <details>
         <summary>
           <span class="tree-name">{_e(capability.name)}</span>
+          {_mini_dimensions_markup(assessment.scores if assessment else None)}
           <span class="aggregate">{_e(aggregate_text)}</span>
           <span class="lifecycle">{_e(capability.lifecycle)}</span>
         </summary>
@@ -225,6 +253,9 @@ def render_overview_html(
     .band-critical {{ border-left-color:var(--critical); }} .band-watch {{ border-left-color:var(--watch); }} .band-healthy {{ border-left-color:var(--healthy); }}
     summary {{ cursor:pointer; }} .capability > details > summary {{ display:flex; gap:10px; align-items:center; padding:12px 14px; }}
     .tree-name {{ flex:1; font-weight:700; }} .capability-body {{ border-top:1px solid var(--line); padding:14px; }}
+    .mini-dimensions {{ display:grid; grid-template-columns:repeat(7,18px); gap:3px; }}
+    .mini-dimension {{ width:18px; height:8px; border-radius:8px; background:linear-gradient(to right,#60a5fa var(--score),#25304a var(--score)); }}
+    .mini-unknown {{ background:var(--unknown); opacity:.55; }}
     .dimensions {{ display:grid; grid-template-columns:repeat(auto-fit,minmax(230px,1fr)); gap:10px; margin:14px 0; }}
     .dimension {{ border:1px solid var(--line); border-radius:8px; padding:10px; }} .dimension-label {{ display:flex; justify-content:space-between; gap:8px; }}
     .dimension-track {{ height:8px; margin:7px 0; border-radius:8px; background:#25304a; overflow:hidden; }} .dimension-bar {{ display:block; height:100%; background:#60a5fa; }}
@@ -232,7 +263,7 @@ def render_overview_html(
     .drilldown,.citations {{ margin-top:10px; }} .evidence-list,.finding-list {{ padding-left:20px; }} .evidence-list li,.finding-list li {{ margin:7px 0; }} .basis {{ color:var(--muted); margin-left:8px; }}
     .gaps-panel {{ margin:24px 0; padding:16px; border:1px solid var(--line); border-radius:10px; background:var(--panel); }}
     footer {{ margin-top:28px; padding:18px 0 36px; border-top:1px solid var(--line); color:var(--muted); overflow-wrap:anywhere; }}
-    @media (max-width:650px) {{ .capability {{ margin-left:calc(var(--depth) * 8px); }} .capability > details > summary {{ align-items:flex-start; flex-wrap:wrap; }} }}
+    @media (max-width:650px) {{ .capability {{ margin-left:calc(var(--depth) * 8px); }} .capability > details > summary {{ align-items:flex-start; flex-wrap:wrap; }} .mini-dimensions {{ order:4; width:100%; }} }}
   </style>
 </head>
 <body>

--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -31,6 +31,7 @@ from app.builderops.ckm.gaps import GapDetectionConfig, detect_gaps
 from app.builderops.ckm.ingest_github import ingest_github
 from app.builderops.ckm.ingest_repo import ingest_repo
 from app.builderops.ckm.linkers import link_deterministic
+from app.builderops.ckm.overview_html import write_overview_html
 from app.builderops.ckm.projections import (
     PROJECTION_FILENAMES as CKM_PROJECTION_FILENAMES,
     render_capability_show,
@@ -579,6 +580,24 @@ def ckm_project(ctx: click.Context, projection_type: str, output_dir: Path) -> N
     except (CkmValidationError, OSError, sqlite3.Error) as exc:
         raise click.ClickException(f"ckm projection failed: {exc}") from exc
     click.echo(f"{result.projection_type}\t{result.path}")
+
+
+@ckm.command("overview", help="Write the self-contained CKM Development Overview HTML.")
+@click.option(
+    "--out",
+    "output_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    required=True,
+)
+@click.pass_context
+def ckm_overview(ctx: click.Context, output_path: Path) -> None:
+    try:
+        store = _ckm_store(ctx)
+        store.ensure_schema()
+        result = write_overview_html(store, output_path)
+    except (OSError, sqlite3.Error) as exc:
+        raise click.ClickException(f"ckm overview failed: {exc}") from exc
+    click.echo(result)
 
 
 @builderops.group("inquiry", help="Persist and inspect pre-ticket model inquiry artifacts.")

--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -593,9 +593,10 @@ def ckm_project(ctx: click.Context, projection_type: str, output_dir: Path) -> N
 def ckm_overview(ctx: click.Context, output_path: Path) -> None:
     try:
         store = _ckm_store(ctx)
-        store.ensure_schema()
+        if not store.db_path.is_file():
+            raise CkmValidationError(f"CKM database does not exist: {store.db_path}")
         result = write_overview_html(store, output_path)
-    except (OSError, sqlite3.Error) as exc:
+    except (CkmValidationError, OSError, sqlite3.Error) as exc:
         raise click.ClickException(f"ckm overview failed: {exc}") from exc
     click.echo(result)
 

--- a/docs/CAPABILITY_KNOWLEDGE_MODEL/README.md
+++ b/docs/CAPABILITY_KNOWLEDGE_MODEL/README.md
@@ -57,11 +57,11 @@ Partial-failure walk: seed applied but ingestion fails → registry exists with 
 
 ## Acceptance criteria (capability level)
 
-- [ ] The CEG exists in the BuilderOps store, seeded from SBS + Capability Contract Model, populated with evidence from repo + GitHub sources, and rebuildable from scratch. Verify: `tests/builderops/ckm/test_rebuild_roundtrip.py::test_drop_and_rebuild_reproduces_graph`
-- [ ] Every capability has a seven-dimension assessment where every dimension cites its evidence, with candidate/confirmed share visible. Verify: `tests/builderops/ckm/test_assessment_engine.py::test_every_dimension_cites_evidence`
-- [ ] Gap and missing-evidence findings are generated and specific (capability + dimension + citation). Verify: `tests/builderops/ckm/test_gap_detection.py::test_findings_name_capability_dimension_and_citation`
-- [ ] Projections + CLI + HTML overview exist, self-identify as projections, and carry watermarks. Verify: `tests/builderops/ckm/test_projections.py::test_all_egress_self_identifies_with_watermark`
-- [ ] The orthogonality contract holds on the live path. Verify: `tests/builderops/ckm/test_evidence_kind_orthogonality.py::test_ckm_never_touches_runtime_evidence_role`
+- [x] The CEG exists in the BuilderOps store, seeded from SBS + Capability Contract Model, populated with evidence from repo + GitHub sources, and rebuildable from scratch. Verify: `tests/builderops/ckm/test_rebuild_roundtrip.py::test_drop_and_rebuild_reproduces_graph`
+- [x] Every capability has a seven-dimension assessment where every dimension cites its evidence, with candidate/confirmed share visible. Verify: `tests/builderops/ckm/test_assessment_engine.py::test_every_dimension_cites_evidence`
+- [x] Gap and missing-evidence findings are generated and specific (capability + dimension + citation). Verify: `tests/builderops/ckm/test_gap_detection.py::test_findings_name_capability_dimension_and_citation`
+- [x] Projections + CLI + HTML overview exist, self-identify as projections, and carry watermarks. Verify: `tests/builderops/ckm/test_projections.py::test_all_egress_self_identifies_with_watermark` and `tests/builderops/ckm/test_overview_html.py::test_projection_footer_always_present`
+- [x] The orthogonality contract holds on the live path. Verify: `tests/builderops/ckm/test_evidence_kind_orthogonality.py::test_ckm_never_touches_runtime_evidence_role`
 - [ ] Owner has viewed the Development Overview against the real repo and the parent issue records the validation receipt. Verify: parent feature issue validation comment (operator receipt)
 
 ## Relationship to GitHub issues

--- a/tests/builderops/ckm/test_overview_html.py
+++ b/tests/builderops/ckm/test_overview_html.py
@@ -129,6 +129,8 @@ def test_pure_render_over_fixture_graph(overview_store: CkmStore) -> None:
     assert 'style="--depth:1"' in first
     assert 'data-aggregate-band="healthy"' in first
     assert first.count('class="dimension-bar"') == len(MATURITY_DIMENSIONS)
+    summary = first.split("</summary>", maxsplit=1)[0]
+    assert summary.count('class="mini-dimension"') == len(MATURITY_DIMENSIONS)
     assert '<details class="drilldown"><summary>Evidence and basis</summary>' in first
     assert "Retrieval needs stronger test evidence." in first
 
@@ -139,6 +141,8 @@ def test_honesty_markers_render(overview_store: CkmStore) -> None:
     assert "STALE relative to evidence" in rendered
     assert "LOW CONFIDENCE" in rendered
     assert "candidate share 75.0%" in rendered
+    assert "candidate share unavailable" in rendered
+    assert rendered.count('mini-dimension mini-unknown') == len(MATURITY_DIMENSIONS)
     assert "2 confirmed / 1 candidate" not in rendered
     assert "1 confirmed / 1 candidate" in rendered
     assert '<span class="badge">candidate</span>' in rendered
@@ -159,7 +163,6 @@ def test_projection_footer_always_present(tmp_path: Path, overview_store: CkmSto
         assert "Generated: 2026-07-14T15:00:00Z" in rendered
         assert "Watermarks:" in rendered
         assert "Candidate and confirmed evidence remain distinct." in rendered
-
 
 def test_no_external_references(overview_store: CkmStore) -> None:
     rendered = render_overview_html(overview_store)
@@ -190,3 +193,18 @@ def test_cli_writes_overview(overview_store: CkmStore, tmp_path: Path) -> None:
     assert result.exit_code == 0, result.output
     assert output.is_file()
     assert "Development Overview" in output.read_text(encoding="utf-8")
+
+
+def test_cli_rejects_missing_database_without_creating_it(tmp_path: Path) -> None:
+    database = tmp_path / "missing" / "ckm.sqlite3"
+    output = tmp_path / "ckm-overview.html"
+
+    result = CliRunner().invoke(
+        builderops,
+        ["--db-path", str(database), "ckm", "overview", "--out", str(output)],
+    )
+
+    assert result.exit_code != 0
+    assert "CKM database does not exist" in result.output
+    assert not database.exists()
+    assert not output.exists()

--- a/tests/builderops/ckm/test_overview_html.py
+++ b/tests/builderops/ckm/test_overview_html.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from app.builderops.cli import builderops
+from app.builderops.ckm.models import MATURITY_DIMENSIONS
+from app.builderops.ckm.overview_html import render_overview_html
+from app.builderops.ckm.store import CkmStore
+
+
+@pytest.fixture()
+def overview_store(tmp_path: Path) -> CkmStore:
+    store = CkmStore(tmp_path / "overview.sqlite3")
+    store.ensure_schema()
+    store.set_watermark("fixture", "one")
+    parent = store.upsert_capability(
+        name="Retrieval",
+        definition="Retrieve grounded context.",
+        existence_provenance="seeded:fixture",
+        lifecycle="confirmed",
+        boundary_ref="RCA",
+    )
+    store.upsert_capability(
+        name="Context Assembly",
+        definition="Assemble a bounded context bundle.",
+        existence_provenance="seeded:fixture-child",
+        lifecycle="confirmed",
+        parent_id=parent.id,
+        boundary_ref="RCA",
+    )
+    confirmed_artifact = store.upsert_artifact(
+        source_ref="app/retrieval.py",
+        artifact_kind="source_file",
+        source="fixture",
+        watermark="one",
+        provenance='{"source_ref":"app/retrieval.py"}',
+    )
+    confirmed_edge = store.upsert_evidence_edge(
+        artifact_id=confirmed_artifact.id,
+        capability_id=parent.id,
+        evidence_kind="source",
+        polarity="supports",
+        maturity_dimension="functional_completeness",
+        confidence=1.0,
+        extraction_method="deterministic",
+        lifecycle="confirmed",
+        source_ref=confirmed_artifact.source_ref,
+        basis="fixture:confirmed-source",
+    )
+    candidate_artifact = store.upsert_artifact(
+        source_ref="docs/retrieval-draft.md",
+        artifact_kind="document",
+        source="fixture",
+        watermark="one",
+        provenance='{"source_ref":"docs/retrieval-draft.md"}',
+    )
+    store.upsert_evidence_edge(
+        artifact_id=candidate_artifact.id,
+        capability_id=parent.id,
+        evidence_kind="doc",
+        polarity="supports",
+        maturity_dimension="documentation_quality",
+        confidence=0.7,
+        extraction_method="inferred",
+        lifecycle="candidate",
+        source_ref=candidate_artifact.source_ref,
+        basis="semantic:retrieval-draft",
+        model="fixture-model",
+        provider="fixture-provider",
+    )
+    citation = {
+        "edge_id": confirmed_edge.id,
+        "artifact_id": confirmed_artifact.id,
+        "source_ref": confirmed_artifact.source_ref,
+        "lifecycle": confirmed_edge.lifecycle,
+        "edge": confirmed_edge.to_dict(),
+        "artifact": confirmed_artifact.to_dict(),
+    }
+    store.append_assessment(
+        capability_id=parent.id,
+        scores={dimension: 0.8 for dimension in MATURITY_DIMENSIONS},
+        citations={dimension: [citation] for dimension in MATURITY_DIMENSIONS},
+        candidate_shares={dimension: 0.75 for dimension in MATURITY_DIMENSIONS},
+        formula_ids={dimension: "fixture-formula" for dimension in MATURITY_DIMENSIONS},
+        aggregate=0.8,
+        aggregate_formula_id="fixture-aggregate",
+        low_confidence=True,
+        edge_fingerprint="fixture-fingerprint",
+        watermark_set={"fixture": "one"},
+    )
+    store.upsert_finding(
+        kind="gap",
+        capability_id=parent.id,
+        dimension="test_completeness",
+        statement="Retrieval needs stronger test evidence.",
+        citations=[citation],
+    )
+    store.set_watermark("fixture", "two")
+    return store
+
+
+def test_pure_render_over_fixture_graph(overview_store: CkmStore) -> None:
+    before = (
+        overview_store.list_capabilities(),
+        overview_store.list_evidence_edges(),
+        overview_store.list_findings(),
+    )
+    first = render_overview_html(
+        overview_store,
+        generated_at="2026-07-14T15:00:00Z",
+    )
+    second = render_overview_html(
+        overview_store,
+        generated_at="2026-07-14T15:00:00Z",
+    )
+
+    assert first == second
+    assert before == (
+        overview_store.list_capabilities(),
+        overview_store.list_evidence_edges(),
+        overview_store.list_findings(),
+    )
+    assert '<div class="capability-tree">' in first
+    assert "Retrieval" in first and "Context Assembly" in first
+    assert 'style="--depth:1"' in first
+    assert 'data-aggregate-band="healthy"' in first
+    assert first.count('class="dimension-bar"') == len(MATURITY_DIMENSIONS)
+    assert '<details class="drilldown"><summary>Evidence and basis</summary>' in first
+    assert "Retrieval needs stronger test evidence." in first
+
+
+def test_honesty_markers_render(overview_store: CkmStore) -> None:
+    rendered = render_overview_html(overview_store)
+
+    assert "STALE relative to evidence" in rendered
+    assert "LOW CONFIDENCE" in rendered
+    assert "candidate share 75.0%" in rendered
+    assert "2 confirmed / 1 candidate" not in rendered
+    assert "1 confirmed / 1 candidate" in rendered
+    assert '<span class="badge">candidate</span>' in rendered
+    assert "Basis: semantic:retrieval-draft" in rendered
+
+
+def test_projection_footer_always_present(tmp_path: Path, overview_store: CkmStore) -> None:
+    empty = CkmStore(tmp_path / "empty.sqlite3")
+    empty.ensure_schema()
+
+    for store in (overview_store, empty):
+        rendered = render_overview_html(
+            store,
+            generated_at="2026-07-14T15:00:00Z",
+        )
+        assert '<footer class="projection-footer">' in rendered
+        assert "Generated projection (BuilderOps CKM). Not source of truth." in rendered
+        assert "Generated: 2026-07-14T15:00:00Z" in rendered
+        assert "Watermarks:" in rendered
+        assert "Candidate and confirmed evidence remain distinct." in rendered
+
+
+def test_no_external_references(overview_store: CkmStore) -> None:
+    rendered = render_overview_html(overview_store)
+
+    assert not re.search(r"<(?:script|link|img)\b", rendered, flags=re.IGNORECASE)
+    assert not re.search(
+        r"(?:src|href)\s*=\s*['\"](?:https?:)?//",
+        rendered,
+        flags=re.IGNORECASE,
+    )
+    assert "<style>" in rendered
+
+
+def test_cli_writes_overview(overview_store: CkmStore, tmp_path: Path) -> None:
+    output = tmp_path / "delivery" / "ckm-overview.html"
+    result = CliRunner().invoke(
+        builderops,
+        [
+            "--db-path",
+            str(overview_store.db_path),
+            "ckm",
+            "overview",
+            "--out",
+            str(output),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert output.is_file()
+    assert "Development Overview" in output.read_text(encoding="utf-8")


### PR DESCRIPTION
## Change Lane

Implementation

## Linked Issue

Closes #3148

Parent validation hub: #3138

## Summary

- add a deterministic, self-contained CKM Development Overview HTML renderer
- expose the projection through `ckm overview --out FILE`
- show the capability hierarchy, always-visible seven-dimension maturity bars, aggregate bands, confidence and staleness markers, evidence basis, citations, findings, and gaps
- keep the overview command read-only and fail clearly when its CKM database is absent
- document the delivered projection while leaving the human owner-view criterion explicitly pending

## SBS Impact

No runtime system-boundary change. This is a read-only BuilderOps projection over the CKM store. The renderer and CLI command perform no schema or source-data writes.

## Acceptance Evidence

- `pytest -q tests/builderops/ckm/test_overview_html.py`: 6 passed
- `pytest -q tests/builderops/ckm`: 118 passed
- `ruff check app tests`: passed
- `mypy app/builderops/ckm app/builderops/cli.py`: passed (14 source files)
- `git diff --check`: passed
- `pytest -q -m "not pg"`: 8256 passed, 114 skipped, 85 deselected, 18 xfailed; two known clean-main baseline failures remain outside this issue: write_note_relative call-site census and standing-questions timestamp validation
- live projection generated from a CKM store containing 31 capabilities and 50 cited findings
- self-contained live-artifact check found no script, link, img, remote src, or remote href
- visual inspection covered the initial hierarchy heatmap with seven visible dimension bars per capability and the expanded evidence/finding drill-down
- owner artifact: `/Users/rasmus/Desktop/ckm-overview.html` SHA-256 `94f45944c122ea30fb1af3d819b09deb8b84b5c71516139b69ba332a9eb63707`
- screenshot: `/Users/rasmus/Desktop/ckm-overview.png` SHA-256 `cdbd7f1846002ab1a10f617c7f69214b1b1ddc35255d0595ea2870eba78f017d`

## Review Repair

Independent review of the original head rejected hidden maturity dimensions, schema creation on a missing database, and a misleading zero candidate-share marker. Exact head `3afb1a58f8ddee1af2f8db745e20a40d648f30f1` repairs all three and adds regression tests.

## Dispatcher / Workspace

Dispatcher pull did not materialize task #3148, so the governed GitHub-label-only fallback was used with claimant receipt on the issue. Work was completed in isolated worktree `/Users/rasmus/workspace/agentic-pkm-mvp-3148`.

## Owner-Doc Writeback

`docs/CAPABILITY_KNOWLEDGE_MODEL/README.md` now records the delivered machine-verifiable overview criteria. The owner-view criterion remains unchecked until the owner validation receipt is posted on #3138.

## TCD Review

```yaml
tcd_review:
  verdict: accept
  risk_level: medium
  model_used: GPT-5 Codex
  reasoning_effort_used: high
  under_modeling_detected: false
  over_modeling_detected: false
  blocking_issues: []
  non_blocking_issues:
    - two unrelated clean-main baseline test failures
  missing_tests: []
  hidden_defect_risks:
    - browser rendering differences outside Chromium
  recommended_fixes: []
  recommended_model_for_fix: Terra
  recommended_reasoning_for_fix: medium
  residual_risk: low after exact-head re-review and CI
```

## BuilderOps Routing

- Records/projections/receipts: none
- Reason: This PR changes repo-governed implementation, tests, and the owning CKM specification directly; no BuilderOps operational record is required.
