### PR TITLE
fix(dispatcher): quarantine b4e2310 artifact-provenance pre-trust rows

### DIFF
--- a/app/dispatcher/store.py
+++ b/app/dispatcher/store.py
@@ -86,6 +86,16 @@ _PRE_TRUST_NESTED_FIELDS = {
         {"repository", "pr_number", "current_head_sha", "source_run_id"}
     ),
 }
+# The b4e2310 producer bound verification artifacts to GitHub provenance,
+# adding exactly one top-level field (``artifact_provenance``) to the pre-trust
+# shape and no ``supporting_issues``. Its provenance object is descriptive audit
+# metadata only and is never authoritative for execution.
+_PRE_TRUST_ARTIFACT_PROVENANCE_FIELDS = _PRE_TRUST_REQUEST_FIELDS | {
+    "artifact_provenance"
+}
+_PRE_TRUST_ARTIFACT_PROVENANCE_NESTED = frozenset(
+    {"workflow_run_id", "repository_id", "artifact_name"}
+)
 _CANONICAL_VERIFICATION_STATUSES = frozenset(
     {
         "queued",
@@ -108,29 +118,45 @@ def recognized_pre_trust_verification_request(
     row: Mapping[str, Any] | sqlite3.Row,
     request: Mapping[str, object],
 ) -> bool:
-    """Recognize the exact request contract deployed before artifact authority.
+    """Recognize the exact request contracts deployed before trust closure.
 
-    These requests are audit evidence only. Recognition never upgrades them to
-    the current closed request contract; it only permits an atomic migration to
-    a permanently inert ledger state.
+    Two historical producer shapes are recognized: the original pre-trust shape
+    (no ``artifact_provenance``) and the b4e2310 shape, which added exactly one
+    top-level field, ``artifact_provenance``, and still predates
+    ``supporting_issues``. Both are audit evidence only. Recognition never
+    upgrades them to the current closed request contract; it only permits an
+    atomic migration to a permanently inert ledger state. The recognizer stays
+    exact-shape and fail-closed: any other field set, extra key, or malformed
+    provenance object is rejected.
     """
-    if (
-        row["request_json"]
-        != json.dumps(
-            request,
-            sort_keys=True,
-            separators=(",", ":"),
-            ensure_ascii=False,
-        )
-        or set(request) != _PRE_TRUST_REQUEST_FIELDS
+    fields = set(request)
+    if fields == _PRE_TRUST_REQUEST_FIELDS:
+        has_artifact_provenance = False
+    elif fields == _PRE_TRUST_ARTIFACT_PROVENANCE_FIELDS:
+        has_artifact_provenance = True
+    else:
+        return False
+    if row["request_json"] != json.dumps(
+        request,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
     ):
         return False
     nested: dict[str, Mapping[str, object]] = {}
-    for field, fields in _PRE_TRUST_NESTED_FIELDS.items():
+    for field, fields_set in _PRE_TRUST_NESTED_FIELDS.items():
         value = request.get(field)
-        if not isinstance(value, Mapping) or set(value) != fields:
+        if not isinstance(value, Mapping) or set(value) != fields_set:
             return False
         nested[field] = value
+    if has_artifact_provenance:
+        provenance = request.get("artifact_provenance")
+        if (
+            not isinstance(provenance, Mapping)
+            or set(provenance) != _PRE_TRUST_ARTIFACT_PROVENANCE_NESTED
+        ):
+            return False
+        nested["artifact_provenance"] = provenance
 
     repository = request.get("repository")
     pr_number = request.get("pr_number")
@@ -169,8 +195,15 @@ def recognized_pre_trust_verification_request(
     source = nested["source_workflow"]
     evidence = nested["evidence_pack"]
     live_truth = nested["live_truth"]
+    artifact_provenance_ok = not has_artifact_provenance or bool(
+        _positive_int(nested["artifact_provenance"].get("workflow_run_id"))
+        and _positive_int(nested["artifact_provenance"].get("repository_id"))
+        and nested["artifact_provenance"].get("artifact_name")
+        == f"verification-dispatch-{pr_number}-{head_sha}"
+    )
     return bool(
-        idempotency_key == expected_idempotency
+        artifact_provenance_ok
+        and idempotency_key == expected_idempotency
         and row["run_id"] == f"vrun-{idempotency_key[:16]}"
         and row["idempotency_key"] == idempotency_key
         and row["contract_version"] == request["contract_version"]

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -165,12 +165,15 @@ The dispatcher is an operational coordination layer, not a lifecycle replacement
   request head while retaining all prior audit rows. Missing older audit tables, columns, or unique
   keys still fail closed before migration. Both normal self-migration and explicit initialization
   validate the complete resulting verification schema inside the migration transaction before the
-  v3 marker can be written or committed. The one recognized pre-trust v3 request shape, deployed
-  before `supporting_issues` and authenticated artifact provenance became request authority, is never
-  upgraded by invention. Its immutable request, terminal receipt, attempts, and exceptions remain
-  audit evidence, while migration marks the run `legacy_untrusted`, clears every lease, session,
-  context, retry, and active projection, and stores no supporting authority. Status may list that
-  inert row, but every mutation and reopen path rejects it. A later authenticated canonical artifact
+  v3 marker can be written or committed. Exactly two pre-trust v3 request shapes, both deployed
+  before `supporting_issues` became request authority, are recognized and never upgraded by
+  invention: the original thirteen-field shape without artifact provenance, and the b4e2310
+  fourteen-field shape that adds exactly one descriptive `artifact_provenance` object (positive
+  workflow-run and repository ids plus the head-bound dispatch artifact name) carrying no execution
+  authority. Each recognized row's immutable request, terminal receipt, attempts, and exceptions
+  remain audit evidence, while migration marks the run `legacy_untrusted`, clears every lease,
+  session, context, retry, and active projection, and stores no supporting authority. Status may
+  list that inert row, but every mutation and reopen path rejects it. A later authenticated canonical artifact
   on a new head may start a fresh executable chain beside the retained audit row; any other malformed
   historical request still rolls the whole additive migration back.
   If normal stale-head handling supersedes a chain before the repaired-head artifact arrives, only

--- a/tests/dispatcher/test_control_plane.py
+++ b/tests/dispatcher/test_control_plane.py
@@ -16,6 +16,7 @@ from app.dispatcher.schema import DDL_STATEMENTS, SCHEMA_VERSION
 from app.dispatcher.store import SqliteStore
 from app.dispatcher.verification_dispatch import VerificationDispatchLedger
 from tests.dispatcher.verification_helpers import (
+    b4e2310_pre_trust_request,
     downgrade_verification_schema_to_v3,
     pre_trust_request,
     request as verification_request,
@@ -94,12 +95,17 @@ def _write_pre_repair_v3_state(tmp_path: Path):
     return paths, run
 
 
-def _write_pre_trust_v3_state(tmp_path: Path):
-    """Create the exact deployed verification state from before trust closure."""
+def _write_pre_trust_v3_state(tmp_path: Path, legacy_request: dict | None = None):
+    """Create the exact deployed verification state from before trust closure.
+
+    ``legacy_request`` selects which historical producer shape is stamped into
+    the row; it defaults to the original pre-trust shape.
+    """
     store, paths = _store(tmp_path)
     store.upsert_task(_task())
     run = VerificationDispatchLedger(store).ingest(verification_request())
-    legacy_request = pre_trust_request()
+    if legacy_request is None:
+        legacy_request = pre_trust_request()
     with sqlite3.connect(paths.db_path) as conn:
         conn.execute(
             """
@@ -314,6 +320,92 @@ def test_unrecognized_pre_trust_verification_row_rolls_back_migration(
             ),
         )
         conn.commit()
+    before = paths.db_path.read_bytes()
+
+    with pytest.raises(ValueError, match="supporting authority is malformed"):
+        SqliteStore(paths.db_path).get_meta("schema_version")
+
+    assert paths.db_path.read_bytes() == before
+    with sqlite3.connect(paths.db_path) as conn:
+        columns = {
+            row[1] for row in conn.execute("PRAGMA table_info(verification_runs)")
+        }
+    assert "supporting_authority_json" not in columns
+
+
+def test_pre_trust_artifact_provenance_row_migrates_to_inert_audit_state(
+    tmp_path: Path,
+) -> None:
+    legacy_request = b4e2310_pre_trust_request()
+    assert "artifact_provenance" in legacy_request
+    assert "supporting_issues" not in legacy_request
+    paths, original, stamped = _write_pre_trust_v3_state(tmp_path, legacy_request)
+    assert stamped == legacy_request
+
+    migrated_store = SqliteStore(paths.db_path)
+    migrated = VerificationDispatchLedger(migrated_store).get(original.run_id)
+
+    assert migrated is not None
+    assert migrated.status == "legacy_untrusted"
+    assert migrated.authority_state == "legacy_untrusted"
+    assert migrated.request == legacy_request
+    assert migrated.supporting_authority == ()
+    assert migrated.claimed_by is None
+    assert migrated.lease_id is None
+    assert migrated.lease_expires_at is None
+    assert migrated.coordinator_session_id is None
+    assert migrated.context_pack is None
+    assert migrated.retry_after is None
+    assert migrated.verified_head_sha is None
+    assert migrated.terminal_receipt == {"legacy": "terminal"}
+    assert migrated.stop_reason == "legacy_failure"
+    compact = _compact_verification_run(migrated)
+    assert compact["authority_state"] == "legacy_untrusted"
+    assert "request" not in compact
+    assert "artifact_provenance" not in json.dumps(compact, sort_keys=True)
+    with sqlite3.connect(paths.db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        durable = conn.execute(
+            "SELECT * FROM verification_runs WHERE run_id=?", (original.run_id,)
+        ).fetchone()
+        attempt = conn.execute(
+            "SELECT attempt_id, run_id, receipt_json FROM verification_attempts"
+        ).fetchone()
+        exception = conn.execute(
+            "SELECT exception_id, run_id, packet_json FROM verification_exceptions"
+        ).fetchone()
+    assert durable is not None
+    # The historical request evidence, including artifact_provenance, is
+    # preserved verbatim; only the authority projection is neutralized.
+    assert json.loads(durable["request_json"]) == legacy_request
+    assert json.loads(durable["request_json"])["artifact_provenance"] == (
+        legacy_request["artifact_provenance"]
+    )
+    assert json.loads(durable["supporting_authority_json"]) == []
+    assert durable["last_heartbeat_at"] is None
+    assert durable["context_pack_json"] is None
+    assert tuple(attempt) == ("attempt-pre-trust", original.run_id, '{"legacy":true}')
+    assert tuple(exception) == (
+        "exception-pre-trust",
+        original.run_id,
+        '{"legacy":true}',
+    )
+    assert [
+        run.run_id for run in VerificationDispatchLedger(migrated_store).list()
+    ] == [original.run_id]
+    assert control_plane.health(paths)["ok"] is True
+
+
+def test_unrecognized_artifact_provenance_pre_trust_row_rolls_back_migration(
+    tmp_path: Path,
+) -> None:
+    legacy_request = b4e2310_pre_trust_request()
+    # An extra key inside artifact_provenance is not an exact b4e2310 shape and
+    # must not be recognized for inert quarantine.
+    provenance = legacy_request["artifact_provenance"]
+    assert isinstance(provenance, dict)
+    provenance["unexpected"] = "must-not-be-recognized"
+    paths, original, _ = _write_pre_trust_v3_state(tmp_path, legacy_request)
     before = paths.db_path.read_bytes()
 
     with pytest.raises(ValueError, match="supporting authority is malformed"):

--- a/tests/dispatcher/test_control_plane.py
+++ b/tests/dispatcher/test_control_plane.py
@@ -246,99 +246,12 @@ def test_pre_repair_v3_backup_restore_self_migrates_without_data_loss(
     assert control_plane.health(restored)["ok"] is True
 
 
-def test_pre_trust_verification_row_migrates_to_inert_audit_state(
+def _assert_pre_trust_row_migrates_to_inert(
     tmp_path: Path,
+    legacy_request: dict[str, object],
+    leak_markers: tuple[str, ...],
 ) -> None:
-    paths, original, legacy_request = _write_pre_trust_v3_state(tmp_path)
-
-    migrated_store = SqliteStore(paths.db_path)
-    migrated = VerificationDispatchLedger(migrated_store).get(original.run_id)
-
-    assert migrated is not None
-    assert migrated.status == "legacy_untrusted"
-    assert migrated.authority_state == "legacy_untrusted"
-    assert migrated.request == legacy_request
-    assert migrated.supporting_authority == ()
-    assert migrated.claimed_by is None
-    assert migrated.lease_id is None
-    assert migrated.lease_expires_at is None
-    assert migrated.coordinator_session_id is None
-    assert migrated.context_pack is None
-    assert migrated.retry_after is None
-    assert migrated.verified_head_sha is None
-    assert migrated.terminal_receipt == {"legacy": "terminal"}
-    assert migrated.stop_reason == "legacy_failure"
-    compact = _compact_verification_run(migrated)
-    assert compact["authority_state"] == "legacy_untrusted"
-    assert "request" not in compact
-    assert "base_ref" not in json.dumps(compact, sort_keys=True)
-    assert "head_ref" not in json.dumps(compact, sort_keys=True)
-    with sqlite3.connect(paths.db_path) as conn:
-        conn.row_factory = sqlite3.Row
-        durable = conn.execute(
-            "SELECT * FROM verification_runs WHERE run_id=?", (original.run_id,)
-        ).fetchone()
-        attempt = conn.execute(
-            "SELECT attempt_id, run_id, receipt_json FROM verification_attempts"
-        ).fetchone()
-        exception = conn.execute(
-            "SELECT exception_id, run_id, packet_json FROM verification_exceptions"
-        ).fetchone()
-    assert durable is not None
-    assert json.loads(durable["request_json"]) == legacy_request
-    assert json.loads(durable["supporting_authority_json"]) == []
-    assert durable["last_heartbeat_at"] is None
-    assert durable["context_pack_json"] is None
-    assert tuple(attempt) == ("attempt-pre-trust", original.run_id, '{"legacy":true}')
-    assert tuple(exception) == (
-        "exception-pre-trust",
-        original.run_id,
-        '{"legacy":true}',
-    )
-    assert [run.run_id for run in VerificationDispatchLedger(migrated_store).list()] == [
-        original.run_id
-    ]
-    assert control_plane.health(paths)["ok"] is True
-
-
-def test_unrecognized_pre_trust_verification_row_rolls_back_migration(
-    tmp_path: Path,
-) -> None:
-    paths, original, legacy_request = _write_pre_trust_v3_state(tmp_path)
-    legacy_request["unexpected"] = "must-not-be-recognized"
-    with sqlite3.connect(paths.db_path) as conn:
-        conn.execute(
-            "UPDATE verification_runs SET request_json=? WHERE run_id=?",
-            (
-                json.dumps(
-                    legacy_request,
-                    sort_keys=True,
-                    separators=(",", ":"),
-                    ensure_ascii=False,
-                ),
-                original.run_id,
-            ),
-        )
-        conn.commit()
-    before = paths.db_path.read_bytes()
-
-    with pytest.raises(ValueError, match="supporting authority is malformed"):
-        SqliteStore(paths.db_path).get_meta("schema_version")
-
-    assert paths.db_path.read_bytes() == before
-    with sqlite3.connect(paths.db_path) as conn:
-        columns = {
-            row[1] for row in conn.execute("PRAGMA table_info(verification_runs)")
-        }
-    assert "supporting_authority_json" not in columns
-
-
-def test_pre_trust_artifact_provenance_row_migrates_to_inert_audit_state(
-    tmp_path: Path,
-) -> None:
-    legacy_request = b4e2310_pre_trust_request()
-    assert "artifact_provenance" in legacy_request
-    assert "supporting_issues" not in legacy_request
+    """Shared inert-quarantine contract for every recognized historical shape."""
     paths, original, stamped = _write_pre_trust_v3_state(tmp_path, legacy_request)
     assert stamped == legacy_request
 
@@ -362,7 +275,8 @@ def test_pre_trust_artifact_provenance_row_migrates_to_inert_audit_state(
     compact = _compact_verification_run(migrated)
     assert compact["authority_state"] == "legacy_untrusted"
     assert "request" not in compact
-    assert "artifact_provenance" not in json.dumps(compact, sort_keys=True)
+    for marker in leak_markers:
+        assert marker not in json.dumps(compact, sort_keys=True)
     with sqlite3.connect(paths.db_path) as conn:
         conn.row_factory = sqlite3.Row
         durable = conn.execute(
@@ -375,12 +289,9 @@ def test_pre_trust_artifact_provenance_row_migrates_to_inert_audit_state(
             "SELECT exception_id, run_id, packet_json FROM verification_exceptions"
         ).fetchone()
     assert durable is not None
-    # The historical request evidence, including artifact_provenance, is
-    # preserved verbatim; only the authority projection is neutralized.
+    # The historical request evidence is preserved verbatim; only the
+    # authority projection is neutralized.
     assert json.loads(durable["request_json"]) == legacy_request
-    assert json.loads(durable["request_json"])["artifact_provenance"] == (
-        legacy_request["artifact_provenance"]
-    )
     assert json.loads(durable["supporting_authority_json"]) == []
     assert durable["last_heartbeat_at"] is None
     assert durable["context_pack_json"] is None
@@ -396,16 +307,11 @@ def test_pre_trust_artifact_provenance_row_migrates_to_inert_audit_state(
     assert control_plane.health(paths)["ok"] is True
 
 
-def test_unrecognized_artifact_provenance_pre_trust_row_rolls_back_migration(
-    tmp_path: Path,
+def _assert_unrecognized_pre_trust_row_rolls_back(
+    tmp_path: Path, legacy_request: dict[str, object]
 ) -> None:
-    legacy_request = b4e2310_pre_trust_request()
-    # An extra key inside artifact_provenance is not an exact b4e2310 shape and
-    # must not be recognized for inert quarantine.
-    provenance = legacy_request["artifact_provenance"]
-    assert isinstance(provenance, dict)
-    provenance["unexpected"] = "must-not-be-recognized"
-    paths, original, _ = _write_pre_trust_v3_state(tmp_path, legacy_request)
+    """Shared fail-closed contract: unrecognized rows abort the migration whole."""
+    paths, _, _ = _write_pre_trust_v3_state(tmp_path, legacy_request)
     before = paths.db_path.read_bytes()
 
     with pytest.raises(ValueError, match="supporting authority is malformed"):
@@ -417,6 +323,100 @@ def test_unrecognized_artifact_provenance_pre_trust_row_rolls_back_migration(
             row[1] for row in conn.execute("PRAGMA table_info(verification_runs)")
         }
     assert "supporting_authority_json" not in columns
+
+
+def test_pre_trust_verification_row_migrates_to_inert_audit_state(
+    tmp_path: Path,
+) -> None:
+    _assert_pre_trust_row_migrates_to_inert(
+        tmp_path, pre_trust_request(), leak_markers=("base_ref", "head_ref")
+    )
+
+
+def test_unrecognized_pre_trust_verification_row_rolls_back_migration(
+    tmp_path: Path,
+) -> None:
+    legacy_request = pre_trust_request()
+    legacy_request["unexpected"] = "must-not-be-recognized"
+    _assert_unrecognized_pre_trust_row_rolls_back(tmp_path, legacy_request)
+
+
+def test_pre_trust_artifact_provenance_row_migrates_to_inert_audit_state(
+    tmp_path: Path,
+) -> None:
+    legacy_request = b4e2310_pre_trust_request()
+    assert "artifact_provenance" in legacy_request
+    assert "supporting_issues" not in legacy_request
+    _assert_pre_trust_row_migrates_to_inert(
+        tmp_path,
+        legacy_request,
+        leak_markers=("base_ref", "head_ref", "artifact_provenance"),
+    )
+
+
+def _b4e2310_extra_top_level_key() -> dict[str, object]:
+    request = b4e2310_pre_trust_request()
+    request["unexpected"] = "must-not-be-recognized"
+    return request
+
+
+def _b4e2310_stray_supporting_issues() -> dict[str, object]:
+    # supporting_issues alongside artifact_provenance is neither historical
+    # shape; it must never be recognized (nor synthesized into authority).
+    request = b4e2310_pre_trust_request()
+    request["supporting_issues"] = None
+    return request
+
+
+def _b4e2310_provenance(mutate: dict[str, object]) -> dict[str, object]:
+    request = b4e2310_pre_trust_request()
+    provenance = request["artifact_provenance"]
+    assert isinstance(provenance, dict)
+    provenance.update(mutate)
+    return request
+
+
+@pytest.mark.parametrize(
+    "malformed_factory",
+    [
+        pytest.param(_b4e2310_extra_top_level_key, id="extra-top-level-key"),
+        pytest.param(_b4e2310_stray_supporting_issues, id="stray-supporting-issues"),
+        pytest.param(
+            lambda: _b4e2310_provenance({"unexpected": "must-not-be-recognized"}),
+            id="extra-provenance-key",
+        ),
+        pytest.param(
+            lambda: _b4e2310_provenance(
+                {"artifact_name": f"verification-dispatch-9999-{'c' * 40}"}
+            ),
+            id="artifact-name-not-head-bound",
+        ),
+        pytest.param(
+            lambda: _b4e2310_provenance({"workflow_run_id": True}),
+            id="boolean-workflow-run-id",
+        ),
+        pytest.param(
+            lambda: _b4e2310_provenance({"repository_id": True}),
+            id="boolean-repository-id",
+        ),
+        pytest.param(
+            lambda: _b4e2310_provenance({"workflow_run_id": "123"}),
+            id="string-workflow-run-id",
+        ),
+        pytest.param(
+            lambda: _b4e2310_provenance({"repository_id": None}),
+            id="null-repository-id",
+        ),
+        pytest.param(
+            lambda: _b4e2310_provenance({"artifact_name": None}),
+            id="null-artifact-name",
+        ),
+    ],
+)
+def test_unrecognized_artifact_provenance_pre_trust_row_rolls_back_migration(
+    tmp_path: Path, malformed_factory
+) -> None:
+    _assert_unrecognized_pre_trust_row_rolls_back(tmp_path, malformed_factory())
 
 
 def test_noncanonical_current_request_rolls_back_additive_migration(
@@ -476,10 +476,19 @@ def test_pre_trust_advanced_head_is_normalized_to_inert_request_head(
     assert migrated.request == legacy_request
 
 
+@pytest.mark.parametrize(
+    "shape_factory",
+    [
+        pytest.param(pre_trust_request, id="pre-trust"),
+        pytest.param(b4e2310_pre_trust_request, id="b4e2310-artifact-provenance"),
+    ],
+)
 def test_schema_complete_pre_trust_row_still_enters_inert_quarantine(
-    tmp_path: Path,
+    tmp_path: Path, shape_factory
 ) -> None:
-    paths, original, legacy_request = _write_pre_trust_v3_state(tmp_path)
+    paths, original, legacy_request = _write_pre_trust_v3_state(
+        tmp_path, shape_factory()
+    )
     with sqlite3.connect(paths.db_path) as conn:
         conn.execute(
             "ALTER TABLE verification_runs ADD COLUMN "

--- a/tests/dispatcher/test_verification_dispatch.py
+++ b/tests/dispatcher/test_verification_dispatch.py
@@ -195,11 +195,13 @@ _INERT_MUTATION_ENTRYPOINTS = [
 ]
 
 
-@pytest.mark.parametrize("mutation", _INERT_MUTATION_ENTRYPOINTS)
-def test_inert_legacy_run_rejects_every_mutation_entrypoint(
-    tmp_path, mutation
+def _assert_inert_legacy_run_rejects_mutation(
+    tmp_path, legacy_request: dict | None, mutation
 ) -> None:
-    state, legacy = _migrated_legacy_ledger(tmp_path)
+    """Shared mutation-fencing contract for every recognized historical shape."""
+    state, legacy = _migrated_legacy_ledger(tmp_path, legacy_request)
+    if legacy_request is not None:
+        assert legacy.request == legacy_request
     with state.store._connect() as conn:
         before = dict(
             conn.execute(
@@ -217,6 +219,13 @@ def test_inert_legacy_run_rejects_every_mutation_entrypoint(
             ).fetchone()
         )
     assert after == before
+
+
+@pytest.mark.parametrize("mutation", _INERT_MUTATION_ENTRYPOINTS)
+def test_inert_legacy_run_rejects_every_mutation_entrypoint(
+    tmp_path, mutation
+) -> None:
+    _assert_inert_legacy_run_rejects_mutation(tmp_path, None, mutation)
 
 
 @pytest.mark.parametrize("mutation", _INERT_MUTATION_ENTRYPOINTS)
@@ -225,26 +234,7 @@ def test_inert_artifact_provenance_legacy_run_rejects_mutations(
 ) -> None:
     legacy_request = b4e2310_pre_trust_request()
     assert "artifact_provenance" in legacy_request
-    state, legacy = _migrated_legacy_ledger(tmp_path, legacy_request)
-    assert legacy.status == "legacy_untrusted"
-    assert legacy.request == legacy_request
-    with state.store._connect() as conn:
-        before = dict(
-            conn.execute(
-                "SELECT * FROM verification_runs WHERE run_id=?", (legacy.run_id,)
-            ).fetchone()
-        )
-
-    with pytest.raises(ValueError, match="legacy verification audit is not executable"):
-        mutation(state, legacy)
-
-    with state.store._connect() as conn:
-        after = dict(
-            conn.execute(
-                "SELECT * FROM verification_runs WHERE run_id=?", (legacy.run_id,)
-            ).fetchone()
-        )
-    assert after == before
+    _assert_inert_legacy_run_rejects_mutation(tmp_path, legacy_request, mutation)
 
 
 def test_authenticated_artifact_starts_fresh_chain_beside_inert_legacy_audit(

--- a/tests/dispatcher/test_verification_dispatch.py
+++ b/tests/dispatcher/test_verification_dispatch.py
@@ -12,6 +12,7 @@ import pytest
 import app.dispatcher.verification_dispatch as verification_dispatch
 from app.dispatcher.verification_dispatch import VerificationRun
 from tests.dispatcher.verification_helpers import (
+    b4e2310_pre_trust_request,
     downgrade_verification_schema_to_v3,
     ledger,
     pre_trust_request,
@@ -24,10 +25,11 @@ CLAIM_PRE_LOCK = "2030-01-01T00:00:00.000000+00:00"
 CLAIM_POST_LOCK = "2030-01-01T00:00:20.000000+00:00"
 
 
-def _migrated_legacy_ledger(tmp_path):
+def _migrated_legacy_ledger(tmp_path, legacy_request: dict | None = None):
     state = ledger(tmp_path)
     original = state.ingest(request())
-    legacy_request = pre_trust_request()
+    if legacy_request is None:
+        legacy_request = pre_trust_request()
     with sqlite3.connect(state.store.db_path) as conn:
         conn.execute(
             "UPDATE verification_runs SET request_json=? WHERE run_id=?",
@@ -125,79 +127,107 @@ def test_canonical_request_projection_preserves_idempotent_replay(tmp_path) -> N
         assert conn.execute("SELECT COUNT(*) FROM verification_runs").fetchone()[0] == 1
 
 
-@pytest.mark.parametrize(
-    "mutation",
-    [
-        lambda state, run: state.claim(run.run_id, "host"),
-        lambda state, run: state.heartbeat(run.run_id, "host", "lease"),
-        lambda state, run: state.start(
-            run.run_id, "host", "lease", "session", {"head": run.head_sha}
-        ),
-        lambda state, run: state.terminal(
-            run.run_id,
-            "failed",
-            {"outcome": "blocked"},
-            holder="host",
-            lease_id="lease",
-        ),
-        lambda state, run: state.rebind_head(
-            run.run_id,
-            "b" * 40,
-            expected_head_sha=run.head_sha,
-            observed_repository=run.repository,
-            observed_pr_number=run.pr_number,
-            observed_head_sha="b" * 40,
-            holder="host",
-            lease_id="lease",
-        ),
-        lambda state, run: state.backoff(
-            run.run_id,
-            {"outcome": "retry"},
-            "2030-01-01T00:00:00+00:00",
-            holder="host",
-            lease_id="lease",
-        ),
-        lambda state, run: state.defer_unclaimed(
-            run.run_id,
-            {"outcome": "retry"},
-            "2030-01-01T00:00:00+00:00",
-        ),
-        lambda state, run: state.supersede_unclaimed(
-            run.run_id, {"outcome": "superseded"}, reason="stale_head"
-        ),
-        lambda state, run: state.record_attempt(
-            run.run_id,
-            "review",
-            "session",
-            "terra",
-            "high",
-            {"head": run.head_sha},
-            "clean",
-            holder="host",
-            lease_id="lease",
-        ),
-        lambda state, run: state.record_attempt_batch(
-            run.run_id,
-            "batch",
-            1,
-            run.head_sha,
-            lambda _attempts, _attempt_id: [],
-            holder="host",
-            lease_id="lease",
-        ),
-        lambda state, run: state.exception(
-            run.run_id,
-            "technical",
-            {"failure_class": "technical"},
-            holder="host",
-            lease_id="lease",
-        ),
-    ],
-)
+_INERT_MUTATION_ENTRYPOINTS = [
+    lambda state, run: state.claim(run.run_id, "host"),
+    lambda state, run: state.heartbeat(run.run_id, "host", "lease"),
+    lambda state, run: state.start(
+        run.run_id, "host", "lease", "session", {"head": run.head_sha}
+    ),
+    lambda state, run: state.terminal(
+        run.run_id,
+        "failed",
+        {"outcome": "blocked"},
+        holder="host",
+        lease_id="lease",
+    ),
+    lambda state, run: state.rebind_head(
+        run.run_id,
+        "b" * 40,
+        expected_head_sha=run.head_sha,
+        observed_repository=run.repository,
+        observed_pr_number=run.pr_number,
+        observed_head_sha="b" * 40,
+        holder="host",
+        lease_id="lease",
+    ),
+    lambda state, run: state.backoff(
+        run.run_id,
+        {"outcome": "retry"},
+        "2030-01-01T00:00:00+00:00",
+        holder="host",
+        lease_id="lease",
+    ),
+    lambda state, run: state.defer_unclaimed(
+        run.run_id,
+        {"outcome": "retry"},
+        "2030-01-01T00:00:00+00:00",
+    ),
+    lambda state, run: state.supersede_unclaimed(
+        run.run_id, {"outcome": "superseded"}, reason="stale_head"
+    ),
+    lambda state, run: state.record_attempt(
+        run.run_id,
+        "review",
+        "session",
+        "terra",
+        "high",
+        {"head": run.head_sha},
+        "clean",
+        holder="host",
+        lease_id="lease",
+    ),
+    lambda state, run: state.record_attempt_batch(
+        run.run_id,
+        "batch",
+        1,
+        run.head_sha,
+        lambda _attempts, _attempt_id: [],
+        holder="host",
+        lease_id="lease",
+    ),
+    lambda state, run: state.exception(
+        run.run_id,
+        "technical",
+        {"failure_class": "technical"},
+        holder="host",
+        lease_id="lease",
+    ),
+]
+
+
+@pytest.mark.parametrize("mutation", _INERT_MUTATION_ENTRYPOINTS)
 def test_inert_legacy_run_rejects_every_mutation_entrypoint(
     tmp_path, mutation
 ) -> None:
     state, legacy = _migrated_legacy_ledger(tmp_path)
+    with state.store._connect() as conn:
+        before = dict(
+            conn.execute(
+                "SELECT * FROM verification_runs WHERE run_id=?", (legacy.run_id,)
+            ).fetchone()
+        )
+
+    with pytest.raises(ValueError, match="legacy verification audit is not executable"):
+        mutation(state, legacy)
+
+    with state.store._connect() as conn:
+        after = dict(
+            conn.execute(
+                "SELECT * FROM verification_runs WHERE run_id=?", (legacy.run_id,)
+            ).fetchone()
+        )
+    assert after == before
+
+
+@pytest.mark.parametrize("mutation", _INERT_MUTATION_ENTRYPOINTS)
+def test_inert_artifact_provenance_legacy_run_rejects_mutations(
+    tmp_path, mutation
+) -> None:
+    legacy_request = b4e2310_pre_trust_request()
+    assert "artifact_provenance" in legacy_request
+    state, legacy = _migrated_legacy_ledger(tmp_path, legacy_request)
+    assert legacy.status == "legacy_untrusted"
+    assert legacy.request == legacy_request
     with state.store._connect() as conn:
         before = dict(
             conn.execute(

--- a/tests/dispatcher/verification_helpers.py
+++ b/tests/dispatcher/verification_helpers.py
@@ -59,5 +59,18 @@ def pre_trust_request(head: str = HEAD) -> dict[str, object]:
     return result
 
 
+def b4e2310_pre_trust_request(head: str = HEAD) -> dict[str, object]:
+    """Return the exact b4e2310 producer shape.
+
+    This shape bound verification artifacts to GitHub provenance
+    (``artifact_provenance`` present) but still predates ``supporting_issues``.
+    """
+    result = request(head)
+    result.pop("supporting_issues")
+    result["base_ref"] = "main"
+    result["head_ref"] = "codex/issue-3603"
+    return result
+
+
 def ledger(tmp_path: Path) -> VerificationDispatchLedger:
     return VerificationDispatchLedger(SqliteStore(tmp_path / "dispatcher.sqlite3"))


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Fixes #3874

## SBS Impact
- Primary subsystem: Builder System verification dispatch persistence and recovery
- Secondary subsystem(s): dispatcher schema migration compatibility
- Write class: migration-recognition behavior, regression tests, and owner-doc writeback
- Authority impact: grants none; recognized b4e2310 rows migrate only to the permanently inert `legacy_untrusted` audit state
- Persistence impact: preserves historical request/attempt/exception evidence verbatim while allowing the schema migration to complete
- Derived/rebuildable impact: read-only status remains derived from inert audit state
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: unblocks deployed dispatcher databases holding the b4e2310 pre-trust row shape
- External boundary impact: none
- New or changed contract: exactly two historical pre-trust shapes are recognized, only for inert quarantine; artifact_provenance is never authoritative for execution
- Owner-doc impact: updated in this PR — `docs/AGENT_ISSUE_DISPATCHER.md` now enumerates both recognized pre-trust v3 shapes (it previously stated "The one recognized pre-trust v3 request shape")
- Transition debt impact: reduces
- Fitness rule impact: adds historical-row compatibility coverage incl. nine malformed-variant fail-closed regressions
- Boundary risk: low — recognizer stays exact-shape and fail-closed

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- `recognized_pre_trust_verification_request` now recognizes exactly two historical producer shapes: the original pre-trust shape and the b4e2310 shape (adds only `artifact_provenance` with exactly `workflow_run_id`/`repository_id` positive ints and `artifact_name == verification-dispatch-{pr_number}-{head_sha}`, still no `supporting_issues`). Any other field set, extra key, or malformed provenance object stays fail-closed, and the migration remains atomic (byte-identical DB on rejection).
- Regression coverage: b4e2310 rows migrate atomically to the inert `legacy_untrusted` audit state across all three `_ensure_schema` passes; the inert row rejects all 11 mutation entrypoints; nine malformed b4e2310 variants (extra top-level key, stray `supporting_issues`, extra provenance key, non-head-bound artifact name, boolean/string/null ids, null artifact name) each roll the whole migration back byte-identically; fast-path (schema-complete row) inert quarantine is covered for both shapes.
- Review round 1 addressed (review 4712183064): owner doc `docs/AGENT_ISSUE_DISPATCHER.md` enumerates both recognized shapes; near-duplicate test bodies collapsed into shared helpers (`_assert_pre_trust_row_migrates_to_inert`, `_assert_unrecognized_pre_trust_row_rolls_back`, `_assert_inert_legacy_run_rejects_mutation`) so the next historical shape is a one-line addition; all AC-named selectors kept intact.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed (no `supporting_issues` or authority-bearing fields synthesized; `artifact_provenance` never authoritative; no arbitrary extra keys accepted; no historical rows deleted/rewritten/reopened/replayed; no host rollout/provider auth/deployment/release changes).
- [x] Acceptance Criteria from the linked Issue are satisfied (AC4 — resolving PR #3797 review thread `PRRT_kwDOQEip6s6RDKuN` — is owned by the coordinator after this PR merges).
- [x] Docs were updated in the same change when behavior/contracts changed (`docs/AGENT_ISSUE_DISPATCHER.md` recognized-shape enumeration).
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality (owner-doc writeback bundled in this PR).

## Validation
Implementation lane:
- [x] `ruff check app tests`
- [x] Lint output included below.
- [x] `mypy app`
- [x] `pytest -q -m "not pg"`
- [x] Additional targeted checks run as needed

Round 2 (head 06923372, rebased onto ed445d4a; diff since 01f1ce76 touches only `docs/AGENT_ISSUE_DISPATCHER.md`, `tests/dispatcher/test_control_plane.py`, `tests/dispatcher/test_verification_dispatch.py` — full not-pg re-run not required per review gate):
```
$ pytest -q tests/dispatcher/test_control_plane.py::test_pre_trust_artifact_provenance_row_migrates_to_inert_audit_state \
    tests/dispatcher/test_control_plane.py::test_unrecognized_artifact_provenance_pre_trust_row_rolls_back_migration \
    tests/dispatcher/test_verification_dispatch.py::test_inert_artifact_provenance_legacy_run_rejects_mutations
21 passed in 0.55s

$ pytest -q tests/dispatcher
856 passed in 11.52s

$ ruff check app tests
All checks passed!

$ mypy app
app/dispatcher/control_plane.py:273: error: Argument 1 to "get" of "dict" has incompatible type "object | Any"; expected "str"  [arg-type]
Found 1 error in 1 file (checked 746 source files)
# Pre-existing baseline: reproduced byte-identically on pristine origin/main with the local
# mypy version; file untouched by this PR. CI's `mypy app` gate is green on main.
```

Round 1 (original head 01f1ce76):
```
$ pytest -q tests/dispatcher/test_control_plane.py -k 'pre_trust or artifact_provenance'
7 passed, 31 deselected in 0.35s

$ pytest -q tests/dispatcher/test_verification_dispatch.py -k inert
24 passed, 263 deselected in 0.45s

$ pytest -q -m "not pg"  (full suite, run sharded per test directory on this laptop to avoid
  kern.maxfilesperproc fd exhaustion in one monolithic process)
9245 passed, 9 failed total across shards
# All 9 failures (7 tests/deploy compose tests, 1 tests/release_channels harness-fidelity,
# 1 tests/standing_questions created_at format) reproduce identically on pristine origin/main
# in this environment — pre-existing environmental failures on this laptop (no docker), not
# introduced by this change. tests/dispatcher (the touched hot-path): 847/847 green (856 after
# round 2's added variants).
```

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded review-follow-up bug fix on the dispatcher migration path; no BuilderOps divergence to route.

## Notes
- Dispatcher unavailable (control plane: unsupported schema_version 3) — used GitHub-label-only claim.
- Branch rebased onto origin/main ed445d4a for the round-2 push (clean rebase, no conflicts; original head 01f1ce76 → 06923372).
- Residual risk: if yet another undocumented historical producer shape exists in a deployed DB, migration still fails closed (by design) and would need the same bounded recognition treatment.
- PR #3797 review thread `PRRT_kwDOQEip6s6RDKuN` reply/resolution is deferred to the coordinator per dispatch instructions.