### PR TITLE
docs: close ADR-0062 A2 consistency gap

### DIFF
--- a/docs/adr/ADR-0062-builderops-ecosystem-wide-enabling-system.md
+++ b/docs/adr/ADR-0062-builderops-ecosystem-wide-enabling-system.md
@@ -123,6 +123,11 @@ adapter. Production paths contain no SQLite authority or automatic SQLite fallba
 
 ### D4 — Independent deployment, lifecycle, and trust zone
 
+> **Amended by A2 (2026-07-16):** “reuse” below means Demerzel's operational patterns and
+> capability, not a shared container engine or runtime failure domain. This delivery runs the
+> BuilderOps-only Compose project on a separate BuilderOps VM/container engine on Demerzel. See
+> `## Amendments`.
+
 BuilderOps reuses Demerzel's Docker/PostgreSQL operational capability but has its own Compose project
 and lifecycle, separate from `pkm-dev`, `pkm-test`, and `pkm-prod`. It owns distinct:
 


### PR DESCRIPTION
## Change Lane
- [ ] Implementation lane
- [x] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Fixes #

## SBS Impact
- Primary subsystem: Builder System architecture spine
- Secondary subsystem(s): none
- Write class: docs-only target-state clarification
- Authority impact: clarifies the already-merged ADR-0062 A2 amendment in place
- Persistence impact: none
- Derived/rebuildable impact: none
- Human knowledge impact: prevents D4 from being read as permission to share the Product container-engine failure domain
- Memory impact: none
- Retrieval/context impact: improves ADR routing precision
- Sync/deployment impact: names the already-selected separate BuilderOps VM/container engine plus own Compose target
- External boundary impact: none
- New or changed contract: no new decision; explicit supersession marker for merged A2
- Owner-doc impact: ADR-0062 corrected in this PR
- Transition debt impact: closes the post-merge consistency finding from PR #3878 review
- Fitness rule impact: none
- Boundary risk: low, docs-only

## Owner-Doc Writeback
- [x] Owner-doc updated in this PR.

## Summary
- Adds an in-place A2 amendment marker at ADR-0062 D4.
- Clarifies that reuse means operational capability/patterns, while the selected delivery runs the BuilderOps-only Compose project on a separate BuilderOps VM/container engine.

## Docs Authoring Check
- [x] This PR only changes approved docs-authoring surfaces.
- [x] No code, runtime behavior, contracts, or shipped reality changed.
- [x] This PR clarifies authoritative target-state specification.

## Validation
- [x] `python3 scripts/docs_guard.py`
- [x] `git diff --check`
- [x] publication preflight and docs review-before-CI gate

## BuilderOps Routing
- Records/projections/receipts: PR #3878 post-merge owner-doc check
- Reason: bounded correction of a review-proven target-state ambiguity; no new operational record needed

## Notes
- Follow-up to merged PR #3878; canonical Issue #3792 was separately reconciled to ADR-0062 A1.