### PR TITLE
Filter provisional recall stopword matches

### DIFF
--- a/app/agent_memory/provisional_recall.py
+++ b/app/agent_memory/provisional_recall.py
@@ -52,6 +52,38 @@ DEFAULT_PROVISIONAL_RECALL_RECEIPTS_PATH = Path(
 )
 PROVISIONAL_RECALL_RECEIPT_EVENT = "agent_memory.provisional_recall.evaluated"
 _TOKEN_RE = re.compile(r"[A-Za-z0-9]+")
+_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "at",
+    "att",
+    "av",
+    "det",
+    "en",
+    "ett",
+    "for",
+    "för",
+    "i",
+    "in",
+    "is",
+    "it",
+    "med",
+    "of",
+    "och",
+    "om",
+    "on",
+    "or",
+    "på",
+    "som",
+    "the",
+    "to",
+    "vad",
+    "which",
+    "with",
+}
 
 
 @dataclass(frozen=True)
@@ -412,7 +444,11 @@ def _tier_rank(tier: AdmissionTier) -> int:
 
 
 def _tokens(value: str) -> set[str]:
-    return {match.group(0).lower() for match in _TOKEN_RE.finditer(value)}
+    return {
+        token
+        for match in _TOKEN_RE.finditer(value)
+        if (token := match.group(0).lower()) not in _STOPWORDS
+    }
 
 
 def _score(record: ProvisionalMemoryRecord, query_tokens: set[str]) -> float:

--- a/app/agent_memory/provisional_recall.py
+++ b/app/agent_memory/provisional_recall.py
@@ -13,6 +13,7 @@ import json
 import os
 from pathlib import Path
 import re
