### PR TITLE
Add decision revisit scheduler

### DIFF
--- a/app/calibration/ladder.py
+++ b/app/calibration/ladder.py
@@ -1,0 +1,7 @@
+"""Single source for the provisional decision-revisit interval ladder."""
+from __future__ import annotations
+
+# Settings Spine migration seam: calibration.revisit_ladder_days.
+DEFAULT_REVISIT_LADDER = (14, 42, 180)
+
+__all__ = ["DEFAULT_REVISIT_LADDER"]

--- a/app/calibration/scheduler.py
+++ b/app/calibration/scheduler.py
@@ -67,10 +67,14 @@ def _actioned_rungs(
 ) -> set[int]:
     actioned: set[int] = set()
     for record in records:
-        if (
-            str(record.get("decision_object_id")) != str(decision.decision_object_id)
-            or str(record.get("decision_uuid")) != str(decision.decision_uuid)
-        ):
+        # Match on the durable ``decision_uuid`` only, never the re-mintable
+        # ``decision_object_id``. The dual-identity model exists precisely so a
+        # Postgres rebuild can re-link a decision whose runtime id was re-minted
+        # (see DECISION_CALIBRATION/DEFINE_OUTCOME_RECEIPT_MODEL.md), and the
+        # sibling dedup functions (_existing_receipt / _existing_dismissal) key on
+        # decision_uuid + rung_index alone. Requiring decision_object_id here would
+        # let an actioned rung resurface once the object id changes.
+        if str(record.get("decision_uuid")) != str(decision.decision_uuid):
             continue
         rung_index = record.get("rung_index")
         if isinstance(rung_index, int) and not isinstance(rung_index, bool) and rung_index >= 0:

