### PR TITLE
Add host secret contract

### DIFF
--- a/app/ops/host_secret_contract.py
+++ b/app/ops/host_secret_contract.py
@@ -8,6 +8,9 @@ from pathlib import Path
 
 
 DEFAULT_CONTRACT_PATH = Path("config/secrets/host_secret_contract.json")
+_CONTRACT_FIELDS = frozenset({"version", "keychain_service", "keychain_account_template", "consumers"})
+_CONSUMER_FIELDS = frozenset({"channel", "consumer", "secrets"})
+_KEYCHAIN_ACCOUNT_TEMPLATE = "{channel}:{consumer}:{secret}"
 
 
 class UndeclaredSecretConsumerError(ValueError):
@@ -17,6 +20,7 @@ class UndeclaredSecretConsumerError(ValueError):
 @dataclass(frozen=True)
 class HostSecretContract:
     keychain_service: str
+    keychain_account_template: str
     allowed: frozenset[tuple[str, str, str]]
 
     def require_declared(self, *, channel: str, consumer: str, secret: str) -> None:
@@ -25,14 +29,30 @@ class HostSecretContract:
                 f"undeclared host secret request: channel={channel!r}, consumer={consumer!r}, secret={secret!r}"
             )
 
+    def keychain_account(self, *, channel: str, consumer: str, secret: str) -> str:
+        """Return the declared, channel-scoped Keychain account identifier."""
+        self.require_declared(channel=channel, consumer=consumer, secret=secret)
+        return self.keychain_account_template.format(
+            channel=channel, consumer=consumer, secret=secret
+        )
+
 
 def load_host_secret_contract(path: Path = DEFAULT_CONTRACT_PATH) -> HostSecretContract:
     payload = json.loads(path.read_text(encoding="utf-8"))
-    if payload.get("version") != 1 or not isinstance(payload.get("keychain_service"), str):
+    if not isinstance(payload, dict) or set(payload) != _CONTRACT_FIELDS:
+        raise ValueError("invalid host secret contract")
+    if (
+        payload["version"] != 1
+        or not isinstance(payload["keychain_service"], str)
+        or payload["keychain_account_template"] != _KEYCHAIN_ACCOUNT_TEMPLATE
+        or not isinstance(payload["consumers"], list)
+    ):
         raise ValueError("invalid host secret contract")
     allowed: set[tuple[str, str, str]] = set()
-    for item in payload.get("consumers", []):
-        channel, consumer, secrets = item.get("channel"), item.get("consumer"), item.get("secrets")
+    for item in payload["consumers"]:
+        if not isinstance(item, dict) or set(item) != _CONSUMER_FIELDS:
+            raise ValueError("invalid host secret consumer declaration")
+        channel, consumer, secrets = item["channel"], item["consumer"], item["secrets"]
         if not isinstance(channel, str) or not isinstance(consumer, str) or not isinstance(secrets, list):
             raise ValueError("invalid host secret consumer declaration")
         for secret in secrets:
@@ -41,4 +61,8 @@ def load_host_secret_contract(path: Path = DEFAULT_CONTRACT_PATH) -> HostSecretC
             allowed.add((channel, consumer, secret))
     if not allowed:
         raise ValueError("host secret contract declares no consumers")
-    return HostSecretContract(keychain_service=payload["keychain_service"], allowed=frozenset(allowed))
+    return HostSecretContract(
+        keychain_service=payload["keychain_service"],
+        keychain_account_template=payload["keychain_account_template"],
+        allowed=frozenset(allowed),
+    )

--- a/app/ops/host_secret_contract.py
+++ b/app/ops/host_secret_contract.py
@@ -12,6 +12,7 @@ DEFAULT_CONTRACT_PATH = Path("config/secrets/host_secret_contract.json")
 _CONTRACT_FIELDS = frozenset({"version", "keychain_service", "keychain_account_template", "consumers"})
 _CONSUMER_FIELDS = frozenset({"channel", "consumer", "secrets"})
 _KEYCHAIN_ACCOUNT_TEMPLATE = "{channel}:{consumer}:{secret}"
+_KEYCHAIN_SERVICE = "yggdrasil.host-secrets"
 _INITIAL_CHANNELS = frozenset({"dev", "test", "prod"})
 _INITIAL_CONSUMER = "heimdal-capture-watch"
 _INITIAL_SECRET = "heimdal.raw-store-key"
