### PR TITLE
Close post-merge review residue from the #3510 cutover delivery

### DIFF
--- a/app/receipts/decision_receipt_log.py
+++ b/app/receipts/decision_receipt_log.py
@@ -16,11 +16,13 @@ Design (from the spec):
   (``WritesBlockedError``); the governance action never silently proceeds DB-only (C-8).
 - Receipt-before-ack (C-5/P-5): the durable log append is the commit point;
   ``insert_decision`` writes the log *first*, then the DB projection.
-- ``vault_uuid`` resolution: best-effort at write time. ``decisions.object_id`` is the
-  canonical ``store_objects.object_id``. Retained rows may still carry an older continuity UUID
-  in ``objects.uuid``. Fresh canonical-only rows have no proven frontmatter continuity identity,
-  so they use ``vault_uuid: null``; the same honest null is used when no row resolves or the
-  durable lookup is unavailable. Historical receipts that already contain the former canonical-id
+- ``vault_uuid`` resolution: best-effort for absence, fail-loud for ambiguity.
+  ``decisions.object_id`` is the canonical ``store_objects.object_id``. Retained rows may
+  still carry an older continuity UUID in ``objects.uuid``. Fresh canonical-only rows have
+  no proven frontmatter continuity identity, so they use ``vault_uuid: null``; the same
+  honest null is used when no row resolves or the durable lookup is unavailable. An
+  ambiguous retained mapping raises instead of recording null or arbitrary lineage.
+  Historical receipts that already contain the former canonical-id
   fallback remain replay-compatible,
   never invented. Carrying it lets the projection rebuild re-link a decision whose
   ``object_id`` was re-minted (§5 decoupling payoff, Slice 2).
@@ -103,12 +105,17 @@ def decisions_receipts_dir(vault_root: Path | None = None) -> Path:
 
 
 def resolve_vault_uuid(object_id: str) -> str | None:
-    """Best-effort resolve the vault frontmatter uuid for a runtime ``object_id``.
+    """Resolve the vault frontmatter uuid for a runtime ``object_id``.
 
     ``decisions.object_id`` references ``store_objects.object_id``. Return the retained
     ``objects.uuid`` continuity mapping when present. Fresh canonical-only rows have no
     proven frontmatter UUID, so return ``None`` rather than inventing one; ``None`` is also