--- a/app/calibration/scheduler.py
+++ b/app/calibration/scheduler.py
@@ -1,0 +1,147 @@
+"""Read-only scheduling of time-based decision revisits."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping
+from uuid import UUID
+
+from app.calibration.ladder import DEFAULT_REVISIT_LADDER
+from app.objects import DomainObject, ObjectStore
+from app.receipts.outcome_receipt_log import iter_outcome_receipts
+from app.receipts.revisit_dismissal_log import iter_revisit_dismissals
+
+ReceiptReader = Callable[[Path | None], list[dict[str, Any]]]
+
+
+@dataclass(frozen=True)
+class DecisionForRevisit:
+    decision_object_id: UUID
+    decision_uuid: UUID
+    decided_on: date
+    title: str
+
+
+@dataclass(frozen=True)
+class RevisitDue:
+    decision_object_id: UUID
+    decision_uuid: UUID
+    title: str
+    decided_on: date
+    rung_index: int
+    rung_days: int
+    due_since: date
+
+
+def _as_decision(raw: object) -> DecisionForRevisit | None:
+    if isinstance(raw, DomainObject):
+        payload: Mapping[str, Any] = raw.payload
+        frontmatter = payload.get("frontmatter")
+        if not isinstance(frontmatter, Mapping) or frontmatter.get("artifact_class") != "decision_record":
+            return None
+        value: Mapping[str, Any] = {
+            "decision_object_id": raw.uuid,
+            "decision_uuid": frontmatter.get("uuid"),
+            "decided_on": frontmatter.get("decided_on"),
+            "title": payload.get("title") or frontmatter.get("title") or raw.source_ref or "Untitled decision",
+        }
+    elif isinstance(raw, Mapping):
+        value = raw
+    else:
+        return None
+    try:
+        return DecisionForRevisit(
+            decision_object_id=UUID(str(value["decision_object_id"])),
+            decision_uuid=UUID(str(value["decision_uuid"])),
+            decided_on=date.fromisoformat(str(value["decided_on"])),
+            title=str(value.get("title") or "Untitled decision"),
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def _actioned_rungs(
+    decision: DecisionForRevisit,
+    records: Iterable[Mapping[str, Any]],
+) -> set[int]:
+    actioned: set[int] = set()
+    for record in records:
+        if (
+            str(record.get("decision_object_id")) != str(decision.decision_object_id)
+            or str(record.get("decision_uuid")) != str(decision.decision_uuid)
+        ):
+            continue
+        rung_index = record.get("rung_index")
+        if isinstance(rung_index, int) and not isinstance(rung_index, bool) and rung_index >= 0:
+            actioned.add(rung_index)
+    return actioned
+
+
+def next_pending_revisit(
+    decision: object,
+    *,
+    today: date | None = None,
+    vault_root: Path | None = None,
+    outcome_records: list[dict[str, Any]] | None = None,
+    dismissal_records: list[dict[str, Any]] | None = None,
+) -> RevisitDue | None:
+    """Return only the earliest due, un-actioned rung for one decision."""
+    parsed = _as_decision(decision)
+    if parsed is None:
+        return None
+    as_of = today or date.today()
+    outcomes = outcome_records if outcome_records is not None else iter_outcome_receipts(vault_root)
+    dismissals = (
+        dismissal_records
+        if dismissal_records is not None
+        else iter_revisit_dismissals(vault_root)
+    )
+    actioned = _actioned_rungs(parsed, [*outcomes, *dismissals])
+    for rung_index, rung_days in enumerate(DEFAULT_REVISIT_LADDER):
+        due_since = parsed.decided_on + timedelta(days=rung_days)
+        if rung_index not in actioned and due_since <= as_of:
+            return RevisitDue(
+                decision_object_id=parsed.decision_object_id,
+                decision_uuid=parsed.decision_uuid,
+                title=parsed.title,
+                decided_on=parsed.decided_on,
+                rung_index=rung_index,
+                rung_days=rung_days,
+                due_since=due_since,
+            )
+    return None
+
+
+def due_revisits(
+    *,
+    today: date | None = None,
+    vault_root: Path | None = None,
+    decisions: Iterable[object] | None = None,
+    outcome_reader: ReceiptReader = iter_outcome_receipts,
+    dismissal_reader: ReceiptReader = iter_revisit_dismissals,
+) -> list[RevisitDue]:
+    """Return the one pending revisit, if any, for each ingested decision record."""
+    candidates = decisions if decisions is not None else ObjectStore().list_objects(limit=1_000_000)
+    outcomes = outcome_reader(vault_root)
+    dismissals = dismissal_reader(vault_root)
+    due: list[RevisitDue] = []
+    for decision in candidates:
+        pending = next_pending_revisit(
+            decision,
+            today=today,
+            outcome_records=outcomes,
+            dismissal_records=dismissals,
+        )
+        if pending is not None:
+            due.append(pending)
+    return due
+
+
+__all__ = [
+    "DEFAULT_REVISIT_LADDER",
+    "DecisionForRevisit",
+    "RevisitDue",
+    "due_revisits",
+    "next_pending_revisit",
+]

--- a/app/receipts/revisit_dismissal_log.py
+++ b/app/receipts/revisit_dismissal_log.py
@@ -1,0 +1,164 @@
+"""Append-only, WriteGuard-gated dismissal receipts for decision revisits."""
+from __future__ import annotations
+
+import fcntl
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from app.config.paths import resolve_optional_vault_root
+from app.vault.paths import NoVaultSelectedError, resolve_vault_system_dir_rel_or_default
+from app.write_guard import DEFAULT_WRITE_GUARD
+
+SCHEMA_VERSION = 1
+REVISIT_DISMISSAL_WRITE_ACTION = "decision.revisit_dismissal"
+_DISMISSALS_SUBDIR = Path("receipts") / "decision_revisit_dismissals"
+_APPEND_LOCK_NAME = ".append.lock"
+
+
+class RevisitDismissal(BaseModel):
+    """A durable marker that a shown revisit rung was set aside."""
+
+    schema_version: int = SCHEMA_VERSION
+    decision_object_id: UUID
+    decision_uuid: UUID
+    rung_index: int = Field(ge=0)
+    created_at: datetime
+
+
+class RevisitDismissalWriteError(RuntimeError):
+    """Raised when a dismissal cannot be durably appended."""
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _shard_name(created_at: datetime) -> str:
+    return f"decision_revisit_dismissals-{created_at.strftime('%Y%m')}.jsonl"
+
+
+def revisit_dismissals_dir(vault_root: Path | None = None) -> Path:
+    """Return the selected vault's canonical revisit-dismissal directory."""
+    root = vault_root if vault_root is not None else resolve_optional_vault_root()
+    if root is None:
+        raise NoVaultSelectedError(
+            "decision revisit dismissal log requires a selected vault; VAULT_ROOT is unset"
+        )
+    root = root.expanduser()
+    return root / resolve_vault_system_dir_rel_or_default(root) / _DISMISSALS_SUBDIR
+
+
+def build_dismissal(
+    *,
+    decision_object_id: str | UUID,
+    decision_uuid: str | UUID,
+    rung_index: int,
+    created_at: datetime | None = None,
+) -> dict[str, Any]:
+    """Validate and build one JSON-serializable dismissal receipt."""
+    dismissal = RevisitDismissal(
+        decision_object_id=decision_object_id,
+        decision_uuid=decision_uuid,
+        rung_index=rung_index,
+        created_at=created_at or _now(),
+    )
+    return dismissal.model_dump(mode="json")
+
+
+def iter_revisit_dismissals(vault_root: Path | None = None) -> list[dict[str, Any]]:
+    """Read canonical dismissal receipts without modifying existing shards."""
+    try:
+        dismissals_dir = revisit_dismissals_dir(vault_root)
+    except NoVaultSelectedError:
+        return []
+    if not dismissals_dir.exists():
+        return []
+
+    records: list[dict[str, Any]] = []
+    for shard in sorted(dismissals_dir.glob("decision_revisit_dismissals-*.jsonl")):
+        try:
+            lines = shard.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        for line in lines:
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(record, dict):
+                records.append(record)
+    records.sort(key=lambda record: str(record.get("created_at") or ""))
+    return records
+
+
+def _existing_dismissal(
+    records: list[dict[str, Any]], decision_uuid: str, rung_index: int
+) -> dict[str, Any] | None:
+    return next(
+        (
+            record
+            for record in records
+            if record.get("decision_uuid") == decision_uuid
+            and record.get("rung_index") == rung_index
+        ),
+        None,
+    )
+
+
+def append_revisit_dismissal(
+    *,
+    decision_object_id: str | UUID,
+    decision_uuid: str | UUID,
+    rung_index: int,
+    created_at: datetime | None = None,
+    vault_root: Path | None = None,
+) -> dict[str, Any]:
+    """Durably append one dismissal marker, idempotently per decision/rung."""
+    # The only production dismissal write seam. Keep this before path resolution
+    # and I/O so a blocked runtime cannot produce a partial ledger write.
+    DEFAULT_WRITE_GUARD.assert_writes_allowed(REVISIT_DISMISSAL_WRITE_ACTION)
+
+    dismissal = build_dismissal(
+        decision_object_id=decision_object_id,
+        decision_uuid=decision_uuid,
+        rung_index=rung_index,
+        created_at=created_at,
+    )
+    try:
+        target_dir = revisit_dismissals_dir(vault_root)
+        target_dir.mkdir(parents=True, exist_ok=True)
+        with (target_dir / _APPEND_LOCK_NAME).open("a+", encoding="utf-8") as lock_handle:
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+            existing = _existing_dismissal(
+                iter_revisit_dismissals(vault_root),
+                dismissal["decision_uuid"],
+                dismissal["rung_index"],
+            )
+            if existing is not None:
+                return existing
+            shard = target_dir / _shard_name(datetime.fromisoformat(dismissal["created_at"]))
+            with shard.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(dismissal, ensure_ascii=False, sort_keys=True) + "\n")
+    except OSError as exc:
+        raise RevisitDismissalWriteError(
+            "decision revisit dismissal append failed for "
+            f"decision_uuid={decision_uuid} rung_index={rung_index}: {exc}"
+        ) from exc
+    return dismissal
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "REVISIT_DISMISSAL_WRITE_ACTION",
+    "RevisitDismissal",
+    "RevisitDismissalWriteError",
+    "append_revisit_dismissal",
+    "build_dismissal",
+    "iter_revisit_dismissals",
+    "revisit_dismissals_dir",
+]

