### PR TITLE
bug: align Python version between Dockerfile and CI (#3893)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,14 @@
 # registry-1.docker.io/v2/library/python/manifests/<tag> (Accept: oci.image.index.v1+json).
 FROM python:3.12-slim@sha256:c3d81d25b3154142b0b42eb1e61300024426268edeb5b5a26dd7ddf64d9daf28
 
+# TTS layer toggle — see the guarded RUN below. Declared after FROM so it is
+# in scope for this stage. Default 0: the TTS pins cannot install on this
+# python:3.12 base (see the KNOWN BREAKAGE note at the guarded RUN), so
+# attempting them by default made every default build fail — `docker build .`,
+# the compose builds and app-image-build.yml pass no INSTALL_TTS arg. The
+# layer is opt-in (--build-arg INSTALL_TTS=1) until the pins gain 3.12 support.
+ARG INSTALL_TTS=0
+
 # Build-time arguments for version observability.
 # Pass via: docker build --build-arg VCS_REF=$(git rev-parse HEAD) \
 #                        --build-arg BUILT_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ) .
@@ -30,8 +38,27 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt requirements-tts.txt ./
-RUN pip install --no-cache-dir -r requirements.txt \
-  && pip install --no-cache-dir -r requirements-tts.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# KNOWN BREAKAGE (#3893, PR #3910): requirements-tts.txt pins piper-tts==1.2.0
+# -> piper-phonemize~=1.1.0, and piper-phonemize 1.1.0 publishes NO cp312
+# linux wheels and no sdist (PyPI has cp39–cp311 manylinux x86_64/aarch64
+# wheels only; the sole cp312 wheel is macOS x86_64). On this python:3.12
+# base the TTS layer therefore CANNOT install on linux; it worked on the
+# pre-#3893 python:3.11 base (cp311 manylinux wheels exist). The #3893 CI
+# alignment (python 3.12) and a buildable default TTS image are mutually
+# exclusive until the TTS pins gain 3.12 support, and the app-image-build.yml
+# "Build SHA-tagged app image" job requires the default `docker build .` to
+# produce a working image — so the layer is OPT-IN (ARG INSTALL_TTS=0 above).
+# The default image ships WITHOUT piper/kokoro baked in: app/tts/providers.py
+# degrades (those voices report unavailable rather than crashing) and the
+# skip is loud in the build log.
+# Once the pins support 3.12, bake TTS with: docker build --build-arg INSTALL_TTS=1 .
+RUN if [ "$INSTALL_TTS" = "1" ]; then \
+      pip install --no-cache-dir -r requirements-tts.txt; \
+    else \
+      echo "INSTALL_TTS=$INSTALL_TTS: SKIPPING requirements-tts.txt — piper/kokoro NOT baked into this image"; \
+    fi
 
 COPY . .
 RUN chmod +x scripts/start_api.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM python:3.11-slim
+# Python minor version must match CI (ci-smoke.yaml python-version). The digest
+# pins the multi-arch index for reproducibility; to refresh it after a base bump:
+# token from auth.docker.io (scope repository:library/python:pull), then HEAD
+# registry-1.docker.io/v2/library/python/manifests/<tag> (Accept: oci.image.index.v1+json).
+FROM python:3.12-slim@sha256:c3d81d25b3154142b0b42eb1e61300024426268edeb5b5a26dd7ddf64d9daf28
 
 # Build-time arguments for version observability.
 # Pass via: docker build --build-arg VCS_REF=$(git rev-parse HEAD) \

--- a/tests/deploy/test_dockerfile_python_alignment.py
+++ b/tests/deploy/test_dockerfile_python_alignment.py
@@ -1,0 +1,43 @@
+"""Guard Dockerfile base-image alignment with CI (#3893).
+
+Production must run the same Python minor version CI tests against, and the
+base image must be digest-pinned for reproducible builds.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+DOCKERFILE_PATH = Path("Dockerfile")
+CI_SMOKE_PATH = Path(".github/workflows/ci-smoke.yaml")
+
+
+def _dockerfile_from_line() -> str:
+    for line in DOCKERFILE_PATH.read_text(encoding="utf-8").splitlines():
+        if line.startswith("FROM "):
+            return line.strip()
+    raise AssertionError("Dockerfile has no FROM line")
+
+
+def test_dockerfile_base_image_is_digest_pinned() -> None:
+    from_line = _dockerfile_from_line()
+    assert re.fullmatch(
+        r"FROM python:3\.\d+-slim@sha256:[0-9a-f]{64}", from_line
+    ), f"FROM line must be python:3.x-slim pinned by sha256 digest, got: {from_line}"
+
+
+def test_dockerfile_python_minor_matches_ci_smoke() -> None:
+    from_line = _dockerfile_from_line()
+    match = re.search(r"python:(3\.\d+)-slim", from_line)
+    assert match, f"cannot parse python minor version from: {from_line}"
+    docker_minor = match.group(1)
+
+    ci_versions = re.findall(
+        r"python-version:\s*['\"]?(3\.\d+)",
+        CI_SMOKE_PATH.read_text(encoding="utf-8"),
+    )
+    assert ci_versions, "ci-smoke.yaml declares no python-version"
+    assert set(ci_versions) == {docker_minor}, (
+        f"Dockerfile python {docker_minor} != ci-smoke python-version {sorted(set(ci_versions))}"
+    )

--- a/tests/deploy/test_dockerfile_python_alignment.py
+++ b/tests/deploy/test_dockerfile_python_alignment.py
@@ -41,3 +41,28 @@ def test_dockerfile_python_minor_matches_ci_smoke() -> None:
     assert set(ci_versions) == {docker_minor}, (
         f"Dockerfile python {docker_minor} != ci-smoke python-version {sorted(set(ci_versions))}"
     )
+
+
+def test_tts_layer_is_opt_in_so_default_build_succeeds() -> None:
+    """requirements-tts.txt pins piper-tts==1.2.0 -> piper-phonemize~=1.1.0,
+    which publishes no cp312 linux wheels and no sdist, so installing it on
+    the python:3.12 base fails EVERY default build (`docker build .`,
+    compose build, app-image-build.yml — none pass INSTALL_TTS). The
+    app-image-build.yml "Build SHA-tagged app image" job requires the default
+    build to produce a working image, so the TTS layer must be opt-in
+    (default 0) until the pins gain 3.12 support; the guarded RUN keeps the
+    skip loud in the build log."""
+    text = DOCKERFILE_PATH.read_text(encoding="utf-8")
+    assert re.search(r"^ARG INSTALL_TTS=0\s*$", text, flags=re.MULTILINE), (
+        "INSTALL_TTS must default to 0: the TTS pins cannot install on the "
+        "python:3.12 base, so a default of 1 makes every default build fail "
+        "(app-image-build.yml passes no INSTALL_TTS build-arg)"
+    )
+    assert 'if [ "$INSTALL_TTS" = "1" ]' in text, (
+        "the TTS install must stay behind the INSTALL_TTS guard so it can be "
+        "re-enabled with --build-arg INSTALL_TTS=1 once the pins support 3.12"
+    )
+    assert "SKIPPING requirements-tts.txt" in text, (
+        "the skip must be loud in the build log so a missing TTS layer is "
+        "diagnosable from CI output alone"
+    )


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Governing-Issue: #3893

Fixes #3893

## Summary
- Pins the Dockerfile base image from `python:3.11-slim` to `python:3.12-slim@sha256:c3d81d25…` — the same minor version CI tests (ci-smoke.yaml `python-version: 3.12`). The digest is a genuine multi-arch OCI index (linux/amd64 + linux/arm64), verified against the Docker Hub registry API.
- Adds `tests/deploy/test_dockerfile_python_alignment.py` (TDD: red against the old Dockerfile) locking CI↔Dockerfile version parity and the digest pin.
- **Important discovery:** `requirements-tts.txt` → piper-tts==1.2.0 → piper-phonemize~=1.1.0 publishes **no cp312 linux wheels and no sdist** — the hidden coupling that likely kept the Dockerfile on 3.11. On this commit alone the default image build therefore fails at the TTS layer; the stacked hardening PR resolves it by making the TTS layer opt-in. See that PR for the product decision.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed (Dockerfile aligned to CI, not the reverse; 3.13 canary untouched).
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [ ] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Validation
Implementation lane:
- [x] `ruff check` clean on changed files
- [x] TDD red→green; `tests/deploy/` 54 passed at this commit (62 on the stacked tip)
- [x] Digest verified via registry API (docker-content-digest match, OCI index, both platforms)

Stacked PR with the multi-stage hardening (and the TTS resolution) targets this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: dev-flow CI/build/observability change; no BuilderOps records, projections, or receipts were created or consumed by this work.

## Notes
- Delivered as part of the builder-ops-stability issue set (docs/specs/builder-ops-stability/, PR #3898). Residual risks and follow-ups are stated inline above.

