### PR TITLE
feat(memory): admit provisional recall as low trust

### DIFF
--- a/app/agent_memory/authority_guard.py
+++ b/app/agent_memory/authority_guard.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field
 
 from app.agent_memory.candidate import ContradictionState, MemoryType, ReviewState
 from app.agent_memory.promotion import PromotedMemory
+from app.agent_memory.provisional_memory import ProvisionalMemoryRecord
 from app.agent_memory.recall_explanation import RecallUseRight
 
 
@@ -106,4 +107,36 @@ def evaluate_memory_authority(
         posture_visibility_required=posture_visibility_required,
         posture_markers=sorted(set(posture_markers)),
         requested_action_scope=requested_action_scope,
+    )
+
+
+def evaluate_provisional_memory_authority(
+    record: ProvisionalMemoryRecord,
+    *,
+    use_right: RecallUseRight,
+) -> MemoryAuthorityDecision:
+    """Clamp direct-write provisional memory below mutation authority.
+
+    Provisional records are deliberately not converted to ``PromotedMemory``:
+    doing so would manufacture a governance transition that never occurred.
+    """
+
+    blocked = [
+        "provisional_memory_noncanonical",
+        "review_state_not_accepted",
+    ]
+    if use_right is RecallUseRight.ACTION_AUTHORIZING:
+        blocked.append("provisional_memory_never_action_authoritative")
+    return MemoryAuthorityDecision(
+        allow_suggestion=True,
+        allow_mutation=False,
+        authority_level=MemoryAuthorityLevel.SUGGESTION_ONLY,
+        blocked_reasons=sorted(blocked),
+        posture_visibility_required=True,
+        posture_markers=[
+            record.authority_state,
+            "provisional",
+            "low-trust",
+            record.review_state.value,
+        ],
     )

