### PR TITLE
fix(#3930): bind outbox service to real conn_rw; commit poison-path bookkeeping atomically

### DIFF
--- a/app/observability/status_service.py
+++ b/app/observability/status_service.py
@@ -631,7 +631,7 @@ def _count_outbox_pending_db() -> int | None:
         cur = conn.cursor()
         cur.execute("select count(*) from outbox where delivered_at is null")
         row = cur.fetchone()
-        return int(row[0]) if row else 0
+        return int(outbox_service._row_value(row, 0)) if row else 0
     except Exception:
         return None
     finally:
@@ -654,7 +654,7 @@ def _count_outbox_total_db() -> int | None:
         cur = conn.cursor()
         cur.execute("select count(*) from outbox")
         row = cur.fetchone()
-        return int(row[0]) if row else 0
+        return int(outbox_service._row_value(row, 0)) if row else 0
     except Exception:
         return None
     finally:

--- a/app/services/outbox.py
+++ b/app/services/outbox.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import uuid as uuid_module
 from datetime import datetime, timezone
@@ -16,6 +17,8 @@ from app.events.topic_schema_registry import (
     is_registered_topic,
     validate_topic_payload,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 # Optional DB helpers (tests kan ge FakeConn). Import the real implementations
 # from app.db.db directly: the package-level names (`from app.db import
@@ -137,7 +140,12 @@ def open_outbox_txn_conn():
     non-pg test runs hermetic: ``conn_rw`` falls back to ``settings.db_dsn``,
     which could reach a real local database the test run never named. Returns
     ``None`` (never raises) when the helper is unavailable or the connect
-    fails — the degraded path preserves at-least-once semantics.
+    fails — the degraded path preserves at-least-once semantics. Unlike
+    :func:`_open_conn`, this has no plain-DSN fallback: a ``conn_rw`` failure
+    with the DB explicitly configured (as opposed to simply unconfigured)
+    silently reintroduces the non-atomic bookkeeping this function exists to
+    avoid, so that case is logged to distinguish it from the expected
+    unconfigured short-circuit above.
     """
     if not conn_rw:
         return None
@@ -147,6 +155,11 @@ def open_outbox_txn_conn():
     try:
         return conn_rw()
     except Exception:
+        _LOGGER.warning(
+            "open_outbox_txn_conn: DB is configured but conn_rw() failed; "
+            "poison-path bookkeeping degrades to the non-atomic per-call sequence",
+            exc_info=True,
+        )
         return None
 
 

--- a/app/services/outbox.py
+++ b/app/services/outbox.py
@@ -17,9 +17,15 @@ from app.events.topic_schema_registry import (
     validate_topic_payload,
 )
 
-# Optional DB helpers (tests kan ge FakeConn)
+# Optional DB helpers (tests kan ge FakeConn). Import the real implementations
+# from app.db.db directly: the package-level names (`from app.db import
+# conn_rw`) resolve through app/db/__init__.py::__getattr__ to the permanent
+# psycopg-free smoke stub in app/db/sqlalchemy.py (#30), whose conn_rw always
+# raises and whose ensure_schema is a no-op — the same stub-binding defect
+# vault_sync fixed in #2937 (#3930). The try/except keeps this module
+# importable where psycopg or the settings stack is unavailable.
 try:
-    from app.db import conn_rw, ensure_schema  # type: ignore
+    from app.db.db import conn_rw, ensure_schema  # type: ignore
 except Exception:  # pragma: no cover
     conn_rw = None  # type: ignore
 
@@ -78,11 +84,27 @@ def _assert_outbox_schema(conn: Any) -> None:
 
 
 def _open_conn():
+    """Open a connection for a single self-owned outbox statement.
+
+    Prefers the canonical ``app.db.db.conn_rw`` (canonical DSN resolution,
+    dict-row cursors) switched to autocommit: every self-opened caller in this
+    module is single-statement and never calls ``commit()``, and psycopg3
+    rolls back uncommitted work on ``close()`` — handing back conn_rw's
+    manual-commit connection unchanged would silently lose these writes
+    (#3930). Callers that need multi-statement transactions pass their own
+    connection (or use :func:`open_outbox_txn_conn`) and own the commit.
+
+    Falls back to a plain env-DSN ``psycopg.connect`` when the canonical
+    helper is unavailable or cannot connect.
+    """
     if conn_rw:
         try:
-            return conn_rw()
+            conn = conn_rw()
         except Exception:
             pass
+        else:
+            conn.autocommit = True
+            return conn
     import psycopg
 
     url = os.environ.get("DATABASE_URL") or os.environ.get("DB_DSN")
@@ -96,6 +118,36 @@ def _open_conn():
         if url.startswith("postgresql+psycopg://"):
             url = "postgresql://" + url.split("postgresql+psycopg://", 1)[1]
     return psycopg.connect(url, autocommit=True)
+
+
+def open_outbox_txn_conn():
+    """Open one manual-commit canonical connection for multi-statement outbox bookkeeping.
+
+    The outbox worker uses this to commit ``bump_outbox_attempts`` + the
+    dead-letter audit insert + ``ack_outbox`` as ONE transaction (#3930):
+    with per-call autocommit connections a crash between those statements
+    strands partial poison bookkeeping (a row durably ``attempts == max`` yet
+    undelivered) and duplicates the dead-letter audit row under the next
+    attempt-scoped idempotency key on the retry cycle.
+
+    Requires the database to be named explicitly by the environment
+    (``DATABASE_URL``/``DB_DSN``/``STORE_BACKEND=pg``, mirroring the worker's
+    ``_use_db_outbox``); otherwise returns ``None`` and callers degrade to the
+    historical per-call autocommit sequence. The explicit-env gate keeps
+    non-pg test runs hermetic: ``conn_rw`` falls back to ``settings.db_dsn``,
+    which could reach a real local database the test run never named. Returns
+    ``None`` (never raises) when the helper is unavailable or the connect
+    fails — the degraded path preserves at-least-once semantics.
+    """
+    if not conn_rw:
+        return None
+    backend = (os.environ.get("STORE_BACKEND") or "").strip().lower()
+    if backend != "pg" and not (os.environ.get("DATABASE_URL") or os.environ.get("DB_DSN")):
+        return None
+    try:
+        return conn_rw()
+    except Exception:
+        return None
 
 
 def _use_conn(maybe_conn: Any) -> Tuple[Any, bool]:
@@ -126,10 +178,11 @@ def _exec(conn: Any, sql: str, params: tuple = ()) -> Any:
 def _row_value(row: Any, index: int, key: str | None = None) -> Any:
     """Return a column value from a fetched row, tolerating either shape.
 
-    ``_open_conn()``'s plain-psycopg fallback yields tuple rows, but callers
-    (e.g. ``app.services.vault_sync``) may hand in a connection whose cursors
-    use a ``dict_row`` factory (``app.db.db.conn_rw``). Index into either
-    shape by the column's positional index or its select-list name. When
+    ``_open_conn()``'s canonical ``conn_rw`` path (and callers such as
+    ``app.services.vault_sync`` handing in their own connection) yields
+    ``dict_row`` rows; the plain-psycopg env fallback yields tuple rows.
+    Index into either shape by the column's positional index or its
+    select-list name. When
     ``key`` is omitted (unaliased aggregate expressions such as ``count(*)``
     whose dict key is unpredictable), fall back to positional order on the
     dict's values.
@@ -652,6 +705,7 @@ __all__ = [
     "payload_fingerprint",
     "write_outbox_event",
     "insert_object_and_outbox",
+    "open_outbox_txn_conn",
     "poll_outbox_one",
     "ack_outbox",
     "bump_outbox_attempts",

--- a/app/workers/outbox_worker.py
+++ b/app/workers/outbox_worker.py
@@ -1252,13 +1252,15 @@ def _record_failed_dispatch(
                 error=str(error),
                 conn=conn,
             )
-            ack_outbox(conn, message_id)
-            # A commit failure here leaves nothing durable on this connection,
-            # so fall through to the same "not resolved" signal the below-cap
-            # path returns: the caller re-raises the original dispatch error
-            # for crash-retry, instead of a new commit-failure exception
-            # masking it.
-            return _commit_or_log(conn, topic=topic, message_id=message_id)
+            # Ack and commit share one guard: either can raise on the same
+            # broken-connection fault that would make the other fail too, and
+            # nothing durable happens on this connection unless both succeed
+            # (the ack itself rolls back with the rest of the transaction if
+            # only commit fails) — fall through to the same "not resolved"
+            # signal the below-cap path returns: the caller re-raises the
+            # original dispatch error for crash-retry, instead of a new
+            # ack/commit-failure exception masking it.
+            return _ack_and_commit_or_log(conn, message_id, topic=topic)
         _commit_or_log(conn, topic=topic, message_id=message_id)
         return False
     finally:
@@ -1282,6 +1284,29 @@ def _commit_or_log(conn: Any, *, topic: str | None, message_id: Any) -> bool:
     except Exception:
         logger.exception(
             "worker failed to commit dispatch-failure bookkeeping topic=%s id=%s",
+            topic,
+            message_id,
+        )
+        return False
+    return True
+
+
+def _ack_and_commit_or_log(conn: Any, message_id: Any, *, topic: str | None) -> bool:
+    """Ack ``message_id`` and commit ``conn``, logging (not raising) on failure.
+
+    Same rationale as :func:`_commit_or_log`, extended to the ack call: a bare
+    `ack_outbox(conn, message_id)` before the commit shares the identical
+    broken-connection failure surface as `conn.commit()` and can equally raise
+    and mask the caller's original dispatch error (#3930 round-2 review) —
+    both statements are guarded by the same try so either failure degrades to
+    the same "not resolved" bool instead of propagating.
+    """
+    try:
+        ack_outbox(conn, message_id)
+        conn.commit()
+    except Exception:
+        logger.exception(
+            "worker failed to ack/commit dispatch-failure bookkeeping topic=%s id=%s",
             topic,
             message_id,
         )

--- a/app/workers/outbox_worker.py
+++ b/app/workers/outbox_worker.py
@@ -54,6 +54,7 @@ from app.services.outbox import (
     bootstrap,
     bump_outbox_attempts,
     derive_idempotency_key,
+    open_outbox_txn_conn,
     payload_fingerprint,
     poll_outbox_one,
     write_outbox_event,
@@ -356,16 +357,15 @@ def run_once(
             topic,
             message.get("id"),
         )
-        _dead_letter_outbox_message(
-            topic,
-            payload,
-            message_id=str(message.get("id") or ""),
+        _dead_letter_and_ack(
+            message["id"],
+            topic=topic,
+            payload=payload,
             reason=INVALID_NOTE_UUID_REASON,
             attempts=0,
             trace_id=None if trace_id == "-" else trace_id,
             error=str(uuid_exc),
         )
-        ack_outbox(message["id"])
         return WorkerTickResult(state="processed", processed=1)
     except SchemaViolationDispatchError as schema_exc:
         # Immediate dead-letter (KERNEL-08, #2770): see the matching branch in
@@ -376,16 +376,15 @@ def run_once(
             message.get("id"),
             schema_exc.violation.reason,
         )
-        _dead_letter_outbox_message(
-            topic,
-            payload,
-            message_id=str(message.get("id") or ""),
+        _dead_letter_and_ack(
+            message["id"],
+            topic=topic,
+            payload=payload,
             reason=SCHEMA_VIOLATION_REASON,
             attempts=0,
             trace_id=None if trace_id == "-" else trace_id,
             error=str(schema_exc),
         )
-        ack_outbox(message["id"])
         return WorkerTickResult(state="processed", processed=1)
     ack_outbox(message["id"])
     return WorkerTickResult(state="processed", processed=1)
@@ -1056,12 +1055,19 @@ def _dead_letter_outbox_message(
     attempts: int,
     trace_id: str | None,
     error: str,
+    conn: Any = None,
 ) -> None:
     """Audit a poison outbox row that exceeded the dispatch-attempt budget.
 
     Writes an ``outbox.event.dead_lettered`` record to the JSONL audit sink (and the
     DB outbox when enabled) so the drop is observable. Best-effort: a failure here must
     not re-block the queue, so exceptions are swallowed after logging.
+
+    ``conn`` (#3930): when the caller shares its manual-commit connection so the
+    audit row commits atomically with the surrounding bookkeeping, the DB write
+    runs inside a savepoint (``conn.transaction()``) — its failure rolls back
+    only the audit insert, never the caller's transaction, preserving the
+    best-effort contract (the ack must still commit).
     """
     try:
         event = make_outbox_event(
@@ -1082,14 +1088,16 @@ def _dead_letter_outbox_message(
             # Keyed on (topic, poisoned outbox row id, attempts): duplicate
             # audit emission for the same drop dedups; a later re-poisoning at
             # a different attempt count produces a distinct row (I-E1).
-            write_outbox_event(
-                event,
-                idempotency_key=derive_idempotency_key(
-                    OUTBOX_EVENT_DEAD_LETTERED,
-                    str(message_id),
-                    f"poison:{attempts}",
-                ),
+            key = derive_idempotency_key(
+                OUTBOX_EVENT_DEAD_LETTERED,
+                str(message_id),
+                f"poison:{attempts}",
             )
+            if conn is not None:
+                with conn.transaction():
+                    write_outbox_event(event, conn=conn, idempotency_key=key)
+            else:
+                write_outbox_event(event, idempotency_key=key)
         logger.warning(
             "worker dead-lettered poison outbox row topic=%s id=%s reason=%s attempts=%s",
             topic,
@@ -1111,6 +1119,149 @@ def _dead_letter_outbox_message(
         payload=payload,
         trace_id=trace_id,
     )
+
+
+def _dead_letter_and_ack(
+    message_id: Any,
+    *,
+    topic: str | None,
+    payload: Mapping[str, Any],
+    reason: str,
+    attempts: int,
+    trace_id: str | None,
+    error: str,
+) -> None:
+    """Write the dead-letter audit row and ack the poisoned row atomically (#3930).
+
+    One canonical manual-commit connection carries both statements so a crash
+    between them cannot strand an audited-but-unacked row (which would re-poll
+    and duplicate work on restart). When the canonical connection is
+    unavailable, degrade to the historical per-call autocommit sequence —
+    at-least-once semantics hold either way (the attempt-scoped idempotency
+    key dedups the audit row on a same-attempt retry).
+    """
+    conn = open_outbox_txn_conn()
+    if conn is None:
+        _dead_letter_outbox_message(
+            topic,
+            payload,
+            message_id=str(message_id or ""),
+            reason=reason,
+            attempts=attempts,
+            trace_id=trace_id,
+            error=error,
+        )
+        ack_outbox(message_id)
+        return
+    try:
+        # Outermost transaction block: the connection is fresh/idle here, so
+        # this BEGINs and commits both statements on clean exit. Without it,
+        # the dead-letter helper's own savepoint block would be the outermost
+        # transaction on this connection and psycopg3 would commit the audit
+        # insert on block exit — before the ack, i.e. two transactions again.
+        with conn.transaction():
+            _dead_letter_outbox_message(
+                topic,
+                payload,
+                message_id=str(message_id or ""),
+                reason=reason,
+                attempts=attempts,
+                trace_id=trace_id,
+                error=error,
+                conn=conn,
+            )
+            ack_outbox(conn, message_id)
+    finally:
+        try:
+            conn.close()
+        except Exception:  # pragma: no cover - close is best-effort
+            pass
+
+
+def _record_failed_dispatch(
+    message_id: Any,
+    *,
+    topic: str | None,
+    payload: Mapping[str, Any],
+    trace_id: str | None,
+    error: BaseException,
+) -> bool:
+    """Record one failed dispatch: bump the poison budget, dead-letter at the cap.
+
+    Returns True when the row was dead-lettered and acked (the caller moves on
+    to the next row) and False when the row stays pending (the caller re-raises
+    so the supervised worker crash-retries; at-least-once).
+
+    On the canonical connection all bookkeeping for this failure commits as ONE
+    transaction (#3930): below the cap the attempts bump commits alone, making
+    the poison budget durable across the crash-retry (#2252); at the cap bump +
+    dead-letter audit + ack commit together, so a crash between the statements
+    rolls the whole cycle back instead of stranding partial state (a row
+    durably ``attempts == max`` yet undelivered, then a duplicate dead-letter
+    audit row under ``poison:<n+1>`` on the next cycle). When the canonical
+    connection is unavailable, degrade to the historical per-call autocommit
+    sequence.
+    """
+    reason = f"dispatch_failed:{type(error).__name__}"
+    conn = open_outbox_txn_conn()
+    if conn is None:
+        attempts = 0
+        try:
+            attempts = bump_outbox_attempts(message_id)
+        except Exception:
+            logger.exception(
+                "worker failed to record dispatch attempt topic=%s id=%s",
+                topic,
+                message_id,
+            )
+        if attempts and attempts >= _resolve_max_dispatch_attempts():
+            _dead_letter_outbox_message(
+                topic,
+                payload,
+                message_id=str(message_id or ""),
+                reason=reason,
+                attempts=attempts,
+                trace_id=trace_id,
+                error=str(error),
+            )
+            ack_outbox(message_id)
+            return True
+        return False
+    try:
+        attempts = 0
+        try:
+            attempts = bump_outbox_attempts(conn, message_id)
+        except Exception:
+            logger.exception(
+                "worker failed to record dispatch attempt topic=%s id=%s",
+                topic,
+                message_id,
+            )
+            try:
+                conn.rollback()
+            except Exception:  # pragma: no cover - rollback is best-effort
+                pass
+        if attempts and attempts >= _resolve_max_dispatch_attempts():
+            _dead_letter_outbox_message(
+                topic,
+                payload,
+                message_id=str(message_id or ""),
+                reason=reason,
+                attempts=attempts,
+                trace_id=trace_id,
+                error=str(error),
+                conn=conn,
+            )
+            ack_outbox(conn, message_id)
+            conn.commit()
+            return True
+        conn.commit()
+        return False
+    finally:
+        try:
+            conn.close()
+        except Exception:  # pragma: no cover - close is best-effort
+            pass
 
 
 def _draft_schema_violation_case(
@@ -1706,16 +1857,15 @@ def run(
                             topic,
                             message.get("id"),
                         )
-                        _dead_letter_outbox_message(
-                            topic,
-                            payload,
-                            message_id=str(message.get("id") or ""),
+                        _dead_letter_and_ack(
+                            message["id"],
+                            topic=topic,
+                            payload=payload,
                             reason=INVALID_NOTE_UUID_REASON,
                             attempts=0,
                             trace_id=None if trace_id == "-" else trace_id,
                             error=str(uuid_exc),
                         )
-                        ack_outbox(message["id"])
                         continue
                     except SchemaViolationDispatchError as schema_exc:
                         # Immediate dead-letter (KERNEL-08, #2770): a registered-schema
@@ -1729,16 +1879,15 @@ def run(
                             message.get("id"),
                             schema_exc.violation.reason,
                         )
-                        _dead_letter_outbox_message(
-                            topic,
-                            payload,
-                            message_id=str(message.get("id") or ""),
+                        _dead_letter_and_ack(
+                            message["id"],
+                            topic=topic,
+                            payload=payload,
                             reason=SCHEMA_VIOLATION_REASON,
                             attempts=0,
                             trace_id=None if trace_id == "-" else trace_id,
                             error=str(schema_exc),
                         )
-                        ack_outbox(message["id"])
                         continue
                     except Exception as handler_exc:
                         logger.exception(
@@ -1759,27 +1908,16 @@ def run(
                         # Bound retries per row so a single un-handleable (poison) event
                         # cannot crash-loop the worker at the head of the queue and
                         # block every following row (the processed_total=0 stall, #2252).
-                        attempts = 0
-                        try:
-                            attempts = bump_outbox_attempts(message["id"])
-                        except Exception:
-                            logger.exception(
-                                "worker failed to record dispatch attempt topic=%s id=%s",
-                                topic,
-                                message.get("id"),
-                            )
-                        if attempts and attempts >= _resolve_max_dispatch_attempts():
+                        # The bump, dead-letter audit, and ack commit as one
+                        # transaction on one connection (#3930).
+                        if _record_failed_dispatch(
+                            message["id"],
+                            topic=topic,
+                            payload=payload,
+                            trace_id=None if trace_id == "-" else trace_id,
+                            error=handler_exc,
+                        ):
                             errors_total += 1
-                            _dead_letter_outbox_message(
-                                topic,
-                                payload,
-                                message_id=str(message.get("id") or ""),
-                                reason=f"dispatch_failed:{type(handler_exc).__name__}",
-                                attempts=attempts,
-                                trace_id=None if trace_id == "-" else trace_id,
-                                error=str(handler_exc),
-                            )
-                            ack_outbox(message["id"])
                             continue
                         # Below the poison threshold: treat as transient and re-raise so
                         # the supervised worker restarts and retries (at-least-once).

--- a/app/workers/outbox_worker.py
+++ b/app/workers/outbox_worker.py
@@ -1253,15 +1253,40 @@ def _record_failed_dispatch(
                 conn=conn,
             )
             ack_outbox(conn, message_id)
-            conn.commit()
-            return True
-        conn.commit()
+            # A commit failure here leaves nothing durable on this connection,
+            # so fall through to the same "not resolved" signal the below-cap
+            # path returns: the caller re-raises the original dispatch error
+            # for crash-retry, instead of a new commit-failure exception
+            # masking it.
+            return _commit_or_log(conn, topic=topic, message_id=message_id)
+        _commit_or_log(conn, topic=topic, message_id=message_id)
         return False
     finally:
         try:
             conn.close()
         except Exception:  # pragma: no cover - close is best-effort
             pass
+
+
+def _commit_or_log(conn: Any, *, topic: str | None, message_id: Any) -> bool:
+    """Commit ``conn``, logging (not raising) on failure.
+
+    A raise here would replace the caller's own dispatch-failure exception
+    with an unrelated commit-failure exception by the time it reaches the
+    `except Exception as handler_exc: ... raise` re-raise in `run()` (#3930
+    review) — the row stays safely pending either way (nothing committed), so
+    the caller only needs a bool to decide whether bookkeeping is durable.
+    """
+    try:
+        conn.commit()
+    except Exception:
+        logger.exception(
+            "worker failed to commit dispatch-failure bookkeeping topic=%s id=%s",
+            topic,
+            message_id,
+        )
+        return False
+    return True
 
 
 def _draft_schema_violation_case(

--- a/app/workers/outbox_worker.py
+++ b/app/workers/outbox_worker.py
@@ -1260,7 +1260,7 @@ def _record_failed_dispatch(
             # signal the below-cap path returns: the caller re-raises the
             # original dispatch error for crash-retry, instead of a new
             # ack/commit-failure exception masking it.
-            return _ack_and_commit_or_log(conn, message_id, topic=topic)
+            return _ack_and_commit_or_log(conn, message_id=message_id, topic=topic)
         _commit_or_log(conn, topic=topic, message_id=message_id)
         return False
     finally:
@@ -1291,7 +1291,7 @@ def _commit_or_log(conn: Any, *, topic: str | None, message_id: Any) -> bool:
     return True
 
 
-def _ack_and_commit_or_log(conn: Any, message_id: Any, *, topic: str | None) -> bool:
+def _ack_and_commit_or_log(conn: Any, *, message_id: Any, topic: str | None) -> bool:
     """Ack ``message_id`` and commit ``conn``, logging (not raising) on failure.
 
     Same rationale as :func:`_commit_or_log`, extended to the ack call: a bare

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -450,14 +450,20 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
             # Opt-in /metrics endpoint for the outbox worker; its coverage
             # lives in tests/workers/test_worker_metrics.py.
             "app/workers/metrics.py",
+            # The outbox service owns the queue's DB access (connection
+            # binding, idempotent writes, ack/bump) that the worker consumes
+            # (#3930); its regressions live in tests/services and tests/workers.
+            "app/services/outbox.py",
             "tests/workers/",
             "tests/worker/",
             "tests/services/test_outbox_idempotency.py",
+            "tests/services/test_outbox_conn_binding.py",
         ),
         (
             "tests/workers",
             "tests/worker",
             "tests/services/test_outbox_idempotency.py",
+            "tests/services/test_outbox_conn_binding.py",
             "tests/events",
         ),
     ),

--- a/tests/observability/test_status_service.py
+++ b/tests/observability/test_status_service.py
@@ -6,6 +6,7 @@ import pytest
 
 from app.observability.ingest_meta import record_ingest_run, reset_ingest_meta
 from app.observability.status_service import get_system_status, record_ask_error, record_ask_query, reset_ask_metrics
+from app.services import outbox as outbox_service
 from app.stores import get_object_store, reset_store_backends
 import app.observability.status_service as status_service
 
@@ -267,3 +268,41 @@ def test_get_system_status_includes_panel_actions_provenance(monkeypatch, tmp_pa
         assert len(status.panel_diagnostics.source_mtimes) == len(status.panel_diagnostics.source_paths)
         # At least one path should be the panel_actions file we created
         assert str(panel_actions) in status.panel_diagnostics.source_paths
+
+
+class _DictRowCursor:
+    """Emulates psycopg's dict_row cursor factory (app.db.db.conn_rw's shape, #3930)."""
+
+    def __init__(self, count: int) -> None:
+        self._count = count
+
+    def execute(self, *_a, **_k) -> None:
+        return None
+
+    def fetchone(self):
+        return {"count": self._count}
+
+
+class _DictRowConn:
+    def __init__(self, count: int) -> None:
+        self._count = count
+
+    def cursor(self):
+        return _DictRowCursor(self._count)
+
+    def close(self) -> None:
+        pass
+
+
+def test_count_outbox_pending_db_handles_dict_row_cursor(monkeypatch):
+    """Regression for #3930 review: outbox_service._open_conn() now can return
+    the real conn_rw() connection (dict_row cursors), not just the plain
+    tuple-row psycopg fallback that was the only reachable path while
+    app.services.outbox bound the always-raising stub conn_rw."""
+    monkeypatch.setattr(outbox_service, "_open_conn", lambda: _DictRowConn(3))
+    assert status_service._count_outbox_pending_db() == 3
+
+
+def test_count_outbox_total_db_handles_dict_row_cursor(monkeypatch):
+    monkeypatch.setattr(outbox_service, "_open_conn", lambda: _DictRowConn(7))
+    assert status_service._count_outbox_total_db() == 7

--- a/tests/runtime/test_panel_outbox_db.py
+++ b/tests/runtime/test_panel_outbox_db.py
@@ -76,6 +76,6 @@ def test_panel_runtime_enqueues_db_outbox(monkeypatch, tmp_path) -> None:
         cur = conn.cursor()
         cur.execute("select count(*) from outbox where topic = %s", ("promote.intent.created",))
         row = cur.fetchone()
-        assert row and int(row[0]) >= 1
+        assert row and int(outbox_service._row_value(row, 0)) >= 1
     finally:
         conn.close()

--- a/tests/services/test_outbox_conn_binding.py
+++ b/tests/services/test_outbox_conn_binding.py
@@ -1,0 +1,124 @@
+"""Regression coverage for #3930: the outbox service binds the real DB helpers.
+
+``from app.db import conn_rw`` resolves through ``app/db/__init__.py::__getattr__``
+to the permanent psycopg-free smoke stub in ``app/db/sqlalchemy.py`` (#30), whose
+``conn_rw`` always raises ``RuntimeError`` and whose ``ensure_schema`` is a no-op.
+``_open_conn``'s ``except Exception: pass`` swallowed that raise, so every
+self-opened outbox connection silently fell through to the plain
+``psycopg.connect(url, autocommit=True)`` env fallback: the canonical
+``app.db.db.conn_rw`` path (canonical DSN resolution, dict_row cursors) was dead
+code from this call site — the same defect class ``app/services/vault_sync.py``
+fixed in #2937 (see its import NOTE).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import app.db.db as db_module
+from app.services import outbox as outbox_service
+
+pytestmark = pytest.mark.not_pg
+
+
+class _FakeConn:
+    def __init__(self) -> None:
+        self.autocommit = False
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_outbox_service_binds_real_db_helpers() -> None:
+    """The service must bind app.db.db, not the smoke stub (#3930).
+
+    On the defective import the stub's ``conn_rw`` raised on every call and the
+    stub's ``ensure_schema`` no-op silently defeated the KERNEL-05 (#2850)
+    "a failure here must surface" intent inside ``bootstrap()``.
+    """
+    assert outbox_service.conn_rw is db_module.conn_rw
+    assert outbox_service.ensure_schema is db_module.ensure_schema
+
+
+def test_open_conn_prefers_real_conn_rw_autocommit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``_open_conn`` returns the canonical connection switched to autocommit.
+
+    Self-opened callers in the service are single-statement and never call
+    ``commit()``; psycopg3 rolls back uncommitted work on ``close()``, so the
+    manual-commit connection ``conn_rw`` returns must be flipped to autocommit
+    here or every self-opened write would be silently lost.
+    """
+    fake = _FakeConn()
+    monkeypatch.setattr(outbox_service, "conn_rw", lambda *a, **k: fake)
+
+    conn = outbox_service._open_conn()
+
+    assert conn is fake
+    assert conn.autocommit is True
+
+
+def test_open_conn_falls_back_when_conn_rw_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failing canonical helper degrades to the env-DSN fallback, not an error.
+
+    With no DATABASE_URL/DB_DSN configured the fallback's own fail-loud error
+    is the observable proof that the fallback path was reached instead of the
+    conn_rw exception propagating.
+    """
+
+    def _raise() -> Any:
+        raise RuntimeError("simulated conn_rw outage")
+
+    monkeypatch.setattr(outbox_service, "conn_rw", _raise)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_DSN", raising=False)
+
+    with pytest.raises(RuntimeError, match="DATABASE_URL or DB_DSN not set"):
+        outbox_service._open_conn()
+
+
+def test_open_outbox_txn_conn_requires_explicit_db_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without explicit DB env the txn helper degrades to None and never dials out.
+
+    ``conn_rw`` falls back to ``settings.db_dsn`` when the environment names no
+    database, which could reach a real local Postgres a test run never asked
+    for — the explicit-env gate keeps non-pg runs hermetic.
+    """
+
+    def _boom() -> Any:  # pragma: no cover - the assertion is that this never runs
+        raise AssertionError("conn_rw must not be called without explicit DB env")
+
+    monkeypatch.setattr(outbox_service, "conn_rw", _boom)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_DSN", raising=False)
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+
+    assert outbox_service.open_outbox_txn_conn() is None
+
+
+def test_open_outbox_txn_conn_returns_manual_commit_conn(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With explicit DB env the txn helper hands back conn_rw's manual-commit conn."""
+    fake = _FakeConn()
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused-in-test")
+    monkeypatch.setattr(outbox_service, "conn_rw", lambda *a, **k: fake)
+
+    conn = outbox_service.open_outbox_txn_conn()
+
+    assert conn is fake
+    assert conn.autocommit is False
+
+
+def test_open_outbox_txn_conn_degrades_to_none_on_connect_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A connect failure yields None (degraded per-call path), never an exception."""
+
+    def _raise() -> Any:
+        raise RuntimeError("simulated connect failure")
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused-in-test")
+    monkeypatch.setattr(outbox_service, "conn_rw", _raise)
+
+    assert outbox_service.open_outbox_txn_conn() is None

--- a/tests/services/test_outbox_conn_binding.py
+++ b/tests/services/test_outbox_conn_binding.py
@@ -122,3 +122,50 @@ def test_open_outbox_txn_conn_degrades_to_none_on_connect_failure(
     monkeypatch.setattr(outbox_service, "conn_rw", _raise)
 
     assert outbox_service.open_outbox_txn_conn() is None
+
+
+def test_open_outbox_txn_conn_logs_when_db_configured_but_conn_rw_fails(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A conn_rw() failure with DB explicitly configured is logged (#3930 round-2 review).
+
+    Distinguishes this case from the silent, expected short-circuit below: a
+    live worker whose canonical helper breaks while its DSN stays reachable
+    (poll/ack still succeed via `_open_conn`'s fallback) would otherwise
+    silently and permanently revert to the non-atomic per-call bookkeeping
+    this module exists to eliminate, indistinguishable from "DB unconfigured".
+    """
+
+    def _raise() -> Any:
+        raise RuntimeError("simulated connect failure")
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused-in-test")
+    monkeypatch.setattr(outbox_service, "conn_rw", _raise)
+
+    with caplog.at_level("WARNING", logger="app.services.outbox"):
+        assert outbox_service.open_outbox_txn_conn() is None
+
+    assert any("conn_rw" in record.message for record in caplog.records)
+
+
+def test_open_outbox_txn_conn_env_unconfigured_short_circuit_is_silent(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The expected 'DB not configured' short-circuit stays silent (no log spam).
+
+    Guards against the logging fix above firing on every non-pg test run,
+    where DATABASE_URL/DB_DSN are deliberately unset.
+    """
+
+    def _boom() -> Any:  # pragma: no cover - the assertion is that this never runs
+        raise AssertionError("conn_rw must not be called when the env gate short-circuits")
+
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_DSN", raising=False)
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setattr(outbox_service, "conn_rw", _boom)
+
+    with caplog.at_level("WARNING", logger="app.services.outbox"):
+        assert outbox_service.open_outbox_txn_conn() is None
+
+    assert caplog.records == []

--- a/tests/workers/test_outbox_worker_poison_txn.py
+++ b/tests/workers/test_outbox_worker_poison_txn.py
@@ -1,0 +1,441 @@
+"""Atomic poison-path bookkeeping for #3930.
+
+With per-call autocommit connections, ``run()``'s failure path committed
+``bump_outbox_attempts``, the dead-letter audit insert, and ``ack_outbox`` as
+three independent transactions. A worker crash between them stranded partial
+durable state: a row durably ``attempts == max`` yet undelivered, one extra
+dispatch attempt past the configured budget on restart, and a duplicate
+dead-letter audit row under the next attempt-scoped idempotency key
+(``poison:<n+1>``) inflating ``dead_letter_stats()``.
+
+These tests drive the production ``run()``/``run_once()`` paths against an
+in-memory connection that models real transaction semantics (staged writes
+become durable only on ``commit()``; ``close()`` rolls back like psycopg3) and
+lock in the #3930 contract:
+
+1. bump + dead-letter + ack commit as ONE transaction on ONE connection;
+2. a crash before the final commit leaves NO partial durable state;
+3. below the poison threshold the bump alone commits durably before the
+   crash-retry re-raise (the budget survives supervised restarts, #2252);
+4. the dead-letter DB write stays best-effort (savepoint): its failure never
+   blocks the ack;
+5. the schema-violation dead-letter+ack pair shares the same mechanism.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+
+from app.events.types import INGEST_VAULT_CHANGED
+from app.workers import outbox_worker
+
+pytestmark = pytest.mark.not_pg
+
+
+class _FakeCursor:
+    def __init__(self, rows: list[tuple]):
+        self._rows = rows
+
+    def fetchone(self):
+        return self._rows[0] if self._rows else None
+
+    def fetchall(self):
+        return list(self._rows)
+
+
+class FakeTxnConn:
+    """In-memory ``outbox`` table with explicit transaction semantics.
+
+    Unlike the autocommit-shaped fakes elsewhere in the suite, writes are
+    staged per transaction and become durable only on ``commit()``;
+    ``close()`` with a pending transaction rolls back (psycopg3 behavior).
+    ``transaction()`` models a savepoint: on exception the staged state is
+    restored to the snapshot and the exception re-raised.
+    """
+
+    def __init__(self, rows: list[dict[str, Any]] | None = None) -> None:
+        self.committed: dict[str, dict[str, Any]] = {r["id"]: dict(r) for r in (rows or [])}
+        self.pending: dict[str, dict[str, Any]] | None = None
+        self.ops: list[str] = []
+        self.commits = 0
+        self.closes = 0
+        self.fail_on: set[str] = set()
+        self.autocommit = False
+
+    def _staged(self) -> dict[str, dict[str, Any]]:
+        if self.pending is None:
+            self.pending = copy.deepcopy(self.committed)
+            self.ops.append("begin")
+        return self.pending
+
+    def execute(self, sql: str, params: tuple = ()) -> _FakeCursor:
+        text = " ".join(sql.lower().split())
+        rows = self._staged()
+
+        if text.startswith("update outbox set attempts"):
+            self.ops.append("bump")
+            if "bump" in self.fail_on:
+                raise RuntimeError("injected bump failure")
+            row = rows.get(params[0])
+            if row and row["delivered_at"] is None:
+                row["attempts"] = int(row.get("attempts", 0)) + 1
+                return _FakeCursor([(row["attempts"],)])
+            return _FakeCursor([])
+
+        if text.startswith("insert into outbox"):
+            self.ops.append("dead_letter_insert")
+            if "dead_letter_insert" in self.fail_on:
+                raise RuntimeError("injected dead-letter insert failure")
+            row_id, topic, payload, created_at, attempts = params
+            if row_id in rows:
+                return _FakeCursor([])
+            rows[row_id] = {
+                "id": row_id,
+                "topic": topic,
+                "payload": payload,
+                "created_at": created_at,
+                "delivered_at": None,
+                "attempts": attempts,
+            }
+            return _FakeCursor([(row_id,)])
+
+        if text.startswith("update outbox set delivered_at"):
+            self.ops.append("ack")
+            if "ack" in self.fail_on:
+                raise RuntimeError("injected ack failure")
+            row = rows.get(params[0])
+            if row and row["delivered_at"] is None:
+                row["delivered_at"] = "acked"
+                return _FakeCursor([(1,)])
+            return _FakeCursor([])
+
+        return _FakeCursor([])
+
+    def commit(self) -> None:
+        self.ops.append("commit")
+        self.commits += 1
+        if self.pending is not None:
+            self.committed = self.pending
+            self.pending = None
+
+    def rollback(self) -> None:
+        self.ops.append("rollback")
+        self.pending = None
+
+    @contextmanager
+    def transaction(self) -> Iterator[None]:
+        # psycopg3 semantics: the outermost block (no transaction in progress)
+        # BEGINs and commits on clean exit / rolls back on exception; a nested
+        # block (transaction already open) only creates a savepoint and never
+        # commits the outer transaction.
+        outermost = self.pending is None
+        snapshot = copy.deepcopy(self._staged())
+        self.ops.append("txn_begin" if outermost else "savepoint")
+        try:
+            yield
+        except Exception:
+            if outermost:
+                self.rollback()
+            else:
+                self.pending = snapshot
+            raise
+        else:
+            if outermost:
+                self.commit()
+
+    def close(self) -> None:
+        self.closes += 1
+        if self.pending is not None:
+            self.ops.append("rollback_on_close")
+            self.pending = None
+
+    # Test helpers
+    def committed_row(self, row_id: str) -> dict[str, Any]:
+        return self.committed[row_id]
+
+    def committed_dead_letters(self) -> list[dict[str, Any]]:
+        return [
+            r
+            for r in self.committed.values()
+            if r["topic"] == outbox_worker.OUTBOX_EVENT_DEAD_LETTERED
+        ]
+
+
+def _wire_worker_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    conn: FakeTxnConn,
+    *,
+    max_attempts: int,
+) -> None:
+    vault = tmp_path / "selected-vault"
+    vault.mkdir(exist_ok=True)
+    monkeypatch.setenv("VAULT_ROOT", str(vault))
+    monkeypatch.delenv("WATCHER_VAULT_PATH", raising=False)
+    # _use_db_outbox() must be true so the dead-letter audit takes the DB
+    # branch; the value is never dialed (every connection is the fake).
+    monkeypatch.setenv("DATABASE_URL", "postgresql://unused-in-test")
+    # The JSONL audit sink defaults to /app/tmp, which does not exist here; a
+    # failing JSONL append would swallow the DB write this test asserts on.
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(tmp_path / "index-outbox.jsonl"))
+    monkeypatch.setenv("WORKER_MAX_DISPATCH_ATTEMPTS", str(max_attempts))
+    monkeypatch.setattr(outbox_worker, "bootstrap", lambda: None)
+    monkeypatch.setattr(outbox_worker, "write_worker_heartbeat", lambda **_: None)
+    monkeypatch.setattr(outbox_worker, "open_outbox_txn_conn", lambda: conn)
+    outbox_worker._EVENT_DEDUP._seen.clear()
+
+
+def _poison_message() -> dict[str, Any]:
+    return {
+        "id": "row-poison",
+        "topic": INGEST_VAULT_CHANGED,
+        "payload": {"trace_id": "trace-poison"},
+    }
+
+
+def _run_one_tick(monkeypatch: pytest.MonkeyPatch, message: dict[str, Any]) -> None:
+    messages = [message]
+    monkeypatch.setattr(
+        outbox_worker, "poll_outbox_one", lambda: messages.pop(0) if messages else None
+    )
+    outbox_worker.run(
+        interval=0.0,
+        heartbeat_interval=9999,
+        log_heartbeat_interval=None,
+        stop_after_ticks=1,
+    )
+
+
+def test_poison_path_commits_bump_dead_letter_ack_in_one_transaction(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """At the attempt cap, bump + dead-letter + ack commit once, together."""
+    conn = FakeTxnConn(
+        rows=[
+            {
+                "id": "row-poison",
+                "topic": INGEST_VAULT_CHANGED,
+                "payload": "{}",
+                "created_at": "t0",
+                "delivered_at": None,
+                "attempts": 0,
+            }
+        ]
+    )
+    _wire_worker_env(monkeypatch, tmp_path, conn, max_attempts=1)
+
+    def _permanent_failure(*_a: Any, **_k: Any) -> None:
+        raise ValueError("permanent poison payload")
+
+    monkeypatch.setattr(outbox_worker, "_dispatch_topic", _permanent_failure)
+
+    _run_one_tick(monkeypatch, _poison_message())
+
+    assert conn.commits == 1
+    assert conn.ops.count("commit") == 1
+    # All three statements ran on this single connection, in order, with the
+    # only commit after the ack — no independent transaction per statement.
+    assert (
+        conn.ops.index("bump")
+        < conn.ops.index("dead_letter_insert")
+        < conn.ops.index("ack")
+        < conn.ops.index("commit")
+    )
+    assert conn.closes >= 1
+
+    row = conn.committed_row("row-poison")
+    assert row["attempts"] == 1
+    assert row["delivered_at"] is not None
+    dead_letters = conn.committed_dead_letters()
+    assert len(dead_letters) == 1
+    stored = json.loads(dead_letters[0]["payload"])
+    assert stored["payload"]["outbox_id"] == "row-poison"
+    assert stored["payload"]["reason"] == "dispatch_failed:ValueError"
+    assert stored["payload"]["attempts"] == 1
+
+
+def test_poison_path_crash_before_commit_leaves_no_partial_state(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A crash between the statements rolls the whole cycle back.
+
+    With the historical per-call autocommit connections this scenario left the
+    row durably ``attempts == max`` yet undelivered and, on the next cycle,
+    produced a second dead-letter audit row under ``poison:<n+1>``.
+    """
+    conn = FakeTxnConn(
+        rows=[
+            {
+                "id": "row-poison",
+                "topic": INGEST_VAULT_CHANGED,
+                "payload": "{}",
+                "created_at": "t0",
+                "delivered_at": None,
+                "attempts": 0,
+            }
+        ]
+    )
+    conn.fail_on = {"ack"}
+    _wire_worker_env(monkeypatch, tmp_path, conn, max_attempts=1)
+
+    def _permanent_failure(*_a: Any, **_k: Any) -> None:
+        raise ValueError("permanent poison payload")
+
+    monkeypatch.setattr(outbox_worker, "_dispatch_topic", _permanent_failure)
+
+    with pytest.raises(RuntimeError, match="injected ack failure"):
+        _run_one_tick(monkeypatch, _poison_message())
+
+    # Nothing became durable: no commit, bump rolled back, no dead-letter row,
+    # row still pending — the restarted worker retries the whole cycle cleanly.
+    assert conn.commits == 0
+    row = conn.committed_row("row-poison")
+    assert row["attempts"] == 0
+    assert row["delivered_at"] is None
+    assert conn.committed_dead_letters() == []
+
+
+def test_below_threshold_bump_commits_before_reraise(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Below the cap the bump alone commits durably before the crash-retry.
+
+    The re-raise models the supervised restart (#2252); losing the bump with it
+    would reset the poison budget and reintroduce the infinite crash-loop.
+    """
+    conn = FakeTxnConn(
+        rows=[
+            {
+                "id": "row-poison",
+                "topic": INGEST_VAULT_CHANGED,
+                "payload": "{}",
+                "created_at": "t0",
+                "delivered_at": None,
+                "attempts": 0,
+            }
+        ]
+    )
+    _wire_worker_env(monkeypatch, tmp_path, conn, max_attempts=3)
+
+    def _permanent_failure(*_a: Any, **_k: Any) -> None:
+        raise ValueError("permanent poison payload")
+
+    monkeypatch.setattr(outbox_worker, "_dispatch_topic", _permanent_failure)
+
+    with pytest.raises(ValueError, match="permanent poison payload"):
+        _run_one_tick(monkeypatch, _poison_message())
+
+    assert conn.commits == 1
+    assert "dead_letter_insert" not in conn.ops
+    assert "ack" not in conn.ops
+    row = conn.committed_row("row-poison")
+    assert row["attempts"] == 1
+    assert row["delivered_at"] is None
+    assert conn.committed_dead_letters() == []
+
+
+def test_dead_letter_db_failure_does_not_block_ack(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The dead-letter DB write stays best-effort on the shared transaction.
+
+    Its failure rolls back only the savepoint; the bump and the ack still
+    commit, so a broken audit write can never wedge the queue (the documented
+    KERNEL dead-letter contract).
+    """
+    conn = FakeTxnConn(
+        rows=[
+            {
+                "id": "row-poison",
+                "topic": INGEST_VAULT_CHANGED,
+                "payload": "{}",
+                "created_at": "t0",
+                "delivered_at": None,
+                "attempts": 0,
+            }
+        ]
+    )
+    conn.fail_on = {"dead_letter_insert"}
+    _wire_worker_env(monkeypatch, tmp_path, conn, max_attempts=1)
+
+    def _permanent_failure(*_a: Any, **_k: Any) -> None:
+        raise ValueError("permanent poison payload")
+
+    monkeypatch.setattr(outbox_worker, "_dispatch_topic", _permanent_failure)
+
+    _run_one_tick(monkeypatch, _poison_message())
+
+    assert "savepoint" in conn.ops
+    assert conn.commits == 1
+    row = conn.committed_row("row-poison")
+    assert row["attempts"] == 1
+    assert row["delivered_at"] is not None
+    assert conn.committed_dead_letters() == []
+
+
+def test_schema_violation_dead_letter_and_ack_share_transaction(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The immediate dead-letter branches pair audit + ack in one transaction.
+
+    Uses ``run_once`` with a registered-schema violation (KERNEL-08 shape from
+    ``tests/workers/test_outbox_worker.py``); ``run()``'s matching branch
+    shares the same helper.
+    """
+    from app.events.models import new_event
+
+    conn = FakeTxnConn(
+        rows=[
+            {
+                "id": "row-schema-violation",
+                "topic": "index.embedding.requested",
+                "payload": "{}",
+                "created_at": "t0",
+                "delivered_at": None,
+                "attempts": 0,
+            }
+        ]
+    )
+    _wire_worker_env(monkeypatch, tmp_path, conn, max_attempts=3)
+
+    # index.embedding.requested.v1 requires payload.object_id; this payload lacks it.
+    bad_payload = {"not_object_id": "x"}
+    tagged_event = new_event(
+        event_type="index.embedding.requested",
+        payload=bad_payload,
+        meta={"payload_schema": "index.embedding.requested.v1"},
+    )
+    message = {
+        "id": "row-schema-violation",
+        "topic": "index.embedding.requested",
+        "payload": bad_payload,
+        "event": tagged_event,
+    }
+    monkeypatch.setattr(outbox_worker, "poll_outbox_one", lambda: message)
+
+    def _fail_handler(*_a: Any, **_k: Any) -> None:  # pragma: no cover - must never run
+        raise AssertionError("real topic handler must not run on a schema violation")
+
+    monkeypatch.setattr(outbox_worker, "process_indexer_event", _fail_handler)
+
+    result = outbox_worker.run_once(vault_root=None)
+
+    assert result.state == "processed"
+    assert conn.commits == 1
+    assert "bump" not in conn.ops  # no poison budget spent on the first attempt
+    assert (
+        conn.ops.index("dead_letter_insert") < conn.ops.index("ack") < conn.ops.index("commit")
+    )
+    row = conn.committed_row("row-schema-violation")
+    assert row["delivered_at"] is not None
+    dead_letters = conn.committed_dead_letters()
+    assert len(dead_letters) == 1
+    stored = json.loads(dead_letters[0]["payload"])
+    assert stored["payload"]["reason"] == "schema_violation"
+    assert stored["payload"]["outbox_id"] == "row-schema-violation"

--- a/tests/workers/test_outbox_worker_poison_txn.py
+++ b/tests/workers/test_outbox_worker_poison_txn.py
@@ -316,10 +316,14 @@ def test_poison_path_commit_failure_does_not_mask_original_error(
 ) -> None:
     """Same guarantee as above, triggered by a commit failure instead of an ack failure.
 
-    Regression for round-2 #3930 review: an unguarded ``conn.commit()`` after
-    a successful ack could raise and mask ``handler_exc`` (the real dispatch
-    error) with an unrelated commit-failure exception by the time it reached
-    the worker's crash-retry re-raise.
+    Closes a coverage gap round-2 #3930 review flagged: the round-1 fix added
+    ``_commit_or_log`` (guarding ``conn.commit()`` so a failure there can't
+    mask ``handler_exc``, the real dispatch error, with an unrelated
+    commit-failure exception by the time it reaches the worker's crash-retry
+    re-raise) but shipped with no test exercising the failure branch itself —
+    only the round-2 ack-failure fix (the test above) was regression-tested.
+    This test exercises ``_ack_and_commit_or_log`` specifically (the at-cap
+    path); the sibling below asserts the same for below-cap's ``_commit_or_log``.
     """
     conn = FakeTxnConn(
         rows=[
@@ -356,8 +360,10 @@ def test_below_threshold_commit_failure_does_not_mask_original_error(
 ) -> None:
     """Below the cap, a failed bump-commit still lets the original dispatch error propagate.
 
-    Exercises ``_commit_or_log`` (not ``_ack_and_commit_or_log``): only the
-    attempts bump is committed below the poison cap.
+    Closes the same round-2-flagged coverage gap as the at-cap test above, for
+    ``_commit_or_log``'s below-cap call site (only the attempts bump is
+    committed below the poison cap; ``_ack_and_commit_or_log`` is not
+    involved here).
     """
     conn = FakeTxnConn(
         rows=[

--- a/tests/workers/test_outbox_worker_poison_txn.py
+++ b/tests/workers/test_outbox_worker_poison_txn.py
@@ -119,6 +119,8 @@ class FakeTxnConn:
 
     def commit(self) -> None:
         self.ops.append("commit")
+        if "commit" in self.fail_on:
+            raise RuntimeError("injected commit failure")
         self.commits += 1
         if self.pending is not None:
             self.committed = self.pending
@@ -268,6 +270,14 @@ def test_poison_path_crash_before_commit_leaves_no_partial_state(
     With the historical per-call autocommit connections this scenario left the
     row durably ``attempts == max`` yet undelivered and, on the next cycle,
     produced a second dead-letter audit row under ``poison:<n+1>``.
+
+    The ack itself is the injected failure here (round-2 #3930 review): an
+    unguarded ``ack_outbox(conn, message_id)`` would previously let this
+    "injected ack failure" propagate and mask the real dispatch error
+    (``ValueError("permanent poison payload")``) by the time it reached the
+    worker's crash-retry re-raise. The fix (``_ack_and_commit_or_log``) logs
+    the ack failure and lets the original dispatch error propagate instead —
+    asserted below by matching on that original error, not the ack failure.
     """
     conn = FakeTxnConn(
         rows=[
@@ -289,7 +299,7 @@ def test_poison_path_crash_before_commit_leaves_no_partial_state(
 
     monkeypatch.setattr(outbox_worker, "_dispatch_topic", _permanent_failure)
 
-    with pytest.raises(RuntimeError, match="injected ack failure"):
+    with pytest.raises(ValueError, match="permanent poison payload"):
         _run_one_tick(monkeypatch, _poison_message())
 
     # Nothing became durable: no commit, bump rolled back, no dead-letter row,
@@ -299,6 +309,82 @@ def test_poison_path_crash_before_commit_leaves_no_partial_state(
     assert row["attempts"] == 0
     assert row["delivered_at"] is None
     assert conn.committed_dead_letters() == []
+
+
+def test_poison_path_commit_failure_does_not_mask_original_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Same guarantee as above, triggered by a commit failure instead of an ack failure.
+
+    Regression for round-2 #3930 review: an unguarded ``conn.commit()`` after
+    a successful ack could raise and mask ``handler_exc`` (the real dispatch
+    error) with an unrelated commit-failure exception by the time it reached
+    the worker's crash-retry re-raise.
+    """
+    conn = FakeTxnConn(
+        rows=[
+            {
+                "id": "row-poison",
+                "topic": INGEST_VAULT_CHANGED,
+                "payload": "{}",
+                "created_at": "t0",
+                "delivered_at": None,
+                "attempts": 0,
+            }
+        ]
+    )
+    conn.fail_on = {"commit"}
+    _wire_worker_env(monkeypatch, tmp_path, conn, max_attempts=1)
+
+    def _permanent_failure(*_a: Any, **_k: Any) -> None:
+        raise ValueError("permanent poison payload")
+
+    monkeypatch.setattr(outbox_worker, "_dispatch_topic", _permanent_failure)
+
+    with pytest.raises(ValueError, match="permanent poison payload"):
+        _run_one_tick(monkeypatch, _poison_message())
+
+    assert conn.commits == 0
+    row = conn.committed_row("row-poison")
+    assert row["attempts"] == 0
+    assert row["delivered_at"] is None
+    assert conn.committed_dead_letters() == []
+
+
+def test_below_threshold_commit_failure_does_not_mask_original_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Below the cap, a failed bump-commit still lets the original dispatch error propagate.
+
+    Exercises ``_commit_or_log`` (not ``_ack_and_commit_or_log``): only the
+    attempts bump is committed below the poison cap.
+    """
+    conn = FakeTxnConn(
+        rows=[
+            {
+                "id": "row-poison",
+                "topic": INGEST_VAULT_CHANGED,
+                "payload": "{}",
+                "created_at": "t0",
+                "delivered_at": None,
+                "attempts": 0,
+            }
+        ]
+    )
+    conn.fail_on = {"commit"}
+    _wire_worker_env(monkeypatch, tmp_path, conn, max_attempts=3)
+
+    def _permanent_failure(*_a: Any, **_k: Any) -> None:
+        raise ValueError("permanent poison payload")
+
+    monkeypatch.setattr(outbox_worker, "_dispatch_topic", _permanent_failure)
+
+    with pytest.raises(ValueError, match="permanent poison payload"):
+        _run_one_tick(monkeypatch, _poison_message())
+
+    assert conn.commits == 0
+    row = conn.committed_row("row-poison")
+    assert row["attempts"] == 0
 
 
 def test_below_threshold_bump_commits_before_reraise(

--- a/tests/workers/test_outbox_worker_poison_txn_pg.py
+++ b/tests/workers/test_outbox_worker_poison_txn_pg.py
@@ -1,0 +1,152 @@
+"""Real-Postgres atomicity of the poison-path bookkeeping (#3930).
+
+Ground truth for what the fake-conn tests in
+``tests/workers/test_outbox_worker_poison_txn.py`` model: against a live
+migrated database, a crash injected between the poison-path statements must
+leave NO partial durable state (the bump, the dead-letter audit row, and the
+ack are one transaction), and the recovery run must dead-letter exactly once.
+
+Scratch-database fixture mirrors
+``tests/services/test_outbox_bootstrap_assert_only.py``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from typing import Any
+
+import psycopg
+import pytest
+
+from app.workers import outbox_worker
+
+pytestmark = pytest.mark.pg
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture
+def scratch_db(monkeypatch: pytest.MonkeyPatch):
+    """A throwaway database at `alembic upgrade head`, wired into DATABASE_URL."""
+    from app.db.dsn import resolve_dsn
+
+    admin_dsn = resolve_dsn()
+    if not admin_dsn:
+        pytest.skip("DATABASE_URL/DB_DSN not configured")
+    try:
+        probe = psycopg.connect(admin_dsn, connect_timeout=2)
+    except Exception as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"Postgres unavailable: {exc}")
+    probe.close()
+
+    name = f"scratch_outbox_poisontxn_{uuid.uuid4().hex[:12]}"
+    with psycopg.connect(admin_dsn, autocommit=True) as conn:
+        conn.execute(f'CREATE DATABASE "{name}"')
+    base, _, _ = admin_dsn.rpartition("/")
+    dsn = f"{base}/{name}"
+
+    from alembic import command
+    from alembic.config import Config
+
+    monkeypatch.setenv("DATABASE_URL", dsn)
+    monkeypatch.delenv("DB_DSN", raising=False)
+    # An earlier migration declares `embedding VECTOR`, so pgvector must exist.
+    with psycopg.connect(dsn, autocommit=True) as conn:
+        conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
+    cfg = Config(str(REPO_ROOT / "alembic.ini"))
+    cfg.set_main_option("script_location", str(REPO_ROOT / "app" / "alembic"))
+    command.upgrade(cfg, "head")
+
+    yield dsn
+
+    try:
+        with psycopg.connect(admin_dsn, autocommit=True) as conn:
+            conn.execute(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)')
+    except Exception:
+        pass
+
+
+def _run_one_tick() -> None:
+    outbox_worker.run(
+        interval=0.0,
+        heartbeat_interval=9999,
+        log_heartbeat_interval=None,
+        stop_after_ticks=1,
+    )
+
+
+def test_poison_bookkeeping_atomic_pg(
+    scratch_db: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Crash between poison-path statements => full rollback; recovery => exactly once."""
+    from app.events.models import new_event
+    from app.services import outbox as outbox_service
+
+    vault = tmp_path / "selected-vault"
+    vault.mkdir()
+    monkeypatch.setenv("VAULT_ROOT", str(vault))
+    monkeypatch.delenv("WATCHER_VAULT_PATH", raising=False)
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(tmp_path / "index-outbox.jsonl"))
+    monkeypatch.setenv("WORKER_MAX_DISPATCH_ATTEMPTS", "1")
+    monkeypatch.setattr(outbox_worker, "write_worker_heartbeat", lambda **_: None)
+
+    payload = {"vault_path": "x.md", "relative_path": "x.md", "mtime": 1.0, "hash": "h"}
+    event = new_event(event_type="ingest.vault.changed", payload=payload, trace_id="trace-pg")
+    key = outbox_service.derive_idempotency_key(
+        "ingest.vault.changed", "x.md", outbox_service.payload_fingerprint(payload)
+    )
+    row_id = outbox_service.write_outbox_event(event, idempotency_key=key)
+    assert row_id
+
+    def _permanent_failure(*_a: Any, **_k: Any) -> None:
+        raise ValueError("permanent poison payload")
+
+    monkeypatch.setattr(outbox_worker, "_dispatch_topic", _permanent_failure)
+
+    real_ack = outbox_worker.ack_outbox
+
+    def _crash_after_ack(*args: Any, **kwargs: Any) -> Any:
+        real_ack(*args, **kwargs)
+        raise RuntimeError("injected crash before commit")
+
+    monkeypatch.setattr(outbox_worker, "ack_outbox", _crash_after_ack)
+    outbox_worker._EVENT_DEDUP._seen.clear()
+
+    with pytest.raises(RuntimeError, match="injected crash before commit"):
+        _run_one_tick()
+
+    # Ground truth after the crash: the whole cycle rolled back. No stranded
+    # attempts bookkeeping, no ack, no dead-letter audit row.
+    with psycopg.connect(scratch_db) as conn:
+        row = conn.execute(
+            "select attempts, delivered_at from outbox where id = %s", (row_id,)
+        ).fetchone()
+        assert row == (0, None)
+        dl_count = conn.execute(
+            "select count(*) from outbox where topic = %s",
+            (outbox_worker.OUTBOX_EVENT_DEAD_LETTERED,),
+        ).fetchone()
+        assert dl_count == (0,)
+
+    # Recovery run (supervised restart): the row dead-letters exactly once.
+    monkeypatch.setattr(outbox_worker, "ack_outbox", real_ack)
+    outbox_worker._EVENT_DEDUP._seen.clear()
+    _run_one_tick()
+
+    with psycopg.connect(scratch_db) as conn:
+        row = conn.execute(
+            "select attempts, delivered_at from outbox where id = %s", (row_id,)
+        ).fetchone()
+        assert row is not None
+        assert row[0] == 1
+        assert row[1] is not None
+        dl_rows = conn.execute(
+            "select payload from outbox where topic = %s",
+            (outbox_worker.OUTBOX_EVENT_DEAD_LETTERED,),
+        ).fetchall()
+        assert len(dl_rows) == 1
+        stored = dl_rows[0][0]
+        assert stored["payload"]["outbox_id"] == str(row_id)
+        assert stored["payload"]["attempts"] == 1
+        assert stored["payload"]["reason"] == "dispatch_failed:ValueError"


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

Governing-Issue: #3930

## Linked Issue
Fixes #3930

## SBS Impact
- Primary subsystem: PDM (Persistence & Data Management — storage-technology abstraction seam, transactional write discipline)
- Secondary subsystem(s): OEF (dead-letter audit accuracy feeds `dead_letter_stats()` health signals)
- Write class: mechanical (machine-substrate transactional writes; no authority-bearing surface)
- Authority impact: none
- Persistence impact: durable (outbox row commit semantics; no schema change, no migration)
- Derived/rebuildable impact: dead-letter audit rows / health stats stop duplicating across crash windows
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: none (code-only; no image/dependency change)
- External boundary impact: none
- New or changed contract: none — conform (aligns implementation with the existing at-least-once, poison-budget #2252, dead-letter best-effort, and idempotency I-E1/KERNEL-02 contracts)
- Owner-doc impact: none (`docs/EVENTS.md` verified — it documents envelope/idempotency/dead-letter keying, not connection mechanics; no drift from this conform fix)
- Transition debt impact: reduces (removes a dead code path and a latent lost-write trap)
- Fitness rule impact: strengthens (adds an import-binding regression guard for the smoke-stub seam)
- Boundary risk: none (worker keeps zero direct `app.db` imports — the new transaction connection routes through the `app/services/outbox.py` helper, which is already allowlisted in `tests/guard/test_no_direct_db_imports.py`)

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Bind `app/services/outbox.py` to the real `app.db.db.conn_rw`/`ensure_schema` (the `app.db` package-root names resolve to the always-raising psycopg-free smoke stub from #30 — the same defect class vault_sync fixed in #2937). `_open_conn()` now prefers the canonical connection switched to autocommit (self-opened callers are single-statement and never commit; psycopg3 rolls back on close, so a bare manual-commit connection would silently lose writes); the plain env-DSN `psycopg.connect` remains as degradation only.
- Commit the worker's failure-path bookkeeping as ONE transaction on ONE canonical connection (`open_outbox_txn_conn`, explicit-env-gated to mirror `_use_db_outbox` and keep non-pg runs hermetic): below the poison cap the attempts bump commits alone (durable budget across supervised crash-retry, #2252); at the cap bump + dead-letter audit + ack commit together, eliminating the crash window that stranded `attempts == max` undelivered rows, overshot the attempt budget on restart, and duplicated dead-letter audit rows under `poison:<n+1>` keys. The uuid/schema-violation dead-letter+ack pairs in `run()` and `run_once()` share the same helper; the dead-letter DB write stays best-effort inside a savepoint (its failure can never wedge the ack). Degraded (no canonical connection) paths preserve today's exact per-call sequence.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed. (No contract changed; `docs/EVENTS.md` verified for drift — none. Module docstrings/comments updated in place.)
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality. (Not applicable — defect fix, no backlog item shipped.)

## Validation
Implementation lane:
- [x] `ruff check app tests` — All checks passed (ran as `ruff check app tests companion-ui/companion-app`, matching ci-smoke).
- [x] If files under `app/` or `tests/` changed, lint output from `ruff check app tests` is included below or a tooling limitation is stated.
- [x] `mypy app` — 1 pre-existing error in `app/dispatcher/control_plane.py:279` (file byte-identical to origin/main; untouched by this PR).
- [x] `pytest -q -m "not pg"` — full-tree run: 9597 passed, 53 skipped, 18 xfailed; 27 failures fully triaged: 16 were artifacts of the run racing an in-flight edit of `outbox_worker.py` (all green on deterministic rerun of exactly those files), 11 are pre-existing local-environment failures whose failure set is byte-identical on pristine origin/main with this PR's changes stashed (tests/deploy compose checks, watcher CLI, docs-index gates, release-channel harness, standing-questions format check). Run excluded `tests/api/test_companion_vault_settings.py`, a pre-existing whole-tree collection failure on machines without `pip install -e ".[dev]"` (`companion_ui` sys.path shim lives only in `tests/companion_ui/conftest.py`) — follow-up task filed. Two later full-tree reruns on this shared multi-agent laptop degraded into `OSError: Errno 24 Too many open files` cascades (415/509 occurrences, unrelated subsystems erroring at fixture setup); under the same machine conditions the affected blocks (tests/companion_ui + tests/workers + tests/worker + tests/cli, 2168 tests incl. every new test here) pass green in isolation with RC=0, confirming environmental fd exhaustion, not a regression. CI on this PR is the shared authoritative gate.
- [x] Additional targeted checks run as needed — test-first evidence: the 10 new non-pg regression tests fail on unchanged code (binding AttributeError/identity mismatch) and pass after the fix. New pg-marked ground-truth test `tests/workers/test_outbox_worker_poison_txn_pg.py::test_poison_bookkeeping_atomic_pg` (crash injected between poison-path statements → full rollback; recovery run → exactly one dead-letter row) is not runnable on this machine (no Postgres by design); it runs in the pg lanes (workflow_dispatch full suite / test-channel receipts at promote-to-test).

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded issue-backed defect fix; no operational material beyond standard GitHub receipts. The adjacent `companion_ui` pytest path-wiring finding was routed as a spawned follow-up task rather than bundled here.

## Notes
- Behavior note: the first `conn_rw()` per worker process now applies `app/db/migrations_obsidian.sql` at outbox-touch time (objects/file_state DDL only — it contains no outbox DDL, so the KERNEL-05 #2850 assert-only outbox posture is unchanged; `tests/services/test_outbox_bootstrap_assert_only.py` still holds). This matches what every other `conn_rw` consumer (audit, decisions, vault_sync, episode handlers — already imported inside this worker process) does today; it only moves the first-ensure earlier in the process lifetime.
- `bootstrap()`'s `ensure_schema(conn)` call is now genuinely the real implementation, making the KERNEL-05 "a failure here must surface" comment true (it silently bound the stub no-op before).
- Claim receipt: `pickup-claim-complete issue=3930 coordination_mode=github-label-only-fallback agent=claude-fable-wizardly-banach session=72307334-2259-4acb-a7e6-0e2478e452bd evidence=github-comment:4997446545`. Dispatcher unavailable for this freshly created issue (`dispatcher pull` failed: gh ready-issues endpoint HTTP 503) — GitHub-label-only claim per `AGENTS.md :: Dispatcher policy` fallback.
- Out of scope (per issue): happy-path poll/ack connection reuse across loop iterations; `app/db/__init__.py::__getattr__` smoke-seam redesign; deprecated `app/store/relation_index.py` (stub-bound but unreachable via live store resolution).

- CI note: the first CI run fail-closed in test selection (`select_pr_tests` exit 2: `app/services/outbox.py` had no subsystem owner). Fixed in-PR by extending the `outbox_worker` subsystem map to own the outbox service module and the new binding test — the entry's documented purpose; selector governance tests (70) pass.
