### PR TITLE
Fix verified-merge terminal LF digest handling

### DIFF
--- a/.codex/skills/verification-and-closure/SKILL.md
+++ b/.codex/skills/verification-and-closure/SKILL.md
@@ -287,6 +287,12 @@ Rules:
 
 When all prerequisites are met:
 
+Verified-merge authority and phase body digests canonicalize GitHub PR-body storage by removing at
+most one terminal LF before digest derivation or comparison. That LF is equivalent to its absence;
+every other body byte and whitespace character remains exact, and substantive body drift fails
+closed. This digest equivalence does not relax any head, title, closing-set, authority-receipt, or
+phase-continuity gate below.
+
 1. freeze the authenticated v2 context (`run_id`, repository, PR, exact head, governing issue,
    `closing_issues`, durable `supporting_issues`, attempts, and 2+2 repair-budget projection); re-read
    the live PR title/body/head and GitHub `closingIssuesReferences`, and reject any mismatch or title
@@ -297,8 +303,9 @@ When all prerequisites are met:
    changing the body so the original authority remains durable and auditable
 3. replace the live PR body with the plan's neutralized body, which converts every authenticated
    closer to evidence-only `Refs`; immediately re-read the PR and fail closed unless the head and
-   neutralized body are byte-identical to the plan, the title and body contain no canonical or
-   malformed closing attempt, and `closingIssuesReferences` is empty. Because the body edit triggers
+   neutralized body matches the plan under the terminal-LF-only canonical digest contract above, the
+   title and body contain no canonical or malformed closing attempt, and `closingIssuesReferences`
+   is empty. Because the body edit triggers
    governance again, the triggered `pr-contract` must authenticate the trusted, non-conflicting
    exact-head authority receipt against the complete neutralized body issue set; fabricated
    `Refs`/`Verified-Closing-Issues` text is never sufficient. Wait for the latest `pr-contract` run

--- a/.github/workflows/issue-pr-governance.yml
+++ b/.github/workflows/issue-pr-governance.yml
@@ -292,7 +292,10 @@ jobs:
               }
               return JSON.stringify(value);
             };
