### PR TITLE
fix: make YouTube OAuth lifecycle transactional

### DIFF
--- a/app/alembic/versions/a2f1c3e4d5b6_yss02_youtube_account_binding.py
+++ b/app/alembic/versions/a2f1c3e4d5b6_yss02_youtube_account_binding.py
@@ -7,7 +7,9 @@ YouTube/Google account -- the `account_binding_id` that authenticated rows in
 `acquisition_source_registry` (YSS-01) reference. It records the provider
 channel id (`UC...` -- identity, never a title), a display label, the
 connected/degraded auth state + reason code, the granted scopes, and
-timestamps. It carries **no secret**: tokens live in the AES-256-GCM
+timestamps. A monotonic non-secret `binding_generation` supplies compare-and-set
+authority for lifecycle recovery; wall-clock timestamps are observational only.
+It carries **no secret**: tokens live in the AES-256-GCM
 `youtube_token_store` file, client credentials live in host env
 (`docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md :: Secrets and private
 bindings`, INV-YSS-5).
@@ -20,6 +22,7 @@ in `youtube_account_binding.py`):
 - `state` is one of `connected` / `degraded`.
 - a `connected` binding carries no `reason_code` (a degraded reason and a
   healthy state are mutually exclusive).
+- `binding_generation` is positive and advances on every state write.
 
 plus a unique `(provider, provider_channel_id)` index: one binding per account.
 
@@ -67,13 +70,26 @@ def upgrade() -> None:
             obtained_at TIMESTAMPTZ NOT NULL,
             created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
             updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            binding_generation BIGINT NOT NULL DEFAULT 1,
             CONSTRAINT youtube_account_binding_state_chk CHECK (
                 state IN ('connected', 'degraded')
             ),
             CONSTRAINT youtube_account_binding_connected_reason_chk CHECK (
                 state <> 'connected' OR reason_code IS NULL
+            ),
+            CONSTRAINT youtube_account_binding_generation_chk CHECK (
+                binding_generation >= 1
             )
         )
+        """
+    )
+    # The idempotent ALTER also migrates a bootstrap-created table that predates
+    # generation CAS. Existing rows begin at generation 1; every subsequent
+    # service-layer state transition advances it atomically.
+    op.execute(
+        f"""
+        ALTER TABLE {_TABLE}
+        ADD COLUMN IF NOT EXISTS binding_generation BIGINT NOT NULL DEFAULT 1
         """
     )
     # Existing test/bootstrap-created tables predate the CHECK constraints; add
@@ -82,6 +98,7 @@ def upgrade() -> None:
     for name, check in (
         ("youtube_account_binding_state_chk", "state IN ('connected', 'degraded')"),
         ("youtube_account_binding_connected_reason_chk", "state <> 'connected' OR reason_code IS NULL"),
+        ("youtube_account_binding_generation_chk", "binding_generation >= 1"),
     ):
         op.execute(
             f"""

--- a/app/alembic/versions/e1f2a3b4c5d6_yss02_binding_generation_cas.py
+++ b/app/alembic/versions/e1f2a3b4c5d6_yss02_binding_generation_cas.py
@@ -1,0 +1,62 @@
+"""YSS-02 (#3990): add durable account-binding generation CAS authority.
+
+Existing databases may already be stamped past the original YSS-02 table
+revision. This migration adds the positive monotonic generation required by
+OAuth terminal-state recovery without deriving authority from wall-clock
+``updated_at`` values. Existing rows begin at generation 1; every subsequent
+service-layer state write advances the value atomically.
+
+The binding registry is authority-bearing OAuth lifecycle state. Following its
+original migration posture, this schema change is forward-only rather than
+silently removing compare-and-set evidence during downgrade.
+
+Revision ID: e1f2a3b4c5d6
+Revises: d9e0f1a2b3c4
+Create Date: 2026-07-20 19:30:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "e1f2a3b4c5d6"
+down_revision: Union[str, None] = "d9e0f1a2b3c4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+reversibility: str = "forward-only"
+
+_TABLE = "youtube_account_binding"
+
+
+def upgrade() -> None:
+    op.execute(
+        f"""
+        ALTER TABLE {_TABLE}
+        ADD COLUMN IF NOT EXISTS binding_generation BIGINT NOT NULL DEFAULT 1
+        """
+    )
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1
+                FROM pg_constraint
+                WHERE conname = 'youtube_account_binding_generation_chk'
+                  AND conrelid = '{_TABLE}'::regclass
+            ) THEN
+                ALTER TABLE {_TABLE}
+                ADD CONSTRAINT youtube_account_binding_generation_chk
+                CHECK (binding_generation >= 1);
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    raise RuntimeError(
+        "YSS-02 binding-generation CAS migration is forward-only; removing it would erase "
+        "durable terminal-state recovery authority."
+    )

--- a/app/knowledge_acquisition/source_registry.py
+++ b/app/knowledge_acquisition/source_registry.py
@@ -66,6 +66,7 @@ import math
 import os
 import threading
 import uuid
+from collections.abc import Collection
 from copy import deepcopy
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
@@ -583,6 +584,28 @@ class _MemorySourceRegistryBackend:
             self._rows[binding_id] = updated
             return _copy_binding(updated)
 
+    def clear_degradation(
+        self,
+        binding_id: str,
+        *,
+        expected_reason_codes: frozenset[str],
+    ) -> SourceBinding:
+        """Clear only the degradation state owned by the recovering actor."""
+        with self._lock:
+            row = self._rows.get(binding_id)
+            if row is None:
+                raise KeyError(f"no such binding: {binding_id}")
+            reason_code = (
+                row.last_error.get("reason_code")
+                if isinstance(row.last_error, dict)
+                else None
+            )
+            if reason_code not in expected_reason_codes:
+                return _copy_binding(row)
+            updated = replace(row, last_error=None, updated_at=_now_iso())
+            self._rows[binding_id] = updated
+            return _copy_binding(updated)
+
     def clear(self) -> None:
         with self._lock:
             self._rows.clear()
@@ -999,6 +1022,33 @@ class _PgSourceRegistryBackend:
         assert result is not None  # just wrote it
         return result
 
+    def clear_degradation(
+        self,
+        binding_id: str,
+        *,
+        expected_reason_codes: frozenset[str],
+    ) -> SourceBinding:
+        """Atomically clear a still-matching error without clobbering a peer."""
+        conn = _pg_connect()
+        try:
+            _assert_pg_schema(conn)
+            cur = conn.cursor()
+            cur.execute(
+                f"UPDATE {_TABLE} SET last_error = NULL, updated_at = %s::timestamptz "
+                "WHERE binding_id = %s AND last_error->>'reason_code' = ANY(%s) "
+                f"RETURNING {_COLUMNS_SQL}",
+                (_now_iso(), binding_id, list(expected_reason_codes)),
+            )
+            row = cur.fetchone()
+            if row is not None:
+                return _row_to_binding(tuple(row))
+        finally:
+            conn.close()
+        result = self.get(binding_id)
+        if result is None:
+            raise KeyError(f"no such binding: {binding_id}")
+        return result
+
 
 # --- Service layer -------------------------------------------------------
 
@@ -1161,6 +1211,30 @@ class SourceRegistry:
         """
         return self._backend.update_state(
             binding_id, enabled=None, last_error=_build_last_error(reason_code, detail)
+        )
+
+    def clear_source_degradation(
+        self,
+        binding_id: str,
+        *,
+        expected_reason_codes: Collection[str],
+    ) -> SourceBinding:
+        """Clear one recoverable error without erasing a newer unrelated one."""
+        if isinstance(expected_reason_codes, (str, bytes)):
+            raise SourceRegistryValidationError(
+                "expected_reason_codes must be a collection of reason-code strings"
+            )
+        resolved = frozenset(expected_reason_codes)
+        if not resolved or any(
+            not isinstance(reason_code, str) or not reason_code.strip()
+            for reason_code in resolved
+        ):
+            raise SourceRegistryValidationError(
+                "expected_reason_codes must contain non-empty strings"
+            )
+        return self._backend.clear_degradation(
+            binding_id,
+            expected_reason_codes=resolved,
         )
 
     def disable_source_for_auth(

--- a/app/knowledge_acquisition/youtube_account_binding.py
+++ b/app/knowledge_acquisition/youtube_account_binding.py
@@ -34,7 +34,16 @@ VALID_BINDING_STATES: frozenset[str] = frozenset({"connected", "degraded"})
 # The auth reason codes a binding may carry (subset of the contract taxonomy
 # that is auth-scoped). ``None`` means healthy/connected.
 VALID_BINDING_REASON_CODES: frozenset[str] = frozenset(
-    {"auth_missing", "auth_key_missing", "auth_expired", "auth_revoked", "auth_disconnected"}
+    {
+        "auth_missing",
+        "auth_key_missing",
+        "auth_expired",
+        "auth_revoked",
+        "auth_disconnected",
+        "auth_refresh_pending",
+        "auth_refresh_conflict",
+        "auth_refresh_durability",
+    }
 )
 
 _TABLE = "youtube_account_binding"

--- a/app/knowledge_acquisition/youtube_account_binding.py
+++ b/app/knowledge_acquisition/youtube_account_binding.py
@@ -7,7 +7,9 @@ state -- **never** any secret. Tokens live in the encrypted
 ``youtube_token_store``; client credentials live in host env. This row carries
 only: the binding id, the provider channel id (source-native ``UC...`` id --
 identity, never a title), a display label, the connected/degraded state + a
-reason code, the granted scopes, and timestamps (INV-YSS-5).
+reason code, the granted scopes, a monotonic binding generation, and timestamps
+(INV-YSS-5).  The generation is non-secret compare-and-set authority for OAuth
+lifecycle recovery; wall-clock timestamps remain observational only.
 
 Dual backend and store discipline mirror ``source_registry`` exactly: memory
 backend for ``not_pg`` tests, Postgres for a configured runtime (fail-loud on
@@ -50,7 +52,8 @@ _TABLE = "youtube_account_binding"
 _MIGRATION_HINT = (
     "youtube_account_binding schema is migration-owned: run 'alembic upgrade head' "
     "against this database. See "
-    "app/alembic/versions/a2f1c3e4d5b6_yss02_youtube_account_binding.py."
+    "app/alembic/versions/a2f1c3e4d5b6_yss02_youtube_account_binding.py and "
+    "e1f2a3b4c5d6_yss02_binding_generation_cas.py."
 )
 _ALLOWED_BACKENDS = {"memory", "pg"}
 
@@ -65,6 +68,10 @@ class AccountBindingValidationError(ValueError):
 
 class DuplicateAccountBindingError(ValueError):
     """Raised when a binding for the same provider channel id already exists."""
+
+
+class AccountBindingGenerationConflictError(RuntimeError):
+    """Raised when a state write no longer owns its expected binding generation."""
 
 
 def _now_iso() -> str:
@@ -85,6 +92,7 @@ class AccountBinding:
     obtained_at: str
     created_at: str
     updated_at: str
+    binding_generation: int
 
 
 def _validate_state(state: str, reason_code: str | None) -> None:
@@ -178,12 +186,31 @@ class _MemoryAccountBindingBackend:
         with self._lock:
             return tuple(self._rows.values())
 
-    def set_state(self, account_binding_id: str, state: str, reason_code: str | None) -> AccountBinding:
+    def set_state(
+        self,
+        account_binding_id: str,
+        state: str,
+        reason_code: str | None,
+        expected_binding_generation: int | None = None,
+    ) -> AccountBinding:
         with self._lock:
             row = self._rows.get(account_binding_id)
             if row is None:
                 raise KeyError(f"no such account binding: {account_binding_id}")
-            updated = replace(row, state=state, reason_code=reason_code, updated_at=_now_iso())
+            if (
+                expected_binding_generation is not None
+                and row.binding_generation != expected_binding_generation
+            ):
+                raise AccountBindingGenerationConflictError(
+                    "account binding generation changed before state persistence"
+                )
+            updated = replace(
+                row,
+                state=state,
+                reason_code=reason_code,
+                updated_at=_now_iso(),
+                binding_generation=row.binding_generation + 1,
+            )
             self._rows[account_binding_id] = updated
             return updated
 
@@ -217,6 +244,7 @@ _COLUMNS = (
     "obtained_at",
     "created_at",
     "updated_at",
+    "binding_generation",
 )
 _COLUMNS_SQL = ", ".join(_COLUMNS)
 
@@ -240,6 +268,18 @@ def _assert_pg_schema(conn: Any) -> None:
     row = cur.fetchone()
     if not (row and row[0]):
         raise AccountBindingSchemaMissingError(f"Missing table '{_TABLE}'. {_MIGRATION_HINT}")
+    cur.execute(
+        "SELECT 1 FROM information_schema.columns "
+        "WHERE table_schema = current_schema() AND table_name = %s "
+        "AND column_name = 'binding_generation' AND data_type = 'bigint' "
+        "AND is_nullable = 'NO'",
+        (_TABLE,),
+    )
+    if cur.fetchone() is None:
+        raise AccountBindingSchemaMissingError(
+            f"Table '{_TABLE}' lacks required BIGINT NOT NULL column "
+            f"'binding_generation'. {_MIGRATION_HINT}"
+        )
 
 
 def _bootstrap_pg(conn: Any) -> None:
@@ -260,11 +300,36 @@ def _bootstrap_pg(conn: Any) -> None:
             obtained_at TIMESTAMPTZ NOT NULL,
             created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
             updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            binding_generation BIGINT NOT NULL DEFAULT 1,
             CONSTRAINT youtube_account_binding_state_chk CHECK (state IN ('connected', 'degraded')),
             CONSTRAINT youtube_account_binding_connected_reason_chk CHECK (
                 state <> 'connected' OR reason_code IS NULL
+            ),
+            CONSTRAINT youtube_account_binding_generation_chk CHECK (
+                binding_generation >= 1
             )
         )
+        """
+    )
+    cur.execute(
+        f"ALTER TABLE {_TABLE} ADD COLUMN IF NOT EXISTS "
+        "binding_generation BIGINT NOT NULL DEFAULT 1"
+    )
+    cur.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1
+                FROM pg_constraint
+                WHERE conname = 'youtube_account_binding_generation_chk'
+                  AND conrelid = '{_TABLE}'::regclass
+            ) THEN
+                ALTER TABLE {_TABLE}
+                ADD CONSTRAINT youtube_account_binding_generation_chk
+                CHECK (binding_generation >= 1);
+            END IF;
+        END $$;
         """
     )
     cur.execute(
@@ -301,6 +366,7 @@ def _row_to_binding(row: tuple[Any, ...]) -> AccountBinding:
         obtained_at=_iso(values["obtained_at"]) or "",
         created_at=_iso(values["created_at"]) or "",
         updated_at=_iso(values["updated_at"]) or "",
+        binding_generation=int(values["binding_generation"]),
     )
 
 
@@ -324,9 +390,11 @@ class _PgAccountBindingBackend:
                     f"""
                     INSERT INTO {_TABLE} (
                         account_binding_id, provider, provider_channel_id, display_label,
-                        state, reason_code, scopes, obtained_at, created_at, updated_at
+                        state, reason_code, scopes, obtained_at, created_at, updated_at,
+                        binding_generation
                     ) VALUES (
-                        %s, %s, %s, %s, %s, %s, %s::jsonb, %s::timestamptz, %s::timestamptz, %s::timestamptz
+                        %s, %s, %s, %s, %s, %s, %s::jsonb, %s::timestamptz,
+                        %s::timestamptz, %s::timestamptz, %s
                     )
                     """,
                     (
@@ -340,6 +408,7 @@ class _PgAccountBindingBackend:
                         binding.obtained_at,
                         binding.created_at,
                         binding.updated_at,
+                        binding.binding_generation,
                     ),
                 )
             except UniqueViolation as exc:
@@ -388,23 +457,40 @@ class _PgAccountBindingBackend:
         finally:
             conn.close()
 
-    def set_state(self, account_binding_id: str, state: str, reason_code: str | None) -> AccountBinding:
+    def set_state(
+        self,
+        account_binding_id: str,
+        state: str,
+        reason_code: str | None,
+        expected_binding_generation: int | None = None,
+    ) -> AccountBinding:
         conn = _pg_connect()
         try:
             _assert_pg_schema(conn)
             cur = conn.cursor()
+            params: list[Any] = [state, reason_code, _now_iso(), account_binding_id]
+            generation_clause = ""
+            if expected_binding_generation is not None:
+                generation_clause = " AND binding_generation = %s"
+                params.append(expected_binding_generation)
             cur.execute(
-                f"UPDATE {_TABLE} SET state = %s, reason_code = %s, updated_at = %s::timestamptz "
-                "WHERE account_binding_id = %s",
-                (state, reason_code, _now_iso(), account_binding_id),
+                f"UPDATE {_TABLE} SET state = %s, reason_code = %s, "
+                "updated_at = %s::timestamptz, "
+                "binding_generation = binding_generation + 1 "
+                f"WHERE account_binding_id = %s{generation_clause} "
+                f"RETURNING {_COLUMNS_SQL}",
+                tuple(params),
             )
-            if cur.rowcount == 0:
+            row = cur.fetchone()
+            if row is None:
+                if expected_binding_generation is not None:
+                    raise AccountBindingGenerationConflictError(
+                        "account binding generation changed before state persistence"
+                    )
                 raise KeyError(f"no such account binding: {account_binding_id}")
+            return _row_to_binding(tuple(row))
         finally:
             conn.close()
-        result = self.get(account_binding_id)
-        assert result is not None  # just wrote it
-        return result
 
     def delete(self, account_binding_id: str) -> bool:
         conn = _pg_connect()
@@ -458,6 +544,7 @@ class AccountBindingStore:
             obtained_at=obtained_at or now,
             created_at=now,
             updated_at=now,
+            binding_generation=1,
         )
         return self._backend.insert(binding)
 
@@ -471,10 +558,28 @@ class AccountBindingStore:
         return self._backend.list_all()
 
     def set_state(
-        self, account_binding_id: str, *, state: str, reason_code: str | None = None
+        self,
+        account_binding_id: str,
+        *,
+        state: str,
+        reason_code: str | None = None,
+        expected_binding_generation: int | None = None,
     ) -> AccountBinding:
         _validate_state(state, reason_code)
-        return self._backend.set_state(account_binding_id, state, reason_code)
+        if expected_binding_generation is not None and (
+            isinstance(expected_binding_generation, bool)
+            or not isinstance(expected_binding_generation, int)
+            or expected_binding_generation < 1
+        ):
+            raise AccountBindingValidationError(
+                "expected_binding_generation must be an integer >= 1"
+            )
+        return self._backend.set_state(
+            account_binding_id,
+            state,
+            reason_code,
+            expected_binding_generation,
+        )
 
     def delete(self, account_binding_id: str) -> bool:
         return self._backend.delete(account_binding_id)
@@ -482,6 +587,7 @@ class AccountBindingStore:
 
 __all__ = [
     "AccountBinding",
+    "AccountBindingGenerationConflictError",
     "AccountBindingSchemaMissingError",
     "AccountBindingStore",
     "AccountBindingValidationError",

--- a/app/knowledge_acquisition/youtube_oauth.py
+++ b/app/knowledge_acquisition/youtube_oauth.py
@@ -310,6 +310,7 @@ def _canonical_token_from_pending(pending: StoredToken) -> StoredToken:
         promotion_predecessor_refresh_token=None,
         promotion_predecessor_generation=None,
         promotion_display_label=None,
+        promotion_compensation_state=None,
     )
 
 
@@ -618,7 +619,13 @@ def _validate_loopback_redirect_uri(redirect_uri: str) -> None:
     completion both validate. The error excludes the rejected URI because its
     userinfo/query text is untrusted and may contain credential material.
     """
-    valid = isinstance(redirect_uri, str) and redirect_uri == redirect_uri.strip()
+    valid = (
+        isinstance(redirect_uri, str)
+        and redirect_uri == redirect_uri.strip()
+        and "?" not in redirect_uri
+        and "#" not in redirect_uri
+        and not any(ord(character) < 0x20 or ord(character) == 0x7F for character in redirect_uri)
+    )
     try:
         parsed = urlsplit(redirect_uri) if valid else None
         port = parsed.port if parsed is not None else None
@@ -783,7 +790,22 @@ class TokenProvider:
                 # credential and local journaling still fails after preflight,
                 # revoke that returned authority when the provider can confirm
                 # it.  An indeterminate double failure remains fail-closed.
-                if self._compensate_refresh_rotation(pending):
+                compensation_pending = replace(
+                    pending, promotion_compensation_state="pending"
+                )
+                if not self._write_refresh_journal(
+                    pending_id, compensation_pending
+                ):
+                    self._degrade("auth_refresh_durability")
+                    raise OAuthGrantDurabilityError(
+                        "refresh_durability_unavailable"
+                    ) from None
+                if self._compensate_refresh_rotation(compensation_pending):
+                    compensated = replace(
+                        compensation_pending,
+                        promotion_compensation_state="compensated",
+                    )
+                    self._write_refresh_journal(pending_id, compensated)
                     self._delete_refresh_journal(pending_id)
                     self._degrade("auth_revoked")
                     raise AuthDegradedError(
@@ -821,6 +843,32 @@ class TokenProvider:
         pending = self._store.get(pending_id)
         if pending is None:
             return canonical
+        compensation_state = pending.promotion_compensation_state
+        if compensation_state is not None:
+            if compensation_state == "pending":
+                if not self._compensate_refresh_rotation(pending):
+                    self._degrade("auth_refresh_durability")
+                    raise OAuthGrantDurabilityError(
+                        "refresh_durability_unavailable",
+                        pending_grant_id=pending_id,
+                    ) from None
+                compensated = replace(
+                    pending, promotion_compensation_state="compensated"
+                )
+                self._write_refresh_journal(pending_id, compensated)
+                pending = compensated
+            elif compensation_state != "compensated":
+                self._degrade("auth_refresh_durability")
+                raise OAuthGrantDurabilityError(
+                    "refresh_durability_unavailable",
+                    pending_grant_id=pending_id,
+                ) from None
+            self._delete_refresh_journal(pending_id)
+            self._degrade("auth_revoked")
+            raise AuthDegradedError(
+                "auth_revoked",
+                "rotated refresh authority was already provider-compensated",
+            ) from None
         if (
             pending.promotion_target_binding_id != self._binding_id
             or pending.promotion_predecessor_refresh_token is None
@@ -1162,10 +1210,10 @@ class YouTubeAccountBinder:
                 # Resolve an interrupted refresh before asking Google for a
                 # second standing grant. Lock order remains pending grant ->
                 # binding -> aggregate token file.
-                refresh_failure: tuple[str, str | None] | None = None
                 with self._store.binding_lifecycle_lock(
                     connection.reconnect_binding_id
                 ):
+                    refresh_failure: tuple[str, str | None] | None = None
                     try:
                         self._recover_pending_refresh_authority(
                             connection.reconnect_binding_id
@@ -1175,19 +1223,19 @@ class YouTubeAccountBinder:
                             error.reason_code,
                             error.pending_grant_id,
                         )
-                if refresh_failure is not None:
-                    refresh_reason, refresh_pending_id = refresh_failure
-                    self._degrade_refresh_authority(
-                        connection.reconnect_binding_id,
-                        reason_code=self._refresh_degradation_reason(
-                            refresh_reason
-                        ),
-                        pending_grant_id=refresh_pending_id,
-                    )
-                    raise OAuthGrantDurabilityError(
-                        refresh_reason,
-                        pending_grant_id=refresh_pending_id,
-                    ) from None
+                    if refresh_failure is not None:
+                        refresh_reason, refresh_pending_id = refresh_failure
+                        self._degrade_refresh_authority(
+                            connection.reconnect_binding_id,
+                            reason_code=self._refresh_degradation_reason(
+                                refresh_reason
+                            ),
+                            pending_grant_id=refresh_pending_id,
+                        )
+                        raise OAuthGrantDurabilityError(
+                            refresh_reason,
+                            pending_grant_id=refresh_pending_id,
+                        ) from None
             # A standing grant must not be requested until the encryption key,
             # aggregate file, lock directory, and atomic replace path are ready.
             self._store.preflight_write_ready()
@@ -1593,6 +1641,11 @@ class YouTubeAccountBinder:
         pending = self._store.get(pending_id)
         if pending is None:
             return canonical
+        if pending.promotion_compensation_state is not None:
+            raise OAuthGrantDurabilityError(
+                "refresh_durability_unavailable",
+                pending_grant_id=pending_id,
+            ) from None
         if canonical is None or (
             pending.promotion_target_binding_id != binding_id
             or pending.promotion_predecessor_refresh_token is None

--- a/app/knowledge_acquisition/youtube_oauth.py
+++ b/app/knowledge_acquisition/youtube_oauth.py
@@ -30,11 +30,14 @@ reason code, mutates no source cursor, and never records an auth failure as an
 empty-success. Connect, reconnect, refresh, and disconnect serialize each
 binding's credential lifecycle across service instances and processes that
 share its channel token store. Key and atomic-store readiness are proven before
-device polling; an issued grant is encrypted in a pending journal before the
-identity probe or binding work, and an unproven compensation preserves that
-recoverable authority. First-connect binding ids are deterministic per provider
-channel, and an indeterminate binding-create result always preserves the
-encrypted credential so a delayed commit or retry retains authority. Only
+device polling, including cryptographic key/aggregate binding; an issued grant
+is encrypted in a pending journal before the identity probe or binding work,
+and an unproven compensation preserves that recoverable authority. Pending
+promotion/cleanup and retry share one lifecycle-lock order, and retry never
+revokes a grant represented by canonical encrypted authority. First-connect
+binding ids are deterministic per provider channel, and an indeterminate
+binding-create result always preserves the encrypted credential so a delayed
+commit or retry retains authority. Only
 Google's documented ``400 invalid_token`` revoke outcome permits destructive
 local teardown; every other revoke failure preserves retry authority. OAuth
 POSTs never follow redirects. Acquired artifacts are never deleted.
@@ -50,8 +53,8 @@ import os
 import secrets
 import threading
 import uuid
-from contextlib import nullcontext
-from dataclasses import dataclass
+from contextlib import ExitStack, nullcontext
+from dataclasses import dataclass, replace
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, NoReturn
 from urllib.parse import urlencode, urlsplit
@@ -62,9 +65,9 @@ from app.knowledge_acquisition.source_registry import SourceRegistry
 from app.knowledge_acquisition.youtube_account_binding import AccountBinding, AccountBindingStore
 from app.knowledge_acquisition.youtube_token_store import (
     StoredToken,
+    TokenStoreDurabilityError,
     TokenStoreKeyMissingError,
     YouTubeTokenStore,
-    resolve_token_store_key,
 )
 
 _log = logging.getLogger(__name__)
@@ -751,16 +754,78 @@ class YouTubeAccountBinder:
             token = self._store.get(pending_grant_id)
             if token is None:
                 return {"status": "absent", "pending_grant_id": pending_grant_id}
-            if not self._compensate_grant(token):
-                return {"status": "pending", "pending_grant_id": pending_grant_id}
-            try:
-                self._store.delete(pending_grant_id)
-            except Exception:
-                return {
-                    "status": "compensated_pending_cleanup",
-                    "pending_grant_id": pending_grant_id,
+            # A cleanup failure after canonical success leaves two encrypted
+            # copies of one grant. Retry must never revoke the provider grant
+            # while a canonical binding still depends on it. Compose the same
+            # pending -> channel -> binding lock order as promotion, re-read
+            # both sides under those authorities, then clean or compensate.
+            channel_authority = (
+                f"channel:{token.provider_channel_id}"
+                if token.provider_channel_id is not None
+                else None
+            )
+            channel_lifecycle = (
+                self._store.binding_lifecycle_lock(channel_authority)
+                if channel_authority is not None
+                else nullcontext()
+            )
+            with channel_lifecycle:
+                canonical_ids = {
+                    binding_id
+                    for binding_id in self._store.binding_ids()
+                    if binding_id != pending_grant_id
+                    and not binding_id.startswith("pending-youtube-grant-")
                 }
-            return {"status": "compensated", "pending_grant_id": pending_grant_id}
+                if token.provider_channel_id is not None:
+                    canonical_ids.add(_binding_candidate_id(token.provider_channel_id))
+                    visible = self._bindings.get_by_channel_id(token.provider_channel_id)
+                    if visible is not None:
+                        canonical_ids.add(visible.account_binding_id)
+
+                with ExitStack() as lifecycle_stack:
+                    for binding_id in sorted(canonical_ids):
+                        lifecycle_stack.enter_context(
+                            self._store.binding_lifecycle_lock(binding_id)
+                        )
+                    token = self._store.get(pending_grant_id)
+                    if token is None:
+                        return {
+                            "status": "absent",
+                            "pending_grant_id": pending_grant_id,
+                        }
+                    canonical_id = self._canonical_binding_for_pending(
+                        token, canonical_ids
+                    )
+                    if canonical_id is not None:
+                        try:
+                            self._store.delete(pending_grant_id)
+                        except Exception:
+                            return {
+                                "status": "canonical_pending_cleanup",
+                                "pending_grant_id": pending_grant_id,
+                                "binding_id": canonical_id,
+                            }
+                        return {
+                            "status": "canonical",
+                            "pending_grant_id": pending_grant_id,
+                            "binding_id": canonical_id,
+                        }
+                    if not self._compensate_grant(token):
+                        return {
+                            "status": "pending",
+                            "pending_grant_id": pending_grant_id,
+                        }
+                    try:
+                        self._store.delete(pending_grant_id)
+                    except Exception:
+                        return {
+                            "status": "compensated_pending_cleanup",
+                            "pending_grant_id": pending_grant_id,
+                        }
+                    return {
+                        "status": "compensated",
+                        "pending_grant_id": pending_grant_id,
+                    }
 
     def finish_device_connection(self, connection: DeviceConnection) -> dict[str, Any]:
         """Complete one device poll, persist tokens encrypted, bind the account.
@@ -805,6 +870,10 @@ class YouTubeAccountBinder:
                 self._abort_journaled_grant(pending_id, pending_token)
 
             assert identity is not None
+            pending_token = replace(
+                pending_token, provider_channel_id=identity.channel_id
+            )
+            self._bind_pending_grant_identity(pending_id, pending_token)
             binding_error: Exception | None = None
             try:
                 result = self._bind_from_bundle(
@@ -829,48 +898,44 @@ class YouTubeAccountBinder:
                         "grant_pending", pending_grant_id=pending_id
                     )
                 raise binding_error
-            try:
-                self._store.delete(pending_id)
-            except Exception:
-                # The canonical binding token is already durable. A crash or
-                # cleanup failure may leave a duplicate encrypted pending copy,
-                # but cannot remove revocation authority or falsify success.
-                _log.warning(
-                    "youtube oauth: connected binding retained redundant pending grant journal"
-                )
             return result
 
     def _journal_issued_grant(self, pending_id: str, token: StoredToken) -> None:
         """Durably journal a fresh grant or compensate it at the provider."""
-        first_write_failed = False
+        first_write_error: Exception | None = None
         try:
             self._store.put(pending_id, token)
-        except Exception:
-            first_write_failed = True
-        if not first_write_failed:
+        except Exception as error:
+            first_write_error = error
+        if first_write_error is None:
             return
 
         # A store write can durably replace the aggregate and then lose its
         # acknowledgement (including a parent-directory fsync error). Exact
         # encrypted-record readback is success authority: never revoke it.
-        if self._stored_token_matches(pending_id, token):
+        if self._stored_token_matches(
+            pending_id, token, write_error=first_write_error
+        ):
             raise OAuthGrantDurabilityError(
                 "grant_pending", pending_grant_id=pending_id
             )
 
         if self._compensate_grant(token):
+            self._delete_redundant_pending(pending_id)
             raise OAuthGrantDurabilityError("grant_compensated")
 
         # A transient write can fail after the successful readiness probe. If
         # provider compensation is also indeterminate, retry the encrypted
         # journal before returning control so retry authority remains local.
-        retry_write_failed = False
+        retry_write_error: Exception | None = None
         try:
             self._store.put(pending_id, token)
-        except Exception:
-            retry_write_failed = True
-        if retry_write_failed:
-            if self._stored_token_matches(pending_id, token):
+        except Exception as error:
+            retry_write_error = error
+        if retry_write_error is not None:
+            if self._stored_token_matches(
+                pending_id, token, write_error=retry_write_error
+            ):
                 raise OAuthGrantDurabilityError(
                     "grant_pending", pending_grant_id=pending_id
                 )
@@ -878,6 +943,7 @@ class YouTubeAccountBinder:
             # the first. Re-check provider authority once more before declaring
             # the physically unsatisfiable store+provider double outage.
             if self._compensate_grant(token):
+                self._delete_redundant_pending(pending_id)
                 raise OAuthGrantDurabilityError("grant_compensated")
             raise OAuthGrantDurabilityError("grant_durability_unavailable")
         raise OAuthGrantDurabilityError(
@@ -898,13 +964,73 @@ class YouTubeAccountBinder:
             "grant_pending", pending_grant_id=pending_id
         )
 
-    def _stored_token_matches(self, binding_id: str, expected: StoredToken) -> bool:
+    def _bind_pending_grant_identity(
+        self, pending_id: str, token: StoredToken
+    ) -> None:
+        """Durably attach provider identity before canonical promotion.
+
+        If a later canonical cleanup fails, recovery can still recognize the
+        provider/channel relationship even after a subsequent reconnect rotates
+        the refresh token. Failure leaves the earlier unannotated journal as
+        durable revocation authority and stops before canonical mutation.
+        """
+        write_error: Exception | None = None
+        try:
+            self._store.put(pending_id, token)
+        except Exception as error:
+            write_error = error
+        if write_error is None or self._stored_token_matches(
+            pending_id, token, write_error=write_error
+        ):
+            return
+        raise OAuthGrantDurabilityError(
+            "grant_pending", pending_grant_id=pending_id
+        )
+
+    def _stored_token_matches(
+        self,
+        binding_id: str,
+        expected: StoredToken,
+        *,
+        write_error: Exception | None = None,
+    ) -> bool:
         """Exact encrypted-record readback authority for a lost write ack."""
+        if isinstance(write_error, TokenStoreDurabilityError):
+            # Post-replace visibility is not crash durability. Require a new,
+            # successful directory barrier before accepting exact readback.
+            return self._store.confirm_record_durable(binding_id, expected)
         try:
             stored = self._store.get(binding_id)
         except Exception:
             return False
         return stored == expected
+
+    def _delete_redundant_pending(self, pending_id: str) -> None:
+        try:
+            self._store.delete(pending_id)
+        except Exception:
+            _log.warning(
+                "youtube oauth: compensated grant retained redundant encrypted journal"
+            )
+
+    def _canonical_binding_for_pending(
+        self, pending: StoredToken, canonical_ids: set[str]
+    ) -> str | None:
+        """Return canonical local authority that makes revocation unsafe."""
+        for binding_id in sorted(canonical_ids):
+            canonical = self._store.get(binding_id)
+            if canonical is None:
+                continue
+            same_refresh = bool(pending.refresh_token) and hmac.compare_digest(
+                pending.refresh_token, canonical.refresh_token
+            )
+            same_channel = (
+                pending.provider_channel_id is not None
+                and canonical.provider_channel_id == pending.provider_channel_id
+            )
+            if same_refresh or same_channel:
+                return binding_id
+        return None
 
     def _compensate_grant(self, token: StoredToken) -> bool:
         """Return true only when provider revocation is authoritative."""
@@ -951,25 +1077,43 @@ class YouTubeAccountBinder:
             )
             with lifecycle:
                 commit_error: Exception | None = None
+                result: dict[str, Any] | None = None
                 try:
-                    return self._commit_binding(binding, binding_id, identity, token)
+                    result = self._commit_binding(
+                        binding, binding_id, identity, token
+                    )
                 except Exception as error:
                     commit_error = error
-                assert commit_error is not None
-                # This code intentionally runs outside the exception handler:
-                # any later sanitized durability error must not retain a hidden
-                # ``__context__`` reference to a secret-bearing backend error.
-                # Once the target/candidate token is itself durable, the
-                # earlier pending journal is redundant even if binding-row
-                # completion remains indeterminate. If the target write did
-                # not land, retain pending authority for recovery.
-                target_is_durable = self._stored_token_matches(binding_id, token)
-                if target_is_durable:
-                    try:
-                        self._store.delete(pending_id)
-                    except Exception:
-                        pass
-                raise commit_error
+                if commit_error is not None:
+                    # This code intentionally runs outside the exception
+                    # handler: any later sanitized durability error must not
+                    # retain a hidden ``__context__`` reference to a
+                    # secret-bearing backend error. Once the target/candidate
+                    # token is itself durable, the earlier pending journal is
+                    # redundant even if binding-row completion is indeterminate.
+                    target_is_durable = self._stored_token_matches(
+                        binding_id, token, write_error=commit_error
+                    )
+                    if target_is_durable and not isinstance(
+                        commit_error, TokenStoreDurabilityError
+                    ):
+                        try:
+                            self._store.delete(pending_id)
+                        except Exception:
+                            pass
+                    raise commit_error
+                assert result is not None
+                # Promotion and pending cleanup remain inside channel/binding
+                # lifecycle authority. A cleanup failure can leave only a
+                # redundant journal, and the retry path rechecks canonical
+                # authority under the same lock order before any revocation.
+                try:
+                    self._store.delete(pending_id)
+                except Exception:
+                    _log.warning(
+                        "youtube oauth: connected binding retained redundant pending grant journal"
+                    )
+                return result
 
     def _commit_binding(
         self,
@@ -993,7 +1137,9 @@ class YouTubeAccountBinder:
             self._store.put(binding_id, token)
         except Exception as error:
             token_write_error = error
-        if token_write_error is not None and not self._stored_token_matches(binding_id, token):
+        if token_write_error is not None and not self._stored_token_matches(
+            binding_id, token, write_error=token_write_error
+        ):
             raise token_write_error
         if binding is None:
             try:
@@ -1102,13 +1248,12 @@ class YouTubeAccountBinder:
                 {"status": "absent", "reason_code": "auth_missing", "scopes": [], "token_store": "encrypted"}
             )
         state, reason_code = binding.state, binding.reason_code
-        has_token = self._store.has_record(binding_id)
-        if has_token:
-            try:
-                resolve_token_store_key()
-            except TokenStoreKeyMissingError:
-                state, reason_code = "degraded", "auth_key_missing"
-        elif state == "connected":
+        try:
+            token = self._store.get(binding_id)
+        except TokenStoreKeyMissingError:
+            token = None
+            state, reason_code = "degraded", "auth_key_missing"
+        if token is None and state == "connected":
             # Fail closed for any historical/partial connected row that lacks
             # the encrypted authority needed by authenticated operations.
             state, reason_code = "degraded", "auth_missing"

--- a/app/knowledge_acquisition/youtube_oauth.py
+++ b/app/knowledge_acquisition/youtube_oauth.py
@@ -27,8 +27,10 @@ the secret-bearing dataclasses, provider-error sanitization (HTTP status + the
 Auth degradation (INV-YSS-4): a revoked/expired grant or a missing token-store
 key degrades the binding and its dependent authenticated sources with a legible
 reason code, mutates no source cursor, and never records an auth failure as an
-empty-success. Disconnect revokes at the provider, deletes the token record,
-and disables dependent sources -- never an acquired artifact.
+empty-success. Disconnect deletes the token record and disables dependent
+sources only after provider revocation succeeds; a provider failure preserves
+the encrypted credential so revocation remains retryable. Acquired artifacts
+are never deleted.
 """
 
 from __future__ import annotations
@@ -40,6 +42,7 @@ import logging
 import os
 import secrets
 import threading
+import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable
@@ -671,6 +674,7 @@ class YouTubeAccountBinder:
             raise OAuthProviderError(status=200, error_code="missing_refresh_token")
         identity = self._identity(bundle.access_token)
         binding = self._resolve_binding(identity, reconnect_binding_id)
+        binding_id = binding.account_binding_id if binding is not None else str(uuid.uuid4())
         token = StoredToken(
             refresh_token=bundle.refresh_token,
             access_token=bundle.access_token,
@@ -679,7 +683,24 @@ class YouTubeAccountBinder:
             obtained_at=_now_iso(),
             provider_channel_id=identity.channel_id,
         )
-        self._store.put(binding.account_binding_id, token)
+        # Persist the encrypted credential before creating a row whose durable
+        # state claims the account is connected. A missing/invalid key therefore
+        # cannot leave a connected binding without a token record (#3990).
+        self._store.put(binding_id, token)
+        if binding is None:
+            try:
+                binding = self._bindings.create(
+                    provider_channel_id=identity.channel_id,
+                    display_label=identity.channel_title,
+                    scopes=[SCOPE],
+                    account_binding_id=binding_id,
+                )
+            except Exception:
+                # Compensate the private-store write if the non-secret binding
+                # cannot be committed. No orphan credential should survive a
+                # failed initial connect.
+                self._store.delete(binding_id)
+                raise
         if binding.state != "connected" or binding.reason_code is not None:
             binding = self._bindings.set_state(
                 binding.account_binding_id, state="connected", reason_code=None
@@ -695,7 +716,9 @@ class YouTubeAccountBinder:
             }
         )
 
-    def _resolve_binding(self, identity: ChannelIdentity, reconnect_binding_id: str | None) -> AccountBinding:
+    def _resolve_binding(
+        self, identity: ChannelIdentity, reconnect_binding_id: str | None
+    ) -> AccountBinding | None:
         if reconnect_binding_id is not None:
             target = self._bindings.get(reconnect_binding_id)
             if target is None:
@@ -708,11 +731,7 @@ class YouTubeAccountBinder:
         existing = self._bindings.get_by_channel_id(identity.channel_id)
         if existing is not None:
             return existing
-        return self._bindings.create(
-            provider_channel_id=identity.channel_id,
-            display_label=identity.channel_title,
-            scopes=[SCOPE],
-        )
+        return None
 
     # -- status ---------------------------------------------------------------
 
@@ -729,11 +748,16 @@ class YouTubeAccountBinder:
                 {"status": "absent", "reason_code": "auth_missing", "scopes": [], "token_store": "encrypted"}
             )
         state, reason_code = binding.state, binding.reason_code
-        if self._store.has_record(binding_id):
+        has_token = self._store.has_record(binding_id)
+        if has_token:
             try:
                 resolve_token_store_key()
             except TokenStoreKeyMissingError:
                 state, reason_code = "degraded", "auth_key_missing"
+        elif state == "connected":
+            # Fail closed for any historical/partial connected row that lacks
+            # the encrypted authority needed by authenticated operations.
+            state, reason_code = "degraded", "auth_missing"
         return redact(
             {
                 "status": state,
@@ -746,8 +770,12 @@ class YouTubeAccountBinder:
     # -- disconnect -----------------------------------------------------------
 
     def disconnect(self, binding_id: str) -> dict[str, Any]:
-        """Revoke at the provider, delete the token record, disable dependent
-        sources with ``auth_disconnected`` -- and delete no acquired artifacts.
+        """Revoke at the provider, then tear down local authenticated state.
+
+        Provider failure leaves the encrypted token and connected source state
+        intact so the operator can retry revocation. Successful revocation
+        deletes the token record, disables dependent sources with
+        ``auth_disconnected``, and deletes no acquired artifacts.
         """
         binding = self._bindings.get(binding_id)
         if binding is None:
@@ -757,7 +785,17 @@ class YouTubeAccountBinder:
         try:
             token = self._store.get(binding_id)
         except TokenStoreKeyMissingError:
-            token = None  # cannot decrypt to revoke; still tear down locally
+            # The encrypted record is the only recoverable remote-revocation
+            # authority. Preserve it until the key is re-provisioned.
+            return redact(
+                {
+                    "status": "disconnect_failed",
+                    "reason_code": "auth_key_missing",
+                    "revoked": False,
+                    "retryable": True,
+                    "sources_disabled": 0,
+                }
+            )
         if token is not None:
             revocation_token = token.refresh_token or token.access_token or ""
             if revocation_token:
@@ -765,7 +803,19 @@ class YouTubeAccountBinder:
                     self._client.revoke(revocation_token)
                     revoked = True
                 except OAuthProviderError:
-                    revoked = False  # provider revoke failed; local disconnect still proceeds
+                    _log.warning(
+                        "youtube oauth: provider revoke failed; encrypted token preserved "
+                        "for retry (binding %s)",
+                        binding_id,
+                    )
+                    return redact(
+                        {
+                            "status": "disconnect_failed",
+                            "revoked": False,
+                            "retryable": True,
+                            "sources_disabled": 0,
+                        }
+                    )
 
         self._store.delete(binding_id)
         self._bindings.set_state(binding_id, state="degraded", reason_code="auth_disconnected")

--- a/app/knowledge_acquisition/youtube_oauth.py
+++ b/app/knowledge_acquisition/youtube_oauth.py
@@ -718,6 +718,7 @@ class TokenProvider:
             # runtime processes (#3990 review repair).
             with self._store.binding_lifecycle_lock(self._binding_id):
                 token = self._read_token()
+                self._reconcile_terminal_binding()
                 token = self._recover_pending_refresh(token)
                 self._require_connected_binding()
                 if self._is_fresh(token):
@@ -778,6 +779,37 @@ class TokenProvider:
             "account binding lacks connected authority",
         ) from None
 
+    def _reconcile_terminal_binding(self) -> None:
+        """Repair terminal source truth before any journal promotion or cleanup."""
+        terminal_reason = self._terminal_binding_reason()
+        if terminal_reason is None:
+            return
+        pending_id = _pending_refresh_id(self._binding_id)
+        read_failed = False
+        pending: StoredToken | None = None
+        try:
+            pending = self._store.get(pending_id)
+        except Exception:
+            read_failed = True
+        if read_failed:
+            raise OAuthGrantDurabilityError(
+                "refresh_durability_unavailable",
+                pending_grant_id=pending_id,
+            ) from None
+        if (
+            pending is not None
+            and pending.promotion_compensation_state == "compensated"
+        ):
+            self._converge_compensated_refresh(
+                pending_id, terminal_reason=terminal_reason
+            )
+        else:
+            self._degrade(terminal_reason)
+        raise AuthDegradedError(
+            terminal_reason,
+            "account binding authority is locally disabled",
+        ) from None
+
     def _is_fresh(self, token: StoredToken) -> bool:
         if not token.access_token or not token.expires_at:
             return False
@@ -794,11 +826,16 @@ class TokenProvider:
         # The provider call can return fresh authority. Prove the encrypted
         # aggregate and its crash barrier before crossing that boundary.
         self._store.preflight_write_ready()
+        degraded_error: AuthDegradedError | None = None
+        bundle: TokenBundle | None = None
         try:
             bundle = self._client.refresh(token.refresh_token)
-        except AuthDegradedError as exc:
-            self._degrade(exc.reason_code)
-            raise
+        except AuthDegradedError as error:
+            degraded_error = error
+        if degraded_error is not None:
+            self._degrade(degraded_error.reason_code)
+            raise degraded_error from None
+        assert bundle is not None
         rotated_refresh = (
             bundle.refresh_token
             if isinstance(bundle.refresh_token, str)
@@ -850,8 +887,7 @@ class TokenProvider:
                         promotion_compensation_state="compensated",
                     )
                     self._write_refresh_journal(pending_id, compensated)
-                    self._degrade("auth_revoked")
-                    self._delete_refresh_journal(pending_id)
+                    self._converge_compensated_refresh(pending_id)
                     raise AuthDegradedError(
                         "auth_revoked",
                         "rotated refresh authority was revoked after local durability failure",
@@ -907,8 +943,7 @@ class TokenProvider:
                     "refresh_durability_unavailable",
                     pending_grant_id=pending_id,
                 ) from None
-            self._degrade("auth_revoked")
-            self._delete_refresh_journal(pending_id)
+            self._converge_compensated_refresh(pending_id)
             raise AuthDegradedError(
                 "auth_revoked",
                 "rotated refresh authority was already provider-compensated",
@@ -1009,20 +1044,51 @@ class TokenProvider:
         except Exception:
             return False
 
+    def _converge_compensated_refresh(
+        self,
+        pending_id: str,
+        *,
+        terminal_reason: str = "auth_revoked",
+    ) -> None:
+        """Persist terminal binding/source truth before deleting compensation state."""
+        persistence_failed = False
+        try:
+            self._degrade(terminal_reason)
+        except OAuthGrantDurabilityError:
+            persistence_failed = True
+        if persistence_failed:
+            raise OAuthGrantDurabilityError(
+                "refresh_compensated",
+                pending_grant_id=pending_id,
+            ) from None
+        self._delete_refresh_journal(pending_id)
+
     def _degrade(self, reason_code: str) -> None:
         """Stamp the reason on the binding + dependent sources; no cursor touched."""
-        binding = self._bindings.get(self._binding_id)
-        effective_reason = reason_code
-        if binding is not None:
-            if binding.reason_code in {"auth_disconnected", "auth_revoked"}:
-                effective_reason = binding.reason_code
-            else:
-                self._bindings.set_state(self._binding_id, state="degraded", reason_code=reason_code)
-        if self._registry is not None:
-            for source in self._registry.list_for_account(self._binding_id):
-                self._registry.record_source_degradation(
-                    source.binding_id, reason_code=effective_reason
-                )
+        persistence_failed = False
+        try:
+            binding = self._bindings.get(self._binding_id)
+            effective_reason = reason_code
+            if binding is not None:
+                if binding.reason_code in {"auth_disconnected", "auth_revoked"}:
+                    effective_reason = binding.reason_code
+                else:
+                    self._bindings.set_state(
+                        self._binding_id,
+                        state="degraded",
+                        reason_code=reason_code,
+                    )
+            if self._registry is not None:
+                for source in self._registry.list_for_account(self._binding_id):
+                    self._registry.record_source_degradation(
+                        source.binding_id, reason_code=effective_reason
+                    )
+        except Exception:
+            persistence_failed = True
+        if persistence_failed:
+            raise OAuthGrantDurabilityError(
+                "refresh_durability_unavailable"
+            ) from None
 
     def _clear_degradation(self) -> None:
         binding = self._bindings.get(self._binding_id)
@@ -1084,6 +1150,7 @@ class YouTubeAccountBinder:
         *,
         reason_code: str,
         pending_grant_id: str | None,
+        failure_reason: str = "refresh_durability_unavailable",
     ) -> None:
         """Persist fail-closed refresh state on binding and dependent sources."""
         failed = False
@@ -1100,7 +1167,7 @@ class YouTubeAccountBinder:
             failed = True
         if failed:
             raise OAuthGrantDurabilityError(
-                "refresh_durability_unavailable",
+                failure_reason,
                 pending_grant_id=pending_grant_id,
             ) from None
 
@@ -1731,6 +1798,7 @@ class YouTubeAccountBinder:
                 binding_id,
                 reason_code="auth_revoked",
                 pending_grant_id=pending_id,
+                failure_reason="refresh_compensated",
             )
             try:
                 self._store.delete(pending_id)

--- a/app/knowledge_acquisition/youtube_oauth.py
+++ b/app/knowledge_acquisition/youtube_oauth.py
@@ -94,7 +94,17 @@ DEVICE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
 
 _DEFAULT_TIMEOUT_SECONDS = 30.0
 _ACCESS_TOKEN_SKEW_SECONDS = 60
-
+_TERMINAL_AUTH_REASON_CODES = frozenset({"auth_disconnected", "auth_revoked"})
+_RECOVERABLE_AUTH_REASON_CODES = frozenset(
+    {
+        "auth_missing",
+        "auth_key_missing",
+        "auth_expired",
+        "auth_refresh_pending",
+        "auth_refresh_conflict",
+        "auth_refresh_durability",
+    }
+)
 # Defense-in-depth redaction: a value is redacted when its key name carries a
 # secret marker, EXCEPT for these documented non-secret mode fields whose names
 # merely contain such a substring.
@@ -565,6 +575,8 @@ class OAuthClient:
 
     def _post(self, url: str, data: dict[str, str]) -> dict[str, Any]:
         self._guard_host(url)
+        response: httpx.Response | None = None
+        transport_error_code: str | None = None
         try:
             response = self._http.post(
                 url,
@@ -575,8 +587,15 @@ class OAuthClient:
             )
         except httpx.HTTPError as exc:
             # Sanitized: exception class only -- never a URL (may carry query
-            # secrets) or response body (INV-YSS-5).
-            raise OAuthProviderError(status=0, error_code=type(exc).__name__) from None
+            # secrets) or response body (INV-YSS-5). Raise only after leaving
+            # this handler: ``from None`` suppresses display but would retain
+            # the request-bearing exception in ``__context__`` here.
+            transport_error_code = type(exc).__name__
+        if transport_error_code is not None:
+            raise OAuthProviderError(
+                status=0, error_code=transport_error_code
+            ) from None
+        assert response is not None
         if response.status_code // 100 != 2:
             raise OAuthProviderError(status=response.status_code, error_code=_safe_error_code(response))
         if not response.content:
@@ -667,7 +686,9 @@ class OAuthClient:
             if exc.error_code == "invalid_grant":
                 raise AuthDegradedError("auth_revoked", "refresh token rejected (invalid_grant)") from None
             raise
-        return _bundle_from_response(data)
+        return _bundle_from_response(
+            data, preserve_refresh_on_incomplete_access=True
+        )
 
     def revoke(self, token: str) -> None:
         self._post(REVOKE_URL, {"token": token})
@@ -796,6 +817,7 @@ class TokenProvider:
                 token = self._read_token()
                 self._reconcile_terminal_binding()
                 token = self._recover_pending_refresh(token)
+                self._recover_restored_key_degradation()
                 self._require_connected_binding()
                 if self._is_fresh(token):
                     return token.access_token  # type: ignore[return-value]
@@ -826,10 +848,10 @@ class TokenProvider:
 
     def _terminal_binding_reason(self) -> str | None:
         binding = self._bindings.get(self._binding_id)
-        if binding is not None and binding.reason_code in {
-            "auth_disconnected",
-            "auth_revoked",
-        }:
+        if (
+            binding is not None
+            and binding.reason_code in _TERMINAL_AUTH_REASON_CODES
+        ):
             return binding.reason_code
         return None
 
@@ -992,6 +1014,23 @@ class TokenProvider:
                     "refresh_durability_unavailable"
                 ) from None
 
+            if not bundle.access_token:
+                # A malformed 2xx response can still rotate the standing
+                # revocation authority. The encrypted journal now owns
+                # recovery; never overwrite canonical state with an unusable
+                # access token or discard the rotated credential.
+                self._degrade("auth_refresh_pending")
+                raise OAuthGrantDurabilityError(
+                    "refresh_pending", pending_grant_id=pending_id
+                ) from None
+
+        if not bundle.access_token:
+            # No new standing authority exists, so preserve the unchanged
+            # canonical credential and reject the incomplete response.
+            raise OAuthProviderError(
+                status=200, error_code="missing_access_token"
+            ) from None
+
         write_error: Exception | None = None
         try:
             self._store.put(self._binding_id, refreshed)
@@ -1007,9 +1046,12 @@ class TokenProvider:
                 ) from None
             self._degrade("auth_refresh_durability")
             raise OAuthGrantDurabilityError("refresh_durability_unavailable") from None
+        self._clear_degradation(
+            pending_grant_id=pending_id,
+            expected_reason_codes=_RECOVERABLE_AUTH_REASON_CODES,
+        )
         if pending_id is not None:
             self._delete_refresh_journal(pending_id)
-        self._clear_degradation()
         return bundle.access_token
 
     def _recover_pending_refresh(self, canonical: StoredToken) -> StoredToken:
@@ -1061,8 +1103,11 @@ class TokenProvider:
         if _same_refresh_authority(pending, canonical):
             # Canonical promotion already landed (possibly with a lost ack), or
             # a later access-only refresh retained the same standing grant.
+            self._clear_degradation(
+                pending_grant_id=pending_id,
+                expected_reason_codes=_RECOVERABLE_AUTH_REASON_CODES,
+            )
             self._delete_refresh_journal(pending_id)
-            self._clear_degradation()
             return canonical
 
         predecessor_matches = (
@@ -1095,8 +1140,11 @@ class TokenProvider:
             raise OAuthGrantDurabilityError(
                 "refresh_pending", pending_grant_id=pending_id
             ) from None
+        self._clear_degradation(
+            pending_grant_id=pending_id,
+            expected_reason_codes=_RECOVERABLE_AUTH_REASON_CODES,
+        )
         self._delete_refresh_journal(pending_id)
-        self._clear_degradation()
         return promoted
 
     def _write_refresh_journal(self, pending_id: str, pending: StoredToken) -> bool:
@@ -1170,7 +1218,7 @@ class TokenProvider:
             binding = self._bindings.get(self._binding_id)
             effective_reason = reason_code
             if binding is not None:
-                if binding.reason_code in {"auth_disconnected", "auth_revoked"}:
+                if binding.reason_code in _TERMINAL_AUTH_REASON_CODES:
                     effective_reason = binding.reason_code
                 elif binding.state != "degraded" or binding.reason_code != reason_code:
                     self._bindings.set_state(
@@ -1190,14 +1238,107 @@ class TokenProvider:
                 "refresh_durability_unavailable"
             ) from None
 
-    def _clear_degradation(self) -> None:
+    def _recover_restored_key_degradation(self) -> None:
+        """Recover only exact-key, non-terminal degradation under the lock."""
         binding = self._bindings.get(self._binding_id)
+        if binding is None:
+            return
+        source_recovery_pending = False
         if (
-            binding is not None
-            and binding.state != "connected"
-            and binding.reason_code not in {"auth_disconnected", "auth_revoked"}
+            binding.state == "connected"
+            and binding.reason_code is None
+            and self._registry is not None
         ):
-            self._bindings.set_state(self._binding_id, state="connected", reason_code=None)
+            source_recovery_pending = any(
+                isinstance(source.last_error, dict)
+                and source.last_error.get("reason_code") == "auth_key_missing"
+                for source in self._registry.list_for_account(self._binding_id)
+            )
+        if binding.reason_code == "auth_key_missing" or source_recovery_pending:
+            self._clear_degradation(
+                pending_grant_id=None,
+                expected_reason_codes=frozenset({"auth_key_missing"}),
+            )
+
+    def _clear_degradation(
+        self,
+        *,
+        pending_grant_id: str | None,
+        expected_reason_codes: frozenset[str],
+    ) -> None:
+        """Durably converge binding and source truth before journal cleanup."""
+        binding = self._bindings.get(self._binding_id)
+        if binding is None:
+            raise OAuthGrantDurabilityError(
+                "refresh_durability_unavailable",
+                pending_grant_id=pending_grant_id,
+            ) from None
+        if binding.reason_code in _TERMINAL_AUTH_REASON_CODES:
+            self._degrade(binding.reason_code)
+            raise AuthDegradedError(
+                binding.reason_code,
+                "terminal account binding authority cannot be recovered",
+            ) from None
+
+        state_write_failed = False
+        generation_conflict = False
+        if binding.state != "connected" or binding.reason_code is not None:
+            if binding.reason_code not in expected_reason_codes:
+                raise OAuthGrantDurabilityError(
+                    "refresh_durability_unavailable",
+                    pending_grant_id=pending_grant_id,
+                ) from None
+            try:
+                self._bindings.set_state(
+                    self._binding_id,
+                    state="connected",
+                    reason_code=None,
+                    expected_binding_generation=binding.binding_generation,
+                )
+            except AccountBindingGenerationConflictError:
+                generation_conflict = True
+            except Exception:
+                state_write_failed = True
+
+        if generation_conflict:
+            current = self._bindings.get(self._binding_id)
+            if (
+                current is not None
+                and current.reason_code in _TERMINAL_AUTH_REASON_CODES
+            ):
+                self._degrade(current.reason_code)
+                raise AuthDegradedError(
+                    current.reason_code,
+                    "terminal account binding authority won recovery",
+                ) from None
+            if (
+                current is None
+                or current.state != "connected"
+                or current.reason_code is not None
+            ):
+                state_write_failed = True
+
+        if state_write_failed:
+            raise OAuthGrantDurabilityError(
+                "refresh_durability_unavailable",
+                pending_grant_id=pending_grant_id,
+            ) from None
+
+        source_write_failed = False
+        if self._registry is not None:
+            try:
+                for source in self._registry.list_for_account(self._binding_id):
+                    self._registry.clear_source_degradation(
+                        source.binding_id,
+                        expected_reason_codes=expected_reason_codes,
+                    )
+            except Exception:
+                source_write_failed = True
+        if source_write_failed:
+            raise OAuthGrantDurabilityError(
+                "refresh_durability_unavailable",
+                pending_grant_id=pending_grant_id,
+            ) from None
 
 
 # --- Account binding manager -------------------------------------------------

--- a/app/knowledge_acquisition/youtube_oauth.py
+++ b/app/knowledge_acquisition/youtube_oauth.py
@@ -142,6 +142,10 @@ class OAuthStateMismatchError(RuntimeError):
     """Loopback ``state`` did not match -- refuse to exchange the code."""
 
 
+class InvalidLoopbackRedirectURIError(ValueError):
+    """Loopback redirect is outside the exact installed-app boundary."""
+
+
 class DisallowedOAuthHostError(RuntimeError):
     """Refused OAuth egress to a non-allowlisted host (SSRF guard)."""
 
@@ -607,6 +611,36 @@ def _pkce_pair() -> tuple[str, str]:
     return verifier, challenge
 
 
+def _validate_loopback_redirect_uri(redirect_uri: str) -> None:
+    """Admit only ``http://127.0.0.1:<ephemeral-port>/<path>``.
+
+    Flow handles can cross a serialization boundary, so creation and
+    completion both validate. The error excludes the rejected URI because its
+    userinfo/query text is untrusted and may contain credential material.
+    """
+    valid = isinstance(redirect_uri, str) and redirect_uri == redirect_uri.strip()
+    try:
+        parsed = urlsplit(redirect_uri) if valid else None
+        port = parsed.port if parsed is not None else None
+    except ValueError:
+        parsed = None
+        port = None
+    if (
+        parsed is None
+        or parsed.scheme != "http"
+        or parsed.hostname != "127.0.0.1"
+        or parsed.username is not None
+        or parsed.password is not None
+        or port is None
+        or not 1 <= port <= 65535
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise InvalidLoopbackRedirectURIError(
+            "OAuth loopback redirect must use exact http 127.0.0.1 with an explicit valid port and no userinfo, query, or fragment"
+        )
+
+
 def start_loopback_flow(client: OAuthClient, *, redirect_uri: str) -> LoopbackFlow:
     """Build the loopback authorization request: URL + ``state`` + PKCE verifier.
 
@@ -614,6 +648,7 @@ def start_loopback_flow(client: OAuthClient, *, redirect_uri: str) -> LoopbackFl
     (BIND spec); the caller opens ``authorization_url`` and later hands the
     redirect back to :func:`complete_loopback_flow`.
     """
+    _validate_loopback_redirect_uri(redirect_uri)
     state = secrets.token_urlsafe(32)
     verifier, challenge = _pkce_pair()
     url = client.build_authorization_url(redirect_uri=redirect_uri, state=state, code_challenge=challenge)
@@ -628,6 +663,7 @@ def complete_loopback_flow(
     A tampered/mismatched ``state`` is refused with :class:`OAuthStateMismatchError`
     before any token exchange happens.
     """
+    _validate_loopback_redirect_uri(flow.redirect_uri)
     if not hmac.compare_digest(returned_state, flow.state):
         raise OAuthStateMismatchError(
             "OAuth state mismatch: refusing to exchange the authorization code (possible CSRF/tamper)"
@@ -935,6 +971,39 @@ class YouTubeAccountBinder:
             raise KeyError(f"no such account binding: {binding_id}")
         return DeviceConnection(handle=self._client.start_device_flow(), reconnect_binding_id=binding_id)
 
+    @staticmethod
+    def _refresh_degradation_reason(reason_code: str) -> str:
+        return {
+            "refresh_pending": "auth_refresh_pending",
+            "refresh_conflict": "auth_refresh_conflict",
+        }.get(reason_code, "auth_refresh_durability")
+
+    def _degrade_refresh_authority(
+        self,
+        binding_id: str,
+        *,
+        reason_code: str,
+        pending_grant_id: str | None,
+    ) -> None:
+        """Persist fail-closed refresh state on binding and dependent sources."""
+        failed = False
+        try:
+            self._bindings.set_state(
+                binding_id, state="degraded", reason_code=reason_code
+            )
+            if self._registry is not None:
+                for source in self._registry.list_for_account(binding_id):
+                    self._registry.record_source_degradation(
+                        source.binding_id, reason_code=reason_code
+                    )
+        except Exception:
+            failed = True
+        if failed:
+            raise OAuthGrantDurabilityError(
+                "refresh_durability_unavailable",
+                pending_grant_id=pending_grant_id,
+            ) from None
+
     def retry_pending_grant_compensation(self, pending_grant_id: str) -> dict[str, Any]:
         """Retry revocation for one encrypted pre-binding grant journal."""
         if not pending_grant_id.startswith("pending-youtube-grant-"):
@@ -1015,6 +1084,22 @@ class YouTubeAccountBinder:
                                     ),
                                 }
                             canonical_binding = recovered_binding
+                        if (
+                            canonical_binding.state != "connected"
+                            or canonical_binding.reason_code is not None
+                        ):
+                            try:
+                                canonical_binding = self._bindings.set_state(
+                                    canonical_id,
+                                    state="connected",
+                                    reason_code=None,
+                                )
+                            except Exception:
+                                return {
+                                    "status": "binding_pending",
+                                    "pending_grant_id": pending_grant_id,
+                                    "binding_id": canonical_id,
+                                }
                         try:
                             self._store.delete(pending_grant_id)
                         except Exception:
@@ -1077,12 +1162,32 @@ class YouTubeAccountBinder:
                 # Resolve an interrupted refresh before asking Google for a
                 # second standing grant. Lock order remains pending grant ->
                 # binding -> aggregate token file.
+                refresh_failure: tuple[str, str | None] | None = None
                 with self._store.binding_lifecycle_lock(
                     connection.reconnect_binding_id
                 ):
-                    self._recover_pending_refresh_authority(
-                        connection.reconnect_binding_id
+                    try:
+                        self._recover_pending_refresh_authority(
+                            connection.reconnect_binding_id
+                        )
+                    except OAuthGrantDurabilityError as error:
+                        refresh_failure = (
+                            error.reason_code,
+                            error.pending_grant_id,
+                        )
+                if refresh_failure is not None:
+                    refresh_reason, refresh_pending_id = refresh_failure
+                    self._degrade_refresh_authority(
+                        connection.reconnect_binding_id,
+                        reason_code=self._refresh_degradation_reason(
+                            refresh_reason
+                        ),
+                        pending_grant_id=refresh_pending_id,
                     )
+                    raise OAuthGrantDurabilityError(
+                        refresh_reason,
+                        pending_grant_id=refresh_pending_id,
+                    ) from None
             # A standing grant must not be requested until the encryption key,
             # aggregate file, lock directory, and atomic replace path are ready.
             self._store.preflight_write_ready()
@@ -1653,23 +1758,11 @@ class YouTubeAccountBinder:
                     # This code intentionally runs outside the exception
                     # handler: any later sanitized durability error must not
                     # retain a hidden ``__context__`` reference to a
-                    # secret-bearing backend error. Once the target/candidate
-                    # token is itself durable, the earlier pending journal is
-                    # redundant only after binding-row completion is proven.
-                    # An indeterminate first-connect create must retain its
-                    # per-attempt handle even though the deterministic candidate
-                    # ciphertext is visible.
-                    if binding is not None:
-                        target_is_durable = self._stored_token_matches(
-                            binding_id, token, write_error=commit_error
-                        )
-                        if target_is_durable and not isinstance(
-                            commit_error, TokenStoreDurabilityError
-                        ):
-                            try:
-                                self._store.delete(pending_id)
-                            except Exception:
-                                pass
+                    # secret-bearing backend error. Canonical ciphertext alone
+                    # is not a completed reconnect: the binding row must also
+                    # durably converge to connected. Preserve the per-attempt
+                    # pending journal on every commit failure so retry can
+                    # prove and finish both halves before cleanup.
                     raise commit_error
                 assert result is not None
                 # Promotion and pending cleanup remain inside channel/binding
@@ -1887,13 +1980,16 @@ class YouTubeAccountBinder:
                 # Never revoke an older canonical credential while a rotated
                 # refresh response remains pending or conflicts with a proven
                 # newer generation.
+                reason_code = self._refresh_degradation_reason(error.reason_code)
+                self._degrade_refresh_authority(
+                    binding_id,
+                    reason_code=reason_code,
+                    pending_grant_id=error.pending_grant_id,
+                )
                 return redact(
                     {
                         "status": "disconnect_failed",
-                        "reason_code": {
-                            "refresh_pending": "auth_refresh_pending",
-                            "refresh_conflict": "auth_refresh_conflict",
-                        }.get(error.reason_code, "auth_refresh_durability"),
+                        "reason_code": reason_code,
                         "revoked": False,
                         "retryable": True,
                         "sources_disabled": 0,
@@ -1964,6 +2060,7 @@ __all__ = [
     "DeviceFlowHandle",
     "DisallowedOAuthHostError",
     "IdentityProbe",
+    "InvalidLoopbackRedirectURIError",
     "LoopbackFlow",
     "OAuthClient",
     "OAuthClientCredentialsMissingError",

--- a/app/knowledge_acquisition/youtube_oauth.py
+++ b/app/knowledge_acquisition/youtube_oauth.py
@@ -727,12 +727,30 @@ class TokenProvider:
         try:
             token = self._store.get(self._binding_id)
         except TokenStoreKeyMissingError:
+            terminal_reason = self._terminal_binding_reason()
+            if terminal_reason is not None:
+                raise AuthDegradedError(
+                    terminal_reason, "account binding is disconnected"
+                ) from None
             self._degrade("auth_key_missing")
             raise AuthDegradedError("auth_key_missing", "token store key is not provisioned") from None
         if token is None:
+            terminal_reason = self._terminal_binding_reason()
+            if terminal_reason is not None:
+                raise AuthDegradedError(
+                    terminal_reason, "account binding is disconnected"
+                ) from None
             self._degrade("auth_missing")
             raise AuthDegradedError("auth_missing", "no token stored for this binding")
         return token
+
+    def _terminal_binding_reason(self) -> str | None:
+        if self._bindings is None:
+            return None
+        binding = self._bindings.get(self._binding_id)
+        if binding is not None and binding.reason_code == "auth_disconnected":
+            return "auth_disconnected"
+        return None
 
     def _is_fresh(self, token: StoredToken) -> bool:
         if not token.access_token or not token.expires_at:
@@ -806,8 +824,8 @@ class TokenProvider:
                         promotion_compensation_state="compensated",
                     )
                     self._write_refresh_journal(pending_id, compensated)
-                    self._delete_refresh_journal(pending_id)
                     self._degrade("auth_revoked")
+                    self._delete_refresh_journal(pending_id)
                     raise AuthDegradedError(
                         "auth_revoked",
                         "rotated refresh authority was revoked after local durability failure",
@@ -863,8 +881,8 @@ class TokenProvider:
                     "refresh_durability_unavailable",
                     pending_grant_id=pending_id,
                 ) from None
-            self._delete_refresh_journal(pending_id)
             self._degrade("auth_revoked")
+            self._delete_refresh_journal(pending_id)
             raise AuthDegradedError(
                 "auth_revoked",
                 "rotated refresh authority was already provider-compensated",
@@ -970,6 +988,8 @@ class TokenProvider:
         if self._bindings is not None:
             binding = self._bindings.get(self._binding_id)
             if binding is not None:
+                if binding.reason_code == "auth_disconnected":
+                    return
                 self._bindings.set_state(self._binding_id, state="degraded", reason_code=reason_code)
         if self._registry is not None:
             for source in self._registry.list_for_account(self._binding_id):
@@ -1024,6 +1044,7 @@ class YouTubeAccountBinder:
         return {
             "refresh_pending": "auth_refresh_pending",
             "refresh_conflict": "auth_refresh_conflict",
+            "refresh_compensated": "auth_revoked",
         }.get(reason_code, "auth_refresh_durability")
 
     def _degrade_refresh_authority(
@@ -1641,6 +1662,15 @@ class YouTubeAccountBinder:
         pending = self._store.get(pending_id)
         if pending is None:
             return canonical
+        if pending.promotion_compensation_state == "compensated":
+            try:
+                self._store.delete(pending_id)
+            except Exception:
+                raise OAuthGrantDurabilityError(
+                    "refresh_compensated",
+                    pending_grant_id=pending_id,
+                ) from None
+            return canonical
         if pending.promotion_compensation_state is not None:
             raise OAuthGrantDurabilityError(
                 "refresh_durability_unavailable",
@@ -1980,7 +2010,12 @@ class YouTubeAccountBinder:
             # A provider response may have rotated the standing credential
             # while canonical promotion is incomplete. The old canonical row
             # is not sufficient authority for a connected status.
-            state, reason_code = "degraded", "auth_refresh_pending"
+            if pending_refresh.promotion_compensation_state == "compensated":
+                state, reason_code = "degraded", "auth_revoked"
+            elif pending_refresh.promotion_compensation_state is not None:
+                state, reason_code = "degraded", "auth_refresh_durability"
+            else:
+                state, reason_code = "degraded", "auth_refresh_pending"
         if token is None and state == "connected":
             # Fail closed for any historical/partial connected row that lacks
             # the encrypted authority needed by authenticated operations.

--- a/app/knowledge_acquisition/youtube_oauth.py
+++ b/app/knowledge_acquisition/youtube_oauth.py
@@ -27,10 +27,12 @@ the secret-bearing dataclasses, provider-error sanitization (HTTP status + the
 Auth degradation (INV-YSS-4): a revoked/expired grant or a missing token-store
 key degrades the binding and its dependent authenticated sources with a legible
 reason code, mutates no source cursor, and never records an auth failure as an
-empty-success. Disconnect deletes the token record and disables dependent
-sources only after provider revocation succeeds; a provider failure preserves
-the encrypted credential so revocation remains retryable. Acquired artifacts
-are never deleted.
+empty-success. Connect, reconnect, refresh, and disconnect serialize each
+binding's credential lifecycle across service instances and processes that
+share its channel token store. A retryable revoke failure preserves the
+encrypted credential and source state; a permanent provider rejection completes
+local teardown because the old grant no longer provides useful retry authority.
+Acquired artifacts are never deleted.
 """
 
 from __future__ import annotations
@@ -206,6 +208,11 @@ def _safe_error_code(response: httpx.Response) -> str | None:
         if isinstance(error, str):
             return error
     return None
+
+
+def _retryable_revoke_error(error: OAuthProviderError) -> bool:
+    """Whether provider revocation can safely be retried with this token."""
+    return error.status == 0 or error.status in {408, 429} or 500 <= error.status < 600
 
 
 def _now_iso() -> str:
@@ -550,14 +557,15 @@ class TokenProvider:
         self._lock = threading.Lock()
 
     def get_access_token(self) -> str:
-        token = self._read_token()
-        if self._is_fresh(token):
-            return token.access_token  # type: ignore[return-value]
         with self._lock:
-            token = self._read_token()
-            if self._is_fresh(token):
-                return token.access_token  # type: ignore[return-value]
-            return self._refresh(token)
+            # This file-backed binding lock composes the single-flight refresh
+            # with connect/reconnect/disconnect across service instances and
+            # runtime processes (#3990 review repair).
+            with self._store.binding_lifecycle_lock(self._binding_id):
+                token = self._read_token()
+                if self._is_fresh(token):
+                    return token.access_token  # type: ignore[return-value]
+                return self._refresh(token)
 
     def _read_token(self) -> StoredToken:
         try:
@@ -683,38 +691,48 @@ class YouTubeAccountBinder:
             obtained_at=_now_iso(),
             provider_channel_id=identity.channel_id,
         )
-        # Persist the encrypted credential before creating a row whose durable
-        # state claims the account is connected. A missing/invalid key therefore
-        # cannot leave a connected binding without a token record (#3990).
-        self._store.put(binding_id, token)
-        if binding is None:
-            try:
-                binding = self._bindings.create(
-                    provider_channel_id=identity.channel_id,
-                    display_label=identity.channel_title,
-                    scopes=[SCOPE],
-                    account_binding_id=binding_id,
+        with self._store.binding_lifecycle_lock(binding_id):
+            if binding is not None:
+                # The binding object was resolved before waiting for the
+                # cross-instance lock. Re-read it inside the critical section
+                # so a completed disconnect cannot leave reconnect acting on
+                # stale ``connected`` state.
+                current_binding = self._bindings.get(binding_id)
+                if current_binding is None:
+                    raise KeyError(f"no such account binding: {binding_id}")
+                binding = current_binding
+            # Persist the encrypted credential before creating a row whose durable
+            # state claims the account is connected. A missing/invalid key therefore
+            # cannot leave a connected binding without a token record (#3990).
+            self._store.put(binding_id, token)
+            if binding is None:
+                try:
+                    binding = self._bindings.create(
+                        provider_channel_id=identity.channel_id,
+                        display_label=identity.channel_title,
+                        scopes=[SCOPE],
+                        account_binding_id=binding_id,
+                    )
+                except Exception:
+                    # Compensate the private-store write if the non-secret binding
+                    # cannot be committed. No orphan credential should survive a
+                    # failed initial connect.
+                    self._store.delete(binding_id)
+                    raise
+            if binding.state != "connected" or binding.reason_code is not None:
+                binding = self._bindings.set_state(
+                    binding.account_binding_id, state="connected", reason_code=None
                 )
-            except Exception:
-                # Compensate the private-store write if the non-secret binding
-                # cannot be committed. No orphan credential should survive a
-                # failed initial connect.
-                self._store.delete(binding_id)
-                raise
-        if binding.state != "connected" or binding.reason_code is not None:
-            binding = self._bindings.set_state(
-                binding.account_binding_id, state="connected", reason_code=None
+            _log.info("youtube oauth: account connected (binding %s)", binding.account_binding_id)
+            return redact(
+                {
+                    "status": "connected",
+                    "account": {
+                        "binding_id": binding.account_binding_id,
+                        "channel_title": binding.display_label,
+                    },
+                }
             )
-        _log.info("youtube oauth: account connected (binding %s)", binding.account_binding_id)
-        return redact(
-            {
-                "status": "connected",
-                "account": {
-                    "binding_id": binding.account_binding_id,
-                    "channel_title": binding.display_label,
-                },
-            }
-        )
 
     def _resolve_binding(
         self, identity: ChannelIdentity, reconnect_binding_id: str | None
@@ -772,64 +790,81 @@ class YouTubeAccountBinder:
     def disconnect(self, binding_id: str) -> dict[str, Any]:
         """Revoke at the provider, then tear down local authenticated state.
 
-        Provider failure leaves the encrypted token and connected source state
-        intact so the operator can retry revocation. Successful revocation
-        deletes the token record, disables dependent sources with
-        ``auth_disconnected``, and deletes no acquired artifacts.
+        Retryable provider failure leaves the encrypted token and connected
+        source state intact so the operator can retry revocation. Successful
+        revocation or a permanent provider rejection deletes the token record,
+        disables dependent sources with ``auth_disconnected``, and deletes no
+        acquired artifacts. The whole transition is binding-serialized with
+        connect/reconnect/refresh across service instances and processes.
         """
-        binding = self._bindings.get(binding_id)
-        if binding is None:
-            raise KeyError(f"no such account binding: {binding_id}")
+        with self._store.binding_lifecycle_lock(binding_id):
+            binding = self._bindings.get(binding_id)
+            if binding is None:
+                raise KeyError(f"no such account binding: {binding_id}")
 
-        revoked = False
-        try:
-            token = self._store.get(binding_id)
-        except TokenStoreKeyMissingError:
-            # The encrypted record is the only recoverable remote-revocation
-            # authority. Preserve it until the key is re-provisioned.
+            revoked = False
+            try:
+                token = self._store.get(binding_id)
+            except TokenStoreKeyMissingError:
+                # The encrypted record is the only recoverable remote-revocation
+                # authority. Preserve it until the key is re-provisioned.
+                return redact(
+                    {
+                        "status": "disconnect_failed",
+                        "reason_code": "auth_key_missing",
+                        "revoked": False,
+                        "retryable": True,
+                        "sources_disabled": 0,
+                    }
+                )
+            if token is not None:
+                revocation_token = token.refresh_token or token.access_token or ""
+                if revocation_token:
+                    try:
+                        self._client.revoke(revocation_token)
+                        revoked = True
+                    except OAuthProviderError as error:
+                        if _retryable_revoke_error(error):
+                            _log.warning(
+                                "youtube oauth: retryable provider revoke failure; encrypted "
+                                "token preserved (binding %s)",
+                                binding_id,
+                            )
+                            return redact(
+                                {
+                                    "status": "disconnect_failed",
+                                    "revoked": False,
+                                    "retryable": True,
+                                    "sources_disabled": 0,
+                                }
+                            )
+                        _log.warning(
+                            "youtube oauth: provider permanently rejected revoke; "
+                            "continuing local disconnect (binding %s)",
+                            binding_id,
+                        )
+
+            self._store.delete(binding_id)
+            self._bindings.set_state(
+                binding_id, state="degraded", reason_code="auth_disconnected"
+            )
+
+            sources_disabled = 0
+            if self._registry is not None:
+                for source in self._registry.list_for_account(binding_id):
+                    self._registry.disable_source_for_auth(
+                        source.binding_id, reason_code="auth_disconnected"
+                    )
+                    sources_disabled += 1
+
+            _log.info("youtube oauth: account disconnected (binding %s)", binding_id)
             return redact(
                 {
-                    "status": "disconnect_failed",
-                    "reason_code": "auth_key_missing",
-                    "revoked": False,
-                    "retryable": True,
-                    "sources_disabled": 0,
+                    "status": "disconnected",
+                    "revoked": revoked,
+                    "sources_disabled": sources_disabled,
                 }
             )
-        if token is not None:
-            revocation_token = token.refresh_token or token.access_token or ""
-            if revocation_token:
-                try:
-                    self._client.revoke(revocation_token)
-                    revoked = True
-                except OAuthProviderError:
-                    _log.warning(
-                        "youtube oauth: provider revoke failed; encrypted token preserved "
-                        "for retry (binding %s)",
-                        binding_id,
-                    )
-                    return redact(
-                        {
-                            "status": "disconnect_failed",
-                            "revoked": False,
-                            "retryable": True,
-                            "sources_disabled": 0,
-                        }
-                    )
-
-        self._store.delete(binding_id)
-        self._bindings.set_state(binding_id, state="degraded", reason_code="auth_disconnected")
-
-        sources_disabled = 0
-        if self._registry is not None:
-            for source in self._registry.list_for_account(binding_id):
-                self._registry.disable_source_for_auth(source.binding_id, reason_code="auth_disconnected")
-                sources_disabled += 1
-
-        _log.info("youtube oauth: account disconnected (binding %s)", binding_id)
-        return redact(
-            {"status": "disconnected", "revoked": revoked, "sources_disabled": sources_disabled}
-        )
 
 
 __all__ = [

--- a/app/knowledge_acquisition/youtube_oauth.py
+++ b/app/knowledge_acquisition/youtube_oauth.py
@@ -45,6 +45,7 @@ import os
 import secrets
 import threading
 import uuid
+from contextlib import nullcontext
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable
@@ -681,8 +682,6 @@ class YouTubeAccountBinder:
             # carry one.
             raise OAuthProviderError(status=200, error_code="missing_refresh_token")
         identity = self._identity(bundle.access_token)
-        binding = self._resolve_binding(identity, reconnect_binding_id)
-        binding_id = binding.account_binding_id if binding is not None else str(uuid.uuid4())
         token = StoredToken(
             refresh_token=bundle.refresh_token,
             access_token=bundle.access_token,
@@ -691,48 +690,63 @@ class YouTubeAccountBinder:
             obtained_at=_now_iso(),
             provider_channel_id=identity.channel_id,
         )
-        with self._store.binding_lifecycle_lock(binding_id):
-            if binding is not None:
-                # The binding object was resolved before waiting for the
-                # cross-instance lock. Re-read it inside the critical section
-                # so a completed disconnect cannot leave reconnect acting on
-                # stale ``connected`` state.
-                current_binding = self._bindings.get(binding_id)
-                if current_binding is None:
-                    raise KeyError(f"no such account binding: {binding_id}")
-                binding = current_binding
+        identity_authority = reconnect_binding_id or f"channel:{identity.channel_id}"
+        with self._store.binding_lifecycle_lock(identity_authority):
+            binding = self._resolve_binding(identity, reconnect_binding_id)
+            binding_id = binding.account_binding_id if binding is not None else str(uuid.uuid4())
+            lifecycle = (
+                self._store.binding_lifecycle_lock(binding_id)
+                if binding_id != identity_authority
+                else nullcontext()
+            )
+            with lifecycle:
+                return self._commit_binding(binding, binding_id, identity, token)
+
+    def _commit_binding(
+        self,
+        binding: AccountBinding | None,
+        binding_id: str,
+        identity: ChannelIdentity,
+        token: StoredToken,
+    ) -> dict[str, Any]:
+        if binding is not None:
+            # Re-read inside shared authority so a completed disconnect cannot
+            # leave reconnect acting on stale ``connected`` state.
+            current_binding = self._bindings.get(binding_id)
+            if current_binding is None:
+                raise KeyError(f"no such account binding: {binding_id}")
+            binding = current_binding
             # Persist the encrypted credential before creating a row whose durable
             # state claims the account is connected. A missing/invalid key therefore
             # cannot leave a connected binding without a token record (#3990).
-            self._store.put(binding_id, token)
-            if binding is None:
-                try:
-                    binding = self._bindings.create(
-                        provider_channel_id=identity.channel_id,
-                        display_label=identity.channel_title,
-                        scopes=[SCOPE],
-                        account_binding_id=binding_id,
-                    )
-                except Exception:
-                    # Compensate the private-store write if the non-secret binding
-                    # cannot be committed. No orphan credential should survive a
-                    # failed initial connect.
-                    self._store.delete(binding_id)
-                    raise
-            if binding.state != "connected" or binding.reason_code is not None:
-                binding = self._bindings.set_state(
-                    binding.account_binding_id, state="connected", reason_code=None
+        self._store.put(binding_id, token)
+        if binding is None:
+            try:
+                binding = self._bindings.create(
+                    provider_channel_id=identity.channel_id,
+                    display_label=identity.channel_title,
+                    scopes=[SCOPE],
+                    account_binding_id=binding_id,
                 )
-            _log.info("youtube oauth: account connected (binding %s)", binding.account_binding_id)
-            return redact(
-                {
-                    "status": "connected",
-                    "account": {
-                        "binding_id": binding.account_binding_id,
-                        "channel_title": binding.display_label,
-                    },
-                }
+            except Exception:
+                # Compensate the private-store write if the non-secret binding
+                # cannot be committed. No orphan credential should survive.
+                self._store.delete(binding_id)
+                raise
+        if binding.state != "connected" or binding.reason_code is not None:
+            binding = self._bindings.set_state(
+                binding.account_binding_id, state="connected", reason_code=None
             )
+        _log.info("youtube oauth: account connected (binding %s)", binding.account_binding_id)
+        return redact(
+            {
+                "status": "connected",
+                "account": {
+                    "binding_id": binding.account_binding_id,
+                    "channel_title": binding.display_label,
+                },
+            }
+        )
 
     def _resolve_binding(
         self, identity: ChannelIdentity, reconnect_binding_id: str | None

--- a/app/knowledge_acquisition/youtube_oauth.py
+++ b/app/knowledge_acquisition/youtube_oauth.py
@@ -768,6 +768,7 @@ class TokenProvider:
             self._binding_id, refreshed, write_error=write_error
         ):
             if pending_id is not None:
+                self._degrade("auth_refresh_pending")
                 raise OAuthGrantDurabilityError(
                     "refresh_pending", pending_grant_id=pending_id
                 ) from None
@@ -827,6 +828,7 @@ class TokenProvider:
         if write_error is not None and not self._stored_token_matches(
             self._binding_id, promoted, write_error=write_error
         ):
+            self._degrade("auth_refresh_pending")
             raise OAuthGrantDurabilityError(
                 "refresh_pending", pending_grant_id=pending_id
             ) from None
@@ -1316,6 +1318,55 @@ class YouTubeAccountBinder:
     ) -> dict[str, Any]:
         """Complete a proven interrupted promotion without losing authority."""
         binding = self._bindings.get(binding_id)
+        if binding is not None and (
+            binding.provider_channel_id != pending.provider_channel_id
+            or binding.reason_code == "auth_disconnected"
+        ):
+            return {
+                "status": "pending_conflict",
+                "pending_grant_id": pending_id,
+                "binding_id": binding_id,
+            }
+
+        # When an older canonical predecessor already exists, recovering its
+        # row is safe and must precede promotion of a distinct later grant. If
+        # row creation is still failing, leave both encrypted authorities
+        # unchanged instead of overwriting the predecessor without a row.
+        if binding is None and self._store.get(binding_id) is not None:
+            recovery, binding = self._recover_candidate_binding_row(
+                pending, binding_id
+            )
+            if recovery != "recovered" or binding is None:
+                return {
+                    "status": recovery,
+                    "pending_grant_id": pending_id,
+                    "binding_id": (
+                        binding.account_binding_id
+                        if binding is not None
+                        else binding_id
+                    ),
+                }
+
+        # Canonical encrypted authority must be crash-durable before recovery
+        # creates a binding row whose default state claims ``connected``. A
+        # pending-only restart followed by a failed canonical write therefore
+        # leaves no row to overstate authority. Lost acknowledgements still
+        # roll forward through exact durable readback, and a later retry can
+        # recover the deterministic row from the now-canonical ciphertext.
+        canonical = _canonical_token_from_pending(pending)
+        write_error: Exception | None = None
+        try:
+            self._store.put(binding_id, canonical)
+        except Exception as error:
+            write_error = error
+        if write_error is not None and not self._stored_token_matches(
+            binding_id, canonical, write_error=write_error
+        ):
+            return {
+                "status": "promotion_pending",
+                "pending_grant_id": pending_id,
+                "binding_id": binding_id,
+            }
         if binding is None:
             if (
                 pending.provider_channel_id is not None
@@ -1348,21 +1399,6 @@ class YouTubeAccountBinder:
         ):
             return {
                 "status": "pending_conflict",
-                "pending_grant_id": pending_id,
-                "binding_id": binding_id,
-            }
-
-        canonical = _canonical_token_from_pending(pending)
-        write_error: Exception | None = None
-        try:
-            self._store.put(binding_id, canonical)
-        except Exception as error:
-            write_error = error
-        if write_error is not None and not self._stored_token_matches(
-            binding_id, canonical, write_error=write_error
-        ):
-            return {
-                "status": "promotion_pending",
                 "pending_grant_id": pending_id,
                 "binding_id": binding_id,
             }

--- a/app/knowledge_acquisition/youtube_oauth.py
+++ b/app/knowledge_acquisition/youtube_oauth.py
@@ -309,6 +309,23 @@ def _binding_generation_evidence(binding_generation: int) -> str:
     return f"binding-generation:{binding_generation}"
 
 
+def _pending_binding_generation(pending: StoredToken) -> int | None:
+    """Return exact durable binding-generation evidence, never wall-clock data."""
+    evidence = pending.promotion_predecessor_binding_updated_at
+    prefix = "binding-generation:"
+    if evidence is None or not evidence.startswith(prefix):
+        return None
+    try:
+        generation = int(evidence.removeprefix(prefix))
+    except ValueError:
+        return None
+    if generation < 1 or not hmac.compare_digest(
+        evidence, _binding_generation_evidence(generation)
+    ):
+        return None
+    return generation
+
+
 def _same_refresh_authority(left: StoredToken, right: StoredToken) -> bool:
     """Constant-time equality for the standing provider credential."""
     return bool(left.refresh_token) and hmac.compare_digest(
@@ -327,6 +344,45 @@ def _canonical_token_from_pending(pending: StoredToken) -> StoredToken:
         promotion_display_label=None,
         promotion_compensation_state=None,
     )
+
+
+def _legacy_record_matches_binding_authority(
+    binding_store: AccountBindingStore,
+    record_id: str,
+    token: StoredToken,
+) -> bool:
+    """Prove a pre-AAD record's authority identity before store migration.
+
+    Canonical records are checked against durable binding metadata, with the
+    deterministic candidate id as the only row-absent case. Pending refresh
+    ids derive from their encrypted target. Pending grant handles are not
+    promotion authority by themselves: their encrypted target/channel must be
+    coherent with a durable row or deterministic candidate before rebinding.
+    """
+    channel_id = token.provider_channel_id
+    target_id = token.promotion_target_binding_id
+    if record_id.startswith("pending-youtube-refresh-"):
+        if target_id is None or record_id != _pending_refresh_id(target_id):
+            return False
+        target = binding_store.get(target_id)
+        return (
+            target is not None
+            and channel_id is not None
+            and target.provider_channel_id == channel_id
+        )
+    if record_id.startswith("pending-youtube-grant-"):
+        if target_id is None or channel_id is None:
+            return False
+        target = binding_store.get(target_id)
+        if target is not None:
+            return target.provider_channel_id == channel_id
+        return target_id == _binding_candidate_id(channel_id)
+    if channel_id is None:
+        return False
+    binding = binding_store.get(record_id)
+    if binding is not None:
+        return binding.provider_channel_id == channel_id
+    return record_id == _binding_candidate_id(channel_id)
 
 
 def _now_iso() -> str:
@@ -725,6 +781,11 @@ class TokenProvider:
         self._registry = source_registry
         self._skew = skew_seconds
         self._lock = threading.Lock()
+        self._store.set_legacy_record_validator(
+            lambda record_id, token: _legacy_record_matches_binding_authority(
+                self._bindings, record_id, token
+            )
+        )
 
     def get_access_token(self) -> str:
         with self._lock:
@@ -1111,7 +1172,7 @@ class TokenProvider:
             if binding is not None:
                 if binding.reason_code in {"auth_disconnected", "auth_revoked"}:
                     effective_reason = binding.reason_code
-                else:
+                elif binding.state != "degraded" or binding.reason_code != reason_code:
                     self._bindings.set_state(
                         self._binding_id,
                         state="degraded",
@@ -1164,6 +1225,11 @@ class YouTubeAccountBinder:
         self._bindings = binding_store
         self._identity = identity_probe
         self._registry = source_registry
+        self._store.set_legacy_record_validator(
+            lambda record_id, token: _legacy_record_matches_binding_authority(
+                self._bindings, record_id, token
+            )
+        )
 
     # -- connect (device flow) ------------------------------------------------
 
@@ -1293,18 +1359,15 @@ class YouTubeAccountBinder:
                             canonical_binding.state != "connected"
                             or canonical_binding.reason_code is not None
                         ):
-                            expected_generation: int | None = None
+                            expected_generation = _pending_binding_generation(token)
                             if (
-                                canonical_binding.reason_code
-                                in {"auth_disconnected", "auth_revoked"}
+                                expected_generation
+                                != canonical_binding.binding_generation
                             ):
-                                if self._pending_supersedes_binding_state(
-                                    token, canonical_binding
-                                ):
-                                    expected_generation = (
-                                        canonical_binding.binding_generation
-                                    )
-                                else:
+                                if canonical_binding.reason_code in {
+                                    "auth_disconnected",
+                                    "auth_revoked",
+                                }:
                                     try:
                                         self._store.delete(pending_grant_id)
                                     except Exception:
@@ -1318,6 +1381,11 @@ class YouTubeAccountBinder:
                                         "pending_grant_id": pending_grant_id,
                                         "binding_id": canonical_id,
                                     }
+                                return {
+                                    "status": "binding_pending",
+                                    "pending_grant_id": pending_grant_id,
+                                    "binding_id": canonical_id,
+                                }
                             try:
                                 canonical_binding = self._bindings.set_state(
                                     canonical_id,
@@ -1326,10 +1394,26 @@ class YouTubeAccountBinder:
                                     expected_binding_generation=expected_generation,
                                 )
                             except AccountBindingGenerationConflictError:
+                                try:
+                                    concurrent_binding = self._bindings.get(
+                                        canonical_id
+                                    )
+                                except Exception:
+                                    concurrent_binding = None
+                                if (
+                                    concurrent_binding is None
+                                    or concurrent_binding.reason_code
+                                    not in {"auth_disconnected", "auth_revoked"}
+                                ):
+                                    return {
+                                        "status": "binding_pending",
+                                        "pending_grant_id": pending_grant_id,
+                                        "binding_id": canonical_id,
+                                    }
                                 # A newer terminal transition won the durable
-                                # CAS after this journal was created. The same
-                                # canonical credential makes the journal
-                                # redundant, so cleanup cannot lose authority.
+                                # CAS. The same canonical credential makes this
+                                # journal redundant, so cleanup cannot lose
+                                # provider-revocation authority.
                                 try:
                                     self._store.delete(pending_grant_id)
                                 except Exception:
@@ -1398,14 +1482,7 @@ class YouTubeAccountBinder:
         pending: StoredToken, binding: AccountBinding
     ) -> bool:
         """Prove new consent was issued against this exact binding generation."""
-        predecessor_generation = pending.promotion_predecessor_binding_updated_at
-        return (
-            predecessor_generation is not None
-            and hmac.compare_digest(
-                predecessor_generation,
-                _binding_generation_evidence(binding.binding_generation),
-            )
-        )
+        return _pending_binding_generation(pending) == binding.binding_generation
 
     def finish_device_connection(self, connection: DeviceConnection) -> dict[str, Any]:
         """Complete one device poll, persist tokens encrypted, bind the account.
@@ -1722,6 +1799,17 @@ class YouTubeAccountBinder:
                     ),
                 }
 
+        if (
+            binding is not None
+            and (binding.state != "connected" or binding.reason_code is not None)
+            and _pending_binding_generation(pending) != binding.binding_generation
+        ):
+            return {
+                "status": "pending_conflict",
+                "pending_grant_id": pending_id,
+                "binding_id": binding_id,
+            }
+
         # Canonical encrypted authority must be crash-durable before recovery
         # creates a binding row whose default state claims ``connected``. A
         # pending-only restart followed by a failed canonical write therefore
@@ -1776,12 +1864,13 @@ class YouTubeAccountBinder:
             }
         try:
             if binding.state != "connected" or binding.reason_code is not None:
-                expected_generation = (
-                    binding.binding_generation
-                    if binding.reason_code
-                    in {"auth_disconnected", "auth_revoked"}
-                    else None
-                )
+                expected_generation = _pending_binding_generation(pending)
+                if expected_generation != binding.binding_generation:
+                    return {
+                        "status": "pending_conflict",
+                        "pending_grant_id": pending_id,
+                        "binding_id": binding_id,
+                    }
                 self._bindings.set_state(
                     binding_id,
                     state="connected",
@@ -1851,7 +1940,10 @@ class YouTubeAccountBinder:
             isinstance(exact, AccountBinding)
             and exact.account_binding_id == binding_id
             and exact.provider_channel_id == channel_id
-            and exact.reason_code != "auth_disconnected"
+            and (
+                exact.reason_code not in {"auth_disconnected", "auth_revoked"}
+                or self._pending_supersedes_binding_state(pending, exact)
+            )
         ):
             return "recovered", exact
         try:
@@ -2092,7 +2184,11 @@ class YouTubeAccountBinder:
                 result: dict[str, Any] | None = None
                 try:
                     result = self._commit_binding(
-                        binding, binding_id, identity, token
+                        binding,
+                        binding_id,
+                        identity,
+                        token,
+                        pending=pending_with_promotion,
                     )
                 except Exception as error:
                     commit_error = error
@@ -2125,7 +2221,10 @@ class YouTubeAccountBinder:
         binding_id: str,
         identity: ChannelIdentity,
         token: StoredToken,
+        *,
+        pending: StoredToken,
     ) -> dict[str, Any]:
+        expected_binding_generation: int | None = None
         if binding is not None:
             # Re-read inside shared authority so a completed disconnect cannot
             # leave reconnect acting on stale ``connected`` state.
@@ -2133,6 +2232,14 @@ class YouTubeAccountBinder:
             if current_binding is None:
                 raise KeyError(f"no such account binding: {binding_id}")
             binding = current_binding
+            expected_binding_generation = _pending_binding_generation(pending)
+            if (
+                expected_binding_generation is None
+                or binding.binding_generation != expected_binding_generation
+            ):
+                raise AccountBindingGenerationConflictError(
+                    "account binding generation changed before reconnect persistence"
+                )
             # Persist the encrypted credential before creating a row whose durable
             # state claims the account is connected. A missing/invalid key therefore
             # cannot leave a connected binding without a token record (#3990).
@@ -2211,9 +2318,19 @@ class YouTubeAccountBinder:
                     # under the deterministic candidate id; a later retry will
                     # resolve the row and converge without minting another id.
                     raise create_error from None
-        if binding.state != "connected" or binding.reason_code is not None:
+        if expected_binding_generation is not None:
             binding = self._bindings.set_state(
-                binding.account_binding_id, state="connected", reason_code=None
+                binding.account_binding_id,
+                state="connected",
+                reason_code=None,
+                expected_binding_generation=expected_binding_generation,
+            )
+        elif binding.state != "connected" or binding.reason_code is not None:
+            # A binding discovered only after a transient negative read carries
+            # no durable generation evidence. Never clear terminal authority by
+            # deriving a fresh expectation after the grant was issued.
+            raise AccountBindingGenerationConflictError(
+                "pending grant lacks binding generation authority"
             )
         _log.info("youtube oauth: account connected (binding %s)", binding.account_binding_id)
         return redact(

--- a/app/knowledge_acquisition/youtube_oauth.py
+++ b/app/knowledge_acquisition/youtube_oauth.py
@@ -29,9 +29,12 @@ key degrades the binding and its dependent authenticated sources with a legible
 reason code, mutates no source cursor, and never records an auth failure as an
 empty-success. Connect, reconnect, refresh, and disconnect serialize each
 binding's credential lifecycle across service instances and processes that
-share its channel token store. First-connect binding ids are deterministic per
-provider channel, and an indeterminate binding-create result always preserves
-the encrypted credential so a delayed commit or retry retains authority. Only
+share its channel token store. Key and atomic-store readiness are proven before
+device polling; an issued grant is encrypted in a pending journal before the
+identity probe or binding work, and an unproven compensation preserves that
+recoverable authority. First-connect binding ids are deterministic per provider
+channel, and an indeterminate binding-create result always preserves the
+encrypted credential so a delayed commit or retry retains authority. Only
 Google's documented ``400 invalid_token`` revoke outcome permits destructive
 local teardown; every other revoke failure preserves retry authority. OAuth
 POSTs never follow redirects. Acquired artifacts are never deleted.
@@ -50,7 +53,7 @@ import uuid
 from contextlib import nullcontext
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Callable
+from typing import Any, Callable, NoReturn
 from urllib.parse import urlencode, urlsplit
 
 import httpx
@@ -181,6 +184,21 @@ class ReconnectChannelMismatchError(RuntimeError):
     """Reconnect consent resolved to a different channel than the target binding."""
 
 
+class OAuthGrantDurabilityError(RuntimeError):
+    """An issued grant was compensated or retained as pending authority."""
+
+    def __init__(self, reason_code: str, *, pending_grant_id: str | None = None) -> None:
+        self.reason_code = reason_code
+        self.pending_grant_id = pending_grant_id
+        if reason_code == "grant_compensated":
+            message = "OAuth grant finalization failed; provider revocation was confirmed"
+        elif reason_code == "grant_pending":
+            message = "OAuth grant finalization failed; encrypted pending authority was preserved"
+        else:
+            message = "OAuth grant finalization failed without durable recovery authority"
+        super().__init__(message)
+
+
 # --- Credential + redaction helpers -----------------------------------------
 
 
@@ -251,6 +269,13 @@ def _binding_candidate_id(provider_channel_id: str) -> str:
     """Return the stable first-connect idempotency key for a YouTube channel."""
     name = f"urn:agentic-pkm:youtube-account-binding:{provider_channel_id}"
     return str(uuid.uuid5(uuid.NAMESPACE_URL, name))
+
+
+def _pending_grant_id(device_code: str, reconnect_binding_id: str | None) -> str:
+    """Opaque stable journal id for one device-flow completion attempt."""
+    target = reconnect_binding_id or "first-connect"
+    digest = hashlib.sha256(f"{target}\0{device_code}".encode("utf-8")).hexdigest()
+    return f"pending-youtube-grant-{digest}"
 
 
 def _now_iso() -> str:
@@ -366,9 +391,23 @@ class DeviceConnection:
         return self.handle.public_view()
 
 
-def _bundle_from_response(data: dict[str, Any]) -> TokenBundle:
+def _bundle_from_response(
+    data: dict[str, Any], *, preserve_refresh_on_incomplete_access: bool = False
+) -> TokenBundle:
     access = data.get("access_token")
     if not access or not isinstance(access, str):
+        refresh = data.get("refresh_token")
+        if preserve_refresh_on_incomplete_access and isinstance(refresh, str) and refresh:
+            # Device completion owns compensation/journaling. Preserve the
+            # refresh credential in-memory long enough for that boundary to
+            # revoke or encrypt it instead of throwing it away in the parser.
+            return TokenBundle(
+                access_token="",
+                refresh_token=refresh,
+                expires_in=data.get("expires_in"),
+                scope=data.get("scope"),
+                token_type=data.get("token_type"),
+            )
         # A 2xx token response with no access token is not a success -- never
         # treat it as an empty-success (INV-YSS-4).
         raise OAuthProviderError(status=200, error_code="missing_access_token")
@@ -476,7 +515,7 @@ class OAuthClient:
             if exc.error_code in ("access_denied", "expired_token"):
                 raise DeviceAuthorizationError(exc.error_code) from None
             raise
-        return _bundle_from_response(data)
+        return _bundle_from_response(data, preserve_refresh_on_incomplete_access=True)
 
     def build_authorization_url(self, *, redirect_uri: str, state: str, code_challenge: str) -> str:
         params = {
@@ -704,6 +743,25 @@ class YouTubeAccountBinder:
             raise KeyError(f"no such account binding: {binding_id}")
         return DeviceConnection(handle=self._client.start_device_flow(), reconnect_binding_id=binding_id)
 
+    def retry_pending_grant_compensation(self, pending_grant_id: str) -> dict[str, Any]:
+        """Retry revocation for one encrypted pre-binding grant journal."""
+        if not pending_grant_id.startswith("pending-youtube-grant-"):
+            raise ValueError("not a YouTube pending-grant journal id")
+        with self._store.binding_lifecycle_lock(pending_grant_id):
+            token = self._store.get(pending_grant_id)
+            if token is None:
+                return {"status": "absent", "pending_grant_id": pending_grant_id}
+            if not self._compensate_grant(token):
+                return {"status": "pending", "pending_grant_id": pending_grant_id}
+            try:
+                self._store.delete(pending_grant_id)
+            except Exception:
+                return {
+                    "status": "compensated_pending_cleanup",
+                    "pending_grant_id": pending_grant_id,
+                }
+            return {"status": "compensated", "pending_grant_id": pending_grant_id}
+
     def finish_device_connection(self, connection: DeviceConnection) -> dict[str, Any]:
         """Complete one device poll, persist tokens encrypted, bind the account.
 
@@ -711,18 +769,132 @@ class YouTubeAccountBinder:
         material. Raises :class:`DeviceAuthorizationPending` if the user has not
         approved yet (the caller re-polls after ``interval``).
         """
-        bundle = self._client.poll_device_flow(connection.handle.device_code)
-        return self._bind_from_bundle(bundle, connection.reconnect_binding_id)
+        pending_id = _pending_grant_id(
+            connection.handle.device_code,
+            connection.reconnect_binding_id,
+        )
+        # Lock order is pending grant -> channel/reconnect identity -> binding
+        # -> aggregate token file. No lifecycle path acquires these in reverse.
+        with self._store.binding_lifecycle_lock(pending_id):
+            # A standing grant must not be requested until the encryption key,
+            # aggregate file, lock directory, and atomic replace path are ready.
+            self._store.preflight_write_ready()
+            bundle = self._client.poll_device_flow(connection.handle.device_code)
+            pending_token = StoredToken(
+                refresh_token=bundle.refresh_token or "",
+                access_token=bundle.access_token,
+                expires_at=_expiry_iso(bundle.expires_in),
+                scopes=(SCOPE,),
+                obtained_at=_now_iso(),
+                provider_channel_id=None,
+            )
+            self._journal_issued_grant(pending_id, pending_token)
 
-    def _bind_from_bundle(self, bundle: TokenBundle, reconnect_binding_id: str | None) -> dict[str, Any]:
-        if not bundle.refresh_token:
-            # A binding with no refresh token cannot sustain access; fail loud at
-            # bind time rather than storing an empty credential that only breaks
-            # later on the first refresh. The loopback/device requests set
-            # access_type=offline + prompt=consent, so a grant should always
-            # carry one.
-            raise OAuthProviderError(status=200, error_code="missing_refresh_token")
-        identity = self._identity(bundle.access_token)
+            if not bundle.refresh_token or not bundle.access_token:
+                self._abort_journaled_grant(pending_id, pending_token)
+            try:
+                identity = self._identity(bundle.access_token)
+            except Exception:
+                # Identity probing is outside the OAuth transaction and may
+                # fail after Google has issued a standing refresh token. Revoke
+                # when authoritative; otherwise retain the encrypted journal.
+                self._abort_journaled_grant(pending_id, pending_token)
+
+            try:
+                result = self._bind_from_bundle(
+                    bundle,
+                    connection.reconnect_binding_id,
+                    identity,
+                    pending_id=pending_id,
+                )
+            except Exception:
+                # Unknown binding/store exceptions may embed backend details.
+                # When the pending journal still owns the fresh grant, surface
+                # only the stable recovery id/reason and never chain text that
+                # could echo credential material.
+                try:
+                    pending_is_durable = self._store.has_record(pending_id)
+                except Exception:
+                    pending_is_durable = True
+                if pending_is_durable:
+                    raise OAuthGrantDurabilityError(
+                        "grant_pending", pending_grant_id=pending_id
+                    ) from None
+                raise
+            try:
+                self._store.delete(pending_id)
+            except Exception:
+                # The canonical binding token is already durable. A crash or
+                # cleanup failure may leave a duplicate encrypted pending copy,
+                # but cannot remove revocation authority or falsify success.
+                _log.warning(
+                    "youtube oauth: connected binding retained redundant pending grant journal"
+                )
+            return result
+
+    def _journal_issued_grant(self, pending_id: str, token: StoredToken) -> None:
+        """Durably journal a fresh grant or compensate it at the provider."""
+        try:
+            self._store.put(pending_id, token)
+            return
+        except Exception:
+            pass
+
+        if self._compensate_grant(token):
+            raise OAuthGrantDurabilityError("grant_compensated") from None
+
+        # A transient write can fail after the successful readiness probe. If
+        # provider compensation is also indeterminate, retry the encrypted
+        # journal before returning control so retry authority remains local.
+        try:
+            self._store.put(pending_id, token)
+        except Exception:
+            # The second write may fail for a different transient reason than
+            # the first. Re-check provider authority once more before declaring
+            # the physically unsatisfiable store+provider double outage.
+            if self._compensate_grant(token):
+                raise OAuthGrantDurabilityError("grant_compensated") from None
+            raise OAuthGrantDurabilityError("grant_durability_unavailable") from None
+        raise OAuthGrantDurabilityError(
+            "grant_pending", pending_grant_id=pending_id
+        ) from None
+
+    def _abort_journaled_grant(self, pending_id: str, token: StoredToken) -> NoReturn:
+        """Compensate a pre-binding failure or retain its pending authority."""
+        if self._compensate_grant(token):
+            try:
+                self._store.delete(pending_id)
+            except Exception:
+                _log.warning(
+                    "youtube oauth: compensated grant retained redundant encrypted journal"
+                )
+            raise OAuthGrantDurabilityError("grant_compensated") from None
+        raise OAuthGrantDurabilityError(
+            "grant_pending", pending_grant_id=pending_id
+        ) from None
+
+    def _compensate_grant(self, token: StoredToken) -> bool:
+        """Return true only when provider revocation is authoritative."""
+        revocation_token = token.refresh_token or token.access_token or ""
+        if not revocation_token:
+            return False
+        try:
+            self._client.revoke(revocation_token)
+            return True
+        except OAuthProviderError as error:
+            return _provider_confirms_token_already_invalid(error)
+        except Exception:
+            return False
+
+    def _bind_from_bundle(
+        self,
+        bundle: TokenBundle,
+        reconnect_binding_id: str | None,
+        identity: ChannelIdentity,
+        *,
+        pending_id: str,
+    ) -> dict[str, Any]:
+        assert bundle.refresh_token is not None  # checked and journaled by caller
         token = StoredToken(
             refresh_token=bundle.refresh_token,
             access_token=bundle.access_token,
@@ -745,7 +917,23 @@ class YouTubeAccountBinder:
                 else nullcontext()
             )
             with lifecycle:
-                return self._commit_binding(binding, binding_id, identity, token)
+                try:
+                    return self._commit_binding(binding, binding_id, identity, token)
+                except Exception:
+                    # Once the target/candidate token is itself durable, the
+                    # earlier pending journal is redundant even if binding-row
+                    # completion remains indeterminate. If the target write did
+                    # not land, retain pending authority for recovery.
+                    try:
+                        target_is_durable = self._store.get(binding_id) == token
+                    except Exception:
+                        target_is_durable = False
+                    if target_is_durable:
+                        try:
+                            self._store.delete(pending_id)
+                        except Exception:
+                            pass
+                    raise
 
     def _commit_binding(
         self,
@@ -994,6 +1182,7 @@ __all__ = [
     "LoopbackFlow",
     "OAuthClient",
     "OAuthClientCredentialsMissingError",
+    "OAuthGrantDurabilityError",
     "OAuthProviderError",
     "OAuthStateMismatchError",
     "REVOKE_URL",

--- a/app/knowledge_acquisition/youtube_oauth.py
+++ b/app/knowledge_acquisition/youtube_oauth.py
@@ -29,10 +29,11 @@ key degrades the binding and its dependent authenticated sources with a legible
 reason code, mutates no source cursor, and never records an auth failure as an
 empty-success. Connect, reconnect, refresh, and disconnect serialize each
 binding's credential lifecycle across service instances and processes that
-share its channel token store. A retryable revoke failure preserves the
-encrypted credential and source state; a permanent provider rejection completes
-local teardown because the old grant no longer provides useful retry authority.
-Acquired artifacts are never deleted.
+share its channel token store. An indeterminate binding-create result preserves
+the encrypted credential unless authoritative readback proves the row absent.
+Only a definitive non-408/non-429 4xx revoke rejection permits destructive
+local teardown; every other revoke failure preserves retry authority. Acquired
+artifacts are never deleted.
 """
 
 from __future__ import annotations
@@ -211,9 +212,9 @@ def _safe_error_code(response: httpx.Response) -> str | None:
     return None
 
 
-def _retryable_revoke_error(error: OAuthProviderError) -> bool:
-    """Whether provider revocation can safely be retried with this token."""
-    return error.status == 0 or error.status in {408, 429} or 500 <= error.status < 600
+def _permanent_revoke_rejection(error: OAuthProviderError) -> bool:
+    """Whether a provider response authoritatively permits local teardown."""
+    return 400 <= error.status < 500 and error.status not in {408, 429}
 
 
 def _now_iso() -> str:
@@ -728,11 +729,50 @@ class YouTubeAccountBinder:
                     scopes=[SCOPE],
                     account_binding_id=binding_id,
                 )
-            except Exception:
-                # Compensate the private-store write if the non-secret binding
-                # cannot be committed. No orphan credential should survive.
-                self._store.delete(binding_id)
-                raise
+            except Exception as create_error:
+                # A Postgres INSERT can commit even when the client loses its
+                # acknowledgement. Reconcile through fresh authoritative reads
+                # before compensating the only encrypted revocation authority.
+                exact_read_ok = True
+                try:
+                    exact_binding = self._bindings.get(binding_id)
+                except Exception:
+                    exact_binding = None
+                    exact_read_ok = False
+                channel_read_ok = True
+                try:
+                    channel_binding = self._bindings.get_by_channel_id(identity.channel_id)
+                except Exception:
+                    channel_binding = None
+                    channel_read_ok = False
+
+                committed_binding = next(
+                    (
+                        candidate
+                        for candidate in (exact_binding, channel_binding)
+                        if isinstance(candidate, AccountBinding)
+                        and candidate.account_binding_id == binding_id
+                        and candidate.provider_channel_id == identity.channel_id
+                    ),
+                    None,
+                )
+                if committed_binding is not None:
+                    # Lost acknowledgement after commit: roll forward to the
+                    # already-connected row and return the normal idempotent
+                    # connect receipt.
+                    binding = committed_binding
+                elif exact_read_ok and channel_read_ok:
+                    # Both fresh reads authoritatively exclude this candidate
+                    # id. A same-channel row with another id is a concurrent
+                    # winner, not evidence that this INSERT committed.
+                    self._store.delete(binding_id)
+                    raise create_error
+                else:
+                    # Readback itself is indeterminate. Preserve the credential
+                    # under its deterministic candidate id so a retry/recovery
+                    # can reconcile it instead of making the remote grant
+                    # unrevokeable.
+                    raise create_error from None
         if binding.state != "connected" or binding.reason_code is not None:
             binding = self._bindings.set_state(
                 binding.account_binding_id, state="connected", reason_code=None
@@ -804,12 +844,15 @@ class YouTubeAccountBinder:
     def disconnect(self, binding_id: str) -> dict[str, Any]:
         """Revoke at the provider, then tear down local authenticated state.
 
-        Retryable provider failure leaves the encrypted token and connected
-        source state intact so the operator can retry revocation. Successful
-        revocation or a permanent provider rejection deletes the token record,
-        disables dependent sources with ``auth_disconnected``, and deletes no
-        acquired artifacts. The whole transition is binding-serialized with
-        connect/reconnect/refresh across service instances and processes.
+        Only a definitive non-408/non-429 4xx provider rejection authorizes
+        destructive local teardown after a failed revoke. Transport failures,
+        1xx/3xx responses, 408, 429, 5xx, and unknown statuses leave the
+        encrypted token and connected source state intact for retry. Successful
+        revocation or a definitive permanent rejection deletes the token
+        record, disables dependent sources with ``auth_disconnected``, and
+        deletes no acquired artifacts. The whole transition is
+        binding-serialized with connect/reconnect/refresh across service
+        instances and processes.
         """
         with self._store.binding_lifecycle_lock(binding_id):
             binding = self._bindings.get(binding_id)
@@ -838,10 +881,16 @@ class YouTubeAccountBinder:
                         self._client.revoke(revocation_token)
                         revoked = True
                     except OAuthProviderError as error:
-                        if _retryable_revoke_error(error):
+                        if _permanent_revoke_rejection(error):
                             _log.warning(
-                                "youtube oauth: retryable provider revoke failure; encrypted "
-                                "token preserved (binding %s)",
+                                "youtube oauth: provider permanently rejected revoke; "
+                                "continuing local disconnect (binding %s)",
+                                binding_id,
+                            )
+                        else:
+                            _log.warning(
+                                "youtube oauth: indeterminate provider revoke failure; "
+                                "encrypted token preserved (binding %s)",
                                 binding_id,
                             )
                             return redact(
@@ -852,11 +901,6 @@ class YouTubeAccountBinder:
                                     "sources_disabled": 0,
                                 }
                             )
-                        _log.warning(
-                            "youtube oauth: provider permanently rejected revoke; "
-                            "continuing local disconnect (binding %s)",
-                            binding_id,
-                        )
 
             self._store.delete(binding_id)
             self._bindings.set_state(

--- a/app/knowledge_acquisition/youtube_oauth.py
+++ b/app/knowledge_acquisition/youtube_oauth.py
@@ -719,6 +719,12 @@ class TokenProvider:
             with self._store.binding_lifecycle_lock(self._binding_id):
                 token = self._read_token()
                 token = self._recover_pending_refresh(token)
+                terminal_reason = self._terminal_binding_reason()
+                if terminal_reason is not None:
+                    raise AuthDegradedError(
+                        terminal_reason,
+                        "account binding authority is locally disabled",
+                    ) from None
                 if self._is_fresh(token):
                     return token.access_token  # type: ignore[return-value]
                 return self._refresh(token)
@@ -748,8 +754,11 @@ class TokenProvider:
         if self._bindings is None:
             return None
         binding = self._bindings.get(self._binding_id)
-        if binding is not None and binding.reason_code == "auth_disconnected":
-            return "auth_disconnected"
+        if binding is not None and binding.reason_code in {
+            "auth_disconnected",
+            "auth_revoked",
+        }:
+            return binding.reason_code
         return None
 
     def _is_fresh(self, token: StoredToken) -> bool:
@@ -988,7 +997,7 @@ class TokenProvider:
         if self._bindings is not None:
             binding = self._bindings.get(self._binding_id)
             if binding is not None:
-                if binding.reason_code == "auth_disconnected":
+                if binding.reason_code in {"auth_disconnected", "auth_revoked"}:
                     return
                 self._bindings.set_state(self._binding_id, state="degraded", reason_code=reason_code)
         if self._registry is not None:
@@ -999,7 +1008,11 @@ class TokenProvider:
         if self._bindings is None:
             return
         binding = self._bindings.get(self._binding_id)
-        if binding is not None and binding.state != "connected":
+        if (
+            binding is not None
+            and binding.state != "connected"
+            and binding.reason_code not in {"auth_disconnected", "auth_revoked"}
+        ):
             self._bindings.set_state(self._binding_id, state="connected", reason_code=None)
 
 
@@ -1135,7 +1148,6 @@ class YouTubeAccountBinder:
                             canonical_binding is None
                             or canonical_binding.provider_channel_id
                             != token.provider_channel_id
-                            or canonical_binding.reason_code == "auth_disconnected"
                         ):
                             recovery, recovered_binding = (
                                 self._recover_candidate_binding_row(
@@ -1663,6 +1675,14 @@ class YouTubeAccountBinder:
         if pending is None:
             return canonical
         if pending.promotion_compensation_state == "compensated":
+            # The provider-compensated authority is terminal. Persist that
+            # fail-closed truth before removing the only crash-recovery marker;
+            # a crash after cleanup must never make the binding look connected.
+            self._degrade_refresh_authority(
+                binding_id,
+                reason_code="auth_revoked",
+                pending_grant_id=pending_id,
+            )
             try:
                 self._store.delete(pending_id)
             except Exception:
@@ -2084,6 +2104,15 @@ class YouTubeAccountBinder:
                     }
                 )
             if token is not None:
+                # Persist local non-consumability before crossing the provider
+                # revocation boundary. If the process dies after Google accepts
+                # the revoke, restart truth remains fail-closed while the
+                # encrypted record is retained solely as retry authority.
+                self._degrade_refresh_authority(
+                    binding_id,
+                    reason_code="auth_disconnected",
+                    pending_grant_id=None,
+                )
                 revocation_token = token.refresh_token or token.access_token or ""
                 if revocation_token:
                     try:

--- a/app/knowledge_acquisition/youtube_oauth.py
+++ b/app/knowledge_acquisition/youtube_oauth.py
@@ -699,7 +699,7 @@ class TokenProvider:
         binding_id: str,
         token_store: YouTubeTokenStore,
         oauth_client: OAuthClient,
-        binding_store: AccountBindingStore | None = None,
+        binding_store: AccountBindingStore,
         source_registry: SourceRegistry | None = None,
         skew_seconds: int = _ACCESS_TOKEN_SKEW_SECONDS,
     ) -> None:
@@ -719,12 +719,7 @@ class TokenProvider:
             with self._store.binding_lifecycle_lock(self._binding_id):
                 token = self._read_token()
                 token = self._recover_pending_refresh(token)
-                terminal_reason = self._terminal_binding_reason()
-                if terminal_reason is not None:
-                    raise AuthDegradedError(
-                        terminal_reason,
-                        "account binding authority is locally disabled",
-                    ) from None
+                self._require_connected_binding()
                 if self._is_fresh(token):
                     return token.access_token  # type: ignore[return-value]
                 return self._refresh(token)
@@ -735,6 +730,7 @@ class TokenProvider:
         except TokenStoreKeyMissingError:
             terminal_reason = self._terminal_binding_reason()
             if terminal_reason is not None:
+                self._degrade(terminal_reason)
                 raise AuthDegradedError(
                     terminal_reason, "account binding is disconnected"
                 ) from None
@@ -743,6 +739,7 @@ class TokenProvider:
         if token is None:
             terminal_reason = self._terminal_binding_reason()
             if terminal_reason is not None:
+                self._degrade(terminal_reason)
                 raise AuthDegradedError(
                     terminal_reason, "account binding is disconnected"
                 ) from None
@@ -751,8 +748,6 @@ class TokenProvider:
         return token
 
     def _terminal_binding_reason(self) -> str | None:
-        if self._bindings is None:
-            return None
         binding = self._bindings.get(self._binding_id)
         if binding is not None and binding.reason_code in {
             "auth_disconnected",
@@ -760,6 +755,28 @@ class TokenProvider:
         }:
             return binding.reason_code
         return None
+
+    def _require_connected_binding(self) -> None:
+        """Require positive durable binding authority before token release."""
+        binding = self._bindings.get(self._binding_id)
+        if (
+            binding is not None
+            and binding.state == "connected"
+            and binding.reason_code is None
+        ):
+            return
+        reason_code = (
+            binding.reason_code
+            if binding is not None and binding.reason_code is not None
+            else "auth_missing"
+        )
+        # A prior crash can persist the binding before dependent-source truth.
+        # Retrying this idempotent producer repairs that split before failing.
+        self._degrade(reason_code)
+        raise AuthDegradedError(
+            reason_code,
+            "account binding lacks connected authority",
+        ) from None
 
     def _is_fresh(self, token: StoredToken) -> bool:
         if not token.access_token or not token.expires_at:
@@ -994,19 +1011,20 @@ class TokenProvider:
 
     def _degrade(self, reason_code: str) -> None:
         """Stamp the reason on the binding + dependent sources; no cursor touched."""
-        if self._bindings is not None:
-            binding = self._bindings.get(self._binding_id)
-            if binding is not None:
-                if binding.reason_code in {"auth_disconnected", "auth_revoked"}:
-                    return
+        binding = self._bindings.get(self._binding_id)
+        effective_reason = reason_code
+        if binding is not None:
+            if binding.reason_code in {"auth_disconnected", "auth_revoked"}:
+                effective_reason = binding.reason_code
+            else:
                 self._bindings.set_state(self._binding_id, state="degraded", reason_code=reason_code)
         if self._registry is not None:
             for source in self._registry.list_for_account(self._binding_id):
-                self._registry.record_source_degradation(source.binding_id, reason_code=reason_code)
+                self._registry.record_source_degradation(
+                    source.binding_id, reason_code=effective_reason
+                )
 
     def _clear_degradation(self) -> None:
-        if self._bindings is None:
-            return
         binding = self._bindings.get(self._binding_id)
         if (
             binding is not None
@@ -1169,6 +1187,26 @@ class YouTubeAccountBinder:
                             canonical_binding.state != "connected"
                             or canonical_binding.reason_code is not None
                         ):
+                            if (
+                                canonical_binding.reason_code
+                                in {"auth_disconnected", "auth_revoked"}
+                                and not self._pending_supersedes_binding_state(
+                                    token, canonical_binding
+                                )
+                            ):
+                                try:
+                                    self._store.delete(pending_grant_id)
+                                except Exception:
+                                    return {
+                                        "status": "canonical_pending_cleanup",
+                                        "pending_grant_id": pending_grant_id,
+                                        "binding_id": canonical_id,
+                                    }
+                                return {
+                                    "status": "canonical_terminal",
+                                    "pending_grant_id": pending_grant_id,
+                                    "binding_id": canonical_id,
+                                }
                             try:
                                 canonical_binding = self._bindings.set_state(
                                     canonical_id,
@@ -1224,6 +1262,17 @@ class YouTubeAccountBinder:
                         "status": "compensated",
                         "pending_grant_id": pending_grant_id,
                     }
+
+    @staticmethod
+    def _pending_supersedes_binding_state(
+        pending: StoredToken, binding: AccountBinding
+    ) -> bool:
+        """Prove new consent was issued against this exact binding version."""
+        predecessor_version = pending.promotion_predecessor_binding_updated_at
+        return (
+            predecessor_version is not None
+            and hmac.compare_digest(predecessor_version, binding.updated_at)
+        )
 
     def finish_device_connection(self, connection: DeviceConnection) -> dict[str, Any]:
         """Complete one device poll, persist tokens encrypted, bind the account.
@@ -1822,6 +1871,9 @@ class YouTubeAccountBinder:
                         else None
                     ),
                     promotion_predecessor_generation=predecessor_generation,
+                    promotion_predecessor_binding_updated_at=(
+                        binding.updated_at if binding is not None else None
+                    ),
                     promotion_display_label=identity.channel_title,
                 )
                 self._bind_pending_grant_identity(
@@ -2019,14 +2071,22 @@ class YouTubeAccountBinder:
                 {"status": "absent", "reason_code": "auth_missing", "scopes": [], "token_store": "encrypted"}
             )
         state, reason_code = binding.state, binding.reason_code
+        terminal_reason = (
+            reason_code
+            if reason_code in {"auth_disconnected", "auth_revoked"}
+            else None
+        )
         try:
             token = self._store.get(binding_id)
             pending_refresh = self._store.get(_pending_refresh_id(binding_id))
         except TokenStoreKeyMissingError:
             token = None
             pending_refresh = None
-            state, reason_code = "degraded", "auth_key_missing"
-        if pending_refresh is not None:
+            if terminal_reason is None:
+                state, reason_code = "degraded", "auth_key_missing"
+        if terminal_reason is not None:
+            state, reason_code = "degraded", terminal_reason
+        elif pending_refresh is not None:
             # A provider response may have rotated the standing credential
             # while canonical promotion is incomplete. The old canonical row
             # is not sufficient authority for a connected status.

--- a/app/knowledge_acquisition/youtube_oauth.py
+++ b/app/knowledge_acquisition/youtube_oauth.py
@@ -305,6 +305,7 @@ def _canonical_token_from_pending(pending: StoredToken) -> StoredToken:
         promotion_target_binding_id=None,
         promotion_predecessor_refresh_token=None,
         promotion_predecessor_generation=None,
+        promotion_display_label=None,
     )
 
 
@@ -987,6 +988,32 @@ class YouTubeAccountBinder:
                     )
                     if resolution == "canonical" and canonical_id is not None:
                         try:
+                            canonical_binding = self._bindings.get(canonical_id)
+                        except Exception:
+                            canonical_binding = None
+                        if (
+                            canonical_binding is None
+                            or canonical_binding.provider_channel_id
+                            != token.provider_channel_id
+                            or canonical_binding.reason_code == "auth_disconnected"
+                        ):
+                            recovery, recovered_binding = (
+                                self._recover_candidate_binding_row(
+                                    token, canonical_id
+                                )
+                            )
+                            if recovery != "recovered" or recovered_binding is None:
+                                return {
+                                    "status": recovery,
+                                    "pending_grant_id": pending_grant_id,
+                                    "binding_id": (
+                                        recovered_binding.account_binding_id
+                                        if recovered_binding is not None
+                                        else canonical_id
+                                    ),
+                                }
+                            canonical_binding = recovered_binding
+                        try:
                             self._store.delete(pending_grant_id)
                         except Exception:
                             return {
@@ -1289,9 +1316,34 @@ class YouTubeAccountBinder:
     ) -> dict[str, Any]:
         """Complete a proven interrupted promotion without losing authority."""
         binding = self._bindings.get(binding_id)
+        if binding is None:
+            if (
+                pending.provider_channel_id is not None
+                and binding_id
+                == _binding_candidate_id(pending.provider_channel_id)
+            ):
+                recovery, binding = self._recover_candidate_binding_row(
+                    pending, binding_id
+                )
+                if recovery != "recovered" or binding is None:
+                    return {
+                        "status": recovery,
+                        "pending_grant_id": pending_id,
+                        "binding_id": (
+                            binding.account_binding_id
+                            if binding is not None
+                            else binding_id
+                        ),
+                    }
+            else:
+                return {
+                    "status": "pending_conflict",
+                    "pending_grant_id": pending_id,
+                    "binding_id": binding_id,
+                }
+        assert binding is not None
         if (
-            binding is None
-            or binding.provider_channel_id != pending.provider_channel_id
+            binding.provider_channel_id != pending.provider_channel_id
             or binding.reason_code == "auth_disconnected"
         ):
             return {
@@ -1338,6 +1390,54 @@ class YouTubeAccountBinder:
             "pending_grant_id": pending_id,
             "binding_id": binding_id,
         }
+
+    def _recover_candidate_binding_row(
+        self, pending: StoredToken, binding_id: str
+    ) -> tuple[str, AccountBinding | None]:
+        """Retry one deterministic first-connect create without new consent.
+
+        The caller holds pending -> channel -> candidate lifecycle authority.
+        A delayed exact row converges. A different same-channel winner is
+        reported as conflict and neither credential is overwritten or revoked.
+        """
+        channel_id = pending.provider_channel_id
+        display_label = pending.promotion_display_label
+        if (
+            channel_id is None
+            or display_label is None
+            or pending.promotion_target_binding_id != binding_id
+            or binding_id != _binding_candidate_id(channel_id)
+        ):
+            return "pending_conflict", None
+        try:
+            created = self._bindings.create(
+                provider_channel_id=channel_id,
+                display_label=display_label,
+                scopes=list(pending.scopes),
+                account_binding_id=binding_id,
+                obtained_at=pending.obtained_at,
+            )
+            return "recovered", created
+        except Exception:
+            pass
+        try:
+            exact = self._bindings.get(binding_id)
+        except Exception:
+            exact = None
+        if (
+            isinstance(exact, AccountBinding)
+            and exact.account_binding_id == binding_id
+            and exact.provider_channel_id == channel_id
+            and exact.reason_code != "auth_disconnected"
+        ):
+            return "recovered", exact
+        try:
+            winner = self._bindings.get_by_channel_id(channel_id)
+        except Exception:
+            winner = None
+        if isinstance(winner, AccountBinding):
+            return "pending_conflict", winner
+        return "binding_pending", None
 
     def _recover_pending_refresh_authority(
         self, binding_id: str
@@ -1478,10 +1578,33 @@ class YouTubeAccountBinder:
                         else None
                     ),
                     promotion_predecessor_generation=predecessor_generation,
+                    promotion_display_label=identity.channel_title,
                 )
                 self._bind_pending_grant_identity(
                     pending_id, pending_with_promotion
                 )
+                if binding is None and predecessor is not None:
+                    # A prior first-connect attempt durably installed this
+                    # deterministic candidate credential but its binding create
+                    # is still temporally indeterminate. Never overwrite that
+                    # authority with a later consent grant. The new grant keeps
+                    # its own pending handle and predecessor evidence; both can
+                    # converge once the matching delayed row becomes visible.
+                    try:
+                        delayed_binding = self._bindings.get(binding_id)
+                    except Exception:
+                        delayed_binding = None
+                    if (
+                        isinstance(delayed_binding, AccountBinding)
+                        and delayed_binding.account_binding_id == binding_id
+                        and delayed_binding.provider_channel_id
+                        == identity.channel_id
+                    ):
+                        binding = delayed_binding
+                    else:
+                        raise OAuthGrantDurabilityError(
+                            "grant_pending", pending_grant_id=pending_id
+                        ) from None
                 commit_error: Exception | None = None
                 result: dict[str, Any] | None = None
                 try:
@@ -1496,17 +1619,21 @@ class YouTubeAccountBinder:
                     # retain a hidden ``__context__`` reference to a
                     # secret-bearing backend error. Once the target/candidate
                     # token is itself durable, the earlier pending journal is
-                    # redundant even if binding-row completion is indeterminate.
-                    target_is_durable = self._stored_token_matches(
-                        binding_id, token, write_error=commit_error
-                    )
-                    if target_is_durable and not isinstance(
-                        commit_error, TokenStoreDurabilityError
-                    ):
-                        try:
-                            self._store.delete(pending_id)
-                        except Exception:
-                            pass
+                    # redundant only after binding-row completion is proven.
+                    # An indeterminate first-connect create must retain its
+                    # per-attempt handle even though the deterministic candidate
+                    # ciphertext is visible.
+                    if binding is not None:
+                        target_is_durable = self._stored_token_matches(
+                            binding_id, token, write_error=commit_error
+                        )
+                        if target_is_durable and not isinstance(
+                            commit_error, TokenStoreDurabilityError
+                        ):
+                            try:
+                                self._store.delete(pending_id)
+                            except Exception:
+                                pass
                     raise commit_error
                 assert result is not None
                 # Promotion and pending cleanup remain inside channel/binding
@@ -1588,8 +1715,10 @@ class YouTubeAccountBinder:
                 ):
                     # The provider/channel uniqueness constraint makes a
                     # different visible row the canonical concurrent winner.
-                    # Move the new grant under that binding before removing the
-                    # deterministic candidate record.
+                    # A same-channel row is not proof that its credential is
+                    # this grant. Never overwrite a different/newer generation;
+                    # retain the deterministic candidate and per-attempt journal
+                    # for explicit reconciliation instead.
                     canonical_id = channel_binding.account_binding_id
                     canonical_lifecycle = (
                         self._store.binding_lifecycle_lock(canonical_id)
@@ -1597,10 +1726,14 @@ class YouTubeAccountBinder:
                         else nullcontext()
                     )
                     with canonical_lifecycle:
-                        self._store.put(canonical_id, token)
+                        canonical = self._store.get(canonical_id)
+                        if canonical is None or not _same_refresh_authority(
+                            canonical, token
+                        ):
+                            raise create_error from None
                         if canonical_id != binding_id:
                             self._store.delete(binding_id)
-                    binding = channel_binding
+                        binding = channel_binding
                 else:
                     # Even two successful negative reads are only snapshots: a
                     # delayed commit can appear afterward. Preserve the grant

--- a/app/knowledge_acquisition/youtube_oauth.py
+++ b/app/knowledge_acquisition/youtube_oauth.py
@@ -197,6 +197,10 @@ class OAuthGrantDurabilityError(RuntimeError):
             message = "OAuth grant finalization failed; provider revocation was confirmed"
         elif reason_code == "grant_pending":
             message = "OAuth grant finalization failed; encrypted pending authority was preserved"
+        elif reason_code == "refresh_pending":
+            message = "OAuth refresh finalization failed; encrypted pending authority was preserved"
+        elif reason_code == "refresh_conflict":
+            message = "OAuth refresh finalization found conflicting encrypted authority"
         else:
             message = "OAuth grant finalization failed without durable recovery authority"
         super().__init__(message)
@@ -279,6 +283,29 @@ def _pending_grant_id(device_code: str, reconnect_binding_id: str | None) -> str
     target = reconnect_binding_id or "first-connect"
     digest = hashlib.sha256(f"{target}\0{device_code}".encode("utf-8")).hexdigest()
     return f"pending-youtube-grant-{digest}"
+
+
+def _pending_refresh_id(binding_id: str) -> str:
+    """Stable opaque journal id for one binding's serialized refresh lane."""
+    digest = hashlib.sha256(f"youtube-refresh\0{binding_id}".encode("utf-8")).hexdigest()
+    return f"pending-youtube-refresh-{digest}"
+
+
+def _same_refresh_authority(left: StoredToken, right: StoredToken) -> bool:
+    """Constant-time equality for the standing provider credential."""
+    return bool(left.refresh_token) and hmac.compare_digest(
+        left.refresh_token, right.refresh_token
+    )
+
+
+def _canonical_token_from_pending(pending: StoredToken) -> StoredToken:
+    """Remove encrypted retry metadata before canonical persistence."""
+    return replace(
+        pending,
+        promotion_target_binding_id=None,
+        promotion_predecessor_refresh_token=None,
+        promotion_predecessor_generation=None,
+    )
 
 
 def _now_iso() -> str:
@@ -647,6 +674,7 @@ class TokenProvider:
             # runtime processes (#3990 review repair).
             with self._store.binding_lifecycle_lock(self._binding_id):
                 token = self._read_token()
+                token = self._recover_pending_refresh(token)
                 if self._is_fresh(token):
                     return token.access_token  # type: ignore[return-value]
                 return self._refresh(token)
@@ -675,22 +703,180 @@ class TokenProvider:
 
     def _refresh(self, token: StoredToken) -> str:
         _log.debug("youtube oauth: refreshing access token for binding %s", self._binding_id)
+        # The provider call can return fresh authority. Prove the encrypted
+        # aggregate and its crash barrier before crossing that boundary.
+        self._store.preflight_write_ready()
         try:
             bundle = self._client.refresh(token.refresh_token)
         except AuthDegradedError as exc:
             self._degrade(exc.reason_code)
             raise
+        rotated_refresh = (
+            bundle.refresh_token
+            if isinstance(bundle.refresh_token, str)
+            and bundle.refresh_token
+            and not hmac.compare_digest(bundle.refresh_token, token.refresh_token)
+            else None
+        )
         refreshed = StoredToken(
-            refresh_token=bundle.refresh_token or token.refresh_token,
+            refresh_token=rotated_refresh or token.refresh_token,
             access_token=bundle.access_token,
             expires_at=_expiry_iso(bundle.expires_in),
             scopes=token.scopes or (SCOPE,),
             obtained_at=_now_iso(),
             provider_channel_id=token.provider_channel_id,
+            authority_generation=(
+                token.authority_generation + 1
+                if rotated_refresh is not None
+                else token.authority_generation
+            ),
         )
-        self._store.put(self._binding_id, refreshed)
+        pending_id: str | None = None
+        if rotated_refresh is not None:
+            pending_id = _pending_refresh_id(self._binding_id)
+            pending = replace(
+                refreshed,
+                promotion_target_binding_id=self._binding_id,
+                promotion_predecessor_refresh_token=token.refresh_token,
+                promotion_predecessor_generation=token.authority_generation,
+            )
+            if not self._write_refresh_journal(pending_id, pending):
+                # Google documents refresh as access-token renewal, but if an
+                # adversarial/non-standard response rotates the standing
+                # credential and local journaling still fails after preflight,
+                # revoke that returned authority when the provider can confirm
+                # it.  An indeterminate double failure remains fail-closed.
+                if self._compensate_refresh_rotation(pending):
+                    self._delete_refresh_journal(pending_id)
+                    self._degrade("auth_revoked")
+                    raise AuthDegradedError(
+                        "auth_revoked",
+                        "rotated refresh authority was revoked after local durability failure",
+                    ) from None
+                self._degrade("auth_refresh_durability")
+                raise OAuthGrantDurabilityError(
+                    "refresh_durability_unavailable"
+                ) from None
+
+        write_error: Exception | None = None
+        try:
+            self._store.put(self._binding_id, refreshed)
+        except Exception as error:
+            write_error = error
+        if write_error is not None and not self._stored_token_matches(
+            self._binding_id, refreshed, write_error=write_error
+        ):
+            if pending_id is not None:
+                raise OAuthGrantDurabilityError(
+                    "refresh_pending", pending_grant_id=pending_id
+                ) from None
+            self._degrade("auth_refresh_durability")
+            raise OAuthGrantDurabilityError("refresh_durability_unavailable") from None
+        if pending_id is not None:
+            self._delete_refresh_journal(pending_id)
         self._clear_degradation()
         return bundle.access_token
+
+    def _recover_pending_refresh(self, canonical: StoredToken) -> StoredToken:
+        """Promote a journal only while its exact predecessor is canonical."""
+        pending_id = _pending_refresh_id(self._binding_id)
+        pending = self._store.get(pending_id)
+        if pending is None:
+            return canonical
+        if (
+            pending.promotion_target_binding_id != self._binding_id
+            or pending.promotion_predecessor_refresh_token is None
+            or pending.promotion_predecessor_generation is None
+        ):
+            self._degrade("auth_refresh_conflict")
+            raise OAuthGrantDurabilityError(
+                "refresh_conflict", pending_grant_id=pending_id
+            ) from None
+
+        if _same_refresh_authority(pending, canonical):
+            # Canonical promotion already landed (possibly with a lost ack), or
+            # a later access-only refresh retained the same standing grant.
+            self._delete_refresh_journal(pending_id)
+            self._clear_degradation()
+            return canonical
+
+        predecessor_matches = (
+            canonical.authority_generation
+            == pending.promotion_predecessor_generation
+            and hmac.compare_digest(
+                canonical.refresh_token,
+                pending.promotion_predecessor_refresh_token,
+            )
+        )
+        if not predecessor_matches:
+            # A newer/different canonical credential is proven. Neither delete
+            # nor revoke the mismatched pending authority, and never overwrite
+            # the newer generation.
+            self._degrade("auth_refresh_conflict")
+            raise OAuthGrantDurabilityError(
+                "refresh_conflict", pending_grant_id=pending_id
+            ) from None
+
+        promoted = _canonical_token_from_pending(pending)
+        write_error: Exception | None = None
+        try:
+            self._store.put(self._binding_id, promoted)
+        except Exception as error:
+            write_error = error
+        if write_error is not None and not self._stored_token_matches(
+            self._binding_id, promoted, write_error=write_error
+        ):
+            raise OAuthGrantDurabilityError(
+                "refresh_pending", pending_grant_id=pending_id
+            ) from None
+        self._delete_refresh_journal(pending_id)
+        self._clear_degradation()
+        return promoted
+
+    def _write_refresh_journal(self, pending_id: str, pending: StoredToken) -> bool:
+        """Persist rotated authority, retrying one post-preflight store fault."""
+        for _attempt in range(2):
+            write_error: Exception | None = None
+            try:
+                self._store.put(pending_id, pending)
+            except Exception as error:
+                write_error = error
+            if write_error is None or self._stored_token_matches(
+                pending_id, pending, write_error=write_error
+            ):
+                return True
+        return False
+
+    def _delete_refresh_journal(self, pending_id: str) -> None:
+        try:
+            self._store.delete(pending_id)
+        except Exception:
+            _log.warning(
+                "youtube oauth: canonical refresh retained redundant encrypted journal"
+            )
+
+    def _stored_token_matches(
+        self,
+        binding_id: str,
+        expected: StoredToken,
+        *,
+        write_error: Exception | None = None,
+    ) -> bool:
+        if isinstance(write_error, TokenStoreDurabilityError):
+            return self._store.confirm_record_durable(binding_id, expected)
+        try:
+            return self._store.get(binding_id) == expected
+        except Exception:
+            return False
+
+    def _compensate_refresh_rotation(self, pending: StoredToken) -> bool:
+        try:
+            self._client.revoke(pending.refresh_token)
+            return True
+        except OAuthProviderError as error:
+            return _provider_confirms_token_already_invalid(error)
+        except Exception:
+            return False
 
     def _degrade(self, reason_code: str) -> None:
         """Stamp the reason on the binding + dependent sources; no cursor touched."""
@@ -775,12 +961,15 @@ class YouTubeAccountBinder:
                     for binding_id in self._store.binding_ids()
                     if binding_id != pending_grant_id
                     and not binding_id.startswith("pending-youtube-grant-")
+                    and not binding_id.startswith("pending-youtube-refresh-")
                 }
                 if token.provider_channel_id is not None:
                     canonical_ids.add(_binding_candidate_id(token.provider_channel_id))
                     visible = self._bindings.get_by_channel_id(token.provider_channel_id)
                     if visible is not None:
                         canonical_ids.add(visible.account_binding_id)
+                if token.promotion_target_binding_id is not None:
+                    canonical_ids.add(token.promotion_target_binding_id)
 
                 with ExitStack() as lifecycle_stack:
                     for binding_id in sorted(canonical_ids):
@@ -793,10 +982,10 @@ class YouTubeAccountBinder:
                             "status": "absent",
                             "pending_grant_id": pending_grant_id,
                         }
-                    canonical_id = self._canonical_binding_for_pending(
+                    resolution, canonical_id = self._pending_resolution(
                         token, canonical_ids
                     )
-                    if canonical_id is not None:
+                    if resolution == "canonical" and canonical_id is not None:
                         try:
                             self._store.delete(pending_grant_id)
                         except Exception:
@@ -807,6 +996,20 @@ class YouTubeAccountBinder:
                             }
                         return {
                             "status": "canonical",
+                            "pending_grant_id": pending_grant_id,
+                            "binding_id": canonical_id,
+                        }
+                    if resolution == "promotable" and canonical_id is not None:
+                        return self._promote_pending_grant(
+                            pending_grant_id, token, canonical_id
+                        )
+                    if resolution == "conflict" and canonical_id is not None:
+                        # Same channel is not same credential authority. A
+                        # token mismatch without exact predecessor evidence can
+                        # be either an unpromoted grant or a newer rotation, so
+                        # preserve both and perform no provider revocation.
+                        return {
+                            "status": "pending_conflict",
                             "pending_grant_id": pending_grant_id,
                             "binding_id": canonical_id,
                         }
@@ -841,6 +1044,16 @@ class YouTubeAccountBinder:
         # Lock order is pending grant -> channel/reconnect identity -> binding
         # -> aggregate token file. No lifecycle path acquires these in reverse.
         with self._store.binding_lifecycle_lock(pending_id):
+            if connection.reconnect_binding_id is not None:
+                # Resolve an interrupted refresh before asking Google for a
+                # second standing grant. Lock order remains pending grant ->
+                # binding -> aggregate token file.
+                with self._store.binding_lifecycle_lock(
+                    connection.reconnect_binding_id
+                ):
+                    self._recover_pending_refresh_authority(
+                        connection.reconnect_binding_id
+                    )
             # A standing grant must not be requested until the encryption key,
             # aggregate file, lock directory, and atomic replace path are ready.
             self._store.preflight_write_ready()
@@ -1013,24 +1226,188 @@ class YouTubeAccountBinder:
                 "youtube oauth: compensated grant retained redundant encrypted journal"
             )
 
-    def _canonical_binding_for_pending(
+    def _pending_resolution(
         self, pending: StoredToken, canonical_ids: set[str]
-    ) -> str | None:
-        """Return canonical local authority that makes revocation unsafe."""
+    ) -> tuple[str, str | None]:
+        """Classify pending authority using exact credential/generation proof."""
+        canonical_by_id: dict[str, StoredToken] = {}
         for binding_id in sorted(canonical_ids):
             canonical = self._store.get(binding_id)
             if canonical is None:
                 continue
-            same_refresh = bool(pending.refresh_token) and hmac.compare_digest(
-                pending.refresh_token, canonical.refresh_token
-            )
-            same_channel = (
+            canonical_by_id[binding_id] = canonical
+            if _same_refresh_authority(pending, canonical):
+                return "canonical", binding_id
+
+        target_id = pending.promotion_target_binding_id
+        if target_id is not None:
+            pending_refresh = self._store.get(_pending_refresh_id(target_id))
+            if pending_refresh is not None:
+                # A refresh transaction that began after this pending grant is
+                # separate authority even while canonical still equals the
+                # older predecessor. Resolve it first; never let this retry
+                # overwrite or delete the newer pending rotation.
+                return "conflict", target_id
+            target = canonical_by_id.get(target_id)
+            if target is not None:
+                predecessor_matches = (
+                    pending.promotion_predecessor_refresh_token is not None
+                    and pending.promotion_predecessor_generation is not None
+                    and target.authority_generation
+                    == pending.promotion_predecessor_generation
+                    and hmac.compare_digest(
+                        target.refresh_token,
+                        pending.promotion_predecessor_refresh_token,
+                    )
+                )
+                if predecessor_matches:
+                    return "promotable", target_id
+            elif (
+                pending.promotion_predecessor_refresh_token is None
+                and pending.promotion_predecessor_generation == 0
+                and pending.authority_generation == 1
+            ):
+                # Durable evidence recorded that this target had no canonical
+                # credential when promotion began. The binding-row guard in
+                # ``_promote_pending_grant`` prevents resurrecting a completed
+                # disconnect or inventing a never-created first-connect row.
+                return "promotable", target_id
+
+        for binding_id, canonical in canonical_by_id.items():
+            if (
                 pending.provider_channel_id is not None
                 and canonical.provider_channel_id == pending.provider_channel_id
+            ):
+                return "conflict", binding_id
+        return "none", None
+
+    def _promote_pending_grant(
+        self,
+        pending_id: str,
+        pending: StoredToken,
+        binding_id: str,
+    ) -> dict[str, Any]:
+        """Complete a proven interrupted promotion without losing authority."""
+        binding = self._bindings.get(binding_id)
+        if (
+            binding is None
+            or binding.provider_channel_id != pending.provider_channel_id
+            or binding.reason_code == "auth_disconnected"
+        ):
+            return {
+                "status": "pending_conflict",
+                "pending_grant_id": pending_id,
+                "binding_id": binding_id,
+            }
+
+        canonical = _canonical_token_from_pending(pending)
+        write_error: Exception | None = None
+        try:
+            self._store.put(binding_id, canonical)
+        except Exception as error:
+            write_error = error
+        if write_error is not None and not self._stored_token_matches(
+            binding_id, canonical, write_error=write_error
+        ):
+            return {
+                "status": "promotion_pending",
+                "pending_grant_id": pending_id,
+                "binding_id": binding_id,
+            }
+        try:
+            if binding.state != "connected" or binding.reason_code is not None:
+                self._bindings.set_state(
+                    binding_id, state="connected", reason_code=None
+                )
+        except Exception:
+            return {
+                "status": "canonical_pending_state",
+                "pending_grant_id": pending_id,
+                "binding_id": binding_id,
+            }
+        try:
+            self._store.delete(pending_id)
+        except Exception:
+            return {
+                "status": "canonical_pending_cleanup",
+                "pending_grant_id": pending_id,
+                "binding_id": binding_id,
+            }
+        return {
+            "status": "promoted",
+            "pending_grant_id": pending_id,
+            "binding_id": binding_id,
+        }
+
+    def _recover_pending_refresh_authority(
+        self, binding_id: str
+    ) -> StoredToken | None:
+        """Resolve one refresh journal before another credential lifecycle.
+
+        The caller holds the binding lifecycle lock. A mismatched/newer
+        canonical generation is never overwritten, deleted, or revoked.
+        """
+        pending_id = _pending_refresh_id(binding_id)
+        canonical = self._store.get(binding_id)
+        pending = self._store.get(pending_id)
+        if pending is None:
+            return canonical
+        if canonical is None or (
+            pending.promotion_target_binding_id != binding_id
+            or pending.promotion_predecessor_refresh_token is None
+            or pending.promotion_predecessor_generation is None
+        ):
+            raise OAuthGrantDurabilityError(
+                "refresh_conflict", pending_grant_id=pending_id
+            ) from None
+
+        if _same_refresh_authority(pending, canonical):
+            cleanup_failed = False
+            try:
+                self._store.delete(pending_id)
+            except Exception:
+                cleanup_failed = True
+            if cleanup_failed:
+                raise OAuthGrantDurabilityError(
+                    "refresh_pending", pending_grant_id=pending_id
+                ) from None
+            return canonical
+
+        predecessor_matches = (
+            canonical.authority_generation
+            == pending.promotion_predecessor_generation
+            and hmac.compare_digest(
+                canonical.refresh_token,
+                pending.promotion_predecessor_refresh_token,
             )
-            if same_refresh or same_channel:
-                return binding_id
-        return None
+        )
+        if not predecessor_matches:
+            raise OAuthGrantDurabilityError(
+                "refresh_conflict", pending_grant_id=pending_id
+            ) from None
+
+        promoted = _canonical_token_from_pending(pending)
+        write_error: Exception | None = None
+        try:
+            self._store.put(binding_id, promoted)
+        except Exception as error:
+            write_error = error
+        if write_error is not None and not self._stored_token_matches(
+            binding_id, promoted, write_error=write_error
+        ):
+            raise OAuthGrantDurabilityError(
+                "refresh_pending", pending_grant_id=pending_id
+            ) from None
+        cleanup_failed = False
+        try:
+            self._store.delete(pending_id)
+        except Exception:
+            cleanup_failed = True
+        if cleanup_failed:
+            raise OAuthGrantDurabilityError(
+                "refresh_pending", pending_grant_id=pending_id
+            ) from None
+        return promoted
 
     def _compensate_grant(self, token: StoredToken) -> bool:
         """Return true only when provider revocation is authoritative."""
@@ -1076,6 +1453,35 @@ class YouTubeAccountBinder:
                 else nullcontext()
             )
             with lifecycle:
+                self._recover_pending_refresh_authority(binding_id)
+                predecessor = self._store.get(binding_id)
+                predecessor_generation = (
+                    predecessor.authority_generation
+                    if predecessor is not None
+                    else 0
+                )
+                token = replace(
+                    token,
+                    authority_generation=predecessor_generation + 1,
+                )
+                # Record the exact predecessor and target in the encrypted
+                # pending journal while channel/binding authority is held.
+                # Retry can now promote only over that predecessor and cannot
+                # mistake a newer rotated token for the same grant merely
+                # because both belong to one provider channel.
+                pending_with_promotion = replace(
+                    token,
+                    promotion_target_binding_id=binding_id,
+                    promotion_predecessor_refresh_token=(
+                        predecessor.refresh_token
+                        if predecessor is not None
+                        else None
+                    ),
+                    promotion_predecessor_generation=predecessor_generation,
+                )
+                self._bind_pending_grant_identity(
+                    pending_id, pending_with_promotion
+                )
                 commit_error: Exception | None = None
                 result: dict[str, Any] | None = None
                 try:
@@ -1250,9 +1656,16 @@ class YouTubeAccountBinder:
         state, reason_code = binding.state, binding.reason_code
         try:
             token = self._store.get(binding_id)
+            pending_refresh = self._store.get(_pending_refresh_id(binding_id))
         except TokenStoreKeyMissingError:
             token = None
+            pending_refresh = None
             state, reason_code = "degraded", "auth_key_missing"
+        if pending_refresh is not None:
+            # A provider response may have rotated the standing credential
+            # while canonical promotion is incomplete. The old canonical row
+            # is not sufficient authority for a connected status.
+            state, reason_code = "degraded", "auth_refresh_pending"
         if token is None and state == "connected":
             # Fail closed for any historical/partial connected row that lacks
             # the encrypted authority needed by authenticated operations.
@@ -1288,7 +1701,7 @@ class YouTubeAccountBinder:
 
             revoked = False
             try:
-                token = self._store.get(binding_id)
+                token = self._recover_pending_refresh_authority(binding_id)
             except TokenStoreKeyMissingError:
                 # The encrypted record is the only recoverable remote-revocation
                 # authority. Preserve it until the key is re-provisioned.
@@ -1296,6 +1709,22 @@ class YouTubeAccountBinder:
                     {
                         "status": "disconnect_failed",
                         "reason_code": "auth_key_missing",
+                        "revoked": False,
+                        "retryable": True,
+                        "sources_disabled": 0,
+                    }
+                )
+            except OAuthGrantDurabilityError as error:
+                # Never revoke an older canonical credential while a rotated
+                # refresh response remains pending or conflicts with a proven
+                # newer generation.
+                return redact(
+                    {
+                        "status": "disconnect_failed",
+                        "reason_code": {
+                            "refresh_pending": "auth_refresh_pending",
+                            "refresh_conflict": "auth_refresh_conflict",
+                        }.get(error.reason_code, "auth_refresh_durability"),
                         "revoked": False,
                         "retryable": True,
                         "sources_disabled": 0,

--- a/app/knowledge_acquisition/youtube_oauth.py
+++ b/app/knowledge_acquisition/youtube_oauth.py
@@ -29,11 +29,12 @@ key degrades the binding and its dependent authenticated sources with a legible
 reason code, mutates no source cursor, and never records an auth failure as an
 empty-success. Connect, reconnect, refresh, and disconnect serialize each
 binding's credential lifecycle across service instances and processes that
-share its channel token store. An indeterminate binding-create result preserves
-the encrypted credential unless authoritative readback proves the row absent.
-Only a definitive non-408/non-429 4xx revoke rejection permits destructive
-local teardown; every other revoke failure preserves retry authority. Acquired
-artifacts are never deleted.
+share its channel token store. First-connect binding ids are deterministic per
+provider channel, and an indeterminate binding-create result always preserves
+the encrypted credential so a delayed commit or retry retains authority. Only
+Google's documented ``400 invalid_token`` revoke outcome permits destructive
+local teardown; every other revoke failure preserves retry authority. OAuth
+POSTs never follow redirects. Acquired artifacts are never deleted.
 """
 
 from __future__ import annotations
@@ -99,6 +100,29 @@ _SECRET_KEY_MARKERS = (
     "code_verifier",
 )
 _REDACTION_SAFE_KEYS = frozenset({"token_store", "token_type"})
+
+# Provider-controlled strings are not safe merely because they occupy an
+# ``error`` field: a proxy or malformed response could echo secret material
+# there. Admit only documented OAuth enums that local control flow understands
+# or may safely report.
+_SAFE_OAUTH_ERROR_CODES: frozenset[str] = frozenset(
+    {
+        "access_denied",
+        "authorization_pending",
+        "expired_token",
+        "invalid_client",
+        "invalid_grant",
+        "invalid_request",
+        "invalid_scope",
+        "invalid_token",
+        "slow_down",
+        "temporarily_unavailable",
+        "unauthorized_client",
+        "unsupported_grant_type",
+        "unsupported_response_type",
+        "unsupported_token_type",
+    }
+)
 
 
 # --- Errors ------------------------------------------------------------------
@@ -207,14 +231,26 @@ def _safe_error_code(response: httpx.Response) -> str | None:
         return None
     if isinstance(body, dict):
         error = body.get("error")
-        if isinstance(error, str):
+        if isinstance(error, str) and error in _SAFE_OAUTH_ERROR_CODES:
             return error
     return None
 
 
-def _permanent_revoke_rejection(error: OAuthProviderError) -> bool:
-    """Whether a provider response authoritatively permits local teardown."""
-    return 400 <= error.status < 500 and error.status not in {408, 429}
+def _provider_confirms_token_already_invalid(error: OAuthProviderError) -> bool:
+    """Whether Google authoritatively says the revoke objective already holds.
+
+    Google's revocation contract documents ``invalid_token`` for a token that
+    is already expired or revoked, and documents HTTP 400 for error outcomes.
+    Status alone is not authority: intermediary and malformed-request 4xx
+    responses preserve the encrypted credential for retry.
+    """
+    return error.status == 400 and error.error_code == "invalid_token"
+
+
+def _binding_candidate_id(provider_channel_id: str) -> str:
+    """Return the stable first-connect idempotency key for a YouTube channel."""
+    name = f"urn:agentic-pkm:youtube-account-binding:{provider_channel_id}"
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, name))
 
 
 def _now_iso() -> str:
@@ -385,7 +421,11 @@ class OAuthClient:
         self._guard_host(url)
         try:
             response = self._http.post(
-                url, data=data, timeout=self._timeout, headers={"Accept": "application/json"}
+                url,
+                data=data,
+                timeout=self._timeout,
+                headers={"Accept": "application/json"},
+                follow_redirects=False,
             )
         except httpx.HTTPError as exc:
             # Sanitized: exception class only -- never a URL (may carry query
@@ -694,7 +734,11 @@ class YouTubeAccountBinder:
         identity_authority = reconnect_binding_id or f"channel:{identity.channel_id}"
         with self._store.binding_lifecycle_lock(identity_authority):
             binding = self._resolve_binding(identity, reconnect_binding_id)
-            binding_id = binding.account_binding_id if binding is not None else str(uuid.uuid4())
+            binding_id = (
+                binding.account_binding_id
+                if binding is not None
+                else _binding_candidate_id(identity.channel_id)
+            )
             lifecycle = (
                 self._store.binding_lifecycle_lock(binding_id)
                 if binding_id != identity_authority
@@ -730,48 +774,56 @@ class YouTubeAccountBinder:
                     account_binding_id=binding_id,
                 )
             except Exception as create_error:
-                # A Postgres INSERT can commit even when the client loses its
-                # acknowledgement. Reconcile through fresh authoritative reads
-                # before compensating the only encrypted revocation authority.
-                exact_read_ok = True
+                # A Postgres INSERT can commit after the client observes an
+                # exception, and negative snapshots cannot prove a delayed
+                # commit will not appear. Reconcile visible success/concurrent
+                # winners, but never compensate the only encrypted revocation
+                # authority while completion remains indeterminate.
                 try:
                     exact_binding = self._bindings.get(binding_id)
                 except Exception:
                     exact_binding = None
-                    exact_read_ok = False
-                channel_read_ok = True
                 try:
                     channel_binding = self._bindings.get_by_channel_id(identity.channel_id)
                 except Exception:
                     channel_binding = None
-                    channel_read_ok = False
 
-                committed_binding = next(
-                    (
-                        candidate
-                        for candidate in (exact_binding, channel_binding)
-                        if isinstance(candidate, AccountBinding)
-                        and candidate.account_binding_id == binding_id
-                        and candidate.provider_channel_id == identity.channel_id
-                    ),
-                    None,
+                committed_binding = (
+                    exact_binding
+                    if isinstance(exact_binding, AccountBinding)
+                    and exact_binding.account_binding_id == binding_id
+                    and exact_binding.provider_channel_id == identity.channel_id
+                    else None
                 )
                 if committed_binding is not None:
                     # Lost acknowledgement after commit: roll forward to the
                     # already-connected row and return the normal idempotent
                     # connect receipt.
                     binding = committed_binding
-                elif exact_read_ok and channel_read_ok:
-                    # Both fresh reads authoritatively exclude this candidate
-                    # id. A same-channel row with another id is a concurrent
-                    # winner, not evidence that this INSERT committed.
-                    self._store.delete(binding_id)
-                    raise create_error
+                elif (
+                    isinstance(channel_binding, AccountBinding)
+                    and channel_binding.provider_channel_id == identity.channel_id
+                ):
+                    # The provider/channel uniqueness constraint makes a
+                    # different visible row the canonical concurrent winner.
+                    # Move the new grant under that binding before removing the
+                    # deterministic candidate record.
+                    canonical_id = channel_binding.account_binding_id
+                    canonical_lifecycle = (
+                        self._store.binding_lifecycle_lock(canonical_id)
+                        if canonical_id != binding_id
+                        else nullcontext()
+                    )
+                    with canonical_lifecycle:
+                        self._store.put(canonical_id, token)
+                        if canonical_id != binding_id:
+                            self._store.delete(binding_id)
+                    binding = channel_binding
                 else:
-                    # Readback itself is indeterminate. Preserve the credential
-                    # under its deterministic candidate id so a retry/recovery
-                    # can reconcile it instead of making the remote grant
-                    # unrevokeable.
+                    # Even two successful negative reads are only snapshots: a
+                    # delayed commit can appear afterward. Preserve the grant
+                    # under the deterministic candidate id; a later retry will
+                    # resolve the row and converge without minting another id.
                     raise create_error from None
         if binding.state != "connected" or binding.reason_code is not None:
             binding = self._bindings.set_state(
@@ -844,13 +896,13 @@ class YouTubeAccountBinder:
     def disconnect(self, binding_id: str) -> dict[str, Any]:
         """Revoke at the provider, then tear down local authenticated state.
 
-        Only a definitive non-408/non-429 4xx provider rejection authorizes
-        destructive local teardown after a failed revoke. Transport failures,
-        1xx/3xx responses, 408, 429, 5xx, and unknown statuses leave the
-        encrypted token and connected source state intact for retry. Successful
-        revocation or a definitive permanent rejection deletes the token
-        record, disables dependent sources with ``auth_disconnected``, and
-        deletes no acquired artifacts. The whole transition is
+        Only Google's documented HTTP 400 ``invalid_token`` outcome (already
+        expired or revoked) authorizes destructive local teardown after a
+        failed revoke. Every other status/body combination leaves the encrypted
+        token and connected source state intact for retry. Successful revocation
+        or that provider-authoritative outcome deletes the token record,
+        disables dependent sources with ``auth_disconnected``, and deletes no
+        acquired artifacts. The whole transition is
         binding-serialized with connect/reconnect/refresh across service
         instances and processes.
         """
@@ -881,9 +933,9 @@ class YouTubeAccountBinder:
                         self._client.revoke(revocation_token)
                         revoked = True
                     except OAuthProviderError as error:
-                        if _permanent_revoke_rejection(error):
+                        if _provider_confirms_token_already_invalid(error):
                             _log.warning(
-                                "youtube oauth: provider permanently rejected revoke; "
+                                "youtube oauth: provider confirms token already invalid; "
                                 "continuing local disconnect (binding %s)",
                                 binding_id,
                             )

--- a/app/knowledge_acquisition/youtube_oauth.py
+++ b/app/knowledge_acquisition/youtube_oauth.py
@@ -792,14 +792,20 @@ class YouTubeAccountBinder:
 
             if not bundle.refresh_token or not bundle.access_token:
                 self._abort_journaled_grant(pending_id, pending_token)
+            identity: ChannelIdentity | None = None
+            identity_failed = False
             try:
                 identity = self._identity(bundle.access_token)
             except Exception:
+                identity_failed = True
+            if identity_failed:
                 # Identity probing is outside the OAuth transaction and may
                 # fail after Google has issued a standing refresh token. Revoke
                 # when authoritative; otherwise retain the encrypted journal.
                 self._abort_journaled_grant(pending_id, pending_token)
 
+            assert identity is not None
+            binding_error: Exception | None = None
             try:
                 result = self._bind_from_bundle(
                     bundle,
@@ -807,7 +813,9 @@ class YouTubeAccountBinder:
                     identity,
                     pending_id=pending_id,
                 )
-            except Exception:
+            except Exception as error:
+                binding_error = error
+            if binding_error is not None:
                 # Unknown binding/store exceptions may embed backend details.
                 # When the pending journal still owns the fresh grant, surface
                 # only the stable recovery id/reason and never chain text that
@@ -819,8 +827,8 @@ class YouTubeAccountBinder:
                 if pending_is_durable:
                     raise OAuthGrantDurabilityError(
                         "grant_pending", pending_grant_id=pending_id
-                    ) from None
-                raise
+                    )
+                raise binding_error
             try:
                 self._store.delete(pending_id)
             except Exception:
@@ -834,30 +842,47 @@ class YouTubeAccountBinder:
 
     def _journal_issued_grant(self, pending_id: str, token: StoredToken) -> None:
         """Durably journal a fresh grant or compensate it at the provider."""
+        first_write_failed = False
         try:
             self._store.put(pending_id, token)
-            return
         except Exception:
-            pass
+            first_write_failed = True
+        if not first_write_failed:
+            return
+
+        # A store write can durably replace the aggregate and then lose its
+        # acknowledgement (including a parent-directory fsync error). Exact
+        # encrypted-record readback is success authority: never revoke it.
+        if self._stored_token_matches(pending_id, token):
+            raise OAuthGrantDurabilityError(
+                "grant_pending", pending_grant_id=pending_id
+            )
 
         if self._compensate_grant(token):
-            raise OAuthGrantDurabilityError("grant_compensated") from None
+            raise OAuthGrantDurabilityError("grant_compensated")
 
         # A transient write can fail after the successful readiness probe. If
         # provider compensation is also indeterminate, retry the encrypted
         # journal before returning control so retry authority remains local.
+        retry_write_failed = False
         try:
             self._store.put(pending_id, token)
         except Exception:
+            retry_write_failed = True
+        if retry_write_failed:
+            if self._stored_token_matches(pending_id, token):
+                raise OAuthGrantDurabilityError(
+                    "grant_pending", pending_grant_id=pending_id
+                )
             # The second write may fail for a different transient reason than
             # the first. Re-check provider authority once more before declaring
             # the physically unsatisfiable store+provider double outage.
             if self._compensate_grant(token):
-                raise OAuthGrantDurabilityError("grant_compensated") from None
-            raise OAuthGrantDurabilityError("grant_durability_unavailable") from None
+                raise OAuthGrantDurabilityError("grant_compensated")
+            raise OAuthGrantDurabilityError("grant_durability_unavailable")
         raise OAuthGrantDurabilityError(
             "grant_pending", pending_grant_id=pending_id
-        ) from None
+        )
 
     def _abort_journaled_grant(self, pending_id: str, token: StoredToken) -> NoReturn:
         """Compensate a pre-binding failure or retain its pending authority."""
@@ -868,10 +893,18 @@ class YouTubeAccountBinder:
                 _log.warning(
                     "youtube oauth: compensated grant retained redundant encrypted journal"
                 )
-            raise OAuthGrantDurabilityError("grant_compensated") from None
+            raise OAuthGrantDurabilityError("grant_compensated")
         raise OAuthGrantDurabilityError(
             "grant_pending", pending_grant_id=pending_id
-        ) from None
+        )
+
+    def _stored_token_matches(self, binding_id: str, expected: StoredToken) -> bool:
+        """Exact encrypted-record readback authority for a lost write ack."""
+        try:
+            stored = self._store.get(binding_id)
+        except Exception:
+            return False
+        return stored == expected
 
     def _compensate_grant(self, token: StoredToken) -> bool:
         """Return true only when provider revocation is authoritative."""
@@ -917,23 +950,26 @@ class YouTubeAccountBinder:
                 else nullcontext()
             )
             with lifecycle:
+                commit_error: Exception | None = None
                 try:
                     return self._commit_binding(binding, binding_id, identity, token)
-                except Exception:
-                    # Once the target/candidate token is itself durable, the
-                    # earlier pending journal is redundant even if binding-row
-                    # completion remains indeterminate. If the target write did
-                    # not land, retain pending authority for recovery.
+                except Exception as error:
+                    commit_error = error
+                assert commit_error is not None
+                # This code intentionally runs outside the exception handler:
+                # any later sanitized durability error must not retain a hidden
+                # ``__context__`` reference to a secret-bearing backend error.
+                # Once the target/candidate token is itself durable, the
+                # earlier pending journal is redundant even if binding-row
+                # completion remains indeterminate. If the target write did
+                # not land, retain pending authority for recovery.
+                target_is_durable = self._stored_token_matches(binding_id, token)
+                if target_is_durable:
                     try:
-                        target_is_durable = self._store.get(binding_id) == token
+                        self._store.delete(pending_id)
                     except Exception:
-                        target_is_durable = False
-                    if target_is_durable:
-                        try:
-                            self._store.delete(pending_id)
-                        except Exception:
-                            pass
-                    raise
+                        pass
+                raise commit_error
 
     def _commit_binding(
         self,
@@ -952,7 +988,13 @@ class YouTubeAccountBinder:
             # Persist the encrypted credential before creating a row whose durable
             # state claims the account is connected. A missing/invalid key therefore
             # cannot leave a connected binding without a token record (#3990).
-        self._store.put(binding_id, token)
+        token_write_error: Exception | None = None
+        try:
+            self._store.put(binding_id, token)
+        except Exception as error:
+            token_write_error = error
+        if token_write_error is not None and not self._stored_token_matches(binding_id, token):
+            raise token_write_error
         if binding is None:
             try:
                 binding = self._bindings.create(

--- a/app/knowledge_acquisition/youtube_oauth.py
+++ b/app/knowledge_acquisition/youtube_oauth.py
@@ -62,7 +62,11 @@ from urllib.parse import urlencode, urlsplit
 import httpx
 
 from app.knowledge_acquisition.source_registry import SourceRegistry
-from app.knowledge_acquisition.youtube_account_binding import AccountBinding, AccountBindingStore
+from app.knowledge_acquisition.youtube_account_binding import (
+    AccountBinding,
+    AccountBindingGenerationConflictError,
+    AccountBindingStore,
+)
 from app.knowledge_acquisition.youtube_token_store import (
     StoredToken,
     TokenStoreDurabilityError,
@@ -295,6 +299,16 @@ def _pending_refresh_id(binding_id: str) -> str:
     return f"pending-youtube-refresh-{digest}"
 
 
+def _binding_generation_evidence(binding_generation: int) -> str:
+    """Encode monotonic binding CAS authority in the legacy encrypted slot.
+
+    The serialized field name is retained for token-store compatibility, but
+    timestamp-shaped values from older pending journals never match this
+    prefix and therefore fail closed as non-promotable terminal conflicts.
+    """
+    return f"binding-generation:{binding_generation}"
+
+
 def _same_refresh_authority(left: StoredToken, right: StoredToken) -> bool:
     """Constant-time equality for the standing provider credential."""
     return bool(left.refresh_token) and hmac.compare_digest(
@@ -309,6 +323,7 @@ def _canonical_token_from_pending(pending: StoredToken) -> StoredToken:
         promotion_target_binding_id=None,
         promotion_predecessor_refresh_token=None,
         promotion_predecessor_generation=None,
+        promotion_predecessor_binding_updated_at=None,
         promotion_display_label=None,
         promotion_compensation_state=None,
     )
@@ -798,8 +813,22 @@ class TokenProvider:
             ) from None
         if (
             pending is not None
-            and pending.promotion_compensation_state == "compensated"
+            and pending.promotion_compensation_state in {"pending", "compensated"}
         ):
+            if pending.promotion_compensation_state == "pending":
+                if not self._compensate_refresh_rotation(pending):
+                    raise OAuthGrantDurabilityError(
+                        "refresh_durability_unavailable",
+                        pending_grant_id=pending_id,
+                    ) from None
+                compensated = replace(
+                    pending, promotion_compensation_state="compensated"
+                )
+                if not self._write_refresh_journal(pending_id, compensated):
+                    raise OAuthGrantDurabilityError(
+                        "refresh_durability_unavailable",
+                        pending_grant_id=pending_id,
+                    ) from None
             self._converge_compensated_refresh(
                 pending_id, terminal_reason=terminal_reason
             )
@@ -886,7 +915,12 @@ class TokenProvider:
                         compensation_pending,
                         promotion_compensation_state="compensated",
                     )
-                    self._write_refresh_journal(pending_id, compensated)
+                    if not self._write_refresh_journal(pending_id, compensated):
+                        self._degrade("auth_refresh_durability")
+                        raise OAuthGrantDurabilityError(
+                            "refresh_durability_unavailable",
+                            pending_grant_id=pending_id,
+                        ) from None
                     self._converge_compensated_refresh(pending_id)
                     raise AuthDegradedError(
                         "auth_revoked",
@@ -935,7 +969,12 @@ class TokenProvider:
                 compensated = replace(
                     pending, promotion_compensation_state="compensated"
                 )
-                self._write_refresh_journal(pending_id, compensated)
+                if not self._write_refresh_journal(pending_id, compensated):
+                    self._degrade("auth_refresh_durability")
+                    raise OAuthGrantDurabilityError(
+                        "refresh_durability_unavailable",
+                        pending_grant_id=pending_id,
+                    ) from None
                 pending = compensated
             elif compensation_state != "compensated":
                 self._degrade("auth_refresh_durability")
@@ -1254,13 +1293,43 @@ class YouTubeAccountBinder:
                             canonical_binding.state != "connected"
                             or canonical_binding.reason_code is not None
                         ):
+                            expected_generation: int | None = None
                             if (
                                 canonical_binding.reason_code
                                 in {"auth_disconnected", "auth_revoked"}
-                                and not self._pending_supersedes_binding_state(
-                                    token, canonical_binding
-                                )
                             ):
+                                if self._pending_supersedes_binding_state(
+                                    token, canonical_binding
+                                ):
+                                    expected_generation = (
+                                        canonical_binding.binding_generation
+                                    )
+                                else:
+                                    try:
+                                        self._store.delete(pending_grant_id)
+                                    except Exception:
+                                        return {
+                                            "status": "canonical_pending_cleanup",
+                                            "pending_grant_id": pending_grant_id,
+                                            "binding_id": canonical_id,
+                                        }
+                                    return {
+                                        "status": "canonical_terminal",
+                                        "pending_grant_id": pending_grant_id,
+                                        "binding_id": canonical_id,
+                                    }
+                            try:
+                                canonical_binding = self._bindings.set_state(
+                                    canonical_id,
+                                    state="connected",
+                                    reason_code=None,
+                                    expected_binding_generation=expected_generation,
+                                )
+                            except AccountBindingGenerationConflictError:
+                                # A newer terminal transition won the durable
+                                # CAS after this journal was created. The same
+                                # canonical credential makes the journal
+                                # redundant, so cleanup cannot lose authority.
                                 try:
                                     self._store.delete(pending_grant_id)
                                 except Exception:
@@ -1274,12 +1343,6 @@ class YouTubeAccountBinder:
                                     "pending_grant_id": pending_grant_id,
                                     "binding_id": canonical_id,
                                 }
-                            try:
-                                canonical_binding = self._bindings.set_state(
-                                    canonical_id,
-                                    state="connected",
-                                    reason_code=None,
-                                )
                             except Exception:
                                 return {
                                     "status": "binding_pending",
@@ -1334,11 +1397,14 @@ class YouTubeAccountBinder:
     def _pending_supersedes_binding_state(
         pending: StoredToken, binding: AccountBinding
     ) -> bool:
-        """Prove new consent was issued against this exact binding version."""
-        predecessor_version = pending.promotion_predecessor_binding_updated_at
+        """Prove new consent was issued against this exact binding generation."""
+        predecessor_generation = pending.promotion_predecessor_binding_updated_at
         return (
-            predecessor_version is not None
-            and hmac.compare_digest(predecessor_version, binding.updated_at)
+            predecessor_generation is not None
+            and hmac.compare_digest(
+                predecessor_generation,
+                _binding_generation_evidence(binding.binding_generation),
+            )
         )
 
     def finish_device_connection(self, connection: DeviceConnection) -> dict[str, Any]:
@@ -1620,15 +1686,22 @@ class YouTubeAccountBinder:
     ) -> dict[str, Any]:
         """Complete a proven interrupted promotion without losing authority."""
         binding = self._bindings.get(binding_id)
-        if binding is not None and (
-            binding.provider_channel_id != pending.provider_channel_id
-            or binding.reason_code == "auth_disconnected"
-        ):
-            return {
-                "status": "pending_conflict",
-                "pending_grant_id": pending_id,
-                "binding_id": binding_id,
-            }
+        if binding is not None:
+            if binding.provider_channel_id != pending.provider_channel_id:
+                return {
+                    "status": "pending_conflict",
+                    "pending_grant_id": pending_id,
+                    "binding_id": binding_id,
+                }
+            if (
+                binding.reason_code in {"auth_disconnected", "auth_revoked"}
+                and not self._pending_supersedes_binding_state(pending, binding)
+            ):
+                return {
+                    "status": "pending_conflict",
+                    "pending_grant_id": pending_id,
+                    "binding_id": binding_id,
+                }
 
         # When an older canonical predecessor already exists, recovering its
         # row is safe and must precede promotion of a distinct later grant. If
@@ -1695,10 +1768,7 @@ class YouTubeAccountBinder:
                     "binding_id": binding_id,
                 }
         assert binding is not None
-        if (
-            binding.provider_channel_id != pending.provider_channel_id
-            or binding.reason_code == "auth_disconnected"
-        ):
+        if binding.provider_channel_id != pending.provider_channel_id:
             return {
                 "status": "pending_conflict",
                 "pending_grant_id": pending_id,
@@ -1706,9 +1776,24 @@ class YouTubeAccountBinder:
             }
         try:
             if binding.state != "connected" or binding.reason_code is not None:
-                self._bindings.set_state(
-                    binding_id, state="connected", reason_code=None
+                expected_generation = (
+                    binding.binding_generation
+                    if binding.reason_code
+                    in {"auth_disconnected", "auth_revoked"}
+                    else None
                 )
+                self._bindings.set_state(
+                    binding_id,
+                    state="connected",
+                    reason_code=None,
+                    expected_binding_generation=expected_generation,
+                )
+        except AccountBindingGenerationConflictError:
+            return {
+                "status": "pending_conflict",
+                "pending_grant_id": pending_id,
+                "binding_id": binding_id,
+            }
         except Exception:
             return {
                 "status": "canonical_pending_state",
@@ -1790,6 +1875,38 @@ class YouTubeAccountBinder:
         pending = self._store.get(pending_id)
         if pending is None:
             return canonical
+        if pending.promotion_compensation_state == "pending":
+            # Compensation may have reached Google while the durable
+            # ``compensated`` marker did not. Revoke idempotently, then require
+            # exact encrypted marker durability before terminal degradation or
+            # cleanup. Reconnect/disconnect therefore recover this state
+            # directly instead of relying on a separate token consumer.
+            if not self._compensate_grant(pending):
+                raise OAuthGrantDurabilityError(
+                    "refresh_durability_unavailable",
+                    pending_grant_id=pending_id,
+                ) from None
+            compensated = replace(
+                pending, promotion_compensation_state="compensated"
+            )
+            marker_durable = False
+            for _attempt in range(2):
+                marker_write_error: Exception | None = None
+                try:
+                    self._store.put(pending_id, compensated)
+                except Exception as error:
+                    marker_write_error = error
+                if marker_write_error is None or self._stored_token_matches(
+                    pending_id, compensated, write_error=marker_write_error
+                ):
+                    marker_durable = True
+                    break
+            if not marker_durable:
+                raise OAuthGrantDurabilityError(
+                    "refresh_durability_unavailable",
+                    pending_grant_id=pending_id,
+                ) from None
+            pending = compensated
         if pending.promotion_compensation_state == "compensated":
             # The provider-compensated authority is terminal. Persist that
             # fail-closed truth before removing the only crash-recovery marker;
@@ -1940,7 +2057,9 @@ class YouTubeAccountBinder:
                     ),
                     promotion_predecessor_generation=predecessor_generation,
                     promotion_predecessor_binding_updated_at=(
-                        binding.updated_at if binding is not None else None
+                        _binding_generation_evidence(binding.binding_generation)
+                        if binding is not None
+                        else None
                     ),
                     promotion_display_label=identity.channel_title,
                 )
@@ -2144,17 +2263,27 @@ class YouTubeAccountBinder:
             if reason_code in {"auth_disconnected", "auth_revoked"}
             else None
         )
+        if terminal_reason is not None:
+            # Persisted terminal authority is complete status truth. Do not
+            # consult the encrypted projection: its missing key, malformed
+            # aggregate, or ordinary I/O failure cannot outrank an explicit
+            # disconnect/revocation marker.
+            return redact(
+                {
+                    "status": "degraded",
+                    "reason_code": terminal_reason,
+                    "scopes": list(binding.scopes),
+                    "token_store": "encrypted",
+                }
+            )
         try:
             token = self._store.get(binding_id)
             pending_refresh = self._store.get(_pending_refresh_id(binding_id))
         except TokenStoreKeyMissingError:
             token = None
             pending_refresh = None
-            if terminal_reason is None:
-                state, reason_code = "degraded", "auth_key_missing"
-        if terminal_reason is not None:
-            state, reason_code = "degraded", terminal_reason
-        elif pending_refresh is not None:
+            state, reason_code = "degraded", "auth_key_missing"
+        if pending_refresh is not None:
             # A provider response may have rotated the standing credential
             # while canonical promotion is incomplete. The old canonical row
             # is not sufficient authority for a connected status.

--- a/app/knowledge_acquisition/youtube_token_store.py
+++ b/app/knowledge_acquisition/youtube_token_store.py
@@ -25,18 +25,26 @@ Boundary (INV-YSS-5 / INV-YSS-7):
   clear. The record index (which binding ids have tokens) is readable without
   the key so upstream can detect "a binding exists" and fail closed; decrypting
   a record's bytes always requires the key.
+- A binding-scoped lifecycle lock combines a process-local ``RLock`` with an OS
+  file lock so connect, reconnect, refresh, and disconnect can serialize across
+  store instances and runtime processes. Lock filenames are SHA-256 digests of
+  binding ids, and their private app-local files contain no identifiers or
+  credential bytes.
 """
 
 from __future__ import annotations
 
 import base64
+import fcntl
+import hashlib
 import json
 import os
 import threading
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
@@ -47,6 +55,20 @@ _AES_KEY_BYTES = 32  # AES-256
 _NONCE_BYTES = 12  # standard AES-GCM nonce size
 _SCHEMA = "youtube-token-store.v1"
 _DEFAULT_REL_PATH = Path("runtime/knowledge_acquisition/youtube_token_store.enc")
+
+_LIFECYCLE_LOCKS_GUARD = threading.Lock()
+_LIFECYCLE_THREAD_LOCKS: dict[str, threading.RLock] = {}
+
+
+def _lifecycle_thread_lock(lock_path: Path) -> threading.RLock:
+    """Return the process-local half of one cross-process lifecycle lock."""
+    key = str(lock_path)
+    with _LIFECYCLE_LOCKS_GUARD:
+        lock = _LIFECYCLE_THREAD_LOCKS.get(key)
+        if lock is None:
+            lock = threading.RLock()
+            _LIFECYCLE_THREAD_LOCKS[key] = lock
+        return lock
 
 
 class TokenStoreKeyMissingError(RuntimeError):
@@ -156,8 +178,9 @@ class StoredToken:
 class YouTubeTokenStore:
     """AES-256-GCM encrypted token store, one JSON file, one record per binding.
 
-    Thread-safe for concurrent access within a process; cross-process safety is
-    provided by an atomic replace on every write.
+    Individual file operations are thread-safe and writes use atomic replace.
+    Multi-operation credential lifecycles use :meth:`binding_lifecycle_lock`
+    for cross-instance and cross-process serialization.
     """
 
     def __init__(self, path: Path | str | None = None) -> None:
@@ -170,6 +193,35 @@ class YouTubeTokenStore:
     @property
     def path(self) -> Path:
         return self._path
+
+    @contextmanager
+    def binding_lifecycle_lock(self, binding_id: str) -> Iterator[None]:
+        """Serialize one binding's credential lifecycle across actors.
+
+        The process-local ``RLock`` serializes separate service/store instances
+        in one runtime, while ``flock`` on an app-local hashed lock file extends
+        the same critical section across runtime processes sharing this channel
+        token store. The lock file contains no binding id or credential bytes.
+        """
+        if not isinstance(binding_id, str) or not binding_id:
+            raise ValueError("binding_id must be a non-empty string")
+        store_path = self._path.resolve(strict=False)
+        lock_root = store_path.parent / f".{store_path.name}.locks"
+        lock_root.mkdir(mode=0o700, parents=True, exist_ok=True)
+        binding_digest = hashlib.sha256(binding_id.encode("utf-8")).hexdigest()
+        lock_path = lock_root / f"{binding_digest}.lock"
+        thread_lock = _lifecycle_thread_lock(lock_path)
+
+        with thread_lock:
+            descriptor = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_EX)
+                try:
+                    yield
+                finally:
+                    fcntl.flock(descriptor, fcntl.LOCK_UN)
+            finally:
+                os.close(descriptor)
 
     # --- file helpers (no key required) -------------------------------------
 

--- a/app/knowledge_acquisition/youtube_token_store.py
+++ b/app/knowledge_acquisition/youtube_token_store.py
@@ -34,6 +34,9 @@ Boundary (INV-YSS-5 / INV-YSS-7):
   preventing distinct bindings from losing each other's records. The lock
   backend is guarded and portable across POSIX ``flock`` and Windows
   ``msvcrt.locking``; unsupported platforms fail closed.
+- Device-flow completion proves key plus locked atomic write/read readiness
+  before polling can issue a grant. Fresh grants can therefore be journaled
+  immediately under an opaque pending id before identity/binding work.
 """
 
 from __future__ import annotations
@@ -305,6 +308,26 @@ class YouTubeTokenStore:
             return existed
 
     # --- encrypted record access (key required) -----------------------------
+
+    def preflight_write_ready(self) -> None:
+        """Prove key and atomic store I/O readiness before an OAuth grant.
+
+        The unchanged aggregate is rewritten under the normal store lock and
+        read back before any provider token poll may issue a standing grant.
+        This catches a missing/invalid key, corrupt store, unwritable parent,
+        failed temporary write, and failed atomic replacement without placing
+        any secret material in a probe record.
+        """
+        key = resolve_token_store_key()
+        # Exercise the configured key with the same primitive used by ``put``;
+        # the probe remains in memory and contains no credential material.
+        AESGCM(key).encrypt(os.urandom(_NONCE_BYTES), b"youtube-token-store-readiness", None)
+        with self._lock, self._aggregate_file_lock():
+            data = self._load_file()
+            self._write_file(data)
+            verified = self._load_file()
+            if verified != data:
+                raise RuntimeError("YouTube token store readiness verification failed")
 
     def put(self, binding_id: str, token: StoredToken) -> None:
         """Encrypt and persist ``token`` for ``binding_id`` (requires the key)."""

--- a/app/knowledge_acquisition/youtube_token_store.py
+++ b/app/knowledge_acquisition/youtube_token_store.py
@@ -21,7 +21,9 @@ Boundary (INV-YSS-5 / INV-YSS-7):
   plaintext fallback -- this module raises :class:`TokenStoreKeyMissingError`
   and the OAuth layer maps it to the reason code.
 - The on-disk structure carries only non-secret keys (binding ids) mapping to
-  ``{ciphertext, nonce}``; no token, code, or client secret is ever written in
+  ``{ciphertext, nonce, aad_version}``; every current ciphertext authenticates
+  that exact outer id as AEAD associated data and repeats it inside the
+  encrypted envelope. No token, code, or client secret is ever written in
   clear. The record index (which binding ids have tokens) is readable without
   the key so upstream can detect "a binding exists" and fail closed; decrypting
   a record's bytes always requires the key.
@@ -36,8 +38,10 @@ Boundary (INV-YSS-5 / INV-YSS-7):
   ``msvcrt.locking``; unsupported platforms fail closed.
 - Device-flow completion proves key plus locked atomic write/read readiness
   before polling can issue a grant. An encrypted canary binds the configured
-  key to the aggregate, and legacy aggregates authenticate every record before
-  gaining that canary. Each POSIX aggregate write syncs the staged file,
+  key to the aggregate. Pre-AAD aggregates upgrade atomically only after the
+  OAuth layer proves each decrypted record's binding/channel or pending-target
+  identity; an unprovable or pre-swapped legacy association fails closed without
+  mutation. Each POSIX aggregate write syncs the staged file,
   atomically replaces the live path, then syncs its parent directory; Windows
   uses write-through replacement. Visible readback after a failed barrier is
   not durable authority until a fresh barrier succeeds. Fresh grants can
@@ -58,7 +62,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any, Callable, Iterator
 
 from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
@@ -80,6 +84,9 @@ _AES_KEY_BYTES = 32  # AES-256
 _NONCE_BYTES = 12  # standard AES-GCM nonce size
 _SCHEMA = "youtube-token-store.v1"
 _KEY_CHECK_PLAINTEXT = b"youtube-token-store-key-check.v1"
+_RECORD_AAD_VERSION = "binding-id.v1"
+_RECORD_ENVELOPE_VERSION = "youtube-token-record.v2"
+_RECORD_AAD_PREFIX = b"agentic-pkm:youtube-token-store:binding-id:v1\0"
 _DEFAULT_REL_PATH = Path("runtime/knowledge_acquisition/youtube_token_store.enc")
 
 _LIFECYCLE_LOCKS_GUARD = threading.Lock()
@@ -307,6 +314,7 @@ class YouTubeTokenStore:
     def __init__(self, path: Path | str | None = None) -> None:
         self._path = Path(path) if path is not None else default_token_store_path()
         self._lock = threading.Lock()
+        self._legacy_record_validator: Callable[[str, StoredToken], bool] | None = None
 
     def __repr__(self) -> str:
         return f"YouTubeTokenStore(path={str(self._path)!r})"
@@ -314,6 +322,21 @@ class YouTubeTokenStore:
     @property
     def path(self) -> Path:
         return self._path
+
+    def set_legacy_record_validator(
+        self, validator: Callable[[str, StoredToken], bool]
+    ) -> None:
+        """Install the authority check required before rebinding legacy records.
+
+        Pre-AAD ciphertext does not authenticate its outer record id. It may be
+        upgraded only when the OAuth authority layer proves that the decrypted
+        token belongs to that id. Merely decrypting with the configured key is
+        intentionally insufficient because two valid legacy records could have
+        been exchanged before migration.
+        """
+        if not callable(validator):
+            raise TypeError("legacy record validator must be callable")
+        self._legacy_record_validator = validator
 
     @contextmanager
     def binding_lifecycle_lock(self, binding_id: str) -> Iterator[None]:
@@ -359,24 +382,60 @@ class YouTubeTokenStore:
         return data
 
     @staticmethod
-    def _encrypted_record(key: bytes, plaintext: bytes) -> dict[str, str]:
+    def _record_aad(binding_id: str) -> bytes:
+        if not isinstance(binding_id, str) or not binding_id:
+            raise ValueError("binding_id must be a non-empty string")
+        return _RECORD_AAD_PREFIX + binding_id.encode("utf-8")
+
+    @classmethod
+    def _encrypted_record(
+        cls,
+        key: bytes,
+        plaintext: bytes,
+        *,
+        binding_id: str | None = None,
+    ) -> dict[str, str]:
         nonce = os.urandom(_NONCE_BYTES)
-        ciphertext = AESGCM(key).encrypt(nonce, plaintext, None)
-        return {
+        aad = cls._record_aad(binding_id) if binding_id is not None else None
+        ciphertext = AESGCM(key).encrypt(nonce, plaintext, aad)
+        record = {
             "ciphertext": base64.b64encode(ciphertext).decode("ascii"),
             "nonce": base64.b64encode(nonce).decode("ascii"),
         }
+        if binding_id is not None:
+            record["aad_version"] = _RECORD_AAD_VERSION
+        return record
 
-    @staticmethod
-    def _decrypt_record(record: Any, key: bytes) -> bytes:
+    @classmethod
+    def _decrypt_record(
+        cls,
+        record: Any,
+        key: bytes,
+        *,
+        binding_id: str | None = None,
+        allow_legacy: bool = False,
+    ) -> tuple[bytes, bool]:
         failed = False
         plaintext = b""
+        legacy = False
         try:
             if not isinstance(record, dict):
                 raise TypeError
+            aad_version = record.get("aad_version")
+            if binding_id is None:
+                if aad_version is not None:
+                    raise ValueError
+                aad = None
+            elif aad_version == _RECORD_AAD_VERSION:
+                aad = cls._record_aad(binding_id)
+            elif aad_version is None and allow_legacy:
+                aad = None
+                legacy = True
+            else:
+                raise ValueError
             ciphertext = base64.b64decode(record["ciphertext"], validate=True)
             nonce = base64.b64decode(record["nonce"], validate=True)
-            plaintext = AESGCM(key).decrypt(nonce, ciphertext, None)
+            plaintext = AESGCM(key).decrypt(nonce, ciphertext, aad)
         except (InvalidTag, binascii.Error, KeyError, TypeError, ValueError):
             failed = True
         if failed:
@@ -385,7 +444,75 @@ class YouTubeTokenStore:
             raise TokenStoreKeyMismatchError(
                 "configured YouTube token-store key cannot authenticate the encrypted aggregate"
             )
-        return plaintext
+        return plaintext, legacy
+
+    @staticmethod
+    def _token_plaintext(binding_id: str, token: StoredToken) -> bytes:
+        return json.dumps(
+            {
+                "envelope": _RECORD_ENVELOPE_VERSION,
+                "record_binding_id": binding_id,
+                "token": token._to_plain(),
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+
+    @classmethod
+    def _decode_token_plaintext(
+        cls,
+        binding_id: str,
+        plaintext: bytes,
+        *,
+        legacy: bool,
+    ) -> StoredToken:
+        malformed = False
+        token: StoredToken | None = None
+        try:
+            decoded = json.loads(plaintext.decode("utf-8"))
+            if not isinstance(decoded, dict):
+                raise TypeError
+            if legacy:
+                token_data = decoded
+            else:
+                if (
+                    decoded.get("envelope") != _RECORD_ENVELOPE_VERSION
+                    or decoded.get("record_binding_id") != binding_id
+                    or not isinstance(decoded.get("token"), dict)
+                ):
+                    raise ValueError
+                token_data = decoded["token"]
+            token = StoredToken._from_plain(token_data)
+        except (KeyError, TypeError, UnicodeDecodeError, ValueError, json.JSONDecodeError):
+            malformed = True
+        if malformed or token is None:
+            raise TokenStoreKeyMismatchError(
+                "configured YouTube token-store key cannot authenticate the encrypted aggregate"
+            )
+        return token
+
+    @classmethod
+    def _decode_token_record(
+        cls,
+        binding_id: str,
+        record: Any,
+        key: bytes,
+        *,
+        allow_legacy: bool,
+    ) -> tuple[StoredToken, bool]:
+        plaintext, legacy = cls._decrypt_record(
+            record,
+            key,
+            binding_id=binding_id,
+            allow_legacy=allow_legacy,
+        )
+        return (
+            cls._decode_token_plaintext(
+                binding_id,
+                plaintext,
+                legacy=legacy,
+            ),
+            legacy,
+        )
 
     def _bind_or_verify_aggregate_key(
         self,
@@ -396,31 +523,67 @@ class YouTubeTokenStore:
     ) -> bool:
         """Cryptographically bind ``key`` to the whole existing aggregate.
 
-        New/current aggregates carry an encrypted fixed canary. Legacy
-        aggregates without a canary are admitted only after *every* encrypted
-        record authenticates under the configured key; the next write then
-        installs the canary. This prevents a valid-but-wrong key from appending
-        a mixed-key record to an existing file.
+        New/current aggregates carry an encrypted fixed canary and record-id
+        bound envelopes. A legacy record is admitted only after both its
+        ciphertext and its authority identity validate; initialization upgrades
+        every admitted legacy record together and installs a missing canary.
         """
         key_check = data.get("key_check")
         if key_check is not None:
-            if self._decrypt_record(key_check, key) != _KEY_CHECK_PLAINTEXT:
+            key_check_plaintext, _ = self._decrypt_record(key_check, key)
+            if key_check_plaintext != _KEY_CHECK_PLAINTEXT:
                 raise TokenStoreKeyMismatchError(
                     "configured YouTube token-store key cannot authenticate the encrypted aggregate"
                 )
-            # The canary binds the configured key, while authenticating every
-            # record rejects a pre-existing partial/mixed-key aggregate rather
-            # than carrying it forward under an otherwise valid canary.
-            for record in data["records"].values():
-                self._decrypt_record(record, key)
-            return False
 
-        for record in data["records"].values():
-            self._decrypt_record(record, key)
-        if not initialize:
-            return False
-        data["key_check"] = self._encrypted_record(key, _KEY_CHECK_PLAINTEXT)
-        return True
+        decoded_records: dict[str, StoredToken] = {}
+        legacy_ids: list[str] = []
+        for binding_id, record in data["records"].items():
+            token, legacy = self._decode_token_record(
+                binding_id,
+                record,
+                key,
+                allow_legacy=True,
+            )
+            decoded_records[binding_id] = token
+            if legacy:
+                legacy_ids.append(binding_id)
+
+        legacy_invalid = False
+        if legacy_ids:
+            validator = self._legacy_record_validator
+            if validator is None:
+                legacy_invalid = True
+            else:
+                try:
+                    legacy_invalid = any(
+                        not validator(binding_id, decoded_records[binding_id])
+                        for binding_id in legacy_ids
+                    )
+                except Exception:
+                    legacy_invalid = True
+        if legacy_invalid:
+            # Never retain a validator exception as hidden context: backend
+            # detail and token material stay outside the public error chain.
+            raise TokenStoreKeyMismatchError(
+                "legacy YouTube token-store record identity cannot be authenticated"
+            )
+
+        changed = False
+        if initialize:
+            for binding_id in legacy_ids:
+                data["records"][binding_id] = self._encrypted_record(
+                    key,
+                    self._token_plaintext(binding_id, decoded_records[binding_id]),
+                    binding_id=binding_id,
+                )
+                changed = True
+            if key_check is None:
+                data["key_check"] = self._encrypted_record(
+                    key, _KEY_CHECK_PLAINTEXT
+                )
+                changed = True
+        return changed
 
     def _sync_parent_directory(self) -> None:
         """Confirm the complete directory-entry chain on POSIX.
@@ -531,11 +694,14 @@ class YouTubeTokenStore:
     def put(self, binding_id: str, token: StoredToken) -> None:
         """Encrypt and persist ``token`` for ``binding_id`` (requires the key)."""
         key = resolve_token_store_key()
-        plaintext = json.dumps(token._to_plain(), sort_keys=True).encode("utf-8")
         with self._lock, self._aggregate_file_lock():
             data = self._load_file()
             self._bind_or_verify_aggregate_key(data, key, initialize=True)
-            data["records"][binding_id] = self._encrypted_record(key, plaintext)
+            data["records"][binding_id] = self._encrypted_record(
+                key,
+                self._token_plaintext(binding_id, token),
+                binding_id=binding_id,
+            )
             self._write_file(data)
 
     def confirm_record_durable(self, binding_id: str, expected: StoredToken) -> bool:
@@ -555,8 +721,13 @@ class YouTubeTokenStore:
                     return False
                 key = resolve_token_store_key()
                 self._bind_or_verify_aggregate_key(data, key, initialize=False)
-                plaintext = self._decrypt_record(record, key)
-                confirmed = StoredToken._from_plain(json.loads(plaintext.decode("utf-8"))) == expected
+                token, _ = self._decode_token_record(
+                    binding_id,
+                    record,
+                    key,
+                    allow_legacy=False,
+                )
+                confirmed = token == expected
         except Exception:
             confirmed = False
         return confirmed
@@ -575,22 +746,22 @@ class YouTubeTokenStore:
             if record is None:
                 return None
             key = resolve_token_store_key()
-            self._bind_or_verify_aggregate_key(data, key, initialize=False)
-            plaintext = self._decrypt_record(record, key)
-        malformed = False
-        try:
-            decoded = json.loads(plaintext.decode("utf-8"))
-            if not isinstance(decoded, dict):
-                raise TypeError
-            token = StoredToken._from_plain(decoded)
-        except (KeyError, TypeError, UnicodeDecodeError, ValueError, json.JSONDecodeError):
-            malformed = True
-            token = None
-        if malformed:
-            raise TokenStoreKeyMismatchError(
-                "configured YouTube token-store key cannot authenticate the encrypted aggregate"
+            changed = self._bind_or_verify_aggregate_key(
+                data, key, initialize=True
             )
-        return token
+            if changed:
+                self._write_file(data)
+                data = self._load_file()
+                self._bind_or_verify_aggregate_key(
+                    data, key, initialize=False
+                )
+            token, _ = self._decode_token_record(
+                binding_id,
+                data["records"][binding_id],
+                key,
+                allow_legacy=False,
+            )
+            return token
 
 
 __all__ = [

--- a/app/knowledge_acquisition/youtube_token_store.py
+++ b/app/knowledge_acquisition/youtube_token_store.py
@@ -208,6 +208,13 @@ class StoredToken:
     scopes: tuple[str, ...]
     obtained_at: str  # ISO-8601 UTC
     provider_channel_id: str | None
+    # Credential-authority generation and promotion evidence live only inside
+    # this encrypted payload.  They let a retry distinguish the predecessor it
+    # is allowed to replace from a newer independently rotated credential.
+    authority_generation: int = 0
+    promotion_target_binding_id: str | None = None
+    promotion_predecessor_refresh_token: str | None = None
+    promotion_predecessor_generation: int | None = None
 
     def __repr__(self) -> str:  # redaction-aware (INV-YSS-5)
         return (
@@ -225,6 +232,10 @@ class StoredToken:
             scopes=self.scopes,
             obtained_at=self.obtained_at,
             provider_channel_id=self.provider_channel_id,
+            authority_generation=self.authority_generation,
+            promotion_target_binding_id=self.promotion_target_binding_id,
+            promotion_predecessor_refresh_token=self.promotion_predecessor_refresh_token,
+            promotion_predecessor_generation=self.promotion_predecessor_generation,
         )
 
     def _to_plain(self) -> dict[str, Any]:
@@ -235,6 +246,10 @@ class StoredToken:
             "scopes": list(self.scopes),
             "obtained_at": self.obtained_at,
             "provider_channel_id": self.provider_channel_id,
+            "authority_generation": self.authority_generation,
+            "promotion_target_binding_id": self.promotion_target_binding_id,
+            "promotion_predecessor_refresh_token": self.promotion_predecessor_refresh_token,
+            "promotion_predecessor_generation": self.promotion_predecessor_generation,
         }
 
     @classmethod
@@ -246,6 +261,16 @@ class StoredToken:
             scopes=tuple(data.get("scopes") or ()),
             obtained_at=data.get("obtained_at") or _now_iso(),
             provider_channel_id=data.get("provider_channel_id"),
+            authority_generation=int(data.get("authority_generation") or 0),
+            promotion_target_binding_id=data.get("promotion_target_binding_id"),
+            promotion_predecessor_refresh_token=data.get(
+                "promotion_predecessor_refresh_token"
+            ),
+            promotion_predecessor_generation=(
+                int(data["promotion_predecessor_generation"])
+                if data.get("promotion_predecessor_generation") is not None
+                else None
+            ),
         )
 
 

--- a/app/knowledge_acquisition/youtube_token_store.py
+++ b/app/knowledge_acquisition/youtube_token_store.py
@@ -216,6 +216,10 @@ class StoredToken:
     promotion_predecessor_refresh_token: str | None = None
     promotion_predecessor_generation: int | None = None
     promotion_display_label: str | None = None
+    # A rotated refresh journal must become non-promotable before provider
+    # compensation. ``pending`` means revocation must be retried; ``compensated``
+    # means provider authority is already gone and only encrypted cleanup remains.
+    promotion_compensation_state: str | None = None
 
     def __repr__(self) -> str:  # redaction-aware (INV-YSS-5)
         return (
@@ -238,6 +242,7 @@ class StoredToken:
             promotion_predecessor_refresh_token=self.promotion_predecessor_refresh_token,
             promotion_predecessor_generation=self.promotion_predecessor_generation,
             promotion_display_label=self.promotion_display_label,
+            promotion_compensation_state=self.promotion_compensation_state,
         )
 
     def _to_plain(self) -> dict[str, Any]:
@@ -253,6 +258,7 @@ class StoredToken:
             "promotion_predecessor_refresh_token": self.promotion_predecessor_refresh_token,
             "promotion_predecessor_generation": self.promotion_predecessor_generation,
             "promotion_display_label": self.promotion_display_label,
+            "promotion_compensation_state": self.promotion_compensation_state,
         }
 
     @classmethod
@@ -275,6 +281,7 @@ class StoredToken:
                 else None
             ),
             promotion_display_label=data.get("promotion_display_label"),
+            promotion_compensation_state=data.get("promotion_compensation_state"),
         )
 
 

--- a/app/knowledge_acquisition/youtube_token_store.py
+++ b/app/knowledge_acquisition/youtube_token_store.py
@@ -215,6 +215,7 @@ class StoredToken:
     promotion_target_binding_id: str | None = None
     promotion_predecessor_refresh_token: str | None = None
     promotion_predecessor_generation: int | None = None
+    promotion_display_label: str | None = None
 
     def __repr__(self) -> str:  # redaction-aware (INV-YSS-5)
         return (
@@ -236,6 +237,7 @@ class StoredToken:
             promotion_target_binding_id=self.promotion_target_binding_id,
             promotion_predecessor_refresh_token=self.promotion_predecessor_refresh_token,
             promotion_predecessor_generation=self.promotion_predecessor_generation,
+            promotion_display_label=self.promotion_display_label,
         )
 
     def _to_plain(self) -> dict[str, Any]:
@@ -250,6 +252,7 @@ class StoredToken:
             "promotion_target_binding_id": self.promotion_target_binding_id,
             "promotion_predecessor_refresh_token": self.promotion_predecessor_refresh_token,
             "promotion_predecessor_generation": self.promotion_predecessor_generation,
+            "promotion_display_label": self.promotion_display_label,
         }
 
     @classmethod
@@ -271,6 +274,7 @@ class StoredToken:
                 if data.get("promotion_predecessor_generation") is not None
                 else None
             ),
+            promotion_display_label=data.get("promotion_display_label"),
         )
 
 

--- a/app/knowledge_acquisition/youtube_token_store.py
+++ b/app/knowledge_acquisition/youtube_token_store.py
@@ -35,8 +35,10 @@ Boundary (INV-YSS-5 / INV-YSS-7):
   backend is guarded and portable across POSIX ``flock`` and Windows
   ``msvcrt.locking``; unsupported platforms fail closed.
 - Device-flow completion proves key plus locked atomic write/read readiness
-  before polling can issue a grant. Fresh grants can therefore be journaled
-  immediately under an opaque pending id before identity/binding work.
+  before polling can issue a grant. Each aggregate write syncs the staged file,
+  atomically replaces the live path, then syncs its parent directory. Fresh
+  grants can therefore be journaled immediately under an opaque pending id
+  before identity/binding work.
 """
 
 from __future__ import annotations
@@ -223,7 +225,8 @@ class StoredToken:
 class YouTubeTokenStore:
     """AES-256-GCM encrypted token store, one JSON file, one record per binding.
 
-    Individual file operations are thread-safe and writes use atomic replace.
+    Individual file operations are thread-safe and writes sync the staged file,
+    atomically replace the live path, then sync the parent directory.
     Multi-operation credential lifecycles use :meth:`binding_lifecycle_lock`
     for cross-instance and cross-process serialization.
     """
@@ -281,8 +284,20 @@ class YouTubeTokenStore:
     def _write_file(self, data: dict[str, Any]) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)
         tmp = self._path.with_suffix(self._path.suffix + ".tmp")
-        tmp.write_text(json.dumps(data, sort_keys=True), encoding="utf-8")
+        with tmp.open("w", encoding="utf-8") as staged:
+            staged.write(json.dumps(data, sort_keys=True))
+            staged.flush()
+            # The staged ciphertext/index must reach stable storage before its
+            # name can replace the last durable aggregate.
+            os.fsync(staged.fileno())
         os.replace(tmp, self._path)
+        # Persist the directory-entry replacement itself. Without this fsync a
+        # crash can lose the newly renamed token journal despite a synced file.
+        directory_fd = os.open(self._path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
 
     def has_record(self, binding_id: str) -> bool:
         """True if a token record exists for ``binding_id`` (no key required)."""

--- a/app/knowledge_acquisition/youtube_token_store.py
+++ b/app/knowledge_acquisition/youtube_token_store.py
@@ -30,12 +30,15 @@ Boundary (INV-YSS-5 / INV-YSS-7):
   store instances and runtime processes. Lock filenames are SHA-256 digests of
   binding ids, and their private app-local files contain no identifiers or
   credential bytes.
+- Every aggregate token-file read/modify/write also takes one store-wide lock,
+  preventing distinct bindings from losing each other's records. The lock
+  backend is guarded and portable across POSIX ``flock`` and Windows
+  ``msvcrt.locking``; unsupported platforms fail closed.
 """
 
 from __future__ import annotations
 
 import base64
-import fcntl
 import hashlib
 import json
 import os
@@ -47,6 +50,16 @@ from pathlib import Path
 from typing import Any, Iterator
 
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+try:  # POSIX
+    import fcntl as _fcntl
+except ImportError:  # pragma: no cover - exercised through platform-path tests
+    _fcntl = None  # type: ignore[assignment]
+
+try:  # Windows
+    import msvcrt as _msvcrt
+except ImportError:  # pragma: no cover - exercised through platform-path tests
+    _msvcrt = None  # type: ignore[assignment]
 
 KEY_ENV_VAR = "YOUTUBE_TOKEN_STORE_KEY"
 PATH_ENV_VAR = "YOUTUBE_TOKEN_STORE_PATH"
@@ -69,6 +82,35 @@ def _lifecycle_thread_lock(lock_path: Path) -> threading.RLock:
             lock = threading.RLock()
             _LIFECYCLE_THREAD_LOCKS[key] = lock
         return lock
+
+
+@contextmanager
+def _portable_file_lock(lock_path: Path) -> Iterator[None]:
+    """Exclusive portable file lock; fail closed on unsupported platforms."""
+    thread_lock = _lifecycle_thread_lock(lock_path)
+    with thread_lock:
+        descriptor = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            if os.fstat(descriptor).st_size == 0:
+                os.write(descriptor, b"\0")
+            os.lseek(descriptor, 0, os.SEEK_SET)
+            if _fcntl is not None:
+                _fcntl.flock(descriptor, _fcntl.LOCK_EX)
+                try:
+                    yield
+                finally:
+                    _fcntl.flock(descriptor, _fcntl.LOCK_UN)
+            elif _msvcrt is not None:
+                _msvcrt.locking(descriptor, _msvcrt.LK_LOCK, 1)
+                try:
+                    yield
+                finally:
+                    os.lseek(descriptor, 0, os.SEEK_SET)
+                    _msvcrt.locking(descriptor, _msvcrt.LK_UNLCK, 1)
+            else:  # pragma: no cover - defensive unsupported-platform boundary
+                raise RuntimeError("no supported cross-process file locking primitive")
+        finally:
+            os.close(descriptor)
 
 
 class TokenStoreKeyMissingError(RuntimeError):
@@ -210,18 +252,16 @@ class YouTubeTokenStore:
         lock_root.mkdir(mode=0o700, parents=True, exist_ok=True)
         binding_digest = hashlib.sha256(binding_id.encode("utf-8")).hexdigest()
         lock_path = lock_root / f"{binding_digest}.lock"
-        thread_lock = _lifecycle_thread_lock(lock_path)
+        with _portable_file_lock(lock_path):
+            yield
 
-        with thread_lock:
-            descriptor = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
-            try:
-                fcntl.flock(descriptor, fcntl.LOCK_EX)
-                try:
-                    yield
-                finally:
-                    fcntl.flock(descriptor, fcntl.LOCK_UN)
-            finally:
-                os.close(descriptor)
+    @contextmanager
+    def _aggregate_file_lock(self) -> Iterator[None]:
+        store_path = self._path.resolve(strict=False)
+        lock_root = store_path.parent / f".{store_path.name}.locks"
+        lock_root.mkdir(mode=0o700, parents=True, exist_ok=True)
+        with _portable_file_lock(lock_root / "store.lock"):
+            yield
 
     # --- file helpers (no key required) -------------------------------------
 
@@ -243,12 +283,12 @@ class YouTubeTokenStore:
 
     def has_record(self, binding_id: str) -> bool:
         """True if a token record exists for ``binding_id`` (no key required)."""
-        with self._lock:
+        with self._lock, self._aggregate_file_lock():
             return binding_id in self._load_file()["records"]
 
     def binding_ids(self) -> tuple[str, ...]:
         """All binding ids with a token record (no key required)."""
-        with self._lock:
+        with self._lock, self._aggregate_file_lock():
             return tuple(self._load_file()["records"].keys())
 
     def delete(self, binding_id: str) -> bool:
@@ -256,7 +296,7 @@ class YouTubeTokenStore:
 
         No key is required: deletion removes ciphertext, it does not read it.
         """
-        with self._lock:
+        with self._lock, self._aggregate_file_lock():
             data = self._load_file()
             existed = binding_id in data["records"]
             if existed:
@@ -272,7 +312,7 @@ class YouTubeTokenStore:
         plaintext = json.dumps(token._to_plain(), sort_keys=True).encode("utf-8")
         nonce = os.urandom(_NONCE_BYTES)
         ciphertext = AESGCM(key).encrypt(nonce, plaintext, None)
-        with self._lock:
+        with self._lock, self._aggregate_file_lock():
             data = self._load_file()
             data["records"][binding_id] = {
                 "ciphertext": base64.b64encode(ciphertext).decode("ascii"),
@@ -288,7 +328,7 @@ class YouTubeTokenStore:
         raises :class:`TokenStoreKeyMissingError` -- there is no plaintext read
         path (fail closed, INV-YSS-4).
         """
-        with self._lock:
+        with self._lock, self._aggregate_file_lock():
             record = self._load_file()["records"].get(binding_id)
         if record is None:
             return None

--- a/app/knowledge_acquisition/youtube_token_store.py
+++ b/app/knowledge_acquisition/youtube_token_store.py
@@ -406,18 +406,25 @@ class YouTubeTokenStore:
         return True
 
     def _sync_parent_directory(self) -> None:
-        """Confirm the directory-entry barrier on POSIX.
+        """Confirm the complete directory-entry chain on POSIX.
 
         Windows takes the separate ``MoveFileExW(..., WRITE_THROUGH)`` path in
         :meth:`_replace_with_barrier`; opening/fsyncing a directory is not a
-        portable Windows operation.
+        portable Windows operation. On POSIX, syncing only the immediate parent
+        is insufficient when first use created multiple nested parents: the
+        file can be visible while a new directory link is absent after crash.
         """
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
-        directory_fd = os.open(self._path.parent, flags)
-        try:
-            os.fsync(directory_fd)
-        finally:
-            os.close(directory_fd)
+        parent = self._path.parent.resolve(strict=False)
+        while True:
+            directory_fd = os.open(parent, flags)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+            if parent.parent == parent:
+                break
+            parent = parent.parent
 
     def _replace_with_barrier(self, source: Path) -> None:
         if os.name != "nt":

--- a/app/knowledge_acquisition/youtube_token_store.py
+++ b/app/knowledge_acquisition/youtube_token_store.py
@@ -35,15 +35,21 @@ Boundary (INV-YSS-5 / INV-YSS-7):
   backend is guarded and portable across POSIX ``flock`` and Windows
   ``msvcrt.locking``; unsupported platforms fail closed.
 - Device-flow completion proves key plus locked atomic write/read readiness
-  before polling can issue a grant. Each aggregate write syncs the staged file,
-  atomically replaces the live path, then syncs its parent directory. Fresh
-  grants can therefore be journaled immediately under an opaque pending id
-  before identity/binding work.
+  before polling can issue a grant. An encrypted canary binds the configured
+  key to the aggregate, and legacy aggregates authenticate every record before
+  gaining that canary. Each POSIX aggregate write syncs the staged file,
+  atomically replaces the live path, then syncs its parent directory; Windows
+  uses write-through replacement. Visible readback after a failed barrier is
+  not durable authority until a fresh barrier succeeds. Fresh grants can
+  therefore be journaled immediately under an opaque pending id before
+  identity/binding work.
 """
 
 from __future__ import annotations
 
 import base64
+import binascii
+import ctypes
 import hashlib
 import json
 import os
@@ -54,6 +60,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterator
 
+from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
 try:  # POSIX
@@ -72,6 +79,7 @@ PATH_ENV_VAR = "YOUTUBE_TOKEN_STORE_PATH"
 _AES_KEY_BYTES = 32  # AES-256
 _NONCE_BYTES = 12  # standard AES-GCM nonce size
 _SCHEMA = "youtube-token-store.v1"
+_KEY_CHECK_PLAINTEXT = b"youtube-token-store-key-check.v1"
 _DEFAULT_REL_PATH = Path("runtime/knowledge_acquisition/youtube_token_store.enc")
 
 _LIFECYCLE_LOCKS_GUARD = threading.Lock()
@@ -127,6 +135,19 @@ class TokenStoreKeyMissingError(RuntimeError):
     """
 
 
+class TokenStoreKeyMismatchError(TokenStoreKeyMissingError):
+    """The configured key cannot authenticate the existing aggregate.
+
+    This is deliberately a subtype of :class:`TokenStoreKeyMissingError` so
+    callers keep the existing fail-closed ``auth_key_missing`` reason-code
+    contract for both absent and unusable key material.
+    """
+
+
+class TokenStoreDurabilityError(OSError):
+    """An aggregate replacement lacks a confirmed persistence barrier."""
+
+
 def resolve_token_store_key() -> bytes:
     """Resolve the AES-256-GCM key, fail-loud (mirrors ``resolve_raw_store_key``).
 
@@ -142,10 +163,16 @@ def resolve_token_store_key() -> bytes:
             "store refuses to read or write plaintext or use a fixed default key. Set "
             f"{KEY_ENV_VAR} to a 64-char hex string (32 bytes)."
         )
+    invalid_hex = False
     try:
         key = bytes.fromhex(raw.strip())
-    except ValueError as exc:
-        raise TokenStoreKeyMissingError(f"{KEY_ENV_VAR} is not valid hex: {exc}") from exc
+    except ValueError:
+        invalid_hex = True
+        key = b""
+    if invalid_hex:
+        # Raised outside the secret-bearing parse handler so recursive
+        # exception inspection cannot reach the rejected environment value.
+        raise TokenStoreKeyMissingError(f"{KEY_ENV_VAR} is not valid hex")
     if len(key) != _AES_KEY_BYTES:
         raise TokenStoreKeyMissingError(
             f"{KEY_ENV_VAR} must decode to {_AES_KEY_BYTES} bytes (AES-256), got {len(key)}"
@@ -277,9 +304,106 @@ class YouTubeTokenStore:
         except FileNotFoundError:
             return {"schema": _SCHEMA, "records": {}}
         data = json.loads(raw)
-        if not isinstance(data, dict) or "records" not in data:
+        if (
+            not isinstance(data, dict)
+            or data.get("schema") != _SCHEMA
+            or not isinstance(data.get("records"), dict)
+        ):
             raise ValueError(f"corrupt token store file at {self._path}")
         return data
+
+    @staticmethod
+    def _encrypted_record(key: bytes, plaintext: bytes) -> dict[str, str]:
+        nonce = os.urandom(_NONCE_BYTES)
+        ciphertext = AESGCM(key).encrypt(nonce, plaintext, None)
+        return {
+            "ciphertext": base64.b64encode(ciphertext).decode("ascii"),
+            "nonce": base64.b64encode(nonce).decode("ascii"),
+        }
+
+    @staticmethod
+    def _decrypt_record(record: Any, key: bytes) -> bytes:
+        failed = False
+        plaintext = b""
+        try:
+            if not isinstance(record, dict):
+                raise TypeError
+            ciphertext = base64.b64decode(record["ciphertext"], validate=True)
+            nonce = base64.b64decode(record["nonce"], validate=True)
+            plaintext = AESGCM(key).decrypt(nonce, ciphertext, None)
+        except (InvalidTag, binascii.Error, KeyError, TypeError, ValueError):
+            failed = True
+        if failed:
+            # Never chain the cryptography/base64 failure: even defensive error
+            # walkers must not gain another route into credential-bearing data.
+            raise TokenStoreKeyMismatchError(
+                "configured YouTube token-store key cannot authenticate the encrypted aggregate"
+            )
+        return plaintext
+
+    def _bind_or_verify_aggregate_key(
+        self,
+        data: dict[str, Any],
+        key: bytes,
+        *,
+        initialize: bool,
+    ) -> bool:
+        """Cryptographically bind ``key`` to the whole existing aggregate.
+
+        New/current aggregates carry an encrypted fixed canary. Legacy
+        aggregates without a canary are admitted only after *every* encrypted
+        record authenticates under the configured key; the next write then
+        installs the canary. This prevents a valid-but-wrong key from appending
+        a mixed-key record to an existing file.
+        """
+        key_check = data.get("key_check")
+        if key_check is not None:
+            if self._decrypt_record(key_check, key) != _KEY_CHECK_PLAINTEXT:
+                raise TokenStoreKeyMismatchError(
+                    "configured YouTube token-store key cannot authenticate the encrypted aggregate"
+                )
+            # The canary binds the configured key, while authenticating every
+            # record rejects a pre-existing partial/mixed-key aggregate rather
+            # than carrying it forward under an otherwise valid canary.
+            for record in data["records"].values():
+                self._decrypt_record(record, key)
+            return False
+
+        for record in data["records"].values():
+            self._decrypt_record(record, key)
+        if not initialize:
+            return False
+        data["key_check"] = self._encrypted_record(key, _KEY_CHECK_PLAINTEXT)
+        return True
+
+    def _sync_parent_directory(self) -> None:
+        """Confirm the directory-entry barrier on POSIX.
+
+        Windows takes the separate ``MoveFileExW(..., WRITE_THROUGH)`` path in
+        :meth:`_replace_with_barrier`; opening/fsyncing a directory is not a
+        portable Windows operation.
+        """
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+        directory_fd = os.open(self._path.parent, flags)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+
+    def _replace_with_barrier(self, source: Path) -> None:
+        if os.name != "nt":
+            os.replace(source, self._path)
+            self._sync_parent_directory()
+            return
+
+        # MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH. The latter is
+        # Windows' supported persistence barrier for the rename itself; a
+        # directory fsync emulation would be both unreliable and unportable.
+        move_file_ex = getattr(ctypes, "windll").kernel32.MoveFileExW
+        move_file_ex.argtypes = (ctypes.c_wchar_p, ctypes.c_wchar_p, ctypes.c_uint32)
+        move_file_ex.restype = ctypes.c_int
+        if not move_file_ex(str(source), str(self._path), 0x1 | 0x8):
+            raise OSError("Windows write-through token-store replacement failed")
 
     def _write_file(self, data: dict[str, Any]) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)
@@ -290,14 +414,19 @@ class YouTubeTokenStore:
             # The staged ciphertext/index must reach stable storage before its
             # name can replace the last durable aggregate.
             os.fsync(staged.fileno())
-        os.replace(tmp, self._path)
-        # Persist the directory-entry replacement itself. Without this fsync a
-        # crash can lose the newly renamed token journal despite a synced file.
-        directory_fd = os.open(self._path.parent, os.O_RDONLY)
+        barrier_failed = False
         try:
-            os.fsync(directory_fd)
-        finally:
-            os.close(directory_fd)
+            self._replace_with_barrier(tmp)
+        except OSError:
+            barrier_failed = True
+        if barrier_failed:
+            # A visible replacement is intentionally not treated as durable
+            # authority. OAuth callers may retry the barrier explicitly before
+            # accepting exact readback; otherwise they compensate or preserve
+            # the prior pending journal.
+            raise TokenStoreDurabilityError(
+                "YouTube token-store replacement lacks a confirmed persistence barrier"
+            )
 
     def has_record(self, binding_id: str) -> bool:
         """True if a token record exists for ``binding_id`` (no key required)."""
@@ -339,24 +468,45 @@ class YouTubeTokenStore:
         AESGCM(key).encrypt(os.urandom(_NONCE_BYTES), b"youtube-token-store-readiness", None)
         with self._lock, self._aggregate_file_lock():
             data = self._load_file()
+            self._bind_or_verify_aggregate_key(data, key, initialize=True)
             self._write_file(data)
             verified = self._load_file()
             if verified != data:
                 raise RuntimeError("YouTube token store readiness verification failed")
+            self._bind_or_verify_aggregate_key(verified, key, initialize=False)
 
     def put(self, binding_id: str, token: StoredToken) -> None:
         """Encrypt and persist ``token`` for ``binding_id`` (requires the key)."""
         key = resolve_token_store_key()
         plaintext = json.dumps(token._to_plain(), sort_keys=True).encode("utf-8")
-        nonce = os.urandom(_NONCE_BYTES)
-        ciphertext = AESGCM(key).encrypt(nonce, plaintext, None)
         with self._lock, self._aggregate_file_lock():
             data = self._load_file()
-            data["records"][binding_id] = {
-                "ciphertext": base64.b64encode(ciphertext).decode("ascii"),
-                "nonce": base64.b64encode(nonce).decode("ascii"),
-            }
+            self._bind_or_verify_aggregate_key(data, key, initialize=True)
+            data["records"][binding_id] = self._encrypted_record(key, plaintext)
             self._write_file(data)
+
+    def confirm_record_durable(self, binding_id: str, expected: StoredToken) -> bool:
+        """Retry the parent barrier, then authenticate exact record authority.
+
+        Used only after :class:`TokenStoreDurabilityError`. Readback happens
+        *after* the successful retry barrier; visibility alone never proves
+        crash durability.
+        """
+        confirmed = False
+        try:
+            with self._lock, self._aggregate_file_lock():
+                self._sync_parent_directory()
+                data = self._load_file()
+                record = data["records"].get(binding_id)
+                if record is None:
+                    return False
+                key = resolve_token_store_key()
+                self._bind_or_verify_aggregate_key(data, key, initialize=False)
+                plaintext = self._decrypt_record(record, key)
+                confirmed = StoredToken._from_plain(json.loads(plaintext.decode("utf-8"))) == expected
+        except Exception:
+            confirmed = False
+        return confirmed
 
     def get(self, binding_id: str) -> StoredToken | None:
         """Return the decrypted token for ``binding_id``, or None if absent.
@@ -367,21 +517,36 @@ class YouTubeTokenStore:
         path (fail closed, INV-YSS-4).
         """
         with self._lock, self._aggregate_file_lock():
-            record = self._load_file()["records"].get(binding_id)
-        if record is None:
-            return None
-        key = resolve_token_store_key()
-        ciphertext = base64.b64decode(record["ciphertext"])
-        nonce = base64.b64decode(record["nonce"])
-        plaintext = AESGCM(key).decrypt(nonce, ciphertext, None)
-        return StoredToken._from_plain(json.loads(plaintext.decode("utf-8")))
+            data = self._load_file()
+            record = data["records"].get(binding_id)
+            if record is None:
+                return None
+            key = resolve_token_store_key()
+            self._bind_or_verify_aggregate_key(data, key, initialize=False)
+            plaintext = self._decrypt_record(record, key)
+        malformed = False
+        try:
+            decoded = json.loads(plaintext.decode("utf-8"))
+            if not isinstance(decoded, dict):
+                raise TypeError
+            token = StoredToken._from_plain(decoded)
+        except (KeyError, TypeError, UnicodeDecodeError, ValueError, json.JSONDecodeError):
+            malformed = True
+            token = None
+        if malformed:
+            raise TokenStoreKeyMismatchError(
+                "configured YouTube token-store key cannot authenticate the encrypted aggregate"
+            )
+        return token
 
 
 __all__ = [
     "KEY_ENV_VAR",
     "PATH_ENV_VAR",
     "StoredToken",
+    "TokenStoreDurabilityError",
     "TokenStoreKeyMissingError",
+    "TokenStoreKeyMismatchError",
     "YouTubeTokenStore",
     "default_token_store_path",
     "resolve_token_store_key",

--- a/app/knowledge_acquisition/youtube_token_store.py
+++ b/app/knowledge_acquisition/youtube_token_store.py
@@ -215,6 +215,7 @@ class StoredToken:
     promotion_target_binding_id: str | None = None
     promotion_predecessor_refresh_token: str | None = None
     promotion_predecessor_generation: int | None = None
+    promotion_predecessor_binding_updated_at: str | None = None
     promotion_display_label: str | None = None
     # A rotated refresh journal must become non-promotable before provider
     # compensation. ``pending`` means revocation must be retried; ``compensated``
@@ -241,6 +242,9 @@ class StoredToken:
             promotion_target_binding_id=self.promotion_target_binding_id,
             promotion_predecessor_refresh_token=self.promotion_predecessor_refresh_token,
             promotion_predecessor_generation=self.promotion_predecessor_generation,
+            promotion_predecessor_binding_updated_at=(
+                self.promotion_predecessor_binding_updated_at
+            ),
             promotion_display_label=self.promotion_display_label,
             promotion_compensation_state=self.promotion_compensation_state,
         )
@@ -257,6 +261,9 @@ class StoredToken:
             "promotion_target_binding_id": self.promotion_target_binding_id,
             "promotion_predecessor_refresh_token": self.promotion_predecessor_refresh_token,
             "promotion_predecessor_generation": self.promotion_predecessor_generation,
+            "promotion_predecessor_binding_updated_at": (
+                self.promotion_predecessor_binding_updated_at
+            ),
             "promotion_display_label": self.promotion_display_label,
             "promotion_compensation_state": self.promotion_compensation_state,
         }
@@ -279,6 +286,9 @@ class StoredToken:
                 int(data["promotion_predecessor_generation"])
                 if data.get("promotion_predecessor_generation") is not None
                 else None
+            ),
+            promotion_predecessor_binding_updated_at=data.get(
+                "promotion_predecessor_binding_updated_at"
             ),
             promotion_display_label=data.get("promotion_display_label"),
             promotion_compensation_state=data.get("promotion_compensation_state"),

--- a/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
@@ -40,8 +40,13 @@ touch the repo, vault, settings values, logs, events, or receipts.
    from `YOUTUBE_OAUTH_CLIENT_ID`/`YOUTUBE_OAUTH_CLIENT_SECRET` env (host secret-provisioning
    boundary); their *values* are never persisted or printed.
 4. **Degradation + lifecycle:** revoked/expired/invalid_grant map to `auth_revoked`/`auth_expired`
-   reason codes on the binding and dependent sources (INV-YSS-4). Connect persists the encrypted
-   token before claiming a binding is connected. Connect, reconnect, refresh, and disconnect are
+   reason codes on the binding and dependent sources (INV-YSS-4). Before each device-token poll,
+   connect proves encryption-key and locked atomic-store readiness. A returned grant is immediately
+   encrypted under an opaque pending-journal id before the fallible identity probe or binding work.
+   Identity/journal failure is provider-compensated when revocation is authoritative; otherwise the
+   pending authority remains encrypted and locally retryable. Canonical binding persistence precedes
+   the `connected` claim; later pending cleanup may leave only a redundant encrypted copy on crash.
+   Connect, reconnect, refresh, and disconnect are
    serialized per binding across service instances and runtime processes sharing the channel token
    store. The app-local lock filename is a digest of the binding id and the private lock file
    contains no account identifier or secret. A portable store-wide lock serializes aggregate-file

--- a/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
@@ -25,8 +25,10 @@ touch the repo, vault, settings values, logs, events, or receipts.
      verification_url_complete, user_code, interval}`; `poll_device_flow()` until
      granted/denied/expired. Headless-friendly; the complete-URL variant means the user clicks a
      link or scans a QR — no typing required.
-   - **Loopback installed-app flow (secondary):** authorization-code + PKCE against a
-     `127.0.0.1:<ephemeral>` redirect for same-host setups. OAuth `state` validated; tokens never
+   - **Loopback installed-app flow (secondary):** authorization-code + PKCE against an exact
+     `http://127.0.0.1:<ephemeral>` redirect for same-host setups. Start and completion both reject
+     any other scheme/host, missing or invalid port, userinfo, query, or fragment. OAuth `state`
+     validated; tokens never
      appear in URLs beyond the provider's own redirect params.
    - Scope: exactly `https://www.googleapis.com/auth/youtube.readonly`. Refresh, expiry-aware
      access-token provider `TokenProvider.get_access_token()` with single-flight refresh.
@@ -45,7 +47,8 @@ touch the repo, vault, settings values, logs, events, or receipts.
    while rotated-refresh recovery maps to `auth_refresh_pending`, `auth_refresh_conflict`, or
    `auth_refresh_durability`, on both the binding and dependent sources (INV-YSS-4). Before each
    device-token poll, connect proves encryption-key and locked atomic-store readiness. POSIX store
-   writes sync the staged file before atomic replacement and confirm the parent-directory barrier afterward;
+   writes sync the staged file before atomic replacement and confirm the complete parent-directory
+   chain through the filesystem root afterward, including first-use nested directories;
    Windows uses write-through replacement. Visible readback after a failed barrier is not accepted
    as crash-durable until a fresh barrier succeeds. A returned grant is
    immediately encrypted under an opaque pending-journal id before the fallible identity probe or
@@ -71,8 +74,11 @@ touch the repo, vault, settings values, logs, events, or receipts.
    renews the access token and retains the stored refresh credential. Defense in depth still treats
    an unexpected different `refresh_token` as rotation: preflight precedes `/token`, the response is
    journaled encrypted before canonical promotion, and a write failure recovers on the next access
-   only over the proven predecessor generation. Pending/conflicting refresh authority degrades
-   status and blocks reconnect/disconnect provider actions until safely resolved.
+   only over the proven predecessor generation. Pending/conflicting refresh authority durably
+   degrades the account binding and every dependent source, without cursor mutation, and blocks
+   reconnect/disconnect provider actions until safely resolved. A reconnect never cleans its
+   pending journal merely because canonical ciphertext is visible: the binding row must also be
+   durably `connected` before cleanup.
    Connect, reconnect, refresh, and disconnect are
    serialized per binding across service instances and runtime processes sharing the channel token
    store. The app-local lock filename is a digest of the binding id and the private lock file

--- a/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
@@ -40,10 +40,13 @@ touch the repo, vault, settings values, logs, events, or receipts.
    from `YOUTUBE_OAUTH_CLIENT_ID`/`YOUTUBE_OAUTH_CLIENT_SECRET` env (host secret-provisioning
    boundary); their *values* are never persisted or printed.
 4. **Degradation + lifecycle:** revoked/expired/invalid_grant map to `auth_revoked`/`auth_expired`
-   reason codes on the binding and dependent sources (INV-YSS-4). `disconnect()` revokes at
-   `oauth2.googleapis.com/revoke`, deletes the token record, disables dependent sources with
-   `auth_disconnected` — and deletes no acquired artifacts. `reconnect()` re-runs consent onto the
-   same binding when the provider channel id matches.
+   reason codes on the binding and dependent sources (INV-YSS-4). Connect persists the encrypted
+   token before claiming a binding is connected. `disconnect()` revokes at
+   `oauth2.googleapis.com/revoke` before local teardown; provider revoke failure returns a
+   retryable failure and preserves the encrypted token plus dependent-source state. Successful
+   revoke deletes the token record, disables dependent sources with `auth_disconnected`, and
+   deletes no acquired artifacts. `reconnect()` re-runs consent onto the same binding when the
+   provider channel id matches.
 5. Redaction: all exception/log/serialization paths sanitize provider responses (status + error
    class only); no token, code, or client secret in any emitted string.
 

--- a/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
@@ -41,12 +41,16 @@ touch the repo, vault, settings values, logs, events, or receipts.
    boundary); their *values* are never persisted or printed.
 4. **Degradation + lifecycle:** revoked/expired/invalid_grant map to `auth_revoked`/`auth_expired`
    reason codes on the binding and dependent sources (INV-YSS-4). Connect persists the encrypted
-   token before claiming a binding is connected. `disconnect()` revokes at
-   `oauth2.googleapis.com/revoke` before local teardown; provider revoke failure returns a
-   retryable failure and preserves the encrypted token plus dependent-source state. Successful
-   revoke deletes the token record, disables dependent sources with `auth_disconnected`, and
-   deletes no acquired artifacts. `reconnect()` re-runs consent onto the same binding when the
-   provider channel id matches.
+   token before claiming a binding is connected. Connect, reconnect, refresh, and disconnect are
+   serialized per binding across service instances and runtime processes sharing the channel token
+   store. The app-local lock filename is a digest of the binding id and the private lock file
+   contains no account identifier or secret. `disconnect()` revokes at
+   `oauth2.googleapis.com/revoke` before local teardown. Retryable failures (transport, 408, 429,
+   or 5xx) preserve the encrypted token and dependent-source state for retry; a permanent 4xx
+   rejection completes local teardown with `revoked=false` because the old grant supplies no
+   useful retry authority. Teardown deletes the token record, disables dependent sources with
+   `auth_disconnected`, and deletes no acquired artifacts. `reconnect()` re-runs consent onto the
+   same binding when the provider channel id matches.
 5. Redaction: all exception/log/serialization paths sanitize provider responses (status + error
    class only); no token, code, or client secret in any emitted string.
 

--- a/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
@@ -76,7 +76,8 @@ touch the repo, vault, settings values, logs, events, or receipts.
    journaled encrypted before canonical promotion, and a write failure recovers on the next access
    only over the proven predecessor generation. Before provider compensation, the encrypted
    journal is durably marked non-promotable; authoritative revocation advances that marker to
-   compensated before best-effort cleanup, so crash residue can never restore revoked authority.
+   compensated and durably degrades binding/source truth to `auth_revoked` before best-effort
+   cleanup, so a crash can never restore revoked authority or report the binding connected.
    Pending/conflicting refresh authority durably
    degrades the account binding and every dependent source, without cursor mutation, and blocks
    reconnect/disconnect provider actions until safely resolved. Failure classification and the
@@ -84,6 +85,10 @@ touch the repo, vault, settings values, logs, events, or receipts.
    stale actor cannot overwrite another service instance's completed recovery. A reconnect never cleans its
    pending journal merely because canonical ciphertext is visible: the binding row must also be
    durably `connected` before cleanup.
+   A completed operator disconnect is terminal for queued token consumers: missing ciphertext after
+   disconnect preserves `auth_disconnected` on the binding and disabled sources instead of being
+   rewritten as `auth_missing`. Compensated refresh residue reports `auth_revoked`; disconnect may
+   clean it and finish teardown, while reconnect can replace it only through new consent.
    Connect, reconnect, refresh, and disconnect are
    serialized per binding across service instances and runtime processes sharing the channel token
    store. The app-local lock filename is a digest of the binding id and the private lock file

--- a/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
@@ -32,24 +32,30 @@ touch the repo, vault, settings values, logs, events, or receipts.
      access-token provider `TokenProvider.get_access_token()` with single-flight refresh.
 2. **Encrypted token store** `app/knowledge_acquisition/youtube_token_store.py`: AES-256-GCM
    (existing `cryptography` dependency, mirroring `app/heimdal/raw_store.py` key discipline), key
-   from `YOUTUBE_TOKEN_STORE_KEY` (32 bytes; absent key ⇒ `TokenStoreKeyMissingError`, fail
-   closed, never plaintext). Store file path is an app-local binding defaulting under the channel
-   runtime dir; never inside a vault, never tracked.
+   from `YOUTUBE_TOKEN_STORE_KEY` (32 bytes; absent or valid-but-wrong key ⇒
+   `TokenStoreKeyMissingError`, fail closed, never plaintext). An authenticated encrypted canary
+   binds the key to the aggregate; legacy no-canary files authenticate every existing record before
+   upgrade, so a wrong key cannot create a mixed-key store. Store file path is an app-local binding
+   defaulting under the channel runtime dir; never inside a vault, never tracked.
 3. **Account binding record** (non-secret) in the registry substrate: binding id, provider channel
    id, display label, connected/degraded state, scopes, obtained_at. Client credentials resolve
    from `YOUTUBE_OAUTH_CLIENT_ID`/`YOUTUBE_OAUTH_CLIENT_SECRET` env (host secret-provisioning
    boundary); their *values* are never persisted or printed.
 4. **Degradation + lifecycle:** revoked/expired/invalid_grant map to `auth_revoked`/`auth_expired`
    reason codes on the binding and dependent sources (INV-YSS-4). Before each device-token poll,
-   connect proves encryption-key and locked atomic-store readiness. Store writes sync the staged
-   file before atomic replacement and the parent directory afterward. A returned grant is
+   connect proves encryption-key and locked atomic-store readiness. POSIX store writes sync the
+   staged file before atomic replacement and confirm the parent-directory barrier afterward;
+   Windows uses write-through replacement. Visible readback after a failed barrier is not accepted
+   as crash-durable until a fresh barrier succeeds. A returned grant is
    immediately encrypted under an opaque pending-journal id before the fallible identity probe or
    binding work. Exact encrypted-record readback treats a lost write acknowledgement as durable
    success, so a landed pending journal or canonical reconnect token is never revoked as though its
    write failed. Identity/journal failure is provider-compensated when revocation is authoritative;
    otherwise the pending authority remains encrypted and locally retryable. Canonical binding
    persistence precedes the `connected` claim; later pending cleanup may leave only a redundant
-   encrypted copy on crash.
+   encrypted copy on crash. Promotion and cleanup stay within pending/channel/binding lifecycle
+   authority; retry recognizes a live canonical grant (even after later token rotation) and cleans
+   the duplicate without revoking it.
    Connect, reconnect, refresh, and disconnect are
    serialized per binding across service instances and runtime processes sharing the channel token
    store. The app-local lock filename is a digest of the binding id and the private lock file
@@ -125,8 +131,9 @@ Keychain-bootstrap boundary.
 ## Restart / Durability Posture
 
 Bindings and encrypted tokens survive restart on disk (app-local, per channel). A restart with a
-missing key degrades to `auth_key_missing` — visible, fail-closed, recoverable by re-provisioning
-the key; consent is not silently re-requested. In-flight device-flow sessions do not survive
+missing key, wrong key, or unauthenticatable encrypted aggregate degrades to `auth_key_missing` —
+visible, fail-closed, recoverable by re-provisioning the correct key; consent is not silently
+re-requested. In-flight device-flow sessions do not survive
 restart; the user simply restarts the connect step (the UI/CLI says so).
 
 ## Related Docs

--- a/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
@@ -36,9 +36,12 @@ touch the repo, vault, settings values, logs, events, or receipts.
    (existing `cryptography` dependency, mirroring `app/heimdal/raw_store.py` key discipline), key
    from `YOUTUBE_TOKEN_STORE_KEY` (32 bytes; absent or valid-but-wrong key ⇒
    `TokenStoreKeyMissingError`, fail closed, never plaintext). An authenticated encrypted canary
-   binds the key to the aggregate; legacy no-canary files authenticate every existing record before
-   upgrade, so a wrong key cannot create a mixed-key store. Store file path is an app-local binding
-   defaulting under the channel runtime dir; never inside a vault, never tracked.
+   binds the key to the aggregate. Each current record authenticates its exact outer id as
+   domain-separated AEAD associated data and repeats the id inside its encrypted versioned envelope.
+   Legacy pre-AAD files upgrade atomically only after binding/channel and pending-target authority is
+   proven for every decrypted record; a pre-swapped or otherwise unprovable association fails closed
+   without mutation. A wrong key cannot create a mixed-key store. Store file path is an app-local
+   binding defaulting under the channel runtime dir; never inside a vault, never tracked.
 3. **Account binding record** (non-secret) in the registry substrate: binding id, provider channel
    id, display label, connected/degraded state, scopes, obtained_at, and a durable monotonic binding
    generation. Each state write advances the generation; terminal-state recovery compares it
@@ -68,7 +71,10 @@ touch the repo, vault, settings values, logs, events, or receipts.
    winner remains a non-destructive conflict. Later cleanup may leave only a redundant encrypted
    copy on crash. Promotion and cleanup stay within pending/channel/binding lifecycle authority. The
    pending ciphertext records its exact target, predecessor refresh authority, and
-   next generation before canonical write. Retry cleans only the same refresh authority, promotes
+   next credential and binding generation before canonical write. Direct reconnect and candidate-row
+   recovery clear terminal state only through compare-and-set against that durable pending evidence:
+   an exact matching disconnected generation can converge, while a concurrent or stale revoked
+   generation wins. Retry cleans only the same refresh authority, promotes
    only over that unchanged predecessor, and preserves a same-channel token mismatch as
    `pending_conflict` without deletion or provider revocation; channel identity alone is not grant
    identity.

--- a/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
@@ -54,8 +54,17 @@ touch the repo, vault, settings values, logs, events, or receipts.
    otherwise the pending authority remains encrypted and locally retryable. Canonical binding
    persistence precedes the `connected` claim; later pending cleanup may leave only a redundant
    encrypted copy on crash. Promotion and cleanup stay within pending/channel/binding lifecycle
-   authority; retry recognizes a live canonical grant (even after later token rotation) and cleans
-   the duplicate without revoking it.
+   authority. The pending ciphertext records its exact target, predecessor refresh authority, and
+   next generation before canonical write. Retry cleans only the same refresh authority, promotes
+   only over that unchanged predecessor, and preserves a same-channel token mismatch as
+   `pending_conflict` without deletion or provider revocation; channel identity alone is not grant
+   identity.
+   Google's [documented refresh response](https://developers.google.com/identity/protocols/oauth2/web-server#offline)
+   renews the access token and retains the stored refresh credential. Defense in depth still treats
+   an unexpected different `refresh_token` as rotation: preflight precedes `/token`, the response is
+   journaled encrypted before canonical promotion, and a write failure recovers on the next access
+   only over the proven predecessor generation. Pending/conflicting refresh authority degrades
+   status and blocks reconnect/disconnect provider actions until safely resolved.
    Connect, reconnect, refresh, and disconnect are
    serialized per binding across service instances and runtime processes sharing the channel token
    store. The app-local lock filename is a digest of the binding id and the private lock file

--- a/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
@@ -74,9 +74,14 @@ touch the repo, vault, settings values, logs, events, or receipts.
    renews the access token and retains the stored refresh credential. Defense in depth still treats
    an unexpected different `refresh_token` as rotation: preflight precedes `/token`, the response is
    journaled encrypted before canonical promotion, and a write failure recovers on the next access
-   only over the proven predecessor generation. Pending/conflicting refresh authority durably
+   only over the proven predecessor generation. Before provider compensation, the encrypted
+   journal is durably marked non-promotable; authoritative revocation advances that marker to
+   compensated before best-effort cleanup, so crash residue can never restore revoked authority.
+   Pending/conflicting refresh authority durably
    degrades the account binding and every dependent source, without cursor mutation, and blocks
-   reconnect/disconnect provider actions until safely resolved. A reconnect never cleans its
+   reconnect/disconnect provider actions until safely resolved. Failure classification and the
+   matching binding/source degradation remain inside the same per-binding lifecycle lock, so a
+   stale actor cannot overwrite another service instance's completed recovery. A reconnect never cleans its
    pending journal merely because canonical ciphertext is visible: the binding row must also be
    durably `connected` before cleanup.
    Connect, reconnect, refresh, and disconnect are

--- a/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
@@ -46,17 +46,19 @@ touch the repo, vault, settings values, logs, events, or receipts.
    store. The app-local lock filename is a digest of the binding id and the private lock file
    contains no account identifier or secret. A portable store-wide lock serializes aggregate-file
    mutations across distinct bindings on POSIX and Windows, while concurrent first connects
-   re-resolve provider identity under shared authority. A create exception after database commit
-   rolls forward through authoritative binding/channel readback; indeterminate readback preserves
-   the encrypted credential. `disconnect()` revokes at `oauth2.googleapis.com/revoke` before local
-   teardown. Only an applicable non-408/non-429 4xx response is an authoritative permanent
-   rejection and permits local teardown with `revoked=false`. Transport failures, 1xx/3xx, 408,
-   429, 5xx, and unknown statuses preserve the encrypted token and dependent-source state for
-   retry/reconciliation. Teardown deletes the token record, disables dependent sources with
-   `auth_disconnected`, and deletes no acquired artifacts. `reconnect()` re-runs consent onto the
-   same binding when the provider channel id matches.
-5. Redaction: all exception/log/serialization paths sanitize provider responses (status + error
-   class only); no token, code, or client secret in any emitted string.
+   re-resolve provider identity under shared authority. First-connect binding ids are deterministic
+   per provider channel. A create exception rolls forward when the row is visible; negative read
+   snapshots preserve the encrypted credential because a delayed commit may still appear, and retry
+   converges on the same candidate id. `disconnect()` revokes at `oauth2.googleapis.com/revoke`
+   before local teardown. Only Google's documented HTTP 400 `invalid_token` outcome (already expired
+   or revoked) permits teardown with `revoked=false`; `invalid_request`, intermediary/unknown 4xx,
+   redirects, transport failures, and every other unproven outcome preserve the encrypted token and
+   dependent-source state for retry/reconciliation. Every credential-bearing OAuth POST disables
+   redirect following at the request site. Teardown deletes the token record, disables dependent
+   sources with `auth_disconnected`, and deletes no acquired artifacts. `reconnect()` re-runs consent
+   onto the same binding when the provider channel id matches.
+5. Redaction: all exception/log/serialization paths sanitize provider responses (status + an
+   allowlisted OAuth error enum only); no token, code, or client secret in any emitted string.
 
 ## Concretely
 

--- a/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
@@ -46,11 +46,13 @@ touch the repo, vault, settings values, logs, events, or receipts.
    store. The app-local lock filename is a digest of the binding id and the private lock file
    contains no account identifier or secret. A portable store-wide lock serializes aggregate-file
    mutations across distinct bindings on POSIX and Windows, while concurrent first connects
-   re-resolve provider identity under shared authority. `disconnect()` revokes at
-   `oauth2.googleapis.com/revoke` before local teardown. Retryable failures (transport, 408, 429,
-   or 5xx) preserve the encrypted token and dependent-source state for retry; a permanent 4xx
-   rejection completes local teardown with `revoked=false` because the old grant supplies no
-   useful retry authority. Teardown deletes the token record, disables dependent sources with
+   re-resolve provider identity under shared authority. A create exception after database commit
+   rolls forward through authoritative binding/channel readback; indeterminate readback preserves
+   the encrypted credential. `disconnect()` revokes at `oauth2.googleapis.com/revoke` before local
+   teardown. Only an applicable non-408/non-429 4xx response is an authoritative permanent
+   rejection and permits local teardown with `revoked=false`. Transport failures, 1xx/3xx, 408,
+   429, 5xx, and unknown statuses preserve the encrypted token and dependent-source state for
+   retry/reconciliation. Teardown deletes the token record, disables dependent sources with
    `auth_disconnected`, and deletes no acquired artifacts. `reconnect()` re-runs consent onto the
    same binding when the provider channel id matches.
 5. Redaction: all exception/log/serialization paths sanitize provider responses (status + error

--- a/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
@@ -41,21 +41,24 @@ touch the repo, vault, settings values, logs, events, or receipts.
    id, display label, connected/degraded state, scopes, obtained_at. Client credentials resolve
    from `YOUTUBE_OAUTH_CLIENT_ID`/`YOUTUBE_OAUTH_CLIENT_SECRET` env (host secret-provisioning
    boundary); their *values* are never persisted or printed.
-4. **Degradation + lifecycle:** revoked/expired/invalid_grant map to `auth_revoked`/`auth_expired`
-   reason codes on the binding and dependent sources (INV-YSS-4). Before each device-token poll,
-   connect proves encryption-key and locked atomic-store readiness. POSIX store writes sync the
-   staged file before atomic replacement and confirm the parent-directory barrier afterward;
+4. **Degradation + lifecycle:** revoked/expired/invalid_grant map to `auth_revoked`/`auth_expired`,
+   while rotated-refresh recovery maps to `auth_refresh_pending`, `auth_refresh_conflict`, or
+   `auth_refresh_durability`, on both the binding and dependent sources (INV-YSS-4). Before each
+   device-token poll, connect proves encryption-key and locked atomic-store readiness. POSIX store
+   writes sync the staged file before atomic replacement and confirm the parent-directory barrier afterward;
    Windows uses write-through replacement. Visible readback after a failed barrier is not accepted
    as crash-durable until a fresh barrier succeeds. A returned grant is
    immediately encrypted under an opaque pending-journal id before the fallible identity probe or
    binding work. Exact encrypted-record readback treats a lost write acknowledgement as durable
    success, so a landed pending journal or canonical reconnect token is never revoked as though its
    write failed. Identity/journal failure is provider-compensated when revocation is authoritative;
-   otherwise the pending authority remains encrypted and locally retryable. Canonical binding
-   persistence precedes the `connected` claim; pending cleanup begins only after the matching
-   binding row is visible. A deterministic first-connect candidate without that row retains its
-   per-attempt retry journal, and a later consent gets a distinct journal instead of overwriting the
-   earlier grant. Retry uses encrypted display metadata to re-attempt the same deterministic binding
+   otherwise the pending authority remains encrypted and locally retryable. For a pending-only
+   first connect, canonical token durability precedes binding-row creation and the `connected`
+   claim. If an older canonical predecessor already exists, its row is recovered before a distinct
+   later grant may replace it, so failed row recovery preserves both authorities. Pending cleanup
+   begins only after the matching binding row is visible. A deterministic first-connect candidate
+   without that row retains its per-attempt retry journal, and a later consent gets a distinct
+   journal instead of overwriting the earlier grant. Retry uses encrypted display metadata to re-attempt the same deterministic binding
    create without minting another grant; a delayed exact row converges and a different same-channel
    winner remains a non-destructive conflict. Later cleanup may leave only a redundant encrypted
    copy on crash. Promotion and cleanup stay within pending/channel/binding lifecycle authority. The

--- a/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
@@ -82,7 +82,12 @@ touch the repo, vault, settings values, logs, events, or receipts.
    renews the access token and retains the stored refresh credential. Defense in depth still treats
    an unexpected different `refresh_token` as rotation: preflight precedes `/token`, the response is
    journaled encrypted before canonical promotion, and a write failure recovers on the next access
-   only over the proven predecessor generation. Before provider compensation, the encrypted
+   only over the proven predecessor generation. A 2xx response that rotates the refresh credential
+   but omits the access token is incomplete, yet the returned standing authority still follows this
+   journal-or-authoritative-compensation path and is never discarded. Canonical promotion does not
+   remove the journal until the binding is durably `connected` and dependent-source auth errors are
+   cleared; partial state convergence keeps the journal so retry can finish without another grant.
+   Before provider compensation, the encrypted
    journal is durably marked non-promotable; authoritative revocation advances that marker to
    compensated, and that encrypted marker must be confirmed durable before binding/source truth
    becomes `auth_revoked` or best-effort cleanup starts. An unconfirmed marker retains `pending`
@@ -96,7 +101,10 @@ touch the repo, vault, settings values, logs, events, or receipts.
    matching binding/source degradation remain inside the same per-binding lifecycle lock, so a
    stale actor cannot overwrite another service instance's completed recovery. A reconnect never cleans its
    pending journal merely because canonical ciphertext is visible: the binding row must also be
-   durably `connected` before cleanup.
+   durably `connected` and dependent-source auth degradation must be converged before cleanup.
+   Restoring the exact key that authenticates canonical ciphertext clears specifically non-terminal
+   `auth_key_missing` through binding-generation compare-and-set under that lock; terminal
+   `auth_disconnected` and `auth_revoked` remain authoritative and cannot be cleared by key recovery.
    An operator disconnect durably marks the binding/source truth `auth_disconnected` before the
    provider revoke. That marker is terminal for queued token consumers even while encrypted
    ciphertext remains solely as retry authority after a crash or indeterminate provider response;
@@ -133,6 +141,8 @@ touch the repo, vault, settings values, logs, events, or receipts.
    failure.
 5. Redaction: all exception/log/serialization paths sanitize provider responses (status + an
    allowlisted OAuth error enum only); no token, code, or client secret in any emitted string.
+   Transport failures are raised only after leaving the `httpx` handler, so the sanitized exception
+   retains no hidden request-bearing `__context__` or `__cause__` chain.
 
 ## Concretely
 

--- a/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
@@ -90,8 +90,11 @@ touch the repo, vault, settings values, logs, events, or receipts.
    ciphertext remains solely as retry authority after a crash or indeterminate provider response;
    it cannot be rewritten as `auth_missing` or consumed as a fresh cached token. Compensated refresh
    residue reports `auth_revoked`; its cleanup persists that terminal truth before deleting the
-   journal. Disconnect may then finish teardown, while reconnect can replace terminal authority only
-   through new consent whose canonical ciphertext and binding state both converge.
+   journal, retrying dependent-source degradation idempotently after any partial write. Disconnect
+   may then finish teardown, while reconnect can replace terminal authority only through new consent
+   whose pending grant names the exact predecessor binding version and whose canonical
+   ciphertext and binding state both converge. Redundant/stale pending cleanup never clears
+   `auth_disconnected` or `auth_revoked`.
    Connect, reconnect, refresh, and disconnect are
    serialized per binding across service instances and runtime processes sharing the channel token
    store. The app-local lock filename is a digest of the binding id and the private lock file
@@ -110,6 +113,9 @@ touch the repo, vault, settings values, logs, events, or receipts.
    redirect following at the request site. Teardown deletes the token record, disables dependent
    sources with `auth_disconnected`, and deletes no acquired artifacts. `reconnect()` re-runs consent
    onto the same binding when the provider channel id matches.
+   Token consumption requires the non-optional binding authority dependency and a positively durable
+   `connected` row with no reason code; ciphertext alone is never access authority. Status likewise
+   gives persisted `auth_disconnected`/`auth_revoked` precedence over transient token-read failures.
 5. Redaction: all exception/log/serialization paths sanitize provider responses (status + an
    allowlisted OAuth error enum only); no token, code, or client secret in any emitted string.
 

--- a/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
@@ -40,7 +40,9 @@ touch the repo, vault, settings values, logs, events, or receipts.
    upgrade, so a wrong key cannot create a mixed-key store. Store file path is an app-local binding
    defaulting under the channel runtime dir; never inside a vault, never tracked.
 3. **Account binding record** (non-secret) in the registry substrate: binding id, provider channel
-   id, display label, connected/degraded state, scopes, obtained_at. Client credentials resolve
+   id, display label, connected/degraded state, scopes, obtained_at, and a durable monotonic binding
+   generation. Each state write advances the generation; terminal-state recovery compares it
+   atomically, while wall-clock `updated_at` remains observational only. Client credentials resolve
    from `YOUTUBE_OAUTH_CLIENT_ID`/`YOUTUBE_OAUTH_CLIENT_SECRET` env (host secret-provisioning
    boundary); their *values* are never persisted or printed.
 4. **Degradation + lifecycle:** revoked/expired/invalid_grant map to `auth_revoked`/`auth_expired`,
@@ -76,8 +78,12 @@ touch the repo, vault, settings values, logs, events, or receipts.
    journaled encrypted before canonical promotion, and a write failure recovers on the next access
    only over the proven predecessor generation. Before provider compensation, the encrypted
    journal is durably marked non-promotable; authoritative revocation advances that marker to
-   compensated and durably degrades binding/source truth to `auth_revoked` before best-effort
-   cleanup, so a crash can never restore revoked authority or report the binding connected.
+   compensated, and that encrypted marker must be confirmed durable before binding/source truth
+   becomes `auth_revoked` or best-effort cleanup starts. An unconfirmed marker retains `pending`
+   plus `auth_refresh_durability`, and token consumption, reconnect, or disconnect idempotently
+   retries provider compensation and marker persistence. Cleanup failure leaves `compensated`
+   residue that restart converges before any new grant can proceed, so a crash can never restore
+   revoked authority or report the binding connected.
    Pending/conflicting refresh authority durably
    degrades the account binding and every dependent source, without cursor mutation, and blocks
    reconnect/disconnect provider actions until safely resolved. Failure classification and the
@@ -92,8 +98,10 @@ touch the repo, vault, settings values, logs, events, or receipts.
    residue reports `auth_revoked`; its cleanup persists that terminal truth before deleting the
    journal, retrying dependent-source degradation idempotently after any partial write. Disconnect
    may then finish teardown, while reconnect can replace terminal authority only through new consent
-   whose pending grant names the exact predecessor binding version and whose canonical
-   ciphertext and binding state both converge. Redundant/stale pending cleanup never clears
+   whose pending grant names the exact predecessor binding generation and whose canonical
+   ciphertext and binding state both converge through generation compare-and-set. Same-timestamp
+   transitions cannot collide: a terminal state write always advances generation. Stale distinct
+   authority remains `pending_conflict`; redundant same-token cleanup never clears
    `auth_disconnected` or `auth_revoked`.
    Connect, reconnect, refresh, and disconnect are
    serialized per binding across service instances and runtime processes sharing the channel token
@@ -114,8 +122,9 @@ touch the repo, vault, settings values, logs, events, or receipts.
    sources with `auth_disconnected`, and deletes no acquired artifacts. `reconnect()` re-runs consent
    onto the same binding when the provider channel id matches.
    Token consumption requires the non-optional binding authority dependency and a positively durable
-   `connected` row with no reason code; ciphertext alone is never access authority. Status likewise
-   gives persisted `auth_disconnected`/`auth_revoked` precedence over transient token-read failures.
+   `connected` row with no reason code; ciphertext alone is never access authority. Status returns
+   persisted `auth_disconnected`/`auth_revoked` before any token-store read, including ordinary I/O
+   failure.
 5. Redaction: all exception/log/serialization paths sanitize provider responses (status + an
    allowlisted OAuth error enum only); no token, code, or client secret in any emitted string.
 

--- a/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
@@ -44,7 +44,9 @@ touch the repo, vault, settings values, logs, events, or receipts.
    token before claiming a binding is connected. Connect, reconnect, refresh, and disconnect are
    serialized per binding across service instances and runtime processes sharing the channel token
    store. The app-local lock filename is a digest of the binding id and the private lock file
-   contains no account identifier or secret. `disconnect()` revokes at
+   contains no account identifier or secret. A portable store-wide lock serializes aggregate-file
+   mutations across distinct bindings on POSIX and Windows, while concurrent first connects
+   re-resolve provider identity under shared authority. `disconnect()` revokes at
    `oauth2.googleapis.com/revoke` before local teardown. Retryable failures (transport, 408, 429,
    or 5xx) preserve the encrypted token and dependent-source state for retry; a permanent 4xx
    rejection completes local teardown with `revoked=false` because the old grant supplies no

--- a/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
@@ -85,10 +85,13 @@ touch the repo, vault, settings values, logs, events, or receipts.
    stale actor cannot overwrite another service instance's completed recovery. A reconnect never cleans its
    pending journal merely because canonical ciphertext is visible: the binding row must also be
    durably `connected` before cleanup.
-   A completed operator disconnect is terminal for queued token consumers: missing ciphertext after
-   disconnect preserves `auth_disconnected` on the binding and disabled sources instead of being
-   rewritten as `auth_missing`. Compensated refresh residue reports `auth_revoked`; disconnect may
-   clean it and finish teardown, while reconnect can replace it only through new consent.
+   An operator disconnect durably marks the binding/source truth `auth_disconnected` before the
+   provider revoke. That marker is terminal for queued token consumers even while encrypted
+   ciphertext remains solely as retry authority after a crash or indeterminate provider response;
+   it cannot be rewritten as `auth_missing` or consumed as a fresh cached token. Compensated refresh
+   residue reports `auth_revoked`; its cleanup persists that terminal truth before deleting the
+   journal. Disconnect may then finish teardown, while reconnect can replace terminal authority only
+   through new consent whose canonical ciphertext and binding state both converge.
    Connect, reconnect, refresh, and disconnect are
    serialized per binding across service instances and runtime processes sharing the channel token
    store. The app-local lock filename is a digest of the binding id and the private lock file
@@ -97,11 +100,13 @@ touch the repo, vault, settings values, logs, events, or receipts.
    re-resolve provider identity under shared authority. First-connect binding ids are deterministic
    per provider channel. A create exception rolls forward when the row is visible; negative read
    snapshots preserve the encrypted credential because a delayed commit may still appear, and retry
-   converges on the same candidate id. `disconnect()` revokes at `oauth2.googleapis.com/revoke`
-   before local teardown. Only Google's documented HTTP 400 `invalid_token` outcome (already expired
+   converges on the same candidate id. `disconnect()` first makes local token consumption fail
+   closed, then revokes at `oauth2.googleapis.com/revoke` before destructive local teardown. Only
+   Google's documented HTTP 400 `invalid_token` outcome (already expired
    or revoked) permits teardown with `revoked=false`; `invalid_request`, intermediary/unknown 4xx,
-   redirects, transport failures, and every other unproven outcome preserve the encrypted token and
-   dependent-source state for retry/reconciliation. Every credential-bearing OAuth POST disables
+   redirects, transport failures, and every other unproven outcome preserve the encrypted token as
+   revocation-retry authority and keep dependent sources enabled but degraded and non-consumable.
+   Every credential-bearing OAuth POST disables
    redirect following at the request site. Teardown deletes the token record, disables dependent
    sources with `auth_disconnected`, and deletes no acquired artifacts. `reconnect()` re-runs consent
    onto the same binding when the provider channel id matches.

--- a/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
@@ -52,9 +52,14 @@ touch the repo, vault, settings values, logs, events, or receipts.
    success, so a landed pending journal or canonical reconnect token is never revoked as though its
    write failed. Identity/journal failure is provider-compensated when revocation is authoritative;
    otherwise the pending authority remains encrypted and locally retryable. Canonical binding
-   persistence precedes the `connected` claim; later pending cleanup may leave only a redundant
-   encrypted copy on crash. Promotion and cleanup stay within pending/channel/binding lifecycle
-   authority. The pending ciphertext records its exact target, predecessor refresh authority, and
+   persistence precedes the `connected` claim; pending cleanup begins only after the matching
+   binding row is visible. A deterministic first-connect candidate without that row retains its
+   per-attempt retry journal, and a later consent gets a distinct journal instead of overwriting the
+   earlier grant. Retry uses encrypted display metadata to re-attempt the same deterministic binding
+   create without minting another grant; a delayed exact row converges and a different same-channel
+   winner remains a non-destructive conflict. Later cleanup may leave only a redundant encrypted
+   copy on crash. Promotion and cleanup stay within pending/channel/binding lifecycle authority. The
+   pending ciphertext records its exact target, predecessor refresh authority, and
    next generation before canonical write. Retry cleans only the same refresh authority, promotes
    only over that unchanged predecessor, and preserves a same-channel token mismatch as
    `pending_conflict` without deletion or provider revocation; channel identity alone is not grant

--- a/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md
@@ -41,11 +41,15 @@ touch the repo, vault, settings values, logs, events, or receipts.
    boundary); their *values* are never persisted or printed.
 4. **Degradation + lifecycle:** revoked/expired/invalid_grant map to `auth_revoked`/`auth_expired`
    reason codes on the binding and dependent sources (INV-YSS-4). Before each device-token poll,
-   connect proves encryption-key and locked atomic-store readiness. A returned grant is immediately
-   encrypted under an opaque pending-journal id before the fallible identity probe or binding work.
-   Identity/journal failure is provider-compensated when revocation is authoritative; otherwise the
-   pending authority remains encrypted and locally retryable. Canonical binding persistence precedes
-   the `connected` claim; later pending cleanup may leave only a redundant encrypted copy on crash.
+   connect proves encryption-key and locked atomic-store readiness. Store writes sync the staged
+   file before atomic replacement and the parent directory afterward. A returned grant is
+   immediately encrypted under an opaque pending-journal id before the fallible identity probe or
+   binding work. Exact encrypted-record readback treats a lost write acknowledgement as durable
+   success, so a landed pending journal or canonical reconnect token is never revoked as though its
+   write failed. Identity/journal failure is provider-compensated when revocation is authoritative;
+   otherwise the pending authority remains encrypted and locally retryable. Canonical binding
+   persistence precedes the `connected` claim; later pending cleanup may leave only a redundant
+   encrypted copy on crash.
    Connect, reconnect, refresh, and disconnect are
    serialized per binding across service instances and runtime processes sharing the channel token
    store. The app-local lock filename is a digest of the binding id and the private lock file

--- a/docs/YOUTUBE_SOURCE_SYNC/README.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/README.md
@@ -1,4 +1,4 @@
-State: Specification directory (feature-breakdown lane; target-state framing). Instantiates Knowledge Acquisition Platform Phase 4 (continuous discovery) for YouTube. **YSS-01 and YSS-02 are delivered repository-verifiably** (#3916 / PR #3931 and #3917 / PR #3969; YSS-02 transactional lifecycle hardening in #3990); YSS-03..YSS-11 and the parent #3915 operator/live-capability acceptance remain pending. The issue set was filed 2026-07-17.
+State: Specification directory (feature-breakdown lane; target-state framing). Instantiates Knowledge Acquisition Platform Phase 4 (continuous discovery) for YouTube. **YSS-01 through YSS-04 are delivered repository-verifiably** (#3916 / PR #3931, #3917 / PR #3969 with YSS-02 transactional lifecycle hardening in #3990, #3918 / PR #4006, and #3919 / PR #3983); YSS-05..YSS-11 and the parent #3915 operator/live-capability acceptance remain pending. The issue set was filed 2026-07-17.
 Doc role: Capability specification directory
 Authority: Owns the YouTube source-sync capability design — account binding, source registry, continuous discovery, durable acquisition requests, scheduling, and the setup/status surfaces. Subordinate to `docs/KNOWLEDGE_ACQUISITION/README.md` (platform boundary), `docs/KNOWLEDGE_ACQUISITION/SOURCE_PLUGIN_CONTRACT.md` (plugin interface), `docs/KNOWLEDGE_ACQUISITION/REFINEMENT_PIPELINE_CONTRACT.md` (stages), `docs/CONTEXTUALIZATION_LAYER/INGESTION_AND_TRIAGE_POLICY.md` (triage), `docs/EVENTS.md` (event envelope/outbox), and `docs/SECURITY.md` (secret baseline). It revises `docs/KNOWLEDGE_ACQUISITION/YOUTUBE_SOURCE_SPEC.md` §Discovery by owner directive (see §Decision record).
 Owner: Architecture / knowledge acquisition
@@ -114,8 +114,8 @@ it. The operator path (GCP/OAuth setup, first sync, troubleshooting, live accept
 | --- | --- | --- | --- | --- |
 | 1 | [Establish source registry and settings](ESTABLISH_SOURCE_REGISTRY_AND_SETTINGS.md) | YSS-01 | — | **Delivered repository-verifiably** (#3916 / PR #3931): durable per-account source registry + settings model + validation; live capability acceptance remains pending |
 | 2a | [Bind YouTube account with OAuth](BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md) | YSS-02 | YSS-01 | **Delivered repository-verifiably** (#3917 / PR #3969; lifecycle hardening #3990): device+loopback OAuth, secret-ref token store, transactional connect/disconnect, degradation |
-| 2b | [Establish durable acquisition requests](ESTABLISH_DURABLE_ACQUISITION_REQUESTS.md) | YSS-04 | YSS-01 | source-agnostic request queue + dedup + retries + handover to `acquire_youtube` |
-| 3a | [Build YouTube Data API client](BUILD_YOUTUBE_DATA_API_CLIENT.md) | YSS-03 | YSS-02 (token provider interface only — stubbable) | bounded read-only API client: pagination, ETag, quota accounting, host allowlist |
+| 2b | [Establish durable acquisition requests](ESTABLISH_DURABLE_ACQUISITION_REQUESTS.md) | YSS-04 | YSS-01 | **Delivered repository-verifiably** (#3919 / PR #3983): source-agnostic request queue + dedup + retries + handover to `acquire_youtube`; live capability acceptance remains pending |
+| 3a | [Build YouTube Data API client](BUILD_YOUTUBE_DATA_API_CLIENT.md) | YSS-03 | YSS-02 (token provider interface only — stubbable) | **Delivered repository-verifiably** (#3918 / PR #4006): bounded read-only API client with pagination, ETag, quota accounting, and host allowlist; live capability acceptance remains pending |
 | 3b | [Sync subscriptions from Takeout and RSS](SYNC_SUBSCRIPTIONS_FROM_TAKEOUT_AND_RSS.md) | YSS-07 | YSS-01, YSS-04 | Takeout adoption (operator WIP baseline), channel-RSS incremental discovery, policy modes |
 | 4 | [Discover playlist items continuously](DISCOVER_PLAYLIST_ITEMS_CONTINUOUSLY.md) | YSS-05 | YSS-01, YSS-03, YSS-04 | generic playlist adapter (inbox/owned/liked/public/private), dedup + provenance, cursor discipline, unsupported-list refusal |
 | 5 | [Schedule and operate continuous sync](SCHEDULE_AND_OPERATE_CONTINUOUS_SYNC.md) | YSS-06 | YSS-04, YSS-05 | per-source scheduling, single-run lease, pause, offline/restart reconciliation, backoff, safe shutdown |
@@ -165,7 +165,11 @@ Invariants that hold *across* tasks, with their partial-failure seams:
   a pending journal nor a canonical reconnect token is revoked after it actually landed. Identity or
   first-journal failure is provider-compensated when revocation is authoritative; otherwise the
   encrypted pending authority remains locally recoverable and compensation can be retried. Pending
-  cleanup/retry shares the promotion lock order. Encrypted target/predecessor/generation evidence
+  cleanup requires a visible matching binding row; a candidate ciphertext alone cannot discard its
+  per-attempt handle or be overwritten by a later grant. Retry can recreate the deterministic row
+  from encrypted journal metadata without another provider grant; delayed rows converge and
+  different same-channel winners remain conflicts. Cleanup/retry shares the promotion lock order.
+  Encrypted target/predecessor/generation evidence
   allows promotion only over the exact unchanged predecessor; same-channel token mismatch is
   preserved as a conflict without delete/revoke, while exact same refresh authority permits
   redundant cleanup. Refresh proves store readiness before provider egress and journals any
@@ -243,7 +247,8 @@ checklist entries on the parent issue — never claimed shipped in owner docs un
 ## Relationship to GitHub issues
 
 Filed via `feature-breakdown` 2026-07-17: parent feature issue #3915 is the validation hub. Children
-#3916 (YSS-01) and #3917 (YSS-02) are delivered repository-verifiably; #3990 hardens YSS-02's
-transactional OAuth lifecycle. Children #3918–#3926 (YSS-03..YSS-11) remain governed by their live
-GitHub dependency/lifecycle state. `PARENT_FEATURE_ISSUE.md` mirrors the filed parent. The spec
-directory is the source of truth; issues are execution artifacts.
+#3916 (YSS-01), #3917 (YSS-02), #3918 (YSS-03), and #3919 (YSS-04) are delivered
+repository-verifiably; #3990 hardens YSS-02's transactional OAuth lifecycle. Children #3920–#3926
+(YSS-05..YSS-11) remain governed by their live GitHub dependency/lifecycle state, and parent #3915
+still awaits operator/live-capability acceptance. `PARENT_FEATURE_ISSUE.md` mirrors the filed
+parent. The spec directory is the source of truth; issues are execution artifacts.

--- a/docs/YOUTUBE_SOURCE_SYNC/README.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/README.md
@@ -156,7 +156,11 @@ Invariants that hold *across* tasks, with their partial-failure seams:
   a successful sync. Before a device-token poll can issue a standing grant, connect proves the
   encryption key and atomic token-store write/read path. An authenticated encrypted canary binds the
   configured key to the existing aggregate; a valid-but-wrong key blocks before polling and cannot
-  create mixed-key records. Each POSIX aggregate write syncs its staged file, atomically replaces the
+  create mixed-key records. Each current ciphertext also authenticates its exact outer record id and
+  carries that id inside its encrypted envelope, rejecting cross-binding substitution. Legacy
+  pre-AAD records upgrade together only after their binding/channel or pending-target associations
+  are proven; unprovable or pre-swapped authority fails closed without rewriting the aggregate.
+  Each POSIX aggregate write syncs its staged file, atomically replaces the
   live path, and confirms the parent-directory barrier (Windows uses write-through replacement).
   Visible readback after a failed barrier is not crash-durable authority until a retry barrier
   succeeds. A returned grant is immediately
@@ -174,9 +178,10 @@ Invariants that hold *across* tasks, with their partial-failure seams:
   lock order. Encrypted target/predecessor/credential-generation evidence plus the binding row's
   durable monotonic generation allows promotion only over the exact unchanged predecessor;
   same-channel token mismatch is preserved as a conflict without delete/revoke. Clearing terminal
-  binding authority additionally uses generation compare-and-set, so a same-timestamp terminal
-  write defeats stale pending promotion while exact matching-generation reconnect remains
-  recoverable. Exact same refresh authority permits redundant cleanup. Refresh proves store
+  binding authority additionally uses generation compare-and-set on direct reconnect and
+  candidate-row recovery, so a same-timestamp or concurrent terminal write defeats stale pending
+  promotion while exact matching-generation disconnected recovery remains possible. Exact same
+  refresh authority permits redundant cleanup. Refresh proves store
   readiness before provider egress and journals any
   unexpected rotated refresh credential before canonical write, so store failure recovers without
   another provider request and a newer canonical generation is never overwritten. Provider

--- a/docs/YOUTUBE_SOURCE_SYNC/README.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/README.md
@@ -181,10 +181,15 @@ Invariants that hold *across* tasks, with their partial-failure seams:
   binding authority additionally uses generation compare-and-set on direct reconnect and
   candidate-row recovery, so a same-timestamp or concurrent terminal write defeats stale pending
   promotion while exact matching-generation disconnected recovery remains possible. Exact same
-  refresh authority permits redundant cleanup. Refresh proves store
+  refresh authority permits redundant cleanup only after the binding is durably `connected` and
+  dependent-source auth degradation has converged; a partial state-write failure keeps the refresh
+  journal for idempotent retry. Re-provisioning the exact authenticating key may clear specifically
+  non-terminal `auth_key_missing` through the same binding-generation compare-and-set, but never
+  clears `auth_disconnected` or `auth_revoked`. Refresh proves store
   readiness before provider egress and journals any
-  unexpected rotated refresh credential before canonical write, so store failure recovers without
-  another provider request and a newer canonical generation is never overwritten. Provider
+  unexpected rotated refresh credential before canonical write, including an incomplete 2xx that
+  carries a new refresh credential without an access token, so store failure recovers without
+  credential loss and a newer canonical generation is never overwritten. Provider
   compensation must durably advance its encrypted marker before `auth_revoked` or cleanup; an
   unconfirmed marker remains retryable `auth_refresh_durability`, while compensated cleanup residue
   converges idempotently after restart. Connect never records `connected` before encrypted token
@@ -200,7 +205,9 @@ Invariants that hold *across* tasks, with their partial-failure seams:
   possible. Only Google's documented HTTP 400 `invalid_token` revoke outcome (already expired or
   revoked) permits destructive local teardown; every other status/body combination preserves the
   encrypted credential and source state for retry/reconciliation. Credential-bearing OAuth POSTs
-  never follow redirects. Disconnect deletes no acquired Mimer artifacts.
+  never follow redirects, and sanitized transport failures retain neither `__context__` nor
+  `__cause__` references to request-bearing `httpx` exceptions. Disconnect deletes no acquired
+  Mimer artifacts.
 - **INV-YSS-5 — secrets never leave the private boundary.** OAuth client identifiers, refresh/access
   tokens, and token-store key material never appear in the repo, vault files, settings values,
   candidate notes, events, receipts, logs, or exception text. Settings and receipts may carry only

--- a/docs/YOUTUBE_SOURCE_SYNC/README.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/README.md
@@ -171,14 +171,21 @@ Invariants that hold *across* tasks, with their partial-failure seams:
   different same-channel winners remain conflicts. A pending-only retry makes its canonical token
   durable before creating the connected row, while an existing canonical predecessor gets its row
   recovered before any distinct pending grant can replace it. Cleanup/retry shares the promotion
-  lock order. Encrypted target/predecessor/generation evidence
-  allows promotion only over the exact unchanged predecessor; same-channel token mismatch is
-  preserved as a conflict without delete/revoke, while exact same refresh authority permits
-  redundant cleanup. Refresh proves store readiness before provider egress and journals any
+  lock order. Encrypted target/predecessor/credential-generation evidence plus the binding row's
+  durable monotonic generation allows promotion only over the exact unchanged predecessor;
+  same-channel token mismatch is preserved as a conflict without delete/revoke. Clearing terminal
+  binding authority additionally uses generation compare-and-set, so a same-timestamp terminal
+  write defeats stale pending promotion while exact matching-generation reconnect remains
+  recoverable. Exact same refresh authority permits redundant cleanup. Refresh proves store
+  readiness before provider egress and journals any
   unexpected rotated refresh credential before canonical write, so store failure recovers without
-  another provider request and a newer canonical generation is never overwritten. Connect never
-  records `connected` before encrypted token persistence; status never reports an undecryptable or
-  refresh-pending record as connected. Refresh pending, conflict, and durability failures stamp the
+  another provider request and a newer canonical generation is never overwritten. Provider
+  compensation must durably advance its encrypted marker before `auth_revoked` or cleanup; an
+  unconfirmed marker remains retryable `auth_refresh_durability`, while compensated cleanup residue
+  converges idempotently after restart. Connect never records `connected` before encrypted token
+  persistence; status returns persisted terminal binding authority before any token-store read and
+  never reports an undecryptable or refresh-pending record as connected. Refresh pending, conflict,
+  and durability failures stamp the
   same registered reason code on the binding and dependent authenticated sources.
   Connect, reconnect, refresh, and disconnect serialize each binding's credential lifecycle across
   actors sharing its channel token store; portable store-wide serialization prevents distinct

--- a/docs/YOUTUBE_SOURCE_SYNC/README.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/README.md
@@ -154,8 +154,11 @@ Invariants that hold *across* tasks, with their partial-failure seams:
   `reason_code`; logged-out capabilities (RSS, backfill, explicit URLs) continue. No cursor is
   mutated by an auth failure; no empty poll result caused by auth/API failure is ever recorded as
   a successful sync. Before a device-token poll can issue a standing grant, connect proves the
-  encryption key and atomic token-store write/read path. A returned grant is immediately written
-  under an opaque encrypted pending-journal id before identity probing or binding work. Identity or
+  encryption key and atomic token-store write/read path. Each aggregate write syncs its staged file,
+  atomically replaces the live path, and syncs the parent directory. A returned grant is immediately
+  written under an opaque encrypted pending-journal id before identity probing or binding work.
+  Exact encrypted-record readback treats a lost write acknowledgement as durable success, so neither
+  a pending journal nor a canonical reconnect token is revoked after it actually landed. Identity or
   first-journal failure is provider-compensated when revocation is authoritative; otherwise the
   encrypted pending authority remains locally recoverable and compensation can be retried. Connect
   never records `connected` before encrypted token persistence.

--- a/docs/YOUTUBE_SOURCE_SYNC/README.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/README.md
@@ -156,9 +156,11 @@ Invariants that hold *across* tasks, with their partial-failure seams:
   a successful sync. Connect never records `connected` before encrypted token persistence.
   Connect, reconnect, refresh, and disconnect serialize each binding's credential lifecycle across
   actors sharing its channel token store; portable store-wide serialization prevents distinct
-  bindings from losing aggregate token-file updates. Retryable revoke failures (transport, 408, 429, or 5xx)
-  preserve the encrypted credential and source state for retry; permanent 4xx rejection completes
-  local teardown with `revoked=false`. Disconnect deletes no acquired Mimer artifacts.
+  bindings from losing aggregate token-file updates. Binding-create exceptions reconcile through
+  authoritative binding/channel readback; indeterminate readback preserves the credential. Only an
+  applicable non-408/non-429 4xx revoke response permits destructive local teardown. Transport,
+  1xx/3xx, 408, 429, 5xx, and unknown revoke outcomes preserve the encrypted credential and source
+  state for retry/reconciliation. Disconnect deletes no acquired Mimer artifacts.
 - **INV-YSS-5 — secrets never leave the private boundary.** OAuth client identifiers, refresh/access
   tokens, and token-store key material never appear in the repo, vault files, settings values,
   candidate notes, events, receipts, logs, or exception text. Settings and receipts may carry only

--- a/docs/YOUTUBE_SOURCE_SYNC/README.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/README.md
@@ -153,7 +153,12 @@ Invariants that hold *across* tasks, with their partial-failure seams:
   missing token-store key, disables exactly the authenticated capabilities with a per-source
   `reason_code`; logged-out capabilities (RSS, backfill, explicit URLs) continue. No cursor is
   mutated by an auth failure; no empty poll result caused by auth/API failure is ever recorded as
-  a successful sync. Connect never records `connected` before encrypted token persistence.
+  a successful sync. Before a device-token poll can issue a standing grant, connect proves the
+  encryption key and atomic token-store write/read path. A returned grant is immediately written
+  under an opaque encrypted pending-journal id before identity probing or binding work. Identity or
+  first-journal failure is provider-compensated when revocation is authoritative; otherwise the
+  encrypted pending authority remains locally recoverable and compensation can be retried. Connect
+  never records `connected` before encrypted token persistence.
   Connect, reconnect, refresh, and disconnect serialize each binding's credential lifecycle across
   actors sharing its channel token store; portable store-wide serialization prevents distinct
   bindings from losing aggregate token-file updates. First-connect binding ids are deterministic

--- a/docs/YOUTUBE_SOURCE_SYNC/README.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/README.md
@@ -156,11 +156,13 @@ Invariants that hold *across* tasks, with their partial-failure seams:
   a successful sync. Connect never records `connected` before encrypted token persistence.
   Connect, reconnect, refresh, and disconnect serialize each binding's credential lifecycle across
   actors sharing its channel token store; portable store-wide serialization prevents distinct
-  bindings from losing aggregate token-file updates. Binding-create exceptions reconcile through
-  authoritative binding/channel readback; indeterminate readback preserves the credential. Only an
-  applicable non-408/non-429 4xx revoke response permits destructive local teardown. Transport,
-  1xx/3xx, 408, 429, 5xx, and unknown revoke outcomes preserve the encrypted credential and source
-  state for retry/reconciliation. Disconnect deletes no acquired Mimer artifacts.
+  bindings from losing aggregate token-file updates. First-connect binding ids are deterministic
+  per provider channel. Binding-create exceptions roll forward when a row is visible, while even
+  successful negative snapshots preserve the credential because a delayed commit remains
+  possible. Only Google's documented HTTP 400 `invalid_token` revoke outcome (already expired or
+  revoked) permits destructive local teardown; every other status/body combination preserves the
+  encrypted credential and source state for retry/reconciliation. Credential-bearing OAuth POSTs
+  never follow redirects. Disconnect deletes no acquired Mimer artifacts.
 - **INV-YSS-5 — secrets never leave the private boundary.** OAuth client identifiers, refresh/access
   tokens, and token-store key material never appear in the repo, vault files, settings values,
   candidate notes, events, receipts, logs, or exception text. Settings and receipts may carry only

--- a/docs/YOUTUBE_SOURCE_SYNC/README.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/README.md
@@ -1,4 +1,4 @@
-State: Specification directory (feature-breakdown lane; target-state framing). Instantiates Knowledge Acquisition Platform Phase 4 (continuous discovery) for YouTube. **YSS-01 is delivered repository-verifiably** (#3916 / PR #3931, 2026-07-17: source registry + `youtubeSync.*` settings model); YSS-02..YSS-11 and the parent #3915 operator/live-capability acceptance remain pending. The issue set was filed 2026-07-17.
+State: Specification directory (feature-breakdown lane; target-state framing). Instantiates Knowledge Acquisition Platform Phase 4 (continuous discovery) for YouTube. **YSS-01 and YSS-02 are delivered repository-verifiably** (#3916 / PR #3931 and #3917 / PR #3969; YSS-02 transactional lifecycle hardening in #3990); YSS-03..YSS-11 and the parent #3915 operator/live-capability acceptance remain pending. The issue set was filed 2026-07-17.
 Doc role: Capability specification directory
 Authority: Owns the YouTube source-sync capability design — account binding, source registry, continuous discovery, durable acquisition requests, scheduling, and the setup/status surfaces. Subordinate to `docs/KNOWLEDGE_ACQUISITION/README.md` (platform boundary), `docs/KNOWLEDGE_ACQUISITION/SOURCE_PLUGIN_CONTRACT.md` (plugin interface), `docs/KNOWLEDGE_ACQUISITION/REFINEMENT_PIPELINE_CONTRACT.md` (stages), `docs/CONTEXTUALIZATION_LAYER/INGESTION_AND_TRIAGE_POLICY.md` (triage), `docs/EVENTS.md` (event envelope/outbox), and `docs/SECURITY.md` (secret baseline). It revises `docs/KNOWLEDGE_ACQUISITION/YOUTUBE_SOURCE_SPEC.md` §Discovery by owner directive (see §Decision record).
 Owner: Architecture / knowledge acquisition
@@ -113,7 +113,7 @@ it. The operator path (GCP/OAuth setup, first sync, troubleshooting, live accept
 | Order | Task | ID | Prerequisites | Outcome |
 | --- | --- | --- | --- | --- |
 | 1 | [Establish source registry and settings](ESTABLISH_SOURCE_REGISTRY_AND_SETTINGS.md) | YSS-01 | — | **Delivered repository-verifiably** (#3916 / PR #3931): durable per-account source registry + settings model + validation; live capability acceptance remains pending |
-| 2a | [Bind YouTube account with OAuth](BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md) | YSS-02 | YSS-01 | device+loopback OAuth, secret-ref token store, connect/disconnect, degradation |
+| 2a | [Bind YouTube account with OAuth](BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md) | YSS-02 | YSS-01 | **Delivered repository-verifiably** (#3917 / PR #3969; lifecycle hardening #3990): device+loopback OAuth, secret-ref token store, transactional connect/disconnect, degradation |
 | 2b | [Establish durable acquisition requests](ESTABLISH_DURABLE_ACQUISITION_REQUESTS.md) | YSS-04 | YSS-01 | source-agnostic request queue + dedup + retries + handover to `acquire_youtube` |
 | 3a | [Build YouTube Data API client](BUILD_YOUTUBE_DATA_API_CLIENT.md) | YSS-03 | YSS-02 (token provider interface only — stubbable) | bounded read-only API client: pagination, ETag, quota accounting, host allowlist |
 | 3b | [Sync subscriptions from Takeout and RSS](SYNC_SUBSCRIPTIONS_FROM_TAKEOUT_AND_RSS.md) | YSS-07 | YSS-01, YSS-04 | Takeout adoption (operator WIP baseline), channel-RSS incremental discovery, policy modes |
@@ -153,7 +153,10 @@ Invariants that hold *across* tasks, with their partial-failure seams:
   missing token-store key, disables exactly the authenticated capabilities with a per-source
   `reason_code`; logged-out capabilities (RSS, backfill, explicit URLs) continue. No cursor is
   mutated by an auth failure; no empty poll result caused by auth/API failure is ever recorded as
-  a successful sync. Disconnect stops future polling but deletes no acquired Mimer artifacts.
+  a successful sync. Connect never records `connected` before encrypted token persistence.
+  Disconnect stops future polling only after provider revocation succeeds; transient revoke
+  failure preserves the encrypted credential and source state for retry. Disconnect deletes no
+  acquired Mimer artifacts.
 - **INV-YSS-5 — secrets never leave the private boundary.** OAuth client identifiers, refresh/access
   tokens, and token-store key material never appear in the repo, vault files, settings values,
   candidate notes, events, receipts, logs, or exception text. Settings and receipts may carry only
@@ -214,7 +217,8 @@ checklist entries on the parent issue — never claimed shipped in owner docs un
 
 ## Relationship to GitHub issues
 
-Filed via `feature-breakdown` 2026-07-17: parent feature issue #3915 (validation hub, `agent:blocked`)
-plus children #3916 (YSS-01, `agent:ready`) and #3917–#3926 (YSS-02..YSS-11, `agent:blocked` until
-their prerequisites merge). `PARENT_FEATURE_ISSUE.md` mirrors the filed parent. The spec directory
-is the source of truth; issues are execution artifacts.
+Filed via `feature-breakdown` 2026-07-17: parent feature issue #3915 is the validation hub. Children
+#3916 (YSS-01) and #3917 (YSS-02) are delivered repository-verifiably; #3990 hardens YSS-02's
+transactional OAuth lifecycle. Children #3918–#3926 (YSS-03..YSS-11) remain governed by their live
+GitHub dependency/lifecycle state. `PARENT_FEATURE_ISSUE.md` mirrors the filed parent. The spec
+directory is the source of truth; issues are execution artifacts.

--- a/docs/YOUTUBE_SOURCE_SYNC/README.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/README.md
@@ -165,9 +165,14 @@ Invariants that hold *across* tasks, with their partial-failure seams:
   a pending journal nor a canonical reconnect token is revoked after it actually landed. Identity or
   first-journal failure is provider-compensated when revocation is authoritative; otherwise the
   encrypted pending authority remains locally recoverable and compensation can be retried. Pending
-  cleanup/retry shares the promotion lock order and never revokes a grant represented by live
-  canonical authority, including after token rotation. Connect never records `connected` before
-  encrypted token persistence; status never reports an undecryptable record as connected.
+  cleanup/retry shares the promotion lock order. Encrypted target/predecessor/generation evidence
+  allows promotion only over the exact unchanged predecessor; same-channel token mismatch is
+  preserved as a conflict without delete/revoke, while exact same refresh authority permits
+  redundant cleanup. Refresh proves store readiness before provider egress and journals any
+  unexpected rotated refresh credential before canonical write, so store failure recovers without
+  another provider request and a newer canonical generation is never overwritten. Connect never
+  records `connected` before encrypted token persistence; status never reports an undecryptable or
+  refresh-pending record as connected.
   Connect, reconnect, refresh, and disconnect serialize each binding's credential lifecycle across
   actors sharing its channel token store; portable store-wide serialization prevents distinct
   bindings from losing aggregate token-file updates. First-connect binding ids are deterministic

--- a/docs/YOUTUBE_SOURCE_SYNC/README.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/README.md
@@ -154,9 +154,10 @@ Invariants that hold *across* tasks, with their partial-failure seams:
   `reason_code`; logged-out capabilities (RSS, backfill, explicit URLs) continue. No cursor is
   mutated by an auth failure; no empty poll result caused by auth/API failure is ever recorded as
   a successful sync. Connect never records `connected` before encrypted token persistence.
-  Disconnect stops future polling only after provider revocation succeeds; transient revoke
-  failure preserves the encrypted credential and source state for retry. Disconnect deletes no
-  acquired Mimer artifacts.
+  Connect, reconnect, refresh, and disconnect serialize each binding's credential lifecycle across
+  actors sharing its channel token store. Retryable revoke failures (transport, 408, 429, or 5xx)
+  preserve the encrypted credential and source state for retry; permanent 4xx rejection completes
+  local teardown with `revoked=false`. Disconnect deletes no acquired Mimer artifacts.
 - **INV-YSS-5 — secrets never leave the private boundary.** OAuth client identifiers, refresh/access
   tokens, and token-store key material never appear in the repo, vault files, settings values,
   candidate notes, events, receipts, logs, or exception text. Settings and receipts may carry only

--- a/docs/YOUTUBE_SOURCE_SYNC/README.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/README.md
@@ -154,14 +154,20 @@ Invariants that hold *across* tasks, with their partial-failure seams:
   `reason_code`; logged-out capabilities (RSS, backfill, explicit URLs) continue. No cursor is
   mutated by an auth failure; no empty poll result caused by auth/API failure is ever recorded as
   a successful sync. Before a device-token poll can issue a standing grant, connect proves the
-  encryption key and atomic token-store write/read path. Each aggregate write syncs its staged file,
-  atomically replaces the live path, and syncs the parent directory. A returned grant is immediately
+  encryption key and atomic token-store write/read path. An authenticated encrypted canary binds the
+  configured key to the existing aggregate; a valid-but-wrong key blocks before polling and cannot
+  create mixed-key records. Each POSIX aggregate write syncs its staged file, atomically replaces the
+  live path, and confirms the parent-directory barrier (Windows uses write-through replacement).
+  Visible readback after a failed barrier is not crash-durable authority until a retry barrier
+  succeeds. A returned grant is immediately
   written under an opaque encrypted pending-journal id before identity probing or binding work.
   Exact encrypted-record readback treats a lost write acknowledgement as durable success, so neither
   a pending journal nor a canonical reconnect token is revoked after it actually landed. Identity or
   first-journal failure is provider-compensated when revocation is authoritative; otherwise the
-  encrypted pending authority remains locally recoverable and compensation can be retried. Connect
-  never records `connected` before encrypted token persistence.
+  encrypted pending authority remains locally recoverable and compensation can be retried. Pending
+  cleanup/retry shares the promotion lock order and never revokes a grant represented by live
+  canonical authority, including after token rotation. Connect never records `connected` before
+  encrypted token persistence; status never reports an undecryptable record as connected.
   Connect, reconnect, refresh, and disconnect serialize each binding's credential lifecycle across
   actors sharing its channel token store; portable store-wide serialization prevents distinct
   bindings from losing aggregate token-file updates. First-connect binding ids are deterministic

--- a/docs/YOUTUBE_SOURCE_SYNC/README.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/README.md
@@ -155,7 +155,8 @@ Invariants that hold *across* tasks, with their partial-failure seams:
   mutated by an auth failure; no empty poll result caused by auth/API failure is ever recorded as
   a successful sync. Connect never records `connected` before encrypted token persistence.
   Connect, reconnect, refresh, and disconnect serialize each binding's credential lifecycle across
-  actors sharing its channel token store. Retryable revoke failures (transport, 408, 429, or 5xx)
+  actors sharing its channel token store; portable store-wide serialization prevents distinct
+  bindings from losing aggregate token-file updates. Retryable revoke failures (transport, 408, 429, or 5xx)
   preserve the encrypted credential and source state for retry; permanent 4xx rejection completes
   local teardown with `revoked=false`. Disconnect deletes no acquired Mimer artifacts.
 - **INV-YSS-5 — secrets never leave the private boundary.** OAuth client identifiers, refresh/access

--- a/docs/YOUTUBE_SOURCE_SYNC/README.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/README.md
@@ -168,15 +168,18 @@ Invariants that hold *across* tasks, with their partial-failure seams:
   cleanup requires a visible matching binding row; a candidate ciphertext alone cannot discard its
   per-attempt handle or be overwritten by a later grant. Retry can recreate the deterministic row
   from encrypted journal metadata without another provider grant; delayed rows converge and
-  different same-channel winners remain conflicts. Cleanup/retry shares the promotion lock order.
-  Encrypted target/predecessor/generation evidence
+  different same-channel winners remain conflicts. A pending-only retry makes its canonical token
+  durable before creating the connected row, while an existing canonical predecessor gets its row
+  recovered before any distinct pending grant can replace it. Cleanup/retry shares the promotion
+  lock order. Encrypted target/predecessor/generation evidence
   allows promotion only over the exact unchanged predecessor; same-channel token mismatch is
   preserved as a conflict without delete/revoke, while exact same refresh authority permits
   redundant cleanup. Refresh proves store readiness before provider egress and journals any
   unexpected rotated refresh credential before canonical write, so store failure recovers without
   another provider request and a newer canonical generation is never overwritten. Connect never
   records `connected` before encrypted token persistence; status never reports an undecryptable or
-  refresh-pending record as connected.
+  refresh-pending record as connected. Refresh pending, conflict, and durability failures stamp the
+  same registered reason code on the binding and dependent authenticated sources.
   Connect, reconnect, refresh, and disconnect serialize each binding's credential lifecycle across
   actors sharing its channel token store; portable store-wide serialization prevents distinct
   bindings from losing aggregate token-file updates. First-connect binding ids are deterministic

--- a/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
@@ -227,8 +227,9 @@ Per `docs/SECURITY.md`, ADR-0046 (zero secrets in the public tree), the private-
   provider strings or response bodies that may echo tokens).
 - Before polling the device-token endpoint, connect resolves the encryption key and proves the
   aggregate store's locked atomic write/read path without writing secret probe material. Each POSIX
-  write syncs the staged file before atomic replacement and confirms the parent-directory barrier
-  afterward; Windows uses a write-through replacement. A visible record after a failed barrier is
+  write syncs the staged file before atomic replacement and confirms the complete parent-directory
+  chain through the filesystem root, including fresh first-use nested directories. Windows uses a
+  write-through replacement. A visible record after a failed barrier is
   not crash-durable authority until a fresh barrier succeeds. Once
   the provider returns a grant, connect immediately journals it encrypted under an opaque digest
   id; no identity probe or binding mutation occurs first. Exact encrypted-record readback treats a

--- a/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
@@ -292,6 +292,14 @@ Per `docs/SECURITY.md`, ADR-0046 (zero secrets in the public tree), the private-
   `auth_missing` or another transient reason. Before confirmed teardown, dependent sources remain
   enabled but degraded for retry; cursors and acquired artifacts remain unchanged. After confirmed
   teardown they are disabled with the same reason.
+- Authenticated token consumption requires positive durable binding authority (`connected` with no
+  reason code), not merely readable/fresh ciphertext. A postcanonical reconnect failure therefore
+  remains blocked until retry converges the binding row. Pending-grant cleanup may clear a terminal
+  state only when the grant's durable predecessor-version evidence matches that exact terminal
+  transition; stale residue is cleanup-only. Terminal binding/source degradation is an
+  idempotent producer, so a retry repairs dependent-source truth after a partial write before any
+  compensation journal is removed. Status preserves persisted `auth_disconnected`/`auth_revoked`
+  over transient key/read failures.
 - Disconnect then revokes at the provider (`oauth2.googleapis.com/revoke`). Only Google's
   documented HTTP 400 `invalid_token` outcome — meaning already expired or revoked — permits local
   teardown with `revoked=false`. `invalid_request`, intermediary/unknown 4xx responses, redirects,

--- a/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
@@ -276,9 +276,16 @@ Per `docs/SECURITY.md`, ADR-0046 (zero secrets in the public tree), the private-
   `auth_refresh_pending`; the next access promotes without another provider request only if the
   predecessor is unchanged. A newer/different canonical generation yields
   `auth_refresh_conflict` and preserves both encrypted authorities. Status never reports either
-  state as connected; pending, conflict, and durability failures stamp the same registered reason
-  code on the binding and dependent sources, and reconnect/disconnect must resolve the journal or
+  state as connected. If local journaling cannot be confirmed, a durable encrypted compensation
+  marker makes the rotated authority non-promotable before provider revocation; authoritative
+  compensation advances that marker before cleanup, and retained crash residue can only be cleaned
+  or re-compensated, never promoted. Pending, conflict, and durability failures stamp the same registered reason
+  code on the binding and dependent sources while the per-binding lifecycle lock is still held, and reconnect/disconnect must resolve the journal or
   fail closed before polling/revoking.
+- Loopback redirect admission runs on the raw string before URI parsing can normalize it: the URI
+  must be `http`, use exact host `127.0.0.1` with an explicit valid port, contain no ASCII controls,
+  and contain neither a query/fragment delimiter nor query/fragment content. Creation and code
+  exchange both apply the same validation.
 - Disconnect first revokes at the provider (`oauth2.googleapis.com/revoke`). Only Google's
   documented HTTP 400 `invalid_token` outcome — meaning already expired or revoked — permits local
   teardown with `revoked=false`. `invalid_request`, intermediary/unknown 4xx responses, redirects,

--- a/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
@@ -278,14 +278,18 @@ Per `docs/SECURITY.md`, ADR-0046 (zero secrets in the public tree), the private-
   `auth_refresh_conflict` and preserves both encrypted authorities. Status never reports either
   state as connected. If local journaling cannot be confirmed, a durable encrypted compensation
   marker makes the rotated authority non-promotable before provider revocation; authoritative
-  compensation advances that marker before cleanup, and retained crash residue can only be cleaned
-  or re-compensated, never promoted. Pending, conflict, and durability failures stamp the same registered reason
+  compensation advances that marker and persists `auth_revoked` binding/source truth before
+  cleanup. Retained crash residue reports revoked and can only be cleaned or re-compensated, never
+  promoted; reconnect requires new consent. Pending, conflict, and durability failures stamp the same registered reason
   code on the binding and dependent sources while the per-binding lifecycle lock is still held, and reconnect/disconnect must resolve the journal or
   fail closed before polling/revoking.
 - Loopback redirect admission runs on the raw string before URI parsing can normalize it: the URI
   must be `http`, use exact host `127.0.0.1` with an explicit valid port, contain no ASCII controls,
   and contain neither a query/fragment delimiter nor query/fragment content. Creation and code
   exchange both apply the same validation.
+- Once disconnect has durably set `auth_disconnected`, a queued or stale token consumer cannot
+  replace that terminal operator state with `auth_missing` or another transient reason. Dependent
+  sources remain disabled with their cursors and acquired artifacts unchanged.
 - Disconnect first revokes at the provider (`oauth2.googleapis.com/revoke`). Only Google's
   documented HTTP 400 `invalid_token` outcome — meaning already expired or revoked — permits local
   teardown with `revoked=false`. `invalid_request`, intermediary/unknown 4xx responses, redirects,

--- a/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
@@ -228,7 +228,9 @@ Per `docs/SECURITY.md`, ADR-0046 (zero secrets in the public tree), the private-
 - Redaction: all sync surfaces route through redaction-aware serialization; field names carry
   `token`/`secret`/`credential` tokens so existing key-name redactors match. Exception text from
   the OAuth/HTTP layer is sanitized (status + an allowlisted OAuth error enum, never arbitrary
-  provider strings or response bodies that may echo tokens).
+  provider strings or response bodies that may echo tokens). A sanitized transport exception is
+  raised outside the `httpx` handler and retains neither a request-bearing `__context__` nor
+  `__cause__`.
 - Before polling the device-token endpoint, connect resolves the encryption key and proves the
   aggregate store's locked atomic write/read path without writing secret probe material. Each POSIX
   write syncs the staged file before atomic replacement and confirms the complete parent-directory
@@ -287,11 +289,19 @@ Per `docs/SECURITY.md`, ADR-0046 (zero secrets in the public tree), the private-
   token remains the long-lived credential. The implementation nevertheless treats any unexpected,
   non-empty different `refresh_token` in that response as a rotation: it proves store readiness
   before `/token`, durably journals the returned authority with its exact predecessor/generation,
-  and only then promotes canonical state. A canonical-write failure leaves
+  and only then promotes canonical state. This includes an incomplete 2xx response that carries the
+  rotated refresh credential but omits the access token: the response is rejected as incomplete,
+  while its standing authority is journaled or authoritatively compensated rather than discarded.
+  A canonical-write failure leaves
   `auth_refresh_pending`; the next access promotes without another provider request only if the
   predecessor is unchanged. A newer/different canonical generation yields
-  `auth_refresh_conflict` and preserves both encrypted authorities. Status never reports either
-  state as connected. If local journaling cannot be confirmed, a durable encrypted compensation
+  `auth_refresh_conflict` and preserves both encrypted authorities. Canonical promotion is not
+  cleanup authority: the journal remains until the binding is durably `connected` and every
+  dependent source has cleared the matching auth degradation; a partial state write is retried
+  idempotently from that journal. Re-provisioning the exact authenticating key likewise recovers
+  specifically non-terminal `auth_key_missing` under the binding lock and generation compare-and-set;
+  it cannot clear `auth_disconnected` or `auth_revoked`. Status never reports a pending state as
+  connected. If local journaling cannot be confirmed, a durable encrypted compensation
   marker makes the rotated authority non-promotable before provider revocation; authoritative
   compensation must durably advance that marker before `auth_revoked` binding/source truth or
   cleanup may follow. If the marker write or its acknowledgement cannot be confirmed, the durable

--- a/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
@@ -250,10 +250,16 @@ Per `docs/SECURITY.md`, ADR-0046 (zero secrets in the public tree), the private-
   deterministic binding create without polling for another grant; delayed exact rows converge,
   while a different same-channel winner remains a non-destructive conflict. Promotion and cleanup
   remain inside the pending → channel → binding lifecycle-lock order. Before canonical write, the
-  encrypted pending record gains its
-  exact target, predecessor refresh authority, and next authority generation. Retry removes it only
+  encrypted pending record gains its exact target, predecessor refresh authority, next credential
+  generation, and the binding row's durable monotonic generation. The latter is compare-and-set
+  authority; `updated_at` remains observational wall-clock data and is never lifecycle authority.
+  Retry removes it only
   when canonical has the same refresh authority, or promotes it only while canonical still exactly
-  matches that predecessor generation. Same-channel identity alone is never canonical proof: a
+  matches that predecessor generation. Clearing persisted `auth_disconnected`/`auth_revoked`
+  additionally requires an atomic match on the exact predecessor binding generation. A stale
+  distinct-token journal remains encrypted as `pending_conflict`; an exact matching-generation
+  reconnect may converge both canonical ciphertext and `connected` binding state. Same-channel
+  identity alone is never canonical proof: a
   token mismatch against a newer/different generation preserves both records as `pending_conflict`
   and performs no provider revocation.
 - Connect persists the encrypted token before claiming a binding is connected. Connect,
@@ -278,9 +284,13 @@ Per `docs/SECURITY.md`, ADR-0046 (zero secrets in the public tree), the private-
   `auth_refresh_conflict` and preserves both encrypted authorities. Status never reports either
   state as connected. If local journaling cannot be confirmed, a durable encrypted compensation
   marker makes the rotated authority non-promotable before provider revocation; authoritative
-  compensation advances that marker and persists `auth_revoked` binding/source truth before
-  cleanup. Retained crash residue reports revoked and can only be cleaned or re-compensated, never
-  promoted; reconnect requires new consent. Pending, conflict, and durability failures stamp the same registered reason
+  compensation must durably advance that marker before `auth_revoked` binding/source truth or
+  cleanup may follow. If the marker write or its acknowledgement cannot be confirmed, the durable
+  `pending` marker remains `auth_refresh_durability` retry authority; token consumption,
+  reconnect, or disconnect idempotently re-compensates and re-persists the marker. Cleanup failure
+  leaves a durable `compensated` marker that restart converges before any new consent or revoke.
+  Retained crash residue can only be cleaned or re-compensated, never promoted; reconnect requires
+  new consent after compensation. Pending, conflict, and durability failures stamp the same registered reason
   code on the binding and dependent sources while the per-binding lifecycle lock is still held, and reconnect/disconnect must resolve the journal or
   fail closed before polling/revoking.
 - Loopback redirect admission runs on the raw string before URI parsing can normalize it: the URI
@@ -295,11 +305,14 @@ Per `docs/SECURITY.md`, ADR-0046 (zero secrets in the public tree), the private-
 - Authenticated token consumption requires positive durable binding authority (`connected` with no
   reason code), not merely readable/fresh ciphertext. A postcanonical reconnect failure therefore
   remains blocked until retry converges the binding row. Pending-grant cleanup may clear a terminal
-  state only when the grant's durable predecessor-version evidence matches that exact terminal
-  transition; stale residue is cleanup-only. Terminal binding/source degradation is an
+  state only when the grant's durable predecessor binding generation matches atomically; a
+  same-timestamp terminal transition still advances generation, and stale same-token residue is
+  cleanup-only while stale distinct-token authority remains a non-destructive conflict. Terminal
+  binding/source degradation is an
   idempotent producer, so a retry repairs dependent-source truth after a partial write before any
-  compensation journal is removed. Status preserves persisted `auth_disconnected`/`auth_revoked`
-  over transient key/read failures.
+  compensation journal is removed. Status returns persisted `auth_disconnected`/`auth_revoked`
+  before any token-store projection read, so missing keys, malformed aggregates, and ordinary I/O
+  failures cannot outrank terminal authority.
 - Disconnect then revokes at the provider (`oauth2.googleapis.com/revoke`). Only Google's
   documented HTTP 400 `invalid_token` outcome — meaning already expired or revoked — permits local
   teardown with `revoked=false`. `invalid_request`, intermediary/unknown 4xx responses, redirects,

--- a/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
@@ -143,8 +143,13 @@ substrate (the `settings_receipts`/`promotion_receipts` pattern).
 
 ## Reason codes (all surfaces: `last_error`, events, health, UI, CLI)
 
-`auth_missing` (no binding), `auth_key_missing` (token store key absent — fail-closed),
-`auth_expired`, `auth_revoked`, `auth_disconnected` (operator action), `quota_exhausted`,
+`auth_missing` (no binding), `auth_key_missing` (token store key absent or unable to authenticate
+the encrypted aggregate — fail-closed),
+`auth_expired`, `auth_revoked`, `auth_disconnected` (operator action),
+`auth_refresh_pending` (rotated encrypted authority awaits canonical promotion),
+`auth_refresh_conflict` (canonical no longer matches the journal's predecessor generation),
+`auth_refresh_durability` (rotation could not be durably journaled or authoritatively compensated),
+`quota_exhausted`,
 `api_unavailable` (5xx/timeout), `network_error`, `source_gone` (404/private-without-access),
 `source_unsupported` (Watch Later / Watch History), `writeguard_blocked`, `pipeline_dead_letter`,
 `policy_unsupported` (queued acquisition mode/depth has no delivered production path),
@@ -211,13 +216,75 @@ Per `docs/SECURITY.md`, ADR-0046 (zero secrets in the public tree), the private-
 - Tokens (refresh/access) live in an encrypted-at-rest token store file (AES-256-GCM via the
   existing `cryptography` dependency, mirroring `app/heimdal/raw_store.py`): path is an app-local
   binding (default under the channel runtime dir; never the vault, never the repo), key from
-  `YOUTUBE_TOKEN_STORE_KEY` (32 bytes, same provisioning boundary). Missing key with an existing
-  binding ⇒ `auth_key_missing` degraded state — never a plaintext fallback (fail closed).
+  `YOUTUBE_TOKEN_STORE_KEY` (32 bytes, same provisioning boundary). An authenticated encrypted
+  canary binds that configured key to the whole aggregate; a legacy aggregate without the canary is
+  admitted only after every existing record authenticates under the key. A missing or valid-but-
+  wrong key with an existing binding ⇒ `auth_key_missing` degraded state before any grant poll or
+  aggregate mutation — never a plaintext fallback or mixed-key file (fail closed).
 - Redaction: all sync surfaces route through redaction-aware serialization; field names carry
   `token`/`secret`/`credential` tokens so existing key-name redactors match. Exception text from
-  the OAuth/HTTP layer is sanitized (status + class, never response bodies that may echo tokens).
-- Disconnect revokes at the provider (`oauth2.googleapis.com/revoke`), deletes the token record,
-  and disables dependent sources with `auth_disconnected` — acquired artifacts, raw records, and
+  the OAuth/HTTP layer is sanitized (status + an allowlisted OAuth error enum, never arbitrary
+  provider strings or response bodies that may echo tokens).
+- Before polling the device-token endpoint, connect resolves the encryption key and proves the
+  aggregate store's locked atomic write/read path without writing secret probe material. Each POSIX
+  write syncs the staged file before atomic replacement and confirms the parent-directory barrier
+  afterward; Windows uses a write-through replacement. A visible record after a failed barrier is
+  not crash-durable authority until a fresh barrier succeeds. Once
+  the provider returns a grant, connect immediately journals it encrypted under an opaque digest
+  id; no identity probe or binding mutation occurs first. Exact encrypted-record readback treats a
+  lost write acknowledgement as durable success, so a landed pending journal or canonical
+  reconnect token is never revoked as though its write failed. If the journal or identity probe
+  fails without such durable authority, an authoritative provider revocation compensates and
+  removes the journal. An unproven revoke preserves or retries the encrypted pending journal, whose
+  compensation is explicitly retryable. Pending-only first-connect recovery makes the canonical
+  token durable before it creates a binding row whose default state claims `connected`. When an
+  older canonical predecessor exists, recovery first recreates its matching row before a distinct
+  later pending grant can replace it, so a failed row create leaves both authorities intact. After
+  the canonical binding token is durable **and the matching binding row is visible**,
+  pending-journal cleanup is safe and best-effort: a crash can
+  retain a redundant encrypted copy but cannot remove revocation authority. A deterministic
+  first-connect candidate without that row is not canonical authority: its per-attempt journal
+  remains retryable, and a later consent retains a distinct journal rather than overwriting the
+  candidate grant. The encrypted journal carries the display metadata needed to retry the same
+  deterministic binding create without polling for another grant; delayed exact rows converge,
+  while a different same-channel winner remains a non-destructive conflict. Promotion and cleanup
+  remain inside the pending → channel → binding lifecycle-lock order. Before canonical write, the
+  encrypted pending record gains its
+  exact target, predecessor refresh authority, and next authority generation. Retry removes it only
+  when canonical has the same refresh authority, or promotes it only while canonical still exactly
+  matches that predecessor generation. Same-channel identity alone is never canonical proof: a
+  token mismatch against a newer/different generation preserves both records as `pending_conflict`
+  and performs no provider revocation.
+- Connect persists the encrypted token before claiming a binding is connected. Connect,
+  reconnect, refresh, and disconnect serialize each binding's credential lifecycle across service
+  instances and runtime processes sharing the channel token store. The app-local lock filename is
+  a digest of the binding id and its private lock file contains no account identifier or secret.
+  A portable store-wide lock additionally serializes aggregate token-file mutations across
+  distinct bindings (POSIX and Windows), and concurrent first connects re-resolve provider identity
+  under shared authority before creating a binding. First-connect binding ids are deterministic per
+  provider channel. If binding creation returns an exception after its database commit, visible
+  binding/channel readback rolls forward to the committed connected row; negative read snapshots
+  never compensate the encrypted credential because a delayed commit may still appear. Retry then
+  converges through the same candidate id without minting another credential identity.
+- Google's [refresh contract](https://developers.google.com/identity/protocols/oauth2/web-server#offline)
+  documents a successful refresh as returning a new access token while the securely stored refresh
+  token remains the long-lived credential. The implementation nevertheless treats any unexpected,
+  non-empty different `refresh_token` in that response as a rotation: it proves store readiness
+  before `/token`, durably journals the returned authority with its exact predecessor/generation,
+  and only then promotes canonical state. A canonical-write failure leaves
+  `auth_refresh_pending`; the next access promotes without another provider request only if the
+  predecessor is unchanged. A newer/different canonical generation yields
+  `auth_refresh_conflict` and preserves both encrypted authorities. Status never reports either
+  state as connected; pending, conflict, and durability failures stamp the same registered reason
+  code on the binding and dependent sources, and reconnect/disconnect must resolve the journal or
+  fail closed before polling/revoking.
+- Disconnect first revokes at the provider (`oauth2.googleapis.com/revoke`). Only Google's
+  documented HTTP 400 `invalid_token` outcome — meaning already expired or revoked — permits local
+  teardown with `revoked=false`. `invalid_request`, intermediary/unknown 4xx responses, redirects,
+  transport failures, and every other unproven outcome preserve the encrypted token and source state
+  for retry/reconciliation. Credential-bearing OAuth requests set redirect following off at the
+  request site, independent of injected-client defaults. Teardown deletes the token record and
+  disables dependent sources with `auth_disconnected` — acquired artifacts, raw records, and
   receipts are never deleted.
 
 ## Egress posture (YSS-02/03/07/08)

--- a/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
@@ -217,10 +217,14 @@ Per `docs/SECURITY.md`, ADR-0046 (zero secrets in the public tree), the private-
   existing `cryptography` dependency, mirroring `app/heimdal/raw_store.py`): path is an app-local
   binding (default under the channel runtime dir; never the vault, never the repo), key from
   `YOUTUBE_TOKEN_STORE_KEY` (32 bytes, same provisioning boundary). An authenticated encrypted
-  canary binds that configured key to the whole aggregate; a legacy aggregate without the canary is
-  admitted only after every existing record authenticates under the key. A missing or valid-but-
-  wrong key with an existing binding ⇒ `auth_key_missing` degraded state before any grant poll or
-  aggregate mutation — never a plaintext fallback or mixed-key file (fail closed).
+  canary binds that configured key to the whole aggregate. Every current record also authenticates
+  its exact outer binding/record id as domain-separated AEAD associated data and repeats that id in
+  its encrypted versioned envelope, so moving valid ciphertext to another index key is rejected.
+  A pre-AAD aggregate is upgraded as one locked atomic write only after the OAuth authority layer
+  proves every decrypted canonical binding/channel association and pending target relation; an
+  unprovable or already cross-swapped legacy association fails closed without mutation. A missing
+  or valid-but-wrong key with an existing binding ⇒ `auth_key_missing` degraded state before any
+  grant poll or aggregate mutation — never a plaintext fallback or mixed-key file (fail closed).
 - Redaction: all sync surfaces route through redaction-aware serialization; field names carry
   `token`/`secret`/`credential` tokens so existing key-name redactors match. Exception text from
   the OAuth/HTTP layer is sanitized (status + an allowlisted OAuth error enum, never arbitrary
@@ -253,6 +257,11 @@ Per `docs/SECURITY.md`, ADR-0046 (zero secrets in the public tree), the private-
   encrypted pending record gains its exact target, predecessor refresh authority, next credential
   generation, and the binding row's durable monotonic generation. The latter is compare-and-set
   authority; `updated_at` remains observational wall-clock data and is never lifecycle authority.
+  Direct reconnect derives its expected generation from that already-durable pending evidence and
+  performs terminal-to-connected convergence only through the atomic generation compare-and-set;
+  it never derives a fresh expectation after canonical write. Candidate-row recovery applies the
+  same evidence after a transient negative read: an exact matching-generation disconnected row is
+  recoverable, while a concurrently advanced or stale revoked generation wins and remains terminal.
   Retry removes it only
   when canonical has the same refresh authority, or promotes it only while canonical still exactly
   matches that predecessor generation. Clearing persisted `auth_disconnected`/`auth_revoked`

--- a/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
@@ -287,14 +287,17 @@ Per `docs/SECURITY.md`, ADR-0046 (zero secrets in the public tree), the private-
   must be `http`, use exact host `127.0.0.1` with an explicit valid port, contain no ASCII controls,
   and contain neither a query/fragment delimiter nor query/fragment content. Creation and code
   exchange both apply the same validation.
-- Once disconnect has durably set `auth_disconnected`, a queued or stale token consumer cannot
-  replace that terminal operator state with `auth_missing` or another transient reason. Dependent
-  sources remain disabled with their cursors and acquired artifacts unchanged.
-- Disconnect first revokes at the provider (`oauth2.googleapis.com/revoke`). Only Google's
+- Disconnect durably sets `auth_disconnected` before calling the provider. A queued or stale token
+  consumer cannot consume retained ciphertext or replace that terminal operator state with
+  `auth_missing` or another transient reason. Before confirmed teardown, dependent sources remain
+  enabled but degraded for retry; cursors and acquired artifacts remain unchanged. After confirmed
+  teardown they are disabled with the same reason.
+- Disconnect then revokes at the provider (`oauth2.googleapis.com/revoke`). Only Google's
   documented HTTP 400 `invalid_token` outcome — meaning already expired or revoked — permits local
   teardown with `revoked=false`. `invalid_request`, intermediary/unknown 4xx responses, redirects,
-  transport failures, and every other unproven outcome preserve the encrypted token and source state
-  for retry/reconciliation. Credential-bearing OAuth requests set redirect following off at the
+  transport failures, and every other unproven outcome preserve the encrypted token solely as
+  revocation-retry authority while terminal local state blocks consumption. Credential-bearing
+  OAuth requests set redirect following off at the
   request site, independent of injected-client defaults. Teardown deletes the token record and
   disables dependent sources with `auth_disconnected` — acquired artifacts, raw records, and
   receipts are never deleted.

--- a/tests/knowledge_acquisition/_source_registry_contract.py
+++ b/tests/knowledge_acquisition/_source_registry_contract.py
@@ -582,6 +582,46 @@ def assert_provenance_is_strict_portable_json(make_registry: RegistryFactory) ->
     assert zulu.provenance["at"] == "2026-07-18T08:00:00+00:00"
 
 
+def assert_source_degradation_clear_is_reason_compared(
+    make_registry: RegistryFactory,
+) -> None:
+    """OAuth recovery clears only the exact degradation it owns."""
+    reg = make_registry()
+    binding = reg.register(
+        collection_kind="owned_playlist",
+        collection_ref="PLfixtureAUTHRECOVERY",
+        account_binding_id=_acct(),
+        title="Auth recovery",
+    )
+    degraded = reg.record_source_degradation(
+        binding.binding_id,
+        reason_code="auth_key_missing",
+    )
+    assert degraded.last_error is not None
+    assert degraded.last_error["reason_code"] == "auth_key_missing"
+
+    unrelated = reg.clear_source_degradation(
+        binding.binding_id,
+        expected_reason_codes={"auth_refresh_pending"},
+    )
+    assert unrelated.last_error is not None
+    assert unrelated.last_error["reason_code"] == "auth_key_missing"
+
+    cleared = reg.clear_source_degradation(
+        binding.binding_id,
+        expected_reason_codes={"auth_key_missing"},
+    )
+    assert cleared.last_error is None
+    assert cleared.enabled is binding.enabled
+    assert cleared.cursor == binding.cursor
+
+    with pytest.raises(SourceRegistryValidationError, match="expected_reason_codes"):
+        reg.clear_source_degradation(
+            binding.binding_id,
+            expected_reason_codes="auth_key_missing",  # type: ignore[arg-type]
+        )
+
+
 ALL_CONTRACT_ASSERTIONS: tuple[Callable[[RegistryFactory], None], ...] = (
     assert_round_trip_and_contract_fields,
     assert_single_enabled_inbox_and_swap,
@@ -593,4 +633,5 @@ ALL_CONTRACT_ASSERTIONS: tuple[Callable[[RegistryFactory], None], ...] = (
     assert_invalid_interval_and_policy_fail_loud,
     assert_provenance_is_strict_portable_json,
     assert_memory_json_isolation,
+    assert_source_degradation_clear_is_reason_compared,
 )

--- a/tests/knowledge_acquisition/test_source_registry.py
+++ b/tests/knowledge_acquisition/test_source_registry.py
@@ -27,6 +27,7 @@ from tests.knowledge_acquisition._source_registry_contract import (
     assert_provenance_is_strict_portable_json,
     assert_round_trip_and_contract_fields,
     assert_single_enabled_inbox_and_swap,
+    assert_source_degradation_clear_is_reason_compared,
     assert_title_rename_preserves_binding,
     assert_watch_later_and_history_refused,
 )
@@ -87,3 +88,7 @@ def test_memory_json_isolation_matches_postgres_contract() -> None:
 
 def test_provenance_is_strict_portable_json_memory() -> None:
     assert_provenance_is_strict_portable_json(_make_registry)
+
+
+def test_source_degradation_clear_is_reason_compared_memory() -> None:
+    assert_source_degradation_clear_is_reason_compared(_make_registry)

--- a/tests/knowledge_acquisition/test_youtube_account_binding_pg.py
+++ b/tests/knowledge_acquisition/test_youtube_account_binding_pg.py
@@ -4,7 +4,9 @@ Exercises the SAME service-layer contract as the memory backend (which
 ``tests/knowledge_acquisition/test_youtube_oauth.py`` drives implicitly) against
 the real Postgres-backed ``AccountBindingStore``, proving the integrity rules
 hold identically on both backends and that the forward-only migration
-``a2f1c3e4d5b6`` creates the schema the store's fail-loud preflight expects.
+``e1f2a3b4c5d6`` creates the generation-CAS schema the store's fail-loud
+preflight expects. It also proves that an already-stamped pre-repair database
+is upgraded without losing existing bindings.
 
 Marked ``pg``: excluded by the default ``-m "not pg"`` suite; does not run
 locally without a real Postgres. Mirrors ``test_source_registry_pg.py`` -- an
@@ -27,14 +29,16 @@ from psycopg.conninfo import conninfo_to_dict, make_conninfo
 from sqlalchemy.engine import URL
 
 from app.knowledge_acquisition.youtube_account_binding import (
+    AccountBindingGenerationConflictError,
+    AccountBindingSchemaMissingError,
     AccountBindingStore,
     AccountBindingValidationError,
     DuplicateAccountBindingError,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-PRE_YSS02_HEAD = "bd79f3044759"
-YSS02_HEAD = "a2f1c3e4d5b6"
+PRE_BINDING_GENERATION_HEAD = "d9e0f1a2b3c4"
+BINDING_GENERATION_HEAD = "e1f2a3b4c5d6"
 
 # Synthetic ids only (INV-YSS-9).
 CHANNEL_A = "UC__test__acct_binding_pg_a"
@@ -49,8 +53,10 @@ def _alembic_config() -> Config:
 
 
 @pytest.fixture
-def migrated_binding_database(monkeypatch: pytest.MonkeyPatch) -> Iterator[Config]:
-    """Yield an Alembic-migrated isolated database and drop it afterwards."""
+def scratch_binding_database(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[tuple[Config, str]]:
+    """Yield an isolated empty database and drop it afterwards."""
     from app.db.dsn import resolve_dsn
 
     admin_dsn = resolve_dsn()
@@ -86,11 +92,20 @@ def migrated_binding_database(monkeypatch: pytest.MonkeyPatch) -> Iterator[Confi
         monkeypatch.delenv("STORE_SCHEMA_AUTOCREATE", raising=False)
         monkeypatch.delenv("STORE_BACKEND", raising=False)
         config = _alembic_config()
-        command.upgrade(config, YSS02_HEAD)
-        yield config
+        yield config, scratch_conninfo
     finally:
         with psycopg.connect(admin_dsn, autocommit=True) as conn:
             conn.execute(f'DROP DATABASE IF EXISTS "{database_name}" WITH (FORCE)')
+
+
+@pytest.fixture
+def migrated_binding_database(
+    scratch_binding_database: tuple[Config, str],
+) -> Config:
+    """Yield an isolated database migrated through the generation-CAS head."""
+    config, _scratch_conninfo = scratch_binding_database
+    command.upgrade(config, BINDING_GENERATION_HEAD)
+    return config
 
 
 @pytest.mark.pg
@@ -103,6 +118,7 @@ def test_pg_backend_contract(migrated_binding_database: Config) -> None:
     assert created.state == "connected"
     assert created.reason_code is None
     assert created.scopes == (SCOPE,)
+    assert created.binding_generation == 1
 
     # Round-trips out of Postgres unchanged.
     fetched = store.get(created.account_binding_id)
@@ -111,12 +127,34 @@ def test_pg_backend_contract(migrated_binding_database: Config) -> None:
     assert store.get_by_channel_id(CHANNEL_A).account_binding_id == created.account_binding_id
 
     # Degrade → reason set; reconnect → reason cleared.
-    degraded = store.set_state(created.account_binding_id, state="degraded", reason_code="auth_revoked")
+    degraded = store.set_state(
+        created.account_binding_id,
+        state="degraded",
+        reason_code="auth_revoked",
+        expected_binding_generation=created.binding_generation,
+    )
     assert degraded.state == "degraded"
     assert degraded.reason_code == "auth_revoked"
-    reconnected = store.set_state(created.account_binding_id, state="connected", reason_code=None)
+    assert degraded.binding_generation == 2
+    reconnected = store.set_state(
+        created.account_binding_id,
+        state="connected",
+        reason_code=None,
+        expected_binding_generation=degraded.binding_generation,
+    )
     assert reconnected.state == "connected"
     assert reconnected.reason_code is None
+    assert reconnected.binding_generation == 3
+
+    # A stale compare-and-set cannot overwrite or otherwise mutate the winner.
+    with pytest.raises(AccountBindingGenerationConflictError):
+        store.set_state(
+            created.account_binding_id,
+            state="degraded",
+            reason_code="auth_revoked",
+            expected_binding_generation=degraded.binding_generation,
+        )
+    assert store.get(created.account_binding_id) == reconnected
 
     # One binding per channel (unique index).
     with pytest.raises(DuplicateAccountBindingError):
@@ -140,4 +178,62 @@ def test_pg_backend_contract(migrated_binding_database: Config) -> None:
 
     # The migration is forward-only.
     with pytest.raises(RuntimeError, match="forward-only"):
-        command.downgrade(migrated_binding_database, PRE_YSS02_HEAD)
+        command.downgrade(migrated_binding_database, PRE_BINDING_GENERATION_HEAD)
+
+
+@pytest.mark.pg
+def test_existing_resource_upgrade_backfills_generation_and_restores_schema(
+    scratch_binding_database: tuple[Config, str],
+) -> None:
+    config, scratch_conninfo = scratch_binding_database
+    command.upgrade(config, PRE_BINDING_GENERATION_HEAD)
+
+    pre_repair_store = AccountBindingStore.for_runtime()
+    existing = pre_repair_store.create(
+        provider_channel_id=CHANNEL_A,
+        display_label="Existing Chan",
+        scopes=[SCOPE],
+    )
+    assert existing.binding_generation == 1
+
+    # Model an existing DB stamped past the original YSS-02 migration before
+    # binding_generation became a runtime invariant.
+    with psycopg.connect(scratch_conninfo) as conn:
+        conn.execute(
+            "ALTER TABLE youtube_account_binding "
+            "DROP CONSTRAINT IF EXISTS youtube_account_binding_generation_chk"
+        )
+        conn.execute(
+            "ALTER TABLE youtube_account_binding "
+            "DROP COLUMN IF EXISTS binding_generation"
+        )
+
+    with pytest.raises(AccountBindingSchemaMissingError, match="binding_generation"):
+        AccountBindingStore.for_runtime()
+
+    command.upgrade(config, BINDING_GENERATION_HEAD)
+
+    upgraded_store = AccountBindingStore.for_runtime()
+    upgraded = upgraded_store.get(existing.account_binding_id)
+    assert upgraded is not None
+    assert upgraded.provider_channel_id == CHANNEL_A
+    assert upgraded.binding_generation == 1
+
+    with psycopg.connect(scratch_conninfo) as conn:
+        column_shape = conn.execute(
+            "SELECT data_type, is_nullable "
+            "FROM information_schema.columns "
+            "WHERE table_schema = current_schema() "
+            "AND table_name = 'youtube_account_binding' "
+            "AND column_name = 'binding_generation'"
+        ).fetchone()
+        constraint = conn.execute(
+            "SELECT pg_get_constraintdef(oid) "
+            "FROM pg_constraint "
+            "WHERE conname = 'youtube_account_binding_generation_chk' "
+            "AND conrelid = 'youtube_account_binding'::regclass"
+        ).fetchone()
+
+    assert column_shape == ("bigint", "NO")
+    assert constraint is not None
+    assert "binding_generation >= 1" in constraint[0]

--- a/tests/knowledge_acquisition/test_youtube_oauth.py
+++ b/tests/knowledge_acquisition/test_youtube_oauth.py
@@ -295,6 +295,11 @@ def test_loopback_flow_rejects_tampered_state(store, bindings, registry):
         "http://user@127.0.0.1:8765/callback",
         "http://127.0.0.1:8765/callback?code=secret",
         "http://127.0.0.1:8765/callback#fragment",
+        "http://127.0.0.1:8765/callback?",
+        "http://127.0.0.1:8765/callback#",
+        "http://127.0.0.1:8765/call\nback",
+        "http://127.0.0.1:\t8765/callback",
+        "http://127.0.0.1:8765/call\rback",
     ],
 )
 def test_loopback_flow_rejects_non_exact_loopback_redirect_uri(redirect_uri):
@@ -307,13 +312,26 @@ def test_loopback_flow_rejects_non_exact_loopback_redirect_uri(redirect_uri):
     assert provider.requests == []
 
 
-def test_loopback_completion_revalidates_redirect_uri_before_code_exchange():
+@pytest.mark.parametrize(
+    "forged_redirect_uri",
+    [
+        "https://evil.example/callback",
+        "http://127.0.0.1:8765/callback?",
+        "http://127.0.0.1:8765/callback#",
+        "http://127.0.0.1:8765/call\nback",
+        "http://127.0.0.1:\t8765/callback",
+        "http://127.0.0.1:8765/call\rback",
+    ],
+)
+def test_loopback_completion_revalidates_redirect_uri_before_code_exchange(
+    forged_redirect_uri,
+):
     provider = _Provider()
     client = _client(provider)
     flow = oauth.start_loopback_flow(
         client, redirect_uri="http://127.0.0.1:8765/callback"
     )
-    forged = replace(flow, redirect_uri="https://evil.example/callback")
+    forged = replace(flow, redirect_uri=forged_redirect_uri)
 
     with pytest.raises(oauth.InvalidLoopbackRedirectURIError):
         oauth.complete_loopback_flow(
@@ -1828,6 +1846,118 @@ def test_token_provider_refresh_durability_degrades_binding_and_sources_without_
     assert store.get(binding_id).refresh_token == SENTINEL_REFRESH
 
 
+def test_compensated_refresh_cleanup_residue_is_never_promoted(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    canonical = store.get(binding_id)
+    assert canonical is not None
+    store.put(binding_id, canonical.with_expired_access())
+    provider.token_responses.append(
+        _granted_token(access=SENTINEL_ACCESS_2, refresh=SENTINEL_REFRESH_2)
+    )
+    pending_id = oauth._pending_refresh_id(binding_id)
+    original_put = store.put
+    original_confirm = store.confirm_record_durable
+    original_delete = store.delete
+    calls = {"journal_put": 0, "confirm": 0, "cleanup": 0}
+
+    def land_unconfirmed_refresh_journal(target_id, token):
+        if (
+            target_id == pending_id
+            and token.promotion_compensation_state is None
+        ):
+            calls["journal_put"] += 1
+            original_put(target_id, token)
+            raise tokstore.TokenStoreDurabilityError("unconfirmed refresh journal")
+        original_put(target_id, token)
+
+    def refuse_unconfirmed_refresh_journal(target_id, token):
+        if (
+            target_id == pending_id
+            and token.promotion_compensation_state is None
+        ):
+            calls["confirm"] += 1
+            return False
+        return original_confirm(target_id, token)
+
+    def fail_first_compensated_cleanup(target_id):
+        if target_id == pending_id and calls["cleanup"] == 0:
+            calls["cleanup"] += 1
+            raise OSError("cleanup acknowledgement lost")
+        return original_delete(target_id)
+
+    monkeypatch.setattr(store, "put", land_unconfirmed_refresh_journal)
+    monkeypatch.setattr(
+        store, "confirm_record_durable", refuse_unconfirmed_refresh_journal
+    )
+    monkeypatch.setattr(store, "delete", fail_first_compensated_cleanup)
+    token_provider = oauth.TokenProvider(
+        binding_id=binding_id,
+        token_store=store,
+        oauth_client=_client(provider),
+        binding_store=bindings,
+        source_registry=registry,
+    )
+
+    with pytest.raises(oauth.AuthDegradedError) as first_error:
+        token_provider.get_access_token()
+
+    assert first_error.value.reason_code == "auth_revoked"
+    _assert_no_exception_chain(first_error.value)
+    assert calls == {"journal_put": 2, "confirm": 2, "cleanup": 1}
+    assert provider.revoked[-1] == {"token": SENTINEL_REFRESH_2}
+    compensated = store.get(pending_id)
+    assert compensated is not None
+    assert compensated.promotion_compensation_state == "compensated"
+    binding = bindings.get(binding_id)
+    assert binding is not None
+    assert binding.state == "degraded"
+    assert binding.reason_code == "auth_revoked"
+    token_calls = sum(
+        urlsplit(str(request.url)).path.endswith("/token")
+        for request in provider.requests
+    )
+    revoke_calls = sum(
+        urlsplit(str(request.url)).path.endswith("/revoke")
+        for request in provider.requests
+    )
+
+    monkeypatch.setattr(store, "put", original_put)
+    monkeypatch.setattr(store, "confirm_record_durable", original_confirm)
+    monkeypatch.setattr(store, "delete", original_delete)
+    with pytest.raises(oauth.AuthDegradedError) as retry_error:
+        token_provider.get_access_token()
+
+    assert retry_error.value.reason_code == "auth_revoked"
+    _assert_no_exception_chain(retry_error.value)
+    assert store.has_record(pending_id) is False
+    recovered_canonical = store.get(binding_id)
+    assert recovered_canonical is not None
+    assert recovered_canonical.refresh_token == SENTINEL_REFRESH
+    assert (
+        sum(
+            urlsplit(str(request.url)).path.endswith("/token")
+            for request in provider.requests
+        )
+        == token_calls
+    )
+    assert (
+        sum(
+            urlsplit(str(request.url)).path.endswith("/revoke")
+            for request in provider.requests
+        )
+        == revoke_calls
+    )
+    binding = bindings.get(binding_id)
+    assert binding is not None
+    assert binding.state == "degraded"
+    assert binding.reason_code == "auth_revoked"
+
+
 def test_disconnect_promotes_pending_refresh_before_provider_revocation(
     store, bindings, registry
 ):
@@ -1930,6 +2060,103 @@ def test_reconnect_stops_before_token_poll_on_conflicting_refresh_generation(
         )
         == token_calls_before
     )
+
+
+def test_reconnect_degradation_lock_prevents_stale_overwrite_after_peer_recovery(
+    store, bindings, registry, monkeypatch
+):
+    provider_a = _Provider()
+    provider_b = _Provider()
+    binder_a = _binder(provider_a, store, bindings, registry)
+    connected = _connect_device(binder_a)
+    binding_id = connected["account"]["binding_id"]
+    canonical = store.get(binding_id)
+    assert canonical is not None
+    pending_id = oauth._pending_refresh_id(binding_id)
+    pending = replace(
+        canonical,
+        refresh_token=SENTINEL_REFRESH_2,
+        access_token=SENTINEL_ACCESS_2,
+        expires_at="2999-01-01T00:00:00+00:00",
+        authority_generation=canonical.authority_generation + 1,
+        promotion_target_binding_id=binding_id,
+        promotion_predecessor_refresh_token=canonical.refresh_token,
+        promotion_predecessor_generation=canonical.authority_generation,
+    )
+    store.put(pending_id, pending)
+    reconnect = binder_a.start_reconnect(binding_id)
+    original_put = store.put
+    original_degrade = binder_a._degrade_refresh_authority
+    reached_degrade = threading.Event()
+    allow_degrade = threading.Event()
+    peer_finished = threading.Event()
+    actor_a_errors: list[BaseException] = []
+    actor_b_results: list[str] = []
+
+    def fail_only_stale_actor_promotion(target_id, token):
+        if target_id == binding_id and threading.current_thread().name == "stale-reconnect":
+            raise OSError("transient canonical promotion failure")
+        return original_put(target_id, token)
+
+    def pause_before_degradation(
+        target_id, *, reason_code, pending_grant_id
+    ):
+        reached_degrade.set()
+        assert allow_degrade.wait(timeout=5)
+        return original_degrade(
+            target_id,
+            reason_code=reason_code,
+            pending_grant_id=pending_grant_id,
+        )
+
+    monkeypatch.setattr(store, "put", fail_only_stale_actor_promotion)
+    monkeypatch.setattr(binder_a, "_degrade_refresh_authority", pause_before_degradation)
+    token_provider_b = oauth.TokenProvider(
+        binding_id=binding_id,
+        token_store=store,
+        oauth_client=_client(provider_b),
+        binding_store=bindings,
+        source_registry=registry,
+    )
+
+    def stale_reconnect() -> None:
+        try:
+            binder_a.finish_device_connection(reconnect)
+        except BaseException as error:
+            actor_a_errors.append(error)
+
+    def peer_recovery() -> None:
+        try:
+            actor_b_results.append(token_provider_b.get_access_token())
+        finally:
+            peer_finished.set()
+
+    actor_a = threading.Thread(target=stale_reconnect, name="stale-reconnect")
+    actor_a.start()
+    assert reached_degrade.wait(timeout=5)
+    actor_b = threading.Thread(target=peer_recovery, name="peer-recovery")
+    actor_b.start()
+    try:
+        assert peer_finished.wait(timeout=0.2) is False
+    finally:
+        allow_degrade.set()
+    actor_a.join(timeout=5)
+    actor_b.join(timeout=5)
+
+    assert actor_a.is_alive() is False
+    assert actor_b.is_alive() is False
+    assert len(actor_a_errors) == 1
+    assert isinstance(actor_a_errors[0], oauth.OAuthGrantDurabilityError)
+    assert actor_a_errors[0].reason_code == "refresh_pending"
+    assert actor_b_results == [SENTINEL_ACCESS_2]
+    assert store.has_record(pending_id) is False
+    promoted = store.get(binding_id)
+    assert promoted is not None
+    assert promoted.refresh_token == SENTINEL_REFRESH_2
+    binding = bindings.get(binding_id)
+    assert binding is not None
+    assert binding.state == "connected"
+    assert binding.reason_code is None
 
 
 def test_disconnect_pending_refresh_outcome_degrades_without_cursor_or_artifact_mutation(

--- a/tests/knowledge_acquisition/test_youtube_oauth.py
+++ b/tests/knowledge_acquisition/test_youtube_oauth.py
@@ -1058,6 +1058,50 @@ def test_definite_precommit_failure_retry_creates_binding_from_original_grant(
     assert provider.revoked == []
 
 
+def test_pending_only_retry_canonical_failure_does_not_create_connected_binding(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    pending_id = "pending-youtube-grant-canonical-failure"
+    candidate_id = oauth._binding_candidate_id(SYNTH_CHANNEL_ID)
+    pending = tokstore.StoredToken(
+        refresh_token=SENTINEL_REFRESH,
+        access_token=SENTINEL_ACCESS,
+        expires_at=None,
+        scopes=(oauth.SCOPE,),
+        obtained_at="2026-07-20T00:00:00+00:00",
+        provider_channel_id=SYNTH_CHANNEL_ID,
+        authority_generation=1,
+        promotion_target_binding_id=candidate_id,
+        promotion_predecessor_refresh_token=None,
+        promotion_predecessor_generation=0,
+        promotion_display_label=SYNTH_CHANNEL_TITLE,
+    )
+    store.put(pending_id, pending)
+    original_put = store.put
+
+    def fail_canonical_write(target_id, token):
+        if target_id == candidate_id:
+            raise OSError(SENTINEL_REFRESH)
+        original_put(target_id, token)
+
+    monkeypatch.setattr(store, "put", fail_canonical_write)
+
+    result = binder.retry_pending_grant_compensation(pending_id)
+
+    assert result == {
+        "status": "promotion_pending",
+        "pending_grant_id": pending_id,
+        "binding_id": candidate_id,
+    }
+    assert bindings.get(candidate_id) is None
+    assert bindings.get_by_channel_id(SYNTH_CHANNEL_ID) is None
+    assert store.get(candidate_id) is None
+    assert store.get(pending_id) == pending
+    assert provider.revoked == []
+
+
 def test_indeterminate_first_connect_keeps_distinct_grants_retryable_until_delayed_commit(
     store, bindings, registry, monkeypatch
 ):
@@ -1393,6 +1437,10 @@ def test_rotated_refresh_store_failure_preserves_journal_and_recovers_without_pr
     assert excinfo.value.reason_code == "refresh_pending"
     assert excinfo.value.pending_grant_id == pending_id
     _assert_no_exception_chain(excinfo.value)
+    binding = bindings.get(binding_id)
+    assert binding is not None
+    assert binding.state == "degraded"
+    assert binding.reason_code == "auth_refresh_pending"
     canonical = store.get(binding_id)
     pending = store.get(pending_id)
     assert canonical is not None
@@ -1420,6 +1468,10 @@ def test_rotated_refresh_store_failure_preserves_journal_and_recovers_without_pr
 
     monkeypatch.setattr(store, "put", original_put)
     assert token_provider.get_access_token() == SENTINEL_ACCESS_2
+    recovered_binding = bindings.get(binding_id)
+    assert recovered_binding is not None
+    assert recovered_binding.state == "connected"
+    assert recovered_binding.reason_code is None
 
     promoted = store.get(binding_id)
     assert promoted is not None
@@ -1435,6 +1487,138 @@ def test_rotated_refresh_store_failure_preserves_journal_and_recovers_without_pr
         )
         == token_calls_after_failure
     )
+
+
+def test_token_provider_refresh_conflict_degrades_binding_and_sources_without_secret_leak(
+    store, bindings, registry
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    source = registry.register(
+        collection_kind="owned_playlist",
+        collection_ref=SYNTH_PLAYLIST_REF,
+        title="Owned",
+        account_binding_id=binding_id,
+    )
+    cursor_before = dict(source.cursor)
+    predecessor = store.get(binding_id)
+    assert predecessor is not None
+    canonical = tokstore.StoredToken(
+        refresh_token="sentinel-REFRESH3-must-never-leak",
+        access_token="sentinel-ACCESS3-must-never-leak",
+        expires_at=None,
+        scopes=predecessor.scopes,
+        obtained_at="2026-07-20T00:02:00+00:00",
+        provider_channel_id=predecessor.provider_channel_id,
+        authority_generation=predecessor.authority_generation + 2,
+    )
+    pending_id = oauth._pending_refresh_id(binding_id)
+    pending = tokstore.StoredToken(
+        refresh_token=SENTINEL_REFRESH_2,
+        access_token=SENTINEL_ACCESS_2,
+        expires_at=None,
+        scopes=predecessor.scopes,
+        obtained_at="2026-07-20T00:01:00+00:00",
+        provider_channel_id=predecessor.provider_channel_id,
+        authority_generation=predecessor.authority_generation + 1,
+        promotion_target_binding_id=binding_id,
+        promotion_predecessor_refresh_token=predecessor.refresh_token,
+        promotion_predecessor_generation=predecessor.authority_generation,
+    )
+    store.put(binding_id, canonical)
+    store.put(pending_id, pending)
+    token_provider = oauth.TokenProvider(
+        binding_id=binding_id,
+        token_store=store,
+        oauth_client=_client(provider),
+        binding_store=bindings,
+        source_registry=registry,
+    )
+
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
+        token_provider.get_access_token()
+
+    assert excinfo.value.reason_code == "refresh_conflict"
+    _assert_no_exception_chain(excinfo.value)
+    assert all(sentinel not in str(excinfo.value) for sentinel in _ALL_SENTINELS)
+    binding = bindings.get(binding_id)
+    assert binding is not None
+    assert binding.state == "degraded"
+    assert binding.reason_code == "auth_refresh_conflict"
+    degraded_source = registry.get(source.binding_id)
+    assert degraded_source.last_error is not None
+    assert degraded_source.last_error["reason_code"] == "auth_refresh_conflict"
+    assert degraded_source.cursor == cursor_before
+    assert degraded_source.enabled is True
+    assert store.get(binding_id) == canonical
+    assert store.get(pending_id) == pending
+
+
+def test_token_provider_refresh_durability_degrades_binding_and_sources_without_secret_leak(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    source = registry.register(
+        collection_kind="owned_playlist",
+        collection_ref=SYNTH_PLAYLIST_REF,
+        title="Owned",
+        account_binding_id=binding_id,
+    )
+    cursor_before = dict(source.cursor)
+    canonical = store.get(binding_id)
+    assert canonical is not None
+    store.put(binding_id, canonical.with_expired_access())
+    provider.token_responses.append(
+        _granted_token(access=SENTINEL_ACCESS_2, refresh=SENTINEL_REFRESH_2)
+    )
+    provider.revoke_responses.append(
+        httpx.Response(
+            503,
+            json={
+                "error": SENTINEL_REFRESH_2,
+                "error_description": SENTINEL_ACCESS_2,
+            },
+        )
+    )
+    pending_id = oauth._pending_refresh_id(binding_id)
+    original_put = store.put
+
+    def fail_refresh_journal(target_id, token):
+        if target_id == pending_id:
+            raise OSError(SENTINEL_REFRESH_2)
+        original_put(target_id, token)
+
+    monkeypatch.setattr(store, "put", fail_refresh_journal)
+    token_provider = oauth.TokenProvider(
+        binding_id=binding_id,
+        token_store=store,
+        oauth_client=_client(provider),
+        binding_store=bindings,
+        source_registry=registry,
+    )
+
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
+        token_provider.get_access_token()
+
+    assert excinfo.value.reason_code == "refresh_durability_unavailable"
+    _assert_no_exception_chain(excinfo.value)
+    assert all(sentinel not in str(excinfo.value) for sentinel in _ALL_SENTINELS)
+    binding = bindings.get(binding_id)
+    assert binding is not None
+    assert binding.state == "degraded"
+    assert binding.reason_code == "auth_refresh_durability"
+    degraded_source = registry.get(source.binding_id)
+    assert degraded_source.last_error is not None
+    assert degraded_source.last_error["reason_code"] == "auth_refresh_durability"
+    assert degraded_source.cursor == cursor_before
+    assert degraded_source.enabled is True
+    assert store.has_record(pending_id) is False
+    assert store.get(binding_id).refresh_token == SENTINEL_REFRESH
 
 
 def test_disconnect_promotes_pending_refresh_before_provider_revocation(

--- a/tests/knowledge_acquisition/test_youtube_oauth.py
+++ b/tests/knowledge_acquisition/test_youtube_oauth.py
@@ -12,6 +12,7 @@ Secrets and private bindings`` and INV-YSS-4 / INV-YSS-5 in that dir's README.
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
 import secrets
@@ -558,13 +559,44 @@ def test_pending_parent_directory_fsync_lost_ack_keeps_retry_authority(
     with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
         _connect_device(binder)
 
-    assert directory_fsyncs == 2  # readiness, then pending-grant journal
+    # A visible post-replace record is not crash-durable authority by itself.
+    # The failed pending-journal barrier must be retried successfully before
+    # the pending handle can be returned without provider compensation.
+    assert directory_fsyncs == 3  # readiness, failed journal barrier, confirmation barrier
     assert excinfo.value.reason_code == "grant_pending"
     pending_id = excinfo.value.pending_grant_id
     assert pending_id is not None
     assert store.binding_ids() == (pending_id,)
     assert store.get(pending_id).refresh_token == SENTINEL_REFRESH
     assert provider.revoked == []
+    assert SENTINEL_REFRESH not in (repr(excinfo.value) + str(excinfo.value))
+    _assert_no_exception_chain(excinfo.value)
+
+
+def test_repeated_pending_directory_fsync_failure_compensates_visible_record(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    original_fsync = tokstore.os.fsync
+    directory_fsyncs = 0
+
+    def fail_pending_directory_barriers(descriptor):
+        nonlocal directory_fsyncs
+        if stat.S_ISDIR(tokstore.os.fstat(descriptor).st_mode):
+            directory_fsyncs += 1
+            if directory_fsyncs >= 2:
+                raise OSError(SENTINEL_REFRESH)
+        original_fsync(descriptor)
+
+    monkeypatch.setattr(tokstore.os, "fsync", fail_pending_directory_barriers)
+
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
+        _connect_device(binder)
+
+    assert excinfo.value.reason_code == "grant_compensated"
+    assert provider.revoked == [{"token": SENTINEL_REFRESH}]
+    assert bindings.list_all() == ()
     assert SENTINEL_REFRESH not in (repr(excinfo.value) + str(excinfo.value))
     _assert_no_exception_chain(excinfo.value)
 
@@ -616,7 +648,7 @@ def test_reconnect_write_failure_does_not_mistake_old_token_for_new_grant_durabi
 
     def fail_reconnect_canonical_write(target_id, token):
         writes.append(target_id)
-        if len(writes) == 2:
+        if target_id == binding_id:
             raise OSError(SENTINEL_REFRESH_2)
         original_put(target_id, token)
 
@@ -629,7 +661,7 @@ def test_reconnect_write_failure_does_not_mistake_old_token_for_new_grant_durabi
     pending_id = excinfo.value.pending_grant_id
     assert pending_id == writes[0]
     assert pending_id.startswith("pending-youtube-grant-")
-    assert writes[1] == binding_id
+    assert writes == [pending_id, pending_id, binding_id]
     assert set(store.binding_ids()) == {binding_id, pending_id}
     assert store.get(binding_id).refresh_token == SENTINEL_REFRESH
     assert store.get(pending_id).refresh_token == SENTINEL_REFRESH_2
@@ -672,6 +704,134 @@ def test_reconnect_canonical_write_lost_ack_rolls_forward_without_revoking_new_g
     # canonical grant whose exact readback already proved lost-ack success.
     retried = binder.retry_pending_grant_compensation(pending_id)
     assert retried == {"status": "absent", "pending_grant_id": pending_id}
+    assert provider.revoked == []
+
+
+def test_reconnect_pending_cleanup_retry_never_revokes_canonical_grant(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    provider.token_responses.append(
+        _granted_token(access=SENTINEL_ACCESS_2, refresh=SENTINEL_REFRESH_2)
+    )
+    reconnect = binder.start_reconnect(binding_id)
+    pending_id = oauth._pending_grant_id(reconnect.handle.device_code, binding_id)
+    original_delete = store.delete
+    cleanup_attempts = 0
+
+    def fail_first_pending_cleanup(target_id):
+        nonlocal cleanup_attempts
+        if target_id == pending_id:
+            cleanup_attempts += 1
+            if cleanup_attempts == 1:
+                raise OSError(SENTINEL_REFRESH_2)
+        return original_delete(target_id)
+
+    monkeypatch.setattr(store, "delete", fail_first_pending_cleanup)
+
+    result = binder.finish_device_connection(reconnect)
+
+    assert result["status"] == "connected"
+    assert set(store.binding_ids()) == {binding_id, pending_id}
+    assert store.get(binding_id).refresh_token == SENTINEL_REFRESH_2
+    assert store.get(pending_id).refresh_token == SENTINEL_REFRESH_2
+
+    retried = binder.retry_pending_grant_compensation(pending_id)
+
+    assert retried == {
+        "status": "canonical",
+        "pending_grant_id": pending_id,
+        "binding_id": binding_id,
+    }
+    assert store.binding_ids() == (binding_id,)
+    assert store.get(binding_id).refresh_token == SENTINEL_REFRESH_2
+    assert provider.revoked == []
+
+
+def test_reconnect_canonical_directory_barrier_recovery_preserves_pending_handle(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    provider.token_responses.append(
+        _granted_token(access=SENTINEL_ACCESS_2, refresh=SENTINEL_REFRESH_2)
+    )
+    reconnect = binder.start_reconnect(binding_id)
+    pending_id = oauth._pending_grant_id(reconnect.handle.device_code, binding_id)
+    original_fsync = tokstore.os.fsync
+    directory_fsyncs = 0
+
+    def fail_canonical_barrier_and_first_confirmation(descriptor):
+        nonlocal directory_fsyncs
+        if stat.S_ISDIR(tokstore.os.fstat(descriptor).st_mode):
+            directory_fsyncs += 1
+            if directory_fsyncs in {4, 5}:
+                raise OSError(SENTINEL_REFRESH_2)
+        original_fsync(descriptor)
+
+    monkeypatch.setattr(
+        tokstore.os, "fsync", fail_canonical_barrier_and_first_confirmation
+    )
+
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
+        binder.finish_device_connection(reconnect)
+
+    assert directory_fsyncs == 6
+    assert excinfo.value.reason_code == "grant_pending"
+    assert excinfo.value.pending_grant_id == pending_id
+    assert set(store.binding_ids()) == {binding_id, pending_id}
+    assert store.get(binding_id).refresh_token == SENTINEL_REFRESH_2
+    assert store.get(pending_id).refresh_token == SENTINEL_REFRESH_2
+    assert provider.revoked == []
+    _assert_no_exception_chain(excinfo.value)
+
+    retried = binder.retry_pending_grant_compensation(pending_id)
+    assert retried["status"] == "canonical"
+    assert store.binding_ids() == (binding_id,)
+    assert provider.revoked == []
+
+
+def test_pending_retry_never_revokes_rotated_canonical_channel_grant(
+    store, bindings, registry
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    pending_id = "pending-youtube-grant-rotated-canonical-test"
+    stale_pending = tokstore.StoredToken(
+        refresh_token=SENTINEL_REFRESH_2,
+        access_token=SENTINEL_ACCESS_2,
+        expires_at=None,
+        scopes=(oauth.SCOPE,),
+        obtained_at="2026-07-18T00:00:00+00:00",
+        provider_channel_id=SYNTH_CHANNEL_ID,
+    )
+    rotated_canonical = tokstore.StoredToken(
+        refresh_token="sentinel-REFRESH3-must-never-leak",
+        access_token="sentinel-ACCESS3-must-never-leak",
+        expires_at=None,
+        scopes=(oauth.SCOPE,),
+        obtained_at="2026-07-19T00:00:00+00:00",
+        provider_channel_id=SYNTH_CHANNEL_ID,
+    )
+    store.put(pending_id, stale_pending)
+    store.put(binding_id, rotated_canonical)
+
+    retried = binder.retry_pending_grant_compensation(pending_id)
+
+    assert retried == {
+        "status": "canonical",
+        "pending_grant_id": pending_id,
+        "binding_id": binding_id,
+    }
+    assert store.get(binding_id) == rotated_canonical
+    assert store.has_record(pending_id) is False
     assert provider.revoked == []
 
 
@@ -823,6 +983,78 @@ def test_failed_first_connect_status_is_not_connected_without_token_record(
 
     assert status["status"] == "degraded"
     assert status["reason_code"] == "auth_missing"
+
+
+def test_valid_wrong_store_key_blocks_before_token_poll_and_status_fails_closed(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    raw_before = store.path.read_bytes()
+    provider.requests.clear()
+    monkeypatch.setenv(tokstore.KEY_ENV_VAR, secrets.token_hex(32))
+
+    reconnect = binder.start_reconnect(binding_id)
+    with pytest.raises(tokstore.TokenStoreKeyMismatchError) as excinfo:
+        binder.finish_device_connection(reconnect)
+
+    assert not any(urlsplit(str(r.url)).path.endswith("/token") for r in provider.requests)
+    assert store.path.read_bytes() == raw_before
+    assert binder.status(binding_id) == {
+        "status": "degraded",
+        "reason_code": "auth_key_missing",
+        "scopes": [oauth.SCOPE],
+        "token_store": "encrypted",
+    }
+    assert SENTINEL_REFRESH not in (repr(excinfo.value) + str(excinfo.value))
+    _assert_no_exception_chain(excinfo.value)
+
+
+def test_valid_wrong_store_key_cannot_create_mixed_key_aggregate(store, monkeypatch):
+    token = tokstore.StoredToken(
+        refresh_token=SENTINEL_REFRESH,
+        access_token=SENTINEL_ACCESS,
+        expires_at=None,
+        scopes=(oauth.SCOPE,),
+        obtained_at="2026-07-18T00:00:00+00:00",
+        provider_channel_id=SYNTH_CHANNEL_ID,
+    )
+    store.put("canonical", token)
+    raw_before = store.path.read_bytes()
+    monkeypatch.setenv(tokstore.KEY_ENV_VAR, secrets.token_hex(32))
+
+    with pytest.raises(tokstore.TokenStoreKeyMismatchError):
+        store.put("wrong-key-record", token)
+
+    assert store.path.read_bytes() == raw_before
+    monkeypatch.setenv(tokstore.KEY_ENV_VAR, TEST_STORE_KEY)
+    assert store.get("canonical") == token
+    assert store.has_record("wrong-key-record") is False
+
+
+def test_status_never_reports_tampered_encrypted_record_as_connected(
+    store, bindings, registry
+):
+    binder = _binder(_Provider(), store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    aggregate = json.loads(store.path.read_text(encoding="utf-8"))
+    encrypted = base64.b64decode(
+        aggregate["records"][binding_id]["ciphertext"], validate=True
+    )
+    aggregate["records"][binding_id]["ciphertext"] = base64.b64encode(
+        bytes([encrypted[0] ^ 0x01]) + encrypted[1:]
+    ).decode("ascii")
+    store.path.write_text(json.dumps(aggregate), encoding="utf-8")
+
+    assert binder.status(binding_id) == {
+        "status": "degraded",
+        "reason_code": "auth_key_missing",
+        "scopes": [oauth.SCOPE],
+        "token_store": "encrypted",
+    }
 
 
 # --- AC4 --------------------------------------------------------------------
@@ -1232,6 +1464,36 @@ def test_portable_lock_uses_windows_backend_when_fcntl_unavailable(store, monkey
     monkeypatch.setattr(tokstore, "_msvcrt", FakeMsvcrt)
     assert store.has_record("missing") is False
     assert calls == [(FakeMsvcrt.LK_LOCK, 1), (FakeMsvcrt.LK_UNLCK, 1)]
+
+
+def test_windows_store_replacement_uses_write_through(store, tmp_path, monkeypatch):
+    source = tmp_path / "windows-staged-token-store"
+    source.write_bytes(b"encrypted-aggregate")
+    calls: list[tuple[str, str, int]] = []
+    original_replace = tokstore.os.replace
+
+    class FakeMoveFileEx:
+        argtypes = None
+        restype = None
+
+        def __call__(self, staged, target, flags):
+            calls.append((staged, target, flags))
+            original_replace(staged, target)
+            return 1
+
+    class FakeKernel32:
+        MoveFileExW = FakeMoveFileEx()
+
+    class FakeWindll:
+        kernel32 = FakeKernel32()
+
+    monkeypatch.setattr(tokstore.os, "name", "nt")
+    monkeypatch.setattr(tokstore.ctypes, "windll", FakeWindll(), raising=False)
+
+    store._replace_with_barrier(source)
+
+    assert calls == [(str(source), str(store.path), 0x1 | 0x8)]
+    assert store.path.read_bytes() == b"encrypted-aggregate"
 
 
 def test_disconnect_documented_invalid_token_tears_down_local_state(

--- a/tests/knowledge_acquisition/test_youtube_oauth.py
+++ b/tests/knowledge_acquisition/test_youtube_oauth.py
@@ -219,6 +219,18 @@ def _connect_device(binder: oauth.YouTubeAccountBinder) -> dict:
     return binder.finish_device_connection(connection)
 
 
+def _legacy_encrypted_record(token: tokstore.StoredToken) -> dict[str, str]:
+    """Produce the pre-binding-AAD record shape for migration regressions."""
+    key = bytes.fromhex(TEST_STORE_KEY)
+    nonce = secrets.token_bytes(12)
+    plaintext = json.dumps(token._to_plain(), sort_keys=True).encode("utf-8")
+    ciphertext = tokstore.AESGCM(key).encrypt(nonce, plaintext, None)
+    return {
+        "ciphertext": base64.b64encode(ciphertext).decode("ascii"),
+        "nonce": base64.b64encode(nonce).decode("ascii"),
+    }
+
+
 # --- AC1 --------------------------------------------------------------------
 
 
@@ -1618,6 +1630,155 @@ def test_valid_wrong_store_key_cannot_create_mixed_key_aggregate(store, monkeypa
     monkeypatch.setenv(tokstore.KEY_ENV_VAR, TEST_STORE_KEY)
     assert store.get("canonical") == token
     assert store.has_record("wrong-key-record") is False
+
+
+def test_ciphertext_record_swap_cannot_cross_binding_authority(store):
+    token_a = tokstore.StoredToken(
+        refresh_token=SENTINEL_REFRESH,
+        access_token=SENTINEL_ACCESS,
+        expires_at=None,
+        scopes=(oauth.SCOPE,),
+        obtained_at="2026-07-20T00:00:00+00:00",
+        provider_channel_id="UC__test__aad_channel_a",
+    )
+    token_b = replace(
+        token_a,
+        refresh_token=SENTINEL_REFRESH_2,
+        access_token=SENTINEL_ACCESS_2,
+        provider_channel_id="UC__test__aad_channel_b",
+    )
+    store.put("binding-a", token_a)
+    store.put("binding-b", token_b)
+    aggregate = json.loads(store.path.read_text(encoding="utf-8"))
+    aggregate["records"]["binding-a"], aggregate["records"]["binding-b"] = (
+        aggregate["records"]["binding-b"],
+        aggregate["records"]["binding-a"],
+    )
+    store.path.write_text(json.dumps(aggregate, sort_keys=True), encoding="utf-8")
+    swapped_bytes = store.path.read_bytes()
+
+    with pytest.raises(tokstore.TokenStoreKeyMismatchError) as excinfo:
+        store.get("binding-a")
+
+    assert store.path.read_bytes() == swapped_bytes
+    assert all(secret not in str(excinfo.value) for secret in _ALL_SENTINELS)
+    _assert_no_exception_chain(excinfo.value)
+
+
+def test_validated_legacy_store_upgrades_every_record_to_binding_aad(
+    store, bindings, registry
+):
+    channel_a = "UC__test__legacy_channel_a"
+    channel_b = "UC__test__legacy_channel_b"
+    binding_a = bindings.create(
+        provider_channel_id=channel_a,
+        display_label="Legacy A",
+        scopes=[oauth.SCOPE],
+        account_binding_id="legacy-binding-a",
+    )
+    binding_b = bindings.create(
+        provider_channel_id=channel_b,
+        display_label="Legacy B",
+        scopes=[oauth.SCOPE],
+        account_binding_id="legacy-binding-b",
+    )
+    token_a = tokstore.StoredToken(
+        refresh_token=SENTINEL_REFRESH,
+        access_token=SENTINEL_ACCESS,
+        expires_at=None,
+        scopes=(oauth.SCOPE,),
+        obtained_at="2026-07-20T00:00:00+00:00",
+        provider_channel_id=channel_a,
+    )
+    token_b = replace(
+        token_a,
+        refresh_token=SENTINEL_REFRESH_2,
+        access_token=SENTINEL_ACCESS_2,
+        provider_channel_id=channel_b,
+    )
+    store.path.write_text(
+        json.dumps(
+            {
+                "schema": "youtube-token-store.v1",
+                "key_check": tokstore.YouTubeTokenStore._encrypted_record(
+                    bytes.fromhex(TEST_STORE_KEY), tokstore._KEY_CHECK_PLAINTEXT
+                ),
+                "records": {
+                    binding_a.account_binding_id: _legacy_encrypted_record(token_a),
+                    binding_b.account_binding_id: _legacy_encrypted_record(token_b),
+                },
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    _binder(_Provider(), store, bindings, registry)
+
+    assert store.get(binding_a.account_binding_id) == token_a
+    upgraded = json.loads(store.path.read_text(encoding="utf-8"))
+    assert upgraded["key_check"]
+    assert {
+        record["aad_version"] for record in upgraded["records"].values()
+    } == {"binding-id.v1"}
+    assert store.get(binding_b.account_binding_id) == token_b
+
+
+def test_pre_migration_legacy_cross_binding_swap_fails_closed_without_rebind(
+    store, bindings, registry
+):
+    channel_a = "UC__test__legacy_swap_channel_a"
+    channel_b = "UC__test__legacy_swap_channel_b"
+    binding_a = bindings.create(
+        provider_channel_id=channel_a,
+        display_label="Legacy Swap A",
+        scopes=[oauth.SCOPE],
+        account_binding_id="legacy-swap-binding-a",
+    )
+    binding_b = bindings.create(
+        provider_channel_id=channel_b,
+        display_label="Legacy Swap B",
+        scopes=[oauth.SCOPE],
+        account_binding_id="legacy-swap-binding-b",
+    )
+    token_a = tokstore.StoredToken(
+        refresh_token=SENTINEL_REFRESH,
+        access_token=SENTINEL_ACCESS,
+        expires_at=None,
+        scopes=(oauth.SCOPE,),
+        obtained_at="2026-07-20T00:00:00+00:00",
+        provider_channel_id=channel_a,
+    )
+    token_b = replace(
+        token_a,
+        refresh_token=SENTINEL_REFRESH_2,
+        access_token=SENTINEL_ACCESS_2,
+        provider_channel_id=channel_b,
+    )
+    store.path.write_text(
+        json.dumps(
+            {
+                "schema": "youtube-token-store.v1",
+                "key_check": tokstore.YouTubeTokenStore._encrypted_record(
+                    bytes.fromhex(TEST_STORE_KEY), tokstore._KEY_CHECK_PLAINTEXT
+                ),
+                "records": {
+                    binding_a.account_binding_id: _legacy_encrypted_record(token_b),
+                    binding_b.account_binding_id: _legacy_encrypted_record(token_a),
+                },
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    swapped_bytes = store.path.read_bytes()
+    _binder(_Provider(), store, bindings, registry)
+
+    with pytest.raises(tokstore.TokenStoreKeyMismatchError) as excinfo:
+        store.get(binding_a.account_binding_id)
+
+    assert store.path.read_bytes() == swapped_bytes
+    assert all(secret not in str(excinfo.value) for secret in _ALL_SENTINELS)
+    _assert_no_exception_chain(excinfo.value)
 
 
 def test_status_never_reports_tampered_encrypted_record_as_connected(
@@ -3388,6 +3549,172 @@ def test_disconnected_reconnect_postcanonical_failure_blocks_until_retry(
     assert bindings.get(binding_id).state == "connected"
     assert bindings.get(binding_id).reason_code is None
     assert store.get(pending_id) is None
+
+
+def test_direct_reconnect_concurrent_terminal_generation_wins_cas(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    disconnected = bindings.set_state(
+        binding_id, state="degraded", reason_code="auth_disconnected"
+    )
+    reconnect = binder.start_reconnect(binding_id)
+    provider.token_responses.append(
+        _granted_token(access=SENTINEL_ACCESS_2, refresh=SENTINEL_REFRESH_2)
+    )
+    original_set_state = bindings.set_state
+    injected_terminal = False
+
+    def revoke_before_reconnect_cas(
+        target_binding_id,
+        *,
+        state,
+        reason_code,
+        expected_binding_generation=None,
+    ):
+        nonlocal injected_terminal
+        if state == "connected" and not injected_terminal:
+            injected_terminal = True
+            original_set_state(
+                target_binding_id,
+                state="degraded",
+                reason_code="auth_revoked",
+                expected_binding_generation=disconnected.binding_generation,
+            )
+        return original_set_state(
+            target_binding_id,
+            state=state,
+            reason_code=reason_code,
+            expected_binding_generation=expected_binding_generation,
+        )
+
+    monkeypatch.setattr(bindings, "set_state", revoke_before_reconnect_cas)
+
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
+        binder.finish_device_connection(reconnect)
+
+    assert excinfo.value.reason_code == "grant_pending"
+    pending_id = excinfo.value.pending_grant_id
+    assert pending_id is not None
+    terminal = bindings.get(binding_id)
+    assert terminal is not None
+    assert terminal.reason_code == "auth_revoked"
+    assert terminal.binding_generation == disconnected.binding_generation + 1
+    assert store.has_record(pending_id) is True
+    pending = store.get(pending_id)
+    assert pending is not None
+    assert oauth._pending_binding_generation(pending) == disconnected.binding_generation
+
+    result = binder.retry_pending_grant_compensation(pending_id)
+    assert result["status"] == "canonical_terminal"
+    assert bindings.get(binding_id).reason_code == "auth_revoked"
+
+
+def test_candidate_recovery_transient_negative_read_promotes_exact_disconnected_generation(
+    store, bindings, registry, monkeypatch
+):
+    binder = _binder(_Provider(), store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    canonical = store.get(binding_id)
+    assert canonical is not None
+    disconnected = bindings.set_state(
+        binding_id, state="degraded", reason_code="auth_disconnected"
+    )
+    pending_id = oauth._pending_grant_id("candidate-transient-negative", binding_id)
+    pending = replace(
+        canonical,
+        refresh_token=SENTINEL_REFRESH_2,
+        access_token=SENTINEL_ACCESS_2,
+        authority_generation=canonical.authority_generation + 1,
+        promotion_target_binding_id=binding_id,
+        promotion_predecessor_refresh_token=canonical.refresh_token,
+        promotion_predecessor_generation=canonical.authority_generation,
+        promotion_predecessor_binding_updated_at=oauth._binding_generation_evidence(
+            disconnected.binding_generation
+        ),
+        promotion_display_label=SYNTH_CHANNEL_TITLE,
+    )
+    store.put(pending_id, pending)
+    original_get = bindings.get
+    transient_negative = True
+
+    def miss_once(target_binding_id):
+        nonlocal transient_negative
+        if target_binding_id == binding_id and transient_negative:
+            transient_negative = False
+            return None
+        return original_get(target_binding_id)
+
+    monkeypatch.setattr(bindings, "get", miss_once)
+
+    result = binder.retry_pending_grant_compensation(pending_id)
+
+    assert result["status"] == "promoted"
+    assert store.get(binding_id).refresh_token == SENTINEL_REFRESH_2
+    assert store.has_record(pending_id) is False
+    recovered = original_get(binding_id)
+    assert recovered is not None
+    assert recovered.state == "connected"
+    assert recovered.binding_generation == disconnected.binding_generation + 1
+
+
+def test_candidate_recovery_transient_negative_read_rejects_stale_revoked_generation(
+    store, bindings, registry, monkeypatch
+):
+    binder = _binder(_Provider(), store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    canonical = store.get(binding_id)
+    predecessor_binding = bindings.get(binding_id)
+    assert canonical is not None
+    assert predecessor_binding is not None
+    pending_id = oauth._pending_grant_id("candidate-stale-revoked", binding_id)
+    stale_pending = replace(
+        canonical,
+        refresh_token=SENTINEL_REFRESH_2,
+        access_token=SENTINEL_ACCESS_2,
+        authority_generation=canonical.authority_generation + 1,
+        promotion_target_binding_id=binding_id,
+        promotion_predecessor_refresh_token=canonical.refresh_token,
+        promotion_predecessor_generation=canonical.authority_generation,
+        promotion_predecessor_binding_updated_at=oauth._binding_generation_evidence(
+            predecessor_binding.binding_generation
+        ),
+        promotion_display_label=SYNTH_CHANNEL_TITLE,
+    )
+    store.put(pending_id, stale_pending)
+    revoked = bindings.set_state(
+        binding_id, state="degraded", reason_code="auth_revoked"
+    )
+    original_get = bindings.get
+    transient_negative = True
+
+    def miss_once(target_binding_id):
+        nonlocal transient_negative
+        if target_binding_id == binding_id and transient_negative:
+            transient_negative = False
+            return None
+        return original_get(target_binding_id)
+
+    monkeypatch.setattr(bindings, "get", miss_once)
+
+    result = binder.retry_pending_grant_compensation(pending_id)
+
+    assert result == {
+        "status": "pending_conflict",
+        "pending_grant_id": pending_id,
+        "binding_id": binding_id,
+    }
+    assert store.get(binding_id) == canonical
+    assert store.get(pending_id) == stale_pending
+    terminal = original_get(binding_id)
+    assert terminal is not None
+    assert terminal.reason_code == "auth_revoked"
+    assert terminal.binding_generation == revoked.binding_generation
 
 
 @pytest.mark.parametrize("terminal_reason", ["auth_disconnected", "auth_revoked"])

--- a/tests/knowledge_acquisition/test_youtube_oauth.py
+++ b/tests/knowledge_acquisition/test_youtube_oauth.py
@@ -661,12 +661,65 @@ def test_reconnect_write_failure_does_not_mistake_old_token_for_new_grant_durabi
     pending_id = excinfo.value.pending_grant_id
     assert pending_id == writes[0]
     assert pending_id.startswith("pending-youtube-grant-")
-    assert writes == [pending_id, pending_id, binding_id]
+    assert writes == [pending_id, pending_id, pending_id, binding_id]
     assert set(store.binding_ids()) == {binding_id, pending_id}
     assert store.get(binding_id).refresh_token == SENTINEL_REFRESH
     assert store.get(pending_id).refresh_token == SENTINEL_REFRESH_2
     assert SENTINEL_REFRESH_2 not in (repr(excinfo.value) + str(excinfo.value))
     _assert_no_exception_chain(excinfo.value)
+
+
+def test_reconnect_canonical_write_failure_retry_promotes_only_over_proven_predecessor(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    predecessor = store.get(binding_id)
+    assert predecessor is not None
+    provider.token_responses.append(
+        _granted_token(access=SENTINEL_ACCESS_2, refresh=SENTINEL_REFRESH_2)
+    )
+    reconnect = binder.start_reconnect(binding_id)
+    pending_id = oauth._pending_grant_id(reconnect.handle.device_code, binding_id)
+    original_put = store.put
+
+    def fail_canonical_write(target_id, token):
+        if target_id == binding_id:
+            raise OSError(SENTINEL_REFRESH_2)
+        original_put(target_id, token)
+
+    monkeypatch.setattr(store, "put", fail_canonical_write)
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
+        binder.finish_device_connection(reconnect)
+
+    assert excinfo.value.reason_code == "grant_pending"
+    pending = store.get(pending_id)
+    assert pending is not None
+    assert pending.promotion_target_binding_id == binding_id
+    assert pending.promotion_predecessor_refresh_token == predecessor.refresh_token
+    assert pending.promotion_predecessor_generation == predecessor.authority_generation
+    assert pending.authority_generation == predecessor.authority_generation + 1
+    assert store.get(binding_id) == predecessor
+    assert provider.revoked == []
+
+    monkeypatch.setattr(store, "put", original_put)
+    retried = binder.retry_pending_grant_compensation(pending_id)
+
+    assert retried == {
+        "status": "promoted",
+        "pending_grant_id": pending_id,
+        "binding_id": binding_id,
+    }
+    promoted = store.get(binding_id)
+    assert promoted is not None
+    assert promoted.refresh_token == SENTINEL_REFRESH_2
+    assert promoted.authority_generation == pending.authority_generation
+    assert promoted.promotion_target_binding_id is None
+    assert promoted.promotion_predecessor_refresh_token is None
+    assert store.has_record(pending_id) is False
+    assert provider.revoked == []
 
 
 def test_reconnect_canonical_write_lost_ack_rolls_forward_without_revoking_new_grant(
@@ -770,7 +823,7 @@ def test_reconnect_canonical_directory_barrier_recovery_preserves_pending_handle
         nonlocal directory_fsyncs
         if stat.S_ISDIR(tokstore.os.fstat(descriptor).st_mode):
             directory_fsyncs += 1
-            if directory_fsyncs in {4, 5}:
+            if directory_fsyncs in {5, 6}:
                 raise OSError(SENTINEL_REFRESH_2)
         original_fsync(descriptor)
 
@@ -781,7 +834,7 @@ def test_reconnect_canonical_directory_barrier_recovery_preserves_pending_handle
     with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
         binder.finish_device_connection(reconnect)
 
-    assert directory_fsyncs == 6
+    assert directory_fsyncs == 7
     assert excinfo.value.reason_code == "grant_pending"
     assert excinfo.value.pending_grant_id == pending_id
     assert set(store.binding_ids()) == {binding_id, pending_id}
@@ -811,6 +864,10 @@ def test_pending_retry_never_revokes_rotated_canonical_channel_grant(
         scopes=(oauth.SCOPE,),
         obtained_at="2026-07-18T00:00:00+00:00",
         provider_channel_id=SYNTH_CHANNEL_ID,
+        authority_generation=2,
+        promotion_target_binding_id=binding_id,
+        promotion_predecessor_refresh_token=SENTINEL_REFRESH,
+        promotion_predecessor_generation=1,
     )
     rotated_canonical = tokstore.StoredToken(
         refresh_token="sentinel-REFRESH3-must-never-leak",
@@ -819,6 +876,7 @@ def test_pending_retry_never_revokes_rotated_canonical_channel_grant(
         scopes=(oauth.SCOPE,),
         obtained_at="2026-07-19T00:00:00+00:00",
         provider_channel_id=SYNTH_CHANNEL_ID,
+        authority_generation=3,
     )
     store.put(pending_id, stale_pending)
     store.put(binding_id, rotated_canonical)
@@ -826,12 +884,63 @@ def test_pending_retry_never_revokes_rotated_canonical_channel_grant(
     retried = binder.retry_pending_grant_compensation(pending_id)
 
     assert retried == {
-        "status": "canonical",
+        "status": "pending_conflict",
         "pending_grant_id": pending_id,
         "binding_id": binding_id,
     }
     assert store.get(binding_id) == rotated_canonical
-    assert store.has_record(pending_id) is False
+    assert store.get(pending_id) == stale_pending
+    assert provider.revoked == []
+
+
+def test_pending_grant_retry_does_not_overwrite_newer_pending_refresh_rotation(
+    store, bindings, registry
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    canonical = store.get(binding_id)
+    assert canonical is not None
+    grant_pending_id = "pending-youtube-grant-overlapping-refresh-test"
+    grant_pending = tokstore.StoredToken(
+        refresh_token=SENTINEL_REFRESH_2,
+        access_token=SENTINEL_ACCESS_2,
+        expires_at=None,
+        scopes=canonical.scopes,
+        obtained_at="2026-07-20T00:00:00+00:00",
+        provider_channel_id=canonical.provider_channel_id,
+        authority_generation=canonical.authority_generation + 1,
+        promotion_target_binding_id=binding_id,
+        promotion_predecessor_refresh_token=canonical.refresh_token,
+        promotion_predecessor_generation=canonical.authority_generation,
+    )
+    refresh_pending_id = oauth._pending_refresh_id(binding_id)
+    refresh_pending = tokstore.StoredToken(
+        refresh_token="sentinel-REFRESH3-must-never-leak",
+        access_token="sentinel-ACCESS3-must-never-leak",
+        expires_at=None,
+        scopes=canonical.scopes,
+        obtained_at="2026-07-20T00:01:00+00:00",
+        provider_channel_id=canonical.provider_channel_id,
+        authority_generation=canonical.authority_generation + 1,
+        promotion_target_binding_id=binding_id,
+        promotion_predecessor_refresh_token=canonical.refresh_token,
+        promotion_predecessor_generation=canonical.authority_generation,
+    )
+    store.put(grant_pending_id, grant_pending)
+    store.put(refresh_pending_id, refresh_pending)
+
+    result = binder.retry_pending_grant_compensation(grant_pending_id)
+
+    assert result == {
+        "status": "pending_conflict",
+        "pending_grant_id": grant_pending_id,
+        "binding_id": binding_id,
+    }
+    assert store.get(binding_id) == canonical
+    assert store.get(grant_pending_id) == grant_pending
+    assert store.get(refresh_pending_id) == refresh_pending
     assert provider.revoked == []
 
 
@@ -1058,6 +1167,176 @@ def test_status_never_reports_tampered_encrypted_record_as_connected(
 
 
 # --- AC4 --------------------------------------------------------------------
+
+
+def test_rotated_refresh_store_failure_preserves_journal_and_recovers_without_provider_retry(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    predecessor = store.get(binding_id)
+    assert predecessor is not None
+    store.put(binding_id, predecessor.with_expired_access())
+    provider.token_responses.append(
+        _granted_token(access=SENTINEL_ACCESS_2, refresh=SENTINEL_REFRESH_2)
+    )
+    token_provider = oauth.TokenProvider(
+        binding_id=binding_id,
+        token_store=store,
+        oauth_client=_client(provider),
+        binding_store=bindings,
+        source_registry=registry,
+    )
+    pending_id = oauth._pending_refresh_id(binding_id)
+    original_put = store.put
+
+    def fail_canonical_write(target_id, token):
+        if target_id == binding_id:
+            raise OSError(SENTINEL_REFRESH_2)
+        original_put(target_id, token)
+
+    monkeypatch.setattr(store, "put", fail_canonical_write)
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
+        token_provider.get_access_token()
+
+    assert excinfo.value.reason_code == "refresh_pending"
+    assert excinfo.value.pending_grant_id == pending_id
+    _assert_no_exception_chain(excinfo.value)
+    canonical = store.get(binding_id)
+    pending = store.get(pending_id)
+    assert canonical is not None
+    assert pending is not None
+    assert canonical.refresh_token == SENTINEL_REFRESH
+    assert pending.refresh_token == SENTINEL_REFRESH_2
+    assert pending.promotion_target_binding_id == binding_id
+    assert pending.promotion_predecessor_refresh_token == canonical.refresh_token
+    assert pending.promotion_predecessor_generation == canonical.authority_generation
+    assert pending.authority_generation == canonical.authority_generation + 1
+    refresh_failure_text = repr(excinfo.value) + str(excinfo.value) + repr(pending)
+    assert SENTINEL_REFRESH not in refresh_failure_text
+    assert SENTINEL_REFRESH_2 not in refresh_failure_text
+    assert SENTINEL_ACCESS_2 not in refresh_failure_text
+    assert binder.status(binding_id) == {
+        "status": "degraded",
+        "reason_code": "auth_refresh_pending",
+        "scopes": [oauth.SCOPE],
+        "token_store": "encrypted",
+    }
+    token_calls_after_failure = sum(
+        urlsplit(str(request.url)).path.endswith("/token")
+        for request in provider.requests
+    )
+
+    monkeypatch.setattr(store, "put", original_put)
+    assert token_provider.get_access_token() == SENTINEL_ACCESS_2
+
+    promoted = store.get(binding_id)
+    assert promoted is not None
+    assert promoted.refresh_token == SENTINEL_REFRESH_2
+    assert promoted.authority_generation == pending.authority_generation
+    assert promoted.promotion_predecessor_refresh_token is None
+    assert store.has_record(pending_id) is False
+    assert provider.revoked == []
+    assert (
+        sum(
+            urlsplit(str(request.url)).path.endswith("/token")
+            for request in provider.requests
+        )
+        == token_calls_after_failure
+    )
+
+
+def test_disconnect_promotes_pending_refresh_before_provider_revocation(
+    store, bindings, registry
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    canonical = store.get(binding_id)
+    assert canonical is not None
+    pending_id = oauth._pending_refresh_id(binding_id)
+    pending = tokstore.StoredToken(
+        refresh_token=SENTINEL_REFRESH_2,
+        access_token=SENTINEL_ACCESS_2,
+        expires_at=None,
+        scopes=canonical.scopes,
+        obtained_at="2026-07-20T00:00:00+00:00",
+        provider_channel_id=canonical.provider_channel_id,
+        authority_generation=canonical.authority_generation + 1,
+        promotion_target_binding_id=binding_id,
+        promotion_predecessor_refresh_token=canonical.refresh_token,
+        promotion_predecessor_generation=canonical.authority_generation,
+    )
+    store.put(pending_id, pending)
+
+    result = binder.disconnect(binding_id)
+
+    assert result["status"] == "disconnected"
+    assert result["revoked"] is True
+    assert provider.revoked[-1] == {"token": SENTINEL_REFRESH_2}
+    assert store.has_record(binding_id) is False
+    assert store.has_record(pending_id) is False
+    assert bindings.get(binding_id).reason_code == "auth_disconnected"
+
+
+def test_reconnect_stops_before_token_poll_on_conflicting_refresh_generation(
+    store, bindings, registry
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    original = store.get(binding_id)
+    assert original is not None
+    canonical = tokstore.StoredToken(
+        refresh_token="sentinel-REFRESH3-must-never-leak",
+        access_token="sentinel-ACCESS3-must-never-leak",
+        expires_at=None,
+        scopes=original.scopes,
+        obtained_at="2026-07-20T00:01:00+00:00",
+        provider_channel_id=original.provider_channel_id,
+        authority_generation=original.authority_generation + 2,
+    )
+    pending_id = oauth._pending_refresh_id(binding_id)
+    pending = tokstore.StoredToken(
+        refresh_token=SENTINEL_REFRESH_2,
+        access_token=SENTINEL_ACCESS_2,
+        expires_at=None,
+        scopes=original.scopes,
+        obtained_at="2026-07-20T00:00:00+00:00",
+        provider_channel_id=original.provider_channel_id,
+        authority_generation=original.authority_generation + 1,
+        promotion_target_binding_id=binding_id,
+        promotion_predecessor_refresh_token=original.refresh_token,
+        promotion_predecessor_generation=original.authority_generation,
+    )
+    store.put(binding_id, canonical)
+    store.put(pending_id, pending)
+    reconnect = binder.start_reconnect(binding_id)
+    token_calls_before = sum(
+        urlsplit(str(request.url)).path.endswith("/token")
+        for request in provider.requests
+    )
+
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
+        binder.finish_device_connection(reconnect)
+
+    assert excinfo.value.reason_code == "refresh_conflict"
+    assert excinfo.value.pending_grant_id == pending_id
+    _assert_no_exception_chain(excinfo.value)
+    assert store.get(binding_id) == canonical
+    assert store.get(pending_id) == pending
+    assert provider.revoked == []
+    assert (
+        sum(
+            urlsplit(str(request.url)).path.endswith("/token")
+            for request in provider.requests
+        )
+        == token_calls_before
+    )
 
 
 def test_revoked_auth_degrades_without_cursor_mutation(store, bindings, registry):

--- a/tests/knowledge_acquisition/test_youtube_oauth.py
+++ b/tests/knowledge_acquisition/test_youtube_oauth.py
@@ -20,6 +20,7 @@ import stat
 import subprocess
 import sys
 import threading
+from dataclasses import replace
 from pathlib import Path
 from urllib.parse import parse_qs, urlsplit
 
@@ -985,19 +986,200 @@ def test_connect_precommit_binding_failure_preserves_deterministic_retry_authori
 
     monkeypatch.setattr(bindings, "create", fail_before_insert)
 
-    with pytest.raises(RuntimeError, match="synthetic pre-insert failure"):
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as first_error:
         _connect_device(binder)
+    assert first_error.value.reason_code == "grant_pending"
 
     assert bindings.list_all() == ()
-    first_candidate_ids = store.binding_ids()
-    assert len(first_candidate_ids) == 1
-    assert store.get(first_candidate_ids[0]).refresh_token == SENTINEL_REFRESH
+    first_record_ids = store.binding_ids()
+    assert len(first_record_ids) == 2
+    candidate_ids = [
+        record_id
+        for record_id in first_record_ids
+        if not record_id.startswith("pending-youtube-grant-")
+    ]
+    assert len(candidate_ids) == 1
+    assert store.get(candidate_ids[0]).refresh_token == SENTINEL_REFRESH
 
     # Another failed attempt targets the same idempotency key rather than
     # accumulating uncorrelated credential records.
-    with pytest.raises(RuntimeError, match="synthetic pre-insert failure"):
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as second_error:
         _connect_device(binder)
-    assert store.binding_ids() == first_candidate_ids
+    assert second_error.value.reason_code == "grant_pending"
+    assert store.binding_ids() == first_record_ids
+
+
+def test_definite_precommit_failure_retry_creates_binding_from_original_grant(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    original_create = bindings.create
+
+    def fail_before_insert(**_kwargs):
+        raise RuntimeError("synthetic definite precommit failure")
+
+    monkeypatch.setattr(bindings, "create", fail_before_insert)
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
+        _connect_device(binder)
+
+    pending_id = excinfo.value.pending_grant_id
+    assert pending_id is not None
+    pending = store.get(pending_id)
+    assert pending is not None
+    candidate_id = oauth._binding_candidate_id(SYNTH_CHANNEL_ID)
+    assert pending.promotion_target_binding_id == candidate_id
+    assert pending.promotion_display_label == SYNTH_CHANNEL_TITLE
+    assert store.get(candidate_id).refresh_token == SENTINEL_REFRESH
+    assert bindings.list_all() == ()
+    token_polls_before_retry = sum(
+        urlsplit(str(request.url)).path.endswith("/token")
+        for request in provider.requests
+    )
+
+    monkeypatch.setattr(bindings, "create", original_create)
+    recovered = binder.retry_pending_grant_compensation(pending_id)
+
+    assert recovered == {
+        "status": "canonical",
+        "pending_grant_id": pending_id,
+        "binding_id": candidate_id,
+    }
+    assert bindings.get(candidate_id).state == "connected"
+    assert store.binding_ids() == (candidate_id,)
+    assert store.get(candidate_id).refresh_token == SENTINEL_REFRESH
+    assert (
+        sum(
+            urlsplit(str(request.url)).path.endswith("/token")
+            for request in provider.requests
+        )
+        == token_polls_before_retry
+    )
+    assert provider.revoked == []
+
+
+def test_indeterminate_first_connect_keeps_distinct_grants_retryable_until_delayed_commit(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    original_create = bindings.create
+    create_kwargs: dict[str, object] = {}
+
+    def fail_before_commit(**kwargs):
+        create_kwargs.update(kwargs)
+        raise RuntimeError("synthetic indeterminate binding create")
+
+    monkeypatch.setattr(bindings, "create", fail_before_commit)
+    first_connection = binder.start_device_connection()
+    first_connection = replace(
+        first_connection,
+        handle=replace(first_connection.handle, device_code="first-device-attempt"),
+    )
+    second_connection = binder.start_device_connection()
+    second_connection = replace(
+        second_connection,
+        handle=replace(second_connection.handle, device_code="second-device-attempt"),
+    )
+    provider.token_responses.extend(
+        [
+            _granted_token(access=SENTINEL_ACCESS, refresh=SENTINEL_REFRESH),
+            _granted_token(access=SENTINEL_ACCESS_2, refresh=SENTINEL_REFRESH_2),
+        ]
+    )
+
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as first_error:
+        binder.finish_device_connection(first_connection)
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as second_error:
+        binder.finish_device_connection(second_connection)
+
+    first_pending_id = first_error.value.pending_grant_id
+    second_pending_id = second_error.value.pending_grant_id
+    assert first_error.value.reason_code == "grant_pending"
+    assert second_error.value.reason_code == "grant_pending"
+    assert first_pending_id is not None
+    assert second_pending_id is not None
+    assert first_pending_id != second_pending_id
+    candidate_id = str(create_kwargs["account_binding_id"])
+    assert store.get(candidate_id).refresh_token == SENTINEL_REFRESH
+    assert store.get(first_pending_id).refresh_token == SENTINEL_REFRESH
+    assert store.get(second_pending_id).refresh_token == SENTINEL_REFRESH_2
+    assert provider.revoked == []
+
+    # Neither distinct grant is mistaken for canonical authority while the
+    # matching binding row is absent, and both retain an explicit retry handle.
+    assert binder.retry_pending_grant_compensation(first_pending_id) == {
+        "status": "binding_pending",
+        "pending_grant_id": first_pending_id,
+        "binding_id": candidate_id,
+    }
+    assert binder.retry_pending_grant_compensation(second_pending_id) == {
+        "status": "binding_pending",
+        "pending_grant_id": second_pending_id,
+        "binding_id": candidate_id,
+    }
+    assert store.get(candidate_id).refresh_token == SENTINEL_REFRESH
+    assert provider.revoked == []
+
+    # Once the delayed first create becomes visible, retry first recognizes its
+    # exact canonical grant and retry second promotes only over that predecessor.
+    original_create(**create_kwargs)
+    assert binder.retry_pending_grant_compensation(first_pending_id)["status"] == "canonical"
+    assert binder.retry_pending_grant_compensation(second_pending_id) == {
+        "status": "promoted",
+        "pending_grant_id": second_pending_id,
+        "binding_id": candidate_id,
+    }
+    assert store.binding_ids() == (candidate_id,)
+    assert store.get(candidate_id).refresh_token == SENTINEL_REFRESH_2
+    assert provider.revoked == []
+
+
+def test_indeterminate_first_connect_never_overwrites_newer_same_channel_winner(
+    store, bindings, registry, monkeypatch
+):
+    winner = bindings.create(
+        provider_channel_id=SYNTH_CHANNEL_ID,
+        display_label=SYNTH_CHANNEL_TITLE,
+        scopes=[oauth.SCOPE],
+        account_binding_id="newer-same-channel-winner",
+    )
+    newer = tokstore.StoredToken(
+        refresh_token="sentinel-REFRESH3-must-never-leak",
+        access_token="sentinel-ACCESS3-must-never-leak",
+        expires_at=None,
+        scopes=(oauth.SCOPE,),
+        obtained_at="2026-07-20T00:02:00+00:00",
+        provider_channel_id=SYNTH_CHANNEL_ID,
+        authority_generation=3,
+    )
+    store.put(winner.account_binding_id, newer)
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    channel_reads = 0
+
+    def reveal_winner_after_create(_channel_id):
+        nonlocal channel_reads
+        channel_reads += 1
+        return None if channel_reads == 1 else winner
+
+    def lose_create_ack(**_kwargs):
+        raise RuntimeError("synthetic concurrent create collision")
+
+    monkeypatch.setattr(bindings, "get_by_channel_id", reveal_winner_after_create)
+    monkeypatch.setattr(bindings, "create", lose_create_ack)
+
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
+        _connect_device(binder)
+
+    assert excinfo.value.reason_code == "grant_pending"
+    pending_id = excinfo.value.pending_grant_id
+    assert pending_id is not None
+    candidate_id = oauth._binding_candidate_id(SYNTH_CHANNEL_ID)
+    assert store.get(winner.account_binding_id) == newer
+    assert store.get(candidate_id).refresh_token == SENTINEL_REFRESH
+    assert store.get(pending_id).refresh_token == SENTINEL_REFRESH
+    assert provider.revoked == []
 
 
 def test_connect_delayed_commit_after_negative_readbacks_preserves_and_converges(
@@ -1032,12 +1214,16 @@ def test_connect_delayed_commit_after_negative_readbacks_preserves_and_converges
     monkeypatch.setattr(bindings, "get", negative_exact_readback)
     monkeypatch.setattr(bindings, "get_by_channel_id", negative_channel_readback)
 
-    with pytest.raises(RuntimeError, match="synthetic delayed insert acknowledgement"):
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
         _connect_device(binder)
+    assert excinfo.value.reason_code == "grant_pending"
 
     assert readbacks == ["exact", "channel"]
     candidate_id = str(create_kwargs["account_binding_id"])
-    assert store.binding_ids() == (candidate_id,)
+    assert set(store.binding_ids()) == {
+        candidate_id,
+        oauth._pending_grant_id(SENTINEL_DEVICE_CODE, None),
+    }
     assert store.get(candidate_id).refresh_token == SENTINEL_REFRESH
 
     monkeypatch.setattr(bindings, "create", original_create)
@@ -1066,13 +1252,16 @@ def test_connect_indeterminate_create_readback_preserves_token(
     monkeypatch.setattr(bindings, "create", fail_create)
     monkeypatch.setattr(bindings, "get", fail_readback)
 
-    with pytest.raises(RuntimeError, match="synthetic indeterminate create"):
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
         _connect_device(binder)
+    assert excinfo.value.reason_code == "grant_pending"
 
     # The only encrypted authority for revoking the just-issued remote grant
     # survives until authoritative binding readback is available.
-    assert len(store.binding_ids()) == 1
-    assert store.get(store.binding_ids()[0]).refresh_token == SENTINEL_REFRESH
+    assert len(store.binding_ids()) == 2
+    assert {
+        store.get(record_id).refresh_token for record_id in store.binding_ids()
+    } == {SENTINEL_REFRESH}
 
 
 def test_failed_first_connect_status_is_not_connected_without_token_record(

--- a/tests/knowledge_acquisition/test_youtube_oauth.py
+++ b/tests/knowledge_acquisition/test_youtube_oauth.py
@@ -315,6 +315,77 @@ def test_connect_token_store_failure_does_not_create_connected_binding(
     assert store.binding_ids() == ()
 
 
+def test_connect_post_commit_exception_reconciles_without_deleting_token(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    original_create = bindings.create
+    committed_ids: list[str] = []
+
+    def create_then_lose_acknowledgement(**kwargs):
+        committed = original_create(**kwargs)
+        committed_ids.append(committed.account_binding_id)
+        raise RuntimeError("synthetic lost insert acknowledgement")
+
+    monkeypatch.setattr(bindings, "create", create_then_lose_acknowledgement)
+
+    first = _connect_device(binder)
+    binding_id = first["account"]["binding_id"]
+
+    assert first["status"] == "connected"
+    assert committed_ids == [binding_id]
+    assert bindings.get(binding_id).state == "connected"
+    assert store.get(binding_id).refresh_token == SENTINEL_REFRESH
+
+    # A retry converges through the same channel row instead of creating a
+    # second binding or credential record.
+    second = _connect_device(binder)
+    assert second["account"]["binding_id"] == binding_id
+    assert len(bindings.list_all()) == 1
+    assert store.binding_ids() == (binding_id,)
+
+
+def test_connect_precommit_binding_failure_compensates_after_authoritative_absence(
+    store, bindings, registry, monkeypatch
+):
+    binder = _binder(_Provider(), store, bindings, registry)
+
+    def fail_before_insert(**_kwargs):
+        raise RuntimeError("synthetic pre-insert failure")
+
+    monkeypatch.setattr(bindings, "create", fail_before_insert)
+
+    with pytest.raises(RuntimeError, match="synthetic pre-insert failure"):
+        _connect_device(binder)
+
+    assert bindings.list_all() == ()
+    assert store.binding_ids() == ()
+
+
+def test_connect_indeterminate_create_readback_preserves_token(
+    store, bindings, registry, monkeypatch
+):
+    binder = _binder(_Provider(), store, bindings, registry)
+
+    def fail_create(**_kwargs):
+        raise RuntimeError("synthetic indeterminate create")
+
+    def fail_readback(_binding_id):
+        raise RuntimeError("synthetic readback outage")
+
+    monkeypatch.setattr(bindings, "create", fail_create)
+    monkeypatch.setattr(bindings, "get", fail_readback)
+
+    with pytest.raises(RuntimeError, match="synthetic indeterminate create"):
+        _connect_device(binder)
+
+    # The only encrypted authority for revoking the just-issued remote grant
+    # survives until authoritative binding readback is available.
+    assert len(store.binding_ids()) == 1
+    assert store.get(store.binding_ids()[0]).refresh_token == SENTINEL_REFRESH
+
+
 def test_failed_first_connect_status_is_not_connected_without_token_record(
     store, bindings, registry
 ):
@@ -518,6 +589,39 @@ def test_disconnect_preserves_token_when_provider_revoke_fails(store, bindings, 
     assert registry.get(source.binding_id).enabled is False
 
 
+@pytest.mark.parametrize("status", [0, 100, 199, 300, 302, 399, 408, 429, 500, 599, 600])
+def test_disconnect_indeterminate_revoke_status_preserves_retry_authority(
+    store, bindings, registry, monkeypatch, status
+):
+    binder = _binder(_Provider(), store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    source = registry.register(
+        collection_kind="owned_playlist",
+        collection_ref=SYNTH_PLAYLIST_REF,
+        title="Owned",
+        account_binding_id=binding_id,
+    )
+
+    def fail_revoke(_token):
+        raise oauth.OAuthProviderError(status=status, error_code="synthetic_revoke_failure")
+
+    monkeypatch.setattr(binder._client, "revoke", fail_revoke)
+
+    disc = binder.disconnect(binding_id)
+
+    assert disc == {
+        "status": "disconnect_failed",
+        "revoked": False,
+        "retryable": True,
+        "sources_disabled": 0,
+    }
+    assert store.get(binding_id).refresh_token == SENTINEL_REFRESH
+    assert bindings.get(binding_id).state == "connected"
+    assert bindings.get(binding_id).reason_code is None
+    assert registry.get(source.binding_id).enabled is True
+
+
 def test_disconnect_and_reconnect_are_serialized_across_service_instances(
     store, bindings, registry
 ):
@@ -707,8 +811,9 @@ def test_portable_lock_uses_windows_backend_when_fcntl_unavailable(store, monkey
     assert calls == [(FakeMsvcrt.LK_LOCK, 1), (FakeMsvcrt.LK_UNLCK, 1)]
 
 
+@pytest.mark.parametrize("status", [400, 407, 409, 499])
 def test_disconnect_permanent_revoke_error_tears_down_local_state(
-    store, bindings, registry
+    store, bindings, registry, status
 ):
     provider = _Provider()
     binder = _binder(provider, store, bindings, registry)
@@ -722,7 +827,7 @@ def test_disconnect_permanent_revoke_error_tears_down_local_state(
     )
     provider.revoke_responses.append(
         httpx.Response(
-            400,
+            status,
             json={"error": "invalid_token", "error_description": SENTINEL_REFRESH},
         )
     )

--- a/tests/knowledge_acquisition/test_youtube_oauth.py
+++ b/tests/knowledge_acquisition/test_youtube_oauth.py
@@ -1192,6 +1192,16 @@ def test_reconnect_postcanonical_state_failure_preserves_pending_until_state_con
     assert store.get(pending_id).refresh_token == SENTINEL_REFRESH_2
     assert bindings.get(binding_id).state == "degraded"
     _assert_no_exception_chain(excinfo.value)
+    queued_provider = oauth.TokenProvider(
+        binding_id=binding_id,
+        token_store=store,
+        oauth_client=_client(_Provider()),
+        binding_store=bindings,
+        source_registry=registry,
+    )
+    with pytest.raises(oauth.AuthDegradedError) as queued_error:
+        queued_provider.get_access_token()
+    assert queued_error.value.reason_code == "auth_expired"
 
     recovered = binder.retry_pending_grant_compensation(pending_id)
 
@@ -3250,6 +3260,126 @@ def test_disconnected_reconnect_postcanonical_failure_blocks_until_retry(
     assert bindings.get(binding_id).state == "connected"
     assert bindings.get(binding_id).reason_code is None
     assert store.get(pending_id) is None
+
+
+@pytest.mark.parametrize("terminal_reason", ["auth_disconnected", "auth_revoked"])
+def test_stale_pending_cleanup_cannot_resurrect_terminal_binding(
+    store, bindings, registry, terminal_reason
+):
+    binder = _binder(_Provider(), store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    canonical = store.get(binding_id)
+    assert canonical is not None
+    pending_id = oauth._pending_grant_id("stale-cleanup", binding_id)
+    store.put(
+        pending_id,
+        replace(
+            canonical,
+            promotion_target_binding_id=binding_id,
+            promotion_predecessor_refresh_token=canonical.refresh_token,
+            promotion_predecessor_generation=canonical.authority_generation,
+        ),
+    )
+    bindings.set_state(
+        binding_id, state="degraded", reason_code=terminal_reason
+    )
+
+    result = binder.retry_pending_grant_compensation(pending_id)
+
+    assert result["status"] == "canonical_terminal"
+    assert store.has_record(pending_id) is False
+    assert bindings.get(binding_id).state == "degraded"
+    assert bindings.get(binding_id).reason_code == terminal_reason
+    token_provider = oauth.TokenProvider(
+        binding_id=binding_id,
+        token_store=store,
+        oauth_client=_client(_Provider()),
+        binding_store=bindings,
+        source_registry=registry,
+    )
+    with pytest.raises(oauth.AuthDegradedError) as excinfo:
+        token_provider.get_access_token()
+    assert excinfo.value.reason_code == terminal_reason
+
+
+def test_repeated_consumer_converges_partial_terminal_source_degradation(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    source = registry.register(
+        collection_kind="owned_playlist",
+        collection_ref=SYNTH_PLAYLIST_REF,
+        title="Owned",
+        account_binding_id=binding_id,
+    )
+    cursor_before = dict(source.cursor)
+    canonical = store.get(binding_id)
+    assert canonical is not None
+    store.put(binding_id, canonical.with_expired_access())
+    provider.token_responses.append(_invalid_grant())
+    original_record = registry.record_source_degradation
+    failed_once = False
+
+    def fail_source_once(target_binding_id, *, reason_code):
+        nonlocal failed_once
+        if not failed_once:
+            failed_once = True
+            raise OSError("synthetic source degradation crash")
+        return original_record(target_binding_id, reason_code=reason_code)
+
+    monkeypatch.setattr(registry, "record_source_degradation", fail_source_once)
+    token_provider = oauth.TokenProvider(
+        binding_id=binding_id,
+        token_store=store,
+        oauth_client=_client(provider),
+        binding_store=bindings,
+        source_registry=registry,
+    )
+    with pytest.raises(OSError, match="synthetic source degradation crash"):
+        token_provider.get_access_token()
+
+    assert bindings.get(binding_id).reason_code == "auth_revoked"
+    assert registry.get(source.binding_id).last_error is None
+    with pytest.raises(oauth.AuthDegradedError) as retry_error:
+        token_provider.get_access_token()
+
+    assert retry_error.value.reason_code == "auth_revoked"
+    repaired_source = registry.get(source.binding_id)
+    assert repaired_source.last_error["reason_code"] == "auth_revoked"
+    assert repaired_source.cursor == cursor_before
+    assert repaired_source.enabled is True
+
+
+def test_terminal_status_precedes_missing_key_for_disconnect_retry_authority(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    provider.revoke_responses.append(
+        httpx.Response(503, json={"error": "temporarily_unavailable"})
+    )
+
+    result = binder.disconnect(binding_id)
+    assert result["status"] == "disconnect_failed"
+    assert bindings.get(binding_id).reason_code == "auth_disconnected"
+    monkeypatch.delenv(tokstore.KEY_ENV_VAR, raising=False)
+
+    assert binder.status(binding_id)["reason_code"] == "auth_disconnected"
+
+
+def test_token_provider_requires_binding_authority_dependency(store):
+    with pytest.raises(TypeError, match="binding_store"):
+        oauth.TokenProvider(  # type: ignore[call-arg]
+            binding_id="missing-binding-authority",
+            token_store=store,
+            oauth_client=_client(_Provider()),
+        )
 
 
 def test_missing_client_credentials_fail_loud(monkeypatch):

--- a/tests/knowledge_acquisition/test_youtube_oauth.py
+++ b/tests/knowledge_acquisition/test_youtube_oauth.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 import json
 import logging
 import secrets
+import subprocess
+import sys
 import threading
 from pathlib import Path
 from urllib.parse import parse_qs, urlsplit
@@ -580,10 +582,129 @@ def test_disconnect_and_reconnect_are_serialized_across_service_instances(
     assert disconnect_binder.status(binding_id)["status"] == "connected"
     lock_root = store.path.parent / f".{store.path.name}.locks"
     lock_files = tuple(lock_root.iterdir())
-    assert len(lock_files) == 1
-    assert binding_id not in lock_files[0].name
-    assert all(secret not in str(lock_files[0]) for secret in _ALL_SENTINELS)
-    assert lock_files[0].read_bytes() == b""
+    assert len(lock_files) >= 2
+    assert all(binding_id not in path.name for path in lock_files)
+    assert all(secret not in str(path) for path in lock_files for secret in _ALL_SENTINELS)
+    assert all(path.read_bytes() == b"\0" for path in lock_files)
+
+
+def test_distinct_binding_writes_serialize_across_store_instances(store, monkeypatch):
+    second = tokstore.YouTubeTokenStore(path=store.path)
+    first_inside_write = threading.Event()
+    release_first = threading.Event()
+    original_write = store._write_file
+
+    def paused_write(data):
+        first_inside_write.set()
+        assert release_first.wait(timeout=2)
+        original_write(data)
+
+    monkeypatch.setattr(store, "_write_file", paused_write)
+    token = tokstore.StoredToken(
+        refresh_token=SENTINEL_REFRESH,
+        access_token=SENTINEL_ACCESS,
+        expires_at=None,
+        scopes=(oauth.SCOPE,),
+        obtained_at="2026-01-01T00:00:00+00:00",
+        provider_channel_id=SYNTH_CHANNEL_ID,
+    )
+    first = threading.Thread(target=store.put, args=("binding-a", token))
+    second_done = threading.Event()
+    other = threading.Thread(
+        target=lambda: (second.put("binding-b", token), second_done.set())
+    )
+    first.start()
+    assert first_inside_write.wait(timeout=2)
+    other.start()
+    assert not second_done.wait(timeout=0.2)
+    release_first.set()
+    first.join(timeout=2)
+    other.join(timeout=2)
+    assert set(store.binding_ids()) == {"binding-a", "binding-b"}
+
+
+def test_concurrent_first_connects_re_resolve_identity_under_shared_authority(
+    store, bindings, registry, monkeypatch
+):
+    first_provider = _Provider()
+    second_provider = _Provider()
+    first_binder = _binder(first_provider, store, bindings, registry)
+    second_store = tokstore.YouTubeTokenStore(path=store.path)
+    second_binder = _binder(second_provider, second_store, bindings, registry)
+    first_connection = first_binder.start_device_connection()
+    second_connection = second_binder.start_device_connection()
+    first_inside = threading.Event()
+    release_first = threading.Event()
+    original_commit = first_binder._commit_binding
+
+    def paused_commit(*args, **kwargs):
+        first_inside.set()
+        assert release_first.wait(timeout=2)
+        return original_commit(*args, **kwargs)
+
+    monkeypatch.setattr(first_binder, "_commit_binding", paused_commit)
+    results: list[dict] = []
+    first = threading.Thread(
+        target=lambda: results.append(first_binder.finish_device_connection(first_connection))
+    )
+    second_done = threading.Event()
+
+    def connect_second():
+        results.append(second_binder.finish_device_connection(second_connection))
+        second_done.set()
+
+    second = threading.Thread(target=connect_second)
+    first.start()
+    assert first_inside.wait(timeout=2)
+    second.start()
+    assert not second_done.wait(timeout=0.2)
+    release_first.set()
+    first.join(timeout=2)
+    second.join(timeout=2)
+    binding_ids = {result["account"]["binding_id"] for result in results}
+    assert len(binding_ids) == 1
+    binding_id = binding_ids.pop()
+    assert store.has_record(binding_id)
+    assert bindings.get(binding_id).state == "connected"
+
+
+def test_distinct_binding_writes_serialize_across_processes(store, tmp_path):
+    release = tmp_path / "release"
+    script = """
+import os, sys, time
+from app.knowledge_acquisition.youtube_token_store import StoredToken, YouTubeTokenStore
+os.environ['YOUTUBE_TOKEN_STORE_KEY'] = sys.argv[3]
+while not os.path.exists(sys.argv[4]): time.sleep(0.01)
+YouTubeTokenStore(sys.argv[1]).put(sys.argv[2], StoredToken('refresh', 'access', None, ('scope',), '2026-01-01T00:00:00+00:00', 'channel'))
+"""
+    processes = [
+        subprocess.Popen(
+            [sys.executable, "-c", script, str(store.path), binding, TEST_STORE_KEY, str(release)],
+            cwd=Path.cwd(),
+        )
+        for binding in ("process-a", "process-b")
+    ]
+    release.touch()
+    for process in processes:
+        assert process.wait(timeout=10) == 0
+    assert set(store.binding_ids()) == {"process-a", "process-b"}
+
+
+def test_portable_lock_uses_windows_backend_when_fcntl_unavailable(store, monkeypatch):
+    calls: list[tuple[int, int]] = []
+
+    class FakeMsvcrt:
+        LK_LOCK = 1
+        LK_UNLCK = 2
+
+        @staticmethod
+        def locking(_descriptor, mode, size):
+            calls.append((mode, size))
+
+    monkeypatch.setattr(tokstore, "_fcntl", None)
+    monkeypatch.setattr(tokstore, "_msvcrt", FakeMsvcrt)
+    assert store.has_record("missing") is False
+    assert calls == [(FakeMsvcrt.LK_LOCK, 1), (FakeMsvcrt.LK_UNLCK, 1)]
 
 
 def test_disconnect_permanent_revoke_error_tears_down_local_state(

--- a/tests/knowledge_acquisition/test_youtube_oauth.py
+++ b/tests/knowledge_acquisition/test_youtube_oauth.py
@@ -188,13 +188,14 @@ def _binder(
     registry: sr.SourceRegistry,
     *,
     follow_redirects: bool = False,
+    identity_probe: oauth.IdentityProbe = _identity_probe,
 ) -> oauth.YouTubeAccountBinder:
     return oauth.YouTubeAccountBinder(
         oauth_client=_client(provider, follow_redirects=follow_redirects),
         token_store=store,
         binding_store=bindings,
         source_registry=registry,
-        identity_probe=_identity_probe,
+        identity_probe=identity_probe,
     )
 
 
@@ -318,6 +319,242 @@ def test_connect_token_store_failure_does_not_create_connected_binding(
 
     assert bindings.list_all() == ()
     assert store.binding_ids() == ()
+    assert not any(urlsplit(str(r.url)).path.endswith("/token") for r in provider.requests)
+
+
+def test_connect_store_io_preflight_fails_before_provider_poll(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+
+    def fail_readiness():
+        raise OSError("synthetic token-store readiness failure")
+
+    monkeypatch.setattr(store, "preflight_write_ready", fail_readiness)
+
+    with pytest.raises(OSError, match="synthetic token-store readiness failure"):
+        _connect_device(binder)
+
+    assert not any(urlsplit(str(r.url)).path.endswith("/token") for r in provider.requests)
+    assert provider.revoked == []
+    assert bindings.list_all() == ()
+
+
+def test_identity_probe_failure_is_provider_compensated_without_secret_leak(
+    store, bindings, registry
+):
+    provider = _Provider()
+
+    def fail_identity(_access_token):
+        raise RuntimeError(SENTINEL_ACCESS)
+
+    binder = _binder(
+        provider,
+        store,
+        bindings,
+        registry,
+        identity_probe=fail_identity,
+    )
+
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
+        _connect_device(binder)
+
+    assert excinfo.value.reason_code == "grant_compensated"
+    assert excinfo.value.pending_grant_id is None
+    assert provider.revoked == [{"token": SENTINEL_REFRESH}]
+    assert store.binding_ids() == ()
+    assert bindings.list_all() == ()
+    rendered = repr(excinfo.value) + str(excinfo.value)
+    assert SENTINEL_ACCESS not in rendered
+    assert SENTINEL_REFRESH not in rendered
+
+
+def test_incomplete_grant_with_refresh_token_is_compensated_not_discarded(
+    store, bindings, registry
+):
+    provider = _Provider()
+    provider.token_responses.append(
+        httpx.Response(
+            200,
+            json={
+                "refresh_token": SENTINEL_REFRESH,
+                "expires_in": 3600,
+                "scope": oauth.SCOPE,
+                "token_type": "Bearer",
+            },
+        )
+    )
+    binder = _binder(provider, store, bindings, registry)
+
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
+        _connect_device(binder)
+
+    assert excinfo.value.reason_code == "grant_compensated"
+    assert provider.revoked == [{"token": SENTINEL_REFRESH}]
+    assert store.binding_ids() == ()
+    assert bindings.list_all() == ()
+    assert SENTINEL_REFRESH not in (repr(excinfo.value) + str(excinfo.value))
+
+
+def test_identity_probe_and_compensation_failure_preserve_encrypted_pending_authority(
+    store, bindings, registry, tmp_path
+):
+    provider = _Provider()
+    provider.revoke_responses.append(
+        httpx.Response(
+            503,
+            json={"error": "temporarily_unavailable", "error_description": SENTINEL_ACCESS},
+        )
+    )
+
+    def fail_identity(_access_token):
+        raise RuntimeError(SENTINEL_REFRESH)
+
+    binder = _binder(
+        provider,
+        store,
+        bindings,
+        registry,
+        identity_probe=fail_identity,
+    )
+
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
+        _connect_device(binder)
+
+    assert excinfo.value.reason_code == "grant_pending"
+    pending_id = excinfo.value.pending_grant_id
+    assert pending_id is not None
+    assert store.binding_ids() == (pending_id,)
+    assert store.get(pending_id).refresh_token == SENTINEL_REFRESH
+    assert bindings.list_all() == ()
+    raw = (tmp_path / "youtube_token_store.enc").read_bytes()
+    assert SENTINEL_REFRESH.encode() not in raw
+    assert SENTINEL_ACCESS.encode() not in raw
+    rendered = repr(excinfo.value) + str(excinfo.value)
+    assert SENTINEL_REFRESH not in rendered
+    assert SENTINEL_ACCESS not in rendered
+
+    retried = binder.retry_pending_grant_compensation(pending_id)
+    assert retried == {"status": "compensated", "pending_grant_id": pending_id}
+    assert store.binding_ids() == ()
+
+
+def test_pending_journal_write_failure_is_provider_compensated(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+
+    def fail_pending_write(_binding_id, _token):
+        raise OSError("synthetic pending journal write failure")
+
+    monkeypatch.setattr(store, "put", fail_pending_write)
+
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
+        _connect_device(binder)
+
+    assert excinfo.value.reason_code == "grant_compensated"
+    assert provider.revoked == [{"token": SENTINEL_REFRESH}]
+    assert store.binding_ids() == ()
+    assert bindings.list_all() == ()
+
+
+def test_pending_write_and_compensation_failure_retry_preserves_authority(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    provider.revoke_responses.append(
+        httpx.Response(503, json={"error": "temporarily_unavailable"})
+    )
+    binder = _binder(provider, store, bindings, registry)
+    original_put = store.put
+    writes = 0
+
+    def fail_first_pending_write(binding_id, token):
+        nonlocal writes
+        writes += 1
+        if writes == 1:
+            raise OSError("synthetic first pending write failure")
+        original_put(binding_id, token)
+
+    monkeypatch.setattr(store, "put", fail_first_pending_write)
+
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
+        _connect_device(binder)
+
+    assert excinfo.value.reason_code == "grant_pending"
+    pending_id = excinfo.value.pending_grant_id
+    assert pending_id is not None
+    assert writes == 2
+    assert store.get(pending_id).refresh_token == SENTINEL_REFRESH
+    assert bindings.list_all() == ()
+
+
+def test_binding_store_write_failure_leaves_pending_grant_recoverable(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    original_put = store.put
+    writes: list[str] = []
+
+    def fail_canonical_write(binding_id, token):
+        writes.append(binding_id)
+        if len(writes) == 2:
+            raise OSError(SENTINEL_REFRESH)
+        original_put(binding_id, token)
+
+    monkeypatch.setattr(store, "put", fail_canonical_write)
+
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
+        _connect_device(binder)
+
+    assert excinfo.value.reason_code == "grant_pending"
+    assert len(writes) == 2
+    pending_id = excinfo.value.pending_grant_id
+    assert pending_id == writes[0]
+    assert pending_id.startswith("pending-youtube-grant-")
+    assert store.binding_ids() == (pending_id,)
+    assert store.get(pending_id).refresh_token == SENTINEL_REFRESH
+    assert bindings.list_all() == ()
+    assert SENTINEL_REFRESH not in (repr(excinfo.value) + str(excinfo.value))
+
+
+def test_reconnect_write_failure_does_not_mistake_old_token_for_new_grant_durability(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    provider.token_responses.append(
+        _granted_token(access=SENTINEL_ACCESS_2, refresh=SENTINEL_REFRESH_2)
+    )
+    reconnect = binder.start_reconnect(binding_id)
+    original_put = store.put
+    writes: list[str] = []
+
+    def fail_reconnect_canonical_write(target_id, token):
+        writes.append(target_id)
+        if len(writes) == 2:
+            raise OSError(SENTINEL_REFRESH_2)
+        original_put(target_id, token)
+
+    monkeypatch.setattr(store, "put", fail_reconnect_canonical_write)
+
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
+        binder.finish_device_connection(reconnect)
+
+    assert excinfo.value.reason_code == "grant_pending"
+    pending_id = excinfo.value.pending_grant_id
+    assert pending_id == writes[0]
+    assert pending_id.startswith("pending-youtube-grant-")
+    assert writes[1] == binding_id
+    assert set(store.binding_ids()) == {binding_id, pending_id}
+    assert store.get(binding_id).refresh_token == SENTINEL_REFRESH
+    assert store.get(pending_id).refresh_token == SENTINEL_REFRESH_2
+    assert SENTINEL_REFRESH_2 not in (repr(excinfo.value) + str(excinfo.value))
 
 
 def test_connect_post_commit_exception_reconciles_without_deleting_token(

--- a/tests/knowledge_acquisition/test_youtube_oauth.py
+++ b/tests/knowledge_acquisition/test_youtube_oauth.py
@@ -138,8 +138,11 @@ def _invalid_grant() -> httpx.Response:
     return httpx.Response(400, json={"error": "invalid_grant", "error_description": "Token has been revoked."})
 
 
-def _client(provider: _Provider) -> oauth.OAuthClient:
-    http = httpx.Client(transport=httpx.MockTransport(provider.handler))
+def _client(provider: _Provider, *, follow_redirects: bool = False) -> oauth.OAuthClient:
+    http = httpx.Client(
+        transport=httpx.MockTransport(provider.handler),
+        follow_redirects=follow_redirects,
+    )
     return oauth.OAuthClient(client_id=TEST_CLIENT_ID, client_secret=SENTINEL_CLIENT_SECRET, http=http)
 
 
@@ -183,9 +186,11 @@ def _binder(
     store: tokstore.YouTubeTokenStore,
     bindings: yab.AccountBindingStore,
     registry: sr.SourceRegistry,
+    *,
+    follow_redirects: bool = False,
 ) -> oauth.YouTubeAccountBinder:
     return oauth.YouTubeAccountBinder(
-        oauth_client=_client(provider),
+        oauth_client=_client(provider, follow_redirects=follow_redirects),
         token_store=store,
         binding_store=bindings,
         source_registry=registry,
@@ -346,7 +351,7 @@ def test_connect_post_commit_exception_reconciles_without_deleting_token(
     assert store.binding_ids() == (binding_id,)
 
 
-def test_connect_precommit_binding_failure_compensates_after_authoritative_absence(
+def test_connect_precommit_binding_failure_preserves_deterministic_retry_authority(
     store, bindings, registry, monkeypatch
 ):
     binder = _binder(_Provider(), store, bindings, registry)
@@ -360,7 +365,67 @@ def test_connect_precommit_binding_failure_compensates_after_authoritative_absen
         _connect_device(binder)
 
     assert bindings.list_all() == ()
-    assert store.binding_ids() == ()
+    first_candidate_ids = store.binding_ids()
+    assert len(first_candidate_ids) == 1
+    assert store.get(first_candidate_ids[0]).refresh_token == SENTINEL_REFRESH
+
+    # Another failed attempt targets the same idempotency key rather than
+    # accumulating uncorrelated credential records.
+    with pytest.raises(RuntimeError, match="synthetic pre-insert failure"):
+        _connect_device(binder)
+    assert store.binding_ids() == first_candidate_ids
+
+
+def test_connect_delayed_commit_after_negative_readbacks_preserves_and_converges(
+    store, bindings, registry, monkeypatch
+):
+    binder = _binder(_Provider(), store, bindings, registry)
+    original_create = bindings.create
+    original_get = bindings.get
+    original_get_by_channel_id = bindings.get_by_channel_id
+    create_kwargs: dict[str, object] = {}
+    readbacks: list[str] = []
+
+    def lose_ack_before_delayed_commit(**kwargs):
+        create_kwargs.update(kwargs)
+        raise RuntimeError("synthetic delayed insert acknowledgement")
+
+    def negative_exact_readback(_binding_id):
+        readbacks.append("exact")
+        return None
+
+    def negative_channel_readback(_channel_id):
+        if not create_kwargs:
+            # Initial identity resolution happens before create is attempted.
+            return None
+        readbacks.append("channel")
+        # The insert becomes visible only after both negative snapshots. This
+        # is precisely why absence at either read is not temporal proof.
+        original_create(**create_kwargs)
+        return None
+
+    monkeypatch.setattr(bindings, "create", lose_ack_before_delayed_commit)
+    monkeypatch.setattr(bindings, "get", negative_exact_readback)
+    monkeypatch.setattr(bindings, "get_by_channel_id", negative_channel_readback)
+
+    with pytest.raises(RuntimeError, match="synthetic delayed insert acknowledgement"):
+        _connect_device(binder)
+
+    assert readbacks == ["exact", "channel"]
+    candidate_id = str(create_kwargs["account_binding_id"])
+    assert store.binding_ids() == (candidate_id,)
+    assert store.get(candidate_id).refresh_token == SENTINEL_REFRESH
+
+    monkeypatch.setattr(bindings, "create", original_create)
+    monkeypatch.setattr(bindings, "get", original_get)
+    monkeypatch.setattr(bindings, "get_by_channel_id", original_get_by_channel_id)
+
+    # Retry resolves the delayed row, retains its deterministic id, and does
+    # not create a second binding or credential record.
+    retried = _connect_device(binder)
+    assert retried["account"]["binding_id"] == candidate_id
+    assert [row.account_binding_id for row in bindings.list_all()] == [candidate_id]
+    assert store.binding_ids() == (candidate_id,)
 
 
 def test_connect_indeterminate_create_readback_preserves_token(
@@ -589,7 +654,10 @@ def test_disconnect_preserves_token_when_provider_revoke_fails(store, bindings, 
     assert registry.get(source.binding_id).enabled is False
 
 
-@pytest.mark.parametrize("status", [0, 100, 199, 300, 302, 399, 408, 429, 500, 599, 600])
+@pytest.mark.parametrize(
+    "status",
+    [0, 100, 199, 300, 302, 399, 400, 401, 403, 404, 407, 408, 409, 429, 499, 500, 599, 600],
+)
 def test_disconnect_indeterminate_revoke_status_preserves_retry_authority(
     store, bindings, registry, monkeypatch, status
 ):
@@ -811,9 +879,8 @@ def test_portable_lock_uses_windows_backend_when_fcntl_unavailable(store, monkey
     assert calls == [(FakeMsvcrt.LK_LOCK, 1), (FakeMsvcrt.LK_UNLCK, 1)]
 
 
-@pytest.mark.parametrize("status", [400, 407, 409, 499])
-def test_disconnect_permanent_revoke_error_tears_down_local_state(
-    store, bindings, registry, status
+def test_disconnect_documented_invalid_token_tears_down_local_state(
+    store, bindings, registry
 ):
     provider = _Provider()
     binder = _binder(provider, store, bindings, registry)
@@ -827,7 +894,7 @@ def test_disconnect_permanent_revoke_error_tears_down_local_state(
     )
     provider.revoke_responses.append(
         httpx.Response(
-            status,
+            400,
             json={"error": "invalid_token", "error_description": SENTINEL_REFRESH},
         )
     )
@@ -840,6 +907,45 @@ def test_disconnect_permanent_revoke_error_tears_down_local_state(
     assert bindings.get(binding_id).reason_code == "auth_disconnected"
     assert registry.get(source.binding_id).enabled is False
     assert SENTINEL_REFRESH not in json.dumps(disc)
+
+
+@pytest.mark.parametrize(
+    ("status", "error_code"),
+    [
+        (400, "invalid_request"),
+        (400, "unsupported_token_type"),
+        (400, SENTINEL_REFRESH),
+        (407, "invalid_token"),
+        (409, "invalid_token"),
+        (499, "invalid_token"),
+    ],
+)
+def test_disconnect_unproven_4xx_outcome_preserves_retry_authority(
+    store, bindings, registry, status, error_code
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    provider.revoke_responses.append(
+        httpx.Response(
+            status,
+            json={"error": error_code, "error_description": SENTINEL_ACCESS},
+        )
+    )
+
+    disc = binder.disconnect(binding_id)
+
+    assert disc == {
+        "status": "disconnect_failed",
+        "revoked": False,
+        "retryable": True,
+        "sources_disabled": 0,
+    }
+    assert store.get(binding_id).refresh_token == SENTINEL_REFRESH
+    assert bindings.get(binding_id).state == "connected"
+    assert SENTINEL_REFRESH not in json.dumps(disc)
+    assert SENTINEL_ACCESS not in json.dumps(disc)
 
 
 # --- AC7 --------------------------------------------------------------------
@@ -888,6 +994,59 @@ def test_oauth_client_refuses_off_allowlist_host():
     client = oauth.OAuthClient(client_id=TEST_CLIENT_ID, client_secret=SENTINEL_CLIENT_SECRET, http=http)
     with pytest.raises(oauth.DisallowedOAuthHostError):
         client._post("https://evil.example.com/token", {"grant_type": "refresh_token"})
+
+
+@pytest.mark.parametrize("status", [302, 307])
+def test_disconnect_redirect_never_replays_token_and_preserves_retry_authority(
+    store, bindings, registry, status
+):
+    provider = _Provider()
+    # The injected client is deliberately redirect-enabled. The OAuth call
+    # site must override that ambient policy for every credential-bearing POST.
+    binder = _binder(
+        provider,
+        store,
+        bindings,
+        registry,
+        follow_redirects=True,
+    )
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    request_count_before_revoke = len(provider.requests)
+    provider.revoke_responses.append(
+        httpx.Response(
+            status,
+            headers={"Location": "https://off-allowlist.example/collect"},
+        )
+    )
+
+    disc = binder.disconnect(binding_id)
+
+    revoke_requests = provider.requests[request_count_before_revoke:]
+    assert len(revoke_requests) == 1
+    assert urlsplit(str(revoke_requests[0].url)).hostname == "oauth2.googleapis.com"
+    assert disc["status"] == "disconnect_failed"
+    assert disc["retryable"] is True
+    assert store.get(binding_id).refresh_token == SENTINEL_REFRESH
+
+
+def test_provider_error_enum_is_allowlisted_before_exception_rendering():
+    provider = _Provider()
+    provider.token_responses.append(
+        httpx.Response(
+            400,
+            json={"error": SENTINEL_REFRESH, "error_description": SENTINEL_ACCESS},
+        )
+    )
+
+    with pytest.raises(oauth.OAuthProviderError) as excinfo:
+        _client(provider).refresh(SENTINEL_REFRESH_2)
+
+    assert excinfo.value.error_code is None
+    rendered = repr(excinfo.value) + str(excinfo.value)
+    assert SENTINEL_REFRESH not in rendered
+    assert SENTINEL_ACCESS not in rendered
+    assert SENTINEL_REFRESH_2 not in rendered
 
 
 def test_missing_client_credentials_fail_loud(monkeypatch):

--- a/tests/knowledge_acquisition/test_youtube_oauth.py
+++ b/tests/knowledge_acquisition/test_youtube_oauth.py
@@ -285,6 +285,50 @@ def test_loopback_flow_rejects_tampered_state(store, bindings, registry):
     assert body["grant_type"] == "authorization_code"
 
 
+@pytest.mark.parametrize(
+    "redirect_uri",
+    [
+        "https://127.0.0.1:8765/callback",
+        "http://localhost:8765/callback",
+        "http://127.0.0.1/callback",
+        "http://127.0.0.1:0/callback",
+        "http://user@127.0.0.1:8765/callback",
+        "http://127.0.0.1:8765/callback?code=secret",
+        "http://127.0.0.1:8765/callback#fragment",
+    ],
+)
+def test_loopback_flow_rejects_non_exact_loopback_redirect_uri(redirect_uri):
+    provider = _Provider()
+
+    with pytest.raises(oauth.InvalidLoopbackRedirectURIError) as excinfo:
+        oauth.start_loopback_flow(_client(provider), redirect_uri=redirect_uri)
+
+    assert redirect_uri not in str(excinfo.value)
+    assert provider.requests == []
+
+
+def test_loopback_completion_revalidates_redirect_uri_before_code_exchange():
+    provider = _Provider()
+    client = _client(provider)
+    flow = oauth.start_loopback_flow(
+        client, redirect_uri="http://127.0.0.1:8765/callback"
+    )
+    forged = replace(flow, redirect_uri="https://evil.example/callback")
+
+    with pytest.raises(oauth.InvalidLoopbackRedirectURIError):
+        oauth.complete_loopback_flow(
+            client,
+            forged,
+            returned_state=forged.state,
+            returned_code="auth-code-xyz",
+        )
+
+    assert not any(
+        urlsplit(str(request.url)).path.endswith("/token")
+        for request in provider.requests
+    )
+
+
 # --- AC3 --------------------------------------------------------------------
 
 
@@ -544,17 +588,29 @@ def test_pending_parent_directory_fsync_lost_ack_keeps_retry_authority(
 ):
     provider = _Provider()
     binder = _binder(provider, store, bindings, registry)
+    opened_paths: dict[int, Path] = {}
+    original_open = tokstore.os.open
     original_fsync = tokstore.os.fsync
     directory_fsyncs = 0
+    store_parent = store.path.parent.resolve()
+
+    def record_open(path, flags, *args, **kwargs):
+        descriptor = original_open(path, flags, *args, **kwargs)
+        opened_paths[descriptor] = Path(path).resolve()
+        return descriptor
 
     def lose_second_directory_fsync_ack(descriptor):
         nonlocal directory_fsyncs
-        if stat.S_ISDIR(tokstore.os.fstat(descriptor).st_mode):
+        if (
+            stat.S_ISDIR(tokstore.os.fstat(descriptor).st_mode)
+            and opened_paths[descriptor] == store_parent
+        ):
             directory_fsyncs += 1
             if directory_fsyncs == 2:
                 raise OSError(SENTINEL_REFRESH)
         original_fsync(descriptor)
 
+    monkeypatch.setattr(tokstore.os, "open", record_open)
     monkeypatch.setattr(tokstore.os, "fsync", lose_second_directory_fsync_ack)
 
     with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
@@ -574,22 +630,116 @@ def test_pending_parent_directory_fsync_lost_ack_keeps_retry_authority(
     _assert_no_exception_chain(excinfo.value)
 
 
+def test_first_connect_fsyncs_complete_fresh_parent_chain_before_token_poll(
+    tmp_path, bindings, registry, monkeypatch
+):
+    store = tokstore.YouTubeTokenStore(
+        path=tmp_path / "fresh" / "nested" / "channel" / "youtube_token_store.enc"
+    )
+    provider = _Provider()
+    opened_paths: dict[int, Path] = {}
+    synced_directories: list[Path] = []
+    original_open = tokstore.os.open
+    original_fsync = tokstore.os.fsync
+    required = {
+        store.path.parent.resolve(),
+        store.path.parent.parent.resolve(),
+        store.path.parent.parent.parent.resolve(),
+    }
+
+    def record_open(path, flags, *args, **kwargs):
+        descriptor = original_open(path, flags, *args, **kwargs)
+        opened_paths[descriptor] = Path(path).resolve()
+        return descriptor
+
+    def record_fsync(descriptor):
+        if stat.S_ISDIR(tokstore.os.fstat(descriptor).st_mode):
+            synced_directories.append(opened_paths[descriptor])
+        original_fsync(descriptor)
+
+    original_handler = provider.handler
+
+    def require_full_barrier_before_grant(request):
+        if urlsplit(str(request.url)).path.endswith("/token"):
+            assert required.issubset(set(synced_directories))
+        return original_handler(request)
+
+    monkeypatch.setattr(tokstore.os, "open", record_open)
+    monkeypatch.setattr(tokstore.os, "fsync", record_fsync)
+    provider.handler = require_full_barrier_before_grant
+
+    result = _connect_device(_binder(provider, store, bindings, registry))
+
+    assert result["status"] == "connected"
+    assert required.issubset(set(synced_directories))
+
+
+def test_first_connect_parent_chain_barrier_failure_prevents_provider_grant(
+    tmp_path, bindings, registry, monkeypatch
+):
+    store = tokstore.YouTubeTokenStore(
+        path=tmp_path / "fresh" / "nested" / "channel" / "youtube_token_store.enc"
+    )
+    provider = _Provider()
+    opened_paths: dict[int, Path] = {}
+    original_open = tokstore.os.open
+    original_fsync = tokstore.os.fsync
+    failed_ancestor = store.path.parent.parent.resolve()
+
+    def record_open(path, flags, *args, **kwargs):
+        descriptor = original_open(path, flags, *args, **kwargs)
+        opened_paths[descriptor] = Path(path).resolve()
+        return descriptor
+
+    def fail_ancestor_barrier(descriptor):
+        if (
+            stat.S_ISDIR(tokstore.os.fstat(descriptor).st_mode)
+            and opened_paths[descriptor] == failed_ancestor
+        ):
+            raise OSError("synthetic ancestor barrier failure")
+        original_fsync(descriptor)
+
+    monkeypatch.setattr(tokstore.os, "open", record_open)
+    monkeypatch.setattr(tokstore.os, "fsync", fail_ancestor_barrier)
+
+    with pytest.raises(tokstore.TokenStoreDurabilityError):
+        _connect_device(_binder(provider, store, bindings, registry))
+
+    assert not any(
+        urlsplit(str(request.url)).path.endswith("/token")
+        for request in provider.requests
+    )
+    assert bindings.list_all() == ()
+
+
 def test_repeated_pending_directory_fsync_failure_compensates_visible_record(
     store, bindings, registry, monkeypatch
 ):
     provider = _Provider()
     binder = _binder(provider, store, bindings, registry)
+    opened_paths: dict[int, Path] = {}
+    original_open = tokstore.os.open
     original_fsync = tokstore.os.fsync
     directory_fsyncs = 0
+    store_parent = store.path.parent.resolve()
+
+    def record_open(path, flags, *args, **kwargs):
+        descriptor = original_open(path, flags, *args, **kwargs)
+        opened_paths[descriptor] = Path(path).resolve()
+        return descriptor
 
     def fail_pending_directory_barriers(descriptor):
         nonlocal directory_fsyncs
-        if stat.S_ISDIR(tokstore.os.fstat(descriptor).st_mode):
+        if (
+            stat.S_ISDIR(tokstore.os.fstat(descriptor).st_mode)
+            and opened_paths[descriptor] == store_parent
+        ):
             directory_fsyncs += 1
             if directory_fsyncs >= 2:
                 raise OSError(SENTINEL_REFRESH)
         original_fsync(descriptor)
 
+    monkeypatch.setattr(tokstore.os, "open", record_open)
     monkeypatch.setattr(tokstore.os, "fsync", fail_pending_directory_barriers)
 
     with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
@@ -817,17 +967,29 @@ def test_reconnect_canonical_directory_barrier_recovery_preserves_pending_handle
     )
     reconnect = binder.start_reconnect(binding_id)
     pending_id = oauth._pending_grant_id(reconnect.handle.device_code, binding_id)
+    opened_paths: dict[int, Path] = {}
+    original_open = tokstore.os.open
     original_fsync = tokstore.os.fsync
     directory_fsyncs = 0
+    store_parent = store.path.parent.resolve()
+
+    def record_open(path, flags, *args, **kwargs):
+        descriptor = original_open(path, flags, *args, **kwargs)
+        opened_paths[descriptor] = Path(path).resolve()
+        return descriptor
 
     def fail_canonical_barrier_and_first_confirmation(descriptor):
         nonlocal directory_fsyncs
-        if stat.S_ISDIR(tokstore.os.fstat(descriptor).st_mode):
+        if (
+            stat.S_ISDIR(tokstore.os.fstat(descriptor).st_mode)
+            and opened_paths[descriptor] == store_parent
+        ):
             directory_fsyncs += 1
             if directory_fsyncs in {5, 6}:
                 raise OSError(SENTINEL_REFRESH_2)
         original_fsync(descriptor)
 
+    monkeypatch.setattr(tokstore.os, "open", record_open)
     monkeypatch.setattr(
         tokstore.os, "fsync", fail_canonical_barrier_and_first_confirmation
     )
@@ -835,7 +997,7 @@ def test_reconnect_canonical_directory_barrier_recovery_preserves_pending_handle
     with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
         binder.finish_device_connection(reconnect)
 
-    assert directory_fsyncs == 7
+    assert directory_fsyncs == 6
     assert excinfo.value.reason_code == "grant_pending"
     assert excinfo.value.pending_grant_id == pending_id
     assert set(store.binding_ids()) == {binding_id, pending_id}
@@ -974,6 +1136,51 @@ def test_connect_post_commit_exception_reconciles_without_deleting_token(
     assert second["account"]["binding_id"] == binding_id
     assert len(bindings.list_all()) == 1
     assert store.binding_ids() == (binding_id,)
+
+
+def test_reconnect_postcanonical_state_failure_preserves_pending_until_state_converges(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    bindings.set_state(binding_id, state="degraded", reason_code="auth_expired")
+    reconnect = binder.start_reconnect(binding_id)
+    provider.token_responses.append(
+        _granted_token(access=SENTINEL_ACCESS_2, refresh=SENTINEL_REFRESH_2)
+    )
+    original_set_state = bindings.set_state
+    failed_once = False
+
+    def fail_connected_state_once(target_binding_id, *, state, reason_code):
+        nonlocal failed_once
+        if state == "connected" and not failed_once:
+            failed_once = True
+            raise RuntimeError("synthetic binding-state persistence failure")
+        return original_set_state(
+            target_binding_id, state=state, reason_code=reason_code
+        )
+
+    monkeypatch.setattr(bindings, "set_state", fail_connected_state_once)
+
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
+        binder.finish_device_connection(reconnect)
+
+    pending_id = excinfo.value.pending_grant_id
+    assert excinfo.value.reason_code == "grant_pending"
+    assert pending_id is not None
+    assert store.get(binding_id).refresh_token == SENTINEL_REFRESH_2
+    assert store.get(pending_id).refresh_token == SENTINEL_REFRESH_2
+    assert bindings.get(binding_id).state == "degraded"
+    _assert_no_exception_chain(excinfo.value)
+
+    recovered = binder.retry_pending_grant_compensation(pending_id)
+
+    assert recovered["status"] == "canonical"
+    assert bindings.get(binding_id).state == "connected"
+    assert bindings.get(binding_id).reason_code is None
+    assert store.get(pending_id) is None
 
 
 def test_connect_precommit_binding_failure_preserves_deterministic_retry_authority(
@@ -1688,6 +1895,13 @@ def test_reconnect_stops_before_token_poll_on_conflicting_refresh_generation(
     )
     store.put(binding_id, canonical)
     store.put(pending_id, pending)
+    source = registry.register(
+        collection_kind="owned_playlist",
+        collection_ref=SYNTH_PLAYLIST_REF,
+        title="Owned",
+        account_binding_id=binding_id,
+    )
+    cursor_before = dict(source.cursor)
     reconnect = binder.start_reconnect(binding_id)
     token_calls_before = sum(
         urlsplit(str(request.url)).path.endswith("/token")
@@ -1703,6 +1917,12 @@ def test_reconnect_stops_before_token_poll_on_conflicting_refresh_generation(
     assert store.get(binding_id) == canonical
     assert store.get(pending_id) == pending
     assert provider.revoked == []
+    assert bindings.get(binding_id).state == "degraded"
+    assert bindings.get(binding_id).reason_code == "auth_refresh_conflict"
+    degraded_source = registry.get(source.binding_id)
+    assert degraded_source.last_error["reason_code"] == "auth_refresh_conflict"
+    assert degraded_source.cursor == cursor_before
+    assert degraded_source.enabled is True
     assert (
         sum(
             urlsplit(str(request.url)).path.endswith("/token")
@@ -1710,6 +1930,65 @@ def test_reconnect_stops_before_token_poll_on_conflicting_refresh_generation(
         )
         == token_calls_before
     )
+
+
+def test_disconnect_pending_refresh_outcome_degrades_without_cursor_or_artifact_mutation(
+    store, bindings, registry
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    canonical = store.get(binding_id)
+    source = registry.register(
+        collection_kind="owned_playlist",
+        collection_ref=SYNTH_PLAYLIST_REF,
+        title="Owned",
+        account_binding_id=binding_id,
+    )
+    cursor_before = dict(source.cursor)
+    pending_id = oauth._pending_refresh_id(binding_id)
+    pending = replace(
+        canonical,
+        refresh_token=SENTINEL_REFRESH_2,
+        access_token=SENTINEL_ACCESS_2,
+        authority_generation=canonical.authority_generation + 1,
+        promotion_target_binding_id=binding_id,
+        promotion_predecessor_refresh_token="different-predecessor",
+        promotion_predecessor_generation=canonical.authority_generation,
+    )
+    store.put(pending_id, pending)
+
+    result = binder.disconnect(binding_id)
+
+    assert result["status"] == "disconnect_failed"
+    assert result["reason_code"] == "auth_refresh_conflict"
+    assert result["sources_disabled"] == 0
+    assert provider.revoked == []
+    assert store.get(binding_id) == canonical
+    assert store.get(pending_id) == pending
+    assert bindings.get(binding_id).state == "degraded"
+    assert bindings.get(binding_id).reason_code == "auth_refresh_conflict"
+    degraded_source = registry.get(source.binding_id)
+    assert degraded_source.enabled is True
+    assert degraded_source.cursor == cursor_before
+    assert degraded_source.last_error["reason_code"] == "auth_refresh_conflict"
+
+
+def test_refresh_degradation_reason_codes_are_registered_and_redacted():
+    assert {
+        "auth_refresh_pending",
+        "auth_refresh_conflict",
+        "auth_refresh_durability",
+    }.issubset(yab.VALID_BINDING_REASON_CODES)
+    for reason_code in (
+        "auth_refresh_pending",
+        "auth_refresh_conflict",
+        "auth_refresh_durability",
+    ):
+        assert oauth.redact({"reason_code": reason_code}) == {
+            "reason_code": reason_code
+        }
 
 
 def test_revoked_auth_degrades_without_cursor_mutation(store, bindings, registry):
@@ -2285,7 +2564,9 @@ def test_token_store_syncs_staged_file_before_replace_and_parent_after(
 
     store.put("b-durable", token)
 
-    assert events == ["fsync:file", "replace", "fsync:directory"]
+    assert events[:2] == ["fsync:file", "replace"]
+    assert events[2:]
+    assert set(events[2:]) == {"fsync:directory"}
     assert store.get("b-durable") == token
 
 

--- a/tests/knowledge_acquisition/test_youtube_oauth.py
+++ b/tests/knowledge_acquisition/test_youtube_oauth.py
@@ -2608,11 +2608,11 @@ def test_disconnect_preserves_token_when_provider_revoke_fails(store, bindings, 
     }
     assert store.has_record(binding_id) is True
     assert store.get(binding_id).refresh_token == SENTINEL_REFRESH
-    assert bindings.get(binding_id).state == "connected"
-    assert bindings.get(binding_id).reason_code is None
+    assert bindings.get(binding_id).state == "degraded"
+    assert bindings.get(binding_id).reason_code == "auth_disconnected"
     unchanged_source = registry.get(source.binding_id)
     assert unchanged_source.enabled is True
-    assert unchanged_source.last_error is None
+    assert unchanged_source.last_error["reason_code"] == "auth_disconnected"
 
     retried = binder.disconnect(binding_id)
     assert retried["status"] == "disconnected"
@@ -2652,9 +2652,11 @@ def test_disconnect_indeterminate_revoke_status_preserves_retry_authority(
         "sources_disabled": 0,
     }
     assert store.get(binding_id).refresh_token == SENTINEL_REFRESH
-    assert bindings.get(binding_id).state == "connected"
-    assert bindings.get(binding_id).reason_code is None
-    assert registry.get(source.binding_id).enabled is True
+    assert bindings.get(binding_id).state == "degraded"
+    assert bindings.get(binding_id).reason_code == "auth_disconnected"
+    unchanged_source = registry.get(source.binding_id)
+    assert unchanged_source.enabled is True
+    assert unchanged_source.last_error["reason_code"] == "auth_disconnected"
 
 
 def test_disconnect_and_reconnect_are_serialized_across_service_instances(
@@ -2940,7 +2942,8 @@ def test_disconnect_unproven_4xx_outcome_preserves_retry_authority(
         "sources_disabled": 0,
     }
     assert store.get(binding_id).refresh_token == SENTINEL_REFRESH
-    assert bindings.get(binding_id).state == "connected"
+    assert bindings.get(binding_id).state == "degraded"
+    assert bindings.get(binding_id).reason_code == "auth_disconnected"
     assert SENTINEL_REFRESH not in json.dumps(disc)
     assert SENTINEL_ACCESS not in json.dumps(disc)
 
@@ -3077,6 +3080,176 @@ def test_provider_error_enum_is_allowlisted_before_exception_rendering():
     assert SENTINEL_REFRESH not in rendered
     assert SENTINEL_ACCESS not in rendered
     assert SENTINEL_REFRESH_2 not in rendered
+
+
+def test_compensated_refresh_cleanup_keeps_repeated_consumers_fail_closed(
+    store, bindings, registry
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    canonical = store.get(binding_id)
+    assert canonical is not None
+    pending_id = oauth._pending_refresh_id(binding_id)
+    store.put(
+        pending_id,
+        replace(
+            canonical,
+            refresh_token=SENTINEL_REFRESH_2,
+            access_token=SENTINEL_ACCESS_2,
+            authority_generation=canonical.authority_generation + 1,
+            promotion_target_binding_id=binding_id,
+            promotion_predecessor_refresh_token=canonical.refresh_token,
+            promotion_predecessor_generation=canonical.authority_generation,
+            promotion_compensation_state="compensated",
+        ),
+    )
+    token_provider = oauth.TokenProvider(
+        binding_id=binding_id,
+        token_store=store,
+        oauth_client=_client(provider),
+        binding_store=bindings,
+        source_registry=registry,
+    )
+
+    with pytest.raises(oauth.AuthDegradedError) as first_error:
+        token_provider.get_access_token()
+    assert first_error.value.reason_code == "auth_revoked"
+    assert store.has_record(pending_id) is False
+    request_count = len(provider.requests)
+
+    with pytest.raises(oauth.AuthDegradedError) as repeated_error:
+        token_provider.get_access_token()
+    assert repeated_error.value.reason_code == "auth_revoked"
+    assert len(provider.requests) == request_count
+    assert bindings.get(binding_id).reason_code == "auth_revoked"
+
+
+def test_compensated_refresh_cleanup_persists_revoked_before_marker_removal(
+    store, bindings, registry, monkeypatch
+):
+    binder = _binder(_Provider(), store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    canonical = store.get(binding_id)
+    assert canonical is not None
+    pending_id = oauth._pending_refresh_id(binding_id)
+    store.put(
+        pending_id,
+        replace(
+            canonical,
+            refresh_token=SENTINEL_REFRESH_2,
+            access_token=SENTINEL_ACCESS_2,
+            authority_generation=canonical.authority_generation + 1,
+            promotion_target_binding_id=binding_id,
+            promotion_predecessor_refresh_token=canonical.refresh_token,
+            promotion_predecessor_generation=canonical.authority_generation,
+            promotion_compensation_state="compensated",
+        ),
+    )
+    original_delete = store.delete
+
+    def delete_then_lose_ack(target_id):
+        original_delete(target_id)
+        if target_id == pending_id:
+            raise OSError("synthetic cleanup acknowledgement loss")
+
+    monkeypatch.setattr(store, "delete", delete_then_lose_ack)
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
+        with store.binding_lifecycle_lock(binding_id):
+            binder._recover_pending_refresh_authority(binding_id)
+
+    assert excinfo.value.reason_code == "refresh_compensated"
+    assert store.has_record(pending_id) is False
+    assert bindings.get(binding_id).reason_code == "auth_revoked"
+
+
+def test_disconnect_crash_after_provider_revoke_keeps_cached_token_fail_closed(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    original_delete = store.delete
+
+    def crash_before_canonical_delete(target_id):
+        if target_id == binding_id:
+            raise RuntimeError("synthetic crash after provider revoke")
+        original_delete(target_id)
+
+    monkeypatch.setattr(store, "delete", crash_before_canonical_delete)
+    with pytest.raises(RuntimeError, match="synthetic crash"):
+        binder.disconnect(binding_id)
+
+    assert provider.revoked[-1] == {"token": SENTINEL_REFRESH}
+    assert store.get(binding_id).refresh_token == SENTINEL_REFRESH
+    assert bindings.get(binding_id).reason_code == "auth_disconnected"
+    consumer_provider = _Provider()
+    token_provider = oauth.TokenProvider(
+        binding_id=binding_id,
+        token_store=store,
+        oauth_client=_client(consumer_provider),
+        binding_store=bindings,
+        source_registry=registry,
+    )
+    with pytest.raises(oauth.AuthDegradedError) as excinfo:
+        token_provider.get_access_token()
+    assert excinfo.value.reason_code == "auth_disconnected"
+    assert consumer_provider.requests == []
+
+
+def test_disconnected_reconnect_postcanonical_failure_blocks_until_retry(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    bindings.set_state(
+        binding_id, state="degraded", reason_code="auth_disconnected"
+    )
+    reconnect = binder.start_reconnect(binding_id)
+    provider.token_responses.append(
+        _granted_token(access=SENTINEL_ACCESS_2, refresh=SENTINEL_REFRESH_2)
+    )
+    original_set_state = bindings.set_state
+    failed_once = False
+
+    def fail_connected_state_once(target_binding_id, *, state, reason_code):
+        nonlocal failed_once
+        if state == "connected" and not failed_once:
+            failed_once = True
+            raise RuntimeError("synthetic disconnected reconnect state failure")
+        return original_set_state(
+            target_binding_id, state=state, reason_code=reason_code
+        )
+
+    monkeypatch.setattr(bindings, "set_state", fail_connected_state_once)
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
+        binder.finish_device_connection(reconnect)
+
+    pending_id = excinfo.value.pending_grant_id
+    assert pending_id is not None
+    assert store.get(binding_id).refresh_token == SENTINEL_REFRESH_2
+    assert bindings.get(binding_id).reason_code == "auth_disconnected"
+    token_provider = oauth.TokenProvider(
+        binding_id=binding_id,
+        token_store=store,
+        oauth_client=_client(_Provider()),
+        binding_store=bindings,
+        source_registry=registry,
+    )
+    with pytest.raises(oauth.AuthDegradedError) as queued_error:
+        token_provider.get_access_token()
+    assert queued_error.value.reason_code == "auth_disconnected"
+
+    recovered = binder.retry_pending_grant_compensation(pending_id)
+    assert recovered["status"] == "canonical"
+    assert bindings.get(binding_id).state == "connected"
+    assert bindings.get(binding_id).reason_code is None
+    assert store.get(pending_id) is None
 
 
 def test_missing_client_credentials_fail_loud(monkeypatch):

--- a/tests/knowledge_acquisition/test_youtube_oauth.py
+++ b/tests/knowledge_acquisition/test_youtube_oauth.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import logging
 import secrets
+import threading
 from pathlib import Path
 from urllib.parse import parse_qs, urlsplit
 
@@ -35,6 +36,7 @@ SYNTH_PLAYLIST_REF = "PL__test__synthetic_playlist_00"
 # Planted secrets: if any of these ever surfaces in a log line, receipt,
 # exception, or --json payload, AC5 fails. They are deliberately distinctive.
 SENTINEL_REFRESH = "sentinel-REFRESH-must-never-leak-" + secrets.token_hex(8)
+SENTINEL_REFRESH_2 = "sentinel-REFRESH2-must-never-leak-" + secrets.token_hex(8)
 SENTINEL_ACCESS = "sentinel-ACCESS-must-never-leak-" + secrets.token_hex(8)
 SENTINEL_ACCESS_2 = "sentinel-ACCESS2-must-never-leak-" + secrets.token_hex(8)
 SENTINEL_CLIENT_SECRET = "sentinel-CLIENTSECRET-must-never-leak-" + secrets.token_hex(8)
@@ -46,6 +48,7 @@ TEST_STORE_KEY = secrets.token_hex(32)
 
 _ALL_SENTINELS = (
     SENTINEL_REFRESH,
+    SENTINEL_REFRESH_2,
     SENTINEL_ACCESS,
     SENTINEL_ACCESS_2,
     SENTINEL_CLIENT_SECRET,
@@ -67,6 +70,8 @@ class _Provider:
         self.token_responses: list[httpx.Response] = []
         self.revoke_responses: list[httpx.Response] = []
         self.revoked: list[dict[str, str]] = []
+        self.revoke_started = threading.Event()
+        self.revoke_release: threading.Event | None = None
         self.device_granted = True
 
     def _body(self, request: httpx.Request) -> dict[str, str]:
@@ -105,6 +110,9 @@ class _Provider:
             )
         if path.endswith("/revoke"):
             self.revoked.append(self._body(request))
+            self.revoke_started.set()
+            if self.revoke_release is not None:
+                self.revoke_release.wait(timeout=5)
             if self.revoke_responses:
                 return self.revoke_responses.pop(0)
             return httpx.Response(200, request=request, json={})
@@ -506,6 +514,106 @@ def test_disconnect_preserves_token_when_provider_revoke_fails(store, bindings, 
     assert retried["revoked"] is True
     assert store.has_record(binding_id) is False
     assert registry.get(source.binding_id).enabled is False
+
+
+def test_disconnect_and_reconnect_are_serialized_across_service_instances(
+    store, bindings, registry
+):
+    provider = _Provider()
+    disconnect_binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(disconnect_binder)
+    binding_id = connected["account"]["binding_id"]
+
+    # A second production-style service instance shares only durable stores,
+    # not the first binder/token-store object's in-process lock.
+    reconnect_store = tokstore.YouTubeTokenStore(path=store.path)
+    reconnect_binder = _binder(provider, reconnect_store, bindings, registry)
+    reconnect_connection = reconnect_binder.start_reconnect(binding_id)
+    provider.token_responses.append(
+        _granted_token(access=SENTINEL_ACCESS_2, refresh=SENTINEL_REFRESH_2)
+    )
+    provider.revoke_release = threading.Event()
+
+    results: dict[str, dict] = {}
+    errors: list[BaseException] = []
+    reconnect_done = threading.Event()
+
+    def run_disconnect() -> None:
+        try:
+            results["disconnect"] = disconnect_binder.disconnect(binding_id)
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    def run_reconnect() -> None:
+        try:
+            results["reconnect"] = reconnect_binder.finish_device_connection(
+                reconnect_connection
+            )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+        finally:
+            reconnect_done.set()
+
+    disconnect_thread = threading.Thread(target=run_disconnect)
+    reconnect_thread = threading.Thread(target=run_reconnect)
+    disconnect_thread.start()
+    assert provider.revoke_started.wait(timeout=2), "disconnect never reached provider revoke"
+
+    # Exact P1 interleaving: disconnect has read the old token and is paused in
+    # provider revoke while another binder attempts to persist a new grant.
+    reconnect_thread.start()
+    reconnect_was_serialized = not reconnect_done.wait(timeout=0.2)
+    provider.revoke_release.set()
+    disconnect_thread.join(timeout=2)
+    reconnect_thread.join(timeout=2)
+
+    assert reconnect_was_serialized, "reconnect wrote while disconnect held lifecycle authority"
+    assert not disconnect_thread.is_alive()
+    assert not reconnect_thread.is_alive()
+    assert errors == []
+    assert results["disconnect"]["status"] == "disconnected"
+    assert results["reconnect"]["status"] == "connected"
+    surviving = store.get(binding_id)
+    assert surviving is not None
+    assert surviving.refresh_token == SENTINEL_REFRESH_2
+    assert bindings.get(binding_id).state == "connected"
+    assert disconnect_binder.status(binding_id)["status"] == "connected"
+    lock_root = store.path.parent / f".{store.path.name}.locks"
+    lock_files = tuple(lock_root.iterdir())
+    assert len(lock_files) == 1
+    assert binding_id not in lock_files[0].name
+    assert all(secret not in str(lock_files[0]) for secret in _ALL_SENTINELS)
+    assert lock_files[0].read_bytes() == b""
+
+
+def test_disconnect_permanent_revoke_error_tears_down_local_state(
+    store, bindings, registry
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    source = registry.register(
+        collection_kind="owned_playlist",
+        collection_ref=SYNTH_PLAYLIST_REF,
+        title="Owned",
+        account_binding_id=binding_id,
+    )
+    provider.revoke_responses.append(
+        httpx.Response(
+            400,
+            json={"error": "invalid_token", "error_description": SENTINEL_REFRESH},
+        )
+    )
+
+    disc = binder.disconnect(binding_id)
+
+    assert disc["status"] == "disconnected"
+    assert disc["revoked"] is False
+    assert store.has_record(binding_id) is False
+    assert bindings.get(binding_id).reason_code == "auth_disconnected"
+    assert registry.get(source.binding_id).enabled is False
+    assert SENTINEL_REFRESH not in json.dumps(disc)
 
 
 # --- AC7 --------------------------------------------------------------------

--- a/tests/knowledge_acquisition/test_youtube_oauth.py
+++ b/tests/knowledge_acquisition/test_youtube_oauth.py
@@ -392,6 +392,119 @@ def test_missing_store_key_fails_closed(store, bindings, registry, monkeypatch):
         store.get(binding_id)
 
 
+def test_restored_exact_key_recovers_only_nonterminal_key_degradation(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    source = registry.register(
+        collection_kind="owned_playlist",
+        collection_ref=SYNTH_PLAYLIST_REF,
+        title="Owned",
+        account_binding_id=binding_id,
+    )
+    provider.requests.clear()
+    token_provider = oauth.TokenProvider(
+        binding_id=binding_id,
+        token_store=store,
+        oauth_client=_client(provider),
+        binding_store=bindings,
+        source_registry=registry,
+    )
+
+    monkeypatch.delenv(tokstore.KEY_ENV_VAR, raising=False)
+    with pytest.raises(oauth.AuthDegradedError) as missing_key:
+        token_provider.get_access_token()
+    assert missing_key.value.reason_code == "auth_key_missing"
+    assert bindings.get(binding_id).reason_code == "auth_key_missing"
+    assert registry.get(source.binding_id).last_error["reason_code"] == "auth_key_missing"
+
+    # Re-provisioning the exact key proves the canonical ciphertext again and
+    # recovers the non-terminal binding/source projection under the lifecycle
+    # lock without another provider grant or refresh.
+    monkeypatch.setenv(tokstore.KEY_ENV_VAR, TEST_STORE_KEY)
+    assert token_provider.get_access_token() == SENTINEL_ACCESS
+    recovered = bindings.get(binding_id)
+    assert recovered is not None
+    assert recovered.state == "connected"
+    assert recovered.reason_code is None
+    assert registry.get(source.binding_id).last_error is None
+    assert provider.requests == []
+
+    # The same readable canonical credential is never sufficient to bypass a
+    # later terminal authority transition.
+    bindings.set_state(binding_id, state="degraded", reason_code="auth_revoked")
+    with pytest.raises(oauth.AuthDegradedError) as terminal:
+        token_provider.get_access_token()
+    assert terminal.value.reason_code == "auth_revoked"
+    assert bindings.get(binding_id).reason_code == "auth_revoked"
+    assert registry.get(source.binding_id).last_error["reason_code"] == "auth_revoked"
+    assert provider.requests == []
+
+
+def test_restored_key_recovery_cas_cannot_overwrite_concurrent_terminal_state(
+    store, bindings, registry, monkeypatch
+):
+    binder = _binder(_Provider(), store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    source = registry.register(
+        collection_kind="owned_playlist",
+        collection_ref=SYNTH_PLAYLIST_REF,
+        title="Owned",
+        account_binding_id=binding_id,
+    )
+    token_provider = oauth.TokenProvider(
+        binding_id=binding_id,
+        token_store=store,
+        oauth_client=_client(_Provider()),
+        binding_store=bindings,
+        source_registry=registry,
+    )
+    monkeypatch.delenv(tokstore.KEY_ENV_VAR, raising=False)
+    with pytest.raises(oauth.AuthDegradedError):
+        token_provider.get_access_token()
+    degraded = bindings.get(binding_id)
+    assert degraded is not None
+    assert degraded.reason_code == "auth_key_missing"
+
+    monkeypatch.setenv(tokstore.KEY_ENV_VAR, TEST_STORE_KEY)
+    original_set_state = bindings.set_state
+    terminal_injected = False
+
+    def inject_terminal_before_recovery(
+        target_binding_id,
+        *,
+        state,
+        reason_code=None,
+        expected_binding_generation=None,
+    ):
+        nonlocal terminal_injected
+        if state == "connected" and not terminal_injected:
+            terminal_injected = True
+            original_set_state(
+                target_binding_id,
+                state="degraded",
+                reason_code="auth_revoked",
+            )
+        return original_set_state(
+            target_binding_id,
+            state=state,
+            reason_code=reason_code,
+            expected_binding_generation=expected_binding_generation,
+        )
+
+    monkeypatch.setattr(bindings, "set_state", inject_terminal_before_recovery)
+    with pytest.raises(oauth.AuthDegradedError) as terminal:
+        token_provider.get_access_token()
+
+    assert terminal.value.reason_code == "auth_revoked"
+    assert bindings.get(binding_id).reason_code == "auth_revoked"
+    assert registry.get(source.binding_id).last_error["reason_code"] == "auth_revoked"
+
+
 @pytest.mark.parametrize("configured_key", [None, "not-valid-hex"])
 def test_connect_token_store_failure_does_not_create_connected_binding(
     store, bindings, registry, monkeypatch, configured_key
@@ -1894,6 +2007,195 @@ def test_rotated_refresh_store_failure_preserves_journal_and_recovers_without_pr
     )
 
 
+def test_refresh_recovery_retains_journal_until_binding_and_source_converge(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    source = registry.register(
+        collection_kind="owned_playlist",
+        collection_ref=SYNTH_PLAYLIST_REF,
+        title="Owned",
+        account_binding_id=binding_id,
+    )
+    canonical = store.get(binding_id)
+    assert canonical is not None
+    store.put(binding_id, canonical.with_expired_access())
+    provider.token_responses.append(
+        _granted_token(access=SENTINEL_ACCESS_2, refresh=SENTINEL_REFRESH_2)
+    )
+    pending_id = oauth._pending_refresh_id(binding_id)
+    original_put = store.put
+
+    def fail_canonical_write(target_id, token):
+        if target_id == binding_id:
+            raise OSError("synthetic canonical write failure")
+        return original_put(target_id, token)
+
+    monkeypatch.setattr(store, "put", fail_canonical_write)
+    token_provider = oauth.TokenProvider(
+        binding_id=binding_id,
+        token_store=store,
+        oauth_client=_client(provider),
+        binding_store=bindings,
+        source_registry=registry,
+    )
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as first_error:
+        token_provider.get_access_token()
+    assert first_error.value.reason_code == "refresh_pending"
+    assert store.has_record(pending_id) is True
+    assert bindings.get(binding_id).reason_code == "auth_refresh_pending"
+    assert registry.get(source.binding_id).last_error["reason_code"] == "auth_refresh_pending"
+    token_calls_after_provider_refresh = sum(
+        urlsplit(str(request.url)).path.endswith("/token")
+        for request in provider.requests
+    )
+
+    monkeypatch.setattr(store, "put", original_put)
+    original_binding_set_state = bindings.set_state
+    binding_clear_attempts = 0
+
+    def fail_binding_convergence_once(
+        target_binding_id,
+        *,
+        state,
+        reason_code=None,
+        expected_binding_generation=None,
+    ):
+        nonlocal binding_clear_attempts
+        if state == "connected":
+            binding_clear_attempts += 1
+            if binding_clear_attempts == 1:
+                raise OSError("synthetic connected-binding convergence failure")
+        return original_binding_set_state(
+            target_binding_id,
+            state=state,
+            reason_code=reason_code,
+            expected_binding_generation=expected_binding_generation,
+        )
+
+    monkeypatch.setattr(bindings, "set_state", fail_binding_convergence_once)
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as binding_error:
+        token_provider.get_access_token()
+    assert binding_error.value.reason_code == "refresh_durability_unavailable"
+    assert binding_error.value.pending_grant_id == pending_id
+    assert bindings.get(binding_id).reason_code == "auth_refresh_pending"
+    assert registry.get(source.binding_id).last_error["reason_code"] == "auth_refresh_pending"
+    assert store.has_record(pending_id) is True
+
+    monkeypatch.setattr(bindings, "set_state", original_binding_set_state)
+    clear_attempts = 0
+    original_clear = getattr(registry, "clear_source_degradation", None)
+
+    def fail_source_convergence_once(target_binding_id, *, expected_reason_codes):
+        nonlocal clear_attempts
+        clear_attempts += 1
+        if clear_attempts == 1:
+            raise OSError("synthetic connected-source convergence failure")
+        assert original_clear is not None
+        return original_clear(
+            target_binding_id,
+            expected_reason_codes=expected_reason_codes,
+        )
+
+    monkeypatch.setattr(
+        registry,
+        "clear_source_degradation",
+        fail_source_convergence_once,
+        raising=False,
+    )
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as convergence_error:
+        token_provider.get_access_token()
+    assert convergence_error.value.reason_code == "refresh_durability_unavailable"
+    assert convergence_error.value.pending_grant_id == pending_id
+    assert bindings.get(binding_id).state == "connected"
+    assert registry.get(source.binding_id).last_error["reason_code"] == "auth_refresh_pending"
+    assert store.has_record(pending_id) is True
+
+    assert token_provider.get_access_token() == SENTINEL_ACCESS_2
+    assert binding_clear_attempts == 1
+    assert clear_attempts == 2
+    assert store.has_record(pending_id) is False
+    assert bindings.get(binding_id).state == "connected"
+    assert bindings.get(binding_id).reason_code is None
+    assert registry.get(source.binding_id).last_error is None
+    assert (
+        sum(
+            urlsplit(str(request.url)).path.endswith("/token")
+            for request in provider.requests
+        )
+        == token_calls_after_provider_refresh
+    )
+
+
+def test_incomplete_rotated_refresh_is_journaled_and_recovers_without_credential_loss(
+    store, bindings, registry
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    source = registry.register(
+        collection_kind="owned_playlist",
+        collection_ref=SYNTH_PLAYLIST_REF,
+        title="Owned",
+        account_binding_id=binding_id,
+    )
+    canonical = store.get(binding_id)
+    assert canonical is not None
+    store.put(binding_id, canonical.with_expired_access())
+    provider.token_responses.append(
+        httpx.Response(
+            200,
+            json={
+                "refresh_token": SENTINEL_REFRESH_2,
+                "expires_in": 3600,
+                "scope": oauth.SCOPE,
+                "token_type": "Bearer",
+            },
+        )
+    )
+    token_provider = oauth.TokenProvider(
+        binding_id=binding_id,
+        token_store=store,
+        oauth_client=_client(provider),
+        binding_store=bindings,
+        source_registry=registry,
+    )
+    pending_id = oauth._pending_refresh_id(binding_id)
+
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as incomplete:
+        token_provider.get_access_token()
+
+    assert incomplete.value.reason_code == "refresh_pending"
+    assert incomplete.value.pending_grant_id == pending_id
+    _assert_no_exception_chain(incomplete.value)
+    assert store.get(binding_id).refresh_token == SENTINEL_REFRESH
+    pending = store.get(pending_id)
+    assert pending is not None
+    assert pending.refresh_token == SENTINEL_REFRESH_2
+    assert pending.access_token == ""
+    assert bindings.get(binding_id).reason_code == "auth_refresh_pending"
+    assert registry.get(source.binding_id).last_error["reason_code"] == "auth_refresh_pending"
+    assert provider.revoked == []
+
+    provider.token_responses.append(
+        _granted_token(access=SENTINEL_ACCESS_2, refresh=SENTINEL_REFRESH_2)
+    )
+    assert token_provider.get_access_token() == SENTINEL_ACCESS_2
+    recovered = store.get(binding_id)
+    assert recovered is not None
+    assert recovered.refresh_token == SENTINEL_REFRESH_2
+    assert recovered.access_token == SENTINEL_ACCESS_2
+    assert store.has_record(pending_id) is False
+    assert bindings.get(binding_id).state == "connected"
+    assert bindings.get(binding_id).reason_code is None
+    assert registry.get(source.binding_id).last_error is None
+    assert provider.revoked == []
+
+
 def test_token_provider_refresh_conflict_degrades_binding_and_sources_without_secret_leak(
     store, bindings, registry
 ):
@@ -3370,6 +3672,33 @@ def test_provider_error_enum_is_allowlisted_before_exception_rendering():
     assert SENTINEL_REFRESH not in rendered
     assert SENTINEL_ACCESS not in rendered
     assert SENTINEL_REFRESH_2 not in rendered
+
+
+def test_transport_exception_is_detached_from_credential_bearing_httpx_request():
+    captured_requests: list[httpx.Request] = []
+
+    def fail_transport(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        raise httpx.ReadError("synthetic transport failure", request=request)
+
+    http = httpx.Client(transport=httpx.MockTransport(fail_transport))
+    client = oauth.OAuthClient(
+        client_id=TEST_CLIENT_ID,
+        client_secret=SENTINEL_CLIENT_SECRET,
+        http=http,
+    )
+
+    with pytest.raises(oauth.OAuthProviderError) as excinfo:
+        client.refresh(SENTINEL_REFRESH)
+
+    assert excinfo.value.status == 0
+    assert excinfo.value.error_code == "ReadError"
+    _assert_no_exception_chain(excinfo.value)
+    assert len(captured_requests) == 1
+    request_content = captured_requests[0].content.decode()
+    assert SENTINEL_CLIENT_SECRET in request_content
+    assert SENTINEL_REFRESH in request_content
+    assert all(secret not in str(excinfo.value) for secret in _ALL_SENTINELS)
 
 
 def test_compensated_refresh_cleanup_keeps_repeated_consumers_fail_closed(

--- a/tests/knowledge_acquisition/test_youtube_oauth.py
+++ b/tests/knowledge_acquisition/test_youtube_oauth.py
@@ -3339,8 +3339,10 @@ def test_repeated_consumer_converges_partial_terminal_source_degradation(
         binding_store=bindings,
         source_registry=registry,
     )
-    with pytest.raises(OSError, match="synthetic source degradation crash"):
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as first_error:
         token_provider.get_access_token()
+    assert first_error.value.reason_code == "refresh_durability_unavailable"
+    _assert_no_exception_chain(first_error.value)
 
     assert bindings.get(binding_id).reason_code == "auth_revoked"
     assert registry.get(source.binding_id).last_error is None
@@ -3352,6 +3354,101 @@ def test_repeated_consumer_converges_partial_terminal_source_degradation(
     assert repaired_source.last_error["reason_code"] == "auth_revoked"
     assert repaired_source.cursor == cursor_before
     assert repaired_source.enabled is True
+
+
+def test_api_entrypoint_retry_converges_compensated_refresh_sources_before_journal_delete(
+    store, bindings, registry, monkeypatch
+):
+    from app.knowledge_acquisition.youtube_api_client import YouTubeApiClient
+
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    source = registry.register(
+        collection_kind="owned_playlist",
+        collection_ref=SYNTH_PLAYLIST_REF,
+        title="Owned",
+        account_binding_id=binding_id,
+    )
+    canonical = store.get(binding_id)
+    assert canonical is not None
+    pending_id = oauth._pending_refresh_id(binding_id)
+    store.put(
+        pending_id,
+        replace(
+            canonical,
+            refresh_token=SENTINEL_REFRESH_2,
+            access_token=SENTINEL_ACCESS_2,
+            authority_generation=canonical.authority_generation + 1,
+            promotion_target_binding_id=binding_id,
+            promotion_predecessor_refresh_token=canonical.refresh_token,
+            promotion_predecessor_generation=canonical.authority_generation,
+            promotion_compensation_state="compensated",
+        ),
+    )
+    original_record = registry.record_source_degradation
+    source_write_attempts = 0
+
+    def fail_source_once(target_binding_id, *, reason_code):
+        nonlocal source_write_attempts
+        source_write_attempts += 1
+        if source_write_attempts == 1:
+            raise OSError(SENTINEL_ACCESS)
+        return original_record(target_binding_id, reason_code=reason_code)
+
+    original_delete = store.delete
+    cleanup_observations: list[str] = []
+
+    def assert_source_converged_before_cleanup(target_id):
+        if target_id == pending_id:
+            last_error = registry.get(source.binding_id).last_error
+            assert last_error is not None
+            cleanup_observations.append(last_error["reason_code"])
+        return original_delete(target_id)
+
+    monkeypatch.setattr(registry, "record_source_degradation", fail_source_once)
+    monkeypatch.setattr(store, "delete", assert_source_converged_before_cleanup)
+    token_provider = oauth.TokenProvider(
+        binding_id=binding_id,
+        token_store=store,
+        oauth_client=_client(provider),
+        binding_store=bindings,
+        source_registry=registry,
+    )
+    api_requests: list[httpx.Request] = []
+
+    def api_handler(request: httpx.Request) -> httpx.Response:
+        api_requests.append(request)
+        return httpx.Response(500, request=request)
+
+    api_client = YouTubeApiClient(
+        token_provider=token_provider,
+        http=httpx.Client(transport=httpx.MockTransport(api_handler)),
+    )
+
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as first_error:
+        api_client.get_my_channel()
+
+    assert first_error.value.reason_code == "refresh_compensated"
+    assert first_error.value.pending_grant_id == pending_id
+    _assert_no_exception_chain(first_error.value)
+    assert SENTINEL_ACCESS not in str(first_error.value)
+    assert bindings.get(binding_id).reason_code == "auth_revoked"
+    assert registry.get(source.binding_id).last_error is None
+    assert store.has_record(pending_id) is True
+    assert cleanup_observations == []
+
+    with pytest.raises(oauth.AuthDegradedError) as retry_error:
+        api_client.get_my_channel()
+
+    assert retry_error.value.reason_code == "auth_revoked"
+    _assert_no_exception_chain(retry_error.value)
+    assert registry.get(source.binding_id).last_error["reason_code"] == "auth_revoked"
+    assert store.has_record(pending_id) is False
+    assert cleanup_observations == ["auth_revoked"]
+    assert source_write_attempts == 2
+    assert api_requests == []
 
 
 def test_terminal_status_precedes_missing_key_for_disconnect_retry_authority(

--- a/tests/knowledge_acquisition/test_youtube_oauth.py
+++ b/tests/knowledge_acquisition/test_youtube_oauth.py
@@ -1171,13 +1171,22 @@ def test_reconnect_postcanonical_state_failure_preserves_pending_until_state_con
     original_set_state = bindings.set_state
     failed_once = False
 
-    def fail_connected_state_once(target_binding_id, *, state, reason_code):
+    def fail_connected_state_once(
+        target_binding_id,
+        *,
+        state,
+        reason_code,
+        expected_binding_generation=None,
+    ):
         nonlocal failed_once
         if state == "connected" and not failed_once:
             failed_once = True
             raise RuntimeError("synthetic binding-state persistence failure")
         return original_set_state(
-            target_binding_id, state=state, reason_code=reason_code
+            target_binding_id,
+            state=state,
+            reason_code=reason_code,
+            expected_binding_generation=expected_binding_generation,
         )
 
     monkeypatch.setattr(bindings, "set_state", fail_connected_state_once)
@@ -1966,6 +1975,116 @@ def test_compensated_refresh_cleanup_residue_is_never_promoted(
     assert binding is not None
     assert binding.state == "degraded"
     assert binding.reason_code == "auth_revoked"
+
+
+def test_compensated_marker_write_loss_and_cleanup_failure_converge_after_restart(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    canonical = store.get(binding_id)
+    assert canonical is not None
+    store.put(binding_id, canonical.with_expired_access())
+    provider.token_responses.append(
+        _granted_token(access=SENTINEL_ACCESS_2, refresh=SENTINEL_REFRESH_2)
+    )
+    pending_id = oauth._pending_refresh_id(binding_id)
+    original_put = store.put
+    original_confirm = store.confirm_record_durable
+    original_delete = store.delete
+    marker_write_attempts = 0
+    cleanup_attempts = 0
+
+    def fail_unconfirmed_initial_and_compensated_marker(target_id, token):
+        nonlocal marker_write_attempts
+        if target_id == pending_id and token.promotion_compensation_state is None:
+            original_put(target_id, token)
+            raise tokstore.TokenStoreDurabilityError("unconfirmed refresh journal")
+        if (
+            target_id == pending_id
+            and token.promotion_compensation_state == "compensated"
+        ):
+            marker_write_attempts += 1
+            raise OSError("synthetic compensated-marker write failure")
+        original_put(target_id, token)
+
+    def reject_initial_journal_confirmation(target_id, token):
+        if target_id == pending_id and token.promotion_compensation_state is None:
+            return False
+        return original_confirm(target_id, token)
+
+    def fail_first_cleanup(target_id):
+        nonlocal cleanup_attempts
+        if target_id == pending_id and cleanup_attempts == 0:
+            cleanup_attempts += 1
+            raise OSError("synthetic compensated cleanup failure")
+        return original_delete(target_id)
+
+    monkeypatch.setattr(
+        store, "put", fail_unconfirmed_initial_and_compensated_marker
+    )
+    monkeypatch.setattr(
+        store, "confirm_record_durable", reject_initial_journal_confirmation
+    )
+    monkeypatch.setattr(store, "delete", fail_first_cleanup)
+    first_provider = oauth.TokenProvider(
+        binding_id=binding_id,
+        token_store=store,
+        oauth_client=_client(provider),
+        binding_store=bindings,
+        source_registry=registry,
+    )
+
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as first_error:
+        first_provider.get_access_token()
+
+    assert first_error.value.reason_code == "refresh_durability_unavailable"
+    assert first_error.value.pending_grant_id == pending_id
+    _assert_no_exception_chain(first_error.value)
+    assert marker_write_attempts == 2
+    pending = store.get(pending_id)
+    assert pending is not None
+    assert pending.promotion_compensation_state == "pending"
+    assert bindings.get(binding_id).reason_code == "auth_refresh_durability"
+    assert provider.revoked == [{"token": SENTINEL_REFRESH_2}]
+    assert cleanup_attempts == 0
+
+    monkeypatch.setattr(store, "put", original_put)
+    monkeypatch.setattr(store, "confirm_record_durable", original_confirm)
+    restarted_binder = _binder(provider, store, bindings, registry)
+    cleanup_result = restarted_binder.disconnect(binding_id)
+
+    assert cleanup_result == {
+        "status": "disconnect_failed",
+        "reason_code": "auth_revoked",
+        "revoked": False,
+        "retryable": True,
+        "sources_disabled": 0,
+    }
+    compensated = store.get(pending_id)
+    assert compensated is not None
+    assert compensated.promotion_compensation_state == "compensated"
+    assert bindings.get(binding_id).reason_code == "auth_revoked"
+    assert cleanup_attempts == 1
+    assert provider.revoked == [
+        {"token": SENTINEL_REFRESH_2},
+        {"token": SENTINEL_REFRESH_2},
+    ]
+
+    recovered = _binder(provider, store, bindings, registry).disconnect(binding_id)
+
+    assert recovered["status"] == "disconnected"
+    assert recovered["revoked"] is True
+    assert store.has_record(pending_id) is False
+    assert store.has_record(binding_id) is False
+    assert bindings.get(binding_id).reason_code == "auth_disconnected"
+    assert provider.revoked == [
+        {"token": SENTINEL_REFRESH_2},
+        {"token": SENTINEL_REFRESH_2},
+        {"token": SENTINEL_REFRESH},
+    ]
 
 
 def test_compensated_refresh_crash_before_degradation_never_reports_connected(
@@ -3227,13 +3346,22 @@ def test_disconnected_reconnect_postcanonical_failure_blocks_until_retry(
     original_set_state = bindings.set_state
     failed_once = False
 
-    def fail_connected_state_once(target_binding_id, *, state, reason_code):
+    def fail_connected_state_once(
+        target_binding_id,
+        *,
+        state,
+        reason_code,
+        expected_binding_generation=None,
+    ):
         nonlocal failed_once
         if state == "connected" and not failed_once:
             failed_once = True
             raise RuntimeError("synthetic disconnected reconnect state failure")
         return original_set_state(
-            target_binding_id, state=state, reason_code=reason_code
+            target_binding_id,
+            state=state,
+            reason_code=reason_code,
+            expected_binding_generation=expected_binding_generation,
         )
 
     monkeypatch.setattr(bindings, "set_state", fail_connected_state_once)
@@ -3301,6 +3429,142 @@ def test_stale_pending_cleanup_cannot_resurrect_terminal_binding(
     with pytest.raises(oauth.AuthDegradedError) as excinfo:
         token_provider.get_access_token()
     assert excinfo.value.reason_code == terminal_reason
+
+
+@pytest.mark.parametrize("terminal_reason", ["auth_disconnected", "auth_revoked"])
+def test_stale_distinct_token_pending_cannot_resurrect_terminal_binding(
+    store, bindings, registry, terminal_reason
+):
+    binder = _binder(_Provider(), store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    canonical = store.get(binding_id)
+    predecessor_binding = bindings.get(binding_id)
+    assert canonical is not None
+    assert predecessor_binding is not None
+    pending_id = oauth._pending_grant_id("stale-distinct-token", binding_id)
+    stale_pending = replace(
+        canonical,
+        refresh_token=SENTINEL_REFRESH_2,
+        access_token=SENTINEL_ACCESS_2,
+        authority_generation=canonical.authority_generation + 1,
+        promotion_target_binding_id=binding_id,
+        promotion_predecessor_refresh_token=canonical.refresh_token,
+        promotion_predecessor_generation=canonical.authority_generation,
+        promotion_predecessor_binding_updated_at=oauth._binding_generation_evidence(
+            predecessor_binding.binding_generation
+        ),
+    )
+    store.put(pending_id, stale_pending)
+    terminal_binding = bindings.set_state(
+        binding_id, state="degraded", reason_code=terminal_reason
+    )
+    assert (
+        terminal_binding.binding_generation
+        == predecessor_binding.binding_generation + 1
+    )
+
+    result = binder.retry_pending_grant_compensation(pending_id)
+
+    assert result == {
+        "status": "pending_conflict",
+        "pending_grant_id": pending_id,
+        "binding_id": binding_id,
+    }
+    assert store.get(binding_id) == canonical
+    assert store.get(pending_id) == stale_pending
+    assert bindings.get(binding_id).reason_code == terminal_reason
+
+
+def test_matching_generation_disconnected_reconnect_promotes_distinct_pending(
+    store, bindings, registry
+):
+    binder = _binder(_Provider(), store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    canonical = store.get(binding_id)
+    assert canonical is not None
+    disconnected = bindings.set_state(
+        binding_id, state="degraded", reason_code="auth_disconnected"
+    )
+    pending_id = oauth._pending_grant_id("matching-disconnected", binding_id)
+    pending = replace(
+        canonical,
+        refresh_token=SENTINEL_REFRESH_2,
+        access_token=SENTINEL_ACCESS_2,
+        authority_generation=canonical.authority_generation + 1,
+        promotion_target_binding_id=binding_id,
+        promotion_predecessor_refresh_token=canonical.refresh_token,
+        promotion_predecessor_generation=canonical.authority_generation,
+        promotion_predecessor_binding_updated_at=oauth._binding_generation_evidence(
+            disconnected.binding_generation
+        ),
+    )
+    store.put(pending_id, pending)
+
+    result = binder.retry_pending_grant_compensation(pending_id)
+
+    assert result == {
+        "status": "promoted",
+        "pending_grant_id": pending_id,
+        "binding_id": binding_id,
+    }
+    promoted = store.get(binding_id)
+    assert promoted is not None
+    assert promoted.refresh_token == SENTINEL_REFRESH_2
+    assert store.has_record(pending_id) is False
+    reconnected = bindings.get(binding_id)
+    assert reconnected is not None
+    assert reconnected.state == "connected"
+    assert reconnected.reason_code is None
+    assert reconnected.binding_generation == disconnected.binding_generation + 1
+
+
+def test_same_timestamp_terminal_collision_rejects_stale_pending_generation(
+    store, bindings, registry, monkeypatch
+):
+    fixed_now = "2026-07-20T17:00:00+00:00"
+    monkeypatch.setattr(yab, "_now_iso", lambda: fixed_now)
+    binder = _binder(_Provider(), store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    canonical = store.get(binding_id)
+    predecessor_binding = bindings.get(binding_id)
+    assert canonical is not None
+    assert predecessor_binding is not None
+    pending_id = oauth._pending_grant_id("same-timestamp-stale", binding_id)
+    stale_pending = replace(
+        canonical,
+        refresh_token=SENTINEL_REFRESH_2,
+        access_token=SENTINEL_ACCESS_2,
+        authority_generation=canonical.authority_generation + 1,
+        promotion_target_binding_id=binding_id,
+        promotion_predecessor_refresh_token=canonical.refresh_token,
+        promotion_predecessor_generation=canonical.authority_generation,
+        promotion_predecessor_binding_updated_at=oauth._binding_generation_evidence(
+            predecessor_binding.binding_generation
+        ),
+    )
+    store.put(pending_id, stale_pending)
+    terminal = bindings.set_state(
+        binding_id, state="degraded", reason_code="auth_revoked"
+    )
+    assert terminal.updated_at == predecessor_binding.updated_at == fixed_now
+    assert terminal.binding_generation == predecessor_binding.binding_generation + 1
+    with pytest.raises(yab.AccountBindingGenerationConflictError):
+        bindings.set_state(
+            binding_id,
+            state="connected",
+            reason_code=None,
+            expected_binding_generation=predecessor_binding.binding_generation,
+        )
+
+    result = binder.retry_pending_grant_compensation(pending_id)
+
+    assert result["status"] == "pending_conflict"
+    assert store.get(binding_id) == canonical
+    assert store.get(pending_id) == stale_pending
+    assert bindings.get(binding_id).reason_code == "auth_revoked"
 
 
 def test_repeated_consumer_converges_partial_terminal_source_degradation(
@@ -3468,6 +3732,31 @@ def test_terminal_status_precedes_missing_key_for_disconnect_retry_authority(
     monkeypatch.delenv(tokstore.KEY_ENV_VAR, raising=False)
 
     assert binder.status(binding_id)["reason_code"] == "auth_disconnected"
+
+
+def test_terminal_status_short_circuits_token_store_io_failure(
+    store, bindings, registry, monkeypatch
+):
+    binder = _binder(_Provider(), store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    bindings.set_state(binding_id, state="degraded", reason_code="auth_revoked")
+    read_calls = 0
+
+    def fail_token_store_read(_binding_id):
+        nonlocal read_calls
+        read_calls += 1
+        raise OSError("synthetic token-store read failure")
+
+    monkeypatch.setattr(store, "get", fail_token_store_read)
+
+    assert binder.status(binding_id) == {
+        "status": "degraded",
+        "reason_code": "auth_revoked",
+        "scopes": [oauth.SCOPE],
+        "token_store": "encrypted",
+    }
+    assert read_calls == 0
 
 
 def test_token_provider_requires_binding_authority_dependency(store):

--- a/tests/knowledge_acquisition/test_youtube_oauth.py
+++ b/tests/knowledge_acquisition/test_youtube_oauth.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import logging
 import secrets
+import stat
 import subprocess
 import sys
 import threading
@@ -56,6 +57,18 @@ _ALL_SENTINELS = (
     SENTINEL_CLIENT_SECRET,
     SENTINEL_DEVICE_CODE,
 )
+
+
+def _assert_no_exception_chain(error: BaseException) -> None:
+    """Secret-bearing failures must not survive in hidden exception links."""
+    seen: set[int] = set()
+    pending = [error]
+    while pending:
+        current = pending.pop()
+        assert id(current) not in seen
+        seen.add(id(current))
+        assert current.__cause__ is None
+        assert current.__context__ is None
 
 
 # --- Transport stub ---------------------------------------------------------
@@ -368,6 +381,7 @@ def test_identity_probe_failure_is_provider_compensated_without_secret_leak(
     rendered = repr(excinfo.value) + str(excinfo.value)
     assert SENTINEL_ACCESS not in rendered
     assert SENTINEL_REFRESH not in rendered
+    _assert_no_exception_chain(excinfo.value)
 
 
 def test_incomplete_grant_with_refresh_token_is_compensated_not_discarded(
@@ -434,6 +448,7 @@ def test_identity_probe_and_compensation_failure_preserve_encrypted_pending_auth
     rendered = repr(excinfo.value) + str(excinfo.value)
     assert SENTINEL_REFRESH not in rendered
     assert SENTINEL_ACCESS not in rendered
+    _assert_no_exception_chain(excinfo.value)
 
     retried = binder.retry_pending_grant_compensation(pending_id)
     assert retried == {"status": "compensated", "pending_grant_id": pending_id}
@@ -455,6 +470,7 @@ def test_pending_journal_write_failure_is_provider_compensated(
         _connect_device(binder)
 
     assert excinfo.value.reason_code == "grant_compensated"
+    _assert_no_exception_chain(excinfo.value)
     assert provider.revoked == [{"token": SENTINEL_REFRESH}]
     assert store.binding_ids() == ()
     assert bindings.list_all() == ()
@@ -491,6 +507,68 @@ def test_pending_write_and_compensation_failure_retry_preserves_authority(
     assert bindings.list_all() == ()
 
 
+def test_pending_journal_write_lost_ack_returns_retry_handle_without_revocation(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    original_put = store.put
+    first_write = True
+
+    def persist_pending_then_lose_ack(binding_id, token):
+        nonlocal first_write
+        original_put(binding_id, token)
+        if first_write:
+            first_write = False
+            raise OSError(SENTINEL_REFRESH)
+
+    monkeypatch.setattr(store, "put", persist_pending_then_lose_ack)
+
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
+        _connect_device(binder)
+
+    assert excinfo.value.reason_code == "grant_pending"
+    pending_id = excinfo.value.pending_grant_id
+    assert pending_id is not None
+    assert store.binding_ids() == (pending_id,)
+    assert store.get(pending_id).refresh_token == SENTINEL_REFRESH
+    assert provider.revoked == []
+    assert SENTINEL_REFRESH not in (repr(excinfo.value) + str(excinfo.value))
+    _assert_no_exception_chain(excinfo.value)
+
+
+def test_pending_parent_directory_fsync_lost_ack_keeps_retry_authority(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    original_fsync = tokstore.os.fsync
+    directory_fsyncs = 0
+
+    def lose_second_directory_fsync_ack(descriptor):
+        nonlocal directory_fsyncs
+        if stat.S_ISDIR(tokstore.os.fstat(descriptor).st_mode):
+            directory_fsyncs += 1
+            if directory_fsyncs == 2:
+                raise OSError(SENTINEL_REFRESH)
+        original_fsync(descriptor)
+
+    monkeypatch.setattr(tokstore.os, "fsync", lose_second_directory_fsync_ack)
+
+    with pytest.raises(oauth.OAuthGrantDurabilityError) as excinfo:
+        _connect_device(binder)
+
+    assert directory_fsyncs == 2  # readiness, then pending-grant journal
+    assert excinfo.value.reason_code == "grant_pending"
+    pending_id = excinfo.value.pending_grant_id
+    assert pending_id is not None
+    assert store.binding_ids() == (pending_id,)
+    assert store.get(pending_id).refresh_token == SENTINEL_REFRESH
+    assert provider.revoked == []
+    assert SENTINEL_REFRESH not in (repr(excinfo.value) + str(excinfo.value))
+    _assert_no_exception_chain(excinfo.value)
+
+
 def test_binding_store_write_failure_leaves_pending_grant_recoverable(
     store, bindings, registry, monkeypatch
 ):
@@ -519,6 +597,7 @@ def test_binding_store_write_failure_leaves_pending_grant_recoverable(
     assert store.get(pending_id).refresh_token == SENTINEL_REFRESH
     assert bindings.list_all() == ()
     assert SENTINEL_REFRESH not in (repr(excinfo.value) + str(excinfo.value))
+    _assert_no_exception_chain(excinfo.value)
 
 
 def test_reconnect_write_failure_does_not_mistake_old_token_for_new_grant_durability(
@@ -555,6 +634,45 @@ def test_reconnect_write_failure_does_not_mistake_old_token_for_new_grant_durabi
     assert store.get(binding_id).refresh_token == SENTINEL_REFRESH
     assert store.get(pending_id).refresh_token == SENTINEL_REFRESH_2
     assert SENTINEL_REFRESH_2 not in (repr(excinfo.value) + str(excinfo.value))
+    _assert_no_exception_chain(excinfo.value)
+
+
+def test_reconnect_canonical_write_lost_ack_rolls_forward_without_revoking_new_grant(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    provider.token_responses.append(
+        _granted_token(access=SENTINEL_ACCESS_2, refresh=SENTINEL_REFRESH_2)
+    )
+    reconnect = binder.start_reconnect(binding_id)
+    pending_id = oauth._pending_grant_id(reconnect.handle.device_code, binding_id)
+    original_put = store.put
+
+    def persist_canonical_then_lose_ack(target_id, token):
+        original_put(target_id, token)
+        if target_id == binding_id:
+            raise OSError(SENTINEL_REFRESH_2)
+
+    monkeypatch.setattr(store, "put", persist_canonical_then_lose_ack)
+
+    result = binder.finish_device_connection(reconnect)
+
+    assert result == {
+        "status": "connected",
+        "account": {"binding_id": binding_id, "channel_title": SYNTH_CHANNEL_TITLE},
+    }
+    assert store.binding_ids() == (binding_id,)
+    assert store.get(binding_id).refresh_token == SENTINEL_REFRESH_2
+    assert provider.revoked == []
+
+    # A stale retry handle is absent and therefore can never revoke the new
+    # canonical grant whose exact readback already proved lost-ack success.
+    retried = binder.retry_pending_grant_compensation(pending_id)
+    assert retried == {"status": "absent", "pending_grant_id": pending_id}
+    assert provider.revoked == []
 
 
 def test_connect_post_commit_exception_reconciles_without_deleting_token(
@@ -1224,6 +1342,37 @@ def test_token_store_roundtrip_and_delete(store):
     assert store.delete("b-1") is True
     assert store.has_record("b-1") is False
     assert store.get("b-1") is None
+
+
+def test_token_store_syncs_staged_file_before_replace_and_parent_after(
+    store, monkeypatch
+):
+    token = tokstore.StoredToken(
+        refresh_token=SENTINEL_REFRESH,
+        access_token=SENTINEL_ACCESS,
+        expires_at="2999-01-01T00:00:00+00:00",
+        scopes=(oauth.SCOPE,),
+        obtained_at="2026-07-18T00:00:00+00:00",
+        provider_channel_id=SYNTH_CHANNEL_ID,
+    )
+    events: list[str] = []
+    original_replace = tokstore.os.replace
+
+    def record_fsync(descriptor):
+        mode = tokstore.os.fstat(descriptor).st_mode
+        events.append("fsync:directory" if stat.S_ISDIR(mode) else "fsync:file")
+
+    def record_replace(source, target):
+        events.append("replace")
+        original_replace(source, target)
+
+    monkeypatch.setattr(tokstore.os, "fsync", record_fsync)
+    monkeypatch.setattr(tokstore.os, "replace", record_replace)
+
+    store.put("b-durable", token)
+
+    assert events == ["fsync:file", "replace", "fsync:directory"]
+    assert store.get("b-durable") == token
 
 
 def test_oauth_client_refuses_off_allowlist_host():

--- a/tests/knowledge_acquisition/test_youtube_oauth.py
+++ b/tests/knowledge_acquisition/test_youtube_oauth.py
@@ -1958,6 +1958,165 @@ def test_compensated_refresh_cleanup_residue_is_never_promoted(
     assert binding.reason_code == "auth_revoked"
 
 
+def test_compensated_refresh_crash_before_degradation_never_reports_connected(
+    store, bindings, registry, monkeypatch
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    canonical = store.get(binding_id)
+    assert canonical is not None
+    store.put(binding_id, canonical.with_expired_access())
+    provider.token_responses.append(
+        _granted_token(access=SENTINEL_ACCESS_2, refresh=SENTINEL_REFRESH_2)
+    )
+    pending_id = oauth._pending_refresh_id(binding_id)
+    original_put = store.put
+    original_confirm = store.confirm_record_durable
+
+    def land_unconfirmed_initial_journal(target_id, token):
+        if target_id == pending_id and token.promotion_compensation_state is None:
+            original_put(target_id, token)
+            raise tokstore.TokenStoreDurabilityError("unconfirmed refresh journal")
+        original_put(target_id, token)
+
+    def reject_initial_journal_confirmation(target_id, token):
+        if target_id == pending_id and token.promotion_compensation_state is None:
+            return False
+        return original_confirm(target_id, token)
+
+    monkeypatch.setattr(store, "put", land_unconfirmed_initial_journal)
+    monkeypatch.setattr(
+        store, "confirm_record_durable", reject_initial_journal_confirmation
+    )
+    token_provider = oauth.TokenProvider(
+        binding_id=binding_id,
+        token_store=store,
+        oauth_client=_client(provider),
+        binding_store=bindings,
+        source_registry=registry,
+    )
+
+    def crash_before_auth_revoked_write(reason_code):
+        if reason_code == "auth_revoked":
+            raise RuntimeError("simulated crash before binding degradation")
+
+    monkeypatch.setattr(token_provider, "_degrade", crash_before_auth_revoked_write)
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        token_provider.get_access_token()
+
+    assert provider.revoked[-1] == {"token": SENTINEL_REFRESH_2}
+    compensated = store.get(pending_id)
+    assert compensated is not None
+    assert compensated.promotion_compensation_state == "compensated"
+    assert binder.status(binding_id) == {
+        "status": "degraded",
+        "reason_code": "auth_revoked",
+        "scopes": [oauth.SCOPE],
+        "token_store": "encrypted",
+    }
+
+
+def test_compensated_refresh_residue_reports_revoked_and_disconnect_converges(
+    store, bindings, registry
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    canonical = store.get(binding_id)
+    assert canonical is not None
+    pending_id = oauth._pending_refresh_id(binding_id)
+    compensated = replace(
+        canonical,
+        refresh_token=SENTINEL_REFRESH_2,
+        access_token=SENTINEL_ACCESS_2,
+        authority_generation=canonical.authority_generation + 1,
+        promotion_target_binding_id=binding_id,
+        promotion_predecessor_refresh_token=canonical.refresh_token,
+        promotion_predecessor_generation=canonical.authority_generation,
+        promotion_compensation_state="compensated",
+    )
+    store.put(pending_id, compensated)
+    bindings.set_state(binding_id, state="degraded", reason_code="auth_revoked")
+    token_calls_before = sum(
+        urlsplit(str(request.url)).path.endswith("/token")
+        for request in provider.requests
+    )
+
+    assert binder.status(binding_id) == {
+        "status": "degraded",
+        "reason_code": "auth_revoked",
+        "scopes": [oauth.SCOPE],
+        "token_store": "encrypted",
+    }
+    result = binder.disconnect(binding_id)
+
+    assert result["status"] == "disconnected"
+    assert store.has_record(pending_id) is False
+    assert store.has_record(binding_id) is False
+    assert provider.revoked[-1] == {"token": SENTINEL_REFRESH}
+    assert bindings.get(binding_id).reason_code == "auth_disconnected"
+    assert (
+        sum(
+            urlsplit(str(request.url)).path.endswith("/token")
+            for request in provider.requests
+        )
+        == token_calls_before
+    )
+
+
+def test_compensated_refresh_residue_reconnects_only_through_new_consent(
+    store, bindings, registry
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    canonical = store.get(binding_id)
+    assert canonical is not None
+    pending_id = oauth._pending_refresh_id(binding_id)
+    store.put(
+        pending_id,
+        replace(
+            canonical,
+            refresh_token=SENTINEL_REFRESH_2,
+            access_token=SENTINEL_ACCESS_2,
+            authority_generation=canonical.authority_generation + 1,
+            promotion_target_binding_id=binding_id,
+            promotion_predecessor_refresh_token=canonical.refresh_token,
+            promotion_predecessor_generation=canonical.authority_generation,
+            promotion_compensation_state="compensated",
+        ),
+    )
+    bindings.set_state(binding_id, state="degraded", reason_code="auth_revoked")
+    reconnect = binder.start_reconnect(binding_id)
+    token_calls_before = sum(
+        urlsplit(str(request.url)).path.endswith("/token")
+        for request in provider.requests
+    )
+
+    result = binder.finish_device_connection(reconnect)
+
+    assert result["status"] == "connected"
+    assert store.has_record(pending_id) is False
+    reconnected = store.get(binding_id)
+    assert reconnected is not None
+    assert reconnected.refresh_token == SENTINEL_REFRESH
+    assert reconnected.refresh_token != SENTINEL_REFRESH_2
+    assert bindings.get(binding_id).state == "connected"
+    assert bindings.get(binding_id).reason_code is None
+    assert provider.revoked == []
+    assert (
+        sum(
+            urlsplit(str(request.url)).path.endswith("/token")
+            for request in provider.requests
+        )
+        == token_calls_before + 1
+    )
+
+
 def test_disconnect_promotes_pending_refresh_before_provider_revocation(
     store, bindings, registry
 ):
@@ -2359,6 +2518,69 @@ def test_disconnect_revokes_without_deleting_artifacts(store, bindings, registry
     # Acquired artifacts are never deleted by a disconnect.
     assert raw_store.get_raw_record_by_content_identity("cid-artifact-1") is not None
     assert raw_store.all_raw_records()[0].id == raw_row.id
+
+
+def test_token_provider_queued_behind_disconnect_preserves_terminal_reason(
+    store, bindings, registry
+):
+    provider = _Provider()
+    provider.revoke_release = threading.Event()
+    binder = _binder(provider, store, bindings, registry)
+    connected = _connect_device(binder)
+    binding_id = connected["account"]["binding_id"]
+    source = registry.register(
+        collection_kind="owned_playlist",
+        collection_ref=SYNTH_PLAYLIST_REF,
+        title="Owned",
+        account_binding_id=binding_id,
+    )
+    cursor_before = dict(source.cursor)
+    token_provider = oauth.TokenProvider(
+        binding_id=binding_id,
+        token_store=store,
+        oauth_client=_client(_Provider()),
+        binding_store=bindings,
+        source_registry=registry,
+    )
+    disconnect_results: list[dict] = []
+    consumer_errors: list[BaseException] = []
+    consumer_finished = threading.Event()
+
+    def run_disconnect() -> None:
+        disconnect_results.append(binder.disconnect(binding_id))
+
+    def run_queued_consumer() -> None:
+        try:
+            token_provider.get_access_token()
+        except BaseException as error:
+            consumer_errors.append(error)
+        finally:
+            consumer_finished.set()
+
+    disconnect_thread = threading.Thread(target=run_disconnect)
+    disconnect_thread.start()
+    assert provider.revoke_started.wait(timeout=5)
+    consumer_thread = threading.Thread(target=run_queued_consumer)
+    consumer_thread.start()
+    try:
+        assert consumer_finished.wait(timeout=0.2) is False
+    finally:
+        provider.revoke_release.set()
+    disconnect_thread.join(timeout=5)
+    consumer_thread.join(timeout=5)
+
+    assert disconnect_results[0]["status"] == "disconnected"
+    assert len(consumer_errors) == 1
+    assert isinstance(consumer_errors[0], oauth.AuthDegradedError)
+    assert consumer_errors[0].reason_code == "auth_disconnected"
+    binding = bindings.get(binding_id)
+    assert binding is not None
+    assert binding.state == "degraded"
+    assert binding.reason_code == "auth_disconnected"
+    disabled = registry.get(source.binding_id)
+    assert disabled.enabled is False
+    assert disabled.cursor == cursor_before
+    assert disabled.last_error["reason_code"] == "auth_disconnected"
 
 
 def test_disconnect_preserves_token_when_provider_revoke_fails(store, bindings, registry):

--- a/tests/knowledge_acquisition/test_youtube_oauth.py
+++ b/tests/knowledge_acquisition/test_youtube_oauth.py
@@ -65,6 +65,7 @@ class _Provider:
     def __init__(self) -> None:
         self.requests: list[httpx.Request] = []
         self.token_responses: list[httpx.Response] = []
+        self.revoke_responses: list[httpx.Response] = []
         self.revoked: list[dict[str, str]] = []
         self.device_granted = True
 
@@ -104,6 +105,8 @@ class _Provider:
             )
         if path.endswith("/revoke"):
             self.revoked.append(self._body(request))
+            if self.revoke_responses:
+                return self.revoke_responses.pop(0)
             return httpx.Response(200, request=request, json={})
         return httpx.Response(404, request=request, json={"error": "not_found"})  # pragma: no cover
 
@@ -284,6 +287,43 @@ def test_missing_store_key_fails_closed(store, bindings, registry, monkeypatch):
         store.get(binding_id)
 
 
+@pytest.mark.parametrize("configured_key", [None, "not-valid-hex"])
+def test_connect_token_store_failure_does_not_create_connected_binding(
+    store, bindings, registry, monkeypatch, configured_key
+):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    if configured_key is None:
+        monkeypatch.delenv(tokstore.KEY_ENV_VAR, raising=False)
+    else:
+        monkeypatch.setenv(tokstore.KEY_ENV_VAR, configured_key)
+
+    with pytest.raises(tokstore.TokenStoreKeyMissingError):
+        _connect_device(binder)
+
+    assert bindings.list_all() == ()
+    assert store.binding_ids() == ()
+
+
+def test_failed_first_connect_status_is_not_connected_without_token_record(
+    store, bindings, registry
+):
+    # Models the partial row left by the pre-fix connect ordering. Status must
+    # fail closed even when it encounters that durable state after restart.
+    binding = bindings.create(
+        provider_channel_id=SYNTH_CHANNEL_ID,
+        display_label=SYNTH_CHANNEL_TITLE,
+        scopes=[oauth.SCOPE],
+        account_binding_id="binding-without-token",
+    )
+    assert store.has_record(binding.account_binding_id) is False
+
+    status = _binder(_Provider(), store, bindings, registry).status(binding.account_binding_id)
+
+    assert status["status"] == "degraded"
+    assert status["reason_code"] == "auth_missing"
+
+
 # --- AC4 --------------------------------------------------------------------
 
 
@@ -428,6 +468,44 @@ def test_disconnect_revokes_without_deleting_artifacts(store, bindings, registry
     # Acquired artifacts are never deleted by a disconnect.
     assert raw_store.get_raw_record_by_content_identity("cid-artifact-1") is not None
     assert raw_store.all_raw_records()[0].id == raw_row.id
+
+
+def test_disconnect_preserves_token_when_provider_revoke_fails(store, bindings, registry):
+    provider = _Provider()
+    binder = _binder(provider, store, bindings, registry)
+    result = _connect_device(binder)
+    binding_id = result["account"]["binding_id"]
+    source = registry.register(
+        collection_kind="owned_playlist",
+        collection_ref=SYNTH_PLAYLIST_REF,
+        title="Owned",
+        account_binding_id=binding_id,
+    )
+    provider.revoke_responses.append(
+        httpx.Response(503, json={"error": "temporarily_unavailable"})
+    )
+
+    disc = binder.disconnect(binding_id)
+
+    assert disc == {
+        "status": "disconnect_failed",
+        "revoked": False,
+        "retryable": True,
+        "sources_disabled": 0,
+    }
+    assert store.has_record(binding_id) is True
+    assert store.get(binding_id).refresh_token == SENTINEL_REFRESH
+    assert bindings.get(binding_id).state == "connected"
+    assert bindings.get(binding_id).reason_code is None
+    unchanged_source = registry.get(source.binding_id)
+    assert unchanged_source.enabled is True
+    assert unchanged_source.last_error is None
+
+    retried = binder.disconnect(binding_id)
+    assert retried["status"] == "disconnected"
+    assert retried["revoked"] is True
+    assert store.has_record(binding_id) is False
+    assert registry.get(source.binding_id).enabled is False
 
 
 # --- AC7 --------------------------------------------------------------------


### PR DESCRIPTION
Governing-Issue: #3990

Fixes #3990

## Summary
- prove encryption-key and atomic token-store readiness before a device poll can issue a standing grant; immediately journal returned authority before identity or binding work
- compensate pre-binding failures at Google when revocation is authoritative, otherwise retain an encrypted pending-grant journal with an explicit retry path
- persist OAuth grants under a deterministic per-channel binding id before claiming the account is connected, and preserve that encrypted authority across temporally indeterminate create outcomes
- reconcile visible lost-ack commits and concurrent provider/channel winners without treating negative snapshots as proof that a delayed commit cannot appear
- serialize connect, reconnect, refresh, and disconnect across service instances/processes sharing the channel token store, including aggregate token-file writes and portable POSIX/Windows locking
- disable redirect following at every credential-bearing OAuth POST, independent of the injected `httpx.Client` default
- preserve local revoke authority for every unproven provider outcome; destructive teardown after an error is limited to Google's documented HTTP 400 `invalid_token` result (already expired/revoked)
- keep provider-controlled strings out of exception rendering by admitting only allowlisted OAuth error enums
- update the YSS owner contract and delivery state with the shipped lifecycle, egress, and secret-safety boundaries

## Acceptance Evidence
- `test_connect_token_store_failure_does_not_create_connected_binding` and `test_connect_store_io_preflight_fails_before_provider_poll`: missing/invalid keys and store-I/O failure prevent the token/grant poll entirely
- `test_identity_probe_failure_is_provider_compensated_without_secret_leak`: a post-grant identity failure is authoritatively revoked and no secret-bearing cause reaches exception text
- `test_identity_probe_and_compensation_failure_preserve_encrypted_pending_authority`: an unproven revoke retains an encrypted pending journal and a later retry converges by revoking and deleting it
- `test_pending_journal_write_failure_is_provider_compensated` and `test_pending_write_and_compensation_failure_retry_preserves_authority`: post-grant journal failure either revokes authoritatively or retries the encrypted journal when compensation is unproven
- `test_binding_store_write_failure_leaves_pending_grant_recoverable` and `test_reconnect_write_failure_does_not_mistake_old_token_for_new_grant_durability`: canonical write failure retains the fresh pending grant, and an old reconnect token cannot be mistaken for the new grant's durability
- `test_incomplete_grant_with_refresh_token_is_compensated_not_discarded`: a refresh-bearing incomplete 2xx response remains available for revocation instead of being discarded by parsing
- `test_connect_post_commit_exception_reconciles_without_deleting_token`: a committed insert/lost acknowledgement rolls forward with its token intact
- `test_connect_delayed_commit_after_negative_readbacks_preserves_and_converges`: an insert appearing only after both negative reconciliation snapshots retains the credential and retry converges on the same deterministic binding id
- `test_connect_precommit_binding_failure_preserves_deterministic_retry_authority`: repeated ambiguous first-connect failures reuse one credential identity instead of accumulating random candidates
- `test_disconnect_redirect_never_replays_token_and_preserves_retry_authority`: redirect-enabled injected clients cannot follow 302/307 off the allowlist or replay the revoke token, and local retry authority remains intact
- `test_disconnect_documented_invalid_token_tears_down_local_state`: exact HTTP 400 `invalid_token` permits local teardown with `revoked=false`
- `test_disconnect_unproven_4xx_outcome_preserves_retry_authority`: `invalid_request`, `unsupported_token_type`, unknown/error-body strings, 407, 409, and 499 retain the encrypted credential
- `test_provider_error_enum_is_allowlisted_before_exception_rendering`: arbitrary provider `error` and `error_description` strings cannot enter exception text
- `test_disconnect_and_reconnect_are_serialized_across_service_instances`, the aggregate-file lost-update tests, two-process write test, and Windows lock-backend test preserve lifecycle and file authority across actors/platforms
- status remains fail-closed for a connected row without a usable token record; disconnect never deletes acquired artifacts

## Repair Receipt
- Standard repair rounds: exhausted under the earlier concurrency/interleaving and portability bindings; retained as historical evidence in PR comments
- Capability-escalated repair attempt: 2/2 (final bounded repair)
- Failure domain: `review/auth_transaction_authority_loss`
- Mechanism id: `indeterminate_create_and_revoke_status_authority`
- Superseded exact head: `5e3881f293fd5c737f36f6f1c48d55d804ae8214`
- Repaired exact head: `af7526d98c97b157fa76f247dd98fa9680e12cc2`
- Selected capability: Codex `gpt-5.6-sol`, high reasoning (strongest configured capability)
- Create authority repair: first-connect ids are deterministic; visible committed/concurrent rows roll forward; negative read snapshots never compensate the encrypted credential because a delayed commit may still appear
- Egress repair: all OAuth POSTs force `follow_redirects=false`, including when the injected client is redirect-enabled
- Revoke authority repair: only exact HTTP 400 + allowlisted `invalid_token` authorizes error-path teardown; all intermediary, malformed-request, redirect, transport, and unknown outcomes preserve retry authority
- Secret-safety repair: provider `error` strings are allowlisted before entering exceptions; bodies and descriptions remain structurally excluded
- Outcome: focused OAuth, repository Ruff, MyPy, diff check, and one serialized exact-tree full non-PG run are green; independent final re-review remains required

- New materially distinct standard repair attempt: 1/2
- Failure domain: `review/auth_grant_durability`
- Mechanism id: `grant_before_storage_readiness`
- Superseded exact head: `af7526d98c97b157fa76f247dd98fa9680e12cc2`
- Repaired exact head: `e396d6ce9b5cf528bbd272ee4857694d6e45546d`
- Pre-grant repair: device completion proves encryption key, lock directory, aggregate read, temporary write, atomic replace, and readback before calling the provider token endpoint
- Post-grant repair: fresh authority is encrypted under an opaque device-attempt digest before identity/binding work; authoritative revoke compensates failure, while unproven compensation retains an explicit retryable journal
- Crash/ordering repair: pending-grant lifecycle authority encloses poll → journal → identity → canonical persistence; canonical success precedes best-effort pending cleanup, so a crash can retain a redundant encrypted copy but cannot destroy the only credential
- Reconnect repair: pending cleanup verifies exact new-token equality rather than mere record presence, preventing an old reconnect token from masking a failed new-token write
- Secret-safety repair: durability failures expose only a stable reason and opaque pending id, never identity/backend exception text or provider response bodies
- Outcome: focused OAuth, repository Ruff, MyPy, diff check, and one serialized exact-tree full non-PG run were green; independent review rejected attempt 1 on lost-ack, hidden exception-chain, and crash-durability gaps

- Same-binding standard repair attempt: 2/2
- Failure domain: `review/auth_grant_durability`
- Mechanism id: `grant_before_storage_readiness`
- Superseded exact head: `e396d6ce9b5cf528bbd272ee4857694d6e45546d`
- Repaired exact head: `7520de357ce9b996af489402eb4a10b273b00ae9`
- Exception-boundary repair: sanitized durability failures are raised only after leaving secret-bearing exception handlers; tests prove both `__cause__` and `__context__` are absent
- Lost-ack repair: exact encrypted-record readback preserves a landed pending journal without provider revocation and rolls a landed reconnect token forward as canonical success; a stale pending retry cannot revoke that canonical grant
- Crash-durability repair: aggregate writes fsync the staged file before atomic replace and fsync the parent directory afterward; an injected parent-directory-fsync acknowledgement loss preserves the exact encrypted pending authority
- Lock/crash audit: pending → channel/reconnect → binding → aggregate lock order remains acyclic; canonical success still precedes best-effort pending cleanup, so crash residue is redundant authority rather than authority loss
- Outcome: focused OAuth, repository Ruff, MyPy, diff check, and one serialized exact-tree full non-PG run are green; standard repair attempt 2/2 is ready for independent final review

- Capability-escalated repair attempt: 1/2
- Stable review binding: `review/auth_grant_durability::grant_before_storage_readiness`
- Failure domain: `review/auth_grant_durability`
- Mechanism id: `grant_before_storage_readiness`
- Superseded exact head: `7520de357ce9b996af489402eb4a10b273b00ae9`
- Repaired exact head: `9122133838baac04c5fe0f5d44f3e5c7c49eba83`
- Selected capability: Codex `gpt-5.6-sol`, high reasoning (strongest configured capability)
- Canonical-aware retry repair: pending, provider-channel, and sorted binding lifecycle locks make retry re-read canonical authority; same-token or same-channel canonical success deletes only redundant pending state and never revokes the live grant, including after later token rotation
- Key-binding repair: a fixed AEAD canary cryptographically binds the configured key to the aggregate before `/token`; legacy aggregates verify every encrypted record before installing the canary, so a valid wrong key or mixed-key aggregate fails closed without mutation
- Durability repair: a visible readback after parent-directory fsync failure is not accepted as crash-durable; confirmation must complete a successful directory barrier or compensation preserves retryable pending authority
- Portability and secret-safety audit: POSIX staged-file fsync + atomic replace + directory fsync and Windows `MoveFileExW` replace + write-through preserve the same contract; malformed, wrong-key, and tampered records expose only stable sanitized errors
- Status repair: status decrypts the canonical record and degrades undecryptable authority to `auth_key_missing`; it cannot report an unreadable token as connected
- Outcome: focused OAuth, repository Ruff, MyPy, diff check, and the serialized exact-tree full non-PG retry are green; escalated repair attempt 1/2 is ready for independent final review

- Capability-escalated repair attempt: 2/2 (final)
- Stable review binding: `review/auth_grant_durability::grant_before_storage_readiness`
- Failure domain: `review/auth_grant_durability`
- Mechanism id: `grant_before_storage_readiness`
- Superseded exact head: `9122133838baac04c5fe0f5d44f3e5c7c49eba83`
- Repaired exact head: `23c915b8411899a17bc2a8cef46e78be6ae96c4b`
- Selected capability: Codex `gpt-5.6-sol`, high reasoning (strongest configured capability)
- Promotion-evidence repair: each encrypted pending grant records its exact target binding, predecessor refresh authority, and authority generation; retry promotes only over that exact predecessor/generation and cannot infer success from a same-channel row alone
- Conflict repair: a same-channel token mismatch or newer canonical generation is retained as `pending_conflict`; retry neither deletes nor revokes either authority, and a newer pending refresh transaction prevents an older grant retry from overwriting it
- Regression evidence: canonical-write-failure followed by retry promotes over the exact predecessor, while a rotated/newer canonical grant remains intact with the pending grant preserved for explicit reconciliation
- Outcome: focused OAuth, repository Ruff, MyPy, diff check, and the serialized full non-PG validation are green; capability-escalated repair attempt 2/2 is final and ready for independent review

- New materially distinct standard repair attempt: 1/2
- Stable review binding: `review/auth_refresh_rotation::refresh_rotation_authority_loss`
- Failure domain: `review/auth_refresh_rotation`
- Mechanism id: `refresh_rotation_authority_loss`
- Superseded exact head: `9122133838baac04c5fe0f5d44f3e5c7c49eba83`
- Repaired exact head: `23c915b8411899a17bc2a8cef46e78be6ae96c4b`
- Contract basis: Google's standard offline refresh flow returns a new access token from the stored long-lived refresh credential; the implementation additionally fails safe if an adversarial or nonstandard provider response rotates the refresh token ([Google OAuth web-server contract](https://developers.google.com/identity/protocols/oauth2/web-server#offline))
- Rotation transaction repair: token-store readiness is proven before `/token`; a different returned refresh token is durably encrypted in a deterministic pending-refresh journal with exact predecessor/generation evidence before canonical promotion
- Recovery repair: canonical write failure leaves `refresh_pending` authority and a sanitized error; the next access promotes without another provider call only when the exact predecessor still governs, while a different/newer canonical token yields `refresh_conflict` and preserves both authorities
- Lifecycle repair: status degrades to `auth_refresh_pending`; reconnect and disconnect resolve or fail closed on pending refresh authority under the binding lock before provider polling or revocation, and public errors expose only stable reason codes
- Compensation and secret-safety repair: journal failure retries the encrypted write and provider-compensates only when authority is proven; secret-bearing provider/backend exception chains remain excluded
- Outcome: focused OAuth, repository Ruff, MyPy, diff check, and the serialized full non-PG validation are green; materially distinct standard repair attempt 1/2 is ready for independent review



## Validation
- `pytest -q tests/knowledge_acquisition/test_youtube_oauth.py` — 76 passed in 1.83s on the complete refresh-rotation repair content
- `ruff check app tests` — All checks passed
- `mypy app` — Success: no issues found in 790 source files
- `git diff --check` — passed
- First escalated `pytest -q -m "not pg"` attempt — 5 startup-contract failures caused only by the host disk guard (482–494 MiB free versus 1,024 MiB required); 10,263 passed and no OAuth test failed; no publication followed that environmental failure
- Authorized clean retry `pytest -q -m "not pg"` — 10,268 passed, 38 skipped, 272 deselected, 18 xfailed, 1,106 warnings in 470.12s (0:07:50), exit 0, using task-specific `PYTEST_DEBUG_TEMPROOT=/tmp/yss-3990-escalated1-retry.XukpNb` (PID 12734; start 2026-07-20 03:35:06 Europe/Stockholm)

- Final serialized `pytest -q -m "not pg"` — 10,273 passed, 38 skipped, 272 deselected, 18 xfailed, 1,106 warnings in 447.32s (0:07:27), exit 0, using unique `PYTEST_DEBUG_TEMPROOT=/tmp/yss-3990-escalated2-refresh1-full.LoAn2l` (PID 99203; start Mon Jul 20 04:25:45 2026 Europe/Stockholm); this was the single authorized full run for the final repair
- Publication rebase evidence — clean, conflict-free rebase onto exact `origin/main` `61aa6357601cc952e1d9e1bd6425d4ad0e5c2c7d`; upstream changed none of the six #3990-owned files since the prior merge base, so the authorized once-green full receipt was carried forward without a second full run
- Branch-truth evidence — mandatory pre-commit and pre-push `agent_workspace_preflight.sh --allow-dirty` gates both exited 0 in isolated worktree `/Users/rasmus/worktrees/yss-issue-3990`; remote publication used an exact `--force-with-lease` against prior head `9122133838baac04c5fe0f5d44f3e5c7c49eba83`


## BuilderOps Routing
- Records/projections/receipts: LearningSignal `lrn_20260719051454_c578017b`; verified dispatcher lease `lease-1204ed68` for task `github-RasmusTho--agentic-pkm-mvp-issue-3990`
- Reason: the existing LearningSignal owns the review-workflow divergence; this bounded final repair remained inside the governing Issue and required no new BuilderOps record

## Claim Receipt
- `issue=3990 branch=codex/issue-3990-yss-oauth-lifecycle worktree=/Users/rasmus/worktrees/yss-issue-3990 coordination_mode=dispatcher-backed fallback_reason=none task_id=github-RasmusTho--agentic-pkm-mvp-issue-3990 lease_id=lease-1204ed68 holder=yss-3990-sol evidence=verified-dispatcher-lease`
- Dispatcher readback after initial publication: task `completed`, `claimed_by=null`, `lease_id=null`; no repair-time reacquisition or issue-label mutation was needed

## SBS Impact
- Primary subsystem: Product/Runtime System / Knowledge Acquisition Platform
- Secondary boundary: settings/local secret provisioning and Google OAuth device/token/revoke egress
- Write class: authority-bearing runtime credential lifecycle state
- Authority/persistence impact: no grant poll occurs before storage readiness; issued grants are journaled before fallible finalization; a connected binding requires durable encrypted token authority; ambiguous create/revoke outcomes preserve that authority, while exact provider confirmation allows teardown
- Human knowledge, memory, retrieval, and derived/rebuildable impact: none
- Contract impact: strengthens INV-YSS-4 and INV-YSS-5 without adding a trust tier or plaintext path
- Deployment impact: code behavior changes for future releases; this PR performs no deploy, migration, restart, or channel mutation

## Owner-doc Resolution
- Updated `docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md` with pre-grant storage readiness, fsync/replace crash ordering, exact lost-ack readback authority, pending-grant recovery, deterministic create recovery, redirect refusal, provider-authoritative revoke classification, and allowlisted error rendering
- Updated `docs/YOUTUBE_SOURCE_SYNC/BIND_YOUTUBE_ACCOUNT_WITH_OAUTH.md` with the shipped lifecycle and crash-durability behavior
- Updated `docs/YOUTUBE_SOURCE_SYNC/README.md` to record the same INV-YSS-4 behavior

- Same-binding standard repair attempt: 2/2
- Stable review binding: `review/auth_binding_commit_durability::orphan_candidate_grant_authority`
- Failure domain: `review/auth_binding_commit_durability`
- Mechanism id: `binding_commit_orphan_authority`
- Superseded exact head: `23c915b8411899a17bc2a8cef46e78be6ae96c4b`
- Repaired exact head: `7cf92f0a9bee10e10d8bd7c3885ae68979b654c1`
- Attempt-1 disposition: the first focused-green tree was not published after review found that preserved candidate authority could remain permanently `binding_pending` after a definite precommit failure; its full-suite result is retained as pre-repair evidence only
- Authority repair: an indeterminate first-connect candidate never deletes its per-attempt encrypted journal; later distinct grants retain separate handles and cannot overwrite the candidate or a different/newer same-channel canonical generation
- Liveness repair: the encrypted pending record carries the display metadata needed to retry the same deterministic binding-row create after the database recovers, without polling Google for another grant
- Convergence repair: delayed exact rows roll forward; a definite precommit failure recreates the original candidate row; a different same-channel winner remains a non-destructive conflict without token overwrite or provider revocation
- Regression evidence: `test_definite_precommit_failure_retry_creates_binding_from_original_grant`, `test_indeterminate_first_connect_keeps_distinct_grants_retryable_until_delayed_commit`, and `test_indeterminate_first_connect_never_overwrites_newer_same_channel_winner`
- Outcome: focused OAuth 79 passed; repository Ruff, MyPy, diff check, and the one serialized exact-tree full non-PG run are green; standard repair attempt 2/2 is ready for independent review

- New materially distinct standard repair attempt: 1/2
- Stable review binding: `review/docs_shipped_truth::yss_readme_stale_children`
- Failure domain: `review/docs_shipped_truth`
- Mechanism id: `youtube_sync_delivery_state_reconciliation`
- Superseded exact head: `23c915b8411899a17bc2a8cef46e78be6ae96c4b`
- Repaired exact head: `7cf92f0a9bee10e10d8bd7c3885ae68979b654c1`
- Delivery-state repair: the YSS directory state line, task table, and GitHub relationship section now mark YSS-03 (#3918 / PR #4006) and YSS-04 (#3919 / PR #3983) repository-verifiably delivered
- Acceptance boundary: YSS-05..YSS-11 and parent #3915 operator/live-capability acceptance remain explicitly pending; no live/shipped-operator claim was added
- Outcome: owner-doc truth now matches repository delivery state on exact repaired head; standard repair attempt 1/2 is ready for independent review

- Final binding-commit repair `pytest -q tests/knowledge_acquisition/test_youtube_oauth.py` — 79 passed in 1.52s
- Final binding-commit repair `ruff check app tests` — All checks passed
- Final binding-commit repair `mypy app` — Success: no issues found in 792 source files
- Final binding-commit repair `git diff --check` — passed
- Pre-attempt-2 serialized `pytest -q -m "not pg"` — 10,312 passed, 38 skipped, 273 deselected, 18 xfailed, 1,106 warnings in 445.44s, exit 0; retained as pre-repair evidence only after liveness review rejected that tree
- Final exact-head serialized `pytest -q -m "not pg"` — 10,313 passed, 38 skipped, 273 deselected, 18 xfailed, 1,106 warnings in 435.75s (0:07:15), exit 0, using task-specific `PYTEST_DEBUG_TEMPROOT=/tmp/yss-3990-binding-orphan-attempt2-full.N43fmr`
- Final publication evidence — mandatory pre-commit and pre-push `agent_workspace_preflight.sh --allow-dirty` gates both exited 0 in isolated worktree `/Users/rasmus/worktrees/yss-issue-3990`; untracked `runtime/` remained untouched
- Capability-escalated repair attempt: 1/2
- Stable review binding: `review/auth_binding_commit_durability::orphan_candidate_grant_authority`
- Failure domain: `review/auth_binding_commit_durability`
- Mechanism id: `binding_commit_orphan_authority`
- Superseded exact head: `7cf92f0a9bee10e10d8bd7c3885ae68979b654c1`
- Repaired exact head: `db5db85fc2edbd04cd999a214a8a98c3e3cafc78`
- Selected capability: Codex `gpt-5.6-sol`, high reasoning (strongest configured capability)
- Prior context supplied: both standard repairs, the pending-only crash reproduction, lost-ack/delayed-commit/same-channel authority tests, and the complete historical repair-budget record in this body
- Authority-order repair: a pending-only retry proves canonical token crash durability before creating a binding row whose default state claims `connected`; a failed canonical write leaves the encrypted pending journal intact and creates no row
- Liveness preservation: when an older canonical predecessor already exists, its deterministic row is recovered before a distinct later pending grant may replace it, so failed row recovery preserves both authorities; lost acknowledgements, delayed commits, and exact same-channel convergence remain non-destructive
- Regression evidence: `test_pending_only_retry_canonical_failure_does_not_create_connected_binding` plus the explicit lost-ack, definite-precommit, delayed-commit, distinct-grant, and newer-winner adjacency set
- Outcome: focused OAuth/adjacent, repository Ruff, MyPy, diff check, and the single authorized exact-tree full non-PG run are green; capability-escalated attempt 1/2 is ready for independent review

- New materially distinct standard repair attempt: 1/2
- Stable review binding: `review/auth_refresh_degradation::reason_code_registry_mismatch`
- Failure domain: `review/auth_refresh_degradation`
- Mechanism id: `reason_code_registry_mismatch`
- Superseded exact head: `7cf92f0a9bee10e10d8bd7c3885ae68979b654c1`
- Repaired exact head: `db5db85fc2edbd04cd999a214a8a98c3e3cafc78`
- Vocabulary repair: the account-binding validator now admits the contract-owned `auth_refresh_pending`, `auth_refresh_conflict`, and `auth_refresh_durability` reasons emitted by OAuth refresh recovery
- Producer repair: both TokenProvider canonical-promotion failure paths stamp `auth_refresh_pending`; conflict and durability paths now persist their registered reason on the binding and dependent authenticated sources without mutating source cursors
- Secret-safety evidence: TokenProvider conflict/durability regressions assert the sanitized `OAuthGrantDurabilityError`, empty hidden exception chain, preserved encrypted authority, binding degradation, dependent-source degradation, and absence of planted secret text
- Owner-doc truth: the YSS task, normative source-sync contract, and capability README now state the canonical-before-row ordering distinction and registered binding/source refresh degradation vocabulary
- Outcome: new standard attempt 1/2 is focused/full green and ready for independent review

- Final repaired-head `pytest -q tests/knowledge_acquisition/test_youtube_oauth.py` — 82 passed in 1.79s
- Final repaired-head expanded OAuth/API/registry selection — 129 passed in 1.60s
- Final repaired-head `ruff check app tests companion-ui/companion-app` — All checks passed
- Final repaired-head `mypy app` — Success: no issues found in 792 source files
- Final repaired-head `git diff --check` — exit 0
- Final exact-tree `pytest -q -m "not pg"` — 10,316 passed, 38 skipped, 273 deselected, 18 xfailed, 1,106 warnings in 506.39s (0:08:26), direct exit 0, using task-specific `PYTEST_DEBUG_TEMPROOT=/tmp/yss-3990-orphan-escalated1.QDOFdW`
- Publication evidence — mandatory pre-commit and pre-push branch-truth gates exited 0 in `/Users/rasmus/worktrees/yss-issue-3990`; only the six #3990-owned files were committed, pre-existing untracked `runtime/` remained untouched, and no deploy, merge, or lifecycle mutation was performed

## Final rebase and pre-publication evidence — 2026-07-20
- Final exact head: `11546bc2956ae391d605e5a2ed45049effa4d8ae`, rebased onto exact `origin/main` `dfab525e913ed16c8e5aea22531f6bfbbaae8914` (merged #3964).
- Publication ancestry repair: all 11 #3990 commits were replayed. The semantic merge driver auto-resolved the shared `docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md` overlap by initially preferring #3964 and dropping #3990's OAuth contract block; the loss was detected from the changed diff/file inventory. The final commit was amended only with the combined owner doc: exact #3990 OAuth authority plus #3964's accepted-settings/receipt/watcher paragraph.
- Diff integrity: full stable patch-id before/after is identical at `3f82a4880e8978d2d4dd3da0c2497b66900dca74`. The raw full-diff SHA-256 changed from `eeaab048e59c9761bf83488719a2bde9628b47d6d2861673d4a4ae6e7cbc1979` to `1abc9e1f0f776b24946ea43105800dcb5049e830e94a5f91cc816828392eb22f` only because the shared owner-doc context moved into the new base. The six non-overlapping files remained byte-identical at SHA-256 `b157c12fe5fd9aa183c956ba2e6e208b9efa19e809f29002229ae278fa00fffe` and stable patch-id `da9e4f83a2ea0faa97a8c850a37d85199b5c70c0`.
- Cross-impact with #3964: no #3990 diff file overlaps #3964's `app/{receipts,vault,watcher}` or `tests/{architecture,properties,vault,watcher}` surfaces. The only shared file was the owner doc. Two minimal YSS settings/receipt integration nodes passed.
- Exact repaired regressions: 3 passed. Expanded OAuth/API/registry selection: 129 passed. OAuth egress/redaction/security selection: 8 passed. Repository security selection: 1 passed. High-confidence credential-signature scan over all seven changed files found no matches; no dedicated `gitleaks`, `detect-secrets`, `bandit`, `trufflehog`, or `semgrep` executable was installed.
- Static evidence on exact head: `ruff check app tests companion-ui/companion-app` passed; `mypy app` passed across 793 source files; `git diff --check` passed; branch-truth preflight passed in the isolated worktree.
- Final-head full attempt 1 was not used as acceptance evidence: one out-of-scope dispatcher timing test failed while 10,355 tests passed in an unusually slow 1,030.16s host run. The exact node then passed once in isolation and five consecutive explicit repetitions (0.23–0.36s each). Failure mechanics were the test's fixed 0.5s worker-join expiring before the heartbeat thread ran (`terminate_calls=0`, `wait_calls=0`); open bug #4012 owns load-stable authority-loss test synchronization. #4009's temp-root collision was not involved because each run used a unique root.
- Authorized clean retry on unchanged exact head: `pytest -q -m "not pg"` → 10,356 passed, 38 skipped, 273 deselected, 18 xfailed, 1,106 warnings in 425.69s (0:07:05), direct exit 0, 2026-07-20 09:55:41–10:02:49 CEST. Repeated process censuses observed no competing full-suite process; the exact 413 MiB temporary root was removed after success.
- Final remote gate: immediate fetch kept `origin/main` at exact `dfab525e913ed16c8e5aea22531f6bfbbaae8914`, local/tested HEAD at exact `11546bc2956ae391d605e5a2ed45049effa4d8ae`, and remote branch at lease value `db5db85fc2edbd04cd999a214a8a98c3e3cafc78`. The mandatory branch-truth gate exited 0 before the exact force-with-lease update.
- Repair budgets remain unchanged by ancestry integration: `review/auth_binding_commit_durability::orphan_candidate_grant_authority` remains capability-escalated attempt 1/2; `review/auth_refresh_degradation::reason_code_registry_mismatch` remains materially-distinct standard attempt 1/2. The semantic owner-doc rebase resolution and #4012 test-flake classification consumed no reviewer repair attempt.
- Publication only: remote branch advanced under exact force-with-lease from `db5db85fc2edbd04cd999a214a8a98c3e3cafc78` to `11546bc2956ae391d605e5a2ed45049effa4d8ae`. No deploy, merge, issue/dispatcher transition, review-thread resolution, or other lifecycle mutation was performed.

## Bounded recovery publication — 2026-07-20

- Exact published head: `0a8bddbf29f79379030918d8f3d9e2613a0ab3f9`, rebased onto `origin/main` `5f37c2fe1610b6ba518a99f7a2943ca7c1c9c9d2`.
- `redirect_uri_validation` and `postcanonical_reconnect_state_failure` are repaired at standard attempt 2/2.
- `grant_before_storage_readiness` remains `blocked_technical` after its existing 2 standard + 2 capability budget; the bounded Sol/xhigh recovery did not reset it and added full first-use parent-chain fsync durability.
- Focused: OAuth 95 passed; OAuth/API/registry 142 passed. Ruff, MyPy (793 files), and diff check passed.
- New explicitly exclusive exact-SHA full proof: 10,369 passed, 38 skipped, 273 deselected, 18 xfailed, rc 0 in 424.12s.
- Durable receipt: https://github.com/RasmusTho/agentic-pkm-mvp/pull/3995#issuecomment-5022796854
- Current-head CI and two fresh independent Sol/high clean reviews remain required before verification-and-closure.

## Review-race repair publication — exact head 15ed45ff

- Published exact head: `15ed45ffa065ebd657dbd8cf81724351aac58dad`.
- Repairs: raw loopback delimiter/control rejection; non-promotable encrypted refresh-compensation state; binding-locked degradation classification/write.
- Evidence: OAuth 107 passed; adjacent 154 passed; Ruff/MyPy/diff green; exclusive full suite 10,381 passed, rc 0.
- Durable receipt: https://github.com/RasmusTho/agentic-pkm-mvp/pull/3995#issuecomment-5023383684
- Current-head CI and two fresh independent Sol/high clean reviews remain required.


## Terminal-state recovery publication — exact head af3bc472

- Exact published head: `af3bc472956a09c819ed3387ca5866ea4d035a61`, rebased onto `origin/main` `0fe1377d803cbc651092295dff8b85a933df25fa`.
- Durable reject receipt for superseded head `1f47c1d0`: https://github.com/RasmusTho/agentic-pkm-mvp/pull/3995#issuecomment-5023895623
- `review/auth_refresh_compensation_convergence::compensated_refresh_residue_misclassified_and_stranded` — standard attempt 2/2: TokenProvider now enforces `auth_revoked` even with fresh canonical ciphertext, and binder cleanup persists revoked binding/source truth before deleting the compensated journal.
- `review/auth_disconnect_crash_durability::provider_revoke_before_local_disconnect_marker` — standard attempt 1/2: disconnect durably persists fail-closed `auth_disconnected` before provider revoke; ciphertext retained after crash/indeterminate response is revocation-retry authority only.
- `review/auth_reconnect_state_convergence::disconnected_reconnect_postcanonical_state_failure` — standard attempt 1/2: queued consumers remain blocked after canonical write until the binding row converges, and exact canonical retry recovers an `auth_disconnected` row instead of stranding it as first-connect conflict.
- `review/auth_grant_durability::grant_before_storage_readiness` remains `blocked_technical` at the existing exhausted 2 standard + 2 capability budget; no reset.
- Exact focused evidence:
  - `pytest -q tests/knowledge_acquisition/test_youtube_oauth.py` — 115 passed.
  - `pytest -q tests/knowledge_acquisition/test_youtube_oauth.py tests/knowledge_acquisition/test_youtube_api_client.py tests/knowledge_acquisition/test_youtube_fetch.py` — 161 passed.
  - `ruff check app tests` — passed.
  - `mypy app` — passed across 793 source files.
  - `git diff --check` — passed.
- Exact Verify/regression nodeids:
  - `tests/knowledge_acquisition/test_youtube_oauth.py::test_compensated_refresh_cleanup_keeps_repeated_consumers_fail_closed`
  - `tests/knowledge_acquisition/test_youtube_oauth.py::test_compensated_refresh_cleanup_persists_revoked_before_marker_removal`
  - `tests/knowledge_acquisition/test_youtube_oauth.py::test_disconnect_crash_after_provider_revoke_keeps_cached_token_fail_closed`
  - `tests/knowledge_acquisition/test_youtube_oauth.py::test_disconnected_reconnect_postcanonical_failure_blocks_until_retry`
- First exclusive full attempt was non-accepting: 10,396 passed with one 30-second timeout in `test_start_full_system_exports_vcs_ref_for_compose_build`; the exact node then passed alone in 23.90s.
- Authorized exclusive unchanged-SHA retry: `pytest -q -m "not pg"` — 10,397 passed, 38 skipped, 273 deselected, 18 xfailed, rc 0 in 798.94s.
- Publication evidence: post-full fetch kept `origin/main` unchanged and ancestor; mandatory pre-push branch-truth gate passed in the isolated worktree; exact force-with-lease advanced remote head from `1f47c1d0` to `af3bc472`.
- Current-SHA CI and two entirely new independent Sol/high clean reviews are required before verification-and-closure.


## Final terminal-authority capability repair — exact head 8909c51f

- Exact published head: `8909c51f9fa10c0cb5c063169f7ae998463ce938`; exact base: `0fe1377d803cbc651092295dff8b85a933df25fa`.
- Superseded/rejected head: `af3bc472956a09c819ed3387ca5866ea4d035a61`; reject receipt: https://github.com/RasmusTho/agentic-pkm-mvp/pull/3995#issuecomment-5024449347
- `review/auth_refresh_compensation_convergence::partial_source_degradation_never_converges` — bounded Sol/xhigh capability attempt 1/2 after standard 2/2 exhaustion, no budget reset. Compensation journal deletion now follows durable binding plus all-source convergence; partial writes retain the journal and expose sanitized retry authority.
- `review/auth_terminal_authority::pending_cleanup_resurrects_terminal_state` — standard attempt 1/2. A pending reconnect records exact predecessor binding `updated_at`; retry may clear terminal state only when that CAS-style version evidence matches. Stale redundant journals are cleanup-only.
- `review/auth_reconnect_state_convergence::positive_connected_authority_missing` — standard attempt 2/2. TokenProvider requires the binding store and positive durable `connected` authority before returning cached or refreshed tokens.
- `review/auth_status_projection::terminal_reason_loses_to_key_failure` — standard attempt 1/2. Persisted `auth_disconnected`/`auth_revoked` wins over transient key/read projection.
- Exact regression nodes:
  - `tests/knowledge_acquisition/test_youtube_oauth.py::test_reconnect_postcanonical_state_failure_preserves_pending_until_state_converges`
  - `tests/knowledge_acquisition/test_youtube_oauth.py::test_stale_pending_cleanup_cannot_resurrect_terminal_binding`
  - `tests/knowledge_acquisition/test_youtube_oauth.py::test_repeated_consumer_converges_partial_terminal_source_degradation`
  - `tests/knowledge_acquisition/test_youtube_oauth.py::test_api_entrypoint_retry_converges_compensated_refresh_sources_before_journal_delete`
  - `tests/knowledge_acquisition/test_youtube_oauth.py::test_terminal_status_precedes_missing_key_for_disconnect_retry_authority`
  - `tests/knowledge_acquisition/test_youtube_oauth.py::test_token_provider_requires_binding_authority_dependency`
- Focused evidence: OAuth 121; OAuth/API/fetch 167; `ruff check app tests`, `mypy app` (793 files), and `git diff --check` passed.
- Host-serialized exact-SHA `pytest -q -m "not pg"`: 10,403 passed, 38 skipped, 273 deselected, 18 xfailed, rc 0 in 645.27s.
- Publication: post-full fetch kept base unchanged/ancestor; branch-truth gate passed; remote advanced from `af3bc472` to `8909c51f`.
- Current-SHA CI and two entirely new independent Sol/high clean reviews remain mandatory before verification-and-closure.
## Capability-escalated compensation-convergence repair — exact head 8909c51f

- Capability-escalated repair attempt: 1/2
- Stable review binding: review/auth_refresh_compensation_convergence::compensated_refresh_residue_misclassified_and_stranded
- Failure domain: review/auth_refresh_compensation_convergence
- Mechanism id: compensated_refresh_residue_misclassified_and_stranded
- Superseded reviewed head: af3bc472956a09c819ed3387ca5866ea4d035a61
- Repaired exact head: 8909c51f9fa10c0cb5c063169f7ae998463ce938
- Selected capability: Codex gpt-5.6-sol, high reasoning (capability-escalated context)
- Prior context supplied: the standard-attempt 2/2 rejection, exact partial source-write reproduction, terminal binding/source authority contract, compensated-journal ordering, and prior repair history in this PR body
- Convergence repair: auth_revoked/auth_disconnected binding truth is reconciled idempotently onto every dependent source before any compensated refresh journal cleanup; terminal state is checked before refresh-journal promotion
- Failure repair: a partial binding/source persistence failure returns a detached sanitized durability error and retains the encrypted journal for retry
- Production-entrypoint regression: one dependent-source write failure through YouTubeApiClient.get_my_channel() retains the compensated journal; retry proves source auth_revoked before journal deletion and makes no Data API request
- Focused evidence: compensated convergence adjacency 5 passed; complete OAuth file 121 passed
- Static evidence: ruff check app tests passed; mypy app passed across 793 files; git diff --check passed
- Authorized exact-tree full receipt: pytest -q -m "not pg" completed rc 0 with 10,403 passed and no overlapping host-global suite
- Publication evidence: post-full fetch kept origin/main at 0fe1377d803cbc651092295dff8b85a933df25fa and ancestor of the exact head; isolated-worktree branch-truth gate passed; canonical push confirmed the remote branch already equals 8909c51f9fa10c0cb5c063169f7ae998463ce938
- Outcome: capability-escalated attempt 1/2 is published; current-head CI and two entirely new independent Sol/high clean reviews remain required before merge/closure

## Final generation-CAS and compensation-marker repair — exact head 53f4fe51

Durable repair/publication receipt — exact published SHA `53f4fe51af3fd8ae11f320a3b515a9898cda66b6`

- Superseded rejected SHA: `8909c51f9fa10c0cb5c063169f7ae998463ce938`.
- Durable reject receipt: https://github.com/RasmusTho/agentic-pkm-mvp/pull/3995#issuecomment-5024901770
- `review/auth_terminal_authority::pending_cleanup_resurrects_terminal_state` — same-binding standard attempt 2/2: terminal reversal now requires atomic durable `binding_generation` CAS in both same-token cleanup and distinct-token promotion; wall-clock `updated_at` is observational only. Stale distinct authority remains conflict; exact matching-generation disconnected reconnect promotes.
- `review/auth_status_projection::terminal_reason_loses_to_key_failure` — same-binding standard attempt 2/2: persisted `auth_disconnected`/`auth_revoked` returns before every token-store projection read, including ordinary I/O failure.
- `review/auth_refresh_compensation_convergence::compensated_refresh_residue_misclassified_and_stranded` — capability attempt 2/2: provider compensation must have a confirmed durable `compensated` marker before terminal degradation/cleanup; marker write or acknowledgement loss retains retryable `pending` authority, and TokenProvider plus binder reconnect/disconnect recover it idempotently.
- Invariant→producers: original YSS-02 migration produces `binding_generation`; forward-only head migration `e1f2a3b4c5d6` upgrades already-stamped databases; memory/Postgres state writes increment generation; runtime schema preflight fail-louds if BIGINT NOT NULL generation is absent.
- Focused evidence: exact reviewer/recovery selection 11 passed; OAuth/API/fetch 173 passed; final OAuth 127 passed; `ruff check app tests`, `mypy app` (794 files), `git diff --check`, and single-head Alembic graph passed.
- PG evidence: `DATABASE_URL=<isolated pgvector/Postgres 16 scratch service> pytest -q -m pg tests/knowledge_acquisition/test_youtube_account_binding_pg.py` → 2 passed in 5.33s on exact SHA. Tests prove generation create/increment/stale-CAS no-mutation, existing-resource backfill/schema shape, and forward-only downgrade. The task-specific container used a dynamic localhost port and was removed immediately after success with no persistent volume or deploy.
- Host-serialized exact-SHA full: `pytest -q -m "not pg"` → 10,409 passed, 38 skipped, 274 deselected, 18 xfailed, 1,106 warnings, rc 0 in 755.19s; clone fixture resolved without intervention, no overlap.
- Publication evidence: post-full fetch kept `origin/main` at `0fe1377d803cbc651092295dff8b85a933df25fa` and ancestor; isolated-worktree pre-push branch-truth passed; remote advanced fast-forward from `8909c51f` to exact `53f4fe51`.
- `review/auth_grant_durability::grant_before_storage_readiness` remains separately `blocked_technical` at unchanged exhausted 2 standard + 2 capability; no budget reset.

Current-SHA CI and two entirely new independent Sol/high clean reviews remain mandatory before verification-and-closure.

## Rebased final publication — exact head 8c2a4fb4

- Exact published head: `8c2a4fb40fe898238a8e5f81a5238f5c8b4e1237`; exact base: `c24a0b08349dc5faefd6473721a2634e3bf8c243`.
- Rebase incorporated delivered runtime-start stability prerequisite #4025; no #3990 repair budget was reset.
- Focused evidence: OAuth 133 passed; exact AC selection 4 passed; API/fetch adjacency 46 passed.
- Static evidence: `ruff check app tests`, `mypy app` (794 source files), and `git diff --check` passed.
- PG/migration evidence: isolated pgvector/Postgres 16 scratch run of `tests/knowledge_acquisition/test_youtube_account_binding_pg.py` passed 2/2 in 5.27s; the temporary container was removed after the run.
- Evidence-safe host-serialized exact-SHA full: `pytest -q -m "not pg"` → 10,421 passed, 38 skipped, 274 deselected, 18 xfailed, 1,106 warnings, rc 0 in 775.04s; three clean pre-run censuses and no overlap. An earlier same-SHA rc0 run is explicitly excluded because an external suite began after its reservation opened.
- Publication evidence: post-full fetch kept `origin/main` at the exact base and merge-base; isolated-worktree branch-truth passed immediately before an exact force-with-lease from `53f4fe51` to `8c2a4fb4`.
- Current-SHA CI and two entirely new independent Sol/high clean reviews remain mandatory before verification-and-closure.

## Sol/xhigh four-mechanism review repair — exact head e6aadae2

- Exact published head: `e6aadae257fa6c36ce27a07efb8e4ebea8fbc643`; exact base: `c24a0b08349dc5faefd6473721a2634e3bf8c243`.
- Superseded rejected head: `8c2a4fb40fe898238a8e5f81a5238f5c8b4e1237`; reject receipt: https://github.com/RasmusTho/agentic-pkm-mvp/pull/3995#issuecomment-5027835636
- Durable repair/publication receipt: https://github.com/RasmusTho/agentic-pkm-mvp/pull/3995#issuecomment-5028104100
- Repairs detach credential-bearing transport exceptions, converge binding/source state before refresh-journal deletion, retain rotated authority from incomplete 2xx responses, and recover only exact non-terminal `auth_key_missing` while terminal authority wins.
- Focused evidence: exact regressions plus terminal CAS 5 passed; OAuth/source-registry/API adjacency 186 passed; Ruff, MyPy (794 files), and diff check passed.
- Live PG evidence: shared source-registry contract 1 passed on isolated pgvector/PostgreSQL 16; container removed.
- Evidence-safe exclusive exact-SHA full: 10,427 passed, 38 skipped, 274 deselected, 18 xfailed, 1,106 warnings, rc 0 in 1103.68s; no overlap.
- Post-full base and branch-truth gates passed; publication advanced exact remote lease `8c2a4fb4` to `e6aadae2`.
- `grant_before_storage_readiness` remains `blocked_technical` at unchanged exhausted 2 standard + 2 capability; no reset.
- Current-SHA CI and two entirely new independent Sol/high clean reviews remain mandatory.