### PR TITLE
fix: stabilize panel agent import order

### DIFF
--- a/app/agents/panel_agent/__init__.py
+++ b/app/agents/panel_agent/__init__.py
@@ -1,10 +1,20 @@
 from __future__ import annotations
 
+import sys
+
 __all__ = [
     "run_panel_intent_for_note",
     "execute_panel_intent",
     "PanelRuntimeResult",
+    "agent",
 ]
 
 from .agent import run_panel_intent_for_note
 from .runtime import PanelRuntimeResult, execute_panel_intent
+
+# Importing ``app.journaling.draft`` can reach this package through a circular
+# path where Python has already cached the agent submodule but does not restore
+# it as a parent-package attribute.  Bind the cached module explicitly so
+# normal dotted traversal (including pytest monkeypatch resolution) remains
+# import-order independent.
+agent = sys.modules[f"{__name__}.agent"]

--- a/tests/activation/test_journal_panel_import_order.py
+++ b/tests/activation/test_journal_panel_import_order.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_isolated(script: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_journal_import_preserves_panel_agent_submodule_attribute() -> None:
+    result = _run_isolated(
+        """
+import sys
+
+import app.journaling.draft
+import app.agents.panel_agent as panel_package
+
+panel_module = sys.modules["app.agents.panel_agent.agent"]
+assert panel_package.agent is panel_module
+"""
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_journal_first_import_supports_panel_monkeypatch_resolution() -> None:
+    result = _run_isolated(
+        """
+from pathlib import Path
+
+import app.journaling.draft
+from pytest import MonkeyPatch
+
+patch = MonkeyPatch()
+patch.setattr(
+    "app.agents.panel_agent.agent.INDEX_OUTBOX_PATH",
+    Path("isolated-index-outbox.jsonl"),
+    raising=False,
+)
+patch.undo()
+"""
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Linked Issue
Governing-Issue: #3976
Fixes #3976

## SBS Impact
- Primary subsystem: Product/Runtime System — panel agent import surface
- Secondary subsystem(s): conversational journaling activation
- Write class: mechanical runtime/package repair
- Authority impact: none
- Persistence impact: none
- Derived/rebuildable impact: none
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: restores deterministic CI/runtime imports
- External boundary impact: none
- New or changed contract: package submodule traversal is import-order independent
- Owner-doc impact: none
- Transition debt impact: reduces an order-dependent compatibility defect
- Fitness rule impact: strengthens full-suite determinism

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Bind the already-loaded panel `agent` submodule explicitly on its parent package after the journal-first circular import path.
- Add isolated-process regressions for package traversal and pytest monkeypatch resolution.
- Preserve all existing package exports and runtime behavior.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] No owner-doc change is implied by this mechanical import repair.

## Validation
- [x] `pytest -q tests/activation/test_journal_panel_import_order.py` — 2 passed
- [x] `pytest -q tests/activation/test_journal_draft_activation.py tests/agents --tb=short` — 452 passed
- [x] `ruff check app tests` — All checks passed
- [x] `git diff --check` — clean

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: GitHub Issue #3976 and this PR fully capture the bounded CI regression and repair.

## Coordination
- Dispatcher lease: `lease-a9b3cdc7`
- Claimed by: `codex-rescue-root`