-            const sha256 = value => crypto.createHash("sha256").update(value, "utf8").digest("hex");
+            const bodySha256 = value => {
+              const canonicalBody = value.endsWith("\n") ? value.slice(0, -1) : value;
+              return crypto.createHash("sha256").update(canonicalBody, "utf8").digest("hex");
+            };
             const trustedAuthorityReceipts = comments => {
               const escaped = AUTHORITY_MARKER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
               const pattern = new RegExp(`${escaped}\\s*\`\`\`json\\s*([\\s\\S]*?)\\s*\`\`\``, "gm");
@@ -313,7 +316,7 @@ jobs:
             const resolveNeutralizedMergeAuthority = ({comments, issueAuthority, pullRequest, repository}) => {
               if (!issueAuthority.neutralizedValid) return null;
               const liveBody = pullRequest.body || "";
-              const liveDigest = sha256(liveBody);
+              const liveDigest = bodySha256(liveBody);
               const valid = trustedAuthorityReceipts(comments).filter(receipt => {
                 const closing = receipt.closing_issues;
                 const authenticatedSupporting = receipt.authenticated_supporting_issues;

--- a/.github/workflows/post-merge-owner-doc-watchdog.yml
+++ b/.github/workflows/post-merge-owner-doc-watchdog.yml
@@ -118,7 +118,11 @@ jobs:
               return lines.length === 1 && exact.length === 1 ? Number(exact[0][1]) : null;
             };
 
-            const bodySha256 = (body) => crypto.createHash("sha256").update(body, "utf8").digest("hex");
+            const sha256 = value => crypto.createHash("sha256").update(value, "utf8").digest("hex");
+            const bodySha256 = body => {
+              const canonicalBody = body.endsWith("\n") ? body.slice(0, -1) : body;
+              return sha256(canonicalBody);
+            };
 
             const TRUSTED_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
             const AUTHORITY_MARKER = "verified issue-set merge authority:";
@@ -156,7 +160,7 @@ jobs:
               }
               return JSON.stringify(value);
             };
-            const canonicalSha256 = value => bodySha256(canonicalJson(value));
+            const canonicalSha256 = value => sha256(canonicalJson(value));
             const commentReceipts = (comments, marker) => {
               const escaped = marker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
               const pattern = new RegExp(`${escaped}\\s*\`\`\`json\\s*([\\s\\S]*?)\\s*\`\`\``, "gm");

--- a/app/dispatcher/verification_consumer.py
+++ b/app/dispatcher/verification_consumer.py
@@ -57,6 +57,7 @@ from app.dispatcher.verification_contract import (
     resolve_neutralized_issue_authority,
 )
 from app.dispatcher.verified_merge import (
+    _body_digest,
     plan_post_merge_reconciliation,
     resolve_verified_merge_authority_receipt,
     resolve_verified_merge_phase,
@@ -3357,7 +3358,7 @@ class VerificationConsumer:
             raise ValueError(
                 "verification run is no longer resumable: merged_body_missing"
             )
-        live_body_digest = hashlib.sha256(live_body.encode("utf-8")).hexdigest()
+        live_body_digest = _body_digest(live_body)
         if live_body_digest == authority.get("body_sha256"):
             body_state = "restored"
         elif live_body_digest == authority.get("neutralized_body_sha256"):

--- a/app/dispatcher/verified_merge.py
+++ b/app/dispatcher/verified_merge.py
@@ -114,7 +114,15 @@ def _live_closing_issues(value: object, *, repository: str) -> tuple[int, ...]:
 
 
 def _body_digest(body: str) -> str:
-    return hashlib.sha256(body.encode("utf-8")).hexdigest()
+    """Digest the GitHub PR-body form used by verified-merge authority.
+
+    GitHub may persist a body without one terminal LF that was present when the
+    authority receipt was prepared.  That sole representation difference is
+    equivalent here; all other bytes, including whitespace, remain exact.
+    """
+
+    canonical_body = body[:-1] if body.endswith("\n") else body
+    return hashlib.sha256(canonical_body.encode("utf-8")).hexdigest()
 
 
 def _canonical_digest(value: Mapping[str, object]) -> str:

--- a/docs/AGENT_ISSUE_DISPATCHER.md
+++ b/docs/AGENT_ISSUE_DISPATCHER.md
@@ -318,6 +318,10 @@ The dispatcher is an operational coordination layer, not a lifecycle replacement
   they are also named in the exact `closing_authority_json` set. A trusted collaborator-authored
   `verified_issue_set_merge_authority.v1` receipt binds the run, governing issue, exact closing and
   supporting sets, original and neutralized body digests, and current repair-budget projection.
+- Verified-merge authority and phase body digests use one deterministic GitHub PR-body canonical
+  form: remove at most one terminal LF before deriving or comparing the SHA-256 digest. This treats
+  that terminal LF as equivalent to its absence; every other body byte and whitespace character
+  remains exact, and any substantive body drift fails closed.
 - Mutable PR text is never merge-time closure authority. Immediately before merge, the verified
   flow re-reads the exact head, title, body, and GitHub `closingIssuesReferences`, replaces every
   authenticated closing keyword with evidence-only `Refs` plus a bounded

--- a/tests/dispatcher/test_verification_consumer.py
+++ b/tests/dispatcher/test_verification_consumer.py
@@ -1302,6 +1302,81 @@ def test_merged_incomplete_run_recovers_after_raced_body_edit_and_crash(
     assert completed.verified_head_sha == HEAD
 
 
+def test_merged_recovery_accepts_terminal_newline_canonical_body_without_budget_reset(
+    tmp_path,
+) -> None:
+    original_body = "Governing-Issue: #3603\n\nFixes #3603\n"
+    plan = _merge_plan(HEAD, body=original_body)
+    authority = plan["authority_receipt"]
+    assert isinstance(authority, dict)
+    neutral_pr = eligible_pr(body=plan["neutralized_body"])
+    prepared = build_verified_merge_phase(
+        authority_receipt=authority,
+        phase="prepared",
+        pr=neutral_pr,
+    )
+    crashed_pr = merged_pr(body=original_body[:-1])
+
+    class RecoveryTruth(Truth):
+        def __init__(self) -> None:
+            super().__init__(crashed_pr, GREEN)
+            self.restored = False
+
+        def pull_request_comments(self, repository, pr_number):
+            if self.restored:
+                return _merge_comments(self._last_pr)
+            return [
+                {
+                    "author_association": "COLLABORATOR",
+                    "body": plan["authority_receipt_comment"],
+                },
+                {
+                    "author_association": "COLLABORATOR",
+                    "body": prepared["phase_receipt_comment"],
+                },
+            ]
+
+    state = ledger(tmp_path)
+    run = state.ingest(request())
+    claimed = state.claim(run.run_id, "crashed-host")
+    running = state.start(
+        run.run_id,
+        "crashed-host",
+        claimed.lease_id or "",
+        "01900000-0000-7000-8000-000000000005",
+        verification_consumer.context_pack(
+            claimed,
+            eligible_pr(),
+            repair_budget=state.repair_budget_projection(run.run_id),
+        ),
+    )
+    with state.store._connect() as conn:
+        conn.execute(
+            "UPDATE verification_runs SET lease_expires_at=? WHERE run_id=?",
+            ("2000-01-01T00:00:00+00:00", running.run_id),
+        )
+        conn.commit()
+
+    before_budget = state.repair_budget_projection(run.run_id)
+
+    truth = RecoveryTruth()
+
+    class RecoveryLauncher(DeliveredLauncher):
+        def launch(self, context_pack, **kwargs):
+            assert context_pack["merge_recovery"]["body_state"] == "restored"
+            truth.pr = merged_pr(body=original_body[:-1])
+            truth._last_pr = truth.pr
+            truth.restored = True
+            return super().launch(context_pack, **kwargs)
+
+    completed = VerificationConsumer(
+        state, truth, Auth(), RecoveryLauncher(), "recovery-host"
+    ).recover(run.run_id)
+
+    assert completed.status == "completed"
+    assert state.repair_budget_projection(run.run_id) == before_budget
+
+
 def _corrupt_pending_delivered_receipt(state, run_id, mutate) -> None:
     current = state.get(run_id)
     assert current is not None

--- a/tests/dispatcher/test_verification_consumer.py
+++ b/tests/dispatcher/test_verification_consumer.py
@@ -1305,7 +1305,7 @@ def test_merged_incomplete_run_recovers_after_raced_body_edit_and_crash(
 def test_merged_recovery_accepts_terminal_newline_canonical_body_without_budget_reset(
     tmp_path,
 ) -> None:
-    original_body = "Governing-Issue: #3603\n\nFixes #3603\n"
+    original_body = "Governing-Issue: #3603\n\nFixes #3603\n\nFinal-Review-Rounds: 1\n"
     plan = _merge_plan(HEAD, body=original_body)
     authority = plan["authority_receipt"]
     assert isinstance(authority, dict)

--- a/tests/dispatcher/test_verified_merge.py
+++ b/tests/dispatcher/test_verified_merge.py
@@ -100,13 +100,69 @@ def test_prepare_verified_merge_neutralizes_closers_and_preserves_authority() ->
     assert receipt["live_supporting_issues"] == [3820, 3823, 3900]
     assert receipt["repair_budget"] == _context()["repair_budget"]
     assert receipt["body_sha256"] == hashlib.sha256(
-        _body().encode("utf-8")
+        _body()[:-1].encode("utf-8")
     ).hexdigest()
     assert plan["authority_receipt_comment"].startswith(
         "verified issue-set merge authority:\n```json\n"
     )
     assert "Fixes" not in plan["fixed_commit_title"]
     assert "Closes" not in plan["fixed_commit_message"]
+
+
+def test_verified_merge_body_digest_canonicalizes_terminal_newline() -> None:
+    with_terminal_lf = _body()
+    without_terminal_lf = with_terminal_lf[:-1]
+
+    with_lf_plan = prepare_verified_merge(
+        context=_context(), pr=_pr(with_terminal_lf), live_closing_issues=[3820, 3823]
+    )
+    without_lf_plan = prepare_verified_merge(
+        context=_context(), pr=_pr(without_terminal_lf), live_closing_issues=[3820, 3823]
+    )
+
+    assert (
+        with_lf_plan["authority_receipt"]["body_sha256"]
+        == without_lf_plan["authority_receipt"]["body_sha256"]
+    )
+    assert (
+        with_lf_plan["authority_receipt"]["neutralized_body_sha256"]
+        == without_lf_plan["authority_receipt"]["neutralized_body_sha256"]
+    )
+
+
+def test_prepared_phase_accepts_github_terminal_newline_canonicalization() -> None:
+    plan = prepare_verified_merge(
+        context=_context(), pr=_pr(), live_closing_issues=[3820, 3823]
+    )
+    authority = plan["authority_receipt"]
+    assert isinstance(authority, dict)
+    neutralized_body = str(plan["neutralized_body"])
+    assert neutralized_body.endswith("\n")
+    neutralized_without_terminal_lf = neutralized_body[:-1]
+
+    prepared = build_verified_merge_phase(
+        authority_receipt=authority,
+        phase="prepared",
+        pr=_pr(neutralized_without_terminal_lf),
+    )
+
+    assert prepared["phase_receipt"]["head_sha"] == HEAD
+    assert prepared["phase_receipt"]["closed_issues"] == []
+
+
+def test_prepared_phase_rejects_substantive_body_drift_after_canonicalization() -> None:
+    plan = prepare_verified_merge(
+        context=_context(), pr=_pr(), live_closing_issues=[3820, 3823]
+    )
+    authority = plan["authority_receipt"]
+    assert isinstance(authority, dict)
+
+    with pytest.raises(ValueError, match="live state is malformed"):
+        build_verified_merge_phase(
+            authority_receipt=authority,
+            phase="prepared",
+            pr=_pr(str(plan["neutralized_body"]) + "substantive drift"),
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/governance/test_issue_pr_governance.py
+++ b/tests/governance/test_issue_pr_governance.py
@@ -55,6 +55,11 @@ def _read_workflow() -> str:
     )
 
 
+def _verified_merge_body_digest(body: str) -> str:
+    canonical_body = body[:-1] if body.endswith("\n") else body
+    return hashlib.sha256(canonical_body.encode()).hexdigest()
+
+
 def _js_issue_authority(body: str) -> dict[str, object]:
     workflow = _read_workflow()
     classifier = workflow.split("// authority-classifier:start", 1)[1].split(
@@ -141,13 +146,13 @@ def _neutralized_authority_fixture() -> tuple[
     )
     receipt = {
         "authenticated_supporting_issues": [3820],
-        "body_sha256": hashlib.sha256(original.encode()).hexdigest(),
+        "body_sha256": _verified_merge_body_digest(original),
         "closing_issues": [3820],
         "contract": "verified_issue_set_merge_authority.v1",
         "governing_issue": 3821,
         "head_sha": head,
         "live_supporting_issues": [3820, 3900],
-        "neutralized_body_sha256": hashlib.sha256(neutralized.encode()).hexdigest(),
+        "neutralized_body_sha256": _verified_merge_body_digest(neutralized),
         "pr_number": 3822,
         "repair_budget": {"policy_version": "v2", "mechanisms": []},
         "repository": repository,
@@ -333,6 +338,28 @@ def test_neutralized_pr_contract_requires_trusted_exact_head_authority_receipt()
     )
 
     assert resolved == receipt
+
+
+def test_neutralized_pr_contract_canonicalizes_only_one_terminal_lf() -> None:
+    pull_request, comment, receipt = _neutralized_authority_fixture()
+    repository = str(receipt["repository"])
+    body = str(pull_request["body"])
+    assert body.endswith("\n")
+
+    for equivalent_body in (body, body[:-1]):
+        candidate = {**pull_request, "body": equivalent_body}
+        assert _js_neutralized_merge_authority(
+            [comment], candidate, repository
+        ) == receipt
+
+    for changed_body in (body + "\n", body + " ", body + "substantive drift"):
+        substantive_drift = {**pull_request, "body": changed_body}
+        assert (
+            _js_neutralized_merge_authority(
+                [comment], substantive_drift, repository
+            )
+            is None
+        )
 
 
 def test_neutralized_pr_contract_rejects_forged_stale_missing_and_conflicting_authority() -> None:

--- a/tests/governance/test_post_merge_owner_doc_watchdog.py
+++ b/tests/governance/test_post_merge_owner_doc_watchdog.py
@@ -46,6 +46,11 @@ def _body() -> str:
     )
 
 
+def _verified_merge_body_digest(body: str) -> str:
+    canonical_body = body[:-1] if body.endswith("\n") else body
+    return hashlib.sha256(canonical_body.encode()).hexdigest()
+
+
 def _authority_comment(body: str | None = None) -> dict[str, object]:
     original = _body() if body is None else body
     neutralized = original.replace("Fixes #3820", "Refs #3820").replace(
@@ -53,13 +58,13 @@ def _authority_comment(body: str | None = None) -> dict[str, object]:
     ) + "Verified-Closing-Issues: #3820, #3823\n"
     receipt = {
         "authenticated_supporting_issues": [3820, 3823],
-        "body_sha256": hashlib.sha256(original.encode()).hexdigest(),
+        "body_sha256": _verified_merge_body_digest(original),
         "closing_issues": [3820, 3823],
         "contract": "verified_issue_set_merge_authority.v1",
         "governing_issue": 3821,
         "head_sha": HEAD,
         "live_supporting_issues": [3820, 3823],
-        "neutralized_body_sha256": hashlib.sha256(neutralized.encode()).hexdigest(),
+        "neutralized_body_sha256": _verified_merge_body_digest(neutralized),
         "pr_number": 3822,
         "repair_budget": {"policy_version": "v2", "mechanisms": []},
         "repository": REPOSITORY,
@@ -211,6 +216,36 @@ def test_watchdog_accepts_authenticated_receipt_for_original_or_neutral_body() -
         )
         assert result["closing_issues"] == [3820, 3823]
         assert result["repair_budget"]["policy_version"] == "v2"
+
+
+def test_watchdog_body_digest_canonicalizes_only_one_terminal_lf() -> None:
+    original = _body()
+    comment = _authority_comment()
+    assert original.endswith("\n")
+
+    for equivalent_body in (original, original[:-1]):
+        result = _node(
+            "resolveAuthorityReceipt(inputs[0], inputs[1], inputs[2])",
+            [comment],
+            _pr(equivalent_body),
+            REPOSITORY,
+        )
+        assert result["closing_issues"] == [3820, 3823]
+
+    for changed_body in (
+        original + "\n",
+        original + " ",
+        original + "substantive drift",
+    ):
+        assert (
+            _node(
+                "resolveAuthorityReceipt(inputs[0], inputs[1], inputs[2])",
+                [comment],
+                _pr(changed_body),
+                REPOSITORY,
+            )
+            is None
+        )
 
 
 def test_watchdog_rejects_forged_stale_or_conflicting_authority_receipts() -> None:


### PR DESCRIPTION
Governing-Issue: #4010

Fixes #4010

Final-Review-Rounds: 2

## Summary
Canonicalize only one terminal LF in verified-merge PR-body digests across Python authority/phase production, merged recovery, PR governance validation, and the post-merge owner-doc watchdog. Align the existing dispatcher owner contract and verification merge rules with that shipped behavior: every other byte and whitespace remains exact, substantive drift fails closed, and no head/title/closing-set/authority/phase gate is weakened.

## Validation
- All five #4010 AC targets: four exact behavioral selectors passed; both exact doc anchors verified
- `pytest -q tests/dispatcher/test_verified_merge.py tests/dispatcher/test_verification_consumer.py` (266 passed)
- `pytest -q tests/governance/test_issue_pr_governance.py tests/governance/test_post_merge_owner_doc_watchdog.py tests/governance/test_epic_pr_batching_policy.py tests/architecture/test_pr_hot_path_governance.py` (125 passed)
- Skill/governance entrypoint set: 30 passed
- `ruff check app tests`
- `mypy app/dispatcher/verified_merge.py app/dispatcher/verification_consumer.py`
- Workflow YAML parsing and `git diff --check`
- `DOCS_GUARD_ALLOW_TEMPORAL_SKIP=1 python3 scripts/docs_guard.py` (passed; #4010 forbids unrelated temporal-doc changes)
- Governance review-before-CI gate: satisfied

## Docs Governance
- Updated only `docs/AGENT_ISSUE_DISPATCHER.md :: Verified issue-set merge and exact closure` and `.codex/skills/verification-and-closure/SKILL.md :: Merge Rules > When all prerequisites are met`.
- No new document and no DOCS_INDEX impact.

## Review Repair
- `review_code_correctness / verified_merge_terminal_lf_cross_validator_parity`, standard attempt 1: fixed at `2b2d68d888e4e9bcde132333f6bd5b348db61a3d`; evidence replied on discussion `r3611629412`.
- Contract writeback completed at `a4b576484001007cfb45d3d520d8416ce7092c78`.

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: bounded current-state correction; the Issue, PR, claim comment, review thread, and exact-head writeback provide durable traceability.

