### PR TITLE
fix: restore verification dispatch artifact production

### DIFF
--- a/.github/workflows/verification-dispatch-request.yml
+++ b/.github/workflows/verification-dispatch-request.yml
@@ -135,7 +135,7 @@ jobs:
             > verification-dispatch/pr.json
           test -f verification-dispatch/issue.json || printf '{}\n' \
             > verification-dispatch/issue.json
-          python3 scripts/build_verification_dispatch_request.py \
+          python3 -m scripts.build_verification_dispatch_request \
             --event-json "$GITHUB_EVENT_PATH" \
             --pr-json verification-dispatch/pr.json \
             --issue-json verification-dispatch/issue.json \

--- a/tests/governance/test_verification_dispatch_workflow.py
+++ b/tests/governance/test_verification_dispatch_workflow.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
+import subprocess
+import sys
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -22,9 +25,27 @@ def test_workflow_triggers_from_completed_ci_workflow_run() -> None:
     assert 'repos/${REPOSITORY}/pulls/${PR_NUMBER}' in text
     assert 'repos/${REPOSITORY}/commits/${RUN_HEAD_SHA}/pulls' in text
     assert "resolve_pr_number" in text
-    assert "scripts/build_verification_dispatch_request.py" in text
+    assert "python3 -m scripts.build_verification_dispatch_request" in text
     assert '--artifact-workflow-run-id "${{ github.run_id }}"' in text
     assert '--artifact-repository-id "${{ github.repository_id }}"' in text
+
+
+def test_request_builder_runs_as_repository_module() -> None:
+    text = _workflow_text()
+    command = "python3 -m scripts.build_verification_dispatch_request"
+
+    assert command in text
+    assert "python3 scripts/build_verification_dispatch_request.py" not in text
+    result = subprocess.run(
+        [sys.executable, "-m", "scripts.build_verification_dispatch_request", "--help"],
+        cwd=REPO_ROOT,
+        env={"PATH": os.environ.get("PATH", "")},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_successful_current_head_emits_dispatch_artifact() -> None:


### PR DESCRIPTION
Fixes #3804

## Summary

- invoke the verification request builder as a repository module so app imports resolve in GitHub Actions
- add a regression that exercises the exact module command with ambient PYTHONPATH absent
- preserve the artifact-only, least-privilege workflow boundary

## Validation

- 25 passed: tests/governance/test_verification_dispatch_request.py and tests/governance/test_verification_dispatch_workflow.py
- 6 passed: tests/governance/test_verification_consumer_contract.py
- ruff check app tests: passed
- docs guard: passed
- git diff --check: passed
- mypy app: one current-main baseline error at app/dispatcher/control_plane.py:270; the same error reproduces unchanged on origin/main and is not introduced by this workflow/test-only diff

## BuilderOps Routing

- Records/projections/receipts: Dispatcher claim github-RasmusTho--agentic-pkm-mvp-issue-3804 / lease lease-09233616; live failure workflow run 29407871957
- Reason: This bounded repair restores the existing Builder System D11 artifact producer needed by the #3603 D12 host rollout; no new BuilderOps authority record is required.

## Live failure evidence

Verification Dispatch Request run 29407871957 fails before artifact upload because the file-path invocation cannot import app. Exact-head CI and a successful producer artifact remain required before merge/closure.