### PR TITLE
builder: observe epic context budgets at slice boundaries

### DIFF
--- a/app/builderops/epic_run_context_budget.py
+++ b/app/builderops/epic_run_context_budget.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 from typing import Any, Mapping
 
 RECEIPT_SCHEMA_NAME = "epic_run_context_budget_receipt"
@@ -89,35 +90,13 @@ def evaluate_slice_boundary_context_budget(
     )
     external_state_changed = previous_marker is not None and marker != previous_marker
 
-    lifecycle = "keep"
-    reasons: list[str] = []
-    if normalized_pressure == UNKNOWN:
-        reasons.append("context_measurement_unknown")
-    elif normalized_pressure == "low":
-        reasons.append("low_context_pressure")
-    elif normalized_policy["rotate_on_high_context_pressure"]:
-        lifecycle = "checkpoint_rotate"
-        reasons.append("explicit_policy_high_context_pressure")
-    else:
-        reasons.append("high_context_pressure_observed_policy_does_not_rotate")
-
-    if external_state_changed:
-        reasons.append("external_state_refresh_required")
-
-    isolated_worker_candidate = all(normalized_next_slice.values())
-    execution = (
-        "thin_worker"
-        if normalized_policy["thin_worker_when_isolated"] and isolated_worker_candidate
-        else "inline"
+    recommendations, reasons = _build_recommendations_and_reasons(
+        context_pressure=normalized_pressure,
+        uncertainty=normalized_uncertainty,
+        next_slice=normalized_next_slice,
+        policy=normalized_policy,
+        external_state_changed=external_state_changed,
     )
-    reasons.append(
-        "isolated_thin_worker_candidate"
-        if execution == "thin_worker"
-        else "inline_by_explicit_slice_evidence"
-    )
-
-    model_tier = _recommend_model_tier(normalized_uncertainty, normalized_next_slice)
-    reasons.append(f"model_tier_{model_tier}")
 
     return {
         "schema_name": RECEIPT_SCHEMA_NAME,
@@ -131,6 +110,7 @@ def evaluate_slice_boundary_context_budget(
             "repairs": normalized_repairs,
             "uncertainty": normalized_uncertainty,
         },
+        "next_slice": normalized_next_slice,
         "policy": normalized_policy,
         "checkpoint": {
             "slice_status": _required_string(slice_status, "slice_status"),
@@ -146,11 +126,7 @@ def evaluate_slice_boundary_context_budget(
                 "refresh_required": external_state_changed,
             },
         },
-        "recommendations": {
-            "coordinator_lifecycle": lifecycle,
-            "slice_execution": execution,
-            "model_tier": model_tier,
-        },
+        "recommendations": recommendations,
         "recommendation_reasons": reasons,
         "cost_per_accepted_slice": _build_cost_observation(
             cost_inputs,
@@ -184,6 +160,7 @@ def normalize_context_budget_receipt(receipt: Mapping[str, Any]) -> dict[str, An
         "slice_id",
         "measurements",
         "signals",
+        "next_slice",
         "policy",
         "checkpoint",
         "recommendations",
@@ -250,6 +227,7 @@ def normalize_context_budget_receipt(receipt: Mapping[str, Any]) -> dict[str, An
         "repairs": _normalize_repairs(signals["repairs"]),
         "uncertainty": _normalize_uncertainty(signals["uncertainty"]),
     }
+    normalized["next_slice"] = _normalize_next_slice(normalized["next_slice"])
     normalized["policy"] = _normalize_policy(normalized["policy"])
 
     recommendations = _json_object(normalized["recommendations"], "recommendations")
@@ -271,8 +249,7 @@ def normalize_context_budget_receipt(receipt: Mapping[str, Any]) -> dict[str, An
         raise EpicRunContextBudgetError("invalid slice execution recommendation")
     if recommendations.get("model_tier") not in {"luna", "terra", "sol"}:
         raise EpicRunContextBudgetError("invalid model tier recommendation")
-    normalized["recommendations"] = recommendations
-    normalized["recommendation_reasons"] = [
+    recommendation_reasons = [
         _required_string(item, f"recommendation_reasons[{index}]")
         for index, item in enumerate(
             _json_list(normalized["recommendation_reasons"], "recommendation_reasons")
@@ -280,6 +257,23 @@ def normalize_context_budget_receipt(receipt: Mapping[str, Any]) -> dict[str, An
     ]
 
     normalized["checkpoint"] = _normalize_checkpoint(normalized["checkpoint"])
+    expected_recommendations, expected_reasons = _build_recommendations_and_reasons(
+        context_pressure=normalized["signals"]["context_pressure"],
+        uncertainty=normalized["signals"]["uncertainty"],
+        next_slice=normalized["next_slice"],
+        policy=normalized["policy"],
+        external_state_changed=normalized["checkpoint"]["external_state"]["changed"],
+    )
+    if recommendations != expected_recommendations:
+        raise EpicRunContextBudgetError(
+            "recommendations contradict the persisted evaluator evidence"
+        )
+    if recommendation_reasons != expected_reasons:
+        raise EpicRunContextBudgetError(
+            "recommendation_reasons contradict the persisted evaluator evidence"
+        )
+    normalized["recommendations"] = expected_recommendations
+    normalized["recommendation_reasons"] = expected_reasons
     normalized["cost_per_accepted_slice"] = _normalize_cost_observation(
         normalized["cost_per_accepted_slice"]
     )
@@ -357,8 +351,15 @@ def _normalize_measurement(
             f"{field} fields must be exactly value, unit, source"
         )
     value = normalized["value"]
-    if value != UNKNOWN and (isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0):
-        raise EpicRunContextBudgetError(f"{field}.value must be non-negative or unknown")
+    if value != UNKNOWN and (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not _is_finite_number(value)
+        or value < 0
+    ):
+        raise EpicRunContextBudgetError(
+            f"{field}.value must be finite, non-negative, or unknown"
+        )
     normalized["source"] = _required_string(normalized["source"], f"{field}.source")
     normalized["unit"] = _required_string(normalized["unit"], f"{field}.unit")
     if expected_unit is not None and normalized["unit"] != expected_unit:
@@ -385,9 +386,9 @@ def _normalize_uncertainty(value: Mapping[str, Any]) -> dict[str, Any]:
 def _normalize_next_slice(value: Mapping[str, Any]) -> dict[str, bool]:
     normalized = _json_object(value, "next_slice")
     expected = {
-        "contract_complete",
-        "isolated_filescope",
-        "deterministic_verification",
+        "worker_isolated",
+        "setup_cost_high",
+        "merge_risk_low",
     }
     if set(normalized) != expected:
         raise EpicRunContextBudgetError(
@@ -417,9 +418,60 @@ def _recommend_model_tier(
 ) -> str:
     if uncertainty["level"] in {"high", UNKNOWN}:
         return "sol"
-    if uncertainty["level"] == "low" and all(next_slice.values()):
+    if uncertainty["level"] == "low" and next_slice["merge_risk_low"]:
         return "luna"
     return "terra"
+
+
+def _build_recommendations_and_reasons(
+    *,
+    context_pressure: str,
+    uncertainty: Mapping[str, Any],
+    next_slice: Mapping[str, bool],
+    policy: Mapping[str, Any],
+    external_state_changed: bool,
+) -> tuple[dict[str, str], list[str]]:
+    lifecycle = "keep"
+    reasons: list[str] = []
+    if context_pressure == UNKNOWN:
+        reasons.append("context_measurement_unknown")
+    elif context_pressure == "low":
+        reasons.append("low_context_pressure")
+    elif policy["rotate_on_high_context_pressure"]:
+        lifecycle = "checkpoint_rotate"
+        reasons.append("explicit_policy_high_context_pressure")
+    else:
+        reasons.append("high_context_pressure_observed_policy_does_not_rotate")
+
+    if external_state_changed:
+        reasons.append("external_state_refresh_required")
+
+    thin_worker_candidate = (
+        next_slice["worker_isolated"]
+        and not next_slice["setup_cost_high"]
+        and next_slice["merge_risk_low"]
+    )
+    execution = (
+        "thin_worker"
+        if policy["thin_worker_when_isolated"] and thin_worker_candidate
+        else "inline"
+    )
+    reasons.append(
+        "isolated_thin_worker_candidate"
+        if execution == "thin_worker"
+        else "inline_by_explicit_slice_evidence"
+    )
+
+    model_tier = _recommend_model_tier(uncertainty, next_slice)
+    reasons.append(f"model_tier_{model_tier}")
+    return (
+        {
+            "coordinator_lifecycle": lifecycle,
+            "slice_execution": execution,
+            "model_tier": model_tier,
+        },
+        reasons,
+    )
 
 
 def _normalize_checkpoint(value: Mapping[str, Any]) -> dict[str, Any]:
@@ -558,10 +610,11 @@ def _build_cost_observation(
         if value != UNKNOWN and (
             isinstance(value, bool)
             or not isinstance(value, (int, float))
+            or not _is_finite_number(value)
             or value < 0
         ):
             raise EpicRunContextBudgetError(
-                f"cost_inputs.{field}.value must be non-negative or unknown"
+                f"cost_inputs.{field}.value must be finite, non-negative, or unknown"
             )
         normalized_inputs[field] = {
             "value": value,
@@ -595,7 +648,24 @@ def _build_cost_observation(
         and denominator["value"] > 0
         and known_monetary
     ):
-        per_accepted = sum(known_monetary) / denominator["value"]
+        known_monetary_total = sum(known_monetary)
+        if not _is_finite_number(known_monetary_total):
+            raise EpicRunContextBudgetError(
+                "known monetary cost total must remain finite"
+            )
+        try:
+            derived_per_accepted = known_monetary_total / denominator["value"]
+        except OverflowError as exc:
+            raise EpicRunContextBudgetError(
+                "known monetary cost per accepted slice must remain finite"
+            ) from exc
+        if not isinstance(derived_per_accepted, (int, float)) or not math.isfinite(
+            derived_per_accepted
+        ):
+            raise EpicRunContextBudgetError(
+                "known monetary cost per accepted slice must remain finite"
+            )
+        per_accepted = derived_per_accepted
 
     completeness = (
         "complete"
@@ -618,6 +688,12 @@ def _enum(value: Any, allowed: set[str], field: str) -> str:
     return value
 
 
+def _is_finite_number(value: int | float) -> bool:
+    if isinstance(value, int):
+        return True
+    return math.isfinite(value)
+
+
 def _required_string(value: Any, field: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise EpicRunContextBudgetError(f"{field} must be a non-empty string")
@@ -627,10 +703,20 @@ def _required_string(value: Any, field: str) -> str:
 def _json_object(value: Mapping[str, Any], field: str) -> dict[str, Any]:
     if not isinstance(value, Mapping):
         raise EpicRunContextBudgetError(f"{field} must be an object")
-    return json.loads(json.dumps(dict(value), sort_keys=True))
+    try:
+        return json.loads(json.dumps(dict(value), sort_keys=True, allow_nan=False))
+    except (TypeError, ValueError) as exc:
+        raise EpicRunContextBudgetError(
+            f"{field} must contain only finite JSON values"
+        ) from exc
 
 
 def _json_list(value: list[Any], field: str) -> list[Any]:
     if not isinstance(value, list):
         raise EpicRunContextBudgetError(f"{field} must be a list")
-    return json.loads(json.dumps(value, sort_keys=True))
+    try:
+        return json.loads(json.dumps(value, sort_keys=True, allow_nan=False))
+    except (TypeError, ValueError) as exc:
+        raise EpicRunContextBudgetError(
+            f"{field} must contain only finite JSON values"
+        ) from exc

--- a/app/builderops/epic_run_context_budget.py
+++ b/app/builderops/epic_run_context_budget.py
@@ -1,0 +1,416 @@
+"""Observer-only context-budget receipts for epic slice boundaries."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+
+RECEIPT_SCHEMA_NAME = "epic_run_context_budget_receipt"
+RECEIPT_SCHEMA_VERSION = 1
+POLICY_SCHEMA_VERSION = 1
+UNKNOWN = "unknown"
+
+CONTEXT_PRESSURES = {"low", "high", UNKNOWN}
+UNCERTAINTY_LEVELS = {"low", "medium", "high", UNKNOWN}
+MONETARY_COST_FIELDS = (
+    "model_cost_usd",
+    "tool_cost_usd",
+    "wait_cost_usd",
+)
+COST_INPUT_FIELDS = (
+    *MONETARY_COST_FIELDS,
+    "model_input_tokens",
+    "model_output_tokens",
+    "tool_minutes",
+    "wait_minutes",
+    "failed_attempts",
+    "implementation_repairs",
+    "ci_repairs",
+    "review_repairs",
+    "handoffs",
+    "worker_starts",
+    "human_minutes",
+)
+
+
+class EpicRunContextBudgetError(ValueError):
+    """Raised when an advisory context-budget observation is malformed."""
+
+
+def evaluate_slice_boundary_context_budget(
+    *,
+    slice_id: str,
+    slice_status: str,
+    decision_log_delta: list[Any],
+    open_review_findings: list[Any],
+    external_state_marker: Mapping[str, Any],
+    context_measurement: Mapping[str, Any],
+    context_pressure: str,
+    completed_slices_since_checkpoint: int,
+    repairs: Mapping[str, int],
+    uncertainty: Mapping[str, Any],
+    next_slice: Mapping[str, Any],
+    policy: Mapping[str, Any],
+    cost_inputs: Mapping[str, Any],
+    accepted_slice_count: int | None,
+    previous_external_state_marker: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Evaluate one slice boundary without executing any recommendation.
+
+    All policy inputs are explicit and versioned. The returned receipt has no
+    mutation instructions and cannot claim acceptance or gate completion.
+    """
+
+    normalized_policy = _normalize_policy(policy)
+    normalized_context = _normalize_measurement(
+        context_measurement,
+        "context_measurement",
+        expected_unit="tokens",
+    )
+    normalized_pressure = _enum(context_pressure, CONTEXT_PRESSURES, "context_pressure")
+    if normalized_context["value"] == UNKNOWN:
+        normalized_pressure = UNKNOWN
+    if (
+        isinstance(completed_slices_since_checkpoint, bool)
+        or not isinstance(completed_slices_since_checkpoint, int)
+        or completed_slices_since_checkpoint < 0
+    ):
+        raise EpicRunContextBudgetError(
+            "completed_slices_since_checkpoint must be a non-negative integer"
+        )
+    normalized_uncertainty = _normalize_uncertainty(uncertainty)
+    normalized_next_slice = _normalize_next_slice(next_slice)
+    normalized_repairs = _normalize_repairs(repairs)
+    marker = _json_object(external_state_marker, "external_state_marker")
+    previous_marker = (
+        None
+        if previous_external_state_marker is None
+        else _json_object(previous_external_state_marker, "previous_external_state_marker")
+    )
+    external_state_changed = previous_marker is not None and marker != previous_marker
+
+    lifecycle = "keep"
+    reasons: list[str] = []
+    if normalized_pressure == UNKNOWN:
+        reasons.append("context_measurement_unknown")
+    elif normalized_pressure == "low":
+        reasons.append("low_context_pressure")
+    elif normalized_policy["rotate_on_high_context_pressure"]:
+        lifecycle = "checkpoint_rotate"
+        reasons.append("explicit_policy_high_context_pressure")
+    else:
+        reasons.append("high_context_pressure_observed_policy_does_not_rotate")
+
+    if external_state_changed:
+        reasons.append("external_state_refresh_required")
+
+    isolated_worker_candidate = all(normalized_next_slice.values())
+    execution = (
+        "thin_worker"
+        if normalized_policy["thin_worker_when_isolated"] and isolated_worker_candidate
+        else "inline"
+    )
+    reasons.append(
+        "isolated_thin_worker_candidate"
+        if execution == "thin_worker"
+        else "inline_by_explicit_slice_evidence"
+    )
+
+    model_tier = _recommend_model_tier(normalized_uncertainty, normalized_next_slice)
+    reasons.append(f"model_tier_{model_tier}")
+
+    return {
+        "schema_name": RECEIPT_SCHEMA_NAME,
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "mode": "advisory_shadow",
+        "slice_id": _required_string(slice_id, "slice_id"),
+        "measurements": {"context": normalized_context},
+        "signals": {
+            "context_pressure": normalized_pressure,
+            "completed_slices_since_checkpoint": completed_slices_since_checkpoint,
+            "repairs": normalized_repairs,
+            "uncertainty": normalized_uncertainty,
+        },
+        "policy": normalized_policy,
+        "checkpoint": {
+            "slice_status": _required_string(slice_status, "slice_status"),
+            "decision_log_delta": _json_list(decision_log_delta, "decision_log_delta"),
+            "open_review_findings": _json_list(
+                open_review_findings,
+                "open_review_findings",
+            ),
+            "external_state": {
+                "marker": marker,
+                "previous_marker": previous_marker,
+                "changed": external_state_changed,
+                "refresh_required": external_state_changed,
+            },
+        },
+        "recommendations": {
+            "coordinator_lifecycle": lifecycle,
+            "slice_execution": execution,
+            "model_tier": model_tier,
+        },
+        "recommendation_reasons": reasons,
+        "cost_per_accepted_slice": _build_cost_observation(
+            cost_inputs,
+            accepted_slice_count=accepted_slice_count,
+        ),
+        "effects": {
+            "dispatch_mutations": [],
+            "agent_spawns": [],
+            "acceptance_mutations": [],
+            "ci_mutations": [],
+            "review_mutations": [],
+            "closure_mutations": [],
+        },
+        "gate_invariants": {
+            "ci": "unchanged_required",
+            "independent_review": "unchanged_required",
+            "merge": "unchanged_required",
+            "closure": "unchanged_required",
+        },
+    }
+
+
+def normalize_context_budget_receipt(receipt: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate a receipt before it enters dispatcher-backed epic run-state."""
+
+    normalized = _json_object(receipt, "context_budget_receipt")
+    if normalized.get("schema_name") != RECEIPT_SCHEMA_NAME:
+        raise EpicRunContextBudgetError("unsupported context-budget receipt schema_name")
+    if normalized.get("schema_version") != RECEIPT_SCHEMA_VERSION:
+        raise EpicRunContextBudgetError("unsupported context-budget receipt schema_version")
+    if normalized.get("mode") != "advisory_shadow":
+        raise EpicRunContextBudgetError("context-budget receipt must be advisory_shadow")
+
+    recommendations = normalized.get("recommendations")
+    if not isinstance(recommendations, dict):
+        raise EpicRunContextBudgetError("recommendations must be an object")
+    if recommendations.get("coordinator_lifecycle") not in {
+        "keep",
+        "checkpoint_rotate",
+    }:
+        raise EpicRunContextBudgetError("invalid coordinator lifecycle recommendation")
+    if recommendations.get("slice_execution") not in {"inline", "thin_worker"}:
+        raise EpicRunContextBudgetError("invalid slice execution recommendation")
+    if recommendations.get("model_tier") not in {"luna", "terra", "sol"}:
+        raise EpicRunContextBudgetError("invalid model tier recommendation")
+
+    expected_effects: dict[str, list[Any]] = {
+        "dispatch_mutations": [],
+        "agent_spawns": [],
+        "acceptance_mutations": [],
+        "ci_mutations": [],
+        "review_mutations": [],
+        "closure_mutations": [],
+    }
+    if normalized.get("effects") != expected_effects:
+        raise EpicRunContextBudgetError("advisory receipt cannot carry mutations")
+    return normalized
+
+
+def build_3229_pilot_replay() -> dict[str, Any]:
+    """Return the bounded pilot facts without making an unmeasured cost claim."""
+
+    return {
+        "schema_name": "epic_run_context_budget_pilot_replay",
+        "schema_version": 1,
+        "source_epic_issue": 3229,
+        "slice_issue_numbers": [3701, 3707, 3710],
+        "observed_slice_routes": ["inline", "inline", "inline"],
+        "implementation_worker_starts": 0,
+        "coordinator_model_tier": "sol",
+        "long_lived_coordinator_cheapest": UNKNOWN,
+        "claim": "observation_not_cost_proof",
+    }
+
+
+def _normalize_policy(policy: Mapping[str, Any]) -> dict[str, Any]:
+    normalized = _json_object(policy, "policy")
+    expected = {
+        "schema_version",
+        "rotate_on_high_context_pressure",
+        "thin_worker_when_isolated",
+    }
+    if set(normalized) != expected:
+        raise EpicRunContextBudgetError(
+            f"policy fields must be exactly {sorted(expected)}"
+        )
+    if normalized["schema_version"] != POLICY_SCHEMA_VERSION:
+        raise EpicRunContextBudgetError("unsupported policy schema_version")
+    for field in ("rotate_on_high_context_pressure", "thin_worker_when_isolated"):
+        if not isinstance(normalized[field], bool):
+            raise EpicRunContextBudgetError(f"policy.{field} must be boolean")
+    return normalized
+
+
+def _normalize_measurement(
+    measurement: Mapping[str, Any],
+    field: str,
+    *,
+    expected_unit: str | None = None,
+) -> dict[str, Any]:
+    normalized = _json_object(measurement, field)
+    if set(normalized) != {"value", "unit", "source"}:
+        raise EpicRunContextBudgetError(
+            f"{field} fields must be exactly value, unit, source"
+        )
+    value = normalized["value"]
+    if value != UNKNOWN and (isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0):
+        raise EpicRunContextBudgetError(f"{field}.value must be non-negative or unknown")
+    normalized["source"] = _required_string(normalized["source"], f"{field}.source")
+    normalized["unit"] = _required_string(normalized["unit"], f"{field}.unit")
+    if expected_unit is not None and normalized["unit"] != expected_unit:
+        raise EpicRunContextBudgetError(f"{field}.unit must be {expected_unit}")
+    return normalized
+
+
+def _normalize_uncertainty(value: Mapping[str, Any]) -> dict[str, Any]:
+    normalized = _json_object(value, "uncertainty")
+    if set(normalized) != {"level", "reasons"}:
+        raise EpicRunContextBudgetError("uncertainty fields must be level and reasons")
+    normalized["level"] = _enum(
+        normalized["level"],
+        UNCERTAINTY_LEVELS,
+        "uncertainty.level",
+    )
+    normalized["reasons"] = [
+        _required_string(item, f"uncertainty.reasons[{index}]")
+        for index, item in enumerate(_json_list(normalized["reasons"], "uncertainty.reasons"))
+    ]
+    return normalized
+
+
+def _normalize_next_slice(value: Mapping[str, Any]) -> dict[str, bool]:
+    normalized = _json_object(value, "next_slice")
+    expected = {
+        "contract_complete",
+        "isolated_filescope",
+        "deterministic_verification",
+    }
+    if set(normalized) != expected:
+        raise EpicRunContextBudgetError(
+            f"next_slice fields must be exactly {sorted(expected)}"
+        )
+    for field in expected:
+        if not isinstance(normalized[field], bool):
+            raise EpicRunContextBudgetError(f"next_slice.{field} must be boolean")
+    return {field: normalized[field] for field in sorted(expected)}
+
+
+def _normalize_repairs(value: Mapping[str, int]) -> dict[str, int]:
+    normalized = _json_object(value, "repairs")
+    expected = {"implementation", "ci", "review"}
+    if set(normalized) != expected:
+        raise EpicRunContextBudgetError(f"repairs fields must be exactly {sorted(expected)}")
+    for field in expected:
+        count = normalized[field]
+        if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+            raise EpicRunContextBudgetError(f"repairs.{field} must be non-negative")
+    return {field: normalized[field] for field in sorted(expected)}
+
+
+def _recommend_model_tier(
+    uncertainty: Mapping[str, Any],
+    next_slice: Mapping[str, bool],
+) -> str:
+    if uncertainty["level"] in {"high", UNKNOWN}:
+        return "sol"
+    if uncertainty["level"] == "low" and all(next_slice.values()):
+        return "luna"
+    return "terra"
+
+
+def _build_cost_observation(
+    inputs: Mapping[str, Any],
+    *,
+    accepted_slice_count: int | None,
+) -> dict[str, Any]:
+    raw = _json_object(inputs, "cost_inputs")
+    unknown_fields = sorted(set(raw) - set(COST_INPUT_FIELDS))
+    if unknown_fields:
+        raise EpicRunContextBudgetError(f"unknown cost input field(s): {unknown_fields}")
+
+    normalized_inputs: dict[str, dict[str, Any]] = {}
+    for field in COST_INPUT_FIELDS:
+        if field not in raw:
+            normalized_inputs[field] = {"value": UNKNOWN, "source": "unavailable"}
+            continue
+        measurement = _json_object(raw[field], f"cost_inputs.{field}")
+        if set(measurement) != {"value", "source"}:
+            raise EpicRunContextBudgetError(
+                f"cost_inputs.{field} fields must be value and source"
+            )
+        value = measurement["value"]
+        if value != UNKNOWN and (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or value < 0
+        ):
+            raise EpicRunContextBudgetError(
+                f"cost_inputs.{field}.value must be non-negative or unknown"
+            )
+        normalized_inputs[field] = {
+            "value": value,
+            "source": _required_string(
+                measurement["source"],
+                f"cost_inputs.{field}.source",
+            ),
+        }
+
+    if accepted_slice_count is None:
+        denominator: dict[str, Any] = {"value": UNKNOWN, "source": "unavailable"}
+    else:
+        if isinstance(accepted_slice_count, bool) or accepted_slice_count <= 0:
+            raise EpicRunContextBudgetError(
+                "accepted_slice_count must be positive or unknown"
+            )
+        denominator = {"value": accepted_slice_count, "source": "caller"}
+
+    known_monetary = [
+        normalized_inputs[field]["value"]
+        for field in MONETARY_COST_FIELDS
+        if normalized_inputs[field]["value"] != UNKNOWN
+    ]
+    per_accepted: float | str = UNKNOWN
+    if denominator["value"] != UNKNOWN and known_monetary:
+        per_accepted = sum(known_monetary) / denominator["value"]
+
+    completeness = (
+        "complete"
+        if denominator["value"] != UNKNOWN
+        and all(item["value"] != UNKNOWN for item in normalized_inputs.values())
+        else "partial"
+    )
+    return {
+        "accepted_slice_count": denominator,
+        "inputs": normalized_inputs,
+        "known_monetary_cost_per_accepted_slice_usd": per_accepted,
+        "completeness": completeness,
+        "human_minutes_are_not_monetized": True,
+    }
+
+
+def _enum(value: Any, allowed: set[str], field: str) -> str:
+    if not isinstance(value, str) or value not in allowed:
+        raise EpicRunContextBudgetError(f"{field} must be one of {sorted(allowed)}")
+    return value
+
+
+def _required_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise EpicRunContextBudgetError(f"{field} must be a non-empty string")
+    return value.strip()
+
+
+def _json_object(value: Mapping[str, Any], field: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise EpicRunContextBudgetError(f"{field} must be an object")
+    return json.loads(json.dumps(dict(value), sort_keys=True))
+
+
+def _json_list(value: list[Any], field: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise EpicRunContextBudgetError(f"{field} must be a list")
+    return json.loads(json.dumps(value, sort_keys=True))

--- a/app/builderops/epic_run_context_budget.py
+++ b/app/builderops/epic_run_context_budget.py
@@ -177,16 +177,91 @@ def normalize_context_budget_receipt(receipt: Mapping[str, Any]) -> dict[str, An
     """Validate a receipt before it enters dispatcher-backed epic run-state."""
 
     normalized = _json_object(receipt, "context_budget_receipt")
+    expected_top_level = {
+        "schema_name",
+        "schema_version",
+        "mode",
+        "slice_id",
+        "measurements",
+        "signals",
+        "policy",
+        "checkpoint",
+        "recommendations",
+        "recommendation_reasons",
+        "cost_per_accepted_slice",
+        "effects",
+        "gate_invariants",
+    }
+    if set(normalized) != expected_top_level:
+        raise EpicRunContextBudgetError(
+            "context-budget receipt fields must be exactly "
+            f"{sorted(expected_top_level)}"
+        )
     if normalized.get("schema_name") != RECEIPT_SCHEMA_NAME:
         raise EpicRunContextBudgetError("unsupported context-budget receipt schema_name")
     if normalized.get("schema_version") != RECEIPT_SCHEMA_VERSION:
         raise EpicRunContextBudgetError("unsupported context-budget receipt schema_version")
     if normalized.get("mode") != "advisory_shadow":
         raise EpicRunContextBudgetError("context-budget receipt must be advisory_shadow")
+    normalized["slice_id"] = _required_string(normalized["slice_id"], "slice_id")
 
-    recommendations = normalized.get("recommendations")
-    if not isinstance(recommendations, dict):
-        raise EpicRunContextBudgetError("recommendations must be an object")
+    measurements = _json_object(normalized["measurements"], "measurements")
+    if set(measurements) != {"context"}:
+        raise EpicRunContextBudgetError("measurements must contain exactly context")
+    normalized_context = _normalize_measurement(
+        measurements["context"],
+        "measurements.context",
+        expected_unit="tokens",
+    )
+    normalized["measurements"] = {"context": normalized_context}
+
+    signals = _json_object(normalized["signals"], "signals")
+    if set(signals) != {
+        "context_pressure",
+        "completed_slices_since_checkpoint",
+        "repairs",
+        "uncertainty",
+    }:
+        raise EpicRunContextBudgetError(
+            "signals fields must be context_pressure, "
+            "completed_slices_since_checkpoint, repairs, and uncertainty"
+        )
+    pressure = _enum(
+        signals["context_pressure"],
+        CONTEXT_PRESSURES,
+        "signals.context_pressure",
+    )
+    if normalized_context["value"] == UNKNOWN and pressure != UNKNOWN:
+        raise EpicRunContextBudgetError(
+            "unknown context measurement requires unknown context_pressure"
+        )
+    completed_slices = signals["completed_slices_since_checkpoint"]
+    if (
+        isinstance(completed_slices, bool)
+        or not isinstance(completed_slices, int)
+        or completed_slices < 0
+    ):
+        raise EpicRunContextBudgetError(
+            "signals.completed_slices_since_checkpoint must be a non-negative integer"
+        )
+    normalized["signals"] = {
+        "context_pressure": pressure,
+        "completed_slices_since_checkpoint": completed_slices,
+        "repairs": _normalize_repairs(signals["repairs"]),
+        "uncertainty": _normalize_uncertainty(signals["uncertainty"]),
+    }
+    normalized["policy"] = _normalize_policy(normalized["policy"])
+
+    recommendations = _json_object(normalized["recommendations"], "recommendations")
+    if set(recommendations) != {
+        "coordinator_lifecycle",
+        "slice_execution",
+        "model_tier",
+    }:
+        raise EpicRunContextBudgetError(
+            "recommendations fields must be coordinator_lifecycle, "
+            "slice_execution, and model_tier"
+        )
     if recommendations.get("coordinator_lifecycle") not in {
         "keep",
         "checkpoint_rotate",
@@ -196,6 +271,18 @@ def normalize_context_budget_receipt(receipt: Mapping[str, Any]) -> dict[str, An
         raise EpicRunContextBudgetError("invalid slice execution recommendation")
     if recommendations.get("model_tier") not in {"luna", "terra", "sol"}:
         raise EpicRunContextBudgetError("invalid model tier recommendation")
+    normalized["recommendations"] = recommendations
+    normalized["recommendation_reasons"] = [
+        _required_string(item, f"recommendation_reasons[{index}]")
+        for index, item in enumerate(
+            _json_list(normalized["recommendation_reasons"], "recommendation_reasons")
+        )
+    ]
+
+    normalized["checkpoint"] = _normalize_checkpoint(normalized["checkpoint"])
+    normalized["cost_per_accepted_slice"] = _normalize_cost_observation(
+        normalized["cost_per_accepted_slice"]
+    )
 
     expected_effects: dict[str, list[Any]] = {
         "dispatch_mutations": [],
@@ -207,6 +294,19 @@ def normalize_context_budget_receipt(receipt: Mapping[str, Any]) -> dict[str, An
     }
     if normalized.get("effects") != expected_effects:
         raise EpicRunContextBudgetError("advisory receipt cannot carry mutations")
+    normalized["effects"] = expected_effects
+
+    expected_gate_invariants = {
+        "ci": "unchanged_required",
+        "independent_review": "unchanged_required",
+        "merge": "unchanged_required",
+        "closure": "unchanged_required",
+    }
+    if normalized.get("gate_invariants") != expected_gate_invariants:
+        raise EpicRunContextBudgetError(
+            "context-budget receipt cannot weaken or replace gate invariants"
+        )
+    normalized["gate_invariants"] = expected_gate_invariants
     return normalized
 
 
@@ -322,6 +422,118 @@ def _recommend_model_tier(
     return "terra"
 
 
+def _normalize_checkpoint(value: Mapping[str, Any]) -> dict[str, Any]:
+    checkpoint = _json_object(value, "checkpoint")
+    if set(checkpoint) != {
+        "slice_status",
+        "decision_log_delta",
+        "open_review_findings",
+        "external_state",
+    }:
+        raise EpicRunContextBudgetError(
+            "checkpoint fields must be slice_status, decision_log_delta, "
+            "open_review_findings, and external_state"
+        )
+    external_state = _json_object(
+        checkpoint["external_state"],
+        "checkpoint.external_state",
+    )
+    if set(external_state) != {
+        "marker",
+        "previous_marker",
+        "changed",
+        "refresh_required",
+    }:
+        raise EpicRunContextBudgetError(
+            "checkpoint.external_state fields must be marker, previous_marker, "
+            "changed, and refresh_required"
+        )
+    marker = _json_object(external_state["marker"], "checkpoint.external_state.marker")
+    previous_raw = external_state["previous_marker"]
+    previous = (
+        None
+        if previous_raw is None
+        else _json_object(previous_raw, "checkpoint.external_state.previous_marker")
+    )
+    expected_changed = previous is not None and marker != previous
+    if external_state["changed"] is not expected_changed:
+        raise EpicRunContextBudgetError(
+            "checkpoint.external_state.changed does not match the markers"
+        )
+    if external_state["refresh_required"] is not expected_changed:
+        raise EpicRunContextBudgetError(
+            "changed external state must require refresh, and unchanged state must not"
+        )
+    return {
+        "slice_status": _required_string(checkpoint["slice_status"], "checkpoint.slice_status"),
+        "decision_log_delta": _json_list(
+            checkpoint["decision_log_delta"],
+            "checkpoint.decision_log_delta",
+        ),
+        "open_review_findings": _json_list(
+            checkpoint["open_review_findings"],
+            "checkpoint.open_review_findings",
+        ),
+        "external_state": {
+            "marker": marker,
+            "previous_marker": previous,
+            "changed": expected_changed,
+            "refresh_required": expected_changed,
+        },
+    }
+
+
+def _normalize_cost_observation(value: Mapping[str, Any]) -> dict[str, Any]:
+    observation = _json_object(value, "cost_per_accepted_slice")
+    if set(observation) != {
+        "accepted_slice_count",
+        "inputs",
+        "known_monetary_cost_per_accepted_slice_usd",
+        "completeness",
+        "human_minutes_are_not_monetized",
+    }:
+        raise EpicRunContextBudgetError(
+            "cost_per_accepted_slice has missing or unknown fields"
+        )
+    denominator = _json_object(
+        observation["accepted_slice_count"],
+        "cost_per_accepted_slice.accepted_slice_count",
+    )
+    if set(denominator) != {"value", "source"}:
+        raise EpicRunContextBudgetError(
+            "accepted_slice_count fields must be value and source"
+        )
+    denominator_value = denominator["value"]
+    if denominator_value == UNKNOWN:
+        accepted_slice_count = None
+        expected_source = "unavailable"
+    else:
+        if (
+            isinstance(denominator_value, bool)
+            or not isinstance(denominator_value, int)
+            or denominator_value < 0
+        ):
+            raise EpicRunContextBudgetError(
+                "accepted_slice_count must be a non-negative integer or unknown"
+            )
+        accepted_slice_count = denominator_value
+        expected_source = "caller"
+    if denominator.get("source") != expected_source:
+        raise EpicRunContextBudgetError(
+            f"accepted_slice_count source must be {expected_source}"
+        )
+
+    expected = _build_cost_observation(
+        _json_object(observation["inputs"], "cost_per_accepted_slice.inputs"),
+        accepted_slice_count=accepted_slice_count,
+    )
+    if observation != expected:
+        raise EpicRunContextBudgetError(
+            "cost_per_accepted_slice derived values or completeness are inconsistent"
+        )
+    return expected
+
+
 def _build_cost_observation(
     inputs: Mapping[str, Any],
     *,
@@ -362,9 +574,13 @@ def _build_cost_observation(
     if accepted_slice_count is None:
         denominator: dict[str, Any] = {"value": UNKNOWN, "source": "unavailable"}
     else:
-        if isinstance(accepted_slice_count, bool) or accepted_slice_count <= 0:
+        if (
+            isinstance(accepted_slice_count, bool)
+            or not isinstance(accepted_slice_count, int)
+            or accepted_slice_count < 0
+        ):
             raise EpicRunContextBudgetError(
-                "accepted_slice_count must be positive or unknown"
+                "accepted_slice_count must be a non-negative integer or unknown"
             )
         denominator = {"value": accepted_slice_count, "source": "caller"}
 
@@ -374,7 +590,11 @@ def _build_cost_observation(
         if normalized_inputs[field]["value"] != UNKNOWN
     ]
     per_accepted: float | str = UNKNOWN
-    if denominator["value"] != UNKNOWN and known_monetary:
+    if (
+        denominator["value"] != UNKNOWN
+        and denominator["value"] > 0
+        and known_monetary
+    ):
         per_accepted = sum(known_monetary) / denominator["value"]
 
     completeness = (

--- a/app/builderops/epic_run_context_budget.py
+++ b/app/builderops/epic_run_context_budget.py
@@ -18,6 +18,16 @@ MONETARY_COST_FIELDS = (
     "tool_cost_usd",
     "wait_cost_usd",
 )
+INTEGER_COST_FIELDS = (
+    "model_input_tokens",
+    "model_output_tokens",
+    "failed_attempts",
+    "implementation_repairs",
+    "ci_repairs",
+    "review_repairs",
+    "handoffs",
+    "worker_starts",
+)
 COST_INPUT_FIELDS = (
     *MONETARY_COST_FIELDS,
     "model_input_tokens",
@@ -72,8 +82,7 @@ def evaluate_slice_boundary_context_budget(
     if normalized_context["value"] == UNKNOWN:
         normalized_pressure = UNKNOWN
     if (
-        isinstance(completed_slices_since_checkpoint, bool)
-        or not isinstance(completed_slices_since_checkpoint, int)
+        type(completed_slices_since_checkpoint) is not int
         or completed_slices_since_checkpoint < 0
     ):
         raise EpicRunContextBudgetError(
@@ -88,7 +97,10 @@ def evaluate_slice_boundary_context_budget(
         if previous_external_state_marker is None
         else _json_object(previous_external_state_marker, "previous_external_state_marker")
     )
-    external_state_changed = previous_marker is not None and marker != previous_marker
+    external_state_changed = previous_marker is not None and not _json_exact_equal(
+        marker,
+        previous_marker,
+    )
 
     recommendations, reasons = _build_recommendations_and_reasons(
         context_pressure=normalized_pressure,
@@ -152,6 +164,10 @@ def evaluate_slice_boundary_context_budget(
 def normalize_context_budget_receipt(receipt: Mapping[str, Any]) -> dict[str, Any]:
     """Validate a receipt before it enters dispatcher-backed epic run-state."""
 
+    if type(receipt.get("schema_version")) is not int:
+        raise EpicRunContextBudgetError(
+            "context-budget receipt schema_version must be an integer"
+        )
     normalized = _json_object(receipt, "context_budget_receipt")
     expected_top_level = {
         "schema_name",
@@ -176,7 +192,10 @@ def normalize_context_budget_receipt(receipt: Mapping[str, Any]) -> dict[str, An
         )
     if normalized.get("schema_name") != RECEIPT_SCHEMA_NAME:
         raise EpicRunContextBudgetError("unsupported context-budget receipt schema_name")
-    if normalized.get("schema_version") != RECEIPT_SCHEMA_VERSION:
+    if (
+        type(normalized.get("schema_version")) is not int
+        or normalized["schema_version"] != RECEIPT_SCHEMA_VERSION
+    ):
         raise EpicRunContextBudgetError("unsupported context-budget receipt schema_version")
     if normalized.get("mode") != "advisory_shadow":
         raise EpicRunContextBudgetError("context-budget receipt must be advisory_shadow")
@@ -214,8 +233,7 @@ def normalize_context_budget_receipt(receipt: Mapping[str, Any]) -> dict[str, An
         )
     completed_slices = signals["completed_slices_since_checkpoint"]
     if (
-        isinstance(completed_slices, bool)
-        or not isinstance(completed_slices, int)
+        type(completed_slices) is not int
         or completed_slices < 0
     ):
         raise EpicRunContextBudgetError(
@@ -286,7 +304,7 @@ def normalize_context_budget_receipt(receipt: Mapping[str, Any]) -> dict[str, An
         "review_mutations": [],
         "closure_mutations": [],
     }
-    if normalized.get("effects") != expected_effects:
+    if not _json_exact_equal(normalized.get("effects"), expected_effects):
         raise EpicRunContextBudgetError("advisory receipt cannot carry mutations")
     normalized["effects"] = expected_effects
 
@@ -296,7 +314,10 @@ def normalize_context_budget_receipt(receipt: Mapping[str, Any]) -> dict[str, An
         "merge": "unchanged_required",
         "closure": "unchanged_required",
     }
-    if normalized.get("gate_invariants") != expected_gate_invariants:
+    if not _json_exact_equal(
+        normalized.get("gate_invariants"),
+        expected_gate_invariants,
+    ):
         raise EpicRunContextBudgetError(
             "context-budget receipt cannot weaken or replace gate invariants"
         )
@@ -321,6 +342,8 @@ def build_3229_pilot_replay() -> dict[str, Any]:
 
 
 def _normalize_policy(policy: Mapping[str, Any]) -> dict[str, Any]:
+    if type(policy.get("schema_version")) is not int:
+        raise EpicRunContextBudgetError("policy.schema_version must be an integer")
     normalized = _json_object(policy, "policy")
     expected = {
         "schema_version",
@@ -331,7 +354,10 @@ def _normalize_policy(policy: Mapping[str, Any]) -> dict[str, Any]:
         raise EpicRunContextBudgetError(
             f"policy fields must be exactly {sorted(expected)}"
         )
-    if normalized["schema_version"] != POLICY_SCHEMA_VERSION:
+    if (
+        type(normalized["schema_version"]) is not int
+        or normalized["schema_version"] != POLICY_SCHEMA_VERSION
+    ):
         raise EpicRunContextBudgetError("unsupported policy schema_version")
     for field in ("rotate_on_high_context_pressure", "thin_worker_when_isolated"):
         if not isinstance(normalized[field], bool):
@@ -351,14 +377,9 @@ def _normalize_measurement(
             f"{field} fields must be exactly value, unit, source"
         )
     value = normalized["value"]
-    if value != UNKNOWN and (
-        isinstance(value, bool)
-        or not isinstance(value, (int, float))
-        or not _is_finite_number(value)
-        or value < 0
-    ):
+    if value != UNKNOWN and (type(value) is not int or value < 0):
         raise EpicRunContextBudgetError(
-            f"{field}.value must be finite, non-negative, or unknown"
+            f"{field}.value must be a non-negative integer or unknown"
         )
     normalized["source"] = _required_string(normalized["source"], f"{field}.source")
     normalized["unit"] = _required_string(normalized["unit"], f"{field}.unit")
@@ -407,7 +428,7 @@ def _normalize_repairs(value: Mapping[str, int]) -> dict[str, int]:
         raise EpicRunContextBudgetError(f"repairs fields must be exactly {sorted(expected)}")
     for field in expected:
         count = normalized[field]
-        if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+        if type(count) is not int or count < 0:
             raise EpicRunContextBudgetError(f"repairs.{field} must be non-negative")
     return {field: normalized[field] for field in sorted(expected)}
 
@@ -507,7 +528,7 @@ def _normalize_checkpoint(value: Mapping[str, Any]) -> dict[str, Any]:
         if previous_raw is None
         else _json_object(previous_raw, "checkpoint.external_state.previous_marker")
     )
-    expected_changed = previous is not None and marker != previous
+    expected_changed = previous is not None and not _json_exact_equal(marker, previous)
     if external_state["changed"] is not expected_changed:
         raise EpicRunContextBudgetError(
             "checkpoint.external_state.changed does not match the markers"
@@ -561,8 +582,7 @@ def _normalize_cost_observation(value: Mapping[str, Any]) -> dict[str, Any]:
         expected_source = "unavailable"
     else:
         if (
-            isinstance(denominator_value, bool)
-            or not isinstance(denominator_value, int)
+            type(denominator_value) is not int
             or denominator_value < 0
         ):
             raise EpicRunContextBudgetError(
@@ -579,7 +599,7 @@ def _normalize_cost_observation(value: Mapping[str, Any]) -> dict[str, Any]:
         _json_object(observation["inputs"], "cost_per_accepted_slice.inputs"),
         accepted_slice_count=accepted_slice_count,
     )
-    if observation != expected:
+    if not _json_exact_equal(observation, expected):
         raise EpicRunContextBudgetError(
             "cost_per_accepted_slice derived values or completeness are inconsistent"
         )
@@ -607,12 +627,7 @@ def _build_cost_observation(
                 f"cost_inputs.{field} fields must be value and source"
             )
         value = measurement["value"]
-        if value != UNKNOWN and (
-            isinstance(value, bool)
-            or not isinstance(value, (int, float))
-            or not _is_finite_number(value)
-            or value < 0
-        ):
+        if value != UNKNOWN and not _valid_cost_value(field, value):
             raise EpicRunContextBudgetError(
                 f"cost_inputs.{field}.value must be finite, non-negative, or unknown"
             )
@@ -628,8 +643,7 @@ def _build_cost_observation(
         denominator: dict[str, Any] = {"value": UNKNOWN, "source": "unavailable"}
     else:
         if (
-            isinstance(accepted_slice_count, bool)
-            or not isinstance(accepted_slice_count, int)
+            type(accepted_slice_count) is not int
             or accepted_slice_count < 0
         ):
             raise EpicRunContextBudgetError(
@@ -692,6 +706,33 @@ def _is_finite_number(value: int | float) -> bool:
     if isinstance(value, int):
         return True
     return math.isfinite(value)
+
+
+def _valid_cost_value(field: str, value: Any) -> bool:
+    if field in INTEGER_COST_FIELDS:
+        return type(value) is int and value >= 0
+    return (
+        type(value) in {int, float}
+        and _is_finite_number(value)
+        and value >= 0
+    )
+
+
+def _json_exact_equal(left: Any, right: Any) -> bool:
+    """Compare JSON-shaped values without Python's bool/int coercion."""
+
+    if type(left) is not type(right):
+        return False
+    if isinstance(left, dict):
+        return left.keys() == right.keys() and all(
+            _json_exact_equal(left[key], right[key]) for key in left
+        )
+    if isinstance(left, list):
+        return len(left) == len(right) and all(
+            _json_exact_equal(left_item, right_item)
+            for left_item, right_item in zip(left, right, strict=True)
+        )
+    return left == right
 
 
 def _required_string(value: Any, field: str) -> str:

--- a/app/builderops/epic_run_state.py
+++ b/app/builderops/epic_run_state.py
@@ -213,7 +213,10 @@ def apply_epic_run_update(state: Mapping[str, Any], **updates: Any) -> dict[str,
 
     for field in _LIST_FIELDS:
         if field in updates and updates[field] is not None:
-            incoming = _normalize_list(updates[field], field)
+            if field == "context_budget_receipts":
+                incoming = _normalize_context_budget_receipts(updates[field], field)
+            else:
+                incoming = _normalize_list(updates[field], field)
             if field == "learning_evaluation_candidates":
                 normalized[field] = _merge_learning_evaluation_candidates(
                     normalized[field],
@@ -353,6 +356,11 @@ def normalize_epic_run_state(state: Mapping[str, Any]) -> dict[str, Any]:
                 raw.get(field, []),
                 field,
             )
+        elif field == "context_budget_receipts":
+            normalized[field] = _normalize_context_budget_receipts(
+                raw.get(field, []),
+                field,
+            )
         else:
             normalized[field] = _normalize_list(raw.get(field, []), field)
     for field in (*_MERGE_MAPPING_FIELDS, *_REPLACE_MAPPING_FIELDS):
@@ -395,6 +403,21 @@ def _normalize_learning_evaluation_candidates(
     return [
         _normalize_learning_evaluation_candidate(item, f"{field}[{index}]")
         for index, item in enumerate(items)
+    ]
+
+
+def _normalize_context_budget_receipts(
+    value: Any,
+    field: str,
+) -> list[dict[str, Any]]:
+    from app.builderops.epic_run_context_budget import (
+        normalize_context_budget_receipt,
+    )
+
+    items = _normalize_list(value, field)
+    return [
+        normalize_context_budget_receipt(item)
+        for item in items
     ]
 
 

--- a/app/builderops/epic_run_state.py
+++ b/app/builderops/epic_run_state.py
@@ -326,6 +326,8 @@ def normalize_epic_run_state(state: Mapping[str, Any]) -> dict[str, Any]:
 
     if not isinstance(state, Mapping):
         raise EpicRunStateError("run-state must be a JSON object")
+    if "schema_version" in state and type(state["schema_version"]) is not int:
+        raise EpicRunStateError("epic run-state schema_version must be an integer")
     raw = _json_clone(dict(state))
 
     unknown = sorted(set(raw) - set(_STATE_FIELDS))
@@ -333,7 +335,7 @@ def normalize_epic_run_state(state: Mapping[str, Any]) -> dict[str, Any]:
         raise EpicRunStateError(f"unknown run-state field(s): {unknown}")
 
     schema_version = raw.get("schema_version", SCHEMA_VERSION)
-    if schema_version != SCHEMA_VERSION:
+    if type(schema_version) is not int or schema_version != SCHEMA_VERSION:
         raise EpicRunStateError(
             f"unsupported epic run-state schema_version: {schema_version!r}"
         )

--- a/app/builderops/epic_run_state.py
+++ b/app/builderops/epic_run_state.py
@@ -38,6 +38,7 @@ _LIST_FIELDS = (
     "dispatch_decisions",
     "compact_receipts",
     "ci_handoffs",
+    "context_budget_receipts",
 )
 _MERGE_MAPPING_FIELDS = (
     "issue_mappings",
@@ -117,6 +118,7 @@ def new_epic_run_state(
         "dispatcher_status": {},
         "compact_receipts": [],
         "ci_handoffs": [],
+        "context_budget_receipts": [],
         "last_verified_head_sha": None,
     }
     if updates:
@@ -255,6 +257,22 @@ def record_dispatcher_status(
     """Record a dispatcher status snapshot without importing or changing dispatcher."""
 
     return apply_epic_run_update(state, dispatcher_status=dispatcher_status)
+
+
+def record_context_budget_receipt(
+    state: Mapping[str, Any],
+    receipt: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Record one validated observer-only slice-boundary receipt."""
+
+    from app.builderops.epic_run_context_budget import (
+        normalize_context_budget_receipt,
+    )
+
+    return apply_epic_run_update(
+        state,
+        context_budget_receipts=[normalize_context_budget_receipt(receipt)],
+    )
 
 
 def unresolved_learning_evaluation_candidates(

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -687,6 +687,21 @@ dispatcher and epic run-state remain operational coordination evidence only. Liv
 belong to the owning workflow skill (`issue-to-code`, `verification-and-closure`, or issue
 maintenance) and must use explicit commands with verification.
 
+### Epic-runner context-budget observation
+
+Dispatcher-backed epic run-state accepts a versioned v1 context-budget receipt at each slice
+boundary. The observer records an explicit token measurement or `unknown`, a checkpoint/digest
+containing slice status, decision delta, open review findings, and external-state marker, plus
+truthful cost inputs for accepted slices. Missing token, monetary, repair, handoff, worker-start, or
+human-minute evidence remains `unknown`; the receipt never estimates or fabricates it.
+
+The evaluator reports coordinator lifecycle (`keep` or `checkpoint_rotate`) separately from slice
+execution (`inline` or `thin_worker`) and retains the evidence needed to reconstruct both. These are
+strictly advisory shadow recommendations: the receipt cannot dispatch or spawn agents, mutate CI,
+review, acceptance, merge, or closure state, or weaken any quality gate. See
+[the Dispatcher And Routing Model](development/BUILDER_SYSTEM_PROCESS_MAP.md#5-dispatcher-and-routing-model)
+for the cross-system classification.
+
 When a PR is locally validated but GitHub Actions are still pending, coordinators may separate the
 implementation handoff from terminal closure with a CI-monitor handoff record:
 

--- a/docs/development/BUILDER_SYSTEM_PROCESS_MAP.md
+++ b/docs/development/BUILDER_SYSTEM_PROCESS_MAP.md
@@ -5,7 +5,7 @@ Owner: Builder System governance
 Temporal class: operational
 Review cadence: event-driven
 Source of truth: observed repo files and read-only GitHub command output cited inline
-Last reviewed: 2026-07-13
+Last reviewed: 2026-07-15
 
 # Builder System Process Map
 
@@ -215,6 +215,22 @@ Mechanism classification:
 | stale claims detection | deterministic + partial | Dispatcher TTL/heartbeat and reclaim semantics; GitHub-label-only fallback has weaker stale detection | [docs/AGENT_ISSUE_DISPATCHER.md:165-180], [tests/dispatcher/test_leases.py:194-222] |
 | failed work returns to queue | partially implemented | Dispatcher release/block; GitHub labels for blocked; no automated failed-work requeue from CI | [docs/AGENT_ISSUE_DISPATCHER.md:142-150], [`.codex/skills/issue-to-code/SKILL.md`:176-195] |
 | human exception removed from normal queue | deterministic in labels | `agent:needs-human` normally Backlog and not ready | [`.codex/skills/_shared/LABEL_TAXONOMY.md`:18-27] |
+| epic context-budget observation | deterministic + advisory | At slice boundaries, a versioned run-state receipt records explicit context measurement or `unknown`, checkpoint/digest data, cost inputs, and independent lifecycle/execution/model-tier recommendations. It performs no dispatch, spawn, acceptance, CI, review, merge, or closure mutation. | [`app/builderops/epic_run_context_budget.py`], [`tests/builderops/test_epic_run_context_budget.py`], [docs/AGENT_ISSUE_DISPATCHER.md :: Epic-runner context-budget observation] |
+
+The context-budget evaluator is measurement infrastructure, not a routing authority. Its
+`checkpoint_rotate` and `thin_worker` values are recommendations on separate axes: delegating a
+slice does not clear coordinator context, and refreshing changed external state does not alone force
+rotation. The receipt's policy is explicit and versioned, so the three-slice #3229 pilot remains a
+replayable observation (three inline routes, zero implementation-worker starts, long-lived Sol
+coordinator) rather than evidence that Sol or any fixed threshold was cheapest. Missing context,
+token, cost, or human-minute measurements remain `unknown`; available inputs may be reported without
+inventing the rest or fabricating an accepted-slice denominator.
+
+Authority is unchanged. The evaluator's effect lists are empty and its gate invariants retain CI,
+independent review, merge, and closure as separate required surfaces. It neither rotates/compresses a
+coordinator nor starts workers or parallel execution. Dispatcher lease state, live GitHub Issue/PR
+truth, exact branch/SHA, CI, and review state must still be refreshed and acted on through their
+existing owning workflows.
 
 ```mermaid
 flowchart TD

--- a/docs/development/BUILDER_SYSTEM_PROCESS_MAP.md
+++ b/docs/development/BUILDER_SYSTEM_PROCESS_MAP.md
@@ -220,7 +220,10 @@ Mechanism classification:
 The context-budget evaluator is measurement infrastructure, not a routing authority. Its
 `checkpoint_rotate` and `thin_worker` values are recommendations on separate axes: delegating a
 slice does not clear coordinator context, and refreshing changed external state does not alone force
-rotation. The receipt's policy is explicit and versioned, so the three-slice #3229 pilot remains a
+rotation. Persisted worker-isolation, setup-cost, merge-risk, policy, uncertainty, and external-state
+evidence deterministically reconstructs lifecycle, execution, model-tier, and reason fields during
+every generic run-state update or load. The receipt's policy is explicit and versioned, so the
+three-slice #3229 pilot remains a
 replayable observation (three inline routes, zero implementation-worker starts, long-lived Sol
 coordinator) rather than evidence that Sol or any fixed threshold was cheapest. Missing context,
 token, cost, or human-minute measurements remain `unknown`; available inputs may be reported without

--- a/tests/builderops/test_epic_run_context_budget.py
+++ b/tests/builderops/test_epic_run_context_budget.py
@@ -1,14 +1,21 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from pathlib import Path
 
+import pytest
+
 from app.builderops.epic_run_context_budget import (
+    EpicRunContextBudgetError,
     build_3229_pilot_replay,
     evaluate_slice_boundary_context_budget,
 )
 from app.builderops.epic_run_state import (
+    apply_epic_run_update,
     create_epic_run_state,
     load_epic_run_state,
+    new_epic_run_state,
+    normalize_epic_run_state,
     record_context_budget_receipt,
     save_epic_run_state,
 )
@@ -182,3 +189,85 @@ def test_cost_per_accepted_slice_includes_repairs_handoffs_and_unknowns() -> Non
         ["known_monetary_cost_per_accepted_slice_usd"]
         == "unknown"
     )
+
+
+@pytest.mark.parametrize(
+    "malformation",
+    [
+        "accepted_authority",
+        "dispatch_effect",
+        "bypassed_gate",
+        "missing_measurement",
+        "extra_measurement_field",
+        "missing_signal",
+        "extra_policy_field",
+        "invalid_recommendation",
+        "missing_checkpoint_field",
+        "fractional_accepted_count",
+        "unknown_context_with_low_pressure",
+    ],
+)
+def test_malformed_or_authority_bearing_receipts_cannot_persist(
+    malformation: str,
+) -> None:
+    receipt = deepcopy(_evaluate())
+    if malformation == "accepted_authority":
+        receipt["accepted"] = True
+    elif malformation == "dispatch_effect":
+        receipt["effects"]["dispatch_mutations"] = [{"action": "start"}]
+    elif malformation == "bypassed_gate":
+        receipt["gate_invariants"]["ci"] = "bypassed"
+    elif malformation == "missing_measurement":
+        del receipt["measurements"]["context"]
+    elif malformation == "extra_measurement_field":
+        receipt["measurements"]["context"]["confidence"] = "guessed"
+    elif malformation == "missing_signal":
+        del receipt["signals"]["repairs"]
+    elif malformation == "extra_policy_field":
+        receipt["policy"]["universal_token_threshold"] = 1000
+    elif malformation == "invalid_recommendation":
+        receipt["recommendations"]["coordinator_lifecycle"] = "rotate_now"
+    elif malformation == "missing_checkpoint_field":
+        del receipt["checkpoint"]["open_review_findings"]
+    elif malformation == "fractional_accepted_count":
+        receipt["cost_per_accepted_slice"]["accepted_slice_count"] = {
+            "value": 1.5,
+            "source": "caller",
+        }
+    elif malformation == "unknown_context_with_low_pressure":
+        receipt["measurements"]["context"] = {
+            "value": "unknown",
+            "unit": "tokens",
+            "source": "unavailable",
+        }
+        receipt["signals"]["context_pressure"] = "low"
+
+    state = new_epic_run_state(3229, f"reject-{malformation}")
+    with pytest.raises(EpicRunContextBudgetError):
+        apply_epic_run_update(state, context_budget_receipts=[receipt])
+
+    state_with_untrusted_receipt = dict(state)
+    state_with_untrusted_receipt["context_budget_receipts"] = [receipt]
+    with pytest.raises(EpicRunContextBudgetError):
+        normalize_epic_run_state(state_with_untrusted_receipt)
+
+
+@pytest.mark.parametrize("accepted_slice_count", [False, 1.5, -1])
+def test_evaluator_rejects_non_integer_or_negative_accepted_slice_denominator(
+    accepted_slice_count: object,
+) -> None:
+    with pytest.raises(EpicRunContextBudgetError):
+        _evaluate(accepted_slice_count=accepted_slice_count)
+
+
+def test_zero_accepted_slices_preserves_denominator_without_division() -> None:
+    receipt = _evaluate(
+        accepted_slice_count=0,
+        cost_inputs={
+            "model_cost_usd": {"value": 3.0, "source": "provider_receipt"}
+        },
+    )
+
+    cost = receipt["cost_per_accepted_slice"]
+    assert cost["accepted_slice_count"] == {"value": 0, "source": "caller"}
+    assert cost["known_monetary_cost_per_accepted_slice_usd"] == "unknown"

--- a/tests/builderops/test_epic_run_context_budget.py
+++ b/tests/builderops/test_epic_run_context_budget.py
@@ -9,6 +9,7 @@ from app.builderops.epic_run_context_budget import (
     EpicRunContextBudgetError,
     build_3229_pilot_replay,
     evaluate_slice_boundary_context_budget,
+    normalize_context_budget_receipt,
 )
 from app.builderops.epic_run_state import (
     apply_epic_run_update,
@@ -43,9 +44,9 @@ def _evaluate(**overrides: object) -> dict[str, object]:
         "repairs": {"implementation": 1, "ci": 0, "review": 0},
         "uncertainty": {"level": "medium", "reasons": ["first observation"]},
         "next_slice": {
-            "contract_complete": True,
-            "isolated_filescope": True,
-            "deterministic_verification": True,
+            "worker_isolated": True,
+            "setup_cost_high": False,
+            "merge_risk_low": True,
         },
         "policy": {
             "schema_version": 1,
@@ -71,14 +72,17 @@ def test_context_budget_round_trips_in_run_state(tmp_path: Path) -> None:
     assert loaded["dispatcher_status"] == {}
     assert loaded["validation_status"] == {}
     assert loaded["ci_handoffs"] == []
+    assert record_context_budget_receipt(loaded, receipt)["context_budget_receipts"] == [
+        receipt
+    ]
 
 
 def test_lifecycle_and_execution_decisions_are_independent() -> None:
     rotate_inline = _evaluate(
         next_slice={
-            "contract_complete": False,
-            "isolated_filescope": False,
-            "deterministic_verification": False,
+            "worker_isolated": False,
+            "setup_cost_high": True,
+            "merge_risk_low": False,
         }
     )
     keep_worker = _evaluate(context_pressure="low")
@@ -200,6 +204,7 @@ def test_cost_per_accepted_slice_includes_repairs_handoffs_and_unknowns() -> Non
         "missing_measurement",
         "extra_measurement_field",
         "missing_signal",
+        "missing_next_slice_input",
         "extra_policy_field",
         "invalid_recommendation",
         "missing_checkpoint_field",
@@ -223,6 +228,8 @@ def test_malformed_or_authority_bearing_receipts_cannot_persist(
         receipt["measurements"]["context"]["confidence"] = "guessed"
     elif malformation == "missing_signal":
         del receipt["signals"]["repairs"]
+    elif malformation == "missing_next_slice_input":
+        del receipt["next_slice"]["merge_risk_low"]
     elif malformation == "extra_policy_field":
         receipt["policy"]["universal_token_threshold"] = 1000
     elif malformation == "invalid_recommendation":
@@ -271,3 +278,90 @@ def test_zero_accepted_slices_preserves_denominator_without_division() -> None:
     cost = receipt["cost_per_accepted_slice"]
     assert cost["accepted_slice_count"] == {"value": 0, "source": "caller"}
     assert cost["known_monetary_cost_per_accepted_slice_usd"] == "unknown"
+
+
+def test_receipt_recommendations_are_reconstructed_from_persisted_evidence() -> None:
+    receipt = _evaluate(
+        context_pressure="low",
+        uncertainty={"level": "low", "reasons": []},
+    )
+    assert receipt["next_slice"] == {
+        "merge_risk_low": True,
+        "setup_cost_high": False,
+        "worker_isolated": True,
+    }
+    assert receipt["recommendations"] == {
+        "coordinator_lifecycle": "keep",
+        "slice_execution": "thin_worker",
+        "model_tier": "luna",
+    }
+
+    normalized = normalize_context_budget_receipt(receipt)
+    assert normalized == receipt
+    assert normalize_context_budget_receipt(normalized) == normalized
+
+    for field, contradiction in (
+        ("coordinator_lifecycle", "checkpoint_rotate"),
+        ("slice_execution", "inline"),
+        ("model_tier", "sol"),
+    ):
+        contradictory = deepcopy(receipt)
+        contradictory["recommendations"][field] = contradiction
+        state = new_epic_run_state(3229, f"contradict-{field}")
+        with pytest.raises(EpicRunContextBudgetError):
+            apply_epic_run_update(
+                state,
+                context_budget_receipts=[contradictory],
+            )
+        state["context_budget_receipts"] = [contradictory]
+        with pytest.raises(EpicRunContextBudgetError):
+            normalize_epic_run_state(state)
+
+    contradictory_reasons = deepcopy(receipt)
+    contradictory_reasons["recommendation_reasons"] = ["looks_cheaper"]
+    with pytest.raises(EpicRunContextBudgetError):
+        apply_epic_run_update(
+            new_epic_run_state(3229, "contradict-reasons"),
+            context_budget_receipts=[contradictory_reasons],
+        )
+
+
+@pytest.mark.parametrize("non_finite", [float("nan"), float("inf"), float("-inf")])
+@pytest.mark.parametrize("surface", ["context", "cost"])
+def test_non_finite_numbers_are_rejected_by_evaluator_and_persistence(
+    non_finite: float,
+    surface: str,
+) -> None:
+    if surface == "context":
+        evaluator_overrides = {
+            "context_measurement": {
+                "value": non_finite,
+                "unit": "tokens",
+                "source": "provider_usage",
+            }
+        }
+    else:
+        evaluator_overrides = {
+            "cost_inputs": {
+                "model_cost_usd": {
+                    "value": non_finite,
+                    "source": "provider_receipt",
+                }
+            }
+        }
+    with pytest.raises(EpicRunContextBudgetError):
+        _evaluate(**evaluator_overrides)
+
+    receipt = deepcopy(_evaluate())
+    if surface == "context":
+        receipt["measurements"]["context"]["value"] = non_finite
+    else:
+        receipt["cost_per_accepted_slice"]["inputs"]["model_cost_usd"][
+            "value"
+        ] = non_finite
+    state = new_epic_run_state(3229, f"non-finite-{surface}")
+    with pytest.raises(EpicRunContextBudgetError):
+        apply_epic_run_update(state, context_budget_receipts=[receipt])
+    state["context_budget_receipts"] = [receipt]
+    with pytest.raises(EpicRunContextBudgetError):
+        normalize_epic_run_state(state)

--- a/tests/builderops/test_epic_run_context_budget.py
+++ b/tests/builderops/test_epic_run_context_budget.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.builderops.epic_run_context_budget import (
+    build_3229_pilot_replay,
+    evaluate_slice_boundary_context_budget,
+)
+from app.builderops.epic_run_state import (
+    create_epic_run_state,
+    load_epic_run_state,
+    record_context_budget_receipt,
+    save_epic_run_state,
+)
+
+
+def _evaluate(**overrides: object) -> dict[str, object]:
+    inputs: dict[str, object] = {
+        "slice_id": "issue-3798",
+        "slice_status": "validated",
+        "decision_log_delta": ["keep evaluator observer-only"],
+        "open_review_findings": [],
+        "external_state_marker": {
+            "issue": "3798:open",
+            "head_sha": "abc123",
+            "ci": "green",
+            "review": "clean",
+        },
+        "context_measurement": {
+            "value": 72_000,
+            "unit": "tokens",
+            "source": "provider_usage",
+        },
+        "context_pressure": "high",
+        "completed_slices_since_checkpoint": 3,
+        "repairs": {"implementation": 1, "ci": 0, "review": 0},
+        "uncertainty": {"level": "medium", "reasons": ["first observation"]},
+        "next_slice": {
+            "contract_complete": True,
+            "isolated_filescope": True,
+            "deterministic_verification": True,
+        },
+        "policy": {
+            "schema_version": 1,
+            "rotate_on_high_context_pressure": True,
+            "thin_worker_when_isolated": True,
+        },
+        "cost_inputs": {},
+        "accepted_slice_count": None,
+    }
+    inputs.update(overrides)
+    return evaluate_slice_boundary_context_budget(**inputs)  # type: ignore[arg-type]
+
+
+def test_context_budget_round_trips_in_run_state(tmp_path: Path) -> None:
+    state = create_epic_run_state(3229, "measure-context", root=tmp_path)
+    receipt = _evaluate()
+    updated = record_context_budget_receipt(state, receipt)
+    save_epic_run_state(updated, root=tmp_path)
+
+    loaded = load_epic_run_state("measure-context", root=tmp_path)
+
+    assert loaded["context_budget_receipts"] == [receipt]
+    assert loaded["dispatcher_status"] == {}
+    assert loaded["validation_status"] == {}
+    assert loaded["ci_handoffs"] == []
+
+
+def test_lifecycle_and_execution_decisions_are_independent() -> None:
+    rotate_inline = _evaluate(
+        next_slice={
+            "contract_complete": False,
+            "isolated_filescope": False,
+            "deterministic_verification": False,
+        }
+    )
+    keep_worker = _evaluate(context_pressure="low")
+
+    assert rotate_inline["recommendations"]["coordinator_lifecycle"] == "checkpoint_rotate"
+    assert rotate_inline["recommendations"]["slice_execution"] == "inline"
+    assert keep_worker["recommendations"]["coordinator_lifecycle"] == "keep"
+    assert keep_worker["recommendations"]["slice_execution"] == "thin_worker"
+
+
+def test_unknown_context_measurement_does_not_mean_low_pressure() -> None:
+    receipt = _evaluate(
+        context_measurement={"value": "unknown", "unit": "tokens", "source": "unavailable"},
+        context_pressure="low",
+    )
+
+    assert receipt["measurements"]["context"]["value"] == "unknown"
+    assert receipt["measurements"]["context"]["source"] == "unavailable"
+    assert receipt["signals"]["context_pressure"] == "unknown"
+    assert receipt["signals"]["completed_slices_since_checkpoint"] == 3
+    assert "low_context_pressure" not in receipt["recommendation_reasons"]
+    assert "context_measurement_unknown" in receipt["recommendation_reasons"]
+
+
+def test_3229_pilot_replay_preserves_observed_routes() -> None:
+    replay = build_3229_pilot_replay()
+
+    assert replay["slice_issue_numbers"] == [3701, 3707, 3710]
+    assert replay["observed_slice_routes"] == ["inline", "inline", "inline"]
+    assert replay["implementation_worker_starts"] == 0
+    assert replay["coordinator_model_tier"] == "sol"
+    assert replay["long_lived_coordinator_cheapest"] == "unknown"
+    assert replay["claim"] == "observation_not_cost_proof"
+
+
+def test_slice_boundary_checkpoint_requires_refresh_not_unconditional_rotation() -> None:
+    receipt = _evaluate(
+        context_pressure="low",
+        previous_external_state_marker={
+            "issue": "3798:open",
+            "head_sha": "previous",
+            "ci": "pending",
+            "review": "open",
+        },
+    )
+
+    checkpoint = receipt["checkpoint"]
+    assert checkpoint["slice_status"] == "validated"
+    assert checkpoint["decision_log_delta"] == ["keep evaluator observer-only"]
+    assert checkpoint["open_review_findings"] == []
+    assert checkpoint["external_state"]["changed"] is True
+    assert checkpoint["external_state"]["refresh_required"] is True
+    assert receipt["recommendations"]["coordinator_lifecycle"] == "keep"
+
+
+def test_context_routing_cannot_bypass_acceptance_gates() -> None:
+    receipt = _evaluate()
+
+    assert receipt["mode"] == "advisory_shadow"
+    assert receipt["effects"] == {
+        "dispatch_mutations": [],
+        "agent_spawns": [],
+        "acceptance_mutations": [],
+        "ci_mutations": [],
+        "review_mutations": [],
+        "closure_mutations": [],
+    }
+    assert receipt["gate_invariants"] == {
+        "ci": "unchanged_required",
+        "independent_review": "unchanged_required",
+        "merge": "unchanged_required",
+        "closure": "unchanged_required",
+    }
+
+
+def test_cost_per_accepted_slice_includes_repairs_handoffs_and_unknowns() -> None:
+    receipt = _evaluate(
+        cost_inputs={
+            "model_cost_usd": {"value": 3.0, "source": "provider_receipt"},
+            "tool_cost_usd": {"value": "unknown", "source": "unavailable"},
+            "wait_minutes": {"value": 12, "source": "ci_handoff"},
+            "failed_attempts": {"value": 2, "source": "run_receipts"},
+            "implementation_repairs": {"value": 1, "source": "run_receipts"},
+            "ci_repairs": {"value": 1, "source": "ci_receipts"},
+            "review_repairs": {"value": 2, "source": "review_receipts"},
+            "handoffs": {"value": 1, "source": "dispatch_receipts"},
+            "worker_starts": {"value": 0, "source": "dispatch_receipts"},
+            "human_minutes": {"value": "unknown", "source": "unavailable"},
+        },
+        accepted_slice_count=2,
+    )
+
+    cost = receipt["cost_per_accepted_slice"]
+    assert cost["inputs"]["model_cost_usd"]["value"] == 3.0
+    assert cost["inputs"]["tool_cost_usd"]["value"] == "unknown"
+    assert cost["inputs"]["human_minutes"]["value"] == "unknown"
+    assert cost["inputs"]["review_repairs"]["value"] == 2
+    assert cost["inputs"]["handoffs"]["value"] == 1
+    assert cost["inputs"]["worker_starts"]["value"] == 0
+    assert cost["accepted_slice_count"] == {"value": 2, "source": "caller"}
+    assert cost["known_monetary_cost_per_accepted_slice_usd"] == 1.5
+    assert cost["completeness"] == "partial"
+
+    without_denominator = _evaluate(cost_inputs={}, accepted_slice_count=None)
+    assert without_denominator["cost_per_accepted_slice"]["accepted_slice_count"]["value"] == "unknown"
+    assert (
+        without_denominator["cost_per_accepted_slice"]
+        ["known_monetary_cost_per_accepted_slice_usd"]
+        == "unknown"
+    )

--- a/tests/builderops/test_epic_run_context_budget.py
+++ b/tests/builderops/test_epic_run_context_budget.py
@@ -12,6 +12,7 @@ from app.builderops.epic_run_context_budget import (
     normalize_context_budget_receipt,
 )
 from app.builderops.epic_run_state import (
+    EpicRunStateError,
     apply_epic_run_update,
     create_epic_run_state,
     load_epic_run_state,
@@ -60,6 +61,20 @@ def _evaluate(**overrides: object) -> dict[str, object]:
     return evaluate_slice_boundary_context_budget(**inputs)  # type: ignore[arg-type]
 
 
+def _assert_receipt_rejected_on_update_and_load(
+    receipt: dict[str, object],
+    *,
+    run_id: str,
+) -> None:
+    state = new_epic_run_state(3229, run_id)
+    with pytest.raises(EpicRunContextBudgetError):
+        apply_epic_run_update(state, context_budget_receipts=[receipt])
+
+    state["context_budget_receipts"] = [receipt]
+    with pytest.raises(EpicRunContextBudgetError):
+        normalize_epic_run_state(state)
+
+
 def test_context_budget_round_trips_in_run_state(tmp_path: Path) -> None:
     state = create_epic_run_state(3229, "measure-context", root=tmp_path)
     receipt = _evaluate()
@@ -75,6 +90,112 @@ def test_context_budget_round_trips_in_run_state(tmp_path: Path) -> None:
     assert record_context_budget_receipt(loaded, receipt)["context_budget_receipts"] == [
         receipt
     ]
+
+
+@pytest.mark.parametrize("invalid_version", [True, 1.0])
+@pytest.mark.parametrize("surface", ["receipt", "policy", "run_state"])
+def test_schema_versions_require_exact_builtin_integers(
+    invalid_version: object,
+    surface: str,
+) -> None:
+    if surface == "run_state":
+        state = new_epic_run_state(3229, "strict-state-version")
+        state["schema_version"] = invalid_version
+        with pytest.raises(EpicRunStateError, match="schema_version must be an integer"):
+            normalize_epic_run_state(state)
+        return
+
+    receipt = deepcopy(_evaluate())
+    if surface == "receipt":
+        receipt["schema_version"] = invalid_version
+    else:
+        receipt["policy"]["schema_version"] = invalid_version
+        with pytest.raises(EpicRunContextBudgetError):
+            _evaluate(policy=receipt["policy"])
+    _assert_receipt_rejected_on_update_and_load(
+        receipt,
+        run_id=f"strict-{surface}-{type(invalid_version).__name__}",
+    )
+
+
+@pytest.mark.parametrize(
+    ("surface", "invalid_value"),
+    [
+        ("context", True),
+        ("context", 72_000.0),
+        ("accepted_slice_count", True),
+        ("accepted_slice_count", 1.0),
+        ("model_input_tokens", True),
+        ("model_input_tokens", 1.0),
+        ("failed_attempts", True),
+        ("failed_attempts", 1.0),
+    ],
+)
+def test_integer_measurements_reject_bool_and_float_substitution(
+    surface: str,
+    invalid_value: object,
+) -> None:
+    if surface == "context":
+        overrides = {
+            "context_measurement": {
+                "value": invalid_value,
+                "unit": "tokens",
+                "source": "provider_usage",
+            }
+        }
+    elif surface == "accepted_slice_count":
+        overrides = {"accepted_slice_count": invalid_value}
+    else:
+        overrides = {
+            "cost_inputs": {
+                surface: {"value": invalid_value, "source": "run_receipts"}
+            }
+        }
+    with pytest.raises(EpicRunContextBudgetError):
+        _evaluate(**overrides)
+
+
+@pytest.mark.parametrize(
+    ("field", "invalid_value"),
+    [
+        ("human_minutes_are_not_monetized", 1),
+        ("known_monetary_cost_per_accepted_slice_usd", False),
+        ("known_monetary_cost_per_accepted_slice_usd", 0),
+    ],
+)
+def test_derived_cost_values_require_exact_types_on_update_and_load(
+    field: str,
+    invalid_value: object,
+) -> None:
+    receipt = deepcopy(
+        _evaluate(
+            cost_inputs={
+                "model_cost_usd": {"value": 0.0, "source": "provider_receipt"}
+            },
+            accepted_slice_count=1,
+        )
+    )
+    receipt["cost_per_accepted_slice"][field] = invalid_value
+    _assert_receipt_rejected_on_update_and_load(
+        receipt,
+        run_id=f"strict-derived-{field}-{type(invalid_value).__name__}",
+    )
+
+
+def test_cost_numeric_types_round_trip_and_normalize_idempotently() -> None:
+    receipt = _evaluate(
+        cost_inputs={
+            "model_cost_usd": {"value": 2, "source": "provider_receipt"},
+            "tool_minutes": {"value": 1.5, "source": "tool_receipt"},
+            "model_input_tokens": {"value": 100, "source": "provider_usage"},
+        },
+        accepted_slice_count=2,
+    )
+
+    normalized = normalize_context_budget_receipt(receipt)
+
+    assert normalized == receipt
+    assert normalize_context_budget_receipt(normalized) == normalized
 
 
 def test_lifecycle_and_execution_decisions_are_independent() -> None:


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Fixes #3798

Governing-Issue: #3798

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): none for Product/Runtime behavior
- Write class: governance/docs/process and local Builder System tooling
- Authority impact: adds advisory coordination evidence only; existing GitHub, dispatcher, CI, review, merge, and closure authority is unchanged
- Persistence impact: versioned, discardable local epic run-state receipts plus repo-governed code/tests/docs
- Derived/rebuildable impact: receipts/checkpoints are coordination evidence and never outrank live external truth
- Human knowledge impact: none
- Memory impact: none; Builder telemetry does not enter Product/runtime or user memory
- Retrieval/context impact: observes context pressure and records slice digests without rotating or compressing context
- Sync/deployment impact: none; dev/local Builder System tooling only
- External boundary impact: records caller-supplied external markers without new external reads or writes
- New or changed contract: advisory context-budget receipt, replayable orthogonal lifecycle/execution/model recommendations, slice checkpoint, and partial truthful cost observation
- Owner-doc impact: updated in this PR (`docs/AGENT_ISSUE_DISPATCHER.md`, `docs/development/BUILDER_SYSTEM_PROCESS_MAP.md`)
- Transition debt impact: reduces D12 measurement gaps and preserves D11 separation; no new debt row
- Fitness rule impact: focused no-bypass, evidence-integrity, and finite-JSON regression coverage; no universal threshold rule
- Boundary risk: low after validation; observer-only effect lists are empty and quality gates remain separate

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Adds a versioned `advisory_shadow` context-budget receipt to dispatcher-backed epic run-state.
- Evaluates coordinator lifecycle, slice execution, and model tier independently while preserving explicit `unknown`, checkpoint/digest evidence, and partial cost-per-accepted-slice inputs.
- Persists normalized worker-isolation, setup-cost, merge-risk, policy, uncertainty, and external-state evidence; generic update/load reconstructs and verifies every recommendation and reason.
- Rejects NaN and ±Infinity at evaluator and persistence boundaries so accepted output is canonical JSON and idempotently normalizable.
- Replays #3229 as three observed inline routes with zero implementation-worker starts without claiming long-lived Sol was cheapest.
- Carries no dispatch, agent-spawn, acceptance, CI, review, merge, or closure mutations.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [ ] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [x] No product/runtime implementation or shipped feature behavior changed.

## Acceptance Criteria
- [x] Run-state receipt round-trip and idempotency: `test_context_budget_round_trips_in_run_state`
- [x] Independent lifecycle/execution decisions: `test_lifecycle_and_execution_decisions_are_independent`
- [x] Explicit unknown context measurement: `test_unknown_context_measurement_does_not_mean_low_pressure`
- [x] #3229 replay truth: `test_3229_pilot_replay_preserves_observed_routes`
- [x] Slice checkpoint and refresh semantics: `test_slice_boundary_checkpoint_requires_refresh_not_unconditional_rotation`
- [x] No gate bypass or mutation: `test_context_routing_cannot_bypass_acceptance_gates`
- [x] Repairs/handoffs/unknown cost inputs: `test_cost_per_accepted_slice_includes_repairs_handoffs_and_unknowns`
- [x] Both required owner-doc anchors updated

## Validation
Implementation lane:
- [x] `ruff check app tests` — all checks passed at `23bbcf30`
- [x] If files under `app/` or `tests/` changed, lint output from `ruff check app tests` is included below or a tooling limitation is stated.
- [x] `mypy app` — success, 744 source files at `23bbcf30`
- [ ] `pytest -q -m "not pg"` — 8,988 passed, 114 skipped, 18 xfailed on prior head `c0e3fb8e`; current repair head is covered by GitHub `Unit tests (not pg)` rather than claiming the old local run for the new SHA
- [x] Additional targeted checks run as needed

Code-validation checks at `23bbcf30` (code unchanged by Round 4):
- `pytest -q tests/builderops/test_epic_run_context_budget.py` — 48 passed
- `pytest -q tests/builderops/test_epic_run_context_budget.py tests/builderops/test_epic_run_state.py tests/builderops/test_epic_dispatch.py tests/builderops/test_epic_lifecycle_plan.py tests/builderops/test_ci_handoff_state.py` — 112 passed
- `ruff check app tests` — all checks passed
- `mypy app` — success, 744 source files
- `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1 python3 scripts/docs_guard.py` — OK. Temporal skip is justified because this is builder-local observer telemetry with no high-risk temporal current-state doc change; both affected Builder System owner docs are updated in this PR.
- `git diff --check` — passed

The bare `python3 scripts/docs_guard.py` on the original head correctly rejected the temporal code/config change without a high-risk temporal doc. It is not represented as a passing command; the explicit scoped override above is the passing validation receipt for this Builder-only change.

## Current docs-only repair validation (`7df955c4`)
- Exact owner-doc anchor: `docs/AGENT_ISSUE_DISPATCHER.md :: Epic-runner context-budget observation` — present
- Exact process-map anchor/link: `docs/development/BUILDER_SYSTEM_PROCESS_MAP.md :: 5. Dispatcher And Routing Model` — present
- `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1 python3 scripts/docs_guard.py` — OK
- `git diff --check` — passed
- Code/tests were unchanged, so code tests were not rerun for this docs-only repair.

## Review Repair
- Round 1 (`87e95565`) made the full persisted shape strict and routed generic update/load through the canonical validator.
- Round 2 (`07565ec8`) persists the missing `next_slice` decision evidence, reconstructs lifecycle/execution/model/reasons from receipt evidence, and rejects all non-finite numeric JSON values at evaluator and persistence boundaries.
- Round 3 (`23bbcf30`) closes Python numeric-coercion holes: receipt/policy/run-state versions are exact built-in integers; token/count fields reject bool/float substitutions; monetary/time inputs allow finite int/float but never bool; and reconstructed JSON comparisons are type-sensitive. Generic update/load and evaluator round-trip/idempotency tests cover the repaired boundaries.
- Round 4 (`7df955c4`) restores the exact required dispatcher owner-doc heading after rebase and documents the shipped observer-only contract; no code or test files changed.
- Receipt schema remains v1 because this is its first unmerged delivery; run-state schema v1 and legacy run-state files without context receipts remain compatible. Round-trip and repeat-normalization tests cover idempotency.
- Round 3 continued Sol/high design intent after the third reviewer reject. Actual runtime config remained `model=gpt-5.6-sol`, `model_reasoning_effort=medium`.
- Round 2 used Sol/high design intent after the second reviewer reject. Actual runtime config read from `/Users/rasmus/.codex/config.toml`: `model=gpt-5.6-sol`, `model_reasoning_effort=medium`.
- Cumulative real independent-review rejects: 4. Documentation repair rounds: 1. Cumulative code repair rounds: 4 (initial type repair plus review rounds 1, 2, and 3). Validation-invocation repairs: 1. Agent starts: 1 implementation worker, 0 worker-spawned subagents. Human minutes: 0.

## Dispatcher Claim
- coordination_mode: `dispatcher-backed`
- task_id: `github-RasmusTho--agentic-pkm-mvp-issue-3798`
- lease_id: `lease-5cd93b52`
- holder: `codex-issue-3798`
- evidence: `verified-dispatcher-lease`
- fallback_reason: `none`

## BuilderOps Routing
- Records/projections/receipts: `prom_20260715095030_fee8133d`, `lrn_20260715095015_cbb83a15`, accepted inquiry `inq_20260715T091433Z_ea8a849b`
- Reason: PromotionIntent authorized the Issue/PR authority crossing; the LearningSignal records the canonical inquiry-readiness contract repair; this PR applies the accepted inquiry proposal.

## Notes
- Automatic rotation, compression, rehydration/fencing, worker start, new parallelism, universal thresholds, and quality-gate changes remain out of scope.
- Residual risk: real provider context/token/cost/human-minute inputs may remain `unknown` until callers can supply authoritative measurements; receipts label that incompleteness rather than estimating it.