-    returned when no matching object row exists or the durable lookup is unavailable.
+    returned when no matching object row exists or the durable lookup is unavailable
+    (transport-level ``psycopg.Error``). An ambiguous retained mapping — duplicate
+    ``objects.uuid`` rows or a cross-key alias — raises ``RuntimeError`` from the shared
+    identity seam instead of guessing: a receipt recorded with silently wrong lineage
+    would corrupt the projection-rebuild contract, so the write fails loud on exactly
+    the states the #3510 migration and runtime resolver also refuse.
     """
     try:
         with conn_rw() as conn:

--- a/app/services/note_update.py
+++ b/app/services/note_update.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 
 from app.agents.panel.integration import handle_panel_update
 from app.agents.panel.writeback import upsert_executed_ids
+from app.objects import resolve_canonical_object_id
 from app.components.concurrency import OptimisticWriteGuard
 from app.domain.state_axes import resolve_promotion_axes
 from app.knowledge.write_ops import default_vault_root_for_path, write_note_from_absolute
@@ -132,8 +133,14 @@ def process_note_update(
 
     DEFAULT_WRITE_GUARD.assert_writes_allowed("panel runtimes")
 
+    # ObjectStore-facing panel state is keyed by the canonical store id; a
+    # retained legacy note's frontmatter uuid may map to a different
+    # objects.id after #3510, and using it verbatim would split the note
+    # across two parents (the defect class every sibling call site resolves).
+    canonical_note_id = resolve_canonical_object_id(note_uuid)
+
     panel_result = handle_panel_update(
-        note_id=note_uuid,
+        note_id=canonical_note_id,
         old_markdown=old_markdown,
         new_markdown=raw_markdown,
         ctx=ctx,
@@ -158,7 +165,7 @@ def process_note_update(
             panel_result.panel.updated_markdown,
             expected_version=expected_version,
         )
-        upsert_executed_ids(note_uuid, panel_result.panel.executed_action_ids)
+        upsert_executed_ids(canonical_note_id, panel_result.panel.executed_action_ids)
 
     snapshot_path = _snapshot_path(snapshot_dir, note_uuid, ensure_parent=True)
     if snapshot_path is not None:

--- a/docs/RUNTIME_CORRECTNESS_KERNEL/SINGLE_STORE_GENERATION.md
+++ b/docs/RUNTIME_CORRECTNESS_KERNEL/SINGLE_STORE_GENERATION.md
@@ -89,7 +89,8 @@ Issue #3510 completes the deferred parent-row cutover: Alembic revision `7e4f2a1
 and moves supported legacy `objects(id)` foreign keys to canonical `store_objects(object_id)`.
 `PgObjects.upsert` therefore delegates only to `PgObjectStore` and no longer fabricates an empty
 legacy `objects` row. The migration is forward-only and fails loud on unknown FK consumers or
-orphaned ids, with reconciliation guidance in `docs/DB_SCHEMA.md :: Explicit Deltas / Known Gaps`.
+orphaned ids, with reconciliation guidance in
+`docs/DB_SCHEMA.md :: #3510 legacy-FK cutover (current reality)`.
 The retained filesystem-watcher compatibility lane still mirrors complete note state into
 `objects`; its `FilesystemVaultAdapter` producer resolves a retained `objects.uuid` to `objects.id`
 before writing the canonical `store_objects` parent through the single store writer on the same

--- a/scripts/deploy_channel.sh
+++ b/scripts/deploy_channel.sh
@@ -733,7 +733,11 @@ export DEPLOY_EMBEDDING_REBUILD_REQUIRED_ACK
 if [ "${action}" = "deploy" ] && [ "${MIGRATIONS_CHECKED}" -gt 0 ]; then
   write_pending_migration "${migration_from_sha}" "${target_sha}"
 fi
-if [ -n "${current_sha}" ]; then
+if [ -n "${current_sha}" ] && [ "${current_sha}" != "${target_sha}" ]; then
+  # A same-target retry (or same-SHA redeploy) reads current_sha == target_sha
+  # because a prior failed attempt already advanced the pin; overwriting the
+  # rollback anchor with the failed target would make the true last-known-good
+  # SHA unrecoverable through the rollback contract.
   write_pin "${previous_pin_file}" "${current_sha}"
 fi
 write_pin "${pin_file}" "${target_sha}"

--- a/tests/deploy/test_deploy_channel_script.py
+++ b/tests/deploy/test_deploy_channel_script.py
@@ -555,3 +555,33 @@ def test_channel_lock_is_acquired_before_mutable_state_snapshot() -> None:
     snapshot = text.index('current_sha="$(read_pin')
 
     assert lock_call < snapshot
+
+
+def test_incomplete_pending_marker_blocks_retry_with_exit_88(tmp_path: Path) -> None:
+    root, env, sha = _deploy_harness(tmp_path)
+    marker = root / "config/deploy/dev.migration-pending.env"
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("FROM_SHA=\nACK_FORWARD_ONLY=0\n", encoding="utf-8")
+
+    result = _run_deploy(root, env, sha)
+
+    assert result.returncode == 88
+    assert "pending migration marker is incomplete" in result.stderr
+    assert marker.exists(), "an incomplete marker must be preserved for operator inspection"
+
+
+def test_pending_target_mismatch_blocks_different_deploy_with_exit_88(tmp_path: Path) -> None:
+    root, env, sha = _deploy_harness(tmp_path)
+    pending_target = "6" * 40
+    marker = root / "config/deploy/dev.migration-pending.env"
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text(
+        f"FROM_SHA=__NO_BASELINE__\nTARGET_SHA={pending_target}\nACK_FORWARD_ONLY=0\n",
+        encoding="utf-8",
+    )
+
+    result = _run_deploy(root, env, sha)
+
+    assert result.returncode == 88
+    assert f"pending target {pending_target} must be reconciled" in result.stderr
+    assert marker.exists(), "a mismatched marker must survive until reconciled"

--- a/tests/deploy/test_deploy_channel_script.py
+++ b/tests/deploy/test_deploy_channel_script.py
@@ -585,3 +585,28 @@ def test_pending_target_mismatch_blocks_different_deploy_with_exit_88(tmp_path: 
     assert result.returncode == 88
     assert f"pending target {pending_target} must be reconciled" in result.stderr
     assert marker.exists(), "a mismatched marker must survive until reconciled"
+
+
+def test_same_target_retry_preserves_rollback_anchor(tmp_path: Path) -> None:
+    """A failed-then-retried deploy must not stamp previous.env with the failed target."""
+    root, env, sha = _deploy_harness(tmp_path)
+    good_previous = "5" * 40
+    _seed_previous_pin(root, good_previous)
+    target = _commit_migration(root, "feedc0de0003_anchor_probe.py")
+    env = dict(env)
+    env["FAKE_VERSION_SHA"] = target
+    env["FAKE_HEALTH_VERSION_SHA"] = target
+    previous_pin = root / "config/deploy/dev.previous.env"
+
+    fail_env = dict(env)
+    fail_env["FAKE_DOCKER_FAIL_MATCH"] = "--exit-code-from migrate"
+    first = _run_deploy(root, fail_env, target)
+    assert first.returncode != 0
+    assert f"APP_IMAGE_TAG={good_previous}" in previous_pin.read_text(encoding="utf-8")
+
+    retry = _run_deploy(root, env, target)
+    assert retry.returncode == 0, retry.stderr
+    assert f"APP_IMAGE_TAG={good_previous}" in previous_pin.read_text(encoding="utf-8"), (
+        "the rollback anchor must survive a same-target retry"
+    )
+    assert f"APP_IMAGE_TAG={target}" in (root / "config/deploy/dev.env").read_text(encoding="utf-8")

--- a/tests/migrations/test_legacy_objects_fk_migration.py
+++ b/tests/migrations/test_legacy_objects_fk_migration.py
@@ -716,3 +716,79 @@ def test_runtime_bootstrap_preserves_objects_primary_key_after_cutover(scratch_d
         ).fetchone()
 
     assert after == before
+
+
+def test_migration_retargets_every_reviewed_consumer_with_live_rows(scratch_dsn: str) -> None:
+    """Seed a row through every reviewed objects(id) FK consumer, then cut over.
+
+    Covers the structural cases the generic retarget loop must handle beyond the
+    decisions-only seeds used elsewhere: two FK columns on one table
+    (relations.src_id/dst_id), the composite-membership shape, and the CASCADE
+    vs SET NULL delete-rule preservation across all eight reviewed pairs.
+    """
+    _upgrade(PRE_CUTOVER_REVISION)
+    object_id = uuid.uuid4()
+    other_id = uuid.uuid4()
+    set_id = uuid.uuid4()
+    chunk_id = uuid.uuid4()
+    with psycopg.connect(scratch_dsn) as conn:
+        conn.execute(
+            "INSERT INTO objects (id, kind, payload) VALUES (%s, 'note', '{}'::jsonb)",
+            (object_id,),
+        )
+        conn.execute(
+            "INSERT INTO objects (id, kind, payload) VALUES (%s, 'note', '{}'::jsonb)",
+            (other_id,),
+        )
+        conn.execute("INSERT INTO sets (id, name) VALUES (%s, 'inventory-set')", (set_id,))
+        conn.execute(
+            "INSERT INTO chunks (id, object_id, idx, offset_start, offset_end, text) "
+            "VALUES (%s, %s, 0, 0, 1, 'x')",
+            (chunk_id, object_id),
+        )
+        conn.execute(
+            "INSERT INTO embeddings (id, object_id, chunk_id, dim) VALUES (%s, %s, %s, 3)",
+            (uuid.uuid4(), object_id, chunk_id),
+        )
+        conn.execute(
+            "INSERT INTO relations (id, src_id, dst_id, type) VALUES (%s, %s, %s, 'refs')",
+            (uuid.uuid4(), object_id, other_id),
+        )
+        conn.execute(
+            "INSERT INTO membership (id, set_id, object_id) VALUES (%s, %s, %s)",
+            (uuid.uuid4(), set_id, object_id),
+        )
+        conn.execute(
+            "INSERT INTO decisions (object_id, key, value) VALUES (%s, 'review', '{}'::jsonb)",
+            (object_id,),
+        )
+        conn.execute(
+            "INSERT INTO audit (id, object_id, agent, action) VALUES (%s, %s, 'test', 'seed')",
+            (uuid.uuid4(), object_id),
+        )
+
+    _upgrade("head")
+
+    with psycopg.connect(scratch_dsn) as conn:
+        rows = conn.execute(
+            "SELECT conrelid::regclass::text, a.attname, confrelid::regclass::text, c.confdeltype "
+            "FROM pg_constraint c "
+            "JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = c.conkey[1] "
+            "WHERE c.contype = 'f' "
+            "  AND c.confrelid IN ('public.store_objects'::regclass, 'public.objects'::regclass) "
+            "ORDER BY 1, 2"
+        ).fetchall()
+        counts = {
+            table: conn.execute(f"SELECT count(*) FROM {table}").fetchone()[0]
+            for table in ("chunks", "embeddings", "relations", "membership", "decisions", "audit")
+        }
+    retargeted = {(table, column): (target, rule) for table, column, target, rule in rows}
+    assert retargeted[("chunks", "object_id")] == ("store_objects", "c")
+    assert retargeted[("embeddings", "object_id")] == ("store_objects", "c")
+    assert retargeted[("relations", "src_id")] == ("store_objects", "c")
+    assert retargeted[("relations", "dst_id")] == ("store_objects", "c")
+    assert retargeted[("membership", "object_id")] == ("store_objects", "c")
+    assert retargeted[("decisions", "object_id")] == ("store_objects", "n")
+    assert retargeted[("audit", "object_id")] == ("store_objects", "n")
+    assert not any(target == "objects" for target, _ in retargeted.values())
+    assert all(count == 1 for count in counts.values())

--- a/tests/services/test_decision_receipt_log.py
+++ b/tests/services/test_decision_receipt_log.py
@@ -330,3 +330,42 @@ def test_receipts_are_dated_shards_and_append_only(
     ]
     assert all_records[0]["vault_uuid"] == "uuid-1"
     assert all_records[2]["vault_uuid"] == "uuid-2"
+
+
+def test_resolve_vault_uuid_transport_error_returns_none(monkeypatch) -> None:
+    """Transport-level psycopg errors stay best-effort (honest null lineage)."""
+    import psycopg as _psycopg
+
+    from app.receipts import decision_receipt_log as receipt_log
+
+    class _BrokenConn:
+        def __enter__(self):
+            raise _psycopg.OperationalError("db unavailable")
+
+        def __exit__(self, *args):
+            return False
+
+    monkeypatch.setattr(receipt_log, "conn_rw", lambda: _BrokenConn())
+    assert receipt_log.resolve_vault_uuid("00000000-0000-0000-0000-000000000000") is None
+
+
+def test_resolve_vault_uuid_ambiguous_identity_fails_loud(monkeypatch) -> None:
+    """Ambiguous retained identity must abort the write, never record wrong lineage."""
+    import pytest as _pytest
+
+    from app.receipts import decision_receipt_log as receipt_log
+
+    class _Conn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    def _ambiguous(conn, object_id):
+        raise RuntimeError("ambiguous retained identity mapping for test")
+
+    monkeypatch.setattr(receipt_log, "conn_rw", lambda: _Conn())
+    monkeypatch.setattr(receipt_log, "retained_vault_uuid_with_connection", _ambiguous)
+    with _pytest.raises(RuntimeError, match="ambiguous retained identity"):
+        receipt_log.resolve_vault_uuid("00000000-0000-0000-0000-000000000000")

--- a/tests/services/test_note_update_identity.py
+++ b/tests/services/test_note_update_identity.py
@@ -1,0 +1,51 @@
+"""#3510 identity threading for the note_update/note_scan panel seam.
+
+The frontmatter uuid names the vault file; ObjectStore-facing panel state is
+keyed by the canonical store id. For a retained legacy note the two differ, so
+the seam must resolve the canonical id exactly like its sibling call sites
+(watcher registry, vault watcher, outbox worker, checkbox projection).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
+
+from app.services import note_update
+
+
+def test_panel_seam_receives_canonical_identity(tmp_path: Path, monkeypatch) -> None:
+    vault_uuid = str(uuid4())
+    canonical_id = str(uuid4())
+    note = tmp_path / "retained.md"
+    note.write_text(
+        f"---\nuuid: {vault_uuid}\n---\n\nbody\n",
+        encoding="utf-8",
+    )
+
+    seen: dict[str, str] = {}
+
+    def fake_resolve(value: str) -> str:
+        seen["resolved_from"] = value
+        return canonical_id
+
+    def fake_handle_panel_update(*, note_id, old_markdown, new_markdown, ctx, note_path):
+        seen["panel_note_id"] = note_id
+        panel = SimpleNamespace(
+            updated_markdown=new_markdown,
+            executed_action_ids=[],
+        )
+        return SimpleNamespace(panel=panel, events=[], dispatch_count=0)
+
+    monkeypatch.setattr(note_update, "resolve_canonical_object_id", fake_resolve)
+    monkeypatch.setattr(note_update, "handle_panel_update", fake_handle_panel_update)
+    monkeypatch.setattr(
+        note_update.DEFAULT_WRITE_GUARD, "assert_writes_allowed", lambda action: None
+    )
+
+    result = note_update.process_note_update(str(note), None, vault_root=tmp_path)
+
+    assert seen["resolved_from"] == vault_uuid
+    assert seen["panel_note_id"] == canonical_id
+    assert result.uuid == vault_uuid, "the vault-facing result keeps the frontmatter uuid"


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

