### PR TITLE
feat(memory): add governed provisional write API

### DIFF
--- a/app/agent_memory/provisional_write.py
+++ b/app/agent_memory/provisional_write.py
@@ -1,0 +1,401 @@
+"""Governed producer for provisional, direct-write memory.
+
+This module owns the only provisional write seam. It writes meaning-bearing
+content to Vault Markdown and persists only content-free lifecycle receipts.
+It deliberately imports no promotion or materialization path.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Annotated, Callable, Protocol
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+import yaml
+
+from app.agent_memory.candidate import MemoryType
+from app.agent_memory.provisional_memory import (
+    ProvisionalEvidenceRole,
+    ProvisionalFailureCode,
+    ProvisionalLifecycleReceipt,
+    ProvisionalLifecycleTransition,
+    ProvisionalMarkdownArtifact,
+    ProvisionalMemoryReconciliation,
+    ProvisionalSensitivity,
+    rebuild_provisional_memory,
+)
+from app.knowledge.write_ops import write_note_relative
+from app.write_guard import DEFAULT_WRITE_GUARD, WriteGuard
+
+PROVISIONAL_MEMORY_WRITE_ACTION = "memory.provisional.write"
+PROVISIONAL_MEMORY_DIR = "Memory/Provisional"
+DEFAULT_PROVISIONAL_RECEIPTS_PATH = Path(
+    "runtime/agent_memory/provisional_memory_receipts.jsonl"
+)
+_VISIBLE_PREFIX = (
+    "# Provisional memory\n\n"
+    "> [!warning] Provisional / low trust — not authority\n"
+    "> This memory may support reading or a cited proposal, but never APPLY or tool use.\n\n"
+)
+logger = logging.getLogger(__name__)
+ProvenanceRef = Annotated[str, Field(min_length=1, max_length=128)]
+
+
+class ProvisionalWriteRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    scope_id: str = Field(min_length=1, max_length=128, pattern=r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+    principal_id: str = Field(min_length=1, max_length=128, pattern=r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+    memory_type: MemoryType
+    sensitivity: ProvisionalSensitivity
+    content: str = Field(min_length=1)
+    provenance_event_ids: tuple[ProvenanceRef, ...] = Field(min_length=1)
+
+    @field_validator("content")
+    @classmethod
+    def _require_meaningful_content(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("content must contain non-whitespace characters")
+        return stripped
+
+    @field_validator("provenance_event_ids")
+    @classmethod
+    def _require_meaningful_provenance(
+        cls, value: tuple[str, ...]
+    ) -> tuple[str, ...]:
+        if any(not item.strip() for item in value):
+            raise ValueError("provenance references must not be blank")
+        return tuple(item.strip() for item in value)
+
+
+class ProvisionalWriteResult(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    reconciliation: ProvisionalMemoryReconciliation
+    lifecycle_receipt: ProvisionalLifecycleReceipt
+
+
+class ProvisionalReceiptWriter(Protocol):
+    def append(self, receipt: ProvisionalLifecycleReceipt) -> None: ...
+
+    def list_for(self, memory_id: UUID) -> tuple[ProvisionalLifecycleReceipt, ...]: ...
+
+
+class ProvisionalMemoryWriteError(RuntimeError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        reconciliation: ProvisionalMemoryReconciliation,
+        lifecycle_receipt: ProvisionalLifecycleReceipt | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.reconciliation = reconciliation
+        self.lifecycle_receipt = lifecycle_receipt
+
+
+class ProvisionalReceiptStoreError(RuntimeError):
+    """Receipt ledger is unreadable or failed to persist atomically enough."""
+
+
+class ProvisionalReceiptStore:
+    """Append-only, content-free lifecycle receipt JSONL store."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        configured = os.getenv("PROVISIONAL_MEMORY_RECEIPTS_PATH")
+        self.path = path or (Path(configured).expanduser() if configured else DEFAULT_PROVISIONAL_RECEIPTS_PATH)
+
+    def append(self, receipt: ProvisionalLifecycleReceipt) -> None:
+        payload = receipt.content_free_payload()
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n"
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        descriptor = os.open(self.path, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o600)
+        try:
+            remaining = memoryview(encoded.encode("utf-8"))
+            while remaining:
+                written = os.write(descriptor, remaining)
+                if written <= 0:
+                    raise OSError("receipt append made no progress")
+                remaining = remaining[written:]
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+
+    def list_for(self, memory_id: UUID) -> tuple[ProvisionalLifecycleReceipt, ...]:
+        if not self.path.exists():
+            return ()
+        receipts: list[ProvisionalLifecycleReceipt] = []
+        for line in self.path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            try:
+                receipt = ProvisionalLifecycleReceipt.model_validate_json(line)
+            except ValidationError as exc:
+                raise ProvisionalReceiptStoreError(
+                    "provisional receipt ledger contains an invalid line"
+                ) from exc
+            if receipt.memory_id == memory_id:
+                receipts.append(receipt)
+        return tuple(receipts)
+
+
+def assert_provisional_trust_tier(artifact: ProvisionalMarkdownArtifact) -> None:
+    """Production trust ceiling: direct writes are always low-trust and inert."""
+    if (
+        artifact.source_role != "agent_memory"
+        or artifact.authority_state != "noncanonical"
+        or artifact.review_state != "unreviewed"
+        or artifact.evidence_role not in set(ProvisionalEvidenceRole)
+    ):
+        raise ValueError("provisional memory trust ceiling violated")
+
+
+def write_provisional_memory(
+    request: ProvisionalWriteRequest,
+    *,
+    vault_root: Path,
+    write_guard: WriteGuard = DEFAULT_WRITE_GUARD,
+    receipt_store: ProvisionalReceiptWriter | None = None,
+    trust_tier_guard: Callable[[ProvisionalMarkdownArtifact], None] | None = None,
+    now: Callable[[], datetime] | None = None,
+) -> ProvisionalWriteResult:
+    """Write one provisional Markdown artifact and its lifecycle receipts."""
+    store = receipt_store or ProvisionalReceiptStore()
+    clock = now or (lambda: datetime.now(timezone.utc))
+    memory_id = uuid4()
+    artifact_ref = f"vault://{PROVISIONAL_MEMORY_DIR}/{memory_id}.md"
+    artifact = ProvisionalMarkdownArtifact(
+        memory_id=memory_id,
+        artifact_ref=artifact_ref,
+        scope_id=request.scope_id,
+        principal_id=request.principal_id,
+        memory_type=request.memory_type,
+        sensitivity=request.sensitivity,
+        content=request.content,
+        created_by="agent://companion",
+        created_at=_aware_utc(clock()),
+        provenance_event_ids=request.provenance_event_ids,
+    )
+
+    (trust_tier_guard or assert_provisional_trust_tier)(artifact)
+    write_guard.assert_writes_allowed(PROVISIONAL_MEMORY_WRITE_ACTION)
+
+    staged_at = _aware_utc(clock())
+    staged = ProvisionalLifecycleReceipt(
+        receipt_id=uuid4(),
+        memory_id=memory_id,
+        artifact_ref=artifact_ref,
+        transition=ProvisionalLifecycleTransition.WRITE_STAGED,
+        actor_ref="agent",
+        occurred_at=staged_at,
+    )
+    try:
+        store.append(staged)
+    except Exception as exc:
+        reconciliation = rebuild_provisional_memory(
+            memory_id=memory_id,
+            artifact_ref=artifact_ref,
+            artifact=None,
+            receipts=(),
+        )
+        raise ProvisionalMemoryWriteError(
+            "provisional staged receipt persistence failed",
+            reconciliation=reconciliation,
+        ) from exc
+
+    note_rel = f"{PROVISIONAL_MEMORY_DIR}/{memory_id}.md"
+    try:
+        write_note_relative(
+            note_rel,
+            render_provisional_markdown(artifact),
+            vault_root=vault_root,
+            action=PROVISIONAL_MEMORY_WRITE_ACTION,
+            write_guard=write_guard,
+            writer_identity="agent_memory.provisional_write",
+        )
+    except Exception as exc:
+        failed = ProvisionalLifecycleReceipt(
+            receipt_id=uuid4(),
+            memory_id=memory_id,
+            artifact_ref=artifact_ref,
+            transition=ProvisionalLifecycleTransition.WRITE_FAILED,
+            actor_ref="agent",
+            occurred_at=_after(staged_at, clock()),
+            error_code=_failure_code(exc),
+        )
+        try:
+            store.append(failed)
+        except Exception as receipt_exc:
+            logger.warning("failed to persist provisional write failure: %s", receipt_exc)
+        receipts = _safe_receipts(store, memory_id)
+        reconciliation = rebuild_provisional_memory(
+            memory_id=memory_id,
+            artifact_ref=artifact_ref,
+            artifact=None,
+            receipts=receipts,
+        )
+        raise ProvisionalMemoryWriteError(
+            "provisional Markdown write failed",
+            reconciliation=reconciliation,
+            lifecycle_receipt=failed,
+        ) from exc
+
+    created = ProvisionalLifecycleReceipt(
+        receipt_id=uuid4(),
+        memory_id=memory_id,
+        artifact_ref=artifact_ref,
+        transition=ProvisionalLifecycleTransition.CREATED,
+        actor_ref="agent",
+        occurred_at=_after(staged_at, clock()),
+        artifact_digest=artifact.artifact_digest,
+    )
+    try:
+        store.append(created)
+    except Exception as exc:
+        receipts = _safe_receipts(store, memory_id)
+        reconciliation = rebuild_provisional_memory(
+            memory_id=memory_id,
+            artifact_ref=artifact_ref,
+            artifact=_safe_artifact(vault_root / note_rel),
+            receipts=receipts,
+        )
+        raise ProvisionalMemoryWriteError(
+            "provisional lifecycle receipt persistence failed",
+            reconciliation=reconciliation,
+        ) from exc
+
+    persisted_artifact = _safe_artifact(vault_root / note_rel)
+    receipts = _safe_receipts(store, memory_id)
+    reconciliation = rebuild_provisional_memory(
+        memory_id=memory_id,
+        artifact_ref=artifact_ref,
+        artifact=persisted_artifact,
+        receipts=receipts,
+    )
+    if reconciliation.record is None:
+        raise ProvisionalMemoryWriteError(
+            "provisional write did not reconcile to a readable record",
+            reconciliation=reconciliation,
+            lifecycle_receipt=created,
+        )
+    return ProvisionalWriteResult(
+        reconciliation=reconciliation,
+        lifecycle_receipt=created,
+    )
+
+
+def _safe_receipts(
+    store: ProvisionalReceiptWriter,
+    memory_id: UUID,
+) -> tuple[ProvisionalLifecycleReceipt, ...]:
+    try:
+        return store.list_for(memory_id)
+    except Exception as exc:
+        logger.warning("provisional receipt ledger could not be read: %s", exc)
+        return ()
+
+
+def _safe_artifact(path: Path) -> ProvisionalMarkdownArtifact | None:
+    try:
+        return load_provisional_markdown(path)
+    except Exception as exc:
+        logger.warning("provisional Markdown could not be read back: %s", exc)
+        return None
+
+
+def render_provisional_markdown(artifact: ProvisionalMarkdownArtifact) -> str:
+    frontmatter = {
+        "uuid": str(artifact.memory_id),
+        "artifact_class": "agentic_memory",
+        "artifact_type": "provisional_memory",
+        "source_role": artifact.source_role,
+        "authority_state": artifact.authority_state,
+        "evidence_role": artifact.evidence_role.value,
+        "review_state": artifact.review_state.value,
+        "scope_id": artifact.scope_id,
+        "principal_id": artifact.principal_id,
+        "memory_type": artifact.memory_type.value,
+        "sensitivity": artifact.sensitivity.value,
+        "created_by": artifact.created_by,
+        "created_at": artifact.created_at.isoformat().replace("+00:00", "Z"),
+        "provenance_event_ids": list(artifact.provenance_event_ids),
+        "labels": ["provisional-memory", "low-trust", "not-authority"],
+    }
+    yaml_block = yaml.safe_dump(frontmatter, sort_keys=True, allow_unicode=True).strip()
+    return f"---\n{yaml_block}\n---\n\n{_VISIBLE_PREFIX}{artifact.content}\n"
+
+
+def load_provisional_markdown(path: Path) -> ProvisionalMarkdownArtifact:
+    raw = path.read_text(encoding="utf-8")
+    if not raw.startswith("---\n") or "\n---\n" not in raw[4:]:
+        raise ValueError("provisional Markdown requires YAML frontmatter")
+    yaml_text, body = raw[4:].split("\n---\n", 1)
+    metadata = yaml.safe_load(yaml_text)
+    if not isinstance(metadata, dict):
+        raise ValueError("provisional Markdown frontmatter must be a mapping")
+    if metadata.get("artifact_class") != "agentic_memory" or metadata.get("artifact_type") != "provisional_memory":
+        raise ValueError("not a provisional-memory artifact")
+    labels = metadata.get("labels")
+    if labels != ["provisional-memory", "low-trust", "not-authority"]:
+        raise ValueError("provisional-memory visibility labels are required")
+    normalized_body = body.lstrip("\n")
+    if not normalized_body.startswith(_VISIBLE_PREFIX):
+        raise ValueError("provisional-memory low-trust warning is required")
+    content = normalized_body.removeprefix(_VISIBLE_PREFIX).rstrip("\n")
+    memory_id = UUID(str(metadata["uuid"]))
+    return ProvisionalMarkdownArtifact(
+        memory_id=memory_id,
+        artifact_ref=f"vault://{PROVISIONAL_MEMORY_DIR}/{memory_id}.md",
+        scope_id=metadata["scope_id"],
+        principal_id=metadata["principal_id"],
+        memory_type=metadata["memory_type"],
+        evidence_role=metadata["evidence_role"],
+        sensitivity=metadata["sensitivity"],
+        content=content,
+        created_by=metadata["created_by"],
+        created_at=metadata["created_at"],
+        provenance_event_ids=tuple(metadata["provenance_event_ids"]),
+        source_role=metadata["source_role"],
+        authority_state=metadata["authority_state"],
+        review_state=metadata["review_state"],
+    )
+
+
+def _aware_utc(value: datetime) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("clock must return a timezone-aware datetime")
+    return value.astimezone(timezone.utc)
+
+
+def _after(previous: datetime, value: datetime) -> datetime:
+    current = _aware_utc(value)
+    return current if current > previous else previous + timedelta(microseconds=1)
+
+
+def _failure_code(exc: Exception) -> ProvisionalFailureCode:
+    name = type(exc).__name__.lower()
+    if "permission" in name:
+        return ProvisionalFailureCode.PERMISSION_DENIED
+    if "conflict" in name:
+        return ProvisionalFailureCode.WRITE_CONFLICT
+    return ProvisionalFailureCode.VAULT_WRITE_FAILED
+
+
+__all__ = [
+    "DEFAULT_PROVISIONAL_RECEIPTS_PATH",
+    "PROVISIONAL_MEMORY_WRITE_ACTION",
+    "ProvisionalMemoryWriteError",
+    "ProvisionalReceiptStoreError",
+    "ProvisionalReceiptStore",
+    "ProvisionalWriteRequest",
+    "ProvisionalWriteResult",
+    "assert_provisional_trust_tier",
+    "load_provisional_markdown",
+    "render_provisional_markdown",
+    "write_provisional_memory",
+]

