### PR TITLE
Fix runtime-start zombie process-group cleanup

### DIFF
--- a/docs/development/TEST_STRATEGY_HOT_PATH.md
+++ b/docs/development/TEST_STRATEGY_HOT_PATH.md
@@ -21,6 +21,7 @@ The goal is to keep docs-only and governance/skill PRs cheap while preserving di
 - Governance PR contract checks live in `.github/workflows/issue-pr-governance.yml`.
 - The hot-path and direct-repair invariants are covered by `tests/architecture/test_pr_hot_path_governance.py`.
 - PR unit CI uses `scripts/select_pr_tests.py` to map changed files to subsystem-scoped pytest targets. Shared CI/test configuration, migrations, dependencies, and shared fixtures run the deterministic broad suite; E2E coverage is deferred to post-merge and nightly validation. This document is `scripts/select_pr_tests.py`'s `docs/development/` contract for the `scripts/docs_guard_logic.py :: GOVERNANCE_TEMPORAL_ENFORCEMENT` temporal-owner-doc exemption, and the check enforces that pairing specifically: update this doc, not `docs/STATUS.md`/`docs/ROADMAP.md`/etc., when the selection script's behavior changes.
+- Runtime-start harness tests that exercise `scripts/start_full_system.sh` and its process-cleanup behavior are owned by the `ops_deploy` selector, even when the touched files live under `tests/helpers/` or `tests/runtime/`.
 - Store and vault-ingest changes are owned by the `store_ingest` selection and run its focused
   `tests/stores`, `tests/ingest`, and architecture contracts in the ordinary `not pg` job. That job
   intentionally excludes live-Postgres tests; a PR that changes a Postgres store or vault ingest

