### PR TITLE
fix(dispatcher): preserve legacy v1 clean-review receipt replay

### DIFF
--- a/app/dispatcher/verification_consumer.py
+++ b/app/dispatcher/verification_consumer.py
@@ -2029,7 +2029,8 @@ class CodexExecLauncher:
             lines = result.stdout.splitlines()
             stderr_chunks = [str(getattr(result, "stderr", "") or "")[-16_384:]]
         thread_id: str | None = resume_session_id
-        terminal: dict[str, object] | None = None
+        terminal_strict: dict[str, object] | None = None
+        terminal_fallback: dict[str, object] | None = None
         terminal_error: str | None = None
         terminal_rate_limited = False
         try:
@@ -2088,7 +2089,11 @@ class CodexExecLauncher:
                                 # so a policy-v2 run still fails closed there
                                 # (with the accurate invalid_receipt_contract
                                 # reason) instead of being misclassified as a
-                                # launcher contract failure here.
+                                # launcher contract failure here. A fallback
+                                # match is ranked below every strict match: a
+                                # trailing legacy-shaped message must never
+                                # clobber a strictly-valid final receipt the
+                                # stream already produced.
                                 if not isinstance(candidate, Mapping):
                                     continue
                                 try:
@@ -2099,7 +2104,9 @@ class CodexExecLauncher:
                                     )
                                 except jsonschema.ValidationError:
                                     continue
-                            terminal = candidate
+                                terminal_fallback = dict(candidate)
+                            else:
+                                terminal_strict = candidate
         except Exception:
             stop_heartbeat.set()
             terminate_and_reap_child()
@@ -2180,6 +2187,10 @@ class CodexExecLauncher:
             )
         if not thread_id:
             raise RuntimeError("codex exec produced no thread identity")
+        # The latest strictly-valid receipt always outranks any legacy-shaped
+        # fallback candidate; the fallback is used only when the whole stream
+        # produced no strict match.
+        terminal = terminal_strict if terminal_strict is not None else terminal_fallback
         if terminal is None:
             raise RuntimeError("codex exec produced no schema-valid final agent receipt")
         return thread_id, terminal

--- a/app/dispatcher/verification_consumer.py
+++ b/app/dispatcher/verification_consumer.py
@@ -414,11 +414,8 @@ def validate_verification_closer_receipt(
                 f"review event {index} requires a stable finding, failure domain, "
                 "and mechanism binding"
             )
