### PR TITLE
refactor: harden Docker build — multi-stage, explicit runtime assets, HEALTHCHECK (#3896)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -47,9 +47,21 @@ golden
 tools
 claude-skills
 
-# scripts/ is dev tooling EXCEPT the two entrypoints docker-compose.yaml
-# executes inside containers (migrate -> run_migrations.sh, api/CMD ->
-# start_api.sh); re-include only those so the runtime COPY can see them.
+# scripts/ is dev tooling EXCEPT:
+# - the two entrypoints docker-compose.yaml executes inside containers
+#   (migrate -> run_migrations.sh, api/CMD -> start_api.sh), and
+# - the scripts.<module> Python modules app/** imports at RUNTIME
+#   (from scripts.yaml_roundtrip import ... at module top level in
+#   app/services/companion_note.py, app/chat/session_log.py,
+#   app/promotion/queue.py, ...; scripts.validate_* in app/builderops/),
+#   plus scripts/__init__.py so `scripts` resolves as a package — see
+#   tests/deploy/test_dockerfile_hardening.py, which derives this set from
+#   the source imports.
+# Re-include only those so the runtime COPY can see them.
 scripts
 !scripts/start_api.sh
 !scripts/run_migrations.sh
+!scripts/__init__.py
+!scripts/yaml_roundtrip.py
+!scripts/validate_issue_readiness.py
+!scripts/validate_source_anchors.py

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,15 @@
+# VCS / local env
 .git
 .venv
+# Root-level patterns only cover the repo root in .dockerignore matching; the
+# **/ variants keep NESTED host bytecode (app/__pycache__, ...) out of the
+# runtime-stage COPYs too.
 __pycache__
 *.pyc
+**/__pycache__
+**/*.pyc
 
+# Logs and scratch
 logs
 logs/**
 tmp
@@ -10,7 +17,39 @@ tmp/**
 *.log
 *.jsonl
 
+# Local data / backups
 data
 data/**
 backups
 backups/**
+
+# Dev-only surfaces (builder-ops-stability spec Issue 7): never part of the
+# runtime image (the Dockerfile runtime stage copies an explicit asset list),
+# and excluded here so they cannot leak back in and do not bloat the context.
+tests
+docs
+# docs/ is dev-only EXCEPT docs/settings/**: those files are read at RUNTIME
+# relative to /app — the model/tool/agent/graph/event/prompt registries
+# (app/components/settings/*_loader.py defaults, consumed by the LLM router
+# and MCP tool provider), the flow/agent fallbacks (app/settings/flows.py,
+# app/settings/agents.py, app/config/paths.py), and panel-action wiring
+# (app/agents/panel_agent/wiring.py). Re-include so the runtime COPY sees it.
+!docs/settings
+ops
+*.md
+.github
+.codex
+.claude
+.vscode
+.pytest_cache
+.ruff_cache
+golden
+tools
+claude-skills
+
+# scripts/ is dev tooling EXCEPT the two entrypoints docker-compose.yaml
+# executes inside containers (migrate -> run_migrations.sh, api/CMD ->
+# start_api.sh); re-include only those so the runtime COPY can see them.
+scripts
+!scripts/start_api.sh
+!scripts/run_migrations.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,51 @@
+# Multi-stage build (builder-ops-stability spec Issue 7): the builder stage
+# installs the runtime requirement manifests; the runtime stage copies the
+# installed site-packages + console scripts and ONLY genuine runtime assets
+# (no tests/, .git/, ops/, and no docs/ except the runtime-read docs/settings/
+# subtree — see .dockerignore and tests/deploy/test_dockerfile_hardening.py).
+#
 # Python minor version must match CI (ci-smoke.yaml python-version). The digest
 # pins the multi-arch index for reproducibility; to refresh it after a base bump:
 # token from auth.docker.io (scope repository:library/python:pull), then HEAD
 # registry-1.docker.io/v2/library/python/manifests/<tag> (Accept: oci.image.index.v1+json).
-FROM python:3.12-slim@sha256:c3d81d25b3154142b0b42eb1e61300024426268edeb5b5a26dd7ddf64d9daf28
+# BOTH stages must reference the same pinned digest
+# (tests/deploy/test_dockerfile_python_alignment.py).
+FROM python:3.12-slim@sha256:c3d81d25b3154142b0b42eb1e61300024426268edeb5b5a26dd7ddf64d9daf28 AS builder
+
+# TTS layer toggle — see the guarded RUN below. Declared after FROM so it is
+# in scope for this stage; default 1 preserves the previous behavior (every
+# prior Dockerfile attempted the TTS install unconditionally).
+ARG INSTALL_TTS=1
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+# Install into /usr/local exactly as the former single-stage build did (same
+# resolution order: requirements.txt first, then requirements-tts.txt), then
+# hand the resulting site-packages + entry-point scripts to the runtime stage.
+COPY requirements.txt requirements-tts.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# KNOWN BREAKAGE, surfaced deliberately (#3896 review): requirements-tts.txt
+# pins piper-tts==1.2.0 -> piper-phonemize~=1.1.0, and piper-phonemize 1.1.0
+# publishes NO cp312 linux wheels and no sdist (PyPI has cp39–cp311 manylinux
+# x86_64/aarch64 wheels only; the sole cp312 wheel is macOS x86_64). On this
+# python:3.12 base the TTS layer therefore CANNOT install on linux — the
+# default build fails loudly here, exactly as the single-stage 3.12 Dockerfile
+# from #3893 already did. It worked on the pre-#3893 python:3.11 base (cp311
+# manylinux wheels exist). Kept attempted-by-default so an image never
+# silently ships without piper/kokoro; until the TTS pins gain 3.12 support
+# (or product policy drops the baked TTS layer), build a TTS-less image
+# explicitly with: docker build --build-arg INSTALL_TTS=0 .
+RUN if [ "$INSTALL_TTS" = "1" ]; then \
+      pip install --no-cache-dir -r requirements-tts.txt; \
+    else \
+      echo "INSTALL_TTS=$INSTALL_TTS: SKIPPING requirements-tts.txt — piper/kokoro NOT baked into this image"; \
+    fi
+
+
+FROM python:3.12-slim@sha256:c3d81d25b3154142b0b42eb1e61300024426268edeb5b5a26dd7ddf64d9daf28 AS runtime
 
 # Build-time arguments for version observability.
 # Pass via: docker build --build-arg VCS_REF=$(git rev-parse HEAD) \
@@ -25,16 +68,56 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
+# ffmpeg stays in the RUNTIME stage: the capture/transcription path shells out
+# to it (faster-whisper/yt-dlp media handling). espeak-ng backs the local TTS
+# engines (piper phonemization).
 RUN apt-get update \
   && apt-get install -y --no-install-recommends ffmpeg espeak-ng \
   && rm -rf /var/lib/apt/lists/*
 
-COPY requirements.txt requirements-tts.txt ./
-RUN pip install --no-cache-dir -r requirements.txt \
-  && pip install --no-cache-dir -r requirements-tts.txt
+# Installed third-party packages and their console scripts (uvicorn, alembic,
+# piper, ...) from the builder stage. Same base digest, so the interpreter
+# path baked into script shebangs (/usr/local/bin/python) is identical.
+COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=builder /usr/local/bin /usr/local/bin
 
-COPY . .
-RUN chmod +x scripts/start_api.sh
+# Runtime assets only — each COPY below maps to a genuine in-container
+# dependency of the services in docker-compose.yaml:
+# - app/                        the application package (includes app/alembic
+#                               migrations + app/alembic.ini used by
+#                               scripts/run_migrations.sh)
+# - mimer_runtime/              imported directly by app/** (cross_scope, dri, ...)
+# - schemas/                    JSON schemas resolved via REPO_ROOT at runtime
+#                               (app/episodes/schema.py, app/retrieval/envelope.py, ...)
+# - config/ + configs/          runtime defaults/settings files (config/agent.yaml,
+#                               config/runtime.defaults.env, configs/watchers.yaml)
+# - vault/                      default settings/flows templates read by
+#                               app/settings/** (vault/@Settings, vault/_system/**)
+# - docs/settings/              the ONE runtime-read docs/ subtree: settings
+#                               registries + fallbacks resolved relative to
+#                               /app (app/components/settings/*_loader.py
+#                               defaults — LLM router model registry, MCP tool
+#                               provider tool registry, settings compiler —
+#                               plus app/settings/flows.py + agents.py
+#                               fallbacks and app/agents/panel_agent/wiring.py).
+#                               .dockerignore re-includes it (!docs/settings).
+# - companion-ui/companion-app/ the companion_ui package the companion-ui
+#                               service serves (working_dir + PYTHONPATH)
+# - alembic.ini                 root alembic entry (script_location=app/alembic)
+# - sitecustomize.py            import-time classifier persistence hook
+# - scripts/                    ONLY the two entrypoints compose executes
+#                               in-container (migrate + api services)
+COPY app/ ./app/
+COPY mimer_runtime/ ./mimer_runtime/
+COPY schemas/ ./schemas/
+COPY config/ ./config/
+COPY configs/ ./configs/
+COPY vault/ ./vault/
+COPY docs/settings/ ./docs/settings/
+COPY companion-ui/companion-app/ ./companion-ui/companion-app/
+COPY alembic.ini sitecustomize.py ./
+COPY scripts/start_api.sh scripts/run_migrations.sh ./scripts/
+RUN chmod +x scripts/start_api.sh scripts/run_migrations.sh
 
 # Pre-create the runtime scratch dir with open perms so the container can create
 # it even when run under host-uid remapping (compose `user: ${LOCAL_UID}:${LOCAL_GID}`
@@ -48,7 +131,7 @@ RUN mkdir -p /app/tmp && chmod 1777 /app/tmp
 # relevance, builderops, dispatcher, orientation, panel, proposals — see
 # `git grep 'Path("runtime/'` for the current set) resolves it under `/app`
 # (the compose `working_dir`). `/app/runtime` does not exist in the repo (every
-# subdir is `.gitignore`d) so `COPY . .` above never bakes it; without this
+# subdir is `.gitignore`d) so the COPY steps above never bake it; without this
 # step the *first* write from a fresh container calls
 # `path.parent.mkdir(parents=True, exist_ok=True)` against the root-owned
 # `/app`, which is denied under the host-uid-remapped runtime user and fails
@@ -63,5 +146,13 @@ RUN mkdir -p /app/tmp && chmod 1777 /app/tmp
 RUN mkdir -p /app/runtime && chmod 1777 /app/runtime
 
 EXPOSE 8000
+
+# Probe the existing API readiness endpoint (app/api/routes/health_contract.py
+# :: /readyz). API_HEALTHCHECK_URL is the same override the compose api
+# healthcheck consumes (config/runtime.defaults.env sets it to
+# http://127.0.0.1:8000/readyz); the fallback keeps bare `docker run` covered.
+# Compose services define their own healthcheck: blocks, which override this.
+HEALTHCHECK --interval=30s --timeout=3s --start-period=15s --retries=3 \
+  CMD python -c "import os, urllib.request; urllib.request.urlopen(os.environ.get('API_HEALTHCHECK_URL') or 'http://127.0.0.1:8000/readyz', timeout=2)" || exit 1
 
 CMD ["/app/scripts/start_api.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,12 @@
 FROM python:3.12-slim@sha256:c3d81d25b3154142b0b42eb1e61300024426268edeb5b5a26dd7ddf64d9daf28 AS builder
 
 # TTS layer toggle — see the guarded RUN below. Declared after FROM so it is
-# in scope for this stage; default 1 preserves the previous behavior (every
-# prior Dockerfile attempted the TTS install unconditionally).
-ARG INSTALL_TTS=1
+# in scope for this stage. Default 0: the TTS pins cannot install on this
+# python:3.12 base (see the KNOWN BREAKAGE note at the guarded RUN), so
+# attempting them by default made every default build fail — `docker build .`,
+# the compose builds and app-image-build.yml pass no INSTALL_TTS arg. The
+# layer is opt-in (--build-arg INSTALL_TTS=1) until the pins gain 3.12 support.
+ARG INSTALL_TTS=0
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
@@ -27,17 +30,19 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 COPY requirements.txt requirements-tts.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-# KNOWN BREAKAGE, surfaced deliberately (#3896 review): requirements-tts.txt
-# pins piper-tts==1.2.0 -> piper-phonemize~=1.1.0, and piper-phonemize 1.1.0
-# publishes NO cp312 linux wheels and no sdist (PyPI has cp39–cp311 manylinux
-# x86_64/aarch64 wheels only; the sole cp312 wheel is macOS x86_64). On this
-# python:3.12 base the TTS layer therefore CANNOT install on linux — the
-# default build fails loudly here, exactly as the single-stage 3.12 Dockerfile
-# from #3893 already did. It worked on the pre-#3893 python:3.11 base (cp311
-# manylinux wheels exist). Kept attempted-by-default so an image never
-# silently ships without piper/kokoro; until the TTS pins gain 3.12 support
-# (or product policy drops the baked TTS layer), build a TTS-less image
-# explicitly with: docker build --build-arg INSTALL_TTS=0 .
+# KNOWN BREAKAGE (#3896 review): requirements-tts.txt pins piper-tts==1.2.0
+# -> piper-phonemize~=1.1.0, and piper-phonemize 1.1.0 publishes NO cp312
+# linux wheels and no sdist (PyPI has cp39–cp311 manylinux x86_64/aarch64
+# wheels only; the sole cp312 wheel is macOS x86_64). On this python:3.12
+# base the TTS layer therefore CANNOT install on linux; it worked on the
+# pre-#3893 python:3.11 base (cp311 manylinux wheels exist). The #3893 CI
+# alignment (python 3.12) and a buildable default TTS image are mutually
+# exclusive until the TTS pins gain 3.12 support, and the #3896 AC requires
+# the default `docker build .` to produce a working image — so the layer is
+# OPT-IN (ARG INSTALL_TTS=0 above). The default image ships WITHOUT
+# piper/kokoro baked in: app/tts/providers.py degrades (those voices report
+# unavailable rather than crashing) and the skip is loud in the build log.
+# Once the pins support 3.12, bake TTS with: docker build --build-arg INSTALL_TTS=1 .
 RUN if [ "$INSTALL_TTS" = "1" ]; then \
       pip install --no-cache-dir -r requirements-tts.txt; \
     else \
@@ -105,8 +110,18 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 #                               service serves (working_dir + PYTHONPATH)
 # - alembic.ini                 root alembic entry (script_location=app/alembic)
 # - sitecustomize.py            import-time classifier persistence hook
-# - scripts/                    ONLY the two entrypoints compose executes
-#                               in-container (migrate + api services)
+# - scripts/                    the two entrypoints compose executes
+#                               in-container (migrate + api services) PLUS the
+#                               scripts.<module> Python modules app/** imports
+#                               at runtime — scripts.yaml_roundtrip at module
+#                               top level in app/services/companion_note.py,
+#                               app/chat/session_log.py, app/promotion/queue.py,
+#                               ... and scripts.validate_* in app/builderops/ —
+#                               with scripts/__init__.py so `scripts` resolves
+#                               as a package. Without these the worker/watcher/
+#                               heimdal services die at boot (ModuleNotFoundError).
+#                               tests/deploy/test_dockerfile_hardening.py derives
+#                               the set from the source imports.
 COPY app/ ./app/
 COPY mimer_runtime/ ./mimer_runtime/
 COPY schemas/ ./schemas/
@@ -116,7 +131,10 @@ COPY vault/ ./vault/
 COPY docs/settings/ ./docs/settings/
 COPY companion-ui/companion-app/ ./companion-ui/companion-app/
 COPY alembic.ini sitecustomize.py ./
-COPY scripts/start_api.sh scripts/run_migrations.sh ./scripts/
+COPY scripts/start_api.sh scripts/run_migrations.sh \
+     scripts/__init__.py scripts/yaml_roundtrip.py \
+     scripts/validate_issue_readiness.py scripts/validate_source_anchors.py \
+     ./scripts/
 RUN chmod +x scripts/start_api.sh scripts/run_migrations.sh
 
 # Pre-create the runtime scratch dir with open perms so the container can create

--- a/tests/deploy/test_dockerfile_hardening.py
+++ b/tests/deploy/test_dockerfile_hardening.py
@@ -1,0 +1,153 @@
+"""Guard Dockerfile multi-stage hardening (builder-ops-stability spec Issue 7).
+
+The runtime image must not bake the full repo (`COPY . .` pulled in tests,
+docs, .git, ops). Contracts guarded here:
+
+1. Multi-stage build: a builder stage installs the runtime requirement
+   manifests; the runtime stage copies the installed site-packages plus only
+   the assets the services in docker-compose.yaml genuinely need at runtime
+   (app/, mimer_runtime/, schemas/, config/, configs/, vault/, docs/settings/,
+   companion-ui/companion-app/, the two compose entrypoint scripts, alembic
+   config, sitecustomize.py).
+2. Every stage stays on the digest-pinned python:3.x-slim base
+   (tests/deploy/test_dockerfile_python_alignment.py owns the CI alignment;
+   this file only asserts the stages agree with each other).
+3. ffmpeg stays installed in the runtime (final) stage.
+4. A HEALTHCHECK probes the existing API health endpoint (`/readyz`, the same
+   endpoint config/runtime.defaults.env points API_HEALTHCHECK_URL at).
+5. .dockerignore keeps dev-only surfaces (tests/, docs/, .git/, root *.md,
+   ops/, scripts/) out of the build context while re-including the two
+   scripts compose actually executes inside containers
+   (scripts/start_api.sh, scripts/run_migrations.sh) and docs/settings/**,
+   the one docs/ subtree read at runtime (settings registries: model/tool/
+   agent/graph/event/prompt loaders in app/components/settings/, plus
+   app/settings/ fallbacks and panel-action wiring).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCKERFILE_PATH = REPO_ROOT / "Dockerfile"
+DOCKERIGNORE_PATH = REPO_ROOT / ".dockerignore"
+
+# Runtime entrypoints executed inside containers by docker-compose.yaml
+# (`migrate` runs run_migrations.sh; `api` and the image CMD run start_api.sh).
+COMPOSE_RUNTIME_SCRIPTS = ("scripts/start_api.sh", "scripts/run_migrations.sh")
+
+
+def _dockerfile_text() -> str:
+    return DOCKERFILE_PATH.read_text(encoding="utf-8")
+
+
+def _from_lines() -> list[str]:
+    return [
+        line.strip()
+        for line in _dockerfile_text().splitlines()
+        if line.startswith("FROM ")
+    ]
+
+
+def _dockerignore_patterns() -> list[str]:
+    return [
+        line.strip()
+        for line in DOCKERIGNORE_PATH.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+
+def test_dockerfile_is_multi_stage() -> None:
+    from_lines = _from_lines()
+    assert len(from_lines) >= 2, (
+        f"Dockerfile must be a multi-stage build (builder + runtime), "
+        f"got FROM lines: {from_lines}"
+    )
+
+
+def test_all_stages_share_one_pinned_base_digest() -> None:
+    digests = set()
+    for from_line in _from_lines():
+        match = re.search(r"@sha256:([0-9a-f]{64})", from_line)
+        assert match, f"stage base image is not digest-pinned: {from_line}"
+        digests.add(match.group(1))
+    assert len(digests) == 1, (
+        f"all stages must share the same pinned base digest, got {sorted(digests)}"
+    )
+
+
+def test_no_full_context_copy() -> None:
+    text = _dockerfile_text()
+    assert not re.search(r"^\s*COPY\s+\.\s+\.\s*$", text, flags=re.MULTILINE), (
+        "Dockerfile must not COPY the whole build context; the runtime stage "
+        "copies only genuine runtime assets"
+    )
+
+
+def test_healthcheck_probes_existing_health_endpoint() -> None:
+    text = _dockerfile_text()
+    assert "HEALTHCHECK" in text, "Dockerfile must declare a HEALTHCHECK"
+    assert "readyz" in text, (
+        "HEALTHCHECK must use the existing API health endpoint (/readyz, the "
+        "endpoint API_HEALTHCHECK_URL in config/runtime.defaults.env targets)"
+    )
+    assert "API_HEALTHCHECK_URL" in text, (
+        "HEALTHCHECK must honor the API_HEALTHCHECK_URL override the compose "
+        "healthchecks already use"
+    )
+
+
+def test_runtime_stage_keeps_ffmpeg_and_compose_entrypoints() -> None:
+    text = _dockerfile_text()
+    # ffmpeg must be installed in the FINAL stage (after the last FROM), not
+    # only in the builder.
+    final_stage = text[text.rindex("FROM ") :]
+    assert "ffmpeg" in final_stage, "runtime (final) stage must install ffmpeg"
+    for script in COMPOSE_RUNTIME_SCRIPTS:
+        assert script in final_stage, (
+            f"runtime stage must copy {script} (compose executes it in-container)"
+        )
+    assert 'CMD ["/app/scripts/start_api.sh"]' in final_stage, (
+        "image entrypoint/startup behavior must not change"
+    )
+
+
+def test_dockerignore_excludes_dev_only_surfaces() -> None:
+    patterns = _dockerignore_patterns()
+    for required in ("tests", "docs", ".git", "*.md", "ops", "scripts"):
+        assert required in patterns, (
+            f".dockerignore must exclude {required!r} from the build context; "
+            f"got {patterns}"
+        )
+
+
+def test_dockerignore_reincludes_compose_runtime_scripts() -> None:
+    patterns = _dockerignore_patterns()
+    for script in COMPOSE_RUNTIME_SCRIPTS:
+        assert f"!{script}" in patterns, (
+            f".dockerignore must re-include {script} (negation pattern) so the "
+            f"runtime stage can copy the compose entrypoint"
+        )
+
+
+def test_docs_settings_runtime_tree_is_reincluded_and_copied() -> None:
+    """docs/ is dev-only EXCEPT docs/settings/**, which app code reads at
+    RUNTIME relative to /app: the model/tool/agent/graph/event/prompt
+    registries (app/components/settings/*_loader.py defaults, consumed by the
+    LLM router, MCP tool provider and settings compiler), the flow/agent
+    fallbacks (app/settings/flows.py, app/settings/agents.py,
+    app/config/paths.py) and panel-action wiring
+    (app/agents/panel_agent/wiring.py). Dropping it from the image turns every
+    LLM-routed request into a FileNotFoundError."""
+    patterns = _dockerignore_patterns()
+    assert "!docs/settings" in patterns, (
+        ".dockerignore must re-include docs/settings (negation pattern) — it "
+        "is read at runtime by the settings loaders"
+    )
+    text = _dockerfile_text()
+    final_stage = text[text.rindex("FROM ") :]
+    assert re.search(r"^\s*COPY\s+docs/settings/\s", final_stage, flags=re.MULTILINE), (
+        "runtime stage must COPY docs/settings/ (settings registries read at "
+        "runtime by app/components/settings/*_loader.py)"
+    )

--- a/tests/deploy/test_dockerfile_hardening.py
+++ b/tests/deploy/test_dockerfile_hardening.py
@@ -22,6 +22,18 @@ docs, .git, ops). Contracts guarded here:
    the one docs/ subtree read at runtime (settings registries: model/tool/
    agent/graph/event/prompt loaders in app/components/settings/, plus
    app/settings/ fallbacks and panel-action wiring).
+6. scripts/ is NOT dev-only wholesale: app/** imports scripts.<module>
+   Python modules at module top level (scripts.yaml_roundtrip in
+   app/services/companion_note.py, app/chat/session_log.py,
+   app/promotion/queue.py, ...; scripts.validate_* in app/builderops/).
+   Every such module (plus scripts/__init__.py, so `scripts` resolves as a
+   package) must be re-included in .dockerignore and COPYed by the runtime
+   stage or the worker/watcher/heimdal compose services crash at boot with
+   ModuleNotFoundError.
+7. The TTS layer (requirements-tts.txt) is opt-in: its pins cannot install
+   on the python:3.12 base (piper-phonemize~=1.1.0 has no cp312 linux
+   wheels), so attempting it by default makes `docker build .` fail — the
+   #3896 AC requires the default build to produce a working image.
 """
 
 from __future__ import annotations
@@ -37,17 +49,23 @@ DOCKERIGNORE_PATH = REPO_ROOT / ".dockerignore"
 # (`migrate` runs run_migrations.sh; `api` and the image CMD run start_api.sh).
 COMPOSE_RUNTIME_SCRIPTS = ("scripts/start_api.sh", "scripts/run_migrations.sh")
 
+# Python package trees the runtime stage COPYs into /app. Any scripts.<module>
+# import reachable from these trees must be baked into the image too, or the
+# importing service crashes at boot (contract 6 in the module docstring).
+RUNTIME_PACKAGE_DIRS = ("app", "mimer_runtime", "companion-ui/companion-app")
+
+_SCRIPTS_IMPORT_RE = re.compile(
+    r"^\s*(?:from\s+scripts\.([A-Za-z0-9_]+)\s+import\b|import\s+scripts\.([A-Za-z0-9_]+))",
+    flags=re.MULTILINE,
+)
+
 
 def _dockerfile_text() -> str:
     return DOCKERFILE_PATH.read_text(encoding="utf-8")
 
 
 def _from_lines() -> list[str]:
-    return [
-        line.strip()
-        for line in _dockerfile_text().splitlines()
-        if line.startswith("FROM ")
-    ]
+    return [line.strip() for line in _dockerfile_text().splitlines() if line.startswith("FROM ")]
 
 
 def _dockerignore_patterns() -> list[str]:
@@ -72,9 +90,9 @@ def test_all_stages_share_one_pinned_base_digest() -> None:
         match = re.search(r"@sha256:([0-9a-f]{64})", from_line)
         assert match, f"stage base image is not digest-pinned: {from_line}"
         digests.add(match.group(1))
-    assert len(digests) == 1, (
-        f"all stages must share the same pinned base digest, got {sorted(digests)}"
-    )
+    assert (
+        len(digests) == 1
+    ), f"all stages must share the same pinned base digest, got {sorted(digests)}"
 
 
 def test_no_full_context_copy() -> None:
@@ -105,20 +123,19 @@ def test_runtime_stage_keeps_ffmpeg_and_compose_entrypoints() -> None:
     final_stage = text[text.rindex("FROM ") :]
     assert "ffmpeg" in final_stage, "runtime (final) stage must install ffmpeg"
     for script in COMPOSE_RUNTIME_SCRIPTS:
-        assert script in final_stage, (
-            f"runtime stage must copy {script} (compose executes it in-container)"
-        )
-    assert 'CMD ["/app/scripts/start_api.sh"]' in final_stage, (
-        "image entrypoint/startup behavior must not change"
-    )
+        assert (
+            script in final_stage
+        ), f"runtime stage must copy {script} (compose executes it in-container)"
+    assert (
+        'CMD ["/app/scripts/start_api.sh"]' in final_stage
+    ), "image entrypoint/startup behavior must not change"
 
 
 def test_dockerignore_excludes_dev_only_surfaces() -> None:
     patterns = _dockerignore_patterns()
     for required in ("tests", "docs", ".git", "*.md", "ops", "scripts"):
         assert required in patterns, (
-            f".dockerignore must exclude {required!r} from the build context; "
-            f"got {patterns}"
+            f".dockerignore must exclude {required!r} from the build context; " f"got {patterns}"
         )
 
 
@@ -129,6 +146,84 @@ def test_dockerignore_reincludes_compose_runtime_scripts() -> None:
             f".dockerignore must re-include {script} (negation pattern) so the "
             f"runtime stage can copy the compose entrypoint"
         )
+
+
+def _runtime_imported_scripts_modules() -> set[str]:
+    """scripts.<module> names imported (top-level or lazily) anywhere in the
+    package trees the runtime stage bakes into the image."""
+    modules: set[str] = set()
+    for package_dir in RUNTIME_PACKAGE_DIRS:
+        for path in sorted((REPO_ROOT / package_dir).rglob("*.py")):
+            for from_mod, import_mod in _SCRIPTS_IMPORT_RE.findall(
+                path.read_text(encoding="utf-8")
+            ):
+                modules.add(from_mod or import_mod)
+    return modules
+
+
+def test_runtime_imported_scripts_modules_are_baked_into_image() -> None:
+    """app/** imports scripts.yaml_roundtrip and scripts.validate_* at module
+    top level (app/services/companion_note.py, app/chat/session_log.py,
+    app/promotion/queue.py, app/builderops/model_inquiry_promotion.py, ...).
+    If the image bakes only the two .sh entrypoints, the worker
+    (`python -m app.workers.outbox_worker`), watcher (`python -m app.cli
+    watcher run`) and heimdal-capture-watch compose services all die at boot
+    with ModuleNotFoundError: No module named 'scripts.yaml_roundtrip'
+    (#3896 adversarial review). Derive the needed modules from the source so
+    a future scripts.<module> import cannot silently reopen the gap."""
+    modules = _runtime_imported_scripts_modules()
+    assert modules, (
+        f"expected runtime packages {RUNTIME_PACKAGE_DIRS} to import "
+        "scripts.<module>; if that is no longer true this guard (and the "
+        "scripts/*.py COPY in the Dockerfile) can be retired"
+    )
+    needed_files = sorted(f"scripts/{module}.py" for module in modules | {"__init__"})
+
+    patterns = _dockerignore_patterns()
+    # Join backslash line continuations so a multi-line COPY matches.
+    text = _dockerfile_text().replace("\\\n", " ")
+    final_stage = text[text.rindex("FROM ") :]
+    for needed in needed_files:
+        assert (REPO_ROOT / needed).is_file(), (
+            f"runtime code imports scripts.{Path(needed).stem} but {needed} "
+            "does not exist in the repo"
+        )
+        assert f"!{needed}" in patterns, (
+            f".dockerignore must re-include {needed} (negation pattern under "
+            f"the scripts/ exclusion) — app/** imports it at runtime"
+        )
+        assert re.search(
+            rf"^\s*COPY\s[^\n]*{re.escape(needed)}(\s|$)",
+            final_stage,
+            flags=re.MULTILINE,
+        ), (
+            f"runtime stage must COPY {needed} — app/** imports it at runtime "
+            "(worker/watcher/heimdal services crash at boot without it)"
+        )
+
+
+def test_tts_layer_is_opt_in_so_default_build_succeeds() -> None:
+    """requirements-tts.txt pins piper-tts==1.2.0 -> piper-phonemize~=1.1.0,
+    which publishes no cp312 linux wheels and no sdist, so installing it on
+    the python:3.12 base fails EVERY default build (`docker build .`,
+    compose build, app-image-build.yml — none pass INSTALL_TTS). The #3896 AC
+    requires the default build to produce a working image, so the TTS layer
+    must be opt-in (default 0) until the pins gain 3.12 support; the guarded
+    RUN keeps the skip loud in the build log."""
+    text = _dockerfile_text()
+    assert re.search(r"^ARG INSTALL_TTS=0\s*$", text, flags=re.MULTILINE), (
+        "INSTALL_TTS must default to 0: the TTS pins cannot install on the "
+        "python:3.12 base, so a default of 1 makes every default build fail "
+        "(#3896 AC: image builds)"
+    )
+    assert 'if [ "$INSTALL_TTS" = "1" ]' in text, (
+        "the TTS install must stay behind the INSTALL_TTS guard so it can be "
+        "re-enabled with --build-arg INSTALL_TTS=1 once the pins support 3.12"
+    )
+    assert "requirements-tts.txt" in text, (
+        "the guarded TTS layer (requirements-tts.txt) must remain in the "
+        "builder stage as the opt-in path"
+    )
 
 
 def test_docs_settings_runtime_tree_is_reincluded_and_copied() -> None:

--- a/tests/deploy/test_dockerfile_python_alignment.py
+++ b/tests/deploy/test_dockerfile_python_alignment.py
@@ -13,25 +13,37 @@ DOCKERFILE_PATH = Path("Dockerfile")
 CI_SMOKE_PATH = Path(".github/workflows/ci-smoke.yaml")
 
 
-def _dockerfile_from_line() -> str:
-    for line in DOCKERFILE_PATH.read_text(encoding="utf-8").splitlines():
-        if line.startswith("FROM "):
-            return line.strip()
-    raise AssertionError("Dockerfile has no FROM line")
+def _dockerfile_from_lines() -> list[str]:
+    lines = [
+        line.strip()
+        for line in DOCKERFILE_PATH.read_text(encoding="utf-8").splitlines()
+        if line.startswith("FROM ")
+    ]
+    if not lines:
+        raise AssertionError("Dockerfile has no FROM line")
+    return lines
 
 
 def test_dockerfile_base_image_is_digest_pinned() -> None:
-    from_line = _dockerfile_from_line()
-    assert re.fullmatch(
-        r"FROM python:3\.\d+-slim@sha256:[0-9a-f]{64}", from_line
-    ), f"FROM line must be python:3.x-slim pinned by sha256 digest, got: {from_line}"
+    # Every stage of the multi-stage build must stay on the pinned base
+    # (an optional `AS <stage>` suffix names the stage).
+    for from_line in _dockerfile_from_lines():
+        assert re.fullmatch(
+            r"FROM python:3\.\d+-slim@sha256:[0-9a-f]{64}(?: AS [A-Za-z0-9_.-]+)?",
+            from_line,
+        ), f"FROM line must be python:3.x-slim pinned by sha256 digest, got: {from_line}"
 
 
 def test_dockerfile_python_minor_matches_ci_smoke() -> None:
-    from_line = _dockerfile_from_line()
-    match = re.search(r"python:(3\.\d+)-slim", from_line)
-    assert match, f"cannot parse python minor version from: {from_line}"
-    docker_minor = match.group(1)
+    docker_minors: set[str] = set()
+    for from_line in _dockerfile_from_lines():
+        match = re.search(r"python:(3\.\d+)-slim", from_line)
+        assert match, f"cannot parse python minor version from: {from_line}"
+        docker_minors.add(match.group(1))
+    assert len(docker_minors) == 1, (
+        f"all Dockerfile stages must use one python minor, got {sorted(docker_minors)}"
+    )
+    docker_minor = docker_minors.pop()
 
     ci_versions = re.findall(
         r"python-version:\s*['\"]?(3\.\d+)",


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Governing-Issue: #3896

Fixes #3896

## Summary
- Multi-stage Dockerfile: builder stage installs requirements; runtime stage copies site-packages + an **explicit** runtime asset list (app/, alembic surfaces, `scripts/start_api.sh`, `scripts/run_migrations.sh`). ffmpeg preserved; HEALTHCHECK probes `/readyz` (API_HEALTHCHECK_URL override, matching compose).
- `.dockerignore` expanded (tests/, docs/, .git/, ops/, *.md, .github, .codex, nested `**/__pycache__`…), with documented re-includes for genuine runtime files.
- **Two boot-crash regressions caught by adversarial review of the built image, both fixed + guard-tested:**
  - `docs/settings/**` is read at runtime (model registry, MCP tool provider, settings compiler — hard `read_text` of `docs/settings/models/registry.yaml`); excluding docs/ would have thrown FileNotFoundError on every LLM-routed request. Re-included + COPY'd.
  - `scripts/*.py` modules (`yaml_roundtrip`, `validate_*`) are imported at module top-level from app/; 3 of 6 compose services crashed at boot without them. Re-included + COPY'd, with a dynamic test deriving the required set from actual imports.

## ⚠️ Product decision for the owner: TTS layer is now opt-in
piper-phonemize~=1.1.0 has **no Python 3.12 linux wheels/sdist**, so the 3.12 pin (#3893) and a default-built TTS image are mutually exclusive today. This PR sets `ARG INSTALL_TTS=0`: default builds succeed and ship **without** piper/kokoro baked in (`app/tts/providers.py` degrades gracefully; skip is loud in the build log; guarded by test). Options:
1. **Accept opt-in TTS** (this PR's state) — re-enable per-build with `--build-arg INSTALL_TTS=1` once pins gain 3.12 support.
2. Fix the TTS pins for 3.12 (fork/newer piper distribution or vendored phonemizer) — follow-up issue.
3. Reject the 3.12 alignment and stay on 3.11 (closes #3893 as won't-fix).

Empirically verified on a live daemon (linux/arm64): default build exit 0; in-image `import app`, `python -m app.cli --help`, outbox worker boots to its normal DB-wait loop; every previously-crashing module imports cleanly.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed (ffmpeg preserved, entrypoint unchanged, health endpoint reused).
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed (Dockerfile comment block documents the TTS decision).
- [ ] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Validation
Implementation lane:
- [x] `ruff check` clean on changed files
- [x] `tests/deploy/` 62 passed incl. 9 hardening guard tests (TDD red→green)
- [x] Real `docker build` + in-image runtime verification as above (adversarial verify + fix cycle, commits 9106016f + 35288f64)

Stacked on the #3893 PR — merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: dev-flow CI/build/observability change; no BuilderOps records, projections, or receipts were created or consumed by this work.

## Notes
- Delivered as part of the builder-ops-stability issue set (docs/specs/builder-ops-stability/, PR #3898). Residual risks and follow-ups are stated inline above.

