### PR TITLE
fix: make index rebuild and strict doctor converge

### DIFF
--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -649,6 +649,86 @@ jobs:
           name: pytest-not-pg-logs
           path: pytest-not-pg.log
 
+  pr-index-pg-contracts:
+    name: Index PG contracts
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: app
+          POSTGRES_PASSWORD: app
+          POSTGRES_DB: app
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U app"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgresql://app:app@localhost:5432/app
+      DB_DSN: postgresql://app:app@localhost:5432/app
+      PYTHONPATH: ${{ github.workspace }}:${{ github.workspace }}/companion-ui/companion-app
+      STORE_BACKEND: pg
+      LLM_PROVIDER: mock
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect index PG acceptance surface
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            index_pg:
+              - 'app/cli/index_rebuild.py'
+              - 'app/index/**'
+              - 'app/stores/pg.py'
+              - 'tests/index/test_provenance_stamp.py'
+              - 'tests/indexer/test_outbox_roundtrip_pg.py'
+              - '.github/workflows/ci-smoke.yaml'
+
+      - uses: actions/setup-python@v5
+        if: steps.changes.outputs.index_pg == 'true'
+        with:
+          python-version: '3.12'
+          cache: pip
+
+      - name: Install dependencies
+        if: steps.changes.outputs.index_pg == 'true'
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r dev-requirements.txt
+
+      - name: Enable pgvector extension
+        if: steps.changes.outputs.index_pg == 'true'
+        run: python -c "import os, psycopg; psycopg.connect(os.environ['DATABASE_URL'], autocommit=True).execute('CREATE EXTENSION IF NOT EXISTS vector')"
+
+      - name: Run exact index PG acceptance surface
+        if: steps.changes.outputs.index_pg == 'true'
+        shell: bash
+        run: |
+          set -o pipefail
+          pytest -q -m "pg" \
+            tests/index/test_provenance_stamp.py \
+            tests/indexer/test_outbox_roundtrip_pg.py \
+            --tb=short \
+            | tee pytest-index-pg.log
+
+      - name: Skip index PG contracts for unrelated PR
+        if: steps.changes.outputs.index_pg != 'true'
+        run: echo "No index PG acceptance surface changed."
+
+      - name: Upload index PG log
+        if: always() && steps.changes.outputs.index_pg == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-index-pg-log
+          path: pytest-index-pg.log
+
   contract-validation:
     # Activated dead gates (#3892): import-linter, OpenAPI/AsyncAPI
     # validation, and YAML/JSON lint moved here from the retired

--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -684,6 +684,7 @@ jobs:
           filters: |
             index_pg:
               - 'app/cli/index_rebuild.py'
+              - 'app/agents/panel/**'
               - 'app/index/**'
               - 'app/stores/pg.py'
               - 'tests/index/test_provenance_stamp.py'

--- a/app/agents/panel/filters.py
+++ b/app/agents/panel/filters.py
@@ -10,19 +10,26 @@ def strip_ai_panels(full_markdown: str) -> str:
       - fenced blocks between AI fences (%% ...AI... %%),
       - OR (fallback) heading-based panels with ## AI-instruktion/## AI-åtgärder/## AI-logg.
     """
-    lines = full_markdown.splitlines()
-    state = parse_panel(full_markdown)
-    spans = state.spans or []
-    if not spans:
-        return full_markdown
-    to_skip: set[int] = set()
-    for start, end in spans:
-        if start is None or end is None:
-            continue
-        for idx in range(max(0, start), min(len(lines) - 1, end) + 1):
-            to_skip.add(idx)
-    kept = [line for idx, line in enumerate(lines) if idx not in to_skip]
-    return "\n".join(kept)
+    # A note can contain both fenced and legacy heading panels. ``parse_panel``
+    # deliberately prioritizes fenced spans, so removing one format can expose
+    # the other on the next parse. Iterate to a fixed point: every successful
+    # pass removes at least one line, which keeps this bounded by input length.
+    current = full_markdown
+    while True:
+        lines = current.splitlines()
+        spans = parse_panel(current).spans or []
+        if not spans:
+            return current
+        to_skip: set[int] = set()
+        for start, end in spans:
+            if start is None or end is None:
+                continue
+            for idx in range(max(0, start), min(len(lines) - 1, end) + 1):
+                to_skip.add(idx)
+        stripped = "\n".join(line for idx, line in enumerate(lines) if idx not in to_skip)
+        if stripped == current:
+            return current
+        current = stripped
 
 
 __all__ = ["strip_ai_panels", "is_ai_fence"]

--- a/app/cli/index_rebuild.py
+++ b/app/cli/index_rebuild.py
@@ -625,8 +625,10 @@ def reconcile(
         if not text:
             if authoritative_source_present:
                 try:
-                    purged = index_store.purge_vectors(
-                        UUID(str(object_id)), view=DEFAULT_EMBEDDING_VIEW
+                    classification = (
+                        index_store.purge_vector_if_present_source_non_indexable(
+                            UUID(str(object_id)), view=DEFAULT_EMBEDDING_VIEW
+                        )
                     )
                 except Exception as purge_exc:
                     _record_failure(
@@ -640,12 +642,35 @@ def reconcile(
                         False,
                     )
                     continue
-                summary["purged_non_indexable"] = int(
-                    summary["purged_non_indexable"]
-                ) + int(purged)
-            else:
+
+                if classification.source_present and not classification.source_indexable:
+                    summary["purged_non_indexable"] = int(
+                        summary["purged_non_indexable"]
+                    ) + int(classification.purged)
+                    continue
+
+                if classification.source_present:
+                    # The source became indexable after the candidate read.
+                    # Reclassify and embed the locked-read payload instead of
+                    # deleting its derived row from stale evidence.
+                    source_payload = dict(classification.source_payload or {})
+                else:
+                    # The source disappeared after the candidate read.  The
+                    # present-source purge contract no longer applies; retain
+                    # and, where possible, reconcile from vector fallback.
+                    source_payload = vector_payload
+                domain_obj = domain_objects.DomainObject(
+                    uuid=str(object_id),
+                    kind=kind,
+                    source_ref=source_ref,
+                    payload=source_payload,
+                    created_at=datetime.now(timezone.utc),
+                )
+                text = _extract_text(source_payload)
+
+            if not text:
                 summary["skipped"] = int(summary["skipped"]) + 1
-            continue
+                continue
 
         # ``store_vector_index`` is a derived retrieval projection.  Keep both
         # compatibility aliases bound to the exact producer-selected source

--- a/app/cli/index_rebuild.py
+++ b/app/cli/index_rebuild.py
@@ -11,7 +11,11 @@ from uuid import UUID
 import click
 
 from app.components.embeddings import EmbeddingIdentity, get_embedding_client
-from app.index.artifact_metadata import build_indexed_unit_payload, compute_payload_content_hash, extract_indexable_text
+from app.index.artifact_metadata import (
+    build_indexed_unit_payload,
+    canonicalize_indexable_text,
+    compute_payload_content_hash,
+)
 from app.llm.embed_queue import EmbedDeadLetterError, embed_with_retry
 from app import objects as domain_objects
 from app.stores import get_vector_index, resolve_store_backend
@@ -38,7 +42,7 @@ _RETRYABLE_NAMES = {"SerializationFailure", "DeadlockDetected", "TooManyRequests
 
 
 def _extract_text(payload: dict | None) -> str:
-    return extract_indexable_text(payload)
+    return canonicalize_indexable_text(payload)
 
 
 def _load_objects(limit: int | None) -> Tuple[List[domain_objects.DomainObject], str]:
@@ -267,6 +271,10 @@ def rebuild(
             summary["skipped"] = int(summary["skipped"]) + 1
             continue
 
+        indexed_payload = dict(domain_obj.payload or {})
+        indexed_payload["content"] = text
+        indexed_payload["text"] = text
+
         embedding: list | None = None
         try:
             embedding = embed_with_retry(
@@ -315,7 +323,7 @@ def rebuild(
                     object_id=UUID(str(domain_obj.uuid)),
                     kind=str(domain_obj.kind or "note"),
                     source_ref=str(domain_obj.source_ref or ""),
-                    payload=dict(domain_obj.payload or {}),
+                    payload=indexed_payload,
                     text=text,
                     embedding_identity=identity,
                 ),
@@ -432,12 +440,12 @@ def _stale_content_hash_rows(limit: int | None) -> List[dict]:
     return stale
 
 
-def _reconcile_object_text(object_id, vector_payload: dict | None) -> str:
-    """Resolve the source text to re-embed for a row.
+def _reconcile_object_payload(object_id, vector_payload: dict | None) -> dict:
+    """Resolve the authoritative payload to re-embed for a row.
 
     Prefer the authoritative ``store_objects`` payload (the durable object of
-    record); fall back to the text carried in the vector-index row payload when the
-    object row is absent, so an orphaned index row can still be reconciled.
+    record); fall back to the vector-index row payload when the object row is
+    absent, so an orphaned index row can still be reconciled.
     """
     from app.stores.pg import _connect  # local import: pg backend is optional
 
@@ -449,10 +457,10 @@ def _reconcile_object_text(object_id, vector_payload: dict | None) -> str:
             )
             row = cur.fetchone()
     if row and row.get("payload"):
-        text = _extract_text(dict(row["payload"]))
-        if text:
-            return text
-    return _extract_text(vector_payload or {})
+        payload = dict(row["payload"])
+        if _extract_text(payload):
+            return payload
+    return dict(vector_payload or {})
 
 
 @index.command("reconcile", help="Re-embed non-primary-identity vectors under the primary identity (converge a mixed index).")
