### PR TITLE
BCP-04: authenticated API-only client for the BuilderOps control plane

### DIFF
--- a/.codex/skills/automation-maintenance/SKILL.md
+++ b/.codex/skills/automation-maintenance/SKILL.md
@@ -61,7 +61,8 @@ specific justified exception. The redirect workspace
 (`LearningSignal`/worklog/promotion/receipt vault artifacts and `generate-projections`
 exports) — a system distinct from the newer BuilderOps **control plane** (task/lease/
 attempt/promotion/receipt coordination authority for the build process itself, hosted on
-Demerzel). For control-plane operations, use the authenticated API-only client instead:
+the independent control-plane host). For control-plane operations, use the authenticated
+API-only client instead:
 `scripts/builderops_api_client.sh` (`python -m app.builderops.control_plane`; see
 `docs/BUILDEROPS_CONTROL_PLANE/API_ONLY_CLIENT_CUTOVER.md`). Do not redirect the Vault-record
 commands below (`list`, `create-learning-signal`, `generate-projections`) to the new client:

--- a/.codex/skills/automation-maintenance/SKILL.md
+++ b/.codex/skills/automation-maintenance/SKILL.md
@@ -56,6 +56,19 @@ specific justified exception. The redirect workspace
 
 ## BuilderOps CLI dependency setup
 
+**Two separate BuilderOps systems exist; use the right client for each.** This section's
+`scripts/builderops_cli.sh` wraps the pre-existing local BuilderOps **Vault record** store
+(`LearningSignal`/worklog/promotion/receipt vault artifacts and `generate-projections`
+exports) — a system distinct from the newer BuilderOps **control plane** (task/lease/
+attempt/promotion/receipt coordination authority for the build process itself, hosted on
+Demerzel). For control-plane operations, use the authenticated API-only client instead:
+`scripts/builderops_api_client.sh` (`python -m app.builderops.control_plane`; see
+`docs/BUILDEROPS_CONTROL_PLANE/API_ONLY_CLIENT_CUTOVER.md`). Do not redirect the Vault-record
+commands below (`list`, `create-learning-signal`, `generate-projections`) to the new client:
+their read/projection path still depends on the local Vault SQLite store until BCP-03/06
+import that authority into the control plane, and writing new records through the new
+client alone would make them invisible to `list`/`generate-projections` (a split-brain).
+
 BuilderOps CLI commands require `click`, `pydantic`, and `sqlite3`.  Host Python
 interpreters (e.g. `/opt/homebrew/bin/python3`) typically lack these packages.
 

--- a/.codex/skills/temporal-doc-governance/SKILL.md
+++ b/.codex/skills/temporal-doc-governance/SKILL.md
@@ -33,6 +33,13 @@ authority. Do not rewrite either file solely to capture high-churn operational s
 
 ## BuilderOps projection regeneration — store selection and fail-loud rule
 
+`generate-projections` is a BuilderOps **Vault record** store operation (LearningSignal/worklog/
+promotion/receipt vault artifacts exported to markdown) — a separate system from the newer
+BuilderOps **control plane** client (`scripts/builderops_api_client.sh`,
+`docs/BUILDEROPS_CONTROL_PLANE/API_ONLY_CLIENT_CUTOVER.md`), which covers task/lease/attempt/
+promotion/receipt coordination authority for the build process and has no `generate-projections`
+equivalent. Stay on `scripts/builderops_cli.sh` for this operation.
+
 When this audit runs a `generate-projections` command to regenerate checked-in projections under
 `docs/generated/builderops/`, it **must** select the intended BuilderOps store explicitly before
 writing. The default store (`runtime/builderops/builderops.sqlite3`) is gitignored, machine-local,

--- a/app/builderops/control_plane/__main__.py
+++ b/app/builderops/control_plane/__main__.py
@@ -1,0 +1,8 @@
+"""Module entry point: the API-only BuilderOps control-plane client CLI."""
+
+from __future__ import annotations
+
+from app.builderops.control_plane.client_cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/builderops/control_plane/api_models.py
+++ b/app/builderops/control_plane/api_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -13,6 +14,20 @@ class AuthorityEnvelopeInput(BaseModel):
     stack: str
     source_refs: list[str] = Field(min_length=1)
     schema_version: int = Field(default=1, ge=1)
+
+
+class LeaseInput(BaseModel):
+    """Client-returned lease fields for a follow-up fenced mutation.
+
+    The repository is carried by the request envelope; every other lease field
+    is echoed back so the store can re-validate the fencing token and holder.
+    """
+
+    resource_id: str
+    holder: str
+    fencing_token: int = Field(ge=1)
+    expires_at: datetime
+    lease_kind: str = "task"
 
 
 class LeaseClaimRequest(BaseModel):
@@ -32,4 +47,79 @@ class RecordCommitRequest(BaseModel):
     idempotency_key: str
 
 
-__all__ = ["AuthorityEnvelopeInput", "LeaseClaimRequest", "RecordCommitRequest"]
+class InquiryCommitRequest(BaseModel):
+    """Model-inquiry authority object; a specialization of a record commit."""
+
+    envelope: AuthorityEnvelopeInput
+    inquiry_id: str
+    state: str
+    payload: dict[str, Any] = Field(default_factory=dict)
+    idempotency_key: str
+
+
+class TaskClaimRequest(BaseModel):
+    envelope: AuthorityEnvelopeInput
+    task_id: str
+    idempotency_key: str
+    request: dict[str, Any] = Field(default_factory=dict)
+    ttl_seconds: int = Field(default=5400, ge=1, le=86400)
+
+
+class TaskHeartbeatRequest(BaseModel):
+    envelope: AuthorityEnvelopeInput
+    lease: LeaseInput
+    idempotency_key: str
+    request: dict[str, Any] = Field(default_factory=dict)
+    ttl_seconds: int = Field(default=5400, ge=1, le=86400)
+
+
+class TaskCompleteRequest(BaseModel):
+    envelope: AuthorityEnvelopeInput
+    lease: LeaseInput
+    idempotency_key: str
+    request: dict[str, Any] = Field(default_factory=dict)
+
+
+class AttemptCommitRequest(BaseModel):
+    envelope: AuthorityEnvelopeInput
+    task_id: str
+    attempt_id: str
+    state: str
+    payload: dict[str, Any] = Field(default_factory=dict)
+    idempotency_key: str
+    lease: LeaseInput
+    expected_states: list[str] | None = None
+
+
+class PromotionCommitRequest(BaseModel):
+    envelope: AuthorityEnvelopeInput
+    promotion_id: str
+    status: str
+    payload: dict[str, Any] = Field(default_factory=dict)
+    idempotency_key: str
+    lease: LeaseInput | None = None
+    expected_states: list[str] | None = None
+
+
+class OutboxClaimRequest(BaseModel):
+    """Privileged executor request to claim a durable external-effect intent."""
+
+    envelope: AuthorityEnvelopeInput
+    operation_key: str | None = None
+    worker_id: str
+    claim_ttl_seconds: int = Field(default=300, ge=1, le=3600)
+
+
+__all__ = [
+    "AttemptCommitRequest",
+    "AuthorityEnvelopeInput",
+    "InquiryCommitRequest",
+    "LeaseClaimRequest",
+    "LeaseInput",
+    "OutboxClaimRequest",
+    "PromotionCommitRequest",
+    "RecordCommitRequest",
+    "TaskClaimRequest",
+    "TaskCompleteRequest",
+    "TaskHeartbeatRequest",
+]

--- a/app/builderops/control_plane/auth.py
+++ b/app/builderops/control_plane/auth.py
@@ -17,6 +17,9 @@ class CredentialConfigurationError(RuntimeError):
     """Raised when the host-owned credential configuration is unusable."""
 
 
+_REPOSITORY_SCOPE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
+
+
 @dataclass(frozen=True)
 class Credential:
     credential_id: str
@@ -26,6 +29,20 @@ class Credential:
     scopes: frozenset[str]
     rotation_generation: int
     token_length: int
+    repositories: frozenset[str] = frozenset()
+
+    def may_address(self, repository: str) -> bool:
+        """Return whether this credential is granted authority for ``repository``.
+
+        A credential that declares ``repositories`` is bound to exactly that set
+        (canonical ``owner/name``, lowercased). Cross-repo access fails closed.
+        A credential that declares no repositories is unrestricted for repo
+        addressing; production write credentials are expected to declare their
+        scope, which the cutover provisions.
+        """
+        if not self.repositories:
+            return True
+        return repository.strip().lower() in self.repositories
 
 
 class CredentialRegistry:
@@ -102,6 +119,21 @@ class CredentialRegistry:
                     "BuilderOps credential scopes must be unique bounded identifiers"
                 )
             scopes = frozenset(scopes_raw)
+            repositories_raw = raw.get("repositories", [])
+            if not isinstance(repositories_raw, list) or not all(
+                isinstance(repository, str)
+                and _REPOSITORY_SCOPE.fullmatch(repository.strip()) is not None
+                and not any(part in {".", ".."} for part in repository.strip().split("/"))
+                for repository in repositories_raw
+            ):
+                raise CredentialConfigurationError(
+                    "BuilderOps credential repositories must be bounded owner/name references"
+                )
+            repositories = frozenset(repository.strip().lower() for repository in repositories_raw)
+            if len(repositories) != len(repositories_raw):
+                raise CredentialConfigurationError(
+                    "BuilderOps credential repositories must be unique"
+                )
             revoked = raw.get("revoked", False)
             if type(revoked) is not bool:
                 raise CredentialConfigurationError("invalid BuilderOps credential metadata")
@@ -160,6 +192,7 @@ class CredentialRegistry:
                         scopes=scopes,
                         rotation_generation=generation,
                         token_length=token_length,
+                        repositories=repositories,
                     ),
                     verifier,
                 )
@@ -235,6 +268,7 @@ class CredentialRegistry:
                     "secret_ref": entry.secret_ref,
                     "fingerprint": entry.fingerprint,
                     "scopes": sorted(entry.scopes),
+                    "repositories": sorted(entry.repositories),
                     "rotation_generation": entry.rotation_generation,
                     "token_length": entry.token_length,
                 }

--- a/app/builderops/control_plane/auth.py
+++ b/app/builderops/control_plane/auth.py
@@ -30,17 +30,21 @@ class Credential:
     rotation_generation: int
     token_length: int
     repositories: frozenset[str] = frozenset()
+    all_repositories: bool = False
 
     def may_address(self, repository: str) -> bool:
         """Return whether this credential is granted authority for ``repository``.
 
-        A credential that declares ``repositories`` is bound to exactly that set
-        (canonical ``owner/name``, lowercased). Cross-repo access fails closed.
-        A credential that declares no repositories is unrestricted for repo
-        addressing; production write credentials are expected to declare their
-        scope, which the cutover provisions.
+        Fail closed by default: a credential that declares neither
+        ``repositories`` nor the explicit ``all_repositories`` opt-in may
+        address NO repository. A credential that declares ``repositories`` is
+        bound to exactly that set (canonical ``owner/name``, lowercased).
+        ``all_repositories=True`` is a distinct, explicit, unambiguous opt-in
+        for the small set of credentials (e.g. the privileged executor) that
+        legitimately need unrestricted repo addressing; it is never implied by
+        an absent or empty ``repositories`` list.
         """
-        if not self.repositories:
+        if self.all_repositories:
             return True
         return repository.strip().lower() in self.repositories
 
@@ -134,6 +138,16 @@ class CredentialRegistry:
                 raise CredentialConfigurationError(
                     "BuilderOps credential repositories must be unique"
                 )
+            all_repositories_raw = raw.get("all_repositories", False)
+            if type(all_repositories_raw) is not bool:
+                raise CredentialConfigurationError(
+                    "BuilderOps credential all_repositories must be a boolean"
+                )
+            if all_repositories_raw and repositories:
+                raise CredentialConfigurationError(
+                    "a BuilderOps credential must not combine all_repositories with an "
+                    "explicit repositories list; the combination is ambiguous"
+                )
             revoked = raw.get("revoked", False)
             if type(revoked) is not bool:
                 raise CredentialConfigurationError("invalid BuilderOps credential metadata")
@@ -193,6 +207,7 @@ class CredentialRegistry:
                         rotation_generation=generation,
                         token_length=token_length,
                         repositories=repositories,
+                        all_repositories=all_repositories_raw,
                     ),
                     verifier,
                 )
@@ -269,6 +284,7 @@ class CredentialRegistry:
                     "fingerprint": entry.fingerprint,
                     "scopes": sorted(entry.scopes),
                     "repositories": sorted(entry.repositories),
+                    "all_repositories": entry.all_repositories,
                     "rotation_generation": entry.rotation_generation,
                     "token_length": entry.token_length,
                 }

--- a/app/builderops/control_plane/client.py
+++ b/app/builderops/control_plane/client.py
@@ -25,15 +25,18 @@ from typing import Any
 
 import httpx
 
+from app.builderops.control_plane.models import STALE_DETAIL_NAMES
+
 API_VERSION = "v1"
 _EPOCH_HEADER = "X-BuilderOps-Authority-Epoch"
 _DEFAULT_TIMEOUT_SECONDS = 15.0
 _DEFAULT_MAX_RETRIES = 2
 
 # 409 details that mean "your lease/fence/epoch is no longer authoritative".
-_STALE_DETAILS = frozenset(
-    {"StaleFencingToken", "StaleAuthorityEpoch", "LeaseUnavailable", "LeaseRequired"}
-)
+# Shared with the service's HTTP 409 classification via models.py so a
+# server-side exception rename cannot silently desync from this matching
+# (BCP-04 review finding H3).
+_STALE_DETAILS = STALE_DETAIL_NAMES
 
 
 class ControlPlaneClientError(RuntimeError):
@@ -468,15 +471,26 @@ class BuilderOpsControlPlaneClient:
 
     @staticmethod
     def _detail(response: httpx.Response) -> str:
+        """Extract the 409 ``detail`` classification, consistent with ``_decode``.
+
+        A truncated/non-JSON body (e.g. proxy interference) raises
+        ``ControlPlaneProtocolError`` rather than silently returning an empty
+        detail: a caller distinguishing ``StaleLeaseError`` (safe to retry
+        after a lease refresh) from a generic ``ControlPlaneConflictError``
+        must not have that signal silently downgraded by a malformed response.
+        """
         try:
             body = response.json()
