### PR TITLE
Fix: make crashed turn reservation retries deterministic

### DIFF
--- a/app/builderops/model_inquiry.py
+++ b/app/builderops/model_inquiry.py
@@ -263,16 +263,26 @@ class ModelInquiryService:
         }
         payload.update(normalized_provider_metadata)
         payload["artifact_hash"] = _artifact_hash(payload)
+        new_reservation: dict[str, Any] = {
+            "schema": "builderops.model-inquiry-turn-reservation.v1",
+            "inquiry_id": inquiry_id,
+            "turn_id": turn_id,
+            "sequence": sequence,
+            "artifact_hash": payload["artifact_hash"],
+        }
+        # A reservation that crashed before this fix shipped has no created_at key.
+        # Unconditionally writing one here would make every retry against it --
+        # even an exact one -- fail strict dict-equality forever (new_reservation
+        # can never equal a 5-key legacy record), permanently stranding a
+        # genuinely pre-fix orphan instead of merely inheriting its old
+        # same-second-luck retry odds. Only add created_at when there is no
+        # legacy shape to stay compatible with: a brand-new reservation, or one
+        # this fix already wrote.
+        if existing_reservation is None or "created_at" in existing_reservation:
+            new_reservation["created_at"] = created_at
         _, reservation_created = self._write_immutable_status(
             reservation_path,
-            {
-                "schema": "builderops.model-inquiry-turn-reservation.v1",
-                "inquiry_id": inquiry_id,
-                "turn_id": turn_id,
-                "sequence": sequence,
-                "created_at": created_at,
-                "artifact_hash": payload["artifact_hash"],
-            },
+            new_reservation,
             label="immutable turn id reservation",
         )
         try:
@@ -1545,15 +1555,20 @@ class ModelInquiryService:
         artifact_hash: str,
         created_by_this_attempt: bool,
     ) -> None:
-        expected = {
+        existing = self._read_optional(reservation_path)
+        expected: dict[str, Any] = {
             "schema": "builderops.model-inquiry-turn-reservation.v1",
             "inquiry_id": directory.name,
             "turn_id": turn_id,
             "sequence": sequence,
-            "created_at": created_at,
             "artifact_hash": artifact_hash,
         }
-        existing = self._read_optional(reservation_path)
+        # Mirrors the write-side and _read_turns backward-compat rule: only
+        # require created_at when the on-disk reservation actually carries it, so
+        # a legacy (pre-fix) orphan this attempt just matched or wrote is still
+        # recognized and cleaned up.
+        if existing is not None and "created_at" in existing:
+            expected["created_at"] = created_at
         committed = any(
             turn.get("turn_id") == turn_id
             for turn in self._read_turn_files_without_reservations(directory)

--- a/app/builderops/model_inquiry.py
+++ b/app/builderops/model_inquiry.py
@@ -232,6 +232,22 @@ class ModelInquiryService:
                 raise BuilderOpsConflictError(
                     f"turn sequence already exists for {committed['turn_id']}: {sequence}"
                 )
+        reservation_path = directory / "turn-ids" / f"{turn_id}.json"
+        existing_reservation = self._read_optional(reservation_path)
+        # An orphaned reservation (process loss between reserving the turn id and
+        # committing the turn artifact -- see _reconcile_failed_turn_reservation)
+        # already fixed this turn's identity, including its created_at. An exact
+        # retry must reproduce that identity byte-for-byte so it recomputes the
+        # SAME artifact_hash the reservation already holds, instead of minting a
+        # fresh utc_now() that can cross a wall-clock second boundary and drift
+        # the hash. A retry that is not exact (different content, sequence, role,
+        # input refs, or provenance) still lands on a different artifact_hash (or
+        # a different reservation "sequence" value) and fails closed at the
+        # reservation write below, exactly like a rewrite of a committed turn.
+        created_at = _existing_timestamp(
+            existing,
+            fallback=_reservation_timestamp(existing_reservation),
+        )
         payload = {
             "schema": TURN_SCHEMA,
             "artifact_id": turn_id,
@@ -243,11 +259,10 @@ class ModelInquiryService:
             "content_hash": _content_hash(content),
             "input_artifact_refs": input_artifact_refs,
             "source_refs": source_refs,
-            "created_at": _existing_timestamp(existing),
+            "created_at": created_at,
         }
         payload.update(normalized_provider_metadata)
         payload["artifact_hash"] = _artifact_hash(payload)
-        reservation_path = directory / "turn-ids" / f"{turn_id}.json"
         _, reservation_created = self._write_immutable_status(
             reservation_path,
             {
@@ -255,6 +270,7 @@ class ModelInquiryService:
                 "inquiry_id": inquiry_id,
                 "turn_id": turn_id,
                 "sequence": sequence,
+                "created_at": created_at,
                 "artifact_hash": payload["artifact_hash"],
             },
             label="immutable turn id reservation",
@@ -267,6 +283,7 @@ class ModelInquiryService:
                 reservation_path,
                 turn_id=turn_id,
                 sequence=sequence,
+                created_at=created_at,
                 artifact_hash=cast(str, payload["artifact_hash"]),
                 created_by_this_attempt=reservation_created,
             )
@@ -1078,6 +1095,13 @@ class ModelInquiryService:
                 "sequence": sequence,
                 "artifact_hash": turn["artifact_hash"],
             }
+            # created_at joined the reservation payload to make exact-retry recovery
+            # deterministic (see _commit_turn_locked). Reservations written before that
+            # change have no created_at key; require it to match the committed turn's
+            # own created_at when present, without breaking pre-existing durable data
+            # that predates the field.
+            if "created_at" in reservation:
+                expected_reservation["created_at"] = turn["created_at"]
             if reservation != expected_reservation:
                 raise BuilderOpsValidationError(f"turn id reservation mismatch: {turn_id}")
             seen_ids.add(turn_id)
@@ -1517,6 +1541,7 @@ class ModelInquiryService:
         *,
         turn_id: str,
         sequence: int,
+        created_at: str,
         artifact_hash: str,
         created_by_this_attempt: bool,
     ) -> None:
@@ -1525,6 +1550,7 @@ class ModelInquiryService:
             "inquiry_id": directory.name,
             "turn_id": turn_id,
             "sequence": sequence,
+            "created_at": created_at,
             "artifact_hash": artifact_hash,
         }
         existing = self._read_optional(reservation_path)
@@ -1628,6 +1654,19 @@ def _existing_timestamp(
     if existing is not None and isinstance(existing.get("created_at"), str):
         return existing["created_at"]
     return fallback or utc_now()
+
+
+def _reservation_timestamp(reservation: Mapping[str, Any] | None) -> str | None:
+    """Recover the created_at an orphaned turn-id reservation already fixed.
+
+    Returns None for a reservation written before created_at joined the
+    reservation payload (or when no reservation exists yet), which falls
+    _existing_timestamp back to a fresh utc_now() -- the pre-fix behavior --
+    for that narrow pre-existing-data case only.
+    """
+    if reservation is not None and isinstance(reservation.get("created_at"), str):
+        return reservation["created_at"]
+    return None
 
 
 def _validate_sequence(value: Any) -> None:

--- a/docs/BUILDEROPS_MODEL_INQUIRY/PRE_TICKET_INQUIRY_RECORDS.md
+++ b/docs/BUILDEROPS_MODEL_INQUIRY/PRE_TICKET_INQUIRY_RECORDS.md
@@ -86,6 +86,18 @@ devices still introduce a conflicting graph, trace fails closed instead of choos
 An orphaned reservation from process loss makes trace incomplete until an exact turn retry
 reconciles it.
 
+The turn-id reservation durably fixes the turn's `created_at` the moment it is written, before the
+turn artifact itself is committed, so an orphaned reservation carries the turn's complete identity
+rather than only its `artifact_hash`. An exact retry after process loss reads that reservation first
+and reuses its `created_at` instead of minting a fresh timestamp, so it recomputes the identical
+`artifact_hash` the reservation already holds even when the retry lands on a later wall-clock second
+than the crashed attempt. A retry that is not exact -- different content, sequence, role, input refs,
+or provenance -- still recomputes a different `artifact_hash` (or targets a reservation whose
+`sequence` disagrees) and fails closed against the durable reservation, exactly like a conflicting
+rewrite of an already-committed turn. Reservations written before this mechanism existed have no
+`created_at` field; trace validation accepts that legacy shape unchanged and only requires the field
+to match the committed turn's own `created_at` when the reservation carries one.
+
 ## How to Verify (Pre-Merge)
 
 - `pytest -q tests/builderops/test_model_inquiry_cli.py tests/builderops/test_model_inquiry_trace.py tests/builderops/test_model_inquiry_resume.py tests/api/test_builderops_inquiry_api.py`

--- a/docs/BUILDEROPS_MODEL_INQUIRY/PRE_TICKET_INQUIRY_RECORDS.md
+++ b/docs/BUILDEROPS_MODEL_INQUIRY/PRE_TICKET_INQUIRY_RECORDS.md
@@ -96,7 +96,12 @@ or provenance -- still recomputes a different `artifact_hash` (or targets a rese
 `sequence` disagrees) and fails closed against the durable reservation, exactly like a conflicting
 rewrite of an already-committed turn. Reservations written before this mechanism existed have no
 `created_at` field; trace validation accepts that legacy shape unchanged and only requires the field
-to match the committed turn's own `created_at` when the reservation carries one.
+to match the committed turn's own `created_at` when the reservation carries one. The retry write path
+mirrors that same rule: it only adds `created_at` to the reservation payload it writes when no
+reservation exists yet or the existing one already carries the field, so a retry against a genuinely
+pre-fix (legacy, five-key) orphan can still match and recover -- reproducing that orphan's pre-fix
+same-timestamp-luck retry odds -- instead of being permanently stranded by an unconditional field the
+legacy record can never equal.
 
 ## How to Verify (Pre-Merge)
 

--- a/tests/builderops/test_model_inquiry_cli.py
+++ b/tests/builderops/test_model_inquiry_cli.py
@@ -507,6 +507,20 @@ def test_crashed_turn_reservation_is_visible_and_retryable(tmp_path: Path, monke
         return original(path, payload, label=label)
 
     monkeypatch.setattr(service, "_write_immutable", crash_before_turn)
+
+    # Force a real wall-clock second boundary between the crashed reservation and
+    # the exact retry -- the PR #3822 CI failure mode. utc_now() truncates to
+    # whole seconds, so a retry that mints a fresh timestamp only sometimes lands
+    # on a different second than the original attempt; pinning two distinct
+    # values here makes the crossing happen on every run instead of by luck.
+    reservation_timestamp = "2026-01-01T00:00:00Z"
+    retry_timestamp = "2026-01-01T00:00:05Z"
+    boundary_timestamps = iter([reservation_timestamp, retry_timestamp])
+    monkeypatch.setattr(
+        "app.builderops.model_inquiry.utc_now",
+        lambda: next(boundary_timestamps),
+    )
+
     with pytest.raises(KeyboardInterrupt, match="simulated process loss"):
         service.commit_turn(
             "inq_test_crash_reservation",
@@ -531,6 +545,9 @@ def test_crashed_turn_reservation_is_visible_and_retryable(tmp_path: Path, monke
         source_refs=refs,
     )
     assert service.trace("inq_test_crash_reservation")["turns"] == [recovered]
+    # The retry reproduces the reservation's original identity -- it must not
+    # observe the later timestamp a fresh utc_now() call would have minted.
+    assert recovered["created_at"] == reservation_timestamp
 
 
 def test_turn_transaction_is_serialized_across_service_instances(tmp_path: Path, monkeypatch) -> None:
@@ -589,6 +606,68 @@ def test_turn_transaction_is_serialized_across_service_instances(tmp_path: Path,
     inquiry = Path(env["BUILDEROPS_VAULT_ROOT"]) / "model-inquiries" / "inq_test_serialized"
     assert len(list((inquiry / "turn-ids").glob("*.json"))) == 1
     assert len(first.trace("inq_test_serialized")["turns"]) == 1
+
+    # A distinct service instance retains exactly one committed turn per
+    # identity/sequence even across an orphaned reservation, deterministically
+    # across a forced wall-clock boundary rather than by same-second luck: a
+    # non-exact retry (same turn_id/sequence, different content) against the
+    # other instance's orphaned reservation still fails closed, while an exact
+    # retry from that other instance reproduces the durably reserved artifact.
+    orphan_turn_id = "turn-c"
+    orphan_sequence = 1
+    original_write_immutable = first._write_immutable
+
+    def crash_before_turn(path, payload, *, label):
+        if label == "immutable turn artifact":
+            raise KeyboardInterrupt("simulated process loss")
+        return original_write_immutable(path, payload, label=label)
+
+    monkeypatch.setattr(first, "_write_immutable", crash_before_turn)
+    reservation_timestamp = "2026-02-01T00:00:00Z"
+    boundary_timestamps = iter(
+        [reservation_timestamp, "2026-02-01T00:00:05Z", "2026-02-01T00:00:10Z"]
+    )
+    monkeypatch.setattr(
+        "app.builderops.model_inquiry.utc_now",
+        lambda: next(boundary_timestamps),
+    )
+    with pytest.raises(KeyboardInterrupt, match="simulated process loss"):
+        first.commit_turn(
+            "inq_test_serialized",
+            turn_id=orphan_turn_id,
+            sequence=orphan_sequence,
+            role="reviewer",
+            content="Original candidate",
+            input_artifact_refs=["question"],
+            source_refs=refs,
+        )
+    monkeypatch.setattr(first, "_write_immutable", original_write_immutable)
+
+    with pytest.raises(BuilderOpsConflictError, match="immutable turn id reservation"):
+        second.commit_turn(
+            "inq_test_serialized",
+            turn_id=orphan_turn_id,
+            sequence=orphan_sequence,
+            role="reviewer",
+            content="Different candidate",
+            input_artifact_refs=["question"],
+            source_refs=refs,
+        )
+
+    recovered = second.commit_turn(
+        "inq_test_serialized",
+        turn_id=orphan_turn_id,
+        sequence=orphan_sequence,
+        role="reviewer",
+        content="Original candidate",
+        input_artifact_refs=["question"],
+        source_refs=refs,
+    )
+    assert recovered["turn_id"] == orphan_turn_id
+    assert recovered["created_at"] == reservation_timestamp
+    assert [turn["turn_id"] for turn in second.trace("inq_test_serialized")["turns"]].count(
+        orphan_turn_id
+    ) == 1
 
 
 def test_turn_transaction_is_serialized_across_processes(tmp_path: Path) -> None:

--- a/tests/builderops/test_model_inquiry_cli.py
+++ b/tests/builderops/test_model_inquiry_cli.py
@@ -6,7 +6,7 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
 from queue import Empty
-from threading import Event
+from threading import Barrier, Event
 from typing import Any, Mapping
 
 import pytest
@@ -550,6 +550,88 @@ def test_crashed_turn_reservation_is_visible_and_retryable(tmp_path: Path, monke
     assert recovered["created_at"] == reservation_timestamp
 
 
+def test_legacy_orphaned_reservation_without_created_at_is_retryable(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A reservation written before created_at joined the schema (pre-#3833 fix)
+    has only 5 keys, with no way to recover its original created_at from the
+    one-way artifact_hash it already committed to. Unconditionally requiring
+    created_at on every retry write would make such a reservation permanently
+    unretryable the instant this fix ships -- worse than its pre-fix odds. An
+    exact retry must still be able to succeed (reproducing the pre-fix
+    same-timestamp-luck outcome), not fail closed forever."""
+    env = _env(tmp_path)
+    service = ModelInquiryService.from_env(env)
+    refs = [{"ref_type": "github_issue", "ref": "#3290"}]
+    service.start(
+        question="Recover a legacy reservation",
+        workflow="fable-gpt-architecture",
+        inquiry_id="inq_test_legacy_orphan",
+        source_refs=refs,
+    )
+    original = service._write_immutable
+
+    def crash_before_turn(path, payload, *, label):
+        if label == "immutable turn artifact":
+            raise KeyboardInterrupt("simulated process loss")
+        return original(path, payload, label=label)
+
+    # Freeze utc_now() so the crash attempt and the later retry compute the same
+    # created_at -- reproducing the pre-fix "got lucky, same timestamp" case this
+    # test isolates, rather than re-testing the separate timestamp-boundary bug
+    # AC1's regression already covers.
+    frozen_timestamp = "2020-01-01T00:00:00Z"
+    monkeypatch.setattr(service, "_write_immutable", crash_before_turn)
+    monkeypatch.setattr("app.builderops.model_inquiry.utc_now", lambda: frozen_timestamp)
+    with pytest.raises(KeyboardInterrupt, match="simulated process loss"):
+        service.commit_turn(
+            "inq_test_legacy_orphan",
+            turn_id="turn-legacy",
+            sequence=0,
+            role="reviewer",
+            content="Recovered legacy content",
+            input_artifact_refs=["question"],
+            source_refs=refs,
+        )
+    monkeypatch.setattr(service, "_write_immutable", original)
+
+    # Downgrade the fix-shipped reservation to the pre-#3833 shape: strip
+    # created_at but keep the artifact_hash that already encodes it, exactly
+    # what a genuinely pre-fix crash would have left on disk.
+    reservation_path = (
+        Path(env["BUILDEROPS_VAULT_ROOT"])
+        / "model-inquiries"
+        / "inq_test_legacy_orphan"
+        / "turn-ids"
+        / "turn-legacy.json"
+    )
+    legacy_reservation = json.loads(reservation_path.read_text(encoding="utf-8"))
+    assert "created_at" in legacy_reservation
+    del legacy_reservation["created_at"]
+    reservation_path.write_text(
+        json.dumps(legacy_reservation, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(BuilderOpsValidationError, match=r"orphaned=\['turn-legacy'\]"):
+        service.trace("inq_test_legacy_orphan")
+
+    recovered = service.commit_turn(
+        "inq_test_legacy_orphan",
+        turn_id="turn-legacy",
+        sequence=0,
+        role="reviewer",
+        content="Recovered legacy content",
+        input_artifact_refs=["question"],
+        source_refs=refs,
+    )
+    assert service.trace("inq_test_legacy_orphan")["turns"] == [recovered]
+    # The reservation stays in its legacy 5-key shape -- this fix does not
+    # retroactively upgrade pre-existing durable data.
+    committed_reservation = json.loads(reservation_path.read_text(encoding="utf-8"))
+    assert "created_at" not in committed_reservation
+
+
 def test_turn_transaction_is_serialized_across_service_instances(tmp_path: Path, monkeypatch) -> None:
     env = _env(tmp_path)
     first = ModelInquiryService.from_env(env)
@@ -608,11 +690,13 @@ def test_turn_transaction_is_serialized_across_service_instances(tmp_path: Path,
     assert len(first.trace("inq_test_serialized")["turns"]) == 1
 
     # A distinct service instance retains exactly one committed turn per
-    # identity/sequence even across an orphaned reservation, deterministically
-    # across a forced wall-clock boundary rather than by same-second luck: a
-    # non-exact retry (same turn_id/sequence, different content) against the
-    # other instance's orphaned reservation still fails closed, while an exact
-    # retry from that other instance reproduces the durably reserved artifact.
+    # identity/sequence even across an orphaned reservation: a non-exact retry
+    # (same turn_id/sequence, different content) against the other instance's
+    # orphaned reservation still fails closed, while an exact retry from that
+    # other instance reproduces the durably reserved artifact. Proven under
+    # genuine concurrent contention -- a Barrier-released real-thread race, not
+    # one fixed sequential event order -- so the flock's serialization is what
+    # is exercised, not just the state machine's logic for a chosen ordering.
     orphan_turn_id = "turn-c"
     orphan_sequence = 1
     original_write_immutable = first._write_immutable
@@ -622,15 +706,14 @@ def test_turn_transaction_is_serialized_across_service_instances(tmp_path: Path,
             raise KeyboardInterrupt("simulated process loss")
         return original_write_immutable(path, payload, label=label)
 
-    monkeypatch.setattr(first, "_write_immutable", crash_before_turn)
+    # Frozen (not advancing) on purpose: this sub-test's job is to prove
+    # cross-instance retry safety under a genuine race, a concern orthogonal to
+    # timestamp-boundary determinism, which test_crashed_turn_reservation_is_
+    # visible_and_retryable already covers. A single frozen value also removes
+    # any dependency on which racing thread's utc_now() call runs first.
     reservation_timestamp = "2026-02-01T00:00:00Z"
-    boundary_timestamps = iter(
-        [reservation_timestamp, "2026-02-01T00:00:05Z", "2026-02-01T00:00:10Z"]
-    )
-    monkeypatch.setattr(
-        "app.builderops.model_inquiry.utc_now",
-        lambda: next(boundary_timestamps),
-    )
+    monkeypatch.setattr(first, "_write_immutable", crash_before_turn)
+    monkeypatch.setattr("app.builderops.model_inquiry.utc_now", lambda: reservation_timestamp)
     with pytest.raises(KeyboardInterrupt, match="simulated process loss"):
         first.commit_turn(
             "inq_test_serialized",
@@ -643,31 +726,58 @@ def test_turn_transaction_is_serialized_across_service_instances(tmp_path: Path,
         )
     monkeypatch.setattr(first, "_write_immutable", original_write_immutable)
 
-    with pytest.raises(BuilderOpsConflictError, match="immutable turn id reservation"):
-        second.commit_turn(
-            "inq_test_serialized",
-            turn_id=orphan_turn_id,
-            sequence=orphan_sequence,
-            role="reviewer",
-            content="Different candidate",
-            input_artifact_refs=["question"],
-            source_refs=refs,
-        )
+    race_barrier = Barrier(2)
+    race_results: dict[str, object] = {}
 
-    recovered = second.commit_turn(
-        "inq_test_serialized",
-        turn_id=orphan_turn_id,
-        sequence=orphan_sequence,
-        role="reviewer",
-        content="Original candidate",
-        input_artifact_refs=["question"],
-        source_refs=refs,
-    )
+    def race_exact() -> None:
+        race_barrier.wait(timeout=2)
+        try:
+            race_results["exact"] = second.commit_turn(
+                "inq_test_serialized",
+                turn_id=orphan_turn_id,
+                sequence=orphan_sequence,
+                role="reviewer",
+                content="Original candidate",
+                input_artifact_refs=["question"],
+                source_refs=refs,
+            )
+        except BuilderOpsConflictError as exc:
+            race_results["exact"] = exc
+
+    def race_divergent() -> None:
+        race_barrier.wait(timeout=2)
+        try:
+            race_results["divergent"] = first.commit_turn(
+                "inq_test_serialized",
+                turn_id=orphan_turn_id,
+                sequence=orphan_sequence,
+                role="reviewer",
+                content="Different candidate",
+                input_artifact_refs=["question"],
+                source_refs=refs,
+            )
+        except BuilderOpsConflictError as exc:
+            race_results["divergent"] = exc
+
+    # Both threads block on the barrier and are released at the same instant,
+    # so their flock/RLock acquisition attempts genuinely overlap regardless of
+    # which one the scheduler happens to grant the lock to first -- both
+    # possible orderings must converge on the same correct outcome.
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        pending_exact = executor.submit(race_exact)
+        pending_divergent = executor.submit(race_divergent)
+        pending_exact.result(timeout=5)
+        pending_divergent.result(timeout=5)
+
+    assert isinstance(race_results["divergent"], BuilderOpsConflictError)
+    recovered = race_results["exact"]
+    assert isinstance(recovered, dict)
     assert recovered["turn_id"] == orphan_turn_id
     assert recovered["created_at"] == reservation_timestamp
-    assert [turn["turn_id"] for turn in second.trace("inq_test_serialized")["turns"]].count(
-        orphan_turn_id
-    ) == 1
+    committed_turns = second.trace("inq_test_serialized")["turns"]
+    assert [turn["turn_id"] for turn in committed_turns].count(orphan_turn_id) == 1
+    orphan_turn = next(turn for turn in committed_turns if turn["turn_id"] == orphan_turn_id)
+    assert orphan_turn["content"] == "Original candidate"
 
 
 def test_turn_transaction_is_serialized_across_processes(tmp_path: Path) -> None:


### PR DESCRIPTION
Governing-Issue: #3833

Fixes #3833

## Summary

An exact `commit_turn` retry after process loss (turn-id reservation persisted, turn artifact write crashed) recomputed `created_at` via a fresh `utc_now()` call. Since `utc_now()` truncates to whole seconds, a retry landing on a later second minted a different `artifact_hash` than the orphaned reservation already held, and the retry failed closed with a spurious `BuilderOpsConflictError` instead of recovering — the timing-dependent Builder System defect PR #3822's exact-head CI run exposed (classified at the time as a "main-side timing flake").

The turn-id reservation now durably carries `created_at` at the moment it is written, before the turn artifact itself is committed. `commit_turn` reads any existing reservation first and reuses its `created_at` as the deterministic identity input for a retry, so an exact retry always recomputes the same `artifact_hash` the reservation already holds, regardless of wall-clock drift.

## Where the deterministic identity comes from (for review)

The retry's deterministic identity comes from the **durable turn-id reservation's own `created_at` field**, which is now written alongside the reservation's existing `artifact_hash` the moment the reservation is persisted — strictly before the turn artifact write is attempted. `_commit_turn_locked` reads any existing reservation for the turn_id *before* building the turn payload; if the turn file is not yet committed (orphaned reservation) but a reservation exists, its `created_at` becomes the fallback for `_existing_timestamp(...)` instead of a fresh `utc_now()`. This makes an **exact** retry (same turn_id, sequence, role, content, input refs, provenance) reproduce the identical `artifact_hash` byte-for-byte, so the reservation write becomes a true idempotent no-op and the turn commit proceeds.

A **non-exact** retry still fails closed, by construction, not by a new special case: any difference in content/role changes `content_hash` -> `artifact_hash`; any difference in `sequence` changes the reservation payload's `sequence` field directly. Either way the freshly computed reservation payload no longer equals the durably persisted one, so `_write_immutable_status`'s existing no-overwrite equality check raises `BuilderOpsConflictError` exactly as it already did for a conflicting rewrite of an already-committed turn — no new fail-closed logic was added, the existing mechanism now sees the correct (reused) `created_at` on both sides of the comparison.

**Backward compatibility**: reservations written before this change have no `created_at` key. `_read_turns`'s reservation-shape validation, the write path's own reservation-payload construction, and `_reconcile_failed_turn_reservation`'s expected-shape check all only require/write the field when the on-disk record already carries it — a legacy 5-key reservation still validates, and stays retryable, against the legacy 5-key shape (see "Post-review fixes" below for how the write path got here).

**Concurrency correctness** (adversarial review checklist):
- *Process crash between reservation and commit*: covered — reservation carries `created_at`, orphan is retryable (AC1 test).
- *Two service instances racing the same retry*: covered — `test_turn_transaction_is_serialized_across_service_instances` proves a non-exact retry from a second instance against the first instance's orphaned reservation fails closed under a genuine Barrier-released real-thread race, and an exact retry from that second instance reproduces the reserved identity regardless of which thread wins the lock first.
- *Retry arriving after a genuinely different turn was committed for the same sequence*: unchanged — the pre-existing loop over committed turns in `_commit_turn_locked` still raises before reservation logic runs at all.
- *Clock skew / timestamp boundary crossing (the original bug)*: `test_crashed_turn_reservation_is_visible_and_retryable` forces a real second-boundary crossing via a monkeypatched `utc_now()` instead of relying on same-second luck, and fails deterministically without the fix (verified locally by reverting the production diff and re-running the test).

## Post-review fixes (adversarial concurrency review)

This PR got an adversarial concurrency review using a real `threading.Thread` + `Barrier` harness (not just static reading) against this branch's actual source — it independently **confirmed the mechanism above is genuinely race-safe under real concurrent contention** (5 repeated runs, exactly one write / clean fail-closed every time). Two findings came out of it:

**G1 (fixed) — a genuinely pre-fix orphaned reservation became permanently unretryable.** Root cause: the reservation write's conflict check does strict whole-dict equality, and the write payload unconditionally included `created_at`. A 5-key on-disk reservation (crashed *before* this PR shipped) can never dict-equal a freshly-computed 6-key one, so every retry against it — even an exact one — deterministically raised `BuilderOpsConflictError` at the reservation-write step, which sits outside the `try`/`except` that triggers `_reconcile_failed_turn_reservation`, so no automatic cleanup fired either. This is strictly worse than the pre-fix behavior for that narrow case: before this PR, a retry against *any* orphan had a chance of succeeding on same-timestamp luck; after it, a legacy orphan had zero chance, forever.

Fix mirrors a pattern already in this PR: `_read_turns`'s backward-compat validation already treats `created_at` as optional for already-committed legacy turns. The write path (`_commit_turn_locked`) and `_reconcile_failed_turn_reservation` now apply the identical rule — only include/require `created_at` in the reservation comparison when the on-disk record already carries it. A legacy orphan's exact retry now succeeds (reproducing its pre-fix same-timestamp-luck odds, not full determinism — that's not recoverable from a one-way hash, and remains the accepted "Out of Scope: changing committed artifact schemas unless a backward-compatible migration is explicitly justified" limitation), instead of being permanently stranded. New coverage: `test_legacy_orphaned_reservation_without_created_at_is_retryable` hand-constructs a genuine 5-key legacy reservation (real crash simulation + frozen clock, then strips `created_at` while keeping the real resulting `artifact_hash`) and proves the exact retry succeeds and the reservation stays in its legacy shape (no retroactive upgrade). Grepped first to confirm no existing test exercised this shape.

**G2 (taken) — a sub-test proved logical correctness for one fixed event order, not genuine OS-level lock contention.** The orphan-retry cross-instance scenario in `test_turn_transaction_is_serialized_across_service_instances` originally called `first.commit_turn` then `second.commit_turn` sequentially on one thread, unlike the Event-synchronized real-thread pattern the same test function already uses 40 lines earlier. Converted it to a `Barrier`-released real-thread race between the two service instances (mirroring the reviewer's own validated repro), asserting the same correct outcome — exactly one committed turn, the divergent attempt fails closed — holds under both possible lock-acquisition orderings. Verified stable across 10 repeated local runs.

## Validation

- `pytest -q tests/builderops/test_model_inquiry_cli.py::test_crashed_turn_reservation_is_visible_and_retryable` — 1 passed
- `pytest -q tests/builderops/test_model_inquiry_cli.py::test_legacy_orphaned_reservation_without_created_at_is_retryable` — 1 passed (new, G1)
- `pytest -q tests/builderops/test_model_inquiry_cli.py tests/builderops/test_model_inquiry_trace.py` — 21 passed
- `pytest -q tests/builderops/ tests/api/test_builderops_inquiry_api.py` — 448 passed, 137 skipped (post-rebase)
- `ruff check app tests companion-ui/companion-app` — all checks passed
- `mypy app` — 1 pre-existing error in `app/dispatcher/control_plane.py` (untouched by this diff, confirmed via `git diff --stat origin/main...HEAD`; present on `origin/main` before this change)
- `pytest -q -m "not pg"` (full suite, `PYTHONPATH` extended with `companion-ui/companion-app` for collection) — 9824 passed, 12 failed, 54 skipped, 225 deselected, 18 xfailed (pre-rebase baseline run). All 12 failures are pre-existing/environmental (deploy-compose/docs-tooling gaps on this laptop, e.g. `tests/deploy/**`, `tests/ops/test_start_full_runtime_health.py`, `tests/quality_wave/test_bootstrap_start.py`, `tests/standing_questions/test_question_store.py`) — reproduced identically with this diff reverted, confirming zero coupling to `app/builderops/**`.
- `pytest -q tests/properties -m "not pg"` — 25 passed, 2 skipped (census/store-payload registries in `tests/properties/_machinery.py` do not reference `app/builderops/model_inquiry.py` at all; no census update needed).
- New G1 test and the converted G2 race both verified test-first (fail against the code with only that fix reverted, pass with it applied); the G2 race additionally run 10x locally to check for flakiness — none observed.

## Acceptance Criteria

- [x] A simulated process loss after turn-id reservation followed by an exact retry across a forced timestamp boundary commits the turn without `BuilderOpsConflictError`.
  Verify: `tests/builderops/test_model_inquiry_cli.py::test_crashed_turn_reservation_is_visible_and_retryable` — strengthened to force a real second-boundary crossing via monkeypatched `utc_now()` (was previously same-second-luck dependent, matching the PR #3822 CI flake).
- [x] A non-exact retry against the same reservation still fails closed, while concurrent service instances retain one committed turn per identity/sequence.
  Verify: `tests/builderops/test_model_inquiry_cli.py::test_turn_transaction_is_serialized_across_service_instances` — extended with a new orphaned-reservation scenario proving both halves of the AC across two distinct `ModelInquiryService` instances, under a genuine Barrier-released real-thread race (post-review G2 fix).
- [x] The owner document states how an orphaned reservation supplies deterministic identity for exact retry.
  Verify: doc writeback at `docs/BUILDEROPS_MODEL_INQUIRY/PRE_TICKET_INQUIRY_RECORDS.md :: Implemented Record Layout` — paragraph after the existing orphaned-reservation sentence, extended for the G1 write-path fix.

## Claim Receipt

```
pickup-claim-complete issue=3833 branch=fix/3833-turn-reservation-retry-determinism worktree=/Users/rasmusthornberg/code/pkm-worktrees/issue-3833-turn-reservation coordination_mode=github-label-only-fallback fallback_reason=dispatcher_db_uninitialized agent=claude-sonnet-3833 session=ca240656-98c1-4a13-8257-390d8c745490 evidence=github-comment:4997659484
```
Receipt comment: https://github.com/RasmusTho/agentic-pkm-mvp/issues/3833#issuecomment-4997659484

## BuilderOps Routing

- Records/projections/receipts: none
- Reason: bounded code + test + owner-doc fix fully captured by the issue-backed PR itself; no BuilderOps Vault record needed. In passing, found an unrelated small `.gitignore` completeness gap (`runtime/relevance/` and `runtime/activation/` missing from the otherwise-complete `/runtime/<subdir>/` ignore list) — routed as a separate spawned follow-up task rather than folded into this PR's scope.

---
