### PR TITLE
Quarantine pre-trust verification audit rows

### DIFF
--- a/app/dispatcher/cli.py
+++ b/app/dispatcher/cli.py
@@ -365,6 +365,7 @@ def _compact_verification_run(run: Any) -> dict[str, Any]:
         "verified_head_sha": run.verified_head_sha,
         "stage": run.stage,
         "status": run.status,
+        "authority_state": run.authority_state,
         "claimed_by": run.claimed_by,
         "lease_id": run.lease_id,
         "lease_expires_at": run.lease_expires_at,

--- a/app/dispatcher/schema.py
+++ b/app/dispatcher/schema.py
@@ -6,6 +6,8 @@ import sqlite3
 
 SCHEMA_VERSION = 3
 
+LEGACY_UNTRUSTED_VERIFICATION_STATUS = "legacy_untrusted"
+
 VERIFICATION_V3_REQUIRED_TABLES = frozenset(
     {"verification_runs", "verification_attempts", "verification_exceptions"}
 )

--- a/app/dispatcher/store.py
+++ b/app/dispatcher/store.py
@@ -8,15 +8,18 @@ foundation slice.
 
 from __future__ import annotations
 
+import hashlib
 import json
+import re
 import sqlite3
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Mapping, Protocol
 
 from app.dispatcher.events import JsonlEventWriter
 from app.dispatcher.models import EventRecord, LeaseRecord, TaskRecord
 from app.dispatcher.schema import (
     DDL_STATEMENTS,
+    LEGACY_UNTRUSTED_VERIFICATION_STATUS,
     SCHEMA_VERSION,
     verification_v3_schema_error,
 )
@@ -49,10 +52,154 @@ def _loads(value: str | None) -> Any:
     return json.loads(value)
 
 
-def _supporting_authority_from_request_json(value: str) -> str:
-    """Project the cumulative supporting-issue baseline from a stored request."""
+_PRE_TRUST_REQUEST_FIELDS = frozenset(
+    {
+        "base_ref",
+        "contract_version",
+        "current_head_sha",
+        "evidence_pack",
+        "generated_at",
+        "head_ref",
+        "idempotency_key",
+        "linked_issue",
+        "live_truth",
+        "pr_number",
+        "repository",
+        "source_workflow",
+        "stage",
+    }
+)
+_PRE_TRUST_NESTED_FIELDS = {
+    "source_workflow": frozenset({"name", "run_id", "run_attempt", "head_sha"}),
+    "evidence_pack": frozenset(
+        {
+            "contract",
+            "workflow_name",
+            "artifact_name",
+            "repository",
+            "pr_number",
+            "head_sha",
+        }
+    ),
+    "live_truth": frozenset(
+        {"repository", "pr_number", "current_head_sha", "source_run_id"}
+    ),
+}
+_CANONICAL_VERIFICATION_STATUSES = frozenset(
+    {
+        "queued",
+        "backoff",
+        "claimed",
+        "running",
+        "completed",
+        "failed",
+        "needs_human",
+        "superseded",
+    }
+)
+
+
+def _positive_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
+def recognized_pre_trust_verification_request(
+    row: Mapping[str, Any] | sqlite3.Row,
+    request: Mapping[str, object],
+) -> bool:
+    """Recognize the exact request contract deployed before artifact authority.
+
+    These requests are audit evidence only. Recognition never upgrades them to
+    the current closed request contract; it only permits an atomic migration to
+    a permanently inert ledger state.
+    """
+    if (
+        row["request_json"]
+        != json.dumps(
+            request,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+        or set(request) != _PRE_TRUST_REQUEST_FIELDS
+    ):
+        return False
+    nested: dict[str, Mapping[str, object]] = {}
+    for field, fields in _PRE_TRUST_NESTED_FIELDS.items():
+        value = request.get(field)
+        if not isinstance(value, Mapping) or set(value) != fields:
+            return False
+        nested[field] = value
+
+    repository = request.get("repository")
+    pr_number = request.get("pr_number")
+    linked_issue = request.get("linked_issue")
+    head_sha = request.get("current_head_sha")
+    idempotency_key = request.get("idempotency_key")
+    if (
+        request.get("contract_version") != "verification_dispatch_request.v1"
+        or request.get("stage") != "verification"
+        or not isinstance(repository, str)
+        or not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository)
+        or any(part in {".", ".."} for part in repository.split("/"))
+        or not _positive_int(pr_number)
+        or not _positive_int(linked_issue)
+        or not isinstance(head_sha, str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40}", head_sha)
+        or not isinstance(idempotency_key, str)
+        or not re.fullmatch(r"[0-9a-f]{64}", idempotency_key)
+        or any(
+            not isinstance(request.get(field), str) or not request[field]
+            for field in ("base_ref", "head_ref", "generated_at")
+        )
+    ):
+        return False
+
+    identity = {
+        "contract_version": "verification_dispatch_request.v1",
+        "head_sha": head_sha,
+        "pr_number": pr_number,
+        "repository": repository,
+        "stage": "verification",
+    }
+    expected_idempotency = hashlib.sha256(
+        json.dumps(identity, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    source = nested["source_workflow"]
+    evidence = nested["evidence_pack"]
+    live_truth = nested["live_truth"]
+    return bool(
+        idempotency_key == expected_idempotency
+        and row["run_id"] == f"vrun-{idempotency_key[:16]}"
+        and row["idempotency_key"] == idempotency_key
+        and row["contract_version"] == request["contract_version"]
+        and row["repository"] == repository
+        and row["pr_number"] == pr_number
+        and row["head_sha"] == head_sha
+        and row["stage"] == request["stage"]
+        and source.get("name") == "CI"
+        and _positive_int(source.get("run_id"))
+        and _positive_int(source.get("run_attempt"))
+        and source.get("head_sha") == head_sha
+        and evidence.get("contract") == "pr_evidence_pack"
+        and evidence.get("workflow_name") == "PR Evidence Pack"
+        and evidence.get("artifact_name") == f"pr-evidence-pack-{pr_number}"
+        and evidence.get("repository") == repository
+        and evidence.get("pr_number") == pr_number
+        and evidence.get("head_sha") == head_sha
+        and live_truth.get("repository") == repository
+        and live_truth.get("pr_number") == pr_number
+        and live_truth.get("current_head_sha") == head_sha
+        and live_truth.get("source_run_id") == source.get("run_id")
+    )
+
+
+def _verification_authority_migration(
+    row: sqlite3.Row,
+) -> tuple[str, bool]:
+    """Return the durable authority projection and whether the row is inert."""
     try:
-        request = json.loads(value)
+        request = json.loads(row["request_json"])
     except (TypeError, json.JSONDecodeError) as exc:
         raise ValueError("verification request audit is malformed") from exc
     supporting = request.get("supporting_issues") if isinstance(request, dict) else None
@@ -64,8 +211,59 @@ def _supporting_authority_from_request_json(value: str) -> str:
         )
         or len(set(supporting)) != len(supporting)
     ):
