### PR TITLE
Fix CI ownership for deploy pin files

### DIFF
--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -438,7 +438,7 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
     ),
     (
         "ops_deploy",
-        ("scripts/", "ops/", "tests/ops/", "tests/scripts/", "tests/deploy/"),
+        ("scripts/", "ops/", "config/deploy/", "tests/ops/", "tests/scripts/", "tests/deploy/"),
         ("tests/ops", "tests/scripts", "tests/deploy"),
     ),
     (
@@ -562,6 +562,17 @@ def _pr_targets(targets: list[str]) -> tuple[str, ...]:
     return _dedupe(target for target in targets if not target.startswith("tests/e2e/"))
 
 
+def _unowned_runtime_code_paths(paths: tuple[str, ...]) -> tuple[str, ...]:
+    runtime_prefixes = ("app/", "companion-ui/")
+    owned_prefixes = tuple(prefix for _, prefixes, _ in SUBSYSTEMS for prefix in prefixes)
+    return tuple(
+        path
+        for path in paths
+        if path.startswith(runtime_prefixes)
+        and not any(path.startswith(prefix) for prefix in owned_prefixes)
+    )
+
+
 def select_tests(changed_files: list[str]) -> Selection:
     paths = tuple(path for path in (_normalize(item) for item in changed_files) if path)
     if not paths:
@@ -587,6 +598,16 @@ def select_tests(changed_files: list[str]) -> Selection:
         for path in paths
     ):
         return Selection(True, (), (), FULL_SUITE_REASONS[1])
+
+    unowned_runtime_code = _unowned_runtime_code_paths(paths)
+    if unowned_runtime_code:
+        return Selection(
+            False,
+            ("unowned",),
+            (),
+            FULL_SUITE_REASONS[2],
+            unowned_runtime_code,
+        )
 
     changed_tests = _changed_test_targets(paths)
     targets = list(ALWAYS_TARGETS)

--- a/tests/scripts/test_select_pr_tests.py
+++ b/tests/scripts/test_select_pr_tests.py
@@ -59,6 +59,25 @@ def test_unknown_runtime_surface_fails_closed_until_it_has_an_owner() -> None:
     assert selection.unowned_paths == ("app/new_surface/example.py",)
 
 
+def test_deploy_pin_file_selects_ops_deploy() -> None:
+    selection = select_tests(["config/deploy/dev.env"])
+
+    assert selection.full_suite is False
+    assert selection.subsystems == ("ops_deploy",)
+    assert selection.unowned_paths == ()
+    assert "tests/ops" in selection.targets
+    assert "tests/scripts" in selection.targets
+    assert "tests/deploy" in selection.targets
+
+
+def test_deploy_pin_cannot_mask_an_unowned_runtime_path() -> None:
+    selection = select_tests(["config/deploy/dev.env", "app/new_surface/example.py"])
+
+    assert selection.full_suite is False
+    assert selection.subsystems == ("unowned",)
+    assert selection.unowned_paths == ("app/new_surface/example.py",)
+
+
 def test_docs_authoring_and_skill_paths_are_owned() -> None:
     # Reproduces the #3476 / PR #3475 failure: a docs-authoring PR touching
     # docs/contracts/**, docs/HEIMDAL/**, api/openapi.yaml, and .codex/skills/**


### PR DESCRIPTION
## Summary
- assign `config/deploy/**` to the existing `ops_deploy` PR-test selector route
- cover pin-only and mixed owned/unowned changes while preserving fail-closed behavior

## Classification
- Primary subsystem: Builder System
- Secondary subsystem(s): deployment operations
- Change class: current-state correction
- Owner-doc impact: none; `TEST_STRATEGY_HOT_PATH.md` already requires every changed path to resolve to an owner

## Verification
- `pytest -q tests/scripts/test_select_pr_tests.py` — 57 passed
- selected `ops_deploy` command (`tests/ci tests/ops tests/scripts tests/deploy`) — 540 passed, 1 deselected
- `ruff check app tests` — passed
- `git diff --check` — passed

## Coordination
- Dispatcher unavailable (`dispatcher_db_uninitialized`); used GitHub-label-only claim.
- Claim receipt: issue comment `4986057563`.

## BuilderOps Routing
- Records/projections/receipts: GitHub Issue #3839 and pickup claim receipt comment `4986057563`.
- Reason: The CI selector contract defect was promoted to the canonical GitHub backlog and delivered through the issue-to-code lane; no separate BuilderOps Vault record was required.

Fixes #3839
