### PR TITLE
feat: enforce accepted YouTube sync runtime gating

### DIFF
--- a/app/receipts/settings_receipts.py
+++ b/app/receipts/settings_receipts.py
@@ -27,6 +27,8 @@ class SettingsReceiptQuery:
     surface: str | None = None
     actor: str | None = None
     is_runtime_gating: bool | None = None
+    vault_id: str | None = None
+    local_instance_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -42,6 +44,8 @@ class SettingsReceiptRow:
     surface: str | None
     actor: str | None
     is_runtime_gating: bool
+    vault_id: str | None
+    local_instance_id: str | None
 
 
 @dataclass(frozen=True)
@@ -121,6 +125,8 @@ def _project_settings_receipt(record: dict[str, Any]) -> tuple[SettingsReceiptRo
             surface=first_str(payload.get("surface")),
             actor=first_str(payload.get("actor")),
             is_runtime_gating=bool(payload.get("is_runtime_gating", False)),
+            vault_id=first_str(payload.get("vault_id")),
+            local_instance_id=first_str(payload.get("local_instance_id")),
         ),
         "",
     )
@@ -134,6 +140,10 @@ def _matches(row: SettingsReceiptRow, query: SettingsReceiptQuery) -> bool:
     if query.actor and query.actor != row.actor:
         return False
     if query.is_runtime_gating is not None and query.is_runtime_gating != row.is_runtime_gating:
+        return False
+    if query.vault_id and query.vault_id != row.vault_id:
+        return False
+    if query.local_instance_id and query.local_instance_id != row.local_instance_id:
         return False
     return True
 

--- a/app/receipts/settings_receipts.py
+++ b/app/receipts/settings_receipts.py
@@ -8,6 +8,7 @@ receipt data once it has been emitted to the outbox.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable
@@ -44,6 +45,7 @@ class SettingsReceiptRow:
     surface: str | None
     actor: str | None
     is_runtime_gating: bool
+    operation_id: str | None
     vault_id: str | None
     local_instance_id: str | None
 
@@ -61,6 +63,8 @@ def query_settings_receipts(
     vault_root: Path | None = None,
     outbox_path: Path | None = None,
     records: Iterable[dict[str, Any]] | None = None,
+    require_operation_id: bool = False,
+    durable_append_order: bool = False,
 ) -> SettingsReceiptQueryResult:
     """Return typed settings-write receipt rows derived from durable outbox records.
 
@@ -70,12 +74,20 @@ def query_settings_receipts(
     """
 
     del vault_root  # unused today; kept for projection-reader signature symmetry
-    source_records = list(records) if records is not None else read_receipt_source_records(outbox_path=outbox_path)
+    source_records: list[dict[str, Any]] | None
+    if records is not None:
+        source_records = list(records)
+    elif durable_append_order:
+        source_records = _read_durable_jsonl_records(outbox_path=outbox_path)
+    else:
+        source_records = read_receipt_source_records(outbox_path=outbox_path)
     if source_records is None:
         return SettingsReceiptQueryResult(source_available=False)
 
     filters = query or SettingsReceiptQuery()
-    rows: list[SettingsReceiptRow] = []
+    projected_rows: list[SettingsReceiptRow] = []
+    rows_by_operation: dict[str, SettingsReceiptRow] = {}
+    invalid_operations: set[str] = set()
     non_authoritative: list[dict[str, str | None]] = []
     for record in source_records:
         event = record_event(record)
@@ -89,10 +101,40 @@ def query_settings_receipts(
                 "reason": reason,
             })
             continue
-        if _matches(row, filters):
-            rows.append(row)
+        if require_operation_id and not row.operation_id:
+            non_authoritative.append(
+                {
+                    "event_id": row.event_id,
+                    "trace_id": row.trace_id,
+                    "reason": "missing_operation_id",
+                }
+            )
+            continue
+        if row.operation_id:
+            prior = rows_by_operation.get(row.operation_id)
+            if prior is not None:
+                if not _same_operation_payload(prior, row):
+                    invalid_operations.add(row.operation_id)
+                continue
+            rows_by_operation[row.operation_id] = row
+        projected_rows.append(row)
 
-    rows.sort(key=lambda row: row.timestamp)
+    for operation_id in sorted(invalid_operations):
+        prior = rows_by_operation[operation_id]
+        non_authoritative.append(
+            {
+                "event_id": prior.event_id,
+                "trace_id": prior.trace_id,
+                "reason": "operation_id_collision",
+            }
+        )
+    rows = [
+        row
+        for row in projected_rows
+        if row.operation_id not in invalid_operations and _matches(row, filters)
+    ]
+    if not durable_append_order:
+        rows.sort(key=lambda row: row.timestamp)
     return SettingsReceiptQueryResult(
         source_available=True,
         rows=tuple(rows),
@@ -125,6 +167,7 @@ def _project_settings_receipt(record: dict[str, Any]) -> tuple[SettingsReceiptRo
             surface=first_str(payload.get("surface")),
             actor=first_str(payload.get("actor")),
             is_runtime_gating=bool(payload.get("is_runtime_gating", False)),
+            operation_id=first_str(payload.get("operation_id")),
             vault_id=first_str(payload.get("vault_id")),
             local_instance_id=first_str(payload.get("local_instance_id")),
         ),
@@ -146,6 +189,48 @@ def _matches(row: SettingsReceiptRow, query: SettingsReceiptQuery) -> bool:
     if query.local_instance_id and query.local_instance_id != row.local_instance_id:
         return False
     return True
+
+
+def _same_operation_payload(
+    left: SettingsReceiptRow, right: SettingsReceiptRow
+) -> bool:
+    return (
+        left.timestamp == right.timestamp
+        and left.key == right.key
+        and left.value == right.value
+        and left.old_value == right.old_value
+        and left.new_value == right.new_value
+        and left.file == right.file
+        and left.surface == right.surface
+        and left.actor == right.actor
+        and left.is_runtime_gating == right.is_runtime_gating
+        and left.operation_id == right.operation_id
+        and left.vault_id == right.vault_id
+        and left.local_instance_id == right.local_instance_id
+    )
+
+
+def _read_durable_jsonl_records(
+    *, outbox_path: Path | None
+) -> list[dict[str, Any]] | None:
+    if outbox_path is None:
+        from app.outbox.events import get_index_outbox_path  # noqa: PLC0415
+
+        resolved = get_index_outbox_path()
+    else:
+        resolved = Path(outbox_path).expanduser()
+    if not resolved.exists() or not resolved.is_file():
+        return None
+    records: list[dict[str, Any]] = []
+    with resolved.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(record, dict):
+                records.append(record)
+    return records
 
 
 __all__ = [

--- a/app/receipts/settings_write.py
+++ b/app/receipts/settings_write.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import fcntl
 from contextlib import contextmanager
 from contextvars import ContextVar
 from collections.abc import Iterator
@@ -67,6 +68,8 @@ class SettingsWriteReceipt:
     old_value: Any = None
     new_value: Any = field(default=_NEW_VALUE_UNSET, repr=False)
     operation_id: str | None = None
+    vault_id: str | None = None
+    local_instance_id: str | None = None
 
     def __post_init__(self) -> None:
         if self.new_value is _NEW_VALUE_UNSET:
@@ -95,6 +98,8 @@ def emit_settings_write_receipt(
                 "surface": receipt.surface,
                 "actor": receipt.actor,
                 "operation_id": receipt.operation_id,
+                "vault_id": receipt.vault_id,
+                "local_instance_id": receipt.local_instance_id,
                 "timestamp": receipt.timestamp,
                 "is_runtime_gating": receipt.is_runtime_gating,
             },
@@ -195,6 +200,8 @@ def durable_settings_write_receipt_exists(receipt: SettingsWriteReceipt) -> bool
                         "actor": receipt.actor,
                         "timestamp": receipt.timestamp,
                         "is_runtime_gating": receipt.is_runtime_gating,
+                        "vault_id": receipt.vault_id,
+                        "local_instance_id": receipt.local_instance_id,
                     }.items()
                 )
                 if exact_match:
@@ -209,6 +216,40 @@ def durable_settings_write_receipt_exists(receipt: SettingsWriteReceipt) -> bool
         _confirm_file_and_parent_durable(outbox_path)
         return True
     return False