+        if isinstance(request, Mapping) and recognized_pre_trust_verification_request(
+            row, request
+        ):
+            return "[]", True
         raise ValueError("verification supporting authority is malformed")
-    return json.dumps(supporting, separators=(",", ":"), ensure_ascii=False)
+    return (
+        json.dumps(supporting, separators=(",", ":"), ensure_ascii=False),
+        False,
+    )
+
+
+def _legacy_verification_row_is_quarantined(row: sqlite3.Row) -> bool:
+    try:
+        supporting_authority = json.loads(row["supporting_authority_json"])
+    except (TypeError, json.JSONDecodeError):
+        return False
+    return bool(
+        row["status"] == LEGACY_UNTRUSTED_VERIFICATION_STATUS
+        and supporting_authority == []
+        and row["current_head_sha"] == row["head_sha"]
+        and row["verified_head_sha"] is None
+        and all(
+            row[field] is None
+            for field in (
+                "claimed_by",
+                "lease_id",
+                "lease_expires_at",
+                "last_heartbeat_at",
+                "coordinator_session_id",
+                "context_pack_json",
+                "retry_after",
+            )
+        )
+    )
+
+
+def _validate_canonical_authority_projection(
+    row: sqlite3.Row, requested_json: str
+) -> None:
+    try:
+        requested = json.loads(requested_json)
+        durable = json.loads(row["supporting_authority_json"])
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise ValueError("verification supporting authority is malformed") from exc
+    if (
+        row["status"] not in _CANONICAL_VERIFICATION_STATUSES
+        or not isinstance(requested, list)
+        or not isinstance(durable, list)
+        or any(not _positive_int(issue) for issue in durable)
+        or len(set(durable)) != len(durable)
+        or not set(requested).issubset(durable)
+    ):
+        raise ValueError("verification supporting authority is malformed")
 
 
 class SqliteStore:
@@ -159,7 +357,33 @@ class SqliteStore:
             if schema_error is not None:
                 raise ValueError(schema_error)
             if verification_additive_columns_complete:
-                return
+                authority_reconciliation_required = False
+                for verification_row in conn.execute(
+                    "SELECT * FROM verification_runs"
+                ).fetchall():
+                    requested_authority, is_inert = (
+                        _verification_authority_migration(verification_row)
+                    )
+                    if is_inert:
+                        authority_reconciliation_required = (
+                            authority_reconciliation_required
+                            or not _legacy_verification_row_is_quarantined(
+                                verification_row
+                            )
+                        )
+                    else:
+                        if (
+                            verification_row["status"]
+                            == LEGACY_UNTRUSTED_VERIFICATION_STATUS
+                        ):
+                            raise ValueError(
+                                "legacy verification audit classification is malformed"
+                            )
+                        _validate_canonical_authority_projection(
+                            verification_row, requested_authority
+                        )
+                if not authority_reconciliation_required:
+                    return
 
         # Only the original v1 layout is a supported migration source.  In
         # particular, do not turn a database written by a newer dispatcher
@@ -219,23 +443,57 @@ class SqliteStore:
                     conn.execute(
                         "ALTER TABLE verification_runs ADD COLUMN verified_head_sha TEXT"
                     )
-                if "supporting_authority_json" not in verification_columns:
+                supporting_authority_added = (
+                    "supporting_authority_json" not in verification_columns
+                )
+                if supporting_authority_added:
                     conn.execute(
                         "ALTER TABLE verification_runs ADD COLUMN "
                         "supporting_authority_json TEXT NOT NULL DEFAULT '[]'"
                     )
-                    for verification_row in conn.execute(
-                        "SELECT run_id, request_json FROM verification_runs"
-                    ).fetchall():
+                for verification_row in conn.execute(
+                    "SELECT * FROM verification_runs"
+                ).fetchall():
+                    supporting_authority, is_inert = (
+                        _verification_authority_migration(verification_row)
+                    )
+                    if is_inert:
+                        conn.execute(
+                            """
+                            UPDATE verification_runs
+                            SET supporting_authority_json=?, status=?,
+                                verified_head_sha=NULL, claimed_by=NULL,
+                                lease_id=NULL, lease_expires_at=NULL,
+                                last_heartbeat_at=NULL,
+                                coordinator_session_id=NULL,
+                                context_pack_json=NULL, retry_after=NULL
+                            WHERE run_id=?
+                            """,
+                            (
+                                supporting_authority,
+                                LEGACY_UNTRUSTED_VERIFICATION_STATUS,
+                                verification_row["run_id"],
+                            ),
+                        )
+                    elif supporting_authority_added:
                         conn.execute(
                             "UPDATE verification_runs "
                             "SET supporting_authority_json=? WHERE run_id=?",
                             (
-                                _supporting_authority_from_request_json(
-                                    verification_row["request_json"]
-                                ),
+                                supporting_authority,
                                 verification_row["run_id"],
                             ),
+                        )
+                    else:
+                        if (
+                            verification_row["status"]
+                            == LEGACY_UNTRUSTED_VERIFICATION_STATUS
+                        ):
+                            raise ValueError(
+                                "legacy verification audit classification is malformed"
+                            )
+                        _validate_canonical_authority_projection(
+                            verification_row, supporting_authority
                         )
                 schema_error = verification_v3_schema_error(conn)
                 if schema_error is not None:

