### PR TITLE
Tolerate one-second GitHub closure timestamp skew

### DIFF
--- a/app/dispatcher/verification_consumer.py
+++ b/app/dispatcher/verification_consumer.py
@@ -1327,16 +1327,33 @@ class GhCliVerificationSource:
                 )
             except ValueError as exc:
                 raise RuntimeError("malformed GraphQL issue closedAt") from exc
+            closure_timestamp_skew = (
+                abs(closed_instant - latest_instant)
+                if closed_instant is not None
+                and closed_instant.tzinfo is not None
+                and latest_instant is not None
+                and latest_instant.tzinfo is not None
+                else None
+            )
             if state == "CLOSED" and (
                 closed_instant is None
                 or closed_instant.tzinfo is None
-                or closed_instant != latest_instant
+                or closure_timestamp_skew is None
+                or closure_timestamp_skew > timedelta(seconds=1)
             ):
                 raise RuntimeError("GraphQL issue closure timestamp mismatch")
 
             repository_close = repository_closing_issues.get(number)
             if repository_close is not None and latest_instant != repository_close:
                 raise RuntimeError("GraphQL ClosedEvent does not match REST closure")
+            if (
+                state == "CLOSED"
+                and closure_timestamp_skew
+                and repository_close is None
+            ):
+                raise RuntimeError(
+                    "GraphQL closure timestamp skew lacks matching REST closure"
+                )
 
             closer = latest.get("closer") if latest else None
             exact_pr_closer = False

--- a/tests/dispatcher/test_verification_consumer.py
+++ b/tests/dispatcher/test_verification_consumer.py
@@ -1526,6 +1526,75 @@ def _closure_evidence_with_graphql_event(
     )
 
 
+def _closure_evidence_with_timestamp_sources(
+    *,
+    closed_at: str,
+    event_created_at: str,
+    repository_created_at: str,
+    actor: str = "verification-closer",
+    closer_number: int | None = 3603,
+    closer_repository: str = REPO,
+    closer_sha: str | None = "b" * 40,
+    repository_event: str = "closed",
+) -> dict[str, object]:
+    class Result:
+        returncode = 0
+
+        def __init__(self, value: object) -> None:
+            self.stdout = json.dumps(value)
+
+    def runner(command, **_kwargs):
+        if command[:3] == ["gh", "api", "graphql"]:
+            return Result(
+                _graphql_result(
+                    _graphql_issue(
+                        3603,
+                        created_at=closed_at,
+                        event=_graphql_closed_event(
+                            event_created_at,
+                            actor=actor,
+                            closer_number=closer_number,
+                            closer_repository=closer_repository,
+                            closer_sha=closer_sha,
+                        ),
+                    )
+                )
+            )
+        endpoint = command[-1]
+        if endpoint == f"repos/{REPO}/issues/events?per_page=100&page=1":
+            return Result(
+                [
+                    _repository_issue_event(
+                        20,
+                        number=3603,
+                        created_at=repository_created_at,
+                        event=repository_event,
+                    ),
+                    _repository_issue_event(
+                        19,
+                        number=4998,
+                        created_at="2026-07-14T23:59:59Z",
+                        event="labeled",
+                    ),
+                ]
+            )
+        if endpoint == f"repos/{REPO}/issues/3603":
+            return Result(_rest_issue(3603))
+        raise AssertionError(endpoint)
+
+    return dict(
+        GhCliVerificationSource(runner=runner).issue_set_closure_evidence(
+            REPO,
+            3603,
+            issue_numbers=[3603],
+            observed_issue_numbers=[],
+            merged_at="2026-07-15T00:00:00Z",
+            merge_commit_sha="b" * 40,
+            actor_login="verification-closer",
+        )
+    )
+
+
 @pytest.mark.parametrize(
     ("closer_number", "closed_by_pull_requests"),
     [(None, []), (3603, [3603])],
@@ -1551,6 +1620,108 @@ def test_gh_source_accepts_only_explicit_or_exact_target_expected_closure(
             "state": "closed",
         }
     ]