@@ -48,8 +49,9 @@ def load_host_secret_contract(path: Path = DEFAULT_CONTRACT_PATH) -> HostSecretC
     if not isinstance(payload, dict) or set(payload) != _CONTRACT_FIELDS:
         raise ValueError("invalid host secret contract")
     if (
-        payload["version"] != 1
-        or not isinstance(payload["keychain_service"], str)
+        type(payload["version"]) is not int
+        or payload["version"] != 1
+        or payload["keychain_service"] != _KEYCHAIN_SERVICE
         or payload["keychain_account_template"] != _KEYCHAIN_ACCOUNT_TEMPLATE
         or not isinstance(payload["consumers"], list)
     ):

--- a/app/ops/host_secret_contract.py
+++ b/app/ops/host_secret_contract.py
@@ -1,0 +1,44 @@
+"""Value-free contract for host-local Keychain secret consumers."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+DEFAULT_CONTRACT_PATH = Path("config/secrets/host_secret_contract.json")
+
+
+class UndeclaredSecretConsumerError(ValueError):
+    """Raised without secret material when a consumer requests an undeclared key."""
+
+
+@dataclass(frozen=True)
+class HostSecretContract:
+    keychain_service: str
+    allowed: frozenset[tuple[str, str, str]]
+
+    def require_declared(self, *, channel: str, consumer: str, secret: str) -> None:
+        if (channel, consumer, secret) not in self.allowed:
+            raise UndeclaredSecretConsumerError(
+                f"undeclared host secret request: channel={channel!r}, consumer={consumer!r}, secret={secret!r}"
+            )
+
+
+def load_host_secret_contract(path: Path = DEFAULT_CONTRACT_PATH) -> HostSecretContract:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if payload.get("version") != 1 or not isinstance(payload.get("keychain_service"), str):
+        raise ValueError("invalid host secret contract")
+    allowed: set[tuple[str, str, str]] = set()
+    for item in payload.get("consumers", []):
+        channel, consumer, secrets = item.get("channel"), item.get("consumer"), item.get("secrets")
+        if not isinstance(channel, str) or not isinstance(consumer, str) or not isinstance(secrets, list):
+            raise ValueError("invalid host secret consumer declaration")
+        for secret in secrets:
+            if not isinstance(secret, str):
+                raise ValueError("invalid host secret identifier")
+            allowed.add((channel, consumer, secret))
+    if not allowed:
+        raise ValueError("host secret contract declares no consumers")
+    return HostSecretContract(keychain_service=payload["keychain_service"], allowed=frozenset(allowed))

--- a/app/ops/host_secret_contract.py
+++ b/app/ops/host_secret_contract.py
@@ -12,6 +12,9 @@ DEFAULT_CONTRACT_PATH = Path("config/secrets/host_secret_contract.json")
 _CONTRACT_FIELDS = frozenset({"version", "keychain_service", "keychain_account_template", "consumers"})
 _CONSUMER_FIELDS = frozenset({"channel", "consumer", "secrets"})
 _KEYCHAIN_ACCOUNT_TEMPLATE = "{channel}:{consumer}:{secret}"
+_INITIAL_CHANNELS = frozenset({"dev", "test", "prod"})
+_INITIAL_CONSUMER = "heimdal-capture-watch"
+_INITIAL_SECRET = "heimdal.raw-store-key"
 
 
 class UndeclaredSecretConsumerError(ValueError):
@@ -56,10 +59,16 @@ def load_host_secret_contract(path: Path = DEFAULT_CONTRACT_PATH) -> HostSecretC
         if not isinstance(item, dict) or set(item) != _CONSUMER_FIELDS:
             raise ValueError("invalid host secret consumer declaration")
         channel, consumer, secrets = item["channel"], item["consumer"], item["secrets"]
-        if not isinstance(channel, str) or not isinstance(consumer, str) or not isinstance(secrets, list):
+        if (
+            not isinstance(channel, str)
+            or channel not in _INITIAL_CHANNELS
+            or not isinstance(consumer, str)
+            or consumer != _INITIAL_CONSUMER
+            or not isinstance(secrets, list)
+        ):
             raise ValueError("invalid host secret consumer declaration")
         for secret in secrets:
-            if not isinstance(secret, str):
+            if secret != _INITIAL_SECRET:
                 raise ValueError("invalid host secret identifier")
             allowed.add((channel, consumer, secret))
     if not allowed:

--- a/app/ops/host_secret_contract.py
+++ b/app/ops/host_secret_contract.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import quote
 
 
 DEFAULT_CONTRACT_PATH = Path("config/secrets/host_secret_contract.json")
@@ -33,7 +34,9 @@ class HostSecretContract:
         """Return the declared, channel-scoped Keychain account identifier."""
         self.require_declared(channel=channel, consumer=consumer, secret=secret)
         return self.keychain_account_template.format(
-            channel=channel, consumer=consumer, secret=secret
+            channel=quote(channel, safe=""),
+            consumer=quote(consumer, safe=""),
+            secret=quote(secret, safe=""),
         )
 
 

--- a/app/ops/host_secret_contract.py
+++ b/app/ops/host_secret_contract.py
@@ -22,6 +22,15 @@ class UndeclaredSecretConsumerError(ValueError):
     """Raised without secret material when a consumer requests an undeclared key."""
 
 
+def _reject_duplicate_json_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    payload: dict[str, object] = {}
+    for key, value in pairs:
+        if key in payload:
+            raise ValueError("duplicate host secret contract key")
+        payload[key] = value
+    return payload
+
+
 @dataclass(frozen=True)
 class HostSecretContract:
     keychain_service: str
@@ -45,7 +54,7 @@ class HostSecretContract:
 
 
 def load_host_secret_contract(path: Path = DEFAULT_CONTRACT_PATH) -> HostSecretContract:
-    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload = json.loads(path.read_text(encoding="utf-8"), object_pairs_hook=_reject_duplicate_json_keys)
     if not isinstance(payload, dict) or set(payload) != _CONTRACT_FIELDS:
         raise ValueError("invalid host secret contract")
     if (

--- a/app/ops/host_secret_contract.py
+++ b/app/ops/host_secret_contract.py
@@ -39,9 +39,7 @@ class HostSecretContract:
 
     def require_declared(self, *, channel: str, consumer: str, secret: str) -> None:
         if (channel, consumer, secret) not in self.allowed:
-            raise UndeclaredSecretConsumerError(
-                f"undeclared host secret request: channel={channel!r}, consumer={consumer!r}, secret={secret!r}"
-            )
+            raise UndeclaredSecretConsumerError("undeclared host secret request")
 
     def keychain_account(self, *, channel: str, consumer: str, secret: str) -> str:
         """Return the declared, channel-scoped Keychain account identifier."""

--- a/config/secrets/host_secret_contract.json
+++ b/config/secrets/host_secret_contract.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "keychain_service": "yggdrasil.host-secrets",
+  "consumers": [
+    {"channel": "dev", "consumer": "heimdal-capture-watch", "secrets": ["heimdal.raw-store-key"]},
+    {"channel": "test", "consumer": "heimdal-capture-watch", "secrets": ["heimdal.raw-store-key"]},
+    {"channel": "prod", "consumer": "heimdal-capture-watch", "secrets": ["heimdal.raw-store-key"]}
+  ]
+}

--- a/config/secrets/host_secret_contract.json
+++ b/config/secrets/host_secret_contract.json
@@ -1,6 +1,7 @@
 {
   "version": 1,
   "keychain_service": "yggdrasil.host-secrets",
+  "keychain_account_template": "{channel}:{consumer}:{secret}",
   "consumers": [
     {"channel": "dev", "consumer": "heimdal-capture-watch", "secrets": ["heimdal.raw-store-key"]},
     {"channel": "test", "consumer": "heimdal-capture-watch", "secrets": ["heimdal.raw-store-key"]},

--- a/docs/LOCAL_SECRET_PROVISIONING/DEFINE_HOST_SECRET_CONTRACT.md
+++ b/docs/LOCAL_SECRET_PROVISIONING/DEFINE_HOST_SECRET_CONTRACT.md
@@ -29,10 +29,10 @@ accidental secret manager.
 ## Operator runbook
 
 Create or inspect a Keychain item only through the logical identifier and its declared channel and
-consumer. Never paste a value into a shell history, repository file, issue, or receipt. HSP-02 will
-own non-interactive retrieval and temporary runtime material. A raw-store key is generated only when
-the governed preflight proves no encrypted records require an existing key; rotation is a separate
-migration, never a bootstrap retry.
+consumer; its account is deterministically `{channel}:{consumer}:{secret}`. Never paste a value into
+a shell history, repository file, issue, or receipt. HSP-02 will own non-interactive retrieval and
+temporary runtime material. A raw-store key is generated only when the governed preflight proves no
+encrypted records require an existing key; rotation is a separate migration, never a bootstrap retry.
 
 ## Acceptance criteria
 

--- a/docs/LOCAL_SECRET_PROVISIONING/DEFINE_HOST_SECRET_CONTRACT.md
+++ b/docs/LOCAL_SECRET_PROVISIONING/DEFINE_HOST_SECRET_CONTRACT.md
@@ -8,7 +8,7 @@ depends_on: []
 can_parallelize_with: []
 ---
 
-State: Authored task specification (future-state; child issue not yet filed)
+State: Implemented. Delivered by PR #3888 (issue #3845, 2026-07-17).
 
 # Define Host Secret Contract
 
@@ -37,13 +37,13 @@ records require an existing key; rotation is a separate migration, never a boots
 
 ## Acceptance criteria
 
-- [ ] The contract lists every initial logical secret, consumer, and permitted channel without a
+- [x] The contract lists every initial logical secret, consumer, and permitted channel without a
       secret value or copied environment-file content.
       Verify: doc writeback at `docs/LOCAL_SECRET_PROVISIONING/README.md :: Fixed constraints`
-- [ ] The contract names a deterministic Keychain lookup rule and rejects an undeclared
+- [x] The contract names a deterministic Keychain lookup rule and rejects an undeclared
       consumer/secret pair.
       Verify: `tests/ops/test_host_secret_contract.py::test_contract_rejects_undeclared_consumer_secret_pair`
-- [ ] The runbook describes generated-key creation and redacted failure evidence without printing a
+- [x] The runbook describes generated-key creation and redacted failure evidence without printing a
       key.
       Verify: doc writeback at `docs/LOCAL_SECRET_PROVISIONING/DEFINE_HOST_SECRET_CONTRACT.md :: What this task does`
 

--- a/docs/LOCAL_SECRET_PROVISIONING/DEFINE_HOST_SECRET_CONTRACT.md
+++ b/docs/LOCAL_SECRET_PROVISIONING/DEFINE_HOST_SECRET_CONTRACT.md
@@ -26,6 +26,14 @@ accidental secret manager.
 4. Write an operator runbook for initial creation, inspection by identifier, recovery, and the
    explicit non-rotation rule for `HEIMDAL_RAW_STORE_KEY`.
 
+## Operator runbook
+
+Create or inspect a Keychain item only through the logical identifier and its declared channel and
+consumer. Never paste a value into a shell history, repository file, issue, or receipt. HSP-02 will
+own non-interactive retrieval and temporary runtime material. A raw-store key is generated only when
+the governed preflight proves no encrypted records require an existing key; rotation is a separate
+migration, never a bootstrap retry.
+
 ## Acceptance criteria
 
 - [ ] The contract lists every initial logical secret, consumer, and permitted channel without a

--- a/docs/LOCAL_SECRET_PROVISIONING/DEFINE_HOST_SECRET_CONTRACT.md
+++ b/docs/LOCAL_SECRET_PROVISIONING/DEFINE_HOST_SECRET_CONTRACT.md
@@ -29,10 +29,11 @@ accidental secret manager.
 ## Operator runbook
 
 Create or inspect a Keychain item only through the logical identifier and its declared channel and
-consumer; its account is deterministically `{channel}:{consumer}:{secret}`. Never paste a value into
-a shell history, repository file, issue, or receipt. HSP-02 will own non-interactive retrieval and
-temporary runtime material. A raw-store key is generated only when the governed preflight proves no
-encrypted records require an existing key; rotation is a separate migration, never a bootstrap retry.
+consumer; its account is deterministically produced by percent-encoding each
+`{channel}:{consumer}:{secret}` component before colon-joining them. Never paste a value into a shell
+history, repository file, issue, or receipt. HSP-02 will own non-interactive retrieval and temporary
+runtime material. A raw-store key is generated only when the governed preflight proves no encrypted
+records require an existing key; rotation is a separate migration, never a bootstrap retry.
 
 ## Acceptance criteria
 

--- a/docs/LOCAL_SECRET_PROVISIONING/README.md
+++ b/docs/LOCAL_SECRET_PROVISIONING/README.md
@@ -41,6 +41,14 @@ ingress transport only; it is never a secret store or raw-audio archive.
 5. **No cloud secret service now.** 1Password Developer/CLI is a future migration option only when
    sharing/rotation across hosts or CI makes it worthwhile. It is not a prerequisite for v1.
 
+### Initial identifier contract
+
+The only initial logical identifier is `heimdal.raw-store-key`. It is declared separately for the
+`dev`, `test`, and `prod` `heimdal-capture-watch` consumers in
+`config/secrets/host_secret_contract.json`; no value, host path, or Keychain account identifier is
+stored in that file. The Keychain service name is a stable non-secret namespace. HSP-02 is the only
+future component permitted to resolve that declaration into a process-local environment variable.
+
 ## Task order
 
 | Order | Task | ID | Prerequisite | Outcome |

--- a/docs/LOCAL_SECRET_PROVISIONING/README.md
+++ b/docs/LOCAL_SECRET_PROVISIONING/README.md
@@ -45,9 +45,10 @@ ingress transport only; it is never a secret store or raw-audio archive.
 
 The only initial logical identifier is `heimdal.raw-store-key`. It is declared separately for the
 `dev`, `test`, and `prod` `heimdal-capture-watch` consumers in
-`config/secrets/host_secret_contract.json`; no value or host path is stored in that file. The
-Keychain service name is a stable non-secret namespace, and its account is derived by
-percent-encoding each `{channel}:{consumer}:{secret}` component before colon-joining the declared
+`config/secrets/host_secret_contract.json`; no value or host path is stored in that file. The v1
+Keychain service is pinned to the stable non-secret namespace `yggdrasil.host-secrets`, and its
+account is derived by percent-encoding each `{channel}:{consumer}:{secret}` component before
+colon-joining the declared
 tuple, so distinct tuples cannot collide and each channel resolves a distinct item.
 The v1 loader accepts only those three channels, that consumer, and the named logical identifier;
 any other identifier-bearing string is rejected rather than treated as a potential secret value.

--- a/docs/LOCAL_SECRET_PROVISIONING/README.md
+++ b/docs/LOCAL_SECRET_PROVISIONING/README.md
@@ -52,6 +52,8 @@ colon-joining the declared
 tuple, so distinct tuples cannot collide and each channel resolves a distinct item.
 The v1 loader accepts only those three channels, that consumer, and the named logical identifier;
 any other identifier-bearing string is rejected rather than treated as a potential secret value.
+Contract JSON must use unique object keys; a duplicate declaration fails closed rather than allowing a
+value to be hidden behind a later canonical field.
 HSP-02 is the only future component permitted to resolve that declaration into a process-local
 environment variable.
 

--- a/docs/LOCAL_SECRET_PROVISIONING/README.md
+++ b/docs/LOCAL_SECRET_PROVISIONING/README.md
@@ -61,7 +61,7 @@ environment variable.
 
 | Order | Task | ID | Prerequisite | Outcome |
 | --- | --- | --- | --- | --- |
-| 1 | [Define host secret contract](DEFINE_HOST_SECRET_CONTRACT.md) | HSP-01 | — | names, consumer allowlist, Keychain access and redaction contract |
+| 1 | [Define host secret contract](DEFINE_HOST_SECRET_CONTRACT.md) | HSP-01 | — | delivered by [#3845](https://github.com/RasmusTho/agentic-pkm-mvp/issues/3845) / PR #3888: names, consumer allowlist, Keychain access and redaction contract |
 | 2 | [Deliver runtime secret bootstrap](DELIVER_RUNTIME_SECRET_BOOTSTRAP.md) | HSP-02 | HSP-01 | bootstrap, channel integration and fail-closed/redaction tests |
 | Evidence | Delivered [#3830](https://github.com/RasmusTho/agentic-pkm-mvp/issues/3830) | — | completed 2026-07-16 | redacted dev Keychain provisioning and healthy capture-watch receipt; it is not a child or dependency |
 

--- a/docs/LOCAL_SECRET_PROVISIONING/README.md
+++ b/docs/LOCAL_SECRET_PROVISIONING/README.md
@@ -49,6 +49,8 @@ The only initial logical identifier is `heimdal.raw-store-key`. It is declared s
 Keychain service name is a stable non-secret namespace, and its account is derived by
 percent-encoding each `{channel}:{consumer}:{secret}` component before colon-joining the declared
 tuple, so distinct tuples cannot collide and each channel resolves a distinct item.
+The v1 loader accepts only those three channels, that consumer, and the named logical identifier;
+any other identifier-bearing string is rejected rather than treated as a potential secret value.
 HSP-02 is the only future component permitted to resolve that declaration into a process-local
 environment variable.
 

--- a/docs/LOCAL_SECRET_PROVISIONING/README.md
+++ b/docs/LOCAL_SECRET_PROVISIONING/README.md
@@ -45,9 +45,11 @@ ingress transport only; it is never a secret store or raw-audio archive.
 
 The only initial logical identifier is `heimdal.raw-store-key`. It is declared separately for the
 `dev`, `test`, and `prod` `heimdal-capture-watch` consumers in
-`config/secrets/host_secret_contract.json`; no value, host path, or Keychain account identifier is
-stored in that file. The Keychain service name is a stable non-secret namespace. HSP-02 is the only
-future component permitted to resolve that declaration into a process-local environment variable.
+`config/secrets/host_secret_contract.json`; no value or host path is stored in that file. The
+Keychain service name is a stable non-secret namespace, and its account is derived exactly as
+`{channel}:{consumer}:{secret}` from a declared tuple, so each channel resolves a distinct item.
+HSP-02 is the only future component permitted to resolve that declaration into a process-local
+environment variable.
 
 ## Task order
 

--- a/docs/LOCAL_SECRET_PROVISIONING/README.md
+++ b/docs/LOCAL_SECRET_PROVISIONING/README.md
@@ -46,8 +46,9 @@ ingress transport only; it is never a secret store or raw-audio archive.
 The only initial logical identifier is `heimdal.raw-store-key`. It is declared separately for the
 `dev`, `test`, and `prod` `heimdal-capture-watch` consumers in
 `config/secrets/host_secret_contract.json`; no value or host path is stored in that file. The
-Keychain service name is a stable non-secret namespace, and its account is derived exactly as
-`{channel}:{consumer}:{secret}` from a declared tuple, so each channel resolves a distinct item.
+Keychain service name is a stable non-secret namespace, and its account is derived by
+percent-encoding each `{channel}:{consumer}:{secret}` component before colon-joining the declared
+tuple, so distinct tuples cannot collide and each channel resolves a distinct item.
 HSP-02 is the only future component permitted to resolve that declaration into a process-local
 environment variable.
 

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -524,8 +524,13 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
         ),
     ),
     (
+        "ops",
+        ("app/ops/", "tests/ops/"),
+        ("tests/ops",),
+    ),
+    (
         "ops_deploy",
-        ("scripts/", "ops/", "config/deploy/", "tests/ops/", "tests/scripts/", "tests/deploy/"),
+        ("scripts/", "ops/", "config/deploy/", "tests/scripts/", "tests/deploy/"),
         ("tests/ops", "tests/scripts", "tests/deploy"),
     ),
     (

--- a/tests/ops/test_host_secret_contract.py
+++ b/tests/ops/test_host_secret_contract.py
@@ -113,6 +113,20 @@ def test_contract_rejects_noncanonical_top_level_values(
         load_host_secret_contract(contract_path)
 
 
+def test_contract_rejects_duplicate_json_key_that_hides_secret_material(tmp_path: Path) -> None:
+    text = Path("config/secrets/host_secret_contract.json").read_text(encoding="utf-8")
+    text = text.replace(
+        '"keychain_service": "yggdrasil.host-secrets",',
+        '"keychain_service": "actual-secret-material",\n'
+        '  "keychain_service": "yggdrasil.host-secrets",',
+    )
+    contract_path = tmp_path / "host_secret_contract.json"
+    contract_path.write_text(text, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="duplicate host secret contract key"):
+        load_host_secret_contract(contract_path)
+
+
 @pytest.mark.parametrize(
     ("field", "value"),
     [("channel", "secret-value"), ("consumer", "secret-value")],

--- a/tests/ops/test_host_secret_contract.py
+++ b/tests/ops/test_host_secret_contract.py
@@ -99,6 +99,22 @@ def test_contract_rejects_value_bearing_identifier_field(tmp_path: Path) -> None
 
 @pytest.mark.parametrize(
     ("field", "value"),
+    [("keychain_service", "actual-secret-material"), ("version", True)],
+)
+def test_contract_rejects_noncanonical_top_level_values(
+    tmp_path: Path, field: str, value: str | bool
+) -> None:
+    payload = json.loads(Path("config/secrets/host_secret_contract.json").read_text(encoding="utf-8"))
+    payload[field] = value
+    contract_path = tmp_path / "host_secret_contract.json"
+    contract_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="invalid host secret contract"):
+        load_host_secret_contract(contract_path)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
     [("channel", "secret-value"), ("consumer", "secret-value")],
 )
 def test_contract_rejects_unknown_channel_or_consumer(

--- a/tests/ops/test_host_secret_contract.py
+++ b/tests/ops/test_host_secret_contract.py
@@ -3,7 +3,11 @@ from pathlib import Path
 
 import pytest
 
-from app.ops.host_secret_contract import UndeclaredSecretConsumerError, load_host_secret_contract
+from app.ops.host_secret_contract import (
+    HostSecretContract,
+    UndeclaredSecretConsumerError,
+    load_host_secret_contract,
+)
 
 
 def test_contract_rejects_undeclared_consumer_secret_pair() -> None:
@@ -41,6 +45,26 @@ def test_contract_resolves_distinct_channel_scoped_keychain_accounts() -> None:
         "test:heimdal-capture-watch:heimdal.raw-store-key",
         "prod:heimdal-capture-watch:heimdal.raw-store-key",
     }
+
+
+def test_contract_percent_encodes_components_to_prevent_account_collisions() -> None:
+    contract = HostSecretContract(
+        keychain_service="test",
+        keychain_account_template="{channel}:{consumer}:{secret}",
+        allowed=frozenset(
+            {
+                ("dev:ops", "watch", "key"),
+                ("dev", "ops:watch", "key"),
+            }
+        ),
+    )
+
+    left = contract.keychain_account(channel="dev:ops", consumer="watch", secret="key")
+    right = contract.keychain_account(channel="dev", consumer="ops:watch", secret="key")
+
+    assert left == "dev%3Aops:watch:key"
+    assert right == "dev:ops%3Awatch:key"
+    assert left != right
 
 
 def test_contract_rejects_undeclared_consumer_field(tmp_path: Path) -> None:

--- a/tests/ops/test_host_secret_contract.py
+++ b/tests/ops/test_host_secret_contract.py
@@ -21,6 +21,22 @@ def test_contract_rejects_undeclared_consumer_secret_pair() -> None:
         contract.require_declared(channel="dev", consumer="heimdal-capture-watch", secret="unrelated-key")
 
 
+def test_undeclared_request_error_does_not_disclose_caller_identifiers() -> None:
+    contract = load_host_secret_contract()
+    raw_channel = "noncanonical-channel"
+    raw_consumer = "noncanonical-consumer"
+    raw_secret = "raw-key-material"
+
+    with pytest.raises(UndeclaredSecretConsumerError) as error:
+        contract.require_declared(channel=raw_channel, consumer=raw_consumer, secret=raw_secret)
+
+    message = str(error.value)
+    assert message == "undeclared host secret request"
+    assert raw_channel not in message
+    assert raw_consumer not in message
+    assert raw_secret not in message
+
+
 def test_contract_is_value_free() -> None:
     text = Path("config/secrets/host_secret_contract.json").read_text(encoding="utf-8")
 

--- a/tests/ops/test_host_secret_contract.py
+++ b/tests/ops/test_host_secret_contract.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -21,3 +22,42 @@ def test_contract_is_value_free() -> None:
 
     assert "HEIMDAL_RAW_STORE_KEY" not in text
     assert "value" not in text
+
+
+def test_contract_resolves_distinct_channel_scoped_keychain_accounts() -> None:
+    contract = load_host_secret_contract()
+
+    accounts = {
+        contract.keychain_account(
+            channel=channel,
+            consumer="heimdal-capture-watch",
+            secret="heimdal.raw-store-key",
+        )
+        for channel in ("dev", "test", "prod")
+    }
+
+    assert accounts == {
+        "dev:heimdal-capture-watch:heimdal.raw-store-key",
+        "test:heimdal-capture-watch:heimdal.raw-store-key",
+        "prod:heimdal-capture-watch:heimdal.raw-store-key",
+    }
+
+
+def test_contract_rejects_undeclared_consumer_field(tmp_path: Path) -> None:
+    payload = json.loads(Path("config/secrets/host_secret_contract.json").read_text(encoding="utf-8"))
+    payload["consumers"][0]["raw_key"] = "not-a-secret-value"
+    contract_path = tmp_path / "host_secret_contract.json"
+    contract_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="invalid host secret consumer declaration"):
+        load_host_secret_contract(contract_path)
+
+
+def test_contract_rejects_undeclared_top_level_field(tmp_path: Path) -> None:
+    payload = json.loads(Path("config/secrets/host_secret_contract.json").read_text(encoding="utf-8"))
+    payload["raw_key"] = "not-a-secret-value"
+    contract_path = tmp_path / "host_secret_contract.json"
+    contract_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="invalid host secret contract"):
+        load_host_secret_contract(contract_path)

--- a/tests/ops/test_host_secret_contract.py
+++ b/tests/ops/test_host_secret_contract.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+import pytest
+
+from app.ops.host_secret_contract import UndeclaredSecretConsumerError, load_host_secret_contract
+
+
+def test_contract_rejects_undeclared_consumer_secret_pair() -> None:
+    contract = load_host_secret_contract()
+
+    contract.require_declared(
+        channel="dev", consumer="heimdal-capture-watch", secret="heimdal.raw-store-key"
+    )
+
+    with pytest.raises(UndeclaredSecretConsumerError, match="undeclared host secret request"):
+        contract.require_declared(channel="dev", consumer="heimdal-capture-watch", secret="unrelated-key")
+
+
+def test_contract_is_value_free() -> None:
+    text = Path("config/secrets/host_secret_contract.json").read_text(encoding="utf-8")
+
+    assert "HEIMDAL_RAW_STORE_KEY" not in text
+    assert "value" not in text

--- a/tests/ops/test_host_secret_contract.py
+++ b/tests/ops/test_host_secret_contract.py
@@ -85,3 +85,29 @@ def test_contract_rejects_undeclared_top_level_field(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="invalid host secret contract"):
         load_host_secret_contract(contract_path)
+
+
+def test_contract_rejects_value_bearing_identifier_field(tmp_path: Path) -> None:
+    payload = json.loads(Path("config/secrets/host_secret_contract.json").read_text(encoding="utf-8"))
+    payload["consumers"][0]["secrets"] = ["actual-secret-material"]
+    contract_path = tmp_path / "host_secret_contract.json"
+    contract_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="invalid host secret identifier"):
+        load_host_secret_contract(contract_path)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("channel", "secret-value"), ("consumer", "secret-value")],
+)
+def test_contract_rejects_unknown_channel_or_consumer(
+    tmp_path: Path, field: str, value: str
+) -> None:
+    payload = json.loads(Path("config/secrets/host_secret_contract.json").read_text(encoding="utf-8"))
+    payload["consumers"][0][field] = value
+    contract_path = tmp_path / "host_secret_contract.json"
+    contract_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="invalid host secret consumer declaration"):
+        load_host_secret_contract(contract_path)

--- a/tests/scripts/test_select_pr_tests.py
+++ b/tests/scripts/test_select_pr_tests.py
@@ -83,6 +83,16 @@ def test_deploy_pin_file_selects_ops_deploy() -> None:
     assert "tests/deploy" in selection.targets
 
 
+def test_ops_contract_change_selects_ops_coverage() -> None:
+    selection = select_tests(["app/ops/host_secret_contract.py", "tests/ops/test_host_secret_contract.py"])
+
+    assert selection.full_suite is False
+    assert selection.subsystems == ("ops",)
+    assert selection.unowned_paths == ()
+    assert "tests/ops" in selection.targets
+    assert "tests/ops/test_host_secret_contract.py" in selection.targets
+
+
 def test_deploy_pin_cannot_mask_an_unowned_runtime_path() -> None:
     selection = select_tests(["config/deploy/dev.env", "app/new_surface/example.py"])
 


### PR DESCRIPTION
Governing-Issue: #3845
Fixes #3845
Fixes #3905

## Summary
- Define a deterministic, channel-scoped Keychain account mapping for declared host-secret tuples.
- Fail closed on undeclared, noncanonical, and duplicate JSON contract values; register the `app/ops` test-selection owner.
- Percent-encode account components so distinct declared tuples cannot collide.

## Validation
- pytest -q tests/ops/test_host_secret_contract.py tests/scripts/test_select_pr_tests.py tests/governance/test_select_pr_tests.py (84 passed after rebase)
- PYTHONPATH="$PWD:$PWD/companion-ui/companion-app" pytest -q -m "not pg" (9801 passed, 46 skipped, 225 deselected, 18 xfailed before the clean rebase)
- mypy app
- ruff check app tests scripts
- python3 scripts/public_seam_lint.py --mode gate
- python3 scripts/select_pr_tests.py --changed-file app/ops/host_secret_contract.py --changed-file tests/ops/test_host_secret_contract.py

## BuilderOps Routing
- Records/projections/receipts: runtime/builderops/epic-runs/local-secrets-20260716.json
- Reason: Parent-feature delivery coordination for #3843; no Product memory material created.