### PR TITLE
YSS-04: durable acquisition request queue

### DIFF
--- a/app/alembic/versions/b5c6d7e8f9a0_yss04_acquisition_requests.py
+++ b/app/alembic/versions/b5c6d7e8f9a0_yss04_acquisition_requests.py
@@ -1,0 +1,133 @@
+"""YSS-04 (#3919): YouTube Source Sync -- durable acquisition request queue.
+
+Slice YSS-04 of the YouTube Source Sync capability (parent #3915). Creates
+`acquisition_requests`, the durable source-agnostic work-item table backing
+`app/knowledge_acquisition/acquisition_requests.py`
+(`docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md :: AcquisitionRequest`):
+discovery enqueues cheaply, a bounded drain acquires later, and restarts,
+retries, and dedup converge on the row (INV-YSS-1..3). Deliberately a
+migration-owned table, not outbox rows — the queue needs status queries,
+trigger-append provenance, priority, and per-item backoff that append-only
+events cannot carry.
+
+Service-layer integrity rules backed by DB constraints as defense-in-depth
+(the service layer, covering the Postgres and in-process memory backends
+identically, remains authoritative — see the module docstring):
+
+- `status` is one of `pending` / `in_progress` / `completed` / `dead_lettered`
+  (retryable failures stay `pending` with a future `next_attempt_at`).
+- `priority` is `high` | `normal` (drain order `(priority, requested_at)`:
+  'high' < 'normal' sorts high-first on the plain column, so the drain index
+  below serves the claim's status filter and its full ORDER BY).
+- one request per `(source_kind, item_ref, policy_version)` — the identity
+  triple behind the deterministic uuid5 `request_id` (INV-YSS-2), also
+  enforced directly so a hand-written row cannot fork a parallel request.
+
+Forward-only, following the KERNEL-04/KERNEL-05/HEIM/ERE-04 (`a1b2c3d4e5f6`)
+/ YSS-01 / YSS-02 precedent: schema-owning migrations in this repo have no
+downgrade path for their tables. This is a "new rebuildable-class table" per
+the issue's SBS Impact — rebuildable means discovery re-enumerates and
+converges through request idempotency, not that `downgrade()` silently drops
+the queue.
+
+Revision ID: b5c6d7e8f9a0
+Revises: a2f1c3e4d5b6
+Create Date: 2026-07-18 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+# Alembic identifiers
+revision: str = "b5c6d7e8f9a0"
+down_revision: Union[str, None] = "a2f1c3e4d5b6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Machine-readable classification for the promotion migration gate
+# (docs/RELEASE_CHANNELS/DEFINE_MIGRATION_REVERSIBILITY_CLASSIFICATION.md;
+# app/release_channels/reversibility.py). Downgrade raises by design.
+reversibility: str = "forward-only"
+
+_TABLE = "acquisition_requests"
+
+
+def upgrade() -> None:
+    op.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {_TABLE} (
+            request_id TEXT PRIMARY KEY,
+            source_kind TEXT NOT NULL,
+            item_ref TEXT NOT NULL,
+            source_ref TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending',
+            priority TEXT NOT NULL DEFAULT 'normal',
+            requested_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            completed_at TIMESTAMPTZ,
+            attempts INTEGER NOT NULL DEFAULT 0,
+            next_attempt_at TIMESTAMPTZ,
+            last_failure JSONB,
+            discovery_triggers JSONB NOT NULL DEFAULT '[]'::jsonb,
+            policy_snapshot JSONB NOT NULL DEFAULT '{{}}'::jsonb,
+            policy_version INTEGER NOT NULL DEFAULT 1,
+            trace_id TEXT,
+            content_identity TEXT,
+            artifact_path TEXT,
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            CONSTRAINT acquisition_requests_status_chk CHECK (
+                status IN ('pending', 'in_progress', 'completed', 'dead_lettered')
+            ),
+            CONSTRAINT acquisition_requests_priority_chk CHECK (
+                priority IN ('high', 'normal')
+            )
+        )
+        """
+    )
+    # Existing test/bootstrap-created tables predate the CHECK constraints; add
+    # each migration-owned constraint idempotently so upgrading such a resource
+    # reaches the same fail-loud schema as a fresh migration (YSS-01 precedent).
+    for name, check in (
+        (
+            "acquisition_requests_status_chk",
+            "status IN ('pending', 'in_progress', 'completed', 'dead_lettered')",
+        ),
+        ("acquisition_requests_priority_chk", "priority IN ('high', 'normal')"),
+    ):
+        op.execute(
+            f"""
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1
+                    FROM pg_constraint
+                    WHERE conname = '{name}'
+                      AND conrelid = '{_TABLE}'::regclass
+                ) THEN
+                    ALTER TABLE {_TABLE} ADD CONSTRAINT {name} CHECK ({check});
+                END IF;
+            END $$;
+            """
+        )
+    # Drain path: the claim filters status='pending' and orders by
+    # (priority ASC, requested_at ASC) — served by this index prefix; the
+    # next_attempt_at due-gate is a residual filter on the matched rows.
+    op.execute(
+        f"CREATE INDEX IF NOT EXISTS acquisition_requests_drain_idx "
+        f"ON {_TABLE} (status, priority, requested_at)"
+    )
+    # Identity triple behind the deterministic request_id (INV-YSS-2), enforced
+    # directly as defense-in-depth.
+    op.execute(
+        f"CREATE UNIQUE INDEX IF NOT EXISTS acquisition_requests_identity_uq "
+        f"ON {_TABLE} (source_kind, item_ref, policy_version)"
+    )
+
+
+def downgrade() -> None:
+    raise RuntimeError(
+        "YSS-04 acquisition_requests migration is forward-only; this table is the durable "
+        "acquisition request queue for YouTube Source Sync (rebuildable by re-discovery "
+        "converging through request idempotency, not via migration downgrade), and is never "
+        "dropped by downgrade."
+    )

--- a/app/events/types.py
+++ b/app/events/types.py
@@ -110,6 +110,18 @@ SETTINGS_WRITE_RECEIPT = "settings.write.receipt"
 KNOWLEDGE_ACQUISITION_STAGE_COMPLETED = "knowledge_acquisition.stage.completed"
 KNOWLEDGE_ACQUISITION_STAGE_DEAD_LETTERED = "knowledge_acquisition.stage.dead_lettered"
 
+# YSS-04 (#3919): YouTube Source Sync acquisition-queue lineage topics
+# (docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md :: Event topics). Emitted by
+# app/knowledge_acquisition/acquisition_requests.py on the canonical DB outbox
+# with KERNEL-08 registered schemas. Lineage/receipt posture, NOT dispatched
+# commands — no `outbox_worker._dispatch_topic` branch; a future consumer
+# follows the KA-07 route pattern.
+YOUTUBE_SOURCE_DISCOVERED = "youtube.source.discovered"
+ACQUISITION_REQUESTED = "acquisition.requested"
+ACQUISITION_STARTED = "acquisition.started"
+ACQUISITION_COMPLETED = "acquisition.completed"
+ACQUISITION_FAILED = "acquisition.failed"
+
 # Heimdal entity register v0 mutation events (Epic #3019 slice A1, #3038).
 # Register mutations (mint / merge / split / redirect-fold) are audit/lineage
 # events on the existing DB outbox, mirroring the Knowledge Acquisition stage