## Direct Repair
Type: code
Reason: bounded post-merge review-residue repair for merged PR #3696 (the #3510 legacy objects FK cutover, merge commit c3c8f996) — the final review rounds' fixes never reached main and carry no new scope.
Validation: ruff clean; deploy + panel + note_update suites 223 passed locally; isolated Alembic-head pgvector battery green; required check Unit tests (not pg) green on this head; independent whole-diff review seat A returned clean on this content and seat B's two findings are the fixes in this PR.
Issue required: no

- Scope anchor: merged PR #3696 (the #3510 legacy objects FK cutover, merge commit c3c8f996)
- Why bounded: PR #3696 merged at exact head 00e15e7e while the final review rounds were still in flight; the four round-3 findings (repaired on the branch as the stranded commit 192cf932) and two round-4 findings never reached main. This PR carries exactly that residue — no new scope.
- Round-3 residue: precise two-tier contract for `resolve_vault_uuid` (transport errors stay best-effort null; ambiguous retained identity fails loud, matching the migration and runtime resolver) with regression tests; corrected #3510 reconciliation pointer in SINGLE_STORE_GENERATION.md; harness regressions for both exit-88 pending-marker branches; a live pre-cutover seed through every reviewed FK consumer proving the retarget loop across the structural cases.
- Round-4 findings (in merged content, fixed here): (1) `process_note_update` passed the raw frontmatter uuid into `handle_panel_update`/`upsert_executed_ids` — the one ObjectStore-facing panel call site the cutover never patched; a retained note would split into a second parent keyed by the vault uuid. The seam now resolves the canonical id like every sibling call site. (2) A failed deploy retains the target pin by design, so a same-target retry stamped `previous.env` with the just-failed target, making the true last-known-good SHA unrecoverable through the rollback contract; the anchor write is now skipped when `current_sha == target_sha`, with a fail-then-retry harness regression.