--- a/app/agent_memory/provisional_recall.py
+++ b/app/agent_memory/provisional_recall.py
@@ -121,18 +121,34 @@ def retrieve_relevant_provisional(
     by_memory: dict[UUID, list] = {}
     for receipt in receipts:
         by_memory.setdefault(receipt.memory_id, []).append(receipt)
+    excluded: list[ProvisionalRecallExclusion] = []
     directory = vault_root / PROVISIONAL_MEMORY_DIR
     if directory.exists():
         for path in directory.glob("*.md"):
             try:
                 memory_id = UUID(path.stem)
             except ValueError:
+                excluded.append(
+                    ProvisionalRecallExclusion(
+                        memory_id=path.stem,
+                        artifact_ref=f"vault://{PROVISIONAL_MEMORY_DIR}/{path.name}",
+                        reason_code="artifact_identity_invalid",
+                    )
+                )
+                continue
+            if memory_id.version != 4 or path.name != f"{memory_id}.md":
+                excluded.append(
+                    ProvisionalRecallExclusion(
+                        memory_id=path.stem,
+                        artifact_ref=f"vault://{PROVISIONAL_MEMORY_DIR}/{path.name}",
+                        reason_code="artifact_identity_invalid",
+                    )
+                )
                 continue
             by_memory.setdefault(memory_id, [])
 
     query_tokens = _tokens(query)
     candidates: list[ProvisionalRecallCandidate] = []
-    excluded: list[ProvisionalRecallExclusion] = []
     for memory_id in sorted(by_memory, key=str):
         artifact_ref = f"vault://{PROVISIONAL_MEMORY_DIR}/{memory_id}.md"
         path = vault_root / PROVISIONAL_MEMORY_DIR / f"{memory_id}.md"

--- a/app/agent_memory/provisional_recall.py
+++ b/app/agent_memory/provisional_recall.py
@@ -1,0 +1,416 @@
+"""Production recall boundary for provisional, low-trust memory.
+
+Vault Markdown remains the only meaning-bearing input. Lifecycle and recall
+receipts contain identifiers and posture only; they cannot reconstruct claim
+content or confer authority.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import fcntl
+import json
+import os
+from pathlib import Path
+import re
+from uuid import UUID, uuid4
+
+from app.activation.gate import (
+    AdmissionTier,
+    AdmissibilityDecision,
+    CandidateContext,
+    ConsumingAuthority,
+    ConsumingContext,
+    TrustArchetype,
+    evaluate_admissibility,
+)
+from app.agent_memory.authority_guard import (
+    MemoryAuthorityDecision,
+    evaluate_provisional_memory_authority,
+)
+from app.agent_memory.provisional_memory import (
+    ProvisionalMemoryReconciliation,
+    ProvisionalMemoryRecord,
+    ProvisionalReconciliationState,
+    rebuild_provisional_memory,
+)
+from app.agent_memory.provisional_write import (
+    PROVISIONAL_MEMORY_DIR,
+    ProvisionalReceiptStore,
+    load_provisional_markdown,
+)
+from app.agent_memory.recall_explanation import (
+    ActivationReason,
+    MemoryLifecycleState,
+    RecallExplanation,
+    RecallUseRight,
+    SourceProvenance,
+)
+
+DEFAULT_PROVISIONAL_RECALL_RECEIPTS_PATH = Path(
+    "runtime/agent_memory/provisional_recall_receipts.jsonl"
+)
+PROVISIONAL_RECALL_RECEIPT_EVENT = "agent_memory.provisional_recall.evaluated"
+_TOKEN_RE = re.compile(r"[A-Za-z0-9]+")
+
+
+@dataclass(frozen=True)
+class ProvisionalRecallCandidate:
+    record: ProvisionalMemoryRecord
+    reconciliation: ProvisionalMemoryReconciliation
+    score: float
+    reason_code: str
+
+
+@dataclass(frozen=True)
+class ProvisionalRecallExclusion:
+    memory_id: str
+    artifact_ref: str
+    reason_code: str
+
+
+@dataclass(frozen=True)
+class ProvisionalRecallSearch:
+    candidates: tuple[ProvisionalRecallCandidate, ...]
+    excluded: tuple[ProvisionalRecallExclusion, ...]
+
+
+@dataclass(frozen=True)
+class ProvisionalGuardedRecall:
+    memory_id: str
+    admitted: bool
+    may_answer: bool
+    may_propose: bool
+    may_write: bool
+    admissibility_decision: AdmissibilityDecision
+    authority_decision: MemoryAuthorityDecision
+    explanation: RecallExplanation | None
+    receipt_id: str
+
+
+def retrieve_relevant_provisional(
+    query: str,
+    *,
+    vault_root: Path,
+    receipt_store: ProvisionalReceiptStore | None = None,
+    active_scope_id: str,
+    k: int = 3,
+) -> ProvisionalRecallSearch:
+    """Rebuild and rank complete same-scope provisional records.
+
+    Scope filtering and lifecycle reconstruction happen before relevance
+    ranking. Invalid or incomplete records yield content-free exclusions.
+    """
+
+    if k <= 0 or not _tokens(query):
+        return ProvisionalRecallSearch(candidates=(), excluded=())
+    store = receipt_store or ProvisionalReceiptStore()
+    try:
+        receipts = store.list_all()
+    except Exception:
+        return ProvisionalRecallSearch(
+            candidates=(),
+            excluded=(
+                ProvisionalRecallExclusion(
+                    memory_id="unknown",
+                    artifact_ref="vault://Memory/Provisional/unknown",
+                    reason_code="receipt_store_unreadable",
+                ),
+            ),
+        )
+    by_memory: dict[UUID, list] = {}
+    for receipt in receipts:
+        by_memory.setdefault(receipt.memory_id, []).append(receipt)
+    directory = vault_root / PROVISIONAL_MEMORY_DIR
+    if directory.exists():
+        for path in directory.glob("*.md"):
+            try:
+                memory_id = UUID(path.stem)
+            except ValueError:
+                continue
+            by_memory.setdefault(memory_id, [])
+
+    query_tokens = _tokens(query)
+    candidates: list[ProvisionalRecallCandidate] = []
+    excluded: list[ProvisionalRecallExclusion] = []
+    for memory_id in sorted(by_memory, key=str):
+        artifact_ref = f"vault://{PROVISIONAL_MEMORY_DIR}/{memory_id}.md"
+        path = vault_root / PROVISIONAL_MEMORY_DIR / f"{memory_id}.md"
+        artifact_invalid = False
+        try:
+            artifact = (
+                load_provisional_markdown(path, vault_root=vault_root)
+                if path.exists()
+                else None
+            )
+        except Exception:
+            artifact = None
+            artifact_invalid = True
+        reconciliation = rebuild_provisional_memory(
+            memory_id=memory_id,
+            artifact_ref=artifact_ref,
+            artifact=artifact,
+            receipts=tuple(by_memory[memory_id]),
+        )
+        if artifact_invalid:
+            excluded.append(
+                ProvisionalRecallExclusion(
+                    memory_id=str(memory_id),
+                    artifact_ref=artifact_ref,
+                    reason_code="artifact_invalid",
+                )
+            )
+            continue
+        record = reconciliation.record
+        if (
+            reconciliation.state
+            not in {
+                ProvisionalReconciliationState.READY,
+                ProvisionalReconciliationState.EDITED,
+            }
+            or record is None
+        ):
+            excluded.append(
+                ProvisionalRecallExclusion(
+                    memory_id=str(memory_id),
+                    artifact_ref=artifact_ref,
+                    reason_code=reconciliation.diagnostic.value,
+                )
+            )
+            continue
+        if record.scope_id != active_scope_id:
+            excluded.append(
+                ProvisionalRecallExclusion(
+                    memory_id=str(memory_id),
+                    artifact_ref=artifact_ref,
+                    reason_code="cross_sphere_no_allowance",
+                )
+            )
+            continue
+        score = _score(record, query_tokens)
+        if score <= 0:
+            continue
+        candidates.append(
+            ProvisionalRecallCandidate(
+                record=record,
+                reconciliation=reconciliation,
+                score=score,
+                reason_code="lexical_relevance",
+            )
+        )
+    ranked = sorted(
+        candidates,
+        key=lambda item: (item.score, item.record.created_at, str(item.record.memory_id)),
+        reverse=True,
+    )[:k]
+    return ProvisionalRecallSearch(candidates=tuple(ranked), excluded=tuple(excluded))
+
+
+def activate_provisional_recall(
+    candidate: ProvisionalRecallCandidate,
+    *,
+    consuming_authority: ConsumingAuthority,
+    active_scope_id: str,
+    use_right: RecallUseRight,
+    activation_reason: ActivationReason,
+    receipt_path: Path,
+    citation_reference: str | None = None,
+) -> ProvisionalGuardedRecall:
+    """Apply inbound admissibility and outbound authority clamps at consumption."""
+
+    record = candidate.record
+    inbound = evaluate_admissibility(
+        CandidateContext(
+            artifact_id=record.artifact_ref,
+            sphere=record.scope_id,
+            is_memory=True,
+            memory_class=record.memory_type,
+            trust_archetype=TrustArchetype.MACHINE_PROPOSED,
+            review_state=record.review_state,
+            inferred=True,
+            has_provenance=bool(record.provenance_event_ids),
+        ),
+        ConsumingContext(
+            capability_id="agent_memory.provisional_recall",
+            authority=consuming_authority,
+            scope=active_scope_id,
+        ),
+    )
+    outbound = evaluate_provisional_memory_authority(record, use_right=use_right)
+    required_tier = _required_tier(consuming_authority)
+    tier_sufficient = _tier_rank(inbound.admitted_tier) >= _tier_rank(required_tier)
+    citation_sufficient = (
+        consuming_authority is not ConsumingAuthority.PROPOSAL
+        or bool((citation_reference or "").strip())
+    )
+    use_right_sufficient = use_right is {
+        ConsumingAuthority.READ_ONLY: RecallUseRight.ACTIVATABLE,
+        ConsumingAuthority.PROPOSAL: RecallUseRight.CITED_PROPOSAL,
+        ConsumingAuthority.GOVERNED_EXECUTION: RecallUseRight.ACTION_AUTHORIZING,
+    }[consuming_authority]
+    admitted = (
+        inbound.admitted
+        and tier_sufficient
+        and citation_sufficient
+        and use_right_sufficient
+        and consuming_authority is not ConsumingAuthority.GOVERNED_EXECUTION
+        and outbound.allow_suggestion
+        and not outbound.allow_mutation
+    )
+    receipt_id = uuid4().hex
+    explanation = (
+        _build_explanation(
+            candidate,
+            use_right=use_right,
+            activation_reason=activation_reason,
+            receipt_id=receipt_id,
+            citation_reference=citation_reference,
+        )
+        if admitted
+        else None
+    )
+    _emit_recall_receipt(
+        receipt_path,
+        receipt_id=receipt_id,
+        record=record,
+        inbound=inbound,
+        outbound=outbound,
+        consuming_authority=consuming_authority,
+        use_right=use_right,
+        admitted=admitted,
+        citation_present=bool((citation_reference or "").strip()),
+    )
+    return ProvisionalGuardedRecall(
+        memory_id=str(record.memory_id),
+        admitted=admitted,
+        may_answer=admitted and consuming_authority is ConsumingAuthority.READ_ONLY,
+        may_propose=admitted and consuming_authority is ConsumingAuthority.PROPOSAL,
+        may_write=False,
+        admissibility_decision=inbound,
+        authority_decision=outbound,
+        explanation=explanation,
+        receipt_id=receipt_id,
+    )
+
+
+def _build_explanation(
+    candidate: ProvisionalRecallCandidate,
+    *,
+    use_right: RecallUseRight,
+    activation_reason: ActivationReason,
+    receipt_id: str,
+    citation_reference: str | None,
+) -> RecallExplanation:
+    record = candidate.record
+    refs = [record.artifact_ref, *(str(item) for item in record.provenance_event_ids)]
+    if citation_reference:
+        refs.append(citation_reference)
+    return RecallExplanation(
+        artifact_id=record.artifact_ref,
+        title=f"Provisional memory {record.memory_id}",
+        artifact_class="agentic_memory",
+        artifact_type="provisional_memory",
+        memory_type=record.memory_type.value,
+        use_right=use_right,
+        lifecycle_state=MemoryLifecycleState.PROVISIONAL,
+        review_state=record.review_state,
+        trust_state="provisional_low_trust_noncanonical",
+        activation_reason=activation_reason,
+        why_now=candidate.reason_code,
+        source_provenance=SourceProvenance(
+            source_refs=refs,
+            generated_by=record.created_by,
+        ),
+        authority_limits=[
+            "provisional_low_trust_noncanonical",
+            "memory_is_supporting_input_not_source_of_truth",
+            "explicit_citation_required_for_proposal",
+            "does_not_authorize_writeback",
+            "never_apply_or_tool_use",
+        ],
+        receipt_reference=receipt_id,
+    )
+
+
+def _emit_recall_receipt(
+    path: Path,
+    *,
+    receipt_id: str,
+    record: ProvisionalMemoryRecord,
+    inbound: AdmissibilityDecision,
+    outbound: MemoryAuthorityDecision,
+    consuming_authority: ConsumingAuthority,
+    use_right: RecallUseRight,
+    admitted: bool,
+    citation_present: bool,
+) -> None:
+    payload = {
+        "event": PROVISIONAL_RECALL_RECEIPT_EVENT,
+        "event_id": receipt_id,
+        "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "payload": {
+            "memory_id": str(record.memory_id),
+            "artifact_ref": record.artifact_ref,
+            "lifecycle_receipt_refs": [str(item) for item in record.lifecycle_receipt_refs],
+            "consuming_authority": consuming_authority.value,
+            "requested_use_right": use_right.value,
+            "admitted": admitted,
+            "admitted_tier": inbound.admitted_tier.value,
+            "admissibility_reason": inbound.reason,
+            "authority_blocked_reasons": list(outbound.blocked_reasons),
+            "citation_present": citation_present,
+            "may_write": False,
+        },
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    with lock_path.open("a+b") as lock_handle:
+        os.chmod(lock_path, 0o600)
+        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+        try:
+            with path.open("a", encoding="utf-8") as handle:
+                os.chmod(path, 0o600)
+                handle.write(encoded)
+                handle.flush()
+                os.fsync(handle.fileno())
+        finally:
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
+
+
+def _required_tier(authority: ConsumingAuthority) -> AdmissionTier:
+    return {
+        ConsumingAuthority.READ_ONLY: AdmissionTier.READ,
+        ConsumingAuthority.PROPOSAL: AdmissionTier.CITED_PROPOSAL,
+        ConsumingAuthority.GOVERNED_EXECUTION: AdmissionTier.ACTION,
+    }[authority]
+
+
+def _tier_rank(tier: AdmissionTier) -> int:
+    return {
+        AdmissionTier.NONE: 0,
+        AdmissionTier.READ: 1,
+        AdmissionTier.CITED_PROPOSAL: 2,
+        AdmissionTier.ACTION: 3,
+    }[tier]
+
+
+def _tokens(value: str) -> set[str]:
+    return {match.group(0).lower() for match in _TOKEN_RE.finditer(value)}
+
+
+def _score(record: ProvisionalMemoryRecord, query_tokens: set[str]) -> float:
+    content_tokens = _tokens(record.content)
+    overlap = query_tokens & content_tokens
+    return len(overlap) / max(1, len(query_tokens))
+
+
+__all__ = [
+    "PROVISIONAL_RECALL_RECEIPT_EVENT",
+    "ProvisionalGuardedRecall",
+    "ProvisionalRecallCandidate",
+    "ProvisionalRecallExclusion",
+    "ProvisionalRecallSearch",
+    "activate_provisional_recall",
+    "retrieve_relevant_provisional",
+]

--- a/app/agent_memory/provisional_write.py
+++ b/app/agent_memory/provisional_write.py
@@ -224,6 +224,14 @@ class ProvisionalReceiptStore:
             if receipt.memory_id == memory_id
         )
 
+    def list_all(self) -> tuple[ProvisionalLifecycleReceipt, ...]:
+        """Return the content-free ledger for deterministic read-side rebuilds."""
+        if not self.path.exists():
+            return ()
+        with _receipt_ledger_lock(self.path, shared=True):
+            raw = self.path.read_bytes()
+        return _receipts_from_ledger(raw)
+
 
 @contextmanager
 def _receipt_ledger_lock(path: Path, *, shared: bool) -> Iterator[None]:

--- a/app/agent_memory/recall_explanation.py
+++ b/app/agent_memory/recall_explanation.py
@@ -18,6 +18,7 @@ from app.agent_memory.promotion import PromotedMemory
 
 class RecallUseRight(str, Enum):
     ACTIVATABLE = "activatable"
+    CITED_PROPOSAL = "cited_proposal"
     INSTRUCTIONAL = "instructional"
     ACTION_AUTHORIZING = "action_authorizing"
 
@@ -32,6 +33,7 @@ class ActivationReason(str, Enum):
 
 class MemoryLifecycleState(str, Enum):
     PROMOTED = "promoted"
+    PROVISIONAL = "provisional"
     REVISED = "revised"
     REJECTED = "rejected"
 
@@ -51,6 +53,7 @@ class RecallExplanation(BaseModel):
     use_right: RecallUseRight
     lifecycle_state: MemoryLifecycleState
     review_state: ReviewState
+    trust_state: Optional[str] = None
     activation_reason: ActivationReason
     why_now: str
     bundle_reference: Optional[str] = None

--- a/app/agents/ask/graph.py
+++ b/app/agents/ask/graph.py
@@ -20,6 +20,12 @@ from app.agent_memory.recall_explanation import (
     render_recall_footer,
 )
 from app.agent_memory.recall_retrieval import RecallCandidate, retrieve_relevant_promoted
+from app.agent_memory.provisional_recall import (
+    activate_provisional_recall,
+    retrieve_relevant_provisional,
+)
+from app.agent_memory.provisional_write import ProvisionalReceiptStore
+from app.activation.gate import ConsumingAuthority
 from app.agent_memory.ask_provenance_manifest import (
     AuthorizationSnapshot,
     schedule_ask_provenance_capture,
@@ -38,6 +44,9 @@ logger = logging.getLogger(__name__)
 TOP_K_INITIAL = 40
 RECALL_TOP_K = 3
 DEFAULT_RECALL_RECEIPTS_PATH = Path("runtime/agent_memory/recall_receipts.jsonl")
+DEFAULT_PROVISIONAL_RECALL_RECEIPTS_PATH = Path(
+    "runtime/agent_memory/provisional_recall_receipts.jsonl"
+)
 _ASK_LAST_ACTIVE_LOADED_ATTR = "_ask_recall_last_active_loaded"
 
 
@@ -119,6 +128,13 @@ def _recall_receipt_path() -> Path:
     return DEFAULT_RECALL_RECEIPTS_PATH
 
 
+def _provisional_recall_receipt_path() -> Path:
+    configured = os.getenv("PROVISIONAL_RECALL_RECEIPTS_PATH")
+    if configured:
+        return Path(configured).expanduser()
+    return DEFAULT_PROVISIONAL_RECALL_RECEIPTS_PATH
+
+
 def _active_recall_vault_root() -> Path | None:
     manager = get_vault_manager()
     context = manager.context
@@ -158,12 +174,27 @@ def _source_artifact_path(candidate: RecallCandidate, vault_root: Path | None) -
 def _recall_node(state: AgentState, *, ask_settings) -> AgentState:
     vault_root = _active_recall_vault_root()
     candidates = retrieve_relevant_promoted(state.query, k=RECALL_TOP_K, vault_root=vault_root)
-    if not candidates:
+    active_scope = _resolve_domain_scope()
+    provisional = (
+        retrieve_relevant_provisional(
+            state.query,
+            k=RECALL_TOP_K,
+            vault_root=vault_root,
+            receipt_store=ProvisionalReceiptStore(),
+            active_scope_id=active_scope,
+        )
+        if vault_root is not None and active_scope is not None
+        else None
+    )
+    if not candidates and (provisional is None or not provisional.candidates):
         state.recalled = []
+        state.recalled_content = {}
+        state.recalled_context_items = []
         return state
 
     recalled = []
     recalled_content: dict[str, str] = {}
+    recalled_context_items: list[dict[str, Any]] = []
     reasoning = list(state.reasoning or [])
     receipt_path = _recall_receipt_path()
     for candidate in candidates:
@@ -184,8 +215,48 @@ def _recall_node(state: AgentState, *, ask_settings) -> AgentState:
                 f"recall:{guarded.memory_id}:{guarded.explanation.title}:{candidate.reason}"
             )
 
+    for candidate in provisional.candidates if provisional is not None else ():
+        guarded = activate_provisional_recall(
+            candidate,
+            consuming_authority=ConsumingAuthority.READ_ONLY,
+            active_scope_id=active_scope or "",
+            use_right=RecallUseRight.ACTIVATABLE,
+            activation_reason=ActivationReason.CONTEXTUAL_RELEVANCE,
+            receipt_path=_provisional_recall_receipt_path(),
+        )
+        if guarded.may_answer and guarded.explanation is not None:
+            recalled.append(guarded.explanation)
+            recalled_content[guarded.explanation.artifact_id] = candidate.record.content
+            reasoning.append(
+                f"provisional_recall:{guarded.memory_id}:{candidate.reason_code}"
+            )
+            record = candidate.record
+            recalled_context_items.append(
+                {
+                    "id": record.artifact_ref,
+                    "doc_id": record.artifact_ref,
+                    "_admitted_provisional_memory": True,
+                    "payload": {
+                        "uuid": record.artifact_ref,
+                        "object_type": "memory_item",
+                        "scope_id": record.scope_id,
+                        "principal_id": record.principal_id,
+                        "source_role": record.source_role,
+                        "authority_state": record.authority_state,
+                        "evidence_role": record.evidence_role.value,
+                        "sensitivity": record.sensitivity.value,
+                        "created_by": record.created_by,
+                        "created_at": record.created_at.isoformat(),
+                        "provenance_event_ids": list(record.provenance_event_ids),
+                        "memory_state": record.review_state.value,
+                    },
+                    "evidence_role_in_context": record.evidence_role.value,
+                }
+            )
+
     state.recalled = recalled
     state.recalled_content = recalled_content
+    state.recalled_context_items = recalled_context_items
     if reasoning:
         state.reasoning = reasoning
     return state
@@ -237,6 +308,7 @@ def _hits_as_scoped_retrieval(state: AgentState) -> ScopedRetrieval:
                 "evidence_role_in_context": hit.evidence_role_in_context,
             }
         )
+    results.extend(dict(item) for item in (state.recalled_context_items or []))
     # Rehydrate the content-free denials captured at retrieval time (state carries them as plain
     # dicts). They are scope-level: hit reranking/truncation between retrieve and here must not —
     # and does not — affect them.
@@ -379,7 +451,9 @@ def _answer_node(state: AgentState, *, ask_settings) -> AgentState:
     # gate seam so the deterministic admissibility decision is unchanged.
     envelope = build_ask_envelope(state)
     source_ids = _envelope_source_ids(envelope)
-    source_ids.extend(r.artifact_id for r in (state.recalled or []) if r.artifact_id)
+    for recalled in state.recalled or []:
+        if recalled.artifact_id and recalled.artifact_id not in source_ids:
+            source_ids.append(recalled.artifact_id)
     decision = evaluate_ask_synthesis(source_ids)
     if decision.activatable:
         context = build_ask_context(

--- a/app/agents/ask/graph.py
+++ b/app/agents/ask/graph.py
@@ -196,11 +196,17 @@ def _recall_node(
         state.recalled = []
         state.recalled_content = {}
         state.recalled_context_items = []
+        state.proposal_recalled = []
+        state.proposal_recalled_content = {}
+        state.proposal_context_items = []
         return state
 
     recalled = []
     recalled_content: dict[str, str] = {}
     recalled_context_items: list[dict[str, Any]] = []
+    proposal_recalled = []
+    proposal_recalled_content: dict[str, str] = {}
+    proposal_context_items: list[dict[str, Any]] = []
     reasoning = list(state.reasoning or [])
     receipt_path = _recall_receipt_path()
     for candidate in candidates:
@@ -236,39 +242,49 @@ def _recall_node(
             receipt_path=_provisional_recall_receipt_path(),
             citation_reference=citation_reference,
         )
-        if (guarded.may_answer or guarded.may_propose) and guarded.explanation is not None:
-            recalled.append(guarded.explanation)
-            recalled_content[guarded.explanation.artifact_id] = candidate.record.content
-            reasoning.append(
-                f"provisional_recall:{guarded.memory_id}:{candidate.reason_code}"
-            )
+        if guarded.explanation is not None and (guarded.may_answer or guarded.may_propose):
             record = candidate.record
-            recalled_context_items.append(
-                {
-                    "id": record.artifact_ref,
-                    "doc_id": record.artifact_ref,
-                    "_admitted_provisional_memory": True,
-                    "payload": {
-                        "uuid": record.artifact_ref,
-                        "object_type": "memory_item",
-                        "scope_id": record.scope_id,
-                        "principal_id": record.principal_id,
-                        "source_role": record.source_role,
-                        "authority_state": record.authority_state,
-                        "evidence_role": record.evidence_role.value,
-                        "sensitivity": record.sensitivity.value,
-                        "created_by": record.created_by,
-                        "created_at": record.created_at.isoformat(),
-                        "provenance_event_ids": list(record.provenance_event_ids),
-                        "memory_state": record.review_state.value,
-                    },
-                    "evidence_role_in_context": record.evidence_role.value,
-                }
-            )
+            context_item = {
+                "id": record.artifact_ref,
+                "doc_id": record.artifact_ref,
+                "_admitted_provisional_memory": True,
+                "payload": {
+                    "uuid": record.artifact_ref,
+                    "object_type": "memory_item",
+                    "scope_id": record.scope_id,
+                    "principal_id": record.principal_id,
+                    "source_role": record.source_role,
+                    "authority_state": record.authority_state,
+                    "evidence_role": record.evidence_role.value,
+                    "sensitivity": record.sensitivity.value,
+                    "created_by": record.created_by,
+                    "created_at": record.created_at.isoformat(),
+                    "provenance_event_ids": list(record.provenance_event_ids),
+                    "memory_state": record.review_state.value,
+                },
+                "evidence_role_in_context": record.evidence_role.value,
+            }
+            if guarded.may_answer:
+                recalled.append(guarded.explanation)
+                recalled_content[guarded.explanation.artifact_id] = record.content
+                recalled_context_items.append(context_item)
+                reasoning.append(
+                    f"provisional_recall:{guarded.memory_id}:{candidate.reason_code}"
+                )
+            elif guarded.may_propose:
+                proposal_recalled.append(guarded.explanation)
+                proposal_recalled_content[guarded.explanation.artifact_id] = record.content
+                proposal_context_items.append(context_item)
+                reasoning.append(
+                    f"provisional_proposal_recall:{guarded.memory_id}:{candidate.reason_code}"
+                )
 
     state.recalled = recalled
     state.recalled_content = recalled_content
     state.recalled_context_items = recalled_context_items
+    state.proposal_recalled = proposal_recalled
+    state.proposal_recalled_content = proposal_recalled_content
+    state.proposal_context_items = proposal_context_items
     if reasoning:
         state.reasoning = reasoning
     return state

--- a/app/agents/ask/graph.py
+++ b/app/agents/ask/graph.py
@@ -171,7 +171,13 @@ def _source_artifact_path(candidate: RecallCandidate, vault_root: Path | None) -
     return vault_root / candidate.artifact_path
 
 
-def _recall_node(state: AgentState, *, ask_settings) -> AgentState:
+def _recall_node(
+    state: AgentState,
+    *,
+    ask_settings,
+    consuming_authority: ConsumingAuthority = ConsumingAuthority.READ_ONLY,
+    citation_reference: str | None = None,
+) -> AgentState:
     vault_root = _active_recall_vault_root()
     candidates = retrieve_relevant_promoted(state.query, k=RECALL_TOP_K, vault_root=vault_root)
     active_scope = _resolve_domain_scope()
@@ -216,13 +222,19 @@ def _recall_node(state: AgentState, *, ask_settings) -> AgentState:
             )
 
     for candidate in provisional.candidates if provisional is not None else ():
+        use_right = {
+            ConsumingAuthority.READ_ONLY: RecallUseRight.ACTIVATABLE,
+            ConsumingAuthority.PROPOSAL: RecallUseRight.CITED_PROPOSAL,
+            ConsumingAuthority.GOVERNED_EXECUTION: RecallUseRight.ACTION_AUTHORIZING,
+        }[consuming_authority]
         guarded = activate_provisional_recall(
             candidate,
-            consuming_authority=ConsumingAuthority.READ_ONLY,
+            consuming_authority=consuming_authority,
             active_scope_id=active_scope or "",
-            use_right=RecallUseRight.ACTIVATABLE,
+            use_right=use_right,
             activation_reason=ActivationReason.CONTEXTUAL_RELEVANCE,
             receipt_path=_provisional_recall_receipt_path(),
+            citation_reference=citation_reference,
         )
         if guarded.may_answer and guarded.explanation is not None:
             recalled.append(guarded.explanation)

--- a/app/agents/ask/graph.py
+++ b/app/agents/ask/graph.py
@@ -236,7 +236,7 @@ def _recall_node(
             receipt_path=_provisional_recall_receipt_path(),
             citation_reference=citation_reference,
         )
-        if guarded.may_answer and guarded.explanation is not None:
+        if (guarded.may_answer or guarded.may_propose) and guarded.explanation is not None:
             recalled.append(guarded.explanation)
             recalled_content[guarded.explanation.artifact_id] = candidate.record.content
             reasoning.append(

--- a/app/agents/ask/state.py
+++ b/app/agents/ask/state.py
@@ -46,6 +46,10 @@ class AgentState(RuntimeStateModel):
     # Recalled memory bodies keyed by artifact/memory id. Supporting input only,
     # used to compose a recall-only answer when retrieval returns no hits.
     recalled_content: dict[str, str] = Field(default_factory=dict)
+    # Content-free metadata projections for admitted provisional memory. These
+    # are composed into the bounded ContextEnvelope; claim text remains only in
+    # ``recalled_content`` for the already-admitted synthesis context.
+    recalled_context_items: List[dict[str, Any]] = Field(default_factory=list)
     answer: Optional[str] = None
     reasoning: Optional[List[str]] = None
     llm_route: dict[str, Any] | None = None

--- a/app/agents/ask/state.py
+++ b/app/agents/ask/state.py
@@ -50,6 +50,13 @@ class AgentState(RuntimeStateModel):
     # are composed into the bounded ContextEnvelope; claim text remains only in
     # ``recalled_content`` for the already-admitted synthesis context.
     recalled_context_items: List[dict[str, Any]] = Field(default_factory=list)
+    # Proposal-only provisional memory is deliberately separated from answer
+    # recall state. ASK answer fallback, synthesis, and envelope assembly must
+    # never consume these fields; a governed proposal consumer must opt in to
+    # them with the citation-bound authority decision already attached.
+    proposal_recalled: List[RecallExplanation] = Field(default_factory=list)
+    proposal_recalled_content: dict[str, str] = Field(default_factory=dict)
+    proposal_context_items: List[dict[str, Any]] = Field(default_factory=list)
     answer: Optional[str] = None
     reasoning: Optional[List[str]] = None
     llm_route: dict[str, Any] | None = None

--- a/app/agents/ask/utils.py
+++ b/app/agents/ask/utils.py
@@ -86,6 +86,18 @@ def build_ask_context(
     for idx, explanation in enumerate(recalled or [], start=1):
         parts.append(f"[RECALLED MEMORY {idx}] title=\"{explanation.title}\"")
         parts.append(f"why_now={explanation.why_now}")
+        trust_state = getattr(explanation, "trust_state", None) or "unspecified"
+        review_state = getattr(explanation, "review_state", None)
+        review_value = getattr(review_state, "value", review_state) or "unspecified"
+        source_provenance = getattr(explanation, "source_provenance", None)
+        source_refs = getattr(source_provenance, "source_refs", ())
+        parts.append(f"trust_state={trust_state}")
+        parts.append(f"review_state={review_value}")
+        if source_refs:
+            parts.append(
+                "provenance_refs="
+                + ", ".join(source_refs)
+            )
         parts.append("authority_limits=" + ", ".join(explanation.authority_limits))
         # Ground synthesis in the recalled fact itself, not just its metadata.
         # In the recall-only path (no retrieval hits) the body is the only

--- a/app/retrieval/envelope.py
+++ b/app/retrieval/envelope.py
@@ -47,6 +47,10 @@ _DEFAULT_AUTHORITY_STATE = "projection"
 _DEFAULT_SENSITIVITY = "internal"
 _DEFAULT_CREATED_BY = "app:retrieval"
 _DEFAULT_CREATED_AT = "2026-01-01T00:00:00+00:00"
+_MEMORY_STATE_ENUM = frozenset({
+    "unreviewed", "reviewed", "corrected", "decayed", "forgotten", "active",
+    "invalidated", "purged_stub",
+})
 
 # Only enum members are accepted from payload; anything else falls back to the conservative default
 # (never fail the envelope on a dirty payload, but never smuggle an out-of-enum value either).
@@ -106,11 +110,21 @@ def _bundle_from_result(item: dict[str, Any]) -> dict[str, Any]:
     # must carry provenance lineage (schema: derived object types require derived_from). The row's
     # object_id is the source it is derived from. object_id stays the doc id so the consumer keys the
     # admitted set on the same identity the retrieval surfaced.
+    admitted_provisional = item.get("_admitted_provisional_memory") is True
+    object_type = "memory_item" if admitted_provisional else _DEFAULT_OBJECT_TYPE
+    raw_provenance = payload.get("provenance_event_ids")
+    provenance_event_ids = (
+        list(raw_provenance)
+        if admitted_provisional
+        and isinstance(raw_provenance, (list, tuple))
+        and raw_provenance
+        and all(isinstance(item, str) and item for item in raw_provenance)
+        else [f"prov:retrieval:{object_id or uuid4().hex[:12]}"]
+    )
     bundle: dict[str, Any] = {
         "object_id": object_id,
-        "object_type": _DEFAULT_OBJECT_TYPE,
+        "object_type": object_type,
         "scope_id": scope_id or "scope:unscoped",
-        "derived_from": [object_id],
         "source_role": _enum_or_default(
             payload.get("source_role"), _SOURCE_ROLE_ENUM, _DEFAULT_SOURCE_ROLE
         ),
@@ -124,13 +138,21 @@ def _bundle_from_result(item: dict[str, Any]) -> dict[str, Any]:
         "suppression_state": "visible",
         "created_by": str(payload.get("created_by") or _DEFAULT_CREATED_BY),
         "created_at": str(payload.get("created_at") or _DEFAULT_CREATED_AT),
-        "provenance_event_ids": [f"prov:retrieval:{object_id or uuid4().hex[:12]}"],
+        "provenance_event_ids": provenance_event_ids,
         # Propagate the payload's episode binding (derivation survival — mirrors
         # mimer_runtime.dri.derive_segment); a payload without one (all live rows today, until
         # ERE-05 assignment lands) gets the honest 'unbound' default
         # (docs/architecture/semantic-dimensions.md :: episode_ref).
         "episode_ref": _episode_ref_from_payload(payload.get("episode_ref")),
     }
+    if not admitted_provisional:
+        bundle["derived_from"] = [object_id]
+    principal_id = payload.get("principal_id")
+    if admitted_provisional and isinstance(principal_id, str) and principal_id:
+        bundle["principal_id"] = principal_id
+    memory_state = payload.get("memory_state")
+    if admitted_provisional and memory_state in _MEMORY_STATE_ENUM:
+        bundle["memory_state"] = memory_state
     sphere = payload.get("sphere") or payload.get("domain")
     if isinstance(sphere, str) and sphere.strip():
         bundle["sphere"] = sphere.strip()

--- a/docs/CONCEPTS/AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT.md
+++ b/docs/CONCEPTS/AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT.md
@@ -1,5 +1,5 @@
 State: Concept contract companion (agent memory and knowledge; human-authored truth remains primary).
-Changed: 2026-06-13 — Durable Memory and Recall shipped review-decision receipts, queue reconciliation, governed semantic-memory materialization, guarded recall receipts, and Companion provenance surfacing. `may_write=false` remains the default for recalled memory unless a future governed owner contract changes it.
+Changed: 2026-07-15 — Guarded recall now admits complete same-scope provisional memory only as visible low-trust read or explicitly cited proposal support; it remains permanently `may_write=false`. Durable Memory and Recall continues to ship review-decision receipts, queue reconciliation, governed semantic-memory materialization, guarded recall receipts, and Companion provenance surfacing.
 Changed: 2026-06-12 — `docs/AGENT-FLOWS.md` explicitly declines the `may_write` widening slot reserved below for Mimer-mediated agent memory; `may_write=false` remains universal unless a future governed owner contract changes it. Human-declared direct filesystem write zones (see `docs/AGENT-FLOWS.md` §7) are a separate human-delegated access mode, not a `may_write` widening and not agent memory.
 
 # Agent Memory and Knowledge Contract
@@ -420,6 +420,9 @@ Current runtime now ships the Durable Memory and Recall subset:
   actionable;
 - guarded recall invokes the memory authority guard, emits a recall receipt, and does not persist
   activation state as artifact authority;
+- complete same-scope provisional records enter ASK only through the inbound admissibility and
+  outbound authority guards, surface low-trust/review/provenance posture in the bounded context,
+  require an explicit citation for proposal use, and remain permanently `may_write=false`;
 - Companion surfaces materialized-memory provenance, recall provenance, and authority posture.
 
 This shipped subset does not introduce a vector-store choice, context-bundle persistence,

--- a/docs/PROVISIONAL_MEMORY/ADMIT_PROVISIONAL_MEMORY_AS_LOW_TRUST_CONTEXT.md
+++ b/docs/PROVISIONAL_MEMORY/ADMIT_PROVISIONAL_MEMORY_AS_LOW_TRUST_CONTEXT.md
@@ -39,15 +39,15 @@ prevent a new recall caller from bypassing the ceiling.
 
 ## Acceptance Criteria
 
-- [ ] The production recall path invokes admissibility and authority guards for provisional memory.
+- [x] The production recall path invokes admissibility and authority guards for provisional memory.
   Verify: `tests/agent_memory/test_provisional_memory_call_sites.py::test_recall_path_invokes_low_trust_guards`
-- [ ] Read use preserves visible provenance/review posture and `may_write=false`.
+- [x] Read use preserves visible provenance/review posture and `may_write=false`.
   Verify: `tests/agent_memory/test_provisional_memory_recall.py::test_read_context_preserves_low_trust_posture`
-- [ ] Proposal influence requires an explicit citation; uncited background influence is excluded.
+- [x] Proposal influence requires an explicit citation; uncited background influence is excluded.
   Verify: `tests/agent_memory/test_provisional_memory_recall.py::test_proposal_use_requires_explicit_citation`
-- [ ] Provisional memory cannot reach APPLY/tool-use or an action-authorizing context even when
+- [x] Provisional memory cannot reach APPLY/tool-use or an action-authorizing context even when
   repeated or highly ranked. Verify: `tests/agent_memory/test_provisional_memory_call_sites.py::test_provisional_memory_cannot_reach_action_authority`
-- [ ] Activation produces a recall receipt and does not mutate the artifact or lifecycle authority.
+- [x] Activation produces a recall receipt and does not mutate the artifact or lifecycle authority.
   Verify: `tests/agent_memory/test_provisional_memory_recall.py::test_recall_receipt_does_not_persist_activation_authority`
 
 ## How to Verify (Pre-Merge)
@@ -79,5 +79,5 @@ The action-tier assertion must exercise the real consumer entry point.
 
 ## Related GitHub Issues
 
-Filed as #3720, blocked by #3719. TCD hint: Sol/high due to retrieval/context authority and production
-consumer enforcement.
+Implemented under #3720 after #3719 delivered the governed producer. TCD hint: Sol/high due to
+retrieval/context authority and production consumer enforcement.

--- a/docs/PROVISIONAL_MEMORY/README.md
+++ b/docs/PROVISIONAL_MEMORY/README.md
@@ -116,10 +116,10 @@ replace deterministic call-site proof.
 
 Parent validation hub: #2314. Strictly validated task Issues:
 
-1. #3718 — PROVISIONAL-MEMORY-01 (`agent:ready`)
-2. #3719 — PROVISIONAL-MEMORY-02 (`agent:blocked` by #3718)
-3. #3720 — PROVISIONAL-MEMORY-03 (`agent:blocked` by #3719)
-4. #3721 — PROVISIONAL-MEMORY-04 (`agent:blocked` by #3719/#3720)
+1. #3718 — PROVISIONAL-MEMORY-01 (delivered)
+2. #3719 — PROVISIONAL-MEMORY-02 (delivered)
+3. #3720 — PROVISIONAL-MEMORY-03 (implemented; delivery governed by #3720)
+4. #3721 — PROVISIONAL-MEMORY-04 (blocked by #3720 until its merge receipt)
 
 No task may claim #2314 itself. After each merge, the coordinator updates the validation ledger on
 #2314 and recalculates which single dependent Issue can truthfully become ready.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -5,8 +5,8 @@ Owner: Runtime / current-state SoT
 Temporal class: operational
 Review cadence: weekly
 Source of truth: mixed
-Last reviewed: 2026-07-08
-Last verified against: docs/ARCHITECTURE.md, docs/ROADMAP.md, docs/DOCS_INDEX.md, docs/OPERATIONS.md, docs/HUMAN-FLOWS.md, docs/CONTEXTUAL_RELEVANCE_ENGINE/README.md, docs/CONCEPTS/MOMENT_ARTIFACT_CONTRACT.md, docs/CONCEPTS/RELEVANCE_EVALUATOR_CONTRACT.md, docs/CONCEPTS/REACHOUT_AND_SCARCITY_GATE_CONTRACT.md, docs/plans/CONTEXTUAL_RELEVANCE_ENGINE.md, app/relevance/evaluator.py, app/relevance/materialization.py, app/relevance/attention_loop.py, app/relevance/now_surface.py, companion-ui/companion-app/companion_ui/workspace/now_surface.py, tests/relevance/test_vault_native_moments.py, tests/relevance/test_attention_loop_runtime.py, merged PRs #1948/#1977/#2092/#2097/#2098/#2115/#2119/#2127/#2128/#2129/#2131/#2133/#2135/#2137/#2140/#2142/#2636/#2642/#2643/#2645/#2656/#2678/#2686/#2689/#2692, and current repo state at 8e19a275 on 2026-07-08
+Last reviewed: 2026-07-15
+Last verified against: docs/ARCHITECTURE.md, docs/ROADMAP.md, docs/DOCS_INDEX.md, docs/OPERATIONS.md, docs/HUMAN-FLOWS.md, docs/CONTEXTUAL_RELEVANCE_ENGINE/README.md, docs/CONCEPTS/MOMENT_ARTIFACT_CONTRACT.md, docs/CONCEPTS/RELEVANCE_EVALUATOR_CONTRACT.md, docs/CONCEPTS/REACHOUT_AND_SCARCITY_GATE_CONTRACT.md, docs/CONCEPTS/AGENT_MEMORY_AND_KNOWLEDGE_CONTRACT.md, docs/plans/CONTEXTUAL_RELEVANCE_ENGINE.md, app/agent_memory/provisional_recall.py, app/agents/ask/graph.py, app/relevance/evaluator.py, app/relevance/materialization.py, app/relevance/attention_loop.py, app/relevance/now_surface.py, companion-ui/companion-app/companion_ui/workspace/now_surface.py, tests/agent_memory/test_provisional_memory_recall.py, tests/agent_memory/test_provisional_memory_call_sites.py, tests/relevance/test_vault_native_moments.py, tests/relevance/test_attention_loop_runtime.py, merged PRs #1948/#1977/#2092/#2097/#2098/#2115/#2119/#2127/#2128/#2129/#2131/#2133/#2135/#2137/#2140/#2142/#2636/#2642/#2643/#2645/#2656/#2678/#2686/#2689/#2692/#3730, issue #3720, PR #3743, and current repo state on 2026-07-15
 
 Status snapshot now includes SoT baseline + release-line fields and intent/event counters (`promote.intent.created`, `panel.intent.executed`, `watcher.run`, ingest runs by plane). Code still exposes `sot_forward_line_version` / `feature_line_version` as the v5.6 release-line marker, but GitHub issue truth treats v5.6 as delivered rather than active. `watcher_runs` now counts watcher audit events from the registry watcher as well as the legacy snapshot watcher, while runtime health still relies on heartbeat + tick logs.
 
@@ -252,6 +252,13 @@ High-level design rules for this direction now live in `docs/DESIGN_PRINCIPLES.m
   memory with a "Recalled from: … · receipt &lt;id&gt;" footer keyed to the recall receipt (treatment A,
   #1972) plus a structured `recalled` provenance field on the response; no attribution is shown when
   recall did not fire.
+- Provisional-memory recall now has a bounded production ASK seam (#3720): complete same-scope
+  provisional Vault records may enter a read-only answer only after both inbound admissibility and
+  outbound authority checks pass. The resulting context remains visibly provisional, low-trust,
+  non-canonical, provenance-bearing, and usable only as read support or explicitly cited proposal
+  support. It cannot become action-authorizing, set `may_write`, trigger APPLY, or mutate canonical
+  Vault Markdown; malformed artifact identities and governed-execution attempts fail closed with
+  content-free exclusion/recall receipts.
 - Runtime AgentState contract unification is shipped for the current ASK, generic graph, reasoning
   graph-builder, and PanelAgent state surfaces: `app/agents/runtime_state.py` defines the shared
   trace/authority/proposal/receipt linkage fields and the existing state classes now expose or adapt

--- a/tests/agent_memory/test_provisional_memory_call_sites.py
+++ b/tests/agent_memory/test_provisional_memory_call_sites.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import json
 from pathlib import Path
 from uuid import UUID
 
@@ -20,7 +21,6 @@ from app.agent_memory.provisional_write import (
     load_provisional_markdown,
     render_provisional_markdown,
 )
-from app.agent_memory.recall_explanation import ActivationReason, RecallUseRight
 from app.write_guard import WriteGuard
 
 
@@ -282,23 +282,48 @@ def test_recall_path_invokes_low_trust_guards(
     assert provisional_bundle["provenance_event_ids"] == ["event-guard"]
 
 
-def test_provisional_memory_cannot_reach_action_authority(tmp_path: Path) -> None:
-    from app.agent_memory.provisional_recall import activate_provisional_recall
+def test_provisional_memory_cannot_reach_action_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.agent_memory import provisional_recall
+    from app.agents.ask import graph as ask_graph
+    from app.agents.ask.state import AgentState
 
-    result = activate_provisional_recall(
-        _recall_candidate(tmp_path),
-        consuming_authority=ConsumingAuthority.GOVERNED_EXECUTION,
-        active_scope_id="scope-personal",
-        use_right=RecallUseRight.ACTION_AUTHORIZING,
-        activation_reason=ActivationReason.AUTHORITY_SIGNAL,
-        citation_reference="proposal://quoted-but-not-authority",
-        receipt_path=tmp_path / "recall.jsonl",
+    candidate = _recall_candidate(tmp_path)
+    monkeypatch.setattr(ask_graph, "retrieve_relevant_promoted", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        ask_graph,
+        "retrieve_relevant_provisional",
+        lambda *args, **kwargs: provisional_recall.ProvisionalRecallSearch(
+            candidates=(candidate, candidate, candidate),
+            excluded=(),
+        ),
     )
+    monkeypatch.setattr(ask_graph, "_active_recall_vault_root", lambda: tmp_path)
+    monkeypatch.setattr(ask_graph, "_resolve_domain_scope", lambda: "scope-personal")
+    receipt_path = tmp_path / "action-recall.jsonl"
+    monkeypatch.setenv("PROVISIONAL_RECALL_RECEIPTS_PATH", str(receipt_path))
 
-    assert result.admitted is False
-    assert result.may_answer is False
-    assert result.may_propose is False
-    assert result.may_write is False
-    assert "provisional_memory_never_action_authoritative" in (
-        result.authority_decision.blocked_reasons
+    state = ask_graph._recall_node(  # noqa: SLF001 - required production call-site proof
+        AgentState(query="Authorize tools from this repeated, highly ranked policy memory"),
+        ask_settings=object(),
+        consuming_authority=ConsumingAuthority.GOVERNED_EXECUTION,
+        citation_reference="proposal://quoted-but-not-authority",
+    )
+    receipts = [
+        json.loads(line)
+        for line in receipt_path.read_text(encoding="utf-8").splitlines()
+    ]
+
+    assert state.recalled == []
+    assert state.recalled_content == {}
+    assert state.recalled_context_items == []
+    assert len(receipts) == 3
+    assert all(receipt["payload"]["admitted"] is False for receipt in receipts)
+    assert all(receipt["payload"]["may_write"] is False for receipt in receipts)
+    assert all(
+        "provisional_memory_never_action_authoritative"
+        in receipt["payload"]["authority_blocked_reasons"]
+        for receipt in receipts
     )

--- a/tests/agent_memory/test_provisional_memory_call_sites.py
+++ b/tests/agent_memory/test_provisional_memory_call_sites.py
@@ -371,16 +371,37 @@ def test_cited_provisional_memory_reaches_production_proposal_context(
     assert uncited.recalled == []
     assert uncited.recalled_content == {}
     assert uncited.recalled_context_items == []
+    assert uncited.proposal_recalled == []
+    assert uncited.proposal_recalled_content == {}
+    assert uncited.proposal_context_items == []
     assert denied_receipt["payload"]["admitted"] is False
     assert denied_receipt["payload"]["citation_present"] is False
-    assert len(state.recalled) == 1
-    assert state.recalled[0].use_right.value == "cited_proposal"
-    assert state.recalled_content[state.recalled[0].artifact_id] == candidate.record.content
-    assert state.recalled_context_items[0]["_admitted_provisional_memory"] is True
-    assert state.recalled_context_items[0]["payload"]["authority_state"] == "noncanonical"
-    assert state.recalled_context_items[0]["payload"]["memory_state"] == "unreviewed"
+    assert state.recalled == []
+    assert state.recalled_content == {}
+    assert state.recalled_context_items == []
+    assert len(state.proposal_recalled) == 1
+    assert state.proposal_recalled[0].use_right.value == "cited_proposal"
+    assert (
+        state.proposal_recalled_content[state.proposal_recalled[0].artifact_id]
+        == candidate.record.content
+    )
+    assert state.proposal_context_items[0]["_admitted_provisional_memory"] is True
+    assert state.proposal_context_items[0]["payload"]["authority_state"] == "noncanonical"
+    assert state.proposal_context_items[0]["payload"]["memory_state"] == "unreviewed"
     assert receipt["payload"]["admitted"] is True
     assert receipt["payload"]["consuming_authority"] == "proposal"
     assert receipt["payload"]["requested_use_right"] == "cited_proposal"
     assert receipt["payload"]["citation_present"] is True
     assert receipt["payload"]["may_write"] is False
+
+    monkeypatch.setattr(
+        ask_graph,
+        "llm_answer",
+        lambda *args, **kwargs: pytest.fail("proposal-only memory reached ASK synthesis"),
+    )
+    answered = ask_graph._answer_node(  # noqa: SLF001 - authority transition proof
+        state,
+        ask_settings=object(),
+    )
+    assert answered.answer == "No results found."
+    assert candidate.record.content not in answered.answer

--- a/tests/agent_memory/test_provisional_memory_call_sites.py
+++ b/tests/agent_memory/test_provisional_memory_call_sites.py
@@ -327,3 +327,60 @@ def test_provisional_memory_cannot_reach_action_authority(
         in receipt["payload"]["authority_blocked_reasons"]
         for receipt in receipts
     )
+
+
+def test_cited_provisional_memory_reaches_production_proposal_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.agent_memory import provisional_recall
+    from app.agents.ask import graph as ask_graph
+    from app.agents.ask.state import AgentState
+
+    candidate = _recall_candidate(tmp_path)
+    monkeypatch.setattr(ask_graph, "retrieve_relevant_promoted", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        ask_graph,
+        "retrieve_relevant_provisional",
+        lambda *args, **kwargs: provisional_recall.ProvisionalRecallSearch(
+            candidates=(candidate,),
+            excluded=(),
+        ),
+    )
+    monkeypatch.setattr(ask_graph, "_active_recall_vault_root", lambda: tmp_path)
+    monkeypatch.setattr(ask_graph, "_resolve_domain_scope", lambda: "scope-personal")
+    receipt_path = tmp_path / "proposal-recall.jsonl"
+    monkeypatch.setenv("PROVISIONAL_RECALL_RECEIPTS_PATH", str(receipt_path))
+
+    uncited = ask_graph._recall_node(  # noqa: SLF001 - required production call-site proof
+        AgentState(query="Draft a proposal using this memory without a citation"),
+        ask_settings=object(),
+        consuming_authority=ConsumingAuthority.PROPOSAL,
+    )
+    state = ask_graph._recall_node(  # noqa: SLF001 - required production call-site proof
+        AgentState(query="Draft a proposal using this cited memory"),
+        ask_settings=object(),
+        consuming_authority=ConsumingAuthority.PROPOSAL,
+        citation_reference="proposal://draft-1#citation-1",
+    )
+    denied_receipt, receipt = [
+        json.loads(line)
+        for line in receipt_path.read_text(encoding="utf-8").splitlines()
+    ]
+
+    assert uncited.recalled == []
+    assert uncited.recalled_content == {}
+    assert uncited.recalled_context_items == []
+    assert denied_receipt["payload"]["admitted"] is False
+    assert denied_receipt["payload"]["citation_present"] is False
+    assert len(state.recalled) == 1
+    assert state.recalled[0].use_right.value == "cited_proposal"
+    assert state.recalled_content[state.recalled[0].artifact_id] == candidate.record.content
+    assert state.recalled_context_items[0]["_admitted_provisional_memory"] is True
+    assert state.recalled_context_items[0]["payload"]["authority_state"] == "noncanonical"
+    assert state.recalled_context_items[0]["payload"]["memory_state"] == "unreviewed"
+    assert receipt["payload"]["admitted"] is True
+    assert receipt["payload"]["consuming_authority"] == "proposal"
+    assert receipt["payload"]["requested_use_right"] == "cited_proposal"
+    assert receipt["payload"]["citation_present"] is True
+    assert receipt["payload"]["may_write"] is False

--- a/tests/agent_memory/test_provisional_memory_call_sites.py
+++ b/tests/agent_memory/test_provisional_memory_call_sites.py
@@ -7,6 +7,7 @@ from uuid import UUID
 import pytest
 import yaml
 
+from app.activation.gate import ConsumingAuthority
 from app.agent_memory.candidate import MemoryType
 from app.agent_memory.provisional_memory import (
     ProvisionalMarkdownArtifact,
@@ -19,6 +20,8 @@ from app.agent_memory.provisional_write import (
     load_provisional_markdown,
     render_provisional_markdown,
 )
+from app.agent_memory.recall_explanation import ActivationReason, RecallUseRight
+from app.write_guard import WriteGuard
 
 
 def test_write_endpoint_cannot_promote_or_authorize_apply() -> None:
@@ -190,3 +193,112 @@ def test_loader_rejects_non_sequence_provenance(
 
     with pytest.raises(ValueError, match="must be a non-empty string sequence"):
         load_provisional_markdown(path, vault_root=tmp_path)
+
+
+def _recall_candidate(tmp_path: Path):  # type: ignore[no-untyped-def]
+    from app.agent_memory.provisional_recall import retrieve_relevant_provisional
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    store = provisional_write_module.ProvisionalReceiptStore(tmp_path / "receipts.jsonl")
+    provisional_write_module.write_provisional_memory(
+        provisional_write_module.ProvisionalWriteRequest(
+            scope_id="scope-personal",
+            principal_id="principal-1",
+            memory_type=MemoryType.POLICY_MEMORY,
+            sensitivity=ProvisionalSensitivity.PRIVATE,
+            content="Production recall guards cannot authorize tools.",
+            provenance_event_ids=("event-guard",),
+        ),
+        vault_root=vault,
+        receipt_store=store,
+        write_guard=WriteGuard(snapshot_fn=lambda: {"state": "healthy"}),
+    )
+    search = retrieve_relevant_provisional(
+        "Which guards authorize tools?",
+        vault_root=vault,
+        receipt_store=store,
+        active_scope_id="scope-personal",
+    )
+    return search.candidates[0]
+
+
+def test_recall_path_invokes_low_trust_guards(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.agent_memory import provisional_recall
+    from app.agents.ask import graph as ask_graph
+    from app.agents.ask.state import AgentState
+
+    candidate = _recall_candidate(tmp_path)
+    calls: list[str] = []
+    real_inbound = provisional_recall.evaluate_admissibility
+    real_outbound = provisional_recall.evaluate_provisional_memory_authority
+
+    def _inbound(*args: object, **kwargs: object):  # type: ignore[no-untyped-def]
+        calls.append("admissibility")
+        return real_inbound(*args, **kwargs)  # type: ignore[arg-type]
+
+    def _outbound(*args: object, **kwargs: object):  # type: ignore[no-untyped-def]
+        calls.append("authority")
+        return real_outbound(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(provisional_recall, "evaluate_admissibility", _inbound)
+    monkeypatch.setattr(
+        provisional_recall,
+        "evaluate_provisional_memory_authority",
+        _outbound,
+    )
+
+    monkeypatch.setattr(ask_graph, "retrieve_relevant_promoted", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        ask_graph,
+        "retrieve_relevant_provisional",
+        lambda *args, **kwargs: provisional_recall.ProvisionalRecallSearch(
+            candidates=(candidate,),
+            excluded=(),
+        ),
+    )
+    monkeypatch.setattr(ask_graph, "_active_recall_vault_root", lambda: tmp_path)
+    monkeypatch.setattr(ask_graph, "_resolve_domain_scope", lambda: "scope-personal")
+    monkeypatch.setenv("PROVISIONAL_RECALL_RECEIPTS_PATH", str(tmp_path / "recall.jsonl"))
+
+    state = ask_graph._recall_node(  # noqa: SLF001 - verifies the production graph node
+        AgentState(query="Which guards authorize tools?"),
+        ask_settings=object(),
+    )
+    envelope = ask_graph.build_ask_envelope(state)
+    provisional_bundle = next(
+        item["metadata_bundle"]
+        for item in envelope["retrieved_items"]
+        if item["metadata_bundle"]["object_id"] == candidate.record.artifact_ref
+    )
+
+    assert state.recalled
+    assert calls == ["admissibility", "authority"]
+    assert provisional_bundle["authority_state"] == "noncanonical"
+    assert provisional_bundle["memory_state"] == "unreviewed"
+    assert provisional_bundle["provenance_event_ids"] == ["event-guard"]
+
+
+def test_provisional_memory_cannot_reach_action_authority(tmp_path: Path) -> None:
+    from app.agent_memory.provisional_recall import activate_provisional_recall
+
+    result = activate_provisional_recall(
+        _recall_candidate(tmp_path),
+        consuming_authority=ConsumingAuthority.GOVERNED_EXECUTION,
+        active_scope_id="scope-personal",
+        use_right=RecallUseRight.ACTION_AUTHORIZING,
+        activation_reason=ActivationReason.AUTHORITY_SIGNAL,
+        citation_reference="proposal://quoted-but-not-authority",
+        receipt_path=tmp_path / "recall.jsonl",
+    )
+
+    assert result.admitted is False
+    assert result.may_answer is False
+    assert result.may_propose is False
+    assert result.may_write is False
+    assert "provisional_memory_never_action_authoritative" in (
+        result.authority_decision.blocked_reasons
+    )

--- a/tests/agent_memory/test_provisional_memory_recall.py
+++ b/tests/agent_memory/test_provisional_memory_recall.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from uuid import uuid1
 
 from app.activation.gate import AdmissionTier, ConsumingAuthority
 from app.agent_memory.candidate import MemoryType, ReviewState
@@ -184,3 +185,26 @@ def test_missing_provenance_is_excluded_with_content_free_diagnostic(tmp_path: P
     assert search.candidates == ()
     assert search.excluded[0].reason_code == "artifact_invalid"
     assert "deterministic bilingual" not in repr(search.excluded)
+
+
+def test_non_uuid4_filename_is_excluded_without_crashing_recall(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    directory = vault / "Memory" / "Provisional"
+    directory.mkdir(parents=True)
+    memory_id = uuid1()
+    (directory / f"{memory_id}.md").write_text(
+        "---\nartifact_type: provisional_memory\n---\n",
+        encoding="utf-8",
+    )
+
+    search = retrieve_relevant_provisional(
+        "anything",
+        vault_root=vault,
+        receipt_store=ProvisionalReceiptStore(tmp_path / "empty.jsonl"),
+        active_scope_id="scope-personal",
+    )
+
+    assert search.candidates == ()
+    assert search.excluded[0].memory_id == str(memory_id)
+    assert search.excluded[0].reason_code == "artifact_identity_invalid"
+    assert "artifact_type" not in repr(search.excluded)

--- a/tests/agent_memory/test_provisional_memory_recall.py
+++ b/tests/agent_memory/test_provisional_memory_recall.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.activation.gate import AdmissionTier, ConsumingAuthority
+from app.agent_memory.candidate import MemoryType, ReviewState
+from app.agent_memory.provisional_memory import ProvisionalSensitivity
+from app.agent_memory.provisional_recall import (
+    PROVISIONAL_RECALL_RECEIPT_EVENT,
+    ProvisionalRecallCandidate,
+    activate_provisional_recall,
+    retrieve_relevant_provisional,
+)
+from app.agent_memory.provisional_write import (
+    ProvisionalReceiptStore,
+    ProvisionalWriteRequest,
+    write_provisional_memory,
+)
+from app.agent_memory.recall_explanation import ActivationReason, RecallUseRight
+from app.write_guard import WriteGuard
+
+
+def _candidate(tmp_path: Path) -> tuple[Path, ProvisionalReceiptStore, ProvisionalRecallCandidate]:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    store = ProvisionalReceiptStore(tmp_path / "provisional.jsonl")
+    write_provisional_memory(
+        ProvisionalWriteRequest(
+            scope_id="scope-personal",
+            principal_id="principal-1",
+            memory_type=MemoryType.PREFERENCE_MEMORY,
+            sensitivity=ProvisionalSensitivity.PRIVATE,
+            content="Prefer deterministic bilingual retrieval evaluation.",
+            provenance_event_ids=("event-1",),
+        ),
+        vault_root=vault,
+        receipt_store=store,
+        write_guard=WriteGuard(snapshot_fn=lambda: {"state": "healthy"}),
+    )
+    search = retrieve_relevant_provisional(
+        "Which retrieval evaluation is preferred?",
+        vault_root=vault,
+        receipt_store=store,
+        active_scope_id="scope-personal",
+    )
+    assert len(search.candidates) == 1
+    return vault, store, search.candidates[0]
+
+
+def test_read_context_preserves_low_trust_posture(tmp_path: Path) -> None:
+    _, _, candidate = _candidate(tmp_path)
+    result = activate_provisional_recall(
+        candidate,
+        consuming_authority=ConsumingAuthority.READ_ONLY,
+        active_scope_id="scope-personal",
+        use_right=RecallUseRight.ACTIVATABLE,
+        activation_reason=ActivationReason.CONTEXTUAL_RELEVANCE,
+        receipt_path=tmp_path / "recall.jsonl",
+    )
+
+    assert result.admitted is True
+    assert result.may_answer is True
+    assert result.may_propose is False
+    assert result.may_write is False
+    assert result.admissibility_decision.admitted_tier is AdmissionTier.READ
+    assert result.explanation is not None
+    assert result.explanation.trust_state == "provisional_low_trust_noncanonical"
+    assert result.explanation.review_state is ReviewState.UNREVIEWED
+    assert "event-1" in result.explanation.source_provenance.source_refs
+    assert "never_apply_or_tool_use" in result.explanation.authority_limits
+
+
+def test_proposal_use_requires_explicit_citation(tmp_path: Path) -> None:
+    _, _, candidate = _candidate(tmp_path)
+    denied = activate_provisional_recall(
+        candidate,
+        consuming_authority=ConsumingAuthority.PROPOSAL,
+        active_scope_id="scope-personal",
+        use_right=RecallUseRight.CITED_PROPOSAL,
+        activation_reason=ActivationReason.EXPLICIT_REFERENCE,
+        receipt_path=tmp_path / "recall.jsonl",
+    )
+    admitted = activate_provisional_recall(
+        candidate,
+        consuming_authority=ConsumingAuthority.PROPOSAL,
+        active_scope_id="scope-personal",
+        use_right=RecallUseRight.CITED_PROPOSAL,
+        activation_reason=ActivationReason.EXPLICIT_REFERENCE,
+        citation_reference="proposal://draft-1#citation-1",
+        receipt_path=tmp_path / "recall.jsonl",
+    )
+    mismatched_right = activate_provisional_recall(
+        candidate,
+        consuming_authority=ConsumingAuthority.PROPOSAL,
+        active_scope_id="scope-personal",
+        use_right=RecallUseRight.ACTIVATABLE,
+        activation_reason=ActivationReason.EXPLICIT_REFERENCE,
+        citation_reference="proposal://draft-1#citation-1",
+        receipt_path=tmp_path / "recall.jsonl",
+    )
+
+    assert denied.admitted is False
+    assert denied.explanation is None
+    assert admitted.admitted is True
+    assert admitted.may_propose is True
+    assert admitted.may_write is False
+    assert admitted.explanation is not None
+    assert "proposal://draft-1#citation-1" in admitted.explanation.source_provenance.source_refs
+    assert mismatched_right.admitted is False
+
+
+def test_recall_receipt_does_not_persist_activation_authority(tmp_path: Path) -> None:
+    vault, _, candidate = _candidate(tmp_path)
+    artifact = vault / candidate.record.artifact_ref.removeprefix("vault://")
+    before = artifact.read_bytes()
+    receipt_path = tmp_path / "recall.jsonl"
+
+    result = activate_provisional_recall(
+        candidate,
+        consuming_authority=ConsumingAuthority.READ_ONLY,
+        active_scope_id="scope-personal",
+        use_right=RecallUseRight.ACTIVATABLE,
+        activation_reason=ActivationReason.CONTEXTUAL_RELEVANCE,
+        receipt_path=receipt_path,
+    )
+
+    assert artifact.read_bytes() == before
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert receipt["event"] == PROVISIONAL_RECALL_RECEIPT_EVENT
+    assert receipt["event_id"] == result.receipt_id
+    assert receipt["payload"]["may_write"] is False
+    assert "deterministic bilingual" not in receipt_path.read_text(encoding="utf-8")
+
+
+def test_incomplete_lifecycle_pair_is_excluded_before_ranking(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    store = ProvisionalReceiptStore(tmp_path / "provisional.jsonl")
+    result = write_provisional_memory(
+        ProvisionalWriteRequest(
+            scope_id="scope-personal",
+            principal_id="principal-1",
+            memory_type=MemoryType.SEMANTIC_MEMORY,
+            sensitivity=ProvisionalSensitivity.PRIVATE,
+            content="This artifact will lose its terminal receipt.",
+            provenance_event_ids=("event-2",),
+        ),
+        vault_root=vault,
+        receipt_store=store,
+        write_guard=WriteGuard(snapshot_fn=lambda: {"state": "healthy"}),
+    )
+    lines = store.path.read_text(encoding="utf-8").splitlines()
+    store.path.write_text(lines[0] + "\n", encoding="utf-8")
+
+    search = retrieve_relevant_provisional(
+        "terminal receipt",
+        vault_root=vault,
+        receipt_store=store,
+        active_scope_id="scope-personal",
+    )
+
+    assert search.candidates == ()
+    assert search.excluded[0].memory_id == str(result.lifecycle_receipt.memory_id)
+    assert search.excluded[0].reason_code == "artifact_without_terminal_success_receipt"
+
+
+def test_missing_provenance_is_excluded_with_content_free_diagnostic(tmp_path: Path) -> None:
+    vault, store, candidate = _candidate(tmp_path)
+    artifact = vault / candidate.record.artifact_ref.removeprefix("vault://")
+    raw = artifact.read_text(encoding="utf-8")
+    artifact.write_text(
+        raw.replace("provenance_event_ids:\n- event-1\n", ""),
+        encoding="utf-8",
+    )
+
+    search = retrieve_relevant_provisional(
+        "deterministic bilingual retrieval",
+        vault_root=vault,
+        receipt_store=store,
+        active_scope_id="scope-personal",
+    )
+
+    assert search.candidates == ()
+    assert search.excluded[0].reason_code == "artifact_invalid"
+    assert "deterministic bilingual" not in repr(search.excluded)

--- a/tests/agents/ask/test_agent_state_contract.py
+++ b/tests/agents/ask/test_agent_state_contract.py
@@ -19,6 +19,9 @@ def test_agent_state_minimal_valid_shape_and_documented_fields() -> None:
     assert state.hits == []
     assert state.recalled == []
     assert state.recalled_content == {}
+    assert state.proposal_recalled == []
+    assert state.proposal_recalled_content == {}
+    assert state.proposal_context_items == []
     assert state.answer is None
     assert state.reasoning is None
     assert state.llm_route is None


### PR DESCRIPTION
## Summary
- rebuild complete provisional memory only from canonical Vault Markdown plus content-free lifecycle receipts
- enforce scope-before-ranking, inbound admissibility, outbound provisional authority, explicit citation for proposal use, and a permanent no-write/no-APPLY ceiling
- compose visible low-trust, review, provenance, and noncanonical posture into the production ASK ContextEnvelope
- emit content-free provisional recall receipts without mutating Markdown or lifecycle authority
- update the owning provisional-memory specification and Agent Memory current-state contract

Fixes #3720
Parent validation hub: #2314

## Claim
Dispatcher task `github-RasmusTho--agentic-pkm-mvp-issue-3720`, lease `lease-73b10069`, claimed by `codex-root`. Readiness and Source Anchors were strictly validated before claim.

## Validation
- `50 passed` focused current-head tests after the final use-right binding
- `93 passed` broader provisional/recall/context regression set before the final binding
- `8373 passed, 125 skipped, 85 deselected, 18 xfailed` full non-pg suite
- `ruff check app tests`
- `mypy app`
- `python3 scripts/docs_guard.py`

A full unfiltered local run reached `8375 passed` and failed only seven explicit Postgres tests because the configured local service at `127.0.0.1:15432` was unavailable. The governed non-pg selection above is green; CI remains the authoritative current-head integration gate.

## Authority invariants
- Vault Markdown is the sole meaning-bearing source.
- Receipt and envelope projections are content-free/derived and rebuildable.
- Provisional memory remains low-trust, unreviewed, noncanonical, and `may_write=false`.
- Proposal use requires an explicit citation.
- Governed execution, tool use, APPLY, promotion, and authority transition are impossible through this seam.

## BuilderOps Routing
- Records/projections/receipts: None.
- Reason: No new BuilderOps operational record is required; delivery truth is carried by #3720, PR #3743, current-head CI, independent review receipts, and the parent #2314 ledger.