@@ -224,6 +236,11 @@ __all__ = [
     "SETTINGS_WRITE_RECEIPT",
     "KNOWLEDGE_ACQUISITION_STAGE_COMPLETED",
     "KNOWLEDGE_ACQUISITION_STAGE_DEAD_LETTERED",
+    "YOUTUBE_SOURCE_DISCOVERED",
+    "ACQUISITION_REQUESTED",
+    "ACQUISITION_STARTED",
+    "ACQUISITION_COMPLETED",
+    "ACQUISITION_FAILED",
     "HEIMDAL_REGISTER_ENTITY_MINTED",
     "HEIMDAL_REGISTER_ENTITY_MERGED",
     "HEIMDAL_REGISTER_ENTITY_SPLIT",

--- a/app/knowledge_acquisition/acquisition_requests.py
+++ b/app/knowledge_acquisition/acquisition_requests.py
@@ -1,0 +1,1367 @@
+"""YSS-04 (#3919): durable, source-agnostic acquisition request queue.
+
+Implements `docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md :: AcquisitionRequest`
+exactly: discovery must never fetch, and fetch must never depend on discovery
+being alive — the durable request row is the seam. Discovery enqueues cheaply;
+a bounded drain acquires later; restarts, retries, and dedup converge on the
+row (INV-YSS-1..3).
+
+Deliberately a migration-owned table, NOT outbox rows: the queue needs status
+queries, trigger-append provenance, priority, and per-item backoff that
+append-only events cannot carry, and its slow drain must not ride the shared
+outbox worker's fast dispatch loop.
+
+Shape and discipline:
+
+- **Identity (INV-YSS-2):** ``request_id = uuid5(namespace,
+  "{source_kind}:{item_ref}:{policy_version}")`` — one request per
+  ``(source_kind, item_ref, policy_version)``. The same video saved in N
+  playlists is ONE request whose ``discovery_triggers`` records all N bindings;
+  a duplicate discovery appends its trigger (identity-novel triggers only — an
+  identical ``(binding_id, trigger, playlist_item_id)`` re-discovery converges
+  without unbounded growth) and touches nothing else.
+- **Dual backend** (the ``app/heimdal/cursor_store.py`` /
+  ``source_registry.py`` shape): memory for ``not_pg`` tests, Postgres for a
+  configured runtime with fail-loud resolution (never a silent volatile
+  fallback), migration-owned schema with a fail-loud
+  :class:`AcquisitionRequestsSchemaMissingError` preflight and the
+  ``STORE_SCHEMA_AUTOCREATE`` test-only autocreate opt-in.
+- **Events** on the canonical DB outbox only
+  (``app/services/outbox.py::write_outbox_event`` + the single shared
+  ``derive_idempotency_key`` scheme; KERNEL-08 registered schemas). Lineage
+  posture: these topics record queue transitions; no ``_dispatch_topic``
+  branch is added. Keys: ``acquisition.requested`` is
+  ``(topic, request_id, policy_version)``-scoped (first insert only);
+  ``acquisition.started/completed/failed`` are attempt-scoped so a crash-retry
+  duplicate delivery of the SAME attempt dedups while a genuinely new attempt
+  is a distinct event; ``youtube.source.discovered`` is
+  ``(topic, binding_id, item_ref)``-scoped so re-discovery of the same item in
+  the same source dedups.
+- **Terminality (INV-YSS-3):** ``completed`` requires the KA pipeline's
+  terminal candidate outcome (note written or traced dedup no-op). A
+  WriteGuard block or transient failure resets to ``pending`` with a reason
+  code + backoff; ``dead_lettered`` is explicit and item-scoped (KA stage
+  dead-letter surfaced, or attempts exhausted — default max 8).
+- **Retry and backoff** per contract: exponential base 60 s, factor 4, cap
+  6 h, with non-negative jitter (the gate never fires EARLIER than the
+  deterministic floor). Rows stuck ``in_progress`` past a stale threshold are
+  reset to ``pending`` by :meth:`AcquisitionRequests.reset_stale_in_progress`
+  (restart recovery; the re-run converges through KA idempotency).
+
+The drain adapter :func:`drain_one` owns *what happens* when a request runs
+(the mapping from `AcquisitionReceipt` to queue state); the scheduler slice
+(YSS-06) owns *when* it runs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import threading
+import uuid
+from copy import deepcopy
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable
+
+from app.db.dsn import resolve_dsn
+from app.events.models import new_event
+from app.events.types import (
+    ACQUISITION_COMPLETED,
+    ACQUISITION_FAILED,
+    ACQUISITION_REQUESTED,
+    ACQUISITION_STARTED,
+    YOUTUBE_SOURCE_DISCOVERED,
+)
+from app.knowledge_acquisition.source_registry import VALID_PRIORITIES as _registry_priorities
+from app.services.outbox import derive_idempotency_key, write_outbox_event
+
+# --- Contract vocab ----------------------------------------------------------
+
+ACQUISITION_REQUESTED_TOPIC = ACQUISITION_REQUESTED
+ACQUISITION_STARTED_TOPIC = ACQUISITION_STARTED
+ACQUISITION_COMPLETED_TOPIC = ACQUISITION_COMPLETED
+ACQUISITION_FAILED_TOPIC = ACQUISITION_FAILED
+YOUTUBE_SOURCE_DISCOVERED_TOPIC = YOUTUBE_SOURCE_DISCOVERED
+
+# Envelope attribution per SOURCE_SYNC_CONTRACT.md :: Event topics.
+EVENT_SOURCE = "knowledge_acquisition.source_sync"
+
+VALID_STATUSES: frozenset[str] = frozenset({"pending", "in_progress", "completed", "dead_lettered"})
+TERMINAL_STATUSES: frozenset[str] = frozenset({"completed", "dead_lettered"})
+VALID_TRIGGER_KINDS: frozenset[str] = frozenset({"poll", "backfill", "manual"})
+
+# The registry's per-source priority is what flows into request priority — one
+# shared vocabulary, not a second copy (reuse over redeclaration).
+VALID_PRIORITIES = _registry_priorities
+
+# The one source kind the youtube-specific lineage topic applies to. Kept as a
+# module constant (not an import of youtube_plugin, which would couple the
+# source-agnostic queue to the plugin at import time); a test ties it to
+# youtube_plugin.SOURCE_KIND so the two can never drift silently.
+YOUTUBE_SOURCE_KIND = "youtube_url"
+
+DEFAULT_MAX_ATTEMPTS = 8
+DEFAULT_STALE_IN_PROGRESS_SECONDS = 900
+
+BACKOFF_BASE_SECONDS = 60
+BACKOFF_FACTOR = 4
+BACKOFF_CAP_SECONDS = 21600  # 6 h
+
+# Fixed UUIDv5 namespace for deterministic request identity (INV-YSS-2).
+# Changing this value changes every request id and breaks enqueue idempotency
+# against existing rows — never rotate it.
+ACQUISITION_REQUEST_NAMESPACE = uuid.UUID("3f8e6b1a-9d24-5c7e-8a02-6e5b1d4c9f30")
+
+_TABLE = "acquisition_requests"
+_MIGRATION_HINT = (
+    "acquisition_requests schema is migration-owned: run 'alembic upgrade head' "
+    "against this database. See "
+    "app/alembic/versions/b5c6d7e8f9a0_yss04_acquisition_requests.py."
+)
+_ALLOWED_BACKENDS = {"memory", "pg"}
+
+
+class AcquisitionRequestsSchemaMissingError(RuntimeError):
+    """Raised when the Postgres backend is selected but the queue table is absent."""
+
+
+class AcquisitionRequestValidationError(ValueError):
+    """Raised for malformed enqueue/transition inputs (fail-loud, never coerced)."""
+
+
+def request_identity(source_kind: str, item_ref: str, policy_version: int) -> str:
+    """Deterministic request id: ``uuid5(ns, "{source_kind}:{item_ref}:{policy_version}")``."""
+    return str(
+        uuid.uuid5(ACQUISITION_REQUEST_NAMESPACE, f"{source_kind}:{item_ref}:{policy_version}")
+    )
+
+
+def compute_backoff_seconds(attempt: int, *, rng: Callable[[], float] | None = None) -> int:
+    """Backoff gate for a failed ``attempt`` (1-based) per contract §Retry and backoff.
+
+    Deterministic floor ``min(cap, base * factor**(attempt-1))`` with base 60 s,
+    factor 4, cap 6 h, plus non-negative jitter (multiplier in ``[1.0, 1.25)``)
+    so concurrent retries de-synchronize but the gate never fires EARLIER than
+    the floor. ``rng`` is injectable for deterministic tests (``lambda: 0.0``
+    yields the exact floor).
+    """
+    if not isinstance(attempt, int) or isinstance(attempt, bool) or attempt < 1:
+        raise AcquisitionRequestValidationError(f"attempt must be a positive int, got {attempt!r}")
+    floor = min(BACKOFF_CAP_SECONDS, BACKOFF_BASE_SECONDS * BACKOFF_FACTOR ** (attempt - 1))
+    jitter = 1.0 + 0.25 * (rng() if rng is not None else random.random())
+    return int(min(BACKOFF_CAP_SECONDS, floor * jitter))
+
+
+# --- Event key helpers (KERNEL-02: one shared derivation scheme) -------------
+
+
+def requested_event_key(request_id: str, policy_version: int) -> str:
+    """``acquisition.requested`` key — ``(topic, request_id, policy_version)``."""
+    return derive_idempotency_key(ACQUISITION_REQUESTED_TOPIC, request_id, f"policy:{policy_version}")
+
+
+def attempt_event_key(topic: str, request_id: str, attempt: int) -> str:
+    """Attempt-scoped key for started/completed — each attempt is distinct."""
+    return derive_idempotency_key(topic, request_id, f"attempt:{attempt}")
+
+
+def failed_event_key(request_id: str, attempt: int, *, terminal: bool) -> str:
+    """Attempt-scoped key for ``acquisition.failed``, terminal-marked.
+
+    A retryable failure and a terminal dead-letter of the SAME attempt are two
+    distinct lineage facts (an explicit ``dead_letter()`` can follow a
+    retryable ``fail()`` before any new claim), so the terminal marker joins
+    the fingerprint — mirroring the ``retry:<n>`` / ``poison:<attempts>``
+    precedent in :func:`derive_idempotency_key`'s scheme. Duplicate delivery of
+    the same (attempt, terminality) still dedups.
+    """
+    marker = f"attempt:{attempt}:terminal" if terminal else f"attempt:{attempt}"
+    return derive_idempotency_key(ACQUISITION_FAILED_TOPIC, request_id, marker)
+
+
+def discovered_event_key(binding_id: str, item_ref: str) -> str:
+    """``youtube.source.discovered`` key — ``(topic, binding_id, item_ref)``."""
+    return derive_idempotency_key(YOUTUBE_SOURCE_DISCOVERED_TOPIC, binding_id, item_ref)
+
+
+# --- Value types -------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DiscoveryTrigger:
+    """One discovery provenance entry (contract ``discovery_triggers`` row)."""
+
+    binding_id: str
+    collection_kind: str
+    collection_ref: str
+    trigger: str
+    playlist_item_id: str | None = None
+    discovered_at: str | None = None
+
+    def validate(self) -> None:
+        for name in ("binding_id", "collection_kind", "collection_ref", "trigger"):
+            value = getattr(self, name)
+            if not isinstance(value, str) or not value.strip() or "\x00" in value:
+                raise AcquisitionRequestValidationError(
+                    f"trigger.{name} must be a non-empty NUL-free string, got {value!r}"
+                )
+        if self.trigger not in VALID_TRIGGER_KINDS:
+            raise AcquisitionRequestValidationError(
+                f"trigger.trigger must be one of {sorted(VALID_TRIGGER_KINDS)}, got {self.trigger!r}"
+            )
+        if self.playlist_item_id is not None and (
+            not isinstance(self.playlist_item_id, str) or not self.playlist_item_id.strip()
+        ):
+            raise AcquisitionRequestValidationError("trigger.playlist_item_id must be a non-empty string or None")
+
+    def stored_dict(self, *, discovered_at: str) -> dict[str, Any]:
+        """The contract trigger row persisted into ``discovery_triggers``.
+
+        ``playlist_item_id`` is stored explicitly (``null`` when absent) so the
+        novelty probe below is symmetric: identity comparison must not depend on
+        which of two otherwise-identical triggers arrived first.
+        """
+        return {
+            "binding_id": self.binding_id,
+            "collection_kind": self.collection_kind,
+            "playlist_item_id": self.playlist_item_id,
+            "discovered_at": self.discovered_at or discovered_at,
+            "trigger": self.trigger,
+        }
+
+    def identity_dict(self) -> dict[str, Any]:
+        """The novelty probe — the full identity triple, order-independent.
+
+        Always includes ``playlist_item_id`` (as ``null`` when absent): a probe
+        that omitted it would be subset-matched by a stored trigger that HAS
+        one, making provenance depend on discovery arrival order.
+        """
+        return {
+            "binding_id": self.binding_id,
+            "trigger": self.trigger,
+            "playlist_item_id": self.playlist_item_id,
+        }
+
+
+@dataclass(frozen=True)
+class AcquisitionRequest:
+    """One durable queue row. See `SOURCE_SYNC_CONTRACT.md :: AcquisitionRequest`."""
+
+    request_id: str
+    source_kind: str
+    item_ref: str
+    source_ref: str
+    status: str
+    priority: str
+    requested_at: str
+    completed_at: str | None
+    attempts: int
+    next_attempt_at: str | None
+    last_failure: dict[str, Any] | None
+    discovery_triggers: tuple[dict[str, Any], ...]
+    policy_snapshot: dict[str, Any]
+    policy_version: int
+    trace_id: str | None
+    content_identity: str | None
+    artifact_path: str | None
+    updated_at: str = field(default="")
+
+
+def _now(now: datetime | None = None) -> datetime:
+    """Resolve the effective clock; a naive injected ``now`` is treated as UTC.
+
+    Normalizing here keeps both backends parity-identical: the pg backend would
+    coerce a naive timestamp to UTC at the ``::timestamptz`` cast, so the memory
+    backend must not instead raise on aware-vs-naive comparison (AC7).
+    """
+    if now is None:
+        return datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        return now.replace(tzinfo=timezone.utc)
+    return now
+
+
+def _iso(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _parse_iso(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def sanitize_error(error: BaseException | str | None) -> str | None:
+    """Exception-class + bounded safe message (contract: never token material)."""
+    if error is None:
+        return None
+    if isinstance(error, BaseException):
+        text = f"{type(error).__name__}: {error}"
+    else:
+        text = str(error)
+    return text.replace("\x00", "")[:500]
+
+
+def _copy_request(row: AcquisitionRequest) -> AcquisitionRequest:
+    """Detach nested JSON so callers cannot mutate stored state in place.
+
+    ``copy.deepcopy`` mirrors ``source_registry._copy_binding`` — no repeated
+    text serialization per read.
+    """
+    return replace(
+        row,
+        last_failure=deepcopy(row.last_failure),
+        discovery_triggers=tuple(deepcopy(t) for t in row.discovery_triggers),
+        policy_snapshot=deepcopy(row.policy_snapshot),
+    )
+
+
+def _trigger_is_novel(existing: tuple[dict[str, Any], ...], probe: dict[str, Any]) -> bool:
+    return not any(all(t.get(k) == v for k, v in probe.items()) for t in existing)
+
+
+# --- Backend resolution (mirrors source_registry._resolve_backend) ----------
+
+
+def _resolve_backend() -> str:
+    override = (os.getenv("STORE_BACKEND") or "").strip().lower()
+    if override:
+        if override not in _ALLOWED_BACKENDS:
+            raise RuntimeError(
+                f"Store backend '{override}' is not supported for the acquisition request queue: "
+                "set STORE_BACKEND to 'pg' or 'memory', or unset it to resolve from "
+                "DATABASE_URL/DB_DSN."
+            )
+        return override
+    dsn = resolve_dsn()
+    if not dsn:
+        raise RuntimeError(
+            "No store backend configured for the acquisition request queue: set "
+            "STORE_BACKEND=memory explicitly for the volatile in-memory backend, or configure "
+            "DATABASE_URL/DB_DSN."
+        )
+    try:
+        import psycopg  # noqa: PLC0415
+
+        conn = psycopg.connect(dsn, connect_timeout=1)
+        conn.close()
+    except Exception as exc:
+        raise RuntimeError(
+            "Acquisition request queue backend resolution failed: Postgres is configured but "
+            f"unreachable. Refusing to fall back to a volatile in-memory store. Underlying error: {exc}"
+        ) from exc
+    return "pg"
+
+
+# --- Memory backend ----------------------------------------------------------
+
+
+class _MemoryAcquisitionRequestsBackend:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._rows: dict[str, AcquisitionRequest] = {}
+
+    def insert_or_append(
+        self, row: AcquisitionRequest, trigger: DiscoveryTrigger
+    ) -> tuple[AcquisitionRequest, bool]:
+        with self._lock:
+            existing = self._rows.get(row.request_id)
+            if existing is None:
+                self._rows[row.request_id] = _copy_request(row)
+                return _copy_request(row), True
+            probe = trigger.identity_dict()
+            if _trigger_is_novel(existing.discovery_triggers, probe):
+                # Contract: "appends the new discovery trigger ... and touches
+                # nothing else" — updated_at is deliberately NOT bumped; it is
+                # the stale-in_progress recovery clock, and a re-discovery must
+                # never defer a crashed attempt's recovery.
+                appended = replace(
+                    existing,
+                    discovery_triggers=existing.discovery_triggers
+                    + (trigger.stored_dict(discovered_at=row.requested_at),),
+                )
+                self._rows[row.request_id] = appended
+                return _copy_request(appended), False
+            return _copy_request(existing), False
+
+    def get(self, request_id: str) -> AcquisitionRequest | None:
+        with self._lock:
+            row = self._rows.get(request_id)
+            return _copy_request(row) if row is not None else None
+
+    def list_all(self) -> tuple[AcquisitionRequest, ...]:
+        with self._lock:
+            return tuple(_copy_request(r) for r in self._rows.values())
+
+    def claim(self, limit: int, now: datetime) -> tuple[AcquisitionRequest, ...]:
+        with self._lock:
+            eligible = [
+                r
+                for r in self._rows.values()
+                if r.status == "pending"
+                and (r.next_attempt_at is None or _parse_iso(r.next_attempt_at) <= now)
+            ]
+            # 'high' < 'normal' lexicographically, so plain column order gives
+            # high-priority-first — identical to the pg ORDER BY (index-servable).
+            eligible.sort(key=lambda r: (r.priority, r.requested_at))
+            claimed: list[AcquisitionRequest] = []
+            for row in eligible[: max(0, limit)]:
+                updated = replace(
+                    row, status="in_progress", attempts=row.attempts + 1, updated_at=_iso(now)
+                )
+                self._rows[row.request_id] = updated
+                claimed.append(_copy_request(updated))
+            return tuple(claimed)
+
+    def _mutate(
+        self, request_id: str, *, allowed_from: frozenset[str], **changes: Any
+    ) -> AcquisitionRequest | None:
+        """Guarded transition: applies only when the current status is in
+        ``allowed_from``. Returns ``None`` on a guard miss (row exists but is in
+        a disallowed state — the service layer classifies), raises ``KeyError``
+        when the row is missing. This is what makes terminal states terminal
+        (INV-YSS-3): a stale drainer's late ``fail()`` can never reopen a
+        completed/dead-lettered request.
+        """
+        row = self._rows.get(request_id)
+        if row is None:
+            raise KeyError(f"no such acquisition request: {request_id}")
+        if row.status not in allowed_from:
+            return None
+        updated = replace(row, **changes)
+        self._rows[request_id] = updated
+        return _copy_request(updated)
+
+    def set_completed(
+        self,
+        request_id: str,
+        *,
+        content_identity: str,
+        artifact_path: str | None,
+        now: datetime,
+    ) -> AcquisitionRequest | None:
+        with self._lock:
+            return self._mutate(
+                request_id,
+                allowed_from=frozenset({"in_progress"}),
+                status="completed",
+                completed_at=_iso(now),
+                next_attempt_at=None,
+                content_identity=content_identity,
+                artifact_path=artifact_path,
+                updated_at=_iso(now),
+            )
+
+    def set_failed_retryable(
+        self,
+        request_id: str,
+        *,
+        last_failure: dict[str, Any],
+        next_attempt_at: datetime,
+        now: datetime,
+    ) -> AcquisitionRequest | None:
+        with self._lock:
+            return self._mutate(
+                request_id,
+                allowed_from=frozenset({"in_progress"}),
+                status="pending",
+                last_failure=last_failure,
+                next_attempt_at=_iso(next_attempt_at),
+                updated_at=_iso(now),
+            )
+
+    def set_dead_lettered(
+        self, request_id: str, *, last_failure: dict[str, Any], now: datetime
+    ) -> AcquisitionRequest | None:
+        with self._lock:
+            return self._mutate(
+                request_id,
+                allowed_from=frozenset({"in_progress", "pending"}),
+                status="dead_lettered",
+                last_failure=last_failure,
+                next_attempt_at=None,
+                updated_at=_iso(now),
+            )
+
+    def reset_stale(self, older_than_seconds: int, now: datetime) -> int:
+        with self._lock:
+            threshold = now - timedelta(seconds=older_than_seconds)
+            count = 0
+            for request_id, row in list(self._rows.items()):
+                if row.status == "in_progress" and _parse_iso(row.updated_at) <= threshold:
+                    self._rows[request_id] = replace(row, status="pending", updated_at=_iso(now))
+                    count += 1
+            return count
+
+    def clear(self) -> None:
+        with self._lock:
+            self._rows.clear()
+
+
+_MEMORY_REQUESTS = _MemoryAcquisitionRequestsBackend()
+
+
+def reset_memory_acquisition_requests() -> None:
+    """Test-only reset hook (mirrors the other memory-backend reset helpers)."""
+    _MEMORY_REQUESTS.clear()
+
+
+# --- Postgres backend ---------------------------------------------------------
+
+_COLUMNS = (
+    "request_id",
+    "source_kind",
+    "item_ref",
+    "source_ref",
+    "status",
+    "priority",
+    "requested_at",
+    "completed_at",
+    "attempts",
+    "next_attempt_at",
+    "last_failure",
+    "discovery_triggers",
+    "policy_snapshot",
+    "policy_version",
+    "trace_id",
+    "content_identity",
+    "artifact_path",
+    "updated_at",
+)
+_COLUMNS_SQL = ", ".join(_COLUMNS)
+
+
+def _pg_connect() -> Any:
+    import psycopg  # noqa: PLC0415
+
+    url = os.environ.get("DATABASE_URL") or os.environ.get("DB_DSN")
+    if not url:
+        raise RuntimeError("DATABASE_URL or DB_DSN not set")
+    return psycopg.connect(resolve_dsn(url), autocommit=True)
+
+
+def _schema_autocreate_enabled() -> bool:
+    return (os.environ.get("STORE_SCHEMA_AUTOCREATE") or "").strip().lower() in {"1", "true", "yes"}
+
+
+def _assert_pg_schema(conn: Any) -> None:
+    cur = conn.cursor()
+    cur.execute("SELECT to_regclass(%s)", (_TABLE,))
+    row = cur.fetchone()
+    if not (row and row[0]):
+        raise AcquisitionRequestsSchemaMissingError(f"Missing table '{_TABLE}'. {_MIGRATION_HINT}")
+
+
+def _bootstrap_pg(conn: Any) -> None:
+    if not _schema_autocreate_enabled():
+        _assert_pg_schema(conn)
+        return
+    cur = conn.cursor()
+    cur.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {_TABLE} (
+            request_id TEXT PRIMARY KEY,
+            source_kind TEXT NOT NULL,
+            item_ref TEXT NOT NULL,
+            source_ref TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending',
+            priority TEXT NOT NULL DEFAULT 'normal',
+            requested_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            completed_at TIMESTAMPTZ,
+            attempts INTEGER NOT NULL DEFAULT 0,
+            next_attempt_at TIMESTAMPTZ,
+            last_failure JSONB,
+            discovery_triggers JSONB NOT NULL DEFAULT '[]'::jsonb,
+            policy_snapshot JSONB NOT NULL DEFAULT '{{}}'::jsonb,
+            policy_version INTEGER NOT NULL DEFAULT 1,
+            trace_id TEXT,
+            content_identity TEXT,
+            artifact_path TEXT,
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            CONSTRAINT acquisition_requests_status_chk CHECK (
+                status IN ('pending', 'in_progress', 'completed', 'dead_lettered')
+            ),
+            CONSTRAINT acquisition_requests_priority_chk CHECK (priority IN ('high', 'normal'))
+        )
+        """
+    )
+    cur.execute(
+        f"CREATE INDEX IF NOT EXISTS acquisition_requests_drain_idx "
+        f"ON {_TABLE} (status, priority, requested_at)"
+    )
+    cur.execute(
+        f"CREATE UNIQUE INDEX IF NOT EXISTS acquisition_requests_identity_uq "
+        f"ON {_TABLE} (source_kind, item_ref, policy_version)"
+    )
+
+
+def _iso_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is not None:
+            value = value.astimezone(timezone.utc)
+        return value.isoformat()
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return str(value)
+
+
+def _row_to_request(row: tuple[Any, ...]) -> AcquisitionRequest:
+    values = dict(zip(_COLUMNS, row))
+
+    def _json_field(name: str, default: Any) -> Any:
+        value = values[name]
+        if value is None:
+            return default
+        if isinstance(value, str):
+            return json.loads(value)
+        return value
+
+    triggers = _json_field("discovery_triggers", [])
+    return AcquisitionRequest(
+        request_id=values["request_id"],
+        source_kind=values["source_kind"],
+        item_ref=values["item_ref"],
+        source_ref=values["source_ref"],
+        status=values["status"],
+        priority=values["priority"],
+        requested_at=_iso_or_none(values["requested_at"]) or "",
+        completed_at=_iso_or_none(values["completed_at"]),
+        attempts=int(values["attempts"]),
+        next_attempt_at=_iso_or_none(values["next_attempt_at"]),
+        last_failure=_json_field("last_failure", None),
+        discovery_triggers=tuple(triggers if isinstance(triggers, list) else []),
+        policy_snapshot=_json_field("policy_snapshot", {}),
+        policy_version=int(values["policy_version"]),
+        trace_id=values["trace_id"],
+        content_identity=values["content_identity"],
+        artifact_path=values["artifact_path"],
+        updated_at=_iso_or_none(values["updated_at"]) or "",
+    )
+
+
+class _PgAcquisitionRequestsBackend:
+    def __init__(self) -> None:
+        conn = _pg_connect()
+        try:
+            _bootstrap_pg(conn)
+        finally:
+            conn.close()
+
+    def insert_or_append(
+        self, row: AcquisitionRequest, trigger: DiscoveryTrigger
+    ) -> tuple[AcquisitionRequest, bool]:
+        conn = _pg_connect()
+        try:
+            _assert_pg_schema(conn)
+            cur = conn.cursor()
+            cur.execute(
+                f"""
+                INSERT INTO {_TABLE} (
+                    request_id, source_kind, item_ref, source_ref, status, priority,
+                    requested_at, completed_at, attempts, next_attempt_at, last_failure,
+                    discovery_triggers, policy_snapshot, policy_version, trace_id,
+                    content_identity, artifact_path, updated_at
+                ) VALUES (
+                    %s, %s, %s, %s, %s, %s,
+                    %s::timestamptz, %s::timestamptz, %s, %s::timestamptz, %s::jsonb,
+                    %s::jsonb, %s::jsonb, %s, %s,
+                    %s, %s, %s::timestamptz
+                )
+                ON CONFLICT (request_id) DO NOTHING
+                RETURNING {_COLUMNS_SQL}
+                """,
+                (
+                    row.request_id,
+                    row.source_kind,
+                    row.item_ref,
+                    row.source_ref,
+                    row.status,
+                    row.priority,
+                    row.requested_at,
+                    row.completed_at,
+                    row.attempts,
+                    row.next_attempt_at,
+                    json.dumps(row.last_failure) if row.last_failure is not None else None,
+                    json.dumps(list(row.discovery_triggers)),
+                    json.dumps(row.policy_snapshot),
+                    row.policy_version,
+                    row.trace_id,
+                    row.content_identity,
+                    row.artifact_path,
+                    row.updated_at,
+                ),
+            )
+            inserted = cur.fetchone()
+            if inserted is not None:
+                return _row_to_request(tuple(inserted)), True
+            # Conflict: append the trigger IF identity-novel, and touch nothing
+            # else — updated_at deliberately excluded (it is the stale-recovery
+            # clock; a re-discovery must never defer a crashed attempt's reset).
+            probe = trigger.identity_dict()
+            cur.execute(
+                f"""
+                UPDATE {_TABLE}
+                SET discovery_triggers = discovery_triggers || %s::jsonb
+                WHERE request_id = %s
+                  AND NOT (discovery_triggers @> %s::jsonb)
+                RETURNING {_COLUMNS_SQL}
+                """,
+                (
+                    json.dumps([trigger.stored_dict(discovered_at=row.requested_at)]),
+                    row.request_id,
+                    json.dumps([probe]),
+                ),
+            )
+            updated = cur.fetchone()
+            if updated is not None:
+                return _row_to_request(tuple(updated)), False
+            # Exact-duplicate trigger: nothing changed; read the existing row.
+            fetched = self.get(row.request_id, conn=conn)
+            assert fetched is not None  # conflicted on an existing row
+            return fetched, False
+        finally:
+            conn.close()
+
+    def get(self, request_id: str, conn: Any = None) -> AcquisitionRequest | None:
+        own = conn is None
+        conn = conn or _pg_connect()
+        try:
+            _assert_pg_schema(conn)
+            cur = conn.cursor()
+            cur.execute(f"SELECT {_COLUMNS_SQL} FROM {_TABLE} WHERE request_id = %s", (request_id,))
+            row = cur.fetchone()
+            return _row_to_request(tuple(row)) if row else None
+        finally:
+            if own:
+                conn.close()
+
+    def list_all(self) -> tuple[AcquisitionRequest, ...]:
+        conn = _pg_connect()
+        try:
+            _assert_pg_schema(conn)
+            cur = conn.cursor()
+            cur.execute(f"SELECT {_COLUMNS_SQL} FROM {_TABLE} ORDER BY requested_at")
+            return tuple(_row_to_request(tuple(row)) for row in cur.fetchall())
+        finally:
+            conn.close()
+
+    def claim(self, limit: int, now: datetime) -> tuple[AcquisitionRequest, ...]:
+        conn = _pg_connect()
+        try:
+            _assert_pg_schema(conn)
+            cur = conn.cursor()
+            # Single-statement claim: atomic under autocommit; SKIP LOCKED keeps
+            # concurrent drainers from double-claiming (INV-YSS-6 belongs to the
+            # scheduler lease, but the row claim is still race-safe here).
+            cur.execute(
+                f"""
+                WITH picked AS (
+                    SELECT request_id FROM {_TABLE}
+                    WHERE status = 'pending'
+                      AND (next_attempt_at IS NULL OR next_attempt_at <= %s::timestamptz)
+                    ORDER BY priority ASC, requested_at ASC
+                    LIMIT %s
+                    FOR UPDATE SKIP LOCKED
+                )
+                UPDATE {_TABLE} t
+                SET status = 'in_progress', attempts = t.attempts + 1, updated_at = %s::timestamptz
+                FROM picked
+                WHERE t.request_id = picked.request_id
+                RETURNING {", ".join("t." + c for c in _COLUMNS)}
+                """,
+                (_iso(now), max(0, limit), _iso(now)),
+            )
+            rows = [_row_to_request(tuple(r)) for r in cur.fetchall()]
+            # RETURNING order is not guaranteed; re-sort with the same key as
+            # the pick ('high' < 'normal' lexicographically, then FIFO).
+            rows.sort(key=lambda r: (r.priority, r.requested_at))
+            return tuple(rows)
+        finally:
+            conn.close()
+
+    def _mutate(
+        self,
+        request_id: str,
+        sets: str,
+        params: tuple[Any, ...],
+        *,
+        allowed_from: tuple[str, ...],
+    ) -> AcquisitionRequest | None:
+        """Guarded single-statement transition (``UPDATE ... RETURNING``).
+
+        The status predicate makes terminal states terminal (INV-YSS-3): a
+        stale drainer's late ``fail()``/``complete()`` cannot reopen or rewrite
+        a completed/dead-lettered row. Returns ``None`` on a guard miss (row
+        exists in a disallowed state — the service layer classifies), raises
+        ``KeyError`` when the row is missing.
+        """
+        conn = _pg_connect()
+        try:
+            _assert_pg_schema(conn)
+            cur = conn.cursor()
+            cur.execute(
+                f"UPDATE {_TABLE} SET {sets} WHERE request_id = %s AND status = ANY(%s) "
+                f"RETURNING {_COLUMNS_SQL}",
+                (*params, request_id, list(allowed_from)),
+            )
+            row = cur.fetchone()
+            if row is not None:
+                return _row_to_request(tuple(row))
+            if self.get(request_id, conn=conn) is None:
+                raise KeyError(f"no such acquisition request: {request_id}")
+            return None
+        finally:
+            conn.close()
+
+    def set_completed(
+        self, request_id: str, *, content_identity: str, artifact_path: str | None, now: datetime
+    ) -> AcquisitionRequest | None:
+        return self._mutate(
+            request_id,
+            "status = 'completed', completed_at = %s::timestamptz, next_attempt_at = NULL, "
+            "content_identity = %s, artifact_path = %s, updated_at = %s::timestamptz",
+            (_iso(now), content_identity, artifact_path, _iso(now)),
+            allowed_from=("in_progress",),
+        )
+
+    def set_failed_retryable(
+        self, request_id: str, *, last_failure: dict[str, Any], next_attempt_at: datetime, now: datetime
+    ) -> AcquisitionRequest | None:
+        return self._mutate(
+            request_id,
+            "status = 'pending', last_failure = %s::jsonb, next_attempt_at = %s::timestamptz, "
+            "updated_at = %s::timestamptz",
+            (json.dumps(last_failure), _iso(next_attempt_at), _iso(now)),
+            allowed_from=("in_progress",),
+        )
+
+    def set_dead_lettered(
+        self, request_id: str, *, last_failure: dict[str, Any], now: datetime
+    ) -> AcquisitionRequest | None:
+        return self._mutate(
+            request_id,
+            "status = 'dead_lettered', last_failure = %s::jsonb, next_attempt_at = NULL, "
+            "updated_at = %s::timestamptz",
+            (json.dumps(last_failure), _iso(now)),
+            allowed_from=("in_progress", "pending"),
+        )
+
+    def reset_stale(self, older_than_seconds: int, now: datetime) -> int:
+        conn = _pg_connect()
+        try:
+            _assert_pg_schema(conn)
+            cur = conn.cursor()
+            cur.execute(
+                f"""
+                UPDATE {_TABLE}
+                SET status = 'pending', updated_at = %s::timestamptz
+                WHERE status = 'in_progress' AND updated_at <= %s::timestamptz
+                """,
+                (_iso(now), _iso(now - timedelta(seconds=older_than_seconds))),
+            )
+            return cur.rowcount
+        finally:
+            conn.close()
+
+
+# --- Service layer ------------------------------------------------------------
+
+
+class AcquisitionRequests:
+    """Service facade enforcing identical semantics on both backends."""
+
+    def __init__(
+        self,
+        backend: _MemoryAcquisitionRequestsBackend | _PgAcquisitionRequestsBackend,
+        *,
+        max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+    ) -> None:
+        self._backend = backend
+        self._max_attempts = max_attempts
+
+    @classmethod
+    def for_runtime(cls, *, max_attempts: int = DEFAULT_MAX_ATTEMPTS) -> "AcquisitionRequests":
+        if _resolve_backend() == "pg":
+            return cls(_PgAcquisitionRequestsBackend(), max_attempts=max_attempts)
+        return cls(_MEMORY_REQUESTS, max_attempts=max_attempts)
+
+    # -- enqueue ---------------------------------------------------------------
+
+    def enqueue(
+        self,
+        *,
+        source_kind: str,
+        item_ref: str,
+        source_ref: str,
+        trigger: DiscoveryTrigger,
+        priority: str = "normal",
+        policy_snapshot: dict[str, Any] | None = None,
+        trace_id: str | None = None,
+        now: datetime | None = None,
+        conn: Any = None,
+    ) -> AcquisitionRequest:
+        """Idempotent enqueue (INV-YSS-2). Emits ``youtube.source.discovered``
+        (key-deduped per ``(binding_id, item_ref)``) and, on first insert only,
+        ``acquisition.requested``. On conflict the identity-novel trigger is
+        appended and nothing else is touched — a completed/dead-lettered request
+        is never reopened by a late duplicate discovery.
+        """
+        for name, value in (("source_kind", source_kind), ("item_ref", item_ref), ("source_ref", source_ref)):
+            if not isinstance(value, str) or not value.strip() or "\x00" in value:
+                raise AcquisitionRequestValidationError(
+                    f"{name} must be a non-empty NUL-free string, got {value!r}"
+                )
+        if priority not in VALID_PRIORITIES:
+            raise AcquisitionRequestValidationError(
+                f"priority must be one of {sorted(VALID_PRIORITIES)}, got {priority!r}"
+            )
+        if not isinstance(trigger, DiscoveryTrigger):
+            raise AcquisitionRequestValidationError("trigger must be a DiscoveryTrigger")
+        trigger.validate()
+
+        snapshot = dict(policy_snapshot) if policy_snapshot is not None else {"policy_version": 1}
+        policy_version = snapshot.get("policy_version", 1)
+        if not isinstance(policy_version, int) or isinstance(policy_version, bool) or policy_version < 1:
+            raise AcquisitionRequestValidationError(
+                f"policy_snapshot.policy_version must be a positive int, got {policy_version!r}"
+            )
+        # Normalize: the stored snapshot always mirrors the authoritative
+        # policy_version column, so no later reader can see the two disagree.
+        snapshot["policy_version"] = policy_version
+        if snapshot.get("extractor_ids") is not None:
+            extractor_ids = snapshot["extractor_ids"]
+            if not isinstance(extractor_ids, list) or not all(
+                isinstance(x, str) and x.strip() for x in extractor_ids
+            ):
+                raise AcquisitionRequestValidationError(
+                    "policy_snapshot.extractor_ids must be a list of non-empty strings"
+                )
+
+        moment = _now(now)
+        stamp = _iso(moment)
+        request_id = request_identity(source_kind, item_ref, policy_version)
+        row = AcquisitionRequest(
+            request_id=request_id,
+            source_kind=source_kind,
+            item_ref=item_ref,
+            source_ref=source_ref,
+            status="pending",
+            priority=priority,
+            requested_at=stamp,
+            completed_at=None,
+            attempts=0,
+            next_attempt_at=None,
+            last_failure=None,
+            discovery_triggers=(trigger.stored_dict(discovered_at=stamp),),
+            policy_snapshot=snapshot,
+            policy_version=policy_version,
+            trace_id=trace_id,
+            content_identity=None,
+            artifact_path=None,
+            updated_at=stamp,
+        )
+        stored, created = self._backend.insert_or_append(row, trigger)
+
+        # Discovery lineage: youtube-shaped sources only (the queue itself is
+        # source-agnostic; the topic is not).
+        if source_kind == YOUTUBE_SOURCE_KIND:
+            payload: dict[str, Any] = {
+                "binding_id": trigger.binding_id,
+                "collection_kind": trigger.collection_kind,
+                "collection_ref": trigger.collection_ref,
+                "item_ref": item_ref,
+                "trigger": trigger.trigger,
+            }
+            if trigger.playlist_item_id is not None:
+                payload["playlist_item_id"] = trigger.playlist_item_id
+            self._emit(
+                YOUTUBE_SOURCE_DISCOVERED_TOPIC,
+                payload,
+                key=discovered_event_key(trigger.binding_id, item_ref),
+                trace_id=trace_id,
+                conn=conn,
+            )
+        # Emitted unconditionally with the deterministic (request_id,
+        # policy_version) key: the FIRST emission wins and duplicates dedup, so
+        # a crash between the row insert and the emit self-heals on the next
+        # duplicate discovery instead of losing the event forever.
+        self._emit(
+            ACQUISITION_REQUESTED_TOPIC,
+            {
+                "request_id": request_id,
+                "source_kind": source_kind,
+                "item_ref": item_ref,
+                "policy_version": policy_version,
+                "priority": priority,
+                "trigger_count": len(stored.discovery_triggers),
+            },
+            key=requested_event_key(request_id, policy_version),
+            trace_id=trace_id,
+            conn=conn,
+        )
+        del created  # identity/dedup outcome is visible via discovery_triggers
+        return stored
+
+    # -- drain lifecycle -------------------------------------------------------
+
+    def claim_batch(
+        self, limit: int, *, now: datetime | None = None, conn: Any = None
+    ) -> list[AcquisitionRequest]:
+        """Claim up to ``limit`` due pending requests in ``(priority, requested_at)``
+        order, marking them ``in_progress`` (attempt += 1) and emitting one
+        attempt-scoped ``acquisition.started`` per claim.
+        """
+        moment = _now(now)
+        claimed = self._backend.claim(limit, moment)
+        for row in claimed:
+            self._emit(
+                ACQUISITION_STARTED_TOPIC,
+                {"request_id": row.request_id, "attempt": row.attempts},
+                key=attempt_event_key(ACQUISITION_STARTED_TOPIC, row.request_id, row.attempts),
+                trace_id=row.trace_id,
+                conn=conn,
+            )
+        return list(claimed)
+
+    def complete(
+        self,
+        request_id: str,
+        *,
+        content_identity: str,
+        artifact_path: str | None = None,
+        dedup_noop: bool = False,
+        now: datetime | None = None,
+        conn: Any = None,
+    ) -> AcquisitionRequest:
+        """Terminal success (INV-YSS-3): candidate written or traced dedup no-op.
+
+        Applies only to a claimed (``in_progress``) request. A late complete on
+        an already-terminal row is an idempotent no-op returning the terminal
+        row unchanged (no event); completing a never-claimed row is a loud
+        caller error.
+        """
+        if not isinstance(content_identity, str) or not content_identity.strip():
+            raise AcquisitionRequestValidationError("content_identity must be a non-empty string")
+        moment = _now(now)
+        row = self._backend.set_completed(
+            request_id, content_identity=content_identity, artifact_path=artifact_path, now=moment
+        )
+        if row is None:
+            return self._classify_guard_miss(request_id, action="complete")
+        payload: dict[str, Any] = {
+            "request_id": request_id,
+            "attempt": row.attempts,
+            "content_identity": content_identity,
+            "dedup_noop": dedup_noop,
+        }
+        if artifact_path is not None:
+            payload["artifact_path"] = artifact_path
+        self._emit(
+            ACQUISITION_COMPLETED_TOPIC,
+            payload,
+            key=attempt_event_key(ACQUISITION_COMPLETED_TOPIC, request_id, row.attempts),
+            trace_id=row.trace_id,
+            conn=conn,
+        )
+        return row
+
+    def fail(
+        self,
+        request_id: str,
+        *,
+        reason_code: str,
+        error: BaseException | str | None = None,
+        now: datetime | None = None,
+        conn: Any = None,
+        rng: Callable[[], float] | None = None,
+    ) -> AcquisitionRequest:
+        """Reason-coded failure of the current attempt.
+
+        Retryable: back to ``pending`` with a contract backoff gate. Attempts
+        exhausted (``>= max_attempts``): explicit item-scoped ``dead_lettered``
+        with ``terminal: true``. Applies only to a claimed (``in_progress``)
+        request: a late fail from a stale drainer on an already-terminal row is
+        an idempotent no-op (INV-YSS-3 — terminal is terminal), and failing a
+        never-claimed row is a loud caller error.
+        """
+        if not isinstance(reason_code, str) or not reason_code.strip():
+            raise AcquisitionRequestValidationError("reason_code must be a non-empty string")
+        current = self._backend.get(request_id)
+        if current is None:
+            raise KeyError(f"no such acquisition request: {request_id}")
+        if current.status in TERMINAL_STATUSES:
+            return current
+        if current.status != "in_progress":
+            raise AcquisitionRequestValidationError(
+                f"fail requires a claimed (in_progress) request; {request_id} is {current.status!r}"
+            )
+        moment = _now(now)
+        attempt = max(1, current.attempts)
+        last_failure = {
+            "reason_code": reason_code,
+            "error": sanitize_error(error),
+            "at": _iso(moment),
+        }
+        if attempt >= self._max_attempts:
+            row = self._backend.set_dead_lettered(request_id, last_failure=last_failure, now=moment)
+            if row is None:
+                return self._classify_guard_miss(request_id, action="fail")
+            self._emit_failed(row, attempt, reason_code, terminal=True, next_attempt_at=None, conn=conn)
+            return row
+        gate = moment + timedelta(seconds=compute_backoff_seconds(attempt, rng=rng))
+        row = self._backend.set_failed_retryable(
+            request_id, last_failure=last_failure, next_attempt_at=gate, now=moment
+        )
+        if row is None:
+            return self._classify_guard_miss(request_id, action="fail")
+        self._emit_failed(row, attempt, reason_code, terminal=False, next_attempt_at=_iso(gate), conn=conn)
+        return row
+
+    def dead_letter(
+        self,
+        request_id: str,
+        *,
+        reason_code: str,
+        error: BaseException | str | None = None,
+        now: datetime | None = None,
+        conn: Any = None,
+    ) -> AcquisitionRequest:
+        """Explicit item-scoped terminal outcome (KA stage dead-letter surfaced).
+
+        Applies from ``in_progress`` or ``pending``; a repeat on an
+        already-terminal row is an idempotent no-op (INV-YSS-3).
+        """
+        if not isinstance(reason_code, str) or not reason_code.strip():
+            raise AcquisitionRequestValidationError("reason_code must be a non-empty string")
+        moment = _now(now)
+        last_failure = {
+            "reason_code": reason_code,
+            "error": sanitize_error(error),
+            "at": _iso(moment),
+        }
+        row = self._backend.set_dead_lettered(request_id, last_failure=last_failure, now=moment)
+        if row is None:
+            return self._classify_guard_miss(request_id, action="dead_letter")
+        self._emit_failed(
+            row, max(1, row.attempts), reason_code, terminal=True, next_attempt_at=None, conn=conn
+        )
+        return row
+
+    def _classify_guard_miss(self, request_id: str, *, action: str) -> AcquisitionRequest:
+        """A guarded transition matched no row: terminal ⇒ idempotent no-op
+        (return the terminal row unchanged, emit nothing — INV-YSS-3), any other
+        disallowed state ⇒ loud caller error, missing ⇒ KeyError."""
+        current = self._backend.get(request_id)
+        if current is None:
+            raise KeyError(f"no such acquisition request: {request_id}")
+        if current.status in TERMINAL_STATUSES:
+            return current
+        raise AcquisitionRequestValidationError(
+            f"{action} is not applicable to request {request_id} in status {current.status!r}"
+        )
+
+    def reset_stale_in_progress(
+        self,
+        *,
+        older_than_seconds: int = DEFAULT_STALE_IN_PROGRESS_SECONDS,
+        now: datetime | None = None,
+    ) -> int:
+        """Restart recovery: rows stuck ``in_progress`` past the threshold go back
+        to ``pending`` (attempts untouched, no event — the next claim emits its
+        own attempt-scoped ``acquisition.started``). Returns the reset count.
+        """
+        return self._backend.reset_stale(older_than_seconds, _now(now))
+
+    # -- reads ----------------------------------------------------------------
+
+    def get(self, request_id: str) -> AcquisitionRequest | None:
+        return self._backend.get(request_id)
+
+    def list_all(self) -> tuple[AcquisitionRequest, ...]:
+        return self._backend.list_all()
+
+    # -- emission helpers ------------------------------------------------------
+
+    def _emit_failed(
+        self,
+        row: AcquisitionRequest,
+        attempt: int,
+        reason_code: str,
+        *,
+        terminal: bool,
+        next_attempt_at: str | None,
+        conn: Any,
+    ) -> None:
+        payload: dict[str, Any] = {
+            "request_id": row.request_id,
+            "attempt": attempt,
+            "reason_code": reason_code,
+            "terminal": terminal,
+        }
+        if next_attempt_at is not None:
+            payload["next_attempt_at"] = next_attempt_at
+        self._emit(
+            ACQUISITION_FAILED_TOPIC,
+            payload,
+            key=failed_event_key(row.request_id, attempt, terminal=terminal),
+            trace_id=row.trace_id,
+            conn=conn,
+        )
+
+    def _emit(
+        self, topic: str, payload: dict[str, Any], *, key: str, trace_id: str | None, conn: Any
+    ) -> None:
+        event = new_event(event_type=topic, payload=payload, trace_id=trace_id, source=EVENT_SOURCE)
+        write_outbox_event(event, conn=conn, idempotency_key=key)
+
+
+# --- Drain adapter ------------------------------------------------------------
+
+
+def drain_one(
+    request: AcquisitionRequest,
+    *,
+    vault_context: Any,
+    queue: AcquisitionRequests,
+    write_guard: Any = None,
+    conn: Any = None,
+    env: Any = None,
+    now: datetime | None = None,
+    acquire_fn: Callable[..., Any] | None = None,
+) -> AcquisitionRequest:
+    """Run one claimed request through the existing KA pipeline and map its
+    outcome to queue state per INV-YSS-3.
+
+    - ``AcquisitionReceipt.ok`` → :meth:`AcquisitionRequests.complete`
+      (+``content_identity``/``artifact_path``; ``dedup_noop`` when the
+      candidate write was the traced ``already_exists`` no-op).
+    - ``blocked`` (governed WriteGuard denial) → retryable
+      ``writeguard_blocked``.
+    - stage dead-letter (``receipt.dead_lettered`` non-empty) →
+      ``pipeline_dead_letter`` — terminal, item-scoped.
+    - raised :class:`AcquisitionError` → retryable ``network_error`` (the
+      transient fetch/ASR chain dominates this path; deterministic pipeline
+      failures still surface their durable stage dead-letter in lineage and
+      converge to ``dead_lettered`` through attempts exhaustion).
+
+    The scheduler slice (YSS-06) owns *when* this runs; unexpected exceptions
+    (config errors such as ``DatabaseNotConfiguredError`` included) propagate
+    loud rather than being folded into queue state.
+    """
+    from app.knowledge_acquisition.acquire import AcquisitionError, acquire_youtube
+    from app.write_guard import DEFAULT_WRITE_GUARD
+
+    if request.source_kind != YOUTUBE_SOURCE_KIND:
+        # No drain adapter exists for this kind yet: an explicit item-scoped
+        # terminal outcome with the contract reason code, never a crash that
+        # would wedge the whole drain loop on one row.
+        return queue.dead_letter(
+            request.request_id,
+            reason_code="source_unsupported",
+            error=f"no drain adapter for source_kind {request.source_kind!r}",
+            now=now,
+            conn=conn,
+        )
+
+    policy = request.policy_snapshot or {}
+    raw_extractor_ids = policy.get("extractor_ids") or ()
+    if isinstance(raw_extractor_ids, str):
+        raise AcquisitionRequestValidationError(
+            "policy_snapshot.extractor_ids must be a list of strings, not a bare string"
+        )
+    extractor_ids = tuple(raw_extractor_ids) or ("summary",)
+    guard = write_guard if write_guard is not None else DEFAULT_WRITE_GUARD
+    fn = acquire_fn or acquire_youtube
+
+    try:
+        receipt = fn(
+            request.source_ref,
+            vault_context=vault_context,
+            extractor_ids=extractor_ids,
+            write_guard=guard,
+            trace_id=request.trace_id,
+            conn=conn,
+            env=env,
+        )
+    except AcquisitionError as exc:
+        return queue.fail(
+            request.request_id,
+            reason_code="network_error",
+            error=exc,
+            now=now,
+            conn=conn,
+        )
+
+    if receipt.blocked:
+        blocked_detail = next(
+            (s.detail for s in receipt.stages if s.stage == "candidate" and s.status == "blocked"),
+            None,
+        )
+        return queue.fail(
+            request.request_id,
+            reason_code="writeguard_blocked",
+            error=blocked_detail or "candidate write blocked by WriteGuard",
+            now=now,
+            conn=conn,
+        )
+
+    if receipt.dead_lettered:
+        return queue.dead_letter(
+            request.request_id,
+            reason_code="pipeline_dead_letter",
+            error=f"stage dead-letter: {', '.join(receipt.dead_lettered)}",
+            now=now,
+            conn=conn,
+        )
+
+    candidate = next((s for s in receipt.stages if s.stage == "candidate"), None)
+    return queue.complete(
+        request.request_id,
+        content_identity=receipt.content_identity,
+        artifact_path=candidate.artifact_path if candidate is not None else None,
+        dedup_noop=bool(candidate is not None and candidate.status == "already_exists"),
+        now=now,
+        conn=conn,
+    )
+
+
+__all__ = [
+    "ACQUISITION_COMPLETED_TOPIC",
+    "ACQUISITION_FAILED_TOPIC",
+    "ACQUISITION_REQUESTED_TOPIC",
+    "ACQUISITION_REQUEST_NAMESPACE",
+    "ACQUISITION_STARTED_TOPIC",
+    "AcquisitionRequest",
+    "AcquisitionRequestValidationError",
+    "AcquisitionRequests",
+    "AcquisitionRequestsSchemaMissingError",
+    "BACKOFF_BASE_SECONDS",
+    "BACKOFF_CAP_SECONDS",
+    "BACKOFF_FACTOR",
+    "DEFAULT_MAX_ATTEMPTS",
+    "DEFAULT_STALE_IN_PROGRESS_SECONDS",
+    "DiscoveryTrigger",
+    "EVENT_SOURCE",
+    "TERMINAL_STATUSES",
+    "VALID_PRIORITIES",
+    "VALID_STATUSES",
+    "VALID_TRIGGER_KINDS",
+    "YOUTUBE_SOURCE_DISCOVERED_TOPIC",
+    "YOUTUBE_SOURCE_KIND",
+    "attempt_event_key",
+    "compute_backoff_seconds",
+    "discovered_event_key",
+    "drain_one",
+    "failed_event_key",
+    "request_identity",
+    "requested_event_key",
+    "reset_memory_acquisition_requests",
+    "sanitize_error",
+]

