### PR TITLE
feat: deliver DEV Keychain runtime secret bootstrap (HSP-02)

### DIFF
--- a/app/ops/host_secret_bootstrap.py
+++ b/app/ops/host_secret_bootstrap.py
@@ -189,12 +189,20 @@ def materialize_consumer_environment(
     fd: int | None = None
     termination_signal: int | None = None
     cleanup_in_progress = False
+    materialization_ready = False
 
     def cleanup_then_terminate(signum: int, _frame: FrameType | None) -> None:
         nonlocal termination_signal
         if termination_signal is None:
             termination_signal = signum
-        if cleanup_in_progress:
+        if file_path is not None:
+            try:
+                file_path.unlink(missing_ok=True)
+            except OSError as exc:
+                raise HostSecretBootstrapError(
+                    "host secret bootstrap failed for declared consumer"
+                ) from exc
+        if cleanup_in_progress or not materialization_ready:
             return
         raise HostSecretBootstrapTerminated(termination_signal)
 
@@ -219,6 +227,9 @@ def materialize_consumer_environment(
     try:
         with _temporary_signal_handlers(cleanup_then_terminate):
             try:
+                # Defer catchable termination until the descriptor/path pair has
+                # reached a cleanup-safe state. A handler may run after mkstemp
+                # returns but before Python assigns either value.
                 fd, raw_path = tempfile.mkstemp(
                     prefix="yggdrasil-host-secret-",
                     suffix=".env",
@@ -232,6 +243,9 @@ def materialize_consumer_environment(
                         handle.write(f"{name}={values[name]}\n")
                     handle.flush()
                     os.fsync(handle.fileno())
+                materialization_ready = True
+                if termination_signal is not None:
+                    raise HostSecretBootstrapTerminated(termination_signal)
                 yield file_path
             finally:
                 cleanup_materialized_file()

--- a/app/ops/host_secret_bootstrap.py
+++ b/app/ops/host_secret_bootstrap.py
@@ -209,18 +209,25 @@ def materialize_consumer_environment(
     def cleanup_materialized_file() -> None:
         nonlocal cleanup_in_progress, fd
         cleanup_in_progress = True
+        cleanup_error: OSError | None = None
         try:
             if fd is not None:
-                os.close(fd)
-                fd = None
-            if file_path is None:
-                return
-            try:
-                file_path.unlink(missing_ok=True)
-            except OSError as exc:
+                try:
+                    os.close(fd)
+                except OSError as exc:
+                    cleanup_error = exc
+                finally:
+                    fd = None
+            if file_path is not None:
+                try:
+                    file_path.unlink(missing_ok=True)
+                except OSError as exc:
+                    if cleanup_error is None:
+                        cleanup_error = exc
+            if cleanup_error is not None:
                 raise HostSecretBootstrapError(
                     "host secret bootstrap failed for declared consumer"
-                ) from exc
+                ) from cleanup_error
         finally:
             cleanup_in_progress = False
 

--- a/app/ops/host_secret_bootstrap.py
+++ b/app/ops/host_secret_bootstrap.py
@@ -26,6 +26,7 @@ _SECRET_ENV_NAMES = {
 _RAW_STORE_KEY_PATTERN = re.compile(r"^[0-9a-fA-F]{64}$")
 _CHILD_WAIT_POLL_SECONDS = 0.1
 _CHILD_TERMINATION_GRACE_SECONDS = 5.0
+_CHILD_POST_KILL_REAP_SECONDS = 1.0
 
 KeychainLookup = Callable[[str, str], str]
 CommandRunner = Callable[[list[str], dict[str, str]], int]
@@ -298,7 +299,12 @@ def _subprocess_runner(command: list[str], env: dict[str, str]) -> int:
             except subprocess.TimeoutExpired:
                 active_process.kill()
                 break
-        active_process.wait()
+        try:
+            active_process.wait(timeout=_CHILD_POST_KILL_REAP_SECONDS)
+        except subprocess.TimeoutExpired:
+            # A killed child can remain uninterruptible. Do not let an unbounded
+            # reap prevent the outer context from removing plaintext material.
+            pass
 
     with _temporary_signal_handlers(forward_then_terminate):
         process = subprocess.Popen(command, env=env)

--- a/app/ops/host_secret_bootstrap.py
+++ b/app/ops/host_secret_bootstrap.py
@@ -1,0 +1,249 @@
+"""Fail-closed host-secret bootstrap for declared local runtime consumers."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+
+from app.ops.host_secret_contract import HostSecretContract, load_host_secret_contract
+
+
+HOST_SECRET_RUNTIME_ENV_FILE = "HOST_SECRET_RUNTIME_ENV_FILE"
+_SECRET_ENV_NAMES = {
+    "heimdal.raw-store-key": "HEIMDAL_RAW_STORE_KEY",
+}
+_RAW_STORE_KEY_PATTERN = re.compile(r"^[0-9a-fA-F]{64}$")
+
+KeychainLookup = Callable[[str, str], str]
+CommandRunner = Callable[[list[str], dict[str, str]], int]
+
+
+class HostSecretBootstrapError(RuntimeError):
+    """Redacted bootstrap failure that never carries resolved secret material."""
+
+
+def _security_keychain_lookup(service: str, account: str) -> str:
+    try:
+        result = subprocess.run(
+            [
+                "security",
+                "find-generic-password",
+                "-s",
+                service,
+                "-a",
+                account,
+                "-w",
+            ],
+            check=False,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except OSError as exc:
+        raise HostSecretBootstrapError(
+            "host secret bootstrap failed for declared consumer"
+        ) from exc
+    if result.returncode != 0:
+        raise HostSecretBootstrapError(
+            "host secret bootstrap failed for declared consumer"
+        )
+    return result.stdout.rstrip("\r\n")
+
+
+def _declared_secrets(
+    contract: HostSecretContract,
+    *,
+    channel: str,
+    consumer: str,
+) -> list[str]:
+    secrets = sorted(
+        secret
+        for declared_channel, declared_consumer, secret in contract.allowed
+        if declared_channel == channel and declared_consumer == consumer
+    )
+    if not secrets:
+        raise HostSecretBootstrapError(
+            "host secret bootstrap failed for declared consumer"
+        )
+    return secrets
+
+
+def _validate_secret(secret: str, value: str) -> bool:
+    if secret == "heimdal.raw-store-key":
+        return _RAW_STORE_KEY_PATTERN.fullmatch(value) is not None
+    return False
+
+
+def _resolve_consumer_environment(
+    *,
+    channel: str,
+    consumer: str,
+    contract: HostSecretContract,
+    keychain_lookup: KeychainLookup,
+) -> dict[str, str]:
+    resolved: dict[str, str] = {}
+    try:
+        for secret in _declared_secrets(
+            contract,
+            channel=channel,
+            consumer=consumer,
+        ):
+            env_name = _SECRET_ENV_NAMES.get(secret)
+            if env_name is None:
+                raise HostSecretBootstrapError(
+                    "host secret bootstrap failed for declared consumer"
+                )
+            account = contract.keychain_account(
+                channel=channel,
+                consumer=consumer,
+                secret=secret,
+            )
+            value = keychain_lookup(contract.keychain_service, account)
+            if not _validate_secret(secret, value):
+                raise HostSecretBootstrapError(
+                    "host secret bootstrap failed for declared consumer"
+                )
+            resolved[env_name] = value
+    except HostSecretBootstrapError:
+        raise
+    except Exception as exc:
+        raise HostSecretBootstrapError(
+            "host secret bootstrap failed for declared consumer"
+        ) from exc
+    return resolved
+
+
+@contextmanager
+def materialize_consumer_environment(
+    *,
+    channel: str,
+    consumer: str,
+    keychain_lookup: KeychainLookup = _security_keychain_lookup,
+    contract: HostSecretContract | None = None,
+    directory: Path | None = None,
+) -> Iterator[Path]:
+    """Yield one mode-0600 env file containing only the declared values."""
+    try:
+        selected_contract = contract or load_host_secret_contract()
+        values = _resolve_consumer_environment(
+            channel=channel,
+            consumer=consumer,
+            contract=selected_contract,
+            keychain_lookup=keychain_lookup,
+        )
+    except HostSecretBootstrapError:
+        raise
+    except Exception as exc:
+        raise HostSecretBootstrapError(
+            "host secret bootstrap failed for declared consumer"
+        ) from exc
+
+    file_path: Path | None = None
+    fd: int | None = None
+    try:
+        fd, raw_path = tempfile.mkstemp(
+            prefix="yggdrasil-host-secret-",
+            suffix=".env",
+            dir=directory,
+        )
+        file_path = Path(raw_path)
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8", closefd=True) as handle:
+            fd = None
+            for name in sorted(values):
+                handle.write(f"{name}={values[name]}\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        yield file_path
+    except HostSecretBootstrapError:
+        raise
+    except Exception as exc:
+        raise HostSecretBootstrapError(
+            "host secret bootstrap failed for declared consumer"
+        ) from exc
+    finally:
+        if fd is not None:
+            os.close(fd)
+        if file_path is not None:
+            try:
+                file_path.unlink(missing_ok=True)
+            except OSError as exc:
+                raise HostSecretBootstrapError(
+                    "host secret bootstrap failed for declared consumer"
+                ) from exc
+
+
+def _subprocess_runner(command: list[str], env: dict[str, str]) -> int:
+    return subprocess.run(command, env=env, check=False).returncode
+
+
+def run_with_host_secrets(
+    *,
+    channel: str,
+    consumer: str,
+    command: Sequence[str],
+    keychain_lookup: KeychainLookup = _security_keychain_lookup,
+    runner: CommandRunner = _subprocess_runner,
+    contract: HostSecretContract | None = None,
+    directory: Path | None = None,
+) -> int:
+    """Launch *command* with a temporary secret env-file pointer, then clean it."""
+    selected_command = list(command)
+    if not selected_command:
+        raise HostSecretBootstrapError(
+            "host secret bootstrap failed for declared consumer"
+        )
+    with materialize_consumer_environment(
+        channel=channel,
+        consumer=consumer,
+        keychain_lookup=keychain_lookup,
+        contract=contract,
+        directory=directory,
+    ) as env_file:
+        child_env = dict(os.environ)
+        for env_name in _SECRET_ENV_NAMES.values():
+            child_env.pop(env_name, None)
+        child_env[HOST_SECRET_RUNTIME_ENV_FILE] = str(env_file)
+        return runner(selected_command, child_env)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Launch a declared consumer with redacted host-secret bootstrap",
+    )
+    parser.add_argument("--channel", required=True)
+    parser.add_argument("--consumer", required=True)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    command = list(args.command)
+    if command[:1] == ["--"]:
+        command = command[1:]
+    try:
+        return run_with_host_secrets(
+            channel=args.channel,
+            consumer=args.consumer,
+            command=command,
+        )
+    except HostSecretBootstrapError:
+        print(
+            "host secret bootstrap failed for declared consumer; "
+            "verify the declared Keychain item and non-interactive access",
+            file=sys.stderr,
+        )
+        return 78
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/ops/host_secret_bootstrap.py
+++ b/app/ops/host_secret_bootstrap.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+import time
 from types import FrameType
 
 from app.ops.host_secret_contract import HostSecretContract, load_host_secret_contract
@@ -23,6 +24,8 @@ _SECRET_ENV_NAMES = {
     "heimdal.raw-store-key": "HEIMDAL_RAW_STORE_KEY",
 }
 _RAW_STORE_KEY_PATTERN = re.compile(r"^[0-9a-fA-F]{64}$")
+_CHILD_WAIT_POLL_SECONDS = 0.1
+_CHILD_TERMINATION_GRACE_SECONDS = 5.0
 
 KeychainLookup = Callable[[str, str], str]
 CommandRunner = Callable[[list[str], dict[str, str]], int]
@@ -184,70 +187,111 @@ def materialize_consumer_environment(
 
     file_path: Path | None = None
     fd: int | None = None
+    termination_signal: int | None = None
+    cleanup_in_progress = False
 
     def cleanup_then_terminate(signum: int, _frame: FrameType | None) -> None:
-        if file_path is not None:
+        nonlocal termination_signal
+        if termination_signal is None:
+            termination_signal = signum
+        if cleanup_in_progress:
+            return
+        raise HostSecretBootstrapTerminated(termination_signal)
+
+    def cleanup_materialized_file() -> None:
+        nonlocal cleanup_in_progress, fd
+        cleanup_in_progress = True
+        try:
+            if fd is not None:
+                os.close(fd)
+                fd = None
+            if file_path is None:
+                return
             try:
                 file_path.unlink(missing_ok=True)
             except OSError as exc:
                 raise HostSecretBootstrapError(
                     "host secret bootstrap failed for declared consumer"
                 ) from exc
-        raise HostSecretBootstrapTerminated(signum)
+        finally:
+            cleanup_in_progress = False
 
     try:
         with _temporary_signal_handlers(cleanup_then_terminate):
-            fd, raw_path = tempfile.mkstemp(
-                prefix="yggdrasil-host-secret-",
-                suffix=".env",
-                dir=directory,
-            )
-            file_path = Path(raw_path)
-            os.fchmod(fd, 0o600)
-            with os.fdopen(fd, "w", encoding="utf-8", closefd=True) as handle:
-                fd = None
-                for name in sorted(values):
-                    handle.write(f"{name}={values[name]}\n")
-                handle.flush()
-                os.fsync(handle.fileno())
-            yield file_path
+            try:
+                fd, raw_path = tempfile.mkstemp(
+                    prefix="yggdrasil-host-secret-",
+                    suffix=".env",
+                    dir=directory,
+                )
+                file_path = Path(raw_path)
+                os.fchmod(fd, 0o600)
+                with os.fdopen(fd, "w", encoding="utf-8", closefd=True) as handle:
+                    fd = None
+                    for name in sorted(values):
+                        handle.write(f"{name}={values[name]}\n")
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                yield file_path
+            finally:
+                cleanup_materialized_file()
+                if termination_signal is not None:
+                    raise HostSecretBootstrapTerminated(termination_signal)
     except HostSecretBootstrapError:
         raise
     except Exception as exc:
         raise HostSecretBootstrapError(
             "host secret bootstrap failed for declared consumer"
         ) from exc
-    finally:
-        if fd is not None:
-            os.close(fd)
-        if file_path is not None:
-            try:
-                file_path.unlink(missing_ok=True)
-            except OSError as exc:
-                raise HostSecretBootstrapError(
-                    "host secret bootstrap failed for declared consumer"
-                ) from exc
 
 
 def _subprocess_runner(command: list[str], env: dict[str, str]) -> int:
     process: subprocess.Popen[bytes] | None = None
+    termination_signal: int | None = None
 
     def forward_then_terminate(signum: int, _frame: FrameType | None) -> None:
-        if process is not None and process.poll() is None:
-            process.send_signal(signum)
-        raise HostSecretBootstrapTerminated(signum)
+        nonlocal termination_signal
+        if termination_signal is None:
+            termination_signal = signum
+        active_process = process
+        if active_process is not None and active_process.poll() is None:
+            try:
+                active_process.send_signal(signum)
+            except ProcessLookupError:
+                pass
+
+    def terminate_and_reap(active_process: subprocess.Popen[bytes], signum: int) -> None:
+        if active_process.poll() is None:
+            try:
+                active_process.send_signal(signum)
+            except ProcessLookupError:
+                pass
+        deadline = time.monotonic() + _CHILD_TERMINATION_GRACE_SECONDS
+        while active_process.poll() is None:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                active_process.kill()
+                break
+            try:
+                active_process.wait(timeout=remaining)
+            except subprocess.TimeoutExpired:
+                active_process.kill()
+                break
+        active_process.wait()
 
     with _temporary_signal_handlers(forward_then_terminate):
         process = subprocess.Popen(command, env=env)
-        try:
-            return process.wait()
-        except HostSecretBootstrapTerminated:
+        while True:
+            if termination_signal is not None:
+                terminate_and_reap(process, termination_signal)
+                raise HostSecretBootstrapTerminated(termination_signal)
             try:
-                process.wait(timeout=5)
+                returncode = process.wait(timeout=_CHILD_WAIT_POLL_SECONDS)
             except subprocess.TimeoutExpired:
-                process.kill()
-                process.wait()
-            raise
+                continue
+            if termination_signal is not None:
+                raise HostSecretBootstrapTerminated(termination_signal)
+            return returncode
 
 
 def run_with_host_secrets(

--- a/app/ops/host_secret_bootstrap.py
+++ b/app/ops/host_secret_bootstrap.py
@@ -8,9 +8,12 @@ from contextlib import contextmanager
 import os
 from pathlib import Path
 import re
+import signal
 import subprocess
 import sys
 import tempfile
+import threading
+from types import FrameType
 
 from app.ops.host_secret_contract import HostSecretContract, load_host_secret_contract
 
@@ -27,6 +30,39 @@ CommandRunner = Callable[[list[str], dict[str, str]], int]
 
 class HostSecretBootstrapError(RuntimeError):
     """Redacted bootstrap failure that never carries resolved secret material."""
+
+
+class HostSecretBootstrapTerminated(HostSecretBootstrapError):
+    """Signal termination after the bootstrap has begun controlled cleanup."""
+
+    def __init__(self, signum: int) -> None:
+        super().__init__("host secret bootstrap terminated for declared consumer")
+        self.signum = signum
+
+
+SignalHandler = Callable[[int, FrameType | None], None]
+
+
+@contextmanager
+def _temporary_signal_handlers(handler: SignalHandler) -> Iterator[None]:
+    """Install cleanup-aware handlers when running on the main thread."""
+    if threading.current_thread() is not threading.main_thread():
+        yield
+        return
+
+    handled = tuple(
+        selected
+        for selected in (signal.SIGTERM, signal.SIGINT, getattr(signal, "SIGHUP", None))
+        if selected is not None
+    )
+    previous = {selected: signal.getsignal(selected) for selected in handled}
+    try:
+        for selected in handled:
+            signal.signal(selected, handler)
+        yield
+    finally:
+        for selected, prior in previous.items():
+            signal.signal(selected, prior)
 
 
 def _security_keychain_lookup(service: str, account: str) -> str:
@@ -148,21 +184,33 @@ def materialize_consumer_environment(
 
     file_path: Path | None = None
     fd: int | None = None
+
+    def cleanup_then_terminate(signum: int, _frame: FrameType | None) -> None:
+        if file_path is not None:
+            try:
+                file_path.unlink(missing_ok=True)
+            except OSError as exc:
+                raise HostSecretBootstrapError(
+                    "host secret bootstrap failed for declared consumer"
+                ) from exc
+        raise HostSecretBootstrapTerminated(signum)
+
     try:
-        fd, raw_path = tempfile.mkstemp(
-            prefix="yggdrasil-host-secret-",
-            suffix=".env",
-            dir=directory,
-        )
-        file_path = Path(raw_path)
-        os.fchmod(fd, 0o600)
-        with os.fdopen(fd, "w", encoding="utf-8", closefd=True) as handle:
-            fd = None
-            for name in sorted(values):
-                handle.write(f"{name}={values[name]}\n")
-            handle.flush()
-            os.fsync(handle.fileno())
-        yield file_path
+        with _temporary_signal_handlers(cleanup_then_terminate):
+            fd, raw_path = tempfile.mkstemp(
+                prefix="yggdrasil-host-secret-",
+                suffix=".env",
+                dir=directory,
+            )
+            file_path = Path(raw_path)
+            os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8", closefd=True) as handle:
+                fd = None
+                for name in sorted(values):
+                    handle.write(f"{name}={values[name]}\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            yield file_path
     except HostSecretBootstrapError:
         raise
     except Exception as exc:
@@ -182,7 +230,24 @@ def materialize_consumer_environment(
 
 
 def _subprocess_runner(command: list[str], env: dict[str, str]) -> int:
-    return subprocess.run(command, env=env, check=False).returncode
+    process: subprocess.Popen[bytes] | None = None
+
+    def forward_then_terminate(signum: int, _frame: FrameType | None) -> None:
+        if process is not None and process.poll() is None:
+            process.send_signal(signum)
+        raise HostSecretBootstrapTerminated(signum)
+
+    with _temporary_signal_handlers(forward_then_terminate):
+        process = subprocess.Popen(command, env=env)
+        try:
+            return process.wait()
+        except HostSecretBootstrapTerminated:
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
+            raise
 
 
 def run_with_host_secrets(
@@ -236,6 +301,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             consumer=args.consumer,
             command=command,
         )
+    except HostSecretBootstrapTerminated as exc:
+        print(
+            "host secret bootstrap terminated; temporary material removed",
+            file=sys.stderr,
+        )
+        return 128 + exc.signum
     except HostSecretBootstrapError:
         print(
             "host secret bootstrap failed for declared consumer; "

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -59,11 +59,22 @@ services:
       # keys here so the governed env_file chain supplies the binding.
 
   heimdal-capture-watch:
+    # The governed dev deploy wrapper materializes this last layer from the
+    # declared Keychain consumer and removes it after Compose creates the
+    # container. The base interpolation key is reset so it cannot blank or
+    # override the bootstrap layer from a caller shell or runtime env file.
+    env_file: !override
+      - ./config/runtime.defaults.env
+      - path: ${WATCHER_RUNTIME_ENV_FILE:-./tmp/runtime.env}
+        required: false
+      - path: ${HOST_SECRET_RUNTIME_ENV_FILE:-/dev/null}
+        required: false
     environment:
       LLM_PROVIDER: mock
       PKM_ENVIRONMENT: dev
       DATABASE_URL: postgresql+psycopg://app:app@db:5432/app_dev
       DB_DSN: postgresql+psycopg://app:app@db:5432/app_dev
+      HEIMDAL_RAW_STORE_KEY: !reset null
 
   companion-ui:
     ports: !override

--- a/docs/LOCAL_SECRET_PROVISIONING/DELIVER_RUNTIME_SECRET_BOOTSTRAP.md
+++ b/docs/LOCAL_SECRET_PROVISIONING/DELIVER_RUNTIME_SECRET_BOOTSTRAP.md
@@ -43,6 +43,8 @@ may become a second source of truth.
       Verify: `tests/ops/test_host_secret_bootstrap.py::test_sigterm_forwards_to_consumer_and_cleans_runtime_secret_file`
       Verify: `tests/ops/test_host_secret_bootstrap.py::test_runtime_secret_is_removed_before_signal_handlers_are_restored`
       Verify: `tests/ops/test_host_secret_bootstrap.py::test_signal_during_child_spawn_is_forwarded_after_assignment`
+      Verify: `tests/ops/test_host_secret_bootstrap.py::test_signal_during_tempfile_creation_defers_until_cleanup_state_is_safe`
+      Verify: `tests/ops/test_host_secret_bootstrap.py::test_signal_during_fdopen_transfer_unlinks_and_closes_material`
       Verify: `tests/ops/test_host_secret_bootstrap.py::test_repeated_sigterm_kills_and_reaps_ignoring_consumer`
 - [ ] `heimdal-capture-watch` receives `HEIMDAL_RAW_STORE_KEY` through this path without a repository
       secret or changed product code.

--- a/docs/LOCAL_SECRET_PROVISIONING/DELIVER_RUNTIME_SECRET_BOOTSTRAP.md
+++ b/docs/LOCAL_SECRET_PROVISIONING/DELIVER_RUNTIME_SECRET_BOOTSTRAP.md
@@ -45,6 +45,7 @@ may become a second source of truth.
       Verify: `tests/ops/test_host_secret_bootstrap.py::test_signal_during_child_spawn_is_forwarded_after_assignment`
       Verify: `tests/ops/test_host_secret_bootstrap.py::test_signal_during_tempfile_creation_defers_until_cleanup_state_is_safe`
       Verify: `tests/ops/test_host_secret_bootstrap.py::test_signal_during_fdopen_transfer_unlinks_and_closes_material`
+      Verify: `tests/ops/test_host_secret_bootstrap.py::test_fdopen_failure_after_descriptor_close_still_unlinks_material`
       Verify: `tests/ops/test_host_secret_bootstrap.py::test_repeated_sigterm_kills_and_reaps_ignoring_consumer`
 - [ ] `heimdal-capture-watch` receives `HEIMDAL_RAW_STORE_KEY` through this path without a repository
       secret or changed product code.

--- a/docs/LOCAL_SECRET_PROVISIONING/DELIVER_RUNTIME_SECRET_BOOTSTRAP.md
+++ b/docs/LOCAL_SECRET_PROVISIONING/DELIVER_RUNTIME_SECRET_BOOTSTRAP.md
@@ -41,6 +41,9 @@ may become a second source of truth.
       catchable process termination.
       Verify: `tests/ops/test_host_secret_bootstrap.py::test_runtime_secret_file_is_mode_0600_and_cleaned_up`
       Verify: `tests/ops/test_host_secret_bootstrap.py::test_sigterm_forwards_to_consumer_and_cleans_runtime_secret_file`
+      Verify: `tests/ops/test_host_secret_bootstrap.py::test_runtime_secret_is_removed_before_signal_handlers_are_restored`
+      Verify: `tests/ops/test_host_secret_bootstrap.py::test_signal_during_child_spawn_is_forwarded_after_assignment`
+      Verify: `tests/ops/test_host_secret_bootstrap.py::test_repeated_sigterm_kills_and_reaps_ignoring_consumer`
 - [ ] `heimdal-capture-watch` receives `HEIMDAL_RAW_STORE_KEY` through this path without a repository
       secret or changed product code.
       Verify: `tests/ops/test_host_secret_bootstrap.py::test_capture_watch_uses_bootstrap_not_tracked_env`

--- a/docs/LOCAL_SECRET_PROVISIONING/DELIVER_RUNTIME_SECRET_BOOTSTRAP.md
+++ b/docs/LOCAL_SECRET_PROVISIONING/DELIVER_RUNTIME_SECRET_BOOTSTRAP.md
@@ -22,7 +22,8 @@ may become a second source of truth.
 
 1. Resolve declared Keychain identifiers for an explicit `{channel, consumer}` pair.
 2. Materialize only that consumer's values in a temporary owner-only runtime surface, launch the
-   intended process, then remove the material on normal exit and failure.
+   intended process, then remove the material on normal exit, controlled failure, and catchable
+   termination after forwarding the signal to the consumer.
 3. Redact values from diagnostics, deploy receipts, and failure messages while retaining logical
    identifiers and remediation instructions.
 4. Add dev-channel integration for `heimdal-capture-watch`; do not touch test, prod, stable, or
@@ -36,8 +37,10 @@ may become a second source of truth.
 - [ ] Missing, malformed, or permission-denied Keychain entries fail before process startup and leak
       no value.
       Verify: `tests/ops/test_host_secret_bootstrap.py::test_missing_or_malformed_secret_fails_closed`
-- [ ] Temporary material is owner-readable only and removed on success and controlled failure.
+- [ ] Temporary material is owner-readable only and removed on success, controlled failure, and
+      catchable process termination.
       Verify: `tests/ops/test_host_secret_bootstrap.py::test_runtime_secret_file_is_mode_0600_and_cleaned_up`
+      Verify: `tests/ops/test_host_secret_bootstrap.py::test_sigterm_forwards_to_consumer_and_cleans_runtime_secret_file`
 - [ ] `heimdal-capture-watch` receives `HEIMDAL_RAW_STORE_KEY` through this path without a repository
       secret or changed product code.
       Verify: `tests/ops/test_host_secret_bootstrap.py::test_capture_watch_uses_bootstrap_not_tracked_env`

--- a/scripts/lib/deploy_channel_compose.sh
+++ b/scripts/lib/deploy_channel_compose.sh
@@ -40,6 +40,18 @@ raise SystemExit(
 PY
 }
 
+_deploy_channel_needs_dev_capture_secret() {
+  local channel="${1:?channel required}"
+  shift
+  [ "${channel}" = "dev" ] || return 1
+  [ "${1:-}" = "up" ] || return 1
+  local arg
+  for arg in "$@"; do
+    [ "${arg}" = "heimdal-capture-watch" ] && return 0
+  done
+  return 1
+}
+
 deploy_channel_compose() {
   local root="${1:?repo root required}"
   local channel="${2:?channel required}"
@@ -108,10 +120,22 @@ deploy_channel_compose() {
       unset DEPLOY_VAULT_CONTAINER_ROOT
     fi
 
-    docker compose \
-      --env-file "${channel_env_file}" \
-      "${compose_args[@]}" \
-      -p "${compose_project}" \
+    local -a compose_command
+    compose_command=(
+      docker compose
+      --env-file "${channel_env_file}"
+      "${compose_args[@]}"
+      -p "${compose_project}"
       "$@"
+    )
+
+    if _deploy_channel_needs_dev_capture_secret "${channel}" "$@"; then
+      "${PYTHON:-python3}" -m app.ops.host_secret_bootstrap \
+        --channel "${channel}" \
+        --consumer heimdal-capture-watch \
+        -- "${compose_command[@]}"
+    else
+      "${compose_command[@]}"
+    fi
   )
 }

--- a/tests/companion_ui/test_gateway_managed_unit.py
+++ b/tests/companion_ui/test_gateway_managed_unit.py
@@ -16,7 +16,12 @@ def _construct_override(loader: _ComposeLoader, node: yaml.Node) -> object:
     return loader.construct_sequence(node)
 
 
+def _construct_reset(loader: _ComposeLoader, node: yaml.Node) -> object:
+    return loader.construct_scalar(node)
+
+
 _ComposeLoader.add_constructor("!override", _construct_override)
+_ComposeLoader.add_constructor("!reset", _construct_reset)
 
 
 def _compose(path: str) -> dict:

--- a/tests/deploy/test_deploy_channel.py
+++ b/tests/deploy/test_deploy_channel.py
@@ -43,12 +43,18 @@ def _deploy_harness(tmp_path: Path) -> tuple[Path, dict[str, str], str]:
     (root / "scripts/lib").mkdir(parents=True)
     (root / "config/deploy").mkdir(parents=True)
     (root / "app/alembic/versions").mkdir(parents=True)
+    (root / "app/ops").mkdir(parents=True)
     (root / "app/release_channels").mkdir(parents=True)
+    (root / "config/secrets").mkdir(parents=True)
     (root / "ops/deployments").mkdir(parents=True)
 
     for relative in (
         "app/release_channels/__init__.py",
         "app/release_channels/reversibility.py",
+        "app/ops/__init__.py",
+        "app/ops/host_secret_contract.py",
+        "app/ops/host_secret_bootstrap.py",
+        "config/secrets/host_secret_contract.json",
         "scripts/deploy_channel.sh",
         "scripts/companion_ui_postdeploy_smoke.sh",
         "scripts/lib/deploy_channel_compose.sh",
@@ -67,6 +73,13 @@ def _deploy_harness(tmp_path: Path) -> tuple[Path, dict[str, str], str]:
     bin_dir.mkdir()
     docker_marker = tmp_path / "docker-called"
     event_log = tmp_path / "deploy-events.log"
+    _write_executable(
+        bin_dir / "security",
+        """#!/usr/bin/env bash
+set -eu
+printf '%064d\n' 0
+""",
+    )
     _write_executable(
         bin_dir / "docker",
         f"""#!/usr/bin/env bash

--- a/tests/ops/test_host_secret_bootstrap.py
+++ b/tests/ops/test_host_secret_bootstrap.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 import os
 from pathlib import Path
 import signal
@@ -10,8 +12,10 @@ import time
 
 import pytest
 
+import app.ops.host_secret_bootstrap as host_secret_bootstrap
 from app.ops.host_secret_bootstrap import (
     HostSecretBootstrapError,
+    HostSecretBootstrapTerminated,
     KeychainLookup,
     materialize_consumer_environment,
     run_with_host_secrets,
@@ -179,6 +183,156 @@ printf '%s\\n' '{_RAW_KEY}'
     assert process.returncode == 128 + signal.SIGTERM
     assert not secret_file.exists()
     assert _RAW_KEY not in stderr
+
+
+def test_runtime_secret_is_removed_before_signal_handlers_are_restored(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed_path: Path | None = None
+    events: list[str] = []
+
+    @contextmanager
+    def tracing_handlers(
+        handler: host_secret_bootstrap.SignalHandler,
+    ) -> Iterator[None]:
+        events.append("install-cleanup")
+        try:
+            yield
+        finally:
+            events.append("restore-original")
+            assert observed_path is not None
+            assert not observed_path.exists()
+            handler(signal.SIGTERM, None)
+
+    monkeypatch.setattr(
+        host_secret_bootstrap,
+        "_temporary_signal_handlers",
+        tracing_handlers,
+    )
+
+    with pytest.raises(HostSecretBootstrapTerminated) as error:
+        with materialize_consumer_environment(
+            channel="dev",
+            consumer="heimdal-capture-watch",
+            keychain_lookup=_lookup(),
+            directory=tmp_path,
+        ) as env_file:
+            observed_path = env_file
+            assert observed_path.is_file()
+
+    assert error.value.signum == signal.SIGTERM
+    assert events == ["install-cleanup", "restore-original"]
+
+
+def test_signal_during_child_spawn_is_forwarded_after_assignment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class SpawnInterruptedProcess:
+        def __init__(self) -> None:
+            self.returncode: int | None = None
+            self.forwarded: list[int] = []
+
+        def poll(self) -> int | None:
+            return self.returncode
+
+        def send_signal(self, signum: int) -> None:
+            self.forwarded.append(signum)
+            self.returncode = -signum
+
+        def wait(self, timeout: float | None = None) -> int:
+            del timeout
+            assert self.returncode is not None
+            return self.returncode
+
+        def kill(self) -> None:
+            self.returncode = -signal.SIGKILL
+
+    process = SpawnInterruptedProcess()
+
+    def interrupted_popen(
+        _command: list[str],
+        *,
+        env: dict[str, str],
+    ) -> SpawnInterruptedProcess:
+        del env
+        signal.raise_signal(signal.SIGTERM)
+        return process
+
+    monkeypatch.setattr(host_secret_bootstrap.subprocess, "Popen", interrupted_popen)
+
+    with pytest.raises(HostSecretBootstrapTerminated) as error:
+        host_secret_bootstrap._subprocess_runner(["consumer"], {})
+
+    assert error.value.signum == signal.SIGTERM
+    assert process.forwarded == [signal.SIGTERM]
+    assert process.poll() == -signal.SIGTERM
+
+
+def test_repeated_sigterm_kills_and_reaps_ignoring_consumer(
+    tmp_path: Path,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(
+        bin_dir / "security",
+        f"""#!/usr/bin/env bash
+set -eu
+printf '%s\\n' '{_RAW_KEY}'
+""",
+    )
+    ready = tmp_path / "ignoring-consumer-ready"
+    child_pid_path = tmp_path / "child-pid"
+    observed_path = tmp_path / "ignoring-observed-path"
+    consumer = (
+        "import os, pathlib, signal, time; "
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+        f"pathlib.Path({str(child_pid_path)!r}).write_text(str(os.getpid()), encoding='utf-8'); "
+        f"pathlib.Path({str(observed_path)!r}).write_text("
+        "os.environ['HOST_SECRET_RUNTIME_ENV_FILE'], encoding='utf-8'); "
+        f"pathlib.Path({str(ready)!r}).touch(); "
+        "time.sleep(60)"
+    )
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "app.ops.host_secret_bootstrap",
+            "--channel",
+            "dev",
+            "--consumer",
+            "heimdal-capture-watch",
+            "--",
+            sys.executable,
+            "-c",
+            consumer,
+        ],
+        cwd=_REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    deadline = time.monotonic() + 10
+    while not ready.exists() and process.poll() is None and time.monotonic() < deadline:
+        time.sleep(0.05)
+    assert ready.exists(), process.communicate(timeout=5)
+    child_pid = int(child_pid_path.read_text(encoding="utf-8"))
+    secret_file = Path(observed_path.read_text(encoding="utf-8"))
+    assert secret_file.is_file()
+
+    process.terminate()
+    time.sleep(0.1)
+    process.terminate()
+    _stdout, stderr = process.communicate(timeout=10)
+
+    assert process.returncode == 128 + signal.SIGTERM
+    assert not secret_file.exists()
+    assert _RAW_KEY not in stderr
+    with pytest.raises(ProcessLookupError):
+        os.kill(child_pid, 0)
 
 
 def _write_executable(path: Path, text: str) -> None:

--- a/tests/ops/test_host_secret_bootstrap.py
+++ b/tests/ops/test_host_secret_bootstrap.py
@@ -269,6 +269,62 @@ def test_signal_during_child_spawn_is_forwarded_after_assignment(
     assert process.poll() == -signal.SIGTERM
 
 
+def test_signal_during_tempfile_creation_defers_until_cleanup_state_is_safe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_mkstemp = host_secret_bootstrap.tempfile.mkstemp
+
+    def interrupted_mkstemp(*args: object, **kwargs: object) -> tuple[int, str]:
+        fd, path = real_mkstemp(*args, **kwargs)
+        signal.raise_signal(signal.SIGTERM)
+        return fd, path
+
+    monkeypatch.setattr(
+        host_secret_bootstrap.tempfile,
+        "mkstemp",
+        interrupted_mkstemp,
+    )
+
+    with pytest.raises(HostSecretBootstrapTerminated) as error:
+        with materialize_consumer_environment(
+            channel="dev",
+            consumer="heimdal-capture-watch",
+            keychain_lookup=_lookup(),
+            directory=tmp_path,
+        ):
+            pytest.fail("consumer must not launch after deferred termination")
+
+    assert error.value.signum == signal.SIGTERM
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_signal_during_fdopen_transfer_unlinks_and_closes_material(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_fdopen = host_secret_bootstrap.os.fdopen
+
+    def interrupted_fdopen(*args: object, **kwargs: object) -> object:
+        handle = real_fdopen(*args, **kwargs)
+        signal.raise_signal(signal.SIGTERM)
+        return handle
+
+    monkeypatch.setattr(host_secret_bootstrap.os, "fdopen", interrupted_fdopen)
+
+    with pytest.raises(HostSecretBootstrapTerminated) as error:
+        with materialize_consumer_environment(
+            channel="dev",
+            consumer="heimdal-capture-watch",
+            keychain_lookup=_lookup(),
+            directory=tmp_path,
+        ):
+            pytest.fail("consumer must not launch after deferred termination")
+
+    assert error.value.signum == signal.SIGTERM
+    assert list(tmp_path.iterdir()) == []
+
+
 def test_repeated_sigterm_kills_and_reaps_ignoring_consumer(
     tmp_path: Path,
 ) -> None:

--- a/tests/ops/test_host_secret_bootstrap.py
+++ b/tests/ops/test_host_secret_bootstrap.py
@@ -325,6 +325,36 @@ def test_signal_during_fdopen_transfer_unlinks_and_closes_material(
     assert list(tmp_path.iterdir()) == []
 
 
+def test_fdopen_failure_after_descriptor_close_still_unlinks_material(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_close = host_secret_bootstrap.os.close
+
+    def failed_fdopen_after_close(fd: int, *_args: object, **_kwargs: object) -> object:
+        real_close(fd)
+        raise OSError("fdopen ownership transfer failed with sensitive context")
+
+    monkeypatch.setattr(
+        host_secret_bootstrap.os,
+        "fdopen",
+        failed_fdopen_after_close,
+    )
+
+    with pytest.raises(HostSecretBootstrapError) as error:
+        with materialize_consumer_environment(
+            channel="dev",
+            consumer="heimdal-capture-watch",
+            keychain_lookup=_lookup(),
+            directory=tmp_path,
+        ):
+            pytest.fail("consumer must not launch after fdopen failure")
+
+    assert str(error.value) == "host secret bootstrap failed for declared consumer"
+    assert "sensitive context" not in str(error.value)
+    assert list(tmp_path.iterdir()) == []
+
+
 def test_repeated_sigterm_kills_and_reaps_ignoring_consumer(
     tmp_path: Path,
 ) -> None:

--- a/tests/ops/test_host_secret_bootstrap.py
+++ b/tests/ops/test_host_secret_bootstrap.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+import signal
 import stat
 import subprocess
 import sys
+import time
 
 import pytest
 
@@ -119,6 +121,64 @@ def test_runtime_secret_file_is_mode_0600_and_cleaned_up(
     assert result == return_code
     assert observed_path is not None
     assert not observed_path.exists()
+
+
+def test_sigterm_forwards_to_consumer_and_cleans_runtime_secret_file(
+    tmp_path: Path,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(
+        bin_dir / "security",
+        f"""#!/usr/bin/env bash
+set -eu
+printf '%s\\n' '{_RAW_KEY}'
+""",
+    )
+    ready = tmp_path / "consumer-ready"
+    observed_path = tmp_path / "observed-path"
+    consumer = (
+        "import os, pathlib, time; "
+        f"pathlib.Path({str(observed_path)!r}).write_text("
+        "os.environ['HOST_SECRET_RUNTIME_ENV_FILE'], encoding='utf-8'); "
+        f"pathlib.Path({str(ready)!r}).touch(); "
+        "time.sleep(60)"
+    )
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "app.ops.host_secret_bootstrap",
+            "--channel",
+            "dev",
+            "--consumer",
+            "heimdal-capture-watch",
+            "--",
+            sys.executable,
+            "-c",
+            consumer,
+        ],
+        cwd=_REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    deadline = time.monotonic() + 10
+    while not ready.exists() and process.poll() is None and time.monotonic() < deadline:
+        time.sleep(0.05)
+    assert ready.exists(), process.communicate(timeout=5)
+    secret_file = Path(observed_path.read_text(encoding="utf-8"))
+    assert secret_file.is_file()
+
+    process.terminate()
+    _stdout, stderr = process.communicate(timeout=10)
+
+    assert process.returncode == 128 + signal.SIGTERM
+    assert not secret_file.exists()
+    assert _RAW_KEY not in stderr
 
 
 def _write_executable(path: Path, text: str) -> None:

--- a/tests/ops/test_host_secret_bootstrap.py
+++ b/tests/ops/test_host_secret_bootstrap.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+
+import pytest
+
+from app.ops.host_secret_bootstrap import (
+    HostSecretBootstrapError,
+    KeychainLookup,
+    materialize_consumer_environment,
+    run_with_host_secrets,
+)
+
+
+_RAW_KEY = "a" * 64
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _lookup(value: str = _RAW_KEY) -> KeychainLookup:
+    return lambda _service, _account: value
+
+
+def test_consumer_gets_only_allowlisted_values(tmp_path: Path) -> None:
+    requested: list[tuple[str, str]] = []
+
+    def lookup(service: str, account: str) -> str:
+        requested.append((service, account))
+        return _RAW_KEY
+
+    with materialize_consumer_environment(
+        channel="dev",
+        consumer="heimdal-capture-watch",
+        keychain_lookup=lookup,
+        directory=tmp_path,
+    ) as env_file:
+        assert env_file.read_text(encoding="utf-8") == f"HEIMDAL_RAW_STORE_KEY={_RAW_KEY}\n"
+
+    assert requested == [
+        (
+            "yggdrasil.host-secrets",
+            "dev:heimdal-capture-watch:heimdal.raw-store-key",
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    ("lookup", "secret_fragment"),
+    [
+        (
+            lambda _service, _account: (_ for _ in ()).throw(
+                OSError("denied leaked-value")
+            ),
+            "leaked-value",
+        ),
+        (lambda _service, _account: "malformed-secret-value", "malformed-secret-value"),
+        (lambda _service, _account: "", ""),
+    ],
+)
+def test_missing_or_malformed_secret_fails_closed(
+    tmp_path: Path,
+    lookup: KeychainLookup,
+    secret_fragment: str,
+) -> None:
+    launched = False
+
+    def runner(_command: list[str], _env: dict[str, str]) -> int:
+        nonlocal launched
+        launched = True
+        return 0
+
+    with pytest.raises(HostSecretBootstrapError) as error:
+        run_with_host_secrets(
+            channel="dev",
+            consumer="heimdal-capture-watch",
+            command=["never-start"],
+            keychain_lookup=lookup,
+            runner=runner,
+            directory=tmp_path,
+        )
+
+    assert not launched
+    assert str(error.value) == "host secret bootstrap failed for declared consumer"
+    if secret_fragment:
+        assert secret_fragment not in str(error.value)
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.parametrize("return_code", [0, 23])
+def test_runtime_secret_file_is_mode_0600_and_cleaned_up(
+    tmp_path: Path,
+    return_code: int,
+) -> None:
+    observed_path: Path | None = None
+
+    def runner(_command: list[str], env: dict[str, str]) -> int:
+        nonlocal observed_path
+        observed_path = Path(env["HOST_SECRET_RUNTIME_ENV_FILE"])
+        assert observed_path.is_file()
+        assert stat.S_IMODE(observed_path.stat().st_mode) == 0o600
+        assert env.get("HEIMDAL_RAW_STORE_KEY") is None
+        assert observed_path.read_text(encoding="utf-8") == (
+            f"HEIMDAL_RAW_STORE_KEY={_RAW_KEY}\n"
+        )
+        return return_code
+
+    result = run_with_host_secrets(
+        channel="dev",
+        consumer="heimdal-capture-watch",
+        command=["consumer"],
+        keychain_lookup=_lookup(),
+        runner=runner,
+        directory=tmp_path,
+    )
+
+    assert result == return_code
+    assert observed_path is not None
+    assert not observed_path.exists()
+
+
+def _write_executable(path: Path, text: str) -> None:
+    path.write_text(text, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def test_capture_watch_uses_bootstrap_not_tracked_env(tmp_path: Path) -> None:
+    dev_overlay = (_REPO_ROOT / "docker-compose.dev.yml").read_text(encoding="utf-8")
+    assert "${HOST_SECRET_RUNTIME_ENV_FILE:-/dev/null}" in dev_overlay
+    assert "HEIMDAL_RAW_STORE_KEY: !reset null" in dev_overlay
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    runtime_env = tmp_path / "runtime.env"
+    runtime_env.write_text(
+        "HEIMDAL_RAW_STORE_KEY=tracked-runtime-value-must-not-win\n",
+        encoding="utf-8",
+    )
+    channel_env = tmp_path / "dev.env"
+    channel_env.write_text(
+        f"WATCHER_RUNTIME_ENV_FILE={runtime_env}\n",
+        encoding="utf-8",
+    )
+    observed_path_file = tmp_path / "observed-path"
+    observed_content_file = tmp_path / "observed-content"
+    _write_executable(
+        bin_dir / "security",
+        f"""#!/usr/bin/env bash
+set -eu
+printf '%s\\n' '{_RAW_KEY}'
+""",
+    )
+    _write_executable(
+        bin_dir / "docker",
+        f"""#!/usr/bin/env bash
+set -eu
+test -n "${{HOST_SECRET_RUNTIME_ENV_FILE:-}}"
+test -f "$HOST_SECRET_RUNTIME_ENV_FILE"
+test "$(stat -f '%Lp' "$HOST_SECRET_RUNTIME_ENV_FILE")" = 600
+printf '%s' "$HOST_SECRET_RUNTIME_ENV_FILE" > {observed_path_file!s}
+cp "$HOST_SECRET_RUNTIME_ENV_FILE" {observed_content_file!s}
+""",
+    )
+
+    command = f"""
+set -euo pipefail
+source {_REPO_ROOT / 'scripts/lib/deploy_channel_compose.sh'}
+PYTHON={sys.executable!s}
+deploy_channel_compose \\
+  {_REPO_ROOT!s} dev docker-compose.dev.yml pkm-dev-bootstrap-test \\
+  {channel_env!s} up -d heimdal-capture-watch
+"""
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["HEIMDAL_RAW_STORE_KEY"] = "ambient-value-must-not-win"
+    result = subprocess.run(
+        ["bash", "-c", command],
+        cwd=_REPO_ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    secret_file = Path(observed_path_file.read_text(encoding="utf-8"))
+    assert observed_content_file.read_text(encoding="utf-8") == (
+        f"HEIMDAL_RAW_STORE_KEY={_RAW_KEY}\n"
+    )
+    assert not secret_file.exists()

--- a/tests/ops/test_host_secret_bootstrap.py
+++ b/tests/ops/test_host_secret_bootstrap.py
@@ -269,6 +269,66 @@ def test_signal_during_child_spawn_is_forwarded_after_assignment(
     assert process.poll() == -signal.SIGTERM
 
 
+def test_post_kill_reap_timeout_still_returns_to_secret_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class UninterruptibleProcess:
+        def __init__(self) -> None:
+            self.forwarded: list[int] = []
+            self.kills = 0
+            self.wait_timeouts: list[float | None] = []
+
+        def poll(self) -> None:
+            return None
+
+        def send_signal(self, signum: int) -> None:
+            self.forwarded.append(signum)
+
+        def wait(self, timeout: float | None = None) -> int:
+            self.wait_timeouts.append(timeout)
+            raise subprocess.TimeoutExpired("consumer", timeout)
+
+        def kill(self) -> None:
+            self.kills += 1
+
+    process = UninterruptibleProcess()
+
+    def interrupted_popen(
+        _command: list[str],
+        *,
+        env: dict[str, str],
+    ) -> UninterruptibleProcess:
+        observed_path = Path(env["HOST_SECRET_RUNTIME_ENV_FILE"])
+        assert observed_path.is_file()
+        signal.raise_signal(signal.SIGTERM)
+        return process
+
+    monkeypatch.setattr(host_secret_bootstrap.subprocess, "Popen", interrupted_popen)
+    monkeypatch.setattr(
+        host_secret_bootstrap,
+        "_CHILD_TERMINATION_GRACE_SECONDS",
+        0.0,
+    )
+
+    with pytest.raises(HostSecretBootstrapTerminated) as error:
+        run_with_host_secrets(
+            channel="dev",
+            consumer="heimdal-capture-watch",
+            command=["consumer"],
+            keychain_lookup=_lookup(),
+            directory=tmp_path,
+        )
+
+    assert error.value.signum == signal.SIGTERM
+    assert process.forwarded == [signal.SIGTERM]
+    assert process.kills == 1
+    assert process.wait_timeouts == [
+        host_secret_bootstrap._CHILD_POST_KILL_REAP_SECONDS
+    ]
+    assert list(tmp_path.iterdir()) == []
+
+
 def test_signal_during_tempfile_creation_defers_until_cleanup_state_is_safe(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/ops/test_host_secret_bootstrap.py
+++ b/tests/ops/test_host_secret_bootstrap.py
@@ -158,7 +158,7 @@ printf '%s\\n' '{_RAW_KEY}'
 set -eu
 test -n "${{HOST_SECRET_RUNTIME_ENV_FILE:-}}"
 test -f "$HOST_SECRET_RUNTIME_ENV_FILE"
-test "$(stat -f '%Lp' "$HOST_SECRET_RUNTIME_ENV_FILE")" = 600
+python3 -c 'import stat, sys; from pathlib import Path; raise SystemExit(0 if stat.S_IMODE(Path(sys.argv[1]).stat().st_mode) == 0o600 else 1)' "$HOST_SECRET_RUNTIME_ENV_FILE"
 printf '%s' "$HOST_SECRET_RUNTIME_ENV_FILE" > {observed_path_file!s}
 cp "$HOST_SECRET_RUNTIME_ENV_FILE" {observed_content_file!s}
 """,


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

Governing-Issue: #3846

## Linked Issue
Fixes #3846

## SBS Impact
- Primary subsystem: Product/Runtime host/deploy boundary
- Secondary subsystem(s): Heimdal capture runtime
- Write class: deployment bootstrap and security enforcement
- Authority impact: none
- Persistence impact: temporary owner-only runtime material, removed after Compose returns or catchable termination
- Derived/rebuildable impact: redacted diagnostics only
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: DEV capture-watch integration only
- External boundary impact: macOS Keychain
- New or changed contract: HSP runtime bootstrap
- Owner-doc impact: none until parent #3843 acceptance
- Transition debt impact: reduces deploy-file secret dependency
- Fitness rule impact: strengthens fail-closed, minimization, mode-0600, cleanup, and real-call-site coverage
- Boundary risk: Tier 3 security/deployment boundary; deliberately excludes TEST/PROD/stable

## Owner-Doc Writeback
- [x] No owner-doc change implied.
- [ ] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- Resolve only declared `{channel, consumer}` Keychain entries, validate the Heimdal raw-store key, materialize one mode-0600 env file, and remove it after success, controlled failure, or catchable termination.
- Route DEV `heimdal-capture-watch` recreation through the bootstrap while scrubbing ambient raw-key values and preserving the existing governed runtime-env boundary.
- Keep cleanup handlers active through plaintext removal, defer signals across unsafe tempfile-ownership transitions, make descriptor-close and pathname-unlink independent obligations, and make child termination idempotent across spawn-time and repeated signals.

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] The pre-authored HSP-02 specification already describes this exact behavior; parent acceptance owns later current-state promotion.
- [x] Owner-doc promotion remains intentionally gated on parent #3843 validation.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [ ] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [ ] No product/runtime implementation or shipped feature behavior changed.

## Validation
Implementation lane:
- [x] `ruff check app tests companion-ui/companion-app` — `All checks passed!`
- [x] Lint output is included above.
- [x] `mypy app` — `Success: no issues found in 793 source files`
- [x] `pytest -q -m "not pg"` — `10259 passed, 38 skipped, 273 deselected, 18 xfailed`
- [x] `pytest -q tests/ops/test_host_secret_bootstrap.py tests/deploy/test_deploy_channel.py tests/deploy/test_dev_channel_compose.py tests/ops/test_compose_override.py tests/ops/test_heimdal_capture_watch_compose.py` — `60 passed`
- [x] `pytest -q tests/ops/test_host_secret_bootstrap.py` — `15 passed`, including restoration-boundary, mkstemp/fdopen ownership, descriptor-close failure, spawn-time, repeated-signal, child-reap, bounded post-kill timeout, and plaintext-cleanup regressions
- [x] `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1 python3 scripts/docs_guard.py` — `Docs guard: OK`; parent #3843 intentionally owns current-state owner-doc promotion after live DEV acceptance

## BuilderOps Routing
- Records/projections/receipts: epic-run-state `hsp-prod-coldstart-20260719`; claim receipt issue comment 5017479127
- Reason: serial #3846 -> #3885 delivery state and the quarantined-dispatcher label-only claim require durable coordination evidence; no product/runtime truth is stored there

## Notes
- No secret value or sensitive host path is present in this PR or its receipts. Catchable termination is cleaned and the direct child is boundedly reaped; SIGKILL/host failure remains inherently uncatchable.
- TEST/PROD/stable are unchanged. Existing bug #3885 is the separate follow-up for the shared base/PROD cold-start integration.