### PR TITLE
Run MVR-01B launcher producer before raw compose in CI docker smokes (direct repair 2/2)

### DIFF
--- a/.github/workflows/ci-smoke.yaml
+++ b/.github/workflows/ci-smoke.yaml
@@ -315,6 +315,13 @@ jobs:
           }
           trap cleanup EXIT
 
+          # MVR-01B: consumers fail loud unless the launcher prepared the
+          # instance-state layout. Run the exact production producer, like
+          # start_full_system.sh / deploy_channel.sh do.
+          source scripts/lib/instance_state_deployment.sh
+          run_ci_compose() { docker compose $compose_files "$@"; }
+          prepare_instance_state_deployment run_ci_compose "${PKM_ENVIRONMENT:-dev}"
+
           docker compose $compose_files up -d --build worker
 
           start_time=$SECONDS
@@ -461,6 +468,11 @@ jobs:
             exit "$rc"
           }
           trap cleanup EXIT
+
+          # MVR-01B: run the exact production launcher producer before raw compose up.
+          source scripts/lib/instance_state_deployment.sh
+          run_ci_compose() { docker compose $compose_files "$@"; }
+          prepare_instance_state_deployment run_ci_compose "${PKM_ENVIRONMENT:-dev}"
 
           docker compose $compose_files up -d --build db api watcher worker
           LOG_PATH="/tmp/verify_vaultwide_panel.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}.log" \


### PR DESCRIPTION
## Summary

- Layer 2 of the main-only `smoke-docker` red gate. #4037 fixed the compose interpolation (host-state export); the fresh main run 29822659468 then failed one layer deeper: the worker container loops on `InstanceStatePreflightError: instance-state mount/root is missing`.
- Mechanism: `instance-state-init` (compose service) only establishes mount ownership; the channel layout is created exclusively by the launcher producer (`prepare_instance_state_deployment` -> `deployment-begin`), and consumer preflights never create state by contract (that was a #3854 round-1 repair). Raw `docker compose up` is therefore not a sanctioned boot path without the producer.
- Repair: source `scripts/lib/instance_state_deployment.sh` and call `prepare_instance_state_deployment run_ci_compose "${PKM_ENVIRONMENT:-dev}"` before `compose up` in both docker jobs — the exact function `start_full_system.sh:1176` and `deploy_channel.sh` use; no imitation of the ceremony, no contract weakening.
- This is standard repair attempt 2/2 for the `ci-smoke-docker` failure domain. If this mechanism fails again, standard budget is exhausted: stop, diagnose as a real first-boot defect on the producer path (which would itself be signal), and escalate rather than patch again.
- PR-context CI cannot prove the fix (docker steps are skipped on pull_request); proof is the next main push run. YAML parse and `bash -n`-equivalent review done locally; the producer function is exercised by the deploy wrapper test suite that was green on the #3986 head.

## Direct Repair
Type: code
Reason: main push gate smoke-docker still red after #4037; second failure layer is the uninitialized instance-state layout, because the CI job boots raw compose without the MVR-01B launcher producer.
Validation: YAML parse check; mechanism verified from run 29822659468 worker logs (preflight fail-loud loop); repair mirrors start_full_system.sh:1176 exactly; both docker jobs patched.
Issue required: no

## BuilderOps Routing
- Records/projections/receipts: none
- Reason: mechanical CI-launcher repair, layer 2; producer-enumeration learning already recorded on #4036

Final-Review-Rounds: 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)