--- a/scripts/select_pr_tests.py
+++ b/scripts/select_pr_tests.py
@@ -566,7 +566,15 @@ SUBSYSTEMS: tuple[tuple[str, tuple[str, ...], tuple[str, ...]], ...] = (
     ),
     (
         "ops_deploy",
-        ("scripts/", "ops/", "config/deploy/", "tests/scripts/", "tests/deploy/"),
+        (
+            "scripts/",
+            "ops/",
+            "config/deploy/",
+            "tests/scripts/",
+            "tests/deploy/",
+            "tests/helpers/runtime_start_harness.py",
+            "tests/runtime/test_start_full_system_version_marker.py",
+        ),
         ("tests/ops", "tests/scripts", "tests/deploy"),
     ),
     (

--- a/tests/helpers/runtime_start_harness.py
+++ b/tests/helpers/runtime_start_harness.py
@@ -65,7 +65,36 @@ def _progress_tail(path: Path) -> str:
         return ""
 
 
+def _process_group_member_stats(process_group_id: int) -> list[str] | None:
+    try:
+        result = subprocess.run(
+            ["ps", "-axo", "pid=,pgid=,stat="],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+    stats: list[str] = []
+    for line in result.stdout.splitlines():
+        fields = line.split(None, 2)
+        if len(fields) < 3:
+            continue
+        try:
+            pgid = int(fields[1])
+        except ValueError:
+            continue
+        if pgid == process_group_id:
+            stats.append(fields[2])
+    return stats
+
+
 def _process_group_exists(process_group_id: int) -> bool:
+    member_stats = _process_group_member_stats(process_group_id)
+    if member_stats is not None:
+        return any("Z" not in stat for stat in member_stats)
+
     try:
         os.killpg(process_group_id, 0)
     except ProcessLookupError:

--- a/tests/runtime/test_start_full_system_version_marker.py
+++ b/tests/runtime/test_start_full_system_version_marker.py
@@ -15,6 +15,7 @@ from tests.helpers.runtime_start_harness import (
     RuntimeStartHarnessTimeout,
     run_runtime_start,
 )
+from tests.helpers import runtime_start_harness
 
 pytestmark = pytest.mark.not_pg
 
@@ -326,6 +327,36 @@ Path(os.environ["STARTUP_HARNESS_PROGRESS_PATH"]).write_text(
     child_pid = int(progress_file.read_text(encoding="utf-8").strip().split("=", 1)[1])
     with pytest.raises(ProcessLookupError):
         os.kill(child_pid, 0)
+
+
+@pytest.mark.parametrize(
+    ("ps_output", "expected_exists"),
+    [
+        (" 101 4242 Z\n 102 4242 Z+\n", False),
+        (" 101 4242 Z\n 102 4242 S\n", True),
+    ],
+)
+def test_runtime_start_harness_treats_zombie_only_process_groups_as_exited(
+    monkeypatch: pytest.MonkeyPatch,
+    ps_output: str,
+    expected_exists: bool,
+) -> None:
+    def fake_run(
+        command: list[str],
+        *,
+        check: bool,
+        capture_output: bool,
+        text: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        assert command == ["ps", "-axo", "pid=,pgid=,stat="]
+        assert check is True
+        assert capture_output is True
+        assert text is True
+        return subprocess.CompletedProcess(command, 0, stdout=ps_output, stderr="")
+
+    monkeypatch.setattr(runtime_start_harness.subprocess, "run", fake_run)
+
+    assert runtime_start_harness._process_group_exists(4242) is expected_exists
 
 
 def test_runtime_start_harness_fails_loud_when_progress_stalls(tmp_path: Path) -> None:

--- a/tests/runtime/test_start_full_system_version_marker.py
+++ b/tests/runtime/test_start_full_system_version_marker.py
@@ -230,6 +230,40 @@ def test_runtime_start_harness_classifies_missing_initial_progress(
     assert exc_info.value.progress_tail == ""
 
 
+def _assert_descendant_terminated(pid: int, *, timeout: float = 2.0) -> None:
+    """Assert a term-resistant descendant is terminated: gone or a zombie.
+
+    ``_stop_process`` returns as soon as the process group is zombie-only, so a
+    descendant reparented to init after the group SIGKILL may still occupy a
+    not-yet-reaped zombie slot. A zombie is effectively dead, but
+    ``os.kill(pid, 0)`` does not raise ``ProcessLookupError`` for one, so a
+    strict ``pytest.raises(ProcessLookupError)`` oracle contradicts the harness
+    contract and can flake. Accept either fully gone or a zombie state.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return
+        try:
+            stat = subprocess.run(
+                ["ps", "-o", "stat=", "-p", str(pid)],
+                check=False,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+        except (OSError, subprocess.SubprocessError):  # pragma: no cover - defensive
+            stat = ""
+        if not stat or "Z" in stat:
+            return
+        if time.monotonic() >= deadline:
+            raise AssertionError(
+                f"descendant {pid} still running (stat={stat!r}) after {timeout:g}s"
+            )
+        time.sleep(0.02)
+
+
 def test_runtime_start_harness_kills_term_resistant_descendant(
     tmp_path: Path,
 ) -> None:
@@ -271,8 +305,7 @@ time.sleep(30)
 
     assert exc_info.value.stage == "progress_stall_timeout"
     child_pid = int(exc_info.value.progress_tail.strip().split("=", 1)[1])
-    with pytest.raises(ProcessLookupError):
-        os.kill(child_pid, 0)
+    _assert_descendant_terminated(child_pid)
 
 
 def test_runtime_start_harness_cleans_descendant_after_successful_parent_exit(
@@ -325,8 +358,7 @@ Path(os.environ["STARTUP_HARNESS_PROGRESS_PATH"]).write_text(
 
     assert result.returncode == 0, result.stderr + result.stdout
     child_pid = int(progress_file.read_text(encoding="utf-8").strip().split("=", 1)[1])
-    with pytest.raises(ProcessLookupError):
-        os.kill(child_pid, 0)
+    _assert_descendant_terminated(child_pid)
 
 
 @pytest.mark.parametrize(

--- a/tests/scripts/test_select_pr_tests.py
+++ b/tests/scripts/test_select_pr_tests.py
@@ -880,6 +880,24 @@ def test_builder_system_change_selects_its_own_regression_tests() -> None:
     assert "tests/governance" in selection.targets
 
 
+def test_runtime_start_harness_change_selects_ops_deploy_regressions() -> None:
+    selection = select_tests(
+        [
+            "tests/helpers/runtime_start_harness.py",
+            "tests/runtime/test_start_full_system_version_marker.py",
+        ]
+    )
+
+    assert selection.full_suite is False
+    assert selection.subsystems == ("ops_deploy",)
+    assert selection.unowned_paths == ()
+    assert "tests/ops" in selection.targets
+    assert "tests/scripts" in selection.targets
+    assert "tests/deploy" in selection.targets
+    assert "tests/helpers/runtime_start_harness.py" in selection.targets
+    assert "tests/runtime/test_start_full_system_version_marker.py" in selection.targets
+
+
 def test_governance_test_change_is_owned_by_builder_system() -> None:
     selection = select_tests(["tests/governance/test_project_pickup_deprecation.py"])
 


### PR DESCRIPTION
Final-Review-Rounds: 2

## Direct Repair
Type: code
Reason: Daily review-comment closure audit found unresolved actionable inline review feedback on merged PR #4027 after #4025 was closed. The thread reports that zombie-only POSIX process groups can make the runtime-start harness raise cleanup failure after SIGKILL instead of returning the intended timeout/result. The first #4031 CI run also exposed that the runtime-start harness paths lacked a subsystem owner in PR test selection.
Validation: focused runtime-start harness tests, full affected runtime-start test file, selector regression tests, ruff, docs guard, branch-truth gates, direct-repair review-before-CI gate.
Issue required: no

## Summary
- Treat POSIX process groups containing only zombie members as quiesced in the runtime-start test harness.
- Add a regression proving zombie-only groups are considered exited while groups with any live member still block cleanup.
- Map the runtime-start harness helper/test paths to the `ops_deploy` PR-test selector owner so CI runs deploy/startup regressions instead of failing as unowned.

## Review Thread
- Addresses PR #4027 unresolved thread: https://github.com/RasmusTho/agentic-pkm-mvp/pull/4027#discussion_r3617518238
- Related closed Issue: #4025

## Validation
- `pytest -q tests/runtime/test_start_full_system_version_marker.py::test_runtime_start_harness_treats_zombie_only_process_groups_as_exited tests/runtime/test_start_full_system_version_marker.py::test_runtime_start_harness_kills_term_resistant_descendant tests/runtime/test_start_full_system_version_marker.py::test_runtime_start_harness_cleans_descendant_after_successful_parent_exit` - 4 passed
- `pytest -q tests/runtime/test_start_full_system_version_marker.py` - 9 passed
- `pytest -q tests/runtime/test_start_full_system_version_marker.py::test_runtime_start_harness_treats_zombie_only_process_groups_as_exited` - 2 passed after worktree recovery
- `python3 scripts/select_pr_tests.py --base-ref origin/main --head-ref HEAD` - selects `ops_deploy` and includes `tests/helpers/runtime_start_harness.py` plus `tests/runtime/test_start_full_system_version_marker.py`
- `pytest -q tests/scripts/test_select_pr_tests.py::test_runtime_start_harness_change_selects_ops_deploy_regressions tests/runtime/test_start_full_system_version_marker.py::test_runtime_start_harness_treats_zombie_only_process_groups_as_exited` - 3 passed
- `pytest -q tests/scripts/test_select_pr_tests.py` - 68 passed
- `ruff check app tests scripts/select_pr_tests.py` - passed
- `ruff check app tests` - passed before selector repair
- `python3 scripts/docs_guard.py` - passed
- `git diff --check` - passed
- branch-truth gates before both commits and push - passed
- `python3 scripts/review_before_ci_gate.py --lane direct-repair --review-gate-complete --risk-assessment-complete --changed-file tests/helpers/runtime_start_harness.py --changed-file tests/runtime/test_start_full_system_version_marker.py` - passed
- `mypy app` - failed on current-main unrelated error: `app/dispatcher/control_plane.py:279: error: Argument 1 to "get" of "dict" has incompatible type "object | Any"; expected "str" [arg-type]`

## CI Notes
- Initial `pr-contract` failure was a PR-body typo (`Type: implementation`); rerun passed after changing it to `Type: code`.
- Initial `Unit tests (not pg)` failure was selector ownership, before pytest; commit `e39ba68e` maps these paths to `ops_deploy` and adds the selector regression.

## BuilderOps Routing
- Records/projections/receipts: LearningSignals `lrn_20260721092405_a278e9e6`, `lrn_20260721093153_dd063af0`
- Reason: workflow divergences; PR #4027/#4025 closed with one unresolved actionable review thread, and #4031 exposed missing PR-test selector ownership for the runtime-start harness surface.