+import unicodedata
 from uuid import UUID, uuid4
 
 from app.activation.gate import (
@@ -446,7 +447,7 @@ def _tier_rank(tier: AdmissionTier) -> int:
 def _tokens(value: str) -> set[str]:
     return {
         token
-        for match in _TOKEN_RE.finditer(value)
+        for match in _TOKEN_RE.finditer(unicodedata.normalize("NFC", value))
         if (token := match.group(0).casefold()) not in _STOPWORDS
     }
 

--- a/app/agent_memory/provisional_recall.py
+++ b/app/agent_memory/provisional_recall.py
@@ -51,7 +51,7 @@ DEFAULT_PROVISIONAL_RECALL_RECEIPTS_PATH = Path(
     "runtime/agent_memory/provisional_recall_receipts.jsonl"
 )
 PROVISIONAL_RECALL_RECEIPT_EVENT = "agent_memory.provisional_recall.evaluated"
-_TOKEN_RE = re.compile(r"[A-Za-z0-9]+")
+_TOKEN_RE = re.compile(r"[^\W_]+")
 _STOPWORDS = {
     "a",
     "an",
@@ -447,7 +447,7 @@ def _tokens(value: str) -> set[str]:
     return {
         token
         for match in _TOKEN_RE.finditer(value)
-        if (token := match.group(0).lower()) not in _STOPWORDS
+        if (token := match.group(0).casefold()) not in _STOPWORDS
     }
 
 

--- a/app/agent_memory/provisional_recall.py
+++ b/app/agent_memory/provisional_recall.py
@@ -445,10 +445,11 @@ def _tier_rank(tier: AdmissionTier) -> int:
 
 
 def _tokens(value: str) -> set[str]:
+    normalized = unicodedata.normalize("NFC", value.casefold())
     return {
-        token
-        for match in _TOKEN_RE.finditer(unicodedata.normalize("NFC", value))
-        if (token := match.group(0).casefold()) not in _STOPWORDS
+        match.group(0)
+        for match in _TOKEN_RE.finditer(normalized)
+        if match.group(0) not in _STOPWORDS
     }
 
 

--- a/tests/agent_memory/test_provisional_memory_recall.py
+++ b/tests/agent_memory/test_provisional_memory_recall.py
@@ -49,6 +49,30 @@ def _candidate(tmp_path: Path) -> tuple[Path, ProvisionalReceiptStore, Provision
     return vault, store, search.candidates[0]
 
 
+def _write_provisional(
+    tmp_path: Path,
+    *,
+    content: str,
+) -> tuple[Path, ProvisionalReceiptStore]:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    store = ProvisionalReceiptStore(tmp_path / "provisional.jsonl")
+    write_provisional_memory(
+        ProvisionalWriteRequest(
+            scope_id="scope-personal",
+            principal_id="principal-1",
+            memory_type=MemoryType.PREFERENCE_MEMORY,
+            sensitivity=ProvisionalSensitivity.PRIVATE,
+            content=content,
+            provenance_event_ids=("event-1",),
+        ),
+        vault_root=vault,
+        receipt_store=store,
+        write_guard=WriteGuard(snapshot_fn=lambda: {"state": "healthy"}),
+    )
+    return vault, store
+
+
 def test_read_context_preserves_low_trust_posture(tmp_path: Path) -> None:
     _, _, candidate = _candidate(tmp_path)
     result = activate_provisional_recall(
@@ -70,6 +94,39 @@ def test_read_context_preserves_low_trust_posture(tmp_path: Path) -> None:
     assert result.explanation.review_state is ReviewState.UNREVIEWED
     assert "event-1" in result.explanation.source_provenance.source_refs
     assert "never_apply_or_tool_use" in result.explanation.authority_limits
+
+
+def test_stopwords_do_not_create_provisional_recall_match(tmp_path: Path) -> None:
+    vault, store = _write_provisional(
+        tmp_path,
+        content="The and of to in with for.",
+    )
+
+    search = retrieve_relevant_provisional(
+        "the and of",
+        vault_root=vault,
+        receipt_store=store,
+        active_scope_id="scope-personal",
+    )
+
+    assert search.candidates == ()
+
+
+def test_meaningful_terms_survive_stopword_filtering(tmp_path: Path) -> None:
+    vault, store = _write_provisional(
+        tmp_path,
+        content="Prefer deterministic bilingual retrieval evaluation.",
+    )
+
+    search = retrieve_relevant_provisional(
+        "Which retrieval evaluation is preferred?",
+        vault_root=vault,
+        receipt_store=store,
+        active_scope_id="scope-personal",
+    )
+
+    assert len(search.candidates) == 1
+    assert search.candidates[0].score > 0
 
 
 def test_proposal_use_requires_explicit_citation(tmp_path: Path) -> None:

--- a/tests/agent_memory/test_provisional_memory_recall.py
+++ b/tests/agent_memory/test_provisional_memory_recall.py
@@ -99,11 +99,11 @@ def test_read_context_preserves_low_trust_posture(tmp_path: Path) -> None:
 def test_stopwords_do_not_create_provisional_recall_match(tmp_path: Path) -> None:
     vault, store = _write_provisional(
         tmp_path,
-        content="The and of to in with for.",
+        content="The and of to in with for. För och på.",
     )
 
     search = retrieve_relevant_provisional(
-        "the and of",
+        "the and of för på",
         vault_root=vault,
         receipt_store=store,
         active_scope_id="scope-personal",

--- a/tests/agent_memory/test_provisional_memory_recall.py
+++ b/tests/agent_memory/test_provisional_memory_recall.py
@@ -129,6 +129,20 @@ def test_meaningful_terms_survive_stopword_filtering(tmp_path: Path) -> None:
     assert search.candidates[0].score > 0
 
 
+def test_cross_case_combining_mark_tokens_match(tmp_path: Path) -> None:
+    vault, store = _write_provisional(tmp_path, content="\u01f0")
+
+    search = retrieve_relevant_provisional(
+        "J\u030c",
+        vault_root=vault,
+        receipt_store=store,
+        active_scope_id="scope-personal",
+    )
+
+    assert len(search.candidates) == 1
+    assert search.candidates[0].score > 0
+
+
 def test_proposal_use_requires_explicit_citation(tmp_path: Path) -> None:
     _, _, candidate = _candidate(tmp_path)
     denied = activate_provisional_recall(

--- a/tests/agent_memory/test_provisional_memory_recall.py
+++ b/tests/agent_memory/test_provisional_memory_recall.py
@@ -99,11 +99,11 @@ def test_read_context_preserves_low_trust_posture(tmp_path: Path) -> None:
 def test_stopwords_do_not_create_provisional_recall_match(tmp_path: Path) -> None:
     vault, store = _write_provisional(
         tmp_path,
-        content="The and of to in with for. För och på.",
+        content="The and of to in with for. Fo\u0308r och pa\u030a.",
     )
 
     search = retrieve_relevant_provisional(
-        "the and of för på",
+        "the and of fo\u0308r pa\u030a",
         vault_root=vault,
         receipt_store=store,
         active_scope_id="scope-personal",


### PR DESCRIPTION
Fixes #3766

Governing-Issue: #3766

## Summary
- Filter common stopwords out of provisional-memory recall token scoring.
- Add focused regressions proving stopword-only overlap does not recall while meaningful terms still match.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/agent_memory/test_provisional_memory_recall.py` — 9 passed, including decomposed-stopword and cross-case combining-mark regressions
- `ruff check app tests companion-ui/companion-app` — All checks passed
- `mypy app/agent_memory/provisional_recall.py` — Success: no issues found in 1 source file
- `git diff --check` — passed

## BuilderOps Routing
- Records/projections/receipts: `receipt_20260715052144_45f3fe86`
- Reason: closure-audit receipt records terminal review-thread supersession/discard classifications; delivery truth for this residual repair is carried by issue #3766, this PR, and the PR #3743 review-thread source anchor.

## Claim
- Issue pickup: `github-comment:4977122608`
- Coordination mode: GitHub-label-only fallback (`dispatcher_db_uninitialized`)