### PR TITLE
Fix settings path ownership in PR test selection

### DIFF
--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -123,7 +123,12 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
             "tests/settings/",
             "tests/config/",
         ),
-        ("tests/settings", "tests/config"),
+        (
+            "tests/settings",
+            "tests/config",
+            "tests/cli/test_settings_explain_cli.py",
+            "tests/services/test_companion_eligibility.py",
+        ),
     ),
     (
         "vault",

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -22,6 +22,10 @@ FULL_SUITE_REASONS = (
 )
 
 FULL_SUITE_EXACT = {
+    # Shared CLI registration and path resolution affect many runtime
+    # subsystems. Never narrow their coverage to a single feature owner.
+    "app/cli/__init__.py",
+    "app/config/paths.py",
     "conftest.py",
     "pytest.ini",
     "pyproject.toml",
@@ -110,7 +114,15 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
     ),
     (
         "settings",
-        ("app/settings/", "docs/settings/", "tests/settings/", "tests/config/"),
+        (
+            "app/settings/",
+            "app/cli/settings_explain.py",
+            "app/services/companion_eligibility.py",
+            "app/services/settings.py",
+            "docs/settings/",
+            "tests/settings/",
+            "tests/config/",
+        ),
         ("tests/settings", "tests/config"),
     ),
     (

--- a/tests/scripts/test_select_pr_tests.py
+++ b/tests/scripts/test_select_pr_tests.py
@@ -94,17 +94,16 @@ def test_settings_facade_and_shared_adapters_have_safe_owners() -> None:
     assert selection.reason == "shared CI/test/runtime configuration changed"
     assert "tests --ignore=tests/e2e" in selection.pytest_args
 
-    focused_selection = select_tests(
-        [
-            "app/cli/settings_explain.py",
-            "app/services/companion_eligibility.py",
-            "app/services/settings.py",
-        ]
-    )
-    assert focused_selection.subsystems == ("settings",)
-    assert focused_selection.unowned_paths == ()
-    assert "tests/cli/test_settings_explain_cli.py" in focused_selection.targets
-    assert "tests/services/test_companion_eligibility.py" in focused_selection.targets
+    for adapter_path in (
+        "app/cli/settings_explain.py",
+        "app/services/companion_eligibility.py",
+        "app/services/settings.py",
+    ):
+        focused_selection = select_tests([adapter_path])
+        assert focused_selection.subsystems == ("settings",)
+        assert focused_selection.unowned_paths == ()
+        assert "tests/cli/test_settings_explain_cli.py" in focused_selection.targets
+        assert "tests/services/test_companion_eligibility.py" in focused_selection.targets
 
 
 def test_settings_adapter_cannot_mask_unknown_runtime_path() -> None:

--- a/tests/scripts/test_select_pr_tests.py
+++ b/tests/scripts/test_select_pr_tests.py
@@ -94,6 +94,18 @@ def test_settings_facade_and_shared_adapters_have_safe_owners() -> None:
     assert selection.reason == "shared CI/test/runtime configuration changed"
     assert "tests --ignore=tests/e2e" in selection.pytest_args
 
+    focused_selection = select_tests(
+        [
+            "app/cli/settings_explain.py",
+            "app/services/companion_eligibility.py",
+            "app/services/settings.py",
+        ]
+    )
+    assert focused_selection.subsystems == ("settings",)
+    assert focused_selection.unowned_paths == ()
+    assert "tests/cli/test_settings_explain_cli.py" in focused_selection.targets
+    assert "tests/services/test_companion_eligibility.py" in focused_selection.targets
+
 
 def test_settings_adapter_cannot_mask_unknown_runtime_path() -> None:
     selection = select_tests(

--- a/tests/scripts/test_select_pr_tests.py
+++ b/tests/scripts/test_select_pr_tests.py
@@ -78,6 +78,36 @@ def test_deploy_pin_cannot_mask_an_unowned_runtime_path() -> None:
     assert selection.unowned_paths == ("app/new_surface/example.py",)
 
 
+def test_settings_facade_and_shared_adapters_have_safe_owners() -> None:
+    selection = select_tests(
+        [
+            "app/cli/__init__.py",
+            "app/cli/settings_explain.py",
+            "app/config/paths.py",
+            "app/services/companion_eligibility.py",
+            "app/services/settings.py",
+        ]
+    )
+
+    assert selection.full_suite is True
+    assert selection.unowned_paths == ()
+    assert selection.reason == "shared CI/test/runtime configuration changed"
+    assert "tests --ignore=tests/e2e" in selection.pytest_args
+
+
+def test_settings_adapter_cannot_mask_unknown_runtime_path() -> None:
+    selection = select_tests(
+        [
+            "app/services/settings.py",
+            "app/new_surface/example.py",
+        ]
+    )
+
+    assert selection.full_suite is False
+    assert selection.subsystems == ("unowned",)
+    assert selection.unowned_paths == ("app/new_surface/example.py",)
+
+
 def test_docs_authoring_and_skill_paths_are_owned() -> None:
     # Reproduces the #3476 / PR #3475 failure: a docs-authoring PR touching
     # docs/contracts/**, docs/HEIMDAL/**, api/openapi.yaml, and .codex/skills/**


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Closes #3889

## SBS Impact
- Primary subsystem: Builder System / OEF
- Secondary subsystem(s): Product settings verification boundary
- Write class: governance/process
- Authority impact: none; CI routing only
- Persistence impact: none
- Derived/rebuildable impact: selected pytest target output changes
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: none
- External boundary impact: none
- New or changed contract: existing settings facade/adapters have explicit CI ownership
- Owner-doc impact: none; existing hot-path test strategy already requires conservative ownership
- Transition debt impact: reduces CI selector ownership drift
- Fitness rule impact: strengthens fail-closed CI selection
- Boundary risk: low; no product/runtime behavior changes

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Route the shared CLI bootstrap and path resolver through the deterministic broad suite.
- Assign settings-specific facades to the existing settings selector while preserving fail-closed unknown paths.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [ ] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [ ] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [x] Focused AC tests: 2 passed
- [x] Full selector regression suite: 59 passed
- [x] ruff check app tests companion-ui/companion-app: passed

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: No plan divergence, learning, promotion, or operational record was produced by this bounded CI ownership repair.

## Notes
GitHub `Unit tests (not pg)` passed on the current SHA. The broader local run reached 9,271 passed, 36 skipped, and 18 xfailed; its eight failures were confined to `tests/stores/test_store_contract_pg.py` because a reachable local Postgres lacked the migration-owned store tables. This is outside the selector diff and did not reproduce in CI.
