### PR TITLE
task: wire structured JSON logging for runtime services (#3895)

### DIFF
--- a/app/api/app.py
+++ b/app/api/app.py
@@ -11,7 +11,7 @@ from fastapi.staticfiles import StaticFiles
 
 from app.index.doctor import diagnose_index
 from app.middleware.trace import TraceIdMiddleware
-from app.observability import configure_metrics
+from app.observability import configure_metrics, setup_logging
 from app.observability.status_service import register_source_understanding_availability_provider
 
 try:
@@ -238,6 +238,10 @@ async def lifespan(app: FastAPI):
 
 
 def _create_app() -> FastAPI:
+    # Process-level structured logging (#3895): JSON lines on stdout with
+    # span-schema field names (trace_id, status, extra); logging.getLogger
+    # call sites stay untouched.
+    setup_logging()
     application = FastAPI(title="Agentic PKM API", lifespan=lifespan)
     application.add_middleware(TraceIdMiddleware)
     application.mount("/static", StaticFiles(directory=static_dir), name="static")

--- a/app/cli/watcher.py
+++ b/app/cli/watcher.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import click
 
+from app.observability.logging_setup import configure_json_logging
 from app.runtime.runtime_loop import OutboxPathError, _resolve_watcher_run_log, resolve_outbox_path
 from app.settings.tiering import require_lab_profile
 from app.settings.validate import validate_settings
@@ -85,6 +86,9 @@ def watcher_group() -> None:
     help="Run a single watcher scan respecting scope, debounce, and rate limits.",
 )
 def watcher_once() -> None:
+    # Process-level structured logging (#3895): JSON lines on stdout with
+    # span-schema field names (trace_id, status, extra).
+    configure_json_logging()
     _validate_settings_or_exit()
     try:
         cfg = WatcherConfig.from_env()
@@ -130,6 +134,10 @@ def watcher_once() -> None:
     help="Optional safety: stop after N ticks (defaults to run forever).",
 )
 def watcher_run(config: Path, max_ticks: int | None) -> None:
+    # Process-level structured logging (#3895): the watcher container runs
+    # `python -m app.cli watcher run` (docker-compose.yaml / Makefile), so
+    # this is the watcher process's logging setup boundary.
+    configure_json_logging()
     _validate_settings_or_exit()
     try:
         cfg = load_registry_config(config)

--- a/app/middleware/trace.py
+++ b/app/middleware/trace.py
@@ -1,10 +1,20 @@
 from starlette.middleware.base import BaseHTTPMiddleware
 import uuid
 
+from app.observability.tracer import bind_trace_id, reset_trace_id
+
+
 class TraceIdMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request, call_next):
         trace_id = request.headers.get("x-trace-id") or uuid.uuid4().hex
         request.state.trace_id = trace_id
-        response = await call_next(request)
+        # Bind the request trace id into the app.observability.tracer
+        # contextvar so JSON log lines emitted while handling this request
+        # carry trace_id (#3895).
+        token = bind_trace_id(trace_id)
+        try:
+            response = await call_next(request)
+        finally:
+            reset_trace_id(token)
         response.headers["x-trace-id"] = trace_id
         return response

--- a/app/observability/__init__.py
+++ b/app/observability/__init__.py
@@ -11,32 +11,16 @@ from __future__ import annotations
 
 
 def setup_logging() -> None:
-    import json
-    import logging
-    import sys
-    from datetime import timezone, datetime
-    from typing import Any
+    """Install the process-wide JSON log formatter (structured logging #3895).
 
-    class JsonFormatter(logging.Formatter):
-        """Minimal JSON formatter for structured logs."""
+    Delegates to :mod:`app.observability.logging_setup` so API, worker, and
+    watcher processes share one formatter implementation (span-schema field
+    conventions: trace_id, status, extra). Import stays deferred per this
+    module's contract above.
+    """
+    from app.observability.logging_setup import configure_json_logging
 
-        def format(self, record: logging.LogRecord) -> str:  # pragma: no cover
-            payload: dict[str, Any] = {
-                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-                "level": record.levelname,
-                "logger": record.name,
-                "message": record.getMessage(),
-            }
-            if record.exc_info:
-                payload["exc"] = self.formatException(record.exc_info)
-            return json.dumps(payload, ensure_ascii=False)
-
-    root = logging.getLogger()
-    root.handlers.clear()
-    handler = logging.StreamHandler(sys.stdout)
-    handler.setFormatter(JsonFormatter())
-    root.addHandler(handler)
-    root.setLevel(logging.INFO)
+    configure_json_logging()
 
 
 def configure_metrics(app: object) -> None:

--- a/app/observability/logging_setup.py
+++ b/app/observability/logging_setup.py
@@ -1,0 +1,94 @@
+"""Process-level structured JSON logging for runtime services (#3895).
+
+The API, worker, and watcher processes install :class:`JsonLogFormatter` on
+the root logger at process setup so every existing stdlib
+``logging.getLogger(__name__)`` call site emits one JSON object per line on
+stdout — call sites are untouched; only the process-level handler/formatter
+changes.
+
+Field names reuse the span-schema conventions of ``app.observability.log``
+documented in ``docs/OBSERVABILITY.md :: JSON log and span schema``
+(``trace_id``, ``status``, ``extra``) so general service logs and
+instrumented spans correlate with the same jq recipes. ``trace_id`` is read
+from the :mod:`app.observability.tracer` contextvar when a record does not
+carry one explicitly, which is how span/trace context threads into ordinary
+log lines. No external aggregation stack is involved: output is plain
+line-delimited JSON on stdout.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from datetime import datetime, timezone
+from typing import IO, Any, Optional
+
+from app.observability.tracer import current_trace_id
+
+# Attributes owned by the stdlib LogRecord contract; anything else on the
+# record arrived via ``logger.info(..., extra={...})`` and is surfaced under
+# the span-schema ``extra`` field.
+_RESERVED_RECORD_ATTRS = frozenset(vars(logging.makeLogRecord({})).keys()) | {
+    "asctime",
+    "message",
+    "taskName",
+}
+
+
+class JsonLogFormatter(logging.Formatter):
+    """Render one stdlib log record as one JSON line (span-schema field names)."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            "status": "error" if record.levelno >= logging.ERROR else "ok",
+        }
+        trace_id = getattr(record, "trace_id", None) or current_trace_id()
+        if trace_id:
+            payload["trace_id"] = str(trace_id)
+        extra = {
+            key: value
+            for key, value in record.__dict__.items()
+            if key not in _RESERVED_RECORD_ATTRS and key != "trace_id"
+        }
+        if extra:
+            payload["extra"] = extra
+        if record.exc_info:
+            payload["exc"] = self.formatException(record.exc_info)
+        return json.dumps(payload, ensure_ascii=False, default=str)
+
+
+def configure_json_logging(
+    level: int = logging.INFO,
+    *,
+    stream: Optional[IO[str]] = None,
+) -> logging.Handler:
+    """Install the JSON formatter on the root logger (idempotent).
+
+    Keeps the stdlib ``logging.getLogger(__name__)`` call-site API: only the
+    process-level handler/formatter changes. Re-invocation never adds a second
+    handler; it rebinds the existing one to the current ``sys.stdout`` (or the
+    explicit ``stream``) so pytest ``capsys``-replaced streams stay aligned —
+    the same realignment contract the worker's pre-#3895 local setup carried.
+    """
+    target = stream if stream is not None else sys.stdout
+    root = logging.getLogger()
+    for handler in root.handlers:
+        if isinstance(handler, logging.StreamHandler) and isinstance(
+            handler.formatter, JsonLogFormatter
+        ):
+            handler.setStream(target)
+            return handler
+    handler = logging.StreamHandler(target)
+    handler.setFormatter(JsonLogFormatter())
+    root.addHandler(handler)
+    if root.level == logging.NOTSET or root.level > level:
+        root.setLevel(level)
+    return handler
+
+
+__all__ = ["JsonLogFormatter", "configure_json_logging"]

--- a/app/observability/tracer.py
+++ b/app/observability/tracer.py
@@ -1,11 +1,23 @@
 from contextlib import contextmanager
-from contextvars import ContextVar
+from contextvars import ContextVar, Token
 from typing import Dict, Any, Optional
 
 _current_trace_id: ContextVar[Optional[str]] = ContextVar("_current_trace_id", default=None)
 
 def current_trace_id() -> Optional[str]:
     return _current_trace_id.get()