-        if (
-            event.get("kind") == "review"
-            and event.get("outcome") == "clean"
-            and not allow_legacy_unbound_repairs
-            and any(value is not None for value in binding)
+        if event.get("kind") == "review" and event.get("outcome") == "clean" and any(
+            value is not None for value in binding
         ):
             raise jsonschema.ValidationError(
                 f"clean review event {index} cannot carry a failure binding"
@@ -449,6 +446,21 @@ def _normalize_v1_review_event(event: Mapping[str, object]) -> dict[str, object]
     return normalized
 
 
+def _v1_compatible_receipt_candidate(
+    receipt: Mapping[str, object],
+) -> dict[str, object]:
+    """Project one receipt onto its policy-v1 compatible validation shape."""
+
+    candidate = dict(receipt)
+    events = candidate.get("review_events")
+    if isinstance(events, list):
+        candidate["review_events"] = [
+            _normalize_v1_review_event(event) if isinstance(event, Mapping) else event
+            for event in events
+        ]
+    return candidate
+
+
 def load_and_validate_verification_closer_receipt(
     receipt: object,
     schema_path: Path,
@@ -475,16 +487,11 @@ def load_and_validate_verification_closer_receipt(
         raise ReceiptContractError("verification closer receipt schema is invalid") from exc
     if not isinstance(receipt, Mapping):
         raise ReceiptContractError("verification closer receipt must be an object")
-    candidate = dict(receipt)
-    if repair_budget_policy == "v1" and isinstance(
-        candidate.get("review_events"), list
-    ):
-        candidate["review_events"] = [
-            _normalize_v1_review_event(event)
-            if isinstance(event, Mapping)
-            else event
-            for event in candidate["review_events"]
-        ]
+    candidate = (
+        _v1_compatible_receipt_candidate(receipt)
+        if repair_budget_policy == "v1"
+        else dict(receipt)
+    )
     allow_legacy = repair_budget_policy == "v1"
     try:
         validate_verification_closer_receipt(
@@ -2064,9 +2071,34 @@ class CodexExecLauncher:
                         if isinstance(text, str):
                             try:
                                 candidate = json.loads(text)
-                                validate_verification_closer_receipt(candidate, schema)
-                            except (json.JSONDecodeError, jsonschema.ValidationError):
+                            except json.JSONDecodeError:
                                 continue
+                            try:
+                                validate_verification_closer_receipt(candidate, schema)
+                            except jsonschema.ValidationError:
+                                # A resumed policy-v1 coordinator may emit a
+                                # receipt in the legacy shape (missing binding
+                                # keys, or a clean review carrying stale
+                                # binding fields) that the strict contract
+                                # rejects. This stream filter only selects the
+                                # terminal candidate; the consumer re-validates
+                                # it through
+                                # load_and_validate_verification_closer_receipt
+                                # with the run's actual repair_budget_policy,
+                                # so a policy-v2 run still fails closed there
+                                # (with the accurate invalid_receipt_contract
+                                # reason) instead of being misclassified as a
+                                # launcher contract failure here.
+                                if not isinstance(candidate, Mapping):
+                                    continue
+                                try:
+                                    validate_verification_closer_receipt(
+                                        _v1_compatible_receipt_candidate(candidate),
+                                        schema,
+                                        allow_legacy_unbound_repairs=True,
+                                    )
+                                except jsonschema.ValidationError:
+                                    continue
                             terminal = candidate
         except Exception:
             stop_heartbeat.set()

--- a/app/dispatcher/verification_consumer.py
+++ b/app/dispatcher/verification_consumer.py
@@ -414,12 +414,39 @@ def validate_verification_closer_receipt(
                 f"review event {index} requires a stable finding, failure domain, "
                 "and mechanism binding"
             )
-        if event.get("kind") == "review" and event.get("outcome") == "clean" and any(
-            value is not None for value in binding
+        if (
+            event.get("kind") == "review"
+            and event.get("outcome") == "clean"
+            and not allow_legacy_unbound_repairs
+            and any(value is not None for value in binding)
         ):
             raise jsonschema.ValidationError(
                 f"clean review event {index} cannot carry a failure binding"
             )
+
+
+def _normalize_v1_review_event(event: Mapping[str, object]) -> dict[str, object]:
+    """Normalize one policy-v1 review event before validation.
+
+    Policy-v1 pending receipts predate the policy-v2 binding contract: the
+    legacy schema allowed ``finding_id``/``failure_domain``/``mechanism_id``
+    on every review event, and the legacy application ignored those fields
+    on a clean review. Fill in missing binding keys as ``None`` so schema
+    validation sees the key, and scrub a clean review's binding fields to
+    ``None`` so a stale legacy value is never treated as authoritative
+    failure-domain or mechanism data, nor carried into durable state.
+    """
+
+    normalized: dict[str, object] = {
+        **dict(event),
+        "failure_domain": event.get("failure_domain"),
+        "mechanism_id": event.get("mechanism_id"),
+    }
+    if event.get("kind") == "review" and event.get("outcome") == "clean":
+        normalized["finding_id"] = None
+        normalized["failure_domain"] = None
+        normalized["mechanism_id"] = None
+    return normalized
 
 
 def load_and_validate_verification_closer_receipt(
@@ -453,11 +480,7 @@ def load_and_validate_verification_closer_receipt(
         candidate.get("review_events"), list
     ):
         candidate["review_events"] = [
-            {
-                **dict(event),
-                "failure_domain": event.get("failure_domain"),
-                "mechanism_id": event.get("mechanism_id"),
-            }
+            _normalize_v1_review_event(event)
             if isinstance(event, Mapping)
             else event
             for event in candidate["review_events"]

--- a/tests/dispatcher/test_verification_mechanism_budget.py
+++ b/tests/dispatcher/test_verification_mechanism_budget.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sqlite3
 from pathlib import Path
 
@@ -11,6 +12,7 @@ from app.dispatcher.config import load_paths
 from app.dispatcher.store import SqliteStore
 from app.dispatcher.verification_agent_loop import VerificationAgentLoop
 from app.dispatcher.verification_consumer import (
+    CodexExecLauncher,
     ReceiptContractError,
     VerificationConsumer,
     context_pack,
@@ -489,7 +491,15 @@ def test_v1_pending_receipt_replay_accepts_legacy_unbound_event_shape(
     assert attempts[0]["mechanism_id"] is None
 
 
-def test_resumed_v1_launcher_accepts_legacy_repair_receipt(tmp_path) -> None:
+def _v1_backoff_run(tmp_path):
+    """Park one pending policy-v1 run in backoff with a stored session.
+
+    Mirrors the production migration outage shape: the run row carries
+    ``repair_budget_policy='v1'``, a first launch rate-limited into backoff
+    (persisting a coordinator session id to resume), and the retry window is
+    already open.
+    """
+
     state = ledger(tmp_path)
     run = state.ingest(request())
     with state.store._connect() as conn:
@@ -515,6 +525,11 @@ def test_resumed_v1_launcher_accepts_legacy_repair_receipt(tmp_path) -> None:
             (run.run_id,),
         )
         conn.commit()
+    return state, run, truth, first
+
+
+def test_resumed_v1_launcher_accepts_legacy_repair_receipt(tmp_path) -> None:
+    state, run, truth, first = _v1_backoff_run(tmp_path)
 
     class LegacyRepairLauncher(Launcher):
         def launch(self, context_pack, **kwargs):
@@ -565,31 +580,7 @@ def test_v1_pending_clean_review_receipt_ignores_legacy_binding_fields(
     clean outcome). Replay must not terminalize the run as an invalid
     persisted receipt, and the legacy binding must never become durable."""
 
-    state = ledger(tmp_path)
-    run = state.ingest(request())
-    with state.store._connect() as conn:
-        conn.execute(
-            "UPDATE verification_runs SET repair_budget_policy='v1' WHERE run_id=?",
-            (run.run_id,),
-        )
-        conn.commit()
-    truth = Truth(eligible_pr(), GREEN)
-    first = VerificationConsumer(
-        state,
-        truth,
-        Auth(),
-        RateLimitedLauncher(),
-        "host",
-    ).consume(request())
-    assert first.status == "backoff"
-    assert first.coordinator_session_id is not None
-    with state.store._connect() as conn:
-        conn.execute(
-            "UPDATE verification_runs SET retry_after='2000-01-01T00:00:00+00:00' "
-            "WHERE run_id=?",
-            (run.run_id,),
-        )
-        conn.commit()
+    state, run, truth, first = _v1_backoff_run(tmp_path)
 
     class LegacyCleanReviewLauncher(Launcher):
         def launch(self, context_pack, **kwargs):
@@ -688,6 +679,111 @@ def test_v2_clean_review_rejects_failure_binding_fields(tmp_path) -> None:
             trusted_repository="RasmusTho/agentic-pkm-mvp",
             trusted_evidence_urls=frozenset(),
         )
+
+
+def test_v1_real_launcher_stream_filter_accepts_legacy_clean_review_receipt(
+    tmp_path,
+) -> None:
+    """The CodexExecLauncher raw JSONL stream pre-filter must not swallow a
+    policy-v1 legacy clean-review terminal message: doing so leaves the
+    launcher with no schema-valid terminal receipt and misclassifies the run
+    as a launcher contract failure before
+    ``load_and_validate_verification_closer_receipt`` ever sees the receipt.
+    The stub-launcher tests above bypass this filter, so this test drives the
+    real launcher with a fake process runner."""
+
+    state = ledger(tmp_path)
+    run = state.ingest(request())
+    with state.store._connect() as conn:
+        conn.execute(
+            "UPDATE verification_runs SET repair_budget_policy='v1' WHERE run_id=?",
+            (run.run_id,),
+        )
+        conn.commit()
+
+    legacy_receipt = {
+        "verdict": "blocked",
+        "head_sha": HEAD,
+        "summary": "legacy clean review carries stale binding",
+        "receipt_ids": ["review-v1-stream"],
+        "retry_after": None,
+        "review_events": [
+            {
+                "kind": "review",
+                "session_id": "review-v1-stream",
+                "capability": "gpt-5.6-terra",
+                "reasoning_effort": "high",
+                "outcome": "clean",
+                "finding_id": "F1",
+                "failure_domain": CODE,
+                "mechanism_id": "parser",
+                "strongest": None,
+            }
+        ],
+        "human_exception": None,
+    }
+    stdout = (
+        json.dumps(
+            {
+                "type": "thread.started",
+                "thread_id": "01900000-0000-7000-8000-000000000042",
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "agent_message",
+                    "text": json.dumps(legacy_receipt),
+                },
+            }
+        )
+        + "\n"
+    )
+
+    class Result:
+        returncode = 0
+        stderr = ""
+
+    Result.stdout = stdout
+
+    def runner(command, **kwargs):
+        return Result()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    launcher = CodexExecLauncher(
+        tmp_path,
+        repo_root / "app/dispatcher/schemas/verification_closer_receipt.schema.json",
+        tmp_path / "context.json",
+        adapter_path=repo_root / ".codex/agents/verification-closer.toml",
+        runner=runner,
+    )
+    result = VerificationConsumer(
+        state,
+        Truth(eligible_pr(), GREEN),
+        Auth(),
+        launcher,
+        "host",
+    ).consume(request())
+
+    # A blocked verdict terminates as failed; the legacy binding must be
+    # neither a launcher-contract misclassification nor a receipt-contract
+    # rejection, and it must never become durable.
+    assert result.status == "failed"
+    assert result.stop_reason != "invalid_receipt_contract"
+    assert isinstance(result.terminal_receipt, dict)
+    assert result.terminal_receipt.get("outcome") != "launcher_contract_failed"
+    reviews = [
+        attempt
+        for attempt in state.attempts(run.run_id)
+        if attempt["kind"] == "review"
+    ]
+    assert len(reviews) == 1
+    assert reviews[0]["outcome"] == "clean"
+    assert reviews[0]["finding_id"] is None
+    assert reviews[0]["failure_domain"] is None
+    assert reviews[0]["mechanism_id"] is None
 
 
 def test_declared_v4_missing_budget_identity_fails_closed_without_repair(

--- a/tests/dispatcher/test_verification_mechanism_budget.py
+++ b/tests/dispatcher/test_verification_mechanism_budget.py
@@ -556,6 +556,140 @@ def test_resumed_v1_launcher_accepts_legacy_repair_receipt(tmp_path) -> None:
     assert repairs[0]["mechanism_id"] is None
 
 
+def test_v1_pending_clean_review_receipt_ignores_legacy_binding_fields(
+    tmp_path,
+) -> None:
+    """A migrated policy-v1 pending receipt may carry a clean review event
+    with a stale ``finding_id``/``failure_domain``/``mechanism_id`` left over
+    from the legacy schema (the legacy application ignored those fields on a
+    clean outcome). Replay must not terminalize the run as an invalid
+    persisted receipt, and the legacy binding must never become durable."""
+
+    state = ledger(tmp_path)
+    run = state.ingest(request())
+    with state.store._connect() as conn:
+        conn.execute(
+            "UPDATE verification_runs SET repair_budget_policy='v1' WHERE run_id=?",
+            (run.run_id,),
+        )
+        conn.commit()
+    truth = Truth(eligible_pr(), GREEN)
+    first = VerificationConsumer(
+        state,
+        truth,
+        Auth(),
+        RateLimitedLauncher(),
+        "host",
+    ).consume(request())
+    assert first.status == "backoff"
+    assert first.coordinator_session_id is not None
+    with state.store._connect() as conn:
+        conn.execute(
+            "UPDATE verification_runs SET retry_after='2000-01-01T00:00:00+00:00' "
+            "WHERE run_id=?",
+            (run.run_id,),
+        )
+        conn.commit()
+
+    class LegacyCleanReviewLauncher(Launcher):
+        def launch(self, context_pack, **kwargs):
+            resume_session_id = kwargs.get("resume_session_id")
+            self.calls.append((context_pack, resume_session_id))
+            if callback := kwargs.get("on_thread_started"):
+                callback(resume_session_id)
+            return resume_session_id, {
+                "verdict": "blocked",
+                "head_sha": HEAD,
+                "summary": "legacy clean review carries stale binding",
+                "receipt_ids": ["review-v1"],
+                "retry_after": None,
+                "review_events": [
+                    {
+                        "kind": "review",
+                        "session_id": "review-v1",
+                        "capability": "gpt-5.6-terra",
+                        "reasoning_effort": "high",
+                        "outcome": "clean",
+                        "finding_id": "F1",
+                        "failure_domain": CODE,
+                        "mechanism_id": "parser",
+                        "strongest": None,
+                    }
+                ],
+                "human_exception": None,
+            }
+
+    launcher = LegacyCleanReviewLauncher()
+    result = VerificationConsumer(state, truth, Auth(), launcher, "host").consume(
+        request()
+    )
+
+    assert launcher.calls[0][1] == first.coordinator_session_id
+    assert result.status == "failed"
+    assert isinstance(result.terminal_receipt, dict)
+    assert result.terminal_receipt.get("outcome") != "invalid_persisted_verification_receipt"
+    assert result.stop_reason != "invalid_receipt_contract"
+    reviews = [
+        attempt
+        for attempt in state.attempts(run.run_id)
+        if attempt["kind"] == "review"
+    ]
+    assert len(reviews) == 1
+    assert reviews[0]["outcome"] == "clean"
+    assert reviews[0]["finding_id"] is None
+    assert reviews[0]["failure_domain"] is None
+    assert reviews[0]["mechanism_id"] is None
+
+
+def test_v2_clean_review_rejects_failure_binding_fields(tmp_path) -> None:
+    """Policy-v2 clean review events must still fail closed on any binding
+    field — the legacy-compatibility scrub is scoped to policy-v1 only."""
+
+    schema = (
+        Path(__file__).resolve().parents[2]
+        / "app/dispatcher/schemas/verification_closer_receipt.schema.json"
+    )
+    receipt = {
+        "verdict": "blocked",
+        "head_sha": HEAD,
+        "summary": "v2 clean review must not carry a failure binding",
+        "receipt_ids": ["review-v2"],
+        "retry_after": None,
+        "review_events": [
+            {
+                "kind": "review",
+                "session_id": "review-v2",
+                "capability": "terra",
+                "reasoning_effort": "high",
+                "outcome": "clean",
+                "finding_id": "F1",
+                "failure_domain": CODE,
+                "mechanism_id": "parser",
+                "strongest": None,
+            }
+        ],
+        "human_exception": None,
+    }
+
+    with pytest.raises(ReceiptContractError):
+        load_and_validate_verification_closer_receipt(
+            receipt,
+            schema,
+            trusted_repository="RasmusTho/agentic-pkm-mvp",
+            trusted_evidence_urls=frozenset(),
+            repair_budget_policy="v2",
+        )
+
+    # Unset/default policy (not policy-v1) must also stay strict.
+    with pytest.raises(ReceiptContractError):
+        load_and_validate_verification_closer_receipt(
+            receipt,
+            schema,
+            trusted_repository="RasmusTho/agentic-pkm-mvp",
+            trusted_evidence_urls=frozenset(),
+        )
+
+
 def test_declared_v4_missing_budget_identity_fails_closed_without_repair(
     tmp_path,
 ) -> None:

--- a/tests/dispatcher/test_verification_mechanism_budget.py
+++ b/tests/dispatcher/test_verification_mechanism_budget.py
@@ -681,6 +681,54 @@ def test_v2_clean_review_rejects_failure_binding_fields(tmp_path) -> None:
         )
 
 
+def _coordinator_stream(*agent_message_payloads: object) -> str:
+    """One codex-exec JSONL stream: thread start plus final agent messages."""
+
+    lines = [
+        json.dumps(
+            {
+                "type": "thread.started",
+                "thread_id": "01900000-0000-7000-8000-000000000042",
+            }
+        )
+    ]
+    lines += [
+        json.dumps(
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "agent_message",
+                    "text": json.dumps(payload),
+                },
+            }
+        )
+        for payload in agent_message_payloads
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _stream_launcher(tmp_path: Path, stdout: str) -> CodexExecLauncher:
+    """A real CodexExecLauncher whose process runner replays one stream."""
+
+    class Result:
+        returncode = 0
+        stderr = ""
+
+    Result.stdout = stdout
+
+    def runner(command, **kwargs):
+        return Result()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    return CodexExecLauncher(
+        tmp_path,
+        repo_root / "app/dispatcher/schemas/verification_closer_receipt.schema.json",
+        tmp_path / "context.json",
+        adapter_path=repo_root / ".codex/agents/verification-closer.toml",
+        runner=runner,
+    )
+
+
 def test_v1_real_launcher_stream_filter_accepts_legacy_clean_review_receipt(
     tmp_path,
 ) -> None:
@@ -722,42 +770,9 @@ def test_v1_real_launcher_stream_filter_accepts_legacy_clean_review_receipt(
         ],
         "human_exception": None,
     }
-    stdout = (
-        json.dumps(
-            {
-                "type": "thread.started",
-                "thread_id": "01900000-0000-7000-8000-000000000042",
-            }
-        )
-        + "\n"
-        + json.dumps(
-            {
-                "type": "item.completed",
-                "item": {
-                    "type": "agent_message",
-                    "text": json.dumps(legacy_receipt),
-                },
-            }
-        )
-        + "\n"
-    )
-
-    class Result:
-        returncode = 0
-        stderr = ""
-
-    Result.stdout = stdout
-
-    def runner(command, **kwargs):
-        return Result()
-
-    repo_root = Path(__file__).resolve().parents[2]
-    launcher = CodexExecLauncher(
+    launcher = _stream_launcher(
         tmp_path,
-        repo_root / "app/dispatcher/schemas/verification_closer_receipt.schema.json",
-        tmp_path / "context.json",
-        adapter_path=repo_root / ".codex/agents/verification-closer.toml",
-        runner=runner,
+        _coordinator_stream(legacy_receipt),
     )
     result = VerificationConsumer(
         state,
@@ -784,6 +799,89 @@ def test_v1_real_launcher_stream_filter_accepts_legacy_clean_review_receipt(
     assert reviews[0]["finding_id"] is None
     assert reviews[0]["failure_domain"] is None
     assert reviews[0]["mechanism_id"] is None
+
+
+@pytest.mark.parametrize("policy", ["v1", "v2"])
+def test_strict_terminal_receipt_outranks_trailing_legacy_candidate(
+    tmp_path, policy
+) -> None:
+    """A strictly-valid final receipt must win over trailing legacy-shaped
+    stream garbage. The legacy fallback selection widened what the stream
+    pre-filter matches; with last-match-wins it could let a later
+    legacy-shaped agent message clobber an earlier strictly-valid receipt,
+    which the consumer then rejects under the run's real policy —
+    terminalizing a run that had already produced a correct receipt."""
+
+    state = ledger(tmp_path)
+    run = state.ingest(request())
+    if policy == "v1":
+        with state.store._connect() as conn:
+            conn.execute(
+                "UPDATE verification_runs SET repair_budget_policy='v1' "
+                "WHERE run_id=?",
+                (run.run_id,),
+            )
+            conn.commit()
+    else:
+        current = state.get(run.run_id)
+        assert current is not None
+        assert current.repair_budget_policy == "v2"
+
+    strict_receipt = {
+        "verdict": "blocked",
+        "head_sha": HEAD,
+        "summary": "strict final receipt",
+        "receipt_ids": ["strict-1"],
+        "retry_after": None,
+        "review_events": None,
+        "human_exception": None,
+    }
+    trailing_legacy = {
+        "verdict": "blocked",
+        "head_sha": HEAD,
+        "summary": "trailing legacy-shaped message",
+        "receipt_ids": ["legacy-1"],
+        "retry_after": None,
+        "review_events": [
+            {
+                "kind": "review",
+                "session_id": "legacy-trailing",
+                "capability": "gpt-5.6-terra",
+                "reasoning_effort": "high",
+                "outcome": "clean",
+                "finding_id": "F1",
+                "failure_domain": CODE,
+                "mechanism_id": "parser",
+                "strongest": None,
+            }
+        ],
+        "human_exception": None,
+    }
+    launcher = _stream_launcher(
+        tmp_path,
+        _coordinator_stream(strict_receipt, trailing_legacy),
+    )
+    result = VerificationConsumer(
+        state,
+        Truth(eligible_pr(), GREEN),
+        Auth(),
+        launcher,
+        "host",
+    ).consume(request())
+
+    # The strict receipt (no review events) is the selected terminal for both
+    # policies; the trailing legacy candidate is discarded, never rejected
+    # under the run's policy and never applied durably.
+    assert result.status == "failed"
+    assert result.stop_reason != "invalid_receipt_contract"
+    assert isinstance(result.terminal_receipt, dict)
+    assert result.terminal_receipt.get("review_events") is None
+    assert result.terminal_receipt.get("outcome") != "launcher_contract_failed"
+    assert [
+        attempt
+        for attempt in state.attempts(run.run_id)
+        if attempt["kind"] == "review"
+    ] == []
 
 
 def test_declared_v4_missing_budget_identity_fails_closed_without_repair(


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Fixes #3873

## SBS Impact
- Primary subsystem: Builder System verification dispatch
- Secondary subsystem(s): verification closer receipt migration compatibility
- Write class: dispatcher validation behavior and regression test
- Authority impact: preserves historical policy-v1 accounting without expanding policy-v2 authority
- Persistence impact: previously valid pending v1 clean-review receipts replay without terminalizing as invalid; no durable finding/domain/mechanism binding is recorded for a v1 clean review
- Derived/rebuildable impact: none
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: reduces schema-transition risk for verification dispatch hosts
- External boundary impact: none
- New or changed contract: policy-v1 clean-review bindings are scrubbed/ignored for compatibility; policy-v2 remains strict
- Owner-doc impact: none (documented legacy policy contract unchanged; compatibility behavior matches issue contract)
- Transition debt impact: reduces
- Fitness rule impact: adds legacy clean-review replay coverage
- Boundary risk: low — change is confined to the policy-v1 compatibility path in one module

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Migrated policy-v1 pending verification receipts can carry a clean review event with legacy `finding_id`/`failure_domain`/`mechanism_id` (the old schema allowed those fields on all review events; the old application ignored them for clean reviews). `validate_verification_closer_receipt` rejected that shape unconditionally, so the real-outage replay paths (`_replay_pending_delivered`, resumed `_launch`) terminalized runs as `invalid_persisted_verification_receipt`/`invalid_receipt_contract`. Root cause flagged in PR #3819 review thread `PRRT_kwDOQEip6s6RKzjx`.
- Fix, scoped to policy-v1 only: `load_and_validate_verification_closer_receipt` normalizes v1 review events via new `_normalize_v1_review_event` — a clean review's binding fields are scrubbed to `None` before both validation passes and before durable application, so stale legacy bindings are never treated as authoritative and never recorded. The clean-review binding rejection in `validate_verification_closer_receipt` is now gated by `allow_legacy_unbound_repairs`, symmetric with every other binding check in the function. Policy-v2 and unset-policy validation are unchanged and still fail closed (pinned by a new regression test).

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed (v2 validation untouched; legacy bindings not reinterpreted as authoritative; no historical attempts rewritten; no budget constants/convergence/HE routing/rollout/auth/deploy/release changes).
- [x] Acceptance Criteria from the linked Issue are satisfied (AC1/AC2 Verify tests below; AC3 — resolving PR #3819 thread `PRRT_kwDOQEip6s6RKzjx` — is post-merge and owned by the coordinator).
- [x] Docs were updated in the same change when behavior/contracts changed (no doc-owned contract changed; compatibility behavior is what the issue contract specifies).
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality (n/a — no roadmap/plan wording references this fix).

## Validation
Implementation lane:
- [x] `ruff check app tests`
- [x] Lint output included below
- [x] `mypy app`
- [x] `pytest -q -m "not pg"`
- [x] Additional targeted checks run as needed

All commands run from the isolated worktree on branch `fix/3873-legacy-clean-review-replay` (base `origin/main` @ b9cd600c).

```
$ pytest -q tests/dispatcher/test_verification_mechanism_budget.py -k 'v1_pending or clean_review'
3 passed, 10 deselected

$ pytest -q tests/dispatcher/test_verification_consumer.py tests/dispatcher/test_verification_review_repairs_takeover.py
209 passed

$ PYTHONPATH="$PWD/companion-ui/companion-app" pytest -q -m "not pg"   # FULL hot-path suite
11 failed, 9069 passed, 53 skipped, 87 deselected, 18 xfailed, 163 errors in 580.57s
```

Full-suite failure triage — all machine-local and pre-existing, none in dispatcher/properties:
- 163 errors + 3 of the fails: `OSError [Errno 24] Too many open files` — macOS `kern.maxfilesperproc=10240` fd-cascade when running all ~9k tests in one process (CI shards the not-pg suite per subsystem via `scripts/select_pr_tests.py` and does not hit this). Re-running the affected dirs alone: `tests/builderops` fully green.
- Remaining 8 fails (`tests/deploy/test_deploy_channel_vault_overlays.py`, `tests/deploy/test_dev_llm_provider_compose.py`, `tests/deploy/test_test_channel_compose.py`, `tests/standing_questions/test_question_store.py`) reproduce byte-identically on unmodified `origin/main` (verified by stashing this diff and re-running) — this laptop lacks the docker/runtime deps by design.
- Subset receipt: `pytest -q tests/builderops tests/deploy tests/standing_questions/test_question_store.py tests/runtime/test_start_full_system_version_marker.py` => 8 failed (the pre-existing set above), 453 passed.

```
$ ruff check app tests
All checks passed!

$ mypy app
app/dispatcher/control_plane.py:273: error: Argument 1 to "get" of "dict" has incompatible type "object | Any"; expected "str"  [arg-type]
Found 1 error in 1 file (checked 745 source files)
```
The mypy error is pre-existing on unmodified `origin/main` (verified by stashing this diff and re-running `mypy app` — identical output); this change adds zero mypy errors.

Test-first evidence: `test_v1_pending_clean_review_receipt_ignores_legacy_binding_fields` fails against unmodified `origin/main` with `stop_reason='invalid_receipt_contract'` (the exact outage this issue fixes) and passes with this change. `test_v2_clean_review_rejects_failure_binding_fields` pins the v2 fail-closed contract, including unset policy.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded review-follow-up fix from a PR #3819 inline thread; no plan divergence and no operational state worth a record.

## Notes
- Coordination: Dispatcher unavailable (control plane: unsupported schema_version 3) — used GitHub-label-only claim. Pickup receipt: `pickup-claim-complete issue=3873 branch=fix/3873-legacy-clean-review-replay worktree=/Users/rasmusthornberg/code/agentic-pkm-mvp-worktrees/issue-3873 coordination_mode=github-label-only-fallback fallback_reason=dispatcher_db_uninitialized agent=claude-sonnet-issue-3873 session=deliver-3872-3875-fable evidence=github-comment:4989052738`.
- AC3 (resolve PR #3819 review thread `PRRT_kwDOQEip6s6RKzjx`) is verified post-merge; the coordinator owns closure per the delivery plan.
- Residual risk: none identified beyond the compatibility semantics stated above; the scrub applies only when `repair_budget_policy == "v1"` is read from the run row.