--- a/app/dispatcher/store.py
+++ b/app/dispatcher/store.py
@@ -247,23 +247,16 @@ def _legacy_verification_row_is_quarantined(row: sqlite3.Row) -> bool:
     )
 
 
-def _validate_canonical_authority_projection(
-    row: sqlite3.Row, requested_json: str
-) -> None:
-    try:
-        requested = json.loads(requested_json)
-        durable = json.loads(row["supporting_authority_json"])
-    except (TypeError, json.JSONDecodeError) as exc:
-        raise ValueError("verification supporting authority is malformed") from exc
-    if (
-        row["status"] not in _CANONICAL_VERIFICATION_STATUSES
-        or not isinstance(requested, list)
-        or not isinstance(durable, list)
-        or any(not _positive_int(issue) for issue in durable)
-        or len(set(durable)) != len(durable)
-        or not set(requested).issubset(durable)
-    ):
-        raise ValueError("verification supporting authority is malformed")
+def _validate_canonical_verification_row(row: sqlite3.Row) -> None:
+    """Reuse the ledger's complete request/row contract before schema commit."""
+    if row["status"] not in _CANONICAL_VERIFICATION_STATUSES:
+        raise ValueError("verification canonical run authority is malformed")
+    # Local import avoids a module cycle while retaining one canonical
+    # validator for request shape, nested provenance, identity, heads, and
+    # cumulative supporting authority.
+    from app.dispatcher.verification_dispatch import _validated_row_request
+
+    _validated_row_request(row)
 
 
 class SqliteStore:
@@ -361,7 +354,7 @@ class SqliteStore:
                 for verification_row in conn.execute(
                     "SELECT * FROM verification_runs"
                 ).fetchall():
