### PR TITLE
Skip compose-contract tests when Docker is unavailable

### DIFF
--- a/tests/deploy/test_deploy_channel_vault_overlays.py
+++ b/tests/deploy/test_deploy_channel_vault_overlays.py
@@ -3,13 +3,20 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+import shutil
 import subprocess
+
+import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 COMPOSE_HELPER = REPO_ROOT / "scripts/lib/deploy_channel_compose.sh"
 DEPLOY_SCRIPT = REPO_ROOT / "scripts/deploy_channel.sh"
 IMAGE_SHA = "fff07f13665d7e79270e20f8453b06da7b9f53d7"
+requires_docker = pytest.mark.skipif(
+    shutil.which("docker") is None,
+    reason="docker executable not found on PATH",
+)
 
 
 def _render_deploy_compose(
@@ -116,6 +123,7 @@ def _mount_source(service: dict[str, object], target: str) -> str | None:
     return None
 
 
+@requires_docker
 def test_deploy_channel_test_no_vault_keeps_idle_overlay_set(tmp_path: Path) -> None:
     services = _services(
         _render_deploy_compose(tmp_path, channel="test", explicit_vault=False)
@@ -133,6 +141,7 @@ def test_deploy_channel_test_no_vault_keeps_idle_overlay_set(tmp_path: Path) -> 
         assert service["image"] == f"ghcr.io/rasmustho/pkm-app:{IMAGE_SHA}"
 
 
+@requires_docker
 def test_deploy_channel_test_explicit_vault_uses_governed_overlay_order(
     tmp_path: Path,
 ) -> None:
@@ -158,6 +167,7 @@ def test_deploy_channel_test_explicit_vault_uses_governed_overlay_order(
     assert migrate["LLM_PROVIDER"] == "mock"
 
 
+@requires_docker
 def test_deploy_channel_non_test_explicit_vault_uses_legacy_overlay_only(
     tmp_path: Path,
 ) -> None:
@@ -177,6 +187,7 @@ def test_deploy_channel_non_test_explicit_vault_uses_legacy_overlay_only(
         assert env["DB_DSN"].endswith("/app")
 
 
+@requires_docker
 def test_full_host_vault_does_not_add_deadlocking_duplicate_legacy_mount(
     tmp_path: Path,
 ) -> None:
@@ -203,6 +214,7 @@ def test_full_host_vault_does_not_add_deadlocking_duplicate_legacy_mount(
         assert env["WATCHER_VAULT_PATH"] == str(selected_vault)
 
 
+@requires_docker
 def test_symlink_outside_full_host_mount_does_not_select_native_path_overlay(
     tmp_path: Path,
 ) -> None:
@@ -229,6 +241,7 @@ def test_symlink_outside_full_host_mount_does_not_select_native_path_overlay(
         assert env["WATCHER_VAULT_PATH"] == ""
 
 
+@requires_docker
 def test_test_overlay_selection_preserves_idle_and_explicit_vault_modes(
     tmp_path: Path,
 ) -> None:

--- a/tests/deploy/test_dev_llm_provider_compose.py
+++ b/tests/deploy/test_dev_llm_provider_compose.py
@@ -3,13 +3,20 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+import shutil
 import subprocess
+
+import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 BASE_COMPOSE = REPO_ROOT / "docker-compose.yaml"
 DEV_COMPOSE = REPO_ROOT / "docker-compose.dev.yml"
 DEV_ENV = REPO_ROOT / "config/deploy/dev.env"
+pytestmark = pytest.mark.skipif(
+    shutil.which("docker") is None,
+    reason="docker executable not found on PATH",
+)
 
 
 def _merged_dev_compose() -> dict[str, object]:

--- a/tests/deploy/test_test_channel_compose.py
+++ b/tests/deploy/test_test_channel_compose.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+import shutil
 import subprocess
+
+import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -12,6 +15,10 @@ TEST_COMPOSE = REPO_ROOT / "docker-compose.test.yml"
 EXPLICIT_VAULT_COMPOSE = REPO_ROOT / "docker-compose.legacy-vault.yml"
 TEST_VAULT_COMPOSE = REPO_ROOT / "docker-compose.test-vault.yml"
 TEST_ENV = REPO_ROOT / "config/deploy/test.env"
+pytestmark = pytest.mark.skipif(
+    shutil.which("docker") is None,
+    reason="docker executable not found on PATH",
+)
 
 
 def _merged_compose(


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

Governing-Issue: #3945

## Linked Issue
Fixes #3945

## SBS Impact
- Primary subsystem: Builder System (test harness environment preconditions)
- Secondary subsystem(s): none
- Write class: mechanical
- Authority impact: none
- Persistence impact: none
- Derived/rebuildable impact: none
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: none; deployment scripts are unchanged
- External boundary impact: none
- New or changed contract: none; tests now represent the existing Docker CLI precondition truthfully
- Owner-doc impact: no owner-doc change implied
- Transition debt impact: reduces unrelated failures in the mandatory local gate
- Fitness rule impact: no effect
- Boundary risk: skips only when `shutil.which("docker")` finds no executable; Docker-capable execution is unchanged

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Skip only Docker-invoking compose-contract tests when the `docker` executable is absent from PATH, with an explicit missing-precondition reason.
- Preserve the static deploy/rollback source-contract test on Docker-less hosts and run all compose contracts unchanged where Docker is available.

## Pickup Receipt
- Coordination mode: dispatcher-backed
- Task: `github-RasmusTho--agentic-pkm-mvp-issue-3945`
- Lease: `lease-16465e7c`
- Holder: `codex-bug-3945`
- Evidence: verified-dispatcher-lease

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed. (No contract or operator requirement changed.)
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality. (No owner-doc or roadmap writeback is implied.)

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [ ] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [ ] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [x] `ruff check app tests companion-ui/companion-app` — `All checks passed!`
- [x] `mypy app` — `Success: no issues found in 782 source files`
- [x] Docker-less `PATH=/usr/bin:/bin ... pytest -q -rs -m "not pg" tests/deploy` — `82 passed, 10 skipped`; every skip says `docker executable not found on PATH`
- [x] Docker-capable `python -m pytest -q -m "not pg" tests/deploy` — `92 passed`
- [x] Docker-capable focused three modules — `11 passed`
- [x] `pytest -q -m "not pg"` — `10113 passed, 38 skipped, 244 deselected, 18 xfailed`

Docs authoring lane:
- [ ] Docs/governance checks run as appropriate for the touched surfaces
- [ ] Any validation gaps or tooling limitations are stated explicitly

Governance lane:
- [ ] Governance checks run as appropriate for the touched surfaces
- [ ] Any validation gaps or tooling limitations are stated explicitly

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: this bounded test-harness correction produced no learning divergence, docs-freshness finding, roadmap movement, promotion proposal, or cross-authority material.

## Notes
- The Docker-less receipt uses an absolute Python interpreter with a restricted PATH so only executable discovery changes; the same checked-out tests run normally with Docker Compose 2.40.0 present.
