### PR TITLE
fix: keep verification receipt schema in Codex subset

### DIFF
--- a/app/dispatcher/schemas/verification_closer_receipt.schema.json
+++ b/app/dispatcher/schemas/verification_closer_receipt.schema.json
@@ -74,7 +74,6 @@
               "type": "array",
               "minItems": 2,
               "maxItems": 3,
-              "uniqueItems": true,
               "items": {
                 "type": "object",
                 "properties": {

--- a/app/dispatcher/verification_consumer.py
+++ b/app/dispatcher/verification_consumer.py
@@ -312,6 +312,7 @@ _UNSUPPORTED_CODEX_SCHEMA_KEYWORDS = frozenset(
         "allOf",
         "oneOf",
         "not",
+        "uniqueItems",
         "dependentRequired",
         "dependentSchemas",
         "if",

--- a/tests/dispatcher/test_verification_consumer.py
+++ b/tests/dispatcher/test_verification_consumer.py
@@ -3073,6 +3073,7 @@ def test_production_receipt_schema_uses_codex_subset_and_preserves_semantics() -
     verification_consumer.validate_codex_output_schema(schema)
     assert "allOf" not in json.dumps(schema)
     assert "oneOf" not in json.dumps(schema)
+    assert "uniqueItems" not in json.dumps(schema)
 
     valid = {
         "verdict": "delivered",
@@ -3149,6 +3150,45 @@ def test_codex_launcher_rejects_unsupported_schema_before_process_start(tmp_path
         runner=runner,
     )
     with pytest.raises(ValueError, match=r"unsupported output-schema keyword.*allOf"):
+        launcher.launch({"head_sha": HEAD})
+    assert calls == []
+
+
+def test_codex_launcher_rejects_unique_items_before_process_start(tmp_path) -> None:
+    schema = tmp_path / "receipt.schema.json"
+    schema.write_text(
+        json.dumps(
+            {
+                "type": "object",
+                "properties": {
+                    "receipt_ids": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "uniqueItems": True,
+                    }
+                },
+                "required": ["receipt_ids"],
+                "additionalProperties": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    calls = []
+
+    def runner(*args, **kwargs):
+        calls.append((args, kwargs))
+        raise AssertionError("invalid schema must fail before process start")
+
+    launcher = CodexExecLauncher(
+        tmp_path,
+        schema,
+        tmp_path / "context.json",
+        adapter_path=Path(__file__).resolve().parents[2]
+        / ".codex/agents/verification-closer.toml",
+        runner=runner,
+    )
+    with pytest.raises(ValueError, match=r"unsupported output-schema keyword.*uniqueItems"):
         launcher.launch({"head_sha": HEAD})
     assert calls == []
 


### PR DESCRIPTION
Fixes #3657

Governing-Issue: #3657
Refs #3603

## Summary

- remove provider-unsupported uniqueItems from the production verification receipt response schema
- preserve unique Human Exception option IDs through the existing local semantic validator
- reject future uniqueItems usage before any Codex process starts

## Validation

- red proof: both production-schema and launcher-preflight regressions failed before the fix
- 3 focused schema/launcher tests passed
- tests/dispatcher/test_verification_consumer.py: 103 passed
- tests/governance/test_verification_consumer_contract.py: 6 passed
- ruff check app tests: passed
- docs guard: passed
- git diff --check: passed
- actual ChatGPT/keyring Codex response-schema invocation on the exact schema succeeded and its output passed canonical load/sanitize validation
- mypy app reports one unchanged current-main error in app/dispatcher/control_plane.py:270 under the locally available newer mypy; this PR introduces no error in its touched code and exact-head CI remains required

## Host Safety

The Mac mini remains disabled. Preflight and authenticated observe-only passed; the prior non-mutating pilot failed before claim with invalid_json_schema uniqueItems. No request was claimed and no GitHub mutation occurred.

## BuilderOps Routing

- Records/projections/receipts: #3657 host failure comment 4979699033; dispatcher task github-RasmusTho--agentic-pkm-mvp-issue-3657 / lease lease-fec0b91a
- Reason: This is a bounded D12 deployment/model-schema compatibility repair on the existing canonical issue; repo and host receipts carry the delivery truth.