### PR TITLE
Fix BuilderOps host-stable store default

### DIFF
--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -273,7 +273,10 @@ def _handle_create(
     "--db-path",
     type=click.Path(dir_okay=False, path_type=Path),
     default=None,
-    help="Override BuilderOps SQLite DB path. Defaults to BUILDEROPS_DB_PATH or runtime/builderops/builderops.sqlite3.",
+    help=(
+        "Override BuilderOps SQLite DB path. Defaults to BUILDEROPS_DB_PATH "
+        "or the host-stable ~/.local/state/builderops/builderops.sqlite3."
+    ),
 )
 @click.pass_context
 def builderops(ctx: click.Context, db_path: Path | None) -> None:

--- a/app/builderops/cli.py
+++ b/app/builderops/cli.py
@@ -297,6 +297,15 @@ def _effective_paths(ctx: click.Context) -> BuilderOpsPaths:
         raise click.ClickException(str(exc)) from exc
 
 
+def _model_inquiry_service(ctx: click.Context) -> ModelInquiryService:
+    paths = _effective_paths(ctx)
+    if paths.vault_root is None:
+        raise click.ClickException(
+            "BUILDEROPS_VAULT_ROOT is required for model inquiries"
+        )
+    return ModelInquiryService(paths.vault_root)
+
+
 @builderops.group("vault", help="Operate the file-first Builder Ops Vault queue.")
 def vault() -> None:
     """Shared Markdown queue and advisory TTL-claim helpers."""
@@ -620,7 +629,9 @@ def inquiry() -> None:
 @click.option("--source-ref", multiple=True)
 @click.option("--created-by", default=None)
 @click.option("--json", "as_json", is_flag=True)