--- a/schemas/events/acquisition.completed.v1.schema.json
+++ b/schemas/events/acquisition.completed.v1.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yggdrasil.local/schemas/events/acquisition.completed.v1.schema.json",
+  "title": "acquisition.completed payload (v1)",
+  "description": "Payload of the acquisition.completed outbox event (docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md :: Event topics). Producer: app/knowledge_acquisition/acquisition_requests.py::AcquisitionRequests.complete — the request reached the KA pipeline's terminal candidate outcome (note written or traced dedup no-op; INV-YSS-3). Idempotency key basis: (topic, request_id, attempt). Lineage posture: no dispatched consumer.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["request_id", "attempt", "content_identity", "dedup_noop"],
+  "properties": {
+    "request_id": { "type": "string", "minLength": 1 },
+    "attempt": { "type": "integer", "minimum": 1 },
+    "content_identity": { "type": "string", "minLength": 1 },
+    "artifact_path": { "type": ["string", "null"] },
+    "dedup_noop": { "type": "boolean" }
+  }
+}

--- a/schemas/events/acquisition.failed.v1.schema.json
+++ b/schemas/events/acquisition.failed.v1.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yggdrasil.local/schemas/events/acquisition.failed.v1.schema.json",
+  "title": "acquisition.failed payload (v1)",
+  "description": "Payload of the acquisition.failed outbox event (docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md :: Event topics). Producer: app/knowledge_acquisition/acquisition_requests.py::AcquisitionRequests.fail / .dead_letter — one drain attempt failed, retryable (terminal=false, with the backoff gate) or terminal (terminal=true: explicit dead-letter or attempts exhaustion). Idempotency key basis: (topic, request_id, attempt). reason_code follows the contract taxonomy; error text is exception-class + safe message, never token material (INV-YSS-5). Lineage posture: no dispatched consumer.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["request_id", "attempt", "reason_code", "terminal"],
+  "properties": {
+    "request_id": { "type": "string", "minLength": 1 },
+    "attempt": { "type": "integer", "minimum": 1 },
+    "reason_code": { "type": "string", "minLength": 1 },
+    "terminal": { "type": "boolean" },
+    "next_attempt_at": { "type": ["string", "null"] }
+  }
+}

