### PR TITLE
Add bounded YouTube Data API client

### DIFF
--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -687,8 +687,11 @@ jobs:
               - 'app/agents/panel/**'
               - 'app/index/**'
               - 'app/stores/pg.py'
+              - 'app/knowledge_acquisition/youtube_api_client.py'
+              - 'app/alembic/versions/d9e0f1a2b3c4_yss03_youtube_api_quota.py'
               - 'tests/index/test_provenance_stamp.py'
               - 'tests/indexer/test_outbox_roundtrip_pg.py'
+              - 'tests/knowledge_acquisition/test_youtube_api_quota_pg.py'
               - '.github/workflows/ci-smoke.yaml'
 
       - uses: actions/setup-python@v5
@@ -708,7 +711,7 @@ jobs:
         if: steps.changes.outputs.index_pg == 'true'
         run: python -c "import os, psycopg; psycopg.connect(os.environ['DATABASE_URL'], autocommit=True).execute('CREATE EXTENSION IF NOT EXISTS vector')"
 
-      - name: Run exact index PG acceptance surface
+      - name: Run exact index and YouTube quota PG acceptance surface
         if: steps.changes.outputs.index_pg == 'true'
         shell: bash
         run: |
@@ -716,6 +719,7 @@ jobs:
           pytest -q -m "pg" \
             tests/index/test_provenance_stamp.py \
             tests/indexer/test_outbox_roundtrip_pg.py \
+            tests/knowledge_acquisition/test_youtube_api_quota_pg.py \
             --tb=short \
             | tee pytest-index-pg.log
 

--- a/app/alembic/versions/d9e0f1a2b3c4_yss03_youtube_api_quota.py
+++ b/app/alembic/versions/d9e0f1a2b3c4_yss03_youtube_api_quota.py
@@ -1,0 +1,68 @@
+"""YSS-03 (#3918): durable per-UTC-day YouTube Data API quota counter.
+
+Creates the one channel-DB row per UTC day consumed by
+``app.knowledge_acquisition.youtube_api_client.YouTubeQuotaStore``. Every Data
+API request atomically increments ``spent``; a provider quota-family response
+also latches ``exhausted`` for that UTC day. Channel isolation comes from the
+existing DB-per-channel discipline (INV-YSS-7), so this table intentionally
+carries no environment column.
+
+The table is runtime-operational/rebuildable sync state, but silently dropping
+it during downgrade would erase the operator's same-day quota safety signal.
+Following the existing YSS migration posture, this migration is forward-only.
+
+Revision ID: d9e0f1a2b3c4
+Revises: c8d9e0f1a2b3
+Create Date: 2026-07-19 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "d9e0f1a2b3c4"
+down_revision: Union[str, None] = "c8d9e0f1a2b3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+reversibility: str = "forward-only"
+
+_TABLE = "youtube_api_quota_daily"
+
+
+def upgrade() -> None:
+    op.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {_TABLE} (
+            quota_date DATE PRIMARY KEY,
+            spent INTEGER NOT NULL DEFAULT 0,
+            exhausted BOOLEAN NOT NULL DEFAULT false,
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            CONSTRAINT youtube_api_quota_daily_spent_chk CHECK (spent >= 0)
+        )
+        """
+    )
+    # Test/bootstrap-created tables may predate the migration-owned constraint.
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1
+                FROM pg_constraint
+                WHERE conname = 'youtube_api_quota_daily_spent_chk'
+                  AND conrelid = '{_TABLE}'::regclass
+            ) THEN
+                ALTER TABLE {_TABLE}
+                ADD CONSTRAINT youtube_api_quota_daily_spent_chk CHECK (spent >= 0);
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    raise RuntimeError(
+        "YSS-03 youtube_api_quota_daily migration is forward-only; dropping it would erase "
+        "the current UTC day's quota safety state."
+    )

--- a/app/knowledge_acquisition/youtube_api_client.py
+++ b/app/knowledge_acquisition/youtube_api_client.py
@@ -608,6 +608,10 @@ class YouTubeApiClient:
                         )
                     except DisallowedYouTubeHostError as error:
                         pending_error = error
+                    except ValueError:
+                        pending_error = YouTubeApiError(
+                            "api_unavailable", status, "Data API redirect was malformed"
+                        )
                 if pending_error is None:
                     pending_error = YouTubeApiError(
                         "api_unavailable", status, "Data API redirect was refused"

--- a/app/knowledge_acquisition/youtube_api_client.py
+++ b/app/knowledge_acquisition/youtube_api_client.py
@@ -387,8 +387,8 @@ class YouTubeQuotaStore:
     def increment(self) -> _QuotaRow:
         return self._backend.increment(_utc_day(self._clock))
 
-    def mark_exhausted(self) -> _QuotaRow:
-        return self._backend.mark_exhausted(_utc_day(self._clock))
+    def mark_exhausted(self, quota_date: str | None = None) -> _QuotaRow:
+        return self._backend.mark_exhausted(quota_date or _utc_day(self._clock))
 
     def status(self, budget: int) -> dict[str, int | bool]:
         row = self._backend.get(_utc_day(self._clock))
@@ -554,7 +554,7 @@ class YouTubeApiClient:
         # is bearer-only, so strip cookies at the final production call site.
         request.headers.pop("cookie", None)
         _validate_absolute_data_url(str(request.url), require_path=True)
-        self._quota.increment()
+        quota_date = self._quota.increment().quota_date
         try:
             response = self._http.send(request, stream=True, follow_redirects=False)
         except httpx.TimeoutException:
@@ -577,6 +577,24 @@ class YouTubeApiClient:
                 )
             try:
                 raw = _read_bounded(response, self._max_response_bytes)