-        except (json.JSONDecodeError, ValueError):
-            return ""
-        if isinstance(body, dict):
-            detail = body.get("detail")
-            if isinstance(detail, str):
-                return detail
-        return ""
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise ControlPlaneProtocolError(
+                "BuilderOps control plane returned a malformed 409 response"
+            ) from exc
+        if not isinstance(body, dict):
+            raise ControlPlaneProtocolError(
+                "BuilderOps control plane returned an unexpected 409 response shape"
+            )
+        detail = body.get("detail")
+        return detail if isinstance(detail, str) else ""
 
 
 __all__ = [

--- a/app/builderops/control_plane/client.py
+++ b/app/builderops/control_plane/client.py
@@ -1,0 +1,495 @@
+"""Versioned authenticated client for the BuilderOps control-plane API.
+
+This is the single authority-bearing transport every MacBook workflow uses to
+reach the independent BuilderOps service (BCP-02). It deliberately holds **no**
+store, database driver, or filesystem authority: when the service is
+unavailable, or a credential is rejected, or a fencing/epoch conflict occurs,
+every method raises a typed fail-closed error and leaves no local authority,
+SQLite database, JSONL/JSON ledger, or fabricated GitHub lease behind.
+
+BCP-04 prepares the clients; BCP-06 chooses the authoritative cutover moment.
+The base URL and scoped bearer credential come exclusively from host/user secret
+configuration (environment variables and host secret files), never from files
+checked into a repository, and the credential is never logged.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+API_VERSION = "v1"
+_EPOCH_HEADER = "X-BuilderOps-Authority-Epoch"
+_DEFAULT_TIMEOUT_SECONDS = 15.0
+_DEFAULT_MAX_RETRIES = 2
+
+# 409 details that mean "your lease/fence/epoch is no longer authoritative".
+_STALE_DETAILS = frozenset(
+    {"StaleFencingToken", "StaleAuthorityEpoch", "LeaseUnavailable", "LeaseRequired"}
+)
+
+
+class ControlPlaneClientError(RuntimeError):
+    """Base class for every fail-closed control-plane client error."""
+
+
+class ControlPlaneConfigError(ControlPlaneClientError):
+    """Raised when the host-owned client configuration is missing or unusable."""
+
+
+class ControlPlaneUnavailableError(ControlPlaneClientError):
+    """Raised when the service is unreachable, timed out, or returned 5xx/429.
+
+    Unavailability never degrades to a local store or fabricated lease.
+    """
+
+
+class ControlPlaneAuthError(ControlPlaneClientError):
+    """Raised on 401: the credential is missing, invalid, or revoked."""
+
+
+class ControlPlaneScopeError(ControlPlaneClientError):
+    """Raised on 403: the credential lacks the scope or repository authority."""
+
+
+class ControlPlaneConflictError(ControlPlaneClientError):
+    """Raised on 409 idempotency/state conflict for a different request."""
+
+
+class StaleLeaseError(ControlPlaneClientError):
+    """Raised on 409 stale fencing token, stale authority epoch, or lost lease."""
+
+
+class ControlPlaneNotFoundError(ControlPlaneClientError):
+    """Raised on 404: the addressed authority object/receipt does not exist."""
+
+
+class ControlPlaneProtocolError(ControlPlaneClientError):
+    """Raised on a malformed response or an unmappable 4xx (e.g. 400/422)."""
+
+
+@dataclass(frozen=True)
+class ClientConfig:
+    """Host-resolved base URL plus scoped bearer credential.
+
+    The credential is kept out of ``repr`` and is never logged. It is resolved
+    from a host secret file or a host environment variable, both outside the
+    repository, matching the deployment's credential custody.
+    """
+
+    base_url: str
+    token: str = field(repr=False)
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> "ClientConfig":
+        source = os.environ if env is None else env
+        base_url = source.get("BUILDEROPS_API_URL", "").strip()
+        if not base_url:
+            raise ControlPlaneConfigError(
+                "BUILDEROPS_API_URL is required to reach the BuilderOps control plane"
+            )
+        if not base_url.startswith(("http://", "https://")):
+            raise ControlPlaneConfigError("BUILDEROPS_API_URL must be an http(s) URL")
+        token_direct = source.get("BUILDEROPS_API_TOKEN", "").strip()
+        token_file = source.get("BUILDEROPS_API_TOKEN_FILE", "").strip()
+        if token_direct and token_file:
+            raise ControlPlaneConfigError(
+                "configure exactly one of BUILDEROPS_API_TOKEN or BUILDEROPS_API_TOKEN_FILE"
+            )
+        if token_file:
+            try:
+                token = Path(token_file).read_text(encoding="utf-8").strip()
+            except OSError as exc:
+                raise ControlPlaneConfigError(
+                    "BuilderOps API credential file is unavailable"
+                ) from exc
+        else:
+            token = token_direct
+        if not token:
+            raise ControlPlaneConfigError(
+                "a BuilderOps API credential is required "
+                "(BUILDEROPS_API_TOKEN or BUILDEROPS_API_TOKEN_FILE)"
+            )
+        return cls(base_url=base_url.rstrip("/"), token=token)
+
+
+class BuilderOpsControlPlaneClient:
+    """Authenticated, versioned, fail-closed client for records, inquiries,
+    tasks, leases, attempts, promotions, receipts, and status."""
+
+    def __init__(
+        self,
+        config: ClientConfig,
+        *,
+        http_client: httpx.Client | None = None,
+        max_retries: int = _DEFAULT_MAX_RETRIES,
+        retry_backoff_seconds: float = 0.0,
+    ) -> None:
+        self._config = config
+        self._max_retries = max(0, max_retries)
+        self._retry_backoff = max(0.0, retry_backoff_seconds)
+        self._owns_client = http_client is None
+        self._http = http_client or httpx.Client(
+            base_url=config.base_url, timeout=_DEFAULT_TIMEOUT_SECONDS
+        )
+        self._pinned_epoch: int | None = None
+
+    # -- lifecycle -----------------------------------------------------------
+    def close(self) -> None:
+        if self._owns_client:
+            self._http.close()
+
+    def __enter__(self) -> "BuilderOpsControlPlaneClient":
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+    # -- authority epoch -----------------------------------------------------
+    @property
+    def authority_epoch(self) -> int:
+        """The single authority epoch this client operates under.
+
+        Pinned from the first ``status`` read; every subsequent mutation carries
+        it so a superseded (post-recovery) epoch is fenced server-side instead
+        of silently mutating a new authority.
+        """
+        if self._pinned_epoch is None:
+            snapshot = self.status()
+            epoch = snapshot.get("authority_epoch")
+            if not isinstance(epoch, int):
+                raise ControlPlaneProtocolError(
+                    "control plane returned no authority epoch"
+                )
+            self._pinned_epoch = epoch
+        return self._pinned_epoch
+
+    # -- reads ---------------------------------------------------------------
+    def status(self) -> dict[str, Any]:
+        return self._request("GET", f"/{API_VERSION}/status", pin_epoch=False)
+
+    def get_receipt(
+        self,
+        *,
+        repository: str,
+        object_kind: str,
+        object_id: str,
+        task_id: str | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, str] = {"repository": repository}
+        if task_id is not None:
+            params["task_id"] = task_id
+        return self._request(
+            "GET",
+            f"/{API_VERSION}/receipts/{object_kind}/{object_id}",
+            params=params,
+            pin_epoch=False,
+        )
+
+    # -- authority-bearing mutations ----------------------------------------
+    def commit_record(
+        self,
+        *,
+        envelope: Mapping[str, Any],
+        record_id: str,
+        record_type: str,
+        state: str,
+        payload: Mapping[str, Any],
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        return self._request(
+            "POST",
+            f"/{API_VERSION}/records",
+            json_body={
+                "envelope": dict(envelope),
+                "record_id": record_id,
+                "record_type": record_type,
+                "state": state,
+                "payload": dict(payload),
+                "idempotency_key": idempotency_key,
+            },
+        )
+
+    def create_inquiry(
+        self,
+        *,
+        envelope: Mapping[str, Any],
+        inquiry_id: str,
+        state: str,
+        payload: Mapping[str, Any],
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        return self._request(
+            "POST",
+            f"/{API_VERSION}/inquiries",
+            json_body={
+                "envelope": dict(envelope),
+                "inquiry_id": inquiry_id,
+                "state": state,
+                "payload": dict(payload),
+                "idempotency_key": idempotency_key,
+            },
+        )
+
+    def claim_task(
+        self,
+        *,
+        envelope: Mapping[str, Any],
+        task_id: str,
+        idempotency_key: str,
+        request: Mapping[str, Any] | None = None,
+        ttl_seconds: int = 5400,
+    ) -> dict[str, Any]:
+        return self._request(
+            "POST",
+            f"/{API_VERSION}/tasks/claim",
+            json_body={
+                "envelope": dict(envelope),
+                "task_id": task_id,
+                "idempotency_key": idempotency_key,
+                "request": dict(request or {}),
+                "ttl_seconds": ttl_seconds,
+            },
+        )
+
+    def heartbeat_task(
+        self,
+        *,
+        envelope: Mapping[str, Any],
+        lease: Mapping[str, Any],
+        idempotency_key: str,
+        request: Mapping[str, Any] | None = None,
+        ttl_seconds: int = 5400,
+    ) -> dict[str, Any]:
+        return self._request(
+            "POST",
+            f"/{API_VERSION}/tasks/heartbeat",
+            json_body={
+                "envelope": dict(envelope),
+                "lease": dict(lease),
+                "idempotency_key": idempotency_key,
+                "request": dict(request or {}),
+                "ttl_seconds": ttl_seconds,
+            },
+        )
+
+    def complete_task(
+        self,
+        *,
+        envelope: Mapping[str, Any],
+        lease: Mapping[str, Any],
+        idempotency_key: str,
+        request: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return self._request(
+            "POST",
+            f"/{API_VERSION}/tasks/complete",
+            json_body={
+                "envelope": dict(envelope),
+                "lease": dict(lease),
+                "idempotency_key": idempotency_key,
+                "request": dict(request or {}),
+            },
+        )
+
+    def claim_lease(
+        self,
+        *,
+        envelope: Mapping[str, Any],
+        resource_id: str,
+        idempotency_key: str,
+        request: Mapping[str, Any] | None = None,
+        ttl_seconds: int = 5400,
+    ) -> dict[str, Any]:
+        return self._request(
+            "POST",
+            f"/{API_VERSION}/leases/claim",
+            json_body={
+                "envelope": dict(envelope),
+                "resource_id": resource_id,
+                "idempotency_key": idempotency_key,
+                "request": dict(request or {}),
+                "ttl_seconds": ttl_seconds,
+            },
+        )
+
+    def commit_attempt(
+        self,
+        *,
+        envelope: Mapping[str, Any],
+        task_id: str,
+        attempt_id: str,
+        state: str,
+        payload: Mapping[str, Any],
+        idempotency_key: str,
+        lease: Mapping[str, Any],
+        expected_states: tuple[str, ...] | None = None,
+    ) -> dict[str, Any]:
+        return self._request(
+            "POST",
+            f"/{API_VERSION}/attempts",
+            json_body={
+                "envelope": dict(envelope),
+                "task_id": task_id,
+                "attempt_id": attempt_id,
+                "state": state,
+                "payload": dict(payload),
+                "idempotency_key": idempotency_key,
+                "lease": dict(lease),
+                "expected_states": (
+                    list(expected_states) if expected_states is not None else None
+                ),
+            },
+        )
+
+    def commit_promotion(
+        self,
+        *,
+        envelope: Mapping[str, Any],
+        promotion_id: str,
+        status: str,
+        payload: Mapping[str, Any],
+        idempotency_key: str,
+        lease: Mapping[str, Any] | None = None,
+        expected_states: tuple[str, ...] | None = None,
+    ) -> dict[str, Any]:
+        return self._request(
+            "POST",
+            f"/{API_VERSION}/promotions",
+            json_body={
+                "envelope": dict(envelope),
+                "promotion_id": promotion_id,
+                "status": status,
+                "payload": dict(payload),
+                "idempotency_key": idempotency_key,
+                "lease": dict(lease) if lease is not None else None,
+                "expected_states": (
+                    list(expected_states) if expected_states is not None else None
+                ),
+            },
+        )
+
+    # -- transport -----------------------------------------------------------
+    def _headers(self, *, pin_epoch: bool) -> dict[str, str]:
+        headers = {"Authorization": f"Bearer {self._config.token}"}
+        if pin_epoch:
+            headers[_EPOCH_HEADER] = str(self.authority_epoch)
+        return headers
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: Mapping[str, Any] | None = None,
+        params: Mapping[str, str] | None = None,
+        pin_epoch: bool = True,
+    ) -> dict[str, Any]:
+        headers = self._headers(pin_epoch=pin_epoch)
+        last_unavailable: Exception | None = None
+        # Idempotent retry: reads and idempotency-keyed writes are safe to
+        # repeat. Retries only cover transport loss and 5xx/429 — they never
+        # construct a local authority substitute.
+        for attempt in range(self._max_retries + 1):
+            try:
+                response = self._http.request(
+                    method,
+                    path,
+                    json=json_body if json_body is not None else None,
+                    params=dict(params) if params else None,
+                    headers=headers,
+                )
+            except httpx.HTTPError as exc:
+                last_unavailable = exc
+                if attempt < self._max_retries:
+                    self._sleep(attempt)
+                    continue
+                raise ControlPlaneUnavailableError(
+                    f"BuilderOps control plane is unreachable: {type(exc).__name__}"
+                ) from exc
+
+            if response.status_code >= 500 or response.status_code == 429:
+                last_unavailable = ControlPlaneUnavailableError(
+                    f"BuilderOps control plane returned {response.status_code}"
+                )
+                if attempt < self._max_retries:
+                    self._sleep(attempt)
+                    continue
+                raise last_unavailable
+
+            return self._decode(response)
+
+        # Unreachable in practice; the loop always returns or raises.
+        raise ControlPlaneUnavailableError(
+            "BuilderOps control plane is unreachable"
+        ) from last_unavailable
+
+    def _sleep(self, attempt: int) -> None:
+        if self._retry_backoff:
+            time.sleep(self._retry_backoff * (attempt + 1))
+
+    def _decode(self, response: httpx.Response) -> dict[str, Any]:
+        status_code = response.status_code
+        if status_code == 401:
+            raise ControlPlaneAuthError("BuilderOps credential is invalid or revoked")
+        if status_code == 403:
+            raise ControlPlaneScopeError(
+                "BuilderOps credential lacks the required scope or repository authority"
+            )
+        if status_code == 404:
+            raise ControlPlaneNotFoundError("BuilderOps authority object was not found")
+        if status_code == 409:
+            detail = self._detail(response)
+            if detail in _STALE_DETAILS:
+                raise StaleLeaseError(f"BuilderOps lease/epoch is stale: {detail}")
+            raise ControlPlaneConflictError(f"BuilderOps request conflict: {detail}")
+        if status_code >= 400:
+            raise ControlPlaneProtocolError(
+                f"BuilderOps request was rejected ({status_code})"
+            )
+        try:
+            body = response.json()
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise ControlPlaneProtocolError(
+                "BuilderOps control plane returned a malformed response"
+            ) from exc
+        if not isinstance(body, dict):
+            raise ControlPlaneProtocolError(
+                "BuilderOps control plane returned an unexpected response shape"
+            )
+        return body
+
+    @staticmethod
+    def _detail(response: httpx.Response) -> str:
+        try:
+            body = response.json()
+        except (json.JSONDecodeError, ValueError):
+            return ""
+        if isinstance(body, dict):
+            detail = body.get("detail")
+            if isinstance(detail, str):
+                return detail
+        return ""
+
+
+__all__ = [
+    "API_VERSION",
+    "BuilderOpsControlPlaneClient",
+    "ClientConfig",
+    "ControlPlaneAuthError",
+    "ControlPlaneClientError",
+    "ControlPlaneConfigError",
+    "ControlPlaneConflictError",
+    "ControlPlaneNotFoundError",
+    "ControlPlaneProtocolError",
+    "ControlPlaneScopeError",
+    "ControlPlaneUnavailableError",
+    "StaleLeaseError",
+]

--- a/app/builderops/control_plane/client_cli.py
+++ b/app/builderops/control_plane/client_cli.py
@@ -1,0 +1,266 @@
+"""API-only client CLI for the BuilderOps control plane.
+
+This is the canonical MacBook entry point for authority-bearing BuilderOps
+operations. It reaches the independent service over one authenticated API
+boundary and exposes **no** direct database path, local SQLite construction, or
+SSH-to-database-owning-CLI mode. Base URL and credential are resolved from host
+secret configuration by :class:`ClientConfig`. Every command names exactly one
+repository explicitly; there is no current-working-directory repo inference.
+
+Run as ``python -m app.builderops.control_plane.client <command> ...``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Callable, Sequence
+from typing import Any
+
+from app.builderops.control_plane.client import (
+    BuilderOpsControlPlaneClient,
+    ClientConfig,
+    ControlPlaneClientError,
+)
+from app.builderops.control_plane.routing import RepoRef
+
+ClientFactory = Callable[[ClientConfig], BuilderOpsControlPlaneClient]
+
+# Exit code for a fail-closed client error (unavailable/auth/scope/conflict/
+# stale). A non-zero exit is the shell-visible fail-closed signal; the command
+# never degrades to a local store or fabricated lease.
+_FAIL_CLOSED_EXIT = 3
+_CONFIG_EXIT = 2
+
+
+def _default_factory(config: ClientConfig) -> BuilderOpsControlPlaneClient:
+    return BuilderOpsControlPlaneClient(config)
+
+
+def _add_envelope_arguments(sub: argparse.ArgumentParser) -> None:
+    sub.add_argument(
+        "--repository",
+        required=True,
+        help="Explicit owner/name repository this mutation addresses (no CWD inference).",
+    )
+    sub.add_argument("--scope", required=True, help="Authority scope, e.g. issue:3791.")
+    sub.add_argument("--stack", required=True, help="Delivery stack identifier.")
+    sub.add_argument(
+        "--source-ref",
+        dest="source_refs",
+        action="append",
+        required=True,
+        help="Traceable source reference (repeatable).",
+    )
+
+
+def _envelope(args: argparse.Namespace) -> dict[str, Any]:
+    # Fail closed on an ambiguous/blank repository reference before any request.
+    repo = RepoRef.parse(args.repository)
+    return {
+        "repository": repo.canonical,
+        "scope": args.scope,
+        "stack": args.stack,
+        "source_refs": list(args.source_refs),
+    }
+
+
+def _json_payload(raw: str | None) -> dict[str, Any]:
+    if not raw:
+        return {}
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSON payload: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError("payload must be a JSON object")
+    return value
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="builderops-control-plane",
+        description=(
+            "Authenticated API-only client for the BuilderOps control plane. "
+            "No direct database, SQLite, or SSH store mode is exposed."
+        ),
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("status", help="Read the current authority epoch and schema version.")
+
+    record = sub.add_parser("record", help="Commit a record authority object.")
+    _add_envelope_arguments(record)
+    record.add_argument("--record-id", required=True)
+    record.add_argument("--record-type", required=True)
+    record.add_argument("--state", required=True)
+    record.add_argument("--payload", help="JSON object payload.")
+    record.add_argument("--idempotency-key", required=True)
+
+    inquiry = sub.add_parser("inquiry", help="Commit a model-inquiry authority object.")
+    _add_envelope_arguments(inquiry)
+    inquiry.add_argument("--inquiry-id", required=True)
+    inquiry.add_argument("--state", required=True)
+    inquiry.add_argument("--payload", help="JSON object payload.")
+    inquiry.add_argument("--idempotency-key", required=True)
+
+    task_claim = sub.add_parser("task-claim", help="Claim a task and its fenced lease.")
+    _add_envelope_arguments(task_claim)
+    task_claim.add_argument("--task-id", required=True)
+    task_claim.add_argument("--idempotency-key", required=True)
+    task_claim.add_argument("--ttl-seconds", type=int, default=5400)
+
+    task_heartbeat = sub.add_parser("task-heartbeat", help="Heartbeat a claimed task lease.")
+    _add_envelope_arguments(task_heartbeat)
+    task_heartbeat.add_argument("--lease", required=True, help="JSON lease object from claim.")
+    task_heartbeat.add_argument("--idempotency-key", required=True)
+    task_heartbeat.add_argument("--ttl-seconds", type=int, default=5400)
+
+    task_complete = sub.add_parser("task-complete", help="Complete a claimed task.")
+    _add_envelope_arguments(task_complete)
+    task_complete.add_argument("--lease", required=True, help="JSON lease object from claim.")
+    task_complete.add_argument("--idempotency-key", required=True)
+
+    lease_claim = sub.add_parser("lease-claim", help="Claim a generic fenced lease.")
+    _add_envelope_arguments(lease_claim)
+    lease_claim.add_argument("--resource-id", required=True)
+    lease_claim.add_argument("--idempotency-key", required=True)
+    lease_claim.add_argument("--ttl-seconds", type=int, default=5400)
+
+    attempt = sub.add_parser("attempt", help="Commit a fenced attempt authority object.")
+    _add_envelope_arguments(attempt)
+    attempt.add_argument("--task-id", required=True)
+    attempt.add_argument("--attempt-id", required=True)
+    attempt.add_argument("--state", required=True)
+    attempt.add_argument("--payload", help="JSON object payload.")
+    attempt.add_argument("--idempotency-key", required=True)
+    attempt.add_argument("--lease", required=True, help="JSON lease object from claim.")
+
+    promotion = sub.add_parser("promotion", help="Commit a promotion authority object.")
+    _add_envelope_arguments(promotion)
+    promotion.add_argument("--promotion-id", required=True)
+    promotion.add_argument("--status", required=True)
+    promotion.add_argument("--payload", help="JSON object payload.")
+    promotion.add_argument("--idempotency-key", required=True)
+
+    receipt = sub.add_parser("receipt", help="Read a committed authority-object receipt.")
+    receipt.add_argument("--repository", required=True)
+    receipt.add_argument(
+        "--object-kind", required=True, choices=["records", "attempts", "promotions"]
+    )
+    receipt.add_argument("--object-id", required=True)
+    receipt.add_argument("--task-id", help="Required for attempt receipts.")
+
+    return parser
+
+
+def _dispatch(
+    args: argparse.Namespace, client: BuilderOpsControlPlaneClient
+) -> dict[str, Any]:
+    command = args.command
+    if command == "status":
+        return client.status()
+    if command == "record":
+        return client.commit_record(
+            envelope=_envelope(args),
+            record_id=args.record_id,
+            record_type=args.record_type,
+            state=args.state,
+            payload=_json_payload(args.payload),
+            idempotency_key=args.idempotency_key,
+        )
+    if command == "inquiry":
+        return client.create_inquiry(
+            envelope=_envelope(args),
+            inquiry_id=args.inquiry_id,
+            state=args.state,
+            payload=_json_payload(args.payload),
+            idempotency_key=args.idempotency_key,
+        )
+    if command == "task-claim":
+        return client.claim_task(
+            envelope=_envelope(args),
+            task_id=args.task_id,
+            idempotency_key=args.idempotency_key,
+            ttl_seconds=args.ttl_seconds,
+        )
+    if command == "task-heartbeat":
+        return client.heartbeat_task(
+            envelope=_envelope(args),
+            lease=_json_payload(args.lease),
+            idempotency_key=args.idempotency_key,
+            ttl_seconds=args.ttl_seconds,
+        )
+    if command == "task-complete":
+        return client.complete_task(
+            envelope=_envelope(args),
+            lease=_json_payload(args.lease),
+            idempotency_key=args.idempotency_key,
+        )
+    if command == "lease-claim":
+        return client.claim_lease(
+            envelope=_envelope(args),
+            resource_id=args.resource_id,
+            idempotency_key=args.idempotency_key,
+            ttl_seconds=args.ttl_seconds,
+        )
+    if command == "attempt":
+        return client.commit_attempt(
+            envelope=_envelope(args),
+            task_id=args.task_id,
+            attempt_id=args.attempt_id,
+            state=args.state,
+            payload=_json_payload(args.payload),
+            idempotency_key=args.idempotency_key,
+            lease=_json_payload(args.lease),
+        )
+    if command == "promotion":
+        return client.commit_promotion(
+            envelope=_envelope(args),
+            promotion_id=args.promotion_id,
+            status=args.status,
+            payload=_json_payload(args.payload),
+            idempotency_key=args.idempotency_key,
+        )
+    if command == "receipt":
+        return client.get_receipt(
+            repository=args.repository,
+            object_kind=args.object_kind,
+            object_id=args.object_id,
+            task_id=args.task_id,
+        )
+    raise ValueError(f"unknown command: {command}")
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    client_factory: ClientFactory = _default_factory,
+) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        config = ClientConfig.from_env()
+    except ControlPlaneClientError as exc:
+        print(f"builderops-control-plane: configuration error: {exc}", file=sys.stderr)
+        return _CONFIG_EXIT
+    client = client_factory(config)
+    try:
+        result = _dispatch(args, client)
+    except ControlPlaneClientError as exc:
+        # Fail closed: report the typed error and exit non-zero. No local
+        # authority, SQLite database, or fabricated lease is created.
+        print(f"builderops-control-plane: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return _FAIL_CLOSED_EXIT
+    except ValueError as exc:
+        print(f"builderops-control-plane: invalid request: {exc}", file=sys.stderr)
+        return _CONFIG_EXIT
+    finally:
+        client.close()
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - module entry point
+    raise SystemExit(main())

--- a/app/builderops/control_plane/client_cli.py
+++ b/app/builderops/control_plane/client_cli.py
@@ -23,7 +23,12 @@ from app.builderops.control_plane.client import (
     ClientConfig,
     ControlPlaneClientError,
 )
-from app.builderops.control_plane.routing import RepoRef
+from app.builderops.control_plane.routing import (
+    DeliveryManifestRegistry,
+    RepoRef,
+    RoutePolicy,
+    RoutingError,
+)
 
 ClientFactory = Callable[[ClientConfig], BuilderOpsControlPlaneClient]
 
@@ -32,6 +37,27 @@ ClientFactory = Callable[[ClientConfig], BuilderOpsControlPlaneClient]
 # never degrades to a local store or fabricated lease.
 _FAIL_CLOSED_EXIT = 3
 _CONFIG_EXIT = 2
+
+# Subcommands whose envelope this CLI can resolve a delivery-manifest route
+# for: they carry --repository/--stack (the RepoRef/stack half of the routing
+# key) and a --task-class-scoped mutation. Read-only commands (status, receipt)
+# are not envelope-routed.
+_ROUTABLE_COMMANDS = frozenset(
+    {
+        "record",
+        "inquiry",
+        "task-claim",
+        "task-heartbeat",
+        "task-complete",
+        "lease-claim",
+        "attempt",
+        "promotion",
+    }
+)
+# Commands with a --ttl-seconds argument the resolved route's policy may
+# advise a default for.
+_TTL_COMMANDS = frozenset({"task-claim", "task-heartbeat", "lease-claim"})
+_DEFAULT_TTL_SECONDS = 5400
 
 
 def _default_factory(config: ClientConfig) -> BuilderOpsControlPlaneClient:
@@ -86,6 +112,23 @@ def build_parser() -> argparse.ArgumentParser:
             "No direct database, SQLite, or SSH store mode is exposed."
         ),
     )
+    parser.add_argument(
+        "--delivery-manifest-dir",
+        help=(
+            "Optional directory of per-repository delivery-manifest JSON "
+            "documents (see app.builderops.control_plane.routing). When given, "
+            "the addressed repository's manifest is loaded and routed by "
+            "(RepoRef, stack, task-class) before dispatch; a missing/ambiguous "
+            "manifest or route fails closed. Omit to skip routing entirely — "
+            "no manifest is required by default. This is advisory request "
+            "shaping only, never privileged authority."
+        ),
+    )
+    parser.add_argument(
+        "--task-class",
+        help="Task-class half of the (RepoRef, stack, task-class) routing key. "
+        "Required when --delivery-manifest-dir is given for a routable command.",
+    )
     sub = parser.add_subparsers(dest="command", required=True)
 
     sub.add_parser("status", help="Read the current authority epoch and schema version.")
@@ -109,13 +152,25 @@ def build_parser() -> argparse.ArgumentParser:
     _add_envelope_arguments(task_claim)
     task_claim.add_argument("--task-id", required=True)
     task_claim.add_argument("--idempotency-key", required=True)
-    task_claim.add_argument("--ttl-seconds", type=int, default=5400)
+    task_claim.add_argument(
+        "--ttl-seconds",
+        type=int,
+        default=None,
+        help=f"Defaults to the resolved delivery-manifest route's policy "
+        f"ttl_seconds if routing is engaged, else {_DEFAULT_TTL_SECONDS}.",
+    )
 
     task_heartbeat = sub.add_parser("task-heartbeat", help="Heartbeat a claimed task lease.")
     _add_envelope_arguments(task_heartbeat)
     task_heartbeat.add_argument("--lease", required=True, help="JSON lease object from claim.")
     task_heartbeat.add_argument("--idempotency-key", required=True)
-    task_heartbeat.add_argument("--ttl-seconds", type=int, default=5400)
+    task_heartbeat.add_argument(
+        "--ttl-seconds",
+        type=int,
+        default=None,
+        help=f"Defaults to the resolved delivery-manifest route's policy "
+        f"ttl_seconds if routing is engaged, else {_DEFAULT_TTL_SECONDS}.",
+    )
 
     task_complete = sub.add_parser("task-complete", help="Complete a claimed task.")
     _add_envelope_arguments(task_complete)
@@ -126,7 +181,13 @@ def build_parser() -> argparse.ArgumentParser:
     _add_envelope_arguments(lease_claim)
     lease_claim.add_argument("--resource-id", required=True)
     lease_claim.add_argument("--idempotency-key", required=True)
