### PR TITLE
Fix main smoke-docker: resolve instance-ownership host state before raw compose (direct repair)

### DIFF
--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -294,6 +294,8 @@ jobs:
               environment:
                 WORKER_LOG_HEARTBEAT_SECONDS: "${WORKER_LOG_HEARTBEAT_SECONDS}"
           YAML
+          source scripts/lib/instance_ownership_host_state.sh
+          prepare_instance_ownership_host_state_dir
           compose_files="-f docker-compose.yaml -f /tmp/docker-compose.worker-ci.yaml"
           cleanup() {
             rc=$?
@@ -433,6 +435,8 @@ jobs:
           cache/
           EOF
 
+          source scripts/lib/instance_ownership_host_state.sh
+          prepare_instance_ownership_host_state_dir
           compose_files="-f docker-compose.yaml -f docker-compose.legacy-vault.yml"
           cleanup() {
             rc=$?


### PR DESCRIPTION
## Summary

- main-only red gate: the push-context `smoke-docker` job (and the vault-panel docker job) invoke `docker compose` directly, without the instance-ownership host-state export the MVR-01B launchers perform, so compose interpolation fails on `${INSTANCE_OWNERSHIP_HOST_STATE_DIR:?}` — run 29822169606 on `4b8225e3`.
- Repair: source `scripts/lib/instance_ownership_host_state.sh` and call `prepare_instance_ownership_host_state_dir` before the first compose use in both jobs — the exact producer API MVR-01B shipped. The fail-loud compose contract is unchanged (no default added).
- PR-context CI cannot prove this fix (the docker steps are skipped on pull_request); proof is the next main push run. The resolver was validated standalone on a dev host (creates and exports the canonical 0700 directory).

## Direct Repair
Type: code
Reason: main push gate smoke-docker red after the #3986 squash (4b8225e3); the CI workflow is a compose producer that the PR-context gate never exercises (docker steps skipped on PRs), so the missing launcher export surfaced only on main.
Validation: resolver executed standalone (canonical 0700 dir exported); YAML parse check; both raw `docker compose up` sites patched; compose fail-loud semantics unchanged.
Issue required: no

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: mechanical CI-launcher repair; the producer-enumeration learning is recorded on #4036

Final-Review-Rounds: 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)