### PR TITLE
Fix guarded git-hygiene rescue publication

### DIFF
--- a/scripts/git_hygiene.py
+++ b/scripts/git_hygiene.py
@@ -815,8 +815,15 @@ def janitor_apply(
     for remote in plan["candidates"]["remote_branches_requiring_rescue"]:
         branch = remote["branch"]
         rescue_ref = remote["rescue_ref"]
-        if branch in DEFAULT_PROTECTED_BRANCHES or not rescue_ref.startswith(
-            "refs/archive/git-hygiene/"
+        source_ref = f"refs/heads/{branch}"
+        protected_source_refs = {
+            f"refs/heads/{protected}" for protected in DEFAULT_PROTECTED_BRANCHES
+        }
+        if (
+            not branch
+            or branch.startswith("-")
+            or source_ref in protected_source_refs
+            or not rescue_ref.startswith("refs/archive/git-hygiene/")
         ):
             errors.append(
                 {
@@ -832,6 +839,12 @@ def janitor_apply(
         apply_git(
             ["check-ref-format", rescue_ref],
             {"artifact": "remote_branch", "action": "validate_rescue_ref", **remote},
+        )
+        if len(errors) != errors_before_validation:
+            continue
+        apply_git(
+            ["check-ref-format", source_ref],
+            {"artifact": "remote_branch", "action": "validate_source_ref", **remote},
         )
         if len(errors) != errors_before_validation:
             continue
@@ -862,10 +875,11 @@ def janitor_apply(
             # The repository's direct-main pre-push guard is branch-based and
             # rejects every push made while main is checked out. This transport
             # bypass is deliberately confined to a validated archive ref and a
-            # non-protected source-branch delete; refs/heads/main is never an
-            # admissible target here.
+            # fully qualified non-protected source-branch deletion. Prefixing
+            # the plan's short branch name with refs/heads/ prevents ref-like
+            # names from being reinterpreted as refs/heads/main.
             apply_git(
-                ["push", "--no-verify", "origin", "--delete", branch],
+                ["push", "--no-verify", "origin", f":{source_ref}"],
                 {
                     "artifact": "remote_branch",
                     "action": "delete_after_rescue",

--- a/scripts/git_hygiene.py
+++ b/scripts/git_hygiene.py
@@ -813,9 +813,32 @@ def janitor_apply(
     for remote in plan["candidates"]["remote_branches"]:
         apply_git(["push", "origin", "--delete", remote["branch"]], {"artifact": "remote_branch", "action": "delete", **remote})
     for remote in plan["candidates"]["remote_branches_requiring_rescue"]:
+        branch = remote["branch"]
+        rescue_ref = remote["rescue_ref"]
+        if branch in DEFAULT_PROTECTED_BRANCHES or not rescue_ref.startswith(
+            "refs/archive/git-hygiene/"
+        ):
+            errors.append(
+                {
+                    "artifact": "remote_branch",
+                    "action": "validate_rescue_transport",
+                    **remote,
+                    "reason": "unsafe_rescue_transport_target",
+                }
+            )
+            continue
+
+        errors_before_validation = len(errors)
+        apply_git(
+            ["check-ref-format", rescue_ref],
+            {"artifact": "remote_branch", "action": "validate_rescue_ref", **remote},
+        )
+        if len(errors) != errors_before_validation:
+            continue
+
         errors_before_rescue = len(errors)
         apply_git(
-            ["update-ref", remote["rescue_ref"], f"origin/{remote['branch']}"],
+            ["update-ref", rescue_ref, f"origin/{branch}"],
             {"artifact": "remote_branch", "action": "create_rescue_ref", **remote},
         )
         rescue_created = len(errors) == errors_before_rescue
@@ -823,12 +846,32 @@ def janitor_apply(
         if rescue_created:
             errors_before_push = len(errors)
             apply_git(
-                ["push", "origin", f"{remote['rescue_ref']}:{remote['rescue_ref']}"],
+                ["push", "--no-verify", "origin", f"{rescue_ref}:{rescue_ref}"],
                 {"artifact": "remote_branch", "action": "push_rescue_ref", **remote},
             )
             rescue_pushed = len(errors) == errors_before_push
-        if rescue_created and rescue_pushed:
-            apply_git(["push", "origin", "--delete", remote["branch"]], {"artifact": "remote_branch", "action": "delete_after_rescue", **remote})
+        rescue_verified = False
+        if rescue_pushed:
+            errors_before_verify = len(errors)
+            apply_git(
+                ["ls-remote", "--exit-code", "origin", rescue_ref],
+                {"artifact": "remote_branch", "action": "verify_rescue_ref", **remote},
+            )
+            rescue_verified = len(errors) == errors_before_verify
+        if rescue_created and rescue_pushed and rescue_verified:
+            # The repository's direct-main pre-push guard is branch-based and
+            # rejects every push made while main is checked out. This transport
+            # bypass is deliberately confined to a validated archive ref and a
+            # non-protected source-branch delete; refs/heads/main is never an
+            # admissible target here.
+            apply_git(
+                ["push", "--no-verify", "origin", "--delete", branch],
+                {
+                    "artifact": "remote_branch",
+                    "action": "delete_after_rescue",
+                    **remote,
+                },
+            )
     for stash in plan["candidates"]["old_stashes"]:
         apply_git(["stash", "drop", stash["ref"]], {"artifact": "stash", "action": "drop", **stash})
 

--- a/tests/ops/test_git_hygiene.py
+++ b/tests/ops/test_git_hygiene.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 import subprocess
 
+import pytest
+
 from scripts import git_hygiene
 
 
@@ -778,7 +780,7 @@ def test_janitor_apply_creates_rescue_before_remote_delete(tmp_path, monkeypatch
     assert commands.index(
         ["ls-remote", "--exit-code", "origin", rescue_refspec.split(":", 1)[0]]
     ) < commands.index(
-        ["push", "--no-verify", "origin", "--delete", "closed-unmerged"]
+        ["push", "--no-verify", "origin", ":refs/heads/closed-unmerged"]
     )
 
 
@@ -918,7 +920,7 @@ def test_janitor_apply_does_not_delete_remote_when_rescue_push_fails(
     report = git_hygiene.janitor_apply(tmp_path, pr_states={"closed-unmerged": {"state": "CLOSED"}})
 
     assert report["ok"] is False
-    assert ["push", "--no-verify", "origin", "--delete", "closed-unmerged"] not in commands
+    assert ["push", "--no-verify", "origin", ":refs/heads/closed-unmerged"] not in commands
 
 
 def test_janitor_apply_does_not_delete_remote_when_rescue_verification_fails(
@@ -962,7 +964,95 @@ def test_janitor_apply_does_not_delete_remote_when_rescue_verification_fails(
     )
 
     assert report["ok"] is False
-    assert ["push", "--no-verify", "origin", "--delete", "closed-unmerged"] not in commands
+    assert ["push", "--no-verify", "origin", ":refs/heads/closed-unmerged"] not in commands
+
+
+def test_janitor_rescue_delete_uses_exact_full_ref_for_ref_like_branch(
+    tmp_path, monkeypatch
+) -> None:
+    commands: list[list[str]] = []
+    branch = "refs/heads/main"
+    rescue_ref = f"refs/archive/git-hygiene/20260607T000000Z/{branch}"
+
+    def fake_run_git_result(args: list[str], _cwd: Path) -> subprocess.CompletedProcess[str]:
+        commands.append(args)
+        return subprocess.CompletedProcess(["git", *args], 0, "", "")
+
+    monkeypatch.setattr(git_hygiene, "run_git_result", fake_run_git_result)
+    monkeypatch.setattr(
+        git_hygiene,
+        "build_janitor_plan",
+        lambda *args, **kwargs: {
+            "mode": "report",
+            "remote_policy": "merged-and-closed-with-rescue",
+            "destructive_actions": [],
+            "candidates": {
+                "local_branches": [],
+                "worktrees": [],
+                "orphaned_worktrees": [],
+                "remote_branches": [],
+                "remote_branches_requiring_rescue": [
+                    {"branch": branch, "rescue_ref": rescue_ref}
+                ],
+                "old_stashes": [],
+            },
+            "skipped": [],
+            "prune_candidates": {"worktree": [], "remote": []},
+            "active_leases_respected": [],
+        },
+    )
+
+    report = git_hygiene.janitor_apply(
+        tmp_path, pr_states={branch: {"state": "CLOSED"}}
+    )
+
+    assert report["ok"] is True
+    assert ["push", "--no-verify", "origin", ":refs/heads/refs/heads/main"] in commands
+    assert ["push", "--no-verify", "origin", ":refs/heads/main"] not in commands
+    assert ["push", "--no-verify", "origin", "--delete", branch] not in commands
+
+
+@pytest.mark.parametrize("branch", ["--force", "main"])
+def test_janitor_rescue_transport_rejects_unsafe_branch(
+    tmp_path, monkeypatch, branch: str
+) -> None:
+    commands: list[list[str]] = []
+
+    def fake_run_git_result(args: list[str], _cwd: Path) -> subprocess.CompletedProcess[str]:
+        commands.append(args)
+        return subprocess.CompletedProcess(["git", *args], 0, "", "")
+
+    monkeypatch.setattr(git_hygiene, "run_git_result", fake_run_git_result)
+    monkeypatch.setattr(
+        git_hygiene,
+        "build_janitor_plan",
+        lambda *args, **kwargs: {
+            "mode": "report",
+            "remote_policy": "merged-and-closed-with-rescue",
+            "destructive_actions": [],
+            "candidates": {
+                "local_branches": [],
+                "worktrees": [],
+                "orphaned_worktrees": [],
+                "remote_branches": [],
+                "remote_branches_requiring_rescue": [
+                    {
+                        "branch": branch,
+                        "rescue_ref": f"refs/archive/git-hygiene/20260607T000000Z/{branch}",
+                    }
+                ],
+                "old_stashes": [],
+            },
+            "skipped": [],
+            "prune_candidates": {"worktree": [], "remote": []},
+            "active_leases_respected": [],
+        },
+    )
+
+    report = git_hygiene.janitor_apply(tmp_path, pr_states={branch: {"state": "CLOSED"}})
+
+    assert report["ok"] is False
+    assert not any(command[0] == "push" for command in commands)
 
 
 def test_janitor_dry_run_integration_with_temp_repo(tmp_path) -> None:

--- a/tests/ops/test_git_hygiene.py
+++ b/tests/ops/test_git_hygiene.py
@@ -771,10 +771,106 @@ def test_janitor_apply_creates_rescue_before_remote_delete(tmp_path, monkeypatch
             "refs/archive/git-hygiene/20260607T000000Z/closed-unmerged",
             "origin/closed-unmerged",
         ]
-    ) < commands.index(["push", "origin", rescue_refspec])
-    assert commands.index(["push", "origin", rescue_refspec]) < commands.index(
-        ["push", "origin", "--delete", "closed-unmerged"]
+    ) < commands.index(["push", "--no-verify", "origin", rescue_refspec])
+    assert commands.index(["push", "--no-verify", "origin", rescue_refspec]) < commands.index(
+        ["ls-remote", "--exit-code", "origin", rescue_refspec.split(":", 1)[0]]
     )
+    assert commands.index(
+        ["ls-remote", "--exit-code", "origin", rescue_refspec.split(":", 1)[0]]
+    ) < commands.index(
+        ["push", "--no-verify", "origin", "--delete", "closed-unmerged"]
+    )
+
+
+def test_janitor_rescue_publication_works_from_guarded_main_checkout(
+    tmp_path, monkeypatch
+) -> None:
+    remote = tmp_path / "remote.git"
+    repo = tmp_path / "repo"
+    subprocess.run(["git", "init", "--bare", remote], check=True)
+    subprocess.run(["git", "init", "--initial-branch=main", repo], check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, check=True)
+    (repo / "file.txt").write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "add", "file.txt"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "base"], cwd=repo, check=True)
+    subprocess.run(["git", "remote", "add", "origin", str(remote)], cwd=repo, check=True)
+    subprocess.run(["git", "push", "origin", "main"], cwd=repo, check=True)
+    subprocess.run(["git", "checkout", "-b", "closed-unmerged"], cwd=repo, check=True)
+    (repo / "branch.txt").write_text("rescue me\n", encoding="utf-8")
+    subprocess.run(["git", "add", "branch.txt"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "branch"], cwd=repo, check=True)
+    subprocess.run(["git", "push", "origin", "closed-unmerged"], cwd=repo, check=True)
+    subprocess.run(["git", "checkout", "main"], cwd=repo, check=True)
+
+    hook = repo / ".git" / "hooks" / "pre-push"
+    hook.write_text(
+        "#!/bin/sh\n"
+        "test \"$(git symbolic-ref --short HEAD)\" != main || {\n"
+        "  echo 'direct-main push rejected' >&2\n"
+        "  exit 1\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    hook.chmod(0o755)
+    rescue_ref = "refs/archive/git-hygiene/20260607T000000Z/closed-unmerged"
+    monkeypatch.setattr(
+        git_hygiene,
+        "build_janitor_plan",
+        lambda *args, **kwargs: {
+            "mode": "report",
+            "remote_policy": "merged-and-closed-with-rescue",
+            "destructive_actions": [],
+            "candidates": {
+                "local_branches": [],
+                "worktrees": [],
+                "orphaned_worktrees": [],
+                "remote_branches": [],
+                "remote_branches_requiring_rescue": [
+                    {"branch": "closed-unmerged", "rescue_ref": rescue_ref}
+                ],
+                "old_stashes": [],
+            },
+            "skipped": [],
+            "prune_candidates": {"worktree": [], "remote": []},
+            "active_leases_respected": [],
+        },
+    )
+
+    guarded_main = subprocess.run(
+        ["git", "push", "origin", "main:refs/heads/main"],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert guarded_main.returncode != 0
+    assert "direct-main push rejected" in guarded_main.stderr
+
+    report = git_hygiene.janitor_apply(
+        repo, pr_states={"closed-unmerged": {"state": "CLOSED"}}
+    )
+
+    assert report["ok"] is True
+    assert subprocess.run(
+        ["git", "show-ref", "--verify", "--quiet", rescue_ref],
+        cwd=remote,
+        check=False,
+    ).returncode == 0
+    assert subprocess.run(
+        ["git", "show-ref", "--verify", "--quiet", "refs/heads/closed-unmerged"],
+        cwd=remote,
+        check=False,
+    ).returncode != 0
+    guarded_main_after_cleanup = subprocess.run(
+        ["git", "push", "origin", "main:refs/heads/main"],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert guarded_main_after_cleanup.returncode != 0
+    assert "direct-main push rejected" in guarded_main_after_cleanup.stderr
 
 
 def test_janitor_apply_does_not_delete_remote_when_rescue_push_fails(
@@ -788,7 +884,7 @@ def test_janitor_apply_does_not_delete_remote_when_rescue_push_fails(
 
     def fake_run_git_result(args: list[str], _cwd: Path) -> subprocess.CompletedProcess[str]:
         commands.append(args)
-        if args == ["push", "origin", rescue_refspec]:
+        if args == ["push", "--no-verify", "origin", rescue_refspec]:
             return subprocess.CompletedProcess(["git", *args], 1, "", "rejected")
         return subprocess.CompletedProcess(["git", *args], 0, "", "")
 
@@ -822,7 +918,51 @@ def test_janitor_apply_does_not_delete_remote_when_rescue_push_fails(
     report = git_hygiene.janitor_apply(tmp_path, pr_states={"closed-unmerged": {"state": "CLOSED"}})
 
     assert report["ok"] is False
-    assert ["push", "origin", "--delete", "closed-unmerged"] not in commands
+    assert ["push", "--no-verify", "origin", "--delete", "closed-unmerged"] not in commands
+
+
+def test_janitor_apply_does_not_delete_remote_when_rescue_verification_fails(
+    tmp_path, monkeypatch
+) -> None:
+    commands: list[list[str]] = []
+    rescue_ref = "refs/archive/git-hygiene/20260607T000000Z/closed-unmerged"
+
+    def fake_run_git_result(args: list[str], _cwd: Path) -> subprocess.CompletedProcess[str]:
+        commands.append(args)
+        if args == ["ls-remote", "--exit-code", "origin", rescue_ref]:
+            return subprocess.CompletedProcess(["git", *args], 2, "", "not found")
+        return subprocess.CompletedProcess(["git", *args], 0, "", "")
+
+    monkeypatch.setattr(git_hygiene, "run_git_result", fake_run_git_result)
+    monkeypatch.setattr(
+        git_hygiene,
+        "build_janitor_plan",
+        lambda *args, **kwargs: {
+            "mode": "report",
+            "remote_policy": "merged-and-closed-with-rescue",
+            "destructive_actions": [],
+            "candidates": {
+                "local_branches": [],
+                "worktrees": [],
+                "orphaned_worktrees": [],
+                "remote_branches": [],
+                "remote_branches_requiring_rescue": [
+                    {"branch": "closed-unmerged", "rescue_ref": rescue_ref}
+                ],
+                "old_stashes": [],
+            },
+            "skipped": [],
+            "prune_candidates": {"worktree": [], "remote": []},
+            "active_leases_respected": [],
+        },
+    )
+
+    report = git_hygiene.janitor_apply(
+        tmp_path, pr_states={"closed-unmerged": {"state": "CLOSED"}}
+    )
+
+    assert report["ok"] is False
+    assert ["push", "--no-verify", "origin", "--delete", "closed-unmerged"] not in commands
 
 
 def test_janitor_dry_run_integration_with_temp_repo(tmp_path) -> None:


### PR DESCRIPTION
## Change Lane
- [ ] Implementation lane
- [ ] Docs authoring lane
- [x] Governance lane

Governing-Issue: #3971

## Linked Issue
Fixes #3971

## SBS Impact
- Primary subsystem: Builder System / CES boundary
- Secondary subsystem(s): none
- Write class: governance/docs/process
- Authority impact: hardens the Builder System git-hygiene recovery path without changing Product/Runtime authority
- Persistence impact: durable remote Git archive refs; no runtime persistence changes
- Derived/rebuildable impact: local cleanup plans and worktree metadata only
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: none
- External boundary impact: Git remote ref publication used by safe cleanup
- New or changed contract: rescue refs are validated, published, and remotely verified before the eligible source branch is deleted from a guarded `main` checkout
- Owner-doc impact: no owner-doc change implied; operator invocation requirements are unchanged
- Transition debt impact: removes the known manual refs fallback
- Fitness rule impact: adds real guarded-main rescue-path coverage and explicit verification-failure coverage
- Boundary risk: narrowly bypasses local push hooks only for a validated archive ref and a validated non-protected source-branch deletion; `refs/heads/main` is not admissible

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Allow the janitor rescue transport to operate from the guarded canonical `main` checkout without weakening main-ref protection.
- Verify the durable remote archive ref before deleting the source branch, preserving fail-closed behavior on publish or verification failure.
- Add a real bare-remote integration test plus focused ordering and failure coverage.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed. (No update required: operator-visible requirements are unchanged.)
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality. (No owner-doc or roadmap change is implied.)

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [x] This PR only changes approved governance surfaces.
- [x] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [x] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [x] `ruff check app tests`
- [x] Lint output: `All checks passed!` from `ruff check app tests companion-ui/companion-app`
- [x] `mypy app` — `Success: no issues found in 782 source files`
- [x] `pytest -q -m "not pg"` — `10107 passed, 38 skipped, 244 deselected, 18 xfailed`
- [x] Additional targeted checks: `pytest -q tests/ops/test_git_hygiene.py` — `45 passed`

Docs authoring lane:
- [ ] Docs/governance checks run as appropriate for the touched surfaces
- [ ] Any validation gaps or tooling limitations are stated explicitly

Governance lane:
- [x] Governance checks run as appropriate for the touched surfaces
- [x] No validation gaps or tooling limitations

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: this bounded issue-backed governance implementation produced no cross-authority proposal, learning divergence, or separate operational-state record.

## Notes
- Independent review found and the repair now covers ref-like and option-like branch-name ambiguity: deletion uses an explicit validated full refspec, and protected source refs fail closed.
- Residual risk is limited to Git implementations that do not honor standard `--no-verify` or `ls-remote --exit-code` behavior; both paths are exercised using real Git in the integration test.