+
+def bind_trace_id(trace_id: str) -> Token:
+    """Bind ``trace_id`` to the current context; returns the reset token.
+
+    Non-span propagation seam (#3895): lets process boundaries (e.g. the API
+    trace middleware) thread a trace id into the contextvar that
+    ``JsonLogFormatter`` reads, without opening an instrumented span.
+    """
+    return _current_trace_id.set(trace_id)
+
+def reset_trace_id(token: Token) -> None:
+    _current_trace_id.reset(token)
 
 @contextmanager
 def start_span(name: str, trace_id: Optional[str] = None, attrs: Optional[Dict[str, Any]] = None):

--- a/app/workers/outbox_worker.py
+++ b/app/workers/outbox_worker.py
@@ -4,7 +4,6 @@ import errno
 import hashlib
 import logging
 import os
-import sys
 import time
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -37,6 +36,7 @@ from app.events.topic_schema_registry import (
 )
 from app.indexer.consumer import process_event as process_indexer_event
 from app.outbox.events import INDEX_EMBEDDING_REQUESTED
+from app.observability.logging_setup import configure_json_logging
 from app.observability.tracer import start_span
 from app.runtime.worker_heartbeat import resolve_worker_heartbeat_path, write_worker_heartbeat
 from app.services.indexer import handle_ingest_object_created, purge_object_vectors
