### PR TITLE
Fix full-suite collection: companion_ui importable from any test tree

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,19 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
 import pytest
+
+# companion_ui lives at companion-ui/companion-app, outside the rootdir pythonpath,
+# and is imported at module level by test trees beyond tests/companion_ui (tests/api,
+# tests/uat, tests/tts). It must be importable for every collection target and for
+# ini-less CI invocations (`pytest -c /dev/null`), which skip pytest.ini pythonpath
+# but still load this conftest.
+# See: https://github.com/RasmusTho/agentic-pkm-mvp/issues/3941
+_COMPANION_APP_ROOT = Path(__file__).resolve().parent / "companion-ui" / "companion-app"
+if str(_COMPANION_APP_ROOT) not in sys.path:
+    sys.path.insert(0, str(_COMPANION_APP_ROOT))
 
 
 def pytest_configure(config) -> None:

--- a/tests/architecture/test_companion_ui_sys_path.py
+++ b/tests/architecture/test_companion_ui_sys_path.py
@@ -1,0 +1,26 @@
+"""Regression for #3941: companion_ui must be importable from any test tree.
+
+The companion_ui package lives at companion-ui/companion-app/companion_ui,
+outside the rootdir pythonpath. Test trees beyond tests/companion_ui import it
+at module level (tests/api, tests/uat, tests/tts), so the root conftest.py must
+put companion-ui/companion-app on sys.path for every collection target — not
+just for runs that happen to pass through tests/companion_ui/conftest.py.
+
+The module-level import below is the regression: without the root-conftest
+guard, standalone collection of this file (like any out-of-tree importer)
+aborts with ModuleNotFoundError.
+"""
+from pathlib import Path
+
+import companion_ui
+
+
+def test_companion_ui_importable_from_any_test_tree() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    expected = (repo_root / "companion-ui" / "companion-app" / "companion_ui").resolve()
+    package_dirs = [Path(p).resolve() for p in companion_ui.__path__]
+    assert expected in package_dirs, (
+        "companion_ui resolved outside this checkout: "
+        f"{package_dirs} (expected {expected}); a machine-local install or an "
+        "absolute sys.path entry from another checkout is shadowing the repo copy"
+    )


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

Governing-Issue: #3941

## Linked Issue
Fixes #3941

## SBS Impact
- Primary subsystem: Builder System (test harness / collection wiring)
- Secondary subsystem(s): none
- Write class: mechanical
- Authority impact: none
- Persistence impact: none
- Derived/rebuildable impact: none
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: none
- External boundary impact: none
- New or changed contract: none
- Owner-doc impact: none
- Transition debt impact: reduces (single mechanism replaces reliance on scattered per-file sys.path hacks)
- Fitness rule impact: strengthens (new architecture regression test)
- Boundary risk: low — two-file test-infra change; no `app/` or runtime surface touched

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Hoist the `companion-ui/companion-app` sys.path guard from `tests/companion_ui/conftest.py` into the root `conftest.py` (checkout-relative, membership-guarded `insert(0)` — same idiom), so `companion_ui` is importable for every collection target in every checkout, including ini-less CI invocations (`pytest -c /dev/null`), which skip `pytest.ini pythonpath` but still load the root conftest.
- Add `tests/architecture/test_companion_ui_sys_path.py`: a module-level `companion_ui` import (red on main when run standalone — same ModuleNotFoundError that aborts the full suite) plus an assertion that the package resolves inside the current checkout, guarding against machine-local installs shadowing the repo copy.

