### PR TITLE
test: isolate verification CAS authority mutations

### DIFF
--- a/tests/dispatcher/test_verification_review_repairs_takeover.py
+++ b/tests/dispatcher/test_verification_review_repairs_takeover.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import io
 import json
 import os
@@ -29,7 +30,13 @@ from tests.dispatcher.test_verification_consumer import (
     eligible_pr,
 )
 from tests.dispatcher.test_verification_dispatch import _migrated_legacy_ledger
-from tests.dispatcher.verification_helpers import HEAD, REPO, ledger, request
+from tests.dispatcher.verification_helpers import (
+    HEAD,
+    REPO,
+    ledger,
+    pre_trust_request,
+    request,
+)
 
 
 REPAIRED_HEAD = "b" * 40
@@ -432,8 +439,13 @@ def _record_exhausted_chain(
     payload: dict[str, object],
     *,
     expire_lease: bool = True,
+    authenticate_with_live_observation: bool = False,
 ) -> tuple[str, list[dict[str, object]]]:
-    run = state.ingest(payload)
+    run = state.ingest(
+        _live_observed_artifact(state, payload)
+        if authenticate_with_live_observation
+        else payload
+    )
     claimed = state.claim(run.run_id, "head-a-host")
     lease_id = claimed.lease_id or ""
     state.start(
@@ -515,24 +527,183 @@ def _durable_verification_snapshot(
         run = conn.execute(
             "SELECT * FROM verification_runs WHERE run_id=?", (run_id,)
         ).fetchone()
+        assert run is not None
+        chain_runs = conn.execute(
+            """
+            SELECT * FROM verification_runs
+            WHERE repository=? AND pr_number=? AND stage=?
+            ORDER BY created_at, run_id
+            """,
+            (run["repository"], run["pr_number"], run["stage"]),
+        ).fetchall()
+        run_ids = [row["run_id"] for row in chain_runs]
+        placeholders = ", ".join("?" for _ in run_ids)
         attempts = conn.execute(
-            "SELECT * FROM verification_attempts WHERE run_id=? ORDER BY created_at, attempt_id",
-            (run_id,),
+            f"""
+            SELECT * FROM verification_attempts
+            WHERE run_id IN ({placeholders})
+            ORDER BY run_id, created_at, attempt_id
+            """,
+            run_ids,
         ).fetchall()
         exceptions = conn.execute(
-            "SELECT * FROM verification_exceptions WHERE run_id=? ORDER BY exception_id",
-            (run_id,),
+            f"""
+            SELECT * FROM verification_exceptions
+            WHERE run_id IN ({placeholders})
+            ORDER BY run_id, exception_id
+            """,
+            run_ids,
         ).fetchall()
-        run_count = conn.execute(
-            "SELECT COUNT(*) FROM verification_runs"
-        ).fetchone()[0]
-    assert run is not None
     return {
-        "run": dict(run),
+        "runs": [dict(row) for row in chain_runs],
         "attempts": [dict(row) for row in attempts],
         "exceptions": [dict(row) for row in exceptions],
-        "run_count": run_count,
     }
+
+
+def _insert_valid_attempt_authority_change(
+    state: VerificationDispatchLedger, run_id: str
+) -> None:
+    """Insert the same production row shape as a fresh clean review attempt."""
+
+    context = {"head_sha": HEAD}
+    with state.store._connect() as conn:
+        final_repair = conn.execute(
+            """
+            SELECT attempt_id FROM verification_attempts
+            WHERE run_id=? AND attempt_kind IN ('standard_repair', 'escalated_repair')
+            ORDER BY created_at DESC, attempt_id DESC LIMIT 1
+            """,
+            (run_id,),
+        ).fetchone()
+        review_count = conn.execute(
+            """
+            SELECT COUNT(*) FROM verification_attempts
+            WHERE run_id=? AND attempt_kind='review'
+            """,
+            (run_id,),
+        ).fetchone()[0]
+        assert final_repair is not None
+        conn.execute(
+            """
+            INSERT INTO verification_attempts (
+                attempt_id, run_id, attempt_kind, ordinal, session_id,
+                capability, reasoning_effort, context_hash, outcome,
+                receipt_json, created_at
+            ) VALUES (?, ?, 'review', ?, ?, ?, ?, ?, 'clean', ?, ?)
+            """,
+            (
+                "vattempt-delayed-observation-review",
+                run_id,
+                review_count + 1,
+                "delayed-observation-review-session",
+                "gpt-5.6-terra",
+                "high",
+                hashlib.sha256(
+                    json.dumps(context, sort_keys=True, separators=(",", ":")).encode()
+                ).hexdigest(),
+                json.dumps(
+                    {
+                        "head_sha": HEAD,
+                        "reviewed_attempt_id": final_repair["attempt_id"],
+                    },
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ),
+                "2030-01-01T00:00:00.000000+00:00",
+            ),
+        )
+        conn.commit()
+
+
+def _insert_valid_exception_authority_change(
+    state: VerificationDispatchLedger, run_id: str
+) -> None:
+    """Insert the exact durable shape produced by ``ledger.exception``."""
+
+    failure_class = "technical"
+    exception_id = "vexception-" + hashlib.sha256(
+        f"{run_id}:{failure_class}:{HEAD}".encode()
+    ).hexdigest()[:16]
+    with state.store._connect() as conn:
+        conn.execute(
+            """
+            INSERT INTO verification_exceptions (
+                exception_id, run_id, failure_class, head_sha, packet_json,
+                created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                exception_id,
+                run_id,
+                failure_class,
+                HEAD,
+                json.dumps(
+                    {"failure_class": failure_class},
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ),
+                "2030-01-01T00:00:00.000000+00:00",
+                "2030-01-01T00:00:00.000000+00:00",
+            ),
+        )
+        conn.commit()
+
+
+def _insert_inert_legacy_audit_authority_change(
+    state: VerificationDispatchLedger, head_sha: str
+) -> None:
+    """Insert the quarantined row shape produced by the legacy migration."""
+
+    legacy_request = pre_trust_request(head_sha)
+    idempotency_key = legacy_request["idempotency_key"]
+    assert isinstance(idempotency_key, str)
+    with state.store._connect() as conn:
+        conn.execute(
+            """
+            INSERT INTO verification_runs (
+                run_id, idempotency_key, contract_version, repository,
+                pr_number, head_sha, current_head_sha, stage, request_json,
+                supporting_authority_json, status, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, '[]', 'legacy_untrusted', ?, ?)
+            """,
+            (
+                f"vrun-{idempotency_key[:16]}",
+                idempotency_key,
+                legacy_request["contract_version"],
+                legacy_request["repository"],
+                legacy_request["pr_number"],
+                head_sha,
+                head_sha,
+                legacy_request["stage"],
+                json.dumps(
+                    legacy_request,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    ensure_ascii=False,
+                ),
+                "2030-01-01T00:00:00.000000+00:00",
+                "2030-01-01T00:00:00.000000+00:00",
+            ),
+        )
+        conn.commit()
+
+
+def _assert_delayed_observation_rejected_without_mutation(
+    state: VerificationDispatchLedger,
+    run_id: str,
+    delayed_observation: dict[str, object],
+) -> None:
+    snapshot_after_authority_change = _durable_verification_snapshot(state, run_id)
+    database_after_authority_change = state.store.db_path.read_bytes()
+
+    with pytest.raises(
+        ValueError, match="verification canonical authority changed during live observation"
+    ):
+        state.ingest(delayed_observation)
+
+    assert _durable_verification_snapshot(state, run_id) == snapshot_after_authority_change
+    assert state.store.db_path.read_bytes() == database_after_authority_change
 
 
 def test_first_authenticated_new_head_reopens_expired_chain_without_budget_reset(
@@ -918,6 +1089,77 @@ def test_expired_head_reconciliation_rejects_ambiguous_terminal_authority(
     assert retained.status == "running"
     assert retained.current_head_sha == HEAD
     assert state.attempts(run_id) == before
+
+
+def test_delayed_observation_rejects_attempt_only_authority_change(
+    tmp_path: Path,
+) -> None:
+    state = ledger(tmp_path)
+    run_id, _ = _record_exhausted_chain(state, request())
+    delayed_observation = _live_observed_artifact(state, request(REPAIRED_HEAD))
+
+    _insert_valid_attempt_authority_change(state, run_id)
+
+    _assert_delayed_observation_rejected_without_mutation(
+        state, run_id, delayed_observation
+    )
+
+
+def test_delayed_observation_rejects_exception_only_authority_change(
+    tmp_path: Path,
+) -> None:
+    state = ledger(tmp_path)
+    run_id, _ = _record_exhausted_chain(state, request())
+    delayed_observation = _live_observed_artifact(state, request(REPAIRED_HEAD))
+
+    _insert_valid_exception_authority_change(state, run_id)
+
+    _assert_delayed_observation_rejected_without_mutation(
+        state, run_id, delayed_observation
+    )
+
+
+def test_delayed_observation_rejects_cumulative_authority_only_change(
+    tmp_path: Path,
+) -> None:
+    state = ledger(tmp_path)
+    run_id, _ = _record_exhausted_chain(state, request())
+    delayed_observation = _live_observed_artifact(state, request(REPAIRED_HEAD))
+
+    with state.store._connect() as conn:
+        conn.execute(
+            """
+            UPDATE verification_runs
+            SET supporting_authority_json='[3626]'
+            WHERE run_id=?
+            """,
+            (run_id,),
+        )
+        conn.commit()
+
+    _assert_delayed_observation_rejected_without_mutation(
+        state, run_id, delayed_observation
+    )
+
+
+def test_delayed_observation_rejects_inert_legacy_audit_only_change(
+    tmp_path: Path,
+) -> None:
+    state, _ = _migrated_legacy_ledger(tmp_path)
+    run_id, _ = _record_exhausted_chain(
+        state,
+        request(REPAIRED_HEAD),
+        authenticate_with_live_observation=True,
+    )
+    delayed_observation = _live_observed_artifact(
+        state, request(SECOND_REPAIRED_HEAD)
+    )
+
+    _insert_inert_legacy_audit_authority_change(state, THIRD_REPAIRED_HEAD)
+
+    _assert_delayed_observation_rejected_without_mutation(
+        state, run_id, delayed_observation
+    )
 
 
 def test_historical_authenticated_artifact_cannot_move_expired_chain_backward(

--- a/tests/dispatcher/test_verification_review_repairs_takeover.py
+++ b/tests/dispatcher/test_verification_review_repairs_takeover.py
@@ -18,6 +18,7 @@ from app.dispatcher.verification_consumer import (
     _governing_contract_matches,
     _trusted_evidence_urls,
 )
+from app.dispatcher.verification_agent_loop import valid_human_exception_packet
 from app.dispatcher.verification_dispatch import (
     VerificationDispatchLedger,
     _live_observed_verification_request,
@@ -555,10 +556,14 @@ def _durable_verification_snapshot(
             """,
             run_ids,
         ).fetchall()
+        run_count = conn.execute(
+            "SELECT COUNT(*) FROM verification_runs"
+        ).fetchone()[0]
     return {
         "runs": [dict(row) for row in chain_runs],
         "attempts": [dict(row) for row in attempts],
         "exceptions": [dict(row) for row in exceptions],
+        "run_count": run_count,
     }
 
 
@@ -622,7 +627,32 @@ def _insert_valid_exception_authority_change(
 ) -> None:
     """Insert the exact durable shape produced by ``ledger.exception``."""
 
-    failure_class = "technical"
+    failure_class = "authority-critical"
+    packet: dict[str, object] = {
+        "failure_class": failure_class,
+        "original_intent": "verify and close the governed pull request",
+        "current_state": "canonical verification authority changed",
+        "tried_actions": ["re-read the canonical verification chain"],
+        "evidence": [f"verification run {run_id}"],
+        "why_unsafe": "continuing would accept stale authority",
+        "options": [
+            {
+                "id": "hold",
+                "label": "Hold",
+                "consequence": "delivery remains paused",
+            },
+            {
+                "id": "restart",
+                "label": "Restart",
+                "consequence": "delivery restarts from live authority",
+            },
+        ],
+        "no_action_option": "hold",
+        "recommended_option": "hold",
+        "recommendation_rationale": "authority must be revalidated first",
+        "consequence_of_doing_nothing": "delivery remains blocked",
+    }
+    assert valid_human_exception_packet(packet)
     exception_id = "vexception-" + hashlib.sha256(
         f"{run_id}:{failure_class}:{HEAD}".encode()
     ).hexdigest()[:16]
@@ -640,7 +670,7 @@ def _insert_valid_exception_authority_change(
                 failure_class,
                 HEAD,
                 json.dumps(
-                    {"failure_class": failure_class},
+                    packet,
                     sort_keys=True,
                     separators=(",", ":"),
                 ),


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Governing-Issue: #3807
Fixes #3807
Refs #3773
Refs #3603
Refs #3802

## SBS Impact
- Primary subsystem: Builder System canonical verification-chain lifecycle
- Secondary subsystem(s): SQLite concurrency fencing, stale-head takeover verification, migration compatibility
- Write class: correctness fitness repair
- Authority impact: grants none; independently proves every persisted authority category participates in the CAS fence
- Persistence impact: none in production; tests create production-shaped SQLite rows in isolated temporary stores
- Derived/rebuildable impact: none
- Human knowledge impact: closes the aggregate-only proof gap identified after #3802
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: direct verification dependency before #3603 pilot closure
- External boundary impact: delayed GitHub observations remain non-authoritative after any local authority mutation
- New or changed contract: no production contract change
- Owner-doc impact: none; shipped contract text remains accurate
- Transition debt impact: preserves all historical #3620/#3773 repair accounting
- Fitness rule impact: attempt, exception, cumulative authority, and inert legacy audit are each independently CAS-significant

## Summary
- Adds four deterministic delayed-observation regressions for attempt-only, exception-only, cumulative-authority-only, and inert-legacy-audit-only changes.
- Captures the live observation/token before each mutation, snapshots the complete canonical chain and SQLite bytes after the mutation, then proves ingest rejects without any further mutation.
- Uses a production-valid Human Exception packet for the exception-only authority mutation and retains the aggregate A→B→C→historical-B regression.
- Changes tests only; no production or owner-contract behavior changed.

## Owner-Doc Writeback
- [x] No owner-doc change implied; production behavior and the current owner contract are unchanged.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Validation
- [x] Exact final head: `3c72ddb18f3a4f9d7c88113aba7f4295f28b963b` on live base `bde0e27985b964d37dbb4d6225041fd5953bd541`
- [x] All four new exact Verify targets plus the existing aggregate target: 5 passed
- [x] `pytest -q tests/dispatcher/test_verification_review_repairs_takeover.py`: 51 passed
- [x] `pytest -q tests/dispatcher tests/governance`: 888 passed
- [x] `mypy app`: 744 source files clean
- [x] `ruff check app tests`: all checks passed
- [x] `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1 python3 scripts/docs_guard.py`: Docs guard OK
- [x] `git diff --check`: passed
- [x] Branch-truth precommit and prepush gates: passed
- [x] Exact-head GitHub CI latest-per-name green; `Unit tests (not pg)` check `87347497820`, run `29413996840`, completed 2026-07-15T12:09:36Z

## Independent Review and Repair
- Trigger: the post-merge Sol/xhigh review of #3802 rejected closure because four fingerprint categories lacked isolated negative proof.
- Implementation: fresh `gpt-5.6-terra` / high session, test-only, with one pre-publication coordinator correction so cumulative authority changes exactly one persisted field.
- Normal repair 1: Sol/xhigh review rejected the exception-only fixture because `technical` plus a partial packet was not production-valid; repaired to a complete `authority-critical` packet accepted by `valid_human_exception_packet`.
- Normal repair 2: live-main integration exposed removal of the pre-existing global `run_count` snapshot key; restored it while retaining full-chain and raw-byte comparison. No capability-escalated repair was needed.
- Clean review 1: `gpt-5.6-sol` / xhigh, fresh session `019f65b0-0a8d-7020-9487-909c0875ee7e`, ACCEPT on exact final head.
- Clean review 2: `gpt-5.6-sol` / xhigh, fresh session `019f65b8-1641-7c11-ad07-85adfab178fa`, ACCEPT on the same unchanged head.
- Repair/review accounting remains cumulative and is not reset by a new finding; historical #3620/#3773 receipts remain preserved.

## Dispatcher Receipt
- Task: `github-RasmusTho--agentic-pkm-mvp-issue-3807`
- Holder: `codex-3807-cas-proof`
- Lease: `lease-cdc2d46a`
- Coordination mode: dispatcher-backed; no label-only fallback
- Completion: 2026-07-15T11:03:51Z

## BuilderOps Routing
- Records/projections/receipts: `runtime/builderops/epic-runs/3224-human-by-exception-delivery-20260715.json` records the interrupted #3802 review and #3807 follow-up route.
- Reason: This test-only correctness receipt closes a delivery divergence; no Product memory, docs-freshness, roadmap, or cross-authority promotion record is required.
