### PR TITLE
Fix Codex usage-limit event backoff

### DIFF
--- a/app/dispatcher/verification_consumer.py
+++ b/app/dispatcher/verification_consumer.py
@@ -1467,6 +1467,28 @@ def _is_rate_limit_exec_failure(detail: str) -> bool:
     return False
 
 
+def _is_codex_usage_limit_event(event: object) -> bool:
+    """Recognize the bounded Codex CLI envelope for subscription exhaustion."""
+
+    if not isinstance(event, Mapping) or event.get("type") != "error":
+        return False
+    message = event.get("message")
+    if not isinstance(message, str):
+        return False
+    normalized = " ".join(message.strip().split()).casefold()
+    prefixes = (
+        "you've hit your usage limit",
+        "you’ve hit your usage limit",
+        "you have hit your usage limit",
+    )
+    return any(
+        normalized == prefix
+        or normalized.startswith(prefix + ".")
+        or normalized.startswith(prefix + "!")
+        for prefix in prefixes
+    )
+
+
 class CodexExecLauncher:
     """Explicit least-privilege non-interactive verification coordinator."""
 
@@ -1777,6 +1799,7 @@ class CodexExecLauncher:
         thread_id: str | None = resume_session_id
         terminal: dict[str, object] | None = None
         terminal_error: str | None = None
+        terminal_rate_limited = False
         try:
             for line in lines:
                 if authority_lost.is_set():
@@ -1787,6 +1810,10 @@ class CodexExecLauncher:
                     continue
                 if event.get("type") in {"turn.failed", "error"}:
                     terminal_error = json.dumps(event, sort_keys=True)
+                    terminal_rate_limited = (
+                        _is_codex_usage_limit_event(event)
+                        or terminal_rate_limited
+                    )
                 if event.get("type") == "thread.started" and isinstance(event.get("thread_id"), str):
                     thread_id = event["thread_id"]
                     if on_thread_started:
@@ -1872,7 +1899,8 @@ class CodexExecLauncher:
             detail = stderr_detail or terminal_error or "no stderr"
             failure_class = (
                 "rate_limit"
-                if any(
+                if terminal_rate_limited
+                or any(
                     _is_rate_limit_exec_failure(candidate)
                     for candidate in (stderr_detail, terminal_error)
                     if candidate

--- a/app/dispatcher/verification_consumer.py
+++ b/app/dispatcher/verification_consumer.py
@@ -1476,20 +1476,26 @@ def _is_valid_codex_retry(retry: str) -> bool:
     current = datetime.now().astimezone().replace(
         tzinfo=None, second=0, microsecond=0
     )
-    try:
-        parsed_time = datetime.strptime(timestamp, "%I:%M %p")
-    except ValueError:
-        pass
-    else:
+    clock = re.fullmatch(
+        r"(?P<hour>[1-9]|1[0-2]):(?P<minute>[0-9]{2}) (?P<period>AM|PM)",
+        timestamp,
+    )
+    if clock is not None:
+        hour = int(clock.group("hour"))
+        minute = int(clock.group("minute"))
+        if minute > 59:
+            return False
+        hour = hour % 12 + (12 if clock.group("period") == "PM" else 0)
         candidate = current.replace(
-            hour=parsed_time.hour,
-            minute=parsed_time.minute,
+            hour=hour,
+            minute=minute,
         )
         return current <= candidate <= current + timedelta(days=1)
     match = re.fullmatch(
         r"(?P<month>Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) "
-        r"(?P<day>[0-9]{1,2})(?P<suffix>st|nd|rd|th), "
-        r"(?P<year>[0-9]{4}) (?P<clock>[0-9]{1,2}:[0-9]{2} (?:AM|PM))",
+        r"(?P<day>[1-9]|[12][0-9]|3[01])(?P<suffix>st|nd|rd|th), "
+        r"(?P<year>[0-9]{4}) (?P<hour>[1-9]|1[0-2]):"
+        r"(?P<minute>[0-9]{2}) (?P<period>AM|PM)",
         timestamp,
     )
     if match is None:
@@ -1502,13 +1508,29 @@ def _is_valid_codex_retry(retry: str) -> bool:
     )
     if match.group("suffix") != suffix:
         return False
+    minute = int(match.group("minute"))
+    if minute > 59:
+        return False
+    hour = int(match.group("hour")) % 12 + (
+        12 if match.group("period") == "PM" else 0
+    )
+    month = {
+        "Jan": 1,
+        "Feb": 2,
+        "Mar": 3,
+        "Apr": 4,
+        "May": 5,
+        "Jun": 6,
+        "Jul": 7,
+        "Aug": 8,
+        "Sep": 9,
+        "Oct": 10,
+        "Nov": 11,
+        "Dec": 12,
+    }[match.group("month")]
     try:
-        candidate = datetime.strptime(
-            (
-                f"{match.group('month')} {day}, {match.group('year')} "
-                f"{match.group('clock')}"
-            ),
-            "%b %d, %Y %I:%M %p",
+        candidate = datetime(
+            int(match.group("year")), month, day, hour, minute
         )
     except ValueError:
         return False
@@ -1524,9 +1546,10 @@ def _is_codex_usage_limit_event(event: object) -> bool:
     if not isinstance(message, str) or not message.isascii():
         return False
     retry_time = (
-        r"(?:[0-9]{1,2}:[0-9]{2} (?:AM|PM)|"
+        r"(?:(?:[1-9]|1[0-2]):[0-9]{2} (?:AM|PM)|"
         r"(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) "
-        r"[0-9]{1,2}(?:st|nd|rd|th), [0-9]{4} [0-9]{1,2}:[0-9]{2} "
+        r"(?:[1-9]|[12][0-9]|3[01])(?:st|nd|rd|th), [0-9]{4} "
+        r"(?:[1-9]|1[0-2]):[0-9]{2} "
         r"(?:AM|PM))"
     )
     retry = rf"(?:later|at {retry_time})"

--- a/app/dispatcher/verification_consumer.py
+++ b/app/dispatcher/verification_consumer.py
@@ -1476,16 +1476,27 @@ def _is_codex_usage_limit_event(event: object) -> bool:
     if not isinstance(message, str):
         return False
     normalized = " ".join(message.strip().split()).casefold()
-    prefixes = (
-        "you've hit your usage limit",
-        "you’ve hit your usage limit",
-        "you have hit your usage limit",
+    retry_time = (
+        r"(?:[0-9]{1,2}:[0-9]{2} (?:am|pm)|"
+        r"(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec) "
+        r"[0-9]{1,2}(?:st|nd|rd|th), [0-9]{4} [0-9]{1,2}:[0-9]{2} "
+        r"(?:am|pm))"
     )
-    return any(
-        normalized == prefix
-        or normalized.startswith(prefix + ".")
-        or normalized.startswith(prefix + "!")
-        for prefix in prefixes
+    retry = rf"(?:later|at {retry_time})"
+    plan_copy = (
+        r"(?:upgrade to pro \(https://chatgpt\.com/explore/pro\), visit "
+        r"https://chatgpt\.com/codex/settings/usage to purchase more credits|"
+        r"to get more access now, send a request to your admin|"
+        r"upgrade to plus to continue using codex "
+        r"\(https://chatgpt\.com/explore/plus\),|"
+        r"visit https://chatgpt\.com/codex/settings/usage to purchase more credits)"
+    )
+    return bool(
+        re.fullmatch(
+            rf"you've hit your usage limit\. (?:{plan_copy} or try again {retry}|"
+            rf"try again {retry})\.",
+            normalized,
+        )
     )
 
 

--- a/app/dispatcher/verification_consumer.py
+++ b/app/dispatcher/verification_consumer.py
@@ -1467,6 +1467,46 @@ def _is_rate_limit_exec_failure(detail: str) -> bool:
     return False
 
 
+def _is_valid_codex_retry(retry: str) -> bool:
+    if retry == "later":
+        return True
+    if not retry.startswith("at "):
+        return False
+    timestamp = retry.removeprefix("at ")
+    try:
+        datetime.strptime(timestamp.upper(), "%I:%M %p")
+        return True
+    except ValueError:
+        pass
+    match = re.fullmatch(
+        r"(?P<month>jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec) "
+        r"(?P<day>[0-9]{1,2})(?P<suffix>st|nd|rd|th), "
+        r"(?P<year>[0-9]{4}) (?P<clock>[0-9]{1,2}:[0-9]{2} (?:am|pm))",
+        timestamp,
+    )
+    if match is None:
+        return False
+    day = int(match.group("day"))
+    suffix = (
+        "th"
+        if 11 <= day % 100 <= 13
+        else {1: "st", 2: "nd", 3: "rd"}.get(day % 10, "th")
+    )
+    if match.group("suffix") != suffix or int(match.group("year")) < 2000:
+        return False
+    try:
+        datetime.strptime(
+            (
+                f"{match.group('month')} {day}, {match.group('year')} "
+                f"{match.group('clock')}"
+            ).upper(),
+            "%b %d, %Y %I:%M %p",
+        )
+    except ValueError:
+        return False
+    return True
+
+
 def _is_codex_usage_limit_event(event: object) -> bool:
     """Recognize the bounded Codex CLI envelope for subscription exhaustion."""
 
@@ -1482,7 +1522,7 @@ def _is_codex_usage_limit_event(event: object) -> bool:
         r"[0-9]{1,2}(?:st|nd|rd|th), [0-9]{4} [0-9]{1,2}:[0-9]{2} "
         r"(?:am|pm))"
     )
-    retry = rf"(?:later|at {retry_time})"
+    retry = rf"(?P<retry>later|at {retry_time})"
     plan_copy = (
         r"(?:upgrade to pro \(https://chatgpt\.com/explore/pro\), visit "
         r"https://chatgpt\.com/codex/settings/usage to purchase more credits|"
@@ -1491,13 +1531,11 @@ def _is_codex_usage_limit_event(event: object) -> bool:
         r"\(https://chatgpt\.com/explore/plus\),|"
         r"visit https://chatgpt\.com/codex/settings/usage to purchase more credits)"
     )
-    return bool(
-        re.fullmatch(
-            rf"you've hit your usage limit\. (?:{plan_copy} or try again {retry}|"
-            rf"try again {retry})\.",
-            normalized,
-        )
+    match = re.fullmatch(
+        rf"you've hit your usage limit\. (?:{plan_copy} or )?try again {retry}\.",
+        normalized,
     )
+    return bool(match is not None and _is_valid_codex_retry(match.group("retry")))
 
 
 class CodexExecLauncher:

--- a/app/dispatcher/verification_consumer.py
+++ b/app/dispatcher/verification_consumer.py
@@ -29,6 +29,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Callable, Iterable, Mapping, Protocol, Sequence, cast
 from urllib.parse import urlsplit
+from zoneinfo import ZoneInfo
 
 import jsonschema
 
@@ -1467,15 +1468,44 @@ def _is_rate_limit_exec_failure(detail: str) -> bool:
     return False
 
 
+def _local_now() -> datetime:
+    """Return an aware local instant backed by the host's full timezone rules."""
+
+    try:
+        with Path("/etc/localtime").open("rb") as stream:
+            local_zone = ZoneInfo.from_file(stream)
+    except (OSError, ValueError):
+        return datetime.now().astimezone()
+    return datetime.now(local_zone)
+
+
+def _is_future_local_wall_time(
+    current: datetime, wall_time: datetime, *, max_delta: timedelta
+) -> bool:
+    """Accept a local wall time when at least one real fold is a future instant."""
+
+    if current.tzinfo is None or wall_time.tzinfo is not None:
+        return False
+    current_utc = current.astimezone(timezone.utc)
+    latest_utc = current_utc + max_delta
+    for fold in (0, 1):
+        candidate = wall_time.replace(tzinfo=current.tzinfo, fold=fold)
+        candidate_utc = candidate.astimezone(timezone.utc)
+        round_trip = candidate_utc.astimezone(current.tzinfo)
+        if round_trip.replace(tzinfo=None) != wall_time:
+            continue
+        if current_utc <= candidate_utc <= latest_utc:
+            return True
+    return False
+
+
 def _is_valid_codex_retry(retry: str) -> bool:
     if retry == "later":
         return True
     if not retry.startswith("at "):
         return False
     timestamp = retry.removeprefix("at ")
-    current = datetime.now().astimezone().replace(
-        tzinfo=None, second=0, microsecond=0
-    )
+    current = _local_now().replace(second=0, microsecond=0)
     clock = re.fullmatch(
         r"(?P<hour>[1-9]|1[0-2]):(?P<minute>[0-9]{2}) (?P<period>AM|PM)",
         timestamp,
@@ -1486,11 +1516,16 @@ def _is_valid_codex_retry(retry: str) -> bool:
         if minute > 59:
             return False
         hour = hour % 12 + (12 if clock.group("period") == "PM" else 0)
-        candidate = current.replace(
+        candidate = datetime(
+            current.year,
+            current.month,
+            current.day,
             hour=hour,
             minute=minute,
         )
-        return current <= candidate <= current + timedelta(days=1)
+        return _is_future_local_wall_time(
+            current, candidate, max_delta=timedelta(days=1)
+        )
     match = re.fullmatch(
         r"(?P<month>Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) "
         r"(?P<day>[1-9]|[12][0-9]|3[01])(?P<suffix>st|nd|rd|th), "
@@ -1534,7 +1569,11 @@ def _is_valid_codex_retry(retry: str) -> bool:
         )
     except ValueError:
         return False
-    return current <= candidate <= current + timedelta(days=5 * 366)
+    if candidate.date() <= current.date():
+        return False
+    return _is_future_local_wall_time(
+        current, candidate, max_delta=timedelta(days=5 * 366)
+    )
 
 
 def _is_codex_usage_limit_event(event: object) -> bool:

--- a/app/dispatcher/verification_consumer.py
+++ b/app/dispatcher/verification_consumer.py
@@ -1473,15 +1473,23 @@ def _is_valid_codex_retry(retry: str) -> bool:
     if not retry.startswith("at "):
         return False
     timestamp = retry.removeprefix("at ")
+    current = datetime.now().astimezone().replace(
+        tzinfo=None, second=0, microsecond=0
+    )
     try:
-        datetime.strptime(timestamp.upper(), "%I:%M %p")
-        return True
+        parsed_time = datetime.strptime(timestamp, "%I:%M %p")
     except ValueError:
         pass
+    else:
+        candidate = current.replace(
+            hour=parsed_time.hour,
+            minute=parsed_time.minute,
+        )
+        return current <= candidate <= current + timedelta(days=1)
     match = re.fullmatch(
-        r"(?P<month>jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec) "
+        r"(?P<month>Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) "
         r"(?P<day>[0-9]{1,2})(?P<suffix>st|nd|rd|th), "
-        r"(?P<year>[0-9]{4}) (?P<clock>[0-9]{1,2}:[0-9]{2} (?:am|pm))",
+        r"(?P<year>[0-9]{4}) (?P<clock>[0-9]{1,2}:[0-9]{2} (?:AM|PM))",
         timestamp,
     )
     if match is None:
@@ -1492,19 +1500,19 @@ def _is_valid_codex_retry(retry: str) -> bool:
         if 11 <= day % 100 <= 13
         else {1: "st", 2: "nd", 3: "rd"}.get(day % 10, "th")
     )
-    if match.group("suffix") != suffix or int(match.group("year")) < 2000:
+    if match.group("suffix") != suffix:
         return False
     try:
-        datetime.strptime(
+        candidate = datetime.strptime(
             (
                 f"{match.group('month')} {day}, {match.group('year')} "
                 f"{match.group('clock')}"
-            ).upper(),
+            ),
             "%b %d, %Y %I:%M %p",
         )
     except ValueError:
         return False
-    return True
+    return current <= candidate <= current + timedelta(days=5 * 366)
 
 
 def _is_codex_usage_limit_event(event: object) -> bool:
@@ -1513,29 +1521,31 @@ def _is_codex_usage_limit_event(event: object) -> bool:
     if not isinstance(event, Mapping) or event.get("type") != "error":
         return False
     message = event.get("message")
-    if not isinstance(message, str):
+    if not isinstance(message, str) or not message.isascii():
         return False
-    normalized = " ".join(message.strip().split()).casefold()
     retry_time = (
-        r"(?:[0-9]{1,2}:[0-9]{2} (?:am|pm)|"
-        r"(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec) "
+        r"(?:[0-9]{1,2}:[0-9]{2} (?:AM|PM)|"
+        r"(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) "
         r"[0-9]{1,2}(?:st|nd|rd|th), [0-9]{4} [0-9]{1,2}:[0-9]{2} "
-        r"(?:am|pm))"
+        r"(?:AM|PM))"
     )
-    retry = rf"(?P<retry>later|at {retry_time})"
+    retry = rf"(?:later|at {retry_time})"
     plan_copy = (
-        r"(?:upgrade to pro \(https://chatgpt\.com/explore/pro\), visit "
+        r"(?:Upgrade to Pro \(https://chatgpt\.com/explore/pro\), visit "
         r"https://chatgpt\.com/codex/settings/usage to purchase more credits|"
-        r"to get more access now, send a request to your admin|"
-        r"upgrade to plus to continue using codex "
+        r"To get more access now, send a request to your admin|"
+        r"Upgrade to Plus to continue using Codex "
         r"\(https://chatgpt\.com/explore/plus\),|"
-        r"visit https://chatgpt\.com/codex/settings/usage to purchase more credits)"
+        r"Visit https://chatgpt\.com/codex/settings/usage to purchase more credits)"
     )
-    match = re.fullmatch(
-        rf"you've hit your usage limit\. (?:{plan_copy} or )?try again {retry}\.",
-        normalized,
-    )
-    return bool(match is not None and _is_valid_codex_retry(match.group("retry")))
+    for pattern in (
+        rf"You've hit your usage limit\. {plan_copy} or try again (?P<retry>{retry})\.",
+        rf"You've hit your usage limit\. Try again (?P<retry>{retry})\.",
+    ):
+        match = re.fullmatch(pattern, message)
+        if match is not None:
+            return _is_valid_codex_retry(match.group("retry"))
+    return False
 
 
 class CodexExecLauncher:

--- a/app/dispatcher/verification_consumer.py
+++ b/app/dispatcher/verification_consumer.py
@@ -1540,7 +1540,11 @@ def _is_valid_codex_retry(retry: str) -> bool:
 def _is_codex_usage_limit_event(event: object) -> bool:
     """Recognize the bounded Codex CLI envelope for subscription exhaustion."""
 
-    if not isinstance(event, Mapping) or event.get("type") != "error":
+    if (
+        not isinstance(event, Mapping)
+        or set(event) != {"type", "message"}
+        or event.get("type") != "error"
+    ):
         return False
     message = event.get("message")
     if not isinstance(message, str) or not message.isascii():

--- a/app/dispatcher/verification_consumer.py
+++ b/app/dispatcher/verification_consumer.py
@@ -1468,14 +1468,14 @@ def _is_rate_limit_exec_failure(detail: str) -> bool:
     return False
 
 
-def _local_now() -> datetime:
+def _local_now() -> datetime | None:
     """Return an aware local instant backed by the host's full timezone rules."""
 
     try:
         with Path("/etc/localtime").open("rb") as stream:
             local_zone = ZoneInfo.from_file(stream)
     except (OSError, ValueError):
-        return datetime.now().astimezone()
+        return None
     return datetime.now(local_zone)
 
 
@@ -1486,12 +1486,18 @@ def _is_future_local_wall_time(
 
     if current.tzinfo is None or wall_time.tzinfo is not None:
         return False
-    current_utc = current.astimezone(timezone.utc)
-    latest_utc = current_utc + max_delta
+    try:
+        current_utc = current.astimezone(timezone.utc)
+        latest_utc = current_utc + max_delta
+    except (OSError, OverflowError, ValueError):
+        return False
     for fold in (0, 1):
-        candidate = wall_time.replace(tzinfo=current.tzinfo, fold=fold)
-        candidate_utc = candidate.astimezone(timezone.utc)
-        round_trip = candidate_utc.astimezone(current.tzinfo)
+        try:
+            candidate = wall_time.replace(tzinfo=current.tzinfo, fold=fold)
+            candidate_utc = candidate.astimezone(timezone.utc)
+            round_trip = candidate_utc.astimezone(current.tzinfo)
+        except (OSError, OverflowError, ValueError):
+            continue
         if round_trip.replace(tzinfo=None) != wall_time:
             continue
         if current_utc <= candidate_utc <= latest_utc:
@@ -1505,7 +1511,10 @@ def _is_valid_codex_retry(retry: str) -> bool:
     if not retry.startswith("at "):
         return False
     timestamp = retry.removeprefix("at ")
-    current = _local_now().replace(second=0, microsecond=0)
+    current = _local_now()
+    if current is None:
+        return False
+    current = current.replace(second=0, microsecond=0)
     clock = re.fullmatch(
         r"(?P<hour>[1-9]|1[0-2]):(?P<minute>[0-9]{2}) (?P<period>AM|PM)",
         timestamp,

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -104,7 +104,8 @@ The dispatcher is an operational coordination layer, not a lifecycle replacement
   only parsed provider fields such as status 429 or canonical failure codes, inspected independently
   across bounded stderr and structured terminal events, or a full match of the versioned top-level
   Codex CLI `error` event grammar for plan guidance plus its bounded retry suffix, can create that
-  signal. Prefix-only matches are forbidden. The Codex event envelope
+  signal. Retry timestamps must also parse as a real 12-hour time or calendar date with the correct
+  ordinal suffix; regex shape alone is insufficient. Prefix-only matches are forbidden. The Codex event envelope
   is classified while streaming so a later `turn.failed` event cannot erase the earlier signal,
   while free-form, arbitrary, negated, or explicitly false terminal/stderr prose cannot select
   rate-limit backoff. Terminal completion

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -102,8 +102,9 @@ The dispatcher is an operational coordination layer, not a lifecycle replacement
   before `retry_after`. Rate-limit classification requires either a structured `retry` receipt or the
   launcher's structured `failure_class=rate_limit`, derived once from a non-zero provider failure;
   only parsed provider fields such as status 429 or canonical failure codes, inspected independently
-  across bounded stderr and structured terminal events, or the exact top-level Codex CLI `error`
-  event grammar `You've hit your usage limit...`, can create that signal. The Codex event envelope
+  across bounded stderr and structured terminal events, or a full match of the versioned top-level
+  Codex CLI `error` event grammar for plan guidance plus its bounded retry suffix, can create that
+  signal. Prefix-only matches are forbidden. The Codex event envelope
   is classified while streaming so a later `turn.failed` event cannot erase the earlier signal,
   while free-form, arbitrary, negated, or explicitly false terminal/stderr prose cannot select
   rate-limit backoff. Terminal completion

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -102,7 +102,9 @@ The dispatcher is an operational coordination layer, not a lifecycle replacement
   before `retry_after`. Rate-limit classification requires either a structured `retry` receipt or the
   launcher's structured `failure_class=rate_limit`, derived once from a non-zero provider failure;
   only parsed provider fields such as status 429 or canonical failure codes, inspected independently
-  across bounded stderr and structured terminal events, can create that signal,
+  across bounded stderr and structured terminal events, or the exact top-level Codex CLI `error`
+  event grammar `You've hit your usage limit...`, can create that signal. The Codex event envelope
+  is classified while streaming so a later `turn.failed` event cannot erase the earlier signal,
   while free-form, arbitrary, negated, or explicitly false terminal/stderr prose cannot select
   rate-limit backoff. Terminal completion
   additionally requires two fresh clean
@@ -175,7 +177,9 @@ The dispatcher is an operational coordination layer, not a lifecycle replacement
   terminal error events even when stdout contained an otherwise valid receipt. A bounded rate-limit,
   usage-limit, quota, or credit-exhaustion signal on that non-zero path remains a lease-fenced backoff
   receipt with no repair-budget use or API-key fallback; either diagnostic channel can supply the
-  structured signal without masking the other. Raw stderr, terminal event content, exception
+  structured provider signal without masking the other, while the canonical Codex usage-limit
+  message is trusted only in a top-level CLI `error` event and never from stderr, nested model/tool
+  output, quoted examples, or arbitrary prose. Raw stderr, terminal event content, exception
   text, paths, and credentials are transient classification input only: durable attempts, terminal
   receipts, and `verification-status` retain only bounded outcome, return-code, failure-class,
   error-type, retry, and canonical UUID coordinator-session fields. A zero exit without both thread

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -104,8 +104,10 @@ The dispatcher is an operational coordination layer, not a lifecycle replacement
   only parsed provider fields such as status 429 or canonical failure codes, inspected independently
   across bounded stderr and structured terminal events, or a full match of the versioned top-level
   Codex CLI `error` event grammar for plan guidance plus its bounded retry suffix, can create that
-  signal. Retry timestamps must also parse as a real 12-hour time or calendar date with the correct
-  ordinal suffix; regex shape alone is insufficient. Prefix-only matches are forbidden. The Codex event envelope
+  signal. The grammar is exact ASCII with canonical case and spacing; Unicode compatibility folding
+  and whitespace normalization are forbidden. Retry timestamps must parse as a real non-past local
+  12-hour time or calendar date within the bounded future window and carry the correct ordinal suffix;
+  regex shape alone is insufficient. Prefix-only matches are forbidden. The Codex event envelope
   is classified while streaming so a later `turn.failed` event cannot erase the earlier signal,
   while free-form, arbitrary, negated, or explicitly false terminal/stderr prose cannot select
   rate-limit backoff. Terminal completion

--- a/tests/dispatcher/test_verification_consumer.py
+++ b/tests/dispatcher/test_verification_consumer.py
@@ -3451,11 +3451,41 @@ def _codex_json_usage_failure_launcher(
     return launcher, calls
 
 
-def test_codex_json_usage_limit_event_enters_durable_backoff(tmp_path) -> None:
+CANONICAL_CODEX_USAGE_LIMIT = (
+    "You've hit your usage limit. Visit "
+    "https://chatgpt.com/codex/settings/usage to purchase more credits "
+    "or try again at 4:30 PM."
+)
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        CANONICAL_CODEX_USAGE_LIMIT,
+        "You've hit your usage limit. Try again later.",
+        (
+            "You've hit your usage limit. Upgrade to Pro "
+            "(https://chatgpt.com/explore/pro), visit "
+            "https://chatgpt.com/codex/settings/usage to purchase more credits "
+            "or try again later."
+        ),
+        (
+            "You've hit your usage limit. To get more access now, send a request "
+            "to your admin or try again at Jul 16th, 2026 4:30 PM."
+        ),
+        (
+            "You've hit your usage limit. Upgrade to Plus to continue using Codex "
+            "(https://chatgpt.com/explore/plus), or try again later."
+        ),
+    ],
+)
+def test_codex_json_usage_limit_event_enters_durable_backoff(
+    tmp_path, message: str
+) -> None:
     state = ledger(tmp_path)
     launcher, calls = _codex_json_usage_failure_launcher(
         tmp_path,
-        message="You've hit your usage limit. Synthetic retry guidance.",
+        message=message,
     )
 
     result = VerificationConsumer(
@@ -3482,11 +3512,19 @@ def test_codex_json_usage_limit_event_enters_durable_backoff(tmp_path) -> None:
         ("This is not a usage limit.", False, ""),
         ("Example: You've hit your usage limit.", False, ""),
         ("You've hit your usage limit: false", False, ""),
-        ("You've hit your usage limit. Nested model text.", True, ""),
+        ("You've hit your usage limit. false", False, ""),
+        ("You've hit your usage limit! false", False, ""),
+        ("You've hit your usage limit. . This is not an actual limit.", False, ""),
+        (
+            "You've hit your usage limit. Try again later.\" is only an example.",
+            False,
+            "",
+        ),
+        (CANONICAL_CODEX_USAGE_LIMIT, True, ""),
         (
             "synthetic execution failure",
             False,
-            "You've hit your usage limit. Untrusted stderr.",
+            CANONICAL_CODEX_USAGE_LIMIT,
         ),
         (
             "synthetic execution failure",
@@ -3494,7 +3532,7 @@ def test_codex_json_usage_limit_event_enters_durable_backoff(tmp_path) -> None:
             json.dumps(
                 {
                     "type": "error",
-                    "message": "You've hit your usage limit. Untrusted stderr JSON.",
+                    "message": CANONICAL_CODEX_USAGE_LIMIT,
                 }
             ),
         ),
@@ -3520,7 +3558,7 @@ def test_codex_json_usage_limit_backoff_replay_is_idempotent(tmp_path) -> None:
     state = ledger(tmp_path)
     launcher, calls = _codex_json_usage_failure_launcher(
         tmp_path,
-        message="You've hit your usage limit. Synthetic retry guidance.",
+        message=CANONICAL_CODEX_USAGE_LIMIT,
     )
     consumer = VerificationConsumer(
         state, Truth(eligible_pr(), GREEN), Auth(), launcher, "host"
@@ -3538,7 +3576,7 @@ def test_codex_json_usage_limit_backoff_replay_is_idempotent(tmp_path) -> None:
 
 
 def test_codex_json_usage_limit_event_is_not_durable(tmp_path) -> None:
-    marker = "You've hit your usage limit. SYNTHETIC_PRIVATE_DIAGNOSTIC"
+    marker = CANONICAL_CODEX_USAGE_LIMIT
     state = ledger(tmp_path)
     launcher, _ = _codex_json_usage_failure_launcher(tmp_path, message=marker)
 

--- a/tests/dispatcher/test_verification_consumer.py
+++ b/tests/dispatcher/test_verification_consumer.py
@@ -3676,7 +3676,9 @@ def test_codex_json_usage_limit_backoff_replay_is_idempotent(tmp_path) -> None:
         assert conn.execute("SELECT COUNT(*) FROM verification_attempts").fetchone()[0] == 1
 
 
-def test_codex_json_usage_limit_event_is_not_durable(tmp_path) -> None:
+def test_codex_json_usage_limit_event_is_not_durable(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     marker = CANONICAL_CODEX_USAGE_LIMIT
     state = ledger(tmp_path)
     launcher, _ = _codex_json_usage_failure_launcher(tmp_path, message=marker)
@@ -3684,6 +3686,7 @@ def test_codex_json_usage_limit_event_is_not_durable(tmp_path) -> None:
     result = VerificationConsumer(
         state, Truth(eligible_pr(), GREEN), Auth(), launcher, "host"
     ).consume(request())
+    captured = capsys.readouterr()
     backup = tmp_path / "dispatcher-backup.sqlite3"
     with state.store._connect() as source, sqlite3.connect(backup) as destination:
         source.backup(destination)
@@ -3697,6 +3700,8 @@ def test_codex_json_usage_limit_event_is_not_durable(tmp_path) -> None:
         sort_keys=True,
     )
     assert marker not in durable
+    assert marker not in captured.out
+    assert marker not in captured.err
     assert marker.encode() not in state.store.db_path.read_bytes()
     assert marker.encode() not in backup.read_bytes()
 

--- a/tests/dispatcher/test_verification_consumer.py
+++ b/tests/dispatcher/test_verification_consumer.py
@@ -13,6 +13,7 @@ import sys
 from threading import Condition, Thread
 from typing import Callable, Mapping
 import zipfile
+from zoneinfo import ZoneInfo
 
 import pytest
 import jsonschema
@@ -3565,6 +3566,70 @@ def test_codex_json_usage_limit_event_enters_durable_backoff(
     assert [(row[0], row[1]) for row in attempts] == [
         ("verification", "rate_limited")
     ]
+
+
+def test_codex_time_only_retry_accepts_future_fall_back_fold(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stockholm = ZoneInfo("Europe/Stockholm")
+    current = datetime(2026, 10, 25, 2, 30, tzinfo=stockholm, fold=0)
+    monkeypatch.setattr(
+        verification_consumer, "_local_now", lambda: current, raising=False
+    )
+    launcher, _ = _codex_json_usage_failure_launcher(
+        tmp_path,
+        message="You've hit your usage limit. Try again at 2:15 AM.",
+    )
+
+    result = VerificationConsumer(
+        ledger(tmp_path), Truth(eligible_pr(), GREEN), Auth(), launcher, "host"
+    ).consume(request())
+
+    assert result.status == "backoff"
+    assert result.terminal_receipt["outcome"] == "rate_limited"
+
+
+@pytest.mark.parametrize(
+    ("current", "retry"),
+    [
+        (
+            datetime(
+                2026,
+                10,
+                25,
+                2,
+                0,
+                tzinfo=ZoneInfo("Europe/Stockholm"),
+                fold=0,
+            ),
+            "Oct 25th, 2026 2:45 AM",
+        ),
+        (
+            datetime(
+                2026, 3, 28, 12, 0, tzinfo=ZoneInfo("Europe/Stockholm")
+            ),
+            "Mar 29th, 2026 2:30 AM",
+        ),
+    ],
+)
+def test_noncanonical_or_nonexistent_local_retry_cannot_mint_backoff(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    current: datetime,
+    retry: str,
+) -> None:
+    monkeypatch.setattr(verification_consumer, "_local_now", lambda: current)
+    launcher, _ = _codex_json_usage_failure_launcher(
+        tmp_path,
+        message=f"You've hit your usage limit. Try again at {retry}.",
+    )
+
+    result = VerificationConsumer(
+        ledger(tmp_path), Truth(eligible_pr(), GREEN), Auth(), launcher, "host"
+    ).consume(request())
+
+    assert result.status == "failed"
+    assert result.terminal_receipt["failure_class"] == "execution"
 
 
 @pytest.mark.parametrize(

--- a/tests/dispatcher/test_verification_consumer.py
+++ b/tests/dispatcher/test_verification_consumer.py
@@ -3400,6 +3400,7 @@ def _codex_json_usage_failure_launcher(
     message: str,
     nested: bool = False,
     stderr: str = "",
+    extra_event_fields: Mapping[str, object] | None = None,
 ) -> tuple[CodexExecLauncher, list[list[str]]]:
     class Result:
         returncode = 1
@@ -3414,7 +3415,11 @@ def _codex_json_usage_failure_launcher(
                     },
                 }
                 if nested
-                else {"type": "error", "message": message}
+                else {
+                    "type": "error",
+                    "message": message,
+                    **(extra_event_fields or {}),
+                }
             )
             self.stdout = "\n".join(
                 (
@@ -3644,6 +3649,32 @@ def test_untrusted_usage_limit_text_cannot_mint_backoff(
 ) -> None:
     launcher, _ = _codex_json_usage_failure_launcher(
         tmp_path, message=message, nested=nested, stderr=stderr
+    )
+
+    result = VerificationConsumer(
+        ledger(tmp_path), Truth(eligible_pr(), GREEN), Auth(), launcher, "host"
+    ).consume(request())
+
+    assert result.status == "failed"
+    assert result.stop_reason == "codex_exec_failed"
+    assert result.terminal_receipt["failure_class"] == "execution"
+
+
+@pytest.mark.parametrize(
+    "extra_event_fields",
+    [
+        {"usage_limit": False},
+        {"source": "model"},
+        {"payload": {"type": "agent_message", "usage_limit": True}},
+    ],
+)
+def test_noncanonical_codex_usage_limit_event_envelope_cannot_mint_backoff(
+    tmp_path: Path, extra_event_fields: Mapping[str, object]
+) -> None:
+    launcher, _ = _codex_json_usage_failure_launcher(
+        tmp_path,
+        message=CANONICAL_CODEX_USAGE_LIMIT,
+        extra_event_fields=extra_event_fields,
     )
 
     result = VerificationConsumer(

--- a/tests/dispatcher/test_verification_consumer.py
+++ b/tests/dispatcher/test_verification_consumer.py
@@ -3632,6 +3632,48 @@ def test_noncanonical_or_nonexistent_local_retry_cannot_mint_backoff(
     assert result.terminal_receipt["failure_class"] == "execution"
 
 
+def test_retry_timestamp_fails_closed_without_rule_bearing_local_timezone(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(verification_consumer, "_local_now", lambda: None)
+    launcher, _ = _codex_json_usage_failure_launcher(
+        tmp_path,
+        message=f"You've hit your usage limit. Try again at {FUTURE_CODEX_RETRY}.",
+    )
+
+    result = VerificationConsumer(
+        ledger(tmp_path), Truth(eligible_pr(), GREEN), Auth(), launcher, "host"
+    ).consume(request())
+
+    assert result.status == "failed"
+    assert result.stop_reason == "codex_exec_failed"
+    assert result.terminal_receipt["failure_class"] == "execution"
+
+
+def test_unrepresentable_retry_timestamp_cannot_mint_technical_backoff(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    current = datetime(
+        2026, 7, 15, 12, 0, tzinfo=ZoneInfo("America/New_York")
+    )
+    monkeypatch.setattr(verification_consumer, "_local_now", lambda: current)
+    launcher, _ = _codex_json_usage_failure_launcher(
+        tmp_path,
+        message=(
+            "You've hit your usage limit. Try again at "
+            "Dec 31st, 9999 11:59 PM."
+        ),
+    )
+
+    result = VerificationConsumer(
+        ledger(tmp_path), Truth(eligible_pr(), GREEN), Auth(), launcher, "host"
+    ).consume(request())
+
+    assert result.status == "failed"
+    assert result.stop_reason == "codex_exec_failed"
+    assert result.terminal_receipt["failure_class"] == "execution"
+
+
 @pytest.mark.parametrize(
     ("message", "nested", "stderr"),
     [

--- a/tests/dispatcher/test_verification_consumer.py
+++ b/tests/dispatcher/test_verification_consumer.py
@@ -6,6 +6,7 @@ import io
 import json
 import os
 from pathlib import Path
+import re
 import sqlite3
 import subprocess
 import sys
@@ -3484,6 +3485,27 @@ FUTURE_CODEX_RETRY = _codex_retry_timestamp(
 PAST_CODEX_RETRY = _codex_retry_timestamp(
     datetime.now().astimezone() - timedelta(days=1)
 )
+
+
+def _future_single_digit_day_retry() -> str:
+    candidate = datetime.now().astimezone() + timedelta(days=1)
+    while candidate.day >= 10:
+        candidate += timedelta(days=1)
+    return _codex_retry_timestamp(candidate)
+
+
+PADDED_HOUR_CODEX_RETRY = re.sub(
+    r" (?P<hour>[1-9]):(?P<minute>[0-9]{2}) (?P<period>AM|PM)$",
+    r" 0\g<hour>:\g<minute> \g<period>",
+    _codex_retry_timestamp(
+        (datetime.now().astimezone() + timedelta(days=2)).replace(hour=9)
+    ),
+)
+PADDED_DAY_CODEX_RETRY = re.sub(
+    r"^(?P<month>[A-Z][a-z]{2}) (?P<day>[1-9])(?P<suffix>st|nd|rd|th),",
+    r"\g<month> 0\g<day>\g<suffix>,",
+    _future_single_digit_day_retry(),
+)
 CANONICAL_CODEX_USAGE_LIMIT = (
     "You've hit your usage limit. Visit "
     "https://chatgpt.com/codex/settings/usage to purchase more credits "
@@ -3551,6 +3573,17 @@ def test_codex_json_usage_limit_event_enters_durable_backoff(
         ("You've hit your usage limit. . This is not an actual limit.", False, ""),
         ("You've hit your usage limit. Try again at 99:99 PM.", False, ""),
         ("You've hit your usage limit. Try again at 0:00 AM.", False, ""),
+        ("You've hit your usage limit. Try again at 09:30 PM.", False, ""),
+        (
+            f"You've hit your usage limit. Try again at {PADDED_HOUR_CODEX_RETRY}.",
+            False,
+            "",
+        ),
+        (
+            f"You've hit your usage limit. Try again at {PADDED_DAY_CODEX_RETRY}.",
+            False,
+            "",
+        ),
         (f"You've hit your usage limit. Try again at {PAST_CODEX_RETRY}.", False, ""),
         ("You've hit your usage limit. Try again at Jan 1st, 2020 4:30 PM.", False, ""),
         (

--- a/tests/dispatcher/test_verification_consumer.py
+++ b/tests/dispatcher/test_verification_consumer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 import io
 import json
 import os
@@ -3451,10 +3452,42 @@ def _codex_json_usage_failure_launcher(
     return launcher, calls
 
 
+def _codex_retry_timestamp(value: datetime) -> str:
+    suffix = (
+        "th"
+        if 11 <= value.day % 100 <= 13
+        else {1: "st", 2: "nd", 3: "rd"}.get(value.day % 10, "th")
+    )
+    hour = value.strftime("%I").lstrip("0")
+    return f"{value.strftime('%b')} {value.day}{suffix}, {value.year} {hour}:{value:%M %p}"
+
+
+def _next_leap_retry() -> str:
+    current = datetime.now().astimezone()
+    year = current.year
+    while True:
+        try:
+            candidate = current.replace(
+                year=year, month=2, day=29, hour=11, minute=59
+            )
+        except ValueError:
+            year += 1
+            continue
+        if candidate > current:
+            return _codex_retry_timestamp(candidate)
+        year += 1
+
+
+FUTURE_CODEX_RETRY = _codex_retry_timestamp(
+    datetime.now().astimezone() + timedelta(days=2)
+)
+PAST_CODEX_RETRY = _codex_retry_timestamp(
+    datetime.now().astimezone() - timedelta(days=1)
+)
 CANONICAL_CODEX_USAGE_LIMIT = (
     "You've hit your usage limit. Visit "
     "https://chatgpt.com/codex/settings/usage to purchase more credits "
-    "or try again at 4:30 PM."
+    f"or try again at {FUTURE_CODEX_RETRY}."
 )
 
 
@@ -3471,13 +3504,13 @@ CANONICAL_CODEX_USAGE_LIMIT = (
         ),
         (
             "You've hit your usage limit. To get more access now, send a request "
-            "to your admin or try again at Jul 16th, 2026 4:30 PM."
+            "to your admin or try again later."
         ),
         (
             "You've hit your usage limit. Upgrade to Plus to continue using Codex "
             "(https://chatgpt.com/explore/plus), or try again later."
         ),
-        "You've hit your usage limit. Try again at Feb 29th, 2028 11:59 PM.",
+        f"You've hit your usage limit. Try again at {_next_leap_retry()}.",
     ],
 )
 def test_codex_json_usage_limit_event_enters_durable_backoff(
@@ -3518,6 +3551,8 @@ def test_codex_json_usage_limit_event_enters_durable_backoff(
         ("You've hit your usage limit. . This is not an actual limit.", False, ""),
         ("You've hit your usage limit. Try again at 99:99 PM.", False, ""),
         ("You've hit your usage limit. Try again at 0:00 AM.", False, ""),
+        (f"You've hit your usage limit. Try again at {PAST_CODEX_RETRY}.", False, ""),
+        ("You've hit your usage limit. Try again at Jan 1st, 2020 4:30 PM.", False, ""),
         (
             "You've hit your usage limit. Try again at Feb 99th, 0000 88:77 AM.",
             False,
@@ -3530,6 +3565,21 @@ def test_codex_json_usage_limit_event_enters_durable_backoff(
         ),
         (
             "You've hit your usage limit. Try again at Feb 29th, 2025 4:30 PM.",
+            False,
+            "",
+        ),
+        ("You've hit your uſage limit. Try again later.", False, ""),
+        ("You've hit your usage\u00a0limit. Try again later.", False, ""),
+        (
+            "You've hit your usage limit. To get more acceß now, send a request "
+            "to your admin or try again later.",
+            False,
+            "",
+        ),
+        (
+            "You've hit your usage limit. Visit "
+            "httpſ://chatgpt.com/codex/ſettingſ/uſage to purchase more credits "
+            "or try again later.",
             False,
             "",
         ),

--- a/tests/dispatcher/test_verification_consumer.py
+++ b/tests/dispatcher/test_verification_consumer.py
@@ -3477,6 +3477,7 @@ CANONICAL_CODEX_USAGE_LIMIT = (
             "You've hit your usage limit. Upgrade to Plus to continue using Codex "
             "(https://chatgpt.com/explore/plus), or try again later."
         ),
+        "You've hit your usage limit. Try again at Feb 29th, 2028 11:59 PM.",
     ],
 )
 def test_codex_json_usage_limit_event_enters_durable_backoff(
@@ -3515,6 +3516,23 @@ def test_codex_json_usage_limit_event_enters_durable_backoff(
         ("You've hit your usage limit. false", False, ""),
         ("You've hit your usage limit! false", False, ""),
         ("You've hit your usage limit. . This is not an actual limit.", False, ""),
+        ("You've hit your usage limit. Try again at 99:99 PM.", False, ""),
+        ("You've hit your usage limit. Try again at 0:00 AM.", False, ""),
+        (
+            "You've hit your usage limit. Try again at Feb 99th, 0000 88:77 AM.",
+            False,
+            "",
+        ),
+        (
+            "You've hit your usage limit. Try again at Jul 11st, 2026 4:30 PM.",
+            False,
+            "",
+        ),
+        (
+            "You've hit your usage limit. Try again at Feb 29th, 2025 4:30 PM.",
+            False,
+            "",
+        ),
         (
             "You've hit your usage limit. Try again later.\" is only an example.",
             False,

--- a/tests/dispatcher/test_verification_consumer.py
+++ b/tests/dispatcher/test_verification_consumer.py
@@ -5,6 +5,7 @@ import io
 import json
 import os
 from pathlib import Path
+import sqlite3
 import subprocess
 import sys
 from threading import Condition, Thread
@@ -3389,6 +3390,176 @@ def _nonzero_codex_launcher(tmp_path, stderr: str) -> CodexExecLauncher:
         / ".codex/agents/verification-closer.toml",
         runner=runner,
     )
+
+
+def _codex_json_usage_failure_launcher(
+    tmp_path: Path,
+    *,
+    message: str,
+    nested: bool = False,
+    stderr: str = "",
+) -> tuple[CodexExecLauncher, list[list[str]]]:
+    class Result:
+        returncode = 1
+
+        def __init__(self) -> None:
+            event = (
+                {
+                    "type": "item.completed",
+                    "item": {
+                        "type": "agent_message",
+                        "text": json.dumps({"type": "error", "message": message}),
+                    },
+                }
+                if nested
+                else {"type": "error", "message": message}
+            )
+            self.stdout = "\n".join(
+                (
+                    json.dumps(
+                        {
+                            "type": "thread.started",
+                            "thread_id": "01900000-0000-7000-8000-000000000017",
+                        }
+                    ),
+                    json.dumps(event),
+                    json.dumps(
+                        {
+                            "type": "turn.failed",
+                            "error": {"message": "synthetic execution failure"},
+                        }
+                    ),
+                )
+            )
+            self.stderr = stderr
+
+    calls: list[list[str]] = []
+
+    def runner(command: list[str], **_kwargs: object) -> Result:
+        calls.append(command)
+        return Result()
+
+    launcher = CodexExecLauncher(
+        tmp_path,
+        Path(__file__).resolve().parents[2]
+        / "app/dispatcher/schemas/verification_closer_receipt.schema.json",
+        tmp_path / "context.json",
+        adapter_path=Path(__file__).resolve().parents[2]
+        / ".codex/agents/verification-closer.toml",
+        runner=runner,
+    )
+    return launcher, calls
+
+
+def test_codex_json_usage_limit_event_enters_durable_backoff(tmp_path) -> None:
+    state = ledger(tmp_path)
+    launcher, calls = _codex_json_usage_failure_launcher(
+        tmp_path,
+        message="You've hit your usage limit. Synthetic retry guidance.",
+    )
+
+    result = VerificationConsumer(
+        state, Truth(eligible_pr(), GREEN), Auth(), launcher, "host"
+    ).consume(request())
+
+    assert result.status == "backoff"
+    assert result.terminal_receipt["outcome"] == "rate_limited"
+    assert result.terminal_receipt["api_fallback"] is False
+    assert result.terminal_receipt["failure_receipt"]["failure_class"] == "rate_limit"
+    assert len(calls) == 1
+    with state.store._connect() as conn:
+        attempts = conn.execute(
+            "SELECT attempt_kind, outcome FROM verification_attempts"
+        ).fetchall()
+    assert [(row[0], row[1]) for row in attempts] == [
+        ("verification", "rate_limited")
+    ]
+
+
+@pytest.mark.parametrize(
+    ("message", "nested", "stderr"),
+    [
+        ("This is not a usage limit.", False, ""),
+        ("Example: You've hit your usage limit.", False, ""),
+        ("You've hit your usage limit: false", False, ""),
+        ("You've hit your usage limit. Nested model text.", True, ""),
+        (
+            "synthetic execution failure",
+            False,
+            "You've hit your usage limit. Untrusted stderr.",
+        ),
+        (
+            "synthetic execution failure",
+            False,
+            json.dumps(
+                {
+                    "type": "error",
+                    "message": "You've hit your usage limit. Untrusted stderr JSON.",
+                }
+            ),
+        ),
+    ],
+)
+def test_untrusted_usage_limit_text_cannot_mint_backoff(
+    tmp_path: Path, message: str, nested: bool, stderr: str
+) -> None:
+    launcher, _ = _codex_json_usage_failure_launcher(
+        tmp_path, message=message, nested=nested, stderr=stderr
+    )
+
+    result = VerificationConsumer(
+        ledger(tmp_path), Truth(eligible_pr(), GREEN), Auth(), launcher, "host"
+    ).consume(request())
+
+    assert result.status == "failed"
+    assert result.stop_reason == "codex_exec_failed"
+    assert result.terminal_receipt["failure_class"] == "execution"
+
+
+def test_codex_json_usage_limit_backoff_replay_is_idempotent(tmp_path) -> None:
+    state = ledger(tmp_path)
+    launcher, calls = _codex_json_usage_failure_launcher(
+        tmp_path,
+        message="You've hit your usage limit. Synthetic retry guidance.",
+    )
+    consumer = VerificationConsumer(
+        state, Truth(eligible_pr(), GREEN), Auth(), launcher, "host"
+    )
+
+    first = consumer.consume(request())
+    replay = consumer.consume(request())
+
+    assert first.run_id == replay.run_id
+    assert first.status == replay.status == "backoff"
+    assert len(calls) == 1
+    with state.store._connect() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM verification_runs").fetchone()[0] == 1
+        assert conn.execute("SELECT COUNT(*) FROM verification_attempts").fetchone()[0] == 1
+
+
+def test_codex_json_usage_limit_event_is_not_durable(tmp_path) -> None:
+    marker = "You've hit your usage limit. SYNTHETIC_PRIVATE_DIAGNOSTIC"
+    state = ledger(tmp_path)
+    launcher, _ = _codex_json_usage_failure_launcher(tmp_path, message=marker)
+
+    result = VerificationConsumer(
+        state, Truth(eligible_pr(), GREEN), Auth(), launcher, "host"
+    ).consume(request())
+    backup = tmp_path / "dispatcher-backup.sqlite3"
+    with state.store._connect() as source, sqlite3.connect(backup) as destination:
+        source.backup(destination)
+
+    durable = json.dumps(
+        {
+            "attempts": state.attempts(result.run_id),
+            "terminal": result.terminal_receipt,
+            "status": _compact_verification_run(result),
+        },
+        sort_keys=True,
+    )
+    assert marker not in durable
+    assert marker.encode() not in state.store.db_path.read_bytes()
+    assert marker.encode() not in backup.read_bytes()
 
 
 def test_negated_nonzero_rate_limit_text_is_not_backoff_evidence(tmp_path) -> None:


### PR DESCRIPTION
Governing-Issue: #3812

Fixes #3812

## Summary

- retain the exact top-level Codex CLI usage-limit event as a transient boolean even when a later `turn.failed` event arrives
- require exact ASCII/case/spacing for the current official Codex plan-guidance and retry grammar; no Unicode or whitespace normalization crosses the trust boundary
- semantically parse real 12-hour times/calendar dates, verify ordinal suffixes, reject past retries, and bound future dates
- reject prefix-only, impossible timestamp/date, wrong-ordinal, Unicode-folding, old-date, negated, quoted/example, explicit-false, nested model/tool, arbitrary stderr, and stderr-JSON lookalikes
- route only that trusted subscription-exhaustion signal into one durable backoff with no API fallback or repair-budget use
- prove raw event text never reaches SQLite, backups, terminal receipts, or compact status

## SBS impact

Builder System boundary hardening only. D11 keeps one durable run/backoff and the existing attempt evidence without raw diagnostics. D12 grants no new authority: only the top-level Codex CLI event envelope with an exact versioned ASCII grammar and plausible future semantic retry can select this classification. No Product/Runtime, vault, or user-memory changes.

## Verification

- red proof: the production positive and replay regressions failed as terminal `codex_exec_failed` before the repair
- independent review rejects reproduced punctuation-suffix spoofing, impossible time/date/ordinal acceptance, Unicode compatibility folding, and past-date acceptance; every reported finding has a committed production-path negative
- focused success/negative/replay/durability/envelope suite — 40 passed
- `pytest -q tests/dispatcher/test_verification_consumer.py` — 143 passed
- `pytest -q tests/dispatcher/test_verification_review_repairs_takeover.py` — 51 passed
- focused consumer + repair-takeover suites — 194 passed
- `ruff check app tests` — passed
- `mypy app` — passed (744 source files)
- raw `python3 scripts/docs_guard.py` — expected temporal-owner guard rejection; `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1 python3 scripts/docs_guard.py` — passed because the owning dispatcher contract is updated and no high-risk temporal owner doc changes
- `git diff --check` — passed
- repo-wide non-PG suite — 9,122 passed / 114 skipped / 18 xfailed; exact-head GitHub checks remain blocking

## BuilderOps Routing

- Records/projections/receipts: dispatcher claim for issue #3812 and host operational receipt on #3603 after exact-head merge and disabled pilot retry
- Reason: this is Builder System operational truth; no Product-memory or BuilderOps Vault record is created