### PR TITLE
Rebind expired verification backoff to live head

### DIFF
--- a/app/dispatcher/verification_dispatch.py
+++ b/app/dispatcher/verification_dispatch.py
@@ -863,6 +863,7 @@ class VerificationDispatchLedger:
                     raise ValueError("verification canonical run governing issue mismatch")
                 if candidate["current_head_sha"] != request.get("current_head_sha"):
                     lease_expires_at = candidate["lease_expires_at"]
+                    retry_after = candidate["retry_after"]
                     candidate_supporting = _validated_supporting_authority(
                         candidate, candidate_request
                     )
@@ -873,6 +874,17 @@ class VerificationDispatchLedger:
                         raise ValueError(
                             "verification canonical authority changed during live observation"
                         )
+                    expired_running = (
+                        candidate["status"] == "running"
+                        and isinstance(lease_expires_at, str)
+                        and _parse_timestamp(lease_expires_at)
+                        <= _parse_timestamp(now)
+                    )
+                    expired_backoff = (
+                        candidate["status"] == "backoff"
+                        and isinstance(retry_after, str)
+                        and _parse_timestamp(retry_after) <= _parse_timestamp(now)
+                    )
                     authority_matches = (
                         _live_takeover_authority_matches(
                             live_observation,
@@ -880,10 +892,7 @@ class VerificationDispatchLedger:
                             candidate_request,
                             candidate_supporting,
                         )
-                        and candidate["status"] == "running"
-                        and isinstance(lease_expires_at, str)
-                        and _parse_timestamp(lease_expires_at)
-                        <= _parse_timestamp(now)
+                        and (expired_running or expired_backoff)
                     )
                     if not authority_matches:
                         raise ValueError(
@@ -899,14 +908,19 @@ class VerificationDispatchLedger:
                             last_heartbeat_at=NULL, coordinator_session_id=NULL,
                             context_pack_json=NULL, terminal_receipt_json=NULL,
                             stop_reason=NULL, retry_after=NULL, updated_at=?
-                        WHERE run_id=? AND status='running' AND lease_expires_at=?
+                        WHERE run_id=? AND current_head_sha=? AND (
+                            (status='running' AND lease_expires_at=?) OR
+                            (status='backoff' AND retry_after=?)
+                        )
                         """,
                         (
                             next_head,
                             _json(incoming_supporting),
                             now,
                             candidate["run_id"],
+                            candidate["current_head_sha"],
                             lease_expires_at,
+                            retry_after,
                         ),
                     )
                     if conn.execute("SELECT changes()").fetchone()[0] != 1:

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -166,6 +166,11 @@ The dispatcher is an operational coordination layer, not a lifecycle replacement
   replay, so a newer empty run cannot hide older spent budget. More than one active canonical chain
   for the same repository, pull request, and stage is likewise rejected before exact replay; the
   dispatcher never selects a newer empty active row over an older row with spent budget.
+  An expired unclaimed technical backoff follows the same authenticated live-head takeover rule:
+  the first authoritative artifact for the newer live head requeues the existing canonical run,
+  preserves its immutable requested head, attempts, exceptions, and cumulative 2+2 budget, and
+  clears only head-bound coordinator, context, receipt, retry, and verified-head state. An
+  unexpired backoff or any authority/token mismatch remains non-mutating and fail-closed.
 - The Codex process boundary drains bounded stderr concurrently and rejects non-zero exits or
   terminal error events even when stdout contained an otherwise valid receipt. A bounded rate-limit,
   usage-limit, quota, or credit-exhaustion signal on that non-zero path remains a lease-fenced backoff

--- a/tests/dispatcher/test_verification_review_repairs_takeover.py
+++ b/tests/dispatcher/test_verification_review_repairs_takeover.py
@@ -27,6 +27,7 @@ from tests.dispatcher.test_verification_consumer import (
     Launcher,
     Truth,
     eligible_pr,
+    green_checks,
 )
 from tests.dispatcher.test_verification_dispatch import _migrated_legacy_ledger
 from tests.dispatcher.verification_helpers import HEAD, REPO, ledger, request
@@ -613,6 +614,48 @@ def test_expired_backoff_rebind_preserves_cumulative_chain_evidence(
         "review",
         "review",
     ]
+
+
+def test_consumer_rebinds_expired_backoff_and_launches_head_b_fresh(
+    tmp_path: Path,
+) -> None:
+    class HeadBLauncher(Launcher):
+        def launch(self, context_pack, **kwargs):
+            session_id, receipt = super().launch(context_pack, **kwargs)
+            receipt["head_sha"] = REPAIRED_HEAD
+            return session_id, receipt
+
+    state = ledger(tmp_path)
+    run_id, before = _record_backoff_chain(
+        state, retry_after="2000-01-01T00:00:00+00:00"
+    )
+    source, _ = _gh_source(request(REPAIRED_HEAD))
+    authenticated = source.pending_requests(REPO)[0]
+    launcher = HeadBLauncher()
+
+    result = VerificationConsumer(
+        state,
+        Truth(
+            eligible_pr(head={"ref": "branch", "sha": REPAIRED_HEAD}),
+            green_checks(REPAIRED_HEAD),
+        ),
+        Auth(),
+        launcher,
+        "head-b-host",
+    ).consume(authenticated)
+
+    after = _durable_verification_snapshot(state, run_id)
+    assert result.run_id == run_id
+    assert result.requested_head_sha == HEAD
+    assert result.current_head_sha == REPAIRED_HEAD
+    assert result.status == "needs_human"
+    assert len(launcher.calls) == 1
+    context_pack, resume_session_id = launcher.calls[0]
+    assert context_pack["head_sha"] == REPAIRED_HEAD
+    assert resume_session_id is None
+    assert after["attempts"][: len(before["attempts"])] == before["attempts"]
+    assert after["exceptions"][: len(before["exceptions"])] == before["exceptions"]
+    assert after["run_count"] == before["run_count"] == 1
 
 
 @pytest.mark.parametrize("failure", ["unexpired", "unauthenticated", "stale_live_head"])

--- a/tests/dispatcher/test_verification_review_repairs_takeover.py
+++ b/tests/dispatcher/test_verification_review_repairs_takeover.py
@@ -535,6 +535,171 @@ def _durable_verification_snapshot(
     }
 
 
+def _record_backoff_chain(
+    state: VerificationDispatchLedger,
+    *,
+    retry_after: str,
+    payload: dict[str, object] | None = None,
+) -> tuple[str, dict[str, object]]:
+    run_id, _ = _record_exhausted_chain(
+        state, payload or request(), expire_lease=False
+    )
+    running = state.get(run_id)
+    assert running is not None
+    assert running.lease_id is not None
+    state.exception(
+        run_id,
+        "synthetic_failure",
+        {"summary": "bounded synthetic exception", "head_sha": HEAD},
+        holder="head-a-host",
+        lease_id=running.lease_id,
+    )
+    state.backoff(
+        run_id,
+        {"outcome": "launcher_contract_failed", "error_type": "RuntimeError"},
+        retry_after,
+        holder="head-a-host",
+        lease_id=running.lease_id,
+    )
+    return run_id, _durable_verification_snapshot(state, run_id)
+
+
+def test_authenticated_live_head_rebinds_expired_backoff_chain(
+    tmp_path: Path,
+) -> None:
+    state = ledger(tmp_path)
+    run_id, _ = _record_backoff_chain(
+        state, retry_after="2000-01-01T00:00:00+00:00"
+    )
+
+    reopened = state.ingest(
+        _live_observed_artifact(state, request(REPAIRED_HEAD))
+    )
+
+    assert reopened.run_id == run_id
+    assert reopened.status == "queued"
+    assert reopened.requested_head_sha == HEAD
+    assert reopened.current_head_sha == REPAIRED_HEAD
+    assert reopened.claimed_by is None
+    assert reopened.lease_id is None
+    assert reopened.coordinator_session_id is None
+    assert reopened.context_pack is None
+    assert reopened.terminal_receipt is None
+    assert reopened.retry_after is None
+
+
+def test_expired_backoff_rebind_preserves_cumulative_chain_evidence(
+    tmp_path: Path,
+) -> None:
+    state = ledger(tmp_path)
+    run_id, before = _record_backoff_chain(
+        state, retry_after="2000-01-01T00:00:00+00:00"
+    )
+
+    reopened = state.ingest(
+        _live_observed_artifact(state, request(REPAIRED_HEAD))
+    )
+    after = _durable_verification_snapshot(state, run_id)
+
+    assert reopened.run_id == run_id
+    assert after["attempts"] == before["attempts"]
+    assert after["exceptions"] == before["exceptions"]
+    assert after["run_count"] == before["run_count"] == 1
+    assert [attempt["kind"] for attempt in state.attempts(run_id)] == [
+        "standard_repair",
+        "standard_repair",
+        "escalated_repair",
+        "escalated_repair",
+        "review",
+        "review",
+    ]
+
+
+@pytest.mark.parametrize("failure", ["unexpired", "unauthenticated", "stale_live_head"])
+def test_backoff_head_rebind_rejects_untrusted_or_premature_transition(
+    tmp_path: Path, failure: str
+) -> None:
+    state = ledger(tmp_path)
+    retry_after = (
+        "2999-01-01T00:00:00+00:00"
+        if failure == "unexpired"
+        else "2000-01-01T00:00:00+00:00"
+    )
+    run_id, before = _record_backoff_chain(state, retry_after=retry_after)
+    payload = request(REPAIRED_HEAD)
+    if failure == "unauthenticated":
+        incoming: dict[str, object] = payload
+    elif failure == "stale_live_head":
+        source, _ = _gh_source(payload)
+        authenticated = source.pending_requests(REPO)[0]
+        token = state.canonical_chain_token(authenticated)
+        incoming = _live_observed_verification_request(
+            authenticated,
+            observed_repository=REPO,
+            observed_pr_number=payload["pr_number"],
+            observed_head_sha=HEAD,
+            observed_state="open",
+            observed_merged_at=None,
+            observed_draft=False,
+            observed_linked_issue=payload["linked_issue"],
+            observed_supporting_issues=(),
+            canonical_chain_token=token,
+        )
+    else:
+        incoming = _live_observed_artifact(state, payload)
+
+    with pytest.raises(ValueError, match="artifact head does not match canonical run"):
+        state.ingest(incoming)
+
+    assert _durable_verification_snapshot(state, run_id) == before
+
+
+def test_expired_backoff_rebind_rejects_authority_drift(
+    tmp_path: Path,
+) -> None:
+    state = ledger(tmp_path)
+    original = request()
+    original["supporting_issues"] = [3626]
+    run_id, before = _record_backoff_chain(
+        state,
+        retry_after="2000-01-01T00:00:00+00:00",
+        payload=original,
+    )
+
+    removed_support = request(REPAIRED_HEAD)
+    with pytest.raises(ValueError, match="artifact head does not match canonical run"):
+        state.ingest(_live_observed_artifact(state, removed_support))
+
+    wrong_governor = request(REPAIRED_HEAD)
+    wrong_governor["linked_issue"] = 999999
+    with pytest.raises(ValueError, match="governing issue mismatch"):
+        state.ingest(_live_observed_artifact(state, wrong_governor))
+
+    assert _durable_verification_snapshot(state, run_id) == before
+
+
+def test_expired_backoff_rebind_rejects_canonical_chain_race(
+    tmp_path: Path,
+) -> None:
+    state = ledger(tmp_path)
+    run_id, _ = _record_backoff_chain(
+        state, retry_after="2000-01-01T00:00:00+00:00"
+    )
+    incoming = _live_observed_artifact(state, request(REPAIRED_HEAD))
+    with state.store._connect() as conn:
+        conn.execute(
+            "UPDATE verification_runs SET retry_after=? WHERE run_id=?",
+            ("1999-01-01T00:00:00+00:00", run_id),
+        )
+        conn.commit()
+    before = _durable_verification_snapshot(state, run_id)
+
+    with pytest.raises(ValueError, match="canonical authority changed"):
+        state.ingest(incoming)
+
+    assert _durable_verification_snapshot(state, run_id) == before
+
+
 def test_first_authenticated_new_head_reopens_expired_chain_without_budget_reset(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Governing-Issue: #3810

Fixes #3810

## Summary

- requeue one expired technical-backoff chain on the first authenticated exact live-head artifact
- preserve immutable requested-head identity, attempts, exceptions, and cumulative 2+2 budget
- clear only stale head-bound coordinator/context/receipt/retry state under canonical-token and row-CAS fencing
- document the backoff takeover contract and add production-call-path negative/security regressions

## SBS impact

Builder System boundary work only: verification-dispatch lifecycle and Mac mini host orchestration. No Product/Runtime, vault, or user-memory changes. D11 evidence remains durable in the existing dispatcher run/attempt/exception ledger; D12 changes only the governed head-transition path and introduces no new authority.

## Verification

- red proof: the two new expired-backoff success tests failed with `verification artifact head does not match canonical run` before the repair
- `pytest -q tests/dispatcher/test_verification_review_repairs_takeover.py` — 47 passed, including a production `VerificationConsumer` regression that proves head B starts without head A session inheritance
- `pytest -q tests/dispatcher/test_verification_dispatch.py tests/dispatcher/test_verification_consumer.py tests/dispatcher/test_verification_agent_loop.py tests/governance/test_verification_consumer_contract.py` — 389 passed
- focused expired-backoff success/negative suite — 8 passed
- `ruff check app tests` — passed
- `mypy app` — passed (744 source files)
- raw `python3 scripts/docs_guard.py` — expected temporal-owner guard rejection; `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1 python3 scripts/docs_guard.py` — passed because the owning current-state contract is updated in `docs/AGENT_ISSUE_DISPATCHER.md` and no high-risk temporal owner doc changes
- `git diff --check` — passed
- raw `pytest -q -m 'not pg'` was not a valid local broad gate in this checkout because collection could not import the optional `companion_ui` package; exact PR-selected non-PG CI remains required and blocking

## BuilderOps Routing

- Records/projections/receipts: dispatcher claim and PR-link receipt for issue #3810 / PR #3811; production host receipt will be written to #3603 after exact-head merge and limited-run success
- Reason: this is Builder System operational state only; no BuilderOps Vault or Product-memory record is created