+@click.pass_context
 def inquiry_start(
+    ctx: click.Context,
     question_file: Path,
     workflow: str,
     inquiry_id: str | None,
@@ -635,7 +646,7 @@ def inquiry_start(
             if source_ref
             else [{"ref_type": "file", "ref": str(question_file.resolve())}]
         )
-        payload = ModelInquiryService.from_env().start(
+        payload = _model_inquiry_service(ctx).start(
             question=question,
             workflow=workflow,
             inquiry_id=inquiry_id,
@@ -651,9 +662,12 @@ def inquiry_start(
 @click.argument("inquiry_id")
 @click.option("--include-delivery", is_flag=True)
 @click.option("--json", "as_json", is_flag=True)
-def inquiry_trace(inquiry_id: str, include_delivery: bool, as_json: bool) -> None:
+@click.pass_context
+def inquiry_trace(
+    ctx: click.Context, inquiry_id: str, include_delivery: bool, as_json: bool
+) -> None:
     try:
-        payload = ModelInquiryService.from_env().trace(
+        payload = _model_inquiry_service(ctx).trace(
             inquiry_id,
             include_delivery=include_delivery,
         )
@@ -666,13 +680,15 @@ def inquiry_trace(inquiry_id: str, include_delivery: bool, as_json: bool) -> Non
 @click.argument("inquiry_id")
 @click.option("--created-by", default=None)
 @click.option("--json", "as_json", is_flag=True)
+@click.pass_context
 def inquiry_evaluate(
+    ctx: click.Context,
     inquiry_id: str,
     created_by: str | None,
     as_json: bool,
 ) -> None:
     try:
-        service = ModelInquiryService.from_env()
+        service = _model_inquiry_service(ctx)
         gateway = ModelInquiryPromotionGateway(service)
         payload = gateway.evaluate(inquiry_id, actor=_parse_actor(created_by))
         payload["human_readable_report"] = str(
@@ -690,7 +706,9 @@ def inquiry_evaluate(
 @click.option("--label", "labels", multiple=True)
 @click.option("--created-by", default=None)
 @click.option("--json", "as_json", is_flag=True)
+@click.pass_context
 def inquiry_promote(
+    ctx: click.Context,
     inquiry_id: str,
     create_issue: bool,
     repository: str | None,
@@ -708,7 +726,7 @@ def inquiry_promote(
             "--repository or BUILDEROPS_GITHUB_REPOSITORY is required"
         )
     try:
-        service = ModelInquiryService.from_env()
+        service = _model_inquiry_service(ctx)
         gateway = ModelInquiryPromotionGateway(
             service,
             repository=repository,
@@ -729,14 +747,16 @@ def inquiry_promote(
 @click.option("--delivery-ref", required=True, help="JSON ref or ref_type:ref shorthand.")
 @click.option("--created-by", default=None)
 @click.option("--json", "as_json", is_flag=True)
+@click.pass_context
 def inquiry_link_delivery(
+    ctx: click.Context,
     inquiry_id: str,
     delivery_ref: str,
     created_by: str | None,
     as_json: bool,
 ) -> None:
     try:
-        service = ModelInquiryService.from_env()
+        service = _model_inquiry_service(ctx)
         trace = service.trace(inquiry_id)
         payload = service.commit_delivery_reference(
             inquiry_id,
@@ -752,9 +772,10 @@ def inquiry_link_delivery(
 @inquiry.command("resume", help="Plan restart continuation without executing a provider.")
 @click.argument("inquiry_id")
 @click.option("--json", "as_json", is_flag=True)
-def inquiry_resume(inquiry_id: str, as_json: bool) -> None:
+@click.pass_context
+def inquiry_resume(ctx: click.Context, inquiry_id: str, as_json: bool) -> None:
     try:
-        payload = ModelInquiryService.from_env().resume(inquiry_id)
+        payload = _model_inquiry_service(ctx).resume(inquiry_id)
     except BuilderOpsValidationError as exc:
         raise click.ClickException(str(exc)) from exc
     _emit(payload, as_json)
@@ -765,9 +786,16 @@ def inquiry_resume(inquiry_id: str, as_json: bool) -> None:
 @click.option("--dry-run", is_flag=True, help="Return a deterministic plan without mutations.")
 @click.option("--max-rounds", default=3, show_default=True, type=click.IntRange(1, 20))
 @click.option("--json", "as_json", is_flag=True)
-def inquiry_run(inquiry_id: str, dry_run: bool, max_rounds: int, as_json: bool) -> None:
+@click.pass_context
+def inquiry_run(
+    ctx: click.Context,
+    inquiry_id: str,
+    dry_run: bool,
+    max_rounds: int,
+    as_json: bool,
+) -> None:
     try:
-        service = ModelInquiryService.from_env()
+        service = _model_inquiry_service(ctx)
         payload = ModelInquiryRunner(service).run(
             inquiry_id,
             max_rounds=max_rounds,

--- a/app/builderops/config.py
+++ b/app/builderops/config.py
@@ -93,6 +93,30 @@ def current_user_id() -> str:
     return str(os.getuid())
 
 
+def _legacy_store_mtimes(root: Path) -> tuple[float, ...]:
+    """Inventory legacy stores recursively without following symlinked trees."""
+
+    mtimes: list[float] = []
+    for directory, child_dirs, files in os.walk(root, followlinks=False):
+        directory_path = Path(directory)
+        child_dirs[:] = [
+            name for name in child_dirs if not (directory_path / name).is_symlink()
+        ]
+        if (
+            directory_path.name == "builderops"
+            and directory_path.parent.name == "runtime"
+            and DEFAULT_DB_NAME in files
+        ):
+            candidate = directory_path / DEFAULT_DB_NAME
+            candidate_stat = candidate.lstat()
+            if stat.S_ISLNK(candidate_stat.st_mode) or not stat.S_ISREG(
+                candidate_stat.st_mode
+            ):
+                raise ValueError
+            mtimes.append(candidate_stat.st_mtime)
+    return tuple(mtimes)
+
+
 def _validate_host_cutover_ack(state_dir: Path) -> None:
     """Require bounded host-global evidence before implicit store selection."""
 
@@ -117,12 +141,9 @@ def _validate_host_cutover_ack(state_dir: Path) -> None:
         cwd_is_in_inventory = cwd in roots
         latest_legacy_write = max(
             (
-                datetime.fromtimestamp(
-                    (root / "runtime" / "builderops" / DEFAULT_DB_NAME).stat().st_mtime,
-                    tz=timezone.utc,
-                )
+                datetime.fromtimestamp(mtime, tz=timezone.utc)
                 for root in roots
-                if (root / "runtime" / "builderops" / DEFAULT_DB_NAME).is_file()
+                for mtime in _legacy_store_mtimes(root)
             ),
             default=None,
         )

--- a/app/builderops/config.py
+++ b/app/builderops/config.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import json
 import os
+import platform
+import stat
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
+from uuid import UUID
 
 DEFAULT_DB_NAME = "builderops.sqlite3"
 CUTOVER_ACK_NAME = "host-store-cutover-v1.json"
@@ -78,29 +81,80 @@ def host_cutover_ack_path(state_dir: Path | None = None) -> Path:
     return (state_dir if state_dir is not None else default_state_dir()) / CUTOVER_ACK_NAME
 
 
+def current_host_id() -> str:
+    """Return the local host identity recorded in cutover evidence."""
+
+    return platform.node().strip()
+
+
+def current_user_id() -> str:
+    """Return the local OS user identity recorded in cutover evidence."""
+
+    return str(os.getuid())
+
+
 def _validate_host_cutover_ack(state_dir: Path) -> None:
     """Require bounded host-global evidence before implicit store selection."""
 
     path = host_cutover_ack_path(state_dir)
     try:
-        if path.is_symlink():
+        path_stat = path.lstat()
+        if (
+            stat.S_ISLNK(path_stat.st_mode)
+            or not stat.S_ISREG(path_stat.st_mode)
+            or stat.S_IMODE(path_stat.st_mode) != 0o600
+            or path_stat.st_uid != os.getuid()
+        ):
             raise ValueError
         payload: Any = json.loads(path.read_text(encoding="utf-8"))
         acknowledged_at = datetime.fromisoformat(
             str(payload["acknowledged_at"]).replace("Z", "+00:00")
         )
         participating_repos = payload["participating_repos"]
+        participating_roots = payload["participating_roots"]
+        roots = tuple(Path(root).resolve(strict=True) for root in participating_roots)
+        cwd = Path.cwd().resolve()
+        cwd_is_in_inventory = any(cwd == root or root in cwd.parents for root in roots)
+        latest_legacy_write = max(
+            (
+                datetime.fromtimestamp(
+                    (root / "runtime" / "builderops" / DEFAULT_DB_NAME).stat().st_mtime,
+                    tz=timezone.utc,
+                )
+                for root in roots
+                if (root / "runtime" / "builderops" / DEFAULT_DB_NAME).is_file()
+            ),
+            default=None,
+        )
+        now = datetime.now(timezone.utc)
         valid = (
             isinstance(payload, dict)
             and payload.get("schema_version") == CUTOVER_ACK_SCHEMA
             and payload.get("scope") == "same-user-same-host"
+            and payload.get("host_id") == current_host_id()
+            and payload.get("user_id") == current_user_id()
             and payload.get("legacy_stores_reconciled") is True
             and isinstance(payload.get("actor"), str)
             and bool(payload["actor"].strip())
             and acknowledged_at.tzinfo is not None
+            and acknowledged_at <= now + timedelta(minutes=5)
+            and (
+                latest_legacy_write is None
+                or latest_legacy_write <= acknowledged_at
+            )
+            and isinstance(payload.get("inventory_epoch"), str)
+            and bool(UUID(payload["inventory_epoch"]))
             and isinstance(participating_repos, list)
             and all(isinstance(repo, str) and repo.strip() for repo in participating_repos)
             and len(set(participating_repos)) == len(participating_repos)
+            and isinstance(participating_roots, list)
+            and bool(participating_roots)
+            and all(
+                isinstance(root, str) and Path(root).is_absolute()
+                for root in participating_roots
+            )
+            and len(set(participating_roots)) == len(participating_roots)
+            and cwd_is_in_inventory
         )
     except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError):
         valid = False
@@ -110,7 +164,8 @@ def _validate_host_cutover_ack(state_dir: Path) -> None:
         "Refusing implicit host-stable BuilderOps store selection: a valid "
         "same-user/same-host cutover acknowledgement is required. Stop BuilderOps "
         "writers, reconcile legacy stores across every participating repository, "
-        "then install the documented host-store-cutover-v1 acknowledgement or set "
+        "bind a fresh inventory epoch to this host, user, and every participating "
+        "root, then install the documented host-store-cutover-v1 acknowledgement or set "
         "BUILDEROPS_DB_PATH / BUILDEROPS_STATE_DIR explicitly."
     )
 

--- a/app/builderops/config.py
+++ b/app/builderops/config.py
@@ -3,14 +3,23 @@
 from __future__ import annotations
 
 import os
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
-# The BuilderOps store coordinates every agent running as this user on one
-# host. Keep its implicit location outside repository checkouts so separate
-# worktrees cannot accidentally create independent lease tables.
-DEFAULT_STATE_DIR = Path.home() / ".local" / "state" / "builderops"
 DEFAULT_DB_NAME = "builderops.sqlite3"
+LEGACY_STATE_DIR = Path("runtime/builderops")
+
+
+def default_state_dir() -> Path:
+    """Return the implicit same-user, same-host state home lazily.
+
+    Home resolution must not run at import time: hostless automation can still
+    use an explicit absolute DB/state override even when ``Path.home()`` is not
+    available.
+    """
+
+    return Path.home() / ".local" / "state" / "builderops"
 
 
 @dataclass(frozen=True)
@@ -30,12 +39,25 @@ def load_paths(
     db_path_override: Path | None = None,
 ) -> BuilderOpsPaths:
     src = env if env is not None else os.environ
-    state_dir = Path(src.get("BUILDEROPS_STATE_DIR", str(DEFAULT_STATE_DIR))).expanduser()
+    configured_state_dir = src.get("BUILDEROPS_STATE_DIR")
+    configured_db_path = src.get("BUILDEROPS_DB_PATH")
+    exact_db_path = (
+        db_path_override if db_path_override is not None else configured_db_path
+    )
+    if configured_state_dir is not None:
+        state_dir = Path(configured_state_dir).expanduser()
+    elif exact_db_path is not None:
+        state_dir = Path(exact_db_path).expanduser().parent
+    else:
+        _fail_if_legacy_stores_exist()
+        state_dir = default_state_dir()
     db_path = (
         db_path_override.expanduser()
         if db_path_override is not None
         else Path(
-            src.get("BUILDEROPS_DB_PATH", str(state_dir / DEFAULT_DB_NAME))
+            configured_db_path
+            if configured_db_path is not None
+            else state_dir / DEFAULT_DB_NAME
         ).expanduser()
     )
     vault_value = src.get("BUILDEROPS_VAULT_ROOT", "").strip()
@@ -47,6 +69,58 @@ def load_paths(
     )
     _validate_separation(paths)
     return paths
+
+
+def _fail_if_legacy_stores_exist() -> None:
+    legacy_paths = _legacy_store_paths()
+    if not legacy_paths:
+        return
+    raise ValueError(
+        "Refusing implicit host-stable BuilderOps store selection: found "
+        f"{len(legacy_paths)} legacy per-worktree store(s). Stop BuilderOps writers, "
+        "reconcile the legacy stores, then set BUILDEROPS_DB_PATH or "
+        "BUILDEROPS_STATE_DIR explicitly for the operator-approved cutover."
+    )
+
+
+def _legacy_store_paths() -> tuple[Path, ...]:
+    """Return existing legacy stores for the current repo without exposing paths."""
+
+    roots = _git_worktree_roots()
+    if not roots:
+        current = Path.cwd()
+        repo_root = next(
+            (p for p in (current, *current.parents) if (p / ".git").exists()),
+            current,
+        )
+        roots = (repo_root,)
+    paths = {
+        (root / LEGACY_STATE_DIR / DEFAULT_DB_NAME).resolve(strict=False)
+        for root in roots
+        if (root / LEGACY_STATE_DIR / DEFAULT_DB_NAME).is_file()
+    }
+    return tuple(sorted(paths))
+
+
+def _git_worktree_roots() -> tuple[Path, ...]:
+    try:
+        result = subprocess.run(
+            ["git", "worktree", "list", "--porcelain"],
+            cwd=Path.cwd(),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ()
+    if result.returncode != 0:
+        return ()
+    return tuple(
+        Path(line.removeprefix("worktree "))
+        for line in result.stdout.splitlines()
+        if line.startswith("worktree ")
+    )
 
 
 def _validate_separation(paths: BuilderOpsPaths) -> None:

--- a/app/builderops/config.py
+++ b/app/builderops/config.py
@@ -45,8 +45,14 @@ def load_paths(
     db_path_override: Path | None = None,
 ) -> BuilderOpsPaths:
     src = env if env is not None else os.environ
-    configured_state_dir = src.get("BUILDEROPS_STATE_DIR")
-    configured_db_path = src.get("BUILDEROPS_DB_PATH")
+    raw_state_dir = src.get("BUILDEROPS_STATE_DIR")
+    raw_db_path = src.get("BUILDEROPS_DB_PATH")
+    configured_state_dir = (
+        raw_state_dir if raw_state_dir is not None and raw_state_dir.strip() else None
+    )
+    configured_db_path = (
+        raw_db_path if raw_db_path is not None and raw_db_path.strip() else None
+    )
     exact_db_path = (
         db_path_override if db_path_override is not None else configured_db_path
     )

--- a/app/builderops/config.py
+++ b/app/builderops/config.py
@@ -114,7 +114,7 @@ def _validate_host_cutover_ack(state_dir: Path) -> None:
         participating_roots = payload["participating_roots"]
         roots = tuple(Path(root).resolve(strict=True) for root in participating_roots)
         cwd = Path.cwd().resolve()
-        cwd_is_in_inventory = any(cwd == root or root in cwd.parents for root in roots)
+        cwd_is_in_inventory = cwd in roots
         latest_legacy_write = max(
             (
                 datetime.fromtimestamp(
@@ -154,6 +154,8 @@ def _validate_host_cutover_ack(state_dir: Path) -> None:
                 for root in participating_roots
             )
             and len(set(participating_roots)) == len(participating_roots)
+            and len(set(roots)) == len(roots)
+            and len(participating_repos) == len(roots)
             and cwd_is_in_inventory
         )
     except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError):

--- a/app/builderops/config.py
+++ b/app/builderops/config.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import json
 import os
-import subprocess
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 DEFAULT_DB_NAME = "builderops.sqlite3"
-LEGACY_STATE_DIR = Path("runtime/builderops")
+CUTOVER_ACK_NAME = "host-store-cutover-v1.json"
+CUTOVER_ACK_SCHEMA = "builderops.host-store-cutover.v1"
 
 
 def default_state_dir() -> Path:
@@ -49,8 +52,8 @@ def load_paths(
     elif exact_db_path is not None:
         state_dir = Path(exact_db_path).expanduser().parent
     else:
-        _fail_if_legacy_stores_exist()
         state_dir = default_state_dir()
+        _validate_host_cutover_ack(state_dir)
     db_path = (
         db_path_override.expanduser()
         if db_path_override is not None
@@ -71,55 +74,44 @@ def load_paths(
     return paths
 
 
-def _fail_if_legacy_stores_exist() -> None:
-    legacy_paths = _legacy_store_paths()
-    if not legacy_paths:
+def host_cutover_ack_path(state_dir: Path | None = None) -> Path:
+    return (state_dir if state_dir is not None else default_state_dir()) / CUTOVER_ACK_NAME
+
+
+def _validate_host_cutover_ack(state_dir: Path) -> None:
+    """Require bounded host-global evidence before implicit store selection."""
+
+    path = host_cutover_ack_path(state_dir)
+    try:
+        if path.is_symlink():
+            raise ValueError
+        payload: Any = json.loads(path.read_text(encoding="utf-8"))
+        acknowledged_at = datetime.fromisoformat(
+            str(payload["acknowledged_at"]).replace("Z", "+00:00")
+        )
+        participating_repos = payload["participating_repos"]
+        valid = (
+            isinstance(payload, dict)
+            and payload.get("schema_version") == CUTOVER_ACK_SCHEMA
+            and payload.get("scope") == "same-user-same-host"
+            and payload.get("legacy_stores_reconciled") is True
+            and isinstance(payload.get("actor"), str)
+            and bool(payload["actor"].strip())
+            and acknowledged_at.tzinfo is not None
+            and isinstance(participating_repos, list)
+            and all(isinstance(repo, str) and repo.strip() for repo in participating_repos)
+            and len(set(participating_repos)) == len(participating_repos)
+        )
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError):
+        valid = False
+    if valid:
         return
     raise ValueError(
-        "Refusing implicit host-stable BuilderOps store selection: found "
-        f"{len(legacy_paths)} legacy per-worktree store(s). Stop BuilderOps writers, "
-        "reconcile the legacy stores, then set BUILDEROPS_DB_PATH or "
-        "BUILDEROPS_STATE_DIR explicitly for the operator-approved cutover."
-    )
-
-
-def _legacy_store_paths() -> tuple[Path, ...]:
-    """Return existing legacy stores for the current repo without exposing paths."""
-
-    roots = _git_worktree_roots()
-    if not roots:
-        current = Path.cwd()
-        repo_root = next(
-            (p for p in (current, *current.parents) if (p / ".git").exists()),
-            current,
-        )
-        roots = (repo_root,)
-    paths = {
-        (root / LEGACY_STATE_DIR / DEFAULT_DB_NAME).resolve(strict=False)
-        for root in roots
-        if (root / LEGACY_STATE_DIR / DEFAULT_DB_NAME).is_file()
-    }
-    return tuple(sorted(paths))
-
-
-def _git_worktree_roots() -> tuple[Path, ...]:
-    try:
-        result = subprocess.run(
-            ["git", "worktree", "list", "--porcelain"],
-            cwd=Path.cwd(),
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=5,
-        )
-    except (OSError, subprocess.SubprocessError):
-        return ()
-    if result.returncode != 0:
-        return ()
-    return tuple(
-        Path(line.removeprefix("worktree "))
-        for line in result.stdout.splitlines()
-        if line.startswith("worktree ")
+        "Refusing implicit host-stable BuilderOps store selection: a valid "
+        "same-user/same-host cutover acknowledgement is required. Stop BuilderOps "
+        "writers, reconcile legacy stores across every participating repository, "
+        "then install the documented host-store-cutover-v1 acknowledgement or set "
+        "BUILDEROPS_DB_PATH / BUILDEROPS_STATE_DIR explicitly."
     )
 
 

--- a/app/builderops/config.py
+++ b/app/builderops/config.py
@@ -6,7 +6,10 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
-DEFAULT_STATE_DIR = Path("runtime/builderops")
+# The BuilderOps store coordinates every agent running as this user on one
+# host. Keep its implicit location outside repository checkouts so separate
+# worktrees cannot accidentally create independent lease tables.
+DEFAULT_STATE_DIR = Path.home() / ".local" / "state" / "builderops"
 DEFAULT_DB_NAME = "builderops.sqlite3"
 
 

--- a/app/builderops/config.py
+++ b/app/builderops/config.py
@@ -96,8 +96,13 @@ def current_user_id() -> str:
 def _legacy_store_mtimes(root: Path) -> tuple[float, ...]:
     """Inventory legacy stores recursively without following symlinked trees."""
 
+    def fail_on_walk_error(error: OSError) -> None:
+        raise error
+
     mtimes: list[float] = []
-    for directory, child_dirs, files in os.walk(root, followlinks=False):
+    for directory, child_dirs, files in os.walk(
+        root, followlinks=False, onerror=fail_on_walk_error
+    ):
         directory_path = Path(directory)
         child_dirs[:] = [
             name for name in child_dirs if not (directory_path / name).is_symlink()
@@ -176,6 +181,7 @@ def _validate_host_cutover_ack(state_dir: Path) -> None:
             )
             and len(set(participating_roots)) == len(participating_roots)
             and len(set(roots)) == len(roots)
+            and all(root.is_dir() for root in roots)
             and len(participating_repos) == len(roots)
             and cwd_is_in_inventory
         )

--- a/app/ops/builderops_startup.py
+++ b/app/ops/builderops_startup.py
@@ -15,7 +15,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from app.builderops.config import DEFAULT_DB_NAME, DEFAULT_STATE_DIR
+from app.builderops.config import DEFAULT_DB_NAME, default_state_dir
 
 DEFAULT_REPOS = ("RasmusTho/agentic-pkm-mvp", "RasmusTho/bifrost")
 DEFAULT_RATE_LIMIT_MIN = 25
@@ -287,7 +287,7 @@ def _builderops_db_path(root: Path, env: dict[str, str]) -> str:
         return env["BUILDEROPS_DB_PATH"]
     configured_state_dir = env.get("BUILDEROPS_STATE_DIR")
     if configured_state_dir is None:
-        return str(DEFAULT_STATE_DIR / DEFAULT_DB_NAME)
+        return str(default_state_dir() / DEFAULT_DB_NAME)
     state_dir = Path(configured_state_dir).expanduser()
     if not state_dir.is_absolute():
         state_dir = root / state_dir

--- a/app/ops/builderops_startup.py
+++ b/app/ops/builderops_startup.py
@@ -15,6 +15,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from app.builderops.config import DEFAULT_DB_NAME, DEFAULT_STATE_DIR
+
 DEFAULT_REPOS = ("RasmusTho/agentic-pkm-mvp", "RasmusTho/bifrost")
 DEFAULT_RATE_LIMIT_MIN = 25
 
@@ -283,10 +285,13 @@ def _signboard_export(
 def _builderops_db_path(root: Path, env: dict[str, str]) -> str:
     if env.get("BUILDEROPS_DB_PATH"):
         return env["BUILDEROPS_DB_PATH"]
-    state_dir = Path(env.get("BUILDEROPS_STATE_DIR", "runtime/builderops")).expanduser()
+    configured_state_dir = env.get("BUILDEROPS_STATE_DIR")
+    if configured_state_dir is None:
+        return str(DEFAULT_STATE_DIR / DEFAULT_DB_NAME)
+    state_dir = Path(configured_state_dir).expanduser()
     if not state_dir.is_absolute():
         state_dir = root / state_dir
-    return str(state_dir / "builderops.sqlite3")
+    return str(state_dir / DEFAULT_DB_NAME)
 
 
 def _project_reconciliation() -> dict[str, Any]:

--- a/app/ops/builderops_startup.py
+++ b/app/ops/builderops_startup.py
@@ -15,7 +15,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from app.builderops.config import DEFAULT_DB_NAME, default_state_dir
+from app.builderops.config import DEFAULT_DB_NAME, default_state_dir, load_paths
 
 DEFAULT_REPOS = ("RasmusTho/agentic-pkm-mvp", "RasmusTho/bifrost")
 DEFAULT_RATE_LIMIT_MIN = 25
@@ -220,8 +220,17 @@ def _builderops_readiness(*, root: Path, env: dict[str, str], result: dict[str, 
     builderops: dict[str, Any] = {
         "status": "ok",
         "wrapper": str(wrapper.relative_to(root)),
-        "db_path": _builderops_db_path(root, env),
+        "db_path": None,
     }
+    try:
+        load_paths(env)
+    except ValueError as exc:
+        builderops["status"] = "degraded"
+        builderops["reason"] = "builderops_path_preflight_failed"
+        builderops["detail"] = str(exc)
+        _append_reason(result, "builderops_path_preflight_failed")
+        return builderops
+    builderops["db_path"] = _builderops_db_path(root, env)
     if not wrapper.exists():
         builderops["status"] = "degraded"
         builderops["reason"] = "builderops_wrapper_missing"

--- a/app/ops/builderops_startup.py
+++ b/app/ops/builderops_startup.py
@@ -292,10 +292,11 @@ def _signboard_export(
 
 
 def _builderops_db_path(root: Path, env: dict[str, str]) -> str:
-    if env.get("BUILDEROPS_DB_PATH"):
-        return env["BUILDEROPS_DB_PATH"]
+    configured_db_path = env.get("BUILDEROPS_DB_PATH")
+    if configured_db_path is not None and configured_db_path.strip():
+        return configured_db_path
     configured_state_dir = env.get("BUILDEROPS_STATE_DIR")
-    if configured_state_dir is None:
+    if configured_state_dir is None or not configured_state_dir.strip():
         return str(default_state_dir() / DEFAULT_DB_NAME)
     state_dir = Path(configured_state_dir).expanduser()
     if not state_dir.is_absolute():

--- a/docs/builderops/BUILDEROPS_VAULT_PROJECTIONS.md
+++ b/docs/builderops/BUILDEROPS_VAULT_PROJECTIONS.md
@@ -112,15 +112,16 @@ change only through their explicit owner workflows and promotion gates.
 ## Non-Authoritative and Non-Reproducible
 
 Checked-in BuilderOps projections under `docs/generated/builderops/` are **non-authoritative
-repo-readable views** over a gitignored, machine-local, mutable SQLite store
-(`runtime/builderops/builderops.sqlite3`). They are **not reproducible** across devices or over
-time.
+repo-readable views** over a machine-local, mutable SQLite store
+(`~/.local/state/builderops/builderops.sqlite3` by default). They are **not reproducible** across
+devices or over time.
 
 Consequences:
 
 - A regen diff (records appearing or disappearing between regeneration runs) is **expected, not data
-  loss**. The backing store is ephemeral and may not contain the same records on a different machine,
-  in a different worktree, or at a different time.
+  loss**. The backing store may not contain the same records on a different machine or at a different
+  time. Separate worktrees on one host share the default store; explicit overrides can still select
+  a different store deliberately.
 - Checked-in projection records are not a durable authority surface. Records that were once visible
   in a checked-in projection may be absent in the current local store; this is the designed behaviour
   of a non-persistent view over an ephemeral backing store.

--- a/docs/builderops/BUILDEROPS_VAULT_STORE.md
+++ b/docs/builderops/BUILDEROPS_VAULT_STORE.md
@@ -106,19 +106,26 @@ host-stable database unless the operator has installed this host-level acknowled
 {
   "schema_version": "builderops.host-store-cutover.v1",
   "scope": "same-user-same-host",
+  "host_id": "actual local hostname",
+  "user_id": "actual local numeric uid",
   "legacy_stores_reconciled": true,
   "participating_repos": ["owner/repo-a", "owner/repo-b"],
+  "participating_roots": ["/absolute/repo-a", "/absolute/repo-b"],
+  "inventory_epoch": "7afaf9af-b94f-4b5e-8242-c3cb45fc70fb",
   "actor": "operator identity",
   "acknowledged_at": "2026-07-15T00:00:00Z"
 }
 ```
 
-The operator creates this non-symlink marker only after stopping BuilderOps writers, inventorying
+The operator creates this owner-only `0600`, non-symlink marker only after stopping BuilderOps writers, inventorying
 every participating repository on the host, and reconciling or explicitly retaining its legacy
-stores. `participating_repos` is that bounded inventory (an empty list is valid for a verified new
-host). The timestamp must be timezone-aware, the actor must be non-empty, and every listed repo
-must be a unique non-empty string. Missing or malformed evidence produces the same privacy-safe
-fail-loud error; host paths and store contents are never printed.
+stores. The marker is bound to the actual hostname and numeric UID. `participating_repos` names
+the bounded logical inventory; `participating_roots` lists its absolute local roots and must cover
+the current working tree. The UUID `inventory_epoch` and timezone-aware timestamp identify the
+reconciliation pass. A future timestamp, a legacy DB written after that pass, a copied host/user
+identity, an unlisted current root, wrong ownership/mode, or a missing/malformed field fails before
+the consolidated DB is opened. Error text remains privacy-safe; host paths and contents are not
+printed.
 
 `BUILDEROPS_DB_PATH`, `BUILDEROPS_STATE_DIR`, and CLI `--db-path` bypass the acknowledgement gate.
 They remain the operator path for keeping the current store pinned before cutover and selecting the

--- a/docs/builderops/BUILDEROPS_VAULT_STORE.md
+++ b/docs/builderops/BUILDEROPS_VAULT_STORE.md
@@ -132,6 +132,8 @@ the consolidated DB is opened. Error text remains privacy-safe; host paths and c
 printed.
 
 `BUILDEROPS_DB_PATH`, `BUILDEROPS_STATE_DIR`, and CLI `--db-path` bypass the acknowledgement gate.
+Environment overrides must be non-blank after trimming; blank values are treated as absent and
+therefore follow the acknowledged implicit host-store path.
 They remain the operator path for keeping the current store pinned before cutover and selecting the
 reconciled store during cutover. This PR does not create the acknowledgement, inventory repos,
 reconcile records, migrate data, stop writers, or perform the live cutover.

--- a/docs/builderops/BUILDEROPS_VAULT_STORE.md
+++ b/docs/builderops/BUILDEROPS_VAULT_STORE.md
@@ -5,8 +5,8 @@ Owner: BuilderOps governance
 Temporal class: operational
 Review cadence: event-driven
 Source of truth: app/builderops, app/cli/builderops.py, ADR-0010, BuilderOps object model
-Last reviewed: 2026-06-01
-Last verified against: issues #1501/#1502/#1507/#1508
+Last reviewed: 2026-07-14
+Last verified against: issues #1501/#1502/#1507/#1508/#3686
 
 # BuilderOps Vault Store and CLI
 
@@ -72,8 +72,13 @@ or transitioned.
 Default state path:
 
 ```text
-runtime/builderops/builderops.sqlite3
+~/.local/state/builderops/builderops.sqlite3
 ```
+
+The default expands to an absolute, host-stable path in the current user's home directory. It is
+independent of the process working directory, so agents launched from separate checkouts or
+worktrees on the same host share one SQLite database and one lease table. The store remains
+single-host; this default does not add cross-host coordination.
 
 Override mechanisms:
 
@@ -85,8 +90,14 @@ Override mechanisms:
 - API/tool callers may set `builderops_db_path` through tool settings or `BUILDEROPS_DB_PATH`
   through the environment; see `docs/builderops/BUILDEROPS_VAULT_BOUNDARY.md`.
 
-The default path is repo-local runtime state and is ignored by Git via `runtime/builderops/`. It is
-not `$CODEX_HOME`, not local hidden memory, not repo authority, and not a reviewed docs surface.
+The default path is machine-local operating-plane state outside repository checkouts. It is not
+`$CODEX_HOME`, not runtime/user memory, not repo authority, and not a reviewed docs surface.
+Existing legacy stores under `<checkout>/runtime/builderops/` are not migrated, merged, deleted, or
+silently treated as the consolidated store by this code change. Before activating the new default
+on a host that has legacy per-worktree stores, the operator must stop BuilderOps writers, reconcile
+those stores, and select the consolidated database explicitly during the cutover. The existing
+`BUILDEROPS_DB_PATH` and `BUILDEROPS_STATE_DIR` overrides remain the supported way to pin that
+operator-selected path.
 
 ### Shared artifact vault and advisory claim signals
 
@@ -182,9 +193,10 @@ worktrees that regenerate checked-in projection views should set the intended st
 generator may fail loud before overwriting existing generated projections with records from an empty
 or incomplete worktree-local store.
 
-**Store durability and regen diff expectations:** The default store at `runtime/builderops/` is
-gitignored, machine-local, and mutable. It is not shared across devices, not preserved across
-worktree pruning, and not reproducible over time. Checked-in projections under
+**Store durability and regen diff expectations:** The default store at
+`~/.local/state/builderops/builderops.sqlite3` is machine-local and mutable. It is not shared across
+devices and is not reproducible over time. Unlike the former worktree-local default, worktree
+pruning does not remove it. Checked-in projections under
 `docs/generated/builderops/` are non-authoritative views over this ephemeral store; records that
 appear in a checked-in projection may be absent in the current local store after any store rotation,
 device change, or worktree lifecycle event. A regen diff — records appearing or disappearing between

--- a/docs/builderops/BUILDEROPS_VAULT_STORE.md
+++ b/docs/builderops/BUILDEROPS_VAULT_STORE.md
@@ -93,11 +93,16 @@ Override mechanisms:
 The default path is machine-local operating-plane state outside repository checkouts. It is not
 `$CODEX_HOME`, not runtime/user memory, not repo authority, and not a reviewed docs surface.
 Existing legacy stores under `<checkout>/runtime/builderops/` are not migrated, merged, deleted, or
-silently treated as the consolidated store by this code change. Before activating the new default
-on a host that has legacy per-worktree stores, the operator must stop BuilderOps writers, reconcile
-those stores, and select the consolidated database explicitly during the cutover. The existing
-`BUILDEROPS_DB_PATH` and `BUILDEROPS_STATE_DIR` overrides remain the supported way to pin that
-operator-selected path.
+silently treated as the consolidated store by this code change. With neither store override set,
+path loading scans the current Git repository's worktrees for the legacy database location and
+fails before opening or initializing the host-stable database when any legacy store exists. The
+error reports the number of stores without exposing host paths and directs the operator to stop
+writers, reconcile the stores, and pin the approved database using `BUILDEROPS_DB_PATH` or
+`BUILDEROPS_STATE_DIR`. Those explicit overrides bypass the legacy-store guard so the operator can
+keep the current store pinned before cutover and select the reconciled store during cutover.
+
+Default home-directory resolution is lazy. An absolute explicit DB/state/CLI override therefore
+continues to work in hostless automation where no user home can be resolved.
 
 ### Shared artifact vault and advisory claim signals
 

--- a/docs/builderops/BUILDEROPS_VAULT_STORE.md
+++ b/docs/builderops/BUILDEROPS_VAULT_STORE.md
@@ -122,7 +122,9 @@ every participating repository on the host, and reconciling or explicitly retain
 stores. The marker is bound to the actual hostname and numeric UID. `participating_repos` names
 the bounded logical inventory; `participating_roots` lists the same number of unique, resolved,
 absolute local roots in matching inventory order, and the current working directory must equal one
-of those exact roots. A broad ancestor cannot stand in for nested repositories. The UUID
+of those exact roots. Every listed root is recursively inventoried for nested
+`runtime/builderops/builderops.sqlite3` stores without following symlinks, so a broad secondary
+root cannot hide a newer nested legacy store. The UUID
 `inventory_epoch` and timezone-aware timestamp identify the
 reconciliation pass. A future timestamp, a legacy DB written after that pass, a copied host/user
 identity, an unlisted current root, wrong ownership/mode, or a missing/malformed field fails before

--- a/docs/builderops/BUILDEROPS_VAULT_STORE.md
+++ b/docs/builderops/BUILDEROPS_VAULT_STORE.md
@@ -93,13 +93,37 @@ Override mechanisms:
 The default path is machine-local operating-plane state outside repository checkouts. It is not
 `$CODEX_HOME`, not runtime/user memory, not repo authority, and not a reviewed docs surface.
 Existing legacy stores under `<checkout>/runtime/builderops/` are not migrated, merged, deleted, or
-silently treated as the consolidated store by this code change. With neither store override set,
-path loading scans the current Git repository's worktrees for the legacy database location and
-fails before opening or initializing the host-stable database when any legacy store exists. The
-error reports the number of stores without exposing host paths and directs the operator to stop
-writers, reconcile the stores, and pin the approved database using `BUILDEROPS_DB_PATH` or
-`BUILDEROPS_STATE_DIR`. Those explicit overrides bypass the legacy-store guard so the operator can
-keep the current store pinned before cutover and select the reconciled store during cutover.
+silently treated as the consolidated store by this code change. Absence of a legacy store in the
+current repository is not evidence that other participating repositories have no legacy state.
+With neither store override set, path loading therefore fails before opening or initializing the
+host-stable database unless the operator has installed this host-level acknowledgement:
+
+```text
+~/.local/state/builderops/host-store-cutover-v1.json
+```
+
+```json
+{
+  "schema_version": "builderops.host-store-cutover.v1",
+  "scope": "same-user-same-host",
+  "legacy_stores_reconciled": true,
+  "participating_repos": ["owner/repo-a", "owner/repo-b"],
+  "actor": "operator identity",
+  "acknowledged_at": "2026-07-15T00:00:00Z"
+}
+```
+
+The operator creates this non-symlink marker only after stopping BuilderOps writers, inventorying
+every participating repository on the host, and reconciling or explicitly retaining its legacy
+stores. `participating_repos` is that bounded inventory (an empty list is valid for a verified new
+host). The timestamp must be timezone-aware, the actor must be non-empty, and every listed repo
+must be a unique non-empty string. Missing or malformed evidence produces the same privacy-safe
+fail-loud error; host paths and store contents are never printed.
+
+`BUILDEROPS_DB_PATH`, `BUILDEROPS_STATE_DIR`, and CLI `--db-path` bypass the acknowledgement gate.
+They remain the operator path for keeping the current store pinned before cutover and selecting the
+reconciled store during cutover. This PR does not create the acknowledgement, inventory repos,
+reconcile records, migrate data, stop writers, or perform the live cutover.
 
 Default home-directory resolution is lazy. An absolute explicit DB/state/CLI override therefore
 continues to work in hostless automation where no user home can be resolved.

--- a/docs/builderops/BUILDEROPS_VAULT_STORE.md
+++ b/docs/builderops/BUILDEROPS_VAULT_STORE.md
@@ -120,8 +120,10 @@ host-stable database unless the operator has installed this host-level acknowled
 The operator creates this owner-only `0600`, non-symlink marker only after stopping BuilderOps writers, inventorying
 every participating repository on the host, and reconciling or explicitly retaining its legacy
 stores. The marker is bound to the actual hostname and numeric UID. `participating_repos` names
-the bounded logical inventory; `participating_roots` lists its absolute local roots and must cover
-the current working tree. The UUID `inventory_epoch` and timezone-aware timestamp identify the
+the bounded logical inventory; `participating_roots` lists the same number of unique, resolved,
+absolute local roots in matching inventory order, and the current working directory must equal one
+of those exact roots. A broad ancestor cannot stand in for nested repositories. The UUID
+`inventory_epoch` and timezone-aware timestamp identify the
 reconciliation pass. A future timestamp, a legacy DB written after that pass, a copied host/user
 identity, an unlisted current root, wrong ownership/mode, or a missing/malformed field fails before
 the consolidated DB is opened. Error text remains privacy-safe; host paths and contents are not

--- a/tests/builderops/test_config_paths.py
+++ b/tests/builderops/test_config_paths.py
@@ -5,6 +5,8 @@ import os
 from pathlib import Path
 import subprocess
 import sys
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
 
 import pytest
 
@@ -15,21 +17,39 @@ from app.builderops.store import SqliteBuilderOpsStore
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
-def _write_cutover_ack(state_dir: Path, repos: list[str] | None = None) -> None:
+def _write_cutover_ack(
+    state_dir: Path,
+    repos: list[str] | None = None,
+    *,
+    roots: list[Path] | None = None,
+    acknowledged_at: datetime | None = None,
+    host_id: str | None = None,
+    user_id: str | None = None,
+) -> None:
     state_dir.mkdir(parents=True, exist_ok=True)
-    builderops_config.host_cutover_ack_path(state_dir).write_text(
+    path = builderops_config.host_cutover_ack_path(state_dir)
+    path.write_text(
         json.dumps(
             {
                 "schema_version": builderops_config.CUTOVER_ACK_SCHEMA,
                 "scope": "same-user-same-host",
+                "host_id": host_id or builderops_config.current_host_id(),
+                "user_id": user_id or builderops_config.current_user_id(),
                 "legacy_stores_reconciled": True,
                 "participating_repos": repos or [],
+                "participating_roots": [
+                    str(root.resolve()) for root in (roots or [Path.cwd()])
+                ],
+                "inventory_epoch": str(uuid4()),
                 "actor": "operator-test",
-                "acknowledged_at": "2026-07-15T00:00:00Z",
+                "acknowledged_at": (
+                    acknowledged_at or datetime.now(timezone.utc)
+                ).isoformat(),
             }
         ),
         encoding="utf-8",
     )
+    path.chmod(0o600)
 
 
 def _run_implicit_cli(*, cwd: Path, home: Path) -> subprocess.CompletedProcess[str]:
@@ -54,11 +74,15 @@ def test_default_db_path_is_host_stable_and_cwd_independent(
 ) -> None:
     state_dir = tmp_path / "host-state" / "builderops"
     monkeypatch.setattr(builderops_config, "default_state_dir", lambda: state_dir)
-    _write_cutover_ack(state_dir, ["repo-a", "repo-b"])
     first_cwd = tmp_path / "worktree-a"
     second_cwd = tmp_path / "worktree-b"
     first_cwd.mkdir()
     second_cwd.mkdir()
+    _write_cutover_ack(
+        state_dir,
+        ["repo-a", "repo-b"],
+        roots=[first_cwd, second_cwd],
+    )
 
     monkeypatch.chdir(first_cwd)
     first = builderops_config.load_paths({})
@@ -81,7 +105,7 @@ def test_host_stable_default_still_confined_outside_vault(
         "default_state_dir",
         lambda: state_dir,
     )
-    _write_cutover_ack(state_dir)
+    _write_cutover_ack(state_dir, roots=[Path.cwd()])
 
     with pytest.raises(ValueError, match="outside BUILDEROPS_VAULT_ROOT"):
         builderops_config.load_paths({"BUILDEROPS_VAULT_ROOT": str(vault)})
@@ -197,9 +221,68 @@ def test_valid_host_ack_allows_implicit_cli_outside_git(tmp_path: Path) -> None:
     home = tmp_path / "acknowledged-home"
     state_dir = home / ".local" / "state" / "builderops"
     consolidated_db = state_dir / "builderops.sqlite3"
-    _write_cutover_ack(state_dir, ["owner/repo-a", "owner/repo-b"])
+    _write_cutover_ack(
+        state_dir,
+        ["owner/repo-a", "owner/repo-b"],
+        roots=[outside_git],
+    )
 
     result = _run_implicit_cli(cwd=outside_git, home=home)
 
     assert result.returncode == 0, result.stderr
     assert consolidated_db.exists()
+
+
+def test_host_ack_is_bound_to_host_user_inventory_and_reconciliation_epoch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    state_dir = tmp_path / "host-state" / "builderops"
+    legacy_db = repo / "runtime" / "builderops" / "builderops.sqlite3"
+    legacy_db.parent.mkdir(parents=True)
+    legacy_db.write_bytes(b"SQLite format 3\x00")
+    stale = datetime.now(timezone.utc) - timedelta(days=1)
+    monkeypatch.chdir(repo)
+
+    _write_cutover_ack(state_dir, roots=[repo], acknowledged_at=stale)
+    with pytest.raises(ValueError, match="fresh inventory epoch"):
+        builderops_config._validate_host_cutover_ack(state_dir)
+
+    _write_cutover_ack(state_dir, roots=[repo], host_id="copied-host")
+    with pytest.raises(ValueError, match="fresh inventory epoch"):
+        builderops_config._validate_host_cutover_ack(state_dir)
+
+    _write_cutover_ack(state_dir, roots=[repo], user_id="copied-user")
+    with pytest.raises(ValueError, match="fresh inventory epoch"):
+        builderops_config._validate_host_cutover_ack(state_dir)
+
+    other_repo = tmp_path / "new-participant"
+    other_repo.mkdir()
+    _write_cutover_ack(state_dir, roots=[repo])
+    monkeypatch.chdir(other_repo)
+    with pytest.raises(ValueError, match="fresh inventory epoch"):
+        builderops_config._validate_host_cutover_ack(state_dir)
+
+
+def test_host_ack_rejects_future_timestamp_and_permissive_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    state_dir = tmp_path / "host-state" / "builderops"
+    monkeypatch.chdir(repo)
+    _write_cutover_ack(
+        state_dir,
+        roots=[repo],
+        acknowledged_at=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+    with pytest.raises(ValueError, match="fresh inventory epoch"):
+        builderops_config._validate_host_cutover_ack(state_dir)
+
+    _write_cutover_ack(state_dir, roots=[repo])
+    builderops_config.host_cutover_ack_path(state_dir).chmod(0o644)
+    with pytest.raises(ValueError, match="fresh inventory epoch"):
+        builderops_config._validate_host_cutover_ack(state_dir)

--- a/tests/builderops/test_config_paths.py
+++ b/tests/builderops/test_config_paths.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import app.builderops.config as builderops_config
+
+
+def test_default_db_path_is_host_stable_and_cwd_independent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first_cwd = tmp_path / "worktree-a"
+    second_cwd = tmp_path / "worktree-b"
+    first_cwd.mkdir()
+    second_cwd.mkdir()
+
+    monkeypatch.chdir(first_cwd)
+    first = builderops_config.load_paths({})
+    monkeypatch.chdir(second_cwd)
+    second = builderops_config.load_paths({})
+
+    assert first.db_path == second.db_path
+    assert first.db_path == builderops_config.DEFAULT_STATE_DIR / "builderops.sqlite3"
+    assert first.db_path.is_absolute()
+
+
+def test_host_stable_default_still_confined_outside_vault(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = tmp_path / "shared-vault"
+    monkeypatch.setattr(builderops_config, "DEFAULT_STATE_DIR", vault / "builderops")
+
+    with pytest.raises(ValueError, match="outside BUILDEROPS_VAULT_ROOT"):
+        builderops_config.load_paths({"BUILDEROPS_VAULT_ROOT": str(vault)})
+
+
+def test_explicit_overrides_unchanged(tmp_path: Path) -> None:
+    from app.ops.builderops_startup import _builderops_db_path
+
+    relative_state_dir = Path("explicit-relative-state")
+    state_paths = builderops_config.load_paths(
+        {"BUILDEROPS_STATE_DIR": str(relative_state_dir)}
+    )
+    explicit_db_path = Path("explicit-relative.sqlite3")
+    db_paths = builderops_config.load_paths(
+        {"BUILDEROPS_DB_PATH": str(explicit_db_path)}
+    )
+    cli_override = Path("cli-relative.sqlite3")
+    cli_paths = builderops_config.load_paths({}, db_path_override=cli_override)
+
+    assert state_paths.state_dir == relative_state_dir
+    assert state_paths.db_path == relative_state_dir / "builderops.sqlite3"
+    assert db_paths.db_path == explicit_db_path
+    assert cli_paths.db_path == cli_override
+    assert _builderops_db_path(tmp_path, {}) == str(
+        builderops_config.DEFAULT_STATE_DIR / "builderops.sqlite3"
+    )
+    assert _builderops_db_path(
+        tmp_path,
+        {"BUILDEROPS_STATE_DIR": str(relative_state_dir)},
+    ) == str(tmp_path / relative_state_dir / "builderops.sqlite3")
+    assert _builderops_db_path(
+        tmp_path,
+        {"BUILDEROPS_DB_PATH": str(explicit_db_path)},
+    ) == str(explicit_db_path)

--- a/tests/builderops/test_config_paths.py
+++ b/tests/builderops/test_config_paths.py
@@ -144,6 +144,41 @@ def test_explicit_overrides_unchanged(tmp_path: Path) -> None:
     ) == str(explicit_db_path)
 
 
+@pytest.mark.parametrize("variable", ["BUILDEROPS_STATE_DIR", "BUILDEROPS_DB_PATH"])
+def test_blank_override_is_not_an_acknowledgement_bypass(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    variable: str,
+) -> None:
+    state_dir = tmp_path / "host-state" / "builderops"
+    monkeypatch.setattr(builderops_config, "default_state_dir", lambda: state_dir)
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(ValueError, match="cutover acknowledgement is required"):
+        builderops_config.load_paths({variable: "   "})
+
+    assert not (tmp_path / "builderops.sqlite3").exists()
+
+
+def test_nonblank_override_keeps_exact_path_semantics(tmp_path: Path) -> None:
+    from app.ops.builderops_startup import _builderops_db_path
+
+    raw_db_path = f" {tmp_path / 'pinned.sqlite3'} "
+    paths = builderops_config.load_paths({"BUILDEROPS_DB_PATH": raw_db_path})
+
+    assert str(paths.db_path) == raw_db_path
+    assert _builderops_db_path(tmp_path, {"BUILDEROPS_DB_PATH": raw_db_path}) == raw_db_path
+
+    raw_state_dir = f" {tmp_path / 'pinned-state'} "
+    state_paths = builderops_config.load_paths({"BUILDEROPS_STATE_DIR": raw_state_dir})
+
+    assert str(state_paths.state_dir) == raw_state_dir
+    assert str(state_paths.db_path) == str(Path(raw_state_dir) / "builderops.sqlite3")
+    assert _builderops_db_path(
+        tmp_path, {"BUILDEROPS_STATE_DIR": raw_state_dir}
+    ) == str(tmp_path / Path(raw_state_dir) / "builderops.sqlite3")
+
+
 def test_explicit_db_override_does_not_require_resolvable_home(tmp_path: Path) -> None:
     explicit_db = tmp_path / "explicit" / "builderops.sqlite3"
     code = f"""

--- a/tests/builderops/test_config_paths.py
+++ b/tests/builderops/test_config_paths.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 import subprocess
@@ -14,10 +15,46 @@ from app.builderops.store import SqliteBuilderOpsStore
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
+def _write_cutover_ack(state_dir: Path, repos: list[str] | None = None) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    builderops_config.host_cutover_ack_path(state_dir).write_text(
+        json.dumps(
+            {
+                "schema_version": builderops_config.CUTOVER_ACK_SCHEMA,
+                "scope": "same-user-same-host",
+                "legacy_stores_reconciled": True,
+                "participating_repos": repos or [],
+                "actor": "operator-test",
+                "acknowledged_at": "2026-07-15T00:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _run_implicit_cli(*, cwd: Path, home: Path) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    for key in ("BUILDEROPS_DB_PATH", "BUILDEROPS_STATE_DIR", "BUILDEROPS_VAULT_ROOT"):
+        env.pop(key, None)
+    return subprocess.run(
+        [sys.executable, "-m", "app.builderops", "builderops", "list", "--json"],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
 def test_default_db_path_is_host_stable_and_cwd_independent(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    state_dir = tmp_path / "host-state" / "builderops"
+    monkeypatch.setattr(builderops_config, "default_state_dir", lambda: state_dir)
+    _write_cutover_ack(state_dir, ["repo-a", "repo-b"])
     first_cwd = tmp_path / "worktree-a"
     second_cwd = tmp_path / "worktree-b"
     first_cwd.mkdir()
@@ -38,12 +75,13 @@ def test_host_stable_default_still_confined_outside_vault(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     vault = tmp_path / "shared-vault"
+    state_dir = vault / "builderops"
     monkeypatch.setattr(
         builderops_config,
         "default_state_dir",
-        lambda: vault / "builderops",
+        lambda: state_dir,
     )
-    monkeypatch.setattr(builderops_config, "_legacy_store_paths", lambda: ())
+    _write_cutover_ack(state_dir)
 
     with pytest.raises(ValueError, match="outside BUILDEROPS_VAULT_ROOT"):
         builderops_config.load_paths({"BUILDEROPS_VAULT_ROOT": str(vault)})
@@ -106,10 +144,14 @@ with patch.object(Path, "home", side_effect=RuntimeError("home unavailable")):
     assert result.returncode == 0, result.stderr
 
 
-def test_implicit_cli_fails_before_initializing_when_legacy_store_exists(
+def test_implicit_cli_requires_host_ack_when_legacy_store_is_in_another_repo(
     tmp_path: Path,
 ) -> None:
-    legacy_db = tmp_path / "runtime" / "builderops" / "builderops.sqlite3"
+    repo_a = tmp_path / "repo-a"
+    repo_b = tmp_path / "repo-b"
+    (repo_a / ".git").mkdir(parents=True)
+    (repo_b / ".git").mkdir(parents=True)
+    legacy_db = repo_b / "runtime" / "builderops" / "builderops.sqlite3"
     legacy_store = SqliteBuilderOpsStore(legacy_db)
     legacy_store.initialize()
     legacy_store.create_agent_worklog(
@@ -120,28 +162,44 @@ def test_implicit_cli_fails_before_initializing_when_legacy_store_exists(
         source_refs=[{"ref_type": "github_issue", "ref": "#3686"}],
         created_by={"actor_type": "agent", "id": "cutover-test"},
     )
-    home = tmp_path / "home"
+    home = tmp_path / "cross-repo-home"
     consolidated_db = home / ".local" / "state" / "builderops" / "builderops.sqlite3"
-    env = os.environ.copy()
-    env["HOME"] = str(home)
-    env["PYTHONPATH"] = str(REPO_ROOT)
-    for key in ("BUILDEROPS_DB_PATH", "BUILDEROPS_STATE_DIR", "BUILDEROPS_VAULT_ROOT"):
-        env.pop(key, None)
-
-    result = subprocess.run(
-        [sys.executable, "-m", "app.builderops", "builderops", "list", "--json"],
-        cwd=tmp_path,
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    result = _run_implicit_cli(cwd=repo_a, home=home)
 
     assert result.returncode != 0
     assert "Refusing implicit host-stable BuilderOps store selection" in (
         result.stderr + result.stdout
     )
-    assert "set BUILDEROPS_DB_PATH or BUILDEROPS_STATE_DIR explicitly" in (
+    assert "BUILDEROPS_DB_PATH / BUILDEROPS_STATE_DIR explicitly" in (
         result.stderr + result.stdout
     )
     assert not consolidated_db.exists()
+
+
+def test_implicit_cli_requires_host_ack_outside_git(tmp_path: Path) -> None:
+    outside_git = tmp_path / "outside-git"
+    outside_git.mkdir()
+    home = tmp_path / "outside-git-home"
+    consolidated_db = home / ".local" / "state" / "builderops" / "builderops.sqlite3"
+
+    result = _run_implicit_cli(cwd=outside_git, home=home)
+
+    assert result.returncode != 0
+    assert "same-user/same-host cutover acknowledgement is required" in (
+        result.stderr + result.stdout
+    )
+    assert not consolidated_db.exists()
+
+
+def test_valid_host_ack_allows_implicit_cli_outside_git(tmp_path: Path) -> None:
+    outside_git = tmp_path / "outside-git"
+    outside_git.mkdir()
+    home = tmp_path / "acknowledged-home"
+    state_dir = home / ".local" / "state" / "builderops"
+    consolidated_db = state_dir / "builderops.sqlite3"
+    _write_cutover_ack(state_dir, ["owner/repo-a", "owner/repo-b"])
+
+    result = _run_implicit_cli(cwd=outside_git, home=home)
+
+    assert result.returncode == 0, result.stderr
+    assert consolidated_db.exists()

--- a/tests/builderops/test_config_paths.py
+++ b/tests/builderops/test_config_paths.py
@@ -295,6 +295,35 @@ def test_host_ack_rejects_broad_parent_that_hides_newer_nested_legacy_store(
         builderops_config._validate_host_cutover_ack(state_dir)
 
 
+def test_host_ack_rejects_broad_secondary_root_with_newer_nested_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    current_repo = tmp_path / "repo-a"
+    broad_root = tmp_path / "workspace-b"
+    nested_repo = broad_root / "repo-b"
+    current_repo.mkdir()
+    nested_repo.mkdir(parents=True)
+    legacy_db = nested_repo / "runtime" / "builderops" / "builderops.sqlite3"
+    legacy_db.parent.mkdir(parents=True)
+    legacy_db.write_bytes(b"SQLite format 3\x00")
+    acknowledged_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+    newer = acknowledged_at + timedelta(seconds=30)
+    os.utime(legacy_db, (newer.timestamp(), newer.timestamp()))
+    state_dir = tmp_path / "host-state" / "builderops"
+    monkeypatch.chdir(current_repo)
+
+    _write_cutover_ack(
+        state_dir,
+        ["owner/repo-a", "owner/workspace-b"],
+        roots=[current_repo, broad_root],
+        acknowledged_at=acknowledged_at,
+    )
+
+    with pytest.raises(ValueError, match="fresh inventory epoch"):
+        builderops_config._validate_host_cutover_ack(state_dir)
+
+
 def test_host_ack_rejects_future_timestamp_and_permissive_mode(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/builderops/test_config_paths.py
+++ b/tests/builderops/test_config_paths.py
@@ -36,7 +36,9 @@ def _write_cutover_ack(
                 "host_id": host_id or builderops_config.current_host_id(),
                 "user_id": user_id or builderops_config.current_user_id(),
                 "legacy_stores_reconciled": True,
-                "participating_repos": repos or [],
+                "participating_repos": repos
+                if repos is not None
+                else [f"local/repo-{index}" for index, _root in enumerate(roots or [Path.cwd()])],
                 "participating_roots": [
                     str(root.resolve()) for root in (roots or [Path.cwd()])
                 ],
@@ -223,7 +225,7 @@ def test_valid_host_ack_allows_implicit_cli_outside_git(tmp_path: Path) -> None:
     consolidated_db = state_dir / "builderops.sqlite3"
     _write_cutover_ack(
         state_dir,
-        ["owner/repo-a", "owner/repo-b"],
+        ["owner/repo-a"],
         roots=[outside_git],
     )
 
@@ -262,6 +264,33 @@ def test_host_ack_is_bound_to_host_user_inventory_and_reconciliation_epoch(
     other_repo.mkdir()
     _write_cutover_ack(state_dir, roots=[repo])
     monkeypatch.chdir(other_repo)
+    with pytest.raises(ValueError, match="fresh inventory epoch"):
+        builderops_config._validate_host_cutover_ack(state_dir)
+
+
+def test_host_ack_rejects_broad_parent_that_hides_newer_nested_legacy_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = tmp_path / "workspace"
+    repo = workspace / "repo-a"
+    repo.mkdir(parents=True)
+    legacy_db = repo / "runtime" / "builderops" / "builderops.sqlite3"
+    legacy_db.parent.mkdir(parents=True)
+    legacy_db.write_bytes(b"SQLite format 3\x00")
+    acknowledged_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+    newer = acknowledged_at + timedelta(seconds=30)
+    os.utime(legacy_db, (newer.timestamp(), newer.timestamp()))
+    state_dir = tmp_path / "host-state" / "builderops"
+    monkeypatch.chdir(repo)
+
+    _write_cutover_ack(
+        state_dir,
+        ["owner/workspace"],
+        roots=[workspace],
+        acknowledged_at=acknowledged_at,
+    )
+
     with pytest.raises(ValueError, match="fresh inventory epoch"):
         builderops_config._validate_host_cutover_ack(state_dir)
 

--- a/tests/builderops/test_config_paths.py
+++ b/tests/builderops/test_config_paths.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
+import subprocess
+import sys
 
 import pytest
 
 import app.builderops.config as builderops_config
+from app.builderops.store import SqliteBuilderOpsStore
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_default_db_path_is_host_stable_and_cwd_independent(
@@ -22,7 +29,7 @@ def test_default_db_path_is_host_stable_and_cwd_independent(
     second = builderops_config.load_paths({})
 
     assert first.db_path == second.db_path
-    assert first.db_path == builderops_config.DEFAULT_STATE_DIR / "builderops.sqlite3"
+    assert first.db_path == builderops_config.default_state_dir() / "builderops.sqlite3"
     assert first.db_path.is_absolute()
 
 
@@ -31,7 +38,12 @@ def test_host_stable_default_still_confined_outside_vault(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     vault = tmp_path / "shared-vault"
-    monkeypatch.setattr(builderops_config, "DEFAULT_STATE_DIR", vault / "builderops")
+    monkeypatch.setattr(
+        builderops_config,
+        "default_state_dir",
+        lambda: vault / "builderops",
+    )
+    monkeypatch.setattr(builderops_config, "_legacy_store_paths", lambda: ())
 
     with pytest.raises(ValueError, match="outside BUILDEROPS_VAULT_ROOT"):
         builderops_config.load_paths({"BUILDEROPS_VAULT_ROOT": str(vault)})
@@ -56,7 +68,7 @@ def test_explicit_overrides_unchanged(tmp_path: Path) -> None:
     assert db_paths.db_path == explicit_db_path
     assert cli_paths.db_path == cli_override
     assert _builderops_db_path(tmp_path, {}) == str(
-        builderops_config.DEFAULT_STATE_DIR / "builderops.sqlite3"
+        builderops_config.default_state_dir() / "builderops.sqlite3"
     )
     assert _builderops_db_path(
         tmp_path,
@@ -66,3 +78,70 @@ def test_explicit_overrides_unchanged(tmp_path: Path) -> None:
         tmp_path,
         {"BUILDEROPS_DB_PATH": str(explicit_db_path)},
     ) == str(explicit_db_path)
+
+
+def test_explicit_db_override_does_not_require_resolvable_home(tmp_path: Path) -> None:
+    explicit_db = tmp_path / "explicit" / "builderops.sqlite3"
+    code = f"""
+from pathlib import Path
+from unittest.mock import patch
+
+with patch.object(Path, "home", side_effect=RuntimeError("home unavailable")):
+    from app.builderops.config import load_paths
+    paths = load_paths({{"BUILDEROPS_DB_PATH": {str(explicit_db)!r}}})
+    assert paths.db_path == Path({str(explicit_db)!r})
+"""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT)
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_implicit_cli_fails_before_initializing_when_legacy_store_exists(
+    tmp_path: Path,
+) -> None:
+    legacy_db = tmp_path / "runtime" / "builderops" / "builderops.sqlite3"
+    legacy_store = SqliteBuilderOpsStore(legacy_db)
+    legacy_store.initialize()
+    legacy_store.create_agent_worklog(
+        id="awl_legacy_cutover_guard",
+        summary="Legacy state must not be orphaned",
+        body="The implicit consolidated store must fail before initialization.",
+        task_context={"issue": "#3686"},
+        source_refs=[{"ref_type": "github_issue", "ref": "#3686"}],
+        created_by={"actor_type": "agent", "id": "cutover-test"},
+    )
+    home = tmp_path / "home"
+    consolidated_db = home / ".local" / "state" / "builderops" / "builderops.sqlite3"
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    for key in ("BUILDEROPS_DB_PATH", "BUILDEROPS_STATE_DIR", "BUILDEROPS_VAULT_ROOT"):
+        env.pop(key, None)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "app.builderops", "builderops", "list", "--json"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "Refusing implicit host-stable BuilderOps store selection" in (
+        result.stderr + result.stdout
+    )
+    assert "set BUILDEROPS_DB_PATH or BUILDEROPS_STATE_DIR explicitly" in (
+        result.stderr + result.stdout
+    )
+    assert not consolidated_db.exists()

--- a/tests/builderops/test_config_paths.py
+++ b/tests/builderops/test_config_paths.py
@@ -324,6 +324,47 @@ def test_host_ack_rejects_broad_secondary_root_with_newer_nested_store(
         builderops_config._validate_host_cutover_ack(state_dir)
 
 
+def test_host_ack_rejects_non_directory_secondary_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    current_repo = tmp_path / "repo-a"
+    current_repo.mkdir()
+    non_directory = tmp_path / "not-a-repository-root"
+    non_directory.write_text("not a directory", encoding="utf-8")
+    state_dir = tmp_path / "host-state" / "builderops"
+    monkeypatch.chdir(current_repo)
+    _write_cutover_ack(
+        state_dir,
+        ["owner/repo-a", "owner/not-a-root"],
+        roots=[current_repo, non_directory],
+    )
+
+    with pytest.raises(ValueError, match="fresh inventory epoch"):
+        builderops_config._validate_host_cutover_ack(state_dir)
+
+
+def test_host_ack_fails_closed_on_inventory_traversal_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    state_dir = tmp_path / "host-state" / "builderops"
+    monkeypatch.chdir(repo)
+    _write_cutover_ack(state_dir, ["owner/repo"], roots=[repo])
+
+    def failing_walk(root, *, followlinks, onerror):
+        assert Path(root) == repo
+        assert followlinks is False
+        onerror(PermissionError("inventory denied"))
+        return iter(())
+
+    monkeypatch.setattr(builderops_config.os, "walk", failing_walk)
+    with pytest.raises(ValueError, match="fresh inventory epoch"):
+        builderops_config._validate_host_cutover_ack(state_dir)
+
+
 def test_host_ack_rejects_future_timestamp_and_permissive_mode(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/builderops/test_model_inquiry_cli.py
+++ b/tests/builderops/test_model_inquiry_cli.py
@@ -839,3 +839,41 @@ def test_inquiry_run_dry_run_uses_common_runner(tmp_path: Path) -> None:
     assert payload["dry_run"] is True
     assert payload["unavailable_roles"] == ["fable", "gpt_codex"]
     assert ModelInquiryService.from_env(env).trace("inq_test_cli_run") == before
+
+
+def test_inquiry_start_honors_group_db_path_without_host_ack(tmp_path: Path) -> None:
+    vault = tmp_path / "shared-vault"
+    vault.mkdir()
+    question = tmp_path / "question.md"
+    question.write_text("Which store should this inquiry use?", encoding="utf-8")
+    explicit_db = tmp_path / "pinned" / "builderops.sqlite3"
+    env = {
+        "BUILDEROPS_VAULT_ROOT": str(vault),
+        "HOME": str(tmp_path / "home-without-cutover-marker"),
+    }
+
+    result = CliRunner().invoke(
+        builderops_root,
+        [
+            "builderops",
+            "--db-path",
+            str(explicit_db),
+            "inquiry",
+            "start",
+            "--question-file",
+            str(question),
+            "--workflow",
+            "fable-gpt-architecture",
+            "--inquiry-id",
+            "inq_test_explicit_db_bypass",
+            "--json",
+        ],
+        env=env,
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (
+        json.loads(result.output)["inquiry"]["inquiry_id"]
+        == "inq_test_explicit_db_bypass"
+    )

--- a/tests/builderops/test_store.py
+++ b/tests/builderops/test_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -13,10 +14,25 @@ def test_default_store_leases_coordinate_across_cwd(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    state_dir = tmp_path / "host-state" / "builderops"
     monkeypatch.setattr(
         builderops_config,
         "default_state_dir",
-        lambda: tmp_path / "host-state" / "builderops",
+        lambda: state_dir,
+    )
+    state_dir.mkdir(parents=True)
+    builderops_config.host_cutover_ack_path(state_dir).write_text(
+        json.dumps(
+            {
+                "schema_version": builderops_config.CUTOVER_ACK_SCHEMA,
+                "scope": "same-user-same-host",
+                "legacy_stores_reconciled": True,
+                "participating_repos": ["repo-a", "repo-b"],
+                "actor": "operator-test",
+                "acknowledged_at": "2026-07-15T00:00:00Z",
+            }
+        ),
+        encoding="utf-8",
     )
     first_cwd = tmp_path / "worktree-a"
     second_cwd = tmp_path / "worktree-b"

--- a/tests/builderops/test_store.py
+++ b/tests/builderops/test_store.py
@@ -15,8 +15,8 @@ def test_default_store_leases_coordinate_across_cwd(
 ) -> None:
     monkeypatch.setattr(
         builderops_config,
-        "DEFAULT_STATE_DIR",
-        tmp_path / "host-state" / "builderops",
+        "default_state_dir",
+        lambda: tmp_path / "host-state" / "builderops",
     )
     first_cwd = tmp_path / "worktree-a"
     second_cwd = tmp_path / "worktree-b"

--- a/tests/builderops/test_store.py
+++ b/tests/builderops/test_store.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
+from uuid import uuid4
 
 import pytest
 
@@ -20,24 +22,30 @@ def test_default_store_leases_coordinate_across_cwd(
         "default_state_dir",
         lambda: state_dir,
     )
-    state_dir.mkdir(parents=True)
-    builderops_config.host_cutover_ack_path(state_dir).write_text(
-        json.dumps(
-            {
-                "schema_version": builderops_config.CUTOVER_ACK_SCHEMA,
-                "scope": "same-user-same-host",
-                "legacy_stores_reconciled": True,
-                "participating_repos": ["repo-a", "repo-b"],
-                "actor": "operator-test",
-                "acknowledged_at": "2026-07-15T00:00:00Z",
-            }
-        ),
-        encoding="utf-8",
-    )
     first_cwd = tmp_path / "worktree-a"
     second_cwd = tmp_path / "worktree-b"
     first_cwd.mkdir()
     second_cwd.mkdir()
+    state_dir.mkdir(parents=True)
+    ack_path = builderops_config.host_cutover_ack_path(state_dir)
+    ack_path.write_text(
+        json.dumps(
+            {
+                "schema_version": builderops_config.CUTOVER_ACK_SCHEMA,
+                "scope": "same-user-same-host",
+                "host_id": builderops_config.current_host_id(),
+                "user_id": builderops_config.current_user_id(),
+                "legacy_stores_reconciled": True,
+                "participating_repos": ["repo-a", "repo-b"],
+                "participating_roots": [str(first_cwd), str(second_cwd)],
+                "inventory_epoch": str(uuid4()),
+                "actor": "operator-test",
+                "acknowledged_at": datetime.now(timezone.utc).isoformat(),
+            }
+        ),
+        encoding="utf-8",
+    )
+    ack_path.chmod(0o600)
 
     monkeypatch.chdir(first_cwd)
     first_store = SqliteBuilderOpsStore(builderops_config.load_paths({}).db_path)

--- a/tests/builderops/test_store.py
+++ b/tests/builderops/test_store.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import app.builderops.config as builderops_config
+from app.builderops.models import BuilderOpsLeaseError
+from app.builderops.store import SqliteBuilderOpsStore
+
+
+def test_default_store_leases_coordinate_across_cwd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        builderops_config,
+        "DEFAULT_STATE_DIR",
+        tmp_path / "host-state" / "builderops",
+    )
+    first_cwd = tmp_path / "worktree-a"
+    second_cwd = tmp_path / "worktree-b"
+    first_cwd.mkdir()
+    second_cwd.mkdir()
+
+    monkeypatch.chdir(first_cwd)
+    first_store = SqliteBuilderOpsStore(builderops_config.load_paths({}).db_path)
+    first_store.initialize()
+    first_store.create_agent_worklog(
+        id="awl_cross_cwd_lease",
+        summary="Cross-CWD lease coordination",
+        body="Both worktrees must use one same-host lease table.",
+        task_context={"issue": "#3686"},
+        source_refs=[{"ref_type": "github_issue", "ref": "#3686"}],
+        created_by={"actor_type": "agent", "id": "codex-a"},
+    )
+    first_store.acquire_lease(
+        "awl_cross_cwd_lease",
+        actor={"actor_type": "agent", "id": "codex-a"},
+    )
+
+    monkeypatch.chdir(second_cwd)
+    second_store = SqliteBuilderOpsStore(builderops_config.load_paths({}).db_path)
+
+    assert second_store.db_path == first_store.db_path
+    with pytest.raises(BuilderOpsLeaseError, match="active lease already exists"):
+        second_store.acquire_lease(
+            "awl_cross_cwd_lease",
+            actor={"actor_type": "agent", "id": "codex-b"},
+        )

--- a/tests/governance/test_start_model_inquiry_skill.py
+++ b/tests/governance/test_start_model_inquiry_skill.py
@@ -76,6 +76,7 @@ def _configured_env(tmp_path: Path) -> dict[str, str]:
         **os.environ,
         "PATH": "/usr/bin:/bin",
         "BUILDEROPS_PYTHON": sys.executable,
+        "BUILDEROPS_DB_PATH": str(tmp_path / "builderops.sqlite3"),
         "BUILDEROPS_VAULT_ROOT": str(vault),
         "BUILDEROPS_INQUIRY_ADAPTERS_JSON": json.dumps(config),
     }
@@ -277,7 +278,11 @@ def test_desktop_skills_route_to_macmini_launcher(tmp_path: Path) -> None:
 
 
 def test_skill_preflight_reports_missing_dependencies(tmp_path: Path) -> None:
-    clean_env = {"PATH": os.environ["PATH"], "BUILDEROPS_PYTHON": sys.executable}
+    clean_env = {
+        "PATH": os.environ["PATH"],
+        "BUILDEROPS_PYTHON": sys.executable,
+        "BUILDEROPS_DB_PATH": str(tmp_path / "builderops.sqlite3"),
+    }
     missing_vault = subprocess.run(
         [str(LAUNCHER), "Question"],
         cwd=REPO_ROOT,

--- a/tests/ops/test_builderops_startup_bootstrap.py
+++ b/tests/ops/test_builderops_startup_bootstrap.py
@@ -61,6 +61,28 @@ def test_builderops_bootstrap_environment_guard_covers_dev_and_prod_only() -> No
     assert "scripts/start_builderops_services.sh" in guard
 
 
+def test_builderops_readiness_degrades_before_implicit_cutover_without_host_ack(
+    tmp_path: Path,
+) -> None:
+    from app.ops.builderops_startup import _builderops_readiness
+
+    result: dict[str, object] = {"reasons": []}
+    receipt = _builderops_readiness(
+        root=REPO_ROOT,
+        env={"HOME": str(tmp_path / "home")},
+        result=result,
+    )
+
+    assert receipt["status"] == "degraded"
+    assert receipt["reason"] == "builderops_path_preflight_failed"
+    assert receipt["db_path"] is None
+    assert "same-user/same-host cutover acknowledgement is required" in str(
+        receipt["detail"]
+    )
+    assert result["reasons"] == ["builderops_path_preflight_failed"]
+    assert not (tmp_path / "home" / ".local" / "state" / "builderops").exists()
+
+
 def test_builderops_bootstrap_degrades_without_github_access(tmp_path: Path) -> None:
     startup_status = tmp_path / "startup_status.json"
     builderops_status = tmp_path / "builderops_status.json"

--- a/tests/ops/test_builderops_startup_bootstrap.py
+++ b/tests/ops/test_builderops_startup_bootstrap.py
@@ -4,10 +4,39 @@ import json
 import os
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
+from uuid import uuid4
+
+import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _write_cutover_ack(state_dir: Path) -> None:
+    from app.builderops import config as builderops_config
+
+    state_dir.mkdir(parents=True, exist_ok=True)
+    path = builderops_config.host_cutover_ack_path(state_dir)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": builderops_config.CUTOVER_ACK_SCHEMA,
+                "scope": "same-user-same-host",
+                "host_id": builderops_config.current_host_id(),
+                "user_id": builderops_config.current_user_id(),
+                "legacy_stores_reconciled": True,
+                "participating_repos": ["local/repo"],
+                "participating_roots": [str(Path.cwd().resolve())],
+                "inventory_epoch": str(uuid4()),
+                "actor": "operator-test",
+                "acknowledged_at": datetime.now(timezone.utc).isoformat(),
+            }
+        ),
+        encoding="utf-8",
+    )
+    path.chmod(0o600)
 
 
 def test_default_repos_include_agentic_and_bifrost() -> None:
@@ -81,6 +110,64 @@ def test_builderops_readiness_degrades_before_implicit_cutover_without_host_ack(
     )
     assert result["reasons"] == ["builderops_path_preflight_failed"]
     assert not (tmp_path / "home" / ".local" / "state" / "builderops").exists()
+
+
+@pytest.mark.parametrize("variable", ["BUILDEROPS_STATE_DIR", "BUILDEROPS_DB_PATH"])
+def test_builderops_readiness_does_not_treat_blank_override_as_explicit(
+    tmp_path: Path,
+    variable: str,
+) -> None:
+    from app.ops.builderops_startup import _builderops_readiness
+
+    result: dict[str, object] = {"reasons": []}
+    receipt = _builderops_readiness(
+        root=REPO_ROOT,
+        env={"HOME": str(tmp_path / "home"), variable: "   "},
+        result=result,
+    )
+
+    assert receipt["status"] == "degraded"
+    assert receipt["reason"] == "builderops_path_preflight_failed"
+    assert receipt["db_path"] is None
+    assert "same-user/same-host cutover acknowledgement is required" in str(
+        receipt["detail"]
+    )
+    assert result["reasons"] == ["builderops_path_preflight_failed"]
+    assert not (tmp_path / "home" / ".local" / "state" / "builderops").exists()
+
+
+@pytest.mark.parametrize("variable", ["BUILDEROPS_STATE_DIR", "BUILDEROPS_DB_PATH"])
+def test_builderops_readiness_reports_implicit_store_for_blank_override_after_ack(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    variable: str,
+) -> None:
+    from app.builderops import config as builderops_config
+    from app.ops import builderops_startup
+
+    state_dir = tmp_path / "host-state" / "builderops"
+    _write_cutover_ack(state_dir)
+    monkeypatch.setattr(builderops_config, "default_state_dir", lambda: state_dir)
+    monkeypatch.setattr(builderops_startup, "default_state_dir", lambda: state_dir)
+    monkeypatch.setattr(
+        builderops_startup,
+        "_run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="[]", stderr=""
+        ),
+    )
+
+    result: dict[str, object] = {"reasons": []}
+    receipt = builderops_startup._builderops_readiness(
+        root=REPO_ROOT,
+        env={variable: "   "},
+        result=result,
+    )
+
+    assert receipt["status"] == "ok"
+    assert receipt["db_path"] == str(state_dir / "builderops.sqlite3")
+    assert receipt["record_count"] == 0
+    assert result["reasons"] == []
 
 
 def test_builderops_bootstrap_degrades_without_github_access(tmp_path: Path) -> None:

--- a/tests/properties/test_read_purity.py
+++ b/tests/properties/test_read_purity.py
@@ -118,6 +118,7 @@ def _write_note(path: Path, *, with_uuid: bool) -> None:
 @pytest.fixture()
 def vault_with_uuid_note(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     bind_initialized_vault(monkeypatch, tmp_path)
+    monkeypatch.setenv("BUILDEROPS_DB_PATH", str(tmp_path / "builderops.sqlite3"))
     note = tmp_path / "notes" / "note.md"
     _write_note(note, with_uuid=True)
     return tmp_path
@@ -126,6 +127,7 @@ def vault_with_uuid_note(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Pat
 @pytest.fixture()
 def vault_missing_uuid_note(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     bind_initialized_vault(monkeypatch, tmp_path)
+    monkeypatch.setenv("BUILDEROPS_DB_PATH", str(tmp_path / "builderops.sqlite3"))
     note = tmp_path / "notes" / "note.md"
     _write_note(note, with_uuid=False)
     return tmp_path


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Governing-Issue: #3686
Fixes #3686

## SBS Impact
- Primary subsystem: Builder System / CES boundary (BuilderOps operating plane)
- Secondary subsystem(s): none
- Write class: authority-bearing local coordination state
- Authority impact: restores one same-user, same-host SQLite lease table across worktrees; no Product/Runtime authority change
- Persistence impact: durable machine-local BuilderOps SQLite state
- Derived/rebuildable impact: none
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: default path contract only; live-host consolidation/cutover remains operator-coordinated and is not performed by this PR
- External boundary impact: none
- New or changed contract: absent explicit override, the BuilderOps DB path is absolute and CWD-independent, and implicit selection requires an operator-created host cutover acknowledgement
- Owner-doc impact: updated in this PR (`docs/builderops/BUILDEROPS_VAULT_STORE.md`)
- Transition debt impact: reduces per-worktree operating-plane fragmentation without silently orphaning legacy cross-repo state
- Fitness rule impact: strengthens same-host lease serialization
- Boundary risk: medium; durable coordination path changes, with explicit overrides and vault confinement preserved

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Resolve the default BuilderOps state home to `~/.local/state/builderops`, independent of checkout/worktree CWD.
- Fail before implicit initialization until an operator installs bounded same-user/same-host cutover evidence after reconciling legacy stores across all participating repositories.
- Preserve explicit DB/state/CLI overrides as the operator-controlled pin/cutover path, along with lazy home resolution and vault confinement.
- Add regression coverage for cross-CWD path identity and lease conflicts, cross-repo and outside-Git fail-loud behavior, valid acknowledgement startup, startup readiness honesty, and unchanged overrides.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Validation
Implementation lane:
- [x] `ruff check app tests companion-ui/companion-app` — `All checks passed!`
- [x] Lint output included above.
- [x] `mypy app` — `Success: no issues found in 732 source files`
- [ ] `pytest -q -m "not pg"` — earlier full-lane run on the rebased PR: 8,301 passed; two unrelated baseline failures reproduced identically from a clean `origin/main` archive:
  - `tests/properties/test_guard_at_seam.py::test_every_write_note_relative_seam_has_port_coverage`
  - `tests/standing_questions/test_question_store.py::test_validate_question_note_rejects_bad_created_at_format`
- [x] Additional targeted checks on final repair `9892117a`:
  - focused path/store/startup suite — 44 passed
  - `pytest -q -m "not pg" tests/builderops` — 354 passed
  - `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1 python3 scripts/docs_guard.py` — OK
  - `git diff --check` — clean

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: the governing Issue, pickup receipt, PR, tests, and owner-doc writeback fully represent this bounded delivery; no learning divergence or cross-authority promotion material was produced.

## Coordination
- Pickup: `coordination_mode=github-label-only-fallback`
- Reason: `dispatcher_db_uninitialized`
- Receipt: issue comment `4974188974`

## Notes
- This PR does not inventory, migrate, merge, delete, or activate legacy per-worktree stores on the live host, and it does not create the host acknowledgement. The owner doc records the stop-writers/inventory/reconcile/acknowledge workflow.
- Explicit `BUILDEROPS_DB_PATH`, `BUILDEROPS_STATE_DIR`, and CLI `--db-path` behavior remains unchanged and bypasses the acknowledgement gate.

## Review Repair
- Commit `355a0b73` made home resolution lazy and added current-repo legacy-store discovery.
- Final commit `9892117a` replaces discovery with a required non-symlink host marker at `~/.local/state/builderops/host-store-cutover-v1.json`. Its schema records same-user/same-host scope, reconciliation acknowledgement, participating-repo inventory, actor, and timezone-aware timestamp.
- Missing or malformed evidence fails before DB creation in CLI and startup readiness, including outside Git and when a legacy store exists only in another repository. Errors remain privacy-safe.
- A valid marker enables the implicit host-global store; explicit overrides remain the operator bypass/cutover path. No live migration or cutover is performed.