--- a/schemas/events/acquisition.requested.v1.schema.json
+++ b/schemas/events/acquisition.requested.v1.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yggdrasil.local/schemas/events/acquisition.requested.v1.schema.json",
+  "title": "acquisition.requested payload (v1)",
+  "description": "Payload of the acquisition.requested outbox event (docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md :: Event topics). Producer: app/knowledge_acquisition/acquisition_requests.py::AcquisitionRequests.enqueue — emitted exactly once, when the durable request row is first created. Idempotency key basis: (topic, request_id, policy_version). Lineage posture: no dispatched consumer.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["request_id", "source_kind", "item_ref", "policy_version", "priority", "trigger_count"],
+  "properties": {
+    "request_id": { "type": "string", "minLength": 1 },
+    "source_kind": { "type": "string", "minLength": 1 },
+    "item_ref": { "type": "string", "minLength": 1 },
+    "policy_version": { "type": "integer", "minimum": 1 },
+    "priority": { "type": "string", "enum": ["high", "normal"] },
+    "trigger_count": { "type": "integer", "minimum": 1 }
+  }
+}

--- a/schemas/events/acquisition.started.v1.schema.json
+++ b/schemas/events/acquisition.started.v1.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yggdrasil.local/schemas/events/acquisition.started.v1.schema.json",
+  "title": "acquisition.started payload (v1)",
+  "description": "Payload of the acquisition.started outbox event (docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md :: Event topics). Producer: app/knowledge_acquisition/acquisition_requests.py::AcquisitionRequests.claim_batch — one drain attempt began. Idempotency key basis: (topic, request_id, attempt); each attempt is a distinct event, a duplicate delivery of the same attempt dedups. Lineage posture: no dispatched consumer.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["request_id", "attempt"],
+  "properties": {
+    "request_id": { "type": "string", "minLength": 1 },
+    "attempt": { "type": "integer", "minimum": 1 }
+  }
+}