+
+
+def test_gh_source_accepts_one_second_closed_at_event_skew_with_matching_rest_event(
+) -> None:
+    evidence = _closure_evidence_with_timestamp_sources(
+        closed_at="2026-07-15T00:00:02Z",
+        event_created_at="2026-07-15T00:00:03Z",
+        repository_created_at="2026-07-15T00:00:03Z",
+    )
+
+    assert evidence["observed_closing_issues"] == [3603]
+    assert evidence["issue_evidence"] == [
+        {
+            "closed_at": "2026-07-15T00:00:02Z",
+            "closed_by_delivery": True,
+            "closed_by_pull_requests": [3603],
+            "number": 3603,
+            "state": "closed",
+        }
+    ]
+
+
+def test_gh_source_rejects_closed_at_event_skew_over_one_second() -> None:
+    with pytest.raises(
+        RuntimeError, match="GraphQL issue closure timestamp mismatch"
+    ):
+        _closure_evidence_with_timestamp_sources(
+            closed_at="2026-07-15T00:00:01Z",
+            event_created_at="2026-07-15T00:00:03Z",
+            repository_created_at="2026-07-15T00:00:03Z",
+        )
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected_error", "expected_observed"),
+    [
+        (
+            {"repository_created_at": "2026-07-15T00:00:02Z"},
+            "does not match REST closure",
+            None,
+        ),
+        (
+            {"repository_event": "labeled"},
+            "matching REST closure",
+            None,
+        ),
+        (
+            {"closed_at": "2026-07-15T00:00:02"},
+            "closure timestamp mismatch",
+            None,
+        ),
+        (
+            {"actor": "unrelated-closer"},
+            "closer actor mismatch",
+            None,
+        ),
+        (
+            {"closer_repository": "other/repository"},
+            "closer identity mismatch",
+            None,
+        ),
+        (
+            {"closer_sha": "c" * 40},
+            "closer identity mismatch",
+            None,
+        ),
+        (
+            {"closer_number": 4999},
+            None,
+            [],
+        ),
+    ],
+    ids=[
+        "rest-event-race",
+        "missing-rest-event",
+        "naive-closed-at",
+        "actor",
+        "closer-repository",
+        "closer-sha",
+        "foreign-pr",
+    ],
+)
+def test_gh_source_bounded_timestamp_skew_preserves_attribution_fences(
+    overrides: dict[str, object],
+    expected_error: str | None,
+    expected_observed: list[int] | None,
+) -> None:
+    arguments: dict[str, object] = {
+        "closed_at": "2026-07-15T00:00:02Z",
+        "event_created_at": "2026-07-15T00:00:03Z",
+        "repository_created_at": "2026-07-15T00:00:03Z",
+    }
+    arguments.update(overrides)
+
+    if expected_error is not None:
+        with pytest.raises(RuntimeError, match=expected_error):
+            _closure_evidence_with_timestamp_sources(**arguments)
+        return
+
+    evidence = _closure_evidence_with_timestamp_sources(**arguments)
+    assert evidence["observed_closing_issues"] == expected_observed
+    assert evidence["issue_evidence"][0]["closed_by_delivery"] is False
 
 
 def test_foreign_pr_closer_cannot_complete_authenticated_expected_issue(


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

Governing-Issue: #3982

## Linked Issue
Closes #3982

## SBS Impact
- Primary subsystem: Builder System
- Secondary subsystem(s): CES verification consumer and verified issue-set closure
- Write class: governance enforcement code and regression tests
- Authority impact: narrows one timestamp representation check without weakening closure authority
- Persistence impact: none
- Derived/rebuildable impact: none
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: source-only change; no channel mutation or deployment
- External boundary impact: GitHub REST/GraphQL closure timestamps are reconciled with a bounded one-second tolerance backed by exact REST event evidence
- New or changed contract: Issue.closedAt may differ from the latest ClosedEvent.createdAt by at most one second only when the latest repository REST close event exactly matches that ClosedEvent
- Owner-doc impact: none; existing owner docs already require latest-event attribution and fail-closed external evidence
- Transition debt impact: none
- Fitness rule impact: three named regression tests cover the tolerance, over-bound rejection, and independent attribution fences
- Boundary risk: high; terminal GitHub issue closure attribution boundary

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Allow GitHub Issue.closedAt to differ from the latest ClosedEvent by at most one second only when the bounded repository REST feed independently proves that exact event timestamp.
- Preserve all actor, closer, repository, merge-SHA, and race-attribution fences.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [ ] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [ ] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [x] pytest -q tests/dispatcher/test_verification_consumer.py (240 passed)
- [x] ruff check app tests (passed)
- [x] mypy app (passed; 784 source files checked on the current rebased head)
- [x] pytest -q -m 'not pg' reached 1214 passed before deliberate interruption to correct a naive-datetime edge; current-head CI is the broad-suite authority

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The governing Issue and PR fully contain this bounded current-state correction; no learning, freshness, roadmap, or authority-crossing record is needed.

## Notes
Owner-doc writeback is not implied because the normative exact-attribution contract is unchanged.