--- a/app/agent_memory/provisional_write.py
+++ b/app/agent_memory/provisional_write.py
@@ -6,12 +6,15 @@ It deliberately imports no promotion or materialization path.
 """
 from __future__ import annotations
 
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
+import fcntl
 import json
 import logging
 import os
 from pathlib import Path
-from typing import Annotated, Callable, Protocol
+import tempfile
+from typing import Annotated, Callable, Iterator, Protocol
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
@@ -114,34 +117,97 @@ class ProvisionalReceiptStore:
         payload = receipt.content_free_payload()
         encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n"
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        descriptor = os.open(self.path, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o600)
-        try:
-            remaining = memoryview(encoded.encode("utf-8"))
-            while remaining:
-                written = os.write(descriptor, remaining)
-                if written <= 0:
-                    raise OSError("receipt append made no progress")
-                remaining = remaining[written:]
-            os.fsync(descriptor)
-        finally:
-            os.close(descriptor)
+        with _receipt_ledger_lock(self.path, shared=False):
+            existing = self.path.read_bytes() if self.path.exists() else b""
+            _validate_ledger_bytes(existing)
+            descriptor, staged_name = tempfile.mkstemp(
+                dir=self.path.parent,
+                prefix=f".{self.path.name}.",
+                suffix=".tmp",
+            )
+            staged_path = Path(staged_name)
+            try:
+                try:
+                    os.fchmod(descriptor, 0o600)
+                except Exception:
+                    os.close(descriptor)
+                    raise
+                with os.fdopen(descriptor, "wb", closefd=True) as handle:
+                    handle.write(existing)
+                    handle.write(encoded.encode("utf-8"))
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                os.replace(staged_path, self.path)
+                _fsync_directory(self.path.parent)
+            except Exception:
+                staged_path.unlink(missing_ok=True)
+                raise
 
     def list_for(self, memory_id: UUID) -> tuple[ProvisionalLifecycleReceipt, ...]:
         if not self.path.exists():
             return ()
-        receipts: list[ProvisionalLifecycleReceipt] = []
-        for line in self.path.read_text(encoding="utf-8").splitlines():
-            if not line.strip():
-                continue
-            try:
-                receipt = ProvisionalLifecycleReceipt.model_validate_json(line)
-            except ValidationError as exc:
-                raise ProvisionalReceiptStoreError(
-                    "provisional receipt ledger contains an invalid line"
-                ) from exc
-            if receipt.memory_id == memory_id:
-                receipts.append(receipt)
-        return tuple(receipts)
+        with _receipt_ledger_lock(self.path, shared=True):
+            raw = self.path.read_bytes()
+        return tuple(
+            receipt
+            for receipt in _receipts_from_ledger(raw)
+            if receipt.memory_id == memory_id
+        )
+
+
+@contextmanager
+def _receipt_ledger_lock(path: Path, *, shared: bool) -> Iterator[None]:
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+b") as lock_handle:
+        os.chmod(lock_path, 0o600)
+        fcntl.flock(
+            lock_handle.fileno(),
+            fcntl.LOCK_SH if shared else fcntl.LOCK_EX,
+        )
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
+
+
+def _validate_ledger_bytes(raw: bytes) -> None:
+    _receipts_from_ledger(raw)
+
+
+def _receipts_from_ledger(raw: bytes) -> tuple[ProvisionalLifecycleReceipt, ...]:
+    if not raw:
+        return ()
+    if not raw.endswith(b"\n"):
+        raise ProvisionalReceiptStoreError(
+            "provisional receipt ledger ends with an incomplete line"
+        )
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ProvisionalReceiptStoreError(
+            "provisional receipt ledger is not valid UTF-8"
+        ) from exc
+    receipts: list[ProvisionalLifecycleReceipt] = []
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        try:
+            receipt = ProvisionalLifecycleReceipt.model_validate_json(line)
+        except ValidationError as exc:
+            raise ProvisionalReceiptStoreError(
+                "provisional receipt ledger contains an invalid line"
+            ) from exc
+        receipts.append(receipt)
+    return tuple(receipts)
+
+
+def _fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
 
 
 def assert_provisional_trust_tier(artifact: ProvisionalMarkdownArtifact) -> None:
@@ -257,11 +323,15 @@ def write_provisional_memory(
     try:
         store.append(created)
     except Exception as exc:
-        receipts = _safe_receipts(store, memory_id)
+        receipts = tuple(
+            receipt
+            for receipt in _safe_receipts(store, memory_id)
+            if receipt.receipt_id != created.receipt_id
+        )
         reconciliation = rebuild_provisional_memory(
             memory_id=memory_id,
             artifact_ref=artifact_ref,
-            artifact=_safe_artifact(vault_root / note_rel),
+            artifact=_safe_artifact(vault_root / note_rel, vault_root=vault_root),
             receipts=receipts,
         )
         raise ProvisionalMemoryWriteError(
@@ -269,7 +339,7 @@ def write_provisional_memory(
             reconciliation=reconciliation,
         ) from exc
 
-    persisted_artifact = _safe_artifact(vault_root / note_rel)
+    persisted_artifact = _safe_artifact(vault_root / note_rel, vault_root=vault_root)
     receipts = _safe_receipts(store, memory_id)
     reconciliation = rebuild_provisional_memory(
         memory_id=memory_id,
@@ -300,9 +370,13 @@ def _safe_receipts(
         return ()
 
 
-def _safe_artifact(path: Path) -> ProvisionalMarkdownArtifact | None:
+def _safe_artifact(
+    path: Path,
+    *,
+    vault_root: Path,
+) -> ProvisionalMarkdownArtifact | None:
     try:
-        return load_provisional_markdown(path)
+        return load_provisional_markdown(path, vault_root=vault_root)
     except Exception as exc:
         logger.warning("provisional Markdown could not be read back: %s", exc)
         return None
@@ -330,7 +404,26 @@ def render_provisional_markdown(artifact: ProvisionalMarkdownArtifact) -> str:
     return f"---\n{yaml_block}\n---\n\n{_VISIBLE_PREFIX}{artifact.content}\n"
 
 
-def load_provisional_markdown(path: Path) -> ProvisionalMarkdownArtifact:
+def load_provisional_markdown(
+    path: Path,
+    *,
+    vault_root: Path,
+) -> ProvisionalMarkdownArtifact:
+    if ".." in path.parts:
+        raise ValueError("provisional Markdown path must be lexical-canonical")
+    if path.is_symlink():
+        raise ValueError("provisional Markdown path must not be a symlink")
+    resolved_root = vault_root.expanduser().resolve()
+    resolved_path = path.expanduser().resolve()
+    relative_path = resolved_path.relative_to(resolved_root)
+    if relative_path.parent.as_posix() != PROVISIONAL_MEMORY_DIR:
+        raise ValueError("physical provisional Markdown directory is not canonical")
+    try:
+        path_memory_id = UUID(relative_path.stem)
+    except ValueError as exc:
+        raise ValueError("physical provisional Markdown filename is not a UUID") from exc
+    if path_memory_id.version != 4 or relative_path.suffix != ".md":
+        raise ValueError("physical provisional Markdown filename is not canonical")
     raw = path.read_text(encoding="utf-8")
     if not raw.startswith("---\n") or "\n---\n" not in raw[4:]:
         raise ValueError("provisional Markdown requires YAML frontmatter")
@@ -348,6 +441,8 @@ def load_provisional_markdown(path: Path) -> ProvisionalMarkdownArtifact:
         raise ValueError("provisional-memory low-trust warning is required")
     content = normalized_body.removeprefix(_VISIBLE_PREFIX).rstrip("\n")
     memory_id = UUID(str(metadata["uuid"]))
+    if memory_id != path_memory_id:
+        raise ValueError("physical provisional Markdown path does not match its UUID")
     return ProvisionalMarkdownArtifact(
         memory_id=memory_id,
         artifact_ref=f"vault://{PROVISIONAL_MEMORY_DIR}/{memory_id}.md",

--- a/app/agent_memory/provisional_write.py
+++ b/app/agent_memory/provisional_write.py
@@ -424,6 +424,8 @@ def load_provisional_markdown(
         raise ValueError("physical provisional Markdown filename is not a UUID") from exc
     if path_memory_id.version != 4 or relative_path.suffix != ".md":
         raise ValueError("physical provisional Markdown filename is not canonical")
+    if relative_path.name != f"{path_memory_id}.md":
+        raise ValueError("physical provisional Markdown filename is not canonical")
     raw = path.read_text(encoding="utf-8")
     if not raw.startswith("---\n") or "\n---\n" not in raw[4:]:
         raise ValueError("provisional Markdown requires YAML frontmatter")

--- a/app/agent_memory/provisional_write.py
+++ b/app/agent_memory/provisional_write.py
@@ -510,6 +510,18 @@ def load_provisional_markdown(
     labels = metadata.get("labels")
     if labels != ["provisional-memory", "low-trust", "not-authority"]:
         raise ValueError("provisional-memory visibility labels are required")
+    provenance_event_ids = metadata["provenance_event_ids"]
+    if (
+        not isinstance(provenance_event_ids, list)
+        or not provenance_event_ids
+        or any(
+            not isinstance(item, str) or not item.strip()
+            for item in provenance_event_ids
+        )
+    ):
+        raise ValueError(
+            "provisional-memory provenance_event_ids must be a non-empty string sequence"
+        )
     normalized_body = body.lstrip("\n")
     if not normalized_body.startswith(_VISIBLE_PREFIX):
         raise ValueError("provisional-memory low-trust warning is required")
@@ -528,7 +540,7 @@ def load_provisional_markdown(
         content=content,
         created_by=metadata["created_by"],
         created_at=metadata["created_at"],
-        provenance_event_ids=tuple(metadata["provenance_event_ids"]),
+        provenance_event_ids=tuple(provenance_event_ids),
         source_role=metadata["source_role"],
         authority_state=metadata["authority_state"],
         review_state=metadata["review_state"],

--- a/app/agent_memory/provisional_write.py
+++ b/app/agent_memory/provisional_write.py
@@ -138,7 +138,17 @@ class ProvisionalReceiptStore:
                     handle.flush()
                     os.fsync(handle.fileno())
                 os.replace(staged_path, self.path)
-                _fsync_directory(self.path.parent)
+                try:
+                    _fsync_directory(self.path.parent)
+                except Exception:
+                    expected = existing + encoded.encode("utf-8")
+                    if self.path.read_bytes() == expected:
+                        logger.warning(
+                            "receipt ledger directory fsync failed after a visible "
+                            "atomic replace; treating the append as committed"
+                        )
+                    else:
+                        raise
             except Exception:
                 staged_path.unlink(missing_ok=True)
                 raise

--- a/app/agent_memory/provisional_write.py
+++ b/app/agent_memory/provisional_write.py
@@ -19,6 +19,8 @@ from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 import yaml
+from yaml.constructor import ConstructorError
+from yaml.nodes import MappingNode
 
 from app.agent_memory.candidate import MemoryType
 from app.agent_memory.provisional_memory import (
@@ -44,8 +46,66 @@ _VISIBLE_PREFIX = (
     "> [!warning] Provisional / low trust — not authority\n"
     "> This memory may support reading or a cited proposal, but never APPLY or tool use.\n\n"
 )
+_PROVISIONAL_FRONTMATTER_KEYS = frozenset(
+    {
+        "uuid",
+        "artifact_class",
+        "artifact_type",
+        "source_role",
+        "authority_state",
+        "evidence_role",
+        "review_state",
+        "scope_id",
+        "principal_id",
+        "memory_type",
+        "sensitivity",
+        "created_by",
+        "created_at",
+        "provenance_event_ids",
+        "labels",
+    }
+)
 logger = logging.getLogger(__name__)
 ProvenanceRef = Annotated[str, Field(min_length=1, max_length=128)]
+
+
+class _UniqueKeySafeLoader(yaml.SafeLoader):
+    """Safe YAML loader that refuses ambiguous duplicate mapping keys."""
+
+
+def _construct_unique_mapping(
+    loader: yaml.SafeLoader,
+    node: MappingNode,
+    deep: bool = False,
+) -> dict[object, object]:
+    loader.flatten_mapping(node)
+    mapping: dict[object, object] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        try:
+            duplicate = key in mapping
+        except TypeError as exc:
+            raise ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                "found an unhashable mapping key",
+                key_node.start_mark,
+            ) from exc
+        if duplicate:
+            raise ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                f"found duplicate key {key!r}",
+                key_node.start_mark,
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+_UniqueKeySafeLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_unique_mapping,
+)
 
 
 class ProvisionalWriteRequest(BaseModel):
@@ -440,9 +500,11 @@ def load_provisional_markdown(
     if not raw.startswith("---\n") or "\n---\n" not in raw[4:]:
         raise ValueError("provisional Markdown requires YAML frontmatter")
     yaml_text, body = raw[4:].split("\n---\n", 1)
-    metadata = yaml.safe_load(yaml_text)
+    metadata = yaml.load(yaml_text, Loader=_UniqueKeySafeLoader)
     if not isinstance(metadata, dict):
         raise ValueError("provisional Markdown frontmatter must be a mapping")
+    if set(metadata) != _PROVISIONAL_FRONTMATTER_KEYS:
+        raise ValueError("provisional Markdown frontmatter keys must match the schema exactly")
     if metadata.get("artifact_class") != "agentic_memory" or metadata.get("artifact_type") != "provisional_memory":
         raise ValueError("not a provisional-memory artifact")
     labels = metadata.get("labels")

--- a/app/api/app.py
+++ b/app/api/app.py
@@ -122,6 +122,11 @@ except ImportError:
     capture_router = None
 
 try:
+    from app.api.routes.provisional_memory import router as provisional_memory_router
+except ImportError:
+    provisional_memory_router = None
+
+try:
     from app.api.routes.heimdal_screen import router as heimdal_screen_router
 except ImportError:
     heimdal_screen_router = None
@@ -280,6 +285,8 @@ def _create_app() -> FastAPI:
         application.include_router(source_understanding_router, prefix="/api")
     if capture_router is not None:
         application.include_router(capture_router, prefix="/api")
+    if provisional_memory_router is not None:
+        application.include_router(provisional_memory_router, prefix="/api")
     if heimdal_screen_router is not None:
         application.include_router(heimdal_screen_router)
     if version_router is not None:

--- a/app/api/routes/provisional_memory.py
+++ b/app/api/routes/provisional_memory.py
@@ -1,7 +1,7 @@
 """Product API for governed provisional-memory direct writes."""
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse
 
 from app.agent_memory.provisional_write import (
@@ -11,12 +11,17 @@ from app.agent_memory.provisional_write import (
     write_provisional_memory,
 )
 from app.api.routes.vault_resolution import active_vault_root_or_selection_required
+from app.auth import require_loopback_or_api_key
 from app.write_guard import WritesBlockedError
 
 router = APIRouter(prefix="/companion/memory", tags=["companion", "memory"])
 
 
-@router.post("/provisional", response_model=ProvisionalWriteResult)
+@router.post(
+    "/provisional",
+    response_model=ProvisionalWriteResult,
+    dependencies=[Depends(require_loopback_or_api_key)],
+)
 def post_provisional_memory(
     request: ProvisionalWriteRequest,
 ) -> ProvisionalWriteResult | JSONResponse:

--- a/app/api/routes/provisional_memory.py
+++ b/app/api/routes/provisional_memory.py
@@ -1,0 +1,54 @@
+"""Product API for governed provisional-memory direct writes."""
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import JSONResponse
+
+from app.agent_memory.provisional_write import (
+    ProvisionalMemoryWriteError,
+    ProvisionalWriteRequest,
+    ProvisionalWriteResult,
+    write_provisional_memory,
+)
+from app.api.routes.vault_resolution import active_vault_root_or_selection_required
+from app.write_guard import WritesBlockedError
+
+router = APIRouter(prefix="/companion/memory", tags=["companion", "memory"])
+
+
+@router.post("/provisional", response_model=ProvisionalWriteResult)
+def post_provisional_memory(
+    request: ProvisionalWriteRequest,
+) -> ProvisionalWriteResult | JSONResponse:
+    vault_root = active_vault_root_or_selection_required(require_initialized=True)
+    if isinstance(vault_root, JSONResponse):
+        return vault_root
+    try:
+        return write_provisional_memory(request, vault_root=vault_root)
+    except WritesBlockedError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": "writeguard_blocked",
+                "state": exc.state,
+                "reason": exc.reason,
+                "message": str(exc),
+            },
+        ) from exc
+    except ProvisionalMemoryWriteError as exc:
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "error": "provisional_memory_write_incomplete",
+                "state": exc.reconciliation.state.value,
+                "diagnostic": exc.reconciliation.diagnostic.value,
+                "receipt_id": (
+                    str(exc.lifecycle_receipt.receipt_id)
+                    if exc.lifecycle_receipt is not None
+                    else None
+                ),
+            },
+        ) from exc
+
+
+__all__ = ["router"]

--- a/tests/agent_memory/test_provisional_memory_api.py
+++ b/tests/agent_memory/test_provisional_memory_api.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.agent_memory import provisional_write as provisional_write_module
+from app.api.app import app
+from tests.api._vault_test_helpers import bind_initialized_vault
+
+
+def _setup_vault(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[Path, Path]:
+    vault = tmp_path / "vault"
+    vault.mkdir(parents=True)
+    bind_initialized_vault(monkeypatch, vault, store_dir=tmp_path)
+    receipts = tmp_path / "provisional-receipts.jsonl"
+    monkeypatch.setenv("PROVISIONAL_MEMORY_RECEIPTS_PATH", str(receipts))
+    monkeypatch.setenv("PKM_ENVIRONMENT", "dev")
+    return vault, receipts
+
+
+def _payload() -> dict[str, object]:
+    return {
+        "scope_id": "scope-personal",
+        "principal_id": "principal-1",
+        "memory_type": "preference_memory",
+        "sensitivity": "private",
+        "content": "The user prefers explicit verification.",
+        "provenance_event_ids": ["event-1"],
+    }
+
+
+def test_direct_write_creates_provisional_artifact_and_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault, receipts_path = _setup_vault(tmp_path, monkeypatch)
+    guard_calls: list[str] = []
+    real_guard = provisional_write_module.assert_provisional_trust_tier
+
+    def _spy_guard(artifact: object) -> None:
+        guard_calls.append("called")
+        real_guard(artifact)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(
+        provisional_write_module,
+        "assert_provisional_trust_tier",
+        _spy_guard,
+    )
+
+    response = TestClient(app).post(
+        "/api/companion/memory/provisional",
+        json=_payload(),
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    record = body["reconciliation"]["record"]
+    assert guard_calls == ["called"]
+    assert record["authority_state"] == "noncanonical"
+    assert record["review_state"] == "unreviewed"
+    assert record["may_apply"] is False
+    assert record["may_write"] is False
+    note_path = vault / body["reconciliation"]["artifact_ref"].removeprefix("vault://")
+    assert note_path.exists()
+
+    persisted = [
+        json.loads(line)
+        for line in receipts_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert [item["transition"] for item in persisted] == ["write_staged", "created"]
+    assert body["lifecycle_receipt"]["receipt_id"] == persisted[-1]["receipt_id"]
+    assert "The user prefers explicit verification." not in receipts_path.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_provisional_artifact_is_visibly_distinct_from_promoted_memory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault, _ = _setup_vault(tmp_path, monkeypatch)
+
+    response = TestClient(app).post(
+        "/api/companion/memory/provisional",
+        json=_payload(),
+    )
+
+    assert response.status_code == 200, response.text
+    artifact_ref = response.json()["reconciliation"]["artifact_ref"]
+    assert artifact_ref.startswith("vault://Memory/Provisional/")
+    markdown = (vault / artifact_ref.removeprefix("vault://")).read_text(
+        encoding="utf-8"
+    )
+    assert "artifact_type: provisional_memory" in markdown
+    assert "review_state: unreviewed" in markdown
+    assert "authority_state: noncanonical" in markdown
+    assert "Provisional / low trust — not authority" in markdown
+    assert "agent_promoted" not in markdown

--- a/tests/agent_memory/test_provisional_memory_api.py
+++ b/tests/agent_memory/test_provisional_memory_api.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
+import app.auth as auth_module
 from app.agent_memory import provisional_write as provisional_write_module
 from app.api.app import app
 from tests.api._vault_test_helpers import bind_initialized_vault
@@ -102,3 +103,20 @@ def test_provisional_artifact_is_visibly_distinct_from_promoted_memory(
     assert "authority_state: noncanonical" in markdown
     assert "Provisional / low trust — not authority" in markdown
     assert "agent_promoted" not in markdown
+
+
+def test_non_loopback_provisional_write_requires_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(auth_module.settings, "api_key", None)
+    monkeypatch.setattr(auth_module.settings, "companion_trusted_proxy_hosts", "")
+    monkeypatch.setattr(auth_module.settings, "companion_ui_proxy_hosts", "")
+    client = TestClient(app, client=("203.0.113.10", 50000))
+
+    response = client.post(
+        "/api/companion/memory/provisional",
+        json=_payload(),
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "API key required for non-loopback request"

--- a/tests/agent_memory/test_provisional_memory_call_sites.py
+++ b/tests/agent_memory/test_provisional_memory_call_sites.py
@@ -4,6 +4,8 @@ import inspect
 from pathlib import Path
 from uuid import UUID
 
+import pytest
+
 from app.agent_memory.candidate import MemoryType
 from app.agent_memory.provisional_memory import (
     ProvisionalMarkdownArtifact,
@@ -49,7 +51,7 @@ def test_sync_is_not_an_execution_bus(tmp_path: Path) -> None:
     path.parent.mkdir(parents=True)
     path.write_text(render_provisional_markdown(artifact), encoding="utf-8")
 
-    loaded = load_provisional_markdown(path)
+    loaded = load_provisional_markdown(path, vault_root=tmp_path)
     reconciliation = rebuild_provisional_memory(
         memory_id=memory_id,
         artifact_ref=artifact.artifact_ref,
@@ -60,3 +62,26 @@ def test_sync_is_not_an_execution_bus(tmp_path: Path) -> None:
     assert reconciliation.state is ProvisionalReconciliationState.RETRYABLE_PARTIAL
     assert reconciliation.record is None
     assert list(tmp_path.rglob("*.jsonl")) == []
+
+
+def test_loader_rejects_filename_frontmatter_uuid_mismatch(tmp_path: Path) -> None:
+    memory_id = UUID("12345678-1234-4abc-8def-1234567890ab")
+    other_id = UUID("22345678-1234-4abc-8def-1234567890ab")
+    artifact = ProvisionalMarkdownArtifact(
+        memory_id=memory_id,
+        artifact_ref=f"vault://Memory/Provisional/{memory_id}.md",
+        scope_id="scope-personal",
+        principal_id="principal-1",
+        memory_type=MemoryType.PREFERENCE_MEMORY,
+        sensitivity=ProvisionalSensitivity.PRIVATE,
+        content="A copied file cannot acquire another identity.",
+        created_by="human://owner",
+        created_at="2026-07-15T00:00:00Z",
+        provenance_event_ids=("event-1",),
+    )
+    path = tmp_path / "Memory" / "Provisional" / f"{other_id}.md"
+    path.parent.mkdir(parents=True)
+    path.write_text(render_provisional_markdown(artifact), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="physical provisional Markdown path"):
+        load_provisional_markdown(path, vault_root=tmp_path)

--- a/tests/agent_memory/test_provisional_memory_call_sites.py
+++ b/tests/agent_memory/test_provisional_memory_call_sites.py
@@ -85,3 +85,35 @@ def test_loader_rejects_filename_frontmatter_uuid_mismatch(tmp_path: Path) -> No
 
     with pytest.raises(ValueError, match="physical provisional Markdown path"):
         load_provisional_markdown(path, vault_root=tmp_path)
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "12345678-1234-4ABC-8DEF-1234567890AB.md",
+        "{12345678-1234-4abc-8def-1234567890ab}.md",
+    ],
+)
+def test_loader_rejects_noncanonical_uuid_filename_aliases(
+    tmp_path: Path,
+    filename: str,
+) -> None:
+    memory_id = UUID("12345678-1234-4abc-8def-1234567890ab")
+    artifact = ProvisionalMarkdownArtifact(
+        memory_id=memory_id,
+        artifact_ref=f"vault://Memory/Provisional/{memory_id}.md",
+        scope_id="scope-personal",
+        principal_id="principal-1",
+        memory_type=MemoryType.PREFERENCE_MEMORY,
+        sensitivity=ProvisionalSensitivity.PRIVATE,
+        content="UUID textual aliases are not canonical identity.",
+        created_by="human://owner",
+        created_at="2026-07-15T00:00:00Z",
+        provenance_event_ids=("event-1",),
+    )
+    path = tmp_path / "Memory" / "Provisional" / filename
+    path.parent.mkdir(parents=True)
+    path.write_text(render_provisional_markdown(artifact), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="filename is not canonical"):
+        load_provisional_markdown(path, vault_root=tmp_path)

--- a/tests/agent_memory/test_provisional_memory_call_sites.py
+++ b/tests/agent_memory/test_provisional_memory_call_sites.py
@@ -154,3 +154,39 @@ def test_loader_rejects_unmodeled_or_duplicate_authority_frontmatter(
 
     with pytest.raises((ValueError, yaml.YAMLError)):
         load_provisional_markdown(path, vault_root=tmp_path)
+
+
+@pytest.mark.parametrize(
+    "replacement",
+    [
+        "provenance_event_ids: event-1",
+        "provenance_event_ids: {event-1: forged}",
+    ],
+)
+def test_loader_rejects_non_sequence_provenance(
+    tmp_path: Path,
+    replacement: str,
+) -> None:
+    memory_id = UUID("12345678-1234-4abc-8def-1234567890ab")
+    artifact = ProvisionalMarkdownArtifact(
+        memory_id=memory_id,
+        artifact_ref=f"vault://Memory/Provisional/{memory_id}.md",
+        scope_id="scope-personal",
+        principal_id="principal-1",
+        memory_type=MemoryType.PREFERENCE_MEMORY,
+        sensitivity=ProvisionalSensitivity.PRIVATE,
+        content="Provenance shape must be structural, not coerced.",
+        created_by="human://owner",
+        created_at="2026-07-15T00:00:00Z",
+        provenance_event_ids=("event-1",),
+    )
+    path = tmp_path / "Memory" / "Provisional" / f"{memory_id}.md"
+    path.parent.mkdir(parents=True)
+    rendered = render_provisional_markdown(artifact)
+    path.write_text(
+        rendered.replace("provenance_event_ids:\n- event-1", replacement),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="must be a non-empty string sequence"):
+        load_provisional_markdown(path, vault_root=tmp_path)

--- a/tests/agent_memory/test_provisional_memory_call_sites.py
+++ b/tests/agent_memory/test_provisional_memory_call_sites.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from uuid import UUID
+
+from app.agent_memory.candidate import MemoryType
+from app.agent_memory.provisional_memory import (
+    ProvisionalMarkdownArtifact,
+    ProvisionalReconciliationState,
+    ProvisionalSensitivity,
+    rebuild_provisional_memory,
+)
+from app.agent_memory import provisional_write as provisional_write_module
+from app.agent_memory.provisional_write import (
+    load_provisional_markdown,
+    render_provisional_markdown,
+)
+
+
+def test_write_endpoint_cannot_promote_or_authorize_apply() -> None:
+    source = inspect.getsource(provisional_write_module)
+    assert "materialize_promoted_memory" not in source
+    assert "mark_terminal" not in source
+    assert "promotion_state" not in source
+
+    record_source = inspect.getsource(
+        provisional_write_module.write_provisional_memory
+    )
+    assert "assert_provisional_trust_tier" in record_source
+    assert "write_note_relative" in record_source
+
+
+def test_sync_is_not_an_execution_bus(tmp_path: Path) -> None:
+    memory_id = UUID("12345678-1234-4abc-8def-1234567890ab")
+    artifact = ProvisionalMarkdownArtifact(
+        memory_id=memory_id,
+        artifact_ref=f"vault://Memory/Provisional/{memory_id}.md",
+        scope_id="scope-personal",
+        principal_id="principal-1",
+        memory_type=MemoryType.PREFERENCE_MEMORY,
+        sensitivity=ProvisionalSensitivity.PRIVATE,
+        content="A file appearing is not a transition.",
+        created_by="human://owner",
+        created_at="2026-07-15T00:00:00Z",
+        provenance_event_ids=("event-1",),
+    )
+    path = tmp_path / "Memory" / "Provisional" / f"{memory_id}.md"
+    path.parent.mkdir(parents=True)
+    path.write_text(render_provisional_markdown(artifact), encoding="utf-8")
+
+    loaded = load_provisional_markdown(path)
+    reconciliation = rebuild_provisional_memory(
+        memory_id=memory_id,
+        artifact_ref=artifact.artifact_ref,
+        artifact=loaded,
+        receipts=(),
+    )
+
+    assert reconciliation.state is ProvisionalReconciliationState.RETRYABLE_PARTIAL
+    assert reconciliation.record is None
+    assert list(tmp_path.rglob("*.jsonl")) == []

--- a/tests/agent_memory/test_provisional_memory_call_sites.py
+++ b/tests/agent_memory/test_provisional_memory_call_sites.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from uuid import UUID
 
 import pytest
+import yaml
 
 from app.agent_memory.candidate import MemoryType
 from app.agent_memory.provisional_memory import (
@@ -116,4 +117,40 @@ def test_loader_rejects_noncanonical_uuid_filename_aliases(
     path.write_text(render_provisional_markdown(artifact), encoding="utf-8")
 
     with pytest.raises(ValueError, match="filename is not canonical"):
+        load_provisional_markdown(path, vault_root=tmp_path)
+
+
+@pytest.mark.parametrize(
+    "injected_frontmatter",
+    [
+        "promotion_state: promoted\nauthority_receipt_ref: forged\n",
+        "authority_state: canonical\n",
+    ],
+)
+def test_loader_rejects_unmodeled_or_duplicate_authority_frontmatter(
+    tmp_path: Path,
+    injected_frontmatter: str,
+) -> None:
+    memory_id = UUID("12345678-1234-4abc-8def-1234567890ab")
+    artifact = ProvisionalMarkdownArtifact(
+        memory_id=memory_id,
+        artifact_ref=f"vault://Memory/Provisional/{memory_id}.md",
+        scope_id="scope-personal",
+        principal_id="principal-1",
+        memory_type=MemoryType.PREFERENCE_MEMORY,
+        sensitivity=ProvisionalSensitivity.PRIVATE,
+        content="Visible authority claims must never be ignored.",
+        created_by="human://owner",
+        created_at="2026-07-15T00:00:00Z",
+        provenance_event_ids=("event-1",),
+    )
+    path = tmp_path / "Memory" / "Provisional" / f"{memory_id}.md"
+    path.parent.mkdir(parents=True)
+    rendered = render_provisional_markdown(artifact)
+    path.write_text(
+        rendered.replace("---\n", f"---\n{injected_frontmatter}", 1),
+        encoding="utf-8",
+    )
+
+    with pytest.raises((ValueError, yaml.YAMLError)):
         load_provisional_markdown(path, vault_root=tmp_path)

--- a/tests/agent_memory/test_provisional_memory_failures.py
+++ b/tests/agent_memory/test_provisional_memory_failures.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+from app.agent_memory import provisional_write as provisional_write_module
+from app.agent_memory.candidate import MemoryType
+from app.agent_memory.provisional_memory import (
+    ProvisionalLifecycleReceipt,
+    ProvisionalLifecycleTransition,
+    ProvisionalReconciliationState,
+    ProvisionalSensitivity,
+)
+from app.agent_memory.provisional_write import (
+    ProvisionalMemoryWriteError,
+    ProvisionalWriteRequest,
+    write_provisional_memory,
+)
+from app.write_guard import WriteGuard, WritesBlockedError
+
+
+class _FailCreatedReceiptStore:
+    def __init__(self) -> None:
+        self.receipts: list[ProvisionalLifecycleReceipt] = []
+
+    def append(self, receipt: ProvisionalLifecycleReceipt) -> None:
+        if receipt.transition is ProvisionalLifecycleTransition.CREATED:
+            raise OSError("receipt disk unavailable")
+        self.receipts.append(receipt)
+
+    def list_for(self, memory_id: UUID) -> tuple[ProvisionalLifecycleReceipt, ...]:
+        return tuple(item for item in self.receipts if item.memory_id == memory_id)
+
+
+class _FailFirstReceiptStore(_FailCreatedReceiptStore):
+    def append(self, receipt: ProvisionalLifecycleReceipt) -> None:
+        raise OSError("receipt ledger unavailable")
+
+
+class _MemoryReceiptStore(_FailCreatedReceiptStore):
+    def append(self, receipt: ProvisionalLifecycleReceipt) -> None:
+        self.receipts.append(receipt)
+
+
+def _request() -> ProvisionalWriteRequest:
+    return ProvisionalWriteRequest(
+        scope_id="scope-personal",
+        principal_id="principal-1",
+        memory_type=MemoryType.PREFERENCE_MEMORY,
+        sensitivity=ProvisionalSensitivity.PRIVATE,
+        content="Never admit an orphan.",
+        provenance_event_ids=("event-1",),
+    )
+
+
+def test_partial_write_fails_closed_and_reconciles(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    store = _FailCreatedReceiptStore()
+
+    with pytest.raises(ProvisionalMemoryWriteError) as caught:
+        write_provisional_memory(
+            _request(),
+            vault_root=vault,
+            receipt_store=store,
+            write_guard=WriteGuard(snapshot_fn=lambda: {"state": "healthy"}),
+        )
+
+    error = caught.value
+    assert error.reconciliation.state is ProvisionalReconciliationState.RETRYABLE_PARTIAL
+    assert error.reconciliation.record is None
+    assert [item.transition for item in store.receipts] == [
+        ProvisionalLifecycleTransition.WRITE_STAGED
+    ]
+    artifacts = list((vault / "Memory" / "Provisional").glob("*.md"))
+    assert len(artifacts) == 1
+    assert "Never admit an orphan." in artifacts[0].read_text(encoding="utf-8")
+
+
+def test_writeguard_block_creates_neither_artifact_nor_receipt(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    store = _FailCreatedReceiptStore()
+    guard = WriteGuard(
+        snapshot_fn=lambda: {"state": "safe_mode", "reason": "operator block"},
+        bootstrap_actions=(),
+    )
+
+    with pytest.raises(WritesBlockedError):
+        write_provisional_memory(
+            _request(),
+            vault_root=vault,
+            receipt_store=store,
+            write_guard=guard,
+        )
+
+    assert store.receipts == []
+    assert not (vault / "Memory" / "Provisional").exists()
+
+
+def test_staged_receipt_failure_happens_before_artifact_write(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+
+    with pytest.raises(ProvisionalMemoryWriteError) as caught:
+        write_provisional_memory(
+            _request(),
+            vault_root=vault,
+            receipt_store=_FailFirstReceiptStore(),
+            write_guard=WriteGuard(snapshot_fn=lambda: {"state": "healthy"}),
+        )
+
+    assert caught.value.reconciliation.state is ProvisionalReconciliationState.RETRYABLE_PARTIAL
+    assert caught.value.reconciliation.record is None
+    assert not (vault / "Memory" / "Provisional").exists()
+
+
+def test_artifact_failure_records_retryable_content_free_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    store = _MemoryReceiptStore()
+
+    def _fail_write(*args: object, **kwargs: object) -> None:
+        raise PermissionError("claim text must not enter the receipt")
+
+    monkeypatch.setattr(provisional_write_module, "write_note_relative", _fail_write)
+
+    with pytest.raises(ProvisionalMemoryWriteError) as caught:
+        write_provisional_memory(
+            _request(),
+            vault_root=vault,
+            receipt_store=store,
+            write_guard=WriteGuard(snapshot_fn=lambda: {"state": "healthy"}),
+        )
+
+    assert caught.value.reconciliation.state is ProvisionalReconciliationState.RETRYABLE_PARTIAL
+    assert caught.value.reconciliation.record is None
+    assert [item.transition for item in store.receipts] == [
+        ProvisionalLifecycleTransition.WRITE_STAGED,
+        ProvisionalLifecycleTransition.WRITE_FAILED,
+    ]
+    failed_payload = store.receipts[-1].content_free_payload()
+    assert failed_payload["error_code"] == "permission_denied"
+    assert "claim text" not in str(failed_payload)
+    assert not (vault / "Memory" / "Provisional").exists()

--- a/tests/agent_memory/test_provisional_memory_failures.py
+++ b/tests/agent_memory/test_provisional_memory_failures.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+import multiprocessing
 from pathlib import Path
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -15,6 +17,8 @@ from app.agent_memory.provisional_memory import (
 )
 from app.agent_memory.provisional_write import (
     ProvisionalMemoryWriteError,
+    ProvisionalReceiptStore,
+    ProvisionalReceiptStoreError,
     ProvisionalWriteRequest,
     write_provisional_memory,
 )
@@ -42,6 +46,27 @@ class _FailFirstReceiptStore(_FailCreatedReceiptStore):
 class _MemoryReceiptStore(_FailCreatedReceiptStore):
     def append(self, receipt: ProvisionalLifecycleReceipt) -> None:
         self.receipts.append(receipt)
+
+
+def _append_receipt_process(path: str, payload: str) -> None:
+    store = ProvisionalReceiptStore(Path(path))
+    store.append(ProvisionalLifecycleReceipt.model_validate_json(payload))
+
+
+def _staged_receipt(
+    *,
+    memory_id: UUID,
+    offset: int,
+) -> ProvisionalLifecycleReceipt:
+    return ProvisionalLifecycleReceipt(
+        receipt_id=uuid4(),
+        memory_id=memory_id,
+        artifact_ref=f"vault://Memory/Provisional/{memory_id}.md",
+        transition=ProvisionalLifecycleTransition.WRITE_STAGED,
+        actor_ref="agent",
+        occurred_at=datetime(2026, 7, 15, tzinfo=timezone.utc)
+        + timedelta(microseconds=offset),
+    )
 
 
 def _request() -> ProvisionalWriteRequest:
@@ -147,4 +172,79 @@ def test_artifact_failure_records_retryable_content_free_failure(
     failed_payload = store.receipts[-1].content_free_payload()
     assert failed_payload["error_code"] == "permission_denied"
     assert "claim text" not in str(failed_payload)
+    assert not (vault / "Memory" / "Provisional").exists()
+
+
+def test_receipt_store_serializes_cross_process_appends(tmp_path: Path) -> None:
+    path = tmp_path / "receipts.jsonl"
+    memory_id = uuid4()
+    receipts = [_staged_receipt(memory_id=memory_id, offset=index) for index in range(8)]
+    context = multiprocessing.get_context("fork")
+    processes = [
+        context.Process(
+            target=_append_receipt_process,
+            args=(str(path), receipt.model_dump_json()),
+        )
+        for receipt in receipts
+    ]
+
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=20)
+        assert process.exitcode == 0
+
+    restarted = ProvisionalReceiptStore(path)
+    persisted = restarted.list_for(memory_id)
+    assert {item.receipt_id for item in persisted} == {
+        item.receipt_id for item in receipts
+    }
+    assert len(path.read_text(encoding="utf-8").splitlines()) == len(receipts)
+
+
+def test_failed_atomic_replace_preserves_restart_readability(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "receipts.jsonl"
+    memory_id = uuid4()
+    first = _staged_receipt(memory_id=memory_id, offset=1)
+    second = _staged_receipt(memory_id=memory_id, offset=2)
+    store = ProvisionalReceiptStore(path)
+    store.append(first)
+
+    def _fail_replace(source: object, target: object) -> None:
+        raise OSError("simulated replace failure")
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(provisional_write_module.os, "replace", _fail_replace)
+        with pytest.raises(OSError, match="simulated replace failure"):
+            store.append(second)
+
+    restarted = ProvisionalReceiptStore(path)
+    assert restarted.list_for(memory_id) == (first,)
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_corrupt_ledger_restart_fails_closed_before_artifact(tmp_path: Path) -> None:
+    path = tmp_path / "receipts.jsonl"
+    memory_id = uuid4()
+    store = ProvisionalReceiptStore(path)
+    store.append(_staged_receipt(memory_id=memory_id, offset=1))
+    path.write_bytes(path.read_bytes() + b'{"partial"')
+
+    restarted = ProvisionalReceiptStore(path)
+    with pytest.raises(ProvisionalReceiptStoreError):
+        restarted.list_for(memory_id)
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    with pytest.raises(ProvisionalMemoryWriteError) as caught:
+        write_provisional_memory(
+            _request(),
+            vault_root=vault,
+            receipt_store=restarted,
+            write_guard=WriteGuard(snapshot_fn=lambda: {"state": "healthy"}),
+        )
+    assert caught.value.reconciliation.record is None
     assert not (vault / "Memory" / "Provisional").exists()

--- a/tests/agent_memory/test_provisional_memory_failures.py
+++ b/tests/agent_memory/test_provisional_memory_failures.py
@@ -226,6 +226,41 @@ def test_failed_atomic_replace_preserves_restart_readability(
     assert list(tmp_path.glob("*.tmp")) == []
 
 
+def test_visible_receipt_after_directory_fsync_failure_is_committed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    path = tmp_path / "receipts.jsonl"
+    fsync_calls = 0
+
+    def _fail_created_directory_fsync(directory: Path) -> None:
+        nonlocal fsync_calls
+        fsync_calls += 1
+        if fsync_calls == 2:
+            raise OSError("simulated post-replace directory fsync failure")
+
+    monkeypatch.setattr(
+        provisional_write_module,
+        "_fsync_directory",
+        _fail_created_directory_fsync,
+    )
+    result = write_provisional_memory(
+        _request(),
+        vault_root=vault,
+        receipt_store=ProvisionalReceiptStore(path),
+        write_guard=WriteGuard(snapshot_fn=lambda: {"state": "healthy"}),
+    )
+
+    assert result.reconciliation.state is ProvisionalReconciliationState.READY
+    restarted = ProvisionalReceiptStore(path)
+    assert [item.transition for item in restarted.list_for(result.lifecycle_receipt.memory_id)] == [
+        ProvisionalLifecycleTransition.WRITE_STAGED,
+        ProvisionalLifecycleTransition.CREATED,
+    ]
+
+
 def test_corrupt_ledger_restart_fails_closed_before_artifact(tmp_path: Path) -> None:
     path = tmp_path / "receipts.jsonl"
     memory_id = uuid4()

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -676,6 +676,12 @@ WRITE_NOTE_RELATIVE_SITE_CLASSIFICATION: dict[tuple[str, str, int], str] = {
         "assert_writes_allowed(MEMORY_MATERIALIZATION_ACTION) immediately "
         "before this call, in addition to the port's own guard (#2953)."
     ),
+    ("app/agent_memory/provisional_write.py", "write_provisional_memory", 1): (
+        "guarded_by_caller: write_provisional_memory asserts write_guard."
+        "assert_writes_allowed(PROVISIONAL_MEMORY_WRITE_ACTION) before the "
+        "staged receipt and passes the same guard/action to the port, in "
+        "addition to the port's own guard (#3719)."
+    ),
     ("app/knowledge_acquisition/candidate_writeback.py", "write_candidate_note", 1): (
         "guarded_by_caller: write_candidate_note asserts write_guard."
         "assert_writes_allowed(CANDIDATE_WRITE_ACTION) immediately before "


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Fixes #3719

## SBS Impact
- Primary subsystem: MEM — Machine Memory & Learning
- Secondary subsystem(s): GOV, HKA, PDM, HIX
- Write class: authority-sensitive provisional Markdown write plus content-free lifecycle receipts
- Authority impact: production trust-tier guard structurally pins unreviewed/noncanonical/non-action posture; no promotion path is imported
- Persistence impact: Vault Markdown is the sole meaning-bearing artifact; JSONL lifecycle receipts contain UUID/hash/enum/time/canonical refs only
- Derived/rebuildable impact: API response is read back and rebuilt from persisted Markdown plus receipts
- Human knowledge impact: creates an explicitly labeled, human-editable provisional note distinct from promoted memory
- Memory impact: introduces the first provisional direct-write producer
- Retrieval/context impact: none; incomplete and complete records are not wired into recall in this slice
- Sync/deployment impact: filesystem appearance alone creates no receipt or transition; no deployment change
- External boundary impact: new local product endpoint `POST /api/companion/memory/provisional`
- New or changed contract: governed provisional-memory producer and partial-failure ordering
- Owner-doc impact: none; endpoint/artifact contract is already owned by the merged `docs/PROVISIONAL_MEMORY/` spec and capability remains incomplete until #3720/#3721
- Transition debt impact: implements PROVISIONAL-MEMORY-02 without claiming the read/eval boundary
- Fitness rule impact: registers the new knowledge-port seam as caller- and port-guarded
- Boundary risk: critical data/memory-authority and filesystem partial-order boundary, fail-closed by staged receipts and independent review

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Add a single governed provisional-memory API that runs the trust ceiling and WriteGuard before writing canonical, visibly low-trust Vault Markdown.
- Persist only content-free staged/created/failed lifecycle receipts and withhold records on every orphan, corrupt-ledger, write, or receipt failure.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed. (The merged execution spec already defines this exact endpoint/artifact contract.)
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality. (Capability remains incomplete and parent #2314 remains open.)

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [ ] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [ ] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [x] `ruff check app tests` — `All checks passed!`
- [x] If files under `app/` or `tests/` changed, lint output from `ruff check app tests` is included below or a tooling limitation is stated.
- [x] `mypy app` — `Success: no issues found in 737 source files`
- [ ] `pytest -q -m "not pg"` — 8,345 passed; the only failure was the new seam missing from the closed guard census. After classification, the exact failed fitness gate passes; CI must provide the clean full-suite receipt.
- [x] Additional targeted checks run as needed

Targeted checks on rebased head:
- Issue validation plus materialization/review regressions and guard census: 19 passed.
- Agent-memory + OpenAPI + capture regression: 138 passed before the final mechanical census entry.
- Full local run used `PYTHONPATH=companion-ui/companion-app` and an isolated basetemp; initial collection without that path was environment-limited and retried correctly.

## BuilderOps Routing
- Records/projections/receipts: pickup receipt `github-comment:4975228644`
- Reason: dispatcher DB remained uninitialized, so the canonical pickup wrapper used GitHub-label-only fallback; no new learning signal was required.

## Notes
- Current Codex capability was Sol/medium while the issue calls for Sol/high-xhigh. Compensation: explicit partial-order state machine, full local suite, closed seam census, and mandatory two-round independent high-risk review.
- Parent #2314 remains a validation hub and was never claimed.