+
+
+def emit_durable_settings_write_receipt_once(receipt: SettingsWriteReceipt) -> None:
+    """Durably append and read back one operation-scoped receipt exactly once.
+
+    The sibling lock serializes check-and-append across settings writers.  If a
+    prior attempt appended the exact receipt but failed while confirming parent
+    durability, the retry observes and re-confirms that record instead of
+    creating a second accepted operation.
+    """
+
+    if not receipt.operation_id:
+        raise ValueError("durable receipt emission requires operation_id")
+
+    from app.outbox.events import get_index_outbox_path  # noqa: PLC0415
+
+    outbox_path = get_index_outbox_path()
+    outbox_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = outbox_path.with_name(f".{outbox_path.name}.settings-receipt.lock")
+    with lock_path.open("a+b") as lock_handle:
+        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+        try:
+            if durable_settings_write_receipt_exists(receipt):
+                return
+            try:
+                emit_settings_write_receipt(receipt, require_durable=True)
+            except ReceiptDurabilityUncertainError:
+                if durable_settings_write_receipt_exists(receipt):
+                    return
+                raise
+            if not durable_settings_write_receipt_exists(receipt):
+                raise RuntimeError("durable settings receipt readback failed")
+        finally:
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
 
 
 def emit_settings_write_receipts_for_changes(
@@ -277,6 +318,7 @@ def _flatten(values: Mapping[str, Any], prefix: str = "") -> dict[str, Any]:
 __all__ = [
     "SettingsWriteReceipt",
     "durable_settings_write_receipt_exists",
+    "emit_durable_settings_write_receipt_once",
     "emit_settings_write_receipt",
     "emit_settings_write_receipts_for_changes",
     "resolve_settings_receipt_old_value",

--- a/app/receipts/settings_write.py
+++ b/app/receipts/settings_write.py
@@ -8,7 +8,7 @@ import os
 import fcntl
 from contextlib import contextmanager
 from contextvars import ContextVar
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -23,6 +23,12 @@ _NEW_VALUE_UNSET = object()
 _old_value_override: ContextVar[Any] = ContextVar(
     "settings_receipt_old_value",
     default=_OLD_VALUE_UNSET,
+)
+_acceptance_precondition_override: ContextVar[Callable[[], None] | None] = (
+    ContextVar(
+        "settings_receipt_acceptance_precondition",
+        default=None,
+    )
 )
 
 
@@ -218,7 +224,11 @@ def durable_settings_write_receipt_exists(receipt: SettingsWriteReceipt) -> bool
     return False
 
 
-def emit_durable_settings_write_receipt_once(receipt: SettingsWriteReceipt) -> None:
+def emit_durable_settings_write_receipt_once(
+    receipt: SettingsWriteReceipt,
+    *,
+    acceptance_precondition: Callable[[], None] | None = None,
+) -> None:
     """Durably append and read back one operation-scoped receipt exactly once.
 
     The sibling lock serializes check-and-append across settings writers.  If a
@@ -240,6 +250,8 @@ def emit_durable_settings_write_receipt_once(receipt: SettingsWriteReceipt) -> N
         try:
             if durable_settings_write_receipt_exists(receipt):
                 return
+            if acceptance_precondition is not None:
+                acceptance_precondition()
             try:
                 emit_settings_write_receipt(receipt, require_durable=True)
             except ReceiptDurabilityUncertainError:
@@ -304,6 +316,23 @@ def resolve_settings_receipt_old_value(default: Any) -> Any:
     return default if value is _OLD_VALUE_UNSET else value
 
 
+@contextmanager
+def settings_receipt_acceptance_precondition(
+    precondition: Callable[[], None] | None,
+) -> Iterator[None]:
+    """Bind an optimistic generation check to the durable receipt boundary."""
+
+    token = _acceptance_precondition_override.set(precondition)
+    try:
+        yield
+    finally:
+        _acceptance_precondition_override.reset(token)
+
+
+def resolve_settings_receipt_acceptance_precondition() -> Callable[[], None] | None:
+    return _acceptance_precondition_override.get()
+
+
 def _flatten(values: Mapping[str, Any], prefix: str = "") -> dict[str, Any]:
     flattened: dict[str, Any] = {}
     for key, value in values.items():
@@ -321,6 +350,8 @@ __all__ = [
     "emit_durable_settings_write_receipt_once",
     "emit_settings_write_receipt",
     "emit_settings_write_receipts_for_changes",
+    "resolve_settings_receipt_acceptance_precondition",
     "resolve_settings_receipt_old_value",
+    "settings_receipt_acceptance_precondition",
     "settings_receipt_old_value",
 ]

--- a/app/vault/markdown_settings.py
+++ b/app/vault/markdown_settings.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import os
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -72,10 +73,31 @@ class MarkdownSettingsStore:
         return MarkdownSettingsDocument(path=path, frontmatter=frontmatter, body=body)
 
     def write_missing(self, path: Path, frontmatter: Mapping[str, Any], body: str) -> bool:
-        if path.exists():
-            return False
+        """Create a settings document without overwriting a concurrent creator."""
+
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(render_markdown_settings(frontmatter, body), encoding="utf-8")
+        payload = render_markdown_settings(frontmatter, body).encode("utf-8")
+        try:
+            descriptor = os.open(
+                path,
+                os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+                0o600,
+            )
+        except FileExistsError:
+            return False
+        try:
+            written = os.write(descriptor, payload)
+            if written != len(payload):
+                raise OSError("partial settings scaffold write")
+            os.fsync(descriptor)
+        except Exception:
+            try:
+                path.unlink()
+            except OSError:
+                pass
+            raise
+        finally:
+            os.close(descriptor)
         return True
 
     def write_frontmatter(self, path: Path, frontmatter: Mapping[str, Any], *, body: str | None = None) -> None:

--- a/app/vault/settings_service.py
+++ b/app/vault/settings_service.py
@@ -475,21 +475,25 @@ class SettingsService:
             return accepted
 
         for receipt in receipt_result.rows:
-            definition = self.registry.get(receipt.key)
+            receipt_definition = self.registry.get(receipt.key)
             if (
-                definition is None
-                or definition.key not in RUNTIME_GATING_SETTINGS
-                or expected_files.get(definition.key) != receipt.file
+                receipt_definition is None
+                or receipt_definition.key not in RUNTIME_GATING_SETTINGS
+                or expected_files.get(receipt_definition.key) != receipt.file
             ):
                 continue
-            value = definition.default_value if receipt.new_value is None else receipt.new_value
-            valid, _message = _validate_value(definition, value)
+            value = (
+                receipt_definition.default_value
+                if receipt.new_value is None
+                else receipt.new_value
+            )
+            valid, _message = _validate_value(receipt_definition, value)
             if not valid:
                 continue
-            accepted[definition.key] = EffectiveSetting(
-                key=definition.key,
+            accepted[receipt_definition.key] = EffectiveSetting(
+                key=receipt_definition.key,
                 value=value,
-                scope=definition.scope,
+                scope=receipt_definition.scope,
                 source="accepted-runtime-gating-receipt",
                 source_file=receipt.file,
             )

--- a/app/vault/settings_service.py
+++ b/app/vault/settings_service.py
@@ -12,6 +12,7 @@ from app.receipts.settings_write import (
     SettingsWriteReceipt,
     emit_durable_settings_write_receipt_once,
     emit_settings_write_receipt,
+    resolve_settings_receipt_acceptance_precondition,
     resolve_settings_receipt_old_value,
 )
 from app.vault.manager import VaultContext, shared_settings_file_seed
@@ -631,7 +632,7 @@ class SettingsService:
             surface=surface,
             actor=actor,
             is_runtime_gating=is_runtime_gating,
-            file=str(path),
+            file=definition.file,
             old_value=old_value,
             new_value=receipt_value,
             operation_id=f"settings-write:{uuid4()}",
@@ -651,7 +652,16 @@ class SettingsService:
         # survives process restart (#2787).
         try:
             if is_runtime_gating:
-                emit_durable_settings_write_receipt_once(receipt)
+                acceptance_precondition = (
+                    resolve_settings_receipt_acceptance_precondition()
+                )
+                if acceptance_precondition is None:
+                    emit_durable_settings_write_receipt_once(receipt)
+                else:
+                    emit_durable_settings_write_receipt_once(
+                        receipt,
+                        acceptance_precondition=acceptance_precondition,
+                    )
             else:
                 emit_settings_write_receipt(receipt)
         except Exception as exc:

--- a/app/vault/settings_service.py
+++ b/app/vault/settings_service.py
@@ -426,6 +426,75 @@ class SettingsService:
     def reload(self, context: VaultContext) -> SettingsResolution:
         return self.resolve(context)
 
+    def resolve_accepted_runtime_gating(
+        self, context: VaultContext
+    ) -> dict[str, EffectiveSetting]:
+        """Return only runtime-gating values accepted by the governed seam.
+
+        The ordinary resolver intentionally remains an operator-facing view of
+        the Markdown inputs and their provenance.  Runtime consumers must use
+        this accessor instead: first-seen, denied, cross-file, or otherwise
+        unreceipted disk input therefore fails closed to the registered safe
+        default.  The existing durable settings-write receipt is the accepted
+        authority record; this adds no parallel store.
+        """
+        accepted: dict[str, EffectiveSetting] = {}
+        expected_files: dict[str, str] = {}
+        if context.status == "selected" and context.settings_path:
+            settings_path = Path(context.settings_path)
+            expected_files = {
+                definition.key: str(settings_path / definition.file)
+                for definition in self.registry.definitions
+                if definition.key in RUNTIME_GATING_SETTINGS and definition.file
+            }
+
+        for definition in self.registry.definitions:
+            if definition.key not in RUNTIME_GATING_SETTINGS:
+                continue
+            accepted[definition.key] = EffectiveSetting(
+                key=definition.key,
+                value=definition.default_value,
+                scope="built-in",
+                source="accepted-runtime-gating-default",
+            )
+
+        if not expected_files:
+            return accepted
+
+        # Deferred import avoids folding the read-only receipt projection into
+        # the settings compiler import graph.
+        from app.receipts.settings_receipts import (  # noqa: PLC0415
+            SettingsReceiptQuery,
+            query_settings_receipts,
+        )
+
+        receipt_result = query_settings_receipts(
+            SettingsReceiptQuery(is_runtime_gating=True)
+        )
+        if not receipt_result.source_available:
+            return accepted
+
+        for receipt in receipt_result.rows:
+            definition = self.registry.get(receipt.key)
+            if (
+                definition is None
+                or definition.key not in RUNTIME_GATING_SETTINGS
+                or expected_files.get(definition.key) != receipt.file
+            ):
+                continue
+            value = definition.default_value if receipt.new_value is None else receipt.new_value
+            valid, _message = _validate_value(definition, value)
+            if not valid:
+                continue
+            accepted[definition.key] = EffectiveSetting(
+                key=definition.key,
+                value=value,
+                scope=definition.scope,
+                source="accepted-runtime-gating-receipt",
+                source_file=receipt.file,
+            )
+        return accepted
+
     def update_setting(
         self,
         context: VaultContext,
@@ -487,24 +556,32 @@ class SettingsService:
                 ) from exc
 
         path = Path(context.settings_path) / definition.file
+        document: MarkdownSettingsDocument | None
         try:
             document = self.markdown_store.read(path)
         except FileNotFoundError as exc:
-            document = self._scaffold_missing_settings_file(path, definition.file, key=key, cause=exc)
+            # A watcher-observed owner-file deletion must still emit its
+            # governed accepted reset.  ``persist=False`` deliberately does
+            # not recreate a deleted file; it records the reset against the
+            # registered owner definition instead.
+            document = None if not persist else self._scaffold_missing_settings_file(
+                path, definition.file, key=key, cause=exc
+            )
         except (OSError, MarkdownSettingsError) as exc:
             raise SettingsWriteError(str(exc)) from exc
 
-        raw_scope = str(document.frontmatter.get("scope") or definition.scope).strip()
+        raw_scope = str(document.frontmatter.get("scope") or definition.scope).strip() if document else definition.scope
         if raw_scope not in VALID_SOURCE_SCOPES:
             raise SettingsWriteError(f"settings file declares unsupported scope: {raw_scope}")
         source_scope = cast(SettingScope, raw_scope)
         if not _source_can_set_definition(source_scope, definition):
             raise SettingsWriteError(f"{path.name} cannot set {key}")
 
-        frontmatter = dict(document.frontmatter)
+        frontmatter = dict(document.frontmatter) if document else {}
         old_value = resolve_settings_receipt_old_value(frontmatter.get(key))
         frontmatter[key] = value
         if persist:
+            assert document is not None
             self.markdown_store.write_frontmatter(path, frontmatter, body=document.body)
 
         effective = EffectiveSetting(

--- a/app/vault/settings_service.py
+++ b/app/vault/settings_service.py
@@ -5,10 +5,12 @@ import math
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, Mapping, NamedTuple, TypeAlias, cast
+from uuid import uuid4
 
 from app.instance.vault_registry import AppLocalSettingsStore
 from app.receipts.settings_write import (
     SettingsWriteReceipt,
+    emit_durable_settings_write_receipt_once,
     emit_settings_write_receipt,
     resolve_settings_receipt_old_value,
 )
@@ -45,6 +47,13 @@ VALID_SOURCE_SCOPES = {"app-local", "vault-shared", "vault-local"}
 # companion-ui/docs/UI_RUNTIME_BOUNDARIES.md :: Control-action register.
 RUNTIME_GATING_SETTINGS: frozenset[str] = frozenset(
     {"enableVaultWatcher", "enableAutoIndexing", "youtubeSync.enabled", "youtubeSync.runnerEnabled"}
+)
+# Issue #3964 is the pre-consumption gate for YSS-06/YSS-10. Existing watcher
+# gates retain their established permissions path; this accepted-state
+# projection is intentionally limited to the two YouTube keys authorized by
+# that Issue rather than silently changing current watcher startup semantics.
+ACCEPTED_RUNTIME_GATING_SETTINGS: frozenset[str] = frozenset(
+    {"youtubeSync.enabled", "youtubeSync.runnerEnabled"}
 )
 
 _SETTINGS_WRITE_ACTION = "settings.runtime_gating.write"
@@ -445,11 +454,11 @@ class SettingsService:
             expected_files = {
                 definition.key: str(settings_path / definition.file)
                 for definition in self.registry.definitions
-                if definition.key in RUNTIME_GATING_SETTINGS and definition.file
+                if definition.key in ACCEPTED_RUNTIME_GATING_SETTINGS and definition.file
             }
 
         for definition in self.registry.definitions:
-            if definition.key not in RUNTIME_GATING_SETTINGS:
+            if definition.key not in ACCEPTED_RUNTIME_GATING_SETTINGS:
                 continue
             accepted[definition.key] = EffectiveSetting(
                 key=definition.key,
@@ -458,7 +467,11 @@ class SettingsService:
                 source="accepted-runtime-gating-default",
             )
 
-        if not expected_files:
+        if (
+            not expected_files
+            or not context.active_vault_id
+            or not context.local_instance_id
+        ):
             return accepted
 
         # Deferred import avoids folding the read-only receipt projection into
@@ -469,7 +482,11 @@ class SettingsService:
         )
 
         receipt_result = query_settings_receipts(
-            SettingsReceiptQuery(is_runtime_gating=True)
+            SettingsReceiptQuery(
+                is_runtime_gating=True,
+                vault_id=context.active_vault_id,
+                local_instance_id=context.local_instance_id,
+            )
         )
         if not receipt_result.source_available:
             return accepted
@@ -478,8 +495,10 @@ class SettingsService:
             receipt_definition = self.registry.get(receipt.key)
             if (
                 receipt_definition is None
-                or receipt_definition.key not in RUNTIME_GATING_SETTINGS
-                or expected_files.get(receipt_definition.key) != receipt.file
+                or receipt_definition.key not in ACCEPTED_RUNTIME_GATING_SETTINGS
+                or receipt.vault_id != context.active_vault_id
+                or receipt.local_instance_id != context.local_instance_id
+                or Path(receipt.file or "").name != receipt_definition.file
             ):
                 continue
             value = (
@@ -540,6 +559,12 @@ class SettingsService:
             raise SettingsWriteError("settings writes require a selected initialized vault")
         if not definition.file:
             raise SettingsWriteError(f"{key} has no Markdown settings file")
+        if key in ACCEPTED_RUNTIME_GATING_SETTINGS and (
+            not context.active_vault_id or not context.local_instance_id
+        ):
+            raise SettingsWriteError(
+                f"{key} acceptance requires vault and local-instance identity"
+            )
         valid, message = _validate_value(definition, value)
         if not valid:
             raise SettingsWriteError(message or f"invalid value for {key}")
@@ -607,6 +632,9 @@ class SettingsService:
             file=str(path),
             old_value=old_value,
             new_value=receipt_value,
+            operation_id=f"settings-write:{uuid4()}",
+            vault_id=context.active_vault_id,
+            local_instance_id=context.local_instance_id,
         )
         logger.info(
             "settings.write surface=%s actor=%s key=%s runtime_gating=%s ts=%s",
@@ -619,7 +647,15 @@ class SettingsService:
         # Durability is additive: the in-memory receipt above remains the return-value
         # contract; this also persists the same receipt as a durable outbox event so it
         # survives process restart (#2787).
-        emit_settings_write_receipt(receipt)
+        try:
+            if is_runtime_gating:
+                emit_durable_settings_write_receipt_once(receipt)
+            else:
+                emit_settings_write_receipt(receipt)
+        except Exception as exc:
+            raise SettingsWriteError(
+                f"runtime-gating setting receipt was not durably accepted: {key}"
+            ) from exc
 
         return effective, receipt
 
@@ -645,7 +681,12 @@ class SettingsService:
             raise SettingsWriteError(f"settings scaffold blocked by health gate: {exc}") from exc
         seed_frontmatter, seed_body = seed
         try:
-            self.markdown_store.write_frontmatter(path, seed_frontmatter, body=seed_body)
+            created = self.markdown_store.write_missing(path, seed_frontmatter, seed_body)
+            if not created:
+                # Another owner created the file after our failed read. Preserve
+                # that document and let the normal read/merge/write path apply
+                # the requested key; never replace it with the static seed.
+                logger.info("settings scaffold lost create race; preserving owner file name=%s", filename)
             return self.markdown_store.read(path)
         except (OSError, MarkdownSettingsError) as exc:
             raise SettingsWriteError(str(exc)) from exc
@@ -880,6 +921,7 @@ def _validate_value(definition: SettingDefinition, value: Any) -> _ValidationRes
 
 __all__ = [
     "EffectiveSetting",
+    "ACCEPTED_RUNTIME_GATING_SETTINGS",
     "RUNTIME_GATING_SETTINGS",
     "SETTING_DEFINITIONS",
     "SettingDefinition",

--- a/app/vault/settings_service.py
+++ b/app/vault/settings_service.py
@@ -486,7 +486,9 @@ class SettingsService:
                 is_runtime_gating=True,
                 vault_id=context.active_vault_id,
                 local_instance_id=context.local_instance_id,
-            )
+            ),
+            require_operation_id=True,
+            durable_append_order=True,
         )
         if not receipt_result.source_available:
             return accepted

--- a/app/watcher/registry.py
+++ b/app/watcher/registry.py
@@ -1357,23 +1357,22 @@ def _run_spec_tick(
     )
     if removed_runtime_gating_owner_files:
         summary["runtime_gating_owner_file_deletions_in_tick"] = len(removed_runtime_gating_owner_files)
-        if not handled_settings_sources:
-            for rel_path in removed_runtime_gating_owner_files:
-                rel_str = str(rel_path)
-                settings_delta = handle_settings_local_delta(
-                    vault_root=cfg.vault_path,
-                    rel_path=rel_path,
-                    previous_values=state.last_settings_runtime_values(rel_str),
-                )
-                if settings_delta.errors:
-                    state.errors += len(settings_delta.errors)
-                    summary["settings_write_errors_in_tick"] = int(
-                        summary.get("settings_write_errors_in_tick", 0)
-                    ) + len(settings_delta.errors)
-                if settings_delta.receipts:
-                    summary["settings_receipts_in_tick"] = int(
-                        summary.get("settings_receipts_in_tick", 0)
-                    ) + len(settings_delta.receipts)
+        for rel_path in removed_runtime_gating_owner_files:
+            rel_str = str(rel_path)
+            settings_delta = handle_settings_local_delta(
+                vault_root=cfg.vault_path,
+                rel_path=rel_path,
+                previous_values=state.last_settings_runtime_values(rel_str),
+            )
+            if settings_delta.errors:
+                state.errors += len(settings_delta.errors)
+                summary["settings_write_errors_in_tick"] = int(
+                    summary.get("settings_write_errors_in_tick", 0)
+                ) + len(settings_delta.errors)
+            if settings_delta.receipts:
+                summary["settings_receipts_in_tick"] = int(
+                    summary.get("settings_receipts_in_tick", 0)
+                ) + len(settings_delta.receipts)
         for rel_path in removed_runtime_gating_owner_files:
             for active_state in active_states.values():
                 active_state.files.pop(str(rel_path), None)

--- a/app/watcher/registry.py
+++ b/app/watcher/registry.py
@@ -957,6 +957,19 @@ def _sync_settings_local_state(
         state.update_file_state(rel_str, settings_runtime_values=values)
 
 
+def _invalidate_settings_generation(
+    states: Mapping[str, WatcherState],
+    *,
+    rel_str: str,
+    values: Mapping[str, object] | None,
+) -> None:
+    for state in states.values():
+        state.invalidate_file_observation(
+            rel_str,
+            settings_runtime_values=values,
+        )
+
+
 def _collect_changed_entries(
     cfg: RegistryConfig,
     spec: WatcherSpec,
@@ -975,7 +988,11 @@ def _collect_changed_entries(
         scanned_paths.append(rel_str)
         last_mtime = state.last_mtime(rel_str)
         previous_hash = state.last_hash(rel_str)
-        if last_mtime is not None and last_mtime == mtime:
+        if (
+            last_mtime is not None
+            and last_mtime == mtime
+            and not is_runtime_gating_owner_path(rel)
+        ):
             state.update_file_state(rel_str, mtime=mtime, content_hash=previous_hash)
             continue
         hashed = _hash_file(path)
@@ -1003,18 +1020,18 @@ def _collect_changed_entries(
             summary["settings_receipts_in_tick"] = int(summary.get("settings_receipts_in_tick", 0)) + len(
                 settings_delta.receipts
             )
-            try:
-                mtime = path.stat().st_mtime
-            except OSError:
-                pass
-            hashed = _hash_file(path)
-            if hashed is not None:
-                digest = hashed[0]
+        if settings_delta.processed_digest is not None:
+            digest = settings_delta.processed_digest
         if settings_delta.deferred:
             # The gating delta could not be routed (vault not selected). Do
             # not record the file as seen: it must re-process on a later tick
             # once the vault validates, or the unrouted on-disk edit would
             # silently become effective through resolution.
+            _invalidate_settings_generation(
+                states,
+                rel_str=rel_str,
+                values=settings_delta_state_values(settings_delta),
+            )
             continue
         if is_settings_source_path(rel):
             # Settings markdown is runtime control input, never ordinary vault

--- a/app/watcher/registry.py
+++ b/app/watcher/registry.py
@@ -44,7 +44,7 @@ from app.watcher.heartbeat import resolve_heartbeat_path, write_registry_heartbe
 from app.watcher.scope import derive_scope_roots, matches_scope
 from app.watcher.settings_delta import (
     SETTINGS_SOURCE_DIR_NAME,
-    handle_settings_local_delta,
+    handle_settings_detected_delta,
     handle_settings_source_delta,
     is_settings_control_path,
     is_runtime_gating_owner_path,
@@ -986,7 +986,7 @@ def _collect_changed_entries(
         if previous_hash is not None and previous_hash == digest:
             state.update_file_state(rel_str, mtime=mtime, content_hash=digest)
             continue
-        settings_delta = handle_settings_local_delta(
+        settings_delta = handle_settings_detected_delta(
             vault_root=cfg.vault_path,
             rel_path=rel,
             previous_values=state.last_settings_runtime_values(rel_str),
@@ -1359,7 +1359,7 @@ def _run_spec_tick(
         summary["runtime_gating_owner_file_deletions_in_tick"] = len(removed_runtime_gating_owner_files)
         for rel_path in removed_runtime_gating_owner_files:
             rel_str = str(rel_path)
-            settings_delta = handle_settings_local_delta(
+            settings_delta = handle_settings_detected_delta(
                 vault_root=cfg.vault_path,
                 rel_path=rel_path,
                 previous_values=state.last_settings_runtime_values(rel_str),

--- a/app/watcher/registry.py
+++ b/app/watcher/registry.py
@@ -49,6 +49,7 @@ from app.watcher.settings_delta import (
     is_settings_control_path,
     is_runtime_gating_owner_path,
     is_settings_source_path,
+    settings_delta_state_values,
 )
 from app.watcher.state import WatcherState
 from app.write_guard import DEFAULT_WRITE_GUARD
@@ -990,6 +991,8 @@ def _collect_changed_entries(
             vault_root=cfg.vault_path,
             rel_path=rel,
             previous_values=state.last_settings_runtime_values(rel_str),
+            observed_digest=digest,
+            observed_missing=False,
         )
         if settings_delta.errors:
             state.errors += len(settings_delta.errors)
@@ -1045,7 +1048,9 @@ def _collect_changed_entries(
             state.update_file_state(rel_str, mtime=mtime, content_hash=digest)
             if settings_delta.values is not None:
                 _sync_settings_local_state(
-                    states, rel_str=rel_str, values=settings_delta.values
+                    states,
+                    rel_str=rel_str,
+                    values=settings_delta_state_values(settings_delta) or {},
                 )
             changed_entries.append(
                 ChangedEntry(rel_path=rel, mtime=mtime, digest=digest)
@@ -1053,7 +1058,11 @@ def _collect_changed_entries(
             continue
         changed_entries.append(ChangedEntry(rel_path=rel, mtime=mtime, digest=digest))
         if settings_delta.values is not None:
-            _sync_settings_local_state(states, rel_str=rel_str, values=settings_delta.values)
+            _sync_settings_local_state(
+                states,
+                rel_str=rel_str,
+                values=settings_delta_state_values(settings_delta) or {},
+            )
     return changed_entries, scanned_paths
 
 
@@ -1355,6 +1364,7 @@ def _run_spec_tick(
         for path in state.files.keys() - set(scanned_paths)
         if is_runtime_gating_owner_path(Path(path))
     )
+    pending_runtime_gating_deletions: set[str] = set()
     if removed_runtime_gating_owner_files:
         summary["runtime_gating_owner_file_deletions_in_tick"] = len(removed_runtime_gating_owner_files)
         for rel_path in removed_runtime_gating_owner_files:
@@ -1363,6 +1373,7 @@ def _run_spec_tick(
                 vault_root=cfg.vault_path,
                 rel_path=rel_path,
                 previous_values=state.last_settings_runtime_values(rel_str),
+                observed_missing=True,
             )
             if settings_delta.errors:
                 state.errors += len(settings_delta.errors)
@@ -1373,9 +1384,18 @@ def _run_spec_tick(
                 summary["settings_receipts_in_tick"] = int(
                     summary.get("settings_receipts_in_tick", 0)
                 ) + len(settings_delta.receipts)
-        for rel_path in removed_runtime_gating_owner_files:
-            for active_state in active_states.values():
-                active_state.files.pop(str(rel_path), None)
+            if settings_delta.errors or settings_delta.deferred:
+                retained_values = settings_delta_state_values(settings_delta)
+                if retained_values is not None:
+                    _sync_settings_local_state(
+                        active_states,
+                        rel_str=rel_str,
+                        values=retained_values,
+                    )
+                pending_runtime_gating_deletions.add(rel_str)
+            else:
+                for active_state in active_states.values():
+                    active_state.files.pop(rel_str, None)
 
     removed_settings_sources = sorted(
         Path(path)
@@ -1466,7 +1486,7 @@ def _run_spec_tick(
     elapsed_ms = max(int((time.time() - tick_start) * 1000), 0)
     summary["tick_ms"] = elapsed_ms
     _apply_guardrails_registry(cfg, state, summary)
-    state.prune_files(scanned_paths)
+    state.prune_files([*scanned_paths, *pending_runtime_gating_deletions])
 
     return _finalize_spec_tick(cfg, state, summary, tick_start, scan_roots[0] if scan_roots else None, spec.name)
 

--- a/app/watcher/registry.py
+++ b/app/watcher/registry.py
@@ -47,6 +47,7 @@ from app.watcher.settings_delta import (
     handle_settings_local_delta,
     handle_settings_source_delta,
     is_settings_control_path,
+    is_runtime_gating_owner_path,
     is_settings_source_path,
 )
 from app.watcher.state import WatcherState
@@ -1349,6 +1350,34 @@ def _run_spec_tick(
         states=active_states,
         handled_settings_sources=handled_settings_sources,
     )
+    removed_runtime_gating_owner_files = sorted(
+        Path(path)
+        for path in state.files.keys() - set(scanned_paths)
+        if is_runtime_gating_owner_path(Path(path))
+    )
+    if removed_runtime_gating_owner_files:
+        summary["runtime_gating_owner_file_deletions_in_tick"] = len(removed_runtime_gating_owner_files)
+        if not handled_settings_sources:
+            for rel_path in removed_runtime_gating_owner_files:
+                rel_str = str(rel_path)
+                settings_delta = handle_settings_local_delta(
+                    vault_root=cfg.vault_path,
+                    rel_path=rel_path,
+                    previous_values=state.last_settings_runtime_values(rel_str),
+                )
+                if settings_delta.errors:
+                    state.errors += len(settings_delta.errors)
+                    summary["settings_write_errors_in_tick"] = int(
+                        summary.get("settings_write_errors_in_tick", 0)
+                    ) + len(settings_delta.errors)
+                if settings_delta.receipts:
+                    summary["settings_receipts_in_tick"] = int(
+                        summary.get("settings_receipts_in_tick", 0)
+                    ) + len(settings_delta.receipts)
+        for rel_path in removed_runtime_gating_owner_files:
+            for active_state in active_states.values():
+                active_state.files.pop(str(rel_path), None)
+
     removed_settings_sources = sorted(
         Path(path)
         for path in state.files.keys() - set(scanned_paths)

--- a/app/watcher/settings_delta.py
+++ b/app/watcher/settings_delta.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+import subprocess
 from typing import Any, Mapping
 
 from app.vault.manager import VaultManager
@@ -171,9 +172,10 @@ def handle_settings_local_delta(
     machine legitimately accepted and receipted); the returned ACCEPTED
     values stay at the last guarded state and the denial surfaces via
     ``errors`` with no success receipt. Because ``SettingsService.resolve``
-    re-reads the owner file directly, runtime-gating consumers MUST consume
-    this seam's accepted values (as the watcher does for
-    ``enableVaultWatcher``), never raw resolution. When the vault is not
+    re-reads the owner file directly, the future YSS-06/YSS-10 consumers MUST
+    consume the accepted accessor for the two YouTube gates, never raw
+    resolution. Existing watcher/indexing gates keep their established
+    permissions path outside #3964. When the vault is not
     selected the delta cannot be routed at all and the result is marked
     ``deferred``: callers skip recording the file as seen so the edit
     re-processes once the vault validates.
@@ -202,14 +204,33 @@ def handle_settings_local_delta(
         if document is not None and key in document.frontmatter
     }
     service = settings_service or SettingsService(markdown_store=store)
+    manager = VaultManager(markdown_store=store)
+    context = manager.validate_vault(vault_root)
+    if context.status != "selected":
+        fallback_values = dict(previous_values or {})
+        detail = f": {context.validation_error}" if context.validation_error else ""
+        return SettingsDeltaResult(
+            values=fallback_values,
+            errors=(
+                f"{rel_path.as_posix()} delta requires selected vault; "
+                f"status={context.status}{detail}",
+            ),
+            deferred=True,
+        )
+
     if previous_values is None:
         # A lost/empty watcher state is not evidence that an on-disk gate was
-        # previously accepted. Treat each present value as a transition from
-        # its registered safe/default baseline so activation still requires
-        # WriteGuard and a durable receipt.
+        # previously accepted. Rebuild the YSS baseline from receipts bound to
+        # this vault identity/generation; keys outside #3964 retain their
+        # established registered defaults.
+        durable_accepted = service.resolve_accepted_runtime_gating(context)
         accepted_previous_values = {
-            key: definition.default_value
-            for key in current_values
+            key: (
+                durable_accepted[key].value
+                if key in durable_accepted
+                else definition.default_value
+            )
+            for key in gating_keys
             if (definition := service.registry.get(key)) is not None
         }
     else:
@@ -219,19 +240,6 @@ def handle_settings_local_delta(
         accepted_previous_values = {
             key: value for key, value in previous_values.items() if key in gating_keys
         }
-
-    manager = VaultManager(markdown_store=store)
-    context = manager.validate_vault(vault_root)
-    if context.status != "selected":
-        detail = f": {context.validation_error}" if context.validation_error else ""
-        return SettingsDeltaResult(
-            values=accepted_previous_values,
-            errors=(
-                f"{rel_path.as_posix()} delta requires selected vault; "
-                f"status={context.status}{detail}",
-            ),
-            deferred=True,
-        )
 
     resolution = service.resolve(context)
     errors = []
@@ -322,6 +330,95 @@ def handle_settings_sync_arrival(
     )
 
 
+def settings_delta_is_sync_arrival(*, vault_root: Path, rel_path: Path) -> bool:
+    """Return true when the observed settings bytes are clean Git state.
+
+    The production watcher is filesystem-polled, so Git cleanliness is the
+    available provenance boundary: a tracked clean file (or clean tracked
+    deletion) arrived through repository synchronization; a modified or
+    untracked working-tree file remains a local file edit. Non-Git vaults and
+    Git inspection failures conservatively stay local-human.
+    """
+
+    if not (vault_root / ".git").exists():
+        return False
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "status",
+                "--porcelain=v1",
+                "--untracked-files=all",
+                "--",
+                rel_path.as_posix(),
+            ],
+            cwd=vault_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return False
+    if result.returncode != 0 or result.stdout.strip():
+        return False
+
+    tracked = subprocess.run(
+        ["git", "ls-files", "--error-unmatch", "--", rel_path.as_posix()],
+        cwd=vault_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if tracked.returncode == 0:
+        return True
+    if (vault_root / rel_path).exists():
+        # In particular, settings/local.md is intentionally gitignored. A
+        # clean `git status` alone would misclassify every local edit as sync.
+        return False
+
+    head_change = subprocess.run(
+        [
+            "git",
+            "diff-tree",
+            "--root",
+            "--no-commit-id",
+            "--name-status",
+            "-r",
+            "HEAD",
+            "--",
+            rel_path.as_posix(),
+        ],
+        cwd=vault_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return head_change.returncode == 0 and any(
+        line.startswith("D\t") for line in head_change.stdout.splitlines()
+    )
+
+
+def handle_settings_detected_delta(
+    *,
+    vault_root: Path,
+    rel_path: Path,
+    previous_values: Mapping[str, Any] | None,
+) -> SettingsDeltaResult:
+    """Dispatch a production watcher delta with its real local/sync provenance."""
+
+    if settings_delta_is_sync_arrival(vault_root=vault_root, rel_path=rel_path):
+        return handle_settings_sync_arrival(
+            vault_root=vault_root,
+            rel_path=rel_path,
+            previous_values=previous_values,
+        )
+    return handle_settings_local_delta(
+        vault_root=vault_root,
+        rel_path=rel_path,
+        previous_values=previous_values,
+    )
+
+
 __all__ = [
     "SETTINGS_LOCAL_REL",
     "SETTINGS_YOUTUBE_REL",
@@ -329,9 +426,11 @@ __all__ = [
     "SettingsDeltaResult",
     "SettingsSourceDeltaResult",
     "handle_settings_local_delta",
+    "handle_settings_detected_delta",
     "handle_settings_sync_arrival",
     "handle_settings_source_delta",
     "is_runtime_gating_owner_path",
     "is_settings_source_path",
     "is_settings_control_path",
+    "settings_delta_is_sync_arrival",
 ]

--- a/app/watcher/settings_delta.py
+++ b/app/watcher/settings_delta.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import hashlib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 import subprocess
 from typing import Any, Mapping
@@ -9,7 +9,12 @@ from typing import Any, Mapping
 from app.vault.manager import VaultContext, VaultManager
 from app.receipts.settings_write import settings_receipt_old_value
 from app.settings.locations import CANONICAL_SETTINGS_DIR_NAME, LEGACY_COMPILED_DIR
-from app.vault.markdown_settings import MarkdownSettingsError, MarkdownSettingsStore
+from app.vault.markdown_settings import (
+    MarkdownSettingsDocument,
+    MarkdownSettingsError,
+    MarkdownSettingsStore,
+    split_markdown_settings,
+)
 from app.vault.settings_service import (
     RUNTIME_GATING_SETTINGS,
     SETTING_DEFINITIONS,
@@ -79,6 +84,82 @@ class SettingsDeltaResult:
 class _ObservedSettingsSnapshot:
     exists: bool
     digest: str | None
+    payload: bytes | None = field(default=None, compare=False, repr=False)
+
+
+class _SnapshotBoundMarkdownSettingsStore(MarkdownSettingsStore):
+    """Read one owner document from the exact watcher-observed snapshot."""
+
+    def __init__(
+        self,
+        *,
+        delegate: MarkdownSettingsStore,
+        path: Path,
+        snapshot: _ObservedSettingsSnapshot,
+    ) -> None:
+        self._delegate = delegate
+        self._path = path
+        self._document: MarkdownSettingsDocument | None = None
+        if snapshot.exists:
+            if snapshot.payload is None:
+                raise MarkdownSettingsError(
+                    f"settings snapshot payload is unavailable: {path}"
+                )
+            try:
+                text = snapshot.payload.decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise MarkdownSettingsError(
+                    f"settings file is not valid UTF-8: {path}"
+                ) from exc
+            frontmatter, body = split_markdown_settings(text, path=path)
+            self._document = MarkdownSettingsDocument(
+                path=path,
+                frontmatter=frontmatter,
+                body=body,
+            )
+
+    def read(self, path: Path) -> MarkdownSettingsDocument:
+        if path != self._path:
+            return self._delegate.read(path)
+        if self._document is None:
+            raise FileNotFoundError(path)
+        return self._document
+
+    def write_missing(
+        self,
+        path: Path,
+        frontmatter: Mapping[str, Any],
+        body: str,
+    ) -> bool:
+        raise OSError(
+            f"snapshot-bound settings processing cannot create settings file: {path}"
+        )
+
+    def write_frontmatter(
+        self,
+        path: Path,
+        frontmatter: Mapping[str, Any],
+        *,
+        body: str | None = None,
+    ) -> None:
+        if path != self._path:
+            raise OSError(
+                f"snapshot-bound settings processing cannot write settings file: {path}"
+            )
+        if self._document is None:
+            raise OSError(
+                f"snapshot-bound settings processing cannot rewrite deleted owner file: {path}"
+            )
+        expected_body = self._document.body if body is None else body
+        if (
+            dict(frontmatter) != self._document.frontmatter
+            or expected_body != self._document.body
+        ):
+            raise OSError(
+                f"snapshot-bound settings processing cannot rewrite owner file: {path}"
+            )
+        # Watcher processing accepts already-authored bytes. Rewriting them is
+        # unnecessary and could clobber a local edit that arrived after capture.
 
 
 @dataclass(frozen=True)
@@ -240,6 +321,7 @@ def handle_settings_local_delta(
     markdown_store: MarkdownSettingsStore | None = None,
     surface: str = "file",
     actor: str = "human",
+    _verified_snapshot: _ObservedSettingsSnapshot | None = None,
 ) -> SettingsDeltaResult:
     """Route watcher-detected runtime-gating file deltas through the governed seam.
 
@@ -270,6 +352,35 @@ def handle_settings_local_delta(
 
     store = markdown_store or MarkdownSettingsStore()
     path = vault_root / rel_path
+    if _verified_snapshot is not None:
+        try:
+            processing_snapshot = _capture_settings_snapshot(path)
+        except OSError as exc:
+            return SettingsDeltaResult(
+                values=dict(previous_runtime_values or {}),
+                errors=(str(exc),),
+                deferred=True,
+                vault_id=retained_vault_id,
+                local_instance_id=retained_local_instance_id,
+            )
+        if processing_snapshot != _verified_snapshot:
+            return SettingsDeltaResult(
+                values=dict(previous_runtime_values or {}),
+                errors=(
+                    f"{rel_path.as_posix()} changed before governed processing",
+                ),
+                deferred=True,
+                vault_id=retained_vault_id,
+                local_instance_id=retained_local_instance_id,
+            )
+        try:
+            store = _SnapshotBoundMarkdownSettingsStore(
+                delegate=store,
+                path=path,
+                snapshot=processing_snapshot,
+            )
+        except MarkdownSettingsError as exc:
+            return SettingsDeltaResult(values=None, errors=(str(exc),))
     try:
         document = store.read(path)
     except FileNotFoundError:
@@ -288,7 +399,20 @@ def handle_settings_local_delta(
     }
     service = settings_service or SettingsService(markdown_store=store)
     manager = VaultManager(markdown_store=store)
-    context = manager.validate_vault(vault_root)
+    if (
+        _verified_snapshot is not None
+        and not _verified_snapshot.exists
+        and rel_path == SETTINGS_LOCAL_REL
+    ):
+        context = VaultContext(
+            status="uninitialized",
+            active_vault_name=vault_root.name,
+            active_vault_path=str(vault_root),
+            settings_path=str(vault_root / "settings"),
+            validation_error="missing required settings: local.md",
+        )
+    else:
+        context = manager.validate_vault(vault_root)
     retained_context = _retained_context_for_local_owner_deletion(
         vault_root=vault_root,
         rel_path=rel_path,
@@ -416,6 +540,7 @@ def handle_settings_sync_arrival(
     previous_values: Mapping[str, Any] | None,
     settings_service: SettingsService | None = None,
     markdown_store: MarkdownSettingsStore | None = None,
+    _verified_snapshot: _ObservedSettingsSnapshot | None = None,
 ) -> SettingsDeltaResult:
     """Replay a git-synced settings arrival without misattributing its actor.
 
@@ -432,6 +557,7 @@ def handle_settings_sync_arrival(
         markdown_store=markdown_store,
         surface="sync",
         actor="sync",
+        _verified_snapshot=_verified_snapshot,
     )
 
 
@@ -443,6 +569,7 @@ def _capture_settings_snapshot(path: Path) -> _ObservedSettingsSnapshot:
     return _ObservedSettingsSnapshot(
         exists=True,
         digest=hashlib.sha256(payload).hexdigest(),
+        payload=payload,
     )
 
 
@@ -610,11 +737,13 @@ def handle_settings_detected_delta(
             vault_root=vault_root,
             rel_path=rel_path,
             previous_values=previous_values,
+            _verified_snapshot=after,
         )
     return handle_settings_local_delta(
         vault_root=vault_root,
         rel_path=rel_path,
         previous_values=previous_values,
+        _verified_snapshot=after,
     )
 
 

--- a/app/watcher/settings_delta.py
+++ b/app/watcher/settings_delta.py
@@ -92,6 +92,11 @@ def is_settings_source_path(rel_path: Path) -> bool:
     )
 
 
+def is_runtime_gating_owner_path(rel_path: Path) -> bool:
+    """Whether a removed path owns one or more runtime-gating settings."""
+    return rel_path in _RUNTIME_GATING_KEYS_BY_FILE
+
+
 def is_settings_control_path(
     rel_path: Path, *, configured_system_dir: Path | str | None = None
 ) -> bool:
@@ -153,6 +158,8 @@ def handle_settings_local_delta(
     previous_values: Mapping[str, Any] | None,
     settings_service: SettingsService | None = None,
     markdown_store: MarkdownSettingsStore | None = None,
+    surface: str = "file",
+    actor: str = "human",
 ) -> SettingsDeltaResult:
     """Route watcher-detected runtime-gating file deltas through the governed seam.
 
@@ -180,13 +187,19 @@ def handle_settings_local_delta(
     path = vault_root / rel_path
     try:
         document = store.read(path)
-    except (FileNotFoundError, OSError, MarkdownSettingsError) as exc:
+    except FileNotFoundError:
+        # A registered owner-file deletion is an authority-bearing reset, not
+        # an absent signal that may silently fall back through raw resolution.
+        # Continue below with no current values so every formerly accepted
+        # gating key is routed through ``update_setting(..., persist=False)``.
+        document = None
+    except (OSError, MarkdownSettingsError) as exc:
         return SettingsDeltaResult(values=None, errors=(str(exc),))
 
     current_values = {
         key: document.frontmatter[key]
         for key in sorted(gating_keys)
-        if key in document.frontmatter
+        if document is not None and key in document.frontmatter
     }
     service = settings_service or SettingsService(markdown_store=store)
     if previous_values is None:
@@ -257,8 +270,8 @@ def handle_settings_local_delta(
                     context,
                     key,
                     value,
-                    surface="file",
-                    actor="human",
+                    surface=surface,
+                    actor=actor,
                     persist=persist,
                 )
         except SettingsWriteError as exc:
@@ -269,11 +282,43 @@ def handle_settings_local_delta(
                 accepted_values.pop(key, None)
             continue
         receipts.append(receipt)
+        if not persist and document is None:
+            # The entire registered owner file disappeared. Retain the
+            # explicitly accepted default in watcher state so a later
+            # reappearance compares against the governed reset rather than
+            # treating the old on-disk value as trusted history.
+            accepted_values[key] = value
 
     return SettingsDeltaResult(
         values=accepted_values,
         receipts=tuple(receipts),
         errors=tuple(errors),
+    )
+
+
+def handle_settings_sync_arrival(
+    *,
+    vault_root: Path,
+    rel_path: Path,
+    previous_values: Mapping[str, Any] | None,
+    settings_service: SettingsService | None = None,
+    markdown_store: MarkdownSettingsStore | None = None,
+) -> SettingsDeltaResult:
+    """Replay a git-synced settings arrival without misattributing its actor.
+
+    Sync arrival is still locally WriteGuard-gated and receipted, but it is
+    evidence of synchronization rather than a local human edit.  This keeps
+    the same accepted-state enforcement without inventing another approval or
+    persistence path.
+    """
+    return handle_settings_local_delta(
+        vault_root=vault_root,
+        rel_path=rel_path,
+        previous_values=previous_values,
+        settings_service=settings_service,
+        markdown_store=markdown_store,
+        surface="sync",
+        actor="sync",
     )
 
 
@@ -284,7 +329,9 @@ __all__ = [
     "SettingsDeltaResult",
     "SettingsSourceDeltaResult",
     "handle_settings_local_delta",
+    "handle_settings_sync_arrival",
     "handle_settings_source_delta",
+    "is_runtime_gating_owner_path",
     "is_settings_source_path",
     "is_settings_control_path",
 ]

--- a/app/watcher/settings_delta.py
+++ b/app/watcher/settings_delta.py
@@ -7,7 +7,10 @@ import subprocess
 from typing import Any, Mapping
 
 from app.vault.manager import VaultContext, VaultManager
-from app.receipts.settings_write import settings_receipt_old_value
+from app.receipts.settings_write import (
+    settings_receipt_acceptance_precondition,
+    settings_receipt_old_value,
+)
 from app.settings.locations import CANONICAL_SETTINGS_DIR_NAME, LEGACY_COMPILED_DIR
 from app.vault.markdown_settings import (
     MarkdownSettingsDocument,
@@ -78,6 +81,8 @@ class SettingsDeltaResult:
     deferred: bool = False
     vault_id: str | None = None
     local_instance_id: str | None = None
+    processed_digest: str | None = None
+    processed_missing: bool | None = None
 
 
 @dataclass(frozen=True)
@@ -352,6 +357,7 @@ def handle_settings_local_delta(
 
     store = markdown_store or MarkdownSettingsStore()
     path = vault_root / rel_path
+    processing_snapshot: _ObservedSettingsSnapshot | None = None
     if _verified_snapshot is not None:
         try:
             processing_snapshot = _capture_settings_snapshot(path)
@@ -487,20 +493,54 @@ def handle_settings_local_delta(
         if current_present and previous_values.get(key) != current_values[key]:
             changed_keys.append(key)
     if not changed_keys:
+        generation_error = _settings_generation_error(
+            path=path,
+            rel_path=rel_path,
+            expected=processing_snapshot,
+            phase="before state advance",
+        )
         return SettingsDeltaResult(
             values=current_values,
-            errors=tuple(errors),
+            errors=tuple([*errors, generation_error] if generation_error else errors),
+            deferred=generation_error is not None,
             vault_id=context.active_vault_id,
             local_instance_id=context.local_instance_id,
+            processed_digest=(
+                processing_snapshot.digest if processing_snapshot is not None else None
+            ),
+            processed_missing=(
+                not processing_snapshot.exists
+                if processing_snapshot is not None
+                else None
+            ),
         )
 
     receipts: list[SettingsWriteReceipt] = []
     accepted_values = dict(current_values)
+    acceptance_failed = False
+
+    def _assert_generation_current() -> None:
+        generation_error = _settings_generation_error(
+            path=path,
+            rel_path=rel_path,
+            expected=processing_snapshot,
+            phase="before durable acceptance",
+        )
+        if generation_error is not None:
+            raise SettingsWriteError(generation_error)
+
     for key in changed_keys:
         try:
             persist = key in current_keys
             value = current_values[key] if persist else resolution.settings[key].value
-            with settings_receipt_old_value(previous_values.get(key)):
+            with (
+                settings_receipt_old_value(previous_values.get(key)),
+                settings_receipt_acceptance_precondition(
+                    _assert_generation_current
+                    if processing_snapshot is not None
+                    else None
+                ),
+            ):
                 _effective, receipt = service.update_setting(
                     context,
                     key,
@@ -511,6 +551,7 @@ def handle_settings_local_delta(
                 )
         except SettingsWriteError as exc:
             errors.append(str(exc))
+            acceptance_failed = True
             if key in previous_values:
                 accepted_values[key] = previous_values[key]
             else:
@@ -524,12 +565,30 @@ def handle_settings_local_delta(
             # treating the old on-disk value as trusted history.
             accepted_values[key] = value
 
+    generation_error = _settings_generation_error(
+        path=path,
+        rel_path=rel_path,
+        expected=processing_snapshot,
+        phase="before state advance",
+    )
+    if generation_error is not None:
+        errors.append(generation_error)
+
     return SettingsDeltaResult(
         values=accepted_values,
         receipts=tuple(receipts),
         errors=tuple(errors),
+        deferred=acceptance_failed or generation_error is not None,
         vault_id=context.active_vault_id,
         local_instance_id=context.local_instance_id,
+        processed_digest=(
+            processing_snapshot.digest if processing_snapshot is not None else None
+        ),
+        processed_missing=(
+            not processing_snapshot.exists
+            if processing_snapshot is not None
+            else None
+        ),
     )
 
 
@@ -571,6 +630,24 @@ def _capture_settings_snapshot(path: Path) -> _ObservedSettingsSnapshot:
         digest=hashlib.sha256(payload).hexdigest(),
         payload=payload,
     )
+
+
+def _settings_generation_error(
+    *,
+    path: Path,
+    rel_path: Path,
+    expected: _ObservedSettingsSnapshot | None,
+    phase: str,
+) -> str | None:
+    if expected is None:
+        return None
+    try:
+        current = _capture_settings_snapshot(path)
+    except OSError as exc:
+        return f"{rel_path.as_posix()} generation unavailable {phase}: {exc}"
+    if current != expected:
+        return f"{rel_path.as_posix()} changed {phase}"
+    return None
 
 
 def _git_snapshot_is_sync_arrival(

--- a/app/watcher/settings_delta.py
+++ b/app/watcher/settings_delta.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass
 from pathlib import Path
 import subprocess
 from typing import Any, Mapping
 
-from app.vault.manager import VaultManager
+from app.vault.manager import VaultContext, VaultManager
 from app.receipts.settings_write import settings_receipt_old_value
 from app.settings.locations import CANONICAL_SETTINGS_DIR_NAME, LEGACY_COMPILED_DIR
 from app.vault.markdown_settings import MarkdownSettingsError, MarkdownSettingsStore
@@ -19,6 +20,8 @@ from app.vault.settings_service import (
 
 SETTINGS_LOCAL_REL = Path("settings/local.md")
 SETTINGS_YOUTUBE_REL = Path("settings/youtube.md")
+_STATE_VAULT_ID = "__accepted_runtime_gating_vault_id__"
+_STATE_LOCAL_INSTANCE_ID = "__accepted_runtime_gating_local_instance_id__"
 
 # Derived entirely from SETTING_DEFINITIONS so a future runtime-gating key in
 # a third owner file cannot silently bypass the governed delta path: every
@@ -68,6 +71,14 @@ class SettingsDeltaResult:
     # has to re-process on a later tick once the vault validates, or the
     # unrouted on-disk value would silently become effective via resolution.
     deferred: bool = False
+    vault_id: str | None = None
+    local_instance_id: str | None = None
+
+
+@dataclass(frozen=True)
+class _ObservedSettingsSnapshot:
+    exists: bool
+    digest: str | None
 
 
 @dataclass(frozen=True)
@@ -96,6 +107,74 @@ def is_settings_source_path(rel_path: Path) -> bool:
 def is_runtime_gating_owner_path(rel_path: Path) -> bool:
     """Whether a removed path owns one or more runtime-gating settings."""
     return rel_path in _RUNTIME_GATING_KEYS_BY_FILE
+
+
+def settings_delta_state_values(result: SettingsDeltaResult) -> dict[str, Any] | None:
+    """Encode accepted values plus retained acceptance identity for watcher state."""
+
+    if result.values is None:
+        return None
+    values = dict(result.values)
+    if result.vault_id:
+        values[_STATE_VAULT_ID] = result.vault_id
+    if result.local_instance_id:
+        values[_STATE_LOCAL_INSTANCE_ID] = result.local_instance_id
+    return values
+
+
+def _split_retained_settings_state(
+    previous_values: Mapping[str, Any] | None,
+) -> tuple[dict[str, Any] | None, str | None, str | None]:
+    if previous_values is None:
+        return None, None, None
+    values = dict(previous_values)
+    vault_id_raw = values.pop(_STATE_VAULT_ID, None)
+    local_instance_id_raw = values.pop(_STATE_LOCAL_INSTANCE_ID, None)
+    vault_id = str(vault_id_raw).strip() if vault_id_raw is not None else None
+    local_instance_id = (
+        str(local_instance_id_raw).strip()
+        if local_instance_id_raw is not None
+        else None
+    )
+    return values, vault_id or None, local_instance_id or None
+
+
+def _retained_context_for_local_owner_deletion(
+    *,
+    vault_root: Path,
+    rel_path: Path,
+    document_missing: bool,
+    context: VaultContext,
+    store: MarkdownSettingsStore,
+    retained_vault_id: str | None,
+    retained_local_instance_id: str | None,
+) -> VaultContext | None:
+    """Recover only the identity needed to receipt an observed local.md deletion."""
+
+    if (
+        rel_path != SETTINGS_LOCAL_REL
+        or not document_missing
+        or context.status != "uninitialized"
+        or not retained_vault_id
+        or not retained_local_instance_id
+    ):
+        return None
+    try:
+        vault_document = store.read(vault_root / "settings" / "vault.md")
+    except (FileNotFoundError, OSError, MarkdownSettingsError):
+        return None
+    if (
+        vault_document.frontmatter.get("schema") != "design-handoff.vault.v1"
+        or vault_document.frontmatter.get("vaultId") != retained_vault_id
+    ):
+        return None
+    return VaultContext(
+        status="selected",
+        active_vault_id=retained_vault_id,
+        active_vault_path=str(vault_root),
+        settings_path=str(vault_root / "settings"),
+        local_instance_id=retained_local_instance_id,
+    )
 
 
 def is_settings_control_path(
@@ -185,6 +264,10 @@ def handle_settings_local_delta(
     if gating_keys is None:
         return SettingsDeltaResult(values=None)
 
+    previous_runtime_values, retained_vault_id, retained_local_instance_id = (
+        _split_retained_settings_state(previous_values)
+    )
+
     store = markdown_store or MarkdownSettingsStore()
     path = vault_root / rel_path
     try:
@@ -206,8 +289,19 @@ def handle_settings_local_delta(
     service = settings_service or SettingsService(markdown_store=store)
     manager = VaultManager(markdown_store=store)
     context = manager.validate_vault(vault_root)
+    retained_context = _retained_context_for_local_owner_deletion(
+        vault_root=vault_root,
+        rel_path=rel_path,
+        document_missing=document is None,
+        context=context,
+        store=store,
+        retained_vault_id=retained_vault_id,
+        retained_local_instance_id=retained_local_instance_id,
+    )
+    if retained_context is not None:
+        context = retained_context
     if context.status != "selected":
-        fallback_values = dict(previous_values or {})
+        fallback_values = dict(previous_runtime_values or {})
         detail = f": {context.validation_error}" if context.validation_error else ""
         return SettingsDeltaResult(
             values=fallback_values,
@@ -216,9 +310,11 @@ def handle_settings_local_delta(
                 f"status={context.status}{detail}",
             ),
             deferred=True,
+            vault_id=retained_vault_id,
+            local_instance_id=retained_local_instance_id,
         )
 
-    if previous_values is None:
+    if previous_runtime_values is None:
         # A lost/empty watcher state is not evidence that an on-disk gate was
         # previously accepted. Rebuild the YSS baseline from receipts bound to
         # this vault identity/generation; keys outside #3964 retain their
@@ -238,7 +334,9 @@ def handle_settings_local_delta(
         # Discard those values rather than carrying an invalid authority source
         # forward after the ownership rule is tightened.
         accepted_previous_values = {
-            key: value for key, value in previous_values.items() if key in gating_keys
+            key: value
+            for key, value in previous_runtime_values.items()
+            if key in gating_keys
         }
 
     resolution = service.resolve(context)
@@ -265,7 +363,12 @@ def handle_settings_local_delta(
         if current_present and previous_values.get(key) != current_values[key]:
             changed_keys.append(key)
     if not changed_keys:
-        return SettingsDeltaResult(values=current_values, errors=tuple(errors))
+        return SettingsDeltaResult(
+            values=current_values,
+            errors=tuple(errors),
+            vault_id=context.active_vault_id,
+            local_instance_id=context.local_instance_id,
+        )
 
     receipts: list[SettingsWriteReceipt] = []
     accepted_values = dict(current_values)
@@ -301,6 +404,8 @@ def handle_settings_local_delta(
         values=accepted_values,
         receipts=tuple(receipts),
         errors=tuple(errors),
+        vault_id=context.active_vault_id,
+        local_instance_id=context.local_instance_id,
     )
 
 
@@ -330,20 +435,31 @@ def handle_settings_sync_arrival(
     )
 
 
-def settings_delta_is_sync_arrival(*, vault_root: Path, rel_path: Path) -> bool:
-    """Return true when the observed settings bytes are clean Git state.
-
-    The production watcher is filesystem-polled, so Git cleanliness is the
-    available provenance boundary: a tracked clean file (or clean tracked
-    deletion) arrived through repository synchronization; a modified or
-    untracked working-tree file remains a local file edit. Non-Git vaults and
-    Git inspection failures conservatively stay local-human.
-    """
-
-    if not (vault_root / ".git").exists():
-        return False
+def _capture_settings_snapshot(path: Path) -> _ObservedSettingsSnapshot:
     try:
-        result = subprocess.run(
+        payload = path.read_bytes()
+    except FileNotFoundError:
+        return _ObservedSettingsSnapshot(exists=False, digest=None)
+    return _ObservedSettingsSnapshot(
+        exists=True,
+        digest=hashlib.sha256(payload).hexdigest(),
+    )
+
+
+def _git_snapshot_is_sync_arrival(
+    *, vault_root: Path, rel_path: Path, snapshot: _ObservedSettingsSnapshot
+) -> bool:
+    try:
+        inside = subprocess.run(
+            ["git", "rev-parse", "--is-inside-work-tree"],
+            cwd=vault_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if inside.returncode != 0 or inside.stdout.strip() != "true":
+            return False
+        status = subprocess.run(
             [
                 "git",
                 "status",
@@ -357,45 +473,80 @@ def settings_delta_is_sync_arrival(*, vault_root: Path, rel_path: Path) -> bool:
             text=True,
             check=False,
         )
+        if status.returncode != 0 or status.stdout.strip():
+            return False
+
+        tracked = subprocess.run(
+            ["git", "ls-files", "--error-unmatch", "--", rel_path.as_posix()],
+            cwd=vault_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if snapshot.exists:
+            if tracked.returncode != 0 or snapshot.digest is None:
+                return False
+            head_blob = subprocess.run(
+                ["git", "show", f"HEAD:{rel_path.as_posix()}"],
+                cwd=vault_root,
+                capture_output=True,
+                check=False,
+            )
+            return (
+                head_blob.returncode == 0
+                and hashlib.sha256(head_blob.stdout).hexdigest() == snapshot.digest
+            )
+        if tracked.returncode == 0:
+            return False
+
+        head_change = subprocess.run(
+            [
+                "git",
+                "diff-tree",
+                "--root",
+                "--no-commit-id",
+                "--name-status",
+                "-r",
+                "HEAD",
+                "--",
+                rel_path.as_posix(),
+            ],
+            cwd=vault_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return head_change.returncode == 0 and any(
+            line.startswith("D\t") for line in head_change.stdout.splitlines()
+        )
     except OSError:
         return False
-    if result.returncode != 0 or result.stdout.strip():
-        return False
 
-    tracked = subprocess.run(
-        ["git", "ls-files", "--error-unmatch", "--", rel_path.as_posix()],
-        cwd=vault_root,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if tracked.returncode == 0:
-        return True
-    if (vault_root / rel_path).exists():
-        # In particular, settings/local.md is intentionally gitignored. A
-        # clean `git status` alone would misclassify every local edit as sync.
-        return False
 
-    head_change = subprocess.run(
-        [
-            "git",
-            "diff-tree",
-            "--root",
-            "--no-commit-id",
-            "--name-status",
-            "-r",
-            "HEAD",
-            "--",
-            rel_path.as_posix(),
-        ],
-        cwd=vault_root,
-        capture_output=True,
-        text=True,
-        check=False,
+def settings_delta_is_sync_arrival(*, vault_root: Path, rel_path: Path) -> bool:
+    """Return true when the observed settings bytes are clean Git state.
+
+    The production watcher is filesystem-polled, so Git cleanliness is the
+    available provenance boundary: a tracked clean file (or clean tracked
+    deletion) arrived through repository synchronization; a modified or
+    untracked working-tree file remains a local file edit. Non-Git vaults and
+    Git inspection failures conservatively stay local-human.
+    """
+
+    try:
+        before = _capture_settings_snapshot(vault_root / rel_path)
+    except OSError:
+        return False
+    is_sync = _git_snapshot_is_sync_arrival(
+        vault_root=vault_root,
+        rel_path=rel_path,
+        snapshot=before,
     )
-    return head_change.returncode == 0 and any(
-        line.startswith("D\t") for line in head_change.stdout.splitlines()
-    )
+    try:
+        after = _capture_settings_snapshot(vault_root / rel_path)
+    except OSError:
+        return False
+    return is_sync and after == before
 
 
 def handle_settings_detected_delta(
@@ -403,10 +554,58 @@ def handle_settings_detected_delta(
     vault_root: Path,
     rel_path: Path,
     previous_values: Mapping[str, Any] | None,
+    observed_digest: str | None = None,
+    observed_missing: bool | None = None,
 ) -> SettingsDeltaResult:
     """Dispatch a production watcher delta with its real local/sync provenance."""
 
-    if settings_delta_is_sync_arrival(vault_root=vault_root, rel_path=rel_path):
+    if observed_missing is None:
+        try:
+            before = _capture_settings_snapshot(vault_root / rel_path)
+        except OSError as exc:
+            previous_runtime_values, retained_vault_id, retained_local_instance_id = (
+                _split_retained_settings_state(previous_values)
+            )
+            return SettingsDeltaResult(
+                values=dict(previous_runtime_values or {}),
+                errors=(str(exc),),
+                deferred=True,
+                vault_id=retained_vault_id,
+                local_instance_id=retained_local_instance_id,
+            )
+    else:
+        before = _ObservedSettingsSnapshot(
+            exists=not observed_missing,
+            digest=None if observed_missing else observed_digest,
+        )
+
+    is_sync = _git_snapshot_is_sync_arrival(
+        vault_root=vault_root,
+        rel_path=rel_path,
+        snapshot=before,
+    )
+    try:
+        after = _capture_settings_snapshot(vault_root / rel_path)
+    except OSError as exc:
+        after = None
+        race_error = str(exc)
+    else:
+        race_error = (
+            f"{rel_path.as_posix()} changed during provenance inspection"
+        )
+    if after != before:
+        previous_runtime_values, retained_vault_id, retained_local_instance_id = (
+            _split_retained_settings_state(previous_values)
+        )
+        return SettingsDeltaResult(
+            values=dict(previous_runtime_values or {}),
+            errors=(race_error,),
+            deferred=True,
+            vault_id=retained_vault_id,
+            local_instance_id=retained_local_instance_id,
+        )
+
+    if is_sync:
         return handle_settings_sync_arrival(
             vault_root=vault_root,
             rel_path=rel_path,
@@ -432,5 +631,6 @@ __all__ = [
     "is_runtime_gating_owner_path",
     "is_settings_source_path",
     "is_settings_control_path",
+    "settings_delta_state_values",
     "settings_delta_is_sync_arrival",
 ]

--- a/app/watcher/state.py
+++ b/app/watcher/state.py
@@ -161,6 +161,21 @@ class WatcherState:
             entry["last_emitted"] = emitted_at
         self.files[rel_path] = entry
 
+    def invalidate_file_observation(
+        self,
+        rel_path: str,
+        *,
+        settings_runtime_values: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Retain accepted settings state while forcing the file to be rehashed."""
+
+        entry = dict(self.files.get(rel_path) or {})
+        entry.pop("mtime", None)
+        entry.pop("hash", None)
+        if settings_runtime_values is not None:
+            entry["settings_runtime_values"] = dict(settings_runtime_values)
+        self.files[rel_path] = entry
+
     def prune_files(self, keep_paths: Iterable[str]) -> None:
         keep = {path for path in keep_paths if path}
         if not keep:

--- a/app/watcher/watcher.py
+++ b/app/watcher/watcher.py
@@ -20,6 +20,7 @@ from app.watcher.settings_delta import (
     is_settings_control_path,
     is_runtime_gating_owner_path,
     is_settings_source_path,
+    settings_delta_state_values,
 )
 from app.settings.locations import CANONICAL_SETTINGS_DIR_NAME, LEGACY_COMPILED_DIR
 from app.watcher.state import WatcherState
@@ -307,6 +308,7 @@ def run_tick(
         changed_entries.append((rel, mtime, digest))
 
     settings_source_processed = False
+    pending_runtime_gating_deletions: set[str] = set()
     removed_runtime_gating_owner_files = sorted(
         Path(path)
         for path in state.files.keys() - set(scanned_paths)
@@ -318,6 +320,7 @@ def run_tick(
             vault_root=cfg.vault_path,
             rel_path=rel_path,
             previous_values=state.last_settings_runtime_values(rel_str),
+            observed_missing=True,
         )
         if settings_delta.errors:
             state.errors += len(settings_delta.errors)
@@ -328,9 +331,18 @@ def run_tick(
             summary["settings_receipts_in_tick"] = int(summary.get("settings_receipts_in_tick", 0)) + len(
                 settings_delta.receipts
             )
-        # Remove the vanished path after its one governed reset so repeated
-        # watcher ticks cannot emit duplicate deletion receipts.
-        state.files.pop(rel_str, None)
+        if settings_delta.errors or settings_delta.deferred:
+            retained_values = settings_delta_state_values(settings_delta)
+            if retained_values is not None:
+                state.update_file_state(
+                    rel_str,
+                    settings_runtime_values=retained_values,
+                )
+            pending_runtime_gating_deletions.add(rel_str)
+        else:
+            # Retire the vanished path only after every governed reset was
+            # durably receipted. Failed/partial resets stay pending for retry.
+            state.files.pop(rel_str, None)
     if removed_runtime_gating_owner_files:
         summary["runtime_gating_owner_file_deletions_in_tick"] = len(removed_runtime_gating_owner_files)
 
@@ -365,6 +377,8 @@ def run_tick(
             vault_root=cfg.vault_path,
             rel_path=rel,
             previous_values=state.last_settings_runtime_values(rel_str),
+            observed_digest=digest,
+            observed_missing=False,
         )
         if settings_delta.errors:
             state.errors += len(settings_delta.errors)
@@ -395,7 +409,7 @@ def run_tick(
                 rel_str,
                 mtime=mtime,
                 content_hash=digest,
-                settings_runtime_values=settings_delta.values,
+                settings_runtime_values=settings_delta_state_values(settings_delta),
                 seen_at=now,
             )
             continue
@@ -421,7 +435,7 @@ def run_tick(
                 rel_str,
                 mtime=mtime,
                 content_hash=digest,
-                settings_runtime_values=settings_delta.values,
+                settings_runtime_values=settings_delta_state_values(settings_delta),
                 seen_at=now,
             )
             continue
@@ -435,7 +449,7 @@ def run_tick(
                 rel_str,
                 mtime=mtime,
                 content_hash=digest,
-                settings_runtime_values=settings_delta.values,
+                settings_runtime_values=settings_delta_state_values(settings_delta),
                 seen_at=now,
             )
             continue
@@ -443,7 +457,7 @@ def run_tick(
             rel_str,
             mtime=mtime,
             content_hash=digest,
-            settings_runtime_values=settings_delta.values,
+            settings_runtime_values=settings_delta_state_values(settings_delta),
             seen_at=now,
         )
         if last_seen is not None and (now - last_seen) * 1000 < cfg.debounce_ms:
@@ -496,7 +510,7 @@ def run_tick(
     elapsed_ms = max(int((time.time() - tick_start) * 1000), 0)
     summary["tick_ms"] = elapsed_ms
     _apply_guardrails(cfg, state, summary)
-    state.prune_files(scanned_paths)
+    state.prune_files([*scanned_paths, *pending_runtime_gating_deletions])
 
     return _finalize_tick(cfg, state, summary, tick_start, scan_roots[0] if scan_roots else None)
 

--- a/app/watcher/watcher.py
+++ b/app/watcher/watcher.py
@@ -18,6 +18,7 @@ from app.watcher.settings_delta import (
     handle_settings_local_delta,
     handle_settings_source_delta,
     is_settings_control_path,
+    is_runtime_gating_owner_path,
     is_settings_source_path,
 )
 from app.settings.locations import CANONICAL_SETTINGS_DIR_NAME, LEGACY_COMPILED_DIR
@@ -306,6 +307,33 @@ def run_tick(
         changed_entries.append((rel, mtime, digest))
 
     settings_source_processed = False
+    removed_runtime_gating_owner_files = sorted(
+        Path(path)
+        for path in state.files.keys() - set(scanned_paths)
+        if is_runtime_gating_owner_path(Path(path))
+    )
+    for rel_path in removed_runtime_gating_owner_files:
+        rel_str = str(rel_path)
+        settings_delta = handle_settings_local_delta(
+            vault_root=cfg.vault_path,
+            rel_path=rel_path,
+            previous_values=state.last_settings_runtime_values(rel_str),
+        )
+        if settings_delta.errors:
+            state.errors += len(settings_delta.errors)
+            summary["settings_write_errors_in_tick"] = int(summary.get("settings_write_errors_in_tick", 0)) + len(
+                settings_delta.errors
+            )
+        if settings_delta.receipts:
+            summary["settings_receipts_in_tick"] = int(summary.get("settings_receipts_in_tick", 0)) + len(
+                settings_delta.receipts
+            )
+        # Remove the vanished path after its one governed reset so repeated
+        # watcher ticks cannot emit duplicate deletion receipts.
+        state.files.pop(rel_str, None)
+    if removed_runtime_gating_owner_files:
+        summary["runtime_gating_owner_file_deletions_in_tick"] = len(removed_runtime_gating_owner_files)
+
     removed_settings_sources = sorted(
         Path(path)
         for path in state.files.keys() - set(scanned_paths)

--- a/app/watcher/watcher.py
+++ b/app/watcher/watcher.py
@@ -293,7 +293,11 @@ def run_tick(
         scanned_paths.append(rel_str)
         last_mtime = state.last_mtime(rel_str)
         previous_hash = state.last_hash(rel_str)
-        if last_mtime is not None and last_mtime == mtime:
+        if (
+            last_mtime is not None
+            and last_mtime == mtime
+            and not is_runtime_gating_owner_path(rel)
+        ):
             state.update_file_state(rel_str, mtime=mtime, content_hash=previous_hash, seen_at=now)
             continue
         hashed = _hash_file(path)
@@ -389,18 +393,17 @@ def run_tick(
             summary["settings_receipts_in_tick"] = int(summary.get("settings_receipts_in_tick", 0)) + len(
                 settings_delta.receipts
             )
-            try:
-                mtime = (cfg.vault_path / rel).stat().st_mtime
-            except OSError:
-                pass
-            hashed = _hash_file(cfg.vault_path / rel)
-            if hashed is not None:
-                digest = hashed[0]
+        if settings_delta.processed_digest is not None:
+            digest = settings_delta.processed_digest
         if settings_delta.deferred:
             # The gating delta could not be routed (vault not selected). Do
             # not record the file as seen: it must re-process on a later tick
             # once the vault validates, or the unrouted on-disk edit would
             # silently become effective through resolution.
+            state.invalidate_file_observation(
+                rel_str,
+                settings_runtime_values=settings_delta_state_values(settings_delta),
+            )
             continue
         # A settings source edit re-ingests the effective bundle
         # so the running services honor it within one tick (SETTINGS-01 / F1).

--- a/app/watcher/watcher.py
+++ b/app/watcher/watcher.py
@@ -15,7 +15,7 @@ from app.watcher.config import WatcherConfig
 from app.watcher.heartbeat import write_heartbeat
 from app.watcher.relevance_tick import relevance_tick_enabled, run_relevance_tick
 from app.watcher.settings_delta import (
-    handle_settings_local_delta,
+    handle_settings_detected_delta,
     handle_settings_source_delta,
     is_settings_control_path,
     is_runtime_gating_owner_path,
@@ -314,7 +314,7 @@ def run_tick(
     )
     for rel_path in removed_runtime_gating_owner_files:
         rel_str = str(rel_path)
-        settings_delta = handle_settings_local_delta(
+        settings_delta = handle_settings_detected_delta(
             vault_root=cfg.vault_path,
             rel_path=rel_path,
             previous_values=state.last_settings_runtime_values(rel_str),
@@ -361,7 +361,7 @@ def run_tick(
     for rel, mtime, digest in changed_entries:
         rel_str = str(rel)
         last_seen = state.last_seen(rel_str)
-        settings_delta = handle_settings_local_delta(
+        settings_delta = handle_settings_detected_delta(
             vault_root=cfg.vault_path,
             rel_path=rel,
             previous_values=state.last_settings_runtime_values(rel_str),

--- a/docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_RUNTIME_CONTROL_ACTION_BOUNDARY.md
+++ b/docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_RUNTIME_CONTROL_ACTION_BOUNDARY.md
@@ -72,16 +72,21 @@ WriteGuard health-gate and emits an actor-tagged receipt.
    (`app/vault/settings_service.py :: _emit_settings_write_receipt`, #2787) so the accountability
    evidence survives process restart — the in-memory dataclass in step 4 is no longer the only
    record. Queryable via `app/receipts/settings_receipts.py :: query_settings_receipts`, mirroring
-   the `promotion.transition.applied` / `PromotionReceiptQuery` precedent.
+   the `promotion.transition.applied` / `PromotionReceiptQuery` precedent. Runtime acceptance
+   replays that durable stream in serialized append order and deduplicates combined receipt views
+   by validated operation identity rather than wall-clock order.
 
 **Valid origins of the same seam (no new surfaces here):**
 - UI → `POST /api/companion/vault/settings` (surface=`'api'`) — **wired** (sole caller: `app/api/routes/companion.py:826`)
 - CLI → existing `app.cli vault` commands (surface=`'cli'`) — **NOT yet wired** (the `app.cli vault` group does init/preflight only; no command toggles runtime-gating settings through the seam; addable when a consumer exists)
 - File edit → watcher-detected registered-owner-file delta (surface=`'file'`) — **wired** for
   runtime-gating key deltas; whole-file deletion is a receipted accepted reset rather than a raw
-  fallback.
+  fallback. A blocked or deferred deletion stays pending for retry, and deletion of `local.md`
+  retains its accepted identity only while the surviving vault owner proves the same vault.
 - Git-synced file arrival → the same local gate (surface=`'sync'`, actor=`'sync'`) — it is never
-  attributed as a local human write and never bypasses accepted-state enforcement.
+  attributed as a local human write and never bypasses accepted-state enforcement. Sync provenance
+  requires the exact observed bytes to match the clean tracked Git snapshot and to remain unchanged
+  through inspection; raced observations are deferred.
 - Future MCP/API → addable when there is a consumer (out of scope here)
 
 ### Tier 3 — External-boundary enable

--- a/docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_RUNTIME_CONTROL_ACTION_BOUNDARY.md
+++ b/docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_RUNTIME_CONTROL_ACTION_BOUNDARY.md
@@ -42,7 +42,9 @@ settings write).
 
 ### Tier 2 — Runtime gating (post-init, authority-bearing)
 
-`enableVaultWatcher` and `enableAutoIndexing` gate whether the watcher/indexing runtime runs:
+`enableVaultWatcher`, `enableAutoIndexing`, `youtubeSync.enabled`, and
+`youtubeSync.runnerEnabled` are runtime-gating settings. The first two gate whether the
+watcher/indexing runtime runs:
 - `app/watcher/registry.py:734` — watcher registry refuses to start when `enable_vault_watcher`
   is false.
 - `app/watcher/config.py:92` — watcher config refuses to start when `enable_vault_watcher` is
@@ -63,7 +65,7 @@ WriteGuard health-gate and emits an actor-tagged receipt.
 1. `RUNTIME_GATING_SETTINGS: frozenset` classifies the key.
 2. `DEFAULT_WRITE_GUARD.assert_writes_allowed()` is called; blocks if `state in
    WRITE_BLOCKED_STATES` (i.e. `safe_mode` or `unhealthy`).
-3. The markdown write is applied to `settings/local.md`.
+3. The markdown write is applied to its registered owner file.
 4. `SettingsWriteReceipt(key, value, surface, actor, timestamp, is_runtime_gating=True)` is
    emitted and logged at INFO.
 5. The same receipt is durably persisted as a `settings.write.receipt` outbox event
@@ -75,8 +77,11 @@ WriteGuard health-gate and emits an actor-tagged receipt.
 **Valid origins of the same seam (no new surfaces here):**
 - UI → `POST /api/companion/vault/settings` (surface=`'api'`) — **wired** (sole caller: `app/api/routes/companion.py:826`)
 - CLI → existing `app.cli vault` commands (surface=`'cli'`) — **NOT yet wired** (the `app.cli vault` group does init/preflight only; no command toggles runtime-gating settings through the seam; addable when a consumer exists)
-- File edit → watcher-detected `settings/local.md` delta (surface=`'file'`) — **wired** for
-  runtime-gating key deltas by #2512
+- File edit → watcher-detected registered-owner-file delta (surface=`'file'`) — **wired** for
+  runtime-gating key deltas; whole-file deletion is a receipted accepted reset rather than a raw
+  fallback.
+- Git-synced file arrival → the same local gate (surface=`'sync'`, actor=`'sync'`) — it is never
+  attributed as a local human write and never bypasses accepted-state enforcement.
 - Future MCP/API → addable when there is a consumer (out of scope here)
 
 ### Tier 3 — External-boundary enable
@@ -86,11 +91,12 @@ TTS provider enable crosses an external boundary. EBF applies. Not re-decided he
 
 ## Audit blind-spot — closed for runtime-gating settings
 
-A direct hand-edit of `settings/local.md` previously produced no receipt — only the watcher
-picking it up at next start. The API door is wired, and #2512 wires the file-originated door for
-runtime-gating deltas (`enableVaultWatcher` / `enableAutoIndexing`) through
-`SettingsService.update_setting(..., surface='file', actor='human')`. The CLI `app.cli vault`
-group is init/preflight only and still has no runtime-gating toggle command to wire.
+A direct hand-edit of a registered owner file previously produced no receipt — only the watcher
+picking it up at next start. The API door is wired, and the file-originated door routes
+runtime-gating deltas through `SettingsService.update_setting`. Runtime consumers use
+`SettingsService.resolve_accepted_runtime_gating`, not the raw Markdown resolver, so a denied,
+first-seen, cross-file, or unreceipted on-disk value cannot become trusted runtime state. The CLI
+`app.cli vault` group is init/preflight only and still has no runtime-gating toggle command to wire.
 
 ## Server-authoritative classification rule
 

--- a/docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_RUNTIME_CONTROL_ACTION_BOUNDARY.md
+++ b/docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_RUNTIME_CONTROL_ACTION_BOUNDARY.md
@@ -93,9 +93,12 @@ TTS provider enable crosses an external boundary. EBF applies. Not re-decided he
 
 A direct hand-edit of a registered owner file previously produced no receipt — only the watcher
 picking it up at next start. The API door is wired, and the file-originated door routes
-runtime-gating deltas through `SettingsService.update_setting`. Runtime consumers use
-`SettingsService.resolve_accepted_runtime_gating`, not the raw Markdown resolver, so a denied,
-first-seen, cross-file, or unreceipted on-disk value cannot become trusted runtime state. The CLI
+runtime-gating deltas through `SettingsService.update_setting`. The future YSS-06/YSS-10
+consumers use `SettingsService.resolve_accepted_runtime_gating` for
+`youtubeSync.enabled` / `youtubeSync.runnerEnabled`, not the raw Markdown resolver, so a denied,
+first-seen, cross-file, or unreceipted on-disk YouTube gate cannot become trusted runtime state.
+The existing watcher/indexing startup gates retain their established `VaultPermissions` path; this
+slice does not silently change their current runtime semantics. The CLI
 `app.cli vault` group is init/preflight only and still has no runtime-gating toggle command to wire.
 
 ## Server-authoritative classification rule

--- a/docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_RUNTIME_CONTROL_ACTION_BOUNDARY.md
+++ b/docs/INTERACTION_SURFACES_AND_AUTHORITY/DEFINE_RUNTIME_CONTROL_ACTION_BOUNDARY.md
@@ -69,12 +69,13 @@ WriteGuard health-gate and emits an actor-tagged receipt.
 4. `SettingsWriteReceipt(key, value, surface, actor, timestamp, is_runtime_gating=True)` is
    emitted and logged at INFO.
 5. The same receipt is durably persisted as a `settings.write.receipt` outbox event
-   (`app/vault/settings_service.py :: _emit_settings_write_receipt`, #2787) so the accountability
+   (`app/receipts/settings_write.py :: emit_durable_settings_write_receipt_once`, #2787) so the accountability
    evidence survives process restart — the in-memory dataclass in step 4 is no longer the only
    record. Queryable via `app/receipts/settings_receipts.py :: query_settings_receipts`, mirroring
    the `promotion.transition.applied` / `PromotionReceiptQuery` precedent. Runtime acceptance
    replays that durable stream in serialized append order and deduplicates combined receipt views
-   by validated operation identity rather than wall-clock order.
+   by validated operation identity rather than wall-clock order. The receipt names only the
+   registered owner filename; it never persists the vault path.
 
 **Valid origins of the same seam (no new surfaces here):**
 - UI → `POST /api/companion/vault/settings` (surface=`'api'`) — **wired** (sole caller: `app/api/routes/companion.py:826`)
@@ -86,7 +87,9 @@ WriteGuard health-gate and emits an actor-tagged receipt.
 - Git-synced file arrival → the same local gate (surface=`'sync'`, actor=`'sync'`) — it is never
   attributed as a local human write and never bypasses accepted-state enforcement. Sync provenance
   requires the exact observed bytes to match the clean tracked Git snapshot and to remain unchanged
-  through inspection; raced observations are deferred.
+  through durable acceptance. Watcher state advances only the accepted digest; a newer generation
+  invalidates the observation and remains pending for the next tick. Raced observations and
+  transient receipt failures are deferred.
 - Future MCP/API → addable when there is a consumer (out of scope here)
 
 ### Tier 3 — External-boundary enable

--- a/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
@@ -180,8 +180,14 @@ store *path*, local Takeout import path. Candidate posture (`requires_review: tr
 by WriteGuard + durable settings receipt). Each runtime-gating key is accepted only from its
 registered owner file (`youtube.md` for the shared master switch, `local.md` for the machine-local
 runner switch); a cross-file override is ignored with a `SettingsValidationError` and no success
-receipt. Validation errors degrade to defaults with a `SettingsValidationError`, never silently
-apply. Effective values, scope, and source file are shown by the capability doctor
+receipt. Runtime consumers use `SettingsService.resolve_accepted_runtime_gating`, which derives
+accepted state from the durable governed-write receipts and fails closed to the registered default;
+raw `SettingsService.resolve` remains the operator/provenance view and is not a runtime-gating
+authority accessor. Deleting an owner file is a governed reset to its registered default, and a
+git-synced arrival replays through the same local gate with `surface='sync'` and
+`actor='sync'`, never as a local human receipt. Validation errors degrade to defaults with a
+`SettingsValidationError`, never silently apply. Effective values, scope, and source file are
+shown by the capability doctor
 (`youtube-sync doctor`) via `EffectiveSetting` provenance.
 
 ## Secrets and private bindings (YSS-02)

--- a/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
@@ -181,11 +181,14 @@ by WriteGuard + durable settings receipt). Each runtime-gating key is accepted o
 registered owner file (`youtube.md` for the shared master switch, `local.md` for the machine-local
 runner switch); a cross-file override is ignored with a `SettingsValidationError` and no success
 receipt. Runtime consumers use `SettingsService.resolve_accepted_runtime_gating`, which derives
-accepted state from the durable governed-write receipts and fails closed to the registered default;
+accepted state for the two issue-authorized YouTube gates from identity-bound durable
+governed-write receipts and fails closed to the registered default;
 raw `SettingsService.resolve` remains the operator/provenance view and is not a runtime-gating
 authority accessor. Deleting an owner file is a governed reset to its registered default, and a
 git-synced arrival replays through the same local gate with `surface='sync'` and
-`actor='sync'`, never as a local human receipt. Validation errors degrade to defaults with a
+`actor='sync'`, never as a local human receipt. The watcher identifies that production provenance
+from a clean tracked Git state; modified/untracked files and non-Git vaults remain local file edits.
+Validation errors degrade to defaults with a
 `SettingsValidationError`, never silently apply. Effective values, scope, and source file are
 shown by the capability doctor
 (`youtube-sync doctor`) via `EffectiveSetting` provenance.

--- a/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
@@ -190,9 +190,11 @@ or deferred reset remains pending for retry, and deletion of the vault-local own
 accepted identity only while the surviving vault owner still proves the same vault. A git-synced
 arrival replays through the same local gate with `surface='sync'` and `actor='sync'`, never as a
 local human receipt. The watcher identifies that production provenance only when the exact observed
-bytes match the clean tracked Git snapshot and remain unchanged through provenance inspection;
-modified/untracked, raced, or non-Git observations remain local or deferred rather than receiving
-sync attribution.
+bytes match the clean tracked Git snapshot and remain unchanged through durable acceptance; watcher
+state advances only that accepted digest, so a later generation remains pending rather than being
+marked seen. Durable receipts carry the registered owner filename, never the vault path.
+Modified/untracked, raced, receipt-failed, or non-Git observations remain local or deferred rather
+than receiving stale sync attribution.
 Validation errors degrade to defaults with a
 `SettingsValidationError`, never silently apply. Effective values, scope, and source file are
 shown by the capability doctor

--- a/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
+++ b/docs/YOUTUBE_SOURCE_SYNC/SOURCE_SYNC_CONTRACT.md
@@ -182,12 +182,17 @@ registered owner file (`youtube.md` for the shared master switch, `local.md` for
 runner switch); a cross-file override is ignored with a `SettingsValidationError` and no success
 receipt. Runtime consumers use `SettingsService.resolve_accepted_runtime_gating`, which derives
 accepted state for the two issue-authorized YouTube gates from identity-bound durable
-governed-write receipts and fails closed to the registered default;
+governed-write receipts in serialized durable append order, deduplicated by validated operation
+identity, and fails closed to the registered default;
 raw `SettingsService.resolve` remains the operator/provenance view and is not a runtime-gating
-authority accessor. Deleting an owner file is a governed reset to its registered default, and a
-git-synced arrival replays through the same local gate with `surface='sync'` and
-`actor='sync'`, never as a local human receipt. The watcher identifies that production provenance
-from a clean tracked Git state; modified/untracked files and non-Git vaults remain local file edits.
+authority accessor. Deleting an owner file is a governed reset to its registered default; a failed
+or deferred reset remains pending for retry, and deletion of the vault-local owner retains its
+accepted identity only while the surviving vault owner still proves the same vault. A git-synced
+arrival replays through the same local gate with `surface='sync'` and `actor='sync'`, never as a
+local human receipt. The watcher identifies that production provenance only when the exact observed
+bytes match the clean tracked Git snapshot and remain unchanged through provenance inspection;
+modified/untracked, raced, or non-Git observations remain local or deferred rather than receiving
+sync attribution.
 Validation errors degrade to defaults with a
 `SettingsValidationError`, never silently apply. Effective values, scope, and source file are
 shown by the capability doctor

--- a/tests/architecture/test_runtime_gating_consumer_accessor.py
+++ b/tests/architecture/test_runtime_gating_consumer_accessor.py
@@ -1,0 +1,27 @@
+"""Architecture guard for future YouTube runtime-gating consumers (YSS-06/YSS-10)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.not_pg
+
+
+def test_yss06_yss10_consume_gating_only_via_accessor() -> None:
+    root = Path(__file__).resolve().parents[2]
+    consumer_paths = (
+        root / "app/watcher/registry.py",  # YSS-06 tick host
+        root / "app/knowledge_acquisition/sync_scheduler.py",  # YSS-06
+        root / "app/cli/youtube_sync.py",  # YSS-10
+    )
+    for path in consumer_paths:
+        if not path.exists():
+            continue
+        source = path.read_text(encoding="utf-8")
+        if "youtubeSync.enabled" not in source and "youtubeSync.runnerEnabled" not in source:
+            continue
+        assert "resolve_accepted_runtime_gating" in source, path
+        assert ".resolve(context)" not in source, path

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -467,11 +467,11 @@ WRITE_FRONTMATTER_SITE_CLASSIFICATION: dict[tuple[str, int], str] = {
         "call (#2910 identity-heal fix); a denying/raising guard raises before "
         "reaching this line."
     ),
-    ("app/vault/settings_service.py", 616): (
+    ("app/vault/settings_service.py", 617): (
         "guarded: SettingsService.update_setting asserts "
         "DEFAULT_WRITE_GUARD.assert_writes_allowed(_SETTINGS_WRITE_ACTION) "
         "earlier in the same method before persist=True reaches this write. "
-        "Line drifted 348 -> 508 -> 589 -> 614 -> 616 (site unchanged); re-pinned per this census's "
+        "Line drifted 348 -> 508 -> 589 -> 614 -> 616 -> 617 (site unchanged); re-pinned per this census's "
         "own directly-related-repair convention when YSS-01 (#3916) added the "
         "youtubeSync.* SettingDefinitions and the scaffold action constant "
         "earlier in the file."
@@ -494,7 +494,7 @@ WRITE_MISSING_SITE_CLASSIFICATION: dict[tuple[str, int], str] = {
         "bootstrap: VaultManager.initialize_vault is the explicit human/operator "
         "pre-selection initialization transition; O_EXCL preserves existing owner files."
     ),
-    ("app/vault/settings_service.py", 686): (
+    ("app/vault/settings_service.py", 696): (
         "guarded: _scaffold_missing_settings_file asserts DEFAULT_WRITE_GUARD."
         "assert_writes_allowed(_SETTINGS_SCAFFOLD_ACTION) before the O_EXCL scaffold call."
     ),

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -467,23 +467,24 @@ WRITE_FRONTMATTER_SITE_CLASSIFICATION: dict[tuple[str, int], str] = {
         "call (#2910 identity-heal fix); a denying/raising guard raises before "
         "reaching this line."
     ),
-    ("app/vault/settings_service.py", 508): (
+    ("app/vault/settings_service.py", 589): (
         "guarded: SettingsService.update_setting asserts "
         "DEFAULT_WRITE_GUARD.assert_writes_allowed(_SETTINGS_WRITE_ACTION) "
         "earlier in the same method before persist=True reaches this write. "
-        "Line drifted 348 -> 508 (site unchanged); re-pinned per this census's "
+        "Line drifted 348 -> 508 -> 589 (site unchanged); re-pinned per this census's "
         "own directly-related-repair convention when YSS-01 (#3916) added the "
         "youtubeSync.* SettingDefinitions and the scaffold action constant "
         "earlier in the file."
     ),
-    ("app/vault/settings_service.py", 567): (
+    ("app/vault/settings_service.py", 648): (
         "guarded: _scaffold_missing_settings_file asserts "
         "DEFAULT_WRITE_GUARD.assert_writes_allowed(_SETTINGS_SCAFFOLD_ACTION) "
         "before writing every missing static vault-shared settings seed, including "
         "legacy non-gating paths.md and settings/youtube.md. Line drifted 558 -> 567 "
         "when the scaffold gained its own WriteGuard action name (YSS-01 #3916 "
         "round-B review: scaffolds must not be conflated with runtime-gating "
-        "writes in guard errors/audits)."
+        "writes in guard errors/audits), then 567 -> 648 when #3964 added runtime-"
+        "gating acceptance and reset handling above the unchanged scaffold seam."
     ),
     ("app/instance/vault_registry.py", 1088): (
         "out_of_scope: AppLocalSettingsStore persists the app-local device "

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -467,11 +467,11 @@ WRITE_FRONTMATTER_SITE_CLASSIFICATION: dict[tuple[str, int], str] = {
         "call (#2910 identity-heal fix); a denying/raising guard raises before "
         "reaching this line."
     ),
-    ("app/vault/settings_service.py", 614): (
+    ("app/vault/settings_service.py", 616): (
         "guarded: SettingsService.update_setting asserts "
         "DEFAULT_WRITE_GUARD.assert_writes_allowed(_SETTINGS_WRITE_ACTION) "
         "earlier in the same method before persist=True reaches this write. "
-        "Line drifted 348 -> 508 -> 589 -> 614 (site unchanged); re-pinned per this census's "
+        "Line drifted 348 -> 508 -> 589 -> 614 -> 616 (site unchanged); re-pinned per this census's "
         "own directly-related-repair convention when YSS-01 (#3916) added the "
         "youtubeSync.* SettingDefinitions and the scaffold action constant "
         "earlier in the file."
@@ -481,6 +481,22 @@ WRITE_FRONTMATTER_SITE_CLASSIFICATION: dict[tuple[str, int], str] = {
         "registry (default_app_local_settings_path(), typically an XDG data "
         "dir) -- a machine-local app config store outside the vault content "
         "plane Sigma (formal-model.md sec 2.3), not a Human Knowledge Artifact."
+    ),
+}
+
+# ``MarkdownSettingsStore.write_missing`` is a distinct O_EXCL vault-write
+# primitive. It is intentionally available to explicit vault bootstrap, while
+# post-init scaffolding must be guarded by its direct caller. Keep the census
+# closed so moving a write from ``write_frontmatter`` cannot make it disappear
+# from the WriteGuard inventory.
+WRITE_MISSING_SITE_CLASSIFICATION: dict[tuple[str, int], str] = {
+    ("app/vault/manager.py", 496): (
+        "bootstrap: VaultManager.initialize_vault is the explicit human/operator "
+        "pre-selection initialization transition; O_EXCL preserves existing owner files."
+    ),
+    ("app/vault/settings_service.py", 686): (
+        "guarded: _scaffold_missing_settings_file asserts DEFAULT_WRITE_GUARD."
+        "assert_writes_allowed(_SETTINGS_SCAFFOLD_ACTION) before the O_EXCL scaffold call."
     ),
 }
 
@@ -562,6 +578,7 @@ def spy_on_durable_writes(monkeypatch: pytest.MonkeyPatch, spy: WriteSpy) -> Ite
     import app.knowledge.write_ops as write_ops_mod
 
     original_write_frontmatter = markdown_settings_mod.MarkdownSettingsStore.write_frontmatter
+    original_write_missing = markdown_settings_mod.MarkdownSettingsStore.write_missing
     original_write_note_from_absolute = write_ops_mod.write_note_from_absolute
 
     def traced_write_frontmatter(
@@ -573,6 +590,16 @@ def spy_on_durable_writes(monkeypatch: pytest.MonkeyPatch, spy: WriteSpy) -> Ite
             args_repr=f"path={path!r}",
         )
         return original_write_frontmatter(self, path, frontmatter, body=body)
+
+    def traced_write_missing(
+        self: Any, path: Any, frontmatter: Any, body: Any
+    ) -> Any:
+        spy.record(
+            seam="app.vault.markdown_settings::MarkdownSettingsStore.write_missing",
+            caller=_immediate_caller_qualname(),
+            args_repr=f"path={path!r}",
+        )
+        return original_write_missing(self, path, frontmatter, body)
 
     def traced_write_note_from_absolute(
         path: Any, content: Any, *, vault_root: Any, **kwargs: Any
@@ -586,6 +613,9 @@ def spy_on_durable_writes(monkeypatch: pytest.MonkeyPatch, spy: WriteSpy) -> Ite
 
     monkeypatch.setattr(
         markdown_settings_mod.MarkdownSettingsStore, "write_frontmatter", traced_write_frontmatter
+    )
+    monkeypatch.setattr(
+        markdown_settings_mod.MarkdownSettingsStore, "write_missing", traced_write_missing
     )
     monkeypatch.setattr(write_ops_mod, "write_note_from_absolute", traced_write_note_from_absolute)
     # note_uuid.py imported write_note_from_absolute directly into its module
@@ -632,6 +662,29 @@ def find_write_frontmatter_call_sites(root: Path = APP_ROOT) -> list[tuple[str, 
                 continue
             func = node.func
             if isinstance(func, ast.Attribute) and func.attr == "write_frontmatter":
+                sites.append((rel, node.lineno))
+    return sites
+
+
+def find_write_missing_call_sites(root: Path = APP_ROOT) -> list[tuple[str, int]]:
+    """AST-scan every production ``*.write_missing(...)`` call site."""
+
+    sites: list[tuple[str, int]] = []
+    for path in sorted(root.rglob("*.py")):
+        try:
+            source = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError:
+            continue
+        rel = str(path.relative_to(REPO_ROOT))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if isinstance(func, ast.Attribute) and func.attr == "write_missing":
                 sites.append((rel, node.lineno))
     return sites
 

--- a/tests/properties/_machinery.py
+++ b/tests/properties/_machinery.py
@@ -467,24 +467,14 @@ WRITE_FRONTMATTER_SITE_CLASSIFICATION: dict[tuple[str, int], str] = {
         "call (#2910 identity-heal fix); a denying/raising guard raises before "
         "reaching this line."
     ),
-    ("app/vault/settings_service.py", 589): (
+    ("app/vault/settings_service.py", 614): (
         "guarded: SettingsService.update_setting asserts "
         "DEFAULT_WRITE_GUARD.assert_writes_allowed(_SETTINGS_WRITE_ACTION) "
         "earlier in the same method before persist=True reaches this write. "
-        "Line drifted 348 -> 508 -> 589 (site unchanged); re-pinned per this census's "
+        "Line drifted 348 -> 508 -> 589 -> 614 (site unchanged); re-pinned per this census's "
         "own directly-related-repair convention when YSS-01 (#3916) added the "
         "youtubeSync.* SettingDefinitions and the scaffold action constant "
         "earlier in the file."
-    ),
-    ("app/vault/settings_service.py", 648): (
-        "guarded: _scaffold_missing_settings_file asserts "
-        "DEFAULT_WRITE_GUARD.assert_writes_allowed(_SETTINGS_SCAFFOLD_ACTION) "
-        "before writing every missing static vault-shared settings seed, including "
-        "legacy non-gating paths.md and settings/youtube.md. Line drifted 558 -> 567 "
-        "when the scaffold gained its own WriteGuard action name (YSS-01 #3916 "
-        "round-B review: scaffolds must not be conflated with runtime-gating "
-        "writes in guard errors/audits), then 567 -> 648 when #3964 added runtime-"
-        "gating acceptance and reset handling above the unchanged scaffold seam."
     ),
     ("app/instance/vault_registry.py", 1088): (
         "out_of_scope: AppLocalSettingsStore persists the app-local device "

--- a/tests/properties/test_guard_at_seam.py
+++ b/tests/properties/test_guard_at_seam.py
@@ -42,8 +42,10 @@ import pytest
 from tests.properties._machinery import (
     REGISTERED_WRITE_SEAMS,
     WRITE_FRONTMATTER_SITE_CLASSIFICATION,
+    WRITE_MISSING_SITE_CLASSIFICATION,
     WRITE_NOTE_RELATIVE_SITE_CLASSIFICATION,
     find_write_frontmatter_call_sites,
+    find_write_missing_call_sites,
     find_write_note_relative_call_sites,
 )
 
@@ -93,6 +95,32 @@ def test_every_write_seam_asserts_writeguard() -> None:
     ]
     assert not bad_classification, (
         f"Every classification must start with 'guarded' or 'out_of_scope': {bad_classification}"
+    )
+
+    write_missing_sites = find_write_missing_call_sites()
+    assert write_missing_sites, "expected known production write_missing call sites"
+    unregistered_write_missing = [
+        site for site in write_missing_sites if site not in WRITE_MISSING_SITE_CLASSIFICATION
+    ]
+    assert not unregistered_write_missing, (
+        "Unregistered write_missing call site(s) found; classify each guarded or "
+        f"explicit bootstrap caller: {unregistered_write_missing}"
+    )
+    stale_write_missing = [
+        site for site in WRITE_MISSING_SITE_CLASSIFICATION if site not in set(write_missing_sites)
+    ]
+    assert not stale_write_missing, (
+        "WRITE_MISSING_SITE_CLASSIFICATION has stale entries: "
+        f"{stale_write_missing}"
+    )
+    invalid_write_missing = [
+        (site, classification)
+        for site, classification in WRITE_MISSING_SITE_CLASSIFICATION.items()
+        if not classification.startswith(("guarded", "bootstrap"))
+    ]
+    assert not invalid_write_missing, (
+        "write_missing classifications must be guarded or bootstrap: "
+        f"{invalid_write_missing}"
     )
 
 

--- a/tests/vault/test_settings_receipt_durable.py
+++ b/tests/vault/test_settings_receipt_durable.py
@@ -16,6 +16,7 @@ This test asserts:
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 from textwrap import dedent
@@ -203,6 +204,81 @@ def test_runtime_acceptance_receipt_is_idempotent_by_operation_identity(
     ]
     assert len(records) == 1
     assert durable_settings_write_receipt_exists(receipt) is True
+
+
+def test_runtime_acceptance_replays_durable_append_order_not_wall_clock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    outbox_path = tmp_path / "outbox.jsonl"
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    manager, vault = _manager(tmp_path)
+    context = manager.context
+    owner_file = str(vault / "settings" / "youtube.md")
+
+    emit_durable_settings_write_receipt_once(
+        SettingsWriteReceipt(
+            key="youtubeSync.enabled",
+            value=True,
+            old_value=False,
+            new_value=True,
+            file=owner_file,
+            surface="api",
+            actor="human",
+            timestamp="2099-01-01T00:00:00+00:00",
+            is_runtime_gating=True,
+            operation_id="runtime-gating:enable",
+            vault_id=context.active_vault_id,
+            local_instance_id=context.local_instance_id,
+        )
+    )
+    emit_durable_settings_write_receipt_once(
+        SettingsWriteReceipt(
+            key="youtubeSync.enabled",
+            value=False,
+            old_value=True,
+            new_value=False,
+            file=owner_file,
+            surface="api",
+            actor="human",
+            timestamp="2000-01-01T00:00:00+00:00",
+            is_runtime_gating=True,
+            operation_id="runtime-gating:disable",
+            vault_id=context.active_vault_id,
+            local_instance_id=context.local_instance_id,
+        )
+    )
+
+    accepted = SettingsService().resolve_accepted_runtime_gating(context)
+    assert accepted["youtubeSync.enabled"].value is False
+
+
+def test_settings_receipt_query_deduplicates_validated_operation_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    outbox_path = tmp_path / "outbox.jsonl"
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    receipt = SettingsWriteReceipt(
+        key="youtubeSync.enabled",
+        value=True,
+        old_value=False,
+        new_value=True,
+        file="youtube.md",
+        surface="sync",
+        actor="sync",
+        is_runtime_gating=True,
+        operation_id="runtime-gating:dedup",
+        vault_id="vault-test",
+        local_instance_id="local-test",
+    )
+    emit_durable_settings_write_receipt_once(receipt)
+    record = json.loads(outbox_path.read_text(encoding="utf-8"))
+
+    result = query_settings_receipts(records=[record, dict(record)])
+
+    assert len(result.rows) == 1
+    assert result.rows[0].operation_id == receipt.operation_id
 
 
 def test_required_receipt_fsyncs_full_fresh_parent_chain(

--- a/tests/vault/test_settings_receipt_durable.py
+++ b/tests/vault/test_settings_receipt_durable.py
@@ -29,6 +29,7 @@ from app.receipts.settings_receipts import (
 )
 from app.receipts.settings_write import (
     durable_settings_write_receipt_exists,
+    emit_durable_settings_write_receipt_once,
     emit_settings_write_receipt,
 )
 from app.settings import compiler
@@ -170,6 +171,38 @@ def test_required_receipt_appends_each_record_with_one_os_write(
 
     assert len(writes) == 1
     assert writes[0].endswith(b"\n")
+
+
+def test_runtime_acceptance_receipt_is_idempotent_by_operation_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    outbox_path = tmp_path / "outbox.jsonl"
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    receipt = SettingsWriteReceipt(
+        key="youtubeSync.enabled",
+        value=True,
+        old_value=False,
+        new_value=True,
+        file="youtube.md",
+        surface="sync",
+        actor="sync",
+        is_runtime_gating=True,
+        operation_id="runtime-gating:test-operation",
+        vault_id="vault-test",
+        local_instance_id="local-test",
+    )
+
+    emit_durable_settings_write_receipt_once(receipt)
+    emit_durable_settings_write_receipt_once(receipt)
+
+    records = [
+        line
+        for line in outbox_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(records) == 1
+    assert durable_settings_write_receipt_exists(receipt) is True
 
 
 def test_required_receipt_fsyncs_full_fresh_parent_chain(

--- a/tests/vault/test_youtube_sync_settings.py
+++ b/tests/vault/test_youtube_sync_settings.py
@@ -21,6 +21,7 @@ from unittest.mock import patch
 import pytest
 
 from app.knowledge_acquisition.source_registry import VALID_ACQUISITION_MODES
+from app.receipts.settings_receipts import query_settings_receipts
 from app.vault.manager import VaultContext
 from app.vault.markdown_settings import MarkdownSettingsStore
 from app.vault.settings_service import (
@@ -204,6 +205,47 @@ def test_accepted_runtime_receipt_best_effort_after_write_fails_closed(
     # receipt exists.
     assert service.resolve(context).settings["youtubeSync.enabled"].value is True
     assert service.resolve_accepted_runtime_gating(context)["youtubeSync.enabled"].value is False
+
+
+def test_runtime_acceptance_receipt_uses_non_sensitive_owner_identifier(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault_root = tmp_path / "vault"
+    settings_dir = _init_minimal_vault(vault_root)
+    context = VaultContext(
+        status="selected",
+        active_vault_id="vault-test",
+        active_vault_path=str(vault_root),
+        settings_path=str(settings_dir),
+        local_instance_id="l1",
+    )
+    outbox_path = tmp_path / "outbox.jsonl"
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    _write(
+        settings_dir / "youtube.md",
+        "---\nscope: vault-shared\nyoutubeSync.enabled: false\n---\n",
+    )
+
+    _effective, receipt = SettingsService().update_setting(
+        context,
+        "youtubeSync.enabled",
+        True,
+        surface="api",
+        actor="human",
+    )
+
+    assert receipt.file == "youtube.md"
+    assert str(vault_root) not in outbox_path.read_text(encoding="utf-8")
+    rows = query_settings_receipts(outbox_path=outbox_path).rows
+    assert [(row.key, row.file) for row in rows] == [
+        ("youtubeSync.enabled", "youtube.md")
+    ]
+    assert (
+        SettingsService().resolve_accepted_runtime_gating(context)[
+            "youtubeSync.enabled"
+        ].value
+        is True
+    )
 
 
 def test_defaults_scopes_provenance_and_gated_writes(tmp_path: Path) -> None:

--- a/tests/vault/test_youtube_sync_settings.py
+++ b/tests/vault/test_youtube_sync_settings.py
@@ -22,7 +22,13 @@ import pytest
 
 from app.knowledge_acquisition.source_registry import VALID_ACQUISITION_MODES
 from app.vault.manager import VaultContext
-from app.vault.settings_service import RUNTIME_GATING_SETTINGS, SettingsService, SettingsWriteError
+from app.vault.markdown_settings import MarkdownSettingsStore
+from app.vault.settings_service import (
+    ACCEPTED_RUNTIME_GATING_SETTINGS,
+    RUNTIME_GATING_SETTINGS,
+    SettingsService,
+    SettingsWriteError,
+)
 
 pytestmark = pytest.mark.not_pg
 
@@ -80,7 +86,13 @@ def test_runtime_gating_accessor_rejects_unaccepted_disk_value(
     """Raw owner-file input is not runtime-trusted until the governed seam accepts it."""
     vault_root = tmp_path / "vault"
     settings_dir = _init_minimal_vault(vault_root)
-    context = VaultContext(status="selected", active_vault_path=str(vault_root), settings_path=str(settings_dir))
+    context = VaultContext(
+        status="selected",
+        active_vault_id="vault-test",
+        active_vault_path=str(vault_root),
+        settings_path=str(settings_dir),
+        local_instance_id="l1",
+    )
     outbox_path = tmp_path / "outbox.jsonl"
     monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
 
@@ -96,10 +108,114 @@ def test_runtime_gating_accessor_rejects_unaccepted_disk_value(
     assert service.resolve_accepted_runtime_gating(context)["youtubeSync.enabled"].value is True
 
 
+def test_runtime_gating_receipt_identity_path_only_does_not_cross_vault_generation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault_root = tmp_path / "vault"
+    settings_dir = _init_minimal_vault(vault_root)
+    outbox_path = tmp_path / "outbox.jsonl"
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    _write(settings_dir / "youtube.md", "---\nscope: vault-shared\nyoutubeSync.enabled: true\n---\n")
+
+    first = VaultContext(
+        status="selected",
+        active_vault_id="vault-first",
+        active_vault_path=str(vault_root),
+        settings_path=str(settings_dir),
+        local_instance_id="local-first",
+    )
+    second_generation_same_path = VaultContext(
+        status="selected",
+        active_vault_id="vault-second",
+        active_vault_path=str(vault_root),
+        settings_path=str(settings_dir),
+        local_instance_id="local-second",
+    )
+    service = SettingsService()
+
+    service.update_setting(first, "youtubeSync.enabled", True, surface="api", actor="human")
+
+    assert service.resolve_accepted_runtime_gating(first)["youtubeSync.enabled"].value is True
+    assert (
+        service.resolve_accepted_runtime_gating(second_generation_same_path)[
+            "youtubeSync.enabled"
+        ].value
+        is False
+    )
+
+
+def test_runtime_gating_current_consumers_bypass_accessor_scope_is_yss_only(
+    tmp_path: Path,
+) -> None:
+    vault_root = tmp_path / "vault"
+    settings_dir = _init_minimal_vault(vault_root)
+    context = VaultContext(
+        status="selected",
+        active_vault_id="vault-test",
+        active_vault_path=str(vault_root),
+        settings_path=str(settings_dir),
+        local_instance_id="l1",
+    )
+
+    assert set(SettingsService().resolve_accepted_runtime_gating(context)) == set(
+        ACCEPTED_RUNTIME_GATING_SETTINGS
+    )
+    assert ACCEPTED_RUNTIME_GATING_SETTINGS == frozenset(
+        {"youtubeSync.enabled", "youtubeSync.runnerEnabled"}
+    )
+
+
+def test_accepted_runtime_receipt_best_effort_after_write_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault_root = tmp_path / "vault"
+    settings_dir = _init_minimal_vault(vault_root)
+    context = VaultContext(
+        status="selected",
+        active_vault_id="vault-test",
+        active_vault_path=str(vault_root),
+        settings_path=str(settings_dir),
+        local_instance_id="l1",
+    )
+    outbox_path = tmp_path / "outbox.jsonl"
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    _write(settings_dir / "youtube.md", "---\nscope: vault-shared\nyoutubeSync.enabled: false\n---\n")
+
+    def _fail_receipt(_receipt: object) -> None:
+        raise RuntimeError("synthetic durable sink failure")
+
+    monkeypatch.setattr(
+        "app.vault.settings_service.emit_durable_settings_write_receipt_once",
+        _fail_receipt,
+    )
+    service = SettingsService()
+
+    with pytest.raises(SettingsWriteError, match="not durably accepted"):
+        service.update_setting(
+            context,
+            "youtubeSync.enabled",
+            True,
+            surface="api",
+            actor="human",
+        )
+
+    # The raw file may have been written, but success was not reported and the
+    # runtime projection remains fail-closed because no durable acceptance
+    # receipt exists.
+    assert service.resolve(context).settings["youtubeSync.enabled"].value is True
+    assert service.resolve_accepted_runtime_gating(context)["youtubeSync.enabled"].value is False
+
+
 def test_defaults_scopes_provenance_and_gated_writes(tmp_path: Path) -> None:
     vault_root = tmp_path / "vault"
     settings_dir = _init_minimal_vault(vault_root)
-    context = VaultContext(status="selected", active_vault_path=str(vault_root), settings_path=str(settings_dir))
+    context = VaultContext(
+        status="selected",
+        active_vault_id="vault-test",
+        active_vault_path=str(vault_root),
+        settings_path=str(settings_dir),
+        local_instance_id="l1",
+    )
     service = SettingsService()
 
     # --- 1. Defaults resolve built-in when youtube.md/local.md carry no override ---
@@ -225,7 +341,13 @@ def test_bounded_youtube_numeric_settings_reject_non_finite_non_integer_values(
     """Resolution and the production write seam share finite-int validation."""
     vault_root = tmp_path / "vault"
     settings_dir = _init_minimal_vault(vault_root)
-    context = VaultContext(status="selected", active_vault_path=str(vault_root), settings_path=str(settings_dir))
+    context = VaultContext(
+        status="selected",
+        active_vault_id="vault-test",
+        active_vault_path=str(vault_root),
+        settings_path=str(settings_dir),
+        local_instance_id="l1",
+    )
     service = SettingsService()
     youtube_md = settings_dir / "youtube.md"
 
@@ -248,7 +370,13 @@ def test_update_setting_scaffolds_missing_youtube_settings_file(tmp_path: Path) 
 
     vault_root = tmp_path / "vault"
     settings_dir = _init_minimal_vault(vault_root)
-    context = VaultContext(status="selected", active_vault_path=str(vault_root), settings_path=str(settings_dir))
+    context = VaultContext(
+        status="selected",
+        active_vault_id="vault-test",
+        active_vault_path=str(vault_root),
+        settings_path=str(settings_dir),
+        local_instance_id="l1",
+    )
     service = SettingsService()
     youtube_md = settings_dir / "youtube.md"
     assert not youtube_md.exists()
@@ -304,6 +432,45 @@ def test_update_setting_scaffolds_missing_youtube_settings_file(tmp_path: Path) 
     ):
         service.update_setting(context, "youtubeSync.runnerEnabled", True, surface="cli", actor="human")
     assert not local_md.exists()
+
+
+def test_settings_scaffold_toctou_overwrite_preserves_concurrent_owner_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class RacingStore(MarkdownSettingsStore):
+        def write_missing(self, path: Path, frontmatter: object, body: str) -> bool:
+            del frontmatter, body
+            path.write_text(
+                "---\nscope: vault-shared\nyoutubeSync.captionsEnabled: false\n"
+                "ownerSentinel: preserve-me\n---\n# Concurrent owner\n",
+                encoding="utf-8",
+            )
+            return False
+
+    vault_root = tmp_path / "vault"
+    settings_dir = _init_minimal_vault(vault_root)
+    context = VaultContext(
+        status="selected",
+        active_vault_id="vault-test",
+        active_vault_path=str(vault_root),
+        settings_path=str(settings_dir),
+        local_instance_id="l1",
+    )
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(tmp_path / "outbox.jsonl"))
+    service = SettingsService(markdown_store=RacingStore())
+
+    service.update_setting(
+        context,
+        "youtubeSync.captionsEnabled",
+        True,
+        surface="api",
+        actor="human",
+    )
+
+    document = MarkdownSettingsStore().read(settings_dir / "youtube.md")
+    assert document.frontmatter["ownerSentinel"] == "preserve-me"
+    assert document.frontmatter["youtubeSync.captionsEnabled"] is True
+    assert document.body.strip() == "# Concurrent owner"
 
 
 def test_static_shared_settings_scaffold_is_guarded_for_legacy_paths_file(tmp_path: Path) -> None:

--- a/tests/vault/test_youtube_sync_settings.py
+++ b/tests/vault/test_youtube_sync_settings.py
@@ -74,6 +74,28 @@ def test_subscription_default_policy_matches_registry_contract() -> None:
     assert frozenset(definition.allowed_values) == VALID_ACQUISITION_MODES
 
 
+def test_runtime_gating_accessor_rejects_unaccepted_disk_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Raw owner-file input is not runtime-trusted until the governed seam accepts it."""
+    vault_root = tmp_path / "vault"
+    settings_dir = _init_minimal_vault(vault_root)
+    context = VaultContext(status="selected", active_vault_path=str(vault_root), settings_path=str(settings_dir))
+    outbox_path = tmp_path / "outbox.jsonl"
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+
+    _write(settings_dir / "youtube.md", "---\nscope: vault-shared\nyoutubeSync.enabled: true\n---\n")
+    service = SettingsService()
+
+    # ``resolve`` remains the operator/provenance view; runtime callers use
+    # the accepted accessor and must not trust a first-seen disk value.
+    assert service.resolve(context).settings["youtubeSync.enabled"].value is True
+    assert service.resolve_accepted_runtime_gating(context)["youtubeSync.enabled"].value is False
+
+    service.update_setting(context, "youtubeSync.enabled", True, surface="api", actor="human")
+    assert service.resolve_accepted_runtime_gating(context)["youtubeSync.enabled"].value is True
+
+
 def test_defaults_scopes_provenance_and_gated_writes(tmp_path: Path) -> None:
     vault_root = tmp_path / "vault"
     settings_dir = _init_minimal_vault(vault_root)

--- a/tests/watcher/test_settings_delta_receipts.py
+++ b/tests/watcher/test_settings_delta_receipts.py
@@ -456,24 +456,55 @@ def test_owner_file_deletion_routes_runtime_gating_reset_through_governed_seam(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     vault_root = tmp_path / "vault"
-    initialize_test_vault(vault_root)
+    VaultManager().initialize_vault(vault_root, machine_role="primary", remember=False)
     outbox_path = tmp_path / "outbox.jsonl"
+    config_path = tmp_path / "watchers.yaml"
+    _write_watchers_config(config_path)
+
+    monkeypatch.setenv("WATCHER_ENABLE", "1")
+    monkeypatch.setenv("WATCHER_VAULT_PATH", str(vault_root))
+    monkeypatch.setenv("WATCHER_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.setenv("WATCHER_SCOPE_GLOB", "settings/*.md")
+    monkeypatch.setenv("WATCHER_SUMMARY_INTERVAL", "0")
+    monkeypatch.setenv("WATCHER_TICK_SLEEP_SECONDS", "0.05")
+    monkeypatch.setenv("WATCHER_DEBOUNCE_MS", "0")
     monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    monkeypatch.setenv("PKM_SETTINGS_PROFILE", "lab")
     monkeypatch.setenv("STORE_BACKEND", "memory")
 
-    youtube_md = _write_youtube_settings(vault_root, {"youtubeSync.enabled": True})
-    youtube_md.unlink()
+    registry.run_registry_once(config_path)
 
-    result = handle_settings_local_delta(
-        vault_root=vault_root,
-        rel_path=SETTINGS_YOUTUBE_REL,
-        previous_values={"youtubeSync.enabled": True},
+    youtube_md = _write_youtube_settings(vault_root, {"youtubeSync.enabled": True})
+    _touch(youtube_md, 1_700_000_100.0)
+    registry.run_registry_once(config_path)
+
+    youtube_md.unlink()
+    # Exercise the production race window: a compiler-source delta in the
+    # same tick must not suppress the authority-bearing owner-file reset.
+    source_md = vault_root / "settings" / "runtime-source.md"
+    source_md.write_text("---\n{}\n---\n", encoding="utf-8")
+    _touch(source_md, 1_700_000_101.0)
+
+    summaries = registry.run_registry_once(config_path)
+    total_deletions = sum(
+        int(summary.get("runtime_gating_owner_file_deletions_in_tick", 0))
+        for summary in summaries.values()
+    )
+    total_receipts = sum(
+        int(summary.get("settings_receipts_in_tick", 0))
+        for summary in summaries.values()
     )
 
-    assert result.errors == ()
-    assert result.values == {"youtubeSync.enabled": False}
-    assert [(receipt.key, receipt.old_value, receipt.new_value) for receipt in result.receipts] == [
-        ("youtubeSync.enabled", True, None)
+    assert total_deletions == 1
+    assert total_receipts == 1
+    rows = [
+        row
+        for row in query_settings_receipts(outbox_path=outbox_path).rows
+        if row.key == "youtubeSync.enabled"
+    ]
+    assert [(row.old_value, row.new_value) for row in rows] == [
+        (False, True),
+        (True, None),
     ]
     assert SettingsService().resolve_accepted_runtime_gating(
         VaultManager().validate_vault(vault_root)

--- a/tests/watcher/test_settings_delta_receipts.py
+++ b/tests/watcher/test_settings_delta_receipts.py
@@ -10,6 +10,7 @@ import pytest
 import yaml
 
 import app.watcher.registry as registry
+import app.watcher.settings_delta as settings_delta_module
 import app.watcher.watcher as legacy_watcher
 from app.vault.manager import VaultManager
 from app.vault.markdown_settings import MarkdownSettingsStore
@@ -785,6 +786,113 @@ def test_sync_arrival_revalidates_exact_bytes_after_git_provenance_probe(
     assert result.receipts == ()
     assert result.errors and "changed during provenance inspection" in result.errors[0]
     assert not query_settings_receipts(outbox_path=outbox_path).rows
+
+
+def test_sync_arrival_defers_edit_after_final_provenance_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault_root = tmp_path / "vault"
+    initialize_test_vault(vault_root)
+    outbox_path = tmp_path / "outbox.jsonl"
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    subprocess.run(["git", "init", "-q"], cwd=vault_root, check=True)
+    subprocess.run(["git", "config", "user.name", "Sync Test"], cwd=vault_root, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "sync-test@example.invalid"],
+        cwd=vault_root,
+        check=True,
+    )
+    subprocess.run(["git", "add", "settings"], cwd=vault_root, check=True)
+    subprocess.run(["git", "commit", "-qm", "baseline"], cwd=vault_root, check=True)
+    youtube_md = _write_youtube_settings(vault_root, {"youtubeSync.enabled": True})
+    subprocess.run(["git", "add", "settings/youtube.md"], cwd=vault_root, check=True)
+    subprocess.run(["git", "commit", "-qm", "sync arrival"], cwd=vault_root, check=True)
+
+    real_capture = settings_delta_module._capture_settings_snapshot
+    captures = 0
+
+    def _capture_then_edit(path: Path):  # type: ignore[no-untyped-def]
+        nonlocal captures
+        snapshot = real_capture(path)
+        captures += 1
+        if captures == 2:
+            path.write_text(
+                f"{path.read_text(encoding='utf-8')}local edit after provenance\n",
+                encoding="utf-8",
+            )
+        return snapshot
+
+    monkeypatch.setattr(
+        settings_delta_module,
+        "_capture_settings_snapshot",
+        _capture_then_edit,
+    )
+    result = handle_settings_detected_delta(
+        vault_root=vault_root,
+        rel_path=SETTINGS_YOUTUBE_REL,
+        previous_values={"youtubeSync.enabled": False},
+    )
+
+    assert result.deferred is True
+    assert result.receipts == ()
+    assert result.errors and "changed before governed processing" in result.errors[0]
+    assert not query_settings_receipts(outbox_path=outbox_path).rows
+    assert youtube_md.read_text(encoding="utf-8").endswith(
+        "local edit after provenance\n"
+    )
+
+
+def test_sync_deletion_defers_recreation_after_final_provenance_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault_root = tmp_path / "vault"
+    initialize_test_vault(vault_root)
+    outbox_path = tmp_path / "outbox.jsonl"
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    youtube_md = _write_youtube_settings(vault_root, {"youtubeSync.enabled": True})
+    subprocess.run(["git", "init", "-q"], cwd=vault_root, check=True)
+    subprocess.run(["git", "config", "user.name", "Sync Test"], cwd=vault_root, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "sync-test@example.invalid"],
+        cwd=vault_root,
+        check=True,
+    )
+    subprocess.run(["git", "add", "settings"], cwd=vault_root, check=True)
+    subprocess.run(["git", "commit", "-qm", "baseline"], cwd=vault_root, check=True)
+    deleted_payload = youtube_md.read_bytes()
+    youtube_md.unlink()
+    subprocess.run(["git", "add", "-u", "settings/youtube.md"], cwd=vault_root, check=True)
+    subprocess.run(["git", "commit", "-qm", "sync deletion"], cwd=vault_root, check=True)
+
+    real_capture = settings_delta_module._capture_settings_snapshot
+    captures = 0
+
+    def _capture_then_recreate(path: Path):  # type: ignore[no-untyped-def]
+        nonlocal captures
+        snapshot = real_capture(path)
+        captures += 1
+        if captures == 2:
+            path.write_bytes(deleted_payload)
+        return snapshot
+
+    monkeypatch.setattr(
+        settings_delta_module,
+        "_capture_settings_snapshot",
+        _capture_then_recreate,
+    )
+    result = handle_settings_detected_delta(
+        vault_root=vault_root,
+        rel_path=SETTINGS_YOUTUBE_REL,
+        previous_values={"youtubeSync.enabled": True},
+    )
+
+    assert result.deferred is True
+    assert result.receipts == ()
+    assert result.errors and "changed before governed processing" in result.errors[0]
+    assert not query_settings_receipts(outbox_path=outbox_path).rows
+    assert youtube_md.read_bytes() == deleted_payload
 
 
 def test_gitignored_local_settings_edit_is_not_misattributed_as_sync(

--- a/tests/watcher/test_settings_delta_receipts.py
+++ b/tests/watcher/test_settings_delta_receipts.py
@@ -17,6 +17,7 @@ from app.watcher.settings_delta import (
     SETTINGS_LOCAL_REL,
     SETTINGS_YOUTUBE_REL,
     handle_settings_local_delta,
+    handle_settings_sync_arrival,
 )
 from tests.helpers.vault_settings import initialize_test_vault
 
@@ -449,3 +450,79 @@ def test_runtime_gating_key_removal_routes_settings_receipt(
     assert row.value is None
     assert row.old_value is True
     assert row.new_value is None
+
+
+def test_owner_file_deletion_routes_runtime_gating_reset_through_governed_seam(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault_root = tmp_path / "vault"
+    initialize_test_vault(vault_root)
+    outbox_path = tmp_path / "outbox.jsonl"
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+
+    youtube_md = _write_youtube_settings(vault_root, {"youtubeSync.enabled": True})
+    youtube_md.unlink()
+
+    result = handle_settings_local_delta(
+        vault_root=vault_root,
+        rel_path=SETTINGS_YOUTUBE_REL,
+        previous_values={"youtubeSync.enabled": True},
+    )
+
+    assert result.errors == ()
+    assert result.values == {"youtubeSync.enabled": False}
+    assert [(receipt.key, receipt.old_value, receipt.new_value) for receipt in result.receipts] == [
+        ("youtubeSync.enabled", True, None)
+    ]
+    assert SettingsService().resolve_accepted_runtime_gating(
+        VaultManager().validate_vault(vault_root)
+    )["youtubeSync.enabled"].value is False
+
+
+def test_sync_arrival_replay_does_not_emit_human_actor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault_root = tmp_path / "vault"
+    initialize_test_vault(vault_root)
+    outbox_path = tmp_path / "outbox.jsonl"
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    _write_youtube_settings(vault_root, {"youtubeSync.enabled": True})
+
+    result = handle_settings_sync_arrival(
+        vault_root=vault_root,
+        rel_path=SETTINGS_YOUTUBE_REL,
+        previous_values={"youtubeSync.enabled": False},
+    )
+
+    assert result.errors == ()
+    assert [receipt.actor for receipt in result.receipts] == ["sync"]
+    assert [receipt.surface for receipt in result.receipts] == ["sync"]
+    rows = query_settings_receipts(outbox_path=outbox_path).rows
+    assert [row.actor for row in rows if row.key == "youtubeSync.enabled"] == ["sync"]
+
+
+def test_cross_file_runtime_gating_residue_is_reported_and_unaccepted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault_root = tmp_path / "vault"
+    initialize_test_vault(vault_root)
+    outbox_path = tmp_path / "outbox.jsonl"
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    _write_local_settings(vault_root, {"youtubeSync.enabled": True})
+
+    result = handle_settings_local_delta(
+        vault_root=vault_root,
+        rel_path=SETTINGS_LOCAL_REL,
+        previous_values=None,
+    )
+
+    assert result.values == {"enableAutoIndexing": True, "enableVaultWatcher": True, "youtubeSync.runnerEnabled": False}
+    assert result.receipts == ()
+    assert any("owned by youtube.md" in error for error in result.errors)
+    assert SettingsService().resolve_accepted_runtime_gating(
+        VaultManager().validate_vault(vault_root)
+    )["youtubeSync.enabled"].value is False
+    assert not [row for row in query_settings_receipts(outbox_path=outbox_path).rows if row.key == "youtubeSync.enabled"]

--- a/tests/watcher/test_settings_delta_receipts.py
+++ b/tests/watcher/test_settings_delta_receipts.py
@@ -10,17 +10,22 @@ import pytest
 import yaml
 
 import app.watcher.registry as registry
+import app.watcher.watcher as legacy_watcher
 from app.vault.manager import VaultManager
 from app.vault.markdown_settings import MarkdownSettingsStore
 from app.vault.settings_service import RUNTIME_GATING_SETTINGS, SettingsService
 from app.receipts.settings_receipts import query_settings_receipts
+from app.watcher.config import WatcherConfig
 from app.watcher.settings_delta import (
     SETTINGS_LOCAL_REL,
     SETTINGS_YOUTUBE_REL,
+    handle_settings_detected_delta,
     handle_settings_local_delta,
     handle_settings_sync_arrival,
+    settings_delta_state_values,
     settings_delta_is_sync_arrival,
 )
+from app.watcher.state import WatcherState
 from tests.helpers.vault_settings import initialize_test_vault
 
 pytestmark = pytest.mark.not_pg
@@ -513,6 +518,159 @@ def test_owner_file_deletion_routes_runtime_gating_reset_through_governed_seam(
     )["youtubeSync.enabled"].value is False
 
 
+def test_local_owner_file_deletion_uses_retained_identity_for_governed_reset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault_root = tmp_path / "vault"
+    initialize_test_vault(vault_root)
+    outbox_path = tmp_path / "outbox.jsonl"
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    _write_local_settings(vault_root, {"youtubeSync.runnerEnabled": True})
+
+    accepted = handle_settings_local_delta(
+        vault_root=vault_root,
+        rel_path=SETTINGS_LOCAL_REL,
+        previous_values={"youtubeSync.runnerEnabled": False},
+    )
+    assert accepted.errors == ()
+    retained_state = settings_delta_state_values(accepted)
+
+    (vault_root / SETTINGS_LOCAL_REL).unlink()
+    reset = handle_settings_local_delta(
+        vault_root=vault_root,
+        rel_path=SETTINGS_LOCAL_REL,
+        previous_values=retained_state,
+    )
+
+    assert reset.deferred is False
+    assert reset.errors == ()
+    runner_receipts = [
+        receipt
+        for receipt in reset.receipts
+        if receipt.key == "youtubeSync.runnerEnabled"
+    ]
+    assert [(receipt.old_value, receipt.new_value) for receipt in runner_receipts] == [
+        (True, None)
+    ]
+    assert runner_receipts[0].vault_id == accepted.vault_id
+    assert runner_receipts[0].local_instance_id == accepted.local_instance_id
+
+
+def test_registry_retries_blocked_owner_file_deletion_until_receipted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import app.write_guard as write_guard_module
+
+    vault_root = tmp_path / "vault"
+    initialize_test_vault(vault_root)
+    config_path = tmp_path / "watchers.yaml"
+    _write_watchers_config(config_path)
+    outbox_path = tmp_path / "outbox.jsonl"
+    monkeypatch.setenv("WATCHER_ENABLE", "1")
+    monkeypatch.setenv("WATCHER_VAULT_PATH", str(vault_root))
+    monkeypatch.setenv("WATCHER_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.setenv("WATCHER_SCOPE_GLOB", "settings/*.md")
+    monkeypatch.setenv("WATCHER_SUMMARY_INTERVAL", "0")
+    monkeypatch.setenv("WATCHER_DEBOUNCE_MS", "0")
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    monkeypatch.setenv("PKM_SETTINGS_PROFILE", "lab")
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    registry.run_registry_once(config_path)
+
+    youtube_md = _write_youtube_settings(vault_root, {"youtubeSync.enabled": True})
+    _touch(youtube_md, 1_700_000_300.0)
+    registry.run_registry_once(config_path)
+    youtube_md.unlink()
+
+    with patch.object(
+        write_guard_module.DEFAULT_WRITE_GUARD,
+        "snapshot_fn",
+        return_value={"state": "safe_mode", "reason": "maintenance"},
+    ):
+        blocked = registry.run_registry_once(config_path)
+    assert sum(
+        int(summary.get("settings_write_errors_in_tick", 0))
+        for summary in blocked.values()
+    ) >= 1
+
+    with patch.object(
+        write_guard_module.DEFAULT_WRITE_GUARD,
+        "snapshot_fn",
+        return_value={"state": "healthy", "reason": None},
+    ):
+        recovered = registry.run_registry_once(config_path)
+    assert sum(
+        int(summary.get("settings_receipts_in_tick", 0))
+        for summary in recovered.values()
+    ) == 1
+    rows = [
+        row
+        for row in query_settings_receipts(outbox_path=outbox_path).rows
+        if row.key == "youtubeSync.enabled"
+    ]
+    assert [(row.old_value, row.new_value) for row in rows] == [
+        (False, True),
+        (True, None),
+    ]
+
+
+def test_legacy_watcher_retries_blocked_owner_file_deletion_until_receipted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import app.write_guard as write_guard_module
+
+    vault_root = tmp_path / "vault"
+    initialize_test_vault(vault_root)
+    outbox_path = tmp_path / "outbox.jsonl"
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    cfg = WatcherConfig(
+        enable=True,
+        vault_path=vault_root,
+        scope_glob="settings/*.md",
+        debounce_ms=0,
+        rate_limit_per_min=30,
+        state_path=tmp_path / "legacy-state.json",
+        stop_file=tmp_path / "WATCHER_STOP",
+        outbox_path=outbox_path,
+        summary_interval=0,
+        tick_sleep_seconds=0.0,
+        tick_log_path=tmp_path / "legacy-tick.jsonl",
+    )
+    state = WatcherState()
+    legacy_watcher.run_tick(cfg, state, now=1_700_000_400.0)
+    youtube_md = _write_youtube_settings(vault_root, {"youtubeSync.enabled": True})
+    _touch(youtube_md, 1_700_000_401.0)
+    legacy_watcher.run_tick(cfg, state, now=1_700_000_401.0)
+    youtube_md.unlink()
+
+    with patch.object(
+        write_guard_module.DEFAULT_WRITE_GUARD,
+        "snapshot_fn",
+        return_value={"state": "safe_mode", "reason": "maintenance"},
+    ):
+        blocked = legacy_watcher.run_tick(cfg, state, now=1_700_000_402.0)
+    assert int(blocked.get("settings_write_errors_in_tick", 0)) >= 1
+
+    with patch.object(
+        write_guard_module.DEFAULT_WRITE_GUARD,
+        "snapshot_fn",
+        return_value={"state": "healthy", "reason": None},
+    ):
+        recovered = legacy_watcher.run_tick(cfg, state, now=1_700_000_403.0)
+    assert int(recovered.get("settings_receipts_in_tick", 0)) == 1
+    rows = [
+        row
+        for row in query_settings_receipts(outbox_path=outbox_path).rows
+        if row.key == "youtubeSync.enabled"
+    ]
+    assert [(row.old_value, row.new_value) for row in rows] == [
+        (False, True),
+        (True, None),
+    ]
+
+
 def test_sync_arrival_replay_does_not_emit_human_actor(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -581,6 +739,52 @@ def test_runtime_gating_sync_arrival_unwired_uses_production_dispatch(
     assert [(row.surface, row.actor, row.new_value) for row in rows] == [
         ("sync", "sync", True)
     ]
+
+
+def test_sync_arrival_revalidates_exact_bytes_after_git_provenance_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault_root = tmp_path / "vault"
+    initialize_test_vault(vault_root)
+    outbox_path = tmp_path / "outbox.jsonl"
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    subprocess.run(["git", "init", "-q"], cwd=vault_root, check=True)
+    subprocess.run(["git", "config", "user.name", "Sync Test"], cwd=vault_root, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "sync-test@example.invalid"],
+        cwd=vault_root,
+        check=True,
+    )
+    subprocess.run(["git", "add", "settings"], cwd=vault_root, check=True)
+    subprocess.run(["git", "commit", "-qm", "baseline"], cwd=vault_root, check=True)
+    _write_youtube_settings(vault_root, {"youtubeSync.enabled": True})
+    subprocess.run(["git", "add", "settings/youtube.md"], cwd=vault_root, check=True)
+    subprocess.run(["git", "commit", "-qm", "sync arrival"], cwd=vault_root, check=True)
+
+    real_run = subprocess.run
+    raced = False
+
+    def _run_with_race(*args, **kwargs):  # type: ignore[no-untyped-def]
+        nonlocal raced
+        result = real_run(*args, **kwargs)
+        command = args[0] if args else kwargs.get("args")
+        if not raced and isinstance(command, list) and "status" in command:
+            raced = True
+            _write_youtube_settings(vault_root, {"youtubeSync.enabled": False})
+        return result
+
+    monkeypatch.setattr("app.watcher.settings_delta.subprocess.run", _run_with_race)
+    result = handle_settings_detected_delta(
+        vault_root=vault_root,
+        rel_path=SETTINGS_YOUTUBE_REL,
+        previous_values={"youtubeSync.enabled": False},
+    )
+
+    assert result.deferred is True
+    assert result.receipts == ()
+    assert result.errors and "changed during provenance inspection" in result.errors[0]
+    assert not query_settings_receipts(outbox_path=outbox_path).rows
 
 
 def test_gitignored_local_settings_edit_is_not_misattributed_as_sync(

--- a/tests/watcher/test_settings_delta_receipts.py
+++ b/tests/watcher/test_settings_delta_receipts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import subprocess
 from pathlib import Path
 from textwrap import dedent
 from unittest.mock import patch
@@ -18,6 +19,7 @@ from app.watcher.settings_delta import (
     SETTINGS_YOUTUBE_REL,
     handle_settings_local_delta,
     handle_settings_sync_arrival,
+    settings_delta_is_sync_arrival,
 )
 from tests.helpers.vault_settings import initialize_test_vault
 
@@ -532,6 +534,116 @@ def test_sync_arrival_replay_does_not_emit_human_actor(
     assert [receipt.surface for receipt in result.receipts] == ["sync"]
     rows = query_settings_receipts(outbox_path=outbox_path).rows
     assert [row.actor for row in rows if row.key == "youtubeSync.enabled"] == ["sync"]
+
+
+def test_runtime_gating_sync_arrival_unwired_uses_production_dispatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault_root = tmp_path / "vault"
+    VaultManager().initialize_vault(vault_root, machine_role="primary", remember=False)
+    config_path = tmp_path / "watchers.yaml"
+    outbox_path = tmp_path / "outbox.jsonl"
+    _write_watchers_config(config_path)
+    subprocess.run(["git", "init", "-q"], cwd=vault_root, check=True)
+    subprocess.run(["git", "config", "user.name", "Sync Test"], cwd=vault_root, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "sync-test@example.invalid"],
+        cwd=vault_root,
+        check=True,
+    )
+    subprocess.run(["git", "add", "settings"], cwd=vault_root, check=True)
+    subprocess.run(["git", "commit", "-qm", "baseline"], cwd=vault_root, check=True)
+
+    monkeypatch.setenv("WATCHER_ENABLE", "1")
+    monkeypatch.setenv("WATCHER_VAULT_PATH", str(vault_root))
+    monkeypatch.setenv("WATCHER_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.setenv("WATCHER_SCOPE_GLOB", "settings/*.md")
+    monkeypatch.setenv("WATCHER_SUMMARY_INTERVAL", "0")
+    monkeypatch.setenv("WATCHER_TICK_SLEEP_SECONDS", "0.05")
+    monkeypatch.setenv("WATCHER_DEBOUNCE_MS", "0")
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    monkeypatch.setenv("PKM_SETTINGS_PROFILE", "lab")
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    registry.run_registry_once(config_path)
+
+    youtube_md = _write_youtube_settings(vault_root, {"youtubeSync.enabled": True})
+    _touch(youtube_md, 1_700_000_200.0)
+    subprocess.run(["git", "add", "settings/youtube.md"], cwd=vault_root, check=True)
+    subprocess.run(["git", "commit", "-qm", "sync arrival"], cwd=vault_root, check=True)
+
+    registry.run_registry_once(config_path)
+
+    rows = [
+        row
+        for row in query_settings_receipts(outbox_path=outbox_path).rows
+        if row.key == "youtubeSync.enabled"
+    ]
+    assert [(row.surface, row.actor, row.new_value) for row in rows] == [
+        ("sync", "sync", True)
+    ]
+
+
+def test_gitignored_local_settings_edit_is_not_misattributed_as_sync(
+    tmp_path: Path,
+) -> None:
+    vault_root = tmp_path / "vault"
+    VaultManager().initialize_vault(vault_root, machine_role="primary", remember=False)
+    subprocess.run(["git", "init", "-q"], cwd=vault_root, check=True)
+    subprocess.run(["git", "config", "user.name", "Sync Test"], cwd=vault_root, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "sync-test@example.invalid"],
+        cwd=vault_root,
+        check=True,
+    )
+    subprocess.run(["git", "add", "settings"], cwd=vault_root, check=True)
+    subprocess.run(["git", "commit", "-qm", "baseline"], cwd=vault_root, check=True)
+
+    _write_local_settings(vault_root, {"youtubeSync.runnerEnabled": True})
+
+    assert settings_delta_is_sync_arrival(
+        vault_root=vault_root,
+        rel_path=SETTINGS_LOCAL_REL,
+    ) is False
+
+
+def test_runtime_gating_replay_ignores_durable_accepted_baseline_is_repaired(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import app.write_guard as _wg_module
+
+    vault_root = tmp_path / "vault"
+    initialize_test_vault(vault_root)
+    outbox_path = tmp_path / "outbox.jsonl"
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    _write_youtube_settings(vault_root, {"youtubeSync.enabled": True})
+    accepted = handle_settings_local_delta(
+        vault_root=vault_root,
+        rel_path=SETTINGS_YOUTUBE_REL,
+        previous_values={"youtubeSync.enabled": False},
+    )
+    assert len(accepted.receipts) == 1
+
+    with patch.object(
+        _wg_module.DEFAULT_WRITE_GUARD,
+        "snapshot_fn",
+        return_value={"state": "safe_mode", "reason": "maintenance window"},
+    ):
+        replay = handle_settings_local_delta(
+            vault_root=vault_root,
+            rel_path=SETTINGS_YOUTUBE_REL,
+            previous_values=None,
+        )
+
+    assert replay.errors == ()
+    assert replay.receipts == ()
+    assert replay.values == {"youtubeSync.enabled": True}
+    rows = [
+        row
+        for row in query_settings_receipts(outbox_path=outbox_path).rows
+        if row.key == "youtubeSync.enabled"
+    ]
+    assert len(rows) == 1
 
 
 def test_cross_file_runtime_gating_residue_is_reported_and_unaccepted(

--- a/tests/watcher/test_settings_delta_receipts.py
+++ b/tests/watcher/test_settings_delta_receipts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import os
 import subprocess
 from pathlib import Path
@@ -55,7 +56,7 @@ def test_delta_apply_receipted(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     rows = query_settings_receipts(outbox_path=outbox_path).rows
     row = next(row for row in rows if row.key == "enableAutoIndexing")
     assert row.surface == "file"
-    assert row.file == str(vault_root / SETTINGS_LOCAL_REL)
+    assert row.file == SETTINGS_LOCAL_REL.name
     assert row.old_value is True
     assert row.new_value is False
 
@@ -893,6 +894,242 @@ def test_sync_deletion_defers_recreation_after_final_provenance_snapshot(
     assert result.errors and "changed before governed processing" in result.errors[0]
     assert not query_settings_receipts(outbox_path=outbox_path).rows
     assert youtube_md.read_bytes() == deleted_payload
+
+
+def test_sync_arrival_defers_mutation_after_processing_capture_three(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Capture three is not acceptance when the live generation changes next."""
+
+    vault_root = tmp_path / "vault"
+    initialize_test_vault(vault_root)
+    outbox_path = tmp_path / "outbox.jsonl"
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    subprocess.run(["git", "init", "-q"], cwd=vault_root, check=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Sync Test"], cwd=vault_root, check=True
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "sync-test@example.invalid"],
+        cwd=vault_root,
+        check=True,
+    )
+    subprocess.run(["git", "add", "settings"], cwd=vault_root, check=True)
+    subprocess.run(["git", "commit", "-qm", "baseline"], cwd=vault_root, check=True)
+    _write_youtube_settings(vault_root, {"youtubeSync.enabled": True})
+    subprocess.run(["git", "add", "settings/youtube.md"], cwd=vault_root, check=True)
+    subprocess.run(["git", "commit", "-qm", "sync arrival"], cwd=vault_root, check=True)
+
+    real_capture = settings_delta_module._capture_settings_snapshot
+    captures = 0
+
+    def _capture_then_mutate(path: Path):  # type: ignore[no-untyped-def]
+        nonlocal captures
+        snapshot = real_capture(path)
+        captures += 1
+        if captures == 3:
+            path.write_text(
+                f"{path.read_text(encoding='utf-8')}generation after capture three\n",
+                encoding="utf-8",
+            )
+        return snapshot
+
+    monkeypatch.setattr(
+        settings_delta_module,
+        "_capture_settings_snapshot",
+        _capture_then_mutate,
+    )
+    result = handle_settings_detected_delta(
+        vault_root=vault_root,
+        rel_path=SETTINGS_YOUTUBE_REL,
+        previous_values={"youtubeSync.enabled": False},
+    )
+
+    assert captures >= 4
+    assert result.deferred is True
+    assert result.receipts == ()
+    assert not query_settings_receipts(outbox_path=outbox_path).rows
+    assert (
+        SettingsService().resolve_accepted_runtime_gating(
+            VaultManager().validate_vault(vault_root)
+        )["youtubeSync.enabled"].value
+        is False
+    )
+
+
+def test_registry_generation_race_after_processing_snapshot_is_not_stranded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Acceptance and watcher state advance must name the same file generation."""
+
+    vault_root = tmp_path / "vault"
+    initialize_test_vault(vault_root)
+    config_path = tmp_path / "watchers.yaml"
+    outbox_path = tmp_path / "outbox.jsonl"
+    config_path.write_text(
+        dedent(
+            """\
+            version: 1
+            watchers:
+              - name: panel
+                scope_glob: ""
+                debounce_ms: 0
+                rate_limit_per_min: 30
+                emit_event: "panel.scan.requested"
+            """
+        ),
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init", "-q"], cwd=vault_root, check=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Sync Test"], cwd=vault_root, check=True
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "sync-test@example.invalid"],
+        cwd=vault_root,
+        check=True,
+    )
+    subprocess.run(["git", "add", "settings"], cwd=vault_root, check=True)
+    subprocess.run(["git", "commit", "-qm", "baseline"], cwd=vault_root, check=True)
+
+    monkeypatch.setenv("WATCHER_ENABLE", "1")
+    monkeypatch.setenv("WATCHER_VAULT_PATH", str(vault_root))
+    monkeypatch.setenv("WATCHER_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.setenv("WATCHER_SCOPE_GLOB", "settings/*.md")
+    monkeypatch.setenv("WATCHER_SUMMARY_INTERVAL", "0")
+    monkeypatch.setenv("WATCHER_TICK_SLEEP_SECONDS", "0.05")
+    monkeypatch.setenv("WATCHER_DEBOUNCE_MS", "0")
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    monkeypatch.setenv("PKM_SETTINGS_PROFILE", "lab")
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    registry.run_registry_once(config_path)
+
+    youtube_md = _write_youtube_settings(
+        vault_root, {"youtubeSync.enabled": True}
+    )
+    _touch(youtube_md, 1_700_000_500.0)
+    subprocess.run(["git", "add", "settings/youtube.md"], cwd=vault_root, check=True)
+    subprocess.run(["git", "commit", "-qm", "sync arrival"], cwd=vault_root, check=True)
+
+    original_update = SettingsService.update_setting
+    raced = False
+
+    def _update_after_processing_snapshot(
+        self: SettingsService,
+        context,
+        key,
+        value,
+        **kwargs,
+    ):
+        nonlocal raced
+        if not raced and key == "youtubeSync.enabled":
+            raced = True
+            youtube_md.write_text(
+                f"{youtube_md.read_text(encoding='utf-8')}post-snapshot generation\n",
+                encoding="utf-8",
+            )
+        return original_update(self, context, key, value, **kwargs)
+
+    with patch.object(
+        SettingsService,
+        "update_setting",
+        _update_after_processing_snapshot,
+    ):
+        raced_summaries = registry.run_registry_once(config_path)
+
+    assert raced is True
+    assert sum(
+        int(summary.get("settings_receipts_in_tick", 0))
+        for summary in raced_summaries.values()
+    ) == 0
+    assert not query_settings_receipts(outbox_path=outbox_path).rows
+    context = VaultManager().validate_vault(vault_root)
+    assert (
+        SettingsService().resolve_accepted_runtime_gating(context)[
+            "youtubeSync.enabled"
+        ].value
+        is False
+    )
+
+    newer_digest = hashlib.sha256(youtube_md.read_bytes()).hexdigest()
+    panel_state = WatcherState.load(
+        tmp_path / "state" / "watcher_state_panel.json"
+    )
+    assert panel_state.last_hash(str(SETTINGS_YOUTUBE_REL)) != newer_digest
+
+    recovered_summaries = registry.run_registry_once(config_path)
+    assert sum(
+        int(summary.get("settings_receipts_in_tick", 0))
+        for summary in recovered_summaries.values()
+    ) == 1
+    rows = query_settings_receipts(outbox_path=outbox_path).rows
+    assert [
+        (row.surface, row.actor, row.new_value)
+        for row in rows
+        if row.key == "youtubeSync.enabled"
+    ] == [("file", "human", True)]
+    assert (
+        SettingsService().resolve_accepted_runtime_gating(context)[
+            "youtubeSync.enabled"
+        ].value
+        is True
+    )
+    recovered_state = WatcherState.load(
+        tmp_path / "state" / "watcher_state_panel.json"
+    )
+    assert recovered_state.last_hash(str(SETTINGS_YOUTUBE_REL)) == newer_digest
+
+
+def test_registry_retries_non_deletion_receipt_failure_without_marking_seen(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A transient durable-receipt failure leaves an owner delta pending."""
+
+    vault_root = tmp_path / "vault"
+    initialize_test_vault(vault_root)
+    config_path = tmp_path / "watchers.yaml"
+    outbox_path = tmp_path / "outbox.jsonl"
+    _write_watchers_config(config_path)
+    monkeypatch.setenv("WATCHER_ENABLE", "1")
+    monkeypatch.setenv("WATCHER_VAULT_PATH", str(vault_root))
+    monkeypatch.setenv("WATCHER_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.setenv("WATCHER_SCOPE_GLOB", "settings/*.md")
+    monkeypatch.setenv("WATCHER_SUMMARY_INTERVAL", "0")
+    monkeypatch.setenv("WATCHER_TICK_SLEEP_SECONDS", "0.05")
+    monkeypatch.setenv("WATCHER_DEBOUNCE_MS", "0")
+    monkeypatch.setenv("INDEX_OUTBOX_PATH", str(outbox_path))
+    monkeypatch.setenv("PKM_SETTINGS_PROFILE", "lab")
+    monkeypatch.setenv("STORE_BACKEND", "memory")
+    registry.run_registry_once(config_path)
+
+    youtube_md = _write_youtube_settings(
+        vault_root, {"youtubeSync.enabled": True}
+    )
+    _touch(youtube_md, 1_700_000_510.0)
+    with patch(
+        "app.vault.settings_service.emit_durable_settings_write_receipt_once",
+        side_effect=RuntimeError("synthetic durable sink failure"),
+    ):
+        failed_summaries = registry.run_registry_once(config_path)
+
+    assert sum(
+        int(summary.get("settings_write_errors_in_tick", 0))
+        for summary in failed_summaries.values()
+    ) >= 1
+    assert not query_settings_receipts(outbox_path=outbox_path).rows
+
+    recovered_summaries = registry.run_registry_once(config_path)
+    assert sum(
+        int(summary.get("settings_receipts_in_tick", 0))
+        for summary in recovered_summaries.values()
+    ) == 1
+    rows = query_settings_receipts(outbox_path=outbox_path).rows
+    assert [
+        (row.old_value, row.new_value)
+        for row in rows
+        if row.key == "youtubeSync.enabled"
+    ] == [(False, True)]
 
 
 def test_gitignored_local_settings_edit_is_not_misattributed_as_sync(


### PR DESCRIPTION
## Change Lane
- [x] Implementation lane
- [ ] Docs authoring lane
- [ ] Governance lane

Governing-Issue: #3964

## Linked Issue
Closes #3964

## SBS Impact
- Primary subsystem: Product/Runtime System — settings authority and runtime gating
- Secondary subsystem(s): watcher/registry and YouTube Source Sync
- Write class: mechanical durable receipt and derived runtime setting
- Authority impact: consumes existing owner-file authority; no new authority source
- Persistence impact: durable accepted settings receipts; rebuildable runtime projection
- Derived/rebuildable impact: watcher consumers rebuild accepted gating state from governed receipts
- Human knowledge impact: none
- Memory impact: none
- Retrieval/context impact: none
- Sync/deployment impact: runtime source-sync enablement and frequency changes apply only after accepted watcher receipts
- External boundary impact: none
- New or changed contract: accepted runtime-gating accessor, deletion reset, and fail-closed watcher application
- Owner-doc impact: owner docs updated in this PR
- Transition debt impact: reduces the YSS runtime-gating transition row
- Fitness rule impact: strengthens
- Boundary risk: settings-file authority to watcher runtime consumer; covered by production-path tests

## Owner-Doc Writeback
- [ ] No owner-doc change implied.
- [x] Owner-doc updated in this PR.
- [ ] Owner-doc follow-up issue created and linked.

## Summary
- expose only accepted `youtubeSync.enabled` and `youtubeSync.runnerEnabled` values to future YSS-06/YSS-10 runtime consumers
- apply watcher updates and owner-file deletion resets atomically while preserving fail-closed authority and retry state
- replay accepted receipts in durable operation order, bind sync provenance to exact observed bytes, and close the `write_missing` WriteGuard census
- align YSS and runtime-control owner docs with the repaired authority contract

## Implementation Scope Check
- [x] Change stays within the linked Issue scope.
- [x] Constraints from the linked Issue were followed.
- [x] Acceptance Criteria from the linked Issue are satisfied.
- [x] Docs were updated in the same change when behavior/contracts changed.
- [x] Owner docs and roadmap/plan wording were updated when this PR turns a tracked backlog item into shipped reality.

## Docs Authoring Check
- [ ] This PR only changes approved docs-authoring surfaces.
- [ ] No code, runtime behavior, contracts, or shipped reality changed.
- [ ] This PR prepares or clarifies authoritative docs/specification and may later feed `docs-to-issue` extraction.

## Governance Lane Check
- [ ] This PR only changes approved governance surfaces.
- [ ] The change is limited to repo governance, agent workflow, or lightweight enforcement.
- [ ] No product/runtime implementation or shipped feature behavior changed.

## Review Repair — attempt 1
- Repaired all six stable `review/code_correctness` findings: production sync provenance dispatch, durable replay baseline, vault/generation receipt identity, issue-bounded YSS accessor scope, fail-loud idempotent receipt durability, and scaffold create-race protection.
- Updated the WriteGuard census for the live `write_frontmatter` site at line 614 and removed the obsolete scaffold entry after scaffolding moved to exclusive `write_missing`.
- Repair commit: `492d0f76` (published from exact reviewed base `699ddb45`).
- Host full release gate: `10220 passed, 38 skipped, 272 deselected, 18 xfailed`; exit 0; temp root `/tmp/yss3964-review-repair-final.tE3FQu`.
- No deploy or merge was performed.

## Review Repair — attempt 2
- Published exact head: `cc07a199475a89ac3dcc2816b9f7155a6adc67f8` (rebased onto `origin/main` at `61aa6357601cc952e1d9e1bd6425d4ad0e5c2c7d`).
- `runtime_gating_deletion_reset_retry`: standard repair 1/2 — new stable mechanism; retain identity-bound deletion state and retry blocked/deferred resets in both watcher loops.
- `accepted_receipt_order_and_dedup`: standard repair 2/2 — continuation; replay serialized durable append order and deduplicate validated operation identities.
- `sync_arrival_byte_provenance`: standard repair 2/2 — continuation; require observed bytes to equal the clean Git snapshot and defer provenance races.
- `write_missing_writeguard_census`: standard repair 2/2 — continuation; close the production `write_missing` caller census and classify guarded/bootstrap sites.
- Exact five Issue Verify targets: `5 passed`.
- Expanded focused watcher/settings/census set: `136 passed` both before and after the required `origin/main` rebase.
- Pre-rebase repaired-tree full non-PG host gate: `10226 passed, 38 skipped, 272 deselected, 18 xfailed`; direct exit 0; temp root `/tmp/yss-3964-pytest.Rd6XZ1`.
- Exact published head after rebase: `ruff check app tests companion-ui/companion-app` passed; `mypy app` passed across 792 source files; `python -m app.cli settings-validate --json` returned `ok: true`.
- Per host-slot authority, no second full suite was started after rebase. No deploy or merge was performed.

## Review Repair — capability-escalated attempt 1
- Published exact head: `0a26e37cd507ff14020ff1c66159248ef0730a80`, rebased onto `origin/main` at `e95cd659c8763ef23944c924d4c081fed1103315`.
- Stable binding `review/sync_provenance::sync_arrival_byte_provenance`: capability-escalated repair 1/2 using Sol/high.
- Bound governed watcher processing to the exact process-adjacent observed bytes or verified absence, added a final pre-processing snapshot comparison, and deferred without a receipt when arrival bytes changed after provenance verification.
- Added a snapshot-bound settings store that prevents downstream reopen/rewrite from accepting or clobbering a later local edit while preserving retained local identity for deletion handling.
- Added deterministic regressions for both a present-file edit and a clean Git deletion followed by recreation after the second provenance snapshot; both defer, emit no receipt, and retain the later local bytes.
- Exact five Issue Verify targets: `5 passed`; expanded watcher/settings/YSS/receipt/architecture/census set: `177 passed`.
- Static gates: `ruff check app tests companion-ui/companion-app`, `mypy app` across 793 source files, settings validation, diff check, and the no-hardcoded-settings architecture gate all passed.
- The host runner initially lacked the repo-declared `rfc3339-validator==0.1.4`, matching closed dependency-parity issue #3582. The exact failing node passed with that declared dependency installed only in a task-specific temporary target placed first in `PYTHONPATH`; the shared venv and repository were not mutated. Follow-ups #4009 and #4012 are unrelated.
- Final post-rebase full non-PG host gate on the exact dirty repair tree: `10280 passed, 38 skipped, 273 deselected, 18 xfailed`; direct exit 0 in 570.61s, with no overlapping external full/deploy process. Exact pytest and dependency temp roots were deleted after success.
- No deploy or merge was performed.

## Validation
Implementation lane:
- [x] `ruff check app tests`
- [x] If files under `app/` or `tests/` changed, lint output from `ruff check app tests` is included below or a tooling limitation is stated.
- [x] `mypy app`
- [x] `pytest -q -m "not pg"`
- [x] Additional targeted checks run as needed

Evidence:
- `ruff check app tests companion-ui/companion-app` → `All checks passed!`
- `mypy app` → `Success: no issues found in 793 source files`
- exact five Issue Verify targets → 5 passed
- expanded focused settings/watcher/runtime-gating/receipt/architecture/census set → 177 passed after the final rebase
- `python -m app.cli settings-validate --json` → `ok: true`
- final post-rebase full non-PG host gate on the exact repair tree → 10,280 passed, 38 skipped, 273 deselected, 18 xfailed; direct exit 0 in 570.61s; clean external-process census
- full-suite dependency parity used the repo-declared `rfc3339-validator==0.1.4` from an isolated temporary `PYTHONPATH` target; shared venv/repo unchanged; temporary roots deleted after success

## BuilderOps Routing
- Records/projections/receipts: epic run `yss-delivery-2026-07-19`; learning `lrn_20260719091832_72beb8f7`
- Reason: this slice is coordinated under epic #3915; the full-suite collision learning was captured separately.

## Notes
- Parent epic #3915 remains open.
- Follow-up #4012 is out of scope and does not change this slice contract.

## Review Repair — capability-escalated attempt 2 / path-safety attempt 1
- Published exact head: `6de96c8d60d051dfdc1a511729b5bf5da2f07b76`, containing `origin/main` at `e95cd659c8763ef23944c924d4c081fed1103315`.
- `review/sync_provenance::sync_arrival_byte_provenance`: capability-escalated repair 2/2 FINAL. Generation verification now occurs inside the durable-receipt lock; watcher/registry advance only the processed digest, invalidate cached state on defer/failure, and retry ordinary receipt failures. Capture-three/process-adjacent regressions prove no stale receipt or acceptance and no stranded newer digest.
- `review/secret_safety::settings_receipt_vault_path_disclosure`: standard repair 1/2. Durable receipts persist only the registered owner filename; raw JSONL and fresh-accessor recovery tests prove no vault path disclosure.
- Corrected the owner-doc durable seam name to `emit_durable_settings_write_receipt_once`.
- Exact five ACs plus new regressions: `9 passed`; primary watcher/YSS files: `37 passed`; expanded focused set: `195 passed`; architecture/hardcoded gates: `7 passed`.
- Static gates: Ruff passed; MyPy passed across 793 files; settings validation and diff check passed.
- Exact pre-publication non-PG full: `10284 passed, 38 skipped, 273 deselected, 18 xfailed`; direct rc 0 in 551.01s with no external full/deploy overlap. Declared `rfc3339-validator==0.1.4` was loaded from a task-isolated temporary target; shared venv/repo unchanged; exact temp roots removed.
- Reject source: https://github.com/RasmusTho/agentic-pkm-mvp/pull/4013#issuecomment-5019244560
- Clean review streak resets to 0/2 on this head. No deploy or merge was performed.