### PR TITLE
test: exclude PostgreSQL store parameters from not-pg suite

### DIFF
--- a/tests/governance/test_pytest_marker_contract.py
+++ b/tests/governance/test_pytest_marker_contract.py
@@ -1,0 +1,114 @@
+"""Governance regression test for the ``pg`` pytest marker contract on the
+PostgreSQL store-contract suite (issue #3879).
+
+``tests/stores/test_store_contract_pg.py`` parametrizes several store-contract
+tests over a memory backend and a real PostgreSQL backend, plus three
+standalone PostgreSQL-only regression tests. The required validation gate is
+``pytest -q -m "not pg"``: every PostgreSQL-backed case must be *deselected*
+by that marker expression regardless of whether a PostgreSQL socket happens
+to be reachable on the host running the suite.
+
+Regression context: while validating #3162, a locally reachable but
+unmigrated PostgreSQL server let unmarked ``backend="pg"`` parameters and
+standalone PostgreSQL tests run under the nominal ``not pg`` gate instead of
+being deselected, failing with ``StoreSchemaMissingError``. On CI (no
+PostgreSQL reachable) the same unmarked cases merely skipped, hiding the
+marker gap entirely.
+
+This test proves the deselection contract statically via ``--collect-only``,
+so it never touches a database itself: marker-based deselection is decided
+entirely at collection time, before any fixture or test body executes, so
+the result cannot depend on host DB reachability.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from functools import lru_cache
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TARGET = "tests/stores/test_store_contract_pg.py"
+
+
+@lru_cache(maxsize=None)
+def _collect_node_ids(marker_expr: str | None) -> frozenset[str]:
+    """Return the set of test node ids pytest collects for ``TARGET``.
+
+    Uses ``--collect-only -q`` so no test body, fixture, or database
+    connection ever executes for the collected file -- this only exercises
+    pytest's marker-expression evaluation at collection time, which is
+    independent of whether a PostgreSQL socket happens to be reachable.
+    """
+    cmd = [sys.executable, "-m", "pytest", "--collect-only", "-q"]
+    if marker_expr is not None:
+        cmd += ["-m", marker_expr]
+    cmd.append(TARGET)
+    result = subprocess.run(
+        cmd,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"pytest --collect-only failed (exit {result.returncode}) for "
+        f"marker={marker_expr!r}:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    return frozenset(
+        line.strip() for line in result.stdout.splitlines() if "::" in line
+    )
+
+
+def test_store_contract_postgres_cases_are_marked_pg() -> None:
+    """``-m "not pg"`` deselects every PostgreSQL-backed case in the file.
+
+    A case is treated as PostgreSQL-backed when its node id does not carry
+    the ``[memory]`` parametrization id -- in this file that is exactly the
+    ``backend="pg"`` parametrizations plus the standalone PostgreSQL-only
+    regression tests. Every such case must both (a) be absent from the
+    ``not pg`` collection and (b) be present in the ``pg`` collection, so a
+    case can't silently lose its marker without also disappearing from the
+    intentional ``pg`` selection.
+    """
+    full = _collect_node_ids(None)
+    not_pg = _collect_node_ids("not pg")
+    pg_only = _collect_node_ids("pg")
+
+    postgres_backed = {node_id for node_id in full if not node_id.endswith("[memory]")}
+    assert postgres_backed, "expected at least one PostgreSQL-backed case in the file"
+
+    leaked = postgres_backed & not_pg
+    assert not leaked, (
+        "PostgreSQL-backed case(s) were collected under -m 'not pg' (missing "
+        f"the pg marker): {sorted(leaked)}"
+    )
+
+    unmarked = postgres_backed - pg_only
+    assert not unmarked, (
+        f"PostgreSQL-backed case(s) missing from -m 'pg': {sorted(unmarked)}"
+    )
+
+    # Known from the issue context: 5 parametrized backend="pg" cases + 3
+    # standalone PostgreSQL-only tests. Pinning the count also guards
+    # against silent coverage shrinkage, not just missing markers.
+    assert len(postgres_backed) == 8, sorted(postgres_backed)
+
+
+def test_store_contract_memory_cases_remain_not_pg() -> None:
+    """Memory-backed store contract coverage remains in the non-PG suite."""
+    full = _collect_node_ids(None)
+    not_pg = _collect_node_ids("not pg")
+
+    memory_backed = {node_id for node_id in full if node_id.endswith("[memory]")}
+    assert memory_backed, "expected at least one memory-backed case in the file"
+
+    missing = memory_backed - not_pg
+    assert not missing, (
+        f"memory-backed case(s) missing from -m 'not pg': {sorted(missing)}"
+    )
+
+    # Known from the issue context: 5 parametrized store-contract functions
+    # cover the memory backend.
+    assert len(memory_backed) == 5, sorted(memory_backed)

--- a/tests/stores/test_store_contract_pg.py
+++ b/tests/stores/test_store_contract_pg.py
@@ -14,7 +14,7 @@ TEST_PG_IDENTITY = EmbeddingIdentity(provider="test", model="pg-test", dim=4)
 
 BACKENDS = [
     pytest.param("memory", id="memory"),
-    pytest.param("pg", id="pg"),
+    pytest.param("pg", id="pg", marks=pytest.mark.pg),
 ]
 
 
@@ -118,6 +118,7 @@ def test_relation_memberships_are_optional_and_empty_by_default(monkeypatch, bac
     assert rel.memberships(uuid4(), rel="sphere_membership") == []
 
 
+@pytest.mark.pg
 def test_pg_vector_index_query_dim_mismatch(monkeypatch):
     if not _pg_available():
         pytest.skip("Postgres backend not available")
@@ -132,6 +133,7 @@ def test_pg_vector_index_query_dim_mismatch(monkeypatch):
         idx.search([0.5, 0.5, 0.5], k=1, identity=TEST_PG_IDENTITY)
 
 
+@pytest.mark.pg
 def test_pg_vector_index_detects_mixed_dims(monkeypatch):
     if not _pg_available():
         pytest.skip("Postgres backend not available")
@@ -151,6 +153,7 @@ def test_pg_vector_index_detects_mixed_dims(monkeypatch):
         idx.search([1, 0, 0, 0], k=1, identity=TEST_PG_IDENTITY)
 
 
+@pytest.mark.pg
 def test_pg_vector_index_identity_mismatch(monkeypatch):
     if not _pg_available():
         pytest.skip("Postgres backend not available")


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

Governing-Issue: #3879

## Linked Issue
Fixes #3879

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): OEF (test signal truth)
- Write class: governance/process
- Authority impact: none
- Persistence impact: none
- Derived/rebuildable impact: none
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: none
- External boundary impact: none
- New or changed contract: the `not pg` validation selector now excludes PostgreSQL integration cases in tests/stores/test_store_contract_pg.py independently of local host state
- Owner-doc impact: none
- Transition debt impact: reduces validation-environment coupling
- Fitness rule impact: strengthens test isolation
- Boundary risk: low - test-marker and new governance-test-only change; no app/ source, runtime, or product behavior touched

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Mark every `backend="pg"` parametrized case and the three standalone PostgreSQL-only tests in `tests/stores/test_store_contract_pg.py` with the canonical `pg` pytest marker, so `-m "not pg"` deselects them at collection time regardless of whether a PostgreSQL socket happens to be reachable on the host.
- Add `tests/governance/test_pytest_marker_contract.py`, a static regression test that runs `pytest --collect-only` as a subprocess (no test bodies execute, no DB touched) to prove the `not pg` / `pg` marker expressions partition the file's 13 cases into exactly 5 memory-backed (`not pg`) and 8 PostgreSQL-backed (`pg`) cases.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [ ] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [ ] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [x] `pytest -q tests/governance/test_pytest_marker_contract.py` -> 2 passed
- [x] `pytest --collect-only -q -m "not pg" tests/stores/test_store_contract_pg.py` -> 5/13 collected, 8 deselected (all 5 backend="pg" parametrizations + 3 standalone PostgreSQL-only tests excluded)
- [x] `pytest --collect-only -q -m "pg" tests/stores/test_store_contract_pg.py` -> 8/13 collected, 5 deselected (all 8 PostgreSQL-backed cases selected; memory cases excluded)
- [x] `pytest -q -m "not pg" tests/stores/` -> 45 passed, 2 skipped, 25 deselected, 0 failed
- [x] `ruff check app tests` -> All checks passed!
- [x] mypy app not run: change is test-only (no app/ source modified) and not in this issue's Suggested Validation list; ruff check app tests satisfies the required lint gate for tests/ changes
- [x] `pytest -q -m "not pg" tests/governance/` (full directory, includes the new file) -> 250 passed, 0 failed
- [x] FULL `pytest -q -m "not pg"`: run 3x across two rebases onto a moving origin/main (this laptop has several concurrent sibling-agent worktrees active). Cleanest isolated run (pre-rebase, base 79ee902d): 22 failed / 9603 passed / 45 skipped / 231 deselected / 18 xfailed, matching this issue's stated ~23 known pre-existing/environmental baseline. Later reruns on the same laptop under heavier concurrent load (371 active processes observed) grew to 42 then 153 failed, entirely via OSError/ENOENT-style collection errors in unrelated CLI/companion_ui/commitments/workers modules - never in tests/stores/ or tests/governance/. Targeted, deterministic reruns of exactly those two directories stayed 100% green across every attempt (see the two lines above), so the full-suite noise is attributed to shared machine load, not this change; diff-stat vs origin/main confirms this PR touches only tests/stores/test_store_contract_pg.py and the new tests/governance/test_pytest_marker_contract.py

## Claim Receipt
```
pickup-claim-complete issue=3879 branch=fix/3879-pg-marker-exclusion worktree=/Users/rasmusthornberg/code/pkm-worktrees/issue-3879-pg-markers coordination_mode=github-label-only-fallback fallback_reason=dispatcher_db_uninitialized agent=claude-sonnet-3879 session=ca240656-98c1-4a13-8257-390d8c745490 evidence=github-comment:4997622831
```

## BuilderOps Routing
- Records/projections/receipts: Applies learning: lrn_20260716073739_28ee8f0a from #3162
- Reason: This slice's scope (mark backend="pg" parameters and standalone PostgreSQL tests with the canonical pg marker; add a static -m marker-deselection regression test) was directly shaped by BuilderOps LearningSignal lrn_20260716073739_28ee8f0a, captured while validating #3162's `not pg` gate. No new BuilderOps record was created by this PR; the governing issue already carries the applied-learning provenance.

## Notes
Environmental observation (not a change in this PR): full-suite `not pg` runs got noisier across repeated back-to-back invocations on this laptop while origin/main moved twice during delivery (rebased onto #3933's docs-index fix, then onto #3947's companion_ui sys.path fix + several unrelated merges). The failure/error set each time was a different unrelated slice of the suite (cli/, commitments/, companion_ui/, workers/, etc.), never tests/stores/ or tests/governance/, and process listing showed 371 active processes for this user with multiple sibling agent worktrees present, consistent with shared-machine contention rather than a regression. No follow-up filed for this since it did not block scoped validation; flagging for visibility only.
