### PR TITLE
Fix runtime-start contract test stability

### DIFF
--- a/tests/helpers/runtime_start_harness.py
+++ b/tests/helpers/runtime_start_harness.py
@@ -12,13 +12,14 @@ from pathlib import Path
 
 
 class RuntimeStartHarnessTimeout(TimeoutError):
-    """A runtime-start fixture failed to begin or stopped making progress."""
+    """A runtime-start fixture exceeded one of its bounded deadlines."""
 
     def __init__(
         self,
         *,
         stage: str,
         timeout_seconds: float,
+        elapsed_seconds: float,
         command: Sequence[str],
         progress_tail: str,
         stdout: str,
@@ -26,16 +27,27 @@ class RuntimeStartHarnessTimeout(TimeoutError):
     ) -> None:
         self.stage = stage
         self.timeout_seconds = timeout_seconds
+        self.elapsed_seconds = elapsed_seconds
         self.command = tuple(command)
         self.progress_tail = progress_tail
         self.stdout = stdout
         self.stderr = stderr
+        reason = (
+            "exceeded its non-resettable total deadline"
+            if stage == "total_timeout"
+            else "stopped making observable progress"
+        )
         super().__init__(
-            f"runtime-start harness {stage} after {timeout_seconds:g}s without "
-            f"observable progress; command={list(command)!r}; "
+            f"runtime-start harness {stage} {reason}; "
+            f"elapsed={elapsed_seconds:.3f}s; budget={timeout_seconds:g}s; "
+            f"command={list(command)!r}; "
             f"progress_tail={progress_tail!r}; stdout={stdout[-800:]!r}; "
             f"stderr={stderr[-800:]!r}"
         )
+
+
+class RuntimeStartHarnessCleanupError(RuntimeError):
+    """A runtime-start process group survived the bounded cleanup budget."""
 
 
 def _progress_signature(path: Path) -> tuple[int, int] | None:
@@ -53,29 +65,84 @@ def _progress_tail(path: Path) -> str:
         return ""
 
 
-def _stop_process(process: subprocess.Popen[str]) -> None:
-    if process.poll() is not None:
-        return
+def _process_group_exists(process_group_id: int) -> bool:
     try:
-        if os.name == "posix":
-            os.killpg(process.pid, signal.SIGTERM)
-        else:  # pragma: no cover - exercised by supported Windows hosts
-            process.terminate()
+        os.killpg(process_group_id, 0)
     except ProcessLookupError:
-        return
-    try:
-        process.wait(timeout=1)
-        return
-    except subprocess.TimeoutExpired:
-        pass
-    try:
-        if os.name == "posix":
-            os.killpg(process.pid, signal.SIGKILL)
-        else:  # pragma: no cover - exercised by supported Windows hosts
+        return False
+    except PermissionError:  # pragma: no cover - defensive on restricted hosts
+        return True
+    return True
+
+
+def _wait_for_process_group_exit(
+    process: subprocess.Popen[str],
+    *,
+    process_group_id: int,
+    deadline: float,
+    poll_interval: float = 0.01,
+) -> bool:
+    while time.monotonic() < deadline:
+        process.poll()  # Reap the group leader as soon as it becomes terminal.
+        if not _process_group_exists(process_group_id):
+            return True
+        time.sleep(poll_interval)
+    process.poll()
+    return not _process_group_exists(process_group_id)
+
+
+def _stop_process(
+    process: subprocess.Popen[str], *, cleanup_timeout: float = 2
+) -> None:
+    cleanup_deadline = time.monotonic() + cleanup_timeout
+
+    if os.name != "posix":  # pragma: no cover - exercised by supported Windows hosts
+        if process.poll() is not None:
+            return
+        process.terminate()
+        try:
+            process.wait(timeout=cleanup_timeout / 2)
+            return
+        except subprocess.TimeoutExpired:
             process.kill()
+        try:
+            process.wait(timeout=max(0, cleanup_deadline - time.monotonic()))
+            return
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeStartHarnessCleanupError(
+                "runtime-start process survived bounded cleanup"
+            ) from exc
+
+    process_group_id = process.pid
+    try:
+        os.killpg(process_group_id, signal.SIGTERM)
     except ProcessLookupError:
+        process.poll()
         return
-    process.wait(timeout=1)
+
+    term_deadline = min(cleanup_deadline, time.monotonic() + cleanup_timeout / 2)
+    if _wait_for_process_group_exit(
+        process,
+        process_group_id=process_group_id,
+        deadline=term_deadline,
+    ):
+        return
+
+    try:
+        os.killpg(process_group_id, signal.SIGKILL)
+    except ProcessLookupError:
+        process.poll()
+        return
+    if _wait_for_process_group_exit(
+        process,
+        process_group_id=process_group_id,
+        deadline=cleanup_deadline,
+    ):
+        return
+    raise RuntimeStartHarnessCleanupError(
+        "runtime-start process group "
+        f"{process_group_id} survived {cleanup_timeout:g}s cleanup budget"
+    )
 
 
 def run_runtime_start(
@@ -86,16 +153,23 @@ def run_runtime_start(
     progress_path: Path,
     initial_progress_timeout: float = 30,
     stall_timeout: float = 30,
+    total_timeout: float | None = None,
     poll_interval: float = 0.02,
 ) -> subprocess.CompletedProcess[str]:
-    """Run a synthetic startup while bounding lack of progress, not total time.
+    """Run a synthetic startup with independent progress and total bounds.
 
     The fake external tools used by the contract test append events to
     ``progress_path``. Initial tool readiness and an in-flight stall have
     separate deadlines, so host scheduling delay cannot consume the whole
     startup budget while a truly hung phase still fails within ``stall_timeout``.
+    The total deadline is measured once from process launch and is never reset
+    by progress, so a process cannot run forever by emitting progress events.
+    By default, its budget is exactly one initial window plus one stall window
+    (60 seconds with the defaults), rather than an independently inflated wait.
     """
 
+    if total_timeout is None:
+        total_timeout = initial_progress_timeout + stall_timeout
     progress_path.unlink(missing_ok=True)
     with (
         tempfile.TemporaryFile(mode="w+", encoding="utf-8") as stdout_file,
@@ -110,31 +184,40 @@ def run_runtime_start(
             text=True,
             start_new_session=True,
         )
+        started_at = time.monotonic()
+        total_deadline = started_at + total_timeout
         stage = "initial_progress_timeout"
         timeout_seconds = initial_progress_timeout
-        deadline = time.monotonic() + initial_progress_timeout
+        progress_deadline = started_at + initial_progress_timeout
         last_signature: tuple[int, int] | None = None
 
         while process.poll() is None:
+            now = time.monotonic()
             signature = _progress_signature(progress_path)
             if signature is not None and signature != last_signature:
                 last_signature = signature
                 stage = "progress_stall_timeout"
                 timeout_seconds = stall_timeout
-                deadline = time.monotonic() + stall_timeout
-            if time.monotonic() >= deadline:
+                progress_deadline = now + stall_timeout
+            if now >= total_deadline:
+                stage = "total_timeout"
+                timeout_seconds = total_timeout
+            elif now < progress_deadline:
+                time.sleep(poll_interval)
+                continue
+            if now >= progress_deadline or stage == "total_timeout":
                 _stop_process(process)
                 stdout_file.seek(0)
                 stderr_file.seek(0)
                 raise RuntimeStartHarnessTimeout(
                     stage=stage,
                     timeout_seconds=timeout_seconds,
+                    elapsed_seconds=now - started_at,
                     command=command,
                     progress_tail=_progress_tail(progress_path),
                     stdout=stdout_file.read(),
                     stderr=stderr_file.read(),
                 )
-            time.sleep(poll_interval)
 
         stdout_file.seek(0)
         stderr_file.seek(0)

--- a/tests/helpers/runtime_start_harness.py
+++ b/tests/helpers/runtime_start_harness.py
@@ -219,6 +219,10 @@ def run_runtime_start(
                     stderr=stderr_file.read(),
                 )
 
+        # The leader's return code is authoritative, but a terminal leader does
+        # not prove that descendants in its private session also exited.
+        # Quiesce that process group before exposing the successful result.
+        _stop_process(process)
         stdout_file.seek(0)
         stderr_file.seek(0)
         return subprocess.CompletedProcess(

--- a/tests/helpers/runtime_start_harness.py
+++ b/tests/helpers/runtime_start_harness.py
@@ -1,0 +1,146 @@
+"""Load-stable subprocess runner for runtime-start contract tests."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import tempfile
+import time
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+
+class RuntimeStartHarnessTimeout(TimeoutError):
+    """A runtime-start fixture failed to begin or stopped making progress."""
+
+    def __init__(
+        self,
+        *,
+        stage: str,
+        timeout_seconds: float,
+        command: Sequence[str],
+        progress_tail: str,
+        stdout: str,
+        stderr: str,
+    ) -> None:
+        self.stage = stage
+        self.timeout_seconds = timeout_seconds
+        self.command = tuple(command)
+        self.progress_tail = progress_tail
+        self.stdout = stdout
+        self.stderr = stderr
+        super().__init__(
+            f"runtime-start harness {stage} after {timeout_seconds:g}s without "
+            f"observable progress; command={list(command)!r}; "
+            f"progress_tail={progress_tail!r}; stdout={stdout[-800:]!r}; "
+            f"stderr={stderr[-800:]!r}"
+        )
+
+
+def _progress_signature(path: Path) -> tuple[int, int] | None:
+    try:
+        stat_result = path.stat()
+    except FileNotFoundError:
+        return None
+    return stat_result.st_size, stat_result.st_mtime_ns
+
+
+def _progress_tail(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")[-800:]
+    except FileNotFoundError:
+        return ""
+
+
+def _stop_process(process: subprocess.Popen[str]) -> None:
+    if process.poll() is not None:
+        return
+    try:
+        if os.name == "posix":
+            os.killpg(process.pid, signal.SIGTERM)
+        else:  # pragma: no cover - exercised by supported Windows hosts
+            process.terminate()
+    except ProcessLookupError:
+        return
+    try:
+        process.wait(timeout=1)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        if os.name == "posix":
+            os.killpg(process.pid, signal.SIGKILL)
+        else:  # pragma: no cover - exercised by supported Windows hosts
+            process.kill()
+    except ProcessLookupError:
+        return
+    process.wait(timeout=1)
+
+
+def run_runtime_start(
+    command: Sequence[str],
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+    progress_path: Path,
+    initial_progress_timeout: float = 30,
+    stall_timeout: float = 30,
+    poll_interval: float = 0.02,
+) -> subprocess.CompletedProcess[str]:
+    """Run a synthetic startup while bounding lack of progress, not total time.
+
+    The fake external tools used by the contract test append events to
+    ``progress_path``. Initial tool readiness and an in-flight stall have
+    separate deadlines, so host scheduling delay cannot consume the whole
+    startup budget while a truly hung phase still fails within ``stall_timeout``.
+    """
+
+    progress_path.unlink(missing_ok=True)
+    with (
+        tempfile.TemporaryFile(mode="w+", encoding="utf-8") as stdout_file,
+        tempfile.TemporaryFile(mode="w+", encoding="utf-8") as stderr_file,
+    ):
+        process = subprocess.Popen(
+            list(command),
+            cwd=cwd,
+            env=dict(env),
+            stdout=stdout_file,
+            stderr=stderr_file,
+            text=True,
+            start_new_session=True,
+        )
+        stage = "initial_progress_timeout"
+        timeout_seconds = initial_progress_timeout
+        deadline = time.monotonic() + initial_progress_timeout
+        last_signature: tuple[int, int] | None = None
+
+        while process.poll() is None:
+            signature = _progress_signature(progress_path)
+            if signature is not None and signature != last_signature:
+                last_signature = signature
+                stage = "progress_stall_timeout"
+                timeout_seconds = stall_timeout
+                deadline = time.monotonic() + stall_timeout
+            if time.monotonic() >= deadline:
+                _stop_process(process)
+                stdout_file.seek(0)
+                stderr_file.seek(0)
+                raise RuntimeStartHarnessTimeout(
+                    stage=stage,
+                    timeout_seconds=timeout_seconds,
+                    command=command,
+                    progress_tail=_progress_tail(progress_path),
+                    stdout=stdout_file.read(),
+                    stderr=stderr_file.read(),
+                )
+            time.sleep(poll_interval)
+
+        stdout_file.seek(0)
+        stderr_file.seek(0)
+        return subprocess.CompletedProcess(
+            args=list(command),
+            returncode=process.returncode,
+            stdout=stdout_file.read(),
+            stderr=stderr_file.read(),
+        )

--- a/tests/ops/test_start_full_runtime_health.py
+++ b/tests/ops/test_start_full_runtime_health.py
@@ -7,6 +7,8 @@ import subprocess
 import textwrap
 from pathlib import Path
 
+from tests.helpers.runtime_start_harness import run_runtime_start
+
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -69,6 +71,7 @@ def _fake_docker_bin(bin_dir: Path, health: dict[str, object]) -> None:
         f"""
         #!/usr/bin/env python3
         import json
+        import os
         import sys
 
         HEALTH = {health_json!r}
@@ -87,6 +90,10 @@ def _fake_docker_bin(bin_dir: Path, health: dict[str, object]) -> None:
                 print(f"pkm-dev-{{service}}-1    {{service}}   running")
 
         args = sys.argv[1:]
+        progress_path = os.environ.get("STARTUP_HARNESS_PROGRESS_PATH")
+        if progress_path:
+            with open(progress_path, "a", encoding="utf-8") as handle:
+                handle.write(f"docker {{' '.join(args)}}\\n")
         if not args:
             raise SystemExit(0)
         if args[0] == "info":
@@ -175,9 +182,14 @@ def _fake_curl_bin(bin_dir: Path, health: dict[str, object]) -> None:
         bin_dir / "curl",
         f"""
         #!/usr/bin/env python3
+        import os
         import sys
 
         HEALTH = {health_json!r}
+        progress_path = os.environ.get("STARTUP_HARNESS_PROGRESS_PATH")
+        if progress_path:
+            with open(progress_path, "a", encoding="utf-8") as handle:
+                handle.write(f"curl {{' '.join(sys.argv[1:])}}\\n")
         url = next((arg for arg in reversed(sys.argv[1:]) if arg.startswith("http")), "")
         if "/api/health" in url:
             print(HEALTH)
@@ -224,6 +236,7 @@ def _runtime_env(tmp_path: Path, health: dict[str, object]) -> dict[str, str]:
             "WORKER_HEARTBEAT_TIMEOUT": "1",
             "VERIFY_RUNTIME_SERVICE_WAIT_SECONDS": "1",
             "VERIFY_RUNTIME_SERVICE_WAIT_SLEEP_SECONDS": "1",
+            "STARTUP_HARNESS_PROGRESS_PATH": str(tmp_path / "startup-progress.log"),
         }
     )
     return env