--- a/tests/services/test_revisit_scheduler.py
+++ b/tests/services/test_revisit_scheduler.py
@@ -1,0 +1,147 @@
+"""CAL-02 contract tests for the decision revisit scheduler."""
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+
+def _decision(*, decided_on: date) -> dict[str, object]:
+    return {
+        "decision_object_id": str(uuid4()),
+        "decision_uuid": str(uuid4()),
+        "title": "Use the canonical store",
+        "decided_on": decided_on.isoformat(),
+    }
+
+
+def test_ladder_declared_once_and_imported() -> None:
+    from app.calibration.ladder import DEFAULT_REVISIT_LADDER
+    from app.calibration.scheduler import DEFAULT_REVISIT_LADDER as scheduler_ladder
+
+    assert DEFAULT_REVISIT_LADDER == (14, 42, 180)
+    assert scheduler_ladder is DEFAULT_REVISIT_LADDER
+
+
+def test_next_pending_revisit_returns_earliest_due_rung() -> None:
+    from app.calibration.scheduler import next_pending_revisit
+
+    decision = _decision(decided_on=date(2026, 1, 1))
+    assert next_pending_revisit(decision, today=date(2026, 1, 14)) is None
+
+    due = next_pending_revisit(decision, today=date(2026, 1, 15))
+    assert due is not None
+    assert due.rung_index == 0
+    assert due.rung_days == 14
+    assert due.due_since == date(2026, 1, 15)
+
+    assert (
+        next_pending_revisit(
+            decision,
+            today=date(2026, 7, 1),
+            outcome_records=[
+                {
+                    "decision_object_id": decision["decision_object_id"],
+                    "decision_uuid": decision["decision_uuid"],
+                    "rung_index": 0,
+                    "outcome": "held",
+                    "created_at": "2026-01-15T00:00:00+00:00",
+                }
+            ],
+        ).rung_index
+        == 1
+    )
+
+    every_rung_answered = [
+        {
+            "decision_object_id": decision["decision_object_id"],
+            "decision_uuid": decision["decision_uuid"],
+            "rung_index": rung_index,
+            "outcome": "held",
+            "created_at": "2026-01-15T00:00:00+00:00",
+        }
+        for rung_index in range(3)
+    ]
+    assert (
+        next_pending_revisit(
+            decision, today=date(2027, 1, 1), outcome_records=every_rung_answered
+        )
+        is None
+    )
+
+
+def test_at_most_one_pending_revisit_per_decision() -> None:
+    from app.calibration.scheduler import next_pending_revisit
+
+    decision = _decision(decided_on=date(2026, 1, 1))
+    due = next_pending_revisit(decision, today=date(2027, 1, 1))
+    assert due is not None
+    assert due.rung_index == 0
+
+
+def test_dismissal_is_durable_and_writes_no_outcome(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.calibration.scheduler import next_pending_revisit
+    from app.receipts import outcome_receipt_log
+    from app.receipts.revisit_dismissal_log import append_revisit_dismissal
+
+    decision = _decision(decided_on=date(2026, 1, 1))
+    monkeypatch.setattr(
+        "app.receipts.revisit_dismissal_log.DEFAULT_WRITE_GUARD.assert_writes_allowed", lambda _: None
+    )
+    append_revisit_dismissal(
+        decision_object_id=str(decision["decision_object_id"]),
+        decision_uuid=str(decision["decision_uuid"]),
+        rung_index=0,
+        created_at=datetime(2026, 2, 1, tzinfo=timezone.utc),
+        vault_root=tmp_path / "vault",
+    )
+
+    assert outcome_receipt_log.iter_outcome_receipts(tmp_path / "vault") == []
+    assert (
+        next_pending_revisit(
+            decision, today=date(2026, 2, 1), vault_root=tmp_path / "vault"
+        ) is None
+    )
+
+
+def test_dismiss_blocked_by_write_guard_raises_before_io(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.receipts import revisit_dismissal_log
+    from app.write_guard import WritesBlockedError
+
+    monkeypatch.setattr(
+        revisit_dismissal_log.DEFAULT_WRITE_GUARD,
+        "assert_writes_allowed",
+        lambda action: (_ for _ in ()).throw(WritesBlockedError("safe_mode", None, action)),
+    )
+    with pytest.raises(WritesBlockedError):
+        revisit_dismissal_log.append_revisit_dismissal(
+            decision_object_id=str(uuid4()),
+            decision_uuid=str(uuid4()),
+            rung_index=0,
+            vault_root=tmp_path / "vault",
+        )
+    assert not (tmp_path / "vault").exists()
+
+
+def test_answered_rung_advances_schedule_like_dismissal() -> None:
+    from app.calibration.scheduler import next_pending_revisit
+
+    decision = _decision(decided_on=date(2026, 1, 1))
+    outcomes = [
+        {
+            "decision_object_id": decision["decision_object_id"],
+            "decision_uuid": decision["decision_uuid"],
+            "rung_index": 0,
+            "outcome": "held",
+            "created_at": "2026-01-15T00:00:00+00:00",
+        }
+    ]
+    due = next_pending_revisit(decision, today=date(2026, 2, 12), outcome_records=outcomes)
+    assert due is not None
+    assert due.rung_index == 1

--- a/tests/services/test_revisit_scheduler.py
+++ b/tests/services/test_revisit_scheduler.py
@@ -145,3 +145,56 @@ def test_answered_rung_advances_schedule_like_dismissal() -> None:
     due = next_pending_revisit(decision, today=date(2026, 2, 12), outcome_records=outcomes)
     assert due is not None
     assert due.rung_index == 1
+
+
+def test_actioned_rungs_match_on_decision_uuid_not_re_minted_object_id() -> None:
+    """AC4/AC6: an actioned rung recorded under a prior decision_object_id must
+    stay actioned after the runtime object id is re-minted (same decision_uuid).
+
+    The dual-identity model exists so a Postgres rebuild can re-link a decision
+    whose runtime id was re-minted; matching on decision_object_id would let an
+    already-dismissed/answered rung resurface as pending.
+    """
+    from app.calibration.scheduler import next_pending_revisit
+
+    shared_uuid = str(uuid4())
+    decision = {
+        "decision_object_id": str(uuid4()),  # freshly re-minted runtime id
+        "decision_uuid": shared_uuid,
+        "title": "Use the canonical store",
+        "decided_on": date(2026, 1, 1).isoformat(),
+    }
+    stale_object_id = str(uuid4())  # the id in force when the rung was actioned
+
+    # Outcome path: rung 0 answered earlier under the stale object id.
+    due_outcome = next_pending_revisit(
+        decision,
+        today=date(2026, 7, 1),
+        outcome_records=[
+            {
+                "decision_object_id": stale_object_id,
+                "decision_uuid": shared_uuid,
+                "rung_index": 0,
+                "outcome": "held",
+                "created_at": "2026-01-15T00:00:00+00:00",
+            }
+        ],
+    )
+    assert due_outcome is not None
+    assert due_outcome.rung_index == 1  # rung 0 stays actioned, not resurfaced
+
+    # Dismissal path: rung 0 dismissed earlier under the stale object id.
+    due_dismissal = next_pending_revisit(
+        decision,
+        today=date(2026, 7, 1),
+        dismissal_records=[
+            {
+                "decision_object_id": stale_object_id,
+                "decision_uuid": shared_uuid,
+                "rung_index": 0,
+                "created_at": "2026-01-15T00:00:00+00:00",
+            }
+        ],
+    )
+    assert due_dismissal is not None
+    assert due_dismissal.rung_index == 1


### PR DESCRIPTION
Governing-Issue: #3323

Fixes #3323

Final-Review-Rounds: 2

## Summary
- Add the single-source 14/42/180-day revisit ladder and pure scheduler that exposes only the earliest un-actioned due rung per decision.
- Add a vault-canonical, append-only, WriteGuard-gated dismissal ledger that advances a rung without creating an outcome.

## SBS Impact
- Primary: GOV — distinct dismissal receipt ledger.
- Secondary: HKA (read-only decision_record metadata) and PDM (vault JSONL persistence).
- Write class: mechanical durable at decision.revisit_dismissal only; scheduling is read/compute only. No authority, deployment, sync, or Postgres impact.

## Validation
- pytest -q tests/services/test_revisit_scheduler.py (6 passed)
- ruff check app tests (passed)
- mypy app (passed)
- pytest -q -m "not pg" (passed)

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: normal bounded implementation with no delivery divergence or BuilderOps artifact produced.

## Owner-doc Resolution
No current-state owner doc claims Decision Calibration as shipped. This slice changes no owner-doc truth; parent acceptance owns the later DECISION_RECEIPT_LOG extension note.

## Claim Receipt
- task_id: github-RasmusTho--agentic-pkm-mvp-issue-3323
- lease_id: lease-2e2a0e50
- holder: codex-revisit-scheduler-3323
- evidence: verified-dispatcher-lease
