### PR TITLE
Fix YouTube acquisition policy enforcement at drain

### DIFF
--- a/app/knowledge_acquisition/acquisition_requests.py
+++ b/app/knowledge_acquisition/acquisition_requests.py
@@ -1254,10 +1254,11 @@ def drain_one(
     A queue row carries the effective acquisition policy at enqueue time, so
     the drain is its enforcement boundary.  The current ``acquire_youtube``
     entrypoint is a full transcript/caption pipeline: it cannot truthfully
-    service ``candidate_metadata_only`` or ``captions: false``.  Those modes
-    therefore produce an explicit terminal policy disposition before any
-    external acquisition occurs; a future metadata-only pipeline must replace
-    this guarded branch rather than bypass it.
+    service ``candidate_metadata_only``, ``captions: false``, or enabled media
+    archival. Those modes therefore produce an explicit terminal policy
+    disposition before any external acquisition occurs; a future metadata-only
+    or media pipeline must replace the corresponding guarded branch rather
+    than bypass it.
 
     The scheduler slice (YSS-06) owns *when* this runs; unexpected exceptions
     (config errors such as ``DatabaseNotConfiguredError`` included) propagate
@@ -1281,8 +1282,19 @@ def drain_one(
     policy = request.policy_snapshot or {}
     mode = policy.get("mode")
     captions = policy.get("captions")
+    media = policy.get("media")
     unsupported_policy: str | None = None
-    if mode == "candidate_metadata_only":
+    if media is not None and not isinstance(media, dict):
+        unsupported_policy = "policy media must be an object when present"
+    elif media is not None and media.get("enabled") is True:
+        return queue.dead_letter(
+            request.request_id,
+            reason_code="media_policy_disabled",
+            error="media acquisition is disabled because the archival engine is not delivered",
+            now=now,
+            conn=conn,
+        )
+    elif mode == "candidate_metadata_only":
         unsupported_policy = (
             "policy mode 'candidate_metadata_only' requires a metadata-only candidate "
             "pipeline, which is not available at this drain boundary"

--- a/app/knowledge_acquisition/acquisition_requests.py
+++ b/app/knowledge_acquisition/acquisition_requests.py
@@ -1251,6 +1251,14 @@ def drain_one(
       failures still surface their durable stage dead-letter in lineage and
       converge to ``dead_lettered`` through attempts exhaustion).
 
+    A queue row carries the effective acquisition policy at enqueue time, so
+    the drain is its enforcement boundary.  The current ``acquire_youtube``
+    entrypoint is a full transcript/caption pipeline: it cannot truthfully
+    service ``candidate_metadata_only`` or ``captions: false``.  Those modes
+    therefore produce an explicit terminal policy disposition before any
+    external acquisition occurs; a future metadata-only pipeline must replace
+    this guarded branch rather than bypass it.
+
     The scheduler slice (YSS-06) owns *when* this runs; unexpected exceptions
     (config errors such as ``DatabaseNotConfiguredError`` included) propagate
     loud rather than being folded into queue state.
@@ -1271,6 +1279,31 @@ def drain_one(
         )
 
     policy = request.policy_snapshot or {}
+    mode = policy.get("mode")
+    captions = policy.get("captions")
+    unsupported_policy: str | None = None
+    if mode == "candidate_metadata_only":
+        unsupported_policy = (
+            "policy mode 'candidate_metadata_only' requires a metadata-only candidate "
+            "pipeline, which is not available at this drain boundary"
+        )
+    elif captions is False:
+        unsupported_policy = (
+            "policy captions=false cannot be honored by the current full transcript "
+            "acquisition pipeline"
+        )
+    elif mode not in (None, "acquire_transcript"):
+        unsupported_policy = f"policy mode {mode!r} has no acquisition drain implementation"
+
+    if unsupported_policy is not None:
+        return queue.dead_letter(
+            request.request_id,
+            reason_code="policy_unsupported",
+            error=unsupported_policy,
+            now=now,
+            conn=conn,
+        )
+
     raw_extractor_ids = policy.get("extractor_ids") or ()
     if isinstance(raw_extractor_ids, str):
         raise AcquisitionRequestValidationError(

--- a/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
@@ -147,6 +147,7 @@ substrate (the `settings_receipts`/`promotion_receipts` pattern).
 `auth_expired`, `auth_revoked`, `auth_disconnected` (operator action), `quota_exhausted`,
 `api_unavailable` (5xx/timeout), `network_error`, `source_gone` (404/private-without-access),
 `source_unsupported` (Watch Later / Watch History), `writeguard_blocked`, `pipeline_dead_letter`,
+`policy_unsupported` (queued acquisition mode/depth has no delivered production path),
 `paused_global`, `paused_source`, `runner_offline` (staleness derived, not self-reported),
 `media_policy_disabled`. UI copy maps these through the Companion UI's single degraded-copy module;
 unknown codes fail closed to the generic degraded message.

--- a/tests/knowledge_acquisition/test_acquisition_requests.py
+++ b/tests/knowledge_acquisition/test_acquisition_requests.py
@@ -668,3 +668,87 @@ def test_drain_one_dead_letters_unknown_source_kind() -> None:
     result = drain_one(q.get(row.request_id), vault_context=None, queue=q, conn=conn)
     assert result.status == "dead_lettered"
     assert result.last_failure["reason_code"] == "source_unsupported"
+
+
+def test_drain_candidate_metadata_only_does_not_run_transcript_acquisition() -> None:
+    """The drain boundary must not turn a shallow request into a full fetch."""
+    conn = FakeOutboxConn()
+    q = _queue()
+    _enqueue(
+        q,
+        conn,
+        policy_snapshot={"policy_version": 1, "mode": "candidate_metadata_only"},
+    )
+    claimed = q.claim_batch(1, conn=conn)
+    calls: list[dict[str, Any]] = []
+
+    def acquire_must_not_run(*args: Any, **kwargs: Any) -> None:
+        calls.append(kwargs)
+        raise AssertionError("metadata-only requests must not enter the transcript pipeline")
+
+    result = drain_one(
+        claimed[0], vault_context=None, queue=q, conn=conn, acquire_fn=acquire_must_not_run
+    )
+
+    assert calls == []
+    assert result.status == "dead_lettered"
+    assert result.completed_at is None
+    assert result.last_failure is not None
+    assert result.last_failure["reason_code"] == "policy_unsupported"
+    assert "candidate_metadata_only" in result.last_failure["error"]
+
+
+def test_drain_honors_captions_false_before_acquire_youtube() -> None:
+    """A disabled-caption policy cannot silently use the current full pipeline."""
+    conn = FakeOutboxConn()
+    q = _queue()
+    _enqueue(
+        q,
+        conn,
+        policy_snapshot={"policy_version": 1, "mode": "acquire_transcript", "captions": False},
+    )
+    claimed = q.claim_batch(1, conn=conn)
+    calls: list[dict[str, Any]] = []
+
+    def acquire_must_not_run(*args: Any, **kwargs: Any) -> None:
+        calls.append(kwargs)
+        raise AssertionError("captions=false requests must not enter acquire_youtube")
+
+    result = drain_one(
+        claimed[0], vault_context=None, queue=q, conn=conn, acquire_fn=acquire_must_not_run
+    )
+
+    assert calls == []
+    assert result.status == "dead_lettered"
+    assert result.completed_at is None
+    assert result.last_failure is not None
+    assert result.last_failure["reason_code"] == "policy_unsupported"
+    assert "captions=false" in result.last_failure["error"]
+
+
+def test_drain_unsupported_policy_depth_is_legible_non_completed() -> None:
+    conn = FakeOutboxConn()
+    q = _queue()
+    _enqueue(
+        q,
+        conn,
+        policy_snapshot={"policy_version": 1, "mode": "discover_only"},
+    )
+    claimed = q.claim_batch(1, conn=conn)
+
+    def acquire_must_not_run(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("unsupported policies must stop before acquire_youtube")
+
+    result = drain_one(
+        claimed[0],
+        vault_context=None,
+        queue=q,
+        conn=conn,
+        acquire_fn=acquire_must_not_run,
+    )
+
+    assert result.status == "dead_lettered"
+    assert result.completed_at is None
+    assert result.last_failure is not None
+    assert result.last_failure["reason_code"] == "policy_unsupported"
+    assert "discover_only" in result.last_failure["error"]

--- a/tests/knowledge_acquisition/test_acquisition_requests.py
+++ b/tests/knowledge_acquisition/test_acquisition_requests.py
@@ -726,6 +726,42 @@ def test_drain_honors_captions_false_before_acquire_youtube() -> None:
     assert "captions=false" in result.last_failure["error"]
 
 
+def test_drain_media_enabled_fails_closed_before_acquire_youtube() -> None:
+    """The undelivered media engine must be refused before acquisition egress."""
+    conn = FakeOutboxConn()
+    q = _queue()
+    _enqueue(
+        q,
+        conn,
+        policy_snapshot={
+            "policy_version": 1,
+            "mode": "acquire_transcript",
+            "captions": True,
+            "media": {"enabled": True},
+        },
+    )
+    claimed = q.claim_batch(1, conn=conn)
+    calls: list[dict[str, Any]] = []
+
+    def acquire_must_not_run(*args: Any, **kwargs: Any) -> None:
+        calls.append(kwargs)
+        raise AssertionError("media-enabled requests must stop before acquire_youtube")
+
+    result = drain_one(
+        claimed[0], vault_context=None, queue=q, conn=conn, acquire_fn=acquire_must_not_run
+    )
+
+    assert calls == []
+    assert result.status == "dead_lettered"
+    assert result.completed_at is None
+    assert result.last_failure is not None
+    assert result.last_failure["reason_code"] == "media_policy_disabled"
+    assert "media" in result.last_failure["error"]
+    failed_events = conn.payloads_for(ACQUISITION_FAILED_TOPIC)
+    assert failed_events[-1]["reason_code"] == "media_policy_disabled"
+    assert failed_events[-1]["terminal"] is True
+
+
 def test_drain_unsupported_policy_depth_is_legible_non_completed() -> None:
     conn = FakeOutboxConn()
     q = _queue()


### PR DESCRIPTION
Governing-Issue: #3991

Fixes #3991

## Summary
- Enforce each queued YouTube request policy at the production `drain_one` boundary before `acquire_youtube` is called.
- Fail closed with an item-scoped `policy_unsupported` dead letter when `candidate_metadata_only`, `captions: false`, or another unsupported acquisition mode cannot be honored by the current full transcript pipeline.
- Refuse `policy_snapshot.media.enabled=true` before acquisition with the contract-owned `media_policy_disabled` outcome.
- Add production-dispatch regression coverage proving forbidden policy depths never enter transcript/caption/media acquisition.

## Validation
- `pytest -q tests/knowledge_acquisition/test_acquisition_requests.py` (24 passed)
- Focused four-policy-path pytest selection (4 passed)
- `pytest -q -m "not pg"` (passed; one isolated complete run after repair)
- `ruff check app tests` (passed)
- `mypy app` (passed)

## Claim Receipt
- `coordination_mode=dispatcher-backed`; `task_id=github-RasmusTho--agentic-pkm-mvp-issue-3991`; `lease_id=lease-fa056dab`; `holder=yss-3991-terra`; `evidence=verified-dispatcher-lease`.

## SBS Impact
- Product/Runtime System / Knowledge Acquisition Platform, YouTube source sync: the durable request policy snapshot is enforced authority at the drain boundary.
- Requests that cannot be honored receive an explicit item-scoped terminal disposition before any prohibited external transcript/caption/media acquisition; retryable network, WriteGuard, and downstream pipeline semantics are unchanged.

## Owner-doc Resolution
- Updated `docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md :: Reason codes` so `policy_unsupported` is an owned all-surfaces reason code rather than runtime taxonomy drift.
- No supported metadata-only or media pipeline is claimed; both remain fail-closed at the current drain.

## BuilderOps Routing
- Records/projections/receipts: LearningSignal `lrn_20260719051454_c578017b`; dispatcher claim receipt above.
- Reason: the issue already links the review-comment-closure learning signal; this PR adds no new BuilderOps record because implementation and repair remain within that bounded residual route.