--- a/schemas/events/youtube.source.discovered.v1.schema.json
+++ b/schemas/events/youtube.source.discovered.v1.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://yggdrasil.local/schemas/events/youtube.source.discovered.v1.schema.json",
+  "title": "youtube.source.discovered payload (v1)",
+  "description": "Payload of the youtube.source.discovered outbox event (docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md :: Event topics). Producer: app/knowledge_acquisition/acquisition_requests.py::AcquisitionRequests.enqueue — a not-previously-disposed item was seen in a synced source. Idempotency key basis: (topic, binding_id, item_ref), so re-discovery of the same item in the same source dedups. Lineage posture: no dispatched consumer.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["binding_id", "collection_kind", "collection_ref", "item_ref", "trigger"],
+  "properties": {
+    "binding_id": { "type": "string", "minLength": 1 },
+    "collection_kind": { "type": "string", "minLength": 1 },
+    "collection_ref": { "type": "string", "minLength": 1 },
+    "item_ref": { "type": "string", "minLength": 1 },
+    "playlist_item_id": { "type": ["string", "null"] },
+    "trigger": { "type": "string", "enum": ["poll", "backfill", "manual"] }
+  }
+}

--- a/tests/guard/test_no_direct_db_imports.py
+++ b/tests/guard/test_no_direct_db_imports.py
@@ -144,6 +144,11 @@ ALLOW_FILES = (
     # (youtube_account_binding) with a self-contained dual memory/pg backend,
     # direct DSN connection, no ORM layer to route through.
     'app/knowledge_acquisition/youtube_account_binding.py',
+    # YouTube Source Sync durable acquisition request queue (YSS-04, #3919).
+    # Same bounded pattern: a dedicated table (acquisition_requests) with a
+    # self-contained dual memory/pg backend, direct DSN connection, no ORM
+    # layer to route through.
+    'app/knowledge_acquisition/acquisition_requests.py',
 )
 
 def _allowed(p: Path) -> bool:

--- a/tests/knowledge_acquisition/_acquisition_requests_contract.py
+++ b/tests/knowledge_acquisition/_acquisition_requests_contract.py
@@ -1,0 +1,277 @@
+"""YSS-04 (#3919): shared service-layer contract for the acquisition queue.
+
+The SAME behavioral assertions run against the memory backend (implicitly via
+`test_acquisition_requests.py`'s AC tests) and the real Postgres backend
+(`test_acquisition_requests_pg.py`) — proving the queue semantics hold
+identically on both backends (AC7), mirroring
+`_source_registry_contract.py`'s pattern.
+
+Every assertion uses unique synthetic item refs (INV-YSS-9: no real ids) so
+the suite is self-contained against a shared database.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable
+
+from app.knowledge_acquisition.acquisition_requests import (
+    ACQUISITION_FAILED_TOPIC,
+    ACQUISITION_REQUESTED_TOPIC,
+    ACQUISITION_STARTED_TOPIC,
+    DEFAULT_MAX_ATTEMPTS,
+    AcquisitionRequests,
+    DiscoveryTrigger,
+    request_identity,
+)
+
+
+class _FakeCursor:
+    def __init__(self, rows: list[tuple]):
+        self._rows = rows
+
+    def fetchone(self):
+        return self._rows[0] if self._rows else None
+
+    def fetchall(self):
+        return list(self._rows)
+
+
+class FakeOutboxConn:
+    """In-memory outbox emulating the keyed insert's PK-conflict dedup.
+
+    The ONE shared fake for this suite: the memory-backend AC tests and the pg
+    parity suite must exercise identical outbox semantics, so there is exactly
+    one emulation to keep in sync with the real insert shape.
+    """
+
+    def __init__(self) -> None:
+        self.rows: dict[str, dict[str, Any]] = {}
+
+    def execute(self, sql: str, params: tuple = ()) -> _FakeCursor:
+        text = " ".join(sql.lower().split())
+        if text.startswith("insert into outbox (id,"):
+            assert "on conflict (id) do nothing" in text
+            row_id, topic, payload, created_at, attempts = params
+            if row_id in self.rows:
+                return _FakeCursor([])
+            self.rows[row_id] = {
+                "id": row_id,
+                "topic": topic,
+                "payload": payload,
+                "created_at": created_at,
+                "attempts": attempts,
+            }
+            return _FakeCursor([(row_id,)])
+        raise AssertionError(f"unexpected SQL shape reached the outbox: {text!r}")
+
+    def close(self) -> None:  # pragma: no cover - psycopg parity
+        pass
+
+    def rows_for(self, topic: str) -> list[dict[str, Any]]:
+        return [r for r in self.rows.values() if r["topic"] == topic]
+
+    def payloads_for(self, topic: str) -> list[dict[str, Any]]:
+        import json as _json
+
+        return [_json.loads(r["payload"])["payload"] for r in self.rows_for(topic)]
+
+
+MakeQueue = Callable[[], AcquisitionRequests]
+
+
+def _item() -> str:
+    return uuid.uuid4().hex[:11]
+
+
+def _trigger(**overrides: Any) -> DiscoveryTrigger:
+    defaults: dict[str, Any] = dict(
+        binding_id=str(uuid.uuid4()),
+        collection_kind="owned_playlist",
+        collection_ref="PL__test__contract",
+        trigger="poll",
+    )
+    defaults.update(overrides)
+    return DiscoveryTrigger(**defaults)
+
+
+def _enqueue(q: AcquisitionRequests, conn: FakeOutboxConn, item: str, **kw: Any):
+    return q.enqueue(
+        source_kind="youtube_url",
+        item_ref=item,
+        source_ref=f"https://www.youtube.com/watch?v={item}",
+        trigger=kw.pop("trigger", _trigger()),
+        conn=conn,
+        **kw,
+    )
+
+
+def _terminalize(q: AcquisitionRequests, conn: FakeOutboxConn, *rows: Any) -> None:
+    """Leave no claimable rows behind: each assertion runs against a shared
+    database in the pg parity suite, so a leftover pending/in_progress row from
+    one assertion must never leak into the next one's claim ordering."""
+    for row in rows:
+        current = q.get(row.request_id)
+        if current is not None and current.status in ("pending", "in_progress"):
+            q.dead_letter(
+                row.request_id, reason_code="pipeline_dead_letter", error="contract cleanup", conn=conn
+            )
+
+
+def assert_identity_and_trigger_merge(make_queue: MakeQueue) -> None:
+    q = make_queue()
+    conn = FakeOutboxConn()
+    item = _item()
+    t1, t2 = _trigger(), _trigger(collection_kind="inbox_playlist")
+
+    r1 = _enqueue(q, conn, item, trigger=t1)
+    r2 = _enqueue(q, conn, item, trigger=t2)
+    assert r1.request_id == r2.request_id == request_identity("youtube_url", item, 1)
+    assert len(r2.discovery_triggers) == 2
+    assert {t["binding_id"] for t in r2.discovery_triggers} == {t1.binding_id, t2.binding_id}
+    # Identical re-discovery converges without unbounded growth.
+    r3 = _enqueue(q, conn, item, trigger=t1)
+    assert len(r3.discovery_triggers) == 2
+    assert len(conn.rows_for(ACQUISITION_REQUESTED_TOPIC)) == 1
+    _terminalize(q, conn, r1)
+
+
+def assert_durable_completed_lifecycle(make_queue: MakeQueue) -> None:
+    q = make_queue()
+    conn = FakeOutboxConn()
+    item = _item()
+    row = _enqueue(q, conn, item)
+    assert row.status == "pending"
+    assert row.attempts == 0
+    assert row.completed_at is None
+
+    # A fresh service instance sees the same durable row (restart durability).
+    q2 = make_queue()
+    reloaded = q2.get(row.request_id)
+    assert reloaded is not None and reloaded.status == "pending"
+
+    claimed = q2.claim_batch(10, conn=conn)
+    claimed_ids = [c.request_id for c in claimed]
+    assert row.request_id in claimed_ids
+    mine = next(c for c in claimed if c.request_id == row.request_id)
+    assert mine.status == "in_progress"
+    assert mine.attempts == 1
+    assert conn.rows_for(ACQUISITION_STARTED_TOPIC)
+
+    done = q2.complete(
+        row.request_id, content_identity="cid-contract", artifact_path="inbox/n.md", conn=conn
+    )
+    assert done.status == "completed"
+    assert done.completed_at is not None
+    assert done.content_identity == "cid-contract"
+    assert done.artifact_path == "inbox/n.md"
+
+    # Late duplicate discovery never reopens a terminal request.
+    late = _enqueue(q2, conn, item)
+    assert late.status == "completed"
+    _terminalize(q2, conn, *claimed)
+
+
+def assert_claim_order_and_backoff_gate(make_queue: MakeQueue) -> None:
+    q = make_queue()
+    conn = FakeOutboxConn()
+    now = datetime.now(timezone.utc)
+
+    older_normal = _enqueue(q, conn, _item(), priority="normal", now=now)
+    high = _enqueue(q, conn, _item(), priority="high", now=now + timedelta(seconds=1))
+    newer_normal = _enqueue(q, conn, _item(), priority="normal", now=now + timedelta(seconds=2))
+
+    order = [r.request_id for r in q.claim_batch(3, now=now + timedelta(seconds=3), conn=conn)]
+    assert order == [high.request_id, older_normal.request_id, newer_normal.request_id]
+
+    # Backoff gate: a failed attempt is not claimable before next_attempt_at.
+    q.fail(high.request_id, reason_code="network_error", error="transient", now=now, conn=conn)
+    gated = q.get(high.request_id)
+    assert gated.status == "pending"
+    assert gated.next_attempt_at is not None
+    assert q.claim_batch(5, now=now + timedelta(seconds=30), conn=conn) == []
+    reclaim = q.claim_batch(5, now=now + timedelta(hours=7), conn=conn)
+    assert high.request_id in [r.request_id for r in reclaim]
+    _terminalize(q, conn, older_normal, high, newer_normal)
+
+
+def assert_retry_then_exhaustion_dead_letter(make_queue: MakeQueue) -> None:
+    q = make_queue()
+    conn = FakeOutboxConn()
+    row = _enqueue(q, conn, _item())
+    # Moving clock: each iteration jumps a day, always past the ≤6 h backoff
+    # gate the previous fail() set (fail at t gates retry at t + backoff).
+    t = datetime.now(timezone.utc)
+    for _ in range(DEFAULT_MAX_ATTEMPTS):
+        t = t + timedelta(days=1)
+        claimed = q.claim_batch(1, now=t, conn=conn)
+        assert [c.request_id for c in claimed] == [row.request_id]
+        q.fail(row.request_id, reason_code="network_error", error="down", now=t, conn=conn)
+    final = q.get(row.request_id)
+    assert final.status == "dead_lettered"
+    assert final.attempts == DEFAULT_MAX_ATTEMPTS
+    assert final.last_failure["reason_code"] == "network_error"
+    assert conn.rows_for(ACQUISITION_FAILED_TOPIC)
+
+
+def assert_explicit_dead_letter(make_queue: MakeQueue) -> None:
+    q = make_queue()
+    conn = FakeOutboxConn()
+    row = _enqueue(q, conn, _item())
+    q.claim_batch(1, conn=conn)
+    q.dead_letter(row.request_id, reason_code="pipeline_dead_letter", error="stage", conn=conn)
+    final = q.get(row.request_id)
+    assert final.status == "dead_lettered"
+    assert final.last_failure["reason_code"] == "pipeline_dead_letter"
+
+
+def assert_reset_stale_in_progress(make_queue: MakeQueue) -> None:
+    q = make_queue()
+    conn = FakeOutboxConn()
+    row = _enqueue(q, conn, _item())
+    q.claim_batch(1, conn=conn)
+    assert q.get(row.request_id).status == "in_progress"
+    assert q.reset_stale_in_progress(older_than_seconds=3600) == 0
+    future = datetime.now(timezone.utc) + timedelta(hours=2)
+    assert q.reset_stale_in_progress(older_than_seconds=3600, now=future) >= 1
+    recovered = q.get(row.request_id)
+    assert recovered.status == "pending"
+    assert recovered.attempts == 1
+    _terminalize(q, conn, row)
+
+
+def assert_terminal_states_never_reopened(make_queue: MakeQueue) -> None:
+    """INV-YSS-3: a late fail/complete from a stale drainer cannot reopen a
+    terminal row, and the no-op emits no event."""
+    q = make_queue()
+    conn = FakeOutboxConn()
+
+    # completed stays completed through a late fail().
+    row = _enqueue(q, conn, _item())
+    q.claim_batch(10, conn=conn)
+    q.complete(row.request_id, content_identity="cid-terminal", conn=conn)
+    failed_before = len(conn.rows_for(ACQUISITION_FAILED_TOPIC))
+    after = q.fail(row.request_id, reason_code="network_error", error="stale drainer", conn=conn)
+    assert after.status == "completed"
+    assert after.content_identity == "cid-terminal"
+    assert len(conn.rows_for(ACQUISITION_FAILED_TOPIC)) == failed_before
+
+    # dead_lettered stays dead_lettered through a late complete().
+    row2 = _enqueue(q, conn, _item())
+    q.claim_batch(10, conn=conn)
+    q.dead_letter(row2.request_id, reason_code="pipeline_dead_letter", error="stage", conn=conn)
+    after2 = q.complete(row2.request_id, content_identity="cid-late", conn=conn)
+    assert after2.status == "dead_lettered"
+    assert q.get(row2.request_id).content_identity is None
+
+
+ALL_CONTRACT_ASSERTIONS = (
+    assert_identity_and_trigger_merge,
+    assert_durable_completed_lifecycle,
+    assert_claim_order_and_backoff_gate,
+    assert_retry_then_exhaustion_dead_letter,
+    assert_explicit_dead_letter,
+    assert_reset_stale_in_progress,
+    assert_terminal_states_never_reopened,
+)