+            except httpx.DecodingError:
+                if response.status_code >= 400:
+                    error = _mapped_http_error(response.status_code, {})
+                    if error.reason_code == "quota_exhausted":
+                        self._quota.mark_exhausted(quota_date)
+                    raise error from None
+                raise YouTubeApiError(
+                    "api_unavailable",
+                    response.status_code,
+                    "Data API response decoding failed",
+                ) from None
+            except YouTubeApiError:
+                if response.status_code >= 400:
+                    error = _mapped_http_error(response.status_code, {})
+                    if error.reason_code == "quota_exhausted":
+                        self._quota.mark_exhausted(quota_date)
+                    raise error from None
+                raise
             except httpx.TimeoutException:
                 raise YouTubeApiError(
                     "api_unavailable", response.status_code, "Data API response timed out"
@@ -588,12 +606,13 @@ class YouTubeApiClient:
         finally:
             response.close()
 
-        payload = _decode_object(raw)
         if response.status_code >= 400:
+            payload = _decode_error_object(raw)
             error = _mapped_http_error(response.status_code, payload)
             if error.reason_code == "quota_exhausted":
-                self._quota.mark_exhausted()
+                self._quota.mark_exhausted(quota_date)
             raise error
+        payload = _decode_object(raw, status=response.status_code)
         return payload, response_etag
 
 
@@ -639,14 +658,25 @@ def _read_bounded(response: httpx.Response, maximum: int) -> bytes:
     return b"".join(chunks)
 
 
-def _decode_object(raw: bytes) -> dict[str, Any]:
+def _decode_object(raw: bytes, *, status: int | None = None) -> dict[str, Any]:
     try:
         value = json.loads(raw or b"{}")
     except (json.JSONDecodeError, UnicodeDecodeError):
-        raise YouTubeApiError("api_unavailable", None, "Data API returned invalid JSON") from None
+        raise YouTubeApiError("api_unavailable", status, "Data API returned invalid JSON") from None
     if not isinstance(value, dict):
-        raise YouTubeApiError("api_unavailable", None, "Data API returned an invalid object shape")
+        raise YouTubeApiError(
+            "api_unavailable", status, "Data API returned an invalid object shape"
+        )
     return value
+
+
+def _decode_error_object(raw: bytes) -> dict[str, Any]:
+    """Best-effort provider error parsing after HTTP status classification."""
+    try:
+        value = json.loads(raw or b"{}")
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return {}
+    return value if isinstance(value, dict) else {}
 
 
 def _provider_reasons(payload: Mapping[str, Any]) -> frozenset[str]:

--- a/app/knowledge_acquisition/youtube_api_client.py
+++ b/app/knowledge_acquisition/youtube_api_client.py
@@ -1,0 +1,791 @@
+"""YSS-03 (#3918): bounded read-only YouTube Data API v3 client.
+
+This module is the single Data API boundary for YouTube Source Sync. It owns
+the absolute ``www.googleapis.com`` allowlist, input validation, pagination
+and payload bounds, conditional ETag reads, secret-free error taxonomy, and
+durable per-UTC-day quota accounting required by
+``docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md``.
+
+The quota store follows the existing YSS store discipline: an explicit memory
+backend for ``not pg`` tests and a migration-owned Postgres table for runtime.
+A configured-but-unreachable Postgres backend never silently falls back to
+volatile memory (INV-YSS-7).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import threading
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from typing import Any, Protocol
+from urllib.parse import urljoin, urlsplit
+
+import httpx
+
+from app.db.dsn import resolve_dsn
+
+ALLOWED_DATA_API_HOST = "www.googleapis.com"
+DEFAULT_BASE_URL = "https://www.googleapis.com/youtube/v3/"
+DEFAULT_TIMEOUT_SECONDS = 30.0
+DEFAULT_MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+DEFAULT_MAX_PAGES = 10
+DEFAULT_QUOTA_BUDGET = 10_000
+MAX_PAGE_TOKEN_LENGTH = 2_048
+
+_TABLE = "youtube_api_quota_daily"
+_MIGRATION_HINT = (
+    "youtube_api_quota_daily schema is migration-owned: run 'alembic upgrade head' "
+    "against this database. See "
+    "app/alembic/versions/d9e0f1a2b3c4_yss03_youtube_api_quota.py."
+)
+_ALLOWED_BACKENDS = {"memory", "pg"}
+_SAFE_REF = re.compile(r"^[A-Za-z0-9_-]+$")
+_VIDEO_ID = re.compile(r"^[A-Za-z0-9_-]{11}$")
+_QUOTA_REASONS = frozenset(
+    {
+        "quotaExceeded",
+        "dailyLimitExceeded",
+        "rateLimitExceeded",
+        "userRateLimitExceeded",
+    }
+)
+
+
+class AccessTokenProvider(Protocol):
+    """The YSS-02 token-provider port consumed by this client."""
+
+    def get_access_token(self) -> str: ...
+
+
+class InvalidYouTubeRefError(ValueError):
+    """A source-native id or opaque page token failed local validation."""
+
+
+class DisallowedYouTubeHostError(ValueError):
+    """A request or redirect targeted a host outside the Data API allowlist."""
+
+
+class YouTubeQuotaSchemaMissingError(RuntimeError):
+    """The runtime selected Postgres but its migration-owned table is absent."""
+
+
+class YouTubeApiError(RuntimeError):
+    """Safe, structured Data API failure.
+
+    ``detail`` is constructed only from local classifications and status
+    values. Provider bodies, URLs, headers, and exception text are never
+    copied into it (INV-YSS-5).
+    """
+
+    def __init__(self, reason_code: str, status: int | None, detail: str) -> None:
+        self.reason_code = reason_code
+        self.status = status
+        self.detail = detail
+        super().__init__(f"{reason_code}: {detail}")
+
+
+@dataclass(frozen=True)
+class Playlist:
+    playlist_id: str
+    title: str
+    item_count: int
+
+
+@dataclass(frozen=True)
+class PlaylistItem:
+    playlist_item_id: str
+    video_id: str
+    position: int
+    published_at: str
+    title: str
+
+
+@dataclass(frozen=True)
+class PlaylistListResult:
+    items: tuple[Playlist, ...]
+    next_page_token: str | None
+    pagination_truncated: bool
+
+
+@dataclass(frozen=True)
+class PlaylistItemsPage:
+    items: tuple[PlaylistItem, ...]
+    next_page_token: str | None
+    etag: str | None
+    pagination_truncated: bool
+    not_modified: bool = False
+
+
+@dataclass(frozen=True)
+class NotModified:
+    etag: str | None
+    not_modified: bool = True
+
+
+@dataclass(frozen=True)
+class Channel:
+    channel_id: str
+    title: str
+    liked_videos_ref: str = "LL"
+
+
+@dataclass(frozen=True)
+class _QuotaRow:
+    quota_date: str
+    spent: int
+    exhausted: bool
+
+
+def validate_video_id(value: str) -> str:
+    if not isinstance(value, str) or not _VIDEO_ID.fullmatch(value):
+        raise InvalidYouTubeRefError("video id must be exactly 11 URL-safe characters")
+    return value
+
+
+def validate_playlist_id(value: str) -> str:
+    if not isinstance(value, str) or not value or not _SAFE_REF.fullmatch(value):
+        raise InvalidYouTubeRefError("playlist id must be a non-empty URL-safe source id")
+    if value in {"WL", "HL"}:
+        raise InvalidYouTubeRefError("Watch Later and Watch History are unsupported")
+    if value != "LL" and not value.startswith(("PL", "UU", "LL")):
+        raise InvalidYouTubeRefError("playlist id must use the PL, UU, or LL source-id shape")
+    return value
+
+
+def validate_channel_id(value: str) -> str:
+    if (
+        not isinstance(value, str)
+        or not value.startswith("UC")
+        or len(value) <= 2
+        or not _SAFE_REF.fullmatch(value)
+    ):
+        raise InvalidYouTubeRefError("channel id must use the UC source-id shape")
+    return value
+
+
+def _validate_page_token(value: str | None) -> str | None:
+    if value is None:
+        return None
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > MAX_PAGE_TOKEN_LENGTH
+        or "\x00" in value
+    ):
+        raise InvalidYouTubeRefError("page token must be a bounded non-empty opaque string")
+    return value
+
+
+def _utc_day(clock: Callable[[], datetime]) -> str:
+    now = clock()
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    return now.astimezone(timezone.utc).date().isoformat()
+
+
+class _QuotaBackend(Protocol):
+    def increment(self, quota_date: str) -> _QuotaRow: ...
+
+    def mark_exhausted(self, quota_date: str) -> _QuotaRow: ...
+
+    def get(self, quota_date: str) -> _QuotaRow: ...
+
+
+class _MemoryQuotaBackend:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._rows: dict[str, _QuotaRow] = {}
+
+    def increment(self, quota_date: str) -> _QuotaRow:
+        with self._lock:
+            current = self._rows.get(quota_date, _QuotaRow(quota_date, 0, False))
+            updated = _QuotaRow(quota_date, current.spent + 1, current.exhausted)
+            self._rows[quota_date] = updated
+            return updated
+
+    def mark_exhausted(self, quota_date: str) -> _QuotaRow:
+        with self._lock:
+            current = self._rows.get(quota_date, _QuotaRow(quota_date, 0, False))
+            updated = _QuotaRow(quota_date, current.spent, True)
+            self._rows[quota_date] = updated
+            return updated
+
+    def get(self, quota_date: str) -> _QuotaRow:
+        with self._lock:
+            return self._rows.get(quota_date, _QuotaRow(quota_date, 0, False))
+
+    def clear(self) -> None:
+        with self._lock:
+            self._rows.clear()
+
+
+_MEMORY_QUOTA = _MemoryQuotaBackend()
+
+
+def reset_memory_youtube_quota() -> None:
+    """Test-only reset hook for the explicit in-process fallback."""
+    _MEMORY_QUOTA.clear()
+
+
+def _resolve_backend() -> str:
+    override = (os.getenv("STORE_BACKEND") or "").strip().lower()
+    if override:
+        if override not in _ALLOWED_BACKENDS:
+            raise RuntimeError(
+                f"Store backend {override!r} is unsupported for YouTube quota accounting; "
+                "set STORE_BACKEND to 'pg' or 'memory'."
+            )
+        return override
+    dsn = resolve_dsn()
+    if not dsn:
+        raise RuntimeError(
+            "No store backend configured for YouTube quota accounting: set "
+            "STORE_BACKEND=memory explicitly for tests or configure DATABASE_URL/DB_DSN."
+        )
+    try:
+        import psycopg  # noqa: PLC0415
+
+        conn = psycopg.connect(dsn, connect_timeout=1)
+        conn.close()
+    except Exception as exc:
+        raise RuntimeError(
+            "YouTube quota backend resolution failed: Postgres is configured but unreachable. "
+            "Refusing volatile fallback."
+        ) from exc
+    return "pg"
+
+
+def _pg_connect() -> Any:
+    import psycopg  # noqa: PLC0415
+
+    url = os.environ.get("DATABASE_URL") or os.environ.get("DB_DSN")
+    if not url:
+        raise RuntimeError("DATABASE_URL or DB_DSN not set")
+    return psycopg.connect(resolve_dsn(url), autocommit=True)
+
+
+def _schema_autocreate_enabled() -> bool:
+    return (os.getenv("STORE_SCHEMA_AUTOCREATE") or "").strip().lower() in {"1", "true", "yes"}
+
+
+def _assert_pg_schema(conn: Any) -> None:
+    cur = conn.cursor()
+    cur.execute("SELECT to_regclass(%s)", (_TABLE,))
+    row = cur.fetchone()
+    if not (row and row[0]):
+        raise YouTubeQuotaSchemaMissingError(f"Missing table '{_TABLE}'. {_MIGRATION_HINT}")
+
+
+def _bootstrap_pg(conn: Any) -> None:
+    if not _schema_autocreate_enabled():
+        _assert_pg_schema(conn)
+        return
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {_TABLE} (
+            quota_date DATE PRIMARY KEY,
+            spent INTEGER NOT NULL DEFAULT 0,
+            exhausted BOOLEAN NOT NULL DEFAULT false,
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            CONSTRAINT youtube_api_quota_daily_spent_chk CHECK (spent >= 0)
+        )
+        """
+    )
+
+
+def _row_to_quota(row: tuple[Any, ...]) -> _QuotaRow:
+    day = row[0]
+    if isinstance(day, date):
+        day = day.isoformat()
+    return _QuotaRow(str(day), int(row[1]), bool(row[2]))
+
+
+class _PgQuotaBackend:
+    def __init__(self) -> None:
+        conn = _pg_connect()
+        try:
+            _bootstrap_pg(conn)
+        finally:
+            conn.close()
+
+    def increment(self, quota_date: str) -> _QuotaRow:
+        conn = _pg_connect()
+        try:
+            _assert_pg_schema(conn)
+            row = conn.execute(
+                f"""
+                INSERT INTO {_TABLE} (quota_date, spent, exhausted, updated_at)
+                VALUES (%s::date, 1, false, now())
+                ON CONFLICT (quota_date) DO UPDATE
+                SET spent = {_TABLE}.spent + 1, updated_at = now()
+                RETURNING quota_date, spent, exhausted
+                """,
+                (quota_date,),
+            ).fetchone()
+            assert row is not None
+            return _row_to_quota(tuple(row))
+        finally:
+            conn.close()
+
+    def mark_exhausted(self, quota_date: str) -> _QuotaRow:
+        conn = _pg_connect()
+        try:
+            _assert_pg_schema(conn)
+            row = conn.execute(
+                f"""
+                INSERT INTO {_TABLE} (quota_date, spent, exhausted, updated_at)
+                VALUES (%s::date, 0, true, now())
+                ON CONFLICT (quota_date) DO UPDATE
+                SET exhausted = true, updated_at = now()
+                RETURNING quota_date, spent, exhausted
+                """,
+                (quota_date,),
+            ).fetchone()
+            assert row is not None
+            return _row_to_quota(tuple(row))
+        finally:
+            conn.close()
+
+    def get(self, quota_date: str) -> _QuotaRow:
+        conn = _pg_connect()
+        try:
+            _assert_pg_schema(conn)
+            row = conn.execute(
+                f"SELECT quota_date, spent, exhausted FROM {_TABLE} WHERE quota_date = %s::date",
+                (quota_date,),
+            ).fetchone()
+            return _row_to_quota(tuple(row)) if row else _QuotaRow(quota_date, 0, False)
+        finally:
+            conn.close()
+
+
+class YouTubeQuotaStore:
+    """Atomic per-UTC-day quota counter over the selected store backend."""
+
+    def __init__(
+        self,
+        backend: _QuotaBackend,
+        *,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._backend = backend
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+
+    @classmethod
+    def for_runtime(cls, *, clock: Callable[[], datetime] | None = None) -> YouTubeQuotaStore:
+        backend: _QuotaBackend
+        if _resolve_backend() == "pg":
+            backend = _PgQuotaBackend()
+        else:
+            backend = _MEMORY_QUOTA
+        return cls(backend, clock=clock)
+
+    def increment(self) -> _QuotaRow:
+        return self._backend.increment(_utc_day(self._clock))
+
+    def mark_exhausted(self) -> _QuotaRow:
+        return self._backend.mark_exhausted(_utc_day(self._clock))
+
+    def status(self, budget: int) -> dict[str, int | bool]:
+        row = self._backend.get(_utc_day(self._clock))
+        return {
+            "spent_today": row.spent,
+            "budget": budget,
+            "exhausted": row.exhausted or row.spent >= budget,
+        }
+
+
+class YouTubeApiClient:
+    """One bounded, allowlisted, quota-accounted Data API client."""
+
+    def __init__(
+        self,
+        *,
+        token_provider: AccessTokenProvider,
+        quota: YouTubeQuotaStore | None = None,
+        http: httpx.Client | None = None,
+        base_url: str = DEFAULT_BASE_URL,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+        max_response_bytes: int = DEFAULT_MAX_RESPONSE_BYTES,
+        max_pages: int = DEFAULT_MAX_PAGES,
+        quota_budget: int = DEFAULT_QUOTA_BUDGET,
+    ) -> None:
+        self._base_url = _validate_absolute_data_url(base_url, require_path=True)
+        if not self._base_url.endswith("/"):
+            self._base_url += "/"
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        if max_response_bytes <= 0:
+            raise ValueError("max_response_bytes must be positive")
+        if max_pages <= 0:
+            raise ValueError("max_pages must be positive")
+        if quota_budget <= 0:
+            raise ValueError("quota_budget must be positive")
+        self._tokens = token_provider
+        self._quota = quota or YouTubeQuotaStore.for_runtime()
+        self._http = http or httpx.Client()
+        self._timeout = timeout_seconds
+        self._max_response_bytes = max_response_bytes
+        self._max_pages = max_pages
+        self._quota_budget = quota_budget
+
+    def list_my_playlists(self) -> PlaylistListResult:
+        rows: list[Playlist] = []
+        token: str | None = None
+        for _ in range(self._max_pages):
+            payload, _ = self._get_json(
+                "playlists",
+                {
+                    "part": "snippet,contentDetails",
+                    "mine": "true",
+                    "maxResults": "50",
+                    "fields": "nextPageToken,items(id,snippet(title),contentDetails(itemCount))",
+                    **({"pageToken": token} if token else {}),
+                },
+            )
+            if isinstance(payload, NotModified):  # impossible without allow_not_modified
+                raise _shape_error()
+            rows.extend(_parse_playlists(payload))
+            next_token = _payload_page_token(payload)
+            if not next_token:
+                return PlaylistListResult(tuple(rows), None, False)
+            _reject_token_cycle(token, next_token)
+            token = next_token
+        return PlaylistListResult(tuple(rows), token, token is not None)
+
+    def list_playlist_items(
+        self,
+        playlist_id: str,
+        *,
+        etag: str | None = None,
+        page_token: str | None = None,
+    ) -> PlaylistItemsPage | NotModified:
+        playlist_id = validate_playlist_id(playlist_id)
+        token = _validate_page_token(page_token)
+        if etag is not None and (
+            not isinstance(etag, str) or not etag or "\r" in etag or "\n" in etag
+        ):
+            raise InvalidYouTubeRefError("etag must be a non-empty single-line string")
+        rows: list[PlaylistItem] = []
+        first_etag: str | None = None
+        for page_index in range(self._max_pages):
+            payload, response_etag = self._get_json(
+                "playlistItems",
+                {
+                    "part": "snippet",
+                    "playlistId": playlist_id,
+                    "maxResults": "50",
+                    "fields": (
+                        "etag,nextPageToken,items(id,snippet(position,publishedAt,title,"
+                        "resourceId(videoId)))"
+                    ),
+                    **({"pageToken": token} if token else {}),
+                },
+                etag=etag if page_index == 0 else None,
+                allow_not_modified=page_index == 0,
+            )
+            if isinstance(payload, NotModified):
+                return payload
+            if page_index == 0:
+                first_etag = response_etag or _optional_str(payload.get("etag"))
+            rows.extend(_parse_playlist_items(payload))
+            next_token = _payload_page_token(payload)
+            if not next_token:
+                return PlaylistItemsPage(tuple(rows), None, first_etag, False)
+            _reject_token_cycle(token, next_token)
+            token = next_token
+        return PlaylistItemsPage(tuple(rows), token, first_etag, token is not None)
+
+    def get_my_channel(self) -> Channel:
+        payload, _ = self._get_json(
+            "channels",
+            {
+                "part": "snippet",
+                "mine": "true",
+                "maxResults": "1",
+                "fields": "items(id,snippet(title))",
+            },
+        )
+        if isinstance(payload, NotModified):  # impossible without allow_not_modified
+            raise _shape_error()
+        items = _payload_items(payload)
+        if not items:
+            raise YouTubeApiError("source_gone", 404, "authenticated channel was not found")
+        item = items[0]
+        snippet = item.get("snippet")
+        if not isinstance(snippet, Mapping):
+            raise _shape_error()
+        channel_id = _required_str(item.get("id"))
+        title = _required_str(snippet.get("title"))
+        try:
+            validate_channel_id(channel_id)
+        except InvalidYouTubeRefError as exc:
+            raise _shape_error() from exc
+        return Channel(channel_id, title)
+
+    def quota_status(self) -> dict[str, int | bool]:
+        return self._quota.status(self._quota_budget)
+
+    def _get_json(
+        self,
+        resource: str,
+        params: Mapping[str, str],
+        *,
+        etag: str | None = None,
+        allow_not_modified: bool = False,
+    ) -> tuple[dict[str, Any] | NotModified, str | None]:
+        url = _validate_absolute_data_url(urljoin(self._base_url, resource), require_path=True)
+        access_token = self._tokens.get_access_token()
+        headers = {"Authorization": f"Bearer {access_token}", "Accept": "application/json"}
+        if etag:
+            headers["If-None-Match"] = etag
+        request = self._http.build_request(
+            "GET",
+            url,
+            params=params,
+            headers=headers,
+            timeout=self._timeout,
+        )
+        # An injected/default Client may carry a cookie jar. This API boundary
+        # is bearer-only, so strip cookies at the final production call site.
+        request.headers.pop("cookie", None)
+        _validate_absolute_data_url(str(request.url), require_path=True)
+        self._quota.increment()
+        try:
+            response = self._http.send(request, stream=True, follow_redirects=False)
+        except httpx.TimeoutException:
+            raise YouTubeApiError("api_unavailable", None, "Data API request timed out") from None
+        except httpx.TransportError:
+            raise YouTubeApiError("network_error", None, "Data API transport failed") from None
+
+        try:
+            response_etag = response.headers.get("etag")
+            if response.status_code == 304 and allow_not_modified:
+                return NotModified(response_etag or etag), response_etag
+            if response.is_redirect:
+                location = response.headers.get("location")
+                if location:
+                    _validate_absolute_data_url(
+                        urljoin(str(request.url), location), require_path=True
+                    )
+                raise YouTubeApiError(
+                    "api_unavailable", response.status_code, "Data API redirect was refused"
+                )
+            try:
+                raw = _read_bounded(response, self._max_response_bytes)
+            except httpx.TimeoutException:
+                raise YouTubeApiError(
+                    "api_unavailable", response.status_code, "Data API response timed out"
+                ) from None
+            except httpx.TransportError:
+                raise YouTubeApiError(
+                    "network_error", response.status_code, "Data API response transport failed"
+                ) from None
+        finally:
+            response.close()
+
+        payload = _decode_object(raw)
+        if response.status_code >= 400:
+            error = _mapped_http_error(response.status_code, payload)
+            if error.reason_code == "quota_exhausted":
+                self._quota.mark_exhausted()
+            raise error
+        return payload, response_etag
+
+
+def _validate_absolute_data_url(value: str, *, require_path: bool) -> str:
+    parsed = urlsplit(value)
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname != ALLOWED_DATA_API_HOST
+        or parsed.username
+        or parsed.password
+    ):
+        raise DisallowedYouTubeHostError(
+            f"Data API egress requires https://{ALLOWED_DATA_API_HOST}"
+        )
+    if parsed.port not in (None, 443):
+        raise DisallowedYouTubeHostError("Data API egress refuses non-HTTPS-standard ports")
+    if require_path and not (
+        parsed.path == "/youtube/v3" or parsed.path.startswith("/youtube/v3/")
+    ):
+        raise DisallowedYouTubeHostError("Data API egress path must stay under /youtube/v3")
+    return value
+
+
+def _read_bounded(response: httpx.Response, maximum: int) -> bytes:
+    declared = response.headers.get("content-length")
+    if declared:
+        try:
+            if int(declared) > maximum:
+                raise YouTubeApiError(
+                    "api_unavailable", response.status_code, "Data API response exceeded byte bound"
+                )
+        except ValueError:
+            pass
+    chunks: list[bytes] = []
+    total = 0
+    for chunk in response.iter_bytes():
+        total += len(chunk)
+        if total > maximum:
+            raise YouTubeApiError(
+                "api_unavailable", response.status_code, "Data API response exceeded byte bound"
+            )
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _decode_object(raw: bytes) -> dict[str, Any]:
+    try:
+        value = json.loads(raw or b"{}")
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        raise YouTubeApiError("api_unavailable", None, "Data API returned invalid JSON") from None
+    if not isinstance(value, dict):
+        raise YouTubeApiError("api_unavailable", None, "Data API returned an invalid object shape")
+    return value
+
+
+def _provider_reasons(payload: Mapping[str, Any]) -> frozenset[str]:
+    error = payload.get("error")
+    if not isinstance(error, Mapping):
+        return frozenset()
+    entries = error.get("errors")
+    if not isinstance(entries, list):
+        return frozenset()
+    reasons: set[str] = set()
+    for entry in entries:
+        if isinstance(entry, Mapping) and isinstance(entry.get("reason"), str):
+            reasons.add(entry["reason"])
+    return frozenset(reasons)
+
+
+def _mapped_http_error(status: int, payload: Mapping[str, Any]) -> YouTubeApiError:
+    reasons = _provider_reasons(payload)
+    if status == 429 or (status == 403 and reasons.intersection(_QUOTA_REASONS)):
+        reason_code = "quota_exhausted"
+    elif status == 401:
+        reason_code = "auth_expired"
+    elif status in {403, 404}:
+        reason_code = "source_gone"
+    elif status >= 500:
+        reason_code = "api_unavailable"
+    else:
+        reason_code = "api_unavailable"
+    return YouTubeApiError(reason_code, status, f"Data API request failed with HTTP {status}")
+
+
+def _shape_error() -> YouTubeApiError:
+    return YouTubeApiError("api_unavailable", None, "Data API returned an invalid resource shape")
+
+
+def _required_str(value: Any) -> str:
+    if not isinstance(value, str) or not value:
+        raise _shape_error()
+    return value
+
+
+def _optional_str(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _payload_items(payload: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    items = payload.get("items", [])
+    if not isinstance(items, list) or not all(isinstance(item, Mapping) for item in items):
+        raise _shape_error()
+    return items
+
+
+def _payload_page_token(payload: Mapping[str, Any]) -> str | None:
+    value = payload.get("nextPageToken")
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise _shape_error()
+    try:
+        return _validate_page_token(value)
+    except InvalidYouTubeRefError as exc:
+        raise _shape_error() from exc
+
+
+def _reject_token_cycle(previous: str | None, next_token: str) -> None:
+    if previous is not None and previous == next_token:
+        raise YouTubeApiError("api_unavailable", None, "Data API pagination token repeated")
+
+
+def _parse_playlists(payload: Mapping[str, Any]) -> tuple[Playlist, ...]:
+    parsed: list[Playlist] = []
+    for item in _payload_items(payload):
+        snippet = item.get("snippet")
+        content = item.get("contentDetails")
+        if not isinstance(snippet, Mapping) or not isinstance(content, Mapping):
+            raise _shape_error()
+        playlist_id = _required_str(item.get("id"))
+        count_value = content.get("itemCount")
+        if isinstance(count_value, bool) or not isinstance(count_value, (int, str)):
+            raise _shape_error()
+        try:
+            validate_playlist_id(playlist_id)
+            count = int(count_value)
+        except (InvalidYouTubeRefError, TypeError, ValueError) as exc:
+            raise _shape_error() from exc
+        if count < 0:
+            raise _shape_error()
+        parsed.append(Playlist(playlist_id, _required_str(snippet.get("title")), count))
+    return tuple(parsed)
+
+
+def _parse_playlist_items(payload: Mapping[str, Any]) -> tuple[PlaylistItem, ...]:
+    parsed: list[PlaylistItem] = []
+    for item in _payload_items(payload):
+        snippet = item.get("snippet")
+        if not isinstance(snippet, Mapping):
+            raise _shape_error()
+        resource = snippet.get("resourceId")
+        if not isinstance(resource, Mapping):
+            raise _shape_error()
+        video_id = _required_str(resource.get("videoId"))
+        position_value = snippet.get("position")
+        if isinstance(position_value, bool) or not isinstance(position_value, (int, str)):
+            raise _shape_error()
+        try:
+            validate_video_id(video_id)
+            position = int(position_value)
+        except (InvalidYouTubeRefError, TypeError, ValueError) as exc:
+            raise _shape_error() from exc
+        if position < 0:
+            raise _shape_error()
+        parsed.append(
+            PlaylistItem(
+                playlist_item_id=_required_str(item.get("id")),
+                video_id=video_id,
+                position=position,
+                published_at=_required_str(snippet.get("publishedAt")),
+                title=_required_str(snippet.get("title")),
+            )
+        )
+    return tuple(parsed)
+
+
+__all__ = [
+    "AccessTokenProvider",
+    "Channel",
+    "DisallowedYouTubeHostError",
+    "InvalidYouTubeRefError",
+    "NotModified",
+    "Playlist",
+    "PlaylistItem",
+    "PlaylistItemsPage",
+    "PlaylistListResult",
+    "YouTubeApiClient",
+    "YouTubeApiError",
+    "YouTubeQuotaSchemaMissingError",
+    "YouTubeQuotaStore",
+    "reset_memory_youtube_quota",
+    "validate_channel_id",
+    "validate_playlist_id",
+    "validate_video_id",
+]

--- a/app/knowledge_acquisition/youtube_api_client.py
+++ b/app/knowledge_acquisition/youtube_api_client.py
@@ -591,6 +591,11 @@ class YouTubeApiClient:
                 self._quota.mark_exhausted(quota_date)
             return error
 
+        def response_failure(reason_code: str, detail: str) -> YouTubeApiError:
+            if status >= 400:
+                return status_error(_decode_error_object(raw))
+            return YouTubeApiError(reason_code, status, detail)
+
         try:
             if status == 304 and allow_not_modified:
                 not_modified = NotModified(response_etag or etag)
@@ -649,14 +654,20 @@ class YouTubeApiClient:
         finally:
             try:
                 response.close()
+            except httpx.TimeoutException:
+                if pending_error is None:
+                    pending_error = response_failure(
+                        "api_unavailable", "Data API response close timed out"
+                    )
+            except httpx.TransportError:
+                if pending_error is None:
+                    pending_error = response_failure(
+                        "network_error", "Data API response close transport failed"
+                    )
             except httpx.StreamError:
                 if pending_error is None:
-                    pending_error = (
-                        status_error(_decode_error_object(raw))
-                        if status >= 400
-                        else YouTubeApiError(
-                            "api_unavailable", status, "Data API response stream failed"
-                        )
+                    pending_error = response_failure(
+                        "api_unavailable", "Data API response stream failed"
                     )
 
         if pending_error is not None:

--- a/app/knowledge_acquisition/youtube_api_client.py
+++ b/app/knowledge_acquisition/youtube_api_client.py
@@ -523,8 +523,8 @@ class YouTubeApiClient:
         title = _required_str(snippet.get("title"))
         try:
             validate_channel_id(channel_id)
-        except InvalidYouTubeRefError as exc:
-            raise _shape_error() from exc
+        except InvalidYouTubeRefError:
+            raise _shape_error() from None
         return Channel(channel_id, title)
 
     def quota_status(self) -> dict[str, int | bool]:
@@ -561,58 +561,96 @@ class YouTubeApiClient:
             raise YouTubeApiError("api_unavailable", None, "Data API request timed out") from None
         except httpx.TransportError:
             raise YouTubeApiError("network_error", None, "Data API transport failed") from None
+        except httpx.StreamError:
+            raise YouTubeApiError("api_unavailable", None, "Data API stream failed") from None
 
-        try:
-            response_etag = response.headers.get("etag")
-            if response.status_code == 304 and allow_not_modified:
-                return NotModified(response_etag or etag), response_etag
-            if response.is_redirect:
-                location = response.headers.get("location")
-                if location:
-                    _validate_absolute_data_url(
-                        urljoin(str(request.url), location), require_path=True
-                    )
-                raise YouTubeApiError(
-                    "api_unavailable", response.status_code, "Data API redirect was refused"
-                )
-            try:
-                raw = _read_bounded(response, self._max_response_bytes)
-            except httpx.DecodingError:
-                if response.status_code >= 400:
-                    error = _mapped_http_error(response.status_code, {})
-                    if error.reason_code == "quota_exhausted":
-                        self._quota.mark_exhausted(quota_date)
-                    raise error from None
-                raise YouTubeApiError(
-                    "api_unavailable",
-                    response.status_code,
-                    "Data API response decoding failed",
-                ) from None
-            except YouTubeApiError:
-                if response.status_code >= 400:
-                    error = _mapped_http_error(response.status_code, {})
-                    if error.reason_code == "quota_exhausted":
-                        self._quota.mark_exhausted(quota_date)
-                    raise error from None
-                raise
-            except httpx.TimeoutException:
-                raise YouTubeApiError(
-                    "api_unavailable", response.status_code, "Data API response timed out"
-                ) from None
-            except httpx.TransportError:
-                raise YouTubeApiError(
-                    "network_error", response.status_code, "Data API response transport failed"
-                ) from None
-        finally:
-            response.close()
+        status = response.status_code
+        response_etag = response.headers.get("etag")
+        raw = b""
+        pending_error: Exception | None = None
+        not_modified: NotModified | None = None
 
-        if response.status_code >= 400:
-            payload = _decode_error_object(raw)
-            error = _mapped_http_error(response.status_code, payload)
+        def status_error(payload: Mapping[str, Any]) -> YouTubeApiError:
+            error = _mapped_http_error(status, payload)
             if error.reason_code == "quota_exhausted":
                 self._quota.mark_exhausted(quota_date)
-            raise error
-        payload = _decode_object(raw, status=response.status_code)
+            return error
+
+        try:
+            if status == 304 and allow_not_modified:
+                not_modified = NotModified(response_etag or etag)
+            elif response.is_redirect:
+                location = response.headers.get("location")
+                if location:
+                    try:
+                        _validate_absolute_data_url(
+                            urljoin(str(request.url), location), require_path=True
+                        )
+                    except DisallowedYouTubeHostError as error:
+                        pending_error = error
+                if pending_error is None:
+                    pending_error = YouTubeApiError(
+                        "api_unavailable", status, "Data API redirect was refused"
+                    )
+            elif not_modified is None:
+                try:
+                    raw = _read_bounded(response, self._max_response_bytes)
+                except httpx.DecodingError:
+                    pending_error = (
+                        status_error({})
+                        if status >= 400
+                        else YouTubeApiError(
+                            "api_unavailable",
+                            status,
+                            "Data API response decoding failed",
+                        )
+                    )
+                except YouTubeApiError as error:
+                    pending_error = status_error({}) if status >= 400 else error
+                except httpx.TimeoutException:
+                    pending_error = (
+                        status_error({})
+                        if status >= 400
+                        else YouTubeApiError(
+                            "api_unavailable", status, "Data API response timed out"
+                        )
+                    )
+                except httpx.TransportError:
+                    pending_error = (
+                        status_error({})
+                        if status >= 400
+                        else YouTubeApiError(
+                            "network_error", status, "Data API response transport failed"
+                        )
+                    )
+                except httpx.StreamError:
+                    pending_error = (
+                        status_error({})
+                        if status >= 400
+                        else YouTubeApiError(
+                            "api_unavailable", status, "Data API response stream failed"
+                        )
+                    )
+        finally:
+            try:
+                response.close()
+            except httpx.StreamError:
+                if pending_error is None:
+                    pending_error = (
+                        status_error(_decode_error_object(raw))
+                        if status >= 400
+                        else YouTubeApiError(
+                            "api_unavailable", status, "Data API response stream failed"
+                        )
+                    )
+
+        if pending_error is not None:
+            raise pending_error from None
+        if not_modified is not None:
+            return not_modified, response_etag
+        if status >= 400:
+            raise status_error(_decode_error_object(raw)) from None
+        payload = _decode_object(raw, status=status)
         return payload, response_etag
 
 
@@ -737,8 +775,8 @@ def _payload_page_token(payload: Mapping[str, Any]) -> str | None:
         raise _shape_error()
     try:
         return _validate_page_token(value)
-    except InvalidYouTubeRefError as exc:
-        raise _shape_error() from exc
+    except InvalidYouTubeRefError:
+        raise _shape_error() from None
 
 
 def _reject_token_cycle(previous: str | None, next_token: str) -> None:
@@ -760,8 +798,8 @@ def _parse_playlists(payload: Mapping[str, Any]) -> tuple[Playlist, ...]:
         try:
             validate_playlist_id(playlist_id)
             count = int(count_value)
-        except (InvalidYouTubeRefError, TypeError, ValueError) as exc:
-            raise _shape_error() from exc
+        except (InvalidYouTubeRefError, TypeError, ValueError):
+            raise _shape_error() from None
         if count < 0:
             raise _shape_error()
         parsed.append(Playlist(playlist_id, _required_str(snippet.get("title")), count))
@@ -784,8 +822,8 @@ def _parse_playlist_items(payload: Mapping[str, Any]) -> tuple[PlaylistItem, ...
         try:
             validate_video_id(video_id)
             position = int(position_value)
-        except (InvalidYouTubeRefError, TypeError, ValueError) as exc:
-            raise _shape_error() from exc
+        except (InvalidYouTubeRefError, TypeError, ValueError):
+            raise _shape_error() from None
         if position < 0:
             raise _shape_error()
         parsed.append(

--- a/app/knowledge_acquisition/youtube_api_client.py
+++ b/app/knowledge_acquisition/youtube_api_client.py
@@ -21,7 +21,7 @@ import threading
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
-from typing import Any, Protocol
+from typing import Any, NoReturn, Protocol
 from urllib.parse import urljoin, urlsplit
 
 import httpx
@@ -86,6 +86,13 @@ class YouTubeApiError(RuntimeError):
         self.status = status
         self.detail = detail
         super().__init__(f"{reason_code}: {detail}")
+
+
+def _raise_detached(error: BaseException) -> NoReturn:
+    """Raise a normalized failure without retaining a prior exception graph."""
+    error.__cause__ = None
+    error.__context__ = None
+    raise error from None
 
 
 @dataclass(frozen=True)
@@ -521,10 +528,13 @@ class YouTubeApiClient:
             raise _shape_error()
         channel_id = _required_str(item.get("id"))
         title = _required_str(snippet.get("title"))
+        shape_error: YouTubeApiError | None = None
         try:
             validate_channel_id(channel_id)
         except InvalidYouTubeRefError:
-            raise _shape_error() from None
+            shape_error = _shape_error()
+        if shape_error is not None:
+            _raise_detached(shape_error)
         return Channel(channel_id, title)
 
     def quota_status(self) -> dict[str, int | bool]:
@@ -555,14 +565,19 @@ class YouTubeApiClient:
         request.headers.pop("cookie", None)
         _validate_absolute_data_url(str(request.url), require_path=True)
         quota_date = self._quota.increment().quota_date
+        response: httpx.Response | None = None
+        send_error: YouTubeApiError | None = None
         try:
             response = self._http.send(request, stream=True, follow_redirects=False)
         except httpx.TimeoutException:
-            raise YouTubeApiError("api_unavailable", None, "Data API request timed out") from None
+            send_error = YouTubeApiError("api_unavailable", None, "Data API request timed out")
         except httpx.TransportError:
-            raise YouTubeApiError("network_error", None, "Data API transport failed") from None
+            send_error = YouTubeApiError("network_error", None, "Data API transport failed")
         except httpx.StreamError:
-            raise YouTubeApiError("api_unavailable", None, "Data API stream failed") from None
+            send_error = YouTubeApiError("api_unavailable", None, "Data API stream failed")
+        if send_error is not None:
+            _raise_detached(send_error)
+        assert response is not None
 
         status = response.status_code
         response_etag = response.headers.get("etag")
@@ -645,11 +660,11 @@ class YouTubeApiClient:
                     )
 
         if pending_error is not None:
-            raise pending_error from None
+            _raise_detached(pending_error)
         if not_modified is not None:
             return not_modified, response_etag
         if status >= 400:
-            raise status_error(_decode_error_object(raw)) from None
+            _raise_detached(status_error(_decode_error_object(raw)))
         payload = _decode_object(raw, status=status)
         return payload, response_etag
 
@@ -697,10 +712,14 @@ def _read_bounded(response: httpx.Response, maximum: int) -> bytes:
 
 
 def _decode_object(raw: bytes, *, status: int | None = None) -> dict[str, Any]:
+    value: Any = None
+    decode_error: YouTubeApiError | None = None
     try:
         value = json.loads(raw or b"{}")
     except (json.JSONDecodeError, UnicodeDecodeError):
-        raise YouTubeApiError("api_unavailable", status, "Data API returned invalid JSON") from None
+        decode_error = YouTubeApiError("api_unavailable", status, "Data API returned invalid JSON")
+    if decode_error is not None:
+        _raise_detached(decode_error)
     if not isinstance(value, dict):
         raise YouTubeApiError(
             "api_unavailable", status, "Data API returned an invalid object shape"
@@ -773,10 +792,15 @@ def _payload_page_token(payload: Mapping[str, Any]) -> str | None:
         return None
     if not isinstance(value, str):
         raise _shape_error()
+    validated: str | None = None
+    shape_error: YouTubeApiError | None = None
     try:
-        return _validate_page_token(value)
+        validated = _validate_page_token(value)
     except InvalidYouTubeRefError:
-        raise _shape_error() from None
+        shape_error = _shape_error()
+    if shape_error is not None:
+        _raise_detached(shape_error)
+    return validated
 
 
 def _reject_token_cycle(previous: str | None, next_token: str) -> None:
@@ -795,11 +819,16 @@ def _parse_playlists(payload: Mapping[str, Any]) -> tuple[Playlist, ...]:
         count_value = content.get("itemCount")
         if isinstance(count_value, bool) or not isinstance(count_value, (int, str)):
             raise _shape_error()
+        count: int | None = None
+        shape_error: YouTubeApiError | None = None
         try:
             validate_playlist_id(playlist_id)
             count = int(count_value)
         except (InvalidYouTubeRefError, TypeError, ValueError):
-            raise _shape_error() from None
+            shape_error = _shape_error()
+        if shape_error is not None:
+            _raise_detached(shape_error)
+        assert count is not None
         if count < 0:
             raise _shape_error()
         parsed.append(Playlist(playlist_id, _required_str(snippet.get("title")), count))
@@ -819,11 +848,16 @@ def _parse_playlist_items(payload: Mapping[str, Any]) -> tuple[PlaylistItem, ...
         position_value = snippet.get("position")
         if isinstance(position_value, bool) or not isinstance(position_value, (int, str)):
             raise _shape_error()
+        position: int | None = None
+        shape_error: YouTubeApiError | None = None
         try:
             validate_video_id(video_id)
             position = int(position_value)
         except (InvalidYouTubeRefError, TypeError, ValueError):
-            raise _shape_error() from None
+            shape_error = _shape_error()
+        if shape_error is not None:
+            _raise_detached(shape_error)
+        assert position is not None
         if position < 0:
             raise _shape_error()
         parsed.append(

--- a/app/knowledge_acquisition/youtube_api_client.py
+++ b/app/knowledge_acquisition/youtube_api_client.py
@@ -731,7 +731,7 @@ def _decode_object(raw: bytes, *, status: int | None = None) -> dict[str, Any]:
     decode_error: YouTubeApiError | None = None
     try:
         value = json.loads(raw or b"{}")
-    except (json.JSONDecodeError, UnicodeDecodeError):
+    except (json.JSONDecodeError, UnicodeDecodeError, RecursionError):
         decode_error = YouTubeApiError("api_unavailable", status, "Data API returned invalid JSON")
     if decode_error is not None:
         _raise_detached(decode_error)
@@ -746,7 +746,7 @@ def _decode_error_object(raw: bytes) -> dict[str, Any]:
     """Best-effort provider error parsing after HTTP status classification."""
     try:
         value = json.loads(raw or b"{}")
-    except (json.JSONDecodeError, UnicodeDecodeError):
+    except (json.JSONDecodeError, UnicodeDecodeError, RecursionError):
         return {}
     return value if isinstance(value, dict) else {}
 

--- a/tests/guard/test_no_direct_db_imports.py
+++ b/tests/guard/test_no_direct_db_imports.py
@@ -144,6 +144,12 @@ ALLOW_FILES = (
     # (youtube_account_binding) with a self-contained dual memory/pg backend,
     # direct DSN connection, no ORM layer to route through.
     'app/knowledge_acquisition/youtube_account_binding.py',
+    # YouTube Source Sync bounded Data API client + daily quota counter (YSS-03,
+    # #3918). The HTTP boundary owns one dedicated migration-backed quota table
+    # with the same explicit memory/pg backend and fail-loud schema preflight as
+    # the adjacent YSS stores; no other Data API caller or persistence path is
+    # introduced.
+    'app/knowledge_acquisition/youtube_api_client.py',
     # YouTube Source Sync durable acquisition request queue (YSS-04, #3919).
     # Same bounded pattern: a dedicated table (acquisition_requests) with a
     # self-contained dual memory/pg backend, direct DSN connection, no ORM

--- a/tests/knowledge_acquisition/test_youtube_api_client.py
+++ b/tests/knowledge_acquisition/test_youtube_api_client.py
@@ -442,6 +442,82 @@ def test_malformed_content_encoding_is_normalized_without_raw_cause() -> None:
     _assert_exception_graph_secret_free(captured.value, sentinel.decode())
 
 
+def test_recursive_provider_json_uses_status_taxonomy_and_quota_latch() -> None:
+    from app.knowledge_acquisition.youtube_api_client import YouTubeApiError
+
+    sentinel = "SENTINEL-recursive-provider-json-must-never-leak"
+    body = b'{"' + sentinel.encode() + b'":' + b'{"x":' * 10_000 + b"0" + b"}" * 10_000 + b"}"
+    response_holder: list[httpx.Response] = []
+
+    class _TrackedResponse(httpx.Response):
+        close_calls = 0
+
+        def close(self) -> None:
+            self.close_calls += 1
+            super().close()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        response = _TrackedResponse(
+            429,
+            request=request,
+            stream=httpx.ByteStream(body),
+        )
+        response_holder.append(response)
+        return response
+
+    client = _client(_Api(handler), budget=100)
+    with pytest.raises(YouTubeApiError) as captured:
+        client.get_my_channel()
+
+    error = captured.value
+    assert error.reason_code == "quota_exhausted"
+    assert error.status == 429
+    assert client.quota_status() == {
+        "spent_today": 1,
+        "budget": 100,
+        "exhausted": True,
+    }
+    assert response_holder[0].close_calls == 2
+    assert sentinel not in error.detail
+    assert sentinel not in "".join(traceback.format_exception(error))
+    _assert_exception_graph_secret_free(error, sentinel)
+
+
+def test_recursive_provider_json_on_success_is_safely_normalized() -> None:
+    from app.knowledge_acquisition.youtube_api_client import YouTubeApiError
+
+    sentinel = "SENTINEL-recursive-provider-json-must-never-leak"
+    body = b'{"' + sentinel.encode() + b'":' + b'{"x":' * 10_000 + b"0" + b"}" * 10_000 + b"}"
+    response_holder: list[httpx.Response] = []
+
+    class _TrackedResponse(httpx.Response):
+        close_calls = 0
+
+        def close(self) -> None:
+            self.close_calls += 1
+            super().close()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        response = _TrackedResponse(
+            200,
+            request=request,
+            stream=httpx.ByteStream(body),
+        )
+        response_holder.append(response)
+        return response
+
+    with pytest.raises(YouTubeApiError) as captured:
+        _client(_Api(handler)).get_my_channel()
+
+    error = captured.value
+    assert error.reason_code == "api_unavailable"
+    assert error.status == 200
+    assert response_holder[0].close_calls == 2
+    assert sentinel not in error.detail
+    assert sentinel not in "".join(traceback.format_exception(error))
+    _assert_exception_graph_secret_free(error, sentinel)
+
+
 @pytest.mark.parametrize(
     ("status", "reason_code"),
     ((401, "auth_expired"), (404, "source_gone"), (429, "quota_exhausted")),

--- a/tests/knowledge_acquisition/test_youtube_api_client.py
+++ b/tests/knowledge_acquisition/test_youtube_api_client.py
@@ -492,6 +492,87 @@ def test_actual_stream_error_on_success_status_is_safely_normalized(
     _assert_exception_graph_secret_free(error, sentinel)
 
 
+@pytest.mark.parametrize(
+    ("status", "allow_not_modified", "body", "headers", "fail_on_close", "status_reason"),
+    (
+        (304, True, b"", {"ETag": "etag-v2"}, 1, None),
+        (
+            302,
+            False,
+            b"",
+            {"Location": "https://www.googleapis.com/youtube/v3/channels"},
+            1,
+            "api_unavailable",
+        ),
+        (200, False, b'{"items": []}', {}, 2, None),
+        (401, False, b'{"error": {}}', {}, 2, "auth_expired"),
+    ),
+)
+@pytest.mark.parametrize(
+    ("failure_type", "close_reason"),
+    ((httpx.CloseError, "network_error"), (httpx.ReadTimeout, "api_unavailable")),
+)
+def test_explicit_response_close_failure_is_safely_normalized(
+    status: int,
+    allow_not_modified: bool,
+    body: bytes,
+    headers: dict[str, str],
+    fail_on_close: int,
+    status_reason: str | None,
+    failure_type: type[httpx.RequestError],
+    close_reason: str,
+) -> None:
+    from app.knowledge_acquisition.youtube_api_client import YouTubeApiError
+
+    sentinel = f"SENTINEL-explicit-close-{failure_type.__name__}-must-never-leak"
+    response_holder: list[httpx.Response] = []
+    stream_holder: list[httpx.SyncByteStream] = []
+
+    class _TrackedBodyStream(httpx.SyncByteStream):
+        iterations = 0
+
+        def __iter__(self):
+            self.iterations += 1
+            yield body
+
+    class _ExplicitCloseFailureResponse(httpx.Response):
+        close_calls = 0
+
+        def close(self) -> None:
+            self.close_calls += 1
+            if self.close_calls == fail_on_close:
+                raise failure_type(sentinel, request=self.request)
+            super().close()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        stream = _TrackedBodyStream()
+        response = _ExplicitCloseFailureResponse(
+            status,
+            request=request,
+            headers=headers,
+            stream=stream,
+        )
+        stream_holder.append(stream)
+        response_holder.append(response)
+        return response
+
+    client = _client(_Api(handler))
+    with pytest.raises(YouTubeApiError) as captured:
+        if allow_not_modified:
+            client.list_playlist_items("PL__test__playlist", etag="etag-v1")
+        else:
+            client.get_my_channel()
+
+    error = captured.value
+    assert error.reason_code == (status_reason or close_reason)
+    assert error.status == status
+    assert response_holder[0].close_calls == fail_on_close
+    assert stream_holder[0].iterations == (0 if status in {302, 304} else 1)
+    assert sentinel not in error.detail
+    assert sentinel not in "".join(traceback.format_exception(error))
+    _assert_exception_graph_secret_free(error, sentinel)
+
+
 @pytest.mark.parametrize("resource", ("playlists", "playlist_items"))
 def test_provider_controlled_shape_value_is_absent_from_exception_chain(
     resource: str,

--- a/tests/knowledge_acquisition/test_youtube_api_client.py
+++ b/tests/knowledge_acquisition/test_youtube_api_client.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from datetime import datetime, timezone
+import traceback
 from typing import Any
 
 import httpx
@@ -362,6 +363,134 @@ def test_malformed_content_encoding_is_normalized_without_raw_cause() -> None:
     assert captured.value.status == 200
     assert sentinel.decode() not in captured.value.detail
     assert captured.value.__cause__ is None
+
+
+@pytest.mark.parametrize(
+    ("status", "reason_code"),
+    ((401, "auth_expired"), (404, "source_gone"), (429, "quota_exhausted")),
+)
+@pytest.mark.parametrize("failure_stage", ("iterate", "close"))
+def test_actual_stream_error_uses_known_status_and_keeps_exception_chain_secret(
+    status: int,
+    reason_code: str,
+    failure_stage: str,
+) -> None:
+    from app.knowledge_acquisition.youtube_api_client import (
+        YouTubeApiError,
+        YouTubeQuotaStore,
+    )
+
+    sentinel = "SENTINEL-stream-error-must-never-leak"
+    now = {"value": datetime(2026, 7, 19, 23, 59, tzinfo=timezone.utc)}
+    quota = YouTubeQuotaStore.for_runtime(clock=lambda: now["value"])
+
+    class _ActualStreamError(httpx.SyncByteStream):
+        def __iter__(self):
+            if failure_stage == "iterate":
+                raise httpx.StreamError(sentinel)
+            yield b"not-json"
+
+        def close(self) -> None:
+            if failure_stage == "close":
+                raise httpx.StreamError(sentinel)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        now["value"] = datetime(2026, 7, 20, 0, 0, tzinfo=timezone.utc)
+        return httpx.Response(status, request=request, stream=_ActualStreamError())
+
+    with pytest.raises(YouTubeApiError) as captured:
+        _client(_Api(handler), quota=quota).get_my_channel()
+
+    error = captured.value
+    assert error.reason_code == reason_code
+    assert error.status == status
+    assert error.__cause__ is None
+    assert sentinel not in error.detail
+    assert sentinel not in "".join(traceback.format_exception(error))
+
+    if status == 429:
+        now["value"] = datetime(2026, 7, 19, 23, 59, tzinfo=timezone.utc)
+        assert quota.status(100) == {
+            "spent_today": 1,
+            "budget": 100,
+            "exhausted": True,
+        }
+        now["value"] = datetime(2026, 7, 20, 0, 0, tzinfo=timezone.utc)
+        assert quota.status(100) == {
+            "spent_today": 0,
+            "budget": 100,
+            "exhausted": False,
+        }
+
+
+@pytest.mark.parametrize("failure_stage", ("iterate", "close"))
+def test_actual_stream_error_on_success_status_is_safely_normalized(
+    failure_stage: str,
+) -> None:
+    from app.knowledge_acquisition.youtube_api_client import YouTubeApiError
+
+    sentinel = "SENTINEL-stream-error-must-never-leak"
+
+    class _ActualStreamError(httpx.SyncByteStream):
+        def __iter__(self):
+            if failure_stage == "iterate":
+                raise httpx.StreamError(sentinel)
+            yield b'{"items": []}'
+
+        def close(self) -> None:
+            if failure_stage == "close":
+                raise httpx.StreamError(sentinel)
+
+    api = _Api(lambda request: httpx.Response(200, request=request, stream=_ActualStreamError()))
+    with pytest.raises(YouTubeApiError) as captured:
+        _client(api).get_my_channel()
+
+    error = captured.value
+    assert error.reason_code == "api_unavailable"
+    assert error.status == 200
+    assert error.__cause__ is None
+    assert sentinel not in error.detail
+    assert sentinel not in "".join(traceback.format_exception(error))
+
+
+@pytest.mark.parametrize("resource", ("playlists", "playlist_items"))
+def test_provider_controlled_shape_value_is_absent_from_exception_chain(
+    resource: str,
+) -> None:
+    from app.knowledge_acquisition.youtube_api_client import YouTubeApiError
+
+    sentinel = "SENTINEL-provider-field-must-never-leak"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if resource == "playlists":
+            return _response(
+                request,
+                {
+                    "items": [
+                        {
+                            "id": "PL__test__owned",
+                            "snippet": {"title": "Owned"},
+                            "contentDetails": {"itemCount": sentinel},
+                        }
+                    ]
+                },
+            )
+        item = _playlist_item(1)
+        item["snippet"]["position"] = sentinel
+        return _response(request, {"items": [item]})
+
+    with pytest.raises(YouTubeApiError) as captured:
+        client = _client(_Api(handler))
+        if resource == "playlists":
+            client.list_my_playlists()
+        else:
+            client.list_playlist_items("PL__test__playlist")
+
+    error = captured.value
+    assert error.reason_code == "api_unavailable"
+    assert error.__cause__ is None
+    assert sentinel not in error.detail
+    assert sentinel not in "".join(traceback.format_exception(error))
 
 
 def test_quota_accounting_durable_and_exhaustion() -> None:

--- a/tests/knowledge_acquisition/test_youtube_api_client.py
+++ b/tests/knowledge_acquisition/test_youtube_api_client.py
@@ -45,6 +45,39 @@ class _Api:
         return self._handler(request)
 
 
+def _exception_graph(error: BaseException) -> tuple[BaseException, ...]:
+    pending = [error]
+    seen: set[int] = set()
+    graph: list[BaseException] = []
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        graph.append(current)
+        if current.__cause__ is not None:
+            pending.append(current.__cause__)
+        if current.__context__ is not None:
+            pending.append(current.__context__)
+    return tuple(graph)
+
+
+def _assert_exception_graph_secret_free(error: BaseException, sentinel: str) -> None:
+    graph = _exception_graph(error)
+    for current in graph:
+        inspectable = "\n".join(
+            (
+                str(current),
+                repr(current),
+                repr(current.args),
+                repr(vars(current)),
+            )
+        )
+        assert sentinel not in inspectable
+    assert error.__cause__ is None
+    assert error.__context__ is None
+
+
 @pytest.fixture(autouse=True)
 def _memory_quota(monkeypatch: pytest.MonkeyPatch):
     from app.knowledge_acquisition import youtube_api_client as api
@@ -256,6 +289,7 @@ def test_error_taxonomy_mapping_secret_free() -> None:
         assert sentinel not in error.detail
         assert sentinel not in str(error)
         assert "sentinel-access-token-never-leak" not in error.detail
+        _assert_exception_graph_secret_free(error, sentinel)
 
     timeout_api = _Api(
         lambda request: (_ for _ in ()).throw(httpx.ReadTimeout(sentinel, request=request))
@@ -264,7 +298,7 @@ def test_error_taxonomy_mapping_secret_free() -> None:
         _client(timeout_api).get_my_channel()
     assert timeout_error.value.reason_code == "api_unavailable"
     assert sentinel not in timeout_error.value.detail
-    assert timeout_error.value.__cause__ is None
+    _assert_exception_graph_secret_free(timeout_error.value, sentinel)
 
     network_api = _Api(
         lambda request: (_ for _ in ()).throw(httpx.ConnectError(sentinel, request=request))
@@ -273,7 +307,7 @@ def test_error_taxonomy_mapping_secret_free() -> None:
         _client(network_api).get_my_channel()
     assert network_error.value.reason_code == "network_error"
     assert sentinel not in network_error.value.detail
-    assert network_error.value.__cause__ is None
+    _assert_exception_graph_secret_free(network_error.value, sentinel)
 
     class _FailingResponseStream(httpx.SyncByteStream):
         def __iter__(self):
@@ -290,7 +324,7 @@ def test_error_taxonomy_mapping_secret_free() -> None:
         _client(stream_api).get_my_channel()
     assert stream_error.value.reason_code == "network_error"
     assert sentinel not in stream_error.value.detail
-    assert stream_error.value.__cause__ is None
+    _assert_exception_graph_secret_free(stream_error.value, sentinel)
 
     invalid_json_api = _Api(
         lambda request: httpx.Response(
@@ -302,7 +336,7 @@ def test_error_taxonomy_mapping_secret_free() -> None:
     with pytest.raises(YouTubeApiError) as invalid_json_error:
         _client(invalid_json_api).get_my_channel()
     assert invalid_json_error.value.reason_code == "api_unavailable"
-    assert invalid_json_error.value.__cause__ is None
+    _assert_exception_graph_secret_free(invalid_json_error.value, sentinel)
 
     auth_api = _Api(lambda request: _response(request, {"items": []}))
     with pytest.raises(AuthDegradedError) as auth_error:
@@ -362,7 +396,7 @@ def test_malformed_content_encoding_is_normalized_without_raw_cause() -> None:
     assert captured.value.reason_code == "api_unavailable"
     assert captured.value.status == 200
     assert sentinel.decode() not in captured.value.detail
-    assert captured.value.__cause__ is None
+    _assert_exception_graph_secret_free(captured.value, sentinel.decode())
 
 
 @pytest.mark.parametrize(
@@ -404,9 +438,9 @@ def test_actual_stream_error_uses_known_status_and_keeps_exception_chain_secret(
     error = captured.value
     assert error.reason_code == reason_code
     assert error.status == status
-    assert error.__cause__ is None
     assert sentinel not in error.detail
     assert sentinel not in "".join(traceback.format_exception(error))
+    _assert_exception_graph_secret_free(error, sentinel)
 
     if status == 429:
         now["value"] = datetime(2026, 7, 19, 23, 59, tzinfo=timezone.utc)
@@ -423,7 +457,7 @@ def test_actual_stream_error_uses_known_status_and_keeps_exception_chain_secret(
         }
 
 
-@pytest.mark.parametrize("failure_stage", ("iterate", "close"))
+@pytest.mark.parametrize("failure_stage", ("send", "iterate", "close"))
 def test_actual_stream_error_on_success_status_is_safely_normalized(
     failure_stage: str,
 ) -> None:
@@ -441,16 +475,21 @@ def test_actual_stream_error_on_success_status_is_safely_normalized(
             if failure_stage == "close":
                 raise httpx.StreamError(sentinel)
 
-    api = _Api(lambda request: httpx.Response(200, request=request, stream=_ActualStreamError()))
+    def handler(request: httpx.Request) -> httpx.Response:
+        if failure_stage == "send":
+            raise httpx.StreamError(sentinel)
+        return httpx.Response(200, request=request, stream=_ActualStreamError())
+
+    api = _Api(handler)
     with pytest.raises(YouTubeApiError) as captured:
         _client(api).get_my_channel()
 
     error = captured.value
     assert error.reason_code == "api_unavailable"
-    assert error.status == 200
-    assert error.__cause__ is None
+    assert error.status == (None if failure_stage == "send" else 200)
     assert sentinel not in error.detail
     assert sentinel not in "".join(traceback.format_exception(error))
+    _assert_exception_graph_secret_free(error, sentinel)
 
 
 @pytest.mark.parametrize("resource", ("playlists", "playlist_items"))
@@ -488,9 +527,9 @@ def test_provider_controlled_shape_value_is_absent_from_exception_chain(
 
     error = captured.value
     assert error.reason_code == "api_unavailable"
-    assert error.__cause__ is None
     assert sentinel not in error.detail
     assert sentinel not in "".join(traceback.format_exception(error))
+    _assert_exception_graph_secret_free(error, sentinel)
 
 
 def test_quota_accounting_durable_and_exhaustion() -> None:

--- a/tests/knowledge_acquisition/test_youtube_api_client.py
+++ b/tests/knowledge_acquisition/test_youtube_api_client.py
@@ -10,6 +10,7 @@ headers never enter structured error details (INV-YSS-5).
 from __future__ import annotations
 
 from collections.abc import Callable
+from datetime import datetime, timezone
 from typing import Any
 
 import httpx
@@ -67,6 +68,7 @@ def _client(
     budget: int = 10_000,
     max_response_bytes: int = 2 * 1024 * 1024,
     cookies: dict[str, str] | None = None,
+    quota: Any | None = None,
 ):
     from app.knowledge_acquisition.youtube_api_client import YouTubeApiClient
 
@@ -76,6 +78,7 @@ def _client(
         max_pages=max_pages,
         quota_budget=budget,
         max_response_bytes=max_response_bytes,
+        quota=quota,
     )
 
 
@@ -307,6 +310,60 @@ def test_error_taxonomy_mapping_secret_free() -> None:
     assert auth_api.requests == []
 
 
+@pytest.mark.parametrize(
+    ("status", "reason_code"),
+    ((401, "auth_expired"), (404, "source_gone"), (429, "quota_exhausted")),
+)
+@pytest.mark.parametrize("body", (b"not-json", b"x" * 256))
+def test_http_status_taxonomy_survives_non_json_and_oversized_bodies(
+    status: int,
+    reason_code: str,
+    body: bytes,
+) -> None:
+    from app.knowledge_acquisition.youtube_api_client import YouTubeApiError
+
+    api = _Api(
+        lambda request: httpx.Response(
+            status,
+            request=request,
+            content=body,
+        )
+    )
+    with pytest.raises(YouTubeApiError) as captured:
+        _client(api, max_response_bytes=64).get_my_channel()
+
+    assert captured.value.reason_code == reason_code
+    assert captured.value.status == status
+    if status == 429:
+        assert (
+            _client(_Api(lambda request: _response(request, {"items": []}))).quota_status()[
+                "exhausted"
+            ]
+            is True
+        )
+
+
+def test_malformed_content_encoding_is_normalized_without_raw_cause() -> None:
+    from app.knowledge_acquisition.youtube_api_client import YouTubeApiError
+
+    sentinel = b"SENTINEL-malformed-gzip-must-never-leak"
+    api = _Api(
+        lambda request: httpx.Response(
+            200,
+            request=request,
+            headers={"Content-Encoding": "gzip"},
+            stream=httpx.ByteStream(sentinel),
+        )
+    )
+    with pytest.raises(YouTubeApiError) as captured:
+        _client(api).get_my_channel()
+
+    assert captured.value.reason_code == "api_unavailable"
+    assert captured.value.status == 200
+    assert sentinel.decode() not in captured.value.detail
+    assert captured.value.__cause__ is None
+
+
 def test_quota_accounting_durable_and_exhaustion() -> None:
     from app.knowledge_acquisition.youtube_api_client import YouTubeApiError
 
@@ -336,6 +393,28 @@ def test_quota_accounting_durable_and_exhaustion() -> None:
         "budget": 100,
         "exhausted": True,
     }
+
+
+def test_quota_exhaustion_latches_the_request_day_across_utc_rollover() -> None:
+    from app.knowledge_acquisition.youtube_api_client import (
+        YouTubeApiError,
+        YouTubeQuotaStore,
+    )
+
+    now = {"value": datetime(2026, 7, 19, 23, 59, tzinfo=timezone.utc)}
+    quota = YouTubeQuotaStore.for_runtime(clock=lambda: now["value"])
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        now["value"] = datetime(2026, 7, 20, 0, 0, tzinfo=timezone.utc)
+        return httpx.Response(429, request=request, content=b"not-json")
+
+    with pytest.raises(YouTubeApiError, match="quota_exhausted"):
+        _client(_Api(handler), quota=quota).get_my_channel()
+
+    now["value"] = datetime(2026, 7, 19, 23, 59, tzinfo=timezone.utc)
+    assert quota.status(100) == {"spent_today": 1, "budget": 100, "exhausted": True}
+    now["value"] = datetime(2026, 7, 20, 0, 0, tzinfo=timezone.utc)
+    assert quota.status(100) == {"spent_today": 0, "budget": 100, "exhausted": False}
 
 
 def test_resource_shapes_minimal_fields_and_response_bound() -> None:

--- a/tests/knowledge_acquisition/test_youtube_api_client.py
+++ b/tests/knowledge_acquisition/test_youtube_api_client.py
@@ -1,0 +1,390 @@
+"""YSS-03 (#3918): bounded YouTube Data API client contract.
+
+All egress runs through ``httpx.MockTransport`` while exercising the real
+request-building, host-validation, response-bounding, parsing, pagination,
+error-mapping, and quota-accounting call sites. Fixture ids are synthetic
+(INV-YSS-9), and planted secret sentinels prove provider bodies and auth
+headers never enter structured error details (INV-YSS-5).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+import pytest
+
+from app.knowledge_acquisition.youtube_oauth import AuthDegradedError
+
+
+class _TokenProvider:
+    def __init__(self, token: str = "sentinel-access-token-never-leak") -> None:
+        self.token = token
+        self.calls = 0
+
+    def get_access_token(self) -> str:
+        self.calls += 1
+        return self.token
+
+
+class _RevokedTokenProvider:
+    def get_access_token(self) -> str:
+        raise AuthDegradedError("auth_revoked")
+
+
+class _Api:
+    def __init__(self, handler: Callable[[httpx.Request], httpx.Response]) -> None:
+        self.requests: list[httpx.Request] = []
+        self._handler = handler
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        return self._handler(request)
+
+
+@pytest.fixture(autouse=True)
+def _memory_quota(monkeypatch: pytest.MonkeyPatch):
+    from app.knowledge_acquisition import youtube_api_client as api
+
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    api.reset_memory_youtube_quota()
+    yield
+    api.reset_memory_youtube_quota()
+
+
+def _response(
+    request: httpx.Request, payload: dict[str, Any], *, status: int = 200
+) -> httpx.Response:
+    return httpx.Response(status, request=request, json=payload)
+
+
+def _client(
+    api: _Api,
+    *,
+    token_provider: Any | None = None,
+    max_pages: int = 10,
+    budget: int = 10_000,
+    max_response_bytes: int = 2 * 1024 * 1024,
+    cookies: dict[str, str] | None = None,
+):
+    from app.knowledge_acquisition.youtube_api_client import YouTubeApiClient
+
+    return YouTubeApiClient(
+        token_provider=token_provider or _TokenProvider(),
+        http=httpx.Client(transport=httpx.MockTransport(api.handler), cookies=cookies),
+        max_pages=max_pages,
+        quota_budget=budget,
+        max_response_bytes=max_response_bytes,
+    )
+
+
+def _playlist_item(n: int) -> dict[str, Any]:
+    return {
+        "id": f"PLI__test__{n}",
+        "snippet": {
+            "position": n,
+            "publishedAt": "2026-07-19T00:00:00Z",
+            "title": f"Fixture video {n}",
+            "resourceId": {"videoId": f"vidTEST{n:04d}"},
+        },
+    }
+
+
+def test_pagination_and_bounded_page_cap() -> None:
+    from app.knowledge_acquisition.youtube_api_client import PlaylistItemsPage
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        token = request.url.params.get("pageToken")
+        page = {None: 1, "page-2": 2, "page-3": 3}[token]
+        next_token = {1: "page-2", 2: "page-3", 3: None}[page]
+        payload: dict[str, Any] = {"etag": "etag-first", "items": [_playlist_item(page)]}
+        if next_token:
+            payload["nextPageToken"] = next_token
+        return _response(request, payload)
+
+    complete_api = _Api(handler)
+    complete = _client(
+        complete_api,
+        max_pages=3,
+        cookies={"session": "sentinel-cookie-must-not-cross-boundary"},
+    ).list_playlist_items("PL__test__playlist")
+    assert isinstance(complete, PlaylistItemsPage)
+    assert [item.position for item in complete.items] == [1, 2, 3]
+    assert complete.pagination_truncated is False
+    assert complete.next_page_token is None
+    assert complete.etag == "etag-first"
+    assert len(complete_api.requests) == 3
+
+    capped_api = _Api(handler)
+    capped = _client(capped_api, max_pages=2).list_playlist_items("PL__test__playlist")
+    assert isinstance(capped, PlaylistItemsPage)
+    assert [item.position for item in capped.items] == [1, 2]
+    assert capped.pagination_truncated is True
+    assert capped.next_page_token == "page-3"
+    assert len(capped_api.requests) == 2
+
+    for request in complete_api.requests + capped_api.requests:
+        assert request.url.host == "www.googleapis.com"
+        assert request.url.params["maxResults"] == "50"
+        assert request.url.params["part"] == "snippet"
+        assert "items(id,snippet(" in request.url.params["fields"]
+        assert "cookie" not in request.headers
+
+    def playlists_handler(request: httpx.Request) -> httpx.Response:
+        token = request.url.params.get("pageToken")
+        page = 1 if token is None else 2
+        payload: dict[str, Any] = {
+            "items": [
+                {
+                    "id": f"PL__test__owned_{page}",
+                    "snippet": {"title": f"Owned {page}"},
+                    "contentDetails": {"itemCount": page},
+                }
+            ]
+        }
+        if page == 1:
+            payload["nextPageToken"] = "owned-page-2"
+        return _response(request, payload)
+
+    playlists_api = _Api(playlists_handler)
+    playlists = _client(playlists_api, max_pages=2).list_my_playlists()
+    assert [row.playlist_id for row in playlists.items] == [
+        "PL__test__owned_1",
+        "PL__test__owned_2",
+    ]
+    assert playlists.pagination_truncated is False
+    assert playlists.next_page_token is None
+    assert playlists_api.requests[1].url.params["pageToken"] == "owned-page-2"
+
+
+def test_etag_not_modified_roundtrip() -> None:
+    from app.knowledge_acquisition.youtube_api_client import NotModified
+
+    api = _Api(lambda request: httpx.Response(304, request=request, headers={"ETag": "etag-v2"}))
+    result = _client(api).list_playlist_items("PL__test__playlist", etag="etag-v1")
+
+    assert isinstance(result, NotModified)
+    assert result.not_modified is True
+    assert result.etag == "etag-v2"
+    assert api.requests[0].headers["If-None-Match"] == "etag-v1"
+    assert (
+        _client(_Api(lambda request: _response(request, {"items": []}))).quota_status()[
+            "spent_today"
+        ]
+        == 1
+    )
+
+
+def test_host_allowlist_and_ref_validation() -> None:
+    from app.knowledge_acquisition.youtube_api_client import (
+        DisallowedYouTubeHostError,
+        InvalidYouTubeRefError,
+        YouTubeApiClient,
+        validate_channel_id,
+        validate_video_id,
+    )
+
+    token_provider = _TokenProvider()
+    api = _Api(lambda request: _response(request, {"items": []}))
+    client = _client(api, token_provider=token_provider)
+
+    for invalid in ("", "WL", "HL", "https://evil.example/playlist", "PL bad", "XX123"):
+        with pytest.raises(InvalidYouTubeRefError):
+            client.list_playlist_items(invalid)
+    with pytest.raises(InvalidYouTubeRefError):
+        validate_video_id("too-short")
+    with pytest.raises(InvalidYouTubeRefError):
+        validate_channel_id("PL__not_a_channel")
+    assert api.requests == []
+    assert token_provider.calls == 0
+
+    with pytest.raises(DisallowedYouTubeHostError):
+        YouTubeApiClient(
+            token_provider=token_provider,
+            http=httpx.Client(transport=httpx.MockTransport(api.handler)),
+            base_url="https://evil.example/youtube/v3",
+        )
+    with pytest.raises(DisallowedYouTubeHostError):
+        YouTubeApiClient(
+            token_provider=token_provider,
+            http=httpx.Client(transport=httpx.MockTransport(api.handler)),
+            base_url="https://www.googleapis.com/youtube/v3-impersonator/",
+        )
+
+    redirect_api = _Api(
+        lambda request: httpx.Response(
+            302, request=request, headers={"Location": "https://evil.example/steal"}
+        )
+    )
+    with pytest.raises(DisallowedYouTubeHostError):
+        _client(redirect_api).get_my_channel()
+    assert len(redirect_api.requests) == 1
+
+
+def test_error_taxonomy_mapping_secret_free() -> None:
+    from app.knowledge_acquisition.youtube_api_client import YouTubeApiError
+
+    sentinel = "SENTINEL-provider-body-must-never-leak"
+
+    cases = (
+        (
+            403,
+            {"error": {"message": sentinel, "errors": [{"reason": "quotaExceeded"}]}},
+            "quota_exhausted",
+        ),
+        (
+            403,
+            {"error": {"message": sentinel, "errors": [{"reason": "playlistItemsNotAccessible"}]}},
+            "source_gone",
+        ),
+        (404, {"error": {"message": sentinel}}, "source_gone"),
+        (503, {"error": {"message": sentinel}}, "api_unavailable"),
+        (401, {"error": {"message": sentinel}}, "auth_expired"),
+    )
+    for status, payload, reason_code in cases:
+        api = _Api(lambda request, s=status, p=payload: _response(request, p, status=s))
+        with pytest.raises(YouTubeApiError) as captured:
+            _client(api).get_my_channel()
+        error = captured.value
+        assert error.reason_code == reason_code
+        assert error.status == status
+        assert sentinel not in error.detail
+        assert sentinel not in str(error)
+        assert "sentinel-access-token-never-leak" not in error.detail
+
+    timeout_api = _Api(
+        lambda request: (_ for _ in ()).throw(httpx.ReadTimeout(sentinel, request=request))
+    )
+    with pytest.raises(YouTubeApiError) as timeout_error:
+        _client(timeout_api).get_my_channel()
+    assert timeout_error.value.reason_code == "api_unavailable"
+    assert sentinel not in timeout_error.value.detail
+    assert timeout_error.value.__cause__ is None
+
+    network_api = _Api(
+        lambda request: (_ for _ in ()).throw(httpx.ConnectError(sentinel, request=request))
+    )
+    with pytest.raises(YouTubeApiError) as network_error:
+        _client(network_api).get_my_channel()
+    assert network_error.value.reason_code == "network_error"
+    assert sentinel not in network_error.value.detail
+    assert network_error.value.__cause__ is None
+
+    class _FailingResponseStream(httpx.SyncByteStream):
+        def __iter__(self):
+            raise httpx.ReadError(sentinel)
+
+    stream_api = _Api(
+        lambda request: httpx.Response(
+            200,
+            request=request,
+            stream=_FailingResponseStream(),
+        )
+    )
+    with pytest.raises(YouTubeApiError) as stream_error:
+        _client(stream_api).get_my_channel()
+    assert stream_error.value.reason_code == "network_error"
+    assert sentinel not in stream_error.value.detail
+    assert stream_error.value.__cause__ is None
+
+    invalid_json_api = _Api(
+        lambda request: httpx.Response(
+            200,
+            request=request,
+            content=b'{"provider_secret":"SENTINEL-provider-body-must-never-leak",',
+        )
+    )
+    with pytest.raises(YouTubeApiError) as invalid_json_error:
+        _client(invalid_json_api).get_my_channel()
+    assert invalid_json_error.value.reason_code == "api_unavailable"
+    assert invalid_json_error.value.__cause__ is None
+
+    auth_api = _Api(lambda request: _response(request, {"items": []}))
+    with pytest.raises(AuthDegradedError) as auth_error:
+        _client(auth_api, token_provider=_RevokedTokenProvider()).get_my_channel()
+    assert auth_error.value.reason_code == "auth_revoked"
+    assert auth_api.requests == []
+
+
+def test_quota_accounting_durable_and_exhaustion() -> None:
+    from app.knowledge_acquisition.youtube_api_client import YouTubeApiError
+
+    ok_api = _Api(lambda request: _response(request, {"items": []}))
+    first = _client(ok_api, budget=2)
+    first.list_my_playlists()
+    assert first.quota_status() == {"spent_today": 1, "budget": 2, "exhausted": False}
+
+    # A distinct client + quota-store instance sees the same process-wide memory
+    # fallback row. The Postgres backend uses the same per-day key durably.
+    second = _client(ok_api, budget=2)
+    second.list_my_playlists()
+    assert second.quota_status() == {"spent_today": 2, "budget": 2, "exhausted": True}
+
+    quota_api = _Api(
+        lambda request: _response(
+            request,
+            {"error": {"errors": [{"reason": "rateLimitExceeded"}]}},
+            status=403,
+        )
+    )
+    quota_client = _client(quota_api, budget=100)
+    with pytest.raises(YouTubeApiError, match="quota_exhausted"):
+        quota_client.get_my_channel()
+    assert quota_client.quota_status() == {
+        "spent_today": 3,
+        "budget": 100,
+        "exhausted": True,
+    }
+
+
+def test_resource_shapes_minimal_fields_and_response_bound() -> None:
+    from app.knowledge_acquisition.youtube_api_client import YouTubeApiError
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/playlists"):
+            return _response(
+                request,
+                {
+                    "items": [
+                        {
+                            "id": "PL__test__owned",
+                            "snippet": {"title": "Owned"},
+                            "contentDetails": {"itemCount": 7},
+                        }
+                    ]
+                },
+            )
+        return _response(
+            request,
+            {"items": [{"id": "UC__test__channel", "snippet": {"title": "Fixture channel"}}]},
+        )
+
+    api = _Api(handler)
+    client = _client(api)
+    playlists = client.list_my_playlists()
+    channel = client.get_my_channel()
+    assert [(row.playlist_id, row.title, row.item_count) for row in playlists.items] == [
+        ("PL__test__owned", "Owned", 7)
+    ]
+    assert (channel.channel_id, channel.title, channel.liked_videos_ref) == (
+        "UC__test__channel",
+        "Fixture channel",
+        "LL",
+    )
+    assert api.requests[0].url.params["mine"] == "true"
+    assert api.requests[0].url.params["part"] == "snippet,contentDetails"
+    assert api.requests[1].url.params["mine"] == "true"
+    assert api.requests[1].url.params["part"] == "snippet"
+
+    oversize = _Api(
+        lambda request: httpx.Response(
+            200,
+            request=request,
+            content=b'{"items":["' + (b"x" * 200) + b'"]}',
+        )
+    )
+    with pytest.raises(YouTubeApiError) as captured:
+        _client(oversize, max_response_bytes=64).get_my_channel()
+    assert captured.value.reason_code == "api_unavailable"
+    assert "response exceeded" in captured.value.detail

--- a/tests/knowledge_acquisition/test_youtube_api_client.py
+++ b/tests/knowledge_acquisition/test_youtube_api_client.py
@@ -259,6 +259,49 @@ def test_host_allowlist_and_ref_validation() -> None:
     assert len(redirect_api.requests) == 1
 
 
+@pytest.mark.parametrize(
+    "location",
+    (
+        "https://[SENTINEL-malformed-redirect/youtube/v3/channels",
+        "https://www.googleapis.com:65536/youtube/v3/channels"
+        "?provider=SENTINEL-malformed-redirect",
+    ),
+)
+def test_malformed_redirect_location_is_safely_normalized(location: str) -> None:
+    from app.knowledge_acquisition.youtube_api_client import YouTubeApiError
+
+    sentinel = "SENTINEL-malformed-redirect"
+    response_holder: list[httpx.Response] = []
+
+    class _TrackedRedirectResponse(httpx.Response):
+        close_calls = 0
+
+        def close(self) -> None:
+            self.close_calls += 1
+            super().close()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        response = _TrackedRedirectResponse(
+            302,
+            request=request,
+            headers={"Location": location},
+            stream=httpx.ByteStream(b"provider body must remain unread"),
+        )
+        response_holder.append(response)
+        return response
+
+    with pytest.raises(YouTubeApiError) as captured:
+        _client(_Api(handler)).get_my_channel()
+
+    error = captured.value
+    assert error.reason_code == "api_unavailable"
+    assert error.status == 302
+    assert response_holder[0].close_calls == 1
+    assert sentinel not in error.detail
+    assert sentinel not in "".join(traceback.format_exception(error))
+    _assert_exception_graph_secret_free(error, sentinel)
+
+
 def test_error_taxonomy_mapping_secret_free() -> None:
     from app.knowledge_acquisition.youtube_api_client import YouTubeApiError
 

--- a/tests/knowledge_acquisition/test_youtube_api_quota_pg.py
+++ b/tests/knowledge_acquisition/test_youtube_api_quota_pg.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from pathlib import Path
+from threading import Barrier
 
 import psycopg
 import pytest
@@ -80,10 +82,34 @@ def test_pg_quota_counter_is_durable_atomic_and_forward_only(
     first.increment()
     first.increment()
 
+    workers = 8
+    increments_per_worker = 12
+    start = Barrier(workers)
+
+    def increment_concurrently() -> None:
+        quota = YouTubeQuotaStore.for_runtime(clock=clock)
+        start.wait()
+        for _ in range(increments_per_worker):
+            quota.increment()
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = [pool.submit(increment_concurrently) for _ in range(workers)]
+        for future in futures:
+            future.result()
+
+    expected_spent = 2 + workers * increments_per_worker
     second = YouTubeQuotaStore.for_runtime(clock=clock)
-    assert second.status(10) == {"spent_today": 2, "budget": 10, "exhausted": False}
+    assert second.status(1_000) == {
+        "spent_today": expected_spent,
+        "budget": 1_000,
+        "exhausted": False,
+    }
     second.mark_exhausted()
-    assert first.status(10) == {"spent_today": 2, "budget": 10, "exhausted": True}
+    assert first.status(1_000) == {
+        "spent_today": expected_spent,
+        "budget": 1_000,
+        "exhausted": True,
+    }
 
     with pytest.raises(RuntimeError, match="forward-only"):
         command.downgrade(migrated_quota_database, PRE_YSS03_HEAD)

--- a/tests/knowledge_acquisition/test_youtube_api_quota_pg.py
+++ b/tests/knowledge_acquisition/test_youtube_api_quota_pg.py
@@ -1,0 +1,89 @@
+"""YSS-03 durable quota accounting against the migration-owned Postgres row."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from pathlib import Path
+
+import psycopg
+import pytest
+from alembic import command
+from alembic.config import Config
+from psycopg.conninfo import conninfo_to_dict, make_conninfo
+from sqlalchemy.engine import URL
+
+from app.knowledge_acquisition.youtube_api_client import YouTubeQuotaStore
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PRE_YSS03_HEAD = "c8d9e0f1a2b3"
+YSS03_HEAD = "d9e0f1a2b3c4"
+
+
+def _alembic_config() -> Config:
+    config = Config(str(REPO_ROOT / "alembic.ini"))
+    config.set_main_option("script_location", str(REPO_ROOT / "app" / "alembic"))
+    return config
+
+
+@pytest.fixture
+def migrated_quota_database(monkeypatch: pytest.MonkeyPatch) -> Iterator[Config]:
+    from app.db.dsn import resolve_dsn
+
+    admin_dsn = resolve_dsn()
+    if not admin_dsn:
+        pytest.skip("DATABASE_URL/DB_DSN not configured")
+    try:
+        with psycopg.connect(admin_dsn, connect_timeout=2):
+            pass
+    except Exception as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"Postgres unavailable: {exc}")
+
+    database_name = f"scratch_yss03_quota_{uuid.uuid4().hex[:12]}"
+    scratch_params = conninfo_to_dict(admin_dsn)
+    scratch_params["dbname"] = database_name
+    scratch_conninfo = make_conninfo(**scratch_params)
+    scratch_url = URL.create(
+        "postgresql",
+        username=scratch_params.get("user"),
+        password=scratch_params.get("password"),
+        host=scratch_params.get("host"),
+        port=int(scratch_params["port"]) if scratch_params.get("port") else None,
+        database=database_name,
+    ).render_as_string(hide_password=False)
+
+    with psycopg.connect(admin_dsn, autocommit=True) as conn:
+        conn.execute(f'CREATE DATABASE "{database_name}"')
+    try:
+        with psycopg.connect(scratch_conninfo, autocommit=True) as conn:
+            conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
+        monkeypatch.setenv("DATABASE_URL", scratch_url)
+        monkeypatch.delenv("DB_DSN", raising=False)
+        monkeypatch.delenv("STORE_SCHEMA_AUTOCREATE", raising=False)
+        monkeypatch.delenv("STORE_BACKEND", raising=False)
+        config = _alembic_config()
+        command.upgrade(config, YSS03_HEAD)
+        yield config
+    finally:
+        with psycopg.connect(admin_dsn, autocommit=True) as conn:
+            conn.execute(f'DROP DATABASE IF EXISTS "{database_name}" WITH (FORCE)')
+
+
+@pytest.mark.pg
+def test_pg_quota_counter_is_durable_atomic_and_forward_only(
+    migrated_quota_database: Config,
+) -> None:
+    clock = lambda: datetime(2026, 7, 19, 23, 59, tzinfo=timezone.utc)
+    first = YouTubeQuotaStore.for_runtime(clock=clock)
+    assert first.status(10) == {"spent_today": 0, "budget": 10, "exhausted": False}
+    first.increment()
+    first.increment()
+
+    second = YouTubeQuotaStore.for_runtime(clock=clock)
+    assert second.status(10) == {"spent_today": 2, "budget": 10, "exhausted": False}
+    second.mark_exhausted()
+    assert first.status(10) == {"spent_today": 2, "budget": 10, "exhausted": True}
+
+    with pytest.raises(RuntimeError, match="forward-only"):
+        command.downgrade(migrated_quota_database, PRE_YSS03_HEAD)

--- a/tests/ops/test_ci_workflow.py
+++ b/tests/ops/test_ci_workflow.py
@@ -58,6 +58,9 @@ def test_pr_index_pg_contracts_run_exact_acceptance_surface() -> None:
     assert "app/agents/panel/**" in job
     assert "tests/index/test_provenance_stamp.py" in job
     assert "tests/indexer/test_outbox_roundtrip_pg.py" in job
+    assert "app/knowledge_acquisition/youtube_api_client.py" in job
+    assert "app/alembic/versions/d9e0f1a2b3c4_yss03_youtube_api_quota.py" in job
+    assert "tests/knowledge_acquisition/test_youtube_api_quota_pg.py" in job
     assert '-m "pg"' in job
 
 


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

Governing-Issue: #3918

## Linked Issue
Closes #3918

## SBS Impact
- Primary subsystem: EBF
- Secondary subsystem(s): PDM (daily quota counter), OEF (quota/error status)
- Write class: Mechanical durable runtime state; code and tests
- Authority impact: None; no human-knowledge or candidate authority changes
- Persistence impact: One migration-owned youtube_api_quota_daily row per UTC day in the channel database, with an explicit memory backend for tests
- Derived/rebuildable impact: Quota state is runtime-operational; wider sync state remains rebuildable from source plus the durable queue
- Human knowledge impact: None
- Memory impact: None
- Retrieval/context impact: None
- Sync/deployment impact: No new service or channel mutation; DB-per-channel isolation remains authoritative
- External boundary impact: Adds read-only HTTPS egress to www.googleapis.com only; redirects and off-boundary paths are refused
- New or changed contract: Implements the existing YouTube Source Sync Data API/quota contract; no contract change
- Owner-doc impact: None per #3918; parent #3915 acceptance retains shipped-truth promotion responsibility
- Transition debt impact: None
- Fitness rule impact: Strengthens the Data API and PDM guardrails with production-call-site tests and explicit DB-import registration
- Boundary risk: SSRF/redirect escape, secret leakage, quota error misclassification, and migration/schema drift

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Add the single allowlisted YouTube Data API v3 boundary for owned playlists, playlist items, and the authenticated channel, including bounded pagination, ETag/304 handling, response limits, and secret-free error mapping.
- Add migration-owned per-UTC-day quota accounting with an explicit memory test backend, fail-loud Postgres schema checks, and fixture-only HTTP coverage.
- Normalize provider, transport, and explicit response-close failures outside active handlers and detach both cause/context graphs so provider-controlled values remain unreachable through structured errors.
- Normalize malformed provider-controlled redirect locations into status-preserving structured redirect errors without bypassing response cleanup.
- Normalize provider JSON recursion in both success and HTTP-error decode paths without losing status taxonomy, quota latching, cleanup, or exception-graph secrecy.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [ ] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [ ] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [x] pytest -q tests/knowledge_acquisition/test_youtube_api_client.py tests/release_channels/test_migration_reversibility.py tests/guard/test_no_direct_db_imports.py::test_no_direct_db_imports tests/ops/test_ci_workflow.py::test_pr_index_pg_contracts_run_exact_acceptance_surface --tb=short — 45 passed
- [x] pytest -q tests/knowledge_acquisition/test_youtube_api_client.py — 37 passed
- [x] Recursive actual-StreamError/provider-field/explicit-close exception-graph regression subset — 20 passed
- [x] pytest -q tests/knowledge_acquisition/test_youtube_api_client.py::test_malformed_redirect_location_is_safely_normalized — 2 passed
- [x] Recursive provider JSON production-call-site regressions (429 and 200) — 2 passed
- [x] pytest -q -m pg tests/knowledge_acquisition/test_youtube_api_quota_pg.py --collect-only — 1 collected
- [x] Disposable pgvector/pg16 quota execution — 1 passed
- [x] Exact CI PG command over provenance, outbox, and YouTube quota files — 12 passed, 4 deselected
- [x] CI path-filter contract selects the YouTube client, migration, and quota PG test in Index PG contracts
- [x] pytest -q tests/guard/test_no_direct_db_imports.py::test_no_direct_db_imports — 1 passed
- [x] pytest -q tests/release_channels/test_migration_reversibility.py — 18 passed
- [x] ruff check app tests companion-ui/companion-app — All checks passed
- [x] ruff format --check on the changed client/test files — 2 files already formatted
- [x] mypy app — Success: no issues found in 792 source files
- [x] python -m alembic heads — one head: d9e0f1a2b3c4
- [x] PYTEST_DEBUG_TEMPROOT=<task-specific ephemeral mktemp namespace> env -u MallocStackLogging pytest -q -m "not pg" — 10,244 passed, 38 skipped, 273 deselected, 18 xfailed, 1,106 warnings; exit 0
- [x] git diff --check and empty docs diff — passed; no contract change

## Review Repair Receipt
- Attempt: standard 1/2
- Failure domain: `review/external_api_data_correctness`
- Mechanism ID: `provider_json_recursion_normalization`
- Repaired prior head: `29169effa99766b8c466beb6e887a281604a4695`
- Repair head: `c0d5c7e08b8c6e1205238ecf306a149c2b19d456`
- Outcome: both provider JSON decode boundaries now catch `RecursionError` alongside syntax and Unicode failures. A deeply nested 429 body preserves `quota_exhausted`, status 429, one spent request, the exhaustion latch, and response cleanup; the corresponding 200 path normalizes to detached `api_unavailable` with status 200. Both recursive cause/context graphs are sentinel-free. The nested-JSON audit found exactly two `json.loads` call sites in the client and both are covered.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: The governing issue, isolated branch, Git history, validation receipt, and PR fully represent the work; no upstream-contract divergence, docs-freshness item, roadmap movement, or cross-authority promotion needed a separate record.

## Notes
The quota contract passed against a disposable local pgvector/pg16 service and is selected for execution in the PR Index PG contracts job. This PR does not deploy, promote, or activate the wider YouTube Source Sync capability.

## Local Review Receipts
- CLEAN 1/2 on exact head `c0d5c7e08b8c6e1205238ecf306a149c2b19d456`: https://github.com/RasmusTho/agentic-pkm-mvp/pull/4006#issuecomment-5018027827
- CLEAN 2/2 on exact head `c0d5c7e08b8c6e1205238ecf306a149c2b19d456`: https://github.com/RasmusTho/agentic-pkm-mvp/pull/4006#issuecomment-5018028969
