### PR TITLE
Fix denied model adapter cleanup

### DIFF
--- a/app/builderops/model_inquiry_adapters.py
+++ b/app/builderops/model_inquiry_adapters.py
@@ -7,10 +7,12 @@ import os
 import selectors
 import signal
 import subprocess
+import sys
 import tempfile
 import time
+from ctypes import CDLL, Structure, byref, c_char, c_int32, c_uint32, c_uint64, sizeof
 from dataclasses import dataclass
-from typing import Any, Mapping, Protocol
+from typing import Any, Mapping, Never, Protocol
 
 import requests  # type: ignore[import-untyped]  # third-party lib ships no type stubs
 
@@ -20,6 +22,7 @@ from app.builderops.models import BuilderOpsValidationError
 ADAPTER_CONFIG_ENV = "BUILDEROPS_INQUIRY_ADAPTERS_JSON"
 ROLE_NAMES = ("fable", "gpt_codex")
 SUBSCRIPTION_ADAPTER_TIMEOUT_EXIT_CODE = 124
+CLEANUP_TIMEOUT_SECONDS = 2.0
 ADAPTER_FAILURE_CLASSES = frozenset(
     {
         "command_exit_nonzero",
@@ -451,10 +454,11 @@ def _read_bounded_process_output(
     adapter_id: str,
 ) -> bytes:
     if process.stdout is None:
-        _kill_process_group(process, adapter_id=adapter_id)
-        raise AdapterExecutionError(
+        cleanup_denied = _kill_process_group(process)
+        _raise_local_command_failure(
             f"local command stdout unavailable: {adapter_id}",
             failure_class="stdout_unavailable",
+            cleanup_denied=cleanup_denied,
         )
     selector = selectors.DefaultSelector()
     selector.register(process.stdout, selectors.EVENT_READ)
@@ -465,10 +469,11 @@ def _read_bounded_process_output(
         while selector.get_map():
             remaining = deadline - time.monotonic()
             if remaining <= 0:
-                _kill_process_group(process, adapter_id=adapter_id)
-                raise AdapterExecutionError(
+                cleanup_denied = _kill_process_group(process)
+                _raise_local_command_failure(
                     f"local command timed out: {adapter_id}",
                     failure_class="command_timeout",
+                    cleanup_denied=cleanup_denied,
                 )
             events = selector.select(min(remaining, 0.1))
             if not events and process.poll() is not None:
@@ -480,71 +485,191 @@ def _read_bounded_process_output(
                     continue
                 size += len(chunk)
                 if size > max_output_bytes:
-                    _kill_process_group(process, adapter_id=adapter_id)
-                    raise AdapterExecutionError(
+                    cleanup_denied = _kill_process_group(process)
+                    _raise_local_command_failure(
                         f"local command output exceeded limit: {adapter_id}",
                         failure_class="stdout_oversize",
+                        cleanup_denied=cleanup_denied,
                     )
                 chunks.append(chunk)
         remaining = deadline - time.monotonic()
         if remaining <= 0:
-            _kill_process_group(process, adapter_id=adapter_id)
-            raise AdapterExecutionError(
+            cleanup_denied = _kill_process_group(process)
+            _raise_local_command_failure(
                 f"local command timed out: {adapter_id}",
                 failure_class="command_timeout",
+                cleanup_denied=cleanup_denied,
             )
         process.wait(timeout=remaining)
         return b"".join(chunks)
-    except subprocess.TimeoutExpired as exc:
-        _kill_process_group(process, adapter_id=adapter_id)
-        raise AdapterExecutionError(
+    except subprocess.TimeoutExpired:
+        cleanup_denied = _kill_process_group(process)
+        _raise_local_command_failure(
             f"local command timed out: {adapter_id}",
             failure_class="command_timeout",
-        ) from exc
+            cleanup_denied=cleanup_denied,
+        )
     finally:
         selector.close()
 
 
-def _kill_process_group(process: subprocess.Popen[bytes], *, adapter_id: str) -> None:
+def _raise_local_command_failure(
+    message: str,
+    *,
+    failure_class: str,
+    cleanup_denied: bool,
+) -> Never:
+    if cleanup_denied:
+        message += "; process-group cleanup denied"
+    raise AdapterExecutionError(message, failure_class=failure_class) from None
+
+
+def _kill_process_group(process: subprocess.Popen[bytes]) -> bool:
+    """Boundedly terminate a command tree; return whether group signaling was denied."""
     if process.poll() is not None:
-        return
+        return False
+    deadline = time.monotonic() + CLEANUP_TIMEOUT_SECONDS
     try:
         os.killpg(process.pid, signal.SIGKILL)
     except ProcessLookupError:
-        return
+        return False
     except PermissionError:
+        descendants = _descendant_process_identities(process.pid, deadline=deadline)
+        for pid, identity in reversed(descendants):
+            if time.monotonic() >= deadline:
+                break
+            current_identity = _kernel_process_identity(pid)
+            if time.monotonic() >= deadline:
+                break
+            if current_identity != identity:
+                continue
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except (PermissionError, ProcessLookupError):
+                pass
         try:
             process.kill()
-        except ProcessLookupError:
-            return
-        except PermissionError as exc:
-            raise AdapterExecutionError(
-                f"local command cleanup failed: {adapter_id}"
-            ) from exc
-        try:
-            process.wait(timeout=1)
-        except subprocess.TimeoutExpired as exc:
-            raise AdapterExecutionError(
-                f"local command cleanup failed: {adapter_id}"
-            ) from exc
-        raise AdapterExecutionError(f"local command cleanup denied: {adapter_id}")
+        except (PermissionError, ProcessLookupError):
+            pass
+        _bounded_wait(process, deadline=deadline)
+        return True
+    _bounded_wait(process, deadline=deadline)
+    return False
+
+
+def _bounded_wait(process: subprocess.Popen[bytes], *, deadline: float) -> None:
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        return
     try:
-        process.wait(timeout=1)
+        process.wait(timeout=remaining)
     except subprocess.TimeoutExpired:
         try:
             process.kill()
-        except ProcessLookupError:
+        except (PermissionError, ProcessLookupError):
             return
-        except PermissionError as exc:
-            raise AdapterExecutionError(
-                f"local command cleanup failed: {adapter_id}"
-            ) from exc
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return
         try:
-            process.wait(timeout=1)
-        except subprocess.TimeoutExpired as exc:
-            raise AdapterExecutionError(
-                f"local command cleanup failed: {adapter_id}"
-            ) from exc
+            process.wait(timeout=remaining)
+        except subprocess.TimeoutExpired:
+            return
+
+
+def _descendant_process_identities(
+    root_pid: int,
+    *,
+    deadline: float,
+) -> list[tuple[int, tuple[int, int, int]]]:
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        return []
+    try:
+        result = subprocess.run(
+            ["ps", "-axo", "pid=,ppid="],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=remaining,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    children: dict[int, list[int]] = {}
+    for line in result.stdout.splitlines():
+        try:
+            pid_text, parent_text = line.split()
+            pid, parent = int(pid_text), int(parent_text)
+        except (ValueError, TypeError):
+            continue
+        children.setdefault(parent, []).append(pid)
+    descendant_candidates: list[tuple[int, int]] = []
+    pending = [(pid, root_pid) for pid in children.get(root_pid, ())]
+    while pending:
+        pid, captured_parent = pending.pop()
+        descendant_candidates.append((pid, captured_parent))
+        pending.extend((child, pid) for child in children.get(pid, ()))
+    descendants: list[tuple[int, tuple[int, int, int]]] = []
+    for pid, captured_parent in descendant_candidates:
+        if time.monotonic() >= deadline:
+            break
+        identity = _kernel_process_identity(pid)
+        if identity is not None and identity[0] == captured_parent:
+            descendants.append((pid, identity))
+    return descendants
+
+
+def _kernel_process_identity(pid: int) -> tuple[int, int, int] | None:
+    if sys.platform.startswith("linux"):
+        try:
+            with open(f"/proc/{pid}/stat", "rb") as stat_file:
+                stat = stat_file.read()
+            fields = stat[stat.rfind(b")") + 2 :].split()
+            return (int(fields[1]), int(fields[19]), 0)
+        except (OSError, IndexError, ValueError):
+            return None
+    if sys.platform == "darwin":
+        return _darwin_process_identity(pid)
+    return None
+
+
+class _DarwinProcBSDInfo(Structure):
+    _fields_ = [
+        ("flags", c_uint32),
+        ("status", c_uint32),
+        ("xstatus", c_uint32),
+        ("pid", c_uint32),
+        ("ppid", c_uint32),
+        ("uid", c_uint32),
+        ("gid", c_uint32),
+        ("ruid", c_uint32),
+        ("rgid", c_uint32),
+        ("svuid", c_uint32),
+        ("svgid", c_uint32),
+        ("rfu_1", c_uint32),
+        ("comm", c_char * 16),
+        ("name", c_char * 32),
+        ("nfiles", c_uint32),
+        ("pgid", c_uint32),
+        ("pjobc", c_uint32),
+        ("tdev", c_uint32),
+        ("tpgid", c_uint32),
+        ("nice", c_int32),
+        ("start_tvsec", c_uint64),
+        ("start_tvusec", c_uint64),
+    ]
+
+
+def _darwin_process_identity(pid: int) -> tuple[int, int, int] | None:
+    try:
+        libproc = CDLL("/usr/lib/libproc.dylib")
+        info = _DarwinProcBSDInfo()
+        read_size = libproc.proc_pidinfo(pid, 3, 0, byref(info), sizeof(info))
+    except OSError:
+        return None
+    if read_size != sizeof(info):
+        return None
+    return (int(info.ppid), int(info.start_tvsec), int(info.start_tvusec))
 
 
 def adapter_request_id(request: Mapping[str, Any]) -> str:

--- a/app/builderops/model_inquiry_adapters.py
+++ b/app/builderops/model_inquiry_adapters.py
@@ -451,7 +451,7 @@ def _read_bounded_process_output(
     adapter_id: str,
 ) -> bytes:
     if process.stdout is None:
-        _kill_process_group(process)
+        _kill_process_group(process, adapter_id=adapter_id)
         raise AdapterExecutionError(
             f"local command stdout unavailable: {adapter_id}",
             failure_class="stdout_unavailable",
@@ -465,7 +465,7 @@ def _read_bounded_process_output(
         while selector.get_map():
             remaining = deadline - time.monotonic()
             if remaining <= 0:
-                _kill_process_group(process)
+                _kill_process_group(process, adapter_id=adapter_id)
                 raise AdapterExecutionError(
                     f"local command timed out: {adapter_id}",
                     failure_class="command_timeout",
@@ -480,7 +480,7 @@ def _read_bounded_process_output(
                     continue
                 size += len(chunk)
                 if size > max_output_bytes:
-                    _kill_process_group(process)
+                    _kill_process_group(process, adapter_id=adapter_id)
                     raise AdapterExecutionError(
                         f"local command output exceeded limit: {adapter_id}",
                         failure_class="stdout_oversize",
@@ -488,7 +488,7 @@ def _read_bounded_process_output(
                 chunks.append(chunk)
         remaining = deadline - time.monotonic()
         if remaining <= 0:
-            _kill_process_group(process)
+            _kill_process_group(process, adapter_id=adapter_id)
             raise AdapterExecutionError(
                 f"local command timed out: {adapter_id}",
                 failure_class="command_timeout",
@@ -496,7 +496,7 @@ def _read_bounded_process_output(
         process.wait(timeout=remaining)
         return b"".join(chunks)
     except subprocess.TimeoutExpired as exc:
-        _kill_process_group(process)
+        _kill_process_group(process, adapter_id=adapter_id)
         raise AdapterExecutionError(
             f"local command timed out: {adapter_id}",
             failure_class="command_timeout",
@@ -505,18 +505,46 @@ def _read_bounded_process_output(
         selector.close()
 
 
-def _kill_process_group(process: subprocess.Popen[bytes]) -> None:
+def _kill_process_group(process: subprocess.Popen[bytes], *, adapter_id: str) -> None:
     if process.poll() is not None:
         return
     try:
         os.killpg(process.pid, signal.SIGKILL)
     except ProcessLookupError:
-        pass
-    finally:
+        return
+    except PermissionError:
+        try:
+            process.kill()
+        except ProcessLookupError:
+            return
+        except PermissionError as exc:
+            raise AdapterExecutionError(
+                f"local command cleanup failed: {adapter_id}"
+            ) from exc
         try:
             process.wait(timeout=1)
-        except subprocess.TimeoutExpired:
+        except subprocess.TimeoutExpired as exc:
+            raise AdapterExecutionError(
+                f"local command cleanup failed: {adapter_id}"
+            ) from exc
+        raise AdapterExecutionError(f"local command cleanup denied: {adapter_id}")
+    try:
+        process.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        try:
             process.kill()
+        except ProcessLookupError:
+            return
+        except PermissionError as exc:
+            raise AdapterExecutionError(
+                f"local command cleanup failed: {adapter_id}"
+            ) from exc
+        try:
+            process.wait(timeout=1)
+        except subprocess.TimeoutExpired as exc:
+            raise AdapterExecutionError(
+                f"local command cleanup failed: {adapter_id}"
+            ) from exc
 
 
 def adapter_request_id(request: Mapping[str, Any]) -> str:

--- a/tests/builderops/test_model_inquiry_adapters.py
+++ b/tests/builderops/test_model_inquiry_adapters.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -82,6 +83,41 @@ def test_local_command_adapter_is_bounded_and_secret_safe(tmp_path: Path) -> Non
     )
     with pytest.raises(AdapterExecutionError, match="contained an allowed environment value"):
         echo_secret.execute({"request": True})
+
+
+def test_local_command_adapter_translates_process_group_permission_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    processes: list[subprocess.Popen[bytes]] = []
+    real_popen = subprocess.Popen
+
+    def track_process(*args: object, **kwargs: object) -> subprocess.Popen[bytes]:
+        process = real_popen(*args, **kwargs)
+        processes.append(process)
+        return process
+
+    def deny_process_group_signal(*_args: object) -> None:
+        raise PermissionError("secret host path must not leak")
+
+    monkeypatch.setattr("app.builderops.model_inquiry_adapters.subprocess.Popen", track_process)
+    monkeypatch.setattr("app.builderops.model_inquiry_adapters.os.killpg", deny_process_group_signal)
+    adapter = LocalCommandAdapter(
+        adapter_id="permission-denied-cleanup",
+        provider="local",
+        model="fixture",
+        argv=(sys.executable, "-c", "import time; time.sleep(60)"),
+        timeout_seconds=0.01,
+        environment={"LOCAL_SECRET": "credential-sentinel"},
+    )
+
+    with pytest.raises(AdapterExecutionError, match="cleanup denied") as raised:
+        adapter.execute({"request": True})
+
+    assert raised.value.failure_class == "unexpected_adapter_error"
+    assert "credential-sentinel" not in str(raised.value)
+    assert "secret host path" not in str(raised.value)
+    assert len(processes) == 1
+    assert processes[0].poll() is not None
 
 
 def test_local_command_adapter_exposes_allowlisted_exit_diagnostic_without_stderr() -> None:

--- a/tests/builderops/test_model_inquiry_adapters.py
+++ b/tests/builderops/test_model_inquiry_adapters.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import io
 import json
-import subprocess
+import os
 import sys
+import time
+import traceback
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
@@ -13,6 +17,7 @@ from app.builderops.model_inquiry_adapters import (
     LocalCommandAdapter,
     load_adapter_descriptors,
 )
+from app.builderops import model_inquiry_adapters as adapters_module
 from app.builderops.model_inquiry_contract import RESPONSE_SCHEMA_VERSION
 
 
@@ -86,38 +91,200 @@ def test_local_command_adapter_is_bounded_and_secret_safe(tmp_path: Path) -> Non
 
 
 def test_local_command_adapter_translates_process_group_permission_error(
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    processes: list[subprocess.Popen[bytes]] = []
-    real_popen = subprocess.Popen
-
-    def track_process(*args: object, **kwargs: object) -> subprocess.Popen[bytes]:
-        process = real_popen(*args, **kwargs)
-        processes.append(process)
-        return process
-
+    pid_file = tmp_path / "command-tree-pids"
     def deny_process_group_signal(*_args: object) -> None:
-        raise PermissionError("secret host path must not leak")
+        raise PermissionError("credential-sentinel /secret/host/path must not leak")
 
-    monkeypatch.setattr("app.builderops.model_inquiry_adapters.subprocess.Popen", track_process)
     monkeypatch.setattr("app.builderops.model_inquiry_adapters.os.killpg", deny_process_group_signal)
+    wrapper = (
+        "import os,subprocess,sys,time; "
+        "child=subprocess.Popen([sys.executable,'-c','import time; time.sleep(60)']); "
+        f"open({str(pid_file)!r},'w').write(f'{{os.getpid()}} {{child.pid}}'); "
+        "print('x' * 100000, flush=True); "
+        "time.sleep(60)"
+    )
     adapter = LocalCommandAdapter(
         adapter_id="permission-denied-cleanup",
         provider="local",
         model="fixture",
-        argv=(sys.executable, "-c", "import time; time.sleep(60)"),
-        timeout_seconds=0.01,
+        argv=(sys.executable, "-c", wrapper),
+        timeout_seconds=2,
+        max_output_bytes=10,
         environment={"LOCAL_SECRET": "credential-sentinel"},
     )
 
     with pytest.raises(AdapterExecutionError, match="cleanup denied") as raised:
         adapter.execute({"request": True})
 
-    assert raised.value.failure_class == "unexpected_adapter_error"
-    assert "credential-sentinel" not in str(raised.value)
-    assert "secret host path" not in str(raised.value)
-    assert len(processes) == 1
-    assert processes[0].poll() is not None
+    assert raised.value.failure_class == "stdout_oversize"
+    formatted = "".join(
+        traceback.format_exception(type(raised.value), raised.value, raised.value.__traceback__)
+    )
+    assert "credential-sentinel" not in formatted
+    assert "/secret/host/path" not in formatted
+    wrapper_pid, child_pid = (int(value) for value in pid_file.read_text().split())
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline and any(
+        _process_exists(pid) for pid in (wrapper_pid, child_pid)
+    ):
+        time.sleep(0.01)
+    assert not _process_exists(wrapper_pid)
+    assert not _process_exists(child_pid)
+
+
+def _process_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def test_local_command_adapter_preserves_output_failure_when_cleanup_is_denied(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def deny_process_group_signal(*_args: object) -> None:
+        raise PermissionError("credential-sentinel /secret/host/path must not leak")
+
+    monkeypatch.setattr("app.builderops.model_inquiry_adapters.os.killpg", deny_process_group_signal)
+    adapter = LocalCommandAdapter(
+        adapter_id="permission-denied-output",
+        provider="local",
+        model="fixture",
+        argv=(sys.executable, "-c", "print('x' * 100000)"),
+        timeout_seconds=2,
+        max_output_bytes=10,
+    )
+
+    with pytest.raises(AdapterExecutionError, match="cleanup denied") as raised:
+        adapter.execute({"request": True})
+
+    assert raised.value.failure_class == "stdout_oversize"
+    formatted = "".join(
+        traceback.format_exception(type(raised.value), raised.value, raised.value.__traceback__)
+    )
+    assert "credential-sentinel" not in formatted
+    assert "/secret/host/path" not in formatted
+
+
+def test_denied_cleanup_does_not_signal_same_lstart_reused_descendant_pid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = Mock()
+    process.pid = 7000
+    process.poll.return_value = None
+    process.wait.return_value = -9
+    signaled: list[int] = []
+
+    monkeypatch.setattr(adapters_module.os, "killpg", Mock(side_effect=PermissionError))
+    monkeypatch.setattr(
+        adapters_module,
+        "_descendant_process_identities",
+        Mock(return_value=[(7001, (7000, 100, 0))]),
+    )
+    monkeypatch.setattr(
+        adapters_module,
+        "_kernel_process_identity",
+        Mock(return_value=(7000, 200, 0)),
+    )
+    monkeypatch.setattr(adapters_module.os, "kill", lambda pid, _signal: signaled.append(pid))
+
+    assert adapters_module._kill_process_group(process) is True
+    assert signaled == []
+    process.kill.assert_called_once_with()
+
+
+def test_denied_cleanup_preserves_timeout_failure_and_hides_exception_chain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def deny_process_group_signal(*_args: object) -> None:
+        raise PermissionError("credential-sentinel /secret/host/path must not leak")
+
+    monkeypatch.setattr("app.builderops.model_inquiry_adapters.os.killpg", deny_process_group_signal)
+    adapter = LocalCommandAdapter(
+        adapter_id="permission-denied-timeout",
+        provider="local",
+        model="fixture",
+        argv=(sys.executable, "-c", "import time; time.sleep(60)"),
+        timeout_seconds=0.01,
+    )
+
+    with pytest.raises(AdapterExecutionError, match="cleanup denied") as raised:
+        adapter.execute({"request": True})
+
+    assert raised.value.failure_class == "command_timeout"
+    formatted = "".join(
+        traceback.format_exception(type(raised.value), raised.value, raised.value.__traceback__)
+    )
+    assert "credential-sentinel" not in formatted
+    assert "/secret/host/path" not in formatted
+    assert "TimeoutExpired" not in formatted
+
+
+def test_denied_cleanup_uses_one_global_deadline_for_many_descendants(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = Mock()
+    process.pid = 8000
+    process.poll.return_value = None
+    clock = Mock()
+    clock.now = 0.0
+    signaled: list[int] = []
+
+    def monotonic() -> float:
+        return float(clock.now)
+
+    def identity(pid: int) -> tuple[int, int, int]:
+        clock.now += 0.4
+        return (8000, pid, 0)
+
+    identities = [(pid, (8000, pid, 0)) for pid in range(8001, 8101)]
+    monkeypatch.setattr(adapters_module.time, "monotonic", monotonic)
+    monkeypatch.setattr(adapters_module.os, "killpg", Mock(side_effect=PermissionError))
+    monkeypatch.setattr(
+        adapters_module,
+        "_descendant_process_identities",
+        Mock(return_value=identities),
+    )
+    monkeypatch.setattr(adapters_module, "_kernel_process_identity", identity)
+    monkeypatch.setattr(adapters_module.os, "kill", lambda pid, _signal: signaled.append(pid))
+
+    assert adapters_module._kill_process_group(process) is True
+    assert len(signaled) < len(identities)
+    assert clock.now <= adapters_module.CLEANUP_TIMEOUT_SECONDS
+    process.kill.assert_called_once_with()
+
+
+def test_descendant_identity_capture_rejects_changed_parent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tree_snapshot = Mock(stdout="8000 1\n8001 8000\n")
+    monkeypatch.setattr(adapters_module.subprocess, "run", Mock(return_value=tree_snapshot))
+    monkeypatch.setattr(
+        adapters_module,
+        "_kernel_process_identity",
+        Mock(return_value=(9999, 12345, 0)),
+    )
+
+    descendants = adapters_module._descendant_process_identities(
+        8000,
+        deadline=time.monotonic() + 1,
+    )
+
+    assert descendants == []
+
+
+def test_linux_process_identity_is_bytes_safe_for_non_utf8_comm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stat = b"9000 (bad\xffname) S 8000 " + b" ".join([b"0"] * 17 + [b"12345"])
+    monkeypatch.setattr(adapters_module.sys, "platform", "linux")
+    monkeypatch.setattr("builtins.open", lambda *_args, **_kwargs: io.BytesIO(stat))
+
+    assert adapters_module._kernel_process_identity(9000) == (8000, 12345, 0)
 
 
 def test_local_command_adapter_exposes_allowlisted_exit_diagnostic_without_stderr() -> None:


### PR DESCRIPTION
Governing-Issue: #4000

Fixes #4000

## Summary
- Preserve the originating adapter failure class when process-group cleanup is denied.
- Boundedly terminate wrapper descendants using kernel-backed process identity and parent validation before signaling.
- Suppress raw cleanup exception chains and cover timeout, oversize, secret-safety, PID-reuse, global-deadline, and wrapper/descendant regressions.

## Validation
- pytest -q tests/builderops/test_model_inquiry_adapters.py (11 passed)
- wrapper + descendant regression repeated 10/10 passes
- ruff check app tests
- mypy app (790 files)
- pytest -q -m "not pg" (10203 passed, 38 skipped, 272 deselected, 18 xfailed)

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded code repair is fully represented by the governing Issue and PR.