--- a/tests/knowledge_acquisition/test_acquisition_requests.py
+++ b/tests/knowledge_acquisition/test_acquisition_requests.py
@@ -1,0 +1,670 @@
+"""YSS-04 (#3919): durable acquisition request queue — memory backend + drain seam.
+
+The binding contract is `docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md ::
+AcquisitionRequest / Event topics / Retry and backoff` and INV-YSS-1..3 in that
+dir's README. All source egress is stubbed at the plugin level
+(`yt_dlp_extract_info` / `fetch_caption_body` monkeypatched, per
+`test_acquire.py`), the LLM extractor is stubbed via
+`summary_extractor.register(complete=...)`, and the outbox is the in-memory
+`FakeOutboxConn` — no real Postgres for these `not_pg` tests, but
+`DATABASE_URL` must be present for `acquire_youtube`'s DB-required guard
+(presence check only; the fake conn is injected).
+
+No real playlist/channel/account identifiers anywhere (INV-YSS-9).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from app import objects as object_store_module
+from app.knowledge_acquisition import youtube_plugin as plugin
+from app.knowledge_acquisition.acquisition_requests import (
+    ACQUISITION_FAILED_TOPIC,
+    ACQUISITION_REQUESTED_TOPIC,
+    ACQUISITION_STARTED_TOPIC,
+    DEFAULT_MAX_ATTEMPTS,
+    YOUTUBE_SOURCE_DISCOVERED_TOPIC,
+    AcquisitionRequests,
+    DiscoveryTrigger,
+    attempt_event_key,
+    compute_backoff_seconds,
+    drain_one,
+    request_identity,
+    reset_memory_acquisition_requests,
+)
+from app.knowledge_acquisition.extraction_registry import clear_registry
+from app.knowledge_acquisition.extractors import summary_extractor
+from app.services.outbox import write_outbox_event
+from app.events.models import new_event
+from app.vault.manager import VaultContext
+from app.write_guard import WriteGuard
+from tests.knowledge_acquisition._acquisition_requests_contract import FakeOutboxConn
+
+pytestmark = pytest.mark.not_pg
+
+FAKE_URL = "https://www.youtube.com/watch?v=abcdefghijk"
+VIDEO_ID = "abcdefghijk"
+
+# Synthetic binding ids only (INV-YSS-9).
+BINDING_INBOX = str(uuid.uuid4())
+BINDING_OWNED = str(uuid.uuid4())
+
+
+# --- Harness (fetch/extractor stubs mirror test_acquire.py; the outbox fake is
+# the ONE shared emulation in _acquisition_requests_contract so the memory and
+# pg suites always test identical outbox semantics) ---------------------------
+
+
+def _stub_completion(raw: str):
+    def complete(*, system: str, user: str, trace_id=None, max_tokens=None) -> str:
+        return raw
+
+    return complete
+
+
+_VALID_SUMMARY = json.dumps({"summary": "A deterministic test summary.", "confidence": 0.75})
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    clear_registry()
+    summary_extractor.register(complete=_stub_completion(_VALID_SUMMARY))
+    yield
+    clear_registry()
+    summary_extractor.register()
+
+
+@pytest.fixture(autouse=True)
+def _memory_store(monkeypatch):
+    from app.stores import reset_store_backends
+
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    reset_store_backends()
+    object_store_module._MEMORY_STORE.clear()
+    reset_memory_acquisition_requests()
+    yield
+    reset_store_backends()
+    object_store_module._MEMORY_STORE.clear()
+    reset_memory_acquisition_requests()
+
+
+@pytest.fixture(autouse=True)
+def _configured_db_env(monkeypatch):
+    """acquire_youtube's DB-required guard checks env presence only (conn is injected)."""
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test:test@localhost:5432/app_test")
+    yield
+
+
+def _base_info(**overrides):
+    info = {
+        "id": VIDEO_ID,
+        "title": "A Test Video",
+        "channel": "Test Channel",
+        "channel_id": "UC123",
+        "upload_date": "20260101",
+        "duration": 600,
+        "description": "desc",
+        "chapters": [],
+        "tags": ["a", "b"],
+        "language": "en",
+        "thumbnail": "https://example.com/thumb.jpg",
+        "subtitles": {"en": [{"ext": "vtt", "url": "https://example.com/manual.vtt"}]},
+        "automatic_captions": {},
+    }
+    info.update(overrides)
+    return info
+
+
+_CAPTION_BODY = (
+    "WEBVTT\n\n"
+    "00:00:00.000 --> 00:00:02.000\n"
+    "Hello world\n\n"
+    "00:00:02.000 --> 00:00:04.000\n"
+    "This is a transcript about testing.\n"
+)
+
+
+def _stub_caption_fetch(monkeypatch, *, info: dict[str, Any] | None = None, body: str = _CAPTION_BODY):
+    monkeypatch.setattr(plugin, "yt_dlp_extract_info", lambda url: info or _base_info())
+    monkeypatch.setattr(plugin, "fetch_caption_body", lambda url: body)
+
+
+def _vault(root: Path) -> VaultContext:
+    root.mkdir(parents=True, exist_ok=True)
+    return VaultContext(
+        status="selected",
+        active_vault_id="vault-test",
+        active_vault_name="Vault Test",
+        active_vault_path=str(root),
+    )
+
+
+def _allowing_guard() -> WriteGuard:
+    return WriteGuard(lambda: {"state": "healthy"})
+
+
+def _denying_guard() -> WriteGuard:
+    return WriteGuard(lambda: {"state": "safe_mode", "reason": "runtime degraded (test)"})
+
+
+def _trigger(binding_id: str, kind: str = "owned_playlist", **overrides) -> DiscoveryTrigger:
+    defaults = dict(
+        binding_id=binding_id,
+        collection_kind=kind,
+        collection_ref="PL__test__synthetic",
+        trigger="poll",
+        playlist_item_id=None,
+    )
+    defaults.update(overrides)
+    return DiscoveryTrigger(**defaults)
+
+
+def _queue() -> AcquisitionRequests:
+    return AcquisitionRequests.for_runtime()
+
+
+def _enqueue(q: AcquisitionRequests, conn: FakeOutboxConn, *, binding=BINDING_INBOX, kind="inbox_playlist", priority="normal", item=VIDEO_ID, **kw):
+    return q.enqueue(
+        source_kind="youtube_url",
+        item_ref=item,
+        source_ref=f"https://www.youtube.com/watch?v={item}",
+        trigger=_trigger(binding, kind),
+        priority=priority,
+        conn=conn,
+        **kw,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC1
+# ---------------------------------------------------------------------------
+
+
+def test_same_video_two_sources_single_request_merged_provenance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_caption_fetch(monkeypatch)
+    conn = FakeOutboxConn()
+    q = _queue()
+
+    r1 = _enqueue(q, conn, binding=BINDING_INBOX, kind="inbox_playlist", priority="high")
+    r2 = _enqueue(q, conn, binding=BINDING_OWNED, kind="owned_playlist")
+
+    # One request, deterministic identity, both triggers preserved (INV-YSS-2).
+    assert r1.request_id == r2.request_id == request_identity("youtube_url", VIDEO_ID, 1)
+    assert len(r2.discovery_triggers) == 2
+    assert {t["binding_id"] for t in r2.discovery_triggers} == {BINDING_INBOX, BINDING_OWNED}
+
+    # Exactly one acquisition.requested; one discovered event per source binding.
+    assert len(conn.rows_for(ACQUISITION_REQUESTED_TOPIC)) == 1
+    discovered = conn.payloads_for(YOUTUBE_SOURCE_DISCOVERED_TOPIC)
+    assert {d["binding_id"] for d in discovered} == {BINDING_INBOX, BINDING_OWNED}
+
+    # End-to-end through the (stubbed-egress) production pipeline: one candidate.
+    vault = _vault(tmp_path / "vault")
+    claimed = q.claim_batch(1, conn=conn)
+    assert [c.request_id for c in claimed] == [r1.request_id]
+    result = drain_one(claimed[0], vault_context=vault, queue=q, write_guard=_allowing_guard(), conn=conn)
+    assert result.status == "completed"
+    assert result.content_identity
+    assert result.artifact_path
+    notes = list((tmp_path / "vault").rglob("*.md"))
+    assert len(notes) == 1
+
+    # Converged: nothing left to claim.
+    assert q.claim_batch(5, conn=conn) == []
+
+
+# ---------------------------------------------------------------------------
+# AC2
+# ---------------------------------------------------------------------------
+
+
+def test_request_durable_before_drain_and_restart_converges(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = FakeOutboxConn()
+    q = _queue()
+    row = _enqueue(q, conn)
+    assert row.status == "pending"
+    assert row.completed_at is None
+
+    # Simulated restart: a fresh service instance sees the same durable row.
+    q2 = AcquisitionRequests.for_runtime()
+    reloaded = q2.get(row.request_id)
+    assert reloaded is not None
+    assert reloaded.status == "pending"
+    assert reloaded.request_id == row.request_id
+
+    # Crash between enqueue and drain: re-discovery converges to the same row.
+    again = _enqueue(q2, conn)
+    assert again.request_id == row.request_id
+    assert len(conn.rows_for(ACQUISITION_REQUESTED_TOPIC)) == 1
+
+    # Drain through an injected acquire seam: pipeline runs exactly once.
+    calls = {"n": 0}
+
+    def fake_acquire(url, **kwargs):
+        calls["n"] += 1
+        from app.knowledge_acquisition.acquire import AcquireStageReceipt, AcquisitionReceipt
+
+        return AcquisitionReceipt(
+            source_kind="youtube_url",
+            item_ref=VIDEO_ID,
+            raw_record_id="raw-1",
+            content_identity="cid-1",
+            is_new_raw=True,
+            acquisition_method="captions_manual",
+            stages=(AcquireStageReceipt(stage="candidate", status="written", artifact_path="inbox/x.md"),),
+        )
+
+    claimed = q2.claim_batch(1, conn=conn)
+    result = drain_one(claimed[0], vault_context=None, queue=q2, conn=conn, acquire_fn=fake_acquire)
+    assert result.status == "completed"
+    assert result.content_identity == "cid-1"
+    assert calls["n"] == 1
+
+    # Late duplicate discovery after completion: trigger append only, no reopen,
+    # no second pipeline effect.
+    late = _enqueue(q2, conn, binding=BINDING_OWNED, kind="owned_playlist")
+    assert late.status == "completed"
+    assert q2.claim_batch(5, conn=conn) == []
+    assert calls["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# AC3
+# ---------------------------------------------------------------------------
+
+
+def test_writeguard_block_reported_and_retryable_at_call_site(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_caption_fetch(monkeypatch)
+    conn = FakeOutboxConn()
+    q = _queue()
+    vault = _vault(tmp_path / "vault")
+    row = _enqueue(q, conn)
+
+    # Production call site: drain_one -> acquire_youtube (real), WriteGuard denies.
+    claimed = q.claim_batch(1, conn=conn)
+    blocked = drain_one(claimed[0], vault_context=vault, queue=q, write_guard=_denying_guard(), conn=conn)
+
+    assert blocked.status == "pending"  # retryable, never completed/dead-lettered
+    assert blocked.last_failure is not None
+    assert blocked.last_failure["reason_code"] == "writeguard_blocked"
+    assert blocked.next_attempt_at is not None
+    failed = conn.payloads_for(ACQUISITION_FAILED_TOPIC)
+    assert len(failed) == 1
+    assert failed[0]["terminal"] is False
+    assert failed[0]["reason_code"] == "writeguard_blocked"
+    assert list((tmp_path / "vault").rglob("*.md")) == []
+
+    # A later drain (past the backoff gate) completes it.
+    future = datetime.now(timezone.utc) + timedelta(hours=7)
+    reclaimed = q.claim_batch(1, now=future, conn=conn)
+    assert [r.request_id for r in reclaimed] == [row.request_id]
+    done = drain_one(reclaimed[0], vault_context=vault, queue=q, write_guard=_allowing_guard(), conn=conn)
+    assert done.status == "completed"
+    assert len(list((tmp_path / "vault").rglob("*.md"))) == 1
+
+
+# ---------------------------------------------------------------------------
+# AC4
+# ---------------------------------------------------------------------------
+
+
+def test_dead_letter_item_scoped_and_attempts_exhaustion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = FakeOutboxConn()
+    q = _queue()
+    vault = _vault(tmp_path / "vault")
+
+    # Item A: extractor dead-letters (invalid completion) -> pipeline_dead_letter,
+    # terminal and item-scoped.
+    _stub_caption_fetch(monkeypatch)
+    clear_registry()
+    summary_extractor.register(complete=_stub_completion("not json at all"))
+    row_a = _enqueue(q, conn, item=VIDEO_ID)
+    claimed = q.claim_batch(1, conn=conn)
+    dead = drain_one(claimed[0], vault_context=vault, queue=q, write_guard=_allowing_guard(), conn=conn)
+    assert dead.status == "dead_lettered"
+    assert dead.last_failure["reason_code"] == "pipeline_dead_letter"
+    failed_events = conn.payloads_for(ACQUISITION_FAILED_TOPIC)
+    assert len(failed_events) == 1
+    assert failed_events[0]["terminal"] is True
+
+    # Sibling item B is unaffected and completes once the extractor is healthy.
+    info_b = _base_info(id="lmnopqrstuv")
+    monkeypatch.setattr(plugin, "yt_dlp_extract_info", lambda url: info_b)
+    clear_registry()
+    summary_extractor.register(complete=_stub_completion(_VALID_SUMMARY))
+    row_b = _enqueue(q, conn, item="lmnopqrstuv", binding=BINDING_OWNED, kind="owned_playlist")
+    assert q.get(row_b.request_id).status == "pending"
+    claimed_b = q.claim_batch(1, conn=conn)
+    assert [c.request_id for c in claimed_b] == [row_b.request_id]
+    done_b = drain_one(claimed_b[0], vault_context=vault, queue=q, write_guard=_allowing_guard(), conn=conn)
+    assert done_b.status == "completed"
+    # A's terminal state never changed.
+    assert q.get(row_a.request_id).status == "dead_lettered"
+
+    # Item C: attempts exhaustion dead-letters with terminal: true.
+    row_c = _enqueue(q, conn, item="zzzzzzzzzzz", binding=str(uuid.uuid4()), kind="public_playlist")
+    far_future = datetime.now(timezone.utc) + timedelta(days=365)
+    for _attempt in range(DEFAULT_MAX_ATTEMPTS):
+        claimed_c = q.claim_batch(1, now=far_future, conn=conn)
+        assert [c.request_id for c in claimed_c] == [row_c.request_id]
+        q.fail(row_c.request_id, reason_code="network_error", error="boom", conn=conn)
+    final_c = q.get(row_c.request_id)
+    assert final_c.status == "dead_lettered"
+    assert final_c.attempts == DEFAULT_MAX_ATTEMPTS
+    c_failed = [
+        p for p in conn.payloads_for(ACQUISITION_FAILED_TOPIC) if p["request_id"] == row_c.request_id
+    ]
+    assert len(c_failed) == DEFAULT_MAX_ATTEMPTS
+    assert [p["terminal"] for p in c_failed].count(True) == 1
+    assert c_failed[-1]["terminal"] is True
+
+
+# ---------------------------------------------------------------------------
+# AC5
+# ---------------------------------------------------------------------------
+
+
+def test_backoff_gate_and_priority_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = FakeOutboxConn()
+    q = _queue()
+    now = datetime.now(timezone.utc)
+
+    # Backoff floor per contract: base 60 s, factor 4, cap 6 h.
+    assert compute_backoff_seconds(1, rng=lambda: 0.0) == 60
+    assert compute_backoff_seconds(2, rng=lambda: 0.0) == 240
+    assert compute_backoff_seconds(3, rng=lambda: 0.0) == 960
+    assert compute_backoff_seconds(6, rng=lambda: 0.0) == 21600
+    assert compute_backoff_seconds(7, rng=lambda: 0.0) == 21600
+    # Jitter never fires the gate EARLIER than the deterministic floor.
+    for attempt in (1, 2, 5):
+        assert compute_backoff_seconds(attempt) >= compute_backoff_seconds(attempt, rng=lambda: 0.0)
+
+    row = _enqueue(q, conn, item="aaaaaaaaaaa", priority="normal")
+    q.claim_batch(1, now=now, conn=conn)
+    q.fail(row.request_id, reason_code="network_error", error="transient", now=now, conn=conn)
+
+    gated = q.get(row.request_id)
+    assert gated.status == "pending"
+    gate = datetime.fromisoformat(gated.next_attempt_at)
+    assert gate >= now + timedelta(seconds=60)
+
+    # claim_batch respects the gate.
+    assert q.claim_batch(5, now=now + timedelta(seconds=30), conn=conn) == []
+    assert [r.request_id for r in q.claim_batch(5, now=gate + timedelta(seconds=1), conn=conn)] == [
+        row.request_id
+    ]
+    q.fail(row.request_id, reason_code="network_error", error="still down", now=now, conn=conn)
+
+    # Priority order: high (inbox-discovered) before normal, then requested_at.
+    older_normal = _enqueue(q, conn, item="bbbbbbbbbbb", priority="normal", binding=str(uuid.uuid4()))
+    high = _enqueue(q, conn, item="ccccccccccc", priority="high", binding=str(uuid.uuid4()), kind="inbox_playlist")
+    newer_normal = _enqueue(q, conn, item="ddddddddddd", priority="normal", binding=str(uuid.uuid4()))
+
+    order = [r.request_id for r in q.claim_batch(3, now=now, conn=conn)]
+    assert order == [high.request_id, older_normal.request_id, newer_normal.request_id]
+
+
+# ---------------------------------------------------------------------------
+# AC6
+# ---------------------------------------------------------------------------
+
+
+def test_event_idempotency_keys_per_attempt(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = FakeOutboxConn()
+    q = _queue()
+    row = _enqueue(q, conn)
+
+    # Duplicate discovery: acquisition.requested dedups to one row.
+    _enqueue(q, conn)
+    assert len(conn.rows_for(ACQUISITION_REQUESTED_TOPIC)) == 1
+
+    # Attempt 1 started event.
+    q.claim_batch(1, conn=conn)
+    started = conn.rows_for(ACQUISITION_STARTED_TOPIC)
+    assert len(started) == 1
+
+    # Re-emission of the SAME attempt (crash-retry duplicate delivery) dedups.
+    dup = new_event(
+        event_type=ACQUISITION_STARTED_TOPIC,
+        payload={"request_id": row.request_id, "attempt": 1},
+        source="knowledge_acquisition.source_sync",
+    )
+    write_outbox_event(dup, conn=conn, idempotency_key=attempt_event_key(ACQUISITION_STARTED_TOPIC, row.request_id, 1))
+    assert len(conn.rows_for(ACQUISITION_STARTED_TOPIC)) == 1
+
+    # A NEW attempt is a distinct event.
+    now = datetime.now(timezone.utc)
+    q.fail(row.request_id, reason_code="network_error", error="t1", now=now, conn=conn)
+    q.claim_batch(1, now=now + timedelta(hours=7), conn=conn)
+    started_after = conn.rows_for(ACQUISITION_STARTED_TOPIC)
+    assert len(started_after) == 2
+    attempts_seen = {p["attempt"] for p in conn.payloads_for(ACQUISITION_STARTED_TOPIC)}
+    assert attempts_seen == {1, 2}
+
+    # failed events are attempt-scoped too.
+    q.fail(row.request_id, reason_code="network_error", error="t2", now=now, conn=conn)
+    failed_payloads = [
+        p for p in conn.payloads_for(ACQUISITION_FAILED_TOPIC) if p["request_id"] == row.request_id
+    ]
+    assert {p["attempt"] for p in failed_payloads} == {1, 2}
+
+
+# ---------------------------------------------------------------------------
+# Supporting unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_request_identity_deterministic_and_policy_version_sensitive() -> None:
+    a = request_identity("youtube_url", VIDEO_ID, 1)
+    b = request_identity("youtube_url", VIDEO_ID, 1)
+    c = request_identity("youtube_url", VIDEO_ID, 2)
+    assert a == b != c
+    assert uuid.UUID(a).version == 5
+
+
+def test_enqueue_validates_inputs() -> None:
+    conn = FakeOutboxConn()
+    q = _queue()
+    with pytest.raises(ValueError):
+        q.enqueue(source_kind="", item_ref=VIDEO_ID, source_ref="x", trigger=_trigger(BINDING_INBOX), conn=conn)
+    with pytest.raises(ValueError):
+        q.enqueue(source_kind="youtube_url", item_ref=" ", source_ref="x", trigger=_trigger(BINDING_INBOX), conn=conn)
+    with pytest.raises(ValueError):
+        _enqueue(q, conn, priority="urgent")
+    with pytest.raises(ValueError):
+        q.enqueue(
+            source_kind="youtube_url",
+            item_ref=VIDEO_ID,
+            source_ref="x",
+            trigger=_trigger(BINDING_INBOX, trigger="webhook"),
+            conn=conn,
+        )
+
+
+def test_reset_stale_in_progress_recovers_without_attempt_increment() -> None:
+    conn = FakeOutboxConn()
+    q = _queue()
+    row = _enqueue(q, conn)
+    q.claim_batch(1, conn=conn)
+    assert q.get(row.request_id).status == "in_progress"
+    assert q.get(row.request_id).attempts == 1
+
+    # Not yet stale: nothing resets.
+    assert q.reset_stale_in_progress(older_than_seconds=3600) == 0
+    assert q.get(row.request_id).status == "in_progress"
+
+    # Past the threshold (clock injected): reset to pending, attempts untouched.
+    future = datetime.now(timezone.utc) + timedelta(hours=2)
+    assert q.reset_stale_in_progress(older_than_seconds=3600, now=future) == 1
+    recovered = q.get(row.request_id)
+    assert recovered.status == "pending"
+    assert recovered.attempts == 1
+
+
+def test_memory_backend_passes_shared_contract() -> None:
+    """AC7 counterpart: the SAME contract suite the pg test runs, on memory."""
+    from tests.knowledge_acquisition._acquisition_requests_contract import ALL_CONTRACT_ASSERTIONS
+
+    for assertion in ALL_CONTRACT_ASSERTIONS:
+        assertion(_queue)
+
+
+def test_explicit_dead_letter_is_terminal() -> None:
+    conn = FakeOutboxConn()
+    q = _queue()
+    row = _enqueue(q, conn)
+    q.claim_batch(1, conn=conn)
+    q.dead_letter(row.request_id, reason_code="pipeline_dead_letter", error="stage dead-letter", conn=conn)
+    final = q.get(row.request_id)
+    assert final.status == "dead_lettered"
+    assert final.last_failure["reason_code"] == "pipeline_dead_letter"
+    failed = conn.payloads_for(ACQUISITION_FAILED_TOPIC)
+    assert failed[-1]["terminal"] is True
+
+
+# --- Review-gate regressions -------------------------------------------------
+
+
+def test_terminal_request_not_reopened_by_stale_drainer_fail() -> None:
+    """INV-YSS-3: the stale-reset race (drainer A hangs past the threshold,
+    drainer B completes the row, A's late fail lands) must not reopen the
+    completed request nor emit a failure event."""
+    from app.knowledge_acquisition.acquisition_requests import ACQUISITION_STARTED_TOPIC as _started
+
+    conn = FakeOutboxConn()
+    q = _queue()
+    row = _enqueue(q, conn)
+    q.claim_batch(1, conn=conn)  # drainer A claims
+    future = datetime.now(timezone.utc) + timedelta(hours=1)
+    assert q.reset_stale_in_progress(older_than_seconds=900, now=future) == 1
+    q.claim_batch(1, now=future, conn=conn)  # drainer B claims (attempt 2)
+    q.complete(row.request_id, content_identity="cid-b", conn=conn)
+
+    failed_before = len(conn.rows_for(ACQUISITION_FAILED_TOPIC))
+    late = q.fail(row.request_id, reason_code="network_error", error="drainer A woke up", conn=conn)
+    assert late.status == "completed"
+    assert late.content_identity == "cid-b"
+    assert len(conn.rows_for(ACQUISITION_FAILED_TOPIC)) == failed_before
+    # Both attempts left their started lineage; the completion is attempt 2's.
+    assert {p["attempt"] for p in conn.payloads_for(_started)} == {1, 2}
+
+
+def test_dead_letter_after_retryable_fail_same_attempt_keeps_terminal_event() -> None:
+    """The terminal acquisition.failed of attempt N must not be key-swallowed by
+    the earlier retryable failure of the same attempt."""
+    conn = FakeOutboxConn()
+    q = _queue()
+    row = _enqueue(q, conn)
+    q.claim_batch(1, conn=conn)
+    q.fail(row.request_id, reason_code="network_error", error="transient", conn=conn)
+    # Stage dead-letter surfaces before any new claim: explicit terminal outcome.
+    q.dead_letter(row.request_id, reason_code="pipeline_dead_letter", error="stage", conn=conn)
+    failed = conn.payloads_for(ACQUISITION_FAILED_TOPIC)
+    assert len(failed) == 2
+    assert [p["terminal"] for p in failed] == [False, True]
+    assert q.get(row.request_id).status == "dead_lettered"
+
+
+def test_transitions_on_unclaimed_row_are_loud() -> None:
+    from app.knowledge_acquisition.acquisition_requests import AcquisitionRequestValidationError
+
+    conn = FakeOutboxConn()
+    q = _queue()
+    row = _enqueue(q, conn)  # pending, never claimed
+    with pytest.raises(AcquisitionRequestValidationError):
+        q.complete(row.request_id, content_identity="cid-x", conn=conn)
+    with pytest.raises(AcquisitionRequestValidationError):
+        q.fail(row.request_id, reason_code="network_error", conn=conn)
+    assert q.get(row.request_id).status == "pending"
+    assert conn.payloads_for(ACQUISITION_FAILED_TOPIC) == []
+
+
+def test_naive_injected_clock_is_treated_as_utc() -> None:
+    conn = FakeOutboxConn()
+    q = _queue()
+    row = _enqueue(q, conn)
+    q.claim_batch(1, conn=conn)
+    q.fail(row.request_id, reason_code="network_error", error="t", conn=conn)
+    naive_future = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(hours=7)
+    claimed = q.claim_batch(1, now=naive_future, conn=conn)  # must not TypeError
+    assert [c.request_id for c in claimed] == [row.request_id]
+
+
+def test_trigger_append_does_not_touch_updated_at() -> None:
+    """Contract: a duplicate discovery 'appends the new discovery trigger ...
+    and touches nothing else' — updated_at is the stale-recovery clock and a
+    re-discovery must never defer a crashed attempt's reset."""
+    conn = FakeOutboxConn()
+    q = _queue()
+    row = _enqueue(q, conn)
+    q.claim_batch(1, conn=conn)  # in_progress; drainer then "crashes"
+    stamp_before = q.get(row.request_id).updated_at
+    _enqueue(q, conn, binding=str(uuid.uuid4()), kind="owned_playlist")  # novel trigger
+    refreshed = q.get(row.request_id)
+    assert len(refreshed.discovery_triggers) == 2
+    assert refreshed.updated_at == stamp_before
+    future = datetime.now(timezone.utc) + timedelta(hours=1)
+    assert q.reset_stale_in_progress(older_than_seconds=900, now=future) == 1
+
+
+def test_trigger_novelty_is_arrival_order_independent() -> None:
+    conn = FakeOutboxConn()
+    q = _queue()
+    binding = str(uuid.uuid4())
+    bare = _trigger(binding, "owned_playlist")
+    with_item = _trigger(binding, "owned_playlist", playlist_item_id="pli-1")
+    r1 = q.enqueue(
+        source_kind="youtube_url", item_ref=VIDEO_ID,
+        source_ref=f"https://www.youtube.com/watch?v={VIDEO_ID}", trigger=with_item, conn=conn,
+    )
+    r2 = q.enqueue(
+        source_kind="youtube_url", item_ref=VIDEO_ID,
+        source_ref=f"https://www.youtube.com/watch?v={VIDEO_ID}", trigger=bare, conn=conn,
+    )
+    assert r1.request_id == r2.request_id
+    # Both provenance entries survive regardless of which arrived first.
+    assert len(r2.discovery_triggers) == 2
+
+
+def test_youtube_source_kind_matches_plugin_constant() -> None:
+    from app.knowledge_acquisition.acquisition_requests import YOUTUBE_SOURCE_KIND
+
+    assert YOUTUBE_SOURCE_KIND == plugin.SOURCE_KIND
+
+
+def test_enqueue_rejects_string_extractor_ids() -> None:
+    from app.knowledge_acquisition.acquisition_requests import AcquisitionRequestValidationError
+
+    conn = FakeOutboxConn()
+    q = _queue()
+    with pytest.raises(AcquisitionRequestValidationError):
+        _enqueue(q, conn, policy_snapshot={"policy_version": 1, "extractor_ids": "summary"})
+
+
+def test_drain_one_dead_letters_unknown_source_kind() -> None:
+    conn = FakeOutboxConn()
+    q = _queue()
+    row = q.enqueue(
+        source_kind="podcast_rss",
+        item_ref="ep-001",
+        source_ref="https://example.com/feed/ep-001",
+        trigger=_trigger(str(uuid.uuid4())),
+        conn=conn,
+    )
+    q.claim_batch(1, conn=conn)
+    result = drain_one(q.get(row.request_id), vault_context=None, queue=q, conn=conn)
+    assert result.status == "dead_lettered"
+    assert result.last_failure["reason_code"] == "source_unsupported"

--- a/tests/knowledge_acquisition/test_acquisition_requests_pg.py
+++ b/tests/knowledge_acquisition/test_acquisition_requests_pg.py
@@ -1,0 +1,96 @@
+"""YSS-04 (#3919): acquisition queue service contract, Postgres backend.
+
+Exercises the SAME service-layer contract suite as the memory backend
+(`_acquisition_requests_contract.py`, driven for memory by
+`test_acquisition_requests.py`) against the real Postgres-backed
+`AcquisitionRequests`, proving the queue semantics hold identically on both
+backends (AC7) and that the forward-only migration `b5c6d7e8f9a0` creates the
+schema the store's fail-loud preflight expects.
+
+Marked `pg`: excluded by the default `-m "not pg"` suite. Mirrors
+`test_source_registry_pg.py` / `test_youtube_account_binding_pg.py` — an
+isolated database, upgraded through Alembic with schema autocreate disabled
+(the migration, not the store bootstrap, owns the schema), then the shared
+contract, then the forward-only downgrade assertion.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+
+import psycopg
+import pytest
+from alembic import command
+from alembic.config import Config
+from psycopg.conninfo import conninfo_to_dict, make_conninfo
+from sqlalchemy.engine import URL
+
+from app.knowledge_acquisition.acquisition_requests import AcquisitionRequests
+from tests.knowledge_acquisition._acquisition_requests_contract import ALL_CONTRACT_ASSERTIONS
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PRE_YSS04_HEAD = "a2f1c3e4d5b6"
+YSS04_HEAD = "b5c6d7e8f9a0"
+
+
+def _alembic_config() -> Config:
+    config = Config(str(REPO_ROOT / "alembic.ini"))
+    config.set_main_option("script_location", str(REPO_ROOT / "app" / "alembic"))
+    return config
+
+
+@pytest.fixture
+def migrated_queue_database(monkeypatch: pytest.MonkeyPatch) -> Iterator[Config]:
+    """Yield an Alembic-migrated isolated database and drop it afterwards."""
+    from app.db.dsn import resolve_dsn
+
+    admin_dsn = resolve_dsn()
+    if not admin_dsn:
+        pytest.skip("DATABASE_URL/DB_DSN not configured")
+    try:
+        with psycopg.connect(admin_dsn, connect_timeout=2):
+            pass
+    except Exception as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"Postgres unavailable: {exc}")
+
+    database_name = f"scratch_yss04_queue_{uuid.uuid4().hex[:12]}"
+    scratch_params = conninfo_to_dict(admin_dsn)
+    scratch_params["dbname"] = database_name
+    scratch_conninfo = make_conninfo(**scratch_params)
+    scratch_url = URL.create(
+        "postgresql",
+        username=scratch_params.get("user"),
+        password=scratch_params.get("password"),
+        host=scratch_params.get("host"),
+        port=int(scratch_params["port"]) if scratch_params.get("port") else None,
+        database=database_name,
+    ).render_as_string(hide_password=False)
+
+    with psycopg.connect(admin_dsn, autocommit=True) as conn:
+        conn.execute(f'CREATE DATABASE "{database_name}"')
+    try:
+        with psycopg.connect(scratch_conninfo, autocommit=True) as conn:
+            conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
+
+        monkeypatch.setenv("DATABASE_URL", scratch_url)
+        monkeypatch.delenv("DB_DSN", raising=False)
+        monkeypatch.delenv("STORE_SCHEMA_AUTOCREATE", raising=False)
+        monkeypatch.delenv("STORE_BACKEND", raising=False)
+        config = _alembic_config()
+        command.upgrade(config, YSS04_HEAD)
+        yield config
+    finally:
+        with psycopg.connect(admin_dsn, autocommit=True) as conn:
+            conn.execute(f'DROP DATABASE IF EXISTS "{database_name}" WITH (FORCE)')
+
+
+@pytest.mark.pg
+def test_pg_backend_contract(migrated_queue_database: Config) -> None:
+    for assertion in ALL_CONTRACT_ASSERTIONS:
+        assertion(lambda: AcquisitionRequests.for_runtime())
+
+    # The migration is forward-only (reversibility marker; downgrade raises).
+    with pytest.raises(RuntimeError, match="forward-only"):
+        command.downgrade(migrated_queue_database, PRE_YSS04_HEAD)


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

Governing-Issue: #3919

## Linked Issue
Fixes #3919

## SBS Impact
- Primary subsystem: PDM
- Secondary subsystem(s): EBF, OEF
- Write class: mechanical durable (machine-side code/tests; no authority-bearing writes)
- Authority impact: none (candidates stay review-required; INV-YSS-8)
- Persistence impact: new rebuildable-class table `acquisition_requests` via forward-only Alembic migration + memory backend for `not_pg` tests
- Derived/rebuildable impact: all sync state rebuildable from source + queue (re-discovery converges through request idempotency)
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: none (no new services; channel isolation per INV-YSS-7)
- External boundary impact: none directly (the drain calls the existing `acquire_youtube` entrypoint; tests stub egress at the plugin layer)
- New or changed contract: implements `docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md` (no contract change)
- Owner-doc impact: none
- Transition debt impact: no effect
- Fitness rule impact: strengthens (AC3 asserts the production `drain_one` → `acquire_youtube` call site; identity triple also DB-enforced)
- Boundary risk: idempotency/provenance-merge correctness; INV-YSS-2/3 seams

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Lands the durable, source-agnostic **acquisition request queue** (`app/knowledge_acquisition/acquisition_requests.py`): deterministic `uuid5` request identity (one request per `(source_kind, item_ref, policy_version)`, INV-YSS-2), idempotent enqueue with **append-only multi-trigger provenance**, `claim_batch`/`complete`/`fail`/`dead_letter` lifecycle with contract backoff (base 60 s, factor 4, cap 6 h, non-negative jitter), stale-`in_progress` restart recovery, and dual memory/pg backends behind the repo's fail-loud store discipline + forward-only migration `b5c6d7e8f9a0`.
- Adds the **drain seam** `drain_one` mapping `AcquisitionReceipt` per INV-YSS-3: `ok` → `completed` (+`content_identity`/`artifact_path`/`dedup_noop`), WriteGuard `blocked` → retryable `writeguard_blocked`, stage dead-letter → terminal item-scoped `pipeline_dead_letter`, raised `AcquisitionError` → retryable. The scheduler slice (YSS-06) owns *when* this runs.
- Registers the **five KERNEL-08 event schemas** (`acquisition.requested/started/completed/failed`, `youtube.source.discovered`) + constants in `app/events/types.py`; emissions ride the canonical DB outbox with contract idempotency keys (attempt-scoped for started/completed/failed; `(binding_id, item_ref)`-scoped for discovered; first-insert-only for requested). Lineage posture — no `_dispatch_topic` branch.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed. (No contract/behavior doc change — implements the existing SOURCE_SYNC_CONTRACT.)
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality. (Owner-doc impact: none per the Issue; capability status lives on parent #3915.)

## Validation
Implementation lane:
- [x] `ruff check app tests` → **All checks passed!**
- [x] Lint output included above; new/changed files pass individually.
- [x] `mypy app/knowledge_acquisition/acquisition_requests.py` → **0 errors in the new module** (full `mypy app` deferred to CI; the local workspace venv lacks type stubs for some unrelated modules — known environment limitation).
- [x] `pytest -q -m "not pg"` — directly affected packages green locally: `tests/knowledge_acquisition/ + tests/guard/test_no_direct_db_imports.py + tests/events/` → **165 passed, 3 pg-deselected**, including all six behavioral AC tests, the shared-contract memory parity run, and nine review-gate regression tests; full-repo `-m "not pg"` run in CI is authoritative (local venv has known stale collections in unrelated subsystems).
- [x] Additional targeted checks: `tests/knowledge_acquisition/test_acquisition_requests_pg.py::test_pg_backend_contract` (marked `pg`) runs the **real forward-only migration** `b5c6d7e8f9a0` on an isolated database, drives the SAME shared behavioral contract as the memory backend, and asserts the downgrade raises — exercised by the CI `pg` job. `alembic heads` → single head `b5c6d7e8f9a0`.

Every Acceptance Criterion's `Verify:` test is present and passing:
`test_same_video_two_sources_single_request_merged_provenance`, `test_request_durable_before_drain_and_restart_converges`, `test_writeguard_block_reported_and_retryable_at_call_site`, `test_dead_letter_item_scoped_and_attempts_exhaustion`, `test_backoff_gate_and_priority_order`, `test_event_idempotency_keys_per_attempt`, `test_pg_backend_contract` (pg).

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded single-slice implementation delivered directly from the governing Issue #3919; no plan divergence, docs-freshness, roadmap-movement, or promotion material to route.

## Notes
- **Pickup coordination:** github-label-only fallback per operator direction; the local dispatcher singleton remains stale (holder `codex-root`, lease expired 2026-07-15) and the issue task is not synced into the local queue. Claim receipt: issue comment `5012840052`.
- **Design notes within contract latitude:** (1) trigger append is identity-novel (`(binding_id, trigger, playlist_item_id)`) so same-source crash-replay converges without unbounded `discovery_triggers` growth — N distinct bindings still yield N triggers (INV-YSS-2 upheld); (2) `youtube.source.discovered` is emitted only for `source_kind="youtube_url"` (the queue is source-agnostic; the topic is not); (3) raised `AcquisitionError` in `drain_one` is classified retryable `network_error` (the transient fetch/ASR chain dominates that path; deterministic pipeline failures still surface their durable KA stage dead-letter in lineage and converge to `dead_lettered` via attempts exhaustion, default max 8); (4) storage adds an `updated_at` column beyond the contract row shape — required for the stale-`in_progress` threshold; storage may differ where the port requires it, never in meaning.
- **Guard allowlist:** `tests/guard/test_no_direct_db_imports.py` allowlists the new store module (same bounded dedicated-table pattern as `source_registry.py`/`youtube_account_binding.py`).
- **Local review gate (8-angle finder pass + cross-angle verification) ran before publish and its findings are fixed in this PR:** status-guarded transitions so a stale drainer's late `fail()`/`complete()` can never reopen a terminal request (INV-YSS-3; found independently by three angles), terminal-marked `acquisition.failed` keys so an explicit dead-letter after a retryable failure of the same attempt is never key-swallowed, trigger-append no longer touches `updated_at` (contract "touches nothing else"; re-discovery can no longer defer stale-recovery), symmetric trigger-novelty probing (`playlist_item_id` stored/probed explicitly, arrival-order independent), naive-injected-clock normalization (memory/pg parity), `acquisition.requested` emitted unconditionally under its deterministic key (crash between row-insert and emit now self-heals), `extractor_ids` shape validation at enqueue, `drain_one` dead-letters unknown `source_kind` as `source_unsupported` instead of crashing a future drain loop, index-servable claim ordering (`ORDER BY priority ASC` — identical order, plain-index-servable) with honest index comments, plus reuse/simplification cleanups (shared `VALID_PRIORITIES` from the source registry, plugin-tied `YOUTUBE_SOURCE_KIND` constant, one shared outbox fake for both test suites, snapshot `policy_version` normalization, `UPDATE ... RETURNING` single-statement transitions, `deepcopy` row detachment).
- **Documented residuals (deliberate):** a raised `AcquisitionError` maps to retryable `network_error` (the issue contract mandates "raised → retryable"; the transient fetch/ASR chain dominates that path, deterministic pipeline failures still emit durable KA stage dead-letters in lineage and converge via attempts exhaustion — richer reason classification belongs where the failure kind is known, a later slice). Row transitions and their lineage events are not cross-connection atomic (rows are authoritative; same posture as the KA stage events, and the `requested` event now self-heals). The autocreate bootstrap DDL intentionally mirrors the migration DDL (repo store convention; verified column-identical).

---