@@ -555,18 +563,27 @@ def reconcile(
         kind = str(row.get("kind") or "note")
         source_ref = str(row.get("source_ref") or "")
         vector_payload = dict(row.get("payload") or {})
+        source_payload = _reconcile_object_payload(object_id, vector_payload)
         domain_obj = domain_objects.DomainObject(
             uuid=str(object_id),
             kind=kind,
             source_ref=source_ref,
-            payload=vector_payload,
+            payload=source_payload,
             created_at=datetime.now(timezone.utc),
         )
 
-        text = _reconcile_object_text(object_id, vector_payload)
+        text = _extract_text(source_payload)
         if not text:
             summary["skipped"] = int(summary["skipped"]) + 1
             continue
+
+        # ``store_vector_index`` is a derived retrieval projection.  Keep both
+        # compatibility aliases bound to the exact producer-selected source
+        # text so a successful reconcile cannot leave retrieval serving a
+        # stale legacy ``text`` value while provenance already reports clean.
+        indexed_payload = dict(source_payload)
+        indexed_payload["content"] = text
+        indexed_payload["text"] = text
 
         embedding: list | None = None
         try:
@@ -588,7 +605,7 @@ def reconcile(
             _oid=object_id,
             _kind=kind,
             _source_ref=source_ref,
-            _payload=vector_payload,
+            _payload=indexed_payload,
             _text=text,
             _embedding=embedding,
         ) -> None:

--- a/app/cli/index_rebuild.py
+++ b/app/cli/index_rebuild.py
@@ -441,6 +441,42 @@ def _stale_content_hash_rows(limit: int | None) -> List[dict]:
     return stale
 
 
+def _present_non_indexable_rows(limit: int | None) -> List[dict]:
+    """Return derived rows whose present source now has no canonical text.
+
+    This candidate class is independent of identity and content hash.  Legacy
+    panel-bearing vectors can already carry the current primary identity and a
+    hash of the empty canonical body, so neither ordinary reconcile selector
+    can prove that their stale retrieval bytes must be purged.
+    """
+    from app.stores.pg import _connect  # local import: pg backend is optional
+
+    with _connect() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT v.object_id AS object_id, v.kind AS kind,
+                       v.source_ref AS source_ref, v.payload AS payload,
+                       v.provider AS provider, v.model AS model,
+                       v.dim AS dim, v.normalize AS normalize,
+                       o.payload AS current_payload
+                FROM store_vector_index AS v
+                JOIN store_objects AS o ON o.object_id = v.object_id
+                ORDER BY v.object_id
+                """
+            )
+            candidates = list(cur.fetchall())
+
+    rows = [
+        row
+        for row in candidates
+        if not canonicalize_indexable_text(dict(row.get("current_payload") or {}))
+    ]
+    if limit is not None:
+        rows = rows[:limit]
+    return rows
+
+
 def _reconcile_object_payload(object_id, vector_payload: dict | None) -> Tuple[dict, bool]:
     """Resolve the authoritative payload to re-embed for a row.
 
@@ -505,6 +541,7 @@ def reconcile(
     summary: Dict[str, object] = {
         "backend": resolved_backend,
         "total_mismatched": 0,
+        "total_present_non_indexable": 0,
         "reconciled": 0,
         "purged_non_indexable": 0,
         "skipped": 0,
@@ -541,9 +578,15 @@ def reconcile(
     stale_content_rows = [
         row for row in _stale_content_hash_rows(limit) if row["object_id"] not in seen_ids
     ]
-    rows = identity_rows + stale_content_rows
+    seen_ids.update(row["object_id"] for row in stale_content_rows)
+    present_non_indexable_rows = _present_non_indexable_rows(limit)
+    additional_non_indexable_rows = [
+        row for row in present_non_indexable_rows if row["object_id"] not in seen_ids
+    ]
+    rows = identity_rows + stale_content_rows + additional_non_indexable_rows
     summary["total_mismatched"] = len(identity_rows)
     summary["total_stale_content_hash"] = len(stale_content_rows)
+    summary["total_present_non_indexable"] = len(present_non_indexable_rows)
 
     if not as_json:
         click.echo(
@@ -552,9 +595,10 @@ def reconcile(
         )
         click.echo(f"Mismatched rows: {len(identity_rows)}")
         click.echo(f"Stale content-hash rows: {len(stale_content_rows)}")
+        click.echo(f"Present non-indexable source rows: {len(present_non_indexable_rows)}")
 
     if dry_run:
-        summary["message"] = "Dry run complete; no vectors re-embedded."
+        summary["message"] = "Dry run complete; no vectors re-embedded or purged."
         _emit_reconcile_summary(summary, as_json)
         return
 
@@ -678,6 +722,7 @@ def _emit_reconcile_summary(summary: Dict[str, object], as_json: bool) -> None:
     click.echo(
         f"total_mismatched={summary.get('total_mismatched', 0)} "
         f"total_stale_content_hash={summary.get('total_stale_content_hash', 0)} "
+        f"total_present_non_indexable={summary.get('total_present_non_indexable', 0)} "
         f"reconciled={summary.get('reconciled', 0)} "
         f"skipped={summary.get('skipped', 0)} "
         f"errors={summary['error_count']}"

--- a/app/cli/index_rebuild.py
+++ b/app/cli/index_rebuild.py
@@ -11,7 +11,7 @@ from uuid import UUID
 import click
 
 from app.components.embeddings import EmbeddingIdentity, get_embedding_client
-from app.index.artifact_metadata import build_indexed_unit_payload
+from app.index.artifact_metadata import build_indexed_unit_payload, compute_payload_content_hash, extract_indexable_text
 from app.llm.embed_queue import EmbedDeadLetterError, embed_with_retry
 from app import objects as domain_objects
 from app.stores import get_vector_index, resolve_store_backend
@@ -38,12 +38,7 @@ _RETRYABLE_NAMES = {"SerializationFailure", "DeadlockDetected", "TooManyRequests
 
 
 def _extract_text(payload: dict | None) -> str:
-    data = payload or {}
-    for key in ("content", "text", "raw_text"):
-        val = data.get(key)
-        if val:
-            return str(val)
-    return ""
+    return extract_indexable_text(payload)
 
 
 def _load_objects(limit: int | None) -> Tuple[List[domain_objects.DomainObject], str]:
@@ -408,7 +403,6 @@ def _stale_content_hash_rows(limit: int | None) -> List[dict]:
     ``inspect_pg_content_hash_staleness`` reports them separately as
     ``unstamped_count`` for visibility.
     """
-    from app.index.artifact_metadata import compute_content_hash
     from app.stores.pg import _connect  # local import: pg backend is optional
 
     with _connect() as conn:
@@ -418,7 +412,7 @@ def _stale_content_hash_rows(limit: int | None) -> List[dict]:
                        v.payload AS payload, v.provider AS provider, v.model AS model,
                        v.dim AS dim, v.normalize AS normalize,
                        v.payload->'provenance'->>'content_hash' AS stored_hash,
-                       COALESCE(o.payload->>'text', o.payload->>'content', '') AS current_text
+                       o.payload AS current_payload
                 FROM store_vector_index AS v
                 JOIN store_objects AS o ON o.object_id = v.object_id
                 WHERE v.payload->'provenance'->>'content_hash' IS NOT NULL
@@ -430,7 +424,8 @@ def _stale_content_hash_rows(limit: int | None) -> List[dict]:
     stale = [
         row
         for row in candidates
-        if compute_content_hash(row.get("current_text") or "") != row.get("stored_hash")
+        if compute_payload_content_hash(dict(row.get("current_payload") or {}))
+        != row.get("stored_hash")
     ]
     if limit is not None:
         stale = stale[:limit]

--- a/app/cli/index_rebuild.py
+++ b/app/cli/index_rebuild.py
@@ -18,6 +18,7 @@ from app.index.artifact_metadata import (
 )
 from app.llm.embed_queue import EmbedDeadLetterError, embed_with_retry
 from app import objects as domain_objects
+from app.outbox.events import DEFAULT_EMBEDDING_VIEW
 from app.stores import get_vector_index, resolve_store_backend
 
 FAILURES_PATH_ENV = "INDEX_REBUILD_FAILURES_PATH"
@@ -440,7 +441,7 @@ def _stale_content_hash_rows(limit: int | None) -> List[dict]:
     return stale
 
 
-def _reconcile_object_payload(object_id, vector_payload: dict | None) -> dict:
+def _reconcile_object_payload(object_id, vector_payload: dict | None) -> Tuple[dict, bool]:
     """Resolve the authoritative payload to re-embed for a row.
 
     Prefer the authoritative ``store_objects`` payload (the durable object of
@@ -456,11 +457,9 @@ def _reconcile_object_payload(object_id, vector_payload: dict | None) -> dict:
                 (object_id,),
             )
             row = cur.fetchone()
-    if row and row.get("payload"):
-        payload = dict(row["payload"])
-        if _extract_text(payload):
-            return payload
-    return dict(vector_payload or {})
+    if row is not None:
+        return dict(row.get("payload") or {}), True
+    return dict(vector_payload or {}), False
 
 
 @index.command("reconcile", help="Re-embed non-primary-identity vectors under the primary identity (converge a mixed index).")
@@ -493,8 +492,11 @@ def reconcile(
     the run is interrupted (SIGINT, crash, embed failure), already-processed rows carry
     the primary identity and unprocessed rows retain their prior (fallback) identity —
     the index is still mixed but never missing a vector or partially written. A row is
-    never deleted; a failed re-embed leaves the original fallback vector in place and is
-    dead-lettered for retry.
+    never deleted because an embed/upsert failed; a failed re-embed leaves the original
+    fallback vector in place and is dead-lettered for retry. The one semantic deletion
+    is a derived vector
+    whose present authoritative source has become canonically non-indexable;
+    explicit reconcile purges that row so retrieval cannot serve stale bytes.
     """
     if backend:
         os.environ["STORE_BACKEND"] = backend
@@ -504,6 +506,7 @@ def reconcile(
         "backend": resolved_backend,
         "total_mismatched": 0,
         "reconciled": 0,
+        "purged_non_indexable": 0,
         "skipped": 0,
         "errors": [],
     }
@@ -563,7 +566,9 @@ def reconcile(
         kind = str(row.get("kind") or "note")
         source_ref = str(row.get("source_ref") or "")
         vector_payload = dict(row.get("payload") or {})
-        source_payload = _reconcile_object_payload(object_id, vector_payload)
+        source_payload, authoritative_source_present = _reconcile_object_payload(
+            object_id, vector_payload
+        )
         domain_obj = domain_objects.DomainObject(
             uuid=str(object_id),
             kind=kind,
@@ -574,7 +579,28 @@ def reconcile(
 
         text = _extract_text(source_payload)
         if not text:
-            summary["skipped"] = int(summary["skipped"]) + 1
+            if authoritative_source_present:
+                try:
+                    purged = index_store.purge_vectors(
+                        UUID(str(object_id)), view=DEFAULT_EMBEDDING_VIEW
+                    )
+                except Exception as purge_exc:
+                    _record_failure(
+                        summary,
+                        path,
+                        identity_info,
+                        domain_obj,
+                        "purge",
+                        purge_exc,
+                        1,
+                        False,
+                    )
+                    continue
+                summary["purged_non_indexable"] = int(
+                    summary["purged_non_indexable"]
+                ) + int(purged)
+            else:
+                summary["skipped"] = int(summary["skipped"]) + 1
             continue
 
         # ``store_vector_index`` is a derived retrieval projection.  Keep both

--- a/app/index/artifact_metadata.py
+++ b/app/index/artifact_metadata.py
@@ -67,10 +67,10 @@ def extract_indexable_text(payload: dict | None) -> str:
 
 def canonicalize_indexable_text(payload: dict | None) -> str:
     """Return the exact producer text used for embedding and provenance."""
-    return _canonicalize_indexed_text(extract_indexable_text(payload))
+    return canonicalize_indexed_text(extract_indexable_text(payload))
 
 
-def _canonicalize_indexed_text(text: str) -> str:
+def canonicalize_indexed_text(text: str) -> str:
     """Strip panels while preserving meaningful source whitespace.
 
     Panel removal can leave only separator newlines around an otherwise
@@ -84,7 +84,7 @@ def _canonicalize_indexed_text(text: str) -> str:
 
 def compute_indexed_content_hash(text: str) -> str:
     """Hash text with the producer's AI-panel canonicalization."""
-    return compute_content_hash(_canonicalize_indexed_text(text))
+    return compute_content_hash(canonicalize_indexed_text(text))
 
 
 def compute_payload_content_hash(payload: dict | None) -> str:
@@ -100,15 +100,22 @@ def build_indexed_unit_payload(
     payload: dict | None,
     text: str | None = None,
     embedding_identity: Any = None,
+    bind_text_aliases: bool = True,
 ) -> dict:
     payload_out = dict(payload or {})
     safe_object_id = str(object_id)
     safe_source_ref = str(source_ref)
     safe_kind = str(kind or "note")
 
-    if text is not None:
-        payload_out.setdefault("text", text)
-        payload_out.setdefault("content", text)
+    canonical_text = canonicalize_indexed_text(
+        text if text is not None else extract_indexable_text(payload_out)
+    )
+    if text is not None and bind_text_aliases:
+        # A derived vector payload must expose exactly the bytes that produced
+        # both its embedding and provenance hash.  Assignment is intentional:
+        # compatibility aliases copied from a source row may be stale/raw.
+        payload_out["text"] = canonical_text
+        payload_out["content"] = canonical_text
     payload_out.setdefault("object_type", safe_kind)
     payload_out.setdefault("system_intent", "learn")
     payload_out.setdefault("emergent_tags", [])
@@ -142,10 +149,9 @@ def build_indexed_unit_payload(
     # note (idempotent no-op on panel-free text). Hashing the enriched body
     # instead makes content_hash non-deterministic and breaks reingest
     # idempotence + cold-rebuild (registry_chain).
-    embedded_text = text if text is not None else extract_indexable_text(payload_out)
     payload_out["provenance"] = {
         "source_ref": safe_source_ref,
-        "content_hash": compute_indexed_content_hash(embedded_text),
+        "content_hash": compute_content_hash(canonical_text),
         "chunk_policy_version": CHUNK_POLICY_VERSION,
         "pipeline_version": EMBED_PIPELINE_VERSION,
         "embedding_identity": _embedding_identity_dict(embedding_identity) if embedding_identity is not None else None,
@@ -156,6 +162,7 @@ def build_indexed_unit_payload(
 __all__ = [
     "build_indexed_unit_payload",
     "canonicalize_indexable_text",
+    "canonicalize_indexed_text",
     "compute_content_hash",
     "compute_indexed_content_hash",
     "compute_payload_content_hash",

--- a/app/index/artifact_metadata.py
+++ b/app/index/artifact_metadata.py
@@ -14,6 +14,7 @@ from app.ingest.episode_ref import episode_ref_from_frontmatter
 # re-run, independent of a chunk-policy or model change.
 EMBED_PIPELINE_VERSION = "v1"
 INDEXABLE_TEXT_KEYS = ("content", "text", "raw_text")
+INDEXABLE_TEXT_SOURCE_KEY = "indexable_text_source"
 
 
 def _embedding_identity_dict(identity: Any) -> dict[str, Any]:
@@ -58,6 +59,10 @@ def extract_indexable_text(payload: dict | None) -> str:
     and reconcile must not independently choose a different alias.
     """
     data = payload or {}
+    selected_key = data.get(INDEXABLE_TEXT_SOURCE_KEY)
+    if selected_key in INDEXABLE_TEXT_KEYS:
+        value = data.get(selected_key)
+        return "" if value is None else str(value)
     for key in INDEXABLE_TEXT_KEYS:
         value = data.get(key)
         if value:
@@ -169,4 +174,5 @@ __all__ = [
     "extract_indexable_text",
     "EMBED_PIPELINE_VERSION",
     "INDEXABLE_TEXT_KEYS",
+    "INDEXABLE_TEXT_SOURCE_KEY",
 ]

--- a/app/index/artifact_metadata.py
+++ b/app/index/artifact_metadata.py
@@ -13,6 +13,7 @@ from app.ingest.episode_ref import episode_ref_from_frontmatter
 # changes in a way that would make existing vectors stale relative to a
 # re-run, independent of a chunk-policy or model change.
 EMBED_PIPELINE_VERSION = "v1"
+INDEXABLE_TEXT_KEYS = ("content", "text", "raw_text")
 
 
 def _embedding_identity_dict(identity: Any) -> dict[str, Any]:
@@ -47,6 +48,31 @@ def compute_content_hash(text: str) -> str:
     changed since the vector was produced).
     """
     return hashlib.sha256((text or "").encode("utf-8")).hexdigest()
+
+
+def extract_indexable_text(payload: dict | None) -> str:
+    """Select source text with the same precedence used by index rebuild.
+
+    ``store_objects`` can carry compatibility aliases simultaneously.  The
+    producer contract is content-first, then text, then raw_text; diagnosis
+    and reconcile must not independently choose a different alias.
+    """
+    data = payload or {}
+    for key in INDEXABLE_TEXT_KEYS:
+        value = data.get(key)
+        if value:
+            return str(value)
+    return ""
+
+
+def compute_indexed_content_hash(text: str) -> str:
+    """Hash text with the producer's AI-panel canonicalization."""
+    return compute_content_hash(strip_ai_panels(text or ""))
+
+
+def compute_payload_content_hash(payload: dict | None) -> str:
+    """Hash the producer-selected text from a durable object payload."""
+    return compute_indexed_content_hash(extract_indexable_text(payload))
 
 
 def build_indexed_unit_payload(
@@ -99,11 +125,10 @@ def build_indexed_unit_payload(
     # note (idempotent no-op on panel-free text). Hashing the enriched body
     # instead makes content_hash non-deterministic and breaks reingest
     # idempotence + cold-rebuild (registry_chain).
-    embedded_text = text if text is not None else str(payload_out.get("text") or payload_out.get("content") or "")
-    canonical_text = strip_ai_panels(embedded_text)
+    embedded_text = text if text is not None else extract_indexable_text(payload_out)
     payload_out["provenance"] = {
         "source_ref": safe_source_ref,
-        "content_hash": compute_content_hash(canonical_text),
+        "content_hash": compute_indexed_content_hash(embedded_text),
         "chunk_policy_version": CHUNK_POLICY_VERSION,
         "pipeline_version": EMBED_PIPELINE_VERSION,
         "embedding_identity": _embedding_identity_dict(embedding_identity) if embedding_identity is not None else None,
@@ -114,5 +139,9 @@ def build_indexed_unit_payload(
 __all__ = [
     "build_indexed_unit_payload",
     "compute_content_hash",
+    "compute_indexed_content_hash",
+    "compute_payload_content_hash",
+    "extract_indexable_text",
     "EMBED_PIPELINE_VERSION",
+    "INDEXABLE_TEXT_KEYS",
 ]

--- a/app/index/artifact_metadata.py
+++ b/app/index/artifact_metadata.py
@@ -65,6 +65,11 @@ def extract_indexable_text(payload: dict | None) -> str:
     return ""
 
 
+def canonicalize_indexable_text(payload: dict | None) -> str:
+    """Return the exact producer text used for embedding and provenance."""
+    return strip_ai_panels(extract_indexable_text(payload))
+
+
 def compute_indexed_content_hash(text: str) -> str:
     """Hash text with the producer's AI-panel canonicalization."""
     return compute_content_hash(strip_ai_panels(text or ""))
@@ -72,7 +77,7 @@ def compute_indexed_content_hash(text: str) -> str:
 
 def compute_payload_content_hash(payload: dict | None) -> str:
     """Hash the producer-selected text from a durable object payload."""
-    return compute_indexed_content_hash(extract_indexable_text(payload))
+    return compute_content_hash(canonicalize_indexable_text(payload))
 
 
 def build_indexed_unit_payload(
@@ -138,6 +143,7 @@ def build_indexed_unit_payload(
 
 __all__ = [
     "build_indexed_unit_payload",
+    "canonicalize_indexable_text",
     "compute_content_hash",
     "compute_indexed_content_hash",
     "compute_payload_content_hash",

--- a/app/index/artifact_metadata.py
+++ b/app/index/artifact_metadata.py
@@ -67,12 +67,24 @@ def extract_indexable_text(payload: dict | None) -> str:
 
 def canonicalize_indexable_text(payload: dict | None) -> str:
     """Return the exact producer text used for embedding and provenance."""
-    return strip_ai_panels(extract_indexable_text(payload))
+    return _canonicalize_indexed_text(extract_indexable_text(payload))
+
+
+def _canonicalize_indexed_text(text: str) -> str:
+    """Strip panels while preserving meaningful source whitespace.
+
+    Panel removal can leave only separator newlines around an otherwise
+    panel-only note.  Such a remainder has no semantic bytes to embed and must
+    converge with contentless source handling, while text-bearing notes retain
+    their exact post-panel bytes.
+    """
+    canonical = strip_ai_panels(text or "")
+    return canonical if canonical.strip() else ""
 
 
 def compute_indexed_content_hash(text: str) -> str:
     """Hash text with the producer's AI-panel canonicalization."""
-    return compute_content_hash(strip_ai_panels(text or ""))
+    return compute_content_hash(_canonicalize_indexed_text(text))
 
 
 def compute_payload_content_hash(payload: dict | None) -> str:

--- a/app/index/doctor.py
+++ b/app/index/doctor.py
@@ -341,27 +341,7 @@ def inspect_unembedded_pg_objects(*, limit: int = 5) -> tuple[int, list[str]]:
         with conn.cursor() as cur:
             cur.execute(
                 """
-                SELECT count(*) AS total
-                FROM store_objects AS o
-                LEFT JOIN store_vector_index AS v
-                  ON v.object_id = o.object_id
-                 AND v.embedding IS NOT NULL
-                 AND array_length(v.embedding, 1) > 0
-                WHERE v.object_id IS NULL
-                  AND (
-                    COALESCE(o.payload->>'content', '') <> ''
-                    OR COALESCE(o.payload->>'text', '') <> ''
-                    OR COALESCE(o.payload->>'raw_text', '') <> ''
-                  )
-                """
-            )
-            row = cur.fetchone()
-            total = int((row.get("total") if isinstance(row, dict) else row[0]) or 0) if row else 0
-            if not total:
-                return 0, []
-            cur.execute(
-                """
-                SELECT o.object_id AS object_id
+                SELECT o.object_id AS object_id, o.payload AS payload
                 FROM store_objects AS o
                 LEFT JOIN store_vector_index AS v
                   ON v.object_id = o.object_id
@@ -374,14 +354,23 @@ def inspect_unembedded_pg_objects(*, limit: int = 5) -> tuple[int, list[str]]:
                     OR COALESCE(o.payload->>'raw_text', '') <> ''
                   )
                 ORDER BY o.updated_at DESC
-                LIMIT %s
-                """,
-                (limit,),
+                """
             )
-            return total, [
-                str(sample.get("object_id") if isinstance(sample, dict) else sample[0])
-                for sample in cur.fetchall()
-            ]
+            rows = cur.fetchall()
+
+    from app.index.artifact_metadata import canonicalize_indexable_text
+
+    indexable_rows = [
+        row
+        for row in rows
+        if canonicalize_indexable_text(
+            dict((row.get("payload") or {}) if isinstance(row, dict) else (row[1] or {}))
+        )
+    ]
+    return len(indexable_rows), [
+        str(row.get("object_id") if isinstance(row, dict) else row[0])
+        for row in indexable_rows[:limit]
+    ]
 
 
 def inspect_vault_coverage_gap(*, limit: int = 5) -> Dict[str, Any]:

--- a/app/index/doctor.py
+++ b/app/index/doctor.py
@@ -348,6 +348,11 @@ def inspect_unembedded_pg_objects(*, limit: int = 5) -> tuple[int, list[str]]:
                  AND v.embedding IS NOT NULL
                  AND array_length(v.embedding, 1) > 0
                 WHERE v.object_id IS NULL
+                  AND (
+                    COALESCE(o.payload->>'content', '') <> ''
+                    OR COALESCE(o.payload->>'text', '') <> ''
+                    OR COALESCE(o.payload->>'raw_text', '') <> ''
+                  )
                 """
             )
             row = cur.fetchone()
@@ -363,6 +368,11 @@ def inspect_unembedded_pg_objects(*, limit: int = 5) -> tuple[int, list[str]]:
                  AND v.embedding IS NOT NULL
                  AND array_length(v.embedding, 1) > 0
                 WHERE v.object_id IS NULL
+                  AND (
+                    COALESCE(o.payload->>'content', '') <> ''
+                    OR COALESCE(o.payload->>'text', '') <> ''
+                    OR COALESCE(o.payload->>'raw_text', '') <> ''
+                  )
                 ORDER BY o.updated_at DESC
                 LIMIT %s
                 """,

--- a/app/indexer/consumer.py
+++ b/app/indexer/consumer.py
@@ -38,13 +38,17 @@ def _extract_text(obj_payload: Dict[str, Any]) -> str:
     return canonicalize_indexable_text(obj_payload)
 
 
-def _purge_vectors(idx: object, object_id: UUID) -> int:
+def _purge_vectors(idx: object, object_id: UUID, *, required: bool = False) -> int:
     purge = getattr(idx, "purge_vectors", None)
     if purge is None:
+        if required:
+            raise RuntimeError("vector index does not support required purge_vectors")
         return 0
     try:
         return purge(object_id, view=outbox_events.DEFAULT_EMBEDDING_VIEW)
     except Exception:
+        if required:
+            raise
         return 0
 
 
@@ -70,7 +74,7 @@ def process_event(evt: Dict[str, Any]) -> None:
         # payload text is already canonical byte-for-byte; otherwise fail
         # closed instead of stamping a canonical hash onto a raw-panel vector.
         if not text or text != raw_text:
-            _purge_vectors(idx, object_id)
+            _purge_vectors(idx, object_id, required=True)
             return
         _purge_vectors(idx, object_id)
         payload = build_indexed_unit_payload(
@@ -127,7 +131,7 @@ def process_event(evt: Dict[str, Any]) -> None:
     text = _extract_text(obj_payload)
     idx = get_vector_index()
     if not text:
-        _purge_vectors(idx, obj_uuid)
+        _purge_vectors(idx, obj_uuid, required=True)
         return
 
     embedder = get_embeddings_client(LLMTaskIntent(task_kind="embed", strict_identity_required=True))

--- a/app/indexer/consumer.py
+++ b/app/indexer/consumer.py
@@ -8,7 +8,12 @@ from app.components.embeddings import EmbeddingIdentity, get_embedding_identity
 from app.components.llm.fabric import get_embeddings_client
 from app.components.llm.router import LLMTaskIntent
 from app.embedding_config import coerce_floats
-from app.index.artifact_metadata import build_indexed_unit_payload
+from app.index.artifact_metadata import (
+    build_indexed_unit_payload,
+    canonicalize_indexable_text,
+    canonicalize_indexed_text,
+    extract_indexable_text,
+)
 from app.llm.embed_queue import EmbedDeadLetterError
 from app.llm.fallback_orchestrator import embed_with_fallback
 from app.llm.embeddings import EMBED_MODEL
@@ -30,11 +35,7 @@ def _extract_object_id(evt: Dict[str, Any]) -> str | None:
 
 
 def _extract_text(obj_payload: Dict[str, Any]) -> str:
-    for key in ("content", "text", "raw_text"):
-        val = obj_payload.get(key)
-        if val:
-            return str(val)
-    return ""
+    return canonicalize_indexable_text(obj_payload)
 
 
 def _purge_vectors(idx: object, object_id: UUID) -> int:
@@ -62,12 +63,22 @@ def process_event(evt: Dict[str, Any]) -> None:
         identity = EmbeddingIdentity(provider="legacy-event", model=model, dim=len(embedding))
 
         idx = get_vector_index()
+        raw_text = extract_indexable_text(payload)
+        text = canonicalize_indexed_text(raw_text)
+        # A precomputed legacy vector does not carry the bytes it embedded as
+        # independently verifiable evidence.  Accept it only when the selected
+        # payload text is already canonical byte-for-byte; otherwise fail
+        # closed instead of stamping a canonical hash onto a raw-panel vector.
+        if not text or text != raw_text:
+            _purge_vectors(idx, object_id)
+            return
         _purge_vectors(idx, object_id)
         payload = build_indexed_unit_payload(
             object_id=object_id,
             kind=kind,
             source_ref=source_ref,
             payload=payload,
+            text=text,
             embedding_identity=identity,
         )
         idx.upsert(
@@ -114,6 +125,10 @@ def process_event(evt: Dict[str, Any]) -> None:
     obj_uuid = UUID(str(obj.uuid))
     obj_payload = dict(obj.payload or {})
     text = _extract_text(obj_payload)
+    idx = get_vector_index()
+    if not text:
+        _purge_vectors(idx, obj_uuid)
+        return
 
     embedder = get_embeddings_client(LLMTaskIntent(task_kind="embed", strict_identity_required=True))
     identity = get_embedding_identity(client=embedder)
@@ -140,7 +155,6 @@ def process_event(evt: Dict[str, Any]) -> None:
         )
         return
 
-    idx = get_vector_index()
     _purge_vectors(idx, obj_uuid)
     upsert_kwargs = {
         "kind": str(obj.kind or "note"),

--- a/app/search/service.py
+++ b/app/search/service.py
@@ -4,8 +4,8 @@ from typing import Any, Iterable
 import logging
 
 from app.components.retrieval import embed_query
-from app.agents.panel.filters import strip_ai_panels
-from app.index.artifact_metadata import build_indexed_unit_payload
+from app.index.artifact_metadata import build_indexed_unit_payload, canonicalize_indexed_text
+from app.outbox.events import DEFAULT_EMBEDDING_VIEW
 
 logger = logging.getLogger(__name__)
 
@@ -261,7 +261,13 @@ def search(query_text: str, k: int = 5, *_a, **_k) -> list:
 
 def ingest_object(object_id=None, *, kind: str, source_ref: str, payload: dict, text: str, **__):
     oid = object_id or uuid4()
-    safe_text = strip_ai_panels(text)
+    safe_text = canonicalize_indexed_text(text)
+    idx = get_vector_index()
+    if not safe_text:
+        purge = getattr(idx, "purge_vectors", None)
+        if purge is not None:
+            purge(oid, view=DEFAULT_EMBEDDING_VIEW)
+        return (oid, 0)
 
     embedding, identity = embed_query(safe_text)
     payload_out = build_indexed_unit_payload(
@@ -272,7 +278,6 @@ def ingest_object(object_id=None, *, kind: str, source_ref: str, payload: dict, 
         text=safe_text,
         embedding_identity=identity,
     )
-    idx = get_vector_index()
     try:
         idx.upsert(
             object_id=oid,
@@ -292,16 +297,16 @@ def ingest_object(object_id=None, *, kind: str, source_ref: str, payload: dict, 
             item = st[oid]
             if isinstance(item, dict):
                 item.setdefault("payload", {})
-                item["payload"].setdefault("text", safe_text)
-                item["payload"].setdefault("content", safe_text)
+                item["payload"]["text"] = safe_text
+                item["payload"]["content"] = safe_text
                 item["payload"].setdefault("object_type", kind)
                 item["payload"].setdefault("system_intent", "learn")
                 item["payload"].setdefault("emergent_tags", [])
             else:
                 pl = getattr(item, "payload", None)
                 if isinstance(pl, dict):
-                    pl.setdefault("text", safe_text)
-                    pl.setdefault("content", safe_text)
+                    pl["text"] = safe_text
+                    pl["content"] = safe_text
                     pl.setdefault("object_type", kind)
                     pl.setdefault("system_intent", "learn")
                     pl.setdefault("emergent_tags", [])

--- a/app/services/indexer.py
+++ b/app/services/indexer.py
@@ -108,6 +108,14 @@ def handle_ingest_object_created(obj: Dict[str, object]) -> None:
         payload["indexable_text_source"] = "content"
     else:
         canonical_content = canonicalize_indexable_text(payload)
+        payload["indexable_text_source"] = next(
+            (
+                key
+                for key in ("content", "text", "raw_text")
+                if payload.get(key)
+            ),
+            "content",
+        )
     # Carry the note's vault-canonical episode_ref (ERE-03/ERE-05, invariant->producers): the
     # POST /ingest → outbox → this-handler path builds a FRESH store_objects/store_vector_index
     # payload. When the event carries frontmatter (the ingest.vault.changed path), that frontmatter

--- a/app/services/indexer.py
+++ b/app/services/indexer.py
@@ -105,6 +105,7 @@ def handle_ingest_object_created(obj: Dict[str, object]) -> None:
         # through to raw_text would re-index YAML/frontmatter for a panel-only
         # note whose authoritative body is empty.
         canonical_content = canonicalize_indexed_text(content)
+        payload["indexable_text_source"] = "content"
     else:
         canonical_content = canonicalize_indexable_text(payload)
     # Carry the note's vault-canonical episode_ref (ERE-03/ERE-05, invariant->producers): the

--- a/app/services/indexer.py
+++ b/app/services/indexer.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from typing import Dict
 
 from app.components.embeddings import get_embedding_client, get_embedding_identity
-from app.index.artifact_metadata import build_indexed_unit_payload
+from app.index.artifact_metadata import build_indexed_unit_payload, canonicalize_indexable_text
 from app.ingest.episode_ref import episode_ref_from_frontmatter
 from app.llm.embed_queue import EmbedDeadLetterError
 from app.llm.fallback_orchestrator import embed_with_fallback
@@ -83,7 +83,7 @@ def handle_ingest_object_created(obj: Dict[str, object]) -> None:
     incoming_uuid = obj.get("uuid")
     object_uuid = incoming_uuid if _is_valid_uuid(incoming_uuid) else str(_uuid.uuid4())
 
-    content = obj.get("content") or ""
+    content = str(obj.get("content") or "")
     obj_payload = obj.get("payload") or {}
     payload = {
         "title": obj.get("title"),
@@ -94,6 +94,7 @@ def handle_ingest_object_created(obj: Dict[str, object]) -> None:
         "raw_text": obj_payload.get("raw_text"),
         "text": content,
     }
+    canonical_content = canonicalize_indexable_text(payload)
     # Carry the note's vault-canonical episode_ref (ERE-03/ERE-05, invariant->producers): the
     # POST /ingest → outbox → this-handler path builds a FRESH store_objects/store_vector_index
     # payload. When the event carries frontmatter (the ingest.vault.changed path), that frontmatter
@@ -132,9 +133,17 @@ def handle_ingest_object_created(obj: Dict[str, object]) -> None:
         kind=domain.kind,
         source_ref=domain.source_ref or "",
         payload=domain.payload,
-        text=str(content or ""),
+        text=canonical_content,
+        bind_text_aliases=False,
     )
     store.save_object(domain, emit_outbox=False, trace_id=trace_id)
+
+    if not canonical_content:
+        vector_index = get_vector_index()
+        vector_index.purge_vectors(
+            _uuid.UUID(str(object_uuid)), view=DEFAULT_EMBEDDING_VIEW
+        )
+        return
 
     identity = get_embedding_identity()
     actual_identity = identity
@@ -144,11 +153,11 @@ def handle_ingest_object_created(obj: Dict[str, object]) -> None:
 
     try:
         embedding, actual_identity, is_fallback = embed_with_fallback(
-            content,
+            canonical_content,
             primary_identity=identity,
             object_id=object_uuid,
             primary_embed_callable=lambda: llm_embed_text(
-                text=content,
+                text=canonical_content,
                 provider=identity.provider,
                 model=identity.model,
                 dim=identity.dim,
@@ -198,7 +207,7 @@ def handle_ingest_object_created(obj: Dict[str, object]) -> None:
                     kind=domain.kind,
                     source_ref=domain.source_ref or "",
                     payload=domain.payload,
-                    text=str(content or ""),
+                    text=canonical_content,
                     embedding_identity=actual_identity,
                 ),
                 "embedding": embedding,

--- a/app/services/indexer.py
+++ b/app/services/indexer.py
@@ -7,7 +7,11 @@ from datetime import datetime, timezone
 from typing import Dict
 
 from app.components.embeddings import get_embedding_client, get_embedding_identity
-from app.index.artifact_metadata import build_indexed_unit_payload, canonicalize_indexable_text
+from app.index.artifact_metadata import (
+    build_indexed_unit_payload,
+    canonicalize_indexable_text,
+    canonicalize_indexed_text,
+)
 from app.ingest.episode_ref import episode_ref_from_frontmatter
 from app.llm.embed_queue import EmbedDeadLetterError
 from app.llm.fallback_orchestrator import embed_with_fallback
@@ -94,7 +98,15 @@ def handle_ingest_object_created(obj: Dict[str, object]) -> None:
         "raw_text": obj_payload.get("raw_text"),
         "text": content,
     }
-    canonical_content = canonicalize_indexable_text(payload)
+    frontmatter = obj_payload.get("frontmatter")
+    if isinstance(frontmatter, dict) and "content" in obj:
+        # Vault-change events carry the already selected note body explicitly.
+        # Preserve that selection even when it canonicalizes to empty: falling
+        # through to raw_text would re-index YAML/frontmatter for a panel-only
+        # note whose authoritative body is empty.
+        canonical_content = canonicalize_indexed_text(content)
+    else:
+        canonical_content = canonicalize_indexable_text(payload)
     # Carry the note's vault-canonical episode_ref (ERE-03/ERE-05, invariant->producers): the
     # POST /ingest → outbox → this-handler path builds a FRESH store_objects/store_vector_index
     # payload. When the event carries frontmatter (the ingest.vault.changed path), that frontmatter
@@ -103,7 +115,6 @@ def handle_ingest_object_created(obj: Dict[str, object]) -> None:
     # (the raw POST /ingest path), episode_ref is deliberately left off `payload` so the merge
     # PRESERVES any existing DB binding and the build_indexed_unit_payload choke defaults a fresh
     # object to the honest 'unbound' -- never clobbering a real binding with 'unbound'.
-    frontmatter = obj_payload.get("frontmatter")
     if isinstance(frontmatter, dict):
         payload["episode_ref"] = episode_ref_from_frontmatter(frontmatter)
     trace_id = obj.get("trace_id")

--- a/app/stores/pg.py
+++ b/app/stores/pg.py
@@ -922,14 +922,14 @@ def inspect_pg_content_hash_staleness(*, limit: int = 5) -> dict:
                 """
                 SELECT v.object_id AS object_id,
                        v.payload->'provenance'->>'content_hash' AS stored_hash,
-                       COALESCE(o.payload->>'text', o.payload->>'content', '') AS current_text
+                       o.payload AS current_payload
                 FROM store_vector_index AS v
                 JOIN store_objects AS o ON o.object_id = v.object_id
                 """
             )
             rows = cur.fetchall()
 
-    from app.index.artifact_metadata import compute_content_hash
+    from app.index.artifact_metadata import compute_payload_content_hash
 
     stale_ids: list[str] = []
     unstamped_ids: list[str] = []
@@ -938,7 +938,7 @@ def inspect_pg_content_hash_staleness(*, limit: int = 5) -> dict:
         if not stored_hash:
             unstamped_ids.append(str(row["object_id"]))
             continue
-        current_hash = compute_content_hash(row.get("current_text") or "")
+        current_hash = compute_payload_content_hash(dict(row.get("current_payload") or {}))
         if current_hash != stored_hash:
             stale_ids.append(str(row["object_id"]))
 

--- a/app/stores/pg.py
+++ b/app/stores/pg.py
@@ -15,6 +15,7 @@ from app.components.embeddings import EmbeddingIdentity, get_embedding_identity
 from app.db.dsn import resolve_dsn
 from app.db.errors import StoreSchemaMissingError
 from app.embedding_config import coerce_floats, l2_normalize
+from app.index.artifact_metadata import canonicalize_indexable_text
 
 from .base import ObjectStore, RelationIndex, RelationMembership, VectorIndex, _IDENTITY_HASH_LEN
 
@@ -445,6 +446,16 @@ class _VectorHit:
     score: float
 
 
+@dataclass(frozen=True)
+class ConditionalVectorPurgeResult:
+    """Atomic classification receipt for reconcile's semantic purge."""
+
+    source_present: bool
+    source_payload: dict | None
+    source_indexable: bool
+    purged: int
+
+
 class PgVectorIndex(VectorIndex):
     rebuild_source = "PgObjectStore payloads + embedding model (see docs/EMBEDDINGS.md)"
 
@@ -619,6 +630,54 @@ class PgVectorIndex(VectorIndex):
                     (object_id,),
                 )
                 return cur.rowcount or 0
+
+    def purge_vector_if_present_source_non_indexable(
+        self, object_id: UUID, *, view: str
+    ) -> ConditionalVectorPurgeResult:
+        """Purge only while a locked authoritative source is non-indexable.
+
+        Reconcile's earlier candidate read is advisory: the source can change
+        before mutation.  This method reclassifies the source under
+        ``FOR UPDATE`` and performs the derived-row deletion in the same
+        transaction, closing that read/purge TOCTOU window.
+        """
+        del view
+        _ensure_tables()
+        with _connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT payload FROM store_objects "
+                    "WHERE object_id = %s FOR UPDATE",
+                    (object_id,),
+                )
+                row = cur.fetchone()
+                if row is None:
+                    return ConditionalVectorPurgeResult(
+                        source_present=False,
+                        source_payload=None,
+                        source_indexable=False,
+                        purged=0,
+                    )
+
+                source_payload = dict(row.get("payload") or {})
+                if canonicalize_indexable_text(source_payload):
+                    return ConditionalVectorPurgeResult(
+                        source_present=True,
+                        source_payload=source_payload,
+                        source_indexable=True,
+                        purged=0,
+                    )
+
+                cur.execute(
+                    "DELETE FROM store_vector_index WHERE object_id = %s",
+                    (object_id,),
+                )
+                return ConditionalVectorPurgeResult(
+                    source_present=True,
+                    source_payload=source_payload,
+                    source_indexable=False,
+                    purged=cur.rowcount or 0,
+                )
 
     def count_vectors(self) -> int:
         _ensure_tables()

--- a/docs/DB_SCHEMA.md
+++ b/docs/DB_SCHEMA.md
@@ -160,7 +160,8 @@ mirror/projection surfaces and do not hold semantic authority over the note cont
     doctor's read-only missing-vector and staleness checks use that
     same canonical predicate. `index reconcile` re-embeds only rows that drifted; when a present
     authoritative `store_objects` row has become canonically non-indexable, explicit reconcile
-    purges only its derived vector row so retrieval cannot serve obsolete bytes. It never mutates
+    selects it for purge independently of stored hash or embedding identity, then purges only its
+    derived vector row so retrieval cannot serve obsolete bytes. It never mutates
     the source row, and a genuinely absent source row retains the existing vector-payload fallback.
     A B-tree expression index on `payload->>'content_hash'` (migration `699c97b7c007`) backs the
     staleness scan.

--- a/docs/DB_SCHEMA.md
+++ b/docs/DB_SCHEMA.md
@@ -154,9 +154,15 @@ mirror/projection surfaces and do not hold semantic authority over the note cont
   - **transform provenance stamp (KERNEL-06, #2768):** `payload.provenance` carries `{source_ref,
     content_hash, chunk_policy_version, pipeline_version, embedding_identity}`, written in the same
     upsert statement as the vector (never a separate write). `content_hash` is a `sha256` of the
-    exact embedded text; the index doctor's read-only staleness check compares it against the
-    current `store_objects` text, and `index reconcile` re-embeds only the rows that drifted. A
-    B-tree expression index on `payload->>'content_hash'` (migration `699c97b7c007`) backs that scan.
+    exact embedded text. Canonical source selection is `content` → `text` → `raw_text`; AI panels
+    are stripped before embedding, hashing, and projection into the derived row's `content`/`text`
+    retrieval aliases. The index doctor's read-only missing-vector and staleness checks use that
+    same canonical predicate. `index reconcile` re-embeds only rows that drifted; when a present
+    authoritative `store_objects` row has become canonically non-indexable, explicit reconcile
+    purges only its derived vector row so retrieval cannot serve obsolete bytes. It never mutates
+    the source row, and a genuinely absent source row retains the existing vector-payload fallback.
+    A B-tree expression index on `payload->>'content_hash'` (migration `699c97b7c007`) backs the
+    staleness scan.
 
 ### `store_relations`
 - `src_id` (`uuid`, `NOT NULL`)

--- a/docs/DB_SCHEMA.md
+++ b/docs/DB_SCHEMA.md
@@ -155,14 +155,18 @@ mirror/projection surfaces and do not hold semantic authority over the note cont
     content_hash, chunk_policy_version, pipeline_version, embedding_identity}`, written in the same
     upsert statement as the vector (never a separate write). `content_hash` is a `sha256` of the
     exact embedded text. Canonical source selection is `content` → `text` → `raw_text`; AI panels
-    are stripped to a fixed point before embedding, hashing, and projection into the derived row's `content`/`text`
-    retrieval aliases; a post-panel remainder containing only whitespace is non-indexable. The index
-    doctor's read-only missing-vector and staleness checks use that
+    are stripped to a fixed point once per producer before the provider call, and that exact result
+    is used for embedding, hashing, and assignment (not `setdefault`) into the derived row's
+    `content`/`text` retrieval aliases. A post-panel remainder containing only whitespace is
+    non-indexable: producers do not embed or upsert it and remove any prior derived vector instead.
+    A legacy precomputed vector is accepted only when its selected payload text is already canonical
+    byte-for-byte. The index doctor's read-only missing-vector and staleness checks use that
     same canonical predicate. `index reconcile` re-embeds only rows that drifted; when a present
     authoritative `store_objects` row has become canonically non-indexable, explicit reconcile
-    selects it for purge independently of stored hash or embedding identity, then purges only its
-    derived vector row so retrieval cannot serve obsolete bytes. It never mutates
-    the source row, and a genuinely absent source row retains the existing vector-payload fallback.
+    selects it for purge independently of stored hash or embedding identity, then re-reads and locks
+    the source row and conditionally purges only its derived vector in that same transaction. A source
+    that became indexable is reclassified and embedded; one that disappeared retains the existing
+    vector-payload fallback. Reconcile never mutates the source row.
     A B-tree expression index on `payload->>'content_hash'` (migration `699c97b7c007`) backs the
     staleness scan.
 

--- a/docs/DB_SCHEMA.md
+++ b/docs/DB_SCHEMA.md
@@ -156,7 +156,8 @@ mirror/projection surfaces and do not hold semantic authority over the note cont
     upsert statement as the vector (never a separate write). `content_hash` is a `sha256` of the
     exact embedded text. Canonical source selection is `content` → `text` → `raw_text`; AI panels
     are stripped to a fixed point before embedding, hashing, and projection into the derived row's `content`/`text`
-    retrieval aliases. The index doctor's read-only missing-vector and staleness checks use that
+    retrieval aliases; a post-panel remainder containing only whitespace is non-indexable. The index
+    doctor's read-only missing-vector and staleness checks use that
     same canonical predicate. `index reconcile` re-embeds only rows that drifted; when a present
     authoritative `store_objects` row has become canonically non-indexable, explicit reconcile
     purges only its derived vector row so retrieval cannot serve obsolete bytes. It never mutates

--- a/docs/DB_SCHEMA.md
+++ b/docs/DB_SCHEMA.md
@@ -155,7 +155,7 @@ mirror/projection surfaces and do not hold semantic authority over the note cont
     content_hash, chunk_policy_version, pipeline_version, embedding_identity}`, written in the same
     upsert statement as the vector (never a separate write). `content_hash` is a `sha256` of the
     exact embedded text. Canonical source selection is `content` → `text` → `raw_text`; AI panels
-    are stripped before embedding, hashing, and projection into the derived row's `content`/`text`
+    are stripped to a fixed point before embedding, hashing, and projection into the derived row's `content`/`text`
     retrieval aliases. The index doctor's read-only missing-vector and staleness checks use that
     same canonical predicate. `index reconcile` re-embeds only rows that drifted; when a present
     authoritative `store_objects` row has become canonically non-indexable, explicit reconcile

--- a/docs/EMBEDDINGS.md
+++ b/docs/EMBEDDINGS.md
@@ -308,6 +308,19 @@ Indexer MUST NOT call deterministic/test-only helpers in production paths.
 
 ## Indexing behavior and invariants
 
+Every document producer MUST select `content` → `text` → `raw_text`, remove AI panels to a fixed
+point once, and use that exact canonical result for the provider call, `provenance.content_hash`, and
+the derived row's `content`/`text` aliases. Producers MUST NOT stamp a canonical hash onto an
+embedding generated from different bytes. A canonical result containing only whitespace is
+non-indexable: do not call the embedder or upsert a vector, and purge any previous derived vector for
+that object/view. A legacy event carrying a precomputed vector is accepted only when its selected
+payload text is already canonical byte-for-byte; otherwise it is discarded fail-closed.
+
+`index reconcile` may purge a derived row for a present, canonically non-indexable source only after
+re-reading and locking that source and performing the conditional delete in the same transaction. If
+the source became indexable, reclassify and embed it; if it disappeared, preserve the vector-payload
+fallback. This prevents a stale candidate read from deleting a vector after source update/deletion.
+
 ### Success
 
 For each object:

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -382,8 +382,9 @@ Startup/runtime verification now treats task routes and embeddings explicitly:
   AI-panel removal reaches a fixed point, and a remainder containing only whitespace is treated as
   non-indexable rather than embedded as an empty vector payload.
   `index doctor` remains read-only. During explicit `index reconcile`, a present authoritative
-  source that has become canonically non-indexable causes only its rebuildable vector row to be
-  purged; the source row is never mutated, and an absent source retains the vector-payload fallback.
+  source that has become canonically non-indexable is selected regardless of its stored hash or
+  identity and causes only its rebuildable vector row to be purged; the source row is never mutated,
+  and an absent source retains the vector-payload fallback.
 
 ## Startup telemetry (startup_status.json)
 - Location: `tmp/startup_status.json` (workspace root on the host).

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -353,6 +353,7 @@ Use `python -m app.cli <command> --help` for the full, current argument list. Th
 | `settings-explain` | Show settings provenance and effective resolution. |
 | `canvas open|edit|close` | Operate the bounded canvas co-authoring surface when `CANVAS_ENABLED=1`. |
 | `llm check` | Probe LLM/embedding endpoint reachability. |
+| `index rebuild|doctor|reconcile` | Rebuild derived vectors, diagnose drift read-only, or explicitly reconcile stale/mixed rows. |
 | `pipe <note.md>` | Run ingest for a note/path outside the watcher loop. |
 | `pkm-alpha-ingest`, `vault-alpha-ingest` | Compatibility aliases for legacy startup and ingest callers; prefer the neutral ingest commands for new scripts. |
 | `make verify-runtime` | Check container health plus in-container runtime health/status for the live Docker stack. |
@@ -377,6 +378,10 @@ Startup/runtime verification now treats task routes and embeddings explicitly:
 - `checks.llm_task_routes` verifies the effective chat/reasoning/embed/eval routes for the current config.
 - `checks.embedding_index` reports `rebuild_required=true|false` and the active/stored embedding identity relationship.
 - `make verify-runtime` prints both the task-route summary and the embedding-index rebuild state from inside the containerized stack.
+- Index operations share the canonical text contract in `docs/DB_SCHEMA.md :: store_vector_index`.
+  `index doctor` remains read-only. During explicit `index reconcile`, a present authoritative
+  source that has become canonically non-indexable causes only its rebuildable vector row to be
+  purged; the source row is never mutated, and an absent source retains the vector-payload fallback.
 
 ## Startup telemetry (startup_status.json)
 - Location: `tmp/startup_status.json` (workspace root on the host).

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -379,12 +379,15 @@ Startup/runtime verification now treats task routes and embeddings explicitly:
 - `checks.embedding_index` reports `rebuild_required=true|false` and the active/stored embedding identity relationship.
 - `make verify-runtime` prints both the task-route summary and the embedding-index rebuild state from inside the containerized stack.
 - Index operations share the canonical text contract in `docs/DB_SCHEMA.md :: store_vector_index`.
-  AI-panel removal reaches a fixed point, and a remainder containing only whitespace is treated as
-  non-indexable rather than embedded as an empty vector payload.
+  Every producer removes AI panels to a fixed point once, then uses those exact bytes for the
+  provider call, content hash, and derived `content`/`text` aliases. A remainder containing only
+  whitespace is treated as non-indexable rather than embedded or upserted as an empty vector payload;
+  any prior derived vector is removed.
   `index doctor` remains read-only. During explicit `index reconcile`, a present authoritative
   source that has become canonically non-indexable is selected regardless of its stored hash or
-  identity and causes only its rebuildable vector row to be purged; the source row is never mutated,
-  and an absent source retains the vector-payload fallback.
+  identity. Before deletion, reconcile locks and reclassifies that source in the same transaction as
+  the conditional vector purge: a newly indexable source is embedded instead, while a source that
+  disappeared retains the vector-payload fallback. The source row is never mutated.
 
 ## Startup telemetry (startup_status.json)
 - Location: `tmp/startup_status.json` (workspace root on the host).

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -379,6 +379,8 @@ Startup/runtime verification now treats task routes and embeddings explicitly:
 - `checks.embedding_index` reports `rebuild_required=true|false` and the active/stored embedding identity relationship.
 - `make verify-runtime` prints both the task-route summary and the embedding-index rebuild state from inside the containerized stack.
 - Index operations share the canonical text contract in `docs/DB_SCHEMA.md :: store_vector_index`.
+  AI-panel removal reaches a fixed point, and a remainder containing only whitespace is treated as
+  non-indexable rather than embedded as an empty vector payload.
   `index doctor` remains read-only. During explicit `index reconcile`, a present authoritative
   source that has become canonically non-indexable causes only its rebuildable vector row to be
   purged; the source row is never mutated, and an absent source retains the vector-payload fallback.

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -328,6 +328,13 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
             # Index rebuild is the memory-retrieval CLI producer for the
             # canonical vector rows exercised by the index suites.
             "app/cli/index_rebuild.py",
+            # Runtime vector producers share the same canonical-byte and
+            # provenance contract as rebuild/reconcile. Keep changes to these
+            # exact seams on the index/search acceptance surface instead of
+            # failing closed as unowned after implementation has already run.
+            "app/indexer/consumer.py",
+            "app/search/service.py",
+            "app/services/indexer.py",
             "tests/agent_memory/",
             "tests/retrieval/",
             "tests/indexer/",

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -325,6 +325,9 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
             "app/memory/",
             "app/retrieval/",
             "app/index/",
+            # Index rebuild is the memory-retrieval CLI producer for the
+            # canonical vector rows exercised by the index suites.
+            "app/cli/index_rebuild.py",
             "tests/agent_memory/",
             "tests/retrieval/",
             "tests/indexer/",

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -335,7 +335,16 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
             "tests/e2e/test_promotion_intent_to_index.py",
             "tests/e2e/test_reality_mvp_pipeline.py",
         ),
-        ("tests/agent_memory", "tests/retrieval", "tests/indexer", "tests/search", *E2E_TARGETS["memory_retrieval"]),
+        (
+            "tests/agent_memory",
+            "tests/retrieval",
+            "tests/index",
+            "tests/indexer",
+            "tests/search",
+            "tests/cli/test_index_rebuild_resilience.py",
+            "tests/cli/test_index_doctor_mixed_identity.py",
+            *E2E_TARGETS["memory_retrieval"],
+        ),
     ),
     (
         "episodes",

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -348,6 +348,7 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
             "tests/index",
             "tests/indexer",
             "tests/search",
+            "tests/services/test_indexer_worker.py",
             "tests/cli/test_index_rebuild_resilience.py",
             "tests/cli/test_index_doctor_mixed_identity.py",
             *E2E_TARGETS["memory_retrieval"],

--- a/tests/cli/test_index_rebuild_resilience.py
+++ b/tests/cli/test_index_rebuild_resilience.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 
 from click.testing import CliRunner
 
+from app.agents.panel.filters import strip_ai_panels
 from app.llm.embed_queue import EmbedDeadLetterError
 from app.objects import DomainObject, ObjectStore
 from app import objects as legacy_store
@@ -175,4 +176,36 @@ def test_rebuild_max_retries_wires_embed_attempt_budget(monkeypatch):
     assert result.exit_code == 0, f"CLI exited non-zero: {result.output}\n{result.exception}"
     assert seen == [1], f"--max-retries 0 should pass max_attempts=1 to embed_with_retry, got {seen}"
 
+    legacy_store._MEMORY_STORE.clear()
+
+
+def test_rebuild_embeds_the_same_ai_panel_stripped_text_it_hashes(monkeypatch):
+    """Rebuild provenance must hash the exact bytes sent to the embedder."""
+    reset_store_backends()
+    legacy_store._MEMORY_STORE.clear()
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv("LLM_PROVIDER", "mock")
+    monkeypatch.setenv("EMBED_DIM", "8")
+
+    source_text = """Canonical note body.
+
+%% AI:Start %%
+## AI-instruktion
+Transient panel text.
+%% AI:End %%
+"""
+    _seed_object(source_text, source_ref="vault/panel.md")
+    embedded_texts: list[str] = []
+
+    def capture_embed(text, **_kwargs):
+        embedded_texts.append(text)
+        return [0.1] * 8
+
+    from app.cli import cli
+
+    with patch("app.cli.index_rebuild.embed_with_retry", side_effect=capture_embed):
+        result = CliRunner().invoke(cli, ["index", "rebuild", "--backend", "memory", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert embedded_texts == [strip_ai_panels(source_text)]
     legacy_store._MEMORY_STORE.clear()

--- a/tests/index/test_artifact_metadata.py
+++ b/tests/index/test_artifact_metadata.py
@@ -62,6 +62,17 @@ def test_panel_only_canonicalization_collapses_whitespace_only_remainder() -> No
     assert canonicalize_indexable_text({"content": meaningful_whitespace}) == meaningful_whitespace
 
 
+def test_explicit_empty_selected_source_does_not_fall_through_to_raw_text() -> None:
+    assert canonicalize_indexable_text(
+        {
+            "content": "",
+            "text": "",
+            "raw_text": "---\ntitle: Panel only\n---\n",
+            "indexable_text_source": "content",
+        }
+    ) == ""
+
+
 def test_indexed_unit_payload_binds_aliases_and_hash_to_exact_text() -> None:
     identity = EmbeddingIdentity(provider="mock", model="mock-embedding", dim=3, normalize=True)
     canonical = "retained canonical bytes"

--- a/tests/index/test_artifact_metadata.py
+++ b/tests/index/test_artifact_metadata.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import pytest
 
 from app.components.embeddings import EmbeddingIdentity
-from app.index.artifact_metadata import _embedding_identity_dict
+from app.index.artifact_metadata import (
+    _embedding_identity_dict,
+    canonicalize_indexable_text,
+    compute_content_hash,
+    compute_indexed_content_hash,
+)
 
 pytestmark = pytest.mark.not_pg
 
@@ -44,3 +49,13 @@ def test_embedding_identity_dict_variants() -> None:
 
     duck_typed = _DuckIdentity(provider="mock", model="mock-embedding", dim=3, normalize=True)
     assert _embedding_identity_dict(duck_typed) == expected
+
+
+def test_panel_only_canonicalization_collapses_whitespace_only_remainder() -> None:
+    panel_only = "\n%% AI:Start %%\nTransient panel text.\n%% AI:End %%\n\n"
+
+    assert canonicalize_indexable_text({"content": panel_only}) == ""
+    assert compute_indexed_content_hash(panel_only) == compute_content_hash("")
+
+    meaningful_whitespace = "\n  Retained text.  \n"
+    assert canonicalize_indexable_text({"content": meaningful_whitespace}) == meaningful_whitespace

--- a/tests/index/test_artifact_metadata.py
+++ b/tests/index/test_artifact_metadata.py
@@ -5,6 +5,7 @@ import pytest
 from app.components.embeddings import EmbeddingIdentity
 from app.index.artifact_metadata import (
     _embedding_identity_dict,
+    build_indexed_unit_payload,
     canonicalize_indexable_text,
     compute_content_hash,
     compute_indexed_content_hash,
@@ -59,3 +60,21 @@ def test_panel_only_canonicalization_collapses_whitespace_only_remainder() -> No
 
     meaningful_whitespace = "\n  Retained text.  \n"
     assert canonicalize_indexable_text({"content": meaningful_whitespace}) == meaningful_whitespace
+
+
+def test_indexed_unit_payload_binds_aliases_and_hash_to_exact_text() -> None:
+    identity = EmbeddingIdentity(provider="mock", model="mock-embedding", dim=3, normalize=True)
+    canonical = "retained canonical bytes"
+
+    payload = build_indexed_unit_payload(
+        object_id="11111111-1111-1111-1111-111111111111",
+        kind="note",
+        source_ref="unit-test://exact-aliases",
+        payload={"content": "stale raw content", "text": "stale raw text"},
+        text=canonical,
+        embedding_identity=identity,
+    )
+
+    assert payload["content"] == canonical
+    assert payload["text"] == canonical
+    assert payload["provenance"]["content_hash"] == compute_content_hash(canonical)

--- a/tests/index/test_provenance_stamp.py
+++ b/tests/index/test_provenance_stamp.py
@@ -566,6 +566,68 @@ def test_reconcile_purges_vector_for_present_non_indexable_source(tmp_path, monk
 
 
 @pytest.mark.pg
+def test_explicit_empty_selected_body_converges_through_doctor_and_reconcile(
+    tmp_path, monkeypatch
+) -> None:
+    """A durable empty vault-body selection must not fall through to raw frontmatter."""
+    if not _pg_available():
+        pytest.skip("Postgres backend not available")
+
+    from click.testing import CliRunner
+
+    from app.cli import cli
+    from app.index.doctor import inspect_unembedded_pg_objects, reset_diagnose_cache
+    from app.stores import get_object_store
+    from app.stores.pg import _connect
+    from tests.indexer.test_outbox_roundtrip_pg import (
+        _configure_isolated_pg_test,
+        _drop_schema,
+        _reset_store_backend_cache_only,
+    )
+
+    base_dsn, schema = _configure_isolated_pg_test(tmp_path, monkeypatch)
+    try:
+        oid = uuid4()
+        payload = {
+            "content": "",
+            "text": "",
+            "raw_text": "---\ntitle: Panel only\n---\n%% AI:Start %%\ntransient\n%% AI:End %%\n",
+            "indexable_text_source": "content",
+        }
+        get_object_store().put(
+            oid,
+            kind="note",
+            source_ref="unit-test://explicit-empty-vault-body",
+            payload=payload,
+        )
+
+        reset_diagnose_cache()
+        assert inspect_unembedded_pg_objects(limit=10) == (0, [])
+        result = CliRunner().invoke(
+            cli,
+            ["index", "reconcile", "--backend", "pg", "--json", "--strict"],
+            env=dict(os.environ),
+        )
+        assert result.exit_code == 0, result.output
+        summary = json.loads(result.output)
+        assert summary["reconciled"] == 0
+        assert summary["purged_non_indexable"] == 0
+        with _connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT count(*) AS total FROM store_vector_index WHERE object_id = %s",
+                    (oid,),
+                )
+                assert cur.fetchone()["total"] == 0
+        reset_diagnose_cache()
+        assert inspect_unembedded_pg_objects(limit=10) == (0, [])
+    finally:
+        reset_diagnose_cache()
+        _reset_store_backend_cache_only()
+        _drop_schema(base_dsn, schema)
+
+
+@pytest.mark.pg
 def test_reconcile_purges_equal_empty_hash_panel_only_vector(tmp_path, monkeypatch) -> None:
     """A legacy panel vector is purgeable even when its hash already looks clean."""
     if not _pg_available():

--- a/tests/index/test_provenance_stamp.py
+++ b/tests/index/test_provenance_stamp.py
@@ -21,6 +21,7 @@ import os
 
 import pytest
 
+from app.agents.panel.filters import strip_ai_panels
 from app.components.embeddings import EmbeddingIdentity
 from app.index.artifact_metadata import compute_content_hash
 from app.ingest.chunk_policy import CHUNK_POLICY_VERSION
@@ -169,6 +170,51 @@ def test_doctor_lists_stale_candidates(tmp_path, monkeypatch) -> None:
 
 
 @pytest.mark.pg
+def test_doctor_uses_rebuild_text_precedence_for_content_hash(tmp_path, monkeypatch) -> None:
+    """Doctor hashes the same ``content`` field that rebuild embeds when both
+    ``content`` and a divergent legacy ``text`` field are present."""
+    if not _pg_available():
+        pytest.skip("Postgres backend not available")
+
+    from app.index.doctor import diagnose_index, reset_diagnose_cache
+    from app.stores import get_object_store
+    from tests.indexer.test_outbox_roundtrip_pg import (
+        _configure_isolated_pg_test,
+        _drop_schema,
+        _reset_store_backend_cache_only,
+    )
+
+    base_dsn, schema = _configure_isolated_pg_test(tmp_path, monkeypatch)
+    reset_diagnose_cache()
+    try:
+        from app.search import service as search_service
+
+        canonical_content = "producer-selected content"
+        oid, _dim = search_service.ingest_object(
+            kind="note",
+            source_ref="unit-test://doctor-content-precedence",
+            payload={"content": canonical_content, "text": "legacy shadow text"},
+            text=canonical_content,
+        )
+        get_object_store().put(
+            oid,
+            kind="note",
+            source_ref="unit-test://doctor-content-precedence",
+            payload={"content": canonical_content, "text": "legacy shadow text"},
+        )
+
+        reset_diagnose_cache()
+        result = diagnose_index()
+        staleness = result.get("content_hash_staleness") or {}
+        assert staleness.get("stale_count", 0) == 0
+        assert str(oid) not in (staleness.get("stale_sample_ids") or [])
+    finally:
+        reset_diagnose_cache()
+        _reset_store_backend_cache_only()
+        _drop_schema(base_dsn, schema)
+
+
+@pytest.mark.pg
 def test_reconcile_incremental_on_stale_only(tmp_path, monkeypatch) -> None:
     """`index reconcile` re-embeds only stale rows: unchanged rows are untouched."""
     if not _pg_available():
@@ -214,14 +260,25 @@ def test_reconcile_incremental_on_stale_only(tmp_path, monkeypatch) -> None:
             payload={"text": "fresh unchanged", "content": "fresh unchanged"},
         )
 
-        # Simulate content drift on ONE object only: store_objects text
-        # changes but the durable vector row (and its stamped content_hash)
-        # is untouched until reconcile runs.
+        # Simulate content drift on ONE object only. The authoritative
+        # ``content`` field includes an AI panel while the legacy ``text``
+        # field diverges; reconcile and doctor must both use content-first
+        # precedence and the producer's panel-stripping hash canonicalization.
+        changed_content = """stale changed
+
+%% AI:Start %%
+## AI-instruktion
+Transient panel text.
+%% AI:End %%
+"""
         with _connect() as conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    "UPDATE store_objects SET payload = payload || '{\"text\": \"stale changed\", \"content\": \"stale changed\"}'::jsonb WHERE object_id = %s",
-                    (stale_oid,),
+                    "UPDATE store_objects "
+                    "SET payload = payload || "
+                    "jsonb_build_object('content', %s::text, 'text', %s::text) "
+                    "WHERE object_id = %s",
+                    (changed_content, "legacy shadow text", stale_oid),
                 )
 
         runner = CliRunner()
@@ -238,12 +295,21 @@ def test_reconcile_incremental_on_stale_only(tmp_path, monkeypatch) -> None:
                 )
                 rows_after = {row["object_id"]: row["content_hash"] for row in cur.fetchall()}
 
-        # Stale row is re-embedded: its content_hash now matches the new text.
-        assert rows_after[stale_oid] == compute_content_hash("stale changed")
+        # Stale row is re-embedded: its hash matches the producer's canonical
+        # panel-free form of the selected content field.
+        assert rows_after[stale_oid] == compute_content_hash(strip_ai_panels(changed_content))
 
         # Fresh (unchanged) row is untouched: same content_hash as before —
         # incremental repair, not a blanket re-embed of the whole index.
         assert rows_after[fresh_oid] == compute_content_hash("fresh unchanged")
+
+        from app.index.doctor import diagnose_index, reset_diagnose_cache
+
+        reset_diagnose_cache()
+        diagnosis = diagnose_index()
+        staleness = diagnosis.get("content_hash_staleness") or {}
+        assert staleness.get("stale_count", 0) == 0
+        assert str(stale_oid) not in (staleness.get("stale_sample_ids") or [])
     finally:
         _reset_store_backend_cache_only()
         _drop_schema(base_dsn, schema)

--- a/tests/index/test_provenance_stamp.py
+++ b/tests/index/test_provenance_stamp.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import os
+from uuid import uuid4
 
 import pytest
 
@@ -177,8 +178,12 @@ def test_doctor_uses_rebuild_text_precedence_for_content_hash(tmp_path, monkeypa
     if not _pg_available():
         pytest.skip("Postgres backend not available")
 
+    from click.testing import CliRunner
+
+    from app.cli import cli
     from app.index.doctor import diagnose_index, reset_diagnose_cache
     from app.stores import get_object_store
+    from app.stores.pg import _connect
     from tests.indexer.test_outbox_roundtrip_pg import (
         _configure_isolated_pg_test,
         _drop_schema,
@@ -188,20 +193,36 @@ def test_doctor_uses_rebuild_text_precedence_for_content_hash(tmp_path, monkeypa
     base_dsn, schema = _configure_isolated_pg_test(tmp_path, monkeypatch)
     reset_diagnose_cache()
     try:
-        from app.search import service as search_service
-
         canonical_content = "producer-selected content"
-        oid, _dim = search_service.ingest_object(
-            kind="note",
-            source_ref="unit-test://doctor-content-precedence",
-            payload={"content": canonical_content, "text": "legacy shadow text"},
-            text=canonical_content,
-        )
+        oid = uuid4()
         get_object_store().put(
             oid,
             kind="note",
             source_ref="unit-test://doctor-content-precedence",
             payload={"content": canonical_content, "text": "legacy shadow text"},
+        )
+
+        rebuild = CliRunner().invoke(
+            cli,
+            ["index", "rebuild", "--backend", "pg", "--json", "--strict"],
+            env=dict(os.environ),
+        )
+        assert rebuild.exit_code == 0, rebuild.output
+        rebuild_summary = json.loads(rebuild.output)
+        assert rebuild_summary["processed"] == 1
+
+        with _connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT payload FROM store_vector_index WHERE object_id = %s",
+                    (oid,),
+                )
+                vector_row = cur.fetchone()
+
+        assert vector_row["payload"]["content"] == canonical_content
+        assert vector_row["payload"]["text"] == canonical_content
+        assert vector_row["payload"]["provenance"]["content_hash"] == compute_content_hash(
+            canonical_content
         )
 
         reset_diagnose_cache()

--- a/tests/index/test_provenance_stamp.py
+++ b/tests/index/test_provenance_stamp.py
@@ -17,6 +17,7 @@ auto-mutates.
 
 from __future__ import annotations
 
+import json
 import os
 
 import pytest
@@ -339,6 +340,81 @@ Transient panel text.
         staleness = diagnosis.get("content_hash_staleness") or {}
         assert staleness.get("stale_count", 0) == 0
         assert str(stale_oid) not in (staleness.get("stale_sample_ids") or [])
+    finally:
+        _reset_store_backend_cache_only()
+        _drop_schema(base_dsn, schema)
+
+
+@pytest.mark.pg
+def test_reconcile_purges_vector_for_present_non_indexable_source(tmp_path, monkeypatch) -> None:
+    """Explicit reconcile removes derived bytes after their source becomes non-indexable."""
+    if not _pg_available():
+        pytest.skip("Postgres backend not available")
+
+    from click.testing import CliRunner
+
+    from app.cli import cli
+    from app.index.doctor import inspect_unembedded_pg_objects
+    from app.stores import get_object_store
+    from app.stores.pg import _connect, inspect_pg_content_hash_staleness
+    from tests.indexer.test_outbox_roundtrip_pg import (
+        _configure_isolated_pg_test,
+        _drop_schema,
+        _reset_store_backend_cache_only,
+    )
+
+    base_dsn, schema = _configure_isolated_pg_test(tmp_path, monkeypatch)
+    try:
+        from app.search import service as search_service
+
+        oid, _ = search_service.ingest_object(
+            kind="note",
+            source_ref="unit-test://reconcile-non-indexable",
+            payload={"content": "previous source text", "text": "previous source text"},
+            text="previous source text",
+        )
+        get_object_store().put(
+            oid,
+            kind="note",
+            source_ref="unit-test://reconcile-non-indexable",
+            payload={"content": "previous source text", "text": "previous source text"},
+        )
+
+        authoritative_payload = {"url": "https://example.invalid/now-contentless"}
+        with _connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE store_objects SET payload = %s::jsonb WHERE object_id = %s",
+                    (json.dumps(authoritative_payload), oid),
+                )
+
+        result = CliRunner().invoke(
+            cli,
+            ["index", "reconcile", "--backend", "pg", "--json", "--strict"],
+            env=dict(os.environ),
+        )
+        assert result.exit_code == 0, result.output
+        summary = json.loads(result.output)
+        assert summary["purged_non_indexable"] == 1
+        assert summary["reconciled"] == 0
+
+        with _connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT payload FROM store_objects WHERE object_id = %s",
+                    (oid,),
+                )
+                source_row = cur.fetchone()
+                cur.execute(
+                    "SELECT count(*) AS total FROM store_vector_index WHERE object_id = %s",
+                    (oid,),
+                )
+                vector_row = cur.fetchone()
+
+        assert source_row["payload"] == authoritative_payload
+        assert vector_row["total"] == 0
+        assert inspect_unembedded_pg_objects(limit=10) == (0, [])
+        assert inspect_pg_content_hash_staleness()["stale_count"] == 0
     finally:
         _reset_store_backend_cache_only()
         _drop_schema(base_dsn, schema)

--- a/tests/index/test_provenance_stamp.py
+++ b/tests/index/test_provenance_stamp.py
@@ -25,7 +25,7 @@ import pytest
 
 from app.agents.panel.filters import strip_ai_panels
 from app.components.embeddings import EmbeddingIdentity
-from app.index.artifact_metadata import compute_content_hash
+from app.index.artifact_metadata import canonicalize_indexable_text, compute_content_hash
 from app.ingest.chunk_policy import CHUNK_POLICY_VERSION
 from app.settings.models import SettingsBundle
 
@@ -54,9 +54,55 @@ def _isolate_llm_routing_settings(monkeypatch) -> None:
 class CapturingVectorIndex:
     def __init__(self) -> None:
         self.calls: list[dict] = []
+        self.purge_calls: list[tuple[object, str]] = []
 
     def upsert(self, **kwargs) -> None:
         self.calls.append(kwargs)
+
+    def purge_vectors(self, object_id, *, view: str) -> int:
+        self.purge_calls.append((object_id, view))
+        return 0
+
+
+def _seed_legacy_panel_vector(*, source_ref: str) -> tuple[object, str]:
+    """Construct the pre-fix panel-only vector state without a live producer."""
+    from app.search import service as search_service
+    from app.stores import get_object_store
+    from app.stores.pg import _connect
+
+    placeholder = "legacy placeholder used only to create a vector row"
+    panel_only = "%% AI:Start %%\nLegacy indexed panel bytes.\n%% AI:End %%"
+    oid, _ = search_service.ingest_object(
+        kind="note",
+        source_ref=source_ref,
+        payload={"content": placeholder, "text": placeholder},
+        text=placeholder,
+    )
+    get_object_store().put(
+        oid,
+        kind="note",
+        source_ref=source_ref,
+        payload={"content": panel_only, "text": panel_only},
+    )
+
+    with _connect() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT payload FROM store_vector_index WHERE object_id = %s",
+                (oid,),
+            )
+            vector_payload = dict(cur.fetchone()["payload"])
+            vector_payload["content"] = panel_only
+            vector_payload["text"] = panel_only
+            provenance = dict(vector_payload.get("provenance") or {})
+            provenance["content_hash"] = compute_content_hash("")
+            vector_payload["provenance"] = provenance
+            cur.execute(
+                "UPDATE store_vector_index SET payload = %s::jsonb WHERE object_id = %s",
+                (json.dumps(vector_payload), oid),
+            )
+
+    return oid, panel_only
 
 
 def test_upsert_writes_provenance(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -90,6 +136,70 @@ def test_upsert_writes_provenance(monkeypatch: pytest.MonkeyPatch) -> None:
         "dim": identity.dim,
         "normalize": identity.normalize,
     }
+
+
+def test_ingest_object_embeds_hashes_and_projects_exact_canonical_bytes(monkeypatch) -> None:
+    from app.search import service as search_service
+
+    identity = EmbeddingIdentity(provider="mock", model="mock-embedding", dim=3, normalize=True)
+    index = CapturingVectorIndex()
+    embedded_texts: list[str] = []
+
+    def fake_embed(text: str):
+        embedded_texts.append(text)
+        return [0.1, 0.2, 0.3], identity
+
+    monkeypatch.setattr(search_service, "embed_query", fake_embed)
+    monkeypatch.setattr(search_service, "get_vector_index", lambda: index)
+
+    raw = "\n".join(
+        (
+            "retained before",
+            "%% AI:Start %%",
+            "fenced panel",
+            "%% AI:End %%",
+            "## AI-instruktion",
+            "legacy panel",
+            "## Retained section",
+            "retained after",
+        )
+    )
+    canonical = canonicalize_indexable_text({"content": raw})
+
+    search_service.ingest_object(
+        kind="note",
+        source_ref="unit-test://producer-exact-bytes",
+        payload={"content": raw, "text": "stale alias"},
+        text=raw,
+    )
+
+    assert embedded_texts == [canonical]
+    payload = index.calls[-1]["payload"]
+    assert payload["content"] == canonical
+    assert payload["text"] == canonical
+    assert payload["provenance"]["content_hash"] == compute_content_hash(canonical)
+
+
+def test_ingest_object_does_not_recreate_panel_only_vector(monkeypatch) -> None:
+    from app.search import service as search_service
+
+    index = CapturingVectorIndex()
+    monkeypatch.setattr(search_service, "get_vector_index", lambda: index)
+
+    def unexpected_embed(_text: str):
+        raise AssertionError("panel-only source must not reach the embedder")
+
+    monkeypatch.setattr(search_service, "embed_query", unexpected_embed)
+    oid, dim = search_service.ingest_object(
+        kind="note",
+        source_ref="unit-test://producer-panel-only",
+        payload={"content": "\n%% AI:Start %%\ntransient\n%% AI:End %%\n\n"},
+        text="\n%% AI:Start %%\ntransient\n%% AI:End %%\n\n",
+    )
+
+    assert dim == 0
+    assert index.calls == []
+    assert index.purge_calls == [(oid, "markdown.semantic")]
 
 
 def test_content_hash_is_stable_for_same_text() -> None:
@@ -465,7 +575,6 @@ def test_reconcile_purges_equal_empty_hash_panel_only_vector(tmp_path, monkeypat
 
     from app.cli import cli
     from app.index.doctor import inspect_unembedded_pg_objects, reset_diagnose_cache
-    from app.stores import get_object_store
     from app.stores.pg import _connect, inspect_pg_content_hash_staleness
     from tests.indexer.test_outbox_roundtrip_pg import (
         _configure_isolated_pg_test,
@@ -475,20 +584,8 @@ def test_reconcile_purges_equal_empty_hash_panel_only_vector(tmp_path, monkeypat
 
     base_dsn, schema = _configure_isolated_pg_test(tmp_path, monkeypatch)
     try:
-        from app.search import service as search_service
-
-        panel_only = "%% AI:Start %%\nLegacy indexed panel bytes.\n%% AI:End %%"
-        oid, _ = search_service.ingest_object(
-            kind="note",
-            source_ref="unit-test://reconcile-equal-empty-panel",
-            payload={"content": panel_only, "text": panel_only},
-            text=panel_only,
-        )
-        get_object_store().put(
-            oid,
-            kind="note",
-            source_ref="unit-test://reconcile-equal-empty-panel",
-            payload={"content": panel_only, "text": panel_only},
+        oid, panel_only = _seed_legacy_panel_vector(
+            source_ref="unit-test://reconcile-equal-empty-panel"
         )
 
         with _connect() as conn:
@@ -537,6 +634,176 @@ def test_reconcile_purges_equal_empty_hash_panel_only_vector(tmp_path, monkeypat
         assert inspect_pg_content_hash_staleness()["stale_count"] == 0
     finally:
         reset_diagnose_cache()
+        _reset_store_backend_cache_only()
+        _drop_schema(base_dsn, schema)
+
+
+@pytest.mark.pg
+def test_reconcile_reclassifies_source_update_before_conditional_purge(
+    tmp_path, monkeypatch
+) -> None:
+    """A concurrent source repair is embedded rather than purged from a stale read."""
+    if not _pg_available():
+        pytest.skip("Postgres backend not available")
+
+    from click.testing import CliRunner
+
+    from app.cli import cli
+    from app.stores.pg import _connect
+    from tests.indexer.test_outbox_roundtrip_pg import (
+        _configure_isolated_pg_test,
+        _drop_schema,
+        _reset_store_backend_cache_only,
+    )
+
+    base_dsn, schema = _configure_isolated_pg_test(tmp_path, monkeypatch)
+    try:
+        oid, _panel_only = _seed_legacy_panel_vector(
+            source_ref="unit-test://reconcile-source-update-race"
+        )
+        repaired_raw = "retained before\n%% AI:Start %%\ntransient\n%% AI:End %%\nretained after"
+        repaired_canonical = canonicalize_indexable_text({"content": repaired_raw})
+
+        import importlib
+
+        rebuild_module = importlib.import_module("app.cli.index_rebuild")
+        original_resolve = rebuild_module._reconcile_object_payload
+        resolved_client = rebuild_module.get_embedding_client(profile="default")
+        embedded_texts: list[str] = []
+        raced = False
+
+        class CapturingClient:
+            identity = resolved_client.identity
+
+            def embed_text(self, text: str) -> list[float]:
+                embedded_texts.append(text)
+                return resolved_client.embed_text(text)
+
+        def update_after_stale_read(object_id, vector_payload):
+            nonlocal raced
+            result = original_resolve(object_id, vector_payload)
+            if not raced:
+                with _connect() as conn:
+                    with conn.cursor() as cur:
+                        cur.execute(
+                            "UPDATE store_objects SET payload = %s::jsonb WHERE object_id = %s",
+                            (json.dumps({"content": repaired_raw, "text": "stale alias"}), oid),
+                        )
+                raced = True
+            return result
+
+        monkeypatch.setattr(rebuild_module, "_reconcile_object_payload", update_after_stale_read)
+        monkeypatch.setattr(
+            rebuild_module,
+            "get_embedding_client",
+            lambda *, profile="default": CapturingClient(),
+        )
+
+        result = CliRunner().invoke(
+            cli,
+            ["index", "reconcile", "--backend", "pg", "--json", "--strict"],
+            env=dict(os.environ),
+        )
+        assert result.exit_code == 0, result.output
+        summary = json.loads(result.output)
+        assert summary["purged_non_indexable"] == 0
+        assert summary["reconciled"] == 1
+        assert embedded_texts == [repaired_canonical]
+
+        with _connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT payload FROM store_objects WHERE object_id = %s",
+                    (oid,),
+                )
+                source_payload = cur.fetchone()["payload"]
+                cur.execute(
+                    "SELECT payload FROM store_vector_index WHERE object_id = %s",
+                    (oid,),
+                )
+                vector_payload = cur.fetchone()["payload"]
+
+        assert source_payload == {"content": repaired_raw, "text": "stale alias"}
+        assert vector_payload["content"] == repaired_canonical
+        assert vector_payload["text"] == repaired_canonical
+        assert vector_payload["provenance"]["content_hash"] == compute_content_hash(
+            repaired_canonical
+        )
+    finally:
+        _reset_store_backend_cache_only()
+        _drop_schema(base_dsn, schema)
+
+
+@pytest.mark.pg
+def test_reconcile_reclassifies_source_delete_before_conditional_purge(
+    tmp_path, monkeypatch
+) -> None:
+    """A concurrently deleted source retains the existing vector fallback."""
+    if not _pg_available():
+        pytest.skip("Postgres backend not available")
+
+    from click.testing import CliRunner
+
+    from app.cli import cli
+    from app.stores.pg import _connect
+    from tests.indexer.test_outbox_roundtrip_pg import (
+        _configure_isolated_pg_test,
+        _drop_schema,
+        _reset_store_backend_cache_only,
+    )
+
+    base_dsn, schema = _configure_isolated_pg_test(tmp_path, monkeypatch)
+    try:
+        oid, panel_only = _seed_legacy_panel_vector(
+            source_ref="unit-test://reconcile-source-delete-race"
+        )
+
+        import importlib
+
+        rebuild_module = importlib.import_module("app.cli.index_rebuild")
+        original_resolve = rebuild_module._reconcile_object_payload
+        raced = False
+
+        def delete_after_stale_read(object_id, vector_payload):
+            nonlocal raced
+            result = original_resolve(object_id, vector_payload)
+            if not raced:
+                with _connect() as conn:
+                    with conn.cursor() as cur:
+                        cur.execute("DELETE FROM store_objects WHERE object_id = %s", (oid,))
+                raced = True
+            return result
+
+        monkeypatch.setattr(rebuild_module, "_reconcile_object_payload", delete_after_stale_read)
+
+        result = CliRunner().invoke(
+            cli,
+            ["index", "reconcile", "--backend", "pg", "--json", "--strict"],
+            env=dict(os.environ),
+        )
+        assert result.exit_code == 0, result.output
+        summary = json.loads(result.output)
+        assert summary["purged_non_indexable"] == 0
+        assert summary["reconciled"] == 0
+        assert summary["skipped"] == 1
+
+        with _connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT count(*) AS total FROM store_objects WHERE object_id = %s",
+                    (oid,),
+                )
+                assert cur.fetchone()["total"] == 0
+                cur.execute(
+                    "SELECT payload FROM store_vector_index WHERE object_id = %s",
+                    (oid,),
+                )
+                vector_row = cur.fetchone()
+
+        assert vector_row is not None
+        assert vector_row["payload"]["content"] == panel_only
+        assert vector_row["payload"]["provenance"]["content_hash"] == compute_content_hash("")
+    finally:
         _reset_store_backend_cache_only()
         _drop_schema(base_dsn, schema)
 

--- a/tests/index/test_provenance_stamp.py
+++ b/tests/index/test_provenance_stamp.py
@@ -453,3 +453,80 @@ def test_reconcile_purges_vector_for_present_non_indexable_source(tmp_path, monk
     finally:
         _reset_store_backend_cache_only()
         _drop_schema(base_dsn, schema)
+
+
+@pytest.mark.pg
+def test_reconcile_absent_source_retains_vector_payload_fallback(tmp_path, monkeypatch) -> None:
+    """An orphaned vector remains reconcilable from its derived payload."""
+    if not _pg_available():
+        pytest.skip("Postgres backend not available")
+
+    from click.testing import CliRunner
+
+    from app.cli import cli
+    from app.stores.pg import _connect
+    from tests.indexer.test_outbox_roundtrip_pg import (
+        _configure_isolated_pg_test,
+        _drop_schema,
+        _reset_store_backend_cache_only,
+    )
+
+    base_dsn, schema = _configure_isolated_pg_test(tmp_path, monkeypatch)
+    try:
+        from app.search import service as search_service
+
+        fallback_text = "orphaned derived fallback"
+        oid, _ = search_service.ingest_object(
+            kind="note",
+            source_ref="unit-test://reconcile-absent-source",
+            payload={"content": fallback_text, "text": fallback_text},
+            text=fallback_text,
+        )
+
+        with _connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE store_vector_index "
+                    "SET provider = %s, model = %s "
+                    "WHERE object_id = %s",
+                    ("legacy-provider", "legacy-model", oid),
+                )
+                cur.execute(
+                    "SELECT count(*) AS total FROM store_objects WHERE object_id = %s",
+                    (oid,),
+                )
+                assert cur.fetchone()["total"] == 0
+
+        result = CliRunner().invoke(
+            cli,
+            ["index", "reconcile", "--backend", "pg", "--json", "--strict"],
+            env=dict(os.environ),
+        )
+        assert result.exit_code == 0, result.output
+        summary = json.loads(result.output)
+        assert summary["reconciled"] == 1
+        assert summary["purged_non_indexable"] == 0
+        assert summary["skipped"] == 0
+
+        with _connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT payload, provider, model FROM store_vector_index "
+                    "WHERE object_id = %s",
+                    (oid,),
+                )
+                vector_row = cur.fetchone()
+                cur.execute(
+                    "SELECT count(*) AS total FROM store_objects WHERE object_id = %s",
+                    (oid,),
+                )
+                source_count = cur.fetchone()["total"]
+
+        assert vector_row["payload"]["content"] == fallback_text
+        assert vector_row["payload"]["text"] == fallback_text
+        assert vector_row["provider"] == "mock"
+        assert vector_row["model"] == "mock-embedding"
+        assert source_count == 0
+    finally:
+        _reset_store_backend_cache_only()
+        _drop_schema(base_dsn, schema)

--- a/tests/index/test_provenance_stamp.py
+++ b/tests/index/test_provenance_stamp.py
@@ -281,6 +281,25 @@ Transient panel text.
                     (changed_content, "legacy shadow text", stale_oid),
                 )
 
+        import importlib
+
+        rebuild_module = importlib.import_module("app.cli.index_rebuild")
+        resolved_client = rebuild_module.get_embedding_client(profile="default")
+        embedded_texts: list[str] = []
+
+        class CapturingClient:
+            identity = resolved_client.identity
+
+            def embed_text(self, text: str) -> list[float]:
+                embedded_texts.append(text)
+                return resolved_client.embed_text(text)
+
+        monkeypatch.setattr(
+            rebuild_module,
+            "get_embedding_client",
+            lambda *, profile="default": CapturingClient(),
+        )
+
         runner = CliRunner()
         env = dict(os.environ)
         result = runner.invoke(cli, ["index", "reconcile", "--backend", "pg", "--json"], env=env)
@@ -289,19 +308,29 @@ Transient panel text.
         with _connect() as conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    "SELECT object_id, payload->'provenance'->>'content_hash' AS content_hash "
+                    "SELECT object_id, payload, "
+                    "payload->'provenance'->>'content_hash' AS content_hash "
                     "FROM store_vector_index WHERE object_id IN (%s, %s)",
                     (stale_oid, fresh_oid),
                 )
-                rows_after = {row["object_id"]: row["content_hash"] for row in cur.fetchall()}
+                rows_after = {row["object_id"]: row for row in cur.fetchall()}
 
         # Stale row is re-embedded: its hash matches the producer's canonical
         # panel-free form of the selected content field.
-        assert rows_after[stale_oid] == compute_content_hash(strip_ai_panels(changed_content))
+        assert rows_after[stale_oid]["content_hash"] == compute_content_hash(
+            strip_ai_panels(changed_content)
+        )
+        # The derived retrieval payload must also carry the authoritative
+        # source text.  Otherwise doctor can report convergence while hybrid
+        # retrieval still serves the legacy ``text`` alias.
+        canonical_changed_content = strip_ai_panels(changed_content)
+        assert embedded_texts == [canonical_changed_content]
+        assert rows_after[stale_oid]["payload"]["content"] == canonical_changed_content
+        assert rows_after[stale_oid]["payload"]["text"] == canonical_changed_content
 
         # Fresh (unchanged) row is untouched: same content_hash as before —
         # incremental repair, not a blanket re-embed of the whole index.
-        assert rows_after[fresh_oid] == compute_content_hash("fresh unchanged")
+        assert rows_after[fresh_oid]["content_hash"] == compute_content_hash("fresh unchanged")
 
         from app.index.doctor import diagnose_index, reset_diagnose_cache
 

--- a/tests/index/test_provenance_stamp.py
+++ b/tests/index/test_provenance_stamp.py
@@ -456,6 +456,92 @@ def test_reconcile_purges_vector_for_present_non_indexable_source(tmp_path, monk
 
 
 @pytest.mark.pg
+def test_reconcile_purges_equal_empty_hash_panel_only_vector(tmp_path, monkeypatch) -> None:
+    """A legacy panel vector is purgeable even when its hash already looks clean."""
+    if not _pg_available():
+        pytest.skip("Postgres backend not available")
+
+    from click.testing import CliRunner
+
+    from app.cli import cli
+    from app.index.doctor import inspect_unembedded_pg_objects, reset_diagnose_cache
+    from app.stores import get_object_store
+    from app.stores.pg import _connect, inspect_pg_content_hash_staleness
+    from tests.indexer.test_outbox_roundtrip_pg import (
+        _configure_isolated_pg_test,
+        _drop_schema,
+        _reset_store_backend_cache_only,
+    )
+
+    base_dsn, schema = _configure_isolated_pg_test(tmp_path, monkeypatch)
+    try:
+        from app.search import service as search_service
+
+        panel_only = "%% AI:Start %%\nLegacy indexed panel bytes.\n%% AI:End %%"
+        oid, _ = search_service.ingest_object(
+            kind="note",
+            source_ref="unit-test://reconcile-equal-empty-panel",
+            payload={"content": panel_only, "text": panel_only},
+            text=panel_only,
+        )
+        get_object_store().put(
+            oid,
+            kind="note",
+            source_ref="unit-test://reconcile-equal-empty-panel",
+            payload={"content": panel_only, "text": panel_only},
+        )
+
+        with _connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT payload, provider, model FROM store_vector_index "
+                    "WHERE object_id = %s",
+                    (oid,),
+                )
+                before = cur.fetchone()
+
+        assert before["payload"]["content"] == panel_only
+        assert before["payload"]["provenance"]["content_hash"] == compute_content_hash("")
+        assert before["provider"] == "mock"
+        assert before["model"] == "mock-embedding"
+        assert inspect_pg_content_hash_staleness()["stale_count"] == 0
+
+        result = CliRunner().invoke(
+            cli,
+            ["index", "reconcile", "--backend", "pg", "--json", "--strict"],
+            env=dict(os.environ),
+        )
+        assert result.exit_code == 0, result.output
+        summary = json.loads(result.output)
+        assert summary["total_present_non_indexable"] == 1
+        assert summary["purged_non_indexable"] == 1
+        assert summary["reconciled"] == 0
+
+        with _connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT payload FROM store_objects WHERE object_id = %s",
+                    (oid,),
+                )
+                source_row = cur.fetchone()
+                cur.execute(
+                    "SELECT count(*) AS total FROM store_vector_index WHERE object_id = %s",
+                    (oid,),
+                )
+                vector_total = cur.fetchone()["total"]
+
+        reset_diagnose_cache()
+        assert source_row["payload"] == {"content": panel_only, "text": panel_only}
+        assert vector_total == 0
+        assert inspect_unembedded_pg_objects(limit=10) == (0, [])
+        assert inspect_pg_content_hash_staleness()["stale_count"] == 0
+    finally:
+        reset_diagnose_cache()
+        _reset_store_backend_cache_only()
+        _drop_schema(base_dsn, schema)
+
+
+@pytest.mark.pg
 def test_reconcile_absent_source_retains_vector_payload_fallback(tmp_path, monkeypatch) -> None:
     """An orphaned vector remains reconcilable from its derived payload."""
     if not _pg_available():

--- a/tests/index/test_provenance_stamp.py
+++ b/tests/index/test_provenance_stamp.py
@@ -193,7 +193,21 @@ def test_doctor_uses_rebuild_text_precedence_for_content_hash(tmp_path, monkeypa
     base_dsn, schema = _configure_isolated_pg_test(tmp_path, monkeypatch)
     reset_diagnose_cache()
     try:
-        canonical_content = "producer-selected content"
+        canonical_content = "\n".join(
+            (
+                "producer-selected content",
+                "%% AI:Start %%",
+                "fenced panel text",
+                "%% AI:End %%",
+                "## AI-instruktion",
+                "legacy panel text",
+                "## Retained section",
+                "retained content",
+            )
+        )
+        expected_canonical = "\n".join(
+            ("producer-selected content", "## Retained section", "retained content")
+        )
         oid = uuid4()
         get_object_store().put(
             oid,
@@ -219,10 +233,10 @@ def test_doctor_uses_rebuild_text_precedence_for_content_hash(tmp_path, monkeypa
                 )
                 vector_row = cur.fetchone()
 
-        assert vector_row["payload"]["content"] == canonical_content
-        assert vector_row["payload"]["text"] == canonical_content
+        assert vector_row["payload"]["content"] == expected_canonical
+        assert vector_row["payload"]["text"] == expected_canonical
         assert vector_row["payload"]["provenance"]["content_hash"] == compute_content_hash(
-            canonical_content
+            expected_canonical
         )
 
         reset_diagnose_cache()

--- a/tests/indexer/test_outbox_roundtrip_pg.py
+++ b/tests/indexer/test_outbox_roundtrip_pg.py
@@ -314,6 +314,20 @@ def test_unembedded_objects_fail_loud(tmp_path, monkeypatch) -> None:
             emit_outbox=False,
             trace_id="trace-contentless",
         )
+        panel_only_oid = uuid4()
+        store.save_object(
+            DomainObject(
+                uuid=str(panel_only_oid),
+                kind="note",
+                payload={
+                    "content": "%% AI:Start %%\nTransient panel only.\n%% AI:End %%\n"
+                },
+                source_ref="unit-test:panel-only",
+                created_at=datetime.now(timezone.utc),
+            ),
+            emit_outbox=False,
+            trace_id="trace-panel-only",
+        )
         events.emit_index_embedding_requested(
             {"object_id": oid, "trace_id": "trace-fail-loud", "source": "test"}
         )
@@ -338,6 +352,7 @@ def test_unembedded_objects_fail_loud(tmp_path, monkeypatch) -> None:
         assert unembedded_total == 1
         assert str(oid) in unembedded_samples
         assert str(contentless_oid) not in unembedded_samples
+        assert str(panel_only_oid) not in unembedded_samples
         from app.index.doctor import diagnose_index, reset_diagnose_cache
 
         reset_diagnose_cache()

--- a/tests/indexer/test_outbox_roundtrip_pg.py
+++ b/tests/indexer/test_outbox_roundtrip_pg.py
@@ -320,7 +320,7 @@ def test_unembedded_objects_fail_loud(tmp_path, monkeypatch) -> None:
                 uuid=str(panel_only_oid),
                 kind="note",
                 payload={
-                    "content": "%% AI:Start %%\nTransient panel only.\n%% AI:End %%\n"
+                    "content": "\n%% AI:Start %%\nTransient panel only.\n%% AI:End %%\n\n"
                 },
                 source_ref="unit-test:panel-only",
                 created_at=datetime.now(timezone.utc),

--- a/tests/indexer/test_outbox_roundtrip_pg.py
+++ b/tests/indexer/test_outbox_roundtrip_pg.py
@@ -302,6 +302,18 @@ def test_unembedded_objects_fail_loud(tmp_path, monkeypatch) -> None:
             emit_outbox=False,
             trace_id="trace-fail-loud",
         )
+        contentless_oid = uuid4()
+        store.save_object(
+            DomainObject(
+                uuid=str(contentless_oid),
+                kind="knowledge_acquisition.raw",
+                payload={"url": "https://example.invalid/contentless-source"},
+                source_ref="unit-test:contentless",
+                created_at=datetime.now(timezone.utc),
+            ),
+            emit_outbox=False,
+            trace_id="trace-contentless",
+        )
         events.emit_index_embedding_requested(
             {"object_id": oid, "trace_id": "trace-fail-loud", "source": "test"}
         )
@@ -314,10 +326,18 @@ def test_unembedded_objects_fail_loud(tmp_path, monkeypatch) -> None:
 
         # Drive the REAL production verifier (app.index.doctor.verify_object_embedded),
         # not a self-defined raiser, against the objects-present/no-vector state.
-        from app.index.doctor import IndexDriftError, verify_object_embedded
+        from app.index.doctor import (
+            IndexDriftError,
+            inspect_unembedded_pg_objects,
+            verify_object_embedded,
+        )
 
         with pytest.raises(IndexDriftError, match="present in store_objects but has no embedded"):
             verify_object_embedded(str(oid))
+        unembedded_total, unembedded_samples = inspect_unembedded_pg_objects(limit=10)
+        assert unembedded_total == 1
+        assert str(oid) in unembedded_samples
+        assert str(contentless_oid) not in unembedded_samples
         from app.index.doctor import diagnose_index, reset_diagnose_cache
 
         reset_diagnose_cache()
@@ -330,6 +350,8 @@ def test_unembedded_objects_fail_loud(tmp_path, monkeypatch) -> None:
         assert processed_total >= 1
         reset_diagnose_cache()
         verify_object_embedded(str(oid))
+        diagnosis = diagnose_index()
+        assert not any("store_objects rows have no embedded" in issue for issue in diagnosis["issues"])
     finally:
         _reset_store_backend_cache_only()
         _drop_schema(base_dsn, schema)

--- a/tests/indexer/test_provider_fallback_consumer.py
+++ b/tests/indexer/test_provider_fallback_consumer.py
@@ -7,6 +7,7 @@ import app.objects as legacy_object_store
 import pytest
 
 from app.components.embeddings import EmbeddingIdentity
+from app.index.artifact_metadata import canonicalize_indexable_text, compute_content_hash
 from app.llm import fallback_orchestrator
 from app.llm.embed_queue import EmbedDeadLetterError
 from app.objects import DomainObject, ObjectStore
@@ -17,9 +18,11 @@ from app.stores import reset_store_backends
 class _SpyVectorIndex:
     def __init__(self) -> None:
         self.upsert_calls: list[dict[str, object]] = []
+        self.purge_calls: list[UUID] = []
 
     def purge_vectors(self, object_id: UUID, *, view: str) -> int:
-        del object_id, view
+        del view
+        self.purge_calls.append(object_id)
         return 0
 
     def upsert(self, object_id: UUID, **kwargs) -> None:
@@ -110,3 +113,111 @@ def test_fallback_invoked_from_process_event(monkeypatch: pytest.MonkeyPatch) ->
     assert len(created_events) == 1
     assert created_events[0]["provider"] == "gemini"
     assert created_events[0]["meta"]["fallback_used"] is True
+
+
+def test_process_event_embeds_and_projects_exact_canonical_bytes(monkeypatch) -> None:
+    from app.indexer.consumer import process_event
+
+    identity = EmbeddingIdentity(provider="mock", model="mock-embedding", dim=3)
+    embedder = _FakeEmbeddingClient(identity, [0.1, 0.2, 0.3])
+    spy_index = _SpyVectorIndex()
+    monkeypatch.setattr("app.indexer.consumer.get_embeddings_client", lambda intent: embedder)
+    monkeypatch.setattr("app.indexer.consumer.get_vector_index", lambda: spy_index)
+    monkeypatch.setattr(
+        "app.indexer.consumer.outbox_events.emit_index_embedding_created", lambda **kwargs: None
+    )
+
+    raw = "\n".join(
+        (
+            "retained before",
+            "%% AI:Start %%",
+            "fenced panel",
+            "%% AI:End %%",
+            "## AI-instruktion",
+            "legacy panel",
+            "## Retained section",
+            "retained after",
+        )
+    )
+    canonical = canonicalize_indexable_text({"content": raw})
+    object_id = "44444444-4444-4444-4444-444444444444"
+    ObjectStore().save_object(
+        DomainObject(
+            uuid=object_id,
+            kind="note",
+            payload={"content": raw, "text": "stale alias"},
+            source_ref="vault/canonical-consumer.md",
+            created_at=datetime.now(timezone.utc),
+        ),
+        emit_outbox=False,
+    )
+
+    process_event(
+        {
+            "event": outbox_events.INDEX_EMBEDDING_REQUESTED,
+            "payload": {"object_id": object_id},
+        }
+    )
+
+    assert embedder.calls == [canonical]
+    payload = spy_index.upsert_calls[-1]["payload"]
+    assert payload["content"] == canonical
+    assert payload["text"] == canonical
+    assert payload["provenance"]["content_hash"] == compute_content_hash(canonical)
+
+
+def test_process_event_does_not_recreate_panel_only_vector(monkeypatch) -> None:
+    from app.indexer.consumer import process_event
+
+    identity = EmbeddingIdentity(provider="mock", model="mock-embedding", dim=3)
+    embedder = _FakeEmbeddingClient(identity, [0.1, 0.2, 0.3])
+    spy_index = _SpyVectorIndex()
+    monkeypatch.setattr("app.indexer.consumer.get_embeddings_client", lambda intent: embedder)
+    monkeypatch.setattr("app.indexer.consumer.get_vector_index", lambda: spy_index)
+
+    object_id = "55555555-5555-5555-5555-555555555555"
+    ObjectStore().save_object(
+        DomainObject(
+            uuid=object_id,
+            kind="note",
+            payload={"content": "\n%% AI:Start %%\ntransient\n%% AI:End %%\n\n"},
+            source_ref="vault/panel-only-consumer.md",
+            created_at=datetime.now(timezone.utc),
+        ),
+        emit_outbox=False,
+    )
+
+    process_event(
+        {
+            "event": outbox_events.INDEX_EMBEDDING_REQUESTED,
+            "payload": {"object_id": object_id},
+        }
+    )
+
+    assert embedder.calls == []
+    assert spy_index.upsert_calls == []
+    assert spy_index.purge_calls == [UUID(object_id)]
+
+
+def test_legacy_precomputed_event_rejects_noncanonical_source_bytes(monkeypatch) -> None:
+    from app.indexer.consumer import process_event
+
+    spy_index = _SpyVectorIndex()
+    monkeypatch.setattr("app.indexer.consumer.get_vector_index", lambda: spy_index)
+
+    object_id = "88888888-8888-8888-8888-888888888888"
+    process_event(
+        {
+            "object_id": object_id,
+            "kind": "note",
+            "source_ref": "vault/legacy-precomputed-panel.md",
+            "payload": {
+                "content": "retained\n%% AI:Start %%\ntransient\n%% AI:End %%"
+            },
+            "embedding": [0.1, 0.2, 0.3],
+            "model": "legacy-model",
+        }
+    )
+
+    assert spy_index.upsert_calls == []
+    assert spy_index.purge_calls == [UUID(object_id)]

--- a/tests/indexer/test_provider_fallback_consumer.py
+++ b/tests/indexer/test_provider_fallback_consumer.py
@@ -199,6 +199,37 @@ def test_process_event_does_not_recreate_panel_only_vector(monkeypatch) -> None:
     assert spy_index.purge_calls == [UUID(object_id)]
 
 
+def test_process_event_retries_when_panel_only_purge_fails(monkeypatch) -> None:
+    from app.indexer.consumer import process_event
+
+    class FailingPurgeIndex(_SpyVectorIndex):
+        def purge_vectors(self, object_id: UUID, *, view: str) -> int:
+            raise ConnectionError("postgres unavailable")
+
+    monkeypatch.setattr(
+        "app.indexer.consumer.get_vector_index", lambda: FailingPurgeIndex()
+    )
+    object_id = "56565656-5656-5656-5656-565656565656"
+    ObjectStore().save_object(
+        DomainObject(
+            uuid=object_id,
+            kind="note",
+            payload={"content": "%% AI:Start %%\ntransient\n%% AI:End %%"},
+            source_ref="vault/panel-only-retry.md",
+            created_at=datetime.now(timezone.utc),
+        ),
+        emit_outbox=False,
+    )
+
+    with pytest.raises(ConnectionError, match="postgres unavailable"):
+        process_event(
+            {
+                "event": outbox_events.INDEX_EMBEDDING_REQUESTED,
+                "payload": {"object_id": object_id},
+            }
+        )
+
+
 def test_legacy_precomputed_event_rejects_noncanonical_source_bytes(monkeypatch) -> None:
     from app.indexer.consumer import process_event
 
@@ -221,3 +252,29 @@ def test_legacy_precomputed_event_rejects_noncanonical_source_bytes(monkeypatch)
 
     assert spy_index.upsert_calls == []
     assert spy_index.purge_calls == [UUID(object_id)]
+
+
+def test_legacy_precomputed_rejection_retries_when_purge_fails(monkeypatch) -> None:
+    from app.indexer.consumer import process_event
+
+    class FailingPurgeIndex(_SpyVectorIndex):
+        def purge_vectors(self, object_id: UUID, *, view: str) -> int:
+            raise ConnectionError("postgres unavailable")
+
+    monkeypatch.setattr(
+        "app.indexer.consumer.get_vector_index", lambda: FailingPurgeIndex()
+    )
+
+    with pytest.raises(ConnectionError, match="postgres unavailable"):
+        process_event(
+            {
+                "object_id": "89898989-8989-8989-8989-898989898989",
+                "kind": "note",
+                "source_ref": "vault/legacy-precomputed-panel-retry.md",
+                "payload": {
+                    "content": "retained\n%% AI:Start %%\ntransient\n%% AI:End %%"
+                },
+                "embedding": [0.1, 0.2, 0.3],
+                "model": "legacy-model",
+            }
+        )

--- a/tests/ingest/test_vault_alpha_title_fallback.py
+++ b/tests/ingest/test_vault_alpha_title_fallback.py
@@ -73,4 +73,7 @@ def test_vault_alpha_title_fallbacks_and_search_titles(tmp_path: Path, monkeypat
     assert all(title for title in index_titles)
     assert "Heading Title" in index_titles
     assert "First line title" in index_titles
-    assert "NoHeading" in index_titles
+    # The source object still receives its filename-derived title, but an
+    # otherwise empty note is canonically non-indexable and must not create a
+    # vector row merely to project that metadata.
+    assert "NoHeading" not in index_titles

--- a/tests/ops/test_ci_workflow.py
+++ b/tests/ops/test_ci_workflow.py
@@ -55,6 +55,7 @@ def test_pr_index_pg_contracts_run_exact_acceptance_surface() -> None:
     assert "pgvector/pgvector:pg16" in job
     assert "dorny/paths-filter@v3" in job
     assert "app/cli/index_rebuild.py" in job
+    assert "app/agents/panel/**" in job
     assert "tests/index/test_provenance_stamp.py" in job
     assert "tests/indexer/test_outbox_roundtrip_pg.py" in job
     assert '-m "pg"' in job

--- a/tests/ops/test_ci_workflow.py
+++ b/tests/ops/test_ci_workflow.py
@@ -44,6 +44,22 @@ def test_pr_ci_selects_subsystem_scoped_pytest_targets() -> None:
     assert "tests/eval/test_classification_golden.py" in job
 
 
+def test_pr_index_pg_contracts_run_exact_acceptance_surface() -> None:
+    workflow = _smoke_text()
+
+    assert "pr-index-pg-contracts:" in workflow
+    job = workflow[
+        workflow.index("pr-index-pg-contracts:") : workflow.index("contract-validation:")
+    ]
+    assert "if: github.event_name == 'pull_request'" in job
+    assert "pgvector/pgvector:pg16" in job
+    assert "dorny/paths-filter@v3" in job
+    assert "app/cli/index_rebuild.py" in job
+    assert "tests/index/test_provenance_stamp.py" in job
+    assert "tests/indexer/test_outbox_roundtrip_pg.py" in job
+    assert '-m "pg"' in job
+
+
 def test_pr_ci_fetches_base_ref_before_diff_selection() -> None:
     job = _unit_tests_job_text()
 

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -47,7 +47,7 @@ APP_ROOT = REPO_ROOT / "app"
 # NEVER run against a real vault -- they are not part of this census.
 
 REGISTERED_MIRRORS: dict[tuple[str, int], str] = {
-    ("app/services/indexer.py", 137): (
+    ("app/services/indexer.py", 139): (
         "T-materialize sink (handle_ingest_object_created): the INGEST_OBJECT_CREATED "
         "event that CAUSED this row is its own record -- emitting a second event here "
         "would be a duplicate, not completeness (formal-model.md T-materialize)."
@@ -1428,28 +1428,28 @@ STORE_PAYLOAD_SINK_CLASSIFICATION: dict[tuple[str, int], str] = {
         "carries_via_indexed_unit_builder: cold rebuild re-embeds store_objects rows through "
         "build_indexed_unit_payload (defaults episode_ref) -> idx.upsert -> store_vector_index."
     ),
-    ("app/cli/index_rebuild.py", 685): (
+    ("app/cli/index_rebuild.py", 710): (
         "carries_via_indexed_unit_builder: fallback rebuild upsert via build_indexed_unit_payload "
         "-> store_vector_index."
     ),
-    ("app/indexer/consumer.py", 73): (
+    ("app/indexer/consumer.py", 84): (
         "carries_via_indexed_unit_builder: legacy embedding-in-event path; payload = "
         "build_indexed_unit_payload(...) -> idx.upsert -> store_vector_index."
     ),
-    ("app/indexer/consumer.py", 162): (
+    ("app/indexer/consumer.py", 176): (
         "carries_via_indexed_unit_builder: INDEX_EMBEDDING_REQUESTED path; upsert_kwargs['payload'] "
         "= build_indexed_unit_payload(payload=dict(obj.payload)) -> store_vector_index."
     ),
-    ("app/search/service.py", 277): (
+    ("app/search/service.py", 282): (
         "carries_via_indexed_unit_builder: ingest_object's internal idx.upsert; payload_out = "
         "build_indexed_unit_payload(payload=<caller payload>) -> store_vector_index."
     ),
-    ("app/services/indexer.py", 137): (
+    ("app/services/indexer.py", 139): (
         "carries_via_indexed_unit_builder: handle_ingest_object_created save_object; domain.payload "
         "= build_indexed_unit_payload(...) -> store_objects. Also carries frontmatter episode_ref "
         "into the input on the vault-changed path and preserves an existing binding via the merge."
     ),
-    ("app/services/indexer.py", 210): (
+    ("app/services/indexer.py", 219): (
         "carries_via_indexed_unit_builder: same handler's vector_index.upsert; upsert_kwargs["
         "'payload'] = build_indexed_unit_payload(...) -> store_vector_index."
     ),

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -47,7 +47,7 @@ APP_ROOT = REPO_ROOT / "app"
 # NEVER run against a real vault -- they are not part of this census.
 
 REGISTERED_MIRRORS: dict[tuple[str, int], str] = {
-    ("app/services/indexer.py", 139): (
+    ("app/services/indexer.py", 150): (
         "T-materialize sink (handle_ingest_object_created): the INGEST_OBJECT_CREATED "
         "event that CAUSED this row is its own record -- emitting a second event here "
         "would be a duplicate, not completeness (formal-model.md T-materialize)."
@@ -1432,11 +1432,11 @@ STORE_PAYLOAD_SINK_CLASSIFICATION: dict[tuple[str, int], str] = {
         "carries_via_indexed_unit_builder: fallback rebuild upsert via build_indexed_unit_payload "
         "-> store_vector_index."
     ),
-    ("app/indexer/consumer.py", 84): (
+    ("app/indexer/consumer.py", 88): (
         "carries_via_indexed_unit_builder: legacy embedding-in-event path; payload = "
         "build_indexed_unit_payload(...) -> idx.upsert -> store_vector_index."
     ),
-    ("app/indexer/consumer.py", 176): (
+    ("app/indexer/consumer.py", 180): (
         "carries_via_indexed_unit_builder: INDEX_EMBEDDING_REQUESTED path; upsert_kwargs['payload'] "
         "= build_indexed_unit_payload(payload=dict(obj.payload)) -> store_vector_index."
     ),
@@ -1444,12 +1444,12 @@ STORE_PAYLOAD_SINK_CLASSIFICATION: dict[tuple[str, int], str] = {
         "carries_via_indexed_unit_builder: ingest_object's internal idx.upsert; payload_out = "
         "build_indexed_unit_payload(payload=<caller payload>) -> store_vector_index."
     ),
-    ("app/services/indexer.py", 139): (
+    ("app/services/indexer.py", 150): (
         "carries_via_indexed_unit_builder: handle_ingest_object_created save_object; domain.payload "
         "= build_indexed_unit_payload(...) -> store_objects. Also carries frontmatter episode_ref "
         "into the input on the vault-changed path and preserves an existing binding via the merge."
     ),
-    ("app/services/indexer.py", 219): (
+    ("app/services/indexer.py", 230): (
         "carries_via_indexed_unit_builder: same handler's vector_index.upsert; upsert_kwargs["
         "'payload'] = build_indexed_unit_payload(...) -> store_vector_index."
     ),

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -1424,11 +1424,11 @@ STORE_PAYLOAD_SINK_CLASSIFICATION: dict[tuple[str, int], str] = {
         "derived-artifact payload; ingest_object -> store_vector_index."
     ),
     # -- carries_via_indexed_unit_builder: payload = build_indexed_unit_payload(...) (the choke) --
-    ("app/cli/index_rebuild.py", 310): (
+    ("app/cli/index_rebuild.py", 318): (
         "carries_via_indexed_unit_builder: cold rebuild re-embeds store_objects rows through "
         "build_indexed_unit_payload (defaults episode_ref) -> idx.upsert -> store_vector_index."
     ),
-    ("app/cli/index_rebuild.py", 598): (
+    ("app/cli/index_rebuild.py", 615): (
         "carries_via_indexed_unit_builder: fallback rebuild upsert via build_indexed_unit_payload "
         "-> store_vector_index."
     ),

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -1428,7 +1428,7 @@ STORE_PAYLOAD_SINK_CLASSIFICATION: dict[tuple[str, int], str] = {
         "carries_via_indexed_unit_builder: cold rebuild re-embeds store_objects rows through "
         "build_indexed_unit_payload (defaults episode_ref) -> idx.upsert -> store_vector_index."
     ),
-    ("app/cli/index_rebuild.py", 641): (
+    ("app/cli/index_rebuild.py", 685): (
         "carries_via_indexed_unit_builder: fallback rebuild upsert via build_indexed_unit_payload "
         "-> store_vector_index."
     ),

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -1424,11 +1424,11 @@ STORE_PAYLOAD_SINK_CLASSIFICATION: dict[tuple[str, int], str] = {
         "derived-artifact payload; ingest_object -> store_vector_index."
     ),
     # -- carries_via_indexed_unit_builder: payload = build_indexed_unit_payload(...) (the choke) --
-    ("app/cli/index_rebuild.py", 318): (
+    ("app/cli/index_rebuild.py", 319): (
         "carries_via_indexed_unit_builder: cold rebuild re-embeds store_objects rows through "
         "build_indexed_unit_payload (defaults episode_ref) -> idx.upsert -> store_vector_index."
     ),
-    ("app/cli/index_rebuild.py", 615): (
+    ("app/cli/index_rebuild.py", 640): (
         "carries_via_indexed_unit_builder: fallback rebuild upsert via build_indexed_unit_payload "
         "-> store_vector_index."
     ),

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -47,7 +47,7 @@ APP_ROOT = REPO_ROOT / "app"
 # NEVER run against a real vault -- they are not part of this census.
 
 REGISTERED_MIRRORS: dict[tuple[str, int], str] = {
-    ("app/services/indexer.py", 151): (
+    ("app/services/indexer.py", 159): (
         "T-materialize sink (handle_ingest_object_created): the INGEST_OBJECT_CREATED "
         "event that CAUSED this row is its own record -- emitting a second event here "
         "would be a duplicate, not completeness (formal-model.md T-materialize)."
@@ -1444,12 +1444,12 @@ STORE_PAYLOAD_SINK_CLASSIFICATION: dict[tuple[str, int], str] = {
         "carries_via_indexed_unit_builder: ingest_object's internal idx.upsert; payload_out = "
         "build_indexed_unit_payload(payload=<caller payload>) -> store_vector_index."
     ),
-    ("app/services/indexer.py", 151): (
+    ("app/services/indexer.py", 159): (
         "carries_via_indexed_unit_builder: handle_ingest_object_created save_object; domain.payload "
         "= build_indexed_unit_payload(...) -> store_objects. Also carries frontmatter episode_ref "
         "into the input on the vault-changed path and preserves an existing binding via the merge."
     ),
-    ("app/services/indexer.py", 231): (
+    ("app/services/indexer.py", 239): (
         "carries_via_indexed_unit_builder: same handler's vector_index.upsert; upsert_kwargs["
         "'payload'] = build_indexed_unit_payload(...) -> store_vector_index."
     ),

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -1428,7 +1428,7 @@ STORE_PAYLOAD_SINK_CLASSIFICATION: dict[tuple[str, int], str] = {
         "carries_via_indexed_unit_builder: cold rebuild re-embeds store_objects rows through "
         "build_indexed_unit_payload (defaults episode_ref) -> idx.upsert -> store_vector_index."
     ),
-    ("app/cli/index_rebuild.py", 640): (
+    ("app/cli/index_rebuild.py", 641): (
         "carries_via_indexed_unit_builder: fallback rebuild upsert via build_indexed_unit_payload "
         "-> store_vector_index."
     ),

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -1424,11 +1424,11 @@ STORE_PAYLOAD_SINK_CLASSIFICATION: dict[tuple[str, int], str] = {
         "derived-artifact payload; ingest_object -> store_vector_index."
     ),
     # -- carries_via_indexed_unit_builder: payload = build_indexed_unit_payload(...) (the choke) --
-    ("app/cli/index_rebuild.py", 315): (
+    ("app/cli/index_rebuild.py", 310): (
         "carries_via_indexed_unit_builder: cold rebuild re-embeds store_objects rows through "
         "build_indexed_unit_payload (defaults episode_ref) -> idx.upsert -> store_vector_index."
     ),
-    ("app/cli/index_rebuild.py", 603): (
+    ("app/cli/index_rebuild.py", 598): (
         "carries_via_indexed_unit_builder: fallback rebuild upsert via build_indexed_unit_payload "
         "-> store_vector_index."
     ),

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -47,7 +47,7 @@ APP_ROOT = REPO_ROOT / "app"
 # NEVER run against a real vault -- they are not part of this census.
 
 REGISTERED_MIRRORS: dict[tuple[str, int], str] = {
-    ("app/services/indexer.py", 150): (
+    ("app/services/indexer.py", 151): (
         "T-materialize sink (handle_ingest_object_created): the INGEST_OBJECT_CREATED "
         "event that CAUSED this row is its own record -- emitting a second event here "
         "would be a duplicate, not completeness (formal-model.md T-materialize)."
@@ -1444,12 +1444,12 @@ STORE_PAYLOAD_SINK_CLASSIFICATION: dict[tuple[str, int], str] = {
         "carries_via_indexed_unit_builder: ingest_object's internal idx.upsert; payload_out = "
         "build_indexed_unit_payload(payload=<caller payload>) -> store_vector_index."
     ),
-    ("app/services/indexer.py", 150): (
+    ("app/services/indexer.py", 151): (
         "carries_via_indexed_unit_builder: handle_ingest_object_created save_object; domain.payload "
         "= build_indexed_unit_payload(...) -> store_objects. Also carries frontmatter episode_ref "
         "into the input on the vault-changed path and preserves an existing binding via the merge."
     ),
-    ("app/services/indexer.py", 230): (
+    ("app/services/indexer.py", 231): (
         "carries_via_indexed_unit_builder: same handler's vector_index.upsert; upsert_kwargs["
         "'payload'] = build_indexed_unit_payload(...) -> store_vector_index."
     ),

--- a/tests/retrieval/test_panel_filtering.py
+++ b/tests/retrieval/test_panel_filtering.py
@@ -56,6 +56,29 @@ def test_strip_ai_panels_removes_heading_only_panels() -> None:
     assert "This is after." in stripped
 
 
+def test_strip_ai_panels_reaches_fixed_point_for_mixed_formats() -> None:
+    markdown = "\n".join(
+        (
+            "Real content before.",
+            "%% AI:Start %%",
+            "Fenced panel text.",
+            "%% AI:End %%",
+            "## AI-instruktion",
+            "Legacy panel text.",
+            "## Retained section",
+            "Real content after.",
+        )
+    )
+
+    expected = "\n".join(
+        ("Real content before.", "## Retained section", "Real content after.")
+    )
+    stripped = strip_ai_panels(markdown)
+
+    assert stripped == expected
+    assert strip_ai_panels(stripped) == stripped
+
+
 def test_hybrid_store_does_not_contain_panel_text() -> None:
     markdown = textwrap.dedent(
         """

--- a/tests/scripts/test_select_pr_tests.py
+++ b/tests/scripts/test_select_pr_tests.py
@@ -305,6 +305,7 @@ def test_index_rebuild_cli_change_selects_memory_retrieval_coverage() -> None:
     assert "tests/indexer" in selection.targets
     assert "tests/index" in selection.targets
     assert "tests/search" in selection.targets
+    assert "tests/services/test_indexer_worker.py" in selection.targets
     assert "tests/cli/test_index_rebuild_resilience.py" in selection.targets
     assert "tests/cli/test_index_doctor_mixed_identity.py" in selection.targets
 
@@ -324,6 +325,7 @@ def test_runtime_index_producers_select_memory_retrieval_coverage() -> None:
     assert "tests/index" in selection.targets
     assert "tests/indexer" in selection.targets
     assert "tests/search" in selection.targets
+    assert "tests/services/test_indexer_worker.py" in selection.targets
 
 
 def test_reasoning_expansion_paths_select_owned_cognition_coverage() -> None:

--- a/tests/scripts/test_select_pr_tests.py
+++ b/tests/scripts/test_select_pr_tests.py
@@ -296,6 +296,16 @@ def test_relevance_runtime_and_regression_changes_select_relevance_coverage() ->
     assert not selection.unowned_paths
 
 
+def test_index_rebuild_cli_change_selects_memory_retrieval_coverage() -> None:
+    selection = select_tests(["app/cli/index_rebuild.py"])
+
+    assert selection.full_suite is False
+    assert selection.subsystems == ("memory_retrieval",)
+    assert selection.unowned_paths == ()
+    assert "tests/indexer" in selection.targets
+    assert "tests/search" in selection.targets
+
+
 def test_reasoning_expansion_paths_select_owned_cognition_coverage() -> None:
     selection = select_tests(
         [

--- a/tests/scripts/test_select_pr_tests.py
+++ b/tests/scripts/test_select_pr_tests.py
@@ -303,7 +303,10 @@ def test_index_rebuild_cli_change_selects_memory_retrieval_coverage() -> None:
     assert selection.subsystems == ("memory_retrieval",)
     assert selection.unowned_paths == ()
     assert "tests/indexer" in selection.targets
+    assert "tests/index" in selection.targets
     assert "tests/search" in selection.targets
+    assert "tests/cli/test_index_rebuild_resilience.py" in selection.targets
+    assert "tests/cli/test_index_doctor_mixed_identity.py" in selection.targets
 
 
 def test_reasoning_expansion_paths_select_owned_cognition_coverage() -> None:

--- a/tests/scripts/test_select_pr_tests.py
+++ b/tests/scripts/test_select_pr_tests.py
@@ -309,6 +309,23 @@ def test_index_rebuild_cli_change_selects_memory_retrieval_coverage() -> None:
     assert "tests/cli/test_index_doctor_mixed_identity.py" in selection.targets
 
 
+def test_runtime_index_producers_select_memory_retrieval_coverage() -> None:
+    selection = select_tests(
+        [
+            "app/indexer/consumer.py",
+            "app/search/service.py",
+            "app/services/indexer.py",
+        ]
+    )
+
+    assert selection.full_suite is False
+    assert selection.subsystems == ("memory_retrieval",)
+    assert selection.unowned_paths == ()
+    assert "tests/index" in selection.targets
+    assert "tests/indexer" in selection.targets
+    assert "tests/search" in selection.targets
+
+
 def test_reasoning_expansion_paths_select_owned_cognition_coverage() -> None:
     selection = select_tests(
         [

--- a/tests/services/test_indexer_worker.py
+++ b/tests/services/test_indexer_worker.py
@@ -6,6 +6,7 @@ from uuid import UUID
 
 from app.services.indexer import handle_ingest_object_created
 from app import objects as object_store_module
+from app.index.artifact_metadata import canonicalize_indexable_text, compute_content_hash
 from app.objects import ObjectStore
 
 
@@ -160,3 +161,127 @@ def test_handle_ingest_object_created_replaces_vectors_on_update(monkeypatch):
     assert purge_calls[1][2] == 1
     store = get_vector_index()
     assert len(store._entries) == 1
+
+
+def test_handle_ingest_object_created_preserves_source_and_indexes_canonical_bytes(monkeypatch):
+    object_store_module._MEMORY_STORE.clear()
+    calls: list[dict] = []
+    embedded_texts: list[str] = []
+
+    class DummyIndex:
+        def purge_vectors(self, object_id, *, view):
+            return 0
+
+        def upsert(self, object_id, **kwargs):
+            calls.append({"object_id": object_id, **kwargs})
+
+    identity = SimpleNamespace(provider="mock", model="mock-embedding", dim=3, normalize=True)
+    monkeypatch.setattr("app.services.indexer.get_vector_index", lambda: DummyIndex())
+    monkeypatch.setattr("app.services.indexer.get_embedding_identity", lambda: identity)
+    monkeypatch.setattr("app.services.indexer.emit_index_object_embedded", lambda **kwargs: None)
+    monkeypatch.setattr("app.services.indexer.emit_index_embedding_failed", lambda **kwargs: None)
+
+    def fake_embed(**kwargs):
+        embedded_texts.append(kwargs["text"])
+        return [0.1, 0.2, 0.3]
+
+    monkeypatch.setattr("app.services.indexer.llm_embed_text", fake_embed)
+
+    raw = "\n".join(
+        (
+            "retained before",
+            "%% AI:Start %%",
+            "fenced panel",
+            "%% AI:End %%",
+            "## AI-instruktion",
+            "legacy panel",
+            "## Retained section",
+            "retained after",
+        )
+    )
+    canonical = canonicalize_indexable_text({"content": raw})
+    event = _make_event(source_ref="vault/canonical-indexer.md")
+    event["uuid"] = "66666666-6666-6666-6666-666666666666"
+    event["content"] = raw
+
+    handle_ingest_object_created(event)
+
+    source = ObjectStore().get_object(event["uuid"])
+    assert source is not None
+    assert source.payload["content"] == raw
+    assert embedded_texts == [canonical]
+    vector_payload = calls[-1]["payload"]
+    assert vector_payload["content"] == canonical
+    assert vector_payload["text"] == canonical
+    assert vector_payload["provenance"]["content_hash"] == compute_content_hash(canonical)
+
+
+def test_handle_ingest_object_created_does_not_recreate_panel_only_vector(monkeypatch):
+    object_store_module._MEMORY_STORE.clear()
+    purge_calls: list[tuple[UUID, str]] = []
+
+    class DummyIndex:
+        def purge_vectors(self, object_id, *, view):
+            purge_calls.append((object_id, view))
+            return 1
+
+        def upsert(self, object_id, **kwargs):
+            raise AssertionError("panel-only source must not be upserted")
+
+    monkeypatch.setattr("app.services.indexer.get_vector_index", lambda: DummyIndex())
+    monkeypatch.setattr(
+        "app.services.indexer.get_embedding_identity",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("panel-only source must not resolve an embedding identity")
+        ),
+    )
+
+    panel_only = "\n%% AI:Start %%\ntransient\n%% AI:End %%\n\n"
+    event = _make_event(source_ref="vault/panel-only-indexer.md")
+    event["uuid"] = "77777777-7777-7777-7777-777777777777"
+    event["content"] = panel_only
+
+    handle_ingest_object_created(event)
+
+    source = ObjectStore().get_object(event["uuid"])
+    assert source is not None
+    assert source.payload["content"] == panel_only
+    assert purge_calls == [(UUID(event["uuid"]), "markdown.semantic")]
+
+
+def test_handle_ingest_object_created_uses_raw_text_fallback_bytes(monkeypatch):
+    object_store_module._MEMORY_STORE.clear()
+    embedded_texts: list[str] = []
+    vector_payloads: list[dict] = []
+
+    class DummyIndex:
+        def purge_vectors(self, object_id, *, view):
+            return 0
+
+        def upsert(self, object_id, **kwargs):
+            vector_payloads.append(kwargs["payload"])
+
+    identity = SimpleNamespace(provider="mock", model="mock-embedding", dim=3, normalize=True)
+    monkeypatch.setattr("app.services.indexer.get_vector_index", lambda: DummyIndex())
+    monkeypatch.setattr("app.services.indexer.get_embedding_identity", lambda: identity)
+    monkeypatch.setattr("app.services.indexer.emit_index_object_embedded", lambda **kwargs: None)
+
+    def fake_embed(**kwargs):
+        embedded_texts.append(kwargs["text"])
+        return [0.1, 0.2, 0.3]
+
+    monkeypatch.setattr("app.services.indexer.llm_embed_text", fake_embed)
+
+    event = _make_event(source_ref="vault/raw-text-fallback.md")
+    event["uuid"] = "99999999-9999-9999-9999-999999999999"
+    event["content"] = ""
+    event["payload"] = {"raw_text": "raw fallback bytes"}
+
+    handle_ingest_object_created(event)
+
+    assert embedded_texts == ["raw fallback bytes"]
+    assert vector_payloads[-1]["content"] == "raw fallback bytes"
+    assert vector_payloads[-1]["text"] == "raw fallback bytes"
+    assert vector_payloads[-1]["provenance"]["content_hash"] == compute_content_hash(
+        "raw fallback bytes"
+    )

--- a/tests/services/test_indexer_worker.py
+++ b/tests/services/test_indexer_worker.py
@@ -249,6 +249,43 @@ def test_handle_ingest_object_created_does_not_recreate_panel_only_vector(monkey
     assert purge_calls == [(UUID(event["uuid"]), "markdown.semantic")]
 
 
+def test_vault_event_preserves_explicitly_empty_canonical_body(monkeypatch):
+    object_store_module._MEMORY_STORE.clear()
+    purge_calls: list[tuple[UUID, str]] = []
+
+    class DummyIndex:
+        def purge_vectors(self, object_id, *, view):
+            purge_calls.append((object_id, view))
+            return 1
+
+        def upsert(self, object_id, **kwargs):
+            raise AssertionError("empty canonical vault body must not be upserted")
+
+    monkeypatch.setattr("app.services.indexer.get_vector_index", lambda: DummyIndex())
+    monkeypatch.setattr(
+        "app.services.indexer.get_embedding_identity",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("empty canonical vault body must not be embedded")
+        ),
+    )
+
+    event = _make_event(source_ref="vault/panel-only-with-frontmatter.md")
+    event["uuid"] = "78787878-7878-7878-7878-787878787878"
+    event["content"] = ""
+    event["payload"] = {
+        "frontmatter": {"title": "Panel only"},
+        "raw_text": "---\ntitle: Panel only\n---\n%% AI:Start %%\ntransient\n%% AI:End %%\n",
+    }
+
+    handle_ingest_object_created(event)
+
+    source = ObjectStore().get_object(event["uuid"])
+    assert source is not None
+    assert source.payload["content"] == ""
+    assert source.payload["raw_text"].startswith("---\n")
+    assert purge_calls == [(UUID(event["uuid"]), "markdown.semantic")]
+
+
 def test_handle_ingest_object_created_uses_raw_text_fallback_bytes(monkeypatch):
     object_store_module._MEMORY_STORE.clear()
     embedded_texts: list[str] = []

--- a/tests/services/test_indexer_worker.py
+++ b/tests/services/test_indexer_worker.py
@@ -283,6 +283,8 @@ def test_vault_event_preserves_explicitly_empty_canonical_body(monkeypatch):
     assert source is not None
     assert source.payload["content"] == ""
     assert source.payload["raw_text"].startswith("---\n")
+    assert source.payload["indexable_text_source"] == "content"
+    assert canonicalize_indexable_text(source.payload) == ""
     assert purge_calls == [(UUID(event["uuid"]), "markdown.semantic")]
 
 

--- a/tests/services/test_indexer_worker.py
+++ b/tests/services/test_indexer_worker.py
@@ -313,6 +313,14 @@ def test_handle_ingest_object_created_uses_raw_text_fallback_bytes(monkeypatch):
 
     event = _make_event(source_ref="vault/raw-text-fallback.md")
     event["uuid"] = "99999999-9999-9999-9999-999999999999"
+    explicit_empty = dict(event)
+    explicit_empty["content"] = ""
+    explicit_empty["payload"] = {
+        "frontmatter": {"title": "Panel only"},
+        "raw_text": "---\ntitle: Panel only\n---\n",
+    }
+    handle_ingest_object_created(explicit_empty)
+
     event["content"] = ""
     event["payload"] = {"raw_text": "raw fallback bytes"}
 
@@ -324,3 +332,7 @@ def test_handle_ingest_object_created_uses_raw_text_fallback_bytes(monkeypatch):
     assert vector_payloads[-1]["provenance"]["content_hash"] == compute_content_hash(
         "raw fallback bytes"
     )
+    source = ObjectStore().get_object(event["uuid"])
+    assert source is not None
+    assert source.payload["indexable_text_source"] == "raw_text"
+    assert canonicalize_indexable_text(source.payload) == "raw fallback bytes"


### PR DESCRIPTION
Governing-Issue: #3955

Fixes #3955

## Change Lane
- [x] Implementation
- [ ] Docs authoring lane
- [ ] Governance lane

## SBS Impact
- Primary subsystem: DRI
- Secondary subsystem(s): PDM, RCA, OEF, Builder System
- Write class: derived
- Authority impact: none
- Persistence impact: rebuildable Postgres vector-index diagnostics and explicit cleanup of a vector whose present source became non-indexable
- Derived/rebuildable impact: aligns rebuild, reconcile, retrieval aliases, and doctor on indexability and canonical source text
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: prevents false stale or missing-vector diagnostics after a complete rebuild
- Sync/deployment impact: path-scoped PR Postgres verification; runtime promotion remains governed separately
- External boundary impact: none
- New or changed contract: explicit reconcile purges only the derived vector for a present canonically non-indexable source; absent-source fallback remains
- Owner-doc impact: `docs/DB_SCHEMA.md :: store_vector_index`; `docs/EMBEDDINGS.md :: Indexing behavior and invariants`; `docs/OPERATIONS.md :: CLI commands and runtime verification`
- Transition debt impact: reduces
- Fitness rule impact: strengthens
- Boundary risk: medium; Product data-path behavior and its path-scoped Builder System PG gate ship together

## Owner-Doc Writeback
`docs/DB_SCHEMA.md :: store_vector_index` and `docs/EMBEDDINGS.md :: Indexing behavior and invariants` now record canonical exact-byte production and bounded atomic derived-vector purge semantics. `docs/OPERATIONS.md :: CLI commands and runtime verification` records the operator-facing effect while preserving source immutability and absent-source fallback.

## Summary
- Centralize indexable text selection and provenance hashing so rebuild, reconcile, and doctor use `content` → `text` → `raw_text` plus the same fixed-point AI-panel canonicalization, including notes that mix fenced and legacy panels.
- Refresh the derived retrieval payload from authoritative source data during reconcile and keep its text aliases bound to the exact embedded bytes.
- Exclude genuinely contentless and AI-panel-only durable objects from the aggregate unembedded-stall diagnosis while preserving fail-loud behavior for every canonically text-bearing object.
- Treat a whitespace-only remainder after fixed-point panel removal as non-indexable while preserving exact whitespace on meaningful text.
- Canonicalize once before every runtime provider call, bind vector `content`/`text` and provenance to those exact bytes, preserve raw authoritative source payloads, and reject noncanonical legacy precomputed vectors fail-closed.
- Select and purge a derived vector whenever its present authoritative source is non-indexable, even if the vector already has the primary identity and empty canonical hash; never mutate the source or republish old retrieval bytes, and preserve the derived-payload fallback for an absent source.
- Reclassify source presence/indexability under a Postgres row lock and conditionally purge in that same transaction, so concurrent source updates are embedded and concurrent deletions retain fallback.
- Add a path-scoped PR Postgres gate that owns the panel canonicalizer, real Postgres regressions, direct CI ownership, and keep the store-payload sink census aligned with the moved call sites.
- Register all three runtime vector-producer seams with the memory-retrieval test selector so Unit tests (not pg) fail closed only on genuinely unowned paths.

## Validation
- `ruff check app tests` — passed.
- `mypy app` — passed (768 source files).
- Focused non-Postgres suite — 52 passed, 8 deselected on integrated `main`.
- Focused real-Postgres suite — 10 passed, 4 deselected, including deterministic source-update and source-delete purge races.
- `pytest -q -m "not pg"` — 10,014 passed, 38 skipped, 242 deselected, 18 xfailed on integrated `main`.
- Selector/producer regression bundle — 112 passed, 8 deselected.
- `python scripts/docs_guard.py` — passed.

## Coordination
- Pickup mode: `github-label-only-fallback` because the isolated repository had no dispatcher DB.
- Claim evidence: GitHub comment `5002349878`; agent `codex-root`; branch `codex/issue-3955-index-doctor-convergence`.

## BuilderOps Routing
- Records/projections/receipts: LearningSignal `lrn_20260717111149_fa737940`; pickup receipt comment `5002349878`.
- Reason: Captures the BGE-M3 runbook divergence where a zero-error rebuild could not converge strict doctor until producer/verifier semantics were repaired.

## Notes
PROD and release-channel pins are not changed by this PR.
