### PR TITLE
task: expand Prometheus scrape targets and add basic alerts (#3897)

### DIFF
--- a/app/workers/metrics.py
+++ b/app/workers/metrics.py
@@ -1,0 +1,57 @@
+"""Minimal opt-in Prometheus metrics endpoint for the outbox worker.
+
+Off by default: the /metrics HTTP server only starts when WORKER_METRICS_PORT
+is set to a positive integer port (builder-ops-stability spec Issue 6). The
+metric objects themselves are always defined so call sites stay unconditional;
+they are only observable once the server is enabled.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Mapping
+from wsgiref.simple_server import WSGIServer
+
+from prometheus_client import Counter, Gauge, start_http_server
+
+logger = logging.getLogger(__name__)
+
+WORKER_METRICS_PORT_ENV = "WORKER_METRICS_PORT"
+
+WORKER_LAST_TICK_TIMESTAMP = Gauge(
+    "pkm_worker_last_tick_timestamp_seconds",
+    "Unix timestamp of the outbox worker's most recent poll tick.",
+)
+WORKER_PROCESSED = Counter(
+    "pkm_worker_processed_total",
+    "Outbox messages processed by the worker.",
+)
+
+
+def resolve_worker_metrics_port(environ: Mapping[str, str] | None = None) -> int | None:
+    """Return the configured metrics port, or None when metrics are off."""
+    raw = (environ if environ is not None else os.environ).get(WORKER_METRICS_PORT_ENV, "")
+    raw = raw.strip()
+    if not raw:
+        return None
+    try:
+        port = int(raw)
+    except ValueError:
+        logger.warning("Ignoring invalid %s=%r; worker metrics stay off", WORKER_METRICS_PORT_ENV, raw)
+        return None
+    if port <= 0:
+        return None
+    return port
+
+
+def maybe_start_worker_metrics_server(
+    environ: Mapping[str, str] | None = None,
+) -> WSGIServer | None:
+    """Start the prometheus_client /metrics server when configured; else no-op."""
+    port = resolve_worker_metrics_port(environ)
+    if port is None:
+        return None
+    server, _thread = start_http_server(port)
+    logger.info("worker metrics server listening on port %s (/metrics)", port)
+    return server

--- a/app/workers/outbox_worker.py
+++ b/app/workers/outbox_worker.py
@@ -39,6 +39,11 @@ from app.indexer.consumer import process_event as process_indexer_event
 from app.outbox.events import INDEX_EMBEDDING_REQUESTED
 from app.observability.tracer import start_span
 from app.runtime.worker_heartbeat import resolve_worker_heartbeat_path, write_worker_heartbeat
+from app.workers.metrics import (
+    WORKER_LAST_TICK_TIMESTAMP,
+    WORKER_PROCESSED,
+    maybe_start_worker_metrics_server,
+)
 from app.services.indexer import handle_ingest_object_created, purge_object_vectors
 from app.services.companion_note import CompanionNote, scan_attachments, write_companion
 from app.settings.runtime import get_settings_bundle
@@ -1562,6 +1567,10 @@ def run(
 ) -> None:
     _ensure_logging_configured()
 
+    # Opt-in Prometheus endpoint (builder-ops-stability Issue 6): no-op unless
+    # WORKER_METRICS_PORT is set to a positive port.
+    maybe_start_worker_metrics_server()
+
     for attempt in range(startup_retries):
         try:
             bootstrap()
@@ -1625,6 +1634,7 @@ def run(
     # (heartbeats, logging, sleep, and stop-after-ticks below still run).
     while True:
         ticks_total += 1
+        WORKER_LAST_TICK_TIMESTAMP.set(time.time())
         no_vault_idle = _resolve_optional_vault_root(None) is None
         if no_vault_idle:
             # No-vault idle guard (#2407): match run_once's runtime decision. With
@@ -1637,6 +1647,7 @@ def run(
             message = None if no_vault_idle else poll_outbox_one()
             if message:
                 processed_total += 1
+                WORKER_PROCESSED.inc()
                 topic = message.get("topic")
                 event_ts = time.time()
                 if topic:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -201,6 +201,9 @@ services:
       VAULT_INBOX_DIR_REL: ${VAULT_INBOX_DIR_REL:-}
       VAULT_DESK_DIR_REL: ${VAULT_DESK_DIR_REL:-}
       LLM_PROVIDER: ${LLM_PROVIDER}
+      # Opt-in worker /metrics endpoint (builder-ops-stability Issue 6):
+      # empty/unset keeps it off; see ops/observability/prometheus.yml.
+      WORKER_METRICS_PORT: ${WORKER_METRICS_PORT:-}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -129,7 +129,7 @@ docker compose -f ops/observability/docker-compose.yaml up
 
 Grafana should use Prometheus at `http://prometheus:9090` as a data source.
 
-Alerting: `ops/observability/alerts.yml` ships basic rules (scrape target down for 5m, API 5xx rate > 5% over 15m from the instrumentator's `http_requests_total`, worker poll loop stalled via `pkm_worker_last_tick_timestamp_seconds`). Alertmanager runs with a log/UI-only null receiver — no external notification channels.
+Alerting: `ops/observability/alerts.yml` ships basic rules (always-on scrape target down for 5m, API 5xx rate > 5% over 15m from the instrumentator's `http_requests_total`, worker poll loop stalled via `pkm_worker_last_tick_timestamp_seconds`). The opt-in worker target is deliberately excluded from the generic down rule — it would otherwise fire a permanent false critical while `WORKER_METRICS_PORT` is unset (the default) — and is instead covered by `WorkerMetricsDown`, which only fires once the worker `/metrics` endpoint has been seen up within the last hour and then become unreachable. Alertmanager runs with a log/UI-only null receiver — no external notification channels.
 
 When finished:
 

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -109,16 +109,27 @@ export METRICS_ENABLED=1
 uvicorn app.main:app --reload --port 18000
 ```
 
-Start Prometheus + Grafana:
+Optional worker metrics: the outbox worker exposes a Prometheus `/metrics` endpoint (via `prometheus_client`) only when `WORKER_METRICS_PORT` is set to a positive port; it stays off by default. The Prometheus scrape config expects port `9101`:
+
+```bash
+WORKER_METRICS_PORT=9101 python -m app.workers.outbox_worker
+```
+
+The main compose file passes `WORKER_METRICS_PORT` through to the `worker` service (default empty = off); scraping a containerized worker additionally requires publishing that port from the container, so the host-run worker above is the simple path.
+
+Start Prometheus + Alertmanager + Grafana:
 
 ```bash
 docker compose -f ops/observability/docker-compose.yaml up
 ```
 
 - Prometheus UI: `http://localhost:9090`
+- Alertmanager UI: `http://localhost:9093`
 - Grafana UI: `http://localhost:3000`
 
 Grafana should use Prometheus at `http://prometheus:9090` as a data source.
+
+Alerting: `ops/observability/alerts.yml` ships basic rules (scrape target down for 5m, API 5xx rate > 5% over 15m from the instrumentator's `http_requests_total`, worker poll loop stalled via `pkm_worker_last_tick_timestamp_seconds`). Alertmanager runs with a log/UI-only null receiver — no external notification channels.
 
 When finished:
 

--- a/ops/observability/alertmanager.yml
+++ b/ops/observability/alertmanager.yml
@@ -1,0 +1,13 @@
+---
+# Minimal local Alertmanager config (builder-ops-stability spec Issue 6):
+# alerts are visible in the Alertmanager UI (http://localhost:9093) and in
+# `docker logs alertmanager`; no external notification channels on purpose.
+route:
+  receiver: "null"
+  group_by: ["alertname", "job"]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+
+receivers:
+  - name: "null"

--- a/ops/observability/alerts.yml
+++ b/ops/observability/alerts.yml
@@ -10,8 +10,14 @@
 groups:
   - name: pkm-availability
     rules:
+      # The worker scrape target is listed unconditionally in prometheus.yml
+      # while its /metrics endpoint is opt-in (WORKER_METRICS_PORT, default
+      # off), and Prometheus records up == 0 for an unreachable target from
+      # the very first scrape. A bare `up == 0` rule would therefore fire a
+      # permanent false critical for job="worker" in the default setup, so
+      # ServiceDown excludes the worker and WorkerMetricsDown below covers it.
       - alert: ServiceDown
-        expr: up == 0
+        expr: up{job!="worker"} == 0
         for: 5m
         labels:
           severity: critical
@@ -19,9 +25,25 @@ groups:
           summary: "Scrape target {{ $labels.job }} is down"
           description: >-
             Prometheus has failed to scrape {{ $labels.job }}
-            ({{ $labels.instance }}) for 5 minutes. Note: the worker target is
-            opt-in (WORKER_METRICS_PORT), so this fires for the worker only
-            once it has been enabled and then disappears.
+            ({{ $labels.instance }}) for 5 minutes.
+
+      - alert: WorkerMetricsDown
+        expr: >-
+          up{job="worker"} == 0
+          and max_over_time(up{job="worker"}[1h]) == 1
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Outbox worker metrics endpoint is down"
+          description: >-
+            The opt-in outbox worker /metrics endpoint
+            ({{ $labels.instance }}) was up within the last hour but has now
+            been unreachable for 5 minutes. This rule never fires while the
+            endpoint has simply not been enabled (WORKER_METRICS_PORT unset,
+            the default), and it auto-resolves about an hour after the
+            endpoint was last seen up, so deliberately stopping the worker
+            clears it on its own.
 
       - alert: ApiHigh5xxErrorRate
         expr: >-

--- a/ops/observability/alerts.yml
+++ b/ops/observability/alerts.yml
@@ -1,0 +1,53 @@
+---
+# Basic alert rules for the local observability stack
+# (builder-ops-stability spec Issue 6). Every rule is based on a signal that
+# actually exists today:
+# - `up` from Prometheus itself for each scrape job,
+# - `http_requests_total{status=...}` from prometheus-fastapi-instrumentator
+#   (status codes grouped, e.g. "5xx"),
+# - `pkm_worker_last_tick_timestamp_seconds` from app/workers/metrics.py
+#   (only present when the worker runs with WORKER_METRICS_PORT set).
+groups:
+  - name: pkm-availability
+    rules:
+      - alert: ServiceDown
+        expr: up == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Scrape target {{ $labels.job }} is down"
+          description: >-
+            Prometheus has failed to scrape {{ $labels.job }}
+            ({{ $labels.instance }}) for 5 minutes. Note: the worker target is
+            opt-in (WORKER_METRICS_PORT), so this fires for the worker only
+            once it has been enabled and then disappears.
+
+      - alert: ApiHigh5xxErrorRate
+        expr: >-
+          (
+            sum(rate(http_requests_total{job="fastapi", status="5xx"}[15m]))
+            /
+            sum(rate(http_requests_total{job="fastapi"}[15m]))
+          ) > 0.05
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "API 5xx error rate above 5%"
+          description: >-
+            More than 5% of FastAPI requests returned 5xx over the last 15
+            minutes (prometheus-fastapi-instrumentator http_requests_total).
+
+      - alert: WorkerTickStalled
+        expr: >-
+          (time() - pkm_worker_last_tick_timestamp_seconds{job="worker"}) > 120
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Outbox worker poll loop stalled"
+          description: >-
+            The outbox worker /metrics endpoint is still up but its poll loop
+            has not ticked for more than 2 minutes; the worker is likely
+            wedged (heartbeats normally advance every tick).

--- a/ops/observability/docker-compose.yaml
+++ b/ops/observability/docker-compose.yaml
@@ -7,10 +7,23 @@ services:
     container_name: prometheus
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./alerts.yml:/etc/prometheus/alerts.yml:ro
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
     ports:
       - "9090:9090"
+    depends_on:
+      - alertmanager
+
+  alertmanager:
+    image: prom/alertmanager:v0.27.0
+    container_name: alertmanager
+    volumes:
+      - ./alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+    command:
+      - "--config.file=/etc/alertmanager/alertmanager.yml"
+    ports:
+      - "9093:9093"
 
   grafana:
     image: grafana/grafana-oss:11.3.0

--- a/ops/observability/prometheus.yml
+++ b/ops/observability/prometheus.yml
@@ -2,8 +2,27 @@
 global:
   scrape_interval: 15s
 
+rule_files:
+  - "alerts.yml"
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
+
 scrape_configs:
+  # FastAPI app on the host (uvicorn with METRICS_ENABLED=1), exposed via
+  # prometheus-fastapi-instrumentator at /metrics.
   - job_name: "fastapi"
     metrics_path: "/metrics"
     static_configs:
       - targets: ["host.docker.internal:18000"]
+
+  # Outbox worker /metrics (opt-in, builder-ops-stability Issue 6): only
+  # serves when the worker runs with WORKER_METRICS_PORT=9101 (default off).
+  # Run the worker on the host, or publish the port from the worker
+  # container, for this target to be reachable.
+  - job_name: "worker"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: ["host.docker.internal:9101"]

--- a/ops/observability/prometheus.yml
+++ b/ops/observability/prometheus.yml
@@ -21,7 +21,9 @@ scrape_configs:
   # Outbox worker /metrics (opt-in, builder-ops-stability Issue 6): only
   # serves when the worker runs with WORKER_METRICS_PORT=9101 (default off).
   # Run the worker on the host, or publish the port from the worker
-  # container, for this target to be reachable.
+  # container, for this target to be reachable. While the endpoint is
+  # disabled, up{job="worker"} is 0 on every scrape; alerts.yml therefore
+  # excludes this job from ServiceDown and covers it with WorkerMetricsDown.
   - job_name: "worker"
     metrics_path: "/metrics"
     static_configs:

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -367,6 +367,9 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
         "outbox_worker",
         (
             "app/workers/outbox_worker.py",
+            # Opt-in /metrics endpoint for the outbox worker; its coverage
+            # lives in tests/workers/test_worker_metrics.py.
+            "app/workers/metrics.py",
             "tests/workers/",
             "tests/worker/",
             "tests/services/test_outbox_idempotency.py",

--- a/tests/ops/test_observability_alerts.py
+++ b/tests/ops/test_observability_alerts.py
@@ -1,0 +1,67 @@
+"""Contract tests for ops/observability/alerts.yml availability rules.
+
+The Prometheus scrape config lists the worker /metrics target unconditionally
+(``host.docker.internal:9101`` in ops/observability/prometheus.yml) while the
+endpoint itself is opt-in (``WORKER_METRICS_PORT``, default off). Prometheus
+records ``up{job="worker"} == 0`` from the very first scrape of an
+unreachable target — there is no "never enabled" state — so an availability
+rule written as a bare ``up == 0`` fires a permanent false critical alert in
+the documented default setup (``docker compose -f
+ops/observability/docker-compose.yaml up`` with ``WORKER_METRICS_PORT``
+unset). These tests pin the contract that prevents that regression.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OBSERVABILITY_DIR = REPO_ROOT / "ops" / "observability"
+
+
+def _load_alert_rules() -> dict[str, dict]:
+    doc = yaml.safe_load((OBSERVABILITY_DIR / "alerts.yml").read_text(encoding="utf-8"))
+    return {rule["alert"]: rule for group in doc["groups"] for rule in group["rules"]}
+
+
+def _normalized(expr: str) -> str:
+    """PromQL with all whitespace stripped, for layout-insensitive matching."""
+    return "".join(expr.split())
+
+
+def test_worker_scrape_target_is_unconditional() -> None:
+    """Premise guard: prometheus.yml scrapes job="worker" unconditionally.
+
+    The exclusion contract in the tests below only matters while the worker
+    target is always configured; if the scrape job is ever removed or made
+    conditional, revisit those tests together with this one.
+    """
+    prom = yaml.safe_load((OBSERVABILITY_DIR / "prometheus.yml").read_text(encoding="utf-8"))
+    jobs = {cfg["job_name"] for cfg in prom["scrape_configs"]}
+    assert "worker" in jobs
+
+
+def test_service_down_excludes_the_opt_in_worker_target() -> None:
+    """ServiceDown must not match the default-off worker target.
+
+    A bare ``up == 0`` matches ``up{job="worker"} == 0``, which holds forever
+    when the opt-in worker /metrics endpoint is disabled (the default), so the
+    critical rule would fire perpetually out of the box.
+    """
+    expr = _normalized(_load_alert_rules()["ServiceDown"]["expr"])
+    assert 'up{job!="worker"}==0' in expr
+
+
+def test_worker_down_rule_only_fires_after_the_endpoint_has_been_up() -> None:
+    """The worker gets its own availability rule gated on prior success.
+
+    ``max_over_time(up{job="worker"}[...]) == 1`` is unsatisfiable in the
+    never-enabled default state (up is 0 on every sample), so the rule can
+    only fire once the endpoint has actually been seen up and then vanished.
+    """
+    expr = _normalized(_load_alert_rules()["WorkerMetricsDown"]["expr"])
+    assert 'up{job="worker"}==0' in expr
+    assert 'max_over_time(up{job="worker"}[' in expr
+    assert "])==1" in expr

--- a/tests/scripts/test_select_pr_tests.py
+++ b/tests/scripts/test_select_pr_tests.py
@@ -297,6 +297,21 @@ def test_outbox_worker_change_selects_worker_regressions() -> None:
     assert "tests/workers/test_outbox_worker.py" in selection.targets
 
 
+def test_worker_metrics_module_change_has_a_ci_owner() -> None:
+    """The worker /metrics endpoint module is outbox_worker surface: its
+    coverage lives in tests/workers/test_worker_metrics.py, so a change must
+    route to the worker regressions rather than fail-close as unowned."""
+    selection = select_tests(
+        ["app/workers/metrics.py", "tests/workers/test_worker_metrics.py"]
+    )
+
+    assert selection.full_suite is False
+    assert selection.subsystems == ("outbox_worker",)
+    assert selection.unowned_paths == ()
+    assert "tests/workers" in selection.targets
+    assert "tests/workers/test_worker_metrics.py" in selection.targets
+
+
 def test_heimdal_capture_adapter_change_has_a_ci_owner() -> None:
     selection = select_tests(["app/heimdal/capture_adapter.py", "tests/heimdal/test_capture_adapter.py"])
 

--- a/tests/workers/test_worker_metrics.py
+++ b/tests/workers/test_worker_metrics.py
@@ -1,0 +1,58 @@
+"""Opt-in Prometheus metrics endpoint for the outbox worker (builder-ops-stability Issue 6).
+
+Contract: the worker exposes /metrics via prometheus_client only when
+WORKER_METRICS_PORT is set to a positive integer port; it stays off by default.
+"""
+
+from __future__ import annotations
+
+import socket
+import urllib.request
+
+import pytest
+
+from app.workers.metrics import (
+    WORKER_METRICS_PORT_ENV,
+    maybe_start_worker_metrics_server,
+    resolve_worker_metrics_port,
+)
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def test_metrics_server_off_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(WORKER_METRICS_PORT_ENV, raising=False)
+    assert resolve_worker_metrics_port() is None
+    assert maybe_start_worker_metrics_server() is None
+
+
+@pytest.mark.parametrize("raw", ["", "   ", "0", "-1", "not-a-port"])
+def test_metrics_port_invalid_values_stay_off(
+    monkeypatch: pytest.MonkeyPatch, raw: str
+) -> None:
+    monkeypatch.setenv(WORKER_METRICS_PORT_ENV, raw)
+    assert resolve_worker_metrics_port() is None
+    assert maybe_start_worker_metrics_server() is None
+
+
+def test_metrics_server_starts_and_serves_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    port = _free_port()
+    monkeypatch.setenv(WORKER_METRICS_PORT_ENV, str(port))
+    server = maybe_start_worker_metrics_server()
+    assert server is not None
+    try:
+        with urllib.request.urlopen(
+            f"http://127.0.0.1:{port}/metrics", timeout=5
+        ) as response:
+            assert response.status == 200
+            body = response.read()
+    finally:
+        server.shutdown()
+    assert b"pkm_worker_last_tick_timestamp_seconds" in body
+    assert b"pkm_worker_processed_total" in body


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Governing-Issue: #3897

Fixes #3897

## Summary
- Adds an opt-in Prometheus `/metrics` endpoint to the outbox worker (`app/workers/metrics.py`, gated on `WORKER_METRICS_PORT`, default **off**) with tick/processed metrics wired into the worker loop.
- Extends `ops/observability/prometheus.yml` to scrape API + worker, wires `rule_files` and alertmanager targeting.
- New `ops/observability/alerts.yml` with 3 rules grounded in metrics that actually exist: `ServiceDown` (up == 0 for 5m), `ApiHigh5xxErrorRate` (instrumentator http metrics), `WorkerTickStalled` (new worker tick metric).
- Alertmanager v0.27.0 service added to the observability compose (null receiver, no external channels). Stack remains optional/separate from the main compose; only a default-off env passthrough touched the main compose.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [ ] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Validation
Implementation lane:
- [x] `ruff check` clean on app/workers/metrics.py, app/workers/outbox_worker.py, tests
- [x] TDD: AC greps + new pytest red first → `tests/workers/test_worker_metrics.py` 7 passed; full tests/workers (not pg) 50 passed
- [x] All YAML validates; prometheus rule_files ↔ alerts.yml ↔ alertmanager wiring verified internally consistent
- [ ] Runtime `docker compose up` of the observability stack: blocked in build env (no daemon) — config-validated only

Scraping a containerized worker additionally requires publishing the metrics port from the worker container; per the default-off constraint only the env passthrough was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: dev-flow CI/build/observability change; no BuilderOps records, projections, or receipts were created or consumed by this work.

## Notes
- Delivered as part of the builder-ops-stability issue set (docs/specs/builder-ops-stability/, PR #3898). Residual risks and follow-ups are stated inline above.