## SBS Impact
- Primary subsystem: Product/Runtime System — durable persistence identity seam; Builder System — deploy gate
- Write class: mechanical durable (identity threading) + deploy tooling
- Authority impact: none
- Persistence impact: prevents split-parent rows from the note_update seam on retained notes
- Sync/deployment impact: rollback anchor preserved across same-target retries; no channel mutation performed by this PR
- Owner-doc impact: updated in this PR (`docs/RUNTIME_CORRECTNESS_KERNEL/SINGLE_STORE_GENERATION.md` pointer)
- Fitness rule impact: strengthens single-store-generation enforcement and the deploy fail-closed contract

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Thread canonical identity through the note_update/note_scan panel seam (retained-note split-parent fix) with a seam regression test.
- Preserve the rollback anchor across same-target deploy retries with a harness regression.
- Land the stranded round-3 branch commit: resolve_vault_uuid contract docs + tests, doc pointer fix, exit-88 regressions, all-consumers live retarget test.

## Implementation Scope Check
- [x] Change stays within the bounded direct-repair scope above.
- [x] Docs were updated in the same change when behavior/contracts changed.

## Validation
- `ruff check app tests scripts` — All checks passed!
- `pytest -q tests/deploy/ tests/services/test_note_update_identity.py tests/cli/test_note_update_cli.py tests/cli/test_note_scan_cli.py tests/agents/panel_agent/` — 223 passed, 10 skipped
- `DATABASE_URL=<isolated-pg> pytest -q tests/migrations/ tests/ingest/test_vault_root_ingest_pg.py tests/integration/test_vault_sync_atomicity.py tests/stores/test_pg_truncate_reset.py` — green on an isolated Alembic-head pgvector database (single pre-existing baseline failure tracked as #3988)
- `mypy app` — 1 pre-existing local-env error in app/dispatcher/control_plane.py, identical on main (CI's pinned env is green)
- Independent whole-diff review round 4 seat A returned clean on this exact content; seat B's two findings are the fixes in this PR

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: review-residue routing is carried by this PR plus bounded issues #3987 (consolidation follow-ups) and #3988 (outbox schema parity baseline); no additional BuilderOps record is required for a bounded direct repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