-                    requested_authority, is_inert = (
+                    _, is_inert = (
                         _verification_authority_migration(verification_row)
                     )
                     if is_inert:
@@ -379,9 +372,7 @@ class SqliteStore:
                             raise ValueError(
                                 "legacy verification audit classification is malformed"
                             )
-                        _validate_canonical_authority_projection(
-                            verification_row, requested_authority
-                        )
+                        _validate_canonical_verification_row(verification_row)
                 if not authority_reconciliation_required:
                     return
 
@@ -462,6 +453,7 @@ class SqliteStore:
                             """
                             UPDATE verification_runs
                             SET supporting_authority_json=?, status=?,
+                                current_head_sha=head_sha,
                                 verified_head_sha=NULL, claimed_by=NULL,
                                 lease_id=NULL, lease_expires_at=NULL,
                                 last_heartbeat_at=NULL,
@@ -484,6 +476,19 @@ class SqliteStore:
                                 verification_row["run_id"],
                             ),
                         )
+                for verification_row in conn.execute(
+                    "SELECT * FROM verification_runs"
+                ).fetchall():
+                    _, is_inert = _verification_authority_migration(
+                        verification_row
+                    )
+                    if is_inert:
+                        if not _legacy_verification_row_is_quarantined(
+                            verification_row
+                        ):
+                            raise ValueError(
+                                "legacy verification audit classification is malformed"
+                            )
                     else:
                         if (
                             verification_row["status"]
@@ -492,9 +497,7 @@ class SqliteStore:
                             raise ValueError(
                                 "legacy verification audit classification is malformed"
                             )
-                        _validate_canonical_authority_projection(
-                            verification_row, supporting_authority
-                        )
+                        _validate_canonical_verification_row(verification_row)
                 schema_error = verification_v3_schema_error(conn)
                 if schema_error is not None:
                     raise ValueError(schema_error)

--- a/app/dispatcher/verification_dispatch.py
+++ b/app/dispatcher/verification_dispatch.py
@@ -12,7 +12,11 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Mapping, Sequence, TypeGuard
 
-from app.dispatcher.store import SqliteStore
+from app.dispatcher.schema import LEGACY_UNTRUSTED_VERIFICATION_STATUS
+from app.dispatcher.store import (
+    SqliteStore,
+    recognized_pre_trust_verification_request,
+)
 
 CONTRACT_VERSION = "verification_dispatch_request.v1"
 TERMINAL_STATES = frozenset({"completed", "failed", "needs_human", "superseded"})
@@ -267,6 +271,8 @@ def _validated_stored_request(value: str | None) -> dict[str, object]:
 
 
 def _validated_row_request(row: sqlite3.Row) -> dict[str, object]:
+    if row["status"] == LEGACY_UNTRUSTED_VERIFICATION_STATUS:
+        raise ValueError("legacy verification audit is not executable")
     request = _validated_stored_request(row["request_json"])
     idempotency_key = request["idempotency_key"]
     assert isinstance(idempotency_key, str)
@@ -297,6 +303,32 @@ def _validated_row_request(row: sqlite3.Row) -> dict[str, object]:
     return request
 
 
+def _validated_legacy_row_request(row: sqlite3.Row) -> dict[str, object]:
+    loaded = _load(row["request_json"])
+    if (
+        row["status"] != LEGACY_UNTRUSTED_VERIFICATION_STATUS
+        or not isinstance(loaded, Mapping)
+        or not recognized_pre_trust_verification_request(row, loaded)
+        or _load(row["supporting_authority_json"]) != []
+        or row["current_head_sha"] != row["head_sha"]
+        or row["verified_head_sha"] is not None
+        or any(
+            row[field] is not None
+            for field in (
+                "claimed_by",
+                "lease_id",
+                "lease_expires_at",
+                "last_heartbeat_at",
+                "coordinator_session_id",
+                "context_pack_json",
+                "retry_after",
+            )
+        )
+    ):
+        raise ValueError("legacy verification audit is malformed")
+    return dict(loaded)
+
+
 def _validated_supporting_authority(
     row: sqlite3.Row, request: Mapping[str, object]
 ) -> list[int]:
@@ -322,6 +354,9 @@ def _validated_mutation_row(
         "SELECT * FROM verification_runs WHERE run_id = ?", (run_id,)
     ).fetchone()
     if row is not None:
+        if row["status"] == LEGACY_UNTRUSTED_VERIFICATION_STATUS:
+            _validated_legacy_row_request(row)
+            raise ValueError("legacy verification audit is not executable")
         _validated_row_request(row)
     return row
 
@@ -337,6 +372,7 @@ class VerificationRun:
     verified_head_sha: str | None
     stage: str
     status: str
+    authority_state: str
     claimed_by: str | None
     lease_id: str | None
     lease_expires_at: str | None
@@ -355,7 +391,15 @@ class VerificationRun:
 
 
 def _run(row: sqlite3.Row) -> VerificationRun:
-    request = _validated_row_request(row)
+    is_legacy = row["status"] == LEGACY_UNTRUSTED_VERIFICATION_STATUS
+    request = (
+        _validated_legacy_row_request(row)
+        if is_legacy
+        else _validated_row_request(row)
+    )
+    supporting_authority = (
+        [] if is_legacy else _validated_supporting_authority(row, request)
+    )
     return VerificationRun(
         run_id=row["run_id"],
         idempotency_key=row["idempotency_key"],
@@ -366,12 +410,15 @@ def _run(row: sqlite3.Row) -> VerificationRun:
         verified_head_sha=row["verified_head_sha"],
         stage=row["stage"],
         status=row["status"],
+        authority_state=(
+            LEGACY_UNTRUSTED_VERIFICATION_STATUS if is_legacy else "canonical"
+        ),
         claimed_by=row["claimed_by"],
         lease_id=row["lease_id"],
         lease_expires_at=row["lease_expires_at"],
         coordinator_session_id=row["coordinator_session_id"],
         request=request,
-        supporting_authority=tuple(_validated_supporting_authority(row, request)),
+        supporting_authority=tuple(supporting_authority),
         context_pack=_load(row["context_pack_json"]),
         terminal_receipt=_load(row["terminal_receipt_json"]),
         stop_reason=row["stop_reason"],
@@ -407,6 +454,23 @@ class VerificationDispatchLedger:
         run_id = f"vrun-{str(request['idempotency_key'])[:16]}"
         with self.store._connect() as conn:
             now = _begin_immediate_now(conn)
+            inert_audit_exists = conn.execute(
+                """
+                SELECT 1 FROM verification_runs
+                WHERE repository=? AND pr_number=? AND stage=? AND status=?
+                LIMIT 1
+                """,
+                (
+                    request["repository"],
+                    request["pr_number"],
+                    request["stage"],
+                    LEGACY_UNTRUSTED_VERIFICATION_STATUS,
+                ),
+            ).fetchone()
+            if inert_audit_exists is not None and not authenticated_artifact:
+                raise ValueError(
+                    "legacy verification audit requires an authenticated artifact"
+                )
             active_before_exact = list(
                 conn.execute(
                     """
@@ -1255,11 +1319,15 @@ class VerificationDispatchLedger:
     def closure_ready(self, run_id: str) -> bool:
         with self.store._connect() as conn:
             row = conn.execute(
-                "SELECT current_head_sha FROM verification_runs WHERE run_id=?",
+                "SELECT * FROM verification_runs WHERE run_id=?",
                 (run_id,),
             ).fetchone()
             if row is None:
                 return False
+            if row["status"] == LEGACY_UNTRUSTED_VERIFICATION_STATUS:
+                _validated_legacy_row_request(row)
+                return False
+            _validated_row_request(row)
             return self._closure_ready(conn, run_id, row["current_head_sha"])
 
     def exception(

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -132,7 +132,14 @@ The dispatcher is an operational coordination layer, not a lifecycle replacement
   request head while retaining all prior audit rows. Missing older audit tables, columns, or unique
   keys still fail closed before migration. Both normal self-migration and explicit initialization
   validate the complete resulting verification schema inside the migration transaction before the
-  v3 marker can be written or committed.
+  v3 marker can be written or committed. The one recognized pre-trust v3 request shape, deployed
+  before `supporting_issues` and authenticated artifact provenance became request authority, is never
+  upgraded by invention. Its immutable request, terminal receipt, attempts, and exceptions remain
+  audit evidence, while migration marks the run `legacy_untrusted`, clears every lease, session,
+  context, retry, and active projection, and stores no supporting authority. Status may list that
+  inert row, but every mutation and reopen path rejects it. A later authenticated canonical artifact
+  on a new head may start a fresh executable chain beside the retained audit row; any other malformed
+  historical request still rolls the whole additive migration back.
   If normal stale-head handling supersedes a chain before the repaired-head artifact arrives, only
   a later artifact with the same repository, PR, stage, and governing issue may reopen that exact
   chain on the new head. Reopening preserves immutable requested-head audit plus all attempts and

--- a/tests/dispatcher/test_control_plane.py
+++ b/tests/dispatcher/test_control_plane.py
@@ -8,14 +8,17 @@ from pathlib import Path
 import pytest
 
 from app.dispatcher import control_plane, leases
-from app.dispatcher.cli import main
+from app.dispatcher.cli import _compact_verification_run, main
 from app.dispatcher.config import load_paths
 from app.dispatcher.events import JsonlEventWriter
 from app.dispatcher.models import TaskRecord
 from app.dispatcher.schema import DDL_STATEMENTS, SCHEMA_VERSION
 from app.dispatcher.store import SqliteStore
 from app.dispatcher.verification_dispatch import VerificationDispatchLedger
-from tests.dispatcher.verification_helpers import request as verification_request
+from tests.dispatcher.verification_helpers import (
+    pre_trust_request,
+    request as verification_request,
+)
 
 
 def _store(tmp_path: Path) -> tuple[SqliteStore, object]:
@@ -87,6 +90,64 @@ def _write_pre_repair_v3_state(tmp_path: Path):
         conn.commit()
     paths.events_path.touch()
     return paths, run
+
+
+def _write_pre_trust_v3_state(tmp_path: Path):
+    """Create the exact deployed verification state from before trust closure."""
+    store, paths = _store(tmp_path)
+    store.upsert_task(_task())
+    run = VerificationDispatchLedger(store).ingest(verification_request())
+    legacy_request = pre_trust_request()
+    with sqlite3.connect(paths.db_path) as conn:
+        conn.execute(
+            """
+            UPDATE verification_runs
+            SET request_json=?, status='backoff', last_heartbeat_at=?,
+                coordinator_session_id='legacy-session',
+                context_pack_json='{"legacy":"context"}',
+                terminal_receipt_json='{"legacy":"terminal"}',
+                stop_reason='legacy_failure', retry_after=?
+            WHERE run_id=?
+            """,
+            (
+                json.dumps(
+                    legacy_request,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    ensure_ascii=False,
+                ),
+                "2026-07-13T12:00:03+00:00",
+                "2030-01-01T00:00:00+00:00",
+                run.run_id,
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO verification_attempts (
+                attempt_id, run_id, attempt_kind, ordinal, session_id,
+                capability, reasoning_effort, context_hash, outcome,
+                receipt_json, created_at
+            ) VALUES (?, ?, 'review', 1, 'legacy-review', 'terra', 'high',
+                      'legacy-context-hash', 'clean', '{"legacy":true}',
+                      '2026-07-13T12:00:01+00:00')
+            """,
+            ("attempt-pre-trust", run.run_id),
+        )
+        conn.execute(
+            """
+            INSERT INTO verification_exceptions (
+                exception_id, run_id, failure_class, head_sha, packet_json,
+                created_at, updated_at
+            ) VALUES (?, ?, 'review_blocked', ?, '{"legacy":true}',
+                      '2026-07-13T12:00:02+00:00',
+                      '2026-07-13T12:00:02+00:00')
+            """,
+            ("exception-pre-trust", run.run_id, run.requested_head_sha),
+        )
+        conn.execute("ALTER TABLE verification_runs DROP COLUMN supporting_authority_json")
+        conn.commit()
+    paths.events_path.touch()
+    return paths, run, legacy_request
 
 
 def test_recovery_accepts_and_restores_canonical_v1_until_store_migrates_it(
@@ -174,6 +235,171 @@ def test_pre_repair_v3_backup_restore_self_migrates_without_data_loss(
     assert exception_after == exception_before
     assert migrated.get_task("task-1") is not None
     assert control_plane.health(restored)["ok"] is True
+
+
+def test_pre_trust_verification_row_migrates_to_inert_audit_state(
+    tmp_path: Path,
+) -> None:
+    paths, original, legacy_request = _write_pre_trust_v3_state(tmp_path)
+
+    migrated_store = SqliteStore(paths.db_path)
+    migrated = VerificationDispatchLedger(migrated_store).get(original.run_id)
+
+    assert migrated is not None
+    assert migrated.status == "legacy_untrusted"
+    assert migrated.authority_state == "legacy_untrusted"
+    assert migrated.request == legacy_request
+    assert migrated.supporting_authority == ()
+    assert migrated.claimed_by is None
+    assert migrated.lease_id is None
+    assert migrated.lease_expires_at is None
+    assert migrated.coordinator_session_id is None
+    assert migrated.context_pack is None
+    assert migrated.retry_after is None
+    assert migrated.verified_head_sha is None
+    assert migrated.terminal_receipt == {"legacy": "terminal"}
+    assert migrated.stop_reason == "legacy_failure"
+    compact = _compact_verification_run(migrated)
+    assert compact["authority_state"] == "legacy_untrusted"
+    assert "request" not in compact
+    assert "base_ref" not in json.dumps(compact, sort_keys=True)
+    assert "head_ref" not in json.dumps(compact, sort_keys=True)
+    with sqlite3.connect(paths.db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        durable = conn.execute(
+            "SELECT * FROM verification_runs WHERE run_id=?", (original.run_id,)
+        ).fetchone()
+        attempt = conn.execute(
+            "SELECT attempt_id, run_id, receipt_json FROM verification_attempts"
+        ).fetchone()
+        exception = conn.execute(
+            "SELECT exception_id, run_id, packet_json FROM verification_exceptions"
+        ).fetchone()
+    assert durable is not None
+    assert json.loads(durable["request_json"]) == legacy_request
+    assert json.loads(durable["supporting_authority_json"]) == []
+    assert durable["last_heartbeat_at"] is None
+    assert durable["context_pack_json"] is None
+    assert tuple(attempt) == ("attempt-pre-trust", original.run_id, '{"legacy":true}')
+    assert tuple(exception) == (
+        "exception-pre-trust",
+        original.run_id,
+        '{"legacy":true}',
+    )
+    assert [run.run_id for run in VerificationDispatchLedger(migrated_store).list()] == [
+        original.run_id
+    ]
+    assert control_plane.health(paths)["ok"] is True
+
+
+def test_unrecognized_pre_trust_verification_row_rolls_back_migration(
+    tmp_path: Path,
+) -> None:
+    paths, original, legacy_request = _write_pre_trust_v3_state(tmp_path)
+    legacy_request["unexpected"] = "must-not-be-recognized"
+    with sqlite3.connect(paths.db_path) as conn:
+        conn.execute(
+            "UPDATE verification_runs SET request_json=? WHERE run_id=?",
+            (
+                json.dumps(
+                    legacy_request,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    ensure_ascii=False,
+                ),
+                original.run_id,
+            ),
+        )
+        conn.commit()
+    before = paths.db_path.read_bytes()
+
+    with pytest.raises(ValueError, match="supporting authority is malformed"):
+        SqliteStore(paths.db_path).get_meta("schema_version")
+
+    assert paths.db_path.read_bytes() == before
+    with sqlite3.connect(paths.db_path) as conn:
+        columns = {
+            row[1] for row in conn.execute("PRAGMA table_info(verification_runs)")
+        }
+    assert "supporting_authority_json" not in columns
+
+
+def test_schema_complete_pre_trust_row_still_enters_inert_quarantine(
+    tmp_path: Path,
+) -> None:
+    paths, original, legacy_request = _write_pre_trust_v3_state(tmp_path)
+    with sqlite3.connect(paths.db_path) as conn:
+        conn.execute(
+            "ALTER TABLE verification_runs ADD COLUMN "
+            "supporting_authority_json TEXT NOT NULL DEFAULT '[]'"
+        )
+        conn.commit()
+
+    migrated = VerificationDispatchLedger(SqliteStore(paths.db_path)).get(
+        original.run_id
+    )
+
+    assert migrated is not None
+    assert migrated.status == "legacy_untrusted"
+    assert migrated.authority_state == "legacy_untrusted"
+    assert migrated.request == legacy_request
+    assert migrated.context_pack is None
+    assert migrated.retry_after is None
+
+
+def test_inert_verification_audit_survives_backup_restore(tmp_path: Path) -> None:
+    paths, original, legacy_request = _write_pre_trust_v3_state(tmp_path)
+    migrated = VerificationDispatchLedger(SqliteStore(paths.db_path)).get(original.run_id)
+    assert migrated is not None
+
+    backup = tmp_path / "backup"
+    control_plane.backup(paths, backup)
+    restored = load_paths({"DISPATCHER_STATE_DIR": str(tmp_path / "restored")})
+    assert control_plane.restore(backup, restored)["integrity"] == "ok"
+
+    restored_run = VerificationDispatchLedger(SqliteStore(restored.db_path)).get(
+        original.run_id
+    )
+    assert restored_run is not None
+    assert restored_run.status == "legacy_untrusted"
+    assert restored_run.authority_state == "legacy_untrusted"
+    assert restored_run.request == legacy_request
+    with sqlite3.connect(restored.db_path) as conn:
+        assert conn.execute(
+            "SELECT attempt_id FROM verification_attempts WHERE run_id=?",
+            (original.run_id,),
+        ).fetchone() == ("attempt-pre-trust",)
+        assert conn.execute(
+            "SELECT exception_id FROM verification_exceptions WHERE run_id=?",
+            (original.run_id,),
+        ).fetchone() == ("exception-pre-trust",)
+
+
+def test_raw_pre_trust_backup_restore_then_migrates_to_inert(tmp_path: Path) -> None:
+    paths, original, legacy_request = _write_pre_trust_v3_state(tmp_path)
+
+    backup = tmp_path / "raw-backup"
+    control_plane.backup(paths, backup)
+    restored = load_paths({"DISPATCHER_STATE_DIR": str(tmp_path / "raw-restored")})
+    assert control_plane.restore(backup, restored)["integrity"] == "ok"
+
+    restored_run = VerificationDispatchLedger(SqliteStore(restored.db_path)).get(
+        original.run_id
+    )
+    assert restored_run is not None
+    assert restored_run.status == "legacy_untrusted"
+    assert restored_run.request == legacy_request
+    assert restored_run.context_pack is None
+    assert restored_run.retry_after is None
+    with sqlite3.connect(restored.db_path) as conn:
+        assert conn.execute(
+            "SELECT attempt_id FROM verification_attempts WHERE run_id=?",
+            (original.run_id,),
+        ).fetchone() == ("attempt-pre-trust",)
+        assert conn.execute(
+            "SELECT exception_id FROM verification_exceptions WHERE run_id=?",
+            (original.run_id,),
+        ).fetchone() == ("exception-pre-trust",)
 
 
 @pytest.mark.parametrize(

--- a/tests/dispatcher/test_control_plane.py
+++ b/tests/dispatcher/test_control_plane.py
@@ -324,6 +324,62 @@ def test_unrecognized_pre_trust_verification_row_rolls_back_migration(
     assert "supporting_authority_json" not in columns
 
 
+def test_noncanonical_current_request_rolls_back_additive_migration(
+    tmp_path: Path,
+) -> None:
+    store, paths = _store(tmp_path)
+    run = VerificationDispatchLedger(store).ingest(verification_request())
+    malformed = verification_request()
+    malformed.pop("artifact_provenance")
+    with sqlite3.connect(paths.db_path) as conn:
+        conn.execute(
+            "UPDATE verification_runs SET request_json=? WHERE run_id=?",
+            (
+                json.dumps(
+                    malformed,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    ensure_ascii=False,
+                ),
+                run.run_id,
+            ),
+        )
+        conn.execute("ALTER TABLE verification_runs DROP COLUMN supporting_authority_json")
+        conn.commit()
+    before = paths.db_path.read_bytes()
+
+    with pytest.raises(ValueError, match="missing required properties"):
+        SqliteStore(paths.db_path).get_meta("schema_version")
+
+    assert paths.db_path.read_bytes() == before
+    with sqlite3.connect(paths.db_path) as conn:
+        columns = {
+            row[1] for row in conn.execute("PRAGMA table_info(verification_runs)")
+        }
+    assert "supporting_authority_json" not in columns
+
+
+def test_pre_trust_advanced_head_is_normalized_to_inert_request_head(
+    tmp_path: Path,
+) -> None:
+    paths, original, legacy_request = _write_pre_trust_v3_state(tmp_path)
+    with sqlite3.connect(paths.db_path) as conn:
+        conn.execute(
+            "UPDATE verification_runs SET current_head_sha=? WHERE run_id=?",
+            ("b" * 40, original.run_id),
+        )
+        conn.commit()
+
+    migrated = VerificationDispatchLedger(SqliteStore(paths.db_path)).get(
+        original.run_id
+    )
+
+    assert migrated is not None
+    assert migrated.status == "legacy_untrusted"
+    assert migrated.current_head_sha == original.requested_head_sha
+    assert migrated.request == legacy_request
+
+
 def test_schema_complete_pre_trust_row_still_enters_inert_quarantine(
     tmp_path: Path,
 ) -> None:

--- a/tests/dispatcher/test_verification_dispatch.py
+++ b/tests/dispatcher/test_verification_dispatch.py
@@ -11,12 +11,40 @@ import pytest
 
 import app.dispatcher.verification_dispatch as verification_dispatch
 from app.dispatcher.verification_dispatch import VerificationRun
-from tests.dispatcher.verification_helpers import ledger, request
+from tests.dispatcher.verification_helpers import ledger, pre_trust_request, request
 from app.dispatcher.store import SqliteStore
 
 
 CLAIM_PRE_LOCK = "2030-01-01T00:00:00.000000+00:00"
 CLAIM_POST_LOCK = "2030-01-01T00:00:20.000000+00:00"
+
+
+def _migrated_legacy_ledger(tmp_path):
+    state = ledger(tmp_path)
+    original = state.ingest(request())
+    legacy_request = pre_trust_request()
+    with sqlite3.connect(state.store.db_path) as conn:
+        conn.execute(
+            "UPDATE verification_runs SET request_json=? WHERE run_id=?",
+            (
+                json.dumps(
+                    legacy_request,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    ensure_ascii=False,
+                ),
+                original.run_id,
+            ),
+        )
+        conn.execute("ALTER TABLE verification_runs DROP COLUMN supporting_authority_json")
+        conn.commit()
+    migrated = verification_dispatch.VerificationDispatchLedger(
+        SqliteStore(state.store.db_path)
+    )
+    legacy = migrated.get(original.run_id)
+    assert legacy is not None
+    assert legacy.status == "legacy_untrusted"
+    return migrated, legacy
 
 
 def test_shared_request_fixture_carries_governing_issue() -> None:
@@ -89,6 +117,157 @@ def test_canonical_request_projection_preserves_idempotent_replay(tmp_path) -> N
     assert replay.request == first.request
     with state.store._connect() as conn:
         assert conn.execute("SELECT COUNT(*) FROM verification_runs").fetchone()[0] == 1
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda state, run: state.claim(run.run_id, "host"),
+        lambda state, run: state.heartbeat(run.run_id, "host", "lease"),
+        lambda state, run: state.start(
+            run.run_id, "host", "lease", "session", {"head": run.head_sha}
+        ),
+        lambda state, run: state.terminal(
+            run.run_id,
+            "failed",
+            {"outcome": "blocked"},
+            holder="host",
+            lease_id="lease",
+        ),
+        lambda state, run: state.rebind_head(
+            run.run_id,
+            "b" * 40,
+            expected_head_sha=run.head_sha,
+            observed_repository=run.repository,
+            observed_pr_number=run.pr_number,
+            observed_head_sha="b" * 40,
+            holder="host",
+            lease_id="lease",
+        ),
+        lambda state, run: state.backoff(
+            run.run_id,
+            {"outcome": "retry"},
+            "2030-01-01T00:00:00+00:00",
+            holder="host",
+            lease_id="lease",
+        ),
+        lambda state, run: state.defer_unclaimed(
+            run.run_id,
+            {"outcome": "retry"},
+            "2030-01-01T00:00:00+00:00",
+        ),
+        lambda state, run: state.supersede_unclaimed(
+            run.run_id, {"outcome": "superseded"}, reason="stale_head"
+        ),
+        lambda state, run: state.record_attempt(
+            run.run_id,
+            "review",
+            "session",
+            "terra",
+            "high",
+            {"head": run.head_sha},
+            "clean",
+            holder="host",
+            lease_id="lease",
+        ),
+        lambda state, run: state.record_attempt_batch(
+            run.run_id,
+            "batch",
+            1,
+            run.head_sha,
+            lambda _attempts, _attempt_id: [],
+            holder="host",
+            lease_id="lease",
+        ),
+        lambda state, run: state.exception(
+            run.run_id,
+            "technical",
+            {"failure_class": "technical"},
+            holder="host",
+            lease_id="lease",
+        ),
+    ],
+)
+def test_inert_legacy_run_rejects_every_mutation_entrypoint(
+    tmp_path, mutation
+) -> None:
+    state, legacy = _migrated_legacy_ledger(tmp_path)
+    with state.store._connect() as conn:
+        before = dict(
+            conn.execute(
+                "SELECT * FROM verification_runs WHERE run_id=?", (legacy.run_id,)
+            ).fetchone()
+        )
+
+    with pytest.raises(ValueError, match="legacy verification audit is not executable"):
+        mutation(state, legacy)
+
+    with state.store._connect() as conn:
+        after = dict(
+            conn.execute(
+                "SELECT * FROM verification_runs WHERE run_id=?", (legacy.run_id,)
+            ).fetchone()
+        )
+    assert after == before
+
+
+def test_authenticated_artifact_starts_fresh_chain_beside_inert_legacy_audit(
+    tmp_path,
+) -> None:
+    state, legacy = _migrated_legacy_ledger(tmp_path)
+    with pytest.raises(
+        ValueError, match="legacy verification audit requires an authenticated artifact"
+    ):
+        state.ingest(request("b" * 40))
+    assert [run.run_id for run in state.list()] == [legacy.run_id]
+
+    authenticated = verification_dispatch._authenticated_verification_request(
+        request("b" * 40)
+    )
+
+    current = state.ingest(authenticated)
+
+    assert current.status == "queued"
+    assert current.authority_state == "canonical"
+    assert current.run_id != legacy.run_id
+    assert state.get(legacy.run_id) == legacy
+    assert {run.run_id for run in state.list()} == {legacy.run_id, current.run_id}
+    assert state.closure_ready(legacy.run_id) is False
+
+
+def test_authenticated_same_head_artifact_cannot_replace_inert_audit(tmp_path) -> None:
+    state, legacy = _migrated_legacy_ledger(tmp_path)
+    authenticated = verification_dispatch._authenticated_verification_request(request())
+
+    with pytest.raises(ValueError, match="legacy verification audit is not executable"):
+        state.ingest(authenticated)
+
+    assert state.get(legacy.run_id) == legacy
+    assert [run.run_id for run in state.list()] == [legacy.run_id]
+
+
+@pytest.mark.parametrize("corruption", ["legacy_as_queued", "canonical_as_legacy"])
+def test_legacy_classification_pair_fails_closed_when_corrupted(
+    tmp_path, corruption: str
+) -> None:
+    state, legacy = _migrated_legacy_ledger(tmp_path)
+    with state.store._connect() as conn:
+        if corruption == "legacy_as_queued":
+            conn.execute(
+                "UPDATE verification_runs SET status='queued' WHERE run_id=?",
+                (legacy.run_id,),
+            )
+        else:
+            conn.execute(
+                "UPDATE verification_runs SET request_json=? WHERE run_id=?",
+                (json.dumps(request(), sort_keys=True), legacy.run_id),
+            )
+        conn.commit()
+
+    with pytest.raises(ValueError):
+        state.get(legacy.run_id)
+    with pytest.raises(ValueError):
+        state.claim(legacy.run_id, "host")
 
 
 _REQUEST_SCALAR_PATHS: tuple[tuple[str | int, ...], ...] = (

--- a/tests/dispatcher/verification_helpers.py
+++ b/tests/dispatcher/verification_helpers.py
@@ -39,5 +39,15 @@ def request(head: str = HEAD) -> dict[str, object]:
     return result
 
 
+def pre_trust_request(head: str = HEAD) -> dict[str, object]:
+    """Return the exact producer shape deployed before artifact authority."""
+    result = request(head)
+    result.pop("supporting_issues")
+    result.pop("artifact_provenance")
+    result["base_ref"] = "main"
+    result["head_ref"] = "codex/issue-3603"
+    return result
+
+
 def ledger(tmp_path: Path) -> VerificationDispatchLedger:
     return VerificationDispatchLedger(SqliteStore(tmp_path / "dispatcher.sqlite3"))


### PR DESCRIPTION
Fixes #3794

## Summary
- Recognize only the exact compact historical verification request shape and atomically quarantine it as `legacy_untrusted` without synthesizing supporting authority or artifact provenance.
- Preserve immutable request, attempt, exception, terminal, and stop evidence while clearing every lease, heartbeat, coordinator session, context, retry, and executable projection.
- Keep inert rows listable through a sanitized status projection, reject every mutation/reopen/same-head collision, and require authenticated artifact authority for a fresh different-head chain.
- Scan schema-complete restores on first open so a partial prior migration cannot bypass quarantine.

## Validation
- `pytest -q tests/dispatcher tests/governance` — 864 passed.
- `python -m mypy --no-incremental app` — success across 743 source files.
- `ruff check app tests` — passed.
- `git diff --check` — passed.
- Exact deployed local dispatcher database was copied with SQLite online backup, integrity-checked, and opened with this head: all three historical PR #3620 rows migrated to sanitized `legacy_untrusted` status with zero active runs; the source database was not mutated by this proof.
- Independent architecture/security design review accepted the status-only quarantine model after authenticated-ingest, early-return, classification-pair, closure-readiness, same-head, backup/restore, and mutation fences were added. Final exact-head review remains required after CI.

## Coordination
- Pickup used GitHub-label-only fallback because dispatcher pull failed on the defect being repaired: `verification supporting authority is malformed`.
- Claim receipt: issue comment `4979072925`.
- #3626 exception remains untouched; no repair loop or reclassification is included.

## BuilderOps Routing
- Records/projections/receipts: `lrn_20260715094533_08cedc6c`.
- Reason: captured the migration-contract divergence against `docs/AGENT_ISSUE_DISPATCHER.md :: Verification dispatch consumer`.

## TCD
- Capability: `gpt-5.6-sol`, xhigh reasoning, migration/security review depth.
- Rationale: authority-bearing SQLite migration and host rollout unblocker with high hidden-defect cost.
## Review Repair
- Round 1 on `00799404b49f61035b7ac056329f31756ed674c6`: REJECT with two findings.
- Repaired on `d246a329`: every non-legacy row now crosses the full canonical request/row validator before early return or migration commit; inert migration resets mutable current-head projection to immutable request head.
- Added adversarial rollback coverage for missing artifact provenance with valid supporting authority and advanced legacy current-head coverage.
- Post-repair local gates: 864 dispatcher/governance tests, mypy 743 files, ruff, diff check, and exact deployed database-copy status proof all pass.
- Two consecutive clean independent reviews remain required after exact-head CI.
