### PR TITLE
fix(logging): tolerate closed capture stream rebind

### DIFF
--- a/app/observability/logging_setup.py
+++ b/app/observability/logging_setup.py
@@ -81,7 +81,22 @@ def configure_json_logging(
         if isinstance(handler, logging.StreamHandler) and isinstance(
             handler.formatter, JsonLogFormatter
         ):
-            handler.setStream(target)
+            current = handler.stream
+            if current is target:
+                return handler
+            if getattr(current, "closed", False):
+                # StreamHandler.setStream() flushes the old stream before it
+                # rebinds. Pytest capture streams can already be closed by the
+                # time another runtime entrypoint configures process logging.
+                # Assign under the handler lock only for that closed-stream
+                # case; live streams keep the normal flush-on-rebind contract.
+                handler.acquire()
+                try:
+                    handler.stream = target
+                finally:
+                    handler.release()
+            else:
+                handler.setStream(target)
             return handler
     handler = logging.StreamHandler(target)
     handler.setFormatter(JsonLogFormatter())

--- a/tests/observability/test_structured_logging.py
+++ b/tests/observability/test_structured_logging.py
@@ -150,6 +150,30 @@ def test_configure_json_logging_is_idempotent(clean_root_logger):
     assert len(json_handlers) == 1
 
 
+def test_reconfigure_json_logging_replaces_closed_capture_stream(clean_root_logger):
+    from app.observability.logging_setup import (
+        JsonLogFormatter,
+        configure_json_logging,
+    )
+
+    closed_capture = io.StringIO()
+    handler = configure_json_logging(stream=closed_capture)
+    closed_capture.close()
+    replacement = io.StringIO()
+
+    rebound = configure_json_logging(stream=replacement)
+    logging.getLogger("app.test.closed.capture").info("rebound")
+
+    assert rebound is handler
+    assert json.loads(replacement.getvalue())["message"] == "rebound"
+    json_handlers = [
+        candidate
+        for candidate in logging.getLogger().handlers
+        if isinstance(candidate.formatter, JsonLogFormatter)
+    ]
+    assert json_handlers == [handler]
+
+
 # ---------------------------------------------------------------------------
 # Process entrypoint wiring: API, worker, watcher.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Governing-Issue: #3935

Refs #3935

## Summary

- avoid flushing a stale closed capture stream when the existing JSON handler is rebound
- retain normal `StreamHandler.setStream` flush semantics for live streams
- prove the production reconfiguration path emits valid JSON and keeps exactly one handler

## SBS impact

- Product Runtime observability behavior with Builder System CI verification impact
- no authority, persistence, deployment, or external-service change

## Validation

- `32 passed` — structured logging plus the watcher/worker cluster that failed in PR #3884 CI
- `ruff check app tests` — passed
- `mypy app` — passed (757 source files)
- `git diff --check` — passed

## BuilderOps Routing

- Records/projections/receipts: GitHub-label fallback pickup receipt `4997723371`
- Reason: dispatcher claim could not find the newly created task; implementation remained isolated in an Issue-backed worktree.
Verified-Closing-Issues: #3935