@@ -751,19 +751,20 @@ def handle_knowledge_acquisition_stage_dead_lettered(
 
 
 def _ensure_logging_configured() -> None:
-    if logger.handlers:
-        # pytest's capsys replaces sys.stderr; keep the handler stream aligned so tests
-        # can assert on startup logging even if another test configured logging first.
-        for h in logger.handlers:
-            if isinstance(h, logging.StreamHandler):
-                h.stream = sys.stderr
-        return
-    handler = logging.StreamHandler(stream=sys.stderr)
-    handler.setLevel(logging.INFO)
-    handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
-    logger.addHandler(handler)
-    logger.setLevel(logging.INFO)
-    logger.propagate = False
+    """Install the shared process-level JSON formatter (structured logging #3895).
+
+    Root-logger wiring via ``configure_json_logging`` keeps every
+    ``logging.getLogger(__name__)`` call site untouched and renders each
+    worker log line as one JSON object on stdout with the span-schema field
+    conventions (trace_id, status, extra) from
+    ``docs/OBSERVABILITY.md :: JSON log and span schema``. Re-invocation
+    rebinds the handler to the current stdout so pytest's capsys-replaced
+    streams stay aligned (same contract the previous local stderr setup had).
+    """
+    configure_json_logging()
+    # Records must reach the root JSON handler; the pre-#3895 local handler
+    # setup switched this off.
+    logger.propagate = True
 
 
 def _resolve_optional_vault_root(vault_root: Path | None = None) -> Path | None:

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -177,6 +177,20 @@ Example (QA response):
 }
 ```
 
+### Service-process JSON logs (API, worker, watcher)
+The API, worker, and watcher processes install a shared JSON formatter (`app/observability/logging_setup.py`) on the root logger at process setup — `app/api/app.py::_create_app` (API), `app/workers/outbox_worker.py::run` via `_ensure_logging_configured` (worker), and `app/cli/watcher.py` `watcher run`/`watcher once` (watcher). Every stdlib `logging.getLogger(__name__)` call site renders as one JSON object per line on stdout; call sites keep the stdlib logging API and there is no external aggregation stack.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `timestamp` | str | ISO-8601 UTC record time. |
+| `level` / `logger` / `message` | str | Standard stdlib record fields. |
+| `status` | "ok" \| "error" | `error` for records at ERROR and above (span-schema convention). |
+| `trace_id` | str (optional) | Present when the `app/observability/tracer.py` contextvar is bound; the API trace middleware binds the request `x-trace-id` for the request duration. |
+| `extra` | dict (optional) | Fields passed via `logger.*(..., extra={...})`. |
+| `exc` | str (optional) | Formatted traceback when exception info is attached. |
+
+`trace_id`, `status`, and `extra` reuse the span-schema names above, so the same jq recipes correlate instrumented spans and general service logs.
+
 ## jq recipes
 - Latency per node (average):  
   ```bash

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -123,6 +123,10 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
         (
             "companion-ui/",
             "app/api/",
+            # HTTP middleware is API surface: TraceIdMiddleware is wired only
+            # into app/api/app.py, and its x-trace-id propagation regression
+            # lives in tests/api (test_ask_contract).
+            "app/middleware/",
             "api/",
             "tests/companion_ui/",
             "tests/api/",
@@ -146,6 +150,10 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
         (
             "app/watcher/",
             "app/sync/",
+            # Watcher process entrypoint (`python -m app.cli watcher run`);
+            # its CLI regressions live in tests/watcher (same single-file
+            # granularity as runtime_health's app/cli/health.py).
+            "app/cli/watcher.py",
             "scripts/run_live_watcher.sh",
             "tests/watcher/",
             "tests/sync/",
@@ -167,6 +175,21 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
             "docs/OBSERVABILITY_STABILIZATION/",
         ),
         ("tests/health", "tests/invariants", "tests/api"),
+    ),
+    (
+        # Structured logging / tracing / status-model surface (#3895). Its
+        # home suite is tests/observability; the API status routes and the
+        # trace-context consumers (app/api/routes/status.py, TraceIdMiddleware
+        # binding app.observability.tracer) regress in tests/api. The docs
+        # owner file is the exact path docs/OBSERVABILITY.md so this prefix
+        # never steals runtime_health's docs/OBSERVABILITY_STABILIZATION/.
+        "observability",
+        (
+            "app/observability/",
+            "tests/observability/",
+            "docs/OBSERVABILITY.md",
+        ),
+        ("tests/observability", "tests/api"),
     ),
     (
         "store_ingest",

--- a/tests/governance/test_select_pr_tests.py
+++ b/tests/governance/test_select_pr_tests.py
@@ -25,3 +25,42 @@ def test_companion_api_paths_select_api_targets() -> None:
     assert "companion_ui" in selection.subsystems
     assert "tests/companion_ui" in selection.targets
     assert "tests/api" in selection.targets
+
+
+def test_observability_runtime_paths_select_observability_coverage() -> None:
+    # Structured-logging surface (#3895): app/observability/** is owned so a
+    # logging/tracer change runs its home suite instead of fail-closing as
+    # unowned before pytest starts.
+    selection = select_tests(
+        [
+            "app/observability/__init__.py",
+            "app/observability/logging_setup.py",
+            "app/observability/tracer.py",
+        ]
+    )
+
+    assert selection.full_suite is False
+    assert selection.subsystems == ("observability",)
+    assert selection.unowned_paths == ()
+    assert "tests/observability" in selection.targets
+    assert "tests/api" in selection.targets
+
+
+def test_trace_middleware_is_owned_by_companion_ui() -> None:
+    # TraceIdMiddleware is wired only into app/api/app.py; its regression
+    # lives in tests/api (a companion_ui target).
+    selection = select_tests(["app/middleware/trace.py"])
+
+    assert selection.unowned_paths == ()
+    assert "companion_ui" in selection.subsystems
+    assert "tests/api" in selection.targets
+
+
+def test_watcher_cli_entrypoint_is_owned_by_watcher_sync() -> None:
+    # `python -m app.cli watcher run` is the watcher process entrypoint; its
+    # CLI regressions live in tests/watcher (e.g. test_cli_idle_vs_disabled).
+    selection = select_tests(["app/cli/watcher.py"])
+
+    assert selection.unowned_paths == ()
+    assert "watcher_sync" in selection.subsystems
+    assert "tests/watcher" in selection.targets

--- a/tests/observability/test_structured_logging.py
+++ b/tests/observability/test_structured_logging.py
@@ -1,0 +1,230 @@
+"""Structured JSON logging for runtime service processes (#3895).
+
+Contract for ``app/observability/logging_setup.py``: API, worker, and watcher
+processes install one shared JSON formatter on the root logger at process
+setup. Field names reuse the span-schema conventions of
+``app/observability/log.py`` documented in
+``docs/OBSERVABILITY.md :: JSON log and span schema`` (``trace_id``,
+``status``, ``extra``) so service logs and instrumented spans correlate with
+the same jq recipes. Call sites keep the stdlib ``logging.getLogger(__name__)``
+API untouched.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+
+import pytest
+
+
+@pytest.fixture()
+def clean_root_logger():
+    """Snapshot and restore root-logger handlers/level around a test."""
+    root = logging.getLogger()
+    saved_handlers = list(root.handlers)
+    saved_level = root.level
+    for handler in saved_handlers:
+        root.removeHandler(handler)
+    try:
+        yield root
+    finally:
+        for handler in list(root.handlers):
+            root.removeHandler(handler)
+        for handler in saved_handlers:
+            root.addHandler(handler)
+        root.setLevel(saved_level)
+
+
+def _make_record(
+    msg: str = "hello world",
+    level: int = logging.INFO,
+    extra: dict | None = None,
+) -> logging.LogRecord:
+    logger = logging.getLogger("app.test.structured")
+    return logger.makeRecord(
+        logger.name, level, __file__, 42, msg, (), None, extra=extra
+    )
+
+
+# ---------------------------------------------------------------------------
+# (1) Formatter renders a log record as valid JSON with the expected keys.
+# ---------------------------------------------------------------------------
+
+
+def test_formatter_renders_valid_json_with_expected_keys():
+    from app.observability.logging_setup import JsonLogFormatter
+
+    line = JsonLogFormatter().format(_make_record())
+    payload = json.loads(line)
+    assert payload["message"] == "hello world"
+    assert payload["level"] == "INFO"
+    assert payload["logger"] == "app.test.structured"
+    assert payload["status"] == "ok"
+    assert "timestamp" in payload
+
+
+def test_formatter_marks_error_records_with_span_schema_status():
+    from app.observability.logging_setup import JsonLogFormatter
+
+    line = JsonLogFormatter().format(_make_record("boom", logging.ERROR))
+    assert json.loads(line)["status"] == "error"
+
+
+def test_formatter_surfaces_extra_fields_under_extra_key():
+    from app.observability.logging_setup import JsonLogFormatter
+
+    line = JsonLogFormatter().format(
+        _make_record(extra={"note_path": "inbox/a.md", "attempts": 3})
+    )
+    payload = json.loads(line)
+    assert payload["extra"] == {"note_path": "inbox/a.md", "attempts": 3}
+
+
+def test_formatter_renders_exception_info():
+    from app.observability.logging_setup import JsonLogFormatter
+
+    try:
+        raise ValueError("kaput")
+    except ValueError:
+        import sys
+
+        record = _make_record("failed", logging.ERROR)
+        record.exc_info = sys.exc_info()
+    payload = json.loads(JsonLogFormatter().format(record))
+    assert "ValueError: kaput" in payload["exc"]
+    assert payload["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# (2) trace_id contextvar (app.observability.tracer) threads into log lines.
+# ---------------------------------------------------------------------------
+
+
+def test_trace_id_present_when_context_set():
+    from app.observability.logging_setup import JsonLogFormatter
+    from app.observability.tracer import start_span
+
+    with start_span("test.span", trace_id="trace-ctx-1"):
+        line = JsonLogFormatter().format(_make_record())
+    assert json.loads(line)["trace_id"] == "trace-ctx-1"
+
+
+def test_trace_id_absent_outside_context():
+    from app.observability.logging_setup import JsonLogFormatter
+
+    payload = json.loads(JsonLogFormatter().format(_make_record()))
+    assert "trace_id" not in payload
+
+
+def test_configured_logger_emits_json_line_with_trace_id(clean_root_logger):
+    from app.observability.logging_setup import configure_json_logging
+    from app.observability.tracer import start_span
+
+    stream = io.StringIO()
+    configure_json_logging(stream=stream)
+    logger = logging.getLogger("app.test.structured.e2e")
+    with start_span("test.span", trace_id="trace-e2e-1"):
+        logger.info("worker starting interval=%s", 0.2)
+    line = stream.getvalue().strip().splitlines()[-1]
+    payload = json.loads(line)
+    assert payload["message"] == "worker starting interval=0.2"
+    assert payload["trace_id"] == "trace-e2e-1"
+    assert payload["status"] == "ok"
+
+
+def test_configure_json_logging_is_idempotent(clean_root_logger):
+    from app.observability.logging_setup import (
+        JsonLogFormatter,
+        configure_json_logging,
+    )
+
+    configure_json_logging(stream=io.StringIO())
+    configure_json_logging(stream=io.StringIO())
+    json_handlers = [
+        h
+        for h in logging.getLogger().handlers
+        if isinstance(h.formatter, JsonLogFormatter)
+    ]
+    assert len(json_handlers) == 1
+
+
+# ---------------------------------------------------------------------------
+# Process entrypoint wiring: API, worker, watcher.
+# ---------------------------------------------------------------------------
+
+
+def _root_has_json_handler() -> bool:
+    from app.observability.logging_setup import JsonLogFormatter
+
+    return any(
+        isinstance(h.formatter, JsonLogFormatter)
+        for h in logging.getLogger().handlers
+    )
+
+
+def test_api_app_factory_wires_json_formatter(clean_root_logger):
+    from app.api.app import _create_app
+
+    _create_app()
+    assert _root_has_json_handler()
+
+
+def test_api_request_log_lines_carry_request_trace_id(clean_root_logger):
+    from fastapi.testclient import TestClient
+
+    from app.api.app import _create_app
+    from app.observability.logging_setup import configure_json_logging
+
+    app = _create_app()
+    stream = io.StringIO()
+    # Idempotent re-call rebinds the handler installed by _create_app to a
+    # capturable stream without adding a second handler.
+    configure_json_logging(stream=stream)
+
+    @app.get("/__structured_logging_probe")
+    def _probe():  # pragma: no cover - exercised via TestClient below
+        logging.getLogger("app.test.api.probe").info("inside request")
+        return {"ok": True}
+
+    client = TestClient(app)
+    response = client.get(
+        "/__structured_logging_probe", headers={"x-trace-id": "req-trace-1"}
+    )
+    assert response.status_code == 200
+    lines = [json.loads(l) for l in stream.getvalue().strip().splitlines() if l]
+    probe_lines = [p for p in lines if p.get("logger") == "app.test.api.probe"]
+    assert probe_lines, f"no probe log line captured; got: {lines}"
+    assert probe_lines[-1]["trace_id"] == "req-trace-1"
+
+
+def test_worker_entrypoint_configures_json_logging(clean_root_logger, capsys):
+    from app.workers import outbox_worker
+
+    outbox_worker._ensure_logging_configured()
+    assert _root_has_json_handler()
+
+    outbox_worker.logger.info("worker starting")
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out.strip().splitlines()[-1])
+    assert payload["logger"] == "app.workers.outbox_worker"
+    assert payload["message"] == "worker starting"
+
+
+def test_watcher_entrypoint_configures_json_logging(clean_root_logger, monkeypatch):
+    from click.testing import CliRunner
+
+    import app.cli.watcher as watcher_cli
+
+    monkeypatch.delenv("WATCHER_ENABLE", raising=False)
+    monkeypatch.setattr(watcher_cli, "_validate_settings_or_exit", lambda: None)
+
+    def _stop(*args, **kwargs):
+        raise RuntimeError("stop before watcher loop")
+
+    monkeypatch.setattr(watcher_cli, "load_registry_config", _stop)
+
+    result = CliRunner().invoke(watcher_cli.watcher_group, ["run"])
+    assert result.exit_code != 0  # stopped deliberately after logging setup
+    assert _root_has_json_handler()


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Governing-Issue: #3895

Fixes #3895

## Summary
- New module `app/observability/logging_setup.py`: `JsonLogFormatter` + idempotent `configure_json_logging()` installed on the root logger (stdout, one JSON object per line), keeping the stdlib `logging.getLogger` call-site API untouched.
- Wired into all three runtime processes: API (`setup_logging()` in `_create_app`), worker (`_ensure_logging_configured` in `run()`), and watcher.
- `trace_id` propagates into every log line when present in context, reusing the existing trace-contextvar mechanism; field names follow the span-schema conventions of `app/observability/log.py` per docs/OBSERVABILITY.md.
- Anchor drift noted: the issue references `app/obs/log.py`; the actual module is `app/observability/log.py` — its span schema is preserved and its tests stay green.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [ ] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Validation
Implementation lane:
- [x] `ruff check` clean on changed files
- [x] TDD: new test file red first (ModuleNotFoundError) → `tests/observability/test_structured_logging.py` 12 passed
- [x] tests/observability/ + trace-header + reviewer tests: 55 passed; tests/workers/: 43 passed; CLI watcher + knowledge-acquisition suites green
- [x] Pre-existing unrelated failure noted: `tests/api/test_companion_vault_settings.py` collection error (companion_ui not on sys.path) — exists on main, excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: dev-flow CI/build/observability change; no BuilderOps records, projections, or receipts were created or consumed by this work.

## Notes
- Delivered as part of the builder-ops-stability issue set (docs/specs/builder-ops-stability/, PR #3898). Residual risks and follow-ups are stated inline above.

