### PR TITLE
YSS-02: OAuth account binding + encrypted token store

### DIFF
--- a/app/alembic/versions/a2f1c3e4d5b6_yss02_youtube_account_binding.py
+++ b/app/alembic/versions/a2f1c3e4d5b6_yss02_youtube_account_binding.py
@@ -1,0 +1,115 @@
+"""YSS-02 (#3917): YouTube Source Sync -- durable, non-secret account binding.
+
+Slice YSS-02 of the YouTube Source Sync capability (parent #3915). Creates
+`youtube_account_binding`, the durable non-secret table backing
+`app/knowledge_acquisition/youtube_account_binding.py`: one row per connected
+YouTube/Google account -- the `account_binding_id` that authenticated rows in
+`acquisition_source_registry` (YSS-01) reference. It records the provider
+channel id (`UC...` -- identity, never a title), a display label, the
+connected/degraded auth state + reason code, the granted scopes, and
+timestamps. It carries **no secret**: tokens live in the AES-256-GCM
+`youtube_token_store` file, client credentials live in host env
+(`docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md :: Secrets and private
+bindings`, INV-YSS-5).
+
+Two service-layer integrity rules are backed by DB constraints as
+defense-in-depth (the service layer, covering both Postgres and the in-process
+memory backend identically, remains authoritative -- see the module docstring
+in `youtube_account_binding.py`):
+
+- `state` is one of `connected` / `degraded`.
+- a `connected` binding carries no `reason_code` (a degraded reason and a
+  healthy state are mutually exclusive).
+
+plus a unique `(provider, provider_channel_id)` index: one binding per account.
+
+Forward-only, following the KERNEL-04/KERNEL-05/HEIM/YSS-01 precedent:
+schema-owning migrations in this repo have no downgrade path for their tables.
+This is a "new rebuildable-class table" per the issue's SBS Impact (all sync
+state is rebuildable from the source + queue) -- rebuildable means an
+operator-recovery story exists outside this migration, not that `downgrade()`
+silently drops the account bindings.
+
+Revision ID: a2f1c3e4d5b6
+Revises: bd79f3044759
+Create Date: 2026-07-18 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# Alembic identifiers
+revision: str = "a2f1c3e4d5b6"
+down_revision: Union[str, None] = "bd79f3044759"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Machine-readable classification for the promotion migration gate
+# (docs/RELEASE_CHANNELS/DEFINE_MIGRATION_REVERSIBILITY_CLASSIFICATION.md;
+# app/release_channels/reversibility.py). Downgrade raises by design.
+reversibility: str = "forward-only"
+
+_TABLE = "youtube_account_binding"
+
+
+def upgrade() -> None:
+    op.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {_TABLE} (
+            account_binding_id TEXT PRIMARY KEY,
+            provider TEXT NOT NULL,
+            provider_channel_id TEXT NOT NULL,
+            display_label TEXT NOT NULL,
+            state TEXT NOT NULL,
+            reason_code TEXT,
+            scopes JSONB NOT NULL,
+            obtained_at TIMESTAMPTZ NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            CONSTRAINT youtube_account_binding_state_chk CHECK (
+                state IN ('connected', 'degraded')
+            ),
+            CONSTRAINT youtube_account_binding_connected_reason_chk CHECK (
+                state <> 'connected' OR reason_code IS NULL
+            )
+        )
+        """
+    )
+    # Existing test/bootstrap-created tables predate the CHECK constraints; add
+    # each migration-owned constraint idempotently so upgrading such a resource
+    # reaches the same fail-loud schema as a fresh migration (YSS-01 precedent).
+    for name, check in (
+        ("youtube_account_binding_state_chk", "state IN ('connected', 'degraded')"),
+        ("youtube_account_binding_connected_reason_chk", "state <> 'connected' OR reason_code IS NULL"),
+    ):
+        op.execute(
+            f"""
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1
+                    FROM pg_constraint
+                    WHERE conname = '{name}'
+                      AND conrelid = '{_TABLE}'::regclass
+                ) THEN
+                    ALTER TABLE {_TABLE} ADD CONSTRAINT {name} CHECK ({check});
+                END IF;
+            END $$;
+            """
+        )
+    # One binding per account (INV-YSS-9: identity is the channel id, never a title).
+    op.execute(
+        f"""
+        CREATE UNIQUE INDEX IF NOT EXISTS youtube_account_binding_channel_uq
+        ON {_TABLE} (provider, provider_channel_id)
+        """
+    )
+
+
+def downgrade() -> None:
+    raise RuntimeError(
+        "YSS-02 youtube_account_binding migration is forward-only; this table is the durable "
+        "per-account OAuth binding registry for YouTube Source Sync (rebuildable by re-consenting, "
+        "not via migration downgrade), and is never dropped by downgrade."
+    )

--- a/app/knowledge_acquisition/source_registry.py
+++ b/app/knowledge_acquisition/source_registry.py
@@ -563,6 +563,26 @@ class _MemorySourceRegistryBackend:
             self._rows[binding_id] = updated_target
             return _copy_binding(updated_target)
 
+    def update_state(
+        self,
+        binding_id: str,
+        *,
+        enabled: bool | None,
+        last_error: dict[str, Any] | None,
+    ) -> SourceBinding:
+        with self._lock:
+            row = self._rows.get(binding_id)
+            if row is None:
+                raise KeyError(f"no such binding: {binding_id}")
+            updated = replace(
+                row,
+                enabled=row.enabled if enabled is None else enabled,
+                last_error=deepcopy(last_error),
+                updated_at=_now_iso(),
+            )
+            self._rows[binding_id] = updated
+            return _copy_binding(updated)
+
     def clear(self) -> None:
         with self._lock:
             self._rows.clear()
@@ -944,8 +964,54 @@ class _PgSourceRegistryBackend:
         assert result is not None  # just wrote it
         return result
 
+    def update_state(
+        self,
+        binding_id: str,
+        *,
+        enabled: bool | None,
+        last_error: dict[str, Any] | None,
+    ) -> SourceBinding:
+        conn = _pg_connect()
+        try:
+            _assert_pg_schema(conn)
+            now = _now_iso()
+            cur = conn.cursor()
+            last_error_json = json.dumps(last_error) if last_error is not None else None
+            # cursor is deliberately never in the SET list: an auth degradation
+            # or disconnect must not mutate a source cursor (INV-YSS-1/INV-YSS-4).
+            if enabled is None:
+                cur.execute(
+                    f"UPDATE {_TABLE} SET last_error = %s::jsonb, updated_at = %s::timestamptz "
+                    "WHERE binding_id = %s",
+                    (last_error_json, now, binding_id),
+                )
+            else:
+                cur.execute(
+                    f"UPDATE {_TABLE} SET enabled = %s, last_error = %s::jsonb, "
+                    "updated_at = %s::timestamptz WHERE binding_id = %s",
+                    (enabled, last_error_json, now, binding_id),
+                )
+            if cur.rowcount == 0:
+                raise KeyError(f"no such binding: {binding_id}")
+        finally:
+            conn.close()
+        result = self.get(binding_id)
+        assert result is not None  # just wrote it
+        return result
+
 
 # --- Service layer -------------------------------------------------------
+
+
+def _build_last_error(reason_code: str, detail: Any) -> dict[str, Any]:
+    """Build a portable ``{reason_code, detail, at}`` last_error payload."""
+    if not isinstance(reason_code, str) or not reason_code.strip():
+        raise SourceRegistryValidationError("reason_code must be a non-empty string")
+    payload = {"reason_code": reason_code, "detail": detail, "at": _now_iso()}
+    result = _portable_json_copy(payload, field="last_error")
+    if not isinstance(result, dict):  # pragma: no cover - fixed object above
+        raise SourceRegistryValidationError("last_error must be a JSON object")
+    return result
 
 
 class SourceRegistry:
@@ -1081,6 +1147,35 @@ class SourceRegistry:
 
     def list_for_account(self, account_binding_id: str | None) -> tuple[SourceBinding, ...]:
         return self._backend.list_for_account(_normalize_account_binding_id(account_binding_id))
