### PR TITLE
feat(memory): define provisional record lifecycle

### DIFF
--- a/app/agent_memory/provisional_memory.py
+++ b/app/agent_memory/provisional_memory.py
@@ -1,0 +1,282 @@
+"""Fail-closed read model for provisional, direct-write memory.
+
+Markdown is the only meaning-bearing input. Lifecycle receipts deliberately
+contain identifiers, hashes, and transition metadata only; they can never be
+used to reconstruct a missing claim.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from hashlib import sha256
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from app.agent_memory.candidate import MemoryType, ReviewState
+
+NonEmptyRef = Annotated[str, Field(min_length=1)]
+
+
+class ProvisionalEvidenceRole(str, Enum):
+    BACKGROUND = "background"
+    REFERENCE = "reference"
+    ANALOGY = "analogy"
+    INSPIRATION = "inspiration"
+    NON_EVIDENCE = "non_evidence"
+
+
+class ProvisionalSensitivity(str, Enum):
+    PUBLIC = "public"
+    INTERNAL = "internal"
+    PRIVATE = "private"
+    SECRET = "secret"
+
+
+class ProvisionalLifecycleTransition(str, Enum):
+    WRITE_STAGED = "write_staged"
+    CREATED = "created"
+    WRITE_FAILED = "write_failed"
+    DELETED = "deleted"
+
+
+class ProvisionalReconciliationState(str, Enum):
+    READY = "ready"
+    EDITED = "edited"
+    RETRYABLE_PARTIAL = "retryable_partial"
+    MISSING = "missing"
+    TERMINAL_DELETED = "terminal_deleted"
+    INCONSISTENT = "inconsistent"
+
+
+class ProvisionalMarkdownArtifact(BaseModel):
+    """Metadata parsed with the current content of one Markdown artifact."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    memory_id: str = Field(min_length=1)
+    artifact_ref: str = Field(min_length=1)
+    scope_id: str = Field(min_length=1)
+    principal_id: str = Field(min_length=1)
+    memory_type: MemoryType
+    evidence_role: ProvisionalEvidenceRole = ProvisionalEvidenceRole.BACKGROUND
+    sensitivity: ProvisionalSensitivity
+    content: str = Field(min_length=1)
+    created_by: str = Field(min_length=1)
+    created_at: datetime
+    provenance_event_ids: tuple[NonEmptyRef, ...] = Field(min_length=1)
+    source_role: Literal["agent_memory"] = "agent_memory"
+    authority_state: Literal["noncanonical"] = "noncanonical"
+    review_state: Literal[ReviewState.UNREVIEWED] = ReviewState.UNREVIEWED
+
+    @field_validator("created_at")
+    @classmethod
+    def _require_aware_created_at(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("created_at must be timezone-aware")
+        return value
+
+    @property
+    def content_digest(self) -> str:
+        return sha256(self.content.encode("utf-8")).hexdigest()
+
+
+class ProvisionalLifecycleReceipt(BaseModel):
+    """Content-free proof of a provisional-memory lifecycle transition."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    receipt_id: str = Field(min_length=1)
+    memory_id: str = Field(min_length=1)
+    artifact_ref: str = Field(min_length=1)
+    transition: ProvisionalLifecycleTransition
+    actor_ref: str = Field(min_length=1)
+    occurred_at: datetime
+    artifact_digest: str | None = Field(default=None, pattern=r"^[0-9a-f]{64}$")
+    error_code: str | None = None
+
+    @field_validator("occurred_at")
+    @classmethod
+    def _require_aware_occurred_at(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("occurred_at must be timezone-aware")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_transition_metadata(self) -> "ProvisionalLifecycleReceipt":
+        if self.transition is ProvisionalLifecycleTransition.CREATED:
+            if self.artifact_digest is None:
+                raise ValueError("created receipt requires artifact_digest")
+            if self.error_code is not None:
+                raise ValueError("created receipt cannot carry error_code")
+        elif self.transition is ProvisionalLifecycleTransition.WRITE_FAILED:
+            if not self.error_code:
+                raise ValueError("write_failed receipt requires error_code")
+            if self.artifact_digest is not None:
+                raise ValueError("failed write cannot claim an artifact digest")
+        elif self.error_code is not None:
+            raise ValueError("error_code is only valid for write_failed")
+        return self
+
+    @property
+    def terminal(self) -> bool:
+        return self.transition in {
+            ProvisionalLifecycleTransition.CREATED,
+            ProvisionalLifecycleTransition.DELETED,
+        }
+
+    @property
+    def retryable(self) -> bool:
+        return self.transition in {
+            ProvisionalLifecycleTransition.WRITE_STAGED,
+            ProvisionalLifecycleTransition.WRITE_FAILED,
+        }
+
+    def content_free_payload(self) -> dict[str, object]:
+        """Return the persistence shape; no claim-content field exists."""
+        return self.model_dump(mode="json", exclude_none=True)
+
+
+class ProvisionalMemoryRecord(BaseModel):
+    """Derived MemoryItem-compatible view of current Markdown content."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    memory_id: str
+    artifact_ref: str
+    scope_id: str
+    principal_id: str
+    memory_type: MemoryType
+    evidence_role: ProvisionalEvidenceRole
+    sensitivity: ProvisionalSensitivity
+    content: str
+    created_by: str
+    created_at: datetime
+    provenance_event_ids: tuple[NonEmptyRef, ...]
+    lifecycle_receipt_refs: tuple[NonEmptyRef, ...]
+    source_role: Literal["agent_memory"] = "agent_memory"
+    authority_state: Literal["noncanonical"] = "noncanonical"
+    review_state: Literal[ReviewState.UNREVIEWED] = ReviewState.UNREVIEWED
+    may_read: Literal[True] = True
+    may_support_cited_proposal: Literal[True] = True
+    may_apply: Literal[False] = False
+    may_write: Literal[False] = False
+
+
+class ProvisionalMemoryReconciliation(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    memory_id: str
+    artifact_ref: str
+    state: ProvisionalReconciliationState
+    record: ProvisionalMemoryRecord | None = None
+    receipt_refs: tuple[str, ...] = ()
+    diagnostic: str
+
+
+def rebuild_provisional_memory(
+    *,
+    memory_id: str,
+    artifact_ref: str,
+    artifact: ProvisionalMarkdownArtifact | None,
+    receipts: tuple[ProvisionalLifecycleReceipt, ...] = (),
+) -> ProvisionalMemoryReconciliation:
+    """Reconcile current Markdown with content-free lifecycle receipts.
+
+    Incomplete pairs fail closed. A completed artifact remains readable after a
+    human edit, but its state exposes that the receipt digest describes an
+    earlier revision. Missing Markdown always produces ``record=None``.
+    """
+    ordered = tuple(sorted(receipts, key=lambda item: (item.occurred_at, item.receipt_id)))
+    refs = tuple(receipt.receipt_id for receipt in ordered)
+    if any(
+        receipt.memory_id != memory_id or receipt.artifact_ref != artifact_ref
+        for receipt in ordered
+    ):
+        return _reconciliation(
+            memory_id, artifact_ref, ProvisionalReconciliationState.INCONSISTENT,
+            refs, "receipt_identity_mismatch",
+        )
+    if artifact is not None and (
+        artifact.memory_id != memory_id or artifact.artifact_ref != artifact_ref
+    ):
+        return _reconciliation(
+            memory_id, artifact_ref, ProvisionalReconciliationState.INCONSISTENT,
+            refs, "artifact_identity_mismatch",
+        )
+
+    latest = ordered[-1] if ordered else None
+    if latest is not None and latest.transition is ProvisionalLifecycleTransition.DELETED:
+        return _reconciliation(
+            memory_id, artifact_ref, ProvisionalReconciliationState.TERMINAL_DELETED,
+            refs, "terminal_delete_receipt",
+        )
+    if artifact is None:
+        state = (
+            ProvisionalReconciliationState.RETRYABLE_PARTIAL
+            if latest is None or latest.retryable
+            else ProvisionalReconciliationState.MISSING
+        )
+        diagnostic = (
+            "artifact_absent_retryable"
+            if state is ProvisionalReconciliationState.RETRYABLE_PARTIAL
+            else "artifact_missing_after_success"
+        )
+        return _reconciliation(memory_id, artifact_ref, state, refs, diagnostic)
+    if latest is None or latest.retryable:
+        return _reconciliation(
+            memory_id, artifact_ref, ProvisionalReconciliationState.RETRYABLE_PARTIAL,
+            refs, "artifact_without_terminal_success_receipt",
+        )
+    if latest.transition is not ProvisionalLifecycleTransition.CREATED:
+        return _reconciliation(
+            memory_id, artifact_ref, ProvisionalReconciliationState.INCONSISTENT,
+            refs, "unsupported_terminal_transition",
+        )
+
+    state = (
+        ProvisionalReconciliationState.READY
+        if latest.artifact_digest == artifact.content_digest
+        else ProvisionalReconciliationState.EDITED
+    )
+    record = ProvisionalMemoryRecord(
+        **artifact.model_dump(),
+        lifecycle_receipt_refs=refs,
+    )
+    return ProvisionalMemoryReconciliation(
+        memory_id=memory_id,
+        artifact_ref=artifact_ref,
+        state=state,
+        record=record,
+        receipt_refs=refs,
+        diagnostic="receipt_matches_markdown" if state is ProvisionalReconciliationState.READY else "markdown_edited_after_receipt",
+    )
+
+
+def _reconciliation(
+    memory_id: str,
+    artifact_ref: str,
+    state: ProvisionalReconciliationState,
+    receipt_refs: tuple[str, ...],
+    diagnostic: str,
+) -> ProvisionalMemoryReconciliation:
+    return ProvisionalMemoryReconciliation(
+        memory_id=memory_id,
+        artifact_ref=artifact_ref,
+        state=state,
+        receipt_refs=receipt_refs,
+        diagnostic=diagnostic,
+    )
+
+
+__all__ = [
+    "ProvisionalEvidenceRole",
+    "ProvisionalLifecycleReceipt",
+    "ProvisionalLifecycleTransition",
+    "ProvisionalMarkdownArtifact",
+    "ProvisionalMemoryReconciliation",
+    "ProvisionalMemoryRecord",
+    "ProvisionalReconciliationState",
+    "ProvisionalSensitivity",
+    "rebuild_provisional_memory",
+]

--- a/app/agent_memory/provisional_memory.py
+++ b/app/agent_memory/provisional_memory.py
@@ -40,6 +40,14 @@ class ProvisionalLifecycleTransition(str, Enum):
     DELETED = "deleted"
 
 
+class ProvisionalFailureCode(str, Enum):
+    VAULT_WRITE_FAILED = "vault_write_failed"
+    RECEIPT_PERSIST_FAILED = "receipt_persist_failed"
+    VALIDATION_FAILED = "validation_failed"
+    WRITE_CONFLICT = "write_conflict"
+    PERMISSION_DENIED = "permission_denied"
+
+
 class ProvisionalReconciliationState(str, Enum):
     READY = "ready"
     EDITED = "edited"
@@ -93,7 +101,7 @@ class ProvisionalLifecycleReceipt(BaseModel):
     actor_ref: str = Field(min_length=1)
     occurred_at: datetime
     artifact_digest: str | None = Field(default=None, pattern=r"^[0-9a-f]{64}$")
-    error_code: str | None = None
+    error_code: ProvisionalFailureCode | None = None
 
     @field_validator("occurred_at")
     @classmethod
@@ -142,18 +150,18 @@ class ProvisionalMemoryRecord(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    memory_id: str
-    artifact_ref: str
-    scope_id: str
-    principal_id: str
+    memory_id: str = Field(min_length=1)
+    artifact_ref: str = Field(min_length=1)
+    scope_id: str = Field(min_length=1)
+    principal_id: str = Field(min_length=1)
     memory_type: MemoryType
     evidence_role: ProvisionalEvidenceRole
     sensitivity: ProvisionalSensitivity
-    content: str
-    created_by: str
+    content: str = Field(min_length=1)
+    created_by: str = Field(min_length=1)
     created_at: datetime
-    provenance_event_ids: tuple[NonEmptyRef, ...]
-    lifecycle_receipt_refs: tuple[NonEmptyRef, ...]
+    provenance_event_ids: tuple[NonEmptyRef, ...] = Field(min_length=1)
+    lifecycle_receipt_refs: tuple[NonEmptyRef, ...] = Field(min_length=1)
     source_role: Literal["agent_memory"] = "agent_memory"
     authority_state: Literal["noncanonical"] = "noncanonical"
     review_state: Literal[ReviewState.UNREVIEWED] = ReviewState.UNREVIEWED
@@ -161,6 +169,13 @@ class ProvisionalMemoryRecord(BaseModel):
     may_support_cited_proposal: Literal[True] = True
     may_apply: Literal[False] = False
     may_write: Literal[False] = False
+
+    @field_validator("created_at")
+    @classmethod
+    def _require_aware_created_at(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("created_at must be timezone-aware")
+        return value
 
 
 class ProvisionalMemoryReconciliation(BaseModel):
@@ -206,7 +221,10 @@ def rebuild_provisional_memory(
         )
 
     latest = ordered[-1] if ordered else None
-    if latest is not None and latest.transition is ProvisionalLifecycleTransition.DELETED:
+    if any(
+        receipt.transition is ProvisionalLifecycleTransition.DELETED
+        for receipt in ordered
+    ):
         return _reconciliation(
             memory_id, artifact_ref, ProvisionalReconciliationState.TERMINAL_DELETED,
             refs, "terminal_delete_receipt",
@@ -271,6 +289,7 @@ def _reconciliation(
 
 __all__ = [
     "ProvisionalEvidenceRole",
+    "ProvisionalFailureCode",
     "ProvisionalLifecycleReceipt",
     "ProvisionalLifecycleTransition",
     "ProvisionalMarkdownArtifact",

--- a/app/agent_memory/provisional_memory.py
+++ b/app/agent_memory/provisional_memory.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from datetime import datetime
 from enum import Enum
 from hashlib import sha256
+import json
 from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -16,6 +17,26 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from app.agent_memory.candidate import MemoryType, ReviewState
 
 NonEmptyRef = Annotated[str, Field(min_length=1)]
+OpaqueId = Annotated[
+    str,
+    Field(min_length=1, max_length=128, pattern=r"^[A-Za-z0-9][A-Za-z0-9._:-]*$"),
+]
+ArtifactRef = Annotated[
+    str,
+    Field(
+        min_length=12,
+        max_length=256,
+        pattern=r"^vault://[A-Za-z0-9._~!$&'()*+,;=:@%/-]+\.md$",
+    ),
+]
+ActorRef = Annotated[
+    str,
+    Field(
+        min_length=9,
+        max_length=80,
+        pattern=r"^(agent|human|system)://[A-Za-z0-9][A-Za-z0-9._:-]*$",
+    ),
+]
 
 
 class ProvisionalEvidenceRole(str, Enum):
@@ -57,20 +78,34 @@ class ProvisionalReconciliationState(str, Enum):
     INCONSISTENT = "inconsistent"
 
 
+class ProvisionalDiagnostic(str, Enum):
+    RECEIPT_IDENTITY_MISMATCH = "receipt_identity_mismatch"
+    ARTIFACT_IDENTITY_MISMATCH = "artifact_identity_mismatch"
+    CONFLICTING_RECEIPT_ID = "conflicting_receipt_id"
+    AMBIGUOUS_RECEIPT_ORDER = "ambiguous_receipt_order"
+    TERMINAL_DELETE_RECEIPT = "terminal_delete_receipt"
+    ARTIFACT_ABSENT_RETRYABLE = "artifact_absent_retryable"
+    ARTIFACT_MISSING_AFTER_SUCCESS = "artifact_missing_after_success"
+    ARTIFACT_WITHOUT_SUCCESS = "artifact_without_terminal_success_receipt"
+    UNSUPPORTED_TERMINAL = "unsupported_terminal_transition"
+    RECEIPT_MATCHES_MARKDOWN = "receipt_matches_markdown"
+    MARKDOWN_EDITED_AFTER_RECEIPT = "markdown_edited_after_receipt"
+
+
 class ProvisionalMarkdownArtifact(BaseModel):
     """Metadata parsed with the current content of one Markdown artifact."""
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    memory_id: str = Field(min_length=1)
-    artifact_ref: str = Field(min_length=1)
-    scope_id: str = Field(min_length=1)
-    principal_id: str = Field(min_length=1)
+    memory_id: OpaqueId
+    artifact_ref: ArtifactRef
+    scope_id: OpaqueId
+    principal_id: OpaqueId
     memory_type: MemoryType
     evidence_role: ProvisionalEvidenceRole = ProvisionalEvidenceRole.BACKGROUND
     sensitivity: ProvisionalSensitivity
     content: str = Field(min_length=1)
-    created_by: str = Field(min_length=1)
+    created_by: ActorRef
     created_at: datetime
     provenance_event_ids: tuple[NonEmptyRef, ...] = Field(min_length=1)
     source_role: Literal["agent_memory"] = "agent_memory"
@@ -85,8 +120,14 @@ class ProvisionalMarkdownArtifact(BaseModel):
         return value
 
     @property
-    def content_digest(self) -> str:
-        return sha256(self.content.encode("utf-8")).hexdigest()
+    def artifact_digest(self) -> str:
+        canonical = json.dumps(
+            self.model_dump(mode="json"),
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        return sha256(canonical.encode("utf-8")).hexdigest()
 
 
 class ProvisionalLifecycleReceipt(BaseModel):
@@ -94,11 +135,11 @@ class ProvisionalLifecycleReceipt(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    receipt_id: str = Field(min_length=1)
-    memory_id: str = Field(min_length=1)
-    artifact_ref: str = Field(min_length=1)
+    receipt_id: OpaqueId
+    memory_id: OpaqueId
+    artifact_ref: ArtifactRef
     transition: ProvisionalLifecycleTransition
-    actor_ref: str = Field(min_length=1)
+    actor_ref: ActorRef
     occurred_at: datetime
     artifact_digest: str | None = Field(default=None, pattern=r"^[0-9a-f]{64}$")
     error_code: ProvisionalFailureCode | None = None
@@ -150,18 +191,18 @@ class ProvisionalMemoryRecord(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    memory_id: str = Field(min_length=1)
-    artifact_ref: str = Field(min_length=1)
-    scope_id: str = Field(min_length=1)
-    principal_id: str = Field(min_length=1)
+    memory_id: OpaqueId
+    artifact_ref: ArtifactRef
+    scope_id: OpaqueId
+    principal_id: OpaqueId
     memory_type: MemoryType
     evidence_role: ProvisionalEvidenceRole
     sensitivity: ProvisionalSensitivity
     content: str = Field(min_length=1)
-    created_by: str = Field(min_length=1)
+    created_by: ActorRef
     created_at: datetime
     provenance_event_ids: tuple[NonEmptyRef, ...] = Field(min_length=1)
-    lifecycle_receipt_refs: tuple[NonEmptyRef, ...] = Field(min_length=1)
+    lifecycle_receipt_refs: tuple[OpaqueId, ...] = Field(min_length=1)
     source_role: Literal["agent_memory"] = "agent_memory"
     authority_state: Literal["noncanonical"] = "noncanonical"
     review_state: Literal[ReviewState.UNREVIEWED] = ReviewState.UNREVIEWED
@@ -181,12 +222,32 @@ class ProvisionalMemoryRecord(BaseModel):
 class ProvisionalMemoryReconciliation(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    memory_id: str
-    artifact_ref: str
+    memory_id: OpaqueId
+    artifact_ref: ArtifactRef
     state: ProvisionalReconciliationState
     record: ProvisionalMemoryRecord | None = None
-    receipt_refs: tuple[str, ...] = ()
-    diagnostic: str
+    receipt_refs: tuple[OpaqueId, ...] = ()
+    diagnostic: ProvisionalDiagnostic
+
+    @model_validator(mode="after")
+    def _enforce_record_posture(self) -> "ProvisionalMemoryReconciliation":
+        readable = self.state in {
+            ProvisionalReconciliationState.READY,
+            ProvisionalReconciliationState.EDITED,
+        }
+        if readable and self.record is None:
+            raise ValueError("readable reconciliation state requires record")
+        if not readable and self.record is not None:
+            raise ValueError("excluded reconciliation state cannot carry record")
+        if self.record is not None:
+            if (
+                self.record.memory_id != self.memory_id
+                or self.record.artifact_ref != self.artifact_ref
+            ):
+                raise ValueError("record identity must match reconciliation envelope")
+            if self.record.lifecycle_receipt_refs != self.receipt_refs:
+                raise ValueError("record receipt refs must match reconciliation envelope")
+        return self
 
 
 def rebuild_provisional_memory(
@@ -202,7 +263,10 @@ def rebuild_provisional_memory(
     human edit, but its state exposes that the receipt digest describes an
     earlier revision. Missing Markdown always produces ``record=None``.
     """
-    ordered = tuple(sorted(receipts, key=lambda item: (item.occurred_at, item.receipt_id)))
+    normalized, conflict = _normalize_receipts(receipts)
+    if conflict is not None:
+        return _reconciliation(memory_id, artifact_ref, conflict[0], (), conflict[1])
+    ordered = tuple(sorted(normalized, key=lambda item: (item.occurred_at, item.receipt_id)))
     refs = tuple(receipt.receipt_id for receipt in ordered)
     if any(
         receipt.memory_id != memory_id or receipt.artifact_ref != artifact_ref
@@ -210,14 +274,14 @@ def rebuild_provisional_memory(
     ):
         return _reconciliation(
             memory_id, artifact_ref, ProvisionalReconciliationState.INCONSISTENT,
-            refs, "receipt_identity_mismatch",
+            refs, ProvisionalDiagnostic.RECEIPT_IDENTITY_MISMATCH,
         )
     if artifact is not None and (
         artifact.memory_id != memory_id or artifact.artifact_ref != artifact_ref
     ):
         return _reconciliation(
             memory_id, artifact_ref, ProvisionalReconciliationState.INCONSISTENT,
-            refs, "artifact_identity_mismatch",
+            refs, ProvisionalDiagnostic.ARTIFACT_IDENTITY_MISMATCH,
         )
 
     latest = ordered[-1] if ordered else None
@@ -227,7 +291,7 @@ def rebuild_provisional_memory(
     ):
         return _reconciliation(
             memory_id, artifact_ref, ProvisionalReconciliationState.TERMINAL_DELETED,
-            refs, "terminal_delete_receipt",
+            refs, ProvisionalDiagnostic.TERMINAL_DELETE_RECEIPT,
         )
     if artifact is None:
         state = (
@@ -236,25 +300,25 @@ def rebuild_provisional_memory(
             else ProvisionalReconciliationState.MISSING
         )
         diagnostic = (
-            "artifact_absent_retryable"
+            ProvisionalDiagnostic.ARTIFACT_ABSENT_RETRYABLE
             if state is ProvisionalReconciliationState.RETRYABLE_PARTIAL
-            else "artifact_missing_after_success"
+            else ProvisionalDiagnostic.ARTIFACT_MISSING_AFTER_SUCCESS
         )
         return _reconciliation(memory_id, artifact_ref, state, refs, diagnostic)
     if latest is None or latest.retryable:
         return _reconciliation(
             memory_id, artifact_ref, ProvisionalReconciliationState.RETRYABLE_PARTIAL,
-            refs, "artifact_without_terminal_success_receipt",
+            refs, ProvisionalDiagnostic.ARTIFACT_WITHOUT_SUCCESS,
         )
     if latest.transition is not ProvisionalLifecycleTransition.CREATED:
         return _reconciliation(
             memory_id, artifact_ref, ProvisionalReconciliationState.INCONSISTENT,
-            refs, "unsupported_terminal_transition",
+            refs, ProvisionalDiagnostic.UNSUPPORTED_TERMINAL,
         )
 
     state = (
         ProvisionalReconciliationState.READY
-        if latest.artifact_digest == artifact.content_digest
+        if latest.artifact_digest == artifact.artifact_digest
         else ProvisionalReconciliationState.EDITED
     )
     record = ProvisionalMemoryRecord(
@@ -267,7 +331,11 @@ def rebuild_provisional_memory(
         state=state,
         record=record,
         receipt_refs=refs,
-        diagnostic="receipt_matches_markdown" if state is ProvisionalReconciliationState.READY else "markdown_edited_after_receipt",
+        diagnostic=(
+            ProvisionalDiagnostic.RECEIPT_MATCHES_MARKDOWN
+            if state is ProvisionalReconciliationState.READY
+            else ProvisionalDiagnostic.MARKDOWN_EDITED_AFTER_RECEIPT
+        ),
     )
 
 
@@ -276,7 +344,7 @@ def _reconciliation(
     artifact_ref: str,
     state: ProvisionalReconciliationState,
     receipt_refs: tuple[str, ...],
-    diagnostic: str,
+    diagnostic: ProvisionalDiagnostic,
 ) -> ProvisionalMemoryReconciliation:
     return ProvisionalMemoryReconciliation(
         memory_id=memory_id,
@@ -287,8 +355,34 @@ def _reconciliation(
     )
 
 
+def _normalize_receipts(
+    receipts: tuple[ProvisionalLifecycleReceipt, ...],
+) -> tuple[
+    tuple[ProvisionalLifecycleReceipt, ...],
+    tuple[ProvisionalReconciliationState, ProvisionalDiagnostic] | None,
+]:
+    by_id: dict[str, ProvisionalLifecycleReceipt] = {}
+    for receipt in receipts:
+        existing = by_id.get(receipt.receipt_id)
+        if existing is not None and existing != receipt:
+            return (), (
+                ProvisionalReconciliationState.INCONSISTENT,
+                ProvisionalDiagnostic.CONFLICTING_RECEIPT_ID,
+            )
+        by_id[receipt.receipt_id] = receipt
+    normalized = tuple(by_id.values())
+    timestamps = [receipt.occurred_at for receipt in normalized]
+    if len(timestamps) != len(set(timestamps)):
+        return (), (
+            ProvisionalReconciliationState.INCONSISTENT,
+            ProvisionalDiagnostic.AMBIGUOUS_RECEIPT_ORDER,
+        )
+    return normalized, None
+
+
 __all__ = [
     "ProvisionalEvidenceRole",
+    "ProvisionalDiagnostic",
     "ProvisionalFailureCode",
     "ProvisionalLifecycleReceipt",
     "ProvisionalLifecycleTransition",

--- a/app/agent_memory/provisional_memory.py
+++ b/app/agent_memory/provisional_memory.py
@@ -221,6 +221,12 @@ class ProvisionalMemoryRecord(BaseModel):
     may_apply: Literal[False] = False
     may_write: Literal[False] = False
 
+    @model_validator(mode="after")
+    def _require_canonical_artifact_ref(self) -> "ProvisionalMemoryRecord":
+        if self.artifact_ref != _artifact_ref_for(self.memory_id):
+            raise ValueError("artifact_ref must be canonical for memory_id")
+        return self
+
     @field_validator("created_at")
     @classmethod
     def _require_aware_created_at(cls, value: datetime) -> datetime:

--- a/app/agent_memory/provisional_memory.py
+++ b/app/agent_memory/provisional_memory.py
@@ -12,29 +12,25 @@ from hashlib import sha256
 import json
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import UUID4, BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from app.agent_memory.candidate import MemoryType, ReviewState
 
 NonEmptyRef = Annotated[str, Field(min_length=1)]
-OpaqueId = Annotated[
+EntityId = Annotated[
     str,
     Field(min_length=1, max_length=128, pattern=r"^[A-Za-z0-9][A-Za-z0-9._:-]*$"),
 ]
 ArtifactRef = Annotated[
     str,
     Field(
-        min_length=12,
-        max_length=256,
-        pattern=r"^vault://[A-Za-z0-9._~!$&'()*+,;=:@%/-]+\.md$",
-    ),
-]
-ActorRef = Annotated[
-    str,
-    Field(
-        min_length=9,
-        max_length=80,
-        pattern=r"^(agent|human|system)://[A-Za-z0-9][A-Za-z0-9._:-]*$",
+        min_length=66,
+        max_length=66,
+        pattern=(
+            r"^vault://Memory/Provisional/"
+            r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-"
+            r"[0-9a-f]{12}\.md$"
+        ),
     ),
 ]
 
@@ -69,6 +65,12 @@ class ProvisionalFailureCode(str, Enum):
     PERMISSION_DENIED = "permission_denied"
 
 
+class ProvisionalActor(str, Enum):
+    AGENT = "agent"
+    HUMAN = "human"
+    SYSTEM = "system"
+
+
 class ProvisionalReconciliationState(str, Enum):
     READY = "ready"
     EDITED = "edited"
@@ -97,20 +99,26 @@ class ProvisionalMarkdownArtifact(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    memory_id: OpaqueId
+    memory_id: UUID4
     artifact_ref: ArtifactRef
-    scope_id: OpaqueId
-    principal_id: OpaqueId
+    scope_id: EntityId
+    principal_id: EntityId
     memory_type: MemoryType
     evidence_role: ProvisionalEvidenceRole = ProvisionalEvidenceRole.BACKGROUND
     sensitivity: ProvisionalSensitivity
     content: str = Field(min_length=1)
-    created_by: ActorRef
+    created_by: NonEmptyRef
     created_at: datetime
     provenance_event_ids: tuple[NonEmptyRef, ...] = Field(min_length=1)
     source_role: Literal["agent_memory"] = "agent_memory"
     authority_state: Literal["noncanonical"] = "noncanonical"
     review_state: Literal[ReviewState.UNREVIEWED] = ReviewState.UNREVIEWED
+
+    @model_validator(mode="after")
+    def _require_canonical_artifact_ref(self) -> "ProvisionalMarkdownArtifact":
+        if self.artifact_ref != _artifact_ref_for(self.memory_id):
+            raise ValueError("artifact_ref must be canonical for memory_id")
+        return self
 
     @field_validator("created_at")
     @classmethod
@@ -135,11 +143,11 @@ class ProvisionalLifecycleReceipt(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    receipt_id: OpaqueId
-    memory_id: OpaqueId
+    receipt_id: UUID4
+    memory_id: UUID4
     artifact_ref: ArtifactRef
     transition: ProvisionalLifecycleTransition
-    actor_ref: ActorRef
+    actor_ref: ProvisionalActor
     occurred_at: datetime
     artifact_digest: str | None = Field(default=None, pattern=r"^[0-9a-f]{64}$")
     error_code: ProvisionalFailureCode | None = None
@@ -153,6 +161,8 @@ class ProvisionalLifecycleReceipt(BaseModel):
 
     @model_validator(mode="after")
     def _validate_transition_metadata(self) -> "ProvisionalLifecycleReceipt":
+        if self.artifact_ref != _artifact_ref_for(self.memory_id):
+            raise ValueError("artifact_ref must be canonical for memory_id")
         if self.transition is ProvisionalLifecycleTransition.CREATED:
             if self.artifact_digest is None:
                 raise ValueError("created receipt requires artifact_digest")
@@ -191,18 +201,18 @@ class ProvisionalMemoryRecord(BaseModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    memory_id: OpaqueId
+    memory_id: UUID4
     artifact_ref: ArtifactRef
-    scope_id: OpaqueId
-    principal_id: OpaqueId
+    scope_id: EntityId
+    principal_id: EntityId
     memory_type: MemoryType
     evidence_role: ProvisionalEvidenceRole
     sensitivity: ProvisionalSensitivity
     content: str = Field(min_length=1)
-    created_by: ActorRef
+    created_by: NonEmptyRef
     created_at: datetime
     provenance_event_ids: tuple[NonEmptyRef, ...] = Field(min_length=1)
-    lifecycle_receipt_refs: tuple[OpaqueId, ...] = Field(min_length=1)
+    lifecycle_receipt_refs: tuple[UUID4, ...] = Field(min_length=1)
     source_role: Literal["agent_memory"] = "agent_memory"
     authority_state: Literal["noncanonical"] = "noncanonical"
     review_state: Literal[ReviewState.UNREVIEWED] = ReviewState.UNREVIEWED
@@ -222,15 +232,17 @@ class ProvisionalMemoryRecord(BaseModel):
 class ProvisionalMemoryReconciliation(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    memory_id: OpaqueId
+    memory_id: UUID4
     artifact_ref: ArtifactRef
     state: ProvisionalReconciliationState
     record: ProvisionalMemoryRecord | None = None
-    receipt_refs: tuple[OpaqueId, ...] = ()
+    receipt_refs: tuple[UUID4, ...] = ()
     diagnostic: ProvisionalDiagnostic
 
     @model_validator(mode="after")
     def _enforce_record_posture(self) -> "ProvisionalMemoryReconciliation":
+        if self.artifact_ref != _artifact_ref_for(self.memory_id):
+            raise ValueError("artifact_ref must be canonical for memory_id")
         readable = self.state in {
             ProvisionalReconciliationState.READY,
             ProvisionalReconciliationState.EDITED,
@@ -252,7 +264,7 @@ class ProvisionalMemoryReconciliation(BaseModel):
 
 def rebuild_provisional_memory(
     *,
-    memory_id: str,
+    memory_id: UUID4,
     artifact_ref: str,
     artifact: ProvisionalMarkdownArtifact | None,
     receipts: tuple[ProvisionalLifecycleReceipt, ...] = (),
@@ -340,10 +352,10 @@ def rebuild_provisional_memory(
 
 
 def _reconciliation(
-    memory_id: str,
+    memory_id: UUID4,
     artifact_ref: str,
     state: ProvisionalReconciliationState,
-    receipt_refs: tuple[str, ...],
+    receipt_refs: tuple[UUID4, ...],
     diagnostic: ProvisionalDiagnostic,
 ) -> ProvisionalMemoryReconciliation:
     return ProvisionalMemoryReconciliation(
@@ -361,7 +373,7 @@ def _normalize_receipts(
     tuple[ProvisionalLifecycleReceipt, ...],
     tuple[ProvisionalReconciliationState, ProvisionalDiagnostic] | None,
 ]:
-    by_id: dict[str, ProvisionalLifecycleReceipt] = {}
+    by_id: dict[UUID4, ProvisionalLifecycleReceipt] = {}
     for receipt in receipts:
         existing = by_id.get(receipt.receipt_id)
         if existing is not None and existing != receipt:
@@ -380,9 +392,14 @@ def _normalize_receipts(
     return normalized, None
 
 
+def _artifact_ref_for(memory_id: UUID4) -> str:
+    return f"vault://Memory/Provisional/{memory_id}.md"
+
+
 __all__ = [
     "ProvisionalEvidenceRole",
     "ProvisionalDiagnostic",
+    "ProvisionalActor",
     "ProvisionalFailureCode",
     "ProvisionalLifecycleReceipt",
     "ProvisionalLifecycleTransition",

--- a/tests/agent_memory/test_provisional_memory_record.py
+++ b/tests/agent_memory/test_provisional_memory_record.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from app.agent_memory.candidate import MemoryType
+from app.agent_memory.provisional_memory import (
+    ProvisionalLifecycleReceipt,
+    ProvisionalLifecycleTransition,
+    ProvisionalMarkdownArtifact,
+    ProvisionalReconciliationState,
+    ProvisionalSensitivity,
+    rebuild_provisional_memory,
+)
+
+NOW = datetime(2026, 7, 15, tzinfo=timezone.utc)
+
+
+def _artifact(content: str = "The user prefers explicit verification.") -> ProvisionalMarkdownArtifact:
+    return ProvisionalMarkdownArtifact(
+        memory_id="memory-1",
+        artifact_ref="vault://Memory/Provisional/memory-1.md",
+        scope_id="scope-personal",
+        principal_id="principal-1",
+        memory_type=MemoryType.PREFERENCE_MEMORY,
+        sensitivity=ProvisionalSensitivity.PRIVATE,
+        content=content,
+        created_by="agent://mimer",
+        created_at=NOW,
+        provenance_event_ids=("event-1",),
+    )
+
+
+def _created_receipt(artifact: ProvisionalMarkdownArtifact) -> ProvisionalLifecycleReceipt:
+    return ProvisionalLifecycleReceipt(
+        receipt_id="receipt-created",
+        memory_id=artifact.memory_id,
+        artifact_ref=artifact.artifact_ref,
+        transition=ProvisionalLifecycleTransition.CREATED,
+        actor_ref="agent://mimer",
+        occurred_at=NOW,
+        artifact_digest=artifact.content_digest,
+    )
+
+
+def test_record_pins_noncanonical_low_trust_roles() -> None:
+    artifact = _artifact()
+    result = rebuild_provisional_memory(
+        memory_id=artifact.memory_id,
+        artifact_ref=artifact.artifact_ref,
+        artifact=artifact,
+        receipts=(_created_receipt(artifact),),
+    )
+
+    assert result.state is ProvisionalReconciliationState.READY
+    assert result.record is not None
+    assert result.record.source_role == "agent_memory"
+    assert result.record.authority_state == "noncanonical"
+    assert result.record.review_state == "unreviewed"
+    assert result.record.evidence_role.value == "background"
+    assert result.record.scope_id == "scope-personal"
+    assert result.record.provenance_event_ids == ("event-1",)
+    assert result.record.may_read is True
+    assert result.record.may_support_cited_proposal is True
+    assert result.record.may_apply is False
+    assert result.record.may_write is False
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("source_role", "human_knowledge"),
+        ("authority_state", "canonical"),
+        ("evidence_role", "evidence"),
+        ("review_state", "accepted"),
+    ],
+)
+def test_record_rejects_authority_escalation(field: str, value: str) -> None:
+    payload = _artifact().model_dump()
+    payload[field] = value
+    with pytest.raises(ValidationError):
+        ProvisionalMarkdownArtifact.model_validate(payload)
+
+    with pytest.raises(ValidationError):
+        ProvisionalMarkdownArtifact.model_validate(
+            {**_artifact().model_dump(), "provenance_event_ids": ("",)}
+        )
+
+
+def test_lifecycle_receipts_are_content_free_and_distinguish_retryable_state() -> None:
+    artifact = _artifact()
+    failed = ProvisionalLifecycleReceipt(
+        receipt_id="receipt-failed",
+        memory_id=artifact.memory_id,
+        artifact_ref=artifact.artifact_ref,
+        transition=ProvisionalLifecycleTransition.WRITE_FAILED,
+        actor_ref="agent://mimer",
+        occurred_at=NOW,
+        error_code="vault_write_failed",
+    )
+    deleted = ProvisionalLifecycleReceipt(
+        receipt_id="receipt-deleted",
+        memory_id=artifact.memory_id,
+        artifact_ref=artifact.artifact_ref,
+        transition=ProvisionalLifecycleTransition.DELETED,
+        actor_ref="human://owner",
+        occurred_at=NOW,
+    )
+
+    assert failed.retryable is True
+    assert failed.terminal is False
+    assert deleted.retryable is False
+    assert deleted.terminal is True
+    assert "content" not in failed.content_free_payload()
+    with pytest.raises(ValidationError):
+        ProvisionalLifecycleReceipt.model_validate(
+            {**failed.model_dump(), "content": "must not persist"}
+        )
+    partial = rebuild_provisional_memory(
+        memory_id=artifact.memory_id,
+        artifact_ref=artifact.artifact_ref,
+        artifact=artifact,
+        receipts=(failed,),
+    )
+    terminal = rebuild_provisional_memory(
+        memory_id=artifact.memory_id,
+        artifact_ref=artifact.artifact_ref,
+        artifact=None,
+        receipts=(deleted,),
+    )
+    assert partial.state is ProvisionalReconciliationState.RETRYABLE_PARTIAL
+    assert partial.record is None
+    assert terminal.state is ProvisionalReconciliationState.TERMINAL_DELETED
+    assert terminal.record is None
+
+
+def test_record_rebuild_follows_markdown_and_never_resurrects_missing_content() -> None:
+    original = _artifact("Original Markdown claim")
+    receipt = _created_receipt(original)
+    edited = _artifact("Human-edited Markdown claim")
+
+    rebuilt = rebuild_provisional_memory(
+        memory_id=edited.memory_id,
+        artifact_ref=edited.artifact_ref,
+        artifact=edited,
+        receipts=(receipt,),
+    )
+    missing = rebuild_provisional_memory(
+        memory_id=edited.memory_id,
+        artifact_ref=edited.artifact_ref,
+        artifact=None,
+        receipts=(receipt,),
+    )
+
+    assert rebuilt.state is ProvisionalReconciliationState.EDITED
+    assert rebuilt.record is not None
+    assert rebuilt.record.content == "Human-edited Markdown claim"
+    assert missing.state is ProvisionalReconciliationState.MISSING
+    assert missing.record is None
+    assert "Original Markdown claim" not in str(missing.model_dump())

--- a/tests/agent_memory/test_provisional_memory_record.py
+++ b/tests/agent_memory/test_provisional_memory_record.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from uuid import UUID
 
 import pytest
 from pydantic import ValidationError
@@ -17,12 +18,17 @@ from app.agent_memory.provisional_memory import (
 )
 
 NOW = datetime(2026, 7, 15, tzinfo=timezone.utc)
+MEMORY_ID = UUID("12345678-1234-4abc-8def-1234567890ab")
+OTHER_MEMORY_ID = UUID("22345678-1234-4abc-8def-1234567890ab")
+CREATED_RECEIPT_ID = UUID("32345678-1234-4abc-8def-1234567890ab")
+FAILED_RECEIPT_ID = UUID("42345678-1234-4abc-8def-1234567890ab")
+DELETED_RECEIPT_ID = UUID("52345678-1234-4abc-8def-1234567890ab")
 
 
 def _artifact(content: str = "The user prefers explicit verification.") -> ProvisionalMarkdownArtifact:
     return ProvisionalMarkdownArtifact(
-        memory_id="memory-1",
-        artifact_ref="vault://Memory/Provisional/memory-1.md",
+        memory_id=MEMORY_ID,
+        artifact_ref=f"vault://Memory/Provisional/{MEMORY_ID}.md",
         scope_id="scope-personal",
         principal_id="principal-1",
         memory_type=MemoryType.PREFERENCE_MEMORY,
@@ -36,11 +42,11 @@ def _artifact(content: str = "The user prefers explicit verification.") -> Provi
 
 def _created_receipt(artifact: ProvisionalMarkdownArtifact) -> ProvisionalLifecycleReceipt:
     return ProvisionalLifecycleReceipt(
-        receipt_id="receipt-created",
+        receipt_id=CREATED_RECEIPT_ID,
         memory_id=artifact.memory_id,
         artifact_ref=artifact.artifact_ref,
         transition=ProvisionalLifecycleTransition.CREATED,
-        actor_ref="agent://mimer",
+        actor_ref="agent",
         occurred_at=NOW,
         artifact_digest=artifact.artifact_digest,
     )
@@ -122,20 +128,20 @@ def test_direct_record_construction_cannot_bypass_invariants(
 def test_lifecycle_receipts_are_content_free_and_distinguish_retryable_state() -> None:
     artifact = _artifact()
     failed = ProvisionalLifecycleReceipt(
-        receipt_id="receipt-failed",
+        receipt_id=FAILED_RECEIPT_ID,
         memory_id=artifact.memory_id,
         artifact_ref=artifact.artifact_ref,
         transition=ProvisionalLifecycleTransition.WRITE_FAILED,
-        actor_ref="agent://mimer",
+        actor_ref="agent",
         occurred_at=NOW,
         error_code="vault_write_failed",
     )
     deleted = ProvisionalLifecycleReceipt(
-        receipt_id="receipt-deleted",
+        receipt_id=DELETED_RECEIPT_ID,
         memory_id=artifact.memory_id,
         artifact_ref=artifact.artifact_ref,
         transition=ProvisionalLifecycleTransition.DELETED,
-        actor_ref="human://owner",
+        actor_ref="human",
         occurred_at=NOW,
     )
 
@@ -184,16 +190,16 @@ def test_lifecycle_receipts_are_content_free_and_distinguish_retryable_state() -
 def test_terminal_delete_cannot_be_reversed_by_later_created_receipt() -> None:
     artifact = _artifact()
     deleted = ProvisionalLifecycleReceipt(
-        receipt_id="receipt-deleted",
+        receipt_id=DELETED_RECEIPT_ID,
         memory_id=artifact.memory_id,
         artifact_ref=artifact.artifact_ref,
         transition=ProvisionalLifecycleTransition.DELETED,
-        actor_ref="human://owner",
+        actor_ref="human",
         occurred_at=NOW,
     )
     later_created = _created_receipt(artifact).model_copy(
         update={
-            "receipt_id": "receipt-created-later",
+            "receipt_id": UUID("62345678-1234-4abc-8def-1234567890ab"),
             "occurred_at": NOW + timedelta(seconds=1),
         }
     )
@@ -217,7 +223,7 @@ def test_conflicting_receipt_identity_and_order_fail_closed() -> None:
         memory_id=artifact.memory_id,
         artifact_ref=artifact.artifact_ref,
         transition=ProvisionalLifecycleTransition.WRITE_FAILED,
-        actor_ref="agent://mimer",
+        actor_ref="agent",
         occurred_at=NOW,
         error_code="vault_write_failed",
     )
@@ -233,7 +239,7 @@ def test_conflicting_receipt_identity_and_order_fail_closed() -> None:
         artifact=artifact,
         receipts=(
             created,
-            conflicting.model_copy(update={"receipt_id": "receipt-failed"}),
+            conflicting.model_copy(update={"receipt_id": FAILED_RECEIPT_ID}),
         ),
     )
 
@@ -257,7 +263,7 @@ def test_reconciliation_envelope_cannot_resurrect_excluded_record() -> None:
         type(ready).model_validate(payload)
 
     assert ready.record is not None
-    mismatched = ready.record.model_copy(update={"memory_id": "memory-other"})
+    mismatched = ready.record.model_copy(update={"memory_id": OTHER_MEMORY_ID})
     with pytest.raises(ValidationError):
         type(ready).model_validate({**ready.model_dump(), "record": mismatched})
 
@@ -295,3 +301,21 @@ def test_record_rebuild_follows_markdown_and_never_resurrects_missing_content() 
         receipts=(receipt,),
     )
     assert metadata_result.state is ProvisionalReconciliationState.EDITED
+
+
+@pytest.mark.parametrize(
+    "artifact_ref",
+    [
+        "vault://Private/user%20has%20cancer.md",
+        "vault://Memory/Provisional/../secret.md",
+        "vault://Memory/Provisional/%2e%2e/secret.md",
+        f"vault://Memory/Provisional/{OTHER_MEMORY_ID}.md",
+    ],
+)
+def test_artifact_reference_is_canonical_and_bound_to_memory_id(
+    artifact_ref: str,
+) -> None:
+    with pytest.raises(ValidationError):
+        ProvisionalMarkdownArtifact.model_validate(
+            {**_artifact().model_dump(), "artifact_ref": artifact_ref}
+        )

--- a/tests/agent_memory/test_provisional_memory_record.py
+++ b/tests/agent_memory/test_provisional_memory_record.py
@@ -106,6 +106,10 @@ def test_record_rejects_authority_escalation(field: str, value: str) -> None:
         ("lifecycle_receipt_refs", ()),
         ("created_at", datetime(2026, 7, 15)),
         ("may_apply", True),
+        (
+            "artifact_ref",
+            f"vault://Memory/Provisional/{OTHER_MEMORY_ID}.md",
+        ),
     ],
 )
 def test_direct_record_construction_cannot_bypass_invariants(

--- a/tests/agent_memory/test_provisional_memory_record.py
+++ b/tests/agent_memory/test_provisional_memory_record.py
@@ -42,7 +42,7 @@ def _created_receipt(artifact: ProvisionalMarkdownArtifact) -> ProvisionalLifecy
         transition=ProvisionalLifecycleTransition.CREATED,
         actor_ref="agent://mimer",
         occurred_at=NOW,
-        artifact_digest=artifact.content_digest,
+        artifact_digest=artifact.artifact_digest,
     )
 
 
@@ -148,6 +148,14 @@ def test_lifecycle_receipts_are_content_free_and_distinguish_retryable_state() -
         ProvisionalLifecycleReceipt.model_validate(
             {**failed.model_dump(), "content": "must not persist"}
         )
+    for field in ("receipt_id", "memory_id", "artifact_ref", "actor_ref"):
+        with pytest.raises(ValidationError):
+            ProvisionalLifecycleReceipt.model_validate(
+                {
+                    **failed.model_dump(),
+                    field: "The user prefers explicit verification.",
+                }
+            )
     with pytest.raises(ValidationError):
         ProvisionalLifecycleReceipt.model_validate(
             {
@@ -201,6 +209,59 @@ def test_terminal_delete_cannot_be_reversed_by_later_created_receipt() -> None:
     assert result.record is None
 
 
+def test_conflicting_receipt_identity_and_order_fail_closed() -> None:
+    artifact = _artifact()
+    created = _created_receipt(artifact)
+    conflicting = ProvisionalLifecycleReceipt(
+        receipt_id=created.receipt_id,
+        memory_id=artifact.memory_id,
+        artifact_ref=artifact.artifact_ref,
+        transition=ProvisionalLifecycleTransition.WRITE_FAILED,
+        actor_ref="agent://mimer",
+        occurred_at=NOW,
+        error_code="vault_write_failed",
+    )
+    conflict = rebuild_provisional_memory(
+        memory_id=artifact.memory_id,
+        artifact_ref=artifact.artifact_ref,
+        artifact=artifact,
+        receipts=(created, conflicting),
+    )
+    same_time = rebuild_provisional_memory(
+        memory_id=artifact.memory_id,
+        artifact_ref=artifact.artifact_ref,
+        artifact=artifact,
+        receipts=(
+            created,
+            conflicting.model_copy(update={"receipt_id": "receipt-failed"}),
+        ),
+    )
+
+    assert conflict.state is ProvisionalReconciliationState.INCONSISTENT
+    assert conflict.record is None
+    assert same_time.state is ProvisionalReconciliationState.INCONSISTENT
+    assert same_time.record is None
+
+
+def test_reconciliation_envelope_cannot_resurrect_excluded_record() -> None:
+    artifact = _artifact()
+    ready = rebuild_provisional_memory(
+        memory_id=artifact.memory_id,
+        artifact_ref=artifact.artifact_ref,
+        artifact=artifact,
+        receipts=(_created_receipt(artifact),),
+    )
+    payload = ready.model_dump()
+    payload["state"] = ProvisionalReconciliationState.MISSING
+    with pytest.raises(ValidationError):
+        type(ready).model_validate(payload)
+
+    assert ready.record is not None
+    mismatched = ready.record.model_copy(update={"memory_id": "memory-other"})
+    with pytest.raises(ValidationError):
+        type(ready).model_validate({**ready.model_dump(), "record": mismatched})
+
+
 def test_record_rebuild_follows_markdown_and_never_resurrects_missing_content() -> None:
     original = _artifact("Original Markdown claim")
     receipt = _created_receipt(original)
@@ -225,3 +286,12 @@ def test_record_rebuild_follows_markdown_and_never_resurrects_missing_content() 
     assert missing.state is ProvisionalReconciliationState.MISSING
     assert missing.record is None
     assert "Original Markdown claim" not in str(missing.model_dump())
+
+    metadata_edited = original.model_copy(update={"scope_id": "scope-work"})
+    metadata_result = rebuild_provisional_memory(
+        memory_id=metadata_edited.memory_id,
+        artifact_ref=metadata_edited.artifact_ref,
+        artifact=metadata_edited,
+        receipts=(receipt,),
+    )
+    assert metadata_result.state is ProvisionalReconciliationState.EDITED

--- a/tests/agent_memory/test_provisional_memory_record.py
+++ b/tests/agent_memory/test_provisional_memory_record.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from pydantic import ValidationError
@@ -10,6 +10,7 @@ from app.agent_memory.provisional_memory import (
     ProvisionalLifecycleReceipt,
     ProvisionalLifecycleTransition,
     ProvisionalMarkdownArtifact,
+    ProvisionalMemoryRecord,
     ProvisionalReconciliationState,
     ProvisionalSensitivity,
     rebuild_provisional_memory,
@@ -89,6 +90,35 @@ def test_record_rejects_authority_escalation(field: str, value: str) -> None:
         )
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("scope_id", ""),
+        ("principal_id", ""),
+        ("content", ""),
+        ("provenance_event_ids", ()),
+        ("lifecycle_receipt_refs", ()),
+        ("created_at", datetime(2026, 7, 15)),
+        ("may_apply", True),
+    ],
+)
+def test_direct_record_construction_cannot_bypass_invariants(
+    field: str, value: object
+) -> None:
+    artifact = _artifact()
+    result = rebuild_provisional_memory(
+        memory_id=artifact.memory_id,
+        artifact_ref=artifact.artifact_ref,
+        artifact=artifact,
+        receipts=(_created_receipt(artifact),),
+    )
+    assert result.record is not None
+    payload = result.record.model_dump()
+    payload[field] = value
+    with pytest.raises(ValidationError):
+        ProvisionalMemoryRecord.model_validate(payload)
+
+
 def test_lifecycle_receipts_are_content_free_and_distinguish_retryable_state() -> None:
     artifact = _artifact()
     failed = ProvisionalLifecycleReceipt(
@@ -118,6 +148,13 @@ def test_lifecycle_receipts_are_content_free_and_distinguish_retryable_state() -
         ProvisionalLifecycleReceipt.model_validate(
             {**failed.model_dump(), "content": "must not persist"}
         )
+    with pytest.raises(ValidationError):
+        ProvisionalLifecycleReceipt.model_validate(
+            {
+                **failed.model_dump(),
+                "error_code": "The user prefers explicit verification.",
+            }
+        )
     partial = rebuild_provisional_memory(
         memory_id=artifact.memory_id,
         artifact_ref=artifact.artifact_ref,
@@ -134,6 +171,34 @@ def test_lifecycle_receipts_are_content_free_and_distinguish_retryable_state() -
     assert partial.record is None
     assert terminal.state is ProvisionalReconciliationState.TERMINAL_DELETED
     assert terminal.record is None
+
+
+def test_terminal_delete_cannot_be_reversed_by_later_created_receipt() -> None:
+    artifact = _artifact()
+    deleted = ProvisionalLifecycleReceipt(
+        receipt_id="receipt-deleted",
+        memory_id=artifact.memory_id,
+        artifact_ref=artifact.artifact_ref,
+        transition=ProvisionalLifecycleTransition.DELETED,
+        actor_ref="human://owner",
+        occurred_at=NOW,
+    )
+    later_created = _created_receipt(artifact).model_copy(
+        update={
+            "receipt_id": "receipt-created-later",
+            "occurred_at": NOW + timedelta(seconds=1),
+        }
+    )
+
+    result = rebuild_provisional_memory(
+        memory_id=artifact.memory_id,
+        artifact_ref=artifact.artifact_ref,
+        artifact=artifact,
+        receipts=(deleted, later_created),
+    )
+
+    assert result.state is ProvisionalReconciliationState.TERMINAL_DELETED
+    assert result.record is None
 
 
 def test_record_rebuild_follows_markdown_and_never_resurrects_missing_content() -> None:


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Fixes #3718

## SBS Impact
- Primary subsystem: MEM — Machine Memory & Learning
- Secondary subsystem(s): GOV, HKA, PDM
- Write class: mechanical typed read model and content-free lifecycle receipt semantics
- Authority impact: pins provisional memory to unreviewed, noncanonical, non-evidence, non-action-authorizing roles
- Persistence impact: no persistence writer is added; the only serializable receipt shape is content-free
- Derived/rebuildable impact: the typed record is rebuilt from current Markdown plus lifecycle receipts
- Human knowledge impact: Vault Markdown remains the sole meaning-bearing artifact and human edits win on rebuild
- Memory impact: adds the record/lifecycle foundation only; no producer, consumer, or promotion path
- Retrieval/context impact: none
- Sync/deployment impact: none
- External boundary impact: none
- New or changed contract: executable provisional-memory record and reconciliation contract
- Owner-doc impact: none; the accepted target contract and execution source were corrected in #3711
- Transition debt impact: implements PROVISIONAL-MEMORY-01 without widening authority
- Fitness rule impact: fail-closed orphan/partial reconciliation and no content resurrection
- Boundary risk: high; memory-authority and persistence boundary, bounded by literals, content-free receipts, and regression tests

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Add a frozen, strict provisional Markdown/read-record model that structurally pins low-trust roles and action denial.
- Add content-free lifecycle receipts and reconciliation that follows edited Markdown while excluding missing, deleted, inconsistent, and retryable partial pairs.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed. (No doc change needed: #3711 is the accepted execution contract.)
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality. (Not yet a shipped capability; parent ledger remains open.)

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [ ] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [ ] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [x] `ruff check app tests` — `All checks passed!`
- [x] If files under `app/` or `tests/` changed, lint output from `ruff check app tests` is included below or a tooling limitation is stated.
- [x] `mypy app` — `Success: no issues found in 733 source files`
- [ ] `pytest -q -m "not pg"` — environment-limited after 7,980 passes: pytest exhausted numbered `tmp_path` creation at 60%, causing 316 setup errors and 15 follow-on failures; CI must provide the clean full-suite result.
- [x] Additional targeted checks run as needed

Targeted checks:
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/agent_memory/test_provisional_memory_record.py tests/agent_memory/test_memory_promotion.py::test_promoted_memory_preserves_provenance tests/agent_memory/test_guarded_recall_activation.py::test_unreviewed_recall_cannot_authorize_writeback` — 9 passed.
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/agent_memory` — 111 passed.
- Persistence review: no store or writer was added; `ProvisionalLifecycleReceipt` forbids extra fields and exposes only ids, artifact hash/ref, transition, actor/time, and error code.

## BuilderOps Routing
- Records/projections/receipts: issue pickup receipt `github-comment:4974994377`; source learning `lrn_20260714225746_cd793a00`
- Reason: pickup used GitHub-label-only fallback because dispatcher DB was uninitialized; the existing LearningSignal is already promoted through #3711/#3718.

## Notes
- Current Codex capability was Sol/medium; the issue calls for Sol/high. The implementation compensates with frozen/forbid models, literal authority ceilings, fail-closed reconciliation, full agent-memory regression, and mandatory independent review.
- Parent #2314 remains a validation hub and was not claimed.