@@ -250,14 +263,11 @@ def test_runtime_verify_tolerates_deferred_index_rebuild(tmp_path: Path) -> None
 def test_dev_start_full_returns_zero_with_deferred_index_rebuild(tmp_path: Path) -> None:
     env = _runtime_env(tmp_path, _deferred_index_health())
 
-    result = subprocess.run(
+    result = run_runtime_start(
         ["make", "dev-start-full"],
         cwd=REPO_ROOT,
         env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-        timeout=30,
+        progress_path=Path(env["STARTUP_HARNESS_PROGRESS_PATH"]),
     )
 
     assert result.returncode == 0, result.stderr + result.stdout
@@ -269,14 +279,11 @@ def test_dev_channel_alias_returns_zero_with_deferred_index_rebuild(tmp_path: Pa
     env = _runtime_env(tmp_path, _deferred_index_health())
     env["ENVIRONMENT"] = "dev"
 
-    result = subprocess.run(
+    result = run_runtime_start(
         ["bash", "scripts/start_full_system.sh"],
         cwd=REPO_ROOT,
         env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-        timeout=30,
+        progress_path=Path(env["STARTUP_HARNESS_PROGRESS_PATH"]),
     )
 
     assert result.returncode == 0, result.stderr + result.stdout
@@ -290,14 +297,11 @@ def test_prod_start_full_rejects_deferred_index_rebuild(tmp_path: Path) -> None:
     env["COMPOSE_PROJECT_NAME"] = "pkm-prod"
     env["PKM_ENVIRONMENT"] = "prod"
 
-    result = subprocess.run(
+    result = run_runtime_start(
         ["bash", "scripts/start_full_system.sh"],
         cwd=REPO_ROOT,
         env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-        timeout=30,
+        progress_path=Path(env["STARTUP_HARNESS_PROGRESS_PATH"]),
     )
 
     assert result.returncode == 1

--- a/tests/runtime/test_start_full_system_version_marker.py
+++ b/tests/runtime/test_start_full_system_version_marker.py
@@ -274,6 +274,60 @@ time.sleep(30)
         os.kill(child_pid, 0)
 
 
+def test_runtime_start_harness_cleans_descendant_after_successful_parent_exit(
+    tmp_path: Path,
+) -> None:
+    progress_file = tmp_path / "progress.log"
+    ready_file = tmp_path / "descendant-ready"
+    script = """
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+child = subprocess.Popen(
+    [
+        sys.executable,
+        "-c",
+        "import os, signal, time; from pathlib import Path; "
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+        "Path(os.environ['DESCENDANT_READY_PATH']).write_text('ready', encoding='utf-8'); "
+        "time.sleep(30)",
+    ]
+)
+ready = Path(os.environ["DESCENDANT_READY_PATH"])
+deadline = time.monotonic() + 2
+while not ready.exists() and time.monotonic() < deadline:
+    time.sleep(0.01)
+if not ready.exists():
+    raise SystemExit(97)
+Path(os.environ["STARTUP_HARNESS_PROGRESS_PATH"]).write_text(
+    f"child-pid={child.pid}\\n", encoding="utf-8"
+)
+"""
+    env = {
+        **os.environ,
+        "DESCENDANT_READY_PATH": str(ready_file),
+        "STARTUP_HARNESS_PROGRESS_PATH": str(progress_file),
+    }
+
+    result = run_runtime_start(
+        [sys.executable, "-c", script],
+        cwd=REPO_ROOT,
+        env=env,
+        progress_path=progress_file,
+        initial_progress_timeout=2,
+        stall_timeout=2,
+        total_timeout=5,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    child_pid = int(progress_file.read_text(encoding="utf-8").strip().split("=", 1)[1])
+    with pytest.raises(ProcessLookupError):
+        os.kill(child_pid, 0)
+
+
 def test_runtime_start_harness_fails_loud_when_progress_stalls(tmp_path: Path) -> None:
     progress_file = tmp_path / "progress.log"
     script = """

--- a/tests/runtime/test_start_full_system_version_marker.py
+++ b/tests/runtime/test_start_full_system_version_marker.py
@@ -163,12 +163,115 @@ for phase in range(4):
         progress_path=progress_file,
         initial_progress_timeout=5,
         stall_timeout=0.6,
+        total_timeout=2,
     )
 
     assert result.returncode == 0, result.stderr + result.stdout
     # A fixed total timeout of 0.6s would expire even though every phase makes
     # progress inside that same bounded stall budget.
     assert time.monotonic() - started > 0.6
+
+
+def test_runtime_start_harness_fails_on_total_timeout_despite_progress(
+    tmp_path: Path,
+) -> None:
+    progress_file = tmp_path / "progress.log"
+    script = """
+import os
+import time
+from pathlib import Path
+
+progress = Path(os.environ["STARTUP_HARNESS_PROGRESS_PATH"])
+while True:
+    with progress.open("a", encoding="utf-8") as handle:
+        handle.write("still-running\\n")
+    time.sleep(0.02)
+"""
+    env = {
+        **os.environ,
+        "STARTUP_HARNESS_PROGRESS_PATH": str(progress_file),
+    }
+
+    with pytest.raises(RuntimeStartHarnessTimeout) as exc_info:
+        run_runtime_start(
+            [sys.executable, "-c", script],
+            cwd=REPO_ROOT,
+            env=env,
+            progress_path=progress_file,
+            initial_progress_timeout=1,
+            stall_timeout=1,
+            total_timeout=0.25,
+        )
+
+    assert exc_info.value.stage == "total_timeout"
+    assert exc_info.value.timeout_seconds == 0.25
+    assert exc_info.value.elapsed_seconds >= 0.25
+    assert "still-running" in exc_info.value.progress_tail
+
+
+def test_runtime_start_harness_classifies_missing_initial_progress(
+    tmp_path: Path,
+) -> None:
+    progress_file = tmp_path / "progress.log"
+
+    with pytest.raises(RuntimeStartHarnessTimeout) as exc_info:
+        run_runtime_start(
+            [sys.executable, "-c", "import time; time.sleep(5)"],
+            cwd=REPO_ROOT,
+            env=os.environ,
+            progress_path=progress_file,
+            initial_progress_timeout=0.1,
+            stall_timeout=1,
+            total_timeout=2,
+        )
+
+    assert exc_info.value.stage == "initial_progress_timeout"
+    assert exc_info.value.progress_tail == ""
+
+
+def test_runtime_start_harness_kills_term_resistant_descendant(
+    tmp_path: Path,
+) -> None:
+    progress_file = tmp_path / "progress.log"
+    script = """
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+child = subprocess.Popen(
+    [
+        sys.executable,
+        "-c",
+        "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(30)",
+    ]
+)
+Path(os.environ["STARTUP_HARNESS_PROGRESS_PATH"]).write_text(
+    f"child-pid={child.pid}\\n", encoding="utf-8"
+)
+time.sleep(30)
+"""
+    env = {
+        **os.environ,
+        "STARTUP_HARNESS_PROGRESS_PATH": str(progress_file),
+    }
+
+    with pytest.raises(RuntimeStartHarnessTimeout) as exc_info:
+        run_runtime_start(
+            [sys.executable, "-c", script],
+            cwd=REPO_ROOT,
+            env=env,
+            progress_path=progress_file,
+            initial_progress_timeout=1,
+            stall_timeout=0.15,
+            total_timeout=2,
+        )
+
+    assert exc_info.value.stage == "progress_stall_timeout"
+    child_pid = int(exc_info.value.progress_tail.strip().split("=", 1)[1])
+    with pytest.raises(ProcessLookupError):
+        os.kill(child_pid, 0)
 
 
 def test_runtime_start_harness_fails_loud_when_progress_stalls(tmp_path: Path) -> None:
@@ -196,6 +299,7 @@ time.sleep(5)
             progress_path=progress_file,
             initial_progress_timeout=5,
             stall_timeout=0.2,
+            total_timeout=2,
         )
 
     assert exc_info.value.stage == "progress_stall_timeout"

--- a/tests/runtime/test_start_full_system_version_marker.py
+++ b/tests/runtime/test_start_full_system_version_marker.py
@@ -5,9 +5,16 @@ from __future__ import annotations
 import os
 import re
 import subprocess
+import sys
+import time
 from pathlib import Path
 
 import pytest
+
+from tests.helpers.runtime_start_harness import (
+    RuntimeStartHarnessTimeout,
+    run_runtime_start,
+)
 
 pytestmark = pytest.mark.not_pg
 
@@ -34,6 +41,7 @@ def test_start_full_system_exports_vcs_ref_for_compose_build(tmp_path: Path) -> 
     ).stdout.strip()
 
     capture_file = tmp_path / "compose-up.env"
+    progress_file = tmp_path / "startup-progress.log"
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
     fake_docker = fake_bin / "docker"
@@ -42,6 +50,10 @@ def test_start_full_system_exports_vcs_ref_for_compose_build(tmp_path: Path) -> 
 set -euo pipefail
 
 capture_file={capture_file!s}
+
+if [ -n "${{STARTUP_HARNESS_PROGRESS_PATH:-}}" ]; then
+  printf 'docker %s\n' "$*" >>"$STARTUP_HARNESS_PROGRESS_PATH"
+fi
 
 if [ "${{1:-}}" = "info" ]; then
   exit 0
@@ -96,17 +108,19 @@ exit 97
         "PKM_ENVIRONMENT": "prod",
         "START_MODE": "diagnostic",
         "START_FLIGHT_RECORDER": "0",
+        # BuilderOps is an independent runtime bootstrap and is irrelevant to
+        # this diagnostic Compose/build-identity contract.
+        "BUILDEROPS_BOOTSTRAP": "0",
+        "STARTUP_HARNESS_PROGRESS_PATH": str(progress_file),
         "VCS_REF": "unknown",
         "BUILT_AT": "unknown",
     }
 
-    proc = subprocess.run(
+    proc = run_runtime_start(
         ["bash", "scripts/start_full_system.sh"],
         cwd=REPO_ROOT,
         env=env,
-        capture_output=True,
-        text=True,
-        timeout=30,
+        progress_path=progress_file,
     )
 
     assert proc.returncode == 99, proc.stderr + proc.stdout
@@ -119,3 +133,70 @@ exit 97
     assert captured["VCS_REF"] == expected_sha
     assert captured["BUILT_AT"] != "unknown"
     assert TIMESTAMP_RE.fullmatch(captured["BUILT_AT"])
+
+
+def test_runtime_start_harness_allows_delayed_scheduling_while_progress_continues(
+    tmp_path: Path,
+) -> None:
+    progress_file = tmp_path / "progress.log"
+    script = """
+import os
+import time
+from pathlib import Path
+
+progress = Path(os.environ["STARTUP_HARNESS_PROGRESS_PATH"])
+for phase in range(4):
+    with progress.open("a", encoding="utf-8") as handle:
+        handle.write(f"phase-{phase}\\n")
+    time.sleep(0.25)
+"""
+    env = {
+        **os.environ,
+        "STARTUP_HARNESS_PROGRESS_PATH": str(progress_file),
+    }
+
+    started = time.monotonic()
+    result = run_runtime_start(
+        [sys.executable, "-c", script],
+        cwd=REPO_ROOT,
+        env=env,
+        progress_path=progress_file,
+        initial_progress_timeout=5,
+        stall_timeout=0.6,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    # A fixed total timeout of 0.6s would expire even though every phase makes
+    # progress inside that same bounded stall budget.
+    assert time.monotonic() - started > 0.6
+
+
+def test_runtime_start_harness_fails_loud_when_progress_stalls(tmp_path: Path) -> None:
+    progress_file = tmp_path / "progress.log"
+    script = """
+import os
+import time
+from pathlib import Path
+
+Path(os.environ["STARTUP_HARNESS_PROGRESS_PATH"]).write_text(
+    "phase-started\\n", encoding="utf-8"
+)
+time.sleep(5)
+"""
+    env = {
+        **os.environ,
+        "STARTUP_HARNESS_PROGRESS_PATH": str(progress_file),
+    }
+
+    with pytest.raises(RuntimeStartHarnessTimeout) as exc_info:
+        run_runtime_start(
+            [sys.executable, "-c", script],
+            cwd=REPO_ROOT,
+            env=env,
+            progress_path=progress_file,
+            initial_progress_timeout=5,
+            stall_timeout=0.2,
+        )
+
+    assert exc_info.value.stage == "progress_stall_timeout"
+    assert "phase-started" in exc_info.value.progress_tail


### PR DESCRIPTION
## Summary

- isolate the diagnostic build-identity contract from unrelated BuilderOps bootstrap work
- replace fixed wall-clock subprocess waits with observable initial-progress and stall deadlines plus a non-resettable total bound
- quiesce the private POSIX process group on timeout and normal parent exit, including TERM-resistant descendants

## Contract

Governing-Issue: #4025

Fixes #4025

## Validation

- `pytest -q tests/ops/test_start_full_runtime_health.py tests/runtime/test_start_full_system_version_marker.py` — 12 passed
- exact AC nodeids repeated three times — 2 passed each run
- `ruff check app tests` — passed
- `mypy app` — passed (793 source files)
- `pytest -q -m "not pg"` — 10,298 passed, 38 skipped, 273 deselected, 18 xfailed on exact `61416ff61236eaccf8ada9a14bea4b822086c27e`
- two independent Sol/high clean reviews — ACCEPT / ACCEPT

## Owner docs

No owner-doc change: this is a test-harness load-stability correction and preserves runtime/startup behavior and assertions.

## BuilderOps Routing

- Records/projections/receipts: none
- Reason: The existing issue and PR receipts fully capture this bounded test-harness defect; no separate BuilderOps learning or projection was created.