+
+    def record_source_degradation(
+        self, binding_id: str, *, reason_code: str, detail: Any = None
+    ) -> SourceBinding:
+        """Stamp an auth/degradation reason on a source's ``last_error`` without
+        touching its cursor or ``enabled`` flag.
+
+        INV-YSS-4: an auth failure mutates no cursor and does not disable the
+        source -- it is degraded (legible, recoverable), not disconnected. Used
+        by ``youtube_oauth`` to degrade dependent authenticated sources when the
+        account binding's auth is revoked/expired/key-missing.
+        """
+        return self._backend.update_state(
+            binding_id, enabled=None, last_error=_build_last_error(reason_code, detail)
+        )
+
+    def disable_source_for_auth(
+        self, binding_id: str, *, reason_code: str, detail: Any = None
+    ) -> SourceBinding:
+        """Disable a source and stamp the auth reason (operator disconnect path).
+
+        Sets ``enabled = false`` + ``last_error`` in one write; the row, cursor,
+        and history are kept (disabled sources keep rows, cursors, and history).
+        The cursor is never mutated (INV-YSS-1). Used by
+        ``youtube_oauth.disconnect`` for the account's dependent sources.
+        """
+        return self._backend.update_state(
+            binding_id, enabled=False, last_error=_build_last_error(reason_code, detail)
+        )
 
 
 __all__ = [

--- a/app/knowledge_acquisition/youtube_account_binding.py
+++ b/app/knowledge_acquisition/youtube_account_binding.py
@@ -1,0 +1,484 @@
+"""YSS-02 (#3917): durable, non-secret YouTube account-binding registry.
+
+The account binding is the ``account_binding_id`` referenced by every
+authenticated row in ``app/knowledge_acquisition/source_registry.py`` (YSS-01).
+It records *which* Google/YouTube account is connected and its legible auth
+state -- **never** any secret. Tokens live in the encrypted
+``youtube_token_store``; client credentials live in host env. This row carries
+only: the binding id, the provider channel id (source-native ``UC...`` id --
+identity, never a title), a display label, the connected/degraded state + a
+reason code, the granted scopes, and timestamps (INV-YSS-5).
+
+Dual backend and store discipline mirror ``source_registry`` exactly: memory
+backend for ``not_pg`` tests, Postgres for a configured runtime (fail-loud on
+an unreachable DSN, never a silent volatile fallback), a migration-owned table
+(``youtube_account_binding``) with a fail-loud schema preflight, and the
+``STORE_SCHEMA_AUTOCREATE`` test-only autocreate opt-in. Channel isolation is
+DB-per-channel (INV-YSS-7); this table carries no environment column.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import uuid
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from typing import Any
+
+from app.db.dsn import resolve_dsn
+
+PROVIDER_YOUTUBE = "youtube"
+VALID_BINDING_STATES: frozenset[str] = frozenset({"connected", "degraded"})
+# The auth reason codes a binding may carry (subset of the contract taxonomy
+# that is auth-scoped). ``None`` means healthy/connected.
+VALID_BINDING_REASON_CODES: frozenset[str] = frozenset(
+    {"auth_missing", "auth_key_missing", "auth_expired", "auth_revoked", "auth_disconnected"}
+)
+
+_TABLE = "youtube_account_binding"
+_MIGRATION_HINT = (
+    "youtube_account_binding schema is migration-owned: run 'alembic upgrade head' "
+    "against this database. See "
+    "app/alembic/versions/a2f1c3e4d5b6_yss02_youtube_account_binding.py."
+)
+_ALLOWED_BACKENDS = {"memory", "pg"}
+
+
+class AccountBindingSchemaMissingError(RuntimeError):
+    """Raised when the Postgres backend is selected but the binding table is absent."""
+
+
+class AccountBindingValidationError(ValueError):
+    """Raised for malformed/unknown account-binding field values (fail-loud)."""
+
+
+class DuplicateAccountBindingError(ValueError):
+    """Raised when a binding for the same provider channel id already exists."""
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass(frozen=True)
+class AccountBinding:
+    """One durable, non-secret account-binding row."""
+
+    account_binding_id: str
+    provider: str
+    provider_channel_id: str
+    display_label: str
+    state: str
+    reason_code: str | None
+    scopes: tuple[str, ...]
+    obtained_at: str
+    created_at: str
+    updated_at: str
+
+
+def _validate_state(state: str, reason_code: str | None) -> None:
+    if state not in VALID_BINDING_STATES:
+        raise AccountBindingValidationError(
+            f"state must be one of {sorted(VALID_BINDING_STATES)}, got {state!r}"
+        )
+    if reason_code is not None and reason_code not in VALID_BINDING_REASON_CODES:
+        raise AccountBindingValidationError(
+            f"reason_code must be null or one of {sorted(VALID_BINDING_REASON_CODES)}, got {reason_code!r}"
+        )
+    if state == "connected" and reason_code is not None:
+        raise AccountBindingValidationError("a connected binding must not carry a reason_code")
+
+
+def _validate_scopes(scopes: Any) -> tuple[str, ...]:
+    if not isinstance(scopes, (list, tuple)) or not scopes:
+        raise AccountBindingValidationError("scopes must be a non-empty list of strings")
+    resolved: list[str] = []
+    for scope in scopes:
+        if not isinstance(scope, str) or not scope.strip():
+            raise AccountBindingValidationError("each scope must be a non-empty string")
+        if "\x00" in scope:
+            raise AccountBindingValidationError("scope must not contain NUL")
+        resolved.append(scope)
+    return tuple(resolved)
+
+
+# --- Backend resolution (mirrors source_registry._resolve_backend) ----------
+
+
+def _resolve_backend() -> str:
+    override = (os.getenv("STORE_BACKEND") or "").strip().lower()
+    if override:
+        if override not in _ALLOWED_BACKENDS:
+            raise RuntimeError(
+                f"Store backend '{override}' is not supported for the account binding registry: "
+                "set STORE_BACKEND to 'pg' or 'memory', or unset it to resolve from "
+                "DATABASE_URL/DB_DSN."
+            )
+        return override
+    dsn = resolve_dsn()
+    if not dsn:
+        raise RuntimeError(
+            "No store backend configured for the account binding registry: set STORE_BACKEND=memory "
+            "explicitly for the volatile in-memory backend, or configure DATABASE_URL/DB_DSN."
+        )
+    try:
+        import psycopg  # noqa: PLC0415
+
+        conn = psycopg.connect(dsn, connect_timeout=1)
+        conn.close()
+    except Exception as exc:
+        raise RuntimeError(
+            "Account binding backend resolution failed: Postgres is configured but unreachable. "
+            f"Refusing to fall back to a volatile in-memory store. Underlying error: {exc}"
+        ) from exc
+    return "pg"
+
+
+# --- Memory backend ----------------------------------------------------------
+
+
+class _MemoryAccountBindingBackend:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._rows: dict[str, AccountBinding] = {}
+
+    def insert(self, binding: AccountBinding) -> AccountBinding:
+        with self._lock:
+            for row in self._rows.values():
+                if row.provider_channel_id == binding.provider_channel_id:
+                    raise DuplicateAccountBindingError(
+                        f"a binding already exists for provider_channel_id={binding.provider_channel_id!r}"
+                    )
+            self._rows[binding.account_binding_id] = binding
+            return binding
+
+    def get(self, account_binding_id: str) -> AccountBinding | None:
+        with self._lock:
+            return self._rows.get(account_binding_id)
+
+    def get_by_channel_id(self, provider_channel_id: str) -> AccountBinding | None:
+        with self._lock:
+            for row in self._rows.values():
+                if row.provider_channel_id == provider_channel_id:
+                    return row
+            return None
+
+    def list_all(self) -> tuple[AccountBinding, ...]:
+        with self._lock:
+            return tuple(self._rows.values())
+
+    def set_state(self, account_binding_id: str, state: str, reason_code: str | None) -> AccountBinding:
+        with self._lock:
+            row = self._rows.get(account_binding_id)
+            if row is None:
+                raise KeyError(f"no such account binding: {account_binding_id}")
+            updated = replace(row, state=state, reason_code=reason_code, updated_at=_now_iso())
+            self._rows[account_binding_id] = updated
+            return updated
+
+    def delete(self, account_binding_id: str) -> bool:
+        with self._lock:
+            return self._rows.pop(account_binding_id, None) is not None
+
+    def clear(self) -> None:
+        with self._lock:
+            self._rows.clear()
+
+
+_MEMORY_BINDINGS = _MemoryAccountBindingBackend()
+
+
+def reset_memory_account_bindings() -> None:
+    """Test-only reset hook (mirrors reset_memory_source_registry)."""
+    _MEMORY_BINDINGS.clear()
+
+
+# --- Postgres backend --------------------------------------------------------
+
+_COLUMNS = (
+    "account_binding_id",
+    "provider",
+    "provider_channel_id",
+    "display_label",
+    "state",
+    "reason_code",
+    "scopes",
+    "obtained_at",
+    "created_at",
+    "updated_at",
+)
+_COLUMNS_SQL = ", ".join(_COLUMNS)
+
+
+def _pg_connect() -> Any:
+    import psycopg  # noqa: PLC0415
+
+    url = os.environ.get("DATABASE_URL") or os.environ.get("DB_DSN")
+    if not url:
+        raise RuntimeError("DATABASE_URL or DB_DSN not set")
+    return psycopg.connect(resolve_dsn(url), autocommit=True)
+
+
+def _schema_autocreate_enabled() -> bool:
+    return (os.environ.get("STORE_SCHEMA_AUTOCREATE") or "").strip().lower() in {"1", "true", "yes"}
+
+
+def _assert_pg_schema(conn: Any) -> None:
+    cur = conn.cursor()
+    cur.execute("SELECT to_regclass(%s)", (_TABLE,))
+    row = cur.fetchone()
+    if not (row and row[0]):
+        raise AccountBindingSchemaMissingError(f"Missing table '{_TABLE}'. {_MIGRATION_HINT}")
+
+
+def _bootstrap_pg(conn: Any) -> None:
+    if not _schema_autocreate_enabled():
+        _assert_pg_schema(conn)
+        return
+    cur = conn.cursor()
+    cur.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {_TABLE} (
+            account_binding_id TEXT PRIMARY KEY,
+            provider TEXT NOT NULL,
+            provider_channel_id TEXT NOT NULL,
+            display_label TEXT NOT NULL,
+            state TEXT NOT NULL,
+            reason_code TEXT,
+            scopes JSONB NOT NULL,
+            obtained_at TIMESTAMPTZ NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            CONSTRAINT youtube_account_binding_state_chk CHECK (state IN ('connected', 'degraded')),
+            CONSTRAINT youtube_account_binding_connected_reason_chk CHECK (
+                state <> 'connected' OR reason_code IS NULL
+            )
+        )
+        """
+    )
+    cur.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS youtube_account_binding_channel_uq "
+        f"ON {_TABLE} (provider, provider_channel_id)"
+    )
+
+
+def _iso(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is not None:
+            value = value.astimezone(timezone.utc)
+        return value.isoformat()
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return str(value)
+
+
+def _row_to_binding(row: tuple[Any, ...]) -> AccountBinding:
+    values = dict(zip(_COLUMNS, row))
+    scopes = values["scopes"]
+    if isinstance(scopes, str):
+        scopes = json.loads(scopes)
+    return AccountBinding(
+        account_binding_id=values["account_binding_id"],
+        provider=values["provider"],
+        provider_channel_id=values["provider_channel_id"],
+        display_label=values["display_label"],
+        state=values["state"],
+        reason_code=values["reason_code"],
+        scopes=tuple(scopes or ()),
+        obtained_at=_iso(values["obtained_at"]) or "",
+        created_at=_iso(values["created_at"]) or "",
+        updated_at=_iso(values["updated_at"]) or "",
+    )
+
+
+class _PgAccountBindingBackend:
+    def __init__(self) -> None:
+        conn = _pg_connect()
+        try:
+            _bootstrap_pg(conn)
+        finally:
+            conn.close()
+
+    def insert(self, binding: AccountBinding) -> AccountBinding:
+        from psycopg.errors import UniqueViolation  # noqa: PLC0415
+
+        conn = _pg_connect()
+        try:
+            _assert_pg_schema(conn)
+            cur = conn.cursor()
+            try:
+                cur.execute(
+                    f"""
+                    INSERT INTO {_TABLE} (
+                        account_binding_id, provider, provider_channel_id, display_label,
+                        state, reason_code, scopes, obtained_at, created_at, updated_at
+                    ) VALUES (
+                        %s, %s, %s, %s, %s, %s, %s::jsonb, %s::timestamptz, %s::timestamptz, %s::timestamptz
+                    )
+                    """,
+                    (
+                        binding.account_binding_id,
+                        binding.provider,
+                        binding.provider_channel_id,
+                        binding.display_label,
+                        binding.state,
+                        binding.reason_code,
+                        json.dumps(list(binding.scopes)),
+                        binding.obtained_at,
+                        binding.created_at,
+                        binding.updated_at,
+                    ),
+                )
+            except UniqueViolation as exc:
+                raise DuplicateAccountBindingError(
+                    f"a binding already exists for provider_channel_id={binding.provider_channel_id!r}"
+                ) from exc
+            return binding
+        finally:
+            conn.close()
+
+    def get(self, account_binding_id: str) -> AccountBinding | None:
+        conn = _pg_connect()
+        try:
+            _assert_pg_schema(conn)
+            cur = conn.cursor()
+            cur.execute(
+                f"SELECT {_COLUMNS_SQL} FROM {_TABLE} WHERE account_binding_id = %s",
+                (account_binding_id,),
+            )
+            row = cur.fetchone()
+            return _row_to_binding(tuple(row)) if row else None
+        finally:
+            conn.close()
+
+    def get_by_channel_id(self, provider_channel_id: str) -> AccountBinding | None:
+        conn = _pg_connect()
+        try:
+            _assert_pg_schema(conn)
+            cur = conn.cursor()
+            cur.execute(
+                f"SELECT {_COLUMNS_SQL} FROM {_TABLE} WHERE provider = %s AND provider_channel_id = %s",
+                (PROVIDER_YOUTUBE, provider_channel_id),
+            )
+            row = cur.fetchone()
+            return _row_to_binding(tuple(row)) if row else None
+        finally:
+            conn.close()
+
+    def list_all(self) -> tuple[AccountBinding, ...]:
+        conn = _pg_connect()
+        try:
+            _assert_pg_schema(conn)
+            cur = conn.cursor()
+            cur.execute(f"SELECT {_COLUMNS_SQL} FROM {_TABLE} ORDER BY created_at")
+            return tuple(_row_to_binding(tuple(row)) for row in cur.fetchall())
+        finally:
+            conn.close()
+
+    def set_state(self, account_binding_id: str, state: str, reason_code: str | None) -> AccountBinding:
+        conn = _pg_connect()
+        try:
+            _assert_pg_schema(conn)
+            cur = conn.cursor()
+            cur.execute(
+                f"UPDATE {_TABLE} SET state = %s, reason_code = %s, updated_at = %s::timestamptz "
+                "WHERE account_binding_id = %s",
+                (state, reason_code, _now_iso(), account_binding_id),
+            )
+            if cur.rowcount == 0:
+                raise KeyError(f"no such account binding: {account_binding_id}")
+        finally:
+            conn.close()
+        result = self.get(account_binding_id)
+        assert result is not None  # just wrote it
+        return result
+
+    def delete(self, account_binding_id: str) -> bool:
+        conn = _pg_connect()
+        try:
+            _assert_pg_schema(conn)
+            cur = conn.cursor()
+            cur.execute(f"DELETE FROM {_TABLE} WHERE account_binding_id = %s", (account_binding_id,))
+            return cur.rowcount > 0
+        finally:
+            conn.close()
+
+
+# --- Service layer -----------------------------------------------------------
+
+
+class AccountBindingStore:
+    """Service facade enforcing the same validation on both backends."""
+
+    def __init__(self, backend: _MemoryAccountBindingBackend | _PgAccountBindingBackend) -> None:
+        self._backend = backend
+
+    @classmethod
+    def for_runtime(cls) -> "AccountBindingStore":
+        if _resolve_backend() == "pg":
+            return cls(_PgAccountBindingBackend())
+        return cls(_MEMORY_BINDINGS)
+
+    def create(
+        self,
+        *,
+        provider_channel_id: str,
+        display_label: str,
+        scopes: Any,
+        account_binding_id: str | None = None,
+        obtained_at: str | None = None,
+    ) -> AccountBinding:
+        if not isinstance(provider_channel_id, str) or not provider_channel_id.strip():
+            raise AccountBindingValidationError("provider_channel_id must be a non-empty string")
+        if not isinstance(display_label, str) or not display_label.strip():
+            raise AccountBindingValidationError("display_label must be a non-empty string")
+        resolved_scopes = _validate_scopes(scopes)
+        now = _now_iso()
+        binding = AccountBinding(
+            account_binding_id=account_binding_id or str(uuid.uuid4()),
+            provider=PROVIDER_YOUTUBE,
+            provider_channel_id=provider_channel_id,
+            display_label=display_label,
+            state="connected",
+            reason_code=None,
+            scopes=resolved_scopes,
+            obtained_at=obtained_at or now,
+            created_at=now,
+            updated_at=now,
+        )
+        return self._backend.insert(binding)
+
+    def get(self, account_binding_id: str) -> AccountBinding | None:
+        return self._backend.get(account_binding_id)
+
+    def get_by_channel_id(self, provider_channel_id: str) -> AccountBinding | None:
+        return self._backend.get_by_channel_id(provider_channel_id)
+
+    def list_all(self) -> tuple[AccountBinding, ...]:
+        return self._backend.list_all()
+
+    def set_state(
+        self, account_binding_id: str, *, state: str, reason_code: str | None = None
+    ) -> AccountBinding:
+        _validate_state(state, reason_code)
+        return self._backend.set_state(account_binding_id, state, reason_code)
+
+    def delete(self, account_binding_id: str) -> bool:
+        return self._backend.delete(account_binding_id)
+
+
+__all__ = [
+    "AccountBinding",
+    "AccountBindingSchemaMissingError",
+    "AccountBindingStore",
+    "AccountBindingValidationError",
+    "DuplicateAccountBindingError",
+    "PROVIDER_YOUTUBE",
+    "VALID_BINDING_REASON_CODES",
+    "VALID_BINDING_STATES",
+    "reset_memory_account_bindings",
+]

--- a/app/knowledge_acquisition/youtube_oauth.py
+++ b/app/knowledge_acquisition/youtube_oauth.py
@@ -1,0 +1,815 @@
+"""YSS-02 (#3917): minimal-scope OAuth 2.0 account binding for YouTube.
+
+Implements ``docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md`` and
+the normative ``SOURCE_SYNC_CONTRACT.md :: Secrets and private bindings /
+Egress posture / Reason codes``. Two consent flows over the existing ``httpx``
+dependency (no Google SDK):
+
+- **Device authorization grant (primary)** -- headless-friendly; the user
+  approves in any browser via the complete-URL / QR.
+- **Loopback installed-app grant (secondary)** -- authorization-code + PKCE
+  against a ``127.0.0.1`` redirect, with OAuth ``state`` validated before any
+  code exchange.
+
+The single requested scope is exactly ``youtube.readonly`` (AC7). Tokens are
+persisted only through the AES-256-GCM ``youtube_token_store``; the non-secret
+account binding lives in ``youtube_account_binding``; OAuth client credentials
+resolve from host env and their values are never persisted or printed.
+
+Secret discipline (INV-YSS-5): no refresh/access token, authorization/device
+code, or client secret ever appears in a returned payload, log line, event,
+receipt, or exception text. The guarantee is primarily *structural* -- secrets
+never enter those objects -- and defended by redaction-aware ``__repr__`` on
+the secret-bearing dataclasses, provider-error sanitization (HTTP status + the
+``error`` enum only, never a response body that might echo a token), and
+:func:`redact` over every emitted mapping.
+
+Auth degradation (INV-YSS-4): a revoked/expired grant or a missing token-store
+key degrades the binding and its dependent authenticated sources with a legible
+reason code, mutates no source cursor, and never records an auth failure as an
+empty-success. Disconnect revokes at the provider, deletes the token record,
+and disables dependent sources -- never an acquired artifact.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import logging
+import os
+import secrets
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable
+from urllib.parse import urlencode, urlsplit
+
+import httpx
+
+from app.knowledge_acquisition.source_registry import SourceRegistry
+from app.knowledge_acquisition.youtube_account_binding import AccountBinding, AccountBindingStore
+from app.knowledge_acquisition.youtube_token_store import (
+    StoredToken,
+    TokenStoreKeyMissingError,
+    YouTubeTokenStore,
+    resolve_token_store_key,
+)
+
+_log = logging.getLogger(__name__)
+
+# --- Contract constants ------------------------------------------------------
+
+SCOPE = "https://www.googleapis.com/auth/youtube.readonly"
+CLIENT_ID_ENV = "YOUTUBE_OAUTH_CLIENT_ID"
+CLIENT_SECRET_ENV = "YOUTUBE_OAUTH_CLIENT_SECRET"
+
+# Egress posture (SSRF guard): every OAuth call must target one of these hosts.
+ALLOWED_OAUTH_HOSTS: frozenset[str] = frozenset(
+    {"accounts.google.com", "oauth2.googleapis.com", "www.googleapis.com"}
+)
+DEVICE_CODE_URL = "https://oauth2.googleapis.com/device/code"
+TOKEN_URL = "https://oauth2.googleapis.com/token"
+REVOKE_URL = "https://oauth2.googleapis.com/revoke"
+AUTHORIZATION_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth"
+DEVICE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
+
+_DEFAULT_TIMEOUT_SECONDS = 30.0
+_ACCESS_TOKEN_SKEW_SECONDS = 60
+
+# Defense-in-depth redaction: a value is redacted when its key name carries a
+# secret marker, EXCEPT for these documented non-secret mode fields whose names
+# merely contain such a substring.
+_SECRET_KEY_MARKERS = (
+    "token",
+    "secret",
+    "password",
+    "credential",
+    "refresh",
+    "authorization",
+    "client_id",
+    "device_code",
+    "code_verifier",
+)
+_REDACTION_SAFE_KEYS = frozenset({"token_store", "token_type"})
+
+
+# --- Errors ------------------------------------------------------------------
+
+
+class OAuthClientCredentialsMissingError(RuntimeError):
+    """OAuth client id/secret env not provisioned (host secret boundary)."""
+
+
+class OAuthStateMismatchError(RuntimeError):
+    """Loopback ``state`` did not match -- refuse to exchange the code."""
+
+
+class DisallowedOAuthHostError(RuntimeError):
+    """Refused OAuth egress to a non-allowlisted host (SSRF guard)."""
+
+
+class OAuthProviderError(RuntimeError):
+    """A non-2xx (or transport) response from the OAuth provider.
+
+    Carries only the HTTP ``status`` and the provider's ``error`` enum value --
+    never the response body, which could echo a token (INV-YSS-5).
+    """
+
+    def __init__(self, *, status: int, error_code: str | None) -> None:
+        self.status = status
+        self.error_code = error_code
+        super().__init__(f"OAuth provider error: HTTP {status} ({error_code or 'unknown'})")
+
+
+class DeviceAuthorizationPending(RuntimeError):
+    """The user has not yet approved the device code (poll again after interval)."""
+
+    def __init__(self, error_code: str) -> None:
+        self.error_code = error_code
+        super().__init__(f"device authorization pending: {error_code}")
+
+
+class DeviceAuthorizationError(RuntimeError):
+    """The device flow terminally failed (denied or expired) before any binding."""
+
+    def __init__(self, error_code: str) -> None:
+        self.error_code = error_code
+        super().__init__(f"device authorization failed: {error_code}")
+
+
+class AuthDegradedError(RuntimeError):
+    """An authenticated operation degraded with a legible reason code (INV-YSS-4)."""
+
+    def __init__(self, reason_code: str, message: str | None = None) -> None:
+        self.reason_code = reason_code
+        super().__init__(message or f"authentication degraded: {reason_code}")
+
+
+class ReconnectChannelMismatchError(RuntimeError):
+    """Reconnect consent resolved to a different channel than the target binding."""
+
+
+# --- Credential + redaction helpers -----------------------------------------
+
+
+def resolve_oauth_client_credentials() -> tuple[str, str]:
+    """Resolve ``(client_id, client_secret)`` from env; fail loud if absent.
+
+    Their *values* are never persisted or printed; only the env-var *names* may
+    appear in settings/receipts (INV-YSS-5).
+    """
+    client_id = (os.environ.get(CLIENT_ID_ENV) or "").strip()
+    client_secret = (os.environ.get(CLIENT_SECRET_ENV) or "").strip()
+    if not client_id or not client_secret:
+        missing = [n for n, v in ((CLIENT_ID_ENV, client_id), (CLIENT_SECRET_ENV, client_secret)) if not v]
+        raise OAuthClientCredentialsMissingError(
+            "OAuth client credentials are not provisioned: missing env "
+            f"{', '.join(missing)}. Provision them via the host secret boundary "
+            "(docs/LOCAL_SECRET_PROVISIONING/); their values are never stored in the repo/vault."
+        )
+    return client_id, client_secret
+
+
+def redact(payload: Any) -> Any:
+    """Redaction-aware copy: values under secret-marked keys become ``***``.
+
+    Defense-in-depth over the structural guarantee that secrets never enter
+    emitted payloads. Known non-secret mode fields (``token_store``,
+    ``token_type``) are preserved.
+    """
+    if isinstance(payload, dict):
+        out: dict[str, Any] = {}
+        for key, value in payload.items():
+            key_lower = str(key).lower()
+            if key_lower not in _REDACTION_SAFE_KEYS and any(m in key_lower for m in _SECRET_KEY_MARKERS):
+                out[key] = "***"
+            else:
+                out[key] = redact(value)
+        return out
+    if isinstance(payload, list):
+        return [redact(item) for item in payload]
+    return payload
+
+
+def _safe_error_code(response: httpx.Response) -> str | None:
+    """Extract only the provider ``error`` enum; never the body (INV-YSS-5)."""
+    try:
+        body = response.json()
+    except Exception:
+        return None
+    if isinstance(body, dict):
+        error = body.get("error")
+        if isinstance(error, str):
+            return error
+    return None
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _expiry_iso(expires_in: Any) -> str | None:
+    if expires_in is None:
+        return None
+    try:
+        seconds = int(expires_in)
+    except (TypeError, ValueError):
+        return None
+    return (datetime.now(timezone.utc) + timedelta(seconds=seconds)).isoformat()
+
+
+# --- Value types -------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ChannelIdentity:
+    """The connected account's primary channel (resolved by an injected probe).
+
+    Resolving the real channel id/title is a Data API read owned by YSS-03; this
+    slice takes it as an injected ``IdentityProbe`` so the binding seam stays
+    decoupled from the API client (and stubbable in tests).
+    """
+
+    channel_id: str
+    channel_title: str
+
+
+IdentityProbe = Callable[[str], ChannelIdentity]
+
+
+@dataclass(frozen=True)
+class TokenBundle:
+    """A token grant/refresh result. Secret fields are redacted in ``repr``."""
+
+    access_token: str
+    refresh_token: str | None
+    expires_in: int | None
+    scope: str | None
+    token_type: str | None
+
+    def __repr__(self) -> str:  # redaction-aware (INV-YSS-5)
+        return (
+            f"TokenBundle(access_token=***, refresh_token=***, expires_in={self.expires_in!r}, "
+            f"scope={self.scope!r}, token_type={self.token_type!r})"
+        )
+
+
+@dataclass(frozen=True)
+class DeviceFlowHandle:
+    """Device-flow handle. ``device_code`` is secret-ish and never emitted."""
+
+    device_code: str
+    user_code: str
+    verification_url: str
+    verification_url_complete: str
+    interval: int
+    expires_in: int
+
+    def __repr__(self) -> str:  # redaction-aware (INV-YSS-5)
+        return (
+            f"DeviceFlowHandle(device_code=***, user_code={self.user_code!r}, "
+            f"verification_url={self.verification_url!r}, "
+            f"verification_url_complete={self.verification_url_complete!r}, "
+            f"interval={self.interval!r}, expires_in={self.expires_in!r})"
+        )
+
+    def public_view(self) -> dict[str, Any]:
+        """The non-secret subset safe to emit as ``--json`` (no ``device_code``)."""
+        return redact(
+            {
+                "user_code": self.user_code,
+                "verification_url": self.verification_url,
+                "verification_url_complete": self.verification_url_complete,
+                "interval": self.interval,
+                "expires_in": self.expires_in,
+            }
+        )
+
+
+@dataclass(frozen=True)
+class LoopbackFlow:
+    """Loopback flow handle. ``code_verifier`` is a PKCE secret; never emitted."""
+
+    authorization_url: str
+    state: str
+    code_verifier: str
+    redirect_uri: str
+
+    def __repr__(self) -> str:  # redaction-aware (INV-YSS-5)
+        # The authorization_url embeds the client_id, state, and code_challenge;
+        # redact it wholesale so a repr'd flow in a log/exception cannot leak the
+        # client identifier or the CSRF state (redacting only the fields would
+        # otherwise be defeated by printing the URL that contains them).
+        return (
+            "LoopbackFlow(authorization_url=***, state=***, code_verifier=***, "
+            f"redirect_uri={self.redirect_uri!r})"
+        )
+
+
+@dataclass(frozen=True)
+class DeviceConnection:
+    """An in-flight device connection (start → finish), plus reconnect target."""
+
+    handle: DeviceFlowHandle
+    reconnect_binding_id: str | None = None
+
+    def public_view(self) -> dict[str, Any]:
+        return self.handle.public_view()
+
+
+def _bundle_from_response(data: dict[str, Any]) -> TokenBundle:
+    access = data.get("access_token")
+    if not access or not isinstance(access, str):
+        # A 2xx token response with no access token is not a success -- never
+        # treat it as an empty-success (INV-YSS-4).
+        raise OAuthProviderError(status=200, error_code="missing_access_token")
+    return TokenBundle(
+        access_token=access,
+        refresh_token=data.get("refresh_token"),
+        expires_in=data.get("expires_in"),
+        scope=data.get("scope"),
+        token_type=data.get("token_type"),
+    )
+
+
+# --- OAuth HTTP client -------------------------------------------------------
+
+
+class OAuthClient:
+    """Thin OAuth 2.0 client over ``httpx`` with an SSRF host allowlist.
+
+    Every request targets an allowlisted host; a non-2xx response is surfaced as
+    a sanitized :class:`OAuthProviderError` (status + provider ``error`` enum).
+    """
+
+    def __init__(
+        self,
+        *,
+        client_id: str,
+        client_secret: str,
+        http: httpx.Client,
+        timeout: float = _DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._http = http
+        self._timeout = timeout
+
+    @classmethod
+    def from_env(cls, *, http: httpx.Client, timeout: float = _DEFAULT_TIMEOUT_SECONDS) -> "OAuthClient":
+        client_id, client_secret = resolve_oauth_client_credentials()
+        return cls(client_id=client_id, client_secret=client_secret, http=http, timeout=timeout)
+
+    def _guard_host(self, url: str) -> None:
+        host = urlsplit(url).hostname
+        if host not in ALLOWED_OAUTH_HOSTS:
+            raise DisallowedOAuthHostError(
+                f"refusing OAuth egress to non-allowlisted host: {host!r} "
+                f"(allowed: {sorted(ALLOWED_OAUTH_HOSTS)})"
+            )
+
+    def _post(self, url: str, data: dict[str, str]) -> dict[str, Any]:
+        self._guard_host(url)
+        try:
+            response = self._http.post(
+                url, data=data, timeout=self._timeout, headers={"Accept": "application/json"}
+            )
+        except httpx.HTTPError as exc:
+            # Sanitized: exception class only -- never a URL (may carry query
+            # secrets) or response body (INV-YSS-5).
+            raise OAuthProviderError(status=0, error_code=type(exc).__name__) from None
+        if response.status_code // 100 != 2:
+            raise OAuthProviderError(status=response.status_code, error_code=_safe_error_code(response))
+        if not response.content:
+            return {}
+        try:
+            body = response.json()
+        except Exception:
+            return {}
+        return body if isinstance(body, dict) else {}
+
+    def start_device_flow(self) -> DeviceFlowHandle:
+        data = self._post(DEVICE_CODE_URL, {"client_id": self._client_id, "scope": SCOPE})
+        _log.debug("youtube oauth: device flow started")
+        return DeviceFlowHandle(
+            device_code=str(data.get("device_code", "")),
+            user_code=str(data.get("user_code", "")),
+            verification_url=str(data.get("verification_url") or data.get("verification_uri") or ""),
+            verification_url_complete=str(
+                data.get("verification_url_complete") or data.get("verification_uri_complete") or ""
+            ),
+            interval=int(data.get("interval", 5)),
+            expires_in=int(data.get("expires_in", 1800)),
+        )
+
+    def poll_device_flow(self, device_code: str) -> TokenBundle:
+        """One device-token poll. Raises :class:`DeviceAuthorizationPending`
+        while the user has not approved, :class:`DeviceAuthorizationError` on a
+        terminal denial/expiry, and returns the :class:`TokenBundle` on grant.
+        """
+        try:
+            data = self._post(
+                TOKEN_URL,
+                {
+                    "client_id": self._client_id,
+                    "client_secret": self._client_secret,
+                    "device_code": device_code,
+                    "grant_type": DEVICE_GRANT_TYPE,
+                },
+            )
+        except OAuthProviderError as exc:
+            if exc.error_code in ("authorization_pending", "slow_down"):
+                raise DeviceAuthorizationPending(exc.error_code) from None
+            if exc.error_code in ("access_denied", "expired_token"):
+                raise DeviceAuthorizationError(exc.error_code) from None
+            raise
+        return _bundle_from_response(data)
+
+    def build_authorization_url(self, *, redirect_uri: str, state: str, code_challenge: str) -> str:
+        params = {
+            "client_id": self._client_id,
+            "redirect_uri": redirect_uri,
+            "response_type": "code",
+            "scope": SCOPE,
+            "state": state,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+            "access_type": "offline",
+            "prompt": "consent",
+        }
+        return f"{AUTHORIZATION_ENDPOINT}?{urlencode(params)}"
+
+    def exchange_code(self, *, code: str, code_verifier: str, redirect_uri: str) -> TokenBundle:
+        data = self._post(
+            TOKEN_URL,
+            {
+                "client_id": self._client_id,
+                "client_secret": self._client_secret,
+                "code": code,
+                "code_verifier": code_verifier,
+                "redirect_uri": redirect_uri,
+                "grant_type": "authorization_code",
+            },
+        )
+        return _bundle_from_response(data)
+
+    def refresh(self, refresh_token: str) -> TokenBundle:
+        try:
+            data = self._post(
+                TOKEN_URL,
+                {
+                    "client_id": self._client_id,
+                    "client_secret": self._client_secret,
+                    "refresh_token": refresh_token,
+                    "grant_type": "refresh_token",
+                },
+            )
+        except OAuthProviderError as exc:
+            if exc.error_code == "invalid_grant":
+                raise AuthDegradedError("auth_revoked", "refresh token rejected (invalid_grant)") from None
+            raise
+        return _bundle_from_response(data)
+
+    def revoke(self, token: str) -> None:
+        self._post(REVOKE_URL, {"token": token})
+
+
+# --- Loopback (installed-app) flow ------------------------------------------
+
+
+def _pkce_pair() -> tuple[str, str]:
+    verifier = secrets.token_urlsafe(64)  # 43-128 chars per RFC 7636
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return verifier, challenge
+
+
+def start_loopback_flow(client: OAuthClient, *, redirect_uri: str) -> LoopbackFlow:
+    """Build the loopback authorization request: URL + ``state`` + PKCE verifier.
+
+    The tokens never appear in any URL beyond the provider's own redirect params
+    (BIND spec); the caller opens ``authorization_url`` and later hands the
+    redirect back to :func:`complete_loopback_flow`.
+    """
+    state = secrets.token_urlsafe(32)
+    verifier, challenge = _pkce_pair()
+    url = client.build_authorization_url(redirect_uri=redirect_uri, state=state, code_challenge=challenge)
+    return LoopbackFlow(authorization_url=url, state=state, code_verifier=verifier, redirect_uri=redirect_uri)
+
+
+def complete_loopback_flow(
+    client: OAuthClient, flow: LoopbackFlow, *, returned_state: str, returned_code: str
+) -> TokenBundle:
+    """Validate the redirect ``state`` (constant-time) then exchange the code.
+
+    A tampered/mismatched ``state`` is refused with :class:`OAuthStateMismatchError`
+    before any token exchange happens.
+    """
+    if not hmac.compare_digest(returned_state, flow.state):
+        raise OAuthStateMismatchError(
+            "OAuth state mismatch: refusing to exchange the authorization code (possible CSRF/tamper)"
+        )
+    return client.exchange_code(
+        code=returned_code, code_verifier=flow.code_verifier, redirect_uri=flow.redirect_uri
+    )
+
+
+# --- Expiry-aware access-token provider -------------------------------------
+
+
+class TokenProvider:
+    """Expiry-aware access-token provider with single-flight refresh.
+
+    Returns a valid access token, refreshing under a lock when the cached one is
+    within the skew window of expiry. A missing token-store key or a rejected
+    refresh degrades the binding and its dependent sources (INV-YSS-4) and
+    raises :class:`AuthDegradedError` -- it never returns an empty/absent token
+    as a success.
+    """
+
+    def __init__(
+        self,
+        *,
+        binding_id: str,
+        token_store: YouTubeTokenStore,
+        oauth_client: OAuthClient,
+        binding_store: AccountBindingStore | None = None,
+        source_registry: SourceRegistry | None = None,
+        skew_seconds: int = _ACCESS_TOKEN_SKEW_SECONDS,
+    ) -> None:
+        self._binding_id = binding_id
+        self._store = token_store
+        self._client = oauth_client
+        self._bindings = binding_store
+        self._registry = source_registry
+        self._skew = skew_seconds
+        self._lock = threading.Lock()
+
+    def get_access_token(self) -> str:
+        token = self._read_token()
+        if self._is_fresh(token):
+            return token.access_token  # type: ignore[return-value]
+        with self._lock:
+            token = self._read_token()
+            if self._is_fresh(token):
+                return token.access_token  # type: ignore[return-value]
+            return self._refresh(token)
+
+    def _read_token(self) -> StoredToken:
+        try:
+            token = self._store.get(self._binding_id)
+        except TokenStoreKeyMissingError:
+            self._degrade("auth_key_missing")
+            raise AuthDegradedError("auth_key_missing", "token store key is not provisioned") from None
+        if token is None:
+            self._degrade("auth_missing")
+            raise AuthDegradedError("auth_missing", "no token stored for this binding")
+        return token
+
+    def _is_fresh(self, token: StoredToken) -> bool:
+        if not token.access_token or not token.expires_at:
+            return False
+        try:
+            expires = datetime.fromisoformat(token.expires_at)
+        except ValueError:
+            return False
+        if expires.tzinfo is None:
+            expires = expires.replace(tzinfo=timezone.utc)
+        return expires > datetime.now(timezone.utc) + timedelta(seconds=self._skew)
+
+    def _refresh(self, token: StoredToken) -> str:
+        _log.debug("youtube oauth: refreshing access token for binding %s", self._binding_id)
+        try:
+            bundle = self._client.refresh(token.refresh_token)
+        except AuthDegradedError as exc:
+            self._degrade(exc.reason_code)
+            raise
+        refreshed = StoredToken(
+            refresh_token=bundle.refresh_token or token.refresh_token,
+            access_token=bundle.access_token,
+            expires_at=_expiry_iso(bundle.expires_in),
+            scopes=token.scopes or (SCOPE,),
+            obtained_at=_now_iso(),
+            provider_channel_id=token.provider_channel_id,
+        )
+        self._store.put(self._binding_id, refreshed)
+        self._clear_degradation()
+        return bundle.access_token
+
+    def _degrade(self, reason_code: str) -> None:
+        """Stamp the reason on the binding + dependent sources; no cursor touched."""
+        if self._bindings is not None:
+            binding = self._bindings.get(self._binding_id)
+            if binding is not None:
+                self._bindings.set_state(self._binding_id, state="degraded", reason_code=reason_code)
+        if self._registry is not None:
+            for source in self._registry.list_for_account(self._binding_id):
+                self._registry.record_source_degradation(source.binding_id, reason_code=reason_code)
+
+    def _clear_degradation(self) -> None:
+        if self._bindings is None:
+            return
+        binding = self._bindings.get(self._binding_id)
+        if binding is not None and binding.state != "connected":
+            self._bindings.set_state(self._binding_id, state="connected", reason_code=None)
+
+
+# --- Account binding manager -------------------------------------------------
+
+
+class YouTubeAccountBinder:
+    """Connect / status / disconnect / reconnect for a YouTube account binding.
+
+    Wires the OAuth flows, the encrypted token store, the account-binding
+    registry, and (for degradation) the source registry into the one seam every
+    authenticated surface uses.
+    """
+
+    def __init__(
+        self,
+        *,
+        oauth_client: OAuthClient,
+        token_store: YouTubeTokenStore,
+        binding_store: AccountBindingStore,
+        identity_probe: IdentityProbe,
+        source_registry: SourceRegistry | None = None,
+    ) -> None:
+        self._client = oauth_client
+        self._store = token_store
+        self._bindings = binding_store
+        self._identity = identity_probe
+        self._registry = source_registry
+
+    # -- connect (device flow) ------------------------------------------------
+
+    def start_device_connection(self) -> DeviceConnection:
+        return DeviceConnection(handle=self._client.start_device_flow(), reconnect_binding_id=None)
+
+    def start_reconnect(self, binding_id: str) -> DeviceConnection:
+        if self._bindings.get(binding_id) is None:
+            raise KeyError(f"no such account binding: {binding_id}")
+        return DeviceConnection(handle=self._client.start_device_flow(), reconnect_binding_id=binding_id)
+
+    def finish_device_connection(self, connection: DeviceConnection) -> dict[str, Any]:
+        """Complete one device poll, persist tokens encrypted, bind the account.
+
+        Returns the non-secret connect receipt ``{status, account}`` -- no token
+        material. Raises :class:`DeviceAuthorizationPending` if the user has not
+        approved yet (the caller re-polls after ``interval``).
+        """
+        bundle = self._client.poll_device_flow(connection.handle.device_code)
+        return self._bind_from_bundle(bundle, connection.reconnect_binding_id)
+
+    def _bind_from_bundle(self, bundle: TokenBundle, reconnect_binding_id: str | None) -> dict[str, Any]:
+        if not bundle.refresh_token:
+            # A binding with no refresh token cannot sustain access; fail loud at
+            # bind time rather than storing an empty credential that only breaks
+            # later on the first refresh. The loopback/device requests set
+            # access_type=offline + prompt=consent, so a grant should always
+            # carry one.
+            raise OAuthProviderError(status=200, error_code="missing_refresh_token")
+        identity = self._identity(bundle.access_token)
+        binding = self._resolve_binding(identity, reconnect_binding_id)
+        token = StoredToken(
+            refresh_token=bundle.refresh_token,
+            access_token=bundle.access_token,
+            expires_at=_expiry_iso(bundle.expires_in),
+            scopes=(SCOPE,),
+            obtained_at=_now_iso(),
+            provider_channel_id=identity.channel_id,
+        )
+        self._store.put(binding.account_binding_id, token)
+        if binding.state != "connected" or binding.reason_code is not None:
+            binding = self._bindings.set_state(
+                binding.account_binding_id, state="connected", reason_code=None
+            )
+        _log.info("youtube oauth: account connected (binding %s)", binding.account_binding_id)
+        return redact(
+            {
+                "status": "connected",
+                "account": {
+                    "binding_id": binding.account_binding_id,
+                    "channel_title": binding.display_label,
+                },
+            }
+        )
+
+    def _resolve_binding(self, identity: ChannelIdentity, reconnect_binding_id: str | None) -> AccountBinding:
+        if reconnect_binding_id is not None:
+            target = self._bindings.get(reconnect_binding_id)
+            if target is None:
+                raise KeyError(f"no such account binding: {reconnect_binding_id}")
+            if target.provider_channel_id != identity.channel_id:
+                raise ReconnectChannelMismatchError(
+                    "reconnect consent resolved to a different channel than the target binding"
+                )
+            return target
+        existing = self._bindings.get_by_channel_id(identity.channel_id)
+        if existing is not None:
+            return existing
+        return self._bindings.create(
+            provider_channel_id=identity.channel_id,
+            display_label=identity.channel_title,
+            scopes=[SCOPE],
+        )
+
+    # -- status ---------------------------------------------------------------
+
+    def status(self, binding_id: str) -> dict[str, Any]:
+        """Live, non-secret status view for ``binding_id``.
+
+        Derives the fail-closed ``auth_key_missing`` state when a token record
+        exists but the store key is absent (INV-YSS-4), without persisting a
+        read-derived state.
+        """
+        binding = self._bindings.get(binding_id)
+        if binding is None:
+            return redact(
+                {"status": "absent", "reason_code": "auth_missing", "scopes": [], "token_store": "encrypted"}
+            )
+        state, reason_code = binding.state, binding.reason_code
+        if self._store.has_record(binding_id):
+            try:
+                resolve_token_store_key()
+            except TokenStoreKeyMissingError:
+                state, reason_code = "degraded", "auth_key_missing"
+        return redact(
+            {
+                "status": state,
+                "reason_code": reason_code,
+                "scopes": list(binding.scopes),
+                "token_store": "encrypted",
+            }
+        )
+
+    # -- disconnect -----------------------------------------------------------
+
+    def disconnect(self, binding_id: str) -> dict[str, Any]:
+        """Revoke at the provider, delete the token record, disable dependent
+        sources with ``auth_disconnected`` -- and delete no acquired artifacts.
+        """
+        binding = self._bindings.get(binding_id)
+        if binding is None:
+            raise KeyError(f"no such account binding: {binding_id}")
+
+        revoked = False
+        try:
+            token = self._store.get(binding_id)
+        except TokenStoreKeyMissingError:
+            token = None  # cannot decrypt to revoke; still tear down locally
+        if token is not None:
+            revocation_token = token.refresh_token or token.access_token or ""
+            if revocation_token:
+                try:
+                    self._client.revoke(revocation_token)
+                    revoked = True
+                except OAuthProviderError:
+                    revoked = False  # provider revoke failed; local disconnect still proceeds
+
+        self._store.delete(binding_id)
+        self._bindings.set_state(binding_id, state="degraded", reason_code="auth_disconnected")
+
+        sources_disabled = 0
+        if self._registry is not None:
+            for source in self._registry.list_for_account(binding_id):
+                self._registry.disable_source_for_auth(source.binding_id, reason_code="auth_disconnected")
+                sources_disabled += 1
+
+        _log.info("youtube oauth: account disconnected (binding %s)", binding_id)
+        return redact(
+            {"status": "disconnected", "revoked": revoked, "sources_disabled": sources_disabled}
+        )
+
+
+__all__ = [
+    "ALLOWED_OAUTH_HOSTS",
+    "AUTHORIZATION_ENDPOINT",
+    "AuthDegradedError",
+    "CLIENT_ID_ENV",
+    "CLIENT_SECRET_ENV",
+    "ChannelIdentity",
+    "DEVICE_CODE_URL",
+    "DeviceAuthorizationError",
+    "DeviceAuthorizationPending",
+    "DeviceConnection",
+    "DeviceFlowHandle",
+    "DisallowedOAuthHostError",
+    "IdentityProbe",
+    "LoopbackFlow",
+    "OAuthClient",
+    "OAuthClientCredentialsMissingError",
+    "OAuthProviderError",
+    "OAuthStateMismatchError",
+    "REVOKE_URL",
+    "ReconnectChannelMismatchError",
+    "SCOPE",
+    "TOKEN_URL",
+    "TokenBundle",
+    "TokenProvider",
+    "YouTubeAccountBinder",
+    "complete_loopback_flow",
+    "redact",
+    "resolve_oauth_client_credentials",
+    "start_loopback_flow",
+]

--- a/app/knowledge_acquisition/youtube_token_store.py
+++ b/app/knowledge_acquisition/youtube_token_store.py
@@ -1,0 +1,258 @@
+"""YSS-02 (#3917): encrypted-at-rest OAuth token store for YouTube bindings.
+
+Implements ``docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md :: Secrets and
+private bindings``: refresh/access tokens live only inside an AES-256-GCM
+encrypted file, keyed by the account binding id. The key discipline mirrors
+``app/heimdal/raw_store.py`` exactly -- authenticated encryption, a fresh
+random nonce per record, and fail-loud key resolution that refuses to write or
+read plaintext when the key is absent.
+
+Boundary (INV-YSS-5 / INV-YSS-7):
+
+- The store file path is an **app-local** binding, defaulting under the
+  channel runtime dir (``runtime/knowledge_acquisition/``); it is never placed
+  inside a vault and never tracked by git. Per-channel isolation (dev/test/prod
+  never share OAuth state) comes from the per-channel runtime dir / the
+  ``YOUTUBE_TOKEN_STORE_PATH`` override, exactly as the dispatcher isolates its
+  state dir per channel.
+- The key comes from ``YOUTUBE_TOKEN_STORE_KEY`` (32 bytes, hex), resolved
+  through the host secret-provisioning boundary. A missing key with an existing
+  binding is a legible ``auth_key_missing`` degraded state upstream, never a
+  plaintext fallback -- this module raises :class:`TokenStoreKeyMissingError`
+  and the OAuth layer maps it to the reason code.
+- The on-disk structure carries only non-secret keys (binding ids) mapping to
+  ``{ciphertext, nonce}``; no token, code, or client secret is ever written in
+  clear. The record index (which binding ids have tokens) is readable without
+  the key so upstream can detect "a binding exists" and fail closed; decrypting
+  a record's bytes always requires the key.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+KEY_ENV_VAR = "YOUTUBE_TOKEN_STORE_KEY"
+PATH_ENV_VAR = "YOUTUBE_TOKEN_STORE_PATH"
+
+_AES_KEY_BYTES = 32  # AES-256
+_NONCE_BYTES = 12  # standard AES-GCM nonce size
+_SCHEMA = "youtube-token-store.v1"
+_DEFAULT_REL_PATH = Path("runtime/knowledge_acquisition/youtube_token_store.enc")
+
+
+class TokenStoreKeyMissingError(RuntimeError):
+    """No/invalid encryption key configured -- refuse, never read/write plaintext.
+
+    Upstream (``youtube_oauth``) catches this and degrades the binding to the
+    ``auth_key_missing`` reason code (INV-YSS-4); it is never swallowed into a
+    silent plaintext path.
+    """
+
+
+def resolve_token_store_key() -> bytes:
+    """Resolve the AES-256-GCM key, fail-loud (mirrors ``resolve_raw_store_key``).
+
+    The key is a 64-char hex string (32 bytes) in ``YOUTUBE_TOKEN_STORE_KEY``;
+    generate with ``python -c "import secrets; print(secrets.token_hex(32))"``.
+    A missing or malformed key raises rather than falling back to plaintext or
+    a fixed default key.
+    """
+    raw = os.environ.get(KEY_ENV_VAR)
+    if not raw:
+        raise TokenStoreKeyMissingError(
+            f"{KEY_ENV_VAR} is not set: YouTube OAuth tokens are encrypted at rest and this "
+            "store refuses to read or write plaintext or use a fixed default key. Set "
+            f"{KEY_ENV_VAR} to a 64-char hex string (32 bytes)."
+        )
+    try:
+        key = bytes.fromhex(raw.strip())
+    except ValueError as exc:
+        raise TokenStoreKeyMissingError(f"{KEY_ENV_VAR} is not valid hex: {exc}") from exc
+    if len(key) != _AES_KEY_BYTES:
+        raise TokenStoreKeyMissingError(
+            f"{KEY_ENV_VAR} must decode to {_AES_KEY_BYTES} bytes (AES-256), got {len(key)}"
+        )
+    return key
+
+
+def default_token_store_path() -> Path:
+    """App-local default path, overridable per channel via ``YOUTUBE_TOKEN_STORE_PATH``."""
+    override = (os.environ.get(PATH_ENV_VAR) or "").strip()
+    if override:
+        return Path(override).expanduser()
+    return _DEFAULT_REL_PATH
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass(frozen=True)
+class StoredToken:
+    """The decrypted token material for one binding.
+
+    ``refresh_token`` is a standing credential to the user's account; it and
+    ``access_token`` never leave this object except through the encrypted store
+    or the in-memory access-token provider. :meth:`__repr__` is redaction-aware
+    so an accidental log/exception interpolation cannot leak the secret bytes.
+    """
+
+    refresh_token: str
+    access_token: str | None
+    expires_at: str | None  # ISO-8601 UTC access-token expiry, or None
+    scopes: tuple[str, ...]
+    obtained_at: str  # ISO-8601 UTC
+    provider_channel_id: str | None
+
+    def __repr__(self) -> str:  # redaction-aware (INV-YSS-5)
+        return (
+            "StoredToken(refresh_token=***, access_token=***, "
+            f"expires_at={self.expires_at!r}, scopes={list(self.scopes)!r}, "
+            f"obtained_at={self.obtained_at!r}, provider_channel_id={self.provider_channel_id!r})"
+        )
+
+    def with_expired_access(self) -> "StoredToken":
+        """Return a copy whose access token is already expired (forces refresh)."""
+        return StoredToken(
+            refresh_token=self.refresh_token,
+            access_token=self.access_token,
+            expires_at="1970-01-01T00:00:00+00:00",
+            scopes=self.scopes,
+            obtained_at=self.obtained_at,
+            provider_channel_id=self.provider_channel_id,
+        )
+
+    def _to_plain(self) -> dict[str, Any]:
+        return {
+            "refresh_token": self.refresh_token,
+            "access_token": self.access_token,
+            "expires_at": self.expires_at,
+            "scopes": list(self.scopes),
+            "obtained_at": self.obtained_at,
+            "provider_channel_id": self.provider_channel_id,
+        }
+
+    @classmethod
+    def _from_plain(cls, data: dict[str, Any]) -> "StoredToken":
+        return cls(
+            refresh_token=data["refresh_token"],
+            access_token=data.get("access_token"),
+            expires_at=data.get("expires_at"),
+            scopes=tuple(data.get("scopes") or ()),
+            obtained_at=data.get("obtained_at") or _now_iso(),
+            provider_channel_id=data.get("provider_channel_id"),
+        )
+
+
+class YouTubeTokenStore:
+    """AES-256-GCM encrypted token store, one JSON file, one record per binding.
+
+    Thread-safe for concurrent access within a process; cross-process safety is
+    provided by an atomic replace on every write.
+    """
+
+    def __init__(self, path: Path | str | None = None) -> None:
+        self._path = Path(path) if path is not None else default_token_store_path()
+        self._lock = threading.Lock()
+
+    def __repr__(self) -> str:
+        return f"YouTubeTokenStore(path={str(self._path)!r})"
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    # --- file helpers (no key required) -------------------------------------
+
+    def _load_file(self) -> dict[str, Any]:
+        try:
+            raw = self._path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return {"schema": _SCHEMA, "records": {}}
+        data = json.loads(raw)
+        if not isinstance(data, dict) or "records" not in data:
+            raise ValueError(f"corrupt token store file at {self._path}")
+        return data
+
+    def _write_file(self, data: dict[str, Any]) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self._path.with_suffix(self._path.suffix + ".tmp")
+        tmp.write_text(json.dumps(data, sort_keys=True), encoding="utf-8")
+        os.replace(tmp, self._path)
+
+    def has_record(self, binding_id: str) -> bool:
+        """True if a token record exists for ``binding_id`` (no key required)."""
+        with self._lock:
+            return binding_id in self._load_file()["records"]
+
+    def binding_ids(self) -> tuple[str, ...]:
+        """All binding ids with a token record (no key required)."""
+        with self._lock:
+            return tuple(self._load_file()["records"].keys())
+
+    def delete(self, binding_id: str) -> bool:
+        """Remove one binding's token record. Returns True if a record existed.
+
+        No key is required: deletion removes ciphertext, it does not read it.
+        """
+        with self._lock:
+            data = self._load_file()
+            existed = binding_id in data["records"]
+            if existed:
+                del data["records"][binding_id]
+                self._write_file(data)
+            return existed
+
+    # --- encrypted record access (key required) -----------------------------
+
+    def put(self, binding_id: str, token: StoredToken) -> None:
+        """Encrypt and persist ``token`` for ``binding_id`` (requires the key)."""
+        key = resolve_token_store_key()
+        plaintext = json.dumps(token._to_plain(), sort_keys=True).encode("utf-8")
+        nonce = os.urandom(_NONCE_BYTES)
+        ciphertext = AESGCM(key).encrypt(nonce, plaintext, None)
+        with self._lock:
+            data = self._load_file()
+            data["records"][binding_id] = {
+                "ciphertext": base64.b64encode(ciphertext).decode("ascii"),
+                "nonce": base64.b64encode(nonce).decode("ascii"),
+            }
+            self._write_file(data)
+
+    def get(self, binding_id: str) -> StoredToken | None:
+        """Return the decrypted token for ``binding_id``, or None if absent.
+
+        Returns None when no record exists (no key needed for that). When a
+        record DOES exist, the key is required to decrypt it; a missing key
+        raises :class:`TokenStoreKeyMissingError` -- there is no plaintext read
+        path (fail closed, INV-YSS-4).
+        """
+        with self._lock:
+            record = self._load_file()["records"].get(binding_id)
+        if record is None:
+            return None
+        key = resolve_token_store_key()
+        ciphertext = base64.b64decode(record["ciphertext"])
+        nonce = base64.b64decode(record["nonce"])
+        plaintext = AESGCM(key).decrypt(nonce, ciphertext, None)
+        return StoredToken._from_plain(json.loads(plaintext.decode("utf-8")))
+
+
+__all__ = [
+    "KEY_ENV_VAR",
+    "PATH_ENV_VAR",
+    "StoredToken",
+    "TokenStoreKeyMissingError",
+    "YouTubeTokenStore",
+    "default_token_store_path",
+    "resolve_token_store_key",
+]

--- a/tests/guard/test_no_direct_db_imports.py
+++ b/tests/guard/test_no_direct_db_imports.py
@@ -139,6 +139,11 @@ ALLOW_FILES = (
     # (acquisition_source_registry) with a self-contained dual memory/pg
     # backend, direct DSN connection, no ORM layer to route through.
     'app/knowledge_acquisition/source_registry.py',
+    # YouTube Source Sync durable account-binding registry (YSS-02, #3917). Same
+    # bounded pattern as source_registry.py above: a dedicated table
+    # (youtube_account_binding) with a self-contained dual memory/pg backend,
+    # direct DSN connection, no ORM layer to route through.
+    'app/knowledge_acquisition/youtube_account_binding.py',
 )
 
 def _allowed(p: Path) -> bool:

--- a/tests/knowledge_acquisition/test_youtube_account_binding_pg.py
+++ b/tests/knowledge_acquisition/test_youtube_account_binding_pg.py
@@ -1,0 +1,143 @@
+"""YSS-02 (#3917): account-binding registry service contract, Postgres backend.
+
+Exercises the SAME service-layer contract as the memory backend (which
+``tests/knowledge_acquisition/test_youtube_oauth.py`` drives implicitly) against
+the real Postgres-backed ``AccountBindingStore``, proving the integrity rules
+hold identically on both backends and that the forward-only migration
+``a2f1c3e4d5b6`` creates the schema the store's fail-loud preflight expects.
+
+Marked ``pg``: excluded by the default ``-m "not pg"`` suite; does not run
+locally without a real Postgres. Mirrors ``test_source_registry_pg.py`` -- an
+isolated database, upgraded through Alembic with schema autocreate disabled (so
+the migration, not the store's bootstrap, owns the schema), then the contract,
+then the forward-only downgrade assertion.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+
+import psycopg
+import pytest
+from alembic import command
+from alembic.config import Config
+from psycopg.conninfo import conninfo_to_dict, make_conninfo
+from sqlalchemy.engine import URL
+
+from app.knowledge_acquisition.youtube_account_binding import (
+    AccountBindingStore,
+    AccountBindingValidationError,
+    DuplicateAccountBindingError,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PRE_YSS02_HEAD = "bd79f3044759"
+YSS02_HEAD = "a2f1c3e4d5b6"
+
+# Synthetic ids only (INV-YSS-9).
+CHANNEL_A = "UC__test__acct_binding_pg_a"
+CHANNEL_B = "UC__test__acct_binding_pg_b"
+SCOPE = "https://www.googleapis.com/auth/youtube.readonly"
+
+
+def _alembic_config() -> Config:
+    config = Config(str(REPO_ROOT / "alembic.ini"))
+    config.set_main_option("script_location", str(REPO_ROOT / "app" / "alembic"))
+    return config
+
+
+@pytest.fixture
+def migrated_binding_database(monkeypatch: pytest.MonkeyPatch) -> Iterator[Config]:
+    """Yield an Alembic-migrated isolated database and drop it afterwards."""
+    from app.db.dsn import resolve_dsn
+
+    admin_dsn = resolve_dsn()
+    if not admin_dsn:
+        pytest.skip("DATABASE_URL/DB_DSN not configured")
+    try:
+        with psycopg.connect(admin_dsn, connect_timeout=2):
+            pass
+    except Exception as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"Postgres unavailable: {exc}")
+
+    database_name = f"scratch_yss02_binding_{uuid.uuid4().hex[:12]}"
+    scratch_params = conninfo_to_dict(admin_dsn)
+    scratch_params["dbname"] = database_name
+    scratch_conninfo = make_conninfo(**scratch_params)
+    scratch_url = URL.create(
+        "postgresql",
+        username=scratch_params.get("user"),
+        password=scratch_params.get("password"),
+        host=scratch_params.get("host"),
+        port=int(scratch_params["port"]) if scratch_params.get("port") else None,
+        database=database_name,
+    ).render_as_string(hide_password=False)
+
+    with psycopg.connect(admin_dsn, autocommit=True) as conn:
+        conn.execute(f'CREATE DATABASE "{database_name}"')
+    try:
+        with psycopg.connect(scratch_conninfo, autocommit=True) as conn:
+            conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
+
+        monkeypatch.setenv("DATABASE_URL", scratch_url)
+        monkeypatch.delenv("DB_DSN", raising=False)
+        monkeypatch.delenv("STORE_SCHEMA_AUTOCREATE", raising=False)
+        monkeypatch.delenv("STORE_BACKEND", raising=False)
+        config = _alembic_config()
+        command.upgrade(config, YSS02_HEAD)
+        yield config
+    finally:
+        with psycopg.connect(admin_dsn, autocommit=True) as conn:
+            conn.execute(f'DROP DATABASE IF EXISTS "{database_name}" WITH (FORCE)')
+
+
+@pytest.mark.pg
+def test_pg_backend_contract(migrated_binding_database: Config) -> None:
+    store = AccountBindingStore.for_runtime()
+
+    created = store.create(
+        provider_channel_id=CHANNEL_A, display_label="Chan A", scopes=[SCOPE]
+    )
+    assert created.state == "connected"
+    assert created.reason_code is None
+    assert created.scopes == (SCOPE,)
+
+    # Round-trips out of Postgres unchanged.
+    fetched = store.get(created.account_binding_id)
+    assert fetched is not None
+    assert fetched.provider_channel_id == CHANNEL_A
+    assert store.get_by_channel_id(CHANNEL_A).account_binding_id == created.account_binding_id
+
+    # Degrade → reason set; reconnect → reason cleared.
+    degraded = store.set_state(created.account_binding_id, state="degraded", reason_code="auth_revoked")
+    assert degraded.state == "degraded"
+    assert degraded.reason_code == "auth_revoked"
+    reconnected = store.set_state(created.account_binding_id, state="connected", reason_code=None)
+    assert reconnected.state == "connected"
+    assert reconnected.reason_code is None
+
+    # One binding per channel (unique index).
+    with pytest.raises(DuplicateAccountBindingError):
+        store.create(provider_channel_id=CHANNEL_A, display_label="dup", scopes=[SCOPE])
+
+    # A connected binding may not carry a reason code (service + DB check).
+    with pytest.raises(AccountBindingValidationError):
+        store.set_state(created.account_binding_id, state="connected", reason_code="auth_revoked")
+
+    # A second, distinct channel is fine.
+    other = store.create(provider_channel_id=CHANNEL_B, display_label="Chan B", scopes=[SCOPE])
+    assert {b.account_binding_id for b in store.list_all()} == {
+        created.account_binding_id,
+        other.account_binding_id,
+    }
+
+    # Delete removes exactly one row.
+    assert store.delete(created.account_binding_id) is True
+    assert store.get(created.account_binding_id) is None
+    assert store.delete(created.account_binding_id) is False
+
+    # The migration is forward-only.
+    with pytest.raises(RuntimeError, match="forward-only"):
+        command.downgrade(migrated_binding_database, PRE_YSS02_HEAD)

--- a/tests/knowledge_acquisition/test_youtube_oauth.py
+++ b/tests/knowledge_acquisition/test_youtube_oauth.py
@@ -1,0 +1,485 @@
+"""YSS-02 (#3917): OAuth account binding + encrypted token store.
+
+Every network egress is stubbed at the httpx transport layer
+(``httpx.MockTransport``), so the production request-building code paths run
+unchanged and the outgoing requests can be asserted directly (AC7). No real
+Google credentials, no real playlist/channel/account identifiers (INV-YSS-9);
+every id here is a synthetic ``__test__`` constant.
+
+The binding contract is ``docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md ::
+Secrets and private bindings`` and INV-YSS-4 / INV-YSS-5 in that dir's README.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import secrets
+from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
+
+import httpx
+import pytest
+
+from app.knowledge_acquisition import source_registry as sr
+from app.knowledge_acquisition import youtube_account_binding as yab
+from app.knowledge_acquisition import youtube_oauth as oauth
+from app.knowledge_acquisition import youtube_token_store as tokstore
+
+# --- Synthetic constants (INV-YSS-9: never a real id, ever) -----------------
+
+SYNTH_CHANNEL_ID = "UC__test__synthetic_channel_00"
+SYNTH_CHANNEL_TITLE = "Test Fixture Channel"
+SYNTH_PLAYLIST_REF = "PL__test__synthetic_playlist_00"
+
+# Planted secrets: if any of these ever surfaces in a log line, receipt,
+# exception, or --json payload, AC5 fails. They are deliberately distinctive.
+SENTINEL_REFRESH = "sentinel-REFRESH-must-never-leak-" + secrets.token_hex(8)
+SENTINEL_ACCESS = "sentinel-ACCESS-must-never-leak-" + secrets.token_hex(8)
+SENTINEL_ACCESS_2 = "sentinel-ACCESS2-must-never-leak-" + secrets.token_hex(8)
+SENTINEL_CLIENT_SECRET = "sentinel-CLIENTSECRET-must-never-leak-" + secrets.token_hex(8)
+SENTINEL_DEVICE_CODE = "sentinel-DEVICECODE-must-never-leak-" + secrets.token_hex(8)
+
+TEST_CLIENT_ID = "test-client-id.apps.googleusercontent.example"
+# 64 hex chars => 32 bytes AES-256 key
+TEST_STORE_KEY = secrets.token_hex(32)
+
+_ALL_SENTINELS = (
+    SENTINEL_REFRESH,
+    SENTINEL_ACCESS,
+    SENTINEL_ACCESS_2,
+    SENTINEL_CLIENT_SECRET,
+    SENTINEL_DEVICE_CODE,
+)
+
+
+# --- Transport stub ---------------------------------------------------------
+
+
+class _Provider:
+    """Scriptable Google-OAuth stub bound to a ``httpx.MockTransport``.
+
+    Records every request so tests can assert on the production call site.
+    """
+
+    def __init__(self) -> None:
+        self.requests: list[httpx.Request] = []
+        self.token_responses: list[httpx.Response] = []
+        self.revoked: list[dict[str, str]] = []
+        self.device_granted = True
+
+    def _body(self, request: httpx.Request) -> dict[str, str]:
+        raw = request.content.decode() if request.content else ""
+        return {k: v[0] for k, v in parse_qs(raw).items()}
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        path = urlsplit(str(request.url)).path
+        if path.endswith("/device/code"):
+            return httpx.Response(
+                200,
+                request=request,
+                json={
+                    "device_code": SENTINEL_DEVICE_CODE,
+                    "user_code": "WXYZ-ABCD",
+                    "verification_url": "https://www.google.com/device",
+                    "verification_url_complete": "https://www.google.com/device?user_code=WXYZ-ABCD",
+                    "expires_in": 1800,
+                    "interval": 5,
+                },
+            )
+        if path.endswith("/token"):
+            if self.token_responses:
+                return self.token_responses.pop(0)
+            return httpx.Response(
+                200,
+                request=request,
+                json={
+                    "access_token": SENTINEL_ACCESS,
+                    "refresh_token": SENTINEL_REFRESH,
+                    "expires_in": 3600,
+                    "scope": oauth.SCOPE,
+                    "token_type": "Bearer",
+                },
+            )
+        if path.endswith("/revoke"):
+            self.revoked.append(self._body(request))
+            return httpx.Response(200, request=request, json={})
+        return httpx.Response(404, request=request, json={"error": "not_found"})  # pragma: no cover
+
+
+def _granted_token(access: str = SENTINEL_ACCESS, refresh: str = SENTINEL_REFRESH) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={
+            "access_token": access,
+            "refresh_token": refresh,
+            "expires_in": 3600,
+            "scope": oauth.SCOPE,
+            "token_type": "Bearer",
+        },
+    )
+
+
+def _invalid_grant() -> httpx.Response:
+    return httpx.Response(400, json={"error": "invalid_grant", "error_description": "Token has been revoked."})
+
+
+def _client(provider: _Provider) -> oauth.OAuthClient:
+    http = httpx.Client(transport=httpx.MockTransport(provider.handler))
+    return oauth.OAuthClient(client_id=TEST_CLIENT_ID, client_secret=SENTINEL_CLIENT_SECRET, http=http)
+
+
+def _identity_probe(_access_token: str) -> oauth.ChannelIdentity:
+    return oauth.ChannelIdentity(channel_id=SYNTH_CHANNEL_ID, channel_title=SYNTH_CHANNEL_TITLE)
+
+
+# --- Fixtures ---------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_memory_backends(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    monkeypatch.setenv(tokstore.KEY_ENV_VAR, TEST_STORE_KEY)
+    monkeypatch.setenv(oauth.CLIENT_ID_ENV, TEST_CLIENT_ID)
+    monkeypatch.setenv(oauth.CLIENT_SECRET_ENV, SENTINEL_CLIENT_SECRET)
+    sr.reset_memory_source_registry()
+    yab.reset_memory_account_bindings()
+    yield
+    sr.reset_memory_source_registry()
+    yab.reset_memory_account_bindings()
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> tokstore.YouTubeTokenStore:
+    return tokstore.YouTubeTokenStore(path=tmp_path / "youtube_token_store.enc")
+
+
+@pytest.fixture()
+def bindings() -> yab.AccountBindingStore:
+    return yab.AccountBindingStore.for_runtime()
+
+
+@pytest.fixture()
+def registry() -> sr.SourceRegistry:
+    return sr.SourceRegistry.for_runtime()
+
+
+def _binder(
+    provider: _Provider,
+    store: tokstore.YouTubeTokenStore,
+    bindings: yab.AccountBindingStore,
+    registry: sr.SourceRegistry,
+) -> oauth.YouTubeAccountBinder:
+    return oauth.YouTubeAccountBinder(
+        oauth_client=_client(provider),
+        token_store=store,
+        binding_store=bindings,
+        source_registry=registry,
+        identity_probe=_identity_probe,
+    )
+
+
+def _connect_device(binder: oauth.YouTubeAccountBinder) -> dict:
+    connection = binder.start_device_connection()
+    return binder.finish_device_connection(connection)
+
+
+# --- AC1 --------------------------------------------------------------------
+
+
+def test_device_flow_persists_encrypted_only(store, bindings, registry, tmp_path):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+
+    result = _connect_device(binder)
+    assert result["status"] == "connected"
+    binding_id = result["account"]["binding_id"]
+
+    # The token round-trips through the encrypted store with the key present.
+    loaded = store.get(binding_id)
+    assert loaded is not None
+    assert loaded.refresh_token == SENTINEL_REFRESH
+    assert loaded.access_token == SENTINEL_ACCESS
+
+    # ...but the on-disk bytes carry no plaintext token material.
+    raw = (tmp_path / "youtube_token_store.enc").read_bytes()
+    for sentinel in (SENTINEL_REFRESH, SENTINEL_ACCESS):
+        assert sentinel.encode() not in raw
+    # ...and are unreadable without the key (fail closed, no plaintext path).
+    import os
+
+    del os.environ[tokstore.KEY_ENV_VAR]
+    reopened = tokstore.YouTubeTokenStore(path=tmp_path / "youtube_token_store.enc")
+    with pytest.raises(tokstore.TokenStoreKeyMissingError):
+        reopened.get(binding_id)
+
+
+# --- AC2 --------------------------------------------------------------------
+
+
+def test_loopback_flow_rejects_tampered_state(store, bindings, registry):
+    provider = _Provider()
+    client = _client(provider)
+
+    flow = oauth.start_loopback_flow(client, redirect_uri="http://127.0.0.1:8765/callback")
+
+    parts = urlsplit(flow.authorization_url)
+    assert parts.netloc == "accounts.google.com"
+    params = {k: v[0] for k, v in parse_qs(parts.query).items()}
+    assert params["scope"] == oauth.SCOPE
+    assert params["code_challenge_method"] == "S256"
+    assert params["code_challenge"] and params["code_challenge"] != flow.code_verifier
+    assert params["state"] == flow.state
+    assert params["response_type"] == "code"
+
+    # A tampered state must be refused before any code exchange happens.
+    with pytest.raises(oauth.OAuthStateMismatchError):
+        oauth.complete_loopback_flow(
+            client, flow, returned_state=flow.state + "-tampered", returned_code="whatever"
+        )
+    assert not any(urlsplit(str(r.url)).path.endswith("/token") for r in provider.requests)
+
+    # The honest state exchanges the code, forwarding the PKCE verifier.
+    bundle = oauth.complete_loopback_flow(
+        client, flow, returned_state=flow.state, returned_code="auth-code-xyz"
+    )
+    assert bundle.access_token == SENTINEL_ACCESS
+    token_req = next(r for r in provider.requests if urlsplit(str(r.url)).path.endswith("/token"))
+    body = {k: v[0] for k, v in parse_qs(token_req.content.decode()).items()}
+    assert body["code_verifier"] == flow.code_verifier
+    assert body["grant_type"] == "authorization_code"
+
+
+# --- AC3 --------------------------------------------------------------------
+
+
+def test_missing_store_key_fails_closed(store, bindings, registry, monkeypatch):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    result = _connect_device(binder)
+    binding_id = result["account"]["binding_id"]
+
+    # Key vanishes (e.g. host secret not re-provisioned after restart).
+    monkeypatch.delenv(tokstore.KEY_ENV_VAR, raising=False)
+
+    status = binder.status(binding_id)
+    assert status["status"] == "degraded"
+    assert status["reason_code"] == "auth_key_missing"
+
+    provider_client = _client(provider)
+    tp = oauth.TokenProvider(
+        binding_id=binding_id,
+        token_store=store,
+        oauth_client=provider_client,
+        binding_store=bindings,
+        source_registry=registry,
+    )
+    with pytest.raises(oauth.AuthDegradedError) as excinfo:
+        tp.get_access_token()
+    assert excinfo.value.reason_code == "auth_key_missing"
+
+    # No plaintext read path exists: the store itself refuses without a key.
+    with pytest.raises(tokstore.TokenStoreKeyMissingError):
+        store.get(binding_id)
+
+
+# --- AC4 --------------------------------------------------------------------
+
+
+def test_revoked_auth_degrades_without_cursor_mutation(store, bindings, registry):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    result = _connect_device(binder)
+    binding_id = result["account"]["binding_id"]
+
+    # A dependent authenticated source under this binding.
+    source = registry.register(
+        collection_kind="owned_playlist",
+        collection_ref=SYNTH_PLAYLIST_REF,
+        title="Owned",
+        account_binding_id=binding_id,
+    )
+    cursor_before = dict(source.cursor)
+
+    # Force a refresh whose refresh_token the provider now rejects.
+    store.put(
+        binding_id,
+        store.get(binding_id).with_expired_access(),
+    )
+    provider.token_responses.append(_invalid_grant())
+
+    tp = oauth.TokenProvider(
+        binding_id=binding_id,
+        token_store=store,
+        oauth_client=_client(provider),
+        binding_store=bindings,
+        source_registry=registry,
+    )
+    with pytest.raises(oauth.AuthDegradedError) as excinfo:
+        tp.get_access_token()
+    assert excinfo.value.reason_code == "auth_revoked"
+
+    # Binding + dependent source both read auth_revoked.
+    assert bindings.get(binding_id).state == "degraded"
+    assert bindings.get(binding_id).reason_code == "auth_revoked"
+    degraded_source = registry.get(source.binding_id)
+    assert degraded_source.last_error is not None
+    assert degraded_source.last_error["reason_code"] == "auth_revoked"
+    # No cursor was mutated by the auth failure (INV-YSS-4/INV-YSS-1), and the
+    # source row stays enabled (degraded, recoverable — not disconnected).
+    assert degraded_source.cursor == cursor_before
+    assert degraded_source.enabled is True
+
+
+# --- AC5 --------------------------------------------------------------------
+
+
+def test_no_secret_in_logs_events_receipts_or_json(store, bindings, registry, caplog):
+    caplog.set_level(logging.DEBUG)
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+
+    emitted: list[dict] = []
+
+    connect_result = _connect_device(binder)
+    emitted.append(connect_result)
+    binding_id = connect_result["account"]["binding_id"]
+    emitted.append(binder.status(binding_id))
+
+    # A successful refresh, then a failing (revoked) one.
+    store.put(binding_id, store.get(binding_id).with_expired_access())
+    provider.token_responses.append(_granted_token(access=SENTINEL_ACCESS_2, refresh=SENTINEL_REFRESH))
+    tp = oauth.TokenProvider(
+        binding_id=binding_id,
+        token_store=store,
+        oauth_client=_client(provider),
+        binding_store=bindings,
+        source_registry=registry,
+    )
+    tp.get_access_token()  # refreshes to SENTINEL_ACCESS_2
+
+    store.put(binding_id, store.get(binding_id).with_expired_access())
+    provider.token_responses.append(_invalid_grant())
+    captured_exc = ""
+    try:
+        tp.get_access_token()
+    except oauth.AuthDegradedError as exc:
+        captured_exc = repr(exc) + str(exc)
+    emitted.append(binder.status(binding_id))
+
+    haystack = "\n".join([json.dumps(e) for e in emitted])
+    haystack += "\n" + captured_exc
+    haystack += "\n" + caplog.text
+    # repr of the stored token must not leak either.
+    haystack += "\n" + repr(store.get.__self__)
+
+    for sentinel in _ALL_SENTINELS:
+        assert sentinel not in haystack, f"secret leaked: {sentinel[:24]}..."
+
+
+# --- AC6 --------------------------------------------------------------------
+
+
+def test_disconnect_revokes_without_deleting_artifacts(store, bindings, registry, monkeypatch, tmp_path):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    result = _connect_device(binder)
+    binding_id = result["account"]["binding_id"]
+
+    source = registry.register(
+        collection_kind="owned_playlist",
+        collection_ref=SYNTH_PLAYLIST_REF,
+        title="Owned",
+        account_binding_id=binding_id,
+    )
+
+    # A pre-existing acquired raw record must survive disconnect untouched.
+    monkeypatch.setenv("HEIMDAL_RAW_STORE_KEY", secrets.token_hex(32))
+    from app.heimdal import raw_store
+
+    raw_store.reset_memory_raw_store()
+    key = raw_store.resolve_raw_store_key()
+    ciphertext, nonce = raw_store.encrypt_raw_bytes(b"acquired-evidence", key=key)
+    raw_row, _created = raw_store.insert_raw_record(
+        content_identity="cid-artifact-1",
+        capture_chain=["youtube"],
+        sensor={"id": "yt"},
+        consent={"grant_ref": "g1"},
+        ciphertext=ciphertext,
+        nonce=nonce,
+        key_ref="k1",
+        source_path="mem://x",
+    )
+
+    disc = binder.disconnect(binding_id)
+    assert disc["status"] == "disconnected"
+
+    # Provider revoke was actually called.
+    assert provider.revoked, "revoke endpoint was not called"
+    # Token record deleted; binding marked disconnected.
+    assert store.has_record(binding_id) is False
+    assert bindings.get(binding_id).reason_code == "auth_disconnected"
+    # Dependent source disabled with auth_disconnected — but the row/cursor kept.
+    disabled = registry.get(source.binding_id)
+    assert disabled.enabled is False
+    assert disabled.last_error["reason_code"] == "auth_disconnected"
+    assert disabled.collection_ref == SYNTH_PLAYLIST_REF
+    # Acquired artifacts are never deleted by a disconnect.
+    assert raw_store.get_raw_record_by_content_identity("cid-artifact-1") is not None
+    assert raw_store.all_raw_records()[0].id == raw_row.id
+
+
+# --- AC7 --------------------------------------------------------------------
+
+
+def test_minimal_scope_requested_at_call_site(store, bindings, registry):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+
+    # Device flow: the scope on the real outgoing device-code request.
+    binder.start_device_connection()
+    device_req = next(r for r in provider.requests if urlsplit(str(r.url)).path.endswith("/device/code"))
+    device_body = {k: v[0] for k, v in parse_qs(device_req.content.decode()).items()}
+    assert device_body["scope"] == oauth.SCOPE
+    assert device_body["scope"].split() == [oauth.SCOPE]  # exactly one scope, nothing extra
+
+    # Loopback flow: the scope on the built authorization URL.
+    flow = oauth.start_loopback_flow(_client(provider), redirect_uri="http://127.0.0.1:8765/callback")
+    params = {k: v[0] for k, v in parse_qs(urlsplit(flow.authorization_url).query).items()}
+    assert params["scope"] == oauth.SCOPE
+    assert params["scope"].split() == [oauth.SCOPE]
+
+
+# --- Supporting unit tests --------------------------------------------------
+
+
+def test_token_store_roundtrip_and_delete(store):
+    token = tokstore.StoredToken(
+        refresh_token=SENTINEL_REFRESH,
+        access_token=SENTINEL_ACCESS,
+        expires_at="2999-01-01T00:00:00+00:00",
+        scopes=(oauth.SCOPE,),
+        obtained_at="2026-07-18T00:00:00+00:00",
+        provider_channel_id=SYNTH_CHANNEL_ID,
+    )
+    store.put("b-1", token)
+    assert store.has_record("b-1") is True
+    assert store.get("b-1").refresh_token == SENTINEL_REFRESH
+    assert store.delete("b-1") is True
+    assert store.has_record("b-1") is False
+    assert store.get("b-1") is None
+
+
+def test_oauth_client_refuses_off_allowlist_host():
+    http = httpx.Client(transport=httpx.MockTransport(lambda r: httpx.Response(200, json={})))
+    client = oauth.OAuthClient(client_id=TEST_CLIENT_ID, client_secret=SENTINEL_CLIENT_SECRET, http=http)
+    with pytest.raises(oauth.DisallowedOAuthHostError):
+        client._post("https://evil.example.com/token", {"grant_type": "refresh_token"})
+
+
+def test_missing_client_credentials_fail_loud(monkeypatch):
+    monkeypatch.delenv(oauth.CLIENT_ID_ENV, raising=False)
+    monkeypatch.delenv(oauth.CLIENT_SECRET_ENV, raising=False)
+    with pytest.raises(oauth.OAuthClientCredentialsMissingError):
+        oauth.resolve_oauth_client_credentials()


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

Governing-Issue: #3917

## Linked Issue
Fixes #3917

## SBS Impact
- Primary subsystem: EBF
- Secondary subsystem(s): PDM, OEF
- Write class: mechanical durable (machine-side code/tests; no authority-bearing writes)
- Authority impact: none (candidates stay review-required; INV-YSS-8)
- Persistence impact: AES-256-GCM encrypted app-local token store file (never vault/repo) + a new migration-owned `youtube_account_binding` table (non-secret binding metadata)
- Derived/rebuildable impact: all sync state rebuildable from source + queue (binding rebuildable by re-consenting)
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: none (no new services; channel isolation per INV-YSS-7)
- External boundary impact: adds `accounts.google.com` + `oauth2.googleapis.com` egress (OAuth device/loopback/token/revoke) behind an SSRF host allowlist, fully degradable
- New or changed contract: implements `docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md` (no contract change)
- Owner-doc impact: none (runbook already in the spec dir)
- Transition debt impact: no effect
- Fitness rule impact: strengthens (enforcement ACs assert the production request-building call site)
- Boundary risk: secret non-disclosure (INV-YSS-5); fail-closed key handling

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Lands the single minimal-scope (`youtube.readonly`) OAuth account-binding seam for YouTube Source Sync: **device-authorization** (primary) + **loopback/PKCE** (secondary) consent flows over the existing `httpx` dependency, with an SSRF host allowlist and `state`/PKCE validation.
- Persists tokens only in an **AES-256-GCM encrypted-at-rest token store** (`youtube_token_store.py`, mirroring `app/heimdal/raw_store.py` key discipline) that **fails closed** on a missing `YOUTUBE_TOKEN_STORE_KEY` (`auth_key_missing`, never plaintext); the non-secret **account binding** lives in a dual memory/pg registry (`youtube_account_binding.py`) with a forward-only migration.
- Adds an expiry-aware **single-flight `TokenProvider`** and legible **auth degradation** (revoke/expire/key-missing/disconnect) that stamps reason codes on the binding and its dependent sources **without mutating any cursor** and **never deletes acquired artifacts**. No secret enters a returned payload, log line, event, receipt, or exception (INV-YSS-5).

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed. (No contract/behavior doc change — implements the existing SOURCE_SYNC_CONTRACT; runbook already present.)
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality. (Owner-doc impact: none per the Issue; live-capability acceptance remains a parent-issue checklist item.)

## Validation
Implementation lane:
- [x] `ruff check app tests` → **All checks passed!**
- [x] Lint output included: `ruff check app tests` passes; new files pass `ruff check` individually.
- [x] `mypy app/knowledge_acquisition/{youtube_oauth,youtube_token_store,youtube_account_binding,source_registry}.py` → **Success: no issues found in 4 source files** (full `mypy app` deferred to CI; local venv lacks some type stubs).
- [x] `pytest -q -m "not pg"` — the directly-affected package is green: `tests/knowledge_acquisition/` → **110 passed, 2 pg-deselected**; the AC file `test_youtube_oauth.py` → **10 passed** (7 ACs + 3 supporting units). The full-repo `-m "not pg"` run is authoritative in CI (local workspace venv is known-stale for a few unrelated collections).
- [x] Additional targeted checks: `test_youtube_account_binding_pg.py::test_pg_backend_contract` (marked `pg`) runs the **real forward-only migration** on an isolated database and asserts the downgrade raises — exercised by the CI `pg` job.

Every Acceptance Criterion's `Verify:` test is present and passing:
`test_device_flow_persists_encrypted_only`, `test_loopback_flow_rejects_tampered_state`, `test_missing_store_key_fails_closed`, `test_revoked_auth_degrades_without_cursor_mutation`, `test_no_secret_in_logs_events_receipts_or_json`, `test_disconnect_revokes_without_deleting_artifacts`, `test_minimal_scope_requested_at_call_site`.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded single-slice implementation delivered directly from the governing Issue #3917; no plan divergence, docs-freshness, roadmap-movement, or promotion material to route.

## Notes
- **Pickup coordination:** github-label-only fallback. The local dispatcher DB reports `dispatcher-backed`, but its coordination singleton is **stale** (holder `codex-root`, lease expired 2026-07-15) and the issue task was never synced into the local queue, so a dispatcher-backed claim could not verify a lease. Claim receipt: issue comment `5010051243`. Also cleared a stale `agent:blocked` label that the wave-unblock automation left alongside `agent:ready` (dependency YSS-01 / #3931 merged 2026-07-17).
- **Scope boundaries respected:** the two CLI commands shown in the spec and the full `youtube-auth` CLI family are **YSS-10** (`OPERATE_SYNC_FROM_CLI` lists `auth connect/status/disconnect`); this slice ships the module seam that CLI/UI will wrap. Real channel-identity resolution (`channels?mine=true`) is a **YSS-03** Data API read, taken here as an injected `IdentityProbe` so the binding seam stays decoupled and stubbable. No new `acquisition.*`/`youtube.sync.*` event topics are registered (that is YSS-04's KERNEL-08 scope); YSS-02 emits none.
- **Live verification** (real Google OAuth consent + revoke drill) needs the owner's OAuth client (`YOUTUBE_OAUTH_CLIENT_ID`/`YOUTUBE_OAUTH_CLIENT_SECRET`, `YOUTUBE_TOKEN_STORE_KEY` via the host secret boundary) and is a parent-issue live-acceptance checklist item; the implementation and full test suite run entirely on stubbed/fixture egress.
- **Local review gate:** ran before publish; found and fixed two secret-hygiene/robustness items (a `LoopbackFlow.__repr__` that could leak `client_id`/`state` via the embedded authorization URL; a bind path that silently stored an empty refresh token instead of failing loud).

---