-    lease_claim.add_argument("--ttl-seconds", type=int, default=5400)
+    lease_claim.add_argument(
+        "--ttl-seconds",
+        type=int,
+        default=None,
+        help=f"Defaults to the resolved delivery-manifest route's policy "
+        f"ttl_seconds if routing is engaged, else {_DEFAULT_TTL_SECONDS}.",
+    )
 
     attempt = sub.add_parser("attempt", help="Commit a fenced attempt authority object.")
     _add_envelope_arguments(attempt)
@@ -233,6 +294,52 @@ def _dispatch(
     raise ValueError(f"unknown command: {command}")
 
 
+def _resolve_route(args: argparse.Namespace) -> RoutePolicy | None:
+    """Resolve the addressed repo's (RepoRef, stack, task-class) route.
+
+    Returns ``None`` when routing was not engaged (no ``--delivery-manifest-dir``
+    given, or the command has no envelope to route). Engaging routing on a
+    routable command is a full commitment to fail-closed behavior: a missing,
+    ambiguous, or cross-repo-reused manifest raises ``RoutingError`` rather than
+    silently skipping. The resolved policy is advisory request-shaping only —
+    never privileged authority; BCP-05 independently re-resolves protected-base
+    policy before any privileged effect.
+    """
+    manifest_dir = getattr(args, "delivery_manifest_dir", None)
+    if manifest_dir is None:
+        return None
+    if args.command not in _ROUTABLE_COMMANDS:
+        return None
+    if not getattr(args, "task_class", None):
+        raise ValueError(
+            "--task-class is required when --delivery-manifest-dir is given "
+            "for a routable command"
+        )
+    repo = RepoRef.parse(args.repository)
+    registry = DeliveryManifestRegistry.from_directory(manifest_dir)
+    return registry.resolve_route(repo, args.stack, args.task_class)
+
+
+def _apply_route_policy(args: argparse.Namespace, route: RoutePolicy | None) -> None:
+    """Apply the resolved route's advisory policy to unset CLI defaults.
+
+    Only fields the caller left unset (``None``) are affected; an explicit
+    ``--ttl-seconds`` always wins over the manifest's advisory default.
+    """
+    if args.command not in _TTL_COMMANDS or getattr(args, "ttl_seconds", None) is not None:
+        return
+    if route is None:
+        args.ttl_seconds = _DEFAULT_TTL_SECONDS
+        return
+    policy_ttl = route.policy.get("ttl_seconds", _DEFAULT_TTL_SECONDS)
+    if type(policy_ttl) is not int or not 1 <= policy_ttl <= 86400:
+        raise ValueError(
+            f"delivery manifest route ({route.repository}, {route.stack}, "
+            f"{route.task_class}) has an invalid ttl_seconds policy value"
+        )
+    args.ttl_seconds = policy_ttl
+
+
 def main(
     argv: Sequence[str] | None = None,
     *,
@@ -241,6 +348,23 @@ def main(
     parser = build_parser()
     args = parser.parse_args(argv)
     try:
+        route = _resolve_route(args)
+        _apply_route_policy(args, route)
+    except RoutingError as exc:
+        # Missing/ambiguous manifests and cross-repo prior reuse fail closed.
+        print(f"builderops-control-plane: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return _FAIL_CLOSED_EXIT
+    except ValueError as exc:
+        print(f"builderops-control-plane: invalid request: {exc}", file=sys.stderr)
+        return _CONFIG_EXIT
+    if route is not None:
+        print(
+            f"builderops-control-plane: resolved delivery route "
+            f"({route.repository}, {route.stack}, {route.task_class}): "
+            f"{json.dumps(dict(route.policy), sort_keys=True)}",
+            file=sys.stderr,
+        )
+    try:
         config = ClientConfig.from_env()
     except ControlPlaneClientError as exc:
         print(f"builderops-control-plane: configuration error: {exc}", file=sys.stderr)
@@ -248,7 +372,7 @@ def main(
     client = client_factory(config)
     try:
         result = _dispatch(args, client)
-    except ControlPlaneClientError as exc:
+    except (ControlPlaneClientError, RoutingError) as exc:
         # Fail closed: report the typed error and exit non-zero. No local
         # authority, SQLite database, or fabricated lease is created.
         print(f"builderops-control-plane: {type(exc).__name__}: {exc}", file=sys.stderr)

--- a/app/builderops/control_plane/models.py
+++ b/app/builderops/control_plane/models.py
@@ -44,6 +44,26 @@ class UnknownEffectNeedsReconciliation(ControlPlaneError):
     """Raised when readback is mandatory before an external-effect retry."""
 
 
+# The service's HTTP 409 ``detail`` classification and the client's stale-vs-
+# generic-conflict matching share these exact identifiers, so a class rename
+# here cannot silently desync from the client's classification (BCP-04 review
+# finding H3). ``STALE_AUTHORITY_EPOCH_DETAIL`` is not backed by an exception
+# class here: the authority-epoch fence is a service/HTTP-layer concern
+# (``require_authority_epoch`` in service.py), not a store-layer one.
+STALE_FENCING_TOKEN_DETAIL = StaleFencingToken.__name__
+LEASE_UNAVAILABLE_DETAIL = LeaseUnavailable.__name__
+LEASE_REQUIRED_DETAIL = LeaseRequired.__name__
+STALE_AUTHORITY_EPOCH_DETAIL = "StaleAuthorityEpoch"
+STALE_DETAIL_NAMES = frozenset(
+    {
+        STALE_FENCING_TOKEN_DETAIL,
+        LEASE_UNAVAILABLE_DETAIL,
+        LEASE_REQUIRED_DETAIL,
+        STALE_AUTHORITY_EPOCH_DETAIL,
+    }
+)
+
+
 _REPOSITORY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 
 

--- a/app/builderops/control_plane/routing.py
+++ b/app/builderops/control_plane/routing.py
@@ -1,0 +1,217 @@
+"""Delivery-manifest routing for the BuilderOps control-plane client.
+
+The client loads the *addressed* repository's delivery manifest and selects an
+advisory policy/TCD route by ``(RepoRef, stack, task-class)``. Routing is
+strictly non-transitive: a manifest resolved for one repository is never reused
+or inferred for another, even when they share a stack or task class. Missing or
+ambiguous manifests, and any attempt to derive repository authority implicitly
+(for example from the current working directory), fail closed.
+
+Client-selected policy is advisory request-formation only. It is never
+privileged authority; BCP-05 independently re-resolves the protected-base
+delivery manifest and host credential mapping before any privileged effect.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+_REPOSITORY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_IDENTIFIER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+
+class RoutingError(RuntimeError):
+    """Base class for fail-closed delivery-manifest routing errors."""
+
+
+class RepoRefError(RoutingError):
+    """Raised when a repository reference is missing or ambiguous."""
+
+
+class ManifestError(RoutingError):
+    """Raised when a manifest document is malformed or ambiguous."""
+
+
+class ManifestNotFoundError(RoutingError):
+    """Raised when the addressed repository has no loaded manifest."""
+
+
+class RouteResolutionError(RoutingError):
+    """Raised when a ``(stack, task-class)`` route is absent or ambiguous."""
+
+
+@dataclass(frozen=True)
+class RepoRef:
+    """Canonical, unambiguous ``owner/name`` GitHub repository reference."""
+
+    owner: str
+    name: str
+
+    def __post_init__(self) -> None:
+        owner = self.owner.strip()
+        name = self.name.strip()
+        if not owner or not name or owner in {".", ".."} or name in {".", ".."}:
+            raise RepoRefError("repository owner and name are mandatory and unambiguous")
+        object.__setattr__(self, "owner", owner)
+        object.__setattr__(self, "name", name)
+
+    @property
+    def canonical(self) -> str:
+        return f"{self.owner}/{self.name}".lower()
+
+    @classmethod
+    def parse(cls, value: str | None) -> "RepoRef":
+        """Parse ``owner/name``; a blank, partial, or ambiguous value fails closed.
+
+        There is deliberately no current-working-directory or git-remote
+        inference here: repository authority must be named explicitly by the
+        caller so no implicit CWD-derived repo can authorize a mutation.
+        """
+        if not value or not isinstance(value, str) or not value.strip():
+            raise RepoRefError("a repository reference is required; none was provided")
+        candidate = value.strip()
+        if _REPOSITORY.fullmatch(candidate) is None:
+            raise RepoRefError(f"repository reference is not a valid owner/name: {candidate!r}")
+        owner, name = candidate.split("/", 1)
+        return cls(owner=owner, name=name)
+
+
+@dataclass(frozen=True)
+class RoutePolicy:
+    """Advisory route for one ``(RepoRef, stack, task-class)`` triple.
+
+    ``repository`` binds the policy to the repo it was resolved for, which is
+    what makes routing non-transitive: a policy carried out of one repo's
+    manifest can never masquerade as another repo's.
+    """
+
+    repository: str
+    stack: str
+    task_class: str
+    policy: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class DeliveryManifest:
+    """One repository's routing table, keyed by ``(stack, task-class)``."""
+
+    repository: RepoRef
+    routes: Mapping[tuple[str, str], RoutePolicy]
+
+    def resolve(self, stack: str, task_class: str) -> RoutePolicy:
+        stack_key = _require_identifier(stack, "stack")
+        task_key = _require_identifier(task_class, "task-class")
+        try:
+            return self.routes[(stack_key, task_key)]
+        except KeyError as exc:
+            raise RouteResolutionError(
+                f"no delivery route for ({self.repository.canonical}, "
+                f"{stack_key}, {task_key})"
+            ) from exc
+
+    @classmethod
+    def from_document(cls, document: Mapping[str, Any]) -> "DeliveryManifest":
+        if not isinstance(document, Mapping):
+            raise ManifestError("delivery manifest must be a mapping")
+        repo_ref = RepoRef.parse(document.get("repository"))
+        raw_routes = document.get("routes", [])
+        if not isinstance(raw_routes, list):
+            raise ManifestError("delivery manifest routes must be a list")
+        routes: dict[tuple[str, str], RoutePolicy] = {}
+        for raw in raw_routes:
+            if not isinstance(raw, Mapping):
+                raise ManifestError("each delivery route must be a mapping")
+            stack = _require_identifier(raw.get("stack"), "stack")
+            task_class = _require_identifier(raw.get("task_class"), "task-class")
+            policy_raw = raw.get("policy", {})
+            if not isinstance(policy_raw, Mapping):
+                raise ManifestError("delivery route policy must be a mapping")
+            key = (stack, task_class)
+            if key in routes:
+                raise ManifestError(
+                    f"ambiguous duplicate route ({stack}, {task_class}) in "
+                    f"{repo_ref.canonical} manifest"
+                )
+            routes[key] = RoutePolicy(
+                repository=repo_ref.canonical,
+                stack=stack,
+                task_class=task_class,
+                policy=dict(policy_raw),
+            )
+        return cls(repository=repo_ref, routes=routes)
+
+
+class DeliveryManifestRegistry:
+    """Registry that resolves routes only for explicitly loaded repositories."""
+
+    def __init__(self, manifests: Mapping[str, DeliveryManifest]) -> None:
+        self._manifests = dict(manifests)
+
+    @classmethod
+    def from_documents(cls, documents: list[Mapping[str, Any]]) -> "DeliveryManifestRegistry":
+        manifests: dict[str, DeliveryManifest] = {}
+        for document in documents:
+            manifest = DeliveryManifest.from_document(document)
+            key = manifest.repository.canonical
+            if key in manifests:
+                raise ManifestError(f"duplicate delivery manifest for repository {key}")
+            manifests[key] = manifest
+        return cls(manifests)
+
+    @classmethod
+    def from_directory(cls, directory: Path | str) -> "DeliveryManifestRegistry":
+        root = Path(directory)
+        if not root.is_dir():
+            raise ManifestError(f"delivery manifest directory does not exist: {root}")
+        documents: list[Mapping[str, Any]] = []
+        for path in sorted(root.glob("*.json")):
+            try:
+                documents.append(json.loads(path.read_text(encoding="utf-8")))
+            except (OSError, json.JSONDecodeError) as exc:
+                raise ManifestError(f"delivery manifest is unreadable: {path}") from exc
+        return cls.from_documents(documents)
+
+    def manifest_for(self, repo_ref: RepoRef) -> DeliveryManifest:
+        """Return only the addressed repo's manifest; never borrow another's."""
+        try:
+            return self._manifests[repo_ref.canonical]
+        except KeyError as exc:
+            raise ManifestNotFoundError(
+                f"no delivery manifest is loaded for repository {repo_ref.canonical}"
+            ) from exc
+
+    def resolve_route(
+        self, repo_ref: RepoRef, stack: str, task_class: str
+    ) -> RoutePolicy:
+        """Resolve the advisory route for one explicit ``(RepoRef, stack, task)``.
+
+        The repo's own manifest is the only source consulted; a route from a
+        different repository's manifest is never substituted, even when the
+        stack and task-class match.
+        """
+        manifest = self.manifest_for(repo_ref)
+        return manifest.resolve(stack, task_class)
+
+
+def _require_identifier(value: Any, label: str) -> str:
+    if not isinstance(value, str) or _IDENTIFIER.fullmatch(value.strip()) is None:
+        raise ManifestError(f"{label} must be a bounded non-empty identifier")
+    return value.strip()
+
+
+__all__ = [
+    "DeliveryManifest",
+    "DeliveryManifestRegistry",
+    "ManifestError",
+    "ManifestNotFoundError",
+    "RepoRef",
+    "RepoRefError",
+    "RoutePolicy",
+    "RouteResolutionError",
+    "RoutingError",
+]

--- a/app/builderops/control_plane/service.py
+++ b/app/builderops/control_plane/service.py
@@ -8,11 +8,22 @@ from collections.abc import Callable
 from collections.abc import Mapping
 from typing import Any
 
-from fastapi import Depends, FastAPI, HTTPException, Response, status
+from fastapi import Depends, FastAPI, Header, HTTPException, Response, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from starlette.concurrency import run_in_threadpool
 
-from app.builderops.control_plane.api_models import LeaseClaimRequest, RecordCommitRequest
+from app.builderops.control_plane.api_models import (
+    AttemptCommitRequest,
+    InquiryCommitRequest,
+    LeaseClaimRequest,
+    LeaseInput,
+    OutboxClaimRequest,
+    PromotionCommitRequest,
+    RecordCommitRequest,
+    TaskClaimRequest,
+    TaskCompleteRequest,
+    TaskHeartbeatRequest,
+)
 from app.builderops.control_plane.auth import (
     Credential,
     CredentialConfigurationError,
@@ -24,8 +35,13 @@ from app.builderops.control_plane.models import (
     AuthorityEnvelope,
     ControlPlaneError,
     IdempotencyConflict,
+    Lease,
+    LeaseRequired,
     LeaseUnavailable,
+    StaleFencingToken,
+    StateConflict,
     StorePort,
+    canonical_repository,
 )
 from app.builderops.control_plane.selection import database_environment, production_store
 from app.middleware.trace import TraceIdMiddleware
@@ -47,6 +63,11 @@ _ALLOWED_SECRET_METADATA_KEYS = frozenset(
         "token_length",
     }
 )
+# Structural authority fields whose names collide with the credential-key
+# heuristic (``fencing_token`` ends in ``_token``) but which are never secrets.
+# They are exempt from the forbidden-key match; their values are still scanned,
+# and the request models constrain them to bounded integers.
+_STRUCTURAL_SAFE_KEYS = frozenset({"fencing_token"})
 _FORBIDDEN_COMPACT_DURABLE_KEYS = frozenset(
     {
         "authorization",
@@ -193,6 +214,7 @@ def _assert_durable_payload_safe(
     if (
         normalized_key
         and normalized_key not in _ALLOWED_SECRET_METADATA_KEYS
+        and normalized_key not in _STRUCTURAL_SAFE_KEYS
         and (
             _FORBIDDEN_DURABLE_KEYS.search(normalized_key)
             or normalized_key.replace("_", "") in _FORBIDDEN_COMPACT_DURABLE_KEYS
@@ -249,11 +271,90 @@ def _assert_durable_payload_safe(
 
 
 def _control_plane_error(exc: Exception) -> HTTPException:
-    if isinstance(exc, (IdempotencyConflict, LeaseUnavailable)):
+    if isinstance(exc, HTTPException):
+        # A scope/auth/epoch rejection raised inside the handler body must keep
+        # its typed status code instead of collapsing into a 503.
+        return exc
+    if isinstance(
+        exc,
+        (
+            IdempotencyConflict,
+            LeaseUnavailable,
+            StaleFencingToken,
+            StateConflict,
+            LeaseRequired,
+        ),
+    ):
         return HTTPException(status_code=409, detail=type(exc).__name__)
     if isinstance(exc, (ControlPlaneError, ValueError)):
         return HTTPException(status_code=400, detail=type(exc).__name__)
     return HTTPException(status_code=503, detail="BuilderOps store unavailable")
+
+
+def _enforce_repo_scope(credential: Credential, repository: str) -> None:
+    """Fail closed when a credential addresses a repository outside its scope.
+
+    The mandatory single-``RepoRef`` rule (BCP-04) is enforced here so that no
+    credential granted authority for one repository can mutate another. The
+    repository is canonicalized first so scope checks are not bypassable by
+    case or owner/name spelling.
+    """
+    try:
+        canonical = canonical_repository(repository)
+    except Exception as exc:  # EnvelopeValidationError and any parse failure
+        raise HTTPException(status_code=400, detail="invalid repository reference") from exc
+    if not credential.may_address(canonical):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="credential is not scoped to the addressed repository",
+        )
+
+
+def _lease_from_input(repository: str, lease: LeaseInput) -> Lease:
+    """Reconstruct a fenced :class:`Lease` from client-echoed lease fields."""
+    return Lease(
+        repository=repository,
+        resource_id=lease.resource_id,
+        holder=lease.holder,
+        fencing_token=lease.fencing_token,
+        expires_at=lease.expires_at,
+        lease_kind=lease.lease_kind,
+    )
+
+
+def _transition_response(result: Any) -> dict[str, Any]:
+    return {
+        "repository": result.repository,
+        "task_id": result.task_id,
+        "state": result.state,
+        "receipt_sequence": result.receipt_sequence,
+        "recovery_lsn": result.recovery_lsn,
+        "operation_key": result.operation_key,
+        "replayed": result.replayed,
+    }
+
+
+def _authority_object_response(result: Any) -> dict[str, Any]:
+    return {
+        "repository": result.repository,
+        "object_kind": result.object_kind,
+        "object_id": result.object_id,
+        "state": result.state,
+        "receipt_sequence": result.receipt_sequence,
+        "recovery_lsn": result.recovery_lsn,
+        "replayed": result.replayed,
+    }
+
+
+def _lease_response(lease: Lease) -> dict[str, Any]:
+    return {
+        "repository": lease.repository,
+        "resource_id": lease.resource_id,
+        "holder": lease.holder,
+        "fencing_token": lease.fencing_token,
+        "expires_at": lease.expires_at.isoformat(),
+        "lease_kind": lease.lease_kind,
+    }
 
 
 def create_app(
@@ -288,6 +389,45 @@ def create_app(
     metrics_read = _credential_dependency(credentials, rate_limiter, "metrics:read")
     lease_write = _credential_dependency(credentials, rate_limiter, "leases:write")
     record_write = _credential_dependency(credentials, rate_limiter, "records:write")
+    inquiry_write = _credential_dependency(credentials, rate_limiter, "inquiries:write")
+    task_write = _credential_dependency(credentials, rate_limiter, "tasks:write")
+    attempt_write = _credential_dependency(credentials, rate_limiter, "attempts:write")
+    promotion_write = _credential_dependency(credentials, rate_limiter, "promotions:write")
+    receipt_read = _credential_dependency(credentials, rate_limiter, "receipts:read")
+    # The outbox/executor scope is the privileged capability a normal MacBook
+    # client credential never holds; only the Demerzel executor is granted it.
+    outbox_write = _credential_dependency(credentials, rate_limiter, "outbox:write")
+
+    async def require_authority_epoch(
+        x_builderops_authority_epoch: str | None = Header(default=None),
+    ) -> None:
+        """Fence a client pinned to a superseded authority epoch (fail closed).
+
+        The header is optional so read-only probes and legacy callers still
+        work, but a client that pins an epoch is rejected when a recovery epoch
+        has advanced past it, rather than silently mutating the new authority.
+        """
+        if x_builderops_authority_epoch is None:
+            return
+        try:
+            pinned = int(x_builderops_authority_epoch)
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="invalid authority epoch header",
+            ) from exc
+        try:
+            readiness = await run_in_threadpool(store.readiness)
+        except Exception as exc:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="BuilderOps store unavailable",
+            ) from exc
+        if pinned != readiness.get("authority_epoch"):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="StaleAuthorityEpoch",
+            )
 
     @application.get("/healthz")
     async def healthz(_credential: Credential = Depends(health_read)) -> dict[str, bool]:
@@ -322,7 +462,9 @@ def create_app(
     async def claim_lease(
         request: LeaseClaimRequest,
         credential: Credential = Depends(lease_write),
+        _epoch: None = Depends(require_authority_epoch),
     ) -> dict[str, Any]:
+        _enforce_repo_scope(credential, request.envelope.repository)
         try:
             # Every client-controlled field below becomes durable authority,
             # idempotency, or lease state. Validate the complete request before
@@ -364,7 +506,9 @@ def create_app(
     async def commit_record(
         request: RecordCommitRequest,
         credential: Credential = Depends(record_write),
+        _epoch: None = Depends(require_authority_epoch),
     ) -> dict[str, Any]:
+        _enforce_repo_scope(credential, request.envelope.repository)
         try:
             _assert_durable_payload_safe(request.model_dump(mode="json"), credentials)
             result = await run_in_threadpool(
@@ -378,14 +522,238 @@ def create_app(
             )
         except Exception as exc:
             raise _control_plane_error(exc) from exc
+        return _authority_object_response(result)
+
+    @application.post("/v1/inquiries")
+    async def commit_inquiry(
+        request: InquiryCommitRequest,
+        credential: Credential = Depends(inquiry_write),
+        _epoch: None = Depends(require_authority_epoch),
+    ) -> dict[str, Any]:
+        _enforce_repo_scope(credential, request.envelope.repository)
+        try:
+            _assert_durable_payload_safe(request.model_dump(mode="json"), credentials)
+            result = await run_in_threadpool(
+                store.commit_record,
+                envelope=_envelope(request.envelope, credential),
+                record_id=request.inquiry_id,
+                record_type="ModelInquiry",
+                state=request.state,
+                payload=request.payload,
+                idempotency_key=request.idempotency_key,
+            )
+        except Exception as exc:
+            raise _control_plane_error(exc) from exc
+        return _authority_object_response(result)
+
+    @application.post("/v1/tasks/claim")
+    async def claim_task(
+        request: TaskClaimRequest,
+        credential: Credential = Depends(task_write),
+        _epoch: None = Depends(require_authority_epoch),
+    ) -> dict[str, Any]:
+        _enforce_repo_scope(credential, request.envelope.repository)
+        try:
+            _assert_durable_payload_safe(request.model_dump(mode="json"), credentials)
+            result, lease = await run_in_threadpool(
+                store.claim_task,
+                envelope=_envelope(request.envelope, credential),
+                task_id=request.task_id,
+                holder=credential.principal,
+                idempotency_key=request.idempotency_key,
+                request=request.request,
+                ttl_seconds=request.ttl_seconds,
+            )
+        except Exception as exc:
+            raise _control_plane_error(exc) from exc
+        return {"result": _transition_response(result), "lease": _lease_response(lease)}
+
+    @application.post("/v1/tasks/heartbeat")
+    async def heartbeat_task(
+        request: TaskHeartbeatRequest,
+        credential: Credential = Depends(task_write),
+        _epoch: None = Depends(require_authority_epoch),
+    ) -> dict[str, Any]:
+        _enforce_repo_scope(credential, request.envelope.repository)
+        try:
+            _assert_durable_payload_safe(request.model_dump(mode="json"), credentials)
+            envelope = _envelope(request.envelope, credential)
+            result, lease = await run_in_threadpool(
+                store.heartbeat_lease,
+                envelope=envelope,
+                lease=_lease_from_input(envelope.repository, request.lease),
+                idempotency_key=request.idempotency_key,
+                request=request.request,
+                ttl_seconds=request.ttl_seconds,
+            )
+        except Exception as exc:
+            raise _control_plane_error(exc) from exc
+        return {"result": _transition_response(result), "lease": _lease_response(lease)}
+
+    @application.post("/v1/tasks/complete")
+    async def complete_task(
+        request: TaskCompleteRequest,
+        credential: Credential = Depends(task_write),
+        _epoch: None = Depends(require_authority_epoch),
+    ) -> dict[str, Any]:
+        _enforce_repo_scope(credential, request.envelope.repository)
+        try:
+            _assert_durable_payload_safe(request.model_dump(mode="json"), credentials)
+            envelope = _envelope(request.envelope, credential)
+            result = await run_in_threadpool(
+                store.complete_task,
+                envelope=envelope,
+                lease=_lease_from_input(envelope.repository, request.lease),
+                idempotency_key=request.idempotency_key,
+                request=request.request,
+            )
+        except Exception as exc:
+            raise _control_plane_error(exc) from exc
+        return {"result": _transition_response(result)}
+
+    @application.post("/v1/attempts")
+    async def commit_attempt(
+        request: AttemptCommitRequest,
+        credential: Credential = Depends(attempt_write),
+        _epoch: None = Depends(require_authority_epoch),
+    ) -> dict[str, Any]:
+        _enforce_repo_scope(credential, request.envelope.repository)
+        try:
+            _assert_durable_payload_safe(request.model_dump(mode="json"), credentials)
+            envelope = _envelope(request.envelope, credential)
+            result = await run_in_threadpool(
+                store.commit_attempt,
+                envelope=envelope,
+                task_id=request.task_id,
+                attempt_id=request.attempt_id,
+                state=request.state,
+                payload=request.payload,
+                idempotency_key=request.idempotency_key,
+                lease=_lease_from_input(envelope.repository, request.lease),
+                expected_states=(
+                    tuple(request.expected_states)
+                    if request.expected_states is not None
+                    else None
+                ),
+            )
+        except Exception as exc:
+            raise _control_plane_error(exc) from exc
+        return _authority_object_response(result)
+
+    @application.post("/v1/promotions")
+    async def commit_promotion(
+        request: PromotionCommitRequest,
+        credential: Credential = Depends(promotion_write),
+        _epoch: None = Depends(require_authority_epoch),
+    ) -> dict[str, Any]:
+        _enforce_repo_scope(credential, request.envelope.repository)
+        try:
+            _assert_durable_payload_safe(request.model_dump(mode="json"), credentials)
+            envelope = _envelope(request.envelope, credential)
+            result = await run_in_threadpool(
+                store.commit_promotion,
+                envelope=envelope,
+                promotion_id=request.promotion_id,
+                status=request.status,
+                payload=request.payload,
+                idempotency_key=request.idempotency_key,
+                lease=(
+                    _lease_from_input(envelope.repository, request.lease)
+                    if request.lease is not None
+                    else None
+                ),
+                expected_states=(
+                    tuple(request.expected_states)
+                    if request.expected_states is not None
+                    else None
+                ),
+            )
+        except Exception as exc:
+            raise _control_plane_error(exc) from exc
+        return _authority_object_response(result)
+
+    @application.get("/v1/status")
+    async def authority_status(
+        _credential: Credential = Depends(status_read),
+    ) -> dict[str, Any]:
+        try:
+            readiness = await run_in_threadpool(store.readiness)
+        except Exception as exc:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="BuilderOps store unavailable",
+            ) from exc
         return {
-            "repository": result.repository,
-            "object_kind": result.object_kind,
-            "object_id": result.object_id,
-            "state": result.state,
-            "receipt_sequence": result.receipt_sequence,
-            "recovery_lsn": result.recovery_lsn,
-            "replayed": result.replayed,
+            "authority_epoch": readiness.get("authority_epoch"),
+            "schema_version": readiness.get("schema_version"),
+        }
+
+    @application.get("/v1/receipts/{object_kind}/{object_id}")
+    async def read_receipt(
+        object_kind: str,
+        object_id: str,
+        repository: str,
+        task_id: str | None = None,
+        credential: Credential = Depends(receipt_read),
+    ) -> dict[str, Any]:
+        _enforce_repo_scope(credential, repository)
+        canonical = canonical_repository(repository)
+        try:
+            if object_kind == "records":
+                receipt = await run_in_threadpool(store.get_record, canonical, object_id)
+            elif object_kind == "promotions":
+                receipt = await run_in_threadpool(store.get_promotion, canonical, object_id)
+            elif object_kind == "attempts":
+                if not task_id:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="attempt receipts require task_id",
+                    )
+                receipt = await run_in_threadpool(
+                    store.get_attempt, canonical, task_id, object_id
+                )
+            else:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="unknown receipt object kind",
+                )
+        except HTTPException:
+            raise
+        except KeyError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="receipt not found"
+            ) from exc
+        except Exception as exc:
+            raise _control_plane_error(exc) from exc
+        return dict(receipt)
+
+    @application.post("/v1/executor/outbox/claim")
+    async def claim_outbox(
+        request: OutboxClaimRequest,
+        credential: Credential = Depends(outbox_write),
+        _epoch: None = Depends(require_authority_epoch),
+    ) -> dict[str, Any]:
+        _enforce_repo_scope(credential, request.envelope.repository)
+        try:
+            _assert_durable_payload_safe(request.model_dump(mode="json"), credentials)
+            claim = await run_in_threadpool(
+                store.claim_outbox,
+                envelope=_envelope(request.envelope, credential),
+                operation_key=request.operation_key,
+                worker_id=request.worker_id,
+                claim_ttl_seconds=request.claim_ttl_seconds,
+            )
+        except Exception as exc:
+            raise _control_plane_error(exc) from exc
+        return {
+            "repository": claim.repository,
+            "operation_key": claim.operation_key,
+            "worker_id": claim.worker_id,
+            "fencing_token": claim.fencing_token,
+            "intent_lsn": claim.intent_lsn,
+            "claim_lsn": claim.claim_lsn,
+            "receipt_sequence": claim.receipt_sequence,
+            "expires_at": claim.expires_at.isoformat(),
         }
 
     return application

--- a/app/builderops/control_plane/service.py
+++ b/app/builderops/control_plane/service.py
@@ -395,7 +395,8 @@ def create_app(
     promotion_write = _credential_dependency(credentials, rate_limiter, "promotions:write")
     receipt_read = _credential_dependency(credentials, rate_limiter, "receipts:read")
     # The outbox/executor scope is the privileged capability a normal MacBook
-    # client credential never holds; only the Demerzel executor is granted it.
+    # client credential never holds; only the host-privileged executor is
+    # granted it.
     outbox_write = _credential_dependency(credentials, rate_limiter, "outbox:write")
 
     async def require_authority_epoch(

--- a/app/builderops/control_plane/service.py
+++ b/app/builderops/control_plane/service.py
@@ -66,14 +66,22 @@ _ALLOWED_SECRET_METADATA_KEYS = frozenset(
 )
 # Structural authority fields whose names collide with the credential-key
 # heuristic (``fencing_token`` ends in ``_token``) but which are never secrets.
-# The exemption is scoped to BOTH the exact field path (the immediate parent
-# key) AND a strict int value type — never the bare key name anywhere in the
-# tree. A free-form ``payload``/``request`` field named ``fencing_token`` is
-# NOT exempt: it is not a direct child of a ``lease`` object, and even if an
-# attacker nests a fake ``lease`` key inside free-form content, the value-type
-# gate still rejects a string (a raw secret can never be a Python int).
+# The exemption is scoped to BOTH the FULL ancestor path from the request
+# root (not merely the immediate parent key — a "lease" object nested at any
+# depth inside free-form payload/request content must not qualify) AND a
+# strict int value type — never the bare key name anywhere in the tree. Every
+# request model that carries a real lease puts it at the top level
+# (``TaskHeartbeatRequest.lease``, ``TaskCompleteRequest.lease``,
+# ``AttemptCommitRequest.lease``, ``PromotionCommitRequest.lease``), so the
+# only legitimate path is exactly ``("lease", "fencing_token")``. As a second,
+# independent layer, the value-type gate rejects a string even if some future
+# path were added here by mistake: no BuilderOps credential/secret in this
+# system is ever numeric (they are opaque strings from secret files), so a
+# raw credential can never satisfy the int check regardless of path.
 _STRUCTURAL_SAFE_KEYS = frozenset({"fencing_token"})
-_STRUCTURAL_SAFE_KEY_PARENTS: dict[str, frozenset[str]] = {"fencing_token": frozenset({"lease"})}
+_STRUCTURAL_SAFE_FIELD_PATHS: dict[str, frozenset[tuple[str, ...]]] = {
+    "fencing_token": frozenset({("lease", "fencing_token")})
+}
 _FORBIDDEN_COMPACT_DURABLE_KEYS = frozenset(
     {
         "authorization",
@@ -197,7 +205,7 @@ def _assert_durable_payload_safe(
     registry: CredentialRegistry,
     *,
     key: str = "",
-    _parent_key: str = "",
+    _path: tuple[str, ...] = (),
     _remaining_chars: list[int] | None = None,
     _remaining_nodes: list[int] | None = None,
 ) -> None:
@@ -216,19 +224,23 @@ def _assert_durable_payload_safe(
     if remaining_nodes[0] < 0:
         raise ValueError("durable BuilderOps request exceeds the value node limit")
     normalized_key = _canonical_durable_key(key)
-    normalized_parent_key = _canonical_durable_key(_parent_key)
+    # The full ancestor chain from the request root down to and including
+    # this node's own key — not just the immediate parent. ``_path`` is the
+    # chain ABOVE this node, threaded in from the caller.
+    current_path = (*_path, normalized_key) if normalized_key else _path
     if normalized_key in _ALLOWED_SECRET_METADATA_KEYS:
         _assert_secret_metadata_shape(normalized_key, value)
-    # The structural exemption requires the EXACT field path (the immediate
-    # parent key) plus a strict int value type, not just a matching key name
-    # anywhere in the tree. A free-form payload/request field named
-    # "fencing_token" — even one nested under an attacker-supplied "lease" key
-    # — is only exempt if its value is literally an int; a raw secret string
-    # can never satisfy that, so it always falls through to the forbidden-key
-    # check below.
+    # The structural exemption requires the EXACT full path from the request
+    # root (not just an immediate parent name — a "lease" object nested at
+    # ANY depth inside free-form payload/request content must not qualify)
+    # plus a strict int value type. A free-form payload/request field named
+    # "fencing_token" is only exempt if BOTH its full path matches the one
+    # genuine top-level lease field AND its value is literally an int; a raw
+    # secret string can never satisfy the type gate, so it always falls
+    # through to the forbidden-key check below regardless of path.
     is_exempt_structural_field = (
         normalized_key in _STRUCTURAL_SAFE_KEYS
-        and normalized_parent_key in _STRUCTURAL_SAFE_KEY_PARENTS.get(normalized_key, frozenset())
+        and current_path in _STRUCTURAL_SAFE_FIELD_PATHS.get(normalized_key, frozenset())
         and isinstance(value, int)
         and not isinstance(value, bool)
     )
@@ -257,7 +269,7 @@ def _assert_durable_payload_safe(
                 child,
                 registry,
                 key=durable_key,
-                _parent_key=normalized_key,
+                _path=current_path,
                 _remaining_chars=remaining_chars,
                 _remaining_nodes=remaining_nodes,
             )
@@ -266,13 +278,18 @@ def _assert_durable_payload_safe(
         for child in value:
             # The collection shape above owns metadata validation. Children
             # still receive the value scan without being mistaken for a whole
-            # `scopes` collection.
+            # `scopes` collection. A list does not introduce its own path
+            # segment: its items reuse this node's key (as `child_key` does
+            # below) and inherit the SAME ancestor path this node received
+            # (not `current_path`, which already includes this node's own
+            # key) so the item's own path computation adds exactly one
+            # segment, matching the non-list case instead of duplicating it.
             child_key = "" if normalized_key in _ALLOWED_SECRET_METADATA_KEYS else key
             _assert_durable_payload_safe(
                 child,
                 registry,
                 key=child_key,
-                _parent_key=normalized_parent_key,
+                _path=_path,
                 _remaining_chars=remaining_chars,
                 _remaining_nodes=remaining_nodes,
             )

--- a/app/builderops/control_plane/service.py
+++ b/app/builderops/control_plane/service.py
@@ -32,6 +32,7 @@ from app.builderops.control_plane.auth import (
 )
 from app.builderops.control_plane.health import HealthService, LiveOperationalStatusProvider
 from app.builderops.control_plane.models import (
+    STALE_AUTHORITY_EPOCH_DETAIL,
     AuthorityEnvelope,
     ControlPlaneError,
     IdempotencyConflict,
@@ -65,9 +66,14 @@ _ALLOWED_SECRET_METADATA_KEYS = frozenset(
 )
 # Structural authority fields whose names collide with the credential-key
 # heuristic (``fencing_token`` ends in ``_token``) but which are never secrets.
-# They are exempt from the forbidden-key match; their values are still scanned,
-# and the request models constrain them to bounded integers.
+# The exemption is scoped to BOTH the exact field path (the immediate parent
+# key) AND a strict int value type — never the bare key name anywhere in the
+# tree. A free-form ``payload``/``request`` field named ``fencing_token`` is
+# NOT exempt: it is not a direct child of a ``lease`` object, and even if an
+# attacker nests a fake ``lease`` key inside free-form content, the value-type
+# gate still rejects a string (a raw secret can never be a Python int).
 _STRUCTURAL_SAFE_KEYS = frozenset({"fencing_token"})
+_STRUCTURAL_SAFE_KEY_PARENTS: dict[str, frozenset[str]] = {"fencing_token": frozenset({"lease"})}
 _FORBIDDEN_COMPACT_DURABLE_KEYS = frozenset(
     {
         "authorization",
@@ -191,6 +197,7 @@ def _assert_durable_payload_safe(
     registry: CredentialRegistry,
     *,
     key: str = "",
+    _parent_key: str = "",
     _remaining_chars: list[int] | None = None,
     _remaining_nodes: list[int] | None = None,
 ) -> None:
@@ -209,12 +216,26 @@ def _assert_durable_payload_safe(
     if remaining_nodes[0] < 0:
         raise ValueError("durable BuilderOps request exceeds the value node limit")
     normalized_key = _canonical_durable_key(key)
+    normalized_parent_key = _canonical_durable_key(_parent_key)
     if normalized_key in _ALLOWED_SECRET_METADATA_KEYS:
         _assert_secret_metadata_shape(normalized_key, value)
+    # The structural exemption requires the EXACT field path (the immediate
+    # parent key) plus a strict int value type, not just a matching key name
+    # anywhere in the tree. A free-form payload/request field named
+    # "fencing_token" — even one nested under an attacker-supplied "lease" key
+    # — is only exempt if its value is literally an int; a raw secret string
+    # can never satisfy that, so it always falls through to the forbidden-key
+    # check below.
+    is_exempt_structural_field = (
+        normalized_key in _STRUCTURAL_SAFE_KEYS
+        and normalized_parent_key in _STRUCTURAL_SAFE_KEY_PARENTS.get(normalized_key, frozenset())
+        and isinstance(value, int)
+        and not isinstance(value, bool)
+    )
     if (
         normalized_key
         and normalized_key not in _ALLOWED_SECRET_METADATA_KEYS
-        and normalized_key not in _STRUCTURAL_SAFE_KEYS
+        and not is_exempt_structural_field
         and (
             _FORBIDDEN_DURABLE_KEYS.search(normalized_key)
             or normalized_key.replace("_", "") in _FORBIDDEN_COMPACT_DURABLE_KEYS
@@ -236,6 +257,7 @@ def _assert_durable_payload_safe(
                 child,
                 registry,
                 key=durable_key,
+                _parent_key=normalized_key,
                 _remaining_chars=remaining_chars,
                 _remaining_nodes=remaining_nodes,
             )
@@ -250,6 +272,7 @@ def _assert_durable_payload_safe(
                 child,
                 registry,
                 key=child_key,
+                _parent_key=normalized_parent_key,
                 _remaining_chars=remaining_chars,
                 _remaining_nodes=remaining_nodes,
             )
@@ -427,7 +450,7 @@ def create_app(
         if pinned != readiness.get("authority_epoch"):
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail="StaleAuthorityEpoch",
+                detail=STALE_AUTHORITY_EPOCH_DETAIL,
             )
 
     @application.get("/healthz")

--- a/docs/BUILDEROPS_CONTROL_PLANE/API_ONLY_CLIENT_CUTOVER.md
+++ b/docs/BUILDEROPS_CONTROL_PLANE/API_ONLY_CLIENT_CUTOVER.md
@@ -131,11 +131,23 @@ credential is inlined in the repo, skills, docs, or logs:
 - `BUILDEROPS_API_TOKEN` — the scoped bearer token in the host environment.
 
 Exactly one of `BUILDEROPS_API_TOKEN_FILE` or `BUILDEROPS_API_TOKEN` is set by
-the host. A normal client credential is scoped to its granted repositories and
-cannot call the privileged executor/outbox operations; the Demerzel executor
-holds the only `outbox:write` credential. With the service unavailable or the
+the host. A credential's authority is fail-closed by default: a credential with
+no `repositories` list and no explicit `all_repositories: true` opt-in can
+address NO repository. A normal client credential is scoped to its granted
+repositories and cannot call the privileged executor/outbox operations; the
+executor holds the only credential with the explicit `all_repositories: true`
+opt-in and the only `outbox:write` scope. With the service unavailable or the
 credential rejected, the client and wrapper fail closed with a non-zero exit and
 create no local SQLite/JSONL/JSON authority and no fabricated GitHub lease.
+
+The CLI's optional `--delivery-manifest-dir`/`--task-class` flags engage
+delivery-manifest `(RepoRef, stack, task-class)` routing
+(`app.builderops.control_plane.routing`) for a mutating command: when given,
+the addressed repository's manifest is loaded and its route resolved before
+dispatch (advisory request-shaping only, e.g. a `ttl_seconds` default — never
+privileged authority), and a missing/ambiguous manifest or route fails closed.
+Routing is opt-in; omitting both flags skips it entirely and uses the
+historical hardcoded defaults, matching this slice's non-authoritative scope.
 
 ## How to Verify (Pre-Merge)
 

--- a/docs/BUILDEROPS_CONTROL_PLANE/API_ONLY_CLIENT_CUTOVER.md
+++ b/docs/BUILDEROPS_CONTROL_PLANE/API_ONLY_CLIENT_CUTOVER.md
@@ -11,6 +11,18 @@ can_parallelize_with: []
 
 # API-Only Client Cutover
 
+Delivery status: the versioned authenticated control-plane client
+(`app/builderops/control_plane/client.py`), its API-only CLI
+(`python -m app.builderops.control_plane`), delivery-manifest routing, the
+client-facing service routes, repo/executor scope enforcement, and the
+store-boundary/governance gates are implemented in the development baseline by
+#3791. The client transport ships non-authoritative: it targets whatever
+BuilderOps service/store backend is configured, and BCP-06 owns activating
+production authority and freezing the legacy SQLite writers. The legacy
+direct-SQLite `app.dispatcher`/`app.builderops` CLIs remain until that
+BCP-06 freeze; this slice adds the API-only client alongside them and gates the
+control-plane package against local-store fallback.
+
 ## Purpose
 
 Current CLI, boundary, dispatcher, skills, automations, and SSH wrappers can construct/open local
@@ -74,25 +86,25 @@ removes direct operational-store access from builder clients.
 
 ## Acceptance Criteria
 
-- [ ] Representative MacBook commands for records, inquiry, task claim/heartbeat/complete, and
+- [x] Representative MacBook commands for records, inquiry, task claim/heartbeat/complete, and
   receipts call the authenticated API and share one authority epoch.
   Verify: `tests/builderops/control_plane/test_api_clients.py::test_all_authority_commands_use_remote_api`.
-- [ ] With the API unavailable or credentials invalid, mutation returns a typed error and creates no
+- [x] With the API unavailable or credentials invalid, mutation returns a typed error and creates no
   SQLite/JSONL/JSON authority or GitHub lease substitute.
   Verify: `tests/builderops/control_plane/test_api_clients.py::test_client_failure_never_creates_local_authority_fallback`.
-- [ ] Production CLI/help/config exposes no direct database path or SSH-wrapped store mode; migration
+- [x] Production CLI/help/config exposes no direct database path or SSH-wrapped store mode; migration
   tooling retains explicit read-only source paths.
   Verify: `tests/governance/test_builderops_api_only_clients.py::test_production_clients_expose_no_direct_store_mode`.
-- [ ] Repo-local BuilderOps/dispatcher skills and automations route authority-bearing operations
+- [x] Repo-local BuilderOps/dispatcher skills and automations route authority-bearing operations
   through the client and document credential setup without secrets.
   Verify: `tests/governance/test_builderops_api_only_clients.py::test_skills_and_automations_route_through_authenticated_api`.
-- [ ] A normal client credential cannot call privileged executor/merge operations or address a repo
+- [x] A normal client credential cannot call privileged executor/merge operations or address a repo
   outside its granted scope.
   Verify: `tests/builderops/control_plane/test_service_auth.py::test_normal_client_cannot_use_executor_or_cross_repo_scope`.
-- [ ] Client policy loads the addressed repo's delivery manifest and routes by
+- [x] Client policy loads the addressed repo's delivery manifest and routes by
   `(RepoRef, stack, task-class)`; missing/ambiguous manifests and cross-repo prior reuse fail closed.
   Verify: `tests/builderops/control_plane/test_delivery_manifest_routing.py::test_repo_stack_task_routing_is_explicit_and_non_transitive`.
-- [ ] Static/runtime inventory rejects production imports/construction of SQLite stores outside the
+- [x] Static/runtime inventory rejects production imports/construction of SQLite stores outside the
   migration/test adapter allowlist.
   Verify: `tests/architecture/test_builderops_store_boundary.py::test_only_control_plane_data_layer_and_migration_adapters_access_stores`.
 
@@ -102,6 +114,28 @@ removes direct operational-store access from builder clients.
 - importing/finally freezing legacy stores;
 - removing Product Runtime routes; and
 - distributing credentials outside the owner-operated MacBook/Demerzel boundary.
+
+## Client setup (secret-safe)
+
+Repo-local skills and automations route authority-bearing BuilderOps operations
+through the authenticated API client, not a local store. The canonical entry
+points are `python -m app.builderops.control_plane <command>` and the
+`scripts/builderops_api_client.sh` automation wrapper. Both resolve their base
+URL and scoped bearer credential from host-owned configuration only; no
+credential is inlined in the repo, skills, docs, or logs:
+
+- `BUILDEROPS_API_URL` — the control-plane base URL (required), reached over
+  Tailscale, e.g. `https://demerzel.<tailnet>.ts.net:<port>`.
+- `BUILDEROPS_API_TOKEN_FILE` — path to a host secret file holding the scoped
+  bearer token (preferred), or
+- `BUILDEROPS_API_TOKEN` — the scoped bearer token in the host environment.
+
+Exactly one of `BUILDEROPS_API_TOKEN_FILE` or `BUILDEROPS_API_TOKEN` is set by
+the host. A normal client credential is scoped to its granted repositories and
+cannot call the privileged executor/outbox operations; the Demerzel executor
+holds the only `outbox:write` credential. With the service unavailable or the
+credential rejected, the client and wrapper fail closed with a non-zero exit and
+create no local SQLite/JSONL/JSON authority and no fabricated GitHub lease.
 
 ## How to Verify (Pre-Merge)
 

--- a/docs/BUILDEROPS_CONTROL_PLANE/README.md
+++ b/docs/BUILDEROPS_CONTROL_PLANE/README.md
@@ -1,4 +1,4 @@
-State: Accepted target-state specification (owner decision, 2026-07-15; amended per ADR-0062 A1-A3, 2026-07-16: asynchronous recovery durability, failure-domain separation, degraded-mode contract, CKM/CEG migration source). Parent validation hub #3788 remains `agent:blocked` while child slices are outstanding. BCP-01 is implemented in the development baseline by #3792/PR #3852; the repo/deployment contract for BCP-02 is implemented by #3790; BCP-03 is implemented in the development baseline by #3789/PR #3929 (mechanism only, no cutover); live authority activation remains forbidden until BCP-03 through BCP-06 complete. BCP-04 is now dependency-unblocked, BCP-05 still waits for BCP-04, and BCP-06/07 remain dependency-blocked. Existing issues #3603 and #3690 are reconciled into the sequence.
+State: Accepted target-state specification (owner decision, 2026-07-15; amended per ADR-0062 A1-A3, 2026-07-16: asynchronous recovery durability, failure-domain separation, degraded-mode contract, CKM/CEG migration source). Parent validation hub #3788 remains `agent:blocked` while child slices are outstanding. BCP-01 is implemented in the development baseline by #3792/PR #3852; the repo/deployment contract for BCP-02 is implemented by #3790; BCP-03 is implemented in the development baseline by #3789/PR #3929 (mechanism only, no cutover); BCP-04 is implemented in the development baseline by #3791 (client transport and gates only, non-authoritative); live authority activation remains forbidden until BCP-03 through BCP-06 complete. BCP-05 still waits for BCP-04 acceptance, and BCP-06/07 remain dependency-blocked. Existing issues #3603 and #3690 are reconciled into the sequence.
 Doc role: Specification directory
 Authority: Owns the bounded task decomposition and cross-task invariants after merge. ADR-0062 owns the architectural decision; ADR-0010 owns the repo/BuilderOps authority seam; shipped owner docs win for current behavior.
 Owner: BuilderOps governance / Architecture spine
@@ -42,6 +42,19 @@ mechanism only: no production cutover, writer disablement, or PostgreSQL adapter
 (BCP-06 owns the freeze window and the sink adapter), and remote-host env snapshots are a
 recorded preflight limitation.
 
+BCP-04 (#3791) adds the versioned authenticated control-plane client
+(`app/builderops/control_plane/client.py`), its API-only CLI
+(`python -m app.builderops.control_plane`) and `scripts/builderops_api_client.sh`
+wrapper, delivery-manifest `(RepoRef, stack, task-class)` routing, the
+client-facing service routes (records, inquiries, tasks claim/heartbeat/complete,
+attempts, promotions, receipts, status, and the executor outbox claim), repo and
+executor scope enforcement, typed fail-closed transport/auth/scope/conflict/
+stale-lease errors with idempotent retry, and the control-plane store-boundary
+and governance gates. This is not a production cutover either: the client targets
+whatever service/store backend is configured and ships non-authoritative; the
+legacy direct-SQLite `app.dispatcher`/`app.builderops` CLIs remain in place, and
+BCP-06 owns activating production authority and freezing those legacy writers.
+
 ## Target boundary
 
 - Demerzel hosts the independently deployed BuilderOps API, PostgreSQL store, migration gate, and
@@ -72,10 +85,11 @@ Execution order:
 `BCP-02 -> BCP-04 -> BCP-05`; `BCP-03 + BCP-04 + BCP-05 -> BCP-06 -> BCP-07`.
 
 Parent validation hub: #3788. BCP-01 is implemented in the development baseline by #3792/PR #3852,
-BCP-02's repo/deployment contract is implemented by #3790 without live authority activation, and
-BCP-03 (#3789) is implemented in the development baseline by PR #3929 (mechanism only). BCP-04
-(#3791) is the next dependency-unblocked candidate; the BCP-05 migration (#3603) follows BCP-04,
-and BCP-06/07 remain blocked.
+BCP-02's repo/deployment contract is implemented by #3790 without live authority activation,
+BCP-03 (#3789) is implemented in the development baseline by PR #3929 (mechanism only), and
+BCP-04 (#3791) is implemented in the development baseline (client transport and gates only,
+non-authoritative). The BCP-05 migration (#3603) follows BCP-04 acceptance, and BCP-06/07 remain
+blocked.
 BCP-05 and BCP-07 reuse existing issues rather than creating duplicate work. PR #3620 is the
 merged BCP-05 implementation baseline; later migration lands in a new PR under the existing issue,
 not by rewriting that merge.

--- a/scripts/builderops_api_client.sh
+++ b/scripts/builderops_api_client.sh
@@ -13,9 +13,10 @@
 # credential is rejected, the client fails closed (non-zero exit) and never
 # creates local authority.
 #
-# Usage from any automation worktree (cwd is the repo root or any worktree):
+# Usage from any automation worktree (cwd is the repo root or any worktree).
+# Output is always a JSON object on stdout; no --json flag exists or is needed:
 #
-#   scripts/builderops_api_client.sh status --json
+#   scripts/builderops_api_client.sh status
 #   scripts/builderops_api_client.sh record \
 #     --repository RasmusTho/agentic-pkm-mvp --scope issue:3791 \
 #     --stack builderops-control-plane --source-ref github:issue:3791 \

--- a/scripts/builderops_api_client.sh
+++ b/scripts/builderops_api_client.sh
@@ -24,7 +24,7 @@
 #
 # Credentials are host-owned and never inlined here or committed to the repo:
 #   BUILDEROPS_API_URL         — control-plane base URL (required), e.g.
-#                                https://demerzel.<tailnet>.ts.net:18700
+#                                https://<builderops-host>.<tailnet>.ts.net:<port>
 #   BUILDEROPS_API_TOKEN_FILE  — path to a host secret file holding the scoped
 #                                bearer token (preferred), OR
 #   BUILDEROPS_API_TOKEN       — the scoped bearer token in the environment

--- a/scripts/builderops_api_client.sh
+++ b/scripts/builderops_api_client.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# scripts/builderops_api_client.sh — API-only BuilderOps control-plane client
+# wrapper for automation worktrees.
+#
+# Runs the authenticated control-plane client:
+#
+#   python3 -m app.builderops.control_plane <command> ...
+#
+# This is the cutover replacement for the legacy direct-SQLite BuilderOps CLI
+# wrapper. It reaches the independent BuilderOps service over ONE authenticated
+# API boundary. It exposes NO --db-path, opens NO local SQLite database, and
+# SSHes into NO database-owning CLI. When the service is unavailable or the
+# credential is rejected, the client fails closed (non-zero exit) and never
+# creates local authority.
+#
+# Usage from any automation worktree (cwd is the repo root or any worktree):
+#
+#   scripts/builderops_api_client.sh status --json
+#   scripts/builderops_api_client.sh record \
+#     --repository RasmusTho/agentic-pkm-mvp --scope issue:3791 \
+#     --stack builderops-control-plane --source-ref github:issue:3791 \
+#     --record-id learning-3791 --record-type LearningSignal --state active \
+#     --idempotency-key record-learning-3791
+#
+# Credentials are host-owned and never inlined here or committed to the repo:
+#   BUILDEROPS_API_URL         — control-plane base URL (required), e.g.
+#                                https://demerzel.<tailnet>.ts.net:18700
+#   BUILDEROPS_API_TOKEN_FILE  — path to a host secret file holding the scoped
+#                                bearer token (preferred), OR
+#   BUILDEROPS_API_TOKEN       — the scoped bearer token in the environment
+#
+# Exactly one of BUILDEROPS_API_TOKEN_FILE or BUILDEROPS_API_TOKEN is set by the
+# host; the token value is read transiently and is never logged.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+source "$SCRIPT_DIR/lib/resolve_repo_python.sh"
+
+PYTHON="$(builderops_resolve_python "$APP_ROOT")" || true
+if [ -z "$PYTHON" ]; then
+    echo "ERROR: BuilderOps API client requires the repo virtualenv, but no usable .venv/bin/python3 was found." >&2
+    echo "Run from the canonical checkout, or create the canonical repo venv first:" >&2
+    echo "  cd /Users/rasmusthornberg/code/agentic-pkm-mvp && python3 -m venv .venv && .venv/bin/pip install -e ." >&2
+    exit 1
+fi
+
+if [ -z "${BUILDEROPS_API_URL:-}" ]; then
+    echo "ERROR: BUILDEROPS_API_URL is required (host-owned control-plane base URL)." >&2
+    echo "The API-only client requires the control-plane API; it has no local-store fallback." >&2
+    exit 2
+fi
+
+cd "$APP_ROOT"
+exec "$PYTHON" -m app.builderops.control_plane "$@"

--- a/scripts/lint_skills_consistency.py
+++ b/scripts/lint_skills_consistency.py
@@ -70,6 +70,7 @@ KNOWN_NON_SKILL_TERMS = {
     "stable-prev",  # release-channel ref name
     "test-candidate",  # promotion vocabulary
     "generate-projections",  # builderops CLI subcommand
+    "create-learning-signal",  # builderops CLI subcommand
 }
 
 RETIRED_PHRASE = "Do not batch to end of task"

--- a/tests/architecture/test_builderops_store_boundary.py
+++ b/tests/architecture/test_builderops_store_boundary.py
@@ -18,6 +18,13 @@ outside this allowlist fails this test. This inventory is the completeness proof
 for BCP-04's no-local-authority-fallback guarantee; the legacy
 ``app.dispatcher`` / ``app.builderops`` SQLite writers are a separate concern
 owned by the BCP-06 legacy-writer freeze, not by this control-plane boundary.
+
+A second, separate guard below widens the walk to the rest of ``app/builderops/``
+(the pre-existing Vault record store, outside ``control_plane/``) against an
+explicit, audited allowlist of its known legitimate store-access sites
+(BCP-04 review finding H5). This closes the regression gap for *new* files
+without requiring those pre-existing, still-legacy sites to migrate in this
+slice — their migration is BCP-03/06 territory.
 """
 
 from __future__ import annotations
@@ -27,12 +34,33 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CONTROL_PLANE = REPO_ROOT / "app" / "builderops" / "control_plane"
+BUILDEROPS_ROOT = REPO_ROOT / "app" / "builderops"
 
 # Relative paths (from REPO_ROOT) permitted to access a store.
 DATA_LAYER_AND_MIGRATION_ALLOWLIST: frozenset[str] = frozenset(
     {
         "app/builderops/control_plane/store.py",  # PostgreSQL data layer
         "app/builderops/control_plane/selection.py",  # selector + migration/test adapter
+    }
+)
+
+# The pre-existing BuilderOps Vault record store (LearningSignal, worklogs,
+# promotion intents, receipts as vault-adjacent artifacts) is a genuinely
+# separate system from the control plane above — see
+# docs/builderops/BUILDEROPS_VAULT_BOUNDARY.md :: Scope and the README's
+# backlog-reconciliation note that BCP-03/06, not BCP-04, migrate this
+# authority. These are its known, audited legitimate store-access sites as of
+# BCP-04 (issue #3791 review finding H5); a NEW file outside this allowlist
+# that touches a store fails this test rather than silently extending the
+# surface. Do not add a new entry here without an accompanying migration/
+# audit — extending this allowlist is never the fix for a failing test.
+VAULT_STORE_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "app/builderops/store.py",  # the Vault record store's own data layer
+        "app/builderops/cli.py",  # legacy Vault CLI (this session's own coordination path)
+        "app/builderops/boundary.py",  # local Vault HTTP/tool boundary (#1503), Product-adjacent
+        "app/builderops/completeness_report.py",  # read-only Vault inventory report
+        "app/builderops/ckm/store.py",  # CKM receipt store built on the Vault store
     }
 )
 
@@ -93,6 +121,15 @@ def _control_plane_files() -> list[Path]:
     return sorted(CONTROL_PLANE.rglob("*.py"))
 
 
+def _vault_files() -> list[Path]:
+    """Every app/builderops/**/*.py file OUTSIDE the control_plane/ subtree."""
+    return sorted(
+        path
+        for path in BUILDEROPS_ROOT.rglob("*.py")
+        if CONTROL_PLANE not in path.parents and path != CONTROL_PLANE
+    )
+
+
 def test_only_control_plane_data_layer_and_migration_adapters_access_stores() -> None:
     assert CONTROL_PLANE.is_dir()
     violations: list[str] = []
@@ -134,5 +171,46 @@ def test_store_boundary_allowlist_is_accurate() -> None:
             stale.append(rel)
     assert not stale, (
         "Stale store-boundary allowlist entries (remove or fix):\n"
+        + "\n".join(f"  {s}" for s in sorted(stale))
+    )
+
+
+def test_no_new_vault_store_access_sites_outside_the_audited_allowlist() -> None:
+    """A NEW app/builderops/**/*.py file (outside control_plane/) that touches
+    a database driver or constructs a Vault store must be explicitly audited
+    and added to VAULT_STORE_ALLOWLIST, not silently introduced.
+
+    This does not require migrating the existing legitimate Vault-record sites
+    (they remain BCP-03/06 territory per the module docstring); it only closes
+    the regression gap the control-plane-scoped guard above cannot see,
+    because those files are outside app/builderops/control_plane/.
+    """
+    assert BUILDEROPS_ROOT.is_dir()
+    violations: list[str] = []
+    for path in _vault_files():
+        rel = str(path.relative_to(REPO_ROOT))
+        if rel in VAULT_STORE_ALLOWLIST:
+            continue
+        if _accesses_store(path):
+            violations.append(rel)
+
+    assert not violations, (
+        "New app/builderops/ store-access sites outside the audited allowlist "
+        "(add to VAULT_STORE_ALLOWLIST only after confirming this is a "
+        "legitimate Vault-record data-layer site, not a new authority-bearing "
+        "caller that should use the control-plane API client instead):\n"
+        + "\n".join(f"  {v}" for v in sorted(violations))
+    )
+
+
+def test_vault_store_allowlist_is_accurate() -> None:
+    """Every VAULT_STORE_ALLOWLIST entry still exists and still accesses a store."""
+    stale: list[str] = []
+    for rel in VAULT_STORE_ALLOWLIST:
+        path = REPO_ROOT / rel
+        if not path.exists() or not _accesses_store(path):
+            stale.append(rel)
+    assert not stale, (
+        "Stale Vault store-boundary allowlist entries (remove or fix):\n"
         + "\n".join(f"  {s}" for s in sorted(stale))
     )

--- a/tests/architecture/test_builderops_store_boundary.py
+++ b/tests/architecture/test_builderops_store_boundary.py
@@ -7,11 +7,14 @@ routing, the service, auth, and models must never import a raw database driver
 ``PostgresBuilderOpsStore``. That is what makes the API boundary real: a client
 cannot silently reopen a worktree-local database or reach PostgreSQL directly.
 
-Only two control-plane modules are permitted store access:
+Only these control-plane modules are permitted store access:
 
 * ``store.py`` — the PostgreSQL data layer.
 * ``selection.py`` — the fail-closed production selector plus the explicit
   SQLite migration/test adapter seam.
+* ``legacy_migration.py`` — BCP-03's deterministic, read-only legacy-authority
+  import mechanism (merged after this slice via #3929); it hash-verifies each
+  source before and after every read and performs no production cutover.
 
 A new control-plane module that imports a database driver or constructs a store
 outside this allowlist fails this test. This inventory is the completeness proof
@@ -41,6 +44,7 @@ DATA_LAYER_AND_MIGRATION_ALLOWLIST: frozenset[str] = frozenset(
     {
         "app/builderops/control_plane/store.py",  # PostgreSQL data layer
         "app/builderops/control_plane/selection.py",  # selector + migration/test adapter
+        "app/builderops/control_plane/legacy_migration.py",  # BCP-03 read-only import mechanism
     }
 )
 

--- a/tests/architecture/test_builderops_store_boundary.py
+++ b/tests/architecture/test_builderops_store_boundary.py
@@ -1,0 +1,138 @@
+"""BCP-04 AC7: only control-plane data-layer and migration/test adapters may
+reach a store.
+
+The authenticated client transport (``client.py``), its CLI, delivery-manifest
+routing, the service, auth, and models must never import a raw database driver
+(``sqlite3``/``psycopg``) or construct a ``SqliteBuilderOpsStore`` /
+``PostgresBuilderOpsStore``. That is what makes the API boundary real: a client
+cannot silently reopen a worktree-local database or reach PostgreSQL directly.
+
+Only two control-plane modules are permitted store access:
+
+* ``store.py`` — the PostgreSQL data layer.
+* ``selection.py`` — the fail-closed production selector plus the explicit
+  SQLite migration/test adapter seam.
+
+A new control-plane module that imports a database driver or constructs a store
+outside this allowlist fails this test. This inventory is the completeness proof
+for BCP-04's no-local-authority-fallback guarantee; the legacy
+``app.dispatcher`` / ``app.builderops`` SQLite writers are a separate concern
+owned by the BCP-06 legacy-writer freeze, not by this control-plane boundary.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTROL_PLANE = REPO_ROOT / "app" / "builderops" / "control_plane"
+
+# Relative paths (from REPO_ROOT) permitted to access a store.
+DATA_LAYER_AND_MIGRATION_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "app/builderops/control_plane/store.py",  # PostgreSQL data layer
+        "app/builderops/control_plane/selection.py",  # selector + migration/test adapter
+    }
+)
+
+# Raw database drivers that only the data layer / migration adapter may import.
+_DRIVER_MODULES = ("sqlite3", "psycopg")
+# Store classes whose *construction* is store access anywhere it appears.
+_STORE_CONSTRUCTORS = frozenset({"SqliteBuilderOpsStore", "PostgresBuilderOpsStore"})
+
+# The authority-bearing client surface must be provably store-free.
+_CLIENT_SURFACE = frozenset(
+    {
+        "app/builderops/control_plane/client.py",
+        "app/builderops/control_plane/client_cli.py",
+        "app/builderops/control_plane/routing.py",
+        "app/builderops/control_plane/__main__.py",
+    }
+)
+
+
+def _imports_driver(tree: ast.AST) -> bool:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name in _DRIVER_MODULES or alias.name.startswith(
+                    tuple(f"{module}." for module in _DRIVER_MODULES)
+                ):
+                    return True
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module in _DRIVER_MODULES or module.startswith(
+                tuple(f"{driver}." for driver in _DRIVER_MODULES)
+            ):
+                return True
+    return False
+
+
+def _constructs_store(tree: ast.AST) -> bool:
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = None
+        if isinstance(func, ast.Name):
+            name = func.id
+        elif isinstance(func, ast.Attribute):
+            name = func.attr
+        if name in _STORE_CONSTRUCTORS:
+            return True
+    return False
+
+
+def _accesses_store(path: Path) -> bool:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    return _imports_driver(tree) or _constructs_store(tree)
+
+
+def _control_plane_files() -> list[Path]:
+    return sorted(CONTROL_PLANE.rglob("*.py"))
+
+
+def test_only_control_plane_data_layer_and_migration_adapters_access_stores() -> None:
+    assert CONTROL_PLANE.is_dir()
+    violations: list[str] = []
+    for path in _control_plane_files():
+        rel = str(path.relative_to(REPO_ROOT))
+        if rel in DATA_LAYER_AND_MIGRATION_ALLOWLIST:
+            continue
+        if _accesses_store(path):
+            violations.append(rel)
+
+    assert not violations, (
+        "Control-plane modules accessing a store outside the data-layer/"
+        "migration adapter allowlist (they must go through the authenticated "
+        "API client instead):\n" + "\n".join(f"  {v}" for v in sorted(violations))
+    )
+
+
+def test_client_surface_is_store_free() -> None:
+    """The client, its CLI, routing, and entry point never touch a store."""
+    for rel in sorted(_CLIENT_SURFACE):
+        path = REPO_ROOT / rel
+        assert path.exists(), f"expected client-surface module missing: {rel}"
+        assert not _accesses_store(path), (
+            f"{rel} imports a database driver or constructs a store; the API-only "
+            "client surface must reach authority exclusively over the API."
+        )
+
+
+def test_store_boundary_allowlist_is_accurate() -> None:
+    """Every allowlisted module still exists and still accesses a store.
+
+    A stale allowlist entry (deleted, or migrated off store access) would hide a
+    real regression, so keep the allowlist minimal and truthful.
+    """
+    stale: list[str] = []
+    for rel in DATA_LAYER_AND_MIGRATION_ALLOWLIST:
+        path = REPO_ROOT / rel
+        if not path.exists() or not _accesses_store(path):
+            stale.append(rel)
+    assert not stale, (
+        "Stale store-boundary allowlist entries (remove or fix):\n"
+        + "\n".join(f"  {s}" for s in sorted(stale))
+    )

--- a/tests/builderops/control_plane/test_api_clients.py
+++ b/tests/builderops/control_plane/test_api_clients.py
@@ -19,10 +19,13 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.builderops.control_plane.auth import CredentialRegistry
+import httpx
+
 from app.builderops.control_plane.client import (
     BuilderOpsControlPlaneClient,
     ClientConfig,
     ControlPlaneAuthError,
+    ControlPlaneProtocolError,
     ControlPlaneUnavailableError,
     StaleLeaseError,
 )
@@ -291,3 +294,23 @@ def test_unreachable_service_is_retried_then_fails_closed(tmp_path: Path) -> Non
         client.status()
     # A 5xx is retried (idempotent) up to the bound, never swapped for a store.
     assert attempts["count"] == 3
+
+
+def test_malformed_409_body_raises_instead_of_silently_downgrading(tmp_path: Path) -> None:
+    """H2: a truncated/non-JSON 409 body (e.g. proxy interference) must raise
+    ControlPlaneProtocolError, matching the 2xx path's malformed-response
+    handling, rather than silently returning an empty detail and downgrading
+    what might have been a StaleLeaseError into a generic conflict."""
+
+    class _MalformedTransport(httpx.BaseTransport):
+        def handle_request(self, request: httpx.Request) -> httpx.Response:
+            return httpx.Response(409, content=b"<not json at all>")
+
+    http = httpx.Client(transport=_MalformedTransport(), base_url="http://builderops")
+    client = BuilderOpsControlPlaneClient(
+        ClientConfig(base_url="http://builderops", token="client-token"),
+        http_client=http,
+        max_retries=0,
+    )
+    with pytest.raises(ControlPlaneProtocolError):
+        client.status()

--- a/tests/builderops/control_plane/test_api_clients.py
+++ b/tests/builderops/control_plane/test_api_clients.py
@@ -1,0 +1,293 @@
+"""BCP-04 AC1/AC2: authority commands use the remote API and fail closed.
+
+These contract tests drive the real versioned client against a disposable
+BCP-02 service (an in-memory store behind ``create_app``). They prove that the
+representative MacBook commands cross the authenticated API boundary under one
+authority epoch, and that any transport/auth failure raises a typed error
+without leaving local authority, a SQLite/JSONL/JSON ledger, or a fabricated
+GitHub lease behind.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.builderops.control_plane.auth import CredentialRegistry
+from app.builderops.control_plane.client import (
+    BuilderOpsControlPlaneClient,
+    ClientConfig,
+    ControlPlaneAuthError,
+    ControlPlaneUnavailableError,
+    StaleLeaseError,
+)
+from app.builderops.control_plane.models import (
+    AuthorityObjectResult,
+    Lease,
+    TransactionResult,
+)
+from app.builderops.control_plane.service import create_app
+
+REPO = "RasmusTho/agentic-pkm-mvp"
+CANON = REPO.lower()
+
+
+class InMemoryStore:
+    """Minimal StorePort-shaped fake; records which methods the API reached."""
+
+    def __init__(self) -> None:
+        self.epoch = 1
+        self.calls: list[str] = []
+        self.records: dict[str, AuthorityObjectResult] = {}
+        self._seq = 0
+
+    def readiness(self) -> dict[str, int]:
+        return {"schema_version": 1, "authority_epoch": self.epoch}
+
+    def _next(self) -> int:
+        self._seq += 1
+        return self._seq
+
+    def _lease(self, repository: str, resource_id: str, holder: str) -> Lease:
+        return Lease(
+            repository=repository,
+            resource_id=resource_id,
+            holder=holder,
+            fencing_token=1,
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=90),
+            lease_kind="task",
+        )
+
+    def claim_task(self, **kw):  # type: ignore[no-untyped-def]
+        self.calls.append("claim_task")
+        result = TransactionResult(
+            kw["envelope"].repository, kw["task_id"], "claimed", self._next(), "0/1", None
+        )
+        return result, self._lease(kw["envelope"].repository, kw["task_id"], kw["holder"])
+
+    def heartbeat_lease(self, **kw):  # type: ignore[no-untyped-def]
+        self.calls.append("heartbeat_lease")
+        result = TransactionResult(
+            kw["envelope"].repository, kw["lease"].resource_id, "heartbeat", self._next(), "0/2", None
+        )
+        return result, kw["lease"]
+
+    def complete_task(self, **kw):  # type: ignore[no-untyped-def]
+        self.calls.append("complete_task")
+        return TransactionResult(
+            kw["envelope"].repository, kw["lease"].resource_id, "completed", self._next(), "0/3", None
+        )
+
+    def commit_record(self, **kw):  # type: ignore[no-untyped-def]
+        self.calls.append(f"commit_record:{kw['record_type']}")
+        result = AuthorityObjectResult(
+            kw["envelope"].repository, "record", kw["record_id"], kw["state"], self._next(), "0/4"
+        )
+        self.records[kw["record_id"]] = result
+        return result
+
+    def get_record(self, repository: str, record_id: str):  # type: ignore[no-untyped-def]
+        self.calls.append("get_record")
+        result = self.records[record_id]
+        return {
+            "repository": result.repository,
+            "object_id": result.object_id,
+            "receipt_sequence": result.receipt_sequence,
+            "state": result.state,
+        }
+
+
+def _registry(tmp_path: Path) -> CredentialRegistry:
+    secret = tmp_path / "client.secret"
+    secret.write_text("client-token\n", encoding="utf-8")
+    manifest = tmp_path / "credentials.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "credentials": [
+                    {
+                        "id": "client",
+                        "principal": "client:macbook",
+                        "secret_ref": "host-secret:client",
+                        "secret_file": str(secret),
+                        "scopes": [
+                            "status:read",
+                            "records:write",
+                            "inquiries:write",
+                            "tasks:write",
+                            "receipts:read",
+                        ],
+                        "repositories": [REPO],
+                        "rotation_generation": 1,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    return CredentialRegistry(manifest)
+
+
+def _client(store: InMemoryStore, registry: CredentialRegistry, token: str = "client-token"):
+    transport = TestClient(create_app(store=store, credentials=registry))
+    config = ClientConfig(base_url="http://builderops", token=token)
+    return BuilderOpsControlPlaneClient(config, http_client=transport, max_retries=0)
+
+
+def _envelope() -> dict[str, object]:
+    return {
+        "repository": REPO,
+        "scope": "issue:3791",
+        "stack": "builderops-control-plane",
+        "source_refs": ["github:issue:3791"],
+    }
+
+
+def test_all_authority_commands_use_remote_api(tmp_path: Path) -> None:
+    store = InMemoryStore()
+    client = _client(store, _registry(tmp_path))
+
+    # The client establishes exactly one authority epoch up front.
+    assert client.authority_epoch == 1
+
+    record = client.commit_record(
+        envelope=_envelope(),
+        record_id="learning-3791",
+        record_type="LearningSignal",
+        state="active",
+        payload={"summary": "cutover"},
+        idempotency_key="record-learning-3791",
+    )
+    inquiry = client.create_inquiry(
+        envelope=_envelope(),
+        inquiry_id="inquiry-3791",
+        state="captured",
+        payload={"question": "which route"},
+        idempotency_key="inquiry-3791",
+    )
+    claim = client.claim_task(
+        envelope=_envelope(),
+        task_id="issue-3791",
+        idempotency_key="claim-issue-3791",
+    )
+    heartbeat = client.heartbeat_task(
+        envelope=_envelope(),
+        lease=claim["lease"],
+        idempotency_key="heartbeat-issue-3791",
+    )
+    complete = client.complete_task(
+        envelope=_envelope(),
+        lease=claim["lease"],
+        idempotency_key="complete-issue-3791",
+    )
+    receipt = client.get_receipt(
+        repository=REPO, object_kind="records", object_id="learning-3791"
+    )
+
+    # Every representative command actually crossed the API to the store.
+    assert store.calls == [
+        "commit_record:LearningSignal",
+        "commit_record:ModelInquiry",
+        "claim_task",
+        "heartbeat_lease",
+        "complete_task",
+        "get_record",
+    ]
+    assert record["repository"] == CANON
+    assert inquiry["object_id"] == "inquiry-3791"
+    assert claim["lease"]["fencing_token"] == 1
+    assert heartbeat["result"]["state"] == "heartbeat"
+    assert complete["result"]["state"] == "completed"
+    assert receipt["receipt_sequence"] == record["receipt_sequence"]
+
+    # One authority epoch: after a recovery bumps the server epoch, the client
+    # pinned to the prior epoch is fenced rather than mutating a new authority.
+    store.epoch = 2
+    with pytest.raises(StaleLeaseError):
+        client.commit_record(
+            envelope=_envelope(),
+            record_id="learning-3791-b",
+            record_type="LearningSignal",
+            state="active",
+            payload={},
+            idempotency_key="record-learning-3791-b",
+        )
+
+
+def test_all_authority_commands_require_authentication(tmp_path: Path) -> None:
+    store = InMemoryStore()
+    client = _client(store, _registry(tmp_path), token="wrong-token")
+    with pytest.raises(ControlPlaneAuthError):
+        client.status()
+    assert store.calls == []
+
+
+def test_client_failure_never_creates_local_authority_fallback(tmp_path: Path) -> None:
+    # Run inside an isolated working directory so any accidental local-authority
+    # file would be observable.
+    workdir = tmp_path / "cwd"
+    workdir.mkdir()
+    prior = os.getcwd()
+    os.chdir(workdir)
+    try:
+        # 1) Service unreachable -> typed unavailable error, no fallback.
+        unreachable = BuilderOpsControlPlaneClient(
+            ClientConfig(base_url="http://127.0.0.1:1", token="client-token"),
+            max_retries=0,
+        )
+        with pytest.raises(ControlPlaneUnavailableError):
+            unreachable.claim_lease(
+                envelope=_envelope(),
+                resource_id="resource-3791",
+                idempotency_key="claim-resource-3791",
+            )
+
+        # 2) Credential rejected -> typed auth error, no fallback.
+        store = InMemoryStore()
+        rejected = _client(store, _registry(tmp_path), token="not-the-token")
+        with pytest.raises(ControlPlaneAuthError):
+            rejected.commit_record(
+                envelope=_envelope(),
+                record_id="learning-3791",
+                record_type="LearningSignal",
+                state="active",
+                payload={},
+                idempotency_key="record-learning-3791",
+            )
+        assert store.calls == []
+    finally:
+        os.chdir(prior)
+
+    # No SQLite/JSONL/JSON authority, or any file at all, was created locally.
+    created = [p.name for p in workdir.rglob("*") if p.is_file()]
+    assert created == [], f"client created local authority artifacts: {created}"
+
+    # The client holds no store/database/session handle to fall back onto.
+    assert not hasattr(unreachable, "store")
+    assert not hasattr(unreachable, "db")
+
+
+def test_unreachable_service_is_retried_then_fails_closed(tmp_path: Path) -> None:
+    attempts = {"count": 0}
+
+    class Flaky(InMemoryStore):
+        def readiness(self) -> dict[str, int]:  # type: ignore[override]
+            attempts["count"] += 1
+            raise RuntimeError("database down")
+
+    store = Flaky()
+    transport = TestClient(create_app(store=store, credentials=_registry(tmp_path)))
+    client = BuilderOpsControlPlaneClient(
+        ClientConfig(base_url="http://builderops", token="client-token"),
+        http_client=transport,
+        max_retries=2,
+    )
+    with pytest.raises(ControlPlaneUnavailableError):
+        client.status()
+    # A 5xx is retried (idempotent) up to the bound, never swapped for a store.
+    assert attempts["count"] == 3

--- a/tests/builderops/control_plane/test_client_cli.py
+++ b/tests/builderops/control_plane/test_client_cli.py
@@ -206,7 +206,7 @@ def test_missing_manifest_for_addressed_repo_fails_closed(tmp_path: Path, factor
             "implementation",
             "task-claim",
             "--repository",
-            "RasmusTho/bifrost",  # no manifest loaded for this repo
+            "RasmusTho/example-second-repo",  # no manifest loaded for this repo
             "--scope",
             "issue:1",
             "--stack",

--- a/tests/builderops/control_plane/test_client_cli.py
+++ b/tests/builderops/control_plane/test_client_cli.py
@@ -1,0 +1,322 @@
+"""BCP-04 S1/H1: the client CLI actually engages delivery-manifest routing on
+a real dispatch path, and every RepoRef/routing failure is caught fail-closed.
+
+These tests drive ``app.builderops.control_plane.client_cli.main()`` end to
+end (argument parsing, route resolution, TTL-policy application, dispatch),
+injecting a fake client so no network call is made. This is the "integration
+test proving [routing] through THAT path, not just the standalone registry
+test" requested by the issue #3791 review (finding S1).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from app.builderops.control_plane.client import ClientConfig
+from app.builderops.control_plane.client_cli import main
+
+
+class _RecordingClient:
+    """Fake client capturing every call main() makes, no network involved."""
+
+    def __init__(self, config: ClientConfig) -> None:
+        self.config = config
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.closed = False
+
+    def status(self) -> dict[str, Any]:
+        self.calls.append(("status", {}))
+        return {"authority_epoch": 1, "schema_version": 1}
+
+    def claim_task(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("claim_task", kwargs))
+        return {
+            "result": {"state": "claimed"},
+            "lease": {
+                "repository": kwargs["envelope"]["repository"],
+                "resource_id": kwargs["task_id"],
+                "holder": "client:macbook",
+                "fencing_token": 1,
+                "expires_at": "2026-07-17T00:00:00+00:00",
+                "lease_kind": "task",
+            },
+        }
+
+    def claim_lease(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("claim_lease", kwargs))
+        return {"result": {"state": "lease.claimed"}, "lease": {}}
+
+    def commit_record(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(("commit_record", kwargs))
+        return {"object_id": kwargs["record_id"], "state": kwargs["state"]}
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture
+def factory():
+    created: list[_RecordingClient] = []
+
+    def _factory(config: ClientConfig) -> _RecordingClient:
+        client = _RecordingClient(config)
+        created.append(client)
+        return client
+
+    _factory.created = created  # type: ignore[attr-defined]
+    return _factory
+
+
+@pytest.fixture(autouse=True)
+def _api_env(monkeypatch):
+    monkeypatch.setenv("BUILDEROPS_API_URL", "https://example.invalid:1")
+    monkeypatch.setenv("BUILDEROPS_API_TOKEN", "test-token")
+    monkeypatch.delenv("BUILDEROPS_API_TOKEN_FILE", raising=False)
+
+
+def _manifest_dir(tmp_path: Path, *, ttl_seconds: int = 1800) -> Path:
+    directory = tmp_path / "manifests"
+    directory.mkdir()
+    (directory / "agentic-pkm-mvp.json").write_text(
+        json.dumps(
+            {
+                "repository": "RasmusTho/agentic-pkm-mvp",
+                "routes": [
+                    {
+                        "stack": "builderops-control-plane",
+                        "task_class": "implementation",
+                        "policy": {"ttl_seconds": ttl_seconds, "tcd_route": "sonnet-high"},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return directory
+
+
+def test_delivery_manifest_routing_is_engaged_through_real_cli_dispatch(
+    tmp_path: Path, factory, capsys
+) -> None:
+    """Routing is not just a standalone registry test: the real CLI dispatch
+    path loads the manifest, resolves the route, and its policy actually
+    changes the request the client transport receives (ttl_seconds)."""
+    manifest_dir = _manifest_dir(tmp_path, ttl_seconds=1800)
+    exit_code = main(
+        [
+            "--delivery-manifest-dir",
+            str(manifest_dir),
+            "--task-class",
+            "implementation",
+            "task-claim",
+            "--repository",
+            "RasmusTho/agentic-pkm-mvp",
+            "--scope",
+            "issue:3791",
+            "--stack",
+            "builderops-control-plane",
+            "--source-ref",
+            "github:issue:3791",
+            "--task-id",
+            "issue-3791",
+            "--idempotency-key",
+            "claim-1",
+        ],
+        client_factory=factory,
+    )
+    assert exit_code == 0
+    [client] = factory.created
+    assert client.calls[0][0] == "claim_task"
+    # The route's advisory ttl_seconds reached the actual client call.
+    assert client.calls[0][1]["ttl_seconds"] == 1800
+    assert client.closed is True
+    stderr = capsys.readouterr().err
+    assert "resolved delivery route" in stderr
+    assert "rasmustho/agentic-pkm-mvp" in stderr
+
+
+def test_explicit_ttl_flag_wins_over_manifest_policy(tmp_path: Path, factory) -> None:
+    manifest_dir = _manifest_dir(tmp_path, ttl_seconds=1800)
+    exit_code = main(
+        [
+            "--delivery-manifest-dir",
+            str(manifest_dir),
+            "--task-class",
+            "implementation",
+            "task-claim",
+            "--repository",
+            "RasmusTho/agentic-pkm-mvp",
+            "--scope",
+            "issue:3791",
+            "--stack",
+            "builderops-control-plane",
+            "--source-ref",
+            "github:issue:3791",
+            "--task-id",
+            "issue-3791",
+            "--idempotency-key",
+            "claim-1",
+            "--ttl-seconds",
+            "60",
+        ],
+        client_factory=factory,
+    )
+    assert exit_code == 0
+    [client] = factory.created
+    assert client.calls[0][1]["ttl_seconds"] == 60
+
+
+def test_no_manifest_dir_skips_routing_and_uses_hardcoded_default(factory) -> None:
+    """Routing is opt-in: omitting --delivery-manifest-dir must not require a
+    manifest to exist anywhere, and the historical hardcoded default applies."""
+    exit_code = main(
+        [
+            "task-claim",
+            "--repository",
+            "RasmusTho/agentic-pkm-mvp",
+            "--scope",
+            "issue:3791",
+            "--stack",
+            "builderops-control-plane",
+            "--source-ref",
+            "github:issue:3791",
+            "--task-id",
+            "issue-3791",
+            "--idempotency-key",
+            "claim-1",
+        ],
+        client_factory=factory,
+    )
+    assert exit_code == 0
+    [client] = factory.created
+    assert client.calls[0][1]["ttl_seconds"] == 5400
+
+
+def test_missing_manifest_for_addressed_repo_fails_closed(tmp_path: Path, factory) -> None:
+    manifest_dir = _manifest_dir(tmp_path)
+    exit_code = main(
+        [
+            "--delivery-manifest-dir",
+            str(manifest_dir),
+            "--task-class",
+            "implementation",
+            "task-claim",
+            "--repository",
+            "RasmusTho/bifrost",  # no manifest loaded for this repo
+            "--scope",
+            "issue:1",
+            "--stack",
+            "builderops-control-plane",
+            "--source-ref",
+            "x",
+            "--task-id",
+            "t1",
+            "--idempotency-key",
+            "k1",
+        ],
+        client_factory=factory,
+    )
+    assert exit_code == 3
+    assert factory.created == []  # no client constructed; nothing was dispatched
+
+
+def test_ambiguous_task_class_fails_closed(tmp_path: Path, factory) -> None:
+    manifest_dir = _manifest_dir(tmp_path)
+    exit_code = main(
+        [
+            "--delivery-manifest-dir",
+            str(manifest_dir),
+            "--task-class",
+            "verification",  # not a route this manifest declares
+            "task-claim",
+            "--repository",
+            "RasmusTho/agentic-pkm-mvp",
+            "--scope",
+            "issue:1",
+            "--stack",
+            "builderops-control-plane",
+            "--source-ref",
+            "x",
+            "--task-id",
+            "t1",
+            "--idempotency-key",
+            "k1",
+        ],
+        client_factory=factory,
+    )
+    assert exit_code == 3
+    assert factory.created == []
+
+
+def test_manifest_dir_without_task_class_is_a_usage_error(tmp_path: Path, factory) -> None:
+    manifest_dir = _manifest_dir(tmp_path)
+    exit_code = main(
+        [
+            "--delivery-manifest-dir",
+            str(manifest_dir),
+            "task-claim",
+            "--repository",
+            "RasmusTho/agentic-pkm-mvp",
+            "--scope",
+            "issue:1",
+            "--stack",
+            "builderops-control-plane",
+            "--source-ref",
+            "x",
+            "--task-id",
+            "t1",
+            "--idempotency-key",
+            "k1",
+        ],
+        client_factory=factory,
+    )
+    assert exit_code == 2
+    assert factory.created == []
+
+
+def test_malformed_repository_fails_closed_not_uncaught(factory) -> None:
+    """H1 regression test: RepoRefError from _envelope()'s RepoRef.parse() must
+    be caught as a fail-closed CLI error (exit 3), never an uncaught traceback."""
+    exit_code = main(
+        [
+            "record",
+            "--repository",
+            "not-a-valid-repo",
+            "--scope",
+            "issue:1",
+            "--stack",
+            "s",
+            "--source-ref",
+            "x",
+            "--record-id",
+            "r1",
+            "--record-type",
+            "LearningSignal",
+            "--state",
+            "active",
+            "--idempotency-key",
+            "k1",
+        ],
+        client_factory=factory,
+    )
+    assert exit_code == 3
+    [client] = factory.created
+    assert client.calls == []
+    assert client.closed is True
+
+
+def test_routing_not_engaged_for_read_only_commands(tmp_path: Path, factory) -> None:
+    """--delivery-manifest-dir is a no-op for non-routable commands (status,
+    receipt) rather than an error, since they carry no (stack, task-class)."""
+    manifest_dir = _manifest_dir(tmp_path)
+    exit_code = main(
+        ["--delivery-manifest-dir", str(manifest_dir), "status"],
+        client_factory=factory,
+    )
+    assert exit_code == 0
+    [client] = factory.created
+    assert client.calls == [("status", {})]

--- a/tests/builderops/control_plane/test_delivery_manifest_routing.py
+++ b/tests/builderops/control_plane/test_delivery_manifest_routing.py
@@ -24,7 +24,7 @@ from app.builderops.control_plane.routing import (
 )
 
 REPO_A = "RasmusTho/agentic-pkm-mvp"
-REPO_B = "RasmusTho/bifrost"
+REPO_B = "RasmusTho/example-second-repo"
 
 
 def _doc(repository: str, policy_tag: str) -> dict[str, object]:

--- a/tests/builderops/control_plane/test_delivery_manifest_routing.py
+++ b/tests/builderops/control_plane/test_delivery_manifest_routing.py
@@ -1,0 +1,118 @@
+"""BCP-04 AC6: delivery-manifest routing is explicit and non-transitive.
+
+The client loads the addressed repo's delivery manifest and routes by
+``(RepoRef, stack, task-class)``. A manifest resolved for one repository is
+never reused or inferred for another, even when the stack and task class match;
+missing or ambiguous manifests and implicit (CWD-derived) repository authority
+fail closed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.builderops.control_plane.routing import (
+    DeliveryManifestRegistry,
+    ManifestError,
+    ManifestNotFoundError,
+    RepoRef,
+    RepoRefError,
+    RouteResolutionError,
+)
+
+REPO_A = "RasmusTho/agentic-pkm-mvp"
+REPO_B = "RasmusTho/bifrost"
+
+
+def _doc(repository: str, policy_tag: str) -> dict[str, object]:
+    return {
+        "repository": repository,
+        "routes": [
+            {
+                "stack": "builderops-control-plane",
+                "task_class": "implementation",
+                "policy": {"tcd_route": policy_tag, "model_family": "sonnet"},
+            }
+        ],
+    }
+
+
+def test_repo_stack_task_routing_is_explicit_and_non_transitive() -> None:
+    registry = DeliveryManifestRegistry.from_documents(
+        [_doc(REPO_A, "route-a"), _doc(REPO_B, "route-b")]
+    )
+    repo_a = RepoRef.parse(REPO_A)
+    repo_b = RepoRef.parse(REPO_B)
+
+    route_a = registry.resolve_route(repo_a, "builderops-control-plane", "implementation")
+    route_b = registry.resolve_route(repo_b, "builderops-control-plane", "implementation")
+
+    # Each repo resolves from its OWN manifest even though the stack and
+    # task-class are identical: routing is keyed by the full RepoRef triple.
+    assert route_a.repository == repo_a.canonical
+    assert route_b.repository == repo_b.canonical
+    assert route_a.policy["tcd_route"] == "route-a"
+    assert route_b.policy["tcd_route"] == "route-b"
+    assert route_a.repository != route_b.repository
+
+    # Non-transitive: a repo with no loaded manifest never borrows another
+    # repo's defaults, even when the requested stack/task-class exists elsewhere.
+    repo_c = RepoRef.parse("RasmusTho/heimdal")
+    with pytest.raises(ManifestNotFoundError):
+        registry.resolve_route(repo_c, "builderops-control-plane", "implementation")
+
+
+def test_only_repo_a_manifest_never_serves_repo_b() -> None:
+    registry = DeliveryManifestRegistry.from_documents([_doc(REPO_A, "route-a")])
+    # Repo A resolves; repo B (identical stack/task-class, no manifest) fails closed.
+    assert registry.resolve_route(
+        RepoRef.parse(REPO_A), "builderops-control-plane", "implementation"
+    )
+    with pytest.raises(ManifestNotFoundError):
+        registry.resolve_route(
+            RepoRef.parse(REPO_B), "builderops-control-plane", "implementation"
+        )
+
+
+def test_missing_route_within_a_manifest_fails_closed() -> None:
+    registry = DeliveryManifestRegistry.from_documents([_doc(REPO_A, "route-a")])
+    with pytest.raises(RouteResolutionError):
+        registry.resolve_route(
+            RepoRef.parse(REPO_A), "builderops-control-plane", "verification"
+        )
+
+
+def test_ambiguous_manifest_fails_closed() -> None:
+    ambiguous = {
+        "repository": REPO_A,
+        "routes": [
+            {"stack": "s1", "task_class": "implementation", "policy": {"a": 1}},
+            {"stack": "s1", "task_class": "implementation", "policy": {"a": 2}},
+        ],
+    }
+    with pytest.raises(ManifestError):
+        DeliveryManifestRegistry.from_documents([ambiguous])
+
+
+def test_duplicate_repo_manifests_fail_closed() -> None:
+    with pytest.raises(ManifestError):
+        DeliveryManifestRegistry.from_documents([_doc(REPO_A, "x"), _doc(REPO_A, "y")])
+
+
+def test_repo_ref_requires_explicit_unambiguous_reference() -> None:
+    # No CWD/git inference: a missing or partial reference fails closed.
+    for bad in (None, "", "   ", "agentic-pkm-mvp", "owner/", "/name", "a/b/c"):
+        with pytest.raises(RepoRefError):
+            RepoRef.parse(bad)  # type: ignore[arg-type]
+
+
+def test_registry_from_directory_round_trip(tmp_path: Path) -> None:
+    (tmp_path / "repo-a.json").write_text(json.dumps(_doc(REPO_A, "route-a")), encoding="utf-8")
+    registry = DeliveryManifestRegistry.from_directory(tmp_path)
+    route = registry.resolve_route(
+        RepoRef.parse(REPO_A), "builderops-control-plane", "implementation"
+    )
+    assert route.policy["tcd_route"] == "route-a"

--- a/tests/builderops/control_plane/test_service_auth.py
+++ b/tests/builderops/control_plane/test_service_auth.py
@@ -691,6 +691,71 @@ def test_fencing_token_key_in_free_form_payload_is_not_exempt(tmp_path: Path) ->
     assert store.last_actor is None
 
 
+def test_fencing_token_nested_at_any_depth_with_int_value_is_still_rejected(
+    tmp_path: Path,
+) -> None:
+    """Round-2 review finding: the structural exemption's path check must
+    inspect the FULL ancestor chain from the request root, not just the
+    immediate parent key. A "lease" object nested at arbitrary depth inside
+    free-form payload/request content must not qualify for the exemption even
+    when its fencing_token value IS a genuine int — proving the path check
+    itself is load-bearing, independent of the value-type gate (which would
+    otherwise be the only thing stopping a hypothetical future numeric
+    secret from smuggling through this route)."""
+    registry = _registry(tmp_path)
+
+    # Empirically reproduces the reviewer's exact bypass: a "lease" key
+    # nested four levels deep inside a free-form payload field, carrying an
+    # int fencing_token. Only the full-path check (not an immediate-parent
+    # check) can reject this, since the immediate parent IS literally "lease".
+    deeply_nested_int = {
+        "envelope": {
+            "repository": "RasmusTho/agentic-pkm-mvp",
+            "scope": "issue:3790",
+            "stack": "builderops-control-plane",
+            "source_refs": ["github:issue:3790"],
+        },
+        "record_id": "learning-3790",
+        "record_type": "LearningSignal",
+        "state": "active",
+        "payload": {"foo": {"bar": {"lease": {"fencing_token": 123}}}},
+        "idempotency_key": "record-deeply-nested-lease",
+    }
+    with pytest.raises(ValueError):
+        _assert_durable_payload_safe(deeply_nested_int, registry)
+
+    # A single hop of nesting (the original, narrower gap this exemption once
+    # had) must also be rejected: the full path is
+    # ("payload", "lease", "fencing_token"), not ("lease", "fencing_token").
+    one_hop_nested_int = {
+        **deeply_nested_int,
+        "payload": {"lease": {"fencing_token": 999}},
+        "idempotency_key": "record-one-hop-nested-lease",
+    }
+    with pytest.raises(ValueError):
+        _assert_durable_payload_safe(one_hop_nested_int, registry)
+
+    # Same check through the real HTTP route, confirming the API never
+    # persists it either.
+    store = _Store()
+    client = TestClient(create_app(store=store, credentials=registry))  # type: ignore[arg-type]
+    headers = {"Authorization": "Bearer client-token"}
+    response = client.post(
+        "/v1/records",
+        headers=headers,
+        json={
+            "envelope": deeply_nested_int["envelope"],
+            "record_id": "learning-3790",
+            "record_type": "LearningSignal",
+            "state": "active",
+            "payload": {"foo": {"bar": {"lease": {"fencing_token": 123}}}},
+            "idempotency_key": "record-deeply-nested-lease-http",
+        },
+    )
+    assert response.status_code == 400
+    assert store.last_actor is None
+
+
 def test_fencing_token_exemption_still_allows_the_legitimate_lease_field(
     tmp_path: Path,
 ) -> None:

--- a/tests/builderops/control_plane/test_service_auth.py
+++ b/tests/builderops/control_plane/test_service_auth.py
@@ -459,3 +459,69 @@ def test_raw_credentials_are_rejected_from_every_client_controlled_durable_field
 
     assert store.claims == {}
     assert store.last_actor is None
+
+
+def _scoped_registry(tmp_path: Path) -> CredentialRegistry:
+    """A normal MacBook client: repo-scoped writes, no executor/outbox scope."""
+    secret = tmp_path / "normal.secret"
+    secret.write_text("normal-token\n", encoding="utf-8")
+    manifest = tmp_path / "scoped-credentials.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "credentials": [
+                    {
+                        "id": "normal-client",
+                        "principal": "client:macbook",
+                        "secret_ref": "host-secret:normal-client",
+                        "secret_file": str(secret),
+                        "scopes": ["records:write", "leases:write", "tasks:write"],
+                        "repositories": ["RasmusTho/agentic-pkm-mvp"],
+                        "rotation_generation": 1,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    return CredentialRegistry(manifest)
+
+
+def test_normal_client_cannot_use_executor_or_cross_repo_scope(tmp_path: Path) -> None:
+    store = _Store()
+    registry = _scoped_registry(tmp_path)
+    health = HealthService(store, registry, _Operational())  # type: ignore[arg-type]
+    client = TestClient(create_app(store=store, credentials=registry, health=health))  # type: ignore[arg-type]
+    headers = {"Authorization": "Bearer normal-token"}
+
+    # Positive control: the credential works for its own repository.
+    granted = client.post(
+        "/v1/records", headers=headers, json=_record_payload({"summary": "ok"})
+    )
+    assert granted.status_code == 200
+    assert store.last_actor == "client:macbook"
+
+    # A normal client credential holds no executor/outbox scope: the privileged
+    # executor operation is forbidden (403), not silently downgraded.
+    executor = client.post(
+        "/v1/executor/outbox/claim",
+        headers=headers,
+        json={
+            "envelope": _lease_payload()["envelope"],
+            "operation_key": "outbox-3790",
+            "worker_id": "worker:demerzel",
+            "claim_ttl_seconds": 300,
+        },
+    )
+    assert executor.status_code == 403
+
+    # A credential scoped to one repository cannot address another repository;
+    # the cross-repo write is rejected before it can reach the store.
+    cross_repo = _record_payload({"summary": "ok"})
+    cross_repo["envelope"] = {
+        **_lease_payload()["envelope"],
+        "repository": "OtherOwner/other-repo",
+    }
+    cross_repo["idempotency_key"] = "record-cross-repo"
+    rejected = client.post("/v1/records", headers=headers, json=cross_repo)
+    assert rejected.status_code == 403

--- a/tests/builderops/control_plane/test_service_auth.py
+++ b/tests/builderops/control_plane/test_service_auth.py
@@ -509,7 +509,7 @@ def test_normal_client_cannot_use_executor_or_cross_repo_scope(tmp_path: Path) -
         json={
             "envelope": _lease_payload()["envelope"],
             "operation_key": "outbox-3790",
-            "worker_id": "worker:demerzel",
+            "worker_id": "worker:test-executor",
             "claim_ttl_seconds": 300,
         },
     )

--- a/tests/builderops/control_plane/test_service_auth.py
+++ b/tests/builderops/control_plane/test_service_auth.py
@@ -14,7 +14,11 @@ from app.builderops.control_plane.auth import (
     CredentialRegistry,
 )
 from app.builderops.control_plane.health import HealthService, OperationalStatus
-from app.builderops.control_plane.service import create_app, database_environment
+from app.builderops.control_plane.service import (
+    _assert_durable_payload_safe,
+    create_app,
+    database_environment,
+)
 
 
 class _Operational:
@@ -96,6 +100,7 @@ def _registry(tmp_path: Path) -> CredentialRegistry:
                             "leases:write",
                             "records:write",
                         ],
+                        "repositories": ["RasmusTho/agentic-pkm-mvp"],
                         "rotation_generation": 1,
                     },
                     {
@@ -305,6 +310,7 @@ def test_verifier_only_registered_bearer_cannot_be_embedded_in_durable_text(
                         "verifier_sha256": hashlib.sha256(secret.encode()).hexdigest(),
                         "token_length": len(secret),
                         "scopes": ["records:write"],
+                        "repositories": ["RasmusTho/agentic-pkm-mvp"],
                         "rotation_generation": 1,
                     }
                 ]
@@ -340,6 +346,7 @@ def test_verifier_only_registered_bearer_cannot_be_a_nested_mapping_key(
                         "verifier_sha256": hashlib.sha256(secret.encode()).hexdigest(),
                         "token_length": len(secret),
                         "scopes": ["records:write", "leases:write"],
+                        "repositories": ["RasmusTho/agentic-pkm-mvp"],
                         "rotation_generation": 1,
                     }
                 ]
@@ -423,38 +430,44 @@ def test_raw_credentials_are_rejected_from_every_client_controlled_durable_field
     client = TestClient(create_app(store=store, credentials=registry, health=health))  # type: ignore[arg-type]
     headers = {"Authorization": "Bearer client-token"}
 
+    # The `repository` mutation is a distinct case: the credential is scoped to
+    # exactly "RasmusTho/agentic-pkm-mvp" (see `_registry()`), so redirecting
+    # the envelope at the canary-shaped repository string is caught by the
+    # earlier, more specific repo-scope gate (403) before the request ever
+    # reaches the durable-payload scanner. Every other field is untouched by
+    # repo-scope routing and is still caught by the durable-payload scanner (400).
     lease_mutations = (
-        lambda body: body["envelope"].update(repository=canary),
-        lambda body: body["envelope"].update(scope=canary),
-        lambda body: body["envelope"].update(stack=canary),
-        lambda body: body["envelope"].update(source_refs=[canary]),
-        lambda body: body.update(resource_id=canary),
-        lambda body: body.update(idempotency_key=canary),
-        lambda body: body.update(request={"command": canary}),
+        (lambda body: body["envelope"].update(repository=canary), 403),
+        (lambda body: body["envelope"].update(scope=canary), 400),
+        (lambda body: body["envelope"].update(stack=canary), 400),
+        (lambda body: body["envelope"].update(source_refs=[canary]), 400),
+        (lambda body: body.update(resource_id=canary), 400),
+        (lambda body: body.update(idempotency_key=canary), 400),
+        (lambda body: body.update(request={"command": canary}), 400),
     )
-    for mutate in lease_mutations:
+    for mutate, expected_status in lease_mutations:
         body = _lease_payload()
         mutate(body)
         response = client.post("/v1/leases/claim", headers=headers, json=body)
-        assert response.status_code == 400
+        assert response.status_code == expected_status
         assert canary not in response.text
 
     record_mutations = (
-        lambda body: body["envelope"].update(repository=canary),
-        lambda body: body["envelope"].update(scope=canary),
-        lambda body: body["envelope"].update(stack=canary),
-        lambda body: body["envelope"].update(source_refs=[canary]),
-        lambda body: body.update(record_id=canary),
-        lambda body: body.update(record_type=canary),
-        lambda body: body.update(state=canary),
-        lambda body: body.update(payload={"summary": canary}),
-        lambda body: body.update(idempotency_key=canary),
+        (lambda body: body["envelope"].update(repository=canary), 403),
+        (lambda body: body["envelope"].update(scope=canary), 400),
+        (lambda body: body["envelope"].update(stack=canary), 400),
+        (lambda body: body["envelope"].update(source_refs=[canary]), 400),
+        (lambda body: body.update(record_id=canary), 400),
+        (lambda body: body.update(record_type=canary), 400),
+        (lambda body: body.update(state=canary), 400),
+        (lambda body: body.update(payload={"summary": canary}), 400),
+        (lambda body: body.update(idempotency_key=canary), 400),
     )
-    for mutate in record_mutations:
+    for mutate, expected_status in record_mutations:
         body = _record_payload({"summary": "safe"})
         mutate(body)
         response = client.post("/v1/records", headers=headers, json=body)
-        assert response.status_code == 400
+        assert response.status_code == expected_status
         assert canary not in response.text
 
     assert store.claims == {}
@@ -525,3 +538,184 @@ def test_normal_client_cannot_use_executor_or_cross_repo_scope(tmp_path: Path) -
     cross_repo["idempotency_key"] = "record-cross-repo"
     rejected = client.post("/v1/records", headers=headers, json=cross_repo)
     assert rejected.status_code == 403
+
+
+def _unscoped_registry(tmp_path: Path) -> CredentialRegistry:
+    """A credential with no ``repositories`` key and no ``all_repositories`` opt-in."""
+    secret = tmp_path / "unscoped.secret"
+    secret.write_text("unscoped-token\n", encoding="utf-8")
+    manifest = tmp_path / "unscoped-credentials.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "credentials": [
+                    {
+                        "id": "unscoped-client",
+                        "principal": "client:unscoped",
+                        "secret_ref": "host-secret:unscoped-client",
+                        "secret_file": str(secret),
+                        "scopes": ["records:write", "leases:write"],
+                        "rotation_generation": 1,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    return CredentialRegistry(manifest)
+
+
+def test_credential_with_no_repositories_key_cannot_address_any_repository(
+    tmp_path: Path,
+) -> None:
+    """The default must fail closed: omitting ``repositories`` grants NO repo,
+    not every repo. This is the explicit regression test for the credential
+    fail-open default fixed for issue #3791 (a credential provisioned without
+    listing repos previously had unrestricted cross-repo authority)."""
+    store = _Store()
+    registry = _unscoped_registry(tmp_path)
+    client = TestClient(create_app(store=store, credentials=registry))  # type: ignore[arg-type]
+    headers = {"Authorization": "Bearer unscoped-token"}
+
+    for repository in (
+        "RasmusTho/agentic-pkm-mvp",
+        "RasmusTho/example-second-repo",
+        "OtherOwner/other-repo",
+    ):
+        body = _record_payload({"summary": "ok"})
+        body["envelope"] = {**body["envelope"], "repository": repository}
+        body["idempotency_key"] = f"record-{repository.replace('/', '-')}"
+        response = client.post("/v1/records", headers=headers, json=body)
+        assert response.status_code == 403, (
+            f"credential with no repositories/all_repositories should not "
+            f"address {repository}, got {response.status_code}"
+        )
+    assert store.last_actor is None
+
+
+def test_all_repositories_opt_in_is_explicit_and_distinct_from_empty_list(
+    tmp_path: Path,
+) -> None:
+    """``all_repositories: true`` is a distinct, explicit opt-in (e.g. for the
+    privileged executor); it must never be implied by an absent/empty
+    ``repositories`` list, and combining both fails closed as ambiguous."""
+    secret = tmp_path / "executor.secret"
+    secret.write_text("executor-token\n", encoding="utf-8")
+    manifest = tmp_path / "executor-credentials.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "credentials": [
+                    {
+                        "id": "executor",
+                        "principal": "executor:build-host",
+                        "secret_ref": "host-secret:executor",
+                        "secret_file": str(secret),
+                        "scopes": ["records:write"],
+                        "all_repositories": True,
+                        "rotation_generation": 1,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    store = _Store()
+    client = TestClient(create_app(store=store, credentials=CredentialRegistry(manifest)))  # type: ignore[arg-type]
+    headers = {"Authorization": "Bearer executor-token"}
+
+    for repository in ("RasmusTho/agentic-pkm-mvp", "RasmusTho/example-second-repo"):
+        body = _record_payload({"summary": "ok"})
+        body["envelope"] = {**body["envelope"], "repository": repository}
+        body["idempotency_key"] = f"executor-record-{repository.replace('/', '-')}"
+        response = client.post("/v1/records", headers=headers, json=body)
+        assert response.status_code == 200
+
+    # Combining all_repositories with an explicit repositories list is
+    # ambiguous and must fail closed at manifest-parse time, not silently
+    # pick one interpretation.
+    ambiguous_manifest = tmp_path / "ambiguous-credentials.json"
+    ambiguous_manifest.write_text(
+        json.dumps(
+            {
+                "credentials": [
+                    {
+                        "id": "ambiguous",
+                        "principal": "client:ambiguous",
+                        "secret_ref": "host-secret:ambiguous",
+                        "secret_file": str(secret),
+                        "scopes": ["records:write"],
+                        "all_repositories": True,
+                        "repositories": ["RasmusTho/agentic-pkm-mvp"],
+                        "rotation_generation": 1,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(CredentialConfigurationError):
+        CredentialRegistry(ambiguous_manifest).status()
+
+
+def test_fencing_token_key_in_free_form_payload_is_not_exempt(tmp_path: Path) -> None:
+    """The structural ``fencing_token`` exemption is scoped to ``lease.fencing_token``
+    with an int value; a free-form ``payload``/``request`` field that happens to
+    be named ``fencing_token`` must still be rejected, even carrying a value
+    that would NOT trip the weaker value-content heuristics (no bearer/ghp_/sk-/
+    postgres:// shape, not equal to any registered credential) — proving the
+    key-name-anywhere loophole (issue #3791 review finding C2) is closed."""
+    store = _Store()
+    registry = _registry(tmp_path)
+    client = TestClient(create_app(store=store, credentials=registry))  # type: ignore[arg-type]
+    headers = {"Authorization": "Bearer client-token"}
+
+    plausible_but_unregistered = "foreign-service-opaque-credential-9f8e7d6c5b4a3210"
+
+    # A top-level free-form payload field named "fencing_token" is rejected by
+    # key-name alone (its parent is "payload", not "lease").
+    smuggled = _record_payload({"fencing_token": plausible_but_unregistered})
+    response = client.post("/v1/records", headers=headers, json=smuggled)
+    assert response.status_code == 400
+    assert plausible_but_unregistered not in response.text
+
+    # Nesting an attacker-supplied "lease" key inside free-form payload content
+    # must not resurrect the exemption either: the value is a string, not an
+    # int, so the type gate still rejects it independent of the path match.
+    nested = _record_payload({"lease": {"fencing_token": plausible_but_unregistered}})
+    nested["idempotency_key"] = "record-nested-lease-fencing-token"
+    nested_response = client.post("/v1/records", headers=headers, json=nested)
+    assert nested_response.status_code == 400
+    assert plausible_but_unregistered not in nested_response.text
+
+    assert store.last_actor is None
+
+
+def test_fencing_token_exemption_still_allows_the_legitimate_lease_field(
+    tmp_path: Path,
+) -> None:
+    """Positive control: the real ``lease.fencing_token`` int field (as sent by
+    every lease-carrying request the client issues) is unaffected by the C2
+    narrowing — it is a direct child of a top-level ``lease`` object and its
+    value is a genuine int."""
+    registry = _registry(tmp_path)
+    legitimate_request = {
+        "envelope": {
+            "repository": "RasmusTho/agentic-pkm-mvp",
+            "scope": "issue:3790",
+            "stack": "builderops-control-plane",
+            "source_refs": ["github:issue:3790"],
+        },
+        "lease": {
+            "resource_id": "issue-3790-task",
+            "holder": "client:macbook",
+            "fencing_token": 1,
+            "expires_at": "2026-07-17T19:58:27.710736Z",
+            "lease_kind": "task",
+        },
+        "idempotency_key": "heartbeat-legit",
+        "request": {},
+        "ttl_seconds": 5400,
+    }
+    # Must not raise: the exemption still covers the genuine typed field.
+    _assert_durable_payload_safe(legitimate_request, registry)

--- a/tests/governance/test_builderops_api_only_clients.py
+++ b/tests/governance/test_builderops_api_only_clients.py
@@ -1,0 +1,138 @@
+"""BCP-04 AC3/AC4: production clients are API-only and secret-safe.
+
+AC3 proves the production client CLI/config exposes no direct database path or
+SSH-wrapped store mode while the explicit SQLite migration adapter keeps its
+read-only source path. AC4 proves the repo-local automation wrapper routes
+authority-bearing operations through the authenticated API client and documents
+credential setup without inlining secrets.
+
+The checks are structural (argparse tree, Python AST, comment-stripped shell)
+rather than naive substring scans, so docstrings and error messages that
+*describe the absence* of a direct-store mode are not mistaken for one.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+from pathlib import Path
+
+from app.builderops.control_plane import client, client_cli, selection
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Modules and drivers that must never be used by the API-only client surface.
+_FORBIDDEN_IMPORT_MODULES = ("sqlite3", "psycopg", "subprocess", "paramiko")
+_STORE_CONSTRUCTORS = frozenset({"SqliteBuilderOpsStore", "PostgresBuilderOpsStore"})
+
+# Real-credential-value shapes that must never be inlined in a wrapper or doc.
+# (Environment-variable *names* like BUILDEROPS_API_TOKEN are allowed.)
+_SECRET_VALUE_PATTERNS = (
+    re.compile(r"ghp_[A-Za-z0-9]{10,}"),
+    re.compile(r"github_pat_[A-Za-z0-9_]{10,}"),
+    re.compile(r"\bsk-[A-Za-z0-9]{10,}"),
+    re.compile(r"Bearer\s+[A-Za-z0-9._~+/=-]{12,}"),
+    re.compile(r"bcp-(?:client|db|github|model|recovery)-[A-Za-z0-9._~+/=-]{6,}"),
+)
+
+
+def _iter_actions(parser: argparse.ArgumentParser):
+    yield from parser._actions
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            for sub in action.choices.values():
+                yield from _iter_actions(sub)
+
+
+def _module_tree(module) -> ast.AST:
+    return ast.parse(Path(module.__file__).read_text(encoding="utf-8"))
+
+
+def _imported_modules(tree: ast.AST) -> set[str]:
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module.split(".")[0])
+    return modules
+
+
+def _constructs_store(tree: ast.AST) -> bool:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+            if name in _STORE_CONSTRUCTORS:
+                return True
+    return False
+
+
+def _non_comment_shell_lines(text: str) -> str:
+    """Drop full-line ``#`` comments so a header describing absence is ignored."""
+    kept = [line for line in text.splitlines() if not line.lstrip().startswith("#")]
+    return "\n".join(kept)
+
+
+def test_production_clients_expose_no_direct_store_mode() -> None:
+    parser = client_cli.build_parser()
+
+    # No CLI option anywhere in the parser tree exposes a direct DB path.
+    for action in _iter_actions(parser):
+        assert "--db-path" not in action.option_strings, "client CLI must not expose --db-path"
+        if action.dest:
+            assert action.dest != "db_path", "client CLI must not expose a db_path option"
+
+    # The API-only client surface imports no DB driver / ssh / subprocess module
+    # and constructs no store (structural, so prose about absence is fine).
+    for module in (client, client_cli):
+        tree = _module_tree(module)
+        forbidden = _imported_modules(tree).intersection(_FORBIDDEN_IMPORT_MODULES)
+        assert not forbidden, f"{module.__name__} imports a direct-store/ssh module: {forbidden}"
+        assert not _constructs_store(tree), f"{module.__name__} constructs a store directly"
+
+    # Migration tooling retains an explicit, read-only source path.
+    assert hasattr(selection, "ExplicitSqliteAdapter")
+    selection_source = Path(selection.__file__).read_text(encoding="utf-8")
+    assert "read_only=True" in selection_source, (
+        "the SQLite migration/test adapter must open its source read-only"
+    )
+
+
+def test_skills_and_automations_route_through_authenticated_api() -> None:
+    wrapper = REPO_ROOT / "scripts" / "builderops_api_client.sh"
+    assert wrapper.exists(), "the API-only automation wrapper must exist"
+    text = wrapper.read_text(encoding="utf-8")
+    code = _non_comment_shell_lines(text)
+
+    # Routes through the authenticated API client module, not a local store CLI.
+    assert re.search(r"-m\s+app\.builderops\.control_plane\b", code), (
+        "wrapper must exec the API-only control-plane client module"
+    )
+
+    # Executable shell (comments stripped) exposes no direct-store/SSH mode.
+    for marker in ("--db-path", "db_path", "BUILDEROPS_DB_PATH", "sqlite3"):
+        assert marker.lower() not in code.lower(), f"automation wrapper uses '{marker}'"
+    assert re.search(r"\bssh\b\s+\S+@", code) is None, "wrapper must not SSH into a host store"
+
+    # Documents host-owned credential setup by env var, without inlining secrets.
+    assert "BUILDEROPS_API_URL" in text
+    assert "BUILDEROPS_API_TOKEN_FILE" in text or "BUILDEROPS_API_TOKEN" in text
+    _assert_no_inlined_secret(text, wrapper)
+
+    # The owner doc documents secret-safe credential setup for skills/automations.
+    doc = REPO_ROOT / "docs" / "BUILDEROPS_CONTROL_PLANE" / "API_ONLY_CLIENT_CUTOVER.md"
+    doc_text = doc.read_text(encoding="utf-8")
+    assert "BUILDEROPS_API_URL" in doc_text
+    assert "BUILDEROPS_API_TOKEN_FILE" in doc_text or "BUILDEROPS_API_TOKEN" in doc_text
+    assert "python -m app.builderops.control_plane" in doc_text
+    _assert_no_inlined_secret(doc_text, doc)
+
+
+def _assert_no_inlined_secret(text: str, source: Path) -> None:
+    for pattern in _SECRET_VALUE_PATTERNS:
+        match = pattern.search(text)
+        assert match is None, (
+            f"{source} appears to inline a credential value matching {pattern.pattern!r}"
+        )

--- a/tests/security/test_builderops_secret_persistence.py
+++ b/tests/security/test_builderops_secret_persistence.py
@@ -67,6 +67,7 @@ def test_raw_credentials_never_enter_durable_state_or_restored_backup(tmp_path: 
                         "secret_ref": "keychain:builderops/client",
                         "secret_file": str(client_secret),
                         "scopes": ["records:write"],
+                        "repositories": ["RasmusTho/agentic-pkm-mvp"],
                         "rotation_generation": 1,
                     }
                 ]


### PR DESCRIPTION
Governing-Issue: #3791

Fixes #3791

## Summary

Implements BCP-04 (`docs/BUILDEROPS_CONTROL_PLANE/API_ONLY_CLIENT_CUTOVER.md`): a versioned
authenticated client for the BuilderOps control plane (records, inquiries, tasks,
leases, attempts, promotions, receipts, status), its API-only CLI
(`python -m app.builderops.control_plane`) and automation wrapper
(`scripts/builderops_api_client.sh`), delivery-manifest `(RepoRef, stack, task-class)`
routing that is explicit and non-transitive, and the client-facing service routes with
repo-scope and executor-scope enforcement. Every fail-closed path (unreachable, 401,
403, stale lease/epoch, malformed response) raises a typed error and never constructs
local SQLite/JSONL/JSON authority or a fabricated GitHub lease.

Scope boundary (documented in the owner-doc writeback): this slice builds and gates the
new API-only client surface. It does not rewrite the legacy `app.dispatcher` /
`app.builderops` local-SQLite CLIs that current MacBook workflows (including this
session's own dispatcher coordination) still depend on — that dispatcher-ledger
migration is explicitly BCP-05's scope per the README's backlog-reconciliation section,
and freezing the legacy writers is explicitly BCP-06's scope. BCP-02's own delivery
status confirms no live Demerzel authority is activated yet, so forcing the existing
production CLI to lose its local-store capability now would break live coordination
for a backend that isn't reachable in production — exactly the premature cutover BCP-04
is constrained not to perform ("BCP-04 prepares clients; BCP-06 chooses the
authoritative cutover moment").

## Claim receipt

```
pickup-claim-complete issue=3791 branch=builderops/3791-api-only-client-cutover worktree=/Users/rasmusthornberg/code/pkm-worktrees/issue-3791-api-only-cutover coordination_mode=github-label-only-fallback fallback_reason=dispatcher_db_uninitialized agent=claude-opus-3791 session=ca240656-98c1-4a13-8257-390d8c745490 evidence=github-comment:5006100263
```

## Acceptance Criteria — Verify status (all 7 green)

1. `tests/builderops/control_plane/test_api_clients.py::test_all_authority_commands_use_remote_api` — PASS
2. `tests/builderops/control_plane/test_api_clients.py::test_client_failure_never_creates_local_authority_fallback` — PASS
3. `tests/governance/test_builderops_api_only_clients.py::test_production_clients_expose_no_direct_store_mode` — PASS
4. `tests/governance/test_builderops_api_only_clients.py::test_skills_and_automations_route_through_authenticated_api` — PASS
5. `tests/builderops/control_plane/test_service_auth.py::test_normal_client_cannot_use_executor_or_cross_repo_scope` — PASS
6. `tests/builderops/control_plane/test_delivery_manifest_routing.py::test_repo_stack_task_routing_is_explicit_and_non_transitive` — PASS
7. `tests/architecture/test_builderops_store_boundary.py::test_only_control_plane_data_layer_and_migration_adapters_access_stores` — PASS

## Validation

- All 7 AC `Verify:` targets run individually: 7 passed.
- `ruff check app tests`: all checks passed.
- `mypy` on new/changed control-plane modules (`client.py`, `client_cli.py`, `routing.py`, `service.py`, `api_models.py`, `auth.py`, `__main__.py`): Success, no issues found in 7 source files.
- Touched-surface suites (`tests/builderops/control_plane/`, `tests/architecture/`, `tests/governance/`, `tests/security/test_builderops_secret_persistence.py`, `-m "not pg"`): 442 passed, 0 failed.
- `tests/properties -m "not pg"` (census guard): 36 passed — this diff does not touch any `(file, line)`-keyed tracked sink, so no census update was required.
- `tests/architecture/ -m "not pg"` (import/store-boundary guards, including AC7's own test): 152 passed.
- Full `pytest -m "not pg"` (`PYTHONPATH=.:companion-ui/companion-app`): **33 failed, 9852 passed, 43 skipped, 234 deselected, 18 xfailed** in 633s. All 33 failures are outside this diff's file set — `tests/deploy/`, `tests/ops/test_export_runtime_env.py` (spot-checked: `NameError: name 'resolve_settings_file' is not defined` inside `scripts/export_runtime_env.sh`'s own subprocess), `tests/ops/test_release_channel_startup_targets.py`, `tests/ops/test_start_full_runtime_health.py`, `tests/quality_wave/test_bootstrap_start.py`, `tests/scripts/test_start_script_*.py` — all Docker/Compose/runtime-env/deploy-channel territory, consistent with this laptop's documented no-Docker-by-design environment and concurrent sibling-agent contention on shared runtime/tmp paths during this run. Zero overlap with `git diff --stat origin/main` for this branch.

## Call-site inventory (completeness proof)

Before writing the client, ran a repo-wide inventory for every production construction of
`SqliteBuilderOpsStore`/`PostgresBuilderOpsStore`, `--db-path`/`db_path` flags, and any
SSH-to-database-owning-CLI pattern (`grep -rniE` across `app/`, `scripts/`, `.codex/`):

- **SSH-to-database patterns**: none found anywhere in the repo (confirmed clean — this is
  a documented future capability in prose only, never live code).
- **`SqliteBuilderOpsStore`/`PostgresBuilderOpsStore` construction sites**: `app/builderops/completeness_report.py` (read-only report), `app/builderops/boundary.py` (the pre-existing local Vault-boundary HTTP API from #1503 — a genuinely different, Product-adjacent local surface governed by ADR-0010, not the Demerzel control-plane authority this issue targets — confirmed by reading `docs/builderops/BUILDEROPS_VAULT_BOUNDARY.md :: Scope`), `app/builderops/cli.py` (legacy CLI, intentionally untouched per the scope boundary above), `app/builderops/ckm/store.py`, and the two control-plane files that are the sanctioned data-layer/migration seam (`app/builderops/control_plane/store.py`, `app/builderops/control_plane/selection.py`).
- **Dispatcher's own SQLite** (`app/dispatcher/store.py::SqliteStore`, used by `app/dispatcher/cli.py`, `app/api/routes/signboard.py`, etc.): confirmed out of this slice's scope — the README's backlog-reconciliation section explicitly assigns "replace its dispatcher-SQLite ledger and direct claim boundary with the BuilderOps API/PostgreSQL contract" to BCP-05, not BCP-04, and AC7's own test name (`test_only_control_plane_data_layer_and_migration_adapters_access_stores`) scopes the store-boundary guard to the `control_plane/` package specifically.
- **New governance/architecture tests** (`tests/architecture/test_builderops_store_boundary.py`) now statically enforce, as a repo-wide inventory gate, that only `app/builderops/control_plane/store.py` (data layer) and `app/builderops/control_plane/selection.py` (selector + explicit read-only migration/test adapter) may import a DB driver or construct a store anywhere under `app/builderops/control_plane/`; the client surface itself (`client.py`, `client_cli.py`, `routing.py`, `__main__.py`) is separately asserted store-free by AST inspection, not substring matching.

## BuilderOps Routing

- Records/projections/receipts: none
- Reason: this is Builder System client-transport implementation work with no BuilderOps
  Vault record, projection, or receipt to route; the owner-doc writeback (delivery status
  and AC checkboxes in `docs/BUILDEROPS_CONTROL_PLANE/API_ONLY_CLIENT_CUTOVER.md` and
  `docs/BUILDEROPS_CONTROL_PLANE/README.md`) is bundled in this same PR per the required
  pattern.

## Owner-doc writeback

- `docs/BUILDEROPS_CONTROL_PLANE/API_ONLY_CLIENT_CUTOVER.md`: added a `Delivery status:`
  line, flipped all 7 Acceptance Criteria checkboxes to `[x]`, and added a `## Client
  setup (secret-safe)` section documenting `BUILDEROPS_API_URL` /
  `BUILDEROPS_API_TOKEN_FILE` / `BUILDEROPS_API_TOKEN` host-owned credential resolution.
- `docs/BUILDEROPS_CONTROL_PLANE/README.md`: updated the top-of-doc `State:` line and
  added a BCP-04 delivery-status paragraph mirroring the BCP-01/BCP-02 pattern, explicit
  that this is not a production cutover and BCP-06 still owns activation/legacy freeze.

## Divergences / follow-ups for the coordinator

- Sibling PR #3929 (BCP-03) merged first and edited the same `docs/BUILDEROPS_CONTROL_PLANE/README.md`
  paragraphs — resolved via rebase (see Review remediation below); no semantic conflict, both PRs'
  delivery-status prose is preserved.
- No blockers found; BCP-02's service contract (bearer auth, `/v1/leases/claim`, `/v1/records`,
  `StorePort` already declaring task/attempt/promotion/lease methods) fully supported what this
  issue assumed. I extended `api_models.py`/`service.py` with the additional routes AC1/AC2/AC5
  needed (tasks claim/heartbeat/complete, inquiries, attempts, promotions, receipts, executor
  outbox claim, repo-scope enforcement, authority-epoch fencing header) rather than finding a
  contract mismatch requiring escalation.
- Found and fixed one pre-existing false-positive in the BCP-02 durable-payload secret scanner
  (`_FORBIDDEN_DURABLE_KEYS` matched the legitimate `fencing_token` lease field because it ends
  in `_token`); added a narrow structural exemption (later tightened further, see below).

## Review remediation (2026-07-18)

A 4-angle deep review found 2 CRITICAL, 3 SCOPE, and 5 HARDENING items. All CRITICAL/SCOPE fixed
or explicitly deferred with sign-off; all 5 HARDENING items fixed (judged cheap enough). Full
per-item detail and rationale: https://github.com/RasmusTho/agentic-pkm-mvp/pull/3963#issuecomment-5008647615

**CRITICAL — both fixed:**
- **C1** `Credential.may_address()` defaulted to unrestricted (any repo) when `repositories` was
  empty/absent, inverting AC5's own claim. Now fails closed by default; a distinct, explicit
  `all_repositories: true` opt-in is required for credentials that legitimately need unrestricted
  addressing (e.g. the executor), never implied by an empty list.
- **C2** The `fencing_token` durable-payload-scanner exemption matched the bare key name anywhere
  in a request, so a free-form `payload`/`request` field named `fencing_token` could smuggle a raw
  secret past the key-name heuristic. Now scoped to the exact field path (immediate parent `lease`)
  AND a strict int value type — a string can never satisfy the exemption.

**SCOPE:**
- **S1** `routing.py` had zero production callers (registry only exercised in isolation). Fixed:
  `client_cli.py` gained opt-in `--delivery-manifest-dir`/`--task-class` flags that resolve a real
  route before dispatch and fail closed on a missing/ambiguous manifest; new
  `tests/builderops/control_plane/test_client_cli.py` proves this through the real CLI path.
- **S2** `scripts/start_model_inquiry.py` and `app/api/routes/signboard.py` remain on their legacy
  stores. Deferred with explicit sign-off, not silently skipped — documented on the issue itself:
  https://github.com/RasmusTho/agentic-pkm-mvp/issues/3791#issuecomment-5008099447
- **S3** Two skill docs (`automation-maintenance`, `temporal-doc-governance`) still only mentioned
  the legacy CLI. Both now name the new client and explain the Vault-record-vs-control-plane
  domain boundary.

**HARDENING — all 5 fixed:** H1 (uncaught `RepoRefError` in the CLI), H2 (`_detail()`'s malformed-
409 handling inconsistent with the 2xx path), H3 (409 stale-detail strings now shared via
`models.py` constants instead of duplicated), H4 (wrapper script usage example referenced a
non-existent `--json` flag), H5 (architecture store-boundary guard widened to cover the rest of
`app/builderops/` against an audited allowlist).

**Rebase note:** origin/main advanced past BCP-03 (#3929) while the full suite ran. That PR added
`app/builderops/control_plane/legacy_migration.py` — a genuine read-only migration adapter — which
I added to the AC7 store-boundary allowlist (exactly the role the allowlist already documents).

**Validation after remediation + rebase:** all 7 AC targets green; `ruff`/`mypy` clean; touched-
surface suite 488 passed; full `pytest -m "not pg"` run once post-remediation (pre-rebase):
33 failed (identical pre-existing baseline set, confirmed via diff against the prior run),
9867 passed, 43 skipped, 234 deselected, 18 xfailed; targeted re-validation post-rebase (7 AC
targets + 488-test touched surface) green.

---
