### PR TITLE
Align governance prompt allowlist documentation

### DIFF
--- a/docs/development/DEV_WORKFLOW.md
+++ b/docs/development/DEV_WORKFLOW.md
@@ -154,6 +154,7 @@ Use this lane only when:
   - `.github/workflows/issue-pr-governance.yml`
   - `scripts/docs_guard.py`
   - `scripts/await_pr_checks.sh`
+  - `companion-ui/prompts/codex/deliver-epic-autonomous-runner.md`
   - `tests/architecture/test_agent_skill_entrypoints.py`
   - `tests/governance/test_codex_agents_contract.py`
 - the PR is limited to repo governance, agent workflow, or lightweight enforcement

--- a/tests/governance/test_issue_pr_governance.py
+++ b/tests/governance/test_issue_pr_governance.py
@@ -30,6 +30,12 @@ def _read_workflow() -> str:
     )
 
 
+def _read_development_workflow() -> str:
+    return (REPO_ROOT / "docs/development/DEV_WORKFLOW.md").read_text(
+        encoding="utf-8"
+    )
+
+
 def _has_builderops_routing(body: str) -> bool:
     match = _BUILDEROPS_ROUTING_REGEX.search(body)
     if not match:
@@ -147,6 +153,18 @@ def test_autonomous_runner_prompt_is_governance_lane_allowed() -> None:
 
     assert '"companion-ui/prompts/codex/deliver-epic-autonomous-runner.md"' in exact
     assert '"companion-ui/prompts/codex/deliver-epic-autonomous-runner.md"' not in prefixes
+
+
+def test_governance_lane_companion_prompt_surface_matches_owner_doc() -> None:
+    workflow = _read_development_workflow()
+    governance_lane = workflow.split("## Governance lane", 1)[1].split(
+        "## Runtime separation", 1
+    )[0]
+
+    assert (
+        "`companion-ui/prompts/codex/deliver-epic-autonomous-runner.md`"
+        in governance_lane
+    )
 
 
 def test_review_before_ci_gate_is_governance_lane_allowed() -> None:


### PR DESCRIPTION
Fixes #3684

- [x] Governance lane

## Summary

Aligns the Governance-lane owner document with the existing exact CI allowlist for the autonomous epic-runner prompt and adds a focused drift regression.

## Changes

- Documents the allowed companion prompt surface in the Governance-lane owner doc.
- Verifies the path remains in that specific owner-doc section.

## Validation

- `pytest -q tests/governance/test_issue_pr_governance.py` — 9 passed
- `python3 scripts/docs_guard.py` — passed
- `git diff --check` — passed
- `python3 scripts/review_before_ci_gate.py --lane governance --review-gate-complete ...` — passed

## BuilderOps Routing

- Records/projections/receipts: none
- Reason: bounded governance contract alignment; the issue and PR retain the delivery receipt.