### PR TITLE
fix: preserve promoted verifier replay identity

### DIFF
--- a/app/dispatcher/verification_dispatch.py
+++ b/app/dispatcher/verification_dispatch.py
@@ -1391,7 +1391,15 @@ class VerificationDispatchLedger:
                     existing, existing_request
                 )
                 incoming_closing = _request_closing_authority(request)
-                if set(incoming_closing) != set(stored_closing):
+                stored_supporting = _validated_supporting_authority(
+                    existing, existing_request
+                )
+                incoming_supporting = request.get("supporting_issues")
+                if (
+                    not isinstance(incoming_supporting, list)
+                    or set(incoming_supporting) != set(stored_supporting)
+                    or set(incoming_closing) != set(stored_closing)
+                ):
                     raise ValueError("verification idempotency authority conflict")
                 active_status = existing["status"] in {
                     "queued",
@@ -1413,11 +1421,7 @@ class VerificationDispatchLedger:
                             "verification canonical run governing issue mismatch"
                         )
                     raise ValueError("verification idempotency authority conflict")
-                if (
-                    active_status
-                    and existing["current_head_sha"]
-                    != request.get("current_head_sha")
-                ):
+                if existing["current_head_sha"] != request.get("current_head_sha"):
                     raise ValueError(
                         "verification artifact head does not match canonical run"
                     )

--- a/app/dispatcher/verification_dispatch.py
+++ b/app/dispatcher/verification_dispatch.py
@@ -859,13 +859,13 @@ def _live_takeover_authority_matches(
     )
 
 