Root cause (full diagnosis in #3941): #3706 added a module-level `companion_ui` import to `tests/api/test_companion_vault_settings.py`, which is outside the scope of the only conftest that provided the path — so `pytest -q -m "not pg"` aborted at collection (`Interrupted: 1 error during collection`) in every clean checkout of main. Stale long-lived checkouts masked it locally; CI never collects the full tree (backstop tracked in #3942).

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed (checkout-relative path only; existing per-file guards untouched and now no-ops; `--import-mode=importlib` and `app/` untouched; prepend semantics match the existing idiom).
- [x] Acceptance Criteria from the linked Issue are satisfied (AC receipts below).
- [x] Docs were updated in the same change when behavior/contracts changed. (No behavior/contract change — restores the documented gate.)
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality. (Not applicable — defect fix.)

## Validation
Implementation lane:
- [x] `ruff check app tests` — ran the repo-standard superset `ruff check app tests companion-ui/companion-app`: `All checks passed!`
- [x] Lint output included (above).
- [x] `mypy app` — `Success: no issues found in 757 source files`
- [x] `pytest -q -m "not pg"` — full suite on this branch (base 2af4f38a): `19 failed, 9617 passed, 50 skipped, 223 deselected, 18 xfailed in 19:01`. **All 19 failures are pre-existing and unrelated to this change**, proven by A/B baseline: the identical command on unfixed `origin/main` (2af4f38a) with only the collection-broken file `--ignore`d yields a **byte-identical FAILED set** (`19 failed, 9606 passed`); the A/B delta is exactly the +11 tests this PR restores/adds (10 in `tests/api/test_companion_vault_settings.py` + the new regression test), all passing. The 19 pre-existing failures are now tracked: 7 `tests/deploy/*` fail deterministically on docker-less machines (`FileNotFoundError: 'docker'` / exit 127 — #3945); 12 watcher/worker tests fail only under full-suite ordering (`ValueError: I/O operation on closed file` logging-stream pollution; pass targeted on both trees — #3946).
- [x] Additional targeted checks:
  - Test-first red receipt: standalone `pytest tests/architecture/test_companion_ui_sys_path.py` on unfixed tree → `ModuleNotFoundError: No module named 'companion_ui'`, `Interrupted: 1 error during collection`.
  - Post-fix: same command → `1 passed`; ini-less mode `pytest -c /dev/null --import-mode=importlib` → `1 passed`.
  - Symptom file: `pytest -q --collect-only tests/api/test_companion_vault_settings.py` → `10 tests collected`.
  - **AC2 fresh-worktree receipt:** `git worktree add --detach <tmp> b56d30c5`, then from that clean worktree with the shared venv python and **no PYTHONPATH**: `pytest -q --collect-only -m "not pg"` → exit 0, `9699/9922 tests collected (223 deselected) in 138.04s`; targeted symptom file → `10 tests collected`, exit 0. Throwaway worktree removed afterwards.
  - `RUN_INTEGRATED_RUNTIME_UAT=1` opt-in UAT not run: no vault/runtime hot-path surface touched (test-collection wiring only); `tests/uat` collection verified via the full-tree collect receipt.

## BuilderOps Routing
- Records/projections/receipts: `LearningSignal lrn_20260717081617_d165d105` (workflow_divergence: the mandated full "not pg" pre-PR gate was silently unenforceable on main for 2 days — no CI full-tree collection backstop; repair tracked as #3942).
- Reason: gate-divergence routed per the divergence checkpoint; no other operational material (diagnosis narrative lives in #3941).

## Notes
- Issue claim receipt: `scripts/issue_pickup_claim.sh` ran in github-label-only fallback (dispatcher queue had no task for the freshly created issue) — claimant comment `5000551457`, agent `claude-fable-3941`, session `gracious-saha-1fd897`, worktree `.claude/worktrees/gracious-saha-1fd897`; published from branch `fix-3941-companion-ui-collection-syspath` created off `origin/main` in that same dedicated worktree.
- Follow-up (out of scope here): #3942 adds a ci-smoke full-tree `--collect-only` gate so this class of breakage fails at PR time instead of in every agent's worktree.
- The three pre-existing per-file/per-directory guards remain in place as harmless no-ops per the Issue constraint; removing them is deferred cleanup.
- Residual risk: low. The guard prepends one directory; shadowing was checked in #3941 (`companion-app` exposes only `companion_ui`, `converse_layout_state`, and a non-importable `tests/fixtures/obsidian-renderer`; no submodule collision with rootdir `tests/fixtures/*`).