-def _terminal_current_head_replay_matches(
+def _current_head_replay_authority_matches(
     observation: _LiveVerificationObservation | None,
     request: Mapping[str, object],
     candidate_request: Mapping[str, object],
     candidate_supporting: Sequence[int],
 ) -> bool:
-    """Recognize the authenticated current-head identity of a terminal chain."""
+    """Require exact durable and live authority for current-head replay."""
 
     incoming_supporting = request.get("supporting_issues")
     incoming_closing = _request_closing_authority(request)
@@ -1512,6 +1512,38 @@ class VerificationDispatchLedger:
                     assert reopened is not None
                     conn.commit()
                     return _run(reopened)
+                candidate_supporting = _validated_supporting_authority(
+                    candidate, candidate_request
+                )
+                candidate_closing = _validated_closing_authority(
+                    candidate, candidate_request
+                )
+                incoming_supporting = request.get("supporting_issues")
+                incoming_closing = _request_closing_authority(request)
+                if (
+                    not isinstance(incoming_supporting, list)
+                    or set(incoming_supporting) != set(candidate_supporting)
+                    or set(incoming_closing) != set(candidate_closing)
+                ):
+                    raise ValueError(
+                        "verification active replay authority does not match canonical run"
+                    )
+                if live_observation is not None:
+                    if not _canonical_chain_token_matches(
+                        conn, canonical_chain_token, request
+                    ):
+                        raise ValueError(
+                            "verification canonical authority changed during live observation"
+                        )
+                    if not _current_head_replay_authority_matches(
+                        live_observation,
+                        request,
+                        candidate_request,
+                        candidate_supporting,
+                    ):
+                        raise ValueError(
+                            "verification active replay authority does not match canonical run"
+                        )
                 conn.commit()
                 return _run(candidate)
             terminal_candidates = list(
@@ -1542,7 +1574,7 @@ class VerificationDispatchLedger:
                         raise ValueError(
                             "verification canonical authority changed during live observation"
                         )
-                    if not _terminal_current_head_replay_matches(
+                    if not _current_head_replay_authority_matches(
                         live_observation,
                         request,
                         candidate_request,

--- a/app/dispatcher/verification_dispatch.py
+++ b/app/dispatcher/verification_dispatch.py
@@ -1403,7 +1403,8 @@ class VerificationDispatchLedger:
                     existing["repository"] != request["repository"]
                     or existing["pr_number"] != request["pr_number"]
                     or existing["stage"] != request["stage"]
-                    or existing["head_sha"] != request["current_head_sha"]
+                    or existing_request["current_head_sha"]
+                    != request["current_head_sha"]
                 ):
                     raise ValueError("verification idempotency authority conflict")
                 if existing_request.get("linked_issue") != request.get("linked_issue"):

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -5,8 +5,8 @@ Owner: Delivery governance / multi-agent coordination
 Temporal class: operational
 Review cadence: event-driven
 Source of truth: mixed (GitHub issue contracts + repo governance docs)
-Last reviewed: 2026-07-16
-Last verified against: #3821, PR #3822 exact head `30e30830ea533a971fc7a39fb6fc2e4eded903d8`, `app/dispatcher/schema.py`, `app/dispatcher/verification_dispatch.py`, `app/dispatcher/verification_consumer.py`, `app/dispatcher/verified_merge.py`, `AGENTS.md`, and `.codex/skills/verification-and-closure/SKILL.md`
+Last reviewed: 2026-07-17
+Last verified against: #3821, PR #3949 delivery diff, `app/dispatcher/schema.py`, `app/dispatcher/verification_dispatch.py`, `app/dispatcher/verification_consumer.py`, `app/dispatcher/verified_merge.py`, `AGENTS.md`, and `.codex/skills/verification-and-closure/SKILL.md`
 
 # Agent Issue Dispatcher (MVP Contract)
 
@@ -102,7 +102,10 @@ The dispatcher is an operational coordination layer, not a lifecycle replacement
   terminal, restart and replay of the authenticated exact current-head identity returns the same
   terminal canonical run without changing the immutable original request/idempotency audit or creating
   another chain; governing or cumulative-authority drift still fails closed. The live observation
-  becomes mutation authority only for a different-head takeover.
+  becomes mutation authority only for a different-head takeover. An authenticated current-head
+  replay through a new idempotency identity, whether the chain is active or terminal, returns the
+  durable run only when the fresh observation and artifact exactly match its governing, cumulative
+  supporting, and closing authority; drift fails closed without ledger mutation.
 - Missing or pending checks and auth/rate limits enter time-bounded `backoff`; replay cannot launch
   before `retry_after`. Rate-limit classification requires either a structured `retry` receipt or the
   launcher's structured `failure_class=rate_limit`, derived once from a non-zero provider failure;

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -190,7 +190,9 @@ The dispatcher is an operational coordination layer, not a lifecycle replacement
   identity; the live row may later rebind to another freshly observed repair head without making
   the immutable archive unreadable or resetting the chain. An authenticated artifact for the
   immutable requested head or any unrelated head cannot create a parallel canonical run around a
-  recoverable inert repaired-head chain.
+  recoverable inert repaired-head chain. After promotion, an identical authenticated artifact
+  replays against the stored recovered-request head rather than the immutable legacy requested
+  head; once the active chain rebinds again, the older recovered-head artifact fails closed.
   Existing v1 recovery-audit receipts remain readable; ambiguity, drift, missing authentication,
   incompatible supporting authority, or any token mismatch is non-mutating and fail-closed.
   If normal stale-head handling supersedes a chain before the repaired-head artifact arrives, only

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -192,7 +192,9 @@ The dispatcher is an operational coordination layer, not a lifecycle replacement
   immutable requested head or any unrelated head cannot create a parallel canonical run around a
   recoverable inert repaired-head chain. After promotion, an identical authenticated artifact
   replays against the stored recovered-request head rather than the immutable legacy requested
-  head; once the active chain rebinds again, the older recovered-head artifact fails closed.
+  head only while its exact durable supporting and closing authority still match. Once the active
+  chain rebinds again, the older recovered-head artifact fails closed in both active and terminal
+  states.
   Existing v1 recovery-audit receipts remain readable; ambiguity, drift, missing authentication,
   incompatible supporting authority, or any token mismatch is non-mutating and fail-closed.
   If normal stale-head handling supersedes a chain before the repaired-head artifact arrives, only

--- a/tests/dispatcher/test_verification_dispatch.py
+++ b/tests/dispatcher/test_verification_dispatch.py
@@ -529,6 +529,95 @@ def test_promoted_legacy_v2_identical_replay_is_idempotent(tmp_path) -> None:
     assert _verification_state_snapshot(state) == terminal_snapshot
 
 
+@pytest.mark.parametrize("terminal", [False, True], ids=["active", "terminal"])
+@pytest.mark.parametrize("authority", ["supporting", "closing"])
+def test_post_rebind_promoted_legacy_current_head_replay_rejects_authority_drift(
+    tmp_path,
+    terminal: bool,
+    authority: str,
+) -> None:
+    promoted_head = "b" * 40
+    rebound_head = "c" * 40
+    initial = ledger(tmp_path)
+    run_id, _legacy_request = _write_deployed_v1_run(
+        initial, supporting_issues=[3626]
+    )
+    with sqlite3.connect(initial.store.db_path) as conn:
+        conn.execute(
+            "UPDATE verification_runs SET current_head_sha=?, status='backoff', "
+            "terminal_receipt_json=?, retry_after=? WHERE run_id=?",
+            (
+                promoted_head,
+                json.dumps(
+                    {
+                        "outcome": "deferred",
+                        "reason": "checks_not_green",
+                        "head_sha": promoted_head,
+                    },
+                    sort_keys=True,
+                ),
+                "2030-01-01T00:00:00+00:00",
+                run_id,
+            ),
+        )
+        conn.execute(
+            "ALTER TABLE verification_runs DROP COLUMN legacy_recovery_audit_json"
+        )
+        conn.execute(
+            "UPDATE dispatcher_meta SET value='5' WHERE key='schema_version'"
+        )
+        conn.commit()
+
+    state = ledger(tmp_path)
+    promoted_request = request(promoted_head)
+    promoted_request["supporting_issues"] = [3626]
+    recovered = state.ingest(_live_observed_request(state, promoted_request))
+    claimed = state.claim(recovered.run_id, "repair-host")
+    running = state.start(
+        recovered.run_id,
+        "repair-host",
+        claimed.lease_id or "",
+        "01900000-0000-7000-8000-000000000053",
+        {"head_sha": promoted_head},
+    )
+    rebound = state.rebind_head(
+        recovered.run_id,
+        rebound_head,
+        expected_head_sha=promoted_head,
+        observed_repository=recovered.repository,
+        observed_pr_number=recovered.pr_number,
+        observed_head_sha=rebound_head,
+        holder="repair-host",
+        lease_id=running.lease_id or "",
+    )
+    if terminal:
+        state.terminal(
+            recovered.run_id,
+            "failed",
+            {"outcome": "blocked", "head_sha": rebound_head},
+            holder="repair-host",
+            lease_id=rebound.lease_id or "",
+        )
+
+    conflicting_request = request(rebound_head)
+    conflicting_request["supporting_issues"] = [3626]
+    if authority == "supporting":
+        conflicting_request["supporting_issues"] = [3626, 4999]
+    else:
+        conflicting_request["closing_issues"] = [3626]
+    assert conflicting_request["idempotency_key"] != promoted_request["idempotency_key"]
+    before = _verification_state_snapshot(state)
+    attempts_before = state.attempts(run_id)
+    budget_before = state.repair_budget_projection(run_id)
+
+    with pytest.raises(ValueError, match="replay authority does not match"):
+        state.ingest(_live_observed_request(state, conflicting_request))
+
+    assert _verification_state_snapshot(state) == before
+    assert state.attempts(run_id) == attempts_before
+    assert state.repair_budget_projection(run_id) == budget_before
+
+
 def test_migrated_repaired_head_v1_recovers_only_on_preserved_current_head(
     tmp_path,
 ) -> None:

--- a/tests/dispatcher/test_verification_dispatch.py
+++ b/tests/dispatcher/test_verification_dispatch.py
@@ -459,6 +459,55 @@ def test_promoted_legacy_v2_identical_replay_is_idempotent(tmp_path) -> None:
     assert _verification_state_snapshot(state) == snapshot_before_replay
     assert len(state.list()) == 1
 
+    conflicting_supporting = request(repaired_head)
+    conflicting_supporting["supporting_issues"] = [3626]
+    with pytest.raises(
+        ValueError,
+        match="idempotency authority conflict",
+    ):
+        state.ingest(
+            _live_observed_request(state, conflicting_supporting)
+        )
+    assert _verification_state_snapshot(state) == snapshot_before_replay
+
+    claimed = state.claim(run_id, "repair-host")
+    running = state.start(
+        run_id,
+        "repair-host",
+        claimed.lease_id or "",
+        "01900000-0000-7000-8000-000000000052",
+        {"head_sha": repaired_head},
+    )
+    terminal_head = "c" * 40
+    rebound = state.rebind_head(
+        run_id,
+        terminal_head,
+        expected_head_sha=repaired_head,
+        observed_repository=recovered.repository,
+        observed_pr_number=recovered.pr_number,
+        observed_head_sha=terminal_head,
+        holder="repair-host",
+        lease_id=running.lease_id or "",
+    )
+    terminal = state.terminal(
+        run_id,
+        "failed",
+        {"outcome": "blocked", "head_sha": terminal_head},
+        holder="repair-host",
+        lease_id=rebound.lease_id or "",
+    )
+    terminal_snapshot = _verification_state_snapshot(state)
+    with pytest.raises(
+        ValueError,
+        match="artifact head does not match canonical run",
+    ):
+        state.ingest(
+            _live_observed_request(state, promoted_request)
+        )
+    assert terminal.status == "failed"
+    assert terminal.current_head_sha == terminal_head
+    assert _verification_state_snapshot(state) == terminal_snapshot
+
 
 def test_migrated_repaired_head_v1_recovers_only_on_preserved_current_head(
     tmp_path,

--- a/tests/dispatcher/test_verification_dispatch.py
+++ b/tests/dispatcher/test_verification_dispatch.py
@@ -402,6 +402,64 @@ def test_authenticated_same_head_v2_recovers_inert_audit_and_budget(tmp_path) ->
     assert audit["quarantined_exceptions"] == []
 
 
+def test_promoted_legacy_v2_identical_replay_is_idempotent(tmp_path) -> None:
+    requested_head = request()["current_head_sha"]
+    assert isinstance(requested_head, str)
+    repaired_head = "b" * 40
+    initial = ledger(tmp_path)
+    run_id, _legacy_request = _write_deployed_v1_run(
+        initial, supporting_issues=[]
+    )
+    with sqlite3.connect(initial.store.db_path) as conn:
+        conn.execute(
+            "UPDATE verification_runs SET current_head_sha=?, status='backoff', "
+            "terminal_receipt_json=?, retry_after=? WHERE run_id=?",
+            (
+                repaired_head,
+                json.dumps(
+                    {
+                        "outcome": "deferred",
+                        "reason": "checks_not_green",
+                        "head_sha": repaired_head,
+                    },
+                    sort_keys=True,
+                ),
+                "2030-01-01T00:00:00+00:00",
+                run_id,
+            ),
+        )
+        conn.execute(
+            "ALTER TABLE verification_runs DROP COLUMN legacy_recovery_audit_json"
+        )
+        conn.execute(
+            "UPDATE dispatcher_meta SET value='5' WHERE key='schema_version'"
+        )
+        conn.commit()
+
+    state = ledger(tmp_path)
+    attempts_before = state.attempts(run_id)
+    budget_before = state.repair_budget_projection(run_id)
+    promoted_request = request(repaired_head)
+    recovered = state.ingest(
+        _live_observed_request(state, promoted_request)
+    )
+    snapshot_before_replay = _verification_state_snapshot(state)
+
+    replayed = state.ingest(
+        _live_observed_request(state, promoted_request)
+    )
+
+    assert replayed == recovered
+    assert replayed.run_id == run_id
+    assert replayed.requested_head_sha == requested_head
+    assert replayed.request["current_head_sha"] == repaired_head
+    assert replayed.current_head_sha == repaired_head
+    assert state.attempts(run_id) == attempts_before
+    assert state.repair_budget_projection(run_id) == budget_before
+    assert _verification_state_snapshot(state) == snapshot_before_replay
+    assert len(state.list()) == 1
+
+
 def test_migrated_repaired_head_v1_recovers_only_on_preserved_current_head(
     tmp_path,
 ) -> None:
@@ -513,6 +571,16 @@ def test_migrated_repaired_head_v1_recovers_only_on_preserved_current_head(
     assert state.get(run_id) == rebound
     assert state.attempts(run_id) == attempts_before
     assert state.repair_budget_projection(run_id) == budget_before
+
+    before_stale_replay = snapshot()
+    with pytest.raises(
+        ValueError,
+        match="artifact head does not match canonical run",
+    ):
+        state.ingest(
+            _live_observed_request(state, request(repaired_head))
+        )
+    assert snapshot() == before_stale_replay
 
     deferred = state.backoff(
         run_id,

--- a/tests/dispatcher/test_verification_dispatch.py
+++ b/tests/dispatcher/test_verification_dispatch.py
@@ -408,7 +408,7 @@ def test_promoted_legacy_v2_identical_replay_is_idempotent(tmp_path) -> None:
     repaired_head = "b" * 40
     initial = ledger(tmp_path)
     run_id, _legacy_request = _write_deployed_v1_run(
-        initial, supporting_issues=[]
+        initial, supporting_issues=[3626]
     )
     with sqlite3.connect(initial.store.db_path) as conn:
         conn.execute(
@@ -440,6 +440,7 @@ def test_promoted_legacy_v2_identical_replay_is_idempotent(tmp_path) -> None:
     attempts_before = state.attempts(run_id)
     budget_before = state.repair_budget_projection(run_id)
     promoted_request = request(repaired_head)
+    promoted_request["supporting_issues"] = [3626]
     recovered = state.ingest(
         _live_observed_request(state, promoted_request)
     )
@@ -459,16 +460,35 @@ def test_promoted_legacy_v2_identical_replay_is_idempotent(tmp_path) -> None:
     assert _verification_state_snapshot(state) == snapshot_before_replay
     assert len(state.list()) == 1
 
-    conflicting_supporting = request(repaired_head)
-    conflicting_supporting["supporting_issues"] = [3626]
-    with pytest.raises(
-        ValueError,
-        match="idempotency authority conflict",
-    ):
-        state.ingest(
-            _live_observed_request(state, conflicting_supporting)
-        )
-    assert _verification_state_snapshot(state) == snapshot_before_replay
+    conflicting_authority = []
+    conflicting_supporting = dict(promoted_request)
+    conflicting_supporting["supporting_issues"] = [3626, 4999]
+    conflicting_authority.append(conflicting_supporting)
+    conflicting_governing = dict(promoted_request)
+    conflicting_governing["linked_issue"] = 3626
+    # The request grammar forbids the governing issue from also appearing in
+    # supporting authority, so a valid changed-governor artifact must move the
+    # former governor into the evidence set while retaining the closing child.
+    conflicting_governing["supporting_issues"] = [3603]
+    conflicting_authority.append(conflicting_governing)
+    conflicting_closing = dict(promoted_request)
+    conflicting_closing["closing_issues"] = [3626]
+    conflicting_authority.append(conflicting_closing)
+
+    for conflicting_request in conflicting_authority:
+        with pytest.raises(
+            ValueError,
+            match=(
+                "idempotency authority conflict|"
+                "canonical run governing issue mismatch"
+            ),
+        ):
+            state.ingest(
+                _live_observed_request(state, conflicting_request)
+            )
+        assert _verification_state_snapshot(state) == snapshot_before_replay
+        assert state.attempts(run_id) == attempts_before
+        assert state.repair_budget_projection(run_id) == budget_before
 
     claimed = state.claim(run_id, "repair-host")
     running = state.start(


### PR DESCRIPTION
Governing-Issue: #3821

Fixes #3821

## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Summary
- Make identical authenticated v2 artifacts replay idempotently after legacy requested-head A/current-head B promotion.
- Preserve immutable legacy audit identity, run id, attempts, repair policy, and consumed/remaining 2+2 budget.
- Keep stale recovered-head replay and current-head governing/supporting/closing authority drift fail-closed after an active B→C rebind.

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): none
- Write class: Builder System authority/accounting correction
- Authority impact: narrows existing authenticated verification replay to its stored promoted request identity; grants no new merge or issue authority
- Persistence impact: existing dispatcher verification ledger semantics only; no schema change
- Derived/rebuildable impact: verification artifacts remain rebuildable from authenticated GitHub/CI truth
- Human knowledge impact: unaffected
- Memory impact: builder learning only; no runtime/user memory
- Retrieval/context impact: unaffected
- Sync/deployment impact: unaffected
- External boundary impact: authenticated workflow artifact replay into the dispatcher ledger
- New or changed contract: identical promoted-v2 replay is idempotent; stale or conflicting authority remains fail-closed
- Owner-doc impact: docs/AGENT_ISSUE_DISPATCHER.md updated in this PR
- Transition debt impact: D11 preserved; D12 reduced through durable issue/learning/verification receipts
- Fitness rule impact: production-path regression protects exact authority and accounting

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Validation
- [x] Red-before-fix production regression reproduced the authority conflict
- [x] Post-rebind active/terminal authority-drift matrix — 4 passed
- [x] Full dispatcher suite — 990 passed
- [x] ruff check app tests companion-ui/companion-app
- [x] mypy app — 757 source files clean
- [x] `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1 python scripts/docs_guard.py` — Docs guard: OK. Skip is bounded to this non-temporal dispatcher correctness repair; the authoritative dispatcher owner doc is updated here.
- [x] skill consistency and git diff --check

## BuilderOps Routing
- Records/projections/receipts: LearningSignal lrn_20260717092445_871f55a7; epic run-state issue-3821-postmerge-20260717
- Reason: PR #3822 merged before its mandatory two-clean-review gate completed, and that review reproduced this in-scope defect.

## Reconciliation
PR #3822 merged as 5352a7cc50ae0e148cda6c9ee47afb729917102c before review 1 completed. Issue #3821 was reopened truthfully; this bounded follow-up must pass exact-head CI and two fresh independent Sol/xhigh clean reviews before merge and closure.
